### PR TITLE
00028 New infrastructure and AWS keys

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -236,7 +236,8 @@ commands:
         type: boolean
         default: false
     steps:
-      - fetch-testnet-control-assets
+      - fetch-testnet-control-assets:
+          infra-branch: "hashgraph-hedera-services"
       - unless:
           condition: << parameters.use-existing-network >>
           steps:


### PR DESCRIPTION
**Related issue(s)**:
Closes #28

**Summary of the change**:
Use new keys to checkout infrastructure repo and to access AWS instances.

**External impacts**:
None.

**Applicable documentation**
None.