### PR TITLE
Fix typo in Docker quickstart

### DIFF
--- a/docs/docker-quickstart.md
+++ b/docs/docker-quickstart.md
@@ -20,7 +20,7 @@ Prefer the latter until you want to test a change you have made to the source co
 Clone this repository:
 ```
 git clone git@github.com:hashgraph/hedera-services.git
-cd services-hedera
+cd hedera-services
 ```
 
 Ensure the Docker Compose [.env file](../.env) has the following contents:


### PR DESCRIPTION
Repo name was mistyped in quickstart.
