### PR TITLE
Revert surefire plugin back to 2.22.2 

### DIFF
--- a/hedera-node/pom.xml
+++ b/hedera-node/pom.xml
@@ -291,6 +291,12 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
+      <version>${junit.vintage.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest-all</artifactId>
       <version>${hamcrest-all.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
     <maven-source.version>3.1.0</maven-source.version>
     <maven-license.version>2.0.0</maven-license.version>
     <maven-compiler.version>3.8.1</maven-compiler.version>
-    <maven-surefire.version>2.22.2</maven-surefire.version>
+    <maven-surefire.version>3.0.0-M5</maven-surefire.version>
     <maven-dependency.version>3.1.1</maven-dependency.version>
     <commons-io.version>2.1</commons-io.version>
 


### PR DESCRIPTION
Resolve conflicts due to using junit4 and junit 5 in the project

**Related issue(s)**:
N/A

**Summary of the change**:
N/
**External impacts**:
None.

