### PR TITLE
Use settings names for 0.7.0 SDK

### DIFF
--- a/hedera-node/configuration/dev/settings.txt
+++ b/hedera-node/configuration/dev/settings.txt
@@ -12,8 +12,8 @@ lockLogTimeout, 4000
 maxEventQueueForCons,1000
 maxOutgoingSyncs, 4
 numConnections, 1000
+roundsExpired, 500
 showInternalStats, 1
-state.roundsExpired, 500
 state.roundsStale, 25
 state.saveStatePeriod, 900
 state.signedStateDisk, 5


### PR DESCRIPTION
Use 0.7.0 SDK names in _hedera-node/configuration/dev/settings.txt_
