### PR TITLE
sleep shorter time to avoid ci complains no output

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2766,7 +2766,7 @@ jobs:
           name: wait HGCApp restarted
           no_output_timeout: 4m
           command: |
-            sleep 300
+            sleep 200
       - run:
           name: Show java process
           command: |


### PR DESCRIPTION
**Related issue(s)**:
None

**Summary of the change**:
Previous sleep time is too long

**External impacts**:
None.

**Applicable documentation**
None

![image](https://user-images.githubusercontent.com/39912573/90251993-55445b00-de04-11ea-880d-d423195bab57.png)
