### PR TITLE
Use read/writeNormalisedString for Topic memos

### DIFF
--- a/hedera-node/src/main/java/com/hedera/services/state/serdes/TopicSerde.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/serdes/TopicSerde.java
@@ -23,7 +23,6 @@ package com.hedera.services.state.serdes;
 import com.hedera.services.state.merkle.MerkleTopic;
 import com.swirlds.common.io.SerializableDataInputStream;
 import com.swirlds.common.io.SerializableDataOutputStream;
-import org.apache.commons.codec.binary.StringUtils;
 
 import java.io.IOException;
 
@@ -35,10 +34,7 @@ public class TopicSerde {
 	public void deserializeV1(SerializableDataInputStream in, MerkleTopic to) throws IOException {
 		to.setMemo(null);
 		if (in.readBoolean()) {
-			var bytes = in.readByteArray(MAX_MEMO_BYTES);
-			if (null != bytes) {
-				to.setMemo(StringUtils.newStringUtf8(bytes));
-			}
+			to.setMemo(in.readNormalisedString(MAX_MEMO_BYTES));
 		}
 
 		to.setAdminKey(in.readBoolean() ? serdes.deserializeKey(in) : null);
@@ -54,7 +50,7 @@ public class TopicSerde {
 	public void serialize(MerkleTopic merkleTopic, SerializableDataOutputStream out) throws IOException {
 		if (merkleTopic.hasMemo()) {
 			out.writeBoolean(true);
-			out.writeBytes(merkleTopic.getMemo());
+			out.writeNormalisedString(merkleTopic.getMemo());
 		} else {
 			out.writeBoolean(false);
 		}

--- a/hedera-node/src/test/java/com/hedera/services/state/serdes/MerkleTopicSerdeTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/state/serdes/MerkleTopicSerdeTest.java
@@ -93,7 +93,7 @@ class MerkleTopicSerdeTest {
 
 		// then:
 		inOrder.verify(out).writeBoolean(true);
-		inOrder.verify(out).writeBytes(memo);
+		inOrder.verify(out).writeNormalisedString(memo);
 		// and:
 		inOrder.verify(out).writeBoolean(true);
 		inOrder.verify(serdes).serializeKey(adminKey, out);
@@ -204,9 +204,8 @@ class MerkleTopicSerdeTest {
 	private void configureFull(SerializableDataInputStream in, DomainSerdes serdes) throws IOException {
 		given(in.readBoolean())
 				.willReturn(true);
-		given(in.readByteArray(TopicSerde.MAX_MEMO_BYTES))
-				.willReturn(memo.getBytes())
-				.willReturn(null);
+		given(in.readNormalisedString(TopicSerde.MAX_MEMO_BYTES))
+				.willReturn(memo);
 		given(in.readByteArray(MerkleTopic.RUNNING_HASH_BYTE_ARRAY_SIZE))
 				.willReturn(hash);
 		given(serdes.deserializeKey(in))


### PR DESCRIPTION
**Summary of the change**:
Fix inconsistent use of `SerializableDataOutputStream#writeBytes` and `SerializableDataInputStream#readByteArray` in [`TopicSerde`](hedera-node/src/main/java/com/hedera/services/state/serdes/TopicSerde.java).

