### PR TITLE
Fix JRS test file names based on new naming conventions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1670,12 +1670,12 @@ jobs:
             echo -n "$KEY_50" > /repo/test-clients/src/main/resource/StartUpAccount.txt;
 
       - run:
-          name: Run Migration With Restart test
+          name: Run Migration test
           command: |
             cd /repo ; mvn --no-transfer-progress clean install -DskipTests;
             cd /swirlds-platform/regression;
             rm -rf /swirlds-platform/regression/results/;
-            ./regression_services_circleci.sh AWS-Services-Daily-MigrationWithRestart-4N-1C.json /repo
+            ./regression_services_circleci.sh AWS-Services-Daily-Migration-4N-1C.json /repo
 
       - run:
           name: Sync results of migration test to AWS

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1670,12 +1670,12 @@ jobs:
             echo -n "$KEY_50" > /repo/test-clients/src/main/resource/StartUpAccount.txt;
 
       - run:
-          name: Run Migration test
+          name: Run Migration With Restart test
           command: |
             cd /repo ; mvn --no-transfer-progress clean install -DskipTests;
             cd /swirlds-platform/regression;
             rm -rf /swirlds-platform/regression/results/;
-            ./regression_services_circleci.sh AWS-Services-Daily-Migration-4N-1C.json /repo
+            ./regression_services_circleci.sh AWS-Services-Daily-MigrationWithRestart-4N-1C.json /repo
 
       - run:
           name: Sync results of migration test to AWS

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1619,7 +1619,7 @@ jobs:
       - run:
           name: Run various suites in SuiteRunner
           command: |
-            cd /swirlds-platform/regression; ./regression_services_circleci.sh AwsNightlyServicesRegressionCfg.json /repo
+            cd /swirlds-platform/regression; ./regression_services_circleci.sh AWS-Services-Daily-Comp-4N-1C.json /repo
 
       - run:
           name: Sync results of SuiteRunner suites to AWS
@@ -1631,7 +1631,7 @@ jobs:
           command: |
             cd /swirlds-platform/regression;
             rm -rf /swirlds-platform/regression/results/;
-            ./regression_services_circleci.sh AwsServicesPerformanceRegressionCfg.json /repo
+            ./regression_services_circleci.sh AWS-Services-Daily-Perf-4N-4C.json /repo
 
       - run:
           name: Sync results of performance regression to AWS
@@ -1643,7 +1643,7 @@ jobs:
           command: |
             cd /swirlds-platform/regression;
             rm -rf /swirlds-platform/regression/results/;
-            ./regression_services_circleci.sh AwsSerivceRegressionNetworkError.json /repo
+            ./regression_services_circleci.sh AWS-Services-Daily-NetError-4N-1C.json /repo
 
       - run:
           name: Sync results of network error regression to AWS
@@ -1655,7 +1655,7 @@ jobs:
           command: |
             cd /swirlds-platform/regression;
             rm -rf /swirlds-platform/regression/results/;
-            ./regression_services_circleci.sh AWSNightlyServicesZeroStakeRegressionCfg.json /repo
+            ./regression_services_circleci.sh AWS-Services-Daily-Comp-6_2N-1C.json /repo
 
       - run:
           name: Sync results of zero stake regression to AWS
@@ -1675,7 +1675,7 @@ jobs:
             cd /repo ; mvn --no-transfer-progress clean install -DskipTests;
             cd /swirlds-platform/regression;
             rm -rf /swirlds-platform/regression/results/;
-            ./regression_services_circleci.sh AwsServicesMigrationCfg.json /repo
+            ./regression_services_circleci.sh AWS-Services-Daily-Migration-4N-1C.json /repo
 
       - run:
           name: Sync results of migration test to AWS

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -891,7 +891,7 @@ workflows:
   nightly-services-regression:
     triggers:
       - schedule:
-          cron: "0 4,8,12 * * *"
+          cron: "0 23,8 * * *"
           filters:
             branches:
               only:


### PR DESCRIPTION
In this PR https://github.com/swirlds/swirlds-platform-regression/pull/410 the names of JRS regression JSONS are modified. change names of those JSONs in the cron job that runs nightly regression