### PR TITLE
Remove impure Repository references in contract queries

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -837,6 +837,16 @@ commands:
           fqcn: com.hedera.services.legacy.CI.SmartContractSelfDestruct
       - run-property-driven-scenario-test:
           fqcn: com.hedera.services.legacy.regression.SmartContractSimpleStorageLinked
+      - run-eet-suites:
+          dsl-args: "CryptoTransferSuite"
+      - run-eet-suites:
+          dsl-args: "CryptoQueriesStressTests"
+      - run-eet-suites:
+          dsl-args: "FileQueriesStressTests"
+      - run-eet-suites:
+          dsl-args: "ConsensusQueriesStressTests"
+      - run-eet-suites:
+          dsl-args: "ContractQueriesStressTests"
       - run:
           name: Set log level to INFO
           command: /repo/.circleci/scripts/config-log4j-4normal.sh
@@ -1369,7 +1379,6 @@ workflows:
               ignore:
                 - /.*-PERF/
                 - /.*-REGRESSION/
-                - stable-iss-forensics
           workflow-name: "Continuous integration"
       - start-singlejob-testnet:
           context: Slack

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1369,6 +1369,7 @@ workflows:
               ignore:
                 - /.*-PERF/
                 - /.*-REGRESSION/
+                - stable-iss-forensics
           workflow-name: "Continuous integration"
       - start-singlejob-testnet:
           context: Slack

--- a/.gitignore
+++ b/.gitignore
@@ -60,11 +60,13 @@ evm-adapter/target/
 test-clients/logs/
 test-clients/*.bin
 test-clients/output/
-test-clients/devops-utils/validation-scenarios/logs/
+test-clients/devops-utils/validation-scenarios/fees/
 test-clients/devops-utils/validation-scenarios/output/
+test-clients/devops-utils/validation-scenarios/cost-snapshots/
 test-clients/devops-utils/sysfiles-update/svctools.tar.gz
 test-clients/devops-utils/sysfiles-update/certs/*.crt
 test-clients/devops-utils/sysfiles-update/run/SysFilesUpdate.jar
+test-clients/devops-utils/validation-scenarios/ValidationScenarios.jar
 test-clients/devops-utils/sysfiles-update/b64GenesisKeyPair.txt
 test-clients/src/main/resource/TestnetStartupAccount.txt
 test-clients/saved/

--- a/hedera-node/pom.xml
+++ b/hedera-node/pom.xml
@@ -32,7 +32,7 @@
 
     <commons-io.version>2.1</commons-io.version>
     <ethereum-core.version>1.12.0-v0.5.0</ethereum-core.version>
-    <swirlds.version>0.7.2</swirlds.version>
+    <swirlds.version>0.7.3</swirlds.version>
 
     <hamcrest-all.version>1.3</hamcrest-all.version>
     <mockito-junit-jupiter.version>3.3.0</mockito-junit-jupiter.version>
@@ -338,7 +338,7 @@
     <repository>
       <id>ossrh-swirlds-staging</id>
       <name>Staging repo</name>
-      <url>https://oss.sonatype.org/content/repositories/comhederahashgraph-1160</url>
+      <url>https://oss.sonatype.org/content/repositories/comhederahashgraph-1167</url>
     </repository>
     <repository>
       <id>ossrh-ethereumj-staging</id>

--- a/hedera-node/src/main/java/com/hedera/services/context/ServicesContext.java
+++ b/hedera-node/src/main/java/com/hedera/services/context/ServicesContext.java
@@ -31,11 +31,14 @@ import com.hedera.services.context.domain.trackers.ConsensusStatusCounts;
 import com.hedera.services.context.domain.trackers.IssEventInfo;
 import com.hedera.services.fees.StandardExemptions;
 import com.hedera.services.fees.calculation.TxnResourceUsageEstimator;
+import com.hedera.services.fees.calculation.contract.queries.GetBytecodeResourceUsage;
 import com.hedera.services.files.EntityExpiryMapFactory;
 import com.hedera.services.keys.LegacyEd25519KeyReader;
 import com.hedera.services.ledger.accounts.BackingAccounts;
 import com.hedera.services.ledger.accounts.PureFCMapBackingAccounts;
 import com.hedera.services.queries.answering.ZeroStakeAnswerFlow;
+import com.hedera.services.queries.contract.ContractAnswers;
+import com.hedera.services.queries.contract.GetBytecodeAnswer;
 import com.hedera.services.records.TxnIdRecentHistory;
 import com.hedera.services.security.ops.SystemOpPolicies;
 import com.hedera.services.sigs.metadata.DelegatingSigMetadataLookup;
@@ -310,6 +313,7 @@ public class ServicesContext {
 	private EntityIdSource ids;
 	private FileController fileGrpc;
 	private AnswerFunctions answerFunctions;
+	private ContractAnswers contractAnswers;
 	private OptionValidator validator;
 	private LedgerValidator ledgerValidator;
 	private HederaNodeStats stats;
@@ -515,6 +519,15 @@ public class ServicesContext {
 		return fileAnswers;
 	}
 
+	public ContractAnswers contractAnswers() {
+		if (contractAnswers == null) {
+			contractAnswers = new ContractAnswers(
+					new GetBytecodeAnswer(validator())
+			);
+		}
+		return contractAnswers;
+	}
+
 	public HcsAnswers hcsAnswers() {
 		if (hcsAnswers == null) {
 			hcsAnswers = new HcsAnswers(
@@ -591,7 +604,9 @@ public class ServicesContext {
 							new GetFileInfoResourceUsage(fileFees),
 							new GetFileContentsResourceUsage(fileFees),
 							/* Consensus */
-							new GetTopicInfoResourceUsage()
+							new GetTopicInfoResourceUsage(),
+							/* Smart Contract */
+							new GetBytecodeResourceUsage(contractFees)
 					),
 					txnUsageEstimators(fileFees, cryptoFees, contractFees)
 			);
@@ -1056,7 +1071,9 @@ public class ServicesContext {
 					stats(),
 					usagePrices(),
 					exchange(),
-					nodeType());
+					nodeType(),
+					contractAnswers(),
+					queryResponseHelper());
 		}
 		return contractsGrpc;
 	}

--- a/hedera-node/src/main/java/com/hedera/services/contracts/sources/BlobStorageSource.java
+++ b/hedera-node/src/main/java/com/hedera/services/contracts/sources/BlobStorageSource.java
@@ -20,13 +20,11 @@ package com.hedera.services.contracts.sources;
  * ‍
  */
 
-import java.util.Map;
-import java.util.Set;
-
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.ethereum.datasource.DbSettings;
 import org.ethereum.datasource.DbSource;
+
+import java.util.Map;
+import java.util.Set;
 
 public class BlobStorageSource implements DbSource<byte[]> {
 	private String name = "<N/A>";

--- a/hedera-node/src/main/java/com/hedera/services/fees/calculation/contract/queries/GetBytecodeResourceUsage.java
+++ b/hedera-node/src/main/java/com/hedera/services/fees/calculation/contract/queries/GetBytecodeResourceUsage.java
@@ -1,0 +1,45 @@
+package com.hedera.services.fees.calculation.contract.queries;
+
+import com.hedera.services.context.primitives.StateView;
+import com.hedera.services.fees.calculation.QueryResourceUsageEstimator;
+import com.hedera.services.fees.calculation.crypto.queries.GetTxnRecordResourceUsage;
+import com.hederahashgraph.api.proto.java.FeeData;
+import com.hederahashgraph.api.proto.java.Query;
+import com.hederahashgraph.api.proto.java.ResponseType;
+import com.hederahashgraph.fee.SmartContractFeeBuilder;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+public class GetBytecodeResourceUsage implements QueryResourceUsageEstimator {
+	private static final Logger log = LogManager.getLogger(GetTxnRecordResourceUsage.class);
+
+	private static final byte[] EMPTY_BYTECODE = new byte[0];
+
+	private final SmartContractFeeBuilder usageEstimator;
+
+	public GetBytecodeResourceUsage(SmartContractFeeBuilder usageEstimator) {
+		this.usageEstimator = usageEstimator;
+	}
+
+	@Override
+	public boolean applicableTo(Query query) {
+		return query.hasContractGetBytecode();
+	}
+
+	@Override
+	public FeeData usageGiven(Query query, StateView view) {
+		return usageGivenType(query, view, query.getContractGetBytecode().getHeader().getResponseType());
+	}
+
+	@Override
+	public FeeData usageGivenType(Query query, StateView view, ResponseType type) {
+		try {
+			var op = query.getContractGetBytecode();
+			var bytecode = view.bytecodeOf(op.getContractID()).orElse(EMPTY_BYTECODE);
+			return usageEstimator.getContractByteCodeQueryFeeMatrices(bytecode.length, type);
+		} catch (Exception illegal) {
+			log.warn("Usage estimation unexpectedly failed for {}!", query);
+			throw new IllegalArgumentException(illegal);
+		}
+	}
+}

--- a/hedera-node/src/main/java/com/hedera/services/legacy/handler/SmartContractRequestHandler.java
+++ b/hedera-node/src/main/java/com/hedera/services/legacy/handler/SmartContractRequestHandler.java
@@ -456,7 +456,6 @@ public class SmartContractRequestHandler {
 		String receiverAccountEthAddress = asSolidityAddressHex(receiverAccount);
 		ResponseCodeEnum callResponseStatus = validateContractExistence(contractCall.getContractID());
 		if (callResponseStatus == ResponseCodeEnum.OK) {
-			byte[] senderAccAddressBytes = ByteUtil.hexStringToBytes(senderAccountEthAddress);
 			BigInteger gas;
 			if (contractCall.getGas() <= PropertiesLoader.getMaxGasLimit()) {
 				gas = BigInteger.valueOf(contractCall.getGas());
@@ -465,8 +464,6 @@ public class SmartContractRequestHandler {
 				log.debug("Gas offered: {} reduced to maxGasLimit: {} in call", () -> contractCall.getGas(),
 						() -> PropertiesLoader.getMaxGasLimit());
 			}
-
-			BigInteger senderNonce = repository.getNonce(senderAccAddressBytes);
 
 			String data = "";
 			if (contractCall.getFunctionParameters() != null
@@ -493,7 +490,7 @@ public class SmartContractRequestHandler {
 				return getFailureTransactionRecord(transaction, consensusTime,
 						ResponseCodeEnum.CONTRACT_EXECUTION_EXCEPTION);
 			}
-			tx = new Transaction(senderNonce, biGasPrice, gas, senderAccountEthAddress,
+			tx = new Transaction(BigInteger.ZERO, biGasPrice, gas, senderAccountEthAddress,
 					receiverAccountEthAddress, value, data);
 
 			try {
@@ -566,7 +563,6 @@ public class SmartContractRequestHandler {
 		ResponseCodeEnum callResponseStatus =
 				validateContractExistence(transactionContractCallLocal.getContractID());
 		if (callResponseStatus == ResponseCodeEnum.OK) {
-			byte[] senderAccAddressBytes = ByteUtil.hexStringToBytes(senderAccountEthAddress);
 			BigInteger gas;
 			if (transactionContractCallLocal.getGas() <= PropertiesLoader.getMaxGasLimit()) {
 				gas = BigInteger.valueOf(transactionContractCallLocal.getGas());
@@ -575,8 +571,6 @@ public class SmartContractRequestHandler {
 				log.debug("Gas offered: {} reduced to maxGasLimit: {} in local call",
 						() -> transactionContractCallLocal.getGas(), () -> PropertiesLoader.getMaxGasLimit());
 			}
-			BigInteger senderNonce = repository.getNonce(senderAccAddressBytes);
-
 			String data = "";
 			if (transactionContractCallLocal.getFunctionParameters() != null
 					&& !transactionContractCallLocal.getFunctionParameters().isEmpty()) {
@@ -585,7 +579,7 @@ public class SmartContractRequestHandler {
 			}
 			BigInteger value = BigInteger.ZERO;
 
-			tx = new Transaction(senderNonce, BigInteger.ONE, gas, senderAccountEthAddress,
+			tx = new Transaction(BigInteger.ZERO, BigInteger.ONE, gas, senderAccountEthAddress,
 					receiverAccountEthAddress, value, data);
 			responseToReturn = runPure(
 					tx,

--- a/hedera-node/src/main/java/com/hedera/services/legacy/utils/TransactionValidationUtils.java
+++ b/hedera-node/src/main/java/com/hedera/services/legacy/utils/TransactionValidationUtils.java
@@ -29,7 +29,6 @@ import com.hederahashgraph.api.proto.java.AccountID;
 import com.hederahashgraph.api.proto.java.ContractCallLocalResponse;
 import com.hederahashgraph.api.proto.java.ContractCallTransactionBody;
 import com.hederahashgraph.api.proto.java.ContractCreateTransactionBody;
-import com.hederahashgraph.api.proto.java.ContractGetBytecodeResponse;
 import com.hederahashgraph.api.proto.java.ContractGetInfoResponse;
 import com.hederahashgraph.api.proto.java.ContractGetRecordsResponse;
 import com.hederahashgraph.api.proto.java.ContractUpdateTransactionBody;
@@ -223,15 +222,6 @@ public class TransactionValidationUtils {
 		responseObserver.onCompleted();
 	}
 
-	public static void constructContractGetBytecodeInfoErrorResponse(
-			StreamObserver<Response> responseObserver, ResponseCodeEnum validationCode, long scheduledFee) {
-		ResponseHeader responseHeader = RequestBuilder.getResponseHeader(
-				validationCode, scheduledFee, ResponseType.ANSWER_ONLY, ByteString.EMPTY);
-		responseObserver.onNext(Response.newBuilder().setContractGetBytecodeResponse(
-				ContractGetBytecodeResponse.newBuilder().setHeader(responseHeader)).build());
-		responseObserver.onCompleted();
-	}
-
 	public static void constructGetAccountRecordsErrorResponse(
 			StreamObserver<Response> responseObserver, ResponseCodeEnum validationCode, long scheduledFee) {
 		ResponseHeader responseHeader = RequestBuilder
@@ -272,18 +262,12 @@ public class TransactionValidationUtils {
 		} else if (methodMsg.startsWith("getContractInfo")) {
 			TransactionValidationUtils.constructContractGetInfoErrorResponse(responseObserver,
 					responseCode, 0);
-		} else if (methodMsg.startsWith("getContractBytecode")) {
-			TransactionValidationUtils.constructContractGetBytecodeInfoErrorResponse(responseObserver,
-					responseCode, 0);
 		} else if (methodMsg.startsWith("contractCallLocalMethod")) {
 			TransactionValidationUtils.constructContractCallLocalErrorResponse(responseObserver,
 					responseCode, 0);
 		} else if (methodMsg.startsWith("getTxRecordByContractID")) {
 			TransactionValidationUtils.constructContractGetRecordsErrorResponse(responseObserver,
 					responseCode, 0);
-		} else if (methodMsg.startsWith("contractGetBytecode")) {
-			TransactionValidationUtils
-					.constructContractGetBytecodeInfoErrorResponse(responseObserver, responseCode, 0);
 		}
 	}
 

--- a/hedera-node/src/main/java/com/hedera/services/queries/answering/QueryResponseHelper.java
+++ b/hedera-node/src/main/java/com/hedera/services/queries/answering/QueryResponseHelper.java
@@ -103,6 +103,20 @@ public class QueryResponseHelper {
 				() -> stats.fileQuerySubmitted(metric));
 	}
 
+	public void respondToContract(
+			Query query,
+			StreamObserver<Response> observer,
+			AnswerService answer,
+			String metric
+	) {
+		respondWithMetrics(
+				query,
+				observer,
+				answer,
+				() -> stats.smartContractQueryReceived(metric),
+				() -> stats.smartContractQuerySubmitted(metric));
+	}
+
 	private void respondWithMetrics(
 			Query query,
 			StreamObserver<Response> observer,

--- a/hedera-node/src/main/java/com/hedera/services/queries/contract/ContractAnswers.java
+++ b/hedera-node/src/main/java/com/hedera/services/queries/contract/ContractAnswers.java
@@ -1,0 +1,33 @@
+package com.hedera.services.queries.contract;
+
+/*-
+ * ‌
+ * Hedera Services Node
+ * ​
+ * Copyright (C) 2018 - 2020 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+public class ContractAnswers {
+	private final GetBytecodeAnswer getBytecodeAnswer;
+
+	public ContractAnswers(GetBytecodeAnswer getBytecodeAnswer) {
+		this.getBytecodeAnswer = getBytecodeAnswer;
+	}
+
+	public GetBytecodeAnswer bytecodeAnswer() {
+		return getBytecodeAnswer;
+	}
+}

--- a/hedera-node/src/main/java/com/hedera/services/queries/contract/GetBytecodeAnswer.java
+++ b/hedera-node/src/main/java/com/hedera/services/queries/contract/GetBytecodeAnswer.java
@@ -1,0 +1,107 @@
+package com.hedera.services.queries.contract;
+
+/*-
+ * ‌
+ * Hedera Services Node
+ * ​
+ * Copyright (C) 2018 - 2020 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import com.google.protobuf.ByteString;
+import com.hedera.services.context.primitives.StateView;
+import com.hedera.services.queries.AnswerService;
+import com.hedera.services.txns.validation.OptionValidator;
+import com.hedera.services.utils.SignedTxnAccessor;
+import com.hederahashgraph.api.proto.java.ContractGetBytecodeResponse;
+import com.hederahashgraph.api.proto.java.HederaFunctionality;
+import com.hederahashgraph.api.proto.java.Query;
+import com.hederahashgraph.api.proto.java.Response;
+import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
+
+import java.util.Optional;
+
+import static com.hedera.services.utils.SignedTxnAccessor.uncheckedFrom;
+import static com.hederahashgraph.api.proto.java.HederaFunctionality.ContractGetBytecode;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OK;
+import static com.hederahashgraph.api.proto.java.ResponseType.COST_ANSWER;
+
+public class GetBytecodeAnswer implements AnswerService {
+	private static final byte[] EMPTY_BYTECODE = new byte[0];
+
+	private final OptionValidator validator;
+
+	public GetBytecodeAnswer(OptionValidator validator) {
+		this.validator = validator;
+	}
+
+	@Override
+	public boolean needsAnswerOnlyCost(Query query) {
+		return COST_ANSWER == query.getContractGetBytecode().getHeader().getResponseType();
+	}
+
+	@Override
+	public boolean requiresNodePayment(Query query) {
+		return typicallyRequiresNodePayment(query.getContractGetBytecode().getHeader().getResponseType());
+	}
+
+	@Override
+	public Response responseGiven(Query query, StateView view, ResponseCodeEnum validity, long cost) {
+		var op = query.getContractGetBytecode();
+		var target = op.getContractID();
+
+		var response = ContractGetBytecodeResponse.newBuilder();
+		var type = op.getHeader().getResponseType();
+		if (validity != OK) {
+			response.setHeader(header(validity, type, cost));
+			response.setBytecode(ByteString.copyFrom(EMPTY_BYTECODE));
+		} else {
+			if (type == COST_ANSWER) {
+				response.setHeader(costAnswerHeader(OK, cost));
+				response.setBytecode(ByteString.copyFrom(EMPTY_BYTECODE));
+			} else {
+				/* Include cost here to satisfy legacy regression tests. */
+				response.setHeader(answerOnlyHeader(OK, cost));
+				response.setBytecode(ByteString.copyFrom(view.bytecodeOf(target).orElse(EMPTY_BYTECODE)));
+			}
+		}
+		return Response.newBuilder()
+				.setContractGetBytecodeResponse(response)
+				.build();
+	}
+
+	@Override
+	public ResponseCodeEnum checkValidity(Query query, StateView view) {
+		var id = query.getContractGetBytecode().getContractID();
+
+		return validator.queryableContractStatus(id, view.contracts());
+	}
+
+	@Override
+	public HederaFunctionality canonicalFunction() {
+		return ContractGetBytecode;
+	}
+
+	@Override
+	public ResponseCodeEnum extractValidityFrom(Response response) {
+		return response.getContractGetBytecodeResponse().getHeader().getNodeTransactionPrecheckCode();
+	}
+
+	@Override
+	public Optional<SignedTxnAccessor> extractPaymentFrom(Query query) {
+		var paymentTxn = query.getContractGetBytecode().getHeader().getPayment();
+		return Optional.ofNullable(uncheckedFrom(paymentTxn));
+	}
+}

--- a/hedera-node/src/main/java/com/hedera/services/state/logic/ServicesTxnManager.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/logic/ServicesTxnManager.java
@@ -1,5 +1,25 @@
 package com.hedera.services.state.logic;
 
+/*-
+ * ‌
+ * Hedera Services Node
+ * ​
+ * Copyright (C) 2018 - 2020 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
 import com.hedera.services.context.ServicesContext;
 import com.hedera.services.utils.PlatformTxnAccessor;
 

--- a/hedera-node/src/main/java/com/hedera/services/state/logic/ServicesTxnManager.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/logic/ServicesTxnManager.java
@@ -1,0 +1,95 @@
+package com.hedera.services.state.logic;
+
+import com.hedera.services.context.ServicesContext;
+import com.hedera.services.utils.PlatformTxnAccessor;
+
+import java.time.Instant;
+import java.util.function.BiConsumer;
+
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.FAIL_INVALID;
+
+public class ServicesTxnManager {
+	private final Runnable scopedProcessing;
+	private final Runnable scopedRecordStreaming;
+	private final BiConsumer<Exception, String> warning;
+
+	public ServicesTxnManager(
+			Runnable scopedProcessing,
+			Runnable scopedRecordStreaming,
+			BiConsumer<Exception, String> warning
+	) {
+		this.warning = warning;
+		this.scopedProcessing = scopedProcessing;
+		this.scopedRecordStreaming = scopedRecordStreaming;
+	}
+
+	private boolean createdStreamableRecord;
+
+	public void process(
+			PlatformTxnAccessor accessor,
+			Instant consensusTime,
+			long submittingMember,
+			ServicesContext ctx
+	) {
+		createdStreamableRecord = false;
+
+		try {
+			ctx.ledger().begin();
+			ctx.txnCtx().resetFor(accessor, consensusTime, submittingMember);
+			scopedProcessing.run();
+		} catch (Exception processFailure) {
+			warning.accept(processFailure, "txn processing");
+			ctx.txnCtx().setStatus(FAIL_INVALID);
+		} finally {
+			attemptCommit(accessor, consensusTime, submittingMember, ctx);
+			if (createdStreamableRecord) {
+				attemptRecordStreaming();
+			}
+		}
+	}
+
+	private void attemptRecordStreaming() {
+		try {
+			scopedRecordStreaming.run();
+		} catch (Exception streamingFailure) {
+			warning.accept(streamingFailure, "record streaming");
+		}
+	}
+
+	private void attemptCommit(
+			PlatformTxnAccessor accessor,
+			Instant consensusTime,
+			long submittingMember,
+			ServicesContext ctx
+	) {
+		try {
+			ctx.ledger().commit();
+			createdStreamableRecord = true;
+		} catch (Exception commitFailure) {
+			warning.accept(commitFailure, "txn commit");
+			attemptRollback(accessor, consensusTime, submittingMember, ctx);
+		}
+	}
+
+	private void attemptRollback(
+			PlatformTxnAccessor accessor,
+			Instant consensusTime,
+			long submittingMember,
+			ServicesContext ctx
+	) {
+		try {
+			ctx.recordCache().setFailInvalid(
+					ctx.txnCtx().effectivePayer(),
+					accessor,
+					consensusTime,
+					submittingMember);
+		} catch (Exception recordFailure) {
+			warning.accept(recordFailure, "creating failure record");
+		}
+		try {
+			ctx.ledger().rollback();
+		} catch (Exception rollbackFailure) {
+			warning.accept(rollbackFailure, "txn rollback");
+		}
+	}
+}

--- a/hedera-node/src/main/java/com/hedera/services/state/merkle/MerkleAccount.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/merkle/MerkleAccount.java
@@ -103,13 +103,19 @@ public class MerkleAccount extends AbstractMerkleInternal implements FCMValue, M
 
 	@Override
 	public MerkleAccount copy() {
-		var records = records();
-		var payerRecords = payerRecords();
+		if (isImmutable()) {
+			var msg = String.format("Copy called on an immutable MerkleAccount by thread '%s'! " +
+							"(Records mutable? %s. Payer records mutable? %s.)",
+					Thread.currentThread().getName(),
+					records().isImmutable() ? "NO" : "YES",
+					payerRecords().isImmutable() ? "NO" : "YES");
+			log.warn(msg);
+			/* Ensure we get this stack trace in case a caller incorrectly suppresses the exception. */
+			Thread.dumpStack();
+			throw new IllegalStateException("Tried to make a copy of an immutable MerkleAccount!");
+		}
 
-		return new MerkleAccount(List.of(
-				state().copy(),
-				records.isImmutable() ? records : records.copy(),
-				payerRecords.isImmutable() ? payerRecords : payerRecords.copy()));
+		return new MerkleAccount(List.of(state().copy(), records().copy(), payerRecords().copy()));
 	}
 
 	@Override

--- a/hedera-node/src/main/java/com/hedera/services/utils/SignedTxnAccessor.java
+++ b/hedera-node/src/main/java/com/hedera/services/utils/SignedTxnAccessor.java
@@ -89,11 +89,11 @@ public class SignedTxnAccessor {
 	public Transaction getSignedTxn4Log() {
 		if (signedTxn4Log == null) {
 			try {
-				signedTxn4Log = signedTxn.toBuilder()
+				signedTxn4Log = signedTxn.hasBody() ? signedTxn : signedTxn.toBuilder()
 						.setBody(TransactionBody.parseFrom(signedTxn.getBodyBytes()))
 						.clearBodyBytes()
 						.build();
-			} catch (InvalidProtocolBufferException ignore) {}
+			} catch (InvalidProtocolBufferException ignore) { }
 		}
 		return signedTxn4Log;
 	}

--- a/hedera-node/src/test/java/com/hedera/services/context/ServicesContextTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/context/ServicesContextTest.java
@@ -28,6 +28,7 @@ import com.hedera.services.fees.StandardExemptions;
 import com.hedera.services.keys.LegacyEd25519KeyReader;
 import com.hedera.services.ledger.accounts.FCMapBackingAccounts;
 import com.hedera.services.queries.answering.ZeroStakeAnswerFlow;
+import com.hedera.services.queries.contract.ContractAnswers;
 import com.hedera.services.security.ops.SystemOpPolicies;
 import com.hedera.services.state.expiry.ExpiringCreations;
 import com.hedera.services.state.expiry.ExpiryManager;
@@ -406,6 +407,7 @@ public class ServicesContextTest {
 		assertThat(ctx.ledgerValidator(), instanceOf(BasedLedgerValidator.class));
 		assertThat(ctx.systemOpPolicies(), instanceOf(SystemOpPolicies.class));
 		assertThat(ctx.exemptions(), instanceOf(StandardExemptions.class));
+		assertThat(ctx.contractAnswers(), instanceOf(ContractAnswers.class));
 		assertEquals(ServicesNodeType.STAKED_NODE, ctx.nodeType());
 		// and expect legacy:
 		assertThat(ctx.exchange(), instanceOf(DefaultHbarCentExchange.class));

--- a/hedera-node/src/test/java/com/hedera/services/fees/calculation/contract/queries/GetBytecodeResourceUsageTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/fees/calculation/contract/queries/GetBytecodeResourceUsageTest.java
@@ -1,0 +1,132 @@
+package com.hedera.services.fees.calculation.contract.queries;
+
+/*-
+ * ‌
+ * Hedera Services Node
+ * ​
+ * Copyright (C) 2018 - 2020 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import static com.hedera.test.utils.IdUtils.asContract;
+import static com.hedera.test.utils.IdUtils.asFile;
+import static com.hederahashgraph.api.proto.java.ResponseType.ANSWER_ONLY;
+import static com.hederahashgraph.api.proto.java.ResponseType.COST_ANSWER;
+import static org.junit.jupiter.api.Assertions.*;
+import com.google.protobuf.ByteString;
+import com.hedera.services.context.primitives.StateView;
+import com.hedera.services.fees.calculation.file.queries.GetFileContentsResourceUsage;
+import com.hedera.services.queries.contract.GetBytecodeAnswer;
+import com.hedera.test.utils.IdUtils;
+import com.hederahashgraph.api.proto.java.ContractGetBytecodeQuery;
+import com.hederahashgraph.api.proto.java.ContractID;
+import com.hederahashgraph.api.proto.java.FeeData;
+import com.hederahashgraph.api.proto.java.FileAppendTransactionBody;
+import com.hederahashgraph.api.proto.java.FileGetContentsQuery;
+import com.hederahashgraph.api.proto.java.FileID;
+import com.hederahashgraph.api.proto.java.Key;
+import com.hederahashgraph.api.proto.java.Query;
+import com.hederahashgraph.api.proto.java.QueryHeader;
+import com.hederahashgraph.api.proto.java.ResponseType;
+import com.hederahashgraph.api.proto.java.Timestamp;
+import com.hederahashgraph.api.proto.java.TransactionBody;
+import com.hederahashgraph.fee.FileFeeBuilder;
+import com.hederahashgraph.fee.SigValueObj;
+import com.hedera.services.legacy.core.jproto.JFileInfo;
+import com.hedera.services.legacy.core.jproto.JKey;
+import com.hederahashgraph.fee.SmartContractFeeBuilder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.platform.runner.JUnitPlatform;
+import org.junit.runner.RunWith;
+
+import java.util.Optional;
+
+import static org.mockito.BDDMockito.*;
+
+@RunWith(JUnitPlatform.class)
+class GetBytecodeResourceUsageTest {
+	byte[] bytecode = "A Supermarket in California".getBytes();
+	ContractID target = asContract("0.0.123");
+	StateView view;
+	SmartContractFeeBuilder usageEstimator;
+
+	GetBytecodeResourceUsage subject;
+
+	@BeforeEach
+	private void setup() throws Throwable {
+		usageEstimator = mock(SmartContractFeeBuilder.class);
+		view = mock(StateView.class);
+
+		subject = new GetBytecodeResourceUsage(usageEstimator);
+	}
+
+	@Test
+	public void recognizesApplicableQuery() {
+		// given:
+		var applicable = bytecodeQuery(target, COST_ANSWER);
+		var inapplicable = Query.getDefaultInstance();
+
+		// expect:
+		assertTrue(subject.applicableTo(applicable));
+		assertFalse(subject.applicableTo(inapplicable));
+	}
+
+	@Test
+	public void invokesEstimatorAsExpectedForType() {
+		// setup:
+		FeeData costAnswerUsage = mock(FeeData.class);
+		FeeData answerOnlyUsage = mock(FeeData.class);
+		int size = bytecode.length;
+
+		// given:
+		Query answerOnlyQuery = bytecodeQuery(target, ANSWER_ONLY);
+		Query costAnswerQuery = bytecodeQuery(target, COST_ANSWER);
+		// and:
+		given(view.bytecodeOf(target)).willReturn(Optional.of(bytecode));
+		// and:
+		given(usageEstimator.getContractByteCodeQueryFeeMatrices(size, COST_ANSWER))
+				.willReturn(costAnswerUsage);
+		given(usageEstimator.getContractByteCodeQueryFeeMatrices(size, ANSWER_ONLY))
+				.willReturn(answerOnlyUsage);
+
+		// when:
+		FeeData costAnswerEstimate = subject.usageGiven(costAnswerQuery, view);
+		FeeData answerOnlyEstimate = subject.usageGiven(answerOnlyQuery, view);
+
+		// then:
+		assertSame(costAnswerEstimate, costAnswerUsage);
+		assertSame(answerOnlyEstimate, answerOnlyUsage);
+	}
+
+	@Test
+	public void throwsIaeOnUnexpectedProblem() {
+		Query answerOnlyQuery = bytecodeQuery(target, ANSWER_ONLY);
+
+		given(view.bytecodeOf(any())).willThrow(IllegalStateException.class);
+
+		// then:
+		assertThrows(IllegalArgumentException.class, () -> subject.usageGiven(answerOnlyQuery, view));
+	}
+
+	private Query bytecodeQuery(ContractID id, ResponseType type) {
+		ContractGetBytecodeQuery.Builder op = ContractGetBytecodeQuery.newBuilder()
+				.setContractID(id)
+				.setHeader(QueryHeader.newBuilder().setResponseType(type));
+		return Query.newBuilder()
+				.setContractGetBytecode(op)
+				.build();
+	}
+}

--- a/hedera-node/src/test/java/com/hedera/services/fees/calculation/file/queries/GetFileContentsResourceUsageTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/fees/calculation/file/queries/GetFileContentsResourceUsageTest.java
@@ -33,6 +33,9 @@ import com.hederahashgraph.api.proto.java.ResponseType;
 import com.hederahashgraph.fee.FileFeeBuilder;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.platform.runner.JUnitPlatform;
+import org.junit.runner.RunWith;
+
 import java.util.Optional;
 import static com.hedera.test.utils.IdUtils.asFile;
 import static com.hederahashgraph.api.proto.java.ResponseType.ANSWER_ONLY;
@@ -42,6 +45,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 
+@RunWith(JUnitPlatform.class)
 class GetFileContentsResourceUsageTest {
 	FileID target = asFile("0.0.123");
 	StateView view;

--- a/hedera-node/src/test/java/com/hedera/services/fees/calculation/file/queries/GetFileInfoResourceUsageTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/fees/calculation/file/queries/GetFileInfoResourceUsageTest.java
@@ -33,6 +33,9 @@ import com.hederahashgraph.api.proto.java.ResponseType;
 import com.hederahashgraph.fee.FileFeeBuilder;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.platform.runner.JUnitPlatform;
+import org.junit.runner.RunWith;
+
 import java.util.Optional;
 import static com.hedera.test.utils.IdUtils.asFile;
 import static com.hederahashgraph.api.proto.java.ResponseType.ANSWER_ONLY;
@@ -42,6 +45,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 
+@RunWith(JUnitPlatform.class)
 class GetFileInfoResourceUsageTest {
 	FileID target = asFile("0.0.123");
 	StateView view;

--- a/hedera-node/src/test/java/com/hedera/services/legacy/unit/service/SmartContractServiceImplTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/legacy/unit/service/SmartContractServiceImplTest.java
@@ -468,8 +468,15 @@ public class SmartContractServiceImplTest {
 		when(platform.createTransaction(new com.swirlds.common.Transaction(trx.toByteArray())))
 				.thenReturn(true);
 
-		smartContractImpl = new SmartContractServiceImpl(platform, transactionHandler,
-				smartContractHandler, hederaNodeStats, TEST_USAGE_PRICES, TEST_EXCHANGE, STAKED_NODE);
+		smartContractImpl = new SmartContractServiceImpl(
+				platform, transactionHandler,
+				smartContractHandler,
+				hederaNodeStats,
+				TEST_USAGE_PRICES,
+				TEST_EXCHANGE,
+				STAKED_NODE,
+				null,
+				null);
 
 		smartContractImpl.createContract(trx, responseObserver);
 
@@ -503,7 +510,7 @@ public class SmartContractServiceImplTest {
 
 			smartContractImpl = new SmartContractServiceImpl(platform, transactionHandler,
 					smartContractHandler, hederaNodeStats,
-					TEST_USAGE_PRICES, TEST_EXCHANGE, STAKED_NODE);
+					TEST_USAGE_PRICES, TEST_EXCHANGE, STAKED_NODE, null, null);
 
 			StreamObserver<Response> respOb = new StreamObserver<Response>() {
 

--- a/hedera-node/src/test/java/com/hedera/services/queries/answering/QueryResponseHelperTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/queries/answering/QueryResponseHelperTest.java
@@ -87,6 +87,25 @@ class QueryResponseHelperTest {
 	}
 
 	@Test
+	public void helpsWithContractHappyPath() {
+		// setup:
+		InOrder inOrder = inOrder(answerFlow, stats, observer);
+
+		given(answerFlow.satisfyUsing(answer, query)).willReturn(okResponse);
+		given(answer.extractValidityFrom(okResponse)).willReturn(OK);
+
+		// when:
+		subject.respondToContract(query, observer, answer, metric);
+
+		// then:
+		inOrder.verify(stats).smartContractQueryReceived(metric);
+		inOrder.verify(answerFlow).satisfyUsing(answer, query);
+		inOrder.verify(observer).onNext(okResponse);
+		inOrder.verify(observer).onCompleted();
+		inOrder.verify(stats).smartContractQuerySubmitted(metric);
+	}
+
+	@Test
 	public void helpsWithCryptoHappyPath() {
 		// setup:
 		InOrder inOrder = inOrder(answerFlow, stats, observer);

--- a/hedera-node/src/test/java/com/hedera/services/queries/contract/ContractAnswersTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/queries/contract/ContractAnswersTest.java
@@ -1,0 +1,46 @@
+package com.hedera.services.queries.contract;
+
+/*-
+ * ‌
+ * Hedera Services Node
+ * ​
+ * Copyright (C) 2018 - 2020 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.hedera.services.queries.consensus.GetTopicInfoAnswer;
+import com.hedera.services.queries.consensus.HcsAnswers;
+import org.junit.jupiter.api.Test;
+import org.junit.platform.runner.JUnitPlatform;
+import org.junit.runner.RunWith;
+import static org.mockito.BDDMockito.*;
+
+@RunWith(JUnitPlatform.class)
+class ContractAnswersTest {
+	GetBytecodeAnswer getBytecodeAnswer = mock(GetBytecodeAnswer.class);
+
+	ContractAnswers subject;
+
+	@Test
+	public void hasExpectedAnswers() {
+		// given:
+		subject = new ContractAnswers(getBytecodeAnswer);
+
+		// then:
+		assertEquals(getBytecodeAnswer, subject.bytecodeAnswer());
+	}
+}

--- a/hedera-node/src/test/java/com/hedera/services/queries/contract/GetBytecodeAnswerTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/queries/contract/GetBytecodeAnswerTest.java
@@ -1,0 +1,209 @@
+package com.hedera.services.queries.contract;
+
+/*-
+ * ‌
+ * Hedera Services Node
+ * ​
+ * Copyright (C) 2018 - 2020 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import com.hedera.services.context.primitives.StateView;
+import com.hedera.services.ledger.accounts.FCMapBackingAccounts;
+import com.hedera.services.queries.file.GetFileContentsAnswer;
+import com.hedera.services.state.merkle.MerkleAccount;
+import com.hedera.services.state.merkle.MerkleEntityId;
+import com.hedera.services.txns.validation.OptionValidator;
+import com.hedera.test.factories.scenarios.TxnHandlingScenario;
+import com.hederahashgraph.api.proto.java.ContractGetBytecodeQuery;
+import com.hederahashgraph.api.proto.java.ContractGetBytecodeResponse;
+import com.hederahashgraph.api.proto.java.FileGetContentsQuery;
+import com.hederahashgraph.api.proto.java.FileGetContentsResponse;
+import com.hederahashgraph.api.proto.java.FileGetInfoResponse;
+import com.hederahashgraph.api.proto.java.HederaFunctionality;
+import com.hederahashgraph.api.proto.java.Query;
+import com.hederahashgraph.api.proto.java.QueryHeader;
+import com.hederahashgraph.api.proto.java.Response;
+import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
+import com.hederahashgraph.api.proto.java.ResponseType;
+import com.hederahashgraph.api.proto.java.Timestamp;
+import com.hederahashgraph.api.proto.java.Transaction;
+import com.swirlds.fcmap.FCMap;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.platform.runner.JUnitPlatform;
+import org.junit.runner.RunWith;
+
+import java.util.Arrays;
+import java.util.Optional;
+
+import static com.hedera.test.factories.scenarios.TxnHandlingScenario.COMPLEX_KEY_ACCOUNT_KT;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.*;
+import static com.hederahashgraph.api.proto.java.ResponseType.ANSWER_ONLY;
+import static com.hederahashgraph.api.proto.java.ResponseType.COST_ANSWER;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.BDDMockito.*;
+import static com.hedera.test.utils.IdUtils.*;
+import static com.hedera.test.utils.TxnUtils.*;
+
+@RunWith(JUnitPlatform.class)
+class GetBytecodeAnswerTest {
+	private Transaction paymentTxn;
+	private String node = "0.0.3";
+	private String payer = "0.0.12345";
+	private String target = "0.0.123";
+	private long fee = 1_234L;
+	private byte[] bytecode = "A Supermarket in California".getBytes();
+
+	OptionValidator optionValidator;
+	StateView view;
+	FCMap<MerkleEntityId, MerkleAccount> contracts;
+
+	GetBytecodeAnswer subject;
+
+	@BeforeEach
+	public void setup() {
+		contracts = mock(FCMap.class);
+
+		view = mock(StateView.class);
+		given(view.contracts()).willReturn(contracts);
+		optionValidator = mock(OptionValidator.class);
+
+		subject = new GetBytecodeAnswer(optionValidator);
+	}
+
+	@Test
+	public void recognizesFunction() {
+		// expect:
+		assertEquals(HederaFunctionality.ContractGetBytecode, subject.canonicalFunction());
+	}
+
+	@Test
+	public void requiresAnswerOnlyCostAsExpected() throws Throwable {
+		// expect:
+		assertTrue(subject.needsAnswerOnlyCost(validQuery(COST_ANSWER, 0, target)));
+		assertFalse(subject.needsAnswerOnlyCost(validQuery(ANSWER_ONLY, 0, target)));
+	}
+
+	@Test
+	public void requiresAnswerOnlyPayment() throws Throwable {
+		// expect:
+		assertFalse(subject.requiresNodePayment(validQuery(COST_ANSWER, 0, target)));
+		assertTrue(subject.requiresNodePayment(validQuery(ANSWER_ONLY, 0, target)));
+	}
+
+	@Test
+	public void getsValidity() {
+		// given:
+		Response response = Response.newBuilder().setContractGetBytecodeResponse(
+				ContractGetBytecodeResponse.newBuilder()
+						.setHeader(subject.answerOnlyHeader(RESULT_SIZE_LIMIT_EXCEEDED))).build();
+
+		// expect:
+		assertEquals(RESULT_SIZE_LIMIT_EXCEEDED, subject.extractValidityFrom(response));
+	}
+
+	@Test
+	public void getsExpectedPayment() throws Throwable {
+		// given:
+		Query query = validQuery(COST_ANSWER, fee, target);
+
+		// expect:
+		assertEquals(paymentTxn, subject.extractPaymentFrom(query).get().getSignedTxn());
+	}
+
+	@Test
+	public void getsTheBytecode() throws Throwable {
+		// setup:
+		Query query = validQuery(ANSWER_ONLY, fee, target);
+
+		given(view.bytecodeOf(asContract(target))).willReturn(Optional.of(bytecode));
+
+		// when:
+		Response response = subject.responseGiven(query, view, OK, fee);
+
+		// then:
+		assertTrue(response.hasContractGetBytecodeResponse());
+		assertTrue(response.getContractGetBytecodeResponse().hasHeader(), "Missing response header!");
+		assertEquals(OK, response.getContractGetBytecodeResponse().getHeader().getNodeTransactionPrecheckCode());
+		assertEquals(ANSWER_ONLY, response.getContractGetBytecodeResponse().getHeader().getResponseType());
+		assertEquals(fee, response.getContractGetBytecodeResponse().getHeader().getCost());
+		// and:
+		var actual = response.getContractGetBytecodeResponse().getBytecode().toByteArray();
+		assertTrue(Arrays.equals(bytecode, actual));
+	}
+
+	@Test
+	public void getsCostAnswerResponse() throws Throwable {
+		// setup:
+		Query query = validQuery(COST_ANSWER, fee, target);
+
+		// when:
+		Response response = subject.responseGiven(query, view, OK, fee);
+
+		// then:
+		assertTrue(response.hasContractGetBytecodeResponse());
+		assertEquals(OK, response.getContractGetBytecodeResponse().getHeader().getNodeTransactionPrecheckCode());
+		assertEquals(COST_ANSWER, response.getContractGetBytecodeResponse().getHeader().getResponseType());
+		assertEquals(fee, response.getContractGetBytecodeResponse().getHeader().getCost());
+	}
+
+	@Test
+	public void getsInvalidResponse() throws Throwable {
+		// setup:
+		Query query = validQuery(COST_ANSWER, fee, target);
+
+		// when:
+		Response response = subject.responseGiven(query, view, CONTRACT_DELETED, fee);
+
+		// then:
+		assertTrue(response.hasContractGetBytecodeResponse());
+		assertEquals(
+				CONTRACT_DELETED,
+				response.getContractGetBytecodeResponse().getHeader().getNodeTransactionPrecheckCode());
+		assertEquals(COST_ANSWER, response.getContractGetBytecodeResponse().getHeader().getResponseType());
+		assertEquals(fee, response.getContractGetBytecodeResponse().getHeader().getCost());
+	}
+
+	@Test
+	public void usesValidator() throws Throwable {
+		// setup:
+		Query query = validQuery(COST_ANSWER, fee, target);
+
+		given(optionValidator.queryableContractStatus(asContract(target), contracts))
+				.willReturn(CONTRACT_DELETED);
+
+		// when:
+		ResponseCodeEnum validity = subject.checkValidity(query, view);
+
+		// then:
+		assertEquals(CONTRACT_DELETED, validity);
+		// and:
+		verify(optionValidator).queryableContractStatus(any(), any());
+	}
+
+	private Query validQuery(ResponseType type, long payment, String idLit) throws Throwable {
+		this.paymentTxn = payerSponsoredTransfer(payer, COMPLEX_KEY_ACCOUNT_KT, node, payment);
+		QueryHeader.Builder header = QueryHeader.newBuilder()
+				.setPayment(this.paymentTxn)
+				.setResponseType(type);
+		ContractGetBytecodeQuery.Builder op = ContractGetBytecodeQuery.newBuilder()
+				.setHeader(header)
+				.setContractID(asContract(idLit));
+		return Query.newBuilder().setContractGetBytecode(op).build();
+	}
+}

--- a/hedera-node/src/test/java/com/hedera/services/state/logic/ServicesTxnManagerTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/state/logic/ServicesTxnManagerTest.java
@@ -1,0 +1,199 @@
+package com.hedera.services.state.logic;
+
+/*-
+ * ‌
+ * Hedera Services Node
+ * ​
+ * Copyright (C) 2018 - 2020 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import com.hedera.services.context.ServicesContext;
+import com.hedera.services.context.TransactionContext;
+import com.hedera.services.ledger.HederaLedger;
+import com.hedera.services.records.RecordCache;
+import com.hedera.services.utils.PlatformTxnAccessor;
+import com.hedera.test.utils.IdUtils;
+import com.hederahashgraph.api.proto.java.AccountID;
+import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.platform.runner.JUnitPlatform;
+import org.junit.runner.RunWith;
+import org.mockito.InOrder;
+
+import java.time.Instant;
+import java.util.function.BiConsumer;
+
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.any;
+import static org.mockito.BDDMockito.argThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.mock;
+import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@RunWith(JUnitPlatform.class)
+class ServicesTxnManagerTest {
+	PlatformTxnAccessor accessor;
+	Instant consensusTime = Instant.now();
+	long submittingMember = 1;
+	AccountID effectivePayer = IdUtils.asAccount("0.0.75231");
+
+	Runnable processLogic;
+	Runnable recordStreaming;
+	BiConsumer<Exception, String> warning;
+
+	HederaLedger ledger;
+	RecordCache recordCache;
+	TransactionContext txnCtx;
+	ServicesContext ctx;
+
+	ServicesTxnManager subject;
+
+	@BeforeEach
+	public void setup() {
+		accessor = mock(PlatformTxnAccessor.class);
+
+		processLogic = mock(Runnable.class);
+		recordCache = mock(RecordCache.class);
+		recordStreaming = mock(Runnable.class);
+		warning = mock(BiConsumer.class);
+
+		subject = new ServicesTxnManager(processLogic, recordStreaming, warning);
+
+		ledger = mock(HederaLedger.class);
+		txnCtx = mock(TransactionContext.class);
+		ctx = mock(ServicesContext.class);
+		given(ctx.ledger()).willReturn(ledger);
+		given(ctx.txnCtx()).willReturn(txnCtx);
+		given(txnCtx.effectivePayer()).willReturn(effectivePayer);
+		given(ctx.recordCache()).willReturn(recordCache);
+	}
+
+	@Test
+	public void managesHappyPath() {
+		// setup:
+		InOrder inOrder = inOrder(ledger, txnCtx, processLogic, recordStreaming);
+
+		// when:
+		subject.process(accessor, consensusTime, submittingMember, ctx);
+
+		// then:
+		inOrder.verify(ledger).begin();
+		inOrder.verify(txnCtx).resetFor(accessor, consensusTime, submittingMember);
+		inOrder.verify(processLogic).run();
+		inOrder.verify(ledger).commit();
+		inOrder.verify(recordStreaming).run();
+	}
+
+	@Test
+	public void warnsOnFailedRecordStreaming() {
+		willThrow(IllegalStateException.class).given(recordStreaming).run();
+
+		// when:
+		subject.process(accessor, consensusTime, submittingMember, ctx);
+
+		// then:
+		verify(warning).accept(any(IllegalStateException.class), argThat("record streaming"::equals));
+	}
+
+	@Test
+	public void setsFailInvalidAndWarnsOnProcessFailure() {
+		// setup:
+		InOrder inOrder = inOrder(ledger, txnCtx, processLogic, recordStreaming, warning);
+
+		willThrow(IllegalStateException.class).given(ledger).begin();
+
+		// when:
+		subject.process(accessor, consensusTime, submittingMember, ctx);
+
+		// then:
+		inOrder.verify(ledger).begin();
+		inOrder.verify(warning).accept(any(IllegalStateException.class), argThat("txn processing"::equals));
+		inOrder.verify(txnCtx).setStatus(ResponseCodeEnum.FAIL_INVALID);
+		inOrder.verify(ledger).commit();
+		inOrder.verify(recordStreaming).run();
+	}
+
+	@Test
+	public void retriesRecordCreationOnCommitFailureThenRollbacks() {
+		// setup:
+		InOrder inOrder = inOrder(ledger, txnCtx, processLogic, recordStreaming, warning, recordCache);
+
+		willThrow(IllegalStateException.class).given(ledger).commit();
+
+		// when:
+		subject.process(accessor, consensusTime, submittingMember, ctx);
+
+		// then:
+		inOrder.verify(ledger).begin();
+		inOrder.verify(txnCtx).resetFor(accessor, consensusTime, submittingMember);
+		inOrder.verify(processLogic).run();
+		inOrder.verify(ledger).commit();
+		inOrder.verify(warning).accept(any(IllegalStateException.class), argThat("txn commit"::equals));
+		inOrder.verify(recordCache).setFailInvalid(effectivePayer, accessor, consensusTime, submittingMember);
+		inOrder.verify(ledger).rollback();
+		inOrder.verify(recordStreaming, never()).run();
+	}
+
+	@Test
+	public void warnsOnFailedRecordRecreate() {
+		// setup:
+		InOrder inOrder = inOrder(ledger, txnCtx, processLogic, recordStreaming, warning, recordCache);
+
+		willThrow(IllegalStateException.class).given(ledger).commit();
+		willThrow(IllegalStateException.class).given(recordCache).setFailInvalid(any(), any(), any(), anyLong());
+
+		// when:
+		subject.process(accessor, consensusTime, submittingMember, ctx);
+
+		// then:
+		inOrder.verify(ledger).begin();
+		inOrder.verify(txnCtx).resetFor(accessor, consensusTime, submittingMember);
+		inOrder.verify(processLogic).run();
+		inOrder.verify(ledger).commit();
+		inOrder.verify(warning).accept(any(IllegalStateException.class), argThat("txn commit"::equals));
+		inOrder.verify(recordCache).setFailInvalid(effectivePayer, accessor, consensusTime, submittingMember);
+		inOrder.verify(warning).accept(any(IllegalStateException.class), argThat("creating failure record"::equals));
+		inOrder.verify(ledger).rollback();
+		inOrder.verify(recordStreaming, never()).run();
+	}
+
+	@Test
+	public void warnsOnFailedRollback() {
+		// setup:
+		InOrder inOrder = inOrder(ledger, txnCtx, processLogic, recordStreaming, warning, recordCache);
+
+		willThrow(IllegalStateException.class).given(ledger).commit();
+		willThrow(IllegalStateException.class).given(ledger).rollback();
+
+		// when:
+		subject.process(accessor, consensusTime, submittingMember, ctx);
+
+		// then:
+		inOrder.verify(ledger).begin();
+		inOrder.verify(txnCtx).resetFor(accessor, consensusTime, submittingMember);
+		inOrder.verify(processLogic).run();
+		inOrder.verify(ledger).commit();
+		inOrder.verify(warning).accept(any(IllegalStateException.class), argThat("txn commit"::equals));
+		inOrder.verify(recordCache).setFailInvalid(effectivePayer, accessor, consensusTime, submittingMember);
+		inOrder.verify(ledger).rollback();
+		inOrder.verify(warning).accept(any(IllegalStateException.class), argThat("txn rollback"::equals));
+		inOrder.verify(recordStreaming, never()).run();
+	}
+}

--- a/hedera-node/src/test/java/com/hedera/services/state/merkle/MerkleAccountStateTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/state/merkle/MerkleAccountStateTest.java
@@ -20,12 +20,12 @@ package com.hedera.services.state.merkle;
  * ‍
  */
 
+import com.hedera.services.legacy.core.jproto.JEd25519Key;
+import com.hedera.services.legacy.core.jproto.JKey;
 import com.hedera.services.state.serdes.DomainSerdes;
 import com.hedera.services.state.serdes.IoReadingFunction;
 import com.hedera.services.state.serdes.IoWritingConsumer;
 import com.hedera.services.state.submerkle.EntityId;
-import com.hedera.services.legacy.core.jproto.JEd25519Key;
-import com.hedera.services.legacy.core.jproto.JKey;
 import com.hedera.services.utils.MiscUtils;
 import com.swirlds.common.io.SerializableDataInputStream;
 import com.swirlds.common.io.SerializableDataOutputStream;
@@ -38,13 +38,16 @@ import org.mockito.InOrder;
 
 import java.io.IOException;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.BDDMockito.*;
+import static org.mockito.BDDMockito.any;
+import static org.mockito.BDDMockito.anyInt;
+import static org.mockito.BDDMockito.argThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.mock;
+import static org.mockito.BDDMockito.times;
 import static org.mockito.Mockito.inOrder;
 
 @RunWith(JUnitPlatform.class)

--- a/hedera-node/src/test/java/com/hedera/services/state/merkle/MerkleAccountTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/state/merkle/MerkleAccountTest.java
@@ -130,16 +130,15 @@ public class MerkleAccountTest {
 	}
 
 	@Test
-	public void fastCopyUsesImmutableFcqs() {
+	public void immutableAccountThrowsIse() {
+		// given:
+		var original = new MerkleAccount();
+
 		// when:
-		var copy = subject.copy();
+		original.copy();
 
 		// then:
-		verify(records).isImmutable();
-		verify(records).copy();
-		// and:
-		verify(payerRecords).isImmutable();
-		verify(payerRecords).copy();
+		assertThrows(IllegalStateException.class, () -> original.copy());
 	}
 
 	@Test
@@ -237,22 +236,6 @@ public class MerkleAccountTest {
 		// then:
 		verify(records).copy();
 		verify(payerRecords).copy();
-		// and:
-		assertEquals(records, copy.records());
-		assertEquals(payerRecords, copy.payerRecords());
-	}
-
-	@Test
-	public void copyConstructorReusesImmutableFcqs() {
-		given(records.isImmutable()).willReturn(true);
-		given(payerRecords.isImmutable()).willReturn(true);
-
-		// when:
-		var copy = subject.copy();
-
-		// then:
-		verify(records, never()).copy();
-		verify(payerRecords, never()).copy();
 		// and:
 		assertEquals(records, copy.records());
 		assertEquals(payerRecords, copy.payerRecords());

--- a/hedera-node/src/test/java/com/hedera/test/forensics/domain/PojoLedger.java
+++ b/hedera-node/src/test/java/com/hedera/test/forensics/domain/PojoLedger.java
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.hedera.services.state.merkle.MerkleAccount;
 import com.hedera.services.state.merkle.MerkleEntityId;
 import com.swirlds.common.io.SerializableDataInputStream;
+import com.swirlds.common.merkle.io.MerkleDataInputStream;
 import com.swirlds.fcmap.FCMap;
 
 import java.io.File;
@@ -39,12 +40,10 @@ public class PojoLedger {
 	private List<PojoAccount> accounts;
 
 	public static PojoLedger fromDisk(String dumpLoc) throws Exception {
-		try (SerializableDataInputStream fin = new SerializableDataInputStream(Files.newInputStream(Path.of(dumpLoc)))) {
-			FCMap<MerkleEntityId, MerkleAccount> fcm =
-					new FCMap<>(new MerkleEntityId.Provider(), MerkleAccount.LEGACY_PROVIDER);
-			fcm.copyFrom(fin);
-			fcm.copyFromExtra(fin);
-			return from(fcm);
+		try (MerkleDataInputStream in = new MerkleDataInputStream(Files.newInputStream(Path.of(dumpLoc)), false)) {
+			FCMap<MerkleEntityId, MerkleAccount> fcm = in.readMerkleTree(Integer.MAX_VALUE);
+			var pojo = from(fcm);
+			return pojo;
 		}
 	}
 

--- a/test-clients/devops-utils/validation-scenarios/config.yml
+++ b/test-clients/devops-utils/validation-scenarios/config.yml
@@ -76,12 +76,8 @@ networks:
     - {account: 3, ipv4Addr: '127.0.0.1:50211'}
     scenarioPayer: 1001
     scenarios:
-      consensus: {persistent: 1010}
       contract:
-        persistent: {bytecode: 1007, luckyNo: 42, num: 1008, source: Multipurpose.sol}
-      crypto: {receiver: 1003, sender: 1002}
-      file:
-        persistent: {contents: MrBleaney.txt, num: 1005}
+        persistent: {bytecode: 1002, luckyNo: 42, num: 1003, source: Multipurpose.sol}
   staging:
     bootstrap: 2
     defaultNode: 3

--- a/test-clients/devops-utils/validation-scenarios/config.yml
+++ b/test-clients/devops-utils/validation-scenarios/config.yml
@@ -1,6 +1,7 @@
 networks:
   integration:
     bootstrap: 2
+    defaultNode: 3
     ensureScenarioPayerHbars: 25
     nodes:
     - {account: 3, ipv4Addr: 35.196.146.2}
@@ -23,6 +24,7 @@ networks:
         numsToFetch: [121]
   testnet:
     bootstrap: 50
+    defaultNode: 3
     ensureScenarioPayerHbars: 300
     nodes:
     - {account: 3, ipv4Addr: 34.94.254.82}
@@ -43,6 +45,7 @@ networks:
       versions: {hapiProtoSemVer: 0.5.1, servicesSemVer: 0.5.0}
   mainnet:
     bootstrap: 950
+    defaultNode: 3
     ensureScenarioPayerHbars: 100
     nodes:
     - {account: 5, ipv4Addr: 35.192.2.25}
@@ -67,11 +70,21 @@ networks:
         persistent: {contents: MrBleaney.txt, num: 39283}
   localhost:
     bootstrap: 2
+    defaultNode: 3
     ensureScenarioPayerHbars: 100000
     nodes:
     - {account: 3, ipv4Addr: '127.0.0.1:50211'}
+    scenarioPayer: 1001
+    scenarios:
+      consensus: {persistent: 1010}
+      contract:
+        persistent: {bytecode: 1007, luckyNo: 42, num: 1008, source: Multipurpose.sol}
+      crypto: {receiver: 1003, sender: 1002}
+      file:
+        persistent: {contents: MrBleaney.txt, num: 1005}
   staging:
     bootstrap: 2
+    defaultNode: 3
     ensureScenarioPayerHbars: 25
     nodes:
     - {account: 3, ipv4Addr: 35.237.182.66}
@@ -93,6 +106,7 @@ networks:
         numsToFetch: []
   stagingsm:
     bootstrap: 50
+    defaultNode: 3
     ensureScenarioPayerHbars: 300
     nodes:
     - {account: 3, ipv4Addr: 104.196.48.231}
@@ -109,6 +123,7 @@ networks:
         persistent: {contents: MrBleaney.txt, num: 39040}
   staginglg:
     bootstrap: 950
+    defaultNode: 3
     ensureScenarioPayerHbars: 200
     nodes:
     - {account: 3, ipv4Addr: 35.237.182.66}

--- a/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/contract/HapiContractCallLocal.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/contract/HapiContractCallLocal.java
@@ -111,7 +111,9 @@ public class HapiContractCallLocal extends HapiQueryOp<HapiContractCallLocal> {
 	protected void assertExpectationsGiven(HapiApiSpec spec) throws Throwable {
 		if (expectations.isPresent()) {
 			ContractFunctionResult actual = response.getContractCallLocal().getFunctionResult();
-			log.info(Hex.toHexString(actual.getContractCallResult().toByteArray()));
+			if (!loggingOff) {
+				log.info(Hex.toHexString(actual.getContractCallResult().toByteArray()));
+			}
 			ErroringAsserts<ContractFunctionResult> asserts = expectations.get().assertsFor(spec);
 			List<Throwable> errors = asserts.errorsIn(actual);
 			rethrowSummaryError(log, "Bad local call result!", errors);

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/SuiteRunner.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/SuiteRunner.java
@@ -22,7 +22,6 @@ package com.hedera.services.bdd.suites;
 
 import com.hedera.services.bdd.spec.HapiApiSpec;
 import com.hedera.services.bdd.spec.HapiSpecSetup;
-import com.hedera.services.bdd.suites.compose.LocalNetworkCheck;
 import com.hedera.services.bdd.suites.consensus.ChunkingSuite;
 import com.hedera.services.bdd.suites.consensus.ConsensusThrottlesSuite;
 import com.hedera.services.bdd.suites.consensus.SubmitMessageSuite;
@@ -47,6 +46,10 @@ import com.hedera.services.bdd.suites.freeze.UpdateServerFiles;
 import com.hedera.services.bdd.suites.issues.Issue2144Spec;
 import com.hedera.services.bdd.suites.issues.IssueXXXXSpec;
 import com.hedera.services.bdd.suites.meta.VersionInfoSpec;
+import com.hedera.services.bdd.suites.misc.ConsensusQueriesStressTests;
+import com.hedera.services.bdd.suites.misc.ContractQueriesStressTests;
+import com.hedera.services.bdd.suites.misc.CryptoQueriesStressTests;
+import com.hedera.services.bdd.suites.misc.FileQueriesStressTests;
 import com.hedera.services.bdd.suites.misc.ZeroStakeNodeTest;
 import com.hedera.services.bdd.suites.perf.ContractCallLoadTest;
 import com.hedera.services.bdd.suites.perf.CryptoTransferLoadTest;
@@ -150,15 +153,19 @@ public class SuiteRunner {
 		put("HCSTopicFragmentationSuite", aof(new ChunkingSuite()));
 		put("TopicGetInfoSpecs", aof(new TopicGetInfoSuite()));
 		put("ConsensusThrottlesSpecs", aof(new ConsensusThrottlesSuite()));
+		put("ConsensusQueriesStressTests", aof(new ConsensusQueriesStressTests()));
 		/* Functional tests - FILE */
 		put("PermissionSemanticsSpec", aof(new PermissionSemanticsSpec()));
+		put("FileQueriesStressTests", aof(new FileQueriesStressTests()));
 		/* Functional tests - CRYPTO */
 		put("CryptoCreateSuite", aof(new CryptoCreateSuite()));
 		put("CryptoUpdateSuite", aof(new CryptoUpdateSuite()));
+		put("CryptoQueriesStressTests", aof(new CryptoQueriesStressTests()));
 		/* Functional tests - CONTRACTS */
 		put("NewOpInConstructorSpecs", aof(new NewOpInConstructorSuite()));
 		put("DeprecatedContractKeySpecs", aof(new DeprecatedContractKeySuite()));
 		put("MultipleSelfDestructsAreSafe", aof(new IssueXXXXSpec()));
+		put("ContractQueriesStressTests", aof(new ContractQueriesStressTests()));
 		put("ChildStorageSpecs", aof(new ChildStorageSpec()));
 		/* Functional tests - MIXED (record emphasis) */
 		put("ThresholdRecordCreationSpecs", aof(new ThresholdRecordCreationSuite()));

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/compose/PerpetualLocalCalls.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/compose/PerpetualLocalCalls.java
@@ -24,8 +24,8 @@ import com.hedera.services.bdd.spec.HapiApiSpec;
 import com.hedera.services.bdd.spec.HapiSpecOperation;
 import com.hedera.services.bdd.spec.infrastructure.OpProvider;
 import com.hedera.services.bdd.suites.HapiApiSuite;
-import org.apache.log4j.LogManager;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.math.BigInteger;
 import java.util.List;

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/compose/PerpetualLocalCalls.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/compose/PerpetualLocalCalls.java
@@ -1,0 +1,119 @@
+package com.hedera.services.bdd.suites.compose;
+
+/*-
+ * ‌
+ * Hedera Services Test Clients
+ * ​
+ * Copyright (C) 2018 - 2020 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import com.hedera.services.bdd.spec.HapiApiSpec;
+import com.hedera.services.bdd.spec.HapiSpecOperation;
+import com.hedera.services.bdd.spec.infrastructure.OpProvider;
+import com.hedera.services.bdd.suites.HapiApiSuite;
+import org.apache.log4j.LogManager;
+import org.apache.log4j.Logger;
+
+import java.math.BigInteger;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
+
+import static com.hedera.services.bdd.spec.HapiApiSpec.defaultHapiSpec;
+import static com.hedera.services.bdd.spec.assertions.ContractFnResultAsserts.isLiteralResult;
+import static com.hedera.services.bdd.spec.assertions.ContractFnResultAsserts.resultWith;
+import static com.hedera.services.bdd.spec.queries.QueryVerbs.contractCallLocal;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.contractCreate;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoCreate;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoTransfer;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.fileCreate;
+import static com.hedera.services.bdd.spec.transactions.crypto.HapiCryptoTransfer.tinyBarsFromTo;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.runWithProvider;
+import static java.util.concurrent.TimeUnit.MINUTES;
+
+public class PerpetualLocalCalls extends HapiApiSuite {
+	private static final Logger log = LogManager.getLogger(PerpetualLocalCalls.class);
+
+	final String PATH_TO_CHILD_STORAGE_BYTECODE = "src/main/resource/testfiles/ChildStorage.bin";
+
+	private static final String GET_MY_VALUE_ABI =
+			"{\"constant\":true,\"inputs\":[],\"name\":\"getMyValue\"," +
+					"\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"_get\",\"type\":\"uint256\"}]," +
+					"\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"}\n";
+
+	private AtomicLong duration = new AtomicLong(Long.MAX_VALUE);
+	private AtomicReference<TimeUnit> unit = new AtomicReference<>(MINUTES);
+	private AtomicInteger maxOpsPerSec = new AtomicInteger(100);
+	private AtomicInteger totalBeforeFailure = new AtomicInteger(0);
+
+	public static void main(String... args) {
+		new PerpetualLocalCalls().runSuiteSync();
+	}
+
+	@Override
+	protected List<HapiApiSpec> getSpecsInSuite() {
+		return List.of(
+				new HapiApiSpec[] {
+						localCallsForever(),
+				}
+		);
+	}
+
+	private HapiApiSpec localCallsForever() {
+		return defaultHapiSpec("LocalCallsForever").
+				given().when().then(
+						runWithProvider(localCallsFactory())
+								.lasting(duration::get, unit::get)
+								.maxOpsPerSec(maxOpsPerSec::get)
+				);
+	}
+
+	private Function<HapiApiSpec, OpProvider> localCallsFactory() {
+		return spec -> new OpProvider() {
+			@Override
+			public List<HapiSpecOperation> suggestedInitializers() {
+				return List.of(
+						fileCreate("bytecode").path(PATH_TO_CHILD_STORAGE_BYTECODE),
+						contractCreate("childStorage").bytecode("bytecode")
+				);
+			}
+
+			@Override
+			public Optional<HapiSpecOperation> get() {
+				var op = contractCallLocal("childStorage", GET_MY_VALUE_ABI)
+								.noLogging()
+								.has(resultWith().resultThruAbi(
+										GET_MY_VALUE_ABI,
+										isLiteralResult(new Object[] { BigInteger.valueOf(73) })));
+				var soFar = totalBeforeFailure.getAndIncrement();
+				if (soFar % 1000 == 0) {
+					log.info("--- " + soFar);
+				}
+				return Optional.of(op);
+			}
+		};
+	}
+
+	@Override
+	protected Logger getResultsLogger() {
+		return log;
+	}
+}

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/misc/ConsensusQueriesStressTests.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/misc/ConsensusQueriesStressTests.java
@@ -25,8 +25,8 @@ import com.hedera.services.bdd.spec.HapiPropertySource;
 import com.hedera.services.bdd.spec.HapiSpecOperation;
 import com.hedera.services.bdd.spec.infrastructure.OpProvider;
 import com.hedera.services.bdd.suites.HapiApiSuite;
-import org.apache.log4j.LogManager;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.util.List;
 import java.util.Optional;

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/misc/ConsensusQueriesStressTests.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/misc/ConsensusQueriesStressTests.java
@@ -1,0 +1,119 @@
+package com.hedera.services.bdd.suites.misc;
+
+/*-
+ * ‌
+ * Hedera Services Test Clients
+ * ​
+ * Copyright (C) 2018 - 2020 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import com.hedera.services.bdd.spec.HapiApiSpec;
+import com.hedera.services.bdd.spec.HapiPropertySource;
+import com.hedera.services.bdd.spec.HapiSpecOperation;
+import com.hedera.services.bdd.spec.infrastructure.OpProvider;
+import com.hedera.services.bdd.suites.HapiApiSuite;
+import org.apache.log4j.LogManager;
+import org.apache.log4j.Logger;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+import static com.hedera.services.bdd.spec.HapiApiSpec.defaultHapiSpec;
+import static com.hedera.services.bdd.spec.queries.QueryVerbs.getTopicInfo;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.createTopic;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.runWithProvider;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.withOpContext;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+public class ConsensusQueriesStressTests extends HapiApiSuite {
+	private static final Logger log = LogManager.getLogger(ConsensusQueriesStressTests.class);
+
+	private AtomicLong duration = new AtomicLong(30);
+	private AtomicReference<TimeUnit> unit = new AtomicReference<>(SECONDS);
+	private AtomicInteger maxOpsPerSec = new AtomicInteger(100);
+
+	public static void main(String... args) {
+		new ConsensusQueriesStressTests().runSuiteSync();
+	}
+
+	@Override
+	protected List<HapiApiSpec> getSpecsInSuite() {
+		return List.of(
+				new HapiApiSpec[] {
+						getTopicInfoStress(),
+				}
+		);
+	}
+
+	private HapiApiSpec getTopicInfoStress() {
+		return defaultHapiSpec("GetTopicInfoStress")
+				.given().when().then(
+						withOpContext((spec, opLog) -> configureFromCi(spec)),
+						runWithProvider(getTopicInfoFactory())
+								.lasting(duration::get, unit::get)
+								.maxOpsPerSec(maxOpsPerSec::get)
+				);
+	}
+
+	private Function<HapiApiSpec, OpProvider> getTopicInfoFactory() {
+		var memo = "General interest only.";
+
+		return spec -> new OpProvider() {
+			@Override
+			public List<HapiSpecOperation> suggestedInitializers() {
+				return List.of(
+						createTopic("about").topicMemo(memo)
+				);
+			}
+
+			@Override
+			public Optional<HapiSpecOperation> get() {
+				return Optional.of(getTopicInfo("about")
+						.noLogging()
+						.hasMemo(memo));
+			}
+		};
+	}
+
+	private void configureFromCi(HapiApiSpec spec) {
+		HapiPropertySource ciProps = spec.setup().ciPropertiesMap();
+		configure("duration", duration::set, ciProps, ciProps::getLong);
+		configure("unit", unit::set, ciProps, ciProps::getTimeUnit);
+		configure("maxOpsPerSec", maxOpsPerSec::set, ciProps, ciProps::getInteger);
+	}
+
+	private <T> void configure(
+			String name,
+			Consumer<T> configurer,
+			HapiPropertySource ciProps,
+			Function<String, T> getter
+	) {
+		if (ciProps.has(name)) {
+			configurer.accept(getter.apply(name));
+		}
+	}
+
+	@Override
+	protected Logger getResultsLogger() {
+		return log;
+	}
+}

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/misc/ContractQueriesStressTests.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/misc/ContractQueriesStressTests.java
@@ -1,0 +1,247 @@
+package com.hedera.services.bdd.suites.misc;
+
+/*-
+ * ‌
+ * Hedera Services Test Clients
+ * ​
+ * Copyright (C) 2018 - 2020 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import com.hedera.services.bdd.spec.HapiApiSpec;
+import com.hedera.services.bdd.spec.HapiPropertySource;
+import com.hedera.services.bdd.spec.HapiSpecOperation;
+import com.hedera.services.bdd.spec.infrastructure.OpProvider;
+import com.hedera.services.bdd.suites.HapiApiSuite;
+import org.apache.log4j.LogManager;
+import org.apache.log4j.Logger;
+
+import java.math.BigInteger;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+import static com.hedera.services.bdd.spec.HapiApiSpec.defaultHapiSpec;
+import static com.hedera.services.bdd.spec.assertions.AssertUtils.inOrder;
+import static com.hedera.services.bdd.spec.assertions.ContractFnResultAsserts.isLiteralResult;
+import static com.hedera.services.bdd.spec.assertions.ContractFnResultAsserts.resultWith;
+import static com.hedera.services.bdd.spec.assertions.TransactionRecordAsserts.recordWith;
+import static com.hedera.services.bdd.spec.queries.QueryVerbs.contractCallLocal;
+import static com.hedera.services.bdd.spec.queries.QueryVerbs.getAccountRecords;
+import static com.hedera.services.bdd.spec.queries.QueryVerbs.getContractBytecode;
+import static com.hedera.services.bdd.spec.queries.QueryVerbs.getContractInfo;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.contractCall;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.contractCreate;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.fileCreate;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.runWithProvider;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.withOpContext;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+public class ContractQueriesStressTests extends HapiApiSuite {
+	private static final Logger log = LogManager.getLogger(ContractQueriesStressTests.class);
+
+	final String PATH_TO_CHILD_STORAGE_BYTECODE = "src/main/resource/testfiles/ChildStorage.bin";
+
+	private static final String GET_MY_VALUE_ABI =
+			"{\"constant\":true," +
+					"\"inputs\":[],\"name\":\"getMyValue\"," +
+					"\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"_get\",\"type\":\"uint256\"}]," +
+					"\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"}\n";
+	private static final String SET_ZERO_READ_ONE_ABI =
+			"{\"constant\":false," +
+					"\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"_value\",\"type\":\"uint256\"}]," +
+					"\"name\":\"setZeroReadOne\"," +
+					"\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"_getOne\",\"type\":\"uint256\"}]," +
+					"\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"function\"}\n";
+	private static final String GROW_CHILD_ABI =
+			"{\"constant\":false," +
+					"\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"_childId\",\"type\":\"uint256\"}," +
+					"{\"internalType\":\"uint256\",\"name\":\"_howManyKB\",\"type\":\"uint256\"}," +
+					"{\"internalType\":\"uint256\",\"name\":\"_value\",\"type\":\"uint256\"}]," +
+					"\"name\":\"growChild\"," +
+					"\"outputs\":[]," +
+					"\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"function\"}\n";
+
+	private AtomicLong duration = new AtomicLong(30);
+	private AtomicReference<TimeUnit> unit = new AtomicReference<>(SECONDS);
+	private AtomicInteger maxOpsPerSec = new AtomicInteger(100);
+
+	public static void main(String... args) {
+		new ContractQueriesStressTests().runSuiteSync();
+	}
+
+	@Override
+	protected List<HapiApiSpec> getSpecsInSuite() {
+		return List.of(
+				new HapiApiSpec[] {
+						contractCallLocalStress(),
+						getContractRecordsStress(),
+						getContractBytecodeStress(),
+						getContractInfoStress(),
+				}
+		);
+	}
+
+	private HapiApiSpec getContractInfoStress() {
+		return defaultHapiSpec("GetContractInfoStress")
+				.given().when().then(
+						withOpContext((spec, opLog) -> configureFromCi(spec)),
+						runWithProvider(getContractInfoFactory())
+								.lasting(duration::get, unit::get)
+								.maxOpsPerSec(maxOpsPerSec::get)
+				);
+	}
+
+	private HapiApiSpec getContractBytecodeStress() {
+		return defaultHapiSpec("GetAccountRecordsStress")
+				.given().when().then(
+						withOpContext((spec, opLog) -> configureFromCi(spec)),
+						runWithProvider(getContractBytecodeFactory())
+								.lasting(duration::get, unit::get)
+								.maxOpsPerSec(maxOpsPerSec::get)
+				);
+	}
+
+	private HapiApiSpec contractCallLocalStress() {
+		return defaultHapiSpec("ContractCallLocalStress")
+				.given().when().then(
+						withOpContext((spec, opLog) -> configureFromCi(spec)),
+						runWithProvider(contractCallLocalFactory())
+								.lasting(duration::get, unit::get)
+								.maxOpsPerSec(maxOpsPerSec::get)
+				);
+	}
+
+	private HapiApiSpec getContractRecordsStress() {
+		return defaultHapiSpec("GetContractRecordsStress")
+				.given().when().then(
+						withOpContext((spec, opLog) -> configureFromCi(spec)),
+						runWithProvider(getContractRecordsFactory())
+								.lasting(duration::get, unit::get)
+								.maxOpsPerSec(maxOpsPerSec::get)
+				);
+	}
+
+	private Function<HapiApiSpec, OpProvider> getContractRecordsFactory() {
+		return spec -> new OpProvider() {
+			@Override
+			public List<HapiSpecOperation> suggestedInitializers() {
+				return List.of(
+						fileCreate("bytecode").path(PATH_TO_CHILD_STORAGE_BYTECODE),
+						contractCreate("childStorage").bytecode("bytecode"),
+						contractCall( "childStorage", GROW_CHILD_ABI, 0, 1, 1),
+						contractCall( "childStorage", GROW_CHILD_ABI, 1, 1, 3),
+						contractCall( "childStorage", SET_ZERO_READ_ONE_ABI, 23).via("first"),
+						contractCall( "childStorage", SET_ZERO_READ_ONE_ABI, 23).via("second"),
+						contractCall( "childStorage", SET_ZERO_READ_ONE_ABI, 23).via("third")
+				);
+			}
+
+			@Override
+			public Optional<HapiSpecOperation> get() {
+				return Optional.of(getAccountRecords("somebody")
+						.has(inOrder(
+								recordWith().txnId("first"),
+								recordWith().txnId("second"),
+								recordWith().txnId("third")))
+						.noLogging());
+			}
+		};
+	}
+
+	private Function<HapiApiSpec, OpProvider> getContractInfoFactory() {
+		return spec -> new OpProvider() {
+			@Override
+			public List<HapiSpecOperation> suggestedInitializers() {
+				return List.of(
+						fileCreate("bytecode").path(PATH_TO_CHILD_STORAGE_BYTECODE),
+						contractCreate("childStorage").bytecode("bytecode")
+				);
+			}
+
+			@Override
+			public Optional<HapiSpecOperation> get() {
+				return Optional.of(getContractInfo("childStorage").noLogging());
+			}
+		};
+	}
+
+	private Function<HapiApiSpec, OpProvider> getContractBytecodeFactory() {
+		return spec -> new OpProvider() {
+			@Override
+			public List<HapiSpecOperation> suggestedInitializers() {
+				return List.of(
+						fileCreate("bytecode").path(PATH_TO_CHILD_STORAGE_BYTECODE),
+						contractCreate("childStorage").bytecode("bytecode")
+				);
+			}
+
+			@Override
+			public Optional<HapiSpecOperation> get() {
+				return Optional.of(getContractBytecode("childStorage").noLogging());
+			}
+		};
+	}
+
+	private Function<HapiApiSpec, OpProvider> contractCallLocalFactory() {
+		return spec -> new OpProvider() {
+			@Override
+			public List<HapiSpecOperation> suggestedInitializers() {
+				return List.of(
+						fileCreate("bytecode").path(PATH_TO_CHILD_STORAGE_BYTECODE),
+						contractCreate("childStorage").bytecode("bytecode")
+				);
+			}
+
+			@Override
+			public Optional<HapiSpecOperation> get() {
+				var op = contractCallLocal("childStorage", GET_MY_VALUE_ABI)
+						.noLogging()
+						.has(resultWith().resultThruAbi(
+								GET_MY_VALUE_ABI,
+								isLiteralResult(new Object[] { BigInteger.valueOf(73) })));
+				return Optional.of(op);
+			}
+		};
+	}
+
+	private void configureFromCi(HapiApiSpec spec) {
+		HapiPropertySource ciProps = spec.setup().ciPropertiesMap();
+		configure("duration", duration::set, ciProps, ciProps::getLong);
+		configure("unit", unit::set, ciProps, ciProps::getTimeUnit);
+		configure("maxOpsPerSec", maxOpsPerSec::set, ciProps, ciProps::getInteger);
+	}
+
+	private <T> void configure(
+			String name,
+			Consumer<T> configurer,
+			HapiPropertySource ciProps,
+			Function<String, T> getter
+	) {
+		if (ciProps.has(name)) {
+			configurer.accept(getter.apply(name));
+		}
+	}
+
+	@Override
+	protected Logger getResultsLogger() {
+		return log;
+	}
+}

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/misc/ContractQueriesStressTests.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/misc/ContractQueriesStressTests.java
@@ -25,8 +25,8 @@ import com.hedera.services.bdd.spec.HapiPropertySource;
 import com.hedera.services.bdd.spec.HapiSpecOperation;
 import com.hedera.services.bdd.spec.infrastructure.OpProvider;
 import com.hedera.services.bdd.suites.HapiApiSuite;
-import org.apache.log4j.LogManager;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.math.BigInteger;
 import java.util.List;

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/misc/CryptoQueriesStressTests.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/misc/CryptoQueriesStressTests.java
@@ -1,0 +1,183 @@
+package com.hedera.services.bdd.suites.misc;
+
+/*-
+ * ‌
+ * Hedera Services Test Clients
+ * ​
+ * Copyright (C) 2018 - 2020 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import com.hedera.services.bdd.spec.HapiApiSpec;
+import com.hedera.services.bdd.spec.HapiPropertySource;
+import com.hedera.services.bdd.spec.HapiSpecOperation;
+import com.hedera.services.bdd.spec.infrastructure.OpProvider;
+import com.hedera.services.bdd.suites.HapiApiSuite;
+import org.apache.log4j.LogManager;
+import org.apache.log4j.Logger;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+import static com.hedera.services.bdd.spec.HapiApiSpec.defaultHapiSpec;
+import static com.hedera.services.bdd.spec.assertions.AssertUtils.inOrder;
+import static com.hedera.services.bdd.spec.assertions.TransactionRecordAsserts.recordWith;
+import static com.hedera.services.bdd.spec.queries.QueryVerbs.getAccountBalance;
+import static com.hedera.services.bdd.spec.queries.QueryVerbs.getAccountInfo;
+import static com.hedera.services.bdd.spec.queries.QueryVerbs.getAccountRecords;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoCreate;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoTransfer;
+import static com.hedera.services.bdd.spec.transactions.crypto.HapiCryptoTransfer.tinyBarsFromTo;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.runWithProvider;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.withOpContext;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+public class CryptoQueriesStressTests extends HapiApiSuite {
+	private static final Logger log = LogManager.getLogger(CryptoQueriesStressTests.class);
+
+	private AtomicLong duration = new AtomicLong(30);
+	private AtomicReference<TimeUnit> unit = new AtomicReference<>(SECONDS);
+	private AtomicInteger maxOpsPerSec = new AtomicInteger(100);
+
+	public static void main(String... args) {
+		new CryptoQueriesStressTests().runSuiteSync();
+	}
+
+	@Override
+	protected List<HapiApiSpec> getSpecsInSuite() {
+		return List.of(
+				new HapiApiSpec[] {
+						getAccountInfoStress(),
+						getAccountRecordsStress(),
+						getAccountBalanceStress(),
+				}
+		);
+	}
+
+	private HapiApiSpec getAccountBalanceStress() {
+		return defaultHapiSpec("getAccountBalanceStress")
+				.given().when().then(
+						withOpContext((spec, opLog) -> configureFromCi(spec)),
+						runWithProvider(getAccountBalanceFactory())
+								.lasting(duration::get, unit::get)
+								.maxOpsPerSec(maxOpsPerSec::get)
+				);
+	}
+
+	private HapiApiSpec getAccountInfoStress() {
+		return defaultHapiSpec("getAccountInfoStress")
+				.given().when().then(
+						withOpContext((spec, opLog) -> configureFromCi(spec)),
+						runWithProvider(getAccountInfoFactory())
+								.lasting(duration::get, unit::get)
+								.maxOpsPerSec(maxOpsPerSec::get)
+				);
+	}
+
+	private HapiApiSpec getAccountRecordsStress() {
+		return defaultHapiSpec("getAccountRecordsStress")
+				.given().when().then(
+						withOpContext((spec, opLog) -> configureFromCi(spec)),
+						runWithProvider(getAccountRecordsFactory())
+								.lasting(duration::get, unit::get)
+								.maxOpsPerSec(maxOpsPerSec::get)
+				);
+	}
+
+	private Function<HapiApiSpec, OpProvider> getAccountRecordsFactory() {
+		return spec -> new OpProvider() {
+			@Override
+			public List<HapiSpecOperation> suggestedInitializers() {
+				return List.of(
+						cryptoCreate("somebody").sendThreshold(1L),
+						cryptoTransfer(tinyBarsFromTo("somebody", FUNDING, 2L)).via("first"),
+						cryptoTransfer(tinyBarsFromTo("somebody", FUNDING, 3L)).via("second"),
+						cryptoTransfer(tinyBarsFromTo("somebody", FUNDING, 4L)).via("third")
+				);
+			}
+
+			@Override
+			public Optional<HapiSpecOperation> get() {
+				return Optional.of(getAccountRecords("somebody")
+						.has(inOrder(
+								recordWith().txnId("first"),
+								recordWith().txnId("second"),
+								recordWith().txnId("third")))
+						.noLogging());
+			}
+		};
+	}
+
+	private Function<HapiApiSpec, OpProvider> getAccountBalanceFactory() {
+		return spec -> new OpProvider() {
+			@Override
+			public List<HapiSpecOperation> suggestedInitializers() {
+				return List.of(
+						cryptoCreate("somebody")
+				);
+			}
+
+			@Override
+			public Optional<HapiSpecOperation> get() {
+				return Optional.of(getAccountBalance("somebody").noLogging());
+			}
+		};
+	}
+
+	private Function<HapiApiSpec, OpProvider> getAccountInfoFactory() {
+		return spec -> new OpProvider() {
+			@Override
+			public List<HapiSpecOperation> suggestedInitializers() {
+				return List.of(
+						cryptoCreate("somebody")
+				);
+			}
+
+			@Override
+			public Optional<HapiSpecOperation> get() {
+				return Optional.of(getAccountInfo("somebody").noLogging());
+			}
+		};
+	}
+
+	private void configureFromCi(HapiApiSpec spec) {
+		HapiPropertySource ciProps = spec.setup().ciPropertiesMap();
+		configure("duration", duration::set, ciProps, ciProps::getLong);
+		configure("unit", unit::set, ciProps, ciProps::getTimeUnit);
+		configure("maxOpsPerSec", maxOpsPerSec::set, ciProps, ciProps::getInteger);
+	}
+
+	private <T> void configure(
+			String name,
+			Consumer<T> configurer,
+			HapiPropertySource ciProps,
+			Function<String, T> getter
+	) {
+		if (ciProps.has(name)) {
+			configurer.accept(getter.apply(name));
+		}
+	}
+
+	@Override
+	protected Logger getResultsLogger() {
+		return log;
+	}
+}

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/misc/CryptoQueriesStressTests.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/misc/CryptoQueriesStressTests.java
@@ -25,8 +25,8 @@ import com.hedera.services.bdd.spec.HapiPropertySource;
 import com.hedera.services.bdd.spec.HapiSpecOperation;
 import com.hedera.services.bdd.spec.infrastructure.OpProvider;
 import com.hedera.services.bdd.suites.HapiApiSuite;
-import org.apache.log4j.LogManager;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.util.List;
 import java.util.Optional;

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/misc/FileQueriesStressTests.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/misc/FileQueriesStressTests.java
@@ -25,8 +25,8 @@ import com.hedera.services.bdd.spec.HapiPropertySource;
 import com.hedera.services.bdd.spec.HapiSpecOperation;
 import com.hedera.services.bdd.spec.infrastructure.OpProvider;
 import com.hedera.services.bdd.suites.HapiApiSuite;
-import org.apache.log4j.LogManager;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.util.List;
 import java.util.Optional;

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/misc/FileQueriesStressTests.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/misc/FileQueriesStressTests.java
@@ -1,0 +1,147 @@
+package com.hedera.services.bdd.suites.misc;
+
+/*-
+ * ‌
+ * Hedera Services Test Clients
+ * ​
+ * Copyright (C) 2018 - 2020 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import com.hedera.services.bdd.spec.HapiApiSpec;
+import com.hedera.services.bdd.spec.HapiPropertySource;
+import com.hedera.services.bdd.spec.HapiSpecOperation;
+import com.hedera.services.bdd.spec.infrastructure.OpProvider;
+import com.hedera.services.bdd.suites.HapiApiSuite;
+import org.apache.log4j.LogManager;
+import org.apache.log4j.Logger;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+import static com.hedera.services.bdd.spec.HapiApiSpec.defaultHapiSpec;
+import static com.hedera.services.bdd.spec.queries.QueryVerbs.getFileContents;
+import static com.hedera.services.bdd.spec.queries.QueryVerbs.getFileInfo;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.fileCreate;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.runWithProvider;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.withOpContext;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+public class FileQueriesStressTests extends HapiApiSuite {
+	private static final Logger log = LogManager.getLogger(FileQueriesStressTests.class);
+
+	private AtomicLong duration = new AtomicLong(30);
+	private AtomicReference<TimeUnit> unit = new AtomicReference<>(SECONDS);
+	private AtomicInteger maxOpsPerSec = new AtomicInteger(100);
+
+	public static void main(String... args) {
+		new FileQueriesStressTests().runSuiteSync();
+	}
+
+	@Override
+	protected List<HapiApiSpec> getSpecsInSuite() {
+		return List.of(
+				new HapiApiSpec[] {
+						getFileInfoStress(),
+						getFileContentsStress(),
+				}
+		);
+	}
+
+	private HapiApiSpec getFileContentsStress() {
+		return defaultHapiSpec("getFileContentsStress")
+				.given().when().then(
+						withOpContext((spec, opLog) -> configureFromCi(spec)),
+						runWithProvider(getFileContentsFactory())
+								.lasting(duration::get, unit::get)
+								.maxOpsPerSec(maxOpsPerSec::get)
+				);
+	}
+
+	private HapiApiSpec getFileInfoStress() {
+		return defaultHapiSpec("getFileInfoStress")
+				.given().when().then(
+						withOpContext((spec, opLog) -> configureFromCi(spec)),
+						runWithProvider(getFileInfoFactory())
+								.lasting(duration::get, unit::get)
+								.maxOpsPerSec(maxOpsPerSec::get)
+				);
+	}
+
+	private Function<HapiApiSpec, OpProvider> getFileContentsFactory() {
+		byte[] contents = "You won't believe this!".getBytes();
+
+		return spec -> new OpProvider() {
+			@Override
+			public List<HapiSpecOperation> suggestedInitializers() {
+				return List.of(
+						fileCreate("something").contents(contents)
+				);
+			}
+
+			@Override
+			public Optional<HapiSpecOperation> get() {
+				return Optional.of(getFileContents("something")
+						.hasContents(ignore -> contents)
+						.noLogging());
+			}
+		};
+	}
+
+	private Function<HapiApiSpec, OpProvider> getFileInfoFactory() {
+		return spec -> new OpProvider() {
+			@Override
+			public List<HapiSpecOperation> suggestedInitializers() {
+				return List.of(
+						fileCreate("something").contents("You won't believe this!")
+				);
+			}
+
+			@Override
+			public Optional<HapiSpecOperation> get() {
+				return Optional.of(getFileInfo("something").noLogging());
+			}
+		};
+	}
+
+	private void configureFromCi(HapiApiSpec spec) {
+		HapiPropertySource ciProps = spec.setup().ciPropertiesMap();
+		configure("duration", duration::set, ciProps, ciProps::getLong);
+		configure("unit", unit::set, ciProps, ciProps::getTimeUnit);
+		configure("maxOpsPerSec", maxOpsPerSec::set, ciProps, ciProps::getInteger);
+	}
+
+	private <T> void configure(
+			String name,
+			Consumer<T> configurer,
+			HapiPropertySource ciProps,
+			Function<String, T> getter
+	) {
+		if (ciProps.has(name)) {
+			configurer.accept(getter.apply(name));
+		}
+	}
+
+	@Override
+	protected Logger getResultsLogger() {
+		return log;
+	}
+}

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/misc/PerpetualTransfers.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/misc/PerpetualTransfers.java
@@ -1,0 +1,104 @@
+package com.hedera.services.bdd.suites.misc;
+
+/*-
+ * ‌
+ * Hedera Services Test Clients
+ * ​
+ * Copyright (C) 2018 - 2020 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import com.hedera.services.bdd.spec.HapiApiSpec;
+import com.hedera.services.bdd.spec.HapiSpecOperation;
+import com.hedera.services.bdd.spec.infrastructure.OpProvider;
+import com.hedera.services.bdd.suites.HapiApiSuite;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
+
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoCreate;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoTransfer;
+import static com.hedera.services.bdd.spec.transactions.crypto.HapiCryptoTransfer.tinyBarsFromTo;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.runWithProvider;
+import static java.util.concurrent.TimeUnit.MINUTES;
+
+public class PerpetualTransfers extends HapiApiSuite {
+	private static final Logger log = LogManager.getLogger(PerpetualTransfers.class);
+
+	private AtomicLong duration = new AtomicLong(Long.MAX_VALUE);
+	private AtomicReference<TimeUnit> unit = new AtomicReference<>(MINUTES);
+	private AtomicInteger maxOpsPerSec = new AtomicInteger(10);
+
+	public static void main(String... args) {
+		new PerpetualTransfers().runSuiteSync();
+	}
+
+	@Override
+	protected List<HapiApiSpec> getSpecsInSuite() {
+		return List.of(
+				new HapiApiSpec[] {
+						canTransferBackAndForthForever(),
+				}
+		);
+	}
+
+	private HapiApiSpec canTransferBackAndForthForever() {
+		return HapiApiSpec.defaultHapiSpec("CanTransferBackAndForthForever")
+				.given().when().then(
+						runWithProvider(transfersFactory())
+								.lasting(duration::get, unit::get)
+								.maxOpsPerSec(maxOpsPerSec::get)
+				);
+	}
+
+	private Function<HapiApiSpec, OpProvider> transfersFactory() {
+		AtomicBoolean fromAtoB = new AtomicBoolean(true);
+		return spec -> new OpProvider() {
+			@Override
+			public List<HapiSpecOperation> suggestedInitializers() {
+				return List.of(
+						cryptoCreate("A"),
+						cryptoCreate("B")
+				);
+			}
+
+			@Override
+			public Optional<HapiSpecOperation> get() {
+				var from = fromAtoB.get() ? "A" : "B";
+				var to = fromAtoB.get() ? "B" : "A";
+				fromAtoB.set(!fromAtoB.get());
+
+				var op = cryptoTransfer(tinyBarsFromTo(from, to, 1)).deferStatusResolution();
+
+				return Optional.of(op);
+			}
+		};
+	}
+
+	@Override
+	protected Logger getResultsLogger() {
+		return log;
+	}
+
+
+}


### PR DESCRIPTION
**Related issue(s)**:
- Closes #471 

**Summary of the change**:
Remove all impure usage of the mutable `ServicesRepositoryRoot` in smart contract queries.
- Delete the [obsolete](https://github.com/hashgraph/hedera-services/compare/release-v0.7.0...0471-M-FixScCallLocalRace?expand=1#diff-98e68de2c727cd6819590f97951000f0L469) [calls](https://github.com/hashgraph/hedera-services/compare/release-v0.7.0...0471-M-FixScCallLocalRace?expand=1#diff-98e68de2c727cd6819590f97951000f0L578) to `ServicesRepositoryRoot#getNonce` which always return `BigInteger.ZERO`.
- Refactor the `ContractGetByteCode` query as an [`AnswerService` implementation](https://github.com/hashgraph/hedera-services/compare/release-v0.7.0...0471-M-FixScCallLocalRace?expand=1#diff-489b465f5370d6bfb85a39f846546d78R481).

Other improvements:
- [Fail fast](https://github.com/hashgraph/hedera-services/compare/release-v0.7.0...0471-M-FixScCallLocalRace?expand=1#diff-f7f12fa164aa28b945b16a3faeaa5854R106) and capture the error in logs if `MerkleAccount#copy` is called on an immutable instance.
- Refactor the transactional processing + error handling in legacy `AwareProcessLogic` into a dedicated [`ServicesTxnManager`](https://github.com/hashgraph/hedera-services/compare/release-v0.7.0...0471-M-FixScCallLocalRace?expand=1#diff-10dffbc67fab6906b17a67c3a0a87571R48), ensuring exceptions are not propagated to the Platform.
- Add [query stress tests](v0.7.0-rc1) to the end of regression runs.
- Various improvements to forensics "tests" for analysis of e.g. record [streams](https://github.com/hashgraph/hedera-services/pull/474/files#diff-8ace1feecdad8f1699f8da2a74b25fc2).