### PR TITLE
Disable CircleCi nightly regression for master as per discussed.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1072,6 +1072,10 @@ workflows:
             - attach_workspace:
                 at: /
 
+# Now that JRS nightly regression covers all this regression workflow's coverage and is stable.
+# We'll disable the CircleCi side regression workflow. No need to keep both
+# We'll keep this workflow for now in case we need to run some tests and need this workflow.
+# Later we may clean up these obsolete workflows completely.
   nightly-regression:
     triggers:
       - schedule:
@@ -1079,7 +1083,7 @@ workflows:
             filters:
               branches:
                 only:
-                  - disable-master
+                  - X-disable-master
     jobs:
       - fast-build-artifact:
           context: Slack

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1079,7 +1079,7 @@ workflows:
             filters:
               branches:
                 only:
-                  - master
+                  - disable-master
     jobs:
       - fast-build-artifact:
           context: Slack
@@ -2548,12 +2548,12 @@ jobs:
           dsl-args: "ControlAccountsExemptForUpdates"
       - run-scenario-test:
           fqcn: com.hedera.services.legacy.CI.MultipleCryptoTransfers
-      - run-scenario-test:
-          fqcn: com.hedera.services.legacy.CI.TxRecordTest
-      - run-scenario-test:
-          fqcn: com.hedera.services.legacy.CI.NegativeAccountCreateTest
-      - run-scenario-test:
-          fqcn: com.hedera.services.legacy.CI.NegativeCryptoQueryTest
+#      - run-scenario-test:
+#          fqcn: com.hedera.services.legacy.CI.TxRecordTest
+#      - run-scenario-test:
+#          fqcn: com.hedera.services.legacy.CI.NegativeAccountCreateTest
+#      - run-scenario-test:
+#          fqcn: com.hedera.services.legacy.CI.NegativeCryptoQueryTest
       - run-eet-suites:
           dsl-args: "CryptoUpdateSuite -TLS=on"
       - run-eet-suites:


### PR DESCRIPTION
**Related issue(s)**:
Closes #488 

**Summary of the change**:
1. Temporarily disable several legacy tests to avoid possible threshold caused failure;
2. Also disable nightly regression for master branch per discussion with Nosh and Neeha;

**External impacts**:
None.

**Applicable documentation**
- [ ] Javadoc
- [ ] HAPI protobuf comments
- [ ] README
