### PR TITLE
Modifying the cron times for JRS regression tests.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -917,7 +917,7 @@ workflows:
   nightly-basic-suiterunner-regression:
     triggers:
       - schedule:
-          cron: "0 23,8 * * *"
+          cron: "15 17,4 * * *"
           filters:
             branches:
               only:
@@ -937,7 +937,7 @@ workflows:
   nightly-performance-regression:
     triggers:
       - schedule:
-          cron: "0 23,8 * * *"
+          cron: "30 17,4 * * *"
           filters:
             branches:
               only:
@@ -957,7 +957,7 @@ workflows:
   nightly-network-error-regression:
     triggers:
       - schedule:
-          cron: "0 23,8 * * *"
+          cron: "45 17,4 * * *"
           filters:
             branches:
               only:
@@ -977,7 +977,7 @@ workflows:
   nightly-zero-stake-regression:
     triggers:
       - schedule:
-          cron: "0 23,8 * * *"
+          cron: "0 18,5 * * *"
           filters:
             branches:
               only:
@@ -998,7 +998,7 @@ workflows:
   nightly-public-testnet-migration-regression:
     triggers:
           - schedule:
-              cron: "0 23,8 * * *"
+              cron: "15 18,5 * * *"
               filters:
                 branches:
                   only:
@@ -1041,7 +1041,7 @@ workflows:
   nightly-software-update-regression:
     triggers:
       - schedule:
-          cron: "0 23,8 * * *"
+          cron: "30 18,5 * * *"
           filters:
             branches:
               only:
@@ -1932,7 +1932,7 @@ jobs:
             cd /; GIT_SSH_COMMAND="ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no" \
               git clone  --recurse-submodule ssh://git@github.com/swirlds/swirlds-platform.git
             cd /swirlds-platform; git submodule update --init --recursive --checkout
-            cd /swirlds-platform/regression;   git checkout 00438-D-migration-test-for-mainnet;
+            cd /swirlds-platform/regression;   git checkout 334-D-Add-services-config;
             cd /swirlds-platform; mvn --no-transfer-progress clean install -DskipTests;
 
       - run:


### PR DESCRIPTION
**Related issue(s)**:
Closes #515 

**Summary of the change**:

1. Changed the start times for JRS regression tests;
2. Also restored the swirlds-platform-regression branch to the right one;


**External impacts**:
None.

**Applicable documentation**
- [ ] Javadoc
- [ ] HAPI protobuf comments
- [ ] README
