### PR TITLE
Fix(token-divisibility): check if 10 ^ divisibility > long max value

### DIFF
--- a/hedera-node/src/main/java/com/hedera/services/tokens/HederaTokenStore.java
+++ b/hedera-node/src/main/java/com/hedera/services/tokens/HederaTokenStore.java
@@ -502,8 +502,13 @@ public class HederaTokenStore implements TokenStore {
 		}
 
 		try {
-			var tinyTokenFloat = BigInteger.valueOf(10)
-					.pow(divisibility)
+			var divisibilityFloat = BigInteger.valueOf(10)
+					.pow(divisibility);
+			if (divisibilityFloat.longValue() < 0) {
+				return INVALID_TOKEN_DIVISIBILITY;
+			}
+
+			var tinyTokenFloat = divisibilityFloat
 					.multiply(BigInteger.valueOf(tokenFloat));
 			return tinyTokenFloat.longValueExact() >= 0 ? OK : INVALID_TOKEN_DIVISIBILITY;
 		} catch (ArithmeticException ignore) {

--- a/hedera-node/src/test/java/com/hedera/services/tokens/HederaTokenStoreTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/tokens/HederaTokenStoreTest.java
@@ -1344,6 +1344,36 @@ class HederaTokenStoreTest {
 	}
 
 	@Test
+	public void allowsToCreateTokenWithTheBiggestAmountInLong() {
+		// given:
+		var req = fullyValidAttempt()
+				.setFloat(9)
+				.setDivisibility(18)
+				.build();
+
+		// when:
+		var result = subject.createProvisionally(req, sponsor);
+
+		// then:
+		assertEquals(ResponseCodeEnum.OK, result.getStatus());
+	}
+
+	@Test
+	public void rejectsToCreateTokenWithAmountBiggerThanLong() {
+		// given:
+		var req = fullyValidAttempt()
+				.setFloat(10)
+				.setDivisibility(18)
+				.build();
+
+		// when:
+		var result = subject.createProvisionally(req, sponsor);
+
+		// then:
+		assertEquals(ResponseCodeEnum.INVALID_TOKEN_DIVISIBILITY, result.getStatus());
+	}
+
+	@Test
 	public void rejectsJustOverflowingFloat() {
 		int divisibility = 1;
 		long initialFloat = 1L << 62;
@@ -1385,6 +1415,36 @@ class HederaTokenStoreTest {
 		var req = fullyValidAttempt()
 				.setDivisibility(1 << 30)
 				.setFloat(1L << 34)
+				.build();
+
+		// when:
+		var result = subject.createProvisionally(req, sponsor);
+
+		// then:
+		assertEquals(ResponseCodeEnum.INVALID_TOKEN_DIVISIBILITY, result.getStatus());
+	}
+
+	@Test
+	public void rejectsOverflowingDivisibility() {
+		// given:
+		var req = fullyValidAttempt()
+				.setDivisibility(19)
+				.setFloat(0L)
+				.build();
+
+		// when:
+		var result = subject.createProvisionally(req, sponsor);
+
+		// then:
+		assertEquals(ResponseCodeEnum.INVALID_TOKEN_DIVISIBILITY, result.getStatus());
+	}
+
+	@Test
+	public void rejectsInvalidAmountForDivisibility() {
+		// given:
+		var req = fullyValidAttempt()
+				.setDivisibility(18)
+				.setFloat(10)
 				.build();
 
 		// when:

--- a/hedera-node/src/test/java/com/hedera/services/tokens/HederaTokenStoreTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/tokens/HederaTokenStoreTest.java
@@ -1359,21 +1359,6 @@ class HederaTokenStoreTest {
 	}
 
 	@Test
-	public void rejectsToCreateTokenWithAmountBiggerThanLong() {
-		// given:
-		var req = fullyValidAttempt()
-				.setFloat(10)
-				.setDivisibility(18)
-				.build();
-
-		// when:
-		var result = subject.createProvisionally(req, sponsor);
-
-		// then:
-		assertEquals(ResponseCodeEnum.INVALID_TOKEN_DIVISIBILITY, result.getStatus());
-	}
-
-	@Test
 	public void rejectsJustOverflowingFloat() {
 		int divisibility = 1;
 		long initialFloat = 1L << 62;

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenCreateSpecs.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenCreateSpecs.java
@@ -37,14 +37,7 @@ import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoCreate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.fileUpdate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.tokenCreate;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.newKeyNamed;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_SIGNATURE;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_TOKEN_DIVISIBILITY;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_TOKEN_FLOAT;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_TOKEN_SYMBOL;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.MISSING_TOKEN_SYMBOL;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TOKENS_PER_ACCOUNT_LIMIT_EXCEEDED;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TOKEN_SYMBOL_ALREADY_IN_USE;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TOKEN_SYMBOL_TOO_LONG;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.*;
 
 public class TokenCreateSpecs extends HapiApiSuite {
 	private static final Logger log = LogManager.getLogger(TokenCreateSpecs.class);
@@ -130,6 +123,10 @@ public class TokenCreateSpecs extends HapiApiSuite {
 								.payingWith("payer")
 								.symbol("")
 								.hasKnownStatus(MISSING_TOKEN_SYMBOL),
+						tokenCreate("whiteSpaces")
+								.payingWith("payer")
+								.symbol(" ")
+								.hasKnownStatus(INVALID_TOKEN_SYMBOL),
 						tokenCreate("tooLong")
 								.payingWith("payer")
 								.symbol("ABCDEZABCDEZABCDEZABCDEZABCDEZABCDEZ")
@@ -178,6 +175,16 @@ public class TokenCreateSpecs extends HapiApiSuite {
 								.payingWith("payer")
 								.divisibility(1)
 								.initialFloat(1L << 62)
+								.hasKnownStatus(INVALID_TOKEN_DIVISIBILITY),
+						tokenCreate("toobigdivisibility")
+								.payingWith("payer")
+								.initialFloat(0)
+								.divisibility(19)
+								.hasKnownStatus(INVALID_TOKEN_DIVISIBILITY),
+						tokenCreate("toobigdivisibility")
+								.payingWith("payer")
+								.initialFloat(10)
+								.divisibility(18)
 								.hasKnownStatus(INVALID_TOKEN_DIVISIBILITY)
 				);
 	}


### PR DESCRIPTION
Summary of the change:
- Add check if token divisibility is bigger than `Long.Max_value` (e.g. set too big divisibility upon token creation)
- Add tests