### PR TITLE
Update to comments

### DIFF
--- a/hapi-proto/src/main/proto/CryptoUpdate.proto
+++ b/hapi-proto/src/main/proto/CryptoUpdate.proto
@@ -31,7 +31,7 @@ import "Timestamp.proto";
 import "google/protobuf/wrappers.proto";
 
 /*
-Change properties for the given account. Any null field is ignored (left unchanged). This transaction must be signed by the existing key for this account. If the transaction is changing the key field, then the transaction must be signed by both the old key (from before the change) and the new key. The old key must sign for security. The new key must sign as a safeguard to avoid accidentally changing to an invalid key, and then having no way to recover.
+Change properties for the given account. Any null field is ignored (left unchanged). This transaction must be signed by the existing key for this account. 
 */
 message CryptoUpdateTransactionBody {
     AccountID accountIDToUpdate = 2; // The account ID which is being updated in this transaction


### PR DESCRIPTION
Key changes on an account currently require the old key to sign at this time. Not implemented: https://github.com/hashgraph/hedera-services/issues/162

**Related issue(s)**:
N/A

**External impacts**:
None.
