### PR TITLE
Use ethj from Maven Central

### DIFF
--- a/hedera-node/pom.xml
+++ b/hedera-node/pom.xml
@@ -341,11 +341,6 @@
       <url>https://oss.sonatype.org/content/repositories/comhederahashgraph-1167</url>
     </repository>
     <repository>
-      <id>ossrh-ethereumj-staging</id>
-      <name>Staging repo</name>
-      <url>https://oss.sonatype.org/content/repositories/comhederahashgraph-1169</url>
-    </repository>
-    <repository>
       <snapshots>
         <enabled>false</enabled>
       </snapshots>

--- a/test-clients/pom.xml
+++ b/test-clients/pom.xml
@@ -148,11 +148,6 @@
 
   <repositories>
     <repository>
-      <id>ossrh-staging</id>
-      <name>Staging repo</name>
-      <url>https://oss.sonatype.org/content/repositories/comhederahashgraph-1169</url>
-    </repository>
-    <repository>
       <id>Ethereum</id>
       <name>Ethereum</name>
       <url>https://dl.bintray.com/ethereum/maven/</url>


### PR DESCRIPTION
Remove `ethereumj-core` staging repo since the artifact is now in Maven Central.
