### PR TITLE
Lower TPS for circle ci network error test flow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1079,6 +1079,13 @@ workflows:
           requires:
             - start-singlejob-testnet
   nightly-simulate-network-outage:
+    triggers:
+        - schedule:
+            cron: "0 0,12 * * *"
+            filters:
+              branches:
+                only:
+                  - master
     jobs:
       - fast-build-artifact:
           context: Slack

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3131,7 +3131,7 @@ jobs:
             '/repo/.circleci/scripts/firewall_create_rules.sh'
       - run-eet-suites:
           dsl-args: "CryptoTransferLoadTest status.preResolve.pause.ms=8000"
-          ci-properties-map: mins=50
+          ci-properties-map: mins=50,tps=10,threads=3
       - run:
           name: call script to remove firewall rules
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1079,13 +1079,6 @@ workflows:
           requires:
             - start-singlejob-testnet
   nightly-simulate-network-outage:
-    triggers:
-        - schedule:
-            cron: "0 0,12 * * *"
-            filters:
-              branches:
-                only:
-                  - master
     jobs:
       - fast-build-artifact:
           context: Slack


### PR DESCRIPTION

**Related issue(s)**:
Closes #501 

**Summary of the change**:
Reduce TPS to avoid overloading GRPC server
