### PR TITLE
Adjust the transaction fee for fixing the insufficient tx fee error

### DIFF
--- a/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/OpProvider.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/OpProvider.java
@@ -82,6 +82,6 @@ public interface OpProvider {
 
 	String UNIQUE_PAYER_ACCOUNT = "uniquePayerAccount";
 	long UNIQUE_PAYER_ACCOUNT_INITIAL_BALANCE = 50_000_000_000L;
-	long TRANSACTION_FEE = 500_000_000L;
+	long TRANSACTION_FEE = 5_000_000_000L;
 
 }

--- a/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/TxnUtils.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/TxnUtils.java
@@ -247,7 +247,6 @@ public class TxnUtils {
 				.setSeconds(instant.getEpochSecond() + offsetSecs)
 				.setNanos(candidateNano).build();
 
-		log.info("timestamp : {}", uniqueTS);
 		return uniqueTS;
 	}
 


### PR DESCRIPTION
**Related issue(s)**:
Closes #497 

**Summary of the change**:
This is a follow-up of previous commit, which has caused insufficient_tx_fee error for smart contract test.
**External impacts**:
None.

**Applicable documentation**
- [ ] Javadoc
- [ ] HAPI protobuf comments
- [ ] README
