### PR TITLE
Fix rc1 issues

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2930,7 +2930,7 @@ jobs:
       - run-eet-suites:
           dsl-args: "-A DeprecatedContractKeySpecs"
       - run-eet-suites:
-          dsl-args: "-A ThresholdRecordCreationSpecs"
+          dsl-args: "ThresholdRecordCreationSpecs"
       - run-eet-suites:
           dsl-args: "ContractRecordSanityChecks"
   run-umbrella-freeze-restart-test:

--- a/hapi-proto/pom.xml
+++ b/hapi-proto/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>com.hedera.services</groupId>
     <artifactId>hedera-services</artifactId>
-    <version>0.7.0</version>
+    <version>0.8.0</version>
   </parent>
 
   <properties>

--- a/hedera-node/pom.xml
+++ b/hedera-node/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>com.hedera.services</groupId>
     <artifactId>hedera-services</artifactId>
-    <version>0.7.0</version>
+    <version>0.8.0</version>
   </parent>
 
   <properties>

--- a/hedera-node/src/main/java/com/hedera/services/context/ServicesContext.java
+++ b/hedera-node/src/main/java/com/hedera/services/context/ServicesContext.java
@@ -1006,7 +1006,8 @@ public class ServicesContext {
 					txnCtx(),
 					charging(),
 					this::accounts,
-					expiries());
+					expiries(),
+					globalDynamicProperties());
 		}
 		return recordsHistorian;
 	}

--- a/hedera-node/src/main/java/com/hedera/services/context/properties/BootstrapProperties.java
+++ b/hedera-node/src/main/java/com/hedera/services/context/properties/BootstrapProperties.java
@@ -37,7 +37,6 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static java.util.Collections.unmodifiableSet;
-import static java.util.Set.of;
 import static java.util.Map.entry;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toSet;
@@ -200,6 +199,7 @@ public class BootstrapProperties implements PropertySource {
 	static final Set<String> GLOBAL_DYNAMIC_PROPS = Set.of(
 			"contracts.defaultReceiveThreshold",
 			"contracts.defaultSendThreshold",
+			"ledger.createThresholdRecords",
 			"ledger.maxAccountNum",
 			"tokens.maxPerAccount",
 			"tokens.maxSymbolLength"
@@ -240,6 +240,7 @@ public class BootstrapProperties implements PropertySource {
 			entry("bootstrap.rates.nextCentEquiv", AS_INT),
 			entry("bootstrap.rates.nextExpiry", AS_LONG),
 			entry("bootstrap.system.entityExpiry", AS_LONG),
+			entry("ledger.createThresholdRecords", AS_BOOLEAN),
 			entry("ledger.maxAccountNum", AS_LONG),
 			entry("ledger.numSystemAccounts", AS_INT),
 			entry("ledger.totalTinyBarFloat", AS_LONG),

--- a/hedera-node/src/main/java/com/hedera/services/context/properties/GlobalDynamicProperties.java
+++ b/hedera-node/src/main/java/com/hedera/services/context/properties/GlobalDynamicProperties.java
@@ -28,6 +28,7 @@ public class GlobalDynamicProperties {
 	private long maxAccountNum;
 	private long defaultContractSendThreshold;
 	private long defaultContractReceiveThreshold;
+	private boolean shouldCreateThresholdRecords;
 
 	public GlobalDynamicProperties(PropertySource properties) {
 		this.properties = properties;
@@ -36,6 +37,7 @@ public class GlobalDynamicProperties {
 	}
 
 	public void reload() {
+		shouldCreateThresholdRecords = properties.getBooleanProperty("ledger.createThresholdRecords");
 		maxTokensPerAccount = properties.getIntProperty("tokens.maxPerAccount");
 		maxTokensSymbolLength = properties.getIntProperty("tokens.maxSymbolLength");
 		maxAccountNum = properties.getLongProperty("ledger.maxAccountNum");
@@ -61,5 +63,9 @@ public class GlobalDynamicProperties {
 
 	public long maxAccountNum() {
 		return maxAccountNum;
+	}
+
+	public boolean shouldCreateThresholdRecords() {
+		return shouldCreateThresholdRecords;
 	}
 }

--- a/hedera-node/src/main/java/com/hedera/services/context/properties/PropertySource.java
+++ b/hedera-node/src/main/java/com/hedera/services/context/properties/PropertySource.java
@@ -41,6 +41,7 @@ public interface PropertySource {
 
 	Function<String, Object> AS_INT = Integer::valueOf;
 	Function<String, Object> AS_LONG = Long::valueOf;
+	Function<String, Object> AS_BOOLEAN = Boolean::valueOf;
 
 	boolean containsProperty(String name);
 	Object getProperty(String name);

--- a/hedera-node/src/main/resources/bootstrap.properties
+++ b/hedera-node/src/main/resources/bootstrap.properties
@@ -41,6 +41,7 @@ ledger.totalTinyBarFloat=5000000000000000000
 # Global dynamic properties
 contracts.defaultReceiveThreshold=5000000000000000000
 contracts.defaultSendThreshold=5000000000000000000
+ledger.createThresholdRecords=false
 ledger.maxAccountNum=100000000
 tokens.maxPerAccount=1000
 tokens.maxSymbolLength=32

--- a/hedera-node/src/main/resources/semantic-version.properties
+++ b/hedera-node/src/main/resources/semantic-version.properties
@@ -1,2 +1,2 @@
-hapi.proto.version=0.7.0
-hedera.services.version=0.7.0
+hapi.proto.version=0.8.0
+hedera.services.version=0.8.0

--- a/hedera-node/src/test/java/com/hedera/services/ServicesStateTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/ServicesStateTest.java
@@ -170,6 +170,15 @@ class ServicesStateTest {
 	}
 
 	@Test
+	void ensuresNonNullTokenFcmAfterReadingFromLegacySavedState() {
+		// when:
+		subject.initialize(null);
+
+		// then:
+		assertNotNull(subject.tokens());
+	}
+
+	@Test
 	public void hasExpectedMinChildCounts() {
 		// given:
 		subject = new ServicesState(ctx, self, Collections.emptyList());

--- a/hedera-node/src/test/java/com/hedera/services/context/properties/BootstrapPropertiesTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/context/properties/BootstrapPropertiesTest.java
@@ -86,6 +86,7 @@ class BootstrapPropertiesTest {
 			entry("hedera.numReservedSystemEntities", 1_000L),
 			entry("hedera.realm", 0L),
 			entry("hedera.shard", 0L),
+			entry("ledger.createThresholdRecords", false),
 			entry("ledger.maxAccountNum", 100_000_000L),
 			entry("ledger.numSystemAccounts", 100),
 			entry("ledger.totalTinyBarFloat", 5000000000000000000L),

--- a/hedera-node/src/test/java/com/hedera/services/context/properties/GlobalDynamicPropertiesTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/context/properties/GlobalDynamicPropertiesTest.java
@@ -26,6 +26,8 @@ import org.junit.platform.runner.JUnitPlatform;
 import org.junit.runner.RunWith;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 
@@ -48,6 +50,7 @@ class GlobalDynamicPropertiesTest {
 		subject = new GlobalDynamicProperties(properties);
 
 		// expect:
+		assertFalse(subject.shouldCreateThresholdRecords());
 		assertEquals(1, subject.maxTokensPerAccount());
 		assertEquals(2, subject.maxTokenSymbolLength());
 		assertEquals(3L, subject.maxAccountNum());
@@ -63,6 +66,7 @@ class GlobalDynamicPropertiesTest {
 		subject = new GlobalDynamicProperties(properties);
 
 		// expect:
+		assertTrue(subject.shouldCreateThresholdRecords());
 		assertEquals(2, subject.maxTokensPerAccount());
 		assertEquals(3, subject.maxTokenSymbolLength());
 		assertEquals(4L, subject.maxAccountNum());
@@ -73,6 +77,7 @@ class GlobalDynamicPropertiesTest {
 	private void givenPropsWithSeed(int i) {
 		given(properties.getIntProperty("tokens.maxPerAccount")).willReturn(i);
 		given(properties.getIntProperty("tokens.maxSymbolLength")).willReturn(i + 1);
+		given(properties.getBooleanProperty("ledger.createThresholdRecords")).willReturn((i % 2) == 0);
 		given(properties.getLongProperty("ledger.maxAccountNum")).willReturn((long)i + 2);
 		given(properties.getLongProperty("contracts.defaultSendThreshold")).willReturn((long)i + 3);
 		given(properties.getLongProperty("contracts.defaultReceiveThreshold")).willReturn((long)i + 4);

--- a/hedera-node/src/test/resources/bootstrap/standard.properties
+++ b/hedera-node/src/test/resources/bootstrap/standard.properties
@@ -41,6 +41,7 @@ ledger.totalTinyBarFloat=5000000000000000000
 # Global dynamic properties
 contracts.defaultReceiveThreshold=5000000000000000000
 contracts.defaultSendThreshold=5000000000000000000
+ledger.createThresholdRecords=false
 ledger.maxAccountNum=100000000
 tokens.maxPerAccount=1000
 tokens.maxSymbolLength=32

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>com.hedera.services</groupId>
   <artifactId>hedera-services</artifactId>
-  <version>0.7.0</version>
+  <version>0.8.0</version>
   <description>
     Hedera Services (crypto, file, contract, consensus) on the Platform
   </description>
@@ -40,7 +40,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <hedera-services.version>0.7.0</hedera-services.version>
+    <hedera-services.version>0.8.0</hedera-services.version>
 
     <!-- Plugin property overrides -->
     <maven.compiler.source>12</maven.compiler.source>

--- a/test-clients/devops-utils/validation-scenarios/config.yml
+++ b/test-clients/devops-utils/validation-scenarios/config.yml
@@ -70,7 +70,7 @@ networks:
         persistent: {contents: MrBleaney.txt, num: 39283}
       sysFilesDown:
         evalMode: snapshot
-        numsToFetch: [121]
+        numsToFetch: [101, 102]
   localhost:
     bootstrap: 2
     defaultNode: 3
@@ -79,12 +79,12 @@ networks:
     - {account: 3, ipv4Addr: '127.0.0.1:50211'}
     scenarioPayer: 1001
     scenarios:
-      consensus: {persistent: 1010}
+      consensus: {persistent: 1007}
       contract:
-        persistent: {bytecode: 1007, luckyNo: 42, num: 1008, source: Multipurpose.sol}
+        persistent: {bytecode: 1005, luckyNo: 42, num: 1006, source: Multipurpose.sol}
       crypto: {receiver: 1003, sender: 1002}
       file:
-        persistent: {contents: MrBleaney.txt, num: 1005}
+        persistent: {contents: MrBleaney.txt, num: 1004}
   staging:
     bootstrap: 2
     defaultNode: 3

--- a/test-clients/pom.xml
+++ b/test-clients/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>com.hedera.services</groupId>
     <artifactId>hedera-services</artifactId>
-    <version>0.7.0</version>
+    <version>0.8.0</version>
   </parent>
 
   <properties>

--- a/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/TxnUtils.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/TxnUtils.java
@@ -247,7 +247,6 @@ public class TxnUtils {
 				.setSeconds(instant.getEpochSecond() + offsetSecs)
 				.setNanos(candidateNano).build();
 
-		log.info("timestamp : {}", uniqueTS);
 		return uniqueTS;
 	}
 

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/meta/VersionInfoSpec.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/meta/VersionInfoSpec.java
@@ -37,8 +37,8 @@ import java.util.List;
 public class VersionInfoSpec extends HapiApiSuite {
 	private static final Logger log = LogManager.getLogger(VersionInfoSpec.class);
 
-	private static final SemanticVersion EXPECTED_HAPI_PROTO = HapiPropertySource.asSemVer("0.7.0");
-	private static final SemanticVersion EXPECTED_HEDERA_SERVICES = HapiPropertySource.asSemVer("0.7.0");
+	private static final SemanticVersion EXPECTED_HAPI_PROTO = HapiPropertySource.asSemVer("0.8.0");
+	private static final SemanticVersion EXPECTED_HEDERA_SERVICES = HapiPropertySource.asSemVer("0.8.0");
 
 	public static void main(String... args) {
 		new VersionInfoSpec().runSuiteSync();

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/records/ThresholdRecordCreationSuite.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/records/ThresholdRecordCreationSuite.java
@@ -9,9 +9,9 @@ package com.hedera.services.bdd.suites.records;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -30,6 +30,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.List;
+import java.util.Map;
 
 /* --------------------------- SPEC STATIC IMPORTS --------------------------- */
 import static com.hedera.services.bdd.spec.HapiApiSpec.*;
@@ -54,15 +55,16 @@ public class ThresholdRecordCreationSuite extends HapiApiSuite {
 	@Override
 	protected List<HapiApiSpec> getSpecsInSuite() {
 		return List.of(
-			new HapiApiSpec[] {
-					newlyCreatedContractGetsRecord(),
-					cacheRecordPersistenceIsAsExpected(),
-					successfullyCalledContractGetsRecord(),
-					unsuccessfullyCalledContractGetsRecord(),
-					onlyNetAdjustmentIsComparedToThreshold(),
-					bothSendAndReceiveThresholdsAreConsidered(),
-					newlyCreatedAccountReceiveThresholdIsIgnored(),
-			}
+				new HapiApiSpec[] {
+						newlyCreatedContractGetsRecord(),
+						cacheRecordPersistenceIsAsExpected(),
+						successfullyCalledContractGetsRecord(),
+						unsuccessfullyCalledContractGetsRecord(),
+						onlyNetAdjustmentIsComparedToThresholdWhenCreating(),
+						bothSendAndReceiveThresholdsAreConsideredWhenCreating(),
+						newlyCreatedAccountReceiveThresholdIsIgnored(),
+						neitherSendAndReceiveThresholdsAreConsideredWhenNotCreating(),
+				}
 		);
 	}
 
@@ -88,6 +90,23 @@ public class ThresholdRecordCreationSuite extends HapiApiSuite {
 				).then(finalClause);
 	}
 
+	private HapiApiSpec neitherSendAndReceiveThresholdsAreConsideredWhenNotCreating() {
+		long A_LOW_THRESHOLD = 100L;
+
+		return defaultHapiSpec("NeitherSendAndReceiveThresholdsAreConsideredWhenNotCreating")
+				.given(
+						cryptoCreate("lowSend").sendThreshold(A_LOW_THRESHOLD),
+						cryptoCreate("lowReceive").receiveThreshold(A_LOW_THRESHOLD)
+				).when(
+						cryptoTransfer(
+								tinyBarsFromTo("lowSend", "lowReceive", A_LOW_THRESHOLD + 1L)
+						).via("transferTxn")
+				).then(
+						getAccountRecords("lowSend").has(inOrder()),
+						getAccountRecords("lowReceive").has(inOrder())
+				);
+	}
+
 	/**
 	 * Builds a spec in which we do a CryptoTransfer from an account with
 	 * a low send threshold, to an account with a low receive threshold.
@@ -95,11 +114,14 @@ public class ThresholdRecordCreationSuite extends HapiApiSuite {
 	 *
 	 * @return the spec.
 	 */
-	private HapiApiSpec bothSendAndReceiveThresholdsAreConsidered() {
+	private HapiApiSpec bothSendAndReceiveThresholdsAreConsideredWhenCreating() {
 		long A_LOW_THRESHOLD = 100L;
 
 		return defaultHapiSpec("BothSendAndReceiveThresholdsAreConsidered")
 				.given(
+						fileUpdate(APP_PROPERTIES).overridingProps(Map.of(
+								"ledger.createThresholdRecords", "true"
+						)),
 						cryptoCreate("lowSend").sendThreshold(A_LOW_THRESHOLD),
 						cryptoCreate("lowReceive").receiveThreshold(A_LOW_THRESHOLD)
 				).when(
@@ -112,6 +134,9 @@ public class ThresholdRecordCreationSuite extends HapiApiSuite {
 						)),
 						getAccountRecords("lowReceive").has(inOrder(
 								recordWith().txnId("transferTxn")
+						)),
+						fileUpdate(APP_PROPERTIES).overridingProps(Map.of(
+								"ledger.createThresholdRecords", "false"
 						))
 				);
 	}
@@ -129,7 +154,7 @@ public class ThresholdRecordCreationSuite extends HapiApiSuite {
 				).when(
 						contractCreate("contract").bytecode("bytecode").via("createTxn"),
 						contractCall("contract", DEPOSIT_ABI, 1_000L).via("callTxn").sending(1L)
-							.hasKnownStatus(CONTRACT_REVERT_EXECUTED)
+								.hasKnownStatus(CONTRACT_REVERT_EXECUTED)
 				).then(
 						getContractRecords("contract").has(inOrder(
 								recordWith().txnId("createTxn"),
@@ -173,7 +198,7 @@ public class ThresholdRecordCreationSuite extends HapiApiSuite {
 						contractCreate("contract").bytecode("bytecode").via("createTxn")
 				).then(
 						getContractRecords("contract").has(inOrder(
-							recordWith().txnId("createTxn")
+								recordWith().txnId("createTxn")
 						))
 				);
 	}
@@ -199,10 +224,10 @@ public class ThresholdRecordCreationSuite extends HapiApiSuite {
 	/**
 	 * Creates a spec in which we pay for two CryptoTransfers using a payer
 	 * with a very low send threshold and a very high receive threshold.
-	 *   1. In the first CryptoTransfer, the payer is a net sender of funds; hence
-	 *   should get a long-lived record of the transfer.
-	 *   2. In the second CryptoTransfer, the payer is a net receiver of funds,
-	 *   and should thus not get a long-lived record.
+	 * 1. In the first CryptoTransfer, the payer is a net sender of funds; hence
+	 * should get a long-lived record of the transfer.
+	 * 2. In the second CryptoTransfer, the payer is a net receiver of funds,
+	 * and should thus not get a long-lived record.
 	 *
 	 * In particular, the payer should have exactly one more record with the
 	 * txnId of the first transfer than the txnId of the second transfer (no
@@ -210,12 +235,15 @@ public class ThresholdRecordCreationSuite extends HapiApiSuite {
 	 *
 	 * @return the spec.
 	 */
-	private HapiApiSpec onlyNetAdjustmentIsComparedToThreshold() {
+	private HapiApiSpec onlyNetAdjustmentIsComparedToThresholdWhenCreating() {
 		final long WAY_LESS_THAN_A_TRANSFER_FEE = 1L;
 		final long WAY_MORE_THAN_A_TRANSFER_FEE = 1_000_000_000L;
 
-		return defaultHapiSpec("OnlyNetAdjustmentIsComparedToThresholds")
+		return defaultHapiSpec("OnlyNetAdjustmentIsComparedToThresholdWhenCreating")
 				.given(
+						fileUpdate(APP_PROPERTIES).overridingProps(Map.of(
+								"ledger.createThresholdRecords", "true"
+						)),
 						cryptoCreate("lowSendThreshPayer")
 								.sendThreshold(1L),
 						cryptoCreate("misc")
@@ -243,12 +271,15 @@ public class ThresholdRecordCreationSuite extends HapiApiSuite {
 									"Wrong difference in records generated!",
 									1,
 									numForThresholdRecordTxn - numForNoThresholdRecordTxn);
-						})
+						}),
+						fileUpdate(APP_PROPERTIES).overridingProps(Map.of(
+								"ledger.createThresholdRecords", "false"
+						))
 				);
 	}
 
 	private int numRecordsWithTxnId(List<TransactionRecord> records, TransactionID txnId) {
-		return (int)records
+		return (int) records
 				.stream()
 				.filter(r -> r.getTransactionID().equals(txnId))
 				.count();
@@ -260,5 +291,6 @@ public class ThresholdRecordCreationSuite extends HapiApiSuite {
 	}
 
 	private final String PATH_TO_PAYABLE_CONTRACT_BYTECODE = "src/main/resource/PayReceivable.bin";
-	private final String DEPOSIT_ABI = "{\"constant\":false,\"inputs\":[{\"name\":\"amount\",\"type\":\"uint256\"}],\"name\":\"deposit\",\"outputs\":[],\"payable\":true,\"stateMutability\":\"payable\",\"type\":\"function\"}";
+	private final String DEPOSIT_ABI = "{\"constant\":false,\"inputs\":[{\"name\":\"amount\",\"type\":\"uint256\"}]," +
+			"\"name\":\"deposit\",\"outputs\":[],\"payable\":true,\"stateMutability\":\"payable\",\"type\":\"function\"}";
 }


### PR DESCRIPTION
**Summary of the change**:
- Roll _pom.xml_ versions to `0.8.0`.
- Use the `SwirldState#initialize` method to ensure the tokens `FCMap` is created when restoring from an `0.7.0` state.
- Add a global/dynamic property `ledger.createThresholdRecords` (default `false`) to disable threshold records in a more principled way than the targeted code deletion.

