### PR TITLE
00551-D-FieldSourcedFeeScreeningNPE

### DIFF
--- a/hedera-node/src/main/java/com/hedera/services/fees/charging/FieldSourcedFeeScreening.java
+++ b/hedera-node/src/main/java/com/hedera/services/fees/charging/FieldSourcedFeeScreening.java
@@ -83,14 +83,18 @@ public class FieldSourcedFeeScreening implements TxnScopedFeeScreening {
 	@Override
 	public boolean canParticipantAfford(AccountID participant, EnumSet<TxnFeeType> fees) {
 		long exemptAmount = 0;
-		if (fees.contains(THRESHOLD_RECORD)) {
+		if (fees.contains(THRESHOLD_RECORD) && feeAmounts.containsKey(THRESHOLD_RECORD)) {
 			exemptAmount += exemptions.isExemptFromRecordFees(participant) ? feeAmounts.get(THRESHOLD_RECORD) : 0;
 		}
-		long netAmount = totalAmountOf(fees) - exemptAmount;
+
+		final long netAmount = totalAmountOf(fees) - exemptAmount;
 		return check.canAfford(participant, netAmount);
 	}
 
 	protected long totalAmountOf(EnumSet<TxnFeeType> fees) {
-		return fees.stream().mapToLong(feeAmounts::get).sum();
+		return fees.stream()
+				.filter(fee -> feeAmounts.containsKey(fee))
+				.mapToLong(feeAmounts::get)
+				.sum();
 	}
 }

--- a/hedera-node/src/test/java/com/hedera/services/fees/charging/FieldSourcedFeeScreeningTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/fees/charging/FieldSourcedFeeScreeningTest.java
@@ -183,6 +183,20 @@ class FieldSourcedFeeScreeningTest {
 		verify(check).canAfford(payer, willingness);
 	}
 
+	@Test
+	public void feeTest() {
+		// setup:
+		EnumSet<TxnFeeType> thresholdRecordFee = EnumSet.of(THRESHOLD_RECORD);
+		subject.setFor(NETWORK, network);
+		subject.setFor(SERVICE, service);
+		subject.setFor(NODE, node);
+		subject.setFor(CACHE_RECORD, cacheRecord);
+		// when:
+		boolean viability = subject.canParticipantAfford(master, thresholdRecordFee);
+		// then:
+		assertFalse(viability);
+	}
+
 	private void givenKnownFeeAmounts() {
 		subject.setFor(NETWORK, network);
 		subject.setFor(SERVICE, service);

--- a/hedera-node/src/test/java/com/hedera/services/fees/charging/FieldSourcedFeeScreeningTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/fees/charging/FieldSourcedFeeScreeningTest.java
@@ -41,8 +41,14 @@ import static com.hedera.services.fees.TxnFeeType.*;
 
 @RunWith(JUnitPlatform.class)
 class FieldSourcedFeeScreeningTest {
-	long willingness = 1_000L;
-	long network = 500L, service = 200L, node = 100L, stateRecord = 150L, cacheRecord = 50L;
+
+	final long willingness = 1_000L;
+	final long network = 500L;
+	final long service = 200L;
+	final long node = 100L;
+	final long stateRecord = 150L;
+	final long cacheRecord = 50L;
+
 	AccountID payer = IdUtils.asAccount("0.0.1001");
 	AccountID master = IdUtils.asAccount("0.0.50");
 	AccountID participant = IdUtils.asAccount("0.0.2002");
@@ -184,13 +190,32 @@ class FieldSourcedFeeScreeningTest {
 	}
 
 	@Test
-	public void feeTest() {
+	public void canParticipantAffordTest() {
 		// setup:
 		EnumSet<TxnFeeType> thresholdRecordFee = EnumSet.of(THRESHOLD_RECORD);
 		subject.setFor(NETWORK, network);
 		subject.setFor(SERVICE, service);
 		subject.setFor(NODE, node);
 		subject.setFor(CACHE_RECORD, cacheRecord);
+		// when:
+		boolean viability = subject.canParticipantAfford(master, thresholdRecordFee);
+		// then:
+		assertFalse(viability);
+	}
+
+	@Test
+	public void participantCantAffordTest() {
+		// setup:
+		final BalanceCheck check = (payer, amount) -> amount >= stateRecord;
+
+		final EnumSet<TxnFeeType> thresholdRecordFee = EnumSet.of(THRESHOLD_RECORD);
+		subject.setFor(NETWORK, network);
+		subject.setFor(SERVICE, service);
+		subject.setFor(NODE, node);
+		subject.setFor(CACHE_RECORD, cacheRecord);
+		subject.setFor(THRESHOLD_RECORD, stateRecord);
+		subject.setBalanceCheck(check);
+
 		// when:
 		boolean viability = subject.canParticipantAfford(master, thresholdRecordFee);
 		// then:


### PR DESCRIPTION
**Related issue(s)**:
Closes #551 

Related to [261](https://github.com/swirlds/hedera-fpcomplete-audit/pull/261)

**Summary of the change**:
Validates that `THRESHOLD_RECORD` is present in `feeAmounts` to avoid a NullPointerException. 

