### PR TITLE
Support querypayment testing

### DIFF
--- a/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/HapiQueryOp.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/HapiQueryOp.java
@@ -22,6 +22,7 @@ package com.hedera.services.bdd.spec.queries;
 
 import com.hedera.services.bdd.spec.HapiPropertySource;
 import com.hedera.services.bdd.spec.keys.SigStyle;
+import com.hedera.services.bdd.spec.transactions.crypto.HapiCryptoTransfer;
 import com.hederahashgraph.api.proto.java.CryptoTransferTransactionBody;
 import com.hederahashgraph.api.proto.java.HederaFunctionality;
 import com.hederahashgraph.api.proto.java.Key;
@@ -61,19 +62,20 @@ public abstract class HapiQueryOp<T extends HapiQueryOp<T>> extends HapiSpecOper
 	private static final Logger log = LogManager.getLogger(HapiQueryOp.class);
 
 	private String nodePaymentName;
-	protected boolean recordsNodePayment = false;
-	protected boolean stopAfterCostAnswer = false;
-	protected boolean expectStrictCostAnswer = false;
+	private boolean recordsNodePayment = false;
+	private boolean stopAfterCostAnswer = false;
+	private boolean expectStrictCostAnswer = false;
 	protected Response response = null;
+	private Optional<ResponseCodeEnum> answerOnlyPrecheck = Optional.empty();
+	private Optional<Function<HapiApiSpec, Long>> nodePaymentFn = Optional.empty();
+	private Optional<EnumSet<ResponseCodeEnum>> permissibleAnswerOnlyPrechecks = Optional.empty();
+	private Optional<EnumSet<ResponseCodeEnum>> permissibleCostAnswerPrechecks = Optional.empty();
+	private ResponseCodeEnum expectedCostAnswerPrecheck() { return costAnswerPrecheck.orElse(OK); }
+	private ResponseCodeEnum expectedAnswerOnlyPrecheck() { return answerOnlyPrecheck.orElse(OK); }
+
 	protected Optional<Long> nodePayment = Optional.empty();
 	protected Optional<ResponseCodeEnum> costAnswerPrecheck = Optional.empty();
-	protected Optional<ResponseCodeEnum> answerOnlyPrecheck = Optional.empty();
-	protected Optional<Function<HapiApiSpec, Long>> nodePaymentFn = Optional.empty();
-	protected Optional<EnumSet<ResponseCodeEnum>> permissibleAnswerOnlyPrechecks = Optional.empty();
-	protected Optional<EnumSet<ResponseCodeEnum>> permissibleCostAnswerPrechecks = Optional.empty();
-
-	protected ResponseCodeEnum expectedCostAnswerPrecheck() { return costAnswerPrecheck.orElse(OK); }
-	protected ResponseCodeEnum expectedAnswerOnlyPrecheck() { return answerOnlyPrecheck.orElse(OK); }
+	protected Optional<HapiCryptoTransfer> explicitPayment = Optional.empty();
 
 	/* WARNING: Must set `response` as a side effect! */
 	protected abstract void submitWith(HapiApiSpec spec, Transaction payment) throws Throwable;
@@ -170,7 +172,9 @@ public abstract class HapiQueryOp<T extends HapiQueryOp<T>> extends HapiSpecOper
 	}
 
 	private Transaction fittedPayment(HapiApiSpec spec) throws Throwable {
-		if (nodePaymentFn.isPresent()) {
+		if (explicitPayment.isPresent()) {
+			return explicitPayment.get().signedTxnFor(spec);
+		} else if (nodePaymentFn.isPresent()) {
 			return finalizedTxn(spec, opDef(spec, nodePaymentFn.get().apply(spec)));
 		} else if (nodePayment.isPresent()) {
 			return finalizedTxn(spec, opDef(spec, nodePayment.get()));
@@ -212,6 +216,7 @@ public abstract class HapiQueryOp<T extends HapiQueryOp<T>> extends HapiSpecOper
 			return finalizedTxn(spec, opDef(spec, realNodePayment));
 		}
 	}
+
 	private long timedCostLookupWith(HapiApiSpec spec, Transaction payment)	throws Throwable {
 		if (suppressStats) {
 			return lookupCostWith(spec, payment);
@@ -336,7 +341,6 @@ public abstract class HapiQueryOp<T extends HapiQueryOp<T>> extends HapiSpecOper
 		loggingOff = false;
 		return self();
 	}
-
 	public T recordNodePaymentAs(String s) {
 		recordsNodePayment = true;
 		nodePaymentName = s;
@@ -360,6 +364,10 @@ public abstract class HapiQueryOp<T extends HapiQueryOp<T>> extends HapiSpecOper
 	}
 	public T setNodeFrom(Supplier<String> accountSupplier) {
 		nodeSupplier = Optional.of(() -> HapiPropertySource.asAccount(accountSupplier.get()));
+		return self();
+	}
+	public T withPayment(HapiCryptoTransfer txn) {
+		explicitPayment = Optional.of(txn);
 		return self();
 	}
 }

--- a/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/HapiTxnOp.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/HapiTxnOp.java
@@ -122,6 +122,10 @@ public abstract class HapiTxnOp<T extends HapiTxnOp<T>> extends HapiSpecOperatio
 		return finalizedTxn(spec, opBodyDef(spec)).toByteArray();
 	}
 
+	public Transaction signedTxnFor(HapiApiSpec spec) throws Throwable {
+		return finalizedTxn(spec, opBodyDef(spec));
+	}
+
 	@Override
 	protected boolean submitOp(HapiApiSpec spec) throws Throwable {
 		stats = new TxnObs(type());


### PR DESCRIPTION
**Summary of the change**:
Enhance `HapiQueryOp` to allow the user to set the query payment explicitly.

This allows tests such as [`queryPaymentsAreSanityChecked` here](https://github.com/hashgraph/hedera-services/blob/support-querypayment-testing/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoCreateSuite.java#L95):
```
	private HapiApiSpec queryPaymentsAreSanityChecked() {
		return defaultHapiSpec("QueryPaymentsAreSanityChecked")
				.given(
						cryptoCreate("a"),
						cryptoCreate("b")
				).when().then(
						getAccountInfo(GENESIS)
								.withPayment(
										cryptoTransfer(spec ->
												invalidMultiAccountPaymentToNode003(
														spec, "a", "b", 1_000L))
								).hasAnswerOnlyPrecheck(INVALID_QUERY_PAYMENT_ACCOUNT_AMOUNTS)
				);
	}
```
