### PR TITLE
update the key depth limit

### DIFF
--- a/hapi-proto/src/main/java/com/hedera/services/legacy/proto/utils/KeyExpansion.java
+++ b/hapi-proto/src/main/java/com/hedera/services/legacy/proto/utils/KeyExpansion.java
@@ -51,7 +51,7 @@ import org.junit.Assert;
 public class KeyExpansion {
 
   private static final Logger log = LogManager.getLogger(KeyExpansion.class);
-  public static int KEY_EXPANSION_DEPTH = 100; // recursion level for expansion
+  public static int KEY_EXPANSION_DEPTH = 15; // recursion level for expansion
   public static boolean USE_HEX_ENCODED_KEY = false;
 
   /**

--- a/hedera-node/src/main/java/com/hedera/services/legacy/core/jproto/JKey.java
+++ b/hedera-node/src/main/java/com/hedera/services/legacy/core/jproto/JKey.java
@@ -73,7 +73,7 @@ public abstract class JKey implements Serializable, Cloneable {
 	 */
 	public static JKey convertKey(Key key, int depth) throws DecoderException {
 		if (depth > KeyExpansion.KEY_EXPANSION_DEPTH) {
-			log.debug("Exceeding max expansion depth of " + KeyExpansion.KEY_EXPANSION_DEPTH);
+			throw new DecoderException("Exceeding max expansion depth of " + KeyExpansion.KEY_EXPANSION_DEPTH);
 		}
 
 		if (!(key.hasThresholdKey() || key.hasKeyList())) {

--- a/hedera-node/src/test/java/com/hedera/services/legacy/core/jproto/JKeyTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/legacy/core/jproto/JKeyTest.java
@@ -1,0 +1,55 @@
+package com.hedera.services.legacy.core.jproto;
+
+/*-
+ * ‌
+ * Hedera Services Node
+ * ​
+ * Copyright (C) 2018 - 2020 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import com.hedera.services.legacy.proto.utils.KeyExpansion;
+import com.hedera.services.legacy.util.ComplexKeyManager;
+import com.hederahashgraph.api.proto.java.Key;
+import org.apache.commons.codec.DecoderException;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import org.junit.platform.runner.JUnitPlatform;
+import org.junit.runner.RunWith;
+
+@RunWith(JUnitPlatform.class)
+public class JKeyTest {
+	@Test
+	public void positiveConvertKeyTest() throws Exception {
+		//given
+		Key accountKey = ComplexKeyManager
+				.genComplexKey(ComplexKeyManager.SUPPORTE_KEY_TYPES.single.name());
+
+		//expect
+		assertDoesNotThrow(() -> JKey.convertKey(accountKey,1));
+	}
+
+	@Test
+	public void negativeConvertKeyTest() throws Exception {
+		//given
+		Key accountKey = ComplexKeyManager
+				.genComplexKey(ComplexKeyManager.SUPPORTE_KEY_TYPES.thresholdKey.name());
+
+		//expect
+		assertThrows(DecoderException.class, () -> JKey.convertKey(accountKey, KeyExpansion.KEY_EXPANSION_DEPTH+1),
+				"Exceeding max expansion depth of " + KeyExpansion.KEY_EXPANSION_DEPTH);
+	}
+}


### PR DESCRIPTION
Signed-off-by: Anirudh Ghanta <anirudh.ghanta@hedera.com>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `0<issue number>-<target branch>-<summary>`
-->

**Related issue(s)**:
Closes #602 

**Summary of the change**:
Updated the key depth limit `KEY_EXPANSION_DEPTH` and we throw a `DecoderException` error when this limit is reached.

**External impacts**:
None.

**Applicable documentation**
- [ ] Javadoc
- [ ] HAPI protobuf comments
- [ ] README
