### PR TITLE
Add comments clarifying abbreviated serde in MerkleOptionalBlob

### DIFF
--- a/hedera-node/src/main/java/com/hedera/services/state/merkle/MerkleOptionalBlob.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/merkle/MerkleOptionalBlob.java
@@ -144,7 +144,12 @@ public class MerkleOptionalBlob extends AbstractMerkleNode implements FCMValue, 
 	}
 
 	@Override
-	public void serializeAbbreviated(SerializableDataOutputStream out) { }
+	public void serializeAbbreviated(SerializableDataOutputStream out) { 
+                /* Nothing to do here, since Platform automatically serializes the 
+                 * hash of an MerkleExternalLeaf and passes it as an argument to 
+                 * deserializeAbbreviated as below. (Our BinaryObject delegate 
+                 * doesn't need anything except this hash to deserialize itself.) */
+        }
 
 	@Override
 	public void deserializeAbbreviated(


### PR DESCRIPTION
**Summary of the change**:
- Add a comment to clarify why `MerkleOptionalBlob#serializeAbbreviated` is a no-op.
