### PR TITLE
Fix(token): Restrict empty token transfers

### DIFF
--- a/hapi-proto/HAPI.html
+++ b/hapi-proto/HAPI.html
@@ -8267,19 +8267,30 @@ by HAPI.</p></td>
                 <td><p>An attempted operation is invalid because the account is a treasury</p></td>
               </tr>
             
-
               <tr>
                 <td>TOKEN_ID_REPEATED_IN_TOKEN_LIST</td>
                 <td>197</td>
                 <td><p>Same TokenIDs present in the token list</p></td>
               </tr>
-
+            
               <tr>
                 <td>TOKEN_TRANSFER_LIST_SIZE_LIMIT_EXCEEDED</td>
                 <td>198</td>
                 <td><p>Exceeded the number of token transfers (both from and to) allowed for token transfer list</p></td>
               </tr>
-
+            
+              <tr>
+                <td>EMPTY_TOKEN_TRANSFER_BODY</td>
+                <td>199</td>
+                <td><p>TokenTransfersTransactionBody has no TokenTransferList</p></td>
+              </tr>
+            
+              <tr>
+                <td>EMPTY_TOKEN_TRANSFER_ACCOUNT_AMOUNTS</td>
+                <td>200</td>
+                <td><p>TokenTransfersTransactionBody has a TokenTransferList with no AccountAmounts</p></td>
+              </tr>
+            
           </tbody>
         </table>
       

--- a/hapi-proto/src/main/proto/ResponseCode.proto
+++ b/hapi-proto/src/main/proto/ResponseCode.proto
@@ -210,4 +210,6 @@ enum ResponseCodeEnum {
   ACCOUNT_IS_TREASURY = 196; // An attempted operation is invalid because the account is a treasury
   TOKEN_ID_REPEATED_IN_TOKEN_LIST = 197; // Same TokenIDs present in the token list
   TOKEN_TRANSFER_LIST_SIZE_LIMIT_EXCEEDED = 198; // Exceeded the number of token transfers (both from and to) allowed for token transfer list
+  EMPTY_TOKEN_TRANSFER_BODY = 199; // TokenTransfersTransactionBody has no TokenTransferList
+  EMPTY_TOKEN_TRANSFER_ACCOUNT_AMOUNTS = 200; // TokenTransfersTransactionBody has a TokenTransferList with no AccountAmounts
 }

--- a/hedera-node/src/main/java/com/hedera/services/txns/token/TokenTransferTransitionLogic.java
+++ b/hedera-node/src/main/java/com/hedera/services/txns/token/TokenTransferTransitionLogic.java
@@ -80,8 +80,9 @@ public class TokenTransferTransitionLogic implements TransitionLogic {
 	public ResponseCodeEnum validate(TransactionBody txnBody) {
 		TokenTransfersTransactionBody op = txnBody.getTokenTransfers();
 
-		if (!validator.isAcceptableTokenTransfersLength(op.getTokenTransfersList())) {
-			return TOKEN_TRANSFER_LIST_SIZE_LIMIT_EXCEEDED;
+		var validity = validator.isAcceptableTokenTransfersLength(op.getTokenTransfersList());
+		if (validity != OK) {
+			return validity;
 		}
 
 		return checkTokenTransfers(op.getTokenTransfersList());

--- a/hedera-node/src/main/java/com/hedera/services/txns/validation/OptionValidator.java
+++ b/hedera-node/src/main/java/com/hedera/services/txns/validation/OptionValidator.java
@@ -30,6 +30,7 @@ import com.hederahashgraph.api.proto.java.ContractID;
 import com.hederahashgraph.api.proto.java.Duration;
 import com.hederahashgraph.api.proto.java.FileID;
 import com.hederahashgraph.api.proto.java.Key;
+import com.hederahashgraph.api.proto.java.ResponseCode;
 import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
 import com.hederahashgraph.api.proto.java.Timestamp;
 import com.hederahashgraph.api.proto.java.TokenTransferList;
@@ -54,11 +55,11 @@ public interface OptionValidator {
 	boolean isValidTxnDuration(long duration);
 	boolean isValidAutoRenewPeriod(Duration autoRenewPeriod);
 	boolean isAcceptableTransfersLength(TransferList accountAmounts);
-	boolean isAcceptableTokenTransfersLength(List<TokenTransferList> tokenTransferLists);
 
 	ResponseCodeEnum queryableTopicStatus(TopicID id, FCMap<MerkleEntityId, MerkleTopic> topics);
 	ResponseCodeEnum tokenSymbolCheck(String symbol);
 	ResponseCodeEnum tokenNameCheck(String name);
+	ResponseCodeEnum isAcceptableTokenTransfersLength(List<TokenTransferList> tokenTransferLists);
 
 	default ResponseCodeEnum queryableAccountStatus(AccountID id, FCMap<MerkleEntityId, MerkleAccount> accounts) {
 		return PureValidation.queryableAccountStatus(id, accounts);

--- a/hedera-node/src/test/java/com/hedera/services/txns/token/TokenTransferTransitionLogicTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/txns/token/TokenTransferTransitionLogicTest.java
@@ -39,6 +39,8 @@ import static com.hedera.test.utils.IdUtils.adjustFrom;
 import static com.hedera.test.utils.IdUtils.asAccount;
 import static com.hedera.test.utils.IdUtils.asToken;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.ACCOUNT_REPEATED_IN_ACCOUNT_AMOUNTS;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.EMPTY_TOKEN_TRANSFER_ACCOUNT_AMOUNTS;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.EMPTY_TOKEN_TRANSFER_BODY;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.FAIL_INVALID;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_ACCOUNT_AMOUNTS;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_ACCOUNT_ID;
@@ -82,7 +84,7 @@ class TokenTransferTransitionLogicTest {
 		accessor = mock(PlatformTxnAccessor.class);
 
 		txnCtx = mock(TransactionContext.class);
-		given(validator.isAcceptableTokenTransfersLength(any())).willReturn(true);
+		given(validator.isAcceptableTokenTransfersLength(any())).willReturn(OK);
 
 		subject = new TokenTransferTransitionLogic(ledger, validator, txnCtx);
 	}
@@ -145,12 +147,30 @@ class TokenTransferTransitionLogicTest {
 	}
 
 	@Test
-	public void rejectsIncorrectTransfersLength() {
+	public void rejectsExceedingTransfersLength() {
 		givenValidTxnCtx();
-		given(validator.isAcceptableTokenTransfersLength(any())).willReturn(false);
+		given(validator.isAcceptableTokenTransfersLength(any())).willReturn(TOKEN_TRANSFER_LIST_SIZE_LIMIT_EXCEEDED);
 
 		// expect:
 		assertEquals(TOKEN_TRANSFER_LIST_SIZE_LIMIT_EXCEEDED, subject.syntaxCheck().apply(tokenTransactTxn));
+	}
+
+	@Test
+	public void rejectsEmptyTokenTransferBody() {
+		givenValidTxnCtx();
+		given(validator.isAcceptableTokenTransfersLength(any())).willReturn(EMPTY_TOKEN_TRANSFER_BODY);
+
+		// expect:
+		assertEquals(EMPTY_TOKEN_TRANSFER_BODY, subject.syntaxCheck().apply(tokenTransactTxn));
+	}
+
+	@Test
+	public void rejectsEmptyTokenTransferAccountAmounts() {
+		givenValidTxnCtx();
+		given(validator.isAcceptableTokenTransfersLength(any())).willReturn(EMPTY_TOKEN_TRANSFER_ACCOUNT_AMOUNTS);
+
+		// expect:
+		assertEquals(EMPTY_TOKEN_TRANSFER_ACCOUNT_AMOUNTS, subject.syntaxCheck().apply(tokenTransactTxn));
 	}
 
 	@Test

--- a/hedera-node/src/test/java/com/hedera/services/txns/validation/ContextOptionValidatorTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/txns/validation/ContextOptionValidatorTest.java
@@ -74,6 +74,9 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_TOPIC_
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_TRANSACTION_START;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.MISSING_TOKEN_NAME;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.MISSING_TOKEN_SYMBOL;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TOKEN_TRANSFER_LIST_SIZE_LIMIT_EXCEEDED;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.EMPTY_TOKEN_TRANSFER_BODY;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.EMPTY_TOKEN_TRANSFER_ACCOUNT_AMOUNTS;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OK;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TOKEN_NAME_TOO_LONG;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TOKEN_SYMBOL_TOO_LONG;
@@ -599,39 +602,48 @@ public class ContextOptionValidatorTest {
 		given(dynamicProperties.maxTokenTransferListSize()).willReturn(4);
 
 		// expect:
-		assertTrue(subject.isAcceptableTokenTransfersLength(wrapper));
+		assertEquals(OK, subject.isAcceptableTokenTransfersLength(wrapper));
 	}
 
 	@Test
-	public void rejectsInvalidTokenTransfersLength() {
+	public void rejectsExceedingTokenTransfersLength() {
 		// setup:
 		List<TokenTransferList> wrapper = withTokenAdjustments(aTId, a, -1, bTId, b, 2, cTId, c, 3);
 
 		given(dynamicProperties.maxTokenTransferListSize()).willReturn(2);
 
 		// expect:
-		assertFalse(subject.isAcceptableTokenTransfersLength(wrapper));
+		assertEquals(TOKEN_TRANSFER_LIST_SIZE_LIMIT_EXCEEDED, subject.isAcceptableTokenTransfersLength(wrapper));
 	}
 
 	@Test
-	public void rejectsInvalidTokenTransfersAccountAmountsLength() {
+	public void rejectsExceedingTokenTransfersAccountAmountsLength() {
 		// setup:
 		List<TokenTransferList> wrapper = withTokenAdjustments(aTId, a, -1, bTId, b, 2, cTId, c, 3, dTId, d, -4);
 
 		given(dynamicProperties.maxTokenTransferListSize()).willReturn(4);
 
 		// expect:
-		assertFalse(subject.isAcceptableTokenTransfersLength(wrapper));
+		assertEquals(TOKEN_TRANSFER_LIST_SIZE_LIMIT_EXCEEDED, subject.isAcceptableTokenTransfersLength(wrapper));
 	}
 
 	@Test
-	public void rejectsInvalidTokenTransfersEmptyAccountAmounts() {
+	public void rejectsEmptyTokenTransferAccountAmounts() {
 		// setup:
 		List<TokenTransferList> wrapper = withTokenAdjustments(aTId, bTId);
 
 		given(dynamicProperties.maxTokenTransferListSize()).willReturn(2);
 
 		// expect:
-		assertFalse(subject.isAcceptableTokenTransfersLength(wrapper));
+		assertEquals(EMPTY_TOKEN_TRANSFER_ACCOUNT_AMOUNTS, subject.isAcceptableTokenTransfersLength(wrapper));
+	}
+
+	@Test
+	public void rejectsEmptyTokenTransfersBody() {
+		// setup:
+		List<TokenTransferList> wrapper = List.of();
+
+		// expect:
+		assertEquals(EMPTY_TOKEN_TRANSFER_BODY, subject.isAcceptableTokenTransfersLength(wrapper));
 	}
 }

--- a/hedera-node/src/test/java/com/hedera/test/mocks/TestContextValidator.java
+++ b/hedera-node/src/test/java/com/hedera/test/mocks/TestContextValidator.java
@@ -81,7 +81,7 @@ public enum TestContextValidator implements OptionValidator {
 	}
 
 	@Override
-	public boolean isAcceptableTokenTransfersLength(List<TokenTransferList> tokenTransferLists) {
+	public ResponseCodeEnum isAcceptableTokenTransfersLength(List<TokenTransferList> tokenTransferLists) {
 		throw new UnsupportedOperationException();
 	}
 

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenAssociationSpecs.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenAssociationSpecs.java
@@ -45,6 +45,7 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.ACCOUNT_IS_TRE
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_TOKEN_ID;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TOKENS_PER_ACCOUNT_LIMIT_EXCEEDED;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TOKEN_ALREADY_ASSOCIATED_TO_ACCOUNT;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TOKEN_ID_REPEATED_IN_TOKEN_LIST;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TOKEN_NOT_ASSOCIATED_TO_ACCOUNT;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TRANSACTION_REQUIRES_ZERO_TOKEN_BALANCES;
 import static com.hederahashgraph.api.proto.java.TokenFreezeStatus.FreezeNotApplicable;
@@ -120,6 +121,10 @@ public class TokenAssociationSpecs extends HapiApiSuite {
 								.hasKnownStatus(TOKEN_ALREADY_ASSOCIATED_TO_ACCOUNT),
 						tokenAssociate("misc", "1.2.3")
 								.hasKnownStatus(INVALID_TOKEN_ID),
+						tokenAssociate("misc", "1.2.3", "1.2.3")
+								.hasPrecheck(TOKEN_ID_REPEATED_IN_TOKEN_LIST),
+						tokenDissociate("misc", "1.2.3", "1.2.3")
+								.hasPrecheck(TOKEN_ID_REPEATED_IN_TOKEN_LIST),
 						fileUpdate(APP_PROPERTIES).overridingProps(Map.of(
 								"tokens.maxPerAccount", "" + 1
 						)).payingWith(ADDRESS_BOOK_CONTROL),

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenTransactSpecs.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenTransactSpecs.java
@@ -64,9 +64,70 @@ public class TokenTransactSpecs extends HapiApiSuite {
 						duplicateAccountsInTokenTransferRejected(),
 						allRequiredSigsAreChecked(),
 						txnsAreAtomic(),
-						nonZeroTransfersRejected()
+						nonZeroTransfersRejected(),
+						prechecksWork(),
 				}
 		);
+	}
+
+	private HapiApiSpec prechecksWork() {
+		return defaultHapiSpec("PrechecksWork")
+				.given(
+						cryptoCreate(TOKEN_TREASURY),
+						cryptoCreate(FIRST_USER)
+				).when(
+						tokenCreate(A_TOKEN)
+								.initialSupply(100)
+								.treasury(TOKEN_TREASURY),
+						tokenCreate(B_TOKEN)
+								.initialSupply(100)
+								.treasury(TOKEN_TREASURY)
+				).then(
+						fileUpdate(APP_PROPERTIES).overridingProps(Map.of(
+								"ledger.tokenTransfers.maxLen", "" + 1
+						)).payingWith(ADDRESS_BOOK_CONTROL),
+						tokenTransact(
+								moving(1, A_TOKEN)
+										.between(TOKEN_TREASURY, FIRST_USER),
+								moving(1, A_TOKEN)
+										.between(TOKEN_TREASURY, FIRST_USER)
+						)
+								.hasPrecheck(TOKEN_TRANSFER_LIST_SIZE_LIMIT_EXCEEDED),
+						tokenTransact(
+								moving(1, A_TOKEN)
+										.between(TOKEN_TREASURY, FIRST_USER),
+								moving(1, B_TOKEN)
+										.between(TOKEN_TREASURY, FIRST_USER)
+						)
+								.hasPrecheck(TOKEN_TRANSFER_LIST_SIZE_LIMIT_EXCEEDED),
+						fileUpdate(APP_PROPERTIES).overridingProps(Map.of(
+								"ledger.tokenTransfers.maxLen", "" + 10
+						)).payingWith(ADDRESS_BOOK_CONTROL),
+						tokenTransact(
+								moving(1, A_TOKEN)
+										.between(TOKEN_TREASURY, FIRST_USER),
+								moving(1, A_TOKEN)
+										.between(TOKEN_TREASURY, FIRST_USER)
+						)
+								.hasPrecheck(ACCOUNT_REPEATED_IN_ACCOUNT_AMOUNTS),
+						tokenTransact(
+								moving(0, A_TOKEN)
+										.between(TOKEN_TREASURY, FIRST_USER)
+						)
+								.hasPrecheck(INVALID_ACCOUNT_AMOUNTS),
+						tokenTransact(
+								moving(10, A_TOKEN)
+										.from(TOKEN_TREASURY)
+						)
+								.hasPrecheck(TRANSFERS_NOT_ZERO_SUM_FOR_TOKEN),
+						tokenTransact()
+								.hasPrecheck(EMPTY_TOKEN_TRANSFER_BODY),
+						tokenTransact(
+								moving(10, A_TOKEN)
+										.empty()
+						)
+								.hasPrecheck(EMPTY_TOKEN_TRANSFER_ACCOUNT_AMOUNTS)
+				);
 	}
 
 	public HapiApiSpec balancesAreChecked() {


### PR DESCRIPTION
**Related issue(s)**:
Closes #None

**Summary of the change**:
* Add two ResponseCodes - `EMPTY_TOKEN_TRANSFER_BODY` and `EMPTY_TOKEN_TRANSFER_ACCOUNT_AMOUNTS`.
* Update `isAcceptableTokenTransfersLength`.
* Add/update unit tests.
* Update `HapiTokenTransact` to allow token transfers with empty account amounts.
* Add BDD Tests.

**Applicable documentation**
- [ ] Javadoc
- [x] HAPI protobuf comments
- [ ] README
