### PR TITLE
Make state payer records optional

### DIFF
--- a/hedera-node/src/main/java/com/hedera/services/context/ServicesContext.java
+++ b/hedera-node/src/main/java/com/hedera/services/context/ServicesContext.java
@@ -60,7 +60,6 @@ import com.hedera.services.queries.token.TokenAnswers;
 import com.hedera.services.records.TxnIdRecentHistory;
 import com.hedera.services.security.ops.SystemOpPolicies;
 import com.hedera.services.sigs.metadata.DelegatingSigMetadataLookup;
-import com.hedera.services.sigs.metadata.SigMetadataLookup;
 import com.hedera.services.state.expiry.ExpiringCreations;
 import com.hedera.services.state.expiry.ExpiryManager;
 import com.hedera.services.state.initialization.BackedSystemAccountsCreator;
@@ -991,7 +990,7 @@ public class ServicesContext {
 	public RecordCache recordCache() {
 		if (recordCache == null) {
 			recordCache = new RecordCache(
-					creator(),
+					this,
 					new RecordCacheFactory(properties()).getRecordCache(),
 					txnHistories());
 		}
@@ -1062,8 +1061,8 @@ public class ServicesContext {
 
 	public ExpiryManager expiries() {
 		if (expiries == null) {
-			expiries = new ExpiryManager(txnHistories());
-			expiries.setRecordCache(recordCache());
+			var histories = txnHistories();
+			expiries = new ExpiryManager(recordCache(), histories);
 		}
 		return expiries;
 	}
@@ -1071,6 +1070,7 @@ public class ServicesContext {
 	public ExpiringCreations creator() {
 		if (creator == null) {
 			creator = new ExpiringCreations(expiries(), properties(), globalDynamicProperties());
+			creator.setRecordCache(recordCache());
 		}
 		return creator;
 	}

--- a/hedera-node/src/main/java/com/hedera/services/context/ServicesContext.java
+++ b/hedera-node/src/main/java/com/hedera/services/context/ServicesContext.java
@@ -1062,14 +1062,14 @@ public class ServicesContext {
 
 	public ExpiryManager expiries() {
 		if (expiries == null) {
-			expiries = new ExpiryManager(txnHistories());
+			expiries = new ExpiryManager(recordCache(), txnHistories());
 		}
 		return expiries;
 	}
 
 	public ExpiringCreations creator() {
 		if (creator == null) {
-			creator = new ExpiringCreations(expiries(), properties());
+			creator = new ExpiringCreations(expiries(), properties(), globalDynamicProperties());
 		}
 		return creator;
 	}

--- a/hedera-node/src/main/java/com/hedera/services/context/ServicesContext.java
+++ b/hedera-node/src/main/java/com/hedera/services/context/ServicesContext.java
@@ -1062,7 +1062,8 @@ public class ServicesContext {
 
 	public ExpiryManager expiries() {
 		if (expiries == null) {
-			expiries = new ExpiryManager(recordCache(), txnHistories());
+			expiries = new ExpiryManager(txnHistories());
+			expiries.setRecordCache(recordCache());
 		}
 		return expiries;
 	}

--- a/hedera-node/src/main/java/com/hedera/services/context/properties/BootstrapProperties.java
+++ b/hedera-node/src/main/java/com/hedera/services/context/properties/BootstrapProperties.java
@@ -199,6 +199,7 @@ public class BootstrapProperties implements PropertySource {
 	static final Set<String> GLOBAL_DYNAMIC_PROPS = Set.of(
 			"contracts.defaultReceiveThreshold",
 			"contracts.defaultSendThreshold",
+			"ledger.createPayerRecords",
 			"ledger.createThresholdRecords",
 			"ledger.maxAccountNum",
 			"tokens.maxPerAccount",
@@ -240,6 +241,7 @@ public class BootstrapProperties implements PropertySource {
 			entry("bootstrap.rates.nextCentEquiv", AS_INT),
 			entry("bootstrap.rates.nextExpiry", AS_LONG),
 			entry("bootstrap.system.entityExpiry", AS_LONG),
+			entry("ledger.createPayerRecords", AS_BOOLEAN),
 			entry("ledger.createThresholdRecords", AS_BOOLEAN),
 			entry("ledger.maxAccountNum", AS_LONG),
 			entry("ledger.numSystemAccounts", AS_INT),

--- a/hedera-node/src/main/java/com/hedera/services/context/properties/GlobalDynamicProperties.java
+++ b/hedera-node/src/main/java/com/hedera/services/context/properties/GlobalDynamicProperties.java
@@ -28,6 +28,7 @@ public class GlobalDynamicProperties {
 	private long maxAccountNum;
 	private long defaultContractSendThreshold;
 	private long defaultContractReceiveThreshold;
+	private boolean shouldCreatePayerRecords;
 	private boolean shouldCreateThresholdRecords;
 
 	public GlobalDynamicProperties(PropertySource properties) {
@@ -37,6 +38,7 @@ public class GlobalDynamicProperties {
 	}
 
 	public void reload() {
+		shouldCreatePayerRecords = properties.getBooleanProperty("ledger.createPayerRecords");
 		shouldCreateThresholdRecords = properties.getBooleanProperty("ledger.createThresholdRecords");
 		maxTokensPerAccount = properties.getIntProperty("tokens.maxPerAccount");
 		maxTokensSymbolLength = properties.getIntProperty("tokens.maxSymbolLength");
@@ -63,6 +65,10 @@ public class GlobalDynamicProperties {
 
 	public long maxAccountNum() {
 		return maxAccountNum;
+	}
+
+	public boolean shouldCreatePayerRecords() {
+		return shouldCreatePayerRecords;
 	}
 
 	public boolean shouldCreateThresholdRecords() {

--- a/hedera-node/src/main/java/com/hedera/services/fees/calculation/crypto/queries/GetTxnRecordResourceUsage.java
+++ b/hedera-node/src/main/java/com/hedera/services/fees/calculation/crypto/queries/GetTxnRecordResourceUsage.java
@@ -23,7 +23,6 @@ package com.hedera.services.fees.calculation.crypto.queries;
 import com.hedera.services.context.primitives.StateView;
 import com.hedera.services.fees.calculation.FeeCalcUtils;
 import com.hedera.services.fees.calculation.QueryResourceUsageEstimator;
-import com.hedera.services.queries.AnswerService;
 import com.hedera.services.queries.answering.AnswerFunctions;
 import com.hedera.services.records.RecordCache;
 import com.hederahashgraph.api.proto.java.FeeData;

--- a/hedera-node/src/main/java/com/hedera/services/records/RecordCache.java
+++ b/hedera-node/src/main/java/com/hedera/services/records/RecordCache.java
@@ -147,4 +147,8 @@ public class RecordCache {
 		}
 		return null;
 	}
+
+	public void forgetAnyOtherExpiredHistory(long at) {
+		throw new AssertionError("Not implemented!");
+	}
 }

--- a/hedera-node/src/main/java/com/hedera/services/records/RecordCache.java
+++ b/hedera-node/src/main/java/com/hedera/services/records/RecordCache.java
@@ -63,7 +63,9 @@ public class RecordCache {
 			Map<TransactionID, TxnIdRecentHistory> histories
 	) {
 		this.creator = creator;
-		creator.setRecordCache(this);
+		if (creator != null) {
+			creator.setRecordCache(this);
+		}
 		this.histories = histories;
 		this.timedReceiptCache = timedReceiptCache;
 	}

--- a/hedera-node/src/main/java/com/hedera/services/records/RecordCache.java
+++ b/hedera-node/src/main/java/com/hedera/services/records/RecordCache.java
@@ -21,6 +21,7 @@ package com.hedera.services.records;
  */
 
 import com.google.common.cache.Cache;
+import com.hedera.services.context.ServicesContext;
 import com.hedera.services.legacy.core.jproto.TxnReceipt;
 import com.hedera.services.state.EntityCreator;
 import com.hedera.services.state.expiry.MonotonicFullQueueExpiries;
@@ -37,6 +38,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Random;
 
 import static com.hedera.services.utils.MiscUtils.asTimestamp;
 import static com.hedera.services.utils.MiscUtils.sha384HashOf;
@@ -51,21 +53,18 @@ public class RecordCache {
 
 	public static final Boolean MARKER = Boolean.TRUE;
 
-	private EntityCreator creator;
+	private ServicesContext ctx;
 	private Cache<TransactionID, Boolean> timedReceiptCache;
 	private Map<TransactionID, TxnIdRecentHistory> histories;
 
 	MonotonicFullQueueExpiries<TransactionID> recordExpiries = new MonotonicFullQueueExpiries<>();
 
 	public RecordCache(
-			EntityCreator creator,
+			ServicesContext ctx,
 			Cache<TransactionID, Boolean> timedReceiptCache,
 			Map<TransactionID, TxnIdRecentHistory> histories
 	) {
-		this.creator = creator;
-		if (creator != null) {
-			creator.setRecordCache(this);
-		}
+		this.ctx = ctx;
 		this.histories = histories;
 		this.timedReceiptCache = timedReceiptCache;
 	}
@@ -97,7 +96,7 @@ public class RecordCache {
 				.setTransactionHash(sha384HashOf(accessor))
 				.setConsensusTimestamp(asTimestamp(consensusTimestamp))
 				.build();
-		var record = creator.createExpiringPayerRecord(
+		var record = ctx.creator().createExpiringPayerRecord(
 				effectivePayer,
 				grpc,
 				consensusTimestamp.getEpochSecond(),

--- a/hedera-node/src/main/java/com/hedera/services/state/EntityCreator.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/EntityCreator.java
@@ -21,12 +21,14 @@ package com.hedera.services.state;
  */
 
 import com.hedera.services.ledger.HederaLedger;
+import com.hedera.services.records.RecordCache;
 import com.hedera.services.state.submerkle.ExpirableTxnRecord;
 import com.hederahashgraph.api.proto.java.AccountID;
 import com.hederahashgraph.api.proto.java.TransactionRecord;
 
 public interface EntityCreator {
 	void setLedger(HederaLedger ledger);
+	void setRecordCache(RecordCache recordCache);
 	void createExpiringHistoricalRecord(AccountID id, TransactionRecord record, long now, long submittingMember);
 	ExpirableTxnRecord createExpiringPayerRecord(AccountID id, TransactionRecord record, long now, long submittingMember);
 }

--- a/hedera-node/src/main/java/com/hedera/services/state/expiry/ExpiringCreations.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/expiry/ExpiringCreations.java
@@ -23,6 +23,7 @@ package com.hedera.services.state.expiry;
 import com.hedera.services.context.properties.GlobalDynamicProperties;
 import com.hedera.services.context.properties.PropertySource;
 import com.hedera.services.ledger.HederaLedger;
+import com.hedera.services.records.RecordCache;
 import com.hedera.services.state.EntityCreator;
 import com.hedera.services.state.submerkle.ExpirableTxnRecord;
 import com.hederahashgraph.api.proto.java.AccountID;
@@ -37,6 +38,8 @@ public class ExpiringCreations implements EntityCreator {
 	private ExpirableTxnRecord currentExpirableRecord = null;
 
 	private HederaLedger ledger;
+	private RecordCache recordCache;
+	private final ExpiryManager expiries;
 	private final PropertySource properties;
 	private final GlobalDynamicProperties dynamicProperties;
 
@@ -50,20 +53,39 @@ public class ExpiringCreations implements EntityCreator {
 			PropertySource properties,
 			GlobalDynamicProperties dynamicProperties
 	) {
+		this.expiries = expiries;
 		this.properties = properties;
 		this.dynamicProperties = dynamicProperties;
 
-		payerTracker = expiries::trackPayerRecord;
+		payerTracker = this::trackPayerRecord;
 		historicalTracker = expiries::trackHistoricalRecord;
 	}
 
+	@Override
+	public void setRecordCache(RecordCache recordCache) {
+		this.recordCache = recordCache;
+	}
+
+	@Override
 	public void setLedger(HederaLedger ledger) {
 		this.ledger = ledger;
-		payerRecordFn = ledger::addPayerRecord;
+		payerRecordFn = this::updatePayerRecord;
 		historicalRecordFn = ledger::addRecord;
 	}
 
-	private long updateForPayerRecord(AccountID id, ExpirableTxnRecord record) {
+	private void trackPayerRecord(AccountID effectivePayer, long expiry) {
+		if (dynamicProperties.shouldCreatePayerRecords()) {
+			expiries.trackPayerRecord(effectivePayer, expiry);
+		}
+	}
+
+	private long updatePayerRecord(AccountID id, ExpirableTxnRecord record) {
+		if (dynamicProperties.shouldCreatePayerRecords()) {
+			return ledger.addPayerRecord(id, record);
+		} else {
+			recordCache.trackForExpiry(record);
+			return 0L;
+		}
 	}
 
 	@Override

--- a/hedera-node/src/main/java/com/hedera/services/state/expiry/ExpiringCreations.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/expiry/ExpiringCreations.java
@@ -20,6 +20,7 @@ package com.hedera.services.state.expiry;
  * ‍
  */
 
+import com.hedera.services.context.properties.GlobalDynamicProperties;
 import com.hedera.services.context.properties.PropertySource;
 import com.hedera.services.ledger.HederaLedger;
 import com.hedera.services.state.EntityCreator;
@@ -35,23 +36,34 @@ public class ExpiringCreations implements EntityCreator {
 	private TransactionRecord currentRecord = null;
 	private ExpirableTxnRecord currentExpirableRecord = null;
 
+	private HederaLedger ledger;
 	private final PropertySource properties;
+	private final GlobalDynamicProperties dynamicProperties;
 
 	private ObjLongConsumer<AccountID> payerTracker;
 	private ObjLongConsumer<AccountID> historicalTracker;
 	private ToLongBiFunction<AccountID, ExpirableTxnRecord> payerRecordFn;
 	private ToLongBiFunction<AccountID, ExpirableTxnRecord> historicalRecordFn;
 
-	public ExpiringCreations(ExpiryManager expiries, PropertySource properties) {
+	public ExpiringCreations(
+			ExpiryManager expiries,
+			PropertySource properties,
+			GlobalDynamicProperties dynamicProperties
+	) {
 		this.properties = properties;
+		this.dynamicProperties = dynamicProperties;
 
 		payerTracker = expiries::trackPayerRecord;
 		historicalTracker = expiries::trackHistoricalRecord;
 	}
 
 	public void setLedger(HederaLedger ledger) {
+		this.ledger = ledger;
 		payerRecordFn = ledger::addPayerRecord;
 		historicalRecordFn = ledger::addRecord;
+	}
+
+	private long updateForPayerRecord(AccountID id, ExpirableTxnRecord record) {
 	}
 
 	@Override

--- a/hedera-node/src/main/java/com/hedera/services/state/expiry/ExpiryManager.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/expiry/ExpiryManager.java
@@ -39,16 +39,19 @@ import java.util.List;
 import java.util.Map;
 
 public class ExpiryManager {
-	private final RecordCache recordCache;
 	private final Map<TransactionID, TxnIdRecentHistory> txnHistories;
+	private RecordCache recordCache;
 
 	long sharedNow;
 	MonotonicFullQueueExpiries<Long> payerExpiries = new MonotonicFullQueueExpiries<>();
 	MonotonicFullQueueExpiries<Long> historicalExpiries = new MonotonicFullQueueExpiries<>();
 
-	public ExpiryManager(RecordCache recordCache, Map<TransactionID, TxnIdRecentHistory> txnHistories) {
-		this.recordCache = recordCache;
+	public ExpiryManager(Map<TransactionID, TxnIdRecentHistory> txnHistories) {
 		this.txnHistories = txnHistories;
+	}
+
+	public void setRecordCache(RecordCache recordCache) {
+		this.recordCache = recordCache;
 	}
 
 	public void trackHistoricalRecord(AccountID payer, long expiry) {

--- a/hedera-node/src/main/java/com/hedera/services/state/expiry/ExpiryManager.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/expiry/ExpiryManager.java
@@ -20,7 +20,6 @@ package com.hedera.services.state.expiry;
  * ‍
  */
 
-import com.hedera.services.context.properties.GlobalDynamicProperties;
 import com.hedera.services.ledger.HederaLedger;
 import com.hedera.services.records.RecordCache;
 import com.hedera.services.records.TxnIdRecentHistory;
@@ -39,19 +38,19 @@ import java.util.List;
 import java.util.Map;
 
 public class ExpiryManager {
+	private final RecordCache recordCache;
 	private final Map<TransactionID, TxnIdRecentHistory> txnHistories;
-	private RecordCache recordCache;
 
 	long sharedNow;
 	MonotonicFullQueueExpiries<Long> payerExpiries = new MonotonicFullQueueExpiries<>();
 	MonotonicFullQueueExpiries<Long> historicalExpiries = new MonotonicFullQueueExpiries<>();
 
-	public ExpiryManager(Map<TransactionID, TxnIdRecentHistory> txnHistories) {
-		this.txnHistories = txnHistories;
-	}
-
-	public void setRecordCache(RecordCache recordCache) {
+	public ExpiryManager(
+			RecordCache recordCache,
+			Map<TransactionID, TxnIdRecentHistory> txnHistories
+	) {
 		this.recordCache = recordCache;
+		this.txnHistories = txnHistories;
 	}
 
 	public void trackHistoricalRecord(AccountID payer, long expiry) {

--- a/hedera-node/src/main/java/com/hedera/services/state/expiry/NoopExpiringCreations.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/expiry/NoopExpiringCreations.java
@@ -21,6 +21,7 @@ package com.hedera.services.state.expiry;
  */
 
 import com.hedera.services.ledger.HederaLedger;
+import com.hedera.services.records.RecordCache;
 import com.hedera.services.state.EntityCreator;
 import com.hedera.services.state.submerkle.ExpirableTxnRecord;
 import com.hederahashgraph.api.proto.java.AccountID;
@@ -31,6 +32,9 @@ public enum NoopExpiringCreations implements EntityCreator {
 
 	@Override
 	public void setLedger(HederaLedger ledger) { }
+
+	@Override
+	public void setRecordCache(RecordCache recordCache) { }
 
 	@Override
 	public ExpirableTxnRecord createExpiringPayerRecord(

--- a/hedera-node/src/main/resources/bootstrap.properties
+++ b/hedera-node/src/main/resources/bootstrap.properties
@@ -41,6 +41,7 @@ ledger.totalTinyBarFloat=5000000000000000000
 # Global dynamic properties
 contracts.defaultReceiveThreshold=5000000000000000000
 contracts.defaultSendThreshold=5000000000000000000
+ledger.createPayerRecords=false
 ledger.createThresholdRecords=false
 ledger.maxAccountNum=100000000
 tokens.maxPerAccount=1000

--- a/hedera-node/src/test/java/com/hedera/services/context/ServicesContextTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/context/ServicesContextTest.java
@@ -126,7 +126,6 @@ import org.junit.runner.RunWith;
 import org.mockito.InOrder;
 
 import java.time.Instant;
-import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;

--- a/hedera-node/src/test/java/com/hedera/services/context/properties/BootstrapPropertiesTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/context/properties/BootstrapPropertiesTest.java
@@ -86,6 +86,7 @@ class BootstrapPropertiesTest {
 			entry("hedera.numReservedSystemEntities", 1_000L),
 			entry("hedera.realm", 0L),
 			entry("hedera.shard", 0L),
+			entry("ledger.createPayerRecords", false),
 			entry("ledger.createThresholdRecords", false),
 			entry("ledger.maxAccountNum", 100_000_000L),
 			entry("ledger.numSystemAccounts", 100),

--- a/hedera-node/src/test/java/com/hedera/services/context/properties/GlobalDynamicPropertiesTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/context/properties/GlobalDynamicPropertiesTest.java
@@ -50,6 +50,7 @@ class GlobalDynamicPropertiesTest {
 		subject = new GlobalDynamicProperties(properties);
 
 		// expect:
+		assertFalse(subject.shouldCreatePayerRecords());
 		assertFalse(subject.shouldCreateThresholdRecords());
 		assertEquals(1, subject.maxTokensPerAccount());
 		assertEquals(2, subject.maxTokenSymbolLength());
@@ -66,6 +67,7 @@ class GlobalDynamicPropertiesTest {
 		subject = new GlobalDynamicProperties(properties);
 
 		// expect:
+		assertTrue(subject.shouldCreatePayerRecords());
 		assertTrue(subject.shouldCreateThresholdRecords());
 		assertEquals(2, subject.maxTokensPerAccount());
 		assertEquals(3, subject.maxTokenSymbolLength());
@@ -77,6 +79,7 @@ class GlobalDynamicPropertiesTest {
 	private void givenPropsWithSeed(int i) {
 		given(properties.getIntProperty("tokens.maxPerAccount")).willReturn(i);
 		given(properties.getIntProperty("tokens.maxSymbolLength")).willReturn(i + 1);
+		given(properties.getBooleanProperty("ledger.createPayerRecords")).willReturn((i % 2) == 0);
 		given(properties.getBooleanProperty("ledger.createThresholdRecords")).willReturn((i % 2) == 0);
 		given(properties.getLongProperty("ledger.maxAccountNum")).willReturn((long)i + 2);
 		given(properties.getLongProperty("contracts.defaultSendThreshold")).willReturn((long)i + 3);

--- a/hedera-node/src/test/java/com/hedera/services/legacy/unit/FreezeServiceImplTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/legacy/unit/FreezeServiceImplTest.java
@@ -27,13 +27,11 @@ import com.hedera.services.config.MockEntityNumbers;
 import com.hedera.services.context.properties.PropertySource;
 import com.hedera.services.fees.StandardExemptions;
 import com.hedera.services.legacy.services.context.ContextPlatformStatus;
-import com.hedera.services.records.TxnIdRecentHistory;
 import com.hedera.services.security.ops.SystemOpPolicies;
 import com.hedera.services.state.merkle.MerkleAccount;
 import com.hedera.services.state.merkle.MerkleTopic;
 import com.hedera.services.context.primitives.StateView;
 import com.hedera.services.fees.HbarCentExchange;
-import com.hedera.services.legacy.config.PropertiesLoader;
 import com.hedera.services.legacy.core.jproto.JKey;
 import com.hedera.services.legacy.handler.TransactionHandler;
 import com.hedera.services.state.merkle.MerkleEntityId;
@@ -70,7 +68,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.platform.runner.JUnitPlatform;
 import org.junit.runner.RunWith;
-import org.mockito.Mockito;
 
 import java.security.KeyPair;
 import java.security.PrivateKey;
@@ -82,7 +79,6 @@ import static com.hedera.test.mocks.TestUsagePricesProvider.TEST_USAGE_PRICES;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_FREEZE_TRANSACTION_BODY;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OK;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.when;
 import static org.mockito.BDDMockito.*;
 
 /**

--- a/hedera-node/src/test/java/com/hedera/services/legacy/unit/PreCheckValidationTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/legacy/unit/PreCheckValidationTest.java
@@ -88,8 +88,6 @@ import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.junit.platform.runner.JUnitPlatform;
 import org.junit.runner.RunWith;
 
-import javax.naming.Context;
-
 import static com.hedera.test.mocks.TestExchangeRates.TEST_EXCHANGE;
 import static com.hedera.test.mocks.TestUsagePricesProvider.TEST_USAGE_PRICES;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OK;

--- a/hedera-node/src/test/java/com/hedera/services/legacy/unit/QueryValidationTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/legacy/unit/QueryValidationTest.java
@@ -25,7 +25,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import com.hedera.services.config.MockAccountNumbers;
 import com.hedera.services.config.MockEntityNumbers;
 import com.hedera.services.fees.StandardExemptions;
-import com.hedera.services.legacy.config.PropertiesLoader;
 import com.hedera.services.legacy.handler.TransactionHandler;
 import com.hedera.services.legacy.service.GlobalFlag;
 import com.hedera.services.legacy.services.context.ContextPlatformStatus;

--- a/hedera-node/src/test/java/com/hedera/services/legacy/unit/handler/TransactionHandlerTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/legacy/unit/handler/TransactionHandlerTest.java
@@ -45,18 +45,14 @@ import com.hederahashgraph.api.proto.java.TransactionID;
 import com.swirlds.common.Platform;
 import com.swirlds.common.PlatformStatus;
 import com.swirlds.fcmap.FCMap;
-import org.junit.Assert;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 import org.junit.platform.runner.JUnitPlatform;
 import org.junit.runner.RunWith;
 
 import java.util.function.Supplier;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 @RunWith(JUnitPlatform.class)

--- a/hedera-node/src/test/java/com/hedera/services/legacy/unit/service/SmartContractServiceImplTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/legacy/unit/service/SmartContractServiceImplTest.java
@@ -37,7 +37,6 @@ import com.google.protobuf.ByteString;
 import com.hedera.services.config.MockAccountNumbers;
 import com.hedera.services.config.MockEntityNumbers;
 import com.hedera.services.config.MockGlobalDynamicProps;
-import com.hedera.services.context.ServicesNodeType;
 import com.hedera.services.context.properties.PropertySource;
 import com.hedera.services.fees.StandardExemptions;
 import com.hedera.services.legacy.services.context.ContextPlatformStatus;

--- a/hedera-node/src/test/java/com/hedera/services/records/RecordCacheFactoryTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/records/RecordCacheFactoryTest.java
@@ -20,15 +20,12 @@ package com.hedera.services.records;
  * ‍
  */
 
-import com.google.common.cache.Cache;
 import com.hedera.services.context.properties.PropertySource;
 import com.hederahashgraph.api.proto.java.TransactionID;
 import com.hederahashgraph.api.proto.java.TransactionRecord;
 import org.junit.jupiter.api.Test;
 import org.junit.platform.runner.JUnitPlatform;
 import org.junit.runner.RunWith;
-
-import java.util.Optional;
 
 import static com.hedera.services.utils.SleepingPause.INSTANCE;
 import static com.hedera.test.utils.IdUtils.asAccount;

--- a/hedera-node/src/test/java/com/hedera/services/records/RecordCacheTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/records/RecordCacheTest.java
@@ -43,6 +43,7 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 
 import java.time.Instant;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -126,12 +127,15 @@ class RecordCacheTest {
 	@Test
 	public void expiresOtherForgottenHistory() {
 		// setup:
+		subject = new RecordCache(creator, receiptCache, new HashMap<>());
+
+		// given:
 		record.setExpiry(someExpiry);
 		subject.setPostConsensus(txnIdA, SUCCESS, record);
 		subject.trackForExpiry(record);
 
 		// when:
-		subject.forgetAnyOtherExpiredHistory(someExpiry - 1);
+		subject.forgetAnyOtherExpiredHistory(someExpiry + 1);
 
 		// then:
 		assertFalse(subject.isReceiptPresent(txnIdA));

--- a/hedera-node/src/test/java/com/hedera/services/state/expiry/ExpiringCreationsTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/state/expiry/ExpiringCreationsTest.java
@@ -20,6 +20,7 @@ package com.hedera.services.state.expiry;
  * ‍
  */
 
+import com.hedera.services.context.properties.GlobalDynamicProperties;
 import com.hedera.services.context.properties.PropertySource;
 import com.hedera.services.ledger.HederaLedger;
 import com.hedera.services.state.serdes.DomainSerdesTest;
@@ -48,16 +49,18 @@ class ExpiringCreationsTest {
 	ExpiryManager expiries;
 	PropertySource properties;
 	ExpiringCreations subject;
+	GlobalDynamicProperties dynamicProperties;
 
 	@BeforeEach
 	public void setup() {
 		ledger = mock(HederaLedger.class);
 		expiries = mock(ExpiryManager.class);
 		properties = mock(PropertySource.class);
+		dynamicProperties = mock(GlobalDynamicProperties.class);
 		given(properties.getIntProperty("ledger.records.ttl")).willReturn(historyTtl);
 		given(properties.getIntProperty("cache.records.ttl")).willReturn(cacheTtl);
 
-		subject = new ExpiringCreations(expiries, properties);
+		subject = new ExpiringCreations(expiries, properties, dynamicProperties);
 		subject.setLedger(ledger);
 	}
 

--- a/hedera-node/src/test/java/com/hedera/services/state/expiry/ExpiryManagerTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/state/expiry/ExpiryManagerTest.java
@@ -86,7 +86,8 @@ class ExpiryManagerTest {
 
 		ledger = mock(HederaLedger.class);
 
-		subject = new ExpiryManager(recordCache, txnHistories);
+		subject = new ExpiryManager(txnHistories);
+		subject.setRecordCache(recordCache);
 	}
 
 	@Test

--- a/hedera-node/src/test/java/com/hedera/services/state/expiry/ExpiryManagerTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/state/expiry/ExpiryManagerTest.java
@@ -23,6 +23,7 @@ package com.hedera.services.state.expiry;
 import com.hedera.services.ledger.HederaLedger;
 import com.hedera.services.legacy.core.jproto.TxnId;
 import com.hedera.services.legacy.core.jproto.TxnReceipt;
+import com.hedera.services.records.RecordCache;
 import com.hedera.services.records.TxnIdRecentHistory;
 import com.hedera.services.state.merkle.MerkleAccount;
 import com.hedera.services.state.merkle.MerkleEntityId;
@@ -70,6 +71,7 @@ class ExpiryManagerTest {
 	long expiry = 1_234_567L;
 	AccountID payer = IdUtils.asAccount("0.0.13257");
 
+	RecordCache recordCache;
 	HederaLedger ledger;
 	FCMap<MerkleEntityId, MerkleAccount> accounts;
 	Map<TransactionID, TxnIdRecentHistory> txnHistories;
@@ -80,10 +82,11 @@ class ExpiryManagerTest {
 	public void setup() {
 		accounts = new FCMap<>();
 		txnHistories = new HashMap<>();
+		recordCache = mock(RecordCache.class);
 
 		ledger = mock(HederaLedger.class);
 
-		subject = new ExpiryManager(txnHistories);
+		subject = new ExpiryManager(recordCache, txnHistories);
 	}
 
 	@Test
@@ -111,6 +114,8 @@ class ExpiryManagerTest {
 		// and:
 		System.out.println("Final payerExpiries: " + subject.payerExpiries.allExpiries);
 		System.out.println("Final historicalExpiries: " + subject.historicalExpiries.allExpiries);
+		// and:
+		verify(recordCache).forgetAnyOtherExpiredHistory(33);
 	}
 
 	private AccountID asAccount(long num) {

--- a/hedera-node/src/test/java/com/hedera/services/state/expiry/ExpiryManagerTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/state/expiry/ExpiryManagerTest.java
@@ -86,8 +86,7 @@ class ExpiryManagerTest {
 
 		ledger = mock(HederaLedger.class);
 
-		subject = new ExpiryManager(txnHistories);
-		subject.setRecordCache(recordCache);
+		subject = new ExpiryManager(recordCache, txnHistories);
 	}
 
 	@Test

--- a/hedera-node/src/test/java/com/hedera/test/mocks/TestFeesFactory.java
+++ b/hedera-node/src/test/java/com/hedera/test/mocks/TestFeesFactory.java
@@ -23,7 +23,6 @@ package com.hedera.test.mocks;
 import com.google.common.cache.CacheBuilder;
 import com.hedera.services.context.properties.BootstrapProperties;
 import com.hedera.services.context.properties.PropertySource;
-import com.hedera.services.context.properties.PropertySources;
 import com.hedera.services.context.properties.StandardizedPropertySources;
 import com.hedera.services.fees.FeeCalculator;
 import com.hedera.services.fees.HbarCentExchange;
@@ -54,10 +53,8 @@ import com.hedera.services.fees.calculation.file.txns.SystemUndeleteFileResource
 import com.hedera.services.fees.calculation.system.txns.FreezeResourceUsage;
 import com.hedera.services.queries.answering.AnswerFunctions;
 import com.hedera.services.records.RecordCache;
-import com.hedera.services.records.RecordCacheFactory;
 import com.hederahashgraph.api.proto.java.HederaFunctionality;
 import com.hederahashgraph.fee.CryptoFeeBuilder;
-import com.hederahashgraph.fee.FeeObject;
 import com.hederahashgraph.fee.FileFeeBuilder;
 import com.hederahashgraph.fee.SmartContractFeeBuilder;
 

--- a/hedera-node/src/test/resources/bootstrap/standard.properties
+++ b/hedera-node/src/test/resources/bootstrap/standard.properties
@@ -41,6 +41,7 @@ ledger.totalTinyBarFloat=5000000000000000000
 # Global dynamic properties
 contracts.defaultReceiveThreshold=5000000000000000000
 contracts.defaultSendThreshold=5000000000000000000
+ledger.createPayerRecords=false
 ledger.createThresholdRecords=false
 ledger.maxAccountNum=100000000
 tokens.maxPerAccount=1000

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/misc/PerpetualTransfers.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/misc/PerpetualTransfers.java
@@ -47,7 +47,7 @@ public class PerpetualTransfers extends HapiApiSuite {
 
 	private AtomicLong duration = new AtomicLong(Long.MAX_VALUE);
 	private AtomicReference<TimeUnit> unit = new AtomicReference<>(MINUTES);
-	private AtomicInteger maxOpsPerSec = new AtomicInteger(10);
+	private AtomicInteger maxOpsPerSec = new AtomicInteger(500);
 
 	public static void main(String... args) {
 		new PerpetualTransfers().runSuiteSync();
@@ -88,7 +88,9 @@ public class PerpetualTransfers extends HapiApiSuite {
 				var to = fromAtoB.get() ? "B" : "A";
 				fromAtoB.set(!fromAtoB.get());
 
-				var op = cryptoTransfer(tinyBarsFromTo(from, to, 1)).deferStatusResolution();
+				var op = cryptoTransfer(tinyBarsFromTo(from, to, 1))
+						.noLogging()
+						.deferStatusResolution();
 
 				return Optional.of(op);
 			}

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/misc/ReviewMainnetEntities.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/misc/ReviewMainnetEntities.java
@@ -79,19 +79,21 @@ public class ReviewMainnetEntities extends HapiApiSuite {
 	}
 
 	private HapiApiSpec xfer() {
-		final String NODES = "35.237.200.180:0.0.3";
+//		final String NODES = "35.237.200.180:0.0.3";
+		final String NODES = "34.94.106.61:0.0.3";
 		final long ONE_HBAR = 100_000_000L;
 		return customHapiSpec("xfer")
 				.withProperties(Map.of(
 						"nodes", NODES,
-						"default.payer", "0.0.950",
-						"startupAccounts.path", "src/main/resource/MainnetStartupAccount.txt"
+						"default.payer", "0.0.50",
+//						"startupAccounts.path", "src/main/resource/MainnetStartupAccount.txt"
+						"startupAccounts.path", "src/main/resource/StableTestnetAccount50StartupAccount.txt"
 				)).given(
 				).when(
-//						cryptoTransfer(tinyBarsFromTo(GENESIS, ADDRESS_BOOK_CONTROL, 100 * ONE_HBAR))
+						cryptoTransfer(tinyBarsFromTo(GENESIS, FEE_SCHEDULE_CONTROL, 100 * ONE_HBAR))
 				).then(
 						getAccountBalance(GENESIS).logged(),
-						getAccountBalance("0.0.55").logged()
+						getAccountBalance("0.0.56").logged()
 				);
 	}
 

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/misc/TogglePayerRecordUse.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/misc/TogglePayerRecordUse.java
@@ -1,0 +1,74 @@
+package com.hedera.services.bdd.suites.misc;
+
+/*-
+ * ‌
+ * Hedera Services Test Clients
+ * ​
+ * Copyright (C) 2018 - 2020 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import com.hedera.services.bdd.spec.HapiApiSpec;
+import com.hedera.services.bdd.spec.keys.KeyFactory;
+import com.hedera.services.bdd.spec.keys.KeyShape;
+import com.hedera.services.bdd.suites.HapiApiSuite;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static com.hedera.services.bdd.spec.HapiApiSpec.defaultHapiSpec;
+import static com.hedera.services.bdd.spec.keys.KeyShape.listOf;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.fileCreate;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.fileUpdate;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.keyFromPem;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.newKeyNamed;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.withOpContext;
+
+public class TogglePayerRecordUse extends HapiApiSuite {
+	private static final Logger log = LogManager.getLogger(TogglePayerRecordUse.class);
+
+	public static void main(String... args) throws Exception {
+		new TogglePayerRecordUse().runSuiteSync();
+	}
+
+	@Override
+	protected List<HapiApiSpec> getSpecsInSuite() {
+		return List.of(new HapiApiSpec[] {
+						changePayerRecordStateStorage(),
+				}
+		);
+	}
+
+	private HapiApiSpec changePayerRecordStateStorage() {
+		final String NEW_VALUE = "false";
+
+		return defaultHapiSpec("ChangePayerRecordStateStorage")
+				.given().when().then(
+						fileUpdate(APP_PROPERTIES).overridingProps(Map.of(
+								"ledger.createPayerRecords", NEW_VALUE
+						))
+				);
+	}
+
+	@Override
+	protected Logger getResultsLogger() {
+		return log;
+	}
+}


### PR DESCRIPTION
**Summary of change**
Introduce the `ledger.createPayerRecords` (default is `false`) flag to control if 3-min payer records should be added to the `payerRecords` FCQ of the effective payer for each consensus txn handled.