### PR TITLE
add a mock UpdateResult so that setAttr method of Hederafs doesnt return null

### DIFF
--- a/hedera-node/src/test/java/com/hedera/services/txns/file/FileUpdateTransitionLogicTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/txns/file/FileUpdateTransitionLogicTest.java
@@ -127,12 +127,14 @@ class FileUpdateTransitionLogicTest {
 	@Test
 	public void doesntUpdateWaclIfNoNew() {
 		// setup:
+		HederaFs.UpdateResult res = mock(HederaFs.UpdateResult.class);
 		ArgumentCaptor<JFileInfo> captor = ArgumentCaptor.forClass(JFileInfo.class);
 
 		givenTxnCtxUpdating(EnumSet.of(UpdateTarget.EXPIRY));
 		// and:
 		given(hfs.getattr(nonSysFileTarget)).willReturn(
 				new JFileInfo(false, oldWacl, oldExpiry));
+		given(hfs.setattr(any(), any())).willReturn(res);
 
 		// when:
 		subject.doStateTransition();
@@ -145,9 +147,11 @@ class FileUpdateTransitionLogicTest {
 
 	@Test
 	public void doesntOverwriteIfNoContents() {
+		HederaFs.UpdateResult res = mock(HederaFs.UpdateResult.class);
 		givenTxnCtxUpdating(EnumSet.of(UpdateTarget.EXPIRY, UpdateTarget.KEY));
 		// and:
 		given(hfs.getattr(nonSysFileTarget)).willReturn(oldAttr);
+		given(hfs.setattr(any(), any())).willReturn(res);
 
 		// when:
 		subject.doStateTransition();


### PR DESCRIPTION
Signed-off-by: Anirudh Ghanta <anirudh.ghanta@hedera.com>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `0<issue number>-<target branch>-<summary>`
-->

**Related issue(s)**:
Closes #617 

**Summary of the change**:
Mock the class 'UpdateResult' to remove the NPE logs.

**External impacts**:
None.

**Applicable documentation**
- [ ] Javadoc
- [ ] HAPI protobuf comments
- [ ] README
