### PR TITLE
Fix the TPS reduced by half for HCSSubmitMessage performance test 

### DIFF
--- a/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/providers/ops/consensus/RandomMessageSubmit.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/providers/ops/consensus/RandomMessageSubmit.java
@@ -98,10 +98,6 @@ public class RandomMessageSubmit implements OpProvider {
                         .hasKnownStatusFrom(permissibleOutcomes)
                         .hasPrecheckFrom(STANDARD_PERMISSIBLE_PRECHECKS);
 
-                if (r.nextBoolean()) {
-                        op = op.usePresetTimestamp();
-                }
-
                 return Optional.of(op);
         }
 }


### PR DESCRIPTION
Closes #578 

Passed test https://hedera-hashgraph.slack.com/archives/C018CBQBTGB/p1602113932103000 
Expected 7200 with 6 SuiteRunner processes and 4 clients and 300 maxOpsSec , achieved 7000 