### PR TITLE
Fix netty channels closing issue

### DIFF
--- a/test-clients/src/main/java/com/hedera/services/bdd/spec/HapiApiSpec.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/spec/HapiApiSpec.java
@@ -206,7 +206,7 @@ public class HapiApiSpec implements Runnable {
 		if (finalizingExecutor != null) {
 			finalizingExecutor.shutdown();
 		}
-		this.clients().closeChannels();
+		this.clients().tearDown();
 	}
 
 	private void exec(List<HapiSpecOperation> ops) {

--- a/test-clients/src/main/java/com/hedera/services/bdd/spec/HapiApiSpec.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/spec/HapiApiSpec.java
@@ -206,7 +206,6 @@ public class HapiApiSpec implements Runnable {
 		if (finalizingExecutor != null) {
 			finalizingExecutor.shutdown();
 		}
-		this.clients().tearDown();
 	}
 
 	private void exec(List<HapiSpecOperation> ops) {

--- a/test-clients/src/main/java/com/hedera/services/bdd/spec/HapiApiSpec.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/spec/HapiApiSpec.java
@@ -240,12 +240,8 @@ public class HapiApiSpec implements Runnable {
 			if (finishingError.get().isPresent()) {
 				status = FAILED;
 			}
-		} else {
-			if (finalizingExecutor != null) {
-				finalizingExecutor.shutdown();
-				this.clients().closeChannels();
-			}
 		}
+		tearDown();
 		log.info(logPrefix() + "final status: " + status + "!");
 
 		if(saveContextFlag) {
@@ -290,7 +286,6 @@ public class HapiApiSpec implements Runnable {
 
 	private void finishFinalizingOps() {
 		if (pendingOps.isEmpty()) {
-			finalizingExecutor.shutdown();
 			return;
 		}
 		log.info(logPrefix() + "executed " + numLedgerOpsExecuted.get() + " ledger ops.");
@@ -299,8 +294,6 @@ public class HapiApiSpec implements Runnable {
 			startFinalizingOps();
 		}
 		finalizingFuture.join();
-		finalizingExecutor.shutdown();
-		this.clients().closeChannels();
 	}
 
 	public void offerFinisher(HapiSpecOpFinisher finisher) {

--- a/test-clients/src/main/java/com/hedera/services/bdd/spec/HapiApiSpec.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/spec/HapiApiSpec.java
@@ -202,6 +202,13 @@ public class HapiApiSpec implements Runnable {
 		return true;
 	}
 
+	private void tearDown() {
+		if (finalizingExecutor != null) {
+			finalizingExecutor.shutdown();
+		}
+		this.clients().closeChannels();
+	}
+
 	private void exec(List<HapiSpecOperation> ops) {
 		if (status == ERROR) {
 			log.warn("'" + name + "' failed to initialize, being skipped!");

--- a/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/HapiApiClients.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/HapiApiClients.java
@@ -207,10 +207,25 @@ public class HapiApiClients {
 	/**
 	 * Close all netty channels that are opened for clients
 	 */
-	public void closeChannels() {
+	private void closeChannels() {
 		if (channels.isEmpty()) {
 			return;
 		}
 		channels.forEach(channel -> channel.shutdown());
+	}
+
+	private void clearStubs() {
+		scSvcStubs.clear();
+		consSvcStubs.clear();
+		fileSvcStubs.clear();
+		tokenSvcStubs.clear();
+		cryptoSvcStubs.clear();
+		freezeSvcStubs.clear();
+		networkSvcStubs.clear();
+	}
+
+	public void tearDown() {
+		closeChannels();
+		clearStubs();
 	}
 }

--- a/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/HapiApiClients.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/HapiApiClients.java
@@ -104,6 +104,20 @@ public class HapiApiClients {
 		return null;
 	}
 
+	private void addStubs(NodeConnectInfo node, String uri, boolean useTls) {
+		if (!channels.containsKey(uri)) {
+			ManagedChannel channel = createNettyChannel(node, useTls);
+			channels.put(uri, channel);
+			scSvcStubs.put(uri, SmartContractServiceGrpc.newBlockingStub(channel));
+			consSvcStubs.put(uri, ConsensusServiceGrpc.newBlockingStub(channel));
+			fileSvcStubs.put(uri, FileServiceGrpc.newBlockingStub(channel));
+			tokenSvcStubs.put(uri, TokenServiceGrpc.newBlockingStub(channel));
+			cryptoSvcStubs.put(uri, CryptoServiceGrpc.newBlockingStub(channel));
+			freezeSvcStubs.put(uri, FreezeServiceGrpc.newBlockingStub(channel));
+			networkSvcStubs.put(uri, NetworkServiceGrpc.newBlockingStub(channel));
+		}
+	}
+
 	private HapiApiClients(List<NodeConnectInfo> nodes, AccountID defaultNode) {
 		this.nodes = nodes;
 		stubIds = nodes
@@ -114,31 +128,8 @@ public class HapiApiClients {
 				.collect(toMap(NodeConnectInfo::getAccount, NodeConnectInfo::tlsUri));
 		int before = stubCount();
 		nodes.forEach(node -> {
-			String stubsId = node.uri();
-			if (!channels.containsKey(stubsId)) {
-				ManagedChannel channel = createNettyChannel(node, false);
-				channels.put(stubsId, channel);
-				scSvcStubs.put(stubsId, SmartContractServiceGrpc.newBlockingStub(channel));
-				consSvcStubs.put(stubsId, ConsensusServiceGrpc.newBlockingStub(channel));
-				fileSvcStubs.put(stubsId, FileServiceGrpc.newBlockingStub(channel));
-				tokenSvcStubs.put(stubsId, TokenServiceGrpc.newBlockingStub(channel));
-				cryptoSvcStubs.put(stubsId, CryptoServiceGrpc.newBlockingStub(channel));
-				freezeSvcStubs.put(stubsId, FreezeServiceGrpc.newBlockingStub(channel));
-				networkSvcStubs.put(stubsId, NetworkServiceGrpc.newBlockingStub(channel));
-			}
-
-			String tlsStubsId = node.tlsUri();
-			if (!channels.containsKey(tlsStubsId)) {
-				ManagedChannel tlsChannel = createNettyChannel(node, true);
-				channels.put(tlsStubsId, tlsChannel);
-				scSvcStubs.put(tlsStubsId, SmartContractServiceGrpc.newBlockingStub(tlsChannel));
-				consSvcStubs.put(tlsStubsId, ConsensusServiceGrpc.newBlockingStub(tlsChannel));
-				fileSvcStubs.put(tlsStubsId, FileServiceGrpc.newBlockingStub(tlsChannel));
-				tokenSvcStubs.put(tlsStubsId, TokenServiceGrpc.newBlockingStub(tlsChannel));
-				cryptoSvcStubs.put(tlsStubsId, CryptoServiceGrpc.newBlockingStub(tlsChannel));
-				freezeSvcStubs.put(tlsStubsId, FreezeServiceGrpc.newBlockingStub(tlsChannel));
-				networkSvcStubs.put(stubsId, NetworkServiceGrpc.newBlockingStub(tlsChannel));
-			}
+			addStubs(node, node.uri(), false);
+			addStubs(node, node.tlsUri(), true);
 		});
 		int after = stubCount();
 		this.defaultNode = defaultNode;

--- a/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/HapiApiClients.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/HapiApiClients.java
@@ -214,6 +214,7 @@ public class HapiApiClients {
 			return;
 		}
 		channels.forEach((uri, channel) -> channel.shutdown());
+		channels.clear();
 	}
 
 	private static void clearStubs() {

--- a/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/HapiApiClients.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/HapiApiClients.java
@@ -40,7 +40,6 @@ import com.hederahashgraph.service.proto.java.NetworkServiceGrpc.NetworkServiceB
 import com.hederahashgraph.service.proto.java.TokenServiceGrpc;
 import com.hederahashgraph.service.proto.java.TokenServiceGrpc.TokenServiceBlockingStub;
 import io.grpc.ManagedChannel;
-import io.grpc.ManagedChannelBuilder;
 import io.grpc.netty.GrpcSslContexts;
 import io.grpc.netty.NegotiationType;
 import io.grpc.netty.NettyChannelBuilder;
@@ -54,7 +53,6 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 
 import static java.util.stream.Collectors.toMap;
 
@@ -73,7 +71,7 @@ public class HapiApiClients {
 	private final List<NodeConnectInfo> nodes;
 	private final Map<AccountID, String> stubIds;
 	private final Map<AccountID, String> tlsStubIds;
-	private List<ManagedChannel> channels;
+	private static List<ManagedChannel> channels;
 
 	private final ManagedChannel createNettyChannel(NodeConnectInfo node, boolean useTls) {
 		try {
@@ -207,14 +205,14 @@ public class HapiApiClients {
 	/**
 	 * Close all netty channels that are opened for clients
 	 */
-	private void closeChannels() {
+	private static void closeChannels() {
 		if (channels.isEmpty()) {
 			return;
 		}
 		channels.forEach(channel -> channel.shutdown());
 	}
 
-	private void clearStubs() {
+	private static void clearStubs() {
 		scSvcStubs.clear();
 		consSvcStubs.clear();
 		fileSvcStubs.clear();
@@ -224,7 +222,7 @@ public class HapiApiClients {
 		networkSvcStubs.clear();
 	}
 
-	public void tearDown() {
+	public static void tearDown() {
 		closeChannels();
 		clearStubs();
 	}

--- a/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/HapiApiClients.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/HapiApiClients.java
@@ -118,27 +118,26 @@ public class HapiApiClients {
 			if (!channels.containsKey(stubsId)) {
 				ManagedChannel channel = createNettyChannel(node, false);
 				channels.put(stubsId, channel);
-				scSvcStubs.computeIfAbsent(stubsId, ignore -> SmartContractServiceGrpc.newBlockingStub(channel));
-				consSvcStubs.computeIfAbsent(stubsId, ignore -> ConsensusServiceGrpc.newBlockingStub(channel));
-				fileSvcStubs.computeIfAbsent(stubsId, ignore -> FileServiceGrpc.newBlockingStub(channel));
-				tokenSvcStubs.computeIfAbsent(stubsId, ignore -> TokenServiceGrpc.newBlockingStub(channel));
-				cryptoSvcStubs.computeIfAbsent(stubsId, ignore -> CryptoServiceGrpc.newBlockingStub(channel));
-				freezeSvcStubs.computeIfAbsent(stubsId, ignore -> FreezeServiceGrpc.newBlockingStub(channel));
-				networkSvcStubs.computeIfAbsent(stubsId, ignore -> NetworkServiceGrpc.newBlockingStub(channel));
+				scSvcStubs.put(stubsId, SmartContractServiceGrpc.newBlockingStub(channel));
+				consSvcStubs.put(stubsId, ConsensusServiceGrpc.newBlockingStub(channel));
+				fileSvcStubs.put(stubsId, FileServiceGrpc.newBlockingStub(channel));
+				tokenSvcStubs.put(stubsId, TokenServiceGrpc.newBlockingStub(channel));
+				cryptoSvcStubs.put(stubsId, CryptoServiceGrpc.newBlockingStub(channel));
+				freezeSvcStubs.put(stubsId, FreezeServiceGrpc.newBlockingStub(channel));
+				networkSvcStubs.put(stubsId, NetworkServiceGrpc.newBlockingStub(channel));
 			}
 
 			String tlsStubsId = node.tlsUri();
 			if (!channels.containsKey(tlsStubsId)) {
 				ManagedChannel tlsChannel = createNettyChannel(node, true);
 				channels.put(tlsStubsId, tlsChannel);
-				channels.computeIfAbsent(tlsStubsId, ignore -> tlsChannel);
-				scSvcStubs.computeIfAbsent(tlsStubsId, ignore -> SmartContractServiceGrpc.newBlockingStub(tlsChannel));
-				consSvcStubs.computeIfAbsent(tlsStubsId, ignore -> ConsensusServiceGrpc.newBlockingStub(tlsChannel));
-				fileSvcStubs.computeIfAbsent(tlsStubsId, ignore -> FileServiceGrpc.newBlockingStub(tlsChannel));
-				tokenSvcStubs.computeIfAbsent(tlsStubsId, ignore -> TokenServiceGrpc.newBlockingStub(tlsChannel));
-				cryptoSvcStubs.computeIfAbsent(tlsStubsId, ignore -> CryptoServiceGrpc.newBlockingStub(tlsChannel));
-				freezeSvcStubs.computeIfAbsent(tlsStubsId, ignore -> FreezeServiceGrpc.newBlockingStub(tlsChannel));
-				networkSvcStubs.computeIfAbsent(stubsId, ignore -> NetworkServiceGrpc.newBlockingStub(tlsChannel));
+				scSvcStubs.put(tlsStubsId, SmartContractServiceGrpc.newBlockingStub(tlsChannel));
+				consSvcStubs.put(tlsStubsId, ConsensusServiceGrpc.newBlockingStub(tlsChannel));
+				fileSvcStubs.put(tlsStubsId, FileServiceGrpc.newBlockingStub(tlsChannel));
+				tokenSvcStubs.put(tlsStubsId, TokenServiceGrpc.newBlockingStub(tlsChannel));
+				cryptoSvcStubs.put(tlsStubsId, CryptoServiceGrpc.newBlockingStub(tlsChannel));
+				freezeSvcStubs.put(tlsStubsId, FreezeServiceGrpc.newBlockingStub(tlsChannel));
+				networkSvcStubs.put(stubsId, NetworkServiceGrpc.newBlockingStub(tlsChannel));
 			}
 		});
 		int after = stubCount();

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/HapiApiSuite.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/HapiApiSuite.java
@@ -24,6 +24,7 @@ import com.google.common.math.Stats;
 import com.hedera.services.bdd.spec.HapiApiSpec;
 import com.hedera.services.bdd.spec.HapiSpecOperation;
 import com.hedera.services.bdd.spec.HapiSpecSetup;
+import com.hedera.services.bdd.spec.infrastructure.HapiApiClients;
 import com.hedera.services.bdd.spec.queries.HapiQueryOp;
 import com.hedera.services.bdd.spec.stats.HapiStats;
 import com.hedera.services.bdd.spec.stats.OpObs;
@@ -42,7 +43,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Random;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -138,6 +138,7 @@ public abstract class HapiApiSuite {
 		runner.accept(specs);
 		finalSpecs = specs;
 		summarizeResults(getResultsLogger());
+		HapiApiClients.tearDown();
 		return finalOutcomeFor(finalSpecs);
 	}
 


### PR DESCRIPTION
**Related issue(s)**:
Closes #659

**Summary of the change**:
- [x] Add correct tearDown function for HapiApiSpec, HapiApiSuite and HapiApiClients
- [x] Move the logic of tearing down clients to in suite instead of in spec.

**External impacts**:
None.

**Applicable documentation**
None.