### PR TITLE
Try hard-coding argLine

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -174,7 +174,8 @@
           <artifactId>maven-surefire-plugin</artifactId>
           <version>${maven-surefire.version}</version>
           <configuration>
-            <argLine>@{argLine} -Xmx2048m </argLine>
+            <argLine>-Xmx2048m -XX:MaxPermSize=256m</argLine>
+            <forkedProcessExitTimeoutInSeconds>120</forkedProcessExitTimeoutInSeconds>
           </configuration>
         </plugin>
         <plugin>


### PR DESCRIPTION
**Summary of the change**:
Change config for `maven-surefire-plugin` to avoid random crashes of forked VMs during `mvn test`.
