### PR TITLE
Revert Surefire argLine config

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -251,8 +251,7 @@ ${git.signoff}
           <artifactId>maven-surefire-plugin</artifactId>
           <version>${maven-surefire.version}</version>
           <configuration>
-            <argLine>-Xmx2048m -XX:MaxPermSize=256m</argLine>
-            <forkedProcessExitTimeoutInSeconds>120</forkedProcessExitTimeoutInSeconds>
+            <argLine>@{argLine} -Xmx2048m</argLine>
           </configuration>
         </plugin>
         <plugin>


### PR DESCRIPTION
Restore `@{argLine}` interpolation in Surefire config to get Jacoco reports  discoverable by CodeCov.