### PR TITLE
Add weekly performance regression tests.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -925,7 +925,9 @@ workflows:
   weekly-perf-start-from-saved-state-regression:
     triggers:
       - schedule:
-          cron: "0 1 * * 0,6"
+#  Make it run daily before converting to weekly
+#          cron: "0 1 * * 0,6"
+          cron: "0 21 * * *"
           filters:
             branches:
               only:
@@ -1030,7 +1032,7 @@ workflows:
   nightly-start-from-saved-state-regression:
     triggers:
       - schedule:
-          cron: "45 18,5 * * *"
+          cron: "30 20,5 * * *"
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -922,6 +922,27 @@ workflows:
                 at: /
           workflow-name: "nightly-performance-regression"
 
+  weekly-perf-start-from-saved-state-regression:
+    triggers:
+      - schedule:
+          cron: "0 1 * * 0,6"
+          filters:
+            branches:
+              only:
+                - master
+    jobs:
+      - build-platform-and-services
+      - weekly-run-start-from-saved-state-regression:
+          context: Slack
+          requires:
+            - build-platform-and-services
+          pre-steps:
+            - install-tools
+            - attach_workspace:
+                at: /
+          workflow-name: "weekly-perf-start-from-saved-state-regression"
+
+
   nightly-network-error-regression:
     triggers:
       - schedule:
@@ -1684,6 +1705,36 @@ jobs:
 
       - store_artifacts:
           path: /results.tar.gz
+
+  weekly-run-start-from-saved-state-regression:
+    parameters:
+      workflow-name:
+        type: string
+        default: ""
+    executor:
+      name: build-executor
+      workflow-name: << parameters.workflow-name >>
+    steps:
+      - run:
+          name: Modify Payer account for Public testnet start from saved state test
+          command: |
+            echo -n "$KEY_DevTestNetTreasury" > /repo/test-clients/src/main/resource/StartUpAccount.txt;
+      - run:
+          name: Run start from saved state regression tests
+          no_output_timeout: 60m
+          command: |
+            cd /swirlds-platform/regression;
+            ./regression_services_circleci.sh configs/services/weekly/15N_15C/AWS-Services-Weekly-Perf-StartFromState-15N-15C.json /repo
+
+      - run:
+          name: Sync results of software update regression to AWS
+          command: |
+            aws s3 sync /swirlds-platform/regression/results/ s3://hedera-service-regression-jrs;
+            tar -czvf /results.tar.gz  /swirlds-platform/regression/results/*
+
+      - store_artifacts:
+          path: /results.tar.gz
+
 
   build-platform-and-services:
     parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -927,7 +927,7 @@ workflows:
       - schedule:
 #  Make it run daily before converting to weekly
 #          cron: "0 1 * * 0,6"
-          cron: "0 21 * * *"
+          cron: "0 10,22 * * *"
           filters:
             branches:
               only:
@@ -1032,7 +1032,7 @@ workflows:
   nightly-start-from-saved-state-regression:
     triggers:
       - schedule:
-          cron: "30 20,5 * * *"
+          cron: "30 5,20 * * *"
           filters:
             branches:
               only:


### PR DESCRIPTION
**Related issue(s)**:
Closes #678

**Summary of the change**:
1. Enable 6-node JRS daily regression in hedera-regression channel;
2. Add the weekly performance regression tests for hedera services CryptoTransfer and HCS;
3. Currently starting from fresh instead of start from saved state as planned. Have hedera services issue #691 tracking this;

**External impacts**:
None.

**Applicable documentation**
- [ ] Javadoc
- [ ] HAPI protobuf comments
- [ ] README
