### PR TITLE
Add hbarTransfers field to TokenTransfersTransactionBody

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -804,23 +804,23 @@ commands:
       - run-eet-suites:
           dsl-args: "CryptoTransferSuite"
       - run-eet-suites:
-          dsl-args: "ContractCallLocalSuite -TLS=on -NODE=random"
+          dsl-args: "ContractCallLocalSuite -TLS=on"
       - run-eet-suites:
-          dsl-args: "ContractCallSuite -TLS=on -NODE=random"
+          dsl-args: "ContractCallSuite -TLS=on"
       - run-eet-suites:
-          dsl-args: "ChildStorageSpecs -TLS=on -NODE=random"
+          dsl-args: "ChildStorageSpecs -TLS=on"
       - run-eet-suites:
-          dsl-args: "BigArraySpec -TLS=on -NODE=random"
+          dsl-args: "BigArraySpec -TLS=on"
       - run-eet-suites:
-          dsl-args: "SmartContractInlineAssemblySpec -TLS=on -NODE=random"
+          dsl-args: "SmartContractInlineAssemblySpec -TLS=on"
       - run-eet-suites:
-          dsl-args: "OCTokenSpec -TLS=on -NODE=random"
+          dsl-args: "OCTokenSpec -TLS=on"
       - run-eet-suites:
-          dsl-args: "CharacterizationSuite -TLS=on -NODE=random"
+          dsl-args: "CharacterizationSuite -TLS=on"
       - run-eet-suites:
-          dsl-args: "SmartContractFailFirstSpec -TLS=on -NODE=random"
+          dsl-args: "SmartContractFailFirstSpec -TLS=on"
       - run-eet-suites:
-          dsl-args: "SmartContractSelfDestructSpec -TLS=on -NODE=random"
+          dsl-args: "SmartContractSelfDestructSpec -TLS=on"
       - run-eet-suites:
           dsl-args: "CryptoTransferSuite"
       - run-eet-suites:
@@ -2722,7 +2722,7 @@ jobs:
       - run-eet-suites:
           dsl-args: "SubmitMessageSpecs"
       - run-eet-suites:
-          dsl-args: "HCSTopicFragmentationSuite -TLS=alternate -NODE=random"
+          dsl-args: "HCSTopicFragmentationSuite -TLS=alternate"
       - run-eet-suites:
           dsl-args: "TopicGetInfoSpecs"
       - run-eet-suites:
@@ -2830,11 +2830,11 @@ jobs:
           dsl-args: "MultipleSelfDestructsAreSafe"
       - postgres-get-counts
       - run-eet-suites:
-          dsl-args: "ContractCallSuite -TLS=on -NODE=random"
+          dsl-args: "ContractCallSuite -TLS=on"
       - postgres-verify-counts:
           expected-difference: 17
       - run-eet-suites:
-          dsl-args: "ContractCallLocalSuite -TLS=on -NODE=random"
+          dsl-args: "ContractCallLocalSuite -TLS=on"
       - run-eet-suites:
           dsl-args: "ContractUpdateSuite -TLS=on"
       - run-eet-suites:

--- a/hapi-fees/pom.xml
+++ b/hapi-fees/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>com.hedera.services</groupId>
     <artifactId>hedera-services</artifactId>
-    <version>0.9.0-alpha.2-SNAPSHOT</version>
+    <version>0.9.0-alpha.6-SNAPSHOT</version>
   </parent>
 
   <properties>
@@ -21,7 +21,7 @@
     <dependency>
       <groupId>com.hedera.hashgraph</groupId>
       <artifactId>hedera-protobuf-java-api</artifactId>
-      <version>0.9.0-alpha.2-SNAPSHOT</version>
+      <version>0.9.0-alpha.6-SNAPSHOT</version>
     </dependency>
     <!-- Test dependencies -->
     <dependency>

--- a/hapi-fees/src/main/java/com/hedera/services/usage/token/TokenTransactUsage.java
+++ b/hapi-fees/src/main/java/com/hedera/services/usage/token/TokenTransactUsage.java
@@ -46,15 +46,19 @@ public class TokenTransactUsage extends TokenTxnUsage<TokenTransactUsage> {
 	public FeeData get() {
 		var op = this.op.getTokenTransfers();
 
-		int xfers = 0;
+		int hbarXfers = op.getHbarTransfers().getAccountAmountsCount();
+		int tokenXfers = 0;
 		long xferBytes = 0;
 		for (TokenTransferList transfer : op.getTokenTransfersList()) {
 			xferBytes += BASIC_ENTITY_ID_SIZE;
-			xfers += transfer.getTransfersCount();
+			tokenXfers += transfer.getTransfersCount();
 		}
-		xferBytes += xfers * usageProperties.accountAmountBytes();
+		xferBytes += (hbarXfers + tokenXfers) * usageProperties.accountAmountBytes();
 		usageEstimator.addBpt(xferBytes);
-		addTokenTransfersRecordRb(op.getTokenTransfersCount(), xfers);
+		if (hbarXfers > 0) {
+			addRecordRb(hbarXfers * usageProperties.accountAmountBytes());
+		}
+		addTokenTransfersRecordRb(op.getTokenTransfersCount(), tokenXfers);
 
 		return usageEstimator.get();
 	}

--- a/hapi-proto/pom.xml
+++ b/hapi-proto/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>com.hedera.services</groupId>
     <artifactId>hedera-services</artifactId>
-    <version>0.9.0-alpha.2-SNAPSHOT</version>
+    <version>0.9.0-alpha.6-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/hapi-proto/src/main/proto/BasicTypes.proto
+++ b/hapi-proto/src/main/proto/BasicTypes.proto
@@ -73,6 +73,11 @@ message AccountAmount {
     sint64 amount = 2; // The amount of tinybars (for Crypto transfers) or in the lowest denomination (for Token transfers) that the account sends(negative) or receives(positive)
 }
 
+/* A list of accounts and amounts to transfer out of each account (negative) or into it (positive). */
+message TransferList {
+    repeated AccountAmount accountAmounts = 1; // Multiple list of AccountAmount pairs, each of which has an account and an amount to transfer into it (positive) or out of it (negative)
+}
+
 /* A list of token IDs and amounts representing the transferred out (negative) or into (positive) amounts, represented in the lowest denomination of the token */
 message TokenTransferList {
     TokenID token = 1; // The ID of the token

--- a/hapi-proto/src/main/proto/CryptoTransfer.proto
+++ b/hapi-proto/src/main/proto/CryptoTransfer.proto
@@ -27,11 +27,6 @@ option java_multiple_files = true;
 
 import "BasicTypes.proto";
 
-/* A list of accounts and amounts to transfer out of each account (negative) or into it (positive). */
-message TransferList {
-    repeated AccountAmount accountAmounts = 1; // Multiple list of AccountAmount pairs, each of which has an account and an amount to transfer into it (positive) or out of it (negative)
-}
-
 /* Transfer cryptocurrency from some accounts to other accounts. The accounts list can contain up to 10 accounts. The amounts list must be the same length as the accounts list. Each negative amount is withdrawn from the corresponding account (a sender), and each positive one is added to the corresponding account (a receiver). The amounts list must sum to zero. Each amount is a number of tinyBars (there are 100,000,000 tinyBars in one Hbar).
 If any sender account fails to have sufficient hbars, then the entire transaction fails, and none of those transfers occur, though the transaction fee is still charged. This transaction must be signed by the keys for all the sending accounts, and for any receiving accounts that have receiverSigRequired == true. The signatures are in the same order as the accounts, skipping those accounts that don't need a signature.
 */

--- a/hapi-proto/src/main/proto/TokenTransfer.proto
+++ b/hapi-proto/src/main/proto/TokenTransfer.proto
@@ -35,4 +35,5 @@ If any sender account fails to have sufficient token balance, then the entire tr
 */
 message TokenTransfersTransactionBody {
     repeated TokenTransferList tokenTransfers = 1;
+    TransferList hbarTransfers = 2;
 }

--- a/hedera-node/pom.xml
+++ b/hedera-node/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>com.hedera.services</groupId>
     <artifactId>hedera-services</artifactId>
-    <version>0.9.0-alpha.2-SNAPSHOT</version>
+    <version>0.9.0-alpha.6-SNAPSHOT</version>
   </parent>
 
   <properties>
@@ -258,12 +258,12 @@
     <dependency>
       <groupId>com.hedera.services</groupId>
       <artifactId>hapi-fees</artifactId>
-      <version>0.9.0-alpha.2-SNAPSHOT</version>
+      <version>0.9.0-alpha.6-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>com.hedera.hashgraph</groupId>
       <artifactId>hedera-protobuf-java-api</artifactId>
-      <version>0.9.0-alpha.2-SNAPSHOT</version>
+      <version>0.9.0-alpha.6-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>com.swirlds</groupId>

--- a/hedera-node/src/main/java/com/hedera/services/ledger/HederaLedger.java
+++ b/hedera-node/src/main/java/com/hedera/services/ledger/HederaLedger.java
@@ -36,6 +36,7 @@ import com.hedera.services.state.merkle.MerkleAccountTokens;
 import com.hedera.services.state.merkle.MerkleTokenRelStatus;
 import com.hedera.services.state.submerkle.ExpirableTxnRecord;
 import com.hedera.services.tokens.TokenStore;
+import com.hedera.services.txns.crypto.CryptoTransferTransitionLogic;
 import com.hedera.services.utils.EntityIdUtils;
 import com.hederahashgraph.api.proto.java.AccountAmount;
 import com.hederahashgraph.api.proto.java.AccountID;
@@ -70,6 +71,7 @@ import static com.hedera.services.ledger.properties.AccountProperty.PAYER_RECORD
 import static com.hedera.services.ledger.properties.AccountProperty.TOKENS;
 import static com.hedera.services.ledger.properties.TokenRelProperty.TOKEN_BALANCE;
 import static com.hedera.services.tokens.TokenStore.MISSING_TOKEN;
+import static com.hedera.services.txns.crypto.CryptoTransferTransitionLogic.tryTransfers;
 import static com.hedera.services.txns.validation.TransferListChecks.isNetZeroAdjustment;
 import static com.hedera.services.utils.EntityIdUtils.readableId;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_TOKEN_ID;
@@ -349,7 +351,6 @@ public class HederaLedger {
 
 	public ResponseCodeEnum doAtomicZeroSumTokenTransfers(TokenTransfersTransactionBody transfers) {
 		var validity = OK;
-
 		for (TokenTransferList xfers : transfers.getTokenTransfersList()) {
 			var id = tokenStore.resolve(xfers.getToken());
 			if (id == MISSING_TOKEN) {
@@ -370,6 +371,14 @@ public class HederaLedger {
 		}
 		if (validity == OK) {
 			validity = checkNetOfTokenTransfers();
+		}
+		if (validity == OK) {
+			if (transfers.hasHbarTransfers()) {
+				var hbarTransfers = transfers.getHbarTransfers();
+				if (hbarTransfers.getAccountAmountsCount() > 0) {
+					validity = tryTransfers(this, hbarTransfers);
+				}
+			}
 		}
 		if (validity != OK) {
 			dropPendingTokenChanges();

--- a/hedera-node/src/main/java/com/hedera/services/ledger/HederaLedger.java
+++ b/hedera-node/src/main/java/com/hedera/services/ledger/HederaLedger.java
@@ -293,6 +293,9 @@ public class HederaLedger {
 
 		var tokens = (MerkleAccountTokens) accountsLedger.get(aId, TOKENS);
 		for (TokenID tId : tokens.asIds()) {
+			if (tokenStore.get(tId).isDeleted()) {
+				continue;
+			}
 			var relationship = asTokenRel(aId, tId);
 			var balance = (long)tokenRelsLedger.get(relationship, TOKEN_BALANCE);
 			if (balance > 0) {

--- a/hedera-node/src/main/java/com/hedera/services/legacy/evm/SolidityExecutor.java
+++ b/hedera-node/src/main/java/com/hedera/services/legacy/evm/SolidityExecutor.java
@@ -429,7 +429,6 @@ public class SolidityExecutor {
 				trackingRepository.commit();
 			}
 		} catch (Throwable e) {
-			e.printStackTrace();
 			if (e instanceof Program.OutOfGasException) {
 				BigInteger gasUpperBound = BigInteger.valueOf(PropertiesLoader.getMaxGasLimit());
 				BigInteger gasProvided = ByteUtil.bytesToBigInteger(solidityTxn.getGasLimit());

--- a/hedera-node/src/main/java/com/hedera/services/legacy/handler/SmartContractRequestHandler.java
+++ b/hedera-node/src/main/java/com/hedera/services/legacy/handler/SmartContractRequestHandler.java
@@ -254,7 +254,6 @@ public class SmartContractRequestHandler {
 					sbhInTinybars,
 					true);
 		} catch (Exception e) {
-			e.printStackTrace();
 			result = getFailureTransactionRecord(transaction, consensusTime, CONTRACT_EXECUTION_EXCEPTION);
 		}
 		if (result.getReceipt().getStatus() == SUCCESS) {
@@ -507,7 +506,6 @@ public class SmartContractRequestHandler {
 						record.getContractCallResult().getCreatedContractIDsList());
 				return record;
 			} catch (Exception e) {
-				e.printStackTrace();
 				return getFailureTransactionRecord(transaction, consensusTime, CONTRACT_EXECUTION_EXCEPTION);
 			}
 		} else {

--- a/hedera-node/src/main/java/com/hedera/services/txns/file/FileDeleteTransitionLogic.java
+++ b/hedera-node/src/main/java/com/hedera/services/txns/file/FileDeleteTransitionLogic.java
@@ -77,7 +77,6 @@ public class FileDeleteTransitionLogic implements TransitionLogic {
 			var result = hfs.delete(tbd);
 			txnCtx.setStatus(result.outcome());
 		} catch (Exception unknown) {
-			unknown.printStackTrace();
 			log.warn("Unrecognized failure handling {}!", txnCtx.accessor().getSignedTxn4Log(), unknown);
 			txnCtx.setStatus(FAIL_INVALID);
 		}

--- a/hedera-node/src/main/java/com/hedera/services/txns/file/FileUpdateTransitionLogic.java
+++ b/hedera-node/src/main/java/com/hedera/services/txns/file/FileUpdateTransitionLogic.java
@@ -124,7 +124,6 @@ public class FileUpdateTransitionLogic implements TransitionLogic {
 		} catch (IllegalArgumentException iae) {
 			mapToStatus(iae, txnCtx);
 		} catch (Exception unknown) {
-			unknown.printStackTrace();
 			log.warn("Unrecognized failure handling {}!", txnCtx.accessor().getSignedTxn4Log(), unknown);
 			txnCtx.setStatus(FAIL_INVALID);
 		}

--- a/hedera-node/src/main/java/com/hedera/services/txns/token/TokenTransferTransitionLogic.java
+++ b/hedera-node/src/main/java/com/hedera/services/txns/token/TokenTransferTransitionLogic.java
@@ -23,6 +23,7 @@ package com.hedera.services.txns.token;
 import com.hedera.services.context.TransactionContext;
 import com.hedera.services.ledger.HederaLedger;
 import com.hedera.services.txns.TransitionLogic;
+import com.hedera.services.txns.crypto.CryptoTransferTransitionLogic;
 import com.hedera.services.txns.validation.OptionValidator;
 import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
 import com.hederahashgraph.api.proto.java.TokenTransfersTransactionBody;
@@ -33,11 +34,11 @@ import org.apache.logging.log4j.Logger;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
+import static com.hedera.services.txns.crypto.CryptoTransferTransitionLogic.basicSyntaxChecks;
 import static com.hedera.services.txns.validation.TokenListChecks.checkTokenTransfers;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.FAIL_INVALID;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OK;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SUCCESS;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TOKEN_TRANSFER_LIST_SIZE_LIMIT_EXCEEDED;
 
 
 public class TokenTransferTransitionLogic implements TransitionLogic {
@@ -80,7 +81,12 @@ public class TokenTransferTransitionLogic implements TransitionLogic {
 	public ResponseCodeEnum validate(TransactionBody txnBody) {
 		TokenTransfersTransactionBody op = txnBody.getTokenTransfers();
 
-		var validity = validator.isAcceptableTokenTransfersLength(op.getTokenTransfersList());
+		var validity = basicSyntaxChecks(op.getHbarTransfers(), validator);
+		if (validity != OK) {
+			return validity;
+		}
+
+		validity = validator.isAcceptableTokenTransfersLength(op.getTokenTransfersList());
 		if (validity != OK) {
 			return validity;
 		}

--- a/hedera-node/src/test/java/com/hedera/services/ledger/BaseHederaLedgerTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/ledger/BaseHederaLedgerTest.java
@@ -210,6 +210,7 @@ public class BaseHederaLedgerTest {
 				.willReturn(frozenId);
 		given(tokenStore.resolve(tokenId))
 				.willReturn(tokenId);
+		given(tokenStore.get(frozenId)).willReturn(frozenToken);
 
 		subject = new HederaLedger(tokenStore, ids, creator, historian, accountsLedger);
 		subject.setTokenRelsLedger(tokenRelsLedger);

--- a/hedera-node/src/test/java/com/hedera/services/ledger/HederLedgerTokensTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/ledger/HederLedgerTokensTest.java
@@ -84,6 +84,14 @@ public class HederLedgerTokensTest extends BaseHederaLedgerTest {
 	}
 
 	@Test
+	public void ignoresNonZeroBalanceOfDeletedToken() {
+		given(frozenToken.isDeleted()).willReturn(true);
+		
+		// expect:
+		assertTrue(subject.allTokenBalancesVanish(misc));
+	}
+
+	@Test
 	public void throwsIfSubjectHasNoUsableTokenRelsLedger() {
 		subject.setTokenRelsLedger(HederaLedger.UNUSABLE_TOKEN_RELS_LEDGER);
 

--- a/hedera-node/src/test/java/com/hedera/services/sigs/order/HederaSigningOrderTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/sigs/order/HederaSigningOrderTest.java
@@ -1201,6 +1201,34 @@ public class HederaSigningOrderTest {
 	}
 
 	@Test
+	public void getsTokenTransactMovingHbarsReceiverSigReq() throws Throwable {
+		// given:
+		setupFor(TOKEN_TRANSACT_MOVING_HBARS_WITH_RECEIVER_SIG_REQ_AND_EXTANT_SENDER);
+
+		// when:
+		var summary = subject.keysForOtherParties(txn, summaryFactory);
+
+		// then:
+		assertThat(
+				sanityRestored(summary.getOrderedKeys()),
+				contains(FIRST_TOKEN_SENDER_KT.asKey(), RECEIVER_SIG_KT.asKey()));
+	}
+
+	@Test
+	public void getsTokenTransactMovingHbars() throws Throwable {
+		// given:
+		setupFor(TOKEN_TRANSACT_MOVING_HBARS_WITH_EXTANT_SENDER);
+
+		// when:
+		var summary = subject.keysForOtherParties(txn, summaryFactory);
+
+		// then:
+		assertThat(
+				sanityRestored(summary.getOrderedKeys()),
+				contains(FIRST_TOKEN_SENDER_KT.asKey()));
+	}
+
+	@Test
 	public void getsTokenTransactMissingSenders() throws Throwable {
 		// given:
 		setupFor(TOKEN_TRANSACT_WITH_MISSING_SENDERS);

--- a/hedera-node/src/test/java/com/hedera/services/tokens/HederaTokenStoreTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/tokens/HederaTokenStoreTest.java
@@ -218,6 +218,7 @@ class HederaTokenStoreTest {
 		subject = new HederaTokenStore(ids, TEST_VALIDATOR, properties, () -> tokens, tokenRelsLedger);
 		subject.setAccountsLedger(accountsLedger);
 		subject.setHederaLedger(hederaLedger);
+		subject.knownTreasuries.put(treasury, new HashSet<>() {{ add(misc); }});
 	}
 
 	@Test
@@ -289,6 +290,8 @@ class HederaTokenStoreTest {
 
 		// then:
 		assertEquals(OK, outcome);
+		// and:
+		assertTrue(subject.knownTreasuries.isEmpty());
 	}
 
 	@Test

--- a/hedera-node/src/test/java/com/hedera/services/tokens/HederaTokenStoreTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/tokens/HederaTokenStoreTest.java
@@ -918,6 +918,9 @@ class HederaTokenStoreTest {
 
 	@Test
 	public void isTreasuryForTokenReturnsFalse() {
+		// setup:
+		subject.knownTreasuries.clear();
+		
 		// expect:
 		assertFalse(subject.isTreasuryForToken(treasury, misc));
 	}
@@ -930,6 +933,9 @@ class HederaTokenStoreTest {
 
 	@Test
 	public void throwsIfInvalidTreasury() {
+		// setup:
+		subject.knownTreasuries.clear();
+
 		// expect:
 		assertThrows(IllegalArgumentException.class, () -> subject.removeKnownTreasuryForToken(treasury, misc));
 	}
@@ -1451,8 +1457,6 @@ class HederaTokenStoreTest {
 		// setup:
 		subject.pendingId = created;
 		subject.pendingCreation = token;
-		Set<TokenID> tokenSet = new HashSet<>();
-		tokenSet.add(subject.pendingId);
 
 		// when:
 		subject.commitCreation();
@@ -1464,7 +1468,7 @@ class HederaTokenStoreTest {
 		assertNull(subject.pendingCreation);
 		// and:
 		assertTrue(subject.isKnownTreasury(treasury));
-		assertEquals(tokenSet, subject.knownTreasuries.get(treasury));
+		assertEquals(Set.of(created, misc), subject.knownTreasuries.get(treasury));
 	}
 
 	@Test

--- a/hedera-node/src/test/java/com/hedera/test/factories/scenarios/TokenTransactScenarios.java
+++ b/hedera-node/src/test/java/com/hedera/test/factories/scenarios/TokenTransactScenarios.java
@@ -39,6 +39,30 @@ public enum TokenTransactScenarios implements TxnHandlingScenario {
 			));
 		}
 	},
+	TOKEN_TRANSACT_MOVING_HBARS_WITH_EXTANT_SENDER {
+		@Override
+		public PlatformTxnAccessor platformTxn() throws Throwable {
+			return new PlatformTxnAccessor(from(
+					newSignedTokenTransact()
+							.adjustingHbars(FIRST_TOKEN_SENDER, -2_000)
+							.adjustingHbars(TOKEN_RECEIVER, +2_000)
+							.nonPayerKts(FIRST_TOKEN_SENDER_KT)
+							.get()
+			));
+		}
+	},
+	TOKEN_TRANSACT_MOVING_HBARS_WITH_RECEIVER_SIG_REQ_AND_EXTANT_SENDER {
+		@Override
+		public PlatformTxnAccessor platformTxn() throws Throwable {
+			return new PlatformTxnAccessor(from(
+					newSignedTokenTransact()
+							.adjustingHbars(FIRST_TOKEN_SENDER, -2_000)
+							.adjustingHbars(RECEIVER_SIG, +2_000)
+							.nonPayerKts(FIRST_TOKEN_SENDER_KT, RECEIVER_SIG_KT)
+							.get()
+			));
+		}
+	},
 	TOKEN_TRANSACT_WITH_RECEIVER_SIG_REQ_AND_EXTANT_SENDERS {
 		@Override
 		public PlatformTxnAccessor platformTxn() throws Throwable {

--- a/hedera-node/src/test/java/com/hedera/test/factories/txns/TokenTransactFactory.java
+++ b/hedera-node/src/test/java/com/hedera/test/factories/txns/TokenTransactFactory.java
@@ -27,6 +27,7 @@ import com.hederahashgraph.api.proto.java.TokenTransferList;
 import com.hederahashgraph.api.proto.java.TokenTransfersTransactionBody;
 import com.hederahashgraph.api.proto.java.Transaction;
 import com.hederahashgraph.api.proto.java.TransactionBody;
+import com.hederahashgraph.api.proto.java.TransferList;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -34,6 +35,7 @@ import java.util.List;
 import java.util.Map;
 
 public class TokenTransactFactory extends SignedTxnFactory<TokenTransactFactory> {
+	List<AccountAmount> hbarAdjustments = new ArrayList<>();
 	Map<TokenID, List<AccountAmount>> adjustments = new HashMap<>();
 
 	private boolean adjustmentsAreSet = false;
@@ -43,6 +45,11 @@ public class TokenTransactFactory extends SignedTxnFactory<TokenTransactFactory>
 
 	public static TokenTransactFactory newSignedTokenTransact() {
 		return new TokenTransactFactory();
+	}
+
+	public TokenTransactFactory adjustingHbars(AccountID aId, long amount) {
+		hbarAdjustments.add(AccountAmount.newBuilder().setAccountID(aId).setAmount(amount) .build());
+		return this;
 	}
 
 	public TokenTransactFactory adjusting(AccountID aId, TokenID tId, long amount) {
@@ -72,6 +79,7 @@ public class TokenTransactFactory extends SignedTxnFactory<TokenTransactFactory>
 							.setToken(entry.getKey())
 							.addAllTransfers(entry.getValue())
 							.build()));
+			xfers.setHbarTransfers(TransferList.newBuilder().addAllAccountAmounts(hbarAdjustments));
 			adjustmentsAreSet = true;
 		}
 		txn.setTokenTransfers(xfers);

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
   <groupId>com.hedera.services</groupId>
   <artifactId>hedera-services</artifactId>
-  <version>0.9.0-alpha.2-SNAPSHOT</version>
+  <version>0.9.0-alpha.6-SNAPSHOT</version>
   <description>
     Hedera Services (crypto, file, contract, consensus) on the Platform
   </description>

--- a/test-clients/pom.xml
+++ b/test-clients/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>com.hedera.services</groupId>
     <artifactId>hedera-services</artifactId>
-    <version>0.9.0-alpha.2-SNAPSHOT</version>
+    <version>0.9.0-alpha.6-SNAPSHOT</version>
   </parent>
 
   <properties>
@@ -219,12 +219,12 @@
     <dependency>
       <groupId>com.hedera.hashgraph</groupId>
       <artifactId>hedera-protobuf-java-api</artifactId>
-      <version>0.9.0-alpha.2-SNAPSHOT</version>
+      <version>0.9.0-alpha.6-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>com.hedera.services</groupId>
       <artifactId>hapi-fees</artifactId>
-      <version>0.9.0-alpha.2-SNAPSHOT</version>
+      <version>0.9.0-alpha.6-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>

--- a/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/TxnUtils.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/TxnUtils.java
@@ -353,7 +353,13 @@ public class TxnUtils {
 	private static final char[] CANDIDATES = "ABCDEFGHIJKLMNOPQRSTUVWXYZ".toCharArray();
 
 	public static String readableTokenTransferList(TokenTransfersTransactionBody xfers) {
-		return xfers.getTokenTransfersList().stream()
+		String readableHbarXfers = xfers.hasHbarTransfers()
+				? String.format(
+						"HBAR(%s)%s",
+						readableTransferList(xfers.getHbarTransfers()),
+				        (xfers.getTokenTransfersCount() > 0 ? " & " : ""))
+				: "";
+		return readableHbarXfers + xfers.getTokenTransfersList().stream()
 				.map(scopedXfers -> String.format("%s(%s)",
 						asTokenString(scopedXfers.getToken()),
 						readableTransferList(scopedXfers.getTransfersList())))

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/HapiApiSuite.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/HapiApiSuite.java
@@ -90,6 +90,8 @@ public abstract class HapiApiSuite {
 
 	public static final String NODE = HapiSpecSetup.getDefaultInstance().defaultNodeName();
 
+	public static final String HBAR_TOKEN_SENTINEL = "HBAR";
+
 	public static final String MASTER = HapiSpecSetup.getDefaultInstance().strongControlName();
 	public static final String FUNDING = HapiSpecSetup.getDefaultInstance().fundingAccountName();
 	public static final String GENESIS = HapiSpecSetup.getDefaultInstance().genesisAccountName();

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/ContractCallSuite.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/ContractCallSuite.java
@@ -24,7 +24,6 @@ import com.hedera.services.bdd.spec.HapiApiSpec;
 import com.hedera.services.bdd.spec.HapiSpecSetup;
 import com.hedera.services.bdd.spec.keys.KeyShape;
 import com.hedera.services.bdd.spec.utilops.CustomSpecAssert;
-import com.hedera.services.bdd.spec.utilops.UtilVerbs;
 import com.hedera.services.bdd.suites.HapiApiSuite;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -34,32 +33,18 @@ import java.time.Instant;
 import java.util.Arrays;
 import java.util.List;
 
+import static com.hedera.services.bdd.spec.HapiApiSpec.defaultHapiSpec;
 import static com.hedera.services.bdd.spec.assertions.AccountInfoAsserts.changeFromSnapshot;
-import static com.hedera.services.bdd.spec.queries.QueryVerbs.getAccountBalance;
-import static com.hedera.services.bdd.spec.utilops.UtilVerbs.balanceSnapshot;
-import static com.hedera.services.bdd.spec.utilops.UtilVerbs.contractListWithPropertiesInheritedFrom;
-import static com.hedera.services.bdd.spec.utilops.UtilVerbs.sleepFor;
-import static com.hedera.services.bdd.spec.utilops.UtilVerbs.takeBalanceSnapshots;
-import static com.hedera.services.bdd.spec.utilops.UtilVerbs.validateTransferListForBalances;
-import static com.hedera.services.bdd.spec.utilops.UtilVerbs.withOpContext;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.CONTRACT_REVERT_EXECUTED;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.EXPIRATION_REDUCTION_NOT_ALLOWED;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INSUFFICIENT_TX_FEE;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INSUFFICIENT_GAS;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_CONTRACT_ID;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_SIGNATURE;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.MODIFYING_IMMUTABLE_CONTRACT;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OK;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SUCCESS;
-import static com.hedera.services.bdd.spec.HapiApiSpec.*;
 import static com.hedera.services.bdd.spec.assertions.AssertUtils.inOrder;
-import static com.hedera.services.bdd.spec.assertions.ContractLogAsserts.*;
-import static com.hedera.services.bdd.spec.assertions.ContractFnResultAsserts.*;
+import static com.hedera.services.bdd.spec.assertions.ContractFnResultAsserts.isContractWith;
 import static com.hedera.services.bdd.spec.assertions.ContractFnResultAsserts.isLiteralResult;
 import static com.hedera.services.bdd.spec.assertions.ContractFnResultAsserts.resultWith;
 import static com.hedera.services.bdd.spec.assertions.ContractInfoAsserts.contractWith;
+import static com.hedera.services.bdd.spec.assertions.ContractLogAsserts.logWith;
 import static com.hedera.services.bdd.spec.assertions.TransactionRecordAsserts.recordWith;
+import static com.hedera.services.bdd.spec.keys.KeyFactory.KeyType.THRESHOLD;
 import static com.hedera.services.bdd.spec.keys.KeyShape.listOf;
+import static com.hedera.services.bdd.spec.queries.QueryVerbs.getAccountBalance;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getContractInfo;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getTxnRecord;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.contractCall;
@@ -68,8 +53,18 @@ import static com.hedera.services.bdd.spec.transactions.TxnVerbs.contractDelete;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.contractUpdate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoCreate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.fileCreate;
-import static com.hedera.services.bdd.spec.keys.KeyFactory.KeyType.*;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.balanceSnapshot;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.contractListWithPropertiesInheritedFrom;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.newKeyNamed;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.withOpContext;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.CONTRACT_REVERT_EXECUTED;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.EXPIRATION_REDUCTION_NOT_ALLOWED;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INSUFFICIENT_GAS;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INSUFFICIENT_TX_FEE;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_CONTRACT_ID;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_SIGNATURE;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.MODIFYING_IMMUTABLE_CONTRACT;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SUCCESS;
 
 public class ContractCallSuite extends HapiApiSuite {
 	private static final Logger log = LogManager.getLogger(ContractCallSuite.class);
@@ -148,7 +143,6 @@ public class ContractCallSuite extends HapiApiSuite {
 								.adminKey("initialAdminKey")
 								.memo(INITIAL_MEMO)
 								.bytecode("bytecode"),
-						sleepFor(3_000),
 						getContractInfo("contract")
 								.payingWith("payer")
 								.logged()
@@ -173,7 +167,6 @@ public class ContractCallSuite extends HapiApiSuite {
 								.payingWith("payer")
 								.newExpiryTime(newExpiry)
 								.newMemo(NEW_MEMO),
-						sleepFor(3_000),
 						getContractInfo("contract")
 								.payingWith("payer")
 								.logged()
@@ -184,7 +177,6 @@ public class ContractCallSuite extends HapiApiSuite {
 						contractUpdate("contract")
 								.payingWith("payer")
 								.newMemo(BETTER_MEMO),
-						sleepFor(3_000),
 						getContractInfo("contract")
 								.payingWith("payer")
 								.logged()
@@ -195,7 +187,6 @@ public class ContractCallSuite extends HapiApiSuite {
 								.payingWith("payer")
 								.signedBy("payer")
 								.newExpiryTime(betterExpiry),
-						sleepFor(3_000),
 						getContractInfo("contract")
 								.payingWith("payer")
 								.logged()
@@ -258,8 +249,7 @@ public class ContractCallSuite extends HapiApiSuite {
 		return defaultHapiSpec("DepositSuccess")
 				.given(
 						fileCreate("payableBytecode").path(PATH_TO_PAYABLE_CONTRACT_BYTECODE),
-						contractCreate("payableContract").bytecode("payableBytecode").adminKey(THRESHOLD),
-						sleepFor(3_000L)
+						contractCreate("payableContract").bytecode("payableBytecode").adminKey(THRESHOLD)
 				)
 				.when()
 				.then(
@@ -313,7 +303,6 @@ public class ContractCallSuite extends HapiApiSuite {
 				.given(
 						fileCreate("parentDelegateBytecode").path(PATH_TO_DELEGATING_CONTRACT_BYTECODE),
 						contractCreate("parentDelegate").bytecode("parentDelegateBytecode").adminKey(THRESHOLD),
-						sleepFor(3_000L),
 						getContractInfo("parentDelegate").saveToRegistry("parentInfo")
 				).when(
 						contractCall("parentDelegate", CREATE_CHILD_ABI).via("createChildTxn"),
@@ -346,7 +335,6 @@ public class ContractCallSuite extends HapiApiSuite {
 				.given(
 						fileCreate("simpleStorageBytecode").path(PATH_TO_SIMPLE_STORAGE_BYTECODE),
 						contractCreate("simpleStorage").bytecode("simpleStorageBytecode").adminKey(THRESHOLD),
-						sleepFor(3_000L),
 						getContractInfo("simpleStorage").saveToRegistry("simpleStorageInfo")
 				).when().then(
 						contractCall("simpleStorage", CREATE_CHILD_ABI).via("simpleStorageTxn")

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenTransactSpecs.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenTransactSpecs.java
@@ -63,7 +63,7 @@ public class TokenTransactSpecs extends HapiApiSuite {
 						balancesAreChecked(),
 						duplicateAccountsInTokenTransferRejected(),
 						allRequiredSigsAreChecked(),
-						txnsAreAtomic(),
+						tokenOnlyTxnsAreAtomic(),
 						nonZeroTransfersRejected(),
 						prechecksWork(),
 				}
@@ -245,8 +245,8 @@ public class TokenTransactSpecs extends HapiApiSuite {
 				);
 	}
 
-	public HapiApiSpec txnsAreAtomic() {
-		return defaultHapiSpec("TxnsAreAtomic")
+	public HapiApiSpec tokenOnlyTxnsAreAtomic() {
+		return defaultHapiSpec("TokenOnlyTxnsAreAtomic")
 				.given(
 						cryptoCreate("payer").balance(A_HUNDRED_HBARS),
 						cryptoCreate("firstTreasury"),


### PR DESCRIPTION
**Related issue(s)**:
- Closes #695 
- Closes #698

**Summary of the change**:
- Extend the `TokenTransact` functionality to include **both** token and hbar transfers:
```
message TokenTransfersTransactionBody {
    repeated TokenTransferList tokenTransfers = 1;
    TransferList hbarTransfers = 2;
}
```
- Fix #698 by updating `HederaTokenStore#knownTreasuries` after a token is successfully deleted.

**External impacts**:
- SDK needs to support populating the `hbarTransfers` list.