### PR TITLE
00678 d weekend perf regression

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -927,11 +927,12 @@ workflows:
   weekly-crypto-transfer-perf-start-from-saved-state-regression:
     triggers:
       - schedule:
-          cron: "0 1,13 * * *"
+          cron: "0 5 * * *"
           filters:
             branches:
               only:
-                - master
+#                - master
+                - 00678-D-weekend-perf-regression
     jobs:
       - build-platform-and-services
       - weekly-run-crypto-transfer-start-from-saved-state-regression:
@@ -947,7 +948,7 @@ workflows:
   weekly-HCS-perf-start-from-saved-state-regression:
     triggers:
       - schedule:
-          cron: "0 6,18 * * *"
+          cron: "0 8 * * *"
           filters:
             branches:
               only:
@@ -1739,10 +1740,11 @@ jobs:
       - run:
           name: Modify Payer account for Public testnet start from saved state test
           command: |
-            echo -n "$KEY_DevTestNetTreasury" > /repo/test-clients/src/main/resource/StartUpAccount.txt;
+            echo -n "$KEY_DevTestNetTreasury";    echo -n /repo/test-clients/src/main/resource/StartUpAccount.txt;
+#            echo -n "$KEY_DevTestNetTreasury" > /repo/test-clients/src/main/resource/StartUpAccount.txt;
       - run:
           name: Run start from saved state regression tests
-          no_output_timeout: 60m
+          no_output_timeout: 120m
           command: |
             cd /swirlds-platform/regression;
             ./regression_services_circleci.sh configs/services/weekly/15N_15C/AWS-Services-Weekly-CryptoTransfer-Perf-StartFromState-15N-15C.json /repo
@@ -1768,10 +1770,11 @@ jobs:
       - run:
           name: Modify Payer account for Public testnet start from saved state test
           command: |
-            echo -n "$KEY_DevTestNetTreasury" > /repo/test-clients/src/main/resource/StartUpAccount.txt;
+            echo -n "$KEY_DevTestNetTreasury";    echo -n /repo/test-clients/src/main/resource/StartUpAccount.txt;
+#            echo -n "$KEY_DevTestNetTreasury" > /repo/test-clients/src/main/resource/StartUpAccount.txt;
       - run:
           name: Run start from saved state regression tests
-          no_output_timeout: 60m
+          no_output_timeout: 180m
           command: |
             cd /swirlds-platform/regression;
             ./regression_services_circleci.sh configs/services/weekly/15N_15C/AWS-Services-Weekly-HCS-Perf-StartFromState-15N-15C.json /repo


### PR DESCRIPTION
**Related issue(s)**:
Closes #678 

**Summary of the change**:
Right now the planned 4 hour performance regression starting from saved state is impossible due to validation memory limitation and issues from saved state file loading. Now the intermediate solution is:
1. run for one hour for started;
2. Start from scratch instead of from saved state;

We will have follow up issues to fix these issues and reach the designed goal.

**External impacts**:
None.

**Applicable documentation**
- [ ] Javadoc
- [ ] HAPI protobuf comments
- [ ] README
