### PR TITLE
Add simple freeze test to close stream file properly

### DIFF
--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/SuiteRunner.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/SuiteRunner.java
@@ -34,9 +34,6 @@ import com.hedera.services.bdd.suites.contract.ChildStorageSpec;
 import com.hedera.services.bdd.suites.contract.ContractCallLocalSuite;
 import com.hedera.services.bdd.suites.contract.ContractCallSuite;
 import com.hedera.services.bdd.suites.contract.ContractCreateSuite;
-import com.hedera.services.bdd.suites.contract.ContractDeleteSuite;
-import com.hedera.services.bdd.suites.contract.ContractGetBytecodeSuite;
-import com.hedera.services.bdd.suites.contract.ContractUpdateSuite;
 import com.hedera.services.bdd.suites.contract.DeprecatedContractKeySuite;
 import com.hedera.services.bdd.suites.contract.NewOpInConstructorSuite;
 import com.hedera.services.bdd.suites.contract.OCTokenSpec;
@@ -62,6 +59,7 @@ import com.hedera.services.bdd.suites.file.ProtectedFilesUpdateSuite;
 import com.hedera.services.bdd.suites.file.negative.UpdateFailuresSpec;
 import com.hedera.services.bdd.suites.file.positive.SysDelSysUndelSpec;
 import com.hedera.services.bdd.suites.freeze.FreezeSuite;
+import com.hedera.services.bdd.suites.freeze.SimpleFreezeOnly;
 import com.hedera.services.bdd.suites.freeze.UpdateServerFiles;
 import com.hedera.services.bdd.suites.issues.Issue2144Spec;
 import com.hedera.services.bdd.suites.issues.IssueXXXXSpec;
@@ -82,7 +80,6 @@ import com.hedera.services.bdd.suites.perf.SubmitMessageLoadTest;
 import com.hedera.services.bdd.suites.perf.TokenTransfersLoadProvider;
 import com.hedera.services.bdd.suites.reconnect.CheckUnavailableNode;
 import com.hedera.services.bdd.suites.reconnect.GetAccountBalanceAfterReconnect;
-import com.hedera.services.bdd.suites.records.CharacterizationSuite;
 import com.hedera.services.bdd.suites.records.ContractRecordsSanityCheckSuite;
 import com.hedera.services.bdd.suites.records.CryptoRecordsSanityCheckSuite;
 import com.hedera.services.bdd.suites.records.DuplicateManagementTest;
@@ -277,6 +274,7 @@ public class SuiteRunner {
 		put("ZeroStakeTest", aof(new ZeroStakeNodeTest()));
 		/* Query payment validation */
 		put("QueryPaymentSuite", aof(new QueryPaymentSuite()));
+		put("SimpleFreezeOnly", aof(new SimpleFreezeOnly()));
 	}};
 
 	static boolean runAsync;

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/freeze/SimpleFreezeOnly.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/freeze/SimpleFreezeOnly.java
@@ -1,0 +1,45 @@
+package com.hedera.services.bdd.suites.freeze;
+
+import com.hedera.services.bdd.spec.HapiApiSpec;
+import com.hedera.services.bdd.suites.HapiApiSuite;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import java.util.Arrays;
+import java.util.List;
+import static com.hedera.services.bdd.spec.HapiApiSpec.defaultHapiSpec;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.freeze;
+
+public class SimpleFreezeOnly extends HapiApiSuite {
+	private static final Logger log = LogManager.getLogger(FreezeSuite.class);
+
+	public static void main(String... args) {
+		new FreezeSuite().runSuiteSync();
+	}
+
+	@Override
+	protected Logger getResultsLogger() {
+		return log;
+	}
+
+	@Override
+	protected List<HapiApiSpec> getSpecsInSuite() {
+		return allOf(
+				positiveTests()
+		);
+	}
+
+	private List<HapiApiSpec> positiveTests() {
+		return Arrays.asList(
+				SimpleFreezeOnly()
+		);
+	}
+
+	private HapiApiSpec SimpleFreezeOnly() {
+		return defaultHapiSpec("SimpleFreezeOnly")
+				.given(
+				).when(
+						freeze().payingWith(GENESIS).startingIn(60).seconds().andLasting(10).minutes()
+				).then(
+				);
+	}
+}


### PR DESCRIPTION
Added a simple freeze test will be used at the end of state recover test,
so the event stream file can be flushed with running hash and closed properly.