### PR TITLE
Update grpc versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,11 +61,11 @@
     <!-- Dependency properties -->
     <commons-codec.version>1.11</commons-codec.version>
     <eddsa.version>0.3.0</eddsa.version>
-    <grpc.version>1.22.0</grpc.version>
+    <grpc.version>1.33.0</grpc.version>
     <jackson-databind.version>2.9.10.5</jackson-databind.version>
     <javax.annotation-api.version>1.3.2</javax.annotation-api.version>
     <log4j.version>2.13.2</log4j.version>
-    <netty.version>4.1.52.Final</netty.version>
+    <netty.version>4.1.51.Final</netty.version>
     <!-- Test dependency properties -->
     <hamcrest-all.version>1.3</hamcrest-all.version>
     <junit.version>4.12</junit.version>

--- a/test-clients/src/main/java/com/hedera/services/legacy/CI/MultipleCryptoTransfers.java
+++ b/test-clients/src/main/java/com/hedera/services/legacy/CI/MultipleCryptoTransfers.java
@@ -80,7 +80,7 @@ public class MultipleCryptoTransfers {
   public MultipleCryptoTransfers(int port, String host) {
     // connecting to the grpc server on the port
     channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     MultipleCryptoTransfers.stub = CryptoServiceGrpc.newBlockingStub(channel);
   }

--- a/test-clients/src/main/java/com/hedera/services/legacy/CI/NegativeAccountCreateTest.java
+++ b/test-clients/src/main/java/com/hedera/services/legacy/CI/NegativeAccountCreateTest.java
@@ -78,7 +78,7 @@ public class NegativeAccountCreateTest {
   public NegativeAccountCreateTest(int port, String host) {
     // connecting to the grpc server on the port
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     NegativeAccountCreateTest.stub = CryptoServiceGrpc.newBlockingStub(channel);
   }

--- a/test-clients/src/main/java/com/hedera/services/legacy/CI/NegativeCryptoQueryTest.java
+++ b/test-clients/src/main/java/com/hedera/services/legacy/CI/NegativeCryptoQueryTest.java
@@ -69,7 +69,7 @@ public class NegativeCryptoQueryTest {
   private NegativeCryptoQueryTest(int port, String host) {
     // connecting to the grpc server on the port
     channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     NegativeCryptoQueryTest.stub = CryptoServiceGrpc.newBlockingStub(channel);
   }

--- a/test-clients/src/main/java/com/hedera/services/legacy/CI/NegativeTransferTest.java
+++ b/test-clients/src/main/java/com/hedera/services/legacy/CI/NegativeTransferTest.java
@@ -79,7 +79,7 @@ public class NegativeTransferTest {
   public NegativeTransferTest(int port, String host) {
     // connecting to the grpc server on the port
     NegativeTransferTest.channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     NegativeTransferTest.stub = CryptoServiceGrpc.newBlockingStub(channel);
   }

--- a/test-clients/src/main/java/com/hedera/services/legacy/CI/SmartContractFailFirst.java
+++ b/test-clients/src/main/java/com/hedera/services/legacy/CI/SmartContractFailFirst.java
@@ -148,7 +148,7 @@ public class SmartContractFailFirst {
   private AccountID createAccount(KeyPair keyPair, AccountID payerAccount, long initialBalance)
       throws Exception {
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
     Transaction transaction = TestHelper
@@ -175,7 +175,7 @@ public class SmartContractFailFirst {
         .setTransactionGetReceipt(RequestBuilder.getTransactionGetReceiptQuery(
             transactionId, ResponseType.ANSWER_ONLY)).build();
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
     Response transactionReceipts = stub.getTransactionReceipts(query);
@@ -202,7 +202,7 @@ public class SmartContractFailFirst {
       long durationInSeconds, long gas, long balance, ResponseCodeEnum expectedStatus)
       throws Exception {
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
 
     Duration contractAutoRenew = Duration.newBuilder().setSeconds(durationInSeconds).build();
@@ -255,7 +255,7 @@ public class SmartContractFailFirst {
     long totalCost = 0; // gas plus fees
     ContractID createdContract = null;
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     SmartContractServiceGrpc.SmartContractServiceBlockingStub stub = SmartContractServiceGrpc
         .newBlockingStub(channel);
@@ -303,7 +303,7 @@ public class SmartContractFailFirst {
   private TransactionRecord getTransactionRecordUsingGenesisAccount(TransactionID transactionId)
       throws Exception {
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
     long fee = FeeClient.getCostForGettingTxRecord();
@@ -363,7 +363,7 @@ public class SmartContractFailFirst {
     byte[] dataToReturn = null;
     AccountID createdAccount = null;
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     SmartContractServiceGrpc.SmartContractServiceBlockingStub stub = SmartContractServiceGrpc
         .newBlockingStub(channel);
@@ -420,7 +420,7 @@ public class SmartContractFailFirst {
     loadGenesisAndNodeAcccounts();
 
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     TestHelper.initializeFeeClient(channel, genesisAccount, accountKeyPairs.get(genesisAccount),
         nodeAccount);

--- a/test-clients/src/main/java/com/hedera/services/legacy/CI/SmartContractSelfDestruct.java
+++ b/test-clients/src/main/java/com/hedera/services/legacy/CI/SmartContractSelfDestruct.java
@@ -155,7 +155,7 @@ public class SmartContractSelfDestruct {
 	  private AccountID createAccount(KeyPair keyPair, AccountID payerAccount, long initialBalance)
 	      throws Exception {
 	    ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-	        .usePlaintext(true)
+	        .usePlaintext()
 	        .build();
 	    CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
 	    Transaction transaction = TestHelper
@@ -182,7 +182,7 @@ public class SmartContractSelfDestruct {
 	        .setTransactionGetReceipt(RequestBuilder.getTransactionGetReceiptQuery(
 	            transactionId, ResponseType.ANSWER_ONLY)).build();
 	    ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-	        .usePlaintext(true)
+	        .usePlaintext()
 	        .build();
 	    CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
 	    Response transactionReceipts = stub.getTransactionReceipts(query);
@@ -209,7 +209,7 @@ public class SmartContractSelfDestruct {
 	      long durationInSeconds) throws Exception {
 	    ContractID createdContract = null;
 	    ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-	        .usePlaintext(true)
+	        .usePlaintext()
 	        .build();
 
 	    Duration contractAutoRenew = Duration.newBuilder().setSeconds(durationInSeconds).build();
@@ -262,7 +262,7 @@ public class SmartContractSelfDestruct {
 	    byte[] dataToReturn = null;
 	    ContractID createdContract = null;
 	    ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-	        .usePlaintext(true)
+	        .usePlaintext()
 	        .build();
 	    SmartContractServiceGrpc.SmartContractServiceBlockingStub stub = SmartContractServiceGrpc
 	        .newBlockingStub(channel);
@@ -316,7 +316,7 @@ public class SmartContractSelfDestruct {
 	      TransactionID transactionId) throws Exception {
 	    AccountID createdAccount = null;
 	    ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-	        .usePlaintext(true)
+	        .usePlaintext()
 	        .build();
 	    CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
 	    long fee = FeeClient.getCostForGettingTxRecord();
@@ -346,7 +346,7 @@ public class SmartContractSelfDestruct {
 	    byte[] dataToReturn = null;
 	    ContractID createdContract = null;
 	    ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-	        .usePlaintext(true)
+	        .usePlaintext()
 	        .build();
 	    SmartContractServiceGrpc.SmartContractServiceBlockingStub stub = SmartContractServiceGrpc
 	        .newBlockingStub(channel);
@@ -425,7 +425,7 @@ public class SmartContractSelfDestruct {
 	    byte[] dataToReturn = null;
 	    AccountID createdAccount = null;
 	    ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-	        .usePlaintext(true)
+	        .usePlaintext()
 	        .build();
 	    SmartContractServiceGrpc.SmartContractServiceBlockingStub stub = SmartContractServiceGrpc
 	        .newBlockingStub(channel);
@@ -471,7 +471,7 @@ public class SmartContractSelfDestruct {
 	  private AccountInfo getCryptoGetAccountInfo(AccountID payerAccount,
 	      AccountID accountID) throws Exception {
 	    ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-	        .usePlaintext(true)
+	        .usePlaintext()
 	        .build();
 	    CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
 
@@ -505,7 +505,7 @@ public class SmartContractSelfDestruct {
 	  private GetBySolidityIDResponse getBySolidityID(AccountID payerAccount,
 	      String solidityId) throws Exception {
 	    ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-	        .usePlaintext(true)
+	        .usePlaintext()
 	        .build();
 	    SmartContractServiceGrpc.SmartContractServiceBlockingStub stub = SmartContractServiceGrpc
 	        .newBlockingStub(channel);
@@ -527,7 +527,7 @@ public class SmartContractSelfDestruct {
 	    loadGenesisAndNodeAcccounts();
 
 			ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-					.usePlaintext(true)
+					.usePlaintext()
 					.build();
 			TestHelper.initializeFeeClient(channel, genesisAccount, accountKeyPairs.get(genesisAccount),
 					nodeAccount);
@@ -585,7 +585,7 @@ public class SmartContractSelfDestruct {
 	  private ContractInfo getContractInfo(AccountID payerAccount,
 	      ContractID contractId,ResponseCodeEnum expectedConstResponse , ResponseCodeEnum expecedAnswerResponse) throws Exception {
 	    ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-	        .usePlaintext(true)
+	        .usePlaintext()
 	        .build();
 	    SmartContractServiceGrpc.SmartContractServiceBlockingStub stub = SmartContractServiceGrpc
 	        .newBlockingStub(channel);
@@ -706,7 +706,7 @@ public class SmartContractSelfDestruct {
 		        .setTransactionGetReceipt(RequestBuilder.getTransactionGetReceiptQuery(
 		            transactionId, ResponseType.ANSWER_ONLY)).build();
 		    ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-		        .usePlaintext(true)
+		        .usePlaintext()
 		        .build();
 		    CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
 		    Response transactionReceipts = stub.getTransactionReceipts(query);

--- a/test-clients/src/main/java/com/hedera/services/legacy/CI/SpecialAccountFeeTest.java
+++ b/test-clients/src/main/java/com/hedera/services/legacy/CI/SpecialAccountFeeTest.java
@@ -67,7 +67,7 @@ public class SpecialAccountFeeTest {
   public SpecialAccountFeeTest(int port, String host) {
     // connecting to the grpc server on the port
     channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     SpecialAccountFeeTest.stub = CryptoServiceGrpc.newBlockingStub(channel);
   }

--- a/test-clients/src/main/java/com/hedera/services/legacy/CI/ThresholdRecordTest.java
+++ b/test-clients/src/main/java/com/hedera/services/legacy/CI/ThresholdRecordTest.java
@@ -68,7 +68,7 @@ public class ThresholdRecordTest {
   public ThresholdRecordTest(int port, String host) {
     // connecting to the grpc server on the port
     channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     ThresholdRecordTest.stub = CryptoServiceGrpc.newBlockingStub(channel);
   }

--- a/test-clients/src/main/java/com/hedera/services/legacy/CI/TxRecordTest.java
+++ b/test-clients/src/main/java/com/hedera/services/legacy/CI/TxRecordTest.java
@@ -69,7 +69,7 @@ public class TxRecordTest {
   private TxRecordTest(int port, String host) {
     // connecting to the grpc server on the port
     channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     stub = CryptoServiceGrpc.newBlockingStub(channel);
   }

--- a/test-clients/src/main/java/com/hedera/services/legacy/autorenew/CryptoFileAutoRenewDurationCheck.java
+++ b/test-clients/src/main/java/com/hedera/services/legacy/autorenew/CryptoFileAutoRenewDurationCheck.java
@@ -85,7 +85,7 @@ public class CryptoFileAutoRenewDurationCheck {
   public CryptoFileAutoRenewDurationCheck(int port, String host) {
     // connecting to the grpc server on the port
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     CryptoFileAutoRenewDurationCheck.stub = CryptoServiceGrpc.newBlockingStub(channel);
     CryptoFileAutoRenewDurationCheck.fileStub = FileServiceGrpc.newBlockingStub(channel);

--- a/test-clients/src/main/java/com/hedera/services/legacy/autorenew/SmartContractAutoRenewCheck.java
+++ b/test-clients/src/main/java/com/hedera/services/legacy/autorenew/SmartContractAutoRenewCheck.java
@@ -156,7 +156,7 @@ public class SmartContractAutoRenewCheck {
   private AccountID createAccount(KeyPair keyPair, AccountID payerAccount, long initialBalance)
       throws Exception {
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
     Transaction transaction = TestHelper
@@ -182,7 +182,7 @@ public class SmartContractAutoRenewCheck {
         .setTransactionGetReceipt(RequestBuilder.getTransactionGetReceiptQuery(
             transactionId, ResponseType.ANSWER_ONLY)).build();
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
     Response transactionReceipts = stub.getTransactionReceipts(query);
@@ -207,7 +207,7 @@ public class SmartContractAutoRenewCheck {
       AccountID adminAccount) throws Exception {
     ContractID createdContract = null;
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
 
     Duration contractAutoRenew = Duration.newBuilder().setSeconds(durationInSeconds).build();
@@ -251,7 +251,7 @@ public class SmartContractAutoRenewCheck {
       AccountID adminAccount) throws Exception {
     ContractID createdContract = null;
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
 
     Duration contractAutoRenew = Duration.newBuilder().setSeconds(durationInSeconds).build();
@@ -301,7 +301,7 @@ public class SmartContractAutoRenewCheck {
     byte[] dataToReturn = null;
     ContractID createdContract = null;
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     SmartContractServiceGrpc.SmartContractServiceBlockingStub stub = SmartContractServiceGrpc
         .newBlockingStub(channel);
@@ -355,7 +355,7 @@ public class SmartContractAutoRenewCheck {
       TransactionID transactionId) throws Exception {
     AccountID createdAccount = null;
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
     long fee = FeeClient.getCostForGettingTxRecord();
@@ -412,7 +412,7 @@ public class SmartContractAutoRenewCheck {
     byte[] dataToReturn = null;
     AccountID createdAccount = null;
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     SmartContractServiceGrpc.SmartContractServiceBlockingStub stub = SmartContractServiceGrpc
         .newBlockingStub(channel);
@@ -473,7 +473,7 @@ public class SmartContractAutoRenewCheck {
       AccountID adminAccount) throws Exception {
 
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     SmartContractServiceGrpc.SmartContractServiceBlockingStub stub = SmartContractServiceGrpc
         .newBlockingStub(channel);
@@ -515,7 +515,7 @@ public class SmartContractAutoRenewCheck {
       ContractID contractId) throws Exception {
     String byteCode = "";
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     SmartContractServiceGrpc.SmartContractServiceBlockingStub stub = SmartContractServiceGrpc
         .newBlockingStub(channel);
@@ -551,7 +551,7 @@ public class SmartContractAutoRenewCheck {
   private AccountInfo getCryptoGetAccountInfo(
       AccountID accountID) throws Exception {
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
     long fee = FeeClient.getFeeByID(HederaFunctionality.CryptoGetInfo);
@@ -582,7 +582,7 @@ public class SmartContractAutoRenewCheck {
   private GetBySolidityIDResponse getBySolidityID(AccountID payerAccount,
       String solidityId) throws Exception {
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     SmartContractServiceGrpc.SmartContractServiceBlockingStub stub = SmartContractServiceGrpc
         .newBlockingStub(channel);
@@ -666,7 +666,7 @@ public class SmartContractAutoRenewCheck {
   private ContractInfo getContractInfo(AccountID payerAccount,
       ContractID contractId) throws Exception {
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     SmartContractServiceGrpc.SmartContractServiceBlockingStub stub = SmartContractServiceGrpc
         .newBlockingStub(channel);

--- a/test-clients/src/main/java/com/hedera/services/legacy/bip39utils/BIP39KeysUtil.java
+++ b/test-clients/src/main/java/com/hedera/services/legacy/bip39utils/BIP39KeysUtil.java
@@ -61,7 +61,7 @@ public class BIP39KeysUtil {
   public BIP39KeysUtil( String host, int port, long nodeAccountId, long accountId) {
     // connecting to the grpc server on the port
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     this.stub = CryptoServiceGrpc.newBlockingStub(channel);
     this.host = host;

--- a/test-clients/src/main/java/com/hedera/services/legacy/client/core/GrpcStub.java
+++ b/test-clients/src/main/java/com/hedera/services/legacy/client/core/GrpcStub.java
@@ -67,7 +67,7 @@ public class GrpcStub {
 		this.port = port;
 
 		channel = ManagedChannelBuilder.forAddress(host, port)
-				.usePlaintext(true)
+				.usePlaintext()
 				.build();
 		cryptoStub = CryptoServiceGrpc.newBlockingStub(channel);
 		scStub = SmartContractServiceGrpc.newBlockingStub(channel);

--- a/test-clients/src/main/java/com/hedera/services/legacy/client/test/ClientBaseThread.java
+++ b/test-clients/src/main/java/com/hedera/services/legacy/client/test/ClientBaseThread.java
@@ -191,7 +191,7 @@ public class ClientBaseThread extends Thread {
 		while (channel == null || (channel.getState(false) != ConnectivityState.READY
 				&& channel.getState(false) != ConnectivityState.IDLE)) {
 
-			channel = ManagedChannelBuilder.forAddress(host, port).usePlaintext(true).build();
+			channel = ManagedChannelBuilder.forAddress(host, port).usePlaintext().build();
 			if (retry < MAX_RETRY_TIMES) {
 				log.info("{} Retry times {} state {}", getName(), retry, channel.getState(false));
 				retry++;
@@ -259,7 +259,7 @@ public class ClientBaseThread extends Thread {
 		nodeAccount = RequestBuilder.getAccountIdBuild(nodeAccountNumber, 0l, 0l);
 
 		channel = ManagedChannelBuilder.forAddress(host, port)
-				.usePlaintext(true)
+				.usePlaintext()
 				.build();
 		stub = CryptoServiceGrpc.newBlockingStub(channel);
 		sCServiceStub = SmartContractServiceGrpc.newBlockingStub(channel);

--- a/test-clients/src/main/java/com/hedera/services/legacy/core/CommonUtils.java
+++ b/test-clients/src/main/java/com/hedera/services/legacy/core/CommonUtils.java
@@ -20,16 +20,16 @@ package com.hedera.services.legacy.core;
  * ‍
  */
 
-import com.google.gson.Gson;
-import com.google.protobuf.ByteString;
-import com.google.protobuf.InvalidProtocolBufferException;
-import com.google.protobuf.TextFormat;
 import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
-import com.hederahashgraph.api.proto.java.Transaction;
 import com.hederahashgraph.api.proto.java.TransactionBody;
 import com.hederahashgraph.api.proto.java.TransactionID;
 import com.hederahashgraph.api.proto.java.TransactionRecord;
 import com.hederahashgraph.api.proto.java.TransferList;
+import org.apache.commons.codec.DecoderException;
+import org.apache.commons.codec.binary.Hex;
+import org.ethereum.util.ByteUtil;
+import org.junit.Assert;
+
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
@@ -46,15 +46,9 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.ArrayList;
 import java.util.Base64;
-import java.util.List;
 import java.util.Optional;
 import java.util.Random;
-import org.apache.commons.codec.DecoderException;
-import org.apache.commons.codec.binary.Hex;
-import org.ethereum.util.ByteUtil;
-import org.junit.Assert;
 
 import static java.lang.Boolean.parseBoolean;
 
@@ -336,45 +330,6 @@ public class CommonUtils {
       rv[i] = b[i];
     }
 
-    return rv;
-  }
-
-  /**
-   * Returns a short form of a string in the form of display first and last n characters.
-   */
-  public static String shortForm(String string, int n) {
-    int d = 2 * n;
-    int len = string.length();
-    if (string.length() <= d) {
-      return string;
-    }
-    String rv = "length=" + len + ": content=" + string.substring(0, n) + " ... " + string
-        .substring(len - d, len);
-    return rv;
-  }
-
-  /**
-   * Serialize a Java object into Json string.
-   *
-   * @param obj Java object
-   * @return Json string
-   */
-  public static String serialize2Json(Object obj) {
-    Gson gsonObj = new Gson();
-    String json = gsonObj.toJson(obj);
-    return json;
-  }
-
-  /**
-   * Deserialize a Json string into a Java object.
-   *
-   * @param json Java object
-   * @return Json string
-   */
-  @SuppressWarnings({"unchecked"})
-  public static List<String> deserializeListOfStringFromJson(String json) {
-    Gson gsonObj = new Gson();
-    List<String> rv = gsonObj.fromJson(json, ArrayList.class);
     return rv;
   }
 

--- a/test-clients/src/main/java/com/hedera/services/legacy/core/TestHelper.java
+++ b/test-clients/src/main/java/com/hedera/services/legacy/core/TestHelper.java
@@ -992,7 +992,7 @@ public class TestHelper {
           if (channel == null) {
             Properties properties = TestHelper.getApplicationProperties();
             int port = Integer.parseInt(properties.getProperty("port"));
-            channel = ManagedChannelBuilder.forAddress(host, port).usePlaintext(true).build();
+            channel = ManagedChannelBuilder.forAddress(host, port).usePlaintext().build();
             cstub = CryptoServiceGrpc.newBlockingStub(channel);
           }
         }

--- a/test-clients/src/main/java/com/hedera/services/legacy/crypto/CreateAccountPayerScenario.java
+++ b/test-clients/src/main/java/com/hedera/services/legacy/crypto/CreateAccountPayerScenario.java
@@ -67,7 +67,7 @@ public class CreateAccountPayerScenario {
   public CreateAccountPayerScenario(int port, String host) {
     // connecting to the grpc server on the port
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     CreateAccountPayerScenario.stub = CryptoServiceGrpc.newBlockingStub(channel);
   }

--- a/test-clients/src/main/java/com/hedera/services/legacy/crypto/CryptoDeleteTest.java
+++ b/test-clients/src/main/java/com/hedera/services/legacy/crypto/CryptoDeleteTest.java
@@ -77,7 +77,7 @@ public class CryptoDeleteTest {
   public CryptoDeleteTest(int port, String host) {
     // connecting to the grpc server on the port
     channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     CryptoDeleteTest.stub = CryptoServiceGrpc.newBlockingStub(channel);
   }

--- a/test-clients/src/main/java/com/hedera/services/legacy/crypto/CryptoLiveHashTest.java
+++ b/test-clients/src/main/java/com/hedera/services/legacy/crypto/CryptoLiveHashTest.java
@@ -85,7 +85,7 @@ public class CryptoLiveHashTest {
   public CryptoLiveHashTest(int port, String host) {
     // connecting to the grpc server on the port
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     CryptoLiveHashTest.stub = CryptoServiceGrpc.newBlockingStub(channel);
   }

--- a/test-clients/src/main/java/com/hedera/services/legacy/crypto/DoubleSpendingTest.java
+++ b/test-clients/src/main/java/com/hedera/services/legacy/crypto/DoubleSpendingTest.java
@@ -78,7 +78,7 @@ public class DoubleSpendingTest {
   public DoubleSpendingTest(int port, String host) {
     // connecting to the grpc server on the port
     channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     DoubleSpendingTest.stub = CryptoServiceGrpc.newBlockingStub(channel);
   }

--- a/test-clients/src/main/java/com/hedera/services/legacy/crypto/DuplicateTransactionTest.java
+++ b/test-clients/src/main/java/com/hedera/services/legacy/crypto/DuplicateTransactionTest.java
@@ -79,7 +79,7 @@ public class DuplicateTransactionTest {
   public DuplicateTransactionTest(int port, String host) {
     // connecting to the grpc server on the port
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     DuplicateTransactionTest.stub = CryptoServiceGrpc.newBlockingStub(channel);
   }

--- a/test-clients/src/main/java/com/hedera/services/legacy/crypto/FastTxRecordTest.java
+++ b/test-clients/src/main/java/com/hedera/services/legacy/crypto/FastTxRecordTest.java
@@ -69,7 +69,7 @@ public class FastTxRecordTest {
   public FastTxRecordTest(int port, String host) {
     // connecting to the grpc server on the port
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     stub = CryptoServiceGrpc.newBlockingStub(channel);
   }

--- a/test-clients/src/main/java/com/hedera/services/legacy/crypto/MultiSigCreationTransfer.java
+++ b/test-clients/src/main/java/com/hedera/services/legacy/crypto/MultiSigCreationTransfer.java
@@ -75,7 +75,7 @@ public class MultiSigCreationTransfer {
   public MultiSigCreationTransfer(int port, String host) {
     // connecting to the grpc server on the port
     channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     MultiSigCreationTransfer.stub = CryptoServiceGrpc.newBlockingStub(channel);
   }

--- a/test-clients/src/main/java/com/hedera/services/legacy/crypto/NegativeCryptoDeleteTest.java
+++ b/test-clients/src/main/java/com/hedera/services/legacy/crypto/NegativeCryptoDeleteTest.java
@@ -68,7 +68,7 @@ public class NegativeCryptoDeleteTest {
   public NegativeCryptoDeleteTest(int port, String host) {
     // connecting to the grpc server on the port
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     NegativeCryptoDeleteTest.stub = CryptoServiceGrpc.newBlockingStub(channel);
   }

--- a/test-clients/src/main/java/com/hedera/services/legacy/crypto/TransactionRecordUniquenesTest.java
+++ b/test-clients/src/main/java/com/hedera/services/legacy/crypto/TransactionRecordUniquenesTest.java
@@ -73,7 +73,7 @@ public class TransactionRecordUniquenesTest {
   public TransactionRecordUniquenesTest(int port, String host) {
     // connecting to the grpc server on the port
     channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     TransactionRecordUniquenesTest.stub = CryptoServiceGrpc.newBlockingStub(channel);
   }

--- a/test-clients/src/main/java/com/hedera/services/legacy/file/FileServiceIT.java
+++ b/test-clients/src/main/java/com/hedera/services/legacy/file/FileServiceIT.java
@@ -195,7 +195,7 @@ public class FileServiceIT {
         channel.awaitTermination(10, TimeUnit.SECONDS);
       }catch (Exception e) {}
     }
-    channel = ManagedChannelBuilder.forAddress(host, port).usePlaintext(true).build();
+    channel = ManagedChannelBuilder.forAddress(host, port).usePlaintext().build();
     stub = FileServiceGrpc.newBlockingStub(channel);
     cstub = CryptoServiceGrpc.newBlockingStub(channel);
   }

--- a/test-clients/src/main/java/com/hedera/services/legacy/file/SystemDeleteIT.java
+++ b/test-clients/src/main/java/com/hedera/services/legacy/file/SystemDeleteIT.java
@@ -85,7 +85,7 @@ public class SystemDeleteIT {
   public SystemDeleteIT(int port, String host) {
     // connecting to the grpc server on the port
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     SystemDeleteIT.fileServiceBlockingStub = FileServiceGrpc.newBlockingStub(channel);
     SystemDeleteIT.cryptoStub = CryptoServiceGrpc.newBlockingStub(channel);
@@ -336,7 +336,7 @@ public class SystemDeleteIT {
     AccountID nodeAccount = AccountID.newBuilder().setAccountNum(3l).build();
     ContractID createdContract = null;
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
 
     Duration contractAutoRenew = Duration.newBuilder().setSeconds(durationInSeconds).build();
@@ -379,7 +379,7 @@ public class SystemDeleteIT {
         .setTransactionGetReceipt(RequestBuilder.getTransactionGetReceiptQuery(
             transactionId, ResponseType.ANSWER_ONLY)).build();
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
     Response transactionReceipts = stub.getTransactionReceipts(query);

--- a/test-clients/src/main/java/com/hedera/services/legacy/initialization/GenesisCreateAndTransfer.java
+++ b/test-clients/src/main/java/com/hedera/services/legacy/initialization/GenesisCreateAndTransfer.java
@@ -69,7 +69,7 @@ public class GenesisCreateAndTransfer {
       throws Exception {
     log.info("Genesis Account to Create and Transfer Started");
     int port = 50211;
-    channel = ManagedChannelBuilder.forAddress("localhost", port).usePlaintext(true)
+    channel = ManagedChannelBuilder.forAddress("localhost", port).usePlaintext()
         .build();
     CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
 

--- a/test-clients/src/main/java/com/hedera/services/legacy/initialization/NodeCreateAndTransfer.java
+++ b/test-clients/src/main/java/com/hedera/services/legacy/initialization/NodeCreateAndTransfer.java
@@ -62,7 +62,7 @@ public class NodeCreateAndTransfer {
       throws Exception {
     log.info("Node Account to Create and Transfer Started");
     int port = 50211;
-    channel = ManagedChannelBuilder.forAddress("localhost", port).usePlaintext(true)
+    channel = ManagedChannelBuilder.forAddress("localhost", port).usePlaintext()
         .build();
     CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
 

--- a/test-clients/src/main/java/com/hedera/services/legacy/netty/CryptoCreatePerformance.java
+++ b/test-clients/src/main/java/com/hedera/services/legacy/netty/CryptoCreatePerformance.java
@@ -95,7 +95,7 @@ public class CryptoCreatePerformance implements Runnable {
   public CryptoCreatePerformance(int port, String host, int batchSize, boolean retrieveTxReceipt, long nodeAccount, boolean retrieveTxRecord) {
     // connecting to the grpc server on the port
 //    channel = ManagedChannelBuilder.forAddress(host, port)
-//        .usePlaintext(true)
+//        .usePlaintext()
 //        .build();
 
     this.channel = NettyChannelBuilder.forAddress(host, port)

--- a/test-clients/src/main/java/com/hedera/services/legacy/regression/BaseFeeTests.java
+++ b/test-clients/src/main/java/com/hedera/services/legacy/regression/BaseFeeTests.java
@@ -214,7 +214,7 @@ public class BaseFeeTests extends BaseClient {
     accountKeyPairs.put(queryPayerId, queryPayerKeyPair);
 
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true).build();
+        .usePlaintext().build();
     channelList.add(channel);
     sstub = SmartContractServiceGrpc.newBlockingStub(channel);
 
@@ -379,7 +379,7 @@ public class BaseFeeTests extends BaseClient {
       TransactionID transactionId) throws Exception {
     AccountID createdAccount = null;
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
     long fee = FeeClient.getCostForGettingTxRecord();
@@ -531,7 +531,7 @@ public class BaseFeeTests extends BaseClient {
             .setTransactionGetReceipt(RequestBuilder.getTransactionGetReceiptQuery(
                     transactionId, ResponseType.ANSWER_ONLY)).build();
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-            .usePlaintext(true)
+            .usePlaintext()
             .build();
     CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
     Response transactionReceipts = stub.getTransactionReceipts(query);

--- a/test-clients/src/main/java/com/hedera/services/legacy/regression/BatchCreateAccount.java
+++ b/test-clients/src/main/java/com/hedera/services/legacy/regression/BatchCreateAccount.java
@@ -72,7 +72,7 @@ public class BatchCreateAccount {
   public BatchCreateAccount(int port, String host, int batchSize, boolean retrieveTxReceipt) {
     // connecting to the grpc server on the port
     channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     this.stub = CryptoServiceGrpc.newBlockingStub(channel);
     this.BATCH_SIZE = batchSize;

--- a/test-clients/src/main/java/com/hedera/services/legacy/regression/BatchThreadCreate.java
+++ b/test-clients/src/main/java/com/hedera/services/legacy/regression/BatchThreadCreate.java
@@ -75,7 +75,7 @@ public class BatchThreadCreate {
   private BatchThreadCreate(int port, String host) {
     // connecting to the grpc server on the port
     channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     this.stub = CryptoServiceGrpc.newBlockingStub(channel);
   }

--- a/test-clients/src/main/java/com/hedera/services/legacy/regression/BatchThreadTransfer.java
+++ b/test-clients/src/main/java/com/hedera/services/legacy/regression/BatchThreadTransfer.java
@@ -75,7 +75,7 @@ public class BatchThreadTransfer {
   public BatchThreadTransfer(int port, String host, int batchSize) {
     // connecting to the grpc server on the port
     channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     this.stub = CryptoServiceGrpc.newBlockingStub(channel);
     this.BATCH_SIZE = batchSize;

--- a/test-clients/src/main/java/com/hedera/services/legacy/regression/BatchTransfer.java
+++ b/test-clients/src/main/java/com/hedera/services/legacy/regression/BatchTransfer.java
@@ -71,7 +71,7 @@ public class BatchTransfer {
   public BatchTransfer(int port, String host, int batchSize, boolean retrieveTxReceipt) {
     // connecting to the grpc server on the port
     channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     this.stub = CryptoServiceGrpc.newBlockingStub(channel);
     this.BATCH_SIZE = batchSize;

--- a/test-clients/src/main/java/com/hedera/services/legacy/regression/ContractGetBalance.java
+++ b/test-clients/src/main/java/com/hedera/services/legacy/regression/ContractGetBalance.java
@@ -168,7 +168,7 @@ public class ContractGetBalance {
 	}
 
 	private AccountID createAccount(KeyPair keyPair, AccountID payerAccount, long initialBalance) throws Exception {
-		ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port).usePlaintext(true).build();
+		ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port).usePlaintext().build();
 		CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
 		Transaction transaction = TestHelper.createAccountWithFee(payerAccount, nodeAccount, keyPair, initialBalance,
 				accountKeys.get(payerAccount));
@@ -190,7 +190,7 @@ public class ContractGetBalance {
 		TransactionGetReceiptResponse receiptToReturn = null;
 		Query query = Query.newBuilder().setTransactionGetReceipt(
 				RequestBuilder.getTransactionGetReceiptQuery(transactionId, ResponseType.ANSWER_ONLY)).build();
-		ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port).usePlaintext(true).build();
+		ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port).usePlaintext().build();
 		CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
 		Response transactionReceipts = stub.getTransactionReceipts(query);
 		int attempts = 1;
@@ -213,7 +213,7 @@ public class ContractGetBalance {
 	private ContractID createContract(AccountID payerAccount, FileID contractFile, long durationInSeconds)
 			throws Exception {
 		ContractID createdContract = null;
-		ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port).usePlaintext(true).build();
+		ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port).usePlaintext().build();
 
 		Duration contractAutoRenew = Duration.newBuilder().setSeconds(durationInSeconds).build();
 		SmartContractServiceGrpc.SmartContractServiceBlockingStub stub = SmartContractServiceGrpc
@@ -262,7 +262,7 @@ public class ContractGetBalance {
 	private byte[] callContract(AccountID payerAccount, ContractID contractToCall, byte[] data) throws Exception {
 		byte[] dataToReturn = null;
 		ContractID createdContract = null;
-		ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port).usePlaintext(true).build();
+		ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port).usePlaintext().build();
 		SmartContractServiceGrpc.SmartContractServiceBlockingStub stub = SmartContractServiceGrpc
 				.newBlockingStub(channel);
 
@@ -308,7 +308,7 @@ public class ContractGetBalance {
 	private TransactionRecord getTransactionRecord(AccountID payerAccount, TransactionID transactionId)
 			throws Exception {
 		AccountID createdAccount = null;
-		ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port).usePlaintext(true).build();
+		ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port).usePlaintext().build();
 		CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
 		long fee = FeeClient.getCostForGettingTxRecord();
 		Response recordResp = executeQueryForTxRecord(payerAccount, transactionId, stub, fee, ResponseType.COST_ANSWER);
@@ -332,7 +332,7 @@ public class ContractGetBalance {
 			throws Exception {
 		byte[] dataToReturn = null;
 		ContractID createdContract = null;
-		ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port).usePlaintext(true).build();
+		ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port).usePlaintext().build();
 		SmartContractServiceGrpc.SmartContractServiceBlockingStub stub = SmartContractServiceGrpc
 				.newBlockingStub(channel);
 
@@ -402,7 +402,7 @@ public class ContractGetBalance {
 	private byte[] callContractLocal(AccountID payerAccount, ContractID contractToCall, byte[] data) throws Exception {
 		byte[] dataToReturn = null;
 		AccountID createdAccount = null;
-		ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port).usePlaintext(true).build();
+		ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port).usePlaintext().build();
 		SmartContractServiceGrpc.SmartContractServiceBlockingStub stub = SmartContractServiceGrpc
 				.newBlockingStub(channel);
 
@@ -456,7 +456,7 @@ public class ContractGetBalance {
 	public void updateContract(AccountID payerAccount, ContractID contractToUpdate, Duration autoRenewPeriod,
 			Timestamp expirationTime) throws Exception {
 
-		ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port).usePlaintext(true).build();
+		ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port).usePlaintext().build();
 		SmartContractServiceGrpc.SmartContractServiceBlockingStub stub = SmartContractServiceGrpc
 				.newBlockingStub(channel);
 
@@ -481,7 +481,7 @@ public class ContractGetBalance {
 
 	private String getContractByteCode(AccountID payerAccount, ContractID contractId) throws Exception {
 		String byteCode = "";
-		ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port).usePlaintext(true).build();
+		ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port).usePlaintext().build();
 		SmartContractServiceGrpc.SmartContractServiceBlockingStub stub = SmartContractServiceGrpc
 				.newBlockingStub(channel);
 		long fee = FeeClient.getFeeByID(HederaFunctionality.ContractGetBytecode);
@@ -511,7 +511,7 @@ public class ContractGetBalance {
 	}
 
 	private AccountInfo getCryptoGetAccountInfo(AccountID payerAccount, AccountID accountID) throws Exception {
-		ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port).usePlaintext(true).build();
+		ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port).usePlaintext().build();
 		CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
 
 		long fee = FeeClient.getFeeByID(HederaFunctionality.CryptoGetInfo);
@@ -537,7 +537,7 @@ public class ContractGetBalance {
 	}
 
 	private GetBySolidityIDResponse getBySolidityID(AccountID payerAccount, String solidityId) throws Exception {
-		ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port).usePlaintext(true).build();
+		ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port).usePlaintext().build();
 		SmartContractServiceGrpc.SmartContractServiceBlockingStub stub = SmartContractServiceGrpc
 				.newBlockingStub(channel);
 		long fee = FeeClient.getFeegetBySolidityID();
@@ -557,7 +557,7 @@ public class ContractGetBalance {
 		loadGenesisAndNodeAcccounts();
 
 		ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-				.usePlaintext(true)
+				.usePlaintext()
 				.build();
 		TestHelper.initializeFeeClient(channel, genesisAccount, genesisKeyPair, nodeAccount);
 		channel.shutdown();
@@ -631,7 +631,7 @@ public class ContractGetBalance {
 	}
 
 	private ContractInfo getContractInfo(AccountID payerAccount, ContractID contractId) throws Exception {
-		ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port).usePlaintext(true).build();
+		ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port).usePlaintext().build();
 		SmartContractServiceGrpc.SmartContractServiceBlockingStub stub = SmartContractServiceGrpc
 				.newBlockingStub(channel);
 		long fee = FeeClient.getFeeByID(HederaFunctionality.ContractGetInfo);
@@ -780,7 +780,7 @@ public class ContractGetBalance {
 		}
 		accBalanceBuilder.setHeader(queryHeader);
 		Query getBalQuery = Query.newBuilder().setCryptogetAccountBalance(accBalanceBuilder).build();
-		ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port).usePlaintext(true).build();
+		ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port).usePlaintext().build();
 		CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
 		respToReturn = stub.cryptoGetBalance(getBalQuery);
 		channel.shutdown();
@@ -791,7 +791,7 @@ public class ContractGetBalance {
 	private TransactionRecord deleteContractAndGetRecord(AccountID payerAccount, ContractID contractId,
 			AccountID transferAccount, ContractID transferContractID) throws Exception {
 		ContractID createdContract = null;
-		ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port).usePlaintext(true).build();
+		ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port).usePlaintext().build();
 
 		SmartContractServiceGrpc.SmartContractServiceBlockingStub stub = SmartContractServiceGrpc
 				.newBlockingStub(channel);
@@ -824,7 +824,7 @@ public class ContractGetBalance {
 	private ContractID createContractWithKey(AccountID payerAccount, FileID contractFile, long durationInSeconds,
 			KeyPair adminKeyPair) throws Exception {
 		ContractID createdContract = null;
-		ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port).usePlaintext(true).build();
+		ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port).usePlaintext().build();
 
 		byte[] pubKey = ((EdDSAPublicKey) adminKeyPair.getPublic()).getAbyte();
 		// note the admin key should be wrapped in a KeyList to match the signing

--- a/test-clients/src/main/java/com/hedera/services/legacy/regression/ContractToContract.java
+++ b/test-clients/src/main/java/com/hedera/services/legacy/regression/ContractToContract.java
@@ -158,7 +158,7 @@ public class ContractToContract {
 	}
 
 	private AccountID createAccount(KeyPair keyPair, AccountID payerAccount, long initialBalance) throws Exception {
-		ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port).usePlaintext(true).build();
+		ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port).usePlaintext().build();
 		CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
 		Transaction transaction = TestHelper.createAccountWithFee(payerAccount, nodeAccount, keyPair, initialBalance,
 				accountKeys.get(payerAccount));
@@ -179,7 +179,7 @@ public class ContractToContract {
 		TransactionGetReceiptResponse receiptToReturn = null;
 		Query query = Query.newBuilder().setTransactionGetReceipt(
 				RequestBuilder.getTransactionGetReceiptQuery(transactionId, ResponseType.ANSWER_ONLY)).build();
-		ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port).usePlaintext(true).build();
+		ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port).usePlaintext().build();
 		CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
 		Response transactionReceipts = stub.getTransactionReceipts(query);
 		int attempts = 1;
@@ -202,7 +202,7 @@ public class ContractToContract {
 	private ContractID createContract(AccountID payerAccount, FileID contractFile, long durationInSeconds)
 			throws Exception {
 		ContractID createdContract = null;
-		ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port).usePlaintext(true).build();
+		ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port).usePlaintext().build();
 
 		Duration contractAutoRenew = Duration.newBuilder().setSeconds(durationInSeconds).build();
 		SmartContractServiceGrpc.SmartContractServiceBlockingStub stub = SmartContractServiceGrpc
@@ -245,7 +245,7 @@ public class ContractToContract {
 	private byte[] callContract(AccountID payerAccount, ContractID contractToCall, byte[] data) throws Exception {
 		byte[] dataToReturn = null;
 		ContractID createdContract = null;
-		ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port).usePlaintext(true).build();
+		ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port).usePlaintext().build();
 		SmartContractServiceGrpc.SmartContractServiceBlockingStub stub = SmartContractServiceGrpc
 				.newBlockingStub(channel);
 
@@ -291,7 +291,7 @@ public class ContractToContract {
 			throws Exception {
 		AccountID createdAccount = null;
 		int port = 50211;
-		ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port).usePlaintext(true).build();
+		ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port).usePlaintext().build();
 		CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
 		long fee = FeeClient.getCostForGettingTxRecord();
 		Response recordResp = executeQueryForTxRecord(payerAccount, transactionId, stub, fee, ResponseType.COST_ANSWER);
@@ -338,7 +338,7 @@ public class ContractToContract {
 	private byte[] callContractLocal(AccountID payerAccount, ContractID contractToCall, byte[] data) throws Exception {
 		byte[] dataToReturn = null;
 		AccountID createdAccount = null;
-		ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port).usePlaintext(true).build();
+		ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port).usePlaintext().build();
 		SmartContractServiceGrpc.SmartContractServiceBlockingStub stub = SmartContractServiceGrpc
 				.newBlockingStub(channel);
 		ByteString callData = ByteString.EMPTY;
@@ -389,7 +389,7 @@ public class ContractToContract {
 	public void updateContract(AccountID payerAccount, ContractID contractToUpdate, Duration autoRenewPeriod,
 			Timestamp expirationTime) throws Exception {
 
-		ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port).usePlaintext(true).build();
+		ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port).usePlaintext().build();
 		SmartContractServiceGrpc.SmartContractServiceBlockingStub stub = SmartContractServiceGrpc
 				.newBlockingStub(channel);
 
@@ -413,7 +413,7 @@ public class ContractToContract {
 
 	private String getContractByteCode(AccountID payerAccount, ContractID contractId) throws Exception {
 		String byteCode = "";
-		ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port).usePlaintext(true).build();
+		ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port).usePlaintext().build();
 
 		SmartContractServiceGrpc.SmartContractServiceBlockingStub stub = SmartContractServiceGrpc
 				.newBlockingStub(channel);
@@ -445,7 +445,7 @@ public class ContractToContract {
 	}
 
 	private AccountInfo getCryptoGetAccountInfo(AccountID accountID) throws Exception {
-		ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port).usePlaintext(true).build();
+		ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port).usePlaintext().build();
 		CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
 
 		long fee = FeeClient.getFeeByID(HederaFunctionality.CryptoGetInfo);
@@ -472,7 +472,7 @@ public class ContractToContract {
 
 	private GetBySolidityIDResponse getBySolidityID(AccountID payerAccount, String solidityId) throws Exception {
 		int port = 50211;
-		ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port).usePlaintext(true).build();
+		ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port).usePlaintext().build();
 		SmartContractServiceGrpc.SmartContractServiceBlockingStub stub = SmartContractServiceGrpc
 				.newBlockingStub(channel);
 		long fee = FeeClient.getFeegetBySolidityID();
@@ -492,7 +492,7 @@ public class ContractToContract {
 		loadGenesisAndNodeAcccounts();
 
 		ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-				.usePlaintext(true)
+				.usePlaintext()
 				.build();
 		TestHelper.initializeFeeClient(channel, genesisAccount, genesisKeyPair, nodeAccount);
 		channel.shutdown();
@@ -583,7 +583,7 @@ public class ContractToContract {
 	}
 
 	private ContractInfo getContractInfo(AccountID payerAccount, ContractID contractId) throws Exception {
-		ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port).usePlaintext(true).build();
+		ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port).usePlaintext().build();
 
 		SmartContractServiceGrpc.SmartContractServiceBlockingStub stub = SmartContractServiceGrpc
 				.newBlockingStub(channel);

--- a/test-clients/src/main/java/com/hedera/services/legacy/regression/CryptoCreatePerformance.java
+++ b/test-clients/src/main/java/com/hedera/services/legacy/regression/CryptoCreatePerformance.java
@@ -61,7 +61,7 @@ public class CryptoCreatePerformance {
   public CryptoCreatePerformance(int port, String host, int batchSize, boolean retrieveTxReceipt) {
     // connecting to the grpc server on the port
     channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     this.stub = CryptoServiceGrpc.newBlockingStub(channel);
     this.BATCH_SIZE = batchSize;

--- a/test-clients/src/main/java/com/hedera/services/legacy/regression/CryptoDuplicatedTransaction.java
+++ b/test-clients/src/main/java/com/hedera/services/legacy/regression/CryptoDuplicatedTransaction.java
@@ -99,11 +99,11 @@ public class CryptoDuplicatedTransaction extends Thread {
     String host = properties.getProperty("host");
     int port = Integer.parseInt(properties.getProperty("port"));
 
-    channel = ManagedChannelBuilder.forAddress(host, port).usePlaintext(true).build();
+    channel = ManagedChannelBuilder.forAddress(host, port).usePlaintext().build();
     stub = CryptoServiceGrpc.newBlockingStub(channel);
 
     channel2 = ManagedChannelBuilder.forAddress(properties.getProperty("host2"),
-            Integer.parseInt(properties.getProperty("port2"))).usePlaintext(true).build();
+            Integer.parseInt(properties.getProperty("port2"))).usePlaintext().build();
     stub2 = CryptoServiceGrpc.newBlockingStub(channel2);
 
     try {

--- a/test-clients/src/main/java/com/hedera/services/legacy/regression/CryptoFeeTest.java
+++ b/test-clients/src/main/java/com/hedera/services/legacy/regression/CryptoFeeTest.java
@@ -70,7 +70,7 @@ public class CryptoFeeTest {
   public CryptoFeeTest(int port, String host) {
     // connecting to the grpc server on the port
     channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     CryptoFeeTest.stub = CryptoServiceGrpc.newBlockingStub(channel);
   }

--- a/test-clients/src/main/java/com/hedera/services/legacy/regression/CryptoTransferAll.java
+++ b/test-clients/src/main/java/com/hedera/services/legacy/regression/CryptoTransferAll.java
@@ -124,7 +124,7 @@ public class CryptoTransferAll {
 	  private AccountID createAccount(KeyPair keyPair, AccountID payerAccount, long initialBalance)
 	      throws Exception {
 	    ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-	        .usePlaintext(true)
+	        .usePlaintext()
 	        .build();
 	    CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
 	    Transaction transaction = TestHelper
@@ -150,7 +150,7 @@ public class CryptoTransferAll {
 	        .setTransactionGetReceipt(RequestBuilder.getTransactionGetReceiptQuery(
 	            transactionId, ResponseType.ANSWER_ONLY)).build();
 	    ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-	        .usePlaintext(true)
+	        .usePlaintext()
 	        .build();
 	    CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
 	    Response transactionReceipts = stub.getTransactionReceipts(query);
@@ -170,7 +170,7 @@ public class CryptoTransferAll {
 
 	  private TransactionRecord transferTo (AccountID fromAcct, AccountID toAcct, long amount) throws Exception {
 			ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-					.usePlaintext(true)
+					.usePlaintext()
 					.build();
 			CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
 
@@ -199,7 +199,7 @@ public class CryptoTransferAll {
 	      TransactionID transactionId) throws Exception {
 	    AccountID createdAccount = null;
 	    ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-	        .usePlaintext(true)
+	        .usePlaintext()
 	        .build();
 	    CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
 	    long fee = FeeClient.getCostForGettingTxRecord();

--- a/test-clients/src/main/java/com/hedera/services/legacy/regression/CryptoTransferCheckBalance.java
+++ b/test-clients/src/main/java/com/hedera/services/legacy/regression/CryptoTransferCheckBalance.java
@@ -92,7 +92,7 @@ public class CryptoTransferCheckBalance extends Thread {
     String host = properties.getProperty("host");
     int port = Integer.parseInt(properties.getProperty("port"));
 
-    channel = ManagedChannelBuilder.forAddress(host, port).usePlaintext(true).build();
+    channel = ManagedChannelBuilder.forAddress(host, port).usePlaintext().build();
     stub = CryptoServiceGrpc.newBlockingStub(channel);
 
     try {

--- a/test-clients/src/main/java/com/hedera/services/legacy/regression/CryptoTransferandUpdateParallel.java
+++ b/test-clients/src/main/java/com/hedera/services/legacy/regression/CryptoTransferandUpdateParallel.java
@@ -106,7 +106,7 @@ public class CryptoTransferandUpdateParallel {
     int port = Integer.parseInt(properties.getProperty("port"));
 
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     CryptoTransferandUpdateParallel.stub = CryptoServiceGrpc.newBlockingStub(channel);
 

--- a/test-clients/src/main/java/com/hedera/services/legacy/regression/CryptoTwoToFifty.java
+++ b/test-clients/src/main/java/com/hedera/services/legacy/regression/CryptoTwoToFifty.java
@@ -64,7 +64,7 @@ public class CryptoTwoToFifty {
   public CryptoTwoToFifty(int port, String host) {
     // connecting to the grpc server on the port
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     CryptoTwoToFifty.stub = CryptoServiceGrpc.newBlockingStub(channel);
   }
@@ -88,7 +88,7 @@ public class CryptoTwoToFifty {
 
     log.info("Connecting host = " + host + "; port = " + port);
     channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     CryptoTwoToFifty.stub = CryptoServiceGrpc.newBlockingStub(channel);
 

--- a/test-clients/src/main/java/com/hedera/services/legacy/regression/DynamicRestartTest.java
+++ b/test-clients/src/main/java/com/hedera/services/legacy/regression/DynamicRestartTest.java
@@ -542,7 +542,7 @@ public class DynamicRestartTest extends TestHelperComplex {
                 .setTransactionGetReceipt(RequestBuilder.getTransactionGetReceiptQuery(
                         transactionId, ResponseType.ANSWER_ONLY)).build();
         ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-                .usePlaintext(true)
+                .usePlaintext()
                 .build();
         CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
         Response transactionReceipts = stub.getTransactionReceipts(query);

--- a/test-clients/src/main/java/com/hedera/services/legacy/regression/FeeUtility.java
+++ b/test-clients/src/main/java/com/hedera/services/legacy/regression/FeeUtility.java
@@ -105,7 +105,7 @@ public class FeeUtility {
 
     loadGenesisAndNodeAcccounts();  // Use the genesisAccount
 
-    channel = ManagedChannelBuilder.forAddress(host, port).usePlaintext(true).build();
+    channel = ManagedChannelBuilder.forAddress(host, port).usePlaintext().build();
     fStub = FileServiceGrpc.newBlockingStub(channel);
 
     // Get the cost of gas in thousands of tinycents per unit

--- a/test-clients/src/main/java/com/hedera/services/legacy/regression/MaxFileSizeTest.java
+++ b/test-clients/src/main/java/com/hedera/services/legacy/regression/MaxFileSizeTest.java
@@ -142,7 +142,7 @@ public class MaxFileSizeTest {
 	}
 
 	private AccountID createAccount(KeyPair keyPair, AccountID payerAccount, long initialBalance) throws Exception {
-		ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port).usePlaintext(true).build();
+		ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port).usePlaintext().build();
 		CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
 		Transaction transaction = TestHelper.createAccountWithSigMap(payerAccount, nodeAccount, keyPair, initialBalance,
 				accountKeyPairs.get(payerAccount));
@@ -162,7 +162,7 @@ public class MaxFileSizeTest {
 			throws Exception {
 		Query query = Query.newBuilder().setTransactionGetReceipt(
 				RequestBuilder.getTransactionGetReceiptQuery(transactionId, ResponseType.ANSWER_ONLY)).build();
-		ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port).usePlaintext(true).build();
+		ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port).usePlaintext().build();
 		CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
 		Response transactionReceipts = stub.getTransactionReceipts(query);
 		int attempts = 1;
@@ -182,7 +182,7 @@ public class MaxFileSizeTest {
 
 	private TransactionRecord getTransactionRecord(AccountID payerAccount, TransactionID transactionId)
 			throws Exception {
-		ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port).usePlaintext(true).build();
+		ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port).usePlaintext().build();
 		CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
 		long fee = FeeClient.getCostForGettingTxRecord();
 		Response recordResp = executeQueryForTxRecord(payerAccount, transactionId, stub, fee, ResponseType.COST_ANSWER);
@@ -206,7 +206,7 @@ public class MaxFileSizeTest {
 			Timestamp expirationTime, String contractMemo, AccountID adminAccount, ResponseCodeEnum expectedStatus)
 			throws Exception {
 
-		ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port).usePlaintext(true).build();
+		ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port).usePlaintext().build();
 		SmartContractServiceGrpc.SmartContractServiceBlockingStub stub = SmartContractServiceGrpc
 				.newBlockingStub(channel);
 
@@ -346,7 +346,7 @@ public class MaxFileSizeTest {
         populateKeyListAndMapFromWacl(waclPubKeyList,waclPrivKeyList,keyList, pubKey2privKeyMap);
         Transaction signedFileCreate =TransactionSigner.signTransactionComplexWithSigMap(fileCreateRequest, keyList,
                 pubKey2privKeyMap);
-        ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port).usePlaintext(true).build();
+        ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port).usePlaintext().build();
 		FileServiceGrpc.FileServiceBlockingStub stub = FileServiceGrpc
 				.newBlockingStub(channel);
 		
@@ -384,7 +384,7 @@ public class MaxFileSizeTest {
         populateKeyListAndMapFromWacl(waclPubKeyList,waclPrivKeyList,keyList, pubKey2privKeyMap);
         Transaction signedFileAppend =TransactionSigner.signTransactionComplexWithSigMap(fileAppendRequest, keyList,
                 pubKey2privKeyMap);
-        ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port).usePlaintext(true).build();
+        ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port).usePlaintext().build();
 		FileServiceGrpc.FileServiceBlockingStub stub = FileServiceGrpc
 				.newBlockingStub(channel);
 		

--- a/test-clients/src/main/java/com/hedera/services/legacy/regression/MultiTransferConfigrableTest.java
+++ b/test-clients/src/main/java/com/hedera/services/legacy/regression/MultiTransferConfigrableTest.java
@@ -69,7 +69,7 @@ public class MultiTransferConfigrableTest {
       boolean retrieveTxReceipt) {
     // connecting to the grpc server on the port
     channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     this.stub = CryptoServiceGrpc.newBlockingStub(channel);
     this.BATCH_SIZE = batchSize;

--- a/test-clients/src/main/java/com/hedera/services/legacy/regression/RecordTestsContractCall.java
+++ b/test-clients/src/main/java/com/hedera/services/legacy/regression/RecordTestsContractCall.java
@@ -145,7 +145,7 @@ public class RecordTestsContractCall {
   private AccountID createAccount(KeyPair keyPair, AccountID payerAccount, long initialBalance)
       throws Exception {
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
     Transaction transaction = TestHelper
@@ -172,7 +172,7 @@ public class RecordTestsContractCall {
         .setTransactionGetReceipt(RequestBuilder.getTransactionGetReceiptQuery(
             transactionId, ResponseType.ANSWER_ONLY)).build();
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
     Response transactionReceipts = stub.getTransactionReceipts(query);
@@ -200,7 +200,7 @@ public class RecordTestsContractCall {
       throws Exception {
     ContractID createdContract = null;
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
 
     Duration contractAutoRenew = Duration.newBuilder().setSeconds(durationInSeconds).build();
@@ -255,7 +255,7 @@ public class RecordTestsContractCall {
     long totalCost = 0; // gas plus fees
     ContractID createdContract = null;
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     SmartContractServiceGrpc.SmartContractServiceBlockingStub stub = SmartContractServiceGrpc
         .newBlockingStub(channel);
@@ -308,7 +308,7 @@ public class RecordTestsContractCall {
       TransactionID transactionId) throws Exception {
     AccountID createdAccount = null;
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
     long fee = FeeClient.getCostForGettingTxRecord();
@@ -363,7 +363,7 @@ public class RecordTestsContractCall {
     byte[] dataToReturn = null;
     AccountID createdAccount = null;
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     SmartContractServiceGrpc.SmartContractServiceBlockingStub stub = SmartContractServiceGrpc
         .newBlockingStub(channel);
@@ -440,7 +440,7 @@ public class RecordTestsContractCall {
 
       // Get stub for querying cr account balance
       ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-          .usePlaintext(true)
+          .usePlaintext()
           .build();
       CryptoServiceGrpc.CryptoServiceBlockingStub balanceStub = CryptoServiceGrpc.newBlockingStub(channel);
 

--- a/test-clients/src/main/java/com/hedera/services/legacy/regression/RecordTestsContractCreate.java
+++ b/test-clients/src/main/java/com/hedera/services/legacy/regression/RecordTestsContractCreate.java
@@ -134,7 +134,7 @@ public class RecordTestsContractCreate {
   private AccountID createAccount(KeyPair keyPair, AccountID payerAccount, long initialBalance)
       throws Exception {
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
     Transaction transaction = TestHelper
@@ -161,7 +161,7 @@ public class RecordTestsContractCreate {
         .setTransactionGetReceipt(RequestBuilder.getTransactionGetReceiptQuery(
             transactionId, ResponseType.ANSWER_ONLY)).build();
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
     Response transactionReceipts = stub.getTransactionReceipts(query);
@@ -236,7 +236,7 @@ public class RecordTestsContractCreate {
       throws Exception {
     ContractID createdContract = null;
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
 
     Duration contractAutoRenew = Duration.newBuilder().setSeconds(autoRenewInSeconds).build();
@@ -289,7 +289,7 @@ public class RecordTestsContractCreate {
     loadGenesisAndNodeAcccounts();
 
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     TestHelper.initializeFeeClient(channel, genesisAccount, accountKeyPairs.get(genesisAccount),
         nodeAccount);
@@ -348,7 +348,7 @@ public class RecordTestsContractCreate {
       TransactionID transactionId) throws Exception {
     AccountID createdAccount = null;
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
     long fee = FeeClient.getCostForGettingTxRecord();

--- a/test-clients/src/main/java/com/hedera/services/legacy/regression/ServerAppConfigUtility.java
+++ b/test-clients/src/main/java/com/hedera/services/legacy/regression/ServerAppConfigUtility.java
@@ -100,7 +100,7 @@ public class ServerAppConfigUtility {
 
     loadGenesisAndNodeAcccounts();  // Use the genesisAccount
 
-    channel = ManagedChannelBuilder.forAddress(hostName, port).usePlaintext(true).build();
+    channel = ManagedChannelBuilder.forAddress(hostName, port).usePlaintext().build();
     fStub = FileServiceGrpc.newBlockingStub(channel);
     Response response;
 

--- a/test-clients/src/main/java/com/hedera/services/legacy/regression/SmartContractAdminSigning.java
+++ b/test-clients/src/main/java/com/hedera/services/legacy/regression/SmartContractAdminSigning.java
@@ -132,7 +132,7 @@ public class SmartContractAdminSigning {
   private AccountID createAccount(KeyPair keyPair, AccountID payerAccount, long initialBalance)
       throws Exception {
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
     Transaction transaction = TestHelper
@@ -158,7 +158,7 @@ public class SmartContractAdminSigning {
         .setTransactionGetReceipt(RequestBuilder.getTransactionGetReceiptQuery(
             transactionId, ResponseType.ANSWER_ONLY)).build();
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
     Response transactionReceipts = stub.getTransactionReceipts(query);
@@ -179,7 +179,7 @@ public class SmartContractAdminSigning {
       long durationInSeconds, Key adminKey,
       AccountID adminAccount, ResponseCodeEnum expectedStatus) throws Exception {
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
 
     Duration contractAutoRenew = Duration.newBuilder().setSeconds(durationInSeconds).build();
@@ -232,7 +232,7 @@ public class SmartContractAdminSigning {
     AccountID createdAccount = null;
     int port = 50211;
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
     long fee = FeeClient.getCostForGettingTxRecord();
@@ -270,7 +270,7 @@ public class SmartContractAdminSigning {
     loadGenesisAndNodeAcccounts();
 
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     TestHelper.initializeFeeClient(channel, genesisAccount, accountKeyPairs.get(genesisAccount),
         nodeAccount);

--- a/test-clients/src/main/java/com/hedera/services/legacy/regression/SmartContractCRUD.java
+++ b/test-clients/src/main/java/com/hedera/services/legacy/regression/SmartContractCRUD.java
@@ -136,7 +136,7 @@ public class SmartContractCRUD {
   private AccountID createAccount(KeyPair keyPair, AccountID payerAccount, long initialBalance)
       throws Exception {
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
     Transaction transaction = TestHelper
@@ -163,7 +163,7 @@ public class SmartContractCRUD {
         .setTransactionGetReceipt(RequestBuilder.getTransactionGetReceiptQuery(
             transactionId, ResponseType.ANSWER_ONLY)).build();
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
     Response transactionReceipts = stub.getTransactionReceipts(query);
@@ -188,7 +188,7 @@ public class SmartContractCRUD {
       AccountID adminAccount) throws Exception {
     ContractID createdContract = null;
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
 
     Duration contractAutoRenew = Duration.newBuilder().setSeconds(durationInSeconds).build();
@@ -254,7 +254,7 @@ public class SmartContractCRUD {
     byte[] dataToReturn = null;
     ContractID createdContract = null;
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     SmartContractServiceGrpc.SmartContractServiceBlockingStub stub = SmartContractServiceGrpc
         .newBlockingStub(channel);
@@ -307,7 +307,7 @@ public class SmartContractCRUD {
       TransactionID transactionId) throws Exception {
     AccountID createdAccount = null;
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
     long fee = FeeClient.getCostForGettingTxRecord();
@@ -364,7 +364,7 @@ public class SmartContractCRUD {
     byte[] dataToReturn = null;
     AccountID createdAccount = null;
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     SmartContractServiceGrpc.SmartContractServiceBlockingStub stub = SmartContractServiceGrpc
         .newBlockingStub(channel);
@@ -426,7 +426,7 @@ public class SmartContractCRUD {
       Key newAdminKey, AccountID newAdminAccount) throws Exception {
 
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     SmartContractServiceGrpc.SmartContractServiceBlockingStub stub = SmartContractServiceGrpc
         .newBlockingStub(channel);
@@ -479,7 +479,7 @@ public class SmartContractCRUD {
       AccountID adminAccount, ResponseCodeEnum expectedStatus) throws Exception {
     ContractID createdContract = null;
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
 
     SmartContractServiceGrpc.SmartContractServiceBlockingStub stub = SmartContractServiceGrpc
@@ -520,7 +520,7 @@ public class SmartContractCRUD {
       ContractID contractId) throws Exception {
     String byteCode = "";
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     SmartContractServiceGrpc.SmartContractServiceBlockingStub stub = SmartContractServiceGrpc
         .newBlockingStub(channel);
@@ -556,7 +556,7 @@ public class SmartContractCRUD {
   private AccountInfo getCryptoGetAccountInfo(
       AccountID accountID) throws Exception {
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
     long fee = FeeClient.getFeeByID(HederaFunctionality.CryptoGetInfo);
@@ -587,7 +587,7 @@ public class SmartContractCRUD {
   private GetBySolidityIDResponse getBySolidityID(AccountID payerAccount,
       String solidityId) throws Exception {
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     SmartContractServiceGrpc.SmartContractServiceBlockingStub stub = SmartContractServiceGrpc
         .newBlockingStub(channel);
@@ -609,7 +609,7 @@ public class SmartContractCRUD {
     loadGenesisAndNodeAcccounts();
 
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     TestHelper.initializeFeeClient(channel, genesisAccount, accountKeyPairs.get(genesisAccount),
         nodeAccount);
@@ -805,7 +805,7 @@ public class SmartContractCRUD {
   private ContractInfo getContractInfo(AccountID payerAccount,
       ContractID contractId) throws Exception {
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     SmartContractServiceGrpc.SmartContractServiceBlockingStub stub = SmartContractServiceGrpc
         .newBlockingStub(channel);

--- a/test-clients/src/main/java/com/hedera/services/legacy/regression/SmartContractCallLocal.java
+++ b/test-clients/src/main/java/com/hedera/services/legacy/regression/SmartContractCallLocal.java
@@ -145,7 +145,7 @@ public class SmartContractCallLocal {
   private AccountID createAccount(KeyPair keyPair, AccountID payerAccount, long initialBalance)
       throws Exception {
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
     Transaction transaction = TestHelper
@@ -172,7 +172,7 @@ public class SmartContractCallLocal {
         .setTransactionGetReceipt(RequestBuilder.getTransactionGetReceiptQuery(
             transactionId, ResponseType.ANSWER_ONLY)).build();
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
     Response transactionReceipts = stub.getTransactionReceipts(query);
@@ -199,7 +199,7 @@ public class SmartContractCallLocal {
       long durationInSeconds) throws Exception {
     ContractID createdContract = null;
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
 
     Duration contractAutoRenew = Duration.newBuilder().setSeconds(durationInSeconds).build();
@@ -259,7 +259,7 @@ public class SmartContractCallLocal {
     byte[] dataToReturn = null;
     ContractID createdContract = null;
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     SmartContractServiceGrpc.SmartContractServiceBlockingStub stub = SmartContractServiceGrpc
         .newBlockingStub(channel);
@@ -311,7 +311,7 @@ public class SmartContractCallLocal {
     AccountID createdAccount = null;
     int port = 50211;
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
     long fee = FeeClient.getCostForGettingTxRecord();
@@ -385,7 +385,7 @@ public class SmartContractCallLocal {
     byte[] dataToReturn = null;
     AccountID createdAccount = null;
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     SmartContractServiceGrpc.SmartContractServiceBlockingStub stub = SmartContractServiceGrpc
         .newBlockingStub(channel);
@@ -430,7 +430,7 @@ public class SmartContractCallLocal {
     loadGenesisAndNodeAcccounts();
 
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     TestHelper.initializeFeeClient(channel, genesisAccount, accountKeyPairs.get(genesisAccount),
         nodeAccount);

--- a/test-clients/src/main/java/com/hedera/services/legacy/regression/SmartContractCreateContract.java
+++ b/test-clients/src/main/java/com/hedera/services/legacy/regression/SmartContractCreateContract.java
@@ -144,7 +144,7 @@ public class SmartContractCreateContract {
   private AccountID createAccount(KeyPair keyPair, AccountID payerAccount, long initialBalance)
       throws Exception {
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
     Transaction transaction = TestHelper
@@ -170,7 +170,7 @@ public class SmartContractCreateContract {
         .setTransactionGetReceipt(RequestBuilder.getTransactionGetReceiptQuery(
             transactionId, ResponseType.ANSWER_ONLY)).build();
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
     Response transactionReceipts = stub.getTransactionReceipts(query);
@@ -191,7 +191,7 @@ public class SmartContractCreateContract {
       long durationInSeconds) throws Exception {
     ContractID createdContract = null;
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
 
     Duration contractAutoRenew = Duration.newBuilder().setSeconds(durationInSeconds).build();
@@ -301,7 +301,7 @@ public class SmartContractCreateContract {
       byte[] data, ResponseCodeEnum expectedStatus)
       throws Exception {
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     SmartContractServiceGrpc.SmartContractServiceBlockingStub stub = SmartContractServiceGrpc
         .newBlockingStub(channel);
@@ -347,7 +347,7 @@ public class SmartContractCreateContract {
     AccountID createdAccount = null;
     int port = 50211;
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
     long fee = FeeClient.getCostForGettingTxRecord();
@@ -376,7 +376,7 @@ public class SmartContractCreateContract {
   private byte[] callContractLocal(AccountID payerAccount, ContractID contractToCall, byte[] data)
       throws Exception {
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     SmartContractServiceGrpc.SmartContractServiceBlockingStub stub = SmartContractServiceGrpc
         .newBlockingStub(channel);
@@ -447,7 +447,7 @@ public class SmartContractCreateContract {
     loadGenesisAndNodeAcccounts();
 
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     TestHelper.initializeFeeClient(channel, genesisAccount, accountKeyPairs.get(genesisAccount),
         nodeAccount);
@@ -496,7 +496,7 @@ public class SmartContractCreateContract {
   private ContractInfo getContractInfo(AccountID payerAccount,
       ContractID contractId) throws Exception {
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
 
     SmartContractServiceGrpc.SmartContractServiceBlockingStub stub = SmartContractServiceGrpc

--- a/test-clients/src/main/java/com/hedera/services/legacy/regression/SmartContractDeletePayable.java
+++ b/test-clients/src/main/java/com/hedera/services/legacy/regression/SmartContractDeletePayable.java
@@ -157,7 +157,7 @@ public class SmartContractDeletePayable {
 	}
 
 	private AccountID createAccount(KeyPair keyPair, AccountID payerAccount, long initialBalance) throws Exception {
-		ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port).usePlaintext(true).build();
+		ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port).usePlaintext().build();
 		CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
 		Transaction transaction = TestHelper.createAccountWithSigMap(payerAccount, nodeAccount, keyPair, initialBalance,
 				accountKeyPairs.get(payerAccount));
@@ -178,7 +178,7 @@ public class SmartContractDeletePayable {
 		TransactionGetReceiptResponse receiptToReturn = null;
 		Query query = Query.newBuilder().setTransactionGetReceipt(
 				RequestBuilder.getTransactionGetReceiptQuery(transactionId, ResponseType.ANSWER_ONLY)).build();
-		ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port).usePlaintext(true).build();
+		ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port).usePlaintext().build();
 		CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
 		Response transactionReceipts = stub.getTransactionReceipts(query);
 		int attempts = 1;
@@ -215,7 +215,7 @@ public class SmartContractDeletePayable {
 	private byte[] callContract(AccountID payerAccount, ContractID contractToCall, byte[] data) throws Exception {
 		byte[] dataToReturn = null;
 		ContractID createdContract = null;
-		ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port).usePlaintext(true).build();
+		ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port).usePlaintext().build();
 		SmartContractServiceGrpc.SmartContractServiceBlockingStub stub = SmartContractServiceGrpc
 				.newBlockingStub(channel);
 
@@ -262,7 +262,7 @@ public class SmartContractDeletePayable {
 	private TransactionRecord getTransactionRecord(AccountID payerAccount, TransactionID transactionId)
 			throws Exception {
 		AccountID createdAccount = null;
-		ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port).usePlaintext(true).build();
+		ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port).usePlaintext().build();
 		CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
 		long fee = FeeClient.getCostForGettingTxRecord();
 		Response recordResp = executeQueryForTxRecord(payerAccount, transactionId, stub, fee, ResponseType.COST_ANSWER);
@@ -285,7 +285,7 @@ public class SmartContractDeletePayable {
 	private ResponseCodeEnum callContract(AccountID payerAccount, ContractID contractToCall, byte[] data, long value)
 			throws Exception {
 		ContractID createdContract = null;
-		ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port).usePlaintext(true).build();
+		ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port).usePlaintext().build();
 		SmartContractServiceGrpc.SmartContractServiceBlockingStub stub = SmartContractServiceGrpc
 				.newBlockingStub(channel);
 
@@ -358,7 +358,7 @@ public class SmartContractDeletePayable {
 			ResponseCodeEnum expectedPrecheckCode) throws Exception {
 		byte[] dataToReturn = null;
 		AccountID createdAccount = null;
-		ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port).usePlaintext(true).build();
+		ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port).usePlaintext().build();
 		SmartContractServiceGrpc.SmartContractServiceBlockingStub stub = SmartContractServiceGrpc
 				.newBlockingStub(channel);
 
@@ -415,7 +415,7 @@ public class SmartContractDeletePayable {
 	public ResponseCodeEnum updateContract(AccountID payerAccount, ContractID contractToUpdate,
 			Duration autoRenewPeriod) throws Exception {
 
-		ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port).usePlaintext(true).build();
+		ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port).usePlaintext().build();
 		SmartContractServiceGrpc.SmartContractServiceBlockingStub stub = SmartContractServiceGrpc
 				.newBlockingStub(channel);
 
@@ -454,7 +454,7 @@ public class SmartContractDeletePayable {
 
 	private String getContractByteCode(AccountID payerAccount, ContractID contractId) throws Exception {
 		String byteCode = "";
-		ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port).usePlaintext(true).build();
+		ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port).usePlaintext().build();
 		SmartContractServiceGrpc.SmartContractServiceBlockingStub stub = SmartContractServiceGrpc
 				.newBlockingStub(channel);
 		long fee = FeeClient.getFeeByID(HederaFunctionality.ContractGetBytecode);
@@ -484,7 +484,7 @@ public class SmartContractDeletePayable {
 	}
 
 	private AccountInfo getCryptoGetAccountInfo(AccountID payerAccount, AccountID accountID) throws Exception {
-		ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port).usePlaintext(true).build();
+		ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port).usePlaintext().build();
 		CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
 
 		long fee = FeeClient.getFeeByID(HederaFunctionality.CryptoGetInfo);
@@ -510,7 +510,7 @@ public class SmartContractDeletePayable {
 	}
 
 	private GetBySolidityIDResponse getBySolidityID(AccountID payerAccount, String solidityId) throws Exception {
-		ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port).usePlaintext(true).build();
+		ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port).usePlaintext().build();
 		SmartContractServiceGrpc.SmartContractServiceBlockingStub stub = SmartContractServiceGrpc
 				.newBlockingStub(channel);
 		long fee = FeeClient.getFeegetBySolidityID();
@@ -530,7 +530,7 @@ public class SmartContractDeletePayable {
 		loadGenesisAndNodeAcccounts();
 
 		ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-				.usePlaintext(true)
+				.usePlaintext()
 				.build();
 		TestHelper.initializeFeeClient(channel, genesisAccount, accountKeyPairs.get(genesisAccount),
 				nodeAccount);
@@ -633,7 +633,7 @@ public class SmartContractDeletePayable {
 
 	private ContractInfo getContractInfo(AccountID payerAccount, ContractID contractId,
 			ResponseCodeEnum expectedConstResponse, ResponseCodeEnum expecedAnswerResponse) throws Exception {
-		ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port).usePlaintext(true).build();
+		ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port).usePlaintext().build();
 		SmartContractServiceGrpc.SmartContractServiceBlockingStub stub = SmartContractServiceGrpc
 				.newBlockingStub(channel);
 		ContractInfo contractInfToReturn = null;
@@ -780,7 +780,7 @@ public class SmartContractDeletePayable {
 	private ResponseCodeEnum deleteContract(AccountID payerAccount, ContractID contractId, AccountID transferAccount,
 			ContractID transferContractID) throws Exception {
 		ContractID createdContract = null;
-		ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port).usePlaintext(true).build();
+		ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port).usePlaintext().build();
 
 		SmartContractServiceGrpc.SmartContractServiceBlockingStub stub = SmartContractServiceGrpc
 				.newBlockingStub(channel);
@@ -814,7 +814,7 @@ public class SmartContractDeletePayable {
 	private ContractID createContractWithKey(AccountID payerAccount, FileID contractFile, long durationInSeconds,
 			KeyPair adminKeyPair) throws Exception {
 		ContractID createdContract = null;
-		ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port).usePlaintext(true).build();
+		ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port).usePlaintext().build();
 
 		byte[] pubKey = ((EdDSAPublicKey) adminKeyPair.getPublic()).getAbyte();
 		// note the admin key should be wrapped in a KeyList to match the signing
@@ -859,7 +859,7 @@ public class SmartContractDeletePayable {
 	private TransactionRecord deleteContractAndGetRecord(AccountID payerAccount, ContractID contractId,
 			AccountID transferAccount, ContractID transferContractID) throws Exception {
 		ContractID createdContract = null;
-		ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port).usePlaintext(true).build();
+		ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port).usePlaintext().build();
 
 		SmartContractServiceGrpc.SmartContractServiceBlockingStub stub = SmartContractServiceGrpc
 				.newBlockingStub(channel);

--- a/test-clients/src/main/java/com/hedera/services/legacy/regression/SmartContractInvalidCallWithValue.java
+++ b/test-clients/src/main/java/com/hedera/services/legacy/regression/SmartContractInvalidCallWithValue.java
@@ -141,7 +141,7 @@ public class SmartContractInvalidCallWithValue {
   private AccountID createAccount(KeyPair keyPair, AccountID payerAccount, long initialBalance)
       throws Exception {
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
     Transaction transaction = TestHelper
@@ -168,7 +168,7 @@ public class SmartContractInvalidCallWithValue {
         .setTransactionGetReceipt(RequestBuilder.getTransactionGetReceiptQuery(
             transactionId, ResponseType.ANSWER_ONLY)).build();
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
     Response transactionReceipts = stub.getTransactionReceipts(query);
@@ -196,7 +196,7 @@ public class SmartContractInvalidCallWithValue {
       throws Exception {
     ContractID createdContract = null;
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
 
     Duration contractAutoRenew = Duration.newBuilder().setSeconds(durationInSeconds).build();
@@ -258,7 +258,7 @@ public class SmartContractInvalidCallWithValue {
     long totalCost = 0; // gas plus fees
     ContractID createdContract = null;
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     SmartContractServiceGrpc.SmartContractServiceBlockingStub stub = SmartContractServiceGrpc
         .newBlockingStub(channel);
@@ -315,7 +315,7 @@ public class SmartContractInvalidCallWithValue {
       TransactionID transactionId) throws Exception {
     AccountID createdAccount = null;
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
     long fee = FeeClient.getCostForGettingTxRecord();
@@ -370,7 +370,7 @@ public class SmartContractInvalidCallWithValue {
     byte[] dataToReturn = null;
     AccountID createdAccount = null;
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     SmartContractServiceGrpc.SmartContractServiceBlockingStub stub = SmartContractServiceGrpc
         .newBlockingStub(channel);
@@ -447,7 +447,7 @@ public class SmartContractInvalidCallWithValue {
 
       // Get stub for querying cr account balance
       ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-          .usePlaintext(true)
+          .usePlaintext()
           .build();
       CryptoServiceGrpc.CryptoServiceBlockingStub balanceStub = CryptoServiceGrpc.newBlockingStub(channel);
 

--- a/test-clients/src/main/java/com/hedera/services/legacy/regression/SmartContractNegativeCalls.java
+++ b/test-clients/src/main/java/com/hedera/services/legacy/regression/SmartContractNegativeCalls.java
@@ -148,7 +148,7 @@ public class SmartContractNegativeCalls {
   private AccountID createAccount(KeyPair keyPair, AccountID payerAccount, long initialBalance)
       throws Exception {
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
     Transaction transaction = TestHelper
@@ -174,7 +174,7 @@ public class SmartContractNegativeCalls {
         .setTransactionGetReceipt(RequestBuilder.getTransactionGetReceiptQuery(
             transactionId, ResponseType.ANSWER_ONLY)).build();
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
     Response transactionReceipts = stub.getTransactionReceipts(query);
@@ -198,7 +198,7 @@ public class SmartContractNegativeCalls {
       long durationInSeconds) throws Exception {
     ContractID createdContract = null;
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
 
     Duration contractAutoRenew = Duration.newBuilder().setSeconds(durationInSeconds).build();
@@ -259,7 +259,7 @@ public class SmartContractNegativeCalls {
     byte[] dataToReturn = null;
     ContractID createdContract = null;
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     SmartContractServiceGrpc.SmartContractServiceBlockingStub stub = SmartContractServiceGrpc
         .newBlockingStub(channel);
@@ -319,7 +319,7 @@ public class SmartContractNegativeCalls {
     AccountID createdAccount = null;
     int port = 50211;
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
     long fee = FeeClient.getCostForGettingTxRecord();
@@ -376,7 +376,7 @@ public class SmartContractNegativeCalls {
     byte[] dataToReturn = null;
     AccountID createdAccount = null;
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     SmartContractServiceGrpc.SmartContractServiceBlockingStub stub = SmartContractServiceGrpc
         .newBlockingStub(channel);
@@ -437,7 +437,7 @@ public class SmartContractNegativeCalls {
     loadGenesisAndNodeAcccounts();
 
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     TestHelper.initializeFeeClient(channel, genesisAccount, accountKeyPairs.get(genesisAccount),
         nodeAccount);

--- a/test-clients/src/main/java/com/hedera/services/legacy/regression/SmartContractNegativeCreates.java
+++ b/test-clients/src/main/java/com/hedera/services/legacy/regression/SmartContractNegativeCreates.java
@@ -134,7 +134,7 @@ public class SmartContractNegativeCreates {
   private AccountID createAccount(KeyPair keyPair, AccountID payerAccount, long initialBalance)
       throws Exception {
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
     Transaction transaction = TestHelper
@@ -161,7 +161,7 @@ public class SmartContractNegativeCreates {
         .setTransactionGetReceipt(RequestBuilder.getTransactionGetReceiptQuery(
             transactionId, ResponseType.ANSWER_ONLY)).build();
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
     Response transactionReceipts = stub.getTransactionReceipts(query);
@@ -236,7 +236,7 @@ public class SmartContractNegativeCreates {
       throws Exception {
     ContractID createdContract = null;
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
 
     Duration contractAutoRenew = Duration.newBuilder().setSeconds(autoRenewInSeconds).build();
@@ -305,7 +305,7 @@ public class SmartContractNegativeCreates {
     AccountID createdAccount = null;
     int port = 50211;
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
     long fee = FeeClient.getCostForGettingTxRecord();
@@ -342,7 +342,7 @@ public class SmartContractNegativeCreates {
     loadGenesisAndNodeAcccounts();
 
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     TestHelper.initializeFeeClient(channel, genesisAccount, accountKeyPairs.get(genesisAccount),
         nodeAccount);

--- a/test-clients/src/main/java/com/hedera/services/legacy/regression/SmartContractNonexistent.java
+++ b/test-clients/src/main/java/com/hedera/services/legacy/regression/SmartContractNonexistent.java
@@ -153,7 +153,7 @@ public class SmartContractNonexistent {
 	  private AccountID createAccount(KeyPair keyPair, AccountID payerAccount, long initialBalance)
 	      throws Exception {
 	    ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-	        .usePlaintext(true)
+	        .usePlaintext()
 	        .build();
 	    CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
 	    Transaction transaction = TestHelper
@@ -180,7 +180,7 @@ public class SmartContractNonexistent {
 	        .setTransactionGetReceipt(RequestBuilder.getTransactionGetReceiptQuery(
 	            transactionId, ResponseType.ANSWER_ONLY)).build();
 	    ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-	        .usePlaintext(true)
+	        .usePlaintext()
 	        .build();
 	    CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
 	    Response transactionReceipts = stub.getTransactionReceipts(query);
@@ -207,7 +207,7 @@ public class SmartContractNonexistent {
 	      long durationInSeconds) throws Exception {
 	    ContractID createdContract = null;
 	    ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-	        .usePlaintext(true)
+	        .usePlaintext()
 	        .build();
 
 	    Duration contractAutoRenew = Duration.newBuilder().setSeconds(durationInSeconds).build();
@@ -260,7 +260,7 @@ public class SmartContractNonexistent {
 	    byte[] dataToReturn = null;
 	    ContractID createdContract = null;
 	    ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-	        .usePlaintext(true)
+	        .usePlaintext()
 	        .build();
 	    SmartContractServiceGrpc.SmartContractServiceBlockingStub stub = SmartContractServiceGrpc
 	        .newBlockingStub(channel);
@@ -314,7 +314,7 @@ public class SmartContractNonexistent {
 	      TransactionID transactionId) throws Exception {
 	    AccountID createdAccount = null;
 	    ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-	        .usePlaintext(true)
+	        .usePlaintext()
 	        .build();
 	    CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
 	    long fee = FeeClient.getCostForGettingTxRecord();
@@ -343,7 +343,7 @@ public class SmartContractNonexistent {
 			byte[] data, long value) throws Exception {
 	    ContractID createdContract = null;
 	    ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-	        .usePlaintext(true)
+	        .usePlaintext()
 	        .build();
 	    SmartContractServiceGrpc.SmartContractServiceBlockingStub stub = SmartContractServiceGrpc
 	        .newBlockingStub(channel);
@@ -400,7 +400,7 @@ public class SmartContractNonexistent {
 	    byte[] dataToReturn = null;
 	    AccountID createdAccount = null;
 	    ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-	        .usePlaintext(true)
+	        .usePlaintext()
 	        .build();
 	    SmartContractServiceGrpc.SmartContractServiceBlockingStub stub = SmartContractServiceGrpc
 	        .newBlockingStub(channel);
@@ -455,7 +455,7 @@ public class SmartContractNonexistent {
 	      Duration autoRenewPeriod) throws Exception {
 
 	    ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-	        .usePlaintext(true)
+	        .usePlaintext()
 	        .build();
 	    SmartContractServiceGrpc.SmartContractServiceBlockingStub stub = SmartContractServiceGrpc
 	        .newBlockingStub(channel);
@@ -499,7 +499,7 @@ public class SmartContractNonexistent {
 	      ContractID contractId) throws Exception {
 	    String byteCode = "";
 	    ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-	        .usePlaintext(true)
+	        .usePlaintext()
 	        .build();
 	    SmartContractServiceGrpc.SmartContractServiceBlockingStub stub = SmartContractServiceGrpc
 	        .newBlockingStub(channel);
@@ -535,7 +535,7 @@ public class SmartContractNonexistent {
 	  private AccountInfo getCryptoGetAccountInfo(AccountID payerAccount,
 	      AccountID accountID) throws Exception {
 	    ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-	        .usePlaintext(true)
+	        .usePlaintext()
 	        .build();
 	    CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
 
@@ -569,7 +569,7 @@ public class SmartContractNonexistent {
 	  private GetBySolidityIDResponse getBySolidityID(AccountID payerAccount,
 	      String solidityId) throws Exception {
 	    ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-	        .usePlaintext(true)
+	        .usePlaintext()
 	        .build();
 	    SmartContractServiceGrpc.SmartContractServiceBlockingStub stub = SmartContractServiceGrpc
 	        .newBlockingStub(channel);
@@ -591,7 +591,7 @@ public class SmartContractNonexistent {
 	    loadGenesisAndNodeAcccounts();
 
 			ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-					.usePlaintext(true)
+					.usePlaintext()
 					.build();
 			TestHelper.initializeFeeClient(channel, genesisAccount, accountKeyPairs.get(genesisAccount),
 					nodeAccount);
@@ -662,7 +662,7 @@ public class SmartContractNonexistent {
 	  private ContractInfo getContractInfo(AccountID payerAccount,
 		      ContractID contractId,ResponseCodeEnum expectedConstResponse , ResponseCodeEnum expecedAnswerResponse) throws Exception {
 		    ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-		        .usePlaintext(true)
+		        .usePlaintext()
 		        .build();
 		    SmartContractServiceGrpc.SmartContractServiceBlockingStub stub = SmartContractServiceGrpc
 		        .newBlockingStub(channel);
@@ -786,7 +786,7 @@ public class SmartContractNonexistent {
 		      AccountID transferAccount , ContractID transferContractID ) throws Exception {
 		    ContractID createdContract = null;
 		    ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-		        .usePlaintext(true)
+		        .usePlaintext()
 		        .build();
 
 		   

--- a/test-clients/src/main/java/com/hedera/services/legacy/regression/SmartContractPay.java
+++ b/test-clients/src/main/java/com/hedera/services/legacy/regression/SmartContractPay.java
@@ -156,7 +156,7 @@ public class SmartContractPay {
   private AccountID createAccount(KeyPair keyPair, AccountID payerAccount, long initialBalance)
       throws Exception {
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
     Transaction transaction = TestHelper
@@ -183,7 +183,7 @@ public class SmartContractPay {
         .setTransactionGetReceipt(RequestBuilder.getTransactionGetReceiptQuery(
             transactionId, ResponseType.ANSWER_ONLY)).build();
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
     Response transactionReceipts = stub.getTransactionReceipts(query);
@@ -210,7 +210,7 @@ public class SmartContractPay {
       long durationInSeconds) throws Exception {
     ContractID createdContract = null;
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
 
     Duration contractAutoRenew = Duration.newBuilder().setSeconds(durationInSeconds).build();
@@ -271,7 +271,7 @@ public class SmartContractPay {
     byte[] dataToReturn = null;
     ContractID createdContract = null;
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     SmartContractServiceGrpc.SmartContractServiceBlockingStub stub = SmartContractServiceGrpc
         .newBlockingStub(channel);
@@ -325,7 +325,7 @@ public class SmartContractPay {
       TransactionID transactionId) throws Exception {
     AccountID createdAccount = null;
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
     long fee = TestHelper.getCryptoMaxFee();
@@ -352,7 +352,7 @@ public class SmartContractPay {
     byte[] dataToReturn = null;
     ContractID createdContract = null;
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     SmartContractServiceGrpc.SmartContractServiceBlockingStub stub = SmartContractServiceGrpc
         .newBlockingStub(channel);
@@ -432,7 +432,7 @@ public class SmartContractPay {
     byte[] dataToReturn = null;
     AccountID createdAccount = null;
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     SmartContractServiceGrpc.SmartContractServiceBlockingStub stub = SmartContractServiceGrpc
         .newBlockingStub(channel);
@@ -493,7 +493,7 @@ public class SmartContractPay {
       ContractID contractId) throws Exception {
     String byteCode = "";
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     SmartContractServiceGrpc.SmartContractServiceBlockingStub stub = SmartContractServiceGrpc
         .newBlockingStub(channel);
@@ -525,7 +525,7 @@ public class SmartContractPay {
   private AccountInfo getCryptoGetAccountInfo(AccountID payerAccount,
       AccountID accountID) throws Exception {
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
 
@@ -559,7 +559,7 @@ public class SmartContractPay {
   private GetBySolidityIDResponse getBySolidityID(AccountID payerAccount,
       String solidityId) throws Exception {
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     SmartContractServiceGrpc.SmartContractServiceBlockingStub stub = SmartContractServiceGrpc
         .newBlockingStub(channel);
@@ -581,7 +581,7 @@ public class SmartContractPay {
     loadGenesisAndNodeAcccounts();
 
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     TestHelper.initializeFeeClient(channel, genesisAccount, accountKeyPairs.get(genesisAccount),
         nodeAccount);
@@ -630,7 +630,7 @@ public class SmartContractPay {
   private ContractInfo getContractInfo(AccountID payerAccount,
       ContractID contractId) throws Exception {
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     SmartContractServiceGrpc.SmartContractServiceBlockingStub stub = SmartContractServiceGrpc
         .newBlockingStub(channel);

--- a/test-clients/src/main/java/com/hedera/services/legacy/regression/SmartContractPayReceivable.java
+++ b/test-clients/src/main/java/com/hedera/services/legacy/regression/SmartContractPayReceivable.java
@@ -158,7 +158,7 @@ public class SmartContractPayReceivable {
   private AccountID createAccount(KeyPair keyPair, AccountID payerAccount, long initialBalance)
       throws Exception {
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
     Transaction transaction = TestHelper
@@ -184,7 +184,7 @@ public class SmartContractPayReceivable {
         .setTransactionGetReceipt(RequestBuilder.getTransactionGetReceiptQuery(
             transactionId, ResponseType.ANSWER_ONLY)).build();
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
     Response transactionReceipts = stub.getTransactionReceipts(query);
@@ -211,7 +211,7 @@ public class SmartContractPayReceivable {
       long durationInSeconds) throws Exception {
     ContractID createdContract = null;
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
 
     Duration contractAutoRenew = Duration.newBuilder().setSeconds(durationInSeconds).build();
@@ -271,7 +271,7 @@ public class SmartContractPayReceivable {
     byte[] dataToReturn = null;
     ContractID createdContract = null;
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     SmartContractServiceGrpc.SmartContractServiceBlockingStub stub = SmartContractServiceGrpc
         .newBlockingStub(channel);
@@ -325,7 +325,7 @@ public class SmartContractPayReceivable {
       TransactionID transactionId) throws Exception {
     AccountID createdAccount = null;
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
     long fee = FeeClient.getCostForGettingTxRecord();
@@ -355,7 +355,7 @@ public class SmartContractPayReceivable {
     byte[] dataToReturn = null;
     ContractID createdContract = null;
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     SmartContractServiceGrpc.SmartContractServiceBlockingStub stub = SmartContractServiceGrpc
         .newBlockingStub(channel);
@@ -435,7 +435,7 @@ public class SmartContractPayReceivable {
     byte[] dataToReturn = null;
     AccountID createdAccount = null;
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     SmartContractServiceGrpc.SmartContractServiceBlockingStub stub = SmartContractServiceGrpc
         .newBlockingStub(channel);
@@ -499,7 +499,7 @@ public class SmartContractPayReceivable {
       ContractID contractId) throws Exception {
     String byteCode = "";
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     SmartContractServiceGrpc.SmartContractServiceBlockingStub stub = SmartContractServiceGrpc
         .newBlockingStub(channel);
@@ -535,7 +535,7 @@ public class SmartContractPayReceivable {
   private AccountInfo getCryptoGetAccountInfo(
       AccountID accountID) throws Exception {
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
 
@@ -567,7 +567,7 @@ public class SmartContractPayReceivable {
   private GetBySolidityIDResponse getBySolidityID(AccountID payerAccount,
       String solidityId) throws Exception {
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     SmartContractServiceGrpc.SmartContractServiceBlockingStub stub = SmartContractServiceGrpc
         .newBlockingStub(channel);
@@ -589,7 +589,7 @@ public class SmartContractPayReceivable {
     loadGenesisAndNodeAcccounts();
 
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     TestHelper.initializeFeeClient(channel, genesisAccount, accountKeyPairs.get(genesisAccount),
         nodeAccount);
@@ -634,7 +634,7 @@ public class SmartContractPayReceivable {
   private ContractInfo getContractInfo(AccountID payerAccount,
       ContractID contractId) throws Exception {
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     SmartContractServiceGrpc.SmartContractServiceBlockingStub stub = SmartContractServiceGrpc
         .newBlockingStub(channel);

--- a/test-clients/src/main/java/com/hedera/services/legacy/regression/SmartContractPayReceivableAmount.java
+++ b/test-clients/src/main/java/com/hedera/services/legacy/regression/SmartContractPayReceivableAmount.java
@@ -156,7 +156,7 @@ public class SmartContractPayReceivableAmount {
 	  private AccountID createAccount(KeyPair keyPair, AccountID payerAccount, long initialBalance)
 	      throws Exception {
 	    ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-	        .usePlaintext(true)
+	        .usePlaintext()
 	        .build();
 	    CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
 	    Transaction transaction = TestHelper
@@ -182,7 +182,7 @@ public class SmartContractPayReceivableAmount {
 	        .setTransactionGetReceipt(RequestBuilder.getTransactionGetReceiptQuery(
 	            transactionId, ResponseType.ANSWER_ONLY)).build();
 	    ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-	        .usePlaintext(true)
+	        .usePlaintext()
 	        .build();
 	    CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
 	    Response transactionReceipts = stub.getTransactionReceipts(query);
@@ -209,7 +209,7 @@ public class SmartContractPayReceivableAmount {
 	      long durationInSeconds) throws Exception {
 	    ContractID createdContract = null;
 	    ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-	        .usePlaintext(true)
+	        .usePlaintext()
 	        .build();
 
 	    Duration contractAutoRenew = Duration.newBuilder().setSeconds(durationInSeconds).build();
@@ -269,7 +269,7 @@ public class SmartContractPayReceivableAmount {
 	    byte[] dataToReturn = null;
 	    ContractID createdContract = null;
 	    ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-	        .usePlaintext(true)
+	        .usePlaintext()
 	        .build();
 	    SmartContractServiceGrpc.SmartContractServiceBlockingStub stub = SmartContractServiceGrpc
 	        .newBlockingStub(channel);
@@ -322,7 +322,7 @@ public class SmartContractPayReceivableAmount {
 	      TransactionID transactionId) throws Exception {
 	    AccountID createdAccount = null;
 	    ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-	        .usePlaintext(true)
+	        .usePlaintext()
 	        .build();
 	    CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
 	    long fee = FeeClient.getCostForGettingTxRecord();
@@ -352,7 +352,7 @@ public class SmartContractPayReceivableAmount {
 	    byte[] dataToReturn = null;
 	    ContractID createdContract = null;
 	    ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-	        .usePlaintext(true)
+	        .usePlaintext()
 	        .build();
 	    SmartContractServiceGrpc.SmartContractServiceBlockingStub stub = SmartContractServiceGrpc
 	        .newBlockingStub(channel);
@@ -406,7 +406,7 @@ public class SmartContractPayReceivableAmount {
 		    TransactionRecord trRecord = null;
 		    ContractID createdContract = null;
 		    ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-		        .usePlaintext(true)
+		        .usePlaintext()
 		        .build();
 		    SmartContractServiceGrpc.SmartContractServiceBlockingStub stub = SmartContractServiceGrpc
 		        .newBlockingStub(channel);
@@ -474,7 +474,7 @@ public class SmartContractPayReceivableAmount {
 	    byte[] dataToReturn = null;
 	    AccountID createdAccount = null;
 	    ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-	        .usePlaintext(true)
+	        .usePlaintext()
 	        .build();
 	    SmartContractServiceGrpc.SmartContractServiceBlockingStub stub = SmartContractServiceGrpc
 	        .newBlockingStub(channel);
@@ -538,7 +538,7 @@ public class SmartContractPayReceivableAmount {
 	      ContractID contractId) throws Exception {
 	    String byteCode = "";
 	    ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-	        .usePlaintext(true)
+	        .usePlaintext()
 	        .build();
 	    SmartContractServiceGrpc.SmartContractServiceBlockingStub stub = SmartContractServiceGrpc
 	        .newBlockingStub(channel);
@@ -574,7 +574,7 @@ public class SmartContractPayReceivableAmount {
 	  private AccountInfo getCryptoGetAccountInfo(AccountID payerAccount,
 		      AccountID accountID) throws Exception {
 		    ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-		        .usePlaintext(true)
+		        .usePlaintext()
 		        .build();
 		    CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
 
@@ -608,7 +608,7 @@ public class SmartContractPayReceivableAmount {
 	  private GetBySolidityIDResponse getBySolidityID(AccountID payerAccount,
 	      String solidityId) throws Exception {
 	    ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-	        .usePlaintext(true)
+	        .usePlaintext()
 	        .build();
 	    SmartContractServiceGrpc.SmartContractServiceBlockingStub stub = SmartContractServiceGrpc
 	        .newBlockingStub(channel);
@@ -630,7 +630,7 @@ public class SmartContractPayReceivableAmount {
 	    loadGenesisAndNodeAcccounts();
 
 			ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-					.usePlaintext(true)
+					.usePlaintext()
 					.build();
 			TestHelper.initializeFeeClient(channel, genesisAccount, accountKeyPairs.get(genesisAccount),
 					nodeAccount);
@@ -686,7 +686,7 @@ public class SmartContractPayReceivableAmount {
 	  private ContractInfo getContractInfo(AccountID payerAccount,
 	      ContractID contractId) throws Exception {
 	    ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-	        .usePlaintext(true)
+	        .usePlaintext()
 	        .build();
 	    SmartContractServiceGrpc.SmartContractServiceBlockingStub stub = SmartContractServiceGrpc
 	        .newBlockingStub(channel);

--- a/test-clients/src/main/java/com/hedera/services/legacy/regression/SmartContractSimpleStorage.java
+++ b/test-clients/src/main/java/com/hedera/services/legacy/regression/SmartContractSimpleStorage.java
@@ -150,7 +150,7 @@ public class SmartContractSimpleStorage {
   private AccountID createAccount(KeyPair keyPair, AccountID payerAccount, long initialBalance)
       throws Exception {
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
     Transaction transaction = TestHelper
@@ -177,7 +177,7 @@ public class SmartContractSimpleStorage {
         .setTransactionGetReceipt(RequestBuilder.getTransactionGetReceiptQuery(
             transactionId, ResponseType.ANSWER_ONLY)).build();
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
     Response transactionReceipts = stub.getTransactionReceipts(query);
@@ -204,7 +204,7 @@ public class SmartContractSimpleStorage {
       long durationInSeconds) throws Exception {
     ContractID createdContract = null;
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
 
     Duration contractAutoRenew = Duration.newBuilder().setSeconds(durationInSeconds).build();
@@ -264,7 +264,7 @@ public class SmartContractSimpleStorage {
     byte[] dataToReturn = null;
     ContractID createdContract = null;
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     SmartContractServiceGrpc.SmartContractServiceBlockingStub stub = SmartContractServiceGrpc
         .newBlockingStub(channel);
@@ -316,7 +316,7 @@ public class SmartContractSimpleStorage {
     AccountID createdAccount = null;
     int port = 50211;
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
     long fee = FeeClient.getCostForGettingTxRecord();
@@ -373,7 +373,7 @@ public class SmartContractSimpleStorage {
     byte[] dataToReturn = null;
     AccountID createdAccount = null;
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     SmartContractServiceGrpc.SmartContractServiceBlockingStub stub = SmartContractServiceGrpc
         .newBlockingStub(channel);
@@ -433,7 +433,7 @@ public class SmartContractSimpleStorage {
       ContractID contractId) throws Exception {
     String byteCode = "";
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
 
     SmartContractServiceGrpc.SmartContractServiceBlockingStub stub = SmartContractServiceGrpc
@@ -470,7 +470,7 @@ public class SmartContractSimpleStorage {
   private AccountInfo getCryptoGetAccountInfo(
       AccountID accountID) throws Exception {
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
 
@@ -503,7 +503,7 @@ public class SmartContractSimpleStorage {
       String solidityId) throws Exception {
     int port = 50211;
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     SmartContractServiceGrpc.SmartContractServiceBlockingStub stub = SmartContractServiceGrpc
         .newBlockingStub(channel);
@@ -531,7 +531,7 @@ public class SmartContractSimpleStorage {
   public List<TransactionRecord> getTxRecordByContractID(AccountID payerID, ContractID contractId)
       throws Exception {
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
 
     SmartContractServiceGrpc.SmartContractServiceBlockingStub scstub = SmartContractServiceGrpc
@@ -554,7 +554,7 @@ public class SmartContractSimpleStorage {
     loadGenesisAndNodeAcccounts();
 
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     TestHelper.initializeFeeClient(channel, genesisAccount, accountKeyPairs.get(genesisAccount),
         nodeAccount);
@@ -602,7 +602,7 @@ public class SmartContractSimpleStorage {
   private ContractInfo getContractInfo(AccountID payerAccount,
       ContractID contractId) throws Exception {
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
 
     SmartContractServiceGrpc.SmartContractServiceBlockingStub stub = SmartContractServiceGrpc

--- a/test-clients/src/main/java/com/hedera/services/legacy/regression/SmartContractSimpleStorageLinked.java
+++ b/test-clients/src/main/java/com/hedera/services/legacy/regression/SmartContractSimpleStorageLinked.java
@@ -149,7 +149,7 @@ public class SmartContractSimpleStorageLinked {
 	  private AccountID createAccount(KeyPair keyPair, AccountID payerAccount, long initialBalance)
 	      throws Exception {
 	    ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-	        .usePlaintext(true)
+	        .usePlaintext()
 	        .build();
 	    CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
 	    Transaction transaction = TestHelper
@@ -176,7 +176,7 @@ public class SmartContractSimpleStorageLinked {
 	        .setTransactionGetReceipt(RequestBuilder.getTransactionGetReceiptQuery(
 	            transactionId, ResponseType.ANSWER_ONLY)).build();
 	    ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-	        .usePlaintext(true)
+	        .usePlaintext()
 	        .build();
 	    CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
 	    Response transactionReceipts = stub.getTransactionReceipts(query);
@@ -203,7 +203,7 @@ public class SmartContractSimpleStorageLinked {
 	      long durationInSeconds,byte[] contructorArgs) throws Exception {
 	    ContractID createdContract = null;
 	    ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-	        .usePlaintext(true)
+	        .usePlaintext()
 	        .build();
 
 	    
@@ -264,7 +264,7 @@ public class SmartContractSimpleStorageLinked {
 	    byte[] dataToReturn = null;
 	    ContractID createdContract = null;
 	    ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-	        .usePlaintext(true)
+	        .usePlaintext()
 	        .build();
 	    SmartContractServiceGrpc.SmartContractServiceBlockingStub stub = SmartContractServiceGrpc
 	        .newBlockingStub(channel);
@@ -316,7 +316,7 @@ public class SmartContractSimpleStorageLinked {
 	    AccountID createdAccount = null;
 	    int port = 50211;
 	    ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-	        .usePlaintext(true)
+	        .usePlaintext()
 	        .build();
 	    CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
 	    long fee = FeeClient.getCostForGettingTxRecord();
@@ -373,7 +373,7 @@ public class SmartContractSimpleStorageLinked {
 	    byte[] dataToReturn = null;
 	    AccountID createdAccount = null;
 	    ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-	        .usePlaintext(true)
+	        .usePlaintext()
 	        .build();
 	    SmartContractServiceGrpc.SmartContractServiceBlockingStub stub = SmartContractServiceGrpc
 	        .newBlockingStub(channel);
@@ -433,7 +433,7 @@ public class SmartContractSimpleStorageLinked {
 	      ContractID contractId) throws Exception {
 	    String byteCode = "";
 	    ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-	        .usePlaintext(true)
+	        .usePlaintext()
 	        .build();
 
 	    SmartContractServiceGrpc.SmartContractServiceBlockingStub stub = SmartContractServiceGrpc
@@ -470,7 +470,7 @@ public class SmartContractSimpleStorageLinked {
 	  private AccountInfo getCryptoGetAccountInfo(
 	      AccountID accountID) throws Exception {
 	    ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-	        .usePlaintext(true)
+	        .usePlaintext()
 	        .build();
 	    CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
 
@@ -503,7 +503,7 @@ public class SmartContractSimpleStorageLinked {
 	      String solidityId) throws Exception {
 	    int port = 50211;
 	    ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-	        .usePlaintext(true)
+	        .usePlaintext()
 	        .build();
 	    SmartContractServiceGrpc.SmartContractServiceBlockingStub stub = SmartContractServiceGrpc
 	        .newBlockingStub(channel);
@@ -531,7 +531,7 @@ public class SmartContractSimpleStorageLinked {
 	  public List<TransactionRecord> getTxRecordByContractID(AccountID payerID, ContractID contractId)
 	      throws Exception {
 	    ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-	        .usePlaintext(true)
+	        .usePlaintext()
 	        .build();
 
 	    SmartContractServiceGrpc.SmartContractServiceBlockingStub scstub = SmartContractServiceGrpc
@@ -554,7 +554,7 @@ public class SmartContractSimpleStorageLinked {
 	    loadGenesisAndNodeAcccounts();
 
 	    ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-	        .usePlaintext(true)
+	        .usePlaintext()
 	        .build();
 	    TestHelper.initializeFeeClient(channel, genesisAccount, accountKeyPairs.get(genesisAccount),
 	        nodeAccount);
@@ -605,7 +605,7 @@ public class SmartContractSimpleStorageLinked {
 	  private ContractInfo getContractInfo(AccountID payerAccount,
 	      ContractID contractId) throws Exception {
 	    ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-	        .usePlaintext(true)
+	        .usePlaintext()
 	        .build();
 
 	    SmartContractServiceGrpc.SmartContractServiceBlockingStub stub = SmartContractServiceGrpc

--- a/test-clients/src/main/java/com/hedera/services/legacy/regression/SmartContractSimpleStorageWithEvents.java
+++ b/test-clients/src/main/java/com/hedera/services/legacy/regression/SmartContractSimpleStorageWithEvents.java
@@ -154,7 +154,7 @@ public class SmartContractSimpleStorageWithEvents {
   private AccountID createAccount(KeyPair keyPair, AccountID payerAccount, long initialBalance)
       throws Exception {
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
     Transaction transaction = TestHelper
@@ -181,7 +181,7 @@ public class SmartContractSimpleStorageWithEvents {
         .setTransactionGetReceipt(RequestBuilder.getTransactionGetReceiptQuery(
             transactionId, ResponseType.ANSWER_ONLY)).build();
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
     Response transactionReceipts = stub.getTransactionReceipts(query);
@@ -208,7 +208,7 @@ public class SmartContractSimpleStorageWithEvents {
       long durationInSeconds) throws Exception {
     ContractID createdContract = null;
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
 
     Duration contractAutoRenew = Duration.newBuilder().setSeconds(durationInSeconds).build();
@@ -268,7 +268,7 @@ public class SmartContractSimpleStorageWithEvents {
     byte[] dataToReturn = null;
     ContractID createdContract = null;
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     SmartContractServiceGrpc.SmartContractServiceBlockingStub stub = SmartContractServiceGrpc
         .newBlockingStub(channel);
@@ -320,7 +320,7 @@ public class SmartContractSimpleStorageWithEvents {
 	    AccountID createdAccount = null;
 	    int port = 50211;
 	    ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-	        .usePlaintext(true)
+	        .usePlaintext()
 	        .build();
 	    CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
 	    long fee = FeeClient.getCostForGettingTxRecord();
@@ -366,7 +366,7 @@ public class SmartContractSimpleStorageWithEvents {
 	    byte[] dataToReturn = null;
 	    AccountID createdAccount = null;
 	    ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-	        .usePlaintext(true)
+	        .usePlaintext()
 	        .build();
 	    SmartContractServiceGrpc.SmartContractServiceBlockingStub stub = SmartContractServiceGrpc
 	        .newBlockingStub(channel);
@@ -416,7 +416,7 @@ public class SmartContractSimpleStorageWithEvents {
       ContractID contractId) throws Exception {
     String byteCode = "";
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     SmartContractServiceGrpc.SmartContractServiceBlockingStub stub = SmartContractServiceGrpc
         .newBlockingStub(channel);
@@ -440,7 +440,7 @@ public class SmartContractSimpleStorageWithEvents {
   private AccountInfo getCryptoGetAccountInfo(
       AccountID accountID) throws Exception {
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
     long nodeFee = FeeClient.getCostForGettingAccountInfo();
@@ -459,7 +459,7 @@ public class SmartContractSimpleStorageWithEvents {
   private GetBySolidityIDResponse getBySolidityID(AccountID payerAccount,
       String solidityId) throws Exception {
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     SmartContractServiceGrpc.SmartContractServiceBlockingStub stub = SmartContractServiceGrpc
         .newBlockingStub(channel);
@@ -480,7 +480,7 @@ public class SmartContractSimpleStorageWithEvents {
     loadGenesisAndNodeAcccounts();
 
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     TestHelper.initializeFeeClient(channel, genesisAccount, accountKeyPairs.get(genesisAccount),
         nodeAccount);
@@ -522,7 +522,7 @@ public class SmartContractSimpleStorageWithEvents {
   private ContractInfo getContractInfo(AccountID payerAccount,
       ContractID contractId) throws Exception {
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     SmartContractServiceGrpc.SmartContractServiceBlockingStub stub = SmartContractServiceGrpc
         .newBlockingStub(channel);
@@ -545,7 +545,7 @@ public class SmartContractSimpleStorageWithEvents {
     ContractID createdContract = null;
     TransactionRecord trRecord = TransactionRecord.newBuilder().build();
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     SmartContractServiceGrpc.SmartContractServiceBlockingStub stub = SmartContractServiceGrpc
         .newBlockingStub(channel);

--- a/test-clients/src/main/java/com/hedera/services/legacy/regression/SmartContractTestBitcarbon.java
+++ b/test-clients/src/main/java/com/hedera/services/legacy/regression/SmartContractTestBitcarbon.java
@@ -150,7 +150,7 @@ public class SmartContractTestBitcarbon extends LegacySmartContractTest {
   private AccountID createAccount(KeyPair keyPair, AccountID payerAccount, long initialBalance)
       throws Exception {
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
     Transaction transaction = TestHelper
@@ -176,7 +176,7 @@ public class SmartContractTestBitcarbon extends LegacySmartContractTest {
         .setTransactionGetReceipt(RequestBuilder.getTransactionGetReceiptQuery(
             transactionId, ResponseType.ANSWER_ONLY)).build();
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
     Response transactionReceipts = stub.getTransactionReceipts(query);
@@ -202,7 +202,7 @@ public class SmartContractTestBitcarbon extends LegacySmartContractTest {
     }
 
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
 
     Duration contractAutoRenew = Duration.newBuilder().setSeconds(contractDuration).build();
@@ -393,7 +393,7 @@ public class SmartContractTestBitcarbon extends LegacySmartContractTest {
       byte[] data, ResponseCodeEnum expectedStatus)
       throws Exception {
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     SmartContractServiceGrpc.SmartContractServiceBlockingStub stub = SmartContractServiceGrpc
         .newBlockingStub(channel);
@@ -439,7 +439,7 @@ public class SmartContractTestBitcarbon extends LegacySmartContractTest {
     AccountID createdAccount = null;
     int port = 50211;
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
     long fee = FeeClient.getCostForGettingTxRecord();
@@ -468,7 +468,7 @@ public class SmartContractTestBitcarbon extends LegacySmartContractTest {
   private byte[] callContractLocal(AccountID payerAccount, ContractID contractToCall, byte[] data)
       throws Exception {
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     SmartContractServiceGrpc.SmartContractServiceBlockingStub stub = SmartContractServiceGrpc
         .newBlockingStub(channel);
@@ -566,7 +566,7 @@ public class SmartContractTestBitcarbon extends LegacySmartContractTest {
     loadGenesisAndNodeAcccounts();
 
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     TestHelper.initializeFeeClient(channel, genesisAccount, accountKeyPairs.get(genesisAccount),
             SmartContractTestBitcarbon.nodeAccount);

--- a/test-clients/src/main/java/com/hedera/services/legacy/regression/SmartContractTestInlineAssembly.java
+++ b/test-clients/src/main/java/com/hedera/services/legacy/regression/SmartContractTestInlineAssembly.java
@@ -136,7 +136,7 @@ public class SmartContractTestInlineAssembly extends LegacySmartContractTest {
 	  private AccountID createAccount(KeyPair keyPair, AccountID payerAccount, long initialBalance)
 	      throws Exception {
 	    ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-	        .usePlaintext(true)
+	        .usePlaintext()
 	        .build();
 	    CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
 	    Transaction transaction = TestHelper
@@ -163,7 +163,7 @@ public class SmartContractTestInlineAssembly extends LegacySmartContractTest {
 	        .setTransactionGetReceipt(RequestBuilder.getTransactionGetReceiptQuery(
 	            transactionId, ResponseType.ANSWER_ONLY)).build();
 	    ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-	        .usePlaintext(true)
+	        .usePlaintext()
 	        .build();
 	    CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
 	    Response transactionReceipts = stub.getTransactionReceipts(query);
@@ -190,7 +190,7 @@ public class SmartContractTestInlineAssembly extends LegacySmartContractTest {
 	      long durationInSeconds) throws Exception {
 	    ContractID createdContract = null;
 	    ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-	        .usePlaintext(true)
+	        .usePlaintext()
 	        .build();
 
 	    Duration contractAutoRenew = Duration.newBuilder().setSeconds(durationInSeconds).build();
@@ -250,7 +250,7 @@ public class SmartContractTestInlineAssembly extends LegacySmartContractTest {
 	    byte[] dataToReturn = null;
 	    ContractID createdContract = null;
 	    ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-	        .usePlaintext(true)
+	        .usePlaintext()
 	        .build();
 	    SmartContractServiceGrpc.SmartContractServiceBlockingStub stub = SmartContractServiceGrpc
 	        .newBlockingStub(channel);
@@ -302,7 +302,7 @@ public class SmartContractTestInlineAssembly extends LegacySmartContractTest {
 	    AccountID createdAccount = null;
 	    int port = 50211;
 	    ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-	        .usePlaintext(true)
+	        .usePlaintext()
 	        .build();
 	    CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
 	    long fee = FeeClient.getCostForGettingTxRecord();
@@ -359,7 +359,7 @@ public class SmartContractTestInlineAssembly extends LegacySmartContractTest {
 	    byte[] dataToReturn = null;
 	    AccountID createdAccount = null;
 	    ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-	        .usePlaintext(true)
+	        .usePlaintext()
 	        .build();
 	    SmartContractServiceGrpc.SmartContractServiceBlockingStub stub = SmartContractServiceGrpc
 	        .newBlockingStub(channel);
@@ -418,7 +418,7 @@ public class SmartContractTestInlineAssembly extends LegacySmartContractTest {
 	  private AccountInfo getCryptoGetAccountInfo(
 	      AccountID accountID) throws Exception {
 	    ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-	        .usePlaintext(true)
+	        .usePlaintext()
 	        .build();
 	    CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
 
@@ -451,7 +451,7 @@ public class SmartContractTestInlineAssembly extends LegacySmartContractTest {
 	      String solidityId) throws Exception {
 	    int port = 50211;
 	    ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-	        .usePlaintext(true)
+	        .usePlaintext()
 	        .build();
 	    SmartContractServiceGrpc.SmartContractServiceBlockingStub stub = SmartContractServiceGrpc
 	        .newBlockingStub(channel);
@@ -475,7 +475,7 @@ public class SmartContractTestInlineAssembly extends LegacySmartContractTest {
 	    loadGenesisAndNodeAcccounts();
 
 		ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-				.usePlaintext(true)
+				.usePlaintext()
 				.build();
 		TestHelper.initializeFeeClient(channel, genesisAccount, accountKeyPairs.get(genesisAccount),
 				SmartContractTestInlineAssembly.nodeAccount);
@@ -534,7 +534,7 @@ public class SmartContractTestInlineAssembly extends LegacySmartContractTest {
 	private ContractInfo getContractInfo(AccountID payerAccount,
 	      ContractID contractId) throws Exception {
 	    ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-	        .usePlaintext(true)
+	        .usePlaintext()
 	        .build();
 
 	    SmartContractServiceGrpc.SmartContractServiceBlockingStub stub = SmartContractServiceGrpc

--- a/test-clients/src/main/java/com/hedera/services/legacy/regression/SystemFileTest.java
+++ b/test-clients/src/main/java/com/hedera/services/legacy/regression/SystemFileTest.java
@@ -78,7 +78,7 @@ public class SystemFileTest {
   public SystemFileTest(int port, String host) {
     // connecting to the grpc server on the port
     channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     SystemFileTest.stub = CryptoServiceGrpc.newBlockingStub(channel);
     SystemFileTest.fileServiceBlockingStub = FileServiceGrpc.newBlockingStub(channel);

--- a/test-clients/src/main/java/com/hedera/services/legacy/regression/ThresholdRecordTestSC.java
+++ b/test-clients/src/main/java/com/hedera/services/legacy/regression/ThresholdRecordTestSC.java
@@ -106,7 +106,7 @@ public class ThresholdRecordTestSC {
     nodeAccount = AccountID.newBuilder().setAccountNum(node_account_number)
         .setRealmNum(node_shard_number).setShardNum(node_realm_number).build();
     ManagedChannel channel1 = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     stub = CryptoServiceGrpc.newBlockingStub(channel1);
 
@@ -122,7 +122,7 @@ public class ThresholdRecordTestSC {
     loadGenesisAndNodeAcccounts();
 
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     TestHelper.initializeFeeClient(channel, genesisAccount, accountKeyPairs.get(genesisAccount),
         nodeAccount);
@@ -225,7 +225,7 @@ public class ThresholdRecordTestSC {
   public List<TransactionRecord> getTxRecordByContractID(AccountID payerID, ContractID contractId)
       throws Exception {
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
 
     SmartContractServiceGrpc.SmartContractServiceBlockingStub scstub = SmartContractServiceGrpc
@@ -277,7 +277,7 @@ public class ThresholdRecordTestSC {
     byte[] dataToReturn = null;
     AccountID createdAccount = null;
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     SmartContractServiceGrpc.SmartContractServiceBlockingStub stub = SmartContractServiceGrpc
         .newBlockingStub(channel);
@@ -340,7 +340,7 @@ public class ThresholdRecordTestSC {
     byte[] dataToReturn = null;
     ContractID createdContract = null;
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     SmartContractServiceGrpc.SmartContractServiceBlockingStub stub = SmartContractServiceGrpc
         .newBlockingStub(channel);
@@ -393,7 +393,7 @@ public class ThresholdRecordTestSC {
     AccountID createdAccount = null;
     int port = 50211;
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
     long fee = FeeClient.getCostForGettingTxRecord();
@@ -421,7 +421,7 @@ public class ThresholdRecordTestSC {
   private AccountID createAccount(KeyPair keyPair, AccountID payerAccount, long initialBalance)
       throws Exception {
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
     Transaction transaction = TestHelper
@@ -446,7 +446,7 @@ public class ThresholdRecordTestSC {
       long durationInSeconds) throws Exception {
     ContractID createdContract = null;
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
 
     Duration contractAutoRenew = Duration.newBuilder().setSeconds(durationInSeconds).build();
@@ -486,7 +486,7 @@ public class ThresholdRecordTestSC {
         .setTransactionGetReceipt(RequestBuilder.getTransactionGetReceiptQuery(
             transactionId, ResponseType.ANSWER_ONLY)).build();
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
     Response transactionReceipts = stub.getTransactionReceipts(query);

--- a/test-clients/src/main/java/com/hedera/services/legacy/regression/ThresholdSmartContractCall.java
+++ b/test-clients/src/main/java/com/hedera/services/legacy/regression/ThresholdSmartContractCall.java
@@ -155,7 +155,7 @@ public class ThresholdSmartContractCall {
   private AccountID createAccount(KeyPair keyPair, AccountID payerAccount, long initialBalance)
       throws Exception {
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
     Transaction transaction = TestHelper
@@ -181,7 +181,7 @@ public class ThresholdSmartContractCall {
       long initialBalance, long bothThresholds)
       throws Exception {
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
     Transaction transaction = TestHelper
@@ -207,7 +207,7 @@ public class ThresholdSmartContractCall {
         .setTransactionGetReceipt(RequestBuilder.getTransactionGetReceiptQuery(
             transactionId, ResponseType.ANSWER_ONLY)).build();
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
     Response transactionReceipts = stub.getTransactionReceipts(query);
@@ -234,7 +234,7 @@ public class ThresholdSmartContractCall {
       long durationInSeconds) throws Exception {
     ContractID createdContract = null;
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
 
     Duration contractAutoRenew = Duration.newBuilder().setSeconds(durationInSeconds).build();
@@ -294,7 +294,7 @@ public class ThresholdSmartContractCall {
     byte[] dataToReturn = null;
     ContractID createdContract = null;
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     SmartContractServiceGrpc.SmartContractServiceBlockingStub stub = SmartContractServiceGrpc
         .newBlockingStub(channel);
@@ -347,7 +347,7 @@ public class ThresholdSmartContractCall {
       TransactionID transactionId) throws Exception {
     AccountID createdAccount = null;
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
     long fee = FeeClient.getCostForGettingTxRecord();
@@ -377,7 +377,7 @@ public class ThresholdSmartContractCall {
     byte[] dataToReturn = null;
     ContractID createdContract = null;
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     SmartContractServiceGrpc.SmartContractServiceBlockingStub stub = SmartContractServiceGrpc
         .newBlockingStub(channel);
@@ -456,7 +456,7 @@ public class ThresholdSmartContractCall {
     byte[] dataToReturn = null;
     AccountID createdAccount = null;
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     SmartContractServiceGrpc.SmartContractServiceBlockingStub stub = SmartContractServiceGrpc
         .newBlockingStub(channel);
@@ -520,7 +520,7 @@ public class ThresholdSmartContractCall {
       ContractID contractId) throws Exception {
     String byteCode = "";
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     SmartContractServiceGrpc.SmartContractServiceBlockingStub stub = SmartContractServiceGrpc
         .newBlockingStub(channel);
@@ -556,7 +556,7 @@ public class ThresholdSmartContractCall {
   private AccountInfo getCryptoGetAccountInfo(AccountID payerAccount,
       AccountID accountID) throws Exception {
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
 
@@ -590,7 +590,7 @@ public class ThresholdSmartContractCall {
   private GetBySolidityIDResponse getBySolidityID(AccountID payerAccount,
       String solidityId) throws Exception {
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     SmartContractServiceGrpc.SmartContractServiceBlockingStub stub = SmartContractServiceGrpc
         .newBlockingStub(channel);
@@ -615,7 +615,7 @@ public class ThresholdSmartContractCall {
   public List<TransactionRecord> getTxRecordByAccountID(AccountID payerID, AccountID accountID)
       throws Exception {
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
 
     CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc
@@ -638,7 +638,7 @@ public class ThresholdSmartContractCall {
     loadGenesisAndNodeAcccounts();
 
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     TestHelper.initializeFeeClient(channel, genesisAccount, accountKeyPairs.get(genesisAccount),
         nodeAccount);
@@ -705,7 +705,7 @@ public class ThresholdSmartContractCall {
   private ContractInfo getContractInfo(AccountID payerAccount,
       ContractID contractId) throws Exception {
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     SmartContractServiceGrpc.SmartContractServiceBlockingStub stub = SmartContractServiceGrpc
         .newBlockingStub(channel);

--- a/test-clients/src/main/java/com/hedera/services/legacy/regression/TransactionInsufficientFeeCost.java
+++ b/test-clients/src/main/java/com/hedera/services/legacy/regression/TransactionInsufficientFeeCost.java
@@ -147,7 +147,7 @@ public class TransactionInsufficientFeeCost {
   private AccountID createAccount(KeyPair keyPair, AccountID payerAccount, long initialBalance)
       throws Exception {
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
 
@@ -194,7 +194,7 @@ public class TransactionInsufficientFeeCost {
         .setTransactionGetReceipt(RequestBuilder.getTransactionGetReceiptQuery(
             transactionId, ResponseType.ANSWER_ONLY)).build();
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
     Response transactionReceipts = stub.getTransactionReceipts(query);
@@ -218,7 +218,7 @@ public class TransactionInsufficientFeeCost {
       AccountID adminAccount) throws Exception {
     ContractID createdContract = null;
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
 
     Duration contractAutoRenew = Duration.newBuilder()
@@ -285,7 +285,7 @@ public class TransactionInsufficientFeeCost {
       TransactionID transactionId) throws Exception {
     AccountID createdAccount = null;
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
     long fee = FeeClient.getCostForGettingTxRecord();
@@ -316,7 +316,7 @@ public class TransactionInsufficientFeeCost {
       AccountID adminAccount, ResponseCodeEnum expectedStatus) throws Exception {
 
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     SmartContractServiceGrpc.SmartContractServiceBlockingStub stub = SmartContractServiceGrpc
         .newBlockingStub(channel);
@@ -366,7 +366,7 @@ public class TransactionInsufficientFeeCost {
   private ResponseCodeEnum deleteContract(AccountID payerAccount, ContractID contractId,
       AccountID adminAccount, ResponseCodeEnum expectedStatus) throws Exception {
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     SmartContractServiceGrpc.SmartContractServiceBlockingStub stub = SmartContractServiceGrpc
         .newBlockingStub(channel);
@@ -433,7 +433,7 @@ public class TransactionInsufficientFeeCost {
       throws Exception {
     byte[] dataToReturn = null;
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     SmartContractServiceGrpc.SmartContractServiceBlockingStub stub = SmartContractServiceGrpc
         .newBlockingStub(channel);
@@ -504,7 +504,7 @@ public class TransactionInsufficientFeeCost {
   public void crytpoTransfer(AccountID fromAccount, AccountID toAccount, long amount)
       throws Exception {
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
 
@@ -555,7 +555,7 @@ public class TransactionInsufficientFeeCost {
 
   public void crytpoUpdate(AccountID accountID) throws Exception {
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
     Duration accountAutoRenew = Duration.newBuilder()
@@ -604,7 +604,7 @@ public class TransactionInsufficientFeeCost {
 
   public void cryptoDelete(AccountID accountID) throws Exception {
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
 
@@ -673,7 +673,7 @@ public class TransactionInsufficientFeeCost {
 
   public FileID fileCreate(AccountID payerAccount, ByteString fileData) throws Exception {
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     FileServiceGrpc.FileServiceBlockingStub stub = FileServiceGrpc.newBlockingStub(channel);
     Timestamp timestamp = TestHelper.getDefaultCurrentTimestampUTC();
@@ -732,7 +732,7 @@ public class TransactionInsufficientFeeCost {
 
   public void fileAppend(AccountID payerAccount, ByteString fileData, FileID fid) throws Exception {
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     FileServiceGrpc.FileServiceBlockingStub stub = FileServiceGrpc.newBlockingStub(channel);
     Timestamp timestamp = TestHelper.getDefaultCurrentTimestampUTC();
@@ -781,7 +781,7 @@ public class TransactionInsufficientFeeCost {
 
   public void fileUpdate(AccountID payerAccount, ByteString fileData, FileID fid) throws Exception {
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     FileServiceGrpc.FileServiceBlockingStub stub = FileServiceGrpc.newBlockingStub(channel);
     Timestamp timestamp = TestHelper.getDefaultCurrentTimestampUTC();
@@ -833,7 +833,7 @@ public class TransactionInsufficientFeeCost {
 
   public void fileDelete(AccountID payerAccount, FileID fid) throws Exception {
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     FileServiceGrpc.FileServiceBlockingStub stub = FileServiceGrpc.newBlockingStub(channel);
     Timestamp timestamp = TestHelper.getDefaultCurrentTimestampUTC();
@@ -883,7 +883,7 @@ public class TransactionInsufficientFeeCost {
     loadGenesisAndNodeAcccounts();
 
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     TestHelper.initializeFeeClient(channel, genesisAccount, accountKeyPairs.get(genesisAccount),
         nodeAccount);

--- a/test-clients/src/main/java/com/hedera/services/legacy/regression/umbrella/CryptoServiceTest.java
+++ b/test-clients/src/main/java/com/hedera/services/legacy/regression/umbrella/CryptoServiceTest.java
@@ -695,7 +695,7 @@ public class CryptoServiceTest extends TestHelperComplex {
   }
 
   protected void createStubs() throws URISyntaxException, IOException {
-    channel = ManagedChannelBuilder.forAddress(host, port).usePlaintext(true).build();
+    channel = ManagedChannelBuilder.forAddress(host, port).usePlaintext().build();
     stub = FileServiceGrpc.newBlockingStub(channel);
     cstub = CryptoServiceGrpc.newBlockingStub(channel);
   }
@@ -950,7 +950,7 @@ public class CryptoServiceTest extends TestHelperComplex {
       }
     }
 
-    ManagedChannel channel = ManagedChannelBuilder.forAddress(host, p).usePlaintext(true).build();
+    ManagedChannel channel = ManagedChannelBuilder.forAddress(host, p).usePlaintext().build();
     rv = FileServiceGrpc.newBlockingStub(channel);
     nodeID2Stub.put(nodeID, rv);
 
@@ -1779,7 +1779,7 @@ public class CryptoServiceTest extends TestHelperComplex {
    * @param createdChannels to store generated channel
    */
   public static FileServiceBlockingStub createFileServiceStub(ManagedChannel[] createdChannels) {
-    ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port).usePlaintext(true)
+    ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port).usePlaintext()
         .build();
     FileServiceBlockingStub rv = FileServiceGrpc.newBlockingStub(channel);
     createdChannels[0] = channel;

--- a/test-clients/src/main/java/com/hedera/services/legacy/smartcontract/BigArray.java
+++ b/test-clients/src/main/java/com/hedera/services/legacy/smartcontract/BigArray.java
@@ -164,7 +164,7 @@ public class BigArray {
     }
 
     ManagedChannel channel = ManagedChannelBuilder.forAddress(grpcHost, grpcPort)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     TestHelper.initializeFeeClient(channel, genesisAccount, accountKeyPairs.get(genesisAccount),
         nodeAccount);
@@ -237,7 +237,7 @@ public class BigArray {
       channelShared.shutdown();
     }
     channelShared = ManagedChannelBuilder.forAddress(grpcHost, grpcPort)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     cryptoStub = CryptoServiceGrpc.newBlockingStub(channelShared);
     sCServiceStub = SmartContractServiceGrpc.newBlockingStub(channelShared);

--- a/test-clients/src/main/java/com/hedera/services/legacy/smartcontract/BigArrayPerformance.java
+++ b/test-clients/src/main/java/com/hedera/services/legacy/smartcontract/BigArrayPerformance.java
@@ -123,7 +123,7 @@ public class BigArrayPerformance  extends Thread {
   public BigArrayPerformance(String grpcHost, int grpcPort, int index) throws Exception {
 
     channelShared = ManagedChannelBuilder.forAddress(grpcHost, grpcPort)
-            .usePlaintext(true)
+            .usePlaintext()
             .build();
     cryptoStub = CryptoServiceGrpc.newBlockingStub(channelShared);
     sCServiceStub = SmartContractServiceGrpc.newBlockingStub(channelShared);

--- a/test-clients/src/main/java/com/hedera/services/legacy/smartcontract/ChainOfContracts.java
+++ b/test-clients/src/main/java/com/hedera/services/legacy/smartcontract/ChainOfContracts.java
@@ -149,7 +149,7 @@ public class ChainOfContracts {
 
 	    loadGenesisAndNodeAcccounts();
 	    int port = 50211;
-	    ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port).usePlaintext(true)
+	    ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port).usePlaintext()
 	        .build();
 	    FileServiceBlockingStub stub = FileServiceGrpc.newBlockingStub(channel);
 	    CryptoServiceGrpc.CryptoServiceBlockingStub cryptoStub = CryptoServiceGrpc
@@ -211,7 +211,7 @@ public class ChainOfContracts {
 	      KeyPair keyGenerated) throws Exception {
 		  int port = 50211;
 	    ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-	        .usePlaintext(true)
+	        .usePlaintext()
 	        .build();
 	    CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
 	    Transaction transaction = TestHelper
@@ -241,7 +241,7 @@ public class ChainOfContracts {
 	            transactionId, ResponseType.ANSWER_ONLY)).build();
 	    int port = 50211;
 	    ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-	        .usePlaintext(true)
+	        .usePlaintext()
 	        .build();
 	    CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
 	    Response transactionReceipts = stub.getTransactionReceipts(query);
@@ -268,7 +268,7 @@ public class ChainOfContracts {
 	  private static FileID uploadFile(AccountID payerAccount, String fileName) throws Exception {
 	    FileID fileIdToReturn = null;
 	    int port = 50211;
-	    ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port).usePlaintext(true)
+	    ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port).usePlaintext()
 	        .build();
 	    FileServiceBlockingStub stub = FileServiceGrpc.newBlockingStub(channel);
 
@@ -320,7 +320,7 @@ public class ChainOfContracts {
 	    ContractID createdContract = null;
 	    int port = 50211;
 	    ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-	        .usePlaintext(true)
+	        .usePlaintext()
 	        .build();
 
 	    Duration contractAutoRenew = Duration.newBuilder().setSeconds(durationInSeconds).build();
@@ -365,7 +365,7 @@ public class ChainOfContracts {
 	      throws Exception {
 	    FileID fileIdToReturn = null;
 	    int port = 50211;
-	    ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port).usePlaintext(true)
+	    ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port).usePlaintext()
 	        .build();
 	    FileServiceBlockingStub stub = FileServiceGrpc.newBlockingStub(channel);
 	    CryptoServiceGrpc.CryptoServiceBlockingStub cryptoStub = CryptoServiceGrpc
@@ -426,7 +426,7 @@ public class ChainOfContracts {
 	    ContractID createdContract = null;
 	    int port = 50211;
 	    ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-	        .usePlaintext(true)
+	        .usePlaintext()
 	        .build();
 	    SmartContractServiceGrpc.SmartContractServiceBlockingStub stub = SmartContractServiceGrpc
 	        .newBlockingStub(channel);
@@ -479,7 +479,7 @@ public class ChainOfContracts {
 	    AccountID createdAccount = null;
 	    int port = 50211;
 	    ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-	        .usePlaintext(true)
+	        .usePlaintext()
 	        .build();
 	    CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
 	    Transaction paymentTx = createQueryHeaderTransfer(payerAccount);
@@ -523,7 +523,7 @@ public class ChainOfContracts {
 	    AccountID createdAccount = null;
 	    int port = 50211;
 	    ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-	        .usePlaintext(true)
+	        .usePlaintext()
 	        .build();
 	    SmartContractServiceGrpc.SmartContractServiceBlockingStub stub = SmartContractServiceGrpc
 	        .newBlockingStub(channel);
@@ -569,7 +569,7 @@ public class ChainOfContracts {
 	      ContractID contractId) throws Exception {
 	    int port = 50211;
 	    ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-	        .usePlaintext(true)
+	        .usePlaintext()
 	        .build();
 	    SmartContractServiceGrpc.SmartContractServiceBlockingStub stub = SmartContractServiceGrpc
 	        .newBlockingStub(channel);
@@ -591,7 +591,7 @@ public class ChainOfContracts {
 
 	    int port = 50211;
 	    ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-	        .usePlaintext(true)
+	        .usePlaintext()
 	        .build();
 	    SmartContractServiceGrpc.SmartContractServiceBlockingStub stub = SmartContractServiceGrpc
 	        .newBlockingStub(channel);
@@ -625,7 +625,7 @@ public class ChainOfContracts {
 	    String byteCode = "";
 	    int port = 50211;
 	    ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-	        .usePlaintext(true)
+	        .usePlaintext()
 	        .build();
 	    SmartContractServiceGrpc.SmartContractServiceBlockingStub stub = SmartContractServiceGrpc
 	        .newBlockingStub(channel);
@@ -649,7 +649,7 @@ public class ChainOfContracts {
 	      AccountID accountID) throws Exception {
 	    int port = 50211;
 	    ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-	        .usePlaintext(true)
+	        .usePlaintext()
 	        .build();
 	    CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
 
@@ -670,7 +670,7 @@ public class ChainOfContracts {
 	      String solidityId) throws Exception {
 	    int port = 50211;
 	    ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-	        .usePlaintext(true)
+	        .usePlaintext()
 	        .build();
 	    SmartContractServiceGrpc.SmartContractServiceBlockingStub stub = SmartContractServiceGrpc
 	        .newBlockingStub(channel);

--- a/test-clients/src/main/java/com/hedera/services/legacy/smartcontract/CreatePerformanceThread.java
+++ b/test-clients/src/main/java/com/hedera/services/legacy/smartcontract/CreatePerformanceThread.java
@@ -329,7 +329,7 @@ public class CreatePerformanceThread implements Runnable {
     genesisAccountPrivateKeys.add(genesisPrivateKey);
 
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     TestHelper.initializeFeeClient(channel, genesisAccount, accountKeyPairs.get(genesisAccount),
         nodeAccount);
@@ -479,7 +479,7 @@ public class CreatePerformanceThread implements Runnable {
       channel.shutdown();
     }
     channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     cstub = CryptoServiceGrpc.newBlockingStub(channel);
     scstub = SmartContractServiceGrpc.newBlockingStub(channel);

--- a/test-clients/src/main/java/com/hedera/services/legacy/smartcontract/DeletedReceiver.java
+++ b/test-clients/src/main/java/com/hedera/services/legacy/smartcontract/DeletedReceiver.java
@@ -145,7 +145,7 @@ public class DeletedReceiver {
   private AccountID createAccount(KeyPair keyPair, AccountID payerAccount, long initialBalance)
       throws Exception {
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
     Transaction transaction = TestHelper
@@ -171,7 +171,7 @@ public class DeletedReceiver {
         .setTransactionGetReceipt(RequestBuilder.getTransactionGetReceiptQuery(
             transactionId, ResponseType.ANSWER_ONLY)).build();
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
     Response transactionReceipts = stub.getTransactionReceipts(query);
@@ -195,7 +195,7 @@ public class DeletedReceiver {
       long durationInSeconds, KeyPair adminKeyPair) throws Exception {
     ContractID createdContract = null;
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
 
     byte[] pubKey = ((EdDSAPublicKey) adminKeyPair.getPublic()).getAbyte();
@@ -246,7 +246,7 @@ public class DeletedReceiver {
       TransactionID transactionId) throws Exception {
     AccountID createdAccount = null;
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
     long fee = FeeClient.getCostForGettingTxRecord();
@@ -276,7 +276,7 @@ public class DeletedReceiver {
     byte[] dataToReturn = null;
     ContractID createdContract = null;
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     SmartContractServiceGrpc.SmartContractServiceBlockingStub stub = SmartContractServiceGrpc
         .newBlockingStub(channel);
@@ -329,7 +329,7 @@ public class DeletedReceiver {
       Duration autoRenewPeriod, Timestamp expirationTime) throws Exception {
 
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     SmartContractServiceGrpc.SmartContractServiceBlockingStub stub = SmartContractServiceGrpc
         .newBlockingStub(channel);
@@ -360,7 +360,7 @@ public class DeletedReceiver {
   private AccountInfo getCryptoGetAccountInfo(AccountID payerAccount,
       AccountID accountID) throws Exception {
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
 
@@ -394,7 +394,7 @@ public class DeletedReceiver {
   private void deleteAccount(AccountID accountID, AccountID payerAccount, AccountID nodeID)
       throws Exception {
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     CryptoServiceGrpc.CryptoServiceBlockingStub cstub = CryptoServiceGrpc.newBlockingStub(channel);
 
@@ -452,7 +452,7 @@ public class DeletedReceiver {
     log.info("Accounts created successfully");
 
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     TestHelper.initializeFeeClient(channel, crAccount, crAccountKeyPair, nodeAccount);
     channel.shutdown();

--- a/test-clients/src/main/java/com/hedera/services/legacy/smartcontract/EmitEventLocal.java
+++ b/test-clients/src/main/java/com/hedera/services/legacy/smartcontract/EmitEventLocal.java
@@ -132,7 +132,7 @@ public class EmitEventLocal {
   private AccountID createAccount(KeyPair keyPair, AccountID payerAccount, long initialBalance)
       throws Exception {
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
     Transaction transaction = TestHelper
@@ -158,7 +158,7 @@ public class EmitEventLocal {
         .setTransactionGetReceipt(RequestBuilder.getTransactionGetReceiptQuery(
             transactionId, ResponseType.ANSWER_ONLY)).build();
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
     Response transactionReceipts = stub.getTransactionReceipts(query);
@@ -181,7 +181,7 @@ public class EmitEventLocal {
       long durationInSeconds) throws Exception {
     ContractID createdContract = null;
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
 
     Duration contractAutoRenew = Duration.newBuilder().setSeconds(durationInSeconds).build();
@@ -224,7 +224,7 @@ public class EmitEventLocal {
   private TransactionRecord getTransactionRecord(AccountID payerAccount,
       TransactionID transactionId) throws Exception {
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
     long fee = FeeClient.getCostForGettingTxRecord();
@@ -262,7 +262,7 @@ public class EmitEventLocal {
   private ResponseCodeEnum callContractLocal(AccountID payerAccount, ContractID contractToCall, byte[] data)
       throws Exception {
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     SmartContractServiceGrpc.SmartContractServiceBlockingStub stub = SmartContractServiceGrpc
         .newBlockingStub(channel);
@@ -306,7 +306,7 @@ public class EmitEventLocal {
     loadGenesisAndNodeAcccounts();
 
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     TestHelper.initializeFeeClient(channel, genesisAccount, accountKeyPairs.get(genesisAccount),
         nodeAccount);

--- a/test-clients/src/main/java/com/hedera/services/legacy/smartcontract/LandRegistry.java
+++ b/test-clients/src/main/java/com/hedera/services/legacy/smartcontract/LandRegistry.java
@@ -178,7 +178,7 @@ public class LandRegistry {
   private AccountID createAccount(KeyPair keyPair, AccountID payerAccount, long initialBalance)
       throws Exception {
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
     Transaction transaction = TestHelper
@@ -203,7 +203,7 @@ public class LandRegistry {
       long initialBalance) throws Exception {
     long start = System.currentTimeMillis();
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
 
@@ -235,7 +235,7 @@ public class LandRegistry {
         .setTransactionGetReceipt(RequestBuilder.getTransactionGetReceiptQuery(
             transactionId, ResponseType.ANSWER_ONLY)).build();
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
     Response transactionReceipts = stub.getTransactionReceipts(query);
@@ -259,7 +259,7 @@ public class LandRegistry {
       long durationInSeconds) throws Exception {
     ContractID createdContract = null;
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
 
     Duration contractAutoRenew = Duration.newBuilder().setSeconds(durationInSeconds).build();
@@ -428,7 +428,7 @@ Methods to run the highestSold method
     byte[] dataToReturn = null;
     ContractID createdContract = null;
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     SmartContractServiceGrpc.SmartContractServiceBlockingStub stub = SmartContractServiceGrpc
         .newBlockingStub(channel);
@@ -480,7 +480,7 @@ Methods to run the highestSold method
       byte[] data,
       int value) throws Exception {
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     SmartContractServiceGrpc.SmartContractServiceBlockingStub stub = SmartContractServiceGrpc
         .newBlockingStub(channel);
@@ -542,7 +542,7 @@ Methods to run the highestSold method
     AccountID createdAccount = null;
     int port = 50211;
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
     long fee = FeeClient.getCostForGettingTxRecord();
@@ -574,7 +574,7 @@ Methods to run the highestSold method
     byte[] dataToReturn = null;
     AccountID createdAccount = null;
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     SmartContractServiceGrpc.SmartContractServiceBlockingStub stub = SmartContractServiceGrpc
         .newBlockingStub(channel);
@@ -617,7 +617,7 @@ Methods to run the highestSold method
       ContractID contractId) throws Exception {
     String byteCode = "";
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
 
     SmartContractServiceGrpc.SmartContractServiceBlockingStub stub = SmartContractServiceGrpc
@@ -653,7 +653,7 @@ Methods to run the highestSold method
   private AccountInfo getCryptoGetAccountInfo(
       AccountID accountID) throws Exception {
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
 
@@ -686,7 +686,7 @@ Methods to run the highestSold method
       String solidityId) throws Exception {
     int port = 50211;
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     SmartContractServiceGrpc.SmartContractServiceBlockingStub stub = SmartContractServiceGrpc
         .newBlockingStub(channel);
@@ -707,7 +707,7 @@ Methods to run the highestSold method
     loadGenesisAndNodeAcccounts();
 
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     TestHelper.initializeFeeClient(channel, genesisAccount, accountKeyPairs.get(genesisAccount),
         nodeAccount);
@@ -784,7 +784,7 @@ Methods to run the highestSold method
   private ContractInfo getContractInfo(AccountID payerAccount,
       ContractID contractId) throws Exception {
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
 
     SmartContractServiceGrpc.SmartContractServiceBlockingStub stub = SmartContractServiceGrpc

--- a/test-clients/src/main/java/com/hedera/services/legacy/smartcontract/LargeStorage.java
+++ b/test-clients/src/main/java/com/hedera/services/legacy/smartcontract/LargeStorage.java
@@ -148,7 +148,7 @@ public class LargeStorage {
   private AccountID createAccount(KeyPair keyPair, AccountID payerAccount, long initialBalance)
       throws Exception {
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
     Transaction transaction = TestHelper
@@ -174,7 +174,7 @@ public class LargeStorage {
         .setTransactionGetReceipt(RequestBuilder.getTransactionGetReceiptQuery(
             transactionId, ResponseType.ANSWER_ONLY)).build();
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
     Response transactionReceipts = stub.getTransactionReceipts(query);
@@ -194,7 +194,7 @@ public class LargeStorage {
   private ContractID createContract(AccountID payerAccount, FileID contractFile) throws Exception {
     ContractID createdContract = null;
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
 
     Duration contractAutoRenew = Duration.newBuilder().setSeconds(contractDuration).build();
@@ -260,7 +260,7 @@ public class LargeStorage {
       byte[] data, ResponseCodeEnum expectedStatus)
       throws Exception {
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     SmartContractServiceGrpc.SmartContractServiceBlockingStub stub = SmartContractServiceGrpc
         .newBlockingStub(channel);
@@ -307,7 +307,7 @@ public class LargeStorage {
       TransactionID transactionId) throws Exception {
     AccountID createdAccount = null;
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
     long fee = FeeClient.getCostForGettingTxRecord();
@@ -336,7 +336,7 @@ public class LargeStorage {
   private byte[] callContractLocal(AccountID payerAccount, ContractID contractToCall, byte[] data)
       throws Exception {
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     SmartContractServiceGrpc.SmartContractServiceBlockingStub stub = SmartContractServiceGrpc
         .newBlockingStub(channel);
@@ -379,7 +379,7 @@ public class LargeStorage {
      loadGenesisAndNodeAcccounts();
 
       ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-          .usePlaintext(true)
+          .usePlaintext()
           .build();
       TestHelper.initializeFeeClient(channel, genesisAccount, accountKeyPairs.get(genesisAccount),
           nodeAccount);

--- a/test-clients/src/main/java/com/hedera/services/legacy/smartcontract/LocalCallGasFail.java
+++ b/test-clients/src/main/java/com/hedera/services/legacy/smartcontract/LocalCallGasFail.java
@@ -132,7 +132,7 @@ public class LocalCallGasFail {
   private AccountID createAccount(KeyPair keyPair, AccountID payerAccount, long initialBalance)
       throws Exception {
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
     Transaction transaction = TestHelper
@@ -159,7 +159,7 @@ public class LocalCallGasFail {
         .setTransactionGetReceipt(RequestBuilder.getTransactionGetReceiptQuery(
             transactionId, ResponseType.ANSWER_ONLY)).build();
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
     Response transactionReceipts = stub.getTransactionReceipts(query);
@@ -190,7 +190,7 @@ public class LocalCallGasFail {
       long durationInSeconds) throws Exception {
     ContractID createdContract = null;
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
 
     Duration contractAutoRenew = Duration.newBuilder().setSeconds(durationInSeconds).build();
@@ -245,7 +245,7 @@ public class LocalCallGasFail {
       throws Exception {
     byte[] dataToReturn = null;
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     SmartContractServiceGrpc.SmartContractServiceBlockingStub stub = SmartContractServiceGrpc
         .newBlockingStub(channel);
@@ -296,7 +296,7 @@ public class LocalCallGasFail {
       TransactionID transactionId) throws Exception {
     int port = 50211;
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
     long fee = FeeClient.getCostForGettingTxRecord();
@@ -347,7 +347,7 @@ public class LocalCallGasFail {
   private byte[] callContractLocal(AccountID payerAccount, ContractID contractToCall, byte[] data)
       throws Exception {
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     SmartContractServiceGrpc.SmartContractServiceBlockingStub stub = SmartContractServiceGrpc
         .newBlockingStub(channel);
@@ -407,7 +407,7 @@ public class LocalCallGasFail {
     loadGenesisAndNodeAcccounts();
 
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     TestHelper.initializeFeeClient(channel, genesisAccount, accountKeyPairs.get(genesisAccount),
         nodeAccount);

--- a/test-clients/src/main/java/com/hedera/services/legacy/smartcontract/LoopGas.java
+++ b/test-clients/src/main/java/com/hedera/services/legacy/smartcontract/LoopGas.java
@@ -135,7 +135,7 @@ public class LoopGas {
   private AccountID createAccount(KeyPair keyPair, AccountID payerAccount, long initialBalance)
       throws Exception {
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
     Transaction transaction = TestHelper
@@ -161,7 +161,7 @@ public class LoopGas {
         .setTransactionGetReceipt(RequestBuilder.getTransactionGetReceiptQuery(
             transactionId, ResponseType.ANSWER_ONLY)).build();
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
     Response transactionReceipts = stub.getTransactionReceipts(query);
@@ -179,7 +179,7 @@ public class LoopGas {
   private ContractID createContract(AccountID payerAccount, FileID contractFile) throws Exception {
     ContractID createdContract = null;
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
 
     Duration contractAutoRenew = Duration.newBuilder().setSeconds(contractDuration).build();
@@ -246,7 +246,7 @@ public class LoopGas {
       byte[] data, ResponseCodeEnum expectedStatus, long gas)
       throws Exception {
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     SmartContractServiceGrpc.SmartContractServiceBlockingStub stub = SmartContractServiceGrpc
         .newBlockingStub(channel);
@@ -291,7 +291,7 @@ public class LoopGas {
       TransactionID transactionId) throws Exception {
     AccountID createdAccount = null;
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
     long fee = FeeClient.getCostForGettingTxRecord();
@@ -319,7 +319,7 @@ public class LoopGas {
   private byte[] callContractLocal(AccountID payerAccount, ContractID contractToCall, byte[] data)
       throws Exception {
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     SmartContractServiceGrpc.SmartContractServiceBlockingStub stub = SmartContractServiceGrpc
         .newBlockingStub(channel);
@@ -362,7 +362,7 @@ public class LoopGas {
      loadGenesisAndNodeAcccounts();
 
       ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-          .usePlaintext(true)
+          .usePlaintext()
           .build();
       TestHelper.initializeFeeClient(channel, genesisAccount, accountKeyPairs.get(genesisAccount),
           nodeAccount);

--- a/test-clients/src/main/java/com/hedera/services/legacy/smartcontract/MaxGasLimit.java
+++ b/test-clients/src/main/java/com/hedera/services/legacy/smartcontract/MaxGasLimit.java
@@ -150,7 +150,7 @@ public class MaxGasLimit {
   private AccountID createAccount(KeyPair keyPair, AccountID payerAccount, long initialBalance)
       throws Exception {
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
     Transaction transaction = TestHelper
@@ -176,7 +176,7 @@ public class MaxGasLimit {
         .setTransactionGetReceipt(RequestBuilder.getTransactionGetReceiptQuery(
             transactionId, ResponseType.ANSWER_ONLY)).build();
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
     Response transactionReceipts = stub.getTransactionReceipts(query);
@@ -196,7 +196,7 @@ public class MaxGasLimit {
   private ContractID createContract(AccountID payerAccount, FileID contractFile) throws Exception {
     ContractID createdContract = null;
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
 
     Duration contractAutoRenew = Duration.newBuilder().setSeconds(contractDuration).build();
@@ -263,7 +263,7 @@ public class MaxGasLimit {
       byte[] data, ResponseCodeEnum expectedStatus, long gas)
       throws Exception {
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     SmartContractServiceGrpc.SmartContractServiceBlockingStub stub = SmartContractServiceGrpc
         .newBlockingStub(channel);
@@ -309,7 +309,7 @@ public class MaxGasLimit {
       TransactionID transactionId) throws Exception {
     AccountID createdAccount = null;
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
     long fee = FeeClient.getCostForGettingTxRecord();
@@ -350,7 +350,7 @@ public class MaxGasLimit {
     byte[] dataToReturn = null;
     AccountID createdAccount = null;
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     SmartContractServiceGrpc.SmartContractServiceBlockingStub stub = SmartContractServiceGrpc
         .newBlockingStub(channel);

--- a/test-clients/src/main/java/com/hedera/services/legacy/smartcontract/OCTokenIT.java
+++ b/test-clients/src/main/java/com/hedera/services/legacy/smartcontract/OCTokenIT.java
@@ -141,7 +141,7 @@ public class OCTokenIT extends LegacySmartContractTest {
     grpcPort = Integer.parseInt(properties.getProperty("port"));
     localCallGas = Long.parseLong(properties.getProperty("LOCAL_CALL_GAS"));
     channelShared = ManagedChannelBuilder.forAddress(OCTokenIT.grpcHost, grpcPort)
-            .usePlaintext(true)
+            .usePlaintext()
             .build();
     cryptoStub = CryptoServiceGrpc.newBlockingStub(channelShared);
     sCServiceStub = SmartContractServiceGrpc.newBlockingStub(channelShared);

--- a/test-clients/src/main/java/com/hedera/services/legacy/smartcontract/OCTransferMerged.java
+++ b/test-clients/src/main/java/com/hedera/services/legacy/smartcontract/OCTransferMerged.java
@@ -157,7 +157,7 @@ public class OCTransferMerged {
     loadGenesisAndNodeAcccounts();
 
     ManagedChannel channel = ManagedChannelBuilder.forAddress(grpcHost, grpcPort)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     TestHelper.initializeFeeClient(channel, genesisAccount, accountKeyPairs.get(genesisAccount),
         nodeAccount);
@@ -237,7 +237,7 @@ public class OCTransferMerged {
       channelShared.shutdown();
     }
     channelShared = ManagedChannelBuilder.forAddress(grpcHost, grpcPort)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     cryptoStub = CryptoServiceGrpc.newBlockingStub(channelShared);
     sCServiceStub = SmartContractServiceGrpc.newBlockingStub(channelShared);

--- a/test-clients/src/main/java/com/hedera/services/legacy/smartcontract/OCTransferStepOne.java
+++ b/test-clients/src/main/java/com/hedera/services/legacy/smartcontract/OCTransferStepOne.java
@@ -174,7 +174,7 @@ public class OCTransferStepOne {
     System.out.println(grpcHost + ":: is the grpc host");
 
     channelShared = ManagedChannelBuilder.forAddress(grpcHost, grpcPort)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     cryptoStub = CryptoServiceGrpc.newBlockingStub(channelShared);
     sCServiceStub = SmartContractServiceGrpc.newBlockingStub(channelShared);

--- a/test-clients/src/main/java/com/hedera/services/legacy/smartcontract/OCTransferStepTwo.java
+++ b/test-clients/src/main/java/com/hedera/services/legacy/smartcontract/OCTransferStepTwo.java
@@ -167,7 +167,7 @@ public class OCTransferStepTwo {
     System.out.println("Got high account number as " + accountNumberHigh);
 
     channelShared = ManagedChannelBuilder.forAddress(grpcHost, grpcPort)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     cryptoStub = CryptoServiceGrpc.newBlockingStub(channelShared);
     sCServiceStub = SmartContractServiceGrpc.newBlockingStub(channelShared);

--- a/test-clients/src/main/java/com/hedera/services/legacy/smartcontract/PayableConstructor.java
+++ b/test-clients/src/main/java/com/hedera/services/legacy/smartcontract/PayableConstructor.java
@@ -140,7 +140,7 @@ public class PayableConstructor {
 	private AccountID createAccount(KeyPair keyPair, AccountID payerAccount, long initialBalance)
 			throws Exception {
 		ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-				.usePlaintext(true)
+				.usePlaintext()
 				.build();
 		CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
 		Transaction transaction = TestHelper
@@ -167,7 +167,7 @@ public class PayableConstructor {
 				.setTransactionGetReceipt(RequestBuilder.getTransactionGetReceiptQuery(
 						transactionId, ResponseType.ANSWER_ONLY)).build();
 		ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-				.usePlaintext(true)
+				.usePlaintext()
 				.build();
 		CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
 		Response transactionReceipts = stub.getTransactionReceipts(query);
@@ -194,7 +194,7 @@ public class PayableConstructor {
 			TransactionID transactionId) throws Exception {
 		AccountID createdAccount = null;
 		ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-				.usePlaintext(true)
+				.usePlaintext()
 				.build();
 		CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
 		long fee = FeeClient.getCostForGettingTxRecord();
@@ -224,7 +224,7 @@ public class PayableConstructor {
 		loadGenesisAndNodeAcccounts();
 
 		ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-				.usePlaintext(true)
+				.usePlaintext()
 				.build();
 		TestHelper.initializeFeeClient(channel, genesisAccount, accountKeyPairs.get(genesisAccount),
 				nodeAccount);
@@ -259,7 +259,7 @@ public class PayableConstructor {
 			long durationInSeconds, KeyPair adminKeyPair, long initialBalance) throws Exception {
 		ContractID createdContract = null;
 		ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-				.usePlaintext(true)
+				.usePlaintext()
 				.build();
 
 		byte[] pubKey = ((EdDSAPublicKey) adminKeyPair.getPublic()).getAbyte();

--- a/test-clients/src/main/java/com/hedera/services/legacy/smartcontract/PrecompiledOpcodes.java
+++ b/test-clients/src/main/java/com/hedera/services/legacy/smartcontract/PrecompiledOpcodes.java
@@ -144,7 +144,7 @@ public class PrecompiledOpcodes {
   private AccountID createAccount(KeyPair keyPair, AccountID payerAccount, long initialBalance)
       throws Exception {
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
     Transaction transaction = TestHelper
@@ -170,7 +170,7 @@ public class PrecompiledOpcodes {
         .setTransactionGetReceipt(RequestBuilder.getTransactionGetReceiptQuery(
             transactionId, ResponseType.ANSWER_ONLY)).build();
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
     Response transactionReceipts = stub.getTransactionReceipts(query);
@@ -190,7 +190,7 @@ public class PrecompiledOpcodes {
   private ContractID createContract(AccountID payerAccount, FileID contractFile) throws Exception {
     ContractID createdContract = null;
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
 
     Duration contractAutoRenew = Duration.newBuilder().setSeconds(contractDuration).build();
@@ -451,7 +451,7 @@ public class PrecompiledOpcodes {
     AccountID createdAccount = null;
     int port = 50211;
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
     long fee = FeeClient.getCostForGettingTxRecord();
@@ -480,7 +480,7 @@ public class PrecompiledOpcodes {
   private byte[] callContractLocal(AccountID payerAccount, ContractID contractToCall, byte[] data)
       throws Exception {
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     SmartContractServiceGrpc.SmartContractServiceBlockingStub stub = SmartContractServiceGrpc
         .newBlockingStub(channel);
@@ -523,7 +523,7 @@ public class PrecompiledOpcodes {
       loadGenesisAndNodeAcccounts();
 
       ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-          .usePlaintext(true)
+          .usePlaintext()
           .build();
       TestHelper.initializeFeeClient(channel, genesisAccount, accountKeyPairs.get(genesisAccount),
           nodeAccount);

--- a/test-clients/src/main/java/com/hedera/services/legacy/smartcontract/SimpleStoragePerformanceThread.java
+++ b/test-clients/src/main/java/com/hedera/services/legacy/smartcontract/SimpleStoragePerformanceThread.java
@@ -227,7 +227,7 @@ public class SimpleStoragePerformanceThread implements Runnable {
         .setTransactionGetReceipt(RequestBuilder.getTransactionGetReceiptQuery(
             transactionId, ResponseType.ANSWER_ONLY)).build();
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
     Response transactionReceipts = stub.getTransactionReceipts(query);
@@ -432,7 +432,7 @@ public class SimpleStoragePerformanceThread implements Runnable {
     loadGenesisAndNodeAcccounts();
 
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     TestHelper.initializeFeeClient(channel, genesisAccount, accountKeyPairs.get(genesisAccount),
         nodeAccount);
@@ -588,7 +588,7 @@ public class SimpleStoragePerformanceThread implements Runnable {
       channel.shutdown();
     }
     channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     cstub = CryptoServiceGrpc.newBlockingStub(channel);
     scstub = SmartContractServiceGrpc.newBlockingStub(channel);

--- a/test-clients/src/main/java/com/hedera/services/legacy/smartcontract/SizeLimit.java
+++ b/test-clients/src/main/java/com/hedera/services/legacy/smartcontract/SizeLimit.java
@@ -170,7 +170,7 @@ public class SizeLimit {
   private AccountID createAccount(KeyPair keyPair, AccountID payerAccount, long initialBalance)
       throws Exception {
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
     Transaction transaction = TestHelper
@@ -197,7 +197,7 @@ public class SizeLimit {
         .setTransactionGetReceipt(RequestBuilder.getTransactionGetReceiptQuery(
             transactionId, ResponseType.ANSWER_ONLY)).build();
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
     Response transactionReceipts = stub.getTransactionReceipts(query);
@@ -224,7 +224,7 @@ public class SizeLimit {
       long durationInSeconds) throws Exception {
     ContractID createdContract = null;
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
 
     Duration contractAutoRenew = Duration.newBuilder().setSeconds(durationInSeconds).build();
@@ -270,7 +270,7 @@ public class SizeLimit {
     byte[] dataToReturn = null;
     ContractID createdContract = null;
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     SmartContractServiceGrpc.SmartContractServiceBlockingStub stub = SmartContractServiceGrpc
         .newBlockingStub(channel);
@@ -323,7 +323,7 @@ public class SizeLimit {
     AccountID createdAccount = null;
     int port = 50211;
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
     long fee = FeeClient.getCostForGettingTxRecord();
@@ -353,7 +353,7 @@ public class SizeLimit {
     byte[] dataToReturn = null;
     AccountID createdAccount = null;
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     SmartContractServiceGrpc.SmartContractServiceBlockingStub stub = SmartContractServiceGrpc
         .newBlockingStub(channel);
@@ -395,7 +395,7 @@ public class SizeLimit {
       Duration autoRenewPeriod, Timestamp expirationTime) throws Exception {
 
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     SmartContractServiceGrpc.SmartContractServiceBlockingStub stub = SmartContractServiceGrpc
         .newBlockingStub(channel);
@@ -427,7 +427,7 @@ public class SizeLimit {
       ContractID contractId) throws Exception {
     String byteCode = "";
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
 
     SmartContractServiceGrpc.SmartContractServiceBlockingStub stub = SmartContractServiceGrpc
@@ -463,7 +463,7 @@ public class SizeLimit {
   private AccountInfo getCryptoGetAccountInfo(
       AccountID accountID) throws Exception {
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
 
@@ -495,7 +495,7 @@ public class SizeLimit {
       String solidityId) throws Exception {
     int port = 50211;
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     SmartContractServiceGrpc.SmartContractServiceBlockingStub stub = SmartContractServiceGrpc
         .newBlockingStub(channel);
@@ -520,7 +520,7 @@ public class SizeLimit {
   public List<TransactionRecord> getTxRecordByContractID(AccountID payerID, ContractID contractId)
       throws Exception {
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
 
     SmartContractServiceGrpc.SmartContractServiceBlockingStub scstub = SmartContractServiceGrpc
@@ -715,7 +715,7 @@ public class SizeLimit {
 
 
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     TestHelper.initializeFeeClient(channel, crAccount, crAccountKeyPair, nodeAccount);
     channel.shutdown();

--- a/test-clients/src/main/java/com/hedera/services/legacy/smartcontract/StaticOpcodes.java
+++ b/test-clients/src/main/java/com/hedera/services/legacy/smartcontract/StaticOpcodes.java
@@ -149,7 +149,7 @@ public class StaticOpcodes {
   private AccountID createAccount(KeyPair keyPair, AccountID payerAccount, long initialBalance)
       throws Exception {
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
     Transaction transaction = TestHelper
@@ -175,7 +175,7 @@ public class StaticOpcodes {
         .setTransactionGetReceipt(RequestBuilder.getTransactionGetReceiptQuery(
             transactionId, ResponseType.ANSWER_ONLY)).build();
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
     Response transactionReceipts = stub.getTransactionReceipts(query);
@@ -195,7 +195,7 @@ public class StaticOpcodes {
   private ContractID createContract(AccountID payerAccount, FileID contractFile) throws Exception {
     ContractID createdContract = null;
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
 
     Duration contractAutoRenew = Duration.newBuilder().setSeconds(contractDuration).build();
@@ -475,7 +475,7 @@ public class StaticOpcodes {
       byte[] data, ResponseCodeEnum expectedStatus)
       throws Exception {
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     SmartContractServiceGrpc.SmartContractServiceBlockingStub stub = SmartContractServiceGrpc
         .newBlockingStub(channel);
@@ -520,7 +520,7 @@ public class StaticOpcodes {
       TransactionID transactionId) throws Exception {
     AccountID createdAccount = null;
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
     long fee = FeeClient.getCostForGettingTxRecord();
@@ -549,7 +549,7 @@ public class StaticOpcodes {
   private byte[] callContractLocal(AccountID payerAccount, ContractID contractToCall, byte[] data)
       throws Exception {
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     SmartContractServiceGrpc.SmartContractServiceBlockingStub stub = SmartContractServiceGrpc
         .newBlockingStub(channel);
@@ -590,7 +590,7 @@ public class StaticOpcodes {
     loadGenesisAndNodeAcccounts();
 
       ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-          .usePlaintext(true)
+          .usePlaintext()
           .build();
       TestHelper.initializeFeeClient(channel, genesisAccount, accountKeyPairs.get(genesisAccount),
           nodeAccount);

--- a/test-clients/src/main/java/com/hedera/services/legacy/smartcontract/StressCorruptBin.java
+++ b/test-clients/src/main/java/com/hedera/services/legacy/smartcontract/StressCorruptBin.java
@@ -150,7 +150,7 @@ public class StressCorruptBin {
   private AccountID createAccount(KeyPair keyPair, AccountID payerAccount, long initialBalance)
       throws Exception {
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
     Transaction transaction = TestHelper
@@ -177,7 +177,7 @@ public class StressCorruptBin {
         .setTransactionGetReceipt(RequestBuilder.getTransactionGetReceiptQuery(
             transactionId, ResponseType.ANSWER_ONLY)).build();
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
     Response transactionReceipts = stub.getTransactionReceipts(query);
@@ -201,7 +201,7 @@ public class StressCorruptBin {
       ResponseCodeEnum expectedStatus) throws Exception {
     ContractID createdContract = null;
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
 
     Duration contractAutoRenew = Duration.newBuilder().setSeconds(contractDuration).build();
@@ -261,7 +261,7 @@ public class StressCorruptBin {
       byte[] data, ResponseCodeEnum expectedStatus, long gas)
       throws Exception {
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     SmartContractServiceGrpc.SmartContractServiceBlockingStub stub = SmartContractServiceGrpc
         .newBlockingStub(channel);
@@ -308,7 +308,7 @@ public class StressCorruptBin {
       TransactionID transactionId) throws Exception {
     AccountID createdAccount = null;
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
     long fee = FeeClient.getCostForGettingTxRecord();
@@ -337,7 +337,7 @@ public class StressCorruptBin {
   private byte[] callContractLocal(AccountID payerAccount, ContractID contractToCall, byte[] data)
       throws Exception {
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     SmartContractServiceGrpc.SmartContractServiceBlockingStub stub = SmartContractServiceGrpc
         .newBlockingStub(channel);
@@ -380,7 +380,7 @@ public class StressCorruptBin {
      loadGenesisAndNodeAcccounts();
 
       ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-          .usePlaintext(true)
+          .usePlaintext()
           .build();
       TestHelper.initializeFeeClient(channel, genesisAccount, accountKeyPairs.get(genesisAccount),
           nodeAccount);

--- a/test-clients/src/main/java/com/hedera/services/legacy/smartcontract/StressInfiniteLoop.java
+++ b/test-clients/src/main/java/com/hedera/services/legacy/smartcontract/StressInfiniteLoop.java
@@ -160,7 +160,7 @@ public class StressInfiniteLoop {
   private AccountID createAccount(KeyPair keyPair, AccountID payerAccount, long initialBalance)
       throws Exception {
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
     Transaction transaction = TestHelper
@@ -186,7 +186,7 @@ public class StressInfiniteLoop {
         .setTransactionGetReceipt(RequestBuilder.getTransactionGetReceiptQuery(
             transactionId, ResponseType.ANSWER_ONLY)).build();
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
     Response transactionReceipts = stub.getTransactionReceipts(query);
@@ -206,7 +206,7 @@ public class StressInfiniteLoop {
   private ContractID createContract(AccountID payerAccount, FileID contractFile) throws Exception {
     ContractID createdContract = null;
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
 
     Duration contractAutoRenew = Duration.newBuilder().setSeconds(contractDuration).build();
@@ -273,7 +273,7 @@ public class StressInfiniteLoop {
       byte[] data, ResponseCodeEnum expectedStatus, long gas)
       throws Exception {
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     SmartContractServiceGrpc.SmartContractServiceBlockingStub stub = SmartContractServiceGrpc
         .newBlockingStub(channel);
@@ -319,7 +319,7 @@ public class StressInfiniteLoop {
       TransactionID transactionId) throws Exception {
     AccountID createdAccount = null;
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
     long fee = FeeClient.getCostForGettingTxRecord();
@@ -347,7 +347,7 @@ public class StressInfiniteLoop {
   private byte[] callContractLocal(AccountID payerAccount, ContractID contractToCall, byte[] data)
       throws Exception {
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     SmartContractServiceGrpc.SmartContractServiceBlockingStub stub = SmartContractServiceGrpc
         .newBlockingStub(channel);
@@ -390,7 +390,7 @@ public class StressInfiniteLoop {
      loadGenesisAndNodeAcccounts();
 
       ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-          .usePlaintext(true)
+          .usePlaintext()
           .build();
       TestHelper.initializeFeeClient(channel, genesisAccount, accountKeyPairs.get(genesisAccount),
           nodeAccount);

--- a/test-clients/src/main/java/com/hedera/services/legacy/smartcontract/StressInfiniteRecursion.java
+++ b/test-clients/src/main/java/com/hedera/services/legacy/smartcontract/StressInfiniteRecursion.java
@@ -140,7 +140,7 @@ public class StressInfiniteRecursion {
   private AccountID createAccount(KeyPair keyPair, AccountID payerAccount, long initialBalance)
       throws Exception {
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
     Transaction transaction = TestHelper
@@ -166,7 +166,7 @@ public class StressInfiniteRecursion {
         .setTransactionGetReceipt(RequestBuilder.getTransactionGetReceiptQuery(
             transactionId, ResponseType.ANSWER_ONLY)).build();
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
     Response transactionReceipts = stub.getTransactionReceipts(query);
@@ -186,7 +186,7 @@ public class StressInfiniteRecursion {
   private ContractID createContract(AccountID payerAccount, FileID contractFile) throws Exception {
     ContractID createdContract = null;
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
 
     Duration contractAutoRenew = Duration.newBuilder().setSeconds(contractDuration).build();
@@ -253,7 +253,7 @@ public class StressInfiniteRecursion {
       byte[] data, ResponseCodeEnum expectedStatus, long gas)
       throws Exception {
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     SmartContractServiceGrpc.SmartContractServiceBlockingStub stub = SmartContractServiceGrpc
         .newBlockingStub(channel);
@@ -301,7 +301,7 @@ public class StressInfiniteRecursion {
       TransactionID transactionId) throws Exception {
     AccountID createdAccount = null;
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
     long fee = FeeClient.getCostForGettingTxRecord();
@@ -330,7 +330,7 @@ public class StressInfiniteRecursion {
   private byte[] callContractLocal(AccountID payerAccount, ContractID contractToCall, byte[] data)
       throws Exception {
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     SmartContractServiceGrpc.SmartContractServiceBlockingStub stub = SmartContractServiceGrpc
         .newBlockingStub(channel);
@@ -373,7 +373,7 @@ public class StressInfiniteRecursion {
      loadGenesisAndNodeAcccounts();
 
       ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-          .usePlaintext(true)
+          .usePlaintext()
           .build();
       TestHelper.initializeFeeClient(channel, genesisAccount, accountKeyPairs.get(genesisAccount),
           nodeAccount);

--- a/test-clients/src/main/java/com/hedera/services/legacy/smartcontract/StressLargeData.java
+++ b/test-clients/src/main/java/com/hedera/services/legacy/smartcontract/StressLargeData.java
@@ -137,7 +137,7 @@ public class StressLargeData {
   private AccountID createAccount(KeyPair keyPair, AccountID payerAccount, long initialBalance)
       throws Exception {
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
     Transaction transaction = TestHelper
@@ -163,7 +163,7 @@ public class StressLargeData {
         .setTransactionGetReceipt(RequestBuilder.getTransactionGetReceiptQuery(
             transactionId, ResponseType.ANSWER_ONLY)).build();
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
     Response transactionReceipts = stub.getTransactionReceipts(query);
@@ -183,7 +183,7 @@ public class StressLargeData {
   private ContractID createContract(AccountID payerAccount, FileID contractFile) throws Exception {
     ContractID createdContract = null;
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
 
     Duration contractAutoRenew = Duration.newBuilder().setSeconds(contractDuration).build();
@@ -249,7 +249,7 @@ public class StressLargeData {
       byte[] data)
       throws Exception {
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     SmartContractServiceGrpc.SmartContractServiceBlockingStub stub = SmartContractServiceGrpc
         .newBlockingStub(channel);
@@ -299,7 +299,7 @@ public class StressLargeData {
       TransactionID transactionId) throws Exception {
     AccountID createdAccount = null;
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
     long fee = FeeClient.getCostForGettingTxRecord();
@@ -328,7 +328,7 @@ public class StressLargeData {
   private byte[] callContractLocal(AccountID payerAccount, ContractID contractToCall, byte[] data)
       throws Exception {
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     SmartContractServiceGrpc.SmartContractServiceBlockingStub stub = SmartContractServiceGrpc
         .newBlockingStub(channel);
@@ -371,7 +371,7 @@ public class StressLargeData {
      loadGenesisAndNodeAcccounts();
 
       ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-          .usePlaintext(true)
+          .usePlaintext()
           .build();
       TestHelper.initializeFeeClient(channel, genesisAccount, accountKeyPairs.get(genesisAccount),
           nodeAccount);

--- a/test-clients/src/main/java/com/hedera/services/legacy/smartcontract/V3V4After.java
+++ b/test-clients/src/main/java/com/hedera/services/legacy/smartcontract/V3V4After.java
@@ -141,7 +141,7 @@ public class V3V4After {
   private AccountID createAccount(KeyPair keyPair, AccountID payerAccount, long initialBalance)
       throws Exception {
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
     Transaction transaction = TestHelper
@@ -168,7 +168,7 @@ public class V3V4After {
         .setTransactionGetReceipt(RequestBuilder.getTransactionGetReceiptQuery(
             transactionId, ResponseType.ANSWER_ONLY)).build();
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
     Response transactionReceipts = stub.getTransactionReceipts(query);
@@ -193,7 +193,7 @@ public class V3V4After {
       AccountID adminAccount, String memo) throws Exception {
     ContractID createdContract = null;
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
 
     Duration contractAutoRenew = Duration.newBuilder().setSeconds(DAY_SEC * 30).build();
@@ -244,7 +244,7 @@ public class V3V4After {
       TransactionID transactionId) throws Exception {
     AccountID createdAccount = null;
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
     long fee = FeeClient.getCostForGettingTxRecord();
@@ -333,7 +333,7 @@ public class V3V4After {
   private ContractInfo getContractInfo(AccountID payerAccount,
       ContractID contractId) throws Exception {
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     SmartContractServiceGrpc.SmartContractServiceBlockingStub stub = SmartContractServiceGrpc
         .newBlockingStub(channel);

--- a/test-clients/src/main/java/com/hedera/services/legacy/smartcontract/V3V4Before.java
+++ b/test-clients/src/main/java/com/hedera/services/legacy/smartcontract/V3V4Before.java
@@ -143,7 +143,7 @@ public class V3V4Before {
   private AccountID createAccount(KeyPair keyPair, AccountID payerAccount, long initialBalance)
       throws Exception {
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
     Transaction transaction = TestHelper
@@ -170,7 +170,7 @@ public class V3V4Before {
         .setTransactionGetReceipt(RequestBuilder.getTransactionGetReceiptQuery(
             transactionId, ResponseType.ANSWER_ONLY)).build();
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
     Response transactionReceipts = stub.getTransactionReceipts(query);
@@ -195,7 +195,7 @@ public class V3V4Before {
       AccountID adminAccount, String memo) throws Exception {
     ContractID createdContract = null;
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
 
     Duration contractAutoRenew = Duration.newBuilder().setSeconds(DAY_SEC * 30).build();
@@ -246,7 +246,7 @@ public class V3V4Before {
       TransactionID transactionId) throws Exception {
     AccountID createdAccount = null;
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     CryptoServiceGrpc.CryptoServiceBlockingStub stub = CryptoServiceGrpc.newBlockingStub(channel);
     long fee = FeeClient.getCostForGettingTxRecord();
@@ -338,7 +338,7 @@ public class V3V4Before {
   private ContractInfo getContractInfo(AccountID payerAccount,
       ContractID contractId) throws Exception {
     ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     SmartContractServiceGrpc.SmartContractServiceBlockingStub stub = SmartContractServiceGrpc
         .newBlockingStub(channel);

--- a/test-clients/src/main/java/com/hedera/services/legacy/throttling/ContractCallThrottling.java
+++ b/test-clients/src/main/java/com/hedera/services/legacy/throttling/ContractCallThrottling.java
@@ -104,7 +104,7 @@ public class ContractCallThrottling {
   public ContractCallThrottling(int port, String host) {
     // connecting to the grpc server on the port
     channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     createStubs();
   }

--- a/test-clients/src/main/java/com/hedera/services/legacy/throttling/CryptoCreateThrottling.java
+++ b/test-clients/src/main/java/com/hedera/services/legacy/throttling/CryptoCreateThrottling.java
@@ -78,7 +78,7 @@ public class CryptoCreateThrottling {
   public CryptoCreateThrottling(int port, String host) {
     // connecting to the grpc server on the port
     channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     stub = CryptoServiceGrpc.newBlockingStub(channel);
   }

--- a/test-clients/src/main/java/com/hedera/services/legacy/walletsupport/CreateAccount.java
+++ b/test-clients/src/main/java/com/hedera/services/legacy/walletsupport/CreateAccount.java
@@ -67,7 +67,7 @@ public class CreateAccount {
   public CreateAccount(int port, String host) {
     // connecting to the grpc server on the port
     channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext(true)
+        .usePlaintext()
         .build();
     CreateAccount.stub = CryptoServiceGrpc.newBlockingStub(channel);
   }

--- a/test-clients/src/main/java/com/hedera/services/legacy/walletsupport/CreateAccountWithParams.java
+++ b/test-clients/src/main/java/com/hedera/services/legacy/walletsupport/CreateAccountWithParams.java
@@ -70,7 +70,7 @@ public class CreateAccountWithParams {
     public CreateAccountWithParams(int port, String host) {
         // connecting to the grpc server on the port
         ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
-                .usePlaintext(true)
+                .usePlaintext()
                 .build();
         CreateAccountWithParams.stub = CryptoServiceGrpc.newBlockingStub(channel);
     }


### PR DESCRIPTION
Upgrade to the latest version of the [_grpc-java_](https://github.com/grpc/grpc-java) project and use their stated Netty dependency.

Only code change required is using `ManagedChannelBuilder#usePlaintext` instead of the deprecated `ManagedChannelBuilder#usePlaintext(boolean)`.