### PR TITLE
00715 d nightly update regression failure

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2139,7 +2139,6 @@ jobs:
             '/repo/.circleci/scripts/show_java_process.sh'
       - run-eet-suites:
           dsl-args: FreezeSuite
-          ci-properties-map: default.payer=0.0.2
       - run:
           name: Show logs before HGCApp restart
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -911,7 +911,7 @@ workflows:
           filters:
             branches:
               only:
-                - master
+                - Disable_4N_Perf_JRS_Regression_master
     jobs:
       - build-platform-and-services
       - run-performance-regression:
@@ -1154,20 +1154,16 @@ workflows:
             - attach_workspace:
                 at: /
   feature-update-regression:
-#    triggers:
-#        - schedule:
-#            cron: "0 8 * * *"
-#            filters:
-#              branches:
-#                only:
-#                  - master
+    triggers:
+        - schedule:
+            cron: "0 8 * * *"
+            filters:
+              branches:
+                only:
+                  - master
     jobs:
       - fast-build-artifact:
           context: Slack
-          filters:
-            branches:
-              only:
-                - 00715-D-nightly-update-regression-failure
           post-steps:
             - save-this-job-client-logs:
                 workflow-name: "feature-update-regression"
@@ -1326,7 +1322,6 @@ workflows:
               ignore:
                 - /.*-PERF/
                 - /.*-REGRESSION/
-                - 00715-D-nightly-update-regression-failure
           workflow-name: "Continuous integration"
       - start-singlejob-testnet:
           context: Slack

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1154,16 +1154,20 @@ workflows:
             - attach_workspace:
                 at: /
   feature-update-regression:
-    triggers:
-        - schedule:
-            cron: "0 8 * * *"
-            filters:
-              branches:
-                only:
-                  - master
+#    triggers:
+#        - schedule:
+#            cron: "0 8 * * *"
+#            filters:
+#              branches:
+#                only:
+#                  - master
     jobs:
       - fast-build-artifact:
           context: Slack
+          filters:
+            branches:
+              only:
+                - 00715-D-nightly-update-regression-failure
           post-steps:
             - save-this-job-client-logs:
                 workflow-name: "feature-update-regression"
@@ -1322,6 +1326,7 @@ workflows:
               ignore:
                 - /.*-PERF/
                 - /.*-REGRESSION/
+                - 00715-D-nightly-update-regression-failure
           workflow-name: "Continuous integration"
       - start-singlejob-testnet:
           context: Slack
@@ -2134,6 +2139,7 @@ jobs:
             '/repo/.circleci/scripts/show_java_process.sh'
       - run-eet-suites:
           dsl-args: FreezeSuite
+          ci-properties-map: default.payer=0.0.2
       - run:
           name: Show logs before HGCApp restart
           command: |

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/freeze/FreezeSuite.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/freeze/FreezeSuite.java
@@ -106,9 +106,11 @@ public class FreezeSuite extends HapiApiSuite {
 		return defaultHapiSpec("uploadFileAndUpdate")
 				.given(
 						fileUpdate(fileIDString).path(uploadFile)
+						.payingWith(GENESIS)
 				).when(
 						freeze().setFileID(fileIDString)
 								.setFileHash(hash)
+								.payingWith(GENESIS)
 								.startingIn(60).seconds().andLasting(1).minutes()
 				).then(
 				);


### PR DESCRIPTION
**Related issue(s)**:
Closes #715 

**Summary of the change**:
1. Changes to fix the feature update CircleCi regression test. Here we force the FreezeSuite's transactions to be paid by treasury account as recent check only allow treasury account to do update. 
2. Also disable 4-node perf JRS regression test;

**External impacts**:
None.

**Applicable documentation**
- [ ] Javadoc
- [ ] HAPI protobuf comments
- [ ] README
