### PR TITLE
Add + use ServicesContext#rebuildBackingStoresIfPresent

### DIFF
--- a/hedera-node/src/main/java/com/hedera/services/ServicesMain.java
+++ b/hedera-node/src/main/java/com/hedera/services/ServicesMain.java
@@ -164,8 +164,6 @@ public class ServicesMain implements SwirldMain {
 		log.info("System files rationalized.");
 		exportAccountsIfDesired();
 		log.info("Accounts exported.");
-		reviewRecordExpirations();
-		log.info("Record expiration reviewed.");
 		loadFeeSchedule();
 		log.info("Fee schedule loaded.");
 		initializeStats();
@@ -281,10 +279,6 @@ public class ServicesMain implements SwirldMain {
 		if (ctx.nodeAccount() == null) {
 			throw new IllegalStateException("Unknown ledger account!");
 		}
-	}
-
-	private void reviewRecordExpirations() {
-		ctx.recordsHistorian().reviewExistingRecords();
 	}
 
 	void logInfoWithConsoleEcho(String s) {

--- a/hedera-node/src/main/java/com/hedera/services/ServicesState.java
+++ b/hedera-node/src/main/java/com/hedera/services/ServicesState.java
@@ -216,15 +216,19 @@ public class ServicesState extends AbstractMerkleInternal implements SwirldState
 			printHashes();
 		}
 
-		ctx.update(this);
-
-		ctx.txnHistories().clear();
-		ctx.recordsHistorian().reviewExistingRecords();
+		initializeContext(ctx);
 		CONTEXTS.store(ctx);
 
 		log.info("  --> Context initialized accordingly on Services node {}", nodeId);
 		log.info("ServicesState init with {} accounts", () -> this.accounts().size());
 		log.info("ServicesState init with {} topics", () -> this.topics().size());
+	}
+
+	private void initializeContext(ServicesContext ctx) {
+		ctx.update(this);
+		ctx.txnHistories().clear();
+		ctx.recordsHistorian().reviewExistingRecords();
+		ctx.rebuildBackingStoresIfPresent();
 	}
 
 	@Override

--- a/hedera-node/src/main/java/com/hedera/services/context/ServicesContext.java
+++ b/hedera-node/src/main/java/com/hedera/services/context/ServicesContext.java
@@ -468,6 +468,15 @@ public class ServicesContext {
 		queryableTokenAssociations().set(tokenAssociations());
 	}
 
+	public void rebuildBackingStoresIfPresent() {
+		if (backingTokenRels != null) {
+			backingTokenRels.rebuildFromSources();
+		}
+		if (backingAccounts != null) {
+			backingAccounts.rebuildFromSources();
+		}
+	}
+
 	public HapiOpCounters opCounters() {
 		if (opCounters == null) {
 			opCounters = new HapiOpCounters(new CounterFactory() {}, MiscUtils::baseStatNameOf);
@@ -1678,5 +1687,13 @@ public class ServicesContext {
 
 	public MerkleDiskFs diskFs() {
 		return state.diskFs();
+	}
+
+	void setBackingTokenRels(BackingTokenRels backingTokenRels) {
+		this.backingTokenRels = backingTokenRels;
+	}
+
+	void setBackingAccounts(FCMapBackingAccounts backingAccounts) {
+		this.backingAccounts = backingAccounts;
 	}
 }

--- a/hedera-node/src/main/java/com/hedera/services/ledger/accounts/BackingStore.java
+++ b/hedera-node/src/main/java/com/hedera/services/ledger/accounts/BackingStore.java
@@ -36,9 +36,17 @@ import java.util.Set;
  */
 public interface BackingStore<K, A> {
 	/**
-	 * Alerts this {@code BackingAccounts} it should flush any cached mutable references.
+	 * Alerts this {@code BackingStore} it should flush any cached mutable references.
 	 */
 	void flushMutableRefs();
+
+	/**
+	 * Alerts this {@code BackingStore} it should reconstruct any auxiliary data structures
+	 * based on its underlying sources. Used in particular for reconnect.
+	 */
+	default void rebuildFromSources() {
+		/* No-op. */
+	}
 
 	/**
 	 * Gets a possibly mutable reference to the account with the specified id.

--- a/hedera-node/src/main/java/com/hedera/services/ledger/accounts/BackingTokenRels.java
+++ b/hedera-node/src/main/java/com/hedera/services/ledger/accounts/BackingTokenRels.java
@@ -60,7 +60,12 @@ public class BackingTokenRels implements BackingStore<Map.Entry<AccountID, Token
 
 	public BackingTokenRels(Supplier<FCMap<MerkleEntityAssociation, MerkleTokenRelStatus>> delegate) {
 		this.delegate = delegate;
+		rebuildFromSources();
+	}
 
+	@Override
+	public void rebuildFromSources() {
+		existingRels.clear();
 		delegate.get().keySet().stream()
 				.map(MerkleEntityAssociation::asAccountTokenRel)
 				.forEach(existingRels::add);

--- a/hedera-node/src/main/java/com/hedera/services/ledger/accounts/FCMapBackingAccounts.java
+++ b/hedera-node/src/main/java/com/hedera/services/ledger/accounts/FCMapBackingAccounts.java
@@ -43,7 +43,12 @@ public class FCMapBackingAccounts implements BackingStore<AccountID, MerkleAccou
 
 	public FCMapBackingAccounts(Supplier<FCMap<MerkleEntityId, MerkleAccount>> delegate) {
 		this.delegate = delegate;
+		rebuildFromSources();
+	}
 
+	@Override
+	public void rebuildFromSources() {
+		existingAccounts.clear();
 		delegate.get().keySet().stream()
 				.map(MerkleEntityId::toAccountId)
 				.forEach(existingAccounts::add);

--- a/hedera-node/src/test/java/com/hedera/services/ServicesMainTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/ServicesMainTest.java
@@ -276,7 +276,6 @@ public class ServicesMainTest {
 		inOrder.verify(recordStreamThread).start();
 		inOrder.verify(ledgerValidator).assertIdsAreValid(accounts);
 		inOrder.verify(ledgerValidator).hasExpectedTotalBalance(accounts);
-		inOrder.verify(recordsHistorian).reviewExistingRecords();
 		inOrder.verify(fees).init();
 		inOrder.verify(statsManager).initializeFor(platform);
 	}

--- a/hedera-node/src/test/java/com/hedera/services/context/ServicesContextTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/context/ServicesContextTest.java
@@ -137,9 +137,12 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 
 import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.BDDMockito.*;
 import static org.hamcrest.MatcherAssert.assertThat;
 
@@ -323,6 +326,30 @@ public class ServicesContextTest {
 		assertEquals(ServicesNodeType.ZERO_STAKE_NODE, ctx.nodeType());
 		// and:
 		assertThat(ctx.answerFlow(), instanceOf(ZeroStakeAnswerFlow.class));
+	}
+
+	@Test
+	public void rebuildsBackingAccountsIfNonNull() {
+		// setup:
+		BackingTokenRels tokenRels = mock(BackingTokenRels.class);
+		FCMapBackingAccounts backingAccounts = mock(FCMapBackingAccounts.class);
+
+		// given:
+		ServicesContext ctx = new ServicesContext(id, platform, state, propertySources);
+
+		// expect:
+		assertDoesNotThrow(ctx::rebuildBackingStoresIfPresent);
+
+		// and given:
+		ctx.setBackingAccounts(backingAccounts);
+		ctx.setBackingTokenRels(tokenRels);
+
+		// when:
+		ctx.rebuildBackingStoresIfPresent();
+
+		// then:
+		verify(tokenRels).rebuildFromSources();
+		verify(backingAccounts).rebuildFromSources();
 	}
 
 	@Test

--- a/hedera-node/src/test/java/com/hedera/services/ledger/accounts/BackingTokenRelsTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/ledger/accounts/BackingTokenRelsTest.java
@@ -151,6 +151,21 @@ class BackingTokenRelsTest {
 	}
 
 	@Test
+	public void rebuildsFromChangedSources() {
+		// when:
+		rels.clear();
+		rels.put(cKey, cValue);
+		// and:
+		subject.rebuildFromSources();
+
+		// then:
+		assertFalse(subject.existingRels.contains(asTokenRel(a, at)));
+		assertFalse(subject.existingRels.contains(asTokenRel(b, bt)));
+		// and:
+		assertTrue(subject.existingRels.contains(asTokenRel(c, ct)));
+	}
+
+	@Test
 	public void containsWorks() {
 		// expect:
 		assertTrue(subject.contains(asTokenRel(a, at)));

--- a/hedera-node/src/test/java/com/hedera/services/ledger/accounts/FCMapBackingAccountsTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/ledger/accounts/FCMapBackingAccountsTest.java
@@ -81,6 +81,30 @@ class FCMapBackingAccountsTest {
 	}
 
 	@Test
+	public void rebuildsFromChangedSources() {
+		// setup:
+		map = new FCMap<>();
+		map.put(aKey, aValue);
+		map.put(bKey, bValue);
+		// and:
+		subject = new FCMapBackingAccounts(() -> map);
+
+		// when:
+		map.clear();
+		map.put(cKey, cValue);
+		map.put(dKey, dValue);
+		// and:
+		subject.rebuildFromSources();
+
+		// then:
+		assertFalse(subject.existingAccounts.contains(a));
+		assertFalse(subject.existingAccounts.contains(b));
+		// and:
+		assertTrue(subject.existingAccounts.contains(c));
+		assertTrue(subject.existingAccounts.contains(d));
+	}
+
+	@Test
 	public void containsDelegatesToKnownActive() {
 		// setup:
 		subject.existingAccounts = Set.of(a, b);


### PR DESCRIPTION
If the context's `backingAccounts` or `backingTokenRels` are non-`null` in `ServicesState#init`, then rebuild their "existing entities"  lookups because this implies a reconnect just finished.