### PR TITLE
Fix building swirlds-platform in cicleci JRS regression

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1858,9 +1858,11 @@ jobs:
       - run:
           name: Checkout swirlds-platform repos and build
           command: |
+            sed -i -e 's/Host services-jrs-regression/Host services-jrs-regression\n HostName github.com/g' ~/.ssh/config
             cd /; GIT_SSH_COMMAND="ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no" \
-              git clone  --recurse-submodule ssh://git@github.com/swirlds/swirlds-platform.git
-            cd /swirlds-platform; git checkout develop;
+            git clone ssh://git@services-jrs-regression/swirlds/swirlds-platform.git;
+            cd /swirlds-platform;
+            sed -i -e 's/github.com/services-jrs-regression/g' .gitmodules;
             git submodule update --init --recursive --checkout;
             mvn --no-transfer-progress clean install -DskipTests;
 
@@ -1898,12 +1900,15 @@ jobs:
       - run:
           name: Checkout swirlds-platform repos and build
           command: |
+            sed -i -e 's/Host services-jrs-regression/Host services-jrs-regression\n HostName github.com/g' ~/.ssh/config
             cd /; GIT_SSH_COMMAND="ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no" \
-              git clone  --recurse-submodule ssh://git@github.com/swirlds/swirlds-platform.git
-            cd /swirlds-platform; git checkout services-regression;
+            git clone ssh://git@services-jrs-regression/swirlds/swirlds-platform.git;
+            cd /swirlds-platform;
+            sed -i -e 's/github.com/services-jrs-regression/g' .gitmodules;
             git submodule update --init --recursive --checkout;
+            cd /swirlds-platform; git checkout services-regression;
             cd /swirlds-platform/regression;   git checkout 334-D-Add-services-config;
-            cd /swirlds-platform; mvn --no-transfer-progress clean install -DskipTests;
+            mvn --no-transfer-progress clean install -DskipTests;
 
       - run:
           name: Save PEM file to keys folder

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1903,11 +1903,9 @@ jobs:
             sed -i -e 's/Host services-jrs-regression/Host services-jrs-regression\n HostName github.com/g' ~/.ssh/config
             cd /; GIT_SSH_COMMAND="ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no" \
             git clone ssh://git@services-jrs-regression/swirlds/swirlds-platform.git;
-            cd /swirlds-platform;
+            cd /swirlds-platform; git checkout services-regression;
             sed -i -e 's/github.com/services-jrs-regression/g' .gitmodules;
             git submodule update --init --recursive --checkout;
-            cd /swirlds-platform; git checkout services-regression;
-            cd /swirlds-platform/regression;   git checkout 334-D-Add-services-config;
             mvn --no-transfer-progress clean install -DskipTests;
 
       - run:


### PR DESCRIPTION
While running nightly JRS regression `swirlds-platform` build is failing. This PR fixes the build