### PR TITLE
Clear all record-based views in ExpiryManager#restartTrackingFrom

### DIFF
--- a/hedera-node/src/main/java/com/hedera/services/ServicesState.java
+++ b/hedera-node/src/main/java/com/hedera/services/ServicesState.java
@@ -235,7 +235,6 @@ public class ServicesState extends AbstractMerkleInternal implements SwirldState
 		/* Use any payer records stored in state to rebuild the recent transaction
 		* history. This history has two main uses: Purging expired records, and
 		* classifying duplicate transactions. */
-		ctx.txnHistories().clear();
 		ctx.recordsHistorian().reviewExistingRecords();
 
 		/* Ensure files 0.0.121 and 0.0.122 exist in state, creating them from

--- a/hedera-node/src/main/java/com/hedera/services/records/RecordCache.java
+++ b/hedera-node/src/main/java/com/hedera/services/records/RecordCache.java
@@ -166,4 +166,8 @@ public class RecordCache {
 	public void trackForExpiry(ExpirableTxnRecord record) {
 		recordExpiries.track(record.getTxnId().toGrpc(), record.getExpiry());
 	}
+
+	public void reset() {
+		recordExpiries.reset();
+	}
 }

--- a/hedera-node/src/main/java/com/hedera/services/records/TxnAwareRecordsHistorian.java
+++ b/hedera-node/src/main/java/com/hedera/services/records/TxnAwareRecordsHistorian.java
@@ -101,6 +101,6 @@ public class TxnAwareRecordsHistorian implements AccountRecordsHistorian {
 
 	@Override
 	public void reviewExistingRecords() {
-		expiries.resumeTrackingFrom(accounts.get());
+		expiries.restartTrackingFrom(accounts.get());
 	}
 }

--- a/hedera-node/src/main/java/com/hedera/services/state/expiry/ExpiryManager.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/expiry/ExpiryManager.java
@@ -56,7 +56,11 @@ public class ExpiryManager {
 		payerExpiries.track(owner.getAccountNum(), expiry);
 	}
 
-	public void resumeTrackingFrom(FCMap<MerkleEntityId, MerkleAccount> accounts) {
+	public void restartTrackingFrom(FCMap<MerkleEntityId, MerkleAccount> accounts) {
+		recordCache.reset();
+		txnHistories.clear();
+		payerExpiries.reset();
+
 		var _payerExpiries = new ArrayList<Map.Entry<Long, Long>>();
 		accounts.forEach((id, account) -> {
 			addUniqueExpiries(id.getNum(), account.records(), _payerExpiries);

--- a/hedera-node/src/main/java/com/hedera/services/state/expiry/KeyedExpirations.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/expiry/KeyedExpirations.java
@@ -21,6 +21,7 @@ package com.hedera.services.state.expiry;
  */
 
 public interface KeyedExpirations<K> {
+	void reset();
 	void track(K id, long expiry);
 	boolean hasExpiringAt(long now);
 	K expireNextAt(long now);

--- a/hedera-node/src/main/java/com/hedera/services/state/expiry/MonotonicFullQueueExpiries.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/expiry/MonotonicFullQueueExpiries.java
@@ -31,6 +31,12 @@ public class MonotonicFullQueueExpiries<K> implements KeyedExpirations<K> {
 	Deque<ExpiryEvent> allExpiries = new ArrayDeque<>();
 
 	@Override
+	public void reset() {
+		now = 0L;
+		allExpiries.clear();
+	}
+
+	@Override
 	public void track(K id, long expiry) {
 		if (expiry < now) {
 			throw new IllegalArgumentException(String.format("Track time %d for %s not later than %d", expiry, id, now));

--- a/hedera-node/src/test/java/com/hedera/services/ServicesStateTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/ServicesStateTest.java
@@ -286,7 +286,6 @@ class ServicesStateTest {
 		inOrder.verify(ctx).nodeAccount();
 		inOrder.verify(ctx).update(subject);
 		inOrder.verify(ctx).rebuildBackingStoresIfPresent();
-		inOrder.verify(txnHistories).clear();
 		inOrder.verify(historian).reviewExistingRecords();
 		inOrder.verify(systemFilesManager).loadApplicationProperties();
 		inOrder.verify(systemFilesManager).loadApiPermissions();

--- a/hedera-node/src/test/java/com/hedera/services/records/RecordCacheTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/records/RecordCacheTest.java
@@ -122,6 +122,17 @@ class RecordCacheTest {
 	}
 
 	@Test
+	public void resetsHistoriesIfRequested() {
+		subject.recordExpiries = mock(MonotonicFullQueueExpiries.class);
+
+		// when:
+		subject.reset();
+
+		// then:
+		verify(subject.recordExpiries).reset();
+	}
+
+	@Test
 	public void expiresOtherForgottenHistory() {
 		// setup:
 		subject = new RecordCache(ctx, receiptCache, new HashMap<>());

--- a/hedera-node/src/test/java/com/hedera/services/records/TxnAwareRecordsHistorianTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/records/TxnAwareRecordsHistorianTest.java
@@ -128,7 +128,7 @@ public class TxnAwareRecordsHistorianTest {
 		subject.reviewExistingRecords();
 
 		// then:
-		verify(expiries).resumeTrackingFrom(accounts);
+		verify(expiries).restartTrackingFrom(accounts);
 	}
 
 	@Test

--- a/hedera-node/src/test/java/com/hedera/services/state/expiry/ExpiryManagerTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/state/expiry/ExpiryManagerTest.java
@@ -95,7 +95,7 @@ class ExpiryManagerTest {
 		givenAccount(a, aPayer);
 		givenAccount(b, bPayer);
 		// given:
-		subject.resumeTrackingFrom(accounts);
+		subject.restartTrackingFrom(accounts);
 
 		// when:
 		subject.purgeExpiredRecordsAt(33, ledger);
@@ -114,14 +114,36 @@ class ExpiryManagerTest {
 	}
 
 	@Test
+	void restartClearsExistingState() {
+		// setup:
+		long oldExpiry = 2_345_678L;
+		AccountID payer = IdUtils.asAccount("0.0.2");
+		txnHistories = mock(Map.class);
+
+		// given:
+		subject = new ExpiryManager(recordCache, txnHistories);
+		// and:
+		subject.trackRecord(payer, oldExpiry);
+		// and:
+		givenAccount(2, new long[] { expiry });
+		// and:
+		given(txnHistories.computeIfAbsent(any(), any())).willReturn(new TxnIdRecentHistory());
+
+		// when:
+		subject.restartTrackingFrom(accounts);
+
+		// then:
+		verify(recordCache).reset();
+		verify(txnHistories).clear();
+	}
+
+	@Test
 	public void resumesTrackingAsExpected() {
 		givenAccount(a, aPayer);
 		givenAccount(b, bPayer);
 
 		// when:
-		txnHistories.clear();
-		// and:
-		subject.resumeTrackingFrom(accounts);
+		subject.restartTrackingFrom(accounts);
 
 		// then:
 		var e1 = subject.payerExpiries.allExpiries.poll();

--- a/hedera-node/src/test/java/com/hedera/services/state/expiry/MonotonicFullQueueExpiriesTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/state/expiry/MonotonicFullQueueExpiriesTest.java
@@ -78,6 +78,19 @@ class MonotonicFullQueueExpiriesTest {
 	}
 
 	@Test
+	public void resetWorks() {
+		// given:
+		subject.track(k1, expiry1);
+
+		// when:
+		subject.reset();
+
+		// then:
+		assertTrue(subject.allExpiries.isEmpty());
+		assertEquals(0L, subject.now);
+	}
+
+	@Test
 	public void throwsIfNextExpiryIsFuture() {
 		// given:
 		subject.track(k1, expiry1);


### PR DESCRIPTION
**Summary of the change**:
Ensure that not only the `txnHistories` map, but also the expiry queues in both `ExpiryManager` and `RecordCache` are cleared when starting from a saved state.