### PR TITLE
Defer sysfile loads until ServicesMain#init if BinaryObjectStore#isInitializing

### DIFF
--- a/hedera-node/src/main/java/com/hedera/services/ServicesMain.java
+++ b/hedera-node/src/main/java/com/hedera/services/ServicesMain.java
@@ -185,8 +185,10 @@ public class ServicesMain implements SwirldMain {
 		try {
 			ctx.systemFilesManager().createAddressBookIfMissing();
 			ctx.systemFilesManager().createNodeDetailsIfMissing();
-			ctx.systemFilesManager().loadExchangeRates();
 			ctx.systemFilesManager().createUpdateZipFileIfMissing();
+			if (!ctx.systemFilesManager().areFilesLoaded()) {
+				ctx.systemFilesManager().loadAllSystemFiles();
+			}
 		} catch (Exception e) {
 			throw new IllegalStateException("Could not create system files!", e);
 		}

--- a/hedera-node/src/main/java/com/hedera/services/state/initialization/HfsSystemFilesManager.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/initialization/HfsSystemFilesManager.java
@@ -65,7 +65,7 @@ public class HfsSystemFilesManager implements SystemFilesManager {
 	private static final String FEE_SCHEDULES_TAG = "fee schedules";
 
 	private JKey systemKey;
-
+	private boolean filesLoaded = false;
 	private final AddressBook currentBook;
 	private final FileNumbers fileNumbers;
 	private final PropertySource properties;
@@ -145,6 +145,16 @@ public class HfsSystemFilesManager implements SystemFilesManager {
 				schedulesCb,
 				CurrentAndNextFeeSchedule::parseFrom,
 				() -> defaultSchedules().toByteArray());
+	}
+
+	@Override
+	public void setFilesLoaded() {
+		filesLoaded = true;
+	}
+
+	@Override
+	public boolean areFilesLoaded() {
+		return filesLoaded;
 	}
 
 	@Override

--- a/hedera-node/src/main/java/com/hedera/services/state/initialization/SystemFilesManager.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/initialization/SystemFilesManager.java
@@ -25,9 +25,28 @@ public interface SystemFilesManager {
 	void createNodeDetailsIfMissing();
 	void createUpdateZipFileIfMissing();
 
+	/* Ensure files 0.0.111 and 0.0.112 exist in state, creating them
+	 * from the FeeSchedules.json and bootstrap.properties resources/files
+	 * if they are missing. (The {@code HfsSystemFilesManager} will signal interested
+	 * components of the loaded files via a callback.) */
 	void loadExchangeRates();
 	void loadFeeSchedules();
 
+	/* Ensure files 0.0.121 and 0.0.122 exist in state, creating them from
+	 * the application.properties and api-permission.properties assets if they
+	 * are missing. (The {@code HfsSystemFilesManager} will signal interested
+	 * components of the loaded files via a callback.) */
 	void loadApiPermissions();
 	void loadApplicationProperties();
+
+	default void loadAllSystemFiles() {
+		loadApplicationProperties();
+		loadApiPermissions();
+		loadFeeSchedules();
+		loadExchangeRates();
+
+		setFilesLoaded();
+	}
+	void setFilesLoaded();
+	boolean areFilesLoaded();
 }

--- a/hedera-node/src/test/java/com/hedera/services/ServicesMainTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/ServicesMainTest.java
@@ -351,16 +351,35 @@ public class ServicesMainTest {
 		// then:
 		verify(grpc).start(intThat(i -> i == 50212), intThat(i -> i == 50213), any());
 	}
-	
+
 	@Test
-	public void managesSystemFiles() {
+	public void loadsSystemFilesIfNotAlreadyDone() {
+		given(systemFilesManager.areFilesLoaded()).willReturn(true);
+
 		// when:
 		subject.init(null, new NodeId(false, NODE_ID));
 
 		// then:
 		verify(systemFilesManager).createAddressBookIfMissing();
 		verify(systemFilesManager).createNodeDetailsIfMissing();
-		verify(systemFilesManager).loadExchangeRates();
+		verify(systemFilesManager).createUpdateZipFileIfMissing();
+		// and:
+		verify(systemFilesManager, never()).loadAllSystemFiles();
+	}
+
+	@Test
+	public void managesSystemFiles() {
+		given(systemFilesManager.areFilesLoaded()).willReturn(false);
+
+		// when:
+		subject.init(null, new NodeId(false, NODE_ID));
+
+		// then:
+		verify(systemFilesManager).createAddressBookIfMissing();
+		verify(systemFilesManager).createNodeDetailsIfMissing();
+		verify(systemFilesManager).createUpdateZipFileIfMissing();
+		// and:
+		verify(systemFilesManager).loadAllSystemFiles();
 	}
 
 	@Test

--- a/hedera-node/src/test/java/com/hedera/services/state/initialization/HfsSystemFilesManagerTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/state/initialization/HfsSystemFilesManagerTest.java
@@ -204,6 +204,36 @@ class HfsSystemFilesManagerTest {
 	}
 
 	@Test
+	public void loadsEverything() {
+		// setup:
+		SystemFilesManager sub = mock(SystemFilesManager.class);
+
+		willCallRealMethod().given(sub).loadAllSystemFiles();
+
+		// when:
+		sub.loadAllSystemFiles();
+
+		// then:
+		verify(sub).loadApplicationProperties();
+		verify(sub).loadApiPermissions();
+		verify(sub).loadFeeSchedules();
+		verify(sub).loadExchangeRates();
+		verify(sub).setFilesLoaded();
+	}
+
+	@Test
+	public void tracksFileLoading() {
+		// expect:
+		assertFalse(subject.areFilesLoaded());
+
+		// when:
+		subject.setFilesLoaded();
+
+		// then:
+		assertTrue(subject.areFilesLoaded());
+	}
+
+	@Test
 	public void doesntCreateAddressBookIfPresent() {
 		given(hfs.exists(bookId)).willReturn(true);
 

--- a/test-clients/devops-utils/validation-scenarios/config.yml
+++ b/test-clients/devops-utils/validation-scenarios/config.yml
@@ -92,12 +92,12 @@ networks:
     - {account: 3, ipv4Addr: '127.0.0.1:50211'}
     scenarioPayer: 1001
     scenarios:
-      feeSnapshots:
-        appendToSnapshotCsv: false
-        ignoreCostAnswer: true
-        opsConfig: {bytecode: 1002, memoLength: 32}
-        scheduleDesc: Bootstrap
-        tinyBarsToOffer: 10000000000
+      consensus: {persistent: 1007}
+      contract:
+        persistent: {bytecode: 1005, luckyNo: 42, num: 1006, source: Multipurpose.sol}
+      crypto: {receiver: 1003, sender: 1002}
+      file:
+        persistent: {contents: MrBleaney.txt, num: 1004}
       sysFilesDown:
         evalMode: snapshot
         numsToFetch: [111]


### PR DESCRIPTION
**Related issue(s)**:
- Closes #786 

**Summary of the change**:
- Skip `SystemFilesManager` load calls in `ServicesState#init` if `BinaryObjectStore.isInitializing()` is `true`.
- Initialize system files in `ServicesMain#init` if `SystemFilesManager.areFilesLoaded()` is `false`. 

