### PR TITLE
Avoid false alarm when using default price usage

### DIFF
--- a/hedera-node/src/main/java/com/hedera/services/fees/calculation/AwareFcfsUsagePrices.java
+++ b/hedera-node/src/main/java/com/hedera/services/fees/calculation/AwareFcfsUsagePrices.java
@@ -9,9 +9,9 @@ package com.hedera.services.fees.calculation;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -118,10 +118,10 @@ public class AwareFcfsUsagePrices implements UsagePricesProvider {
 			return usagePrices;
 		} catch (Exception e) {
 			log.warn(
-					"Only default usage prices available for function {} @ {}! ({})",
+					"Default usage price will be used, no specific usage prices available for function {} @ {}!",
 					function,
-					Instant.ofEpochSecond(at.getSeconds(), at.getNanos()),
-					e);
+					Instant.ofEpochSecond(at.getSeconds(), at.getNanos())
+					);
 		}
 		return DEFAULT_USAGE_PRICES;
 	}

--- a/hedera-node/src/test/java/com/hedera/services/fees/calculation/AwareFcfsUsagePricesTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/fees/calculation/AwareFcfsUsagePricesTest.java
@@ -9,9 +9,9 @@ package com.hedera.services.fees.calculation;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -206,7 +206,7 @@ class AwareFcfsUsagePricesTest {
 		// then:
 		assertEquals(DEFAULT_USAGE_PRICES, actual);
 		assertEquals(1, mockAppender.size());
-		assertEquals("WARN - Only default usage prices available for function UNRECOGNIZED @ 1970-01-15T06:56:06Z! (java.lang.NullPointerException)",
+		assertEquals("WARN - Default usage price will be used, no specific usage prices available for function UNRECOGNIZED @ 1970-01-15T06:56:06Z!",
 				mockAppender.get(0));
 
 		// tearDown:


### PR DESCRIPTION
**Related issue(s)**:
N/A
**Summary of the change**:
Create standalone PR since other changes may take a while to finish test.

Closes #793 