### PR TITLE
Payer ID should not be set to an invalid value if Creation of unique payer for each SuiteRunner Fails

### DIFF
--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/SuiteRunner.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/SuiteRunner.java
@@ -129,6 +129,7 @@ import java.util.stream.Stream;
 
 import static com.hedera.services.bdd.spec.HapiSpecSetup.NodeSelection.FIXED;
 import static com.hedera.services.bdd.spec.HapiSpecSetup.TlsConfig.OFF;
+import static com.hedera.services.bdd.spec.transactions.TxnUtils.isIdLiteral;
 import static com.hedera.services.bdd.suites.HapiApiSuite.FinalOutcome;
 import static java.util.concurrent.CompletableFuture.runAsync;
 import static java.util.stream.Collectors.groupingBy;
@@ -146,7 +147,7 @@ public class SuiteRunner {
 
 	private static final int EXPECTED_DEV_NETWORK_SIZE = 3;
 	private static final int EXPECTED_CI_NETWORK_SIZE = 4;
-	private static final String DEFAULT_PAYER_ID = "2";
+	private static final String DEFAULT_PAYER_ID = "0.0.2";
 
 	public static int expectedNetworkSize = EXPECTED_DEV_NETWORK_SIZE;
 
@@ -374,6 +375,9 @@ public class SuiteRunner {
 			Thread.sleep(r.nextInt(5000));
 			new CryptoCreateForSuiteRunner(nodes, defaultNode).runSuiteAsync();
 			Thread.sleep(2000);
+			if(!isIdLiteral(payerId)){
+				payerId = DEFAULT_PAYER_ID;
+			}
 		} catch (InterruptedException e) {
 			e.printStackTrace();
 		}


### PR DESCRIPTION
On failure of creating a unique payer ID for a suiteRunner, payer Id should be defaulted

Signed-off-by: Anirudh Ghanta <anirudh.ghanta@hedera.com>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `0<issue number>-<target branch>-<summary>`
-->

**Related issue(s)**:
Closes #687 

**Summary of the change**:
If an invalid payer is generated, set it back to the default value.

**External impacts**:
None.

**Applicable documentation**
- [ ] Javadoc
- [ ] HAPI protobuf comments
- [ ] README
