### PR TITLE
add reconnect tests to nightly

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1109,6 +1109,26 @@ workflows:
                 at: /
           workflow-name: "nightly-start-from-saved-state-regression"
 
+  nightly-reconnect-regression:
+    triggers:
+      - schedule:
+          cron: "0 7 * * *"
+          filters:
+            branches:
+              only:
+                - master
+    jobs:
+      - build-platform-and-services
+      - run-reconnect-regression:
+          context: Slack
+          requires:
+            - build-platform-and-services
+          pre-steps:
+            - install-tools
+            - attach_workspace:
+                at: /
+          workflow-name: "nightly-reconnect-regression"
+
   nightly-simulate-network-outage:
     triggers:
         - schedule:
@@ -1791,6 +1811,31 @@ jobs:
 
       - run:
           name: Sync results of software update regression to AWS
+          command: |
+            aws s3 sync /swirlds-platform/regression/results/ s3://hedera-service-regression-jrs;
+            tar -czvf /results.tar.gz  /swirlds-platform/regression/results/*
+
+      - store_artifacts:
+          path: /results.tar.gz
+
+  run-reconnect-regression:
+    parameters:
+      workflow-name:
+        type: string
+        default: ""
+    executor:
+      name: build-executor
+      workflow-name: << parameters.workflow-name >>
+    steps:
+      - run:
+          name: Run reconnect regression tests
+          no_output_timeout: 30m
+          command: |
+            cd /swirlds-platform/regression;
+            ./regression_services_circleci.sh configs/services/suites/daily/AWS-Daily-Services-Comp-Reconnect-4N-1C.json /repo
+
+      - run:
+          name: Sync results of reconnect regression to AWS
           command: |
             aws s3 sync /swirlds-platform/regression/results/ s3://hedera-service-regression-jrs;
             tar -czvf /results.tar.gz  /swirlds-platform/regression/results/*


### PR DESCRIPTION
Add Reconnect tests to run once a night in addition to other daily tests.

**Related issue(s)**:
Should be closed after https://github.com/swirlds/swirlds-platform-regression/pull/683


Sanity check test passed: https://hedera-hashgraph.slack.com/archives/C018CBQBTGB/p1606236412106000