### PR TITLE
Rationalize init order in ServicesMain for restart case

### DIFF
--- a/hedera-node/src/main/java/com/hedera/services/ServicesMain.java
+++ b/hedera-node/src/main/java/com/hedera/services/ServicesMain.java
@@ -142,28 +142,28 @@ public class ServicesMain implements SwirldMain {
 	}
 
 	private void contextDrivenInit() {
-		registerIssListener();
-		log.info("Platform callbacks registered.");
 		checkPropertySources();
 		log.info("Property sources are available.");
-		configurePlatform();
-		log.info("Platform is configured.");
+		initSystemFiles();
+		log.info("System files rationalized.");
+		createSystemAccountsIfNeeded();
+		log.info("System accounts initialized.");
 		migrateStateIfNeeded();
 		log.info("Migrations complete.");
-		startRecordStreamThread();
-		log.info("Record stream started.");
-		startNettyIfAppropriate();
-		log.info("Netty started.");
-		createSystemAccountsIfNeeded();
-		log.info("System accounts rationalized.");
 		validateLedgerState();
 		log.info("Ledger state ok.");
-		createSystemFilesIfNeeded();
-		log.info("System files rationalized.");
+		configurePlatform();
+		log.info("Platform is configured.");
+		registerIssListener();
+		log.info("Platform callbacks registered.");
 		exportAccountsIfDesired();
 		log.info("Accounts exported.");
 		initializeStats();
 		log.info("Stats initialized.");
+		startRecordStreamThread();
+		log.info("Record stream started in directory {}.", ctx.recordStream().recordStreamsDirectory);
+		startNettyIfAppropriate();
+		log.info("Netty started.");
 
 		log.info("Completed initialization of {} #{}", ctx.nodeType(), ctx.id());
 	}
@@ -181,7 +181,7 @@ public class ServicesMain implements SwirldMain {
 		}
 	}
 
-	private void createSystemFilesIfNeeded() {
+	private void initSystemFiles() {
 		try {
 			ctx.systemFilesManager().createAddressBookIfMissing();
 			ctx.systemFilesManager().createNodeDetailsIfMissing();
@@ -236,10 +236,6 @@ public class ServicesMain implements SwirldMain {
 		String myNodeAccount = ctx.addressBook().getAddress(ctx.id().getId()).getMemo();
 		String blessedNodeAccount = ctx.properties().getStringProperty("dev.defaultListeningNodeAccount");
 		return myNodeAccount.equals(blessedNodeAccount);
-	}
-
-	private void loadFeeSchedule() {
-		ctx.fees().init();
 	}
 
 	private void initializeStats() {

--- a/hedera-node/src/main/java/com/hedera/services/ServicesMain.java
+++ b/hedera-node/src/main/java/com/hedera/services/ServicesMain.java
@@ -161,7 +161,7 @@ public class ServicesMain implements SwirldMain {
 		initializeStats();
 		log.info("Stats initialized.");
 		startRecordStreamThread();
-		log.info("Record stream started in directory {}.", ctx.recordStream().recordStreamsDirectory);
+		log.info("Record stream started in directory {}.", ctx.recordStream().getRecordStreamsDirectory());
 		startNettyIfAppropriate();
 		log.info("Netty started.");
 

--- a/hedera-node/src/main/java/com/hedera/services/legacy/stream/RecordStream.java
+++ b/hedera-node/src/main/java/com/hedera/services/legacy/stream/RecordStream.java
@@ -85,7 +85,7 @@ public class RecordStream implements Runnable {
 	Platform platform;
 	MiscRunningAvgs runningAvgs;
 	boolean inFreeze;
-	public final String recordStreamsDirectory;
+	final String recordStreamsDirectory;
 
 	private final PropertySource properties;
 
@@ -393,6 +393,10 @@ public class RecordStream implements Runnable {
 			return 0;
 		}
 		return recordBuffer.size();
+	}
+
+	public String getRecordStreamsDirectory() {
+		return recordStreamsDirectory;
 	}
 
 	/**

--- a/hedera-node/src/main/java/com/hedera/services/legacy/stream/RecordStream.java
+++ b/hedera-node/src/main/java/com/hedera/services/legacy/stream/RecordStream.java
@@ -85,7 +85,7 @@ public class RecordStream implements Runnable {
 	Platform platform;
 	MiscRunningAvgs runningAvgs;
 	boolean inFreeze;
-	String recordStreamsDirectory;
+	public final String recordStreamsDirectory;
 
 	private final PropertySource properties;
 

--- a/hedera-node/src/test/java/com/hedera/services/ServicesMainTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/ServicesMainTest.java
@@ -243,6 +243,7 @@ public class ServicesMainTest {
 	public void initializesSanelyGivenPreconditions() {
 		// given:
 		InOrder inOrder = inOrder(
+				systemFilesManager,
 				propertySources,
 				platform,
 				stateMigrations,
@@ -257,14 +258,15 @@ public class ServicesMainTest {
 		subject.init(null, new NodeId(false, NODE_ID));
 
 		// then:
-		inOrder.verify(platform).addSignedStateListener(any(IssListener.class));
 		inOrder.verify(propertySources).assertSourcesArePresent();
-		inOrder.verify(platform).setSleepAfterSync(0L);
+		inOrder.verify(systemFilesManager).loadAllSystemFiles();
 		inOrder.verify(stateMigrations).runAllFor(ctx);
-		inOrder.verify(recordStreamThread).start();
 		inOrder.verify(ledgerValidator).assertIdsAreValid(accounts);
 		inOrder.verify(ledgerValidator).hasExpectedTotalBalance(accounts);
+		inOrder.verify(platform).setSleepAfterSync(0L);
+		inOrder.verify(platform).addSignedStateListener(any(IssListener.class));
 		inOrder.verify(statsManager).initializeFor(platform);
+		inOrder.verify(recordStreamThread).start();
 	}
 
 	@Test


### PR DESCRIPTION
**Related issue(s)**:
Closes #806 

**Summary of the change**:
Ensure that any context objects using `ctx.properties()` initialize _after_ `ctx.systemFilesManager().loadAllSystemFiles()` is called.
