### PR TITLE
Stabilize jrs clients

### DIFF
--- a/docs/privileged-transactions.md
+++ b/docs/privileged-transactions.md
@@ -1,0 +1,84 @@
+# System accounts and files
+
+The Hedera network reserves the first 
+[`ledger.numReservedSystemEntities=1000`](../hedera-node/src/main/resources/bootstrap.properties#L37) 
+entity numbers for use by the system. 
+An account with a number in the reserved range is called a **system account**. 
+A file with a number in the reserved range is called a **system file**. 
+
+## System account roles
+
+Certain system accounts have predefined roles in the network. For the purposes of this document,
+we primarily care about the the following:
+ - The **treasury account**, which upon network creation receives all minted ℏ except those
+ explicitly designated for a network node account. 
+ - The **address book admin account**, used to manage metadata on network nodes 
+ such as their id numbers, IP addresses, TLS certificate information, and signing keys.
+ - The **fee schedules admin account**, used to set the prices of resources consumed 
+ by HAPI operations.
+ - The **exchange rates admin account**, used to set the network's active conversion
+ ratio between USD and ℏ.
+ - The **freeze admin account**, used to schedule maintenance periods during which the 
+ network stops accepting new transactions.
+ - The **system delete admin account**, used to delete files or contracts which may 
+ have been created on the network with illicit storage contents. (Note that crypto 
+ accounts, topics, and tokens are untouchable.)
+ - The **system undelete admin account**, used to reverse provisional actions of the 
+ system delete admin account under certain conditions. 
+ - The **system admin**, used primarily to manage the keys of the above admin accounts;
+ or substitute for them in circumstances where they have been compromised or rendered
+ unusable.
+
+The account number that plays each role is set, once, on network startup, by consulting
+the [_bootstrap.properties_](../hedera-node/src/main/resources/bootstrap.properties) 
+resource. For example, using the mainnet configuration, the treasury account is account
+`0.0.2` because we have `accounts.treasury=2` in the _bootstrap.properties_.
+
+# Privileged transactions
+
+When a system account is the designated payer for a transaction, there 
+are cases in which the network grants special **privileges** to the transaction. 
+(It is crucial to understand the relevant system account must be the _payer_ of 
+the transaction for privileges to be granted; that is, it must be the `AccountID`
+designated in the transaction's `TransactionID`.)
+
+There are two kinds of privileges, 
+  1. _Authorization_ - some transaction types, such as `Freeze`, require authorization to submit to the network. All such transactions will be rejected with the status `UNAUTHORIZED` unless they are privileged.
+  2. _Waived signing requirements_ - all unprivileged `CryptoUpdate` and `FileUpdate` transactions must be signed with the target entity's key, or they will fail with status `INVALID_SIGNATURE`. The network waives this requirement for certain privileged updates.
+
+This document lists all cases of privileged transactions 
+currently recognized by the Hedera network. 
+
+## Authorization privileges
+
+First we consider the four transaction types that always require authorization to execute. These include:
+  1. The `Freeze` transaction that schedules a maintenance window in which the network 
+  will stop accepting transactions for a specified period.
+  2. The `SystemDelete` transaction that deletes a file or contract (even an immutable
+  file or contract), without requiring the target entity's key to sign the transaction.
+  3. The `SystemUndelete` transaction that reverses the action of a `SystemDelete` 
+  transaction, if within the window during which such a reversal is possible.
+  4. The `UncheckedSubmit` transaction that submits a transaction to the network 
+  without enforcing standard prechecks. (The only real use cases for `UncheckedSubmit`
+  are in development environments, where it can be invaluable for testing.)
+
+| Payer | `Freeze` | `SystemDelete` | `SystemUndelete` | `UncheckedSubmit` |
+| --- | :---: | :---: | :---: | :---: | 
+| [`accounts.treasury=2`](../hedera-node/src/main/resources/bootstrap.properties#L28) | X | X | X | X |
+| [`accounts.systemAdmin=50`](../hedera-node/src/main/resources/bootstrap.properties#L23) | X | X | X | X |
+| [`accounts.freezeAdmin=58`](../hedera-node/src/main/resources/bootstrap.properties#L22) | X |   |   |   |
+| [`accounts.systemDeleteAdmin=59`](../hedera-node/src/main/resources/bootstrap.properties#L24) |   | X |   |   |
+| [`accounts.systemUndeleteAdmin=60`](../hedera-node/src/main/resources/bootstrap.properties#L24) |   |   | X |   |
+
+Next we consider `FileUpdate` and `FileAppend` transactions when targeting one of the system files.
+
+| Payer | [`files.addressBook=101`](../hedera-node/src/main/resources/bootstrap.properties#L29)/[`files.nodeDetails=102`](../hedera-node/src/main/resources/bootstrap.properties#L35) | [`files.networkProperties=121`](../hedera-node/src/main/resources/bootstrap.properties#L31)/[`files.hapiPermissions=122`](../hedera-node/src/main/resources/bootstrap.properties#L34)| [`files.feeSchedules=111`](../hedera-node/src/main/resources/bootstrap.properties#L33) | [`files.exchangeRates=112`](../hedera-node/src/main/resources/bootstrap.properties#L32)|
+| --- | :---: | :---: | :---: | :---: | 
+| [`accounts.treasury=2`](../hedera-node/src/main/resources/bootstrap.properties#L28) | X | X | X | X |
+| [`accounts.systemAdmin=50`](../hedera-node/src/main/resources/bootstrap.properties#L23) | X | X | X | X |
+| [`accounts.feeSchedulesAdmin=56`](../hedera-node/src/main/resources/bootstrap.properties#L21) |   |   | X |   |
+| [`accounts.exchangeRatesAdmin=57`](../hedera-node/src/main/resources/bootstrap.properties#L20) |   | X |   | X |
+
+## Waived signature privileges
+
+

--- a/docs/privileged-transactions.md
+++ b/docs/privileged-transactions.md
@@ -2,28 +2,29 @@
 
 The Hedera network reserves the first 
 [`ledger.numReservedSystemEntities=1000`](../hedera-node/src/main/resources/bootstrap.properties#L37) 
-entity numbers for use by the system. 
+entity numbers for its own uses. 
 An account with a number in the reserved range is called a **system account**. 
 A file with a number in the reserved range is called a **system file**. 
 
 ## System account roles
 
-Certain system accounts have predefined roles in the network. For the purposes of this document,
-we primarily care about the the following:
- - The **treasury account**, which upon network creation receives all minted ℏ except those
+Certain system accounts have predefined roles in the network. 
+
+For the purposes of this document, we care about the the following:
+ - The **treasury**, which upon network creation receives all minted ℏ except those
  explicitly designated for a network node account. 
- - The **address book admin account**, used to manage metadata on network nodes 
+ - The **address book admin**, used to manage metadata on network nodes 
  such as their id numbers, IP addresses, TLS certificate information, and signing keys.
- - The **fee schedules admin account**, used to set the prices of resources consumed 
+ - The **fee schedules admin**, used to set the prices of resources consumed 
  by HAPI operations.
- - The **exchange rates admin account**, used to set the network's active conversion
+ - The **exchange rates admin**, used to set the network's active conversion
  ratio between USD and ℏ.
- - The **freeze admin account**, used to schedule maintenance periods during which the 
+ - The **freeze admin**, used to schedule maintenance periods during which the 
  network stops accepting new transactions.
- - The **system delete admin account**, used to delete files or contracts which may 
+ - The **system delete admin**, used to delete files or contracts which may 
  have been created on the network with illicit storage contents. (Note that crypto 
  accounts, topics, and tokens are untouchable.)
- - The **system undelete admin account**, used to reverse provisional actions of the 
+ - The **system undelete admin**, used to reverse provisional actions of the 
  system delete admin account under certain conditions. 
  - The **system admin**, used primarily to manage the keys of the above admin accounts;
  or substitute for them in circumstances where they have been compromised or rendered

--- a/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/TxnUtils.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/TxnUtils.java
@@ -32,6 +32,7 @@ import com.hederahashgraph.api.proto.java.FeeData;
 import com.hederahashgraph.api.proto.java.FileID;
 import com.hederahashgraph.api.proto.java.Key;
 import com.hederahashgraph.api.proto.java.KeyList;
+import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
 import com.hederahashgraph.api.proto.java.ThresholdKey;
 import com.hederahashgraph.api.proto.java.Timestamp;
 import com.hederahashgraph.api.proto.java.TokenID;
@@ -77,6 +78,11 @@ import static com.hedera.services.legacy.proto.utils.CommonUtils.extractTransact
 import static com.hedera.services.bdd.spec.HapiPropertySource.asTopic;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getContractInfo;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getFileInfo;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.BUSY;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.DUPLICATE_TRANSACTION;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OK;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.PLATFORM_TRANSACTION_NOT_CREATED;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SUCCESS;
 import static com.hederahashgraph.fee.FeeBuilder.BASIC_RECEIPT_SIZE;
 import static com.hederahashgraph.fee.FeeBuilder.FEE_MATRICES_CONST;
 import static com.hederahashgraph.fee.FeeBuilder.HRS_DIVISOR;
@@ -88,8 +94,16 @@ import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toMap;
 
 public class TxnUtils {
+	private static final Logger log = LogManager.getLogger(TxnUtils.class);
+
+	public static final ResponseCodeEnum[] NOISY_RETRY_PRECHECKS = {
+			BUSY, PLATFORM_TRANSACTION_NOT_CREATED, DUPLICATE_TRANSACTION
+	};
+	public final static ResponseCodeEnum[] NOISY_ALLOWED_STATUSES = {
+			OK, SUCCESS, DUPLICATE_TRANSACTION
+	};
+
 	public static final int BYTES_4K = 4 * (1 << 10);
-	static final Logger log = LogManager.getLogger(TxnUtils.class);
 
 	private static Pattern ID_LITERAL_PATTERN = Pattern.compile("\\d+[.]\\d+[.]\\d+");
 	private static Pattern PORT_LITERAL_PATTERN = Pattern.compile("\\d+");

--- a/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/CustomSpecAssert.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/CustomSpecAssert.java
@@ -38,7 +38,6 @@ public class CustomSpecAssert extends UtilOp {
 			Optional<Throwable>	error = op.execFor(spec);
 			if (error.isPresent()) {
 				Assert.fail("Operation '" + op.toString() + "' :: " + error.get().getMessage());
-				error.get().printStackTrace();
 			}
 		}
 	}

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoCreateForSuiteRunner.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoCreateForSuiteRunner.java
@@ -33,12 +33,10 @@ import java.util.Map;
 import static com.hedera.services.bdd.spec.HapiApiSpec.customHapiSpec;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getAccountInfo;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getTxnRecord;
+import static com.hedera.services.bdd.spec.transactions.TxnUtils.NOISY_RETRY_PRECHECKS;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoCreate;
 import static com.hedera.services.bdd.spec.utilops.CustomSpecAssert.allRunFor;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.withOpContext;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.BUSY;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.DUPLICATE_TRANSACTION;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.PLATFORM_TRANSACTION_NOT_CREATED;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SUCCESS;
 
 /**
@@ -84,10 +82,7 @@ public class CryptoCreateForSuiteRunner extends HapiApiSuite {
 													.rechargeWindow(3)
 													.key(GENESIS)
 													.payingWith(GENESIS)
-													.hasRetryPrecheckFrom(
-															BUSY,
-															DUPLICATE_TRANSACTION,
-															PLATFORM_TRANSACTION_NOT_CREATED)
+													.hasRetryPrecheckFrom(NOISY_RETRY_PRECHECKS)
 													.via("txn");
 											allRunFor(spec, cryptoCreateOp);
 											var gotCreationRecord = false;

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/TokenTransfersLoadProvider.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/TokenTransfersLoadProvider.java
@@ -24,6 +24,7 @@ import com.hedera.services.bdd.spec.HapiApiSpec;
 import com.hedera.services.bdd.spec.HapiSpecOperation;
 import com.hedera.services.bdd.spec.infrastructure.OpProvider;
 import com.hedera.services.bdd.spec.transactions.HapiTxnOp;
+import com.hedera.services.bdd.spec.transactions.TxnUtils;
 import com.hedera.services.bdd.spec.transactions.token.TokenMovement;
 import com.hedera.services.bdd.suites.HapiApiSuite;
 import org.apache.logging.log4j.LogManager;
@@ -41,6 +42,8 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 
+import static com.hedera.services.bdd.spec.transactions.TxnUtils.NOISY_ALLOWED_STATUSES;
+import static com.hedera.services.bdd.spec.transactions.TxnUtils.NOISY_RETRY_PRECHECKS;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoCreate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoTransfer;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.fileUpdate;
@@ -49,9 +52,6 @@ import static com.hedera.services.bdd.spec.transactions.TxnVerbs.tokenCreate;
 import static com.hedera.services.bdd.spec.transactions.token.TokenMovement.moving;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.runWithProvider;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.withOpContext;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.BUSY;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.DUPLICATE_TRANSACTION;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.PLATFORM_TRANSACTION_NOT_CREATED;
 import static java.util.Map.entry;
 import static java.util.concurrent.TimeUnit.MINUTES;
 
@@ -174,7 +174,7 @@ public class TokenTransfersLoadProvider extends HapiApiSuite {
 				}
 
 				for (HapiSpecOperation op : initializers) {
-					((HapiTxnOp) op).hasRetryPrecheckFrom(BUSY, DUPLICATE_TRANSACTION, PLATFORM_TRANSACTION_NOT_CREATED);
+					((HapiTxnOp)op).hasRetryPrecheckFrom(NOISY_RETRY_PRECHECKS);
 				}
 
 				return initializers;
@@ -200,7 +200,8 @@ public class TokenTransfersLoadProvider extends HapiApiSuite {
 						}
 					}
 					op = cryptoTransfer(xfers)
-							.hasRetryPrecheckFrom(BUSY, DUPLICATE_TRANSACTION, PLATFORM_TRANSACTION_NOT_CREATED)
+							.hasKnownStatusFrom(NOISY_ALLOWED_STATUSES)
+							.hasRetryPrecheckFrom(NOISY_RETRY_PRECHECKS)
 							.noLogging()
 							.deferStatusResolution();
 					firstDir.set(Boolean.FALSE);
@@ -218,7 +219,8 @@ public class TokenTransfersLoadProvider extends HapiApiSuite {
 						}
 					}
 					op = cryptoTransfer(xfers)
-							.hasRetryPrecheckFrom(BUSY, DUPLICATE_TRANSACTION, PLATFORM_TRANSACTION_NOT_CREATED)
+							.hasRetryPrecheckFrom(NOISY_RETRY_PRECHECKS)
+							.hasKnownStatusFrom(NOISY_ALLOWED_STATUSES)
 							.noLogging()
 							.deferStatusResolution();
 					firstDir.set(Boolean.TRUE);
@@ -232,6 +234,4 @@ public class TokenTransfersLoadProvider extends HapiApiSuite {
 	protected Logger getResultsLogger() {
 		return log;
 	}
-
-
 }

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/TokenTransfersLoadProvider.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/TokenTransfersLoadProvider.java
@@ -121,6 +121,7 @@ public class TokenTransfersLoadProvider extends HapiApiSuite {
 				List<HapiSpecOperation> initializers = new ArrayList<>();
 				initializers.add(
 						fileUpdate(API_PERMISSIONS)
+								.fee(9_999_999_999L)
 								.payingWith(GENESIS)
 								.overridingProps(Map.ofEntries(
 										entry("tokenCreate", "0-*"),
@@ -140,6 +141,7 @@ public class TokenTransfersLoadProvider extends HapiApiSuite {
 				);
 				initializers.add(
 						fileUpdate(APP_PROPERTIES)
+								.fee(9_999_999_999L)
 								.payingWith(GENESIS)
 								.overridingProps(Map.ofEntries(
 										entry("hapi.throttling.buckets.fastOpBucket.capacity", "4000")


### PR DESCRIPTION
**Summary of the change**:
- Add appropriate retries for various `CryptoCreate`/`GetTxnRecord`/`FileUpdate` operations that may run into `DUPLICATE_TRANSACTION` or---much more rarely---`INVALID_FILE_ID` prechecks during a JRS test with multiple clients. 
    - The main thing is to catch `Throwable`s instead of `Exception`s since many operations use `Assert.fail` to die, which raises an `AssertionError` and will slip through a `catch (Exception...` clause.
- Accidentally added working draft of _docs/privileged-transactions.md_, doesn't need review here. 😁 