### PR TITLE
Use minimal initial balances for accounts created in HTS functional tests

### DIFF
--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenAssociationSpecs.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenAssociationSpecs.java
@@ -135,7 +135,7 @@ public class TokenAssociationSpecs extends HapiApiSuite {
 						tokenCreate("b"),
 						tokenCreate("c"),
 						tokenCreate("tbd").adminKey("simple"),
-						cryptoCreate("account")
+						cryptoCreate("account").balance(0L)
 				).when(
 						tokenAssociate("account", "a", "b", "c", "tbd"),
 						getAccountInfo("account")
@@ -158,8 +158,7 @@ public class TokenAssociationSpecs extends HapiApiSuite {
 	public HapiApiSpec dissociateHasExpectedSemantics() {
 		return defaultHapiSpec("DissociateHasExpectedSemantics")
 				.given(flattened(
-						basicKeysAndTokens(),
-						cryptoCreate("payer")
+						basicKeysAndTokens()
 				)).when(
 						tokenCreate("tkn1")
 								.treasury(TOKEN_TREASURY),
@@ -192,10 +191,9 @@ public class TokenAssociationSpecs extends HapiApiSuite {
 	public HapiApiSpec associateHasExpectedSemantics() {
 		return defaultHapiSpec("AssociateHasExpectedSemantics")
 				.given(flattened(
-						basicKeysAndTokens(),
-						cryptoCreate("payer")
+						basicKeysAndTokens()
 				)).when(
-						cryptoCreate("misc"),
+						cryptoCreate("misc").balance(0L),
 						tokenAssociate("misc", FREEZABLE_TOKEN_ON_BY_DEFAULT),
 						tokenAssociate("misc", FREEZABLE_TOKEN_ON_BY_DEFAULT)
 								.hasKnownStatus(TOKEN_ALREADY_ASSOCIATED_TO_ACCOUNT),
@@ -267,7 +265,7 @@ public class TokenAssociationSpecs extends HapiApiSuite {
 		return new HapiSpecOperation[] {
 				newKeyNamed("kycKey"),
 				newKeyNamed("freezeKey"),
-				cryptoCreate(TOKEN_TREASURY),
+				cryptoCreate(TOKEN_TREASURY).balance(0L),
 				tokenCreate(FREEZABLE_TOKEN_ON_BY_DEFAULT)
 						.treasury(TOKEN_TREASURY)
 						.freezeKey("freezeKey")

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenDeleteSpecs.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenDeleteSpecs.java
@@ -69,7 +69,7 @@ public class TokenDeleteSpecs extends HapiApiSuite {
 		return defaultHapiSpec("TreasuryBecomesDeletableAfterTokenDelete")
 				.given(
 						newKeyNamed("tokenAdmin"),
-						cryptoCreate(TOKEN_TREASURY),
+						cryptoCreate(TOKEN_TREASURY).balance(0L),
 						tokenCreate("firstTbd")
 								.adminKey("tokenAdmin")
 								.treasury(TOKEN_TREASURY),
@@ -92,7 +92,7 @@ public class TokenDeleteSpecs extends HapiApiSuite {
 		return defaultHapiSpec("DeletionValidatesAlreadyDeletedToken")
 				.given(
 						newKeyNamed("multiKey"),
-						cryptoCreate(TOKEN_TREASURY),
+						cryptoCreate(TOKEN_TREASURY).balance(0L),
 						tokenCreate("tbd")
 								.adminKey("multiKey")
 								.treasury(TOKEN_TREASURY),
@@ -107,9 +107,8 @@ public class TokenDeleteSpecs extends HapiApiSuite {
 		return defaultHapiSpec("DeletionValidatesMissingAdminKey")
 				.given(
 						newKeyNamed("multiKey"),
-						cryptoCreate(TOKEN_TREASURY),
-						cryptoCreate("payer")
-								.balance(A_HUNDRED_HBARS),
+						cryptoCreate(TOKEN_TREASURY).balance(0L),
+						cryptoCreate("payer"),
 						tokenCreate("tbd")
 								.freezeDefault(false)
 								.treasury(TOKEN_TREASURY)
@@ -126,9 +125,8 @@ public class TokenDeleteSpecs extends HapiApiSuite {
 		return defaultHapiSpec("DeletionWorksAsExpected")
 				.given(
 						newKeyNamed("multiKey"),
-						cryptoCreate(TOKEN_TREASURY),
-						cryptoCreate("payer")
-								.balance(A_HUNDRED_HBARS),
+						cryptoCreate(TOKEN_TREASURY).balance(0L),
+						cryptoCreate("payer"),
 						tokenCreate("tbd")
 								.adminKey("multiKey")
 								.freezeKey("multiKey")
@@ -149,8 +147,7 @@ public class TokenDeleteSpecs extends HapiApiSuite {
 						tokenUnfreeze("tbd", GENESIS),
 						cryptoTransfer(moving(1, "tbd")
 								.between(TOKEN_TREASURY, GENESIS)),
-						tokenDelete("tbd")
-								.payingWith("payer")
+						tokenDelete("tbd").payingWith("payer")
 				).then(
 						getTokenInfo("tbd").logged(),
 						getAccountInfo(TOKEN_TREASURY).logged(),
@@ -175,7 +172,7 @@ public class TokenDeleteSpecs extends HapiApiSuite {
 	public HapiApiSpec deletionValidatesRef() {
 		return defaultHapiSpec("DeletionValidatesRef")
 				.given(
-						cryptoCreate("payer").balance(A_HUNDRED_HBARS)
+						cryptoCreate("payer")
 				).when().then(
 						tokenDelete("1.2.3")
 								.payingWith("payer")

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenManagementSpecs.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenManagementSpecs.java
@@ -95,7 +95,7 @@ public class TokenManagementSpecs extends HapiApiSuite {
 				.given(
 						newKeyNamed("supplyKey"),
 						newKeyNamed("freezeKey"),
-						cryptoCreate(TOKEN_TREASURY)
+						cryptoCreate(TOKEN_TREASURY).balance(0L)
 				).when(
 						tokenCreate("supple")
 								.freezeKey("freezeKey")
@@ -124,7 +124,7 @@ public class TokenManagementSpecs extends HapiApiSuite {
 				.given(
 						newKeyNamed("supplyKey"),
 						newKeyNamed("kycKey"),
-						cryptoCreate(TOKEN_TREASURY)
+						cryptoCreate(TOKEN_TREASURY).balance(0L)
 				).when(
 						tokenCreate("supple")
 								.kycKey("kycKey")
@@ -157,8 +157,8 @@ public class TokenManagementSpecs extends HapiApiSuite {
 		return defaultHapiSpec("BurnTokenFailsDueToInsufficientTreasuryBalance")
 				.given(
 						newKeyNamed("burnKey"),
-						cryptoCreate("misc"),
-						cryptoCreate(TOKEN_TREASURY)
+						cryptoCreate("misc").balance(0L),
+						cryptoCreate(TOKEN_TREASURY).balance(0L)
 				).when(
 						tokenCreate(BURN_TOKEN)
 								.treasury(TOKEN_TREASURY)
@@ -194,8 +194,8 @@ public class TokenManagementSpecs extends HapiApiSuite {
 		return defaultHapiSpec("WipeAccountSuccessCasesWork")
 				.given(
 						newKeyNamed("wipeKey"),
-						cryptoCreate("misc"),
-						cryptoCreate(TOKEN_TREASURY)
+						cryptoCreate("misc").balance(0L),
+						cryptoCreate(TOKEN_TREASURY).balance(0L)
 				).when(
 						tokenCreate(wipeableToken)
 								.treasury(TOKEN_TREASURY)
@@ -231,8 +231,8 @@ public class TokenManagementSpecs extends HapiApiSuite {
 		return defaultHapiSpec("WipeAccountFailureCasesWork")
 				.given(
 						newKeyNamed("wipeKey"),
-						cryptoCreate("misc"),
-						cryptoCreate(TOKEN_TREASURY)
+						cryptoCreate("misc").balance(0L),
+						cryptoCreate(TOKEN_TREASURY).balance(0L)
 				).when(
 						tokenCreate(unwipeableToken)
 								.treasury(TOKEN_TREASURY),
@@ -273,7 +273,7 @@ public class TokenManagementSpecs extends HapiApiSuite {
 		return defaultHapiSpec("KycMgmtFailureCasesWork")
 				.given(
 						newKeyNamed("oneKyc"),
-						cryptoCreate(TOKEN_TREASURY),
+						cryptoCreate(TOKEN_TREASURY).balance(0L),
 						tokenCreate(withoutKycKey)
 								.treasury(TOKEN_TREASURY),
 						tokenCreate(withKycKey)
@@ -310,8 +310,8 @@ public class TokenManagementSpecs extends HapiApiSuite {
 		return defaultHapiSpec("FreezeMgmtFailureCasesWork")
 				.given(
 						newKeyNamed("oneFreeze"),
-						cryptoCreate(TOKEN_TREASURY),
-						cryptoCreate("go"),
+						cryptoCreate(TOKEN_TREASURY).balance(0L),
+						cryptoCreate("go").balance(0L),
 						tokenCreate(unfreezableToken)
 								.treasury(TOKEN_TREASURY),
 						tokenCreate(freezableToken)
@@ -351,8 +351,8 @@ public class TokenManagementSpecs extends HapiApiSuite {
 
 		return defaultHapiSpec("FreezeMgmtSuccessCasesWork")
 				.given(
-						cryptoCreate(TOKEN_TREASURY),
-						cryptoCreate("misc"),
+						cryptoCreate(TOKEN_TREASURY).balance(0L),
+						cryptoCreate("misc").balance(0L),
 						newKeyNamed("oneFreeze"),
 						newKeyNamed("twoFreeze"),
 						tokenCreate(withPlusDefaultFalse)
@@ -385,8 +385,8 @@ public class TokenManagementSpecs extends HapiApiSuite {
 
 		return defaultHapiSpec("KycMgmtSuccessCasesWork")
 				.given(
-						cryptoCreate(TOKEN_TREASURY),
-						cryptoCreate("misc"),
+						cryptoCreate(TOKEN_TREASURY).balance(0L),
+						cryptoCreate("misc").balance(0L),
 						newKeyNamed("oneKyc"),
 						newKeyNamed("twoKyc"),
 						tokenCreate(withKycKey)
@@ -421,7 +421,7 @@ public class TokenManagementSpecs extends HapiApiSuite {
 	public HapiApiSpec supplyMgmtSuccessCasesWork() {
 		return defaultHapiSpec("SupplyMgmtSuccessCasesWork")
 				.given(
-						cryptoCreate(TOKEN_TREASURY),
+						cryptoCreate(TOKEN_TREASURY).balance(0L),
 						newKeyNamed("supplyKey"),
 						tokenCreate("supple")
 								.supplyKey("supplyKey")

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenTransactSpecs.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenTransactSpecs.java
@@ -87,8 +87,8 @@ public class TokenTransactSpecs extends HapiApiSuite {
 	private HapiApiSpec prechecksWork() {
 		return defaultHapiSpec("PrechecksWork")
 				.given(
-						cryptoCreate(TOKEN_TREASURY),
-						cryptoCreate(FIRST_USER)
+						cryptoCreate(TOKEN_TREASURY).balance(0L),
+						cryptoCreate(FIRST_USER).balance(0L)
 				).when(
 						tokenCreate(A_TOKEN)
 								.initialSupply(100)
@@ -145,7 +145,7 @@ public class TokenTransactSpecs extends HapiApiSuite {
 	public HapiApiSpec balancesAreChecked() {
 		return defaultHapiSpec("BalancesAreChecked")
 				.given(
-						cryptoCreate("payer").balance(A_HUNDRED_HBARS),
+						cryptoCreate("payer"),
 						cryptoCreate("firstTreasury"),
 						cryptoCreate("secondTreasury"),
 						cryptoCreate("beneficiary")
@@ -173,9 +173,9 @@ public class TokenTransactSpecs extends HapiApiSuite {
 	public HapiApiSpec accountsMustBeExplicitlyUnfrozenOnlyIfDefaultFreezeIsTrue() {
 		return defaultHapiSpec("AccountsMustBeExplicitlyUnfrozenOnlyIfDefaultFreezeIsTrue")
 				.given(
-						cryptoCreate("randomBeneficiary"),
-						cryptoCreate("treasury"),
-						cryptoCreate("payer").balance(A_HUNDRED_HBARS),
+						cryptoCreate("randomBeneficiary").balance(0L),
+						cryptoCreate("treasury").balance(0L),
+						cryptoCreate("payer"),
 						newKeyNamed("freezeKey")
 				).when(
 						tokenCreate(A_TOKEN)
@@ -207,9 +207,9 @@ public class TokenTransactSpecs extends HapiApiSuite {
 	public HapiApiSpec allRequiredSigsAreChecked() {
 		return defaultHapiSpec("SenderSigsAreChecked")
 				.given(
-						cryptoCreate("payer").balance(A_HUNDRED_HBARS),
-						cryptoCreate("firstTreasury"),
-						cryptoCreate("secondTreasury"),
+						cryptoCreate("payer"),
+						cryptoCreate("firstTreasury").balance(0L),
+						cryptoCreate("secondTreasury").balance(0L),
 						cryptoCreate("sponsor"),
 						cryptoCreate("beneficiary").receiverSigRequired(true)
 				).when(
@@ -253,9 +253,9 @@ public class TokenTransactSpecs extends HapiApiSuite {
 	public HapiApiSpec senderSigsAreValid() {
 		return defaultHapiSpec("SenderSigsAreValid")
 				.given(
-						cryptoCreate("payer").balance(A_HUNDRED_HBARS),
-						cryptoCreate("firstTreasury"),
-						cryptoCreate("secondTreasury"),
+						cryptoCreate("payer"),
+						cryptoCreate("firstTreasury").balance(0L),
+						cryptoCreate("secondTreasury").balance(0L),
 						cryptoCreate("beneficiary")
 				).when(
 						tokenCreate(A_TOKEN)
@@ -287,11 +287,11 @@ public class TokenTransactSpecs extends HapiApiSuite {
 	public HapiApiSpec tokenPlusHbarTxnsAreAtomic() {
 		return defaultHapiSpec("TokenPlusHbarTxnsAreAtomic")
 				.given(
-						cryptoCreate("payer").balance(A_HUNDRED_HBARS),
-						cryptoCreate("firstTreasury"),
-						cryptoCreate("secondTreasury"),
+						cryptoCreate("payer"),
+						cryptoCreate("firstTreasury").balance(0L),
+						cryptoCreate("secondTreasury").balance(0L),
 						cryptoCreate("beneficiary"),
-						cryptoCreate("tbd")
+						cryptoCreate("tbd").balance(0L)
 				).when(
 						cryptoDelete("tbd"),
 						tokenCreate(A_TOKEN)
@@ -323,9 +323,9 @@ public class TokenTransactSpecs extends HapiApiSuite {
 	public HapiApiSpec tokenOnlyTxnsAreAtomic() {
 		return defaultHapiSpec("TokenOnlyTxnsAreAtomic")
 				.given(
-						cryptoCreate("payer").balance(A_HUNDRED_HBARS),
-						cryptoCreate("firstTreasury"),
-						cryptoCreate("secondTreasury"),
+						cryptoCreate("payer"),
+						cryptoCreate("firstTreasury").balance(0L),
+						cryptoCreate("secondTreasury").balance(0L),
 						cryptoCreate("beneficiary")
 				).when(
 						tokenCreate(A_TOKEN)
@@ -353,8 +353,8 @@ public class TokenTransactSpecs extends HapiApiSuite {
 	public HapiApiSpec duplicateAccountsInTokenTransferRejected() {
 		return defaultHapiSpec("DuplicateAccountsInTokenTransferRejected")
 				.given(
-						cryptoCreate("firstTreasury"),
-						cryptoCreate("beneficiary")
+						cryptoCreate("firstTreasury").balance(0L),
+						cryptoCreate("beneficiary").balance(0L)
 				).when(
 						tokenCreate(A_TOKEN)
 				).then(
@@ -368,7 +368,7 @@ public class TokenTransactSpecs extends HapiApiSuite {
 	public HapiApiSpec nonZeroTransfersRejected() {
 		return defaultHapiSpec("NonZeroTransfersRejected")
 				.given(
-						cryptoCreate("firstTreasury")
+						cryptoCreate("firstTreasury").balance(0L)
 				).when(
 						tokenCreate(A_TOKEN)
 				).then(
@@ -384,9 +384,9 @@ public class TokenTransactSpecs extends HapiApiSuite {
 	public HapiApiSpec balancesChangeOnTokenTransfer() {
 		return defaultHapiSpec("BalancesChangeOnTokenTransfer")
 				.given(
-						cryptoCreate(FIRST_USER),
-						cryptoCreate(SECOND_USER),
-						cryptoCreate(TOKEN_TREASURY),
+						cryptoCreate(FIRST_USER).balance(0L),
+						cryptoCreate(SECOND_USER).balance(0L),
+						cryptoCreate(TOKEN_TREASURY).balance(0L),
 						tokenCreate(A_TOKEN)
 								.initialSupply(TOTAL_SUPPLY)
 								.treasury(TOKEN_TREASURY),

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenUpdateSpecs.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenUpdateSpecs.java
@@ -94,7 +94,7 @@ public class TokenUpdateSpecs extends HapiApiSuite {
 		return defaultHapiSpec("ValidatesAlreadyDeletedToken")
 				.given(
 						newKeyNamed("adminKey"),
-						cryptoCreate(TOKEN_TREASURY),
+						cryptoCreate(TOKEN_TREASURY).balance(0L),
 						tokenCreate("tbd")
 								.adminKey("adminKey")
 								.treasury(TOKEN_TREASURY),
@@ -109,7 +109,7 @@ public class TokenUpdateSpecs extends HapiApiSuite {
 		return defaultHapiSpec("TokensCanBeMadeImmutableWithEmptyKeyList")
 				.given(
 						newKeyNamed("initialAdmin"),
-						cryptoCreate("neverToBe"),
+						cryptoCreate("neverToBe").balance(0L),
 						tokenCreate("mutableForNow").adminKey("initialAdmin")
 				).when(
 						tokenUpdate("mutableForNow")
@@ -147,7 +147,7 @@ public class TokenUpdateSpecs extends HapiApiSuite {
 	private HapiApiSpec validatesMissingRef() {
 		return defaultHapiSpec("UpdateValidatesRef")
 				.given(
-						cryptoCreate("payer").balance(A_HUNDRED_HBARS)
+						cryptoCreate("payer")
 				).when().then(
 						tokenUpdate("1.2.3")
 								.payingWith("payer")
@@ -159,9 +159,8 @@ public class TokenUpdateSpecs extends HapiApiSuite {
 	private HapiApiSpec validatesMissingAdminKey() {
 		return defaultHapiSpec("ValidatesMissingAdminKey")
 				.given(
-						cryptoCreate(TOKEN_TREASURY),
-						cryptoCreate("payer")
-								.balance(A_HUNDRED_HBARS),
+						cryptoCreate(TOKEN_TREASURY).balance(0L),
+						cryptoCreate("payer"),
 						tokenCreate("tbd")
 								.freezeDefault(false)
 								.treasury(TOKEN_TREASURY)
@@ -183,8 +182,8 @@ public class TokenUpdateSpecs extends HapiApiSuite {
 						newKeyNamed("freezeThenKycKey"),
 						newKeyNamed("wipeThenSupplyKey"),
 						newKeyNamed("supplyThenWipeKey"),
-						cryptoCreate("misc"),
-						cryptoCreate(TOKEN_TREASURY),
+						cryptoCreate("misc").balance(0L),
+						cryptoCreate(TOKEN_TREASURY).balance(0L),
 						tokenCreate("tbu")
 								.treasury(TOKEN_TREASURY)
 								.freezeDefault(true)
@@ -226,12 +225,12 @@ public class TokenUpdateSpecs extends HapiApiSuite {
 		return defaultHapiSpec("NewTreasuryMustBeAssociated")
 				.given(
 						newKeyNamed("adminKey"),
-						cryptoCreate("oldTreasury"),
+						cryptoCreate("oldTreasury").balance(0L),
 						tokenCreate("tbu")
 								.adminKey("adminKey")
 								.treasury("oldTreasury")
 				).when(
-						cryptoCreate("newTreasury")
+						cryptoCreate("newTreasury").balance(0L)
 				).then(
 						tokenUpdate("tbu")
 								.treasury("newTreasury").hasKnownStatus(INVALID_TREASURY_ACCOUNT_FOR_TOKEN)
@@ -242,8 +241,8 @@ public class TokenUpdateSpecs extends HapiApiSuite {
 		return defaultHapiSpec("NewTreasuryMustSign")
 				.given(
 						newKeyNamed("adminKey"),
-						cryptoCreate("oldTreasury"),
-						cryptoCreate("newTreasury"),
+						cryptoCreate("oldTreasury").balance(0L),
+						cryptoCreate("newTreasury").balance(0L),
 						tokenCreate("tbu")
 								.adminKey("adminKey")
 								.treasury("oldTreasury")
@@ -267,8 +266,8 @@ public class TokenUpdateSpecs extends HapiApiSuite {
 						newKeyNamed("adminKey"),
 						newKeyNamed("kycKey"),
 						newKeyNamed("freezeKey"),
-						cryptoCreate("oldTreasury"),
-						cryptoCreate("newTreasury"),
+						cryptoCreate("oldTreasury").balance(0L),
+						cryptoCreate("newTreasury").balance(0L),
 						tokenCreate("tbu")
 								.adminKey("adminKey")
 								.freezeDefault(true)
@@ -293,8 +292,8 @@ public class TokenUpdateSpecs extends HapiApiSuite {
 		long firstPeriod = 500_000, secondPeriod = 600_000;
 		return defaultHapiSpec("AutoRenewInfoChanges")
 				.given(
-						cryptoCreate("autoRenew"),
-						cryptoCreate("newAutoRenew"),
+						cryptoCreate("autoRenew").balance(0L),
+						cryptoCreate("newAutoRenew").balance(0L),
 						newKeyNamed("adminKey")
 				).when(
 						tokenCreate("tbu")
@@ -320,7 +319,7 @@ public class TokenUpdateSpecs extends HapiApiSuite {
 		return defaultHapiSpec("SymbolChanges")
 				.given(
 						newKeyNamed("adminKey"),
-						cryptoCreate(TOKEN_TREASURY)
+						cryptoCreate(TOKEN_TREASURY).balance(0L)
 				).when(
 						tokenCreate("tbu")
 								.adminKey("adminKey")
@@ -341,7 +340,7 @@ public class TokenUpdateSpecs extends HapiApiSuite {
 		return defaultHapiSpec("NameChanges")
 				.given(
 						newKeyNamed("adminKey"),
-						cryptoCreate(TOKEN_TREASURY)
+						cryptoCreate(TOKEN_TREASURY).balance(0L)
 				).when(
 						tokenCreate("tbu")
 								.adminKey("adminKey")
@@ -359,7 +358,7 @@ public class TokenUpdateSpecs extends HapiApiSuite {
 		return defaultHapiSpec("TooLongNameCheckHolds")
 				.given(
 						newKeyNamed("adminKey"),
-						cryptoCreate(TOKEN_TREASURY)
+						cryptoCreate(TOKEN_TREASURY).balance(0L)
 				).when(
 						tokenCreate("tbu")
 								.adminKey("adminKey")
@@ -377,7 +376,7 @@ public class TokenUpdateSpecs extends HapiApiSuite {
 		return defaultHapiSpec("TooLongSymbolCheckHolds")
 				.given(
 						newKeyNamed("adminKey"),
-						cryptoCreate(TOKEN_TREASURY)
+						cryptoCreate(TOKEN_TREASURY).balance(0L)
 				).when(
 						tokenCreate("tbu")
 								.adminKey("adminKey")
@@ -393,8 +392,8 @@ public class TokenUpdateSpecs extends HapiApiSuite {
 		return defaultHapiSpec("DeletedAutoRenewAccountCheckHolds")
 				.given(
 						newKeyNamed("adminKey"),
-						cryptoCreate("autoRenewAccount"),
-						cryptoCreate(TOKEN_TREASURY)
+						cryptoCreate("autoRenewAccount").balance(0L),
+						cryptoCreate(TOKEN_TREASURY).balance(0L)
 				).when(
 						cryptoDelete("autoRenewAccount"),
 						tokenCreate("tbu")
@@ -411,8 +410,8 @@ public class TokenUpdateSpecs extends HapiApiSuite {
 		return defaultHapiSpec("RenewalPeriodCheckHolds")
 				.given(
 						newKeyNamed("adminKey"),
-						cryptoCreate(TOKEN_TREASURY),
-						cryptoCreate("autoRenewAccount")
+						cryptoCreate(TOKEN_TREASURY).balance(0L),
+						cryptoCreate("autoRenewAccount").balance(0L)
 				).when(
 						tokenCreate("tbu")
 								.adminKey("adminKey")
@@ -443,8 +442,8 @@ public class TokenUpdateSpecs extends HapiApiSuite {
 		return defaultHapiSpec("InvalidTreasuryCheckHolds")
 				.given(
 						newKeyNamed("adminKey"),
-						cryptoCreate(TOKEN_TREASURY),
-						cryptoCreate("invalidTreasury")
+						cryptoCreate(TOKEN_TREASURY).balance(0L),
+						cryptoCreate("invalidTreasury").balance(0L)
 				).when(
 						cryptoDelete("invalidTreasury"),
 						tokenCreate("tbu")
@@ -462,10 +461,10 @@ public class TokenUpdateSpecs extends HapiApiSuite {
 		String newSaltedName = salted("primary");
 		return defaultHapiSpec("UpdateHappyPath")
 				.given(
-						cryptoCreate(TOKEN_TREASURY),
-						cryptoCreate("newTokenTreasury"),
-						cryptoCreate("autoRenewAccount"),
-						cryptoCreate("newAutoRenewAccount"),
+						cryptoCreate(TOKEN_TREASURY).balance(0L),
+						cryptoCreate("newTokenTreasury").balance(0L),
+						cryptoCreate("autoRenewAccount").balance(0L),
+						cryptoCreate("newAutoRenewAccount").balance(0L),
 						newKeyNamed("adminKey"),
 						newKeyNamed("freezeKey"),
 						newKeyNamed("newFreezeKey"),


### PR DESCRIPTION
**Summary of the change**:
In HTS correctness specs, don't give non-trivial balances to scratch crypto accounts unless really necessary.
