### PR TITLE
Fix incorrect runSuiteSync of SimpleFreezeOnly

### DIFF
--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/freeze/SimpleFreezeOnly.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/freeze/SimpleFreezeOnly.java
@@ -9,9 +9,9 @@ package com.hedera.services.bdd.suites.freeze;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -30,10 +30,10 @@ import static com.hedera.services.bdd.spec.HapiApiSpec.defaultHapiSpec;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.freeze;
 
 public class SimpleFreezeOnly extends HapiApiSuite {
-	private static final Logger log = LogManager.getLogger(FreezeSuite.class);
+	private static final Logger log = LogManager.getLogger(SimpleFreezeOnly.class);
 
 	public static void main(String... args) {
-		new FreezeSuite().runSuiteSync();
+		new SimpleFreezeOnly().runSuiteSync();
 	}
 
 	@Override


### PR DESCRIPTION


**Summary of the change**:
When looking at some failed regression, I realized some test only need a freeze at the end 
of the test, but they actually got an update jar transaction.
It turned out the SimpleFreezeOnly was incorrectly calling FreezeSuite function.

