### PR TITLE
Add new system entities deletion test cases.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2043,6 +2043,8 @@ jobs:
           dsl-args: "CryptoRecordSanityChecks"
       - run-eet-suites:
           dsl-args: "SuperusersAreNeverThrottled"
+      - run-eet-suites:
+          dsl-args: "CannotDeleteSystemEntitiesSuite"
 
   run-token-scenarios:
     parameters:

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/SuiteRunner.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/SuiteRunner.java
@@ -64,6 +64,7 @@ import com.hedera.services.bdd.suites.freeze.UpdateServerFiles;
 import com.hedera.services.bdd.suites.issues.Issue2144Spec;
 import com.hedera.services.bdd.suites.issues.IssueXXXXSpec;
 import com.hedera.services.bdd.suites.meta.VersionInfoSpec;
+import com.hedera.services.bdd.suites.misc.CannotDeleteSystemEntitiesSuite;
 import com.hedera.services.bdd.suites.misc.ConsensusQueriesStressTests;
 import com.hedera.services.bdd.suites.misc.ContractQueriesStressTests;
 import com.hedera.services.bdd.suites.misc.CryptoQueriesStressTests;
@@ -281,6 +282,7 @@ public class SuiteRunner {
 		put("ControlAccountsExemptForUpdates", aof(new SpecialAccountsAreExempted()));
 		/* System files. */
 		put("FetchSystemFiles", aof(new FetchSystemFiles()));
+		put("CannotDeleteSystemEntitiesSuite", aof(new CannotDeleteSystemEntitiesSuite()));
 		/* Throttling */
 		put("BucketThrottlingSpec", aof(new BucketThrottlingSpec()));
 		/* Network metadata. */

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/misc/CannotDeleteSystemEntitiesSuite.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/misc/CannotDeleteSystemEntitiesSuite.java
@@ -42,7 +42,7 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.ENTITY_NOT_ALL
 public class CannotDeleteSystemEntitiesSuite extends HapiApiSuite {
 	private static final Logger log = LogManager.getLogger(CannotDeleteSystemEntitiesSuite.class);
 
-	final Integer[] sysFileIds = {101,102,111,112,121,122,150};
+	final int[] sysFileIds = {101,102,111,112,121,122,150};
 
 	public static void main(String... args) {
 		CannotDeleteSystemEntitiesSuite suite = new CannotDeleteSystemEntitiesSuite();
@@ -112,13 +112,13 @@ public class CannotDeleteSystemEntitiesSuite extends HapiApiSuite {
 				);
 	}
 
-	private HapiApiSpec systemUserCannotDeleteSystemFiles(Integer[] fileIds, String sysUser) {
+	private HapiApiSpec systemUserCannotDeleteSystemFiles(int[] fileIds, String sysUser) {
 		return defaultHapiSpec("systemUserCannotDeleteSystemFiles")
 				.given()
 				.when()
 				.then(
 						inParallel(
-								Arrays.stream(fileIds).map(id ->
+								Arrays.stream(fileIds).mapToObj(id ->
 										cryptoDelete("0.0." + id)
 												.payingWith(sysUser)
 												.signedBy(sysUser)
@@ -128,7 +128,7 @@ public class CannotDeleteSystemEntitiesSuite extends HapiApiSuite {
 				);
 	}
 
-	private HapiApiSpec normalUserCannotDeleteSystemFiles(Integer[] fileIds) {
+	private HapiApiSpec normalUserCannotDeleteSystemFiles(int[] fileIds) {
 		return defaultHapiSpec("normalUserCannotDeleteSystemFiles")
 				.given(
 						newKeyNamed("normalKey")
@@ -138,7 +138,7 @@ public class CannotDeleteSystemEntitiesSuite extends HapiApiSuite {
 								.balance(1_000_000_000L))
 				.then(
 						inParallel(
-								Arrays.stream(fileIds).map(id ->
+								Arrays.stream(fileIds).mapToObj(id ->
 										fileDelete("0.0." + id)
 												.payingWith("normalUser")
 												.signedBy("normalKey")
@@ -149,13 +149,13 @@ public class CannotDeleteSystemEntitiesSuite extends HapiApiSuite {
 	}
 
 
-	private HapiApiSpec systemDeleteCannotDeleteSystemFiles(Integer[] fileIds, String sysUser) {
+	private HapiApiSpec systemDeleteCannotDeleteSystemFiles(int[] fileIds, String sysUser) {
 		return defaultHapiSpec("systemDeleteCannotDeleteSystemFiles")
 				.given()
 				.when()
 				.then(
 						inParallel(
-								Arrays.stream(fileIds).map(id ->
+								Arrays.stream(fileIds).mapToObj(id ->
 										systemFileDelete("0.0." + id)
 												.payingWith(sysUser)
 												.signedBy(sysUser)


### PR DESCRIPTION
**Related issue(s)**:
Closes #823 

**Summary of the change**:
1. Added the test suite to make sure nobody can delete current system entities (entity with id < 1000);
2. Added the test suite to Continuous Integration workflow;

**External impacts**:
None.

**Applicable documentation**
- [ ] Javadoc
- [ ] HAPI protobuf comments
- [ ] README
