### PR TITLE
00814 d reconnect api permission update failure

### DIFF
--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/reconnect/UpdateApiPermissionsDuringReconnect.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/reconnect/UpdateApiPermissionsDuringReconnect.java
@@ -29,7 +29,9 @@ import org.apache.logging.log4j.Logger;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
+import java.time.Duration;
 
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.sleepFor;
 import static com.hedera.services.bdd.spec.HapiApiSpec.defaultHapiSpec;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getAccountBalance;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getFileContents;
@@ -54,6 +56,7 @@ public class UpdateApiPermissionsDuringReconnect extends HapiApiSuite {
 		final String fileInfoRegistry = "apiPermissionsReconnect";
 		return defaultHapiSpec("updateApiPermissionsDuringReconnect")
 				.given(
+						sleepFor(Duration.ofSeconds(25).toMillis()),
 						getAccountBalance(GENESIS).setNode("0.0.6").unavailableNode()
 				)
 				.when(


### PR DESCRIPTION
**Related issue(s)**:
Closes #814 

**Summary of the change**:
Add initial delay to make sure the last server node is disconnected before moving forward with rest of the test. This should help with random failure of this test case. 

**External impacts**:
None.

**Applicable documentation**
- [ ] Javadoc
- [ ] HAPI protobuf comments
- [ ] README
