### PR TITLE
Fix S3 folder link to see the results of nightly regression

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1600,8 +1600,8 @@ jobs:
       - run:
           name: Sync results of SuiteRunner suites to AWS
           command: |
-              aws s3 sync /swirlds-platform/regression/results/ s3://hedera-service-regression-jrs;
-              tar -czvf /results.tar.gz  /swirlds-platform/regression/results/*
+              aws s3 sync /swirlds-platform/regression/results/4N_1C/Basic/ s3://hedera-service-regression-jrs;
+              tar -czvf /results.tar.gz  /swirlds-platform/regression/results/4N_1C/Basic/*
 
       - store_artifacts:
           path: /results.tar.gz
@@ -1624,8 +1624,8 @@ jobs:
       - run:
           name: Sync results of update node tests to AWS
           command: |
-            aws s3 sync /swirlds-platform/regression/results/ s3://hedera-service-regression-jrs;
-            tar -czvf /results.tar.gz  /swirlds-platform/regression/results/*
+            aws s3 sync /swirlds-platform/regression/results/5N_1C/Update/ s3://hedera-service-regression-jrs;
+            tar -czvf /results.tar.gz  /swirlds-platform/regression/results/5N_1C/Update/*
 
       - store_artifacts:
           path: /results.tar.gz
@@ -1648,8 +1648,8 @@ jobs:
       - run:
           name: Sync results of performance regression to AWS
           command: |
-            aws s3 sync /swirlds-platform/regression/results/ s3://hedera-service-regression-jrs;
-            tar -czvf /results.tar.gz  /swirlds-platform/regression/results/*
+            aws s3 sync /swirlds-platform/regression/results/4N_4C/Performance/ s3://hedera-service-regression-jrs;
+            tar -czvf /results.tar.gz  /swirlds-platform/regression/results/4N_4C/Performance/*
 
       - store_artifacts:
           path: /results.tar.gz
@@ -1672,8 +1672,8 @@ jobs:
       - run:
           name: Sync results of network error regression to AWS
           command: |
-            aws s3 sync /swirlds-platform/regression/results/ s3://hedera-service-regression-jrs;
-            tar -czvf /results.tar.gz  /swirlds-platform/regression/results/*
+            aws s3 sync /swirlds-platform/regression/results/4N_1C/NetError/ s3://hedera-service-regression-jrs;
+            tar -czvf /results.tar.gz  /swirlds-platform/regression/results/4N_1C/NetError/*
 
       - store_artifacts:
           path: /results.tar.gz
@@ -1702,8 +1702,8 @@ jobs:
       - run:
           name: Sync results of public testnet migration test to AWS
           command: |
-            aws s3 sync /swirlds-platform/regression/results/ s3://hedera-service-regression-jrs;
-            tar -czvf /results.tar.gz  /swirlds-platform/regression/results/*
+            aws s3 sync /swirlds-platform/regression/results/4N_1C/Migration/ s3://hedera-service-regression-jrs;
+            tar -czvf /results.tar.gz  /swirlds-platform/regression/results/4N_1C/Migration/*
 
       - store_artifacts:
           path: /results.tar.gz
@@ -1758,8 +1758,8 @@ jobs:
       - run:
           name: Sync results of software update regression to AWS
           command: |
-            aws s3 sync /swirlds-platform/regression/results/ s3://hedera-service-regression-jrs;
-            tar -czvf /results.tar.gz  /swirlds-platform/regression/results/*
+            aws s3 sync /swirlds-platform/regression/results/4N_1C/Restart/ s3://hedera-service-regression-jrs;
+            tar -czvf /results.tar.gz  /swirlds-platform/regression/results/4N_1C/Restart/*
 
       - store_artifacts:
           path: /results.tar.gz
@@ -1783,8 +1783,8 @@ jobs:
       - run:
           name: Sync results of state recover regression to AWS
           command: |
-            aws s3 sync /swirlds-platform/regression/results/ s3://hedera-service-regression-jrs;
-            tar -czvf /results.tar.gz  /swirlds-platform/regression/results/*
+            aws s3 sync /swirlds-platform/regression/results/4N_1C/Recovery/ s3://hedera-service-regression-jrs;
+            tar -czvf /results.tar.gz  /swirlds-platform/regression/results/4N_1C/Recovery/*
 
       - store_artifacts:
           path: /results.tar.gz
@@ -1812,8 +1812,8 @@ jobs:
       - run:
           name: Sync results of software update regression to AWS
           command: |
-            aws s3 sync /swirlds-platform/regression/results/ s3://hedera-service-regression-jrs;
-            tar -czvf /results.tar.gz  /swirlds-platform/regression/results/*
+            aws s3 sync /swirlds-platform/regression/results/6N_6C/Performance/ s3://hedera-service-regression-jrs;
+            tar -czvf /results.tar.gz  /swirlds-platform/regression/results/6N_6C/Performance/*
 
       - store_artifacts:
           path: /results.tar.gz
@@ -1837,8 +1837,8 @@ jobs:
       - run:
           name: Sync results of reconnect regression to AWS
           command: |
-            aws s3 sync /swirlds-platform/regression/results/ s3://hedera-service-regression-jrs;
-            tar -czvf /results.tar.gz  /swirlds-platform/regression/results/*
+            aws s3 sync /swirlds-platform/regression/results/4N_1C/Reconnect/ s3://hedera-service-regression-jrs;
+            tar -czvf /results.tar.gz  /swirlds-platform/regression/results/4N_1C/Reconnect/*
 
       - store_artifacts:
           path: /results.tar.gz
@@ -1867,8 +1867,8 @@ jobs:
       - run:
           name: Sync results of software update regression to AWS
           command: |
-            aws s3 sync /swirlds-platform/regression/results/ s3://hedera-service-regression-jrs;
-            tar -czvf /results.tar.gz  /swirlds-platform/regression/results/*
+            aws s3 sync /swirlds-platform/regression/results/15N_15C/ s3://hedera-service-regression-jrs;
+            tar -czvf /results.tar.gz  /swirlds-platform/regression/results/15N_15C/*
 
       - store_artifacts:
           path: /results.tar.gz
@@ -1897,8 +1897,8 @@ jobs:
       - run:
           name: Sync results of software update regression to AWS
           command: |
-            aws s3 sync /swirlds-platform/regression/results/ s3://hedera-service-regression-jrs;
-            tar -czvf /results.tar.gz  /swirlds-platform/regression/results/*
+            aws s3 sync /swirlds-platform/regression/results/15N_15C/ s3://hedera-service-regression-jrs;
+            tar -czvf /results.tar.gz  /swirlds-platform/regression/results/15N_15C/*
 
       - store_artifacts:
           path: /results.tar.gz


### PR DESCRIPTION
As the folder structure has changed, S3 link in slack message doesn't work. Fixed the folder structure that syncs to S3.

**Related issue(s)**:
Closes #769 

Running a test to validate this change works