### PR TITLE
00815: Waits for reconnect to happen

### DIFF
--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/reconnect/ValidateDuplicateTransactionAfterReconnect.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/reconnect/ValidateDuplicateTransactionAfterReconnect.java
@@ -21,6 +21,7 @@ package com.hedera.services.bdd.suites.reconnect;
  */
 
 import com.hedera.services.bdd.spec.HapiApiSpec;
+import com.hedera.services.bdd.spec.utilops.UtilVerbs;
 import com.hedera.services.bdd.suites.HapiApiSuite;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -64,9 +65,6 @@ public class ValidateDuplicateTransactionAfterReconnect extends HapiApiSuite {
 								.unavailableNode()
 				)
 				.when(
-						getAccountBalance(GENESIS)
-								.setNode("0.0.6")
-								.unavailableNode(),
 						cryptoCreate("repeatedTransaction")
 								.payingWith(MASTER)
 								.validDurationSecs(180)
@@ -77,9 +75,14 @@ public class ValidateDuplicateTransactionAfterReconnect extends HapiApiSuite {
 				)
 				.then(
 						withLiveNode("0.0.6")
-								.within(180, TimeUnit.SECONDS)
-								.loggingAvailabilityEvery(30)
-								.sleepingBetweenRetriesFor(10),
+								.within(60, TimeUnit.SECONDS)
+								.loggingAvailabilityEvery(10)
+								.sleepingBetweenRetriesFor(5),
+						UtilVerbs.sleepFor(30 * 1000),
+						withLiveNode("0.0.6")
+								.within(60, TimeUnit.SECONDS)
+								.loggingAvailabilityEvery(10)
+								.sleepingBetweenRetriesFor(5),
 						cryptoCreate("repeatedTransaction")
 								.payingWith(MASTER)
 								.txnId(transactionId)


### PR DESCRIPTION
**Related issue(s)**:
Related to #815

**Summary of the change**:
Reduces the wait time for the node to reconnect, because the transaction is only alive for 180 seconds. It waits after the first check and checks again due to the transition DISCONNECTED -> ACTIVE -> BEHIND, documented in #833 

This change will not be required or could be removed once #833 is completed
