### PR TITLE
00836 d move basic tests out of jrs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1357,7 +1357,7 @@ workflows:
   nightly-comprehensive-functional-regression:
     triggers:
       - schedule:
-          cron: "35 18 * * *"
+          cron: "32 19 * * *"
           filters:
             branches:
               only:
@@ -2448,8 +2448,8 @@ jobs:
           dsl-args: "CryptoRecordSanityChecks -TLS=on"
       - run-eet-suites:
           dsl-args: "SignedTransactionBytesRecordsSuite -TLS=on"
-      - run-eet-suites:
-          dsl-args: "SuperusersAreNeverThrottled"
+#      - run-eet-suites:
+#          dsl-args: "SuperusersAreNeverThrottled"
       - run-eet-suites:
           dsl-args: "FileRecordSanityChecks"
       - run-eet-suites:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -884,26 +884,6 @@ executors:
     working_directory: /repo
 
 workflows:
-  AWS-Daily-Services-Comp-Basic-4N-1C:
-    triggers:
-      - schedule:
-          cron: "15 4 * * *"
-          filters:
-            branches:
-              only:
-                - Disable-X-master
-    jobs:
-      - build-platform-and-services
-      - run-basic-suiterunner-tests:
-          context: Slack
-          requires:
-            - build-platform-and-services
-          pre-steps:
-            - install-tools
-            - attach_workspace:
-                at: /
-          workflow-name: "AWS-Daily-Services-Comp-Basic-4N-1C"
-
   AWS-Daily-Services-Crypto-Update-5N-1C:
     triggers:
       - schedule:
@@ -1618,31 +1598,7 @@ jobs:
             - repo/HapiApp2.0
             - root/.m2
             - repo/hedera-node
-
-  run-basic-suiterunner-tests:
-    parameters:
-      workflow-name:
-        type: string
-        default: ""
-    executor:
-      name: build-executor
-      workflow-name:  << parameters.workflow-name >>
-    steps:
-      - run:
-          name: Run various suites in SuiteRunner
-          command: |
-            cd /swirlds-platform/regression;
-            ./regression_services_circleci.sh configs/services/suites/daily/AWS-Daily-Services-Comp-Basic-4N-1C.json /repo
-
-      - run:
-          name: Sync results of SuiteRunner suites to AWS
-          command: |
-              aws s3 sync /swirlds-platform/regression/results/4N_1C/Basic/ s3://hedera-service-regression-jrs;
-              tar -czvf /results.tar.gz  /swirlds-platform/regression/results/4N_1C/Basic/*
-
-      - store_artifacts:
-          path: /results.tar.gz
-
+            
   run-update-node-tests:
     parameters:
       workflow-name:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1357,7 +1357,7 @@ workflows:
   nightly-comprehensive-functional-regression:
     triggers:
       - schedule:
-          cron: "32 19 * * *"
+          cron: "12 21 * * *"
           filters:
             branches:
               only:
@@ -2448,8 +2448,8 @@ jobs:
           dsl-args: "CryptoRecordSanityChecks -TLS=on"
       - run-eet-suites:
           dsl-args: "SignedTransactionBytesRecordsSuite -TLS=on"
-#      - run-eet-suites:
-#          dsl-args: "SuperusersAreNeverThrottled"
+      - run-eet-suites:
+          dsl-args: "SuperusersAreNeverThrottled"
       - run-eet-suites:
           dsl-args: "FileRecordSanityChecks"
       - run-eet-suites:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1357,11 +1357,11 @@ workflows:
   nightly-comprehensive-functional-regression:
     triggers:
       - schedule:
-          cron: "12 21 * * *"
+          cron: "15 4 * * *"
           filters:
             branches:
               only:
-                - 00836-D-move-basic-tests-out-of-JRS
+                - master
     jobs:
       - fast-build-artifact:
           context: Slack
@@ -1401,7 +1401,6 @@ workflows:
               ignore:
                 - /.*-PERF/
                 - /.*-REGRESSION/
-                - 00836-D-move-basic-tests-out-of-JRS
           workflow-name: "Continuous integration"
       - start-singlejob-testnet:
           context: Slack

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -891,7 +891,7 @@ workflows:
           filters:
             branches:
               only:
-                - master
+                - Disable-X-master
     jobs:
       - build-platform-and-services
       - run-basic-suiterunner-tests:
@@ -1354,6 +1354,44 @@ workflows:
       - aws-summary:
           context: Slack
 
+  nightly-comprehensive-functional-regression:
+    triggers:
+      - schedule:
+          cron: "35 18 * * *"
+          filters:
+            branches:
+              only:
+                - 00836-D-move-basic-tests-out-of-JRS
+    jobs:
+      - fast-build-artifact:
+          context: Slack
+          workflow-name: freeze restart
+      - start-singlejob-testnet:
+          context: Slack
+          requires:
+            - fast-build-artifact
+          workflow-name: "nightly-comprehensive-functional-regression"
+          infra-branch: services-with-platform070
+      - run-comprehensive-functional-test:
+          context: Slack
+          requires:
+            - start-singlejob-testnet
+          pre-steps:
+            - attach_workspace:
+                at: /
+            - ensure-testnet-for-reruns
+          post-steps:
+            - cleanup-rerun-testnet-if-present
+          workflow-name: "nightly-comprehensive-functional-regression"
+
+      - cleanup-singlejob-testnet:
+          context: Slack
+          requires:
+            - run-comprehensive-functional-test
+          pre-steps:
+            - attach_workspace:
+                at: /
+
   continuous-integration:
     jobs:
       - build-artifact:
@@ -1363,6 +1401,7 @@ workflows:
               ignore:
                 - /.*-PERF/
                 - /.*-REGRESSION/
+                - 00836-D-move-basic-tests-out-of-JRS
           workflow-name: "Continuous integration"
       - start-singlejob-testnet:
           context: Slack
@@ -2378,3 +2417,78 @@ jobs:
           name: Show logs after HGCApp restart
           command: |
             /repo/.circleci/scripts/show_logs.sh
+
+  run-comprehensive-functional-test:
+    parameters:
+      runner:
+        type: executor
+        default: ci-test-executor
+      workflow-name:
+        type: string
+        default: ""
+    executor:
+      name: ci-test-executor
+      workflow-name:  << parameters.workflow-name >>
+    steps:
+      - run-eet-suites:
+          dsl-args: "BucketAndLegacyThrottlingSpec"
+      - run-eet-suites:
+          dsl-args: "ControlAccountsExemptForUpdates"
+      - run-eet-suites:
+          dsl-args: "TopicCreateSpecs"
+      - run-eet-suites:
+          dsl-args: "SubmitMessageSpecs"
+      - run-eet-suites:
+          dsl-args: "TopicUpdateSpecs"
+      - run-eet-suites:
+          dsl-args: "TopicGetInfoSpecs"
+      - run-eet-suites:
+          dsl-args: "CryptoCreateSuite -TLS=on"
+      - run-eet-suites:
+          dsl-args: "CryptoRecordSanityChecks -TLS=on"
+      - run-eet-suites:
+          dsl-args: "SignedTransactionBytesRecordsSuite -TLS=on"
+      - run-eet-suites:
+          dsl-args: "SuperusersAreNeverThrottled"
+      - run-eet-suites:
+          dsl-args: "FileRecordSanityChecks"
+      - run-eet-suites:
+          dsl-args: "VersionInfoSpec"
+      - run-eet-suites:
+          dsl-args: "PermissionSemanticsSpec"
+      - run-eet-suites:
+          dsl-args: "SysDelSysUndelSpec"
+      - run-eet-suites:
+          dsl-args: "NewOpInConstructorSpecs"
+      - run-eet-suites:
+          dsl-args: "MultipleSelfDestructsAreSafe"
+      - run-eet-suites:
+          dsl-args: "FetchSystemFiles"
+      - run-eet-suites:
+          dsl-args: "ChildStorageSpecs"
+      - run-eet-suites:
+          dsl-args: "DeprecatedContractKeySpecs"
+      - run-eet-suites:
+          dsl-args: "ThresholdRecordCreationSpecs"
+      - run-eet-suites:
+          dsl-args: "ContractRecordSanityChecks"
+      - run-eet-suites:
+          dsl-args: "TopicDeleteSpecs"
+      - run-eet-suites:
+          dsl-args: "ProtectedFilesUpdateSuite"
+      - run-eet-suites:
+          dsl-args: "TokenCreateSpecs"
+      - run-eet-suites:
+          dsl-args: "TokenUpdateSpecs"
+      - run-eet-suites:
+          dsl-args: "TokenDeleteSpecs"
+      - run-eet-suites:
+          dsl-args: "TokenTransactSpecs"
+      - run-eet-suites:
+          dsl-args: "TokenManagementSpecs"
+      - run-eet-suites:
+          dsl-args: "TokenAssociationSpecs"
+      - run-eet-suites:
+          dsl-args: "CannotDeleteSystemEntitiesSuite"
+      - run-eet-suites:
+          dsl-args: "UmbrellaRedux"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1365,13 +1365,12 @@ workflows:
     jobs:
       - fast-build-artifact:
           context: Slack
-          workflow-name: freeze restart
+          workflow-name: "nightly-comprehensive-functional-regression"
       - start-singlejob-testnet:
           context: Slack
           requires:
             - fast-build-artifact
           workflow-name: "nightly-comprehensive-functional-regression"
-          infra-branch: services-with-platform070
       - run-comprehensive-functional-test:
           context: Slack
           requires:

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/issues/Issue2144Spec.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/issues/Issue2144Spec.java
@@ -94,7 +94,8 @@ public class Issue2144Spec extends HapiApiSuite {
 	private HapiApiSpec superusersAreNeverThrottledOnTransfers() {
 		return defaultHapiSpec("MasterIsNeverThrottledOnTransfers")
 				.given(
-						cryptoTransfer(tinyBarsFromTo(ADDRESS_BOOK_CONTROL, MASTER, 1_000_000_000L))
+						cryptoTransfer(tinyBarsFromTo(GENESIS, ADDRESS_BOOK_CONTROL, 1_000_000_000_000L)),
+						cryptoTransfer(tinyBarsFromTo(GENESIS, MASTER, 1_000_000_000_000L))
 				).when(
 						fileUpdate(APP_PROPERTIES)
 								.payingWith(ADDRESS_BOOK_CONTROL)
@@ -114,7 +115,8 @@ public class Issue2144Spec extends HapiApiSuite {
 	private HapiApiSpec superusersAreNeverThrottledOnMiscTxns() {
 		return defaultHapiSpec("MasterIsNeverThrottledOnMiscTxns")
 				.given(
-						cryptoTransfer(tinyBarsFromTo(ADDRESS_BOOK_CONTROL, MASTER, 1_000_000_000L))
+						cryptoTransfer(tinyBarsFromTo(GENESIS, ADDRESS_BOOK_CONTROL, 1_000_000_000_000L)),
+						cryptoTransfer(tinyBarsFromTo(GENESIS, MASTER, 1_000_000_000_000L))
 				).when(
 						fileUpdate(APP_PROPERTIES)
 								.payingWith(ADDRESS_BOOK_CONTROL)
@@ -133,7 +135,8 @@ public class Issue2144Spec extends HapiApiSuite {
 	private HapiApiSpec superusersAreNeverThrottledOnHcsTxns() {
 		return defaultHapiSpec("MasterIsNeverThrottledOnHcsTxns")
 				.given(
-						cryptoTransfer(tinyBarsFromTo(ADDRESS_BOOK_CONTROL, MASTER, 1_000_000_000L))
+						cryptoTransfer(tinyBarsFromTo(GENESIS, ADDRESS_BOOK_CONTROL, 1_000_000_000_000L)),
+						cryptoTransfer(tinyBarsFromTo(GENESIS, MASTER, 1_000_000_000_000L))
 				).when(
 						fileUpdate(APP_PROPERTIES)
 								.payingWith(ADDRESS_BOOK_CONTROL)
@@ -152,7 +155,8 @@ public class Issue2144Spec extends HapiApiSuite {
 	private HapiApiSpec superusersAreNeverThrottledOnMiscQueries() {
 		return defaultHapiSpec("MasterIsNeverThrottledOnMiscQueries")
 				.given(
-						cryptoTransfer(tinyBarsFromTo(GENESIS, MASTER, 1_000_000_000L))
+						cryptoTransfer(tinyBarsFromTo(GENESIS, ADDRESS_BOOK_CONTROL, 1_000_000_000_000L)),
+						cryptoTransfer(tinyBarsFromTo(GENESIS, MASTER, 1_000_000_000_000L))
 				).when(
 						fileUpdate(APP_PROPERTIES)
 								.payingWith(ADDRESS_BOOK_CONTROL)
@@ -170,7 +174,8 @@ public class Issue2144Spec extends HapiApiSuite {
 	private HapiApiSpec superusersAreNeverThrottledOnHcsQueries() {
 		return defaultHapiSpec("MasterIsNeverThrottledOnHcsQueries")
 				.given(
-						cryptoTransfer(tinyBarsFromTo(ADDRESS_BOOK_CONTROL, MASTER, 1_000_000_000L)),
+						cryptoTransfer(tinyBarsFromTo(GENESIS, ADDRESS_BOOK_CONTROL, 1_000_000_000_000L)),
+						cryptoTransfer(tinyBarsFromTo(GENESIS, MASTER, 1_000_000_000_000L)),
 						createTopic("misc")
 				).when(
 						fileUpdate(APP_PROPERTIES)


### PR DESCRIPTION
**Related issue(s)**:
Closes #836 

**Summary of the change**:
1. Disabled the daily basic JRS regression test. Didn't delete it because we may bring it back after some thinking;
2. Created a CircleCi regression test workflow to cover the JRS regression test disabled;
3. Modified the superuser throttling test case to not run into INSUFFICIENT_ACCOUNT_BALANCE error;

The successful test run: https://app.circleci.com/pipelines/github/hashgraph/hedera-services/7546/workflows/74da5c55-0a3f-4a64-b13a-e366e660b998


**External impacts**:
None.

**Applicable documentation**
- [ ] Javadoc
- [ ] HAPI protobuf comments
- [ ] README
