### PR TITLE
Added newTotalSuppy in TransactionReceipt for token mint/burn/wipe transactions

### DIFF
--- a/hapi-proto/src/main/proto/TransactionReceipt.proto
+++ b/hapi-proto/src/main/proto/TransactionReceipt.proto
@@ -100,4 +100,7 @@ message TransactionReceipt {
 
     // In the receipt of a CreateToken, the id of the newly created token
     TokenID tokenID = 10;
+
+    // In the receipt of TokenMint, TokenWipe, TokenBurn, the current total supply of this token
+    uint64 newTotalSupply = 11;
 }

--- a/hedera-node/src/main/java/com/hedera/services/ServicesState.java
+++ b/hedera-node/src/main/java/com/hedera/services/ServicesState.java
@@ -76,7 +76,8 @@ public class ServicesState extends AbstractMerkleInternal implements SwirldState
 	static final int RELEASE_070_VERSION = 1;
 	static final int RELEASE_080_VERSION = 2;
 	static final int RELEASE_090_VERSION = 3;
-	static final int MERKLE_VERSION = RELEASE_090_VERSION;
+	static final int RELEASE_0100_VERSION = 4;
+	static final int MERKLE_VERSION = RELEASE_0100_VERSION;
 	static final long RUNTIME_CONSTRUCTABLE_ID = 0x8e300b0dfdafbb1aL;
 
 	static Consumer<MerkleNode> merkleDigest = CryptoFactory.getInstance()::digestTreeSync;

--- a/hedera-node/src/main/java/com/hedera/services/context/AwareTransactionContext.java
+++ b/hedera-node/src/main/java/com/hedera/services/context/AwareTransactionContext.java
@@ -232,6 +232,11 @@ public class AwareTransactionContext implements TransactionContext {
 	}
 
 	@Override
+	public void setNewTotalSupply(long newTotalTokenSupply) {
+		receiptConfig = receipt -> receipt.setNewTotalSupply(newTotalTokenSupply);
+	}
+
+	@Override
 	public void setCreated(FileID id) {
 		receiptConfig = receipt -> receipt.setFileID(id);
 	}

--- a/hedera-node/src/main/java/com/hedera/services/context/TransactionContext.java
+++ b/hedera-node/src/main/java/com/hedera/services/context/TransactionContext.java
@@ -215,4 +215,10 @@ public interface TransactionContext {
 	 * @param sequenceNumber
 	 */
 	void setTopicRunningHash(byte[] runningHash, long sequenceNumber);
+
+	/**
+	 * Set this token's new total supply for mint/burn/wipe transaction
+	 * @param newTotalTokenSupply
+	 */
+	void setNewTotalSupply(long newTotalTokenSupply);
 }

--- a/hedera-node/src/main/java/com/hedera/services/legacy/core/jproto/TxnReceipt.java
+++ b/hedera-node/src/main/java/com/hedera/services/legacy/core/jproto/TxnReceipt.java
@@ -58,7 +58,8 @@ public class TxnReceipt implements SelfSerializable {
 	static final int RELEASE_070_VERSION = 1;
 	static final int RELEASE_080_VERSION = 2;
 	static final int RELEASE_090_VERSION = 3;
-	static final int MERKLE_VERSION = RELEASE_080_VERSION;
+	static final int RELEASE_0100_VERSION = 4;
+	static final int MERKLE_VERSION = RELEASE_0100_VERSION;
 	static final long RUNTIME_CONSTRUCTABLE_ID = 0x65ef569a77dcf125L;
 
 	static DomainSerdes serdes = new DomainSerdes();

--- a/hedera-node/src/main/java/com/hedera/services/legacy/core/jproto/TxnReceipt.java
+++ b/hedera-node/src/main/java/com/hedera/services/legacy/core/jproto/TxnReceipt.java
@@ -110,9 +110,6 @@ public class TxnReceipt implements SelfSerializable {
 				receipt.runningHashVersion = in.readLong();
 			}
 
-			if(version > RELEASE_090_VERSION) {
-				receipt.newTotalSupply = in.readLong();
-			}
 			return receipt;
 		}
 	}

--- a/hedera-node/src/main/java/com/hedera/services/txns/token/TokenBurnTransitionLogic.java
+++ b/hedera-node/src/main/java/com/hedera/services/txns/token/TokenBurnTransitionLogic.java
@@ -69,6 +69,9 @@ public class TokenBurnTransitionLogic implements TransitionLogic {
 			} else {
 				var outcome = store.burn(id, op.getAmount());
 				txnCtx.setStatus((outcome == OK) ? SUCCESS : outcome);
+				if(outcome == OK) {
+					txnCtx.setNewTotalSupply(store.get(id).totalSupply());
+				}
 			}
 		} catch (Exception e) {
 			log.warn("Unhandled error while processing :: {}!", txnCtx.accessor().getSignedTxn4Log(), e);

--- a/hedera-node/src/main/java/com/hedera/services/txns/token/TokenMintTransitionLogic.java
+++ b/hedera-node/src/main/java/com/hedera/services/txns/token/TokenMintTransitionLogic.java
@@ -69,6 +69,9 @@ public class TokenMintTransitionLogic implements TransitionLogic {
 			} else {
 				var outcome = store.mint(id, op.getAmount());
 				txnCtx.setStatus((outcome == OK) ? SUCCESS : outcome);
+				if(outcome == OK) {
+					txnCtx.setNewTotalSupply(store.get(id).totalSupply());
+				}
 			}
 		} catch (Exception e) {
 			log.warn("Unhandled error while processing :: {}!", txnCtx.accessor().getSignedTxn4Log(), e);

--- a/hedera-node/src/main/java/com/hedera/services/txns/token/TokenWipeTransitionLogic.java
+++ b/hedera-node/src/main/java/com/hedera/services/txns/token/TokenWipeTransitionLogic.java
@@ -65,7 +65,11 @@ public class TokenWipeTransitionLogic implements TransitionLogic {
 		try {
 			var op = txnCtx.accessor().getTxn().getTokenWipe();
 			var outcome = store.wipe(op.getAccount(), store.resolve(op.getToken()), op.getAmount(),false);
+			var id = store.resolve(op.getToken());
 			txnCtx.setStatus((outcome == OK) ? SUCCESS : outcome);
+			if(outcome == OK) {
+				txnCtx.setNewTotalSupply(store.get(id).totalSupply());
+			}
 		} catch (Exception e) {
 			log.warn("Unhandled error while processing :: {}!", txnCtx.accessor().getSignedTxn4Log(), e);
 			txnCtx.setStatus(FAIL_INVALID);

--- a/hedera-node/src/test/java/com/hedera/services/context/AwareTransactionContextTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/context/AwareTransactionContextTest.java
@@ -442,6 +442,20 @@ public class AwareTransactionContextTest {
 	}
 
 	@Test
+	public void getsExpectedReceiptForTokenMintBurnWipe() {
+		// when:
+		final var newTotalSupply = 1000L;
+		subject.setNewTotalSupply(newTotalSupply);
+		record = subject.recordSoFar();
+
+		// then:
+		assertEquals(ratesNow, record.getReceipt().getExchangeRate());
+		assertEquals(newTotalSupply, record.getReceipt().getNewTotalSupply());
+	}
+
+
+
+	@Test
 	public void getsExpectedReceiptForFileCreation() {
 		// when:
 		subject.setCreated(fileCreated);

--- a/hedera-node/src/test/java/com/hedera/services/legacy/core/jproto/TxnReceiptTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/legacy/core/jproto/TxnReceiptTest.java
@@ -21,22 +21,60 @@ package com.hedera.services.legacy.core.jproto;
  */
 
 import com.google.protobuf.ByteString;
+import com.hedera.services.state.serdes.DomainSerdes;
+import com.hedera.services.state.submerkle.CurrencyAdjustments;
 import com.hedera.services.state.submerkle.EntityId;
 import com.hedera.services.state.submerkle.ExchangeRates;
+import com.hedera.services.state.submerkle.ExpirableTxnRecord;
+import com.hedera.services.state.submerkle.RichInstant;
+import com.hedera.services.state.submerkle.SolidityFnResult;
 import com.hederahashgraph.api.proto.java.ExchangeRate;
 import com.hederahashgraph.api.proto.java.ExchangeRateSet;
 import com.hederahashgraph.api.proto.java.TokenID;
 import com.hederahashgraph.api.proto.java.TopicID;
 import com.hederahashgraph.api.proto.java.TransactionReceipt;
+import com.swirlds.common.io.SelfSerializable;
+import com.swirlds.common.io.SerializableDataInputStream;
+import com.swirlds.common.io.SerializableDataOutputStream;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.platform.runner.JUnitPlatform;
 import org.junit.runner.RunWith;
+import org.mockito.InOrder;
+import org.mockito.Mockito;
 
-import static org.junit.jupiter.api.Assertions.*;
+import java.io.DataInputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+//import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 @RunWith(JUnitPlatform.class)
 public class TxnReceiptTest {
+  private static final int MAX_STATUS_BYTES = 128;
+//  private static final int MAX_RUNNING_HASH_BYTES = 1024;
+  DomainSerdes serdes;
+  ExchangeRates mockRates;
+
+  TxnReceipt subject;
+
+
   private TopicID getTopicId(long shard, long realm, long num) {
     return TopicID.newBuilder().setShardNum(shard).setRealmNum(realm).setTopicNum(num).build();
   }
@@ -52,6 +90,29 @@ public class TxnReceiptTest {
     }
     return hash;
   }
+
+  @BeforeEach
+  public void setup() {
+    subject = new TxnReceipt();
+
+//    din = mock(DataInputStream.class);
+//
+    serdes = mock(DomainSerdes.class);
+    mockRates = mock(ExchangeRates.class);
+//    legacyTxnIdProvider = mock(TxnId.Provider.class);
+//    legacyReceiptProvider = mock(TxnReceipt.Provider.class);
+//    legacyInstantProvider = mock(RichInstant.Provider.class);
+//    legacyFnResultProvider = mock(SolidityFnResult.Provider.class);
+//    legacyAdjustmentsProvider = mock(CurrencyAdjustments.Provider.class);
+//
+//    ExpirableTxnRecord.legacyAdjustmentsProvider = legacyAdjustmentsProvider;
+//    ExpirableTxnRecord.legacyFnResultProvider = legacyFnResultProvider;
+//    ExpirableTxnRecord.legacyInstantProvider = legacyInstantProvider;
+//    ExpirableTxnRecord.legacyReceiptProvider = legacyReceiptProvider;
+//    ExpirableTxnRecord.legacyTxnIdProvider = legacyTxnIdProvider;
+    TxnReceipt.serdes = serdes;
+  }
+
 
   @Test
   public void constructorPostConsensusCreateTopic() {
@@ -269,6 +330,84 @@ public class TxnReceiptTest {
 
     assertAll(() -> Assertions.assertDoesNotThrow(() -> cut.toString()),
             () -> assertNotNull(cut.toString()));
+  }
+
+
+  @Test
+  public void testSerialize() throws IOException {
+    // setup:
+    SerializableDataOutputStream fout = mock(SerializableDataOutputStream.class);
+    // and:
+    InOrder inOrder = Mockito.inOrder(serdes, fout);
+
+    subject = new TxnReceipt("SUCCESS", null, null,
+            null,null,mockRates,
+            null, -1, null, -1, 100);
+    // when:
+    subject.serialize(fout);
+
+    // then:
+    inOrder.verify(fout).writeNormalisedString(subject.getStatus());
+    inOrder.verify(fout).writeSerializable(mockRates, true);
+    inOrder.verify(serdes, times(5)).writeNullableSerializable(subject.getAccountId(), fout);
+    inOrder.verify(fout).writeBoolean(false);
+    inOrder.verify(fout).writeLong(subject.getNewTotalSupply());
+  }
+
+
+  @Test
+  public void testDeserialize() throws IOException {
+    // setup:
+    SerializableDataOutputStream fout = mock(SerializableDataOutputStream.class);
+    // and:
+    InOrder inOrder = Mockito.inOrder(serdes, fout);
+
+    subject = new TxnReceipt("SUCCESS", null, null,
+            null,null,mockRates,
+            null, -1, null, -1, 100);
+    // when:
+    subject.serialize(fout);
+
+    // then:
+    inOrder.verify(fout).writeNormalisedString(subject.getStatus());
+    inOrder.verify(fout).writeSerializable(mockRates, true);
+    inOrder.verify(serdes, times(5)).writeNullableSerializable(subject.getAccountId(), fout);
+    inOrder.verify(fout).writeBoolean(false);
+    inOrder.verify(fout).writeLong(subject.getNewTotalSupply());
+  }
+
+
+  @Test
+  public void v0100DeserializeWorks() throws IOException {
+    // setup:
+    SerializableDataInputStream fin = mock(SerializableDataInputStream.class);
+    subject = new TxnReceipt("SUCCESS", null, null,
+            null,null,mockRates,
+            null, 0, null, 0, 100);
+
+    given(fin.readByteArray(MAX_STATUS_BYTES)).willReturn(subject.getStatus().getBytes());
+    given(fin.readSerializable(anyBoolean(), any())).willReturn(mockRates);
+    given(serdes.readNullableSerializable(fin))
+            .willReturn(subject.getAccountId())
+            .willReturn(subject.getFileId())
+            .willReturn(subject.getContractId())
+            .willReturn(subject.getTopicId())
+            .willReturn(subject.getTokenId());
+    given(fin.readBoolean()).willReturn(true);
+    given(fin.readLong()).willReturn(subject.getTopicSequenceNumber());
+    given(fin.readLong()).willReturn(subject.getRunningHashVersion());
+    given(fin.readAllBytes()).willReturn(subject.getTopicRunningHash());
+    given(fin.readLong()).willReturn(subject.getNewTotalSupply());
+
+    // and:
+    TxnReceipt txnReceipt = new TxnReceipt();
+
+    // when:
+    txnReceipt.deserialize(fin, TxnReceipt.RELEASE_0100_VERSION);
+
+    // then:
+    assertEquals(subject.getNewTotalSupply(), txnReceipt.getNewTotalSupply());
+
   }
 
 }

--- a/hedera-node/src/test/java/com/hedera/services/state/submerkle/ExpirableTxnRecordTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/state/submerkle/ExpirableTxnRecordTest.java
@@ -303,7 +303,7 @@ class ExpirableTxnRecordTest {
 				"ExpirableTxnRecord{receipt=TxnReceipt{status=INVALID_ACCOUNT_ID, " +
 						"exchangeRates=ExchangeRates{currHbarEquiv=0, currCentEquiv=0, currExpiry=0, " +
 						"nextHbarEquiv=0, nextCentEquiv=0, nextExpiry=0}, " +
-						"accountCreated=EntityId{shard=0, realm=0, num=3}}, " +
+						"accountCreated=EntityId{shard=0, realm=0, num=3}, newTotalTokenSupply=0}, " +
 						"txnHash=6e6f742d7265616c6c792d612d68617368, " +
 						"txnId=TxnId{payer=EntityId{shard=0, realm=0, num=0}, " +
 						"validStart=RichInstant{seconds=9999999999, nanos=0}}, " +

--- a/hedera-node/src/test/java/com/hedera/services/txns/token/TokenBurnTransitionLogicTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/txns/token/TokenBurnTransitionLogicTest.java
@@ -21,6 +21,7 @@ package com.hedera.services.txns.token;
  */
 
 import com.hedera.services.context.TransactionContext;
+import com.hedera.services.state.merkle.MerkleToken;
 import com.hedera.services.tokens.TokenStore;
 import com.hedera.services.utils.PlatformTxnAccessor;
 import com.hedera.test.utils.IdUtils;
@@ -55,6 +56,7 @@ class TokenBurnTransitionLogicTest {
 	private TokenStore tokenStore;
 	private TransactionContext txnCtx;
 	private PlatformTxnAccessor accessor;
+	private MerkleToken token;
 
 	private TransactionBody tokenBurnTxn;
 	private TokenBurnTransitionLogic subject;
@@ -63,6 +65,7 @@ class TokenBurnTransitionLogicTest {
 	private void setup() {
 		tokenStore = mock(TokenStore.class);
 		accessor = mock(PlatformTxnAccessor.class);
+		token = mock(MerkleToken.class);
 
 		txnCtx = mock(TransactionContext.class);
 
@@ -108,6 +111,7 @@ class TokenBurnTransitionLogicTest {
 		// then:
 		verify(tokenStore).burn(id, amount);
 		verify(txnCtx).setStatus(SUCCESS);
+		verify(txnCtx).setNewTotalSupply(amount);
 	}
 
 	@Test
@@ -174,6 +178,8 @@ class TokenBurnTransitionLogicTest {
 		given(accessor.getTxn()).willReturn(tokenBurnTxn);
 		given(txnCtx.accessor()).willReturn(accessor);
 		given(tokenStore.resolve(id)).willReturn(id);
+		given(tokenStore.get(id)).willReturn(token);
+		given(token.totalSupply()).willReturn(amount);
 	}
 
 	private void givenMissingToken() {

--- a/hedera-node/src/test/java/com/hedera/services/txns/token/TokenMintTransitionLogicTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/txns/token/TokenMintTransitionLogicTest.java
@@ -21,6 +21,8 @@ package com.hedera.services.txns.token;
  */
 
 import com.hedera.services.context.TransactionContext;
+import com.hedera.services.state.merkle.MerkleAccount;
+import com.hedera.services.state.merkle.MerkleToken;
 import com.hedera.services.tokens.TokenStore;
 import com.hedera.services.utils.PlatformTxnAccessor;
 import com.hedera.test.utils.IdUtils;
@@ -55,6 +57,7 @@ class TokenMintTransitionLogicTest {
 	private TokenStore tokenStore;
 	private TransactionContext txnCtx;
 	private PlatformTxnAccessor accessor;
+	private MerkleToken token;
 
 	private TransactionBody tokenMintTxn;
 	private TokenMintTransitionLogic subject;
@@ -63,6 +66,7 @@ class TokenMintTransitionLogicTest {
 	private void setup() {
 		tokenStore = mock(TokenStore.class);
 		accessor = mock(PlatformTxnAccessor.class);
+		token = mock(MerkleToken.class);
 
 		txnCtx = mock(TransactionContext.class);
 
@@ -108,6 +112,7 @@ class TokenMintTransitionLogicTest {
 		// then:
 		verify(tokenStore).mint(id, amount);
 		verify(txnCtx).setStatus(SUCCESS);
+		verify(txnCtx).setNewTotalSupply(amount);
 	}
 
 	@Test
@@ -174,6 +179,8 @@ class TokenMintTransitionLogicTest {
 		given(accessor.getTxn()).willReturn(tokenMintTxn);
 		given(txnCtx.accessor()).willReturn(accessor);
 		given(tokenStore.resolve(id)).willReturn(id);
+		given(tokenStore.get(id)).willReturn(token);
+		given(token.totalSupply()).willReturn(amount);
 	}
 
 	private void givenMissingToken() {

--- a/hedera-node/src/test/java/com/hedera/services/txns/token/TokenWipeTransitionLogicTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/txns/token/TokenWipeTransitionLogicTest.java
@@ -21,6 +21,7 @@ package com.hedera.services.txns.token;
  */
 
 import com.hedera.services.context.TransactionContext;
+import com.hedera.services.state.merkle.MerkleToken;
 import com.hedera.services.tokens.TokenStore;
 import com.hedera.services.utils.PlatformTxnAccessor;
 import com.hedera.test.utils.IdUtils;
@@ -55,10 +56,12 @@ class TokenWipeTransitionLogicTest {
     private AccountID account = IdUtils.asAccount("1.2.4");
     private TokenID id = IdUtils.asToken("1.2.3");
     private long wipeAmount = 100;
+    private long totalAmount = 1000L;
 
     private TokenStore tokenStore;
     private TransactionContext txnCtx;
     private PlatformTxnAccessor accessor;
+    private MerkleToken token;
 
     private TransactionBody tokenWipeTxn;
     private TokenWipeTransitionLogic subject;
@@ -67,6 +70,7 @@ class TokenWipeTransitionLogicTest {
     private void setup() {
         tokenStore = mock(TokenStore.class);
         accessor = mock(PlatformTxnAccessor.class);
+        token = mock(MerkleToken.class);
 
         txnCtx = mock(TransactionContext.class);
 
@@ -98,6 +102,7 @@ class TokenWipeTransitionLogicTest {
         // then:
         verify(tokenStore).wipe(account, id, wipeAmount, false);
         verify(txnCtx).setStatus(SUCCESS);
+        verify(txnCtx).setNewTotalSupply(totalAmount);
     }
 
     @Test
@@ -173,6 +178,8 @@ class TokenWipeTransitionLogicTest {
         given(accessor.getTxn()).willReturn(tokenWipeTxn);
         given(txnCtx.accessor()).willReturn(accessor);
         given(tokenStore.resolve(id)).willReturn(id);
+        given(tokenStore.get(id)).willReturn(token);
+        given(token.totalSupply()).willReturn(totalAmount);
     }
 
     private void givenMissingToken() {

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenTotalSupplyAfterMintBurnWipeSuite.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenTotalSupplyAfterMintBurnWipeSuite.java
@@ -1,0 +1,144 @@
+package com.hedera.services.bdd.suites.token;
+
+/*-
+ * ‌
+ * Hedera Services Test Clients
+ * ​
+ * Copyright (C) 2018 - 2020 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import com.hedera.services.bdd.spec.HapiApiSpec;
+import com.hedera.services.bdd.suites.HapiApiSuite;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.List;
+
+import static com.hedera.services.bdd.spec.HapiApiSpec.defaultHapiSpec;
+import static com.hedera.services.bdd.spec.queries.QueryVerbs.getAccountBalance;
+import static com.hedera.services.bdd.spec.queries.QueryVerbs.getAccountInfo;
+import static com.hedera.services.bdd.spec.queries.QueryVerbs.getTokenInfo;
+import static com.hedera.services.bdd.spec.queries.QueryVerbs.getTxnRecord;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.burnToken;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoCreate;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoTransfer;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.mintToken;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.tokenAssociate;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.tokenCreate;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.wipeTokenAccount;
+import static com.hedera.services.bdd.spec.transactions.token.TokenMovement.moving;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.newKeyNamed;
+
+public class TokenTotalSupplyAfterMintBurnWipeSuite extends HapiApiSuite {
+	private static final Logger log = LogManager.getLogger(TokenTotalSupplyAfterMintBurnWipeSuite.class);
+
+	private static String TOKEN_TREASURY = "treasury";
+
+	public static void main(String... args) {
+		new TokenTotalSupplyAfterMintBurnWipeSuite().runSuiteSync();
+	}
+
+	@Override
+	protected List<HapiApiSpec> getSpecsInSuite() {
+		return List.of(new HapiApiSpec[] {
+				checkTokenTotalSupplyAfterMintAndBurn(),
+				totalSupplyAfterWipe()
+				}
+		);
+	}
+
+
+	public HapiApiSpec checkTokenTotalSupplyAfterMintAndBurn() {
+		String tokenName = "tokenToTest";
+		return defaultHapiSpec("checkTokenTotalSupplyAfterMintAndBurn")
+				.given(
+						cryptoCreate(TOKEN_TREASURY).balance(0L),
+						cryptoCreate("tokenReceiver").balance(0L),
+						newKeyNamed("adminKey"),
+						newKeyNamed("supplyKey")
+				).when(
+						tokenCreate(tokenName)
+								.treasury(TOKEN_TREASURY)
+								.initialSupply(1000)
+								.decimals(1)
+								.supplyKey("supplyKey")
+								.via("createTxn")
+						).then(
+						getTxnRecord("createTxn").logged(),
+						mintToken(tokenName, 1000).via("mintToken"),
+						getTxnRecord("mintToken").logged(),
+						getTokenInfo(tokenName)
+								.hasTreasury(TOKEN_TREASURY)
+								.hasTotalSupply(2000),
+						burnToken(tokenName, 200).via("burnToken"),
+						getTxnRecord("burnToken").logged(),
+
+						getTokenInfo(tokenName)
+								.logged()
+								.hasTreasury(TOKEN_TREASURY)
+								.hasTotalSupply(1800)
+
+				);
+	}
+
+	public HapiApiSpec totalSupplyAfterWipe() {
+		var tokenToWipe = "tokenToWipe";
+
+		return defaultHapiSpec("totalSupplyAfterWipe")
+				.given(
+						newKeyNamed("wipeKey"),
+						cryptoCreate("assoc1").balance(0L),
+						cryptoCreate("assoc2").balance(0L),
+						cryptoCreate(TOKEN_TREASURY).balance(0L)
+				).when(
+						tokenCreate(tokenToWipe)
+								.name(tokenToWipe)
+								.treasury(TOKEN_TREASURY)
+								.initialSupply(1_000)
+								.wipeKey("wipeKey"),
+						tokenAssociate("assoc1", tokenToWipe),
+						tokenAssociate("assoc2", tokenToWipe),
+						cryptoTransfer(
+								moving(500, tokenToWipe).between(TOKEN_TREASURY, "assoc1")),
+						cryptoTransfer(
+								moving(200, tokenToWipe).between(TOKEN_TREASURY, "assoc2")),
+						getAccountBalance("assoc1")
+								.hasTokenBalance(tokenToWipe, 500),
+						getAccountBalance(TOKEN_TREASURY)
+								.hasTokenBalance(tokenToWipe, 300),
+						getAccountInfo("assoc1").logged(),
+
+						wipeTokenAccount(tokenToWipe, "assoc1", 200)
+								.via("wipeTxn1").logged(),
+						wipeTokenAccount(tokenToWipe, "assoc2", 200)
+								.via("wipeTxn2").logged()
+				).then(
+						getAccountBalance("assoc2")
+								.hasTokenBalance(tokenToWipe, 0),
+						getTokenInfo(tokenToWipe)
+								.hasTotalSupply(600)
+								.hasName(tokenToWipe)
+						.logged(),
+						getAccountBalance(TOKEN_TREASURY)
+								.hasTokenBalance(tokenToWipe, 300)
+				);
+	}
+
+	@Override
+	protected Logger getResultsLogger() {
+		return log;
+	}
+}


### PR DESCRIPTION
**Related issue(s)**:
Closes #645 

**Summary of the change**:
1. Added newTotalSupply in TransactionReceipt for Token mint/burn/wipe transactions if these these transactions are successful;

**External impacts**:
None.

**Applicable documentation**
- [ ] Javadoc
- [X] HAPI protobuf comments
- [ ] README
