### PR TITLE
00784 Special accounts creation

### DIFF
--- a/hedera-node/src/main/java/com/hedera/services/state/initialization/BackedSystemAccountsCreator.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/initialization/BackedSystemAccountsCreator.java
@@ -103,6 +103,13 @@ public class BackedSystemAccountsCreator implements SystemAccountsCreator {
 			}
 		}
 
+		for (long num = 900; num <= 1000; num++) {
+			var id = idWith(num);
+			if (!accounts.contains(id)) {
+				accounts.put(id, accountWith(0, expiry));
+			}
+		}
+
 		var allIds = accounts.idSet();
 		var ledgerFloat = allIds.stream().mapToLong(id -> accounts.getUnsafeRef(id).getBalance()).sum();
 		var msg = String.format("Ledger float is %d tinyBars in %d accounts.", ledgerFloat, allIds.size());

--- a/hedera-node/src/test/java/com/hedera/services/state/initialization/BackedSystemAccountsCreatorTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/state/initialization/BackedSystemAccountsCreatorTest.java
@@ -51,6 +51,7 @@ import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.mock;
 import static org.mockito.Mockito.never;
@@ -209,6 +210,17 @@ class BackedSystemAccountsCreatorTest {
 	}
 
 	@Test
+	public void createsMissingSpecialAccounts() throws NegativeAccountBalanceException{
+		givenMissingSpecialAccounts();
+		given(legacyReader.hexedABytesFrom(b64Loc, legacyId)).willReturn(hexedABytes);
+
+		subject.ensureSystemAccounts(backingAccounts, book);
+
+		verify(backingAccounts).put(accountWith(900), expectedWith(0));
+		verify(backingAccounts).put(accountWith(1000), expectedWith(0));
+	}
+
+	@Test
 	public void createsNothingIfAllPresent() {
 		// setup:
 		BackedSystemAccountsCreator.log = mock(Logger.class);
@@ -233,6 +245,7 @@ class BackedSystemAccountsCreatorTest {
 		given(backingAccounts.contains(accountWith(2L))).willReturn(true);
 		given(backingAccounts.contains(accountWith(3L))).willReturn(true);
 		given(backingAccounts.contains(accountWith(4L))).willReturn(false);
+		givenAllPresentSpecialAccounts();
 	}
 
 	private void givenMissingTreasury() {
@@ -240,6 +253,7 @@ class BackedSystemAccountsCreatorTest {
 		given(backingAccounts.contains(accountWith(2L))).willReturn(false);
 		given(backingAccounts.contains(accountWith(3L))).willReturn(true);
 		given(backingAccounts.contains(accountWith(4L))).willReturn(true);
+		givenAllPresentSpecialAccounts();
 	}
 
 	private void givenMissingNode() {
@@ -247,6 +261,21 @@ class BackedSystemAccountsCreatorTest {
 		given(backingAccounts.contains(accountWith(2L))).willReturn(true);
 		given(backingAccounts.contains(accountWith(3L))).willReturn(false);
 		given(backingAccounts.contains(accountWith(4L))).willReturn(true);
+		givenAllPresentSpecialAccounts();
+	}
+
+	private void givenAllPresentSpecialAccounts() {
+		given(backingAccounts.contains(
+				argThat(accountID -> (900 <= accountID.getAccountNum() && accountID.getAccountNum() <= 1000)))
+		).willReturn(true);
+	}
+
+	private void givenMissingSpecialAccounts() {
+		given(backingAccounts.contains(
+				argThat(accountID -> (accountID.getAccountNum() != 900 && accountID.getAccountNum() != 1000)))
+		).willReturn(true);
+		given(backingAccounts.contains(accountWith(900L))).willReturn(false);
+		given(backingAccounts.contains(accountWith(1000L))).willReturn(false);
 	}
 
 	private AccountID accountWith(long num) {

--- a/hedera-node/src/test/java/com/hedera/services/state/initialization/BackedSystemAccountsCreatorTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/state/initialization/BackedSystemAccountsCreatorTest.java
@@ -279,7 +279,7 @@ class BackedSystemAccountsCreatorTest {
 	}
 
 	private AccountID accountWith(long num) {
-		return IdUtils.asAccount(String.format("1.2.%d", num));
+		return IdUtils.asAccount(String.format("%d.%d.%d", shard, realm, num));
 	}
 
 	private MerkleAccount expectedWith(long balance) throws NegativeAccountBalanceException {

--- a/hedera-node/src/test/java/com/hedera/services/state/initialization/BackedSystemAccountsCreatorTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/state/initialization/BackedSystemAccountsCreatorTest.java
@@ -125,10 +125,10 @@ class BackedSystemAccountsCreatorTest {
 				accountWith(2),
 				accountWith(3),
 				accountWith(4)));
-		given(backingAccounts.getUnsafeRef(accountWith(1))).willReturn(expectedWith(stdBalance));
-		given(backingAccounts.getUnsafeRef(accountWith(2))).willReturn(expectedWith(treasuryBalance));
-		given(backingAccounts.getUnsafeRef(accountWith(3))).willReturn(expectedWith(nodeBalance));
-		given(backingAccounts.getUnsafeRef(accountWith(4))).willReturn(expectedWith(stdBalance));
+		given(backingAccounts.getUnsafeRef(accountWith(1))).willReturn(withExpectedBalance(stdBalance));
+		given(backingAccounts.getUnsafeRef(accountWith(2))).willReturn(withExpectedBalance(treasuryBalance));
+		given(backingAccounts.getUnsafeRef(accountWith(3))).willReturn(withExpectedBalance(nodeBalance));
+		given(backingAccounts.getUnsafeRef(accountWith(4))).willReturn(withExpectedBalance(stdBalance));
 
 		subject = new BackedSystemAccountsCreator(
 				hederaNums,
@@ -180,7 +180,7 @@ class BackedSystemAccountsCreatorTest {
 		subject.ensureSystemAccounts(backingAccounts, book);
 
 		// then:
-		verify(backingAccounts).put(accountWith(3), expectedWith(nodeBalance));
+		verify(backingAccounts).put(accountWith(3), withExpectedBalance(nodeBalance));
 	}
 
 	@Test
@@ -193,7 +193,7 @@ class BackedSystemAccountsCreatorTest {
 		subject.ensureSystemAccounts(backingAccounts, book);
 
 		// then:
-		verify(backingAccounts).put(accountWith(4), expectedWith(stdBalance));
+		verify(backingAccounts).put(accountWith(4), withExpectedBalance(stdBalance));
 	}
 
 	@Test
@@ -206,7 +206,7 @@ class BackedSystemAccountsCreatorTest {
 		subject.ensureSystemAccounts(backingAccounts, book);
 
 		// then:
-		verify(backingAccounts).put(accountWith(2), expectedWith(treasuryBalance));
+		verify(backingAccounts).put(accountWith(2), withExpectedBalance(treasuryBalance));
 	}
 
 	@Test
@@ -216,8 +216,8 @@ class BackedSystemAccountsCreatorTest {
 
 		subject.ensureSystemAccounts(backingAccounts, book);
 
-		verify(backingAccounts).put(accountWith(900), expectedWith(0));
-		verify(backingAccounts).put(accountWith(1000), expectedWith(0));
+		verify(backingAccounts).put(accountWith(900), withExpectedBalance(0));
+		verify(backingAccounts).put(accountWith(1000), withExpectedBalance(0));
 	}
 
 	@Test
@@ -282,7 +282,7 @@ class BackedSystemAccountsCreatorTest {
 		return IdUtils.asAccount(String.format("%d.%d.%d", shard, realm, num));
 	}
 
-	private MerkleAccount expectedWith(long balance) throws NegativeAccountBalanceException {
+	private MerkleAccount withExpectedBalance(long balance) throws NegativeAccountBalanceException {
 		MerkleAccount hAccount = new HederaAccountCustomizer()
 				.isReceiverSigRequired(false)
 				.proxy(EntityId.MISSING_ENTITY_ID)

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/SuiteRunner.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/SuiteRunner.java
@@ -46,6 +46,7 @@ import com.hedera.services.bdd.suites.crypto.CryptoCreateForSuiteRunner;
 import com.hedera.services.bdd.suites.crypto.CryptoCreateSuite;
 import com.hedera.services.bdd.suites.crypto.CryptoDeleteSuite;
 import com.hedera.services.bdd.suites.crypto.CryptoGetInfoRegression;
+import com.hedera.services.bdd.suites.crypto.CryptoTransferSuite;
 import com.hedera.services.bdd.suites.crypto.CryptoUpdateSuite;
 import com.hedera.services.bdd.suites.crypto.QueryPaymentSuite;
 import com.hedera.services.bdd.suites.fees.SpecialAccountsAreExempted;
@@ -252,6 +253,7 @@ public class SuiteRunner {
 		put("TokenManagementSpecs", aof(new TokenManagementSpecs()));
 		put("TokenAssociationSpecs", aof(new TokenAssociationSpecs()));
 		/* Functional tests - CRYPTO */
+		put("CryptoTransferSuite", aof(new CryptoTransferSuite()));
 		put("CryptoDeleteSuite", aof(new CryptoDeleteSuite()));
 		put("CryptoCreateSuite", aof(new CryptoCreateSuite()));
 		put("CryptoUpdateSuite", aof(new CryptoUpdateSuite()));

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoTransferSuite.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoTransferSuite.java
@@ -88,10 +88,10 @@ public class CryptoTransferSuite extends HapiApiSuite {
 							invalidAccountId.set(asTopicString(topicId));
 						})
 				).when().then(
-						cryptoTransfer(spec -> tinyBarsFromTo(GENESIS, invalidAccountId.get(), 1L).apply((spec)))
+						cryptoTransfer(spec -> tinyBarsFromTo(DEFAULT_PAYER, invalidAccountId.get(), 1L).apply((spec)))
 								.hasKnownStatus(INVALID_ACCOUNT_ID),
 						cryptoTransfer(moving(1, "token")
-								.between(spec -> GENESIS, spec -> invalidAccountId.get()))
+								.between(spec -> DEFAULT_PAYER, spec -> invalidAccountId.get()))
 								.hasKnownStatus(INVALID_ACCOUNT_ID)
 				);
 	}

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoTransferSuite.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoTransferSuite.java
@@ -26,18 +26,11 @@ import static com.hedera.services.bdd.spec.HapiPropertySource.asTopicString;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.createTopic;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.tokenCreate;
 import static com.hedera.services.bdd.spec.transactions.token.TokenMovement.moving;
-import static com.hedera.services.bdd.spec.utilops.CustomSpecAssert.allRunFor;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.withOpContext;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_ACCOUNT_ID;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SUCCESS;
 import static com.hedera.services.bdd.spec.assertions.AccountInfoAsserts.accountWith;
-import static com.hedera.services.bdd.spec.assertions.AccountInfoAsserts.approxChangeFromSnapshot;
-import static com.hedera.services.bdd.spec.assertions.AccountInfoAsserts.changeFromSnapshot;
-import static com.hedera.services.bdd.spec.assertions.TransactionRecordAsserts.*;
 
-import static com.hedera.services.bdd.spec.assertions.TransferListAsserts.*;
-
-import com.hedera.services.bdd.spec.HapiPropertySource;
 import com.hedera.services.bdd.spec.HapiSpecOperation;
 import com.hedera.services.bdd.spec.HapiSpecSetup;
 
@@ -50,16 +43,11 @@ import static com.hedera.services.bdd.spec.keys.ControlForKey.*;
 
 import com.hedera.services.bdd.spec.keys.KeyShape;
 import com.hedera.services.bdd.spec.keys.SigControl;
-import com.hedera.services.bdd.spec.transactions.crypto.HapiCryptoTransfer;
-import com.hedera.services.bdd.spec.transactions.token.TokenMovement;
-import com.hedera.services.bdd.spec.utilops.CustomSpecAssert;
 import com.hedera.services.bdd.spec.utilops.UtilVerbs;
 import com.hedera.services.bdd.suites.HapiApiSuite;
-import com.hederahashgraph.api.proto.java.AccountID;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.IntStream;
@@ -93,7 +81,7 @@ public class CryptoTransferSuite extends HapiApiSuite {
 
 		return defaultHapiSpec("TransferToTopicReturnsInvalidAccountId")
 				.given(
-						tokenCreate("any"),
+						tokenCreate("token"),
 						createTopic("something"),
 						withOpContext((spec, opLog) -> {
 							var topicId = spec.registry().getTopicID("something");
@@ -102,7 +90,7 @@ public class CryptoTransferSuite extends HapiApiSuite {
 				).when().then(
 						cryptoTransfer(spec -> tinyBarsFromTo(GENESIS, invalidAccountId.get(), 1L).apply((spec)))
 								.hasKnownStatus(INVALID_ACCOUNT_ID),
-						cryptoTransfer(moving(1, "any")
+						cryptoTransfer(moving(1, "token")
 								.between(spec -> GENESIS, spec -> invalidAccountId.get()))
 								.hasKnownStatus(INVALID_ACCOUNT_ID)
 				);

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoTransferSuite.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoTransferSuite.java
@@ -70,7 +70,7 @@ public class CryptoTransferSuite extends HapiApiSuite {
 						vanillaTransferSucceeds(),
 						complexKeyAcctPaysForOwnTransfer(),
 						twoComplexKeysRequired(),
-						systemBalancesCheck(),
+						specialAccountsBalanceCheck(),
 						transferToTopicReturnsInvalidAccountId(),
 				}
 		);
@@ -144,10 +144,10 @@ public class CryptoTransferSuite extends HapiApiSuite {
 				);
 	}
 
-	private HapiApiSpec systemBalancesCheck() {
-		return defaultHapiSpec("SystemBalancesCheck")
+	private HapiApiSpec specialAccountsBalanceCheck() {
+		return defaultHapiSpec("SpecialAccountsBalanceCheck")
 				.given().when().then(
-						IntStream.range(1, 101)
+						IntStream.concat(IntStream.range(1, 101), IntStream.range(900, 1001))
 								.mapToObj(i -> getAccountBalance("0.0." + i).logged())
 								.toArray(n -> new HapiSpecOperation[n])
 				);


### PR DESCRIPTION
**Related issue(s)**:
Closes #784

**External impacts**:
Special accounts from 900 to 1000 will be created with zero balance and genesis key if they don't exist.
Note that no records will be created for the creation of these special accounts.