### PR TITLE
Add some run/gcr* helper scripts; roll TAG in .env to 0.10.0 

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,2 @@
-TAG=0.7.0-alpha
+TAG=0.10.0
 REGISTRY_PREFIX=gcr.io/hedera-registry/

--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ hs_err_pid*
 *.sh
 !run/generate-changelog.sh
 !run/new-release-branch.sh
+!run/gcr-*.sh
 !hapi-proto/add-copyright.sh
 !hapi-proto/gen-proto-docs.sh
 !hedera-node/data/backup/*.sh

--- a/compose-build.sh
+++ b/compose-build.sh
@@ -1,5 +1,7 @@
 #! /bin/sh
-GIT_TAG=$(git describe --tags --always --dirty)
+DEFAULT_TAG=$(git describe --tags --always --dirty)
+GIT_TAG=${1:-"$DEFAULT_TAG"}
+echo $GIT_TAG
 echo "TAG=$GIT_TAG" > .env
 echo "REGISTRY_PREFIX=" >> .env
 docker build -t services-node:${GIT_TAG} .

--- a/run/gcr-login.sh
+++ b/run/gcr-login.sh
@@ -1,0 +1,9 @@
+#! /bin/sh
+if [ $# -lt 1 ]; then
+  echo "USAGE: $0 <JSON keyfile>"
+  exit 1
+fi
+
+KEYFILE_JSON=$1
+cat $KEYFILE_JSON | \
+  docker login -u _json_key --password-stdin https://gcr.io

--- a/run/gcr-push.sh
+++ b/run/gcr-push.sh
@@ -1,0 +1,8 @@
+#! /bin/sh
+if [ $# -lt 1 ]; then
+  echo "USAGE: $0 <tag>"
+  exit 1
+fi
+
+TAG=$1
+docker push gcr.io/hedera-registry/services-node:$TAG

--- a/run/gcr-tag.sh
+++ b/run/gcr-tag.sh
@@ -1,0 +1,8 @@
+#! /bin/sh
+if [ $# -lt 1 ]; then
+  echo "USAGE: $0 <local tag>"
+  exit 1
+fi
+
+TAG=$1
+docker tag services-node:$TAG gcr.io/hedera-registry/services-node:$TAG


### PR DESCRIPTION
**Related issue(s)**:
- Addresses #532 (will close pending secondary confirmation of new Docker image)

**Summary of the change**:
Update `TAG=0.10.0` in _.env_ so default `docker-compose up` will use the `gcr.io/hedera-registry/services-node:0.10.0` image.
