### PR TITLE
Fix S3 Upload

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1946,7 +1946,8 @@ jobs:
       - run:
           name: Sync results of update node tests to AWS
           command: |
-            aws s3 sync /swirlds-platform/regression/results/5N_1C/Update/ s3://hedera-service-regression-jrs --include '*' --exclude "*/data/*";
+            cd /swirlds-platform/regression/results/5N_1C/Update/; find . -type d -name data -prune -exec rm -rf {} \;
+            aws s3 sync /swirlds-platform/regression/results/5N_1C/Update/ s3://hedera-service-regression-jrs;
             tar -czvf /results.tar.gz  /swirlds-platform/regression/results/5N_1C/Update/*
 
       - store_artifacts:
@@ -1970,7 +1971,8 @@ jobs:
       - run:
           name: Sync results of performance regression to AWS
           command: |
-            aws s3 sync /swirlds-platform/regression/results/4N_4C/Performance/ s3://hedera-service-regression-jrs --include '*' --exclude "*/data/*";
+            cd /swirlds-platform/regression/results/4N_4C/Performance/; find . -type d -name data -prune -exec rm -rf {} \;
+            aws s3 sync /swirlds-platform/regression/results/4N_4C/Performance/ s3://hedera-service-regression-jrs;
             tar -czvf /results.tar.gz  /swirlds-platform/regression/results/4N_4C/Performance/*
 
       - store_artifacts:
@@ -1994,7 +1996,8 @@ jobs:
       - run:
           name: Sync results of network error regression to AWS
           command: |
-            aws s3 sync /swirlds-platform/regression/results/4N_1C/NetError/ s3://hedera-service-regression-jrs --include '*' --exclude "*/data/*";
+            cd /swirlds-platform/regression/results/4N_1C/NetError/; find . -type d -name data -prune -exec rm -rf {} \;
+            aws s3 sync /swirlds-platform/regression/results/4N_1C/NetError/ s3://hedera-service-regression-jrs;
             tar -czvf /results.tar.gz  /swirlds-platform/regression/results/4N_1C/NetError/*
 
       - store_artifacts:
@@ -2028,7 +2031,8 @@ jobs:
       - run:
           name: Sync results of public testnet migration test to AWS
           command: |
-            aws s3 sync /swirlds-platform/regression/results/4N_1C/Migration/ s3://hedera-service-regression-jrs --include '*' --exclude "*/data/*";
+            cd /swirlds-platform/regression/results/4N_1C/Migration/; find . -type d -name data -prune -exec rm -rf {} \;
+            aws s3 sync /swirlds-platform/regression/results/4N_1C/Migration/ s3://hedera-service-regression-jrs;
             tar -czvf /results.tar.gz  /swirlds-platform/regression/results/4N_1C/Migration/*
 
       - store_artifacts:
@@ -2059,7 +2063,8 @@ jobs:
       - run:
           name: Sync results of mainnet migration test to AWS
           command: |
-            aws s3 sync /swirlds-platform/regression/results/ s3://hedera-service-regression-jrs --include '*' --exclude "*/data/*";
+            cd /swirlds-platform/regression/results/; find . -type d -name data -prune -exec rm -rf {} \;
+            aws s3 sync /swirlds-platform/regression/results/ s3://hedera-service-regression-jrs;
             tar -czvf /results.tar.gz  /swirlds-platform/regression/results/*
 
       - store_artifacts:
@@ -2083,7 +2088,8 @@ jobs:
       - run:
           name: Sync results of software update regression to AWS
           command: |
-            aws s3 sync /swirlds-platform/regression/results/4N_1C/Restart/ s3://hedera-service-regression-jrs --include '*' --exclude "*/data/*";
+            cd /swirlds-platform/regression/results/4N_1C/Restart/; find . -type d -name data -prune -exec rm -rf {} \;
+            aws s3 sync /swirlds-platform/regression/results/4N_1C/Restart/ s3://hedera-service-regression-jrs;
             tar -czvf /results.tar.gz  /swirlds-platform/regression/results/4N_1C/Restart/*
 
       - store_artifacts:
@@ -2107,7 +2113,8 @@ jobs:
       - run:
           name: Sync results of state recover regression to AWS
           command: |
-            aws s3 sync /swirlds-platform/regression/results/4N_1C/Recovery/ s3://hedera-service-regression-jrs --include '*' --exclude "*/data/*";
+            cd /swirlds-platform/regression/results/4N_1C/Recovery/; find . -type d -name data -prune -exec rm -rf {} \;
+            aws s3 sync /swirlds-platform/regression/results/4N_1C/Recovery/ s3://hedera-service-regression-jrs;
             tar -czvf /results.tar.gz  /swirlds-platform/regression/results/4N_1C/Recovery/*
 
       - store_artifacts:
@@ -2136,7 +2143,8 @@ jobs:
       - run:
           name: Sync results of software update regression to AWS
           command: |
-            aws s3 sync /swirlds-platform/regression/results/6N_6C/Performance/ s3://hedera-service-regression-jrs --include '*' --exclude "*/data/*";
+            cd /swirlds-platform/regression/results/6N_6C/Performance/; find . -type d -name data -prune -exec rm -rf {} \;
+            aws s3 sync /swirlds-platform/regression/results/6N_6C/Performance/ s3://hedera-service-regression-jrs;
             tar -czvf /results.tar.gz  /swirlds-platform/regression/results/6N_6C/Performance/*
 
       - store_artifacts:
@@ -2160,7 +2168,8 @@ jobs:
       - run:
           name: Sync results of reconnect regression to AWS
           command: |
-            aws s3 sync /swirlds-platform/regression/results/4N_1C/Reconnect/ s3://hedera-service-regression-jrs --include '*' --exclude "*/data/*";
+            cd /swirlds-platform/regression/results/4N_1C/Reconnect/; find . -type d -name data -prune -exec rm -rf {} \;
+            aws s3 sync /swirlds-platform/regression/results/4N_1C/Reconnect/ s3://hedera-service-regression-jrs;
             tar -czvf /results.tar.gz  /swirlds-platform/regression/results/4N_1C/Reconnect/*
 
       - store_artifacts:
@@ -2194,7 +2203,8 @@ jobs:
       - run:
           name: Sync results of software update regression to AWS
           command: |
-            aws s3 sync /swirlds-platform/regression/results/15N_15C/ s3://hedera-service-regression-jrs --include '*' --exclude "*/data/*";
+            cd /swirlds-platform/regression/results/15N_15C/; find . -type d -name data -prune -exec rm -rf {} \;
+            aws s3 sync /swirlds-platform/regression/results/15N_15C/ s3://hedera-service-regression-jrs;
             tar -czvf /results.tar.gz  /swirlds-platform/regression/results/15N_15C/*
 
       - store_artifacts:
@@ -2228,7 +2238,8 @@ jobs:
       - run:
           name: Sync results of software update regression to AWS
           command: |
-            aws s3 sync /swirlds-platform/regression/results/15N_15C/ s3://hedera-service-regression-jrs --include '*' --exclude "*/data/*";
+            cd /swirlds-platform/regression/results/15N_15C/; find . -type d -name data -prune -exec rm -rf {} \;
+            aws s3 sync /swirlds-platform/regression/results/15N_15C/ s3://hedera-service-regression-jrs;
             tar -czvf /results.tar.gz  /swirlds-platform/regression/results/15N_15C/*
 
       - store_artifacts:


### PR DESCRIPTION
Using the  `--include` and `--exclude` flags are still taking time to upload though they are not uploading data/saved folder to s3.
So we are deleting the folder before uploading to s3.