### PR TITLE
Move tests on 0.10.0 to run on GCP

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -941,7 +941,7 @@ workflows:
   GCP-Daily-Services-Crypto-Update-5N-1C:
     triggers:
       - schedule:
-          cron: "35 5 * * *"
+          cron: "30 3 * * *"
           filters:
             branches:
               only:
@@ -982,11 +982,11 @@ workflows:
   GCP-Weekly-Services-Crypto-Restart-Performance-15N-15C:
     triggers:
       - schedule:
-          cron: "5 6 * * 6,0"
+          cron: "5 5 * * 6,0"
           filters:
             branches:
               only:
-                - rel-v0.10.0
+                - master
     jobs:
       - build-platform-and-services
       - weekly-run-crypto-transfer-start-from-saved-state-regression:
@@ -1023,11 +1023,11 @@ workflows:
   GCP-Weekly-Services-HCS-Restart-Performance-15N-15C:
     triggers:
       - schedule:
-          cron: "5 11 * * 6,0"
+          cron: "5 10 * * 6,0"
           filters:
             branches:
               only:
-                - rel-v0.10.0
+                - master
     jobs:
       - build-platform-and-services
       - weekly-run-HCS-start-from-saved-state-regression:
@@ -1064,7 +1064,7 @@ workflows:
   GCP-Daily-Services-Comp-NetError-4N-1C:
     triggers:
       - schedule:
-          cron: "20 6 * * *"
+          cron: "15 4 * * *"
           filters:
             branches:
               only:
@@ -1107,11 +1107,11 @@ workflows:
   GCP-Daily-Services-Crypto-Migration-4N-1C:
     triggers:
       - schedule:
-          cron: "35 5 * * *"
+          cron: "45 5 * * *"
           filters:
             branches:
               only:
-                - master
+                - rel-v0.10.0
     jobs:
       - build-platform-and-services
       - run-testnet-migration-regression:
@@ -1171,7 +1171,7 @@ workflows:
   GCP-Daily-Services-Crypto-Restart-4N-1C:
     triggers:
       - schedule:
-          cron: "5 7 * * *"
+          cron: "30 6 * * *"
           filters:
             branches:
               only:
@@ -1212,7 +1212,7 @@ workflows:
   GCP-Daily-Services-Recovery-4N-1C:
     triggers:
       - schedule:
-          cron: "35 7 * * *"
+          cron: "5 6 * * *"
           filters:
             branches:
               only:
@@ -1257,7 +1257,7 @@ workflows:
           filters:
             branches:
               only:
-                - master
+                - Disable-master
     jobs:
       - build-platform-and-services
       - run-performance-regression:
@@ -1300,7 +1300,7 @@ workflows:
           filters:
             branches:
               only:
-                - master
+                - Disable-master
     jobs:
       - build-platform-and-services
       - run-start-from-saved-state-regression:
@@ -1317,7 +1317,7 @@ workflows:
   GCP-Daily-Services-Comp-Basic-Performance-4N-4C:
     triggers:
       - schedule:
-          cron: "30 7 * * *"
+          cron: "30 6 * * *"
           filters:
             branches:
               only:
@@ -1338,7 +1338,7 @@ workflows:
   GCP-Daily-Services-Comp-Basic-HCS-Performance-4N-4C:
     triggers:
       - schedule:
-          cron: "30 11 * * *"
+          cron: "30 7 * * *"
           filters:
             branches:
               only:
@@ -1420,11 +1420,11 @@ workflows:
   GCP-Daily-Services-Comp-Reconnect-4N-1C:
     triggers:
       - schedule:
-          cron: "5 7 * * *"
+          cron: "0 10 * * *"
           filters:
             branches:
               only:
-                - master
+                - rel-v0.10.0
     jobs:
       - build-platform-and-services
       - run-reconnect-regression:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -941,7 +941,7 @@ workflows:
   GCP-Daily-Services-Crypto-Update-5N-1C:
     triggers:
       - schedule:
-          cron: "30 3 * * *"
+          cron: "45 4 * * *"
           filters:
             branches:
               only:
@@ -1064,7 +1064,7 @@ workflows:
   GCP-Daily-Services-Comp-NetError-4N-1C:
     triggers:
       - schedule:
-          cron: "15 4 * * *"
+          cron: "30 5 * * *"
           filters:
             branches:
               only:
@@ -1171,7 +1171,7 @@ workflows:
   GCP-Daily-Services-Crypto-Restart-4N-1C:
     triggers:
       - schedule:
-          cron: "30 6 * * *"
+          cron: "15 6 * * *"
           filters:
             branches:
               only:
@@ -1212,7 +1212,7 @@ workflows:
   GCP-Daily-Services-Recovery-4N-1C:
     triggers:
       - schedule:
-          cron: "5 6 * * *"
+          cron: "45 6 * * *"
           filters:
             branches:
               only:
@@ -1317,7 +1317,7 @@ workflows:
   GCP-Daily-Services-Comp-Basic-Performance-4N-4C:
     triggers:
       - schedule:
-          cron: "30 6 * * *"
+          cron: "45 6 * * *"
           filters:
             branches:
               only:
@@ -1338,7 +1338,7 @@ workflows:
   GCP-Daily-Services-Comp-Basic-HCS-Performance-4N-4C:
     triggers:
       - schedule:
-          cron: "30 7 * * *"
+          cron: "40 10 * * *"
           filters:
             branches:
               only:
@@ -1358,7 +1358,7 @@ workflows:
   GCP-Daily-Services-Comp-Restart-Performance-6N-6C:
     triggers:
       - schedule:
-          cron: "35 6 * * *"
+          cron: "45 6 * * *"
           filters:
             branches:
               only:
@@ -1378,7 +1378,7 @@ workflows:
   GCP-Daily-Services-Comp-Restart-HTS-Performance-6N-6C:
     triggers:
       - schedule:
-          cron: "39 0 * * *"
+          cron: "49 0 * * *"
           filters:
             branches:
               only:
@@ -1420,7 +1420,7 @@ workflows:
   GCP-Daily-Services-Comp-Reconnect-4N-1C:
     triggers:
       - schedule:
-          cron: "0 10 * * *"
+          cron: "15 7 * * *"
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -920,11 +920,11 @@ workflows:
   AWS-Daily-Services-Crypto-Update-5N-1C:
     triggers:
       - schedule:
-          cron: "30 3 * * *"
+          cron: "30 4 * * *"
           filters:
             branches:
               only:
-                - rel-v0.10.0
+                - Disable-master
     jobs:
       - build-platform-and-services
       - run-update-node-tests:
@@ -941,11 +941,11 @@ workflows:
   GCP-Daily-Services-Crypto-Update-5N-1C:
     triggers:
       - schedule:
-          cron: "35 4 * * *"
+          cron: "35 5 * * *"
           filters:
             branches:
               only:
-                - master
+                - rel-v0.10.0
     jobs:
       - build-platform-and-services
       - run-update-node-tests:
@@ -965,7 +965,7 @@ workflows:
           filters:
             branches:
               only:
-                - master
+                - Disable-master
     jobs:
       - build-platform-and-services
       - weekly-run-crypto-transfer-start-from-saved-state-regression:
@@ -982,11 +982,11 @@ workflows:
   GCP-Weekly-Services-Crypto-Restart-Performance-15N-15C:
     triggers:
       - schedule:
-          cron: "5 5 * * 6,0"
+          cron: "5 6 * * 6,0"
           filters:
             branches:
               only:
-                - master
+                - rel-v0.10.0
     jobs:
       - build-platform-and-services
       - weekly-run-crypto-transfer-start-from-saved-state-regression:
@@ -1006,7 +1006,7 @@ workflows:
           filters:
             branches:
               only:
-                - master
+                - Disable-master
     jobs:
       - build-platform-and-services
       - weekly-run-HCS-start-from-saved-state-regression:
@@ -1023,11 +1023,11 @@ workflows:
   GCP-Weekly-Services-HCS-Restart-Performance-15N-15C:
     triggers:
       - schedule:
-          cron: "5 10 * * 6,0"
+          cron: "5 11 * * 6,0"
           filters:
             branches:
               only:
-                - master
+                - rel-v0.10.0
     jobs:
       - build-platform-and-services
       - weekly-run-HCS-start-from-saved-state-regression:
@@ -1043,11 +1043,11 @@ workflows:
   AWS-Daily-Services-Comp-NetError-4N-1C:
     triggers:
       - schedule:
-          cron: "15 4 * * *"
+          cron: "15 5 * * *"
           filters:
             branches:
               only:
-                - rel-v0.10.0
+                - Disable-master
     jobs:
       - build-platform-and-services
       - run-network-error-regression:
@@ -1064,11 +1064,11 @@ workflows:
   GCP-Daily-Services-Comp-NetError-4N-1C:
     triggers:
       - schedule:
-          cron: "20 5 * * *"
+          cron: "20 6 * * *"
           filters:
             branches:
               only:
-                - master
+                - rel-v0.10.0
     jobs:
       - build-platform-and-services
       - run-network-error-regression:
@@ -1085,11 +1085,11 @@ workflows:
   AWS-Daily-Services-Crypto-Migration-4N-1C:
     triggers:
           - schedule:
-              cron: "45 5 * * *"
+              cron: "30 5 * * *"
               filters:
                 branches:
                   only:
-                    - rel-v0.10.0
+                    - Disable-master
     jobs:
       - build-platform-and-services
       - run-testnet-migration-regression:
@@ -1150,11 +1150,11 @@ workflows:
   AWS-Daily-Services-Crypto-Restart-4N-1C:
     triggers:
       - schedule:
-          cron: "30 6 * * *"
+          cron: "0 6 * * *"
           filters:
             branches:
               only:
-                - rel-v0.10.0
+                - Disable-master
     jobs:
       - build-platform-and-services
       - run-software-update-regression:
@@ -1171,11 +1171,11 @@ workflows:
   GCP-Daily-Services-Crypto-Restart-4N-1C:
     triggers:
       - schedule:
-          cron: "5 6 * * *"
+          cron: "5 7 * * *"
           filters:
             branches:
               only:
-                - master
+                - rel-v0.10.0
     jobs:
       - build-platform-and-services
       - run-software-update-regression:
@@ -1195,7 +1195,7 @@ workflows:
           filters:
             branches:
               only:
-                - rel-v0.10.0
+                - Disable-master
     jobs:
       - build-platform-and-services
       - run-state-recover-regression:
@@ -1212,11 +1212,11 @@ workflows:
   GCP-Daily-Services-Recovery-4N-1C:
     triggers:
       - schedule:
-          cron: "35 6 * * *"
+          cron: "35 7 * * *"
           filters:
             branches:
               only:
-                - master
+                - rel-v0.10.0
     jobs:
       - build-platform-and-services
       - run-state-recover-regression:
@@ -1232,11 +1232,11 @@ workflows:
   AWS-Daily-Services-Comp-Basic-Performance-4N-4C:
     triggers:
       - schedule:
-          cron: "30 7 * * *"
+          cron: "30 6 * * *"
           filters:
             branches:
               only:
-                - rel-v0.10.0
+                - Disable-master
     jobs:
       - build-platform-and-services
       - run-performance-regression:
@@ -1257,8 +1257,7 @@ workflows:
           filters:
             branches:
               only:
-                - rel-v0.10.0
-
+                - master
     jobs:
       - build-platform-and-services
       - run-performance-regression:
@@ -1279,7 +1278,8 @@ workflows:
           filters:
             branches:
               only:
-                - rel-v0.10.0
+                - Disable-master
+
     jobs:
       - build-platform-and-services
       - run-start-from-saved-state-regression:
@@ -1300,7 +1300,7 @@ workflows:
           filters:
             branches:
               only:
-                - rel-v0.10.0
+                - master
     jobs:
       - build-platform-and-services
       - run-start-from-saved-state-regression:
@@ -1317,11 +1317,11 @@ workflows:
   GCP-Daily-Services-Comp-Basic-Performance-4N-4C:
     triggers:
       - schedule:
-          cron: "35 6 * * *"
+          cron: "30 7 * * *"
           filters:
             branches:
               only:
-                - master
+                - rel-v0.10.0
     jobs:
       - build-platform-and-services
       - run-performance-regression:
@@ -1338,11 +1338,11 @@ workflows:
   GCP-Daily-Services-Comp-Basic-HCS-Performance-4N-4C:
     triggers:
       - schedule:
-          cron: "30 10 * * *"
+          cron: "30 11 * * *"
           filters:
             branches:
               only:
-                - master
+                - rel-v0.10.0
     jobs:
       - build-platform-and-services
       - run-performance-regression:
@@ -1362,7 +1362,7 @@ workflows:
           filters:
             branches:
               only:
-                - master
+                - rel-v0.10.0
     jobs:
       - build-platform-and-services
       - run-start-from-saved-state-regression:
@@ -1382,8 +1382,7 @@ workflows:
           filters:
             branches:
               only:
-#                - master
-                - 00862-D-split-perf-tests
+                - rel-v0.10.0
 
     jobs:
       - build-platform-and-services
@@ -1400,11 +1399,11 @@ workflows:
   AWS-Daily-Services-Comp-Reconnect-4N-1C:
     triggers:
       - schedule:
-          cron: "0 10 * * *"
+          cron: "0 7 * * *"
           filters:
             branches:
               only:
-                - rel-v0.10.0
+                - Disable-master
     jobs:
       - build-platform-and-services
       - run-reconnect-regression:


### PR DESCRIPTION
All regression tests on master runs on GCP. Move all tests that run on v0.10.0 release tag to run on GCP instead of AWS.