### PR TITLE
Add use name and key file location to fix updated node test

### DIFF
--- a/test-clients/scripts/updateNodeTransfer.sh
+++ b/test-clients/scripts/updateNodeTransfer.sh
@@ -8,16 +8,18 @@ UPDATE_NODE_IP_ADDRESS=""
 NODE0_IP_ADDRESS=""
 CONFIG_FILE_PATH=""
 copyFilesToUpdateNode() {
+  USER=$1
+  KEY_FILE=$2
   # copy config.txt , File0.0.150 and saved state to update nodes to start from the state
   set -x
-  scp -o StrictHostKeyChecking=no -i services-regression.pem -p $CONFIG_FILE_PATH ubuntu@$UPDATE_NODE_IP_ADDRESS:/home/ubuntu/remoteExperiment >> shell.log 2>&1
+  scp -o StrictHostKeyChecking=no -i $KEY_FILE -p $CONFIG_FILE_PATH $USER@$UPDATE_NODE_IP_ADDRESS:/home/$USER/remoteExperiment >> shell.log 2>&1
   echo "Copying config.txt to the update Node" >> shell.log 2>&1
-  ssh -t -t -o StrictHostKeyChecking=no  -i services-regression.pem  ubuntu@$UPDATE_NODE_IP_ADDRESS "mkdir -p  /home/ubuntu/remoteExperiment/data/diskFs/0.0.7" >> shell.log 2>&1
-  scp -o StrictHostKeyChecking=no -i services-regression.pem -r -p data/diskFs/0.0.3/* ubuntu@$UPDATE_NODE_IP_ADDRESS:/home/ubuntu/remoteExperiment/data/diskFs/0.0.7 >> shell.log 2>&1
+  ssh -t -t -o StrictHostKeyChecking=no  -i $KEY_FILE  $USER@$UPDATE_NODE_IP_ADDRESS "mkdir -p  /home/$USER/remoteExperiment/data/diskFs/0.0.7" >> shell.log 2>&1
+  scp -o StrictHostKeyChecking=no -i $KEY_FILE -r -p data/diskFs/0.0.3/* $USER@$UPDATE_NODE_IP_ADDRESS:/home/$USER/remoteExperiment/data/diskFs/0.0.7 >> shell.log 2>&1
   echo "Copying File0.0.150 to the update Node" >> shell.log 2>&1
-  ssh -t -t -o StrictHostKeyChecking=no  -i services-regression.pem  ubuntu@$UPDATE_NODE_IP_ADDRESS "mkdir -p  /home/ubuntu/remoteExperiment/data/saved/com.hedera.services.ServicesMain/4/" >> shell.log 2>&1
-  scp -o StrictHostKeyChecking=no -i services-regression.pem -r -p data/saved/com.hedera.services.ServicesMain/0/123/ \
-    ubuntu@$UPDATE_NODE_IP_ADDRESS:~/remoteExperiment/data/saved/com.hedera.services.ServicesMain/4/  >> shell.log 2>&1
+  ssh -t -t -o StrictHostKeyChecking=no  -i $KEY_FILE  $USER@$UPDATE_NODE_IP_ADDRESS "mkdir -p  /home/$USER/remoteExperiment/data/saved/com.hedera.services.ServicesMain/4/" >> shell.log 2>&1
+  scp -o StrictHostKeyChecking=no -i $KEY_FILE -r -p data/saved/com.hedera.services.ServicesMain/0/123/ \
+    $USER@$UPDATE_NODE_IP_ADDRESS:~/remoteExperiment/data/saved/com.hedera.services.ServicesMain/4/  >> shell.log 2>&1
   echo "Copying saved state files to the update Node"  >> shell.log 2>&1
 }
 
@@ -32,4 +34,4 @@ parseNewConfig() {
 }
 
 parseNewConfig
-copyFilesToUpdateNode
+copyFilesToUpdateNode $1 $2


### PR DESCRIPTION

**Related issue(s)**:
Related with regression issue https://github.com/swirlds/swirlds-platform-regression/pull/755

**Summary of the change**:
Replacing hard coded user name and key file with command line parameter

