### PR TITLE
Property ledger.keepRecordsInState is set to true by default.

### DIFF
--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/records/RecordCreationSuite.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/records/RecordCreationSuite.java
@@ -60,6 +60,9 @@ public class RecordCreationSuite extends HapiApiSuite {
 				.given(
 						cryptoCreate("payer")
 				).when(
+						fileUpdate(APP_PROPERTIES)
+								.payingWith(ADDRESS_BOOK_CONTROL)
+								.overridingProps(Map.of("ledger.keepRecordsInState", "false")),
 						cryptoTransfer(
 								tinyBarsFromTo(GENESIS, FUNDING, 1_000L)
 						).payingWith("payer").via("firstXfer"),
@@ -71,10 +74,7 @@ public class RecordCreationSuite extends HapiApiSuite {
 						cryptoTransfer(
 								tinyBarsFromTo(GENESIS, FUNDING, 1_000L)
 						).payingWith("payer").via("secondXfer"),
-						getAccountRecords("payer").has(inOrder(recordWith().txnId("secondXfer"))),
-						fileUpdate(APP_PROPERTIES)
-								.payingWith(ADDRESS_BOOK_CONTROL)
-								.overridingProps(Map.of("ledger.keepRecordsInState", "false"))
+						getAccountRecords("payer").has(inOrder(recordWith().txnId("secondXfer")))
 				);
 	}
 


### PR DESCRIPTION
set the property ledger.keepRecordsInState before the tests as it is being set to true at startUp on every regression run.

Signed-off-by: Anirudh Ghanta <anirudh.ghanta@hedera.com>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `0<issue number>-<target branch>-<summary>`
-->

**Related issue(s)**:
Closes #898 

**Summary of the change**:
Set ledger.keepRecordsInState=false before the test `accountsGetPayerRecordsIfSoConfigured`.

**External impacts**:
None.

**Applicable documentation**
- [ ] Javadoc
- [ ] HAPI protobuf comments
- [ ] README
