### PR TITLE
Fix ValidateDuplicateTransactionAfterReconnect to set ledger.keepRecordsInState as true 

### DIFF
--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/reconnect/ValidateDuplicateTransactionAfterReconnect.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/reconnect/ValidateDuplicateTransactionAfterReconnect.java
@@ -34,6 +34,7 @@ import java.util.concurrent.TimeUnit;
 import static com.hedera.services.bdd.spec.HapiApiSpec.customHapiSpec;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getAccountBalance;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoCreate;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.fileUpdate;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.sleepFor;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.withLiveNode;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.DUPLICATE_TRANSACTION;
@@ -62,7 +63,10 @@ public class ValidateDuplicateTransactionAfterReconnect extends HapiApiSuite {
 						sleepFor(Duration.ofSeconds(25).toMillis()),
 						getAccountBalance(GENESIS)
 								.setNode("0.0.6")
-								.unavailableNode()
+								.unavailableNode(),
+						fileUpdate(APP_PROPERTIES)
+								.payingWith(ADDRESS_BOOK_CONTROL)
+								.overridingProps(Map.of("ledger.keepRecordsInState", "true"))
 				)
 				.when(
 						cryptoCreate("repeatedTransaction")


### PR DESCRIPTION
**Related issue(s)**:
Closes #936 

Related regression PR : https://github.com/swirlds/swirlds-platform-regression/pull/765
**Summary of the change**:
Instead of setting `ledger.keepRecordsInState` as true for all the tests in regression, set the value to true for `ValidateDuplicateTransactionAfterReconnect` as it is needed for the test `TransactionHistory-Reconnect-1-12m.json`

Passed Reconnect test : 
`TransactionHistory-Reconnect-1-12m` : https://hedera-hashgraph.slack.com/archives/C018CBQBTGB/p1609954937441200
Passed other reconnect tests : https://hedera-hashgraph.slack.com/archives/C018CBQBTGB/p1609953504440500
