### PR TITLE
Improve build portability; add psql to image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,18 +4,10 @@
 ##  * Configuration from /opt/hedera/services/config-mount; and, 
 ##  * Logs at /opt/hedera/services/output; and, 
 ##  * Saved states under /opt/hedera/services/output
-FROM ubuntu:18.04 AS base-runtime
+FROM ubuntu:20.10 AS base-runtime
 RUN apt-get update && \
     apt-get upgrade -y && \
-    apt-get install -y wget dos2unix openssl
-RUN cd /tmp && \
-    wget --quiet https://jvm-storage.s3.amazonaws.com/openjdk-12.0.2_linux-x64_bin.tar.gz && \
-    mkdir -p /usr/local/java && \
-    tar -zxf openjdk-12.0.2_linux-x64_bin.tar.gz -C /usr/local/java && \
-    update-alternatives --install "/usr/bin/java" "java" "/usr/local/java/jdk-12.0.2/bin/java" 1500 && \
-    update-alternatives --install "/usr/bin/javac" "javac" "/usr/local/java/jdk-12.0.2/bin/javac" 1500 && \
-    update-alternatives --install "/usr/bin/javadoc" "javadoc" "/usr/local/java/jdk-12.0.2/bin/javadoc" 1500 && \
-    rm -f /tmp/jdk-12.0.2_linux-x64_bin.tar.gz
+    apt-get install -y dos2unix openssl openjdk-15-jdk libsodium23 postgresql-client
 # Services runtime
 RUN mkdir -p /opt/hedera/services/data/lib
 RUN mkdir -p /opt/hedera/services/data/backup

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,7 +36,6 @@ services:
   postgres:
     container_name: hedera-postgres
     image: postgres:10.9-alpine
-    stop_grace_period: 2m
     environment:
       - POSTGRES_PASSWORD=password
       - POSTGRES_USER=swirlds


### PR DESCRIPTION
**Summary of the change**:
- @mark-hedera surfaced a problem when building the Docker image on a Raspberry PI 4 (`libsodium` was missing); he also provided this fix. 
- Install `postgresql-client` so that database recovery from a _PostgresBackup.tar.gz_ will work with the Docker Compose network.