### PR TITLE
Refine exception-handling for JKey.mapKey

### DIFF
--- a/hedera-node/src/main/java/com/hedera/services/context/AwareTransactionContext.java
+++ b/hedera-node/src/main/java/com/hedera/services/context/AwareTransactionContext.java
@@ -21,25 +21,40 @@ package com.hedera.services.context;
  */
 
 import com.google.protobuf.ByteString;
+import com.hedera.services.legacy.core.jproto.JKey;
 import com.hedera.services.state.merkle.MerkleTopic;
 import com.hedera.services.utils.PlatformTxnAccessor;
-import com.hederahashgraph.api.proto.java.*;
-import com.hedera.services.legacy.core.jproto.JKey;
+import com.hederahashgraph.api.proto.java.AccountAmount;
+import com.hederahashgraph.api.proto.java.AccountID;
+import com.hederahashgraph.api.proto.java.ContractFunctionResult;
+import com.hederahashgraph.api.proto.java.ContractID;
+import com.hederahashgraph.api.proto.java.FileID;
+import com.hederahashgraph.api.proto.java.Key;
+import com.hederahashgraph.api.proto.java.KeyList;
+import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
+import com.hederahashgraph.api.proto.java.ScheduleID;
+import com.hederahashgraph.api.proto.java.Timestamp;
+import com.hederahashgraph.api.proto.java.TokenID;
+import com.hederahashgraph.api.proto.java.TopicID;
+import com.hederahashgraph.api.proto.java.Transaction;
+import com.hederahashgraph.api.proto.java.TransactionReceipt;
+import com.hederahashgraph.api.proto.java.TransactionRecord;
+import com.hederahashgraph.api.proto.java.TransferList;
 import com.swirlds.common.Address;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import static com.hedera.services.state.merkle.MerkleEntityId.fromAccountId;
-import static com.hedera.services.utils.MiscUtils.asTimestamp;
-import static com.hedera.services.utils.MiscUtils.canonicalDiffRepr;
-import static com.hedera.services.utils.EntityIdUtils.accountParsedFromString;
-import static com.hedera.services.utils.MiscUtils.readableTransferList;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.*;
-import static com.hedera.services.legacy.core.jproto.JKey.mapKey;
-
 import java.time.Instant;
 import java.util.List;
 import java.util.function.Consumer;
+
+import static com.hedera.services.state.merkle.MerkleEntityId.fromAccountId;
+import static com.hedera.services.utils.EntityIdUtils.accountParsedFromString;
+import static com.hedera.services.utils.MiscUtils.asFcKeyUnchecked;
+import static com.hedera.services.utils.MiscUtils.asTimestamp;
+import static com.hedera.services.utils.MiscUtils.canonicalDiffRepr;
+import static com.hedera.services.utils.MiscUtils.readableTransferList;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.UNKNOWN;
 
 /**
  * Implements a transaction context using infrastructure known to be
@@ -55,11 +70,7 @@ public class AwareTransactionContext implements TransactionContext {
 
 	public static final JKey EMPTY_KEY;
 	static {
-		try {
-			EMPTY_KEY = mapKey(Key.newBuilder().setKeyList(KeyList.getDefaultInstance()).build());
-		} catch (Exception impossible) {
-			throw new IllegalStateException("Empty Hedera key could not be initialized!", impossible);
-		}
+		EMPTY_KEY = asFcKeyUnchecked(Key.newBuilder().setKeyList(KeyList.getDefaultInstance()).build());
 	}
 
 	private final ServicesContext ctx;

--- a/hedera-node/src/main/java/com/hedera/services/legacy/core/jproto/JFileInfo.java
+++ b/hedera-node/src/main/java/com/hedera/services/legacy/core/jproto/JFileInfo.java
@@ -28,6 +28,8 @@ import com.hederahashgraph.api.proto.java.Timestamp;
 import com.hedera.services.legacy.exception.DeserializationException;
 import com.hedera.services.legacy.exception.InvalidFileWACLException;
 import com.hedera.services.legacy.exception.SerializationException;
+import org.apache.commons.codec.DecoderException;
+
 import java.io.ByteArrayInputStream;
 import java.io.DataInputStream;
 import java.io.Serializable;
@@ -98,7 +100,7 @@ public class JFileInfo implements Serializable {
    * @return converted JFileInfo object
    * @throws Exception
    */
-  public static JFileInfo convert(FileInfo fi) throws Exception {
+  public static JFileInfo convert(FileInfo fi) throws DecoderException {
     JFileInfo jfi = new JFileInfo(fi.getDeleted(),
         JKey.mapKey(Key.newBuilder().setKeyList(fi.getKeys()).build()), fi.getExpirationTime().getSeconds());
     return jfi;
@@ -130,7 +132,7 @@ public class JFileInfo implements Serializable {
   public static JKey convertWacl(KeyList waclAsKeyList) throws InvalidFileWACLException {
     try {
       return JKey.mapKey(Key.newBuilder().setKeyList(waclAsKeyList).build());
-    } catch (Exception e) {
+    } catch (DecoderException e) {
       throw new InvalidFileWACLException("input wacl=" + waclAsKeyList, e);
     }
   }

--- a/hedera-node/src/main/java/com/hedera/services/legacy/core/jproto/JKey.java
+++ b/hedera-node/src/main/java/com/hedera/services/legacy/core/jproto/JKey.java
@@ -151,7 +151,7 @@ public abstract class JKey implements Serializable, Cloneable {
 	 * 		JKey object to be converted
 	 * @return converted Key instance
 	 */
-	private static Key convertJKeyBasic(JKey jkey) throws DecoderException {
+	static Key convertJKeyBasic(JKey jkey) throws DecoderException {
 		Key rv = null;
 		if (jkey.hasEd25519Key()) {
 			rv = Key.newBuilder().setEd25519(ByteString.copyFrom(jkey.getEd25519())).build();

--- a/hedera-node/src/main/java/com/hedera/services/legacy/core/jproto/JKey.java
+++ b/hedera-node/src/main/java/com/hedera/services/legacy/core/jproto/JKey.java
@@ -21,7 +21,6 @@ package com.hedera.services.legacy.core.jproto;
  */
 
 import com.google.protobuf.ByteString;
-import com.google.protobuf.TextFormat;
 import com.hedera.services.utils.MiscUtils;
 import com.hederahashgraph.api.proto.java.ContractID;
 import com.hederahashgraph.api.proto.java.Key;
@@ -152,7 +151,7 @@ public abstract class JKey implements Serializable, Cloneable {
 	 * 		JKey object to be converted
 	 * @return converted Key instance
 	 */
-	private static Key convertJKeyBasic(JKey jkey) throws Exception {
+	private static Key convertJKeyBasic(JKey jkey) throws DecoderException {
 		Key rv = null;
 		if (jkey.hasEd25519Key()) {
 			rv = Key.newBuilder().setEd25519(ByteString.copyFrom(jkey.getEd25519())).build();
@@ -163,7 +162,7 @@ public abstract class JKey implements Serializable, Cloneable {
 		} else if (jkey.hasContractID()) {
 			rv = Key.newBuilder().setContractID(jkey.getContractIDKey().getContractID()).build();
 		} else {
-			throw new Exception("Key type not implemented: key=" + jkey);
+			throw new DecoderException("Key type not implemented: key=" + jkey);
 		}
 
 		return rv;
@@ -178,7 +177,7 @@ public abstract class JKey implements Serializable, Cloneable {
 	 * 		current level that is to be verified. The first level has a value of 1.
 	 * @return converted proto Key
 	 */
-	public static Key convertJKey(JKey jkey, int depth) throws Exception {
+	public static Key convertJKey(JKey jkey, int depth) throws DecoderException {
 		if (depth > KeyExpansion.KEY_EXPANSION_DEPTH) {
 			log.debug("Exceeding max expansion depth of " + KeyExpansion.KEY_EXPANSION_DEPTH);
 		}
@@ -232,7 +231,7 @@ public abstract class JKey implements Serializable, Cloneable {
 	 * 		the JKey to be converted
 	 * @return the converted Key instance
 	 */
-	public static Key mapJKey(JKey jkey) throws Exception {
+	public static Key mapJKey(JKey jkey) throws DecoderException {
 		return convertJKey(jkey, 1);
 	}
 

--- a/hedera-node/src/main/java/com/hedera/services/txns/crypto/CryptoCreateTransitionLogic.java
+++ b/hedera-node/src/main/java/com/hedera/services/txns/crypto/CryptoCreateTransitionLogic.java
@@ -9,9 +9,9 @@ package com.hedera.services.txns.crypto;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -36,6 +36,7 @@ import org.apache.commons.codec.DecoderException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import static com.hedera.services.utils.MiscUtils.asFcKeyUnchecked;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.*;
 import static com.hedera.services.legacy.core.jproto.JKey.mapKey;
 
@@ -91,16 +92,10 @@ public class CryptoCreateTransitionLogic implements TransitionLogic {
 	}
 
 	private HederaAccountCustomizer asCustomizer(CryptoCreateTransactionBody op) {
-		JKey key;
 		long autoRenewPeriod = op.getAutoRenewPeriod().getSeconds();
 		long expiry = txnCtx.consensusTime().getEpochSecond() + autoRenewPeriod;
 
-		try {
-			key = mapKey(op.getKey());
-		} catch (DecoderException syntaxViolation) {
-			log.warn("Syntax violation in doStateTransition!", syntaxViolation);
-			throw new IllegalArgumentException(syntaxViolation);
-		}
+		JKey key = asFcKeyUnchecked(op.getKey());
 		HederaAccountCustomizer customizer = new HederaAccountCustomizer()
 				.key(key)
 				.expiry(expiry)
@@ -133,13 +128,9 @@ public class CryptoCreateTransitionLogic implements TransitionLogic {
 		}
 
 		try {
-			//convert to JKey and check if after the expansion the key is empty
-			JKey converted = JKey.mapKey(op.getKey());
-			if (converted.isEmpty()) {
-				return KEY_REQUIRED;
-			}
-
-			if (!converted.isValid()) {
+			JKey fcKey = mapKey(op.getKey());
+			/* Note that an empty key is never valid. */
+			if (!fcKey.isValid()) {
 				return BAD_ENCODING;
 			}
 		} catch (DecoderException e) {

--- a/hedera-node/src/main/java/com/hedera/services/txns/crypto/CryptoCreateTransitionLogic.java
+++ b/hedera-node/src/main/java/com/hedera/services/txns/crypto/CryptoCreateTransitionLogic.java
@@ -90,14 +90,14 @@ public class CryptoCreateTransitionLogic implements TransitionLogic {
 		}
 	}
 
-	HederaAccountCustomizer asCustomizer(CryptoCreateTransactionBody op) {
+	private HederaAccountCustomizer asCustomizer(CryptoCreateTransactionBody op) {
 		JKey key;
 		long autoRenewPeriod = op.getAutoRenewPeriod().getSeconds();
 		long expiry = txnCtx.consensusTime().getEpochSecond() + autoRenewPeriod;
 
 		try {
 			key = mapKey(op.getKey());
-		} catch (Exception syntaxViolation) {
+		} catch (DecoderException syntaxViolation) {
 			log.warn("Syntax violation in doStateTransition!", syntaxViolation);
 			throw new IllegalArgumentException(syntaxViolation);
 		}

--- a/hedera-node/src/main/java/com/hedera/services/txns/crypto/CryptoUpdateTransitionLogic.java
+++ b/hedera-node/src/main/java/com/hedera/services/txns/crypto/CryptoUpdateTransitionLogic.java
@@ -37,8 +37,8 @@ import org.apache.commons.codec.DecoderException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import static com.hedera.services.utils.MiscUtils.asFcKeyUnchecked;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.*;
-import static com.hedera.services.legacy.core.jproto.JKey.mapKey;
 
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -92,13 +92,7 @@ public class CryptoUpdateTransitionLogic implements TransitionLogic {
 		HederaAccountCustomizer customizer = new HederaAccountCustomizer();
 
 		if (op.hasKey()) {
-			JKey key;
-			try {
-				key = mapKey(op.getKey());
-			} catch (DecoderException syntaxViolation) {
-				log.warn("Syntax violation in doStateTransition!", syntaxViolation);
-				throw new IllegalArgumentException(syntaxViolation);
-			}
+			JKey key = asFcKeyUnchecked(op.getKey());
 			customizer.key(key);
 		}
 		if (op.hasExpirationTime()) {
@@ -134,8 +128,9 @@ public class CryptoUpdateTransitionLogic implements TransitionLogic {
 
 		if (op.hasKey()) {
 			try {
-				JKey converted = JKey.mapKey(op.getKey());
-				if (!converted.isValid()) {
+				JKey fcKey = JKey.mapKey(op.getKey());
+				/* Note that an empty key is never valid. */
+				if (!fcKey.isValid()) {
 					return BAD_ENCODING;
 				}
 			} catch (DecoderException e) {

--- a/hedera-node/src/main/java/com/hedera/services/txns/crypto/CryptoUpdateTransitionLogic.java
+++ b/hedera-node/src/main/java/com/hedera/services/txns/crypto/CryptoUpdateTransitionLogic.java
@@ -88,14 +88,14 @@ public class CryptoUpdateTransitionLogic implements TransitionLogic {
 		}
 	}
 
-	HederaAccountCustomizer asCustomizer(CryptoUpdateTransactionBody op) {
+	private HederaAccountCustomizer asCustomizer(CryptoUpdateTransactionBody op) {
 		HederaAccountCustomizer customizer = new HederaAccountCustomizer();
 
 		if (op.hasKey()) {
 			JKey key;
 			try {
 				key = mapKey(op.getKey());
-			} catch (Exception syntaxViolation) {
+			} catch (DecoderException syntaxViolation) {
 				log.warn("Syntax violation in doStateTransition!", syntaxViolation);
 				throw new IllegalArgumentException(syntaxViolation);
 			}

--- a/hedera-node/src/main/java/com/hedera/services/txns/file/FileCreateTransitionLogic.java
+++ b/hedera-node/src/main/java/com/hedera/services/txns/file/FileCreateTransitionLogic.java
@@ -9,9 +9,9 @@ package com.hedera.services.txns.file;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -25,6 +25,7 @@ import com.hedera.services.context.primitives.StateView;
 import com.hedera.services.files.HederaFs;
 import com.hedera.services.txns.TransitionLogic;
 import com.hedera.services.txns.validation.OptionValidator;
+import com.hedera.services.utils.MiscUtils;
 import com.hederahashgraph.api.proto.java.Duration;
 import com.hederahashgraph.api.proto.java.FileCreateTransactionBody;
 import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
@@ -40,6 +41,7 @@ import java.util.function.Predicate;
 
 import static com.hedera.services.txns.file.FileUpdateTransitionLogic.mapToStatus;
 import static com.hedera.services.txns.file.FileUpdateTransitionLogic.wrapped;
+import static com.hedera.services.utils.MiscUtils.asFcKeyUnchecked;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.AUTORENEW_DURATION_NOT_IN_RANGE;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.FAIL_INVALID;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_EXPIRATION_TIME;
@@ -113,12 +115,8 @@ public class FileCreateTransitionLogic implements TransitionLogic {
 	private JFileInfo asAttr(FileCreateTransactionBody op) {
 		JKey wacl;
 		if (op.hasKeys()) {
-			try {
-				wacl = mapKey(wrapped(op.getKeys()));
-			} catch (DecoderException syntaxViolation) {
-				log.warn("Syntax violation in file creation!", syntaxViolation);
-				throw new IllegalArgumentException(syntaxViolation);
-			}
+			/* Note that {@code assessedValidity} above will guarantee this conversion succeeds. */
+			wacl = asFcKeyUnchecked(wrapped(op.getKeys()));
 		} else {
 			wacl = StateView.EMPTY_WACL;
 		}

--- a/hedera-node/src/main/java/com/hedera/services/txns/file/FileCreateTransitionLogic.java
+++ b/hedera-node/src/main/java/com/hedera/services/txns/file/FileCreateTransitionLogic.java
@@ -31,6 +31,7 @@ import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
 import com.hederahashgraph.api.proto.java.TransactionBody;
 import com.hedera.services.legacy.core.jproto.JFileInfo;
 import com.hedera.services.legacy.core.jproto.JKey;
+import org.apache.commons.codec.DecoderException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -114,7 +115,7 @@ public class FileCreateTransitionLogic implements TransitionLogic {
 		if (op.hasKeys()) {
 			try {
 				wacl = mapKey(wrapped(op.getKeys()));
-			} catch (Exception syntaxViolation) {
+			} catch (DecoderException syntaxViolation) {
 				log.warn("Syntax violation in file creation!", syntaxViolation);
 				throw new IllegalArgumentException(syntaxViolation);
 			}

--- a/hedera-node/src/main/java/com/hedera/services/txns/validation/ContextOptionValidator.java
+++ b/hedera-node/src/main/java/com/hedera/services/txns/validation/ContextOptionValidator.java
@@ -32,6 +32,7 @@ import com.hederahashgraph.api.proto.java.TokenTransferList;
 import com.hederahashgraph.api.proto.java.TopicID;
 import com.hederahashgraph.api.proto.java.TransferList;
 import com.swirlds.fcmap.FCMap;
+import org.apache.commons.codec.DecoderException;
 import org.apache.commons.codec.binary.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -73,7 +74,7 @@ public class ContextOptionValidator implements OptionValidator {
 		try {
 			mapKey(key);
 			return true;
-		} catch (Exception ignore) {
+		} catch (DecoderException ignore) {
 			return false;
 		}
 	}

--- a/hedera-node/src/main/java/com/hedera/services/txns/validation/PureValidation.java
+++ b/hedera-node/src/main/java/com/hedera/services/txns/validation/PureValidation.java
@@ -32,6 +32,7 @@ import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
 import com.hederahashgraph.api.proto.java.Timestamp;
 import com.hedera.services.state.merkle.MerkleEntityId;
 import com.swirlds.fcmap.FCMap;
+import org.apache.commons.codec.DecoderException;
 
 import java.time.Instant;
 import java.util.Optional;
@@ -100,7 +101,7 @@ public class PureValidation {
 				return failure;
 			}
 			return OK;
-		} catch (Exception ignore) {
+		} catch (DecoderException ignore) {
 			return failure;
 		}
 	}

--- a/hedera-node/src/main/java/com/hedera/services/utils/MiscUtils.java
+++ b/hedera-node/src/main/java/com/hedera/services/utils/MiscUtils.java
@@ -275,8 +275,8 @@ public class MiscUtils {
 	public static JKey asFcKeyUnchecked(Key key) {
 		try {
 			return JKey.mapKey(key);
-		} catch (Exception impossible) {
-			throw new IllegalArgumentException("Key " + key + " should have been decodable!", impossible);
+		} catch (DecoderException impermissible) {
+			throw new IllegalArgumentException("Key " + key + " should have been decode-able!", impermissible);
 		}
 	}
 
@@ -287,7 +287,7 @@ public class MiscUtils {
 				return Optional.empty();
 			}
 			return Optional.of(fcKey);
-		} catch (Exception ignore) {
+		} catch (DecoderException ignore) {
 			return Optional.empty();
 		}
 	}

--- a/hedera-node/src/test/java/com/hedera/services/fees/calculation/crypto/queries/GetAccountInfoResourceUsageTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/fees/calculation/crypto/queries/GetAccountInfoResourceUsageTest.java
@@ -24,13 +24,10 @@ import com.google.protobuf.ByteString;
 import com.hedera.services.context.primitives.StateView;
 import com.hedera.services.context.properties.PropertySource;
 import com.hedera.services.fees.calculation.UsageEstimatorUtils;
-import com.hedera.services.fees.calculation.token.queries.GetTokenInfoResourceUsage;
-import com.hedera.services.legacy.core.jproto.JKey;
+import com.hedera.services.state.merkle.MerkleAccount;
+import com.hedera.services.state.merkle.MerkleEntityId;
 import com.hedera.services.usage.crypto.CryptoGetInfoUsage;
-import com.hedera.services.usage.token.TokenGetInfoUsage;
-import com.hedera.services.utils.MiscUtils;
 import com.hedera.test.factories.accounts.MerkleAccountFactory;
-import com.hedera.test.utils.IdUtils;
 import com.hederahashgraph.api.proto.java.AccountID;
 import com.hederahashgraph.api.proto.java.CryptoGetInfoQuery;
 import com.hederahashgraph.api.proto.java.FeeComponents;
@@ -40,27 +37,28 @@ import com.hederahashgraph.api.proto.java.Query;
 import com.hederahashgraph.api.proto.java.QueryHeader;
 import com.hederahashgraph.api.proto.java.ResponseType;
 import com.hederahashgraph.api.proto.java.TokenID;
-import com.hederahashgraph.fee.CryptoFeeBuilder;
-import com.hedera.services.state.merkle.MerkleEntityId;
-import com.hedera.services.state.merkle.MerkleAccount;
 import com.swirlds.fcmap.FCMap;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.platform.runner.JUnitPlatform;
 import org.junit.runner.RunWith;
 
-import java.util.Collections;
 import java.util.function.Function;
 
 import static com.hedera.services.state.merkle.MerkleEntityId.fromAccountId;
+import static com.hedera.test.utils.IdUtils.asAccount;
+import static com.hedera.test.utils.IdUtils.asToken;
+import static com.hederahashgraph.api.proto.java.ResponseType.ANSWER_ONLY;
+import static com.hederahashgraph.api.proto.java.ResponseType.COST_ANSWER;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.BDDMockito.*;
-import static com.hedera.test.utils.IdUtils.*;
-import static com.hederahashgraph.api.proto.java.ResponseType.*;
+import static org.mockito.BDDMockito.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.mock;
+import static org.mockito.BDDMockito.verify;
 
 @RunWith(JUnitPlatform.class)
 class GetAccountInfoResourceUsageTest {

--- a/hedera-node/src/test/java/com/hedera/services/legacy/core/jproto/JFileInfoTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/legacy/core/jproto/JFileInfoTest.java
@@ -1,0 +1,24 @@
+package com.hedera.services.legacy.core.jproto;
+
+import com.hedera.services.legacy.exception.InvalidFileWACLException;
+import com.hederahashgraph.api.proto.java.Key;
+import com.hederahashgraph.api.proto.java.KeyList;
+import org.junit.jupiter.api.Test;
+import org.junit.platform.runner.JUnitPlatform;
+import org.junit.runner.RunWith;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@RunWith(JUnitPlatform.class)
+class JFileInfoTest {
+	@Test
+	public void translatesDecoderException() throws InvalidFileWACLException {
+		// given:
+		var invalidKeyList = KeyList.newBuilder()
+				.addKeys(Key.getDefaultInstance())
+				.build();
+
+		// when:
+		assertThrows(InvalidFileWACLException.class, () -> JFileInfo.convertWacl(invalidKeyList));
+	}
+}

--- a/hedera-node/src/test/java/com/hedera/services/legacy/core/jproto/JKeyTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/legacy/core/jproto/JKeyTest.java
@@ -52,4 +52,20 @@ public class JKeyTest {
 		assertThrows(DecoderException.class, () -> JKey.convertKey(accountKey, KeyExpansion.KEY_EXPANSION_DEPTH+1),
 				"Exceeding max expansion depth of " + KeyExpansion.KEY_EXPANSION_DEPTH);
 	}
+
+	@Test
+	public void rejectsEmptyKey() {
+		// expect:
+		assertThrows(DecoderException.class, () -> JKey.convertJKeyBasic(new JKey() {
+			@Override
+			public boolean isEmpty() {
+				return false;
+			}
+
+			@Override
+			public boolean isValid() {
+				return false;
+			}
+		}));
+	}
 }

--- a/hedera-node/src/test/java/com/hedera/services/txns/file/FileUpdateTransitionLogicTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/txns/file/FileUpdateTransitionLogicTest.java
@@ -42,6 +42,7 @@ import com.hederahashgraph.api.proto.java.TransactionBody;
 import com.hederahashgraph.api.proto.java.TransactionID;
 import com.hedera.services.legacy.core.jproto.JFileInfo;
 import com.hedera.services.legacy.core.jproto.JKey;
+import org.apache.commons.codec.DecoderException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.platform.runner.JUnitPlatform;
@@ -398,6 +399,20 @@ class FileUpdateTransitionLogicTest {
 
 		// expect:
 		verify(txnCtx).setStatus(INVALID_EXPIRATION_TIME);
+	}
+
+	@Test
+	public void transitionCatchesBadlyEncodedKey() {
+		givenTxnCtxUpdating(EnumSet.of(UpdateTarget.KEY));
+		// and:
+		willThrow(new IllegalArgumentException(new DecoderException()))
+				.given(hfs).setattr(argThat(nonSysFileTarget::equals), any());
+
+		// when:
+		subject.doStateTransition();
+
+		// expect:
+		verify(txnCtx).setStatus(BAD_ENCODING);
 	}
 
 	@Test


### PR DESCRIPTION
**Related issue(s)**:
- Closes #914 

**Summary of the change**:
- Throw only `DecoderException`s from `JKey.mapKey`; refine `catch` clauses in client code.

**External impacts**:
None.