### PR TITLE
Change the log level from Error to warn.

### DIFF
--- a/hedera-node/src/main/java/com/hedera/services/state/merkle/MerkleDiskFs.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/merkle/MerkleDiskFs.java
@@ -129,7 +129,12 @@ public class MerkleDiskFs extends AbstractMerkleLeaf implements MerkleExternalLe
 		try {
 			return bytesHelper.allBytesFrom(pathToContentsOf(fid));
 		} catch (IOException e) {
-			log.error("Error reading '{}' @ {}!", asLiteralString(fid), pathToContentsOf(fid), e);
+			if(log.isDebugEnabled()) {
+				log.warn("Not able to read '{}' @ {}!", asLiteralString(fid), pathToContentsOf(fid), e);
+			}
+			else {
+				log.warn("Not able to read '{}' @ {}!", asLiteralString(fid), pathToContentsOf(fid));
+			}
 			return MISSING_CONTENT;
 		}
 	}

--- a/hedera-node/src/test/java/com/hedera/services/state/merkle/MerkleDiskFsTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/state/merkle/MerkleDiskFsTest.java
@@ -167,8 +167,21 @@ public class MerkleDiskFsTest {
 	}
 
 	@Test
-	public void fileNotExist() throws IOException {
+	public void fileNotExistNoDebug() throws IOException {
 		// setup:
+		subject = new MerkleDiskFs("this/doesnt/exist", asLiteralString(nodeAccount));
+
+		given(getter.allBytesFrom(any())).willThrow(IOException.class);
+
+		Assertions.assertSame(MerkleDiskFs.MISSING_CONTENT, subject.contentsOf(file150));
+	}
+
+	@Test
+	public void fileNotExistDebugEnabled() throws IOException {
+		// setup:
+		Logger log = mock(Logger.class);
+		given(log.isDebugEnabled()).willReturn(true);
+		MerkleDiskFs.log = log;
 		subject = new MerkleDiskFs("this/doesnt/exist", asLiteralString(nodeAccount));
 
 		given(getter.allBytesFrom(any())).willThrow(IOException.class);


### PR DESCRIPTION
**Related issue(s)**:
Closes #955

**Summary of the change**:
Changed the log level from Error to warn and only print out the stack trace when debug is enabled. I checked all the current callers of this method. As of now, this change shouldn't cause any issue.

This method is at low level. When anything happens, it's difficult for this method to decide whether the situation should be treated as error or not.  Its callers shall have better context to decide what it should be.  So an alternative solution is to re-throw this exception and let its called to handle it.


**External impacts**:
None.

**Applicable documentation**
- [ ] Javadoc
- [ ] HAPI protobuf comments
- [ ] README
