### PR TITLE
Let runtime exceptions in query usage estimators propagate

### DIFF
--- a/hedera-node/src/main/java/com/hedera/services/fees/calculation/consensus/queries/GetTopicInfoResourceUsage.java
+++ b/hedera-node/src/main/java/com/hedera/services/fees/calculation/consensus/queries/GetTopicInfoResourceUsage.java
@@ -9,9 +9,9 @@ package com.hedera.services.fees.calculation.consensus.queries;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -23,6 +23,7 @@ package com.hedera.services.fees.calculation.consensus.queries;
 import com.hedera.services.state.merkle.MerkleTopic;
 import com.hedera.services.context.primitives.StateView;
 import com.hedera.services.fees.calculation.QueryResourceUsageEstimator;
+import com.hedera.services.utils.MiscUtils;
 import com.hederahashgraph.api.proto.java.FeeComponents;
 import com.hederahashgraph.api.proto.java.FeeData;
 import com.hederahashgraph.api.proto.java.Query;
@@ -33,6 +34,9 @@ import com.hedera.services.legacy.core.jproto.JKey;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import static com.hedera.services.state.merkle.MerkleEntityId.fromTopicId;
+import static com.hedera.services.utils.MiscUtils.asKeyUnchecked;
+import static com.hederahashgraph.fee.ConsensusServiceFeeBuilder.computeVariableSizedFieldsUsage;
 import static com.hederahashgraph.fee.FeeBuilder.*;
 
 public class GetTopicInfoResourceUsage implements QueryResourceUsageEstimator {
@@ -50,31 +54,35 @@ public class GetTopicInfoResourceUsage implements QueryResourceUsageEstimator {
 
 	@Override
 	public FeeData usageGivenType(Query query, StateView view, ResponseType responseType) {
-	    try {
-			MerkleTopic merkleTopic = view.topics().get(MerkleEntityId.fromTopicId(query.getConsensusGetTopicInfo().getTopicID()));
-			int bpr = BASIC_QUERY_RES_HEADER + getStateProofSize(responseType) +
-					BASIC_ENTITY_ID_SIZE +  // topicID
-					getTopicInfoSize(merkleTopic);
-			FeeComponents feeMatrices = FeeComponents.newBuilder()
-					.setBpt(BASIC_QUERY_HEADER + BASIC_ENTITY_ID_SIZE)
-					.setVpt(0)
-					.setRbh(0)
-					.setSbh(0)
-					.setGas(0)
-					.setTv(0)
-					.setBpr(bpr)
-					.setSbpr(0)
-					.build();
-			return getQueryFeeDataMatrices(feeMatrices);
-		} catch (Exception illegal) {
-			log.warn("Usage estimation unexpectedly failed for {}!", query, illegal);
-			throw new IllegalArgumentException();
+		MerkleTopic merkleTopic = view.topics().get(fromTopicId(query.getConsensusGetTopicInfo().getTopicID()));
+
+		if (merkleTopic == null) {
+			return FeeData.getDefaultInstance();
 		}
+
+		int bpr = BASIC_QUERY_RES_HEADER
+				+ getStateProofSize(responseType)
+				+ BASIC_ENTITY_ID_SIZE
+				+ getTopicInfoSize(merkleTopic);
+		var feeMatrices = FeeComponents.newBuilder()
+				.setBpt(BASIC_QUERY_HEADER + BASIC_ENTITY_ID_SIZE)
+				.setVpt(0)
+				.setRbh(0)
+				.setSbh(0)
+				.setGas(0)
+				.setTv(0)
+				.setBpr(bpr)
+				.setSbpr(0)
+				.build();
+		return getQueryFeeDataMatrices(feeMatrices);
 	}
 
-	private static int getTopicInfoSize(MerkleTopic merkleTopic) throws Exception {
-		return TX_HASH_SIZE + 3 * LONG_SIZE + // runningHash, sequenceNumber, expirationTime, autoRenewPeriod
-				ConsensusServiceFeeBuilder.computeVariableSizedFieldsUsage(JKey.mapJKey(merkleTopic.getAdminKey()),
-						JKey.mapJKey(merkleTopic.getSubmitKey()), merkleTopic.getMemo(), merkleTopic.hasAutoRenewAccountId());
+	private static int getTopicInfoSize(MerkleTopic merkleTopic) {
+		/* Three longs in a topic representation: sequenceNumber, expirationTime, autoRenewPeriod */
+		return TX_HASH_SIZE + 3 * LONG_SIZE + computeVariableSizedFieldsUsage(
+						asKeyUnchecked(merkleTopic.getAdminKey()),
+						asKeyUnchecked(merkleTopic.getSubmitKey()),
+						merkleTopic.getMemo(),
+						merkleTopic.hasAutoRenewAccountId());
 	}
 }

--- a/hedera-node/src/main/java/com/hedera/services/fees/calculation/contract/queries/ContractCallLocalResourceUsage.java
+++ b/hedera-node/src/main/java/com/hedera/services/fees/calculation/contract/queries/ContractCallLocalResourceUsage.java
@@ -99,10 +99,9 @@ public class ContractCallLocalResourceUsage implements QueryResourceUsageEstimat
 					op.getFunctionParameters().size(),
 					response.getFunctionResult(),
 					type);
-			var ans = nonGasUsage.toBuilder()
+			return nonGasUsage.toBuilder()
 					.setNodedata(nonGasUsage.getNodedata().toBuilder().setGas(op.getGas()))
 					.build();
-			return ans;
 		} catch (Exception e) {
 			log.warn("Usage estimation unexpectedly failed for {}!", query, e);
 			throw new IllegalArgumentException(e);

--- a/hedera-node/src/main/java/com/hedera/services/fees/calculation/contract/queries/GetBytecodeResourceUsage.java
+++ b/hedera-node/src/main/java/com/hedera/services/fees/calculation/contract/queries/GetBytecodeResourceUsage.java
@@ -9,9 +9,9 @@ package com.hedera.services.fees.calculation.contract.queries;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -53,13 +53,8 @@ public class GetBytecodeResourceUsage implements QueryResourceUsageEstimator {
 
 	@Override
 	public FeeData usageGivenType(Query query, StateView view, ResponseType type) {
-		try {
-			var op = query.getContractGetBytecode();
-			var bytecode = view.bytecodeOf(op.getContractID()).orElse(EMPTY_BYTECODE);
-			return usageEstimator.getContractByteCodeQueryFeeMatrices(bytecode.length, type);
-		} catch (Exception illegal) {
-			log.warn("Usage estimation unexpectedly failed for {}!", query);
-			throw new IllegalArgumentException(illegal);
-		}
+		var op = query.getContractGetBytecode();
+		var bytecode = view.bytecodeOf(op.getContractID()).orElse(EMPTY_BYTECODE);
+		return usageEstimator.getContractByteCodeQueryFeeMatrices(bytecode.length, type);
 	}
 }

--- a/hedera-node/src/main/java/com/hedera/services/fees/calculation/contract/queries/GetContractInfoResourceUsage.java
+++ b/hedera-node/src/main/java/com/hedera/services/fees/calculation/contract/queries/GetContractInfoResourceUsage.java
@@ -69,23 +69,18 @@ public class GetContractInfoResourceUsage implements QueryResourceUsageEstimator
 	}
 
 	private FeeData usageFor(Query query, StateView view, ResponseType type, Optional<Map<String, Object>> queryCtx) {
-		try {
-			var op = query.getContractGetInfo();
-			var tentativeInfo = view.infoForContract(op.getContractID());
-			if (tentativeInfo.isPresent()) {
-				var info = tentativeInfo.get();
-				queryCtx.ifPresent(ctx -> ctx.put(CONTRACT_INFO_CTX_KEY, info));
-				var estimate = factory.apply(query)
-						.givenCurrentKey(info.getAdminKey())
-						.givenCurrentMemo(info.getMemo())
-						.givenCurrentTokenAssocs(info.getTokenRelationshipsCount());
-				return estimate.get();
-			} else {
-				return FeeData.getDefaultInstance();
-			}
-		} catch (Exception e) {
-			log.warn("Usage estimation unexpectedly failed for {}!", query, e);
-			throw new IllegalArgumentException(e);
+		var op = query.getContractGetInfo();
+		var tentativeInfo = view.infoForContract(op.getContractID());
+		if (tentativeInfo.isPresent()) {
+			var info = tentativeInfo.get();
+			queryCtx.ifPresent(ctx -> ctx.put(CONTRACT_INFO_CTX_KEY, info));
+			var estimate = factory.apply(query)
+					.givenCurrentKey(info.getAdminKey())
+					.givenCurrentMemo(info.getMemo())
+					.givenCurrentTokenAssocs(info.getTokenRelationshipsCount());
+			return estimate.get();
+		} else {
+			return FeeData.getDefaultInstance();
 		}
 	}
 }

--- a/hedera-node/src/main/java/com/hedera/services/fees/calculation/crypto/queries/GetAccountInfoResourceUsage.java
+++ b/hedera-node/src/main/java/com/hedera/services/fees/calculation/crypto/queries/GetAccountInfoResourceUsage.java
@@ -9,9 +9,9 @@ package com.hedera.services.fees.calculation.crypto.queries;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -51,25 +51,20 @@ public class GetAccountInfoResourceUsage implements QueryResourceUsageEstimator 
 
 	@Override
 	public FeeData usageGivenType(Query query, StateView view, ResponseType type) {
-		try {
-			var op = query.getCryptoGetInfo();
-			var key = fromAccountId(op.getAccountID());
-			if (view.accounts().containsKey(key)) {
-				var account = view.accounts().get(key);
-				var estimate = factory.apply(query)
-						.givenCurrentKey(asKeyUnchecked(account.getKey()))
-						.givenCurrentMemo(account.getMemo())
-						.givenCurrentTokenAssocs(account.tokens().numAssociations());
-				if (account.getProxy() != null) {
-					estimate.givenCurrentlyUsingProxy();
-				}
-				return estimate.get();
-			} else {
-				return FeeData.getDefaultInstance();
+		var op = query.getCryptoGetInfo();
+		var key = fromAccountId(op.getAccountID());
+		if (view.accounts().containsKey(key)) {
+			var account = view.accounts().get(key);
+			var estimate = factory.apply(query)
+					.givenCurrentKey(asKeyUnchecked(account.getKey()))
+					.givenCurrentMemo(account.getMemo())
+					.givenCurrentTokenAssocs(account.tokens().numAssociations());
+			if (account.getProxy() != null) {
+				estimate.givenCurrentlyUsingProxy();
 			}
-		} catch (Exception illegal) {
-			log.warn("Usage estimation unexpectedly failed for {}!", query, illegal);
-			throw new IllegalArgumentException();
+			return estimate.get();
+		} else {
+			return FeeData.getDefaultInstance();
 		}
 	}
 }

--- a/hedera-node/src/main/java/com/hedera/services/fees/calculation/crypto/queries/GetAccountRecordsResourceUsage.java
+++ b/hedera-node/src/main/java/com/hedera/services/fees/calculation/crypto/queries/GetAccountRecordsResourceUsage.java
@@ -9,9 +9,9 @@ package com.hedera.services.fees.calculation.crypto.queries;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -23,6 +23,7 @@ package com.hedera.services.fees.calculation.crypto.queries;
 import com.hedera.services.context.primitives.StateView;
 import com.hedera.services.fees.calculation.QueryResourceUsageEstimator;
 import com.hedera.services.queries.answering.AnswerFunctions;
+import com.hedera.services.state.merkle.MerkleEntityId;
 import com.hederahashgraph.api.proto.java.FeeData;
 import com.hederahashgraph.api.proto.java.Query;
 import com.hederahashgraph.api.proto.java.ResponseType;
@@ -30,7 +31,10 @@ import com.hederahashgraph.api.proto.java.TransactionRecord;
 import com.hederahashgraph.fee.CryptoFeeBuilder;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+
 import java.util.List;
+
+import static com.hedera.services.state.merkle.MerkleEntityId.fromAccountId;
 
 public class GetAccountRecordsResourceUsage implements QueryResourceUsageEstimator {
 	private static final Logger log = LogManager.getLogger(GetAccountInfoResourceUsage.class);
@@ -58,12 +62,15 @@ public class GetAccountRecordsResourceUsage implements QueryResourceUsageEstimat
 
 	@Override
 	public FeeData usageGivenType(Query query, StateView view, ResponseType type) {
-		try {
-			List<TransactionRecord> records = answerFunctions.accountRecords(view, query);
-			return usageEstimator.getCryptoAccountRecordsQueryFeeMatrices(records, type);
-		} catch (Exception illegal) {
-			log.warn("Usage estimation unexpectedly failed for {}!", query, illegal);
-			throw new IllegalArgumentException();
+		var target = fromAccountId(query.getCryptoGetAccountRecords().getAccountID());
+		if (!view.accounts().containsKey(target)) {
+			/* Given the test in {@code GetAccountRecordsAnswer.checkValidity}, this can only be
+			 * missing under the extraordinary circumstance that the desired account expired
+			 * during the query answer flow (which will now fail downstream with an appropriate
+			 * status code); so just return the default {@code FeeData} here. */
+			return FeeData.getDefaultInstance();
 		}
+		List<TransactionRecord> records = answerFunctions.accountRecords(view, query);
+		return usageEstimator.getCryptoAccountRecordsQueryFeeMatrices(records, type);
 	}
 }

--- a/hedera-node/src/main/java/com/hedera/services/fees/calculation/file/queries/GetFileContentsResourceUsage.java
+++ b/hedera-node/src/main/java/com/hedera/services/fees/calculation/file/queries/GetFileContentsResourceUsage.java
@@ -9,9 +9,9 @@ package com.hedera.services.fees.calculation.file.queries;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -50,13 +50,15 @@ public class GetFileContentsResourceUsage implements QueryResourceUsageEstimator
 
 	@Override
 	public FeeData usageGivenType(Query query, StateView view, ResponseType type) {
-		try {
-			var op = query.getFileGetContents();
-			var info = view.infoForFile(op.getFileID());
-			return usageEstimator.getFileContentQueryFeeMatrices((int)info.get().getSize(), type);
-		} catch (Exception illegal) {
-			log.warn("Usage estimation unexpectedly failed for {}!", query, illegal);
-			throw new IllegalArgumentException();
+		var op = query.getFileGetContents();
+		var info = view.infoForFile(op.getFileID());
+		/* Given the test in {@code GetFileContentsAnswer.checkValidity}, this can only be empty
+		 * under the extraordinary circumstance that the desired file expired during the query
+		 * answer flow (which will now fail downstream with an appropriate status code); so
+		 * just return the default {@code FeeData} here. */
+		if (info.isEmpty()) {
+			return FeeData.getDefaultInstance();
 		}
+		return usageEstimator.getFileContentQueryFeeMatrices((int) info.get().getSize(), type);
 	}
 }

--- a/hedera-node/src/main/java/com/hedera/services/fees/calculation/file/queries/GetFileInfoResourceUsage.java
+++ b/hedera-node/src/main/java/com/hedera/services/fees/calculation/file/queries/GetFileInfoResourceUsage.java
@@ -9,9 +9,9 @@ package com.hedera.services.fees.calculation.file.queries;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -50,13 +50,15 @@ public class GetFileInfoResourceUsage implements QueryResourceUsageEstimator {
 
 	@Override
 	public FeeData usageGivenType(Query query, StateView view, ResponseType type) {
-		try {
-			var op = query.getFileGetInfo();
-			var info = view.infoForFile(op.getFileID());
-			return usageEstimator.getFileInfoQueryFeeMatrices(info.get().getKeys(), type);
-		} catch (Exception illegal) {
-			log.warn("Usage estimation unexpectedly failed for {}!", query, illegal);
-			throw new IllegalArgumentException();
+		var op = query.getFileGetInfo();
+		var info = view.infoForFile(op.getFileID());
+		/* Given the test in {@code GetFileInfoAnswer.checkValidity}, this can only be empty
+		* under the extraordinary circumstance that the desired file expired during the query
+		* answer flow (which will now fail downstream with an appropriate status code); so
+		* just return the default {@code FeeData} here. */
+		if (info.isEmpty()) {
+			return FeeData.getDefaultInstance();
 		}
+		return usageEstimator.getFileInfoQueryFeeMatrices(info.get().getKeys(), type);
 	}
 }

--- a/hedera-node/src/main/java/com/hedera/services/fees/calculation/schedule/queries/GetScheduleInfoResourceUsage.java
+++ b/hedera-node/src/main/java/com/hedera/services/fees/calculation/schedule/queries/GetScheduleInfoResourceUsage.java
@@ -39,56 +39,51 @@ import static com.hedera.services.queries.AnswerService.NO_QUERY_CTX;
 import static com.hedera.services.queries.schedule.GetScheduleInfoAnswer.SCHEDULE_INFO_CTX_KEY;
 
 public class GetScheduleInfoResourceUsage implements QueryResourceUsageEstimator {
-    private static final Logger log = LogManager.getLogger(GetScheduleInfoResourceUsage.class);
+	private static final Logger log = LogManager.getLogger(GetScheduleInfoResourceUsage.class);
 
-    static Function<Query, ScheduleGetInfoUsage> factory = ScheduleGetInfoUsage::newEstimate;
+	static Function<Query, ScheduleGetInfoUsage> factory = ScheduleGetInfoUsage::newEstimate;
 
-    @Override
-    public boolean applicableTo(Query query) {
-        return query.hasScheduleGetInfo();
-    }
+	@Override
+	public boolean applicableTo(Query query) {
+		return query.hasScheduleGetInfo();
+	}
 
-    @Override
-    public FeeData usageGiven(Query query, StateView view) {
-        return usageFor(query, view, NO_QUERY_CTX);
-    }
+	@Override
+	public FeeData usageGiven(Query query, StateView view) {
+		return usageFor(query, view, NO_QUERY_CTX);
+	}
 
-    @Override
-    public FeeData usageGivenType(Query query, StateView view, ResponseType type) {
-        return usageFor(query, view, NO_QUERY_CTX);
-    }
+	@Override
+	public FeeData usageGivenType(Query query, StateView view, ResponseType type) {
+		return usageFor(query, view, NO_QUERY_CTX);
+	}
 
-    @Override
-    public FeeData usageGiven(Query query, StateView view, Map<String, Object> queryCtx) {
-        return usageFor(
-                query,
-                view,
-                Optional.of(queryCtx));
-    }
+	@Override
+	public FeeData usageGiven(Query query, StateView view, Map<String, Object> queryCtx) {
+		return usageFor(
+				query,
+				view,
+				Optional.of(queryCtx));
+	}
 
-    private FeeData usageFor(Query query, StateView view, Optional<Map<String, Object>> queryCtx) {
-        try {
-            var op = query.getScheduleGetInfo();
-            var optionalInfo = view.infoForSchedule(op.getScheduleID());
-            if (optionalInfo.isPresent()) {
-                var info = optionalInfo.get();
-                queryCtx.ifPresent(ctx -> ctx.put(SCHEDULE_INFO_CTX_KEY, info));
-                var estimate = factory.apply(query)
-                        .givenTransaction(info.getTransactionBody().toByteArray())
-                        .givenSigners(ifPresent(info, ScheduleInfo::hasSigners, ScheduleInfo::getSigners))
-                        .givenCurrentAdminKey(ifPresent(info, ScheduleInfo::hasAdminKey, ScheduleInfo::getAdminKey));
-                return estimate.get();
-            } else {
-                return FeeData.getDefaultInstance();
-            }
-        } catch (Exception e) {
-            log.warn("Usage estimation unexpectedly failed for {}!", query, e);
-            throw new IllegalArgumentException(e);
-        }
-    }
+	private FeeData usageFor(Query query, StateView view, Optional<Map<String, Object>> queryCtx) {
+		var op = query.getScheduleGetInfo();
+		var optionalInfo = view.infoForSchedule(op.getScheduleID());
+		if (optionalInfo.isPresent()) {
+			var info = optionalInfo.get();
+			queryCtx.ifPresent(ctx -> ctx.put(SCHEDULE_INFO_CTX_KEY, info));
+			var estimate = factory.apply(query)
+					.givenTransaction(info.getTransactionBody().toByteArray())
+					.givenSigners(ifPresent(info, ScheduleInfo::hasSigners, ScheduleInfo::getSigners))
+					.givenCurrentAdminKey(ifPresent(info, ScheduleInfo::hasAdminKey, ScheduleInfo::getAdminKey));
+			return estimate.get();
+		} else {
+			return FeeData.getDefaultInstance();
+		}
+	}
 
-    private static <T, K> Optional<T> ifPresent(K info, Predicate<K> check, Function<K, T> getter) {
-        return check.test(info) ? Optional.of(getter.apply(info)) : Optional.empty();
-    }
+	private static <T, K> Optional<T> ifPresent(K info, Predicate<K> check, Function<K, T> getter) {
+		return check.test(info) ? Optional.of(getter.apply(info)) : Optional.empty();
+	}
 
 }

--- a/hedera-node/src/main/java/com/hedera/services/fees/calculation/token/queries/GetTokenInfoResourceUsage.java
+++ b/hedera-node/src/main/java/com/hedera/services/fees/calculation/token/queries/GetTokenInfoResourceUsage.java
@@ -69,30 +69,25 @@ public class GetTokenInfoResourceUsage implements QueryResourceUsageEstimator {
 	}
 
 	private FeeData usageFor(Query query, StateView view, ResponseType type, Optional<Map<String, Object>> queryCtx) {
-		try {
-			var op = query.getTokenGetInfo();
-			var optionalInfo = view.infoForToken(op.getToken());
-			if (optionalInfo.isPresent()) {
-				var info = optionalInfo.get();
-				queryCtx.ifPresent(ctx -> ctx.put(TOKEN_INFO_CTX_KEY, info));
-				var estimate = factory.apply(query)
-						.givenCurrentAdminKey(ifPresent(info, TokenInfo::hasAdminKey, TokenInfo::getAdminKey))
-						.givenCurrentFreezeKey(ifPresent(info, TokenInfo::hasFreezeKey, TokenInfo::getFreezeKey))
-						.givenCurrentWipeKey(ifPresent(info, TokenInfo::hasWipeKey, TokenInfo::getWipeKey))
-						.givenCurrentSupplyKey(ifPresent(info, TokenInfo::hasSupplyKey, TokenInfo::getSupplyKey))
-						.givenCurrentKycKey(ifPresent(info, TokenInfo::hasKycKey, TokenInfo::getKycKey))
-						.givenCurrentName(info.getName())
-						.givenCurrentSymbol(info.getSymbol());
-				if (info.hasAutoRenewAccount()) {
-					estimate.givenCurrentlyUsingAutoRenewAccount();
-				}
-				return estimate.get();
-			} else {
-				return FeeData.getDefaultInstance();
+		var op = query.getTokenGetInfo();
+		var optionalInfo = view.infoForToken(op.getToken());
+		if (optionalInfo.isPresent()) {
+			var info = optionalInfo.get();
+			queryCtx.ifPresent(ctx -> ctx.put(TOKEN_INFO_CTX_KEY, info));
+			var estimate = factory.apply(query)
+					.givenCurrentAdminKey(ifPresent(info, TokenInfo::hasAdminKey, TokenInfo::getAdminKey))
+					.givenCurrentFreezeKey(ifPresent(info, TokenInfo::hasFreezeKey, TokenInfo::getFreezeKey))
+					.givenCurrentWipeKey(ifPresent(info, TokenInfo::hasWipeKey, TokenInfo::getWipeKey))
+					.givenCurrentSupplyKey(ifPresent(info, TokenInfo::hasSupplyKey, TokenInfo::getSupplyKey))
+					.givenCurrentKycKey(ifPresent(info, TokenInfo::hasKycKey, TokenInfo::getKycKey))
+					.givenCurrentName(info.getName())
+					.givenCurrentSymbol(info.getSymbol());
+			if (info.hasAutoRenewAccount()) {
+				estimate.givenCurrentlyUsingAutoRenewAccount();
 			}
-		} catch (Exception e) {
-			log.warn("Usage estimation unexpectedly failed for {}!", query, e);
-			throw new IllegalArgumentException(e);
+			return estimate.get();
+		} else {
+			return FeeData.getDefaultInstance();
 		}
 	}
 

--- a/hedera-node/src/test/java/com/hedera/services/fees/calculation/consensus/queries/GetMerkleTopicInfoResourceUsageTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/fees/calculation/consensus/queries/GetMerkleTopicInfoResourceUsageTest.java
@@ -79,7 +79,7 @@ class GetMerkleTopicInfoResourceUsageTest {
 		Query query = topicInfoQuery(topicId, ANSWER_ONLY);
 
 		// expect:
-		assertThrows(IllegalArgumentException.class, () -> subject.usageGiven(query, view));
+		assertSame(FeeData.getDefaultInstance(), subject.usageGiven(query, view));
 	}
 
 	@ParameterizedTest

--- a/hedera-node/src/test/java/com/hedera/services/fees/calculation/contract/queries/GetBytecodeResourceUsageTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/fees/calculation/contract/queries/GetBytecodeResourceUsageTest.java
@@ -101,16 +101,6 @@ class GetBytecodeResourceUsageTest {
 		assertSame(answerOnlyEstimate, answerOnlyUsage);
 	}
 
-	@Test
-	public void throwsIaeOnUnexpectedProblem() {
-		Query answerOnlyQuery = bytecodeQuery(target, ANSWER_ONLY);
-
-		given(view.bytecodeOf(any())).willThrow(IllegalStateException.class);
-
-		// then:
-		assertThrows(IllegalArgumentException.class, () -> subject.usageGiven(answerOnlyQuery, view));
-	}
-
 	private Query bytecodeQuery(ContractID id, ResponseType type) {
 		ContractGetBytecodeQuery.Builder op = ContractGetBytecodeQuery.newBuilder()
 				.setContractID(id)

--- a/hedera-node/src/test/java/com/hedera/services/fees/calculation/contract/queries/GetContractInfoResourceUsageTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/fees/calculation/contract/queries/GetContractInfoResourceUsageTest.java
@@ -155,17 +155,6 @@ class GetContractInfoResourceUsageTest {
 		assertSame(FeeData.getDefaultInstance(), actual);
 	}
 
-	@Test
-	public void rethrowsIae() {
-		// given:
-		Query query = contractInfoQuery(target, ANSWER_ONLY);
-		given(factory.apply(any()))
-				.willThrow(IllegalStateException.class);
-
-		// expect:
-		assertThrows(IllegalArgumentException.class, () -> subject.usageGiven(query, view));
-	}
-
 	private Query contractInfoQuery(ContractID id, ResponseType type) {
 		ContractGetInfoQuery.Builder op = ContractGetInfoQuery.newBuilder()
 				.setContractID(id)

--- a/hedera-node/src/test/java/com/hedera/services/fees/calculation/crypto/queries/GetAccountInfoResourceUsageTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/fees/calculation/crypto/queries/GetAccountInfoResourceUsageTest.java
@@ -146,18 +146,6 @@ class GetAccountInfoResourceUsageTest {
 		assertSame(FeeData.getDefaultInstance(), usage);
 	}
 
-
-	@Test
-	public void throwsIaeWhenAccountIsntKosher() {
-		// given:
-		Query query = accountInfoQuery(a, ANSWER_ONLY);
-		// and:
-		given(accounts.containsKey(any())).willThrow(IllegalStateException.class);
-
-		// expect:
-		assertThrows(IllegalArgumentException.class, () -> subject.usageGiven(query, view));
-	}
-
 	@Test
 	public void recognizesApplicableQuery() {
 		// given:

--- a/hedera-node/src/test/java/com/hedera/services/fees/calculation/crypto/queries/GetAccountRecordsResourceUsageTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/fees/calculation/crypto/queries/GetAccountRecordsResourceUsageTest.java
@@ -36,6 +36,7 @@ import com.hederahashgraph.fee.CryptoFeeBuilder;
 import com.hedera.services.state.merkle.MerkleEntityId;
 import com.hedera.services.state.merkle.MerkleAccount;
 import com.swirlds.fcmap.FCMap;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.platform.runner.JUnitPlatform;
@@ -77,12 +78,12 @@ class GetAccountRecordsResourceUsageTest {
 	}
 
 	@Test
-	public void throwsIaeWhenAccountIsntKosher() {
+	public void returnsEmptyFeeDataWhenAccountMissing() {
 		// given:
 		Query query = accountRecordsQuery(a, ANSWER_ONLY);
 
 		// expect:
-		assertThrows(IllegalArgumentException.class, () -> subject.usageGiven(query, view));
+		Assertions.assertSame(FeeData.getDefaultInstance(), subject.usageGiven(query, view));
 	}
 
 	@Test

--- a/hedera-node/src/test/java/com/hedera/services/fees/calculation/crypto/queries/GetAccountRecordsResourceUsageTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/fees/calculation/crypto/queries/GetAccountRecordsResourceUsageTest.java
@@ -97,6 +97,7 @@ class GetAccountRecordsResourceUsageTest {
 		Query answerOnlyQuery = accountRecordsQuery(a, ANSWER_ONLY);
 		Query costAnswerQuery = accountRecordsQuery(a, COST_ANSWER);
 		given(accounts.get(key)).willReturn(aValue);
+		given(accounts.containsKey(key)).willReturn(true);
 		given(usageEstimator.getCryptoAccountRecordsQueryFeeMatrices(someRecords, COST_ANSWER))
 				.willReturn(costAnswerUsage);
 		given(usageEstimator.getCryptoAccountRecordsQueryFeeMatrices(someRecords, ANSWER_ONLY))

--- a/hedera-node/src/test/java/com/hedera/services/fees/calculation/crypto/queries/GetTxnRecordResourceUsageTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/fees/calculation/crypto/queries/GetTxnRecordResourceUsageTest.java
@@ -219,17 +219,6 @@ class GetTxnRecordResourceUsageTest {
 	}
 
 	@Test
-	public void rethrowsIae() {
-		// given:
-		Query query = txnRecordQuery(missingTxnId, ANSWER_ONLY);
-		given(usageEstimator.getTransactionRecordQueryFeeMatrices(any(), any()))
-				.willThrow(IllegalStateException.class);
-
-		// expect:
-		assertThrows(IllegalArgumentException.class, () -> subject.usageGiven(query, view));
-	}
-
-	@Test
 	public void recognizesApplicableQueries() {
 		// given:
 		Query no = nonTxnRecordQuery();

--- a/hedera-node/src/test/java/com/hedera/services/fees/calculation/file/queries/GetFileContentsResourceUsageTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/fees/calculation/file/queries/GetFileContentsResourceUsageTest.java
@@ -66,13 +66,13 @@ class GetFileContentsResourceUsageTest {
 	}
 
 	@Test
-	public void throwsIaeOnMissingInfo() {
+	public void returnsDefaultSchedulesOnMissing() {
 		Query answerOnlyQuery = fileContentsQuery(target, ANSWER_ONLY);
 
 		given(view.infoForFile(any())).willReturn(Optional.empty());
 
 		// then:
-		assertThrows(IllegalArgumentException.class, () -> subject.usageGiven(answerOnlyQuery, view));
+		assertSame(FeeData.getDefaultInstance(), subject.usageGiven(answerOnlyQuery, view));
 	}
 
 	@Test

--- a/hedera-node/src/test/java/com/hedera/services/fees/calculation/file/queries/GetFileInfoResourceUsageTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/fees/calculation/file/queries/GetFileInfoResourceUsageTest.java
@@ -65,13 +65,13 @@ class GetFileInfoResourceUsageTest {
 	}
 
 	@Test
-	public void throwsIaeOnMissingInfo() {
+	public void returnsDefaultSchedulesOnMissing() {
 		Query answerOnlyQuery = fileInfoQuery(target, ANSWER_ONLY);
 
 		given(view.infoForFile(any())).willReturn(Optional.empty());
 
 		// then:
-		assertThrows(IllegalArgumentException.class, () -> subject.usageGiven(answerOnlyQuery, view));
+		assertSame(FeeData.getDefaultInstance(), subject.usageGiven(answerOnlyQuery, view));
 	}
 
 	@Test

--- a/hedera-node/src/test/java/com/hedera/services/fees/calculation/schedule/queries/GetScheduleInfoResourceUsageTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/fees/calculation/schedule/queries/GetScheduleInfoResourceUsageTest.java
@@ -154,16 +154,6 @@ public class GetScheduleInfoResourceUsageTest {
         assertSame(FeeData.getDefaultInstance(), usage);
     }
 
-    @Test
-    public void rethrowsIae() {
-        // given:
-        Query query = scheduleInfoQuery(target);
-        given(view.infoForSchedule(any())).willThrow(IllegalStateException.class);
-
-        // expect:
-        assertThrows(IllegalArgumentException.class, () -> subject.usageGiven(query, view));
-    }
-
     private Query scheduleInfoQuery(ScheduleID id) {
         return Query.newBuilder()
                 .setScheduleGetInfo(ScheduleGetInfoQuery.newBuilder()

--- a/hedera-node/src/test/java/com/hedera/services/fees/calculation/schedule/queries/GetScheduleInfoResourceUsageTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/fees/calculation/schedule/queries/GetScheduleInfoResourceUsageTest.java
@@ -20,6 +20,8 @@ import com.hederahashgraph.api.proto.java.ScheduleID;
 import com.hederahashgraph.api.proto.java.ScheduleInfo;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.platform.runner.JUnitPlatform;
+import org.junit.runner.RunWith;
 
 import java.util.HashMap;
 import java.util.Optional;
@@ -35,6 +37,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
+@RunWith(JUnitPlatform.class)
 public class GetScheduleInfoResourceUsageTest {
     ScheduleID target = IdUtils.asSchedule("0.0.123");
 

--- a/hedera-node/src/test/java/com/hedera/services/fees/calculation/token/queries/GetTokenInfoResourceUsageTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/fees/calculation/token/queries/GetTokenInfoResourceUsageTest.java
@@ -166,16 +166,6 @@ class GetTokenInfoResourceUsageTest {
 		assertSame(FeeData.getDefaultInstance(), usage);
 	}
 
-	@Test
-	public void rethrowsIae() {
-		// given:
-		Query query = tokenInfoQuery(target, ANSWER_ONLY);
-		given(view.infoForToken(any())).willThrow(IllegalStateException.class);
-
-		// expect:
-		assertThrows(IllegalArgumentException.class, () -> subject.usageGiven(query, view));
-	}
-
 	private Query tokenInfoQuery(TokenID id, ResponseType type) {
 		TokenGetInfoQuery.Builder op = TokenGetInfoQuery.newBuilder()
 				.setToken(id)


### PR DESCRIPTION
**Related issue(s)**:
- Closes #915

**Summary of the change**:
Dispense with the redundant `catch` clauses in all `QueryResourceUsageEstimator.usageGivenType` implementations except for `ContractCallLocalResourceUsage`, which may benefit by translating exceptions thrown by its legacy delegate.

The top-level handler in `QueryAnswerHelper` can do just as well for any unforeseen condition that causes usage estimation to fail with a runtime exception.

**External impacts**:
None.