### PR TITLE
Use MerkleAccountTokens.set instead of System.arraycopy

### DIFF
--- a/hedera-node/src/main/java/com/hedera/services/state/merkle/MerkleAccountTokens.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/merkle/MerkleAccountTokens.java
@@ -223,8 +223,7 @@ public class MerkleAccountTokens extends AbstractMerkleLeaf {
 				if (isGone.test(id)) {
 					continue;
 				}
-				System.arraycopy(tokenIds, i * NUM_ID_PARTS, newTokenIds, j * NUM_ID_PARTS, NUM_ID_PARTS);
-				j++;
+				set(newTokenIds, j++, id);
 			}
 			this.tokenIds = newTokenIds;
 		}
@@ -252,10 +251,10 @@ public class MerkleAccountTokens extends AbstractMerkleLeaf {
 		return i * NUM_ID_PARTS + SHARD_OFFSET;
 	}
 
-	int logicalIndexOf(TokenID token) {
+	private int logicalIndexOf(TokenID token) {
 		int lo = 0, hi = tokenIds.length / NUM_ID_PARTS - 1;
 		while (lo <= hi) {
-			int mid = (lo + (hi - lo) / NUM_ID_PARTS);
+			int mid = lo + (hi - lo) / 2;
 			int comparison = compareImplied(mid, token);
 			if (comparison == 0) {
 				return mid;


### PR DESCRIPTION
**Related issue(s)**:
 - Closes #916

**Summary of the change**:
- Use `MerkleAccountTokens.set` instead of `System.arraycopy` to set token id parts into `long[]` fields.
- Fix typo using non-standard midpoint calculation in `MerkleAccountTokens.logicalIndexOf` binary search.

**External impacts**:
None.