### PR TITLE
Separate side-effects from IssEventInfo.shouldDumpThisRound

### DIFF
--- a/hedera-node/src/main/java/com/hedera/services/context/domain/trackers/IssEventInfo.java
+++ b/hedera-node/src/main/java/com/hedera/services/context/domain/trackers/IssEventInfo.java
@@ -45,7 +45,11 @@ public class IssEventInfo {
 	}
 
 	public boolean shouldDumpThisRound() {
-		return remainingRoundsToDump-- > 0;
+		return remainingRoundsToDump > 0;
+	}
+
+	public void decrementRoundsToDump() {
+		remainingRoundsToDump--;
 	}
 
 	public synchronized void alert(Instant roundConsensusTime) {

--- a/hedera-node/src/main/java/com/hedera/services/state/forensics/IssListener.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/forensics/IssListener.java
@@ -91,6 +91,7 @@ public class IssListener implements InvalidSignedStateListener {
 						encodeHexString(issState.topics().getRootHash().getValue()));
 				log.error(msg);
 				dumpFcms(issState, self, round);
+				issEventInfo.decrementRoundsToDump();
 			}
 		} catch (Exception any) {
 			String fallbackMsg = String.format(

--- a/hedera-node/src/test/java/com/hedera/services/context/domain/trackers/IssEventInfoTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/context/domain/trackers/IssEventInfoTest.java
@@ -71,10 +71,12 @@ class IssEventInfoTest {
 		assertTrue(subject.shouldDumpThisRound());
 
 		// and when:
+		subject.decrementRoundsToDump();
 		subject.alert(recentIssTime);
 		// then:
 		assertEquals(recentIssTime, subject.consensusTimeOfRecentAlert().get());
 		assertTrue(subject.shouldDumpThisRound());
+		subject.decrementRoundsToDump();
 		assertFalse(subject.shouldDumpThisRound());
 	}
 

--- a/hedera-node/src/test/java/com/hedera/services/state/forensics/IssListenerTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/state/forensics/IssListenerTest.java
@@ -200,6 +200,8 @@ class IssListenerTest {
 		inOrder.verify(storageMerkleOut).close();
 		inOrder.verify(topicsMerkleOut).writeMerkleTree(topics);
 		inOrder.verify(topicsMerkleOut).close();
+		// and:
+		inOrder.verify(info).decrementRoundsToDump();
 	}
 
 	@Test


### PR DESCRIPTION
**Related issue(s)**:
- Closes #917

**Summary of the change**:
Convert `IssEventInfo.shouldDumpThisRound()` into a pure method and use `IssEventInfo.decrementRoundsToDump()` to accomplish the current side-effect of `remainingRoundsToDump--`.

**External impacts**:
None.