### PR TITLE
Use commons Pair instead of Map.Entry; simplify iteration in flushMutableRefs

### DIFF
--- a/hedera-node/src/main/java/com/hedera/services/context/ServicesContext.java
+++ b/hedera-node/src/main/java/com/hedera/services/context/ServicesContext.java
@@ -290,6 +290,7 @@ import com.swirlds.common.Console;
 import com.swirlds.common.NodeId;
 import com.swirlds.common.Platform;
 import com.swirlds.fcmap.FCMap;
+import org.apache.commons.lang3.tuple.Pair;
 import org.ethereum.core.AccountState;
 import org.ethereum.datasource.Source;
 import org.ethereum.datasource.StoragePersistence;
@@ -1243,7 +1244,7 @@ public class ServicesContext {
 		return exchange;
 	}
 
-	public BackingStore<Map.Entry<AccountID, TokenID>, MerkleTokenRelStatus> backingTokenRels() {
+	public BackingStore<Pair<AccountID, TokenID>, MerkleTokenRelStatus> backingTokenRels() {
 		if (backingTokenRels == null) {
 			backingTokenRels = new BackingTokenRels(this::tokenAssociations);
 		}
@@ -1273,7 +1274,7 @@ public class ServicesContext {
 
 	public TokenStore tokenStore() {
 		if (tokenStore == null) {
-			TransactionalLedger<Map.Entry<AccountID, TokenID>, TokenRelProperty, MerkleTokenRelStatus> tokenRelsLedger =
+			TransactionalLedger<Pair<AccountID, TokenID>, TokenRelProperty, MerkleTokenRelStatus> tokenRelsLedger =
 					new TransactionalLedger<>(
 							TokenRelProperty.class,
 							MerkleTokenRelStatus::new,

--- a/hedera-node/src/main/java/com/hedera/services/context/ServicesContext.java
+++ b/hedera-node/src/main/java/com/hedera/services/context/ServicesContext.java
@@ -315,7 +315,7 @@ import static com.hedera.services.contracts.sources.AddressKeyedMapFactory.stora
 import static com.hedera.services.files.interceptors.ConfigListUtils.uncheckedParse;
 import static com.hedera.services.files.interceptors.PureRatesValidation.isNormalIntradayChange;
 import static com.hedera.services.ledger.HederaLedger.ACCOUNT_ID_COMPARATOR;
-import static com.hedera.services.ledger.accounts.BackingTokenRels.RELATIONSHIP_COMPARATOR;
+import static com.hedera.services.ledger.accounts.BackingTokenRels.REL_CMP;
 import static com.hedera.services.ledger.ids.ExceptionalEntityIdSource.NOOP_ID_SOURCE;
 import static com.hedera.services.legacy.config.PropertiesLoader.populateAPIPropertiesWithProto;
 import static com.hedera.services.legacy.config.PropertiesLoader.populateApplicationPropertiesWithProto;
@@ -1280,7 +1280,7 @@ public class ServicesContext {
 							MerkleTokenRelStatus::new,
 							backingTokenRels(),
 							new ChangeSummaryManager<>());
-			tokenRelsLedger.setKeyComparator(RELATIONSHIP_COMPARATOR);
+			tokenRelsLedger.setKeyComparator(REL_CMP);
 			tokenRelsLedger.setKeyToString(BackingTokenRels::readableTokenRel);
 			tokenStore = new HederaTokenStore(
 					ids(),

--- a/hedera-node/src/main/java/com/hedera/services/ledger/HederaLedger.java
+++ b/hedera-node/src/main/java/com/hedera/services/ledger/HederaLedger.java
@@ -44,6 +44,7 @@ import com.hederahashgraph.api.proto.java.TokenID;
 import com.hederahashgraph.api.proto.java.TokenTransferList;
 import com.hederahashgraph.api.proto.java.TransferList;
 import com.swirlds.fcqueue.FCQueue;
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -99,7 +100,7 @@ public class HederaLedger {
 	private static final Logger log = LogManager.getLogger(HederaLedger.class);
 
 	static final TransactionalLedger<
-			Map.Entry<AccountID, TokenID>,
+			Pair<AccountID, TokenID>,
 			TokenRelProperty,
 			MerkleTokenRelStatus> UNUSABLE_TOKEN_RELS_LEDGER = null;
 
@@ -129,7 +130,7 @@ public class HederaLedger {
 	final TokenID[] tokensTouched = new TokenID[MAX_CONCEIVABLE_TOKENS_PER_TXN];
 	final Map<TokenID, TransferList.Builder> netTokenTransfers = new HashMap<>();
 	TransactionalLedger<
-			Map.Entry<AccountID, TokenID>,
+			Pair<AccountID, TokenID>,
 			TokenRelProperty,
 			MerkleTokenRelStatus> tokenRelsLedger = UNUSABLE_TOKEN_RELS_LEDGER;
 
@@ -153,7 +154,7 @@ public class HederaLedger {
 	}
 
 	public void setTokenRelsLedger(
-			TransactionalLedger<Map.Entry<AccountID, TokenID>, TokenRelProperty, MerkleTokenRelStatus> tokenRelsLedger
+			TransactionalLedger<Pair<AccountID, TokenID>, TokenRelProperty, MerkleTokenRelStatus> tokenRelsLedger
 	) {
 		this.tokenRelsLedger = tokenRelsLedger;
 	}

--- a/hedera-node/src/main/java/com/hedera/services/ledger/accounts/BackingTokenRels.java
+++ b/hedera-node/src/main/java/com/hedera/services/ledger/accounts/BackingTokenRels.java
@@ -48,9 +48,11 @@ import org.apache.commons.lang3.tuple.Pair;
  * @author Michael Tinker
  */
 public class BackingTokenRels implements BackingStore<Pair<AccountID, TokenID>, MerkleTokenRelStatus> {
-	public static final Comparator<Pair<AccountID, TokenID>> RELATIONSHIP_COMPARATOR = Comparator
-			.<Pair<AccountID, TokenID>, AccountID>comparing(Pair::getLeft, ACCOUNT_ID_COMPARATOR)
-			.thenComparing(Pair::getRight, TOKEN_ID_COMPARATOR);
+	public static final Comparator<Pair<AccountID, TokenID>> REL_CMP =
+			Comparator.<Pair<AccountID, TokenID>, AccountID>comparing(Pair::getLeft, ACCOUNT_ID_COMPARATOR)
+					.thenComparing(Pair::getRight, TOKEN_ID_COMPARATOR);
+	private static final Comparator<Map.Entry<Pair<AccountID, TokenID>, MerkleTokenRelStatus>> REL_ENTRY_CMP =
+			Comparator.comparing(Map.Entry::getKey, REL_CMP);
 
 	Set<Pair<AccountID, TokenID>> existingRels = new HashSet<>();
 	Map<Pair<AccountID, TokenID>, MerkleTokenRelStatus> cache = new HashMap<>();
@@ -72,10 +74,9 @@ public class BackingTokenRels implements BackingStore<Pair<AccountID, TokenID>, 
 
 	@Override
 	public void flushMutableRefs() {
-		cache.keySet().stream()
-				.sorted(RELATIONSHIP_COMPARATOR)
-				.forEach(key ->
-						delegate.get().replace(fromAccountTokenRel(key.getLeft(), key.getRight()), cache.get(key)));
+		cache.entrySet().stream()
+				.sorted(REL_ENTRY_CMP)
+				.forEach(entry -> delegate.get().replace(fromAccountTokenRel(entry.getKey()), entry.getValue()));
 		cache.clear();
 	}
 

--- a/hedera-node/src/main/java/com/hedera/services/ledger/accounts/BackingTokenRels.java
+++ b/hedera-node/src/main/java/com/hedera/services/ledger/accounts/BackingTokenRels.java
@@ -22,12 +22,10 @@ package com.hedera.services.ledger.accounts;
 
 import com.hedera.services.state.merkle.MerkleEntityAssociation;
 import com.hedera.services.state.merkle.MerkleTokenRelStatus;
-import com.hedera.services.utils.EntityIdUtils;
 import com.hederahashgraph.api.proto.java.AccountID;
 import com.hederahashgraph.api.proto.java.TokenID;
 import com.swirlds.fcmap.FCMap;
 
-import java.util.AbstractMap;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -39,6 +37,7 @@ import static com.hedera.services.ledger.HederaLedger.ACCOUNT_ID_COMPARATOR;
 import static com.hedera.services.ledger.HederaLedger.TOKEN_ID_COMPARATOR;
 import static com.hedera.services.state.merkle.MerkleEntityAssociation.fromAccountTokenRel;
 import static com.hedera.services.utils.EntityIdUtils.readableId;
+import org.apache.commons.lang3.tuple.Pair;
 
 /**
  * A store that provides efficient access to the mutable representations
@@ -48,13 +47,13 @@ import static com.hedera.services.utils.EntityIdUtils.readableId;
  *
  * @author Michael Tinker
  */
-public class BackingTokenRels implements BackingStore<Map.Entry<AccountID, TokenID>, MerkleTokenRelStatus> {
-	public static final Comparator<Map.Entry<AccountID, TokenID>> RELATIONSHIP_COMPARATOR = Comparator
-			.<Map.Entry<AccountID, TokenID>, AccountID>comparing(Map.Entry::getKey, ACCOUNT_ID_COMPARATOR)
-			.thenComparing(Map.Entry::getValue, TOKEN_ID_COMPARATOR);
+public class BackingTokenRels implements BackingStore<Pair<AccountID, TokenID>, MerkleTokenRelStatus> {
+	public static final Comparator<Pair<AccountID, TokenID>> RELATIONSHIP_COMPARATOR = Comparator
+			.<Pair<AccountID, TokenID>, AccountID>comparing(Pair::getLeft, ACCOUNT_ID_COMPARATOR)
+			.thenComparing(Pair::getRight, TOKEN_ID_COMPARATOR);
 
-	Set<Map.Entry<AccountID, TokenID>> existingRels = new HashSet<>();
-	Map<Map.Entry<AccountID, TokenID>, MerkleTokenRelStatus> cache = new HashMap<>();
+	Set<Pair<AccountID, TokenID>> existingRels = new HashSet<>();
+	Map<Pair<AccountID, TokenID>, MerkleTokenRelStatus> cache = new HashMap<>();
 
 	private final Supplier<FCMap<MerkleEntityAssociation, MerkleTokenRelStatus>> delegate;
 
@@ -76,24 +75,24 @@ public class BackingTokenRels implements BackingStore<Map.Entry<AccountID, Token
 		cache.keySet().stream()
 				.sorted(RELATIONSHIP_COMPARATOR)
 				.forEach(key ->
-						delegate.get().replace(fromAccountTokenRel(key.getKey(), key.getValue()), cache.get(key)));
+						delegate.get().replace(fromAccountTokenRel(key.getLeft(), key.getRight()), cache.get(key)));
 		cache.clear();
 	}
 
 	@Override
-	public boolean contains(Map.Entry<AccountID, TokenID> key) {
+	public boolean contains(Pair<AccountID, TokenID> key) {
 		return existingRels.contains(key);
 	}
 
 	@Override
-	public MerkleTokenRelStatus getRef(Map.Entry<AccountID, TokenID> key) {
+	public MerkleTokenRelStatus getRef(Pair<AccountID, TokenID> key) {
 		return cache.computeIfAbsent(
 				key,
-				ignore -> delegate.get().getForModify(fromAccountTokenRel(key.getKey(), key.getValue())));
+				ignore -> delegate.get().getForModify(fromAccountTokenRel(key.getLeft(), key.getRight())));
 	}
 
 	@Override
-	public void put(Map.Entry<AccountID, TokenID> key, MerkleTokenRelStatus status) {
+	public void put(Pair<AccountID, TokenID> key, MerkleTokenRelStatus status) {
 		if (!existingRels.contains(key)) {
 			delegate.get().put(fromAccountTokenRel(key), status);
 			existingRels.add(key);
@@ -105,26 +104,26 @@ public class BackingTokenRels implements BackingStore<Map.Entry<AccountID, Token
 	}
 
 	@Override
-	public void remove(Map.Entry<AccountID, TokenID> key) {
-		existingRels.remove(key);
-		delegate.get().remove(fromAccountTokenRel(key));
+	public void remove(Pair<AccountID, TokenID> id) {
+		existingRels.remove(id);
+		delegate.get().remove(fromAccountTokenRel(id));
 	}
 
 	@Override
-	public MerkleTokenRelStatus getUnsafeRef(Map.Entry<AccountID, TokenID> id) {
+	public MerkleTokenRelStatus getUnsafeRef(Pair<AccountID, TokenID> id) {
 		throw new UnsupportedOperationException();
 	}
 
 	@Override
-	public Set<Map.Entry<AccountID, TokenID>> idSet() {
+	public Set<Pair<AccountID, TokenID>> idSet() {
 		throw new UnsupportedOperationException();
 	}
 
-	public static Map.Entry<AccountID, TokenID> asTokenRel(AccountID account, TokenID token) {
-		return new AbstractMap.SimpleImmutableEntry<>(account, token);
+	public static Pair<AccountID, TokenID> asTokenRel(AccountID account, TokenID token) {
+		return Pair.of(account, token);
 	}
 
-	public static String readableTokenRel(Map.Entry<AccountID, TokenID> relationship) {
-		return String.format("%s <-> %s", readableId(relationship.getKey()), readableId(relationship.getValue()));
+	public static String readableTokenRel(Pair<AccountID, TokenID> rel) {
+		return String.format("%s <-> %s", readableId(rel.getLeft()), readableId(rel.getRight()));
 	}
 }

--- a/hedera-node/src/main/java/com/hedera/services/state/merkle/MerkleEntityAssociation.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/merkle/MerkleEntityAssociation.java
@@ -31,11 +31,10 @@ import com.swirlds.common.io.SerializedObjectProvider;
 import com.swirlds.common.merkle.utility.AbstractMerkleLeaf;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.tuple.Pair;
 
 import java.io.DataInputStream;
 import java.io.IOException;
-import java.util.AbstractMap;
-import java.util.Map;
 
 public class MerkleEntityAssociation extends AbstractMerkleLeaf implements FCMKey {
 	static final int MERKLE_VERSION = 1;
@@ -62,8 +61,8 @@ public class MerkleEntityAssociation extends AbstractMerkleLeaf implements FCMKe
 		this.toNum = toNum;
 	}
 
-	public static MerkleEntityAssociation fromAccountTokenRel(Map.Entry<AccountID, TokenID> key) {
-		return fromAccountTokenRel(key.getKey(), key.getValue());
+	public static MerkleEntityAssociation fromAccountTokenRel(Pair<AccountID, TokenID> rel) {
+		return fromAccountTokenRel(rel.getLeft(), rel.getRight());
 	}
 
 	public static MerkleEntityAssociation fromAccountTokenRel(AccountID account, TokenID token) {
@@ -72,8 +71,8 @@ public class MerkleEntityAssociation extends AbstractMerkleLeaf implements FCMKe
 				token.getShardNum(), token.getRealmNum(), token.getTokenNum());
 	}
 
-	public Map.Entry<AccountID, TokenID> asAccountTokenRel() {
-		return new AbstractMap.SimpleImmutableEntry<>(
+	public Pair<AccountID, TokenID> asAccountTokenRel() {
+		return Pair.of(
 				AccountID.newBuilder()
 						.setShardNum(fromShard)
 						.setRealmNum(fromRealm)

--- a/hedera-node/src/main/java/com/hedera/services/store/tokens/HederaTokenStore.java
+++ b/hedera-node/src/main/java/com/hedera/services/store/tokens/HederaTokenStore.java
@@ -43,6 +43,7 @@ import com.hederahashgraph.api.proto.java.TokenCreateTransactionBody;
 import com.hederahashgraph.api.proto.java.TokenID;
 import com.hederahashgraph.api.proto.java.TokenUpdateTransactionBody;
 import com.swirlds.fcmap.FCMap;
+import org.apache.commons.lang3.tuple.Pair;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -109,7 +110,7 @@ public class HederaTokenStore extends HederaStore implements TokenStore {
 	private final GlobalDynamicProperties properties;
 	private final Supplier<FCMap<MerkleEntityId, MerkleToken>> tokens;
 	private final TransactionalLedger<
-			Map.Entry<AccountID, TokenID>,
+			Pair<AccountID, TokenID>,
 			TokenRelProperty,
 			MerkleTokenRelStatus> tokenRelsLedger;
 	Map<AccountID, Set<TokenID>> knownTreasuries = new HashMap<>();
@@ -122,7 +123,7 @@ public class HederaTokenStore extends HederaStore implements TokenStore {
 			OptionValidator validator,
 			GlobalDynamicProperties properties,
 			Supplier<FCMap<MerkleEntityId, MerkleToken>> tokens,
-			TransactionalLedger<Map.Entry<AccountID, TokenID>, TokenRelProperty, MerkleTokenRelStatus> tokenRelsLedger
+			TransactionalLedger<Pair<AccountID, TokenID>, TokenRelProperty, MerkleTokenRelStatus> tokenRelsLedger
 	) {
 		super(ids);
 		this.tokens = tokens;

--- a/hedera-node/src/test/java/com/hedera/services/ledger/BaseHederaLedgerTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/ledger/BaseHederaLedgerTest.java
@@ -42,6 +42,9 @@ import com.hederahashgraph.api.proto.java.FileID;
 import com.hederahashgraph.api.proto.java.ScheduleID;
 import com.hederahashgraph.api.proto.java.TokenID;
 import com.swirlds.fcqueue.FCQueue;
+import org.apache.commons.lang3.tuple.Pair;
+import org.junit.platform.runner.JUnitPlatform;
+import org.junit.runner.RunWith;
 
 import java.util.Collections;
 import java.util.Map;
@@ -59,6 +62,7 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+@RunWith(JUnitPlatform.class)
 public class BaseHederaLedgerTest {
 	protected long GENESIS_BALANCE = 50_000_000_000L;
 	protected long NEXT_ID = 1_000_000L;
@@ -71,7 +75,7 @@ public class BaseHederaLedgerTest {
 	protected ExpiringCreations creator;
 	protected AccountRecordsHistorian historian;
 	protected TransactionalLedger<AccountID, AccountProperty, MerkleAccount> accountsLedger;
-	protected TransactionalLedger<Map.Entry<AccountID, TokenID>, TokenRelProperty, MerkleTokenRelStatus> tokenRelsLedger;
+	protected TransactionalLedger<Pair<AccountID, TokenID>, TokenRelProperty, MerkleTokenRelStatus> tokenRelsLedger;
 	protected AccountID misc = AccountID.newBuilder().setAccountNum(1_234).build();
 	protected long MISC_BALANCE = 1_234L;
 	protected long RAND_BALANCE = 2_345L;

--- a/hedera-node/src/test/java/com/hedera/services/ledger/accounts/BackingTokenRelsTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/ledger/accounts/BackingTokenRelsTest.java
@@ -201,6 +201,7 @@ class BackingTokenRelsTest {
 	private void setupMocked() {
 		rels = mock(FCMap.class);
 		given(rels.keySet()).willReturn(Collections.emptySet());
+		given(rels.entrySet()).willReturn(Collections.emptySet());
 		subject = new BackingTokenRels(() -> rels);
 	}
 }

--- a/hedera-node/src/test/java/com/hedera/services/ledger/accounts/HashMapBackingTokenRels.java
+++ b/hedera-node/src/test/java/com/hedera/services/ledger/accounts/HashMapBackingTokenRels.java
@@ -24,44 +24,45 @@ import com.hedera.services.state.merkle.MerkleTokenRelStatus;
 import com.hedera.test.utils.IdUtils;
 import com.hederahashgraph.api.proto.java.AccountID;
 import com.hederahashgraph.api.proto.java.TokenID;
+import org.apache.commons.lang3.tuple.Pair;
 
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
-public class HashMapBackingTokenRels implements BackingStore<Map.Entry<AccountID, TokenID>, MerkleTokenRelStatus> {
-	private Map<Map.Entry<AccountID, TokenID>, MerkleTokenRelStatus> rels = new HashMap<>();
+public class HashMapBackingTokenRels implements BackingStore<Pair<AccountID, TokenID>, MerkleTokenRelStatus> {
+	private Map<Pair<AccountID, TokenID>, MerkleTokenRelStatus> rels = new HashMap<>();
 
 	@Override
 	public void flushMutableRefs() { }
 
 	@Override
-	public MerkleTokenRelStatus getRef(Map.Entry<AccountID, TokenID> id) {
+	public MerkleTokenRelStatus getRef(Pair<AccountID, TokenID> id) {
 		return rels.get(id);
 	}
 
 	@Override
-	public void put(Map.Entry<AccountID, TokenID> id, MerkleTokenRelStatus rel) {
+	public void put(Pair<AccountID, TokenID> id, MerkleTokenRelStatus rel) {
 		rels.put(id, rel);
 	}
 
 	@Override
-	public boolean contains(Map.Entry<AccountID, TokenID> id) {
+	public boolean contains(Pair<AccountID, TokenID> id) {
 		return rels.containsKey(id);
 	}
 
 	@Override
-	public void remove(Map.Entry<AccountID, TokenID> id) {
+	public void remove(Pair<AccountID, TokenID> id) {
 		rels.remove(id);
 	}
 
 	@Override
-	public Set<Map.Entry<AccountID, TokenID>> idSet() {
+	public Set<Pair<AccountID, TokenID>> idSet() {
 		return rels.keySet();
 	}
 
 	@Override
-	public MerkleTokenRelStatus getUnsafeRef(Map.Entry<AccountID, TokenID> id) {
+	public MerkleTokenRelStatus getUnsafeRef(Pair<AccountID, TokenID> id) {
 		return rels.get(id);
 	}
 }

--- a/hedera-node/src/test/java/com/hedera/services/store/tokens/HederaTokenStoreTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/store/tokens/HederaTokenStoreTest.java
@@ -45,6 +45,7 @@ import com.hederahashgraph.api.proto.java.TokenCreateTransactionBody;
 import com.hederahashgraph.api.proto.java.TokenID;
 import com.hederahashgraph.api.proto.java.TokenUpdateTransactionBody;
 import com.swirlds.fcmap.FCMap;
+import org.apache.commons.lang3.tuple.Pair;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.platform.runner.JUnitPlatform;
@@ -122,7 +123,7 @@ class HederaTokenStoreTest {
 	GlobalDynamicProperties properties;
 	FCMap<MerkleEntityId, MerkleToken> tokens;
 	TransactionalLedger<AccountID, AccountProperty, MerkleAccount> accountsLedger;
-	TransactionalLedger<Map.Entry<AccountID, TokenID>, TokenRelProperty, MerkleTokenRelStatus> tokenRelsLedger;
+	TransactionalLedger<Pair<AccountID, TokenID>, TokenRelProperty, MerkleTokenRelStatus> tokenRelsLedger;
 	HederaLedger hederaLedger;
 
 	MerkleToken token;
@@ -158,8 +159,8 @@ class HederaTokenStoreTest {
 	int MAX_TOKENS_PER_ACCOUNT = 100;
 	int MAX_TOKEN_SYMBOL_UTF8_BYTES = 10;
 	int MAX_TOKEN_NAME_UTF8_BYTES = 100;
-	Map.Entry<AccountID, TokenID> sponsorMisc = asTokenRel(sponsor, misc);
-	Map.Entry<AccountID, TokenID> treasuryMisc = asTokenRel(treasury, misc);
+	Pair<AccountID, TokenID> sponsorMisc = asTokenRel(sponsor, misc);
+	Pair<AccountID, TokenID> treasuryMisc = asTokenRel(treasury, misc);
 
 	HederaTokenStore subject;
 


### PR DESCRIPTION
**Related issue(s)**:
 - Closes #918 
 - Closes #919

**Summary of the change**:
- Use `org.apache.commons.lang3.tuple.Pair` instead of `Map.Entry` to represent account-token relationships.
- Iterate over the cache entry set in `BackingTokenRels.flushMutableRefs` instead of key set.

**External impacts**:
None.