### PR TITLE
Fix misc typos

### DIFF
--- a/hapi-fees/src/main/java/com/hedera/services/usage/SingletonEstimatorUtils.java
+++ b/hapi-fees/src/main/java/com/hedera/services/usage/SingletonEstimatorUtils.java
@@ -30,14 +30,14 @@ import static com.hederahashgraph.fee.FeeBuilder.BASIC_RECEIPT_SIZE;
 import static com.hederahashgraph.fee.FeeBuilder.BASIC_TX_RECORD_SIZE;
 import static com.hederahashgraph.fee.FeeBuilder.FEE_MATRICES_CONST;
 import static com.hederahashgraph.fee.FeeBuilder.INT_SIZE;
-import static com.hederahashgraph.fee.FeeBuilder.RECIEPT_STORAGE_TIME_SEC;
+import static com.hederahashgraph.fee.FeeBuilder.RECEIPT_STORAGE_TIME_SEC;
 
 public enum SingletonEstimatorUtils implements EstimatorUtils {
 	ESTIMATOR_UTILS;
 
 	@Override
 	public long baseNetworkRbs() {
-		return BASIC_RECEIPT_SIZE * RECIEPT_STORAGE_TIME_SEC;
+		return BASIC_RECEIPT_SIZE * RECEIPT_STORAGE_TIME_SEC;
 	}
 
 	@Override
@@ -47,7 +47,7 @@ public enum SingletonEstimatorUtils implements EstimatorUtils {
 				.setVpt(sigUsage.numSigs())
 				.setBpt(baseBodyBytes(txn) + sigUsage.sigsSize());
 		var estimate = new UsageEstimate(base);
-		estimate.addRbs(baseRecordBytes(txn) * RECIEPT_STORAGE_TIME_SEC);
+		estimate.addRbs(baseRecordBytes(txn) * RECEIPT_STORAGE_TIME_SEC);
 		return estimate;
 	}
 

--- a/hapi-fees/src/main/java/com/hedera/services/usage/UsageEstimate.java
+++ b/hapi-fees/src/main/java/com/hedera/services/usage/UsageEstimate.java
@@ -53,4 +53,8 @@ public class UsageEstimate {
 				.setRbh(estimatorUtils.nonDegenerateDiv(rbs, HRS_DIVISOR))
 				.build();
 	}
+
+	public long getRbs() {
+		return rbs;
+	}
 }

--- a/hapi-fees/src/test/java/com/hedera/services/usage/SingletonEstimatorUtilsTest.java
+++ b/hapi-fees/src/test/java/com/hedera/services/usage/SingletonEstimatorUtilsTest.java
@@ -21,6 +21,8 @@ package com.hedera.services.usage;
  */
 
 import com.hedera.services.test.TxnUtils;
+import com.hederahashgraph.api.proto.java.AccountAmount;
+import com.hederahashgraph.api.proto.java.AccountID;
 import com.hederahashgraph.api.proto.java.CryptoTransferTransactionBody;
 import com.hederahashgraph.api.proto.java.Timestamp;
 import com.hederahashgraph.api.proto.java.TransactionBody;
@@ -41,6 +43,7 @@ import static com.hedera.services.test.UsageUtils.NETWORK_RBH;
 import static com.hedera.services.test.UsageUtils.NUM_PAYER_KEYS;
 import static com.hedera.services.usage.SingletonEstimatorUtils.ESTIMATOR_UTILS;
 import static com.hederahashgraph.fee.FeeBuilder.BASIC_RECEIPT_SIZE;
+import static com.hederahashgraph.fee.FeeBuilder.INT_SIZE;
 import static com.hederahashgraph.fee.FeeBuilder.RECEIPT_STORAGE_TIME_SEC;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -52,6 +55,31 @@ class SingletonEstimatorUtilsTest {
 			asAccount("0.0.2"), -2,
 			asAccount("0.0.3"), 1,
 			asAccount("0.0.4"), 1);
+
+	@Test
+	public void hasExpectedBaseEstimate() {
+		// given:
+		TransactionBody txn = TransactionBody.newBuilder()
+				.setMemo("You won't want to hear this.")
+				.setCryptoTransfer(CryptoTransferTransactionBody.newBuilder()
+						.setTransfers(TransferList.newBuilder()
+								.addAccountAmounts(AccountAmount.newBuilder()
+										.setAmount(123L)
+										.setAccountID(AccountID.newBuilder().setAccountNum(75231)))))
+				.build();
+		// and:
+		long expectedBpt = ESTIMATOR_UTILS.baseBodyBytes(txn) + sigUsage.sigsSize();
+		long expectedRbs = ESTIMATOR_UTILS.baseRecordBytes(txn) * RECEIPT_STORAGE_TIME_SEC;
+
+		// when:
+		var est = ESTIMATOR_UTILS.baseEstimate(txn, sigUsage);
+
+		// then:
+		assertEquals(1L * INT_SIZE, est.base().getBpr());
+		assertEquals(sigUsage.numSigs(), est.base().getVpt());
+		assertEquals(expectedBpt, est.base().getBpt());
+		assertEquals(expectedRbs, est.getRbs());
+	}
 
 	@Test
 	public void hasExpectedBaseNetworkRbs() {

--- a/hapi-fees/src/test/java/com/hedera/services/usage/SingletonEstimatorUtilsTest.java
+++ b/hapi-fees/src/test/java/com/hedera/services/usage/SingletonEstimatorUtilsTest.java
@@ -41,7 +41,7 @@ import static com.hedera.services.test.UsageUtils.NETWORK_RBH;
 import static com.hedera.services.test.UsageUtils.NUM_PAYER_KEYS;
 import static com.hedera.services.usage.SingletonEstimatorUtils.ESTIMATOR_UTILS;
 import static com.hederahashgraph.fee.FeeBuilder.BASIC_RECEIPT_SIZE;
-import static com.hederahashgraph.fee.FeeBuilder.RECIEPT_STORAGE_TIME_SEC;
+import static com.hederahashgraph.fee.FeeBuilder.RECEIPT_STORAGE_TIME_SEC;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @RunWith(JUnitPlatform.class)
@@ -56,7 +56,7 @@ class SingletonEstimatorUtilsTest {
 	@Test
 	public void hasExpectedBaseNetworkRbs() {
 		// expect:
-		assertEquals( BASIC_RECEIPT_SIZE * RECIEPT_STORAGE_TIME_SEC, ESTIMATOR_UTILS.baseNetworkRbs());
+		assertEquals( BASIC_RECEIPT_SIZE * RECEIPT_STORAGE_TIME_SEC, ESTIMATOR_UTILS.baseNetworkRbs());
 	}
 
 	@Test

--- a/hapi-proto/src/main/java/com/hederahashgraph/fee/ConsensusServiceFeeBuilder.java
+++ b/hapi-proto/src/main/java/com/hederahashgraph/fee/ConsensusServiceFeeBuilder.java
@@ -53,7 +53,7 @@ public class ConsensusServiceFeeBuilder extends FeeBuilder {
                 txBody, sigValObj,
                 variableSize + LONG_SIZE,  // For autoRenewPeriod
                 extraRbsServices,
-                BASIC_ENTITY_ID_SIZE * RECIEPT_STORAGE_TIME_SEC);  // For topicID in receipt
+                BASIC_ENTITY_ID_SIZE * RECEIPT_STORAGE_TIME_SEC);  // For topicID in receipt
     }
 
     /**
@@ -173,7 +173,7 @@ public class ConsensusServiceFeeBuilder extends FeeBuilder {
                 txBody, sigValObj,
                 submitMessageTxBodySize,
                 0,
-                (LONG_SIZE + TX_HASH_SIZE) * RECIEPT_STORAGE_TIME_SEC);  // For topicSequenceNumber, topicRunningHash
+                (LONG_SIZE + TX_HASH_SIZE) * RECEIPT_STORAGE_TIME_SEC);  // For topicSequenceNumber, topicRunningHash
     }
 
     /**
@@ -196,7 +196,7 @@ public class ConsensusServiceFeeBuilder extends FeeBuilder {
                 + txBodyDataSize
                 + sigValObj.getSignatureSize());
         feeComponentsBuilder.setRbh(
-                getBaseTransactionRecordSize(txBody) * RECIEPT_STORAGE_TIME_SEC
+                getBaseTransactionRecordSize(txBody) * RECEIPT_STORAGE_TIME_SEC
                 + extraRbsServices);
         long rbsNetwork = getDefaultRBHNetworkSize() + extraRbsNetwork;
         return getFeeDataMatrices(feeComponentsBuilder.build(), sigValObj.getPayerAcctSigCount(), rbsNetwork);

--- a/hapi-proto/src/main/java/com/hederahashgraph/fee/CryptoFeeBuilder.java
+++ b/hapi-proto/src/main/java/com/hederahashgraph/fee/CryptoFeeBuilder.java
@@ -69,8 +69,8 @@ public class CryptoFeeBuilder extends FeeBuilder {
     bpt = txBodySize + cryptoCreateSize + sigValObj.getSignatureSize();
     vpt = sigValObj.getTotalSigCount();
     rbs = getCryptoRBS(txBody, cryptoCreateSize)
-        + getBaseTransactionRecordSize(txBody) * RECIEPT_STORAGE_TIME_SEC; // TxRecord
-    long rbsNetwork = getDefaultRBHNetworkSize() + BASIC_ENTITY_ID_SIZE * (RECIEPT_STORAGE_TIME_SEC);
+        + getBaseTransactionRecordSize(txBody) * RECEIPT_STORAGE_TIME_SEC; // TxRecord
+    long rbsNetwork = getDefaultRBHNetworkSize() + BASIC_ENTITY_ID_SIZE * (RECEIPT_STORAGE_TIME_SEC);
 
     bpr = INT_SIZE;
 
@@ -111,7 +111,7 @@ public class CryptoFeeBuilder extends FeeBuilder {
     bpt = txBodySize + 2 * BASIC_ENTITY_ID_SIZE + sigValObj.getSignatureSize();
     vpt = sigValObj.getTotalSigCount();
     // TxRecord
-    rbs = getBaseTransactionRecordSize(txBody) * RECIEPT_STORAGE_TIME_SEC;
+    rbs = getBaseTransactionRecordSize(txBody) * RECEIPT_STORAGE_TIME_SEC;
     long rbsNetwork = getDefaultRBHNetworkSize();
     FeeComponents feeMatricesForTx = FeeComponents.newBuilder().setBpt(bpt).setVpt(vpt).setRbh(rbs)
         .setSbh(sbs).setGas(gas).setTv(tv).setBpr(bpr).setSbpr(sbpr).build();
@@ -150,7 +150,7 @@ public class CryptoFeeBuilder extends FeeBuilder {
 
     bpr = INT_SIZE;
 
-    rbs = getBaseTransactionRecordSize(txBody) * RECIEPT_STORAGE_TIME_SEC;
+    rbs = getBaseTransactionRecordSize(txBody) * RECEIPT_STORAGE_TIME_SEC;
 
     long rbsNetwork = getDefaultRBHNetworkSize();
 
@@ -186,7 +186,7 @@ public class CryptoFeeBuilder extends FeeBuilder {
     // bpt - Bytes per Transaction
     bpt = txBodySize + getCryptoUpdateBodyTxSize(txBody) +  sigValObj.getSignatureSize();
 
-    rbs = getBaseTransactionRecordSize(txBody) * RECIEPT_STORAGE_TIME_SEC;
+    rbs = getBaseTransactionRecordSize(txBody) * RECEIPT_STORAGE_TIME_SEC;
 
     // vpt - verifications per transactions
     vpt = sigValObj.getTotalSigCount();
@@ -641,7 +641,7 @@ public class CryptoFeeBuilder extends FeeBuilder {
     vpt = sigValObj.getTotalSigCount();
     long rbsNetwork = getDefaultRBHNetworkSize();
     rbs = getCryptoLiveHashStorageBytesSec(txBody)
-        + getBaseTransactionRecordSize(txBody) * RECIEPT_STORAGE_TIME_SEC;
+        + getBaseTransactionRecordSize(txBody) * RECEIPT_STORAGE_TIME_SEC;
 
     bpr = INT_SIZE;
 
@@ -680,7 +680,7 @@ public class CryptoFeeBuilder extends FeeBuilder {
 
     long rbsNetwork = getDefaultRBHNetworkSize();
     rbs = getCryptoLiveHashStorageBytesSec(txBody)
-        + getBaseTransactionRecordSize(txBody) * RECIEPT_STORAGE_TIME_SEC;
+        + getBaseTransactionRecordSize(txBody) * RECEIPT_STORAGE_TIME_SEC;
     FeeComponents feeMatricesForTx = FeeComponents.newBuilder().setBpt(bpt).setVpt(vpt).setRbh(rbs)
         .setSbh(sbs).setGas(gas).setTv(tv).setBpr(bpr).setSbpr(sbpr).build();
 

--- a/hapi-proto/src/main/java/com/hederahashgraph/fee/FeeBuilder.java
+++ b/hapi-proto/src/main/java/com/hederahashgraph/fee/FeeBuilder.java
@@ -45,7 +45,7 @@ public class FeeBuilder {
   public static final int KEY_SIZE = 32;
   public static final int TX_HASH_SIZE = 48;
   public static final int DEFAULT_PAYER_ACC_SIG_COUNT = 0;
-  public static final int RECIEPT_STORAGE_TIME_SEC = 180;
+  public static final int RECEIPT_STORAGE_TIME_SEC = 180;
   public static final int THRESHOLD_STORAGE_TIME_SEC = 90000;
   public static final int DEFAULT_RBS_NETWORK = 0;
   public static final int FEE_DIVISOR_FACTOR = 1000;
@@ -346,7 +346,7 @@ public class FeeBuilder {
   }
 
   public static long getDefaultRBHNetworkSize() {
-    return (BASIC_RECEIPT_SIZE) * (RECIEPT_STORAGE_TIME_SEC);
+    return (BASIC_RECEIPT_SIZE) * (RECEIPT_STORAGE_TIME_SEC);
   }
 
   public static int getBaseTransactionRecordSize(TransactionBody txBody) {

--- a/hapi-proto/src/main/java/com/hederahashgraph/fee/FileFeeBuilder.java
+++ b/hapi-proto/src/main/java/com/hederahashgraph/fee/FileFeeBuilder.java
@@ -74,9 +74,9 @@ public class FileFeeBuilder extends FeeBuilder {
 
     bpr = INT_SIZE;
     
-    rbs =  (getBaseTransactionRecordSize(txBody) + BASIC_ENTITY_ID_SIZE/* Added for File ID size*/) * RECIEPT_STORAGE_TIME_SEC;
+    rbs =  (getBaseTransactionRecordSize(txBody) + BASIC_ENTITY_ID_SIZE/* Added for File ID size*/) * RECEIPT_STORAGE_TIME_SEC;
 
-    long rbsNetwork = getDefaultRBHNetworkSize() + BASIC_ENTITY_ID_SIZE * (RECIEPT_STORAGE_TIME_SEC);
+    long rbsNetwork = getDefaultRBHNetworkSize() + BASIC_ENTITY_ID_SIZE * (RECEIPT_STORAGE_TIME_SEC);
 
     FeeComponents feeMatricesForTx = FeeComponents.newBuilder().setBpt(bpt).setVpt(vpt).setRbh(rbs)
         .setSbh(sbs).setGas(gas).setTv(tv).setBpr(bpr).setSbpr(sbpr).build();
@@ -140,7 +140,7 @@ public class FileFeeBuilder extends FeeBuilder {
       sbs = sbsStorageSize * seconds;
     }
     
-    rbs =  getBaseTransactionRecordSize(txBody) * RECIEPT_STORAGE_TIME_SEC;
+    rbs =  getBaseTransactionRecordSize(txBody) * RECEIPT_STORAGE_TIME_SEC;
 
     long rbsNetwork = getDefaultRBHNetworkSize();
 
@@ -196,7 +196,7 @@ public class FileFeeBuilder extends FeeBuilder {
       long seconds = duration.getSeconds();
       sbs = sbsStorageSize * seconds;
     }
-    rbs =  getBaseTransactionRecordSize(txBody) * RECIEPT_STORAGE_TIME_SEC;
+    rbs =  getBaseTransactionRecordSize(txBody) * RECEIPT_STORAGE_TIME_SEC;
     long rbsNetwork = getDefaultRBHNetworkSize();
 
     FeeComponents feeMatricesForTx = FeeComponents.newBuilder().setBpt(bpt).setVpt(vpt).setRbh(rbs)
@@ -413,7 +413,7 @@ public class FileFeeBuilder extends FeeBuilder {
     bpt = bpt + BASIC_ENTITY_ID_SIZE + LONG_SIZE;
     vpt = numSignatures.getTotalSigCount();
     
-    rbs =  getBaseTransactionRecordSize(txBody) * RECIEPT_STORAGE_TIME_SEC;
+    rbs =  getBaseTransactionRecordSize(txBody) * RECEIPT_STORAGE_TIME_SEC;
     
     long rbsNetwork = getDefaultRBHNetworkSize();
 
@@ -445,7 +445,7 @@ public class FileFeeBuilder extends FeeBuilder {
     bpt = getCommonTransactionBodyBytes(txBody);
     bpt = bpt + BASIC_ENTITY_ID_SIZE + LONG_SIZE;
     vpt = numSignatures.getTotalSigCount();
-    rbs =  getBaseTransactionRecordSize(txBody) * RECIEPT_STORAGE_TIME_SEC;
+    rbs =  getBaseTransactionRecordSize(txBody) * RECEIPT_STORAGE_TIME_SEC;
     long rbsNetwork = getDefaultRBHNetworkSize();
 
     // sbs should not be charged as the fee for storage was already paid. What if expiration is changed though?
@@ -483,7 +483,7 @@ public class FileFeeBuilder extends FeeBuilder {
     bpr = INT_SIZE;
 
    
-    rbs =  getBaseTransactionRecordSize(txBody) * RECIEPT_STORAGE_TIME_SEC;
+    rbs =  getBaseTransactionRecordSize(txBody) * RECEIPT_STORAGE_TIME_SEC;
 
     long rbsNetwork = getDefaultRBHNetworkSize();
 

--- a/hapi-proto/src/main/java/com/hederahashgraph/fee/SmartContractFeeBuilder.java
+++ b/hapi-proto/src/main/java/com/hederahashgraph/fee/SmartContractFeeBuilder.java
@@ -20,7 +20,6 @@ package com.hederahashgraph.fee;
  * ‍
  */
 
-import com.google.protobuf.ByteString;
 import com.hederahashgraph.api.proto.java.ContractCallTransactionBody;
 import com.hederahashgraph.api.proto.java.ContractCreateTransactionBody;
 import com.hederahashgraph.api.proto.java.ContractFunctionResult;
@@ -76,8 +75,8 @@ public class SmartContractFeeBuilder extends FeeBuilder {
 
 
     bpr = INT_SIZE;
-    rbs =  getBaseTransactionRecordSize(txBody) * (RECIEPT_STORAGE_TIME_SEC + THRESHOLD_STORAGE_TIME_SEC);
-    long rbsNetwork = getDefaultRBHNetworkSize() + BASIC_ENTITY_ID_SIZE * (RECIEPT_STORAGE_TIME_SEC);
+    rbs =  getBaseTransactionRecordSize(txBody) * (RECEIPT_STORAGE_TIME_SEC + THRESHOLD_STORAGE_TIME_SEC);
+    long rbsNetwork = getDefaultRBHNetworkSize() + BASIC_ENTITY_ID_SIZE * (RECEIPT_STORAGE_TIME_SEC);
 
     FeeComponents feeMatricesForTx = FeeComponents.newBuilder().setBpt(bpt).setVpt(vpt).setRbh(rbs)
         .setSbh(sbs).setGas(gas).setTv(tv).setBpr(bpr).setSbpr(sbpr).build();
@@ -178,7 +177,7 @@ public class SmartContractFeeBuilder extends FeeBuilder {
 
     long rbsNetwork = getDefaultRBHNetworkSize()  ;
     
-    rbs =  getBaseTransactionRecordSize(txBody) * (RECIEPT_STORAGE_TIME_SEC + THRESHOLD_STORAGE_TIME_SEC);
+    rbs =  getBaseTransactionRecordSize(txBody) * (RECEIPT_STORAGE_TIME_SEC + THRESHOLD_STORAGE_TIME_SEC);
 
     FeeComponents feeMatricesForTx = FeeComponents.newBuilder().setBpt(bpt).setVpt(vpt).setRbh(rbs)
         .setSbh(sbs).setGas(gas).setTv(tv).setBpr(bpr).setSbpr(sbpr).build();
@@ -217,7 +216,7 @@ public class SmartContractFeeBuilder extends FeeBuilder {
 
     bpr = INT_SIZE;
 
-    rbs =  getBaseTransactionRecordSize(txBody) * (RECIEPT_STORAGE_TIME_SEC + THRESHOLD_STORAGE_TIME_SEC);
+    rbs =  getBaseTransactionRecordSize(txBody) * (RECEIPT_STORAGE_TIME_SEC + THRESHOLD_STORAGE_TIME_SEC);
     long rbsNetwork = getDefaultRBHNetworkSize() ;
 
     FeeComponents feeMatricesForTx = FeeComponents.newBuilder().setBpt(bpt).setVpt(vpt).setRbh(rbs)
@@ -655,8 +654,8 @@ public class SmartContractFeeBuilder extends FeeBuilder {
 
     bpr = INT_SIZE;
 
-    rbs =  getBaseTransactionRecordSize(txBody) * RECIEPT_STORAGE_TIME_SEC;
-    long rbsNetwork = getDefaultRBHNetworkSize() + BASIC_ENTITY_ID_SIZE * (RECIEPT_STORAGE_TIME_SEC);
+    rbs =  getBaseTransactionRecordSize(txBody) * RECEIPT_STORAGE_TIME_SEC;
+    long rbsNetwork = getDefaultRBHNetworkSize() + BASIC_ENTITY_ID_SIZE * (RECEIPT_STORAGE_TIME_SEC);
 
     FeeComponents feeMatricesForTx = FeeComponents.newBuilder().setBpt(bpt).setVpt(vpt).setRbh(rbs)
         .setSbh(sbs).setGas(gas).setTv(tv).setBpr(bpr).setSbpr(sbpr).build();

--- a/hedera-node/src/main/java/com/hedera/services/fees/calculation/UsageEstimatorUtils.java
+++ b/hedera-node/src/main/java/com/hedera/services/fees/calculation/UsageEstimatorUtils.java
@@ -37,7 +37,7 @@ import static com.hederahashgraph.fee.FeeBuilder.FEE_MATRICES_CONST;
 import static com.hederahashgraph.fee.FeeBuilder.HRS_DIVISOR;
 import static com.hederahashgraph.fee.FeeBuilder.INT_SIZE;
 import static com.hederahashgraph.fee.FeeBuilder.BASIC_TX_BODY_SIZE;
-import static com.hederahashgraph.fee.FeeBuilder.RECIEPT_STORAGE_TIME_SEC;
+import static com.hederahashgraph.fee.FeeBuilder.RECEIPT_STORAGE_TIME_SEC;
 
 public class UsageEstimatorUtils {
 	public static FeeComponents.Builder withBaseTxnUsage(
@@ -48,7 +48,7 @@ public class UsageEstimatorUtils {
 		components.setBpr(INT_SIZE);
 		components.setVpt(sigUsage.getTotalSigCount());
 		components.setBpt(baseBodyBytes(txn) + sigUsage.getSignatureSize());
-		components.setRbh(nonDegenerateDiv(baseRecordBytes(txn) * RECIEPT_STORAGE_TIME_SEC, HRS_DIVISOR));
+		components.setRbh(nonDegenerateDiv(baseRecordBytes(txn) * RECEIPT_STORAGE_TIME_SEC, HRS_DIVISOR));
 
 		return components;
 	}
@@ -97,7 +97,7 @@ public class UsageEstimatorUtils {
 	public static FeeData defaultPartitioning(FeeComponents components, int numPayerKeys) {
 		var partitions = FeeData.newBuilder();
 
-		long networkRbh = nonDegenerateDiv(BASIC_RECEIPT_SIZE * RECIEPT_STORAGE_TIME_SEC, HRS_DIVISOR);
+		long networkRbh = nonDegenerateDiv(BASIC_RECEIPT_SIZE * RECEIPT_STORAGE_TIME_SEC, HRS_DIVISOR);
 		var network = FeeComponents.newBuilder()
 				.setConstant(FEE_MATRICES_CONST)
 				.setBpt(components.getBpt())

--- a/hedera-node/src/main/java/com/hedera/services/store/CreationResult.java
+++ b/hedera-node/src/main/java/com/hedera/services/store/CreationResult.java
@@ -26,11 +26,16 @@ import java.util.Optional;
 
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OK;
 
+/**
+ * A summary of the result of trying to create a store member, such as a token or scheduled entity.
+ *
+ * @param <T> the type of the store member.
+ */
 public class CreationResult<T> {
     private final ResponseCodeEnum status;
     private final Optional<T> created;
 
-    public CreationResult(
+    private CreationResult(
             ResponseCodeEnum status,
             Optional<T> created
     ) {
@@ -38,10 +43,24 @@ public class CreationResult<T> {
         this.created = created;
     }
 
+    /**
+     * Factory to summarize the result of a failed store member creation.
+     *
+     * @param type the kind of failure that occurred.
+     * @param <T> the type of store member being created.
+     * @return the summary constructed.
+     */
     public static <T> CreationResult<T> failure(ResponseCodeEnum type) {
         return new CreationResult<>(type, Optional.empty());
     }
 
+    /**
+     * Factory to summarize the result of a successful store member creation.
+     *
+     * @param created the resulting store member.
+     * @param <T> the type of store member being created.
+     * @return the summary constructed.
+     */
     public static <T> CreationResult<T> success(T created) {
         return new CreationResult<>(OK, Optional.of(created));
     }

--- a/hedera-node/src/test/java/com/hedera/services/fees/calculation/UsageEstimatorUtilsTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/fees/calculation/UsageEstimatorUtilsTest.java
@@ -40,14 +40,23 @@ import org.junit.runner.RunWith;
 import java.time.Instant;
 import java.util.List;
 
+import static com.hedera.services.fees.calculation.UsageEstimatorUtils.baseRecordBytes;
+import static com.hedera.services.fees.calculation.UsageEstimatorUtils.changeInSbsUsage;
+import static com.hedera.services.fees.calculation.UsageEstimatorUtils.defaultPartitioning;
+import static com.hedera.services.fees.calculation.UsageEstimatorUtils.keyBytes;
+import static com.hedera.services.fees.calculation.UsageEstimatorUtils.memoBytesUtf8;
+import static com.hedera.services.fees.calculation.UsageEstimatorUtils.nonDegenerateDiv;
+import static com.hedera.services.fees.calculation.UsageEstimatorUtils.relativeLifetime;
+import static com.hedera.services.fees.calculation.UsageEstimatorUtils.transferListBytes;
+import static com.hedera.services.fees.calculation.UsageEstimatorUtils.withBaseTxnUsage;
+import static com.hedera.services.fees.calculation.UsageEstimatorUtils.zeroedComponents;
 import static com.hederahashgraph.fee.FeeBuilder.HRS_DIVISOR;
-import static com.hederahashgraph.fee.FeeBuilder.RECIEPT_STORAGE_TIME_SEC;
+import static com.hederahashgraph.fee.FeeBuilder.RECEIPT_STORAGE_TIME_SEC;
 import static com.hederahashgraph.fee.FeeBuilder.getDefaultRBHNetworkSize;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static com.hedera.services.fees.calculation.UsageEstimatorUtils.*;
-import static org.mockito.BDDMockito.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.mock;
+import static org.mockito.BDDMockito.verify;
 
 @RunWith(JUnitPlatform.class)
 class UsageEstimatorUtilsTest {
@@ -172,7 +181,7 @@ class UsageEstimatorUtilsTest {
 		verify(components).setVpt(expectedVpt);
 		verify(components).setBpr(FeeBuilder.INT_SIZE);
 		verify(components).setRbh(
-				nonDegenerateDiv(baseRecordBytes(txn) * RECIEPT_STORAGE_TIME_SEC, HRS_DIVISOR));
+				nonDegenerateDiv(baseRecordBytes(txn) * RECEIPT_STORAGE_TIME_SEC, HRS_DIVISOR));
 	}
 
 	@Test

--- a/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/TxnUtils.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/TxnUtils.java
@@ -86,7 +86,7 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SUCCESS;
 import static com.hederahashgraph.fee.FeeBuilder.BASIC_RECEIPT_SIZE;
 import static com.hederahashgraph.fee.FeeBuilder.FEE_MATRICES_CONST;
 import static com.hederahashgraph.fee.FeeBuilder.HRS_DIVISOR;
-import static com.hederahashgraph.fee.FeeBuilder.RECIEPT_STORAGE_TIME_SEC;
+import static com.hederahashgraph.fee.FeeBuilder.RECEIPT_STORAGE_TIME_SEC;
 import static java.util.stream.Collectors.groupingBy;
 import static java.util.stream.Collectors.joining;
 import static com.hedera.services.bdd.spec.HapiPropertySource.asAccount;
@@ -405,7 +405,7 @@ public class TxnUtils {
 	public static FeeData defaultPartitioning(FeeComponents components, int numPayerKeys) {
 		var partitions = FeeData.newBuilder();
 
-		long networkRbh = nonDegenerateDiv(BASIC_RECEIPT_SIZE * RECIEPT_STORAGE_TIME_SEC, HRS_DIVISOR);
+		long networkRbh = nonDegenerateDiv(BASIC_RECEIPT_SIZE * RECEIPT_STORAGE_TIME_SEC, HRS_DIVISOR);
 		var network = FeeComponents.newBuilder()
 				.setConstant(FEE_MATRICES_CONST)
 				.setBpt(components.getBpt())


### PR DESCRIPTION
**Related issue(s)**:
 - Closes #920
 - Closes #921

**Summary of the change**:
- Fix typo in `FeeBuilder.RECIEPT_STORAGE_TIME_SEC`.
- Add Javadoc to `CreationResult<T>` (replacement of `TokenCreationResult`).

**External impacts**:
None.