### PR TITLE
Remove bespoke finally constructs in store implementations

### DIFF
--- a/hedera-node/src/main/java/com/hedera/services/fees/calculation/TxnResourceUsageEstimator.java
+++ b/hedera-node/src/main/java/com/hedera/services/fees/calculation/TxnResourceUsageEstimator.java
@@ -52,16 +52,4 @@ public interface TxnResourceUsageEstimator {
 	 * @throws NullPointerException or analogous if the estimator does not apply to the txn
 	 */
 	FeeData usageGiven(TransactionBody txn, SigValueObj sigUsage, StateView view) throws InvalidTxBodyException;
-
-	/**
-	 * Returns the expected lifetime of an entity, relative to the valid
-	 * start of the given transaction.
-	 *
-	 * @param txn the txn in question
-	 * @param expiry the entity's expiry
-	 * @return the expected lifetime
-	 */
-	default long relativeLifetime(TransactionBody txn, long expiry) {
-		return expiry - txn.getTransactionID().getTransactionValidStart().getSeconds();
-	}
 }

--- a/hedera-node/src/main/java/com/hedera/services/fees/calculation/UsageBasedFeeCalculator.java
+++ b/hedera-node/src/main/java/com/hedera/services/fees/calculation/UsageBasedFeeCalculator.java
@@ -33,15 +33,17 @@ import com.hederahashgraph.api.proto.java.HederaFunctionality;
 import com.hederahashgraph.api.proto.java.Query;
 import com.hederahashgraph.api.proto.java.ResponseType;
 import com.hederahashgraph.api.proto.java.Timestamp;
-import com.hederahashgraph.api.proto.java.TransactionBody;
+import com.hederahashgraph.exception.InvalidTxBodyException;
 import com.hederahashgraph.fee.FeeBuilder;
 import com.hederahashgraph.fee.FeeObject;
 import com.hederahashgraph.fee.SigValueObj;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.function.Function;
 
@@ -111,14 +113,9 @@ public class UsageBasedFeeCalculator implements FeeCalculator {
 			Timestamp at,
 			Function<QueryResourceUsageEstimator, FeeData> usageFn
 	) {
-		try {
-			var usageEstimator = getQueryUsageEstimator(query);
-			var queryUsage = usageFn.apply(usageEstimator);
-			return FeeBuilder.getFeeObject(usagePrices, queryUsage, exchange.rate(at));
-		} catch (Exception illegal) {
-			log.warn("Unexpected failure for {}!", query, illegal);
-			throw new IllegalArgumentException("UsageBasedFeeCalculator#computeGiven");
-		}
+		var usageEstimator = getQueryUsageEstimator(query);
+		var queryUsage = usageFn.apply(usageEstimator);
+		return FeeBuilder.getFeeObject(usagePrices, queryUsage, exchange.rate(at));
 	}
 
 	@Override
@@ -197,14 +194,17 @@ public class UsageBasedFeeCalculator implements FeeCalculator {
 			FeeData prices,
 			ExchangeRate rate
 	) {
+		var sigUsage = getSigUsage(accessor, payerKey);
+		var usageEstimator = getTxnUsageEstimator(accessor);
 		try {
-			var sigUsage = getSigUsage(accessor, payerKey);
-			var usageEstimator = getTxnUsageEstimator(accessor);
-			var metrics = usageEstimator.usageGiven(accessor.getTxn(), sigUsage, view);
+			FeeData metrics = usageEstimator.usageGiven(accessor.getTxn(), sigUsage, view);
 			return FeeBuilder.getFeeObject(prices, metrics, rate);
-		} catch (Exception illegal) {
-			var msg = String.format("Unable to compute fee for %s, key %s!", accessor.getSignedTxn4Log(), payerKey);
-			throw new IllegalArgumentException(msg, illegal);
+		} catch (InvalidTxBodyException e) {
+			log.warn(
+					"Accessor argument {} malformed for implied estimator {}!",
+					accessor.getSignedTxn4Log(),
+					usageEstimator);
+			throw new IllegalArgumentException(e);
 		}
 	}
 
@@ -216,25 +216,20 @@ public class UsageBasedFeeCalculator implements FeeCalculator {
 		if (usageEstimator.isPresent()) {
 			return usageEstimator.get();
 		}
-		throw new IllegalArgumentException("Missing query usage estimator!");
+		throw new NoSuchElementException("No estimator exists for the given query");
 	}
 
 	private TxnResourceUsageEstimator getTxnUsageEstimator(SignedTxnAccessor accessor) {
-		var usageEstimator = Optional.ofNullable(txnUsageEstimators.apply(accessor.getFunction()))
-				.map(estimators -> from(estimators, accessor.getTxn()));
-		if (usageEstimator.isPresent()) {
-			return usageEstimator.get();
-		}
-		throw new IllegalArgumentException("Missing txn usage estimator!");
-	}
-
-	private TxnResourceUsageEstimator from(List<TxnResourceUsageEstimator> estimators, TransactionBody txn) {
-		for (TxnResourceUsageEstimator candidate : estimators) {
-			if (candidate.applicableTo(txn)) {
-				return candidate;
+		var txn = accessor.getTxn();
+		var estimators = Optional
+				.ofNullable(txnUsageEstimators.apply(accessor.getFunction()))
+				.orElse(Collections.emptyList());
+		for (TxnResourceUsageEstimator estimator : estimators) {
+			if (estimator.applicableTo(txn)) {
+				return estimator;
 			}
 		}
-		throw new IllegalArgumentException("Missing txn usage estimator!");
+		throw new NoSuchElementException("No estimator exists for the given transaction");
 	}
 
 	private SigValueObj getSigUsage(SignedTxnAccessor accessor, JKey payerKey) {

--- a/hedera-node/src/main/java/com/hedera/services/store/schedule/HederaScheduleStore.java
+++ b/hedera-node/src/main/java/com/hedera/services/store/schedule/HederaScheduleStore.java
@@ -97,17 +97,15 @@ public class HederaScheduleStore extends HederaStore implements ScheduleStore {
 	@Override
 	public void apply(ScheduleID id, Consumer<MerkleSchedule> change) {
 		throwIfMissing(id);
+
 		var key = fromScheduleId(id);
 		var schedule = schedules.get().getForModify(key);
-		Exception thrown = null;
 		try {
 			change.accept(schedule);
 		} catch (Exception e) {
-			thrown = e;
-		}
-		schedules.get().replace(key, schedule);
-		if (thrown != null) {
-			throw new IllegalArgumentException("Schedule change failed unexpectedly!", thrown);
+			throw new IllegalArgumentException("Schedule change failed unexpectedly!", e);
+		} finally {
+			schedules.get().replace(key, schedule);
 		}
 	}
 

--- a/hedera-node/src/main/java/com/hedera/services/store/tokens/HederaTokenStore.java
+++ b/hedera-node/src/main/java/com/hedera/services/store/tokens/HederaTokenStore.java
@@ -230,15 +230,12 @@ public class HederaTokenStore extends HederaStore implements TokenStore {
 
 		var key = fromTokenId(id);
 		var token = tokens.get().getForModify(key);
-		Exception thrown = null;
 		try {
 			change.accept(token);
 		} catch (Exception e) {
-			thrown = e;
-		}
-		tokens.get().replace(key, token);
-		if (thrown != null) {
-			throw new IllegalArgumentException("Token change failed unexpectedly!", thrown);
+			throw new IllegalArgumentException("Token change failed unexpectedly!", e);
+		} finally {
+			tokens.get().replace(key, token);
 		}
 	}
 

--- a/hedera-node/src/test/java/com/hedera/services/fees/calculation/UsageBasedFeeCalculatorTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/fees/calculation/UsageBasedFeeCalculatorTest.java
@@ -46,6 +46,7 @@ import org.mockito.ArgumentMatcher;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.NoSuchElementException;
 import java.util.function.Function;
 
 import static com.hedera.services.fees.calculation.AwareFcfsUsagePrices.DEFAULT_USAGE_PRICES;
@@ -257,10 +258,10 @@ class UsageBasedFeeCalculatorTest {
 	}
 
 	@Test
-	public void failsWithIaeSansApplicableUsageCalculator() {
+	public void failsWithNseeSansApplicableUsageCalculator() {
 		// expect:
-		assertThrows(IllegalArgumentException.class, () -> subject.computeFee(accessor, payerKey, view));
-		assertThrows(IllegalArgumentException.class,
+		assertThrows(NoSuchElementException.class, () -> subject.computeFee(accessor, payerKey, view));
+		assertThrows(NoSuchElementException.class,
 				() -> subject.computePayment(query, currentPrices, view, at, Collections.emptyMap()));
 	}
 


### PR DESCRIPTION
**NOTE:** I accidentally pushed commits from branch [`0913-M-StandardizeIaeUsage`](https://github.com/hashgraph/hedera-services/tree/0913-M-StandardizeIaeUsage) here, my bad. 🤕 

**Related issue(s)**:
 - Closes #922

**Summary of the change**:
Replace a "bespoke" `finally` construct in `HederaTokenStore` and `HederaScheduleStore` with the language construct.

**External impacts**:
None.