### PR TITLE
Use try-with-resources when opening property files

### DIFF
--- a/hedera-node/src/main/java/com/hedera/services/context/properties/BootstrapProperties.java
+++ b/hedera-node/src/main/java/com/hedera/services/context/properties/BootstrapProperties.java
@@ -57,14 +57,14 @@ public class BootstrapProperties implements PropertySource {
 		}
 		return in;
 	};
-	static ThrowingStreamProvider fileStreamProvider = loc -> Files.newInputStream(Paths.get(loc));
+	private static ThrowingStreamProvider fileStreamProvider = loc -> Files.newInputStream(Paths.get(loc));
 
 	String BOOTSTRAP_PROPS_RESOURCE = "bootstrap.properties";
 	String BOOTSTRAP_OVERRIDE_PROPS_LOC = "data/config/bootstrap.properties";
 
 	Map<String, Object> bootstrapProps = MISSING_PROPS;
 
-	void initPropsFromResource() {
+	private void initPropsFromResource() {
 		var resourceProps = new Properties();
 		load(BOOTSTRAP_PROPS_RESOURCE, resourceProps);
 		loadOverride(BOOTSTRAP_OVERRIDE_PROPS_LOC, resourceProps, fileStreamProvider, log);
@@ -105,9 +105,7 @@ public class BootstrapProperties implements PropertySource {
 	}
 
 	private void load(String resource, Properties intoProps) {
-		InputStream fin;
-		try {
-			fin = resourceStreamProvider.newInputStream(resource);
+		try (InputStream fin = resourceStreamProvider.newInputStream(resource)) {
 			intoProps.load(fin);
 		} catch (IOException e) {
 			throw new IllegalStateException(

--- a/hedera-node/src/main/java/com/hedera/services/context/properties/PropUtils.java
+++ b/hedera-node/src/main/java/com/hedera/services/context/properties/PropUtils.java
@@ -33,9 +33,7 @@ public class PropUtils {
 			ThrowingStreamProvider fileStreamProvider,
 			Logger log
 	) {
-		InputStream fin;
-		try {
-			fin = fileStreamProvider.newInputStream(loc);
+		try (InputStream fin = fileStreamProvider.newInputStream(loc)) {
 			intoProps.load(fin);
 		} catch (IOException ignore) {
 			log.info("No overrides present at {}.", loc);

--- a/hedera-node/src/main/java/com/hedera/services/state/initialization/HfsSystemFilesManager.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/initialization/HfsSystemFilesManager.java
@@ -45,6 +45,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.Comparator;
@@ -243,23 +244,25 @@ public class HfsSystemFilesManager implements SystemFilesManager {
 	}
 
 	private byte[] asSerializedConfig(String resource, String propsLoc) throws IOException {
-		var jutilProps = new Properties();
-		jutilProps.load(Files.newInputStream(Paths.get(propsLoc)));
-		var config = ServicesConfigurationList.newBuilder();
-		var sb = new StringBuilder(String.format("Bootstrapping network %s from '%s':", resource, propsLoc));
-		jutilProps.entrySet()
-				.stream()
-				.sorted(Comparator.comparing(entry -> String.valueOf(entry.getKey())))
-				.peek(entry -> sb.append(String.format(
-						"\n  %s=%s",
-						String.valueOf(entry.getKey()),
-						String.valueOf(entry.getValue()))))
-				.forEach(entry ->
-						config.addNameValue(Setting.newBuilder()
-								.setName(String.valueOf(entry.getKey()))
-								.setValue(String.valueOf(entry.getValue()))));
-		log.info(sb.toString());
-		return config.build().toByteArray();
+		try (InputStream fin = Files.newInputStream(Paths.get(propsLoc))) {
+			var jutilProps = new Properties();
+			jutilProps.load(fin);
+			var config = ServicesConfigurationList.newBuilder();
+			var sb = new StringBuilder(String.format("Bootstrapping network %s from '%s':", resource, propsLoc));
+			jutilProps.entrySet()
+					.stream()
+					.sorted(Comparator.comparing(entry -> String.valueOf(entry.getKey())))
+					.peek(entry -> sb.append(String.format(
+							"\n  %s=%s",
+							String.valueOf(entry.getKey()),
+							String.valueOf(entry.getValue()))))
+					.forEach(entry ->
+							config.addNameValue(Setting.newBuilder()
+									.setName(String.valueOf(entry.getKey()))
+									.setValue(String.valueOf(entry.getValue()))));
+			log.info(sb.toString());
+			return config.build().toByteArray();
+		}
 	}
 
 	private JFileInfo systemFileInfo() {


### PR DESCRIPTION
**Related issue(s)**:
 - Closes #923

**Summary of the change**:
Use try-with-resources when loading properties files in `BootstrapProps.load`, `PropUtils.loadOverride`, and `HfsSystemFilesManager.asSerializedConfig`.

**External impacts**:
None.