### PR TITLE
Fix failing migration test sync

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2052,9 +2052,9 @@ jobs:
       - run:
           name: Sync results of public testnet migration test to AWS
           command: |
-            cd /swirlds-platform/regression/results/4N_1C/Migration/; find . -type d -name data -prune -exec rm -rf {} \;
-            aws s3 sync /swirlds-platform/regression/results/4N_1C/Migration/ s3://hedera-service-regression-jrs;
-            tar -czvf /results.tar.gz  /swirlds-platform/regression/results/4N_1C/Migration/*
+            cd /swirlds-platform/regression/results/5N_1C/Migration/; find . -type d -name data -prune -exec rm -rf {} \;
+            aws s3 sync /swirlds-platform/regression/results/5N_1C/Migration/ s3://hedera-service-regression-jrs;
+            tar -czvf /results.tar.gz  /swirlds-platform/regression/results/5N_1C/Migration/*
 
       - store_artifacts:
           path: /results.tar.gz


### PR DESCRIPTION
Signed-off-by: Neeharika-Sompalli <neeharika.sompalli@hedera.com>

As the folder that is storing results for Migration test is changed to `5N_1C` on `swirlds-platform-regression`, but the sync command is not changed in services side, Migration test results are not synced. Modified the folder name to be synced.

**Related issue(s)**:
Related to https://github.com/swirlds/swirlds-platform-regression/issues/810

