### PR TITLE
Small HTS doc corrections

### DIFF
--- a/hapi-proto/HAPI.html
+++ b/hapi-proto/HAPI.html
@@ -2228,7 +2228,7 @@
         
       
         <h3 id="proto.ScheduleID">ScheduleID</h3>
-        <p>Unique identifier for a schedule entity</p>
+        <p>Unique identifier for a Schedule</p>
 
         
           <table class="field-table">
@@ -8254,7 +8254,7 @@ by HAPI.</p></td>
               <tr>
                 <td>TOKENS_PER_ACCOUNT_LIMIT_EXCEEDED</td>
                 <td>166</td>
-                <td><p>Maximum number of token relations for a given account is exceeded</p></td>
+                <td><p>An involved account already has more than &lt;tt&gt;tokens.maxPerAccount&lt;/tt&gt; associations with non-deleted tokens.</p></td>
               </tr>
             
               <tr>
@@ -8464,7 +8464,31 @@ by HAPI.</p></td>
               <tr>
                 <td>INVALID_SCHEDULE_ID</td>
                 <td>201</td>
-                <td><p>The scheduled transaction entity is invalid or does not exist</p></td>
+                <td><p>The Scheduled entity does not exist</p></td>
+              </tr>
+            
+              <tr>
+                <td>SCHEDULE_IS_IMMUTABLE</td>
+                <td>202</td>
+                <td><p>The Scheduled entity cannot be modified. Admin key not set</p></td>
+              </tr>
+            
+              <tr>
+                <td>SCHEDULE_WAS_DELETED</td>
+                <td>203</td>
+                <td><p>The Scheduled entity was already deleted</p></td>
+              </tr>
+            
+              <tr>
+                <td>INVALID_SCHEDULE_PAYER_ID</td>
+                <td>204</td>
+                <td><p>The provided Scheduled Payer does not exist</p></td>
+              </tr>
+            
+              <tr>
+                <td>INVALID_SCHEDULE_ACCOUNT_ID</td>
+                <td>205</td>
+                <td><p>The Schedule Create Transaction TransactionID account does not exist</p></td>
               </tr>
             
           </tbody>
@@ -9266,14 +9290,14 @@ by HAPI.</p></td>
                   <td>name</td>
                   <td><a href="#string">string</a></td>
                   <td></td>
-                  <td><p>The publicly visible name of the token, specified as a string of only ASCII characters </p></td>
+                  <td><p>The publicly visible name of the token, limited to a UTF-8 encoding of length &lt;tt&gt;tokens.maxSymbolUtf8Bytes&lt;/tt&gt;. </p></td>
                 </tr>
               
                 <tr>
                   <td>symbol</td>
                   <td><a href="#string">string</a></td>
                   <td></td>
-                  <td><p>The publicly visible token symbol. It is UTF-8 capitalized alphabetical string identifying the token </p></td>
+                  <td><p>The publicly visible token symbol, limited to a UTF-8 encoding of length &lt;tt&gt;tokens.maxTokenNameUtf8Bytes&lt;/tt&gt;. </p></td>
                 </tr>
               
                 <tr>
@@ -10039,14 +10063,14 @@ by HAPI.</p></td>
                   <td>symbol</td>
                   <td><a href="#string">string</a></td>
                   <td></td>
-                  <td><p>The new Symbol of the Token. Must be UTF-8 capitalized alphabetical string identifying the token. </p></td>
+                  <td><p>The new publicly visible Token symbol, limited to a UTF-8 encoding of length &lt;tt&gt;tokens.maxTokenNameUtf8Bytes&lt;/tt&gt;. </p></td>
                 </tr>
               
                 <tr>
                   <td>name</td>
                   <td><a href="#string">string</a></td>
                   <td></td>
-                  <td><p>The new Name of the Token. Must be a string of ASCII characters. </p></td>
+                  <td><p>The new publicly visible name of the Token, limited to a UTF-8 encoding of length &lt;tt&gt;tokens.maxSymbolUtf8Bytes&lt;/tt&gt;. </p></td>
                 </tr>
               
                 <tr>

--- a/hapi-proto/src/main/proto/ResponseCode.proto
+++ b/hapi-proto/src/main/proto/ResponseCode.proto
@@ -173,7 +173,7 @@ enum ResponseCodeEnum {
   INVALID_CHUNK_NUMBER = 163; // chunk number must be from 1 to total (chunks) inclusive.
   INVALID_CHUNK_TRANSACTION_ID = 164; // For every chunk, the payer account that is part of initialTransactionID must match the Payer Account of this transaction. The entire initialTransactionID should match the transactionID of the first chunk, but this is not checked or enforced by Hedera except when the chunk number is 1.
   ACCOUNT_FROZEN_FOR_TOKEN = 165; // Account is frozen and cannot transact with the token
-  TOKENS_PER_ACCOUNT_LIMIT_EXCEEDED = 166; // Maximum number of token relations for a given account is exceeded
+  TOKENS_PER_ACCOUNT_LIMIT_EXCEEDED = 166; // An involved account already has more than <tt>tokens.maxPerAccount</tt> associations with non-deleted tokens.
   INVALID_TOKEN_ID = 167; // The token is invalid or does not exist
   INVALID_TOKEN_DECIMALS = 168; // Invalid token decimals
   INVALID_TOKEN_INITIAL_SUPPLY = 169; // Invalid token initial supply

--- a/hapi-proto/src/main/proto/TokenUpdate.proto
+++ b/hapi-proto/src/main/proto/TokenUpdate.proto
@@ -40,8 +40,8 @@ If no value is given for a field, that field is left unchanged. For an immutable
 4. If a new treasury is set, the new treasury account's key must sign the transaction. */
 message TokenUpdateTransactionBody {
     TokenID token = 1; // The Token to be updated
-    string symbol = 2; // The new Symbol of the Token. Must be UTF-8 capitalized alphabetical string identifying the token.
-    string name = 3; // The new Name of the Token. Must be a string of ASCII characters.
+    string symbol = 2; // The new publicly visible Token symbol, limited to a UTF-8 encoding of length <tt>tokens.maxTokenNameUtf8Bytes</tt>.
+    string name = 3; // The new publicly visible name of the Token, limited to a UTF-8 encoding of length <tt>tokens.maxSymbolUtf8Bytes</tt>.
     AccountID treasury = 4; // The new Treasury account of the Token. If the provided treasury account is not existing or deleted, the response will be INVALID_TREASURY_ACCOUNT_FOR_TOKEN. If successful, the Token balance held in the previous Treasury Account is transferred to the new one.
     Key adminKey = 5; // The new admin key of the Token. If Token is immutable, transaction will resolve to TOKEN_IS_IMMUTABlE.
     Key kycKey = 6; // The new KYC key of the Token. If Token does not have currently a KYC key, transaction will resolve to TOKEN_HAS_NO_KYC_KEY.


### PR DESCRIPTION
**Summary of the change**:
Reflect that name/symbol limits are now in terms of UTF-8 bytes; reference `tokens.maxPerAccount` in `TOKENS_PER_ACCOUNT_LIMIT_EXCEEDED` doc.