### PR TITLE
00988: Removes extra QueueThread from RecordStreamManager

### DIFF
--- a/hedera-node/src/main/java/com/hedera/services/stream/RecordStreamManager.java
+++ b/hedera-node/src/main/java/com/hedera/services/stream/RecordStreamManager.java
@@ -131,16 +131,11 @@ public class RecordStreamManager {
 
 		this.runningAvgs = runningAvgs;
 
-		// receives {@link RecordStreamObject}s from runningHashQueueThread, calculates and set runningHash for this object
+		// receives {@link RecordStreamObject}s from hashCalculator, calculates and set runningHash for this object
 		final RunningHashCalculatorForStream<RecordStreamObject> runningHashCalculator =
 				new RunningHashCalculatorForStream<>();
 
-		// receives {@link RecordStreamObject}s from hashCalculator, then passes to runningHashCalculator
-		final QueueThread<RecordStreamObject> runningHashQueueThread = new QueueThread<>("runningHashQueueThread",
-				platform.getSelfId(),
-				runningHashCalculator,
-				nodeLocalProperties.recordStreamQueueCapacity());
-		hashCalculator = new HashCalculatorForStream<>(runningHashQueueThread);
+		hashCalculator = new HashCalculatorForStream<>(runningHashCalculator);
 		hashQueueThread = new QueueThread<>(
 				"hashQueueThread",
 				platform.getSelfId(),

--- a/hedera-node/src/main/java/com/hedera/services/stream/RecordStreamManager.java
+++ b/hedera-node/src/main/java/com/hedera/services/stream/RecordStreamManager.java
@@ -125,8 +125,7 @@ public class RecordStreamManager {
 					platform,
 					startWriteAtCompleteWindow,
 					RecordStreamType.RECORD);
-			writeQueueThread = new QueueThread<>("writeQueueThread", platform.getSelfId(), streamFileWriter,
-					nodeLocalProperties.recordStreamQueueCapacity());
+			writeQueueThread = new QueueThread<>("writeQueueThread", platform.getSelfId(), streamFileWriter);
 		}
 
 		this.runningAvgs = runningAvgs;
@@ -139,8 +138,7 @@ public class RecordStreamManager {
 		hashQueueThread = new QueueThread<>(
 				"hashQueueThread",
 				platform.getSelfId(),
-				hashCalculator,
-				nodeLocalProperties.recordStreamQueueCapacity());
+				hashCalculator);
 
 		multiStream = new MultiStream<>(
 				nodeLocalProperties.isRecordStreamEnabled()


### PR DESCRIPTION
**Related issue(s)**:
Closes #988

**Summary of the change**:
*Performance results*
Crypto-Basic-Performance-10k-46m:
https://hedera-hashgraph.slack.com/archives/C018CBQBTGB/p1611160463074600
Crypto-Restart-1.5k-10m:
https://hedera-hashgraph.slack.com/archives/C018CBQBTGB/p1611179508083700
Misc-UpdateNode-1-6m   against 0.8.2
Misc-Update-1-5m  against 0.8.2
https://hedera-hashgraph.slack.com/archives/C018CBQBTGB/p1611334794022600
Crypto-Restart-1.5k-10m against 0.8.2
https://hedera-hashgraph.slack.com/archives/C018CBQBTGB/p1611339739025000