### PR TITLE
Incorporate LimeChain:feature/scheduled-txs/libs-execution

### DIFF
--- a/hapi-proto/src/main/proto/BasicTypes.proto
+++ b/hapi-proto/src/main/proto/BasicTypes.proto
@@ -64,7 +64,9 @@ message ContractID {
 /* The ID for a transaction. This is used for retrieving receipts and records for a transaction, for appending to a file right after creating it, for instantiating a smart contract with bytecode in a file just created, and internally by the network for detecting when duplicate transactions are submitted. A user might get a transaction processed faster by submitting it to N nodes, each with a different node account, but all with the same TransactionID. Then, the transaction will take effect when the first of all those nodes submits the transaction and it reaches consensus. The other transactions will not take effect. So this could make the transaction take effect faster, if any given node might be slow. However, the full transaction fee is charged for each transaction, so the total fee is N times as much if the transaction is sent to N nodes. */
 message TransactionID {
     Timestamp transactionValidStart = 1; // The transaction is invalid if consensusTimestamp < transactionID.transactionStartValid
-    AccountID accountID = 2; //The Account ID that paid for this transaction
+    AccountID accountID = 2; // The Account ID that paid for this transaction
+    bool scheduled = 3; // Whether the Transaction is of type Scheduled or no
+    bytes nonce = 4; // Used to manipulate the uniqueness check for idempotent schedule transaction creation
 }
 
 /* An account, and the amount that it sends or receives during a cryptocurrency or token transfer. */

--- a/hedera-node/src/main/java/com/hedera/services/context/TransactionContext.java
+++ b/hedera-node/src/main/java/com/hedera/services/context/TransactionContext.java
@@ -20,7 +20,8 @@ package com.hedera.services.context;
  * ‍
  */
 
-import com.hedera.services.utils.PlatformTxnAccessor;
+import com.hedera.services.legacy.core.jproto.JKey;
+import com.hedera.services.utils.TxnAccessor;
 import com.hederahashgraph.api.proto.java.AccountID;
 import com.hederahashgraph.api.proto.java.ContractFunctionResult;
 import com.hederahashgraph.api.proto.java.ContractID;
@@ -30,7 +31,6 @@ import com.hederahashgraph.api.proto.java.ScheduleID;
 import com.hederahashgraph.api.proto.java.TokenID;
 import com.hederahashgraph.api.proto.java.TopicID;
 import com.hederahashgraph.api.proto.java.TransactionRecord;
-import com.hedera.services.legacy.core.jproto.JKey;
 import com.hederahashgraph.api.proto.java.TransferList;
 
 import java.time.Instant;
@@ -51,7 +51,7 @@ public interface TransactionContext {
 	 * @param accessor the consensus platform txn to manage context of.
 	 * @param consensusTime when the txn reached consensus.
 	 */
-	void resetFor(PlatformTxnAccessor accessor, Instant consensusTime, long submittingMember);
+	void resetFor(TxnAccessor accessor, Instant consensusTime, long submittingMember);
 
 	/**
 	 * Checks if the payer is known to have an active signature (that is, whether
@@ -130,12 +130,12 @@ public interface TransactionContext {
 	TransactionRecord updatedRecordGiven(TransferList listWithNewFees);
 
 	/**
-	 * Gets an accessor to the consensus {@link com.swirlds.common.Transaction}
+	 * Gets an accessor to the defined type {@link TxnAccessor}
 	 * currently being processed.
 	 *
 	 * @return accessor for the current txn.
 	 */
-	PlatformTxnAccessor accessor();
+	TxnAccessor accessor();
 
 	/**
 	 * Set a new status for the current txn's processing.
@@ -229,4 +229,15 @@ public interface TransactionContext {
 	 * @param newTotalTokenSupply
 	 */
 	void setNewTotalSupply(long newTotalTokenSupply);
+
+	/**
+	 * Sets a triggered TxnAccessor for execution
+	 * @param accessor
+	 */
+	void trigger(TxnAccessor accessor);
+
+	/**
+	 * Returns a triggered TxnAccessor
+	 */
+	TxnAccessor triggeredTxn();
 }

--- a/hedera-node/src/main/java/com/hedera/services/fees/FeeCalculator.java
+++ b/hedera-node/src/main/java/com/hedera/services/fees/FeeCalculator.java
@@ -22,6 +22,7 @@ package com.hedera.services.fees;
 
 import com.hedera.services.context.primitives.StateView;
 import com.hedera.services.utils.SignedTxnAccessor;
+import com.hedera.services.utils.TxnAccessor;
 import com.hederahashgraph.api.proto.java.FeeData;
 import com.hederahashgraph.api.proto.java.HederaFunctionality;
 import com.hederahashgraph.api.proto.java.Query;
@@ -44,9 +45,9 @@ public interface FeeCalculator {
 
 	long activeGasPriceInTinybars();
 	long estimatedGasPriceInTinybars(HederaFunctionality function, Timestamp at);
-	long estimatedNonFeePayerAdjustments(SignedTxnAccessor accessor, Timestamp at);
-	FeeObject computeFee(SignedTxnAccessor accessor, JKey payerKey, StateView view);
-	FeeObject estimateFee(SignedTxnAccessor accessor, JKey payerKey, StateView view, Timestamp at);
+	long estimatedNonFeePayerAdjustments(TxnAccessor accessor, Timestamp at);
+	FeeObject computeFee(TxnAccessor accessor, JKey payerKey, StateView view);
+	FeeObject estimateFee(TxnAccessor accessor, JKey payerKey, StateView view, Timestamp at);
 	FeeObject estimatePayment(Query query, FeeData usagePrices, StateView view, Timestamp at, ResponseType type);
 	FeeObject computePayment(
 			Query query,

--- a/hedera-node/src/main/java/com/hedera/services/fees/FeeExemptions.java
+++ b/hedera-node/src/main/java/com/hedera/services/fees/FeeExemptions.java
@@ -21,6 +21,7 @@ package com.hedera.services.fees;
  */
 
 import com.hedera.services.utils.SignedTxnAccessor;
+import com.hedera.services.utils.TxnAccessor;
 import com.hederahashgraph.api.proto.java.AccountID;
 import com.hederahashgraph.api.proto.java.TransactionBody;
 
@@ -31,5 +32,5 @@ import com.hederahashgraph.api.proto.java.TransactionBody;
  * @author Michael Tinker
  */
 public interface FeeExemptions {
-	boolean hasExemptPayer(SignedTxnAccessor accessor);
+	boolean hasExemptPayer(TxnAccessor accessor);
 }

--- a/hedera-node/src/main/java/com/hedera/services/fees/StandardExemptions.java
+++ b/hedera-node/src/main/java/com/hedera/services/fees/StandardExemptions.java
@@ -23,6 +23,7 @@ package com.hedera.services.fees;
 import com.hedera.services.config.AccountNumbers;
 import com.hedera.services.security.ops.SystemOpPolicies;
 import com.hedera.services.utils.SignedTxnAccessor;
+import com.hedera.services.utils.TxnAccessor;
 import com.hederahashgraph.api.proto.java.AccountID;
 
 import static com.hedera.services.security.ops.SystemOpAuthorization.AUTHORIZED;
@@ -37,7 +38,7 @@ public class StandardExemptions implements FeeExemptions {
 	}
 
 	@Override
-	public boolean hasExemptPayer(SignedTxnAccessor accessor) {
+	public boolean hasExemptPayer(TxnAccessor accessor) {
 		if (isAlwaysExempt(accessor.getPayer().getAccountNum())) {
 			return true;
 		}

--- a/hedera-node/src/main/java/com/hedera/services/fees/calculation/UsageBasedFeeCalculator.java
+++ b/hedera-node/src/main/java/com/hedera/services/fees/calculation/UsageBasedFeeCalculator.java
@@ -26,6 +26,7 @@ import com.hedera.services.fees.HbarCentExchange;
 import com.hedera.services.keys.HederaKeyTraversal;
 import com.hedera.services.legacy.core.jproto.JKey;
 import com.hedera.services.utils.SignedTxnAccessor;
+import com.hedera.services.utils.TxnAccessor;
 import com.hederahashgraph.api.proto.java.AccountAmount;
 import com.hederahashgraph.api.proto.java.ExchangeRate;
 import com.hederahashgraph.api.proto.java.FeeData;
@@ -122,12 +123,12 @@ public class UsageBasedFeeCalculator implements FeeCalculator {
 	}
 
 	@Override
-	public FeeObject computeFee(SignedTxnAccessor accessor, JKey payerKey, StateView view) {
+	public FeeObject computeFee(TxnAccessor accessor, JKey payerKey, StateView view) {
 		return feeGiven(accessor, payerKey, view, usagePrices.activePrices(), exchange.activeRate());
 	}
 
 	@Override
-	public FeeObject estimateFee(SignedTxnAccessor accessor, JKey payerKey, StateView view, Timestamp at) {
+	public FeeObject estimateFee(TxnAccessor accessor, JKey payerKey, StateView view, Timestamp at) {
 		FeeData prices = uncheckedPricesGiven(accessor, at);
 
 		return feeGiven(accessor, payerKey, view, prices, exchange.rate(at));
@@ -146,7 +147,7 @@ public class UsageBasedFeeCalculator implements FeeCalculator {
 	}
 
 	@Override
-	public long estimatedNonFeePayerAdjustments(SignedTxnAccessor accessor, Timestamp at) {
+	public long estimatedNonFeePayerAdjustments(TxnAccessor accessor, Timestamp at) {
 		switch (accessor.getFunction()) {
 			case CryptoCreate:
 				var cryptoCreateOp = accessor.getTxn().getCryptoCreateAccount();
@@ -181,7 +182,7 @@ public class UsageBasedFeeCalculator implements FeeCalculator {
 		return Math.max(priceInTinyBars, 1L);
 	}
 
-	private FeeData uncheckedPricesGiven(SignedTxnAccessor accessor, Timestamp at) {
+	private FeeData uncheckedPricesGiven(TxnAccessor accessor, Timestamp at) {
 		try {
 			return usagePrices.pricesGiven(accessor.getFunction(), at);
 		} catch (Exception e) {
@@ -191,7 +192,7 @@ public class UsageBasedFeeCalculator implements FeeCalculator {
 	}
 
 	private FeeObject feeGiven(
-			SignedTxnAccessor accessor,
+			TxnAccessor accessor,
 			JKey payerKey,
 			StateView view,
 			FeeData prices,
@@ -219,7 +220,7 @@ public class UsageBasedFeeCalculator implements FeeCalculator {
 		throw new IllegalArgumentException("Missing query usage estimator!");
 	}
 
-	private TxnResourceUsageEstimator getTxnUsageEstimator(SignedTxnAccessor accessor) {
+	private TxnResourceUsageEstimator getTxnUsageEstimator(TxnAccessor accessor) {
 		var usageEstimator = Optional.ofNullable(txnUsageEstimators.apply(accessor.getFunction()))
 				.map(estimators -> from(estimators, accessor.getTxn()));
 		if (usageEstimator.isPresent()) {
@@ -237,7 +238,7 @@ public class UsageBasedFeeCalculator implements FeeCalculator {
 		throw new IllegalArgumentException("Missing txn usage estimator!");
 	}
 
-	private SigValueObj getSigUsage(SignedTxnAccessor accessor, JKey payerKey) {
+	private SigValueObj getSigUsage(TxnAccessor accessor, JKey payerKey) {
 		return new SigValueObj(
 				FeeBuilder.getSignatureCount(accessor.getBackwardCompatibleSignedTxn()),
 				HederaKeyTraversal.numSimpleKeys(payerKey),

--- a/hedera-node/src/main/java/com/hedera/services/fees/charging/FieldSourcedFeeScreening.java
+++ b/hedera-node/src/main/java/com/hedera/services/fees/charging/FieldSourcedFeeScreening.java
@@ -23,6 +23,7 @@ package com.hedera.services.fees.charging;
 import com.hedera.services.fees.FeeExemptions;
 import com.hedera.services.fees.TxnFeeType;
 import com.hedera.services.utils.SignedTxnAccessor;
+import com.hedera.services.utils.TxnAccessor;
 import com.hederahashgraph.api.proto.java.AccountID;
 
 import java.util.EnumMap;
@@ -40,7 +41,7 @@ public class FieldSourcedFeeScreening implements TxnScopedFeeScreening {
 	private boolean payerExemption;
 	private BalanceCheck check;
 	private final FeeExemptions exemptions;
-	protected SignedTxnAccessor accessor;
+	protected TxnAccessor accessor;
 	EnumMap<TxnFeeType, Long> feeAmounts = new EnumMap<>(TxnFeeType.class);
 
 	public FieldSourcedFeeScreening(FeeExemptions exemptions) {
@@ -51,7 +52,7 @@ public class FieldSourcedFeeScreening implements TxnScopedFeeScreening {
 		this.check = check;
 	}
 
-	public void resetFor(SignedTxnAccessor accessor) {
+	public void resetFor(TxnAccessor accessor) {
 		this.accessor = accessor;
 		payerExemption = exemptions.hasExemptPayer(accessor);
 	}

--- a/hedera-node/src/main/java/com/hedera/services/fees/charging/ItemizableFeeCharging.java
+++ b/hedera-node/src/main/java/com/hedera/services/fees/charging/ItemizableFeeCharging.java
@@ -26,6 +26,7 @@ import com.hedera.services.fees.FeeExemptions;
 import com.hedera.services.fees.TxnFeeType;
 import com.hedera.services.ledger.HederaLedger;
 import com.hedera.services.utils.SignedTxnAccessor;
+import com.hedera.services.utils.TxnAccessor;
 import com.hederahashgraph.api.proto.java.AccountAmount;
 import com.hederahashgraph.api.proto.java.AccountID;
 import com.hederahashgraph.api.proto.java.TransferList;
@@ -90,7 +91,7 @@ public class ItemizableFeeCharging extends FieldSourcedFeeScreening implements T
 		return Optional.ofNullable(submittingNodeFeesCharged.get(fee)).orElse(0L);
 	}
 
-	public void resetFor(SignedTxnAccessor accessor, AccountID submittingNode) {
+	public void resetFor(TxnAccessor accessor, AccountID submittingNode) {
 		super.resetFor(accessor);
 
 		node = accessor.getTxn().getNodeAccountID();

--- a/hedera-node/src/main/java/com/hedera/services/fees/charging/TxnFeeChargingPolicy.java
+++ b/hedera-node/src/main/java/com/hedera/services/fees/charging/TxnFeeChargingPolicy.java
@@ -25,9 +25,15 @@ import com.hederahashgraph.fee.FeeObject;
 
 import java.util.function.Consumer;
 
-import static com.hedera.services.fees.charging.ItemizableFeeCharging.*;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.*;
-import static com.hedera.services.fees.TxnFeeType.*;
+import static com.hedera.services.fees.TxnFeeType.NETWORK;
+import static com.hedera.services.fees.TxnFeeType.NODE;
+import static com.hedera.services.fees.TxnFeeType.SERVICE;
+import static com.hedera.services.fees.charging.ItemizableFeeCharging.NETWORK_FEE;
+import static com.hedera.services.fees.charging.ItemizableFeeCharging.NETWORK_NODE_SERVICE_FEES;
+import static com.hedera.services.fees.charging.ItemizableFeeCharging.NODE_FEE;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INSUFFICIENT_PAYER_BALANCE;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INSUFFICIENT_TX_FEE;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OK;
 
 /**
  * Provides the transaction fee-charging policy for the processing

--- a/hedera-node/src/main/java/com/hedera/services/keys/HederaKeyActivation.java
+++ b/hedera-node/src/main/java/com/hedera/services/keys/HederaKeyActivation.java
@@ -21,19 +21,16 @@ package com.hedera.services.keys;
  */
 
 import com.google.protobuf.ByteString;
-import com.hedera.services.sigs.order.HederaSigningOrder;
-import com.hedera.services.sigs.order.SigningOrderResult;
-import com.hedera.services.sigs.order.SigningOrderResultFactory;
-import com.hedera.services.utils.PlatformTxnAccessor;
-import com.hedera.services.utils.SignedTxnAccessor;
-import com.hederahashgraph.api.proto.java.TransactionBody;
 import com.hedera.services.legacy.core.jproto.JKey;
 import com.hedera.services.legacy.core.jproto.JKeyList;
 import com.hedera.services.legacy.core.jproto.JThresholdKey;
 import com.hedera.services.legacy.crypto.SignatureStatus;
+import com.hedera.services.sigs.order.HederaSigningOrder;
+import com.hedera.services.sigs.order.SigningOrderResult;
+import com.hedera.services.sigs.order.SigningOrderResultFactory;
+import com.hedera.services.utils.TxnAccessor;
 import com.swirlds.common.crypto.TransactionSignature;
 import com.swirlds.common.crypto.VerificationStatus;
-import org.apache.commons.codec.binary.Hex;
 
 import java.util.Arrays;
 import java.util.List;
@@ -43,8 +40,8 @@ import java.util.function.BiPredicate;
 import java.util.function.Function;
 
 import static com.hedera.services.keys.DefaultActivationCharacteristics.DEFAULT_ACTIVATION_CHARACTERISTICS;
-import static com.swirlds.common.crypto.VerificationStatus.*;
-import static java.util.Arrays.copyOfRange;
+import static com.swirlds.common.crypto.VerificationStatus.INVALID;
+import static com.swirlds.common.crypto.VerificationStatus.VALID;
 import static java.util.stream.Collectors.toMap;
 
 /**
@@ -79,7 +76,7 @@ public class HederaKeyActivation {
 	 * @return whether the payer's Hedera key is active.
 	 */
 	public static boolean payerSigIsActive(
-			PlatformTxnAccessor accessor,
+			TxnAccessor accessor,
 			HederaSigningOrder keyOrder,
 			SigningOrderResultFactory<SignatureStatus> summaryFactory
 	) {
@@ -132,7 +129,7 @@ public class HederaKeyActivation {
 	}
 
 	public static Function<byte[], TransactionSignature> aproposPkToSigMapFrom(
-		SignedTxnAccessor accessor,
+		TxnAccessor accessor,
 		List<TransactionSignature> sigs
 	) {
 		switch (accessor.getFunction()) {

--- a/hedera-node/src/main/java/com/hedera/services/keys/InHandleActivationHelper.java
+++ b/hedera-node/src/main/java/com/hedera/services/keys/InHandleActivationHelper.java
@@ -22,7 +22,7 @@ package com.hedera.services.keys;
 
 import com.hedera.services.legacy.core.jproto.JKey;
 import com.hedera.services.sigs.order.HederaSigningOrder;
-import com.hedera.services.utils.PlatformTxnAccessor;
+import com.hedera.services.utils.TxnAccessor;
 import com.hederahashgraph.api.proto.java.TransactionBody;
 import com.swirlds.common.crypto.TransactionSignature;
 import org.apache.logging.log4j.LogManager;
@@ -42,7 +42,7 @@ public class InHandleActivationHelper {
 	private static final Logger log = LogManager.getLogger(InHandleActivationHelper.class);
 
 	private static final List<JKey> NO_OTHER_PARTIES = null;
-	private static final PlatformTxnAccessor NO_LAST_ACCESSOR = null;
+	private static final TxnAccessor NO_LAST_ACCESSOR = null;
 	private static final Function<byte[], TransactionSignature> NO_LAST_SIGS_FN = null;
 
 	static Activation activation = HederaKeyActivation::isActive;
@@ -53,17 +53,17 @@ public class InHandleActivationHelper {
 
 	private final HederaSigningOrder keyOrderer;
 	private final CharacteristicsFactory characteristics;
-	private final Supplier<PlatformTxnAccessor> accessorSource;
+	private final Supplier<TxnAccessor> accessorSource;
 
 	private List<JKey> otherParties = NO_OTHER_PARTIES;
-	private PlatformTxnAccessor accessor = NO_LAST_ACCESSOR;
+	private TxnAccessor accessor = NO_LAST_ACCESSOR;
 	private Function<byte[], TransactionSignature> scheduledSigsFn = NO_LAST_SIGS_FN;
 	private Function<byte[], TransactionSignature> nonScheduledSigsFn = NO_LAST_SIGS_FN;
 
 	public InHandleActivationHelper(
 			HederaSigningOrder keyOrderer,
 			CharacteristicsFactory characteristics,
-			Supplier<PlatformTxnAccessor> accessorSource
+			Supplier<TxnAccessor> accessorSource
 	) {
 		this.keyOrderer = keyOrderer;
 		this.characteristics = characteristics;

--- a/hedera-node/src/main/java/com/hedera/services/keys/StandardSyncActivationCheck.java
+++ b/hedera-node/src/main/java/com/hedera/services/keys/StandardSyncActivationCheck.java
@@ -20,14 +20,13 @@ package com.hedera.services.keys;
  * ‍
  */
 
+import com.hedera.services.legacy.core.jproto.JKey;
 import com.hedera.services.sigs.PlatformSigsFactory;
 import com.hedera.services.sigs.factories.TxnScopedPlatformSigFactory;
 import com.hedera.services.sigs.sourcing.PubKeyToSigBytes;
 import com.hedera.services.sigs.verification.SyncVerifier;
-import com.hedera.services.utils.PlatformTxnAccessor;
-import com.hedera.services.utils.SignedTxnAccessor;
+import com.hedera.services.utils.TxnAccessor;
 import com.hederahashgraph.api.proto.java.Transaction;
-import com.hedera.services.legacy.core.jproto.JKey;
 import com.swirlds.common.crypto.TransactionSignature;
 
 import java.util.List;
@@ -38,10 +37,10 @@ public class StandardSyncActivationCheck {
 	public static boolean allKeysAreActive(
 			List<JKey> keys,
 			SyncVerifier syncVerifier,
-			PlatformTxnAccessor accessor,
+			TxnAccessor accessor,
 			PlatformSigsFactory sigsFactory,
 			Function<Transaction, PubKeyToSigBytes> sigBytesProvider,
-			Function<SignedTxnAccessor, TxnScopedPlatformSigFactory> scopedSigProvider,
+			Function<TxnAccessor, TxnScopedPlatformSigFactory> scopedSigProvider,
 			BiPredicate<JKey, Function<byte[], TransactionSignature>> isActive,
 			Function<List<TransactionSignature>, Function<byte[], TransactionSignature>> sigsFnProvider
 	) {

--- a/hedera-node/src/main/java/com/hedera/services/keys/SyncActivationCheck.java
+++ b/hedera-node/src/main/java/com/hedera/services/keys/SyncActivationCheck.java
@@ -20,15 +20,13 @@ package com.hedera.services.keys;
  * ‍
  */
 
+import com.hedera.services.legacy.core.jproto.JKey;
 import com.hedera.services.sigs.PlatformSigsFactory;
 import com.hedera.services.sigs.factories.TxnScopedPlatformSigFactory;
 import com.hedera.services.sigs.sourcing.PubKeyToSigBytes;
 import com.hedera.services.sigs.verification.SyncVerifier;
-import com.hedera.services.utils.PlatformTxnAccessor;
-import com.hedera.services.utils.SignedTxnAccessor;
+import com.hedera.services.utils.TxnAccessor;
 import com.hederahashgraph.api.proto.java.Transaction;
-import com.hedera.services.legacy.core.jproto.JKey;
-import com.swirlds.common.crypto.Signature;
 import com.swirlds.common.crypto.TransactionSignature;
 
 import java.util.List;
@@ -40,10 +38,10 @@ public interface SyncActivationCheck {
 	boolean allKeysAreActive(
 			List<JKey> keys,
 			SyncVerifier syncVerifier,
-			PlatformTxnAccessor accessor,
+			TxnAccessor accessor,
 			PlatformSigsFactory sigsFactory,
 			Function<Transaction, PubKeyToSigBytes> sigBytesProvider,
-			Function<SignedTxnAccessor, TxnScopedPlatformSigFactory> scopedSigProvider,
+			Function<TxnAccessor, TxnScopedPlatformSigFactory> scopedSigProvider,
 			BiPredicate<JKey, Function<byte[], TransactionSignature>> isActive,
 			Function<List<TransactionSignature>, Function<byte[], TransactionSignature>> sigsFnProvider);
 }

--- a/hedera-node/src/main/java/com/hedera/services/queries/answering/AnswerFunctions.java
+++ b/hedera-node/src/main/java/com/hedera/services/queries/answering/AnswerFunctions.java
@@ -28,7 +28,7 @@ import com.hederahashgraph.api.proto.java.CryptoGetAccountRecordsQuery;
 import com.hederahashgraph.api.proto.java.Query;
 import com.hederahashgraph.api.proto.java.TransactionRecord;
 import com.hedera.services.state.merkle.MerkleEntityId;
-import com.hedera.services.legacy.core.jproto.TxnId;
+import com.hedera.services.state.submerkle.TxnId;
 import com.hedera.services.state.submerkle.ExpirableTxnRecord;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;

--- a/hedera-node/src/main/java/com/hedera/services/security/ops/SystemOpPolicies.java
+++ b/hedera-node/src/main/java/com/hedera/services/security/ops/SystemOpPolicies.java
@@ -21,7 +21,7 @@ package com.hedera.services.security.ops;
  */
 
 import com.hedera.services.config.EntityNumbers;
-import com.hedera.services.utils.SignedTxnAccessor;
+import com.hedera.services.utils.TxnAccessor;
 import com.hederahashgraph.api.proto.java.ContractID;
 import com.hederahashgraph.api.proto.java.FileID;
 import com.hederahashgraph.api.proto.java.HederaFunctionality;
@@ -73,7 +73,7 @@ public class SystemOpPolicies {
 		functionPolicies.put(UncheckedSubmit, this::checkUncheckedSubmit);
 	}
 
-	public SystemOpAuthorization check(SignedTxnAccessor accessor) {
+	public SystemOpAuthorization check(TxnAccessor accessor) {
 		return check(accessor.getTxn(), accessor.getFunction());
 	}
 

--- a/hedera-node/src/main/java/com/hedera/services/sigs/HederaToPlatformSigOps.java
+++ b/hedera-node/src/main/java/com/hedera/services/sigs/HederaToPlatformSigOps.java
@@ -21,6 +21,7 @@ package com.hedera.services.sigs;
  */
 
 import com.hedera.services.legacy.core.jproto.JKey;
+import com.hedera.services.legacy.crypto.SignatureStatus;
 import com.hedera.services.sigs.factories.TxnScopedPlatformSigFactory;
 import com.hedera.services.sigs.order.HederaSigningOrder;
 import com.hedera.services.sigs.order.SigStatusOrderResultFactory;
@@ -28,12 +29,10 @@ import com.hedera.services.sigs.sourcing.PubKeyToSigBytesProvider;
 import com.hedera.services.sigs.verification.SyncVerifier;
 import com.hedera.services.utils.PlatformTxnAccessor;
 import com.hedera.services.utils.SignedTxnAccessor;
+import com.hedera.services.utils.TxnAccessor;
 import com.hederahashgraph.api.proto.java.Transaction;
-import com.hedera.services.legacy.crypto.SignatureStatus;
 import com.swirlds.common.crypto.Signature;
 import com.swirlds.common.crypto.VerificationStatus;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 import java.util.function.Function;
 
@@ -127,11 +126,11 @@ public class HederaToPlatformSigOps {
 	 * @return a representation of the outcome.
 	 */
 	public static SignatureStatus rationalizeIn(
-			PlatformTxnAccessor txnAccessor,
+			TxnAccessor txnAccessor,
 			SyncVerifier syncVerifier,
 			HederaSigningOrder keyOrderer,
 			PubKeyToSigBytesProvider sigsProvider,
-			Function<SignedTxnAccessor, TxnScopedPlatformSigFactory> sigFactoryCreator
+			Function<TxnAccessor, TxnScopedPlatformSigFactory> sigFactoryCreator
 	) {
 		return new Rationalization(
 				txnAccessor,

--- a/hedera-node/src/main/java/com/hedera/services/sigs/Rationalization.java
+++ b/hedera-node/src/main/java/com/hedera/services/sigs/Rationalization.java
@@ -29,8 +29,7 @@ import com.hedera.services.sigs.order.SigningOrderResult;
 import com.hedera.services.sigs.sourcing.PubKeyToSigBytes;
 import com.hedera.services.sigs.sourcing.PubKeyToSigBytesProvider;
 import com.hedera.services.sigs.verification.SyncVerifier;
-import com.hedera.services.utils.PlatformTxnAccessor;
-import com.hedera.services.utils.SignedTxnAccessor;
+import com.hedera.services.utils.TxnAccessor;
 import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
 import com.hederahashgraph.api.proto.java.Transaction;
 import com.hederahashgraph.api.proto.java.TransactionBody;
@@ -57,17 +56,17 @@ public class Rationalization {
 
 	private final SyncVerifier syncVerifier;
 	private final List<TransactionSignature> txnSigs;
-	private final PlatformTxnAccessor txnAccessor;
+	private final TxnAccessor txnAccessor;
 	private final HederaSigningOrder keyOrderer;
 	private final PubKeyToSigBytesProvider sigsProvider;
 	private final TxnScopedPlatformSigFactory sigFactory;
 
 	public Rationalization(
-			PlatformTxnAccessor txnAccessor,
+			TxnAccessor txnAccessor,
 			SyncVerifier syncVerifier,
 			HederaSigningOrder keyOrderer,
 			PubKeyToSigBytesProvider sigsProvider,
-			Function<SignedTxnAccessor, TxnScopedPlatformSigFactory> sigFactoryCreator
+			Function<TxnAccessor, TxnScopedPlatformSigFactory> sigFactoryCreator
 	) {
 		this.txnAccessor = txnAccessor;
 		this.syncVerifier = syncVerifier;

--- a/hedera-node/src/main/java/com/hedera/services/sigs/factories/BodySigningSigFactory.java
+++ b/hedera-node/src/main/java/com/hedera/services/sigs/factories/BodySigningSigFactory.java
@@ -21,7 +21,7 @@ package com.hedera.services.sigs.factories;
  */
 
 import com.google.protobuf.ByteString;
-import com.hedera.services.utils.SignedTxnAccessor;
+import com.hedera.services.utils.TxnAccessor;
 import com.swirlds.common.crypto.TransactionSignature;
 
 /**
@@ -32,9 +32,9 @@ import com.swirlds.common.crypto.TransactionSignature;
  * @author Michael Tinker
  */
 public class BodySigningSigFactory implements TxnScopedPlatformSigFactory {
-	private final SignedTxnAccessor accessor;
+	private final TxnAccessor accessor;
 
-	public BodySigningSigFactory(SignedTxnAccessor accessor) {
+	public BodySigningSigFactory(TxnAccessor accessor) {
 		this.accessor = accessor;
 	}
 

--- a/hedera-node/src/main/java/com/hedera/services/sigs/factories/SigFactoryCreator.java
+++ b/hedera-node/src/main/java/com/hedera/services/sigs/factories/SigFactoryCreator.java
@@ -22,7 +22,7 @@ package com.hedera.services.sigs.factories;
 
 import com.hedera.services.state.merkle.MerkleEntityId;
 import com.hedera.services.state.merkle.MerkleSchedule;
-import com.hedera.services.utils.SignedTxnAccessor;
+import com.hedera.services.utils.TxnAccessor;
 import com.swirlds.fcmap.FCMap;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -42,7 +42,7 @@ public class SigFactoryCreator {
 		this.scheduledTxns = scheduledTxns;
 	}
 
-	public TxnScopedPlatformSigFactory createScopedFactory(SignedTxnAccessor accessor) {
+	public TxnScopedPlatformSigFactory createScopedFactory(TxnAccessor accessor) {
 		switch (accessor.getFunction()) {
 			case ScheduleCreate:
 				return new ScheduleBodySigningSigFactory(

--- a/hedera-node/src/main/java/com/hedera/services/sigs/sourcing/ScopedSigBytesProvider.java
+++ b/hedera-node/src/main/java/com/hedera/services/sigs/sourcing/ScopedSigBytesProvider.java
@@ -20,7 +20,7 @@ package com.hedera.services.sigs.sourcing;
  * ‍
  */
 
-import com.hedera.services.utils.SignedTxnAccessor;
+import com.hedera.services.utils.TxnAccessor;
 import com.hederahashgraph.api.proto.java.Transaction;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -30,7 +30,7 @@ public class ScopedSigBytesProvider implements PubKeyToSigBytesProvider {
 
 	final PubKeyToSigBytes delegate;
 
-	public ScopedSigBytesProvider(SignedTxnAccessor accessor) {
+	public ScopedSigBytesProvider(TxnAccessor accessor) {
 		switch (accessor.getFunction()) {
 			case ScheduleSign:
 				var scheduleSignSigMap = accessor.getTxn().getScheduleSign().getSigMap();

--- a/hedera-node/src/main/java/com/hedera/services/sigs/utils/StatusUtils.java
+++ b/hedera-node/src/main/java/com/hedera/services/sigs/utils/StatusUtils.java
@@ -20,10 +20,10 @@ package com.hedera.services.sigs.utils;
  * ‍
  */
 
-import com.hedera.services.utils.PlatformTxnAccessor;
-import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
 import com.hedera.services.legacy.crypto.SignatureStatus;
 import com.hedera.services.legacy.crypto.SignatureStatusCode;
+import com.hedera.services.utils.TxnAccessor;
+import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
 
 /**
  * Provides static factories of {@link SignatureStatus} instances representing various
@@ -40,7 +40,7 @@ public class StatusUtils {
 	 * @param platformTxn the platform txn experiencing success.
 	 * @return the desired representation of success.
 	 */
-	public static SignatureStatus successFor(boolean inHandleCtx, PlatformTxnAccessor platformTxn) {
+	public static SignatureStatus successFor(boolean inHandleCtx, TxnAccessor platformTxn) {
 		return new SignatureStatus(
 				SignatureStatusCode.SUCCESS, ResponseCodeEnum.OK,
 				inHandleCtx, platformTxn.getTxnId(),

--- a/hedera-node/src/main/java/com/hedera/services/state/logic/ServicesTxnManager.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/logic/ServicesTxnManager.java
@@ -21,7 +21,7 @@ package com.hedera.services.state.logic;
  */
 
 import com.hedera.services.context.ServicesContext;
-import com.hedera.services.utils.PlatformTxnAccessor;
+import com.hedera.services.utils.TxnAccessor;
 
 import java.time.Instant;
 import java.util.function.BiConsumer;
@@ -31,22 +31,25 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.FAIL_INVALID;
 public class ServicesTxnManager {
 	private final Runnable scopedProcessing;
 	private final Runnable scopedRecordStreaming;
+	private final Runnable scopedTriggeredProcessing;
 	private final BiConsumer<Exception, String> warning;
 
 	public ServicesTxnManager(
 			Runnable scopedProcessing,
 			Runnable scopedRecordStreaming,
+			Runnable scopedTriggeredProcessing,
 			BiConsumer<Exception, String> warning
 	) {
 		this.warning = warning;
 		this.scopedProcessing = scopedProcessing;
 		this.scopedRecordStreaming = scopedRecordStreaming;
+		this.scopedTriggeredProcessing = scopedTriggeredProcessing;
 	}
 
 	private boolean createdStreamableRecord;
 
 	public void process(
-			PlatformTxnAccessor accessor,
+			TxnAccessor accessor,
 			Instant consensusTime,
 			long submittingMember,
 			ServicesContext ctx
@@ -56,7 +59,11 @@ public class ServicesTxnManager {
 		try {
 			ctx.ledger().begin();
 			ctx.txnCtx().resetFor(accessor, consensusTime, submittingMember);
-			scopedProcessing.run();
+			if (accessor.isTriggeredTxn()) {
+				scopedTriggeredProcessing.run();
+			} else {
+				scopedProcessing.run();
+			}
 		} catch (Exception processFailure) {
 			warning.accept(processFailure, "txn processing");
 			ctx.txnCtx().setStatus(FAIL_INVALID);
@@ -77,7 +84,7 @@ public class ServicesTxnManager {
 	}
 
 	private void attemptCommit(
-			PlatformTxnAccessor accessor,
+			TxnAccessor accessor,
 			Instant consensusTime,
 			long submittingMember,
 			ServicesContext ctx
@@ -92,7 +99,7 @@ public class ServicesTxnManager {
 	}
 
 	private void attemptRollback(
-			PlatformTxnAccessor accessor,
+			TxnAccessor accessor,
 			Instant consensusTime,
 			long submittingMember,
 			ServicesContext ctx

--- a/hedera-node/src/main/java/com/hedera/services/state/submerkle/ExpirableTxnRecord.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/submerkle/ExpirableTxnRecord.java
@@ -22,7 +22,6 @@ package com.hedera.services.state.submerkle;
 
 import com.google.common.base.MoreObjects;
 import com.google.protobuf.ByteString;
-import com.hedera.services.legacy.core.jproto.TxnId;
 import com.hedera.services.legacy.core.jproto.TxnReceipt;
 import com.hedera.services.state.serdes.DomainSerdes;
 import com.hederahashgraph.api.proto.java.TokenTransferList;
@@ -32,7 +31,6 @@ import java.io.DataInputStream;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.IntStream;
@@ -96,6 +94,7 @@ public class ExpirableTxnRecord implements FCQueueElement<ExpirableTxnRecord> {
 
 	@Override
 	public void release() {
+		/* No-op */
 	}
 
 	@Deprecated

--- a/hedera-node/src/main/java/com/hedera/services/store/schedule/CompositeKey.java
+++ b/hedera-node/src/main/java/com/hedera/services/store/schedule/CompositeKey.java
@@ -20,7 +20,10 @@ package com.hedera.services.store.schedule;
  * ‍
  */
 
+import com.hedera.services.state.merkle.MerkleSchedule;
 import com.hederahashgraph.api.proto.java.AccountID;
+
+import java.util.Arrays;
 
 public class CompositeKey {
     private final int hash;
@@ -52,5 +55,9 @@ public class CompositeKey {
             result = 31 * result + id.hashCode();
         }
         return result;
+    }
+
+    public static CompositeKey fromMerkleSchedule(MerkleSchedule schedule) {
+        return new CompositeKey(Arrays.hashCode(schedule.transactionBody()), schedule.payer().toGrpcAccountId());
     }
 }

--- a/hedera-node/src/main/java/com/hedera/services/store/schedule/ExceptionalScheduleStore.java
+++ b/hedera-node/src/main/java/com/hedera/services/store/schedule/ExceptionalScheduleStore.java
@@ -76,6 +76,9 @@ public enum ExceptionalScheduleStore implements ScheduleStore {
 	}
 
 	@Override
+	public ResponseCodeEnum markAsExecuted(ScheduleID id) { throw new UnsupportedOperationException(); }
+
+	@Override
 	public ResponseCodeEnum delete(ScheduleID id) { throw new UnsupportedOperationException(); }
 
 	@Override

--- a/hedera-node/src/main/java/com/hedera/services/store/schedule/ScheduleStore.java
+++ b/hedera-node/src/main/java/com/hedera/services/store/schedule/ScheduleStore.java
@@ -48,6 +48,7 @@ public interface ScheduleStore extends Store<ScheduleID, MerkleSchedule> {
 	ResponseCodeEnum addSigners(ScheduleID sID, Set<JKey> keys);
 
 	Optional<ScheduleID> lookupScheduleId(byte[] bodyBytes, AccountID scheduledTxPayer);
+	ResponseCodeEnum markAsExecuted(ScheduleID id);
 
 	default ScheduleID resolve(ScheduleID id) {
 		return exists(id) ? id : MISSING_SCHEDULE;

--- a/hedera-node/src/main/java/com/hedera/services/txns/schedule/ScheduleReadyForExecution.java
+++ b/hedera-node/src/main/java/com/hedera/services/txns/schedule/ScheduleReadyForExecution.java
@@ -1,0 +1,80 @@
+package com.hedera.services.txns.schedule;
+
+/*-
+ * ‌
+ * Hedera Services Node
+ * ​
+ * Copyright (C) 2018 - 2020 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.hedera.services.context.TransactionContext;
+import com.hedera.services.state.merkle.MerkleSchedule;
+import com.hedera.services.store.schedule.ScheduleStore;
+import com.hedera.services.utils.MiscUtils;
+import com.hedera.services.utils.TriggeredTxnAccessor;
+import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
+import com.hederahashgraph.api.proto.java.ScheduleID;
+import com.hederahashgraph.api.proto.java.SignedTransaction;
+import com.hederahashgraph.api.proto.java.Transaction;
+import com.hederahashgraph.api.proto.java.TransactionBody;
+import com.hederahashgraph.api.proto.java.TransactionID;
+
+public abstract class ScheduleReadyForExecution {
+    protected final ScheduleStore store;
+    protected final TransactionContext txnCtx;
+
+    protected ScheduleReadyForExecution(
+            ScheduleStore store,
+            TransactionContext context) {
+        this.store = store;
+        this.txnCtx = context;
+    }
+
+    protected Transaction prepareTransaction(MerkleSchedule schedule) throws InvalidProtocolBufferException {
+        var transactionBody = TransactionBody.parseFrom(schedule.transactionBody());
+        var transactionId = TransactionID.newBuilder()
+                .setAccountID(schedule.schedulingAccount().toGrpcAccountId())
+                .setTransactionValidStart(MiscUtils.asTimestamp(schedule.schedulingTXValidStart().toJava()))
+                .setNonce(transactionBody.getTransactionID().getNonce())
+                .setScheduled(true)
+                .build();
+
+        return Transaction.newBuilder()
+                .setSignedTransactionBytes(
+                        SignedTransaction.newBuilder()
+                                .setBodyBytes(
+                                        TransactionBody.newBuilder()
+                                                .mergeFrom(transactionBody)
+                                                .setTransactionID(transactionId)
+                                                .build().toByteString())
+                                .build().toByteString())
+                .build();
+    }
+
+    protected ResponseCodeEnum processExecution(ScheduleID id) throws InvalidProtocolBufferException {
+        var schedule = store.get(id);
+        var transaction = prepareTransaction(schedule);
+
+        txnCtx.trigger(
+                new TriggeredTxnAccessor(
+                        transaction.toByteArray(),
+                        schedule.payer().toGrpcAccountId(),
+                        id));
+
+        return store.markAsExecuted(id);
+    }
+}

--- a/hedera-node/src/main/java/com/hedera/services/txns/validation/OptionValidator.java
+++ b/hedera-node/src/main/java/com/hedera/services/txns/validation/OptionValidator.java
@@ -24,13 +24,12 @@ import com.hedera.services.context.primitives.StateView;
 import com.hedera.services.state.merkle.MerkleAccount;
 import com.hedera.services.state.merkle.MerkleEntityId;
 import com.hedera.services.state.merkle.MerkleTopic;
-import com.hedera.services.utils.SignedTxnAccessor;
+import com.hedera.services.utils.TxnAccessor;
 import com.hederahashgraph.api.proto.java.AccountID;
 import com.hederahashgraph.api.proto.java.ContractID;
 import com.hederahashgraph.api.proto.java.Duration;
 import com.hederahashgraph.api.proto.java.FileID;
 import com.hederahashgraph.api.proto.java.Key;
-import com.hederahashgraph.api.proto.java.ResponseCode;
 import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
 import com.hederahashgraph.api.proto.java.Timestamp;
 import com.hederahashgraph.api.proto.java.TokenTransferList;
@@ -87,7 +86,7 @@ public interface OptionValidator {
 		return amount >= 0;
 	}
 
-	default ResponseCodeEnum chronologyStatus(SignedTxnAccessor accessor, Instant consensusTime) {
+	default ResponseCodeEnum chronologyStatus(TxnAccessor accessor, Instant consensusTime) {
 		return PureValidation.chronologyStatus(
 				consensusTime,
 				asCoercedInstant(accessor.getTxnId().getTransactionValidStart()),

--- a/hedera-node/src/main/java/com/hedera/services/utils/SignedTxnAccessor.java
+++ b/hedera-node/src/main/java/com/hedera/services/utils/SignedTxnAccessor.java
@@ -23,9 +23,9 @@ package com.hedera.services.utils;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.hedera.services.exceptions.UnknownHederaFunctionality;
-import com.hedera.services.legacy.proto.utils.CommonUtils;
 import com.hederahashgraph.api.proto.java.AccountID;
 import com.hederahashgraph.api.proto.java.HederaFunctionality;
+import com.hederahashgraph.api.proto.java.ScheduleID;
 import com.hederahashgraph.api.proto.java.SignatureMap;
 import com.hederahashgraph.api.proto.java.SignedTransaction;
 import com.hederahashgraph.api.proto.java.Transaction;
@@ -34,7 +34,6 @@ import com.hederahashgraph.api.proto.java.TransactionID;
 
 import java.util.function.Function;
 
-import static com.hedera.services.legacy.proto.utils.CommonUtils.extractSignatureMap;
 import static com.hedera.services.legacy.proto.utils.CommonUtils.sha384HashOf;
 import static com.hedera.services.utils.MiscUtils.functionOf;
 import static com.hederahashgraph.api.proto.java.HederaFunctionality.NONE;
@@ -44,7 +43,7 @@ import static com.hederahashgraph.api.proto.java.HederaFunctionality.NONE;
  *
  * @author Michael Tinker
  */
-public class SignedTxnAccessor {
+public class SignedTxnAccessor implements TxnAccessor {
 	private byte[] txnBytes;
 	private byte[] backwardCompatibleSignedTxnBytes;
 	private Transaction backwardCompatibleSignedTxn;
@@ -134,4 +133,13 @@ public class SignedTxnAccessor {
 	public ByteString getHash() {
 		return hash;
 	}
+
+	@Override
+	public boolean canTriggerTxn() {
+		return getTxn().hasScheduleCreate() || getTxn().hasScheduleSign();
+	}
+
+	public boolean isTriggeredTxn() { return false; }
+
+	public ScheduleID getScheduleRef() { return ScheduleID.getDefaultInstance(); }
 }

--- a/hedera-node/src/main/java/com/hedera/services/utils/TriggeredTxnAccessor.java
+++ b/hedera-node/src/main/java/com/hedera/services/utils/TriggeredTxnAccessor.java
@@ -1,0 +1,49 @@
+package com.hedera.services.utils;
+
+/*-
+ * ‌
+ * Hedera Services Node
+ * ​
+ * Copyright (C) 2018 - 2020 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.hederahashgraph.api.proto.java.AccountID;
+import com.hederahashgraph.api.proto.java.ScheduleID;
+
+public class TriggeredTxnAccessor extends SignedTxnAccessor {
+    private final AccountID payer;
+    private final ScheduleID scheduleRef;
+
+    public TriggeredTxnAccessor(byte[] signedTxnBytes, AccountID payer, ScheduleID scheduleRef) throws InvalidProtocolBufferException {
+        super(signedTxnBytes);
+        this.payer = payer;
+        this.scheduleRef = scheduleRef;
+    }
+
+    @Override
+    public boolean isTriggeredTxn() {
+        return true;
+    }
+
+    @Override
+    public AccountID getPayer() { return payer; }
+
+    @Override
+    public ScheduleID getScheduleRef() {
+        return scheduleRef;
+    }
+}

--- a/hedera-node/src/main/java/com/hedera/services/utils/TxnAccessor.java
+++ b/hedera-node/src/main/java/com/hedera/services/utils/TxnAccessor.java
@@ -1,0 +1,64 @@
+package com.hedera.services.utils;
+
+/*-
+ * ‌
+ * Hedera Services Node
+ * ​
+ * Copyright (C) 2018 - 2020 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import com.google.protobuf.ByteString;
+import com.hederahashgraph.api.proto.java.AccountID;
+import com.hederahashgraph.api.proto.java.HederaFunctionality;
+import com.hederahashgraph.api.proto.java.ScheduleID;
+import com.hederahashgraph.api.proto.java.SignatureMap;
+import com.hederahashgraph.api.proto.java.Transaction;
+import com.hederahashgraph.api.proto.java.TransactionBody;
+import com.hederahashgraph.api.proto.java.TransactionID;
+
+/**
+ * Defines a type that gives access to several commonly referenced
+ * parts of a Hedera Services gRPC {@link Transaction}.
+ */
+public interface TxnAccessor {
+    SignatureMap getSigMap();
+
+    HederaFunctionality getFunction();
+
+    Transaction getSignedTxn4Log();
+
+    byte[] getTxnBytes();
+
+    Transaction getBackwardCompatibleSignedTxn();
+
+    TransactionBody getTxn();
+
+    TransactionID getTxnId();
+
+    AccountID getPayer();
+
+    byte[] getBackwardCompatibleSignedTxnBytes();
+
+    ByteString getHash();
+
+    boolean canTriggerTxn();
+
+    boolean isTriggeredTxn();
+
+    ScheduleID getScheduleRef();
+
+    default com.swirlds.common.Transaction getPlatformTxn() { throw new UnsupportedOperationException(); }
+}

--- a/hedera-node/src/test/java/com/hedera/services/fees/charging/TxnFeeChargingPolicyTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/fees/charging/TxnFeeChargingPolicyTest.java
@@ -21,10 +21,10 @@ package com.hedera.services.fees.charging;
  */
 
 import com.hedera.services.context.properties.GlobalDynamicProperties;
-import com.hedera.services.context.properties.PropertySource;
 import com.hedera.services.fees.FeeExemptions;
 import com.hedera.services.ledger.HederaLedger;
 import com.hedera.services.utils.SignedTxnAccessor;
+import com.hedera.services.utils.TxnAccessor;
 import com.hedera.test.utils.IdUtils;
 import com.hederahashgraph.api.proto.java.AccountID;
 import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
@@ -35,16 +35,23 @@ import org.junit.jupiter.api.Test;
 import org.junit.platform.runner.JUnitPlatform;
 import org.junit.runner.RunWith;
 
+import static com.hedera.services.fees.TxnFeeType.NETWORK;
+import static com.hedera.services.fees.TxnFeeType.NODE;
+import static com.hedera.services.fees.TxnFeeType.SERVICE;
+import static com.hedera.services.fees.charging.ItemizableFeeCharging.NETWORK_FEE;
 import static com.hedera.services.fees.charging.ItemizableFeeCharging.NETWORK_NODE_SERVICE_FEES;
 import static com.hedera.services.fees.charging.ItemizableFeeCharging.NODE_FEE;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.collection.IsIterableContainingInOrder.contains;
-import static com.hedera.services.fees.charging.ItemizableFeeCharging.NETWORK_FEE;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INSUFFICIENT_PAYER_BALANCE;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INSUFFICIENT_TX_FEE;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OK;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.BDDMockito.*;
-import static com.hedera.services.fees.TxnFeeType.*;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.*;
+import static org.mockito.BDDMockito.any;
+import static org.mockito.BDDMockito.argThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.longThat;
+import static org.mockito.BDDMockito.mock;
+import static org.mockito.BDDMockito.never;
+import static org.mockito.BDDMockito.verify;
 
 @RunWith(JUnitPlatform.class)
 class TxnFeeChargingPolicyTest {
@@ -132,7 +139,7 @@ class TxnFeeChargingPolicyTest {
 
 	private static class NoExemptions implements FeeExemptions {
 		@Override
-		public boolean hasExemptPayer(SignedTxnAccessor accessor) {
+		public boolean hasExemptPayer(TxnAccessor accessor) {
 			return false;
 		}
 	}

--- a/hedera-node/src/test/java/com/hedera/services/keys/StandardSyncActivationCheckTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/keys/StandardSyncActivationCheckTest.java
@@ -20,33 +20,33 @@ package com.hedera.services.keys;
  * ‍
  */
 
+import com.hedera.services.legacy.core.jproto.JKey;
 import com.hedera.services.sigs.PlatformSigsCreationResult;
 import com.hedera.services.sigs.PlatformSigsFactory;
 import com.hedera.services.sigs.factories.TxnScopedPlatformSigFactory;
 import com.hedera.services.sigs.sourcing.PubKeyToSigBytes;
 import com.hedera.services.sigs.verification.SyncVerifier;
 import com.hedera.services.utils.PlatformTxnAccessor;
-import com.hedera.services.utils.SignedTxnAccessor;
+import com.hedera.services.utils.TxnAccessor;
 import com.hedera.test.factories.scenarios.TxnHandlingScenario;
 import com.hederahashgraph.api.proto.java.Transaction;
-import com.hedera.services.legacy.core.jproto.JKey;
 import com.swirlds.common.crypto.TransactionSignature;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.platform.runner.JUnitPlatform;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import org.junit.runner.RunWith;
 
 import java.util.List;
 import java.util.function.BiPredicate;
 import java.util.function.Function;
 
-import static org.hamcrest.collection.IsIterableContainingInOrder.contains;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static com.hedera.services.keys.StandardSyncActivationCheck.allKeysAreActive;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.BDDMockito.*;
-import static com.hedera.services.keys.StandardSyncActivationCheck.*;
+import static org.mockito.BDDMockito.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.mock;
+import static org.mockito.BDDMockito.verify;
 
 @RunWith(JUnitPlatform.class)
 class StandardSyncActivationCheckTest {
@@ -62,7 +62,7 @@ class StandardSyncActivationCheckTest {
 	TxnScopedPlatformSigFactory scopedSig;
 	Function<byte[], TransactionSignature> sigsFn;
 	Function<Transaction, PubKeyToSigBytes> sigBytesProvider;
-	Function<SignedTxnAccessor, TxnScopedPlatformSigFactory> scopedSigProvider;
+	Function<TxnAccessor, TxnScopedPlatformSigFactory> scopedSigProvider;
 	BiPredicate<JKey, Function<byte[], TransactionSignature>> isActive;
 	Function<List<TransactionSignature>, Function<byte[], TransactionSignature>> sigsFnProvider;
 

--- a/hedera-node/src/test/java/com/hedera/services/legacy/core/jproto/TxnReceiptTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/legacy/core/jproto/TxnReceiptTest.java
@@ -58,7 +58,6 @@ public class TxnReceiptTest {
   ExchangeRates mockRates;
   TxnReceipt subject;
 
-
   private TopicID getTopicId(long shard, long realm, long num) {
     return TopicID.newBuilder().setShardNum(shard).setRealmNum(realm).setTopicNum(num).build();
   }

--- a/hedera-node/src/test/java/com/hedera/services/state/expiry/ExpiryManagerTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/state/expiry/ExpiryManagerTest.java
@@ -21,7 +21,7 @@ package com.hedera.services.state.expiry;
  */
 
 import com.hedera.services.ledger.HederaLedger;
-import com.hedera.services.legacy.core.jproto.TxnId;
+import com.hedera.services.state.submerkle.TxnId;
 import com.hedera.services.legacy.core.jproto.TxnReceipt;
 import com.hedera.services.records.RecordCache;
 import com.hedera.services.records.TxnIdRecentHistory;

--- a/hedera-node/src/test/java/com/hedera/services/state/logic/ServicesTxnManagerTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/state/logic/ServicesTxnManagerTest.java
@@ -56,6 +56,7 @@ class ServicesTxnManagerTest {
 
 	Runnable processLogic;
 	Runnable recordStreaming;
+	Runnable triggeredProcessLogic;
 	BiConsumer<Exception, String> warning;
 
 	HederaLedger ledger;
@@ -72,9 +73,10 @@ class ServicesTxnManagerTest {
 		processLogic = mock(Runnable.class);
 		recordCache = mock(RecordCache.class);
 		recordStreaming = mock(Runnable.class);
+		triggeredProcessLogic = mock(Runnable.class);
 		warning = mock(BiConsumer.class);
 
-		subject = new ServicesTxnManager(processLogic, recordStreaming, warning);
+		subject = new ServicesTxnManager(processLogic, recordStreaming, triggeredProcessLogic, warning);
 
 		ledger = mock(HederaLedger.class);
 		txnCtx = mock(TransactionContext.class);

--- a/hedera-node/src/test/java/com/hedera/services/state/submerkle/ExpirableTxnRecordTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/state/submerkle/ExpirableTxnRecordTest.java
@@ -298,7 +298,7 @@ class ExpirableTxnRecordTest {
 						"accountCreated=EntityId{shard=0, realm=0, num=3}, newTotalTokenSupply=0}, " +
 						"txnHash=6e6f742d7265616c6c792d612d68617368, " +
 						"txnId=TxnId{payer=EntityId{shard=0, realm=0, num=0}, " +
-						"validStart=RichInstant{seconds=9999999999, nanos=0}}, " +
+						"validStart=RichInstant{seconds=9999999999, nanos=0}, scheduled=false}, " +
 						"consensusTimestamp=RichInstant{seconds=9999999999, nanos=0}, " +
 						"expiry=1234567, submittingMember=1, memo=Alpha bravo charlie, " +
 						"contractCreation=SolidityFnResult{gasUsed=55, bloom=, " +

--- a/hedera-node/src/test/java/com/hedera/services/state/submerkle/ExpirableTxnRecordTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/state/submerkle/ExpirableTxnRecordTest.java
@@ -21,7 +21,6 @@ package com.hedera.services.state.submerkle;
  */
 
 import com.google.protobuf.ByteString;
-import com.hedera.services.legacy.core.jproto.TxnId;
 import com.hedera.services.legacy.core.jproto.TxnReceipt;
 import com.hedera.services.state.serdes.DomainSerdes;
 import com.hedera.services.state.serdes.DomainSerdesTest;

--- a/hedera-node/src/test/java/com/hedera/services/state/submerkle/TxnIdTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/state/submerkle/TxnIdTest.java
@@ -1,0 +1,292 @@
+package com.hedera.services.state.submerkle;
+
+/*-
+ * ‌
+ * Hedera Services Node
+ * ​
+ * Copyright (C) 2018 - 2020 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import com.google.protobuf.ByteString;
+import com.hedera.services.state.serdes.DomainSerdes;
+import com.hedera.services.state.submerkle.EntityId;
+import com.hedera.services.state.submerkle.RichInstant;
+import com.hedera.services.state.submerkle.TxnId;
+import com.hedera.test.utils.IdUtils;
+import com.hederahashgraph.api.proto.java.AccountID;
+import com.hederahashgraph.api.proto.java.Timestamp;
+import com.hederahashgraph.api.proto.java.TransactionID;
+import com.swirlds.common.io.SerializableDataInputStream;
+import com.swirlds.common.io.SerializableDataOutputStream;
+import org.apache.commons.codec.binary.Hex;
+import org.junit.jupiter.api.Test;
+import org.junit.platform.runner.JUnitPlatform;
+import org.junit.runner.RunWith;
+import org.mockito.InOrder;
+import org.mockito.Mockito;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.function.Supplier;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.booleanThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@RunWith(JUnitPlatform.class)
+class TxnIdTest {
+	private AccountID payer = IdUtils.asAccount("0.0.75231");
+	private EntityId fcPayer = EntityId.ofNullableAccountId(payer);
+	private Timestamp validStart = Timestamp.newBuilder()
+			.setSeconds(1_234_567L)
+			.setNanos(89)
+			.build();
+	private ByteString nonce = ByteString.copyFrom("THIS_IS_NEW".getBytes());
+	private RichInstant fcValidStart = RichInstant.fromGrpc(validStart);
+
+	DomainSerdes serdes;
+	SerializableDataInputStream din;
+	SerializableDataOutputStream dout;
+
+	TxnId subject;
+
+	@Test
+	void serializeWorksForScheduledNonce() throws IOException {
+		// setup:
+		subject = scheduledSubjectWithNonce();
+		// and:
+		dout = mock(SerializableDataOutputStream.class);
+		serdes = mock(DomainSerdes.class);
+		TxnId.serdes = serdes;
+
+		// given:
+		InOrder inOrder = Mockito.inOrder(serdes, dout);
+
+		// when:
+		subject.serialize(dout);
+
+		// then:
+		inOrder.verify(dout).writeSerializable(fcPayer, Boolean.TRUE);
+		inOrder.verify(serdes).serializeTimestamp(fcValidStart, dout);
+		inOrder.verify(dout, times(2)).writeBoolean(true);
+		inOrder.verify(dout).writeByteArray(argThat((byte[] bytes) -> Arrays.equals(bytes, nonce.toByteArray())));
+
+		// cleanup:
+		TxnId.serdes = new DomainSerdes();
+	}
+
+	@Test
+	void serializeWorksForScheduledNoNonce() throws IOException {
+		// setup:
+		subject = scheduledSubjectWithoutNonce();
+		// and:
+		dout = mock(SerializableDataOutputStream.class);
+		serdes = mock(DomainSerdes.class);
+		TxnId.serdes = serdes;
+
+		// given:
+		InOrder inOrder = Mockito.inOrder(serdes, dout);
+
+		// when:
+		subject.serialize(dout);
+
+		// then:
+		inOrder.verify(dout).writeSerializable(fcPayer, Boolean.TRUE);
+		inOrder.verify(serdes).serializeTimestamp(fcValidStart, dout);
+		inOrder.verify(dout).writeBoolean(true);
+		inOrder.verify(dout).writeBoolean(false);
+		inOrder.verify(dout, never()).writeByteArray(any());
+
+		// cleanup:
+		TxnId.serdes = new DomainSerdes();
+	}
+
+	@Test
+	public void preV0120DeserializeWorks() throws IOException {
+		// setup:
+		subject = unscheduledSubjectNoNonce();
+		// and:
+		din = mock(SerializableDataInputStream.class);
+		serdes = mock(DomainSerdes.class);
+		TxnId.serdes = serdes;
+
+		given(din.readSerializable(booleanThat(Boolean.TRUE::equals), any(Supplier.class))).willReturn(fcPayer);
+		given(serdes.deserializeTimestamp(din)).willReturn(fcValidStart);
+		// and:
+		var deserializedId = new TxnId();
+
+		// when:
+		deserializedId.deserialize(din, TxnId.PRE_RELEASE_0120_VERSION);
+
+		// then:
+		assertEquals(subject, deserializedId);
+		verify(din, never()).readBoolean();
+		verify(din, never()).readByteArray(TxnId.MAX_PERMISSIBLE_NONCE_BYTES);
+
+		// cleanup:
+		TxnId.serdes = new DomainSerdes();
+	}
+
+	@Test
+	public void v0120DeserializeWorksWithoutNonce() throws IOException {
+		// setup:
+		subject = scheduledSubjectWithoutNonce();
+		// and:
+		din = mock(SerializableDataInputStream.class);
+		serdes = mock(DomainSerdes.class);
+		TxnId.serdes = serdes;
+
+		given(din.readSerializable(booleanThat(Boolean.TRUE::equals), any(Supplier.class))).willReturn(fcPayer);
+		given(serdes.deserializeTimestamp(din)).willReturn(fcValidStart);
+		given(din.readBoolean()).willReturn(true).willReturn(false);
+		// and:
+		var deserializedId = new TxnId();
+
+		// when:
+		deserializedId.deserialize(din, TxnId.RELEASE_0120_VERSION);
+
+		// then:
+		assertEquals(subject, deserializedId);
+		// and:
+		verify(din, times(2)).readBoolean();
+		verify(din, never()).readByteArray(anyInt());
+
+		// cleanup:
+		TxnId.serdes = new DomainSerdes();
+	}
+
+	@Test
+	public void v0120DeserializeWorksWithNonce() throws IOException {
+		// setup:
+		subject = scheduledSubjectWithNonce();
+		// and:
+		din = mock(SerializableDataInputStream.class);
+		serdes = mock(DomainSerdes.class);
+		TxnId.serdes = serdes;
+
+		given(din.readSerializable(booleanThat(Boolean.TRUE::equals), any(Supplier.class))).willReturn(fcPayer);
+		given(serdes.deserializeTimestamp(din)).willReturn(fcValidStart);
+		given(din.readBoolean()).willReturn(true).willReturn(true);
+		given(din.readByteArray(TxnId.MAX_PERMISSIBLE_NONCE_BYTES)).willReturn(nonce.toByteArray());
+		// and:
+		var deserializedId = new TxnId();
+
+		// when:
+		deserializedId.deserialize(din, TxnId.RELEASE_0120_VERSION);
+
+		// then:
+		assertEquals(subject, deserializedId);
+		// and:
+		verify(din, times(2)).readBoolean();
+
+		// cleanup:
+		TxnId.serdes = new DomainSerdes();
+	}
+
+	@Test
+	public void equalsWorks() {
+		// given:
+		subject = scheduledSubjectWithNonce();
+
+		// expect:
+		assertNotEquals(subject, unscheduledSubjectWithNonce());
+		// and:
+		assertNotEquals(subject, scheduledSubjectWithoutNonce());
+	}
+
+	@Test
+	public void hashCodeWorks() {
+		// given:
+		subject = scheduledSubjectWithNonce();
+
+		// expect:
+		assertNotEquals(subject.hashCode(), unscheduledSubjectWithNonce().hashCode());
+		// and:
+		assertNotEquals(subject.hashCode(), scheduledSubjectWithoutNonce().hashCode());
+	}
+
+	@Test
+	public void toStringWorks() {
+		// given:
+		subject = scheduledSubjectWithNonce();
+		// and:
+		String expRepr = "TxnId{payer=EntityId{shard=0, realm=0, num=75231}, " +
+				"validStart=RichInstant{seconds=1234567, nanos=89}, " +
+				"scheduled=true, " +
+				"nonce=" + Hex.encodeHexString(nonce.toByteArray()) + "}";
+
+		// expect:
+		assertEquals(expRepr, subject.toString());
+	}
+
+	@Test
+	public void toGrpcWorks() {
+		// given:
+		var subject = scheduledSubjectWithNonce();
+		// and:
+		var expected = base().setScheduled(true).setNonce(nonce).build();
+
+		// expect:
+		assertEquals(expected, subject.toGrpc());
+	}
+
+	@Test
+	public void merkleWorks() {
+		// given:
+		var subject = new TxnId();
+
+		// expect:
+		assertEquals(TxnId.RUNTIME_CONSTRUCTABLE_ID, subject.getClassId());
+		assertEquals(TxnId.RELEASE_0120_VERSION, subject.getVersion());
+	}
+
+	private TxnId unscheduledSubjectNoNonce() {
+		return TxnId.fromGrpc(base().build());
+	}
+
+	private TxnId scheduledSubjectWithoutNonce() {
+		return TxnId.fromGrpc(base()
+				.setScheduled(true)
+				.build());
+	}
+
+	private TxnId scheduledSubjectWithNonce() {
+		return TxnId.fromGrpc(base()
+				.setScheduled(true)
+				.setNonce(nonce)
+				.build());
+	}
+
+	private TxnId unscheduledSubjectWithNonce() {
+		return TxnId.fromGrpc(base()
+				.setNonce(nonce)
+				.build());
+	}
+
+	private TransactionID.Builder base() {
+		return TransactionID.newBuilder()
+				.setAccountID(payer)
+				.setTransactionValidStart(validStart);
+	}
+}

--- a/hedera-node/src/test/java/com/hedera/services/store/schedule/ExceptionalScheduleStoreTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/store/schedule/ExceptionalScheduleStoreTest.java
@@ -39,6 +39,7 @@ class ExceptionalScheduleStoreTest {
         assertThrows(UnsupportedOperationException.class, () -> NOOP_SCHEDULE_STORE.get(null));
         assertThrows(UnsupportedOperationException.class, () -> NOOP_SCHEDULE_STORE.delete(null));
         assertThrows(UnsupportedOperationException.class, () -> NOOP_SCHEDULE_STORE.apply(null, null));
+        assertThrows(UnsupportedOperationException.class, () -> NOOP_SCHEDULE_STORE.markAsExecuted(null));
         assertThrows(UnsupportedOperationException.class, NOOP_SCHEDULE_STORE::commitCreation);
         assertThrows(UnsupportedOperationException.class, NOOP_SCHEDULE_STORE::rollbackCreation);
         assertThrows(UnsupportedOperationException.class, NOOP_SCHEDULE_STORE::isCreationPending);

--- a/hedera-node/src/test/java/com/hedera/test/forensics/AccountsReader.java
+++ b/hedera-node/src/test/java/com/hedera/test/forensics/AccountsReader.java
@@ -20,7 +20,7 @@ package com.hedera.test.forensics;
  * ‍
  */
 
-import com.hedera.services.legacy.core.jproto.TxnId;
+import com.hedera.services.state.submerkle.TxnId;
 import com.hedera.services.legacy.core.jproto.TxnReceipt;
 import com.hedera.services.state.merkle.MerkleAccount;
 import com.hedera.services.state.merkle.MerkleAccountState;

--- a/hedera-node/src/test/java/com/hedera/test/forensics/FcmToJsonUtil.java
+++ b/hedera-node/src/test/java/com/hedera/test/forensics/FcmToJsonUtil.java
@@ -20,7 +20,7 @@ package com.hedera.test.forensics;
  * ‍
  */
 
-import com.hedera.services.legacy.core.jproto.TxnId;
+import com.hedera.services.state.submerkle.TxnId;
 import com.hedera.services.legacy.core.jproto.TxnReceipt;
 import com.hedera.services.state.merkle.MerkleAccount;
 import com.hedera.services.state.merkle.MerkleAccountState;
@@ -29,7 +29,6 @@ import com.hedera.services.state.submerkle.EntityId;
 import com.hedera.services.state.submerkle.ExpirableTxnRecord;
 import com.hedera.services.state.submerkle.CurrencyAdjustments;
 import com.hedera.services.state.submerkle.SolidityFnResult;
-import com.hedera.test.forensics.domain.PojoFs;
 import com.hedera.test.forensics.domain.PojoLedger;
 import com.swirlds.common.constructable.ClassConstructorPair;
 import com.swirlds.common.constructable.ConstructableRegistry;

--- a/hedera-node/src/test/java/com/hedera/test/forensics/domain/PojoRecord.java
+++ b/hedera-node/src/test/java/com/hedera/test/forensics/domain/PojoRecord.java
@@ -25,7 +25,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.hedera.services.utils.MiscUtils;
 import com.hedera.services.state.submerkle.EntityId;
 import com.hedera.services.state.submerkle.RichInstant;
-import com.hedera.services.legacy.core.jproto.TxnId;
+import com.hedera.services.state.submerkle.TxnId;
 import com.hedera.services.legacy.core.jproto.TxnReceipt;
 import com.hedera.services.state.submerkle.ExpirableTxnRecord;
 import org.apache.commons.codec.binary.Hex;

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/schedule/ScheduleCreateSpecs.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/schedule/ScheduleCreateSpecs.java
@@ -21,6 +21,7 @@ package com.hedera.services.bdd.suites.schedule;
  */
 
 import com.hedera.services.bdd.spec.HapiApiSpec;
+import com.hedera.services.bdd.spec.HapiSpecSetup;
 import com.hedera.services.bdd.spec.keys.KeyShape;
 import com.hedera.services.bdd.spec.keys.SigControl;
 import com.hedera.services.bdd.suites.HapiApiSuite;
@@ -37,6 +38,7 @@ import static com.hedera.services.bdd.spec.keys.KeyShape.sigs;
 import static com.hedera.services.bdd.spec.keys.KeyShape.threshOf;
 import static com.hedera.services.bdd.spec.keys.SigControl.OFF;
 import static com.hedera.services.bdd.spec.keys.SigControl.ON;
+import static com.hedera.services.bdd.spec.queries.QueryVerbs.getAccountBalance;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoCreate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoTransfer;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoUpdate;
@@ -197,6 +199,8 @@ public class ScheduleCreateSpecs extends HapiApiSuite {
 	}
 
 	public HapiApiSpec triggersImmediatelyWithBothReqSimpleSigs() {
+		long initialBalance = HapiSpecSetup.getDefaultInstance().defaultBalance();
+		long transferAmount = 1;
 		/*
 >>> START ScheduleCreate >>>
  - Resolved scheduleId: 0.0.1006
@@ -207,13 +211,16 @@ public class ScheduleCreateSpecs extends HapiApiSuite {
 				.given(
 						cryptoCreate("sender"),
 						cryptoCreate("receiver").receiverSigRequired(true)
-				).when().then(
+				).when(
 						scheduleCreate(
 								"basicXfer",
 								cryptoTransfer(
-										tinyBarsFromTo("sender", "receiver", 1)
+										tinyBarsFromTo("sender", "receiver", transferAmount)
 								).signedBy("sender", "receiver")
 						)
+				).then(
+						getAccountBalance("sender").hasTinyBars(initialBalance - transferAmount),
+						getAccountBalance("receiver").hasTinyBars(initialBalance + transferAmount)
 				);
 	}
 


### PR DESCRIPTION
**Summary of the change**
- Merge `LimeChain:feature/scheduled-txs/libs-execution` 
- Update the self-serializable mirror of `TransactionID` (`TxnId`) to include the `scheduled` and `nonce` fields; add full unit test coverage and move out of `com.hedera.services.legacy`.
- Update `HapiScheduleCreate` to use default expiry in fee calculation.
- Ensure all `HapiApiSpec` executors are shut down before calling `HapiApiClients.teardown()`; (at least in case of synchronous spec execution).