### PR TITLE
00955 d file 150 for migration test (merge to 0.11.0 release branch)

### DIFF
--- a/hedera-node/src/main/java/com/hedera/services/state/merkle/MerkleDiskFs.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/merkle/MerkleDiskFs.java
@@ -129,7 +129,12 @@ public class MerkleDiskFs extends AbstractMerkleLeaf implements MerkleExternalLe
 		try {
 			return bytesHelper.allBytesFrom(pathToContentsOf(fid));
 		} catch (IOException e) {
-			log.error("Error reading '{}' @ {}!", asLiteralString(fid), pathToContentsOf(fid), e);
+			if(log.isDebugEnabled()) {
+				log.warn("Not able to read '{}' @ {}!", asLiteralString(fid), pathToContentsOf(fid), e);
+			}
+			else {
+				log.warn("Not able to read '{}' @ {}!", asLiteralString(fid), pathToContentsOf(fid));
+			}
 			return MISSING_CONTENT;
 		}
 	}

--- a/hedera-node/src/test/java/com/hedera/services/state/merkle/MerkleDiskFsTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/state/merkle/MerkleDiskFsTest.java
@@ -167,8 +167,21 @@ public class MerkleDiskFsTest {
 	}
 
 	@Test
-	public void fileNotExist() throws IOException {
+	public void fileNotExistNoDebug() throws IOException {
 		// setup:
+		subject = new MerkleDiskFs("this/doesnt/exist", asLiteralString(nodeAccount));
+
+		given(getter.allBytesFrom(any())).willThrow(IOException.class);
+
+		Assertions.assertSame(MerkleDiskFs.MISSING_CONTENT, subject.contentsOf(file150));
+	}
+
+	@Test
+	public void fileNotExistDebugEnabled() throws IOException {
+		// setup:
+		Logger log = mock(Logger.class);
+		given(log.isDebugEnabled()).willReturn(true);
+		MerkleDiskFs.log = log;
 		subject = new MerkleDiskFs("this/doesnt/exist", asLiteralString(nodeAccount));
 
 		given(getter.allBytesFrom(any())).willThrow(IOException.class);


### PR DESCRIPTION
**Related issue(s):**
Closes #955 

The original changes was already merged to `master` branch. Neeha suggests to also merge the fix to `0.11.0` release branch as well.

**Summary of the change**:
1. Short-term solution to change the log message level from `error` to `warn` to avoid migration test failure;


**External impacts**:
None.

**Applicable documentation**
- [ ] Javadoc
- [ ] HAPI protobuf comments
- [ ] README
