### PR TITLE
Fix HCS-Restart-Performance-Testnet-10k-46m

### DIFF
--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/SubmitMessageLoadTest.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/SubmitMessageLoadTest.java
@@ -189,7 +189,6 @@ public class SubmitMessageLoadTest extends LoadTest {
 				.noLogging()
 				.payingWith(senderId)
 				.signedBy(senderKey, submitKey)
-				//.signedBy(GENESIS, GENESIS)
 				.fee(100_000_000)
 				.suppressStats(true)
 				.hasRetryPrecheckFrom(BUSY, DUPLICATE_TRANSACTION, PLATFORM_TRANSACTION_NOT_CREATED,

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/SubmitMessageLoadTest.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/SubmitMessageLoadTest.java
@@ -119,7 +119,6 @@ public class SubmitMessageLoadTest extends LoadTest {
 	private static HapiApiSpec runSubmitMessages() {
 		PerfTestLoadSettings settings = new PerfTestLoadSettings();
 		final AtomicInteger submittedSoFar = new AtomicInteger(0);
-
 		Supplier<HapiSpecOperation[]> submitBurst = () -> new HapiSpecOperation[] {
 				opSupplier(settings).get()
 		};
@@ -163,10 +162,23 @@ public class SubmitMessageLoadTest extends LoadTest {
 				:  settings.getIntProperty("messageSize", messageSize)
 				        - r.nextInt(settings.getHcsSubmitMessageSizeVar());
 
-		// maybe use some more realistic distributions to simulate real world scenarios
-		String senderId = String.format("0.0.%d", TEST_ACCOUNT_STARTS_FROM + r.nextInt(settings.getTotalAccounts()));
-		String topicId  = String.format("0.0.%d", TEST_ACCOUNT_STARTS_FROM + settings.getTotalAccounts()
-				+ r.nextInt(settings.getTotalTopics() ));
+		String senderId = "sender";
+		String topicId = "topic";
+		String senderKey= "sender";
+		String submitKey = "submitKey";
+		if(settings.getTotalAccounts() > 1) {
+			int s =  r.nextInt(settings.getTotalAccounts());
+			int re = 0;
+			do {
+				re =  r.nextInt(settings.getTotalAccounts());
+			} while (re == s);
+			// maybe use some more realistic distributions to simulate real world scenarios
+			senderId = String.format("0.0.%d", TEST_ACCOUNT_STARTS_FROM + r.nextInt(settings.getTotalAccounts()));
+			topicId  = String.format("0.0.%d", TEST_ACCOUNT_STARTS_FROM + settings.getTotalAccounts()
+					+ r.nextInt(settings.getTotalTopics() ));
+			senderKey = GENESIS;
+			submitKey = GENESIS;
+		}
 
 		if(log.isDebugEnabled()) {
 			log.debug("{} will submit a message of size {} to topic {}", senderId, msgSize, topicId);
@@ -176,7 +188,8 @@ public class SubmitMessageLoadTest extends LoadTest {
 					randomUtf8Bytes( msgSize - 8)))
 				.noLogging()
 				.payingWith(senderId)
-				.signedBy(GENESIS, GENESIS)
+				.signedBy(senderKey, submitKey)
+				//.signedBy(GENESIS, GENESIS)
 				.fee(100_000_000)
 				.suppressStats(true)
 				.hasRetryPrecheckFrom(BUSY, DUPLICATE_TRANSACTION, PLATFORM_TRANSACTION_NOT_CREATED,


### PR DESCRIPTION
**Related issue(s)**:
Closes #1008 

**Summary of the change**:
Allow to use single payer which is the sender while testing with public testnet state

Passed test : https://hedera-hashgraph.slack.com/archives/C018CBQBTGB/p1611699444050000
