### PR TITLE
Scheduled Transactions: Purge expired scheduled entities

### DIFF
--- a/hedera-node/src/test/java/com/hedera/services/records/RecordCacheTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/records/RecordCacheTest.java
@@ -21,15 +21,19 @@ package com.hedera.services.records;
  */
 
 import com.google.common.cache.Cache;
+import com.google.protobuf.InvalidProtocolBufferException;
 import com.hedera.services.context.ServicesContext;
 import com.hedera.services.state.expiry.ExpiringCreations;
 import com.hedera.services.state.expiry.MonotonicFullQueueExpiries;
 import com.hedera.services.state.submerkle.ExpirableTxnRecord;
 import com.hedera.services.utils.PlatformTxnAccessor;
+import com.hedera.services.utils.TriggeredTxnAccessor;
+import com.hedera.services.utils.TxnAccessor;
 import com.hedera.test.utils.IdUtils;
 import com.hederahashgraph.api.proto.java.AccountID;
 import com.hederahashgraph.api.proto.java.ExchangeRate;
 import com.hederahashgraph.api.proto.java.ExchangeRateSet;
+import com.hederahashgraph.api.proto.java.ScheduleID;
 import com.hederahashgraph.api.proto.java.Timestamp;
 import com.hederahashgraph.api.proto.java.TimestampSeconds;
 import com.hederahashgraph.api.proto.java.Transaction;
@@ -349,6 +353,54 @@ class RecordCacheTest {
 				argThat(expectedRecord::equals),
 				argThat(FAIL_INVALID::equals));
 	}
+
+	@Test
+	public void managesTriggeredFailInvalidRecordAsExpected() throws InvalidProtocolBufferException {
+		// setup:
+		Instant consensusTime = Instant.now();
+		TransactionID txnId = TransactionID.newBuilder().setAccountID(asAccount("0.0.1001")).build();
+		Transaction signedTxn = Transaction.newBuilder()
+				.setBodyBytes(TransactionBody.newBuilder()
+						.setTransactionID(txnId)
+						.setMemo("Catastrophe!")
+						.build().toByteString())
+				.build();
+		// and:
+		TxnIdRecentHistory history = mock(TxnIdRecentHistory.class);
+		// and:
+		AccountID effectivePayer = IdUtils.asAccount("0.0.3");
+		ScheduleID effectiveScheduleID = IdUtils.asSchedule("0.0.123");
+
+		given(histories.computeIfAbsent(argThat(txnId::equals), any())).willReturn(history);
+
+		// given:
+		TxnAccessor accessor = new TriggeredTxnAccessor(signedTxn.toByteArray(), effectivePayer, effectiveScheduleID);
+		// and:
+		var grpc = TransactionRecord.newBuilder()
+				.setTransactionID(txnId)
+				.setReceipt(TransactionReceipt.newBuilder().setStatus(FAIL_INVALID))
+				.setMemo(accessor.getTxn().getMemo())
+				.setTransactionHash(accessor.getHash())
+				.setConsensusTimestamp(asTimestamp(consensusTime))
+				.setScheduleRef(effectiveScheduleID)
+				.build();
+
+		var expectedRecord = ExpirableTxnRecord.fromGprc(grpc);
+		given(creator.createExpiringRecord(any(), any(), anyLong(), anyLong())).willReturn(expectedRecord);
+
+		// when:
+		subject.setFailInvalid(
+				effectivePayer,
+				accessor,
+				consensusTime,
+				submittingMember);
+
+		// then:
+		verify(history).observe(
+				argThat(expectedRecord::equals),
+				argThat(FAIL_INVALID::equals));
+	}
+
 
 	@Test
 	public void usesHistoryThenCacheToTestReceiptPresence() {

--- a/hedera-node/src/test/java/com/hedera/services/store/schedule/HederaScheduleStoreTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/store/schedule/HederaScheduleStoreTest.java
@@ -69,6 +69,7 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 public class HederaScheduleStoreTest {
@@ -473,6 +474,9 @@ public class HederaScheduleStoreTest {
         var outcome = subject.delete(created);
 
         // then:
+        verify(schedules, times(3)).containsKey(fromScheduleId(created));
+        verify(schedules).remove(fromScheduleId(created));
+        // and:
         assertEquals(OK, outcome);
     }
 
@@ -485,6 +489,8 @@ public class HederaScheduleStoreTest {
         var outcome = subject.delete(created);
 
         // then:
+        verify(schedules, never()).remove(fromScheduleId(created));
+        // and:
         assertEquals(SCHEDULE_IS_IMMUTABLE, outcome);
     }
 
@@ -497,6 +503,8 @@ public class HederaScheduleStoreTest {
         var outcome = subject.delete(created);
 
         // then:
+        verify(schedules, never()).remove(fromScheduleId(created));
+        // and:
         assertEquals(INVALID_SCHEDULE_ID, outcome);
     }
 
@@ -509,6 +517,8 @@ public class HederaScheduleStoreTest {
         var outcome = subject.markAsExecuted(created);
 
         // then:
+        verify(schedules, never()).remove(fromScheduleId(created));
+        // and:
         assertEquals(INVALID_SCHEDULE_ID, outcome);
     }
 
@@ -521,6 +531,19 @@ public class HederaScheduleStoreTest {
         var outcome = subject.markAsExecuted(created);
 
         // then:
+        verify(schedules, times(3)).containsKey(fromScheduleId(created));
+        verify(schedules).remove(fromScheduleId(created));
+        // and:
         assertEquals(OK, outcome);
+    }
+
+    @Test
+    public void expiresAsExpected() {
+        // when:
+        subject.expire(EntityId.ofNullableScheduleId(created));
+
+        // then:
+        verify(schedules, times(3)).containsKey(fromScheduleId(created));
+        verify(schedules).remove(fromScheduleId(created));
     }
 }

--- a/hedera-node/src/test/java/com/hedera/services/utils/SignedTxnAccessorTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/utils/SignedTxnAccessorTest.java
@@ -24,6 +24,7 @@ import com.google.protobuf.ByteString;
 import com.hedera.services.legacy.proto.utils.CommonUtils;
 import com.hederahashgraph.api.proto.java.Duration;
 import com.hederahashgraph.api.proto.java.HederaFunctionality;
+import com.hederahashgraph.api.proto.java.ScheduleID;
 import com.hederahashgraph.api.proto.java.SignatureMap;
 import com.hederahashgraph.api.proto.java.SignaturePair;
 import com.hederahashgraph.api.proto.java.SignedTransaction;
@@ -75,6 +76,7 @@ public class SignedTxnAccessorTest {
 		assertEquals(HederaFunctionality.CryptoTransfer, accessor.getFunction());
 		assertArrayEquals(CommonUtils.noThrowSha384HashOf(transaction.toByteArray()), accessor.getHash().toByteArray());
 		assertEquals(expectedMap, accessor.getSigMap());
+		assertEquals(ScheduleID.getDefaultInstance(), accessor.getScheduleRef());
 	}
 
 	@Test
@@ -109,5 +111,6 @@ public class SignedTxnAccessorTest {
 		assertArrayEquals(CommonUtils.noThrowSha384HashOf(signedTransaction.toByteArray()),
 				accessor.getHash().toByteArray());
 		assertEquals(expectedMap, accessor.getSigMap());
+		assertEquals(ScheduleID.getDefaultInstance(), accessor.getScheduleRef());
 	}
 }

--- a/hedera-node/src/test/java/com/hedera/services/utils/TriggeredTxnAccessorTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/utils/TriggeredTxnAccessorTest.java
@@ -1,0 +1,82 @@
+package com.hedera.services.utils;
+
+/*-
+ * ‌
+ * Hedera Services Node
+ * ​
+ * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import com.google.protobuf.ByteString;
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.hedera.services.legacy.proto.utils.CommonUtils;
+import com.hederahashgraph.api.proto.java.AccountID;
+import com.hederahashgraph.api.proto.java.ScheduleID;
+import com.hederahashgraph.api.proto.java.SignedTransaction;
+import com.hederahashgraph.api.proto.java.Transaction;
+import com.hederahashgraph.api.proto.java.TransactionBody;
+import com.hederahashgraph.api.proto.java.TransactionID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static com.hedera.test.utils.IdUtils.asAccount;
+import static com.hedera.test.utils.IdUtils.asSchedule;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class TriggeredTxnAccessorTest {
+    AccountID id = asAccount("0.0.1001");
+    String nonce = "123";
+    boolean scheduled = true;
+    AccountID payer = asAccount("0.0.1234");
+    ScheduleID scheduleRef = asSchedule("0.0.5876");
+
+    TransactionID txnId = TransactionID.newBuilder()
+            .setAccountID(id)
+            .setNonce(ByteString.copyFromUtf8(nonce))
+            .setScheduled(scheduled).build();
+    TransactionBody txnBody = TransactionBody.newBuilder()
+            .setTransactionID(txnId)
+            .build();
+    SignedTransaction signedTxn = SignedTransaction.newBuilder()
+            .setBodyBytes(txnBody.toByteString())
+            .build();
+    Transaction tx = Transaction.newBuilder()
+            .setSignedTransactionBytes(
+                    signedTxn.toByteString())
+            .build();
+
+    private TriggeredTxnAccessor subject;
+
+    @BeforeEach
+    public void setup() throws InvalidProtocolBufferException {
+        subject = new TriggeredTxnAccessor(tx.toByteArray(), payer, scheduleRef);
+    }
+
+    @Test
+    public void validProperties() {
+        assertEquals(tx, subject.getBackwardCompatibleSignedTxn());
+        assertEquals(tx, subject.getSignedTxn4Log());
+        assertArrayEquals(tx.toByteArray(), subject.getBackwardCompatibleSignedTxnBytes());
+        assertEquals(scheduleRef, subject.getScheduleRef());
+        assertEquals(payer, subject.getPayer());
+        assertEquals(txnBody, subject.getTxn());
+        assertArrayEquals(txnBody.toByteArray(), subject.getTxnBytes());
+        assertEquals(txnId, subject.getTxnId());
+        assertArrayEquals(CommonUtils.noThrowSha384HashOf(signedTxn.toByteArray()),
+                subject.getHash().toByteArray());
+    }
+}


### PR DESCRIPTION
**Related issue(s)**:
Closes #None

**Summary of the change**:
* `MerkleSchedule` to have `expiry`.
* Remove `MerkleSchedule` `deleted`.
* Same as records, schedule entities are purged in `doProcess`.
* Add `ScheduleGetInfo` - `expiry`.
* Schedule deletion/expiration/execution now removes the entity from the `FCMap`.
* `ExpirableTxnRecord` - add `scheduleRef`

**External impacts**:
None.

**Applicable documentation**
- [ ] Javadoc
- [ ] HAPI protobuf comments
- [ ] README
