### PR TITLE
Fix JSON names for Hotspot and Random tests 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1557,33 +1557,6 @@ workflows:
             - attach_workspace:
                 at: /
 
-#Use this workflow if there are any tests that will be added to use public testnet state
-  GCP-Daily-Services-Comp-Restart-Performance-Testnet-6N-6C:
-    triggers:
-      - schedule:
-          cron: "35 6 * * *"
-          filters:
-            branches:
-              only:
-                - Disable-master
-    jobs:
-      - build-platform-and-services
-      - update-start-up-key:
-          requires:
-            - build-platform-and-services
-      - jrs-regression:
-          context: Slack
-          regression_path: /swirlds-platform/regression
-          result_path: results/6N_6C/Performance
-          config_type: "daily"
-          workflow-name: "GCP-Daily-Services-Comp-Restart-Performance-Testnet-6N-6C"
-          requires:
-            - update-start-up-key
-          pre-steps:
-            - install-tools
-            - attach_workspace:
-                at: /
-
   GCP-Daily-Services-Comp-Reconnect-4N-1C:
     triggers:
       - schedule:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1524,7 +1524,7 @@ workflows:
       - jrs-regression:
           context: Slack
           regression_path: /swirlds-platform/regression
-          result_path: results/4N_4C/Restart
+          result_path: results/6N_6C/Performance
           config_type: "daily"
           workflow-name: "GCP-Daily-Services-Comp-Restart-Performance-Hotspot-6N-6C"
           requires:
@@ -1547,7 +1547,7 @@ workflows:
       - jrs-regression:
           context: Slack
           regression_path: /swirlds-platform/regression
-          result_path: results/4N_4C/Restart
+          result_path: results/6N_6C/Performance
           config_type: "daily"
           workflow-name: "GCP-Daily-Services-Comp-Restart-Performance-Random-6N-6C"
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1511,7 +1511,7 @@ workflows:
             - attach_workspace:
                 at: /
 
-  GCP-Daily-Services-Comp-Restart-Performance-Hotspot-4N-4C:
+  GCP-Daily-Services-Comp-Restart-Performance-Hotspot-6N-6C:
     triggers:
       - schedule:
           cron: "35 6 * * *"
@@ -1526,7 +1526,7 @@ workflows:
           regression_path: /swirlds-platform/regression
           result_path: results/4N_4C/Restart
           config_type: "daily"
-          workflow-name: "GCP-Daily-Services-Comp-Restart-Performance-Hotspot-4N-4C"
+          workflow-name: "GCP-Daily-Services-Comp-Restart-Performance-Hotspot-6N-6C"
           requires:
             - build-platform-and-services
           pre-steps:
@@ -1534,56 +1534,10 @@ workflows:
             - attach_workspace:
                 at: /
 
-  GCP-Daily-Services-Comp-Restart-Performance-Random-4N-4C:
+  GCP-Daily-Services-Comp-Restart-Performance-Random-6N-6C:
     triggers:
       - schedule:
           cron: "30 4 * * *"
-          filters:
-            branches:
-              only:
-                - Disable-master
-    jobs:
-      - build-platform-and-services
-      - jrs-regression:
-          context: Slack
-          regression_path: /swirlds-platform/regression
-          result_path: results/4N_4C/Restart
-          config_type: "daily"
-          workflow-name: "GCP-Daily-Services-Comp-Restart-Performance-Random-4N-4C"
-          requires:
-            - build-platform-and-services
-          pre-steps:
-            - install-tools
-            - attach_workspace:
-                at: /
-
-  GCP-Daily-Services-Comp-Restart-HCS-Performance-Random-4N-4C:
-    triggers:
-      - schedule:
-          cron: "30 4 * * *"
-          filters:
-            branches:
-              only:
-                - Disable-master
-    jobs:
-      - build-platform-and-services
-      - jrs-regression:
-          context: Slack
-          regression_path: /swirlds-platform/regression
-          result_path: results/4N_4C/Restart
-          config_type: "daily"
-          workflow-name: "GCP-Daily-Services-Comp-Restart-HCS-Performance-Random-4N-4C"
-          requires:
-            - build-platform-and-services
-          pre-steps:
-            - install-tools
-            - attach_workspace:
-                at: /
-
-  GCP-Daily-Services-Comp-Restart-HCS-Performance-Hotspot-4N-4C:
-    triggers:
-      - schedule:
-          cron: "30 10 * * *"
           filters:
             branches:
               only:
@@ -1595,7 +1549,7 @@ workflows:
           regression_path: /swirlds-platform/regression
           result_path: results/4N_4C/Restart
           config_type: "daily"
-          workflow-name: "GCP-Daily-Services-Comp-Restart-HCS-Performance-Hotspot-4N-4C"
+          workflow-name: "GCP-Daily-Services-Comp-Restart-Performance-Random-6N-6C"
           requires:
             - build-platform-and-services
           pre-steps:
@@ -1603,14 +1557,15 @@ workflows:
             - attach_workspace:
                 at: /
 
-  GCP-Daily-Services-Comp-Restart-Performance-6N-6C:
+#Use this workflow if there are any tests that will be added to use public testnet state
+  GCP-Daily-Services-Comp-Restart-Performance-Testnet-6N-6C:
     triggers:
       - schedule:
           cron: "35 6 * * *"
           filters:
             branches:
               only:
-                - master
+                - Disable-master
     jobs:
       - build-platform-and-services
       - update-start-up-key:
@@ -1621,34 +1576,7 @@ workflows:
           regression_path: /swirlds-platform/regression
           result_path: results/6N_6C/Performance
           config_type: "daily"
-          workflow-name: "GCP-Daily-Services-Comp-Restart-Performance-6N-6C"
-          requires:
-            - update-start-up-key
-          pre-steps:
-            - install-tools
-            - attach_workspace:
-                at: /
-
-  GCP-Daily-Services-Comp-Restart-HTS-Performance-6N-6C:
-    triggers:
-      - schedule:
-          cron: "39 0 * * *"
-          filters:
-            branches:
-              only:
-                - master
-
-    jobs:
-      - build-platform-and-services
-      - update-start-up-key:
-          requires:
-            - build-platform-and-services
-      - jrs-regression:
-          context: Slack
-          regression_path: /swirlds-platform/regression
-          result_path: results/6N_6C/Performance
-          config_type: "daily"
-          workflow-name: "GCP-Daily-Services-Comp-Restart-HTS-Performance-6N-6C"
+          workflow-name: "GCP-Daily-Services-Comp-Restart-Performance-Testnet-6N-6C"
           requires:
             - update-start-up-key
           pre-steps:

--- a/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/LoadTest.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/LoadTest.java
@@ -46,7 +46,7 @@ public class LoadTest extends HapiApiSuite {
 	public static OptionalInt hcsSubmitMessage = OptionalInt.empty();
 	public static OptionalInt hcsSubmitMessageSizeVar = OptionalInt.empty();
 	/** initial balance of payer account used for paying for performance test transactions */
-	public static OptionalLong initialBalance = OptionalLong.of(90_000_000_000_000L);
+	public static OptionalLong initialBalance = OptionalLong.of(900_000_000_000L);
 	public static OptionalInt totalTestAccounts = OptionalInt.empty();
 	public static OptionalInt totalTestTopics = OptionalInt.empty();
 	public static OptionalInt totalTestTokens = OptionalInt.empty();

--- a/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/LoadTest.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/LoadTest.java
@@ -46,7 +46,7 @@ public class LoadTest extends HapiApiSuite {
 	public static OptionalInt hcsSubmitMessage = OptionalInt.empty();
 	public static OptionalInt hcsSubmitMessageSizeVar = OptionalInt.empty();
 	/** initial balance of payer account used for paying for performance test transactions */
-	public static OptionalLong initialBalance = OptionalLong.of(900_000_000_000L);
+	public static OptionalLong initialBalance = OptionalLong.of(90_000_000_000_000L);
 	public static OptionalInt totalTestAccounts = OptionalInt.empty();
 	public static OptionalInt totalTestTopics = OptionalInt.empty();
 	public static OptionalInt totalTestTokens = OptionalInt.empty();


### PR DESCRIPTION
**Related issue(s)**:
Closes #1051 

**Summary of the change**:
Fixed the JSON names to match the names merged in `swirlds-platform-regression` for Hotspot and Random tests.

Most of the tests started failing as initialBalance is increased and is being used for most of the tests, that gave `INSUFFICIENT_PAYER_BALANCE`
