### PR TITLE
Scheduled Transactions: Fix Sign op usage

### DIFF
--- a/hapi-fees/src/main/java/com/hedera/services/usage/schedule/ScheduleCreateUsage.java
+++ b/hapi-fees/src/main/java/com/hedera/services/usage/schedule/ScheduleCreateUsage.java
@@ -30,6 +30,7 @@ import static com.hederahashgraph.fee.FeeBuilder.BASIC_ENTITY_ID_SIZE;
 import static com.hederahashgraph.fee.FeeBuilder.getAccountKeyStorageSize;
 
 public class ScheduleCreateUsage extends ScheduleTxnUsage<ScheduleCreateUsage> {
+	private int expirationTimeSecs;
 
 	private ScheduleCreateUsage(TransactionBody scheduleCreationOp, TxnUsageEstimator usageEstimator) {
 		super(scheduleCreationOp, usageEstimator);
@@ -37,6 +38,11 @@ public class ScheduleCreateUsage extends ScheduleTxnUsage<ScheduleCreateUsage> {
 
 	public static ScheduleCreateUsage newEstimate(TransactionBody scheduleCreationOp, SigUsage sigUsage) {
 		return new ScheduleCreateUsage(scheduleCreationOp, estimatorFactory.get(sigUsage, scheduleCreationOp, ESTIMATOR_UTILS));
+	}
+
+	public ScheduleCreateUsage givenScheduledTxExpirationTimeSecs(int scheduledTxExpirationTimeSecs) {
+		this.expirationTimeSecs = scheduledTxExpirationTimeSecs;
+		return self();
 	}
 
 	@Override

--- a/hapi-fees/src/main/java/com/hedera/services/usage/schedule/ScheduleTxnUsage.java
+++ b/hapi-fees/src/main/java/com/hedera/services/usage/schedule/ScheduleTxnUsage.java
@@ -29,16 +29,10 @@ import static com.hedera.services.usage.schedule.entities.ScheduleEntitySizes.SC
 
 public abstract class ScheduleTxnUsage<T extends ScheduleTxnUsage<T>> extends TxnUsage {
 	static ScheduleEntitySizes scheduleEntitySizes = SCHEDULE_ENTITY_SIZES;
-	protected int expirationTimeSecs = 0;
 
 	abstract T self();
 
 	protected ScheduleTxnUsage(TransactionBody scheduleOp, TxnUsageEstimator usageEstimator) {
 		super(scheduleOp, usageEstimator);
-	}
-
-	public T givenScheduledTxExpirationTimeSecs(int scheduledTxExpirationTimeSecs) {
-		this.expirationTimeSecs = scheduledTxExpirationTimeSecs;
-		return self();
 	}
 }

--- a/hapi-fees/src/test/java/com/hedera/services/usage/schedule/ScheduleSignUsageTest.java
+++ b/hapi-fees/src/test/java/com/hedera/services/usage/schedule/ScheduleSignUsageTest.java
@@ -48,7 +48,7 @@ import static org.mockito.Mockito.verify;
 public class ScheduleSignUsageTest {
 
 	long now = 1_000L;
-	int scheduledTXExpiry = 1_000;
+	long scheduledTXExpiry = 2_700;
 	ScheduleID scheduleID = IdUtils.asSchedule("0.0.1");
 	int numSigs = 3, sigSize = 100, numPayerKeys = 1;
 	SigUsage sigUsage = new SigUsage(numSigs, sigSize, numPayerKeys);
@@ -86,7 +86,7 @@ public class ScheduleSignUsageTest {
 
 		// and:
 		subject = ScheduleSignUsage.newEstimate(txn, sigUsage)
-				.givenScheduledTxExpirationTimeSecs(scheduledTXExpiry);
+				.givenExpiry(scheduledTXExpiry);
 
 		// when:
 		var actual = subject.get();
@@ -108,7 +108,7 @@ public class ScheduleSignUsageTest {
 
 		// and:
 		subject = ScheduleSignUsage.newEstimate(txn, sigUsage)
-				.givenScheduledTxExpirationTimeSecs(scheduledTXExpiry);
+				.givenExpiry(scheduledTXExpiry);
 
 		// when:
 		var actual = subject.get();
@@ -117,7 +117,7 @@ public class ScheduleSignUsageTest {
 		assertEquals(A_USAGES_MATRIX, actual);
 		// and:
 		verify(base).addBpt(expectedTxBytes);
-		verify(base).addRbs(expectedRamBytes * scheduledTXExpiry);
+		verify(base).addRbs(expectedRamBytes * (scheduledTXExpiry - now));
 		verify(base).addVpt(sigMap.getSigPairCount());
 	}
 

--- a/hedera-node/src/main/java/com/hedera/services/context/ServicesContext.java
+++ b/hedera-node/src/main/java/com/hedera/services/context/ServicesContext.java
@@ -927,7 +927,7 @@ public class ServicesContext {
 				/* Schedule */
 				entry(ScheduleCreate, List.of(new ScheduleCreateResourceUsage(globalDynamicProperties()))),
 				entry(ScheduleDelete, List.of(new ScheduleDeleteResourceUsage())),
-				entry(ScheduleSign, List.of(new ScheduleSignResourceUsage(globalDynamicProperties()))),
+				entry(ScheduleSign, List.of(new ScheduleSignResourceUsage())),
 				/* System */
 				entry(Freeze, List.of(new FreezeResourceUsage())),
 				entry(SystemDelete, List.of(new SystemDeleteFileResourceUsage(fileFees))),

--- a/hedera-node/src/test/java/com/hedera/services/fees/calculation/schedule/txns/ScheduleSignResourceUsageTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/fees/calculation/schedule/txns/ScheduleSignResourceUsageTest.java
@@ -20,27 +20,32 @@ package com.hedera.services.fees.calculation.schedule.txns;
  * ‍
  */
 
-import com.hedera.services.config.MockGlobalDynamicProps;
 import com.hedera.services.context.primitives.StateView;
-import com.hedera.services.context.properties.GlobalDynamicProperties;
 import com.hedera.services.fees.calculation.UsageEstimatorUtils;
 import com.hedera.services.usage.SigUsage;
 import com.hedera.services.usage.schedule.ScheduleSignUsage;
+import com.hedera.test.utils.IdUtils;
 import com.hederahashgraph.api.proto.java.FeeComponents;
 import com.hederahashgraph.api.proto.java.FeeData;
+import com.hederahashgraph.api.proto.java.ScheduleID;
+import com.hederahashgraph.api.proto.java.ScheduleInfo;
+import com.hederahashgraph.api.proto.java.ScheduleSignTransactionBody;
+import com.hederahashgraph.api.proto.java.Timestamp;
 import com.hederahashgraph.api.proto.java.TransactionBody;
 import com.hederahashgraph.fee.SigValueObj;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.Optional;
 import java.util.function.BiFunction;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
 public class ScheduleSignResourceUsageTest {
     ScheduleSignResourceUsage subject;
@@ -49,30 +54,41 @@ public class ScheduleSignResourceUsageTest {
     BiFunction<TransactionBody, SigUsage, ScheduleSignUsage> factory;
     TransactionBody nonScheduleSignTxn;
     TransactionBody scheduleSignTxn;
+    long expiry = 2_345_678L;
 
     int numSigs = 10, sigsSize = 100, numPayerKeys = 3;
+    ScheduleID target = IdUtils.asSchedule("0.0.123");
     SigValueObj obj = new SigValueObj(numSigs, numPayerKeys, sigsSize);
     SigUsage sigUsage = new SigUsage(numSigs, sigsSize, numPayerKeys);
-    GlobalDynamicProperties props = new MockGlobalDynamicProps();
+
+    ScheduleInfo info = ScheduleInfo.newBuilder()
+            .setExpirationTime(Timestamp.newBuilder().setSeconds(expiry))
+            .build();
 
     @BeforeEach
     private void setup() {
         view = mock(StateView.class);
         scheduleSignTxn = mock(TransactionBody.class);
         given(scheduleSignTxn.hasScheduleSign()).willReturn(true);
+        given(scheduleSignTxn.getScheduleSign())
+                .willReturn(ScheduleSignTransactionBody.newBuilder()
+                        .setScheduleID(target)
+                        .build());
 
         nonScheduleSignTxn = mock(TransactionBody.class);
         given(nonScheduleSignTxn.hasScheduleSign()).willReturn(false);
 
         usage = mock(ScheduleSignUsage.class);
-        given(usage.givenScheduledTxExpirationTimeSecs(anyInt())).willReturn(usage);
+        given(usage.givenExpiry(anyLong())).willReturn(usage);
         given(usage.get()).willReturn(MOCK_SCHEDULE_SIGN_USAGE);
 
         factory = (BiFunction<TransactionBody, SigUsage, ScheduleSignUsage>)mock(BiFunction.class);
         given(factory.apply(scheduleSignTxn, sigUsage)).willReturn(usage);
 
+        given(view.infoForSchedule(target)).willReturn(Optional.of(info));
+
         ScheduleSignResourceUsage.factory = factory;
-        subject = new ScheduleSignResourceUsage(props);
+        subject = new ScheduleSignResourceUsage();
     }
 
     @Test
@@ -86,6 +102,20 @@ public class ScheduleSignResourceUsageTest {
     public void delegatesToCorrectEstimate() throws Exception {
         // expect:
         assertEquals(MOCK_SCHEDULE_SIGN_USAGE, subject.usageGiven(scheduleSignTxn, obj, view));
+    }
+
+    @Test
+    public void returnsDefaultIfInfoMissing() throws Exception {
+        given(view.infoForSchedule(target)).willReturn(Optional.empty());
+
+        // expect:
+        assertEquals(
+                FeeData.getDefaultInstance(),
+                subject.usageGiven(scheduleSignTxn, obj, view));
+        // and:
+        verify(factory).apply(scheduleSignTxn, sigUsage);
+        verify(scheduleSignTxn).getScheduleSign();
+        verify(view).infoForSchedule(target);
     }
 
     private static final FeeData MOCK_SCHEDULE_SIGN_USAGE = UsageEstimatorUtils.defaultPartitioning(

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/schedule/ScheduleCreateSpecs.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/schedule/ScheduleCreateSpecs.java
@@ -541,7 +541,7 @@ public class ScheduleCreateSpecs extends HapiApiSuite {
 				.given(
 						updateScheduleExpiryTimeSecs,
 						newKeyNamed("signer"),
-						scheduleCreate("inner", cryptoCreate("someAccount"))
+						scheduleCreate("inner", cryptoTransferTx)
 				)
 				.when(
 						scheduleCreate("outer",


### PR DESCRIPTION
**Related issue(s)**:
Closes #None

**Summary of the change**:
* Fix schedule sig `rbs` - instead of using `scheduedTxExpirationTimeSecs` from global props, multiply it by `expiry - txValidStart`.

**External impacts**:
None.

**Applicable documentation**
- [ ] Javadoc
- [ ] HAPI protobuf comments
- [ ] README
