### PR TITLE
Fix reconnect tests

### DIFF
--- a/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/HapiQueryOp.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/HapiQueryOp.java
@@ -142,13 +142,15 @@ public abstract class HapiQueryOp<T extends HapiQueryOp<T>> extends HapiSpecOper
 			} else {
 				String errMsg = String.format("Answer-only precheck was %s, not one of %s!",
 						actualPrecheck,	permissibleAnswerOnlyPrechecks.get());
-				log.error(errMsg);
+//				Turn this off until HAPIClientValidator needs it and knows how to deal with it
+//				log.error(errMsg);
 				throw new HapiQueryPrecheckStateException(errMsg);
 			}
 		} else {
 			if(expectedAnswerOnlyPrecheck() != actualPrecheck) {
 				String errMsg = String.format("Bad answerOnlyPrecheck! expected %s, actual %s", expectedAnswerOnlyPrecheck(), actualPrecheck);
-				log.error(errMsg);
+//				Turn this off until HAPIClientValidator needs it and knows how to deal with it
+//				log.error(errMsg);
 				throw new HapiQueryPrecheckStateException(errMsg);
 			}
 		}

--- a/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/UtilVerbs.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/UtilVerbs.java
@@ -418,7 +418,7 @@ public class UtilVerbs {
 			perturbedSchedules.getNextFeeScheduleBuilder()
 					.setExpiryTime(schedules.getNextFeeSchedule().getExpiryTime());
 			var rawPerturbedSchedules = perturbedSchedules.build().toByteString();
-			allRunFor(spec, updateLargeFile(SYSTEM_ADMIN, FEE_SCHEDULE, rawPerturbedSchedules));
+			allRunFor(spec, updateLargeFile(GENESIS, FEE_SCHEDULE, rawPerturbedSchedules));
 		});
 	}
 

--- a/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/UtilVerbs.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/UtilVerbs.java
@@ -396,7 +396,7 @@ public class UtilVerbs {
 
 	public static HapiSpecOperation makeFree(HederaFunctionality function) {
 		return withOpContext((spec, opLog) -> {
-			var query = getFileContents(FEE_SCHEDULE).payingWith(SYSTEM_ADMIN);
+			var query = getFileContents(FEE_SCHEDULE).payingWith(GENESIS);
 			allRunFor(spec, query);
 			byte[] rawSchedules =
 					query.getResponse().getFileGetContents().getFileContents().getContents().toByteArray();

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/reconnect/UpdateAllProtectedFilesDuringReconnect.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/reconnect/UpdateAllProtectedFilesDuringReconnect.java
@@ -115,7 +115,7 @@ public class UpdateAllProtectedFilesDuringReconnect extends HapiApiSuite {
 											spec.registry().saveBytes("newRates", newRates);
 											return newRates;
 										}
-								).signedBy(SYSTEM_ADMIN),
+								).signedBy(DEFAULT_PAYER, SYSTEM_ADMIN),
 
 						makeFree(CryptoGetInfo),
 
@@ -137,12 +137,12 @@ public class UpdateAllProtectedFilesDuringReconnect extends HapiApiSuite {
 						getFileContents(API_PERMISSIONS)
 								.logged()
 								.setNode("0.0.3")
-								.signedBy(SYSTEM_ADMIN)
+								.signedBy(DEFAULT_PAYER, SYSTEM_ADMIN)
 								.saveToRegistry(fileInfoRegistry),
 						getFileContents(API_PERMISSIONS)
 								.logged()
 								.setNode("0.0.6")
-								.signedBy(SYSTEM_ADMIN)
+								.signedBy(DEFAULT_PAYER, SYSTEM_ADMIN)
 								.hasContents(fileInfoRegistry),
 
 						fileUpdate(nonUpdatableFile)

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/reconnect/UpdateAllProtectedFilesDuringReconnect.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/reconnect/UpdateAllProtectedFilesDuringReconnect.java
@@ -115,7 +115,7 @@ public class UpdateAllProtectedFilesDuringReconnect extends HapiApiSuite {
 											spec.registry().saveBytes("newRates", newRates);
 											return newRates;
 										}
-								).signedBy(DEFAULT_PAYER, SYSTEM_ADMIN),
+								).payingWith(GENESIS),
 
 						makeFree(CryptoGetInfo),
 
@@ -137,12 +137,12 @@ public class UpdateAllProtectedFilesDuringReconnect extends HapiApiSuite {
 						getFileContents(API_PERMISSIONS)
 								.logged()
 								.setNode("0.0.3")
-								.signedBy(DEFAULT_PAYER, SYSTEM_ADMIN)
+								.payingWith(GENESIS)
 								.saveToRegistry(fileInfoRegistry),
 						getFileContents(API_PERMISSIONS)
 								.logged()
 								.setNode("0.0.6")
-								.signedBy(DEFAULT_PAYER, SYSTEM_ADMIN)
+								.payingWith(GENESIS)
 								.hasContents(fileInfoRegistry),
 
 						fileUpdate(nonUpdatableFile)

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/reconnect/UpdateAllProtectedFilesDuringReconnect.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/reconnect/UpdateAllProtectedFilesDuringReconnect.java
@@ -115,7 +115,7 @@ public class UpdateAllProtectedFilesDuringReconnect extends HapiApiSuite {
 											spec.registry().saveBytes("newRates", newRates);
 											return newRates;
 										}
-								).payingWith(SYSTEM_ADMIN),
+								).signedBy(SYSTEM_ADMIN),
 
 						makeFree(CryptoGetInfo),
 
@@ -137,12 +137,12 @@ public class UpdateAllProtectedFilesDuringReconnect extends HapiApiSuite {
 						getFileContents(API_PERMISSIONS)
 								.logged()
 								.setNode("0.0.3")
-								.payingWith(SYSTEM_ADMIN)
+								.signedBy(SYSTEM_ADMIN)
 								.saveToRegistry(fileInfoRegistry),
 						getFileContents(API_PERMISSIONS)
 								.logged()
 								.setNode("0.0.6")
-								.payingWith(SYSTEM_ADMIN)
+								.signedBy(SYSTEM_ADMIN)
 								.hasContents(fileInfoRegistry),
 
 						fileUpdate(nonUpdatableFile)

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/reconnect/ValidateDuplicateTransactionAfterReconnect.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/reconnect/ValidateDuplicateTransactionAfterReconnect.java
@@ -65,12 +65,11 @@ public class ValidateDuplicateTransactionAfterReconnect extends HapiApiSuite {
 								.setNode("0.0.6")
 								.unavailableNode(),
 						fileUpdate(APP_PROPERTIES)
-								.payingWith(ADDRESS_BOOK_CONTROL)
+								.payingWith(GENESIS)
 								.overridingProps(Map.of("ledger.keepRecordsInState", "true"))
 				)
 				.when(
 						cryptoCreate("repeatedTransaction")
-								.payingWith(SYSTEM_ADMIN)
 								.validDurationSecs(180)
 								.via(transactionId),
 						getAccountBalance(GENESIS)
@@ -88,7 +87,6 @@ public class ValidateDuplicateTransactionAfterReconnect extends HapiApiSuite {
 								.loggingAvailabilityEvery(10)
 								.sleepingBetweenRetriesFor(5),
 						cryptoCreate("repeatedTransaction")
-								.payingWith(SYSTEM_ADMIN)
 								.txnId(transactionId)
 								.validDurationSecs(180)
 								.hasPrecheck(DUPLICATE_TRANSACTION)


### PR DESCRIPTION
**Related issue(s)**:
Closes #1057

**Summary of the change**:
- Use GENESIS or default payer because system accounts have zero initial balance. #1020
- Turn off some log errors that were added in #893, until HAPIClientValidator needs them and knows how to deal with them.

Passing all reconnect tests
https://hedera-hashgraph.slack.com/archives/C018CBQBTGB/p1612582160219000