### PR TITLE
Include token decimals in query responses

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,2 @@
-TAG=v0.11.0-492-g3e086fcfc-dirty
+TAG=v0.11.0-493-g8f79ba46b-dirty
 REGISTRY_PREFIX=

--- a/hedera-node/src/main/java/com/hedera/services/ServicesState.java
+++ b/hedera-node/src/main/java/com/hedera/services/ServicesState.java
@@ -83,7 +83,8 @@ public class ServicesState extends AbstractNaryMerkleInternal implements SwirldS
 	static final int RELEASE_090_VERSION = 3;
 	static final int RELEASE_0100_VERSION = 4;
 	static final int RELEASE_0110_VERSION = 5;
-	static final int MERKLE_VERSION = RELEASE_0110_VERSION;
+	static final int RELEASE_0120_VERSION = 6;
+	static final int MERKLE_VERSION = RELEASE_0120_VERSION;
 	static final long RUNTIME_CONSTRUCTABLE_ID = 0x8e300b0dfdafbb1aL;
 
 	static final String UNSUPPORTED_VERSION_MSG_TPL = "Argument 'version=%d' is invalid!";
@@ -112,6 +113,7 @@ public class ServicesState extends AbstractNaryMerkleInternal implements SwirldS
 		static final int SCHEDULE_TXS = 8;
 		static final int RECORD_STREAM_RUNNING_HASH = 9;
 		static final int NUM_0110_CHILDREN = 10;
+		static final int NUM_0120_CHILDREN = 10;
 	}
 
 	ServicesContext ctx;
@@ -120,7 +122,7 @@ public class ServicesState extends AbstractNaryMerkleInternal implements SwirldS
 	}
 
 	public ServicesState(List<MerkleNode> children) {
-		super(ChildIndices.NUM_0110_CHILDREN);
+		super(ChildIndices.NUM_0120_CHILDREN);
 		addDeserializedChildren(children, MERKLE_VERSION);
 	}
 
@@ -147,6 +149,8 @@ public class ServicesState extends AbstractNaryMerkleInternal implements SwirldS
 	@Override
 	public int getMinimumChildCount(int version) {
 		switch (version) {
+			case RELEASE_0120_VERSION:
+				return ChildIndices.NUM_0120_CHILDREN;
 			case RELEASE_0110_VERSION:
 				return ChildIndices.NUM_0110_CHILDREN;
 			case RELEASE_0100_VERSION:

--- a/hedera-node/src/main/java/com/hedera/services/context/primitives/StateView.java
+++ b/hedera-node/src/main/java/com/hedera/services/context/primitives/StateView.java
@@ -70,6 +70,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.OptionalInt;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiFunction;
 import java.util.function.Supplier;

--- a/hedera-node/src/main/java/com/hedera/services/keys/InHandleActivationHelper.java
+++ b/hedera-node/src/main/java/com/hedera/services/keys/InHandleActivationHelper.java
@@ -124,7 +124,7 @@ public class InHandleActivationHelper {
 			var otherOrderingResult = keyOrderer.keysForOtherParties(current.getTxn(), IN_HANDLE_SUMMARY_FACTORY);
 			if (otherOrderingResult.hasErrorReport()) {
 				var errorReport = otherOrderingResult.getErrorReport();
-				log.warn("Allowing active other-party sigs: {} ({})!", errorReport, errorReport.getResponseCode());
+				log.debug("Allowing active other-party sigs: {} ({})!", errorReport, errorReport.getResponseCode());
 				otherParties = Collections.emptyList();
 			} else {
 				otherParties = otherOrderingResult.getOrderedKeys();

--- a/hedera-node/src/main/java/com/hedera/services/queries/crypto/GetAccountBalanceAnswer.java
+++ b/hedera-node/src/main/java/com/hedera/services/queries/crypto/GetAccountBalanceAnswer.java
@@ -21,6 +21,7 @@ package com.hedera.services.queries.crypto;
  */
 
 import com.hedera.services.context.primitives.StateView;
+import com.hedera.services.state.merkle.MerkleToken;
 import com.hedera.services.txns.validation.OptionValidator;
 import com.hedera.services.queries.AnswerService;
 import com.hedera.services.utils.SignedTxnAccessor;
@@ -88,9 +89,11 @@ public class GetAccountBalanceAnswer implements AnswerService {
 			for (TokenID tId : account.tokens().asIds()) {
 				var relKey = fromAccountTokenRel(id, tId);
 				var relationship = view.tokenAssociations().get().get(relKey);
+				var decimals = view.tokenWith(tId).map(MerkleToken::decimals).orElse(0);
 				opAnswer.addTokenBalances(TokenBalance.newBuilder()
 						.setTokenId(tId)
 						.setBalance(relationship.getBalance())
+						.setDecimals(decimals)
 						.build());
 			}
 		}

--- a/hedera-node/src/main/java/com/hedera/services/records/TxnAwareRecordsHistorian.java
+++ b/hedera-node/src/main/java/com/hedera/services/records/TxnAwareRecordsHistorian.java
@@ -97,9 +97,6 @@ public class TxnAwareRecordsHistorian implements AccountRecordsHistorian {
 				accessor.getTxnId(),
 				lastCreatedRecord.getReceipt().getStatus(),
 				payerRecord);
-//		if (SingletonContextsManager.CONTEXTS.lookup(0L).txnCtx() == txnCtx) {
-//			log.info("Created ({}) -> {}", accessor.getTxnId(), payerRecord);
-//		}
 	}
 
 	@Override
@@ -114,11 +111,10 @@ public class TxnAwareRecordsHistorian implements AccountRecordsHistorian {
 
 	@Override
 	public void addNewEntities() {
-		var expiringEntities = txnCtx.expiringEntities();
-		if (expiringEntities.size() != 0) {
-			for (var expiringEntity : expiringEntities) {
-				expiries.trackEntity(new Pair<>(expiringEntity.id().num(), expiringEntity.consumer()), expiringEntity.expiry());
-			}
+		for (var expiringEntity : txnCtx.expiringEntities()) {
+			expiries.trackEntity(
+					new Pair<>(expiringEntity.id().num(), expiringEntity.consumer()),
+					expiringEntity.expiry());
 		}
 	}
 }

--- a/hedera-node/src/main/java/com/hedera/services/state/submerkle/RawTokenRelationship.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/submerkle/RawTokenRelationship.java
@@ -87,6 +87,7 @@ public class RawTokenRelationship {
 	public TokenRelationship asGrpcFor(MerkleToken token) {
 		return TokenRelationship.newBuilder()
 				.setBalance(balance)
+				.setDecimals(token.decimals())
 				.setSymbol(token.symbol())
 				.setTokenId(TokenID.newBuilder()
 						.setShardNum(shardNum)

--- a/hedera-node/src/main/resources/semantic-version.properties
+++ b/hedera-node/src/main/resources/semantic-version.properties
@@ -1,2 +1,2 @@
-hapi.proto.version=0.11.0
-hedera.services.version=0.11.0
+hapi.proto.version=0.12.0
+hedera.services.version=0.12.0

--- a/hedera-node/src/test/java/com/hedera/services/ServicesStateTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/ServicesStateTest.java
@@ -92,6 +92,7 @@ import java.util.function.Supplier;
 
 import static com.hedera.services.ServicesState.RELEASE_0100_VERSION;
 import static com.hedera.services.ServicesState.RELEASE_0110_VERSION;
+import static com.hedera.services.ServicesState.RELEASE_0120_VERSION;
 import static com.hedera.services.ServicesState.RELEASE_070_VERSION;
 import static com.hedera.services.ServicesState.RELEASE_080_VERSION;
 import static com.hedera.services.ServicesState.RELEASE_090_VERSION;
@@ -285,6 +286,8 @@ class ServicesStateTest {
 	public void hasExpectedMinChildCounts() {
 		// given:
 		subject = new ServicesState(ctx, self, Collections.emptyList());
+		// and:
+		int invalidVersion = ServicesState.MERKLE_VERSION + 1;
 
 		// expect:
 		assertEquals(ServicesState.ChildIndices.NUM_070_CHILDREN, subject.getMinimumChildCount(RELEASE_070_VERSION));
@@ -292,11 +295,12 @@ class ServicesStateTest {
 		assertEquals(ServicesState.ChildIndices.NUM_090_CHILDREN, subject.getMinimumChildCount(RELEASE_090_VERSION));
 		assertEquals(ServicesState.ChildIndices.NUM_0100_CHILDREN, subject.getMinimumChildCount(RELEASE_0100_VERSION));
 		assertEquals(ServicesState.ChildIndices.NUM_0110_CHILDREN, subject.getMinimumChildCount(RELEASE_0110_VERSION));
+		assertEquals(ServicesState.ChildIndices.NUM_0120_CHILDREN, subject.getMinimumChildCount(RELEASE_0120_VERSION));
 
 		Throwable throwable = assertThrows(IllegalArgumentException.class,
-				() -> subject.getMinimumChildCount(RELEASE_0110_VERSION + 1));
+				() -> subject.getMinimumChildCount(invalidVersion));
 		assertEquals(
-				String.format(ServicesState.UNSUPPORTED_VERSION_MSG_TPL, RELEASE_0110_VERSION + 1),
+				String.format(ServicesState.UNSUPPORTED_VERSION_MSG_TPL, invalidVersion),
 				throwable.getMessage());
 	}
 

--- a/hedera-node/src/test/java/com/hedera/services/queries/crypto/GetAccountBalanceAnswerTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/queries/crypto/GetAccountBalanceAnswerTest.java
@@ -101,8 +101,10 @@ public class GetAccountBalanceAnswerTest {
 	private void setup() {
 		deleted = mock(MerkleToken.class);
 		given(deleted.isDeleted()).willReturn(true);
+		given(deleted.decimals()).willReturn(123);
 		notDeleted = mock(MerkleToken.class);
 		given(notDeleted.isDeleted()).willReturn(false);
+		given(notDeleted.decimals()).willReturn(1).willReturn(2);
 
 		tokenRels = new FCMap<>();
 		tokenRels.put(
@@ -281,10 +283,10 @@ public class GetAccountBalanceAnswerTest {
 		// expect:
 		assertTrue(response.getCryptogetAccountBalance().hasHeader(), "Missing response header!");
 		assertEquals(
-				List.of(tokenBalanceWith(aToken, aBalance),
-						tokenBalanceWith(bToken, bBalance),
-						tokenBalanceWith(cToken, cBalance),
-						tokenBalanceWith(dToken, dBalance)
+				List.of(tokenBalanceWith(aToken, aBalance, 1),
+						tokenBalanceWith(bToken, bBalance, 2),
+						tokenBalanceWith(cToken, cBalance, 123),
+						tokenBalanceWith(dToken, dBalance, 0)
 				),
 				response.getCryptogetAccountBalance().getTokenBalancesList());
 		assertEquals(OK, status);

--- a/hedera-node/src/test/java/com/hedera/services/queries/crypto/GetAccountInfoAnswerTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/queries/crypto/GetAccountInfoAnswerTest.java
@@ -126,8 +126,12 @@ class GetAccountInfoAnswerTest {
 		given(token.freezeKey()).willReturn(Optional.of(new JEd25519Key("freeze".getBytes())));
 		given(token.hasKycKey()).willReturn(true);
 		given(token.hasFreezeKey()).willReturn(true);
+		given(token.decimals())
+				.willReturn(1).willReturn(2).willReturn(3)
+				.willReturn(1).willReturn(2).willReturn(3);
 		deletedToken = mock(MerkleToken.class);
 		given(deletedToken.isDeleted()).willReturn(true);
+		given(deletedToken.decimals()).willReturn(4);
 
 		tokenStore = mock(TokenStore.class);
 		given(tokenStore.exists(firstToken)).willReturn(true);

--- a/hedera-node/src/test/java/com/hedera/services/sigs/factories/ScheduleBodySigningSigFactoryTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/sigs/factories/ScheduleBodySigningSigFactoryTest.java
@@ -24,8 +24,6 @@ import com.google.protobuf.ByteString;
 import com.swirlds.common.crypto.TransactionSignature;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
 import static com.hedera.services.sigs.factories.PlatformSigFactoryTest.EXPECTED_DIFFERENT_SIG;
 import static com.hedera.services.sigs.factories.PlatformSigFactoryTest.EXPECTED_SIG;
@@ -35,7 +33,6 @@ import static com.hedera.services.sigs.factories.PlatformSigFactoryTest.differen
 import static com.hedera.services.sigs.factories.PlatformSigFactoryTest.pk;
 import static com.hedera.services.sigs.factories.PlatformSigFactoryTest.sig;
 
-@RunWith(JUnitPlatform.class)
 public class ScheduleBodySigningSigFactoryTest {
 	@Test
 	public void createsExpectedSig() {

--- a/hedera-node/src/test/java/com/hedera/services/sigs/factories/SigFactoryCreatorTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/sigs/factories/SigFactoryCreatorTest.java
@@ -40,8 +40,6 @@ import com.swirlds.fcmap.FCMap;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
 import static com.hedera.services.sigs.factories.PlatformSigFactoryTest.pk;
 import static com.hedera.services.sigs.factories.PlatformSigFactoryTest.sig;
@@ -51,7 +49,6 @@ import static org.hamcrest.Matchers.instanceOf;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.mock;
 
-@RunWith(JUnitPlatform.class)
 public class SigFactoryCreatorTest {
 	FCMap<MerkleEntityId, MerkleSchedule> scheduledTxns;
 

--- a/hedera-node/src/test/java/com/hedera/services/sigs/sourcing/ScheduledPubKeyToSigBytesTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/sigs/sourcing/ScheduledPubKeyToSigBytesTest.java
@@ -23,14 +23,11 @@ package com.hedera.services.sigs.sourcing;
 import com.hedera.services.legacy.exception.KeyPrefixMismatchException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.mock;
 
-@RunWith(JUnitPlatform.class)
 public class ScheduledPubKeyToSigBytesTest {
 	byte[] key = "Putative signatory...".getBytes();
 	byte[] expectedSig = "Anything else a great disappointment!".getBytes();

--- a/hedera-node/src/test/java/com/hedera/services/state/submerkle/RawTokenRelationshipTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/state/submerkle/RawTokenRelationshipTest.java
@@ -32,6 +32,7 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.mockito.BDDMockito.*;
 
 class RawTokenRelationshipTest {
+	int decimals = 5;
 	long num = 123;
 	long balance = 234;
 	boolean frozen = true;
@@ -72,6 +73,8 @@ class RawTokenRelationshipTest {
 
 	@Test
 	public void grpcConversionRecognizesInapplicable() {
+		given(token.decimals()).willReturn(decimals);
+
 		// when:
 		var desc = subject.asGrpcFor(token);
 
@@ -80,6 +83,7 @@ class RawTokenRelationshipTest {
 		assertEquals(IdUtils.tokenWith(num), desc.getTokenId());
 		assertEquals(TokenFreezeStatus.FreezeNotApplicable, desc.getFreezeStatus());
 		assertEquals(TokenKycStatus.KycNotApplicable, desc.getKycStatus());
+		assertEquals(decimals, desc.getDecimals());
 	}
 
 	@Test

--- a/hedera-node/src/test/java/com/hedera/services/throttling/BucketThrottlingTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/throttling/BucketThrottlingTest.java
@@ -137,8 +137,6 @@ class BucketThrottlingTest {
 	@Test
 	void rebuildsAsExpected() {
 		// setup:
-		var oldDisplay = BucketThrottling.displayFn;
-		BucketThrottling.displayFn = System.out::println;
 		subject.functions = new HederaFunctionality[] { FileAppend, ConsensusGetTopicInfo };
 		var oldCapacities = subject.capacities;
 
@@ -148,9 +146,6 @@ class BucketThrottlingTest {
 		// then:
 		assertEquals(2, subject.capacities.size());
 		assertNotSame(oldCapacities, subject.capacities);
-
-		// cleanup:
-		BucketThrottling.displayFn = oldDisplay;
 	}
 
 	@Test

--- a/hedera-node/src/test/java/com/hedera/test/utils/IdUtils.java
+++ b/hedera-node/src/test/java/com/hedera/test/utils/IdUtils.java
@@ -109,10 +109,11 @@ public class IdUtils {
 		return String.format("%d.%d.%d", account.getShardNum(), account.getRealmNum(), account.getAccountNum());
 	}
 
-	public static TokenBalance tokenBalanceWith(TokenID id, long balance) {
+	public static TokenBalance tokenBalanceWith(TokenID id, long balance, int decimals) {
 		return TokenBalance.newBuilder()
 				.setTokenId(id)
 				.setBalance(balance)
+				.setDecimals(decimals)
 				.build();
 	}
 

--- a/pom.xml
+++ b/pom.xml
@@ -153,7 +153,7 @@
     <grpc.version>1.33.0</grpc.version>
     <jackson-databind.version>2.9.10.7</jackson-databind.version>
     <javax.annotation-api.version>1.3.2</javax.annotation-api.version>
-    <hapi-proto.version>0.12.0-SNAPSHOT</hapi-proto.version>
+    <hapi-proto.version>0.12.0-rc.1</hapi-proto.version>
     <log4j.version>2.13.2</log4j.version>
     <netty.version>4.1.51.Final</netty.version>
     <!-- Test dependency properties -->

--- a/test-clients/devops-utils/validation-scenarios/config.yml
+++ b/test-clients/devops-utils/validation-scenarios/config.yml
@@ -114,15 +114,15 @@ networks:
     defaultNode: 3
     ensureScenarioPayerHbars: 100000
     nodes:
-    - {account: 3, ipv4Addr: '127.0.0.1:50213'}
+    - {account: 3, ipv4Addr: '127.0.0.1:50211'}
     scenarioPayer: 1001
     scenarios:
-      consensus: {persistent: 1007}
+      consensus: {persistent: 1010}
       contract:
-        persistent: {bytecode: 1005, luckyNo: 42, num: 1006, source: Multipurpose.sol}
+        persistent: {bytecode: 1007, luckyNo: 42, num: 1008, source: Multipurpose.sol}
       crypto: {receiver: 1003, sender: 1002}
       file:
-        persistent: {contents: MrBleaney.txt, num: 1004}
+        persistent: {contents: MrBleaney.txt, num: 1005}
   staging:
     bootstrap: 2
     defaultNode: 3

--- a/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/crypto/ExpectedTokenRel.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/crypto/ExpectedTokenRel.java
@@ -32,12 +32,14 @@ import org.apache.logging.log4j.Logger;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.OptionalInt;
 import java.util.OptionalLong;
 
 public class ExpectedTokenRel {
 	private static final Logger log = LogManager.getLogger(ExpectedTokenRel.class);
 	private final String token;
 
+	private OptionalInt decimals = OptionalInt.empty();
 	private OptionalLong balance = OptionalLong.empty();
 	private Optional<TokenKycStatus> kycStatus = Optional.empty();
 	private Optional<TokenFreezeStatus> freezeStatus = Optional.empty();
@@ -81,6 +83,7 @@ public class ExpectedTokenRel {
 			for (TokenRelationship actualRel : actualRels) {
 				if (actualRel.getTokenId().equals(expectedId)) {
 					found = true;
+					rel.getDecimals().ifPresent(d -> Assert.assertEquals(d, actualRel.getDecimals()));
 					rel.getBalance().ifPresent(a -> Assert.assertEquals(a, actualRel.getBalance()));
 					rel.getKycStatus().ifPresent(s -> Assert.assertEquals(s, actualRel.getKycStatus()));
 					rel.getFreezeStatus().ifPresent(s -> Assert.assertEquals(s, actualRel.getFreezeStatus()));
@@ -93,6 +96,11 @@ public class ExpectedTokenRel {
 				throw new HapiQueryCheckStateException(errMsg);
 			}
 		}
+	}
+
+	public ExpectedTokenRel decimals(int expected) {
+		decimals = OptionalInt.of(expected);
+		return this;
 	}
 
 	public ExpectedTokenRel balance(long expected) {
@@ -112,6 +120,10 @@ public class ExpectedTokenRel {
 
 	public String getToken() {
 		return token;
+	}
+
+	public OptionalInt getDecimals() {
+		return decimals;
 	}
 
 	public OptionalLong getBalance() {

--- a/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/crypto/HapiGetAccountBalance.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/crypto/HapiGetAccountBalance.java
@@ -21,7 +21,6 @@ package com.hedera.services.bdd.spec.queries.crypto;
  */
 
 import com.google.common.base.MoreObjects;
-import com.hedera.services.bdd.spec.transactions.TxnUtils;
 import com.hederahashgraph.api.proto.java.AccountID;
 import com.hederahashgraph.api.proto.java.CryptoGetAccountBalanceQuery;
 import com.hederahashgraph.api.proto.java.HederaFunctionality;
@@ -33,6 +32,7 @@ import com.hederahashgraph.api.proto.java.Transaction;
 import com.hedera.services.bdd.spec.HapiApiSpec;
 import com.hedera.services.bdd.spec.HapiPropertySource;
 import com.hedera.services.bdd.spec.queries.HapiQueryOp;
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.Assert;
@@ -63,7 +63,7 @@ public class HapiGetAccountBalance extends HapiQueryOp<HapiGetAccountBalance> {
 	Optional<Supplier<String>> entityFn = Optional.empty();
 	Optional<Function<HapiApiSpec, Function<Long, Optional<String>>>> expectedCondition = Optional.empty();
 
-	List<Map.Entry<String, Long>> expectedTokenBalances = Collections.EMPTY_LIST;
+	List<Map.Entry<String, String>> expectedTokenBalances = Collections.EMPTY_LIST;
 
 	public HapiGetAccountBalance(String entity) {
 		this.entity = entity;
@@ -85,7 +85,14 @@ public class HapiGetAccountBalance extends HapiQueryOp<HapiGetAccountBalance> {
 		if (expectedTokenBalances.isEmpty()) {
 			expectedTokenBalances = new ArrayList<>();
 		}
-		expectedTokenBalances.add(new AbstractMap.SimpleImmutableEntry<>(token, amount));
+		expectedTokenBalances.add(new AbstractMap.SimpleImmutableEntry<>(token, amount + "-G"));
+		return this;
+	}
+	public HapiGetAccountBalance hasTokenBalance(String token, long amount, int decimals) {
+		if (expectedTokenBalances.isEmpty()) {
+			expectedTokenBalances = new ArrayList<>();
+		}
+		expectedTokenBalances.add(new AbstractMap.SimpleImmutableEntry<>(token, amount + "-" + decimals));
 		return this;
 	}
 
@@ -116,15 +123,27 @@ public class HapiGetAccountBalance extends HapiQueryOp<HapiGetAccountBalance> {
 		}
 
 		if (expectedTokenBalances.size() > 0) {
-			Map<TokenID, Long> actualTokenBalances = response.getCryptogetAccountBalance().getTokenBalancesList()
+			Pair<Long, Integer> defaultTb = Pair.of(0L, 0);
+			Map<TokenID, Pair<Long, Integer>> actualTokenBalances = response.getCryptogetAccountBalance().getTokenBalancesList()
 					.stream()
-					.collect(Collectors.toMap(TokenBalance::getTokenId, TokenBalance::getBalance));
-			for (Map.Entry<String, Long> tokenBalance : expectedTokenBalances) {
+					.collect(Collectors.toMap(
+							TokenBalance::getTokenId,
+							tb -> Pair.of(tb.getBalance(), tb.getDecimals())));
+			for (Map.Entry<String, String> tokenBalance : expectedTokenBalances) {
 				var tokenId = asTokenId(tokenBalance.getKey(), spec);
-				var expected = tokenBalance.getValue();
+				String[] expectedParts = tokenBalance.getValue().split("-");
+				Long expectedBalance = Long.valueOf(expectedParts[0]);
 				Assert.assertEquals(String.format(
 						"Wrong balance for token '%s'!", HapiPropertySource.asTokenString(tokenId)),
-						expected, actualTokenBalances.getOrDefault(tokenId, 0L));
+						expectedBalance,
+						actualTokenBalances.getOrDefault(tokenId, defaultTb).getLeft());
+				if (!"G".equals(expectedParts[1])) {
+					Integer expectedDecimals = Integer.valueOf(expectedParts[1]);
+					Assert.assertEquals(String.format(
+							"Wrong decimals for token '%s'!", HapiPropertySource.asTokenString(tokenId)),
+							expectedDecimals,
+							actualTokenBalances.getOrDefault(tokenId, defaultTb).getRight());
+				}
 			}
 		}
 	}

--- a/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/file/HapiFileCreate.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/file/HapiFileCreate.java
@@ -64,6 +64,7 @@ public class HapiFileCreate extends HapiTxnOp<HapiFileCreate> {
 	private Key waclKey;
 	private final String fileName;
 	private boolean immutable = false;
+	OptionalLong expiry = OptionalLong.empty();
 	OptionalLong lifetime = OptionalLong.empty();
 	Optional<String> contentsPath = Optional.empty();
 	Optional<byte[]> contents = Optional.empty();
@@ -100,6 +101,11 @@ public class HapiFileCreate extends HapiTxnOp<HapiFileCreate> {
 
 	public HapiFileCreate unmodifiable() {
 		immutable = true;
+		return this;
+	}
+
+	public HapiFileCreate expiry(long at) {
+		this.expiry = OptionalLong.of(at);
 		return this;
 	}
 
@@ -171,6 +177,9 @@ public class HapiFileCreate extends HapiTxnOp<HapiFileCreate> {
 							memo.ifPresent(builder::setMemo);
 							contents.ifPresent(b -> builder.setContents(ByteString.copyFrom(b)));
 							lifetime.ifPresent(s -> builder.setExpirationTime(TxnFactory.expiryGiven(s)));
+							expiry.ifPresent(t -> builder.setExpirationTime(Timestamp.newBuilder()
+									.setSeconds(t)
+									.build()));
 						});
 		return b -> {
 			expiryUsed.set(opBody.getExpirationTime());

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/fees/CreateAndUpdateOps.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/fees/CreateAndUpdateOps.java
@@ -1,0 +1,228 @@
+package com.hedera.services.bdd.suites.fees;
+
+/*-
+ * ‌
+ * Hedera Services Test Clients
+ * ​
+ * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import com.hedera.services.bdd.spec.HapiApiSpec;
+import com.hedera.services.bdd.spec.keys.KeyShape;
+import com.hedera.services.bdd.spec.transactions.TxnUtils;
+import com.hedera.services.bdd.spec.transactions.TxnVerbs;
+import com.hedera.services.bdd.suites.HapiApiSuite;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static com.hedera.services.bdd.spec.HapiApiSpec.CostSnapshotMode;
+import static com.hedera.services.bdd.spec.HapiApiSpec.CostSnapshotMode.TAKE;
+import static com.hedera.services.bdd.spec.HapiApiSpec.customHapiSpec;
+import static com.hedera.services.bdd.spec.keys.KeyShape.SIMPLE;
+import static com.hedera.services.bdd.spec.keys.KeyShape.listOf;
+import static com.hedera.services.bdd.spec.keys.KeyShape.threshOf;
+import static com.hedera.services.bdd.spec.queries.QueryVerbs.contractCallLocal;
+import static com.hedera.services.bdd.spec.queries.QueryVerbs.getAccountInfo;
+import static com.hedera.services.bdd.spec.queries.QueryVerbs.getFileInfo;
+import static com.hedera.services.bdd.spec.queries.QueryVerbs.getTxnRecord;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.contractCall;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.contractCreate;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoCreate;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoTransfer;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoUpdate;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.fileCreate;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.fileUpdate;
+import static com.hedera.services.bdd.spec.transactions.crypto.HapiCryptoTransfer.tinyBarsFromTo;
+import static com.hedera.services.bdd.spec.utilops.CustomSpecAssert.allRunFor;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.newKeyNamed;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.sourcing;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.withOpContext;
+
+public class CreateAndUpdateOps extends HapiApiSuite {
+	private static final Logger log = LogManager.getLogger(CreateAndUpdateOps.class);
+
+	long feeToOffer = A_HUNDRED_HBARS;
+	long paymentToOffer = ONE_HBAR;
+	long payerBalance = feeToOffer * 1000;
+	CostSnapshotMode costSnapshotMode = TAKE;
+//	CostSnapshotMode costSnapshotMode = COMPARE;
+
+	public static void main(String... args) {
+		new CreateAndUpdateOps().runSuiteSync();
+	}
+
+	@Override
+	protected List<HapiApiSpec> getSpecsInSuite() {
+		return List.of(new HapiApiSpec[] {
+//				variousCryptoMutations(),
+				variousFileMutations(),
+		});
+	}
+
+	HapiApiSpec variousFileMutations() {
+		KeyShape smallWacl = listOf(1);
+		KeyShape largeWacl = listOf(3);
+		byte[] smallContents = TxnUtils.randomUtf8Bytes(1_024);
+		byte[] mediumContents = TxnUtils.randomUtf8Bytes(2_048);
+		byte[] largeContents = TxnUtils.randomUtf8Bytes(4_096);
+		long shortExpiry = 100_000L;
+		long mediumExpiry = 10 * shortExpiry;
+		long eternalExpiry = 10 * mediumExpiry;
+		AtomicLong consensusNow = new AtomicLong();
+
+		return customHapiSpec("VariousFileMutations")
+				.withProperties(Map.of("cost.snapshot.mode", costSnapshotMode.toString()))
+				.given(
+						newKeyNamed("sk").shape(smallWacl),
+						newKeyNamed("lk").shape(largeWacl),
+						cryptoCreate("payer")
+								.via("payerCreation")
+								.fee(feeToOffer)
+								.balance(payerBalance),
+						withOpContext((spec, opLog) -> {
+							var lookup = getTxnRecord("payerCreation").nodePayment(paymentToOffer);
+							allRunFor(spec, lookup);
+							var record = lookup.getResponseRecord();
+							consensusNow.set(record.getConsensusTimestamp().getSeconds());
+						})
+				).when(
+						sourcing(() -> fileCreate("sksc")
+								.fee(feeToOffer)
+								.payingWith("payer")
+								.key("sk")
+								.contents(smallContents)
+								.expiry(consensusNow.get() + shortExpiry)),
+						sourcing(() -> fileCreate("skmc")
+								.fee(feeToOffer)
+								.payingWith("payer")
+								.key("sk")
+								.contents(mediumContents)
+								.expiry(consensusNow.get() + mediumExpiry)),
+						sourcing(() -> fileCreate("sklc")
+								.fee(feeToOffer)
+								.payingWith("payer")
+								.key("sk")
+								.contents(largeContents)
+								.expiry(consensusNow.get() + eternalExpiry))
+				).then(
+						fileUpdate("sksc")
+								.fee(feeToOffer)
+								.payingWith("payer")
+								.wacl("lk")
+								.extendingExpiryBy(mediumExpiry - shortExpiry),
+						fileUpdate("skmc")
+								.fee(feeToOffer)
+								.payingWith("payer")
+								.wacl("lk")
+								.extendingExpiryBy(eternalExpiry - mediumExpiry),
+						getFileInfo("sksc"),
+						getFileInfo("skmc"),
+						getFileInfo("sklc")
+				);
+	}
+
+	HapiApiSpec variousCryptoMutations() {
+		KeyShape smallKey = SIMPLE;
+		KeyShape largeKey = listOf(3);
+		long shortExpiry = 100_000L;
+		long mediumExpiry = 10 * shortExpiry;
+		long eternalExpiry = 10 * mediumExpiry;
+		AtomicLong consensusNow = new AtomicLong();
+
+		return customHapiSpec("VariousCryptoMutations")
+				.withProperties(Map.of("cost.snapshot.mode", costSnapshotMode.toString()))
+				.given(
+						newKeyNamed("sk").shape(smallKey),
+						newKeyNamed("lk").shape(largeKey),
+						cryptoCreate("payer")
+								.via("payerCreation")
+								.fee(feeToOffer)
+								.balance(payerBalance),
+						withOpContext((spec, opLog) -> {
+							var lookup = getTxnRecord("payerCreation").nodePayment(paymentToOffer);
+							allRunFor(spec, lookup);
+							var record = lookup.getResponseRecord();
+							consensusNow.set(record.getConsensusTimestamp().getSeconds());
+						}),
+						cryptoCreate("proxy")
+								.fee(feeToOffer)
+				).when(
+						cryptoCreate("sksenp")
+								.fee(feeToOffer)
+								.payingWith("payer")
+								.key("sk")
+								.autoRenewSecs(shortExpiry),
+						cryptoCreate("sksep")
+								.fee(feeToOffer)
+								.payingWith("payer")
+								.proxy("0.0.2")
+								.key("sk")
+								.autoRenewSecs(shortExpiry),
+						cryptoCreate("skmenp")
+								.fee(feeToOffer)
+								.payingWith("payer")
+								.key("sk")
+								.autoRenewSecs(mediumExpiry),
+						cryptoCreate("skmep")
+								.fee(feeToOffer)
+								.payingWith("payer")
+								.proxy("0.0.2")
+								.key("sk")
+								.autoRenewSecs(mediumExpiry),
+						cryptoCreate("skeenp")
+								.fee(feeToOffer)
+								.payingWith("payer")
+								.key("sk")
+								.autoRenewSecs(eternalExpiry),
+						cryptoCreate("skeep")
+								.fee(feeToOffer)
+								.payingWith("payer")
+								.proxy("0.0.2")
+								.key("sk")
+								.autoRenewSecs(eternalExpiry)
+				).then(
+						sourcing(() -> cryptoUpdate("sksenp")
+								.fee(feeToOffer)
+								.payingWith("payer")
+								.newProxy("proxy")
+								.key("lk")
+								.expiring(consensusNow.get() + mediumExpiry)),
+						sourcing(() -> cryptoUpdate("skmenp")
+								.fee(feeToOffer)
+								.payingWith("payer")
+								.newProxy("proxy")
+								.key("lk")
+								.expiring(consensusNow.get() + eternalExpiry)),
+						sourcing(() -> cryptoUpdate("skeenp")
+								.fee(feeToOffer)
+								.payingWith("payer")
+								.newProxy("proxy")
+								.key("lk")),
+						getAccountInfo("sksenp"),
+						getAccountInfo("skmenp"),
+						getAccountInfo("skeenp")
+				);
+	}
+
+	@Override
+	protected Logger getResultsLogger() {
+		return log;
+	}
+}

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/meta/VersionInfoSpec.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/meta/VersionInfoSpec.java
@@ -37,8 +37,8 @@ import java.util.List;
 public class VersionInfoSpec extends HapiApiSuite {
 	private static final Logger log = LogManager.getLogger(VersionInfoSpec.class);
 
-	private static final SemanticVersion EXPECTED_HAPI_PROTO = HapiPropertySource.asSemVer("0.11.0");
-	private static final SemanticVersion EXPECTED_HEDERA_SERVICES = HapiPropertySource.asSemVer("0.11.0");
+	private static final SemanticVersion EXPECTED_HAPI_PROTO = HapiPropertySource.asSemVer("0.12.0");
+	private static final SemanticVersion EXPECTED_HEDERA_SERVICES = HapiPropertySource.asSemVer("0.12.0");
 
 	public static void main(String... args) {
 		new VersionInfoSpec().runSuiteSync();

--- a/test-clients/src/main/resource/spec-default.properties
+++ b/test-clients/src/main/resource/spec-default.properties
@@ -101,7 +101,7 @@ node.details.id=0.0.102
 node.details.name=NODE_DETAILS
 # Valid settings are { fixed, random }
 node.selector=fixed
-nodes=localhost:50213
+nodes=localhost:50211
 # custom testnet
 #nodes=3.13.199.218
 # custom mainnet


### PR DESCRIPTION
**Related issue(s)**:
Closes #1075

**Summary of the change**:
- Set the `decimals` field in `TokenBalance` and `TokenRelationship` messages returned from queries.
-  **NOTE:** this PR also includes some unrelated EET changes helpful for recording cost snapshots in crypto/file mutations. 

**External impacts**:
Nothing breaking; this information will simply be available in queries now.

**Applicable documentation**
- [x] HAPI protobuf comments
