### PR TITLE
Add perf suite for testing entity memos

### DIFF
--- a/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/token/HapiGetTokenInfo.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/token/HapiGetTokenInfo.java
@@ -103,8 +103,8 @@ public class HapiGetTokenInfo extends HapiQueryOp<HapiGetTokenInfo> {
 		expectedId = Optional.of(token);
 		return this;
 	}
-	public HapiGetTokenInfo hasRegisteredMemo() {
-		expectedMemo = Optional.of(token);
+	public HapiGetTokenInfo hasRegisteredMemo(String memo) {
+		expectedMemo = Optional.of(memo);
 		return this;
 	}
 	public HapiGetTokenInfo hasAutoRenewPeriod(Long renewPeriod) {
@@ -215,6 +215,11 @@ public class HapiGetTokenInfo extends HapiQueryOp<HapiGetTokenInfo> {
 					actualInfo.getTreasury());
 		}
 
+		expectedMemo.ifPresent(s -> Assert.assertEquals(
+				"Wrong memo!",
+				s,
+				actualInfo.getMemo()));
+
 		var registry = spec.registry();
 		assertFor(
 				actualInfo.getTokenId(),
@@ -222,12 +227,12 @@ public class HapiGetTokenInfo extends HapiQueryOp<HapiGetTokenInfo> {
 				(n, r) -> r.getTokenID(n),
 				"Wrong token id!",
 				registry);
-		assertFor(
-				actualInfo.getMemo(),
-				expectedMemo,
-				(n, r) -> r.getMemo(n),
-				"Wrong memo!",
-				registry);
+//		assertFor(
+//				actualInfo.getMemo(),
+//				expectedMemo,
+//				(n, r) -> r.getMemo(n),
+//				"Wrong memo!",
+//				registry);
 		assertFor(
 				actualInfo.getExpiry(),
 				expectedExpiry,

--- a/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/token/HapiGetTokenInfo.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/token/HapiGetTokenInfo.java
@@ -227,12 +227,6 @@ public class HapiGetTokenInfo extends HapiQueryOp<HapiGetTokenInfo> {
 				(n, r) -> r.getTokenID(n),
 				"Wrong token id!",
 				registry);
-//		assertFor(
-//				actualInfo.getMemo(),
-//				expectedMemo,
-//				(n, r) -> r.getMemo(n),
-//				"Wrong memo!",
-//				registry);
 		assertFor(
 				actualInfo.getExpiry(),
 				expectedExpiry,

--- a/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/crypto/HapiCryptoCreate.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/crypto/HapiCryptoCreate.java
@@ -169,6 +169,7 @@ public class HapiCryptoCreate extends HapiTxnOp<HapiCryptoCreate> {
 						CryptoCreateTransactionBody.class, b -> {
 							b.setKey(key);
 							proxy.ifPresent(p -> b.setProxyAccountID(p));
+							entityMemo.ifPresent(m -> b.setMemo(m));
 							sendThresh.ifPresent(a -> b.setSendRecordThreshold(a));
 							receiveThresh.ifPresent(a -> b.setReceiveRecordThreshold(a));
 							initialBalance.ifPresent(a -> b.setInitialBalance(a));

--- a/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/token/HapiTokenCreate.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/token/HapiTokenCreate.java
@@ -202,7 +202,7 @@ public class HapiTokenCreate extends HapiTxnOp<HapiTokenCreate> {
 						TokenCreateTransactionBody.class, b -> {
 							symbol.ifPresent(b::setSymbol);
 							name.ifPresent(b::setName);
-							memo.ifPresent(b::setMemo);
+							entityMemo.ifPresent(s -> b.setMemo(s));
 							initialSupply.ifPresent(b::setInitialSupply);
 							decimals.ifPresent(b::setDecimals);
 							freezeDefault.ifPresent(b::setFreezeDefault);

--- a/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/LoadTest.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/LoadTest.java
@@ -35,6 +35,7 @@ import java.util.OptionalLong;
 import java.util.function.Supplier;
 
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.runLoadTest;
+import static com.hedera.services.bdd.suites.perf.PerfTestLoadSettings.DEFAULT_MEMO_LENGTH;
 import static java.util.concurrent.TimeUnit.MINUTES;
 
 public class LoadTest extends HapiApiSuite {
@@ -52,7 +53,7 @@ public class LoadTest extends HapiApiSuite {
 	public static OptionalInt totalTestTokens = OptionalInt.empty();
 	public static OptionalInt testTreasureStartAccount = OptionalInt.empty();
 	public static OptionalInt totalTestTokenAccounts = OptionalInt.empty();
-	public static OptionalInt memoLength = OptionalInt.of(25);
+	public static OptionalInt memoLength = OptionalInt.of(DEFAULT_MEMO_LENGTH);
 
 	public static int parseArgs(String... args) {
 		int usedArgs = 0;
@@ -99,6 +100,10 @@ public class LoadTest extends HapiApiSuite {
 		return targetTPS.getAsDouble();
 	}
 
+	public static int getMemoLength() {
+		return memoLength.getAsInt();
+	}
+
 	public static int getTestDurationMinutes() {
 		return testDurationMinutes.getAsInt();
 	}
@@ -108,6 +113,7 @@ public class LoadTest extends HapiApiSuite {
 				.tps(targetTPS.isPresent() ? LoadTest::getTargetTPS : settings::getTps)
 				.tolerance(settings::getTolerancePercentage)
 				.allowedSecsBelow(settings::getAllowedSecsBelow)
+				.setMemoLength(memoLength.isPresent() ? LoadTest::getMemoLength : settings::getMemoLength)
 				.setNumberOfThreads(threadNumber.isPresent()
 						? threadNumber::getAsInt : settings::getThreads)
 				.setTotalTestAccounts(totalTestAccounts.isPresent()

--- a/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/LoadTest.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/LoadTest.java
@@ -109,11 +109,12 @@ public class LoadTest extends HapiApiSuite {
 	}
 
 	public static RunLoadTest defaultLoadTest(Supplier<HapiSpecOperation[]> opSource, PerfTestLoadSettings settings) {
+		log.info("memo length : " + settings.getMemoLength());
 		return runLoadTest(opSource)
 				.tps(targetTPS.isPresent() ? LoadTest::getTargetTPS : settings::getTps)
 				.tolerance(settings::getTolerancePercentage)
 				.allowedSecsBelow(settings::getAllowedSecsBelow)
-				.setMemoLength(memoLength.isPresent() ? LoadTest::getMemoLength : settings::getMemoLength)
+				.setMemoLength(settings::getMemoLength)
 				.setNumberOfThreads(threadNumber.isPresent()
 						? threadNumber::getAsInt : settings::getThreads)
 				.setTotalTestAccounts(totalTestAccounts.isPresent()

--- a/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/LoadTest.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/LoadTest.java
@@ -109,7 +109,6 @@ public class LoadTest extends HapiApiSuite {
 	}
 
 	public static RunLoadTest defaultLoadTest(Supplier<HapiSpecOperation[]> opSource, PerfTestLoadSettings settings) {
-		log.info("memo length : " + settings.getMemoLength());
 		return runLoadTest(opSource)
 				.tps(targetTPS.isPresent() ? LoadTest::getTargetTPS : settings::getTps)
 				.tolerance(settings::getTolerancePercentage)

--- a/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/RunLoadTest.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/RunLoadTest.java
@@ -54,8 +54,10 @@ public class RunLoadTest extends UtilOp {
 	public static final int DEFAULT_TOTAL_TEST_TOKENS = 1;
 	public static final int DEFAULT_START_TEST_TREASURE_ACCT = 1001;
 	public static final int DEFAULT_TOTAL_TEST_TOKEN_ACCOUNTS = 2;
+	public static final int DEFAULT_MEMO_LENGTH = 25;
 
 	private DoubleSupplier targetTps = () -> DEFAULT_TPS_TARGET;
+	private IntSupplier memoLength = () -> DEFAULT_MEMO_LENGTH;
 	private IntSupplier tpsTolerancePercentage = () -> DEFAULT_TPS_TOLERANCE_PERCENTAGE;
 	private IntSupplier secsAllowedBelowTolerance = () -> DEFAULT_SECS_ALLOWED_BELOW_TOLERANCE;
 	private LongSupplier testDuration = () -> DEFAULT_DURATION;
@@ -75,6 +77,11 @@ public class RunLoadTest extends UtilOp {
 
 	public RunLoadTest tps(DoubleSupplier targetTps) {
 		this.targetTps = targetTps;
+		return this;
+	}
+
+	public RunLoadTest setMemoLength(IntSupplier memoLength) {
+		this.memoLength = memoLength;
 		return this;
 	}
 

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/SuiteRunner.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/SuiteRunner.java
@@ -83,6 +83,7 @@ import com.hedera.services.bdd.suites.perf.CryptoCreatePerfSuite;
 import com.hedera.services.bdd.suites.perf.CryptoTransferLoadTest;
 import com.hedera.services.bdd.suites.perf.FileUpdateLoadTest;
 import com.hedera.services.bdd.suites.perf.HCSChunkingRealisticPerfSuite;
+import com.hedera.services.bdd.suites.perf.MixedOpsMemoPerfSuite;
 import com.hedera.services.bdd.suites.perf.MixedTransferAndSubmitLoadTest;
 import com.hedera.services.bdd.suites.perf.MixedTransferCallAndSubmitLoadTest;
 import com.hedera.services.bdd.suites.perf.SubmitMessageLoadTest;
@@ -239,6 +240,7 @@ public class SuiteRunner {
 		put("HCSChunkingRealisticPerfSuite", aof(new HCSChunkingRealisticPerfSuite()));
 		put("CryptoCreatePerfSuite", aof(new CryptoCreatePerfSuite()));
 		put("CreateTopicPerfSuite", aof(new CreateTopicPerfSuite()));
+		put("MixedOpsMemoPerfSuite", aof(new MixedOpsMemoPerfSuite()));
 		/* Functional tests - RECONNECT */
 		put("CreateAccountsBeforeReconnect", aof(new CreateAccountsBeforeReconnect()));
 		put("CreateTopicsBeforeReconnect", aof(new CreateTopicsBeforeReconnect()));

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/SuiteRunner.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/SuiteRunner.java
@@ -81,6 +81,7 @@ import com.hedera.services.bdd.suites.perf.ContractCallLoadTest;
 import com.hedera.services.bdd.suites.perf.CreateTopicPerfSuite;
 import com.hedera.services.bdd.suites.perf.CryptoCreatePerfSuite;
 import com.hedera.services.bdd.suites.perf.CryptoTransferLoadTest;
+import com.hedera.services.bdd.suites.perf.FileContractMemoPerfSuite;
 import com.hedera.services.bdd.suites.perf.FileUpdateLoadTest;
 import com.hedera.services.bdd.suites.perf.HCSChunkingRealisticPerfSuite;
 import com.hedera.services.bdd.suites.perf.MixedOpsMemoPerfSuite;
@@ -241,6 +242,7 @@ public class SuiteRunner {
 		put("CryptoCreatePerfSuite", aof(new CryptoCreatePerfSuite()));
 		put("CreateTopicPerfSuite", aof(new CreateTopicPerfSuite()));
 		put("MixedOpsMemoPerfSuite", aof(new MixedOpsMemoPerfSuite()));
+		put("FileContractMemoPerfSuite", aof(new FileContractMemoPerfSuite()));
 		/* Functional tests - RECONNECT */
 		put("CreateAccountsBeforeReconnect", aof(new CreateAccountsBeforeReconnect()));
 		put("CreateTopicsBeforeReconnect", aof(new CreateTopicsBeforeReconnect()));

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/CryptoCreatePerfSuite.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/CryptoCreatePerfSuite.java
@@ -37,7 +37,6 @@ public class CryptoCreatePerfSuite extends LoadTest {
 	private static final Logger log = LogManager.getLogger(CryptoCreatePerfSuite.class);
 
 	public static void main(String... args) {
-		parseArgs(args);
 		CryptoCreatePerfSuite suite = new CryptoCreatePerfSuite();
 		suite.setReportStats(true);
 		suite.runSuiteSync();
@@ -55,7 +54,6 @@ public class CryptoCreatePerfSuite extends LoadTest {
 
 	private HapiApiSpec runCryptoCreates() {
 		final int NUM_CREATES = 1000000;
-		final String cryptoCreateMemo = TxnUtils.randomUtf8Bytes(memoLength.getAsInt()).toString();
 		return defaultHapiSpec("cryptoCreatePerf")
 				.given(
 				).when(
@@ -73,7 +71,6 @@ public class CryptoCreatePerfSuite extends LoadTest {
 														.withRecharging()
 														.rechargeWindow(30)
 														.payingWith(GENESIS)
-														.entityMemo(cryptoCreateMemo)
 														.deferStatusResolution()
 								)
 						)

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/FileContractMemoPerfSuite.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/FileContractMemoPerfSuite.java
@@ -1,0 +1,115 @@
+package com.hedera.services.bdd.suites.perf;
+
+import com.hedera.services.bdd.spec.HapiApiSpec;
+import com.hedera.services.bdd.spec.HapiSpecOperation;
+import com.hedera.services.bdd.spec.queries.QueryVerbs;
+import com.hedera.services.bdd.spec.transactions.TxnUtils;
+import com.hedera.services.bdd.spec.utilops.LoadTest;
+
+
+import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
+
+import static com.hedera.services.bdd.spec.HapiApiSpec.defaultHapiSpec;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.contractCreate;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.contractUpdate;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.fileCreate;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.fileUpdate;
+import static com.hedera.services.bdd.spec.queries.QueryVerbs.getFileInfo;
+import static com.hedera.services.bdd.spec.queries.QueryVerbs.getContractInfo;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.logIt;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.withOpContext;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.BUSY;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.DUPLICATE_TRANSACTION;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OK;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.PLATFORM_TRANSACTION_NOT_CREATED;
+
+public class FileContractMemoPerfSuite  extends LoadTest {
+	private static final Logger log = LogManager.getLogger(FileContractMemoPerfSuite.class);
+
+	private final ResponseCodeEnum[] permissiblePrechecks = new ResponseCodeEnum[] {
+			OK, BUSY, DUPLICATE_TRANSACTION, PLATFORM_TRANSACTION_NOT_CREATED
+	};
+
+	private final String INITIAL_MEMO = "InitialMemo";
+	private final String FILE_MEMO = INITIAL_MEMO + " for File Entity";
+	private final String CONTRACT_MEMO = INITIAL_MEMO + " for Contract Entity";
+	private final String TARGET_FILE = "fileForMemo";
+	private final String CONTRACT_FILE = "contractForMemo";
+
+	public static void main(String... args) {
+		parseArgs(args);
+
+		FileContractMemoPerfSuite suite = new FileContractMemoPerfSuite();
+		suite.setReportStats(true);
+		suite.runSuiteSync();
+	}
+
+	@Override
+	protected List<HapiApiSpec> getSpecsInSuite() {
+		return	List.of(
+				RunMixedFileContractMemoOps()
+		);
+	}
+
+	@Override
+	public boolean hasInterestingStats() {
+		return true;
+	}
+
+	// perform cryptoCreate, cryptoUpdate, TokenCreate, TokenUpdate, FileCreate, FileUpdate txs with entity memo set.
+	protected HapiApiSpec RunMixedFileContractMemoOps() {
+		PerfTestLoadSettings settings = new PerfTestLoadSettings();
+		final AtomicInteger createdSoFar = new AtomicInteger(0);
+		Supplier<HapiSpecOperation[]> mixedOpsBurst = () -> new HapiSpecOperation[] {
+				fileCreate("testFile" + createdSoFar.getAndIncrement())
+						.payingWith(GENESIS)
+						.entityMemo(
+								new String(TxnUtils.randomUtf8Bytes(memoLength.getAsInt()), StandardCharsets.UTF_8)
+						)
+						.noLogging()
+						.hasPrecheckFrom(
+								OK, BUSY, DUPLICATE_TRANSACTION, PLATFORM_TRANSACTION_NOT_CREATED)
+						.deferStatusResolution(),
+				getFileInfo(TARGET_FILE+"Info")
+					.hasMemo(FILE_MEMO),
+				fileUpdate(TARGET_FILE)
+						.payingWith(GENESIS)
+						.entityMemo(
+								new String(TxnUtils.randomUtf8Bytes(memoLength.getAsInt()), StandardCharsets.UTF_8)
+						)
+						.noLogging()
+						.hasPrecheckFrom(
+								OK, BUSY, DUPLICATE_TRANSACTION, PLATFORM_TRANSACTION_NOT_CREATED)
+						.deferStatusResolution(),
+//				contractCreate(),
+//				getContractInfo(),
+//				contractUpdate()
+
+		};
+		return defaultHapiSpec("RunMixedFileContractMemoOps")
+				.given(
+						withOpContext((spec, ignore) -> settings.setFrom(spec.setup().ciPropertiesMap())),
+						logIt(ignore -> settings.toString())
+				)
+				.when(
+						fileCreate(TARGET_FILE)
+							.entityMemo(FILE_MEMO)
+							.logged()
+				)
+				.then(
+						defaultLoadTest(mixedOpsBurst, settings)
+				);
+	}
+
+	@Override
+	protected Logger getResultsLogger() {
+		return log;
+	}
+}

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/FileUpdateLoadTest.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/FileUpdateLoadTest.java
@@ -67,7 +67,6 @@ public class FileUpdateLoadTest extends HapiApiSuite {
 
 	private HapiApiSpec runFileUpdates() {
 		PerfTestLoadSettings settings = new PerfTestLoadSettings();
-		String fileUpdateMemo = TxnUtils.randomUtf8Bytes(settings.getMemoLength()).toString();
 		final AtomicInteger submittedSoFar = new AtomicInteger(0);
 		final byte[] NEW_CONTENTS = TxnUtils.randomUtf8Bytes(TxnUtils.BYTES_4K);
 
@@ -78,7 +77,6 @@ public class FileUpdateLoadTest extends HapiApiSuite {
 										.fee(Integer.MAX_VALUE)
 										.contents(NEW_CONTENTS)
 										.noLogging()
-										.entityMemo(fileUpdateMemo)
 										.hasPrecheckFrom(
 												OK,
 												BUSY,

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/MixedOpsMemoPerfSuite.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/MixedOpsMemoPerfSuite.java
@@ -1,5 +1,24 @@
 package com.hedera.services.bdd.suites.perf;
 
+/*-
+ * ‌
+ * Hedera Services Test Clients
+ * ​
+ * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
 
 import com.hedera.services.bdd.spec.HapiApiSpec;
 import com.hedera.services.bdd.spec.HapiSpecOperation;

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/MixedOpsMemoPerfSuite.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/MixedOpsMemoPerfSuite.java
@@ -22,7 +22,6 @@ package com.hedera.services.bdd.suites.perf;
 
 import com.hedera.services.bdd.spec.HapiApiSpec;
 import com.hedera.services.bdd.spec.HapiSpecOperation;
-import com.hedera.services.bdd.spec.queries.QueryVerbs;
 import com.hedera.services.bdd.spec.transactions.TxnUtils;
 import com.hedera.services.bdd.spec.utilops.LoadTest;
 
@@ -31,7 +30,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
-import java.util.stream.IntStream;
 
 import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
 import org.apache.logging.log4j.LogManager;
@@ -44,27 +42,22 @@ import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoCreate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoUpdate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.tokenCreate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.tokenUpdate;
-import static com.hedera.services.bdd.spec.transactions.TxnVerbs.fileCreate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.fileUpdate;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getAccountInfo;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getTokenInfo;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getTopicInfo;
 
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.updateTopic;
-import static com.hedera.services.bdd.spec.utilops.UtilVerbs.inParallel;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.logIt;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.newKeyNamed;
-import static com.hedera.services.bdd.spec.utilops.UtilVerbs.runLoadTest;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.sleepFor;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.withOpContext;
 import static com.hedera.services.bdd.suites.perf.PerfUtilOps.tokenOpsEnablement;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.BUSY;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.DUPLICATE_TRANSACTION;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_TOPIC_ID;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OK;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.PLATFORM_TRANSACTION_NOT_CREATED;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TOPIC_EXPIRED;
-import static java.util.concurrent.TimeUnit.MINUTES;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.UNKNOWN;
 
 public class MixedOpsMemoPerfSuite extends LoadTest {
 	private static final Logger log = LogManager.getLogger(MixedOpsMemoPerfSuite.class);
@@ -74,11 +67,10 @@ public class MixedOpsMemoPerfSuite extends LoadTest {
 	private final String TOKEN_MEMO = INITIAL_MEMO + " for Token Entity";
 	private final String TARGET_ACCOUNT = "accountForMemo";
 	private final String TARGET_TOKEN = "tokenForMemo";
-	private final String TARGET_FILE = "fileForMemo";
 	private final String TARGET_TOPIC = "topicForMemo";
 
 	private final ResponseCodeEnum[] permissiblePrechecks = new ResponseCodeEnum[] {
-			OK, BUSY, DUPLICATE_TRANSACTION, PLATFORM_TRANSACTION_NOT_CREATED
+			OK, BUSY, DUPLICATE_TRANSACTION, PLATFORM_TRANSACTION_NOT_CREATED, UNKNOWN
 	};
 
 	public static void main(String... args) {
@@ -132,28 +124,28 @@ public class MixedOpsMemoPerfSuite extends LoadTest {
 						.noLogging()
 						.hasPrecheckFrom(permissiblePrechecks)
 						.deferStatusResolution(),
-//				tokenCreate("testToken" + createdSoFar.getAndIncrement())
-//						.payingWith(GENESIS)
-//						.entityMemo(
-//								new String(TxnUtils.randomUtf8Bytes(memoLength.getAsInt()), StandardCharsets.UTF_8)
-//						)
-//						.noLogging()
-//						.hasPrecheckFrom(permissiblePrechecks)
-//						.deferStatusResolution(),
-//				getTokenInfo(TARGET_TOKEN+"Info")
-//						.payingWith(GENESIS)
-//						.hasRegisteredMemo(TOKEN_MEMO)
-//						.hasAnswerOnlyPrecheckFrom(permissiblePrechecks)
-//						.hasCostAnswerPrecheckFrom(permissiblePrechecks)
-//						.noLogging(),
-//				tokenUpdate(TARGET_TOKEN)
-//						.payingWith(GENESIS)
-//						.entityMemo(
-//								new String(TxnUtils.randomUtf8Bytes(memoLength.getAsInt()), StandardCharsets.UTF_8)
-//						)
-//						.noLogging()
-//						.hasPrecheckFrom(permissiblePrechecks)
-//						.deferStatusResolution(),
+				tokenCreate("testToken" + createdSoFar.getAndIncrement())
+						.payingWith(GENESIS)
+						.entityMemo(
+								new String(TxnUtils.randomUtf8Bytes(memoLength.getAsInt()), StandardCharsets.UTF_8)
+						)
+						.noLogging()
+						.hasPrecheckFrom(permissiblePrechecks)
+						.deferStatusResolution(),
+				getTokenInfo(TARGET_TOKEN+"Info")
+						.payingWith(GENESIS)
+						.hasRegisteredMemo(TOKEN_MEMO)
+						.hasAnswerOnlyPrecheckFrom(permissiblePrechecks)
+						.hasCostAnswerPrecheckFrom(permissiblePrechecks)
+						.noLogging(),
+				tokenUpdate(TARGET_TOKEN)
+						.payingWith(GENESIS)
+						.entityMemo(
+								new String(TxnUtils.randomUtf8Bytes(memoLength.getAsInt()), StandardCharsets.UTF_8)
+						)
+						.noLogging()
+						.hasPrecheckFrom(permissiblePrechecks)
+						.deferStatusResolution(),
 				createTopic("testTopic" + createdSoFar.getAndIncrement())
 						.topicMemo(
 								new String(TxnUtils.randomUtf8Bytes(memoLength.getAsInt()), StandardCharsets.UTF_8)

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/MixedOpsMemoPerfSuite.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/MixedOpsMemoPerfSuite.java
@@ -1,0 +1,166 @@
+package com.hedera.services.bdd.suites.perf;
+
+
+import com.hedera.services.bdd.spec.HapiApiSpec;
+import com.hedera.services.bdd.spec.HapiSpecOperation;
+import com.hedera.services.bdd.spec.transactions.TxnUtils;
+import com.hedera.services.bdd.spec.utilops.LoadTest;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
+import java.util.stream.IntStream;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import static com.hedera.services.bdd.spec.HapiApiSpec.defaultHapiSpec;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoCreate;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoUpdate;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.tokenCreate;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.tokenUpdate;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.fileCreate;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.fileUpdate;
+
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.inParallel;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.logIt;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.runLoadTest;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.withOpContext;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.BUSY;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.DUPLICATE_TRANSACTION;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OK;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.PLATFORM_TRANSACTION_NOT_CREATED;
+import static java.util.concurrent.TimeUnit.MINUTES;
+
+public class MixedOpsMemoPerfSuite extends LoadTest {
+	private static final Logger log = LogManager.getLogger(MixedOpsMemoPerfSuite.class);
+	private final String TARGET_ACCOUNT = "accountForMemo";
+	private final String TARGET_TOKEN = "tokenForMemo";
+	private final String TARGET_FILE = "fileForMemo";
+
+	public static void main(String... args) {
+		parseArgs(args);
+
+		MixedOpsMemoPerfSuite suite = new MixedOpsMemoPerfSuite();
+		suite.setReportStats(true);
+		suite.runSuiteSync();
+	}
+
+	@Override
+	protected List<HapiApiSpec> getSpecsInSuite() {
+		return	List.of(
+				runMixedMemoOps()
+		);
+	}
+
+	@Override
+	public boolean hasInterestingStats() {
+		return true;
+	}
+
+	// perform cryptoCreate, cryptoUpdate, TokenCreate, TokenUpdate, FileCreate, FileUpdate txs with entity memo set.
+	protected HapiApiSpec runMixedMemoOps() {
+		PerfTestLoadSettings settings = new PerfTestLoadSettings();
+		final AtomicInteger createdSoFar = new AtomicInteger(0);
+		Supplier<HapiSpecOperation[]> transferBurst = () -> new HapiSpecOperation[] {
+				inParallel(flattened(
+						IntStream.range(0, settings.getBurstSize() * 3 / 16)
+								.mapToObj(ignore ->
+										cryptoCreate("testAccount" + createdSoFar)
+												.balance(100_000L)
+												.entityMemo(
+														TxnUtils.randomUtf8Bytes(memoLength.getAsInt()).toString()
+												)
+												.logged()
+												.payingWith(GENESIS)
+												.deferStatusResolution())
+								.toArray(n -> new HapiSpecOperation[n]),
+						IntStream.range(0, settings.getBurstSize() * 3 / 16)
+								.mapToObj(ignore ->
+										cryptoUpdate(TARGET_ACCOUNT)
+												.entityMemo(
+														TxnUtils.randomUtf8Bytes(memoLength.getAsInt()).toString()
+												)
+												.payingWith(GENESIS)
+												.logged()
+												.hasPrecheckFrom(
+														OK, BUSY, DUPLICATE_TRANSACTION, PLATFORM_TRANSACTION_NOT_CREATED)
+												.deferStatusResolution())
+								.toArray(n -> new HapiSpecOperation[n]),
+						IntStream.range(0, settings.getBurstSize() * 3 / 16)
+								.mapToObj(ignore ->
+										tokenCreate("testToken" + createdSoFar)
+												.entityMemo(
+														TxnUtils.randomUtf8Bytes(memoLength.getAsInt()).toString()
+												)
+												.payingWith(GENESIS)
+												.logged()
+												.initialSupply(100_000_000_000L)
+												.hasPrecheckFrom(
+														OK, BUSY, DUPLICATE_TRANSACTION, PLATFORM_TRANSACTION_NOT_CREATED)
+												.deferStatusResolution())
+								.toArray(n -> new HapiSpecOperation[n]),
+						IntStream.range(0, settings.getBurstSize() / 2)
+								.mapToObj(ignore ->
+										tokenUpdate(TARGET_TOKEN)
+												.entityMemo(
+														TxnUtils.randomUtf8Bytes(memoLength.getAsInt()).toString()
+												)
+												.payingWith(GENESIS)
+												.logged()
+												.hasPrecheckFrom(
+														OK, BUSY, DUPLICATE_TRANSACTION, PLATFORM_TRANSACTION_NOT_CREATED)
+												.deferStatusResolution())
+								.toArray(n -> new HapiSpecOperation[n]),
+						IntStream.range(0, settings.getBurstSize() / 8)
+								.mapToObj(ignore ->
+										fileCreate("testFile" + createdSoFar)
+												.entityMemo(
+														TxnUtils.randomUtf8Bytes(memoLength.getAsInt()).toString()
+												)
+												.payingWith(GENESIS)
+												.logged()
+												.hasPrecheckFrom(
+														OK, BUSY, DUPLICATE_TRANSACTION, PLATFORM_TRANSACTION_NOT_CREATED)
+												.deferStatusResolution())
+								.toArray(n -> new HapiSpecOperation[n]),
+						IntStream.range(0, settings.getBurstSize() / 8)
+								.mapToObj(ignore ->
+										fileUpdate(TARGET_FILE)
+												.entityMemo(
+														TxnUtils.randomUtf8Bytes(memoLength.getAsInt()).toString()
+												)
+												.payingWith(GENESIS)
+												.logged()
+												.hasPrecheckFrom(
+														OK, BUSY, DUPLICATE_TRANSACTION, PLATFORM_TRANSACTION_NOT_CREATED)
+												.deferStatusResolution())
+								.toArray(n -> new HapiSpecOperation[n])
+				))
+		};
+		return defaultHapiSpec("RunMixedMemoOps")
+				.given(
+						withOpContext((spec, ignore) -> settings.setFrom(spec.setup().ciPropertiesMap())),
+						logIt(ignore -> settings.toString())
+				)
+				.when(
+						cryptoCreate(TARGET_ACCOUNT)
+								.entityMemo("InitialMemo")
+								.logged(),
+						tokenCreate(TARGET_TOKEN)
+								.entityMemo("InitialMemo")
+								.logged(),
+						fileCreate(TARGET_FILE)
+								.entityMemo("InitialMemo")
+								.logged()
+				)
+				.then(
+						defaultLoadTest(transferBurst, settings)
+				);
+	}
+
+	@Override
+	protected Logger getResultsLogger() {
+		return log;
+	}
+}

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/MixedOpsMemoPerfSuite.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/MixedOpsMemoPerfSuite.java
@@ -154,30 +154,30 @@ public class MixedOpsMemoPerfSuite extends LoadTest {
 //						.noLogging()
 //						.hasPrecheckFrom(permissiblePrechecks)
 //						.deferStatusResolution(),
-//				createTopic("testTopic" + createdSoFar.getAndIncrement())
-//						.topicMemo(
-//								new String(TxnUtils.randomUtf8Bytes(memoLength.getAsInt()), StandardCharsets.UTF_8)
-//						)
-//						.payingWith(GENESIS)
-//						.adminKeyName("adminKey")
-//						.noLogging()
-//						.hasPrecheckFrom(permissiblePrechecks)
-//						.deferStatusResolution(),
-//				getTopicInfo(TARGET_TOPIC+"Info")
-//						.payingWith(GENESIS)
-//						.hasMemo(TOPIC_MEMO)
-//						.hasAnswerOnlyPrecheckFrom(permissiblePrechecks)
-//						.hasCostAnswerPrecheckFrom(permissiblePrechecks)
-//						.noLogging(),
-//				updateTopic(TARGET_TOPIC)
-//						.topicMemo(
-//								new String(TxnUtils.randomUtf8Bytes(memoLength.getAsInt()), StandardCharsets.UTF_8)
-//						)
-//						.payingWith(GENESIS)
-//						.adminKey("adminKey")
-//						.noLogging()
-//						.hasPrecheckFrom(permissiblePrechecks)
-//						.deferStatusResolution()
+				createTopic("testTopic" + createdSoFar.getAndIncrement())
+						.topicMemo(
+								new String(TxnUtils.randomUtf8Bytes(memoLength.getAsInt()), StandardCharsets.UTF_8)
+						)
+						.payingWith(GENESIS)
+						.adminKeyName("adminKey")
+						.noLogging()
+						.hasPrecheckFrom(permissiblePrechecks)
+						.deferStatusResolution(),
+				getTopicInfo(TARGET_TOPIC+"Info")
+						.payingWith(GENESIS)
+						.hasMemo(TOPIC_MEMO)
+						.hasAnswerOnlyPrecheckFrom(permissiblePrechecks)
+						.hasCostAnswerPrecheckFrom(permissiblePrechecks)
+						.noLogging(),
+				updateTopic(TARGET_TOPIC)
+						.topicMemo(
+								new String(TxnUtils.randomUtf8Bytes(memoLength.getAsInt()), StandardCharsets.UTF_8)
+						)
+						.payingWith(GENESIS)
+						.adminKey("adminKey")
+						.noLogging()
+						.hasPrecheckFrom(permissiblePrechecks)
+						.deferStatusResolution()
 		};
 		return defaultHapiSpec("RunMixedMemoOps")
 				.given(
@@ -207,28 +207,25 @@ public class MixedOpsMemoPerfSuite extends LoadTest {
 								.fee(100_000_000L)
 								.payingWith(GENESIS)
 								.entityMemo(ACCOUNT_MEMO)
+								.logged(),
+						createTopic(TARGET_TOPIC)
+								.topicMemo(TOPIC_MEMO)
+								.adminKeyName("adminKey")
+								.payingWith(GENESIS)
+								.logged(),
+						createTopic(TARGET_TOPIC+"Info")
+								.payingWith(GENESIS)
+								.adminKeyName("adminKey")
+								.topicMemo(TOPIC_MEMO)
+								.logged(),
+						tokenCreate(TARGET_TOKEN)
+								.entityMemo(TOKEN_MEMO)
+								.payingWith(GENESIS)
+								.logged(),
+						tokenCreate(TARGET_TOKEN+"Info")
+								.entityMemo(TOKEN_MEMO)
+								.payingWith(GENESIS)
 								.logged()
-//						createTopic(TARGET_TOPIC)
-//								.topicMemo(TOPIC_MEMO)
-//								.adminKeyName("adminKey")
-//								.payingWith(GENESIS)
-//								.logged(),
-//						createTopic(TARGET_TOPIC+"Info")
-//								.payingWith(GENESIS)
-//								.adminKeyName("adminKey")
-//								.topicMemo(TOPIC_MEMO)
-//								.logged()
-//						tokenCreate(TARGET_TOKEN)
-//								.entityMemo(TOKEN_MEMO)
-//								.payingWith(GENESIS)
-//								.logged(),
-//						tokenCreate(TARGET_TOKEN+"Info")
-//								.entityMemo(TOKEN_MEMO)
-//								.payingWith(GENESIS)
-//								.logged()
-//						fileCreate(TARGET_FILE)
-//								.entityMemo(FILE_MEMO)
-//								.logged()
 				)
 				.then(
 						defaultLoadTest(mixedOpsBurst, settings)

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/MixedOpsMemoPerfSuite.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/MixedOpsMemoPerfSuite.java
@@ -22,41 +22,64 @@ package com.hedera.services.bdd.suites.perf;
 
 import com.hedera.services.bdd.spec.HapiApiSpec;
 import com.hedera.services.bdd.spec.HapiSpecOperation;
+import com.hedera.services.bdd.spec.queries.QueryVerbs;
 import com.hedera.services.bdd.spec.transactions.TxnUtils;
 import com.hedera.services.bdd.spec.utilops.LoadTest;
 
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
 import java.util.stream.IntStream;
 
+import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import static com.hedera.services.bdd.spec.HapiApiSpec.defaultHapiSpec;
+import static com.hedera.services.bdd.spec.assertions.AccountInfoAsserts.accountWith;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.createTopic;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoCreate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoUpdate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.tokenCreate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.tokenUpdate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.fileCreate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.fileUpdate;
+import static com.hedera.services.bdd.spec.queries.QueryVerbs.getAccountInfo;
+import static com.hedera.services.bdd.spec.queries.QueryVerbs.getTokenInfo;
+import static com.hedera.services.bdd.spec.queries.QueryVerbs.getTopicInfo;
 
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.updateTopic;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.inParallel;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.logIt;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.newKeyNamed;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.runLoadTest;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.sleepFor;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.withOpContext;
+import static com.hedera.services.bdd.suites.perf.PerfUtilOps.tokenOpsEnablement;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.BUSY;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.DUPLICATE_TRANSACTION;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_TOPIC_ID;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OK;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.PLATFORM_TRANSACTION_NOT_CREATED;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TOPIC_EXPIRED;
 import static java.util.concurrent.TimeUnit.MINUTES;
 
 public class MixedOpsMemoPerfSuite extends LoadTest {
 	private static final Logger log = LogManager.getLogger(MixedOpsMemoPerfSuite.class);
+	private final String INITIAL_MEMO = "InitialMemo";
+	private final String ACCOUNT_MEMO = INITIAL_MEMO + " for Account Entity";
+	private final String TOPIC_MEMO = INITIAL_MEMO + " for Topic Entity";
+	private final String TOKEN_MEMO = INITIAL_MEMO + " for Token Entity";
 	private final String TARGET_ACCOUNT = "accountForMemo";
 	private final String TARGET_TOKEN = "tokenForMemo";
 	private final String TARGET_FILE = "fileForMemo";
+	private final String TARGET_TOPIC = "topicForMemo";
+
+	private final ResponseCodeEnum[] permissiblePrechecks = new ResponseCodeEnum[] {
+			OK, BUSY, DUPLICATE_TRANSACTION, PLATFORM_TRANSACTION_NOT_CREATED
+	};
 
 	public static void main(String... args) {
 		parseArgs(args);
@@ -82,83 +105,133 @@ public class MixedOpsMemoPerfSuite extends LoadTest {
 	protected HapiApiSpec runMixedMemoOps() {
 		PerfTestLoadSettings settings = new PerfTestLoadSettings();
 		final AtomicInteger createdSoFar = new AtomicInteger(0);
-		Supplier<HapiSpecOperation[]> transferBurst = () -> new HapiSpecOperation[] {
-				cryptoCreate("testAccount" + createdSoFar)
-						.balance(100_000L)
-						.entityMemo(
-								TxnUtils.randomUtf8Bytes(memoLength.getAsInt()).toString()
-						)
-						.logged()
+		Supplier<HapiSpecOperation[]> mixedOpsBurst = () -> new HapiSpecOperation[] {
+				cryptoCreate("testAccount" + createdSoFar.getAndIncrement())
+						.balance(1L)
+						.fee(100_000_000L)
 						.payingWith(GENESIS)
+						.entityMemo(
+								new String(TxnUtils.randomUtf8Bytes(memoLength.getAsInt()), StandardCharsets.UTF_8)
+						)
+						.noLogging()
+						.hasPrecheckFrom(permissiblePrechecks)
 						.deferStatusResolution(),
+				getAccountInfo(TARGET_ACCOUNT+"Info")
+						.payingWith(GENESIS)
+						.has(accountWith()
+							.memo(ACCOUNT_MEMO)
+						)
+						.hasAnswerOnlyPrecheckFrom(permissiblePrechecks)
+						.hasCostAnswerPrecheckFrom(permissiblePrechecks)
+						.noLogging(),
 				cryptoUpdate(TARGET_ACCOUNT)
-						.entityMemo(
-								TxnUtils.randomUtf8Bytes(memoLength.getAsInt()).toString()
-						)
 						.payingWith(GENESIS)
-						.logged()
-						.hasPrecheckFrom(
-								OK, BUSY, DUPLICATE_TRANSACTION, PLATFORM_TRANSACTION_NOT_CREATED)
+						.entityMemo(
+								new String(TxnUtils.randomUtf8Bytes(memoLength.getAsInt()), StandardCharsets.UTF_8)
+						)
+						.noLogging()
+						.hasPrecheckFrom(permissiblePrechecks)
 						.deferStatusResolution(),
-				tokenCreate("testToken" + createdSoFar)
-						.entityMemo(
-								TxnUtils.randomUtf8Bytes(memoLength.getAsInt()).toString()
-						)
-						.payingWith(GENESIS)
-						.logged()
-						.initialSupply(100_000_000_000L)
-						.hasPrecheckFrom(
-								OK, BUSY, DUPLICATE_TRANSACTION, PLATFORM_TRANSACTION_NOT_CREATED)
-						.deferStatusResolution(),
-				tokenUpdate(TARGET_TOKEN)
-						.entityMemo(
-								TxnUtils.randomUtf8Bytes(memoLength.getAsInt()).toString()
-						)
-						.payingWith(GENESIS)
-						.logged()
-						.hasPrecheckFrom(
-								OK, BUSY, DUPLICATE_TRANSACTION, PLATFORM_TRANSACTION_NOT_CREATED)
-						.deferStatusResolution(),
-				fileCreate("testFile" + createdSoFar)
-						.entityMemo(
-								TxnUtils.randomUtf8Bytes(memoLength.getAsInt()).toString()
-						)
-						.payingWith(GENESIS)
-						.logged()
-						.hasPrecheckFrom(
-								OK, BUSY, DUPLICATE_TRANSACTION, PLATFORM_TRANSACTION_NOT_CREATED)
-						.deferStatusResolution(),
-				fileUpdate(TARGET_FILE)
-						.entityMemo(
-								TxnUtils.randomUtf8Bytes(memoLength.getAsInt()).toString()
-						)
-						.payingWith(GENESIS)
-						.logged()
-						.hasPrecheckFrom(
-								OK, BUSY, DUPLICATE_TRANSACTION, PLATFORM_TRANSACTION_NOT_CREATED)
-						.deferStatusResolution()
+//				tokenCreate("testToken" + createdSoFar.getAndIncrement())
+//						.payingWith(GENESIS)
+//						.entityMemo(
+//								new String(TxnUtils.randomUtf8Bytes(memoLength.getAsInt()), StandardCharsets.UTF_8)
+//						)
+//						.noLogging()
+//						.hasPrecheckFrom(permissiblePrechecks)
+//						.deferStatusResolution(),
+//				getTokenInfo(TARGET_TOKEN+"Info")
+//						.payingWith(GENESIS)
+//						.hasRegisteredMemo(TOKEN_MEMO)
+//						.hasAnswerOnlyPrecheckFrom(permissiblePrechecks)
+//						.hasCostAnswerPrecheckFrom(permissiblePrechecks)
+//						.noLogging(),
+//				tokenUpdate(TARGET_TOKEN)
+//						.payingWith(GENESIS)
+//						.entityMemo(
+//								new String(TxnUtils.randomUtf8Bytes(memoLength.getAsInt()), StandardCharsets.UTF_8)
+//						)
+//						.noLogging()
+//						.hasPrecheckFrom(permissiblePrechecks)
+//						.deferStatusResolution(),
+//				createTopic("testTopic" + createdSoFar.getAndIncrement())
+//						.topicMemo(
+//								new String(TxnUtils.randomUtf8Bytes(memoLength.getAsInt()), StandardCharsets.UTF_8)
+//						)
+//						.payingWith(GENESIS)
+//						.adminKeyName("adminKey")
+//						.noLogging()
+//						.hasPrecheckFrom(permissiblePrechecks)
+//						.deferStatusResolution(),
+//				getTopicInfo(TARGET_TOPIC+"Info")
+//						.payingWith(GENESIS)
+//						.hasMemo(TOPIC_MEMO)
+//						.hasAnswerOnlyPrecheckFrom(permissiblePrechecks)
+//						.hasCostAnswerPrecheckFrom(permissiblePrechecks)
+//						.noLogging(),
+//				updateTopic(TARGET_TOPIC)
+//						.topicMemo(
+//								new String(TxnUtils.randomUtf8Bytes(memoLength.getAsInt()), StandardCharsets.UTF_8)
+//						)
+//						.payingWith(GENESIS)
+//						.adminKey("adminKey")
+//						.noLogging()
+//						.hasPrecheckFrom(permissiblePrechecks)
+//						.deferStatusResolution()
 		};
 		return defaultHapiSpec("RunMixedMemoOps")
 				.given(
 						withOpContext((spec, ignore) -> settings.setFrom(spec.setup().ciPropertiesMap())),
-						logIt(ignore -> settings.toString())
+						logIt(ignore -> settings.toString()),
+						tokenOpsEnablement()
 				)
 				.when(
 						fileUpdate(APP_PROPERTIES)
 								.payingWith(GENESIS)
-								.overridingProps(Map.of("hapi.throttling.buckets.fastOpBucket.capacity", "1300000.0")),
+								.overridingProps(Map.of("hapi.throttling.buckets.fastOpBucket.capacity", "1300000.0",
+										"hapi.throttling.ops.consensusUpdateTopic.capacityRequired", "1.0",
+										"hapi.throttling.ops.consensusGetTopicInfo.capacityRequired", "1.0",
+										"hapi.throttling.ops.consensusSubmitMessage.capacityRequired", "1.0",
+										"tokens.maxPerAccount", "10000000")),
+						sleepFor(5000),
+						newKeyNamed("adminKey"),
+						logIt(ignore -> settings.toString()),
 						cryptoCreate(TARGET_ACCOUNT)
-								.entityMemo("InitialMemo")
+								.fee(100_000_000L)
+								.payingWith(GENESIS)
+								.entityMemo("Memo Length :" + settings.getMemoLength())
 								.logged(),
-						tokenCreate(TARGET_TOKEN)
-								.entityMemo("InitialMemo")
+						getAccountInfo(TARGET_ACCOUNT)
 								.logged(),
-						fileCreate(TARGET_FILE)
-								.entityMemo("InitialMemo")
+						cryptoCreate(TARGET_ACCOUNT+"Info")
+								.fee(100_000_000L)
+								.payingWith(GENESIS)
+								.entityMemo(ACCOUNT_MEMO)
 								.logged()
+//						createTopic(TARGET_TOPIC)
+//								.topicMemo(TOPIC_MEMO)
+//								.adminKeyName("adminKey")
+//								.payingWith(GENESIS)
+//								.logged(),
+//						createTopic(TARGET_TOPIC+"Info")
+//								.payingWith(GENESIS)
+//								.adminKeyName("adminKey")
+//								.topicMemo(TOPIC_MEMO)
+//								.logged()
+//						tokenCreate(TARGET_TOKEN)
+//								.entityMemo(TOKEN_MEMO)
+//								.payingWith(GENESIS)
+//								.logged(),
+//						tokenCreate(TARGET_TOKEN+"Info")
+//								.entityMemo(TOKEN_MEMO)
+//								.payingWith(GENESIS)
+//								.logged()
+//						fileCreate(TARGET_FILE)
+//								.entityMemo(FILE_MEMO)
+//								.logged()
 				)
 				.then(
-						defaultLoadTest(transferBurst, settings)
+						defaultLoadTest(mixedOpsBurst, settings)
 				);
 	}
 

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/TokenCreatePerfSuite.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/TokenCreatePerfSuite.java
@@ -57,7 +57,6 @@ public class TokenCreatePerfSuite extends LoadTest {
 
 	private HapiApiSpec runTokenCreates() {
 		final int NUM_CREATES = 100000;
-		final String tokenCreateMemo = TxnUtils.randomUtf8Bytes(memoLength.getAsInt()).toString();
 		return defaultHapiSpec("tokenCreatePerf")
 				.given(
 				).when(
@@ -71,7 +70,6 @@ public class TokenCreatePerfSuite extends LoadTest {
 														.payingWith(GENESIS)
 														.signedBy(GENESIS)
 														.initialSupply(100_000_000_000L)
-														.entityMemo(tokenCreateMemo)
 														.deferStatusResolution()
 								)
 						)

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenCreateSpecs.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenCreateSpecs.java
@@ -205,7 +205,7 @@ public class TokenCreateSpecs extends HapiApiSuite {
 						getTokenInfo("primary")
 								.logged()
 								.hasRegisteredId("primary")
-								.hasRegisteredMemo()
+								.hasRegisteredMemo(memo)
 								.hasName(saltedName)
 								.hasTreasury(TOKEN_TREASURY)
 								.hasAutoRenewPeriod(A_HUNDRED_SECONDS)

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenUpdateSpecs.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenUpdateSpecs.java
@@ -517,7 +517,7 @@ public class TokenUpdateSpecs extends HapiApiSuite {
 								),
 						getTokenInfo("primary")
 								.logged()
-								.hasRegisteredMemo()
+								.hasRegisteredMemo(updatedMemo)
 								.hasRegisteredId("primary")
 								.hasName(newSaltedName)
 								.hasTreasury("newTokenTreasury")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `0<issue number>-<target branch>-<summary>`
-->

**Related issue(s)**:
Closes #1071 

**Summary of the change**:
Added a new performance test that does cryptoCreate, cryptoUpdate, TokenCreate, TokenUpdate, FileCreate, FileUpdate transactions with entityMemo set. 
Use memoLength from CI properties map in the load test to vary the length of the memo set to the entities. 

**External impacts**:
None.

**Applicable documentation**
- [ ] Javadoc
- [ ] HAPI protobuf comments
- [ ] README
