### PR TITLE
Ignore the AWS continuous-integration workflow 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1874,8 +1874,7 @@ workflows:
           filters:
             branches:
               ignore:
-                - /.*-PERF/
-                - /.*-REGRESSION/
+                - /.*/
 
           workflow-name: "Continuous integration"
       - start-singlejob-testnet:


### PR DESCRIPTION
Until we understand the explosion of spot nodes in `us-east1`, ignore the `continuous-integration` workflow on all branches.