### PR TITLE
Make SignedStateBalancesExporter CSV output backward-compatible

### DIFF
--- a/hedera-node/src/main/java/com/hedera/services/ServicesMain.java
+++ b/hedera-node/src/main/java/com/hedera/services/ServicesMain.java
@@ -126,8 +126,7 @@ public class ServicesMain implements SwirldMain {
 		}
 		if (ctx.globalDynamicProperties().shouldExportBalances() && ctx.balancesExporter().isTimeToExport(when)) {
 			try {
-				ctx.balancesExporter().toCsvFile((ServicesState) signedState, when);
-				ctx.balancesExporter().toProtoFile((ServicesState) signedState, when);
+				ctx.balancesExporter().exportBalancesFrom((ServicesState) signedState, when);
 			} catch (IllegalStateException ise) {
 				log.error("HederaNode#{} has invalid total balance in signed state, exiting!", ctx.id(), ise);
 				systemExits.fail(1);

--- a/hedera-node/src/main/java/com/hedera/services/state/exports/BalancesExporter.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/exports/BalancesExporter.java
@@ -26,6 +26,5 @@ import java.time.Instant;
 
 public interface BalancesExporter {
 	boolean isTimeToExport(Instant now);
-	void toCsvFile(ServicesState signedState, Instant when);
-	void toProtoFile(ServicesState signedState, Instant when);
+	void exportBalancesFrom(ServicesState signedState, Instant when);
 }

--- a/hedera-node/src/test/java/com/hedera/services/ServicesMainTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/ServicesMainTest.java
@@ -522,8 +522,7 @@ public class ServicesMainTest {
 		subject.newSignedState(signedState, when, 1L);
 
 		// then:
-		verify(balancesExporter, never()).toCsvFile(any(), any());
-		verify(balancesExporter, never()).toProtoFile(any(), any());
+		verify(balancesExporter, never()).exportBalancesFrom(any(), any());
 	}
 
 	@Test
@@ -540,8 +539,7 @@ public class ServicesMainTest {
 		subject.newSignedState(signedState, when, 1L);
 
 		// then:
-		verify(balancesExporter).toCsvFile(signedState, when);
-		verify(balancesExporter).toProtoFile(signedState, when);
+		verify(balancesExporter).exportBalancesFrom(signedState, when);
 	}
 
 	@Test
@@ -569,7 +567,9 @@ public class ServicesMainTest {
 
 		given(globalDynamicProperties.shouldExportBalances()).willReturn(true);
 		given(balancesExporter.isTimeToExport(when)).willReturn(true);
-		willThrow(IllegalStateException.class).given(balancesExporter).toCsvFile(signedState, when);
+		willThrow(IllegalStateException.class)
+				.given(balancesExporter)
+				.exportBalancesFrom(signedState, when);
 
 		// when:
 		subject.newSignedState(signedState, when, 1L);

--- a/hedera-node/src/test/java/com/hedera/services/sigs/factories/SigFactoryCreatorTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/sigs/factories/SigFactoryCreatorTest.java
@@ -21,6 +21,7 @@ package com.hedera.services.sigs.factories;
  */
 
 import com.google.protobuf.ByteString;
+import com.google.protobuf.InvalidProtocolBufferException;
 import com.hedera.services.state.merkle.MerkleEntityId;
 import com.hedera.services.state.merkle.MerkleSchedule;
 import com.hedera.services.utils.SignedTxnAccessor;
@@ -32,6 +33,7 @@ import com.hederahashgraph.api.proto.java.ScheduleCreateTransactionBody;
 import com.hederahashgraph.api.proto.java.ScheduleID;
 import com.hederahashgraph.api.proto.java.ScheduleSignTransactionBody;
 import com.hederahashgraph.api.proto.java.SignedTransaction;
+import com.hederahashgraph.api.proto.java.TokenBalances;
 import com.hederahashgraph.api.proto.java.Transaction;
 import com.hederahashgraph.api.proto.java.TransactionBody;
 import com.hederahashgraph.api.proto.java.TransferList;
@@ -40,6 +42,8 @@ import com.swirlds.fcmap.FCMap;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
+import java.util.Base64;
 
 import static com.hedera.services.sigs.factories.PlatformSigFactoryTest.pk;
 import static com.hedera.services.sigs.factories.PlatformSigFactoryTest.sig;

--- a/hedera-node/src/test/java/com/hedera/services/state/exports/SignedStateBalancesExporterTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/state/exports/SignedStateBalancesExporterTest.java
@@ -20,6 +20,7 @@ package com.hedera.services.state.exports;
  * ‍
  */
 
+import com.google.protobuf.InvalidProtocolBufferException;
 import com.hedera.services.ServicesState;
 import com.hedera.services.config.MockGlobalDynamicProps;
 import com.hedera.services.context.properties.GlobalDynamicProperties;
@@ -35,6 +36,7 @@ import com.hederahashgraph.api.proto.java.AccountID;
 import com.hedera.services.stream.proto.AllAccountBalances;
 import com.hedera.services.stream.proto.SingleAccountBalances;
 import com.hedera.services.stream.proto.TokenUnitBalance;
+import com.hederahashgraph.api.proto.java.TokenBalances;
 import com.hederahashgraph.api.proto.java.TokenID;
 
 import com.swirlds.common.Address;
@@ -47,17 +49,18 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Instant;
 import java.util.ArrayList;
-import java.util.Collections;
+import java.util.Base64;
+import java.util.Base64.Decoder;
 import java.util.Comparator;
 import java.util.List;
 import java.util.function.UnaryOperator;
-import java.util.regex.Pattern;
 import java.util.Optional;
 
 import static com.hedera.services.state.exports.SignedStateBalancesExporter.GOOD_SIGNING_ATTEMPT_DEBUG_MSG_TPL;
@@ -93,16 +96,12 @@ class SignedStateBalancesExporterTest {
 
 	long thisNodeBalance = 400;
 	AccountID thisNode = asAccount("0.0.3");
-
 	long anotherNodeBalance = 100;
 	AccountID anotherNode = asAccount("0.0.4");
-
 	long firstNonNodeAccountBalance = 250;
 	AccountID firstNonNode = asAccount("0.0.1001");
-
 	long secondNonNodeAccountBalance = 250;
 	AccountID secondNonNode = asAccount("0.0.1002");
-
 	AccountID deleted = asAccount("0.0.1003");
 
 	TokenID theToken = asToken("0.0.1004");
@@ -212,7 +211,8 @@ class SignedStateBalancesExporterTest {
 		subject.directories = assurance;
 
 		// when:
-		subject.toCsvFile(state, now);
+		subject.exportProto = false;
+		subject.exportBalancesFrom(state, now);
 
 		// then:
 		verify(mockLog).error(any(String.class), any(Throwable.class));
@@ -226,7 +226,8 @@ class SignedStateBalancesExporterTest {
 		given(hashReader.readHash(loc)).willThrow(IllegalStateException.class);
 
 		// when:
-		subject.toCsvFile(state, now);
+		subject.exportProto = false;
+		subject.exportBalancesFrom(state, now);
 
 		// then:
 		verify(mockLog).error(any(String.class), any(Throwable.class));
@@ -236,11 +237,80 @@ class SignedStateBalancesExporterTest {
 	}
 
 	@Test
+	public void matchesV2OutputForCsv() throws IOException {
+		// setup:
+		ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
+		// and:
+		var loc = expectedExportLoc();
+		// and:
+		accounts.clear();
+		accounts.put(
+				new MerkleEntityId(0, 0, 1),
+				MerkleAccountFactory.newAccount().get());
+		accounts.put(
+				new MerkleEntityId(0, 0, 2),
+				MerkleAccountFactory.newAccount()
+						.balance(4999999999999999920L)
+						.tokens(asToken("0.0.1001"), asToken("0.0.1002"))
+						.get());
+		accounts.put(
+				new MerkleEntityId(0, 0, 3),
+				MerkleAccountFactory.newAccount()
+						.balance(80L)
+						.tokens(asToken("0.0.1002"))
+						.get());
+		// and:
+		tokenRels.clear();
+		tokenRels.put(
+				new MerkleEntityAssociation(0, 0, 2, 0, 0, 1001),
+				new MerkleTokenRelStatus(666L, false, false));
+		tokenRels.put(
+				new MerkleEntityAssociation(0, 0, 2, 0, 0, 1002),
+				new MerkleTokenRelStatus(444L, false, false));
+		tokenRels.put(
+				new MerkleEntityAssociation(0, 0, 3, 0, 0, 1002),
+				new MerkleTokenRelStatus(333L, false, false));
+		// and:
+		tokens.clear();
+		tokens.put(new MerkleEntityId(0, 0, 1001), token);
+		tokens.put(new MerkleEntityId(0, 0, 1002), token);
+
+		given(hashReader.readHash(loc)).willReturn(fileHash);
+		given(sigFileWriter.writeSigFile(captor.capture(), any(), any())).willReturn(loc + "_sig");
+		given(properties.getLongProperty("ledger.totalTinyBarFloat"))
+				.willReturn(5000000000000000000L);
+		given(signer.apply(fileHash)).willReturn(sig);
+		// and:
+		subject = new SignedStateBalancesExporter(properties, signer, dynamicProperties);
+		subject.sigFileWriter = sigFileWriter;
+		subject.hashReader = hashReader;
+
+		// when:
+		subject.exportProto = false;
+		subject.exportBalancesFrom(state, now);
+
+		// then:
+		var lines = Files.readAllLines(Paths.get(loc));
+		assertEquals(6, lines.size());
+		assertEquals(String.format("# " + SignedStateBalancesExporter.CURRENT_VERSION, now), lines.get(0));
+		assertEquals(String.format("# TimeStamp:%s", now), lines.get(1));
+		assertEquals("shardNum,realmNum,accountNum,balance,tokenBalances", lines.get(2));
+		assertEquals("0,0,1,0,", lines.get(3));
+		assertEquals("0,0,2,4999999999999999920,CggKAxjpBxCaBQoICgMY6gcQvAM=", lines.get(4));
+		assertEquals("0,0,3,80,CggKAxjqBxDNAg==", lines.get(5));
+		// and:
+		verify(sigFileWriter).writeSigFile(loc, sig, fileHash);
+		// and:
+		verify(mockLog).debug(String.format(GOOD_SIGNING_ATTEMPT_DEBUG_MSG_TPL, loc + "_sig"));
+
+		// cleanup:
+		new File(loc).delete();
+	}
+
+	@Test
 	public void usesNewFormatWhenExportingTokenBalances() throws IOException {
 		// setup:
 		ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
-		Pattern CSV_NAME_PATTERN = Pattern.compile(
-				".*\\d{4}-\\d{2}-\\d{2}T\\d{2}_\\d{2}_\\d{2}[.]\\d{9}Z_Balances.csv");
 		// and:
 		var loc = expectedExportLoc();
 
@@ -248,7 +318,8 @@ class SignedStateBalancesExporterTest {
 		given(sigFileWriter.writeSigFile(captor.capture(), any(), any())).willReturn(loc + "_sig");
 
 		// when:
-		subject.toCsvFile(state, now);
+		subject.exportProto = false;
+		subject.exportBalancesFrom(state, now);
 
 		// then:
 		var lines = Files.readAllLines(Paths.get(loc));
@@ -271,8 +342,6 @@ class SignedStateBalancesExporterTest {
 		verify(sigFileWriter).writeSigFile(loc, sig, fileHash);
 		// and:
 		verify(mockLog).debug(String.format(GOOD_SIGNING_ATTEMPT_DEBUG_MSG_TPL, loc + "_sig"));
-		// and:
-//		assertTrue(CSV_NAME_PATTERN.matcher(captor.getValue()).matches());
 
 		// cleanup:
 		new File(loc).delete();
@@ -292,7 +361,8 @@ class SignedStateBalancesExporterTest {
 		subject.hashReader = hashReader;
 
 		// when:
-		subject.toCsvFile(state, now);
+		subject.exportProto = false;
+		subject.exportBalancesFrom(state, now);
 
 		// then:
 		var lines = Files.readAllLines(Paths.get(expectedExportLoc()));
@@ -318,8 +388,6 @@ class SignedStateBalancesExporterTest {
 	public void testExportingTokenBalancesProto() throws IOException {
 		// setup:
 		ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
-		Pattern PB_NAME_PATTERN = Pattern.compile(
-				".*\\d{4}-\\d{2}-\\d{2}T\\d{2}_\\d{2}_\\d{2}[.]\\d{9}Z_Balances.pb");
 		// and:
 		var loc = expectedExportLoc(true);
 
@@ -327,23 +395,23 @@ class SignedStateBalancesExporterTest {
 		given(sigFileWriter.writeSigFile(captor.capture(), any(), any())).willReturn(loc + "_sig");
 
 		// when:
-		subject.toProtoFile(state, now);
+		subject.exportCsv = false;
+		subject.exportBalancesFrom(state, now);
 
 		// and:
-		java.util.Optional<AllAccountBalances> fileContent = subject.importBalanceProtoFile(loc);
+		java.util.Optional<AllAccountBalances> fileContent = importBalanceProtoFile(loc);
 
-		AllAccountBalances allAccountBalances = fileContent.get() ;
+		AllAccountBalances allAccountBalances = fileContent.get();
 
 		// then:
 		List<SingleAccountBalances> accounts = allAccountBalances.getAllAccountsList();
 
 		assertEquals(accounts.size(), 4);
 
-		for(SingleAccountBalances account : accounts) {
-			if(account.getAccountID().getAccountNum() == 1001) {
+		for (SingleAccountBalances account : accounts) {
+			if (account.getAccountID().getAccountNum() == 1001) {
 				assertEquals(account.getHbarBalance(), 250);
-			}
-			else if(account.getAccountID().getAccountNum() == 1002) {
+			} else if (account.getAccountID().getAccountNum() == 1002) {
 				assertEquals(account.getHbarBalance(), 250);
 				assertEquals(account.getTokenUnitBalances(0).getTokenId().getTokenNum(), 1004);
 				assertEquals(account.getTokenUnitBalances(0).getBalance(), 100);
@@ -354,8 +422,6 @@ class SignedStateBalancesExporterTest {
 		verify(sigFileWriter).writeSigFile(loc, sig, fileHash);
 		// and:
 		verify(mockLog).debug(String.format(GOOD_SIGNING_ATTEMPT_DEBUG_MSG_TPL, loc + "_sig"));
-		// and:
-//		assertTrue(CSV_NAME_PATTERN.matcher(captor.getValue()).matches());
 
 		// cleanup:
 		new File(loc).delete();
@@ -376,7 +442,8 @@ class SignedStateBalancesExporterTest {
 		subject.directories = assurance;
 
 		// when:
-		subject.toProtoFile(state, now);
+		subject.exportCsv = false;
+		subject.exportBalancesFrom(state, now);
 
 		// then:
 		verify(mockLog).error(any(String.class), any(Throwable.class));
@@ -386,34 +453,20 @@ class SignedStateBalancesExporterTest {
 	@Test
 	public void getEmptyAllAccountBalancesFromCorruptedProtoFileImport() throws Exception {
 		// setup:
-		ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
-		Pattern BAD_PB_NAME_PATTERN = Pattern.compile(
-				".*\\d{4}-\\d{2}-\\d{2}T\\d{2}_\\d{2}_\\d{2}[.]\\d{9}Z_Balances.pb");
-		// and:
 		var loc = expectedExportLoc(true);
 
 		given(hashReader.readHash(loc)).willReturn(fileHash);
 
 		// when: Pretend the .csv file is a corrupted .pb file
-		subject.toCsvFile(state, now);
+		subject.exportProto = false;
+		subject.exportBalancesFrom(state, now);
 
 		// and:
-		java.util.Optional<AllAccountBalances> accounts = subject.importBalanceProtoFile(loc);
+		java.util.Optional<AllAccountBalances> accounts = importBalanceProtoFile(loc);
 
 		// then:
 		assertEquals(Optional.empty(), accounts);
 	}
-
-	@Test
-	public void throwsOnUnexpectedTotalFloatForProtoFile() throws NegativeAccountBalanceException {
-		// given:
-		anotherNodeAccount.setBalance(anotherNodeBalance + 1);
-
-		// then:
-		assertThrows(IllegalStateException.class, () -> subject.toProtoFile(state, now));
-	}
-
-
 
 	@Test
 	public void assuresExpectedProtoFileDir() throws IOException {
@@ -421,7 +474,8 @@ class SignedStateBalancesExporterTest {
 		subject.directories = assurance;
 
 		// when:
-		subject.toProtoFile(state, now);
+		subject.exportCsv = false;
+		subject.exportBalancesFrom(state, now);
 
 		// then:
 		verify(assurance).ensureExistenceOf(expectedExportDir());
@@ -449,20 +503,17 @@ class SignedStateBalancesExporterTest {
 		willThrow(IOException.class).given(assurance).ensureExistenceOf(any());
 
 		// when:
-		subject.toProtoFile(state, now);
+		subject.exportCsv = false;
+		subject.exportBalancesFrom(state, now);
 
 		// then:
 		verify(mockLog).error(String.format(
 				SignedStateBalancesExporter.BAD_EXPORT_DIR_ERROR_MSG_TPL, expectedExportDir()));
 	}
 
-	private String expectedBalancesName(Boolean isProto ) {
+	private String expectedBalancesName(Boolean isProto) {
 		return isProto ? now.toString().replace(":", "_") + "_Balances.pb"
 				: now.toString().replace(":", "_") + "_Balances.csv";
-	}
-
-	private String expectedBalancesName() {
-		return  expectedBalancesName(false) ;
 	}
 
 	@Test
@@ -534,7 +585,8 @@ class SignedStateBalancesExporterTest {
 		subject.directories = assurance;
 
 		// when:
-		subject.toCsvFile(state, now);
+		subject.exportProto = false;
+		subject.exportBalancesFrom(state, now);
 
 		// then:
 		verify(assurance).ensureExistenceOf(expectedExportDir());
@@ -546,7 +598,8 @@ class SignedStateBalancesExporterTest {
 		anotherNodeAccount.setBalance(anotherNodeBalance + 1);
 
 		// then:
-		assertThrows(IllegalStateException.class, () -> subject.toCsvFile(state, now));
+		assertThrows(IllegalStateException.class,
+				() -> subject.exportBalancesFrom(state, now));
 	}
 
 	@Test
@@ -557,7 +610,8 @@ class SignedStateBalancesExporterTest {
 		willThrow(IOException.class).given(assurance).ensureExistenceOf(any());
 
 		// when:
-		subject.toCsvFile(state, now);
+		subject.exportProto = false;
+		subject.exportBalancesFrom(state, now);
 
 		// then:
 		verify(mockLog).error(String.format(
@@ -591,5 +645,16 @@ class SignedStateBalancesExporterTest {
 				.sorted(Comparator.reverseOrder())
 				.map(Path::toFile)
 				.forEach(File::delete);
+	}
+
+	static Optional<AllAccountBalances> importBalanceProtoFile(String protoLoc) {
+		try {
+			FileInputStream fin = new FileInputStream(protoLoc);
+			AllAccountBalances allAccountBalances = AllAccountBalances.parseFrom(fin);
+			return Optional.ofNullable(allAccountBalances);
+		} catch (IOException e) {
+			SignedStateBalancesExporter.log.error("Can't read protobuf message file {}", protoLoc);
+		}
+		return Optional.empty();
 	}
 }

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenMiscOps.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenMiscOps.java
@@ -21,6 +21,7 @@ package com.hedera.services.bdd.suites.token;
  */
 
 import com.hedera.services.bdd.spec.HapiApiSpec;
+import com.hedera.services.bdd.spec.transactions.token.TokenMovement;
 import com.hedera.services.bdd.suites.HapiApiSuite;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -38,6 +39,7 @@ import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoTransfer;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.mintToken;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.tokenAssociate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.tokenCreate;
+import static com.hedera.services.bdd.spec.transactions.token.TokenMovement.moving;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.newKeyNamed;
 
 public class TokenMiscOps extends HapiApiSuite {
@@ -52,10 +54,36 @@ public class TokenMiscOps extends HapiApiSuite {
 		return allOf(
 				List.of(new HapiApiSpec[] {
 //								wellKnownAccountsHaveTokens(),
-								someInfoQueries(),
+//								someLowNumAccountsHaveTokens(),
+//								someInfoQueries(),
+								theCreation(),
 						}
 				)
 		);
+	}
+
+	public HapiApiSpec someLowNumAccountsHaveTokens() {
+		long aSupply = 666L, bSupply = 777L;
+
+		return defaultHapiSpec("SomeLowNumAccountsHaveTokens")
+				.given(
+						tokenCreate("first").treasury(GENESIS).initialSupply(aSupply),
+						tokenCreate("second").treasury(GENESIS).initialSupply(bSupply)
+				).when(
+						tokenAssociate("0.0.3", "second").signedBy(GENESIS),
+						cryptoTransfer(moving(aSupply / 2, "second")
+								.between(GENESIS, "0.0.3")).signedBy(GENESIS)
+				).then(
+						getAccountInfo(GENESIS).logged(),
+						getAccountInfo("0.0.3").logged()
+				);
+	}
+
+	public HapiApiSpec theCreation() {
+		return defaultHapiSpec("TheCreation")
+				.given().when().then(
+						cryptoCreate("adam")
+				);
 	}
 
 	public HapiApiSpec someInfoQueries() {


### PR DESCRIPTION
**Related issue(s)**:
- Closes #1092

**Summary of the change**:
- Revert to using `TokenBalances` proto type in exporting Base64-encoded token balances in CSV format.
- Eliminate duplication in `SignedStateBalancesExporter`.
- Add unit test to ensure `version:2` CSV token balances remain backward-compatible in future.

**External impacts**:
Fixes failure of `0.12.0-rc.1` balances CSV to be backward-compatible with `0.11.0` code.