### PR TITLE
Only check existence against pending id if appropriate

### DIFF
--- a/hedera-node/src/main/java/com/hedera/services/store/schedule/HederaScheduleStore.java
+++ b/hedera-node/src/main/java/com/hedera/services/store/schedule/HederaScheduleStore.java
@@ -96,7 +96,7 @@ public class HederaScheduleStore extends HederaStore implements ScheduleStore {
 
 	@Override
 	public boolean exists(ScheduleID id) {
-		return pendingId.equals(id) || schedules.get().containsKey(fromScheduleId(id));
+		return (isCreationPending() && pendingId.equals(id)) || schedules.get().containsKey(fromScheduleId(id));
 	}
 
 	@Override

--- a/hedera-node/src/main/java/com/hedera/services/store/tokens/HederaTokenStore.java
+++ b/hedera-node/src/main/java/com/hedera/services/store/tokens/HederaTokenStore.java
@@ -234,7 +234,7 @@ public class HederaTokenStore extends HederaStore implements TokenStore {
 
 	@Override
 	public boolean exists(TokenID id) {
-		return pendingId.equals(id) || tokens.get().containsKey(fromTokenId(id));
+		return (isCreationPending() && pendingId.equals(id)) || tokens.get().containsKey(fromTokenId(id));
 	}
 
 	@Override

--- a/hedera-node/src/test/java/com/hedera/services/store/schedule/HederaScheduleStoreTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/store/schedule/HederaScheduleStoreTest.java
@@ -31,6 +31,7 @@ import com.hedera.services.state.merkle.MerkleEntityId;
 import com.hedera.services.state.merkle.MerkleSchedule;
 import com.hedera.services.state.submerkle.EntityId;
 import com.hedera.services.state.submerkle.RichInstant;
+import com.hedera.services.store.tokens.HederaTokenStore;
 import com.hedera.test.utils.IdUtils;
 import com.hedera.test.utils.TxnUtils;
 import com.hederahashgraph.api.proto.java.AccountID;
@@ -323,6 +324,12 @@ public class HederaScheduleStoreTest {
 
         // expect:
         assertSame(schedule, subject.get(created));
+    }
+
+    @Test
+    public void existenceCheckUnderstandsPendingIdOnlyAppliesIfCreationPending() {
+        // expect:
+        assertFalse(subject.exists(HederaScheduleStore.NO_PENDING_ID));
     }
 
     @Test

--- a/hedera-node/src/test/java/com/hedera/services/store/tokens/HederaTokenStoreTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/store/tokens/HederaTokenStoreTest.java
@@ -362,6 +362,12 @@ class HederaTokenStoreTest {
 	}
 
 	@Test
+	public void existenceCheckUnderstandsPendingIdOnlyAppliesIfCreationPending() {
+		// expect:
+		assertFalse(subject.exists(HederaTokenStore.NO_PENDING_ID));
+	}
+
+	@Test
 	public void existenceCheckIncludesPending() {
 		// setup:
 		subject.pendingId = pending;

--- a/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/schedule/HapiGetScheduleInfo.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/schedule/HapiGetScheduleInfo.java
@@ -127,7 +127,6 @@ public class HapiGetScheduleInfo extends HapiQueryOp<HapiGetScheduleInfo> {
                 "Wrong schedule expiry!",
                 spec.registry());
 
-
         var registry = spec.registry();
 
         expectedSignatories.ifPresent(s -> {

--- a/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/HapiTxnOp.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/HapiTxnOp.java
@@ -202,17 +202,18 @@ public abstract class HapiTxnOp<T extends HapiTxnOp<T>> extends HapiSpecOperatio
 //							"{} {} Wrong actual precheck status {}, not one of {}!",spec.logPrefix(), this,
 //							actualPrecheck,
 //							permissiblePrechecks.get());
-					throw new HapiTxnPrecheckStateException(
-							String.format("Wrong actual precheck status %s, expected %s", actualStatus,
-									permissibleStatuses.get()));
+					throw new HapiTxnPrecheckStateException(String.format(
+							"Wrong precheck status! Expected one of %s, actual %s",
+							permissibleStatuses.get(), actualStatus));
 				}
 			} else {
 				if (getExpectedPrecheck() != actualPrecheck) {
 					// Change to an info until HapiClientValidator can be modified and can understand new errors
 					log.info("{} {} Wrong actual precheck status {}, expecting {}", spec.logPrefix(), this,
 							actualPrecheck, getExpectedPrecheck());
-//					throw new HapiTxnPrecheckStateException(String.format("Wrong precheck status! expected %s, actual
-//					%s", getExpectedPrecheck(), actualPrecheck));
+					throw new HapiTxnPrecheckStateException(String.format(
+							"Wrong precheck status! Expected %s, actual %s",
+							getExpectedPrecheck(), actualPrecheck));
 				}
 			}
 		}
@@ -262,16 +263,18 @@ public abstract class HapiTxnOp<T extends HapiTxnOp<T>> extends HapiSpecOperatio
 						"{} {} Wrong actual status {}, not one of {}!", spec.logPrefix(), this,
 						actualStatus,
 						permissibleStatuses.get());
-				throw new HapiTxnCheckStateException(
-						String.format("Wrong actual status %s, expected %s", actualStatus, permissibleStatuses.get()));
+				throw new HapiTxnCheckStateException(String.format(
+						"Wrong status! Expected one of %s, was %s",
+						permissibleStatuses.get(), actualStatus));
 			}
 		} else {
 			if (getExpectedStatus() != actualStatus) {
 				// Change to an info until HapiClientValidator can be modified and can understand new errors
 				log.info("{} {} Wrong actual status {}, expected {}", spec.logPrefix(), this, actualStatus,
 						getExpectedStatus());
-//				throw new HapiTxnCheckStateException(String.format("Wrong actual status %s, expected %s", actualStatus,
-//				getExpectedStatus()));
+				throw new HapiTxnCheckStateException(String.format(
+						"Wrong status! Expected %s, was %s",
+						getExpectedStatus(), actualStatus));
 			}
 		}
 		if (!deferStatusResolution) {

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/schedule/ScheduleCreateSpecs.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/schedule/ScheduleCreateSpecs.java
@@ -62,6 +62,7 @@ import static com.hedera.services.bdd.spec.utilops.UtilVerbs.overriding;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.saveExpirations;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.sleepFor;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_ACCOUNT_ID;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_SCHEDULE_ID;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.MEMO_TOO_LONG;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SOME_SIGNATURES_WERE_INVALID;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.UNPARSEABLE_SCHEDULED_TRANSACTION;
@@ -116,6 +117,7 @@ public class ScheduleCreateSpecs extends HapiApiSuite {
 				allowsDoublingScheduledCreates(),
 				scheduledTXCreatedAfterPreviousIdenticalIsExecuted(),
 				preservesRevocationServiceSemanticsForFileDelete(),
+				worksAsExpectedWithDefaultScheduleId(),
 				suiteCleanup(),
 		});
 	}
@@ -131,6 +133,13 @@ public class ScheduleCreateSpecs extends HapiApiSuite {
 		return defaultHapiSpec("suiteCleanup")
 				.given( ).when( ).then(
 						overriding("ledger.schedule.txExpiryTimeSecs", defaultTxExpiry)
+				);
+	}
+
+	private HapiApiSpec worksAsExpectedWithDefaultScheduleId() {
+		return defaultHapiSpec("WorksAsExpectedWithDefaultScheduleId")
+				.given( ).when( ).then(
+						getScheduleInfo("0.0.0").hasCostAnswerPrecheck(INVALID_SCHEDULE_ID)
 				);
 	}
 

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/schedule/ScheduleDeleteSpecs.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/schedule/ScheduleDeleteSpecs.java
@@ -167,6 +167,8 @@ public class ScheduleDeleteSpecs extends HapiApiSuite {
 		return defaultHapiSpec("DeletingNonExistingFails")
 				.given().when().then(
 						scheduleDelete("0.0.534")
+								.hasKnownStatus(INVALID_SCHEDULE_ID),
+						scheduleDelete("0.0.0")
 								.hasKnownStatus(INVALID_SCHEDULE_ID)
 				);
 	}

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenAssociationSpecs.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenAssociationSpecs.java
@@ -101,8 +101,17 @@ public class TokenAssociationSpecs extends HapiApiSuite {
 						expiredAndDeletedTokensStillAppearInContractInfo(),
 						dissociationFromExpiredTokensAsExpected(),
 						accountInfoQueriesAsExpected(),
+						handlesUseOfDefaultTokenId(),
 				}
 		);
+	}
+
+	public HapiApiSpec handlesUseOfDefaultTokenId() {
+		return defaultHapiSpec("HandlesUseOfDefaultTokenId")
+				.given( ).when( ).then(
+						tokenAssociate(DEFAULT_PAYER, "0.0.0")
+								.hasKnownStatus(INVALID_TOKEN_ID)
+				);
 	}
 
 	public HapiApiSpec associatedContractsMustHaveAdminKeys() {

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenCreateSpecs.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenCreateSpecs.java
@@ -38,6 +38,7 @@ import java.util.stream.IntStream;
 import static com.hedera.services.bdd.spec.HapiApiSpec.defaultHapiSpec;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getAccountBalance;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getAccountInfo;
+import static com.hedera.services.bdd.spec.queries.QueryVerbs.getScheduleInfo;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getTokenInfo;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getTxnRecord;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoCreate;
@@ -80,8 +81,17 @@ public class TokenCreateSpecs extends HapiApiSuite {
 						creationSetsCorrectExpiry(),
 						creationHappyPath(),
 						numAccountsAllowedIsDynamic(),
+						worksAsExpectedWithDefaultTokenId(),
 				}
 		);
+	}
+
+
+	private HapiApiSpec worksAsExpectedWithDefaultTokenId() {
+		return defaultHapiSpec("WorksAsExpectedWithDefaultTokenId")
+				.given().when().then(
+						getTokenInfo("0.0.0").hasCostAnswerPrecheck(INVALID_TOKEN_ID)
+				);
 	}
 
 	public HapiApiSpec autoRenewValidationWorks() {
@@ -334,7 +344,7 @@ public class TokenCreateSpecs extends HapiApiSuite {
 				.given(
 						cryptoCreate(TOKEN_TREASURY).balance(0L),
 						recordSystemProperty("tokens.maxSymbolUtf8Bytes", Integer::parseInt, maxUtf8Bytes::set)
-				).when( ).then(
+				).when().then(
 						tokenCreate("missingSymbol")
 								.symbol("")
 								.hasPrecheck(MISSING_TOKEN_SYMBOL),

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenDeleteSpecs.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenDeleteSpecs.java
@@ -60,8 +60,8 @@ public class TokenDeleteSpecs extends HapiApiSuite {
 						deletionValidatesMissingAdminKey(),
 						deletionWorksAsExpected(),
 						deletionValidatesAlreadyDeletedToken(),
-						deletionValidatesRef(),
 						treasuryBecomesDeletableAfterTokenDelete(),
+						deletionValidatesRef(),
 				}
 		);
 	}
@@ -178,11 +178,11 @@ public class TokenDeleteSpecs extends HapiApiSuite {
 				.given(
 						cryptoCreate("payer")
 				).when().then(
-						tokenDelete("1.2.3")
+						tokenDelete("0.0.0")
 								.payingWith("payer")
 								.signedBy("payer")
 								.hasKnownStatus(INVALID_TOKEN_ID),
-						tokenDelete("0.0.0")
+						tokenDelete("1.2.3")
 								.payingWith("payer")
 								.signedBy("payer")
 								.hasKnownStatus(INVALID_TOKEN_ID)

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenTransactSpecs.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenTransactSpecs.java
@@ -49,7 +49,9 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.EMPTY_TOKEN_TR
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INSUFFICIENT_ACCOUNT_BALANCE;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INSUFFICIENT_TOKEN_BALANCE;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_ACCOUNT_AMOUNTS;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_ACCOUNT_ID;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_SIGNATURE;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_TOKEN_ID;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TOKEN_TRANSFER_LIST_SIZE_LIMIT_EXCEEDED;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TRANSFERS_NOT_ZERO_SUM_FOR_TOKEN;
 
@@ -80,6 +82,7 @@ public class TokenTransactSpecs extends HapiApiSuite {
 						nonZeroTransfersRejected(),
 						prechecksWork(),
 						allRequiredSigsAreChecked(),
+						missingEntitiesRejected(),
 				}
 		);
 	}
@@ -139,6 +142,22 @@ public class TokenTransactSpecs extends HapiApiSuite {
 								moving(10, A_TOKEN)
 										.empty()
 						).hasPrecheck(EMPTY_TOKEN_TRANSFER_ACCOUNT_AMOUNTS)
+				);
+	}
+
+	public HapiApiSpec missingEntitiesRejected() {
+		return defaultHapiSpec("MissingTokensRejected")
+				.given(
+						tokenCreate("some").treasury(DEFAULT_PAYER)
+				).when().then(
+						cryptoTransfer(
+								moving(1L, "some")
+										.between(DEFAULT_PAYER, "0.0.0")
+						).signedBy(DEFAULT_PAYER).hasKnownStatus(INVALID_ACCOUNT_ID),
+						cryptoTransfer(
+								moving(100_000_000_000_000L, "0.0.0")
+										.between(DEFAULT_PAYER, FUNDING)
+						).signedBy(DEFAULT_PAYER).hasKnownStatus(INVALID_TOKEN_ID)
 				);
 	}
 

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenUpdateSpecs.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenUpdateSpecs.java
@@ -75,7 +75,6 @@ public class TokenUpdateSpecs extends HapiApiSuite {
 						nameChanges(),
 						keysChange(),
 						validatesAlreadyDeletedToken(),
-						validatesMissingRef(),
 						treasuryEvolves(),
 						deletedAutoRenewAccountCheckHolds(),
 						renewalPeriodCheckHolds(),
@@ -85,6 +84,7 @@ public class TokenUpdateSpecs extends HapiApiSuite {
 						tokensCanBeMadeImmutableWithEmptyKeyList(),
 						updateHappyPath(),
 						validatesMissingAdminKey(),
+						validatesMissingRef(),
 				}
 		);
 	}
@@ -148,6 +148,10 @@ public class TokenUpdateSpecs extends HapiApiSuite {
 				.given(
 						cryptoCreate("payer")
 				).when().then(
+						tokenUpdate("0.0.0")
+								.payingWith("payer")
+								.signedBy("payer")
+								.hasKnownStatus(INVALID_TOKEN_ID),
 						tokenUpdate("1.2.3")
 								.payingWith("payer")
 								.signedBy("payer")


### PR DESCRIPTION
**Related issue(s)**:
 - Closes #1096

**Summary of the change**:
 - In `HederaTokenStore.exists` and `HederaScheduleStore.exists`, only test id against pending id if `isPendingCreation() == true`.
 - Add various EET specs using id `0.0.0`.
 - Uncomment suppressed `throw` statements in `HapiTxnOp`.