### PR TITLE
Rebuild *Store views upon reconnect

### DIFF
--- a/hedera-node/src/main/java/com/hedera/services/ServicesState.java
+++ b/hedera-node/src/main/java/com/hedera/services/ServicesState.java
@@ -282,14 +282,14 @@ public class ServicesState extends AbstractNaryMerkleInternal implements SwirldS
 		 * All the initialization that follows will be a function of the primitive state. */
 		ctx.update(this);
 		ctx.rebuildBackingStoresIfPresent();
+		ctx.rebuildStoreViewsIfPresent();
 
 		/* Use any payer records stored in state to rebuild the recent transaction
 		 * history. This history has two main uses: Purging expired records, and
 		 * classifying duplicate transactions. */
 		ctx.recordsHistorian().reviewExistingRecords();
 		/*
-		 * Use any entities stored in state to rebuild the history for expired entities.
-		 * This has one main use: purge expired entities.
+		 * Use any entities stored in state to rebuild queue of expired entities.
 		 */
 		ctx.expiries().restartEntitiesTrackingFrom();
 		if (!blobStoreSupplier.get().isInitializing()) {

--- a/hedera-node/src/main/java/com/hedera/services/context/ServicesContext.java
+++ b/hedera-node/src/main/java/com/hedera/services/context/ServicesContext.java
@@ -555,6 +555,15 @@ public class ServicesContext {
 		}
 	}
 
+	public void rebuildStoreViewsIfPresent() {
+		if (scheduleStore != null) {
+			scheduleStore.rebuildViews();
+		}
+		if (tokenStore != null) {
+			tokenStore.rebuildViews();
+		}
+	}
+
 	public SigFactoryCreator sigFactoryCreator() {
 		if (sigFactoryCreator == null) {
 			sigFactoryCreator = new SigFactoryCreator(this::schedules);
@@ -1931,5 +1940,13 @@ public class ServicesContext {
 
 	void setBackingAccounts(FCMapBackingAccounts backingAccounts) {
 		this.backingAccounts = backingAccounts;
+	}
+
+	public void setTokenStore(TokenStore tokenStore) {
+		this.tokenStore = tokenStore;
+	}
+
+	public void setScheduleStore(ScheduleStore scheduleStore) {
+		this.scheduleStore = scheduleStore;
 	}
 }

--- a/hedera-node/src/main/java/com/hedera/services/state/expiry/ExpiryManager.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/expiry/ExpiryManager.java
@@ -88,8 +88,7 @@ public class ExpiryManager {
 	}
 
 	/**
-	 * Invites the expiry manager to build any auxiliary data structures
-	 * later needed to purge expired entities
+	 * Invites the expiry manager to build any auxiliary data structures later needed to purge expired entities.
 	 */
 	public void restartEntitiesTrackingFrom() {
 		entityExpiries.reset();
@@ -99,7 +98,6 @@ public class ExpiryManager {
 			var pair = new Pair<Long, Consumer<EntityId>>(id.getNum(), scheduleStore::expire);
 			expiries.add(new AbstractMap.SimpleImmutableEntry<>(pair, schedule.expiry()));
 		});
-		// todo: add accounts, files, tokens, topics
 
 		var cmp = Comparator
 				.comparing(Map.Entry<Pair<Long, Consumer<EntityId>>, Long>::getValue)

--- a/hedera-node/src/main/java/com/hedera/services/store/Store.java
+++ b/hedera-node/src/main/java/com/hedera/services/store/Store.java
@@ -41,6 +41,10 @@ public interface Store<T, K> {
     void setHederaLedger(HederaLedger ledger);
     void setAccountsLedger(TransactionalLedger<AccountID, AccountProperty, MerkleAccount> accountsLedger);
 
+    default void rebuildViews() {
+        /* No-op. */
+    }
+
     void commitCreation();
     void rollbackCreation();
     boolean isCreationPending();

--- a/hedera-node/src/main/java/com/hedera/services/store/schedule/ContentAddressableSchedule.java
+++ b/hedera-node/src/main/java/com/hedera/services/store/schedule/ContentAddressableSchedule.java
@@ -20,6 +20,7 @@ package com.hedera.services.store.schedule;
  * ‍
  */
 
+import com.google.common.base.MoreObjects;
 import com.google.protobuf.ByteString;
 import com.hedera.services.state.merkle.MerkleSchedule;
 import com.hedera.services.state.submerkle.EntityId;

--- a/hedera-node/src/main/java/com/hedera/services/store/schedule/ContentAddressableSchedule.java
+++ b/hedera-node/src/main/java/com/hedera/services/store/schedule/ContentAddressableSchedule.java
@@ -20,7 +20,6 @@ package com.hedera.services.store.schedule;
  * ‍
  */
 
-import com.google.common.base.MoreObjects;
 import com.google.protobuf.ByteString;
 import com.hedera.services.state.merkle.MerkleSchedule;
 import com.hedera.services.state.submerkle.EntityId;

--- a/hedera-node/src/main/java/com/hedera/services/store/tokens/HederaTokenStore.java
+++ b/hedera-node/src/main/java/com/hedera/services/store/tokens/HederaTokenStore.java
@@ -46,8 +46,6 @@ import org.apache.commons.lang3.tuple.Pair;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -105,6 +103,7 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TRANSACTION_RE
  */
 public class HederaTokenStore extends HederaStore implements TokenStore {
 	private static final Logger log = LogManager.getLogger(HederaTokenStore.class);
+
 	static final TokenID NO_PENDING_ID = TokenID.getDefaultInstance();
 
 	static Predicate<Key> REMOVES_ADMIN_KEY = ImmutableKeyUtils::signalsKeyRemoval;
@@ -133,10 +132,18 @@ public class HederaTokenStore extends HederaStore implements TokenStore {
 		this.validator = validator;
 		this.properties = properties;
 		this.tokenRelsLedger = tokenRelsLedger;
+		rebuildViewOfKnownTreasuries();
+	}
 
-		tokens.get().forEach((key, value) -> {
-			addKnownTreasury(value.treasury().toGrpcAccountId(), key.toTokenId());
-		});
+	@Override
+	public void rebuildViews() {
+		knownTreasuries.clear();
+		rebuildViewOfKnownTreasuries();
+	}
+
+	private void rebuildViewOfKnownTreasuries() {
+		tokens.get().forEach((key, value) ->
+				addKnownTreasury(value.treasury().toGrpcAccountId(), key.toTokenId()));
 	}
 
 	@Override
@@ -743,5 +750,9 @@ public class HederaTokenStore extends HederaStore implements TokenStore {
 			return validity;
 		}
 		return exists(tId) ? OK : INVALID_TOKEN_ID;
+	}
+
+	Map<AccountID, Set<TokenID>> getKnownTreasuries() {
+		return knownTreasuries;
 	}
 }

--- a/hedera-node/src/test/java/com/hedera/services/ServicesStateTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/ServicesStateTest.java
@@ -66,8 +66,8 @@ import com.swirlds.common.NodeId;
 import com.swirlds.common.Platform;
 import com.swirlds.common.Transaction;
 import com.swirlds.common.crypto.CryptoFactory;
-import com.swirlds.common.crypto.DigestType;
 import com.swirlds.common.crypto.Cryptography;
+import com.swirlds.common.crypto.DigestType;
 import com.swirlds.common.crypto.Hash;
 import com.swirlds.common.crypto.ImmutableHash;
 import com.swirlds.common.crypto.RunningHash;
@@ -157,7 +157,6 @@ class ServicesStateTest {
 	SystemExits systemExits;
 	SystemFilesManager systemFilesManager;
 	RecordStreamManager recordStreamManager;
-	SigFactoryCreator sigFactoryCreator;
 	Map<TransactionID, TxnIdRecentHistory> txnHistories;
 
 	ServicesState subject;
@@ -369,6 +368,7 @@ class ServicesStateTest {
 		inOrder.verify(ctx).setRecordsInitialHash(EMPTY_HASH);
 		inOrder.verify(ctx).update(subject);
 		inOrder.verify(ctx).rebuildBackingStoresIfPresent();
+		inOrder.verify(ctx).rebuildStoreViewsIfPresent();
 		inOrder.verify(historian).reviewExistingRecords();
 		inOrder.verify(systemFilesManager).loadAllSystemFiles();
 	}

--- a/hedera-node/src/test/java/com/hedera/services/store/tokens/HederaTokenStoreTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/store/tokens/HederaTokenStoreTest.java
@@ -32,9 +32,12 @@ import com.hedera.services.sigs.utils.ImmutableKeyUtils;
 import com.hedera.services.state.merkle.MerkleAccount;
 import com.hedera.services.state.merkle.MerkleAccountTokens;
 import com.hedera.services.state.merkle.MerkleEntityId;
+import com.hedera.services.state.merkle.MerkleSchedule;
 import com.hedera.services.state.merkle.MerkleToken;
 import com.hedera.services.state.merkle.MerkleTokenRelStatus;
 import com.hedera.services.state.submerkle.EntityId;
+import com.hedera.services.state.submerkle.RichInstant;
+import com.hedera.services.store.schedule.ContentAddressableSchedule;
 import com.hedera.test.factories.scenarios.TxnHandlingScenario;
 import com.hedera.test.utils.IdUtils;
 import com.hederahashgraph.api.proto.java.AccountID;
@@ -49,6 +52,7 @@ import com.swirlds.fcmap.FCMap;
 import org.apache.commons.lang3.tuple.Pair;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InOrder;
 import org.mockito.Mockito;
 
@@ -59,6 +63,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
 import static com.hedera.services.ledger.accounts.BackingTokenRels.asTokenRel;
@@ -66,6 +71,7 @@ import static com.hedera.services.ledger.properties.AccountProperty.IS_DELETED;
 import static com.hedera.services.ledger.properties.TokenRelProperty.IS_FROZEN;
 import static com.hedera.services.ledger.properties.TokenRelProperty.IS_KYC_GRANTED;
 import static com.hedera.services.ledger.properties.TokenRelProperty.TOKEN_BALANCE;
+import static com.hedera.services.state.merkle.MerkleEntityId.fromScheduleId;
 import static com.hedera.services.state.merkle.MerkleEntityId.fromTokenId;
 import static com.hedera.test.factories.scenarios.TxnHandlingScenario.COMPLEX_KEY_ACCOUNT_KT;
 import static com.hedera.test.factories.scenarios.TxnHandlingScenario.MISC_ACCOUNT_KT;
@@ -103,6 +109,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentCaptor.forClass;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.argThat;
@@ -114,6 +121,7 @@ import static org.mockito.BDDMockito.verify;
 import static org.mockito.BDDMockito.willCallRealMethod;
 import static org.mockito.BDDMockito.willThrow;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
 
 class HederaTokenStoreTest {
 	EntityIdSource ids;
@@ -222,6 +230,32 @@ class HederaTokenStoreTest {
 		subject.setAccountsLedger(accountsLedger);
 		subject.setHederaLedger(hederaLedger);
 		subject.knownTreasuries.put(treasury, new HashSet<>() {{ add(misc); }});
+	}
+
+	@Test
+	void rebuildsAsExpected() {
+		// setup:
+		ArgumentCaptor<BiConsumer<MerkleEntityId, MerkleToken>> captor = forClass(BiConsumer.class);
+		// and:
+		subject.getKnownTreasuries().put(treasury, Set.of(anotherMisc));
+
+		// when:
+		subject.rebuildViews();
+
+		// then:
+		verify(tokens, times(2)).forEach(captor.capture());
+		// and:
+		BiConsumer<MerkleEntityId,  MerkleToken> visitor = captor.getAllValues().get(1);
+
+		// and when:
+		visitor.accept(fromTokenId(misc), token);
+
+		// then:
+		var extant = subject.getKnownTreasuries();
+		assertEquals(1, extant.size());
+		// and:
+		assertTrue(extant.containsKey(treasury));
+		assertEquals(extant.get(treasury), Set.of(misc));
 	}
 
 	@Test


### PR DESCRIPTION
**Related issue(s)**:
- Closes #1105
- Closes #1107

**Summary of the change**:
- Add a `Store.rebuildViews()` method.
- Add a `ServicesContext.rebuildStoreViewsIfPresent()` method to be called from `ServicesState.initializeContext()`; dispatch `tokenStore.rebuildViews()` and `scheduleStore.rebuildViews()` from there.
- In `HederaTokenStore`, rebuild the `Map<AccountID, Set<TokenID>>` view of known treasuries.
- In `HederaScheduleStore`, rebuild the `Map<ContentAddressableSchedule, ScheduleID>` view of existing scheduled txns.