### PR TITLE
Add scheduled txn id in receipts of ScheduleCreate, ScheduleSign

### DIFF
--- a/hapi-fees/src/main/java/com/hedera/services/usage/schedule/ScheduleGetInfoUsage.java
+++ b/hapi-fees/src/main/java/com/hedera/services/usage/schedule/ScheduleGetInfoUsage.java
@@ -25,16 +25,15 @@ import com.hedera.services.usage.QueryUsage;
 import com.hederahashgraph.api.proto.java.Key;
 import com.hederahashgraph.api.proto.java.KeyList;
 import com.hederahashgraph.api.proto.java.Query;
+import com.hederahashgraph.api.proto.java.TransactionID;
 import com.hederahashgraph.fee.FeeBuilder;
 
-import java.util.List;
 import java.util.Optional;
 
 import static com.hedera.services.usage.schedule.entities.ScheduleEntitySizes.SCHEDULE_ENTITY_SIZES;
 import static com.hederahashgraph.fee.FeeBuilder.BASIC_ENTITY_ID_SIZE;
 
 public class ScheduleGetInfoUsage extends QueryUsage {
-
 	private ScheduleGetInfoUsage(Query query) {
 		super(query.getScheduleGetInfo().getHeader().getResponseType());
 		updateTb(BASIC_ENTITY_ID_SIZE);
@@ -65,4 +64,8 @@ public class ScheduleGetInfoUsage extends QueryUsage {
 		return this;
 	}
 
+	public ScheduleGetInfoUsage givenScheduledTxnId(TransactionID txnId) {
+		this.updateRb(txnId.getSerializedSize());
+		return this;
+	}
 }

--- a/hapi-fees/src/main/java/com/hedera/services/usage/schedule/ScheduleSignUsage.java
+++ b/hapi-fees/src/main/java/com/hedera/services/usage/schedule/ScheduleSignUsage.java
@@ -27,8 +27,11 @@ import com.hederahashgraph.api.proto.java.TransactionBody;
 
 import static com.hedera.services.usage.SingletonEstimatorUtils.ESTIMATOR_UTILS;
 import static com.hederahashgraph.fee.FeeBuilder.BASIC_ENTITY_ID_SIZE;
+import static com.hederahashgraph.fee.FeeBuilder.BASIC_TX_ID_SIZE;
+import static com.hederahashgraph.fee.FeeBuilder.BOOL_SIZE;
 
 public class ScheduleSignUsage extends ScheduleTxnUsage<ScheduleSignUsage> {
+	private int nonceBytes;
 	private long expiry;
 
 	private ScheduleSignUsage(TransactionBody scheduleSignOp, TxnUsageEstimator usageEstimator) {
@@ -41,6 +44,11 @@ public class ScheduleSignUsage extends ScheduleTxnUsage<ScheduleSignUsage> {
 
 	public ScheduleSignUsage givenExpiry(long expiry) {
 		this.expiry = expiry;
+		return self();
+	}
+
+	public ScheduleSignUsage givenNonceBytes(int nonceBytes) {
+		this.nonceBytes = nonceBytes;
 		return self();
 	}
 
@@ -65,6 +73,9 @@ public class ScheduleSignUsage extends ScheduleTxnUsage<ScheduleSignUsage> {
 		usageEstimator.addRbs(ramBytes * lifetime);
 		usageEstimator.addVpt(scheduledTxSigs);
 
+		/* A ScheduleSign record includes the TransactionID of the associated
+		scheduled transaction (which always has scheduled = true). */
+		addNetworkRecordRb(BASIC_TX_ID_SIZE + BOOL_SIZE + nonceBytes);
 		return usageEstimator.get();
 	}
 }

--- a/hapi-fees/src/test/java/com/hedera/services/usage/schedule/ScheduleCreateUsageTest.java
+++ b/hapi-fees/src/test/java/com/hedera/services/usage/schedule/ScheduleCreateUsageTest.java
@@ -43,6 +43,8 @@ import static com.hedera.services.test.UsageUtils.A_USAGES_MATRIX;
 import static com.hedera.services.usage.SingletonUsageProperties.USAGE_PROPERTIES;
 import static com.hedera.services.usage.schedule.entities.ScheduleEntitySizes.SCHEDULE_ENTITY_SIZES;
 import static com.hederahashgraph.fee.FeeBuilder.BASIC_ENTITY_ID_SIZE;
+import static com.hederahashgraph.fee.FeeBuilder.BASIC_TX_ID_SIZE;
+import static com.hederahashgraph.fee.FeeBuilder.BOOL_SIZE;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
@@ -50,13 +52,19 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
 public class ScheduleCreateUsageTest {
-
 	Key adminKey = KeyUtils.A_THRESHOLD_KEY;
-	byte[] transactionBody = new byte[]{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09};
+	byte[] nonce = "abcdefghijklmnop".getBytes();
+	byte[] transactionBody = TransactionBody.newBuilder()
+			.setTransactionID(TransactionID.newBuilder()
+					.setNonce(ByteString.copyFrom(nonce)))
+			.build().toByteArray();
+
 	long now = 1_000L;
 	int scheduledTXExpiry = 1000;
 	AccountID payer = IdUtils.asAccount("0.0.2");
 	String memo = "Just some memo!";
+
+	int scheduledTxnIdSize = BASIC_TX_ID_SIZE + BOOL_SIZE + nonce.length;
 
 	int numSigs = 3, sigSize = 100, numPayerKeys = 1;
 	SigUsage sigUsage = new SigUsage(numSigs, sigSize, numPayerKeys);
@@ -113,7 +121,8 @@ public class ScheduleCreateUsageTest {
 		verify(base).addBpt(expectedTxBytes);
 		verify(base).addRbs(expectedRamBytes * scheduledTXExpiry);
 		verify(base).addVpt(0);
-		verify(base).addNetworkRbs(BASIC_ENTITY_ID_SIZE * USAGE_PROPERTIES.legacyReceiptStorageSecs());
+		verify(base).addNetworkRbs(
+				(BASIC_ENTITY_ID_SIZE + scheduledTxnIdSize) * USAGE_PROPERTIES.legacyReceiptStorageSecs());
 	}
 
 	@Test
@@ -136,7 +145,8 @@ public class ScheduleCreateUsageTest {
 		verify(base).addBpt(expectedTxBytes);
 		verify(base).addRbs(expectedRamBytes * scheduledTXExpiry);
 		verify(base).addVpt(0);
-		verify(base).addNetworkRbs(BASIC_ENTITY_ID_SIZE * USAGE_PROPERTIES.legacyReceiptStorageSecs());
+		verify(base).addNetworkRbs(
+				(BASIC_ENTITY_ID_SIZE + scheduledTxnIdSize) * USAGE_PROPERTIES.legacyReceiptStorageSecs());
 	}
 
 	@Test
@@ -159,7 +169,8 @@ public class ScheduleCreateUsageTest {
 		verify(base).addBpt(expectedTxBytes);
 		verify(base).addRbs(expectedRamBytes * scheduledTXExpiry);
 		verify(base).addVpt(0);
-		verify(base).addNetworkRbs(BASIC_ENTITY_ID_SIZE * USAGE_PROPERTIES.legacyReceiptStorageSecs());
+		verify(base).addNetworkRbs(
+				(BASIC_ENTITY_ID_SIZE + scheduledTxnIdSize) * USAGE_PROPERTIES.legacyReceiptStorageSecs());
 	}
 
 	@Test
@@ -182,7 +193,8 @@ public class ScheduleCreateUsageTest {
 		verify(base).addBpt(expectedTxBytes);
 		verify(base).addRbs(expectedRamBytes * scheduledTXExpiry);
 		verify(base).addVpt(0);
-		verify(base).addNetworkRbs(BASIC_ENTITY_ID_SIZE * USAGE_PROPERTIES.legacyReceiptStorageSecs());
+		verify(base).addNetworkRbs(
+				(BASIC_ENTITY_ID_SIZE + scheduledTxnIdSize) * USAGE_PROPERTIES.legacyReceiptStorageSecs());
 	}
 
 	@Test
@@ -205,7 +217,8 @@ public class ScheduleCreateUsageTest {
 		verify(base).addBpt(expectedTxBytes);
 		verify(base).addRbs(expectedRamBytes * scheduledTXExpiry);
 		verify(base).addVpt(sigMap.getSigPairCount());
-		verify(base).addNetworkRbs(BASIC_ENTITY_ID_SIZE * USAGE_PROPERTIES.legacyReceiptStorageSecs());
+		verify(base).addNetworkRbs(
+				(BASIC_ENTITY_ID_SIZE + scheduledTxnIdSize) * USAGE_PROPERTIES.legacyReceiptStorageSecs());
 	}
 
 	private long baseRamBytes() {

--- a/hapi-fees/src/test/java/com/hedera/services/usage/schedule/ScheduleGetInfoUsageTest.java
+++ b/hapi-fees/src/test/java/com/hedera/services/usage/schedule/ScheduleGetInfoUsageTest.java
@@ -28,6 +28,7 @@ import com.hederahashgraph.api.proto.java.KeyList;
 import com.hederahashgraph.api.proto.java.Query;
 import com.hederahashgraph.api.proto.java.ScheduleGetInfoQuery;
 import com.hederahashgraph.api.proto.java.ScheduleID;
+import com.hederahashgraph.api.proto.java.TransactionID;
 import com.hederahashgraph.fee.FeeBuilder;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -40,7 +41,11 @@ import static com.hederahashgraph.fee.FeeBuilder.BASIC_QUERY_RES_HEADER;
 import static org.junit.Assert.assertEquals;
 
 public class ScheduleGetInfoUsageTest {
-
+	TransactionID scheduledTxnId = TransactionID.newBuilder()
+			.setScheduled(true)
+			.setAccountID(IdUtils.asAccount("0.0.2"))
+			.setNonce(ByteString.copyFromUtf8("Something something something"))
+			.build();
 	Optional<Key> adminKey = Optional.of(KeyUtils.A_COMPLEX_KEY);
 	Optional<KeyList> signers = Optional.of(KeyUtils.DUMMY_KEY_LIST);
 	ScheduleID id = IdUtils.asSchedule("0.0.1");
@@ -59,14 +64,17 @@ public class ScheduleGetInfoUsageTest {
 		subject.givenCurrentAdminKey(adminKey)
 				.givenSignatories(signers)
 				.givenTransaction(transactionBody)
-				.givenMemo(memo);
-
+				.givenMemo(memo)
+				.givenScheduledTxnId(scheduledTxnId);
 
 		// and:
 		var expectedAdminBytes = FeeBuilder.getAccountKeyStorageSize(adminKey.get());
 		var signersBytes = signers.get().toByteArray().length;
 		var expectedBytes = BASIC_QUERY_RES_HEADER
-				+ expectedAdminBytes + signersBytes + SCHEDULE_ENTITY_SIZES.bytesInBaseReprGiven(transactionBody, memo);
+				+ scheduledTxnId.toByteArray().length
+				+ expectedAdminBytes
+				+ signersBytes
+				+ SCHEDULE_ENTITY_SIZES.bytesInBaseReprGiven(transactionBody, memo);
 
 		// when:
 		var usage = subject.get();

--- a/hapi-fees/src/test/java/com/hedera/services/usage/schedule/ScheduleSignUsageTest.java
+++ b/hapi-fees/src/test/java/com/hedera/services/usage/schedule/ScheduleSignUsageTest.java
@@ -37,8 +37,11 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static com.hedera.services.test.UsageUtils.A_USAGES_MATRIX;
+import static com.hedera.services.usage.SingletonUsageProperties.USAGE_PROPERTIES;
 import static com.hedera.services.usage.schedule.entities.ScheduleEntitySizes.SCHEDULE_ENTITY_SIZES;
 import static com.hederahashgraph.fee.FeeBuilder.BASIC_ENTITY_ID_SIZE;
+import static com.hederahashgraph.fee.FeeBuilder.BASIC_TX_ID_SIZE;
+import static com.hederahashgraph.fee.FeeBuilder.BOOL_SIZE;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
@@ -46,7 +49,8 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
 public class ScheduleSignUsageTest {
-
+	int nonceBytes = 32;
+	int scheduledTxnIdSize = BASIC_TX_ID_SIZE + BOOL_SIZE + nonceBytes;
 	long now = 1_000L;
 	long scheduledTXExpiry = 2_700;
 	ScheduleID scheduleID = IdUtils.asSchedule("0.0.1");
@@ -86,6 +90,7 @@ public class ScheduleSignUsageTest {
 
 		// and:
 		subject = ScheduleSignUsage.newEstimate(txn, sigUsage)
+				.givenNonceBytes(nonceBytes)
 				.givenExpiry(scheduledTXExpiry);
 
 		// when:
@@ -97,6 +102,7 @@ public class ScheduleSignUsageTest {
 		verify(base).addBpt(expectedTxBytes);
 		verify(base).addRbs(0L);
 		verify(base).addVpt(0);
+		verify(base).addNetworkRbs(scheduledTxnIdSize * USAGE_PROPERTIES.legacyReceiptStorageSecs());
 	}
 
 	@Test
@@ -108,6 +114,7 @@ public class ScheduleSignUsageTest {
 
 		// and:
 		subject = ScheduleSignUsage.newEstimate(txn, sigUsage)
+				.givenNonceBytes(nonceBytes)
 				.givenExpiry(scheduledTXExpiry);
 
 		// when:
@@ -119,6 +126,7 @@ public class ScheduleSignUsageTest {
 		verify(base).addBpt(expectedTxBytes);
 		verify(base).addRbs(expectedRamBytes * (scheduledTXExpiry - now));
 		verify(base).addVpt(sigMap.getSigPairCount());
+		verify(base).addNetworkRbs(scheduledTxnIdSize * USAGE_PROPERTIES.legacyReceiptStorageSecs());
 	}
 
 	private void givenBaseOp() {

--- a/hedera-node/pom.xml
+++ b/hedera-node/pom.xml
@@ -28,7 +28,7 @@
 
     <commons-io.version>2.1</commons-io.version>
     <ethereum-core.version>1.12.0-v0.5.0</ethereum-core.version>
-    <swirlds.version>0.9.0-alpha.3</swirlds.version>
+    <swirlds.version>0.9.0</swirlds.version>
   </properties>
 
   <build>

--- a/hedera-node/src/main/java/com/hedera/services/context/AwareTransactionContext.java
+++ b/hedera-node/src/main/java/com/hedera/services/context/AwareTransactionContext.java
@@ -38,6 +38,7 @@ import com.hederahashgraph.api.proto.java.Timestamp;
 import com.hederahashgraph.api.proto.java.TokenID;
 import com.hederahashgraph.api.proto.java.TopicID;
 import com.hederahashgraph.api.proto.java.Transaction;
+import com.hederahashgraph.api.proto.java.TransactionID;
 import com.hederahashgraph.api.proto.java.TransactionReceipt;
 import com.hederahashgraph.api.proto.java.TransactionRecord;
 import com.hederahashgraph.api.proto.java.TransferList;
@@ -258,6 +259,11 @@ public class AwareTransactionContext implements TransactionContext {
 	@Override
 	public void setCreated(ScheduleID id) {
 		receiptConfig = receipt -> receipt.setScheduleID(id);
+	}
+
+	@Override
+	public void setScheduledTxnId(TransactionID txnId) {
+		receiptConfig = receiptConfig.andThen(receipt -> receipt.setScheduledTransactionID(txnId));
 	}
 
 	@Override

--- a/hedera-node/src/main/java/com/hedera/services/context/ServicesContext.java
+++ b/hedera-node/src/main/java/com/hedera/services/context/ServicesContext.java
@@ -942,7 +942,7 @@ public class ServicesContext {
 				/* Schedule */
 				entry(ScheduleCreate, List.of(new ScheduleCreateResourceUsage(globalDynamicProperties()))),
 				entry(ScheduleDelete, List.of(new ScheduleDeleteResourceUsage())),
-				entry(ScheduleSign, List.of(new ScheduleSignResourceUsage())),
+				entry(ScheduleSign, List.of(new ScheduleSignResourceUsage(globalDynamicProperties()))),
 				/* System */
 				entry(Freeze, List.of(new FreezeResourceUsage())),
 				entry(SystemDelete, List.of(new SystemDeleteFileResourceUsage(fileFees))),

--- a/hedera-node/src/main/java/com/hedera/services/context/TransactionContext.java
+++ b/hedera-node/src/main/java/com/hedera/services/context/TransactionContext.java
@@ -31,6 +31,7 @@ import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
 import com.hederahashgraph.api.proto.java.ScheduleID;
 import com.hederahashgraph.api.proto.java.TokenID;
 import com.hederahashgraph.api.proto.java.TopicID;
+import com.hederahashgraph.api.proto.java.TransactionID;
 import com.hederahashgraph.api.proto.java.TransactionRecord;
 import com.hederahashgraph.api.proto.java.TransferList;
 
@@ -185,15 +186,22 @@ public interface TransactionContext {
 	/**
 	 * Record that the current transaction created a scheduled transaction.
 	 *
-	 * @param id the created scheduled transaction.
+	 * @param id the created scheduled transaction
 	 */
 	void setCreated(ScheduleID id);
+
+	/**
+	 * Record that the current transaction references a particular scheduled transaction.
+	 *
+	 * @param txnId the id of the referenced scheduled transaction
+	 */
+	void setScheduledTxnId(TransactionID txnId);
 
 	/**
 	 * Record that the current transaction called a smart contract with
 	 * a specified result.
 	 *
-	 * @param result the result of the contract call.
+	 * @param result the result of the contract call
 	 */
 	void setCallResult(ContractFunctionResult result);
 

--- a/hedera-node/src/main/java/com/hedera/services/context/primitives/StateView.java
+++ b/hedera-node/src/main/java/com/hedera/services/context/primitives/StateView.java
@@ -295,6 +295,7 @@ public class StateView {
 
 			var info = ScheduleInfo.newBuilder()
 					.setScheduleID(id)
+					.setScheduledTransactionID(schedule.scheduledTransactionId())
 					.setTransactionBody(ByteString.copyFrom(schedule.transactionBody()))
 					.setCreatorAccountID(schedule.schedulingAccount().toGrpcAccountId())
 					.setPayerAccountID(schedule.payer().toGrpcAccountId())

--- a/hedera-node/src/main/java/com/hedera/services/fees/calculation/schedule/queries/GetScheduleInfoResourceUsage.java
+++ b/hedera-node/src/main/java/com/hedera/services/fees/calculation/schedule/queries/GetScheduleInfoResourceUsage.java
@@ -73,6 +73,7 @@ public class GetScheduleInfoResourceUsage implements QueryResourceUsageEstimator
 			var info = optionalInfo.get();
 			queryCtx.ifPresent(ctx -> ctx.put(SCHEDULE_INFO_CTX_KEY, info));
 			var estimate = factory.apply(query)
+					.givenScheduledTxnId(info.getScheduledTransactionID())
 					.givenTransaction(info.getTransactionBody().toByteArray())
 					.givenMemo(info.getMemoBytes())
 					.givenSignatories(ifPresent(info, ScheduleInfo::hasSignatories, ScheduleInfo::getSignatories))

--- a/hedera-node/src/main/java/com/hedera/services/legacy/core/jproto/TxnReceipt.java
+++ b/hedera-node/src/main/java/com/hedera/services/legacy/core/jproto/TxnReceipt.java
@@ -64,56 +64,6 @@ public class TxnReceipt implements SelfSerializable {
 	static final long RUNTIME_CONSTRUCTABLE_ID = 0x65ef569a77dcf125L;
 
 	static DomainSerdes serdes = new DomainSerdes();
-	static EntityId.Provider legacyIdProvider = EntityId.LEGACY_PROVIDER;
-	static ExchangeRates.Provider legacyRatesProvider = ExchangeRates.LEGACY_PROVIDER;
-	public static final TxnReceipt.Provider LEGACY_PROVIDER = new TxnReceipt.Provider();
-
-	@Deprecated
-	public static class Provider {
-		private static final long VERSION_WITHOUT_FINAL_RUNNING_HASH = 3;
-
-		public TxnReceipt deserialize(DataInputStream in) throws IOException {
-			var receipt = new TxnReceipt();
-
-			var version = in.readLong();
-			in.readLong();
-			if (in.readBoolean()) {
-				receipt.accountId = legacyIdProvider.deserialize(in);
-			}
-			if (in.readBoolean()) {
-				receipt.fileId = legacyIdProvider.deserialize(in);
-			}
-			if (in.readBoolean()) {
-				receipt.contractId = legacyIdProvider.deserialize(in);
-			}
-			int numStatusBytes = in.readInt();
-			if (numStatusBytes > 0) {
-				byte[] statusBytes = new byte[numStatusBytes];
-				in.readFully(statusBytes);
-				receipt.status = newStringUtf8(statusBytes);
-			}
-			if (in.readBoolean()) {
-				receipt.exchangeRates = legacyRatesProvider.deserialize(in);
-			}
-
-			if (in.readBoolean()) {
-				receipt.topicId = legacyIdProvider.deserialize(in);
-			}
-			if (in.readBoolean()) {
-				receipt.topicSequenceNumber = in.readLong();
-				int numHashBytes = in.readInt();
-				if (numHashBytes > 0) {
-					receipt.topicRunningHash = new byte[numHashBytes];
-					in.readFully(receipt.topicRunningHash);
-				}
-			}
-			if (version != VERSION_WITHOUT_FINAL_RUNNING_HASH) {
-				receipt.runningHashVersion = in.readLong();
-			}
-
-			return receipt;
-		}
-	}
 
 	long runningHashVersion = MISSING_RUNNING_HASH_VERSION;
 	long topicSequenceNumber = MISSING_TOPIC_SEQ_NO;

--- a/hedera-node/src/main/java/com/hedera/services/legacy/core/jproto/TxnReceipt.java
+++ b/hedera-node/src/main/java/com/hedera/services/legacy/core/jproto/TxnReceipt.java
@@ -25,6 +25,7 @@ import com.google.protobuf.ByteString;
 import com.hedera.services.state.serdes.DomainSerdes;
 import com.hedera.services.state.submerkle.EntityId;
 import com.hedera.services.state.submerkle.ExchangeRates;
+import com.hedera.services.state.submerkle.TxnId;
 import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
 import com.hederahashgraph.api.proto.java.TopicID;
 import com.hederahashgraph.api.proto.java.TransactionReceipt;
@@ -37,13 +38,11 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import javax.annotation.Nullable;
-import java.io.DataInputStream;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Objects;
 
 import static com.swirlds.common.CommonUtils.getNormalisedStringFromBytes;
-import static org.apache.commons.codec.binary.StringUtils.newStringUtf8;
 
 public class TxnReceipt implements SelfSerializable {
 	private static final Logger log = LogManager.getLogger(TxnReceipt.class);
@@ -51,6 +50,7 @@ public class TxnReceipt implements SelfSerializable {
 	private static final int MAX_STATUS_BYTES = 128;
 	private static final int MAX_RUNNING_HASH_BYTES = 1024;
 
+	static final TxnId MISSING_SCHEDULED_TXN_ID = null;
 	static final byte[] MISSING_RUNNING_HASH = null;
 	static final long MISSING_TOPIC_SEQ_NO = 0L;
 	static final long MISSING_RUNNING_HASH_VERSION = 0L;
@@ -60,7 +60,8 @@ public class TxnReceipt implements SelfSerializable {
 	static final int RELEASE_090_VERSION = 3;
 	static final int RELEASE_0100_VERSION = 4;
 	static final int RELEASE_0110_VERSION = 5;
-	static final int MERKLE_VERSION = RELEASE_0110_VERSION;
+	static final int RELEASE_0120_VERSION = 6;
+	static final int MERKLE_VERSION = RELEASE_0120_VERSION;
 	static final long RUNTIME_CONSTRUCTABLE_ID = 0x65ef569a77dcf125L;
 
 	static DomainSerdes serdes = new DomainSerdes();
@@ -68,6 +69,7 @@ public class TxnReceipt implements SelfSerializable {
 	long runningHashVersion = MISSING_RUNNING_HASH_VERSION;
 	long topicSequenceNumber = MISSING_TOPIC_SEQ_NO;
 	byte[] topicRunningHash = MISSING_RUNNING_HASH;
+	TxnId scheduledTxnId = MISSING_SCHEDULED_TXN_ID;
 	String status;
 	EntityId accountId;
 	EntityId fileId;
@@ -80,61 +82,7 @@ public class TxnReceipt implements SelfSerializable {
 
 	public TxnReceipt() { }
 
-	public TxnReceipt(
-			@Nullable String status,
-			@Nullable EntityId accountId,
-			@Nullable EntityId fileId,
-			@Nullable EntityId contractId,
-			@Nullable EntityId tokenId,
-			@Nullable EntityId scheduleId,
-			@Nullable ExchangeRates exchangeRates,
-			@Nullable EntityId topicId,
-			long topicSequenceNumber,
-			@Nullable byte[] topicRunningHash
-	) {
-		this(
-				status,
-				accountId,
-				fileId,
-				contractId,
-				tokenId,
-				scheduleId,
-				exchangeRates,
-				topicId,
-				topicSequenceNumber,
-				topicRunningHash,
-				MISSING_RUNNING_HASH_VERSION);
-	}
-
-	public TxnReceipt(
-			@Nullable String status,
-			@Nullable EntityId accountId,
-			@Nullable EntityId fileId,
-			@Nullable EntityId contractId,
-			@Nullable EntityId tokenId,
-			@Nullable EntityId scheduleId,
-			@Nullable ExchangeRates exchangeRates,
-			@Nullable EntityId topicId,
-			long topicSequenceNumber,
-			@Nullable byte[] topicRunningHash,
-			long    runningHashVersion
-	) {
-		this(
-				status,
-				accountId,
-				fileId,
-				contractId,
-				tokenId,
-				scheduleId,
-				exchangeRates,
-				topicId,
-				topicSequenceNumber,
-				topicRunningHash,
-				runningHashVersion,
-				RELEASE_070_VERSION);
-	}
-
-	public TxnReceipt(
+	TxnReceipt(
 			@Nullable String status,
 			@Nullable EntityId accountId,
 			@Nullable EntityId fileId,
@@ -146,7 +94,8 @@ public class TxnReceipt implements SelfSerializable {
 			long topicSequenceNumber,
 			@Nullable byte[] topicRunningHash,
 			long runningHashVersion,
-			long newTotalSupply
+			long newTotalSupply,
+			@Nullable TxnId scheduledTxnId
 	) {
 		this.status = status;
 		this.accountId = accountId;
@@ -162,6 +111,7 @@ public class TxnReceipt implements SelfSerializable {
 				: MISSING_RUNNING_HASH;
 		this.runningHashVersion = runningHashVersion;
 		this.newTotalSupply = newTotalSupply;
+		this.scheduledTxnId = scheduledTxnId;
 	}
 
 	/* --- SelfSerializable --- */
@@ -195,6 +145,7 @@ public class TxnReceipt implements SelfSerializable {
 			out.writeByteArray(topicRunningHash);
 		}
 		out.writeLong(newTotalSupply);
+		serdes.writeNullableSerializable(scheduledTxnId, out);
 	}
 
 	@Override
@@ -219,6 +170,9 @@ public class TxnReceipt implements SelfSerializable {
 		}
 		if (version > RELEASE_090_VERSION) {
 			newTotalSupply = in.readLong();
+		}
+		if (version >= RELEASE_0120_VERSION) {
+			scheduledTxnId = serdes.readNullableSerializable(in);
 		}
 	}
 
@@ -270,6 +224,10 @@ public class TxnReceipt implements SelfSerializable {
 		return newTotalSupply;
 	}
 
+	public TxnId getScheduledTxnId() {
+		return scheduledTxnId;
+	}
+
 	/* --- Object --- */
 
 	@Override
@@ -290,7 +248,8 @@ public class TxnReceipt implements SelfSerializable {
 				Objects.equals(tokenId, that.tokenId) &&
 				Objects.equals(topicSequenceNumber, that.topicSequenceNumber) &&
 				Arrays.equals(topicRunningHash, that.topicRunningHash) &&
-				Objects.equals(newTotalSupply, that.newTotalSupply);
+				Objects.equals(newTotalSupply, that.newTotalSupply) &&
+				Objects.equals(scheduledTxnId, that.scheduledTxnId);
 	}
 
 	@Override
@@ -299,7 +258,7 @@ public class TxnReceipt implements SelfSerializable {
 				runningHashVersion, status,
 				accountId, fileId, contractId, topicId, tokenId,
 				topicSequenceNumber, Arrays.hashCode(topicRunningHash),
-				newTotalSupply);
+				newTotalSupply, scheduledTxnId);
 	}
 
 	@Override
@@ -328,6 +287,9 @@ public class TxnReceipt implements SelfSerializable {
 			helper.add("runningHashVersion", runningHashVersion);
 		}
 		helper.add("newTotalTokenSupply", newTotalSupply);
+		if (scheduledTxnId != MISSING_SCHEDULED_TXN_ID) {
+			helper.add("scheduledTxnId", scheduledTxnId);
+		}
 		return helper.toString();
 	}
 
@@ -345,6 +307,10 @@ public class TxnReceipt implements SelfSerializable {
 		EntityId scheduleId = grpc.hasScheduleID() ? EntityId.ofNullableScheduleId(grpc.getScheduleID()) : null;
 		long runningHashVersion = Math.max(MISSING_RUNNING_HASH_VERSION, grpc.getTopicRunningHashVersion());
 		long newTotalSupply = grpc.getNewTotalSupply();
+		TxnId scheduledTxnId = grpc.hasScheduledTransactionID()
+				? TxnId.fromGrpc(grpc.getScheduledTransactionID())
+				: MISSING_SCHEDULED_TXN_ID;
+
 		return new TxnReceipt(
 				status,
 				accountId,
@@ -357,7 +323,8 @@ public class TxnReceipt implements SelfSerializable {
 				grpc.getTopicSequenceNumber(),
 				grpc.getTopicRunningHash().toByteArray(),
 				runningHashVersion,
-				newTotalSupply);
+				newTotalSupply,
+				scheduledTxnId);
 	}
 
 	public TransactionReceipt toGrpc() {
@@ -409,10 +376,68 @@ public class TxnReceipt implements SelfSerializable {
 		if (txReceipt.getRunningHashVersion() != MISSING_RUNNING_HASH_VERSION) {
 			builder.setTopicRunningHashVersion(txReceipt.getRunningHashVersion());
 		}
-		if(txReceipt.getNewTotalSupply() >= 0) {
+		if (txReceipt.getNewTotalSupply() >= 0) {
 			builder.setNewTotalSupply(txReceipt.newTotalSupply);
+		}
+		if (txReceipt.getScheduledTxnId() != MISSING_SCHEDULED_TXN_ID) {
+			builder.setScheduledTransactionID(txReceipt.getScheduledTxnId().toGrpc());
 		}
 		return builder.build();
 	}
 
+	/* These constructors are only used in tests. */
+	TxnReceipt(
+			@Nullable String status,
+			@Nullable EntityId accountId,
+			@Nullable EntityId fileId,
+			@Nullable EntityId contractId,
+			@Nullable EntityId tokenId,
+			@Nullable EntityId scheduleId,
+			@Nullable ExchangeRates exchangeRates,
+			@Nullable EntityId topicId,
+			long topicSequenceNumber,
+			@Nullable byte[] topicRunningHash
+	) {
+		this(
+				status,
+				accountId,
+				fileId,
+				contractId,
+				tokenId,
+				scheduleId,
+				exchangeRates,
+				topicId,
+				topicSequenceNumber,
+				topicRunningHash,
+				MISSING_RUNNING_HASH_VERSION);
+	}
+
+	TxnReceipt(
+			@Nullable String status,
+			@Nullable EntityId accountId,
+			@Nullable EntityId fileId,
+			@Nullable EntityId contractId,
+			@Nullable EntityId tokenId,
+			@Nullable EntityId scheduleId,
+			@Nullable ExchangeRates exchangeRates,
+			@Nullable EntityId topicId,
+			long topicSequenceNumber,
+			@Nullable byte[] topicRunningHash,
+			long    runningHashVersion
+	) {
+		this(
+				status,
+				accountId,
+				fileId,
+				contractId,
+				tokenId,
+				scheduleId,
+				exchangeRates,
+				topicId,
+				topicSequenceNumber,
+				topicRunningHash,
+				runningHashVersion,
+				RELEASE_070_VERSION,
+				MISSING_SCHEDULED_TXN_ID);
+	}
 }

--- a/hedera-node/src/main/java/com/hedera/services/state/merkle/MerkleSchedule.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/merkle/MerkleSchedule.java
@@ -22,10 +22,15 @@ package com.hedera.services.state.merkle;
 
 import com.google.common.base.MoreObjects;
 import com.google.protobuf.ByteString;
+import com.google.protobuf.InvalidProtocolBufferException;
 import com.hedera.services.legacy.core.jproto.JKey;
 import com.hedera.services.state.serdes.DomainSerdes;
 import com.hedera.services.state.submerkle.EntityId;
 import com.hedera.services.state.submerkle.RichInstant;
+import com.hederahashgraph.api.proto.java.SignedTransaction;
+import com.hederahashgraph.api.proto.java.Transaction;
+import com.hederahashgraph.api.proto.java.TransactionBody;
+import com.hederahashgraph.api.proto.java.TransactionID;
 import com.swirlds.common.FCMValue;
 import com.swirlds.common.io.SerializableDataInputStream;
 import com.swirlds.common.io.SerializableDataOutputStream;
@@ -43,219 +48,281 @@ import java.util.concurrent.ConcurrentHashMap;
 
 import static com.google.protobuf.ByteString.copyFrom;
 import static com.hedera.services.legacy.core.jproto.JKey.equalUpToDecodability;
+import static com.hedera.services.utils.MiscUtils.asTimestamp;
 import static com.hedera.services.utils.MiscUtils.describe;
 import static com.swirlds.common.CommonUtils.hex;
 import static java.util.stream.Collectors.toList;
 
 
 public class MerkleSchedule extends AbstractMerkleLeaf implements FCMValue {
-    static final int MERKLE_VERSION = 1;
+	static final int MERKLE_VERSION = 1;
 
-    static final int NUM_ED25519_PUBKEY_BYTES = 32;
-    static final int UPPER_BOUND_MEMO_UTF8_BYTES = 1024;
+	static final int NUM_ED25519_PUBKEY_BYTES = 32;
+	static final int UPPER_BOUND_MEMO_UTF8_BYTES = 1024;
 
-    static final long RUNTIME_CONSTRUCTABLE_ID = 0x8d2b7d9e673285fcL;
-    static DomainSerdes serdes = new DomainSerdes();
+	static final long RUNTIME_CONSTRUCTABLE_ID = 0x8d2b7d9e673285fcL;
+	static DomainSerdes serdes = new DomainSerdes();
 
-    public static final JKey UNUSED_KEY = null;
-    public static final EntityId UNUSED_PAYER = null;
+	public static final JKey UNUSED_KEY = null;
+	public static final EntityId UNUSED_PAYER = null;
 
-    private byte[] transactionBody;
-    private String memo;
-    private JKey adminKey = UNUSED_KEY;
-    private EntityId payer = UNUSED_PAYER;
-    private EntityId schedulingAccount;
-    private RichInstant schedulingTXValidStart;
-    private long expiry;
+	private byte[] grpcTxn;
+	private String memo;
+	private JKey adminKey = UNUSED_KEY;
+	private EntityId payer = UNUSED_PAYER;
+	private EntityId schedulingAccount;
+	private RichInstant schedulingTXValidStart;
+	private long expiry;
 
-    private Set<ByteString> notary = ConcurrentHashMap.newKeySet();
-    private List<byte[]> signatories = new ArrayList<>();
+	private Set<ByteString> notary = ConcurrentHashMap.newKeySet();
+	private List<byte[]> signatories = new ArrayList<>();
 
 
-    public MerkleSchedule() { }
+	public MerkleSchedule() {
+	}
 
-    public MerkleSchedule(
-            byte[] transactionBody,
-            EntityId schedulingAccount,
-            RichInstant schedulingTXValidStart
-    ) {
-        this.transactionBody = transactionBody;
-        this.schedulingAccount = schedulingAccount;
-        this.schedulingTXValidStart = schedulingTXValidStart;
-    }
+	public MerkleSchedule(
+			byte[] transactionBody,
+			EntityId schedulingAccount,
+			RichInstant schedulingTXValidStart
+	) {
+		this.grpcTxn = transactionBody;
+		this.schedulingAccount = schedulingAccount;
+		this.schedulingTXValidStart = schedulingTXValidStart;
+	}
 
-    /* Notary functions */
-    public boolean witnessValidEd25519Signature(byte[] key) {
-    	var usableKey = copyFrom(key);
-    	if (notary.contains(usableKey)) {
-    		return false;
-        } else {
-            signatories.add(key);
-            notary.add(usableKey);
-            return true;
-        }
-    }
+	/* Notary functions */
+	public boolean witnessValidEd25519Signature(byte[] key) {
+		var usableKey = copyFrom(key);
+		if (notary.contains(usableKey)) {
+			return false;
+		} else {
+			signatories.add(key);
+			notary.add(usableKey);
+			return true;
+		}
+	}
 
-    public boolean hasValidEd25519Signature(byte[] key) {
-    	return notary.contains(copyFrom(key));
-    }
+	public Transaction asScheduledTransaction() {
+		var structuredGrpcTxn = uncheckedGrpcTxn();
+		var scheduledTxnId = scheduledTransactionIdFrom(structuredGrpcTxn);
+		return Transaction.newBuilder()
+				.setSignedTransactionBytes(
+						SignedTransaction.newBuilder()
+								.setBodyBytes(
+										TransactionBody.newBuilder()
+												.mergeFrom(structuredGrpcTxn)
+												.setTransactionID(scheduledTxnId)
+												.build()
+												.toByteString())
+								.build()
+								.toByteString())
+				.build();
+	}
 
-    /* Object */
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || MerkleSchedule.class != o.getClass()) {
-            return false;
-        }
+	public TransactionID scheduledTransactionId() {
+		return scheduledTransactionIdFrom(uncheckedGrpcTxn());
+	}
 
-        var that = (MerkleSchedule) o;
-        return this.expiry == that.expiry &&
-                Arrays.areEqual(this.transactionBody, that.transactionBody) &&
-                Objects.equals(this.memo, that.memo) &&
-                Objects.equals(this.payer, that.payer) &&
-                Objects.equals(this.schedulingAccount, that.schedulingAccount) &&
-                Objects.equals(this.schedulingTXValidStart, that.schedulingTXValidStart) &&
-                equalUpToDecodability(this.adminKey, that.adminKey) &&
-                signatoriesAreSame(this.signatories, that.signatories);
-    }
+	private TransactionID scheduledTransactionIdFrom(TransactionBody structuredGrpcTxn) {
+		return TransactionID.newBuilder()
+				.setAccountID(schedulingAccount.toGrpcAccountId())
+				.setTransactionValidStart(asTimestamp(schedulingTXValidStart.toJava()))
+				.setNonce(structuredGrpcTxn.getTransactionID().getNonce())
+				.setScheduled(true)
+				.build();
+	}
 
-    private boolean signatoriesAreSame(List<byte[]> a, List<byte[]> b) {
-        if (a.size() != b.size()) {
-            return false;
-        } else {
-        	for (int i = 0, n = a.size(); i < n; i++) {
-        	    if (!Arrays.areEqual(a.get(i), b.get(i))) {
-        	        return false;
-                }
-            }
-        }
-        return true;
-    }
+	private TransactionBody uncheckedGrpcTxn() {
+		try {
+			return TransactionBody.parseFrom(grpcTxn);
+		} catch (InvalidProtocolBufferException invariantFailure) {
+			throw new IllegalStateException(this + " contained unparseable transaction bytes!", invariantFailure);
+		}
+	}
 
-    @Override
-    public int hashCode() {
-        return Objects.hash(
-                expiry,
-                transactionBody,
-                memo,
-                payer,
-                schedulingAccount,
-                schedulingTXValidStart,
-                adminKey);
-    }
+	public boolean hasValidEd25519Signature(byte[] key) {
+		return notary.contains(copyFrom(key));
+	}
 
-    @Override
-    public String toString() {
-        return MoreObjects.toStringHelper(MerkleSchedule.class)
-                .add("expiry", expiry)
-                .add("transactionBody", hex(transactionBody))
-                .add("memo", memo)
-                .add("payer", readablePayer())
-                .add("schedulingAccount", schedulingAccount)
-                .add("schedulingTXValidStart", schedulingTXValidStart)
-                .add("signatories", signatories.stream().map(Hex::encodeHexString).collect(toList()))
-                .add("adminKey", describe(adminKey))
-                .toString();
-    }
+	/* Object */
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || MerkleSchedule.class != o.getClass()) {
+			return false;
+		}
 
-    private String readablePayer() {
-        return Optional.ofNullable(payer).map(EntityId::toAbbrevString).orElse("<N/A>");
-    }
+		var that = (MerkleSchedule) o;
+		return this.expiry == that.expiry &&
+				Arrays.areEqual(this.grpcTxn, that.grpcTxn) &&
+				Objects.equals(this.memo, that.memo) &&
+				Objects.equals(this.payer, that.payer) &&
+				Objects.equals(this.schedulingAccount, that.schedulingAccount) &&
+				Objects.equals(this.schedulingTXValidStart, that.schedulingTXValidStart) &&
+				equalUpToDecodability(this.adminKey, that.adminKey) &&
+				signatoriesAreSame(this.signatories, that.signatories);
+	}
 
-    @Override
-    public void deserialize(SerializableDataInputStream in, int version) throws IOException {
-        expiry = in.readLong();
-        int txBodyLength = in.readInt();
-        transactionBody = in.readByteArray(txBodyLength);
-        payer = serdes.readNullableSerializable(in);
-        schedulingAccount = in.readSerializable();
-        schedulingTXValidStart = RichInstant.from(in);
-        adminKey = serdes.readNullable(in, serdes::deserializeKey);
-        int numSignatories = in.readInt();
-        while (numSignatories-- > 0) {
-            witnessValidEd25519Signature(in.readByteArray(NUM_ED25519_PUBKEY_BYTES));
-        }
-        memo = serdes.readNullableString(in, UPPER_BOUND_MEMO_UTF8_BYTES);
-    }
+	private boolean signatoriesAreSame(List<byte[]> a, List<byte[]> b) {
+		if (a.size() != b.size()) {
+			return false;
+		} else {
+			for (int i = 0, n = a.size(); i < n; i++) {
+				if (!Arrays.areEqual(a.get(i), b.get(i))) {
+					return false;
+				}
+			}
+		}
+		return true;
+	}
 
-    @Override
-    public void serialize(SerializableDataOutputStream out) throws IOException {
-        out.writeLong(expiry);
-        out.writeInt(transactionBody.length);
-        out.writeByteArray(transactionBody);
-        serdes.writeNullableSerializable(payer, out);
-        out.writeSerializable(schedulingAccount, true);
-        schedulingTXValidStart.serialize(out);
-        serdes.writeNullable(adminKey, out, serdes::serializeKey);
-        out.writeInt(signatories.size());
-        for (byte[] key : signatories) {
-            out.writeByteArray(key);
-        }
-        serdes.writeNullableString(memo, out);
-    }
+	@Override
+	public int hashCode() {
+		return Objects.hash(
+				expiry,
+				grpcTxn,
+				memo,
+				payer,
+				schedulingAccount,
+				schedulingTXValidStart,
+				adminKey);
+	}
 
-    @Override
-    public long getClassId() {
-        return RUNTIME_CONSTRUCTABLE_ID;
-    }
+	@Override
+	public String toString() {
+		return MoreObjects.toStringHelper(MerkleSchedule.class)
+				.add("expiry", expiry)
+				.add("transactionBody", hex(grpcTxn))
+				.add("memo", memo)
+				.add("payer", readablePayer())
+				.add("schedulingAccount", schedulingAccount)
+				.add("schedulingTXValidStart", schedulingTXValidStart)
+				.add("signatories", signatories.stream().map(Hex::encodeHexString).collect(toList()))
+				.add("adminKey", describe(adminKey))
+				.toString();
+	}
 
-    @Override
-    public int getVersion() {
-        return MERKLE_VERSION;
-    }
+	private String readablePayer() {
+		return Optional.ofNullable(payer).map(EntityId::toAbbrevString).orElse("<N/A>");
+	}
 
-    @Override
-    public MerkleSchedule copy() {
-        var fc = new MerkleSchedule(transactionBody, schedulingAccount, schedulingTXValidStart);
+	@Override
+	public void deserialize(SerializableDataInputStream in, int version) throws IOException {
+		expiry = in.readLong();
+		int txBodyLength = in.readInt();
+		grpcTxn = in.readByteArray(txBodyLength);
+		payer = serdes.readNullableSerializable(in);
+		schedulingAccount = in.readSerializable();
+		schedulingTXValidStart = RichInstant.from(in);
+		adminKey = serdes.readNullable(in, serdes::deserializeKey);
+		int numSignatories = in.readInt();
+		while (numSignatories-- > 0) {
+			witnessValidEd25519Signature(in.readByteArray(NUM_ED25519_PUBKEY_BYTES));
+		}
+		memo = serdes.readNullableString(in, UPPER_BOUND_MEMO_UTF8_BYTES);
+	}
 
-        fc.setMemo(memo);
-        fc.setExpiry(expiry);
-        if (payer != UNUSED_PAYER) {
-            fc.setPayer(payer);
-        }
-        if (adminKey != UNUSED_KEY) {
-            fc.setAdminKey(adminKey);
-        }
-        for (byte[] signatory : signatories) {
-            fc.witnessValidEd25519Signature(signatory);
-        }
+	@Override
+	public void serialize(SerializableDataOutputStream out) throws IOException {
+		out.writeLong(expiry);
+		out.writeInt(grpcTxn.length);
+		out.writeByteArray(grpcTxn);
+		serdes.writeNullableSerializable(payer, out);
+		out.writeSerializable(schedulingAccount, true);
+		schedulingTXValidStart.serialize(out);
+		serdes.writeNullable(adminKey, out, serdes::serializeKey);
+		out.writeInt(signatories.size());
+		for (byte[] key : signatories) {
+			out.writeByteArray(key);
+		}
+		serdes.writeNullableString(memo, out);
+	}
 
-        return fc;
-    }
+	@Override
+	public long getClassId() {
+		return RUNTIME_CONSTRUCTABLE_ID;
+	}
 
-    public byte[] transactionBody() { return this.transactionBody; }
+	@Override
+	public int getVersion() {
+		return MERKLE_VERSION;
+	}
 
-    public Optional<String> memo() { return Optional.ofNullable(this.memo); }
+	@Override
+	public MerkleSchedule copy() {
+		var fc = new MerkleSchedule(grpcTxn, schedulingAccount, schedulingTXValidStart);
 
-    public void setMemo(String memo) { this.memo = memo; }
+		fc.setMemo(memo);
+		fc.setExpiry(expiry);
+		if (payer != UNUSED_PAYER) {
+			fc.setPayer(payer);
+		}
+		if (adminKey != UNUSED_KEY) {
+			fc.setAdminKey(adminKey);
+		}
+		for (byte[] signatory : signatories) {
+			fc.witnessValidEd25519Signature(signatory);
+		}
 
-    public boolean hasAdminKey() {
-        return adminKey != UNUSED_KEY;
-    }
+		return fc;
+	}
 
-    public Optional<JKey> adminKey() {
-        return Optional.ofNullable(adminKey);
-    }
+	public byte[] transactionBody() {
+		return this.grpcTxn;
+	}
 
-    public void setAdminKey(JKey adminKey) {
-        this.adminKey = adminKey;
-    }
+	public Optional<String> memo() {
+		return Optional.ofNullable(this.memo);
+	}
 
-    public void setPayer(EntityId payer) { this.payer = payer; }
+	public void setMemo(String memo) {
+		this.memo = memo;
+	}
 
-    public EntityId payer() { return this.payer; }
+	public boolean hasAdminKey() {
+		return adminKey != UNUSED_KEY;
+	}
 
-    public boolean hasPayer() { return payer != UNUSED_PAYER; }
+	public Optional<JKey> adminKey() {
+		return Optional.ofNullable(adminKey);
+	}
 
-    public EntityId schedulingAccount() { return this.schedulingAccount; }
+	public void setAdminKey(JKey adminKey) {
+		this.adminKey = adminKey;
+	}
 
-    public RichInstant schedulingTXValidStart() { return this.schedulingTXValidStart; }
+	public void setPayer(EntityId payer) {
+		this.payer = payer;
+	}
 
-    public List<byte[]> signatories() { return signatories; }
+	public EntityId payer() {
+		return this.payer;
+	}
 
-    public void setExpiry(long expiry) { this.expiry = expiry; }
+	public boolean hasPayer() {
+		return payer != UNUSED_PAYER;
+	}
 
-    public long expiry() { return expiry; }
+	public EntityId schedulingAccount() {
+		return this.schedulingAccount;
+	}
+
+	public RichInstant schedulingTXValidStart() {
+		return this.schedulingTXValidStart;
+	}
+
+	public List<byte[]> signatories() {
+		return signatories;
+	}
+
+	public void setExpiry(long expiry) {
+		this.expiry = expiry;
+	}
+
+	public long expiry() {
+		return expiry;
+	}
 }

--- a/hedera-node/src/main/java/com/hedera/services/state/merkle/MerkleTopic.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/merkle/MerkleTopic.java
@@ -82,7 +82,6 @@ public final class MerkleTopic extends AbstractMerkleLeaf implements FCMValue {
 
 	static TopicSerde topicSerde = new TopicSerde();
 	static DomainSerdes serdes = new DomainSerdes();
-	static EntityId.Provider legacyIdProvider = EntityId.LEGACY_PROVIDER;
 
 	private String memo;
 	private JKey adminKey;

--- a/hedera-node/src/main/java/com/hedera/services/state/submerkle/CurrencyAdjustments.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/submerkle/CurrencyAdjustments.java
@@ -48,34 +48,8 @@ public class CurrencyAdjustments implements SelfSerializable {
 	static final long RUNTIME_CONSTRUCTABLE_ID = 0xd8b06bd46e12a466L;
 
 	static final long[] NO_ADJUSTMENTS = new long[0];
-	static EntityId.Provider legacyIdProvider = EntityId.LEGACY_PROVIDER;
 
 	public static final int MAX_NUM_ADJUSTMENTS = 25;
-	public static final CurrencyAdjustments.Provider LEGACY_PROVIDER = new Provider();
-
-	@Deprecated
-	public static class Provider {
-		public CurrencyAdjustments deserialize(DataInputStream in) throws IOException {
-			var pojo = new CurrencyAdjustments();
-
-			in.readLong();
-			in.readLong();
-
-			int numAdjustments = in.readInt();
-			if (numAdjustments > 0) {
-				pojo.hbars = new long[numAdjustments];
-				pojo.accountIds = new ArrayList<>(numAdjustments);
-				for (int i = 0; i < numAdjustments; i++) {
-					in.readLong();
-					in.readLong();
-					pojo.accountIds.add(legacyIdProvider.deserialize(in));
-					pojo.hbars[i] = in.readLong();
-				}
-			}
-
-			return pojo;
-		}
-	}
 
 	long[] hbars = NO_ADJUSTMENTS;
 	List<EntityId> accountIds = Collections.emptyList();

--- a/hedera-node/src/main/java/com/hedera/services/state/submerkle/EntityId.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/submerkle/EntityId.java
@@ -33,7 +33,6 @@ import com.swirlds.common.io.SerializableDataOutputStream;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import java.io.DataInputStream;
 import java.io.IOException;
 import java.util.Objects;
 
@@ -44,21 +43,10 @@ public class EntityId implements SelfSerializable {
 	static final long RUNTIME_CONSTRUCTABLE_ID = 0xf35ba643324efa37L;
 
 	public static final EntityId MISSING_ENTITY_ID = new EntityId(0, 0, 0);
-	public static final EntityId.Provider LEGACY_PROVIDER = new Provider();
 
 	private long shard;
 	private long realm;
 	private long num;
-
-	@Deprecated
-	public static class Provider {
-		public EntityId deserialize(DataInputStream in) throws IOException {
-			in.readLong();
-			in.readLong();
-
-			return new EntityId(in.readLong(), in.readLong(), in.readLong());
-		}
-	}
 
 	public EntityId() { }
 

--- a/hedera-node/src/main/java/com/hedera/services/state/submerkle/ExchangeRates.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/submerkle/ExchangeRates.java
@@ -39,37 +39,6 @@ public class ExchangeRates implements SelfSerializable {
 	public static final int MERKLE_VERSION = 1;
 	public static final long RUNTIME_CONSTRUCTABLE_ID = 0x5dfb7b68d7473416L;
 
-	public static final ExchangeRates.Provider LEGACY_PROVIDER = new Provider();
-
-	@Deprecated
-	public static class Provider {
-		public ExchangeRates deserialize(DataInputStream in) throws IOException {
-			in.readLong();
-			in.readLong();
-
-			int currHbarEquiv, currCentEquiv, nextHbarEquiv, nextCentEquiv;
-			long currExpiry, nextExpiry;
-
-			in.readBoolean();
-			in.readLong();
-			in.readLong();
-			currHbarEquiv = in.readInt();
-			currCentEquiv = in.readInt();
-			currExpiry = in.readLong();
-
-			in.readBoolean();
-			in.readLong();
-			in.readLong();
-			nextHbarEquiv = in.readInt();
-			nextCentEquiv = in.readInt();
-			nextExpiry = in.readLong();
-
-			return new ExchangeRates(
-					currHbarEquiv, currCentEquiv, currExpiry,
-					nextHbarEquiv, nextCentEquiv, nextExpiry);
-		}
-	}
-
 	private int currHbarEquiv;
 	private int currCentEquiv;
 	private long currExpiry;

--- a/hedera-node/src/main/java/com/hedera/services/state/submerkle/ExpirableTxnRecord.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/submerkle/ExpirableTxnRecord.java
@@ -67,11 +67,6 @@ public class ExpirableTxnRecord implements FCQueueElement<ExpirableTxnRecord> {
 	static final long RUNTIME_CONSTRUCTABLE_ID = 0x8b9ede7ca8d8db93L;
 
 	static DomainSerdes serdes = new DomainSerdes();
-	static TxnId.Provider legacyTxnIdProvider = TxnId.LEGACY_PROVIDER;
-	static TxnReceipt.Provider legacyReceiptProvider = TxnReceipt.LEGACY_PROVIDER;
-	static RichInstant.Provider legacyInstantProvider = RichInstant.LEGACY_PROVIDER;
-	static CurrencyAdjustments.Provider legacyAdjustmentsProvider = CurrencyAdjustments.LEGACY_PROVIDER;
-	static SolidityFnResult.Provider legacyFnResultProvider = SolidityFnResult.LEGACY_PROVIDER;
 
 	private long expiry;
 	private long submittingMember = UNKNOWN_SUBMITTING_MEMBER;

--- a/hedera-node/src/main/java/com/hedera/services/state/submerkle/RichInstant.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/submerkle/RichInstant.java
@@ -37,20 +37,9 @@ public class RichInstant {
 	private static final Logger log = LogManager.getLogger(RichInstant.class);
 
 	public static final RichInstant MISSING_INSTANT = new RichInstant(0L, 0);
-	public static final RichInstant.Provider LEGACY_PROVIDER = new Provider();
 
 	private int nanos;
 	private long seconds;
-
-	@Deprecated
-	public static class Provider {
-		public RichInstant deserialize(DataInputStream in) throws IOException {
-			in.readLong();
-			in.readLong();
-
-			return new RichInstant(in.readLong(), in.readInt());
-		}
-	}
 
 	public RichInstant() { }
 

--- a/hedera-node/src/main/java/com/hedera/services/state/submerkle/SolidityFnResult.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/submerkle/SolidityFnResult.java
@@ -51,14 +51,11 @@ public class SolidityFnResult implements SelfSerializable {
 	static final long RUNTIME_CONSTRUCTABLE_ID = 0x2055c5c03ff84eb4L;
 
 	static DomainSerdes serdes = new DomainSerdes();
-	static EntityId.Provider legacyIdProvider = EntityId.LEGACY_PROVIDER;
-	static SolidityLog.Provider legacyLogProvider = SolidityLog.LEGACY_PROVIDER;
 
 	public static final int MAX_LOGS = 1_024;
 	public static final int MAX_CREATED_IDS = 32;
 	public static final int MAX_ERROR_BYTES = 1_024;
 	public static final int MAX_RESULT_BYTES = 1_024 * 1_024;
-	public static final Provider LEGACY_PROVIDER = new Provider();
 
 	private long gasUsed;
 	private byte[] bloom = MISSING_BYTES;
@@ -67,57 +64,6 @@ public class SolidityFnResult implements SelfSerializable {
 	private EntityId contractId;
 	private List<EntityId> createdContractIds = new ArrayList<>();
 	private List<SolidityLog> logs = new ArrayList<>();
-
-	@Deprecated
-	public static class Provider {
-		private static final long VERSION_WITH_CREATED_IDS = 3L;
-
-		public SolidityFnResult deserialize(DataInputStream in) throws IOException {
-			var fnResult = new SolidityFnResult();
-
-			var version = in.readLong();
-			in.readLong();
-
-			if (in.readBoolean()) {
-				fnResult.contractId = legacyIdProvider.deserialize(in);
-			}
-
-			int numResultBytes = in.readInt();
-			if (numResultBytes > 0) {
-				fnResult.result = new byte[numResultBytes];
-				in.readFully(fnResult.result);
-			}
-
-			int numErrorBytes = in.readInt();
-			if (numErrorBytes > 0) {
-				byte[] errorBytes = new byte[numErrorBytes];
-				in.readFully(errorBytes);
-				fnResult.error = StringUtils.newStringUtf8(errorBytes);
-			}
-
-			int numBloomBytes = in.readInt();
-			if (numBloomBytes > 0) {
-				fnResult.bloom = new byte[numBloomBytes];
-				in.readFully(fnResult.bloom);
-			}
-
-			fnResult.gasUsed = in.readLong();
-
-			int numLogs = in.readInt();
-			for (int i = 0; i < numLogs; i++) {
-				fnResult.logs.add(legacyLogProvider.deserialize(in));
-			}
-
-			if (version == VERSION_WITH_CREATED_IDS) {
-				int numCreatedContracts = in.readInt();
-				for (int i = 0; i < numCreatedContracts; i++) {
-					fnResult.createdContractIds.add(legacyIdProvider.deserialize(in));
-				}
-			}
-
-			return fnResult;
-		}
-	}
 
 	public SolidityFnResult() { }
 

--- a/hedera-node/src/main/java/com/hedera/services/state/submerkle/SolidityLog.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/submerkle/SolidityLog.java
@@ -52,54 +52,10 @@ public class SolidityLog implements SelfSerializable {
 	private List<byte[]> topics = Collections.emptyList();
 
 	static DomainSerdes serdes = new DomainSerdes();
-	static EntityId.Provider legacyIdProvider = EntityId.LEGACY_PROVIDER;
 
 	public static final int MAX_DATA_BYTES = 32 * 1024;
 	public static final int MAX_BLOOM_BYTES = 256;
 	public static final int MAX_TOPIC_BYTES = 1024;
-
-	public static final Provider LEGACY_PROVIDER = new Provider();
-
-	@Deprecated
-	public static class Provider {
-		public SolidityLog deserialize(DataInputStream in) throws IOException {
-			var log = new SolidityLog();
-
-			in.readLong();
-			in.readLong();
-			if (in.readBoolean()) {
-				log.contractId = legacyIdProvider.deserialize(in);
-			}
-
-			int numBloomBytes = in.readInt();
-			if (numBloomBytes > 0) {
-				log.bloom = new byte[numBloomBytes];
-				in.readFully(log.bloom);
-			}
-
-			int numDataBytes = in.readInt();
-			if (numDataBytes > 0) {
-				log.data = new byte[numDataBytes];
-				in.readFully(log.data);
-			}
-
-			int numTopics = in.readInt();
-			if (numTopics > 0) {
-				log.topics = new LinkedList<>();
-				for (int i = 0; i < numTopics; i++) {
-					int numTopicBytes = in.readInt();
-					if (numTopicBytes > 0) {
-						byte[] topic = new byte[numTopicBytes];
-						in.readFully(topic);
-						log.topics.add(topic);
-					} else {
-						log.topics.add(MISSING_BYTES);
-					}
-				}
-			}
-			return log;
-		}
-	}
 
 	public SolidityLog() { }
 

--- a/hedera-node/src/main/java/com/hedera/services/state/submerkle/TxnId.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/submerkle/TxnId.java
@@ -25,7 +25,6 @@ import com.google.protobuf.ByteString;
 import com.hedera.services.state.serdes.DomainSerdes;
 import com.hederahashgraph.api.proto.java.TransactionID;
 
-import java.io.DataInputStream;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Objects;
@@ -37,7 +36,6 @@ import org.apache.commons.codec.binary.Hex;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import static com.hedera.services.legacy.logic.ApplicationConstants.P;
 import static com.hedera.services.state.submerkle.EntityId.MISSING_ENTITY_ID;
 import static com.hedera.services.state.submerkle.EntityId.ofNullableAccountId;
 import static com.hedera.services.state.submerkle.RichInstant.MISSING_INSTANT;
@@ -48,7 +46,7 @@ public class TxnId implements SelfSerializable {
 
 	private static final byte[] ABSENT_NONCE = null;
 
-	public static final int MAX_PERMISSIBLE_NONCE_BYTES = 48;
+	static final int MAX_CONCEIVABLE_NONCE_BYTES = Integer.MAX_VALUE;
 
 	static final int PRE_RELEASE_0120_VERSION = 1;
 	static final int RELEASE_0120_VERSION = 2;
@@ -104,7 +102,7 @@ public class TxnId implements SelfSerializable {
 			scheduled = in.readBoolean();
 			var hasNonce = in.readBoolean();
 			if (hasNonce) {
-				nonce = in.readByteArray(MAX_PERMISSIBLE_NONCE_BYTES);
+				nonce = in.readByteArray(MAX_CONCEIVABLE_NONCE_BYTES);
 			}
 		}
 	}

--- a/hedera-node/src/main/java/com/hedera/services/state/submerkle/TxnId.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/submerkle/TxnId.java
@@ -57,29 +57,6 @@ public class TxnId implements SelfSerializable {
 	public static final long RUNTIME_CONSTRUCTABLE_ID = 0x61a52dfb3a18d9bL;
 
 	static DomainSerdes serdes = new DomainSerdes();
-	static EntityId.Provider legacyIdProvider = EntityId.LEGACY_PROVIDER;
-	static RichInstant.Provider legacyInstantProvider = RichInstant.LEGACY_PROVIDER;
-
-	public static final TxnId.Provider LEGACY_PROVIDER = new TxnId.Provider();
-
-	@Deprecated
-	public static class Provider {
-		public TxnId deserialize(DataInputStream in) throws IOException {
-			var txnId = new TxnId();
-
-			in.readLong();
-			in.readLong();
-
-			if (in.readChar() == P) {
-				txnId.payerAccount = legacyIdProvider.deserialize(in);
-			}
-			if (in.readBoolean()) {
-				txnId.validStart = legacyInstantProvider.deserialize(in);
-			}
-
-			return txnId;
-		}
-	}
 
 	private byte[] nonce = ABSENT_NONCE;
 	private boolean scheduled = false;

--- a/hedera-node/src/main/java/com/hedera/services/txns/schedule/ScheduleSignTransitionLogic.java
+++ b/hedera-node/src/main/java/com/hedera/services/txns/schedule/ScheduleSignTransitionLogic.java
@@ -74,8 +74,12 @@ public class ScheduleSignTransitionLogic extends ScheduleReadyForExecution imple
         var signingOutcome = signingsWitness.observeInScope(numSigs, scheduleId, store, activationHelper);
 
         var outcome = signingOutcome.getLeft();
-        if (outcome == OK && signingOutcome.getRight()) {
-            outcome = executor.doProcess(scheduleId);
+        if (outcome == OK) {
+            var schedule = store.get(scheduleId);
+            txnCtx.setScheduledTxnId(schedule.scheduledTransactionId());
+            if (signingOutcome.getRight()) {
+                outcome = executor.doProcess(scheduleId);
+            }
         }
 		txnCtx.setStatus(outcome == OK ? SUCCESS : outcome);
     }

--- a/hedera-node/src/main/java/com/hedera/services/utils/TriggeredTxnAccessor.java
+++ b/hedera-node/src/main/java/com/hedera/services/utils/TriggeredTxnAccessor.java
@@ -28,7 +28,11 @@ public class TriggeredTxnAccessor extends SignedTxnAccessor {
     private final AccountID payer;
     private final ScheduleID scheduleRef;
 
-    public TriggeredTxnAccessor(byte[] signedTxnBytes, AccountID payer, ScheduleID scheduleRef) throws InvalidProtocolBufferException {
+    public TriggeredTxnAccessor(
+            byte[] signedTxnBytes,
+            AccountID payer,
+            ScheduleID scheduleRef
+    ) throws InvalidProtocolBufferException {
         super(signedTxnBytes);
         this.payer = payer;
         this.scheduleRef = scheduleRef;

--- a/hedera-node/src/main/resources/semantic-version.properties
+++ b/hedera-node/src/main/resources/semantic-version.properties
@@ -1,2 +1,2 @@
-hapi.proto.version=0.12.0
-hedera.services.version=0.12.0
+hapi.proto.version=0.13.0
+hedera.services.version=0.13.0

--- a/hedera-node/src/test/java/com/hedera/services/context/AwareTransactionContextTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/context/AwareTransactionContextTest.java
@@ -30,6 +30,7 @@ import com.hedera.services.state.merkle.MerkleAccount;
 import com.hedera.services.state.merkle.MerkleEntityId;
 import com.hedera.services.state.merkle.MerkleTopic;
 import com.hedera.services.utils.PlatformTxnAccessor;
+import com.hedera.test.utils.IdUtils;
 import com.hederahashgraph.api.proto.java.AccountAmount;
 import com.hederahashgraph.api.proto.java.AccountID;
 import com.hederahashgraph.api.proto.java.ContractFunctionResult;
@@ -78,6 +79,10 @@ import static org.mockito.BDDMockito.mock;
 import static org.mockito.BDDMockito.verify;
 
 public class AwareTransactionContextTest {
+	final TransactionID scheduledTxnId = TransactionID.newBuilder()
+			.setAccountID(IdUtils.asAccount("0.0.2"))
+			.setNonce(ByteString.copyFromUtf8("Something something something"))
+			.build();
 	private long fee = 123L;
 	private long memberId = 3;
 	private long anotherMemberId = 4;
@@ -512,13 +517,16 @@ public class AwareTransactionContextTest {
 	}
 
 	@Test
-	public void getsExpectedReceiptForScheduleCreation() {
+	public void getsExpectedReceiptForSuccessfulScheduleOps() {
 		// when:
 		subject.setCreated(scheduleCreated);
+		subject.setScheduledTxnId(scheduledTxnId);
+		// and:
 		record = subject.recordSoFar();
 
 		// then:
 		assertEquals(scheduleCreated, record.getReceipt().getScheduleID());
+		assertEquals(scheduledTxnId, record.getReceipt().getScheduledTransactionID());
 	}
 
 	@Test

--- a/hedera-node/src/test/java/com/hedera/services/context/primitives/StateViewTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/context/primitives/StateViewTest.java
@@ -48,6 +48,8 @@ import com.hederahashgraph.api.proto.java.TokenFreezeStatus;
 import com.hederahashgraph.api.proto.java.TokenID;
 import com.hederahashgraph.api.proto.java.TokenKycStatus;
 import com.hederahashgraph.api.proto.java.TokenRelationship;
+import com.hederahashgraph.api.proto.java.TransactionBody;
+import com.hederahashgraph.api.proto.java.TransactionID;
 import com.swirlds.fcmap.FCMap;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -118,7 +120,11 @@ class StateViewTest {
 	FCMap<MerkleEntityId, MerkleAccount> contracts;
 	TokenStore tokenStore;
 	ScheduleStore scheduleStore;
-	byte[] scheduleBody = "abc".getBytes();
+	byte[] scheduleBody = TransactionBody.newBuilder()
+					.setTransactionID(TransactionID.newBuilder()
+							.setNonce(ByteString.copyFromUtf8("Surely this isn't taken!")))
+					.build()
+					.toByteArray();
 
 	MerkleToken token;
 	MerkleSchedule schedule;
@@ -306,6 +312,7 @@ class StateViewTest {
 		assertArrayEquals(expectedSignatoryList.build().getKeysList().toArray(), info.getSignatories().getKeysList().toArray());
 		assertEquals(SCHEDULE_ADMIN_KT.asKey(), info.getAdminKey());
 		assertEquals(ByteString.copyFrom(schedule.transactionBody()), info.getTransactionBody());
+		assertEquals(schedule.scheduledTransactionId(), info.getScheduledTransactionID());
 	}
 
 	@Test

--- a/hedera-node/src/test/java/com/hedera/services/fees/calculation/schedule/queries/GetScheduleInfoResourceUsageTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/fees/calculation/schedule/queries/GetScheduleInfoResourceUsageTest.java
@@ -35,6 +35,7 @@ import com.hederahashgraph.api.proto.java.ResponseType;
 import com.hederahashgraph.api.proto.java.ScheduleGetInfoQuery;
 import com.hederahashgraph.api.proto.java.ScheduleID;
 import com.hederahashgraph.api.proto.java.ScheduleInfo;
+import com.hederahashgraph.api.proto.java.TransactionID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -52,6 +53,11 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 public class GetScheduleInfoResourceUsageTest {
+    TransactionID scheduledTxnId = TransactionID.newBuilder()
+            .setScheduled(true)
+            .setAccountID(IdUtils.asAccount("0.0.2"))
+            .setNonce(ByteString.copyFromUtf8("Something something something"))
+            .build();
     ScheduleID target = IdUtils.asSchedule("0.0.123");
 
     Key randomKey = new KeyFactory().newEd25519();
@@ -61,6 +67,7 @@ public class GetScheduleInfoResourceUsageTest {
             .setAdminKey(TxnHandlingScenario.COMPLEX_KEY_ACCOUNT_KT.asKey())
             .setPayerAccountID(TxnHandlingScenario.COMPLEX_KEY_ACCOUNT)
             .setSignatories(KeyList.newBuilder().addKeys(randomKey))
+			.setScheduledTransactionID(scheduledTxnId)
             .build();
 
     StateView view;
@@ -83,6 +90,7 @@ public class GetScheduleInfoResourceUsageTest {
         given(estimator.givenMemo(info.getMemoBytes())).willReturn(estimator);
         given(estimator.givenCurrentAdminKey(any())).willReturn(estimator);
         given(estimator.givenSignatories(any())).willReturn(estimator);
+        given(estimator.givenScheduledTxnId(any())).willReturn(estimator);
         given(estimator.get()).willReturn(expected);
 
         GetScheduleInfoResourceUsage.factory = factory;
@@ -110,6 +118,7 @@ public class GetScheduleInfoResourceUsageTest {
         verify(estimator).givenTransaction(info.getTransactionBody().toByteArray());
         verify(estimator).givenCurrentAdminKey(Optional.of(info.getAdminKey()));
         verify(estimator).givenSignatories(Optional.of(info.getSignatories()));
+        verify(estimator).givenScheduledTxnId(scheduledTxnId);
         assertSame(expected, usage);
     }
 

--- a/hedera-node/src/test/java/com/hedera/services/legacy/core/jproto/TxnReceiptTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/legacy/core/jproto/TxnReceiptTest.java
@@ -21,11 +21,15 @@ package com.hedera.services.legacy.core.jproto;
  */
 
 import com.google.protobuf.ByteString;
+import com.hedera.services.fees.calculation.TxnResourceUsageEstimator;
 import com.hedera.services.state.serdes.DomainSerdes;
 import com.hedera.services.state.submerkle.EntityId;
 import com.hedera.services.state.submerkle.ExchangeRates;
+import com.hedera.services.state.submerkle.TxnId;
+import com.hedera.test.utils.IdUtils;
 import com.hederahashgraph.api.proto.java.TokenID;
 import com.hederahashgraph.api.proto.java.TopicID;
+import com.hederahashgraph.api.proto.java.TransactionID;
 import com.hederahashgraph.api.proto.java.TransactionReceipt;
 import com.swirlds.common.io.SerializableDataInputStream;
 import com.swirlds.common.io.SerializableDataOutputStream;
@@ -51,6 +55,12 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 
 public class TxnReceiptTest {
   private static final int MAX_STATUS_BYTES = 128;
+
+  final TransactionID scheduledTxnId = TransactionID.newBuilder()
+          .setAccountID(IdUtils.asAccount("0.0.2"))
+          .setNonce(ByteString.copyFromUtf8("Something something something"))
+          .build();
+
   DomainSerdes serdes;
   ExchangeRates mockRates;
   TxnReceipt subject;
@@ -130,6 +140,21 @@ public class TxnReceiptTest {
             () -> assertEquals(0L, cut.getTopicSequenceNumber()),
             () -> assertNull(cut.getTopicRunningHash())
     );
+  }
+
+  @Test
+  public void scheduleCreateInterconversionWorks() {
+    final var scheduleId = IdUtils.asSchedule("0.0.123");
+
+    final var receipt = TransactionReceipt.newBuilder()
+            .setExchangeRate(new ExchangeRates().toGrpc())
+			.setScheduleID(scheduleId)
+			.setScheduledTransactionID(scheduledTxnId)
+            .build();
+    final var cut = TxnReceipt.fromGrpc(receipt);
+    final var back = TxnReceipt.convert(cut);
+
+    assertEquals(receipt, back);
   }
 
   @Test
@@ -255,6 +280,18 @@ public class TxnReceiptTest {
   }
 
   @Test
+  public void scheduleConstructor() {
+    final var scheduleId = EntityId.ofNullableScheduleId(IdUtils.asSchedule("0.0.123"));
+    final var cut = new TxnReceipt(
+            "SUCCESS", null, null, null, null, scheduleId, null,
+            null, 0L, TxnReceipt.MISSING_RUNNING_HASH, 0, 0,
+            TxnId.fromGrpc(scheduledTxnId));
+
+    assertAll(() -> Assertions.assertDoesNotThrow(() -> cut.toString()),
+            () -> assertNotNull(cut.toString()));
+  }
+
+  @Test
   public void hcsConstructor() {
     final var topicId = EntityId.ofNullableTopicId(TopicID.newBuilder().setTopicNum(1L).build());
     final var sequenceNumber = 2L;
@@ -290,14 +327,14 @@ public class TxnReceiptTest {
             TokenID.newBuilder().setTokenNum(1001L).setRealmNum(0).setShardNum(0).build());
     final var cut = new TxnReceipt(
             "SUCCESS", null, null, null, tokenId, null, null,
-            null, 0L, null, TxnReceipt.MISSING_RUNNING_HASH_VERSION, 1000L);
+            null, 0L, null, TxnReceipt.MISSING_RUNNING_HASH_VERSION, 1000L,
+            TxnReceipt.MISSING_SCHEDULED_TXN_ID);
 
     assertEquals(1000L, cut.getNewTotalSupply());
 
     assertAll(() -> Assertions.assertDoesNotThrow(() -> cut.toString()),
             () -> assertNotNull(cut.toString()));
   }
-
 
   @Test
   public void serializeWorks() throws IOException {
@@ -308,7 +345,8 @@ public class TxnReceiptTest {
 
     subject = new TxnReceipt("SUCCESS", null, null, null,
             null,null,mockRates,
-            null, -1, null, -1, 100);
+            null, -1, null, -1, 100,
+            TxnId.fromGrpc(scheduledTxnId));
     // when:
     subject.serialize(fout);
 
@@ -318,6 +356,46 @@ public class TxnReceiptTest {
     inOrder.verify(serdes, times(6)).writeNullableSerializable(null, fout);
     inOrder.verify(fout).writeBoolean(false);
     inOrder.verify(fout).writeLong(subject.getNewTotalSupply());
+    inOrder.verify(serdes).writeNullableSerializable(subject.getScheduledTxnId(), fout);
+  }
+
+  @Test
+  public void v0120DeserializeWorks() throws IOException {
+    final var scheduleId = EntityId.ofNullableScheduleId(IdUtils.asSchedule("0.0.312"));
+    SerializableDataInputStream fin = mock(SerializableDataInputStream.class);
+    subject = new TxnReceipt("SUCCESS", null, null, null,
+            null,scheduleId, mockRates,
+            null, -1, null, -1, 0,
+            TxnId.fromGrpc(scheduledTxnId));
+
+    given(fin.readByteArray(MAX_STATUS_BYTES)).willReturn(subject.getStatus().getBytes());
+    given(fin.readSerializable(anyBoolean(), any())).willReturn(mockRates);
+    given(serdes.readNullableSerializable(fin))
+            .willReturn(subject.getAccountId())
+            .willReturn(subject.getFileId())
+            .willReturn(subject.getContractId())
+            .willReturn(subject.getTopicId())
+            .willReturn(subject.getTokenId())
+            .willReturn(subject.getScheduleId())
+            .willReturn(subject.getScheduledTxnId());
+    given(fin.readBoolean()).willReturn(true);
+    given(fin.readLong()).willReturn(subject.getTopicSequenceNumber());
+    given(fin.readLong()).willReturn(subject.getRunningHashVersion());
+    given(fin.readAllBytes()).willReturn(subject.getTopicRunningHash());
+    given(fin.readLong()).willReturn(subject.getNewTotalSupply());
+
+    // and:
+    TxnReceipt txnReceipt = new TxnReceipt();
+
+    // when:
+    txnReceipt.deserialize(fin, TxnReceipt.RELEASE_0120_VERSION);
+
+    // then:
+    assertEquals(subject.getNewTotalSupply(), txnReceipt.getNewTotalSupply());
+    assertEquals(subject.getStatus(), txnReceipt.getStatus());
+    assertEquals(subject.getExchangeRates(), txnReceipt.getExchangeRates());
+    assertEquals(subject.getTokenId(), txnReceipt.getTokenId());
+    assertEquals(subject.getScheduledTxnId(), txnReceipt.getScheduledTxnId());
   }
 
   @Test
@@ -327,7 +405,8 @@ public class TxnReceiptTest {
     SerializableDataInputStream fin = mock(SerializableDataInputStream.class);
     subject = new TxnReceipt("SUCCESS", null, null, null,
             null,tokenId, mockRates,
-            null, -1, null, -1, 100);
+            null, -1, null, -1, 100,
+            TxnReceipt.MISSING_SCHEDULED_TXN_ID);
 
     given(fin.readByteArray(MAX_STATUS_BYTES)).willReturn(subject.getStatus().getBytes());
     given(fin.readSerializable(anyBoolean(), any())).willReturn(mockRates);

--- a/hedera-node/src/test/java/com/hedera/services/legacy/core/jproto/TxnReceiptTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/legacy/core/jproto/TxnReceiptTest.java
@@ -57,6 +57,7 @@ public class TxnReceiptTest {
   private static final int MAX_STATUS_BYTES = 128;
 
   final TransactionID scheduledTxnId = TransactionID.newBuilder()
+		  .setScheduled(true)
           .setAccountID(IdUtils.asAccount("0.0.2"))
           .setNonce(ByteString.copyFromUtf8("Something something something"))
           .build();

--- a/hedera-node/src/test/java/com/hedera/services/state/merkle/MerkleTopicTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/state/merkle/MerkleTopicTest.java
@@ -64,7 +64,6 @@ class MerkleTopicTest {
 	public void cleanup() {
 		MerkleTopic.topicSerde = new TopicSerde();
 		MerkleTopic.serdes = new DomainSerdes();
-		MerkleTopic.legacyIdProvider = EntityId.LEGACY_PROVIDER;
 	}
 
 	@Test

--- a/hedera-node/src/test/java/com/hedera/services/state/submerkle/CurrencyAdjustmentsTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/state/submerkle/CurrencyAdjustmentsTest.java
@@ -42,11 +42,8 @@ import static org.mockito.BDDMockito.*;
 
 class CurrencyAdjustmentsTest {
 	AccountID a = IdUtils.asAccount("0.0.13257");
-	EntityId aEntity = EntityId.ofNullableAccountId(a);
 	AccountID b = IdUtils.asAccount("0.0.13258");
-	EntityId bEntity = EntityId.ofNullableAccountId(b);
 	AccountID c = IdUtils.asAccount("0.0.13259");
-	EntityId cEntity = EntityId.ofNullableAccountId(c);
 
 	long aAmount = 1L, bAmount = 2L, cAmount = -3L;
 
@@ -54,25 +51,16 @@ class CurrencyAdjustmentsTest {
 	TransferList otherGrpcAdjustments = TxnUtils.withAdjustments(a, aAmount * 2, b, bAmount * 2, c, cAmount * 2);
 
 	DataInputStream din;
-	EntityId.Provider idProvider;
 
 	CurrencyAdjustments subject;
 
 	@BeforeEach
 	public void setup() {
 		din = mock(DataInputStream.class);
-		idProvider = mock(EntityId.Provider.class);
-
-		CurrencyAdjustments.legacyIdProvider = idProvider;
 
 		subject = new CurrencyAdjustments();
 		subject.accountIds = List.of(ofNullableAccountId(a), ofNullableAccountId(b), ofNullableAccountId(c));
 		subject.hbars = new long[] { aAmount, bAmount, cAmount };
-	}
-
-	@AfterEach
-	public void cleanup() {
-		CurrencyAdjustments.legacyIdProvider = EntityId.LEGACY_PROVIDER;
 	}
 
 	@Test
@@ -99,26 +87,6 @@ class CurrencyAdjustmentsTest {
 		// and:
 		assertNotEquals(one.hashCode(), two.hashCode());
 		assertEquals(one.hashCode(), three.hashCode());
-	}
-
-	@Test
-	public void legacyProviderWorks() throws IOException {
-		given(din.readLong())
-				.willReturn(-1L).willReturn(-2L)
-				.willReturn(-1L).willReturn(-2L).willReturn(aAmount)
-				.willReturn(-1L).willReturn(-2L).willReturn(bAmount)
-				.willReturn(-1L).willReturn(-2L).willReturn(cAmount);
-		given(din.readInt()).willReturn(3);
-		given(idProvider.deserialize(din))
-				.willReturn(aEntity)
-				.willReturn(bEntity)
-				.willReturn(cEntity);
-
-		// when:
-		var subjectRead = CurrencyAdjustments.LEGACY_PROVIDER.deserialize(din);
-
-		// then:
-		assertEquals(subject, subjectRead);
 	}
 
 	@Test

--- a/hedera-node/src/test/java/com/hedera/services/state/submerkle/EntityIdTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/state/submerkle/EntityIdTest.java
@@ -145,22 +145,6 @@ public class EntityIdTest {
 	}
 
 	@Test
-	public void legacyProviderWorks() throws IOException {
-		given(in.readLong())
-				.willReturn(5L)
-				.willReturn(4L)
-				.willReturn(shard)
-				.willReturn(realm)
-				.willReturn(num);
-
-		// when:
-		var readSubject = EntityId.LEGACY_PROVIDER.deserialize(in);
-
-		// then:
-		assertEquals(subject, readSubject);
-	}
-
-	@Test
 	public void serializableDetWorks() {
 		// expect;
 		assertEquals(EntityId.MERKLE_VERSION, subject.getVersion());

--- a/hedera-node/src/test/java/com/hedera/services/state/submerkle/ExchangeRatesTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/state/submerkle/ExchangeRatesTest.java
@@ -84,24 +84,6 @@ class ExchangeRatesTest {
 	}
 
 	@Test
-	public void legacyProviderWorks() throws IOException {
-		given(din.readBoolean()).willReturn(true);
-		given(din.readLong())
-				.willReturn(-1L).willReturn(-2L)
-				.willReturn(-1L).willReturn(-2L).willReturn(expCurrentExpiry)
-				.willReturn(-1L).willReturn(-2L).willReturn(expNextExpiry);
-		given(din.readInt())
-				.willReturn(expCurrentHbarEquiv).willReturn(expCurrentCentEquiv)
-				.willReturn(expNextHbarEquiv).willReturn(expNextCentEquiv);
-
-		// when:
-		var subjectRead = ExchangeRates.LEGACY_PROVIDER.deserialize(din);
-
-		// then:
-		assertEquals(subject, subjectRead);
-	}
-
-	@Test
 	public void copyWorks() {
 		// given:
 		var subjectCopy = subject.copy();

--- a/hedera-node/src/test/java/com/hedera/services/state/submerkle/ExpirableTxnRecordTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/state/submerkle/ExpirableTxnRecordTest.java
@@ -64,11 +64,6 @@ class ExpirableTxnRecordTest {
 	DataInputStream din;
 
 	DomainSerdes serdes;
-	TxnId.Provider legacyTxnIdProvider;
-	TxnReceipt.Provider legacyReceiptProvider;
-	RichInstant.Provider legacyInstantProvider;
-	CurrencyAdjustments.Provider legacyAdjustmentsProvider;
-	SolidityFnResult.Provider legacyFnResultProvider;
 
 	byte[] pretendHash = "not-really-a-hash".getBytes();
 
@@ -98,17 +93,7 @@ class ExpirableTxnRecordTest {
 		din = mock(DataInputStream.class);
 
 		serdes = mock(DomainSerdes.class);
-		legacyTxnIdProvider = mock(TxnId.Provider.class);
-		legacyReceiptProvider = mock(TxnReceipt.Provider.class);
-		legacyInstantProvider = mock(RichInstant.Provider.class);
-		legacyFnResultProvider = mock(SolidityFnResult.Provider.class);
-		legacyAdjustmentsProvider = mock(CurrencyAdjustments.Provider.class);
 
-		ExpirableTxnRecord.legacyAdjustmentsProvider = legacyAdjustmentsProvider;
-		ExpirableTxnRecord.legacyFnResultProvider = legacyFnResultProvider;
-		ExpirableTxnRecord.legacyInstantProvider = legacyInstantProvider;
-		ExpirableTxnRecord.legacyReceiptProvider = legacyReceiptProvider;
-		ExpirableTxnRecord.legacyTxnIdProvider = legacyTxnIdProvider;
 		ExpirableTxnRecord.serdes = serdes;
 	}
 
@@ -364,11 +349,6 @@ class ExpirableTxnRecordTest {
 
 	@AfterEach
 	public void cleanup() {
-		ExpirableTxnRecord.legacyTxnIdProvider = TxnId.LEGACY_PROVIDER;
-		ExpirableTxnRecord.legacyReceiptProvider = TxnReceipt.LEGACY_PROVIDER;
-		ExpirableTxnRecord.legacyInstantProvider = RichInstant.LEGACY_PROVIDER;
-		ExpirableTxnRecord.legacyAdjustmentsProvider = CurrencyAdjustments.LEGACY_PROVIDER;
-		ExpirableTxnRecord.legacyFnResultProvider = SolidityFnResult.LEGACY_PROVIDER;
 		ExpirableTxnRecord.serdes = new DomainSerdes();
 	}
 }

--- a/hedera-node/src/test/java/com/hedera/services/state/submerkle/RichInstantTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/state/submerkle/RichInstantTest.java
@@ -90,18 +90,6 @@ class RichInstantTest {
 	}
 
 	@Test
-	public void legacyProviderWorks() throws IOException {
-		given(din.readLong()).willReturn(-1L).willReturn(-2L).willReturn(seconds);
-		given(din.readInt()).willReturn(nanos);
-
-		// when:
-		var readSubject = RichInstant.LEGACY_PROVIDER.deserialize(din);
-
-		// expect:
-		assertEquals(subject, readSubject);
-	}
-
-	@Test
 	public void knowsIfMissing() {
 		// expect:
 		assertFalse(subject.isMissing());

--- a/hedera-node/src/test/java/com/hedera/services/state/submerkle/SolidityFnResultTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/state/submerkle/SolidityFnResultTest.java
@@ -68,8 +68,6 @@ class SolidityFnResultTest {
 
 	DomainSerdes serdes;
 	DataInputStream din;
-	EntityId.Provider idProvider;
-	SolidityLog.Provider logProvider;
 	SerializableDataInputStream in;
 
 	SolidityFnResult subject;
@@ -79,8 +77,6 @@ class SolidityFnResultTest {
 		din = mock(DataInputStream.class);
 		in = mock(SerializableDataInputStream.class);
 		serdes = mock(DomainSerdes.class);
-		idProvider = mock(EntityId.Provider.class);
-		logProvider = mock(SolidityLog.Provider.class);
 
 		subject = new SolidityFnResult(
 				contractId,
@@ -92,15 +88,11 @@ class SolidityFnResultTest {
 				createdContractIds);
 
 		SolidityFnResult.serdes = serdes;
-		SolidityFnResult.legacyIdProvider = idProvider;
-		SolidityFnResult.legacyLogProvider = logProvider;
 	}
 
 	@AfterEach
 	public void cleanup() {
 		SolidityFnResult.serdes = new DomainSerdes();
-		SolidityFnResult.legacyIdProvider = EntityId.LEGACY_PROVIDER;
-		SolidityFnResult.legacyLogProvider = SolidityLog.LEGACY_PROVIDER;
 	}
 
 	@Test
@@ -259,51 +251,6 @@ class SolidityFnResultTest {
 		// expect;
 		assertEquals(SolidityFnResult.MERKLE_VERSION, subject.getVersion());
 		assertEquals(SolidityFnResult.RUNTIME_CONSTRUCTABLE_ID, subject.getClassId());
-	}
-
-	@Test
-	public void legacyProviderWorks() throws IOException {
-		// setup:
-		var readCount = new AtomicInteger(0);
-
-		given(din.readLong())
-				.willReturn(3L)
-				.willReturn(2L)
-				.willReturn(gasUsed);
-		given(din.readBoolean())
-				.willReturn(true);
-		given(din.readInt())
-				.willReturn(result.length)
-				.willReturn(error.length())
-				.willReturn(bloom.length)
-				.willReturn(logs.size())
-				.willReturn(createdContractIds.size());
-		given(logProvider.deserialize(din))
-				.willReturn(logs.get(0))
-				.willReturn(logs.get(1));
-		given(idProvider.deserialize(din))
-				.willReturn(contractId)
-				.willReturn(createdContractIds.get(0))
-				.willReturn(createdContractIds.get(1));
-
-		willAnswer(invoke -> {
-			byte[] arg = invoke.getArgument(0);
-			int whichRead = readCount.getAndIncrement();
-			if (whichRead == 0) {
-				System.arraycopy(result, 0, arg, 0, result.length);
-			} else if (whichRead == 1) {
-				System.arraycopy(error.getBytes(), 0, arg, 0, error.length());
-			} else {
-				System.arraycopy(bloom, 0, arg, 0, bloom.length);
-			}
-			return null;
-		}).given(din).readFully(any());
-
-		// when:
-		var readSubject = SolidityFnResult.LEGACY_PROVIDER.deserialize(din);
-
-		// then:
-		assertEquals(subject, readSubject);
 	}
 
 	public static SolidityLog logFrom(int s) {

--- a/hedera-node/src/test/java/com/hedera/services/state/submerkle/TxnIdTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/state/submerkle/TxnIdTest.java
@@ -22,9 +22,6 @@ package com.hedera.services.state.submerkle;
 
 import com.google.protobuf.ByteString;
 import com.hedera.services.state.serdes.DomainSerdes;
-import com.hedera.services.state.submerkle.EntityId;
-import com.hedera.services.state.submerkle.RichInstant;
-import com.hedera.services.state.submerkle.TxnId;
 import com.hedera.test.utils.IdUtils;
 import com.hederahashgraph.api.proto.java.AccountID;
 import com.hederahashgraph.api.proto.java.Timestamp;
@@ -142,7 +139,7 @@ class TxnIdTest {
 		// then:
 		assertEquals(subject, deserializedId);
 		verify(din, never()).readBoolean();
-		verify(din, never()).readByteArray(TxnId.MAX_PERMISSIBLE_NONCE_BYTES);
+		verify(din, never()).readByteArray(TxnId.MAX_CONCEIVABLE_NONCE_BYTES);
 
 		// cleanup:
 		TxnId.serdes = new DomainSerdes();
@@ -188,7 +185,7 @@ class TxnIdTest {
 		given(din.readSerializable(booleanThat(Boolean.TRUE::equals), any(Supplier.class))).willReturn(fcPayer);
 		given(serdes.deserializeTimestamp(din)).willReturn(fcValidStart);
 		given(din.readBoolean()).willReturn(true).willReturn(true);
-		given(din.readByteArray(TxnId.MAX_PERMISSIBLE_NONCE_BYTES)).willReturn(nonce.toByteArray());
+		given(din.readByteArray(TxnId.MAX_CONCEIVABLE_NONCE_BYTES)).willReturn(nonce.toByteArray());
 		// and:
 		var deserializedId = new TxnId();
 

--- a/hedera-node/src/test/java/com/hedera/services/txns/schedule/ScheduleCreateTransitionLogicTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/txns/schedule/ScheduleCreateTransitionLogicTest.java
@@ -80,6 +80,11 @@ public class ScheduleCreateTransitionLogicTest {
 			.setMemo("Just this")
 			.build()
 			.toByteArray();
+	final TransactionID scheduledTxnId = TransactionID.newBuilder()
+			.setAccountID(IdUtils.asAccount("0.0.2"))
+			.setNonce(ByteString.copyFromUtf8("Something something something"))
+			.setScheduled(true)
+			.build();
 
 	private final Optional<ScheduleID> EMPTY_SCHEDULE = Optional.empty();
 	private final Key key = SignedTxnFactory.DEFAULT_PAYER_KT.asKey();
@@ -161,6 +166,7 @@ public class ScheduleCreateTransitionLogicTest {
 	public void followsHappyPath() {
 		// setup:
 		MerkleSchedule created = mock(MerkleSchedule.class);
+		given(created.scheduledTransactionId()).willReturn(scheduledTxnId);
 		given(created.transactionBody()).willReturn(transactionBody);
 		given(created.expiry()).willReturn(now.getEpochSecond());
 
@@ -193,6 +199,7 @@ public class ScheduleCreateTransitionLogicTest {
 		verify(store).commitCreation();
 		verify(txnCtx).addExpiringEntities(any());
 		verify(txnCtx).setStatus(SUCCESS);
+		verify(txnCtx).setScheduledTxnId(scheduledTxnId);
 	}
 
 	@Test

--- a/hedera-node/src/test/java/com/hedera/services/txns/schedule/ScheduleCreateTransitionLogicTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/txns/schedule/ScheduleCreateTransitionLogicTest.java
@@ -41,6 +41,7 @@ import com.hederahashgraph.api.proto.java.ScheduleID;
 import com.hederahashgraph.api.proto.java.SignatureMap;
 import com.hederahashgraph.api.proto.java.SignaturePair;
 import com.hederahashgraph.api.proto.java.Timestamp;
+import com.hederahashgraph.api.proto.java.Transaction;
 import com.hederahashgraph.api.proto.java.TransactionBody;
 import com.hederahashgraph.api.proto.java.TransactionID;
 import net.i2p.crypto.eddsa.EdDSAPublicKey;
@@ -93,7 +94,6 @@ public class ScheduleCreateTransitionLogicTest {
 	private ScheduleReadyForExecution.ExecutionProcessor executor;
 
 	private AccountID payer = IdUtils.asAccount("1.2.3");
-	private AccountID schedulingAccount = IdUtils.asAccount("7.12.5");
 	private ScheduleID schedule = IdUtils.asSchedule("2.4.6");
 	private String entityMemo = "some cool memo?";
 
@@ -131,11 +131,8 @@ public class ScheduleCreateTransitionLogicTest {
 		givenValidTxnCtx();
 		// and:
 		MerkleSchedule created = mock(MerkleSchedule.class);
-		given(created.transactionBody()).willReturn(scheduleCreateTxn.toByteArray());
-		given(created.expiry()).willReturn(now.getEpochSecond());
-		given(created.schedulingTXValidStart()).willReturn(RichInstant.fromJava(now));
-		given(created.schedulingAccount()).willReturn(EntityId.ofNullableAccountId(schedulingAccount));
 		given(created.payer()).willReturn(EntityId.ofNullableAccountId(payer));
+		given(created.asScheduledTransaction()).willReturn(Transaction.getDefaultInstance());
 		given(store.get(schedule)).willReturn(created);
 		// and:
 		given(store.markAsExecuted(schedule)).willReturn(OK);

--- a/hedera-node/src/test/java/com/hedera/services/txns/schedule/ScheduleReadyForExecutionTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/txns/schedule/ScheduleReadyForExecutionTest.java
@@ -1,0 +1,7 @@
+package com.hedera.services.txns.schedule;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ScheduleReadyForExecutionTest {
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -153,7 +153,7 @@
     <grpc.version>1.33.0</grpc.version>
     <jackson-databind.version>2.9.10.7</jackson-databind.version>
     <javax.annotation-api.version>1.3.2</javax.annotation-api.version>
-    <hapi-proto.version>0.12.0-rc.5-SNAPSHOT</hapi-proto.version>
+    <hapi-proto.version>0.13.0-alpha.1</hapi-proto.version>
     <log4j.version>2.13.2</log4j.version>
     <netty.version>4.1.51.Final</netty.version>
     <!-- Test dependency properties -->

--- a/pom.xml
+++ b/pom.xml
@@ -153,7 +153,7 @@
     <grpc.version>1.33.0</grpc.version>
     <jackson-databind.version>2.9.10.7</jackson-databind.version>
     <javax.annotation-api.version>1.3.2</javax.annotation-api.version>
-    <hapi-proto.version>0.12.0-rc.1</hapi-proto.version>
+    <hapi-proto.version>0.12.0-rc.5-SNAPSHOT</hapi-proto.version>
     <log4j.version>2.13.2</log4j.version>
     <netty.version>4.1.51.Final</netty.version>
     <!-- Test dependency properties -->

--- a/test-clients/devops-utils/validation-scenarios/config.yml
+++ b/test-clients/devops-utils/validation-scenarios/config.yml
@@ -83,7 +83,7 @@ networks:
     scenarios:
       sysFilesDown:
         evalMode: snapshot
-        numsToFetch: [121]
+        numsToFetch: [111]
   mainnet:
     bootstrap: 950
     defaultNode: 3
@@ -111,7 +111,7 @@ networks:
         persistent: {contents: MrBleaney.txt, num: 39283}
       sysFilesDown:
         evalMode: snapshot
-        numsToFetch: [121]
+        numsToFetch: [111]
   localhost:
     bootstrap: 2
     defaultNode: 3

--- a/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/meta/HapiGetTxnRecord.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/meta/HapiGetTxnRecord.java
@@ -29,6 +29,7 @@ import com.hedera.services.bdd.spec.assertions.TransactionRecordAsserts;
 import com.hedera.services.bdd.spec.queries.HapiQueryOp;
 import com.hedera.services.bdd.spec.queries.QueryVerbs;
 import com.hedera.services.bdd.spec.transactions.TxnUtils;
+import com.hedera.services.bdd.spec.transactions.schedule.HapiScheduleCreate;
 import com.hedera.services.bdd.spec.utilops.CustomSpecAssert;
 import com.hedera.services.legacy.proto.utils.CommonUtils;
 import com.hederahashgraph.api.proto.java.HederaFunctionality;
@@ -52,6 +53,7 @@ import java.util.function.BiConsumer;
 import static com.hedera.services.bdd.spec.assertions.AssertUtils.rethrowSummaryError;
 import static com.hedera.services.bdd.spec.queries.QueryUtils.answerCostHeader;
 import static com.hedera.services.bdd.spec.queries.QueryUtils.answerHeader;
+import static com.hedera.services.bdd.spec.transactions.schedule.HapiScheduleCreate.correspondingScheduledTxnId;
 import static org.junit.Assert.assertArrayEquals;
 
 public class HapiGetTxnRecord extends HapiQueryOp<HapiGetTxnRecord> {
@@ -62,13 +64,15 @@ public class HapiGetTxnRecord extends HapiQueryOp<HapiGetTxnRecord> {
 	String txn;
 	boolean scheduled = false;
 	boolean assertNothing = false;
-	boolean assertNothingAboutHashes = false;
 	boolean useDefaultTxnId = false;
 	boolean requestDuplicates = false;
 	boolean shouldBeTransferFree = false;
+	boolean assertNothingAboutHashes = false;
+	boolean lookupScheduledFromRegistryId = false;
 	Optional<TransactionID> explicitTxnId = Optional.empty();
 	Optional<TransactionRecordAsserts> priorityExpectations = Optional.empty();
 	Optional<BiConsumer<TransactionRecord, Logger>> format = Optional.empty();
+	Optional<String> creationName = Optional.empty();
 	Optional<String> saveTxnRecordToRegistry = Optional.empty();
 	Optional<String> registryEntry = Optional.empty();
 	Optional<String> topicToValidate = Optional.empty();
@@ -95,6 +99,13 @@ public class HapiGetTxnRecord extends HapiQueryOp<HapiGetTxnRecord> {
 
 	public HapiGetTxnRecord scheduled() {
 		scheduled = true;
+		return this;
+	}
+
+	public HapiGetTxnRecord scheduledBy(String creation) {
+		scheduled = true;
+		creationName = Optional.of(creation);
+		lookupScheduledFromRegistryId = true;
 		return this;
 	}
 
@@ -269,7 +280,7 @@ public class HapiGetTxnRecord extends HapiQueryOp<HapiGetTxnRecord> {
 					registryEntry.get() + "CallResult",
 					record.getContractCallResult().getCreatedContractIDsList());
 		}
-		if(saveTxnRecordToRegistry.isPresent()) {
+		if (saveTxnRecordToRegistry.isPresent()) {
 			spec.registry().saveTransactionRecord(saveTxnRecordToRegistry.get(), record);
 		}
 	}
@@ -285,13 +296,17 @@ public class HapiGetTxnRecord extends HapiQueryOp<HapiGetTxnRecord> {
 		TransactionID txnId = useDefaultTxnId
 				? defaultTxnId
 				: explicitTxnId.orElseGet(() -> spec.registry().getTxnId(txn));
-		if (scheduled) {
-			txnId = txnId.toBuilder()
-					.setScheduled(true)
-					.build();
-		}
-		if (nonce.isPresent()) {
-			txnId = txnId.toBuilder().setNonce(ByteString.copyFrom(nonce.get())).build();
+		if (lookupScheduledFromRegistryId) {
+			txnId = spec.registry().getTxnId(correspondingScheduledTxnId(creationName.get()));
+		} else {
+			if (scheduled) {
+				txnId = txnId.toBuilder()
+						.setScheduled(true)
+						.build();
+			}
+			if (nonce.isPresent()) {
+				txnId = txnId.toBuilder().setNonce(ByteString.copyFrom(nonce.get())).build();
+			}
 		}
 		TransactionGetRecordQuery getRecordQuery = TransactionGetRecordQuery.newBuilder()
 				.setHeader(costOnly ? answerCostHeader(payment) : answerHeader(payment))

--- a/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/schedule/HapiGetScheduleInfo.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/schedule/HapiGetScheduleInfo.java
@@ -24,6 +24,7 @@ import com.hedera.services.bdd.spec.HapiApiSpec;
 import com.hedera.services.bdd.spec.infrastructure.HapiSpecRegistry;
 import com.hedera.services.bdd.spec.queries.HapiQueryOp;
 import com.hedera.services.bdd.spec.transactions.TxnUtils;
+import com.hedera.services.bdd.spec.transactions.schedule.HapiScheduleCreate;
 import com.hederahashgraph.api.proto.java.HederaFunctionality;
 import com.hederahashgraph.api.proto.java.KeyList;
 import com.hederahashgraph.api.proto.java.Query;
@@ -41,175 +42,187 @@ import java.util.function.BiFunction;
 
 import static com.hedera.services.bdd.spec.queries.QueryUtils.answerCostHeader;
 import static com.hedera.services.bdd.spec.queries.QueryUtils.answerHeader;
+import static com.hedera.services.bdd.spec.transactions.schedule.HapiScheduleCreate.correspondingScheduledTxnId;
 import static com.hedera.services.bdd.spec.transactions.schedule.HapiScheduleCreate.registryBytesTag;
 
 public class HapiGetScheduleInfo extends HapiQueryOp<HapiGetScheduleInfo> {
-    private static final Logger log = LogManager.getLogger(HapiGetScheduleInfo.class);
+	private static final Logger log = LogManager.getLogger(HapiGetScheduleInfo.class);
 
-    String schedule;
+	String schedule;
 
-    public HapiGetScheduleInfo(String schedule) {
-        this.schedule = schedule;
-    }
+	public HapiGetScheduleInfo(String schedule) {
+		this.schedule = schedule;
+	}
 
-    boolean expectValidTxBytes = false;
-    Optional<String> expectedScheduleId = Optional.empty();
-    Optional<String> expectedCreatorAccountID = Optional.empty();
-    Optional<String> expectedPayerAccountID = Optional.empty();
-    Optional<String> expectedAdminKey = Optional.empty();
-    Optional<String> expectedEntityMemo = Optional.empty();
-    Optional<List<String>> expectedSignatories = Optional.empty();
-    Optional<Boolean> expectedExpiry = Optional.empty();
+	boolean expectValidTxBytes = false;
+	Optional<String> expectedScheduleId = Optional.empty();
+	Optional<String> expectedCreatorAccountID = Optional.empty();
+	Optional<String> expectedPayerAccountID = Optional.empty();
+	Optional<String> expectedScheduledTxnId = Optional.empty();
+	Optional<String> expectedAdminKey = Optional.empty();
+	Optional<String> expectedEntityMemo = Optional.empty();
+	Optional<List<String>> expectedSignatories = Optional.empty();
+	Optional<Boolean> expectedExpiry = Optional.empty();
 
-    public HapiGetScheduleInfo hasScheduleId(String s) {
-        expectedScheduleId = Optional.of(s);
-        return this;
-    }
+	public HapiGetScheduleInfo hasScheduledIdSavedBy(String creation) {
+		expectedScheduledTxnId = Optional.of(creation);
+		return this;
+	}
 
-    public HapiGetScheduleInfo hasCreatorAccountID(String s) {
-        expectedCreatorAccountID = Optional.of(s);
-        return this;
-    }
+	public HapiGetScheduleInfo hasScheduleId(String s) {
+		expectedScheduleId = Optional.of(s);
+		return this;
+	}
 
-    public HapiGetScheduleInfo hasPayerAccountID(String s) {
-        expectedPayerAccountID = Optional.of(s);
-        return this;
-    }
+	public HapiGetScheduleInfo hasCreatorAccountID(String s) {
+		expectedCreatorAccountID = Optional.of(s);
+		return this;
+	}
 
-    public HapiGetScheduleInfo hasValidTxBytes() {
-        expectValidTxBytes = true;
-        return this;
-    }
+	public HapiGetScheduleInfo hasPayerAccountID(String s) {
+		expectedPayerAccountID = Optional.of(s);
+		return this;
+	}
 
-    public HapiGetScheduleInfo hasAdminKey(String s) {
-        expectedAdminKey = Optional.of(s);
-        return this;
-    }
+	public HapiGetScheduleInfo hasValidTxBytes() {
+		expectValidTxBytes = true;
+		return this;
+	}
 
-    public HapiGetScheduleInfo hasEntityMemo(String s) {
-        expectedEntityMemo = Optional.of(s);
-        return this;
-    }
+	public HapiGetScheduleInfo hasAdminKey(String s) {
+		expectedAdminKey = Optional.of(s);
+		return this;
+	}
 
-    public HapiGetScheduleInfo hasSignatories(String... s) {
-        expectedSignatories = Optional.of(List.of(s));
-        return this;
-    }
+	public HapiGetScheduleInfo hasEntityMemo(String s) {
+		expectedEntityMemo = Optional.of(s);
+		return this;
+	}
 
-    public HapiGetScheduleInfo hasValidExpirationTime() {
-        expectedExpiry = Optional.of(true);
-        return this;
-    }
+	public HapiGetScheduleInfo hasSignatories(String... s) {
+		expectedSignatories = Optional.of(List.of(s));
+		return this;
+	}
 
-    @Override
-    protected void assertExpectationsGiven(HapiApiSpec spec) {
-        var actualInfo = response.getScheduleGetInfo().getScheduleInfo();
+	public HapiGetScheduleInfo hasValidExpirationTime() {
+		expectedExpiry = Optional.of(true);
+		return this;
+	}
 
-        expectedCreatorAccountID.ifPresent(s -> Assert.assertEquals(
-                "Wrong schedule creator account ID!",
-                TxnUtils.asId(s, spec),
-                actualInfo.getCreatorAccountID()));
+	@Override
+	protected void assertExpectationsGiven(HapiApiSpec spec) {
+		var actualInfo = response.getScheduleGetInfo().getScheduleInfo();
 
-        expectedPayerAccountID.ifPresent(s -> Assert.assertEquals(
-                "Wrong schedule payer account ID!",
-                TxnUtils.asId(s, spec),
-                actualInfo.getPayerAccountID()));
+		expectedScheduledTxnId.ifPresent(n -> Assert.assertEquals(
+				"Wrong scheduled transaction id!",
+				spec.registry().getTxnId(correspondingScheduledTxnId(n)),
+				actualInfo.getScheduledTransactionID()));
 
-        expectedEntityMemo.ifPresent(s -> Assert.assertEquals(
-                "Wrong memo!",
-                s,
-                actualInfo.getMemo()));
+		expectedCreatorAccountID.ifPresent(s -> Assert.assertEquals(
+				"Wrong schedule creator account ID!",
+				TxnUtils.asId(s, spec),
+				actualInfo.getCreatorAccountID()));
 
-        assertFor(
-                actualInfo.getExpirationTime(),
-                expectedExpiry,
-                (n, r) -> Timestamp.newBuilder().setSeconds(r.getExpiry(schedule)).build(),
-                "Wrong schedule expiry!",
-                spec.registry());
+		expectedPayerAccountID.ifPresent(s -> Assert.assertEquals(
+				"Wrong schedule payer account ID!",
+				TxnUtils.asId(s, spec),
+				actualInfo.getPayerAccountID()));
 
-        var registry = spec.registry();
+		expectedEntityMemo.ifPresent(s -> Assert.assertEquals(
+				"Wrong memo!",
+				s,
+				actualInfo.getMemo()));
 
-        expectedSignatories.ifPresent(s -> {
-            var expect = KeyList.newBuilder();
-            for (String signatory : s) {
-                var key = registry.getKey(signatory);
-                expect.addKeys(key);
-            }
-            Assert.assertArrayEquals("Wrong signatories!",
-                    expect.build().getKeysList().toArray(),
-                    actualInfo.getSignatories().getKeysList().toArray());
-        });
+		assertFor(
+				actualInfo.getExpirationTime(),
+				expectedExpiry,
+				(n, r) -> Timestamp.newBuilder().setSeconds(r.getExpiry(schedule)).build(),
+				"Wrong schedule expiry!",
+				spec.registry());
 
-        if (expectValidTxBytes) {
-            Assert.assertArrayEquals(
-                    "Wrong transaction bytes!",
-                    registry.getBytes(registryBytesTag(schedule)),
-                    actualInfo.getTransactionBody().toByteArray());
-        }
-        assertFor(
-                actualInfo.getScheduleID(),
-                expectedScheduleId,
-                (n, r) -> r.getScheduleId(n),
-                "Wrong schedule id!",
-                registry);
-        assertFor(
-                actualInfo.getAdminKey(),
-                expectedAdminKey,
-                (n, r) -> r.getAdminKey(schedule),
-                "Wrong schedule admin key!",
-                registry);
-    }
+		var registry = spec.registry();
 
-    private <T, R> void assertFor(
-            R actual,
-            Optional<T> possible,
-            BiFunction<T, HapiSpecRegistry, R> expectedFn,
-            String error,
-            HapiSpecRegistry registry
-    ) {
-        if (possible.isPresent()) {
-            var expected = expectedFn.apply(possible.get(), registry);
-            Assert.assertEquals(error, expected, actual);
-        }
-    }
+		expectedSignatories.ifPresent(s -> {
+			var expect = KeyList.newBuilder();
+			for (String signatory : s) {
+				var key = registry.getKey(signatory);
+				expect.addKeys(key);
+			}
+			Assert.assertArrayEquals("Wrong signatories!",
+					expect.build().getKeysList().toArray(),
+					actualInfo.getSignatories().getKeysList().toArray());
+		});
 
-    @Override
-    protected void submitWith(HapiApiSpec spec, Transaction payment) throws Throwable {
-        Query query = getScheduleInfoQuery(spec, payment, false);
-        response = spec.clients().getScheduleSvcStub(targetNodeFor(spec), useTls).getScheduleInfo(query);
-        if (verboseLoggingOn) {
-            log.info("Info for '" + schedule + "': " + response.getScheduleGetInfo().getScheduleInfo());
-        }
-    }
+		if (expectValidTxBytes) {
+			Assert.assertArrayEquals(
+					"Wrong transaction bytes!",
+					registry.getBytes(registryBytesTag(schedule)),
+					actualInfo.getTransactionBody().toByteArray());
+		}
+		assertFor(
+				actualInfo.getScheduleID(),
+				expectedScheduleId,
+				(n, r) -> r.getScheduleId(n),
+				"Wrong schedule id!",
+				registry);
+		assertFor(
+				actualInfo.getAdminKey(),
+				expectedAdminKey,
+				(n, r) -> r.getAdminKey(schedule),
+				"Wrong schedule admin key!",
+				registry);
+	}
 
-    @Override
-    protected long lookupCostWith(HapiApiSpec spec, Transaction payment) throws Throwable {
-        Query query = getScheduleInfoQuery(spec, payment, true);
-        Response response = spec.clients().getScheduleSvcStub(targetNodeFor(spec), useTls).getScheduleInfo(query);
-        return costFrom(response);
-    }
+	private <T, R> void assertFor(
+			R actual,
+			Optional<T> possible,
+			BiFunction<T, HapiSpecRegistry, R> expectedFn,
+			String error,
+			HapiSpecRegistry registry
+	) {
+		if (possible.isPresent()) {
+			var expected = expectedFn.apply(possible.get(), registry);
+			Assert.assertEquals(error, expected, actual);
+		}
+	}
 
-    private Query getScheduleInfoQuery(HapiApiSpec spec, Transaction payment, boolean costOnly) {
-        var id = TxnUtils.asScheduleId(schedule, spec);
-        ScheduleGetInfoQuery getScheduleQuery = ScheduleGetInfoQuery.newBuilder()
-                .setHeader(costOnly ? answerCostHeader(payment) : answerHeader(payment))
-                .setScheduleID(id)
-                .build();
-        return Query.newBuilder().setScheduleGetInfo(getScheduleQuery).build();
-    }
+	@Override
+	protected void submitWith(HapiApiSpec spec, Transaction payment) throws Throwable {
+		Query query = getScheduleInfoQuery(spec, payment, false);
+		response = spec.clients().getScheduleSvcStub(targetNodeFor(spec), useTls).getScheduleInfo(query);
+		if (verboseLoggingOn) {
+			log.info("Info for '" + schedule + "': " + response.getScheduleGetInfo().getScheduleInfo());
+		}
+	}
 
-    @Override
-    protected boolean needsPayment() {
-        return true;
-    }
+	@Override
+	protected long lookupCostWith(HapiApiSpec spec, Transaction payment) throws Throwable {
+		Query query = getScheduleInfoQuery(spec, payment, true);
+		Response response = spec.clients().getScheduleSvcStub(targetNodeFor(spec), useTls).getScheduleInfo(query);
+		return costFrom(response);
+	}
 
-    @Override
-    public HederaFunctionality type() {
-        return HederaFunctionality.ScheduleGetInfo;
-    }
+	private Query getScheduleInfoQuery(HapiApiSpec spec, Transaction payment, boolean costOnly) {
+		var id = TxnUtils.asScheduleId(schedule, spec);
+		ScheduleGetInfoQuery getScheduleQuery = ScheduleGetInfoQuery.newBuilder()
+				.setHeader(costOnly ? answerCostHeader(payment) : answerHeader(payment))
+				.setScheduleID(id)
+				.build();
+		return Query.newBuilder().setScheduleGetInfo(getScheduleQuery).build();
+	}
 
-    @Override
-    protected HapiGetScheduleInfo self() {
-        return this;
-    }
+	@Override
+	protected boolean needsPayment() {
+		return true;
+	}
+
+	@Override
+	public HederaFunctionality type() {
+		return HederaFunctionality.ScheduleGetInfo;
+	}
+
+	@Override
+	protected HapiGetScheduleInfo self() {
+		return this;
+	}
 }

--- a/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/schedule/HapiScheduleSign.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/schedule/HapiScheduleSign.java
@@ -30,6 +30,7 @@ import com.hedera.services.bdd.spec.queries.schedule.HapiGetScheduleInfo;
 import com.hedera.services.bdd.spec.transactions.HapiTxnOp;
 import com.hedera.services.usage.schedule.ScheduleSignUsage;
 import com.hederahashgraph.api.proto.java.HederaFunctionality;
+import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
 import com.hederahashgraph.api.proto.java.ScheduleInfo;
 import com.hederahashgraph.api.proto.java.ScheduleSignTransactionBody;
 import com.hederahashgraph.api.proto.java.Transaction;
@@ -48,7 +49,9 @@ import static com.hedera.services.bdd.spec.keys.TrieSigMapGenerator.withNature;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getScheduleInfo;
 import static com.hedera.services.bdd.spec.transactions.TxnUtils.asScheduleId;
 import static com.hedera.services.bdd.spec.transactions.TxnUtils.suFrom;
+import static com.hedera.services.bdd.spec.transactions.schedule.HapiScheduleCreate.correspondingScheduledTxnId;
 import static com.hederahashgraph.api.proto.java.HederaFunctionality.ScheduleSign;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SUCCESS;
 import static java.util.stream.Collectors.toList;
 
 public class HapiScheduleSign extends HapiTxnOp<HapiScheduleSign> {
@@ -56,6 +59,7 @@ public class HapiScheduleSign extends HapiTxnOp<HapiScheduleSign> {
 
 	private final String schedule;
 	private List<String> signatories = Collections.emptyList();
+	private Optional<String> savedScheduledTxnId = Optional.empty();
 	private Optional<byte[]> explicitBytes = Optional.empty();
 
 	public HapiScheduleSign(String schedule) {
@@ -69,6 +73,11 @@ public class HapiScheduleSign extends HapiTxnOp<HapiScheduleSign> {
 
 	public HapiScheduleSign signingExplicit(byte[] bytes) {
 		explicitBytes = Optional.of(bytes);
+		return this;
+	}
+
+	public HapiScheduleSign receiptHasScheduledTxnId(String creation) {
+		savedScheduledTxnId = Optional.of(correspondingScheduledTxnId(creation));
 		return this;
 	}
 

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/meta/VersionInfoSpec.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/meta/VersionInfoSpec.java
@@ -37,8 +37,8 @@ import java.util.List;
 public class VersionInfoSpec extends HapiApiSuite {
 	private static final Logger log = LogManager.getLogger(VersionInfoSpec.class);
 
-	private static final SemanticVersion EXPECTED_HAPI_PROTO = HapiPropertySource.asSemVer("0.12.0");
-	private static final SemanticVersion EXPECTED_HEDERA_SERVICES = HapiPropertySource.asSemVer("0.12.0");
+	private static final SemanticVersion EXPECTED_HAPI_PROTO = HapiPropertySource.asSemVer("0.13.0");
+	private static final SemanticVersion EXPECTED_HEDERA_SERVICES = HapiPropertySource.asSemVer("0.13.0");
 
 	public static void main(String... args) {
 		new VersionInfoSpec().runSuiteSync();

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/schedule/ScheduleCreateSpecs.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/schedule/ScheduleCreateSpecs.java
@@ -118,35 +118,36 @@ public class ScheduleCreateSpecs extends HapiApiSuite {
 				scheduledTXCreatedAfterPreviousIdenticalIsExecuted(),
 				preservesRevocationServiceSemanticsForFileDelete(),
 				worksAsExpectedWithDefaultScheduleId(),
+				infoIncludesTxnIdFromCreationReceipt(),
 				suiteCleanup(),
 		});
 	}
 
 	private HapiApiSpec suiteSetup() {
 		return defaultHapiSpec("suiteSetup")
-				.given( ).when( ).then(
+				.given().when().then(
 						overriding("ledger.schedule.txExpiryTimeSecs", "" + SCHEDULE_EXPIRY_TIME_SECS)
 				);
 	}
 
 	private HapiApiSpec suiteCleanup() {
 		return defaultHapiSpec("suiteCleanup")
-				.given( ).when( ).then(
+				.given().when().then(
 						overriding("ledger.schedule.txExpiryTimeSecs", defaultTxExpiry)
 				);
 	}
 
 	private HapiApiSpec worksAsExpectedWithDefaultScheduleId() {
 		return defaultHapiSpec("WorksAsExpectedWithDefaultScheduleId")
-				.given( ).when( ).then(
+				.given().when().then(
 						getScheduleInfo("0.0.0").hasCostAnswerPrecheck(INVALID_SCHEDULE_ID)
 				);
 	}
 
 	private HapiApiSpec bodyOnlyCreation() {
 		return defaultHapiSpec("BodyOnlyCreation")
-				.given( ).when(
-						scheduleCreate( "onlyBody",
+				.given().when(
+						scheduleCreate("onlyBody",
 								cryptoTransfer(tinyBarsFromTo(DEFAULT_PAYER, GENESIS, 1))
 						).logged()
 				).then(
@@ -174,7 +175,7 @@ public class ScheduleCreateSpecs extends HapiApiSuite {
 
 	private HapiApiSpec onlyBodyAndMemoCreation() {
 		return defaultHapiSpec("OnlyBodyAndMemoCreation")
-				.given( ).when(
+				.given().when(
 						scheduleCreate("onlyBodyAndMemo",
 								cryptoTransfer(tinyBarsFromTo(DEFAULT_PAYER, GENESIS, 1))
 						).withEntityMemo("sample memo")
@@ -226,7 +227,7 @@ public class ScheduleCreateSpecs extends HapiApiSuite {
 
 	private HapiApiSpec failsWithNonExistingPayerAccountId() {
 		return defaultHapiSpec("FailsWithNonExistingPayerAccountId")
-				.given( ).when(
+				.given().when(
 						scheduleCreate("invalidPayer", cryptoCreate("secondary"))
 								.designatingPayer("0.0.9999")
 								.hasKnownStatus(INVALID_ACCOUNT_ID)
@@ -236,7 +237,7 @@ public class ScheduleCreateSpecs extends HapiApiSuite {
 
 	private HapiApiSpec failsWithTooLongMemo() {
 		return defaultHapiSpec("FailsWithTooLongMemo")
-				.given( ).when(
+				.given().when(
 						scheduleCreate("invalidMemo", cryptoCreate("secondary"))
 								.withEntityMemo(nAscii(101))
 								.hasPrecheck(MEMO_TOO_LONG)
@@ -246,6 +247,26 @@ public class ScheduleCreateSpecs extends HapiApiSuite {
 
 	private String nAscii(int n) {
 		return IntStream.range(0, n).mapToObj(ignore -> "A").collect(Collectors.joining());
+	}
+
+	private HapiApiSpec infoIncludesTxnIdFromCreationReceipt() {
+		var nonce = "0123456789".getBytes();
+
+		return defaultHapiSpec("InfoIncludesTxnIdFromCreationReceipt")
+				.given(
+						scheduleCreate("creation",
+								cryptoTransfer(tinyBarsFromTo(DEFAULT_PAYER, FUNDING, 1))
+										.signedBy()
+						)
+								.withNonce(nonce)
+								.inheritingScheduledSigs()
+								.savingExpectedScheduledTxnId()
+				).when().then(
+						getScheduleInfo("creation")
+								.hasScheduleId("creation")
+								.hasScheduledIdSavedBy("creation")
+								.logged()
+				);
 	}
 
 	private HapiApiSpec allowsDoublingScheduledCreates() {
@@ -559,7 +580,7 @@ public class ScheduleCreateSpecs extends HapiApiSuite {
 
 		return defaultHapiSpec("PreservesRevocationServiceSemanticsForFileDelete")
 				.given(
-						overriding( "scheduling.whitelist", "FileDelete"),
+						overriding("scheduling.whitelist", "FileDelete"),
 						fileCreate(shouldBeInstaDeleted).waclShape(waclShape),
 						fileCreate(shouldBeDeletedEventually).waclShape(waclShape)
 				).when(
@@ -637,7 +658,7 @@ public class ScheduleCreateSpecs extends HapiApiSuite {
 
 	public HapiApiSpec requiresExtantPayer() {
 		return defaultHapiSpec("RequiresExtantPayer")
-				.given( ).when( ).then(
+				.given().when().then(
 						scheduleCreate(
 								"neverToBe",
 								cryptoCreate("nope")
@@ -700,7 +721,7 @@ public class ScheduleCreateSpecs extends HapiApiSuite {
 
 	public HapiApiSpec rejectsUnresolvableReqSigners() {
 		return defaultHapiSpec("RejectsUnresolvableReqSigners")
-				.given( ).when().then(
+				.given().when().then(
 						scheduleCreate(
 								"xferWithImaginaryAccount",
 								cryptoTransfer(
@@ -713,7 +734,7 @@ public class ScheduleCreateSpecs extends HapiApiSuite {
 
 	public HapiApiSpec rejectsUnparseableTxn() {
 		return defaultHapiSpec("RejectsUnparseableTxn")
-				.given( ).when().then(
+				.given().when().then(
 						scheduleCreateNonsense("absurd")
 								.hasKnownStatus(UNPARSEABLE_SCHEDULED_TRANSACTION)
 				);


### PR DESCRIPTION
**Related issue(s)**:
- Closes #1127 

**NOTES TO REVIEWERS**: 
 - The `MerkleSchedule` diff is really just lines 106-142; this file was formatted differently than the rest of the project.
 - Similarly, the only change to the EET `HapiGetScheduleInfo` op is adding a `hasScheduledIdSavedBy(String)` method.

**Summary of the change**:
- In the receipt of a `ScheduleCreate` that either creates a new `ScheduleID` _or_ merges with an existing `ScheduleID`, return the `TransactionID` of the corresponding scheduled transaction.
- In the receipt of a `ScheduleSign` that resolves to `SUCCESS`, return the `TransactionID` of the corresponding scheduled transaction.
- In the response of a `getScheduleInfo`, include the `TransactionID` of the pending scheduled transaction.
- Update fees charged to schedule ops based on the presence of these new `TransactionID` fields.
- Roll _src/main/resources/semantic-version.properties_ to `0.13.0`.
- Update `hapi-proto.version` element in _pom.xml_ to `0.13.0-alpha.1`.
- Add EET specs confirming the new behavior.
- Remove confusing dead code in `TxnReceipt` and other `SelfSerializable` classes that was used for `SerializedObjectProvider` implementations.

**External impacts**:
Clients submitting applicable schedule ops now have access to the `TransactionID` of the corresponding scheduled transaction.