### PR TITLE
Only charge service fees to payer for a triggered txn

### DIFF
--- a/hedera-node/src/main/java/com/hedera/services/fees/charging/ItemizableFeeCharging.java
+++ b/hedera-node/src/main/java/com/hedera/services/fees/charging/ItemizableFeeCharging.java
@@ -58,7 +58,6 @@ public class ItemizableFeeCharging extends FieldSourcedFeeScreening implements T
 
 	private final GlobalDynamicProperties properties;
 
-	AccountID node;
 	AccountID funding;
 	AccountID submittingNode;
 	EnumMap<TxnFeeType, Long> payerFeesCharged = new EnumMap<>(TxnFeeType.class);

--- a/hedera-node/src/main/java/com/hedera/services/fees/charging/ItemizableFeeCharging.java
+++ b/hedera-node/src/main/java/com/hedera/services/fees/charging/ItemizableFeeCharging.java
@@ -52,6 +52,7 @@ import static com.hedera.services.fees.TxnFeeType.*;
 public class ItemizableFeeCharging extends FieldSourcedFeeScreening implements TxnScopedFeeCharging {
 	public static EnumSet<TxnFeeType> NODE_FEE = EnumSet.of(NODE);
 	public static EnumSet<TxnFeeType> NETWORK_FEE = EnumSet.of(NETWORK);
+	public static EnumSet<TxnFeeType> SERVICE_FEE = EnumSet.of(SERVICE);
 	public static EnumSet<TxnFeeType> NETWORK_NODE_SERVICE_FEES = EnumSet.of(NETWORK, NODE, SERVICE);
 
 	private HederaLedger ledger;

--- a/hedera-node/src/main/java/com/hedera/services/fees/charging/ItemizableFeeCharging.java
+++ b/hedera-node/src/main/java/com/hedera/services/fees/charging/ItemizableFeeCharging.java
@@ -94,7 +94,6 @@ public class ItemizableFeeCharging extends FieldSourcedFeeScreening implements T
 	public void resetFor(TxnAccessor accessor, AccountID submittingNode) {
 		super.resetFor(accessor);
 
-		node = accessor.getTxn().getNodeAccountID();
 		funding = properties.fundingAccount();
 		this.submittingNode = submittingNode;
 
@@ -120,11 +119,10 @@ public class ItemizableFeeCharging extends FieldSourcedFeeScreening implements T
 	public TransferList itemizedFees() {
 		TransferList.Builder fees = TransferList.newBuilder();
 
-		if (!submittingNodeFeesCharged.isEmpty()) {
+		AccountID payer = accessor.getPayer();
+		if (!payer.equals(submittingNode) && !submittingNodeFeesCharged.isEmpty()) {
 			includeIfCharged(NETWORK, submittingNode, submittingNodeFeesCharged, fees);
 		} else {
-			AccountID payer = accessor.getPayer();
-
 			includeIfCharged(NETWORK, payer, payerFeesCharged, fees);
 			includeIfCharged(NODE, payer, payerFeesCharged, fees);
 			includeIfCharged(SERVICE, payer, payerFeesCharged, fees);
@@ -140,7 +138,7 @@ public class ItemizableFeeCharging extends FieldSourcedFeeScreening implements T
 			TransferList.Builder fees
 	) {
 		if (feesCharged.containsKey(fee)) {
-			AccountID receiver = (fee == NODE) ? node : funding;
+			AccountID receiver = (fee == NODE) ? submittingNode : funding;
 			fees.addAllAccountAmounts(receiverFirst(source, receiver, feesCharged.get(fee)));
 		}
 	}
@@ -177,7 +175,7 @@ public class ItemizableFeeCharging extends FieldSourcedFeeScreening implements T
 	public void chargePayerUpTo(EnumSet<TxnFeeType> fees) {
 		pay(
 				fees,
-				() -> chargeUpTo(accessor.getPayer(), node, NODE),
+				() -> chargeUpTo(accessor.getPayer(), submittingNode, NODE),
 				(fee) -> chargeUpTo(accessor.getPayer(), funding, fee));
 	}
 
@@ -185,7 +183,7 @@ public class ItemizableFeeCharging extends FieldSourcedFeeScreening implements T
 	public void chargeParticipant(AccountID participant, EnumSet<TxnFeeType> fees) {
 		pay(
 				fees,
-				() -> charge(participant, node, NODE),
+				() -> charge(participant, submittingNode, NODE),
 				fee -> charge(participant, funding, fee));
 	}
 

--- a/hedera-node/src/main/java/com/hedera/services/fees/charging/TxnFeeChargingPolicy.java
+++ b/hedera-node/src/main/java/com/hedera/services/fees/charging/TxnFeeChargingPolicy.java
@@ -50,6 +50,7 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OK;
  */
 public class TxnFeeChargingPolicy {
 	private final Consumer<ItemizableFeeCharging> NO_DISCOUNT = c -> {};
+	private final Consumer<ItemizableFeeCharging> TRIGGERED_TXN_DISCOUNT = c -> c.setFor(NODE, 0);
 	private final Consumer<ItemizableFeeCharging> DUPLICATE_TXN_DISCOUNT = c -> c.setFor(SERVICE, 0);
 
 	/**
@@ -62,6 +63,18 @@ public class TxnFeeChargingPolicy {
 	 */
 	public ResponseCodeEnum apply(ItemizableFeeCharging charging, FeeObject fee) {
 		return applyWithDiscount(charging, fee, NO_DISCOUNT);
+	}
+
+	/**
+	 * Apply the fee charging policy to a txn that was submitted responsibly, but
+	 * is a triggered txn rather than a parent txn requiring node precheck work.
+	 *
+	 * @param charging the charging facility to use
+	 * @param fee the fee to charge
+	 * @return the outcome of applying the policy
+	 */
+	public ResponseCodeEnum applyForTriggered(ItemizableFeeCharging charging, FeeObject fee) {
+		return applyWithDiscount(charging, fee, TRIGGERED_TXN_DISCOUNT);
 	}
 
 	/**

--- a/hedera-node/src/main/java/com/hedera/services/fees/charging/TxnFeeChargingPolicy.java
+++ b/hedera-node/src/main/java/com/hedera/services/fees/charging/TxnFeeChargingPolicy.java
@@ -38,12 +38,13 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OK;
 
 /**
  * Provides the transaction fee-charging policy for the processing
- * logic. The policy offers three basic entry points:
+ * logic. The policy offers four basic entry points:
  * <ol>
  *    <li>For a txn whose submitting node seemed to ignore due diligence
  *    (e.g. submitted a txn with an impermissible valid duration); and, </li>
  *    <li>For a txn that looks to have been submitted responsibly, but is
  *    a duplicate of a txn already submitted by a different node; and,</li>
+ *    <li>For a triggered txn; and,</li>
  *    <li>For a txn that was submitted responsibly, and is believed unique.</li>
  * </ol>
  *
@@ -51,7 +52,6 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OK;
  */
 public class TxnFeeChargingPolicy {
 	private final Consumer<ItemizableFeeCharging> NO_DISCOUNT = c -> {};
-	private final Consumer<ItemizableFeeCharging> TRIGGERED_TXN_DISCOUNT = c -> c.setFor(NODE, 0);
 	private final Consumer<ItemizableFeeCharging> DUPLICATE_TXN_DISCOUNT = c -> c.setFor(SERVICE, 0);
 
 	/**

--- a/hedera-node/src/main/java/com/hedera/services/legacy/services/state/AwareProcessLogic.java
+++ b/hedera-node/src/main/java/com/hedera/services/legacy/services/state/AwareProcessLogic.java
@@ -188,7 +188,7 @@ public class AwareProcessLogic implements ProcessLogic {
 
 		FeeObject fee = ctx.fees().computeFee(accessor, ctx.txnCtx().activePayerKey(), ctx.currentView());
 
-		var chargingOutcome = ctx.txnChargingPolicy().apply(ctx.charging(), fee);
+		var chargingOutcome = ctx.txnChargingPolicy().applyForTriggered(ctx.charging(), fee);
 		if (chargingOutcome != OK) {
 			ctx.txnCtx().setStatus(chargingOutcome);
 			return;

--- a/hedera-node/src/test/java/com/hedera/services/fees/charging/TxnFeeChargingPolicyTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/fees/charging/TxnFeeChargingPolicyTest.java
@@ -242,6 +242,26 @@ class TxnFeeChargingPolicyTest {
 	}
 
 	@Test
+	public void doesntChargeNodePenaltyForPayerUnableToPayNetworkWhenTriggeredTxn() {
+		given(charging.isPayerWillingToCover(NETWORK_FEE)).willReturn(true);
+		given(charging.canPayerAfford(NETWORK_FEE)).willReturn(false);
+
+		// when:
+		ResponseCodeEnum outcome = subject.applyForTriggered(charging, fee);
+
+		// then:
+		verify(charging).setFor(NODE, node);
+		verify(charging).setFor(NETWORK, network);
+		verify(charging).setFor(SERVICE, service);
+		// and:
+		verify(charging).isPayerWillingToCover(NETWORK_FEE);
+		verify(charging).canPayerAfford(NETWORK_FEE);
+		verify(charging, never()).chargeSubmittingNodeUpTo(NETWORK_FEE);
+		// and:
+		assertEquals(INSUFFICIENT_PAYER_BALANCE, outcome);
+	}
+
+	@Test
 	public void chargesNodePenaltyForPayerUnableToPayNetwork() {
 		given(charging.isPayerWillingToCover(NETWORK_FEE)).willReturn(true);
 		given(charging.canPayerAfford(NETWORK_FEE)).willReturn(false);
@@ -259,6 +279,24 @@ class TxnFeeChargingPolicyTest {
 		verify(charging).chargeSubmittingNodeUpTo(NETWORK_FEE);
 		// and:
 		assertEquals(INSUFFICIENT_PAYER_BALANCE, outcome);
+	}
+
+	@Test
+	public void doesntChargeNodePenaltyForPayerUnwillingToPayNetworkWhenTriggeredTxn() {
+		given(charging.isPayerWillingToCover(NETWORK_FEE)).willReturn(false);
+
+		// when:
+		ResponseCodeEnum outcome = subject.applyForTriggered(charging, fee);
+
+		// then:
+		verify(charging).setFor(NODE, node);
+		verify(charging).setFor(NETWORK, network);
+		verify(charging).setFor(SERVICE, service);
+		// and:
+		verify(charging).isPayerWillingToCover(NETWORK_FEE);
+		verify(charging, never()).chargeSubmittingNodeUpTo(NETWORK_FEE);
+		// and:
+		assertEquals(INSUFFICIENT_TX_FEE, outcome);
 	}
 
 	@Test

--- a/test-clients/src/main/java/com/hedera/services/bdd/spec/HapiSpecOperation.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/spec/HapiSpecOperation.java
@@ -95,6 +95,7 @@ public abstract class HapiSpecOperation {
 	protected boolean omitTxnId = false;
 	protected boolean loggingOff = false;
 	protected boolean suppressStats = false;
+	protected boolean omitNodeAccount = false;
 	protected boolean verboseLoggingOn = false;
 	protected boolean shouldRegisterTxn = false;
 	protected boolean useDefaultTxnAsCostAnswerPayment = false;
@@ -262,7 +263,11 @@ public abstract class HapiSpecOperation {
 				builder.getTransactionIDBuilder().setNonce(ByteString.copyFrom(nonce));
 			}
 
-			node.ifPresent(builder::setNodeAccountID);
+			if (omitNodeAccount) {
+				builder.clearNodeAccountID();
+			} else {
+				node.ifPresent(builder::setNodeAccountID);
+			}
 			validDurationSecs.ifPresent(s -> {
 				builder.setTransactionValidDuration(Duration.newBuilder().setSeconds(s).build());
 			});

--- a/test-clients/src/main/java/com/hedera/services/bdd/spec/assertions/TransferListAsserts.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/spec/assertions/TransferListAsserts.java
@@ -9,9 +9,9 @@ package com.hedera.services.bdd.spec.assertions;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -43,24 +43,34 @@ import static com.hedera.services.bdd.spec.transactions.TxnUtils.readableTransfe
 import static java.util.stream.Collectors.toSet;
 
 public class TransferListAsserts extends BaseErroringAssertsProvider<TransferList> {
+	public static TransferListAsserts exactParticipants(Function<HapiApiSpec, List<AccountID>> provider) {
+		return new ExactParticipantsAssert(provider);
+	}
+
 	public static TransferListAsserts including(Function<HapiApiSpec, TransferList>... providers) {
 		return new ExplicitTransferAsserts(Arrays.asList(providers));
 	}
+
 	public static TransferListAsserts includingDeduction(LongSupplier from, long amount) {
 		return new DeductionAsserts(from, amount);
 	}
+
 	public static TransferListAsserts includingDeduction(String desc, String payer) {
 		return new QualifyingDeductionAssert(desc, payer);
 	}
+
 	public static TransferListAsserts atLeastOneTransfer() {
 		return new NonEmptyTransferAsserts();
 	}
+
 	public static TransferListAsserts missingPayments(Function<HapiApiSpec, Map.Entry<AccountID, Long>>... providers) {
 		return new MissingPaymentAsserts(providers);
 	}
+
 	public static Function<HapiApiSpec, Map.Entry<AccountID, Long>> to(String account, Long amount) {
 		return spec -> new AbstractMap.SimpleEntry<>(spec.registry().getAccountID(account), amount);
 	}
+
 	public static Function<HapiApiSpec, Map.Entry<AccountID, Long>> from(String account, Long amount) {
 		return spec -> new AbstractMap.SimpleEntry<>(spec.registry().getAccountID(account), -1 * amount);
 	}
@@ -77,10 +87,10 @@ public class TransferListAsserts extends BaseErroringAssertsProvider<TransferLis
 class MissingPaymentAsserts extends TransferListAsserts {
 	public MissingPaymentAsserts(Function<HapiApiSpec, Map.Entry<AccountID, Long>>... providers) {
 		registerProvider((spec, o) -> {
-			TransferList actual = (TransferList)o;
+			TransferList actual = (TransferList) o;
 			Set<String> missing = Stream.of(providers).map(provider -> asSig(provider.apply(spec))).collect(toSet());
 			Set<String> nonAbsent = new HashSet<>();
-			actual.getAccountAmountsList().stream().forEach(entry ->  {
+			actual.getAccountAmountsList().stream().forEach(entry -> {
 				String sig = asSig(new AbstractMap.SimpleEntry<>(entry.getAccountID(), entry.getAmount()));
 				if (missing.contains(sig)) {
 					nonAbsent.add(sig);
@@ -100,12 +110,27 @@ class MissingPaymentAsserts extends TransferListAsserts {
 	}
 }
 
+class ExactParticipantsAssert extends TransferListAsserts {
+	public ExactParticipantsAssert(Function<HapiApiSpec, List<AccountID>> provider) {
+		registerProvider((spec, o) -> {
+			List<AccountID> expectedParticipants = provider.apply(spec);
+			TransferList actual = (TransferList) o;
+			Assert.assertEquals("Wrong number of participants!",
+					expectedParticipants.size(),
+					actual.getAccountAmountsCount());
+			for (int i = 0, n = expectedParticipants.size(); i < n; i++) {
+				Assert.assertEquals(expectedParticipants.get(i), actual.getAccountAmounts(i).getAccountID());
+			}
+		});
+	}
+}
+
 class ExplicitTransferAsserts extends TransferListAsserts {
 	public ExplicitTransferAsserts(List<Function<HapiApiSpec, TransferList>> providers) {
 		providers.stream().forEach(provider -> {
 			registerProvider((spec, o) -> {
 				TransferList expected = provider.apply(spec);
-				assertInclusion(expected, (TransferList)o);
+				assertInclusion(expected, (TransferList) o);
 			});
 		});
 	}
@@ -114,7 +139,7 @@ class ExplicitTransferAsserts extends TransferListAsserts {
 class QualifyingDeductionAssert extends TransferListAsserts {
 	public QualifyingDeductionAssert(String desc, String payer) {
 		registerProvider((spec, o) -> {
-			var transfers = (TransferList)o;
+			var transfers = (TransferList) o;
 			var hasQualifying = getDeduction(transfers, asId(payer, spec)).isPresent();
 			if (!hasQualifying) {
 				Assert.fail("No qualifying " + desc + " from " + payer + " in " + readableTransferList(transfers));
@@ -126,7 +151,7 @@ class QualifyingDeductionAssert extends TransferListAsserts {
 class NonEmptyTransferAsserts extends TransferListAsserts {
 	public NonEmptyTransferAsserts() {
 		registerProvider((spec, o) -> {
-			TransferList transfers = (TransferList)o;
+			TransferList transfers = (TransferList) o;
 			Assert.assertTrue("Transfer list cannot be empty!", !transfers.getAccountAmountsList().isEmpty());
 		});
 	}
@@ -135,7 +160,7 @@ class NonEmptyTransferAsserts extends TransferListAsserts {
 class DeductionAsserts extends TransferListAsserts {
 	public DeductionAsserts(LongSupplier from, long amount) {
 		registerProvider((sepc, o) -> {
-			TransferList transfers = (TransferList)o;
+			TransferList transfers = (TransferList) o;
 			long num = from.getAsLong();
 			Assert.assertTrue(
 					String.format("No deduction of -%d tinyBars from 0.0.%d detected!", amount, num),

--- a/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/meta/HapiGetTxnRecord.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/meta/HapiGetTxnRecord.java
@@ -27,10 +27,7 @@ import com.hedera.services.bdd.spec.assertions.ErroringAsserts;
 import com.hedera.services.bdd.spec.assertions.ErroringAssertsProvider;
 import com.hedera.services.bdd.spec.assertions.TransactionRecordAsserts;
 import com.hedera.services.bdd.spec.queries.HapiQueryOp;
-import com.hedera.services.bdd.spec.queries.QueryVerbs;
 import com.hedera.services.bdd.spec.transactions.TxnUtils;
-import com.hedera.services.bdd.spec.transactions.schedule.HapiScheduleCreate;
-import com.hedera.services.bdd.spec.utilops.CustomSpecAssert;
 import com.hedera.services.legacy.proto.utils.CommonUtils;
 import com.hederahashgraph.api.proto.java.HederaFunctionality;
 import com.hederahashgraph.api.proto.java.Query;
@@ -67,6 +64,7 @@ public class HapiGetTxnRecord extends HapiQueryOp<HapiGetTxnRecord> {
 	boolean useDefaultTxnId = false;
 	boolean requestDuplicates = false;
 	boolean shouldBeTransferFree = false;
+	boolean assertOnlyPriority = false;
 	boolean assertNothingAboutHashes = false;
 	boolean lookupScheduledFromRegistryId = false;
 	Optional<TransactionID> explicitTxnId = Optional.empty();
@@ -99,6 +97,11 @@ public class HapiGetTxnRecord extends HapiQueryOp<HapiGetTxnRecord> {
 
 	public HapiGetTxnRecord scheduled() {
 		scheduled = true;
+		return this;
+	}
+
+	public HapiGetTxnRecord assertingOnlyPriority() {
+		assertOnlyPriority = true;
 		return this;
 	}
 
@@ -242,11 +245,11 @@ public class HapiGetTxnRecord extends HapiQueryOp<HapiGetTxnRecord> {
 		if (assertNothing) {
 			return;
 		}
-		if (scheduled) {
-			return;
-		}
 		TransactionRecord actualRecord = response.getTransactionGetRecord().getTransactionRecord();
 		assertPriority(spec, actualRecord);
+		if (scheduled || assertOnlyPriority) {
+			return;
+		}
 		assertDuplicates(spec);
 		if (!assertNothingAboutHashes) {
 			assertTransactionHash(spec, actualRecord);

--- a/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/HapiTxnOp.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/HapiTxnOp.java
@@ -695,6 +695,11 @@ public abstract class HapiTxnOp<T extends HapiTxnOp<T>> extends HapiSpecOperatio
 		return self();
 	}
 
+	public T sansNodeAccount() {
+		omitNodeAccount = true;
+		return self();
+	}
+
 	public TransactionReceipt getLastReceipt() {
 		return lastReceipt;
 	}

--- a/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/schedule/HapiScheduleCreate.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/schedule/HapiScheduleCreate.java
@@ -23,12 +23,10 @@ package com.hedera.services.bdd.spec.transactions.schedule;
 import com.google.common.base.MoreObjects;
 import com.google.protobuf.ByteString;
 import com.hedera.services.bdd.spec.HapiApiSpec;
-import com.hedera.services.bdd.spec.HapiPropertySource;
 import com.hedera.services.bdd.spec.HapiSpecSetup;
 import com.hedera.services.bdd.spec.keys.TrieSigMapGenerator;
 import com.hedera.services.bdd.spec.transactions.HapiTxnOp;
 import com.hedera.services.bdd.spec.transactions.TxnUtils;
-import com.hedera.services.legacy.proto.utils.CommonUtils;
 import com.hedera.services.usage.schedule.ScheduleCreateUsage;
 import com.hederahashgraph.api.proto.java.FeeData;
 import com.hederahashgraph.api.proto.java.HederaFunctionality;
@@ -37,7 +35,6 @@ import com.hederahashgraph.api.proto.java.ScheduleCreateTransactionBody;
 import com.hederahashgraph.api.proto.java.SignatureMap;
 import com.hederahashgraph.api.proto.java.Transaction;
 import com.hederahashgraph.api.proto.java.TransactionBody;
-import com.hederahashgraph.api.proto.java.TransactionID;
 import com.hederahashgraph.api.proto.java.TransactionResponse;
 import com.hederahashgraph.fee.SigValueObj;
 import org.apache.logging.log4j.LogManager;
@@ -82,7 +79,7 @@ public class HapiScheduleCreate<T extends HapiTxnOp<T>> extends HapiTxnOp<HapiSc
 
 	public HapiScheduleCreate(String scheduled, HapiTxnOp<T> txn) {
 		this.entity = scheduled;
-		this.scheduled = txn.withLegacyProtoStructure().sansTxnId();
+		this.scheduled = txn.withLegacyProtoStructure().sansTxnId().sansNodeAccount();
 	}
 
 	public HapiScheduleCreate<T> savingExpectedScheduledTxnId() {


### PR DESCRIPTION
**Related issue(s)**:
- Closes #1136

**Summary of the change**:
- Respect only the `submittingNode` account in `ItemizableFeeCharging` (allow leaving `TransactionBody.nodeAccountID` empty).
- Charge the payer of a triggered txn only the service fee via a new `TxnFeeChargingPolicy.applyForTriggered()` policy.

**External impacts**:
Node and network fees will not be charged to scheduled txns.