### PR TITLE
Fix reconnect test

### DIFF
--- a/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/file/HapiFileUpdate.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/file/HapiFileUpdate.java
@@ -68,6 +68,7 @@ import static com.hedera.services.bdd.spec.queries.QueryVerbs.getFileContents;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getFileInfo;
 import static com.hedera.services.bdd.spec.transactions.TxnUtils.suFrom;
 import static com.hedera.services.bdd.spec.utilops.CustomSpecAssert.allRunFor;
+import static com.hedera.services.bdd.suites.HapiApiSuite.ONE_HBAR;
 import static java.util.Collections.EMPTY_MAP;
 import static java.util.Collections.EMPTY_SET;
 
@@ -375,12 +376,12 @@ public class HapiFileUpdate extends HapiTxnOp<HapiFileUpdate> {
 			};
 			return spec.fees().forActivityBasedOp(HederaFunctionality.FileUpdate, metricsCalc, txn, numPayerKeys);
 		} catch (Throwable ignore) {
-			return HapiApiSuite.ONE_HBAR;
+			return ONE_HBAR;
 		}
 	}
 
 	private FileGetInfoResponse.FileInfo lookupInfo(HapiApiSpec spec) throws Throwable {
-		HapiGetFileInfo subOp = getFileInfo(file).noLogging();
+		HapiGetFileInfo subOp = getFileInfo(file).noLogging().fee(ONE_HBAR);
 		Optional<Throwable> error = subOp.execFor(spec);
 		if (error.isPresent()) {
 			if (!loggingOff) {

--- a/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/LoadTest.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/LoadTest.java
@@ -28,7 +28,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.List;
-import java.util.Optional;
 import java.util.OptionalDouble;
 import java.util.OptionalInt;
 import java.util.OptionalLong;
@@ -47,7 +46,7 @@ public class LoadTest extends HapiApiSuite {
 	public static OptionalInt hcsSubmitMessage = OptionalInt.empty();
 	public static OptionalInt hcsSubmitMessageSizeVar = OptionalInt.empty();
 	/** initial balance of account used as sender for performance test transactions */
-	public static OptionalLong initialBalance = OptionalLong.of(ONE_HBAR * 1_000_000L);
+	public static OptionalLong initialBalance = OptionalLong.of(ONE_MILLION_HBARS);
 	public static OptionalInt totalTestAccounts = OptionalInt.empty();
 	public static OptionalInt totalTestTopics = OptionalInt.empty();
 	public static OptionalInt totalTestTokens = OptionalInt.empty();

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/HapiApiSuite.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/HapiApiSuite.java
@@ -68,7 +68,7 @@ public abstract class HapiApiSuite {
 	}
 
 	public static final long ONE_HBAR = 100_000_000L;
-	public static final long A_HUNDRED_HBARS = 100 * ONE_HBAR;
+	public static final long ONE_HUNDRED_HBARS = 100 * ONE_HBAR;
 	public static final long ONE_MILLION_HBARS = 1_000_000L * ONE_HBAR;
 	public static final long THREE_MONTHS_IN_SECONDS = 7776000L;
 	public static String TOKEN_TREASURY = "treasury";

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/HapiApiSuite.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/HapiApiSuite.java
@@ -69,6 +69,7 @@ public abstract class HapiApiSuite {
 
 	public static final long ONE_HBAR = 100_000_000L;
 	public static final long A_HUNDRED_HBARS = 100 * ONE_HBAR;
+	public static final long ONE_MILLION_HBARS = 1_000_000L * ONE_HBAR;
 	public static final long THREE_MONTHS_IN_SECONDS = 7776000L;
 	public static String TOKEN_TREASURY = "treasury";
 

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/BigRecordSpec.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/BigRecordSpec.java
@@ -57,7 +57,7 @@ public class BigRecordSpec extends HapiApiSuite {
 
 		return defaultHapiSpec("BigRecord")
 				.given(
-						cryptoCreate("payer").balance( 10 * A_HUNDRED_HBARS),
+						cryptoCreate("payer").balance( 10 * ONE_HUNDRED_HBARS),
 						fileCreate("bytecode")
 								.path(ContractResources.BIG_BIG_BYTECODE_PATH),
 						contractCreate("bigBig")

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/ContractCallSuite.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/ContractCallSuite.java
@@ -123,7 +123,7 @@ public class ContractCallSuite extends HapiApiSuite {
 						newKeyNamed("initialAdminKey").shape(initialKeyShape),
 						newKeyNamed("newAdminKey").shape(newKeyShape),
 						cryptoCreate("payer")
-								.balance(10 * A_HUNDRED_HBARS),
+								.balance(10 * ONE_HUNDRED_HBARS),
 						fileCreate("bytecode")
 								.path(ContractResources.SIMPLE_STORAGE_BYTECODE_PATH)
 								.payingWith("payer")

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/MiscCryptoSuite.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/MiscCryptoSuite.java
@@ -74,7 +74,7 @@ public class MiscCryptoSuite extends HapiApiSuite {
 		final long REDUCED_TOTAL_FEE = REDUCED_NODE_FEE + REDUCED_NETWORK_FEE + REDUCED_SERVICE_FEE;
 		return defaultHapiSpec("ReduceTransferFee")
 				.given(
-						cryptoCreate("sender").balance(A_HUNDRED_HBARS),
+						cryptoCreate("sender").balance(ONE_HUNDRED_HBARS),
 						cryptoCreate("receiver").balance(0L),
 						cryptoTransfer(tinyBarsFromTo("sender", "receiver", ONE_HBAR))
 								.payingWith("sender")
@@ -89,7 +89,7 @@ public class MiscCryptoSuite extends HapiApiSuite {
 								.payingWith("sender")
 								.fee(ONE_HBAR)
 								.hasPrecheck(OK),
-						getAccountBalance("sender").hasTinyBars(A_HUNDRED_HBARS - ONE_HBAR - REDUCED_TOTAL_FEE).logged()
+						getAccountBalance("sender").hasTinyBars(ONE_HUNDRED_HBARS - ONE_HBAR - REDUCED_TOTAL_FEE).logged()
 				);
 	}
 

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/fees/CostOfEverythingSuite.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/fees/CostOfEverythingSuite.java
@@ -22,7 +22,6 @@ package com.hedera.services.bdd.suites.fees;
 
 import com.hedera.services.bdd.spec.HapiApiSpec;
 import com.hedera.services.bdd.spec.keys.KeyShape;
-import com.hedera.services.bdd.spec.utilops.UtilVerbs;
 import com.hedera.services.bdd.suites.HapiApiSuite;
 import com.hederahashgraph.api.proto.java.AccountAmount;
 import com.hederahashgraph.api.proto.java.TransferList;
@@ -104,7 +103,7 @@ public class CostOfEverythingSuite extends HapiApiSuite {
 				.withProperties(Map.of("cost.snapshot.mode", costSnapshotMode.toString()))
 				.given(
 						cryptoCreate("payingSender")
-								.balance(A_HUNDRED_HBARS),
+								.balance(ONE_HUNDRED_HBARS),
 						cryptoCreate("receiver")
 								.balance(0L)
 								.receiverSigRequired(true)
@@ -151,7 +150,7 @@ public class CostOfEverythingSuite extends HapiApiSuite {
 				.withProperties(Map.of("cost.snapshot.mode", costSnapshotMode.toString()))
 				.given(
 						cryptoCreate("civilian")
-								.balance(A_HUNDRED_HBARS),
+								.balance(ONE_HUNDRED_HBARS),
 						fileCreate("multiBytecode")
 								.payingWith("civilian")
 								.path(MULTIPURPOSE_BYTECODE_PATH),

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/fees/CreateAndUpdateOps.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/fees/CreateAndUpdateOps.java
@@ -23,7 +23,6 @@ package com.hedera.services.bdd.suites.fees;
 import com.hedera.services.bdd.spec.HapiApiSpec;
 import com.hedera.services.bdd.spec.keys.KeyShape;
 import com.hedera.services.bdd.spec.transactions.TxnUtils;
-import com.hedera.services.bdd.spec.transactions.TxnVerbs;
 import com.hedera.services.bdd.suites.HapiApiSuite;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -58,7 +57,7 @@ import static com.hedera.services.bdd.spec.utilops.UtilVerbs.withOpContext;
 public class CreateAndUpdateOps extends HapiApiSuite {
 	private static final Logger log = LogManager.getLogger(CreateAndUpdateOps.class);
 
-	long feeToOffer = A_HUNDRED_HBARS;
+	long feeToOffer = ONE_HUNDRED_HBARS;
 	long paymentToOffer = ONE_HBAR;
 	long payerBalance = feeToOffer * 1000;
 	CostSnapshotMode costSnapshotMode = TAKE;

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/AccountBalancesClientSaveLoadTest.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/AccountBalancesClientSaveLoadTest.java
@@ -48,7 +48,6 @@ import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoTransfer;
 import static com.hedera.services.bdd.spec.transactions.token.TokenMovement.moving;
 
 import static com.hedera.services.bdd.spec.utilops.CustomSpecAssert.allRunFor;
-import static com.hedera.services.bdd.spec.utilops.UtilVerbs.newKeyNamed;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.exportAccountBalances;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.runWithProvider;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.sleepFor;
@@ -208,7 +207,7 @@ public class AccountBalancesClientSaveLoadTest extends LoadTest  {
 				var op =  cryptoCreate(String.format("%s%s",ACCT_NAME_PREFIX , next))
 						.balance((long)(r.nextInt((int)ONE_HBAR) * 1000 + MIN_ACCOUNT_BALANCE))
 						.key(GENESIS)
-						.fee(A_HUNDRED_HBARS)
+						.fee(ONE_HUNDRED_HBARS)
 						.withRecharging()
 						.rechargeWindow(30)
 						.noLogging()
@@ -240,7 +239,7 @@ public class AccountBalancesClientSaveLoadTest extends LoadTest  {
 				var payingTreasury = String.format(ACCT_NAME_PREFIX + next);
 				var op = tokenCreate(TOKEN_NAME_PREFIX + next)
 						.signedBy(GENESIS)
-						.fee(A_HUNDRED_HBARS)
+						.fee(ONE_HUNDRED_HBARS)
 						.initialSupply(MIN_TOKEN_SUPPLY + r.nextInt(MAX_TOKEN_SUPPLY))
 						.treasury(payingTreasury)
 						.hasRetryPrecheckFrom(NOISY_RETRY_PRECHECKS)
@@ -280,7 +279,7 @@ public class AccountBalancesClientSaveLoadTest extends LoadTest  {
 						.hasPrecheckFrom(DUPLICATE_TRANSACTION, OK)
 						.hasKnownStatusFrom(SUCCESS, TOKEN_ALREADY_ASSOCIATED_TO_ACCOUNT,INVALID_SIGNATURE,
 								TRANSACTION_EXPIRED, TOKENS_PER_ACCOUNT_LIMIT_EXCEEDED)
-						.fee(A_HUNDRED_HBARS)
+						.fee(ONE_HUNDRED_HBARS)
 						.noLogging()
 						.suppressStats(true)
 						.deferStatusResolution()
@@ -317,7 +316,7 @@ public class AccountBalancesClientSaveLoadTest extends LoadTest  {
 						.noLogging()
 						.signedBy(GENESIS)
 						.suppressStats(true)
-						.fee(A_HUNDRED_HBARS)
+						.fee(ONE_HUNDRED_HBARS)
 						.deferStatusResolution()
 						;
 

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/ReadyToRunScheduledXfersLoad.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/ReadyToRunScheduledXfersLoad.java
@@ -48,7 +48,6 @@ import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoCreate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoTransfer;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.scheduleCreate;
 import static com.hedera.services.bdd.spec.transactions.crypto.HapiCryptoTransfer.tinyBarsFromTo;
-import static com.hedera.services.bdd.spec.utilops.LoadTest.initialBalance;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.inParallel;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.runWithProvider;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.withOpContext;
@@ -112,7 +111,7 @@ public class ReadyToRunScheduledXfersLoad extends HapiApiSuite {
 		for (int i = 0; i < nonDefaultSenders; i++) {
 			initializers.add(
 					cryptoCreate(payingSender(i))
-							.balance(A_HUNDRED_HBARS)
+							.balance(ONE_HUNDRED_HBARS)
 			);
 		}
 		for (int i = 0; i < inertReceivers; i++) {

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/TokenRelStatusChanges.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/TokenRelStatusChanges.java
@@ -23,7 +23,6 @@ package com.hedera.services.bdd.suites.perf;
 import com.hedera.services.bdd.spec.HapiApiSpec;
 import com.hedera.services.bdd.spec.HapiSpecOperation;
 import com.hedera.services.bdd.spec.infrastructure.OpProvider;
-import com.hedera.services.bdd.spec.transactions.HapiTxnOp;
 import com.hedera.services.bdd.suites.HapiApiSuite;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -138,14 +137,14 @@ public class TokenRelStatusChanges extends HapiApiSuite {
 
 				if (nowAssociating.get()) {
 					op = tokenAssociate(accounts.get(account), tokens.get(token))
-							.fee(A_HUNDRED_HBARS)
+							.fee(ONE_HUNDRED_HBARS)
 							.hasRetryPrecheckFrom(NOISY_RETRY_PRECHECKS)
 							.hasKnownStatusFrom(OK, SUCCESS, DUPLICATE_TRANSACTION, TOKEN_ALREADY_ASSOCIATED_TO_ACCOUNT)
 							.noLogging()
 							.deferStatusResolution();
 				} else {
 					op = tokenDissociate(accounts.get(account), tokens.get(token))
-							.fee(A_HUNDRED_HBARS)
+							.fee(ONE_HUNDRED_HBARS)
 							.hasRetryPrecheckFrom(NOISY_RETRY_PRECHECKS)
 							.hasKnownStatusFrom(OK, SUCCESS, DUPLICATE_TRANSACTION, TOKEN_NOT_ASSOCIATED_TO_ACCOUNT)
 							.noLogging()

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/TokenTransferBasicLoadTest.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/TokenTransferBasicLoadTest.java
@@ -38,7 +38,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static com.hedera.services.bdd.spec.HapiApiSpec.defaultHapiSpec;
-import static com.hedera.services.bdd.spec.transactions.TxnUtils.NOISY_RETRY_PRECHECKS;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.tokenCreate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.tokenAssociate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoTransfer;
@@ -113,7 +112,7 @@ public class TokenTransferBasicLoadTest extends LoadTest {
 				var op = tokenCreate(tokenRegistryName(next))
 						.payingWith(GENESIS)
 						.signedBy(GENESIS)
-						.fee(A_HUNDRED_HBARS)
+						.fee(ONE_HUNDRED_HBARS)
 						.initialSupply(100_000_000_000L)
 						.treasury(payingTreasury)
 						.hasRetryPrecheckFrom(BUSY, PLATFORM_TRANSACTION_NOT_CREATED, DUPLICATE_TRANSACTION,INSUFFICIENT_PAYER_BALANCE)
@@ -171,7 +170,7 @@ public class TokenTransferBasicLoadTest extends LoadTest {
 						.hasPrecheckFrom(DUPLICATE_TRANSACTION, OK)
 						.hasKnownStatusFrom(SUCCESS, TOKEN_ALREADY_ASSOCIATED_TO_ACCOUNT,INVALID_TOKEN_ID,
 								TRANSACTION_EXPIRED, TOKENS_PER_ACCOUNT_LIMIT_EXCEEDED,FAIL_INVALID, OK)
-						.fee(A_HUNDRED_HBARS)
+						.fee(ONE_HUNDRED_HBARS)
 						.noLogging()
 						.suppressStats(true)
 						.deferStatusResolution();
@@ -232,7 +231,7 @@ public class TokenTransferBasicLoadTest extends LoadTest {
 				moving(1, tokenRegistryName(tokenNum)).between(senderAcct, receiverAcct))
 				.payingWith(senderAcct)
 				.signedBy(GENESIS)
-				.fee(A_HUNDRED_HBARS)
+				.fee(ONE_HUNDRED_HBARS)
 				.noLogging()
 				.suppressStats(true)
 				.hasPrecheckFrom(OK, INSUFFICIENT_PAYER_BALANCE,EMPTY_TOKEN_TRANSFER_ACCOUNT_AMOUNTS

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/reconnect/UpdateAllProtectedFilesDuringReconnect.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/reconnect/UpdateAllProtectedFilesDuringReconnect.java
@@ -109,7 +109,7 @@ public class UpdateAllProtectedFilesDuringReconnect extends HapiApiSuite {
 										spec -> {
 											ByteString newRates = spec
 													.ratesProvider()
-													.rateSetWith(1, 1)
+													.rateSetWith(100, 1)
 													.toByteString();
 											spec.registry().saveBytes("newRates", newRates);
 											return newRates;
@@ -160,7 +160,7 @@ public class UpdateAllProtectedFilesDuringReconnect extends HapiApiSuite {
 
 						cryptoCreate("civilian")
 								.setNode("0.0.6")
-								.fee(ONE_HBAR)
+								.fee(A_HUNDRED_HBARS)
 								.hasPrecheck(INSUFFICIENT_TX_FEE),
 
 						cryptoCreate("civilian")

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/reconnect/UpdateAllProtectedFilesDuringReconnect.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/reconnect/UpdateAllProtectedFilesDuringReconnect.java
@@ -146,6 +146,7 @@ public class UpdateAllProtectedFilesDuringReconnect extends HapiApiSuite {
 
 						fileUpdate(nonUpdatableFile)
 								.setNode("0.0.6")
+								.fee(A_HUNDRED_HBARS)
 								.hasPrecheck(NOT_SUPPORTED),
 
 						fileCreate("contractFile")

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/reconnect/UpdateAllProtectedFilesDuringReconnect.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/reconnect/UpdateAllProtectedFilesDuringReconnect.java
@@ -146,7 +146,7 @@ public class UpdateAllProtectedFilesDuringReconnect extends HapiApiSuite {
 
 						fileUpdate(nonUpdatableFile)
 								.setNode("0.0.6")
-								.fee(A_HUNDRED_HBARS)
+								.fee(ONE_MILLION_HBARS)
 								.hasPrecheck(NOT_SUPPORTED),
 
 						fileCreate("contractFile")

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/reconnect/UpdateAllProtectedFilesDuringReconnect.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/reconnect/UpdateAllProtectedFilesDuringReconnect.java
@@ -37,7 +37,6 @@ import static com.hedera.services.bdd.spec.HapiApiSpec.customHapiSpec;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getAccountBalance;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getAccountInfo;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getFileContents;
-import static com.hedera.services.bdd.spec.queries.QueryVerbs.getTxnRecord;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.contractCreate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoCreate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.fileCreate;
@@ -75,7 +74,6 @@ public class UpdateAllProtectedFilesDuringReconnect extends HapiApiSuite {
 
 	private HapiApiSpec updateAllProtectedFilesDuringReconnect() {
 		final String fileInfoRegistry = "apiPermissionsReconnect";
-		final String transactionFeeid = "authorizedTxn";
 		final String nonUpdatableFile = "nonUpdatableFile";
 
 		return customHapiSpec("UpdateAllProtectedFilesDuringReconnect")

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/reconnect/UpdateAllProtectedFilesDuringReconnect.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/reconnect/UpdateAllProtectedFilesDuringReconnect.java
@@ -34,7 +34,6 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import static com.hedera.services.bdd.spec.HapiApiSpec.customHapiSpec;
-import static com.hedera.services.bdd.spec.assertions.TransactionRecordAsserts.recordWith;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getAccountBalance;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getAccountInfo;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getFileContents;
@@ -50,6 +49,7 @@ import static com.hedera.services.bdd.spec.utilops.UtilVerbs.sleepFor;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.withLiveNode;
 import static com.hederahashgraph.api.proto.java.HederaFunctionality.CryptoGetInfo;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.AUTORENEW_DURATION_NOT_IN_RANGE;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INSUFFICIENT_TX_FEE;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.NOT_SUPPORTED;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OK;
 
@@ -77,7 +77,6 @@ public class UpdateAllProtectedFilesDuringReconnect extends HapiApiSuite {
 		final String fileInfoRegistry = "apiPermissionsReconnect";
 		final String transactionFeeid = "authorizedTxn";
 		final String nonUpdatableFile = "nonUpdatableFile";
-		final long newFee = 159_588_904;
 
 		return customHapiSpec("UpdateAllProtectedFilesDuringReconnect")
 				.withProperties(Map.of(
@@ -164,7 +163,8 @@ public class UpdateAllProtectedFilesDuringReconnect extends HapiApiSuite {
 								.setNode("0.0.6"),
 						getTxnRecord(transactionFeeid)
 								.setNode("0.0.6")
-								.hasPriority(recordWith().fee(newFee)),
+								.fee(ONE_HBAR)
+								.hasAnswerOnlyPrecheck(INSUFFICIENT_TX_FEE),
 
 						cryptoCreate("civilian")
 								.setNode("0.0.6"),

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/reconnect/UpdateAllProtectedFilesDuringReconnect.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/reconnect/UpdateAllProtectedFilesDuringReconnect.java
@@ -159,12 +159,9 @@ public class UpdateAllProtectedFilesDuringReconnect extends HapiApiSuite {
 								.hasPrecheck(AUTORENEW_DURATION_NOT_IN_RANGE),
 
 						cryptoCreate("civilian")
-								.via(transactionFeeid)
-								.setNode("0.0.6"),
-						getTxnRecord(transactionFeeid)
 								.setNode("0.0.6")
 								.fee(ONE_HBAR)
-								.hasAnswerOnlyPrecheck(INSUFFICIENT_TX_FEE),
+								.hasPrecheck(INSUFFICIENT_TX_FEE),
 
 						cryptoCreate("civilian")
 								.setNode("0.0.6"),

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/reconnect/UpdateAllProtectedFilesDuringReconnect.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/reconnect/UpdateAllProtectedFilesDuringReconnect.java
@@ -159,7 +159,7 @@ public class UpdateAllProtectedFilesDuringReconnect extends HapiApiSuite {
 
 						cryptoCreate("civilian")
 								.setNode("0.0.6")
-								.fee(A_HUNDRED_HBARS)
+								.fee(ONE_HUNDRED_HBARS)
 								.hasPrecheck(INSUFFICIENT_TX_FEE),
 
 						cryptoCreate("civilian")

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/schedule/ScheduleRecordSpecs.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/schedule/ScheduleRecordSpecs.java
@@ -191,7 +191,7 @@ public class ScheduleRecordSpecs extends HapiApiSuite {
 
 		return defaultHapiSpec("CanScheduleChunkedMessages")
 				.given(
-						cryptoCreate("payingSender").balance(A_HUNDRED_HBARS),
+						cryptoCreate("payingSender").balance(ONE_HUNDRED_HBARS),
 						createTopic(ofGeneralInterest)
 				).when(
 						withOpContext((spec, opLog) -> {

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenTransactSpecs.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenTransactSpecs.java
@@ -182,7 +182,7 @@ public class TokenTransactSpecs extends HapiApiSuite {
 								.hasKnownStatus(INSUFFICIENT_TOKEN_BALANCE),
 						cryptoTransfer(
 								moving(1, A_TOKEN).between("firstTreasury", "beneficiary"),
-								movingHbar(A_HUNDRED_HBARS).between("firstTreasury", "beneficiary")
+								movingHbar(ONE_HUNDRED_HBARS).between("firstTreasury", "beneficiary")
 						).payingWith("payer")
 								.signedBy("payer", "firstTreasury")
 								.hasKnownStatus(INSUFFICIENT_ACCOUNT_BALANCE)


### PR DESCRIPTION
**Related issue(s)**:
Closes #1161

**Summary of the change**:
Made the test more robust to handle price fluctuation, by:
- Remove hardcoded fee to be expected https://github.com/hashgraph/hedera-services/blob/e050405b3698faeccd9d845ed9cf3138d399a101/test-clients/src/main/java/com/hedera/services/bdd/suites/reconnect/UpdateAllProtectedFilesDuringReconnect.java#L80
- During reconnect, update exchange rates to have significantly high new fees in hbars
- Provide high, but not high enough fee (100 hbars) for requests with expected `INSUFFICIENT_TX_FEE` for new fees and provide high enough fee (1 mil hbars) for expected passing requests
- Some other minor clean-ups

**Passing tests**:
https://hedera-hashgraph.slack.com/archives/C018CBQBTGB/p1615398086324300
https://hedera-hashgraph.slack.com/archives/C018CBQBTGB/p1615402500325900