### PR TITLE
Fix build after renaming a variable

### DIFF
--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/misc/ReviewMainnetEntities.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/misc/ReviewMainnetEntities.java
@@ -32,7 +32,6 @@ import java.util.stream.IntStream;
 
 import static com.hedera.services.bdd.spec.HapiApiSpec.customHapiSpec;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getAccountBalance;
-import static com.hedera.services.bdd.spec.queries.QueryVerbs.getContractInfo;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getFileInfo;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getTxnRecord;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.burnToken;
@@ -81,7 +80,7 @@ public class ReviewMainnetEntities extends HapiApiSuite {
 				))
 				.given(
 						cryptoCreate("civilian")
-								.balance(A_HUNDRED_HBARS)
+								.balance(ONE_HUNDRED_HBARS)
 				).when(
 						cryptoCreate("another")
 								.payingWith("civilian")

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/regression/AddWellKnownEntities.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/regression/AddWellKnownEntities.java
@@ -54,7 +54,7 @@ public class AddWellKnownEntities extends HapiApiSuite {
 		return HapiApiSpec.customHapiSpec("AddWellKnownEntities")
 				.withProperties(Map.of(
 						"fees.useFixedOffer", "true",
-						"fees.fixedOffer", "" + A_HUNDRED_HBARS,
+						"fees.fixedOffer", "" + ONE_HUNDRED_HBARS,
 						"persistentEntities.dir.path", "src/main/resource/jrs-creations"
 				)).given(
 						expectedEntitiesExist()

--- a/test-clients/src/main/java/com/hedera/services/yahcli/suites/CostOfEveryThingSuite.java
+++ b/test-clients/src/main/java/com/hedera/services/yahcli/suites/CostOfEveryThingSuite.java
@@ -1,13 +1,10 @@
 package com.hedera.services.yahcli.suites;
 
 import com.hedera.services.bdd.spec.HapiApiSpec;
-import com.hedera.services.bdd.spec.HapiSpecOperation;
-import com.hedera.services.bdd.spec.keys.KeyShape;
 import com.hedera.services.bdd.suites.HapiApiSuite;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.Arrays;
@@ -25,7 +22,6 @@ import static com.hedera.services.bdd.spec.infrastructure.meta.ContractResources
 import static com.hedera.services.bdd.spec.infrastructure.meta.ContractResources.GET_CHILD_RESULT_ABI;
 import static com.hedera.services.bdd.spec.keys.KeyShape.SIMPLE;
 import static com.hedera.services.bdd.spec.keys.KeyShape.listOf;
-import static com.hedera.services.bdd.spec.keys.KeyShape.threshOf;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.contractCallLocal;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getAccountInfo;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getAccountRecords;
@@ -503,7 +499,7 @@ public class CostOfEveryThingSuite extends HapiApiSuite {
 				)
 				.given(
 						cryptoCreate("payingSender")
-								.balance(A_HUNDRED_HBARS),
+								.balance(ONE_HUNDRED_HBARS),
 						cryptoCreate("receiver")
 								.balance(0L)
 								.receiverSigRequired(true)


### PR DESCRIPTION
PR #1134, which used the old variable `A_HUNDRED_HBARS`, was merged before PR #1162. Change to using the new `ONE_HUNDRED_HBARS` variable.