### PR TITLE
Change the account balances export timeline.

### DIFF
--- a/hedera-node/src/test/java/com/hedera/services/state/exports/SignedStateBalancesExporterTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/state/exports/SignedStateBalancesExporterTest.java
@@ -626,17 +626,14 @@ class SignedStateBalancesExporterTest {
 	public void initsAsExpected() {
 		// expect:
 		assertEquals(ledgerFloat, subject.expectedFloat);
-		assertEquals(SignedStateBalancesExporter.NEVER, subject.periodEnd);
 	}
 
 	@Test
 	public void exportsWhenPeriodSecsHaveElapsed() {
+		now = subject.periodEnd;
+		anEternityLater = now.plusSeconds(dynamicProperties.balancesExportPeriodSecs() * 2);
 		assertFalse(subject.isTimeToExport(now));
-		assertEquals(now.plusSeconds(dynamicProperties.balancesExportPeriodSecs()), subject.periodEnd);
-		assertFalse(subject.isTimeToExport(shortlyAfter));
-		assertEquals(now.plusSeconds(dynamicProperties.balancesExportPeriodSecs()), subject.periodEnd);
 		assertTrue(subject.isTimeToExport(anEternityLater));
-		assertEquals(anEternityLater.plusSeconds(dynamicProperties.balancesExportPeriodSecs()), subject.periodEnd);
 	}
 
 	@AfterAll

--- a/test-clients/src/main/java/com/hedera/services/bdd/spec/HapiApiSpec.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/spec/HapiApiSpec.java
@@ -146,13 +146,8 @@ public class HapiApiSpec implements Runnable {
 
 
 	public void exportAccountBalances(Supplier<String> dir) {
-		Instant now = Instant.now();
-		Timestamp.Builder timeStamp = Timestamp.newBuilder();
-		timeStamp.setSeconds(now.getEpochSecond())
-				.setNanos(now.getNano());
-
 		AllAccountBalances.Builder allAccountBalancesBuilder = AllAccountBalances.newBuilder()
-				.addAllAllAccounts(accountBalances).setConsensusTimestamp(timeStamp);
+				.addAllAllAccounts(accountBalances);
 
 		try (FileOutputStream fout = new FileOutputStream(dir.get())) {
 			allAccountBalancesBuilder.build().writeTo(fout);


### PR DESCRIPTION
**Related issue(s)**:
Closes #1142 

**Summary of the change**:

1. changed the account balances export timeline;
2. Also wiped out the timestamp field for client account balances .pb file.

**External impacts**:
None.

**Applicable documentation**
- [ ] Javadoc
- [ ] HAPI protobuf comments
- [ ] README
