### PR TITLE
Store logs of CI to GS

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -394,7 +394,7 @@ commands:
             fi
 
             CI_PARAMETERS = ""
-            if [[ "<< parameters.continuous-integration >>" ]]; then
+            if [[ "<< parameters.continuous_integration >>" ]]; then
               CI_PARAMETERS="$CIRCLE_USERNAME $CIRCLE_BUILD_URL"
             fi
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2265,7 +2265,7 @@ jobs:
             cd /swirlds-platform;
             sed -i -e 's/github.com/services-jrs-regression/g' .gitmodules;
             git submodule update --init --recursive --checkout;
-            cd regression;
+            cd regression; git checkout test-log-store;
             cd ..;
             mvn --no-transfer-progress clean install -DskipTests;
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1903,7 +1903,7 @@ workflows:
             result_path: results/4N_1C/CI
             config_type: "ci"
             workflow-name: "GCP-Commit-Services-Comp-Basic-4N-1C"
-            name: "continuous-integration-gcp"
+            name: "run-continuous-integration-gcp"
             continuous_integration: true
             slack_results_channel: "hedera-cicd"
             slack_summary_channel: "hedera-cicd"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2241,7 +2241,7 @@ jobs:
             cd /swirlds-platform;
             sed -i -e 's/github.com/services-jrs-regression/g' .gitmodules;
             git submodule update --init --recursive --checkout;
-            cd regression; git checkout 1207-M-store-logs-to-gs;
+            cd regression;
             cd ..;
             mvn --no-transfer-progress clean install -DskipTests;
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2852,10 +2852,10 @@ jobs:
         default: true
       slack_results_channel:
         type: string
-        default: "hedera-regression-test"
+        default: "hedera-regression"
       slack_summary_channel:
         type: string
-        default: "hedera-regression-test"
+        default: "hedera-regression-summary"
       workflow-name:
         type: string
         default: ""

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -393,11 +393,10 @@ commands:
               JRS_OPTIONS="${JRS_OPTIONS} -Djrs.circleci.slack.results=${SLACK_RESULTS}"
             fi
 
-            CI_PARAMETERS = ""
-            if [[ "<< parameters.continuous_integration >>" ]]; then
-              CI_PARAMETERS="$CIRCLE_USERNAME $CIRCLE_BUILD_URL"
+            CI_PARAMETERS=""
+            if [[ "<< parameters.continuous_integration >>" == "true" ]]; then
+              CI_PARAMETERS="${CI_PARAMETERS} $CIRCLE_USERNAME $CIRCLE_BUILD_URL"
             fi
-
 
             pushd "${REGRESSION_PATH}" > /dev/null 2>&1
               CONFIG_PATH="<< parameters.config_file >>"
@@ -421,7 +420,7 @@ commands:
               ${JRS_OPTIONS} \
               -Dlog4j.configurationFile=log4j2-jrs.xml \
               -Dspring.output.ansi.enabled=ALWAYS \
-              -jar regression.jar "${CONFIG_PATH}" "<< parameters.hedera_services_path >>" "${CI_PARAMETERS}"
+              -jar regression.jar "${CONFIG_PATH}" "<< parameters.hedera_services_path >>" ${CI_PARAMETERS}
             popd > /dev/null 2>&1
           no_output_timeout: 30m
 
@@ -1911,17 +1910,6 @@ workflows:
               - install-tools
               - attach_workspace:
                   at: /
-#        - run-continuous-integration-gcp:
-#            context: Slack
-#            requires:
-#              - javadoc-generation
-#            pre-steps:
-#              - install-tools
-#              - attach_workspace:
-#                  at: /
-#            workflow-name: "Continuous Integration GCP"
-#            bucket_name: ""
-#            result_path: results/4N_1C/CI
 
   continuous-integration:
     jobs:
@@ -2213,36 +2201,30 @@ jobs:
             - repo/
             - swirlds-platform/
 
-  run-continuous-integration-gcp:
-    parameters:
-      workflow-name:
-        type: string
-        default: ""
-      bucket_name:
-        type: string
-        default: ""
-      result_path:
-        type: string
-        default: ""
-    executor:
-      name: build-executor
-      workflow-name: << parameters.workflow-name >>
-    steps:
-      - run:
-          name: Run continuous integration tests
-          no_output_timeout: 30m
-          command: |
-            cd /swirlds-platform/regression;
-            source /root/.bashrc; source /root/google-cloud-sdk/completion.bash.inc; source /root/google-cloud-sdk/path.bash.inc;
-            ./regression_services_circleci.sh configs/services/suites/ci/GCP-Commit-Services-Comp-Basic-4N-1C.json /repo $CIRCLE_USERNAME $CIRCLE_BUILD_URL
-
-      - run:
-          name: Sync results of continuous integration to circelCI job
-          command: |
-            tar -czvf /results.tar.gz  /swirlds-platform/regression/results/4N_1C/CI/*
-
-      - store_artifacts:
-          path: /results.tar.gz
+#  run-continuous-integration-gcp:
+#    parameters:
+#      workflow-name:
+#        type: string
+#        default: ""
+#    executor:
+#      name: build-executor
+#      workflow-name: << parameters.workflow-name >>
+#    steps:
+#      - run:
+#          name: Run continuous integration tests
+#          no_output_timeout: 30m
+#          command: |
+#            cd /swirlds-platform/regression;
+#            source /root/.bashrc; source /root/google-cloud-sdk/completion.bash.inc; source /root/google-cloud-sdk/path.bash.inc;
+#            ./regression_services_circleci.sh configs/services/suites/ci/GCP-Commit-Services-Comp-Basic-4N-1C.json /repo $CIRCLE_USERNAME $CIRCLE_BUILD_URL
+#
+#      - run:
+#          name: Sync results of continuous integration to circelCI job
+#          command: |
+#            tar -czvf /results.tar.gz  /swirlds-platform/regression/results/4N_1C/CI/*
+#
+#      - store_artifacts:
+#          path: /results.tar.gz
 
   javadoc-generation:
     executor:
@@ -2906,7 +2888,6 @@ jobs:
       continuous_integration:
         type: boolean
         default: false
-
     executor:
       name: << parameters.runtime >>
       workflow-name:  << parameters.workflow-name >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1890,15 +1890,27 @@ workflows:
             pre-steps:
               - attach_workspace:
                   at: /
-        - run-continuous-integration-gcp:
+        - jrs-regression:
             context: Slack
+            regression_path: /swirlds-platform/regression
+            result_path: results/CI
+            config_type: "ci"
+            workflow-name: "GCP-Commit-Services-Comp-Basic-4N-1C.json"
             requires:
               - javadoc-generation
             pre-steps:
               - install-tools
               - attach_workspace:
                   at: /
-            workflow-name: "Continuous Integration GCP"
+#        - run-continuous-integration-gcp:
+#            context: Slack
+#            requires:
+#              - javadoc-generation
+#            pre-steps:
+#              - install-tools
+#              - attach_workspace:
+#                  at: /
+#            workflow-name: "Continuous Integration GCP"
 
   continuous-integration:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -437,7 +437,7 @@ commands:
       workflow-name:
         description: name of the workflow
         type: string
-        default: "continuous integration"
+        default: "continuous-integration"
       slack-channel:
         description: name of the slack channel to send report to
         type: string
@@ -1884,12 +1884,12 @@ workflows:
               branches:
                 ignore:
                   - /.*-PERF/
-            workflow-name: "Continuous integration"
+            workflow-name: "Continuous-integration"
         - build-platform-and-services:
             context: SonarCloud
             requires:
               - build-artifact
-            workflow-name: "Continuous integration GCP"
+            workflow-name: "Continuous-integration-GCP"
         - javadoc-generation:
             context: Slack
             requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1903,6 +1903,7 @@ workflows:
             result_path: results/4N_1C/CI
             config_type: "ci"
             workflow-name: "GCP-Commit-Services-Comp-Basic-4N-1C"
+            name: "continuous-integration-gcp"
             continuous_integration: true
             slack_results_channel: "hedera-cicd"
             slack_summary_channel: "hedera-cicd"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2201,31 +2201,6 @@ jobs:
             - repo/
             - swirlds-platform/
 
-#  run-continuous-integration-gcp:
-#    parameters:
-#      workflow-name:
-#        type: string
-#        default: ""
-#    executor:
-#      name: build-executor
-#      workflow-name: << parameters.workflow-name >>
-#    steps:
-#      - run:
-#          name: Run continuous integration tests
-#          no_output_timeout: 30m
-#          command: |
-#            cd /swirlds-platform/regression;
-#            source /root/.bashrc; source /root/google-cloud-sdk/completion.bash.inc; source /root/google-cloud-sdk/path.bash.inc;
-#            ./regression_services_circleci.sh configs/services/suites/ci/GCP-Commit-Services-Comp-Basic-4N-1C.json /repo $CIRCLE_USERNAME $CIRCLE_BUILD_URL
-#
-#      - run:
-#          name: Sync results of continuous integration to circelCI job
-#          command: |
-#            tar -czvf /results.tar.gz  /swirlds-platform/regression/results/4N_1C/CI/*
-#
-#      - store_artifacts:
-#          path: /results.tar.gz
-
   javadoc-generation:
     executor:
       name: build-executor

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -342,6 +342,9 @@ commands:
       hedera_services_path:
         type: string
         default: "/repo"
+      continuous_integration:
+        type: boolean
+        default: false
     steps:
       - run:
           name: Configure JRS Regression Keys
@@ -390,6 +393,11 @@ commands:
               JRS_OPTIONS="${JRS_OPTIONS} -Djrs.circleci.slack.results=${SLACK_RESULTS}"
             fi
 
+            CI_PARAMETERS = ""
+            if [[ "<< parameters.continuous-integration >>" ]]; then
+              CI_PARAMETERS="$CIRCLE_USERNAME $CIRCLE_BUILD_URL"
+            fi
+
 
             pushd "${REGRESSION_PATH}" > /dev/null 2>&1
               CONFIG_PATH="<< parameters.config_file >>"
@@ -413,7 +421,7 @@ commands:
               ${JRS_OPTIONS} \
               -Dlog4j.configurationFile=log4j2-jrs.xml \
               -Dspring.output.ansi.enabled=ALWAYS \
-              -jar regression.jar "${CONFIG_PATH}" "<< parameters.hedera_services_path >>"
+              -jar regression.jar "${CONFIG_PATH}" "<< parameters.hedera_services_path >>" "${CI_PARAMETERS}"
             popd > /dev/null 2>&1
           no_output_timeout: 30m
 
@@ -1893,9 +1901,10 @@ workflows:
         - jrs-regression:
             context: Slack
             regression_path: /swirlds-platform/regression
-            result_path: results/CI
+            result_path: results/4N_1C/CI
             config_type: "ci"
             workflow-name: "GCP-Commit-Services-Comp-Basic-4N-1C"
+            continuous_integration: true
             requires:
               - javadoc-generation
             pre-steps:
@@ -1911,6 +1920,8 @@ workflows:
 #              - attach_workspace:
 #                  at: /
 #            workflow-name: "Continuous Integration GCP"
+#            bucket_name: ""
+#            result_path: results/4N_1C/CI
 
   continuous-integration:
     jobs:
@@ -2205,6 +2216,12 @@ jobs:
   run-continuous-integration-gcp:
     parameters:
       workflow-name:
+        type: string
+        default: ""
+      bucket_name:
+        type: string
+        default: ""
+      result_path:
         type: string
         default: ""
     executor:
@@ -2876,16 +2893,20 @@ jobs:
         default: true
       slack_results_channel:
         type: string
-        default: "hedera-regression"
+        default: "hedera-regression-test"
       slack_summary_channel:
         type: string
-        default: "hedera-regression-summary"
+        default: "hedera-regression-test"
       workflow-name:
         type: string
         default: ""
       hedera_services_path:
         type: string
         default: "/repo"
+      continuous_integration:
+        type: boolean
+        default: false
+
     executor:
       name: << parameters.runtime >>
       workflow-name:  << parameters.workflow-name >>
@@ -2915,6 +2936,7 @@ jobs:
           slack_results_channel: << parameters.slack_results_channel >>
           slack_summary_channel: << parameters.slack_summary_channel >>
           hedera_services_path: << parameters.hedera_services_path >>
+          continuous_integration: << parameters.continuous_integration >>
       - when:
           condition: << parameters.automated_run >>
           steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2241,7 +2241,7 @@ jobs:
             cd /swirlds-platform;
             sed -i -e 's/github.com/services-jrs-regression/g' .gitmodules;
             git submodule update --init --recursive --checkout;
-            cd regression; git checkout test-log-store;
+            cd regression; git checkout 1207-M-store-logs-to-gs;
             cd ..;
             mvn --no-transfer-progress clean install -DskipTests;
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1889,7 +1889,7 @@ workflows:
         - build-platform-and-services:
             context: SonarCloud
             requires:
-              - build-artifact
+              - artifact-build
             workflow-name: "Continuous-integration-GCP"
         - javadoc-generation:
             context: Slack

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1895,7 +1895,7 @@ workflows:
             regression_path: /swirlds-platform/regression
             result_path: results/CI
             config_type: "ci"
-            workflow-name: "GCP-Commit-Services-Comp-Basic-4N-1C.json"
+            workflow-name: "GCP-Commit-Services-Comp-Basic-4N-1C"
             requires:
               - javadoc-generation
             pre-steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1904,6 +1904,8 @@ workflows:
             config_type: "ci"
             workflow-name: "GCP-Commit-Services-Comp-Basic-4N-1C"
             continuous_integration: true
+            slack_results_channel: "hedera-cicd"
+            slack_summary_channel: "hedera-cicd"
             requires:
               - javadoc-generation
             pre-steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1879,6 +1879,7 @@ workflows:
   continuous-integration-gcp:
       jobs:
         - build-artifact:
+            name: "artifact-build"
             context: SonarCloud
             filters:
               branches:


### PR DESCRIPTION
**Related issue(s)**:
Closes #1207 

**Summary of the change**:
Currently logs of Continuous Integration are not uploaded to google storage. This doesn't allow developers to see the logs if there is any error.
Modified to store logs of `continuous-integration-gcp`  to GS.

One of the CI run with results folder link : https://hedera-hashgraph.slack.com/archives/CMD3V6ZC4/p1617074380015200

**NOTE:** The branch checked out in regression will be reverted before merge, once the [PR](https://github.com/swirlds/swirlds-platform-regression/pull/951/files) in regression is merged. 
Space changes are necessary as the path for results folder breaks if there is any space in the path.