### PR TITLE
Differentiate entity deletion and removal

### DIFF
--- a/docs/hip-16.md
+++ b/docs/hip-16.md
@@ -15,34 +15,51 @@ superseded-by:
 
 ## Abstract
 
-When a Hedera entity is created, the payer account is charged enough hbars (as a rental fee) so that the entity can stay active in the ledger state until it reaches the expiration time. Users can extend the expiration time of an entity by paying the appropriate fee for the extension via an update transaction. This HIP defines and discusses another mechanism to be implemented by Hedera Services to automatically renew, using funds of the related accounts, or delete entities lacking such funds.
+When a Hedera entity is created, the payer account is charged enough hbars (as a rental fee) for the entity to stay active 
+in the ledger state until consensus time passes its _expiration time_. Users can extend the expiration time of an entity by 
+paying an extension fee via an update transaction. This HIP defines and discusses another mechanism to be implemented by 
+Hedera Services to automatically renew expired entities using funds of linked _autorenew accounts_ or _admin accounts_; and 
+automatically remove expired entities that lack a funded autorenew account (or are deleted).
 
 ## Motivation
 
-At the time of this writing, the expiration time of a Hedera entity is not checked or enforced. An entity continues to stay active in the ledger after its expiration time, without fees being charged. Hedera Services will __start to charge rent__ for automatically renewing entities or will delete the entity from the ledger if the admin account (or the autoRenewAccount) of the entity has a zero balance at the time of renewal.
+Prior to this HIP, the expiration time of a Hedera entity has not been checked or enforced. An entity remains active in 
+the ledger even after its expiration time, without additional fees being charged. Upon implementation of this HIP, 
+Hedera Services will __begin to charge rent__ for automatically renewed entities; and will remove from the ledger expired
+entities which are either deleted, or have an admin/autorenew account with zero balance at the time renewal fees are due.
 
 ## Rationale
 
-This section seems to be a duplicate of the `Motivation` section above. We will add more details if it is required.
+This section seems to be a duplicate of the `Motivation` section above. We will add more details if required.
 
 ## Specification
 
-All nodes in a system of Hedera Services will perform a synchronous scanning of entities in the ledger. For those entities that have expired, Hedera Services will try to renew them by charging their admin account (or `autoRenewAccount`) for an extension of `autoRenewPeriod`. Records will be added to the record stream for these ledger actions and will be available via mirror nodes. __No__ receipts or records for autorenewal actions will be available via HAPI queries.
+All Hedera Services nodes will perform a synchronous scanning of active entities. When a node finds a non-deleted, expired 
+entity, it will try to renew the entity by charging its admin or autorenew account the renewal fee, for an extension
+period given in seconds. 
 
-Please note that if the `autoRenewAccount` does not have enough balance to cover the fee for an extension of `autoRenewPeriod`, the remaining balance will be wholly used for a shorter extension of the entity, and the autoRenewAccount will have zero balance after this extension. If the autoRenewAccount already reaches a zero balance at the time of renewal, the entity will be deleted permanently from the ledger.
+This extension period can be customized by the `autoRenewPeriod` property of a crypto account, 
+a topic, a smart contract, or a token. For a file, the extension period will be three months. (Future protobuf changes will
+permit customizing this extension period as well.) Records of autorenew charges will appear in the record stream, and 
+will be available via mirror nodes. __No__ receipts or records for autorenewal actions will be available via HAPI queries.
 
-Hedera Services will generate an [autorenewal-record](https://github.com/hashgraph/hedera-services/blob/autorenew-document/docs/autorenew-feature.md#autorenewal-record) for the action on an entity that is autorenewed. Hedera Services will generate an [autodeletion-record](https://github.com/hashgraph/hedera-services/blob/autorenew-document/docs/autorenew-feature.md#autodeletion-record) for the action on each entity that is found deemed to have expired.
+If the linked autorenew or admin account cannot cover the fee required for the default extension period, its remaining balance 
+will be wholly used for a shorter extension of the entity. If the linked account already has a zero balance at the time that 
+renewal fees are due, the entity will be removed permanently from the ledger. Similarly, any expired entity that was already
+marked deleted will be removed from the ledger.
 
-Crypto accounts will be prioritized for autorenewal followed by consensus topics, tokens and smart contracts.
+Hedera Services will generate an [autorenewal-record](https://github.com/hashgraph/hedera-services/blob/autorenew-document/docs/autorenew-feature.md#autorenewal-record) 
+for the action on an entity that is autorenewed. Hedera Services will generate an [autoremoval-record](https://github.com/hashgraph/hedera-services/blob/autorenew-document/docs/autorenew-feature.md#autodeletion-record) 
+for the action on each entity that is automatically removed.
 
-Files do not have an autoRenewAccount so they can only be renewed manually by a file update. We will extend the protobufs for files in the future.
-
-Scheduled transactions do not autorenew. They will be deleted from the ledger after they have expired.
+Crypto accounts will be prioritized for autorenewal, followed by consensus topics, tokens and smart contracts. Schedule entities 
+do not autorenew, and are always removed from the ledger when they expire.
 
 ## Backwards Compatibility
 
-There is no change in existing protobufs. Account and entity owners must ensure that accounts responsible for the renewal of an entity have a sufficient balance or risk deletion of the entity.
-Hedera Services will __start to charge__ for an extension automatically or will delete the entity from the ledger at the time of renewal. The Product team will decide and communicate on when this feature is turned on.
+There is no change in existing protobufs. Account and entity owners must ensure that linked autorenew and admin accounts have 
+sufficient balances for autorenewal fees, or risk permanent removal of their entity! The Hedera Product team will set and
+publicize the timeline for enabling the autorenewal and autoremoval behaviors.
 
 ## Security Implications
 


### PR DESCRIPTION
**Summary of changes**
- Consistently differentiate between _deletion_ and _removal_ of an entity. (That is, entities marked deleted are not removed until they expire.)
- Other minor wording and style suggestions.

