### PR TITLE
01198 d misc basic jrs failure

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1518,7 +1518,7 @@ workflows:
   GCP-Daily-Services-Account-Balances-client-validation-6N-1C:
     triggers:
       - schedule:
-          cron: "42 16 * * *"
+          cron: "56 19 * * *"
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1515,6 +1515,52 @@ workflows:
             - attach_workspace:
                 at: /
 
+  GCP-Daily-Services-Account-Balances-client-validation-6N-1C:
+    triggers:
+      - schedule:
+          cron: "42 16 * * *"
+          filters:
+            branches:
+              only:
+                - 01198-D-Misc-Basic-JRS-failure
+    jobs:
+      - build-platform-and-services
+      - jrs-regression:
+          context: Slack
+          regression_path: /swirlds-platform/regression
+          result_path: results/6N_1C/Restart
+          config_type: "daily"
+          workflow-name: "GCP-Daily-Services-Balances-Validation-6N-1C"
+          requires:
+            - build-platform-and-services
+          pre-steps:
+            - install-tools
+            - attach_workspace:
+                at: /
+
+  GCP-Daily-Services-NetDelay-15N-1C:
+    triggers:
+      - schedule:
+          cron: "45 16 * * *"
+          filters:
+            branches:
+              only:
+                - 01198-D-Misc-Basic-JRS-failure
+    jobs:
+      - build-platform-and-services
+      - jrs-regression:
+          context: Slack
+          regression_path: /swirlds-platform/regression
+          result_path: results/6N_1C/Restart
+          config_type: "daily"
+          workflow-name: "GCP-Daily-Services-Comp-NetDelay-15N-1C"
+          requires:
+            - build-platform-and-services
+          pre-steps:
+            - install-tools
+            - attach_workspace:
+                at: /
+
   GCP-Daily-Services-Recovery-4N-1C:
     triggers:
       - schedule:
@@ -1877,6 +1923,7 @@ workflows:
               branches:
                 ignore:
                   - /.*-PERF/
+                  - 01198-D-Misc-Basic-JRS-failure
             workflow-name: "Continuous integration"
         - build-platform-and-services:
             context: SonarCloud
@@ -2253,7 +2300,7 @@ jobs:
             cd /swirlds-platform;
             sed -i -e 's/github.com/services-jrs-regression/g' .gitmodules;
             git submodule update --init --recursive --checkout;
-            cd regression;
+            cd regression; git checkout 01198-D-Misc-Basic-JRS-failure
             cd ..;
             mvn --no-transfer-progress clean install -DskipTests;
 
@@ -2864,10 +2911,10 @@ jobs:
         default: true
       slack_results_channel:
         type: string
-        default: "hedera-regression"
+        default: "hedera-regression-test"
       slack_summary_channel:
         type: string
-        default: "hedera-regression-summary"
+        default: "hedera-regression-test"
       workflow-name:
         type: string
         default: ""

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1559,8 +1559,8 @@ workflows:
           context: Slack
           regression_path: /swirlds-platform/regression
           result_path: results/15N_1C/Restart
-          config_type: "daily"
-          workflow-name: "GCP-Daily-Services-Comp-NetDelay-15N-1C"
+          config_type: "weekly"
+          workflow-name: "GCP-Weekly-Services-Comp-NetDelay-15N-1C"
           requires:
             - build-platform-and-services
           pre-steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1548,7 +1548,7 @@ workflows:
   GCP-Daily-Services-NetDelay-15N-1C:
     triggers:
       - schedule:
-          cron: "0 5 * * *"
+          cron: "0 5 * * 6"
           filters:
             branches:
               only:
@@ -1558,7 +1558,7 @@ workflows:
       - jrs-regression:
           context: Slack
           regression_path: /swirlds-platform/regression
-          result_path: results/6N_1C/Restart
+          result_path: results/15N_1C/Restart
           config_type: "daily"
           workflow-name: "GCP-Daily-Services-Comp-NetDelay-15N-1C"
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1525,11 +1525,11 @@ workflows:
   GCP-Daily-Services-Account-Balances-client-validation-6N-1C:
     triggers:
       - schedule:
-          cron: "56 19 * * *"
+          cron: "30 6 * * *"
           filters:
             branches:
               only:
-                - 01198-D-Misc-Basic-JRS-failure
+                - master
     jobs:
       - build-platform-and-services
       - jrs-regression:
@@ -1548,11 +1548,11 @@ workflows:
   GCP-Daily-Services-NetDelay-15N-1C:
     triggers:
       - schedule:
-          cron: "45 16 * * *"
+          cron: "0 5 * * *"
           filters:
             branches:
               only:
-                - 01198-D-Misc-Basic-JRS-failure
+                - master
     jobs:
       - build-platform-and-services
       - jrs-regression:
@@ -2289,7 +2289,7 @@ jobs:
             cd /swirlds-platform;
             sed -i -e 's/github.com/services-jrs-regression/g' .gitmodules;
             git submodule update --init --recursive --checkout;
-            cd regression; git checkout 01198-D-Misc-Basic-JRS-failure
+            cd regression;
             cd ..;
             mvn --no-transfer-progress clean install -DskipTests;
 
@@ -2900,10 +2900,10 @@ jobs:
         default: true
       slack_results_channel:
         type: string
-        default: "hedera-regression-test"
+        default: "hedera-regression"
       slack_summary_channel:
         type: string
-        default: "hedera-regression-test"
+        default: "hedera-regression-summary"
       workflow-name:
         type: string
         default: ""

--- a/hedera-node/src/main/java/com/hedera/services/state/exports/SignedStateBalancesExporter.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/exports/SignedStateBalancesExporter.java
@@ -115,9 +115,6 @@ public class SignedStateBalancesExporter implements BalancesExporter {
 	public boolean isTimeToExport(Instant now) {
 		if (periodBegin != NEVER
 				&& now.getEpochSecond() / exportPeriod != periodBegin.getEpochSecond() / exportPeriod) {
-			log.info(String.format("Now %s is time to export. periodBegin = %s, exportPeriod = %d.",
-					now.toString(), periodBegin.toString(), exportPeriod));
-
 			periodBegin = now;
 			return true;
 		}
@@ -163,7 +160,7 @@ public class SignedStateBalancesExporter implements BalancesExporter {
 			tryToSign(csvLoc);
 		}
 
-		log.info(" -> Took {}ms to export and sign CSV balances file", watch.getTime(TimeUnit.MILLISECONDS));
+		log.info(" -> Took {}ms to export and sign CSV balances file at {}", watch.getTime(TimeUnit.MILLISECONDS), exportTimeStamp);
 	}
 
 	private void toProtoFile(Instant exportTimeStamp) {
@@ -178,7 +175,7 @@ public class SignedStateBalancesExporter implements BalancesExporter {
 			tryToSign(protoLoc);
 		}
 
-		log.info(" -> Took {}ms to export and sign proto balances file", watch.getTime(TimeUnit.MILLISECONDS));
+		log.info(" -> Took {}ms to export and sign proto balances file at {}", watch.getTime(TimeUnit.MILLISECONDS), exportTimeStamp);
 	}
 
 	private void tryToSign(String csvLoc) {

--- a/hedera-node/src/main/java/com/hedera/services/state/exports/SignedStateBalancesExporter.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/exports/SignedStateBalancesExporter.java
@@ -124,9 +124,9 @@ public class SignedStateBalancesExporter implements BalancesExporter {
 			return true;
 		}
 		periodBegin = now;
-		if(log.isDebugEnabled()) {
-			log.debug(String.format("Now %s is NOT time to export.", now.toString()));
-		}
+//		if(log.isDebugEnabled()) {
+			log.info(String.format("Now %s is NOT time to export.", now.toString()));
+//		}
 		return false;
 	}
 

--- a/hedera-node/src/main/java/com/hedera/services/state/exports/SignedStateBalancesExporter.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/exports/SignedStateBalancesExporter.java
@@ -96,7 +96,6 @@ public class SignedStateBalancesExporter implements BalancesExporter {
 
 	Instant periodBegin = NEVER;
 	private final int exportPeriod;
-	private static int SCHEDULED_EXPORT_ALLOWED_SKEW = 1;
 
 	static final Comparator<SingleAccountBalances> SINGLE_ACCOUNT_BALANCES_COMPARATOR =
 			Comparator.comparing(SingleAccountBalances::getAccountID, ACCOUNT_ID_COMPARATOR);
@@ -115,8 +114,7 @@ public class SignedStateBalancesExporter implements BalancesExporter {
 	@Override
 	public boolean isTimeToExport(Instant now) {
 		if (periodBegin != NEVER
-				&& now.getEpochSecond() / exportPeriod != periodBegin.getEpochSecond() / exportPeriod
-		        && now.getEpochSecond() % exportPeriod <= SCHEDULED_EXPORT_ALLOWED_SKEW) {
+				&& now.getEpochSecond() / exportPeriod != periodBegin.getEpochSecond() / exportPeriod) {
 			log.info(String.format("Now %s is time to export. periodBegin = %s, exportPeriod = %d.",
 					now.toString(), periodBegin.toString(), exportPeriod));
 

--- a/hedera-node/src/main/java/com/hedera/services/state/exports/SignedStateBalancesExporter.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/exports/SignedStateBalancesExporter.java
@@ -96,6 +96,7 @@ public class SignedStateBalancesExporter implements BalancesExporter {
 
 	Instant periodBegin = NEVER;
 	private final int exportPeriod;
+	private static int SCHEDULED_EXPORT_ALLOWED_SKEW = 1;
 
 	static final Comparator<SingleAccountBalances> SINGLE_ACCOUNT_BALANCES_COMPARATOR =
 			Comparator.comparing(SingleAccountBalances::getAccountID, ACCOUNT_ID_COMPARATOR);
@@ -114,11 +115,18 @@ public class SignedStateBalancesExporter implements BalancesExporter {
 	@Override
 	public boolean isTimeToExport(Instant now) {
 		if (periodBegin != NEVER
-				&& now.getEpochSecond() / exportPeriod != periodBegin.getEpochSecond() / exportPeriod) {
+				&& now.getEpochSecond() / exportPeriod != periodBegin.getEpochSecond() / exportPeriod
+		        && now.getEpochSecond() % exportPeriod <= SCHEDULED_EXPORT_ALLOWED_SKEW) {
+			log.info(String.format("Now %s is time to export. periodBegin = %s, exportPeriod = %d.",
+					now.toString(), periodBegin.toString(), exportPeriod));
+
 			periodBegin = now;
 			return true;
 		}
 		periodBegin = now;
+		if(log.isDebugEnabled()) {
+			log.debug(String.format("Now %s is NOT time to export.", now.toString()));
+		}
 		return false;
 	}
 

--- a/hedera-node/src/main/java/com/hedera/services/state/exports/SignedStateBalancesExporter.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/exports/SignedStateBalancesExporter.java
@@ -124,9 +124,9 @@ public class SignedStateBalancesExporter implements BalancesExporter {
 			return true;
 		}
 		periodBegin = now;
-//		if(log.isDebugEnabled()) {
-			log.info(String.format("Now %s is NOT time to export.", now.toString()));
-//		}
+		if(log.isDebugEnabled()) {
+			log.debug(String.format("Now %s is NOT time to export.", now.toString()));
+		}
 		return false;
 	}
 

--- a/hedera-node/src/test/java/com/hedera/services/state/exports/SignedStateBalancesExporterTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/state/exports/SignedStateBalancesExporterTest.java
@@ -633,6 +633,10 @@ class SignedStateBalancesExporterTest {
 		assertTrue(subject.isTimeToExport(startTime.plusSeconds(1)));
 		assertEquals(startTime.plusSeconds(1), subject.periodBegin);
 
+		// The next consensus time moves out of allowed time window, no export
+		assertFalse(subject.isTimeToExport(startTime.plusSeconds(3)));
+		assertEquals(startTime.plusSeconds(3), subject.periodBegin);
+
 		shortlyAfter = startTime.plusSeconds(dynamicProperties.balancesExportPeriodSecs() / 2);
 		assertFalse(subject.isTimeToExport(shortlyAfter));
 		assertEquals(shortlyAfter, subject.periodBegin);

--- a/hedera-node/src/test/java/com/hedera/services/state/exports/SignedStateBalancesExporterTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/state/exports/SignedStateBalancesExporterTest.java
@@ -629,24 +629,16 @@ class SignedStateBalancesExporterTest {
 		given(mockLog.isDebugEnabled()).willReturn(true);
 		Instant startTime = Instant.parse("2021-03-11T10:59:59.0Z");
 
-		// now.getEpochSecond() % exportPeriod < ALLOWED_SKEW case
 		subject = new SignedStateBalancesExporter(properties, signer, dynamicProperties);
 		assertFalse(subject.isTimeToExport(startTime));
 		assertEquals(startTime, subject.periodBegin);
 		assertTrue(subject.isTimeToExport(startTime.plusSeconds(1)));
 		assertEquals(startTime.plusSeconds(1), subject.periodBegin);
 
-		// now.getEpochSecond() % exportPeriod == ALLOWED_SKEW case
 		subject = new SignedStateBalancesExporter(properties, signer, dynamicProperties);
 		assertFalse(subject.isTimeToExport(startTime));
 		assertTrue(subject.isTimeToExport(startTime.plusSeconds(2)));
 		assertEquals(startTime.plusSeconds(2), subject.periodBegin);
-
-		// The next consensus time moves out of allowed time window, no export
-		subject = new SignedStateBalancesExporter(properties, signer, dynamicProperties);
-		assertFalse(subject.isTimeToExport(startTime));
-		assertFalse(subject.isTimeToExport(startTime.plusSeconds(3)));
-		assertEquals(startTime.plusSeconds(3), subject.periodBegin);
 
 		// Other scenarios
 		shortlyAfter = startTime.plusSeconds(dynamicProperties.balancesExportPeriodSecs() / 2);

--- a/hedera-node/src/test/java/com/hedera/services/state/exports/SignedStateBalancesExporterTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/state/exports/SignedStateBalancesExporterTest.java
@@ -626,17 +626,29 @@ class SignedStateBalancesExporterTest {
 
 	@Test
 	public void exportsWhenPeriodSecsHaveElapsed() {
-		subject = new SignedStateBalancesExporter(properties, signer, dynamicProperties);
+		given(mockLog.isDebugEnabled()).willReturn(true);
 		Instant startTime = Instant.parse("2021-03-11T10:59:59.0Z");
+
+		// now.getEpochSecond() % exportPeriod < ALLOWED_SKEW case
+		subject = new SignedStateBalancesExporter(properties, signer, dynamicProperties);
 		assertFalse(subject.isTimeToExport(startTime));
 		assertEquals(startTime, subject.periodBegin);
 		assertTrue(subject.isTimeToExport(startTime.plusSeconds(1)));
 		assertEquals(startTime.plusSeconds(1), subject.periodBegin);
 
+		// now.getEpochSecond() % exportPeriod == ALLOWED_SKEW case
+		subject = new SignedStateBalancesExporter(properties, signer, dynamicProperties);
+		assertFalse(subject.isTimeToExport(startTime));
+		assertTrue(subject.isTimeToExport(startTime.plusSeconds(2)));
+		assertEquals(startTime.plusSeconds(2), subject.periodBegin);
+
 		// The next consensus time moves out of allowed time window, no export
+		subject = new SignedStateBalancesExporter(properties, signer, dynamicProperties);
+		assertFalse(subject.isTimeToExport(startTime));
 		assertFalse(subject.isTimeToExport(startTime.plusSeconds(3)));
 		assertEquals(startTime.plusSeconds(3), subject.periodBegin);
 
+		// Other scenarios
 		shortlyAfter = startTime.plusSeconds(dynamicProperties.balancesExportPeriodSecs() / 2);
 		assertFalse(subject.isTimeToExport(shortlyAfter));
 		assertEquals(shortlyAfter, subject.periodBegin);
@@ -649,6 +661,11 @@ class SignedStateBalancesExporterTest {
 		anEternityLater = startTime.plusSeconds(dynamicProperties.balancesExportPeriodSecs() * 2 + 1);
 		assertTrue(subject.isTimeToExport(anEternityLater));
 		assertEquals(anEternityLater, subject.periodBegin);
+
+		given(mockLog.isDebugEnabled()).willReturn(false);
+		subject = new SignedStateBalancesExporter(properties, signer, dynamicProperties);
+		startTime = Instant.parse("2021-03-11T10:59:59.0Z");
+		assertFalse(subject.isTimeToExport(startTime));
 	}
 
 	@AfterAll

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/AccountBalancesClientSaveLoadTest.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/AccountBalancesClientSaveLoadTest.java
@@ -161,7 +161,8 @@ public class AccountBalancesClientSaveLoadTest extends LoadTest  {
 						sleepFor(10 * SECOND),
 						withOpContext( (spec, log) -> {
 							log.info("Now get all {} accounts created and save it in spec", totalAccounts);
-							for(int i = totalAccounts - 1; i >=0; i-- ) {
+							//for(int i = totalAccounts - 1; i >=0; i-- ) {
+							for(int i = 0; i < totalAccounts ;  i++ ) {
 								var op = getAccountBalance(ACCT_NAME_PREFIX + i)
 										.hasAnswerOnlyPrecheckFrom(permissiblePrechecks)
 										.persists(true)
@@ -211,10 +212,11 @@ public class AccountBalancesClientSaveLoadTest extends LoadTest  {
 						.withRecharging()
 						.rechargeWindow(30)
 						.noLogging()
+						.deferStatusResolution()
 						;
-				if (next > 0) {
-					op.deferStatusResolution();
-				}
+//				if (next > 0) {
+//					op.deferStatusResolution();
+//				}
 				return Optional.of(op);
 			}
 		};

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/AccountBalancesClientSaveLoadTest.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/AccountBalancesClientSaveLoadTest.java
@@ -161,8 +161,7 @@ public class AccountBalancesClientSaveLoadTest extends LoadTest  {
 						sleepFor(10 * SECOND),
 						withOpContext( (spec, log) -> {
 							log.info("Now get all {} accounts created and save it in spec", totalAccounts);
-							//for(int i = totalAccounts - 1; i >=0; i-- ) {
-							for(int i = 0; i < totalAccounts ;  i++ ) {
+							for(int i = totalAccounts - 1; i >=0; i-- ) {
 								var op = getAccountBalance(ACCT_NAME_PREFIX + i)
 										.hasAnswerOnlyPrecheckFrom(permissiblePrechecks)
 										.persists(true)
@@ -212,11 +211,7 @@ public class AccountBalancesClientSaveLoadTest extends LoadTest  {
 						.withRecharging()
 						.rechargeWindow(30)
 						.noLogging()
-						.deferStatusResolution()
-						;
-//				if (next > 0) {
-//					op.deferStatusResolution();
-//				}
+						.deferStatusResolution();
 				return Optional.of(op);
 			}
 		};


### PR DESCRIPTION
Closes #1198

Test links for account balance validation: 
https://hedera-hashgraph.slack.com/archives/C018CBQBTGB/p1617144468089900
https://hedera-hashgraph.slack.com/archives/C018CBQBTGB/p1617642058166000

Test link for 15N NetDelay test: https://hedera-hashgraph.slack.com/archives/C018CBQBTGB/p1617298643138200

Opened an issue: https://github.com/hashgraph/hedera-services/issues/1229 to track the possible failure of the account balances file is scheduled to export off of the epoch export period boundary. 

**Summary of the change**:
1. Added account balances validation JRS  as a separate workflow; 
2. Some minor changes to fix occasional failure for client account balances validation;
3. Added 15-node NetDelay JRS workflow;


**External impacts**:
None.

**Applicable documentation**
- [ ] Javadoc
- [ ] HAPI protobuf comments
- [ ] README
