### PR TITLE
Exclude unneeded org.ethereum dependencies, remove Ethereum bintray repository

### DIFF
--- a/hedera-node/pom.xml
+++ b/hedera-node/pom.xml
@@ -293,6 +293,20 @@
       <groupId>com.hedera.hashgraph</groupId>
       <artifactId>ethereumj-core</artifactId>
       <version>${ethereum-core.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.ethereum</groupId>
+          <artifactId>leveldbjni-all</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.ethereum</groupId>
+          <artifactId>rocksdbjni</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.ethereum</groupId>
+          <artifactId>solcJ-all</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
@@ -367,11 +381,6 @@
       <id>central</id>
       <name>bintray</name>
       <url>https://jcenter.bintray.com</url>
-    </repository>
-    <repository>
-      <id>Ethereum</id>
-      <name>Ethereum</name>
-      <url>https://dl.bintray.com/ethereum/maven/</url>
     </repository>
   </repositories>
   <profiles>


### PR DESCRIPTION
**Summary of the change**:
- Exclude unneeded transitive dependencies from the `org.ethereum` group.
- Remove the `https://dl.bintray.com/ethereum/maven/` repository, which will be shortly unavailable in any case.
