### PR TITLE
Strip whitespace from preprod/api-permission.properties

### DIFF
--- a/hedera-node/configuration/preprod/api-permission.properties
+++ b/hedera-node/configuration/preprod/api-permission.properties
@@ -44,10 +44,10 @@ systemUndelete=60
 freeze=58
 
 # Scheduling
-scheduleCreate=0-*                                                             
-scheduleDelete=0-*                                                             
-scheduleGetInfo=0-*                                                            
-scheduleSign=0-*   
+scheduleCreate=0-*
+scheduleDelete=0-*
+scheduleGetInfo=0-*
+scheduleSign=0-*
 
 # HCS
 createTopic=0-*


### PR DESCRIPTION
**Summary of the change**:
Remove whitespace from the end of the `schedule*` ops in _configuration/preprod-api-permission.properties_

**External impacts**:
Allow DevOps to use this config for deployment with schedule ops enabled.