### PR TITLE
Use node-agnostic path in disk-based file system

### DIFF
--- a/hedera-node/src/main/java/com/hedera/services/ServicesState.java
+++ b/hedera-node/src/main/java/com/hedera/services/ServicesState.java
@@ -229,8 +229,7 @@ public class ServicesState extends AbstractNaryMerkleInternal implements SwirldS
 			setChild(ChildIndices.ACCOUNTS, new FCMap<>());
 			setChild(ChildIndices.TOKENS, new FCMap<>());
 			setChild(ChildIndices.TOKEN_ASSOCIATIONS, new FCMap<>());
-			setChild(ChildIndices.DISK_FS,
-					new MerkleDiskFs(diskFsBaseDirPath, asLiteralString(ctx.nodeAccount())));
+			setChild(ChildIndices.DISK_FS, new MerkleDiskFs());
 			setChild(ChildIndices.SCHEDULE_TXS, new FCMap<>());
 		} else {
 			log.info("Init called on Services node {} WITH Merkle saved state", nodeId);
@@ -240,8 +239,6 @@ public class ServicesState extends AbstractNaryMerkleInternal implements SwirldS
 			constructed from state with this node's account, which the DiskFs will use to scope the
 			path to its disk-based storage. */
 			var restoredDiskFs = diskFs();
-			restoredDiskFs.setFsBaseDir(diskFsBaseDirPath);
-			restoredDiskFs.setFsNodeScopedDir(asLiteralString(ctx.nodeAccount()));
 			if (!skipDiskFsHashCheck) {
 				restoredDiskFs.checkHashesAgainstDiskContents();
 			}

--- a/hedera-node/src/main/java/com/hedera/services/ServicesState.java
+++ b/hedera-node/src/main/java/com/hedera/services/ServicesState.java
@@ -210,7 +210,6 @@ public class ServicesState extends AbstractNaryMerkleInternal implements SwirldS
 		setChild(ChildIndices.ADDRESS_BOOK, addressBook);
 
 		var bootstrapProps = new BootstrapProperties();
-		var diskFsBaseDirPath = bootstrapProps.getStringProperty("files.diskFsBaseDir.path");
 		var properties = new StandardizedPropertySources(bootstrapProps, loc -> new File(loc).exists());
 		try {
 			ctx = CONTEXTS.lookup(nodeId.getId());

--- a/hedera-node/src/main/java/com/hedera/services/context/properties/BootstrapProperties.java
+++ b/hedera-node/src/main/java/com/hedera/services/context/properties/BootstrapProperties.java
@@ -168,7 +168,6 @@ public class BootstrapProperties implements PropertySource {
 			"accounts.systemUndeleteAdmin",
 			"accounts.treasury",
 			"files.addressBook",
-			"files.diskFsBaseDir.path",
 			"files.networkProperties",
 			"files.exchangeRates",
 			"files.feeSchedules",

--- a/hedera-node/src/main/java/com/hedera/services/state/merkle/MerkleDiskFs.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/merkle/MerkleDiskFs.java
@@ -326,11 +326,11 @@ public class MerkleDiskFs extends AbstractMerkleLeaf implements MerkleExternalLe
 		this.writeHelper = writeHelper;
 	}
 
-	public ThrowingBytesGetter getBytesHelper() {
+	ThrowingBytesGetter getBytesHelper() {
 		return bytesHelper;
 	}
 
-	public ThrowingBytesWriter getWriteHelper() {
+	ThrowingBytesWriter getWriteHelper() {
 		return writeHelper;
 	}
 }

--- a/hedera-node/src/main/resources/bootstrap.properties
+++ b/hedera-node/src/main/resources/bootstrap.properties
@@ -24,7 +24,6 @@ accounts.systemDeleteAdmin=59
 accounts.systemUndeleteAdmin=60
 accounts.treasury=2
 files.addressBook=101
-files.diskFsBaseDir.path=data/diskFs/
 files.networkProperties=121
 files.exchangeRates=112
 files.feeSchedules=111

--- a/hedera-node/src/test/java/com/hedera/services/ServicesStateTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/ServicesStateTest.java
@@ -384,8 +384,6 @@ class ServicesStateTest {
 		subject.init(platform, book);
 
 		// then:
-		inOrder.verify(ctx).nodeAccount();
-		// during migration, if the records directory doesn't have old files, initialHash will be empty hash
 		inOrder.verify(ctx).setRecordsInitialHash(EMPTY_HASH);
 		inOrder.verify(ctx).update(subject);
 		inOrder.verify(ctx).rebuildBackingStoresIfPresent();
@@ -409,7 +407,6 @@ class ServicesStateTest {
 		subject.init(platform, book);
 
 		// then:
-		inOrder.verify(ctx).nodeAccount();
 		inOrder.verify(ctx).update(subject);
 		inOrder.verify(ctx).rebuildBackingStoresIfPresent();
 		inOrder.verify(historian).reviewExistingRecords();
@@ -496,9 +493,6 @@ class ServicesStateTest {
 		InOrder inOrder = inOrder(
 				scheduledTxs, runningHashLeaf, diskFs, ctx, mockDigest,
 				accounts, storage, topics, tokens, tokenAssociations, networkCtx, book);
-		inOrder.verify(diskFs).setFsBaseDir(any());
-		inOrder.verify(ctx).nodeAccount();
-		inOrder.verify(diskFs).setFsNodeScopedDir(any());
 		inOrder.verify(diskFs).checkHashesAgainstDiskContents();
 		inOrder.verify(ctx).setRecordsInitialHash(recordsHash);
 		inOrder.verify(mockDigest).accept(subject);

--- a/hedera-node/src/test/java/com/hedera/services/context/properties/BootstrapPropertiesTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/context/properties/BootstrapPropertiesTest.java
@@ -88,7 +88,6 @@ class BootstrapPropertiesTest {
 			entry("fees.percentCongestionMultipliers", CongestionMultipliers.from("90,10x,95,25x,99,100x")),
 			entry("fees.minCongestionPeriod", 60),
 			entry("files.addressBook", 101L),
-			entry("files.diskFsBaseDir.path", "data/diskFs/"),
 			entry("files.networkProperties", 121L),
 			entry("files.exchangeRates", 112L),
 			entry("files.feeSchedules", 111L),

--- a/hedera-node/src/test/resources/bootstrap/standard.properties
+++ b/hedera-node/src/test/resources/bootstrap/standard.properties
@@ -24,7 +24,6 @@ accounts.systemDeleteAdmin=59
 accounts.systemUndeleteAdmin=60
 accounts.treasury=2
 files.addressBook=101
-files.diskFsBaseDir.path=data/diskFs/
 files.networkProperties=121
 files.exchangeRates=112
 files.feeSchedules=111


### PR DESCRIPTION
**Related issue(s)**:
 - Expected to close #1042 and close #1223
 - Related to swirlds/swirlds-platform-regression#709

**Summary of the change**:
 - Remove node-scoped path segments from the paths of files in the `MerkleDiskFs` disk-based file system.
 - This avoids hard-to-solve race conditions between `ServicesState.init()` and `MerkleDiskFs` serdes during reconnect.