### PR TITLE
Add checks to handle situations when server not able to create accounts.

### DIFF
--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/AccountBalancesClientSaveLoadTest.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/AccountBalancesClientSaveLoadTest.java
@@ -200,7 +200,7 @@ public class AccountBalancesClientSaveLoadTest extends LoadTest  {
 		log.info("Total accounts: {}", totalAccounts);
 		log.info("Total tokens: {}", totalTestTokens);
 
-		AtomicInteger moreToCreate = new AtomicInteger(totalAccounts - 1);
+		AtomicInteger moreToCreate = new AtomicInteger(totalAccounts );
 
 		return spec -> new OpProvider() {
 			@Override
@@ -212,7 +212,8 @@ public class AccountBalancesClientSaveLoadTest extends LoadTest  {
 			@Override
 			public Optional<HapiSpecOperation> get() {
 				int next;
-				if ((next = moreToCreate.getAndDecrement()) < 0) {
+				next = moreToCreate.getAndDecrement();
+				if (next <= 0) {
 					return Optional.empty();
 				}
 
@@ -246,7 +247,8 @@ public class AccountBalancesClientSaveLoadTest extends LoadTest  {
 			@Override
 			public Optional<HapiSpecOperation> get() {
 				int next;
-				if ((next = createdSofar.getAndIncrement()) >= totalTestTokens) {
+				next = createdSofar.getAndIncrement();
+				if (next >= totalTestTokens) {
 					return Optional.empty();
 				}
 				var payingTreasury = String.format(ACCT_NAME_PREFIX + next);

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/AccountBalancesClientSaveLoadTest.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/AccountBalancesClientSaveLoadTest.java
@@ -23,7 +23,9 @@ package com.hedera.services.bdd.suites.perf;
 import com.hedera.services.bdd.spec.HapiApiSpec;
 import com.hedera.services.bdd.spec.HapiSpecOperation;
 import com.hedera.services.bdd.spec.infrastructure.OpProvider;
+import com.hedera.services.bdd.spec.infrastructure.RegistryNotFound;
 import com.hedera.services.bdd.spec.utilops.LoadTest;
+import com.hederahashgraph.api.proto.java.AccountID;
 import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.logging.log4j.LogManager;
@@ -61,6 +63,7 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.ACCOUNT_REPEAT
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.BUSY;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.DUPLICATE_TRANSACTION;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INSUFFICIENT_TOKEN_BALANCE;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INSUFFICIENT_TX_FEE;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_SIGNATURE;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OK;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.PLATFORM_TRANSACTION_NOT_CREATED;
@@ -135,7 +138,7 @@ public class AccountBalancesClientSaveLoadTest extends LoadTest  {
 								.maxOpsPerSec(() -> settings.getTps())
 								.maxPendingOps(() -> MAX_PENDING_OPS_FOR_SETUP)),
 
-						sleepFor(20 * SECOND),
+						sleepFor(10 * SECOND),
 
 						sourcing(() -> runWithProvider(tokensCreate(settings))
 								.lasting(() -> totalTestTokens / ESTIMATED_TOKEN_CREATION_RATE + 10,
@@ -160,13 +163,21 @@ public class AccountBalancesClientSaveLoadTest extends LoadTest  {
 				).then(
 						sleepFor(10 * SECOND),
 						withOpContext( (spec, log) -> {
-							log.info("Now get all {} accounts created and save it in spec", totalAccounts);
-							for(int i = totalAccounts - 1; i >=0; i-- ) {
-								var op = getAccountBalance(ACCT_NAME_PREFIX + i)
+							log.info("Now get all {} accounts created and save them", totalAccounts);
+							AccountID acctID = AccountID.getDefaultInstance();
+							for(int i = 0; i < totalAccounts; i++ ) {
+								String acctName = ACCT_NAME_PREFIX + i;
+								// Make sure the named account was created before query its balances.
+								try {
+									acctID = spec.registry().getAccountID(acctName);
+								} catch (RegistryNotFound e) {
+									log.info(acctName + " was not created successfully, which is normal...");
+									continue;
+								}
+								var op = getAccountBalance("0.0." + acctID.getAccountNum())
 										.hasAnswerOnlyPrecheckFrom(permissiblePrechecks)
 										.persists(true)
 										.noLogging();
-
 								allRunFor(spec, op);
 							}
 						}),
@@ -188,7 +199,7 @@ public class AccountBalancesClientSaveLoadTest extends LoadTest  {
 		log.info("Total accounts: {}", totalAccounts);
 		log.info("Total tokens: {}", totalTestTokens);
 
-		AtomicInteger createdSofar = new AtomicInteger(0);
+		AtomicInteger createdSofar = new AtomicInteger(totalAccounts - 1);
 
 		return spec -> new OpProvider() {
 			@Override
@@ -200,18 +211,22 @@ public class AccountBalancesClientSaveLoadTest extends LoadTest  {
 			@Override
 			public Optional<HapiSpecOperation> get() {
 				int next;
-				if ((next = createdSofar.getAndIncrement()) >= totalAccounts) {
+				if ((next = createdSofar.getAndDecrement()) < 0) {
 					return Optional.empty();
 				}
 
 				var op =  cryptoCreate(String.format("%s%s",ACCT_NAME_PREFIX , next))
-						.balance((long)(r.nextInt((int)ONE_HBAR) * 1000 + MIN_ACCOUNT_BALANCE))
+						.balance((long)(r.nextInt((int)ONE_HBAR) + MIN_ACCOUNT_BALANCE))
 						.key(GENESIS)
 						.fee(ONE_HUNDRED_HBARS)
 						.withRecharging()
 						.rechargeWindow(30)
+						.hasRetryPrecheckFrom(NOISY_RETRY_PRECHECKS)
+						.hasPrecheckFrom(DUPLICATE_TRANSACTION, OK, INSUFFICIENT_TX_FEE)
+						.hasKnownStatusFrom(SUCCESS,INVALID_SIGNATURE)
 						.noLogging()
 						.deferStatusResolution();
+
 				return Optional.of(op);
 			}
 		};

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/AccountBalancesClientSaveLoadTest.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/AccountBalancesClientSaveLoadTest.java
@@ -21,6 +21,7 @@ package com.hedera.services.bdd.suites.perf;
  */
 
 import com.hedera.services.bdd.spec.HapiApiSpec;
+import com.hedera.services.bdd.spec.HapiPropertySource;
 import com.hedera.services.bdd.spec.HapiSpecOperation;
 import com.hedera.services.bdd.spec.infrastructure.OpProvider;
 import com.hedera.services.bdd.spec.infrastructure.RegistryNotFound;
@@ -171,10 +172,10 @@ public class AccountBalancesClientSaveLoadTest extends LoadTest  {
 								try {
 									acctID = spec.registry().getAccountID(acctName);
 								} catch (RegistryNotFound e) {
-									log.info(acctName + " was not created successfully, which is normal...");
+									log.info(acctName + " was not created successfully.");
 									continue;
 								}
-								var op = getAccountBalance("0.0." + acctID.getAccountNum())
+								var op = getAccountBalance(HapiPropertySource.asAccountString(acctID))
 										.hasAnswerOnlyPrecheckFrom(permissiblePrechecks)
 										.persists(true)
 										.noLogging();
@@ -199,7 +200,7 @@ public class AccountBalancesClientSaveLoadTest extends LoadTest  {
 		log.info("Total accounts: {}", totalAccounts);
 		log.info("Total tokens: {}", totalTestTokens);
 
-		AtomicInteger createdSofar = new AtomicInteger(totalAccounts - 1);
+		AtomicInteger moreToCreate = new AtomicInteger(totalAccounts - 1);
 
 		return spec -> new OpProvider() {
 			@Override
@@ -211,11 +212,11 @@ public class AccountBalancesClientSaveLoadTest extends LoadTest  {
 			@Override
 			public Optional<HapiSpecOperation> get() {
 				int next;
-				if ((next = createdSofar.getAndDecrement()) < 0) {
+				if ((next = moreToCreate.getAndDecrement()) < 0) {
 					return Optional.empty();
 				}
 
-				var op =  cryptoCreate(String.format("%s%s",ACCT_NAME_PREFIX , next))
+				var op =  cryptoCreate(String.format("%s%d",ACCT_NAME_PREFIX , next))
 						.balance((long)(r.nextInt((int)ONE_HBAR) + MIN_ACCOUNT_BALANCE))
 						.key(GENESIS)
 						.fee(ONE_HUNDRED_HBARS)


### PR DESCRIPTION
**Related issue(s)**:
Closes #1269

**Summary of the change**:

1. Added defensives to prevent test failure due to server node's failure to create accounts. 


**External impacts**:
None.

**Applicable documentation**
- [ ] Javadoc
- [ ] HAPI protobuf comments
- [ ] README
