### PR TITLE
01268 d 6 n perf platform not active error

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1641,13 +1641,11 @@ workflows:
   GCP-Daily-Services-Comp-Restart-Performance-Random-6N-6C:
     triggers:
       - schedule:
-#          cron: "30 4 * * 3,0"
-          cron: "42 1 * * *"
+          cron: "30 4 * * 3,0"
           filters:
             branches:
               only:
-#                - master
-                - 01268-D-6N-perf-platform-not-active-error
+                - master
     jobs:
       - build-platform-and-services
       - jrs-regression:
@@ -1667,12 +1665,11 @@ workflows:
   GCP-Daily-Services-HTS-Restart-Performance-6N-6C:
     triggers:
       - schedule:
-#          cron: "0 8 * * 3,0"
-          cron: "45 1 * * *"
+          cron: "30 8 * * 3,0"
           filters:
             branches:
               only:
-                - 01268-D-6N-perf-platform-not-active-error
+                - master
     jobs:
       - build-platform-and-services
       - jrs-regression:
@@ -1982,7 +1979,6 @@ workflows:
               branches:
                 ignore:
                   - /.*-PERF/
-                  - 01268-D-6N-perf-platform-not-active-error
             workflow-name: "Continuous-integration"
         - build-platform-and-services:
             context: SonarCloud
@@ -2259,7 +2255,7 @@ jobs:
             cd /swirlds-platform;
             sed -i -e 's/github.com/services-jrs-regression/g' .gitmodules;
             git submodule update --init --recursive --checkout;
-            cd regression; git checkout 01268-D-6N-perf-platform-not-active-error
+            cd regression;
             cd ..;
             mvn --no-transfer-progress clean install -DskipTests;
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1641,11 +1641,13 @@ workflows:
   GCP-Daily-Services-Comp-Restart-Performance-Random-6N-6C:
     triggers:
       - schedule:
-          cron: "30 4 * * 3,0"
+#          cron: "30 4 * * 3,0"
+          cron: "42 1 * * *"
           filters:
             branches:
               only:
-                - master
+#                - master
+                - 01268-D-6N-perf-platform-not-active-error
     jobs:
       - build-platform-and-services
       - jrs-regression:
@@ -1654,6 +1656,31 @@ workflows:
           result_path: results/6N_6C/Performance
           config_type: "daily"
           workflow-name: "GCP-Daily-Services-Comp-Restart-Performance-Random-6N-6C"
+          requires:
+            - build-platform-and-services
+          pre-steps:
+            - install-tools
+            - attach_workspace:
+                at: /
+
+
+  GCP-Daily-Services-HTS-Restart-Performance-6N-6C:
+    triggers:
+      - schedule:
+#          cron: "0 8 * * 3,0"
+          cron: "45 1 * * *"
+          filters:
+            branches:
+              only:
+                - 01268-D-6N-perf-platform-not-active-error
+    jobs:
+      - build-platform-and-services
+      - jrs-regression:
+          context: Slack
+          regression_path: /swirlds-platform/regression
+          result_path: results/6N_6C/Performance
+          config_type: "daily"
+          workflow-name: "GCP-Daily-Services-HTS-Restart-Performance-6N-6C"
           requires:
             - build-platform-and-services
           pre-steps:
@@ -1955,6 +1982,7 @@ workflows:
               branches:
                 ignore:
                   - /.*-PERF/
+                  - 01268-D-6N-perf-platform-not-active-error
             workflow-name: "Continuous-integration"
         - build-platform-and-services:
             context: SonarCloud
@@ -2231,7 +2259,7 @@ jobs:
             cd /swirlds-platform;
             sed -i -e 's/github.com/services-jrs-regression/g' .gitmodules;
             git submodule update --init --recursive --checkout;
-            cd regression;
+            cd regression; git checkout 01268-D-6N-perf-platform-not-active-error
             cd ..;
             mvn --no-transfer-progress clean install -DskipTests;
 


### PR DESCRIPTION
**Related issue(s)**:
Closes #1268 and #1265.

**Summary of the change**:
1. Add the 6-node perf regression for HTS which seems to be missing;

The changes that 'fix' these issues are on platform regression side.

Also opened issue https://github.com/hashgraph/hedera-services/issues/1290 to track why TPSs for 6-node random perf regression tests (Crypto, HCS, and HTS) can't stay on 10K. 

https://github.com/hashgraph/hedera-services/issues/1290
**External impacts**:
None.

**Applicable documentation**
- [ ] Javadoc
- [ ] HAPI protobuf comments
- [ ] README
