### PR TITLE
Automate setting Services and HAPI semvers in Maven build 

### DIFF
--- a/hedera-node/pom.xml
+++ b/hedera-node/pom.xml
@@ -58,6 +58,32 @@
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-resources-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>with-filtering</id>
+            <phase>process-resources</phase>
+            <goals>
+              <goal>resources</goal>
+            </goals>
+            <configuration>
+              <propertiesEncoding>ISO-8859-1</propertiesEncoding>
+              <resources>
+                <resource>
+                  <directory>src/main/resources</directory>
+                  <excludes>
+                    <!-- VIM swap files -->
+                    <exclude>**/*.sw*</exclude>
+                  </excludes>
+                  <filtering>true</filtering>
+                </resource>
+              </resources>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
         <executions>
           <execution>

--- a/hedera-node/src/main/java/com/hedera/services/context/properties/SemanticVersions.java
+++ b/hedera-node/src/main/java/com/hedera/services/context/properties/SemanticVersions.java
@@ -21,7 +21,6 @@ package com.hedera.services.context.properties;
  */
 
 import com.hedera.services.queries.meta.GetVersionInfoAnswer;
-import com.hedera.services.utils.EntityIdUtils;
 import com.hederahashgraph.api.proto.java.SemanticVersion;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -30,51 +29,72 @@ import java.io.InputStream;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.concurrent.atomic.AtomicReference;
-
-import static com.hedera.services.utils.EntityIdUtils.asDotDelimitedLongArray;
+import java.util.regex.Pattern;
 
 public class SemanticVersions {
 	private static final Logger log = LogManager.getLogger(SemanticVersions.class);
 
-	static String HAPI_VERSION_KEY = "hapi.proto.version";
-	static String HEDERA_VERSION_KEY = "hedera.services.version";
-	static String VERSION_INFO_RESOURCE = "semantic-version.properties";
+	/* From https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string */
+	private static final Pattern SEMVER_SPEC_REGEX = Pattern.compile(
+			"^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\." +
+					"(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$");
 
-	static AtomicReference<ActiveVersions> knownActive = new AtomicReference<>(null);
+	private static final String HAPI_VERSION_KEY = "hapi.proto.version";
+	private static final String HEDERA_VERSION_KEY = "hedera.services.version";
+
+	private String versionInfoResource = "semantic-version.properties";
+
+	private AtomicReference<ActiveVersions> knownActive = new AtomicReference<>(null);
 
 	public Optional<ActiveVersions> getDeployed() {
 		return Optional.ofNullable(knownActive.get())
 				.or(() -> Optional.ofNullable(fromResource(
-						VERSION_INFO_RESOURCE,
+						versionInfoResource,
 						HAPI_VERSION_KEY,
 						HEDERA_VERSION_KEY)));
 	}
 
-	private static ActiveVersions fromResource(String propertiesFile, String protoKey, String servicesKey) {
+	ActiveVersions fromResource(String propertiesFile, String protoKey, String servicesKey) {
 		try (InputStream in = GetVersionInfoAnswer.class.getClassLoader().getResourceAsStream(propertiesFile)) {
 			var props = new Properties();
 			props.load(in);
 			log.info("Discovered semantic versions {} from resource '{}'", props, propertiesFile);
-			knownActive.set(new ActiveVersions(
-					asSemVer((String)props.get(protoKey)),
-					asSemVer((String)props.get(servicesKey))));
+			var protoSemVer = asSemVer((String) props.get(protoKey));
+			var hederaSemVer = asSemVer((String) props.get(servicesKey));
+			knownActive.set(new ActiveVersions(protoSemVer, hederaSemVer));
 		} catch (Exception surprising) {
 			log.warn(
-					"Failed to read versions from resource '{}' (keys '{}' and '{}')",
+					"Failed to parse resource '{}' (keys '{}' and '{}'). Version info will be unavailable!",
 					propertiesFile,
 					protoKey,
 					servicesKey,
 					surprising);
+			var emptySemver = SemanticVersion.getDefaultInstance();
+			knownActive.set(new ActiveVersions(emptySemver, emptySemver));
 		}
 		return knownActive.get();
 	}
 
-	public static SemanticVersion asSemVer(String value) {
-		long[] parts = asDotDelimitedLongArray(value);
-		return SemanticVersion.newBuilder()
-				.setMajor((int)parts[0])
-				.setMinor((int)parts[1])
-				.setPatch((int)parts[2])
-				.build();
+	SemanticVersion asSemVer(String value) {
+		final var matcher = SEMVER_SPEC_REGEX.matcher(value);
+		if (matcher.matches()) {
+			final var builder = SemanticVersion.newBuilder()
+					.setMajor(Integer.parseInt(matcher.group(1)))
+					.setMinor(Integer.parseInt(matcher.group(2)))
+					.setPatch(Integer.parseInt(matcher.group(3)));
+			if (matcher.group(4) != null) {
+				builder.setPreReleaseVersion(matcher.group(4));
+			}
+			if (matcher.group(5) != null) {
+				builder.setBuildMetadata(matcher.group(5));
+			}
+			return builder.build();
+		} else {
+			throw new IllegalArgumentException("Argument value='" + value + "' is not a valid semver");
+		}
+	}
+
+	void setVersionInfoResource(String versionInfoResource) {
+		this.versionInfoResource = versionInfoResource;
 	}
 }

--- a/hedera-node/src/main/java/com/hedera/services/context/properties/SemanticVersions.java
+++ b/hedera-node/src/main/java/com/hedera/services/context/properties/SemanticVersions.java
@@ -83,10 +83,10 @@ public class SemanticVersions {
 					.setMinor(Integer.parseInt(matcher.group(2)))
 					.setPatch(Integer.parseInt(matcher.group(3)));
 			if (matcher.group(4) != null) {
-				builder.setPreReleaseVersion(matcher.group(4));
+				builder.setPre(matcher.group(4));
 			}
 			if (matcher.group(5) != null) {
-				builder.setBuildMetadata(matcher.group(5));
+				builder.setBuild(matcher.group(5));
 			}
 			return builder.build();
 		} else {

--- a/hedera-node/src/main/resources/semantic-version.properties
+++ b/hedera-node/src/main/resources/semantic-version.properties
@@ -1,2 +1,2 @@
-hapi.proto.version=0.13.0
-hedera.services.version=0.13.0
+hapi.proto.version=${hapi-proto.version}
+hedera.services.version=${project.version}

--- a/hedera-node/src/test/java/com/hedera/services/context/properties/SemanticVersionsTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/context/properties/SemanticVersionsTest.java
@@ -42,15 +42,15 @@ class SemanticVersionsTest {
 			.setMajor(1)
 			.setMinor(2)
 			.setPatch(4)
-			.setPreReleaseVersion("zeta.123")
-			.setBuildMetadata("2b26be40")
+			.setPre("zeta.123")
+			.setBuild("2b26be40")
 			.build();
 	private static final SemanticVersion FROZEN_SERVICES_SEMVER = SemanticVersion.newBuilder()
 			.setMajor(4)
 			.setMinor(2)
 			.setPatch(1)
-			.setPreReleaseVersion("alpha.0.1.0")
-			.setBuildMetadata("04eb62b2")
+			.setPre("alpha.0.1.0")
+			.setBuild("04eb62b2")
 			.build();
 
 	@Inject
@@ -73,8 +73,8 @@ class SemanticVersionsTest {
 				.setMajor(1)
 				.setMinor(2)
 				.setPatch(4)
-				.setPreReleaseVersion("alpha.1")
-				.setBuildMetadata("2b26be40")
+				.setPre("alpha.1")
+				.setBuild("2b26be40")
 				.build();
 
 		// when:
@@ -93,7 +93,7 @@ class SemanticVersionsTest {
 				.setMajor(1)
 				.setMinor(2)
 				.setPatch(4)
-				.setPreReleaseVersion("alpha.1")
+				.setPre("alpha.1")
 				.build();
 
 		// when:
@@ -130,7 +130,7 @@ class SemanticVersionsTest {
 				.setMajor(1)
 				.setMinor(2)
 				.setPatch(4)
-				.setBuildMetadata("2b26be40")
+				.setBuild("2b26be40")
 				.build();
 
 		// when:

--- a/hedera-node/src/test/resources/frozen-semantic-version.properties
+++ b/hedera-node/src/test/resources/frozen-semantic-version.properties
@@ -1,0 +1,2 @@
+hapi.proto.version=1.2.4-zeta.123+2b26be40
+hedera.services.version=4.2.1-alpha.0.1.0+04eb62b2

--- a/hedera-node/src/test/resources/frozenVersion.properties
+++ b/hedera-node/src/test/resources/frozenVersion.properties
@@ -1,2 +1,0 @@
-hapi.proto.version=0.4.0
-hedera.services.version=0.4.0

--- a/pom.xml
+++ b/pom.xml
@@ -146,6 +146,7 @@
     <!-- Plugin custom properties -->
     <maven-jar.version>3.2.0</maven-jar.version>
     <maven-source.version>3.2.0</maven-source.version>
+    <maven-resources.version>3.2.0</maven-resources.version>
     <maven-license.version>2.0.0</maven-license.version>
     <maven-compiler.version>3.8.1</maven-compiler.version>
     <maven-surefire.version>2.22.2</maven-surefire.version>
@@ -161,7 +162,7 @@
     <grpc.version>1.33.0</grpc.version>
     <jackson-databind.version>2.9.10.7</jackson-databind.version>
     <javax.annotation-api.version>1.3.2</javax.annotation-api.version>
-    <hapi-proto.version>0.13.0-rc.1</hapi-proto.version>
+    <hapi-proto.version>0.14.0-SNAPSHOT</hapi-proto.version>
     <javax-inject.version>1</javax-inject.version>
     <log4j.version>2.13.2</log4j.version>
     <netty.version>4.1.51.Final</netty.version>
@@ -318,6 +319,11 @@ ${git.signoff}
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-source-plugin</artifactId>
+          <version>${maven-source.version}</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-resources-plugin</artifactId>
           <version>${maven-source.version}</version>
         </plugin>
         <plugin>

--- a/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/meta/HapiGetVersionInfo.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/meta/HapiGetVersionInfo.java
@@ -111,12 +111,12 @@ public class HapiGetVersionInfo extends HapiQueryOp<HapiGetVersionInfo> {
 				.append(semver.getMajor()).append(".")
 				.append(semver.getMinor()).append(".")
 				.append(semver.getPatch());
-		var preRelease = semver.getPreReleaseVersion();
+		var preRelease = semver.getPre();
 		if (!preRelease.isBlank()) {
 			sb.append("-").append(preRelease);
 		}
 
-		var buildMeta = semver.getBuildMetadata();
+		var buildMeta = semver.getBuild();
 		if (!buildMeta.isBlank()) {
 			sb.append("+").append(buildMeta);
 		}

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/meta/VersionInfoSpec.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/meta/VersionInfoSpec.java
@@ -9,9 +9,9 @@ package com.hedera.services.bdd.suites.meta;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -37,9 +37,6 @@ import java.util.List;
 public class VersionInfoSpec extends HapiApiSuite {
 	private static final Logger log = LogManager.getLogger(VersionInfoSpec.class);
 
-	private static final SemanticVersion EXPECTED_HAPI_PROTO = HapiPropertySource.asSemVer("0.13.0");
-	private static final SemanticVersion EXPECTED_HEDERA_SERVICES = HapiPropertySource.asSemVer("0.13.0");
-
 	public static void main(String... args) {
 		new VersionInfoSpec().runSuiteSync();
 	}
@@ -56,8 +53,7 @@ public class VersionInfoSpec extends HapiApiSuite {
 		return defaultHapiSpec("getsExpectedVersions").given().when().then(
 				getVersionInfo()
 						.logged()
-						.hasProtoSemVer(EXPECTED_HAPI_PROTO)
-						.hasServicesSemVer(EXPECTED_HEDERA_SERVICES)
+						.hasNoDegenerateSemvers()
 		);
 	}
 

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/utils/validation/ValidationScenarios.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/utils/validation/ValidationScenarios.java
@@ -844,8 +844,6 @@ public class ValidationScenarios extends HapiApiSuite {
 									.linkedTo(() -> String.format("0.0.%d", targetNetwork().getScenarioPayer()))
 					).when().then(
 							getVersionInfo()
-									.hasProtoSemVer(hapiProto[0], hapiProto[1], hapiProto[2])
-									.hasServicesSemVer(services[0], services[1], services[2])
 									.payingWith(SCENARIO_PAYER_NAME)
 									.setNodeFrom(ValidationScenarios::nextNode)
 					);


### PR DESCRIPTION
**Related issue(s)**:
- Closes #1188

**Summary of the change**:
- Replace the hard-coded HAPI and Services semvers in [_hedera-node/src/main/resources/_](https://github.com/hashgraph/hedera-services/blob/master/hedera-node/src/main/resources/semantic-version.properties) with the appropriate Maven properties (`hapi-proto.version` and `project.version`, respectively).
- Update the _hedera-node/pom.xml_ to filter resources.
- Refactor the `SemanticVersions` resource loader utility to understand the (optional) pre-release version and build metadata fields from the [semver spec](https://semver.org/#spec-item-9).
    * We need the full spec to capture our tag name conventions.

**External impacts**:
The semantic versions returned by `getVersionInfo` will automatically be set to the versions that actually obtained when the deployed JAR was built.

**Applicable documentation**
- [x] HAPI protobuf comments
