### PR TITLE
Need to get the export period every time to pick latest value

### DIFF
--- a/hedera-node/src/main/java/com/hedera/services/state/exports/SignedStateBalancesExporter.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/exports/SignedStateBalancesExporter.java
@@ -96,7 +96,6 @@ public class SignedStateBalancesExporter implements BalancesExporter {
 	private BalancesSummary summary;
 
 	Instant periodBegin = NEVER;
-	private final int exportPeriod;
 
 	static final Comparator<SingleAccountBalances> SINGLE_ACCOUNT_BALANCES_COMPARATOR =
 			Comparator.comparing(SingleAccountBalances::getAccountID, ACCOUNT_ID_COMPARATOR);
@@ -109,12 +108,13 @@ public class SignedStateBalancesExporter implements BalancesExporter {
 		this.signer = signer;
 		this.expectedFloat = properties.getLongProperty("ledger.totalTinyBarFloat");
 		this.dynamicProperties = dynamicProperties;
-		exportPeriod = dynamicProperties.balancesExportPeriodSecs();
 	}
 
 	@Override
 	public boolean isTimeToExport(Instant now) {
-		if ( periodBegin != NEVER && now.getEpochSecond() % exportPeriod <= ALLOWED_EXPORT_TIME_SKEW
+		final int exportPeriod = dynamicProperties.balancesExportPeriodSecs();
+		if ( periodBegin != NEVER
+				&& now.getEpochSecond() % exportPeriod <= ALLOWED_EXPORT_TIME_SKEW
 				&& now.getEpochSecond() / exportPeriod != periodBegin.getEpochSecond() / exportPeriod) {
 			periodBegin = now;
 			return true;


### PR DESCRIPTION
**Related issue(s)**:
Closes #1337

Test slack link: https://hedera-hashgraph.slack.com/archives/C018CBQBTGB/p1619738364053600
Summary link: https://hedera-hashgraph.slack.com/archives/C018CBQBTGB/p1619738408054000

**Summary of the change**:
1. Change the logic to allow `balances.exportPeriodSecs`  to be retrieved every time.

NOTE: This allows the user to change the `balances.exportPeriodSecs` in the middle of test, which may cause issues for account balances export.

**External impacts**:
None.

**Applicable documentation**
- [ ] Javadoc
- [ ] HAPI protobuf comments
- [ ] README
