### PR TITLE
fix for ScheduleExecutorTest

### DIFF
--- a/hedera-node/src/main/java/com/hedera/services/txns/schedule/ScheduleExecutor.java
+++ b/hedera-node/src/main/java/com/hedera/services/txns/schedule/ScheduleExecutor.java
@@ -54,7 +54,7 @@ public final class ScheduleExecutor {
 			@NotNull  ScheduleStore store,
 			@NotNull  TransactionContext context
 	) throws
-			InvalidProtocolBufferException, NullPointerException {
+			InvalidProtocolBufferException, IllegalArgumentException {
 		final var executionStatus = store.markAsExecuted(id);
 		if (executionStatus != OK) {
 			return executionStatus;

--- a/hedera-node/src/main/java/com/hedera/services/txns/schedule/ScheduleExecutor.java
+++ b/hedera-node/src/main/java/com/hedera/services/txns/schedule/ScheduleExecutor.java
@@ -28,6 +28,8 @@ import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
 import com.hederahashgraph.api.proto.java.ScheduleID;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.Objects;
+
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OK;
 
 /**
@@ -44,17 +46,23 @@ public final class ScheduleExecutor {
 	 * triggering the underlying transaction. A ResponseEnumCode of OK is returned upon successful trigger of the
 	 * inner transaction. The arguments cannot be null, the return type would always be a proper ResponseEnumCode.
 	 *
-	 * @param id The non null id of the scheduled transaction.
-	 * @param store A non null object to handle scheduled entity type.
-	 * @param context A non null object to handle inner transaction specific context on a node.
-	 * @return the response code {@link ResponseCodeEnum} from executing the inner scheduled transaction
+	 * @param id
+	 * 		the id of the scheduled transaction
+	 * @param store
+	 * 		the relevant store of schedule entities
+	 * @param context
+	 * 		the active (parent) transaction context
+	 * @return the result {@link ResponseCodeEnum} of triggering the scheduled entity
 	 */
 	ResponseCodeEnum processExecution(
 			@NotNull ScheduleID id,
-			@NotNull  ScheduleStore store,
-			@NotNull  TransactionContext context
-	) throws
-			InvalidProtocolBufferException, IllegalArgumentException {
+			@NotNull ScheduleStore store,
+			@NotNull TransactionContext context
+	) throws InvalidProtocolBufferException {
+		Objects.requireNonNull(id, "The id of the scheduled transaction cannot be null");
+		Objects.requireNonNull(store, "The schedule entity store cannot be null");
+		Objects.requireNonNull(context, "The active transaction context cannot be null");
+
 		final var executionStatus = store.markAsExecuted(id);
 		if (executionStatus != OK) {
 			return executionStatus;
@@ -70,3 +78,4 @@ public final class ScheduleExecutor {
 		return OK;
 	}
 }
+

--- a/hedera-node/src/test/java/com/hedera/services/txns/schedule/ScheduleExecutorTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/txns/schedule/ScheduleExecutorTest.java
@@ -37,7 +37,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OK;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SCHEDULE_ALREADY_EXECUTED;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.never;
@@ -62,7 +61,7 @@ class ScheduleExecutorTest {
 	}
 
 	@Test
-	void triggersIfCanMarkAsExecuted() throws InvalidProtocolBufferException, NullPointerException {
+	void triggersIfCanMarkAsExecuted() throws InvalidProtocolBufferException {
 		given(store.markAsExecuted(id)).willReturn(OK);
 		given(store.get(id)).willReturn(schedule);
 		given(schedule.asSignedTxn()).willReturn(Transaction.getDefaultInstance());
@@ -78,15 +77,17 @@ class ScheduleExecutorTest {
 	}
 
 	@Test
-	public void nullArgumentsThrowNullPointerException() throws InvalidProtocolBufferException, NullPointerException {
+	public void nullArgumentsThrowIllegalArgumentException() throws InvalidProtocolBufferException {
+		given(store.markAsExecuted(any()))
+				.willThrow(IllegalArgumentException.class);
 		Assertions.assertThrows(
-				NullPointerException.class, () ->
-				subject.processExecution(null, null, null)
+				IllegalArgumentException.class, () ->
+				subject.processExecution(null, store, txnCtx)
 		);
 	}
 
 	@Test
-	void doesntTriggerUnlessAbleToMarkScheduleExecuted() throws InvalidProtocolBufferException, NullPointerException {
+	void doesntTriggerUnlessAbleToMarkScheduleExecuted() throws InvalidProtocolBufferException {
 		given(store.markAsExecuted(id)).willReturn(SCHEDULE_ALREADY_EXECUTED);
 
 		// when:

--- a/hedera-node/src/test/java/com/hedera/services/txns/schedule/ScheduleExecutorTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/txns/schedule/ScheduleExecutorTest.java
@@ -77,13 +77,16 @@ class ScheduleExecutorTest {
 	}
 
 	@Test
-	public void nullArgumentsThrowIllegalArgumentException() throws InvalidProtocolBufferException {
-		given(store.markAsExecuted(any()))
-				.willThrow(IllegalArgumentException.class);
+	void nullArgumentsThrow() {
 		Assertions.assertThrows(
-				IllegalArgumentException.class, () ->
-				subject.processExecution(null, store, txnCtx)
-		);
+				RuntimeException.class, () ->
+						subject.processExecution(null, store, txnCtx));
+		Assertions.assertThrows(
+				RuntimeException.class, () ->
+						subject.processExecution(id, null, txnCtx));
+		Assertions.assertThrows(
+				RuntimeException.class, () ->
+						subject.processExecution(id, store, null));
 	}
 
 	@Test


### PR DESCRIPTION
Signed-off-by: abhishek-hedera <abhishek.pandey@hedera.com>

**Related issue(s)**:
Closes #<[1374](https://github.com/hashgraph/hedera-services/issues/1374)>

**Summary of the change**:
Modified `ScheduleExecutor` and `ScheduleExecutorTest` for `IllegalArgumentException` check instead of `NullPointerException` check with the use of @NotNull annotation.

**External impacts**:
None.

**Applicable documentation**
- [ ] Javadoc
- [ ] HAPI protobuf comments
- [ ] README
