### PR TITLE
01378-master-UpgradeJacoco

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -17,3 +17,5 @@ hedera-node/output/
 test-clients/target/
 test-clients/devops-utils/
 test-clients/system-files/
+
+.java-version

--- a/pom.xml
+++ b/pom.xml
@@ -174,7 +174,7 @@
     <mockito2.version>3.7.0</mockito2.version>
 
     <!-- SonarCloud properties -->
-    <jacoco.version>0.8.5</jacoco.version>
+    <jacoco.version>0.8.6</jacoco.version>
     <sonar.version>3.7.0.1746</sonar.version>
 
     <sonar.organization>hashgraph</sonar.organization>


### PR DESCRIPTION
**Related issue(s)**:
Closes #1378 

**Summary of the change**:
Updates the version of Jacoco in use. Does not have any impact on runtime.

**External impacts**:
None.

**Applicable documentation**
- [N/A] Javadoc
- [N/A] HAPI protobuf comments
- [N/A] README
