### PR TITLE
Add parameters to avoid hard-coded value

### DIFF
--- a/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/LoadTest.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/LoadTest.java
@@ -32,6 +32,7 @@ import java.util.List;
 import java.util.OptionalDouble;
 import java.util.OptionalInt;
 import java.util.OptionalLong;
+import java.util.Optional;
 import java.util.function.Supplier;
 
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.runLoadTest;
@@ -66,6 +67,8 @@ public class LoadTest extends HapiApiSuite {
 	public static OptionalInt totalScheduled = OptionalInt.empty();
 	public static OptionalInt totalTestTokenAccounts = OptionalInt.empty();
 	public static OptionalInt memoLength = OptionalInt.of(DEFAULT_MEMO_LENGTH);
+	public static OptionalInt balancesExportPeriodSecs = OptionalInt.empty();
+	public static Optional<Boolean> clientToExportBalances = Optional.empty();
 
 	protected final ResponseCodeEnum[] standardPermissiblePrechecks = new ResponseCodeEnum[] {
 			OK, BUSY, DUPLICATE_TRANSACTION, PLATFORM_TRANSACTION_NOT_CREATED
@@ -156,6 +159,10 @@ public class LoadTest extends HapiApiSuite {
 						? hcsSubmitMessage::getAsInt : settings::getHcsSubmitMessageSize)
 				.setHCSSubmitMessageSizeVar(hcsSubmitMessageSizeVar.isPresent()
 						? hcsSubmitMessageSizeVar::getAsInt	: settings::getHcsSubmitMessageSizeVar)
+				.setBalancesExportPeriodSecs(balancesExportPeriodSecs.isPresent()
+						? balancesExportPeriodSecs::getAsInt : settings::getBalancesExportPeriodSecs)
+				.setClientToExportBalances(clientToExportBalances.isPresent()
+								? clientToExportBalances::get : settings::getClientToExportBalances)
 				.setInitialBalance(settings::getInitialBalance)
 				.lasting(
 						(testDurationMinutes.isPresent() ?

--- a/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/RunLoadTest.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/RunLoadTest.java
@@ -28,6 +28,7 @@ import org.apache.logging.log4j.Logger;
 
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.BooleanSupplier;
 import java.util.function.DoubleSupplier;
 import java.util.function.IntSupplier;
 import java.util.function.LongSupplier;
@@ -35,8 +36,10 @@ import java.util.function.Supplier;
 
 import static com.google.common.base.Stopwatch.createStarted;
 import static com.hedera.services.bdd.spec.utilops.CustomSpecAssert.allRunFor;
+import static com.hedera.services.bdd.suites.perf.PerfTestLoadSettings.DEFAULT_BALANCES_EXPORT_PERIOD_SECS;
 import static com.hedera.services.bdd.suites.perf.PerfTestLoadSettings.DEFAULT_DURATION_CREATE_TOKEN_ASSOCIATION;
 import static com.hedera.services.bdd.suites.perf.PerfTestLoadSettings.DEFAULT_DURATION_TOKEN_TRANSFER;
+import static com.hedera.services.bdd.suites.perf.PerfTestLoadSettings.DEFAULT_EXPORT_BALANCES_ON_CLIENT_SIDE;
 import static com.hedera.services.bdd.suites.perf.PerfTestLoadSettings.DEFAULT_INITIAL_BALANCE;
 import static com.hedera.services.bdd.suites.perf.PerfTestLoadSettings.DEFAULT_MEMO_LENGTH;
 import static com.hedera.services.bdd.suites.perf.PerfTestLoadSettings.DEFAULT_SUBMIT_MESSAGE_SIZE;
@@ -79,6 +82,8 @@ public class RunLoadTest extends UtilOp {
 	private IntSupplier totalTokenAssociations = () -> DEFAULT_TOTAL_TOKEN_ASSOCIATIONS;
 	private IntSupplier totalScheduled = () -> DEFAULT_TOTAL_SCHEDULED;
 	private LongSupplier initialBalance = () -> DEFAULT_INITIAL_BALANCE;
+	private IntSupplier balancesExportPeriodSecs = () -> DEFAULT_BALANCES_EXPORT_PERIOD_SECS;
+	private BooleanSupplier clientToExportBalances = () -> DEFAULT_EXPORT_BALANCES_ON_CLIENT_SIDE;
 
 	private final Supplier<HapiSpecOperation[]> opSource;
 
@@ -166,6 +171,16 @@ public class RunLoadTest extends UtilOp {
 
 	public RunLoadTest setInitialBalance(LongSupplier initialBalance) {
 		this.initialBalance = initialBalance;
+		return this;
+	}
+
+	public RunLoadTest setBalancesExportPeriodSecs(IntSupplier balancesExportPeriodSecs) {
+		this.balancesExportPeriodSecs = balancesExportPeriodSecs;
+		return this;
+	}
+
+	public RunLoadTest setClientToExportBalances(BooleanSupplier clientToExportBalances) {
+		this.clientToExportBalances = clientToExportBalances;
 		return this;
 	}
 

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/AccountBalancesClientSaveLoadTest.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/AccountBalancesClientSaveLoadTest.java
@@ -38,6 +38,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Random;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
@@ -136,10 +137,11 @@ public class AccountBalancesClientSaveLoadTest extends LoadTest  {
 						tokenOpsEnablement(),
 						withOpContext((spec, ignore) -> settings.setFrom(spec.setup().ciPropertiesMap())),
 						logIt(ignore -> settings.toString()),
-						fileUpdate(APP_PROPERTIES)
+						sourcing(() -> fileUpdate(APP_PROPERTIES)
 								.payingWith(GENESIS)
 								.overridingProps(Map.of("balances.exportPeriodSecs",
-										String.format("%d", settings.getBalancesExportPeriodSecs()))),
+										String.format("%d",settings.getBalancesExportPeriodSecs()) ))
+								.erasingProps(Set.of("accountBalanceExportPeriodMinutes"))),
 						fileUpdate(THROTTLE_DEFS)
 								.payingWith(EXCHANGE_RATE_CONTROL)
 								.contents(throttlesForJRS.toByteArray())

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/AccountBalancesClientSaveLoadTest.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/AccountBalancesClientSaveLoadTest.java
@@ -54,6 +54,7 @@ import static com.hedera.services.bdd.spec.transactions.token.TokenMovement.movi
 
 import static com.hedera.services.bdd.spec.utilops.CustomSpecAssert.allRunFor;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.exportAccountBalances;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.logIt;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.runWithProvider;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.sleepFor;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.freeze;
@@ -134,13 +135,16 @@ public class AccountBalancesClientSaveLoadTest extends LoadTest  {
 				.given(
 						tokenOpsEnablement(),
 						withOpContext((spec, ignore) -> settings.setFrom(spec.setup().ciPropertiesMap())),
+						logIt(ignore -> settings.toString()),
 						fileUpdate(APP_PROPERTIES)
 								.payingWith(GENESIS)
-								.overridingProps(Map.of("balances.exportPeriodSecs", "60")),
+								.overridingProps(Map.of("balances.exportPeriodSecs",
+										String.format("%d", settings.getBalancesExportPeriodSecs()))),
 						fileUpdate(THROTTLE_DEFS)
 								.payingWith(EXCHANGE_RATE_CONTROL)
 								.contents(throttlesForJRS.toByteArray())
 				).when(
+
 						sourcing(() -> runWithProvider(accountsCreate(settings))
 								.lasting(() -> totalAccounts / ESTIMATED_CRYPTO_CREATION_RATE + 10,
 										() -> TimeUnit.SECONDS)
@@ -173,22 +177,27 @@ public class AccountBalancesClientSaveLoadTest extends LoadTest  {
 				).then(
 						sleepFor(10 * SECOND),
 						withOpContext( (spec, log) -> {
-							log.info("Now get all {} accounts created and save them", totalAccounts);
-							AccountID acctID = AccountID.getDefaultInstance();
-							for(int i = 1; i <= totalAccounts; i++ ) {
-								String acctName = ACCT_NAME_PREFIX + i;
-								// Make sure the named account was created before query its balances.
-								try {
-									acctID = spec.registry().getAccountID(acctName);
-								} catch (RegistryNotFound e) {
-									log.info(acctName + " was not created successfully.");
-									continue;
+							if(settings.getBooleanProperty("clientToExportBalances", false)) {
+								log.info("Now get all {} accounts created and save them", totalAccounts);
+								AccountID acctID = AccountID.getDefaultInstance();
+								for (int i = 1; i <= totalAccounts; i++) {
+									String acctName = ACCT_NAME_PREFIX + i;
+									// Make sure the named account was created before query its balances.
+									try {
+										acctID = spec.registry().getAccountID(acctName);
+									} catch (RegistryNotFound e) {
+										log.info(acctName + " was not created successfully.");
+										continue;
+									}
+									var op = getAccountBalance(HapiPropertySource.asAccountString(acctID))
+											.hasAnswerOnlyPrecheckFrom(permissiblePrechecks)
+											.persists(true)
+											.noLogging();
+									allRunFor(spec, op);
 								}
-								var op = getAccountBalance(HapiPropertySource.asAccountString(acctID))
-										.hasAnswerOnlyPrecheckFrom(permissiblePrechecks)
-										.persists(true)
-										.noLogging();
-								allRunFor(spec, op);
+							}
+							else { // debug
+								log.info("Don't dump account balances from client side.");
 							}
 						}),
 						sleepFor(10 * SECOND),

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/PerfTestLoadSettings.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/PerfTestLoadSettings.java
@@ -49,6 +49,8 @@ public class PerfTestLoadSettings {
 	public static final int DEFAULT_DURATION_CREATE_TOKEN_ASSOCIATION = 60; // in seconds
 	public static final int DEFAULT_DURATION_TOKEN_TRANSFER = 60; // in seconds
 	public static final long DEFAULT_INITIAL_BALANCE = ONE_MILLION_HBARS;
+	public static final int DEFAULT_BALANCES_EXPORT_PERIOD_SECS = 60;
+	public static final boolean DEFAULT_EXPORT_BALANCES_ON_CLIENT_SIDE = false;
 
 	private int tps = DEFAULT_TPS;
 	private int tolerancePercentage = DEFAULT_TOLERANCE_PERCENTAGE;
@@ -108,6 +110,11 @@ public class PerfTestLoadSettings {
 	 * Initial balance for the Crypto accounts created during LoadTest
 	 */
 	private long initialBalance = DEFAULT_INITIAL_BALANCE;
+
+	// test client to tell hedera services how long to export account balances.
+	private int balancesExportPeriodSecs = DEFAULT_BALANCES_EXPORT_PERIOD_SECS;
+	// tell EET client whether to dump account balances or not
+	private boolean clientToExportBalances = DEFAULT_EXPORT_BALANCES_ON_CLIENT_SIDE;
 
 	private HapiPropertySource ciProps = null;
 
@@ -179,6 +186,13 @@ public class PerfTestLoadSettings {
 	}
 	public int getTotalScheduled() {
 		return totalScheduled;
+	}
+
+	public int getBalancesExportPeriodSecs() {
+		return balancesExportPeriodSecs;
+	}
+	public boolean getClientToExportBalances() {
+		return clientToExportBalances;
 	}
 
 	public int getTestTreasureStartAccount() { return testTreasureStartAccount; }
@@ -258,6 +272,12 @@ public class PerfTestLoadSettings {
 		if (ciProps.has("initialBalance")) {
 			initialBalance = ciProps.getLong("initialBalance");
 		}
+		if (ciProps.has("balancesExportPeriodSecs")) {
+			balancesExportPeriodSecs = ciProps.getInteger("balancesExportPeriodSecs");
+		}
+		if (ciProps.has("clientToExportBalances")) {
+			clientToExportBalances = ciProps.getBoolean("clientToExportBalances");
+		}
 	}
 
 	@Override
@@ -283,6 +303,8 @@ public class PerfTestLoadSettings {
 				.add("totalTokenAssociations", totalTokenAssociations)
 				.add("totalScheduledTransactions", totalScheduled)
 				.add("initialBalance", initialBalance)
+				.add("balancesExportPeriodSecs", balancesExportPeriodSecs)
+				.add("clientToExportBalances", clientToExportBalances)
 				.toString();
 	}
 }


### PR DESCRIPTION
**Summary of the change**:

1. Replaced the hard-coded export period value with one that can be controlled by JRS test configuration;
2. Added one parameter to control the export of the client side exporting of account balances;

Passed slack links: https://hedera-hashgraph.slack.com/archives/C018CBQBTGB/p1620742129179700,
https://hedera-hashgraph.slack.com/archives/C018CBQBTGB/p1620745586180200

Latest run link: https://hedera-hashgraph.slack.com/archives/C018CBQBTGB/p1620754060183800 

**External impacts**:
None.

**Applicable documentation**
- [ ] Javadoc
- [ ] HAPI protobuf comments
- [ ] README
