### PR TITLE
Disable daily AWS summary job.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1973,18 +1973,6 @@ workflows:
             - attach_workspace:
                 at: /
 
-  daily-aws-summary:
-    triggers:
-      - schedule:
-          cron: "15 14 * * *"
-          filters:
-            branches:
-              only:
-                - X-dont-run
-    jobs:
-      - aws-summary:
-          context: Slack
-
   nightly-comprehensive-functional-regression:
     triggers:
       - schedule:
@@ -2310,15 +2298,6 @@ jobs:
           paths:
             - repo/
             - swirlds-platform/
-
-  aws-summary:
-    executor: ci-test-executor
-    steps:
-      - checkout
-      - run:
-          name: Summarize all AWS instances currently used by regions
-          command: |
-            /repo/.circleci/scripts/aws-summary.sh
 
   run-accessory-tests:
     parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1980,7 +1980,7 @@ workflows:
           filters:
             branches:
               only:
-                - master
+                - X-dont-run
     jobs:
       - aws-summary:
           context: Slack


### PR DESCRIPTION
**Related issue(s)**:
Closes #1381

**Summary of the change**:

1. Disable daily-aws-summary job.

**External impacts**:
None.

**Applicable documentation**
- [ ] Javadoc
- [ ] HAPI protobuf comments
- [ ] README
