### PR TITLE
Fix HapiQueryOp to compute CryptoTransfer usage exactly as node does;…

### DIFF
--- a/hedera-node/src/main/java/com/hedera/services/queries/validation/QueryFeeCheck.java
+++ b/hedera-node/src/main/java/com/hedera/services/queries/validation/QueryFeeCheck.java
@@ -70,7 +70,7 @@ public class QueryFeeCheck {
 		}
 		// number of beneficiaries in query transfer transaction can be greater than one.
 		// validate if node gets the required query payment
-		if (transfers.stream().noneMatch(adj -> adj.getAmount() > 0 && adj.getAccountID().equals(node))) {
+		if (transfers.stream().noneMatch(adj -> adj.getAmount() >= 0 && adj.getAccountID().equals(node))) {
 			return INVALID_RECEIVING_NODE_ACCOUNT;
 		}
 		if (transfers.stream().anyMatch(adj -> adj.getAccountID().equals(node) && adj.getAmount() < queryFee)) {


### PR DESCRIPTION
**Related issue(s)**:
- Closes #1365

**Summary of the change**:
- Fix `HapiQueryOp `to compute `CryptoTransfer` usage exactly as node does
- Allow 0 node payments in `QueryFeeCheck`
