### PR TITLE
Run 6-node perf tests on a daily basis.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1624,7 +1624,7 @@ workflows:
   GCP-Daily-Services-Comp-Restart-Performance-Hotspot-6N-6C:
     triggers:
       - schedule:
-          cron: "35 6 * * 3,0"
+          cron: "35 6 * * *"
           filters:
             branches:
               only:
@@ -1647,7 +1647,7 @@ workflows:
   GCP-Daily-Services-Comp-Restart-Performance-Random-6N-6C:
     triggers:
       - schedule:
-          cron: "30 4 * * 3,0"
+          cron: "30 4 * * *"
           filters:
             branches:
               only:
@@ -1671,7 +1671,7 @@ workflows:
   GCP-Daily-Services-HTS-Restart-Performance-6N-6C:
     triggers:
       - schedule:
-          cron: "30 8 * * 3,0"
+          cron: "30 8 * * *"
           filters:
             branches:
               only:


### PR DESCRIPTION
**Related issue(s)**:
Closes #1386

**Summary of the change**:

1. Changed the 6-node transaction perf tests to run on daily basis.

**External impacts**:
None.

**Applicable documentation**
- [ ] Javadoc
- [ ] HAPI protobuf comments
- [ ] README
