### PR TITLE
Include autorenew per-second summary counts in network ctx

### DIFF
--- a/hedera-node/src/main/java/com/hedera/services/context/ServicesContext.java
+++ b/hedera-node/src/main/java/com/hedera/services/context/ServicesContext.java
@@ -1493,7 +1493,8 @@ public class ServicesContext {
 			final var renewalProcess = new RenewalProcess(
 					fees(), hederaNums(), helper, recordHelper);
 			entityAutoRenewal = new EntityAutoRenewal(
-					hederaNums(), renewalProcess, this, globalDynamicProperties());
+					hederaNums(), renewalProcess, this,
+					globalDynamicProperties(), networkCtxManager(), networkCtx());
 		}
 		return entityAutoRenewal;
 	}

--- a/hedera-node/src/main/java/com/hedera/services/state/logic/NetworkCtxManager.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/logic/NetworkCtxManager.java
@@ -45,6 +45,8 @@ public class NetworkCtxManager {
 
 	private final int issResetPeriod;
 
+	private boolean consensusSecondJustChanged = false;
+
 	private final IssEventInfo issInfo;
 	private final HapiOpCounters opCounters;
 	private final HbarCentExchange exchange;
@@ -96,6 +98,12 @@ public class NetworkCtxManager {
 		if (lastConsensusTime != null && !inSameUtcDay(lastConsensusTime, consensusTime)) {
 			networkCtxNow.midnightRates().replaceWith(exchange.activeRates());
 		}
+		if (lastConsensusTime == null || consensusTime.getEpochSecond() > lastConsensusTime.getEpochSecond()) {
+			consensusSecondJustChanged = true;
+		} else {
+			consensusSecondJustChanged = false;
+		}
+
 		networkCtxNow.setConsensusTimeOfLastHandledTxn(consensusTime);
 
 		if (issInfo.status() == ONGOING_ISS) {
@@ -104,6 +112,10 @@ public class NetworkCtxManager {
 				issInfo.relax();
 			}
 		}
+	}
+
+	public boolean currentTxnIsFirstInConsensusSecond() {
+		return consensusSecondJustChanged;
 	}
 
 	public void prepareForIncorporating(HederaFunctionality op)	 {

--- a/hedera-node/src/main/java/com/hedera/services/state/merkle/MerkleNetworkContext.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/merkle/MerkleNetworkContext.java
@@ -68,6 +68,8 @@ public class MerkleNetworkContext extends AbstractMerkleLeaf {
 	private RichInstant consensusTimeOfLastHandledTxn;
 	private SequenceNumber seqNo;
 	private long lastScannedEntity;
+	private long entitiesScannedThisSecond = 0L;
+	private long entitiesTouchedThisSecond = 0L;
 	private DeterministicThrottle.UsageSnapshot[] usageSnapshots = NO_SNAPSHOTS;
 
 	public MerkleNetworkContext() {
@@ -93,7 +95,9 @@ public class MerkleNetworkContext extends AbstractMerkleLeaf {
 			ExchangeRates midnightRates,
 			DeterministicThrottle.UsageSnapshot[] usageSnapshots,
 			RichInstant[] congestionStartPeriods,
-			int stateVersion
+			int stateVersion,
+			long entitiesScannedThisSecond,
+			long entitiesTouchedThisSecond
 	) {
 		this.consensusTimeOfLastHandledTxn = consensusTimeOfLastHandledTxn;
 		this.seqNo = seqNo;
@@ -102,6 +106,8 @@ public class MerkleNetworkContext extends AbstractMerkleLeaf {
 		this.usageSnapshots = usageSnapshots;
 		this.congestionLevelStarts = congestionStartPeriods;
 		this.stateVersion = stateVersion;
+		this.entitiesScannedThisSecond = entitiesScannedThisSecond;
+		this.entitiesTouchedThisSecond = entitiesTouchedThisSecond;
 	}
 
 	public void updateSnapshotsFrom(FunctionalityThrottling throttling) {
@@ -167,7 +173,9 @@ public class MerkleNetworkContext extends AbstractMerkleLeaf {
 				midnightRates.copy(),
 				usageSnapshots,
 				congestionLevelStarts,
-				stateVersion);
+				stateVersion,
+				entitiesScannedThisSecond,
+				entitiesTouchedThisSecond);
 	}
 
 	@Override
@@ -200,6 +208,8 @@ public class MerkleNetworkContext extends AbstractMerkleLeaf {
 		}
 		if (version >= RELEASE_0140_VERSION) {
 			lastScannedEntity = in.readLong();
+			entitiesScannedThisSecond = in.readLong();
+			entitiesTouchedThisSecond = in.readLong();
 			stateVersion = in.readInt();
 		}
 	}
@@ -221,6 +231,8 @@ public class MerkleNetworkContext extends AbstractMerkleLeaf {
 			serdes.writeNullableInstant(congestionStart, out);
 		}
 		out.writeLong(lastScannedEntity);
+		out.writeLong(entitiesScannedThisSecond);
+		out.writeLong(entitiesTouchedThisSecond);
 		out.writeInt(stateVersion);
 	}
 
@@ -258,7 +270,11 @@ public class MerkleNetworkContext extends AbstractMerkleLeaf {
 				.append("\n  Next entity number                         :: ")
 				.append(seqNo.current())
 				.append("\n  Last scanned entity                        :: ")
-				.append(lastScannedEntity);
+				.append(lastScannedEntity)
+				.append("\n  Entities scanned last consensus second     :: ")
+				.append(entitiesScannedThisSecond)
+				.append("\n  Entities touched last consensus second     :: ")
+				.append(entitiesTouchedThisSecond);
 		sb.append("\n  Throttle usage snapshots are               ::");
 		for (var snapshot : usageSnapshots) {
 			sb.append("\n    ").append(snapshot.used())
@@ -336,6 +352,16 @@ public class MerkleNetworkContext extends AbstractMerkleLeaf {
 		return lastScannedEntity;
 	}
 
+	public void resetAutoRenewSummaryCounts() {
+		entitiesScannedThisSecond = 0L;
+		entitiesTouchedThisSecond = 0L;
+	}
+
+	public void updateAutoRenewSummaryCounts(int numScanned, int numTouched) {
+		entitiesScannedThisSecond += numScanned;
+		entitiesTouchedThisSecond += numTouched;
+	}
+
 	public void updateLastScannedEntity(long lastScannedEntity) {
 		this.lastScannedEntity = lastScannedEntity;
 	}
@@ -350,5 +376,13 @@ public class MerkleNetworkContext extends AbstractMerkleLeaf {
 
 	public void setStateVersion(int stateVersion) {
 		this.stateVersion = stateVersion;
+	}
+
+	public long getEntitiesScannedThisSecond() {
+		return entitiesScannedThisSecond;
+	}
+
+	public long getEntitiesTouchedThisSecond() {
+		return entitiesTouchedThisSecond;
 	}
 }

--- a/hedera-node/src/test/java/com/hedera/services/state/logic/NetworkCtxManagerTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/state/logic/NetworkCtxManagerTest.java
@@ -193,6 +193,45 @@ class NetworkCtxManagerTest {
 	}
 
 	@Test
+	void recognizesWhenTxnStillInSameConsensusSecond() {
+		// setup:
+		final var sometimePlusSomeNanos = sometime.plusNanos(1_234);
+		final var sometimePlusSomeMoreNanos = sometimePlusSomeNanos.plusNanos(1_234);
+
+		given(networkCtx.consensusTimeOfLastHandledTxn()).willReturn(sometimePlusSomeNanos);
+
+		// when:
+		subject.advanceConsensusClockTo(sometimePlusSomeMoreNanos);
+
+		// then:
+		assertFalse(subject.currentTxnIsFirstInConsensusSecond());
+	}
+
+	@Test
+	void recognizesWhenTxnSecondChanges() {
+		// setup:
+		final var sometimePlusSomeNanos = sometime.plusNanos(1_234);
+		final var sometimePlusOneSecond = sometime.plusSeconds(1);
+
+		given(networkCtx.consensusTimeOfLastHandledTxn()).willReturn(sometimePlusSomeNanos);
+
+		// when:
+		subject.advanceConsensusClockTo(sometimePlusOneSecond);
+
+		// then:
+		assertTrue(subject.currentTxnIsFirstInConsensusSecond());
+	}
+
+	@Test
+	void recognizesFirstTxnMustBeFirstInSecond() {
+		// when:
+		subject.advanceConsensusClockTo(sometimeNextDay);
+
+		// then:
+		assertTrue(subject.currentTxnIsFirstInConsensusSecond());
+	}
+
+	@Test
 	void advancesClockAsExpectedWhenNotPassingMidnight() {
 		given(networkCtx.consensusTimeOfLastHandledTxn()).willReturn(sometime);
 


### PR DESCRIPTION
**Related issue(s)**:
- Closes #1389

**Summary of the change**:
Summarize auto-renew activity per consensus second in two counts: `entitiesScannedThisSecond` and `entitiesTouchedThisSecond`.
