### PR TITLE
Clarify re-key readme and split EET helper into two suites

### DIFF
--- a/docs/dev/testnet-rekey.md
+++ b/docs/dev/testnet-rekey.md
@@ -16,7 +16,12 @@ and key, without any security concerns.)
      server, since it's almost always more convenient to use a 
      dockerized PostgreSQL locally.)
 
-Also note that at the time of writing, stable testnet has five nodes;
+:warning:&nbsp; Always follow these steps **on the tag** matching 
+the version of testnet state that DevOps provided. For example, if
+DevOps provided a 0.14.0 state, do everything that follows on the
+`v0.14.0` tag! 
+
+Also, note that at the time of writing, stable testnet has five nodes;
 this number appears below in a couple places which should be easy to 
 adapt if needed.
 
@@ -88,12 +93,19 @@ final var passphraseForOriginalPemLoc = "<SECRET>";
 ...
 ```
 
-Now just run the `RekeySavedStateTreasury` suite. It should end with 
-logs like,
+Now run the `RekeySavedStateTreasury` suite. The new treasury key
+will be saved at,
+ 1. _test-clients/DevStableTestnetStartUpAccount.txt_
+ 2. _test-clients/dev-stabletestnet-account2.pem_
+
+...where the first is a legacy Base64-encoded "startup account"; and
+the PEM file has a passphrase of "swirlds".
+
+Next, run the `FreezeRekeyedState` EET suite. It should end with logs like,
 ```
 ...
-2021-05-04 09:47:26.187 INFO   311  HapiApiSpec - 'FreezeWithNewTreasuryKey' finished initial execution of HapiFreeze{sigs=1, node=0.0.3, start=14:48, end=14:49}
-2021-05-04 09:47:26.691 INFO   330  HapiApiSpec - 'FreezeWithNewTreasuryKey' - final status: PASSED!
+2021-05-04 09:47:26.187 INFO   311  HapiApiSpec - 'FreezeRekeyedState' finished initial execution of HapiFreeze{sigs=1, node=0.0.3, start=14:48, end=14:49}
+2021-05-04 09:47:26.691 INFO   330  HapiApiSpec - 'FreezeRekeyedState' - final status: PASSED!
 ```
 
 ## Capturing the new state
@@ -107,9 +119,6 @@ stop Services and archive the state with the new treasury key,
 $ tar -cvf rekeyed-testnet-round65464591.tar.gz \
 > hedera-node/data/saved/com.hedera.services.ServicesMain/0/123/65464591
 ```
-(Here 65464591 was the round state saved by the `Freeze`.)  
+(Here 65464591 was the round of state saved by the `Freeze`.)  
 
-You're done! Your shiny new treasury key is at 
-_test-clients/dev-stabletestnet-account2.pem_ with a passphrase of "swirlds".
-There is also a legacy Base64-encoded "startup account" at
-_test-clients/DevStableTestnetStartUpAccount.txt_.
+You're done! Enjoy your shiny new treasury key.

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/misc/FreezeRekeyedState.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/misc/FreezeRekeyedState.java
@@ -1,0 +1,70 @@
+package com.hedera.services.bdd.suites.misc;
+
+/*-
+ * ‌
+ * Hedera Services Test Clients
+ * ​
+ * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import com.hedera.services.bdd.spec.HapiApiSpec;
+import com.hedera.services.bdd.suites.HapiApiSuite;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.List;
+import java.util.Map;
+
+import static com.hedera.services.bdd.spec.HapiApiSpec.customHapiSpec;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.freeze;
+import static com.hedera.services.bdd.suites.misc.RekeySavedStateTreasury.newTreasuryStartUpAccountLoc;
+
+/**
+ * Given a network with a "re-keyed" treasury account, we want to use this the
+ * new treasury account to freeze our network and generate a signed state.
+ */
+public class FreezeRekeyedState extends HapiApiSuite {
+	private static final Logger log = LogManager.getLogger(FreezeRekeyedState.class);
+
+	public static void main(String... args) {
+		new FreezeRekeyedState().runSuiteSync();
+	}
+
+	@Override
+	protected List<HapiApiSpec> getSpecsInSuite() {
+		return List.of(new HapiApiSpec[] {
+						freezeWithNewTreasuryKey(),
+				}
+		);
+	}
+
+	private HapiApiSpec freezeWithNewTreasuryKey() {
+		return customHapiSpec("FreezeWithNewTreasuryKey")
+				.withProperties(Map.of(
+						"nodes", "localhost",
+						"default.payer", "0.0.2",
+						"startupAccounts.path", newTreasuryStartUpAccountLoc
+				))
+				.given().when().then(
+						freeze().startingIn(60).seconds().andLasting(1).minutes()
+				);
+	}
+
+	@Override
+	protected Logger getResultsLogger() {
+		return log;
+	}
+}

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/misc/RekeySavedStateTreasury.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/misc/RekeySavedStateTreasury.java
@@ -22,8 +22,6 @@ package com.hedera.services.bdd.suites.misc;
 
 import com.hedera.services.bdd.spec.HapiApiSpec;
 import com.hedera.services.bdd.spec.HapiPropertySource;
-import com.hedera.services.bdd.spec.transactions.TxnVerbs;
-import com.hedera.services.bdd.spec.utilops.UtilVerbs;
 import com.hedera.services.bdd.suites.HapiApiSuite;
 import org.apache.commons.codec.binary.Hex;
 import org.apache.logging.log4j.LogManager;
@@ -35,7 +33,6 @@ import java.util.Map;
 import static com.hedera.services.bdd.spec.HapiApiSpec.customHapiSpec;
 import static com.hedera.services.bdd.spec.transactions.TxnUtils.randomUtf8Bytes;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoUpdate;
-import static com.hedera.services.bdd.spec.utilops.UtilVerbs.freeze;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.keyFromLiteral;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.withOpContext;
 
@@ -46,7 +43,7 @@ import static com.hedera.services.bdd.spec.utilops.UtilVerbs.withOpContext;
 public class RekeySavedStateTreasury extends HapiApiSuite {
 	private static final Logger log = LogManager.getLogger(RekeySavedStateTreasury.class);
 
-	public static void main(String... args) throws Exception {
+	public static void main(String... args) {
 		new RekeySavedStateTreasury().runSuiteSync();
 	}
 
@@ -54,13 +51,12 @@ public class RekeySavedStateTreasury extends HapiApiSuite {
 	protected List<HapiApiSpec> getSpecsInSuite() {
 		return List.of(new HapiApiSpec[] {
 						rekeyTreasury(),
-						freezeWithNewTreasuryKey(),
 				}
 		);
 	}
 
-	final String newTreasuryStartUpAccountLoc = "DevStableTestnetStartUpAccount.txt";
-	final String newTreasuryPemLoc = "dev-stabletestnet-account2.pem";
+	static final String newTreasuryStartUpAccountLoc = "DevStableTestnetStartUpAccount.txt";
+	static final String newTreasuryPemLoc = "dev-stabletestnet-account2.pem";
 
 	private HapiApiSpec rekeyTreasury() {
 		final var treasury = HapiPropertySource.asAccount("0.0.2");
@@ -88,18 +84,6 @@ public class RekeySavedStateTreasury extends HapiApiSuite {
 						})
 				).when().then(
 						cryptoUpdate(DEFAULT_PAYER).key(newTreasuryKey)
-				);
-	}
-
-	private HapiApiSpec freezeWithNewTreasuryKey() {
-		return customHapiSpec("FreezeWithNewTreasuryKey")
-				.withProperties(Map.of(
-						"nodes", "localhost",
-						"default.payer", "0.0.2",
-						"startupAccounts.path", newTreasuryStartUpAccountLoc
-				))
-				.given().when().then(
-						freeze().startingIn(60).seconds().andLasting(1).minutes()
 				);
 	}
 


### PR DESCRIPTION
**Summary of the change**:
Add warnings to the re-key README and avoid a EET helper failure mode by splitting into two suites.
