### PR TITLE
Add Correctness tests to nightly regression

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1714,6 +1714,29 @@ workflows:
             - attach_workspace:
                 at: /
 
+  GCP-Daily-Services-Comp-Reconnect-Correctness-6N-1C:
+    triggers:
+      - schedule:
+          cron: "15 7 * * *"
+          filters:
+            branches:
+              only:
+                - master
+    jobs:
+      - build-platform-and-services
+      - jrs-regression:
+          context: Slack
+          regression_path: /swirlds-platform/regression
+          result_path: results/6N_1C/ReconnectCorrectness
+          config_type: "daily"
+          workflow-name: "GCP-Daily-Services-Comp-Reconnect-Correctness-6N-1C"
+          requires:
+            - build-platform-and-services
+          pre-steps:
+            - install-tools
+            - attach_workspace:
+                at: /
+
   GCP-Daily-Services-Global-3NReconnect-15N-1C:
     triggers:
       - schedule:


### PR DESCRIPTION
Signed-off-by: Neeharika-Sompalli <neeharika.sompalli@hedera.com>

**Related issue(s)**:
Closes #1396 

**Summary of the change**:
Reconnect tests using reconnect window are added in PR https://github.com/swirlds/swirlds-platform-regression/pull/1096 .
**This will be merged only after merging official `0.9.4-alpha.2` sdk from platform.**
A bug related to schedules expiry is fixed in [commit](https://github.com/hashgraph/hedera-services/pull/1398/commits/c88d68166e86165f8d28db5ee022355e61e47b71)

Passed tests:

- [x] `GCP-Daily-Services-Comp-Reconnect-Correctness-6N-1C.json` : All NI Correctness Reconnect tests with `reconnect.reconnectWindowSeconds=-1` and ND Correctness tests [PASSED](and ND Correctness )
     - [AllProtectedFilesUpdate-NDReconnect-1-12m](https://hedera-hashgraph.slack.com/archives/C018CBQBTGB/p1621010795272200) FAILED 


- [x] `GCP-Daily-Services-Comp-Reconnect-6N-1C.json` : [PASSED](https://hedera-hashgraph.slack.com/archives/C018CBQBTGB/p1621039474318700)
	- [MixedOps-NIReconnectFail-1.5k-10m.json ](https://hedera-hashgraph.slack.com/archives/C018CBQBTGB/p1621026899305200) PASSED, https://hedera-hashgraph.slack.com/archives/C018CBQBTGB/p1621100324318800

- [x] `GCP-Daily-Services-Global-3NReconnect-15N-1C.json` : [PASSED](https://hedera-hashgraph.slack.com/archives/C018CBQBTGB/p1621039235318200)
          - [MixedOps-Global-NI-3NReconnect-1.5k-30m](https://hedera-hashgraph.slack.com/archives/C018CBQBTGB/p1621107386320800) - PASSED

- [x] `GCP-Daily-Services-Comp-3NReconnect-15N-1C.json` : [PASSED](https://hedera-hashgraph.slack.com/archives/C018CBQBTGB/p1621035102313400)
          -  [MixedOps-NI-3NReconnect-1.5k-29m.json](https://hedera-hashgraph.slack.com/archives/C018CBQBTGB/p1621106695320300)  PASSED


