### PR TITLE
Inject schedules FCM supplier to ExpiryManager

### DIFF
--- a/hedera-node/src/main/java/com/hedera/services/context/ServicesContext.java
+++ b/hedera-node/src/main/java/com/hedera/services/context/ServicesContext.java
@@ -1502,7 +1502,7 @@ public class ServicesContext {
 	public ExpiryManager expiries() {
 		if (expiries == null) {
 			var histories = txnHistories();
-			expiries = new ExpiryManager(recordCache(), histories, scheduleStore(), schedules());
+			expiries = new ExpiryManager(recordCache(), histories, scheduleStore(), this::schedules);
 		}
 		return expiries;
 	}

--- a/hedera-node/src/main/java/com/hedera/services/state/expiry/ExpiryManager.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/expiry/ExpiryManager.java
@@ -41,11 +41,12 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
+import java.util.function.Supplier;
 
 public class ExpiryManager {
 	private final RecordCache recordCache;
 	private final Map<TransactionID, TxnIdRecentHistory> txnHistories;
-	private final FCMap<MerkleEntityId, MerkleSchedule> schedules;
+	private final Supplier<FCMap<MerkleEntityId, MerkleSchedule>> schedules;
 
 	private final ScheduleStore scheduleStore;
 
@@ -57,7 +58,7 @@ public class ExpiryManager {
 			RecordCache recordCache,
 			Map<TransactionID, TxnIdRecentHistory> txnHistories,
 			ScheduleStore scheduleStore,
-			FCMap<MerkleEntityId, MerkleSchedule> schedules
+			Supplier<FCMap<MerkleEntityId, MerkleSchedule>> schedules
 	) {
 		this.recordCache = recordCache;
 		this.txnHistories = txnHistories;
@@ -94,7 +95,7 @@ public class ExpiryManager {
 		entityExpiries.reset();
 
 		var expiries = new ArrayList<Map.Entry<Pair<Long, Consumer<EntityId>>, Long>>();
-		schedules.forEach((id, schedule) -> {
+		schedules.get().forEach((id, schedule) -> {
 			Consumer<EntityId> consumer = scheduleStore::expire;
 			var pair = Pair.of(id.getNum(), consumer);
 			expiries.add(new AbstractMap.SimpleImmutableEntry<>(pair, schedule.expiry()));

--- a/hedera-node/src/test/java/com/hedera/services/state/expiry/ExpiryManagerTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/state/expiry/ExpiryManagerTest.java
@@ -102,7 +102,7 @@ class ExpiryManagerTest {
 		given(expiringEntity.getKey()).willReturn(schedule.getScheduleNum());
 		given(expiringEntity.getValue()).willReturn(entityIdConsumer);
 
-		subject = new ExpiryManager(recordCache, txnHistories, scheduleStore, schedules);
+		subject = new ExpiryManager(recordCache, txnHistories, scheduleStore, () -> schedules);
 	}
 
 	@Test
@@ -155,7 +155,7 @@ class ExpiryManagerTest {
 		txnHistories = mock(Map.class);
 
 		// given:
-		subject = new ExpiryManager(recordCache, txnHistories, scheduleStore, schedules);
+		subject = new ExpiryManager(recordCache, txnHistories, scheduleStore, () -> schedules);
 		// and:
 		subject.trackRecord(payer, oldExpiry);
 		// and:


### PR DESCRIPTION
**Related issue(s)**:
Closes #1404

**Summary of the change**:
Ensure the `ExpiryManager` has access to the latest mutable `schedules` FCM when rebuilding its expiration queue after a reconnect.
