### PR TITLE
1429 modified SignedStateBalancesExporter for write performance improvement

### DIFF
--- a/hedera-node/src/main/java/com/hedera/services/state/exports/SignedStateBalancesExporter.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/exports/SignedStateBalancesExporter.java
@@ -68,11 +68,11 @@ public class SignedStateBalancesExporter implements BalancesExporter {
 
 	private static final String LINE_SEPARATOR = System.getProperty("line.separator");
 	private static final String UNKNOWN_EXPORT_DIR = "";
-	private static final String BAD_EXPORT_ATTEMPT_ERROR_MSG_TPL = "Could not export to '%s'!";
-	private static final String BAD_SIGNING_ATTEMPT_ERROR_MSG_TPL = "Could not sign balance file '%s'!";
-	static final String BAD_EXPORT_DIR_ERROR_MSG_TPL = "Cannot ensure existence of export dir '%s'!";
-	static final String LOW_NODE_BALANCE_WARN_MSG_TPL = "Node '%s' has unacceptably low balance %d!";
-	static final String GOOD_SIGNING_ATTEMPT_DEBUG_MSG_TPL = "Created balance signature file '%s'.";
+	private static final String BAD_EXPORT_ATTEMPT_ERROR_MSG_TPL = "Could not export to '{}'!";
+	private static final String BAD_SIGNING_ATTEMPT_ERROR_MSG_TPL = "Could not sign balance file '{}'!";
+	static final String BAD_EXPORT_DIR_ERROR_MSG_TPL = "Cannot ensure existence of export dir '{}'!";
+	static final String LOW_NODE_BALANCE_WARN_MSG_TPL = "Node '{}' has unacceptably low balance {}!";
+	static final String GOOD_SIGNING_ATTEMPT_DEBUG_MSG_TPL = "Created balance signature file '{}'.";
 	static final String CURRENT_VERSION = "version:2";
 
 	private static final String PROTO_FILE_EXTENSION = ".pb";
@@ -121,7 +121,7 @@ public class SignedStateBalancesExporter implements BalancesExporter {
 		}
 		periodBegin = now;
 		if(log.isDebugEnabled()) {
-			log.debug(String.format("Now %s is NOT time to export.", now.toString()));
+			log.debug("Now {} is NOT time to export.", now);
 		}
 		return false;
 	}
@@ -138,7 +138,8 @@ public class SignedStateBalancesExporter implements BalancesExporter {
 		if (!expected.equals(summary.getTotalFloat())) {
 			throw new IllegalStateException(String.format(
 					"Signed state @ %s had total balance %d not %d!",
-					when, summary.getTotalFloat(), expectedFloat)); }
+					when, summary.getTotalFloat(), expectedFloat));
+		}
 		log.info("Took {}ms to summarize signed state balances", watch.getTime(TimeUnit.MILLISECONDS));
 
 		// .pb account balances file is our focus, process it first to let its timestamp to stay close to
@@ -185,10 +186,10 @@ public class SignedStateBalancesExporter implements BalancesExporter {
 			var sig = signer.apply(hash);
 			var sigFileLoc = sigFileWriter.writeSigFile(csvLoc, sig, hash);
 			if (log.isDebugEnabled()) {
-				log.debug(String.format(GOOD_SIGNING_ATTEMPT_DEBUG_MSG_TPL, sigFileLoc));
+				log.debug(GOOD_SIGNING_ATTEMPT_DEBUG_MSG_TPL, sigFileLoc);
 			}
 		} catch (Exception e) {
-			log.error(String.format(BAD_SIGNING_ATTEMPT_ERROR_MSG_TPL, csvLoc), e);
+			log.error(BAD_SIGNING_ATTEMPT_ERROR_MSG_TPL, csvLoc, e);
 		}
 	}
 
@@ -200,15 +201,17 @@ public class SignedStateBalancesExporter implements BalancesExporter {
 				addLegacyHeader(fout, when);
 			}
 			for (SingleAccountBalances singleAccountBalances : summary.getOrderedBalances()) {
-				fout.write(String.format(
-						"%d,%d,%d,%d",
-						singleAccountBalances.getAccountID().getShardNum(),
-						singleAccountBalances.getAccountID().getRealmNum(),
-						singleAccountBalances.getAccountID().getAccountNum(),
-						singleAccountBalances.getHbarBalance()));
+				fout.write(Long.toString(singleAccountBalances.getAccountID().getShardNum()));
+				fout.write(",");
+				fout.write(Long.toString(singleAccountBalances.getAccountID().getRealmNum()));
+				fout.write(",");
+				fout.write(Long.toString(singleAccountBalances.getAccountID().getAccountNum()));
+				fout.write(",");
+				fout.write(Long.toString(singleAccountBalances.getHbarBalance()));
 				if (dynamicProperties.shouldExportTokenBalances()) {
 					if (singleAccountBalances.getTokenUnitBalancesList().size() > 0) {
-						fout.write("," + b64Encode(singleAccountBalances));
+						fout.write(",");
+						fout.write(b64Encode(singleAccountBalances));
 					} else {
 						fout.write(",");
 					}
@@ -216,7 +219,7 @@ public class SignedStateBalancesExporter implements BalancesExporter {
 				fout.write(LINE_SEPARATOR);
 			}
 		} catch (IOException e) {
-			log.error(String.format(BAD_EXPORT_ATTEMPT_ERROR_MSG_TPL, csvLoc), e);
+			log.error(BAD_EXPORT_ATTEMPT_ERROR_MSG_TPL, csvLoc, e);
 			return false;
 		}
 		return true;
@@ -233,21 +236,29 @@ public class SignedStateBalancesExporter implements BalancesExporter {
 		try (FileOutputStream fout = new FileOutputStream(protoLoc)) {
 			allAccountsBuilder.build().writeTo(fout);
 		} catch (IOException e) {
-			log.error(String.format(BAD_EXPORT_ATTEMPT_ERROR_MSG_TPL, protoLoc), e);
+			log.error(BAD_EXPORT_ATTEMPT_ERROR_MSG_TPL, protoLoc, e);
 			return false;
 		}
 		return true;
 	}
 
 	private void addLegacyHeader(Writer writer, Instant at) throws IOException {
-		writer.write(String.format("TimeStamp:%s%s", at, LINE_SEPARATOR));
-		writer.write("shardNum,realmNum,accountNum,balance" + LINE_SEPARATOR);
+		writer.write("TimeStamp:");
+		writer.write(at.toString());
+		writer.write(LINE_SEPARATOR);
+		writer.write("shardNum,realmNum,accountNum,balance");
+		writer.write(LINE_SEPARATOR);
 	}
 
 	private void addRelease090Header(Writer writer, Instant at) throws IOException {
-		writer.write("# " + CURRENT_VERSION + LINE_SEPARATOR);
-		writer.write(String.format("# TimeStamp:%s%s", at, LINE_SEPARATOR));
-		writer.write("shardNum,realmNum,accountNum,balance,tokenBalances" + LINE_SEPARATOR);
+		writer.write("# ");
+		writer.write(CURRENT_VERSION);
+		writer.write(LINE_SEPARATOR);
+		writer.write("# TimeStamp:");
+		writer.write(at.toString());
+		writer.write(LINE_SEPARATOR);
+		writer.write("shardNum,realmNum,accountNum,balance,tokenBalances");
+		writer.write(LINE_SEPARATOR);
 	}
 
 	BalancesSummary summarized(ServicesState signedState) {
@@ -266,10 +277,9 @@ public class SignedStateBalancesExporter implements BalancesExporter {
 				var accountId = id.toAccountId();
 				var balance = account.getBalance();
 				if (nodeIds.contains(accountId) && balance < nodeBalanceWarnThreshold) {
-					log.warn(String.format(
-							LOW_NODE_BALANCE_WARN_MSG_TPL,
+					log.warn(LOW_NODE_BALANCE_WARN_MSG_TPL,
 							readableId(accountId),
-							balance));
+							balance);
 				}
 				totalFloat = totalFloat.add(BigInteger.valueOf(account.getBalance()));
 				SingleAccountBalances.Builder sabBuilder = SingleAccountBalances.newBuilder();
@@ -329,7 +339,7 @@ public class SignedStateBalancesExporter implements BalancesExporter {
 				directories.ensureExistenceOf(candidateDir);
 				lastUsedExportDir = candidateDir;
 			} catch (IOException e) {
-				log.error(String.format(BAD_EXPORT_DIR_ERROR_MSG_TPL, candidateDir));
+				log.error(BAD_EXPORT_DIR_ERROR_MSG_TPL, candidateDir);
 				return false;
 			}
 		}

--- a/hedera-node/src/test/java/com/hedera/services/state/exports/SignedStateBalancesExporterTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/state/exports/SignedStateBalancesExporterTest.java
@@ -53,7 +53,6 @@ import javax.inject.Inject;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
-import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -64,7 +63,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.function.UnaryOperator;
 
-import static com.hedera.services.state.exports.SignedStateBalancesExporter.GOOD_SIGNING_ATTEMPT_DEBUG_MSG_TPL;
 import static com.hedera.services.state.exports.SignedStateBalancesExporter.SINGLE_ACCOUNT_BALANCES_COMPARATOR;
 import static com.hedera.services.state.exports.SignedStateBalancesExporter.b64Encode;
 import static com.hedera.services.state.merkle.MerkleEntityAssociation.fromAccountTokenRel;
@@ -244,7 +242,7 @@ class SignedStateBalancesExporterTest {
 		ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
 		// and:
 		var loc = expectedExportLoc();
-		var desiredDebugMsg = String.format(GOOD_SIGNING_ATTEMPT_DEBUG_MSG_TPL, loc + "_sig");
+		var desiredDebugMsg = "Created balance signature file " + "'" + loc + "_sig'.";
 		// and:
 		accounts.clear();
 		accounts.put(
@@ -295,8 +293,8 @@ class SignedStateBalancesExporterTest {
 		// then:
 		var lines = Files.readAllLines(Paths.get(loc));
 		assertEquals(6, lines.size());
-		assertEquals(String.format("# " + SignedStateBalancesExporter.CURRENT_VERSION, now), lines.get(0));
-		assertEquals(String.format("# TimeStamp:%s", now), lines.get(1));
+		assertEquals("# " + SignedStateBalancesExporter.CURRENT_VERSION, lines.get(0));
+		assertEquals("# TimeStamp:" + now, lines.get(1));
 		assertEquals("shardNum,realmNum,accountNum,balance,tokenBalances", lines.get(2));
 		assertEquals("0,0,1,0,", lines.get(3));
 		assertEquals("0,0,2,4999999999999999920,CggKAxjpBxCaBQoICgMY6gcQvAM=", lines.get(4));
@@ -316,7 +314,7 @@ class SignedStateBalancesExporterTest {
 		ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
 		// and:
 		var loc = expectedExportLoc();
-		var desiredDebugMsg = String.format(GOOD_SIGNING_ATTEMPT_DEBUG_MSG_TPL, loc + "_sig");
+		var desiredDebugMsg = "Created balance signature file " + "'" + loc + "_sig'.";
 
 		given(hashReader.readHash(loc)).willReturn(fileHash);
 		given(sigFileWriter.writeSigFile(captor.capture(), any(), any())).willReturn(loc + "_sig");
@@ -329,8 +327,8 @@ class SignedStateBalancesExporterTest {
 		var lines = Files.readAllLines(Paths.get(loc));
 		var expected = theExpectedBalances();
 		assertEquals(expected.size() + 3, lines.size());
-		assertEquals(String.format("# " + SignedStateBalancesExporter.CURRENT_VERSION, now), lines.get(0));
-		assertEquals(String.format("# TimeStamp:%s", now), lines.get(1));
+		assertEquals("# " + SignedStateBalancesExporter.CURRENT_VERSION, lines.get(0));
+		assertEquals("# TimeStamp:" + now, lines.get(1));
 		assertEquals("shardNum,realmNum,accountNum,balance,tokenBalances", lines.get(2));
 		for (int i = 0; i < expected.size(); i++) {
 			var entry = expected.get(i);
@@ -372,7 +370,7 @@ class SignedStateBalancesExporterTest {
 		var lines = Files.readAllLines(Paths.get(expectedExportLoc()));
 		var expected = theExpectedBalances();
 		assertEquals(expected.size() + 2, lines.size());
-		assertEquals(String.format("TimeStamp:%s", now), lines.get(0));
+		assertEquals("TimeStamp:" + now, lines.get(0));
 		assertEquals("shardNum,realmNum,accountNum,balance", lines.get(1));
 		for (int i = 0; i < expected.size(); i++) {
 			var entry = expected.get(i);
@@ -394,7 +392,7 @@ class SignedStateBalancesExporterTest {
 		ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
 		// and:
 		var loc = expectedExportLoc(true);
-		var desiredDebugMsg = String.format(GOOD_SIGNING_ATTEMPT_DEBUG_MSG_TPL, loc + "_sig");
+		var desiredDebugMsg = "Created balance signature file " + "'" + loc + "_sig'.";
 
 		given(hashReader.readHash(loc)).willReturn(fileHash);
 		given(sigFileWriter.writeSigFile(captor.capture(), any(), any())).willReturn(loc + "_sig");
@@ -504,7 +502,7 @@ class SignedStateBalancesExporterTest {
 	public void errorProtoLogsOnIoException() throws IOException {
 		// given:
 		subject.directories = assurance;
-		var desiredMsg = String.format(SignedStateBalancesExporter.BAD_EXPORT_DIR_ERROR_MSG_TPL, expectedExportDir());
+		var desiredMsg = "Cannot ensure existence of export dir " + "'" + expectedExportDir() + "'!";
 		// and:
 		willThrow(IOException.class).given(assurance).ensureExistenceOf(any());
 
@@ -545,8 +543,7 @@ class SignedStateBalancesExporterTest {
 		// given:
 		List<SingleAccountBalances> expectedBalances = theExpectedBalances();
 		// and:
-		var desiredWarning = String.format(
-				SignedStateBalancesExporter.LOW_NODE_BALANCE_WARN_MSG_TPL, "0.0.4", anotherNodeBalance);
+		var desiredWarning = "Node '0.0.4' has unacceptably low balance " + anotherNodeBalance + "!";
 
 		// when:
 		var summary = subject.summarized(state);
@@ -612,7 +609,7 @@ class SignedStateBalancesExporterTest {
 	public void errorLogsOnIoException() throws IOException {
 		// given:
 		subject.directories = assurance;
-		var desiredError = String.format(SignedStateBalancesExporter.BAD_EXPORT_DIR_ERROR_MSG_TPL, expectedExportDir());
+		var desiredError = "Cannot ensure existence of export dir " + "'" + expectedExportDir() + "'!";
 		// and:
 		willThrow(IOException.class).given(assurance).ensureExistenceOf(any());
 


### PR DESCRIPTION
Signed-off-by: abhishek-hedera <abhishek.pandey@hedera.com>

**Related issue(s)**:
Closes #1429 

**Summary of the change**:
Modified `SignedStateBalancesExporter` and `SignedStateBalancesExporterTest` to use string concatenation instead of `String.format` for basic string concatenations.


**Applicable documentation**
- [ ] Javadoc
- [ ] HAPI protobuf comments
- [ ] README
