### PR TITLE
Add MerkleNetworkContext.deserialize() null-safety and avoid transient ISS

### DIFF
--- a/hedera-node/src/main/java/com/hedera/services/fees/TxnRateFeeMultiplierSource.java
+++ b/hedera-node/src/main/java/com/hedera/services/fees/TxnRateFeeMultiplierSource.java
@@ -160,7 +160,11 @@ public class TxnRateFeeMultiplierSource implements FeeMultiplierSource {
 
 	@Override
 	public Instant[] congestionLevelStarts() {
-		return congestionLevelStarts;
+		/* If the Platform is serializing a fast-copy of the MerkleNetworkContext,
+		and that copy references this object's congestionLevelStarts, we will get
+		a (transient) ISS if the congestion level changes mid-serialization on one
+		node but not others. */
+		return congestionLevelStarts.clone();
 	}
 
 	private boolean ensureConfigUpToDate() {

--- a/hedera-node/src/main/java/com/hedera/services/state/merkle/MerkleNetworkContext.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/merkle/MerkleNetworkContext.java
@@ -171,7 +171,8 @@ public class MerkleNetworkContext extends AbstractMerkleLeaf {
 
 	@Override
 	public void deserialize(SerializableDataInputStream in, int version) throws IOException {
-		consensusTimeOfLastHandledTxn = serdes.readNullableInstant(in).toJava();
+		final var lastHandleTime = serdes.readNullableInstant(in);
+		consensusTimeOfLastHandledTxn = (lastHandleTime == null) ? null : lastHandleTime.toJava();
 
 		seqNo = seqNoSupplier.get();
 		seqNo.deserialize(in);
@@ -185,8 +186,7 @@ public class MerkleNetworkContext extends AbstractMerkleLeaf {
 					var used = in.readLong();
 					var lastUsed = serdes.readNullableInstant(in);
 					usageSnapshots[i] = new DeterministicThrottle.UsageSnapshot(
-							used,
-							Optional.ofNullable(lastUsed).map(RichInstant::toJava).orElse(null));
+							used, (lastUsed == null) ? null : lastUsed.toJava());
 				}
 			}
 
@@ -194,7 +194,8 @@ public class MerkleNetworkContext extends AbstractMerkleLeaf {
 			if (numCongestionStarts > 0) {
 				congestionLevelStarts = new Instant[numCongestionStarts];
 				for (int i = 0; i < numCongestionStarts; i++) {
-					congestionLevelStarts[i] = serdes.readNullableInstant(in).toJava(); // ifPresent...
+					final var levelStart = serdes.readNullableInstant(in);
+					congestionLevelStarts[i] = (levelStart == null) ? null : levelStart.toJava();
 				}
 			}
 		}

--- a/hedera-node/src/test/java/com/hedera/services/fees/TxnRateFeeMultiplierSourceTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/fees/TxnRateFeeMultiplierSourceTest.java
@@ -45,6 +45,7 @@ import static java.time.Instant.ofEpochSecond;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.collection.IsIterableContainingInOrder.contains;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.BDDMockito.given;
 
@@ -67,6 +68,25 @@ class TxnRateFeeMultiplierSourceTest {
 	void setUp() {
 		mockProps = new MockGlobalDynamicProps();
 		subject = new TxnRateFeeMultiplierSource(mockProps, throttling);
+	}
+
+	@Test
+	void makesDefensiveCopyOfCongestionStarts() {
+		// setup:
+		final var someInstants = new Instant[] {
+				Instant.ofEpochSecond(1_234_567),
+				Instant.ofEpochSecond(2_234_567),
+		};
+
+		// given:
+		subject.resetCongestionLevelStarts(someInstants);
+
+		// when:
+		final var equalNotSameInstants = subject.congestionLevelStarts();
+
+		// then:
+		assertEquals(List.of(someInstants), List.of(equalNotSameInstants));
+		assertNotSame(someInstants, equalNotSameInstants);
 	}
 
 	@Test

--- a/hedera-node/src/test/java/com/hedera/services/fees/TxnRateFeeMultiplierSourceTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/fees/TxnRateFeeMultiplierSourceTest.java
@@ -95,7 +95,7 @@ class TxnRateFeeMultiplierSourceTest {
 		subject.resetCongestionLevelStarts(congestionStarts);
 
 		// then:
-		Assertions.assertSame(congestionStarts, subject.congestionLevelStarts());
+		Assertions.assertEquals(List.of(congestionStarts), List.of(subject.congestionLevelStarts()));
 	}
 
 	/* MockGlobalDynamicProps has 2 secs for minCongestionPeriod */


### PR DESCRIPTION
**Summary of the change**:
- Make `MerkleNetworkContext.deserialize` null-safe.
- Return a `clone` from`TxnRateFeeMultiplierSource.congestionLevelStarts()` so that fast-copies of `MerkleNetworkContext` won't share the same array.
    * If the array _is_ shared, and the congestion level changes on one node but not another while Platform is serializing a fast-copy of `MerkleNetworkContext`, we will get a transient ISS.
