### PR TITLE
Reused PlatformTxnAccessor with handleTransaction from expandSignatures

### DIFF
--- a/hedera-node/src/main/java/com/hedera/services/ServicesState.java
+++ b/hedera-node/src/main/java/com/hedera/services/ServicesState.java
@@ -311,11 +311,16 @@ public class ServicesState extends AbstractNaryMerkleInternal implements SwirldS
 			Instant consensusTime,
 			com.swirlds.common.Transaction transaction
 	) {
-		if (isConsensus) {
-			ctx.logic().incorporateConsensusTxn(transaction,
-					platformTxnRecord.getPlatformTxnAccessor(transaction),
-					consensusTime,
-					submittingMember);
+		try{
+			if (isConsensus) {
+				platformTxnRecord.addTransaction(transaction);
+				ctx.logic().incorporateConsensusTxn(transaction,
+						platformTxnRecord.getPlatformTxnAccessor(transaction),
+						consensusTime,
+						submittingMember);
+			}
+		} catch (InvalidProtocolBufferException e) {
+			log.warn("Consensus platform txn was not gRPC!", e);
 		}
 	}
 

--- a/hedera-node/src/main/java/com/hedera/services/ServicesState.java
+++ b/hedera-node/src/main/java/com/hedera/services/ServicesState.java
@@ -55,6 +55,7 @@ import com.swirlds.common.merkle.MerkleInternal;
 import com.swirlds.common.merkle.MerkleNode;
 import com.swirlds.common.merkle.utility.AbstractNaryMerkleInternal;
 import com.swirlds.fcmap.FCMap;
+import com.typesafe.config.ConfigException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -295,8 +296,8 @@ public class ServicesState extends AbstractNaryMerkleInternal implements SwirldS
 		}
 	}
 
-	protected void setPlatformTxnAccessor(Transaction platformTxn){
-		try{
+	private void setPlatformTxnAccessor(Transaction platformTxn){
+		try {
 			txnAccessor = new PlatformTxnAccessor(platformTxn);
 		} catch (InvalidProtocolBufferException e) {
 			log.warn("expandSignatures called with non-gRPC txn!", e);
@@ -316,12 +317,8 @@ public class ServicesState extends AbstractNaryMerkleInternal implements SwirldS
 			Instant consensusTime,
 			com.swirlds.common.Transaction transaction
 	) {
-		try{
-			if (isConsensus) {
-				ctx.logic().incorporateConsensusTxn(transaction, txnAccessor, consensusTime, submittingMember);
-			}
-		} catch (InvalidProtocolBufferException exception) {
-			log.warn("Consensus platform txn was not gRPC!");
+		if (isConsensus) {
+			ctx.logic().incorporateConsensusTxn(transaction, txnAccessor, consensusTime, submittingMember);
 		}
 	}
 
@@ -329,6 +326,9 @@ public class ServicesState extends AbstractNaryMerkleInternal implements SwirldS
 	public void expandSignatures(Transaction platformTxn) {
 		try {
 			setPlatformTxnAccessor(platformTxn);
+			if (txnAccessor == null)
+				return;
+
 			expandIn(
 					txnAccessor,
 					ctx.lookupRetryingKeyOrder(),

--- a/hedera-node/src/main/java/com/hedera/services/ServicesState.java
+++ b/hedera-node/src/main/java/com/hedera/services/ServicesState.java
@@ -55,7 +55,6 @@ import com.swirlds.common.merkle.MerkleInternal;
 import com.swirlds.common.merkle.MerkleNode;
 import com.swirlds.common.merkle.utility.AbstractNaryMerkleInternal;
 import com.swirlds.fcmap.FCMap;
-import com.typesafe.config.ConfigException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 

--- a/hedera-node/src/main/java/com/hedera/services/legacy/services/state/AwareProcessLogic.java
+++ b/hedera-node/src/main/java/com/hedera/services/legacy/services/state/AwareProcessLogic.java
@@ -84,9 +84,12 @@ public class AwareProcessLogic implements ProcessLogic {
 	}
 
 	@Override
-	public void incorporateConsensusTxn(Transaction platformTxn,
-										PlatformTxnAccessor accessor,
-										Instant consensusTime, long submittingMember) throws NullPointerException{
+	public void incorporateConsensusTxn(
+			Transaction platformTxn,
+			PlatformTxnAccessor accessor,
+			Instant consensusTime,
+			long submittingMember
+	) throws NullPointerException {
 		if (accessor == null) {
 			throw new NullPointerException("The PlatformTxnAccessor is not defined.");
 		}

--- a/hedera-node/src/main/java/com/hedera/services/legacy/services/state/AwareProcessLogic.java
+++ b/hedera-node/src/main/java/com/hedera/services/legacy/services/state/AwareProcessLogic.java
@@ -35,7 +35,6 @@ import com.hederahashgraph.fee.FeeObject;
 import com.swirlds.common.Transaction;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.jetbrains.annotations.NotNull;
 
 import java.time.Instant;
 import java.util.EnumSet;
@@ -88,9 +87,9 @@ public class AwareProcessLogic implements ProcessLogic {
 	@Override
 	public void incorporateConsensusTxn(Transaction platformTxn,
 										PlatformTxnAccessor accessor,
-										Instant consensusTime, long submittingMember) throws InvalidProtocolBufferException{
-		if(accessor == null){
-			throw new InvalidProtocolBufferException("The PlatformTxnAccessor is not defined.");
+										Instant consensusTime, long submittingMember) throws NullPointerException{
+		if (accessor == null) {
+			throw new NullPointerException("The PlatformTxnAccessor is not defined.");
 		}
 
 		Instant effectiveConsensusTime = consensusTime;

--- a/hedera-node/src/main/java/com/hedera/services/legacy/services/state/AwareProcessLogic.java
+++ b/hedera-node/src/main/java/com/hedera/services/legacy/services/state/AwareProcessLogic.java
@@ -20,7 +20,6 @@ package com.hedera.services.legacy.services.state;
  * ‍
  */
 
-import com.google.protobuf.InvalidProtocolBufferException;
 import com.hedera.services.context.ServicesContext;
 import com.hedera.services.legacy.crypto.SignatureStatus;
 import com.hedera.services.sigs.sourcing.ScopedSigBytesProvider;

--- a/hedera-node/src/main/java/com/hedera/services/records/TxnIdRecentHistory.java
+++ b/hedera-node/src/main/java/com/hedera/services/records/TxnIdRecentHistory.java
@@ -30,7 +30,6 @@ import java.util.Comparator;
 import java.util.EnumSet;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Stream;
 
 import static com.hedera.services.txns.diligence.DuplicateClassification.BELIEVED_UNIQUE;

--- a/hedera-node/src/main/java/com/hedera/services/txns/ProcessLogic.java
+++ b/hedera-node/src/main/java/com/hedera/services/txns/ProcessLogic.java
@@ -20,7 +20,10 @@ package com.hedera.services.txns;
  * ‍
  */
 
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.hedera.services.utils.PlatformTxnAccessor;
 import com.swirlds.common.Transaction;
+import org.jetbrains.annotations.NotNull;
 
 import java.time.Instant;
 
@@ -42,8 +45,12 @@ public interface ProcessLogic {
 	 * consensus transaction at the specified time.
 	 *
 	 * @param platformTxn the consensus transaction to incorporate.
+	 * @param txnAccessor the accessor to various referenced parts of hedera services gRPC platformTxn
 	 * @param consensusTime the authoritative time of consensus.
 	 * @param submittingMember the id of the member that submitted the txn
 	 */
-	void incorporateConsensusTxn(Transaction platformTxn, Instant consensusTime, long submittingMember);
+	void incorporateConsensusTxn(Transaction platformTxn,
+								 PlatformTxnAccessor txnAccessor,
+								 Instant consensusTime,
+								 long submittingMember) throws InvalidProtocolBufferException;
 }

--- a/hedera-node/src/main/java/com/hedera/services/txns/ProcessLogic.java
+++ b/hedera-node/src/main/java/com/hedera/services/txns/ProcessLogic.java
@@ -20,11 +20,8 @@ package com.hedera.services.txns;
  * ‍
  */
 
-import com.google.protobuf.InvalidProtocolBufferException;
 import com.hedera.services.utils.PlatformTxnAccessor;
 import com.swirlds.common.Transaction;
-import com.typesafe.config.ConfigException;
-import org.jetbrains.annotations.NotNull;
 
 import java.time.Instant;
 

--- a/hedera-node/src/main/java/com/hedera/services/txns/ProcessLogic.java
+++ b/hedera-node/src/main/java/com/hedera/services/txns/ProcessLogic.java
@@ -23,6 +23,7 @@ package com.hedera.services.txns;
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.hedera.services.utils.PlatformTxnAccessor;
 import com.swirlds.common.Transaction;
+import com.typesafe.config.ConfigException;
 import org.jetbrains.annotations.NotNull;
 
 import java.time.Instant;
@@ -52,5 +53,5 @@ public interface ProcessLogic {
 	void incorporateConsensusTxn(Transaction platformTxn,
 								 PlatformTxnAccessor txnAccessor,
 								 Instant consensusTime,
-								 long submittingMember) throws InvalidProtocolBufferException;
+								 long submittingMember) throws NullPointerException;
 }

--- a/hedera-node/src/main/java/com/hedera/services/utils/PlatformTxnRecord.java
+++ b/hedera-node/src/main/java/com/hedera/services/utils/PlatformTxnRecord.java
@@ -47,7 +47,7 @@ public class PlatformTxnRecord {
 
     }
 
-    public void addTransaction(Transaction transaction) throws InvalidProtocolBufferException {
+    public void addTransaction(Transaction transaction) throws InvalidProtocolBufferException, NullPointerException {
         PlatformTxnAccessor accessor = new PlatformTxnAccessor(transaction);
         cache.put(transaction, accessor);
     }

--- a/hedera-node/src/main/java/com/hedera/services/utils/PlatformTxnRecord.java
+++ b/hedera-node/src/main/java/com/hedera/services/utils/PlatformTxnRecord.java
@@ -1,0 +1,58 @@
+package com.hedera.services.utils;
+
+/*-
+ * ‌
+ * Hedera Services Node
+ * ​
+ * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.swirlds.common.Transaction;
+
+import java.util.concurrent.TimeUnit;
+
+public class PlatformTxnRecord {
+
+    private Cache<Transaction, PlatformTxnAccessor> cache;
+    private long timeToExpire;
+
+    public PlatformTxnRecord(long timeToExpire) {
+        this.timeToExpire = timeToExpire;
+        cache = CacheBuilder.newBuilder()
+                .expireAfterWrite(timeToExpire, TimeUnit.SECONDS)
+                .build();
+    }
+
+    public PlatformTxnAccessor getPlatformTxnAccessor(Transaction platformTxn){
+        if(platformTxn == null)
+            return null;
+
+        return cache.getIfPresent(platformTxn);
+
+    }
+
+    public void addTransaction(Transaction transaction) throws InvalidProtocolBufferException {
+        PlatformTxnAccessor accessor = new PlatformTxnAccessor(transaction);
+        cache.put(transaction, accessor);
+    }
+
+    public long getTimeToExpire() {
+        return timeToExpire;
+    }
+}

--- a/hedera-node/src/test/java/com/hedera/services/ServicesStateTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/ServicesStateTest.java
@@ -21,6 +21,7 @@ package com.hedera.services;
  */
 
 import com.google.protobuf.ByteString;
+import com.google.protobuf.InvalidProtocolBufferException;
 import com.hedera.services.context.NodeInfo;
 import com.hedera.services.context.ServicesContext;
 import com.hedera.services.context.properties.PropertySources;
@@ -51,6 +52,7 @@ import com.hedera.services.stream.RecordStreamManager;
 import com.hedera.services.stream.RecordsRunningHashLeaf;
 import com.hedera.services.throttling.FunctionalityThrottling;
 import com.hedera.services.txns.ProcessLogic;
+import com.hedera.services.utils.PlatformTxnAccessor;
 import com.hedera.services.utils.SystemExits;
 import com.hedera.test.extensions.LogCaptor;
 import com.hedera.test.extensions.LogCaptureExtension;
@@ -134,6 +136,7 @@ class ServicesStateTest {
 	BinaryObjectStore blobStore;
 	Instant now = Instant.now();
 	Transaction platformTxn;
+	PlatformTxnAccessor txnAccessor;
 	Address address;
 	AddressBook book;
 	AddressBook bookCopy;
@@ -195,6 +198,7 @@ class ServicesStateTest {
 		out = mock(SerializableDataOutputStream.class);
 		in = mock(SerializableDataInputStream.class);
 		platformTxn = mock(Transaction.class);
+		txnAccessor = mock(PlatformTxnAccessor.class);
 
 		address = mock(Address.class);
 		given(address.getMemo()).willReturn("0.0.3");
@@ -724,7 +728,7 @@ class ServicesStateTest {
 	}
 
 	@Test
-	void doesNothingIfNotConsensus() {
+	public void doesNothingIfNotConsensus() throws InvalidProtocolBufferException {
 		// setup:
 		subject.ctx = ctx;
 
@@ -732,11 +736,11 @@ class ServicesStateTest {
 		subject.handleTransaction(1, false, now, now, platformTxn);
 
 		// then:
-		verify(logic, never()).incorporateConsensusTxn(platformTxn, now, 1);
+		verify(logic, never()).incorporateConsensusTxn(platformTxn, null, now, 1);
 	}
 
 	@Test
-	void incorporatesConsensus() {
+	public void incorporatesConsensus() throws InvalidProtocolBufferException {
 		// setup:
 		subject.ctx = ctx;
 
@@ -744,7 +748,7 @@ class ServicesStateTest {
 		subject.handleTransaction(1, true, now, now, platformTxn);
 
 		// then:
-		verify(logic).incorporateConsensusTxn(platformTxn, now, 1);
+		verify(logic).incorporateConsensusTxn(platformTxn, null, now, 1);
 	}
 
 	@Test

--- a/hedera-node/src/test/java/com/hedera/services/ServicesStateTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/ServicesStateTest.java
@@ -750,6 +750,8 @@ class ServicesStateTest {
 	public void incorporatesConsensus() throws NullPointerException {
 		// setup:
 		subject.ctx = ctx;
+		given(platformTxn.getContents()).willReturn(
+				com.hederahashgraph.api.proto.java.Transaction.getDefaultInstance().toByteArray());
 
 		// when:
 		subject.handleTransaction(1, true, now, now, platformTxn);
@@ -767,6 +769,21 @@ class ServicesStateTest {
 		// expect
 		Assertions.assertThrows(NullPointerException.class,
 				() -> subject.handleTransaction(1, true, now, now, platformTxn));
+	}
+
+	@Test
+	public void catchInvalidProtocolBufferExceptionInHandleTransaction() throws NullPointerException {
+		// setup
+		subject.ctx = ctx;
+		given(platformTxn.getContents()).willReturn("abcd".getBytes());
+
+		//expect
+		Assertions.assertDoesNotThrow(
+				() -> subject.handleTransaction(1, true, now, now, platformTxn)
+		);
+		assertThat(
+				logCaptor.warnLogs(),
+				contains(Matchers.startsWith("Consensus platform txn was not gRPC!")));
 	}
 
 	@Test

--- a/hedera-node/src/test/java/com/hedera/services/ServicesStateTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/ServicesStateTest.java
@@ -51,7 +51,6 @@ import com.hedera.services.stream.RecordStreamManager;
 import com.hedera.services.stream.RecordsRunningHashLeaf;
 import com.hedera.services.throttling.FunctionalityThrottling;
 import com.hedera.services.txns.ProcessLogic;
-import com.hedera.services.utils.PlatformTxnAccessor;
 import com.hedera.services.utils.SystemExits;
 import com.hedera.test.extensions.LogCaptor;
 import com.hedera.test.extensions.LogCaptureExtension;
@@ -136,7 +135,6 @@ class ServicesStateTest {
 	BinaryObjectStore blobStore;
 	Instant now = Instant.now();
 	Transaction platformTxn;
-	PlatformTxnAccessor txnAccessor;
 	Address address;
 	AddressBook book;
 	AddressBook bookCopy;
@@ -198,7 +196,6 @@ class ServicesStateTest {
 		out = mock(SerializableDataOutputStream.class);
 		in = mock(SerializableDataInputStream.class);
 		platformTxn = mock(Transaction.class);
-		txnAccessor = mock(PlatformTxnAccessor.class);
 
 		address = mock(Address.class);
 		given(address.getMemo()).willReturn("0.0.3");
@@ -445,7 +442,17 @@ class ServicesStateTest {
 	}
 
 	@Test
-	void invokesMigrationsAsApropos() {
+	public void catchesNullPointerExceptionInExpandSigs() {
+		// expect
+		assertDoesNotThrow(() -> subject.expandSignatures(null));
+
+		// then:
+		assertThat(logCaptor.warnLogs(),
+				contains(Matchers.startsWith("The platformTxn was null!")));
+	}
+
+	@Test
+	public void invokesMigrationsAsApropos() {
 		// setup:
 		var nodeInfo = mock(NodeInfo.class);
 		given(ctx.nodeInfo()).willReturn(nodeInfo);

--- a/hedera-node/src/test/java/com/hedera/services/ServicesStateTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/ServicesStateTest.java
@@ -29,7 +29,6 @@ import com.hedera.services.legacy.core.jproto.JKey;
 import com.hedera.services.legacy.crypto.SignatureStatus;
 import com.hedera.services.records.AccountRecordsHistorian;
 import com.hedera.services.records.TxnIdRecentHistory;
-import com.hedera.services.sigs.HederaToPlatformSigOps;
 import com.hedera.services.sigs.factories.SigFactoryCreator;
 import com.hedera.services.sigs.order.HederaSigningOrder;
 import com.hedera.services.sigs.order.SigningOrderResult;
@@ -86,11 +85,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InOrder;
-import org.mockito.Mockito;
 
 import javax.inject.Inject;
 import java.io.UncheckedIOException;
-import java.lang.reflect.Field;
 import java.time.Instant;
 import java.util.Collections;
 import java.util.List;
@@ -120,6 +117,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.inOrder;
@@ -127,8 +125,7 @@ import static org.mockito.BDDMockito.mock;
 import static org.mockito.BDDMockito.never;
 import static org.mockito.BDDMockito.verify;
 import static org.mockito.BDDMockito.willThrow;
-import static org.mockito.Mockito.*;
-import org.mockito.MockedStatic;
+import static org.mockito.Mockito.times;
 
 @ExtendWith(LogCaptureExtension.class)
 class ServicesStateTest {
@@ -766,7 +763,7 @@ class ServicesStateTest {
 	}
 
 	@Test
-	void expandsSigs() {
+	public void expandsSigs() {
 		// setup:
 		ByteString mockPk = ByteString.copyFrom("not-a-real-pkPrefix".getBytes());
 		ByteString mockSig = ByteString.copyFrom("not-a-real-sig".getBytes());

--- a/hedera-node/src/test/java/com/hedera/services/legacy/services/state/AwareProcessLogicTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/legacy/services/state/AwareProcessLogicTest.java
@@ -27,7 +27,6 @@ import com.hedera.services.context.TransactionContext;
 import com.hedera.services.fees.FeeCalculator;
 import com.hedera.services.fees.charging.TxnFeeChargingPolicy;
 import com.hedera.services.ledger.HederaLedger;
-import com.hedera.services.legacy.handler.SmartContractRequestHandler;
 import com.hedera.services.records.AccountRecordsHistorian;
 import com.hedera.services.records.TxnIdRecentHistory;
 import com.hedera.services.security.ops.SystemOpAuthorization;
@@ -42,7 +41,6 @@ import com.hedera.services.stats.MiscSpeedometers;
 import com.hedera.services.stream.RecordStreamManager;
 import com.hedera.services.stream.RecordStreamObject;
 import com.hedera.services.txns.TransitionLogicLookup;
-import com.hedera.services.txns.validation.OptionValidator;
 import com.hedera.services.utils.PlatformTxnAccessor;
 import com.hedera.services.utils.TxnAccessor;
 import com.hedera.test.utils.IdUtils;
@@ -65,8 +63,6 @@ import java.util.Map;
 import java.util.Optional;
 
 import static com.hedera.services.txns.diligence.DuplicateClassification.BELIEVED_UNIQUE;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.collection.IsIterableContainingInOrder.contains;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.any;
 import static org.mockito.BDDMockito.anyLong;
@@ -162,7 +158,7 @@ class AwareProcessLogicTest {
 	}
 
 	@Test
-	void shortCircuitsOnInvariantFailure() throws InvalidProtocolBufferException {
+	void shortCircuitsOnInvariantFailure() throws NullPointerException {
 		setupNonTriggeringTxn();
 		given(accessor.canTriggerTxn()).willReturn(false);
 		given(invariantChecks.holdFor(any(), eq(consensusNow), eq(666L))).willReturn(false);
@@ -175,7 +171,7 @@ class AwareProcessLogicTest {
 	}
 
 	@Test
-	void purgesExpiredAtNewConsensusTimeIfInvariantsHold() throws InvalidProtocolBufferException{
+	void purgesExpiredAtNewConsensusTimeIfInvariantsHold() throws NullPointerException{
 		setupNonTriggeringTxn();
 		given(accessor.canTriggerTxn()).willReturn(false);
 		given(invariantChecks.holdFor(any(), eq(consensusNow), eq(666L))).willReturn(true);
@@ -188,7 +184,7 @@ class AwareProcessLogicTest {
 	}
 
 	@Test
-	void decrementsParentConsensusTimeIfCanTrigger() throws InvalidProtocolBufferException{
+	void decrementsParentConsensusTimeIfCanTrigger() throws NullPointerException{
 		setupTriggeringTxn();
 		given(accessor.canTriggerTxn()).willReturn(true);
 		// and:
@@ -210,9 +206,9 @@ class AwareProcessLogicTest {
 		setupNonTriggeringTxn();
 
 		//when
-		Assertions.assertThrows(InvalidProtocolBufferException.class,
-				() -> subject.incorporateConsensusTxn(platformTxn, null, consensusNow, 007),
-				"Should throw InvalidProtocolBufferException");
+		var exception = Assertions.assertThrows(NullPointerException.class,
+				() -> subject.incorporateConsensusTxn(platformTxn, null, consensusNow, 007));
+		Assertions.assertEquals("The PlatformTxnAccessor is not defined.", exception.getMessage());
 	}
 
 	@Test

--- a/hedera-node/src/test/java/com/hedera/services/legacy/services/state/AwareProcessLogicTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/legacy/services/state/AwareProcessLogicTest.java
@@ -21,7 +21,6 @@ package com.hedera.services.legacy.services.state;
  */
 
 import com.google.protobuf.ByteString;
-import com.google.protobuf.InvalidProtocolBufferException;
 import com.hedera.services.context.ServicesContext;
 import com.hedera.services.context.TransactionContext;
 import com.hedera.services.fees.FeeCalculator;

--- a/hedera-node/src/test/java/com/hedera/services/utils/PlatformTxnRecordTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/utils/PlatformTxnRecordTest.java
@@ -71,6 +71,7 @@ public class PlatformTxnRecordTest {
 
         // when
         assertThrows(InvalidProtocolBufferException.class, () -> subject.addTransaction(transactionA));
+        assertThrows(NullPointerException.class, () -> subject.addTransaction(null));
     }
 
     @Test

--- a/hedera-node/src/test/java/com/hedera/services/utils/PlatformTxnRecordTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/utils/PlatformTxnRecordTest.java
@@ -1,0 +1,102 @@
+package com.hedera.services.utils;
+
+/*-
+ * ‌
+ * Hedera Services Node
+ * ​
+ * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.swirlds.common.Transaction;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static com.hedera.services.utils.SleepingPause.SLEEPING_PAUSE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.mock;
+
+public class PlatformTxnRecordTest {
+    private Transaction platformTxn;
+    private PlatformTxnRecord subject;
+
+    @BeforeEach
+    private void setup(){
+        platformTxn = mock(Transaction.class);
+        given(platformTxn.getContents()).willReturn(
+                com.hederahashgraph.api.proto.java.Transaction.getDefaultInstance().toByteArray());
+
+        subject = new PlatformTxnRecord(1L);
+    }
+
+    @Test
+    public void getPlatformTxnAccessorWillReturnNullWhenEmptyTransaction() {
+        // when
+        assertNull(subject.getPlatformTxnAccessor(null));
+    }
+
+    @Test
+    void getPlatformTxnAccessorWillReturnNullWhenTransactionsAreDifferent() throws InvalidProtocolBufferException{
+        // setup
+        Transaction transactionA = new Transaction("abc".getBytes());
+
+        // when
+        subject.addTransaction(platformTxn);
+
+        // then
+        assertNull(subject.getPlatformTxnAccessor(transactionA));
+    }
+
+    @Test
+    void addTransactionWillThrowExceptionOnInvalidTxn() {
+        // setup
+        Transaction transactionA = new Transaction("abc".getBytes());
+
+        // when
+        assertThrows(InvalidProtocolBufferException.class, () -> subject.addTransaction(transactionA));
+    }
+
+    @Test
+    void getPlatformTxnAccessorReturnsSameTransaction() throws InvalidProtocolBufferException{
+        // when
+        subject.addTransaction(platformTxn);
+
+        //then
+        assertEquals(platformTxn, subject.getPlatformTxnAccessor(platformTxn).getPlatformTxn());
+    }
+
+    @Test
+    void defaultTimeToExpireIsSame(){
+        // when
+        assertEquals(1, subject.getTimeToExpire());
+    }
+
+    @Test
+    void getPlatformTxnAccessorWillReturnNullAfterExpiry() throws InvalidProtocolBufferException {
+        // when
+        subject.addTransaction(platformTxn);
+
+        // then
+        SLEEPING_PAUSE.forMs(50L);
+        assertEquals(platformTxn, subject.getPlatformTxnAccessor(platformTxn).getPlatformTxn());
+        SLEEPING_PAUSE.forMs(1000L);
+        assertNull(subject.getPlatformTxnAccessor(platformTxn));
+    }
+}


### PR DESCRIPTION
Signed-off-by: abhishek-hedera <abhishek.pandey@hedera.com>

**Related issue(s)**:
Closes #1421 

**Summary of the change**:
Modified `ServicesState`, `ServicesStateTest`, `ProcessLogic`, `AwareProcessLogic` to reuse `PlatformTxnAccessor`.
Removed unused imports.

**External impacts**:
None.

**Applicable documentation**
- [ ] Javadoc
- [ ] HAPI protobuf comments
- [ ] README
