### PR TITLE
Feat/token seggregation internal (#231)

### DIFF
--- a/hapi-fees/src/main/java/com/hedera/services/usage/token/entities/TokenEntitySizes.java
+++ b/hapi-fees/src/main/java/com/hedera/services/usage/token/entities/TokenEntitySizes.java
@@ -33,8 +33,8 @@ public enum TokenEntitySizes {
 	static int NUM_FLAGS_IN_BASE_TOKEN_REPRESENTATION = 3;
 	/* { decimals, tokenType, supplyType } */
 	static int NUM_INT_FIELDS_IN_BASE_TOKEN_REPRESENTATION = 3;
-	/* { expiry, maxSupply, totalSupply, autoRenewPeriod } */
-	static int NUM_LONG_FIELDS_IN_BASE_TOKEN_REPRESENTATION = 4;
+	/* { expiry, maxSupply, totalSupply, autoRenewPeriod, currentSerialNum } */
+	static int NUM_LONG_FIELDS_IN_BASE_TOKEN_REPRESENTATION = 5;
 	/* { treasury } */
 	static int NUM_ENTITY_ID_FIELDS_IN_BASE_TOKEN_REPRESENTATION = 1;
 

--- a/hedera-node/src/main/java/com/hedera/services/state/merkle/MerkleToken.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/merkle/MerkleToken.java
@@ -59,6 +59,7 @@ public class MerkleToken extends AbstractMerkleLeaf implements FCMValue {
 	private TokenType tokenType;
 	private TokenSupplyType supplyType;
 	private int decimals;
+	private long currentSerialNum;
 	private long expiry;
 	private long maxSupply;
 	private long totalSupply;
@@ -120,6 +121,7 @@ public class MerkleToken extends AbstractMerkleLeaf implements FCMValue {
 				this.maxSupply == that.maxSupply &&
 				this.totalSupply == that.totalSupply &&
 				this.decimals == that.decimals &&
+				this.currentSerialNum == that.currentSerialNum &&
 				this.accountsFrozenByDefault == that.accountsFrozenByDefault &&
 				this.accountsKycGrantedByDefault == that.accountsKycGrantedByDefault &&
 				Objects.equals(this.symbol, that.symbol) &&
@@ -144,6 +146,7 @@ public class MerkleToken extends AbstractMerkleLeaf implements FCMValue {
 				maxSupply,
 				totalSupply,
 				decimals,
+				currentSerialNum,
 				adminKey,
 				freezeKey,
 				kycKey,
@@ -174,6 +177,7 @@ public class MerkleToken extends AbstractMerkleLeaf implements FCMValue {
 				.add("maxSupply", maxSupply)
 				.add("totalSupply", totalSupply)
 				.add("decimals", decimals)
+				.add("currentSerialNum", currentSerialNum)
 				.add("autoRenewAccount", readableAutoRenewAccount())
 				.add("autoRenewPeriod", autoRenewPeriod)
 				.add("adminKey", describe(adminKey))
@@ -226,6 +230,7 @@ public class MerkleToken extends AbstractMerkleLeaf implements FCMValue {
 			tokenType = TokenType.values()[in.readInt()];
 			supplyType = TokenSupplyType.values()[in.readInt()];
 			maxSupply = in.readLong();
+			currentSerialNum = in.readLong();
 		}
 		if (tokenType == null) {
 			tokenType = TokenType.FUNGIBLE_COMMON;
@@ -257,6 +262,7 @@ public class MerkleToken extends AbstractMerkleLeaf implements FCMValue {
 		out.writeInt(tokenType.ordinal());
 		out.writeInt(supplyType.ordinal());
 		out.writeLong(maxSupply);
+		out.writeLong(currentSerialNum);
 	}
 
 	/* --- FastCopyable --- */
@@ -275,6 +281,7 @@ public class MerkleToken extends AbstractMerkleLeaf implements FCMValue {
 		fc.setDeleted(deleted);
 		fc.setAutoRenewPeriod(autoRenewPeriod);
 		fc.setAutoRenewAccount(autoRenewAccount);
+		fc.currentSerialNum = currentSerialNum;
 		fc.setTokenType(tokenType);
 		fc.setSupplyType(supplyType);
 		fc.setMaxSupply(maxSupply);
@@ -455,6 +462,15 @@ public class MerkleToken extends AbstractMerkleLeaf implements FCMValue {
 	public void setMemo(String memo) {
 		this.memo = memo;
 	}
+
+	public long getCurrentSerialNum() {
+		return currentSerialNum;
+	}
+
+	public long incrementSerialNum(){
+		return ++this.currentSerialNum;
+	}
+
 
 	public TokenType tokenType() {
 		return tokenType;

--- a/hedera-node/src/main/java/com/hedera/services/state/merkle/MerkleUniqueToken.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/merkle/MerkleUniqueToken.java
@@ -23,6 +23,11 @@ package com.hedera.services.state.merkle;
 import com.google.common.base.MoreObjects;
 import com.hedera.services.state.submerkle.EntityId;
 import com.hedera.services.state.submerkle.RichInstant;
+import com.hedera.services.state.serdes.DomainSerdes;
+import com.hedera.services.state.submerkle.EntityId;
+import com.hedera.services.state.submerkle.RichInstant;
+import com.hedera.services.store.tokens.unique.OwnerIdentifier;
+import com.hedera.services.utils.invertible_fchashmap.Identifiable;
 import com.swirlds.common.FCMValue;
 import com.swirlds.common.io.SerializableDataInputStream;
 import com.swirlds.common.io.SerializableDataOutputStream;
@@ -36,7 +41,7 @@ import static com.hedera.services.state.merkle.MerkleAccountState.DEFAULT_MEMO;
 /**
  * Represents an uniqueToken entity. Part of the nft implementation.
  */
-public class MerkleUniqueToken extends AbstractMerkleLeaf implements FCMValue {
+public class MerkleUniqueToken extends AbstractMerkleLeaf implements FCMValue, Identifiable<OwnerIdentifier> {
 
 	public static final int UPPER_BOUND_MEMO_UTF8_BYTES = 1024;
 	static final int MERKLE_VERSION = 1;
@@ -141,5 +146,10 @@ public class MerkleUniqueToken extends AbstractMerkleLeaf implements FCMValue {
 
 	public RichInstant getCreationTime() {
 		return creationTime;
+	}
+
+	@Override
+	public OwnerIdentifier getIdentity() {
+		return new OwnerIdentifier(this.owner);
 	}
 }

--- a/hedera-node/src/main/java/com/hedera/services/store/tokens/common/CommonStore.java
+++ b/hedera-node/src/main/java/com/hedera/services/store/tokens/common/CommonStore.java
@@ -1,0 +1,30 @@
+package com.hedera.services.store.tokens.common;
+
+/*
+ * ‌
+ * Hedera Services Node
+ * ​
+ * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import com.hedera.services.store.tokens.TokenStore;
+
+/**
+ * Interface, defining the CommonTokenStore methods
+ * @author Yoan Sredkov
+ */
+public interface CommonStore extends TokenStore {
+}

--- a/hedera-node/src/main/java/com/hedera/services/store/tokens/common/CommonTokenStore.java
+++ b/hedera-node/src/main/java/com/hedera/services/store/tokens/common/CommonTokenStore.java
@@ -1,0 +1,87 @@
+package com.hedera.services.store.tokens.common;
+
+/*
+ * ‌
+ * Hedera Services Node
+ * ​
+ * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import com.hedera.services.context.properties.GlobalDynamicProperties;
+import com.hedera.services.ledger.TransactionalLedger;
+import com.hedera.services.ledger.ids.EntityIdSource;
+import com.hedera.services.ledger.properties.TokenRelProperty;
+import com.hedera.services.state.merkle.MerkleEntityId;
+import com.hedera.services.state.merkle.MerkleToken;
+import com.hedera.services.state.merkle.MerkleTokenRelStatus;
+import com.hedera.services.store.tokens.BaseTokenStore;
+import com.hedera.services.txns.validation.OptionValidator;
+import com.hederahashgraph.api.proto.java.AccountID;
+import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
+import com.hederahashgraph.api.proto.java.TokenID;
+import com.swirlds.fcmap.FCMap;
+import org.apache.commons.lang3.tuple.Pair;
+
+import java.util.function.Supplier;
+
+import static com.hedera.services.ledger.accounts.BackingTokenRels.asTokenRel;
+import static com.hedera.services.ledger.properties.TokenRelProperty.TOKEN_BALANCE;
+import static com.hedera.services.state.submerkle.EntityId.fromGrpcAccountId;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.CANNOT_WIPE_TOKEN_TREASURY_ACCOUNT;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_WIPING_AMOUNT;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OK;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TOKEN_HAS_NO_WIPE_KEY;
+
+/**
+ * Provides functionality to work with Common tokens.
+ */
+public class CommonTokenStore extends BaseTokenStore implements CommonStore {
+
+
+	public CommonTokenStore(EntityIdSource ids,
+							OptionValidator validator,
+							GlobalDynamicProperties properties,
+							Supplier<FCMap<MerkleEntityId, MerkleToken>> tokens,
+							TransactionalLedger<Pair<AccountID, TokenID>, TokenRelProperty, MerkleTokenRelStatus> tokenRelsLedger
+	) {
+		super(ids, validator, properties, tokens, tokenRelsLedger);
+	}
+
+	@Override
+	public ResponseCodeEnum wipe(AccountID aId, TokenID tId, long amount, boolean skipKeyCheck) {
+		return super.sanityChecked(aId, tId, token -> {
+			if (!skipKeyCheck && !token.hasWipeKey()) {
+				return TOKEN_HAS_NO_WIPE_KEY;
+			}
+			if (fromGrpcAccountId(aId).equals(token.treasury())) {
+				return CANNOT_WIPE_TOKEN_TREASURY_ACCOUNT;
+			}
+
+			var relationship = asTokenRel(aId, tId);
+			long balance = (long) super.getTokenRelsLedger().get(relationship, TOKEN_BALANCE);
+			if (amount > balance) {
+				return INVALID_WIPING_AMOUNT;
+			}
+			super.getTokenRelsLedger().set(relationship, TOKEN_BALANCE, balance - amount);
+			// TODO this should and will be updated in another PR
+			hederaLedger.updateTokenXfers(tId, aId, -amount);
+
+			apply(tId, t -> t.adjustTotalSupplyBy(-amount));
+
+			return OK;
+		});
+	}
+}

--- a/hedera-node/src/main/java/com/hedera/services/store/tokens/unique/OwnerIdentifier.java
+++ b/hedera-node/src/main/java/com/hedera/services/store/tokens/unique/OwnerIdentifier.java
@@ -1,0 +1,55 @@
+package com.hedera.services.store.tokens.unique;
+
+/*
+ * ‌
+ * Hedera Services Node
+ * ​
+ * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import com.hedera.services.state.submerkle.EntityId;
+import com.hedera.services.utils.invertible_fchashmap.Identifiable;
+
+import java.util.Objects;
+
+public class OwnerIdentifier implements Identifiable {
+
+	private final EntityId owner;
+
+	public OwnerIdentifier(EntityId owner) {
+		this.owner = owner;
+	}
+
+	/* Object */
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || OwnerIdentifier.class != o.getClass()) {
+			return false;
+		}
+
+		var that = (OwnerIdentifier) o;
+		return this.owner.equals(that.owner);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(owner);
+	}
+
+}

--- a/hedera-node/src/main/java/com/hedera/services/store/tokens/unique/UniqueStore.java
+++ b/hedera-node/src/main/java/com/hedera/services/store/tokens/unique/UniqueStore.java
@@ -1,0 +1,42 @@
+package com.hedera.services.store.tokens.unique;
+
+/*
+ * ‌
+ * Hedera Services Node
+ * ​
+ * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import com.hedera.services.state.submerkle.RichInstant;
+import com.hedera.services.store.tokens.TokenStore;
+import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
+import com.hederahashgraph.api.proto.java.TokenID;
+
+/**
+ * An interface which defines methods for the UniqueTokenStore
+ *
+ * @author Yoan Sredkov
+ */
+public interface UniqueStore extends TokenStore {
+
+	ResponseCodeEnum mint(final TokenID tId, String memo, RichInstant creationTime);
+//	MerkleUniqueToken getUnique(final EntityId eId, final int serialNum);
+//	Iterator<MerkleUniqueTokenId> getByToken(final MerkleUniqueToken token);
+//	Iterator<MerkleUniqueTokenId> getByTokenFromIdx(final MerkleUniqueToken token, final int start);
+//	Iterator<MerkleUniqueTokenId> getByTokenFromIdxToIdx(final MerkleUniqueToken token, final int start, final int end);
+//	Iterator<MerkleUniqueTokenId> getByAccountFromIdxToIdx(final AccountID aId, final int start, final int end);
+
+}

--- a/hedera-node/src/main/java/com/hedera/services/store/tokens/unique/UniqueTokenStore.java
+++ b/hedera-node/src/main/java/com/hedera/services/store/tokens/unique/UniqueTokenStore.java
@@ -1,0 +1,96 @@
+package com.hedera.services.store.tokens.unique;
+
+/*
+ * ‌
+ * Hedera Services Node
+ * ​
+ * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import com.hedera.services.context.properties.GlobalDynamicProperties;
+import com.hedera.services.ledger.TransactionalLedger;
+import com.hedera.services.ledger.ids.EntityIdSource;
+import com.hedera.services.ledger.properties.TokenRelProperty;
+import com.hedera.services.state.merkle.MerkleEntityId;
+import com.hedera.services.state.merkle.MerkleToken;
+import com.hedera.services.state.merkle.MerkleTokenRelStatus;
+import com.hedera.services.state.merkle.MerkleUniqueToken;
+import com.hedera.services.state.merkle.MerkleUniqueTokenId;
+import com.hedera.services.state.submerkle.EntityId;
+import com.hedera.services.state.submerkle.RichInstant;
+import com.hedera.services.store.tokens.BaseTokenStore;
+import com.hedera.services.txns.validation.OptionValidator;
+import com.hedera.services.utils.invertible_fchashmap.FCInvertibleHashMap;
+import com.hederahashgraph.api.proto.java.AccountID;
+import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
+import com.hederahashgraph.api.proto.java.TokenID;
+import com.swirlds.fcmap.FCMap;
+import org.apache.commons.lang3.tuple.Pair;
+
+import java.util.function.Supplier;
+
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OK;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TOKEN_HAS_NO_SUPPLY_KEY;
+
+/**
+ * Provides functionality to work with Unique tokens.
+ *
+ * @author Yoan Sredkov
+ */
+public class UniqueTokenStore extends BaseTokenStore implements UniqueStore {
+
+	private final Supplier<FCInvertibleHashMap<MerkleUniqueTokenId, MerkleUniqueToken, OwnerIdentifier>> uniqueTokenSupplier;
+
+	public UniqueTokenStore(final EntityIdSource ids,
+							final OptionValidator validator,
+							final GlobalDynamicProperties properties,
+							final Supplier<FCMap<MerkleEntityId, MerkleToken>> tokens,
+							final Supplier<FCInvertibleHashMap<MerkleUniqueTokenId, MerkleUniqueToken, OwnerIdentifier>> uniqueTokenSupplier,
+							final TransactionalLedger<Pair<AccountID, TokenID>, TokenRelProperty, MerkleTokenRelStatus> tokenRelsLedger
+	) {
+		super(ids, validator, properties, tokens, tokenRelsLedger);
+		this.uniqueTokenSupplier = uniqueTokenSupplier;
+	}
+
+	@Override
+	public ResponseCodeEnum mint(final TokenID tId, final String memo, final RichInstant creationTime) {
+		return tokenSanityCheck(tId, (merkleToken -> {
+			if (!merkleToken.hasSupplyKey()) {
+				return TOKEN_HAS_NO_SUPPLY_KEY;
+			}
+			var mintResult = super.mint(tId, 1);
+			if (!mintResult.equals(OK)) {
+				return mintResult;
+			}
+			final var suppliedTokens = uniqueTokenSupplier.get();
+			final var eId = EntityId.fromGrpcTokenId(tId);
+			final var owner = merkleToken.treasury();
+			final long serialNum = merkleToken.incrementSerialNum();
+
+			final var nftId = new MerkleUniqueTokenId(eId, serialNum);
+			final var nft = new MerkleUniqueToken(owner, memo, creationTime);
+			suppliedTokens.put(nftId, nft);
+			return OK;
+		}));
+
+	}
+
+	@Override
+	public ResponseCodeEnum wipe(final AccountID aId, final TokenID tId, final long wipingAmount, final boolean skipKeyCheck) {
+		return null;
+	}
+
+}

--- a/hedera-node/src/main/java/com/hedera/services/utils/invertible_fchashmap/FCInvertibleHashMap.java
+++ b/hedera-node/src/main/java/com/hedera/services/utils/invertible_fchashmap/FCInvertibleHashMap.java
@@ -1,0 +1,340 @@
+/*
+ * (c) 2016-2021 Swirlds, Inc.
+ *
+ * This software is the confidential and proprietary information of
+ * Swirlds, Inc. ("Confidential Information"). You shall not
+ * disclose such Confidential Information and shall use it only in
+ * accordance with the terms of the license agreement you entered into
+ * with Swirlds.
+ *
+ * SWIRLDS MAKES NO REPRESENTATIONS OR WARRANTIES ABOUT THE SUITABILITY OF
+ * THE SOFTWARE, EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+ * TO THE IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE, OR NON-INFRINGEMENT. SWIRLDS SHALL NOT BE LIABLE FOR
+ * ANY DAMAGES SUFFERED BY LICENSEE AS A RESULT OF USING, MODIFYING OR
+ * DISTRIBUTING THIS SOFTWARE OR ITS DERIVATIVES.
+ */
+
+package com.hedera.services.utils.invertible_fchashmap;
+
+import com.swirlds.common.FastCopyable;
+import com.swirlds.common.crypto.Hash;
+import com.swirlds.common.merkle.MerkleNode;
+import com.swirlds.fchashmap.FCHashMap;
+
+import java.util.AbstractMap;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * A fast copyable hashmap that is also able to generate inverse mappings between a value and the set of all
+ * keys that map to that value. Supports pagination.
+ * <p>
+ * This data structure does not support null values.
+ *
+ * @param <K>
+ * 		the type of the key. This key must be effectively immutable -- that is, no changes to the key after its
+ * 		insertion may have any effect on its {@link Object#equals(Object)} or {@link Object#hashCode()}.
+ * @param <V>
+ * 		the type of the value
+ * @param <I>
+ * 		the type of the identifier used for the value, as required by the {@link Identifiable} interface
+ */
+public class FCInvertibleHashMap<K, V extends Identifiable<I>, I> extends AbstractMap<K, V> implements FastCopyable, MerkleNode {
+
+	/**
+	 * A standard mapping between keys and values.
+	 */
+	private final FCHashMap<K, V> keyToValueMap;
+
+	/**
+	 * A map between values and keys.
+	 */
+	private final FCHashMap<InverseKey<I>, K> valueToKeyMap;
+
+	/**
+	 * The number of times that a given value appears in the map.
+	 */
+	private final FCHashMap<I, Integer> valueCountMap;
+
+	/**
+	 * The index of each key in the mutable copy.
+	 */
+	private final Map<K, Integer> keyIndexMap;
+
+	private boolean immutable;
+
+	private int referenceCount;
+
+	/**
+	 * Create a new {@link FCInvertibleHashMap}.
+	 */
+	public FCInvertibleHashMap() {
+		this(0);
+	}
+
+	/**
+	 * Create a new {@link FCInvertibleHashMap} with an initial capacity.
+	 *
+	 * @param capacity
+	 * 		the initial capacity of the hashmap
+	 */
+	public FCInvertibleHashMap(final int capacity) {
+		keyToValueMap = new FCHashMap<>(capacity);
+		valueToKeyMap = new FCHashMap<>();
+		valueCountMap = new FCHashMap<>();
+		keyIndexMap = new HashMap<>(capacity);
+		this.referenceCount = 0;
+	}
+
+	/**
+	 * Copy constructor.
+	 *
+	 * @param that
+	 * 		the map to copy
+	 */
+	private FCInvertibleHashMap(final FCInvertibleHashMap<K, V, I> that) {
+		keyToValueMap = that.keyToValueMap.copy();
+		valueToKeyMap = that.valueToKeyMap.copy();
+		valueCountMap = that.valueCountMap.copy();
+		keyIndexMap = that.keyIndexMap;
+		referenceCount = that.referenceCount;
+		that.immutable = true;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public FCInvertibleHashMap<K, V, I> copy() {
+		return new FCInvertibleHashMap<>(this);
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public boolean isImmutable() {
+		return immutable;
+	}
+
+	/**
+	 * Given a value, return an iterator that iterates over the set of keys that map to the value.
+	 * <p>
+	 * This iterator should not used after this copy of the map is updated in any way.
+	 * This iterator may exhibit undefined behavior if this copy of the map is updated between
+	 * the creation of this iterator and the use of this iterator.
+	 *
+	 * @return an iterator for the key set
+	 */
+	public Iterator<K> inverseGet(final V value) {
+		return inverseGet(value, 0, getValueCount(value));
+	}
+
+	/**
+	 * Given a value, return an iterator that iterates over a paginated set of keys that map to the value. Iteration
+	 * starts at a given index and continues until the end of the key set.
+	 * <p>
+	 * This iterator should not used after this copy of the map is updated in any way.
+	 * This iterator may exhibit undefined behavior if this copy of the map is updated between
+	 * the creation of this iterator and the use of this iterator.
+	 *
+	 * @param startIndex
+	 * 		the index of the first key to return (inclusive).
+	 * 		An index of 0 starts iteration at the first key in the set.
+	 * @return an iterator for the key set starting at the given index
+	 */
+	public Iterator<K> inverseGet(final V value, final int startIndex) {
+		return inverseGet(value, startIndex, getValueCount(value));
+	}
+
+	/**
+	 * Given a value, return an iterator that iterates over a paginated set of keys that map to the value.
+	 * <p>
+	 * This iterator should not used after this copy of the map is updated in any way.
+	 * This iterator may exhibit undefined behavior if this copy of the map is updated between
+	 * the creation of this iterator and the use of this iterator.
+	 *
+	 * @param startIndex
+	 * 		the index of the first key to return (inclusive).
+	 * 		An index of 0 starts iteration at the first key in the set.
+	 * @param endIndex
+	 * 		the index bounding the last key to return (exclusive).
+	 * 		An index of N+1 will cause the set to include the last element if there are N elements.
+	 * @return an iterator for the key set starting at the given index
+	 */
+	public Iterator<K> inverseGet(final V value, final int startIndex, final int endIndex) {
+		return new FCInvertibleHashMapIterator<>(this, value, startIndex, endIndex);
+	}
+
+	/**
+	 * Get a key that maps to a given value at a particular index.
+	 * <p>
+	 * This method is intentionally package private and is intended for use by {@link FCInvertibleHashMapIterator}.
+	 *
+	 * @param value
+	 * 		the value that the key maps to
+	 * @param index
+	 * 		the index of the key
+	 * @return the key that matches the value and index
+	 */
+	K getKeyAtIndex(final V value, final int index) {
+		return valueToKeyMap.get(new InverseKey<>(value.getIdentity(), index));
+	}
+
+	/**
+	 * Return a count of the number of keys that reference a given value, i.e. the number of times that a value
+	 * appears in the map.
+	 *
+	 * @param value
+	 * 		the value in question
+	 * @return the number of keys that reference the value
+	 */
+	public int getValueCount(final V value) {
+		return valueCountMap.get(value.getIdentity());
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public synchronized void release() {
+		keyToValueMap.release();
+		valueToKeyMap.release();
+		valueCountMap.release();
+	}
+
+	/**
+	 * Update data structures maintaining the mapping values to keys to include a new value to key association.
+	 *
+	 * @param key
+	 * 		the key that references the value
+	 * @param value
+	 * 		the value that the key references
+	 */
+	private void associateKeyAndValue(final K key, final V value) {
+		final int index = valueCountMap.getOrDefault(value.getIdentity(), 0);
+		valueToKeyMap.put(new InverseKey<>(value.getIdentity(), index), key);
+		valueCountMap.put(value.getIdentity(), index + 1);
+		keyIndexMap.put(key, index);
+	}
+
+	/**
+	 * Update data structures maintaining the mapping values to keys to no
+	 * longer include a new value to key association.
+	 *
+	 * @param key
+	 * 		the key that references the value
+	 * @param value
+	 * 		the value that the key references
+	 */
+	private void disassociateKeyAndValue(final K key, final V value, final boolean replacingValue) {
+		final int keyIndex = keyIndexMap.get(key);
+		final int maxIndex = valueCountMap.get(value.getIdentity()) - 1;
+
+		valueToKeyMap.remove(new InverseKey<>(value.getIdentity(), keyIndex));
+		if (keyIndex != maxIndex) {
+			// We need to fill the gap, key indices must be must not skip any values
+			final K gapFillingKey = valueToKeyMap.remove(new InverseKey<>(value.getIdentity(), maxIndex));
+			valueToKeyMap.put(new InverseKey<>(value.getIdentity(), keyIndex), gapFillingKey);
+			keyIndexMap.put(gapFillingKey, keyIndex);
+		}
+
+		final int newValueCount = valueCountMap.get(value.getIdentity()) - 1;
+		if (newValueCount == 0) {
+			valueCountMap.remove(value.getIdentity());
+		} else {
+			valueCountMap.put(value.getIdentity(), newValueCount);
+		}
+
+		if (!replacingValue) {
+			keyIndexMap.remove(key);
+		}
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public V put(final K key, final V value) {
+		throwIfImmutable();
+		if (value == null) {
+			throw new IllegalArgumentException("FCInvertibleHashMap does not support null values");
+		}
+		final V previousValue = keyToValueMap.get(key);
+		if (Objects.equals(previousValue, value)) {
+			return previousValue;
+		}
+
+		if (keyToValueMap.containsKey(key)) {
+			disassociateKeyAndValue(key, previousValue, true);
+		}
+
+		keyToValueMap.put(key, value);
+		associateKeyAndValue(key, value);
+
+		return previousValue;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@SuppressWarnings("unchecked")
+	@Override
+	public V remove(final Object key) {
+		throwIfImmutable();
+		final V value = keyToValueMap.remove(key);
+		disassociateKeyAndValue((K) key, value, false);
+		return value;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public Set<Entry<K, V>> entrySet() {
+		return keyToValueMap.entrySet();
+	}
+
+	@Override
+	public boolean isLeaf() {
+		return false;
+	}
+
+	@Override
+	public void incrementReferenceCount() {
+		referenceCount++;
+	}
+
+	@Override
+	public void decrementReferenceCount() {
+		referenceCount--;
+	}
+
+	@Override
+	public int getReferenceCount() {
+		return referenceCount;
+	}
+
+	@Override
+	public long getClassId() {
+		return 0;
+	}
+
+	@Override
+	public Hash getHash() {
+		return new Hash();
+	}
+
+	@Override
+	public void setHash(final Hash hash) {
+	}
+
+	@Override
+	public int getVersion() {
+		return 1;
+	}
+}

--- a/hedera-node/src/main/java/com/hedera/services/utils/invertible_fchashmap/FCInvertibleHashMapIterator.java
+++ b/hedera-node/src/main/java/com/hedera/services/utils/invertible_fchashmap/FCInvertibleHashMapIterator.java
@@ -1,0 +1,93 @@
+/*
+ * (c) 2016-2021 Swirlds, Inc.
+ *
+ * This software is the confidential and proprietary information of
+ * Swirlds, Inc. ("Confidential Information"). You shall not
+ * disclose such Confidential Information and shall use it only in
+ * accordance with the terms of the license agreement you entered into
+ * with Swirlds.
+ *
+ * SWIRLDS MAKES NO REPRESENTATIONS OR WARRANTIES ABOUT THE SUITABILITY OF
+ * THE SOFTWARE, EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+ * TO THE IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE, OR NON-INFRINGEMENT. SWIRLDS SHALL NOT BE LIABLE FOR
+ * ANY DAMAGES SUFFERED BY LICENSEE AS A RESULT OF USING, MODIFYING OR
+ * DISTRIBUTING THIS SOFTWARE OR ITS DERIVATIVES.
+ */
+package com.hedera.services.utils.invertible_fchashmap;
+
+
+
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+
+/**
+ * This object is capable of iterating over all keys that map to a given value
+ *
+ * @param <K>
+ * 		the type of the key
+ * @param <V>
+ * 		the type of the value
+ * @param <I>
+ * 		the type of the identifier for the value
+ */
+public class FCInvertibleHashMapIterator<K, V extends Identifiable<I>, I> implements Iterator<K> {
+
+	private final FCInvertibleHashMap<K, V, I> map;
+	private final V value;
+	private final int endIndex;
+
+	private int nextIndex;
+
+	/**
+	 * Create a new iterator.
+	 *
+	 * @param map
+	 * 		the map to iterate over
+	 * @param value
+	 * 		the value whose keys this will iterate
+	 * @param startIndex
+	 * 		the index where iteration starts (inclusive)
+	 * @param endIndex
+	 * 		the index where iteration ends (exclusive)
+	 */
+	public FCInvertibleHashMapIterator(
+			final FCInvertibleHashMap<K, V, I> map,
+			final V value,
+			final int startIndex,
+			final int endIndex) {
+
+		this.map = map;
+		this.value = value;
+
+		final int valueCount = map.getValueCount(value);
+		if (valueCount < endIndex) {
+			throw new IllegalArgumentException(
+					"requested end index " + endIndex + " exceeds number of elements " + valueCount);
+		}
+
+		this.endIndex = endIndex;
+		this.nextIndex = startIndex;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public boolean hasNext() {
+		return nextIndex < endIndex;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public K next() {
+		if (!hasNext()) {
+			throw new NoSuchElementException();
+		}
+		final int index = nextIndex;
+		nextIndex++;
+		return map.getKeyAtIndex(value, index);
+	}
+}

--- a/hedera-node/src/main/java/com/hedera/services/utils/invertible_fchashmap/Identifiable.java
+++ b/hedera-node/src/main/java/com/hedera/services/utils/invertible_fchashmap/Identifiable.java
@@ -1,0 +1,49 @@
+/*
+ * (c) 2016-2021 Swirlds, Inc.
+ *
+ * This software is the confidential and proprietary information of
+ * Swirlds, Inc. ("Confidential Information"). You shall not
+ * disclose such Confidential Information and shall use it only in
+ * accordance with the terms of the license agreement you entered into
+ * with Swirlds.
+ *
+ * SWIRLDS MAKES NO REPRESENTATIONS OR WARRANTIES ABOUT THE SUITABILITY OF
+ * THE SOFTWARE, EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+ * TO THE IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE, OR NON-INFRINGEMENT. SWIRLDS SHALL NOT BE LIABLE FOR
+ * ANY DAMAGES SUFFERED BY LICENSEE AS A RESULT OF USING, MODIFYING OR
+ * DISTRIBUTING THIS SOFTWARE OR ITS DERIVATIVES.
+ */
+
+// TODO this interface does not belong in this package
+package com.hedera.services.utils.invertible_fchashmap;
+
+/**
+ * Describes an object with an immutable ID.
+ *
+ * @param <I>
+ * 		an immutable object type that uniquely identifies another object type.
+ */
+public interface Identifiable<I> {
+
+	/**
+	 * Get an object that uniquely describes this object.
+	 * Over the lifecycle of this object its identity should never change.
+	 * <p>
+	 * Identifiable objects that are also {@link com.swirlds.common.FastCopyable FastCopyable} are required to
+	 * maintain object identifiers that are equal across all copies of a particular object. That is,
+	 * {@code x.getIdentity().equals(x.copy().getIdentity())} must always evaluate to true.
+	 * <p>
+	 * Objects that are self identifiable (i.e. immutable objects) can use themselves as an identifier,
+	 * and can simply use the default implementation provided below. All other objects must provide
+	 * their own implementation of this method that returns an identity object that is not "self".
+	 * <p>
+	 * When implementing non-self Identifiable objects, always reuse identity objects if possible.
+	 * For example, a {@link com.swirlds.common.FastCopyable FastCopyable} object that extends Identifiable
+	 * can simply copy a reference from one copy to the next.
+	 */
+	@SuppressWarnings("unchecked")
+	default I getIdentity() {
+		return (I) this;
+	}
+}

--- a/hedera-node/src/main/java/com/hedera/services/utils/invertible_fchashmap/InverseKey.java
+++ b/hedera-node/src/main/java/com/hedera/services/utils/invertible_fchashmap/InverseKey.java
@@ -1,0 +1,83 @@
+/*
+ * (c) 2016-2021 Swirlds, Inc.
+ *
+ * This software is the confidential and proprietary information of
+ * Swirlds, Inc. ("Confidential Information"). You shall not
+ * disclose such Confidential Information and shall use it only in
+ * accordance with the terms of the license agreement you entered into
+ * with Swirlds.
+ *
+ * SWIRLDS MAKES NO REPRESENTATIONS OR WARRANTIES ABOUT THE SUITABILITY OF
+ * THE SOFTWARE, EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+ * TO THE IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE, OR NON-INFRINGEMENT. SWIRLDS SHALL NOT BE LIABLE FOR
+ * ANY DAMAGES SUFFERED BY LICENSEE AS A RESULT OF USING, MODIFYING OR
+ * DISTRIBUTING THIS SOFTWARE OR ITS DERIVATIVES.
+ */
+
+package com.hedera.services.utils.invertible_fchashmap;
+
+
+import java.util.Objects;
+
+/**
+ * In an {@link FCInvertibleHashMap FCInvertibleHashMap},
+ * an InverseKey uniquely identifies a particular key.
+ *
+ * @param <I>
+ */
+public class InverseKey<I> {
+
+	private final I valueId;
+	private final int index;
+
+	/**
+	 * Create a new inverse key.
+	 *
+	 * @param valueId
+	 * 		the ID of the value that this key references
+	 * @param index
+	 * 		the index of this key
+	 */
+	public InverseKey(final I valueId, final int index) {
+		this.valueId = valueId;
+		this.index = index;
+	}
+
+	/**
+	 * Get the value ID referenced by a key.
+	 */
+	public I getValueId() {
+		return valueId;
+	}
+
+	/**
+	 * Get the index of a key.
+	 */
+	public int getIndex() {
+		return index;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public boolean equals(final Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		final InverseKey<?> that = (InverseKey<?>) o;
+		return index == that.index && Objects.equals(valueId, that.valueId);
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public int hashCode() {
+		return Objects.hash(valueId, index);
+	}
+}

--- a/hedera-node/src/test/java/com/hedera/services/context/ServicesContextTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/context/ServicesContextTest.java
@@ -121,17 +121,17 @@ import com.hedera.services.stats.MiscRunningAvgs;
 import com.hedera.services.stats.MiscSpeedometers;
 import com.hedera.services.stats.ServicesStatsManager;
 import com.hedera.services.store.schedule.ScheduleStore;
-import com.hedera.services.store.tokens.HederaTokenStore;
-import com.hedera.services.store.tokens.TokenStore;
+import com.hedera.services.store.tokens.BaseTokenStore;
+import com.hedera.services.store.tokens.common.CommonStore;
 import com.hedera.services.stream.RecordStreamManager;
 import com.hedera.services.stream.RecordsRunningHashLeaf;
 import com.hedera.services.throttling.HapiThrottling;
 import com.hedera.services.throttling.TransactionThrottling;
 import com.hedera.services.throttling.TxnAwareHandleThrottling;
 import com.hedera.services.txns.TransitionLogicLookup;
+import com.hedera.services.txns.submission.BasicSubmissionFlow;
 import com.hedera.services.txns.submission.PlatformSubmissionManager;
 import com.hedera.services.txns.submission.SyntaxPrecheck;
-import com.hedera.services.txns.submission.BasicSubmissionFlow;
 import com.hedera.services.txns.submission.TransactionPrecheck;
 import com.hedera.services.txns.submission.TxnResponseHelper;
 import com.hedera.services.txns.validation.ContextOptionValidator;
@@ -368,7 +368,7 @@ public class ServicesContextTest {
 	void rebuildsStoreViewsIfNonNull() {
 		// setup:
 		ScheduleStore scheduleStore = mock(ScheduleStore.class);
-		TokenStore tokenStore = mock(TokenStore.class);
+		CommonStore tokenStore = mock(CommonStore.class);
 
 		// given:
 		ServicesContext ctx = new ServicesContext(nodeId, platform, state, propertySources);
@@ -377,7 +377,7 @@ public class ServicesContextTest {
 		assertDoesNotThrow(ctx::rebuildStoreViewsIfPresent);
 
 		// and given:
-		ctx.setTokenStore(tokenStore);
+		ctx.setCommonTokenStore(tokenStore);
 		ctx.setScheduleStore(scheduleStore);
 
 		// when:
@@ -506,7 +506,7 @@ public class ServicesContextTest {
 		assertThat(ctx.submissionManager(), instanceOf(PlatformSubmissionManager.class));
 		assertThat(ctx.platformStatus(), instanceOf(ContextPlatformStatus.class));
 		assertThat(ctx.contractAnswers(), instanceOf(ContractAnswers.class));
-		assertThat(ctx.tokenStore(), instanceOf(HederaTokenStore.class));
+		assertThat(ctx.tokenStore(), instanceOf(BaseTokenStore.class));
 		assertThat(ctx.globalDynamicProperties(), instanceOf(GlobalDynamicProperties.class));
 		assertThat(ctx.tokenGrpc(), instanceOf(TokenController.class));
 		assertThat(ctx.scheduleGrpc(), instanceOf(ScheduleController.class));

--- a/hedera-node/src/test/java/com/hedera/services/ledger/BaseHederaLedgerTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/ledger/BaseHederaLedgerTest.java
@@ -34,10 +34,9 @@ import com.hedera.services.state.merkle.MerkleAccountTokens;
 import com.hedera.services.state.merkle.MerkleToken;
 import com.hedera.services.state.merkle.MerkleTokenRelStatus;
 import com.hedera.services.state.submerkle.ExpirableTxnRecord;
-import com.hedera.services.store.tokens.HederaTokenStore;
+import com.hedera.services.store.tokens.BaseTokenStore;
 import com.hedera.services.store.tokens.TokenStore;
 import com.hedera.services.txns.validation.OptionValidator;
-import com.hedera.test.mocks.TestContextValidator;
 import com.hedera.test.utils.IdUtils;
 import com.hederahashgraph.api.proto.java.AccountAmount;
 import com.hederahashgraph.api.proto.java.AccountID;
@@ -74,7 +73,7 @@ public class BaseHederaLedgerTest {
 
 	protected HederaLedger subject;
 
-	protected HederaTokenStore tokenStore;
+	protected BaseTokenStore tokenStore;
 	protected EntityIdSource ids;
 	protected ExpiringCreations creator;
 	protected AccountRecordsHistorian historian;
@@ -205,7 +204,7 @@ public class BaseHederaLedgerTest {
 		addDeletedAccountToLedger(deleted);
 		given(tokenRelsLedger.isInTransaction()).willReturn(true);
 
-		tokenStore = mock(HederaTokenStore.class);
+		tokenStore = mock(BaseTokenStore.class);
 		given(tokenStore.exists(frozenId)).willReturn(true);
 		given(tokenStore.exists(tokenId)).willReturn(true);
 		given(tokenStore.exists(missingId)).willReturn(false);

--- a/hedera-node/src/test/java/com/hedera/services/ledger/HederaLedgerLiveTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/ledger/HederaLedgerLiveTest.java
@@ -33,7 +33,7 @@ import com.hedera.services.state.merkle.MerkleAccount;
 import com.hedera.services.state.merkle.MerkleEntityId;
 import com.hedera.services.state.merkle.MerkleToken;
 import com.hedera.services.state.merkle.MerkleTokenRelStatus;
-import com.hedera.services.store.tokens.HederaTokenStore;
+import com.hedera.services.store.tokens.common.CommonTokenStore;
 import com.hedera.test.factories.scenarios.TxnHandlingScenario;
 import com.hedera.test.mocks.TestContextValidator;
 import com.hedera.test.utils.TxnUtils;
@@ -78,7 +78,7 @@ public class HederaLedgerLiveTest extends BaseHederaLedgerTest {
 				new HashMapBackingTokenRels(),
 				new ChangeSummaryManager<>());
 		tokenRelsLedger.setKeyToString(BackingTokenRels::readableTokenRel);
-		tokenStore = new HederaTokenStore(
+		tokenStore = new CommonTokenStore(
 				ids,
 				TestContextValidator.TEST_VALIDATOR,
 				new MockGlobalDynamicProps(),

--- a/hedera-node/src/test/java/com/hedera/services/state/merkle/MerkleTokenTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/state/merkle/MerkleTokenTest.java
@@ -67,6 +67,7 @@ class MerkleTokenTest {
 	long expiry = Instant.now().getEpochSecond() + 1_234_567, otherExpiry = expiry + 2_345_678;
 	long autoRenewPeriod = 1_234_567, otherAutoRenewPeriod = 2_345_678;
 	long totalSupply = 1_000_000, otherTotalSupply = 1_000_001;
+	long currentSerialNum = 0;
 	long maxSupply = 123_456_789, otherMaxSupply = 234_567_890;
 	boolean freezeDefault = true, otherFreezeDefault = false;
 	boolean accountsKycGrantedByDefault = true, otherAccountsKycGrantedByDefault = false;
@@ -124,6 +125,12 @@ class MerkleTokenTest {
 	}
 
 	@Test
+	public void incrementsSerialNumber(){
+		var i = subject.incrementSerialNum();
+		assertEquals(i, subject.getCurrentSerialNum());
+	}
+
+	@Test
 	public void serializeWorks() throws IOException {
 		// setup:
 		var out = mock(SerializableDataOutputStream.class);
@@ -157,6 +164,7 @@ class MerkleTokenTest {
 		inOrder.verify(out).writeNormalisedString(memo);
 		inOrder.verify(out, times(2)).writeInt(tokenType.ordinal());
 		inOrder.verify(out).writeLong(maxSupply);
+		inOrder.verify(out).writeLong(currentSerialNum);
 	}
 
 	@Test
@@ -190,7 +198,8 @@ class MerkleTokenTest {
 				.willReturn(subject.expiry())
 				.willReturn(subject.autoRenewPeriod())
 				.willReturn(subject.totalSupply())
-				.willReturn(subject.maxSupply());
+				.willReturn(subject.maxSupply())
+				.willReturn(currentSerialNum);
 		given(fin.readInt())
 				.willReturn(subject.decimals())
 				.willReturn(subject.tokenType().ordinal())
@@ -231,6 +240,7 @@ class MerkleTokenTest {
 				.willReturn(subject.expiry())
 				.willReturn(subject.autoRenewPeriod())
 				.willReturn(subject.totalSupply());
+
 		given(fin.readInt()).willReturn(subject.decimals());
 		given(fin.readBoolean())
 				.willReturn(isDeleted)
@@ -629,6 +639,7 @@ class MerkleTokenTest {
 						"maxSupply=" + maxSupply + ", " +
 						"totalSupply=" + totalSupply + ", " +
 						"decimals=" + decimals + ", " +
+						"currentSerialNum=" + currentSerialNum + ", " +
 						"autoRenewAccount=" + autoRenewAccount.toAbbrevString() + ", " +
 						"autoRenewPeriod=" + autoRenewPeriod + ", " +
 						"adminKey=" + describe(adminKey) + ", " +

--- a/hedera-node/src/test/java/com/hedera/services/state/merkle/MerkleUniqueTokenIdTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/state/merkle/MerkleUniqueTokenIdTest.java
@@ -14,7 +14,6 @@
 
 package com.hedera.services.state.merkle;
 
-import com.hedera.services.state.serdes.DomainSerdes;
 import com.hedera.services.state.submerkle.EntityId;
 import com.swirlds.common.io.SerializableDataInputStream;
 import com.swirlds.common.io.SerializableDataOutputStream;
@@ -25,9 +24,11 @@ import org.mockito.InOrder;
 
 import java.io.IOException;
 
-import static com.hedera.services.state.merkle.MerkleTopic.serdes;
 import static com.hedera.services.state.submerkle.EntityId.MISSING_ENTITY_ID;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
@@ -106,14 +107,14 @@ public class MerkleUniqueTokenIdTest {
 		// setup:
 		var out = mock(SerializableDataOutputStream.class);
 		// and:
-		InOrder inOrder = inOrder(serdes, out);
+		InOrder inOrder = inOrder(out);
 
 		// when:
 		subject.serialize(out);
 
 		// then:
 		inOrder.verify(out).writeSerializable(tokenId, true);
-		inOrder.verify(out).writeInt(serialNumber);
+		inOrder.verify(out).writeLong(serialNumber);
 	}
 
 	@Test

--- a/hedera-node/src/test/java/com/hedera/services/store/tokens/unique/OwnerIdentifierTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/store/tokens/unique/OwnerIdentifierTest.java
@@ -1,0 +1,50 @@
+package com.hedera.services.store.tokens.unique;
+
+/*
+ * ‌
+ * Hedera Services Node
+ * ​
+ * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+
+import com.hedera.services.state.submerkle.EntityId;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class OwnerIdentifierTest {
+
+
+	OwnerIdentifier oid1 = new OwnerIdentifier(new EntityId(1, 2, 3));
+	OwnerIdentifier oid2 = new OwnerIdentifier(new EntityId(1, 2, 3));
+
+	@Test
+	void testRawEquality() {
+		assertEquals(oid1, oid2);
+	}
+
+	@Test
+	void testEqualityWithEquals() {
+		assertTrue(oid1.equals(oid2));
+	}
+
+	@Test
+	void testEqualityWithHashCode() {
+		assertEquals(oid1.hashCode(), oid2.hashCode());
+	}
+}

--- a/hedera-node/src/test/java/com/hedera/services/store/tokens/unique/UniqueTokenStoreTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/store/tokens/unique/UniqueTokenStoreTest.java
@@ -1,0 +1,151 @@
+package com.hedera.services.store.tokens.unique;
+
+/*
+ * ‌
+ * Hedera Services Node
+ * ​
+ * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import com.hedera.services.context.properties.GlobalDynamicProperties;
+import com.hedera.services.ledger.HederaLedger;
+import com.hedera.services.ledger.TransactionalLedger;
+import com.hedera.services.ledger.ids.EntityIdSource;
+import com.hedera.services.ledger.properties.AccountProperty;
+import com.hedera.services.ledger.properties.TokenRelProperty;
+import com.hedera.services.state.merkle.MerkleAccount;
+import com.hedera.services.state.merkle.MerkleEntityId;
+import com.hedera.services.state.merkle.MerkleToken;
+import com.hedera.services.state.merkle.MerkleTokenRelStatus;
+import com.hedera.services.state.merkle.MerkleUniqueToken;
+import com.hedera.services.state.merkle.MerkleUniqueTokenId;
+import com.hedera.services.state.submerkle.EntityId;
+import com.hedera.services.state.submerkle.RichInstant;
+import com.hedera.services.utils.invertible_fchashmap.FCInvertibleHashMap;
+import com.hedera.test.mocks.TestContextValidator;
+import com.hedera.test.utils.IdUtils;
+import com.hederahashgraph.api.proto.java.AccountID;
+import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
+import com.hederahashgraph.api.proto.java.TokenID;
+import com.swirlds.fcmap.FCMap;
+import org.apache.commons.lang3.tuple.Pair;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+
+import static com.hedera.services.ledger.accounts.BackingTokenRels.asTokenRel;
+import static com.hedera.services.ledger.properties.AccountProperty.IS_DELETED;
+import static com.hedera.services.ledger.properties.TokenRelProperty.IS_FROZEN;
+import static com.hedera.services.ledger.properties.TokenRelProperty.IS_KYC_GRANTED;
+import static com.hedera.services.ledger.properties.TokenRelProperty.TOKEN_BALANCE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+class UniqueTokenStoreTest {
+
+	UniqueTokenStore store;
+
+	EntityIdSource ids;
+	GlobalDynamicProperties properties;
+
+	FCMap<MerkleEntityId, MerkleToken> tokens;
+	FCInvertibleHashMap<MerkleUniqueTokenId, MerkleUniqueToken, OwnerIdentifier> nfTokens;
+
+	HederaLedger hederaLedger;
+	TransactionalLedger<AccountID, AccountProperty, MerkleAccount> accountsLedger;
+	TransactionalLedger<Pair<AccountID, TokenID>, TokenRelProperty, MerkleTokenRelStatus> tokenRelsLedger;
+
+	MerkleUniqueTokenId nftId;
+	MerkleUniqueToken nft;
+	MerkleToken token;
+	EntityId eId;
+	TokenID tokenID = IdUtils.asToken("1.2.3");
+	AccountID treasury = IdUtils.asAccount("1.2.3");
+	AccountID sponsor = IdUtils.asAccount("1.2.666");
+	Pair<AccountID, TokenID> sponsorPair = asTokenRel(sponsor, tokenID);
+	long sponsorBalance = 1_000;
+
+
+	@BeforeEach
+	void setUp() {
+		eId = mock(EntityId.class);
+		nftId = mock(MerkleUniqueTokenId.class);
+		nft = mock(MerkleUniqueToken.class);
+		token = mock(MerkleToken.class);
+		given(token.isDeleted()).willReturn(false);
+		given(token.treasury()).willReturn(EntityId.fromGrpcAccountId(sponsor));
+		given(token.totalSupply()).willReturn(2000L);
+		given(token.hasSupplyKey()).willReturn(true);
+
+		properties = mock(GlobalDynamicProperties.class);
+
+		ids = mock(EntityIdSource.class);
+
+		hederaLedger = mock(HederaLedger.class);
+
+		tokens = (FCMap<MerkleEntityId, MerkleToken>) mock(FCMap.class);
+		given(tokens.containsKey(MerkleEntityId.fromTokenId(tokenID))).willReturn(true);
+		given(tokens.get(MerkleEntityId.fromTokenId(tokenID))).willReturn(token);
+		given(tokens.getForModify(any())).willReturn(token);
+
+		nfTokens = mock(FCInvertibleHashMap.class);
+
+
+		accountsLedger = (TransactionalLedger<AccountID, AccountProperty, MerkleAccount>) mock(TransactionalLedger.class);
+		given(accountsLedger.exists(sponsor)).willReturn(true);
+		given(accountsLedger.get(treasury, IS_DELETED)).willReturn(false);
+
+		tokenRelsLedger = mock(TransactionalLedger.class);
+		given(tokenRelsLedger.get(sponsorPair, TOKEN_BALANCE)).willReturn(sponsorBalance);
+		given(tokenRelsLedger.get(sponsorPair, IS_FROZEN)).willReturn(false);
+		given(tokenRelsLedger.get(sponsorPair, IS_KYC_GRANTED)).willReturn(true);
+
+		store = new UniqueTokenStore(ids, TestContextValidator.TEST_VALIDATOR, properties, () -> tokens, () -> nfTokens, tokenRelsLedger);
+		store.setHederaLedger(hederaLedger);
+		store.setAccountsLedger(accountsLedger);
+
+	}
+
+	@Test
+	void mint() {
+		var res = store.mint(tokenID, "memo", RichInstant.fromJava(Instant.now()));
+		assertEquals(ResponseCodeEnum.OK, res);
+		verify(token).incrementSerialNum();
+		verify(nfTokens).put(any(), any());
+	}
+
+
+	@Test
+	void mintFailsIfNoSupplyKey(){
+		given(token.hasSupplyKey()).willReturn(false);
+		var res = store.mint(tokenID, "memo", RichInstant.fromJava(Instant.now()));
+		assertEquals(ResponseCodeEnum.TOKEN_HAS_NO_SUPPLY_KEY, res);
+		verify(token, times(0)).incrementSerialNum();
+	}
+
+	@Test
+	void wipe() {
+		var res = store.wipe(treasury, tokenID, 1, true);
+		assertNull(res);
+	}
+
+}

--- a/hedera-node/src/test/java/com/hedera/services/txns/token/TokenMintTransitionLogicTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/txns/token/TokenMintTransitionLogicTest.java
@@ -20,9 +20,13 @@ package com.hedera.services.txns.token;
  * ‍
  */
 
+import com.google.protobuf.ByteString;
 import com.hedera.services.context.TransactionContext;
+import com.hedera.services.state.enums.TokenType;
 import com.hedera.services.state.merkle.MerkleToken;
+import com.hedera.services.state.submerkle.RichInstant;
 import com.hedera.services.store.tokens.TokenStore;
+import com.hedera.services.store.tokens.unique.UniqueTokenStore;
 import com.hedera.services.utils.PlatformTxnAccessor;
 import com.hedera.test.utils.IdUtils;
 import com.hederahashgraph.api.proto.java.TokenID;
@@ -30,6 +34,8 @@ import com.hederahashgraph.api.proto.java.TokenMintTransactionBody;
 import com.hederahashgraph.api.proto.java.TransactionBody;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
 
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.FAIL_INVALID;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_TOKEN_ID;
@@ -40,17 +46,20 @@ import static junit.framework.TestCase.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.mock;
 import static org.mockito.BDDMockito.verify;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 
 class TokenMintTransitionLogicTest {
 	long amount = 123L;
 	private TokenID id = IdUtils.asToken("1.2.3");
 
 	private TokenStore tokenStore;
+	private UniqueTokenStore uniqueStore;
 	private TransactionContext txnCtx;
 	private PlatformTxnAccessor accessor;
 	private MerkleToken token;
@@ -61,12 +70,13 @@ class TokenMintTransitionLogicTest {
 	@BeforeEach
 	private void setup() {
 		tokenStore = mock(TokenStore.class);
+		uniqueStore = mock(UniqueTokenStore.class);
 		accessor = mock(PlatformTxnAccessor.class);
 		token = mock(MerkleToken.class);
 
 		txnCtx = mock(TransactionContext.class);
 
-		subject = new TokenMintTransitionLogic(tokenStore, txnCtx);
+		subject = new TokenMintTransitionLogic(tokenStore, uniqueStore, txnCtx);
 	}
 
 	@Test
@@ -74,7 +84,7 @@ class TokenMintTransitionLogicTest {
 		givenValidTxnCtx();
 		// and:
 		given(tokenStore.mint(id, amount)).willReturn(INVALID_TOKEN_MINT_AMOUNT);
-
+		given(token.tokenType()).willReturn(TokenType.FUNGIBLE_COMMON);
 		// when:
 		subject.doStateTransition();
 
@@ -101,6 +111,7 @@ class TokenMintTransitionLogicTest {
 		givenValidTxnCtx();
 		// and:
 		given(tokenStore.mint(id, amount)).willReturn(OK);
+		given(token.tokenType()).willReturn(TokenType.FUNGIBLE_COMMON);
 
 		// when:
 		subject.doStateTransition();
@@ -164,6 +175,38 @@ class TokenMintTransitionLogicTest {
 
 		// expect:
 		assertEquals(INVALID_TOKEN_MINT_AMOUNT, subject.semanticCheck().apply(tokenMintTxn));
+	}
+
+	@Test
+	public void followsHappyPathForUnique(){
+		givenValidTxnCtx();
+		var  tokenMintBody = TokenMintTransactionBody.newBuilder()
+				.setToken(id)
+				.setMetadata(ByteString.copyFrom("memo".getBytes(StandardCharsets.UTF_8)))
+				.setAmount(amount).build();
+
+		tokenMintTxn = TransactionBody.newBuilder()
+				.setTokenMint(tokenMintBody)
+				.build();
+
+		given(accessor.getTxn()).willReturn(tokenMintTxn);
+		given(token.tokenType()).willReturn(TokenType.NON_FUNGIBLE_UNIQUE);
+		given(uniqueStore.mint(any(), anyString(), any())).willReturn(OK);
+
+		subject.doStateTransition();
+		verify(uniqueStore, times(1)).mint(id, "memo", RichInstant.fromJava(txnCtx.consensusTime()));
+		verify(txnCtx).setStatus(SUCCESS);
+	}
+
+	@Test
+	public void followsSadPathForUnique(){
+		givenValidTxnCtx();
+		given(token.tokenType()).willReturn(TokenType.NON_FUNGIBLE_UNIQUE);
+		given(tokenStore.resolve(any())).willReturn(TokenID.getDefaultInstance());
+
+		subject.doStateTransition();
+		verify(uniqueStore, times(0)).mint(any(), anyString(), any());
+		verify(txnCtx).setStatus(INVALID_TOKEN_ID);
 	}
 
 	private void givenValidTxnCtx() {


### PR DESCRIPTION
**Summary of the change**:

Added ```UniqueTokenStore```  for working with unique tokens.
Added ```CommonTokenStore``` which has functionallity specific for common tokens.
Refactored ```BaseTokenStore``` to an abstract class, holding common functionality for both types of tokens.
Provided basic ```mint``` operation for unique tokens.
Added ```OwnerIdentifier``` in order to work with the invertible map

Added alpha implementation of``` FCInvertibleHashMap```, used in the unique store.

**External impacts**:
None.


**Notes**:
This will be done in a future PR(s):
- Ledger transfer for unique tokens.
- State transition for N unique tokens.
- Precheck validation.
- Update Invertible map when ready.

**Applicable documentation**
- [ ] Javadoc
- [ ] HAPI protobuf comments
- [ ] README
