### PR TITLE
Fix Reconnect correctness tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1508,11 +1508,11 @@ workflows:
   GCP-Daily-Services-Crypto-Restart-4N-1C:
     triggers:
       - schedule:
-          cron: "7 20 * * *"
+          cron: "15 6 * * *"
           filters:
             branches:
               only:
-                - 1506-1513-M-fix-tests
+                - master-plus-sdk-0.15.0-alpha.1
     jobs:
       - build-platform-and-services
       - jrs-regression:
@@ -1767,11 +1767,11 @@ workflows:
   GCP-Daily-Services-Comp-Reconnect-Correctness-6N-1C:
     triggers:
       - schedule:
-          cron: "7 20 * * *"
+          cron: "25 7 * * *"
           filters:
             branches:
               only:
-                - 1506-1513-M-fix-tests
+                - master-plus-sdk-0.15.0-alpha.1
     jobs:
       - build-platform-and-services
       - jrs-regression:
@@ -2339,7 +2339,7 @@ jobs:
             cd /swirlds-platform;
             sed -i -e 's/github.com/services-jrs-regression/g' .gitmodules;
             git submodule update --init --recursive --checkout;
-            cd regression; git checkout 1506-D-fix-correctness-reconnect-tests;
+            cd regression;
             cd ..;
             mvn --no-transfer-progress clean install -DskipTests;
 
@@ -2755,7 +2755,7 @@ jobs:
         default: "hedera-regression-test"
       slack_summary_channel:
         type: string
-        default: "hedera-regression-test"
+        default: "hedera-regression-summary"
       workflow-name:
         type: string
         default: ""

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1508,7 +1508,7 @@ workflows:
   GCP-Daily-Services-Crypto-Restart-4N-1C:
     triggers:
       - schedule:
-          cron: "5 15 * * *"
+          cron: "7 20 * * *"
           filters:
             branches:
               only:
@@ -1767,11 +1767,11 @@ workflows:
   GCP-Daily-Services-Comp-Reconnect-Correctness-6N-1C:
     triggers:
       - schedule:
-          cron: "25 7 * * *"
+          cron: "7 20 * * *"
           filters:
             branches:
               only:
-                - master-plus-sdk-0.15.0-alpha.1
+                - 1506-1513-M-fix-tests
     jobs:
       - build-platform-and-services
       - jrs-regression:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1508,11 +1508,11 @@ workflows:
   GCP-Daily-Services-Crypto-Restart-4N-1C:
     triggers:
       - schedule:
-          cron: "15 6 * * *"
+          cron: "5 15 * * *"
           filters:
             branches:
               only:
-                - master-plus-sdk-0.15.0-alpha.1
+                - 1506-1513-M-fix-tests
     jobs:
       - build-platform-and-services
       - jrs-regression:
@@ -2339,7 +2339,7 @@ jobs:
             cd /swirlds-platform;
             sed -i -e 's/github.com/services-jrs-regression/g' .gitmodules;
             git submodule update --init --recursive --checkout;
-            cd regression;
+            cd regression; git checkout 1506-D-fix-correctness-reconnect-tests;
             cd ..;
             mvn --no-transfer-progress clean install -DskipTests;
 
@@ -2755,7 +2755,7 @@ jobs:
         default: "hedera-regression-test"
       slack_summary_channel:
         type: string
-        default: "hedera-regression-summary"
+        default: "hedera-regression-test"
       workflow-name:
         type: string
         default: ""

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/reconnect/AutoRenewEntitiesForReconnect.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/reconnect/AutoRenewEntitiesForReconnect.java
@@ -9,9 +9,9 @@ package com.hedera.services.bdd.suites.reconnect;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -60,20 +60,6 @@ public class AutoRenewEntitiesForReconnect extends HapiApiSuite {
 		);
 	}
 
-	public static HapiApiSpec runSomeTransactionsBeforeReconnect() {
-		return defaultHapiSpec("runInitialTransactionsBeforeReconnect")
-				.given().when().then(
-						// do some transfers to save a state before reconnect
-						withOpContext((spec, ctxLog) -> {
-							List<HapiSpecOperation> opsList = new ArrayList<HapiSpecOperation>();
-							for (int i = 0; i < 500; i++) {
-								opsList.add(cryptoTransfer(tinyBarsFromTo(GENESIS, NODE, 1L)).logged());
-							}
-							CustomSpecAssert.allRunFor(spec, opsList);
-						})
-				);
-	}
-
 	private HapiApiSpec autoRenewAccountGetsDeletedOnReconnectingNodeAsWell() {
 		String autoDeleteAccount = "autoDeleteAccount";
 		int autoRenewSecs = 1;
@@ -118,6 +104,26 @@ public class AutoRenewEntitiesForReconnect extends HapiApiSuite {
 	@Override
 	protected Logger getResultsLogger() {
 		return log;
+	}
+
+	/**
+	 * Since reconnect is not supported when node starts from genesis, run some transactions before running correctness
+	 * tests so that a state is saved before reconnect.
+	 *
+	 * @return
+	 */
+	public static HapiApiSpec runSomeTransactionsBeforeReconnect() {
+		return defaultHapiSpec("runInitialTransactionsBeforeReconnect")
+				.given().when().then(
+						// do some transfers to save a state before reconnect
+						withOpContext((spec, ctxLog) -> {
+							List<HapiSpecOperation> opsList = new ArrayList<HapiSpecOperation>();
+							for (int i = 0; i < 500; i++) {
+								opsList.add(cryptoTransfer(tinyBarsFromTo(GENESIS, NODE, 1L)).logged());
+							}
+							CustomSpecAssert.allRunFor(spec, opsList);
+						})
+				);
 	}
 }
 

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/reconnect/AutoRenewEntitiesForReconnect.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/reconnect/AutoRenewEntitiesForReconnect.java
@@ -54,7 +54,7 @@ public class AutoRenewEntitiesForReconnect extends HapiApiSuite {
 	@Override
 	protected List<HapiApiSpec> getSpecsInSuite() {
 		return List.of(
-				runSomeTransactionsBeforeReconnect(),
+				runTransfersBeforeReconnect(),
 				autoRenewAccountGetsDeletedOnReconnectingNodeAsWell(),
 				accountAutoRenewalSuiteCleanup()
 		);
@@ -112,8 +112,8 @@ public class AutoRenewEntitiesForReconnect extends HapiApiSuite {
 	 *
 	 * @return
 	 */
-	public static HapiApiSpec runSomeTransactionsBeforeReconnect() {
-		return defaultHapiSpec("runInitialTransactionsBeforeReconnect")
+	public static HapiApiSpec runTransfersBeforeReconnect() {
+		return defaultHapiSpec("runTransfersBeforeReconnect")
 				.given().when().then(
 						// do some transfers to save a state before reconnect
 						withOpContext((spec, ctxLog) -> {

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/reconnect/AutoRenewEntitiesForReconnect.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/reconnect/AutoRenewEntitiesForReconnect.java
@@ -119,7 +119,7 @@ public class AutoRenewEntitiesForReconnect extends HapiApiSuite {
 						withOpContext((spec, ctxLog) -> {
 							List<HapiSpecOperation> opsList = new ArrayList<HapiSpecOperation>();
 							for (int i = 0; i < 500; i++) {
-								opsList.add(cryptoTransfer(tinyBarsFromTo(GENESIS, NODE, 1L)).logged());
+								opsList.add(cryptoTransfer(tinyBarsFromTo(GENESIS, NODE, 1L)));
 							}
 							CustomSpecAssert.allRunFor(spec, opsList);
 						})

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/reconnect/AutoRenewEntitiesForReconnect.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/reconnect/AutoRenewEntitiesForReconnect.java
@@ -54,9 +54,24 @@ public class AutoRenewEntitiesForReconnect extends HapiApiSuite {
 	@Override
 	protected List<HapiApiSpec> getSpecsInSuite() {
 		return List.of(
+				runSomeTransactionsBeforeReconnect(),
 				autoRenewAccountGetsDeletedOnReconnectingNodeAsWell(),
 				accountAutoRenewalSuiteCleanup()
 		);
+	}
+
+	public static HapiApiSpec runSomeTransactionsBeforeReconnect() {
+		return defaultHapiSpec("runInitialTransactionsBeforeReconnect")
+				.given().when().then(
+						// do some transfers to save a state before reconnect
+						withOpContext((spec, ctxLog) -> {
+							List<HapiSpecOperation> opsList = new ArrayList<HapiSpecOperation>();
+							for (int i = 0; i < 500; i++) {
+								opsList.add(cryptoTransfer(tinyBarsFromTo(GENESIS, NODE, 1L)).logged());
+							}
+							CustomSpecAssert.allRunFor(spec, opsList);
+						})
+				);
 	}
 
 	private HapiApiSpec autoRenewAccountGetsDeletedOnReconnectingNodeAsWell() {

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/reconnect/SchedulesExpiryDuringReconnect.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/reconnect/SchedulesExpiryDuringReconnect.java
@@ -97,8 +97,7 @@ public class SchedulesExpiryDuringReconnect extends HapiApiSuite {
 								.adminKey(DEFAULT_PAYER)
 								.logging()
 								.advertisingCreation()
-								.savingExpectedScheduledTxnId(),
-						sleepFor(Duration.ofSeconds(5).toMillis())
+								.savingExpectedScheduledTxnId()
 				)
 				.when(
 						fileUpdate(APP_PROPERTIES).payingWith(GENESIS)

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/reconnect/SchedulesExpiryDuringReconnect.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/reconnect/SchedulesExpiryDuringReconnect.java
@@ -43,11 +43,13 @@ import static com.hedera.services.bdd.spec.transactions.crypto.HapiCryptoTransfe
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.overriding;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.sleepFor;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.withLiveNode;
+import static com.hedera.services.bdd.suites.perf.PerfUtilOps.scheduleOpsEnablement;
 import static com.hedera.services.bdd.suites.reconnect.ValidateTokensStateAfterReconnect.nonReconnectingNode;
 import static com.hedera.services.bdd.suites.reconnect.ValidateTokensStateAfterReconnect.reconnectingNode;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.IDENTICAL_SCHEDULE_ALREADY_CREATED;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_SCHEDULE_ID;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OK;
+
 /**
  * A reconnect test in which a few schedule transactions are created while the node 0.0.8 is disconnected from the network.
  * Once the node is reconnected the state of the schedules are verified on reconnected node
@@ -79,6 +81,7 @@ public class SchedulesExpiryDuringReconnect extends HapiApiSuite {
 						"txn.start.offset.secs", "-5")
 				)
 				.given(
+						scheduleOpsEnablement(),
 						sleepFor(Duration.ofSeconds(25).toMillis()),
 						scheduleCreate(soonToBeExpiredSchedule,
 								cryptoTransfer(tinyBarsFromTo(GENESIS, FUNDING, 1))
@@ -92,7 +95,8 @@ public class SchedulesExpiryDuringReconnect extends HapiApiSuite {
 								.adminKey(DEFAULT_PAYER)
 								.logging()
 								.advertisingCreation()
-								.savingExpectedScheduledTxnId()
+								.savingExpectedScheduledTxnId(),
+						sleepFor(Duration.ofSeconds(5).toMillis())
 				)
 				.when(
 						fileUpdate(APP_PROPERTIES).payingWith(GENESIS)

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/reconnect/SchedulesExpiryDuringReconnect.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/reconnect/SchedulesExpiryDuringReconnect.java
@@ -44,6 +44,7 @@ import static com.hedera.services.bdd.spec.utilops.UtilVerbs.overriding;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.sleepFor;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.withLiveNode;
 import static com.hedera.services.bdd.suites.perf.PerfUtilOps.scheduleOpsEnablement;
+import static com.hedera.services.bdd.suites.reconnect.AutoRenewEntitiesForReconnect.runSomeTransactionsBeforeReconnect;
 import static com.hedera.services.bdd.suites.reconnect.ValidateTokensStateAfterReconnect.nonReconnectingNode;
 import static com.hedera.services.bdd.suites.reconnect.ValidateTokensStateAfterReconnect.reconnectingNode;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.IDENTICAL_SCHEDULE_ALREADY_CREATED;
@@ -66,6 +67,7 @@ public class SchedulesExpiryDuringReconnect extends HapiApiSuite {
 	@Override
 	protected List<HapiApiSpec> getSpecsInSuite() {
 		return List.of(
+				runSomeTransactionsBeforeReconnect(),
 				suiteSetup(),
 				expireSchedulesDuringReconnect()
 		);

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/reconnect/SchedulesExpiryDuringReconnect.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/reconnect/SchedulesExpiryDuringReconnect.java
@@ -44,7 +44,7 @@ import static com.hedera.services.bdd.spec.utilops.UtilVerbs.overriding;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.sleepFor;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.withLiveNode;
 import static com.hedera.services.bdd.suites.perf.PerfUtilOps.scheduleOpsEnablement;
-import static com.hedera.services.bdd.suites.reconnect.AutoRenewEntitiesForReconnect.runSomeTransactionsBeforeReconnect;
+import static com.hedera.services.bdd.suites.reconnect.AutoRenewEntitiesForReconnect.runTransfersBeforeReconnect;
 import static com.hedera.services.bdd.suites.reconnect.ValidateTokensStateAfterReconnect.nonReconnectingNode;
 import static com.hedera.services.bdd.suites.reconnect.ValidateTokensStateAfterReconnect.reconnectingNode;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.IDENTICAL_SCHEDULE_ALREADY_CREATED;
@@ -67,7 +67,7 @@ public class SchedulesExpiryDuringReconnect extends HapiApiSuite {
 	@Override
 	protected List<HapiApiSpec> getSpecsInSuite() {
 		return List.of(
-				runSomeTransactionsBeforeReconnect(),
+				runTransfersBeforeReconnect(),
 				suiteSetup(),
 				expireSchedulesDuringReconnect()
 		);

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/reconnect/UpdateAllProtectedFilesDuringReconnect.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/reconnect/UpdateAllProtectedFilesDuringReconnect.java
@@ -47,6 +47,7 @@ import static com.hedera.services.bdd.spec.utilops.UtilVerbs.restoreFileFromRegi
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.saveFileToRegistry;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.sleepFor;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.withLiveNode;
+import static com.hedera.services.bdd.suites.reconnect.AutoRenewEntitiesForReconnect.runSomeTransactionsBeforeReconnect;
 import static com.hederahashgraph.api.proto.java.HederaFunctionality.CryptoGetInfo;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.AUTORENEW_DURATION_NOT_IN_RANGE;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INSUFFICIENT_TX_FEE;
@@ -69,6 +70,7 @@ public class UpdateAllProtectedFilesDuringReconnect extends HapiApiSuite {
 	@Override
 	protected List<HapiApiSpec> getSpecsInSuite() {
 		return List.of(
+				runSomeTransactionsBeforeReconnect(),
 				updateAllProtectedFilesDuringReconnect()
 		);
 	}

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/reconnect/UpdateAllProtectedFilesDuringReconnect.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/reconnect/UpdateAllProtectedFilesDuringReconnect.java
@@ -47,7 +47,7 @@ import static com.hedera.services.bdd.spec.utilops.UtilVerbs.restoreFileFromRegi
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.saveFileToRegistry;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.sleepFor;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.withLiveNode;
-import static com.hedera.services.bdd.suites.reconnect.AutoRenewEntitiesForReconnect.runSomeTransactionsBeforeReconnect;
+import static com.hedera.services.bdd.suites.reconnect.AutoRenewEntitiesForReconnect.runTransfersBeforeReconnect;
 import static com.hederahashgraph.api.proto.java.HederaFunctionality.CryptoGetInfo;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.AUTORENEW_DURATION_NOT_IN_RANGE;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INSUFFICIENT_TX_FEE;
@@ -70,7 +70,7 @@ public class UpdateAllProtectedFilesDuringReconnect extends HapiApiSuite {
 	@Override
 	protected List<HapiApiSpec> getSpecsInSuite() {
 		return List.of(
-				runSomeTransactionsBeforeReconnect(),
+				runTransfersBeforeReconnect(),
 				updateAllProtectedFilesDuringReconnect()
 		);
 	}

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/reconnect/ValidateCongestionPricingAfterReconnect.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/reconnect/ValidateCongestionPricingAfterReconnect.java
@@ -50,7 +50,7 @@ import static com.hedera.services.bdd.spec.utilops.UtilVerbs.blockingOrder;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.sleepFor;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.withLiveNode;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.withOpContext;
-import static com.hedera.services.bdd.suites.reconnect.AutoRenewEntitiesForReconnect.runSomeTransactionsBeforeReconnect;
+import static com.hedera.services.bdd.suites.reconnect.AutoRenewEntitiesForReconnect.runTransfersBeforeReconnect;
 import static com.hedera.services.bdd.suites.reconnect.ValidateTokensStateAfterReconnect.reconnectingNode;
 import static com.hedera.services.bdd.suites.utils.sysfiles.serdes.ThrottleDefsLoader.protoDefsFromResource;
 
@@ -74,7 +74,7 @@ public class ValidateCongestionPricingAfterReconnect extends HapiApiSuite {
 	protected List<HapiApiSpec> getSpecsInSuite() {
 		return List.of(
 				new HapiApiSpec[] {
-						runSomeTransactionsBeforeReconnect(),
+						runTransfersBeforeReconnect(),
 						validateCongestionPricing(),
 				}
 		);

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/reconnect/ValidateCongestionPricingAfterReconnect.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/reconnect/ValidateCongestionPricingAfterReconnect.java
@@ -50,6 +50,7 @@ import static com.hedera.services.bdd.spec.utilops.UtilVerbs.blockingOrder;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.sleepFor;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.withLiveNode;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.withOpContext;
+import static com.hedera.services.bdd.suites.reconnect.AutoRenewEntitiesForReconnect.runSomeTransactionsBeforeReconnect;
 import static com.hedera.services.bdd.suites.reconnect.ValidateTokensStateAfterReconnect.reconnectingNode;
 import static com.hedera.services.bdd.suites.utils.sysfiles.serdes.ThrottleDefsLoader.protoDefsFromResource;
 
@@ -73,6 +74,7 @@ public class ValidateCongestionPricingAfterReconnect extends HapiApiSuite {
 	protected List<HapiApiSpec> getSpecsInSuite() {
 		return List.of(
 				new HapiApiSpec[] {
+						runSomeTransactionsBeforeReconnect(),
 						validateCongestionPricing(),
 				}
 		);

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/reconnect/ValidateDuplicateTransactionAfterReconnect.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/reconnect/ValidateDuplicateTransactionAfterReconnect.java
@@ -37,6 +37,7 @@ import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoCreate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.fileUpdate;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.sleepFor;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.withLiveNode;
+import static com.hedera.services.bdd.suites.reconnect.AutoRenewEntitiesForReconnect.runSomeTransactionsBeforeReconnect;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.DUPLICATE_TRANSACTION;
 
 public class ValidateDuplicateTransactionAfterReconnect extends HapiApiSuite {
@@ -49,6 +50,7 @@ public class ValidateDuplicateTransactionAfterReconnect extends HapiApiSuite {
 	@Override
 	protected List<HapiApiSpec> getSpecsInSuite() {
 		return List.of(
+				runSomeTransactionsBeforeReconnect(),
 				validateDuplicateTransactionAfterReconnect()
 		);
 	}

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/reconnect/ValidateDuplicateTransactionAfterReconnect.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/reconnect/ValidateDuplicateTransactionAfterReconnect.java
@@ -37,7 +37,7 @@ import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoCreate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.fileUpdate;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.sleepFor;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.withLiveNode;
-import static com.hedera.services.bdd.suites.reconnect.AutoRenewEntitiesForReconnect.runSomeTransactionsBeforeReconnect;
+import static com.hedera.services.bdd.suites.reconnect.AutoRenewEntitiesForReconnect.runTransfersBeforeReconnect;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.DUPLICATE_TRANSACTION;
 
 public class ValidateDuplicateTransactionAfterReconnect extends HapiApiSuite {
@@ -50,7 +50,7 @@ public class ValidateDuplicateTransactionAfterReconnect extends HapiApiSuite {
 	@Override
 	protected List<HapiApiSpec> getSpecsInSuite() {
 		return List.of(
-				runSomeTransactionsBeforeReconnect(),
+				runTransfersBeforeReconnect(),
 				validateDuplicateTransactionAfterReconnect()
 		);
 	}

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/reconnect/ValidateTokensStateAfterReconnect.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/reconnect/ValidateTokensStateAfterReconnect.java
@@ -51,7 +51,7 @@ import static com.hedera.services.bdd.spec.utilops.UtilVerbs.newKeyNamed;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.sleepFor;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.withLiveNode;
 import static com.hedera.services.bdd.suites.perf.PerfUtilOps.tokenOpsEnablement;
-import static com.hedera.services.bdd.suites.reconnect.AutoRenewEntitiesForReconnect.runSomeTransactionsBeforeReconnect;
+import static com.hedera.services.bdd.suites.reconnect.AutoRenewEntitiesForReconnect.runTransfersBeforeReconnect;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.ACCOUNT_IS_TREASURY;
 
 /**
@@ -71,7 +71,7 @@ public class ValidateTokensStateAfterReconnect extends HapiApiSuite {
 	@Override
 	protected List<HapiApiSpec> getSpecsInSuite() {
 		return List.of(
-				runSomeTransactionsBeforeReconnect(),
+				runTransfersBeforeReconnect(),
 				validateTokensAfterReconnect()
 		);
 	}

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/reconnect/ValidateTokensStateAfterReconnect.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/reconnect/ValidateTokensStateAfterReconnect.java
@@ -51,6 +51,7 @@ import static com.hedera.services.bdd.spec.utilops.UtilVerbs.newKeyNamed;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.sleepFor;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.withLiveNode;
 import static com.hedera.services.bdd.suites.perf.PerfUtilOps.tokenOpsEnablement;
+import static com.hedera.services.bdd.suites.reconnect.AutoRenewEntitiesForReconnect.runSomeTransactionsBeforeReconnect;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.ACCOUNT_IS_TREASURY;
 
 /**
@@ -70,6 +71,7 @@ public class ValidateTokensStateAfterReconnect extends HapiApiSuite {
 	@Override
 	protected List<HapiApiSpec> getSpecsInSuite() {
 		return List.of(
+				runSomeTransactionsBeforeReconnect(),
 				validateTokensAfterReconnect()
 		);
 	}


### PR DESCRIPTION
**Related issue(s)**:
Closes #1506 
Related regression PR : https://github.com/swirlds/swirlds-platform-regression/pull/1152

**Summary of the change**:
Reconnect correctness tests failed as the nodes are killed before saving state, and reconnect is not supported when node starts from genesis. To solve this issue added some transactions before attempting the correctness tests. 

Other validator failures will be resolved with `0.15.0-alpha.2` sdk

Passed tests:
1. `AllProtectedFilesUpdate-NDReconnect-1-12m` : https://hedera-hashgraph.slack.com/archives/C018CBQBTGB/p1622750250246300
2. `TransactionHistory-NDReconnect-1-12m` :https://hedera-hashgraph.slack.com/archives/C018CBQBTGB/p1622779608259700
3. `ScheduleExpiry-NDReconnect-1-12m` : https://hedera-hashgraph.slack.com/archives/C018CBQBTGB/p1622752734248400
4. `CongestionPricing-NDReconnect-1-12m` : https://hedera-hashgraph.slack.com/archives/C018CBQBTGB/p1622753904250300
5. `TokenValidate-NDReconnect-1-12m` : https://hedera-hashgraph.slack.com/archives/C018CBQBTGB/p1622755077251100
6. `AllProtectedFilesUpdate-NIReconnect-1-12m` : https://hedera-hashgraph.slack.com/archives/C018CBQBTGB/p1622756268251500
7. `TransactionHistory-NIReconnect-1-12m` : https://hedera-hashgraph.slack.com/archives/C018CBQBTGB/p1622774042257900
8. `ScheduleExpiry-NIReconnect-1-12m` : https://hedera-hashgraph.slack.com/archives/C018CBQBTGB/p1622758636253000
9. `CongestionPricing-NIReconnect-1-12m` : https://hedera-hashgraph.slack.com/archives/C018CBQBTGB/p1622759880253400
10. `TokenValidate-NIReconnect-1-12m` : https://hedera-hashgraph.slack.com/archives/C018CBQBTGB/p1622761104254300
