### PR TITLE
Fix AccountProperty.TOKENS getter/setter impls for new G4M paradigm

### DIFF
--- a/hedera-node/src/main/java/com/hedera/services/ledger/properties/AccountProperty.java
+++ b/hedera-node/src/main/java/com/hedera/services/ledger/properties/AccountProperty.java
@@ -157,7 +157,7 @@ public enum AccountProperty implements BeanProperty<MerkleAccount> {
 
 		@Override
 		public Function<MerkleAccount, Object> getter() {
-			return a -> a.tokens().copy();
+			return a -> a.tokens().tmpNonMerkleCopy();
 		}
 	};
 

--- a/hedera-node/src/main/java/com/hedera/services/ledger/properties/AccountProperty.java
+++ b/hedera-node/src/main/java/com/hedera/services/ledger/properties/AccountProperty.java
@@ -25,8 +25,6 @@ import com.hedera.services.legacy.core.jproto.JKey;
 import com.hedera.services.state.merkle.MerkleAccount;
 import com.hedera.services.state.merkle.MerkleAccountTokens;
 import com.hedera.services.state.submerkle.EntityId;
-import com.hedera.services.state.submerkle.ExpirableTxnRecord;
-import com.swirlds.fcqueue.FCQueue;
 
 import java.util.function.BiConsumer;
 import java.util.function.Function;
@@ -154,12 +152,12 @@ public enum AccountProperty implements BeanProperty<MerkleAccount> {
 	TOKENS {
 		@Override
 		public BiConsumer<MerkleAccount, Object> setter() {
-			return (a, t) -> a.setTokens((MerkleAccountTokens) t);
+			return (a, t) -> a.tokens().shareTokensOf((MerkleAccountTokens) t);
 		}
 
 		@Override
 		public Function<MerkleAccount, Object> getter() {
-			return MerkleAccount::tokens;
+			return a -> a.tokens().copy();
 		}
 	};
 

--- a/hedera-node/src/main/java/com/hedera/services/state/merkle/MerkleAccountTokens.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/merkle/MerkleAccountTokens.java
@@ -93,6 +93,10 @@ public class MerkleAccountTokens extends AbstractMerkleLeaf {
 		return new MerkleAccountTokens(tokenIds);
 	}
 
+	public MerkleAccountTokens tmpNonMerkleCopy() {
+		return new MerkleAccountTokens(tokenIds);
+	}
+
 	@Override
 	public boolean equals(Object o) {
 		if (this == o) {

--- a/hedera-node/src/test/java/com/hedera/services/ledger/properties/MerkleAccountPropertyTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/ledger/properties/MerkleAccountPropertyTest.java
@@ -29,7 +29,6 @@ import com.hedera.services.state.merkle.MerkleToken;
 import com.hedera.services.state.submerkle.EntityId;
 import com.hedera.services.state.submerkle.ExpirableTxnRecord;
 import com.hedera.test.factories.txns.SignedTxnFactory;
-import com.hedera.test.utils.IdUtils;
 import com.hederahashgraph.api.proto.java.AccountID;
 import com.hederahashgraph.api.proto.java.Key;
 import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
@@ -42,7 +41,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Set;
 
 import static com.hedera.services.ledger.properties.AccountProperty.AUTO_RENEW_PERIOD;
 import static com.hedera.services.ledger.properties.AccountProperty.BALANCE;
@@ -122,9 +120,6 @@ class MerkleAccountPropertyTest {
 		long origBalance = 1L;
 		long origAutoRenew = 1L;
 		long origExpiry = 1L;
-		MerkleAccountTokens origTokens = new MerkleAccountTokens();
-		origTokens.associateAll(Set.of(IdUtils.asToken("1.2.3")));
-		origTokens.associateAll(Set.of(IdUtils.asToken("3.2.1")));
 		Key origKey = SignedTxnFactory.DEFAULT_PAYER_KT.asKey();
 		String origMemo = "a";
 		AccountID origProxy = AccountID.getDefaultInstance();
@@ -141,9 +136,6 @@ class MerkleAccountPropertyTest {
 		long newBalance = 2L;
 		long newAutoRenew = 2L;
 		long newExpiry = 2L;
-		MerkleAccountTokens newTokens = origTokens.copy();
-		newTokens.dissociateAll(Set.of(IdUtils.asToken("1.2.3")));
-		newTokens.associateAll(Set.of(IdUtils.asToken("8.9.10")));
 		JKey newKey = new JKeyList();
 		String newMemo = "b";
 		EntityId newProxy = new EntityId(0, 0, 2);
@@ -158,7 +150,6 @@ class MerkleAccountPropertyTest {
 				.isSmartContract(origIsContract)
 				.isReceiverSigRequired(origIsReceiverSigReq)
 				.customizing(new MerkleAccount());
-		account.setTokens(origTokens);
 		account.setBalance(origBalance);
 		account.records().offer(origPayerRecords.get(0));
 		account.records().offer(origPayerRecords.get(1));
@@ -178,8 +169,6 @@ class MerkleAccountPropertyTest {
 		frozenToken.setKycKey(adminKey);
 
 		// expect:
-		assertEquals(origTokens, TOKENS.getter().apply(account));
-		// and when:
 		IS_DELETED.setter().accept(account, newIsDeleted);
 		IS_RECEIVER_SIG_REQUIRED.setter().accept(account, newIsReceiverSigReq);
 		IS_SMART_CONTRACT.setter().accept(account, newIsContract);
@@ -189,8 +178,6 @@ class MerkleAccountPropertyTest {
 		KEY.setter().accept(account, newKey);
 		MEMO.setter().accept(account, newMemo);
 		PROXY.setter().accept(account, newProxy);
-		// and:
-		TOKENS.setter().accept(account, newTokens);
 
 		// then:
 		assertEquals(newIsDeleted, IS_DELETED.getter().apply(account));
@@ -202,8 +189,6 @@ class MerkleAccountPropertyTest {
 		assertEquals(newKey, KEY.getter().apply(account));
 		assertEquals(newMemo, MEMO.getter().apply(account));
 		assertEquals(newProxy, PROXY.getter().apply(account));
-		// and:
-		assertEquals(newTokens, TOKENS.getter().apply(account));
 	}
 
 	private ExpirableTxnRecord expirableRecord(ResponseCodeEnum status) {

--- a/hedera-node/src/test/java/com/hedera/services/ledger/properties/MerkleAccountPropertyTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/ledger/properties/MerkleAccountPropertyTest.java
@@ -36,6 +36,9 @@ import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
 import com.hederahashgraph.api.proto.java.TransactionReceipt;
 import com.hederahashgraph.api.proto.java.TransactionRecord;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -53,11 +56,49 @@ import static com.hedera.services.ledger.properties.AccountProperty.PROXY;
 import static com.hedera.services.ledger.properties.AccountProperty.TOKENS;
 import static com.hedera.test.factories.scenarios.TxnHandlingScenario.TOKEN_ADMIN_KT;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
 
-public class MerkleAccountPropertyTest {
+@ExtendWith(MockitoExtension.class)
+class MerkleAccountPropertyTest {
+	@Mock
+	private MerkleAccount mockAccount;
+	@Mock
+	private MerkleAccountTokens mockAccountTokens;
+
 	@Test
-	public void cannotSetNegativeBalance() {
+	void tokenGetterWorksWithNewFcmParadigm() {
+		// setup:
+		final var copyResult = new MerkleAccountTokens(new long[] { 1, 2, 3 });
+
+		given(mockAccountTokens.copy()).willReturn(copyResult);
+		given(mockAccount.tokens()).willReturn(mockAccountTokens);
+
+		// when:
+		final var result = TOKENS.getter().apply(mockAccount);
+
+		// then:
+		assertSame(copyResult, result);
+	}
+
+	@Test
+	void tokenSetterWorksWithNewFcmParadigm() {
+		// setup:
+		final var newTokens = new MerkleAccountTokens(new long[] { 1, 2, 3, 4, 5, 6 });
+
+		given(mockAccount.tokens()).willReturn(mockAccountTokens);
+
+		// when:
+		TOKENS.setter().accept(mockAccount, newTokens);
+
+		// then:
+		verify(mockAccountTokens).shareTokensOf(newTokens);
+	}
+
+	@Test
+	void cannotSetNegativeBalance() {
 		// expect:
 		assertThrows(
 				IllegalArgumentException.class,
@@ -65,7 +106,7 @@ public class MerkleAccountPropertyTest {
 	}
 
 	@Test
-	public void cannotConvertNonNumericObjectToBalance() {
+	void cannotConvertNonNumericObjectToBalance() {
 		// expect:
 		assertThrows(
 				IllegalArgumentException.class,
@@ -73,7 +114,7 @@ public class MerkleAccountPropertyTest {
 	}
 
 	@Test
-	public void gettersAndSettersWork() throws Exception {
+	void gettersAndSettersWork() throws Exception {
 		// given:
 		boolean origIsDeleted = false;
 		boolean origIsReceiverSigReq = false;

--- a/hedera-node/src/test/java/com/hedera/services/ledger/properties/MerkleAccountPropertyTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/ledger/properties/MerkleAccountPropertyTest.java
@@ -71,7 +71,7 @@ class MerkleAccountPropertyTest {
 		// setup:
 		final var copyResult = new MerkleAccountTokens(new long[] { 1, 2, 3 });
 
-		given(mockAccountTokens.copy()).willReturn(copyResult);
+		given(mockAccountTokens.tmpNonMerkleCopy()).willReturn(copyResult);
 		given(mockAccount.tokens()).willReturn(mockAccountTokens);
 
 		// when:

--- a/hedera-node/src/test/java/com/hedera/services/state/merkle/MerkleAccountTokensTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/state/merkle/MerkleAccountTokensTest.java
@@ -78,6 +78,21 @@ class MerkleAccountTokensTest {
 	}
 
 	@Test
+	void nonMerkleCopiedSubjectNotImmutable() {
+		// given:
+		final var someSet = Set.of(asToken("1.2.3"));
+
+		// when:
+		final var subjectCopy = subject.tmpNonMerkleCopy();
+
+		// then:
+		assertFalse(subject.isImmutable());
+		Assertions.assertDoesNotThrow(() -> subject.associateAll(someSet));
+		Assertions.assertDoesNotThrow(() -> subject.dissociateAll(someSet));
+		Assertions.assertDoesNotThrow(() -> subject.shareTokensOf(subjectCopy));
+	}
+
+	@Test
 	void shareTokensUsesStructuralSharing() {
 		// given:
 		final var other = new MerkleAccountTokens();

--- a/hedera-node/src/test/java/com/hedera/services/state/merkle/MerkleAccountTokensTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/state/merkle/MerkleAccountTokensTest.java
@@ -20,8 +20,8 @@ package com.hedera.services.state.merkle;
  * ‍
  */
 
-import com.hedera.test.utils.IdUtils;
 import com.hederahashgraph.api.proto.java.TokenID;
+import com.swirlds.common.MutabilityException;
 import com.swirlds.common.io.SerializableDataInputStream;
 import com.swirlds.common.io.SerializableDataOutputStream;
 import org.junit.jupiter.api.Assertions;
@@ -35,6 +35,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
+import static com.hedera.test.utils.IdUtils.asToken;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -47,20 +48,45 @@ import static org.mockito.BDDMockito.inOrder;
 import static org.mockito.BDDMockito.mock;
 
 class MerkleAccountTokensTest {
-	TokenID a = IdUtils.asToken("0.0.2");
-	TokenID b = IdUtils.asToken("0.1.2");
-	TokenID c = IdUtils.asToken("1.1.2");
-	TokenID d = IdUtils.asToken("0.0.3");
-	TokenID e = IdUtils.asToken("0.0.1");
-	long[] initialIds = new long[] {
-		2, 0, 0, 2, 1, 0, 2, 1, 1
-	};
+	private TokenID a = asToken("0.0.2");
+	private TokenID b = asToken("0.1.2");
+	private TokenID c = asToken("1.1.2");
+	private TokenID d = asToken("0.0.3");
+	private TokenID e = asToken("0.0.1");
+	private long[] initialIds = new long[] { 2, 0, 0, 2, 1, 0, 2, 1, 1 };
 
-	MerkleAccountTokens subject;
+	private MerkleAccountTokens subject;
 
 	@BeforeEach
 	private void setup() {
 		subject = new MerkleAccountTokens(initialIds);
+	}
+
+	@Test
+	void copiedSubjectBecomesImmutable() {
+		// given:
+		final var someSet = Set.of(asToken("1.2.3"));
+
+		// when:
+		final var subjectCopy = subject.copy();
+
+		// then:
+		assertTrue(subject.isImmutable());
+		Assertions.assertThrows(MutabilityException.class, () -> subject.associateAll(someSet));
+		Assertions.assertThrows(MutabilityException.class, () -> subject.dissociateAll(someSet));
+		Assertions.assertThrows(MutabilityException.class, () -> subject.shareTokensOf(subjectCopy));
+	}
+
+	@Test
+	void shareTokensUsesStructuralSharing() {
+		// given:
+		final var other = new MerkleAccountTokens();
+
+		// when:
+		other.shareTokensOf(subject);
+
+		// then:
+		assertSame(subject.getTokenIds(), other.getTokenIds());
 	}
 
 	@Test
@@ -72,7 +98,7 @@ class MerkleAccountTokensTest {
 	}
 
 	@Test
-	public void asIdsWorks() {
+	void asIdsWorks() {
 		// expect:
 		assertEquals(
 				List.of(a, b, c),
@@ -84,7 +110,7 @@ class MerkleAccountTokensTest {
 	}
 
 	@Test
-	public void dissociateAllWorks() {
+	void dissociateAllWorks() {
 		// when:
 		subject.dissociateAll(Set.of(a, e));
 
@@ -95,7 +121,7 @@ class MerkleAccountTokensTest {
 	}
 
 	@Test
-	public void associateAllWorks() {
+	void associateAllWorks() {
 		// when:
 		subject.associateAll(Set.of(d, e));
 
@@ -106,7 +132,7 @@ class MerkleAccountTokensTest {
 	}
 
 	@Test
-	public void objectContractMet() {
+	void objectContractMet() {
 		// given:
 		var one = new MerkleAccountTokens();
 		var two = new MerkleAccountTokens();
@@ -122,7 +148,7 @@ class MerkleAccountTokensTest {
 	}
 
 	@Test
-	public void merkleMethodsWork() {
+	void merkleMethodsWork() {
 		// expect;
 		assertEquals(MerkleAccountTokens.MERKLE_VERSION, subject.getVersion());
 		assertEquals(MerkleAccountTokens.RUNTIME_CONSTRUCTABLE_ID, subject.getClassId());
@@ -130,7 +156,7 @@ class MerkleAccountTokensTest {
 	}
 
 	@Test
-	public void serializeWorks() throws IOException {
+	void serializeWorks() throws IOException {
 		// setup:
 		var out = mock(SerializableDataOutputStream.class);
 		// and:
@@ -144,7 +170,7 @@ class MerkleAccountTokensTest {
 	}
 
 	@Test
-	public void deserializeWorks() throws IOException {
+	void deserializeWorks() throws IOException {
 		// setup:
 		var in = mock(SerializableDataInputStream.class);
 		// and:
@@ -160,7 +186,7 @@ class MerkleAccountTokensTest {
 	}
 
 	@Test
-	public void toStringWorks() {
+	void toStringWorks() {
 		// expect:
 		assertEquals(
 				"MerkleAccountTokens{tokens=[0.0.2, 0.1.2, 1.1.2]}",
@@ -168,7 +194,7 @@ class MerkleAccountTokensTest {
 	}
 
 	@Test
-	public void copyWorks() {
+	void copyWorks() {
 		// when:
 		var subjectCopy = subject.copy();
 


### PR DESCRIPTION
**Related issue(s)**:
- Closes #1542

▶️  &nbsp; [Passing `TokenValidate-NIReconnect-1-16m`](https://hedera-hashgraph.slack.com/archives/C018CBQBTGB/p1623078907385800)
▶️  &nbsp; [Passing `TokenValidate-NDReconnect-1-16m`](https://hedera-hashgraph.slack.com/archives/C018CBQBTGB/p1623080057386200)

**Summary of the change**:
- Temporary fix of `AccountProperty.TOKENS` getter/setter to match the new `FCMap.getForModify()` paradigm used by `BackingAccounts`, in which the `getForModify()` call to each mutated account is delayed until `TransactionalLedger.commit()` is called.
- The `MerkleAccountTokens.tmpNonMerkleCopy()` will no longer be necessary when then `TokenAssociate`/`TokenDissociate` refactor are complete and ported from `master`.