### PR TITLE
Refactoring converter utils to reuse checks

### DIFF
--- a/hedera-node/src/test/java/com/hedera/test/utils/AccountIDConverter.java
+++ b/hedera-node/src/test/java/com/hedera/test/utils/AccountIDConverter.java
@@ -30,7 +30,7 @@ public class AccountIDConverter implements ArgumentConverter {
         if (null == input) {
             return null;
         }
-        ConverterUtils.checkIfInputString(input);
-        return IdUtils.asAccount((String) input);
+        final String inputString = ConverterUtils.toStringInstance(input);
+        return IdUtils.asAccount(inputString);
     }
 }

--- a/hedera-node/src/test/java/com/hedera/test/utils/ByteArrayConverter.java
+++ b/hedera-node/src/test/java/com/hedera/test/utils/ByteArrayConverter.java
@@ -35,10 +35,7 @@ public final class ByteArrayConverter implements ArgumentConverter {
 		if (null == input) {
 			return null;
 		}
-		if (!(input instanceof String)) {
-			throw new ArgumentConversionException(input + " is not a string");
-		}
-		var inputString = (String) input;
-		return CommonUtils.unhex(inputString);
+		ConverterUtils.checkIfInputString(input);
+		return CommonUtils.unhex((String) input);
 	}
 }

--- a/hedera-node/src/test/java/com/hedera/test/utils/ByteArrayConverter.java
+++ b/hedera-node/src/test/java/com/hedera/test/utils/ByteArrayConverter.java
@@ -35,7 +35,7 @@ public final class ByteArrayConverter implements ArgumentConverter {
 		if (null == input) {
 			return null;
 		}
-		ConverterUtils.checkIfInputString(input);
-		return CommonUtils.unhex((String) input);
+		final String inputString = ConverterUtils.toStringInstance(input);
+		return CommonUtils.unhex(inputString);
 	}
 }

--- a/hedera-node/src/test/java/com/hedera/test/utils/ConverterUtils.java
+++ b/hedera-node/src/test/java/com/hedera/test/utils/ConverterUtils.java
@@ -23,21 +23,23 @@ package com.hedera.test.utils;
 import org.junit.jupiter.params.converter.ArgumentConversionException;
 
 /**
- * Contians various common checks and methods used by the Converter classes
+ * Contains various common checks and methods used by the Converter classes
  * @author abhishekpandey
  * */
 public final class ConverterUtils {
     /**
-     * Checks if the input to the converter is of type {@link String} else throws an {@link ArgumentConversionException}
+     * Returns the input as a {@link String} if it is string type else throws an {@link ArgumentConversionException}
      * @param input
      *              the input to the converter
-     * @throws ArgumentConversionException
+     * @throws ArgumentConversionException  thrown when the input is not of type {@link String}
+     * @return input casted as a string
      * */
-    public static void checkIfInputString(Object input)
+    public static String toStringInstance(final Object input)
             throws ArgumentConversionException {
         if (!(input instanceof String)) {
             throw new ArgumentConversionException(input + " is not a string");
         }
+        return (String) input;
     }
 
     /**
@@ -45,17 +47,23 @@ public final class ConverterUtils {
      * {@link ArgumentConversionException}
      * @param inputString
      *              the input to the converter
-     * @param limit
-     *              the limit to be applied for the split operation
+     * @param numberOfParts
+     *              the limit to be applied for the split operation, non positive number means it will be applied as many
+     *              times as possible
+     * @param delimiter
+     *              the regex to be applied for the split operation
      * @param type
      *             the string defining the type of input
-     * @throws ArgumentConversionException
+     * @throws ArgumentConversionException thrown when the numberOfParts don't match after the split operation
      * */
-    public static String[] getPartsIfValid(String inputString, int limit, String type)
-            throws ArgumentConversionException {
-        var parts = inputString.split("\\.", limit);
-        if (limit != parts.length) {
-            throw new ArgumentConversionException(inputString + " is not a " + limit + "-part " + type +" ID");
+    public static String[] getPartsIfValid(
+            final String inputString,
+            final int numberOfParts,
+            final String delimiter,
+            final String type) throws ArgumentConversionException {
+        final var parts = inputString.split(delimiter, numberOfParts);
+        if (numberOfParts != parts.length && numberOfParts > 0) {
+            throw new ArgumentConversionException(inputString + " is not a " + numberOfParts + "-part " + type +" ID");
         }
         return parts;
     }

--- a/hedera-node/src/test/java/com/hedera/test/utils/ConverterUtils.java
+++ b/hedera-node/src/test/java/com/hedera/test/utils/ConverterUtils.java
@@ -47,9 +47,9 @@ public final class ConverterUtils {
      * {@link ArgumentConversionException}
      * @param inputString
      *              the input to the converter
-     * @param numberOfParts
-     *              the limit to be applied for the split operation, non positive number means it will be applied as many
-     *              times as possible
+     * @param exactNumberOfParts
+     *              exact number of parts from the string to expect, non positive number means it will be applied as
+     *              many times as possible
      * @param delimiter
      *              the regex to be applied for the split operation
      * @param type
@@ -58,12 +58,12 @@ public final class ConverterUtils {
      * */
     public static String[] getPartsIfValid(
             final String inputString,
-            final int numberOfParts,
+            final int exactNumberOfParts,
             final String delimiter,
             final String type) throws ArgumentConversionException {
-        final var parts = inputString.split(delimiter, numberOfParts);
-        if (numberOfParts != parts.length && numberOfParts > 0) {
-            throw new ArgumentConversionException(inputString + " is not a " + numberOfParts + "-part " + type +" ID");
+        final var parts = inputString.split(delimiter, exactNumberOfParts);
+        if (exactNumberOfParts != parts.length && exactNumberOfParts > 0) {
+            throw new ArgumentConversionException(inputString + " is not a " + exactNumberOfParts + "-part " + type +" ID");
         }
         return parts;
     }

--- a/hedera-node/src/test/java/com/hedera/test/utils/ConverterUtils.java
+++ b/hedera-node/src/test/java/com/hedera/test/utils/ConverterUtils.java
@@ -22,7 +22,17 @@ package com.hedera.test.utils;
 
 import org.junit.jupiter.params.converter.ArgumentConversionException;
 
+/**
+ * Contians various common checks and methods used by the Converter classes
+ * @author abhishekpandey
+ * */
 public final class ConverterUtils {
+    /**
+     * Checks if the input to the converter is of type {@link String} else throws an {@link ArgumentConversionException}
+     * @param input
+     *              the input to the converter
+     * @throws ArgumentConversionException
+     * */
     public static void checkIfInputString(Object input)
             throws ArgumentConversionException {
         if (!(input instanceof String)) {
@@ -30,6 +40,17 @@ public final class ConverterUtils {
         }
     }
 
+    /**
+     * Returns an array of string from the input after performing split operation else throws an
+     * {@link ArgumentConversionException}
+     * @param inputString
+     *              the input to the converter
+     * @param limit
+     *              the limit to be applied for the split operation
+     * @param type
+     *             the string defining the type of input
+     * @throws ArgumentConversionException
+     * */
     public static String[] getPartsIfValid(String inputString, int limit, String type)
             throws ArgumentConversionException {
         var parts = inputString.split("\\.", limit);

--- a/hedera-node/src/test/java/com/hedera/test/utils/ConverterUtils.java
+++ b/hedera-node/src/test/java/com/hedera/test/utils/ConverterUtils.java
@@ -9,9 +9,9 @@ package com.hedera.test.utils;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,17 +20,22 @@ package com.hedera.test.utils;
  * ‍
  */
 
-import org.junit.jupiter.api.extension.ParameterContext;
 import org.junit.jupiter.params.converter.ArgumentConversionException;
-import org.junit.jupiter.params.converter.ArgumentConverter;
 
-public class AccountIDConverter implements ArgumentConverter {
-    @Override
-    public Object convert(Object input, ParameterContext parameterContext) throws ArgumentConversionException {
-        if (null == input) {
-            return null;
+public final class ConverterUtils {
+    public static void checkIfInputString(Object input)
+            throws ArgumentConversionException {
+        if (!(input instanceof String)) {
+            throw new ArgumentConversionException(input + " is not a string");
         }
-        ConverterUtils.checkIfInputString(input);
-        return IdUtils.asAccount((String) input);
+    }
+
+    public static String[] getPartsIfValid(String inputString, int limit, String type)
+            throws ArgumentConversionException {
+        var parts = inputString.split("\\.", limit);
+        if (limit != parts.length) {
+            throw new ArgumentConversionException(inputString + " is not a " + limit + "-part " + type +" ID");
+        }
+        return parts;
     }
 }

--- a/hedera-node/src/test/java/com/hedera/test/utils/DurationConverter.java
+++ b/hedera-node/src/test/java/com/hedera/test/utils/DurationConverter.java
@@ -31,9 +31,7 @@ public class DurationConverter implements ArgumentConverter {
         if (null == input) {
             return null;
         }
-        if (!(input instanceof String)) {
-            throw new ArgumentConversionException(input + " is not a string");
-        }
+        ConverterUtils.checkIfInputString(input);
         return Duration.newBuilder().setSeconds(Long.parseLong((String) input)).build();
     }
 }

--- a/hedera-node/src/test/java/com/hedera/test/utils/DurationConverter.java
+++ b/hedera-node/src/test/java/com/hedera/test/utils/DurationConverter.java
@@ -31,7 +31,7 @@ public class DurationConverter implements ArgumentConverter {
         if (null == input) {
             return null;
         }
-        ConverterUtils.checkIfInputString(input);
-        return Duration.newBuilder().setSeconds(Long.parseLong((String) input)).build();
+        final String inputString = ConverterUtils.toStringInstance(input);
+        return Duration.newBuilder().setSeconds(Long.parseLong(inputString)).build();
     }
 }

--- a/hedera-node/src/test/java/com/hedera/test/utils/Ed25519KeyConverter.java
+++ b/hedera-node/src/test/java/com/hedera/test/utils/Ed25519KeyConverter.java
@@ -34,9 +34,9 @@ public class Ed25519KeyConverter implements ArgumentConverter {
         if (null == input) {
             return null;
         }
-        ConverterUtils.checkIfInputString(input);
+        final String inputString = ConverterUtils.toStringInstance(input);
         try {
-            return JKey.mapJKey(new JEd25519Key(CommonUtils.unhex((String) input)));
+            return JKey.mapJKey(new JEd25519Key(CommonUtils.unhex(inputString)));
         } catch (Exception e) {
             throw new IllegalArgumentException(e);
         }

--- a/hedera-node/src/test/java/com/hedera/test/utils/Ed25519KeyConverter.java
+++ b/hedera-node/src/test/java/com/hedera/test/utils/Ed25519KeyConverter.java
@@ -34,12 +34,9 @@ public class Ed25519KeyConverter implements ArgumentConverter {
         if (null == input) {
             return null;
         }
-        if (!(input instanceof String)) {
-            throw new ArgumentConversionException(input + " is not a string");
-        }
-        var inputString = (String) input;
+        ConverterUtils.checkIfInputString(input);
         try {
-            return JKey.mapJKey(new JEd25519Key(CommonUtils.unhex(inputString)));
+            return JKey.mapJKey(new JEd25519Key(CommonUtils.unhex((String) input)));
         } catch (Exception e) {
             throw new IllegalArgumentException(e);
         }

--- a/hedera-node/src/test/java/com/hedera/test/utils/EntityIdConverter.java
+++ b/hedera-node/src/test/java/com/hedera/test/utils/EntityIdConverter.java
@@ -32,8 +32,8 @@ public final class EntityIdConverter implements ArgumentConverter {
 		if (null == input) {
 			return null;
 		}
-		ConverterUtils.checkIfInputString(input);
-		var parts = ConverterUtils.getPartsIfValid((String) input, 3, "account");
+		final String inputString = ConverterUtils.toStringInstance(input);
+		final var parts = ConverterUtils.getPartsIfValid(inputString, 3, "\\.", "account");
 		return new EntityId(Long.valueOf(parts[0]), Long.valueOf(parts[1]), Long.valueOf(parts[2]));
 	}
 }

--- a/hedera-node/src/test/java/com/hedera/test/utils/EntityIdConverter.java
+++ b/hedera-node/src/test/java/com/hedera/test/utils/EntityIdConverter.java
@@ -32,14 +32,8 @@ public final class EntityIdConverter implements ArgumentConverter {
 		if (null == input) {
 			return null;
 		}
-		if (!(input instanceof String)) {
-			throw new ArgumentConversionException(input + " is not a string");
-		}
-		var inputString = (String) input;
-		var parts = inputString.split("\\.", 3);
-		if (3 != parts.length) {
-			throw new ArgumentConversionException(input + " is not a 3-part account ID");
-		}
+		ConverterUtils.checkIfInputString(input);
+		var parts = ConverterUtils.getPartsIfValid((String) input, 3, "account");
 		return new EntityId(Long.valueOf(parts[0]), Long.valueOf(parts[1]), Long.valueOf(parts[2]));
 	}
 }

--- a/hedera-node/src/test/java/com/hedera/test/utils/InstantConverter.java
+++ b/hedera-node/src/test/java/com/hedera/test/utils/InstantConverter.java
@@ -33,8 +33,8 @@ public final class InstantConverter implements ArgumentConverter {
 		if (null == input) {
 			return null;
 		}
-		ConverterUtils.checkIfInputString(input);
-		var l = Long.valueOf((String) input);
+		final String inputString = ConverterUtils.toStringInstance(input);
+		var l = Long.valueOf(inputString);
 		return Instant.ofEpochSecond(l / 1_000_000_000L, (int) (l % 1_000_000_000L));
 	}
 }

--- a/hedera-node/src/test/java/com/hedera/test/utils/InstantConverter.java
+++ b/hedera-node/src/test/java/com/hedera/test/utils/InstantConverter.java
@@ -33,11 +33,8 @@ public final class InstantConverter implements ArgumentConverter {
 		if (null == input) {
 			return null;
 		}
-		if (!(input instanceof String)) {
-			throw new ArgumentConversionException(input + " is not a string");
-		}
-		var inputString = (String) input;
-		var l = Long.valueOf(inputString);
+		ConverterUtils.checkIfInputString(input);
+		var l = Long.valueOf((String) input);
 		return Instant.ofEpochSecond(l / 1_000_000_000L, (int) (l % 1_000_000_000L));
 	}
 }

--- a/hedera-node/src/test/java/com/hedera/test/utils/JEd25519KeyConverter.java
+++ b/hedera-node/src/test/java/com/hedera/test/utils/JEd25519KeyConverter.java
@@ -33,10 +33,7 @@ public final class JEd25519KeyConverter implements ArgumentConverter {
 		if (null == input) {
 			return null;
 		}
-		if (!(input instanceof String)) {
-			throw new ArgumentConversionException(input + " is not a string");
-		}
-		var inputString = (String) input;
-		return new JEd25519Key(CommonUtils.unhex(inputString));
+		ConverterUtils.checkIfInputString(input);
+		return new JEd25519Key(CommonUtils.unhex((String) input));
 	}
 }

--- a/hedera-node/src/test/java/com/hedera/test/utils/JEd25519KeyConverter.java
+++ b/hedera-node/src/test/java/com/hedera/test/utils/JEd25519KeyConverter.java
@@ -33,7 +33,7 @@ public final class JEd25519KeyConverter implements ArgumentConverter {
 		if (null == input) {
 			return null;
 		}
-		ConverterUtils.checkIfInputString(input);
-		return new JEd25519Key(CommonUtils.unhex((String) input));
+		final String inputString = ConverterUtils.toStringInstance(input);
+		return new JEd25519Key(CommonUtils.unhex(inputString));
 	}
 }

--- a/hedera-node/src/test/java/com/hedera/test/utils/RichInstantConverter.java
+++ b/hedera-node/src/test/java/com/hedera/test/utils/RichInstantConverter.java
@@ -21,7 +21,6 @@ package com.hedera.test.utils;
  */
 
 import com.hedera.services.state.submerkle.RichInstant;
-import org.bouncycastle.util.Strings;
 import org.junit.jupiter.api.extension.ParameterContext;
 import org.junit.jupiter.params.converter.ArgumentConversionException;
 import org.junit.jupiter.params.converter.ArgumentConverter;
@@ -36,8 +35,8 @@ public final class RichInstantConverter implements ArgumentConverter {
 		if (null == input) {
 			return null;
 		}
-		ConverterUtils.checkIfInputString(input);
-		String[] splits = Strings.split((String) input, '_');
+		final String inputString = ConverterUtils.toStringInstance(input);
+		final var splits = ConverterUtils.getPartsIfValid(inputString, 0, "_", "Instant");
 		return new RichInstant(Long.parseLong(splits[0]), Integer.parseInt(splits[1]));
 	}
 }

--- a/hedera-node/src/test/java/com/hedera/test/utils/RichInstantConverter.java
+++ b/hedera-node/src/test/java/com/hedera/test/utils/RichInstantConverter.java
@@ -36,9 +36,7 @@ public final class RichInstantConverter implements ArgumentConverter {
 		if (null == input) {
 			return null;
 		}
-		if (!(input instanceof String)) {
-			throw new ArgumentConversionException(input + " is not a string");
-		}
+		ConverterUtils.checkIfInputString(input);
 		String[] splits = Strings.split((String) input, '_');
 		return new RichInstant(Long.parseLong(splits[0]), Integer.parseInt(splits[1]));
 	}

--- a/hedera-node/src/test/java/com/hedera/test/utils/TopicIDConverter.java
+++ b/hedera-node/src/test/java/com/hedera/test/utils/TopicIDConverter.java
@@ -32,14 +32,8 @@ public final class TopicIDConverter implements ArgumentConverter {
 		if (null == input) {
 			return null;
 		}
-		if (!(input instanceof String)) {
-			throw new ArgumentConversionException(input + " is not a string");
-		}
-		var inputString = (String) input;
-		var parts = inputString.split("\\.", 3);
-		if (3 != parts.length) {
-			throw new ArgumentConversionException(input + " is not a 3-part topic ID");
-		}
+		ConverterUtils.checkIfInputString(input);
+		var parts = ConverterUtils.getPartsIfValid((String) input, 3, "topic");
 		return TopicID.newBuilder()
 				.setShardNum(Long.valueOf(parts[0]))
 				.setRealmNum(Long.valueOf(parts[1]))

--- a/hedera-node/src/test/java/com/hedera/test/utils/TopicIDConverter.java
+++ b/hedera-node/src/test/java/com/hedera/test/utils/TopicIDConverter.java
@@ -32,8 +32,8 @@ public final class TopicIDConverter implements ArgumentConverter {
 		if (null == input) {
 			return null;
 		}
-		ConverterUtils.checkIfInputString(input);
-		var parts = ConverterUtils.getPartsIfValid((String) input, 3, "topic");
+		final String inputString = ConverterUtils.toStringInstance(input);
+		final var parts = ConverterUtils.getPartsIfValid(inputString, 3, "\\.","topic");
 		return TopicID.newBuilder()
 				.setShardNum(Long.valueOf(parts[0]))
 				.setRealmNum(Long.valueOf(parts[1]))

--- a/hedera-node/src/test/java/com/hedera/test/utils/TopicIDConverter.java
+++ b/hedera-node/src/test/java/com/hedera/test/utils/TopicIDConverter.java
@@ -33,7 +33,7 @@ public final class TopicIDConverter implements ArgumentConverter {
 			return null;
 		}
 		final String inputString = ConverterUtils.toStringInstance(input);
-		final var parts = ConverterUtils.getPartsIfValid(inputString, 3, "\\.","topic");
+		final var parts = ConverterUtils.getPartsIfValid(inputString, 3, "\\.", "topic");
 		return TopicID.newBuilder()
 				.setShardNum(Long.valueOf(parts[0]))
 				.setRealmNum(Long.valueOf(parts[1]))

--- a/hedera-node/src/test/java/com/hedera/test/utils/TxnUtils.java
+++ b/hedera-node/src/test/java/com/hedera/test/utils/TxnUtils.java
@@ -37,7 +37,6 @@ import com.hederahashgraph.api.proto.java.TransferList;
 
 import java.util.List;
 import java.util.UUID;
-import java.util.concurrent.atomic.AtomicReference;
 
 import static com.hedera.test.factories.txns.CryptoTransferFactory.newSignedCryptoTransfer;
 import static com.hedera.test.factories.txns.TinyBarsFromTo.tinyBarsFromTo;


### PR DESCRIPTION
Signed-off-by: abhishek-hedera <abhishek.pandey@hedera.com>

**Related issue(s)**:
Closes #1488 

**Summary of the change**:
Created a `ConverterUtils` class to reuse checks and string split operation being used by the converters.

**External impacts**:
None.

**Applicable documentation**
- [ ] Javadoc
