### PR TITLE
Crypto Get Info Modification (#260)

### DIFF
--- a/hedera-node/src/main/java/com/hedera/services/context/primitives/StateView.java
+++ b/hedera-node/src/main/java/com/hedera/services/context/primitives/StateView.java
@@ -443,7 +443,8 @@ public class StateView {
 				.setAutoRenewPeriod(Duration.newBuilder().setSeconds(account.getAutoRenewSecs()))
 				.setBalance(account.getBalance())
 				.setExpirationTime(Timestamp.newBuilder().setSeconds(account.getExpiry()))
-				.setContractAccountID(asSolidityAddressHex(id));
+				.setContractAccountID(asSolidityAddressHex(id))
+				.setOwnedNfts(account.getNftsOwned());
 		Optional.ofNullable(account.getProxy())
 				.map(EntityId::toGrpcAccountId)
 				.ifPresent(info::setProxyAccountID);

--- a/hedera-node/src/main/java/com/hedera/services/state/merkle/MerkleAccount.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/merkle/MerkleAccount.java
@@ -195,6 +195,10 @@ public class MerkleAccount extends AbstractNaryMerkleInternal implements FCMValu
 	}
 
 	/* ----  Bean  ---- */
+	public long getNftsOwned() { return state().nftsOwned(); }
+
+	public void setNftsOwned(long nftsOwned) { state().setNftsOwned(nftsOwned); }
+
 	public String getMemo() {
 		return state().memo();
 	}

--- a/hedera-node/src/main/java/com/hedera/services/state/merkle/MerkleAccountState.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/merkle/MerkleAccountState.java
@@ -47,7 +47,8 @@ public class MerkleAccountState extends AbstractMerkleLeaf {
 	static final int RELEASE_08x_VERSION = 2;
 	static final int RELEASE_090_ALPHA_VERSION = 3;
 	static final int RELEASE_090_VERSION = 4;
-	static final int MERKLE_VERSION = RELEASE_090_VERSION;
+	static final int RELEASE_0150_VERSION = 5;
+	static final int MERKLE_VERSION = RELEASE_0150_VERSION;
 	static final long RUNTIME_CONSTRUCTABLE_ID = 0x354cfc55834e7f12L;
 
 	static DomainSerdes serdes = new DomainSerdes();
@@ -58,6 +59,7 @@ public class MerkleAccountState extends AbstractMerkleLeaf {
 	private long expiry;
 	private long hbarBalance;
 	private long autoRenewSecs;
+	private long nftsOwned;
 	private String memo = DEFAULT_MEMO;
 	private boolean deleted;
 	private boolean smartContract;
@@ -119,6 +121,10 @@ public class MerkleAccountState extends AbstractMerkleLeaf {
 			/* Releases v0.8.0 and v0.8.1 included token information in the account state. */
 			in.readLongArray(MAX_CONCEIVABLE_TOKEN_BALANCES_SIZE);
 		}
+		if (version >= RELEASE_0150_VERSION) {
+			/* The number of nfts owned is being saved in the state after RELEASE_0150_VERSION */
+			nftsOwned = in.readLong();
+		}
 	}
 
 	@Override
@@ -132,11 +138,12 @@ public class MerkleAccountState extends AbstractMerkleLeaf {
 		out.writeBoolean(smartContract);
 		out.writeBoolean(receiverSigRequired);
 		serdes.writeNullableSerializable(proxy, out);
+		out.writeLong(nftsOwned);
 	}
 
 	/* --- Copyable --- */
 	public MerkleAccountState copy() {
-		return new MerkleAccountState(
+		var copied = new MerkleAccountState(
 				key,
 				expiry,
 				hbarBalance,
@@ -146,6 +153,8 @@ public class MerkleAccountState extends AbstractMerkleLeaf {
 				smartContract,
 				receiverSigRequired,
 				proxy);
+		copied.setNftsOwned(this.nftsOwned);
+		return copied;
 	}
 
 	@Override
@@ -162,6 +171,7 @@ public class MerkleAccountState extends AbstractMerkleLeaf {
 		return this.expiry == that.expiry &&
 				this.hbarBalance == that.hbarBalance &&
 				this.autoRenewSecs == that.autoRenewSecs &&
+				this.nftsOwned == that.nftsOwned &&
 				Objects.equals(this.memo, that.memo) &&
 				this.deleted == that.deleted &&
 				this.smartContract == that.smartContract &&
@@ -181,7 +191,8 @@ public class MerkleAccountState extends AbstractMerkleLeaf {
 				deleted,
 				smartContract,
 				receiverSigRequired,
-				proxy);
+				proxy,
+				nftsOwned);
 	}
 
 	/* --- Bean --- */
@@ -197,6 +208,7 @@ public class MerkleAccountState extends AbstractMerkleLeaf {
 				.add("smartContract", smartContract)
 				.add("receiverSigRequired", receiverSigRequired)
 				.add("proxy", proxy)
+				.add("nftsOwned", nftsOwned)
 				.toString();
 	}
 
@@ -214,6 +226,10 @@ public class MerkleAccountState extends AbstractMerkleLeaf {
 
 	public long autoRenewSecs() {
 		return autoRenewSecs;
+	}
+
+	public long nftsOwned() {
+		return nftsOwned;
 	}
 
 	public String memo() {
@@ -246,6 +262,10 @@ public class MerkleAccountState extends AbstractMerkleLeaf {
 
 	public void setHbarBalance(long hbarBalance) {
 		this.hbarBalance = hbarBalance;
+	}
+
+	public void setNftsOwned(long nftsOwned) {
+		this.nftsOwned = nftsOwned;
 	}
 
 	public void setAutoRenewSecs(long autoRenewSecs) {

--- a/hedera-node/src/test/java/com/hedera/services/state/exports/ToStringAccountsExporterTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/state/exports/ToStringAccountsExporterTest.java
@@ -74,7 +74,7 @@ class ToStringAccountsExporterTest {
 				"---\n" +
 				"MerkleAccount{state=MerkleAccountState{key=ed25519: \"first-fake\"\n" +
 				", expiry=1234567, balance=1, autoRenewSecs=555555, memo=This ecstasy doth unperplex, deleted=false, " +
-				"smartContract=true, receiverSigRequired=true, proxy=EntityId{shard=0, realm=0, num=0}}, # records=0, " +
+				"smartContract=true, receiverSigRequired=true, proxy=EntityId{shard=0, realm=0, num=0}, nftsOwned=0}, # records=0, " +
 				"tokens=[3.2.1, 1.2.3]}\n" +
 				"\n" +
 				"0.0.2\n" +
@@ -82,7 +82,7 @@ class ToStringAccountsExporterTest {
 				"MerkleAccount{state=MerkleAccountState{key=ed25519: \"second-fake\"\n" +
 				", expiry=7654321, balance=2, autoRenewSecs=444444, memo=We said, and show us what we love, " +
 				"deleted=true, smartContract=false, receiverSigRequired=false, proxy=EntityId{shard=0, realm=0, " +
-				"num=0}}, # records=0, tokens=[1234.0.0]}\n";
+				"num=0}, nftsOwned=0}, # records=0, tokens=[1234.0.0]}\n";
 
 		// given:
 		FCMap<MerkleEntityId, MerkleAccount> accounts = new FCMap<>();

--- a/hedera-node/src/test/java/com/hedera/services/state/merkle/MerkleAccountTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/state/merkle/MerkleAccountTest.java
@@ -54,6 +54,7 @@ public class MerkleAccountTest {
 	long expiry = 1_234_567L;
 	long balance = 555_555L;
 	long autoRenewSecs = 234_567L;
+	long nftsOwned = 1_234L;
 	long senderThreshold = 1_234L;
 	long receiverThreshold = 4_321L;
 	String memo = "A memo";
@@ -83,6 +84,7 @@ public class MerkleAccountTest {
 	long otherAutoRenewSecs = 432_765L;
 	long otherSenderThreshold = 4_321L;
 	long otherReceiverThreshold = 1_234L;
+	long otherNftsOwned = 1_234L;
 	String otherMemo = "Another memo";
 	boolean otherDeleted = false;
 	boolean otherSmartContract = false;
@@ -215,6 +217,7 @@ public class MerkleAccountTest {
 		subject.setDeleted(otherDeleted);
 		subject.setSmartContract(otherSmartContract);
 		subject.setReceiverSigRequired(otherReceiverSigRequired);
+		subject.setNftsOwned(otherNftsOwned);
 		subject.setMemo(otherMemo);
 		subject.setProxy(otherProxy);
 		subject.setKey(otherKey);
@@ -225,6 +228,7 @@ public class MerkleAccountTest {
 		verify(delegate).setDeleted(otherDeleted);
 		verify(delegate).setSmartContract(otherSmartContract);
 		verify(delegate).setReceiverSigRequired(otherReceiverSigRequired);
+		verify(delegate).setNftsOwned(otherNftsOwned);
 		verify(delegate).setMemo(otherMemo);
 		verify(delegate).setProxy(otherProxy);
 		verify(delegate).setKey(otherKey);

--- a/hedera-node/src/test/java/com/hedera/test/factories/accounts/MerkleAccountFactory.java
+++ b/hedera-node/src/test/java/com/hedera/test/factories/accounts/MerkleAccountFactory.java
@@ -42,6 +42,7 @@ public class MerkleAccountFactory {
 	private Optional<Long> senderThreshold = Optional.empty();
 	private Optional<Boolean> receiverSigRequired = Optional.empty();
 	private Optional<JKey> accountKeys = Optional.empty();
+	private Optional<Long> ownedNfts = Optional.empty();
 	private Optional<Long> autoRenewPeriod = Optional.empty();
 	private Optional<Boolean> deleted = Optional.empty();
 	private Optional<Long> expirationTime = Optional.empty();
@@ -61,6 +62,7 @@ public class MerkleAccountFactory {
 		autoRenewPeriod.ifPresent(d -> value.setAutoRenewSecs(d));
 		isSmartContract.ifPresent(b -> value.setSmartContract(b));
 		receiverSigRequired.ifPresent(b -> value.setReceiverSigRequired(b));
+		ownedNfts.ifPresent(o -> value.setNftsOwned(o));
 		var tokens = new MerkleAccountTokens();
 		tokens.associateAll(associatedTokens);
 		value.setTokens(tokens);
@@ -134,6 +136,10 @@ public class MerkleAccountFactory {
 	}
 	public MerkleAccountFactory isSmartContract(boolean b) {
 		isSmartContract = Optional.of(b);
+		return this;
+	}
+	public MerkleAccountFactory ownedNfts(long l) {
+		ownedNfts = Optional.of(l);
 		return this;
 	}
 }


### PR DESCRIPTION
**Related issue(s)**:
Closes #NONE

**Summary of the change**:
Added `nftsOwned` property in `MerkleAccountState` in order to extend the information in `CryptoGetInfo` query to show basic information for the number of nfts that a certain account owns. Updated unit tests.

**External impacts**:
None.

**Applicable documentation**
- [ ] Javadoc
- [ ] HAPI protobuf comments
- [ ] README
