### PR TITLE
NFT: Memo to Metadata

### DIFF
--- a/hedera-node/src/main/java/com/hedera/services/context/primitives/StateView.java
+++ b/hedera-node/src/main/java/com/hedera/services/context/primitives/StateView.java
@@ -364,7 +364,7 @@ public class StateView {
 					.setCreationTime(Timestamp.newBuilder()
 							.setSeconds(uniqueToken.getCreationTime().getSeconds())
 							.setNanos(uniqueToken.getCreationTime().getNanos()))
-					.setMetadata(ByteString.copyFromUtf8(uniqueToken.getMemo()));
+					.setMetadata(uniqueToken.getMetadata());
 
 			return Optional.of(info.build());
 		} catch (Exception unexpected) {

--- a/hedera-node/src/main/java/com/hedera/services/store/tokens/unique/UniqueTokenStore.java
+++ b/hedera-node/src/main/java/com/hedera/services/store/tokens/unique/UniqueTokenStore.java
@@ -97,9 +97,8 @@ public class UniqueTokenStore extends BaseTokenStore implements UniqueStore {
 			long serialNum = merkleToken.getCurrentSerialNum();
 			for (ByteString el : metadataList) {
 				serialNum++;
-				String metaAsStr = el.toStringUtf8();
 				final var nftId = new MerkleUniqueTokenId(eId, serialNum);
-				final var nft = new MerkleUniqueToken(owner, metaAsStr, creationTime);
+				final var nft = new MerkleUniqueToken(owner, el.toByteArray(), creationTime);
 				provisionalUniqueTokens.add(Pair.of(nftId, nft));
 				lastMintedSerialNumbers.add(serialNum);
 			}
@@ -129,7 +128,7 @@ public class UniqueTokenStore extends BaseTokenStore implements UniqueStore {
 
 	private boolean checkProvisional(List<Pair<MerkleUniqueTokenId, MerkleUniqueToken>> provisionalUniqueTokens) {
 		var provisionalTokenSet = provisionalUniqueTokens.stream()
-				.map(e -> e.getValue().getMemo())
+				.map(e -> e.getValue().getMetadata())
 				.collect(Collectors.toSet());
 		return provisionalTokenSet.size() == provisionalUniqueTokens.size();
 	}

--- a/hedera-node/src/test/java/com/hedera/services/context/primitives/StateViewTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/context/primitives/StateViewTest.java
@@ -230,7 +230,7 @@ class StateViewTest {
 		given(tokenStore.get(tokenId)).willReturn(token);
 
 		uniqueStore = mock(UniqueStore.class);
-		uniqueToken = new MerkleUniqueToken(new EntityId(1, 2, 3), "has to be bytes", RichInstant.fromJava(resolutionTime));
+		uniqueToken = new MerkleUniqueToken(new EntityId(1, 2, 3), "Some metadata here".getBytes(), RichInstant.fromJava(resolutionTime));
 		given(uniqueStore.nftExists(nftId)).willReturn(true);
 		given(uniqueStore.nftExists(missingNftId)).willReturn(false);
 		given(uniqueStore.get(nftId)).willReturn(uniqueToken);
@@ -409,7 +409,7 @@ class StateViewTest {
 		var info = subject.infoForNft(nftId).get();
 
 		// then:
-		assertEquals(uniqueToken.getMemo(), info.getMetadata().toStringUtf8());
+		assertEquals(uniqueToken.getMetadata(), info.getMetadata());
 		assertEquals(uniqueToken.getCreationTime().toGrpc(), info.getCreationTime());
 		assertEquals(asAccount(uniqueToken.getOwner()), info.getAccountID());
 	}

--- a/hedera-node/src/test/java/com/hedera/services/state/merkle/MerkleUniqueTokenTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/state/merkle/MerkleUniqueTokenTest.java
@@ -25,6 +25,7 @@ import org.mockito.InOrder;
 
 import java.io.IOException;
 import java.time.Instant;
+import java.util.Arrays;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.BDDMockito.given;
@@ -36,8 +37,8 @@ public class MerkleUniqueTokenTest {
 
 	private EntityId owner;
 	private EntityId otherOwner;
-	private String memo;
-	private String otherMemo;
+	private byte[] metadata;
+	private byte[] otherMetadata;
 	private RichInstant timestamp;
 	private RichInstant otherTimestamp;
 
@@ -47,12 +48,12 @@ public class MerkleUniqueTokenTest {
 	public void setup() {
 		owner = new EntityId(1, 2, 3);
 		otherOwner = new EntityId(1, 2, 4);
-		memo = "Test NFT";
-		otherMemo = "Test NFT2";
+		metadata = "Test NFT".getBytes();
+		otherMetadata = "Test NFT2".getBytes();
 		timestamp = RichInstant.fromJava(Instant.ofEpochSecond(timestampL));
 		otherTimestamp = RichInstant.fromJava(Instant.ofEpochSecond(1_234_568L));
 
-		subject = new MerkleUniqueToken(owner, memo, timestamp);
+		subject = new MerkleUniqueToken(owner, metadata, timestamp);
 	}
 
 	@AfterEach
@@ -62,10 +63,10 @@ public class MerkleUniqueTokenTest {
 	@Test
 	public void equalsContractWorks() {
 		// given
-		var other = new MerkleUniqueToken(owner, memo, otherTimestamp);
-		var other2 = new MerkleUniqueToken(owner, otherMemo, timestamp);
-		var other3 = new MerkleUniqueToken(otherOwner, memo, timestamp);
-		var identical = new MerkleUniqueToken(owner, memo, timestamp);
+		var other = new MerkleUniqueToken(owner, metadata, otherTimestamp);
+		var other2 = new MerkleUniqueToken(owner, otherMetadata, timestamp);
+		var other3 = new MerkleUniqueToken(otherOwner, metadata, timestamp);
+		var identical = new MerkleUniqueToken(owner, metadata, timestamp);
 
 		// expect
 		assertNotEquals(subject, other);
@@ -77,8 +78,8 @@ public class MerkleUniqueTokenTest {
 	@Test
 	public void hashCodeWorks() {
 		// given:
-		var identical = new MerkleUniqueToken(owner, memo, timestamp);
-		var other = new MerkleUniqueToken(otherOwner, otherMemo, otherTimestamp);
+		var identical = new MerkleUniqueToken(owner, metadata, timestamp);
+		var other = new MerkleUniqueToken(otherOwner, otherMetadata, otherTimestamp);
 
 		// expect:
 		assertNotEquals(subject.hashCode(), other.hashCode());
@@ -91,7 +92,7 @@ public class MerkleUniqueTokenTest {
 		assertEquals("MerkleUniqueToken{" +
 						"owner=" + owner + ", " +
 						"creationTime=" + timestamp + ", " +
-						"memo=" + memo + "}",
+						"metadata=" + Arrays.toString(metadata) + "}",
 				subject.toString());
 	}
 
@@ -122,7 +123,7 @@ public class MerkleUniqueTokenTest {
 		inOrder.verify(out).writeSerializable(owner, true);
 		inOrder.verify(out).writeLong(timestamp.getSeconds());
 		inOrder.verify(out).writeInt(timestamp.getNanos());
-		inOrder.verify(out).writeNormalisedString(memo);
+		inOrder.verify(out).writeByteArray(metadata);
 
 	}
 
@@ -132,7 +133,7 @@ public class MerkleUniqueTokenTest {
 		SerializableDataInputStream in = mock(SerializableDataInputStream.class);
 
 		given(in.readSerializable()).willReturn(owner);
-		given(in.readNormalisedString(anyInt())).willReturn(memo);
+		given(in.readByteArray(anyInt())).willReturn(metadata);
 		given(in.readLong()).willReturn(timestampL);
 		given(in.readInt()).willReturn(0);
 

--- a/hedera-node/src/test/java/com/hedera/services/store/tokens/unique/UniqueTokenStoreTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/store/tokens/unique/UniqueTokenStoreTest.java
@@ -94,7 +94,7 @@ class UniqueTokenStoreTest {
 	AccountID sponsor = IdUtils.asAccount("1.2.666");
 	Pair<AccountID, TokenID> sponsorPair = asTokenRel(sponsor, tokenID);
 	long sponsorBalance = 1_000;
-	String memo = "hello";
+	ByteString metadata = ByteString.copyFromUtf8("hello");
 
 
 	@BeforeEach
@@ -103,7 +103,7 @@ class UniqueTokenStoreTest {
 		nftId = mock(MerkleUniqueTokenId.class);
 		nft = mock(MerkleUniqueToken.class);
 		given(nft.getOwner()).willReturn(EntityId.fromGrpcAccountId(treasury));
-		given(nft.getMemo()).willReturn(memo);
+		given(nft.getMetadata()).willReturn(metadata);
 		token = mock(MerkleToken.class);
 		given(token.isDeleted()).willReturn(false);
 		given(token.treasury()).willReturn(EntityId.fromGrpcAccountId(sponsor));
@@ -138,7 +138,7 @@ class UniqueTokenStoreTest {
 		store.setAccountsLedger(accountsLedger);
 
 		given(nft.getOwner()).willReturn(EntityId.fromGrpcAccountId(treasury));
-		given(nft.getMemo()).willReturn(memo);
+		given(nft.getMetadata()).willReturn(metadata);
 
 		given(nfTokens.containsKey(fromNftID(misc))).willReturn(true);
 		given(nfTokens.get(fromNftID(misc))).willReturn(nft);


### PR DESCRIPTION
**Related issue(s)**:
Closes #NONE

**Summary of the change**:
In recent discussions a refactoring of unique merkle token's memo string to metadata byte array was agreed on. I made the change and updated the correlating unit tests.

**External impacts**:
None.

**Applicable documentation**
- [ ] Javadoc
- [ ] HAPI protobuf comments
- [ ] README
