### PR TITLE
Update channel for Nightly regression results

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2751,7 +2751,7 @@ jobs:
         default: true
       slack_results_channel:
         type: string
-        default: "hedera-regression-test"
+        default: "hedera-regression"
       slack_summary_channel:
         type: string
         default: "hedera-regression-summary"


### PR DESCRIPTION
Slack channel was changed to `hedera-regression-test` by mistake when the master-plus-sdk-0.15.0 branch is merged. Changed back to `hedera-regression` for nightly results