### PR TITLE
Roll to SDK 0.15.1 for v0.15.1 tag

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -166,7 +166,7 @@
     <javax-inject.version>1</javax-inject.version>
     <log4j.version>2.13.2</log4j.version>
     <netty.version>4.1.51.Final</netty.version>
-    <swirlds.version>0.15.0</swirlds.version>
+    <swirlds.version>0.15.1</swirlds.version>
     <!-- Test dependency properties -->
     <hamcrest-all.version>1.3</hamcrest-all.version>
     <junit.version>4.13.1</junit.version>


### PR DESCRIPTION
Use SDK 0.15.1 in preparation for tagging `v0.15.1`.
