### PR TITLE
Update BalanceChange to use Id instead of EntityId

### DIFF
--- a/hedera-node/src/main/java/com/hedera/services/grpc/marshalling/ImpliedTransfers.java
+++ b/hedera-node/src/main/java/com/hedera/services/grpc/marshalling/ImpliedTransfers.java
@@ -24,7 +24,7 @@ import com.google.common.base.MoreObjects;
 import com.hedera.services.ledger.BalanceChange;
 import com.hedera.services.state.submerkle.AssessedCustomFee;
 import com.hedera.services.state.submerkle.CustomFee;
-import com.hedera.services.state.submerkle.EntityId;
+import com.hedera.services.store.models.Id;
 import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
@@ -45,11 +45,11 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OK;
 public class ImpliedTransfers {
 	private final ImpliedTransfersMeta meta;
 	private final List<BalanceChange> changes;
-	private final List<Pair<EntityId, List<CustomFee>>> involvedTokenFeeSchedules;
+	private final List<Pair<Id, List<CustomFee>>> involvedTokenFeeSchedules;
 	private final List<AssessedCustomFee> assessedCustomFees;
 
 	private ImpliedTransfers(ImpliedTransfersMeta meta, List<BalanceChange> changes,
-			List<Pair<EntityId, List<CustomFee>>> entityCustomFees,
+			List<Pair<Id, List<CustomFee>>> entityCustomFees,
 			List<AssessedCustomFee> assessedCustomFees) {
 		this.meta = meta;
 		this.changes = changes;
@@ -61,7 +61,7 @@ public class ImpliedTransfers {
 			int maxHbarAdjusts,
 			int maxTokenAdjusts,
 			List<BalanceChange> changes,
-			List<Pair<EntityId, List<CustomFee>>> entityCustomFees,
+			List<Pair<Id, List<CustomFee>>> entityCustomFees,
 			List<AssessedCustomFee> assessedCustomFees
 	) {
 		final var meta = new ImpliedTransfersMeta(maxHbarAdjusts, maxTokenAdjusts, OK, entityCustomFees);
@@ -85,7 +85,7 @@ public class ImpliedTransfers {
 		return changes;
 	}
 
-	public List<Pair<EntityId, List<CustomFee>>> getInvolvedTokenFeeSchedules() {
+	public List<Pair<Id, List<CustomFee>>> getInvolvedTokenFeeSchedules() {
 		return involvedTokenFeeSchedules;
 	}
 

--- a/hedera-node/src/main/java/com/hedera/services/grpc/marshalling/ImpliedTransfersMarshal.java
+++ b/hedera-node/src/main/java/com/hedera/services/grpc/marshalling/ImpliedTransfersMarshal.java
@@ -201,11 +201,8 @@ public class ImpliedTransfersMarshal {
 			Map<Pair<Id, Id>, BalanceChange> existingBalanceChanges,
 			List<BalanceChange> customFeeChanges, long fees,
 			BalanceChange customFee, boolean isPayer) {
-		if (isPayer) {
-			customFee.setCodeForInsufficientBalance(INSUFFICIENT_PAYER_BALANCE_FOR_CUSTOM_FEE);
-		}
 		boolean isPresent = adjustUnitsIfKeyPresent(pair, existingBalanceChanges, fees, isPayer);
-		addBalanceChangeIfNotPresent(isPresent, customFeeChanges, existingBalanceChanges, pair, customFee);
+		addBalanceChangeIfNotPresent(isPresent, customFeeChanges, existingBalanceChanges, pair, customFee, isPayer);
 	}
 
 
@@ -214,8 +211,11 @@ public class ImpliedTransfersMarshal {
 	 */
 	private void addBalanceChangeIfNotPresent(boolean isPresent, List<BalanceChange> customFeeChanges,
 			Map<Pair<Id, Id>, BalanceChange> existingBalanceChanges,
-			Pair<Id, Id> pair, BalanceChange customFee) {
+			Pair<Id, Id> pair, BalanceChange customFee, boolean isPayer) {
 		if (!isPresent) {
+			if (isPayer) {
+				customFee.setCodeForInsufficientBalance(INSUFFICIENT_PAYER_BALANCE_FOR_CUSTOM_FEE);
+			}
 			customFeeChanges.add(customFee);
 			existingBalanceChanges.put(pair, customFee);
 		}

--- a/hedera-node/src/main/java/com/hedera/services/grpc/marshalling/ImpliedTransfersMarshal.java
+++ b/hedera-node/src/main/java/com/hedera/services/grpc/marshalling/ImpliedTransfersMarshal.java
@@ -25,7 +25,7 @@ import com.hedera.services.ledger.BalanceChange;
 import com.hedera.services.ledger.PureTransferSemanticChecks;
 import com.hedera.services.state.submerkle.AssessedCustomFee;
 import com.hedera.services.state.submerkle.CustomFee;
-import com.hedera.services.state.submerkle.EntityId;
+import com.hedera.services.store.models.Id;
 import com.hedera.services.txns.customfees.CustomFeeSchedules;
 import com.hederahashgraph.api.proto.java.AccountID;
 import com.hederahashgraph.api.proto.java.CryptoTransferTransactionBody;
@@ -38,6 +38,7 @@ import java.util.Map;
 
 import static com.hedera.services.ledger.BalanceChange.hbarAdjust;
 import static com.hedera.services.ledger.BalanceChange.tokenAdjust;
+import static com.hedera.services.store.models.Id.MISSING_ID;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OK;
 
 /**
@@ -76,18 +77,18 @@ public class ImpliedTransfersMarshal {
 		}
 
 		final List<BalanceChange> changes = new ArrayList<>();
-		final List<Pair<EntityId, List<CustomFee>>> entityCustomFees = new ArrayList<>();
+		final List<Pair<Id, List<CustomFee>>> entityCustomFees = new ArrayList<>();
 		List<AssessedCustomFee> assessedCustomFeesForRecord = new ArrayList<>();
-		Map<Pair<EntityId, EntityId>, BalanceChange> existingBalanceChanges = new HashMap<>();
+		Map<Pair<Id, Id>, BalanceChange> existingBalanceChanges = new HashMap<>();
 		for (var aa : op.getTransfers().getAccountAmountsList()) {
 			BalanceChange change = hbarAdjust(aa);
 			changes.add(change);
-			existingBalanceChanges.put(Pair.of(change.getAccount(), EntityId.MISSING_ENTITY_ID), change);
+			existingBalanceChanges.put(Pair.of(change.getAccount(), MISSING_ID), change);
 		}
-		var payerId = EntityId.fromGrpcAccountId(payer);
+		var payerId = Id.fromGrpcAccount(payer);
 		for (var scopedTransfers : op.getTokenTransfersList()) {
 			final var grpcTokenId = scopedTransfers.getToken();
-			final var scopingToken = EntityId.fromGrpcTokenId(grpcTokenId);
+			final var scopingToken = Id.fromGrpcToken(grpcTokenId);
 			var amount = 0L;
 			for (var aa : scopedTransfers.getTransfersList()) {
 				BalanceChange tokenChange = tokenAdjust(scopingToken, grpcTokenId, aa);
@@ -98,7 +99,7 @@ public class ImpliedTransfersMarshal {
 				}
 			}
 
-			List<CustomFee> customFeesOfToken = customFeeSchedules.lookupScheduleFor(scopingToken);
+			List<CustomFee> customFeesOfToken = customFeeSchedules.lookupScheduleFor(scopingToken.asEntityId());
 			entityCustomFees.add(Pair.of(scopingToken, customFeesOfToken));
 			List<BalanceChange> customFeeChanges = computeBalanceChangeForCustomFee(scopingToken, payerId, amount,
 					customFeesOfToken, existingBalanceChanges, assessedCustomFeesForRecord);
@@ -111,10 +112,10 @@ public class ImpliedTransfersMarshal {
 	/**
 	 * Compute the balance changes for custom fees to be added to all balance changes in transfer list
 	 */
-	private List<BalanceChange> computeBalanceChangeForCustomFee(EntityId scopingToken,
-			EntityId payerId,
+	private List<BalanceChange> computeBalanceChangeForCustomFee(Id scopingToken,
+			Id payerId,
 			long totalAmount, List<CustomFee> customFeesOfToken,
-			Map<Pair<EntityId, EntityId>, BalanceChange> existingBalanceChanges,
+			Map<Pair<Id, Id>, BalanceChange> existingBalanceChanges,
 			List<AssessedCustomFee> assessedCustomFeesForRecord) {
 		List<BalanceChange> customFeeChanges = new ArrayList<>();
 		for (CustomFee fees : customFeesOfToken) {
@@ -133,9 +134,9 @@ public class ImpliedTransfersMarshal {
 	 * Calculate fractional fee balance changes for the custom fees
 	 */
 	private void addFractionalFeeBalanceChanges(CustomFee fees,
-			EntityId payerId, long totalAmount, EntityId scopingToken,
+			Id payerId, long totalAmount, Id scopingToken,
 			List<BalanceChange> customFeeChanges,
-			Map<Pair<EntityId, EntityId>, BalanceChange> existingBalanceChanges,
+			Map<Pair<Id, Id>, BalanceChange> existingBalanceChanges,
 			List<AssessedCustomFee> assessedCustomFeesForRecord) {
 		long fee =
 				(fees.getFractionalFeeSpec().getNumerator() * totalAmount / fees.getFractionalFeeSpec().getDenominator());
@@ -145,44 +146,44 @@ public class ImpliedTransfersMarshal {
 			feesToCollect = Math.min(feesToCollect, fees.getFractionalFeeSpec().getMaximumUnitsToCollect());
 		}
 
-		modifyBalanceChange(Pair.of(fees.getFeeCollector(), scopingToken),
+		modifyBalanceChange(Pair.of(fees.getFeeCollectorAsId(), scopingToken),
 				existingBalanceChanges, customFeeChanges, feesToCollect,
-				tokenAdjust(fees.getFeeCollector(), scopingToken, feesToCollect));
+				tokenAdjust(fees.getFeeCollectorAsId(), scopingToken, feesToCollect));
 
 		modifyBalanceChange(Pair.of(payerId, scopingToken),
 				existingBalanceChanges, customFeeChanges, -feesToCollect,
 				tokenAdjust(payerId, scopingToken, -feesToCollect));
 
 		assessedCustomFeesForRecord.add(new AssessedCustomFee(fees.getFeeCollector(),
-				scopingToken,
+				scopingToken.asEntityId(),
 				feesToCollect));
 	}
 
 	/**
 	 * Calculate Fixed fee balance changes for the custom fees
 	 */
-	private void addFixedFeeBalanceChanges(CustomFee fees, EntityId payerId,
+	private void addFixedFeeBalanceChanges(CustomFee fees, Id payerId,
 			List<BalanceChange> customFeeChanges,
-			Map<Pair<EntityId, EntityId>, BalanceChange> existingBalanceChanges,
+			Map<Pair<Id, Id>, BalanceChange> existingBalanceChanges,
 			List<AssessedCustomFee> assessedCustomFeesForRecord) {
 		if (fees.getFixedFeeSpec().getTokenDenomination() == null) {
-			modifyBalanceChange(Pair.of(fees.getFeeCollector(), EntityId.MISSING_ENTITY_ID),
+			modifyBalanceChange(Pair.of(fees.getFeeCollectorAsId(), MISSING_ID),
 					existingBalanceChanges, customFeeChanges, fees.getFixedFeeSpec().getUnitsToCollect(),
-					hbarAdjust(fees.getFeeCollector(), fees.getFixedFeeSpec().getUnitsToCollect()));
+					hbarAdjust(fees.getFeeCollectorAsId(), fees.getFixedFeeSpec().getUnitsToCollect()));
 
-			modifyBalanceChange(Pair.of(payerId, EntityId.MISSING_ENTITY_ID),
+			modifyBalanceChange(Pair.of(payerId, MISSING_ID),
 					existingBalanceChanges, customFeeChanges, -fees.getFixedFeeSpec().getUnitsToCollect(),
 					hbarAdjust(payerId, -fees.getFixedFeeSpec().getUnitsToCollect()));
 			assessedCustomFeesForRecord.add(new AssessedCustomFee(fees.getFeeCollector(),
 					null, fees.getFixedFeeSpec().getUnitsToCollect()));
 		} else {
-			modifyBalanceChange(Pair.of(fees.getFeeCollector(), fees.getFixedFeeSpec().getTokenDenomination()),
+			modifyBalanceChange(Pair.of(fees.getFeeCollectorAsId(), fees.getFixedFeeSpec().getTokenDenomination().asId()),
 					existingBalanceChanges, customFeeChanges, fees.getFixedFeeSpec().getUnitsToCollect(),
-					tokenAdjust(fees.getFeeCollector(), fees.getFixedFeeSpec().getTokenDenomination(),
+					tokenAdjust(fees.getFeeCollectorAsId(), fees.getFixedFeeSpec().getTokenDenomination().asId(),
 							fees.getFixedFeeSpec().getUnitsToCollect()));
-			modifyBalanceChange(Pair.of(payerId, fees.getFixedFeeSpec().getTokenDenomination()),
+			modifyBalanceChange(Pair.of(payerId, fees.getFixedFeeSpec().getTokenDenomination().asId()),
 					existingBalanceChanges, customFeeChanges, -fees.getFixedFeeSpec().getUnitsToCollect(),
-					tokenAdjust(payerId, fees.getFixedFeeSpec().getTokenDenomination(),
+					tokenAdjust(payerId, fees.getFixedFeeSpec().getTokenDenomination().asId(),
 							-fees.getFixedFeeSpec().getUnitsToCollect()));
 			assessedCustomFeesForRecord.add(new AssessedCustomFee(fees.getFeeCollector(),
 					fees.getFixedFeeSpec().getTokenDenomination(),
@@ -194,8 +195,8 @@ public class ImpliedTransfersMarshal {
 	 * Modify the units if the key is already present in the existing balance changes map.
 	 * If not add a new balance change to the map.
 	 */
-	private void modifyBalanceChange(Pair<EntityId, EntityId> pair,
-			Map<Pair<EntityId, EntityId>, BalanceChange> existingBalanceChanges,
+	private void modifyBalanceChange(Pair<Id, Id> pair,
+			Map<Pair<Id, Id>, BalanceChange> existingBalanceChanges,
 			List<BalanceChange> customFeeChanges, long fees,
 			BalanceChange customFee) {
 		boolean isPresent = adjustUnitsIfKeyPresent(pair, existingBalanceChanges, fees);
@@ -207,8 +208,8 @@ public class ImpliedTransfersMarshal {
 	 * Add balance change object to the existing balance changes map only if the key is not present
 	 */
 	private void addBalanceChangeIfNotPresent(boolean isPresent, List<BalanceChange> customFeeChanges,
-			Map<Pair<EntityId, EntityId>, BalanceChange> existingBalanceChanges,
-			Pair<EntityId, EntityId> pair, BalanceChange customFee) {
+			Map<Pair<Id, Id>, BalanceChange> existingBalanceChanges,
+			Pair<Id, Id> pair, BalanceChange customFee) {
 		if (!isPresent) {
 			customFeeChanges.add(customFee);
 			existingBalanceChanges.put(pair, customFee);
@@ -219,8 +220,8 @@ public class ImpliedTransfersMarshal {
 	 * If the key is already present in existing balance chance changes map , modify the units of balance change
 	 * by adding the new fees
 	 */
-	private boolean adjustUnitsIfKeyPresent(Pair<EntityId, EntityId> key,
-			Map<Pair<EntityId, EntityId>, BalanceChange> existingBalanceChanges, long fees) {
+	private boolean adjustUnitsIfKeyPresent(Pair<Id, Id> key,
+			Map<Pair<Id, Id>, BalanceChange> existingBalanceChanges, long fees) {
 		if (existingBalanceChanges.containsKey(key)) {
 			var balChange = existingBalanceChanges.get(key);
 			balChange.adjustUnits(fees);

--- a/hedera-node/src/main/java/com/hedera/services/grpc/marshalling/ImpliedTransfersMarshal.java
+++ b/hedera-node/src/main/java/com/hedera/services/grpc/marshalling/ImpliedTransfersMarshal.java
@@ -230,7 +230,9 @@ public class ImpliedTransfersMarshal {
 		if (existingBalanceChanges.containsKey(key)) {
 			var balChange = existingBalanceChanges.get(key);
 			balChange.adjustUnits(fees);
-			balChange.setCodeForInsufficientBalance(INSUFFICIENT_PAYER_BALANCE_FOR_CUSTOM_FEE);
+			if (isPayer) {
+				balChange.setCodeForInsufficientBalance(INSUFFICIENT_PAYER_BALANCE_FOR_CUSTOM_FEE);
+			}
 			return true;
 		}
 		return false;

--- a/hedera-node/src/main/java/com/hedera/services/grpc/marshalling/ImpliedTransfersMeta.java
+++ b/hedera-node/src/main/java/com/hedera/services/grpc/marshalling/ImpliedTransfersMeta.java
@@ -23,7 +23,7 @@ package com.hedera.services.grpc.marshalling;
 import com.google.common.base.MoreObjects;
 import com.hedera.services.context.properties.GlobalDynamicProperties;
 import com.hedera.services.state.submerkle.CustomFee;
-import com.hedera.services.state.submerkle.EntityId;
+import com.hedera.services.store.models.Id;
 import com.hedera.services.txns.customfees.CustomFeeSchedules;
 import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
 import com.swirlds.common.SwirldDualState;
@@ -52,13 +52,13 @@ public class ImpliedTransfersMeta {
 	private final int maxExplicitHbarAdjusts;
 	private final int maxExplicitTokenAdjusts;
 	private final ResponseCodeEnum code;
-	private final List<Pair<EntityId, List<CustomFee>>> customFeeSchedulesUsedInMarshal;
+	private final List<Pair<Id, List<CustomFee>>> customFeeSchedulesUsedInMarshal;
 
 	public ImpliedTransfersMeta(
 			int maxExplicitHbarAdjusts,
 			int maxExplicitTokenAdjusts,
 			ResponseCodeEnum code,
-			List<Pair<EntityId, List<CustomFee>>> customFeeSchedulesUsedInMarshal
+			List<Pair<Id, List<CustomFee>>> customFeeSchedulesUsedInMarshal
 	) {
 		this.code = code;
 		this.maxExplicitHbarAdjusts = maxExplicitHbarAdjusts;
@@ -74,7 +74,7 @@ public class ImpliedTransfersMeta {
 		}
 		for (var pair : customFeeSchedulesUsedInMarshal) {
 			var customFees = pair.getValue();
-			var newCustomFees = customFeeSchedules.lookupScheduleFor(pair.getKey());
+			var newCustomFees = customFeeSchedules.lookupScheduleFor(pair.getKey().asEntityId());
 			if (!customFees.equals(newCustomFees)) {
 				return false;
 			}

--- a/hedera-node/src/main/java/com/hedera/services/ledger/BalanceChange.java
+++ b/hedera-node/src/main/java/com/hedera/services/ledger/BalanceChange.java
@@ -156,6 +156,7 @@ public class BalanceChange {
 				.add("token", token == null ? "ℏ" : token)
 				.add("account", account)
 				.add("units", units)
+				.add("codeForInsufficientBalance", codeForInsufficientBalance)
 				.toString();
 	}
 

--- a/hedera-node/src/main/java/com/hedera/services/ledger/BalanceChange.java
+++ b/hedera-node/src/main/java/com/hedera/services/ledger/BalanceChange.java
@@ -53,7 +53,6 @@ public class BalanceChange {
 	private Id account;
 	private long units;
 	private ResponseCodeEnum codeForInsufficientBalance;
-
 	private long newBalance;
 	private TokenID tokenId = null;
 	private AccountID accountId;
@@ -158,5 +157,9 @@ public class BalanceChange {
 				.add("account", account)
 				.add("units", units)
 				.toString();
+	}
+
+	public void setCodeForInsufficientBalance(ResponseCodeEnum codeForInsufficientBalance) {
+		this.codeForInsufficientBalance = codeForInsufficientBalance;
 	}
 }

--- a/hedera-node/src/main/java/com/hedera/services/ledger/BalanceChange.java
+++ b/hedera-node/src/main/java/com/hedera/services/ledger/BalanceChange.java
@@ -21,7 +21,7 @@ package com.hedera.services.ledger;
  */
 
 import com.google.common.base.MoreObjects;
-import com.hedera.services.state.submerkle.EntityId;
+import com.hedera.services.store.models.Id;
 import com.hederahashgraph.api.proto.java.AccountAmount;
 import com.hederahashgraph.api.proto.java.AccountID;
 import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
@@ -48,9 +48,9 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INSUFFICIENT_T
 public class BalanceChange {
 	static final TokenID NO_TOKEN_FOR_HBAR_ADJUST = TokenID.getDefaultInstance();
 
-	private EntityId token;
+	private Id token;
 
-	private EntityId account;
+	private Id account;
 	private long units;
 	private ResponseCodeEnum codeForInsufficientBalance;
 
@@ -58,20 +58,20 @@ public class BalanceChange {
 	private TokenID tokenId = null;
 	private AccountID accountId;
 
-	private BalanceChange(final EntityId token, final AccountAmount aa, final ResponseCodeEnum code) {
+	private BalanceChange(final Id token, final AccountAmount aa, final ResponseCodeEnum code) {
 		this.token = token;
 		final var account = aa.getAccountID();
 		this.accountId = account;
-		final var id = EntityId.fromGrpcAccountId(account);
+		final var id = Id.fromGrpcAccount(account);
 		this.account = id;
 		this.units = aa.getAmount();
 		this.codeForInsufficientBalance = code;
 	}
 
-	private BalanceChange(final EntityId account, final long amount, final ResponseCodeEnum code) {
+	private BalanceChange(final Id account, final long amount, final ResponseCodeEnum code) {
 		this.token = null;
 		this.account = account;
-		this.accountId = account.toGrpcAccountId();
+		this.accountId = account.asGrpcAccount();
 		this.units = amount;
 		this.codeForInsufficientBalance = code;
 	}
@@ -84,20 +84,20 @@ public class BalanceChange {
 		return new BalanceChange(null, aa, INSUFFICIENT_ACCOUNT_BALANCE);
 	}
 
-	public static BalanceChange hbarAdjust(final EntityId id, long amount) {
+	public static BalanceChange hbarAdjust(final Id id, long amount) {
 		return new BalanceChange(id, amount, INSUFFICIENT_ACCOUNT_BALANCE);
 	}
 
-	public static BalanceChange tokenAdjust(final EntityId token, final TokenID tokenId, final AccountAmount aa) {
+	public static BalanceChange tokenAdjust(final Id token, final TokenID tokenId, final AccountAmount aa) {
 		final var tokenChange = new BalanceChange(token, aa, INSUFFICIENT_TOKEN_BALANCE);
 		tokenChange.tokenId = tokenId;
 		return tokenChange;
 	}
 
-	public static BalanceChange tokenAdjust(final EntityId account, final EntityId token,  final long amount) {
+	public static BalanceChange tokenAdjust(final Id account, final Id token,  final long amount) {
 		final var tokenChange = new BalanceChange(account, amount, INSUFFICIENT_TOKEN_BALANCE);
 		tokenChange.token = token;
-		tokenChange.tokenId = token.toGrpcTokenId();
+		tokenChange.tokenId = token.asGrpcToken();
 		return tokenChange;
 	}
 
@@ -125,11 +125,11 @@ public class BalanceChange {
 		return accountId;
 	}
 
-	public EntityId getAccount() {
+	public Id getAccount() {
 		return account;
 	}
 
-	public EntityId getToken() {
+	public Id getToken() {
 		return token;
 	}
 

--- a/hedera-node/src/main/java/com/hedera/services/state/submerkle/CustomFee.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/submerkle/CustomFee.java
@@ -22,6 +22,7 @@ package com.hedera.services.state.submerkle;
 
 import com.google.common.base.MoreObjects;
 import com.google.protobuf.UInt64Value;
+import com.hedera.services.store.models.Id;
 import com.hederahashgraph.api.proto.java.Fraction;
 import com.swirlds.common.io.SelfSerializable;
 import com.swirlds.common.io.SerializableDataInputStream;
@@ -158,6 +159,10 @@ public class CustomFee implements SelfSerializable {
 
 	public EntityId getFeeCollector() {
 		return feeCollector;
+	}
+
+	public Id getFeeCollectorAsId() {
+		return feeCollector.asId();
 	}
 
 	public FeeType getFeeType() {

--- a/hedera-node/src/main/java/com/hedera/services/state/submerkle/EntityId.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/submerkle/EntityId.java
@@ -221,4 +221,8 @@ public class EntityId implements SelfSerializable {
 	public MerkleEntityId asMerkle() {
 		return new MerkleEntityId(shard, realm, num);
 	}
+
+	public Id asId() {
+		return new Id(shard, realm, num);
+	}
 }

--- a/hedera-node/src/main/java/com/hedera/services/store/models/Id.java
+++ b/hedera-node/src/main/java/com/hedera/services/store/models/Id.java
@@ -21,6 +21,7 @@ package com.hedera.services.store.models;
  */
 
 import com.google.common.base.MoreObjects;
+import com.hedera.services.state.submerkle.EntityId;
 import com.hederahashgraph.api.proto.java.AccountID;
 import com.hederahashgraph.api.proto.java.TokenID;
 
@@ -31,6 +32,8 @@ public class Id {
 	private final long shard;
 	private final long realm;
 	private final long num;
+
+	public static final Id MISSING_ID = new Id(0, 0, 0);
 
 	public Id(long shard, long realm, long num) {
 		this.shard = shard;
@@ -101,5 +104,9 @@ public class Id {
 				.add("realm", realm)
 				.add("num", num)
 				.toString();
+	}
+
+	public EntityId asEntityId() {
+		return new EntityId(shard, realm, num);
 	}
 }

--- a/hedera-node/src/test/java/com/hedera/services/ledger/BalanceChangeTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/ledger/BalanceChangeTest.java
@@ -9,9 +9,9 @@ package com.hedera.services.ledger;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -44,9 +44,10 @@ class BalanceChangeTest {
 		final var hbarChange = IdUtils.hbarChange(a, delta);
 		final var tokenChange = IdUtils.tokenChange(t, a, delta);
 		// and:
-		final var hbarRepr = "BalanceChange{token=ℏ, account=Id{shard=1, realm=2, num=3}, units=-1234}";
-		final var tokenRepr = "BalanceChange{token=Id{shard=1, realm=2, num=3}, " +
-				"account=Id{shard=1, realm=2, num=3}, units=-1234}";
+		final var hbarRepr = "BalanceChange{token=ℏ, account=Id{shard=1, realm=2, num=3}, units=-1234, " +
+				"codeForInsufficientBalance=INSUFFICIENT_ACCOUNT_BALANCE}";
+		final var tokenRepr = "BalanceChange{token=Id{shard=1, realm=2, num=3}, account=Id{shard=1, realm=2, num=3}, " +
+				"units=-1234, codeForInsufficientBalance=INSUFFICIENT_TOKEN_BALANCE}";
 
 		// expect:
 		assertNotEquals(hbarChange, tokenChange);

--- a/hedera-node/src/test/java/com/hedera/services/ledger/BalanceChangeTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/ledger/BalanceChangeTest.java
@@ -20,7 +20,7 @@ package com.hedera.services.ledger;
  * ‍
  */
 
-import com.hedera.services.state.submerkle.EntityId;
+import com.hedera.services.store.models.Id;
 import com.hedera.test.utils.IdUtils;
 import com.hederahashgraph.api.proto.java.AccountID;
 import org.junit.jupiter.api.Test;
@@ -36,7 +36,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class BalanceChangeTest {
 	private final AccountID a = asAccount("1.2.3");
 	private final long delta = -1_234L;
-	private final EntityId t = new EntityId(1, 2, 3);
+	private final Id t = new Id(1, 2, 3);
 
 	@Test
 	void objectContractSanityChecks() {
@@ -44,9 +44,9 @@ class BalanceChangeTest {
 		final var hbarChange = IdUtils.hbarChange(a, delta);
 		final var tokenChange = IdUtils.tokenChange(t, a, delta);
 		// and:
-		final var hbarRepr = "BalanceChange{token=ℏ, account=EntityId{shard=1, realm=2, num=3}, units=-1234}";
-		final var tokenRepr = "BalanceChange{token=EntityId{shard=1, realm=2, num=3}, " +
-				"account=EntityId{shard=1, realm=2, num=3}, units=-1234}";
+		final var hbarRepr = "BalanceChange{token=ℏ, account=Id{shard=1, realm=2, num=3}, units=-1234}";
+		final var tokenRepr = "BalanceChange{token=Id{shard=1, realm=2, num=3}, " +
+				"account=Id{shard=1, realm=2, num=3}, units=-1234}";
 
 		// expect:
 		assertNotEquals(hbarChange, tokenChange);
@@ -57,7 +57,7 @@ class BalanceChangeTest {
 		// and:
 		assertSame(a, hbarChange.accountId());
 		assertEquals(delta, hbarChange.units());
-		assertEquals(t.toGrpcTokenId(), tokenChange.tokenId());
+		assertEquals(t.asGrpcToken(), tokenChange.tokenId());
 	}
 
 	@Test

--- a/hedera-node/src/test/java/com/hedera/services/ledger/ImpliedTransfersMarshalTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/ledger/ImpliedTransfersMarshalTest.java
@@ -27,6 +27,7 @@ import com.hedera.services.grpc.marshalling.ImpliedTransfersMeta;
 import com.hedera.services.state.submerkle.AssessedCustomFee;
 import com.hedera.services.state.submerkle.CustomFee;
 import com.hedera.services.state.submerkle.EntityId;
+import com.hedera.services.store.models.Id;
 import com.hedera.services.txns.customfees.CustomFeeSchedules;
 import com.hederahashgraph.api.proto.java.AccountID;
 import com.hederahashgraph.api.proto.java.CryptoTransferTransactionBody;
@@ -81,9 +82,9 @@ class ImpliedTransfersMarshalTest {
 	private final AccountID bModel = asAccount("2.3.4");
 	private final AccountID cModel = asAccount("3.4.5");
 	private final AccountID payer = asAccount("5.6.7");
-	private final EntityId token = new EntityId(0, 0, 75231);
-	private final EntityId anotherToken = new EntityId(0, 0, 75232);
-	private final EntityId yetAnotherToken = new EntityId(0, 0, 75233);
+	private final Id token = new Id(0, 0, 75231);
+	private final Id anotherToken = new Id(0, 0, 75232);
+	private final Id yetAnotherToken = new Id(0, 0, 75233);
 	private final TokenID anId = asToken("0.0.75231");
 	private final TokenID anotherId = asToken("0.0.75232");
 	private final TokenID yetAnotherId = asToken("0.0.75233");
@@ -109,8 +110,8 @@ class ImpliedTransfersMarshalTest {
 
 	private final EntityId customFeeToken = new EntityId(0, 0, 123);
 	private final EntityId customFeeCollector = new EntityId(0, 0, 124);
-	final List<Pair<EntityId, List<CustomFee>>> entityCustomFees = List.of(
-			Pair.of(customFeeToken, new ArrayList<>()));
+	final List<Pair<Id, List<CustomFee>>> entityCustomFees = List.of(
+			Pair.of(customFeeToken.asId(), new ArrayList<>()));
 	final List<Pair<EntityId, List<CustomFee>>> newCustomFeeChanges = List.of(
 			Pair.of(customFeeToken, List.of(CustomFee.fixedFee(10L, customFeeToken, customFeeCollector))));
 	private final List<AssessedCustomFee> assessedCustomFees = List.of(
@@ -171,7 +172,7 @@ class ImpliedTransfersMarshalTest {
 				}
 		);
 		final List<CustomFee> customFee = getFixedCustomFee();
-		final List<Pair<EntityId, List<CustomFee>>> expectedCustomFeeChanges =
+		final List<Pair<Id, List<CustomFee>>> expectedCustomFeeChanges =
 				List.of(Pair.of(anotherToken, customFee),
 						Pair.of(token, customFee),
 						Pair.of(yetAnotherToken, customFee));
@@ -210,7 +211,7 @@ class ImpliedTransfersMarshalTest {
 		final var twoMeta = new ImpliedTransfersMeta(1, 2, TOKEN_WAS_DELETED, Collections.emptyList());
 		// and:
 		final var oneRepr = "ImpliedTransfersMeta{code=OK, maxExplicitHbarAdjusts=3, " +
-				"maxExplicitTokenAdjusts=4, customFeeSchedulesUsedInMarshal=[(EntityId{shard=0, realm=0, num=123},[])" +
+				"maxExplicitTokenAdjusts=4, customFeeSchedulesUsedInMarshal=[(Id{shard=0, realm=0, num=123},[])" +
 				"]}";
 		final var twoRepr = "ImpliedTransfersMeta{code=TOKEN_WAS_DELETED, " +
 				"maxExplicitHbarAdjusts=1, maxExplicitTokenAdjusts=2, customFeeSchedulesUsedInMarshal=[]}";
@@ -227,7 +228,7 @@ class ImpliedTransfersMarshalTest {
 	void impliedXfersObjectContractSanityChecks() {
 		// given:
 		final var twoChanges = List.of(tokenChange(
-				new EntityId(1, 2, 3),
+				new Id(1, 2, 3),
 				asAccount("4.5.6"),
 				7));
 		final var oneImpliedXfers = ImpliedTransfers.invalid(3, 4, TOKEN_WAS_DELETED);
@@ -240,11 +241,11 @@ class ImpliedTransfersMarshalTest {
 				" " +
 				"involvedTokenFeeSchedules=[], assessedCustomFees=[]}";
 		final var twoRepr = "ImpliedTransfers{meta=ImpliedTransfersMeta{code=OK, maxExplicitHbarAdjusts=1, " +
-				"maxExplicitTokenAdjusts=100, customFeeSchedulesUsedInMarshal=[(EntityId{shard=0, realm=0, num=123},[])" +
+				"maxExplicitTokenAdjusts=100, customFeeSchedulesUsedInMarshal=[(Id{shard=0, realm=0, num=123},[])" +
 				"]}, " +
-				"changes=[BalanceChange{token=EntityId{shard=1, realm=2, num=3}, account=EntityId{shard=4, realm=5, " +
+				"changes=[BalanceChange{token=Id{shard=1, realm=2, num=3}, account=Id{shard=4, realm=5, " +
 				"num=6}, " +
-				"units=7}], involvedTokenFeeSchedules=[(EntityId{shard=0, realm=0, num=123},[])]," +
+				"units=7}], involvedTokenFeeSchedules=[(Id{shard=0, realm=0, num=123},[])]," +
 				" assessedCustomFees=[AssessedCustomFee{token=EntityId{shard=0, realm=0, num=123}, " +
 				"account=EntityId{shard=0, realm=0, num=124}, units=123}]}";
 
@@ -305,7 +306,7 @@ class ImpliedTransfersMarshalTest {
 		final var expectedCustomFeeChanges =
 				List.of(Pair.of(anotherToken, customFee));
 		final var expectedAssessedCustomFees = List.of(
-				new AssessedCustomFee(EntityId.fromGrpcAccountId(aModel), anotherToken, expectedFractionalFee));
+				new AssessedCustomFee(EntityId.fromGrpcAccountId(aModel), anotherToken.asEntityId(), expectedFractionalFee));
 
 		// and:
 		final var expectedMeta = new ImpliedTransfersMeta(maxExplicitHbarAdjusts, maxExplicitTokenAdjusts,
@@ -364,7 +365,7 @@ class ImpliedTransfersMarshalTest {
 		final var expectedCustomFeeChanges =
 				List.of(Pair.of(anotherToken, customFee));
 		final var expectedAssessedCustomFees = List.of(
-				new AssessedCustomFee(EntityId.fromGrpcAccountId(aModel), token, 20L));
+				new AssessedCustomFee(EntityId.fromGrpcAccountId(aModel), token.asEntityId(), 20L));
 
 		// and:
 		final var expectedMeta = new ImpliedTransfersMeta(maxExplicitHbarAdjusts, maxExplicitTokenAdjusts,
@@ -377,7 +378,7 @@ class ImpliedTransfersMarshalTest {
 				maxExplicitTokenAdjusts,
 				op.getTransfers(),
 				op.getTokenTransfersList())).willReturn(OK);
-		given(customFeeSchedules.lookupScheduleFor(anotherToken)).willReturn(customFee);
+		given(customFeeSchedules.lookupScheduleFor(anotherToken.asEntityId())).willReturn(customFee);
 
 		// when:
 		final var result = subject.unmarshalFromGrpc(op, payer);
@@ -427,7 +428,7 @@ class ImpliedTransfersMarshalTest {
 
 	private List<CustomFee> getFixedCustomFeeNonNullDenom() {
 		return List.of(
-				CustomFee.fixedFee(20L, token, feeCollector)
+				CustomFee.fixedFee(20L, token.asEntityId(), feeCollector)
 		);
 	}
 

--- a/hedera-node/src/test/java/com/hedera/services/ledger/LedgerBalanceChangesTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/ledger/LedgerBalanceChangesTest.java
@@ -396,16 +396,16 @@ class LedgerBalanceChangesTest {
 
 	private List<BalanceChange> fixtureChanges() {
 		final var ans = List.of(new BalanceChange[] {
-						tokenChange(yetAnotherToken, aModel, aYetAnotherTokenChange),
+						tokenChange(yetAnotherToken.asId(), aModel, aYetAnotherTokenChange),
 						hbarChange(aModel, aHbarChange),
 						hbarChange(bModel, bHbarChange),
-						tokenChange(anotherToken, aModel, aAnotherTokenChange),
-						tokenChange(anotherToken, cModel, cAnotherTokenChange),
+						tokenChange(anotherToken.asId(), aModel, aAnotherTokenChange),
+						tokenChange(anotherToken.asId(), cModel, cAnotherTokenChange),
 						hbarChange(cModel, cHbarChange),
-						tokenChange(token, bModel, bTokenChange),
-						tokenChange(token, cModel, cTokenChange),
-						tokenChange(anotherToken, bModel, bAnotherTokenChange),
-						tokenChange(yetAnotherToken, bModel, bYetAnotherTokenChange),
+						tokenChange(token.asId(), bModel, bTokenChange),
+						tokenChange(token.asId(), cModel, cTokenChange),
+						tokenChange(anotherToken.asId(), bModel, bAnotherTokenChange),
+						tokenChange(yetAnotherToken.asId(), bModel, bYetAnotherTokenChange),
 				}
 		);
 		return ans;

--- a/hedera-node/src/test/java/com/hedera/services/txns/crypto/CryptoTransferTransitionLogicTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/txns/crypto/CryptoTransferTransitionLogicTest.java
@@ -26,9 +26,9 @@ import com.hedera.services.grpc.marshalling.ImpliedTransfers;
 import com.hedera.services.grpc.marshalling.ImpliedTransfersMarshal;
 import com.hedera.services.ledger.HederaLedger;
 import com.hedera.services.ledger.PureTransferSemanticChecks;
-import com.hedera.services.state.submerkle.CustomFee;
 import com.hedera.services.state.submerkle.AssessedCustomFee;
-import com.hedera.services.state.submerkle.EntityId;
+import com.hedera.services.state.submerkle.CustomFee;
+import com.hedera.services.store.models.Id;
 import com.hedera.services.txns.span.ExpandHandleSpanMapAccessor;
 import com.hedera.services.utils.PlatformTxnAccessor;
 import com.hederahashgraph.api.proto.java.AccountID;
@@ -156,19 +156,19 @@ class CryptoTransferTransitionLogicTest {
 	@Test
 	void verifyIfAssessedCustomFeesSet() {
 		// setup :
-		final var a = EntityId.fromGrpcAccountId(asAccount("1.2.3"));
-		final var b = EntityId.fromGrpcAccountId(asAccount("2.3.4"));
-		final var c = EntityId.fromGrpcTokenId(asToken("4.5.6"));
+		final var a = Id.fromGrpcAccount(asAccount("1.2.3"));
+		final var b = Id.fromGrpcAccount(asAccount("2.3.4"));
+		final var c = Id.fromGrpcToken(asToken("4.5.6"));
 
 		// and :
 		final var customFeesBalanceChange = List.of(
-				new AssessedCustomFee(a, 10L));
-		final var customFee = List.of(CustomFee.fixedFee(20L, null, a));
-		final List<Pair<EntityId, List<CustomFee>>> customFees = List.of(Pair.of(c, customFee));
+				new AssessedCustomFee(a.asEntityId(), 10L));
+		final var customFee = List.of(CustomFee.fixedFee(20L, null, a.asEntityId()));
+		final List<Pair<Id, List<CustomFee>>> customFees = List.of(Pair.of(c, customFee));
 		final var impliedTransfers = ImpliedTransfers.valid(
 				maxHbarAdjusts, maxTokenAdjusts, List.of(
-						hbarChange(a.toGrpcAccountId(), +100),
-						hbarChange(b.toGrpcAccountId(), -100)
+						hbarChange(a.asGrpcAccount(), +100),
+						hbarChange(b.asGrpcAccount(), -100)
 				),
 				customFees,
 				customFeesBalanceChange);

--- a/hedera-node/src/test/java/com/hedera/services/txns/span/SpanMapManagerTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/txns/span/SpanMapManagerTest.java
@@ -25,7 +25,7 @@ import com.hedera.services.grpc.marshalling.ImpliedTransfers;
 import com.hedera.services.grpc.marshalling.ImpliedTransfersMarshal;
 import com.hedera.services.state.submerkle.AssessedCustomFee;
 import com.hedera.services.state.submerkle.CustomFee;
-import com.hedera.services.state.submerkle.EntityId;
+import com.hedera.services.store.models.Id;
 import com.hedera.services.txns.customfees.CustomFeeSchedules;
 import com.hedera.services.utils.TxnAccessor;
 import com.hederahashgraph.api.proto.java.TransactionBody;
@@ -59,14 +59,15 @@ class SpanMapManagerTest {
 	private final ImpliedTransfers someOtherImpliedXfers = ImpliedTransfers.invalid(
 			maxHbarAdjusts, maxTokenAdjusts + 1, ACCOUNT_REPEATED_IN_ACCOUNT_AMOUNTS);
 
-	private final EntityId customFeeToken = new EntityId(0, 0, 123);
-	private final EntityId customFeeCollector = new EntityId(0, 0, 124);
-	final List<Pair<EntityId, List<CustomFee>>> entityCustomFees = List.of(
+	private final Id customFeeToken = new Id(0, 0, 123);
+	private final Id customFeeCollector = new Id(0, 0, 124);
+	final List<Pair<Id, List<CustomFee>>> entityCustomFees = List.of(
 			Pair.of(customFeeToken, new ArrayList<>()));
-	final List<Pair<EntityId, List<CustomFee>>> newCustomFeeChanges = List.of(
-			Pair.of(customFeeToken, List.of(CustomFee.fixedFee(10L, customFeeToken, customFeeCollector))));
+	final List<Pair<Id, List<CustomFee>>> newCustomFeeChanges = List.of(
+			Pair.of(customFeeToken, List.of(CustomFee.fixedFee(10L, customFeeToken.asEntityId(),
+					customFeeCollector.asEntityId()))));
 	private final List<AssessedCustomFee> assessedCustomFees = List.of(
-			new AssessedCustomFee(customFeeCollector, customFeeToken, 123L));
+			new AssessedCustomFee(customFeeCollector.asEntityId(), customFeeToken.asEntityId(), 123L));
 	private final ImpliedTransfers validImpliedTransfers = ImpliedTransfers.valid(
 			maxHbarAdjusts, maxTokenAdjusts, new ArrayList<>(), entityCustomFees, assessedCustomFees);
 	private final ImpliedTransfers feeChangedImpliedTransfers = ImpliedTransfers.valid(

--- a/hedera-node/src/test/java/com/hedera/test/utils/IdUtils.java
+++ b/hedera-node/src/test/java/com/hedera/test/utils/IdUtils.java
@@ -24,6 +24,7 @@ import com.hedera.services.ledger.BalanceChange;
 import com.hedera.services.state.merkle.MerkleEntityId;
 import com.hedera.services.state.submerkle.AssessedCustomFee;
 import com.hedera.services.state.submerkle.EntityId;
+import com.hedera.services.store.models.Id;
 import com.hederahashgraph.api.proto.java.AccountAmount;
 import com.hederahashgraph.api.proto.java.AccountID;
 import com.hederahashgraph.api.proto.java.ContractID;
@@ -131,8 +132,8 @@ public class IdUtils {
 		return BalanceChange.hbarAdjust(adjustFrom(account, amount));
 	}
 
-	public static BalanceChange tokenChange(final EntityId token, final AccountID account, final long amount) {
-		return BalanceChange.tokenAdjust(token, token.toGrpcTokenId(), adjustFrom(account, amount));
+	public static BalanceChange tokenChange(final Id token, final AccountID account, final long amount) {
+		return BalanceChange.tokenAdjust(token, token.asGrpcToken(), adjustFrom(account, amount));
 	}
 
 	public static AssessedCustomFee hbarChangeForCustomFees(final AccountID account, final long amount) {


### PR DESCRIPTION
`BalanceChange` class is modified to use `EntityId` instead of `Id` as it was previously planned to be used in `ExpirableTransactionRecord`. Since we have created a new class with `AssessedCustomFee` , reverting `Id` to beused in `BalanceChange` 