### PR TITLE
Always reset assessedCustomFees to null in AwareTransactionContext

### DIFF
--- a/hedera-node/src/main/java/com/hedera/services/context/AwareTransactionContext.java
+++ b/hedera-node/src/main/java/com/hedera/services/context/AwareTransactionContext.java
@@ -91,7 +91,7 @@ public class AwareTransactionContext implements TransactionContext {
 	private Consumer<TxnReceipt.Builder> receiptConfig = noopReceiptConfig;
 	private Consumer<ExpirableTxnRecord.Builder> recordConfig = noopRecordConfig;
 	private List<TokenTransferList> explicitTokenTransfers;
-	private List<AssessedCustomFee> customFeesCharged;
+	private List<AssessedCustomFee> assessedCustomFees;
 
 	boolean hasComputedRecordSoFar;
 	ExpirableTxnRecord.Builder recordSoFar = ExpirableTxnRecord.newBuilder();
@@ -116,6 +116,7 @@ public class AwareTransactionContext implements TransactionContext {
 		isPayerSigKnownActive = false;
 		hasComputedRecordSoFar = false;
 		explicitTokenTransfers = null;
+		assessedCustomFees = null;
 
 		ctx.narratedCharging().resetForTxn(accessor, submittingMember);
 
@@ -128,8 +129,8 @@ public class AwareTransactionContext implements TransactionContext {
 	}
 
 	@Override
-	public void setCustomFeesCharged(List<AssessedCustomFee> customFeesCharged){
-		this.customFeesCharged = customFeesCharged;
+	public void setAssessedCustomFees(List<AssessedCustomFee> assessedCustomFees){
+		this.assessedCustomFees = assessedCustomFees;
 	}
 
 	@Override
@@ -174,7 +175,7 @@ public class AwareTransactionContext implements TransactionContext {
 				receipt,
 				explicitTokenTransfers,
 				ctx,
-				customFeesCharged);
+				assessedCustomFees);
 
 		recordConfig.accept(recordSoFar);
 		hasComputedRecordSoFar = true;
@@ -307,5 +308,9 @@ public class AwareTransactionContext implements TransactionContext {
 	@Override
 	public List<ExpiringEntity> expiringEntities() {
 		return expiringEntities;
+	}
+
+	List<AssessedCustomFee> getAssessedCustomFees() {
+		return assessedCustomFees;
 	}
 }

--- a/hedera-node/src/main/java/com/hedera/services/context/TransactionContext.java
+++ b/hedera-node/src/main/java/com/hedera/services/context/TransactionContext.java
@@ -270,5 +270,5 @@ public interface TransactionContext {
 	 *
 	 * @param customFeesCharged the custom fees charged
 	 */
-	void setCustomFeesCharged(List<AssessedCustomFee> customFeesCharged);
+	void setAssessedCustomFees(List<AssessedCustomFee> customFeesCharged);
 }

--- a/hedera-node/src/main/java/com/hedera/services/txns/crypto/CryptoTransferTransitionLogic.java
+++ b/hedera-node/src/main/java/com/hedera/services/txns/crypto/CryptoTransferTransitionLogic.java
@@ -88,7 +88,7 @@ public class CryptoTransferTransitionLogic implements TransitionLogic {
 			}
 
 			txnCtx.setStatus((outcome == OK) ? SUCCESS : outcome);
-			txnCtx.setCustomFeesCharged(impliedTransfers.getAssessedCustomFees());
+			txnCtx.setAssessedCustomFees(impliedTransfers.getAssessedCustomFees());
 		} catch (Exception e) {
 			log.warn("Avoidable exception in CryptoTransfer state transition", e);
 			txnCtx.setStatus(FAIL_INVALID);

--- a/hedera-node/src/test/java/com/hedera/services/context/AwareTransactionContextTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/context/AwareTransactionContextTest.java
@@ -90,6 +90,7 @@ import static org.hamcrest.collection.IsIterableContainingInOrder.contains;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -110,10 +111,6 @@ class AwareTransactionContextTest {
 	private Instant now = Instant.now();
 	private ExchangeRate rateNow = ExchangeRate.newBuilder().setHbarEquiv(1).setCentEquiv(100).setExpirationTime(
 			TimestampSeconds.newBuilder()).build();
-	private Timestamp timeNow = Timestamp.newBuilder()
-			.setSeconds(now.getEpochSecond())
-			.setNanos(now.getNano())
-			.build();
 	private ExchangeRateSet ratesNow =
 			ExchangeRateSet.newBuilder().setCurrentRate(rateNow).setNextRate(rateNow).build();
 	private AccountID payer = asAccount("0.0.2");
@@ -290,12 +287,14 @@ class AwareTransactionContextTest {
 		subject.setCreated(contractCreated);
 		subject.payerSigIsKnownActive();
 		subject.hasComputedRecordSoFar = true;
+		subject.setAssessedCustomFees(Collections.emptyList());
 		// and:
 		assertEquals(memberId, subject.submittingSwirldsMember());
 		assertEquals(nodeAccount, subject.submittingNodeAccount());
 
 		// when:
 		subject.resetFor(accessor, now, anotherMemberId);
+		assertNull(subject.getAssessedCustomFees());
 		assertFalse(subject.hasComputedRecordSoFar);
 		// and:
 		setUpBuildingExpirableTxnRecord();

--- a/hedera-node/src/test/java/com/hedera/services/txns/crypto/CryptoTransferTransitionLogicTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/txns/crypto/CryptoTransferTransitionLogicTest.java
@@ -187,7 +187,7 @@ class CryptoTransferTransitionLogicTest {
 
 		// then:
 		verify(txnCtx).setStatus(SUCCESS);
-		verify(txnCtx).setCustomFeesCharged(customFeesBalanceChange);
+		verify(txnCtx).setAssessedCustomFees(customFeesBalanceChange);
 	}
 
 


### PR DESCRIPTION
**Related issue(s)**:
- Expected to close #1669

**Summary of the change**:
Reset `assessedCustomFees` in `AwareTransactionContext.resetFor()`.
