### PR TITLE
01680: Fix log4j2 issue that resulted in empty hgcaa.log file

### DIFF
--- a/hedera-node/configuration/dev/log4j2.xml
+++ b/hedera-node/configuration/dev/log4j2.xml
@@ -1,59 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- monitorInterval="600" , if any change to log level will be effective after 10 minute -->
 <Configuration status="WARN" monitorInterval="600">
-
-  <Filters>
-    <!-- In the following, enable a marker with onMatch="ACCEPT" and disable with onMatch="DENY". -->
-    <!-- More markers can be added, but ensure that every onMismatch="NEUTRAL", except the last is "DENY". -->
-
-    <!-- Exceptions -->
-    <MarkerFilter marker="EXCEPTION" onMatch="ACCEPT" onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="TESTING_EXCEPTIONS" onMatch="ACCEPT" onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="SOCKET_EXCEPTIONS" onMatch="ACCEPT" onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="TCP_CONNECT_EXCEPTIONS" onMatch="DENY" onMismatch="NEUTRAL"/>
-    <!-- Errors -->
-    <MarkerFilter marker="INVALID_EVENT_ERROR" onMatch="ACCEPT" onMismatch="NEUTRAL"/>
-    <!-- Other -->
-    <MarkerFilter marker="SYNC_START" onMatch="DENY" onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="SYNC_DONE" onMatch="DENY" onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="SYNC_ERROR" onMatch="DENY" onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="SYNC" onMatch="DENY" onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="CREATE_EVENT" onMatch="DENY" onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="INTAKE_EVENT" onMatch="DENY" onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="WATCH_EVENTS_SEND_REC" onMatch="DENY" onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="QUEUES" onMatch="DENY" onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="HEARTBEAT" onMatch="DENY" onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="EVENT_SIG" onMatch="DENY" onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="CERTIFICATES" onMatch="DENY" onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="FCM_COPY" onMatch="DENY" onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="FCM_COPY_FROM" onMatch="DENY" onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="FCM_COPY_TO" onMatch="DENY" onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="FCM_DEMO" onMatch="DENY" onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="FCM_COPY_FROM_DIFF" onMatch="DENY" onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="FCM_COPY_TO_DIFF" onMatch="DENY" onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="FC_SERIALIZATION" onMatch="DENY" onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="MERKLE_FORCE_FLUSH" onMatch="DENY" onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="MERKLE_HASH" onMatch="DENY" onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="MERKLE_GENERATION" onMatch="DENY" onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="MERKLE_LOCKS" onMatch="DENY" onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="LOCKS" onMatch="DENY" onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="TIME_MEASURE" onMatch="DENY" onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="STARTUP" onMatch="ACCEPT" onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="STATE_SIG_DIST" onMatch="DENY" onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="OPENCL_INIT_EXCEPTIONS" onMatch="DENY" onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="ADV_CRYPTO_SYSTEM" onMatch="DENY" onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="EVENT_STREAM" onMatch="DENY" onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="EVENT_RESTART" onMatch="DENY" onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="RECONNECT" onMatch="ACCEPT" onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="FREEZE" onMatch="ACCEPT" onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="STALE_EVENTS" onMatch="DENY" onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="SNAPSHOT_MANAGER" onMatch="ACCEPT" onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="EVENT_PARSER" onMatch="ACCEPT" onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="STATE_TO_DISK" onMatch="ACCEPT" onMismatch="NEUTRAL"/>
-
-    <MarkerFilter marker="DISABLED"               onMatch="DENY"   onMismatch="DENY" />
-  </Filters>
-
   <Appenders>
     <Console name="Console" target="SYSTEM_OUT">
       <PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss.SSS} %-5p %-4L %c{1} - %m%n"/>
@@ -95,58 +42,99 @@
 
   </Appenders>
   <Loggers>
-    <Root level="WARN">
+    <Root level="FATAL">
+      <!-- <AppenderRef ref="Console"/> -->
+      <AppenderRef ref="fileLog"/>
+    </Root>
+
+    <Logger name="com.swirlds" level="DEBUG" additivity="false">
+      <AppenderRef ref="fileLog"/>
+      <!--
+	 Due to known log4j2 issues with how Markers and LogLevels are evaluated there must be a top level <Filter> element
+	 to ensure that the root logger does not execute all the lambda arguments erroneously. Potential work around in the
+	 future is to use a top-level <Filter> and <Logger> specific filters in combination to achieve the desired
+	 multi-logger setup for diagnostic logging.
+	 -->
       <Filters>
+        <!-- Filter out levels above INFO (ex: DEBUG & TRACE) -->
+        <!-- Intentially left disabled by default -->
+        <!-- <ThresholdFilter level="INFO"                 onMatch="NEUTRAL" onMismatch="DENY" />-->
+
         <!-- In the following, enable a marker with onMatch="ACCEPT" and disable with onMatch="DENY". -->
         <!-- More markers can be added, but ensure that every onMismatch="NEUTRAL", except the last is "DENY". -->
 
         <!-- Exceptions -->
-        <MarkerFilter marker="EXCEPTION" onMatch="ACCEPT" onMismatch="NEUTRAL"/>
-        <MarkerFilter marker="TESTING_EXCEPTIONS" onMatch="ACCEPT" onMismatch="NEUTRAL"/>
-        <MarkerFilter marker="SOCKET_EXCEPTIONS" onMatch="ACCEPT" onMismatch="NEUTRAL"/>
-        <MarkerFilter marker="TCP_CONNECT_EXCEPTIONS" onMatch="DENY" onMismatch="NEUTRAL"/>
+        <MarkerFilter marker="EXCEPTION"              onMatch="ACCEPT" onMismatch="NEUTRAL"/>
+        <MarkerFilter marker="TESTING_EXCEPTIONS"     onMatch="ACCEPT" onMismatch="NEUTRAL"/>
+        <MarkerFilter marker="SOCKET_EXCEPTIONS"      onMatch="ACCEPT" onMismatch="NEUTRAL"/>
+        <MarkerFilter marker="TCP_CONNECT_EXCEPTIONS" onMatch="DENY"   onMismatch="NEUTRAL"/>
+
         <!-- Errors -->
-        <MarkerFilter marker="INVALID_EVENT_ERROR" onMatch="ACCEPT" onMismatch="NEUTRAL"/>
-        <!-- Other -->
-        <MarkerFilter marker="SYNC_START" onMatch="DENY" onMismatch="NEUTRAL"/>
-        <MarkerFilter marker="SYNC_DONE" onMatch="DENY" onMismatch="NEUTRAL"/>
-        <MarkerFilter marker="SYNC_ERROR" onMatch="DENY" onMismatch="NEUTRAL"/>
-        <MarkerFilter marker="SYNC" onMatch="DENY" onMismatch="NEUTRAL"/>
-        <MarkerFilter marker="CREATE_EVENT" onMatch="DENY" onMismatch="NEUTRAL"/>
-        <MarkerFilter marker="INTAKE_EVENT" onMatch="DENY" onMismatch="NEUTRAL"/>
-        <MarkerFilter marker="WATCH_EVENTS_SEND_REC" onMatch="DENY" onMismatch="NEUTRAL"/>
-        <MarkerFilter marker="QUEUES" onMatch="DENY" onMismatch="NEUTRAL"/>
-        <MarkerFilter marker="HEARTBEAT" onMatch="DENY" onMismatch="NEUTRAL"/>
-        <MarkerFilter marker="EVENT_SIG" onMatch="DENY" onMismatch="NEUTRAL"/>
-        <MarkerFilter marker="CERTIFICATES" onMatch="DENY" onMismatch="NEUTRAL"/>
-        <MarkerFilter marker="FCM_COPY" onMatch="DENY" onMismatch="NEUTRAL"/>
-        <MarkerFilter marker="FCM_COPY_FROM" onMatch="DENY" onMismatch="NEUTRAL"/>
-        <MarkerFilter marker="FCM_COPY_TO" onMatch="DENY" onMismatch="NEUTRAL"/>
-        <MarkerFilter marker="FCM_DEMO" onMatch="DENY" onMismatch="NEUTRAL"/>
-        <MarkerFilter marker="FCM_COPY_FROM_DIFF" onMatch="DENY" onMismatch="NEUTRAL"/>
-        <MarkerFilter marker="FCM_COPY_TO_DIFF" onMatch="DENY" onMismatch="NEUTRAL"/>
-        <MarkerFilter marker="FC_SERIALIZATION" onMatch="DENY" onMismatch="NEUTRAL"/>
-        <MarkerFilter marker="MERKLE_FORCE_FLUSH" onMatch="DENY" onMismatch="NEUTRAL"/>
-        <MarkerFilter marker="MERKLE_HASH" onMatch="DENY" onMismatch="NEUTRAL"/>
-        <MarkerFilter marker="MERKLE_GENERATION" onMatch="DENY" onMismatch="NEUTRAL"/>
-        <MarkerFilter marker="MERKLE_LOCKS" onMatch="DENY" onMismatch="NEUTRAL"/>
-        <MarkerFilter marker="LOCKS" onMatch="DENY" onMismatch="NEUTRAL"/>
-        <MarkerFilter marker="TIME_MEASURE" onMatch="DENY" onMismatch="NEUTRAL"/>
-        <MarkerFilter marker="STARTUP" onMatch="ACCEPT" onMismatch="NEUTRAL"/>
-        <MarkerFilter marker="STATE_SIG_DIST" onMatch="DENY" onMismatch="NEUTRAL"/>
-        <MarkerFilter marker="OPENCL_INIT_EXCEPTIONS" onMatch="DENY" onMismatch="NEUTRAL"/>
-        <MarkerFilter marker="ADV_CRYPTO_SYSTEM" onMatch="DENY" onMismatch="NEUTRAL"/>
-        <MarkerFilter marker="EVENT_STREAM" onMatch="DENY" onMismatch="NEUTRAL"/>
-        <MarkerFilter marker="EVENT_RESTART" onMatch="DENY" onMismatch="NEUTRAL"/>
-        <MarkerFilter marker="RECONNECT" onMatch="ACCEPT" onMismatch="NEUTRAL"/>
-        <MarkerFilter marker="FREEZE" onMatch="ACCEPT" onMismatch="NEUTRAL"/>
-        <MarkerFilter marker="STALE_EVENTS" onMatch="DENY" onMismatch="NEUTRAL"/>
-        <MarkerFilter marker="SNAPSHOT_MANAGER" onMatch="ACCEPT" onMismatch="NEUTRAL"/>
-        <MarkerFilter marker="STATE_TO_DISK" onMatch="ACCEPT" onMismatch="NEUTRAL"/>
+        <MarkerFilter marker="INVALID_EVENT_ERROR"    onMatch="ACCEPT" onMismatch="NEUTRAL"/>
+
+        <!-- Synchronization/Gossip (Debug) -->
+        <MarkerFilter marker="SYNC_START"             onMatch="DENY"   onMismatch="NEUTRAL"/>
+        <MarkerFilter marker="SYNC_DONE"              onMatch="DENY"   onMismatch="NEUTRAL"/>
+        <MarkerFilter marker="SYNC_ERROR"             onMatch="DENY"   onMismatch="NEUTRAL"/>
+        <MarkerFilter marker="SYNC"                   onMatch="DENY"   onMismatch="NEUTRAL"/>
+        <MarkerFilter marker="HEARTBEAT"              onMatch="DENY"   onMismatch="NEUTRAL"/>
+
+        <!-- Platform Events (Debug) -->
+        <MarkerFilter marker="CREATE_EVENT"           onMatch="DENY"   onMismatch="NEUTRAL"/>
+        <MarkerFilter marker="INTAKE_EVENT"           onMatch="DENY"   onMismatch="NEUTRAL"/>
+        <MarkerFilter marker="WATCH_EVENTS_SEND_REC"  onMatch="DENY"   onMismatch="NEUTRAL"/>
+        <MarkerFilter marker="EVENT_SIG"              onMatch="DENY"   onMismatch="NEUTRAL"/>
+        <MarkerFilter marker="EVENT_STREAM"           onMatch="DENY"   onMismatch="NEUTRAL"/>
+        <MarkerFilter marker="EVENT_RESTART"          onMatch="DENY"   onMismatch="NEUTRAL"/>
+        <MarkerFilter marker="STALE_EVENTS"           onMatch="DENY"   onMismatch="NEUTRAL"/>
+        <MarkerFilter marker="EVENT_PARSER"           onMatch="DENY"   onMismatch="NEUTRAL"/>
+        <MarkerFilter marker="EVENT_CONTENT"          onMatch="DENY"   onMismatch="NEUTRAL"/>
+
+        <!-- Queues/Certificates/Utilities -->
+        <MarkerFilter marker="QUEUES"                 onMatch="DENY"   onMismatch="NEUTRAL"/>
+        <MarkerFilter marker="CERTIFICATES"           onMatch="DENY"   onMismatch="NEUTRAL"/>
+        <MarkerFilter marker="LOCKS"                  onMatch="DENY"   onMismatch="NEUTRAL"/>
+        <MarkerFilter marker="TIME_MEASURE"           onMatch="DENY"   onMismatch="NEUTRAL"/>
+
+        <!-- Signed State Signatures -->
+        <MarkerFilter marker="STATE_SIG_DIST"         onMatch="DENY"   onMismatch="NEUTRAL"/>
+        <MarkerFilter marker="STATE_DELETER"          onMatch="DENY"   onMismatch="NEUTRAL"/>
+
+        <!-- Cryptography -->
+        <MarkerFilter marker="OPENCL_INIT_EXCEPTIONS" onMatch="DENY"   onMismatch="NEUTRAL"/>
+        <MarkerFilter marker="ADV_CRYPTO_SYSTEM"      onMatch="DENY"   onMismatch="NEUTRAL"/>
+
+        <!-- Startup/Restart/Reconnect -->
+        <MarkerFilter marker="STARTUP"                onMatch="ACCEPT" onMismatch="NEUTRAL"/>
+        <MarkerFilter marker="PLATFORM_STATUS"        onMatch="ACCEPT" onMismatch="NEUTRAL"/>
+        <MarkerFilter marker="RECONNECT"              onMatch="ACCEPT" onMismatch="NEUTRAL"/>
+        <MarkerFilter marker="FREEZE"                 onMatch="ACCEPT" onMismatch="NEUTRAL"/>
+
+        <!-- Saved States -->
+        <MarkerFilter marker="SNAPSHOT_MANAGER"       onMatch="ACCEPT" onMismatch="NEUTRAL"/>
+        <MarkerFilter marker="STATE_TO_DISK"          onMatch="ACCEPT" onMismatch="NEUTRAL"/>
+
+        <!-- Beta Mirror -->
+        <MarkerFilter marker="BETA_MIRROR_NODE"       onMatch="ACCEPT" onMismatch="NEUTRAL"/>
+
+        <!-- FCMap -->
+        <MarkerFilter marker="FCM_COPY"               onMatch="DENY"   onMismatch="NEUTRAL"/>
+        <MarkerFilter marker="FCM_COPY_FROM"          onMatch="DENY"   onMismatch="NEUTRAL"/>
+        <MarkerFilter marker="FCM_COPY_TO"            onMatch="DENY"   onMismatch="NEUTRAL"/>
+        <MarkerFilter marker="FCM_DEMO"               onMatch="DENY"   onMismatch="NEUTRAL"/>
+        <MarkerFilter marker="FCM_COPY_FROM_DIFF"     onMatch="DENY"   onMismatch="NEUTRAL"/>
+        <MarkerFilter marker="FCM_COPY_TO_DIFF"       onMatch="DENY"   onMismatch="NEUTRAL"/>
+        <MarkerFilter marker="FC_SERIALIZATION"       onMatch="DENY"   onMismatch="NEUTRAL"/>
+
+        <!-- Merkle Trees & Hashing -->
+        <MarkerFilter marker="MERKLE_FORCE_FLUSH"     onMatch="DENY"   onMismatch="NEUTRAL"/>
+        <MarkerFilter marker="MERKLE_HASHING"         onMatch="DENY"   onMismatch="NEUTRAL"/>
+        <MarkerFilter marker="MERKLE_GENERATION"      onMatch="DENY"   onMismatch="NEUTRAL"/>
+        <MarkerFilter marker="MERKLE_LOCKS"           onMatch="DENY"   onMismatch="NEUTRAL"/>
+
+        <MarkerFilter marker="DISABLED"               onMatch="DENY"   onMismatch="DENY" />
       </Filters>
-      <!-- <AppenderRef ref="Console"/> -->
-      <AppenderRef ref="fileLog"/>
-    </Root>
+    </Logger>
 
     <Logger name="com.hedera" level="info" additivity="false">
       <AppenderRef ref="Console"/>

--- a/hedera-node/configuration/mainnet/log4j2.xml
+++ b/hedera-node/configuration/mainnet/log4j2.xml
@@ -1,92 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- monitorInterval="600" , if any change to log level will be effective after 10 minute -->
 <Configuration status="WARN" monitorInterval="600">
-  <!--
-	  Due to known log4j2 issues with how Markers and LogLevels are evaluated there must be a top level <Filter> element
-	  to ensure that the root logger does not execute all the lambda arguments erroneously. Potential work around in the
-	  future is to use a top-level <Filter> and <Logger> specific filters in combination to achieve the desired
-	  multi-logger setup for diagnostic logging.
-	  -->
-  <Filters>
-    <!-- Filter out levels above INFO (ex: DEBUG & TRACE) -->
-    <!-- Intentially left disabled by default -->
-    <!-- <ThresholdFilter level="INFO"                 onMatch="NEUTRAL" onMismatch="DENY" />-->
-
-    <!-- In the following, enable a marker with onMatch="ACCEPT" and disable with onMatch="DENY". -->
-    <!-- More markers can be added, but ensure that every onMismatch="NEUTRAL", except the last is "DENY". -->
-
-    <!-- Exceptions -->
-    <MarkerFilter marker="EXCEPTION"              onMatch="ACCEPT" onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="TESTING_EXCEPTIONS"     onMatch="ACCEPT" onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="SOCKET_EXCEPTIONS"      onMatch="ACCEPT" onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="TCP_CONNECT_EXCEPTIONS" onMatch="DENY"   onMismatch="NEUTRAL"/>
-
-    <!-- Errors -->
-    <MarkerFilter marker="INVALID_EVENT_ERROR"    onMatch="ACCEPT" onMismatch="NEUTRAL"/>
-
-    <!-- Synchronization/Gossip (Debug) -->
-    <MarkerFilter marker="SYNC_START"             onMatch="DENY"   onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="SYNC_DONE"              onMatch="DENY"   onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="SYNC_ERROR"             onMatch="DENY"   onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="SYNC"                   onMatch="DENY"   onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="HEARTBEAT"              onMatch="DENY"   onMismatch="NEUTRAL"/>
-
-    <!-- Platform Events (Debug) -->
-    <MarkerFilter marker="CREATE_EVENT"           onMatch="DENY"   onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="INTAKE_EVENT"           onMatch="DENY"   onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="WATCH_EVENTS_SEND_REC"  onMatch="DENY"   onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="EVENT_SIG"              onMatch="DENY"   onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="EVENT_STREAM"           onMatch="DENY"   onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="EVENT_RESTART"          onMatch="DENY"   onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="STALE_EVENTS"           onMatch="DENY"   onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="EVENT_PARSER"           onMatch="DENY"   onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="EVENT_CONTENT"          onMatch="DENY"   onMismatch="NEUTRAL"/>
-
-    <!-- Queues/Certificates/Utilities -->
-    <MarkerFilter marker="QUEUES"                 onMatch="DENY"   onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="CERTIFICATES"           onMatch="DENY"   onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="LOCKS"                  onMatch="DENY"   onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="TIME_MEASURE"           onMatch="DENY"   onMismatch="NEUTRAL"/>
-
-    <!-- Signed State Signatures -->
-    <MarkerFilter marker="STATE_SIG_DIST"         onMatch="DENY"   onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="STATE_DELETER"          onMatch="DENY"   onMismatch="NEUTRAL"/>
-
-    <!-- Cryptography -->
-    <MarkerFilter marker="OPENCL_INIT_EXCEPTIONS" onMatch="DENY"   onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="ADV_CRYPTO_SYSTEM"      onMatch="DENY"   onMismatch="NEUTRAL"/>
-
-    <!-- Startup/Restart/Reconnect -->
-    <MarkerFilter marker="STARTUP"                onMatch="ACCEPT" onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="PLATFORM_STATUS"        onMatch="ACCEPT" onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="RECONNECT"              onMatch="ACCEPT" onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="FREEZE"                 onMatch="ACCEPT" onMismatch="NEUTRAL"/>
-
-    <!-- Saved States -->
-    <MarkerFilter marker="SNAPSHOT_MANAGER"       onMatch="ACCEPT" onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="STATE_TO_DISK"          onMatch="ACCEPT" onMismatch="NEUTRAL"/>
-
-    <!-- Beta Mirror -->
-    <MarkerFilter marker="BETA_MIRROR_NODE"       onMatch="ACCEPT" onMismatch="NEUTRAL"/>
-
-    <!-- FCMap -->
-    <MarkerFilter marker="FCM_COPY"               onMatch="DENY"   onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="FCM_COPY_FROM"          onMatch="DENY"   onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="FCM_COPY_TO"            onMatch="DENY"   onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="FCM_DEMO"               onMatch="DENY"   onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="FCM_COPY_FROM_DIFF"     onMatch="DENY"   onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="FCM_COPY_TO_DIFF"       onMatch="DENY"   onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="FC_SERIALIZATION"       onMatch="DENY"   onMismatch="NEUTRAL"/>
-
-    <!-- Merkle Trees & Hashing -->
-    <MarkerFilter marker="MERKLE_FORCE_FLUSH"     onMatch="DENY"   onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="MERKLE_HASHING"         onMatch="DENY"   onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="MERKLE_GENERATION"      onMatch="DENY"   onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="MERKLE_LOCKS"           onMatch="DENY"   onMismatch="NEUTRAL"/>
-
-    <MarkerFilter marker="DISABLED"               onMatch="DENY"   onMismatch="DENY" />
-  </Filters>
-
   <Appenders>
     <Console name="Console" target="SYSTEM_OUT">
       <PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss.SSS} %-5p %-4L %c{1} - %m%n"/>
@@ -128,7 +42,13 @@
 
   </Appenders>
   <Loggers>
-    <Root level="WARN">
+    <Root level="FATAL">
+      <!-- <AppenderRef ref="Console"/> -->
+      <AppenderRef ref="fileLog"/>
+    </Root>
+
+    <Logger name="com.swirlds" level="WARN" additivity="false">
+      <AppenderRef ref="fileLog" />
       <Filters>
         <!-- Filter out levels above INFO (ex: DEBUG & TRACE) -->
         <!-- Intentially left disabled by default -->
@@ -204,11 +124,11 @@
         <MarkerFilter marker="MERKLE_FORCE_FLUSH"     onMatch="DENY"   onMismatch="NEUTRAL"/>
         <MarkerFilter marker="MERKLE_HASHING"         onMatch="DENY"   onMismatch="NEUTRAL"/>
         <MarkerFilter marker="MERKLE_GENERATION"      onMatch="DENY"   onMismatch="NEUTRAL"/>
-        <MarkerFilter marker="MERKLE_LOCKS"           onMatch="DENY"   onMismatch="DENY"/>
+        <MarkerFilter marker="MERKLE_LOCKS"           onMatch="DENY"   onMismatch="NEUTRAL"/>
+
+        <MarkerFilter marker="DISABLED"               onMatch="DENY"   onMismatch="DENY" />
       </Filters>
-      <!-- <AppenderRef ref="Console"/> -->
-      <AppenderRef ref="fileLog"/>
-    </Root>
+    </Logger>
 
     <Logger name="com.hedera" level="info" additivity="false">
       <AppenderRef ref="Console"/>

--- a/hedera-node/configuration/preprod/log4j2.xml
+++ b/hedera-node/configuration/preprod/log4j2.xml
@@ -1,92 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- monitorInterval="600" , if any change to log level will be effective after 10 minute -->
 <Configuration status="WARN" monitorInterval="600">
-  <!--
-	  Due to known log4j2 issues with how Markers and LogLevels are evaluated there must be a top level <Filter> element
-	  to ensure that the root logger does not execute all the lambda arguments erroneously. Potential work around in the
-	  future is to use a top-level <Filter> and <Logger> specific filters in combination to achieve the desired
-	  multi-logger setup for diagnostic logging.
-	  -->
-  <Filters>
-    <!-- Filter out levels above INFO (ex: DEBUG & TRACE) -->
-    <!-- Intentially left disabled by default -->
-    <!-- <ThresholdFilter level="INFO"                 onMatch="NEUTRAL" onMismatch="DENY" />-->
-
-    <!-- In the following, enable a marker with onMatch="ACCEPT" and disable with onMatch="DENY". -->
-    <!-- More markers can be added, but ensure that every onMismatch="NEUTRAL", except the last is "DENY". -->
-
-    <!-- Exceptions -->
-    <MarkerFilter marker="EXCEPTION"              onMatch="ACCEPT" onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="TESTING_EXCEPTIONS"     onMatch="ACCEPT" onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="SOCKET_EXCEPTIONS"      onMatch="ACCEPT" onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="TCP_CONNECT_EXCEPTIONS" onMatch="DENY"   onMismatch="NEUTRAL"/>
-
-    <!-- Errors -->
-    <MarkerFilter marker="INVALID_EVENT_ERROR"    onMatch="ACCEPT" onMismatch="NEUTRAL"/>
-
-    <!-- Synchronization/Gossip (Debug) -->
-    <MarkerFilter marker="SYNC_START"             onMatch="DENY"   onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="SYNC_DONE"              onMatch="DENY"   onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="SYNC_ERROR"             onMatch="DENY"   onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="SYNC"                   onMatch="DENY"   onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="HEARTBEAT"              onMatch="DENY"   onMismatch="NEUTRAL"/>
-
-    <!-- Platform Events (Debug) -->
-    <MarkerFilter marker="CREATE_EVENT"           onMatch="DENY"   onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="INTAKE_EVENT"           onMatch="DENY"   onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="WATCH_EVENTS_SEND_REC"  onMatch="DENY"   onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="EVENT_SIG"              onMatch="DENY"   onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="EVENT_STREAM"           onMatch="DENY"   onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="EVENT_RESTART"          onMatch="DENY"   onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="STALE_EVENTS"           onMatch="DENY"   onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="EVENT_PARSER"           onMatch="DENY"   onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="EVENT_CONTENT"          onMatch="DENY"   onMismatch="NEUTRAL"/>
-
-    <!-- Queues/Certificates/Utilities -->
-    <MarkerFilter marker="QUEUES"                 onMatch="DENY"   onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="CERTIFICATES"           onMatch="DENY"   onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="LOCKS"                  onMatch="DENY"   onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="TIME_MEASURE"           onMatch="DENY"   onMismatch="NEUTRAL"/>
-
-    <!-- Signed State Signatures -->
-    <MarkerFilter marker="STATE_SIG_DIST"         onMatch="DENY"   onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="STATE_DELETER"          onMatch="DENY"   onMismatch="NEUTRAL"/>
-
-    <!-- Cryptography -->
-    <MarkerFilter marker="OPENCL_INIT_EXCEPTIONS" onMatch="DENY"   onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="ADV_CRYPTO_SYSTEM"      onMatch="DENY"   onMismatch="NEUTRAL"/>
-
-    <!-- Startup/Restart/Reconnect -->
-    <MarkerFilter marker="STARTUP"                onMatch="ACCEPT" onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="PLATFORM_STATUS"        onMatch="ACCEPT" onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="RECONNECT"              onMatch="ACCEPT" onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="FREEZE"                 onMatch="ACCEPT" onMismatch="NEUTRAL"/>
-
-    <!-- Saved States -->
-    <MarkerFilter marker="SNAPSHOT_MANAGER"       onMatch="ACCEPT" onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="STATE_TO_DISK"          onMatch="ACCEPT" onMismatch="NEUTRAL"/>
-
-    <!-- Beta Mirror -->
-    <MarkerFilter marker="BETA_MIRROR_NODE"       onMatch="ACCEPT" onMismatch="NEUTRAL"/>
-
-    <!-- FCMap -->
-    <MarkerFilter marker="FCM_COPY"               onMatch="DENY"   onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="FCM_COPY_FROM"          onMatch="DENY"   onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="FCM_COPY_TO"            onMatch="DENY"   onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="FCM_DEMO"               onMatch="DENY"   onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="FCM_COPY_FROM_DIFF"     onMatch="DENY"   onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="FCM_COPY_TO_DIFF"       onMatch="DENY"   onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="FC_SERIALIZATION"       onMatch="DENY"   onMismatch="NEUTRAL"/>
-
-    <!-- Merkle Trees & Hashing -->
-    <MarkerFilter marker="MERKLE_FORCE_FLUSH"     onMatch="DENY"   onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="MERKLE_HASHING"         onMatch="DENY"   onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="MERKLE_GENERATION"      onMatch="DENY"   onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="MERKLE_LOCKS"           onMatch="DENY"   onMismatch="NEUTRAL"/>
-
-    <MarkerFilter marker="DISABLED"               onMatch="DENY"   onMismatch="DENY" />
-  </Filters>
-
   <Appenders>
     <Console name="Console" target="SYSTEM_OUT">
       <PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss.SSS} %-5p %-4L %c{1} - %m%n"/>
@@ -128,7 +42,19 @@
 
   </Appenders>
   <Loggers>
-    <Root level="WARN">
+    <Root level="FATAL">
+      <!-- <AppenderRef ref="Console"/> -->
+      <AppenderRef ref="fileLog"/>
+    </Root>
+
+    <Logger name="com.swirlds" level="WARN" additivity="false">
+      <AppenderRef ref="fileLog" />
+      <!--
+	  Due to known log4j2 issues with how Markers and LogLevels are evaluated there must be a top level <Filter> element
+	  to ensure that the root logger does not execute all the lambda arguments erroneously. Potential work around in the
+	  future is to use a top-level <Filter> and <Logger> specific filters in combination to achieve the desired
+	  multi-logger setup for diagnostic logging.
+	  -->
       <Filters>
         <!-- Filter out levels above INFO (ex: DEBUG & TRACE) -->
         <!-- Intentially left disabled by default -->
@@ -204,11 +130,11 @@
         <MarkerFilter marker="MERKLE_FORCE_FLUSH"     onMatch="DENY"   onMismatch="NEUTRAL"/>
         <MarkerFilter marker="MERKLE_HASHING"         onMatch="DENY"   onMismatch="NEUTRAL"/>
         <MarkerFilter marker="MERKLE_GENERATION"      onMatch="DENY"   onMismatch="NEUTRAL"/>
-        <MarkerFilter marker="MERKLE_LOCKS"           onMatch="DENY"   onMismatch="DENY"/>
+        <MarkerFilter marker="MERKLE_LOCKS"           onMatch="DENY"   onMismatch="NEUTRAL"/>
+
+        <MarkerFilter marker="DISABLED"               onMatch="DENY"   onMismatch="DENY" />
       </Filters>
-      <!-- <AppenderRef ref="Console"/> -->
-      <AppenderRef ref="fileLog"/>
-    </Root>
+    </Logger>
 
     <Logger name="com.hedera" level="info" additivity="false">
       <AppenderRef ref="Console"/>

--- a/hedera-node/configuration/previewnet/log4j2.xml
+++ b/hedera-node/configuration/previewnet/log4j2.xml
@@ -1,92 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- monitorInterval="600" , if any change to log level will be effective after 10 minute -->
 <Configuration status="WARN" monitorInterval="600">
-  <!--
-	  Due to known log4j2 issues with how Markers and LogLevels are evaluated there must be a top level <Filter> element
-	  to ensure that the root logger does not execute all the lambda arguments erroneously. Potential work around in the
-	  future is to use a top-level <Filter> and <Logger> specific filters in combination to achieve the desired
-	  multi-logger setup for diagnostic logging.
-	  -->
-  <Filters>
-    <!-- Filter out levels above INFO (ex: DEBUG & TRACE) -->
-    <!-- Intentially left disabled by default -->
-    <!-- <ThresholdFilter level="INFO"                 onMatch="NEUTRAL" onMismatch="DENY" />-->
-
-    <!-- In the following, enable a marker with onMatch="ACCEPT" and disable with onMatch="DENY". -->
-    <!-- More markers can be added, but ensure that every onMismatch="NEUTRAL", except the last is "DENY". -->
-
-    <!-- Exceptions -->
-    <MarkerFilter marker="EXCEPTION"              onMatch="ACCEPT" onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="TESTING_EXCEPTIONS"     onMatch="ACCEPT" onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="SOCKET_EXCEPTIONS"      onMatch="ACCEPT" onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="TCP_CONNECT_EXCEPTIONS" onMatch="DENY"   onMismatch="NEUTRAL"/>
-
-    <!-- Errors -->
-    <MarkerFilter marker="INVALID_EVENT_ERROR"    onMatch="ACCEPT" onMismatch="NEUTRAL"/>
-
-    <!-- Synchronization/Gossip (Debug) -->
-    <MarkerFilter marker="SYNC_START"             onMatch="DENY"   onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="SYNC_DONE"              onMatch="DENY"   onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="SYNC_ERROR"             onMatch="DENY"   onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="SYNC"                   onMatch="DENY"   onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="HEARTBEAT"              onMatch="DENY"   onMismatch="NEUTRAL"/>
-
-    <!-- Platform Events (Debug) -->
-    <MarkerFilter marker="CREATE_EVENT"           onMatch="DENY"   onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="INTAKE_EVENT"           onMatch="DENY"   onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="WATCH_EVENTS_SEND_REC"  onMatch="DENY"   onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="EVENT_SIG"              onMatch="DENY"   onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="EVENT_STREAM"           onMatch="DENY"   onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="EVENT_RESTART"          onMatch="DENY"   onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="STALE_EVENTS"           onMatch="DENY"   onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="EVENT_PARSER"           onMatch="DENY"   onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="EVENT_CONTENT"          onMatch="DENY"   onMismatch="NEUTRAL"/>
-
-    <!-- Queues/Certificates/Utilities -->
-    <MarkerFilter marker="QUEUES"                 onMatch="DENY"   onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="CERTIFICATES"           onMatch="DENY"   onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="LOCKS"                  onMatch="DENY"   onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="TIME_MEASURE"           onMatch="DENY"   onMismatch="NEUTRAL"/>
-
-    <!-- Signed State Signatures -->
-    <MarkerFilter marker="STATE_SIG_DIST"         onMatch="DENY"   onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="STATE_DELETER"          onMatch="DENY"   onMismatch="NEUTRAL"/>
-
-    <!-- Cryptography -->
-    <MarkerFilter marker="OPENCL_INIT_EXCEPTIONS" onMatch="DENY"   onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="ADV_CRYPTO_SYSTEM"      onMatch="DENY"   onMismatch="NEUTRAL"/>
-
-    <!-- Startup/Restart/Reconnect -->
-    <MarkerFilter marker="STARTUP"                onMatch="ACCEPT" onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="PLATFORM_STATUS"        onMatch="ACCEPT" onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="RECONNECT"              onMatch="ACCEPT" onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="FREEZE"                 onMatch="ACCEPT" onMismatch="NEUTRAL"/>
-
-    <!-- Saved States -->
-    <MarkerFilter marker="SNAPSHOT_MANAGER"       onMatch="ACCEPT" onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="STATE_TO_DISK"          onMatch="ACCEPT" onMismatch="NEUTRAL"/>
-
-    <!-- Beta Mirror -->
-    <MarkerFilter marker="BETA_MIRROR_NODE"       onMatch="ACCEPT" onMismatch="NEUTRAL"/>
-
-    <!-- FCMap -->
-    <MarkerFilter marker="FCM_COPY"               onMatch="DENY"   onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="FCM_COPY_FROM"          onMatch="DENY"   onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="FCM_COPY_TO"            onMatch="DENY"   onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="FCM_DEMO"               onMatch="DENY"   onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="FCM_COPY_FROM_DIFF"     onMatch="DENY"   onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="FCM_COPY_TO_DIFF"       onMatch="DENY"   onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="FC_SERIALIZATION"       onMatch="DENY"   onMismatch="NEUTRAL"/>
-
-    <!-- Merkle Trees & Hashing -->
-    <MarkerFilter marker="MERKLE_FORCE_FLUSH"     onMatch="DENY"   onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="MERKLE_HASHING"         onMatch="DENY"   onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="MERKLE_GENERATION"      onMatch="DENY"   onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="MERKLE_LOCKS"           onMatch="DENY"   onMismatch="NEUTRAL"/>
-
-    <MarkerFilter marker="DISABLED"               onMatch="DENY"   onMismatch="DENY" />
-  </Filters>
-
   <Appenders>
     <Console name="Console" target="SYSTEM_OUT">
       <PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss.SSS} %-5p %-4L %c{1} - %m%n"/>
@@ -128,7 +42,19 @@
 
   </Appenders>
   <Loggers>
-    <Root level="WARN">
+    <Root level="FATAL">
+      <!-- <AppenderRef ref="Console"/> -->
+      <AppenderRef ref="fileLog"/>
+    </Root>
+
+    <Logger name="com.swirlds" level="WARN" additivity="false">
+      <AppenderRef ref="fileLog"/>
+      <!--
+	  Due to known log4j2 issues with how Markers and LogLevels are evaluated there must be a top level <Filter> element
+	  to ensure that the root logger does not execute all the lambda arguments erroneously. Potential work around in the
+	  future is to use a top-level <Filter> and <Logger> specific filters in combination to achieve the desired
+	  multi-logger setup for diagnostic logging.
+	  -->
       <Filters>
         <!-- Filter out levels above INFO (ex: DEBUG & TRACE) -->
         <!-- Intentially left disabled by default -->
@@ -204,11 +130,11 @@
         <MarkerFilter marker="MERKLE_FORCE_FLUSH"     onMatch="DENY"   onMismatch="NEUTRAL"/>
         <MarkerFilter marker="MERKLE_HASHING"         onMatch="DENY"   onMismatch="NEUTRAL"/>
         <MarkerFilter marker="MERKLE_GENERATION"      onMatch="DENY"   onMismatch="NEUTRAL"/>
-        <MarkerFilter marker="MERKLE_LOCKS"           onMatch="DENY"   onMismatch="DENY"/>
+        <MarkerFilter marker="MERKLE_LOCKS"           onMatch="DENY"   onMismatch="NEUTRAL"/>
+
+        <MarkerFilter marker="DISABLED"               onMatch="DENY"   onMismatch="DENY" />
       </Filters>
-      <!-- <AppenderRef ref="Console"/> -->
-      <AppenderRef ref="fileLog"/>
-    </Root>
+    </Logger>
 
     <Logger name="com.hedera" level="info" additivity="false">
       <AppenderRef ref="Console"/>

--- a/hedera-node/configuration/testnet/log4j2.xml
+++ b/hedera-node/configuration/testnet/log4j2.xml
@@ -1,91 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- monitorInterval="600" , if any change to log level will be effective after 10 minute -->
 <Configuration status="WARN" monitorInterval="600">
-  <!--
-	  Due to known log4j2 issues with how Markers and LogLevels are evaluated there must be a top level <Filter> element
-	  to ensure that the root logger does not execute all the lambda arguments erroneously. Potential work around in the
-	  future is to use a top-level <Filter> and <Logger> specific filters in combination to achieve the desired
-	  multi-logger setup for diagnostic logging.
-	  -->
-  <Filters>
-    <!-- Filter out levels above INFO (ex: DEBUG & TRACE) -->
-    <!-- Intentially left disabled by default -->
-    <!-- <ThresholdFilter level="INFO"                 onMatch="NEUTRAL" onMismatch="DENY" />-->
 
-    <!-- In the following, enable a marker with onMatch="ACCEPT" and disable with onMatch="DENY". -->
-    <!-- More markers can be added, but ensure that every onMismatch="NEUTRAL", except the last is "DENY". -->
-
-    <!-- Exceptions -->
-    <MarkerFilter marker="EXCEPTION"              onMatch="ACCEPT" onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="TESTING_EXCEPTIONS"     onMatch="ACCEPT" onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="SOCKET_EXCEPTIONS"      onMatch="ACCEPT" onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="TCP_CONNECT_EXCEPTIONS" onMatch="DENY"   onMismatch="NEUTRAL"/>
-
-    <!-- Errors -->
-    <MarkerFilter marker="INVALID_EVENT_ERROR"    onMatch="ACCEPT" onMismatch="NEUTRAL"/>
-
-    <!-- Synchronization/Gossip (Debug) -->
-    <MarkerFilter marker="SYNC_START"             onMatch="DENY"   onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="SYNC_DONE"              onMatch="DENY"   onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="SYNC_ERROR"             onMatch="DENY"   onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="SYNC"                   onMatch="DENY"   onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="HEARTBEAT"              onMatch="DENY"   onMismatch="NEUTRAL"/>
-
-    <!-- Platform Events (Debug) -->
-    <MarkerFilter marker="CREATE_EVENT"           onMatch="DENY"   onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="INTAKE_EVENT"           onMatch="DENY"   onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="WATCH_EVENTS_SEND_REC"  onMatch="DENY"   onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="EVENT_SIG"              onMatch="DENY"   onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="EVENT_STREAM"           onMatch="DENY"   onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="EVENT_RESTART"          onMatch="DENY"   onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="STALE_EVENTS"           onMatch="DENY"   onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="EVENT_PARSER"           onMatch="DENY"   onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="EVENT_CONTENT"          onMatch="DENY"   onMismatch="NEUTRAL"/>
-
-    <!-- Queues/Certificates/Utilities -->
-    <MarkerFilter marker="QUEUES"                 onMatch="DENY"   onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="CERTIFICATES"           onMatch="DENY"   onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="LOCKS"                  onMatch="DENY"   onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="TIME_MEASURE"           onMatch="DENY"   onMismatch="NEUTRAL"/>
-
-    <!-- Signed State Signatures -->
-    <MarkerFilter marker="STATE_SIG_DIST"         onMatch="DENY"   onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="STATE_DELETER"          onMatch="DENY"   onMismatch="NEUTRAL"/>
-
-    <!-- Cryptography -->
-    <MarkerFilter marker="OPENCL_INIT_EXCEPTIONS" onMatch="DENY"   onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="ADV_CRYPTO_SYSTEM"      onMatch="DENY"   onMismatch="NEUTRAL"/>
-
-    <!-- Startup/Restart/Reconnect -->
-    <MarkerFilter marker="STARTUP"                onMatch="ACCEPT" onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="PLATFORM_STATUS"        onMatch="ACCEPT" onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="RECONNECT"              onMatch="ACCEPT" onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="FREEZE"                 onMatch="ACCEPT" onMismatch="NEUTRAL"/>
-
-    <!-- Saved States -->
-    <MarkerFilter marker="SNAPSHOT_MANAGER"       onMatch="ACCEPT" onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="STATE_TO_DISK"          onMatch="ACCEPT" onMismatch="NEUTRAL"/>
-
-    <!-- Beta Mirror -->
-    <MarkerFilter marker="BETA_MIRROR_NODE"       onMatch="ACCEPT" onMismatch="NEUTRAL"/>
-
-    <!-- FCMap -->
-    <MarkerFilter marker="FCM_COPY"               onMatch="DENY"   onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="FCM_COPY_FROM"          onMatch="DENY"   onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="FCM_COPY_TO"            onMatch="DENY"   onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="FCM_DEMO"               onMatch="DENY"   onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="FCM_COPY_FROM_DIFF"     onMatch="DENY"   onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="FCM_COPY_TO_DIFF"       onMatch="DENY"   onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="FC_SERIALIZATION"       onMatch="DENY"   onMismatch="NEUTRAL"/>
-
-    <!-- Merkle Trees & Hashing -->
-    <MarkerFilter marker="MERKLE_FORCE_FLUSH"     onMatch="DENY"   onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="MERKLE_HASHING"         onMatch="DENY"   onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="MERKLE_GENERATION"      onMatch="DENY"   onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="MERKLE_LOCKS"           onMatch="DENY"   onMismatch="NEUTRAL"/>
-
-    <MarkerFilter marker="DISABLED"               onMatch="DENY"   onMismatch="DENY" />
-  </Filters>
 
   <Appenders>
     <Console name="Console" target="SYSTEM_OUT">
@@ -128,7 +44,19 @@
 
   </Appenders>
   <Loggers>
-    <Root level="WARN">
+    <Root level="FATAL">
+      <!-- <AppenderRef ref="Console"/> -->
+      <AppenderRef ref="fileLog"/>
+    </Root>
+
+    <Logger name="com.swirlds" level="WARN" additivity="false">
+      <AppenderRef ref="fileLog"/>
+      <!--
+	  Due to known log4j2 issues with how Markers and LogLevels are evaluated there must be a top level <Filter> element
+	  to ensure that the root logger does not execute all the lambda arguments erroneously. Potential work around in the
+	  future is to use a top-level <Filter> and <Logger> specific filters in combination to achieve the desired
+	  multi-logger setup for diagnostic logging.
+	  -->
       <Filters>
         <!-- Filter out levels above INFO (ex: DEBUG & TRACE) -->
         <!-- Intentially left disabled by default -->
@@ -204,11 +132,11 @@
         <MarkerFilter marker="MERKLE_FORCE_FLUSH"     onMatch="DENY"   onMismatch="NEUTRAL"/>
         <MarkerFilter marker="MERKLE_HASHING"         onMatch="DENY"   onMismatch="NEUTRAL"/>
         <MarkerFilter marker="MERKLE_GENERATION"      onMatch="DENY"   onMismatch="NEUTRAL"/>
-        <MarkerFilter marker="MERKLE_LOCKS"           onMatch="DENY"   onMismatch="DENY"/>
+        <MarkerFilter marker="MERKLE_LOCKS"           onMatch="DENY"   onMismatch="NEUTRAL"/>
+
+        <MarkerFilter marker="DISABLED"               onMatch="DENY"   onMismatch="DENY" />
       </Filters>
-      <!-- <AppenderRef ref="Console"/> -->
-      <AppenderRef ref="fileLog"/>
-    </Root>
+    </Logger>
 
     <Logger name="com.hedera" level="info" additivity="false">
       <AppenderRef ref="Console"/>

--- a/hedera-node/log4j2.xml
+++ b/hedera-node/log4j2.xml
@@ -1,57 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- monitorInterval="600" , if any change to log level will be effective after 10 minute -->
 <Configuration status="WARN" monitorInterval="600">
-
-  <Filters>
-    <!-- In the following, enable a marker with onMatch="ACCEPT" and disable with onMatch="DENY". -->
-    <!-- More markers can be added, but ensure that every onMismatch="NEUTRAL", except the last is "DENY". -->
-
-    <!-- Exceptions -->
-    <MarkerFilter marker="EXCEPTION" onMatch="ACCEPT" onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="TESTING_EXCEPTIONS" onMatch="ACCEPT" onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="SOCKET_EXCEPTIONS" onMatch="ACCEPT" onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="TCP_CONNECT_EXCEPTIONS" onMatch="DENY" onMismatch="NEUTRAL"/>
-    <!-- Errors -->
-    <MarkerFilter marker="INVALID_EVENT_ERROR" onMatch="ACCEPT" onMismatch="NEUTRAL"/>
-    <!-- Other -->
-    <MarkerFilter marker="SYNC_START" onMatch="DENY" onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="SYNC_DONE" onMatch="DENY" onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="SYNC_ERROR" onMatch="DENY" onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="SYNC" onMatch="DENY" onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="CREATE_EVENT" onMatch="DENY" onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="INTAKE_EVENT" onMatch="DENY" onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="WATCH_EVENTS_SEND_REC" onMatch="DENY" onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="QUEUES" onMatch="DENY" onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="HEARTBEAT" onMatch="DENY" onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="EVENT_SIG" onMatch="DENY" onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="CERTIFICATES" onMatch="DENY" onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="FCM_COPY" onMatch="DENY" onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="FCM_COPY_FROM" onMatch="DENY" onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="FCM_COPY_TO" onMatch="DENY" onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="FCM_DEMO" onMatch="DENY" onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="FCM_COPY_FROM_DIFF" onMatch="DENY" onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="FCM_COPY_TO_DIFF" onMatch="DENY" onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="FC_SERIALIZATION" onMatch="DENY" onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="MERKLE_FORCE_FLUSH" onMatch="DENY" onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="MERKLE_HASH" onMatch="DENY" onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="MERKLE_GENERATION" onMatch="DENY" onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="MERKLE_LOCKS" onMatch="DENY" onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="LOCKS" onMatch="DENY" onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="TIME_MEASURE" onMatch="DENY" onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="STARTUP" onMatch="ACCEPT" onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="STATE_SIG_DIST" onMatch="DENY" onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="OPENCL_INIT_EXCEPTIONS" onMatch="DENY" onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="ADV_CRYPTO_SYSTEM" onMatch="DENY" onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="EVENT_STREAM" onMatch="DENY" onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="EVENT_RESTART" onMatch="DENY" onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="RECONNECT" onMatch="ACCEPT" onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="FREEZE" onMatch="ACCEPT" onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="STALE_EVENTS" onMatch="DENY" onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="SNAPSHOT_MANAGER" onMatch="ACCEPT" onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="EVENT_PARSER" onMatch="ACCEPT" onMismatch="NEUTRAL"/>
-    <MarkerFilter marker="STATE_TO_DISK" onMatch="ACCEPT" onMismatch="NEUTRAL"/>
-  </Filters>
-
   <Appenders>
     <Console name="Console" target="SYSTEM_OUT">
       <PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss.SSS} %-5p %-4L %c{1} - %m%n"/>
@@ -93,62 +42,99 @@
 
   </Appenders>
   <Loggers>
-    <Root level="WARN">
+    <Root level="FATAL">
+      <!-- <AppenderRef ref="Console"/> -->
+      <AppenderRef ref="fileLog"/>
+    </Root>
+
+    <Logger name="com.swirlds" level="DEBUG" additivity="false">
+      <AppenderRef ref="fileLog"/>
+      <!--
+	 Due to known log4j2 issues with how Markers and LogLevels are evaluated there must be a top level <Filter> element
+	 to ensure that the root logger does not execute all the lambda arguments erroneously. Potential work around in the
+	 future is to use a top-level <Filter> and <Logger> specific filters in combination to achieve the desired
+	 multi-logger setup for diagnostic logging.
+	 -->
       <Filters>
+        <!-- Filter out levels above INFO (ex: DEBUG & TRACE) -->
+        <!-- Intentially left disabled by default -->
+        <!-- <ThresholdFilter level="INFO"                 onMatch="NEUTRAL" onMismatch="DENY" />-->
+
         <!-- In the following, enable a marker with onMatch="ACCEPT" and disable with onMatch="DENY". -->
         <!-- More markers can be added, but ensure that every onMismatch="NEUTRAL", except the last is "DENY". -->
 
         <!-- Exceptions -->
-        <MarkerFilter marker="EXCEPTION" onMatch="ACCEPT" onMismatch="NEUTRAL"/>
-        <MarkerFilter marker="TESTING_EXCEPTIONS" onMatch="ACCEPT" onMismatch="NEUTRAL"/>
-        <MarkerFilter marker="SOCKET_EXCEPTIONS" onMatch="ACCEPT" onMismatch="NEUTRAL"/>
-        <MarkerFilter marker="TCP_CONNECT_EXCEPTIONS" onMatch="DENY" onMismatch="NEUTRAL"/>
+        <MarkerFilter marker="EXCEPTION"              onMatch="ACCEPT" onMismatch="NEUTRAL"/>
+        <MarkerFilter marker="TESTING_EXCEPTIONS"     onMatch="ACCEPT" onMismatch="NEUTRAL"/>
+        <MarkerFilter marker="SOCKET_EXCEPTIONS"      onMatch="ACCEPT" onMismatch="NEUTRAL"/>
+        <MarkerFilter marker="TCP_CONNECT_EXCEPTIONS" onMatch="DENY"   onMismatch="NEUTRAL"/>
+
         <!-- Errors -->
-        <MarkerFilter marker="INVALID_EVENT_ERROR" onMatch="ACCEPT" onMismatch="NEUTRAL"/>
-        <!-- Other -->
-        <MarkerFilter marker="SYNC_START" onMatch="DENY" onMismatch="NEUTRAL"/>
-        <MarkerFilter marker="SYNC_DONE" onMatch="DENY" onMismatch="NEUTRAL"/>
-        <MarkerFilter marker="SYNC_ERROR" onMatch="DENY" onMismatch="NEUTRAL"/>
-        <MarkerFilter marker="SYNC" onMatch="DENY" onMismatch="NEUTRAL"/>
-        <MarkerFilter marker="CREATE_EVENT" onMatch="DENY" onMismatch="NEUTRAL"/>
-        <MarkerFilter marker="INTAKE_EVENT" onMatch="DENY" onMismatch="NEUTRAL"/>
-        <MarkerFilter marker="WATCH_EVENTS_SEND_REC" onMatch="DENY" onMismatch="NEUTRAL"/>
-        <MarkerFilter marker="QUEUES" onMatch="DENY" onMismatch="NEUTRAL"/>
-        <MarkerFilter marker="HEARTBEAT" onMatch="DENY" onMismatch="NEUTRAL"/>
-        <MarkerFilter marker="EVENT_SIG" onMatch="DENY" onMismatch="NEUTRAL"/>
-        <MarkerFilter marker="CERTIFICATES" onMatch="DENY" onMismatch="NEUTRAL"/>
-        <MarkerFilter marker="FCM_COPY" onMatch="DENY" onMismatch="NEUTRAL"/>
-        <MarkerFilter marker="FCM_COPY_FROM" onMatch="DENY" onMismatch="NEUTRAL"/>
-        <MarkerFilter marker="FCM_COPY_TO" onMatch="DENY" onMismatch="NEUTRAL"/>
-        <MarkerFilter marker="FCM_DEMO" onMatch="DENY" onMismatch="NEUTRAL"/>
-        <MarkerFilter marker="FCM_COPY_FROM_DIFF" onMatch="DENY" onMismatch="NEUTRAL"/>
-        <MarkerFilter marker="FCM_COPY_TO_DIFF" onMatch="DENY" onMismatch="NEUTRAL"/>
-        <MarkerFilter marker="FC_SERIALIZATION" onMatch="DENY" onMismatch="NEUTRAL"/>
-        <MarkerFilter marker="MERKLE_FORCE_FLUSH" onMatch="DENY" onMismatch="NEUTRAL"/>
-        <MarkerFilter marker="MERKLE_HASH" onMatch="DENY" onMismatch="NEUTRAL"/>
-        <MarkerFilter marker="MERKLE_GENERATION" onMatch="DENY" onMismatch="NEUTRAL"/>
-        <MarkerFilter marker="MERKLE_LOCKS" onMatch="DENY" onMismatch="NEUTRAL"/>
-        <MarkerFilter marker="LOCKS" onMatch="DENY" onMismatch="NEUTRAL"/>
-        <MarkerFilter marker="TIME_MEASURE" onMatch="DENY" onMismatch="NEUTRAL"/>
-        <MarkerFilter marker="STARTUP" onMatch="ACCEPT" onMismatch="NEUTRAL"/>
-        <MarkerFilter marker="STATE_SIG_DIST" onMatch="DENY" onMismatch="NEUTRAL"/>
-        <MarkerFilter marker="OPENCL_INIT_EXCEPTIONS" onMatch="DENY" onMismatch="NEUTRAL"/>
-        <MarkerFilter marker="ADV_CRYPTO_SYSTEM" onMatch="DENY" onMismatch="NEUTRAL"/>
-        <MarkerFilter marker="EVENT_STREAM" onMatch="DENY" onMismatch="NEUTRAL"/>
-        <MarkerFilter marker="EVENT_RESTART" onMatch="DENY" onMismatch="NEUTRAL"/>
-        <MarkerFilter marker="RECONNECT" onMatch="ACCEPT" onMismatch="NEUTRAL"/>
-        <MarkerFilter marker="FREEZE" onMatch="ACCEPT" onMismatch="NEUTRAL"/>
-        <MarkerFilter marker="STALE_EVENTS" onMatch="DENY" onMismatch="NEUTRAL"/>
-        <MarkerFilter marker="SNAPSHOT_MANAGER" onMatch="ACCEPT" onMismatch="NEUTRAL"/>
-        <MarkerFilter marker="EVENT_PARSER" onMatch="ACCEPT"  onMismatch="NEUTRAL"/>
-        <MarkerFilter marker="STATE_TO_DISK" onMatch="ACCEPT" onMismatch="DENY"/>
-        <!-- Record Stream -->
-        <MarkerFilter marker="OBJECT_STREAM_FILE"     onMatch="DENY" onMismatch="NEUTRAL"/>
-        <MarkerFilter marker="OBJECT_STREAM"          onMatch="DENY" onMismatch="NEUTRAL"/>
+        <MarkerFilter marker="INVALID_EVENT_ERROR"    onMatch="ACCEPT" onMismatch="NEUTRAL"/>
+
+        <!-- Synchronization/Gossip (Debug) -->
+        <MarkerFilter marker="SYNC_START"             onMatch="DENY"   onMismatch="NEUTRAL"/>
+        <MarkerFilter marker="SYNC_DONE"              onMatch="DENY"   onMismatch="NEUTRAL"/>
+        <MarkerFilter marker="SYNC_ERROR"             onMatch="DENY"   onMismatch="NEUTRAL"/>
+        <MarkerFilter marker="SYNC"                   onMatch="DENY"   onMismatch="NEUTRAL"/>
+        <MarkerFilter marker="HEARTBEAT"              onMatch="DENY"   onMismatch="NEUTRAL"/>
+
+        <!-- Platform Events (Debug) -->
+        <MarkerFilter marker="CREATE_EVENT"           onMatch="DENY"   onMismatch="NEUTRAL"/>
+        <MarkerFilter marker="INTAKE_EVENT"           onMatch="DENY"   onMismatch="NEUTRAL"/>
+        <MarkerFilter marker="WATCH_EVENTS_SEND_REC"  onMatch="DENY"   onMismatch="NEUTRAL"/>
+        <MarkerFilter marker="EVENT_SIG"              onMatch="DENY"   onMismatch="NEUTRAL"/>
+        <MarkerFilter marker="EVENT_STREAM"           onMatch="DENY"   onMismatch="NEUTRAL"/>
+        <MarkerFilter marker="EVENT_RESTART"          onMatch="DENY"   onMismatch="NEUTRAL"/>
+        <MarkerFilter marker="STALE_EVENTS"           onMatch="DENY"   onMismatch="NEUTRAL"/>
+        <MarkerFilter marker="EVENT_PARSER"           onMatch="DENY"   onMismatch="NEUTRAL"/>
+        <MarkerFilter marker="EVENT_CONTENT"          onMatch="DENY"   onMismatch="NEUTRAL"/>
+
+        <!-- Queues/Certificates/Utilities -->
+        <MarkerFilter marker="QUEUES"                 onMatch="DENY"   onMismatch="NEUTRAL"/>
+        <MarkerFilter marker="CERTIFICATES"           onMatch="DENY"   onMismatch="NEUTRAL"/>
+        <MarkerFilter marker="LOCKS"                  onMatch="DENY"   onMismatch="NEUTRAL"/>
+        <MarkerFilter marker="TIME_MEASURE"           onMatch="DENY"   onMismatch="NEUTRAL"/>
+
+        <!-- Signed State Signatures -->
+        <MarkerFilter marker="STATE_SIG_DIST"         onMatch="DENY"   onMismatch="NEUTRAL"/>
+        <MarkerFilter marker="STATE_DELETER"          onMatch="DENY"   onMismatch="NEUTRAL"/>
+
+        <!-- Cryptography -->
+        <MarkerFilter marker="OPENCL_INIT_EXCEPTIONS" onMatch="DENY"   onMismatch="NEUTRAL"/>
+        <MarkerFilter marker="ADV_CRYPTO_SYSTEM"      onMatch="DENY"   onMismatch="NEUTRAL"/>
+
+        <!-- Startup/Restart/Reconnect -->
+        <MarkerFilter marker="STARTUP"                onMatch="ACCEPT" onMismatch="NEUTRAL"/>
+        <MarkerFilter marker="PLATFORM_STATUS"        onMatch="ACCEPT" onMismatch="NEUTRAL"/>
+        <MarkerFilter marker="RECONNECT"              onMatch="ACCEPT" onMismatch="NEUTRAL"/>
+        <MarkerFilter marker="FREEZE"                 onMatch="ACCEPT" onMismatch="NEUTRAL"/>
+
+        <!-- Saved States -->
+        <MarkerFilter marker="SNAPSHOT_MANAGER"       onMatch="ACCEPT" onMismatch="NEUTRAL"/>
+        <MarkerFilter marker="STATE_TO_DISK"          onMatch="ACCEPT" onMismatch="NEUTRAL"/>
+
+        <!-- Beta Mirror -->
+        <MarkerFilter marker="BETA_MIRROR_NODE"       onMatch="ACCEPT" onMismatch="NEUTRAL"/>
+
+        <!-- FCMap -->
+        <MarkerFilter marker="FCM_COPY"               onMatch="DENY"   onMismatch="NEUTRAL"/>
+        <MarkerFilter marker="FCM_COPY_FROM"          onMatch="DENY"   onMismatch="NEUTRAL"/>
+        <MarkerFilter marker="FCM_COPY_TO"            onMatch="DENY"   onMismatch="NEUTRAL"/>
+        <MarkerFilter marker="FCM_DEMO"               onMatch="DENY"   onMismatch="NEUTRAL"/>
+        <MarkerFilter marker="FCM_COPY_FROM_DIFF"     onMatch="DENY"   onMismatch="NEUTRAL"/>
+        <MarkerFilter marker="FCM_COPY_TO_DIFF"       onMatch="DENY"   onMismatch="NEUTRAL"/>
+        <MarkerFilter marker="FC_SERIALIZATION"       onMatch="DENY"   onMismatch="NEUTRAL"/>
+
+        <!-- Merkle Trees & Hashing -->
+        <MarkerFilter marker="MERKLE_FORCE_FLUSH"     onMatch="DENY"   onMismatch="NEUTRAL"/>
+        <MarkerFilter marker="MERKLE_HASHING"         onMatch="DENY"   onMismatch="NEUTRAL"/>
+        <MarkerFilter marker="MERKLE_GENERATION"      onMatch="DENY"   onMismatch="NEUTRAL"/>
+        <MarkerFilter marker="MERKLE_LOCKS"           onMatch="DENY"   onMismatch="NEUTRAL"/>
+
+        <MarkerFilter marker="DISABLED"               onMatch="DENY"   onMismatch="DENY" />
       </Filters>
-      <!-- <AppenderRef ref="Console"/> -->
-      <AppenderRef ref="fileLog"/>
-    </Root>
+    </Logger>
 
     <Logger name="com.hedera" level="info" additivity="false">
       <AppenderRef ref="Console"/>
@@ -160,10 +146,6 @@
     </Logger>
     <Logger name="com.hedera.services.queries.answering" level="debug" additivity="false">
       <AppenderRef ref="QueriesRollingFile"/>
-    </Logger>
-    <Logger name="com.hedera.services.state.expiry" level="warn" additivity="false">
-      <AppenderRef ref="Console"/>
-      <AppenderRef ref="RollingFile"/>
     </Logger>
 
     <Logger name="com.hedera.services.legacy" level="warn" additivity="false">


### PR DESCRIPTION
Closes #1680 

- Refactor filters by moving out of the global space and into a Logger space
- Define a new com.swirlds logger to contain the filters
- Remove filters from Root logger
- Change Root logger level to FATAL as a last resort catch-all
