### PR TITLE
Add UNKNOWN in acceptable status.

### DIFF
--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/file/MixedFileOpsLoadTest.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/file/MixedFileOpsLoadTest.java
@@ -40,6 +40,9 @@ import static com.hedera.services.bdd.spec.transactions.TxnVerbs.fileUpdate;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.logIt;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.withOpContext;
 
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SUCCESS;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.UNKNOWN;
+
 /**
  * Run mixed operations including FileCreate, FileAppend, FileUpdate
  */
@@ -73,20 +76,23 @@ public class MixedFileOpsLoadTest extends LoadTest {
 		String targetFile = "targetFile";
 
 		Supplier<HapiSpecOperation[]> mixedFileOpsBurst = () -> new HapiSpecOperation[] {
-				fileCreate(targetFile + submittedSoFar.getAndIncrement()).contents(initialContent),
+				fileCreate(targetFile + submittedSoFar.getAndIncrement())
+						.contents(initialContent)
+						.hasKnownStatusFrom(SUCCESS, UNKNOWN),
 				fileUpdate(targetFile)
 						.fee(ONE_HUNDRED_HBARS)
 						.contents(TxnUtils.randomUtf8Bytes(TxnUtils.BYTES_4K))
 						.noLogging()
 						.payingWith(GENESIS)
 						.hasAnyPrecheck()
+						.hasKnownStatusFrom(SUCCESS, UNKNOWN)
 						.deferStatusResolution(),
 				fileAppend(targetFile)
 						.content("dummy")
 						.hasAnyPrecheck()
 						.payingWith(GENESIS)
 						.fee(ONE_HUNDRED_HBARS)
-						.logging()
+						.hasKnownStatusFrom(SUCCESS, UNKNOWN)
 						.deferStatusResolution()
 		};
 


### PR DESCRIPTION
**Related issue(s)**:
Closes #1632


Slack report link: https://hedera-hashgraph.slack.com/archives/C018CBQBTGB/p1624900151228000

**Summary of the change**:
1. In the quasi perf test setup, it's possible to observe some requests that not be answered as SUCCESS. 


**External impacts**:
None.

**Applicable documentation**
- [ ] Javadoc
- [ ] HAPI protobuf comments
- [ ] README
