### PR TITLE
Use ExpiryEvent id in PriorityQueue ordering 

### DIFF
--- a/hedera-node/src/main/java/com/hedera/services/state/expiry/ExpiryEvent.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/expiry/ExpiryEvent.java
@@ -26,7 +26,7 @@ import com.google.common.base.MoreObjects;
 /**
  * Expiry event with the id and expiration time
  */
-public class ExpiryEvent<K> implements Comparable<ExpiryEvent> {
+public class ExpiryEvent<K> {
 	private final K id;
 	private final long expiry;
 
@@ -53,10 +53,5 @@ public class ExpiryEvent<K> implements Comparable<ExpiryEvent> {
 				.add("id", id)
 				.add("expiry", expiry)
 				.toString();
-	}
-
-	@Override
-	public int compareTo(ExpiryEvent that) {
-		return Long.compare(this.expiry, that.expiry);
 	}
 }

--- a/hedera-node/src/main/java/com/hedera/services/state/expiry/ExpiryManager.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/expiry/ExpiryManager.java
@@ -57,7 +57,8 @@ import static java.util.Comparator.comparing;
 public class ExpiryManager {
 	/* Since the key in Pair<Long, Consumer<EntityId>> is the schedule entity number---and
 	entity numbers are unique---the downstream comparator below will guarantee a fixed
-	ordering for ExpiryEvents with the same expiry. */
+	ordering for ExpiryEvents with the same expiry. The reason for different scheduled entities having
+	the same expiry is that we round expiration times to a consensus second. */
 	private static final Comparator<ExpiryEvent<Pair<Long, Consumer<EntityId>>>> PQ_CMP = Comparator
 			.comparingLong(ExpiryEvent<Pair<Long, Consumer<EntityId>>>::getExpiry)
 			.thenComparingLong(ee -> ee.getId().getKey());

--- a/hedera-node/src/main/java/com/hedera/services/state/expiry/MonotonicFullQueueExpiries.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/expiry/MonotonicFullQueueExpiries.java
@@ -39,11 +39,10 @@ public class MonotonicFullQueueExpiries<K> implements KeyedExpirations<K> {
 	@Override
 	public void track(K id, long expiry) {
 		if (expiry < now) {
-			throw new IllegalArgumentException(String.format("Track time %d for %s not later than %d", expiry, id,
-					now));
+			throw new IllegalArgumentException(String.format("Track time %d for %s not later than %d", expiry, id, now));
 		}
 		now = expiry;
-		allExpiries.add(new ExpiryEvent(id, expiry));
+		allExpiries.add(new ExpiryEvent<>(id, expiry));
 	}
 
 	@Override

--- a/hedera-node/src/main/java/com/hedera/services/state/expiry/PriorityQueueExpiries.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/expiry/PriorityQueueExpiries.java
@@ -20,6 +20,7 @@ package com.hedera.services.state.expiry;
  * ‍
  */
 
+import java.util.Comparator;
 import java.util.PriorityQueue;
 
 /**
@@ -27,7 +28,11 @@ import java.util.PriorityQueue;
  */
 public class PriorityQueueExpiries<K> implements KeyedExpirations<K> {
 	private long now = 0L;
-	private PriorityQueue<ExpiryEvent<K>> allExpiries = new PriorityQueue<>();
+	private final PriorityQueue<ExpiryEvent<K>> allExpiries;
+
+	public PriorityQueueExpiries(Comparator<ExpiryEvent<K>> eventCmp) {
+		allExpiries = new PriorityQueue<>(eventCmp);
+	}
 
 	@Override
 	public void reset() {
@@ -37,7 +42,7 @@ public class PriorityQueueExpiries<K> implements KeyedExpirations<K> {
 
 	@Override
 	public void track(K id, long expiry) {
-		allExpiries.offer(new ExpiryEvent(id, expiry));
+		allExpiries.offer(new ExpiryEvent<>(id, expiry));
 		now = allExpiries.peek().getExpiry();
 	}
 
@@ -52,8 +57,7 @@ public class PriorityQueueExpiries<K> implements KeyedExpirations<K> {
 			throw new IllegalStateException("No ids are queued for expiration!");
 		}
 		if (!allExpiries.peek().isExpiredAt(now)) {
-			throw new IllegalArgumentException(String.format("Argument 'now=%d' is earlier than the next expiry!",
-					now));
+			throw new IllegalArgumentException(String.format("Argument 'now=%d' is earlier than the next expiry!", now));
 		}
 		return allExpiries.remove().getId();
 	}

--- a/hedera-node/src/test/java/com/hedera/services/state/expiry/ExpiryEventTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/state/expiry/ExpiryEventTest.java
@@ -47,17 +47,4 @@ public class ExpiryEventTest {
 		// then:
 		assertEquals(expected, actual);
 	}
-
-	@Test
-	void expiryEventCompareTo() {
-		//given:
-		var expiryEvent1 = new ExpiryEvent("expiryEvent1", 1_000_000L);
-
-		// when:
-		int expected = 1;
-		int actual = expiryEvent.compareTo(expiryEvent1);
-
-		// then:
-		assertEquals(expected, actual);
-	}
 }

--- a/hedera-node/src/test/java/com/hedera/services/state/expiry/ExpiryManagerTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/state/expiry/ExpiryManagerTest.java
@@ -33,7 +33,6 @@ import com.hedera.services.state.submerkle.ExpirableTxnRecord;
 import com.hedera.services.state.submerkle.RichInstant;
 import com.hedera.services.state.submerkle.TxnId;
 import com.hedera.services.store.schedule.ScheduleStore;
-import com.hedera.services.utils.MiscUtils;
 import com.hedera.test.utils.IdUtils;
 import com.hederahashgraph.api.proto.java.AccountID;
 import com.hederahashgraph.api.proto.java.Timestamp;
@@ -54,7 +53,6 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SUCCESS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.Mockito.verify;
-
 
 @ExtendWith(MockitoExtension.class)
 class ExpiryManagerTest {

--- a/hedera-node/src/test/java/com/hedera/services/state/expiry/PriorityQueueExpiriesTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/state/expiry/PriorityQueueExpiriesTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -32,14 +33,19 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class PriorityQueueExpiriesTest {
-	String k1 = "first", k2 = "second", k3 = "third";
-	long expiry1 = 50, expiry2 = 1000, expiry3 = 200;
+	private String k1 = "first", k2 = "second", k3 = "third";
+	private long expiry1 = 50, expiry2 = 1000, expiry3 = 200;
 
-	PriorityQueueExpiries<String> subject;
+	private PriorityQueueExpiries<String> subject;
+	private Comparator<ExpiryEvent<String>> testCmp = (aEvent, bEvent) -> {
+		int order;
+		return (order = Long.compare(aEvent.getExpiry(), bEvent.getExpiry())) != 0
+				? order : aEvent.getId().compareTo(bEvent.getId());
+	};
 
 	@BeforeEach
 	void setup() {
-		subject = new PriorityQueueExpiries<>();
+		subject = new PriorityQueueExpiries<>(testCmp);
 	}
 
 	@Test
@@ -153,8 +159,7 @@ class PriorityQueueExpiriesTest {
 	}
 
 	private PriorityQueueExpiries<String> pqFrom(List<ExpiryEvent<String>> events) {
-		System.out.println("Building a queue from " + events);
-		var pq = new PriorityQueueExpiries<String>();
+		var pq = new PriorityQueueExpiries<>(testCmp);
 		for (var event : events) {
 			pq.track(event.getId(), event.getExpiry());
 		}


### PR DESCRIPTION
**Related issue(s)**:
- Closes #1709

**Summary of the change**:
- Use a `Comparator` for the `PriorityQueue` in `PriorityQueueExpiries` to guarantee a unique total order on the `ExpiryEvent`s in the queue.