### PR TITLE
Don't rely on the nodeId being set in a signed state

### DIFF
--- a/hedera-node/src/main/java/com/hedera/services/ServicesMain.java
+++ b/hedera-node/src/main/java/com/hedera/services/ServicesMain.java
@@ -122,13 +122,15 @@ public class ServicesMain implements SwirldMain {
 	}
 
 	@Override
-	public void newSignedState(SwirldState signedState, Instant when, long round) {
+	public void newSignedState(SwirldState signedState, Instant consensusTime, long round) {
 		if (ctx.platformStatus().get() == MAINTENANCE) {
 			((ServicesState) signedState).logSummary();
 		}
-		if (ctx.globalDynamicProperties().shouldExportBalances() && ctx.balancesExporter().isTimeToExport(when)) {
+		final var exportIsEnabled = ctx.globalDynamicProperties().shouldExportBalances();
+		if (exportIsEnabled && ctx.balancesExporter().isTimeToExport(consensusTime)) {
 			try {
-				ctx.balancesExporter().exportBalancesFrom((ServicesState) signedState, when);
+				final var servicesState = (ServicesState) signedState;
+				ctx.balancesExporter().exportBalancesFrom(servicesState, consensusTime, ctx.id());
 			} catch (IllegalStateException ise) {
 				log.error("HederaNode#{} has invalid total balance in signed state, exiting!", ctx.id(), ise);
 				systemExits.fail(1);

--- a/hedera-node/src/main/java/com/hedera/services/ServicesState.java
+++ b/hedera-node/src/main/java/com/hedera/services/ServicesState.java
@@ -319,8 +319,7 @@ public class ServicesState extends AbstractNaryMerkleInternal implements SwirldS
 	}
 
 	/* --------------- */
-
-	public AccountID getNodeAccountId() {
+	public AccountID getAccountFromNodeId(NodeId nodeId) {
 		var address = addressBook().getAddress(nodeId.getId());
 		var memo = address.getMemo();
 		return parseAccount(memo);

--- a/hedera-node/src/main/java/com/hedera/services/state/exports/BalancesExporter.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/exports/BalancesExporter.java
@@ -21,10 +21,11 @@ package com.hedera.services.state.exports;
  */
 
 import com.hedera.services.ServicesState;
+import com.swirlds.common.NodeId;
 
 import java.time.Instant;
 
 public interface BalancesExporter {
 	boolean isTimeToExport(Instant now);
-	void exportBalancesFrom(ServicesState signedState, Instant when);
+	void exportBalancesFrom(ServicesState signedState, Instant consensusTime, NodeId nodeId);
 }

--- a/hedera-node/src/main/java/com/hedera/services/state/exports/SignedStateBalancesExporter.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/exports/SignedStateBalancesExporter.java
@@ -37,6 +37,7 @@ import com.hederahashgraph.api.proto.java.Timestamp;
 import com.hederahashgraph.api.proto.java.TokenBalance;
 import com.hederahashgraph.api.proto.java.TokenBalances;
 import com.hederahashgraph.api.proto.java.TokenID;
+import com.swirlds.common.NodeId;
 import com.swirlds.fcmap.FCMap;
 import org.apache.commons.lang3.time.StopWatch;
 import org.apache.logging.log4j.LogManager;
@@ -128,8 +129,8 @@ public class SignedStateBalancesExporter implements BalancesExporter {
 
 
 	@Override
-	public void exportBalancesFrom(ServicesState signedState, Instant when) {
-		if (!ensureExportDir(signedState.getNodeAccountId())) {
+	public void exportBalancesFrom(ServicesState signedState, Instant consensusTime, NodeId nodeId) {
+		if (!ensureExportDir(signedState.getAccountFromNodeId(nodeId))) {
 			return;
 		}
 		var watch = StopWatch.createStarted();
@@ -138,17 +139,17 @@ public class SignedStateBalancesExporter implements BalancesExporter {
 		if (!expected.equals(summary.getTotalFloat())) {
 			throw new IllegalStateException(String.format(
 					"Signed state @ %s had total balance %d not %d!",
-					when, summary.getTotalFloat(), expectedFloat));
+					consensusTime, summary.getTotalFloat(), expectedFloat));
 		}
 		log.info("Took {}ms to summarize signed state balances", watch.getTime(TimeUnit.MILLISECONDS));
 
 		// .pb account balances file is our focus, process it first to let its timestamp to stay close to
 		// epoch export period boundary
 		if (exportProto) {
-			toProtoFile(when);
+			toProtoFile(consensusTime);
 		}
 		if (exportCsv) {
-			toCsvFile(when);
+			toCsvFile(consensusTime);
 		}
 	}
 

--- a/hedera-node/src/test/java/com/hedera/services/ServicesMainTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/ServicesMainTest.java
@@ -83,7 +83,6 @@ import static org.mockito.BDDMockito.never;
 import static org.mockito.BDDMockito.verify;
 import static org.mockito.BDDMockito.verifyNoInteractions;
 import static org.mockito.BDDMockito.willThrow;
-import static org.mockito.Mockito.mockStatic;
 
 public class ServicesMainTest {
 	private final long NODE_ID = 1L;
@@ -528,7 +527,7 @@ public class ServicesMainTest {
 		subject.newSignedState(signedState, when, 1L);
 
 		// then:
-		verify(balancesExporter, never()).exportBalancesFrom(any(), any());
+		verify(balancesExporter, never()).exportBalancesFrom(any(), any(), any());
 	}
 
 	@Test
@@ -545,7 +544,7 @@ public class ServicesMainTest {
 		subject.newSignedState(signedState, when, 1L);
 
 		// then:
-		verify(balancesExporter).exportBalancesFrom(signedState, when);
+		verify(balancesExporter).exportBalancesFrom(signedState, when, ctx.id());
 	}
 
 	@Test
@@ -575,7 +574,7 @@ public class ServicesMainTest {
 		given(balancesExporter.isTimeToExport(when)).willReturn(true);
 		willThrow(IllegalStateException.class)
 				.given(balancesExporter)
-				.exportBalancesFrom(signedState, when);
+				.exportBalancesFrom(signedState, when, ctx.id());
 
 		// when:
 		subject.newSignedState(signedState, when, 1L);

--- a/hedera-node/src/test/java/com/hedera/services/ServicesMainTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/ServicesMainTest.java
@@ -567,6 +567,7 @@ public class ServicesMainTest {
 	void failsFastIfBalanceExportDetectedInvalidState() throws Exception {
 		// setup:
 		subject.ctx = ctx;
+		var nodeId = ctx.id();
 		Instant when = Instant.now();
 		ServicesState signedState = mock(ServicesState.class);
 
@@ -574,7 +575,7 @@ public class ServicesMainTest {
 		given(balancesExporter.isTimeToExport(when)).willReturn(true);
 		willThrow(IllegalStateException.class)
 				.given(balancesExporter)
-				.exportBalancesFrom(signedState, when, ctx.id());
+				.exportBalancesFrom(signedState, when, nodeId);
 
 		// when:
 		subject.newSignedState(signedState, when, 1L);

--- a/hedera-node/src/test/java/com/hedera/services/ServicesStateTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/ServicesStateTest.java
@@ -306,11 +306,10 @@ class ServicesStateTest {
 	@Test
 	void getsNodeAccount() {
 		// setup:
-		subject.nodeId = self;
 		subject.setChild(ServicesState.ChildIndices.ADDRESS_BOOK, book);
 
 		// when:
-		AccountID actual = subject.getNodeAccountId();
+		AccountID actual = subject.getAccountFromNodeId(self);
 
 		// then:
 		assertEquals(nodeAccount, actual);

--- a/hedera-node/src/test/java/com/hedera/services/state/exports/SignedStateBalancesExporterTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/state/exports/SignedStateBalancesExporterTest.java
@@ -41,6 +41,7 @@ import com.hederahashgraph.api.proto.java.AccountID;
 import com.hederahashgraph.api.proto.java.TokenID;
 import com.swirlds.common.Address;
 import com.swirlds.common.AddressBook;
+import com.swirlds.common.NodeId;
 import com.swirlds.common.constructable.ClassConstructorPair;
 import com.swirlds.common.constructable.ConstructableRegistry;
 import com.swirlds.common.constructable.ConstructableRegistryException;
@@ -89,6 +90,7 @@ import static org.mockito.Mockito.verify;
 
 @ExtendWith(LogCaptureExtension.class)
 class SignedStateBalancesExporterTest {
+	private final NodeId nodeId = new NodeId(false, 1);
 	private FCMap<MerkleEntityId, MerkleToken> tokens = new FCMap<>();
 	private FCMap<MerkleEntityId, MerkleAccount> accounts = new FCMap<>();
 	private FCMap<MerkleEntityAssociation, MerkleTokenRelStatus> tokenRels = new FCMap<>();
@@ -190,7 +192,7 @@ class SignedStateBalancesExporterTest {
 		given(book.getAddress(1)).willReturn(secondNodeAddress);
 
 		state = mock(ServicesState.class);
-		given(state.getNodeAccountId()).willReturn(thisNode);
+		given(state.getAccountFromNodeId(nodeId)).willReturn(thisNode);
 		given(state.tokens()).willReturn(tokens);
 		given(state.accounts()).willReturn(accounts);
 		given(state.tokenAssociations()).willReturn(tokenRels);
@@ -222,7 +224,7 @@ class SignedStateBalancesExporterTest {
 
 		// when:
 		subject.exportProto = false;
-		subject.exportBalancesFrom(state, now);
+		subject.exportBalancesFrom(state, now, nodeId);
 
 		// then:
 		assertThat(logCaptor.errorLogs(), contains(Matchers.startsWith("Could not export to")));
@@ -237,7 +239,7 @@ class SignedStateBalancesExporterTest {
 
 		// when:
 		subject.exportProto = false;
-		subject.exportBalancesFrom(state, now);
+		subject.exportBalancesFrom(state, now, nodeId);
 
 		// then:
 		assertThat(logCaptor.errorLogs(), contains(Matchers.startsWith("Could not sign balance file")));
@@ -298,7 +300,7 @@ class SignedStateBalancesExporterTest {
 
 		// when:
 		subject.exportProto = false;
-		subject.exportBalancesFrom(state, now);
+		subject.exportBalancesFrom(state, now, nodeId);
 
 		// then:
 		var lines = Files.readAllLines(Paths.get(loc));
@@ -331,7 +333,7 @@ class SignedStateBalancesExporterTest {
 
 		// when:
 		subject.exportProto = false;
-		subject.exportBalancesFrom(state, now);
+		subject.exportBalancesFrom(state, now, nodeId);
 
 		// then:
 		var lines = Files.readAllLines(Paths.get(loc));
@@ -374,7 +376,7 @@ class SignedStateBalancesExporterTest {
 
 		// when:
 		subject.exportProto = false;
-		subject.exportBalancesFrom(state, now);
+		subject.exportBalancesFrom(state, now, nodeId);
 
 		// then:
 		var lines = Files.readAllLines(Paths.get(expectedExportLoc()));
@@ -409,7 +411,7 @@ class SignedStateBalancesExporterTest {
 
 		// when:
 		subject.exportCsv = false;
-		subject.exportBalancesFrom(state, now);
+		subject.exportBalancesFrom(state, now, nodeId);
 
 		// and:
 		java.util.Optional<AllAccountBalances> fileContent = importBalanceProtoFile(loc);
@@ -456,7 +458,7 @@ class SignedStateBalancesExporterTest {
 
 		// when:
 		subject.exportCsv = false;
-		subject.exportBalancesFrom(state, now);
+		subject.exportBalancesFrom(state, now, nodeId);
 
 		// then:
 		assertThat(logCaptor.errorLogs(), contains(Matchers.startsWith("Could not export to")));
@@ -472,7 +474,7 @@ class SignedStateBalancesExporterTest {
 
 		// when: Pretend the .csv file is a corrupted .pb file
 		subject.exportProto = false;
-		subject.exportBalancesFrom(state, now);
+		subject.exportBalancesFrom(state, now, nodeId);
 
 		// and:
 		java.util.Optional<AllAccountBalances> accounts = importBalanceProtoFile(loc);
@@ -488,7 +490,7 @@ class SignedStateBalancesExporterTest {
 
 		// when:
 		subject.exportCsv = false;
-		subject.exportBalancesFrom(state, now);
+		subject.exportBalancesFrom(state, now, nodeId);
 
 		// then:
 		verify(assurance).ensureExistenceOf(expectedExportDir());
@@ -518,7 +520,7 @@ class SignedStateBalancesExporterTest {
 
 		// when:
 		subject.exportCsv = false;
-		subject.exportBalancesFrom(state, now);
+		subject.exportBalancesFrom(state, now, nodeId);
 
 		// then:
 		assertThat(logCaptor.errorLogs(), contains(desiredMsg));
@@ -599,7 +601,7 @@ class SignedStateBalancesExporterTest {
 
 		// when:
 		subject.exportProto = false;
-		subject.exportBalancesFrom(state, now);
+		subject.exportBalancesFrom(state, now, nodeId);
 
 		// then:
 		verify(assurance).ensureExistenceOf(expectedExportDir());
@@ -615,7 +617,7 @@ class SignedStateBalancesExporterTest {
 
 		// then:
 		assertThrows(IllegalStateException.class,
-				() -> subject.exportBalancesFrom(state, now));
+				() -> subject.exportBalancesFrom(state, now, nodeId));
 	}
 
 	@Test
@@ -628,7 +630,7 @@ class SignedStateBalancesExporterTest {
 
 		// when:
 		subject.exportProto = false;
-		subject.exportBalancesFrom(state, now);
+		subject.exportBalancesFrom(state, now, nodeId);
 
 		// then:
 		assertThat(logCaptor.errorLogs(), contains(desiredError));


### PR DESCRIPTION
**Note to reviewer:** I don't immediately see why Codecov is showing missing coverage, but if anyone sees why, lmk and I'll add some tests. 

**Related issue(s)**:
- Closes #1686

**Summary of the change**:
- In an NI reconnect scenario, the Platform may call `ServicesMain.newSignedState()` with a signed state that never received a `ServicesState.init()` call.
    * For such a signed state, the `ServicesState#nodeId` field will be `null`.
- Instead of relying on this field, just use `ctx.id()` in `ServicesMain.newSignedState()` to get the node id.