### PR TITLE
Enforce TokenCreate signing reqs; auto-associate fractional fee collectors

### DIFF
--- a/hedera-node/src/main/java/com/hedera/services/legacy/crypto/SignatureStatus.java
+++ b/hedera-node/src/main/java/com/hedera/services/legacy/crypto/SignatureStatus.java
@@ -162,6 +162,7 @@ public class SignatureStatus {
 		formatArguments.add(errorReport.getResponseCode().toString());
 		break;
       case SCHEDULED_TRANSACTION_NOT_IN_WHITELIST:
+      case INVALID_FEE_COLLECTOR:
       case GENERAL_PAYER_ERROR:
       case GENERAL_TRANSACTION_ERROR:
       case KEY_PREFIX_MISMATCH:

--- a/hedera-node/src/main/java/com/hedera/services/legacy/crypto/SignatureStatusCode.java
+++ b/hedera-node/src/main/java/com/hedera/services/legacy/crypto/SignatureStatusCode.java
@@ -47,7 +47,10 @@ public enum SignatureStatusCode {
   UNRESOLVABLE_REQUIRED_SIGNERS(
           "Cannot resolve required signers for scheduled txn [ source = '%s', scheduled = '%s', error = '%s' ]"),
   SCHEDULED_TRANSACTION_NOT_IN_WHITELIST(
-          "Specified txn cannot be scheduled [ source = '%s', transactionId = '%s' ]");
+          "Specified txn cannot be scheduled [ source = '%s', transactionId = '%s' ]"),
+  INVALID_FEE_COLLECTOR(
+          "Fee collector for custom account does not exist [ source = '%s', transactionId = '%s' ]");
+
 
   private String message;
 

--- a/hedera-node/src/main/java/com/hedera/services/sigs/order/HederaSigningOrder.java
+++ b/hedera-node/src/main/java/com/hedera/services/sigs/order/HederaSigningOrder.java
@@ -756,7 +756,7 @@ public class HederaSigningOrder {
 		return basic;
 	}
 
-	private <T> boolean addAccountIfReceiverSigRequired(AccountID id, List<JKey> reqs) {
+	private boolean addAccountIfReceiverSigRequired(AccountID id, List<JKey> reqs) {
 		return addAccount(id, reqs, false);
 	}
 

--- a/hedera-node/src/main/java/com/hedera/services/sigs/order/HederaSigningOrder.java
+++ b/hedera-node/src/main/java/com/hedera/services/sigs/order/HederaSigningOrder.java
@@ -656,9 +656,9 @@ public class HederaSigningOrder {
 			TokenCreateTransactionBody op,
 			SigningOrderResultFactory<T> factory
 	) {
-		List<JKey> required = new ArrayList<>();
+		final List<JKey> required = new ArrayList<>();
 
-		var couldAddTreasury = addAccount(
+		final var couldAddTreasury = addAccount(
 				op,
 				TokenCreateTransactionBody::hasTreasury,
 				TokenCreateTransactionBody::getTreasury,
@@ -666,7 +666,7 @@ public class HederaSigningOrder {
 		if (!couldAddTreasury) {
 			return accountFailure(op.getTreasury(), txnId, MISSING_ACCOUNT, factory);
 		}
-		var couldAddAutoRenew = addAccount(
+		final var couldAddAutoRenew = addAccount(
 				op,
 				TokenCreateTransactionBody::hasAutoRenewAccount,
 				TokenCreateTransactionBody::getAutoRenewAccount,
@@ -679,6 +679,17 @@ public class HederaSigningOrder {
 				TokenCreateTransactionBody::hasAdminKey,
 				TokenCreateTransactionBody::getAdminKey,
 				required);
+		for (var customFee : op.getCustomFees().getCustomFeesList()) {
+			final var collector = customFee.getFeeCollectorAccountId();
+			/* A fractional fee collector must always sign a TokenCreate, since it is
+			automatically associated to the newly created token. */
+			final var couldAddCollector = customFee.hasFixedFee()
+					? addAccountIfReceiverSigRequired(collector, required)
+					: addAccount(collector, required, true);
+			if (!couldAddCollector) {
+				return factory.forMissingFeeCollector(txnId);
+			}
+		}
 
 		return factory.forValidOrder(required);
 	}
@@ -745,14 +756,30 @@ public class HederaSigningOrder {
 		return basic;
 	}
 
+	private <T> boolean addAccountIfReceiverSigRequired(AccountID id, List<JKey> reqs) {
+		return addAccount(id, reqs, false);
+	}
+
 	private <T> boolean addAccount(T op, Predicate<T> isPresent, Function<T, AccountID> getter, List<JKey> reqs) {
 		if (isPresent.test(op)) {
-			var result = sigMetaLookup.accountSigningMetaFor(getter.apply(op));
-			if (result.succeeded()) {
-				reqs.add(result.metadata().getKey());
-			} else {
-				return false;
+			return addAccount(getter.apply(op), reqs, true);
+		}
+		return true;
+	}
+
+	private boolean addAccount(
+			AccountID id,
+			List<JKey> reqs,
+			boolean alwaysAdd
+	) {
+		var result = sigMetaLookup.accountSigningMetaFor(id);
+		if (result.succeeded()) {
+			final var metadata = result.metadata();
+			if (alwaysAdd || metadata.isReceiverSigRequired()) {
+				reqs.add(metadata.getKey());
 			}
+		} else {
+			return false;
 		}
 		return true;
 	}

--- a/hedera-node/src/main/java/com/hedera/services/sigs/order/SigStatusOrderResultFactory.java
+++ b/hedera-node/src/main/java/com/hedera/services/sigs/order/SigStatusOrderResultFactory.java
@@ -164,4 +164,14 @@ public class SigStatusOrderResultFactory implements SigningOrderResultFactory<Si
 				txnId);
 		return new SigningOrderResult<>(error);
 	}
+
+	@Override
+	public SigningOrderResult<SignatureStatus> forMissingFeeCollector(TransactionID txnId) {
+		SignatureStatus error = new SignatureStatus(
+				SignatureStatusCode.INVALID_FEE_COLLECTOR,
+				ResponseCodeEnum.INVALID_CUSTOM_FEE_COLLECTOR,
+				inHandleTxnDynamicContext,
+				txnId);
+		return new SigningOrderResult<>(error);
+	}
 }

--- a/hedera-node/src/main/java/com/hedera/services/sigs/order/SigningOrderResultFactory.java
+++ b/hedera-node/src/main/java/com/hedera/services/sigs/order/SigningOrderResultFactory.java
@@ -168,10 +168,18 @@ public interface SigningOrderResultFactory<T> {
 			T errorReport);
 
 	/**
-	 * Report an invalid attempt to schedule a schedule create txn .
+	 * Report an invalid attempt to schedule a ScheduleCreate transaction.
 	 *
-	 * @param txnId the {@link TransactionID} of the problematic {@code ScheduleCreate}.
-	 * @return the error summary.
+	 * @param txnId the {@link TransactionID} of the problematic {@code ScheduleCreate}
+	 * @return the error summary
 	 */
 	SigningOrderResult<T> forUnschedulableTxn(TransactionID txnId);
+
+	/**
+	 * Report an invalid fee collection account in a TokenCreate or TokenUpdate.
+	 *
+	 * @param txnId the {@link TransactionID} of the problematic token operation
+	 * @return the error summary
+	 */
+	SigningOrderResult<T> forMissingFeeCollector(TransactionID txnId);
 }

--- a/hedera-node/src/main/java/com/hedera/services/store/tokens/HederaTokenStore.java
+++ b/hedera-node/src/main/java/com/hedera/services/store/tokens/HederaTokenStore.java
@@ -447,8 +447,6 @@ public class HederaTokenStore extends HederaStore implements TokenStore {
 					}
 				}
 			} else if (customFee.hasFractionalFee()) {
-				/* TODO: Should fee collectors for fractional fees automatically be associated to the newly
-				    created token?  (This will require their keys to sign the TokenCreate transaction.) */
 				final var fractionalSpec = customFee.getFractionalFee();
 				final var fraction = fractionalSpec.getFractionalAmount();
 				if (fraction.getDenominator() == 0) {

--- a/hedera-node/src/main/java/com/hedera/services/txns/token/TokenCreateTransitionLogic.java
+++ b/hedera-node/src/main/java/com/hedera/services/txns/token/TokenCreateTransitionLogic.java
@@ -25,6 +25,7 @@ import com.hedera.services.ledger.HederaLedger;
 import com.hedera.services.store.tokens.TokenStore;
 import com.hedera.services.txns.TransitionLogic;
 import com.hedera.services.txns.validation.OptionValidator;
+import com.hederahashgraph.api.proto.java.AccountID;
 import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
 import com.hederahashgraph.api.proto.java.TokenCreateTransactionBody;
 import com.hederahashgraph.api.proto.java.TokenID;
@@ -32,7 +33,9 @@ import com.hederahashgraph.api.proto.java.TransactionBody;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
@@ -105,22 +108,20 @@ public class TokenCreateTransitionLogic implements TransitionLogic {
 		}
 
 		var treasury = op.getTreasury();
-		var status = OK;
-		status = store.associate(treasury, List.of(created));
+		var status = autoEnableAccountForNewToken(treasury, created, op);
 		if (status != OK) {
 			abortWith(status);
 			return;
 		}
-		if (op.hasFreezeKey()) {
-			status = ledger.unfreeze(treasury, created);
-		}
-		if (status == OK && op.hasKycKey()) {
-			status = ledger.grantKyc(treasury, created);
-		}
-		if (status == OK) {
-			status = ledger.adjustTokenBalance(treasury, created, op.getInitialSupply());
+		if (op.getCustomFees().getCustomFeesCount() > 0) {
+			status = autoEnableFeeCollectors(created, treasury, op);
+			if (status != OK) {
+				abortWith(status);
+				return;
+			}
 		}
 
+		status = ledger.adjustTokenBalance(treasury, created, op.getInitialSupply());
 		if (status != OK) {
 			abortWith(status);
 			return;
@@ -129,6 +130,50 @@ public class TokenCreateTransitionLogic implements TransitionLogic {
 		store.commitCreation();
 		txnCtx.setCreated(created);
 		txnCtx.setStatus(SUCCESS);
+	}
+
+	private ResponseCodeEnum autoEnableFeeCollectors(
+			TokenID created,
+			AccountID alreadyEnabledTreasury,
+			TokenCreateTransactionBody op
+	) {
+		/* TokenStore.associate() returns TOKEN_ALREADY_ASSOCIATED_TO_ACCOUNT if the
+		account-token relationship already exists. */
+		final Set<AccountID> customCollectorsEnabled = new HashSet<>() {{
+			this.add(alreadyEnabledTreasury);
+		}};
+		ResponseCodeEnum status = OK;
+		for (var fee : op.getCustomFees().getCustomFeesList()) {
+			if (fee.hasFractionalFee()) {
+				final var collector = fee.getFeeCollectorAccountId();
+				if (!customCollectorsEnabled.contains(collector)) {
+					status = autoEnableAccountForNewToken(collector, created, op);
+					if (status != OK) {
+						return status;
+					}
+					customCollectorsEnabled.add(collector);
+				}
+			}
+		}
+		return status;
+	}
+
+	private ResponseCodeEnum autoEnableAccountForNewToken(
+			AccountID id,
+			TokenID created,
+			TokenCreateTransactionBody op
+	) {
+		var status = store.associate(id, List.of(created));
+		if (status != OK) {
+			return status;
+		}
+		if (op.hasFreezeKey()) {
+			status = ledger.unfreeze(id, created);
+		}
+		if (status == OK && op.hasKycKey()) {
+			status = ledger.grantKyc(id, created);
+		}
+		return status;
 	}
 
 	private void abortWith(ResponseCodeEnum cause) {

--- a/hedera-node/src/main/java/com/hedera/services/txns/token/TokenCreateTransitionLogic.java
+++ b/hedera-node/src/main/java/com/hedera/services/txns/token/TokenCreateTransitionLogic.java
@@ -139,9 +139,8 @@ public class TokenCreateTransitionLogic implements TransitionLogic {
 	) {
 		/* TokenStore.associate() returns TOKEN_ALREADY_ASSOCIATED_TO_ACCOUNT if the
 		account-token relationship already exists. */
-		final Set<AccountID> customCollectorsEnabled = new HashSet<>() {{
-			this.add(alreadyEnabledTreasury);
-		}};
+		final Set<AccountID> customCollectorsEnabled = new HashSet<>();
+		customCollectorsEnabled.add(alreadyEnabledTreasury);
 		ResponseCodeEnum status = OK;
 		for (var fee : op.getCustomFees().getCustomFeesList()) {
 			if (fee.hasFractionalFee()) {

--- a/hedera-node/src/test/java/com/hedera/services/ServicesMainTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/ServicesMainTest.java
@@ -83,7 +83,6 @@ import static org.mockito.BDDMockito.never;
 import static org.mockito.BDDMockito.verify;
 import static org.mockito.BDDMockito.verifyNoInteractions;
 import static org.mockito.BDDMockito.willThrow;
-import static org.mockito.Mockito.mockStatic;
 
 public class ServicesMainTest {
 	private final long NODE_ID = 1L;

--- a/hedera-node/src/test/java/com/hedera/services/sigs/order/HederaSigningOrderTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/sigs/order/HederaSigningOrderTest.java
@@ -165,10 +165,10 @@ import static com.hedera.test.factories.scenarios.TokenCreateScenarios.TOKEN_CRE
 import static com.hedera.test.factories.scenarios.TokenCreateScenarios.TOKEN_CREATE_WITH_ADMIN_AND_FREEZE;
 import static com.hedera.test.factories.scenarios.TokenCreateScenarios.TOKEN_CREATE_WITH_ADMIN_ONLY;
 import static com.hedera.test.factories.scenarios.TokenCreateScenarios.TOKEN_CREATE_WITH_AUTO_RENEW;
-import static com.hedera.test.factories.scenarios.TokenCreateScenarios.TOKEN_CREATE_WITH_FRACTIONAL_FEE_COLLECTOR_NO_SIQ_REQ;
+import static com.hedera.test.factories.scenarios.TokenCreateScenarios.TOKEN_CREATE_WITH_FRACTIONAL_FEE_COLLECTOR_NO_SIG_REQ;
 import static com.hedera.test.factories.scenarios.TokenCreateScenarios.TOKEN_CREATE_WITH_MISSING_COLLECTOR;
-import static com.hedera.test.factories.scenarios.TokenCreateScenarios.TOKEN_CREATE_WITH_FIXED_FEE_COLLECTOR_SIQ_REQ;
-import static com.hedera.test.factories.scenarios.TokenCreateScenarios.TOKEN_CREATE_WITH_FIXED_FEE_NO_COLLECTOR_SIQ_REQ;
+import static com.hedera.test.factories.scenarios.TokenCreateScenarios.TOKEN_CREATE_WITH_FIXED_FEE_COLLECTOR_SIG_REQ;
+import static com.hedera.test.factories.scenarios.TokenCreateScenarios.TOKEN_CREATE_WITH_FIXED_FEE_NO_COLLECTOR_SIG_REQ;
 import static com.hedera.test.factories.scenarios.TokenCreateScenarios.TOKEN_CREATE_WITH_MISSING_AUTO_RENEW;
 import static com.hedera.test.factories.scenarios.TokenDeleteScenarios.DELETE_WITH_KNOWN_TOKEN;
 import static com.hedera.test.factories.scenarios.TokenDeleteScenarios.DELETE_WITH_MISSING_TOKEN;
@@ -1317,7 +1317,7 @@ class HederaSigningOrderTest {
 	@Test
 	void getsTokenCreateCustomFixedFeeNoCollectorSigReq() throws Throwable {
 		// given:
-		setupFor(TOKEN_CREATE_WITH_FIXED_FEE_NO_COLLECTOR_SIQ_REQ);
+		setupFor(TOKEN_CREATE_WITH_FIXED_FEE_NO_COLLECTOR_SIG_REQ);
 
 		// when:
 		var summary = subject.keysForOtherParties(txn, summaryFactory);
@@ -1331,7 +1331,7 @@ class HederaSigningOrderTest {
 	@Test
 	void getsTokenCreateCustomFixedFeeAndCollectorSigReq() throws Throwable {
 		// given:
-		setupFor(TOKEN_CREATE_WITH_FIXED_FEE_COLLECTOR_SIQ_REQ);
+		setupFor(TOKEN_CREATE_WITH_FIXED_FEE_COLLECTOR_SIG_REQ);
 
 		// when:
 		var summary = subject.keysForOtherParties(txn, summaryFactory);
@@ -1345,7 +1345,7 @@ class HederaSigningOrderTest {
 	@Test
 	void getsTokenCreateCustomFractionalFeeNoCollectorSigReq() throws Throwable {
 		// given:
-		setupFor(TOKEN_CREATE_WITH_FRACTIONAL_FEE_COLLECTOR_NO_SIQ_REQ);
+		setupFor(TOKEN_CREATE_WITH_FRACTIONAL_FEE_COLLECTOR_NO_SIG_REQ);
 
 		// when:
 		var summary = subject.keysForOtherParties(txn, summaryFactory);

--- a/hedera-node/src/test/java/com/hedera/services/sigs/order/HederaSigningOrderTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/sigs/order/HederaSigningOrderTest.java
@@ -165,6 +165,10 @@ import static com.hedera.test.factories.scenarios.TokenCreateScenarios.TOKEN_CRE
 import static com.hedera.test.factories.scenarios.TokenCreateScenarios.TOKEN_CREATE_WITH_ADMIN_AND_FREEZE;
 import static com.hedera.test.factories.scenarios.TokenCreateScenarios.TOKEN_CREATE_WITH_ADMIN_ONLY;
 import static com.hedera.test.factories.scenarios.TokenCreateScenarios.TOKEN_CREATE_WITH_AUTO_RENEW;
+import static com.hedera.test.factories.scenarios.TokenCreateScenarios.TOKEN_CREATE_WITH_FRACTIONAL_FEE_COLLECTOR_NO_SIQ_REQ;
+import static com.hedera.test.factories.scenarios.TokenCreateScenarios.TOKEN_CREATE_WITH_MISSING_COLLECTOR;
+import static com.hedera.test.factories.scenarios.TokenCreateScenarios.TOKEN_CREATE_WITH_FIXED_FEE_COLLECTOR_SIQ_REQ;
+import static com.hedera.test.factories.scenarios.TokenCreateScenarios.TOKEN_CREATE_WITH_FIXED_FEE_NO_COLLECTOR_SIQ_REQ;
 import static com.hedera.test.factories.scenarios.TokenCreateScenarios.TOKEN_CREATE_WITH_MISSING_AUTO_RENEW;
 import static com.hedera.test.factories.scenarios.TokenDeleteScenarios.DELETE_WITH_KNOWN_TOKEN;
 import static com.hedera.test.factories.scenarios.TokenDeleteScenarios.DELETE_WITH_MISSING_TOKEN;
@@ -190,6 +194,7 @@ import static com.hedera.test.factories.scenarios.TokenUpdateScenarios.UPDATE_WI
 import static com.hedera.test.factories.scenarios.TokenUpdateScenarios.UPDATE_WITH_SUPPLY_KEYED_TOKEN;
 import static com.hedera.test.factories.scenarios.TokenUpdateScenarios.UPDATE_WITH_WIPE_KEYED_TOKEN;
 import static com.hedera.test.factories.scenarios.TokenWipeScenarios.VALID_WIPE_WITH_EXTANT_TOKEN;
+import static com.hedera.test.factories.scenarios.TxnHandlingScenario.NO_RECEIVER_SIG_KT;
 import static com.hedera.test.factories.txns.ConsensusCreateTopicFactory.SIMPLE_TOPIC_ADMIN_KEY;
 import static com.hedera.test.factories.txns.ContractCreateFactory.DEFAULT_ADMIN_KT;
 import static com.hedera.test.factories.txns.CryptoCreateFactory.DEFAULT_ACCOUNT_KT;
@@ -211,7 +216,7 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
-public class HederaSigningOrderTest {
+class HederaSigningOrderTest {
 	private static class TopicAdapter {
 		public static TopicSigMetaLookup with(ThrowingTopicLookup delegate) {
 			return new TopicSigMetaLookup() {
@@ -1307,6 +1312,61 @@ public class HederaSigningOrderTest {
 		assertThat(
 				sanityRestored(summary.getOrderedKeys()),
 				contains(TOKEN_TREASURY_KT.asKey(), TOKEN_ADMIN_KT.asKey()));
+	}
+
+	@Test
+	void getsTokenCreateCustomFixedFeeNoCollectorSigReq() throws Throwable {
+		// given:
+		setupFor(TOKEN_CREATE_WITH_FIXED_FEE_NO_COLLECTOR_SIQ_REQ);
+
+		// when:
+		var summary = subject.keysForOtherParties(txn, summaryFactory);
+
+		// then:
+		assertThat(
+				sanityRestored(summary.getOrderedKeys()),
+				contains(TOKEN_TREASURY_KT.asKey()));
+	}
+
+	@Test
+	void getsTokenCreateCustomFixedFeeAndCollectorSigReq() throws Throwable {
+		// given:
+		setupFor(TOKEN_CREATE_WITH_FIXED_FEE_COLLECTOR_SIQ_REQ);
+
+		// when:
+		var summary = subject.keysForOtherParties(txn, summaryFactory);
+
+		// then:
+		assertThat(
+				sanityRestored(summary.getOrderedKeys()),
+				contains(TOKEN_TREASURY_KT.asKey(), RECEIVER_SIG_KT.asKey()));
+	}
+
+	@Test
+	void getsTokenCreateCustomFractionalFeeNoCollectorSigReq() throws Throwable {
+		// given:
+		setupFor(TOKEN_CREATE_WITH_FRACTIONAL_FEE_COLLECTOR_NO_SIQ_REQ);
+
+		// when:
+		var summary = subject.keysForOtherParties(txn, summaryFactory);
+
+		// then:
+		assertThat(
+				sanityRestored(summary.getOrderedKeys()),
+				contains(TOKEN_TREASURY_KT.asKey(), NO_RECEIVER_SIG_KT.asKey()));
+	}
+
+	@Test
+	void getsTokenCreateCustomFeeAndCollectorMissing() throws Throwable {
+		// given:
+		setupFor(TOKEN_CREATE_WITH_MISSING_COLLECTOR);
+
+		// when:
+		var summary = subject.keysForOtherParties(txn, summaryFactory);
+
+		// then:
+		assertTrue(summary.getOrderedKeys().isEmpty());
+		assertEquals(SignatureStatusCode.INVALID_FEE_COLLECTOR, summary.getErrorReport().getStatusCode());
 	}
 
 	@Test

--- a/hedera-node/src/test/java/com/hedera/services/sigs/order/SigStatusOrderResultFactoryTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/sigs/order/SigStatusOrderResultFactoryTest.java
@@ -43,13 +43,13 @@ import static com.hedera.test.utils.IdUtils.asTopic;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class SigStatusOrderResultFactoryTest {
+class SigStatusOrderResultFactoryTest {
 	private SigStatusOrderResultFactory subject;
 	private boolean inHandleTxnDynamicContext = true;
 	private TransactionID txnId = TransactionID.getDefaultInstance();
 
 	@Test
-	public void returnsNormalSummaryForValidOrder() {
+	void returnsNormalSummaryForValidOrder() {
 		// given:
 		subject = new SigStatusOrderResultFactory(false);
 		SigningOrderResult<SignatureStatus> summary = subject.forValidOrder(new ArrayList<>());
@@ -59,7 +59,7 @@ public class SigStatusOrderResultFactoryTest {
 	}
 
 	@Test
-	public void reportsInvalidAccountError() {
+	void reportsInvalidAccountError() {
 		// setup:
 		AccountID invalidAccount = asAccount("1.2.3");
 		SignatureStatus expectedError = new SignatureStatus(
@@ -76,7 +76,7 @@ public class SigStatusOrderResultFactoryTest {
 	}
 
 	@Test
-	public void reportsGeneralPayerError() {
+	void reportsGeneralPayerError() {
 		// setup:
 		AccountID payer = asAccount("0.0.3");
 		SignatureStatus expectedError = new SignatureStatus(
@@ -93,7 +93,7 @@ public class SigStatusOrderResultFactoryTest {
 	}
 
 	@Test
-	public void reportsGeneralError() {
+	void reportsGeneralError() {
 		// setup:
 		SignatureStatus expectedError = new SignatureStatus(
 				SignatureStatusCode.GENERAL_ERROR, ResponseCodeEnum.INVALID_SIGNATURE,
@@ -109,7 +109,7 @@ public class SigStatusOrderResultFactoryTest {
 	}
 
 	@Test
-	public void reportsMissingAccount() {
+	void reportsMissingAccount() {
 		// setup:
 		AccountID missing = asAccount("1.2.3");
 		SignatureStatus expectedError = new SignatureStatus(
@@ -126,7 +126,7 @@ public class SigStatusOrderResultFactoryTest {
 	}
 
 	@Test
-	public void reportsMissingFile() {
+	void reportsMissingFile() {
 		// setup:
 		FileID missing = asFile("1.2.3");
 		SignatureStatus expectedError = new SignatureStatus(
@@ -143,7 +143,7 @@ public class SigStatusOrderResultFactoryTest {
 	}
 
 	@Test
-	public void reportsInvalidContract() {
+	void reportsInvalidContract() {
 		// setup:
 		ContractID invalid = asContract("1.2.3");
 		SignatureStatus expectedError = new SignatureStatus(
@@ -159,7 +159,7 @@ public class SigStatusOrderResultFactoryTest {
 	}
 
 	@Test
-	public void reportsImmutableContract() {
+	void reportsImmutableContract() {
 		// setup:
 		ContractID immutable = asContract("1.2.3");
 		SignatureStatus expectedError = new SignatureStatus(
@@ -176,7 +176,7 @@ public class SigStatusOrderResultFactoryTest {
 	}
 
 	@Test
-	public void reportsMissingToken() {
+	void reportsMissingToken() {
 		// setup:
 		TokenID missing = IdUtils.asToken("1.2.3");
 		SignatureStatus expectedError = new SignatureStatus(
@@ -193,7 +193,7 @@ public class SigStatusOrderResultFactoryTest {
 	}
 
 	@Test
-	public void reportsMissingSchedule() {
+	void reportsMissingSchedule() {
 		// setup:
 		ScheduleID missing = IdUtils.asSchedule("1.2.3");
 		SignatureStatus expectedError = new SignatureStatus(
@@ -210,7 +210,7 @@ public class SigStatusOrderResultFactoryTest {
 	}
 
 	@Test
-	public void reportsMissingTopic() {
+	void reportsMissingTopic() {
 		// setup:
 		TopicID missing = asTopic("1.2.3");
 		SignatureStatus expectedError = new SignatureStatus(
@@ -227,7 +227,7 @@ public class SigStatusOrderResultFactoryTest {
 	}
 
 	@Test
-	public void reportsInvalidAutoRenewAccount() {
+	void reportsInvalidAutoRenewAccount() {
 		// setup:
 		AccountID missing = asAccount("11.22.33");
 		SignatureStatus expectedError = new SignatureStatus(
@@ -244,7 +244,7 @@ public class SigStatusOrderResultFactoryTest {
 	}
 
 	@Test
-	public void reportsUnresolvableSigners() {
+	void reportsUnresolvableSigners() {
 		// setup:
 		var errorReport = new SignatureStatus(
 				SignatureStatusCode.INVALID_SCHEDULE_ID,
@@ -267,7 +267,7 @@ public class SigStatusOrderResultFactoryTest {
 	}
 
 	@Test
-	public void reportsNestedScheduleCreate() {
+	void reportsNestedScheduleCreate() {
 		// setup:
 		SignatureStatus expectedError = new SignatureStatus(
 				SignatureStatusCode.SCHEDULED_TRANSACTION_NOT_IN_WHITELIST,
@@ -278,6 +278,24 @@ public class SigStatusOrderResultFactoryTest {
 		// given:
 		subject = new SigStatusOrderResultFactory(inHandleTxnDynamicContext);
 		var summary = subject.forUnschedulableTxn(txnId);
+		SignatureStatus error = summary.getErrorReport();
+
+		// expect:
+		assertEquals(expectedError.toLogMessage(), error.toLogMessage());
+	}
+
+	@Test
+	void reportsInvalidFeeCollector() {
+		// setup:
+		SignatureStatus expectedError = new SignatureStatus(
+				SignatureStatusCode.INVALID_FEE_COLLECTOR,
+				ResponseCodeEnum.INVALID_CUSTOM_FEE_COLLECTOR,
+				inHandleTxnDynamicContext,
+				txnId);
+
+		// given:
+		subject = new SigStatusOrderResultFactory(inHandleTxnDynamicContext);
+		var summary = subject.forMissingFeeCollector(txnId);
 		SignatureStatus error = summary.getErrorReport();
 
 		// expect:

--- a/hedera-node/src/test/java/com/hedera/services/txns/token/TokenCreateTransitionLogicTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/txns/token/TokenCreateTransitionLogicTest.java
@@ -31,6 +31,7 @@ import com.hedera.test.factories.scenarios.TxnHandlingScenario;
 import com.hedera.test.factories.txns.SignedTxnFactory;
 import com.hedera.test.utils.IdUtils;
 import com.hederahashgraph.api.proto.java.AccountID;
+import com.hederahashgraph.api.proto.java.Fraction;
 import com.hederahashgraph.api.proto.java.Key;
 import com.hederahashgraph.api.proto.java.Timestamp;
 import com.hederahashgraph.api.proto.java.TokenCreateTransactionBody;
@@ -38,6 +39,7 @@ import com.hederahashgraph.api.proto.java.TokenID;
 import com.hederahashgraph.api.proto.java.TransactionBody;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import proto.CustomFeesOuterClass;
 
 import java.time.Instant;
 import java.util.List;
@@ -206,7 +208,7 @@ class TokenCreateTransitionLogicTest {
 
 	@Test
 	void abortsIfAssociationFails() {
-		givenValidTxnCtx(false, true);
+		givenValidTxnCtx(false, true, false);
 		// and:
 		given(store.createProvisionally(tokenCreateTxn.getTokenCreation(), payer, thisSecond))
 				.willReturn(CreationResult.success(created));
@@ -226,7 +228,7 @@ class TokenCreateTransitionLogicTest {
 
 	@Test
 	void abortsIfUnfreezeFails() {
-		givenValidTxnCtx(false, true);
+		givenValidTxnCtx(false, true, false);
 		// and:
 		given(store.createProvisionally(tokenCreateTxn.getTokenCreation(), payer, thisSecond))
 				.willReturn(CreationResult.success(created));
@@ -247,15 +249,18 @@ class TokenCreateTransitionLogicTest {
 
 	@Test
 	void followsHappyPathWithAllKeys() {
-		givenValidTxnCtx(true, true);
+		givenValidTxnCtx(true, true, true);
 		// and:
 		given(store.createProvisionally(tokenCreateTxn.getTokenCreation(), payer, thisSecond))
 				.willReturn(CreationResult.success(created));
 		given(ledger.unfreeze(treasury, created)).willReturn(OK);
 		given(ledger.grantKyc(treasury, created)).willReturn(OK);
+		given(ledger.unfreeze(feeCollector, created)).willReturn(OK);
+		given(ledger.grantKyc(feeCollector, created)).willReturn(OK);
 		given(ledger.adjustTokenBalance(treasury, created, initialSupply))
 				.willReturn(OK);
 		given(store.associate(treasury, List.of(created))).willReturn(OK);
+		given(store.associate(feeCollector, List.of(created))).willReturn(OK);
 
 		// when:
 		subject.doStateTransition();
@@ -264,6 +269,9 @@ class TokenCreateTransitionLogicTest {
 		verify(store).associate(treasury, List.of(created));
 		verify(ledger).unfreeze(treasury, created);
 		verify(ledger).grantKyc(treasury, created);
+		verify(store).associate(feeCollector, List.of(created));
+		verify(ledger).unfreeze(feeCollector, created);
+		verify(ledger).grantKyc(feeCollector, created);
 		// and:
 		verify(txnCtx).setCreated(created);
 		verify(txnCtx).setStatus(SUCCESS);
@@ -272,8 +280,35 @@ class TokenCreateTransitionLogicTest {
 	}
 
 	@Test
+	void abortsIfFeeCollectorEnablementFails() {
+		givenValidTxnCtx(true, true, true);
+		// and:
+		given(store.createProvisionally(tokenCreateTxn.getTokenCreation(), payer, thisSecond))
+				.willReturn(CreationResult.success(created));
+		given(ledger.unfreeze(treasury, created)).willReturn(OK);
+		given(ledger.grantKyc(treasury, created)).willReturn(OK);
+		given(ledger.unfreeze(feeCollector, created)).willReturn(OK);
+		given(ledger.grantKyc(feeCollector, created)).willReturn(OK);
+		given(ledger.adjustTokenBalance(treasury, created, initialSupply))
+				.willReturn(OK);
+		given(store.associate(treasury, List.of(created))).willReturn(OK);
+		given(store.associate(feeCollector, List.of(created))).willReturn(TOKENS_PER_ACCOUNT_LIMIT_EXCEEDED);
+
+		// when:
+		subject.doStateTransition();
+
+		// then:
+		verify(txnCtx, never()).setCreated(created);
+		verify(txnCtx).setStatus(TOKENS_PER_ACCOUNT_LIMIT_EXCEEDED);
+		// and:
+		verify(store, never()).commitCreation();
+		verify(store).rollbackCreation();
+		verify(ledger).dropPendingTokenChanges();
+	}
+
+	@Test
 	void doesntUnfreezeIfNoKeyIsPresent() {
-		givenValidTxnCtx(true, false);
+		givenValidTxnCtx(true, false, false);
 		// and:
 		given(store.createProvisionally(tokenCreateTxn.getTokenCreation(), payer, thisSecond))
 				.willReturn(CreationResult.success(created));
@@ -297,7 +332,7 @@ class TokenCreateTransitionLogicTest {
 
 	@Test
 	void doesntGrantKycIfNoKeyIsPresent() {
-		givenValidTxnCtx(false, true);
+		givenValidTxnCtx(false, true, false);
 		// and:
 		given(store.createProvisionally(tokenCreateTxn.getTokenCreation(), payer, thisSecond))
 				.willReturn(CreationResult.success(created));
@@ -495,10 +530,10 @@ class TokenCreateTransitionLogicTest {
 	}
 
 	private void givenValidTxnCtx() {
-		givenValidTxnCtx(false, false);
+		givenValidTxnCtx(false, false, false);
 	}
 
-	private void givenValidTxnCtx(boolean withKyc, boolean withFreeze) {
+	private void givenValidTxnCtx(boolean withKyc, boolean withFreeze, boolean withCustomFees) {
 		final var expiry = Timestamp.newBuilder().setSeconds(thisSecond + thisSecond).build();
 		var builder = TransactionBody.newBuilder()
 				.setTokenCreation(TokenCreateTransactionBody.newBuilder()
@@ -509,6 +544,9 @@ class TokenCreateTransitionLogicTest {
 						.setAdminKey(key)
 						.setAutoRenewAccount(renewAccount)
 						.setExpiry(expiry));
+		if (withCustomFees) {
+			builder.getTokenCreationBuilder().setCustomFees(grpcCustomFees);
+		}
 		if (withFreeze) {
 			builder.getTokenCreationBuilder().setFreezeKey(TxnHandlingScenario.TOKEN_FREEZE_KT.asKey());
 		}
@@ -641,4 +679,48 @@ class TokenCreateTransitionLogicTest {
 		given(validator.tokenSymbolCheck(any())).willReturn(OK);
 		given(validator.isValidAutoRenewPeriod(any())).willReturn(true);
 	}
+
+	private TokenID misc = IdUtils.asToken("3.2.1");
+	private Fraction fraction = Fraction.newBuilder().setNumerator(15).setDenominator(100).build();
+	private CustomFeesOuterClass.FractionalFee firstFractionalFee = CustomFeesOuterClass.FractionalFee.newBuilder()
+			.setFractionalAmount(fraction)
+			.setMaximumAmount(50)
+			.setMinimumAmount(10)
+			.build();
+	private CustomFeesOuterClass.FractionalFee secondFractionalFee = CustomFeesOuterClass.FractionalFee.newBuilder()
+			.setFractionalAmount(fraction)
+			.setMaximumAmount(15)
+			.setMinimumAmount(5)
+			.build();
+	private CustomFeesOuterClass.FixedFee fixedFeeInTokenUnits = CustomFeesOuterClass.FixedFee.newBuilder()
+			.setDenominatingTokenId(misc)
+			.setAmount(100)
+			.build();
+	private CustomFeesOuterClass.FixedFee fixedFeeInHbar = CustomFeesOuterClass.FixedFee.newBuilder()
+			.setAmount(100)
+			.build();
+	private AccountID feeCollector = IdUtils.asAccount("6.6.6");
+	private AccountID anotherFeeCollector = IdUtils.asAccount("1.2.777");
+	private CustomFeesOuterClass.CustomFee customFixedFeeInHbar = CustomFeesOuterClass.CustomFee.newBuilder()
+			.setFeeCollectorAccountId(feeCollector)
+			.setFixedFee(fixedFeeInHbar)
+			.build();
+	private CustomFeesOuterClass.CustomFee customFixedFeeInHts = CustomFeesOuterClass.CustomFee.newBuilder()
+			.setFeeCollectorAccountId(anotherFeeCollector)
+			.setFixedFee(fixedFeeInTokenUnits)
+			.build();
+	private CustomFeesOuterClass.CustomFee customFractionalFeeA = CustomFeesOuterClass.CustomFee.newBuilder()
+			.setFeeCollectorAccountId(feeCollector)
+			.setFractionalFee(firstFractionalFee)
+			.build();
+	private CustomFeesOuterClass.CustomFee customFractionalFeeB = CustomFeesOuterClass.CustomFee.newBuilder()
+			.setFeeCollectorAccountId(feeCollector)
+			.setFractionalFee(secondFractionalFee)
+			.build();
+	private CustomFeesOuterClass.CustomFees grpcCustomFees = CustomFeesOuterClass.CustomFees.newBuilder()
+			.addCustomFees(customFixedFeeInHbar)
+			.addCustomFees(customFixedFeeInHts)
+			.addCustomFees(customFractionalFeeA)
+			.addCustomFees(customFractionalFeeB)
+			.build();
 }

--- a/hedera-node/src/test/java/com/hedera/test/factories/scenarios/TokenCreateScenarios.java
+++ b/hedera-node/src/test/java/com/hedera/test/factories/scenarios/TokenCreateScenarios.java
@@ -74,7 +74,7 @@ public enum TokenCreateScenarios implements TxnHandlingScenario {
 			));
 		}
 	},
-	TOKEN_CREATE_WITH_FIXED_FEE_NO_COLLECTOR_SIQ_REQ {
+	TOKEN_CREATE_WITH_FIXED_FEE_NO_COLLECTOR_SIG_REQ {
 		public PlatformTxnAccessor platformTxn() throws Throwable {
 			final var collector = EntityId.fromGrpcAccountId(NO_RECEIVER_SIG);
 			return new PlatformTxnAccessor(from(
@@ -85,7 +85,7 @@ public enum TokenCreateScenarios implements TxnHandlingScenario {
 			));
 		}
 	},
-	TOKEN_CREATE_WITH_FIXED_FEE_COLLECTOR_SIQ_REQ {
+	TOKEN_CREATE_WITH_FIXED_FEE_COLLECTOR_SIG_REQ {
 		public PlatformTxnAccessor platformTxn() throws Throwable {
 			final var collector = EntityId.fromGrpcAccountId(RECEIVER_SIG);
 			return new PlatformTxnAccessor(from(
@@ -96,7 +96,7 @@ public enum TokenCreateScenarios implements TxnHandlingScenario {
 			));
 		}
 	},
-	TOKEN_CREATE_WITH_FRACTIONAL_FEE_COLLECTOR_NO_SIQ_REQ {
+	TOKEN_CREATE_WITH_FRACTIONAL_FEE_COLLECTOR_NO_SIG_REQ {
 		public PlatformTxnAccessor platformTxn() throws Throwable {
 			final var collector = EntityId.fromGrpcAccountId(NO_RECEIVER_SIG);
 			return new PlatformTxnAccessor(from(

--- a/hedera-node/src/test/java/com/hedera/test/factories/scenarios/TokenCreateScenarios.java
+++ b/hedera-node/src/test/java/com/hedera/test/factories/scenarios/TokenCreateScenarios.java
@@ -20,8 +20,11 @@ package com.hedera.test.factories.scenarios;
  * ‍
  */
 
+import com.hedera.services.state.submerkle.EntityId;
 import com.hedera.services.utils.PlatformTxnAccessor;
 
+import static com.hedera.services.state.submerkle.CustomFee.fixedFee;
+import static com.hedera.services.state.submerkle.CustomFee.fractionalFee;
 import static com.hedera.test.factories.txns.PlatformTxnFactory.from;
 import static com.hedera.test.factories.txns.TokenCreateFactory.newSignedTokenCreate;
 
@@ -67,6 +70,53 @@ public enum TokenCreateScenarios implements TxnHandlingScenario {
 					newSignedTokenCreate()
 							.missingAdmin()
 							.autoRenew(MISSING_ACCOUNT)
+							.get()
+			));
+		}
+	},
+	TOKEN_CREATE_WITH_FIXED_FEE_NO_COLLECTOR_SIQ_REQ {
+		public PlatformTxnAccessor platformTxn() throws Throwable {
+			final var collector = EntityId.fromGrpcAccountId(NO_RECEIVER_SIG);
+			return new PlatformTxnAccessor(from(
+					newSignedTokenCreate()
+							.missingAdmin()
+							.plusCustomFee(fixedFee(123L, null, collector))
+							.get()
+			));
+		}
+	},
+	TOKEN_CREATE_WITH_FIXED_FEE_COLLECTOR_SIQ_REQ {
+		public PlatformTxnAccessor platformTxn() throws Throwable {
+			final var collector = EntityId.fromGrpcAccountId(RECEIVER_SIG);
+			return new PlatformTxnAccessor(from(
+					newSignedTokenCreate()
+							.missingAdmin()
+							.plusCustomFee(fixedFee(123L, null, collector))
+							.get()
+			));
+		}
+	},
+	TOKEN_CREATE_WITH_FRACTIONAL_FEE_COLLECTOR_NO_SIQ_REQ {
+		public PlatformTxnAccessor platformTxn() throws Throwable {
+			final var collector = EntityId.fromGrpcAccountId(NO_RECEIVER_SIG);
+			return new PlatformTxnAccessor(from(
+					newSignedTokenCreate()
+							.missingAdmin()
+							.plusCustomFee(fractionalFee(
+									1, 2,
+									3, 4,
+									collector))
+							.get()
+			));
+		}
+	},
+	TOKEN_CREATE_WITH_MISSING_COLLECTOR {
+		public PlatformTxnAccessor platformTxn() throws Throwable {
+			final var collector = EntityId.fromGrpcAccountId(MISSING_ACCOUNT);
+			return new PlatformTxnAccessor(from(
+					newSignedTokenCreate()
+							.missingAdmin()
+							.plusCustomFee(fixedFee(123L, null, collector))
 							.get()
 			));
 		}

--- a/hedera-node/src/test/java/com/hedera/test/factories/txns/TokenCreateFactory.java
+++ b/hedera-node/src/test/java/com/hedera/test/factories/txns/TokenCreateFactory.java
@@ -20,12 +20,15 @@ package com.hedera.test.factories.txns;
  * ‍
  */
 
+import com.hedera.services.state.submerkle.CustomFee;
 import com.hedera.test.factories.scenarios.TxnHandlingScenario;
 import com.hederahashgraph.api.proto.java.AccountID;
 import com.hederahashgraph.api.proto.java.TokenCreateTransactionBody;
 import com.hederahashgraph.api.proto.java.Transaction;
 import com.hederahashgraph.api.proto.java.TransactionBody;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 
 public class TokenCreateFactory extends SignedTxnFactory<TokenCreateFactory> {
@@ -33,6 +36,7 @@ public class TokenCreateFactory extends SignedTxnFactory<TokenCreateFactory> {
 	private boolean omitAdmin = false;
 	private boolean omitTreasury = false;
 	private Optional<AccountID> autoRenew = Optional.empty();
+	private List<CustomFee> customFees = null;
 
 	private TokenCreateFactory() {}
 
@@ -50,13 +54,16 @@ public class TokenCreateFactory extends SignedTxnFactory<TokenCreateFactory> {
 		return this;
 	}
 
-	public TokenCreateFactory missingTreasury() {
-		omitTreasury = true;
+	public TokenCreateFactory missingAdmin() {
+		omitAdmin = true;
 		return this;
 	}
 
-	public TokenCreateFactory missingAdmin() {
-		omitAdmin = true;
+	public TokenCreateFactory plusCustomFee(CustomFee customFee) {
+		if (customFees == null) {
+			customFees = new ArrayList<>();
+		}
+		customFees.add(customFee);
 		return this;
 	}
 
@@ -82,7 +89,12 @@ public class TokenCreateFactory extends SignedTxnFactory<TokenCreateFactory> {
 		if (frozen) {
 			op.setFreezeKey(TxnHandlingScenario.TOKEN_FREEZE_KT.asKey());
 		}
-		autoRenew.ifPresent(a -> op.setAutoRenewAccount(a));
+		if (customFees != null) {
+			for (var fee : customFees) {
+				op.getCustomFeesBuilder().addCustomFees(fee.asGrpc());
+			}
+		}
+		autoRenew.ifPresent(op::setAutoRenewAccount);
 		txn.setTokenCreation(op);
 	}
 }

--- a/hedera-node/src/test/java/com/hedera/test/factories/txns/TokenCreateFactory.java
+++ b/hedera-node/src/test/java/com/hedera/test/factories/txns/TokenCreateFactory.java
@@ -36,7 +36,7 @@ public class TokenCreateFactory extends SignedTxnFactory<TokenCreateFactory> {
 	private boolean omitAdmin = false;
 	private boolean omitTreasury = false;
 	private Optional<AccountID> autoRenew = Optional.empty();
-	private List<CustomFee> customFees = null;
+	private List<CustomFee> customFees = new ArrayList<>();
 
 	private TokenCreateFactory() {}
 
@@ -60,9 +60,6 @@ public class TokenCreateFactory extends SignedTxnFactory<TokenCreateFactory> {
 	}
 
 	public TokenCreateFactory plusCustomFee(CustomFee customFee) {
-		if (customFees == null) {
-			customFees = new ArrayList<>();
-		}
 		customFees.add(customFee);
 		return this;
 	}
@@ -89,10 +86,9 @@ public class TokenCreateFactory extends SignedTxnFactory<TokenCreateFactory> {
 		if (frozen) {
 			op.setFreezeKey(TxnHandlingScenario.TOKEN_FREEZE_KT.asKey());
 		}
-		if (customFees != null) {
-			for (var fee : customFees) {
-				op.getCustomFeesBuilder().addCustomFees(fee.asGrpc());
-			}
+		var cfBuilder = op.getCustomFeesBuilder();
+		for (var fee : customFees) {
+			cfBuilder.addCustomFees(fee.asGrpc());
 		}
 		autoRenew.ifPresent(op::setAutoRenewAccount);
 		txn.setTokenCreation(op);

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenUpdateSpecs.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenUpdateSpecs.java
@@ -100,28 +100,28 @@ public class TokenUpdateSpecs extends HapiApiSuite {
 	@Override
 	protected List<HapiApiSpec> getSpecsInSuite() {
 		return List.of(new HapiApiSpec[] {
-				symbolChanges(),
-				standardImmutabilitySemanticsHold(),
-				validAutoRenewWorks(),
-				tooLongNameCheckHolds(),
-				tooLongSymbolCheckHolds(),
-				nameChanges(),
-				keysChange(),
-				validatesAlreadyDeletedToken(),
-				treasuryEvolves(),
-				deletedAutoRenewAccountCheckHolds(),
-				renewalPeriodCheckHolds(),
-				invalidTreasuryCheckHolds(),
-				newTreasuryMustSign(),
-				newTreasuryMustBeAssociated(),
-				tokensCanBeMadeImmutableWithEmptyKeyList(),
-				updateHappyPath(),
-				validatesMissingAdminKey(),
-				validatesMissingRef(),
-				validatesNewExpiry(),
-				/* HIP-18 */
-				onlyValidCustomFeeScheduleCanBeUpdated(),
-				customFeesOnceImmutableStayImmutable(),
+						symbolChanges(),
+						standardImmutabilitySemanticsHold(),
+						validAutoRenewWorks(),
+						tooLongNameCheckHolds(),
+						tooLongSymbolCheckHolds(),
+						nameChanges(),
+						keysChange(),
+						validatesAlreadyDeletedToken(),
+						treasuryEvolves(),
+						deletedAutoRenewAccountCheckHolds(),
+						renewalPeriodCheckHolds(),
+						invalidTreasuryCheckHolds(),
+						newTreasuryMustSign(),
+						newTreasuryMustBeAssociated(),
+						tokensCanBeMadeImmutableWithEmptyKeyList(),
+						updateHappyPath(),
+						validatesMissingAdminKey(),
+						validatesMissingRef(),
+						validatesNewExpiry(),
+						/* HIP-18 */
+						onlyValidCustomFeeScheduleCanBeUpdated(),
+						customFeesOnceImmutableStayImmutable(),
 				}
 		);
 	}
@@ -647,7 +647,7 @@ public class TokenUpdateSpecs extends HapiApiSuite {
 						fileUpdate(APP_PROPERTIES)
 								.payingWith(GENESIS)
 								.overridingProps(Map.of("tokens.maxCustomFeesAllowed", "1"))
-						)
+				)
 				.when(
 						tokenUpdate(token)
 								.treasury(tokenCollector)
@@ -715,7 +715,7 @@ public class TokenUpdateSpecs extends HapiApiSuite {
 										newNumerator, newDenominator,
 										newMinimumToCollect, OptionalLong.of(newMaximumToCollect),
 										newTokenCollector))
-						)
+				)
 				.then(
 						getTokenInfo(token)
 								.hasCustomFeesMutable(true)
@@ -762,7 +762,7 @@ public class TokenUpdateSpecs extends HapiApiSuite {
 										minimumToCollect, OptionalLong.of(maximumToCollect),
 										tokenCollector))
 
-						)
+				)
 				.when(
 						tokenUpdate(token)
 								.customFeesMutable(false)


### PR DESCRIPTION
**Related issue(s)**:
- Addresses first three bullets in #1699

**Summary of the change**:
- Require any fixed fee collector with `receiverSigRequired=true` to sign a `TokenCreate`.
- Require any fractional fee collector to sign a `TokenCreate`.
- Automatically associate fractional fee collectors to the newly created token (exactly as is done for the treasury).