### PR TITLE
Fix throttles.json resource function names

### DIFF
--- a/hedera-node/src/main/resources/throttles.json
+++ b/hedera-node/src/main/resources/throttles.json
@@ -10,7 +10,7 @@
                         "ScheduleCreate",
                         "CryptoCreate", "CryptoTransfer", "CryptoUpdate", "CryptoDelete", "CryptoGetInfo", "CryptoGetAccountRecords",
                         "ConsensusCreateTopic", "ConsensusSubmitMessage", "ConsensusUpdateTopic", "ConsensusDeleteTopic", "ConsensusGetTopicInfo",
-                        "TokenGetInfo", "TokenNftGetInfo",
+                        "TokenGetInfo", "TokenGetNftInfo", "TokenGetAccountNftInfos",
                         "ScheduleDelete", "ScheduleGetInfo",
                         "FileGetContents", "FileGetInfo",
                         "ContractUpdate", "ContractDelete", "ContractGetInfo", "ContractGetBytecode", "ContractGetRecords", "ContractCallLocal", 


### PR DESCRIPTION
**Summary of the change**:
Replace incorrect `TokenNftGetInfo` with `TokenGetNftInfo`.
