### PR TITLE
Add feeSchedule and feeScheduleKey to the Token Model

### DIFF
--- a/hedera-node/src/main/java/com/hedera/services/context/ServicesContext.java
+++ b/hedera-node/src/main/java/com/hedera/services/context/ServicesContext.java
@@ -1440,7 +1440,7 @@ public class ServicesContext {
 				entry(TokenUpdate,
 						List.of(new TokenUpdateTransitionLogic(
 								validator(), tokenStore(), ledger(), txnCtx(), HederaTokenStore::affectsExpiryAtMost))),
-				entry(TokenFeeScheduleUpdate, List.of(new TokenFeeScheduleUpdateTransitionLogic(typedTokenStore(), txnCtx(),
+				entry(TokenFeeScheduleUpdate, List.of(new TokenFeeScheduleUpdateTransitionLogic(tokenStore(), txnCtx(),
 						validator, globalDynamicProperties()))),
 				entry(TokenFreezeAccount,
 						List.of(new TokenFreezeTransitionLogic(tokenStore(), ledger(), txnCtx()))),

--- a/hedera-node/src/main/java/com/hedera/services/context/ServicesContext.java
+++ b/hedera-node/src/main/java/com/hedera/services/context/ServicesContext.java
@@ -1441,7 +1441,7 @@ public class ServicesContext {
 						List.of(new TokenUpdateTransitionLogic(
 								validator(), tokenStore(), ledger(), txnCtx(), HederaTokenStore::affectsExpiryAtMost))),
 				entry(TokenFeeScheduleUpdate, List.of(new TokenFeeScheduleUpdateTransitionLogic(typedTokenStore(), txnCtx(),
-						validator))),
+						validator, globalDynamicProperties()))),
 				entry(TokenFreezeAccount,
 						List.of(new TokenFreezeTransitionLogic(tokenStore(), ledger(), txnCtx()))),
 				entry(TokenUnfreezeAccount,

--- a/hedera-node/src/main/java/com/hedera/services/state/merkle/MerkleToken.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/merkle/MerkleToken.java
@@ -551,7 +551,7 @@ public class MerkleToken extends AbstractMerkleLeaf {
 		return feeSchedule;
 	}
 
-	private void setFeeSchedule(List<FcCustomFee> feeSchedule) {
+	public void setFeeSchedule(List<FcCustomFee> feeSchedule) {
 		this.feeSchedule = unmodifiableList(feeSchedule);
 	}
 

--- a/hedera-node/src/main/java/com/hedera/services/store/TypedTokenStore.java
+++ b/hedera-node/src/main/java/com/hedera/services/store/TypedTokenStore.java
@@ -61,6 +61,7 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.CUSTOM_FEE_DEN
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.CUSTOM_FEE_MUST_BE_POSITIVE;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.CUSTOM_FEE_NOT_FULLY_SPECIFIED;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.CUSTOM_FRACTIONAL_FEE_ONLY_ALLOWED_FOR_FUNGIBLE_COMMON;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.FRACTIONAL_FEE_MAX_AMOUNT_LESS_THAN_MIN_AMOUNT;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.FRACTION_DIVIDES_BY_ZERO;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_CUSTOM_FEE_COLLECTOR;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_TOKEN_ID;
@@ -337,11 +338,15 @@ public class TypedTokenStore {
 					if (fraction.getDenominator() == 0) {
 						return FRACTION_DIVIDES_BY_ZERO;
 					}
-					if (!signsMatch(fraction.getNumerator(), fraction.getDenominator())) {
+					if (!areValidPositiveNumbers(fraction.getNumerator(), fraction.getDenominator())) {
 						return CUSTOM_FEE_MUST_BE_POSITIVE;
 					}
 					if (fractionalSpec.getMaximumAmount() < 0 || fractionalSpec.getMinimumAmount() < 0) {
 						return CUSTOM_FEE_MUST_BE_POSITIVE;
+					}
+					if (fractionalSpec.getMaximumAmount() > 0 &&
+							fractionalSpec.getMaximumAmount() < fractionalSpec.getMinimumAmount()) {
+						return FRACTIONAL_FEE_MAX_AMOUNT_LESS_THAN_MIN_AMOUNT;
 					}
 				} else {
 					return CUSTOM_FEE_NOT_FULLY_SPECIFIED;
@@ -364,8 +369,8 @@ public class TypedTokenStore {
 		return OK;
 	}
 
-	private boolean signsMatch(long a, long b) {
-		return (a < 0 && b < 0) || (a > 0 && b > 0);
+	private boolean areValidPositiveNumbers(long a, long b) {
+		return (a > 0 && b > 0);
 	}
 
 	private void validateUsable(MerkleTokenRelStatus merkleTokenRelStatus) {

--- a/hedera-node/src/main/java/com/hedera/services/store/TypedTokenStore.java
+++ b/hedera-node/src/main/java/com/hedera/services/store/TypedTokenStore.java
@@ -293,6 +293,10 @@ public class TypedTokenStore {
 		mutableToken.setTotalSupply(token.getTotalSupply());
 		mutableToken.setAccountsFrozenByDefault(token.isFrozenByDefault());
 		mutableToken.setLastUsedSerialNumber(token.getLastUsedSerialNumber());
+		mutableToken.setFeeSchedule(token.getFeeSchedule());
+		if(token.hasFeeScheduleKey()) {
+			mutableToken.setFeeScheduleKey(token.getFeeScheduleKey());
+		}
 	}
 
 	private void initModelAccounts(Token token, EntityId _treasuryId, @Nullable EntityId _autoRenewId) {
@@ -315,6 +319,8 @@ public class TypedTokenStore {
 		token.setFrozenByDefault(immutableToken.accountsAreFrozenByDefault());
 		token.setType(immutableToken.tokenType());
 		token.setLastUsedSerialNumber(immutableToken.getLastUsedSerialNumber());
+		token.setFeeScheduleKey(immutableToken.getFeeScheduleKey());
+		token.setFeeSchedule(immutableToken.customFeeSchedule());
 	}
 
 	private void alertTokenBackingStoreOfNew(TokenRelationship newRel) {

--- a/hedera-node/src/main/java/com/hedera/services/store/models/Token.java
+++ b/hedera-node/src/main/java/com/hedera/services/store/models/Token.java
@@ -25,6 +25,7 @@ import com.google.protobuf.ByteString;
 import com.hedera.services.legacy.core.jproto.JKey;
 import com.hedera.services.state.enums.TokenSupplyType;
 import com.hedera.services.state.enums.TokenType;
+import com.hedera.services.state.submerkle.FcCustomFee;
 import com.hedera.services.state.submerkle.RichInstant;
 import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
 import org.apache.commons.lang3.builder.EqualsBuilder;
@@ -68,9 +69,11 @@ public class Token {
 	private JKey kycKey;
 	private JKey freezeKey;
 	private JKey supplyKey;
+	private JKey feeScheduleKey;
 	private boolean frozenByDefault;
 	private Account treasury;
 	private Account autoRenewAccount;
+	List<FcCustomFee> feeSchedule;
 
 	private long lastUsedSerialNumber;
 
@@ -266,9 +269,29 @@ public class Token {
 		return mintedUniqueTokens;
 	}
 
+	public JKey getFeeScheduleKey() {
+		return feeScheduleKey;
+	}
+
+	public boolean hasFeeScheduleKey() {
+		return feeScheduleKey != null;
+	}
+
+	public void setFeeScheduleKey(final JKey feeScheduleKey) {
+		this.feeScheduleKey = feeScheduleKey;
+	}
+
+	public List<FcCustomFee> getFeeSchedule() {
+		return feeSchedule;
+	}
+
+	public void setFeeSchedule(final List<FcCustomFee> feeSchedule) {
+		this.feeSchedule = feeSchedule;
+	}
+
 	/* NOTE: The object methods below are only overridden to improve
-	readability of unit tests; this model object is not used in hash-based
-	collections, so the performance of these methods doesn't matter. */
+		readability of unit tests; this model object is not used in hash-based
+		collections, so the performance of these methods doesn't matter. */
 	@Override
 	public boolean equals(Object obj) {
 		return EqualsBuilder.reflectionEquals(this, obj);
@@ -289,6 +312,8 @@ public class Token {
 				.add("freezeKey", describe(freezeKey))
 				.add("frozenByDefault", frozenByDefault)
 				.add("supplyKey", describe(supplyKey))
+				.add("feeScheduleKey", describe(feeScheduleKey))
+				.add("feeSchedule", feeSchedule)
 				.toString();
 	}
 }

--- a/hedera-node/src/main/java/com/hedera/services/store/tokens/ExceptionalTokenStore.java
+++ b/hedera-node/src/main/java/com/hedera/services/store/tokens/ExceptionalTokenStore.java
@@ -30,6 +30,7 @@ import com.hedera.services.store.models.NftId;
 import com.hederahashgraph.api.proto.java.AccountID;
 import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
 import com.hederahashgraph.api.proto.java.TokenCreateTransactionBody;
+import com.hederahashgraph.api.proto.java.TokenFeeScheduleUpdateTransactionBody;
 import com.hederahashgraph.api.proto.java.TokenID;
 import com.hederahashgraph.api.proto.java.TokenUpdateTransactionBody;
 
@@ -91,6 +92,11 @@ public enum ExceptionalTokenStore implements TokenStore {
 
 	@Override
 	public ResponseCodeEnum update(TokenUpdateTransactionBody changes, long now) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public ResponseCodeEnum updateFeeSchedule(TokenFeeScheduleUpdateTransactionBody changes) {
 		throw new UnsupportedOperationException();
 	}
 

--- a/hedera-node/src/main/java/com/hedera/services/store/tokens/HederaTokenStore.java
+++ b/hedera-node/src/main/java/com/hedera/services/store/tokens/HederaTokenStore.java
@@ -90,6 +90,7 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.CANNOT_WIPE_TO
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.CUSTOM_FEES_LIST_TOO_LONG;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.CUSTOM_FEE_MUST_BE_POSITIVE;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.CUSTOM_FEE_NOT_FULLY_SPECIFIED;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.FRACTIONAL_FEE_MAX_AMOUNT_LESS_THAN_MIN_AMOUNT;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.FRACTION_DIVIDES_BY_ZERO;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INSUFFICIENT_TOKEN_BALANCE;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_AUTORENEW_ACCOUNT;
@@ -528,11 +529,15 @@ public class HederaTokenStore extends HederaStore implements TokenStore {
 				if (fraction.getDenominator() == 0) {
 					return FRACTION_DIVIDES_BY_ZERO;
 				}
-				if (!signsMatch(fraction.getNumerator(), fraction.getDenominator())) {
+				if (!areValidPositiveNumbers(fraction.getNumerator(), fraction.getDenominator())) {
 					return CUSTOM_FEE_MUST_BE_POSITIVE;
 				}
 				if (fractionalSpec.getMaximumAmount() < 0 || fractionalSpec.getMinimumAmount() < 0) {
 					return CUSTOM_FEE_MUST_BE_POSITIVE;
+				}
+				if (fractionalSpec.getMaximumAmount() > 0 &&
+						fractionalSpec.getMaximumAmount() < fractionalSpec.getMinimumAmount()) {
+					return FRACTIONAL_FEE_MAX_AMOUNT_LESS_THAN_MIN_AMOUNT;
 				}
 			} else {
 				return CUSTOM_FEE_NOT_FULLY_SPECIFIED;
@@ -542,8 +547,8 @@ public class HederaTokenStore extends HederaStore implements TokenStore {
 		return OK;
 	}
 
-	private boolean signsMatch(long a, long b) {
-		return (a < 0 && b < 0) || (a > 0 && b > 0);
+	private boolean areValidPositiveNumbers(long a, long b) {
+		return (a > 0 && b > 0);
 	}
 
 	public void addKnownTreasury(AccountID aId, TokenID tId) {

--- a/hedera-node/src/main/java/com/hedera/services/store/tokens/TokenStore.java
+++ b/hedera-node/src/main/java/com/hedera/services/store/tokens/TokenStore.java
@@ -29,6 +29,7 @@ import com.hederahashgraph.api.proto.java.AccountID;
 import com.hederahashgraph.api.proto.java.NftID;
 import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
 import com.hederahashgraph.api.proto.java.TokenCreateTransactionBody;
+import com.hederahashgraph.api.proto.java.TokenFeeScheduleUpdateTransactionBody;
 import com.hederahashgraph.api.proto.java.TokenID;
 import com.hederahashgraph.api.proto.java.TokenUpdateTransactionBody;
 
@@ -61,6 +62,8 @@ public interface TokenStore extends Store<TokenID, MerkleToken> {
 	ResponseCodeEnum freeze(AccountID aId, TokenID tId);
 
 	ResponseCodeEnum update(TokenUpdateTransactionBody changes, long now);
+
+	ResponseCodeEnum updateFeeSchedule(TokenFeeScheduleUpdateTransactionBody changes);
 
 	ResponseCodeEnum unfreeze(AccountID aId, TokenID tId);
 

--- a/hedera-node/src/main/java/com/hedera/services/txns/token/TokenCreateTransitionLogic.java
+++ b/hedera-node/src/main/java/com/hedera/services/txns/token/TokenCreateTransitionLogic.java
@@ -237,7 +237,8 @@ public class TokenCreateTransitionLogic implements TransitionLogic {
 				op.hasKycKey(), op.getKycKey(),
 				op.hasWipeKey(), op.getWipeKey(),
 				op.hasSupplyKey(), op.getSupplyKey(),
-				op.hasFreezeKey(), op.getFreezeKey());
+				op.hasFreezeKey(), op.getFreezeKey(),
+				op.hasFeeScheduleKey(), op.getFeeScheduleKey());
 		if (validity != OK) {
 			return validity;
 		}

--- a/hedera-node/src/main/java/com/hedera/services/txns/token/TokenFeeScheduleUpdateTransitionLogic.java
+++ b/hedera-node/src/main/java/com/hedera/services/txns/token/TokenFeeScheduleUpdateTransitionLogic.java
@@ -22,23 +22,43 @@ package com.hedera.services.txns.token;
 
 import com.hedera.services.context.TransactionContext;
 import com.hedera.services.context.properties.GlobalDynamicProperties;
+import com.hedera.services.state.merkle.MerkleToken;
 import com.hedera.services.store.TypedTokenStore;
+import com.hedera.services.store.tokens.TokenStore;
 import com.hedera.services.txns.TransitionLogic;
 import com.hedera.services.txns.validation.OptionValidator;
+import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
+import com.hederahashgraph.api.proto.java.TokenFeeScheduleUpdateTransactionBody;
+import com.hederahashgraph.api.proto.java.TokenUpdateTransactionBody;
 import com.hederahashgraph.api.proto.java.TransactionBody;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
+import java.util.function.Function;
 import java.util.function.Predicate;
 
-public class TokenFeeScheduleUpdateTransitionLogic implements TransitionLogic {
+import static com.hedera.services.store.tokens.TokenStore.MISSING_TOKEN;
+import static com.hedera.services.txns.validation.TokenListChecks.checkKeys;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.FAIL_INVALID;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_EXPIRATION_TIME;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_TOKEN_ID;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OK;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SUCCESS;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TOKEN_IS_IMMUTABLE;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TOKEN_WAS_DELETED;
 
-	private final TypedTokenStore tokenStore;
+public class TokenFeeScheduleUpdateTransitionLogic implements TransitionLogic {
+	private static final Logger log = LogManager.getLogger(TokenFeeScheduleUpdateTransitionLogic.class);
+	private final TokenStore store;
 	private final OptionValidator validator;
 	private final TransactionContext txnCtx;
 	private final GlobalDynamicProperties dynamicProperties;
 
-	public TokenFeeScheduleUpdateTransitionLogic(final TypedTokenStore tokenStore, final TransactionContext txnCtx,
+	private final Function<TransactionBody, ResponseCodeEnum> SEMANTIC_CHECK = this::validate;
+
+	public TokenFeeScheduleUpdateTransitionLogic(final TokenStore tokenStore, final TransactionContext txnCtx,
 			final OptionValidator validator, final GlobalDynamicProperties dynamicProperties) {
-		this.tokenStore = tokenStore; // we can change this to HederaTokenStore for simplicity and refactor later.
+		this.store = tokenStore;
 		this.txnCtx = txnCtx;
 		this.validator = validator;
 		this.dynamicProperties = dynamicProperties;
@@ -46,16 +66,59 @@ public class TokenFeeScheduleUpdateTransitionLogic implements TransitionLogic {
 
 	@Override
 	public void doStateTransition() {
-		
-		/* If want to use Model objects  instead of grpc types*/
-		// covert from grpc types
-		// load the token
-		// do businessLogic
-		// persist the token
+		try {
+			transitionFor(txnCtx.accessor().getTxn().getTokenFeeScheduleUpdate());
+		} catch(Exception e) {
+			log.warn("Unhandled error while processing :: {}!", txnCtx.accessor().getSignedTxnWrapper(), e);
+			abortWith(FAIL_INVALID);
+		}
+
+	}
+
+
+	private void transitionFor(TokenFeeScheduleUpdateTransactionBody op) {
+		var id = store.resolve(op.getTokenId());
+		if (id == MISSING_TOKEN) {
+			txnCtx.setStatus(INVALID_TOKEN_ID);
+			return;
+		}
+
+		//var outcome = OK;
+		MerkleToken token = store.get(id);
+
+		if (token.isDeleted()) {
+			txnCtx.setStatus(TOKEN_WAS_DELETED);
+			return;
+		}
+
+		var outcome = store.updateFeeSchedule(op);
+		if(outcome != OK) {
+			abortWith(outcome);
+			return;
+		}
+		txnCtx.setStatus(SUCCESS);
 	}
 
 	@Override
 	public Predicate<TransactionBody> applicability() {
-		return null;
+		return TransactionBody::hasTokenFeeScheduleUpdate;
+	}
+
+	@Override
+	public Function<TransactionBody, ResponseCodeEnum> semanticCheck() {
+		return SEMANTIC_CHECK;
+	}
+
+	public ResponseCodeEnum validate(TransactionBody txnBody) {
+		TokenFeeScheduleUpdateTransactionBody op = txnBody.getTokenFeeScheduleUpdate();
+
+		if (!op.hasTokenId()) {
+			return INVALID_TOKEN_ID;
+		}
+
+		return OK;
+	}
+	private void abortWith(ResponseCodeEnum cause) {
+		txnCtx.setStatus(cause);
 	}
 }

--- a/hedera-node/src/main/java/com/hedera/services/txns/token/TokenFeeScheduleUpdateTransitionLogic.java
+++ b/hedera-node/src/main/java/com/hedera/services/txns/token/TokenFeeScheduleUpdateTransitionLogic.java
@@ -21,6 +21,7 @@ package com.hedera.services.txns.token;
  */
 
 import com.hedera.services.context.TransactionContext;
+import com.hedera.services.context.properties.GlobalDynamicProperties;
 import com.hedera.services.store.TypedTokenStore;
 import com.hedera.services.txns.TransitionLogic;
 import com.hedera.services.txns.validation.OptionValidator;
@@ -33,12 +34,14 @@ public class TokenFeeScheduleUpdateTransitionLogic implements TransitionLogic {
 	private final TypedTokenStore tokenStore;
 	private final OptionValidator validator;
 	private final TransactionContext txnCtx;
+	private final GlobalDynamicProperties dynamicProperties;
 
 	public TokenFeeScheduleUpdateTransitionLogic(final TypedTokenStore tokenStore, final TransactionContext txnCtx,
-			final OptionValidator validator) {
+			final OptionValidator validator, final GlobalDynamicProperties dynamicProperties) {
 		this.tokenStore = tokenStore; // we can change this to HederaTokenStore for simplicity and refactor later.
 		this.txnCtx = txnCtx;
 		this.validator = validator;
+		this.dynamicProperties = dynamicProperties;
 	}
 
 	@Override

--- a/hedera-node/src/main/java/com/hedera/services/txns/token/TokenUpdateTransitionLogic.java
+++ b/hedera-node/src/main/java/com/hedera/services/txns/token/TokenUpdateTransitionLogic.java
@@ -211,7 +211,8 @@ public class TokenUpdateTransitionLogic implements TransitionLogic {
 				op.hasKycKey(), op.getKycKey(),
 				op.hasWipeKey(), op.getWipeKey(),
 				op.hasSupplyKey(), op.getSupplyKey(),
-				op.hasFreezeKey(), op.getFreezeKey());
+				op.hasFreezeKey(), op.getFreezeKey(),
+				op.hasFeeScheduleKey(), op.getFeeScheduleKey());
 		if (validity != OK) {
 			return validity;
 		}

--- a/hedera-node/src/main/java/com/hedera/services/txns/validation/TokenListChecks.java
+++ b/hedera-node/src/main/java/com/hedera/services/txns/validation/TokenListChecks.java
@@ -41,6 +41,7 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_TOKEN_
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_TOKEN_INITIAL_SUPPLY;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_TOKEN_MAX_SUPPLY;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_WIPE_KEY;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_CUSTOM_FEE_SCHEDULE_KEY;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.NOT_SUPPORTED;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OK;
 
@@ -103,7 +104,8 @@ public class TokenListChecks {
             boolean hasKycKey, Key kycKey,
             boolean hasWipeKey, Key wipeKey,
             boolean hasSupplyKey, Key supplyKey,
-            boolean hasFreezeKey, Key freezeKey
+            boolean hasFreezeKey, Key freezeKey,
+            boolean hasFeeScheduleKey, Key feeScheduleKey
     ) {
         ResponseCodeEnum validity = OK;
 
@@ -129,6 +131,11 @@ public class TokenListChecks {
         }
         if (hasFreezeKey) {
             if ((validity = checkKey(freezeKey, INVALID_FREEZE_KEY)) != OK) {
+                return validity;
+            }
+        }
+        if (hasFeeScheduleKey) {
+            if ((validity = checkKey(feeScheduleKey, INVALID_CUSTOM_FEE_SCHEDULE_KEY)) != OK) {
                 return validity;
             }
         }

--- a/hedera-node/src/test/java/com/hedera/services/store/TypedTokenStoreTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/store/TypedTokenStoreTest.java
@@ -380,12 +380,16 @@ class TypedTokenStoreTest {
 	private final JKey feeScheduleKey = TxnHandlingScenario.TOKEN_FEE_SCHEDULE_KT.asJKeyUnchecked();
 	private final List<FcCustomFee> feeSchedule = setUpFeeSchedule();
 	private final long tokenNum = 4_234L;
+	private final long nonfungibleTokenNum = 6_666L;
 	private final long tokenSupply = 777L;
 	private final String name = "Testing123";
 	private final String symbol = "T123";
 	private final MerkleEntityId merkleTokenId = new MerkleEntityId(0, 0, tokenNum);
 	private final Id tokenId = new Id(0, 0, tokenNum);
+	private final MerkleEntityId nonfungibleMerkleTokenId = new MerkleEntityId(0, 0, nonfungibleTokenNum);
+	private final Id nonfungibleTokenId = new Id(0, 0, nonfungibleTokenNum);
 	private final Token token = new Token(tokenId);
+	private final Token nonfungibleToken = new Token(nonfungibleTokenId);
 
 	private final boolean frozen = false;
 	private final boolean kycGranted = true;
@@ -394,7 +398,13 @@ class TypedTokenStoreTest {
 			0, 0, miscAccountNum,
 			0, 0, tokenNum);
 	private final TokenRelationship miscTokenRel = new TokenRelationship(token, miscAccount);
+	private final MerkleEntityAssociation nonfungibleTokenRelId = new MerkleEntityAssociation(
+			0, 0, miscAccountNum,
+			0, 0, nonfungibleTokenNum);
+	private final TokenRelationship nonfungibleTokenRel = new TokenRelationship(nonfungibleToken, miscAccount);
 
 	private MerkleToken merkleToken;
 	private MerkleTokenRelStatus miscTokenMerkleRel;
+	private MerkleToken nonFungibleMerkleToken;
+	private MerkleTokenRelStatus nonFungibleTokenMerkleRel;
 }

--- a/hedera-node/src/test/java/com/hedera/services/store/TypedTokenStoreTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/store/TypedTokenStoreTest.java
@@ -32,6 +32,7 @@ import com.hedera.services.state.merkle.MerkleTokenRelStatus;
 import com.hedera.services.state.merkle.MerkleUniqueToken;
 import com.hedera.services.state.merkle.MerkleUniqueTokenId;
 import com.hedera.services.state.submerkle.EntityId;
+import com.hedera.services.state.submerkle.FcCustomFee;
 import com.hedera.services.state.submerkle.RichInstant;
 import com.hedera.services.store.models.Account;
 import com.hedera.services.store.models.Id;
@@ -41,6 +42,10 @@ import com.hedera.services.store.models.Token;
 import com.hedera.services.store.models.TokenRelationship;
 import com.hedera.services.store.models.UniqueToken;
 import com.hedera.test.factories.scenarios.TxnHandlingScenario;
+import com.hederahashgraph.api.proto.java.CustomFee;
+import com.hederahashgraph.api.proto.java.FixedFee;
+import com.hederahashgraph.api.proto.java.Fraction;
+import com.hederahashgraph.api.proto.java.FractionalFee;
 import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
 import com.swirlds.fchashmap.FCOneToManyRelation;
 import com.swirlds.fcmap.FCMap;
@@ -50,10 +55,13 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.List;
+
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.ACCOUNT_EXPIRED_AND_PENDING_REMOVAL;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_TOKEN_ID;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TOKEN_NOT_ASSOCIATED_TO_ACCOUNT;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TOKEN_WAS_DELETED;
+import static java.util.stream.Collectors.toList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.BDDMockito.given;
@@ -230,6 +238,8 @@ class TypedTokenStoreTest {
 		expectedReplacementToken.setFreezeKey(freezeKey);
 		expectedReplacementToken.setKycKey(kycKey);
 		expectedReplacementToken.setAccountsFrozenByDefault(!freezeDefault);
+		expectedReplacementToken.setFeeSchedule(feeSchedule);
+		expectedReplacementToken.setFeeScheduleKey(feeScheduleKey);
 		// and:
 		final var expectedNewUniqTokenId = new MerkleUniqueTokenId(tokenEntityId, mintedSerialNo);
 		final var expectedNewUniqToken = new MerkleUniqueToken(treasuryId, nftMeta, creationTime);
@@ -302,6 +312,8 @@ class TypedTokenStoreTest {
 		merkleToken.setSupplyKey(supplyKey);
 		merkleToken.setKycKey(kycKey);
 		merkleToken.setFreezeKey(freezeKey);
+		merkleToken.setFeeScheduleKey(feeScheduleKey);
+		merkleToken.setFeeSchedule(feeSchedule);
 
 		token.setTreasury(treasuryAccount);
 		token.setAutoRenewAccount(autoRenewAccount);
@@ -309,7 +321,9 @@ class TypedTokenStoreTest {
 		token.setKycKey(kycKey);
 		token.setSupplyKey(supplyKey);
 		token.setFreezeKey(freezeKey);
+		token.setFeeScheduleKey(feeScheduleKey);
 		token.setFrozenByDefault(freezeDefault);
+		token.setFeeSchedule(feeSchedule);
 	}
 
 	private void setupTokenRel() {
@@ -318,6 +332,34 @@ class TypedTokenStoreTest {
 		miscTokenRel.setFrozen(frozen);
 		miscTokenRel.setKycGranted(kycGranted);
 		miscTokenRel.setNotYetPersisted(false);
+	}
+
+	private List<FcCustomFee> setUpFeeSchedule() {
+		final long validNumerator = 5;
+		final long validDenominator = 100;
+		final long fixedUnitsToCollect = 7;
+		final long minimumUnitsToCollect = 1;
+		final long maximumUnitsToCollect = 55;
+		final EntityId denom = new EntityId(1,2, 3);
+		final EntityId feeCollector = new EntityId(4,5, 6);
+		final CustomFee fractionalFee = CustomFee.newBuilder()
+				.setFeeCollectorAccountId(feeCollector.toGrpcAccountId())
+				.setFractionalFee(FractionalFee.newBuilder()
+						.setFractionalAmount(Fraction.newBuilder()
+								.setNumerator(validNumerator)
+								.setDenominator(validDenominator)
+								.build())
+						.setMinimumAmount(minimumUnitsToCollect)
+						.setMaximumAmount(maximumUnitsToCollect)
+				).build();
+		final CustomFee fixedFee = CustomFee.newBuilder()
+				.setFeeCollectorAccountId(feeCollector.toGrpcAccountId())
+				.setFixedFee(FixedFee.newBuilder()
+						.setDenominatingTokenId(denom.toGrpcTokenId())
+						.setAmount(fixedUnitsToCollect)
+				).build();
+		final List<CustomFee> grpcFeeSchedule = List.of(fixedFee, fractionalFee);
+		return grpcFeeSchedule.stream().map(FcCustomFee::fromGrpc).collect(toList());
 	}
 
 	private final long expiry = 1_234_567L;
@@ -335,6 +377,8 @@ class TypedTokenStoreTest {
 	private final JKey kycKey = TxnHandlingScenario.TOKEN_KYC_KT.asJKeyUnchecked();
 	private final JKey freezeKey = TxnHandlingScenario.TOKEN_FREEZE_KT.asJKeyUnchecked();
 	private final JKey supplyKey = TxnHandlingScenario.TOKEN_SUPPLY_KT.asJKeyUnchecked();
+	private final JKey feeScheduleKey = TxnHandlingScenario.TOKEN_FEE_SCHEDULE_KT.asJKeyUnchecked();
+	private final List<FcCustomFee> feeSchedule = setUpFeeSchedule();
 	private final long tokenNum = 4_234L;
 	private final long tokenSupply = 777L;
 	private final String name = "Testing123";

--- a/hedera-node/src/test/java/com/hedera/services/store/models/TokenRelationshipTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/store/models/TokenRelationshipTest.java
@@ -61,7 +61,7 @@ class TokenRelationshipTest {
 		final var desired = "TokenRelationship{notYetPersisted=true, " +
 				"account=Account{id=Id{shard=1, realm=0, num=1234}, expiry=0, balance=0, deleted=false, " +
 				"tokens=<N/A>}, token=Token{id=Id{shard=0, realm=0, num=1234}, treasury=null, autoRenewAccount=null, " +
-				"kycKey=<N/A>, freezeKey=<N/A>, frozenByDefault=false, supplyKey=<N/A>}, balance=1234, " +
+				"kycKey=<N/A>, freezeKey=<N/A>, frozenByDefault=false, supplyKey=<N/A>, feeScheduleKey=<N/A>, feeSchedule=null}, balance=1234, " +
 				"balanceChange=0, frozen=false, kycGranted=false}";
 
 		// expect:

--- a/hedera-node/src/test/java/com/hedera/services/store/tokens/ExceptionalTokenStoreTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/store/tokens/ExceptionalTokenStoreTest.java
@@ -70,6 +70,7 @@ class ExceptionalTokenStoreTest {
 		assertThrows(UnsupportedOperationException.class, NOOP_TOKEN_STORE::commitCreation);
 		assertThrows(UnsupportedOperationException.class, NOOP_TOKEN_STORE::rollbackCreation);
 		assertThrows(UnsupportedOperationException.class, NOOP_TOKEN_STORE::isCreationPending);
+		assertThrows(UnsupportedOperationException.class, () -> NOOP_TOKEN_STORE.updateFeeSchedule(null));
 		// and:
 		assertDoesNotThrow(() -> NOOP_TOKEN_STORE.setAccountsLedger(null));
 		assertDoesNotThrow(() -> NOOP_TOKEN_STORE.setHederaLedger(null));

--- a/hedera-node/src/test/java/com/hedera/services/txns/token/TokenCreateTransitionLogicTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/txns/token/TokenCreateTransitionLogicTest.java
@@ -50,6 +50,7 @@ import java.util.Optional;
 
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.FAIL_INVALID;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_ADMIN_KEY;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_CUSTOM_FEE_SCHEDULE_KEY;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_EXPIRATION_TIME;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_FREEZE_KEY;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_KYC_KEY;
@@ -453,6 +454,14 @@ class TokenCreateTransitionLogicTest {
 	}
 
 	@Test
+	void rejectsInvalidFeeSchedule() {
+		givenInvalidFeeScheduleKey();
+
+		// expect:
+		assertEquals(INVALID_CUSTOM_FEE_SCHEDULE_KEY, subject.semanticCheck().apply(tokenCreateTxn));
+	}
+
+	@Test
 	void rejectsInvalidAdminKey() {
 		givenInvalidAdminKey();
 
@@ -661,6 +670,16 @@ class TokenCreateTransitionLogicTest {
 						.setDecimals(decimals)
 						.setTreasury(treasury)
 						.setAdminKey(Key.getDefaultInstance()))
+				.build();
+	}
+
+	private void givenInvalidFeeScheduleKey() {
+		tokenCreateTxn = TransactionBody.newBuilder()
+				.setTokenCreation(TokenCreateTransactionBody.newBuilder()
+						.setInitialSupply(initialSupply)
+						.setDecimals(decimals)
+						.setTreasury(treasury)
+						.setFeeScheduleKey(Key.getDefaultInstance()))
 				.build();
 	}
 

--- a/hedera-node/src/test/java/com/hedera/services/txns/validation/TokenListChecksTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/txns/validation/TokenListChecksTest.java
@@ -28,6 +28,8 @@ import org.junit.jupiter.api.Test;
 
 import java.util.function.Predicate;
 
+import static com.hedera.services.txns.validation.PureValidation.checkKey;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_CUSTOM_FEE_SCHEDULE_KEY;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_TOKEN_DECIMALS;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_TOKEN_INITIAL_SUPPLY;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_TOKEN_MAX_SUPPLY;
@@ -118,6 +120,24 @@ class TokenListChecksTest {
 		//
 		validity = TokenListChecks.supplyTypeCheck(TokenSupplyType.UNRECOGNIZED, 10);
 		assertEquals(NOT_SUPPORTED, validity);
+	}
+
+	@Test
+	void checksInvalidFeeScheduleKey(){
+		// setup:
+		given(checkKey(any(), INVALID_CUSTOM_FEE_SCHEDULE_KEY)).willReturn(INVALID_CUSTOM_FEE_SCHEDULE_KEY);
+
+		// when:
+		var validity = TokenListChecks.checkKeys(
+				false, Key.getDefaultInstance(),
+				false, Key.getDefaultInstance(),
+				false, Key.getDefaultInstance(),
+				false, Key.getDefaultInstance(),
+				false, Key.getDefaultInstance(),
+				true, Key.getDefaultInstance());
+
+		// then:
+		assertEquals(INVALID_CUSTOM_FEE_SCHEDULE_KEY, validity);
 	}
 
 }

--- a/hedera-node/src/test/java/com/hedera/services/txns/validation/TokenListChecksTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/txns/validation/TokenListChecksTest.java
@@ -53,6 +53,7 @@ class TokenListChecksTest {
 				false, Key.getDefaultInstance(),
 				false, Key.getDefaultInstance(),
 				false, Key.getDefaultInstance(),
+				false, Key.getDefaultInstance(),
 				false, Key.getDefaultInstance());
 
 		// then:

--- a/hedera-node/src/test/java/com/hedera/services/txns/validation/TokenListChecksTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/txns/validation/TokenListChecksTest.java
@@ -22,13 +22,13 @@ package com.hedera.services.txns.validation;
 
 import com.hedera.services.sigs.utils.ImmutableKeyUtils;
 import com.hederahashgraph.api.proto.java.Key;
+import com.hederahashgraph.api.proto.java.KeyList;
 import com.hederahashgraph.api.proto.java.TokenSupplyType;
 import com.hederahashgraph.api.proto.java.TokenType;
 import org.junit.jupiter.api.Test;
 
 import java.util.function.Predicate;
 
-import static com.hedera.services.txns.validation.PureValidation.checkKey;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_CUSTOM_FEE_SCHEDULE_KEY;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_TOKEN_DECIMALS;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_TOKEN_INITIAL_SUPPLY;
@@ -123,9 +123,10 @@ class TokenListChecksTest {
 	}
 
 	@Test
-	void checksInvalidFeeScheduleKey(){
+	void checksInvalidFeeScheduleKey() {
 		// setup:
-		given(checkKey(any(), INVALID_CUSTOM_FEE_SCHEDULE_KEY)).willReturn(INVALID_CUSTOM_FEE_SCHEDULE_KEY);
+		KeyList invalidKeyList1 = KeyList.newBuilder().build();
+		Key invalidFeeScheduleKey = Key.newBuilder().setKeyList(invalidKeyList1).build();
 
 		// when:
 		var validity = TokenListChecks.checkKeys(
@@ -134,7 +135,7 @@ class TokenListChecksTest {
 				false, Key.getDefaultInstance(),
 				false, Key.getDefaultInstance(),
 				false, Key.getDefaultInstance(),
-				true, Key.getDefaultInstance());
+				true, invalidFeeScheduleKey);
 
 		// then:
 		assertEquals(INVALID_CUSTOM_FEE_SCHEDULE_KEY, validity);


### PR DESCRIPTION
Signed-off-by: anighanta <anirudh.ghanta@hedera.com>

**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->
Add feeSchedule and feeScheduleKey to the Token Model.
Update TypedTokenStore to set these fields and also persist changes to these fields.

**Related issue(s)**:

Addresses #1722 
Closes #1750 

**Checklist**
- [x] Tested (unit, integration, etc.)
