### PR TITLE
01730 m infer default fee data from old json

### DIFF
--- a/hedera-node/src/main/java/com/hedera/services/fees/calculation/AwareFcfsUsagePrices.java
+++ b/hedera-node/src/main/java/com/hedera/services/fees/calculation/AwareFcfsUsagePrices.java
@@ -206,6 +206,9 @@ public class AwareFcfsUsagePrices implements UsagePricesProvider {
 				if (FUNCTIONS_WITH_TOKEN_TYPE_SPECIALIZATIONS.contains(function)) {
 					map.put(SubType.TOKEN_FUNGIBLE_COMMON, untypedPrices);
 					map.put(SubType.TOKEN_NON_FUNGIBLE_UNIQUE, untypedPrices);
+					if (function == TokenAccountWipe) {
+						map.put(SubType.DEFAULT, untypedPrices);
+					}
 				} else {
 					map.put(SubType.DEFAULT, untypedPrices);
 				}

--- a/hedera-node/src/main/java/com/hedera/services/fees/calculation/AwareFcfsUsagePrices.java
+++ b/hedera-node/src/main/java/com/hedera/services/fees/calculation/AwareFcfsUsagePrices.java
@@ -32,18 +32,21 @@ import com.hederahashgraph.api.proto.java.HederaFunctionality;
 import com.hederahashgraph.api.proto.java.SubType;
 import com.hederahashgraph.api.proto.java.Timestamp;
 import com.hederahashgraph.api.proto.java.TimestampSeconds;
-import com.hederahashgraph.api.proto.java.TransactionFeeSchedule;
 import org.apache.commons.lang3.tuple.Triple;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.time.Instant;
 import java.util.EnumMap;
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 
 import static com.hedera.services.utils.EntityIdUtils.readableId;
+import static com.hederahashgraph.api.proto.java.HederaFunctionality.TokenAccountWipe;
+import static com.hederahashgraph.api.proto.java.HederaFunctionality.TokenBurn;
+import static com.hederahashgraph.api.proto.java.HederaFunctionality.TokenMint;
 
 /**
  * Implements a {@link UsagePricesProvider} by loading the required
@@ -53,6 +56,12 @@ import static com.hedera.services.utils.EntityIdUtils.readableId;
  */
 public class AwareFcfsUsagePrices implements UsagePricesProvider {
 	private static final Logger log = LogManager.getLogger(AwareFcfsUsagePrices.class);
+
+	private static EnumSet<HederaFunctionality> FUNCTIONS_WITH_TOKEN_TYPE_SPECIALIZATIONS = EnumSet.of(
+			TokenMint,
+			TokenBurn,
+			TokenAccountWipe
+	);
 
 	public static long DEFAULT_FEE = 100_000L;
 
@@ -181,17 +190,31 @@ public class AwareFcfsUsagePrices implements UsagePricesProvider {
 		return Timestamp.newBuilder().setSeconds(ts.getSeconds()).build();
 	}
 
-	private EnumMap<HederaFunctionality, Map<SubType, FeeData>> functionUsagePricesFrom(FeeSchedule feeSchedule) {
+	EnumMap<HederaFunctionality, Map<SubType, FeeData>> functionUsagePricesFrom(FeeSchedule feeSchedule) {
 		EnumMap<HederaFunctionality, Map<SubType, FeeData>> feeScheduleMap = new EnumMap<>(HederaFunctionality.class);
-		for (TransactionFeeSchedule transactionFeeSchedule : feeSchedule.getTransactionFeeScheduleList()) {
-			Map<SubType, FeeData> map = feeScheduleMap.get(transactionFeeSchedule.getHederaFunctionality());
+		for (var txnFeeSchedule : feeSchedule.getTransactionFeeScheduleList()) {
+			final var function = txnFeeSchedule.getHederaFunctionality();
+
+			Map<SubType, FeeData> map = feeScheduleMap.get(function);
 			if (map == null) {
 				map = new HashMap<>();
 			}
-			for (FeeData feeData : transactionFeeSchedule.getFeesList()) {
+
+			if (txnFeeSchedule.hasFeeData()) {
+				final var untypedPrices = txnFeeSchedule.getFeeData();
+				/* Must be from a pre-0.16.0 signed state when there were no fee sub-types */
+				if (FUNCTIONS_WITH_TOKEN_TYPE_SPECIALIZATIONS.contains(function)) {
+					map.put(SubType.TOKEN_FUNGIBLE_COMMON, untypedPrices);
+					map.put(SubType.TOKEN_NON_FUNGIBLE_UNIQUE, untypedPrices);
+				} else {
+					map.put(SubType.DEFAULT, untypedPrices);
+				}
+			}
+
+			for (var feeData : txnFeeSchedule.getFeesList()) {
 				map.put(feeData.getSubType(), feeData);
 			}
-			feeScheduleMap.put(transactionFeeSchedule.getHederaFunctionality(), map);
+			feeScheduleMap.put(txnFeeSchedule.getHederaFunctionality(), map);
 		}
 		return feeScheduleMap;
 	}

--- a/hedera-node/src/test/java/com/hedera/services/fees/calculation/AwareFcfsUsagePricesTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/fees/calculation/AwareFcfsUsagePricesTest.java
@@ -328,13 +328,14 @@ class AwareFcfsUsagePricesTest {
 		assertEquals(1, xferTypedPricesMap.size());
 		assertEquals(2, mintTypedPricesMap.size());
 		assertEquals(2, burnTypedPricesMap.size());
-		assertEquals(2, wipeTypedPricesMap.size());
+		assertEquals(3, wipeTypedPricesMap.size());
 		// and:
 		assertEquals(currUsagePrices, xferTypedPricesMap.get(SubType.DEFAULT));
 		assertEquals(currUsagePrices, mintTypedPricesMap.get(SubType.TOKEN_FUNGIBLE_COMMON));
 		assertEquals(currUsagePrices, mintTypedPricesMap.get(SubType.TOKEN_NON_FUNGIBLE_UNIQUE));
 		assertEquals(currUsagePrices, burnTypedPricesMap.get(SubType.TOKEN_FUNGIBLE_COMMON));
 		assertEquals(currUsagePrices, burnTypedPricesMap.get(SubType.TOKEN_NON_FUNGIBLE_UNIQUE));
+		assertEquals(currUsagePrices, wipeTypedPricesMap.get(SubType.DEFAULT));
 		assertEquals(currUsagePrices, wipeTypedPricesMap.get(SubType.TOKEN_FUNGIBLE_COMMON));
 		assertEquals(currUsagePrices, wipeTypedPricesMap.get(SubType.TOKEN_NON_FUNGIBLE_UNIQUE));
 	}

--- a/hedera-node/src/test/java/com/hedera/services/fees/calculation/AwareFcfsUsagePricesTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/fees/calculation/AwareFcfsUsagePricesTest.java
@@ -35,6 +35,7 @@ import com.hederahashgraph.api.proto.java.FeeComponents;
 import com.hederahashgraph.api.proto.java.FeeData;
 import com.hederahashgraph.api.proto.java.FeeSchedule;
 import com.hederahashgraph.api.proto.java.FileID;
+import com.hederahashgraph.api.proto.java.HederaFunctionality;
 import com.hederahashgraph.api.proto.java.SubType;
 import com.hederahashgraph.api.proto.java.Timestamp;
 import com.hederahashgraph.api.proto.java.TimestampSeconds;
@@ -53,6 +54,9 @@ import java.util.Map;
 
 import static com.hedera.services.fees.calculation.AwareFcfsUsagePrices.DEFAULT_USAGE_PRICES;
 import static com.hederahashgraph.api.proto.java.HederaFunctionality.CryptoTransfer;
+import static com.hederahashgraph.api.proto.java.HederaFunctionality.TokenAccountWipe;
+import static com.hederahashgraph.api.proto.java.HederaFunctionality.TokenBurn;
+import static com.hederahashgraph.api.proto.java.HederaFunctionality.TokenMint;
 import static com.hederahashgraph.api.proto.java.HederaFunctionality.UNRECOGNIZED;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -308,5 +312,46 @@ class AwareFcfsUsagePricesTest {
 
 		// then:
 		assertEquals(DEFAULT_USAGE_PRICES, prices);
+	}
+
+	@Test
+	void translatesFromUntypedFeeSchedule() {
+		// given:
+		final var inferred = subject.functionUsagePricesFrom(getPreSubTypeFeeSchedule());
+		// and:
+		final var xferTypedPricesMap = inferred.get(CryptoTransfer);
+		final var mintTypedPricesMap = inferred.get(TokenMint);
+		final var burnTypedPricesMap = inferred.get(TokenBurn);
+		final var wipeTypedPricesMap = inferred.get(TokenAccountWipe);
+
+		// expect:
+		assertEquals(1, xferTypedPricesMap.size());
+		assertEquals(2, mintTypedPricesMap.size());
+		assertEquals(2, burnTypedPricesMap.size());
+		assertEquals(2, wipeTypedPricesMap.size());
+		// and:
+		assertEquals(currUsagePrices, xferTypedPricesMap.get(SubType.DEFAULT));
+		assertEquals(currUsagePrices, mintTypedPricesMap.get(SubType.TOKEN_FUNGIBLE_COMMON));
+		assertEquals(currUsagePrices, mintTypedPricesMap.get(SubType.TOKEN_NON_FUNGIBLE_UNIQUE));
+		assertEquals(currUsagePrices, burnTypedPricesMap.get(SubType.TOKEN_FUNGIBLE_COMMON));
+		assertEquals(currUsagePrices, burnTypedPricesMap.get(SubType.TOKEN_NON_FUNGIBLE_UNIQUE));
+		assertEquals(currUsagePrices, wipeTypedPricesMap.get(SubType.TOKEN_FUNGIBLE_COMMON));
+		assertEquals(currUsagePrices, wipeTypedPricesMap.get(SubType.TOKEN_NON_FUNGIBLE_UNIQUE));
+	}
+
+	private FeeSchedule getPreSubTypeFeeSchedule() {
+		return FeeSchedule.newBuilder()
+				.addTransactionFeeSchedule(untypedTransactionFeeSchedule(CryptoTransfer))
+				.addTransactionFeeSchedule(untypedTransactionFeeSchedule(TokenMint))
+				.addTransactionFeeSchedule(untypedTransactionFeeSchedule(TokenBurn))
+				.addTransactionFeeSchedule(untypedTransactionFeeSchedule(TokenAccountWipe))
+				.build();
+	}
+
+	private TransactionFeeSchedule untypedTransactionFeeSchedule(HederaFunctionality function) {
+		return TransactionFeeSchedule.newBuilder()
+				.setHederaFunctionality(function)
+				.setFeeData(currUsagePrices)
+				.build();
 	}
 }

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenManagementSpecs.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenManagementSpecs.java
@@ -26,6 +26,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.List;
+import java.util.Map;
 
 import static com.hedera.services.bdd.spec.HapiApiSpec.defaultHapiSpec;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getAccountBalance;
@@ -36,6 +37,7 @@ import static com.hedera.services.bdd.spec.queries.crypto.ExpectedTokenRel.relat
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.burnToken;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoCreate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoTransfer;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.fileUpdate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.grantTokenKyc;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.mintToken;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.revokeTokenKyc;
@@ -74,21 +76,22 @@ public class TokenManagementSpecs extends HapiApiSuite {
 	protected List<HapiApiSpec> getSpecsInSuite() {
 		return allOf(
 				List.of(new HapiApiSpec[] {
-//								freezeMgmtFailureCasesWork(),
-//								freezeMgmtSuccessCasesWork(),
-//								kycMgmtFailureCasesWork(),
-//								kycMgmtSuccessCasesWork(),
-//								supplyMgmtSuccessCasesWork(),
-//								wipeAccountFailureCasesWork(),
-//								wipeAccountSuccessCasesWork(),
+								freezeMgmtFailureCasesWork(),
+								freezeMgmtSuccessCasesWork(),
+								kycMgmtFailureCasesWork(),
+								kycMgmtSuccessCasesWork(),
+								supplyMgmtSuccessCasesWork(),
+								wipeAccountFailureCasesWork(),
+								wipeAccountSuccessCasesWork(),
 								supplyMgmtFailureCasesWork(),
-//								burnTokenFailsDueToInsufficientTreasuryBalance(),
-//								frozenTreasuryCannotBeMintedOrBurned(),
-//								revokedKYCTreasuryCannotBeMintedOrBurned(),
+								burnTokenFailsDueToInsufficientTreasuryBalance(),
+								frozenTreasuryCannotBeMintedOrBurned(),
+								revokedKYCTreasuryCannotBeMintedOrBurned(),
 						}
 				)
 		);
 	}
+
 
 	private HapiApiSpec frozenTreasuryCannotBeMintedOrBurned() {
 		return defaultHapiSpec("FrozenTreasuryCannotBeMintedOrBurned")
@@ -309,6 +312,11 @@ public class TokenManagementSpecs extends HapiApiSuite {
 
 		return defaultHapiSpec("FreezeMgmtFailureCasesWork")
 				.given(
+							fileUpdate(APP_PROPERTIES)
+									.payingWith(ADDRESS_BOOK_CONTROL)
+									.overridingProps(Map.of(
+											"tokens.maxPerAccount", "" + 1000
+									)),
 						newKeyNamed("oneFreeze"),
 						cryptoCreate(TOKEN_TREASURY).balance(0L),
 						cryptoCreate("go").balance(0L),


### PR DESCRIPTION
**Changes**:
- Migrate prices from deprecated `TransactionFeeSchedule.feeData` into a `SubType -> FeeData` map at startup.
- On EET side, translate a downloaded 0.15.x fee schedule into a form usable by 0.16.0 EET clients.