### PR TITLE
Stack trace shouldn't be printed by default'

### DIFF
--- a/test-clients/src/main/java/com/hedera/services/bdd/spec/HapiSpecOperation.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/spec/HapiSpecOperation.java
@@ -206,7 +206,6 @@ public abstract class HapiSpecOperation {
 				updateStateOf(spec);
 			}
 		} catch (Throwable t) {
-			t.printStackTrace();
 			if (unavailableNode && t.getMessage().startsWith("UNAVAILABLE")) {
 				log.info("Node {} is unavailable as expected!", HapiPropertySource.asAccountString(node.get()));
 				return Optional.empty();


### PR DESCRIPTION
**Issues**
- Expected to close #1745 and close #1746

**Summary of change**
- Don't `printStackTrace()` in `HapiSpecOperation` by default.
