### PR TITLE
Include nft ops in reconnect throttles JSON

### DIFF
--- a/test-clients/src/main/resource/testSystemFiles/artificial-limits-6N.json
+++ b/test-clients/src/main/resource/testSystemFiles/artificial-limits-6N.json
@@ -9,7 +9,7 @@
                     "operations": [
                         "CryptoCreate", "CryptoTransfer", "CryptoUpdate", "CryptoDelete", "CryptoGetInfo", "CryptoGetAccountRecords",
                         "ConsensusCreateTopic", "ConsensusSubmitMessage", "ConsensusUpdateTopic", "ConsensusDeleteTopic", "ConsensusGetTopicInfo",
-                        "TokenGetInfo",
+                        "TokenGetInfo", "TokenGetNftInfo", "TokenGetAccountNftInfos",
                         "ScheduleDelete", "ScheduleGetInfo",
                         "FileGetContents", "FileGetInfo",
                         "ContractUpdate", "ContractDelete", "ContractGetInfo", "ContractGetBytecode", "ContractGetRecords", "ContractCallLocal", 


### PR DESCRIPTION
The `ValidateCongestionPricingAfterReconnect` suite uses _test-clients/src/main/resource/artificial-limits-6N.json_ but the NFT operations weren't added.