### PR TITLE
Change export timing and remove .csv export.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1685,7 +1685,7 @@ workflows:
   GCP-Daily-Services-Account-Balances-client-validation-6N-1C:
     triggers:
       - schedule:
-          cron: "40 6 * * *"
+          cron: "30 6 * * *"
           filters:
             branches:
               only:

--- a/hedera-node/src/main/resources/bootstrap.properties
+++ b/hedera-node/src/main/resources/bootstrap.properties
@@ -40,7 +40,7 @@ ledger.totalTinyBarFloat=5000000000000000000
 # Dynamic properties
 balances.exportDir.path=/opt/hgcapp/accountBalances/
 balances.exportEnabled=true
-balances.exportPeriodSecs=600
+balances.exportPeriodSecs=900
 balances.exportTokenBalances=true
 balances.nodeBalanceWarningThreshold=0
 cache.records.ttl=180

--- a/hedera-node/src/test/java/com/hedera/services/context/properties/BootstrapPropertiesTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/context/properties/BootstrapPropertiesTest.java
@@ -70,7 +70,7 @@ class BootstrapPropertiesTest {
 			entry("accounts.addressBookAdmin", 55L),
 			entry("balances.exportDir.path", "/opt/hgcapp/accountBalances/"),
 			entry("balances.exportEnabled", true),
-			entry("balances.exportPeriodSecs", 600),
+			entry("balances.exportPeriodSecs", 900),
 			entry("balances.exportTokenBalances", true),
 			entry("balances.nodeBalanceWarningThreshold", 0L),
 			entry("accounts.exchangeRatesAdmin", 57L),

--- a/hedera-node/src/test/resources/bootstrap/standard.properties
+++ b/hedera-node/src/test/resources/bootstrap/standard.properties
@@ -40,7 +40,7 @@ ledger.totalTinyBarFloat=5000000000000000000
 # Dynamic properties
 balances.exportDir.path=/opt/hgcapp/accountBalances/
 balances.exportEnabled=true
-balances.exportPeriodSecs=600
+balances.exportPeriodSecs=900
 balances.exportTokenBalances=true
 balances.nodeBalanceWarningThreshold=0
 cache.records.ttl=180


### PR DESCRIPTION
**Description**:
This PR changes the account balances export timing algorithm in order to minimize chances to skip exporting in low TPS environment. 

1. Changed the algorithm to anchor to export period boundary. It will now export account balances at earliest possible consensus time event even it's away from expected export boundary;
2. Changed the default export period to 15 mins;
3. Removed the export of .csv account balance files;

**Related issue(s)**:

Fixes #1732

**Notes for reviewer**:
Slack summary for JRS results for JRS tests:  https://hedera-hashgraph.slack.com/archives/C018CBQBTGB/p1625723064314100

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
