### PR TITLE
Fix NFT record issues

### DIFF
--- a/hedera-node/src/main/java/com/hedera/services/ledger/BalanceChange.java
+++ b/hedera-node/src/main/java/com/hedera/services/ledger/BalanceChange.java
@@ -9,9 +9,9 @@ package com.hedera.services.ledger;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -120,7 +120,7 @@ public class BalanceChange {
 		nftChange.nftId = new NftId(token.getShard(), token.getRealm(), token.getNum(), serialNo);
 		nftChange.tokenId = tokenId;
 		return nftChange;
-        }
+	}
 
 	public static BalanceChange tokenAdjust(Id account, Id token, long amount) {
 		final var tokenChange = new BalanceChange(account, amount, INSUFFICIENT_TOKEN_BALANCE);
@@ -167,7 +167,7 @@ public class BalanceChange {
 
 	public AccountID counterPartyAccountId() {
 		return counterPartyAccountId;
-        }
+	}
 
 	public Id getAccount() {
 		return account;

--- a/hedera-node/src/main/java/com/hedera/services/store/models/Token.java
+++ b/hedera-node/src/main/java/com/hedera/services/store/models/Token.java
@@ -151,9 +151,10 @@ public class Token {
 				"Non fungible burn can be invoked only on Non fungible tokens!");
 		validateFalse(serialNumbers.isEmpty(), FAIL_INVALID,
 				"Non fungible burn cannot be invoked with no serial numbers");
+		final var treasuryId = treasury.getId();
 		for (final long serialNum : serialNumbers) {
-			ownershipTracker.add(id, OwnershipTracker.forRemoving(id, serialNum));
-			removedUniqueTokens.add(new UniqueToken(id, serialNum, treasury.getId()));
+			ownershipTracker.add(id, OwnershipTracker.forRemoving(treasuryId, serialNum));
+			removedUniqueTokens.add(new UniqueToken(id, serialNum, treasuryId));
 		}
 		treasury.setOwnedNfts(treasury.getOwnedNfts() - serialNumbers.size());
 		changeSupply(treasuryRelationship, -serialNumbers.size(), FAIL_INVALID);

--- a/hedera-node/src/main/java/com/hedera/services/txns/token/TokenCreateTransitionLogic.java
+++ b/hedera-node/src/main/java/com/hedera/services/txns/token/TokenCreateTransitionLogic.java
@@ -29,6 +29,7 @@ import com.hederahashgraph.api.proto.java.AccountID;
 import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
 import com.hederahashgraph.api.proto.java.TokenCreateTransactionBody;
 import com.hederahashgraph.api.proto.java.TokenID;
+import com.hederahashgraph.api.proto.java.TokenType;
 import com.hederahashgraph.api.proto.java.TransactionBody;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -123,10 +124,12 @@ public class TokenCreateTransitionLogic implements TransitionLogic {
 			}
 		}
 
-		status = ledger.adjustTokenBalance(treasury, created, op.getInitialSupply());
-		if (status != OK) {
-			abortWith(status);
-			return;
+		if (op.getTokenType() != TokenType.NON_FUNGIBLE_UNIQUE) {
+			status = ledger.adjustTokenBalance(treasury, created, op.getInitialSupply());
+			if (status != OK) {
+				abortWith(status);
+				return;
+			}
 		}
 
 		store.commitCreation();


### PR DESCRIPTION
**Description**:
- Fix typo in `Token.mint()` to use treasury id instead of token id in `OwnershipTracker`.
- In `TokenCreateTransitionLogic`, only initialize supply via `TokenStore.adjustTokenBalance()` if token _isn't_ `NON_FUNGIBLE_UNIQUE`---this method makes stateful changes to the ledger's record-construction behavior. 