### PR TITLE
01810: Support custom fixed fees token to be created/updated

### DIFF
--- a/hedera-node/src/main/java/com/hedera/services/context/ServicesContext.java
+++ b/hedera-node/src/main/java/com/hedera/services/context/ServicesContext.java
@@ -1487,8 +1487,8 @@ public class ServicesContext {
 				entry(TokenUpdate,
 						List.of(new TokenUpdateTransitionLogic(
 								validator(), tokenStore(), ledger(), txnCtx(), HederaTokenStore::affectsExpiryAtMost))),
-				entry(TokenFeeScheduleUpdate, List.of(new TokenFeeScheduleUpdateTransitionLogic(tokenStore(), txnCtx(),
-						validator, globalDynamicProperties()))),
+				entry(TokenFeeScheduleUpdate,
+						List.of(new TokenFeeScheduleUpdateTransitionLogic(tokenStore(), txnCtx()))),
 				entry(TokenFreezeAccount,
 						List.of(new TokenFreezeTransitionLogic(tokenStore(), ledger(), txnCtx()))),
 				entry(TokenUnfreezeAccount,

--- a/hedera-node/src/main/java/com/hedera/services/state/merkle/MerkleToken.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/merkle/MerkleToken.java
@@ -569,8 +569,8 @@ public class MerkleToken extends AbstractMerkleLeaf {
 		return grpcList;
 	}
 
-	public void setFeeScheduleFrom(List<CustomFee> grpcFeeSchedule) {
-		feeSchedule = grpcFeeSchedule.stream().map(FcCustomFee::fromGrpc).collect(toList());
+	public void setFeeScheduleFrom(List<CustomFee> grpcFeeSchedule, EntityId targetId) {
+		feeSchedule = grpcFeeSchedule.stream().map(fee -> FcCustomFee.fromGrpc(fee, targetId)).collect(toList());
 	}
 
 	public void setFeeScheduleKey(final JKey feeScheduleKey) {

--- a/hedera-node/src/main/java/com/hedera/services/state/submerkle/FcCustomFee.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/submerkle/FcCustomFee.java
@@ -107,13 +107,16 @@ public class FcCustomFee implements SelfSerializable {
 		return new FcCustomFee(FIXED_FEE, feeCollector, spec, null);
 	}
 
-	public static FcCustomFee fromGrpc(CustomFee source) {
+	public static FcCustomFee fromGrpc(CustomFee source, EntityId targetId) {
 		final var feeCollector = EntityId.fromGrpcAccountId(source.getFeeCollectorAccountId());
 		if (source.hasFixedFee()) {
 			EntityId denom = null;
 			final var fixedSource = source.getFixedFee();
 			if (fixedSource.hasDenominatingTokenId()) {
 				denom = EntityId.fromGrpcTokenId(fixedSource.getDenominatingTokenId());
+				if (0 == denom.num()) {
+					denom = targetId;
+				}
 			}
 			return fixedFee(fixedSource.getAmount(), denom, feeCollector);
 		} else {

--- a/hedera-node/src/main/java/com/hedera/services/store/tokens/HederaTokenStore.java
+++ b/hedera-node/src/main/java/com/hedera/services/store/tokens/HederaTokenStore.java
@@ -406,7 +406,7 @@ public class HederaTokenStore extends HederaStore implements TokenStore {
 
 		if (request.getCustomFeesCount() > 0) {
 			final var customFees = request.getCustomFeesList();
-			validity = validateFeeSchedule(customFees, false, null, null);
+			validity = validateFeeSchedule(customFees, false, pendingId, pendingCreation);
 			if (validity != OK) {
 				return failure(validity);
 			}
@@ -435,7 +435,7 @@ public class HederaTokenStore extends HederaStore implements TokenStore {
 			}
 			ResponseCodeEnum responseCode;
 			if (customFee.hasFixedFee()) {
-				responseCode = validateFixedFee(customFee, feeCollector);
+				responseCode = validateFixedFee(customFee, feeCollector, targetTokenId);
 				if (responseCode != OK) {
 					return responseCode;
 				}
@@ -489,13 +489,17 @@ public class HederaTokenStore extends HederaStore implements TokenStore {
 
 
 	private ResponseCodeEnum validateFixedFee(CustomFee customFee,
-			AccountID feeCollector) {
+			AccountID feeCollector,
+			TokenID targetTokenId) {
 		final var fixedFee = customFee.getFixedFee();
 		if (fixedFee.getAmount() <= 0) {
 			return CUSTOM_FEE_MUST_BE_POSITIVE;
 		}
 		if (fixedFee.hasDenominatingTokenId()) {
-			final var denom = fixedFee.getDenominatingTokenId();
+			var denom = fixedFee.getDenominatingTokenId();
+			if (0 == denom.getTokenNum()) {
+				denom = targetTokenId;
+			}
 			if (resolve(denom) == MISSING_TOKEN) {
 				return INVALID_TOKEN_ID_IN_CUSTOM_FEES;
 			}
@@ -503,7 +507,7 @@ public class HederaTokenStore extends HederaStore implements TokenStore {
 			if (merkleToken.tokenType() == NON_FUNGIBLE_UNIQUE) {
 				return CUSTOM_FEE_DENOMINATION_MUST_BE_FUNGIBLE_COMMON;
 			}
-			if (!associationExists(feeCollector, denom)) {
+			if (!pendingId.equals(denom) && !associationExists(feeCollector, denom)) {
 				return TOKEN_NOT_ASSOCIATED_TO_FEE_COLLECTOR;
 			}
 		}

--- a/hedera-node/src/main/java/com/hedera/services/store/tokens/HederaTokenStore.java
+++ b/hedera-node/src/main/java/com/hedera/services/store/tokens/HederaTokenStore.java
@@ -410,7 +410,7 @@ public class HederaTokenStore extends HederaStore implements TokenStore {
 			if (validity != OK) {
 				return failure(validity);
 			}
-			pendingCreation.setFeeScheduleFrom(customFees);
+			pendingCreation.setFeeScheduleFrom(customFees, EntityId.fromGrpcTokenId(pendingId));
 		}
 
 		return success(pendingId);
@@ -750,7 +750,7 @@ public class HederaTokenStore extends HederaStore implements TokenStore {
 		if (validity != OK) {
 			return validity;
 		}
-		token.setFeeScheduleFrom(customFees);
+		token.setFeeScheduleFrom(customFees, EntityId.fromGrpcTokenId(tId));
 
 		return OK;
 	}

--- a/hedera-node/src/test/java/com/hedera/services/context/primitives/StateViewTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/context/primitives/StateViewTest.java
@@ -254,7 +254,7 @@ class StateViewTest {
 		token.setDeleted(true);
 		token.setTokenType(TokenType.FUNGIBLE_COMMON);
 		token.setSupplyType(TokenSupplyType.FINITE);
-		token.setFeeScheduleFrom(grpcCustomFees);
+		token.setFeeScheduleFrom(grpcCustomFees, null);
 
 		given(tokenStore.resolve(tokenId)).willReturn(tokenId);
 		given(tokenStore.resolve(missingTokenId)).willReturn(TokenStore.MISSING_TOKEN);

--- a/hedera-node/src/test/java/com/hedera/services/context/primitives/StateViewTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/context/primitives/StateViewTest.java
@@ -45,6 +45,7 @@ import com.hedera.test.extensions.LogCaptor;
 import com.hedera.test.extensions.LogCaptureExtension;
 import com.hedera.test.extensions.LoggingSubject;
 import com.hedera.test.factories.accounts.MerkleAccountFactory;
+import com.hedera.test.factories.fees.CustomFeeBuilder;
 import com.hedera.test.factories.scenarios.TxnHandlingScenario;
 import com.hedera.test.utils.IdUtils;
 import com.hederahashgraph.api.proto.java.AccountID;
@@ -54,9 +55,6 @@ import com.hederahashgraph.api.proto.java.CustomFee;
 import com.hederahashgraph.api.proto.java.Duration;
 import com.hederahashgraph.api.proto.java.FileGetInfoResponse;
 import com.hederahashgraph.api.proto.java.FileID;
-import com.hederahashgraph.api.proto.java.FixedFee;
-import com.hederahashgraph.api.proto.java.Fraction;
-import com.hederahashgraph.api.proto.java.FractionalFee;
 import com.hederahashgraph.api.proto.java.Key;
 import com.hederahashgraph.api.proto.java.KeyList;
 import com.hederahashgraph.api.proto.java.NftID;
@@ -95,6 +93,9 @@ import static com.hedera.services.utils.EntityIdUtils.asAccount;
 import static com.hedera.services.utils.EntityIdUtils.asSolidityAddress;
 import static com.hedera.services.utils.EntityIdUtils.asSolidityAddressHex;
 import static com.hedera.services.utils.MiscUtils.asKeyUnchecked;
+import static com.hedera.test.factories.fees.CustomFeeBuilder.fixedHbar;
+import static com.hedera.test.factories.fees.CustomFeeBuilder.fixedHts;
+import static com.hedera.test.factories.fees.CustomFeeBuilder.fractional;
 import static com.hedera.test.factories.scenarios.TxnHandlingScenario.COMPLEX_KEY_ACCOUNT_KT;
 import static com.hedera.test.factories.scenarios.TxnHandlingScenario.MISC_ACCOUNT_KT;
 import static com.hedera.test.factories.scenarios.TxnHandlingScenario.SCHEDULE_ADMIN_KT;
@@ -1005,34 +1006,18 @@ class StateViewTest {
 	private final MerkleUniqueToken targetNft = new MerkleUniqueToken(EntityId.fromGrpcAccountId(nftOwnerId), nftMeta,
 			fromJava(nftCreation));
 
-	private FixedFee fixedFeeInTokenUnits = FixedFee.newBuilder()
-			.setDenominatingTokenId(tokenId)
-			.setAmount(100)
-			.build();
-	private FixedFee fixedFeeInHbar = FixedFee.newBuilder()
-			.setAmount(100)
-			.build();
-	private Fraction fraction = Fraction.newBuilder().setNumerator(15).setDenominator(100).build();
-	private FractionalFee fractionalFee = FractionalFee.newBuilder()
-			.setFractionalAmount(fraction)
-			.setMaximumAmount(50)
-			.setMinimumAmount(10)
-			.build();
-	private CustomFee customFixedFeeInHbar = CustomFee.newBuilder()
-			.setFeeCollectorAccountId(payerAccountId)
-			.setFixedFee(fixedFeeInHbar)
-			.build();
-	private CustomFee customFixedFeeInHts = CustomFee.newBuilder()
-			.setFeeCollectorAccountId(payerAccountId)
-			.setFixedFee(fixedFeeInTokenUnits)
-			.build();
-	private CustomFee customFractionalFee = CustomFee.newBuilder()
-			.setFeeCollectorAccountId(payerAccountId)
-			.setFractionalFee(fractionalFee)
-			.build();
+	private CustomFeeBuilder builder = new CustomFeeBuilder(payerAccountId);
+	private CustomFee customFixedFeeInHbar = builder.withFixedFee(fixedHbar(100L));
+	private CustomFee customFixedFeeInHts = builder.withFixedFee(fixedHts(tokenId, 100L));
+	private CustomFee customFixedFeeSameToken = builder.withFixedFee(fixedHts(50L));
+	private CustomFee customFractionalFee = builder.withFractionalFee(
+			fractional(15L, 100L)
+					.setMinimumAmount(10L)
+					.setMaximumAmount(50L));
 	private List<CustomFee> grpcCustomFees = List.of(
 			customFixedFeeInHbar,
 			customFixedFeeInHts,
+			customFixedFeeSameToken,
 			customFractionalFee
 	);
 }

--- a/hedera-node/src/test/java/com/hedera/services/state/merkle/MerkleTokenTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/state/merkle/MerkleTokenTest.java
@@ -96,7 +96,7 @@ class MerkleTokenTest {
 	private final long maximumUnitsToCollect = 55;
 	private final EntityId denom = new EntityId(1, 2, 3);
 	private final EntityId feeCollector = new EntityId(4, 5, 6);
-	final CustomFee fractionalFee = CustomFee.newBuilder()
+	private final CustomFee fractionalFee = CustomFee.newBuilder()
 			.setFeeCollectorAccountId(feeCollector.toGrpcAccountId())
 			.setFractionalFee(FractionalFee.newBuilder()
 					.setFractionalAmount(Fraction.newBuilder()
@@ -106,14 +106,16 @@ class MerkleTokenTest {
 					.setMinimumAmount(minimumUnitsToCollect)
 					.setMaximumAmount(maximumUnitsToCollect)
 			).build();
-	final CustomFee fixedFee = CustomFee.newBuilder()
+	private final CustomFee fixedFee = CustomFee.newBuilder()
 			.setFeeCollectorAccountId(feeCollector.toGrpcAccountId())
 			.setFixedFee(FixedFee.newBuilder()
 					.setDenominatingTokenId(denom.toGrpcTokenId())
 					.setAmount(fixedUnitsToCollect)
 			).build();
-	final List<CustomFee> grpcFeeSchedule = List.of(fixedFee, fractionalFee);
-	final List<FcCustomFee> feeSchedule = grpcFeeSchedule.stream().map(FcCustomFee::fromGrpc).collect(toList());
+	private final List<CustomFee> grpcFeeSchedule = List.of(fixedFee, fractionalFee);
+	private final List<FcCustomFee> feeSchedule = grpcFeeSchedule.stream()
+			.map(fee -> FcCustomFee.fromGrpc(fee, null))
+			.collect(toList());
 
 	private MerkleToken subject;
 	private MerkleToken other;
@@ -151,7 +153,7 @@ class MerkleTokenTest {
 		subject.setName(name);
 		subject.setSymbol(symbol);
 		subject.setAccountsFrozenByDefault(true);
-		subject.setFeeScheduleFrom(grpcFeeSchedule);
+		subject.setFeeScheduleFrom(grpcFeeSchedule, null);
 
 		serdes = mock(DomainSerdes.class);
 		MerkleToken.serdes = serdes;
@@ -227,7 +229,7 @@ class MerkleTokenTest {
 	void v0120DeserializeWorks() throws IOException {
 		// setup:
 		SerializableDataInputStream fin = mock(SerializableDataInputStream.class);
-		subject.setFeeScheduleFrom(Collections.emptyList());
+		subject.setFeeScheduleFrom(Collections.emptyList(), null);
 		subject.setFeeScheduleKey(MerkleToken.UNUSED_KEY);
 
 		given(serdes.readNullableSerializable(any())).willReturn(autoRenewAccount);
@@ -610,7 +612,7 @@ class MerkleTokenTest {
 		token.setAutoRenewAccount(autoRenewAccount);
 		token.setAutoRenewPeriod(autoRenewPeriod);
 		token.setMemo(memo);
-		token.setFeeScheduleFrom(grpcFeeSchedule);
+		token.setFeeScheduleFrom(grpcFeeSchedule, null);
 		token.setFeeScheduleKey(feeScheduleKey);
 		token.setTokenType(TokenType.FUNGIBLE_COMMON);
 		token.setSupplyType(TokenSupplyType.INFINITE);
@@ -742,7 +744,7 @@ class MerkleTokenTest {
 				expiry, totalSupply, decimals, symbol, name, freezeDefault, accountsKycGrantedByDefault, treasury);
 		assertEquals(Collections.emptyList(), token.grpcFeeSchedule());
 
-		token.setFeeScheduleFrom(grpcFeeSchedule);
+		token.setFeeScheduleFrom(grpcFeeSchedule, null);
 		assertEquals(grpcFeeSchedule, token.grpcFeeSchedule());
 	}
 }

--- a/hedera-node/src/test/java/com/hedera/services/state/submerkle/FcCustomFeeTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/state/submerkle/FcCustomFeeTest.java
@@ -72,9 +72,9 @@ class FcCustomFeeTest {
 		final var expectedHtsSubject = FcCustomFee.fixedFee(fixedUnitsToCollect, denom, feeCollector);
 		final var expectedHtsSameTokenSubject = FcCustomFee.fixedFee(fixedUnitsToCollect, targetId, feeCollector);
 		final var expectedHbarSubject = FcCustomFee.fixedFee(fixedUnitsToCollect, null, feeCollector);
-		final var htsGrpc = builder.fromFixedFee(fixedHts(grpcDenom, fixedUnitsToCollect));
-		final var htsSameTokenGrpc = builder.fromFixedFee(fixedHts(fixedUnitsToCollect));
-		final var hbarGrpc = builder.fromFixedFee(fixedHbar(fixedUnitsToCollect));
+		final var htsGrpc = builder.withFixedFee(fixedHts(grpcDenom, fixedUnitsToCollect));
+		final var htsSameTokenGrpc = builder.withFixedFee(fixedHts(fixedUnitsToCollect));
+		final var hbarGrpc = builder.withFixedFee(fixedHbar(fixedUnitsToCollect));
 
 		final var htsSubject = FcCustomFee.fromGrpc(htsGrpc, null);
 		final var htsSameTokenSubject = FcCustomFee.fromGrpc(htsSameTokenGrpc, targetId);
@@ -87,7 +87,7 @@ class FcCustomFeeTest {
 
 	@Test
 	void grpcReprWorksForFixedHbar() {
-		final var expected = builder.fromFixedFee(fixedHbar(fixedUnitsToCollect));
+		final var expected = builder.withFixedFee(fixedHbar(fixedUnitsToCollect));
 		final var hbarFee = FcCustomFee.fixedFee(fixedUnitsToCollect, null, feeCollector);
 
 		final var actual = hbarFee.asGrpc();
@@ -97,7 +97,7 @@ class FcCustomFeeTest {
 
 	@Test
 	void grpcReprWorksForFixedHts() {
-		final var expected = builder.fromFixedFee(fixedHts(grpcDenom, fixedUnitsToCollect));
+		final var expected = builder.withFixedFee(fixedHts(grpcDenom, fixedUnitsToCollect));
 		final var htsFee = FcCustomFee.fixedFee(fixedUnitsToCollect, EntityId.fromGrpcTokenId(grpcDenom), feeCollector);
 
 		final var actual = htsFee.asGrpc();
@@ -107,7 +107,7 @@ class FcCustomFeeTest {
 
 	@Test
 	void grpcReprWorksForFractional() {
-		final var expected = builder.fromFractionalFee(
+		final var expected = builder.withFractionalFee(
 				fractional(validNumerator, validDenominator)
 						.setMinimumAmount(minimumUnitsToCollect)
 						.setMaximumAmount(maximumUnitsToCollect));
@@ -125,7 +125,7 @@ class FcCustomFeeTest {
 
 	@Test
 	void grpcReprWorksForFractionalNoMax() {
-		final var expected = builder.fromFractionalFee(
+		final var expected = builder.withFractionalFee(
 				fractional(validNumerator, validDenominator)
 						.setMinimumAmount(minimumUnitsToCollect));
 		final var fractionalFee = FcCustomFee.fractionalFee(
@@ -154,11 +154,11 @@ class FcCustomFeeTest {
 				minimumUnitsToCollect,
 				Long.MAX_VALUE,
 				feeCollector);
-		final var grpcWithExplicitMax = builder.fromFractionalFee(
+		final var grpcWithExplicitMax = builder.withFractionalFee(
 				fractional(validNumerator, validDenominator)
 						.setMinimumAmount(minimumUnitsToCollect)
 						.setMaximumAmount(maximumUnitsToCollect));
-		final var grpcWithoutExplicitMax = builder.fromFractionalFee(
+		final var grpcWithoutExplicitMax = builder.withFractionalFee(
 				fractional(validNumerator, validDenominator)
 						.setMinimumAmount(minimumUnitsToCollect));
 

--- a/hedera-node/src/test/java/com/hedera/services/state/submerkle/FcCustomFeeTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/state/submerkle/FcCustomFeeTest.java
@@ -9,9 +9,9 @@ package com.hedera.services.state.submerkle;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,11 +20,12 @@ package com.hedera.services.state.submerkle;
  * ‍
  */
 
-import com.hedera.test.utils.IdUtils;
+import com.hederahashgraph.api.proto.java.AccountID;
 import com.hederahashgraph.api.proto.java.CustomFee;
 import com.hederahashgraph.api.proto.java.FixedFee;
 import com.hederahashgraph.api.proto.java.Fraction;
 import com.hederahashgraph.api.proto.java.FractionalFee;
+import com.hederahashgraph.api.proto.java.TokenID;
 import com.swirlds.common.io.SerializableDataInputStream;
 import com.swirlds.common.io.SerializableDataOutputStream;
 import org.junit.jupiter.api.Test;
@@ -54,8 +55,10 @@ class FcCustomFeeTest {
 	private final long fixedUnitsToCollect = 7;
 	private final long minimumUnitsToCollect = 1;
 	private final long maximumUnitsToCollect = 55;
-	private final EntityId denom = new EntityId(1,2, 3);
-	private final EntityId feeCollector = new EntityId(4,5, 6);
+	private final EntityId denom = new EntityId(1, 2, 3);
+	private final TokenID grpcDenom = denom.toGrpcTokenId();
+	private final EntityId feeCollector = new EntityId(4, 5, 6);
+	private final AccountID grpcFeeCollector = feeCollector.toGrpcAccountId();
 
 	@Mock
 	private SerializableDataInputStream din;
@@ -64,88 +67,49 @@ class FcCustomFeeTest {
 
 	@Test
 	void grpcConversionWorksForFixed() {
-		// setup:
-		final var grpcDenom = IdUtils.asToken("1.2.3");
+		final var targetId = new EntityId(7, 8, 9);
 		final var expectedHtsSubject = FcCustomFee.fixedFee(fixedUnitsToCollect, denom, feeCollector);
+		final var expectedHtsSameTokenSubject = FcCustomFee.fixedFee(fixedUnitsToCollect, targetId, feeCollector);
 		final var expectedHbarSubject = FcCustomFee.fixedFee(fixedUnitsToCollect, null, feeCollector);
+		final var htsGrpc = fromFixedFee(fixedHts(grpcDenom, fixedUnitsToCollect));
+		final var htsSameTokenGrpc = fromFixedFee(fixedHts(fixedUnitsToCollect));
+		final var hbarGrpc = fromFixedFee(fixedHbar(fixedUnitsToCollect));
 
-		// given:
-		final var htsGrpc = CustomFee.newBuilder()
-				.setFeeCollectorAccountId(feeCollector.toGrpcAccountId())
-				.setFixedFee(FixedFee.newBuilder()
-						.setDenominatingTokenId(grpcDenom)
-						.setAmount(fixedUnitsToCollect)
-				).build();
-		final var hbarGrpc = CustomFee.newBuilder()
-				.setFeeCollectorAccountId(feeCollector.toGrpcAccountId())
-				.setFixedFee(FixedFee.newBuilder()
-						.setAmount(fixedUnitsToCollect)
-				).build();
-
-		// when:
 		final var htsSubject = FcCustomFee.fromGrpc(htsGrpc, null);
+		final var htsSameTokenSubject = FcCustomFee.fromGrpc(htsSameTokenGrpc, targetId);
 		final var hbarSubject = FcCustomFee.fromGrpc(hbarGrpc, null);
 
-		// then:
 		assertEquals(expectedHtsSubject, htsSubject);
+		assertEquals(expectedHtsSameTokenSubject, htsSameTokenSubject);
 		assertEquals(expectedHbarSubject, hbarSubject);
 	}
 
 	@Test
 	void grpcReprWorksForFixedHbar() {
-		// setup:
-		final var expected = CustomFee.newBuilder()
-				.setFeeCollectorAccountId(feeCollector.toGrpcAccountId())
-				.setFixedFee(FixedFee.newBuilder()
-						.setAmount(fixedUnitsToCollect)
-				).build();
-
-		// given:
+		final var expected = fromFixedFee(fixedHbar(fixedUnitsToCollect));
 		final var hbarFee = FcCustomFee.fixedFee(fixedUnitsToCollect, null, feeCollector);
 
-		// when:
 		final var actual = hbarFee.asGrpc();
 
-		// then:
 		assertEquals(expected, actual);
 	}
 
 	@Test
 	void grpcReprWorksForFixedHts() {
-		final var grpcDenom = IdUtils.asToken("1.2.3");
-
-		// setup:
-		final var expected = CustomFee.newBuilder()
-				.setFeeCollectorAccountId(feeCollector.toGrpcAccountId())
-				.setFixedFee(FixedFee.newBuilder()
-						.setDenominatingTokenId(grpcDenom)
-						.setAmount(fixedUnitsToCollect)
-				).build();
-
-		// given:
+		final var expected = fromFixedFee(fixedHts(grpcDenom, fixedUnitsToCollect));
 		final var htsFee = FcCustomFee.fixedFee(fixedUnitsToCollect, EntityId.fromGrpcTokenId(grpcDenom), feeCollector);
 
-		// when:
 		final var actual = htsFee.asGrpc();
 
-		// then:
 		assertEquals(expected, actual);
 	}
 
 	@Test
 	void grpcReprWorksForFractional() {
-		// setup:
-		final var expected = CustomFee.newBuilder()
-				.setFeeCollectorAccountId(feeCollector.toGrpcAccountId())
-				.setFractionalFee(FractionalFee.newBuilder()
-						.setFractionalAmount(Fraction.newBuilder()
-								.setNumerator(validNumerator)
-								.setDenominator(validDenominator))
+		final var expected = fromFractionalFee(
+				fractional(validNumerator, validDenominator)
 						.setMinimumAmount(minimumUnitsToCollect)
-						.setMaximumAmount(maximumUnitsToCollect)
-				).build();
-
-		// given:
+						.setMaximumAmount(maximumUnitsToCollect));
 		final var fractionalFee = FcCustomFee.fractionalFee(
 				validNumerator,
 				validDenominator,
@@ -153,26 +117,16 @@ class FcCustomFeeTest {
 				maximumUnitsToCollect,
 				feeCollector);
 
-		// when:
 		final var actual = fractionalFee.asGrpc();
 
-		// then:
 		assertEquals(expected, actual);
 	}
 
 	@Test
 	void grpcReprWorksForFractionalNoMax() {
-		// setup:
-		final var expected = CustomFee.newBuilder()
-				.setFeeCollectorAccountId(feeCollector.toGrpcAccountId())
-				.setFractionalFee(FractionalFee.newBuilder()
-						.setFractionalAmount(Fraction.newBuilder()
-								.setNumerator(validNumerator)
-								.setDenominator(validDenominator))
-						.setMinimumAmount(minimumUnitsToCollect)
-				).build();
-
-		// given:
+		final var expected = fromFractionalFee(
+				fractional(validNumerator, validDenominator)
+						.setMinimumAmount(minimumUnitsToCollect));
 		final var fractionalFee = FcCustomFee.fractionalFee(
 				validNumerator,
 				validDenominator,
@@ -180,16 +134,13 @@ class FcCustomFeeTest {
 				Long.MAX_VALUE,
 				feeCollector);
 
-		// when:
 		final var actual = fractionalFee.asGrpc();
 
-		// then:
 		assertEquals(expected, actual);
 	}
 
 	@Test
 	void grpcConversionWorksForFractional() {
-		// setup:
 		final var expectedExplicitMaxSubject = FcCustomFee.fractionalFee(
 				validNumerator,
 				validDenominator,
@@ -202,133 +153,90 @@ class FcCustomFeeTest {
 				minimumUnitsToCollect,
 				Long.MAX_VALUE,
 				feeCollector);
-
-		// given:
-		final var grpcWithExplicitMax = CustomFee.newBuilder()
-				.setFeeCollectorAccountId(feeCollector.toGrpcAccountId())
-				.setFractionalFee(FractionalFee.newBuilder()
-						.setFractionalAmount(Fraction.newBuilder()
-								.setNumerator(validNumerator)
-								.setDenominator(validDenominator)
-								.build())
+		final var grpcWithExplicitMax = fromFractionalFee(
+				fractional(validNumerator, validDenominator)
 						.setMinimumAmount(minimumUnitsToCollect)
-						.setMaximumAmount(maximumUnitsToCollect)
-				).build();
-		final var grpcWithoutExplicitMax = CustomFee.newBuilder()
-				.setFeeCollectorAccountId(feeCollector.toGrpcAccountId())
-				.setFractionalFee(FractionalFee.newBuilder()
-						.setFractionalAmount(Fraction.newBuilder()
-								.setNumerator(validNumerator)
-								.setDenominator(validDenominator)
-								.build())
-						.setMinimumAmount(minimumUnitsToCollect)
-				).build();
+						.setMaximumAmount(maximumUnitsToCollect));
+		final var grpcWithoutExplicitMax = fromFractionalFee(
+				fractional(validNumerator, validDenominator)
+						.setMinimumAmount(minimumUnitsToCollect));
 
-		// when:
 		final var explicitMaxSubject = FcCustomFee.fromGrpc(grpcWithExplicitMax, null);
 		final var noExplicitMaxSubject = FcCustomFee.fromGrpc(grpcWithoutExplicitMax, null);
 
-		// then:
 		assertEquals(expectedExplicitMaxSubject, explicitMaxSubject);
 		assertEquals(expectedNoExplicitMaxSubject, noExplicitMaxSubject);
 	}
 
 	@Test
 	void liveFireSerdesWorkForFractional() throws IOException {
-		// setup:
 		final var subject = FcCustomFee.fractionalFee(
 				validNumerator,
 				validDenominator,
 				minimumUnitsToCollect,
 				maximumUnitsToCollect,
 				feeCollector);
-		// and:
 		final ByteArrayOutputStream baos = new ByteArrayOutputStream();
 		final var dos = new SerializableDataOutputStream(baos);
-
-		// given:
 		subject.serialize(dos);
 		dos.flush();
-		// and:
 		final var bytes = baos.toByteArray();
 		final ByteArrayInputStream bais = new ByteArrayInputStream(bytes);
 		final var din = new SerializableDataInputStream(bais);
 
-		// when:
 		final var newSubject = new FcCustomFee();
 		newSubject.deserialize(din, FcCustomFee.MERKLE_VERSION);
 
-		// then:
 		assertEquals(subject.getFractionalFeeSpec(), newSubject.getFractionalFeeSpec());
 		assertEquals(subject.getFeeCollectorAccountId(), newSubject.getFeeCollectorAccountId());
 	}
 
 	@Test
 	void liveFireSerdesWorkForFixed() throws IOException {
-		// setup:
 		final var fixedSubject = FcCustomFee.fixedFee(fixedUnitsToCollect, denom, feeCollector);
-		// and:
 		final ByteArrayOutputStream baos = new ByteArrayOutputStream();
 		final var dos = new SerializableDataOutputStream(baos);
-
-		// given:
 		fixedSubject.serialize(dos);
 		dos.flush();
-		// and:
 		final var bytes = baos.toByteArray();
 		final ByteArrayInputStream bais = new ByteArrayInputStream(bytes);
 		final var din = new SerializableDataInputStream(bais);
 
-		// when:
 		final var newSubject = new FcCustomFee();
 		newSubject.deserialize(din, FcCustomFee.MERKLE_VERSION);
 
-		// then:
 		assertEquals(fixedSubject.getFixedFeeSpec(), newSubject.getFixedFeeSpec());
 		assertEquals(fixedSubject.getFeeCollectorAccountId(), newSubject.getFeeCollectorAccountId());
 	}
 
 	@Test
 	void liveFireSerdesWorkForFixedWithNullDenom() throws IOException {
-		// setup:
 		final var fixedSubject = FcCustomFee.fixedFee(fixedUnitsToCollect, null, feeCollector);
-		// and:
 		final ByteArrayOutputStream baos = new ByteArrayOutputStream();
 		final var dos = new SerializableDataOutputStream(baos);
-
-		// given:
 		fixedSubject.serialize(dos);
 		dos.flush();
-		// and:
 		final var bytes = baos.toByteArray();
 		final ByteArrayInputStream bais = new ByteArrayInputStream(bytes);
 		final var din = new SerializableDataInputStream(bais);
 
-		// when:
 		final var newSubject = new FcCustomFee();
 		newSubject.deserialize(din, FcCustomFee.MERKLE_VERSION);
 
-		// then:
 		assertEquals(fixedSubject.getFixedFeeSpec(), newSubject.getFixedFeeSpec());
 		assertEquals(fixedSubject.getFeeCollectorAccountId(), newSubject.getFeeCollectorAccountId());
 	}
 
 	@Test
 	void deserializeWorksAsExpectedForFixed() throws IOException {
-		// setup:
 		final var expectedFixedSpec = new FcCustomFee.FixedFeeSpec(fixedUnitsToCollect, denom);
-
 		given(din.readByte()).willReturn(FcCustomFee.FIXED_CODE);
 		given(din.readLong()).willReturn(fixedUnitsToCollect);
 		given(din.readSerializable(anyBoolean(), Mockito.any())).willReturn(denom).willReturn(feeCollector);
 
-		// given:
 		final var subject = new FcCustomFee();
-
-		// when:
 		subject.deserialize(din, FcCustomFee.MERKLE_VERSION);
 
-		// then:
 		assertEquals(FcCustomFee.FeeType.FIXED_FEE, subject.getFeeType());
 		assertEquals(expectedFixedSpec, subject.getFixedFeeSpec());
 		assertNull(subject.getFractionalFeeSpec());
@@ -337,13 +245,11 @@ class FcCustomFeeTest {
 
 	@Test
 	void deserializeWorksAsExpectedForFractional() throws IOException {
-		// setup:
 		final var expectedFractionalSpec = new FcCustomFee.FractionalFeeSpec(
 				validNumerator,
 				validDenominator,
 				minimumUnitsToCollect,
 				maximumUnitsToCollect);
-
 		given(din.readByte()).willReturn(FcCustomFee.FRACTIONAL_CODE);
 		given(din.readLong())
 				.willReturn(validNumerator)
@@ -352,13 +258,9 @@ class FcCustomFeeTest {
 				.willReturn(maximumUnitsToCollect);
 		given(din.readSerializable(anyBoolean(), Mockito.any())).willReturn(feeCollector);
 
-		// given:
 		final var subject = new FcCustomFee();
-
-		// when:
 		subject.deserialize(din, FcCustomFee.MERKLE_VERSION);
 
-		// then:
 		assertEquals(FcCustomFee.FeeType.FRACTIONAL_FEE, subject.getFeeType());
 		assertEquals(expectedFractionalSpec, subject.getFractionalFeeSpec());
 		assertNull(subject.getFixedFeeSpec());
@@ -367,10 +269,7 @@ class FcCustomFeeTest {
 
 	@Test
 	void serializeWorksAsExpectedForFractional() throws IOException {
-		// setup:
 		InOrder inOrder = Mockito.inOrder(dos);
-
-		// given:
 		final var subject = FcCustomFee.fractionalFee(
 				validNumerator,
 				validDenominator,
@@ -378,10 +277,8 @@ class FcCustomFeeTest {
 				maximumUnitsToCollect,
 				feeCollector);
 
-		// when:
 		subject.serialize(dos);
 
-		// then:
 		inOrder.verify(dos).writeByte(FcCustomFee.FRACTIONAL_CODE);
 		inOrder.verify(dos).writeLong(validNumerator);
 		inOrder.verify(dos).writeLong(validDenominator);
@@ -392,16 +289,11 @@ class FcCustomFeeTest {
 
 	@Test
 	void serializeWorksAsExpectedForFixed() throws IOException {
-		// setup:
 		InOrder inOrder = Mockito.inOrder(dos);
-
-		// given:
 		final var subject = FcCustomFee.fixedFee(fixedUnitsToCollect, denom, feeCollector);
 
-		// when:
 		subject.serialize(dos);
 
-		// then:
 		inOrder.verify(dos).writeByte(FcCustomFee.FIXED_CODE);
 		inOrder.verify(dos).writeLong(fixedUnitsToCollect);
 		inOrder.verify(dos).writeSerializable(denom, true);
@@ -411,7 +303,6 @@ class FcCustomFeeTest {
 
 	@Test
 	void merkleMethodsWork() {
-		// given:
 		final var subject = FcCustomFee.fixedFee(fixedUnitsToCollect, denom, feeCollector);
 
 		assertEquals(FcCustomFee.MERKLE_VERSION, subject.getVersion());
@@ -420,13 +311,9 @@ class FcCustomFeeTest {
 
 	@Test
 	void fixedFactoryWorks() {
-		// setup:
 		final var expectedFixedSpec = new FcCustomFee.FixedFeeSpec(fixedUnitsToCollect, denom);
-
-		// given:
 		final var fixedSubject = FcCustomFee.fixedFee(fixedUnitsToCollect, denom, feeCollector);
 
-		// expect:
 		assertEquals(FcCustomFee.FeeType.FIXED_FEE, fixedSubject.getFeeType());
 		assertEquals(expectedFixedSpec, fixedSubject.getFixedFeeSpec());
 		assertNull(fixedSubject.getFractionalFeeSpec());
@@ -435,14 +322,11 @@ class FcCustomFeeTest {
 
 	@Test
 	void fractionalFactoryWorks() {
-		// setup:
 		final var expectedFractionalSpec = new FcCustomFee.FractionalFeeSpec(
 				validNumerator,
 				validDenominator,
 				minimumUnitsToCollect,
 				maximumUnitsToCollect);
-
-		// given:
 		final var fractionalSubject = FcCustomFee.fractionalFee(
 				validNumerator,
 				validDenominator,
@@ -450,7 +334,6 @@ class FcCustomFeeTest {
 				maximumUnitsToCollect,
 				feeCollector);
 
-		// expect:
 		assertEquals(FcCustomFee.FeeType.FRACTIONAL_FEE, fractionalSubject.getFeeType());
 		assertEquals(expectedFractionalSpec, fractionalSubject.getFractionalFeeSpec());
 		assertNull(fractionalSubject.getFixedFeeSpec());
@@ -459,20 +342,16 @@ class FcCustomFeeTest {
 
 	@Test
 	void toStringsWork() {
-		// setup:
 		final var fractionalSpec = new FcCustomFee.FractionalFeeSpec(
 				validNumerator,
 				validDenominator,
 				minimumUnitsToCollect,
 				maximumUnitsToCollect);
 		final var fixedSpec = new FcCustomFee.FixedFeeSpec(fixedUnitsToCollect, denom);
-
-		// given:
 		final var desiredFracRepr = "FractionalFeeSpec{numerator=5, denominator=100, " +
 				"minimumUnitsToCollect=1, maximumUnitsToCollect=55}";
 		final var desiredFixedRepr = "FixedFeeSpec{unitsToCollect=7, tokenDenomination=1.2.3}";
 
-		// expect:
 		assertEquals(desiredFixedRepr, fixedSpec.toString());
 		assertEquals(desiredFracRepr, fractionalSpec.toString());
 	}
@@ -485,7 +364,6 @@ class FcCustomFeeTest {
 
 	@Test
 	void failFastIfInvalidFractionUsed() {
-		// expect:
 		assertThrows(IllegalArgumentException.class, () -> new FcCustomFee.FractionalFeeSpec(
 				validNumerator,
 				invalidDenominator,
@@ -520,7 +398,6 @@ class FcCustomFeeTest {
 
 	@Test
 	void gettersWork() {
-		// setup:
 		final var fractionalSpec = new FcCustomFee.FractionalFeeSpec(
 				validNumerator,
 				validDenominator,
@@ -528,7 +405,6 @@ class FcCustomFeeTest {
 				maximumUnitsToCollect);
 		final var fixedSpec = new FcCustomFee.FixedFeeSpec(fixedUnitsToCollect, denom);
 
-		// given:
 		assertEquals(validNumerator, fractionalSpec.getNumerator());
 		assertEquals(validDenominator, fractionalSpec.getDenominator());
 		assertEquals(minimumUnitsToCollect, fractionalSpec.getMinimumAmount());
@@ -539,7 +415,6 @@ class FcCustomFeeTest {
 
 	@Test
 	void hashCodeWorks() {
-		// setup:
 		final var fractionalSpec = new FcCustomFee.FractionalFeeSpec(
 				validNumerator,
 				validDenominator,
@@ -547,21 +422,18 @@ class FcCustomFeeTest {
 				maximumUnitsToCollect);
 		final var fixedSpec = new FcCustomFee.FixedFeeSpec(fixedUnitsToCollect, denom);
 
-		// expect:
 		assertDoesNotThrow(fractionalSpec::hashCode);
 		assertDoesNotThrow(fixedSpec::hashCode);
 	}
 
 	@Test
 	void fixedFeeEqualsWorks() {
-		// given:
 		final var aFixedSpec = new FcCustomFee.FixedFeeSpec(fixedUnitsToCollect, denom);
 		final var bFixedSpec = new FcCustomFee.FixedFeeSpec(fixedUnitsToCollect, denom);
 		final var cFixedSpec = new FcCustomFee.FixedFeeSpec(fixedUnitsToCollect + 1, denom);
 		final var dFixedSpec = new FcCustomFee.FixedFeeSpec(fixedUnitsToCollect, null);
 		final var eFixedSpec = aFixedSpec;
 
-		// expect:
 		assertEquals(aFixedSpec, bFixedSpec);
 		assertEquals(aFixedSpec, eFixedSpec);
 		assertNotEquals(null, aFixedSpec);
@@ -572,13 +444,10 @@ class FcCustomFeeTest {
 
 	@Test
 	void fractionalFeeEqualsWorks() {
-		// setup:
 		long n = 3;
 		long d = 7;
 		long min = 22;
 		long max = 99;
-
-		// given:
 		final var aFractionalSpec = new FcCustomFee.FractionalFeeSpec(n, d, min, max);
 		final var bFractionalSpec = new FcCustomFee.FractionalFeeSpec(n + 1, d, min, max);
 		final var cFractionalSpec = new FcCustomFee.FractionalFeeSpec(n, d + 1, min, max);
@@ -587,7 +456,6 @@ class FcCustomFeeTest {
 		final var fFractionalSpec = new FcCustomFee.FractionalFeeSpec(n, d, min, max);
 		final var gFractionalSpec = aFractionalSpec;
 
-		// expect:
 		assertEquals(aFractionalSpec, fFractionalSpec);
 		assertEquals(aFractionalSpec, gFractionalSpec);
 		assertNotEquals(null, aFractionalSpec);
@@ -600,16 +468,12 @@ class FcCustomFeeTest {
 
 	@Test
 	void customFeeEqualsWorks() {
-		// setup:
 		long n = 3;
 		long d = 7;
 		long min = 22;
 		long max = 99;
-		// and:
 		final var aFeeCollector = new EntityId(1, 2, 3);
 		final var bFeeCollector = new EntityId(2, 3, 4);
-
-		// given:
 		final var aCustomFee = FcCustomFee.fixedFee(fixedUnitsToCollect, denom, aFeeCollector);
 		final var bCustomFee = FcCustomFee.fixedFee(fixedUnitsToCollect + 1, denom, aFeeCollector);
 		final var cCustomFee = FcCustomFee.fixedFee(fixedUnitsToCollect, denom, bFeeCollector);
@@ -617,7 +481,6 @@ class FcCustomFeeTest {
 		final var eCustomFee = aCustomFee;
 		final var fCustomFee = FcCustomFee.fixedFee(fixedUnitsToCollect, denom, aFeeCollector);
 
-		// expect:
 		assertEquals(aCustomFee, eCustomFee);
 		assertEquals(aCustomFee, fCustomFee);
 		assertNotEquals(null, aCustomFee);
@@ -625,13 +488,11 @@ class FcCustomFeeTest {
 		assertNotEquals(aCustomFee, bCustomFee);
 		assertNotEquals(aCustomFee, cCustomFee);
 		assertNotEquals(aCustomFee, dCustomFee);
-		// and:
 		assertEquals(aCustomFee.hashCode(), fCustomFee.hashCode());
 	}
 
 	@Test
 	void toStringWorks() {
-		// setup:
 		final var denom = new EntityId(111, 222, 333);
 		final var fractionalFee = FcCustomFee.fractionalFee(
 				validNumerator,
@@ -641,9 +502,8 @@ class FcCustomFeeTest {
 				feeCollector);
 		final var fixedHbarFee = FcCustomFee.fixedFee(fixedUnitsToCollect, null, feeCollector);
 		final var fixedHtsFee = FcCustomFee.fixedFee(fixedUnitsToCollect, denom, feeCollector);
-
-		// given:
-		final var expectedFractional = "FcCustomFee{feeType=FRACTIONAL_FEE, fractionalFee=FractionalFeeSpec{numerator=5, " +
+		final var expectedFractional = "FcCustomFee{feeType=FRACTIONAL_FEE, " +
+				"fractionalFee=FractionalFeeSpec{numerator=5, " +
 				"denominator=100, minimumUnitsToCollect=1, maximumUnitsToCollect=55}, " +
 				"feeCollector=EntityId{shard=4, realm=5, num=6}}";
 		final var expectedFixedHbar = "FcCustomFee{feeType=FIXED_FEE, fixedFee=FixedFeeSpec{unitsToCollect=7, " +
@@ -651,9 +511,41 @@ class FcCustomFeeTest {
 		final var expectedFixedHts = "FcCustomFee{feeType=FIXED_FEE, fixedFee=FixedFeeSpec{unitsToCollect=7, " +
 				"tokenDenomination=111.222.333}, feeCollector=EntityId{shard=4, realm=5, num=6}}";
 
-		// expect:
 		assertEquals(expectedFractional, fractionalFee.toString());
 		assertEquals(expectedFixedHts, fixedHtsFee.toString());
 		assertEquals(expectedFixedHbar, fixedHbarFee.toString());
+	}
+
+	private CustomFee.Builder customFeeBuilder() {
+		return CustomFee.newBuilder()
+				.setFeeCollectorAccountId(grpcFeeCollector);
+	}
+
+	private CustomFee fromFixedFee(final FixedFee.Builder fee) {
+		return customFeeBuilder().setFixedFee(fee).build();
+	}
+
+	private CustomFee fromFractionalFee(final FractionalFee.Builder fee) {
+		return customFeeBuilder().setFractionalFee(fee).build();
+	}
+
+	private FixedFee.Builder fixedHbar(final long units) {
+		return FixedFee.newBuilder()
+				.setAmount(units);
+	}
+
+	private FixedFee.Builder fixedHts(final TokenID denom, final long units) {
+		return fixedHbar(units).setDenominatingTokenId(denom);
+	}
+
+	private FixedFee.Builder fixedHts(final long units) {
+		return fixedHts(TokenID.getDefaultInstance(), units);
+	}
+
+	private FractionalFee.Builder fractional(final long numerator, final long denominator) {
+		return FractionalFee.newBuilder()
+				.setFractionalAmount(Fraction.newBuilder()
+						.setNumerator(numerator)
+						.setDenominator(denominator));
 	}
 }

--- a/hedera-node/src/test/java/com/hedera/services/state/submerkle/FcCustomFeeTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/state/submerkle/FcCustomFeeTest.java
@@ -83,8 +83,8 @@ class FcCustomFeeTest {
 				).build();
 
 		// when:
-		final var htsSubject = FcCustomFee.fromGrpc(htsGrpc);
-		final var hbarSubject = FcCustomFee.fromGrpc(hbarGrpc);
+		final var htsSubject = FcCustomFee.fromGrpc(htsGrpc, null);
+		final var hbarSubject = FcCustomFee.fromGrpc(hbarGrpc, null);
 
 		// then:
 		assertEquals(expectedHtsSubject, htsSubject);
@@ -225,8 +225,8 @@ class FcCustomFeeTest {
 				).build();
 
 		// when:
-		final var explicitMaxSubject = FcCustomFee.fromGrpc(grpcWithExplicitMax);
-		final var noExplicitMaxSubject = FcCustomFee.fromGrpc(grpcWithoutExplicitMax);
+		final var explicitMaxSubject = FcCustomFee.fromGrpc(grpcWithExplicitMax, null);
+		final var noExplicitMaxSubject = FcCustomFee.fromGrpc(grpcWithoutExplicitMax, null);
 
 		// then:
 		assertEquals(expectedExplicitMaxSubject, explicitMaxSubject);

--- a/hedera-node/src/test/java/com/hedera/services/store/tokens/HederaTokenStoreTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/store/tokens/HederaTokenStoreTest.java
@@ -1758,7 +1758,7 @@ class HederaTokenStoreTest {
 		// setup:
 
 		final var expected = buildFullyValidExpectedToken();
-		expected.setFeeScheduleFrom(Collections.emptyList());
+		expected.setFeeScheduleFrom(Collections.emptyList(), null);
 		final var req = fullyValidTokenCreateAttempt()
 				.clearCustomFees()
 				.setExpiry(Timestamp.newBuilder().setSeconds(0))
@@ -1798,7 +1798,7 @@ class HederaTokenStoreTest {
 		expected.setTokenType(TokenType.FUNGIBLE_COMMON);
 		expected.setSupplyType(TokenSupplyType.INFINITE);
 		expected.setMemo(memo);
-		expected.setFeeScheduleFrom(Collections.emptyList());
+		expected.setFeeScheduleFrom(Collections.emptyList(), null);
 
 		// given:
 		final var req = fullyValidTokenCreateAttempt().clearCustomFees().build();
@@ -1950,7 +1950,7 @@ class HederaTokenStoreTest {
 		expected.setTokenType(TokenType.FUNGIBLE_COMMON);
 		expected.setSupplyType(TokenSupplyType.INFINITE);
 		expected.setMemo(memo);
-		expected.setFeeScheduleFrom(grpcCustomFees);
+		expected.setFeeScheduleFrom(grpcCustomFees, null);
 
 		return expected;
 	}

--- a/hedera-node/src/test/java/com/hedera/services/store/tokens/HederaTokenStoreTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/store/tokens/HederaTokenStoreTest.java
@@ -41,13 +41,12 @@ import com.hedera.services.state.merkle.MerkleUniqueToken;
 import com.hedera.services.state.merkle.MerkleUniqueTokenId;
 import com.hedera.services.state.submerkle.EntityId;
 import com.hedera.services.store.models.NftId;
+import com.hedera.test.factories.fees.CustomFeeBuilder;
 import com.hedera.test.factories.scenarios.TxnHandlingScenario;
 import com.hedera.test.utils.IdUtils;
 import com.hederahashgraph.api.proto.java.AccountID;
 import com.hederahashgraph.api.proto.java.CustomFee;
 import com.hederahashgraph.api.proto.java.Duration;
-import com.hederahashgraph.api.proto.java.FixedFee;
-import com.hederahashgraph.api.proto.java.Fraction;
 import com.hederahashgraph.api.proto.java.FractionalFee;
 import com.hederahashgraph.api.proto.java.Key;
 import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
@@ -82,6 +81,9 @@ import static com.hedera.services.ledger.properties.TokenRelProperty.IS_FROZEN;
 import static com.hedera.services.ledger.properties.TokenRelProperty.IS_KYC_GRANTED;
 import static com.hedera.services.ledger.properties.TokenRelProperty.TOKEN_BALANCE;
 import static com.hedera.services.state.merkle.MerkleEntityId.fromTokenId;
+import static com.hedera.test.factories.fees.CustomFeeBuilder.fixedHbar;
+import static com.hedera.test.factories.fees.CustomFeeBuilder.fixedHts;
+import static com.hedera.test.factories.fees.CustomFeeBuilder.fractional;
 import static com.hedera.test.factories.scenarios.TxnHandlingScenario.COMPLEX_KEY_ACCOUNT_KT;
 import static com.hedera.test.factories.scenarios.TxnHandlingScenario.MISC_ACCOUNT_KT;
 import static com.hedera.test.factories.scenarios.TxnHandlingScenario.TOKEN_ADMIN_KT;
@@ -91,6 +93,7 @@ import static com.hedera.test.factories.scenarios.TxnHandlingScenario.TOKEN_KYC_
 import static com.hedera.test.factories.scenarios.TxnHandlingScenario.TOKEN_TREASURY_KT;
 import static com.hedera.test.mocks.TestContextValidator.CONSENSUS_NOW;
 import static com.hedera.test.mocks.TestContextValidator.TEST_VALIDATOR;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.ACCOUNT_AMOUNT_TRANSFERS_ONLY_ALLOWED_FOR_FUNGIBLE_COMMON;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.ACCOUNT_DELETED;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.ACCOUNT_EXPIRED_AND_PENDING_REMOVAL;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.ACCOUNT_FROZEN_FOR_TOKEN;
@@ -124,7 +127,6 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TOKEN_HAS_NO_W
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TOKEN_IS_IMMUTABLE;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TOKEN_NOT_ASSOCIATED_TO_ACCOUNT;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TOKEN_NOT_ASSOCIATED_TO_FEE_COLLECTOR;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.ACCOUNT_AMOUNT_TRANSFERS_ONLY_ALLOWED_FOR_FUNGIBLE_COMMON;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TOKEN_WAS_DELETED;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -148,7 +150,6 @@ class HederaTokenStoreTest {
 	private EntityIdSource ids;
 	private GlobalDynamicProperties properties;
 	private FCMap<MerkleEntityId, MerkleToken> tokens;
-	private FCMap<MerkleUniqueTokenId, MerkleUniqueToken> uniqueTokens;
 	private FCOneToManyRelation<EntityId, MerkleUniqueTokenId> uniqueTokenAccountOwnerships;
 	private TransactionalLedger<AccountID, AccountProperty, MerkleAccount> accountsLedger;
 	private TransactionalLedger<NftId, NftProperty, MerkleUniqueToken> nftsLedger;
@@ -167,7 +168,7 @@ class HederaTokenStoreTest {
 	private String memo = "TOKENMEMO";
 	private String name = "TOKENNAME";
 	private String newName = "NEWNAME";
-	private int maxCustomFees = 4;
+	private int maxCustomFees = 5;
 	private long expiry = CONSENSUS_NOW + 1_234_567;
 	private long newExpiry = CONSENSUS_NOW + 1_432_765;
 	private long totalSupply = 1_000_000;
@@ -200,128 +201,21 @@ class HederaTokenStoreTest {
 	private Pair<AccountID, TokenID> treasuryMisc = asTokenRel(treasury, misc);
 	private NftId aNft = new NftId(4, 3, 2, 1_234);
 	private Pair<AccountID, TokenID> anotherFeeCollectorMisc = asTokenRel(anotherFeeCollector, misc);
-	private FixedFee fixedFeeInTokenUnits = FixedFee.newBuilder()
-			.setDenominatingTokenId(misc)
-			.setAmount(100)
-			.build();
-	private FixedFee fixedFeeInNftUnits = FixedFee.newBuilder()
-			.setDenominatingTokenId(nonfungible)
-			.setAmount(100)
-			.build();
-	private FixedFee fixedFeeInHbar = FixedFee.newBuilder()
-			.setAmount(100)
-			.build();
-	private Fraction fraction = Fraction.newBuilder().setNumerator(15).setDenominator(100).build();
-	private Fraction invalidFraction = Fraction.newBuilder().setNumerator(15).setDenominator(0).build();
-	private FractionalFee fractionalFee = FractionalFee.newBuilder()
-			.setFractionalAmount(fraction)
+	private CustomFeeBuilder builder = new CustomFeeBuilder(feeCollector);
+	private FractionalFee.Builder fractionalFee = fractional(15L, 100L)
 			.setMaximumAmount(50)
-			.setMinimumAmount(10)
-			.build();
-	private CustomFee customFixedFeeInHbar = CustomFee.newBuilder()
-			.setFeeCollectorAccountId(feeCollector)
-			.setFixedFee(fixedFeeInHbar)
-			.build();
-	private CustomFee customFixedFeeInHts = CustomFee.newBuilder()
-			.setFeeCollectorAccountId(anotherFeeCollector)
-			.setFixedFee(fixedFeeInTokenUnits)
-			.build();
-	private CustomFee customFractionalFee = CustomFee.newBuilder()
-			.setFeeCollectorAccountId(feeCollector)
-			.setFractionalFee(fractionalFee)
-			.build();
+			.setMinimumAmount(10);
+	private CustomFee customFixedFeeInHbar = builder.withFixedFee(fixedHbar(100L));
+	private CustomFee customFixedFeeInHts = new CustomFeeBuilder(anotherFeeCollector).withFixedFee(
+			fixedHts(misc, 100L));
+	private CustomFee customFixedFeeSameToken = builder.withFixedFee(fixedHts(50L));
+	private CustomFee customFractionalFee = builder.withFractionalFee(fractionalFee);
 	private List<CustomFee> grpcCustomFees = List.of(
 			customFixedFeeInHbar,
 			customFixedFeeInHts,
-			customFractionalFee
+			customFractionalFee,
+			customFixedFeeSameToken
 	);
-	private List<CustomFee> grpcNftAsDenominatingToken = List.of(
-			CustomFee.newBuilder().setFeeCollectorAccountId(feeCollector)
-					.setFixedFee(fixedFeeInNftUnits).build()
-	);
-	private List<CustomFee> grpcUnderspecifiedCustomFees = List.of(
-			CustomFee.newBuilder().setFeeCollectorAccountId(feeCollector).build()
-	);
-	private List<CustomFee> grpcDivideByZeroCustomFees = List.of(
-			CustomFee.newBuilder()
-					.setFeeCollectorAccountId(feeCollector)
-					.setFractionalFee(FractionalFee.newBuilder()
-							.setFractionalAmount(invalidFraction)
-					).build());
-	private List<CustomFee> grpcNegativeFractionCustomFees = List.of(
-			CustomFee.newBuilder()
-					.setFeeCollectorAccountId(feeCollector)
-					.setFractionalFee(FractionalFee.newBuilder()
-							.setFractionalAmount(Fraction.newBuilder()
-									.setNumerator(123L).setDenominator(-1_000L)
-							)
-					).build());
-	private List<CustomFee> grpcNegativeMaximumCustomFees = List.of(
-			CustomFee.newBuilder()
-					.setFeeCollectorAccountId(feeCollector)
-					.setFractionalFee(FractionalFee.newBuilder()
-							.setFractionalAmount(Fraction.newBuilder()
-									.setNumerator(123L).setDenominator(1_000L)
-							).setMaximumAmount(-1L)
-					).build());
-	private List<CustomFee> grpcNegativeMinimumCustomFees = List.of(
-			CustomFee.newBuilder()
-					.setFeeCollectorAccountId(feeCollector)
-					.setFractionalFee(FractionalFee.newBuilder()
-							.setFractionalAmount(Fraction.newBuilder()
-									.setNumerator(123L).setDenominator(1_000L)
-							).setMinimumAmount(-1L)
-					).build());
-	private List<CustomFee> grpcZeroFractionCustomFees = List.of(
-			CustomFee.newBuilder()
-					.setFeeCollectorAccountId(feeCollector)
-					.setFractionalFee(FractionalFee.newBuilder()
-							.setFractionalAmount(Fraction.newBuilder()
-									.setNumerator(0L).setDenominator(1_000L)
-							)
-					).build());
-	private List<CustomFee> grpcNegativeFixedCustomFees = List.of(
-			CustomFee.newBuilder()
-					.setFeeCollectorAccountId(feeCollector)
-					.setFixedFee(FixedFee.newBuilder()
-							.setAmount(-1_000L)
-					).build());
-	private List<CustomFee> grpcMaxLessThanMinCustomFees = List.of(
-			CustomFee.newBuilder()
-					.setFeeCollectorAccountId(feeCollector)
-					.setFractionalFee(FractionalFee.newBuilder()
-							.setFractionalAmount(Fraction.newBuilder()
-									.setNumerator(123L).setDenominator(1_000L))
-							.setMaximumAmount(2L)
-							.setMinimumAmount(10L)
-					).build());
-	private List<CustomFee> grpcMaxEqualToMinCustomFees = List.of(
-			CustomFee.newBuilder()
-					.setFeeCollectorAccountId(feeCollector)
-					.setFractionalFee(FractionalFee.newBuilder()
-							.setFractionalAmount(Fraction.newBuilder()
-									.setNumerator(123L).setDenominator(1_000L))
-							.setMaximumAmount(2L)
-							.setMinimumAmount(2L)
-					).build());
-	private List<CustomFee> grpcZeroMaxPositiveMinCustomFees = List.of(
-			CustomFee.newBuilder()
-					.setFeeCollectorAccountId(feeCollector)
-					.setFractionalFee(FractionalFee.newBuilder()
-							.setFractionalAmount(Fraction.newBuilder()
-									.setNumerator(123L).setDenominator(1_000L))
-							.setMaximumAmount(0L)
-							.setMinimumAmount(10L)
-					).build());
-	private List<CustomFee> grpcBothNegativeFractionCustomFees = List.of(
-			CustomFee.newBuilder()
-					.setFeeCollectorAccountId(feeCollector)
-					.setFractionalFee(FractionalFee.newBuilder()
-							.setFractionalAmount(Fraction.newBuilder()
-									.setNumerator(-123L).setDenominator(-1_000L)
-							)
-					).build());
-
 	private HederaTokenStore subject;
 
 	@BeforeEach
@@ -395,7 +289,6 @@ class HederaTokenStoreTest {
 		given(tokens.getForModify(fromTokenId(misc))).willReturn(token);
 		given(tokens.get(fromTokenId(nonfungible))).willReturn(nonfungibleToken);
 
-		uniqueTokens = (FCMap<MerkleUniqueTokenId, MerkleUniqueToken>) mock(FCMap.class);
 		uniqueTokenAccountOwnerships = (FCOneToManyRelation<EntityId, MerkleUniqueTokenId>) mock(
 				FCOneToManyRelation.class);
 
@@ -417,144 +310,109 @@ class HederaTokenStoreTest {
 
 	@Test
 	void rebuildsAsExpected() {
-		// setup:
 		ArgumentCaptor<BiConsumer<MerkleEntityId, MerkleToken>> captor = forClass(BiConsumer.class);
-		// and:
 		subject.getKnownTreasuries().put(treasury, Set.of(anotherMisc));
-		// and:
 		final var deletedToken = new MerkleToken();
 		deletedToken.setDeleted(true);
 		deletedToken.setTreasury(EntityId.fromGrpcAccountId(newTreasury));
 
-		// when:
 		subject.rebuildViews();
 
-		// then:
 		verify(tokens, times(2)).forEach(captor.capture());
-		// and:
-		BiConsumer<MerkleEntityId, MerkleToken> visitor = captor.getAllValues().get(1);
 
-		// and when:
+		BiConsumer<MerkleEntityId, MerkleToken> visitor = captor.getAllValues().get(1);
 		visitor.accept(fromTokenId(misc), token);
 		visitor.accept(fromTokenId(anotherMisc), deletedToken);
 
-		// then:
 		final var extant = subject.getKnownTreasuries();
 		assertEquals(1, extant.size());
-		// and:
 		assertTrue(extant.containsKey(treasury));
 		assertEquals(extant.get(treasury), Set.of(misc));
 	}
 
 	@Test
 	void injectsTokenRelsLedger() {
-		// expect:
 		verify(hederaLedger).setTokenRelsLedger(tokenRelsLedger);
 		verify(hederaLedger).setNftsLedger(nftsLedger);
 	}
 
 	@Test
 	void applicationRejectsMissing() {
-		// setup:
 		final var change = mock(Consumer.class);
 
 		given(tokens.containsKey(fromTokenId(misc))).willReturn(false);
 
-		// expect:
 		assertThrows(IllegalArgumentException.class, () -> subject.apply(misc, change));
 	}
 
 	@Test
 	void applicationAlwaysReplacesModifiableToken() {
-		// setup:
 		final var change = mock(Consumer.class);
 		final var modifiableToken = mock(MerkleToken.class);
 		given(tokens.getForModify(fromTokenId(misc))).willReturn(modifiableToken);
-
 		willThrow(IllegalStateException.class).given(change).accept(modifiableToken);
 
-		// then:
 		assertThrows(IllegalArgumentException.class, () -> subject.apply(misc, change));
 	}
 
 	@Test
 	void applicationWorks() {
-		// setup:
 		final var change = mock(Consumer.class);
-		// and:
 		InOrder inOrder = Mockito.inOrder(change, tokens);
 
-		// when:
 		subject.apply(misc, change);
 
-		// then:
 		inOrder.verify(tokens).getForModify(fromTokenId(misc));
 		inOrder.verify(change).accept(token);
 	}
 
 	@Test
 	void deletionWorksAsExpected() {
-		// when:
 		TokenStore.DELETION.accept(token);
 
-		// then:
 		verify(token).setDeleted(true);
 	}
 
 	@Test
 	void deletesAsExpected() {
-		// when:
 		final var outcome = subject.delete(misc);
 
-		// then:
 		assertEquals(OK, outcome);
-		// and:
 		assertTrue(subject.knownTreasuries.isEmpty());
 	}
 
 	@Test
 	void rejectsDeletionMissingAdminKey() {
-		// given:
 		given(token.adminKey()).willReturn(Optional.empty());
 
-		// when:
 		final var outcome = subject.delete(misc);
 
-		// then:
 		assertEquals(TOKEN_IS_IMMUTABLE, outcome);
 	}
 
 	@Test
 	void rejectsDeletionTokenAlreadyDeleted() {
-		// given:
 		given(token.isDeleted()).willReturn(true);
 
-		// when:
 		final var outcome = subject.delete(misc);
 
-		// then:
 		assertEquals(TOKEN_WAS_DELETED, outcome);
 	}
 
 	@Test
 	void rejectsMissingDeletion() {
-		// given:
 		final var mockSubject = mock(TokenStore.class);
-
 		given(mockSubject.resolve(misc)).willReturn(TokenStore.MISSING_TOKEN);
 		willCallRealMethod().given(mockSubject).delete(misc);
 
-		// when:
 		final var outcome = mockSubject.delete(misc);
 
-		// then:
 		assertEquals(INVALID_TOKEN_ID, outcome);
 		verify(mockSubject, never()).apply(any(), any());
 	}
 
 	@Test
 	void getDelegates() {
-		// expect:
 		assertSame(token, subject.get(misc));
 	}
 
@@ -562,32 +420,26 @@ class HederaTokenStoreTest {
 	void getThrowsIseOnMissing() {
 		given(tokens.containsKey(fromTokenId(misc))).willReturn(false);
 
-		// expect:
 		assertThrows(IllegalArgumentException.class, () -> subject.get(misc));
 	}
 
 	@Test
 	void getCanReturnPending() {
-		// setup:
 		subject.pendingId = pending;
 		subject.pendingCreation = token;
 
-		// expect:
 		assertSame(token, subject.get(pending));
 	}
 
 	@Test
 	void existenceCheckUnderstandsPendingIdOnlyAppliesIfCreationPending() {
-		// expect:
 		assertFalse(subject.exists(HederaTokenStore.NO_PENDING_ID));
 	}
 
 	@Test
 	void existenceCheckIncludesPending() {
-		// setup:
 		subject.pendingId = pending;
 
-		// expect:
 		assertTrue(subject.exists(pending));
 	}
 
@@ -595,10 +447,8 @@ class HederaTokenStoreTest {
 	void freezingRejectsMissingAccount() {
 		given(accountsLedger.exists(sponsor)).willReturn(false);
 
-		// when:
 		final var status = subject.freeze(sponsor, misc);
 
-		// expect:
 		assertEquals(INVALID_ACCOUNT_ID, status);
 	}
 
@@ -606,10 +456,8 @@ class HederaTokenStoreTest {
 	void associatingRejectsDeletedTokens() {
 		given(token.isDeleted()).willReturn(true);
 
-		// when:
 		final var status = subject.associate(sponsor, List.of(misc));
 
-		// expect:
 		assertEquals(TOKEN_WAS_DELETED, status);
 	}
 
@@ -617,10 +465,8 @@ class HederaTokenStoreTest {
 	void associatingRejectsMissingToken() {
 		given(tokens.containsKey(fromTokenId(misc))).willReturn(false);
 
-		// when:
 		final var status = subject.associate(sponsor, List.of(misc));
 
-		// expect:
 		assertEquals(INVALID_TOKEN_ID, status);
 	}
 
@@ -628,16 +474,13 @@ class HederaTokenStoreTest {
 	void associatingRejectsMissingAccounts() {
 		given(accountsLedger.exists(sponsor)).willReturn(false);
 
-		// when:
 		final var status = subject.associate(sponsor, List.of(misc));
 
-		// expect:
 		assertEquals(INVALID_ACCOUNT_ID, status);
 	}
 
 	@Test
 	void realAssociationsExist() {
-		// expect:
 		assertTrue(subject.associationExists(sponsor, misc));
 	}
 
@@ -645,61 +488,47 @@ class HederaTokenStoreTest {
 	void noAssociationsWithMissingAccounts() {
 		given(accountsLedger.exists(sponsor)).willReturn(false);
 
-		// expect:
 		assertFalse(subject.associationExists(sponsor, misc));
 	}
 
 	@Test
 	void associatingRejectsAlreadyAssociatedTokens() {
-		// setup:
 		final var tokens = mock(MerkleAccountTokens.class);
 		given(tokens.includes(misc)).willReturn(true);
 		given(hederaLedger.getAssociatedTokens(sponsor)).willReturn(tokens);
 
-		// when:
 		final var status = subject.associate(sponsor, List.of(misc));
 
-		// expect:
 		assertEquals(TOKEN_ALREADY_ASSOCIATED_TO_ACCOUNT, status);
 	}
 
 	@Test
 	void associatingRejectsIfCappedAssociationsLimit() {
-		// setup:
 		final var tokens = mock(MerkleAccountTokens.class);
 		given(tokens.includes(misc)).willReturn(false);
 		given(tokens.numAssociations()).willReturn(MAX_TOKENS_PER_ACCOUNT);
 		given(hederaLedger.getAssociatedTokens(sponsor)).willReturn(tokens);
 
-		// when:
 		final var status = subject.associate(sponsor, List.of(misc));
 
-		// expect:
 		assertEquals(TOKENS_PER_ACCOUNT_LIMIT_EXCEEDED, status);
-		// and:
 		verify(tokens, never()).associateAll(any());
 		verify(hederaLedger).setAssociatedTokens(sponsor, tokens);
 	}
 
 	@Test
 	void associatingHappyPathWorks() {
-		// setup:
 		final var tokens = mock(MerkleAccountTokens.class);
 		final var key = asTokenRel(sponsor, misc);
-
 		given(tokens.includes(misc)).willReturn(false);
 		given(hederaLedger.getAssociatedTokens(sponsor)).willReturn(tokens);
-		// and:
 		given(token.hasKycKey()).willReturn(true);
 		given(token.hasFreezeKey()).willReturn(true);
 		given(token.accountsAreFrozenByDefault()).willReturn(true);
 
-		// when:
 		final var status = subject.associate(sponsor, List.of(misc));
 
-		// expect:
 		assertEquals(OK, status);
-		// and:
 		verify(tokens).associateAll(Set.of(misc));
 		verify(hederaLedger).setAssociatedTokens(sponsor, tokens);
 		verify(tokenRelsLedger).create(key);
@@ -711,10 +540,8 @@ class HederaTokenStoreTest {
 	void grantingKycRejectsMissingAccount() {
 		given(accountsLedger.exists(sponsor)).willReturn(false);
 
-		// when:
 		final var status = subject.grantKyc(sponsor, misc);
 
-		// expect:
 		assertEquals(INVALID_ACCOUNT_ID, status);
 	}
 
@@ -723,10 +550,8 @@ class HederaTokenStoreTest {
 		given(accountsLedger.exists(sponsor)).willReturn(true);
 		given(hederaLedger.isDetached(sponsor)).willReturn(true);
 
-		// when:
 		final var status = subject.grantKyc(sponsor, misc);
 
-		// expect:
 		assertEquals(ACCOUNT_EXPIRED_AND_PENDING_REMOVAL, status);
 	}
 
@@ -735,10 +560,8 @@ class HederaTokenStoreTest {
 		given(accountsLedger.exists(sponsor)).willReturn(true);
 		given(hederaLedger.isDeleted(sponsor)).willReturn(true);
 
-		// when:
 		final var status = subject.grantKyc(sponsor, misc);
 
-		// expect:
 		assertEquals(ACCOUNT_DELETED, status);
 	}
 
@@ -746,10 +569,8 @@ class HederaTokenStoreTest {
 	void revokingKycRejectsMissingAccount() {
 		given(accountsLedger.exists(sponsor)).willReturn(false);
 
-		// when:
 		final var status = subject.revokeKyc(sponsor, misc);
 
-		// expect:
 		assertEquals(INVALID_ACCOUNT_ID, status);
 	}
 
@@ -757,10 +578,8 @@ class HederaTokenStoreTest {
 	void adjustingRejectsMissingAccount() {
 		given(accountsLedger.exists(sponsor)).willReturn(false);
 
-		// when:
 		final var status = subject.adjustBalance(sponsor, misc, 1);
 
-		// expect:
 		assertEquals(INVALID_ACCOUNT_ID, status);
 	}
 
@@ -768,10 +587,8 @@ class HederaTokenStoreTest {
 	void changingOwnerRejectsMissingSender() {
 		given(accountsLedger.exists(sponsor)).willReturn(false);
 
-		// when:
-		var status = subject.changeOwner(aNft, sponsor, counterparty);
+		final var status = subject.changeOwner(aNft, sponsor, counterparty);
 
-		// expect:
 		assertEquals(INVALID_ACCOUNT_ID, status);
 	}
 
@@ -779,10 +596,8 @@ class HederaTokenStoreTest {
 	void changingOwnerRejectsMissingNftInstance() {
 		given(nftsLedger.exists(aNft)).willReturn(false);
 
-		// when:
-		var status = subject.changeOwner(aNft, sponsor, counterparty);
+		final var status = subject.changeOwner(aNft, sponsor, counterparty);
 
-		// expect:
 		assertEquals(INVALID_NFT_ID, status);
 	}
 
@@ -790,10 +605,8 @@ class HederaTokenStoreTest {
 	void changingOwnerRejectsUnassociatedReceiver() {
 		given(tokenRelsLedger.exists(counterpartyNft)).willReturn(false);
 
-		// when:
-		var status = subject.changeOwner(aNft, sponsor, counterparty);
+		final var status = subject.changeOwner(aNft, sponsor, counterparty);
 
-		// expect:
 		assertEquals(TOKEN_NOT_ASSOCIATED_TO_ACCOUNT, status);
 	}
 
@@ -801,31 +614,25 @@ class HederaTokenStoreTest {
 	void changingOwnerRejectsIllegitimateOwner() {
 		given(nftsLedger.get(aNft, NftProperty.OWNER)).willReturn(EntityId.fromGrpcAccountId(counterparty));
 
-		// when:
-		var status = subject.changeOwner(aNft, sponsor, counterparty);
+		final var status = subject.changeOwner(aNft, sponsor, counterparty);
 
-		// expect:
 		assertEquals(SENDER_DOES_NOT_OWN_NFT_SERIAL_NO, status);
 	}
 
 	@Test
 	void changingOwnerDoesTheExpected() {
-		// setup:
 		long startSponsorNfts = 5, startCounterpartyNfts = 8;
 		long startSponsorANfts = 4, startCounterpartyANfts = 1;
-		var sender = EntityId.fromGrpcAccountId(sponsor);
-		var receiver = EntityId.fromGrpcAccountId(counterparty);
-		var muti = new MerkleUniqueTokenId(EntityId.fromGrpcTokenId(aNft.tokenId()), aNft.serialNo());
-
+		final var sender = EntityId.fromGrpcAccountId(sponsor);
+		final var receiver = EntityId.fromGrpcAccountId(counterparty);
+		final var muti = new MerkleUniqueTokenId(EntityId.fromGrpcTokenId(aNft.tokenId()), aNft.serialNo());
 		given(accountsLedger.get(sponsor, NUM_NFTS_OWNED)).willReturn(startSponsorNfts);
 		given(accountsLedger.get(counterparty, NUM_NFTS_OWNED)).willReturn(startCounterpartyNfts);
 		given(tokenRelsLedger.get(sponsorNft, TOKEN_BALANCE)).willReturn(startSponsorANfts);
 		given(tokenRelsLedger.get(counterpartyNft, TOKEN_BALANCE)).willReturn(startCounterpartyANfts);
 
-		// when:
-		var status = subject.changeOwner(aNft, sponsor, counterparty);
+		final var status = subject.changeOwner(aNft, sponsor, counterparty);
 
-		// expect:
 		assertEquals(OK, status);
 		verify(nftsLedger).set(aNft, NftProperty.OWNER, receiver);
 		verify(uniqueTokenAccountOwnerships).disassociate(sender, muti);
@@ -840,28 +647,22 @@ class HederaTokenStoreTest {
 
 	@Test
 	void updateRejectsInvalidExpiry() {
-		// given:
 		var op = updateWith(NO_KEYS, true, true, false);
 		op = op.toBuilder().setExpiry(Timestamp.newBuilder().setSeconds(expiry - 1)).build();
 
-		// when:
 		final var outcome = subject.update(op, CONSENSUS_NOW);
 
-		// then:
 		assertEquals(INVALID_EXPIRATION_TIME, outcome);
 	}
 
 	@Test
 	void canExtendImmutableExpiry() {
 		given(token.hasAdminKey()).willReturn(false);
-		// given:
 		var op = updateWith(NO_KEYS, false, false, false);
 		op = op.toBuilder().setExpiry(Timestamp.newBuilder().setSeconds(expiry + 1_234)).build();
 
-		// when:
 		final var outcome = subject.update(op, CONSENSUS_NOW);
 
-		// then:
 		assertEquals(OK, outcome);
 	}
 
@@ -894,13 +695,10 @@ class HederaTokenStoreTest {
 	@Test
 	void updateRejectsInvalidNewAutoRenew() {
 		given(accountsLedger.exists(newAutoRenewAccount)).willReturn(false);
-		// and:PermissionFileUtils
 		final var op = updateWith(NO_KEYS, true, true, false, true, false);
 
-		// when:
 		final var outcome = subject.update(op, CONSENSUS_NOW);
 
-		// then:
 		assertEquals(INVALID_AUTORENEW_ACCOUNT, outcome);
 	}
 
@@ -909,25 +707,19 @@ class HederaTokenStoreTest {
 		var op = updateWith(NO_KEYS, true, true, false, false, false);
 		op = op.toBuilder().setAutoRenewPeriod(enduring(-1L)).build();
 
-		// when:
 		final var outcome = subject.update(op, CONSENSUS_NOW);
 
-		// then:
 		assertEquals(INVALID_RENEWAL_PERIOD, outcome);
 	}
 
 	@Test
 	void updateRejectsMissingToken() {
 		given(tokens.containsKey(fromTokenId(misc))).willReturn(false);
-		// and:
 		givenUpdateTarget(ALL_KEYS);
-		// and:
 		final var op = updateWith(ALL_KEYS, true, true, true);
 
-		// when:
 		final var outcome = subject.update(op, CONSENSUS_NOW);
 
-		// then:
 		assertEquals(INVALID_TOKEN_ID, outcome);
 	}
 
@@ -935,52 +727,40 @@ class HederaTokenStoreTest {
 	@Test
 	void updateRejectsInappropriateKycKey() {
 		givenUpdateTarget(NO_KEYS);
-		// and:
 		final var op = updateWith(EnumSet.of(KeyType.KYC), false, false, false);
 
-		// when:
 		final var outcome = subject.update(op, CONSENSUS_NOW);
 
-		// then:
 		assertEquals(TOKEN_HAS_NO_KYC_KEY, outcome);
 	}
 
 	@Test
 	void updateRejectsInappropriateFreezeKey() {
 		givenUpdateTarget(NO_KEYS);
-		// and:
 		final var op = updateWith(EnumSet.of(KeyType.FREEZE), false, false, false);
 
-		// when:
 		final var outcome = subject.update(op, CONSENSUS_NOW);
 
-		// then:
 		assertEquals(TOKEN_HAS_NO_FREEZE_KEY, outcome);
 	}
 
 	@Test
 	void updateRejectsInappropriateWipeKey() {
 		givenUpdateTarget(NO_KEYS);
-		// and:
 		final var op = updateWith(EnumSet.of(KeyType.WIPE), false, false, false);
 
-		// when:
 		final var outcome = subject.update(op, CONSENSUS_NOW);
 
-		// then:
 		assertEquals(TOKEN_HAS_NO_WIPE_KEY, outcome);
 	}
 
 	@Test
 	void updateRejectsInappropriateSupplyKey() {
 		givenUpdateTarget(NO_KEYS);
-		// and:
 		final var op = updateWith(EnumSet.of(KeyType.SUPPLY), false, false, false);
 
-		// when:
 		final var outcome = subject.update(op, CONSENSUS_NOW);
 
-		// then:
 		assertEquals(TOKEN_HAS_NO_SUPPLY_KEY, outcome);
 	}
 
@@ -991,7 +771,6 @@ class HederaTokenStoreTest {
 
 		subject.removeKnownTreasuryForToken(treasury, misc);
 
-		// expect:
 		assertFalse(subject.knownTreasuries.containsKey(treasury));
 		assertTrue(subject.knownTreasuries.isEmpty());
 	}
@@ -1000,7 +779,6 @@ class HederaTokenStoreTest {
 	void addKnownTreasuryWorks() {
 		subject.addKnownTreasury(treasury, misc);
 
-		// expect:
 		assertTrue(subject.knownTreasuries.containsKey(treasury));
 	}
 
@@ -1011,7 +789,6 @@ class HederaTokenStoreTest {
 
 		subject.removeKnownTreasuryForToken(treasury, misc);
 
-		// expect:
 		assertTrue(subject.knownTreasuries.containsKey(treasury));
 		assertEquals(1, subject.knownTreasuries.size());
 		assertTrue(subject.knownTreasuries.get(treasury).contains(anotherMisc));
@@ -1023,7 +800,6 @@ class HederaTokenStoreTest {
 
 		subject.knownTreasuries.put(treasury, tokenSet);
 
-		// expect:
 		assertTrue(subject.isKnownTreasury(treasury));
 	}
 
@@ -1032,14 +808,9 @@ class HederaTokenStoreTest {
 		Set<TokenID> tokenSet = new HashSet<>(List.of(anotherMisc, misc));
 
 		subject.knownTreasuries.put(treasury, tokenSet);
-
-		// expect:
 		assertEquals(List.of(misc, anotherMisc), subject.listOfTokensServed(treasury));
 
-		// and when:
 		subject.knownTreasuries.remove(treasury);
-
-		// then:
 		assertSame(Collections.emptyList(), subject.listOfTokensServed(treasury));
 	}
 
@@ -1049,96 +820,74 @@ class HederaTokenStoreTest {
 
 		subject.knownTreasuries.put(treasury, tokenSet);
 
-		// expect:
 		assertTrue(subject.isTreasuryForToken(treasury, misc));
 	}
 
 	@Test
 	void isTreasuryForTokenReturnsFalse() {
-		// setup:
 		subject.knownTreasuries.clear();
 
-		// expect:
 		assertFalse(subject.isTreasuryForToken(treasury, misc));
 	}
 
 	@Test
 	void throwsIfKnownTreasuryIsMissing() {
-		// expect:
 		assertThrows(IllegalArgumentException.class, () -> subject.removeKnownTreasuryForToken(null, misc));
 	}
 
 	@Test
 	void throwsIfInvalidTreasury() {
-		// setup:
 		subject.knownTreasuries.clear();
 
-		// expect:
 		assertThrows(IllegalArgumentException.class, () -> subject.removeKnownTreasuryForToken(treasury, misc));
 	}
 
 
 	@Test
 	void updateHappyPathIgnoresZeroExpiry() {
-		// setup:
 		subject.addKnownTreasury(treasury, misc);
 		Set<TokenID> tokenSet = new HashSet<>();
 		tokenSet.add(misc);
-
 		givenUpdateTarget(ALL_KEYS);
-		// and:
 		var op = updateWith(ALL_KEYS, true, true, true);
 		op = op.toBuilder().setExpiry(Timestamp.newBuilder().setSeconds(0)).build();
 
-		// when:
 		final var outcome = subject.update(op, CONSENSUS_NOW);
 
-		// then:
 		assertEquals(OK, outcome);
 		verify(token, never()).setExpiry(anyLong());
-		// and:
 		assertFalse(subject.knownTreasuries.containsKey(treasury));
 		assertEquals(subject.knownTreasuries.get(newTreasury), tokenSet);
 	}
 
 	@Test
 	void updateRemovesAdminKeyWhenAppropos() {
-		// setup:
 		subject.addKnownTreasury(treasury, misc);
-
 		Set<TokenID> tokenSet = new HashSet<>();
 		tokenSet.add(misc);
-
 		givenUpdateTarget(EnumSet.noneOf(KeyType.class));
-		// and:
 		final var op = updateWith(EnumSet.of(KeyType.EMPTY_ADMIN), false, false, false);
 
-		// when:
 		final var outcome = subject.update(op, CONSENSUS_NOW);
-		// then:
+
 		assertEquals(OK, outcome);
 		verify(token).setAdminKey(MerkleToken.UNUSED_KEY);
 	}
 
 	@Test
 	void updateHappyPathWorksForEverythingWithNewExpiry() {
-		// setup:
 		subject.addKnownTreasury(treasury, misc);
-
 		Set<TokenID> tokenSet = new HashSet<>();
 		tokenSet.add(misc);
-
 		givenUpdateTarget(ALL_KEYS);
-		// and:
 		var op = updateWith(ALL_KEYS, true, true, true);
 		op = op.toBuilder()
 				.setExpiry(Timestamp.newBuilder().setSeconds(newExpiry))
 				.setFeeScheduleKey(newKey)
 				.build();
 
-		// when:
 		final var outcome = subject.update(op, CONSENSUS_NOW);
-		// then:
+
 		assertEquals(OK, outcome);
 		verify(token).setSymbol(newSymbol);
 		verify(token).setName(newName);
@@ -1150,18 +899,14 @@ class HederaTokenStoreTest {
 		verify(token).setSupplyKey(argThat((JKey k) -> JKey.equalUpToDecodability(k, newFcKey)));
 		verify(token).setWipeKey(argThat((JKey k) -> JKey.equalUpToDecodability(k, newFcKey)));
 		verify(token).setFeeScheduleKey(argThat((JKey k) -> JKey.equalUpToDecodability(k, newFcKey)));
-		// and:
 		assertFalse(subject.knownTreasuries.containsKey(treasury));
 		assertEquals(subject.knownTreasuries.get(newTreasury), tokenSet);
 	}
 
 	@Test
 	void updateHappyPathWorksWithNewMemo() {
-		// setup:
 		subject.addKnownTreasury(treasury, misc);
-
 		givenUpdateTarget(ALL_KEYS);
-		// and:
 		final var op = updateWith(NO_KEYS,
 				false,
 				false,
@@ -1171,27 +916,20 @@ class HederaTokenStoreTest {
 				false,
 				true);
 
-		// when:
 		final var outcome = subject.update(op, CONSENSUS_NOW);
 
-		// then:
 		assertEquals(OK, outcome);
 		verify(token).setMemo(newMemo);
 	}
 
 	@Test
 	void updateHappyPathWorksWithNewAutoRenewAccount() {
-		// setup:
 		subject.addKnownTreasury(treasury, misc);
-
 		givenUpdateTarget(ALL_KEYS);
-		// and:
 		final var op = updateWith(ALL_KEYS, true, true, true, true, true);
 
-		// when:
 		final var outcome = subject.update(op, CONSENSUS_NOW);
 
-		// then:
 		assertEquals(OK, outcome);
 		verify(token).setAutoRenewAccount(EntityId.fromGrpcAccountId(newAutoRenewAccount));
 		verify(token).setAutoRenewPeriod(newAutoRenewPeriod);
@@ -1307,13 +1045,9 @@ class HederaTokenStoreTest {
 
 	@Test
 	void understandsPendingCreation() {
-		// expect:
 		assertFalse(subject.isCreationPending());
 
-		// and when:
 		subject.pendingId = misc;
-
-		// expect:
 		assertTrue(subject.isCreationPending());
 	}
 
@@ -1321,10 +1055,8 @@ class HederaTokenStoreTest {
 	void adjustingRejectsMissingToken() {
 		given(tokens.containsKey(fromTokenId(misc))).willReturn(false);
 
-		// when:
 		final var status = subject.adjustBalance(sponsor, misc, 1);
 
-		// expect:
 		assertEquals(ResponseCodeEnum.INVALID_TOKEN_ID, status);
 	}
 
@@ -1332,10 +1064,8 @@ class HederaTokenStoreTest {
 	void freezingRejectsUnfreezableToken() {
 		given(token.freezeKey()).willReturn(Optional.empty());
 
-		// when:
 		final var status = subject.freeze(treasury, misc);
 
-		// then:
 		assertEquals(ResponseCodeEnum.TOKEN_HAS_NO_FREEZE_KEY, status);
 	}
 
@@ -1343,10 +1073,8 @@ class HederaTokenStoreTest {
 	void grantingRejectsUnknowableToken() {
 		given(token.kycKey()).willReturn(Optional.empty());
 
-		// when:
 		final var status = subject.grantKyc(treasury, misc);
 
-		// then:
 		assertEquals(ResponseCodeEnum.TOKEN_HAS_NO_KYC_KEY, status);
 	}
 
@@ -1355,19 +1083,15 @@ class HederaTokenStoreTest {
 		givenTokenWithFreezeKey(true);
 		given(token.isDeleted()).willReturn(true);
 
-		// when:
 		final var status = subject.freeze(treasury, misc);
 
-		// then:
 		assertEquals(ResponseCodeEnum.TOKEN_WAS_DELETED, status);
 	}
 
 	@Test
 	void unfreezingInvalidWithoutFreezeKey() {
-		// when:
 		final var status = subject.unfreeze(treasury, misc);
 
-		// then:
 		assertEquals(TOKEN_HAS_NO_FREEZE_KEY, status);
 	}
 
@@ -1375,10 +1099,8 @@ class HederaTokenStoreTest {
 	void performsValidFreeze() {
 		givenTokenWithFreezeKey(false);
 
-		// when:
 		subject.freeze(treasury, misc);
 
-		// then:
 		verify(tokenRelsLedger).set(treasuryMisc, TokenRelProperty.IS_FROZEN, true);
 	}
 
@@ -1391,10 +1113,8 @@ class HederaTokenStoreTest {
 	void adjustingRejectsDeletedToken() {
 		given(token.isDeleted()).willReturn(true);
 
-		// when:
 		final var status = subject.adjustBalance(treasury, misc, 1);
 
-		// then:
 		assertEquals(ResponseCodeEnum.TOKEN_WAS_DELETED, status);
 	}
 
@@ -1402,90 +1122,72 @@ class HederaTokenStoreTest {
 	void adjustingRejectsFungibleUniqueToken() {
 		given(token.tokenType()).willReturn(TokenType.NON_FUNGIBLE_UNIQUE);
 
-		// when:
 		final var status = subject.adjustBalance(treasury, misc, 1);
 
-		// then:
 		assertEquals(ACCOUNT_AMOUNT_TRANSFERS_ONLY_ALLOWED_FOR_FUNGIBLE_COMMON, status);
 	}
 
 	@Test
 	void refusesToAdjustFrozenRelationship() {
 		given(tokenRelsLedger.get(treasuryMisc, IS_FROZEN)).willReturn(true);
-		// when:
+
 		final var status = subject.adjustBalance(treasury, misc, -1);
 
-		// then:
 		assertEquals(ACCOUNT_FROZEN_FOR_TOKEN, status);
 	}
 
 	@Test
 	void refusesToAdjustRevokedKycRelationship() {
 		given(tokenRelsLedger.get(treasuryMisc, IS_KYC_GRANTED)).willReturn(false);
-		// when:
+
 		final var status = subject.adjustBalance(treasury, misc, -1);
 
-		// then:
 		assertEquals(ACCOUNT_KYC_NOT_GRANTED_FOR_TOKEN, status);
 	}
 
 	@Test
 	void refusesInvalidAdjustment() {
-		// when:
 		final var status = subject.adjustBalance(treasury, misc, -treasuryBalance - 1);
 
-		// then:
 		assertEquals(INSUFFICIENT_TOKEN_BALANCE, status);
 	}
 
 	@Test
 	void performsValidAdjustment() {
-		// when:
 		subject.adjustBalance(treasury, misc, -1);
 
-		// then:
 		verify(tokenRelsLedger).set(treasuryMisc, TOKEN_BALANCE, treasuryBalance - 1);
 	}
 
 	@Test
 	void rollbackReclaimsIdAndClears() {
-		// setup:
 		subject.pendingId = created;
 		subject.pendingCreation = token;
 
-		// when:
 		subject.rollbackCreation();
 
-		// then:
 		verify(tokens, never()).put(fromTokenId(created), token);
 		verify(ids).reclaimLastId();
-		// and:
 		assertSame(subject.pendingId, HederaTokenStore.NO_PENDING_ID);
 		assertNull(subject.pendingCreation);
 	}
 
 	@Test
 	void commitAndRollbackThrowIseIfNoPendingCreation() {
-		// expect:
 		assertThrows(IllegalStateException.class, subject::commitCreation);
 		assertThrows(IllegalStateException.class, subject::rollbackCreation);
 	}
 
 	@Test
 	void commitPutsToMapAndClears() {
-		// setup:
 		subject.pendingId = created;
 		subject.pendingCreation = token;
 
-		// when:
 		subject.commitCreation();
 
-		// then:
 		verify(tokens).put(fromTokenId(created), token);
-		// and:
 		assertSame(subject.pendingId, HederaTokenStore.NO_PENDING_ID);
 		assertNull(subject.pendingCreation);
-		// and:
 		assertTrue(subject.isKnownTreasury(treasury));
 		assertEquals(Set.of(created, misc), subject.knownTreasuries.get(treasury));
 	}
@@ -1493,27 +1195,21 @@ class HederaTokenStoreTest {
 	@Test
 	void rejectsTooManyFeeSchedules() {
 		given(properties.maxCustomFeesAllowed()).willReturn(1);
-
-		// given:
 		final var req = fullyValidTokenCreateAttempt().build();
 
-		// when:
 		final var result = subject.createProvisionally(req, sponsor, CONSENSUS_NOW);
 
-		// expect:
 		assertEquals(CUSTOM_FEES_LIST_TOO_LONG, result.getStatus());
 		assertTrue(result.getCreated().isEmpty());
 	}
 
 	@Test
 	void rejectsUnderspecifiedFeeSchedules() {
-		// given:
+		final var grpcUnderspecifiedCustomFees = List.of(builder.withOnlyFeeCollector());
 		final var req = fullyValidTokenCreateAttempt().addAllCustomFees(grpcUnderspecifiedCustomFees).build();
 
-		// when:
 		final var result = subject.createProvisionally(req, sponsor, CONSENSUS_NOW);
 
-		// expect:
 		assertEquals(CUSTOM_FEE_NOT_FULLY_SPECIFIED, result.getStatus());
 		assertTrue(result.getCreated().isEmpty());
 	}
@@ -1521,14 +1217,10 @@ class HederaTokenStoreTest {
 	@Test
 	void rejectsInvalidFeeCollector() {
 		given(accountsLedger.exists(anotherFeeCollector)).willReturn(false);
-
-		// given:
 		final var req = fullyValidTokenCreateAttempt().build();
 
-		// when:
 		final var result = subject.createProvisionally(req, sponsor, CONSENSUS_NOW);
 
-		// expect:
 		assertEquals(INVALID_CUSTOM_FEE_COLLECTOR, result.getStatus());
 		assertTrue(result.getCreated().isEmpty());
 	}
@@ -1536,20 +1228,19 @@ class HederaTokenStoreTest {
 	@Test
 	void rejectsMissingTokenDenomination() {
 		given(tokens.containsKey(fromTokenId(misc))).willReturn(false);
-
-		// given:
 		final var req = fullyValidTokenCreateAttempt().build();
 
-		// when:
 		final var result = subject.createProvisionally(req, sponsor, CONSENSUS_NOW);
 
-		// expect:
 		assertEquals(INVALID_TOKEN_ID_IN_CUSTOM_FEES, result.getStatus());
 		assertTrue(result.getCreated().isEmpty());
 	}
 
 	@Test
 	void rejectsNftAsCustomFeeDenomination() {
+		final var grpcNftAsDenominatingToken = List.of(
+				builder.withFixedFee(fixedHts(nonfungible, 100L))
+		);
 		final var req = fullyValidTokenCreateAttempt().addAllCustomFees(grpcNftAsDenominatingToken).build();
 
 		final var result = subject.createProvisionally(req, sponsor, CONSENSUS_NOW);
@@ -1561,14 +1252,10 @@ class HederaTokenStoreTest {
 	@Test
 	void rejectsUnassociatedFeeCollector() {
 		given(tokenRelsLedger.exists(anotherFeeCollectorMisc)).willReturn(false);
-
-		// given:
 		final var req = fullyValidTokenCreateAttempt().build();
 
-		// when:
 		final var result = subject.createProvisionally(req, sponsor, CONSENSUS_NOW);
 
-		// expect:
 		assertEquals(TOKEN_NOT_ASSOCIATED_TO_FEE_COLLECTOR, result.getStatus());
 		assertTrue(result.getCreated().isEmpty());
 	}
@@ -1586,104 +1273,128 @@ class HederaTokenStoreTest {
 
 	@Test
 	void rejectsZeroFractionInFractionalFee() {
+		final var grpcZeroFractionCustomFees = List.of(
+				builder.withFractionalFee(fractional(0L, 1_000L))
+		);
 		final var req = fullyValidTokenCreateAttempt().addAllCustomFees(grpcZeroFractionCustomFees).build();
 
-		// when:
 		final var result = subject.createProvisionally(req, sponsor, CONSENSUS_NOW);
 
-		// expect:
 		assertEquals(CUSTOM_FEE_MUST_BE_POSITIVE, result.getStatus());
 		assertTrue(result.getCreated().isEmpty());
 	}
 
 	@Test
 	void rejectsNegativeFractionInFractionalFee() {
+		final var grpcNegativeFractionCustomFees = List.of(
+				builder.withFractionalFee(fractional(123L, -1_000L))
+		);
 		final var req = fullyValidTokenCreateAttempt().addAllCustomFees(grpcNegativeFractionCustomFees).build();
 
-		// when:
 		final var result = subject.createProvisionally(req, sponsor, CONSENSUS_NOW);
 
-		// expect:
 		assertEquals(CUSTOM_FEE_MUST_BE_POSITIVE, result.getStatus());
 		assertTrue(result.getCreated().isEmpty());
 	}
 
 	@Test
 	void rejectsNegativeMaxInFractionalFee() {
+		final var grpcNegativeMaximumCustomFees = List.of(
+				builder.withFractionalFee(
+						fractional(123L, 1_000L)
+								.setMaximumAmount(-1L))
+		);
 		final var req = fullyValidTokenCreateAttempt().addAllCustomFees(grpcNegativeMaximumCustomFees).build();
 
-		// when:
 		final var result = subject.createProvisionally(req, sponsor, CONSENSUS_NOW);
 
-		// expect:
 		assertEquals(CUSTOM_FEE_MUST_BE_POSITIVE, result.getStatus());
 		assertTrue(result.getCreated().isEmpty());
 	}
 
 	@Test
 	void rejectsNegativeMinInFractionalFee() {
+		final var grpcNegativeMinimumCustomFees = List.of(
+				builder.withFractionalFee(
+						fractional(123L, 1_000L)
+								.setMinimumAmount(-1L))
+		);
 		final var req = fullyValidTokenCreateAttempt().addAllCustomFees(grpcNegativeMinimumCustomFees).build();
 
-		// when:
 		final var result = subject.createProvisionally(req, sponsor, CONSENSUS_NOW);
 
-		// expect:
 		assertEquals(CUSTOM_FEE_MUST_BE_POSITIVE, result.getStatus());
 		assertTrue(result.getCreated().isEmpty());
 	}
 
 	@Test
 	void rejectsNegativeAmountInFixedFee() {
+		final var grpcNegativeFixedCustomFees = List.of(
+				builder.withFixedFee(fixedHts(-1_000L))
+		);
 		final var req = fullyValidTokenCreateAttempt().addAllCustomFees(grpcNegativeFixedCustomFees).build();
 
-		// when:
 		final var result = subject.createProvisionally(req, sponsor, CONSENSUS_NOW);
 
-		// expect:
 		assertEquals(CUSTOM_FEE_MUST_BE_POSITIVE, result.getStatus());
 		assertTrue(result.getCreated().isEmpty());
 	}
 
 	@Test
 	void rejectsInvalidFractionInFractionalFee() {
+		final var grpcDivideByZeroCustomFees = List.of(
+				builder.withFractionalFee(fractional(15, 0))
+		);
 		final var req = fullyValidTokenCreateAttempt().addAllCustomFees(grpcDivideByZeroCustomFees).build();
 
-		// when:
 		final var result = subject.createProvisionally(req, sponsor, CONSENSUS_NOW);
 
-		// expect:
 		assertEquals(FRACTION_DIVIDES_BY_ZERO, result.getStatus());
 		assertTrue(result.getCreated().isEmpty());
 	}
 
 	@Test
 	void rejectsFractionalFeeMaxAmountLessThanMinAmount() {
+		final var grpcMaxLessThanMinCustomFees = List.of(
+				builder.withFractionalFee(
+						fractional(123L, 1_000L)
+								.setMinimumAmount(10L)
+								.setMaximumAmount(2L))
+		);
 		final var req = fullyValidTokenCreateAttempt()
 				.addAllCustomFees(grpcMaxLessThanMinCustomFees).build();
 
-		// when:
 		final var result = subject.createProvisionally(req, sponsor, CONSENSUS_NOW);
 
-		// expect:
 		assertEquals(FRACTIONAL_FEE_MAX_AMOUNT_LESS_THAN_MIN_AMOUNT, result.getStatus());
 		assertTrue(result.getCreated().isEmpty());
 	}
 
 	@Test
 	void acceptsFractionalFeeMaxAmountEqualToMinAmount() {
+		final var grpcMaxEqualToMinCustomFees = List.of(
+				builder.withFractionalFee(
+						fractional(123L, 1_000L)
+								.setMinimumAmount(2L)
+								.setMaximumAmount(2L))
+		);
 		final var req = fullyValidTokenCreateAttempt()
 				.addAllCustomFees(grpcMaxEqualToMinCustomFees).build();
 
-		// when:
 		final var result = subject.createProvisionally(req, sponsor, CONSENSUS_NOW);
 
-		// expect:
 		assertEquals(OK, result.getStatus());
 		assertFalse(result.getCreated().isEmpty());
 	}
 
 	@Test
 	void acceptsFractionalFeeWithZeroMaxAmountPositiveMinAmount() {
+		final var grpcZeroMaxPositiveMinCustomFees = List.of(
+				builder.withFractionalFee(
+						fractional(123L, 1_000L)
+								.setMinimumAmount(10L)
+								.setMaximumAmount(0L))
+		);
 		final var req = fullyValidTokenCreateAttempt()
 				.addAllCustomFees(grpcZeroMaxPositiveMinCustomFees).build();
 
@@ -1695,44 +1406,37 @@ class HederaTokenStoreTest {
 
 	@Test
 	void rejectsBothNumeratorAndDenominatorNegativeInFractionalFee() {
+		final var grpcBothNegativeFractionCustomFees = List.of(
+				builder.withFractionalFee(fractional(-123L, -1_000L))
+		);
 		final var req = fullyValidTokenCreateAttempt()
 				.addAllCustomFees(grpcBothNegativeFractionCustomFees).build();
 
-		// when:
 		final var result = subject.createProvisionally(req, sponsor, CONSENSUS_NOW);
 
-		// expect:
 		assertEquals(CUSTOM_FEE_MUST_BE_POSITIVE, result.getStatus());
 		assertTrue(result.getCreated().isEmpty());
 	}
 
 	@Test
 	void happyPathWorksWithAutoRenew() {
-		// setup:
 		final var expected = buildFullyValidExpectedToken();
-
-		// given:
 		final var req = fullyValidTokenCreateAttempt()
 				.setExpiry(Timestamp.newBuilder().setSeconds(0))
 				.setAutoRenewAccount(autoRenewAccount)
 				.setAutoRenewPeriod(enduring(autoRenewPeriod))
 				.build();
 
-		// when:
 		final var result = subject.createProvisionally(req, sponsor, CONSENSUS_NOW);
 
-		// then:
 		assertEquals(OK, result.getStatus());
 		assertEquals(created, result.getCreated().get());
-		// and:
 		assertEquals(created, subject.pendingId);
 		assertEquals(expected, subject.pendingCreation);
 	}
 
 	@Test
 	void canCreateTokenWithImmutableFeeSchedule() {
-		// setup:
-
 		final var expected = buildFullyValidExpectedToken();
 		expected.setFeeScheduleKey(MerkleToken.UNUSED_KEY);
 		final var req = fullyValidTokenCreateAttempt()
@@ -1742,21 +1446,16 @@ class HederaTokenStoreTest {
 				.setAutoRenewPeriod(enduring(autoRenewPeriod))
 				.build();
 
-		// when:
 		final var result = subject.createProvisionally(req, sponsor, CONSENSUS_NOW);
 
-		// then:
 		assertEquals(OK, result.getStatus());
 		assertEquals(created, result.getCreated().get());
-		// and:
 		assertEquals(created, subject.pendingId);
 		assertEquals(expected, subject.pendingCreation);
 	}
 
 	@Test
 	void canCreateTokenWithFeeScheduleKeyButNoFeeSchedules() {
-		// setup:
-
 		final var expected = buildFullyValidExpectedToken();
 		expected.setFeeScheduleFrom(Collections.emptyList(), null);
 		final var req = fullyValidTokenCreateAttempt()
@@ -1766,20 +1465,16 @@ class HederaTokenStoreTest {
 				.setAutoRenewPeriod(enduring(autoRenewPeriod))
 				.build();
 
-		// when:
 		final var result = subject.createProvisionally(req, sponsor, CONSENSUS_NOW);
 
-		// then:
 		assertEquals(OK, result.getStatus());
 		assertEquals(created, result.getCreated().get());
-		// and:
 		assertEquals(created, subject.pendingId);
 		assertEquals(expected, subject.pendingCreation);
 	}
 
 	@Test
 	void happyPathWorksWithExplicitExpiry() {
-		// setup:
 		final var expected = new MerkleToken(
 				expiry,
 				totalSupply,
@@ -1799,17 +1494,12 @@ class HederaTokenStoreTest {
 		expected.setSupplyType(TokenSupplyType.INFINITE);
 		expected.setMemo(memo);
 		expected.setFeeScheduleFrom(Collections.emptyList(), null);
-
-		// given:
 		final var req = fullyValidTokenCreateAttempt().clearCustomFees().build();
 
-		// when:
 		final var result = subject.createProvisionally(req, sponsor, CONSENSUS_NOW);
 
-		// then:
 		assertEquals(OK, result.getStatus());
 		assertEquals(created, result.getCreated().get());
-		// and:
 		assertEquals(created, subject.pendingId);
 		assertEquals(expected, subject.pendingCreation);
 	}
@@ -1817,93 +1507,71 @@ class HederaTokenStoreTest {
 	@Test
 	void rejectsInvalidAutoRenewAccount() {
 		given(accountsLedger.exists(autoRenewAccount)).willReturn(false);
-
-		// given:
 		final var req = fullyValidTokenCreateAttempt()
 				.setAutoRenewAccount(autoRenewAccount)
 				.setAutoRenewPeriod(enduring(1000L))
 				.build();
 
-		// when:
 		final var result = subject.createProvisionally(req, sponsor, CONSENSUS_NOW);
 
-		// then:
 		assertEquals(INVALID_AUTORENEW_ACCOUNT, result.getStatus());
 	}
 
 	@Test
 	void rejectsMissingTreasury() {
 		given(accountsLedger.exists(treasury)).willReturn(false);
-		// and:
-		final var req = fullyValidTokenCreateAttempt()
-				.build();
+		final var req = fullyValidTokenCreateAttempt().build();
 
-		// when:
 		final var result = subject.createProvisionally(req, sponsor, CONSENSUS_NOW);
 
-		// then:
 		assertEquals(ResponseCodeEnum.INVALID_TREASURY_ACCOUNT_FOR_TOKEN, result.getStatus());
 	}
 
 	@Test
 	void rejectsDeletedTreasuryAccount() {
 		given(hederaLedger.isDeleted(treasury)).willReturn(true);
+		final var req = fullyValidTokenCreateAttempt().build();
 
-		// and:
-		final var req = fullyValidTokenCreateAttempt()
-				.build();
-
-		// when:
 		final var result = subject.createProvisionally(req, sponsor, CONSENSUS_NOW);
 
-		// then:
 		assertEquals(ResponseCodeEnum.INVALID_TREASURY_ACCOUNT_FOR_TOKEN, result.getStatus());
 	}
 
 	@Test
 	void allowsZeroInitialSupplyAndDecimals() {
-		// given:
 		final var req = fullyValidTokenCreateAttempt()
 				.clearCustomFees()
 				.setInitialSupply(0L)
 				.setDecimals(0)
 				.build();
 
-		// when:
 		final var result = subject.createProvisionally(req, sponsor, CONSENSUS_NOW);
 
-		// then:
 		assertEquals(ResponseCodeEnum.OK, result.getStatus());
 	}
 
 	@Test
 	void allowsToCreateTokenWithTheBiggestAmountInLong() {
-		// given:
 		final var req = fullyValidTokenCreateAttempt()
 				.clearCustomFees()
 				.setInitialSupply(9)
 				.setDecimals(18)
 				.build();
 
-		// when:
 		final var result = subject.createProvisionally(req, sponsor, CONSENSUS_NOW);
 
-		// then:
 		assertEquals(ResponseCodeEnum.OK, result.getStatus());
 	}
 
 	@Test
 	void forcesToTrueAccountsKycGrantedByDefaultWithoutKycKey() {
-		// given:
 		final var req = fullyValidTokenCreateAttempt()
 				.clearCustomFees()
 				.clearKycKey()
 				.build();
 
-		// when:
 		final var result = subject.createProvisionally(req, sponsor, CONSENSUS_NOW);
 
-		// then:
 		assertEquals(ResponseCodeEnum.OK, result.getStatus());
 		assertTrue(subject.pendingCreation.accountsKycGrantedByDefault());
 	}
@@ -1929,7 +1597,7 @@ class HederaTokenStoreTest {
 	}
 
 	private MerkleToken buildFullyValidExpectedToken() {
-		var expected = new MerkleToken(
+		final var expected = new MerkleToken(
 				CONSENSUS_NOW + autoRenewPeriod,
 				totalSupply,
 				decimals,
@@ -1950,7 +1618,7 @@ class HederaTokenStoreTest {
 		expected.setTokenType(TokenType.FUNGIBLE_COMMON);
 		expected.setSupplyType(TokenSupplyType.INFINITE);
 		expected.setMemo(memo);
-		expected.setFeeScheduleFrom(grpcCustomFees, null);
+		expected.setFeeScheduleFrom(grpcCustomFees, EntityId.fromGrpcTokenId(created));
 
 		return expected;
 	}
@@ -1959,10 +1627,9 @@ class HederaTokenStoreTest {
 		return Duration.newBuilder().setSeconds(secs).build();
 	}
 
-
 	@Test
 	void rejectsMissingTokenIdCustomFeeUpdates() {
-		var op = updateFeeScheduleWithMissingTokenId();
+		final var op = updateFeeScheduleWithMissingTokenId();
 
 		final var result = subject.updateFeeSchedule(op);
 
@@ -1971,7 +1638,7 @@ class HederaTokenStoreTest {
 
 	@Test
 	void rejectsTooLongCustomFeeUpdates() {
-		var op = updateFeeScheduleWith();
+		final var op = updateFeeScheduleWith();
 		given(properties.maxCustomFeesAllowed()).willReturn(1);
 
 		final var result = subject.updateFeeSchedule(op);
@@ -1981,7 +1648,7 @@ class HederaTokenStoreTest {
 
 	@Test
 	void rejectsEmptyFeesUpdatedWithEmptyFees() {
-		var op = updateFeeScheduleWithEmptyFees();
+		final var op = updateFeeScheduleWithEmptyFees();
 		given(token.grpcFeeSchedule()).willReturn(List.of());
 
 		final var result = subject.updateFeeSchedule(op);
@@ -1991,7 +1658,7 @@ class HederaTokenStoreTest {
 
 	@Test
 	void rejectsFeesUpdatedWithInvalidFractionalFees() {
-		var op = updateFeeScheduleWithInvalidFractionalFee();
+		final var op = updateFeeScheduleWithInvalidFractionalFee();
 
 		final var result = subject.updateFeeSchedule(op);
 
@@ -2002,7 +1669,7 @@ class HederaTokenStoreTest {
 	void canOnlyUpdateTokensWithFeeScheduleKey() {
 		given(token.hasFeeScheduleKey()).willReturn(false);
 
-		var op = updateFeeScheduleWith();
+		final var op = updateFeeScheduleWith();
 
 		final var result = subject.updateFeeSchedule(op);
 
@@ -2013,7 +1680,7 @@ class HederaTokenStoreTest {
 	void cannotUseFractionalFeeWithNonfungibleUpdateTarget() {
 		given(token.tokenType()).willReturn(TokenType.NON_FUNGIBLE_UNIQUE);
 
-		var op = updateFeeScheduleWithOnlyFractional();
+		final var op = updateFeeScheduleWithOnlyFractional();
 
 		final var result = subject.updateFeeSchedule(op);
 
@@ -2022,10 +1689,11 @@ class HederaTokenStoreTest {
 
 	@Test
 	void happyPathCustomFeesUpdated() {
-		var op = updateFeeScheduleWith();
+		final var op = updateFeeScheduleWith();
 
 		final var result = subject.updateFeeSchedule(op);
 
+		verify(token).setFeeScheduleFrom(grpcCustomFees, EntityId.fromGrpcTokenId(misc));
 		assertEquals(OK, result);
 	}
 

--- a/hedera-node/src/test/java/com/hedera/services/txns/customfees/FcmCustomFeeSchedulesTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/txns/customfees/FcmCustomFeeSchedulesTest.java
@@ -53,8 +53,8 @@ class FcmCustomFeeSchedulesTest {
 		//setup:
 		final var tokenAFees = List.of(FcCustomFee.fixedFee(20L, tokenA, feeCollector).asGrpc());
 		final var tokenBFees = List.of(FcCustomFee.fixedFee(40L, tokenB, feeCollector).asGrpc());
-		tokenAValue.setFeeScheduleFrom(tokenAFees);
-		tokenBValue.setFeeScheduleFrom(tokenBFees);
+		tokenAValue.setFeeScheduleFrom(tokenAFees, null);
+		tokenBValue.setFeeScheduleFrom(tokenBFees, null);
 
 		tokenFCMap.put(tokenA.asMerkle(), tokenAValue);
 		tokenFCMap.put(tokenB.asMerkle(), tokenBValue);
@@ -86,7 +86,7 @@ class FcmCustomFeeSchedulesTest {
 		MerkleToken token = new MerkleToken();
 		final var missingFees = List.of(
 				FcCustomFee.fixedFee(50L, missingToken, feeCollector).asGrpc());
-		token.setFeeScheduleFrom(missingFees);
+		token.setFeeScheduleFrom(missingFees, null);
 		secondFCMap.put(missingToken.asMerkle(), new MerkleToken());
 		final var fees1 = new FcmCustomFeeSchedules(() -> tokenFCMap);
 		final var fees2 = new FcmCustomFeeSchedules(() -> secondFCMap);

--- a/hedera-node/src/test/java/com/hedera/services/txns/token/TokenCreateTransitionLogicTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/txns/token/TokenCreateTransitionLogicTest.java
@@ -802,21 +802,19 @@ class TokenCreateTransitionLogicTest {
 	private AccountID fractionalFeeCollector = IdUtils.asAccount("9.9.9");
 	private AccountID nonAutoEnabledFeeCollector = IdUtils.asAccount("1.2.777");
 	private CustomFeeBuilder builder = new CustomFeeBuilder(feeCollector);
-	private CustomFee customFixedFeeInHbar = new CustomFeeBuilder(hbarFeeCollector).fromFixedFee(fixedHbar(100));
-	private CustomFee customFixedFeeInHts = new CustomFeeBuilder(nonAutoEnabledFeeCollector).fromFixedFee(
-			fixedHts(misc, 100));
-	private CustomFee customFixedFeeA = builder.fromFixedFee(
-			fixedHts(200));
-	private CustomFee customFixedFeeB = new CustomFeeBuilder(fixedFeeCollector).fromFixedFee(
-			fixedHts(300));
-	private CustomFee customFractionalFeeA = builder.fromFractionalFee(
-			fractional(15, 100)
-					.setMinimumAmount(10)
-					.setMaximumAmount(50));
-	private CustomFee customFractionalFeeB = new CustomFeeBuilder(fractionalFeeCollector).fromFractionalFee(
-			fractional(15, 100)
-					.setMinimumAmount(5)
-					.setMaximumAmount(15));
+	private CustomFee customFixedFeeInHbar = new CustomFeeBuilder(hbarFeeCollector).withFixedFee(fixedHbar(100L));
+	private CustomFee customFixedFeeInHts = new CustomFeeBuilder(nonAutoEnabledFeeCollector).withFixedFee(
+			fixedHts(misc, 100L));
+	private CustomFee customFixedFeeA = builder.withFixedFee(fixedHts(200L));
+	private CustomFee customFixedFeeB = new CustomFeeBuilder(fixedFeeCollector).withFixedFee(fixedHts(300L));
+	private CustomFee customFractionalFeeA = builder.withFractionalFee(
+			fractional(15L, 100L)
+					.setMinimumAmount(10L)
+					.setMaximumAmount(50L));
+	private CustomFee customFractionalFeeB = new CustomFeeBuilder(fractionalFeeCollector).withFractionalFee(
+			fractional(15L, 100L)
+					.setMinimumAmount(5L)
+					.setMaximumAmount(15L));
 	private List<CustomFee> grpcCustomFees = List.of(
 			customFixedFeeInHbar,
 			customFixedFeeInHts,

--- a/hedera-node/src/test/java/com/hedera/test/factories/fees/CustomFeeBuilder.java
+++ b/hedera-node/src/test/java/com/hedera/test/factories/fees/CustomFeeBuilder.java
@@ -43,11 +43,15 @@ public class CustomFeeBuilder {
 				.setFeeCollectorAccountId(feeCollector);
 	}
 
-	public CustomFee fromFixedFee(final FixedFee.Builder fee) {
+	public CustomFee withOnlyFeeCollector() {
+		return builder().build();
+	}
+
+	public CustomFee withFixedFee(final FixedFee.Builder fee) {
 		return builder().setFixedFee(fee).build();
 	}
 
-	public CustomFee fromFractionalFee(final FractionalFee.Builder fee) {
+	public CustomFee withFractionalFee(final FractionalFee.Builder fee) {
 		return builder().setFractionalFee(fee).build();
 	}
 

--- a/hedera-node/src/test/java/com/hedera/test/factories/fees/CustomFeeBuilder.java
+++ b/hedera-node/src/test/java/com/hedera/test/factories/fees/CustomFeeBuilder.java
@@ -1,0 +1,73 @@
+package com.hedera.test.factories.fees;
+
+/*-
+ * ‌
+ * Hedera Services Node
+ * ​
+ * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import com.hederahashgraph.api.proto.java.AccountID;
+import com.hederahashgraph.api.proto.java.CustomFee;
+import com.hederahashgraph.api.proto.java.FixedFee;
+import com.hederahashgraph.api.proto.java.Fraction;
+import com.hederahashgraph.api.proto.java.FractionalFee;
+import com.hederahashgraph.api.proto.java.TokenID;
+
+public class CustomFeeBuilder {
+	private AccountID feeCollector;
+
+	public CustomFeeBuilder(final AccountID feeCollector) {
+		setFeeCollector(feeCollector);
+	}
+
+	public void setFeeCollector(final AccountID feeCollector) {
+		this.feeCollector = feeCollector;
+	}
+
+	private CustomFee.Builder builder() {
+		return CustomFee.newBuilder()
+				.setFeeCollectorAccountId(feeCollector);
+	}
+
+	public CustomFee fromFixedFee(final FixedFee.Builder fee) {
+		return builder().setFixedFee(fee).build();
+	}
+
+	public CustomFee fromFractionalFee(final FractionalFee.Builder fee) {
+		return builder().setFractionalFee(fee).build();
+	}
+
+	public static FixedFee.Builder fixedHbar(final long units) {
+		return FixedFee.newBuilder()
+				.setAmount(units);
+	}
+
+	public static FixedFee.Builder fixedHts(final TokenID denom, final long units) {
+		return fixedHbar(units).setDenominatingTokenId(denom);
+	}
+
+	public static FixedFee.Builder fixedHts(final long units) {
+		return fixedHts(TokenID.getDefaultInstance(), units);
+	}
+
+	public static FractionalFee.Builder fractional(final long numerator, final long denominator) {
+		return FractionalFee.newBuilder()
+				.setFractionalAmount(Fraction.newBuilder()
+						.setNumerator(numerator)
+						.setDenominator(denominator));
+	}
+}

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenCreateSpecs.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenCreateSpecs.java
@@ -538,7 +538,7 @@ public class TokenCreateSpecs extends HapiApiSuite {
 						getTokenInfo(token)
 								.hasCustom(fixedHbarFeeInSchedule(hbarAmount, hbarCollector))
 								.hasCustom(fixedHtsFeeInSchedule(htsAmount, feeDenom, htsCollector))
-								.hasCustom(fixedHtsFeeInSchedule(htsAmount, "0.0.0", htsCollector))
+								.hasCustom(fixedHtsFeeInSchedule(htsAmount, token, htsCollector))
 								.hasCustom(fractionalFeeInSchedule(
 										numerator, denominator,
 										minimumToCollect, OptionalLong.of(maximumToCollect),

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenCreateSpecs.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenCreateSpecs.java
@@ -529,6 +529,7 @@ public class TokenCreateSpecs extends HapiApiSuite {
 								.treasury(tokenCollector)
 								.withCustom(fixedHbarFee(hbarAmount, hbarCollector))
 								.withCustom(fixedHtsFee(htsAmount, feeDenom, htsCollector))
+								.withCustom(fixedHtsFee(htsAmount, "0.0.0", htsCollector))
 								.withCustom(fractionalFee(
 										numerator, denominator,
 										minimumToCollect, OptionalLong.of(maximumToCollect),
@@ -537,6 +538,7 @@ public class TokenCreateSpecs extends HapiApiSuite {
 						getTokenInfo(token)
 								.hasCustom(fixedHbarFeeInSchedule(hbarAmount, hbarCollector))
 								.hasCustom(fixedHtsFeeInSchedule(htsAmount, feeDenom, htsCollector))
+								.hasCustom(fixedHtsFeeInSchedule(htsAmount, "0.0.0", htsCollector))
 								.hasCustom(fractionalFeeInSchedule(
 										numerator, denominator,
 										minimumToCollect, OptionalLong.of(maximumToCollect),

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenFeeScheduleUpdateSpecs.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenFeeScheduleUpdateSpecs.java
@@ -244,6 +244,7 @@ public class TokenFeeScheduleUpdateSpecs extends HapiApiSuite {
 						tokenFeeScheduleUpdate(token)
 								.withCustom(fixedHbarFee(newHbarAmount, newHbarCollector))
 								.withCustom(fixedHtsFee(newHtsAmount, newFeeDenom, newHtsCollector))
+								.withCustom(fixedHtsFee(newHtsAmount, "0.0.0", newTokenCollector))
 								.withCustom(fractionalFee(
 										newNumerator, newDenominator,
 										newMinimumToCollect, OptionalLong.of(newMaximumToCollect),
@@ -252,6 +253,7 @@ public class TokenFeeScheduleUpdateSpecs extends HapiApiSuite {
 						getTokenInfo(token)
 								.hasCustom(fixedHbarFeeInSchedule(newHbarAmount, newHbarCollector))
 								.hasCustom(fixedHtsFeeInSchedule(newHtsAmount, newFeeDenom, newHtsCollector))
+								.hasCustom(fixedHtsFeeInSchedule(newHtsAmount, "0.0.0", newTokenCollector))
 								.hasCustom(fractionalFeeInSchedule(
 										newNumerator, newDenominator,
 										newMinimumToCollect, OptionalLong.of(newMaximumToCollect),

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenFeeScheduleUpdateSpecs.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenFeeScheduleUpdateSpecs.java
@@ -253,7 +253,7 @@ public class TokenFeeScheduleUpdateSpecs extends HapiApiSuite {
 						getTokenInfo(token)
 								.hasCustom(fixedHbarFeeInSchedule(newHbarAmount, newHbarCollector))
 								.hasCustom(fixedHtsFeeInSchedule(newHtsAmount, newFeeDenom, newHtsCollector))
-								.hasCustom(fixedHtsFeeInSchedule(newHtsAmount, "0.0.0", newTokenCollector))
+								.hasCustom(fixedHtsFeeInSchedule(newHtsAmount, token, newTokenCollector))
 								.hasCustom(fractionalFeeInSchedule(
 										newNumerator, newDenominator,
 										newMinimumToCollect, OptionalLong.of(newMaximumToCollect),

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenTransactSpecs.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenTransactSpecs.java
@@ -936,8 +936,7 @@ public class TokenTransactSpecs extends HapiApiSuite {
 								.withCustom(fixedHtsFee(10L, A_TOKEN, TOKEN_TREASURY))
 								.withCustom(fixedHtsFee(1L, "0.0.0", feeCollector)),
 						tokenAssociate(FIRST_USER, A_TOKEN, B_TOKEN),
-						tokenAssociate(SECOND_USER, A_TOKEN, B_TOKEN),
-						tokenAssociate(feeCollector, B_TOKEN)
+						tokenAssociate(SECOND_USER, A_TOKEN, B_TOKEN)
 				).when(
 						cryptoTransfer(
 								moving(100, A_TOKEN).between(TOKEN_TREASURY, FIRST_USER)

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenTransactSpecs.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenTransactSpecs.java
@@ -920,20 +920,24 @@ public class TokenTransactSpecs extends HapiApiSuite {
 	}
 
 	public HapiApiSpec balancesChangeOnTokenTransferWithFixedHtsCustomFees() {
+		final var feeCollector = "feeCollector";
 		return defaultHapiSpec("BalancesChangeOnTokenTransferWithFixedHtsCustomFees")
 				.given(
 						cryptoCreate(FIRST_USER).balance(ONE_HUNDRED_HBARS),
 						cryptoCreate(SECOND_USER).balance(ONE_HUNDRED_HBARS),
 						cryptoCreate(TOKEN_TREASURY),
+						cryptoCreate(feeCollector),
 						tokenCreate(A_TOKEN)
 								.initialSupply(TOTAL_SUPPLY)
 								.treasury(TOKEN_TREASURY),
 						tokenCreate(B_TOKEN)
 								.initialSupply(TOTAL_SUPPLY)
 								.treasury(TOKEN_TREASURY)
-								.withCustom(fixedHtsFee(10L, A_TOKEN, TOKEN_TREASURY)),
+								.withCustom(fixedHtsFee(10L, A_TOKEN, TOKEN_TREASURY))
+								.withCustom(fixedHtsFee(1L, "0.0.0", feeCollector)),
 						tokenAssociate(FIRST_USER, A_TOKEN, B_TOKEN),
-						tokenAssociate(SECOND_USER, A_TOKEN, B_TOKEN)
+						tokenAssociate(SECOND_USER, A_TOKEN, B_TOKEN),
+						tokenAssociate(feeCollector, B_TOKEN)
 				).when(
 						cryptoTransfer(
 								moving(100, A_TOKEN).between(TOKEN_TREASURY, FIRST_USER)
@@ -948,10 +952,10 @@ public class TokenTransactSpecs extends HapiApiSuite {
 				).then(
 						getAccountBalance(TOKEN_TREASURY)
 								.hasTokenBalance(A_TOKEN, TOTAL_SUPPLY - 90)
-								.hasTokenBalance(B_TOKEN, TOTAL_SUPPLY - 100),
+								.hasTokenBalance(B_TOKEN, TOTAL_SUPPLY - 100 - 1),
 						getAccountBalance(FIRST_USER)
 								.hasTokenBalance(A_TOKEN, 90)
-								.hasTokenBalance(B_TOKEN, 50),
+								.hasTokenBalance(B_TOKEN, 50 - 1),
 						getAccountBalance(SECOND_USER)
 								.hasTokenBalance(B_TOKEN, 50)
 				);


### PR DESCRIPTION
**Related issue(s)**:

Close #1810

**Notes for reviewer**:
- Used sentinel tokenId with tokenNum == 0
- Added CustomFeeBuilder to simplify test codes and remove lots of duplications
- Simplify TokenFeeScheduleUpdateTransitionLogic and its unit tests