### PR TITLE
Custom fee exemptions

### DIFF
--- a/docs/fees/custom-fees-characterization.md
+++ b/docs/fees/custom-fees-characterization.md
@@ -24,6 +24,10 @@ where the `nestedHbarFeeToken` has a custom fee of 1 unit of the
 Fern, where the `nestedFractionalFeeToken` has a custom fee of 
 50 units of the `fractionalFeeToken`.
 
+:free:&nbsp; There are two exemptions from the charging policy. First, token 
+treasury accounts are never charged custom fees. Second, a fee collector
+account is not charged any fractional fees for which it is the collector.
+
 # Fixed fees
 
 ## Fees denominated in ℏ

--- a/hedera-node/src/main/java/com/hedera/services/grpc/marshalling/CustomFeeMeta.java
+++ b/hedera-node/src/main/java/com/hedera/services/grpc/marshalling/CustomFeeMeta.java
@@ -4,10 +4,14 @@ import com.hedera.services.state.submerkle.FcCustomFee;
 import com.hedera.services.store.models.Id;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
 public class CustomFeeMeta {
+	public static final CustomFeeMeta MISSING_META =
+			new CustomFeeMeta(Id.MISSING_ID, Id.MISSING_ID, Collections.emptyList());
+
 	private final Id tokenId;
 	private final Id treasuryId;
 	private final List<FcCustomFee> customFees;

--- a/hedera-node/src/main/java/com/hedera/services/grpc/marshalling/CustomFeeMeta.java
+++ b/hedera-node/src/main/java/com/hedera/services/grpc/marshalling/CustomFeeMeta.java
@@ -1,0 +1,62 @@
+package com.hedera.services.grpc.marshalling;
+
+import com.hedera.services.state.submerkle.FcCustomFee;
+import com.hedera.services.store.models.Id;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+
+import java.util.List;
+import java.util.Objects;
+
+public class CustomFeeMeta {
+	private final Id tokenId;
+	private final Id treasuryId;
+	private final List<FcCustomFee> customFees;
+
+	public CustomFeeMeta(Id tokenId, Id treasuryId, List<FcCustomFee> customFees) {
+		this.tokenId = tokenId;
+		this.treasuryId = treasuryId;
+		this.customFees = customFees;
+	}
+
+	public Id getTokenId() {
+		return tokenId;
+	}
+
+	public Id getTreasuryId() {
+		return treasuryId;
+	}
+
+	public List<FcCustomFee> getCustomFees() {
+		return customFees;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || CustomFeeMeta.class != o.getClass()) {
+			return false;
+		}
+
+		var that = (CustomFeeMeta) o;
+
+		return Objects.equals(this.tokenId, that.tokenId)
+				&& Objects.equals(this.treasuryId, that.treasuryId)
+				&& Objects.equals(this.customFees, that.customFees);
+	}
+
+	@Override
+	public String toString() {
+		return "CustomFeeMeta{" +
+				"tokenId=" + tokenId +
+				", treasuryId=" + treasuryId +
+				", customFees=" + customFees +
+				'}';
+	}
+
+	@Override
+	public int hashCode() {
+		return HashCodeBuilder.reflectionHashCode(this);
+	}
+}

--- a/hedera-node/src/main/java/com/hedera/services/grpc/marshalling/CustomSchedulesManager.java
+++ b/hedera-node/src/main/java/com/hedera/services/grpc/marshalling/CustomSchedulesManager.java
@@ -21,39 +21,36 @@ package com.hedera.services.grpc.marshalling;
  */
 
 import com.hedera.services.state.submerkle.EntityId;
-import com.hedera.services.state.submerkle.FcCustomFee;
-import com.hedera.services.store.models.Id;
 import com.hedera.services.txns.customfees.CustomFeeSchedules;
-import org.apache.commons.lang3.tuple.Pair;
 
 import java.util.ArrayList;
 import java.util.List;
 
 public class CustomSchedulesManager {
 	private final CustomFeeSchedules customFeeSchedules;
-	private final List<Pair<Id, List<FcCustomFee>>> allManagedSchedules = new ArrayList<>();
+	private final List<CustomFeeMeta> allManagedMeta = new ArrayList<>();
 
 	public CustomSchedulesManager(CustomFeeSchedules customFeeSchedules) {
 		this.customFeeSchedules = customFeeSchedules;
 	}
 
-	public List<FcCustomFee> managedSchedulesFor(EntityId token) {
-		List<FcCustomFee> extantSchedule = null;
-		if (!allManagedSchedules.isEmpty()) {
-			for (var schedule : allManagedSchedules) {
-				if (token.matches(schedule.getKey())) {
-					extantSchedule = schedule.getRight();
+	public CustomFeeMeta managedSchedulesFor(EntityId token) {
+		CustomFeeMeta extantMeta = null;
+		if (!allManagedMeta.isEmpty()) {
+			for (var meta : allManagedMeta) {
+				if (token.matches(meta.getTokenId())) {
+					extantMeta = meta;
 				}
 			}
 		}
-		if (extantSchedule == null) {
-			extantSchedule = customFeeSchedules.lookupScheduleFor(token);
-			allManagedSchedules.add(Pair.of(token.asId(), extantSchedule));
+		if (extantMeta == null) {
+			extantMeta = customFeeSchedules.lookupMetaFor(token);
+			allManagedMeta.add(extantMeta);
 		}
-		return extantSchedule;
+		return extantMeta;
 	}
 
-	public List<Pair<Id, List<FcCustomFee>>> schedulesUsed() {
-		return allManagedSchedules;
+	public List<CustomFeeMeta> metaUsed() {
+		return allManagedMeta;
 	}
 }

--- a/hedera-node/src/main/java/com/hedera/services/grpc/marshalling/CustomSchedulesManager.java
+++ b/hedera-node/src/main/java/com/hedera/services/grpc/marshalling/CustomSchedulesManager.java
@@ -20,7 +20,7 @@ package com.hedera.services.grpc.marshalling;
  * ‍
  */
 
-import com.hedera.services.state.submerkle.EntityId;
+import com.hedera.services.store.models.Id;
 import com.hedera.services.txns.customfees.CustomFeeSchedules;
 
 import java.util.ArrayList;
@@ -34,11 +34,11 @@ public class CustomSchedulesManager {
 		this.customFeeSchedules = customFeeSchedules;
 	}
 
-	public CustomFeeMeta managedSchedulesFor(EntityId token) {
+	public CustomFeeMeta managedSchedulesFor(Id token) {
 		CustomFeeMeta extantMeta = null;
 		if (!allManagedMeta.isEmpty()) {
 			for (var meta : allManagedMeta) {
-				if (token.matches(meta.getTokenId())) {
+				if (token.equals(meta.getTokenId())) {
 					extantMeta = meta;
 				}
 			}

--- a/hedera-node/src/main/java/com/hedera/services/grpc/marshalling/CustomSchedulesManager.java
+++ b/hedera-node/src/main/java/com/hedera/services/grpc/marshalling/CustomSchedulesManager.java
@@ -40,6 +40,7 @@ public class CustomSchedulesManager {
 			for (var meta : allManagedMeta) {
 				if (token.equals(meta.getTokenId())) {
 					extantMeta = meta;
+					break;
 				}
 			}
 		}

--- a/hedera-node/src/main/java/com/hedera/services/grpc/marshalling/FeeAssessor.java
+++ b/hedera-node/src/main/java/com/hedera/services/grpc/marshalling/FeeAssessor.java
@@ -56,11 +56,12 @@ public class FeeAssessor {
 		if (balanceChangeManager.getLevelNo() > props.getMaxNestedCustomFees()) {
 			return CUSTOM_FEE_CHARGING_EXCEEDED_MAX_RECURSION_DEPTH;
 		}
-		final var fees = customSchedulesManager.managedSchedulesFor(change.getToken().asEntityId());
+		final var feeMeta = customSchedulesManager.managedSchedulesFor(change.getToken().asEntityId());
+		final var fees = feeMeta.getCustomFees();
 		if (fees.isEmpty()) {
 			return OK;
 		}
-		var numFractionalFees = 0;
+		var hasFractionalFees = false;
 		final var payer = change.getAccount();
 		final var maxBalanceChanges = props.getMaxXferBalanceChanges();
 		for (var fee : fees) {
@@ -75,10 +76,10 @@ public class FeeAssessor {
 					return CUSTOM_FEE_CHARGING_EXCEEDED_MAX_ACCOUNT_AMOUNTS;
 				}
 			} else {
-				numFractionalFees++;
+				hasFractionalFees = true;
 			}
 		}
-		if (numFractionalFees > 0) {
+		if (hasFractionalFees) {
 			final var fractionalValidity =
 					fractionalFeeAssessor.assessAllFractional(change, fees, balanceChangeManager, accumulator);
 			if (fractionalValidity != OK) {

--- a/hedera-node/src/main/java/com/hedera/services/grpc/marshalling/FeeAssessor.java
+++ b/hedera-node/src/main/java/com/hedera/services/grpc/marshalling/FeeAssessor.java
@@ -56,13 +56,13 @@ public class FeeAssessor {
 		if (balanceChangeManager.getLevelNo() > props.getMaxNestedCustomFees()) {
 			return CUSTOM_FEE_CHARGING_EXCEEDED_MAX_RECURSION_DEPTH;
 		}
-		final var feeMeta = customSchedulesManager.managedSchedulesFor(change.getToken().asEntityId());
+		final var feeMeta = customSchedulesManager.managedSchedulesFor(change.getToken());
+		final var payer = change.getAccount();
 		final var fees = feeMeta.getCustomFees();
-		if (fees.isEmpty()) {
+		if (fees.isEmpty() || feeMeta.getTreasuryId().equals(payer)) {
 			return OK;
 		}
 		var hasFractionalFees = false;
-		final var payer = change.getAccount();
 		final var maxBalanceChanges = props.getMaxXferBalanceChanges();
 		for (var fee : fees) {
 			if (fee.getFeeType() == FIXED_FEE) {

--- a/hedera-node/src/main/java/com/hedera/services/grpc/marshalling/FeeAssessor.java
+++ b/hedera-node/src/main/java/com/hedera/services/grpc/marshalling/FeeAssessor.java
@@ -59,12 +59,17 @@ public class FeeAssessor {
 		final var feeMeta = customSchedulesManager.managedSchedulesFor(change.getToken());
 		final var payer = change.getAccount();
 		final var fees = feeMeta.getCustomFees();
+		/* Token treasuries are exempt from all custom fees */
 		if (fees.isEmpty() || feeMeta.getTreasuryId().equals(payer)) {
 			return OK;
 		}
 		var hasFractionalFees = false;
 		final var maxBalanceChanges = props.getMaxXferBalanceChanges();
 		for (var fee : fees) {
+			final var collector = fee.getFeeCollectorAsId();
+			if (payer.equals(collector)) {
+				continue;
+			}
 			if (fee.getFeeType() == FIXED_FEE) {
 				final var fixedSpec = fee.getFixedFeeSpec();
 				if (fixedSpec.getTokenDenomination() == null) {

--- a/hedera-node/src/main/java/com/hedera/services/grpc/marshalling/FractionalFeeAssessor.java
+++ b/hedera-node/src/main/java/com/hedera/services/grpc/marshalling/FractionalFeeAssessor.java
@@ -47,9 +47,15 @@ public class FractionalFeeAssessor {
 		}
 
 		var unitsLeft = initialUnits;
+		final var payer = change.getAccount();
 		final var denom = change.getToken();
 		for (var fee : feesWithFractional) {
 			if (fee.getFeeType() != FRACTIONAL_FEE) {
+				continue;
+			}
+
+			final var collector = fee.getFeeCollectorAsId();
+			if (payer.equals(collector)) {
 				continue;
 			}
 
@@ -71,7 +77,6 @@ public class FractionalFeeAssessor {
 				return CUSTOM_FEE_OUTSIDE_NUMERIC_RANGE;
 			}
 
-			final var collector = fee.getFeeCollectorAsId();
 			adjustedChange(collector, denom, assessedAmount, changeManager);
 			final var assessed = new FcAssessedCustomFee(collector.asEntityId(), denom.asEntityId(), assessedAmount);
 			accumulator.add(assessed);

--- a/hedera-node/src/main/java/com/hedera/services/grpc/marshalling/ImpliedTransfers.java
+++ b/hedera-node/src/main/java/com/hedera/services/grpc/marshalling/ImpliedTransfers.java
@@ -23,12 +23,9 @@ package com.hedera.services.grpc.marshalling;
 import com.google.common.base.MoreObjects;
 import com.hedera.services.ledger.BalanceChange;
 import com.hedera.services.state.submerkle.FcAssessedCustomFee;
-import com.hedera.services.state.submerkle.FcCustomFee;
-import com.hedera.services.store.models.Id;
 import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
-import org.apache.commons.lang3.tuple.Pair;
 
 import java.util.Collections;
 import java.util.List;
@@ -60,10 +57,10 @@ public class ImpliedTransfers {
 	public static ImpliedTransfers valid(
 			ImpliedTransfersMeta.ValidationProps validationProps,
 			List<BalanceChange> changes,
-			List<Pair<Id, List<FcCustomFee>>> tokenFeeSchedules,
+			List<CustomFeeMeta> customFeeMeta,
 			List<FcAssessedCustomFee> assessedCustomFees
 	) {
-		final var meta = new ImpliedTransfersMeta(validationProps, OK, tokenFeeSchedules);
+		final var meta = new ImpliedTransfersMeta(validationProps, OK, customFeeMeta);
 		return new ImpliedTransfers(meta, changes, assessedCustomFees);
 	}
 
@@ -77,10 +74,10 @@ public class ImpliedTransfers {
 
 	public static ImpliedTransfers invalid(
 			ImpliedTransfersMeta.ValidationProps validationProps,
-			List<Pair<Id, List<FcCustomFee>>> tokenFeeSchedulesUpToFailure,
+			List<CustomFeeMeta> customFeeMetaTilFailure,
 			ResponseCodeEnum code
 	) {
-		final var meta = new ImpliedTransfersMeta(validationProps, code, tokenFeeSchedulesUpToFailure);
+		final var meta = new ImpliedTransfersMeta(validationProps, code, customFeeMetaTilFailure);
 		return new ImpliedTransfers(meta, Collections.emptyList(), Collections.emptyList());
 	}
 
@@ -96,9 +93,6 @@ public class ImpliedTransfers {
 		return assessedCustomFees;
 	}
 
-	/* NOTE: The object methods below are only overridden to improve
-			readability of unit tests; this model object is not used in hash-based
-			collections, so the performance of these methods doesn't matter. */
 	@Override
 	public boolean equals(Object obj) {
 		return EqualsBuilder.reflectionEquals(this, obj);
@@ -114,7 +108,7 @@ public class ImpliedTransfers {
 		return MoreObjects.toStringHelper(ImpliedTransfers.class)
 				.add("meta", meta)
 				.add("changes", changes)
-				.add("tokenFeeSchedules", meta.getTokenFeeSchedules())
+				.add("tokenFeeSchedules", meta.getCustomFeeMeta())
 				.add("assessedCustomFees", assessedCustomFees)
 				.toString();
 	}

--- a/hedera-node/src/main/java/com/hedera/services/grpc/marshalling/ImpliedTransfersMarshal.java
+++ b/hedera-node/src/main/java/com/hedera/services/grpc/marshalling/ImpliedTransfersMarshal.java
@@ -92,12 +92,12 @@ public class ImpliedTransfersMarshal {
 		while (change != null) {
 			final var status = feeAssessor.assess(change, schedulesManager, changeManager, fees, props);
 			if (status != OK) {
-				return ImpliedTransfers.invalid(props, schedulesManager.schedulesUsed(), status);
+				return ImpliedTransfers.invalid(props, schedulesManager.metaUsed(), status);
 			}
 			change = changeManager.nextAssessableChange();
 		}
 
-		return ImpliedTransfers.valid(props, changes, schedulesManager.schedulesUsed(), fees);
+		return ImpliedTransfers.valid(props, changes, schedulesManager.metaUsed(), fees);
 	}
 
 	private void appendToken(CryptoTransferTransactionBody op, List<BalanceChange> changes) {

--- a/hedera-node/src/main/java/com/hedera/services/grpc/marshalling/ImpliedTransfersMeta.java
+++ b/hedera-node/src/main/java/com/hedera/services/grpc/marshalling/ImpliedTransfersMeta.java
@@ -75,7 +75,7 @@ public class ImpliedTransfersMeta {
 			return false;
 		}
 		for (var meta : customFeeMeta) {
-			final var tokenId = meta.getTokenId().asEntityId();
+			final var tokenId = meta.getTokenId();
 			var newCustomMeta = customFeeSchedules.lookupMetaFor(tokenId);
 			if (!meta.equals(newCustomMeta)) {
 				return false;

--- a/hedera-node/src/main/java/com/hedera/services/txns/customfees/CustomFeeSchedules.java
+++ b/hedera-node/src/main/java/com/hedera/services/txns/customfees/CustomFeeSchedules.java
@@ -21,14 +21,12 @@ package com.hedera.services.txns.customfees;
  * ‍
  */
 
-import com.hedera.services.state.submerkle.FcCustomFee;
+import com.hedera.services.grpc.marshalling.CustomFeeMeta;
 import com.hedera.services.state.submerkle.EntityId;
-
-import java.util.List;
 
 /**
  * Interface to look up custom fee schedules for an entity
  */
 public interface CustomFeeSchedules {
-	List<FcCustomFee> lookupScheduleFor(EntityId token);
+	CustomFeeMeta lookupMetaFor(EntityId token);
 }

--- a/hedera-node/src/main/java/com/hedera/services/txns/customfees/CustomFeeSchedules.java
+++ b/hedera-node/src/main/java/com/hedera/services/txns/customfees/CustomFeeSchedules.java
@@ -22,11 +22,11 @@ package com.hedera.services.txns.customfees;
  */
 
 import com.hedera.services.grpc.marshalling.CustomFeeMeta;
-import com.hedera.services.state.submerkle.EntityId;
+import com.hedera.services.store.models.Id;
 
 /**
  * Interface to look up custom fee schedules for an entity
  */
 public interface CustomFeeSchedules {
-	CustomFeeMeta lookupMetaFor(EntityId token);
+	CustomFeeMeta lookupMetaFor(Id token);
 }

--- a/hedera-node/src/main/java/com/hedera/services/txns/customfees/FcmCustomFeeSchedules.java
+++ b/hedera-node/src/main/java/com/hedera/services/txns/customfees/FcmCustomFeeSchedules.java
@@ -20,16 +20,14 @@ package com.hedera.services.txns.customfees;
  * ‍
  */
 
+import com.hedera.services.grpc.marshalling.CustomFeeMeta;
 import com.hedera.services.state.merkle.MerkleEntityId;
 import com.hedera.services.state.merkle.MerkleToken;
-import com.hedera.services.state.submerkle.FcCustomFee;
 import com.hedera.services.state.submerkle.EntityId;
 import com.swirlds.fcmap.FCMap;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 
-import java.util.Collections;
-import java.util.List;
 import java.util.function.Supplier;
 
 /**
@@ -43,22 +41,19 @@ public class FcmCustomFeeSchedules implements CustomFeeSchedules {
 	}
 
 	@Override
-	public List<FcCustomFee> lookupScheduleFor(EntityId tokenId) {
+	public CustomFeeMeta lookupMetaFor(EntityId tokenId) {
 		final var currentTokens = tokens.get();
 		if (!currentTokens.containsKey(tokenId.asMerkle())) {
-			return Collections.emptyList();
+			return CustomFeeMeta.MISSING_META;
 		}
 		final var merkleToken = currentTokens.get(tokenId.asMerkle());
-		return merkleToken.customFeeSchedule();
+		return new CustomFeeMeta(tokenId.asId(), merkleToken.treasury().asId(), merkleToken.customFeeSchedule());
 	}
 
 	public Supplier<FCMap<MerkleEntityId, MerkleToken>> getTokens() {
 		return tokens;
 	}
 
-	/* NOTE: The object methods below are only overridden to improve
-				readability of unit tests; this model object is not used in hash-based
-				collections, so the performance of these methods doesn't matter. */
 	@Override
 	public boolean equals(Object obj) {
 		return EqualsBuilder.reflectionEquals(this, obj);

--- a/hedera-node/src/main/java/com/hedera/services/txns/customfees/FcmCustomFeeSchedules.java
+++ b/hedera-node/src/main/java/com/hedera/services/txns/customfees/FcmCustomFeeSchedules.java
@@ -23,7 +23,7 @@ package com.hedera.services.txns.customfees;
 import com.hedera.services.grpc.marshalling.CustomFeeMeta;
 import com.hedera.services.state.merkle.MerkleEntityId;
 import com.hedera.services.state.merkle.MerkleToken;
-import com.hedera.services.state.submerkle.EntityId;
+import com.hedera.services.store.models.Id;
 import com.swirlds.fcmap.FCMap;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
@@ -41,13 +41,13 @@ public class FcmCustomFeeSchedules implements CustomFeeSchedules {
 	}
 
 	@Override
-	public CustomFeeMeta lookupMetaFor(EntityId tokenId) {
+	public CustomFeeMeta lookupMetaFor(Id tokenId) {
 		final var currentTokens = tokens.get();
 		if (!currentTokens.containsKey(tokenId.asMerkle())) {
 			return CustomFeeMeta.MISSING_META;
 		}
 		final var merkleToken = currentTokens.get(tokenId.asMerkle());
-		return new CustomFeeMeta(tokenId.asId(), merkleToken.treasury().asId(), merkleToken.customFeeSchedule());
+		return new CustomFeeMeta(tokenId, merkleToken.treasury().asId(), merkleToken.customFeeSchedule());
 	}
 
 	public Supplier<FCMap<MerkleEntityId, MerkleToken>> getTokens() {

--- a/hedera-node/src/test/java/com/hedera/services/grpc/marshalling/CustomFeeMetaTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/grpc/marshalling/CustomFeeMetaTest.java
@@ -1,0 +1,66 @@
+package com.hedera.services.grpc.marshalling;
+
+import com.hedera.services.state.submerkle.FcCustomFee;
+import com.hedera.services.store.models.Id;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+class CustomFeeMetaTest {
+	@Test
+	void objectContractWorks() {
+		// setup:
+		final var subject = new CustomFeeMeta(aToken, aTreasury, List.of(hbarFee));
+		final var differentToken = new CustomFeeMeta(bToken, aTreasury, List.of(hbarFee));
+		final var differentTreasury = new CustomFeeMeta(aToken, bTreasury, List.of(hbarFee));
+		final var differentFees = new CustomFeeMeta(aToken, aTreasury, List.of(htsFee));
+		final var sameButDifferent = new CustomFeeMeta(aToken, aTreasury, List.of(hbarFee));
+		final var identical = subject;
+
+		// expect:
+		assertNotEquals(subject, null);
+		assertNotEquals(subject, new Object());
+		assertNotEquals(subject, differentFees);
+		assertNotEquals(subject, differentToken);
+		assertNotEquals(subject, differentTreasury);
+		assertNotEquals(subject.hashCode(), differentFees.hashCode());
+		assertNotEquals(subject.hashCode(), differentToken.hashCode());
+		assertNotEquals(subject.hashCode(), differentTreasury.hashCode());
+		// and:
+		assertEquals(subject, identical);
+		assertEquals(subject, sameButDifferent);
+		assertEquals(subject.hashCode(), sameButDifferent.hashCode());
+	}
+
+	@Test
+	void toStringWorks() {
+		final var subject = new CustomFeeMeta(aToken, aTreasury, List.of(hbarFee, htsFee));
+
+		// given:
+		final var desired = "CustomFeeMeta{tokenId=Id{shard=1, realm=1, num=1}, treasuryId=Id{shard=9, realm=9, num=9}, " +
+				"customFees=[FcCustomFee{feeType=FIXED_FEE, fixedFee=FixedFeeSpec{unitsToCollect=100000, " +
+				"tokenDenomination=ℏ}, feeCollector=EntityId{shard=2, realm=3, num=4}}, " +
+				"FcCustomFee{feeType=FIXED_FEE, fixedFee=FixedFeeSpec{unitsToCollect=10, tokenDenomination=6.6.6}, " +
+				"feeCollector=EntityId{shard=3, realm=4, num=5}}]}";
+
+		// expect:
+		assertEquals(desired, subject.toString());
+	}
+
+	private final long amountOfHbarFee = 100_000L;
+	private final long amountOfHtsFee = 10L;
+	private final Id aToken = new Id(1, 1, 1);
+	private final Id bToken = new Id(11, 11, 11);
+	private final Id aTreasury = new Id(9, 9, 9);
+	private final Id bTreasury = new Id(99, 99, 99);
+	private final Id feeDenom = new Id(6, 6, 6);
+	private final Id hbarFeeCollector = new Id(2, 3, 4);
+	private final Id htsFeeCollector = new Id(3, 4, 5);
+	private final FcCustomFee hbarFee = FcCustomFee.fixedFee(
+			amountOfHbarFee, null, hbarFeeCollector.asEntityId());
+	private final FcCustomFee htsFee =
+			FcCustomFee.fixedFee(amountOfHtsFee, feeDenom.asEntityId(), htsFeeCollector.asEntityId());
+}

--- a/hedera-node/src/test/java/com/hedera/services/grpc/marshalling/CustomSchedulesManagerTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/grpc/marshalling/CustomSchedulesManagerTest.java
@@ -51,10 +51,10 @@ class CustomSchedulesManagerTest {
 
 	@Test
 	void usesDelegateForMissing() {
-		given(customFeeSchedules.lookupMetaFor(a.asEntityId())).willReturn(aMeta);
+		given(customFeeSchedules.lookupMetaFor(a)).willReturn(aMeta);
 
 		// when:
-		final var ans = subject.managedSchedulesFor(a.asEntityId());
+		final var ans = subject.managedSchedulesFor(a);
 
 		// then:
 		assertSame(aMeta, ans);
@@ -62,13 +62,13 @@ class CustomSchedulesManagerTest {
 
 	@Test
 	void reusesExtantScheduleIfPresent() {
-		given(customFeeSchedules.lookupMetaFor(a.asEntityId()))
+		given(customFeeSchedules.lookupMetaFor(a))
 				.willReturn(aMeta)
 				.willThrow(AssertionError.class);
 
 		// when:
-		final var firstAns = subject.managedSchedulesFor(a.asEntityId());
-		final var secondAns = subject.managedSchedulesFor(a.asEntityId());
+		final var firstAns = subject.managedSchedulesFor(a);
+		final var secondAns = subject.managedSchedulesFor(a);
 
 		// then:
 		assertSame(firstAns, secondAns);
@@ -76,12 +76,12 @@ class CustomSchedulesManagerTest {
 
 	@Test
 	void enumeratesAllManagedSchedules() {
-		given(customFeeSchedules.lookupMetaFor(a.asEntityId())).willReturn(aMeta);
-		given(customFeeSchedules.lookupMetaFor(b.asEntityId())).willReturn(bMeta);
+		given(customFeeSchedules.lookupMetaFor(a)).willReturn(aMeta);
+		given(customFeeSchedules.lookupMetaFor(b)).willReturn(bMeta);
 
 		// when:
-		subject.managedSchedulesFor(a.asEntityId());
-		subject.managedSchedulesFor(b.asEntityId());
+		subject.managedSchedulesFor(a);
+		subject.managedSchedulesFor(b);
 		// and:
 		final var all = subject.metaUsed();
 

--- a/hedera-node/src/test/java/com/hedera/services/grpc/marshalling/CustomSchedulesManagerTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/grpc/marshalling/CustomSchedulesManagerTest.java
@@ -51,19 +51,19 @@ class CustomSchedulesManagerTest {
 
 	@Test
 	void usesDelegateForMissing() {
-		given(customFeeSchedules.lookupScheduleFor(a.asEntityId())).willReturn(aSchedule);
+		given(customFeeSchedules.lookupMetaFor(a.asEntityId())).willReturn(aMeta);
 
 		// when:
 		final var ans = subject.managedSchedulesFor(a.asEntityId());
 
 		// then:
-		assertSame(aSchedule, ans);
+		assertSame(aMeta, ans);
 	}
 
 	@Test
 	void reusesExtantScheduleIfPresent() {
-		given(customFeeSchedules.lookupScheduleFor(a.asEntityId()))
-				.willReturn(aSchedule)
+		given(customFeeSchedules.lookupMetaFor(a.asEntityId()))
+				.willReturn(aMeta)
 				.willThrow(AssertionError.class);
 
 		// when:
@@ -76,25 +76,23 @@ class CustomSchedulesManagerTest {
 
 	@Test
 	void enumeratesAllManagedSchedules() {
-		given(customFeeSchedules.lookupScheduleFor(a.asEntityId())).willReturn(aSchedule);
-		given(customFeeSchedules.lookupScheduleFor(b.asEntityId())).willReturn(bSchedule);
+		given(customFeeSchedules.lookupMetaFor(a.asEntityId())).willReturn(aMeta);
+		given(customFeeSchedules.lookupMetaFor(b.asEntityId())).willReturn(bMeta);
 
 		// when:
 		subject.managedSchedulesFor(a.asEntityId());
 		subject.managedSchedulesFor(b.asEntityId());
 		// and:
-		final var all = subject.schedulesUsed();
+		final var all = subject.metaUsed();
 
 		// then:
 		assertEquals(2, all.size());
 		// and:
 		final var first = all.get(0);
-		assertEquals(a, first.getLeft());
-		assertSame(aSchedule, first.getRight());
+		assertSame(aMeta, first);
 		// and:
 		final var second = all.get(1);
-		assertEquals(b, second.getLeft());
-		assertSame(bSchedule, second.getRight());
+		assertEquals(bMeta, second);
 	}
 
 	private final long amountOfHbarFee = 100_000L;
@@ -107,7 +105,11 @@ class CustomSchedulesManagerTest {
 	private final EntityId htsFeeCollector = htsFeeCollectorId.asEntityId();
 	private final FcCustomFee htsFee = FcCustomFee.fixedFee(amountOfHtsFee, feeDenom, htsFeeCollector);
 	final Id a = new Id(1, 2, 3);
+	final Id aTreasury = new Id(2, 2, 3);
 	final Id b = new Id(2, 3, 4);
+	final Id bTreasury = new Id(3, 3, 4);
 	final List<FcCustomFee> aSchedule = List.of(hbarFee);
 	final List<FcCustomFee> bSchedule = List.of(htsFee);
+	final CustomFeeMeta aMeta = new CustomFeeMeta(a, aTreasury, aSchedule);
+	final CustomFeeMeta bMeta = new CustomFeeMeta(b, bTreasury, bSchedule);
 }

--- a/hedera-node/src/test/java/com/hedera/services/grpc/marshalling/FeeAssessorTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/grpc/marshalling/FeeAssessorTest.java
@@ -216,7 +216,8 @@ class FeeAssessorTest {
 	}
 
 	private void givenFees(EntityId token, List<FcCustomFee> customFees) {
-		given(customSchedulesManager.managedSchedulesFor(token)).willReturn(customFees);
+		final var meta = new CustomFeeMeta(token.asId(), treasury, customFees);
+		given(customSchedulesManager.managedSchedulesFor(token)).willReturn(meta);
 	}
 
 	private final long amountOfFungibleDebit = 1_000L;
@@ -227,6 +228,7 @@ class FeeAssessorTest {
 	private final long numerator = 1L;
 	private final long denominator = 100L;
 	private final Id payer = new Id(0, 1, 2);
+	private final Id treasury = new Id(6, 6, 6);
 	private final Id fungibleTokenId = new Id(1, 2, 3);
 	private final EntityId feeDenom = new EntityId(6, 6, 6);
 	private final EntityId hbarFeeCollector = new EntityId(2, 3, 4);

--- a/hedera-node/src/test/java/com/hedera/services/grpc/marshalling/FractionalFeeAssessorTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/grpc/marshalling/FractionalFeeAssessorTest.java
@@ -53,7 +53,7 @@ class FractionalFeeAssessorTest {
 	@Test
 	void appliesFeesAsExpected() {
 		// setup:
-		final var fees = List.of(firstFractionalFee, secondFractionalFee);
+		final var fees = List.of(firstFractionalFee, secondFractionalFee, exemptFractionalFee);
 		final var firstCollectorChange = BalanceChange.tokenAdjust(
 				firstFractionalFeeCollector.asId(), tokenWithFractionalFee, 0L);
 		final var secondCollectorChange = BalanceChange.tokenAdjust(
@@ -289,6 +289,12 @@ class FractionalFeeAssessorTest {
 			secondMinAmountOfFractionalFee,
 			secondMaxAmountOfFractionalFee,
 			secondFractionalFeeCollector);
+	private final FcCustomFee exemptFractionalFee = FcCustomFee.fractionalFee(
+			firstNumerator,
+			secondDenominator,
+			firstMinAmountOfFractionalFee,
+			secondMaxAmountOfFractionalFee,
+			payer.asEntityId());
 	private final FcCustomFee nonsenseFee = FcCustomFee.fractionalFee(
 			nonsenseNumerator,
 			nonsenseDenominator,

--- a/hedera-node/src/test/java/com/hedera/services/grpc/marshalling/ImpliedTransfersTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/grpc/marshalling/ImpliedTransfersTest.java
@@ -77,6 +77,7 @@ class ImpliedTransfersTest {
 		given(dynamicProperties.maxNftTransfersLen()).willReturn(maxExplicitOwnershipChanges);
 		given(dynamicProperties.maxXferBalanceChanges()).willReturn(maxBalanceChanges);
 		given(dynamicProperties.maxCustomFeeDepth()).willReturn(maxFeeNesting);
+		given(customFeeSchedules.lookupMetaFor(any())).willReturn(entityCustomFees.get(0));
 
 		// expect:
 		assertTrue(meta.wasDerivedFrom(dynamicProperties, customFeeSchedules));

--- a/hedera-node/src/test/java/com/hedera/services/grpc/marshalling/ImpliedTransfersTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/grpc/marshalling/ImpliedTransfersTest.java
@@ -6,7 +6,6 @@ import com.hedera.services.state.submerkle.FcAssessedCustomFee;
 import com.hedera.services.state.submerkle.FcCustomFee;
 import com.hedera.services.store.models.Id;
 import com.hedera.services.txns.customfees.CustomFeeSchedules;
-import org.apache.commons.lang3.tuple.Pair;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -52,10 +51,12 @@ class ImpliedTransfersTest {
 				"tokenFeeSchedules=[], assessedCustomFees=[]}";
 		final var twoRepr = "ImpliedTransfers{meta=ImpliedTransfersMeta{code=OK, maxExplicitHbarAdjusts=5, " +
 				"maxExplicitTokenAdjusts=50, maxExplicitOwnershipChanges=12, maxNestedCustomFees=1, " +
-				"maxXferBalanceChanges=20, tokenFeeSchedules=[(Id{shard=0, realm=0, num=123},[])]}, " +
+				"maxXferBalanceChanges=20, tokenFeeSchedules=[CustomFeeMeta{tokenId=Id{shard=0, realm=0, num=123}, " +
+				"treasuryId=Id{shard=2, realm=3, num=4}, customFees=[]}]}, " +
 				"changes=[BalanceChange{token=Id{shard=1, realm=2, num=3}, " +
-				"account=Id{shard=4, realm=5, num=6}, units=7}], tokenFeeSchedules=[(Id{shard=0, realm=0, num=123},[])], " +
-				"assessedCustomFees=[FcAssessedCustomFee{token=EntityId{shard=0, realm=0, num=123}, " +
+				"account=Id{shard=4, realm=5, num=6}, units=7}], tokenFeeSchedules=[" +
+				"CustomFeeMeta{tokenId=Id{shard=0, realm=0, num=123}, treasuryId=Id{shard=2, realm=3, num=4}, " +
+				"customFees=[]}], assessedCustomFees=[FcAssessedCustomFee{token=EntityId{shard=0, realm=0, num=123}, " +
 				"account=EntityId{shard=0, realm=0, num=124}, units=123}]}";
 
 		// expect:
@@ -80,8 +81,10 @@ class ImpliedTransfersTest {
 		// expect:
 		assertTrue(meta.wasDerivedFrom(dynamicProperties, customFeeSchedules));
 
-		//modify customFeeChanges to see test fails
-		given(newCustomFeeSchedules.lookupScheduleFor(any())).willReturn(newCustomFeeChanges.get(0).getValue());
+		// and:
+		given(newCustomFeeSchedules.lookupMetaFor(any())).willReturn(newCustomFeeMeta);
+
+		// expect:
 		assertFalse(meta.wasDerivedFrom(dynamicProperties, newCustomFeeSchedules));
 
 		// and:
@@ -132,10 +135,14 @@ class ImpliedTransfersTest {
 			maxBalanceChanges);
 	private final EntityId customFeeToken = new EntityId(0, 0, 123);
 	private final EntityId customFeeCollector = new EntityId(0, 0, 124);
-	final List<Pair<Id, List<FcCustomFee>>> entityCustomFees = List.of(
-			Pair.of(customFeeToken.asId(), new ArrayList<>()));
-	final List<Pair<EntityId, List<FcCustomFee>>> newCustomFeeChanges = List.of(
-			Pair.of(customFeeToken, List.of(FcCustomFee.fixedFee(10L, customFeeToken, customFeeCollector))));
+	private final Id someId = new Id(1, 2, 3);
+	private final Id someTreasuryId = new Id(2, 3, 4);
+	private final List<CustomFeeMeta> entityCustomFees = List.of(
+			new CustomFeeMeta(customFeeToken.asId(), someTreasuryId, new ArrayList<>()));
+	private final CustomFeeMeta newCustomFeeMeta = new CustomFeeMeta(
+			someId,
+			someTreasuryId,
+			List.of(FcCustomFee.fixedFee(10L, customFeeToken, customFeeCollector)));
 	private final List<FcAssessedCustomFee> assessedCustomFees = List.of(
 			new FcAssessedCustomFee(customFeeCollector, customFeeToken, 123L));
 }

--- a/hedera-node/src/test/java/com/hedera/services/txns/crypto/CryptoTransferTransitionLogicTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/txns/crypto/CryptoTransferTransitionLogicTest.java
@@ -22,9 +22,10 @@ package com.hedera.services.txns.crypto;
 
 import com.hedera.services.context.TransactionContext;
 import com.hedera.services.context.properties.GlobalDynamicProperties;
+import com.hedera.services.grpc.marshalling.CustomFeeMeta;
 import com.hedera.services.grpc.marshalling.ImpliedTransfers;
-import com.hedera.services.grpc.marshalling.ImpliedTransfersMeta;
 import com.hedera.services.grpc.marshalling.ImpliedTransfersMarshal;
+import com.hedera.services.grpc.marshalling.ImpliedTransfersMeta;
 import com.hedera.services.ledger.HederaLedger;
 import com.hedera.services.ledger.PureTransferSemanticChecks;
 import com.hedera.services.state.submerkle.FcAssessedCustomFee;
@@ -39,7 +40,6 @@ import com.hederahashgraph.api.proto.java.TokenTransferList;
 import com.hederahashgraph.api.proto.java.TransactionBody;
 import com.hederahashgraph.api.proto.java.TransactionID;
 import com.hederahashgraph.api.proto.java.TransferList;
-import org.apache.commons.lang3.tuple.Pair;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -165,12 +165,13 @@ class CryptoTransferTransitionLogicTest {
 		final var a = Id.fromGrpcAccount(asAccount("1.2.3"));
 		final var b = Id.fromGrpcAccount(asAccount("2.3.4"));
 		final var c = Id.fromGrpcToken(asToken("4.5.6"));
+		final var d = Id.fromGrpcToken(asToken("5.6.7"));
 
 		// and :
 		final var customFeesBalanceChange = List.of(
 				new FcAssessedCustomFee(a.asEntityId(), 10L));
 		final var customFee = List.of(FcCustomFee.fixedFee(20L, null, a.asEntityId()));
-		final List<Pair<Id, List<FcCustomFee>>> customFees = List.of(Pair.of(c, customFee));
+		final List<CustomFeeMeta> customFees = List.of(new CustomFeeMeta(c, d, customFee));
 		final var impliedTransfers = ImpliedTransfers.valid(
 				validationProps, List.of(
 						hbarChange(a.asGrpcAccount(), +100),

--- a/hedera-node/src/test/java/com/hedera/services/txns/customfees/FcmCustomFeeSchedulesTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/txns/customfees/FcmCustomFeeSchedulesTest.java
@@ -69,9 +69,9 @@ class FcmCustomFeeSchedulesTest {
 	@Test
 	void validateLookUpScheduleFor() {
 		// then:
-		final var tokenAFees = subject.lookupMetaFor(tokenA);
-		final var tokenBFees = subject.lookupMetaFor(tokenB);
-		final var missingTokenFees = subject.lookupMetaFor(missingToken);
+		final var tokenAFees = subject.lookupMetaFor(tokenA.asId());
+		final var tokenBFees = subject.lookupMetaFor(tokenB.asId());
+		final var missingTokenFees = subject.lookupMetaFor(missingToken.asId());
 
 		// expect:
 		assertEquals(aToken.customFeeSchedule(), tokenAFees.getCustomFees());

--- a/hedera-node/src/test/java/com/hedera/services/txns/span/SpanMapManagerTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/txns/span/SpanMapManagerTest.java
@@ -21,9 +21,10 @@ package com.hedera.services.txns.span;
  */
 
 import com.hedera.services.context.properties.GlobalDynamicProperties;
+import com.hedera.services.grpc.marshalling.CustomFeeMeta;
 import com.hedera.services.grpc.marshalling.ImpliedTransfers;
-import com.hedera.services.grpc.marshalling.ImpliedTransfersMeta;
 import com.hedera.services.grpc.marshalling.ImpliedTransfersMarshal;
+import com.hedera.services.grpc.marshalling.ImpliedTransfersMeta;
 import com.hedera.services.state.submerkle.FcAssessedCustomFee;
 import com.hedera.services.state.submerkle.FcCustomFee;
 import com.hedera.services.store.models.Id;
@@ -31,7 +32,6 @@ import com.hedera.services.txns.customfees.CustomFeeSchedules;
 import com.hedera.services.usage.crypto.CryptoTransferMeta;
 import com.hedera.services.utils.TxnAccessor;
 import com.hederahashgraph.api.proto.java.TransactionBody;
-import org.apache.commons.lang3.tuple.Pair;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -69,14 +69,16 @@ class SpanMapManagerTest {
 	private final ImpliedTransfers someOtherImpliedXfers = ImpliedTransfers.invalid(
 			otherValidationProps, ACCOUNT_REPEATED_IN_ACCOUNT_AMOUNTS);
 
+	private final Id treasury = new Id(0 , 0, 2);
 	private final Id customFeeToken = new Id(0, 0, 123);
 	private final Id customFeeCollector = new Id(0, 0, 124);
-	final List<Pair<Id, List<FcCustomFee>>> entityCustomFees = List.of(
-			Pair.of(customFeeToken, new ArrayList<>()));
+	final List<CustomFeeMeta> entityCustomFees = List.of(
+			new CustomFeeMeta(customFeeToken, treasury, new ArrayList<>()));
 
-	final List<Pair<Id, List<FcCustomFee>>> newCustomFeeChanges = List.of(
-			Pair.of(customFeeToken, List.of(FcCustomFee.fixedFee(10L, customFeeToken.asEntityId(),
-					customFeeCollector.asEntityId()))));
+	final List<CustomFeeMeta> newCustomFeeChanges = List.of(
+			new CustomFeeMeta(
+					customFeeToken, treasury, List.of(FcCustomFee.fixedFee(
+							10L, customFeeToken.asEntityId(), customFeeCollector.asEntityId()))));
 	private final List<FcAssessedCustomFee> assessedCustomFees = List.of(
 			new FcAssessedCustomFee(customFeeCollector.asEntityId(), customFeeToken.asEntityId(), 123L),
 			new FcAssessedCustomFee(customFeeCollector.asEntityId(), 123L)

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenTransactSpecs.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenTransactSpecs.java
@@ -121,6 +121,8 @@ public class TokenTransactSpecs extends HapiApiSuite {
 						simpleHtsFeeCaseStudy(),
 						nestedHbarCaseStudy(),
 						nestedFractionalCaseStudy(),
+						treasuriesAreExemptFromAllFees(),
+						collectorsAreExemptFromTheirOwnFeesButNotOthers(),
 				}
 		);
 	}
@@ -1069,6 +1071,129 @@ public class TokenTransactSpecs extends HapiApiSuite {
 						getTxnRecord(txnFromTreasury).logged(),
 						getTxnRecord(txnFromEdgar).logged()
 						/* TODO - validate balances */
+				);
+	}
+
+	public HapiApiSpec treasuriesAreExemptFromAllFees() {
+		final var edgar = "Edgar";
+		final var feeToken = "FeeToken";
+		final var topLevelToken = "TopLevelToken";
+		final var treasuryForTopLevel = "TokenTreasury";
+		final var collectorForTopLevel = "FeeCollector";
+		final var nonTreasury = "nonTreasury";
+
+		final var txnFromTreasury = "txnFromTreasury";
+		final var txnFromNonTreasury = "txnFromNonTreasury";
+
+		return defaultHapiSpec("TreasuriesAreExemptFromAllFees")
+				.given(
+						cryptoCreate(edgar),
+						cryptoCreate(nonTreasury),
+						cryptoCreate(TOKEN_TREASURY),
+						cryptoCreate(treasuryForTopLevel),
+						cryptoCreate(collectorForTopLevel).balance(0L),
+						tokenCreate(feeToken)
+								.initialSupply(Long.MAX_VALUE)
+								.treasury(TOKEN_TREASURY),
+						tokenAssociate(collectorForTopLevel, feeToken),
+						tokenAssociate(treasuryForTopLevel, feeToken),
+						tokenCreate(topLevelToken)
+								.initialSupply(Long.MAX_VALUE)
+								.treasury(treasuryForTopLevel)
+								.withCustom(fixedHbarFee(ONE_HBAR, collectorForTopLevel))
+								.withCustom(fixedHtsFee(50, feeToken, collectorForTopLevel))
+								.withCustom(fractionalFee(1, 10, 5, OptionalLong.of(50), collectorForTopLevel))
+								.signedBy(DEFAULT_PAYER, treasuryForTopLevel, collectorForTopLevel),
+						tokenAssociate(nonTreasury, List.of(topLevelToken, feeToken)),
+						tokenAssociate(edgar, topLevelToken),
+						cryptoTransfer(
+								moving(2_000L, feeToken)
+										.distributing(TOKEN_TREASURY, treasuryForTopLevel, nonTreasury),
+								moving(1_000L, topLevelToken)
+										.between(treasuryForTopLevel, nonTreasury)
+						).payingWith(TOKEN_TREASURY).fee(ONE_HBAR)
+				).when(
+						cryptoTransfer(
+								moving(1_000L, topLevelToken)
+										.between(treasuryForTopLevel, edgar)
+						)
+								.payingWith(treasuryForTopLevel)
+								.fee(ONE_HBAR)
+								.via(txnFromTreasury)
+				).then(
+						getTxnRecord(txnFromTreasury).logged(),
+						getAccountBalance(collectorForTopLevel)
+								.logged()
+								.hasTinyBars(0L)
+								.hasTokenBalance(feeToken, 0L)
+								.hasTokenBalance(topLevelToken, 0L),
+						/* Now we perform the same transfer from a non-treasury and see all three fees charged */
+						cryptoTransfer(
+								moving(1_000L, topLevelToken)
+										.between(nonTreasury, edgar)
+						)
+								.payingWith(nonTreasury)
+								.fee(ONE_HBAR)
+								.via(txnFromNonTreasury),
+						getTxnRecord(txnFromNonTreasury).logged(),
+						getAccountBalance(collectorForTopLevel)
+								.logged()
+								.hasTinyBars(ONE_HBAR)
+								.hasTokenBalance(feeToken, 50L)
+								.hasTokenBalance(topLevelToken, 50L),
+						getAccountBalance(edgar)
+								.hasTokenBalance(topLevelToken, 1950L)
+				);
+	}
+
+	public HapiApiSpec collectorsAreExemptFromTheirOwnFeesButNotOthers() {
+		final var edgar = "Edgar";
+		final var topLevelToken = "TopLevelToken";
+		final var treasuryForTopLevel = "TokenTreasury";
+		final var firstCollectorForTopLevel = "AFeeCollector";
+		final var secondCollectorForTopLevel = "BFeeCollector";
+
+		final var txnFromCollector = "txnFromCollector";
+
+		return defaultHapiSpec("CollectorsAreExemptFromTheirOwnFeesButNotOthers")
+				.given(
+						cryptoCreate(edgar),
+						cryptoCreate(TOKEN_TREASURY),
+						cryptoCreate(treasuryForTopLevel),
+						cryptoCreate(firstCollectorForTopLevel).balance(10 * ONE_HBAR),
+						cryptoCreate(secondCollectorForTopLevel).balance(10 * ONE_HBAR),
+						tokenCreate(topLevelToken)
+								.initialSupply(Long.MAX_VALUE)
+								.treasury(treasuryForTopLevel)
+								.withCustom(fixedHbarFee(ONE_HBAR, firstCollectorForTopLevel))
+								.withCustom(fixedHbarFee(2 * ONE_HBAR, secondCollectorForTopLevel))
+								.withCustom(fractionalFee(1, 20, 0, OptionalLong.of(0), firstCollectorForTopLevel))
+								.withCustom(fractionalFee(1, 10, 0, OptionalLong.of(0), secondCollectorForTopLevel))
+								.signedBy(DEFAULT_PAYER, treasuryForTopLevel, firstCollectorForTopLevel,
+										secondCollectorForTopLevel),
+						tokenAssociate(edgar, topLevelToken),
+						cryptoTransfer(moving(2_000L, topLevelToken)
+								.distributing(treasuryForTopLevel, firstCollectorForTopLevel,
+										secondCollectorForTopLevel))
+				).when(
+						cryptoTransfer(
+								moving(1_000L, topLevelToken)
+										.between(firstCollectorForTopLevel, edgar)
+						)
+								.payingWith(firstCollectorForTopLevel)
+								.fee(ONE_HBAR)
+								.via(txnFromCollector)
+				).then(
+						getTxnRecord(txnFromCollector).logged(),
+						getAccountBalance(firstCollectorForTopLevel)
+								.logged()
+								.hasTokenBalance(topLevelToken, 0L),
+						getAccountBalance(secondCollectorForTopLevel)
+								.logged()
+								.hasTinyBars(12 * ONE_HBAR)
+								.hasTokenBalance(topLevelToken, 1_100L),
+						getAccountBalance(edgar)
+								.hasTokenBalance(topLevelToken, 900L)
 				);
 	}
 


### PR DESCRIPTION
**Description**:
Add two exemptions for custom fee charging:
1. A token treasury account is exempt from all custom fees for its token(s).
2. A fee collection account is exempt from the fees for which it is the collector.

**Related issue(s)**:
- Closes #1830
- Closes #1798

**Notes for reviewer**:
- The main step is to include the token treasury in the `ImpliedTransfersMeta` via a new `CustomFeeMeta` wrapper object.
- EETs for exemptions are added in `TokenTransactSpecs`.