### PR TITLE
Call FCOTMR.release() at expected lifecycle points

### DIFF
--- a/hedera-node/src/main/java/com/hedera/services/ServicesState.java
+++ b/hedera-node/src/main/java/com/hedera/services/ServicesState.java
@@ -356,6 +356,19 @@ public class ServicesState extends AbstractNaryMerkleInternal implements SwirldS
 		), mutableUniqTokenAssocsIfInit, mutableOwnerAssocsIfInit, this);
 	}
 
+
+	/* --- Archivable --- */
+	@Override
+	public void archive() {
+		releaseFcotmrIfNonNull();
+	}
+
+	/* --- MerkleNode --- */
+	@Override
+	protected void onRelease() {
+		releaseFcotmrIfNonNull();
+	}
+
 	/* --------------- */
 	public AccountID getAccountFromNodeId(NodeId nodeId) {
 		var address = addressBook().getAddress(nodeId.getId());
@@ -456,5 +469,14 @@ public class ServicesState extends AbstractNaryMerkleInternal implements SwirldS
 
 	void setUniqueOwnershipAssociations(FCOneToManyRelation<EntityId, MerkleUniqueTokenId> uniqueOwnershipAssociations) {
 		this.uniqueOwnershipAssociations = uniqueOwnershipAssociations;
+	}
+
+	private void releaseFcotmrIfNonNull() {
+		if (uniqueTokenAssociations != null) {
+			uniqueTokenAssociations.release();
+		}
+		if (uniqueOwnershipAssociations != null) {
+			uniqueOwnershipAssociations.release();
+		}
 	}
 }

--- a/hedera-node/src/test/java/com/hedera/services/ServicesStateTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/ServicesStateTest.java
@@ -867,6 +867,40 @@ class ServicesStateTest {
 	}
 
 	@Test
+	void archivingReleaseFcotmrAsExpected() {
+		// expect:
+		assertDoesNotThrow(subject::archive);
+
+		// and given:
+		subject.setUniqueTokenAssociations(uniqueTokenAssociations);
+		subject.setUniqueOwnershipAssociations(uniqueOwnershipAssociations);
+
+		// when:
+		subject.archive();
+
+		// then:
+		verify(uniqueTokenAssociations).release();
+		verify(uniqueOwnershipAssociations).release();
+	}
+
+	@Test
+	void onReleaseDoesReleaseFcotmrAsExpected() {
+		// expect:
+		assertDoesNotThrow(subject::onRelease);
+
+		// and given:
+		subject.setUniqueTokenAssociations(uniqueTokenAssociations);
+		subject.setUniqueOwnershipAssociations(uniqueOwnershipAssociations);
+
+		// when:
+		subject.onRelease();
+
+		// then:
+		verify(uniqueTokenAssociations).release();
+		verify(uniqueOwnershipAssociations).release();
+	}
+
+	@Test
 	void expandsSigsWithSignedTransactionBytes() throws InvalidProtocolBufferException {
 		// setup:
 		ByteString mockPk = ByteString.copyFrom("not-a-real-pkPrefix".getBytes());


### PR DESCRIPTION

**Description**:
- Call `FCOneToManyRelation.release()` in the right`ServicesState` lifecycle callbacks.

**Related issue(s)**:
- Fixes #1837