### PR TITLE
Fix Sonarcloud code smell blocker issues.

### DIFF
--- a/hapi-fees/src/main/java/com/hedera/services/pricing/BaseOperationUsage.java
+++ b/hapi-fees/src/main/java/com/hedera/services/pricing/BaseOperationUsage.java
@@ -158,6 +158,7 @@ class BaseOperationUsage {
 					default:
 						break;
 				}
+				break;
 			case TokenMint:
 				if (type == TOKEN_NON_FUNGIBLE_UNIQUE) {
 					return uniqueTokenMint();

--- a/hedera-node/src/test/java/com/hedera/services/ledger/BaseHederaLedgerTestHelper.java
+++ b/hedera-node/src/test/java/com/hedera/services/ledger/BaseHederaLedgerTestHelper.java
@@ -67,7 +67,7 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class BaseHederaLedgerTest {
+public class BaseHederaLedgerTestHelper {
 	protected OptionValidator validator = TEST_VALIDATOR;
 	protected MockGlobalDynamicProps dynamicProps = new MockGlobalDynamicProps();
 

--- a/hedera-node/src/test/java/com/hedera/services/ledger/HederLedgerTokenXfersTestHelper.java
+++ b/hedera-node/src/test/java/com/hedera/services/ledger/HederLedgerTokenXfersTestHelper.java
@@ -39,7 +39,7 @@ import static org.mockito.BDDMockito.never;
 import static org.mockito.BDDMockito.times;
 import static org.mockito.BDDMockito.verify;
 
-class HederLedgerTokenXfersTest extends BaseHederaLedgerTest {
+class HederLedgerTokenXfersTestHelper extends BaseHederaLedgerTestHelper {
 	@BeforeEach
 	private void setup() {
 		commonSetup();

--- a/hedera-node/src/test/java/com/hedera/services/ledger/HederLedgerTokensTestHelper.java
+++ b/hedera-node/src/test/java/com/hedera/services/ledger/HederLedgerTokensTestHelper.java
@@ -46,7 +46,7 @@ import static org.mockito.BDDMockito.inOrder;
 import static org.mockito.BDDMockito.verify;
 import static org.mockito.Mockito.never;
 
-public class HederLedgerTokensTest extends BaseHederaLedgerTest {
+public class HederLedgerTokensTestHelper extends BaseHederaLedgerTestHelper {
 	@BeforeEach
 	private void setup() {
 		commonSetup();

--- a/hedera-node/src/test/java/com/hedera/services/ledger/HederaLedgerLiveTestHelper.java
+++ b/hedera-node/src/test/java/com/hedera/services/ledger/HederaLedgerLiveTestHelper.java
@@ -65,7 +65,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.BDDMockito.verify;
 
-public class HederaLedgerLiveTest extends BaseHederaLedgerTest {
+public class HederaLedgerLiveTestHelper extends BaseHederaLedgerTestHelper {
 	long thisSecond = 1_234_567L;
 	@BeforeEach
 	void setup() {

--- a/hedera-node/src/test/java/com/hedera/services/ledger/HederaLedgerTestHelper.java
+++ b/hedera-node/src/test/java/com/hedera/services/ledger/HederaLedgerTestHelper.java
@@ -53,7 +53,7 @@ import static org.mockito.BDDMockito.never;
 import static org.mockito.BDDMockito.times;
 import static org.mockito.BDDMockito.verify;
 
-public class HederaLedgerTest extends BaseHederaLedgerTest {
+public class HederaLedgerTestHelper extends BaseHederaLedgerTestHelper {
 	@BeforeEach
 	private void setup() {
 		commonSetup();

--- a/hedera-node/src/test/java/com/hedera/services/ledger/HederaLedgerXfersTestHelper.java
+++ b/hedera-node/src/test/java/com/hedera/services/ledger/HederaLedgerXfersTestHelper.java
@@ -44,7 +44,7 @@ import static org.mockito.BDDMockito.verify;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class HederaLedgerXfersTest extends BaseHederaLedgerTest {
+public class HederaLedgerXfersTestHelper extends BaseHederaLedgerTestHelper {
 	@BeforeEach
 	private void setup() {
 		commonSetup();


### PR DESCRIPTION
**Description**:
This PR fixed the Sonarcloud code smell blocker issue.

**Related issue(s)**:

Fixes #1864

The URL for the resulting sonar report: https://sonarcloud.io/project/issues?branch=branch-01864-D-fix-sonar-blocker-codesmells&id=com.hedera.hashgraph%3Ahedera-services&resolved=false&severities=BLOCKER


**Notes for reviewer**:
3 issues complaining no "assertion" statement in the test methods are filtered out from Sonarcloud rule, as those are not real unit tests. 

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
