### PR TITLE
Add AnswerOnly retry precheck to HapiQueryOp

### DIFF
--- a/hedera-node/src/test/java/com/hedera/services/store/tokens/views/TreasuryWildcardsUniqTokenViewTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/store/tokens/views/TreasuryWildcardsUniqTokenViewTest.java
@@ -114,10 +114,10 @@ class TreasuryWildcardsUniqTokenViewTest {
 	void getsAllAssociationsWithRangeToSpare() {
 		setupFirstMockRange();
 		setupSecondMockRange();
-		given(nftsByOwner.getCount(ownerId)).willReturn(end - 1);
-		given(treasuryNftsByType.getCount(treasuryTokenId)).willReturn(1);
-		given(nftsByOwner.get(ownerId, start, end - 1)).willReturn(firstMockRange);
-		given(treasuryNftsByType.get(treasuryTokenId, 0, 1)).willReturn(secondMockRange);
+		given(nftsByOwner.getCount(ownerId.identityCode())).willReturn(end - 1);
+		given(treasuryNftsByType.getCount(treasuryTokenId.identityCode())).willReturn(1);
+		given(nftsByOwner.get(ownerId.identityCode(), start, end - 1)).willReturn(firstMockRange);
+		given(treasuryNftsByType.get(treasuryTokenId.identityCode(), 0, 1)).willReturn(secondMockRange);
 		given(nfts.get(someExplicitNftId)).willReturn(someExplicitNft);
 		given(nfts.get(wildcardNftId)).willReturn(wildcardNft);
 		given(nfts.get(otherWildcardNftId)).willReturn(otherWildNft);

--- a/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/HapiQueryOp.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/HapiQueryOp.java
@@ -62,6 +62,8 @@ import static com.hedera.services.bdd.spec.transactions.TxnUtils.tinyBarsFromTo;
 import static com.hedera.services.bdd.spec.transactions.TxnUtils.txnToString;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INSUFFICIENT_TX_FEE;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OK;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.UNKNOWN;
+import static java.lang.Thread.sleep;
 import static java.util.stream.Collectors.toList;
 
 public abstract class HapiQueryOp<T extends HapiQueryOp<T>> extends HapiSpecOperation {
@@ -72,10 +74,13 @@ public abstract class HapiQueryOp<T extends HapiQueryOp<T>> extends HapiSpecOper
 	private boolean stopAfterCostAnswer = false;
 	private boolean expectStrictCostAnswer = false;
 	protected Response response = null;
+	protected ResponseCodeEnum actualPrecheck = UNKNOWN;
 	private Optional<ResponseCodeEnum> answerOnlyPrecheck = Optional.empty();
 	private Optional<Function<HapiApiSpec, Long>> nodePaymentFn = Optional.empty();
 	private Optional<EnumSet<ResponseCodeEnum>> permissibleAnswerOnlyPrechecks = Optional.empty();
 	private Optional<EnumSet<ResponseCodeEnum>> permissibleCostAnswerPrechecks = Optional.empty();
+	/** if response code in the set then allow to resubmit transaction */
+	protected Optional<EnumSet<ResponseCodeEnum>> answerOnlyRetryPrechecks = Optional.empty();
 
 	private ResponseCodeEnum expectedCostAnswerPrecheck() {
 		return costAnswerPrecheck.orElse(OK);
@@ -143,24 +148,34 @@ public abstract class HapiQueryOp<T extends HapiQueryOp<T>> extends HapiSpecOper
 		fixNodeFor(spec);
 		configureTlsFor(spec);
 
-		/* Note that HapiQueryOp#fittedPayment makes a COST_ANSWER query if necessary. */
-		Transaction payment = needsPayment() ? fittedPayment(spec) : Transaction.getDefaultInstance();
+		Transaction payment = Transaction.getDefaultInstance();
+		while(true) {
+			/* Note that HapiQueryOp#fittedPayment makes a COST_ANSWER query if necessary. */
+			if (needsPayment()) {
+				payment = fittedPayment(spec);
+			}
 
-		if (stopAfterCostAnswer) {
-			return false;
+			if (stopAfterCostAnswer) {
+				return false;
+			}
+
+			/* If the COST_ANSWER query was expected to fail, we will not do anything else for this query. */
+			if (needsPayment() && !nodePayment.isPresent() && expectedCostAnswerPrecheck() != OK) {
+				return false;
+			}
+
+			if (needsPayment() && !loggingOff) {
+				log.info(spec.logPrefix() + "Paying for " + this + " with " + txnToString(payment));
+			}
+			timedSubmitWith(spec, payment);
+
+			actualPrecheck = reflectForPrecheck(response);
+			if (answerOnlyRetryPrechecks.isPresent() && answerOnlyRetryPrechecks.get().contains(actualPrecheck)) {
+				sleep(10);
+			} else {
+				break;
+			}
 		}
-
-		/* If the COST_ANSWER query was expected to fail, we will not do anything else for this query. */
-		if (needsPayment() && !nodePayment.isPresent() && expectedCostAnswerPrecheck() != OK) {
-			return false;
-		}
-
-		if (needsPayment() && !loggingOff) {
-			log.info(spec.logPrefix() + "Paying for " + this + " with " + txnToString(payment));
-		}
-		timedSubmitWith(spec, payment);
-
-		ResponseCodeEnum actualPrecheck = reflectForPrecheck(response);
 		if (permissibleAnswerOnlyPrechecks.isPresent()) {
 			if (permissibleAnswerOnlyPrechecks.get().contains(actualPrecheck)) {
 				answerOnlyPrecheck = Optional.of(actualPrecheck);
@@ -322,6 +337,11 @@ public abstract class HapiQueryOp<T extends HapiQueryOp<T>> extends HapiSpecOper
 
 	public T hasAnswerOnlyPrecheckFrom(ResponseCodeEnum... prechecks) {
 		permissibleAnswerOnlyPrechecks = Optional.of(EnumSet.copyOf(List.of(prechecks)));
+		return self();
+	}
+
+	public T hasRetryAnswerOnlyPrecheck(ResponseCodeEnum... statuses) {
+		answerOnlyRetryPrechecks = Optional.of(EnumSet.copyOf(List.of(statuses)));
 		return self();
 	}
 

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoCreateForSuiteRunner.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoCreateForSuiteRunner.java
@@ -39,6 +39,9 @@ import static com.hedera.services.bdd.spec.transactions.TxnUtils.NOISY_RETRY_PRE
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoCreate;
 import static com.hedera.services.bdd.spec.utilops.CustomSpecAssert.allRunFor;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.withOpContext;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.DUPLICATE_TRANSACTION;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_ACCOUNT_ID;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_TRANSACTION_ID;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SUCCESS;
 
 /**
@@ -92,17 +95,14 @@ public class CryptoCreateForSuiteRunner extends HapiApiSuite {
 													.via("txn")
 													.ensuringResolvedStatusIsntFromDuplicate();
 											allRunFor(spec, cryptoCreateOp);
-											var gotCreationRecord = false;
-											while (!gotCreationRecord) {
-												try {
-													var getRecordOp = getTxnRecord("txn")
-															.assertingNothing()
-															.saveTxnRecordToRegistry("savedTxnRcd")
-															.logged();
-													allRunFor(spec, getRecordOp);
-													gotCreationRecord = true;
-												} catch (Throwable ignoreAndRetry) { }
-											}
+											var getRecordOp = getTxnRecord("txn")
+													.assertingNothing()
+													.saveTxnRecordToRegistry("savedTxnRcd")
+													.hasRetryAnswerOnlyPrecheck(
+															DUPLICATE_TRANSACTION,
+															INVALID_TRANSACTION_ID)
+													.logged();
+											allRunFor(spec, getRecordOp);
 											createdAuditablePayer = true;
 										} catch (Throwable ignoreAgainAndRetry) {
 											retryCount++;
@@ -114,16 +114,13 @@ public class CryptoCreateForSuiteRunner extends HapiApiSuite {
 											.getStatus();
 									Assert.assertEquals("Failed to create payer account!", SUCCESS, status);
 
-									var gotPayerInfo = false;
-									while (!gotPayerInfo) {
-										try {
-											var payerAccountInfo = getAccountInfo("payerAccount")
+									var payerAccountInfo = getAccountInfo("payerAccount")
+													.hasRetryAnswerOnlyPrecheck(
+															DUPLICATE_TRANSACTION,
+															INVALID_ACCOUNT_ID)
 													.saveToRegistry("payerAccountInfo")
 													.logged();
-											allRunFor(spec, payerAccountInfo);
-											gotPayerInfo = true;
-										} catch (Throwable ignoreAndRetry) { }
-									}
+									allRunFor(spec, payerAccountInfo);
 
 									//TODO Should be modified in a different way to avoid setting a static variable of
 									// other class

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/RandomOps.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/RandomOps.java
@@ -58,7 +58,7 @@ public class RandomOps extends HapiApiSuite {
 		return List.of(
 				new HapiApiSpec[]{
 						freezeWorks(),
-//						getAccountInfoRetryWorks()
+						getAccountInfoRetryWorks()
 //						createThenTransferThenUpdateDeleteThenUpdate()
 				}
 		);
@@ -71,6 +71,7 @@ public class RandomOps extends HapiApiSuite {
 				.then(
 						getAccountInfo("0.0.2")
 								.hasRetryAnswerOnlyPrecheck(OK)
+								.setRetryLimit(5)
 				);
 	}
 

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/RandomOps.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/RandomOps.java
@@ -32,6 +32,7 @@ import java.util.Map;
 
 import static com.hedera.services.bdd.spec.HapiApiSpec.customHapiSpec;
 import static com.hedera.services.bdd.spec.HapiApiSpec.defaultHapiSpec;
+import static com.hedera.services.bdd.spec.queries.QueryVerbs.getAccountInfo;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.contractCall;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.contractCreate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoCreate;
@@ -43,6 +44,7 @@ import static com.hedera.services.bdd.spec.transactions.crypto.HapiCryptoTransfe
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.freeze;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.newKeyNamed;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.sleepFor;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OK;
 
 public class RandomOps extends HapiApiSuite {
 	private static final Logger log = LogManager.getLogger(RandomOps.class);
@@ -56,9 +58,20 @@ public class RandomOps extends HapiApiSuite {
 		return List.of(
 				new HapiApiSpec[]{
 						freezeWorks(),
+//						getAccountInfoRetryWorks()
 //						createThenTransferThenUpdateDeleteThenUpdate()
 				}
 		);
+	}
+
+	private HapiApiSpec getAccountInfoRetryWorks() {
+		return defaultHapiSpec("GetAccountInfoRetryWorks")
+				.given()
+				.when()
+				.then(
+						getAccountInfo("0.0.2")
+								.hasRetryAnswerOnlyPrecheck(OK)
+				);
 	}
 
 	private HapiApiSpec freezeWorks() {

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/token/TokenTransferBasicLoadTest.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/token/TokenTransferBasicLoadTest.java
@@ -47,7 +47,6 @@ import static com.hedera.services.bdd.spec.utilops.UtilVerbs.runWithProvider;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.sleepFor;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.sourcing;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.withOpContext;
-import static com.hedera.services.bdd.suites.perf.PerfUtilOps.tokenOpsEnablement;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.BUSY;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.DUPLICATE_TRANSACTION;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.EMPTY_TOKEN_TRANSFER_ACCOUNT_AMOUNTS;
@@ -182,7 +181,6 @@ public class TokenTransferBasicLoadTest extends LoadTest {
 		};
 		return defaultHapiSpec("TokenTransferBasicLoadTest" )
 				.given(
-						tokenOpsEnablement(), // remove this line when token services enabled by default
 						withOpContext((spec, ignore) -> settings.setFrom(spec.setup().ciPropertiesMap()))
 				).when(
 						sourcing(() -> runWithProvider(tokenCreatesFactory(settings))


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->
1. Add AnswerOnly retry prechecks to HapiQueryOp
2. Removed unnecessary token enablement which was supposed to be removed once we enable token operations by default.

**Related issue(s)**:

Fixes #1885, #1880

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->
Will share the JRS run results for test `HTS-Restart-Performance-Random-10k-61m` when run finishes. 
Test result : https://hedera-hashgraph.slack.com/archives/C018CBQBTGB/p1627407100408500
Summary : https://hedera-hashgraph.slack.com/archives/C018CBQBTGB/p1627407151408900
Also added a spec `RandomOps.getAccountInfoRetryWorks()` to validate retry on `AnswerOnlyPrecheck`s
**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
