### PR TITLE
Avoid updating MerkleNetworkContext every handleTransaction

### DIFF
--- a/hedera-node/src/main/java/com/hedera/services/fees/TxnRateFeeMultiplierSource.java
+++ b/hedera-node/src/main/java/com/hedera/services/fees/TxnRateFeeMultiplierSource.java
@@ -164,7 +164,7 @@ public class TxnRateFeeMultiplierSource implements FeeMultiplierSource {
 		and that copy references this object's congestionLevelStarts, we will get
 		a (transient) ISS if the congestion level changes mid-serialization on one
 		node but not others. */
-		return congestionLevelStarts.clone();
+		return congestionLevelStarts;
 	}
 
 	private boolean ensureConfigUpToDate() {

--- a/hedera-node/src/main/java/com/hedera/services/state/merkle/MerkleNetworkContext.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/merkle/MerkleNetworkContext.java
@@ -168,6 +168,8 @@ public class MerkleNetworkContext extends AbstractMerkleLeaf {
 				else
 					usageSnapshots.add(usageSnapshot);
 			}
+			while(usageSnapshots.size() > n)
+				usageSnapshots.remove(usageSnapshots.size() - 1);
 		}
 	}
 


### PR DESCRIPTION
Signed-off-by: abhishek-hedera <abhishek.pandey@hedera.com>

**Description**:
Modifies `usageSnapshots` to be a `List` instead of an `Array`.
Modifies `updateSnapshotsFrom` and `updateCongestionStartsFrom` to sync with references from `DeterministicThrottling` and `FeeMultiplierSource`.
Creates a deep copy of `updateSnapshotsFrom` and `updateCongetsionStartsFrom` when `MerkleNetworkContext.copy()` is called.

**Related issue(s)**: 
#1847 

Fixes #1847 

**Notes for reviewer**:

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
