### PR TITLE
Encode epoch seconds + nano adjustment as a single long valid through…

### DIFF
--- a/hedera-node/src/main/java/com/hedera/services/state/merkle/MerkleUniqueToken.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/merkle/MerkleUniqueToken.java
@@ -33,6 +33,10 @@ import java.time.Instant;
 import java.util.Arrays;
 import java.util.Objects;
 
+import static com.hedera.services.state.merkle.internals.IdentityCodeUtils.nanosFrom;
+import static com.hedera.services.state.merkle.internals.IdentityCodeUtils.packedTime;
+import static com.hedera.services.state.merkle.internals.IdentityCodeUtils.secondsFrom;
+
 /**
  * Represents an uniqueToken entity. Part of the nft implementation.
  */
@@ -45,8 +49,7 @@ public class MerkleUniqueToken extends AbstractMerkleLeaf {
 	public static final int UPPER_BOUND_METADATA_BYTES = 1024;
 
 	private int ownerCode;
-	private int creationNanos;
-	private long creationSecs;
+	private long packedCreationTime;
 	private byte[] metadata;
 
 	/**
@@ -66,8 +69,7 @@ public class MerkleUniqueToken extends AbstractMerkleLeaf {
 	) {
 		this.ownerCode = owner.identityCode();
 		this.metadata = metadata;
-		this.creationSecs = creationTime.getSeconds();
-		this.creationNanos = creationTime.getNanos();
+		this.packedCreationTime = packedTime(creationTime.getSeconds(), creationTime.getNanos());
 	}
 
 	/**
@@ -75,23 +77,20 @@ public class MerkleUniqueToken extends AbstractMerkleLeaf {
 	 *
 	 * @param ownerCode the number of the owning entity as an unsigned {@code int}
 	 * @param metadata the metadata of the unique token
-	 * @param creationSecs the seconds past the consensus epoch when the NFT was minted
-	 * @param creationNanos the nanos past the above consensus second when the NFT was minted
+	 * @param packedCreationTime the "packed" representation of the consensus time at which the token was minted
 	 */
 	public MerkleUniqueToken(
 			int ownerCode,
 			byte[] metadata,
-			long creationSecs,
-			int creationNanos
+			long packedCreationTime
 	) {
 		this.ownerCode = ownerCode;
 		this.metadata = metadata;
-		this.creationSecs = creationSecs;
-		this.creationNanos = creationNanos;
+		this.packedCreationTime = packedCreationTime;
 	}
 
 	public MerkleUniqueToken() {
-		/* No-op. */
+		/* RuntimeConstructable */
 	}
 
 	/* Object */
@@ -106,8 +105,7 @@ public class MerkleUniqueToken extends AbstractMerkleLeaf {
 
 		var that = (MerkleUniqueToken) o;
 		return this.ownerCode == that.ownerCode &&
-				this.creationSecs == that.creationSecs &&
-				this.creationNanos == that.creationNanos &&
+				this.packedCreationTime == that.packedCreationTime &&
 				Objects.deepEquals(this.metadata, that.metadata);
 	}
 
@@ -115,22 +113,21 @@ public class MerkleUniqueToken extends AbstractMerkleLeaf {
 	public int hashCode() {
 		return Objects.hash(
 				ownerCode,
-				creationSecs,
-				creationNanos,
+				packedCreationTime,
 				Arrays.hashCode(metadata));
 	}
 
 	@Override
 	public String toString() {
+		final var then = Instant.ofEpochSecond(secondsFrom(packedCreationTime), nanosFrom(packedCreationTime));
 		return MoreObjects.toStringHelper(MerkleUniqueToken.class)
 				.add("owner", EntityId.fromIdentityCode(ownerCode).toAbbrevString())
-				.add("creationTime", Instant.ofEpochSecond(creationSecs, creationNanos))
+				.add("creationTime", then)
 				.add("metadata", metadata)
 				.toString();
 	}
 
 	/* --- MerkleLeaf --- */
-
 	@Override
 	public long getClassId() {
 		return RUNTIME_CONSTRUCTABLE_ID;
@@ -144,16 +141,14 @@ public class MerkleUniqueToken extends AbstractMerkleLeaf {
 	@Override
 	public void deserialize(SerializableDataInputStream in, int i) throws IOException {
 		ownerCode = in.readInt();
-		creationSecs = in.readLong();
-		creationNanos = in.readInt();
+		packedCreationTime = in.readLong();
 		metadata = in.readByteArray(UPPER_BOUND_METADATA_BYTES);
 	}
 
 	@Override
 	public void serialize(SerializableDataOutputStream out) throws IOException {
 		out.writeInt(ownerCode);
-		out.writeLong(creationSecs);
-		out.writeInt(creationNanos);
+		out.writeLong(packedCreationTime);
 		out.writeByteArray(metadata);
 	}
 
@@ -161,7 +156,7 @@ public class MerkleUniqueToken extends AbstractMerkleLeaf {
 	@Override
 	public MerkleUniqueToken copy() {
 		setImmutable(true);
-		return new MerkleUniqueToken(ownerCode, metadata, creationSecs, creationNanos);
+		return new MerkleUniqueToken(ownerCode, metadata, packedCreationTime);
 	}
 
 	public void setOwner(EntityId owner) {
@@ -178,7 +173,7 @@ public class MerkleUniqueToken extends AbstractMerkleLeaf {
 	}
 
 	public RichInstant getCreationTime() {
-		return new RichInstant(creationSecs, creationNanos);
+		return new RichInstant(secondsFrom(packedCreationTime), nanosFrom(packedCreationTime));
 	}
 
 	public boolean isTreasuryOwned() {

--- a/hedera-node/src/main/java/com/hedera/services/state/merkle/internals/IdentityCodeUtils.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/merkle/internals/IdentityCodeUtils.java
@@ -26,8 +26,46 @@ package com.hedera.services.state.merkle.internals;
  */
 public class IdentityCodeUtils {
 	private static final long MASK_AS_UNSIGNED_LONG = (1L << 32) - 1;
+	private static final long EPOCH_SECONDS_MASK = MASK_AS_UNSIGNED_LONG << 32;
 
 	public static final long MAX_NUM_ALLOWED = -1 & 0xFFFFFFFFL;
+
+	/**
+	 * Returns a {@code long} whose high-order 32-bits "encode" an unsigned
+	 * integer value, and whose low-order 32-bits are a signed integer. For
+	 * use with the {@link IdentityCodeUtils#secondsFrom(long)} and
+	 * {@link IdentityCodeUtils#nanosFrom(long)} helpers below. This format
+	 * can represent timestamps through January 2106.
+	 *
+	 * @param seconds some number of seconds since the epoch
+	 * @param nanos some number of nanos after the above second
+	 * @return a "packed" version of
+	 */
+	public static long packedTime(long seconds, int nanos) {
+		assertValid(seconds);
+		return seconds << 32 | (nanos & MASK_AS_UNSIGNED_LONG);
+	}
+
+	/**
+	 * Returns the high-order 32-bits of the given {@code long}, interpreted
+	 * as an unsigned integer.
+	 *
+	 * @param packedTime any long
+	 * @return the high-order 32-bits as an unsigned integer
+	 */
+	public static long secondsFrom(long packedTime) {
+		return (packedTime & EPOCH_SECONDS_MASK) >>> 32;
+	}
+
+	/**
+	 * Returns the low-order 32-bits of the given {@code long} as a signed integer.
+	 *
+	 * @param packedTime any long
+	 * @return the low-order 32-bits as a signed integer
+	 */
+	public static int nanosFrom(long packedTime) {
+		return (int)(packedTime & MASK_AS_UNSIGNED_LONG);
+	}
 
 	/**
 	 * Returns the positive long represented by the given integer code.

--- a/hedera-node/src/test/java/com/hedera/services/state/merkle/internals/IdentityCodeUtilsTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/state/merkle/internals/IdentityCodeUtilsTest.java
@@ -22,7 +22,12 @@ package com.hedera.services.state.merkle.internals;
 
 import org.junit.jupiter.api.Test;
 
+import java.time.Instant;
+
 import static com.hedera.services.state.merkle.internals.IdentityCodeUtils.MAX_NUM_ALLOWED;
+import static com.hedera.services.state.merkle.internals.IdentityCodeUtils.nanosFrom;
+import static com.hedera.services.state.merkle.internals.IdentityCodeUtils.packedTime;
+import static com.hedera.services.state.merkle.internals.IdentityCodeUtils.secondsFrom;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -58,5 +63,25 @@ class IdentityCodeUtilsTest {
 	@Test
 	void isUninstantiable() {
 		assertThrows(IllegalStateException.class, IdentityCodeUtils::new);
+	}
+
+	@Test
+	void timePackingWorks() {
+		// given:
+		final var distantFuture = Instant.ofEpochSecond(MAX_NUM_ALLOWED, 999_999_999);
+
+		// when:
+		final var packed = packedTime(distantFuture.getEpochSecond(), distantFuture.getNano());
+		// and:
+		final var unpacked = Instant.ofEpochSecond(secondsFrom(packed), nanosFrom(packed));
+
+		// then:
+		assertEquals(distantFuture, unpacked);
+	}
+
+	@Test
+	void cantPackTooFarFuture() {
+		// expect:
+		assertThrows(IllegalArgumentException.class, () -> packedTime(MAX_NUM_ALLOWED + 1, 0));
 	}
 }


### PR DESCRIPTION
**Description**:
Reduce state size of a `MerkleUniqueToken` by 4 bytes, encoding its creation time as a `long` valid through February 7, 2106 6:28 AM.