### PR TITLE
Only update NetworkContext state when FastCopyable.copy() called

### DIFF
--- a/hedera-node/src/main/java/com/hedera/services/state/logic/NetworkCtxManager.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/logic/NetworkCtxManager.java
@@ -157,8 +157,8 @@ public class NetworkCtxManager {
 		opCounters.countHandled(op);
 
 		var networkCtxNow = networkCtx.get();
-		networkCtxNow.updateSnapshotsFrom(handleThrottling);
-		networkCtxNow.updateCongestionStartsFrom(feeMultiplierSource);
+		networkCtxNow.syncThrottling(handleThrottling);
+		networkCtxNow.syncMultiplierSource(feeMultiplierSource);
 	}
 
 	public static boolean inSameUtcDay(Instant now, Instant then) {

--- a/hedera-node/src/main/java/com/hedera/services/state/merkle/MerkleNetworkContext.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/merkle/MerkleNetworkContext.java
@@ -69,6 +69,8 @@ public class MerkleNetworkContext extends AbstractMerkleLeaf {
 	private long lastScannedEntity;
 	private long entitiesScannedThisSecond = 0L;
 	private long entitiesTouchedThisSecond = 0L;
+	private FeeMultiplierSource multiplierSource = null;
+	private FunctionalityThrottling throttling = null;
 	private DeterministicThrottle.UsageSnapshot[] usageSnapshots = NO_SNAPSHOTS;
 
 	public MerkleNetworkContext() {
@@ -152,30 +154,13 @@ public class MerkleNetworkContext extends AbstractMerkleLeaf {
 		this.lastScannedEntity = lastScannedEntity;
 	}
 
-	public void updateSnapshotsFrom(FunctionalityThrottling throttling) {
-		throwIfImmutable("Cannot update usage snapshots on an immutable context");
-		var activeThrottles = throttling.allActiveThrottles();
-		int n = activeThrottles.size();
-		if (n == 0) {
-			usageSnapshots = NO_SNAPSHOTS;
-		} else {
-			usageSnapshots = new DeterministicThrottle.UsageSnapshot[n];
-			for (int i = 0; i < n; i++) {
-				usageSnapshots[i] = activeThrottles.get(i).usageSnapshot();
-			}
-		}
+	public void syncThrottling(FunctionalityThrottling throttling) {
+		this.throttling = throttling;
 	}
 
-	public void updateCongestionStartsFrom(FeeMultiplierSource feeMultiplierSource) {
-		throwIfImmutable("Cannot update congestion starts on an immutable context");
-		final var congestionStarts = feeMultiplierSource.congestionLevelStarts();
-		if (null == congestionStarts) {
-			congestionLevelStarts = NO_CONGESTION_STARTS;
-		} else {
-			congestionLevelStarts = congestionStarts;
-		}
+	public void syncMultiplierSource(FeeMultiplierSource multiplierSource) {
+		this.multiplierSource = multiplierSource;
 	}
-
 	public void setConsensusTimeOfLastHandledTxn(Instant consensusTimeOfLastHandledTxn) {
 		throwIfImmutable("Cannot set consensus time of last transaction on an immutable context");
 		this.consensusTimeOfLastHandledTxn = consensusTimeOfLastHandledTxn;
@@ -194,7 +179,17 @@ public class MerkleNetworkContext extends AbstractMerkleLeaf {
 	/* --- MerkleLeaf --- */
 	@Override
 	public MerkleNetworkContext copy() {
+		if (throttling != null) {
+			updateSnapshotsFrom(throttling);
+			throttling = null;
+		}
+		if (multiplierSource != null) {
+			updateCongestionStartsFrom(multiplierSource);
+			multiplierSource = null;
+		}
+
 		setImmutable(true);
+
 		return new MerkleNetworkContext(
 				consensusTimeOfLastHandledTxn,
 				seqNo.copy(),
@@ -353,6 +348,30 @@ public class MerkleNetworkContext extends AbstractMerkleLeaf {
 	}
 
 	/* --- Internal helpers --- */
+	void updateSnapshotsFrom(FunctionalityThrottling throttling) {
+		throwIfImmutable("Cannot update usage snapshots on an immutable context");
+		var activeThrottles = throttling.allActiveThrottles();
+		int n = activeThrottles.size();
+		if (n == 0) {
+			usageSnapshots = NO_SNAPSHOTS;
+		} else {
+			usageSnapshots = new DeterministicThrottle.UsageSnapshot[n];
+			for (int i = 0; i < n; i++) {
+				usageSnapshots[i] = activeThrottles.get(i).usageSnapshot();
+			}
+		}
+	}
+
+	void updateCongestionStartsFrom(FeeMultiplierSource feeMultiplierSource) {
+		throwIfImmutable("Cannot update congestion starts on an immutable context");
+		final var congestionStarts = feeMultiplierSource.congestionLevelStarts();
+		if (null == congestionStarts) {
+			congestionLevelStarts = NO_CONGESTION_STARTS;
+		} else {
+			congestionLevelStarts = congestionStarts;
+		}
+	}
+
 	private void reset(List<DeterministicThrottle> throttles) {
 		var currUsageSnapshots = throttles.stream()
 				.map(DeterministicThrottle::usageSnapshot)
@@ -399,15 +418,19 @@ public class MerkleNetworkContext extends AbstractMerkleLeaf {
 		return consensusTimeOfLastHandledTxn;
 	}
 
-	DeterministicThrottle.UsageSnapshot[] getUsageSnapshots() {
-		return usageSnapshots;
-	}
-
 	void setUsageSnapshots(DeterministicThrottle.UsageSnapshot[] usageSnapshots) {
 		this.usageSnapshots = usageSnapshots;
 	}
 
 	DeterministicThrottle.UsageSnapshot[] usageSnapshots() {
 		return usageSnapshots;
+	}
+
+	FeeMultiplierSource getMultiplierSource() {
+		return multiplierSource;
+	}
+
+	FunctionalityThrottling getThrottling() {
+		return throttling;
 	}
 }

--- a/hedera-node/src/test/java/com/hedera/services/state/logic/NetworkCtxManagerTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/state/logic/NetworkCtxManagerTest.java
@@ -133,8 +133,8 @@ class NetworkCtxManagerTest {
 
 		// then:
 		verify(opCounters).countHandled(TokenMint);
-		verify(networkCtx).updateSnapshotsFrom(handleThrottling);
-		verify(networkCtx).updateCongestionStartsFrom(feeMultiplierSource);
+		verify(networkCtx).syncThrottling(handleThrottling);
+		verify(networkCtx).syncMultiplierSource(feeMultiplierSource);
 	}
 
 	@Test


### PR DESCRIPTION
**Description**:
- Wait until `MerkleNetworkContext.copy()` is called to deep-copy the `FunctionalityThrottling` usage snapshots and `FeeMultiplierSource` congestion-level starts into the `MerkleNetworkContext` about to be made immutable.

**Related issue(s)**:
- Closes #1847