### PR TITLE
Enable weekly dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+


### PR DESCRIPTION
**Description**:
The maven packages in hedera-services don't get updated very often and can contain bugs or vulnerabilities that might go unnoticed. We should make an effort to proactively keep them up to date. This PR enables automatic weekly [dependabot](https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/enabling-and-disabling-version-updates) version updates. Every week (usually Monday) 5 PRs dependency bump at a time will get created. You can then choose to merge them or close them.

**Related issue(s)**:

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
