### PR TITLE
Revert the changes to `MerkleNetworkContext#deserialize`

### DIFF
--- a/hedera-node/src/main/java/com/hedera/services/state/merkle/MerkleNetworkContext.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/merkle/MerkleNetworkContext.java
@@ -45,6 +45,9 @@ public class MerkleNetworkContext extends AbstractMerkleLeaf {
 
 	static final int UNRECORDED_STATE_VERSION = -1;
 
+	static final int PRE_RELEASE_0130_VERSION = 1;
+	static final int RELEASE_0130_VERSION = 2;
+	static final int RELEASE_0140_VERSION = 3;
 	static final int RELEASE_0150_VERSION = 4;
 	static final int MERKLE_VERSION = RELEASE_0150_VERSION;
 	static final long RUNTIME_CONSTRUCTABLE_ID = 0x8d4aa0f0a968a9f3L;
@@ -209,38 +212,39 @@ public class MerkleNetworkContext extends AbstractMerkleLeaf {
 		seqNo.deserialize(in);
 		midnightRates = in.readSerializable(true, ratesSupplier);
 
-		readCongestionControlData(in);
+		if (version >= RELEASE_0130_VERSION) {
+			int numUsageSnapshots = in.readInt();
+			if (numUsageSnapshots > 0) {
+				usageSnapshots = new DeterministicThrottle.UsageSnapshot[numUsageSnapshots];
+				for (int i = 0; i < numUsageSnapshots; i++) {
+					var used = in.readLong();
+					var lastUsed = serdes.readNullableInstant(in);
+					usageSnapshots[i] = new DeterministicThrottle.UsageSnapshot(
+							used, (lastUsed == null) ? null : lastUsed.toJava());
+				}
+			}
 
-		lastScannedEntity = in.readLong();
-		entitiesScannedThisSecond = in.readLong();
-		entitiesTouchedThisSecond = in.readLong();
-		stateVersion = in.readInt();
-		final var lastBoundaryCheck = serdes.readNullableInstant(in);
-		lastMidnightBoundaryCheck = (lastBoundaryCheck == null) ? null : lastBoundaryCheck.toJava();
-	}
-
-	private void readCongestionControlData(final SerializableDataInputStream in) throws IOException {
-		int numUsageSnapshots = in.readInt();
-		if (numUsageSnapshots > 0) {
-			usageSnapshots = new DeterministicThrottle.UsageSnapshot[numUsageSnapshots];
-			for (int i = 0; i < numUsageSnapshots; i++) {
-				var used = in.readLong();
-				var lastUsed = serdes.readNullableInstant(in);
-				usageSnapshots[i] = new DeterministicThrottle.UsageSnapshot(
-						used, (lastUsed == null) ? null : lastUsed.toJava());
+			int numCongestionStarts = in.readInt();
+			if (numCongestionStarts > 0) {
+				congestionLevelStarts = new Instant[numCongestionStarts];
+				for (int i = 0; i < numCongestionStarts; i++) {
+					final var levelStart = serdes.readNullableInstant(in);
+					congestionLevelStarts[i] = (levelStart == null) ? null : levelStart.toJava();
+				}
 			}
 		}
-
-		int numCongestionStarts = in.readInt();
-		if (numCongestionStarts > 0) {
-			congestionLevelStarts = new Instant[numCongestionStarts];
-			for (int i = 0; i < numCongestionStarts; i++) {
-				final var levelStart = serdes.readNullableInstant(in);
-				congestionLevelStarts[i] = (levelStart == null) ? null : levelStart.toJava();
-			}
+		if (version >= RELEASE_0140_VERSION) {
+			lastScannedEntity = in.readLong();
+			entitiesScannedThisSecond = in.readLong();
+			entitiesTouchedThisSecond = in.readLong();
+			stateVersion = in.readInt();
+		}
+		if (version >= RELEASE_0150_VERSION) {
+			final var lastBoundaryCheck = serdes.readNullableInstant(in);
+			lastMidnightBoundaryCheck = (lastBoundaryCheck == null) ? null : lastBoundaryCheck.toJava();
 		}
 	}
-	
+
 	@Override
 	public void serialize(SerializableDataOutputStream out) throws IOException {
 		serdes.writeNullableInstant(fromJava(consensusTimeOfLastHandledTxn), out);

--- a/hedera-node/src/main/java/com/hedera/services/state/merkle/MerkleNetworkContext.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/merkle/MerkleNetworkContext.java
@@ -45,7 +45,6 @@ public class MerkleNetworkContext extends AbstractMerkleLeaf {
 
 	static final int UNRECORDED_STATE_VERSION = -1;
 
-	static final int PRE_RELEASE_0130_VERSION = 1;
 	static final int RELEASE_0130_VERSION = 2;
 	static final int RELEASE_0140_VERSION = 3;
 	static final int RELEASE_0150_VERSION = 4;
@@ -213,36 +212,49 @@ public class MerkleNetworkContext extends AbstractMerkleLeaf {
 		midnightRates = in.readSerializable(true, ratesSupplier);
 
 		if (version >= RELEASE_0130_VERSION) {
-			int numUsageSnapshots = in.readInt();
-			if (numUsageSnapshots > 0) {
-				usageSnapshots = new DeterministicThrottle.UsageSnapshot[numUsageSnapshots];
-				for (int i = 0; i < numUsageSnapshots; i++) {
-					var used = in.readLong();
-					var lastUsed = serdes.readNullableInstant(in);
-					usageSnapshots[i] = new DeterministicThrottle.UsageSnapshot(
-							used, (lastUsed == null) ? null : lastUsed.toJava());
-				}
-			}
-
-			int numCongestionStarts = in.readInt();
-			if (numCongestionStarts > 0) {
-				congestionLevelStarts = new Instant[numCongestionStarts];
-				for (int i = 0; i < numCongestionStarts; i++) {
-					final var levelStart = serdes.readNullableInstant(in);
-					congestionLevelStarts[i] = (levelStart == null) ? null : levelStart.toJava();
-				}
-			}
+			readCongestionControlData(in);
 		}
+
 		if (version >= RELEASE_0140_VERSION) {
-			lastScannedEntity = in.readLong();
-			entitiesScannedThisSecond = in.readLong();
-			entitiesTouchedThisSecond = in.readLong();
-			stateVersion = in.readInt();
+			whenVersionHigherOrEqualTo0140(in);
 		}
 		if (version >= RELEASE_0150_VERSION) {
-			final var lastBoundaryCheck = serdes.readNullableInstant(in);
-			lastMidnightBoundaryCheck = (lastBoundaryCheck == null) ? null : lastBoundaryCheck.toJava();
+			whenVersionHigherOrEqualTo0150(in);
 		}
+	}
+
+	private void readCongestionControlData(final SerializableDataInputStream in) throws IOException {
+		int numUsageSnapshots = in.readInt();
+		if (numUsageSnapshots > 0) {
+			usageSnapshots = new DeterministicThrottle.UsageSnapshot[numUsageSnapshots];
+			for (int i = 0; i < numUsageSnapshots; i++) {
+				var used = in.readLong();
+				var lastUsed = serdes.readNullableInstant(in);
+				usageSnapshots[i] = new DeterministicThrottle.UsageSnapshot(
+						used, (lastUsed == null) ? null : lastUsed.toJava());
+			}
+		}
+
+		int numCongestionStarts = in.readInt();
+		if (numCongestionStarts > 0) {
+			congestionLevelStarts = new Instant[numCongestionStarts];
+			for (int i = 0; i < numCongestionStarts; i++) {
+				final var levelStart = serdes.readNullableInstant(in);
+				congestionLevelStarts[i] = (levelStart == null) ? null : levelStart.toJava();
+			}
+		}
+	}
+
+	private void whenVersionHigherOrEqualTo0140(final SerializableDataInputStream in) throws IOException {
+		lastScannedEntity = in.readLong();
+		entitiesScannedThisSecond = in.readLong();
+		entitiesTouchedThisSecond = in.readLong();
+		stateVersion = in.readInt();
+	}
+
+	private void whenVersionHigherOrEqualTo0150(final SerializableDataInputStream in) throws IOException {
+		final var lastBoundaryCheck = serdes.readNullableInstant(in);
+		lastMidnightBoundaryCheck = (lastBoundaryCheck == null) ? null : lastBoundaryCheck.toJava();
 	}
 
 	@Override

--- a/hedera-node/src/test/java/com/hedera/services/state/merkle/MerkleNetworkContextTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/state/merkle/MerkleNetworkContextTest.java
@@ -539,28 +539,6 @@ class MerkleNetworkContextTest {
 	}
 
 	@Test
-	void deserializeWorksForPre0130() throws IOException {
-		// setup:
-		var in = mock(SerializableDataInputStream.class);
-		MerkleNetworkContext.ratesSupplier = () -> midnightRateSet;
-		MerkleNetworkContext.seqNoSupplier = () -> seqNo;
-		InOrder inOrder = inOrder(in, seqNo);
-
-		given(serdes.readNullableInstant(in).toJava()).willReturn(consensusTimeOfLastHandledTxn);
-
-		// when:
-		subject.deserialize(in, MerkleNetworkContext.PRE_RELEASE_0130_VERSION);
-
-		// then:
-		assertEquals(consensusTimeOfLastHandledTxn, subject.getConsensusTimeOfLastHandledTxn());
-		assertSame(usageSnapshots, subject.usageSnapshots());
-		assertArrayEquals(congestionStarts(), subject.getCongestionLevelStarts());
-		// and:
-		inOrder.verify(seqNo).deserialize(in);
-		inOrder.verify(in).readSerializable(booleanThat(Boolean.TRUE::equals), any(Supplier.class));
-	}
-
-	@Test
 	void deserializeWorksFor0130() throws IOException {
 		// setup:
 		var in = mock(SerializableDataInputStream.class);
@@ -688,50 +666,7 @@ class MerkleNetworkContextTest {
 	}
 
 	@Test
-	void deserializeWorksFor0140NullInstants() throws IOException {
-		// setup:
-		var in = mock(SerializableDataInputStream.class);
-		MerkleNetworkContext.ratesSupplier = () -> midnightRateSet;
-		MerkleNetworkContext.seqNoSupplier = () -> seqNo;
-		InOrder inOrder = inOrder(in, seqNo);
-
-		subject = new MerkleNetworkContext();
-
-		given(in.readInt())
-				.willReturn(usageSnapshots.length)
-				.willReturn(congestionStarts.length)
-				.willReturn(stateVersion);
-		given(in.readLong())
-				.willReturn(usageSnapshots[0].used())
-				.willReturn(usageSnapshots[1].used())
-				.willReturn(lastScannedEntity)
-				.willReturn(entitiesScannedThisSecond)
-				.willReturn(entitiesTouchedThisSecond);
-		given(serdes.readNullableInstant(in)).willReturn(null);
-
-		// when:
-		subject.deserialize(in, MerkleNetworkContext.RELEASE_0140_VERSION);
-
-		// then:
-		assertNull(subject.getConsensusTimeOfLastHandledTxn());
-		assertNull(subject.lastMidnightBoundaryCheck());
-		assertEquals(entitiesScannedThisSecond, subject.getEntitiesScannedThisSecond());
-		assertEquals(entitiesTouchedThisSecond, subject.getEntitiesTouchedThisSecond());
-		assertArrayEquals(new DeterministicThrottle.UsageSnapshot[] {
-				new DeterministicThrottle.UsageSnapshot(usageSnapshots[0].used(), null),
-				new DeterministicThrottle.UsageSnapshot(usageSnapshots[1].used(), null)
-		}, subject.usageSnapshots());
-		assertArrayEquals(new Instant[] { null, null }, subject.getCongestionLevelStarts());
-		// and:
-		inOrder.verify(seqNo).deserialize(in);
-		inOrder.verify(in).readSerializable(booleanThat(Boolean.TRUE::equals), any(Supplier.class));
-		// and:
-		assertEquals(lastScannedEntity, subject.lastScannedEntity());
-		assertEquals(stateVersion, subject.getStateVersion());
-	}
-
-	@Test
-	void deserializeWorksFor0150NullInstants() throws IOException {
+	void deserializeWorksForNullInstants() throws IOException {
 		// setup:
 		var in = mock(SerializableDataInputStream.class);
 		MerkleNetworkContext.ratesSupplier = () -> midnightRateSet;

--- a/hedera-node/src/test/java/com/hedera/services/state/merkle/MerkleNetworkContextTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/state/merkle/MerkleNetworkContextTest.java
@@ -539,6 +539,109 @@ class MerkleNetworkContextTest {
 	}
 
 	@Test
+	void deserializeWorksForPre0130() throws IOException {
+		// setup:
+		var in = mock(SerializableDataInputStream.class);
+		MerkleNetworkContext.ratesSupplier = () -> midnightRateSet;
+		MerkleNetworkContext.seqNoSupplier = () -> seqNo;
+		InOrder inOrder = inOrder(in, seqNo);
+
+		given(serdes.readNullableInstant(in).toJava()).willReturn(consensusTimeOfLastHandledTxn);
+
+		// when:
+		subject.deserialize(in, MerkleNetworkContext.PRE_RELEASE_0130_VERSION);
+
+		// then:
+		assertEquals(consensusTimeOfLastHandledTxn, subject.getConsensusTimeOfLastHandledTxn());
+		assertSame(usageSnapshots, subject.usageSnapshots());
+		assertArrayEquals(congestionStarts(), subject.getCongestionLevelStarts());
+		// and:
+		inOrder.verify(seqNo).deserialize(in);
+		inOrder.verify(in).readSerializable(booleanThat(Boolean.TRUE::equals), any(Supplier.class));
+	}
+
+	@Test
+	void deserializeWorksFor0130() throws IOException {
+		// setup:
+		var in = mock(SerializableDataInputStream.class);
+		MerkleNetworkContext.ratesSupplier = () -> midnightRateSet;
+		MerkleNetworkContext.seqNoSupplier = () -> seqNo;
+		InOrder inOrder = inOrder(in, seqNo);
+
+		subject = new MerkleNetworkContext();
+
+		given(in.readInt())
+				.willReturn(usageSnapshots.length)
+				.willReturn(congestionStarts.length);
+		given(in.readLong())
+				.willReturn(usageSnapshots[0].used())
+				.willReturn(usageSnapshots[1].used());
+		given(serdes.readNullableInstant(in).toJava())
+				.willReturn(consensusTimeOfLastHandledTxn)
+				.willReturn(usageSnapshots[0].lastDecisionTime())
+				.willReturn(usageSnapshots[1].lastDecisionTime())
+				.willReturn(congestionStarts[0])
+				.willReturn(congestionStarts[1]);
+
+		// when:
+		subject.deserialize(in, MerkleNetworkContext.RELEASE_0130_VERSION);
+
+		// then:
+		assertEquals(consensusTimeOfLastHandledTxn, subject.getConsensusTimeOfLastHandledTxn());
+		assertArrayEquals(usageSnapshots, subject.usageSnapshots());
+		assertArrayEquals(congestionStarts(), subject.getCongestionLevelStarts());
+		// and:
+		inOrder.verify(seqNo).deserialize(in);
+		inOrder.verify(in).readSerializable(booleanThat(Boolean.TRUE::equals), any(Supplier.class));
+		// and:
+		assertEquals(MerkleNetworkContext.UNRECORDED_STATE_VERSION, subject.getStateVersion());
+	}
+
+	@Test
+	void deserializeWorksFor0140() throws IOException {
+		// setup:
+		var in = mock(SerializableDataInputStream.class);
+		MerkleNetworkContext.ratesSupplier = () -> midnightRateSet;
+		MerkleNetworkContext.seqNoSupplier = () -> seqNo;
+		InOrder inOrder = inOrder(in, seqNo);
+
+		subject = new MerkleNetworkContext();
+
+		given(in.readInt())
+				.willReturn(usageSnapshots.length)
+				.willReturn(congestionStarts.length)
+				.willReturn(stateVersion);
+		given(in.readLong())
+				.willReturn(usageSnapshots[0].used())
+				.willReturn(usageSnapshots[1].used())
+				.willReturn(lastScannedEntity)
+				.willReturn(entitiesScannedThisSecond)
+				.willReturn(entitiesTouchedThisSecond);
+		given(serdes.readNullableInstant(in))
+				.willReturn(fromJava(consensusTimeOfLastHandledTxn))
+				.willReturn(fromJava(usageSnapshots[0].lastDecisionTime()))
+				.willReturn(fromJava(usageSnapshots[1].lastDecisionTime()))
+				.willReturn(fromJava(congestionStarts[0]))
+				.willReturn(fromJava(congestionStarts[1]));
+
+		// when:
+		subject.deserialize(in, MerkleNetworkContext.RELEASE_0140_VERSION);
+
+		// then:
+		assertEquals(consensusTimeOfLastHandledTxn, subject.getConsensusTimeOfLastHandledTxn());
+		assertEquals(entitiesScannedThisSecond, subject.getEntitiesScannedThisSecond());
+		assertEquals(entitiesTouchedThisSecond, subject.getEntitiesTouchedThisSecond());
+		assertArrayEquals(usageSnapshots, subject.usageSnapshots());
+		assertArrayEquals(congestionStarts(), subject.getCongestionLevelStarts());
+		// and:
+		inOrder.verify(seqNo).deserialize(in);
+		inOrder.verify(in).readSerializable(booleanThat(Boolean.TRUE::equals), any(Supplier.class));
+		// and:
+		assertEquals(lastScannedEntity, subject.lastScannedEntity());
+		assertEquals(stateVersion, subject.getStateVersion());
+	}
+
+	@Test
 	void deserializeWorksFor0150() throws IOException {
 		// setup:
 		var in = mock(SerializableDataInputStream.class);


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->
Revert the changes that were made assuming that start from saved state tests are only v0.16 and above in PR https://github.com/hashgraph/hedera-services/pull/1901
**Related issue(s)**:

Fixes #1942 

**Notes for reviewer**:
version checks were removed form `MerkleNetworkContext#deserialize` which cause start from saved tests in JRS that use older states [ < v0.16.0] to fail.

Test Runs :
[MixedOps-NI-3NReconnect-6k-24m](https://hedera-hashgraph.slack.com/archives/C018CBQBTGB/p1628192689027600)
[HTS-Restart-Performance-Hotspot-10k-61m](https://hedera-hashgraph.slack.com/archives/C018CBQBTGB/p1628197737028300)
[HTS-Restart-Performance-Random-10k-61m](https://hedera-hashgraph.slack.com/archives/C018CBQBTGB/p1628201818028700)
**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
