### PR TITLE
Enhancement for allowing fractional custom fee to be assessed to sender or receiver

### DIFF
--- a/hedera-node/src/main/java/com/hedera/services/context/ServicesContext.java
+++ b/hedera-node/src/main/java/com/hedera/services/context/ServicesContext.java
@@ -1891,7 +1891,7 @@ public class ServicesContext {
 	public SpanMapManager spanMapManager() {
 		if (spanMapManager == null) {
 			spanMapManager = new SpanMapManager(
-					impliedTransfersMarshal(), globalDynamicProperties(), customFeeSchedules());
+					impliedTransfersMarshal(), globalDynamicProperties(), customFeeSchedules(),ledger());
 		}
 		return spanMapManager;
 	}

--- a/hedera-node/src/main/java/com/hedera/services/grpc/marshalling/AdjustmentUtils.java
+++ b/hedera-node/src/main/java/com/hedera/services/grpc/marshalling/AdjustmentUtils.java
@@ -32,9 +32,9 @@ public class AdjustmentUtils {
 		adjustedChange(collector, denom, +amount, manager, false);
 	}
 
-	static BalanceChange adjustedChange(Id account, Id denom, long amount, BalanceChangeManager manager, boolean changeSender) {
+	static BalanceChange adjustedChange(Id account, Id denom, long amount, BalanceChangeManager manager, boolean simpleAdjust) {
 		/* Always append a new change for an HTS debit since it could trigger another assessed fee */
-		if (denom != Id.MISSING_ID && amount < 0 && !changeSender) {
+		if (denom != Id.MISSING_ID && amount < 0 && !simpleAdjust) {
 			return includedHtsChange(account, denom, amount, manager);
 		}
 

--- a/hedera-node/src/main/java/com/hedera/services/grpc/marshalling/AdjustmentUtils.java
+++ b/hedera-node/src/main/java/com/hedera/services/grpc/marshalling/AdjustmentUtils.java
@@ -27,14 +27,14 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INSUFFICIENT_P
 
 public class AdjustmentUtils {
 	static void adjustForAssessed(Id payer, Id collector, Id denom, long amount, BalanceChangeManager manager) {
-		final var payerChange = adjustedChange(payer, denom, -amount, manager);
+		final var payerChange = adjustedChange(payer, denom, -amount, manager, false);
 		payerChange.setCodeForInsufficientBalance(INSUFFICIENT_PAYER_BALANCE_FOR_CUSTOM_FEE);
-		adjustedChange(collector, denom, +amount, manager);
+		adjustedChange(collector, denom, +amount, manager, false);
 	}
 
-	static BalanceChange adjustedChange(Id account, Id denom, long amount, BalanceChangeManager manager) {
+	static BalanceChange adjustedChange(Id account, Id denom, long amount, BalanceChangeManager manager, boolean changeSender) {
 		/* Always append a new change for an HTS debit since it could trigger another assessed fee */
-		if (denom != Id.MISSING_ID && amount < 0) {
+		if (denom != Id.MISSING_ID && amount < 0 && !changeSender) {
 			return includedHtsChange(account, denom, amount, manager);
 		}
 

--- a/hedera-node/src/main/java/com/hedera/services/grpc/marshalling/BalanceChangeManager.java
+++ b/hedera-node/src/main/java/com/hedera/services/grpc/marshalling/BalanceChangeManager.java
@@ -123,8 +123,7 @@ public class BalanceChangeManager {
 	}
 
 	private boolean couldTriggerCustomFees(BalanceChange candidate) {
-		//return candidate.isForNft() || (!candidate.isForHbar() && candidate.units() < 0);
-		return candidate.isForNft() || (!candidate.isForHbar());
+		return candidate.isForNft() || (!candidate.isForHbar() && candidate.units() < 0);
 	}
 
 	private boolean matches(BalanceChange change, Id account, Id denom) {

--- a/hedera-node/src/main/java/com/hedera/services/grpc/marshalling/BalanceChangeManager.java
+++ b/hedera-node/src/main/java/com/hedera/services/grpc/marshalling/BalanceChangeManager.java
@@ -123,7 +123,8 @@ public class BalanceChangeManager {
 	}
 
 	private boolean couldTriggerCustomFees(BalanceChange candidate) {
-		return candidate.isForNft() || (!candidate.isForHbar() && candidate.units() < 0);
+		//return candidate.isForNft() || (!candidate.isForHbar() && candidate.units() < 0);
+		return candidate.isForNft() || (!candidate.isForHbar());
 	}
 
 	private boolean matches(BalanceChange change, Id account, Id denom) {

--- a/hedera-node/src/main/java/com/hedera/services/grpc/marshalling/FeeAssessor.java
+++ b/hedera-node/src/main/java/com/hedera/services/grpc/marshalling/FeeAssessor.java
@@ -21,6 +21,7 @@ package com.hedera.services.grpc.marshalling;
  */
 
 import com.hedera.services.ledger.BalanceChange;
+import com.hedera.services.ledger.HederaLedger;
 import com.hedera.services.state.submerkle.FcAssessedCustomFee;
 import com.hedera.services.state.submerkle.FcCustomFee;
 import com.hedera.services.store.models.Id;
@@ -55,11 +56,12 @@ public class FeeAssessor {
 	}
 
 	public ResponseCodeEnum assess(
-			BalanceChange change,
-			CustomSchedulesManager customSchedulesManager,
-			BalanceChangeManager balanceChangeManager,
-			List<FcAssessedCustomFee> accumulator,
-			ImpliedTransfersMeta.ValidationProps props
+			final BalanceChange change,
+			final CustomSchedulesManager customSchedulesManager,
+			final BalanceChangeManager balanceChangeManager,
+			final List<FcAssessedCustomFee> accumulator,
+			final ImpliedTransfersMeta.ValidationProps props,
+			final HederaLedger ledger
 	) {
 		if (balanceChangeManager.getLevelNo() > props.getMaxNestedCustomFees()) {
 			return CUSTOM_FEE_CHARGING_EXCEEDED_MAX_RECURSION_DEPTH;
@@ -81,7 +83,7 @@ public class FeeAssessor {
 
 		if (fixedFeeProcessingResult == FixedFeeProcessingResult.FRACTIONAL_FEE_ASSESSMENT_PENDING) {
 			final var fractionalValidity =
-					fractionalFeeAssessor.assessAllFractional(change, fees, balanceChangeManager, accumulator);
+					fractionalFeeAssessor.assessAllFractional(change, fees, balanceChangeManager, accumulator, ledger);
 			if (fractionalValidity != OK) {
 				return fractionalValidity;
 			}

--- a/hedera-node/src/main/java/com/hedera/services/grpc/marshalling/FeeAssessor.java
+++ b/hedera-node/src/main/java/com/hedera/services/grpc/marshalling/FeeAssessor.java
@@ -94,7 +94,8 @@ public class FeeAssessor {
 			final Id payer,
 			final BalanceChangeManager balanceChangeManager,
 			final List<FcAssessedCustomFee> accumulator,
-			final int maxBalanceChanges) {
+			final int maxBalanceChanges
+	) {
 		FixedFeeProcessingResult result = FixedFeeProcessingResult.ASSESSMENT_FINISHED;
 		for (var fee : fees) {
 			final var collector = fee.getFeeCollectorAsId();

--- a/hedera-node/src/main/java/com/hedera/services/grpc/marshalling/FractionalFeeAssessor.java
+++ b/hedera-node/src/main/java/com/hedera/services/grpc/marshalling/FractionalFeeAssessor.java
@@ -72,32 +72,32 @@ public class FractionalFeeAssessor {
 		if(chargeSender) {
 			if (change.units() < 0) { //     // charge sender
 				//if(chargeSender && change.units() < 0) { // ? this doesn't work
-			final var initialUnits = -change.units();
+				final var initialUnits = -change.units();
 
-			var totalCharge = initialUnits;
-			final var payer = change.getAccount();
-			final var denom = change.getToken();
+				var totalCharge = initialUnits;
+				final var payer = change.getAccount();
+				final var denom = change.getToken();
 
-			var assessedAmount = 0L;
-			try {
-				assessedAmount = amountOwedGiven(initialUnits, fee.getFractionalFeeSpec());
-			} catch (ArithmeticException ignore) {
-				return CUSTOM_FEE_OUTSIDE_NUMERIC_RANGE;
-			}
+				var assessedAmount = 0L;
+				try {
+					assessedAmount = amountOwedGiven(initialUnits, fee.getFractionalFeeSpec());
+				} catch (ArithmeticException ignore) {
+					return CUSTOM_FEE_OUTSIDE_NUMERIC_RANGE;
+				}
 
-			System.out.println("token fee: " + assessedAmount);
+				System.out.println("token fee: " + assessedAmount);
 
 //			totalCharge += assessedAmount;
 //			check if its account balance is sufficient
 //			if (totalCharge > payer.asMerkle()) {
 //				return INSUFFICIENT_PAYER_BALANCE_FOR_CUSTOM_FEE;
 //			}
-
-			adjustedChange(payer, denom, -assessedAmount, changeManager, chargeSender);
-			adjustedChange(collector, denom, assessedAmount, changeManager, chargeSender);
-			final var assessed = new FcAssessedCustomFee(collector.asEntityId(), denom.asEntityId(),
-					-assessedAmount);
-			accumulator.add(assessed);
+				// If charging sender, simply adjust the debit total
+				adjustedChange(payer, denom, -assessedAmount, changeManager, chargeSender);
+				adjustedChange(collector, denom, assessedAmount, changeManager, chargeSender);
+				final var assessed = new FcAssessedCustomFee(collector.asEntityId(), denom.asEntityId(),
+						assessedAmount);
+				accumulator.add(assessed);
 			}
 		}
 		else {

--- a/hedera-node/src/main/java/com/hedera/services/grpc/marshalling/FractionalFeeAssessor.java
+++ b/hedera-node/src/main/java/com/hedera/services/grpc/marshalling/FractionalFeeAssessor.java
@@ -93,8 +93,8 @@ public class FractionalFeeAssessor {
 //				return INSUFFICIENT_PAYER_BALANCE_FOR_CUSTOM_FEE;
 //			}
 				// If charging sender, simply adjust the debit total
-				adjustedChange(payer, denom, -assessedAmount, changeManager, chargeSender);
-				adjustedChange(collector, denom, assessedAmount, changeManager, chargeSender);
+				adjustedChange(payer, denom, -assessedAmount, changeManager, true);
+				adjustedChange(collector, denom, assessedAmount, changeManager, false);
 				final var assessed = new FcAssessedCustomFee(collector.asEntityId(), denom.asEntityId(),
 						assessedAmount);
 				accumulator.add(assessed);
@@ -129,7 +129,7 @@ public class FractionalFeeAssessor {
 					return CUSTOM_FEE_OUTSIDE_NUMERIC_RANGE;
 				}
 
-				adjustedChange(collector, denom, assessedAmount, changeManager, chargeSender);
+				adjustedChange(collector, denom, assessedAmount, changeManager, false);
 				final var assessed = new FcAssessedCustomFee(collector.asEntityId(), denom.asEntityId(), assessedAmount);
 				accumulator.add(assessed);
 			}

--- a/hedera-node/src/main/java/com/hedera/services/grpc/marshalling/ImpliedTransfersMarshal.java
+++ b/hedera-node/src/main/java/com/hedera/services/grpc/marshalling/ImpliedTransfersMarshal.java
@@ -22,6 +22,7 @@ package com.hedera.services.grpc.marshalling;
 
 import com.hedera.services.context.properties.GlobalDynamicProperties;
 import com.hedera.services.ledger.BalanceChange;
+import com.hedera.services.ledger.HederaLedger;
 import com.hedera.services.ledger.PureTransferSemanticChecks;
 import com.hedera.services.state.submerkle.FcAssessedCustomFee;
 import com.hedera.services.store.models.Id;
@@ -62,7 +63,7 @@ public class ImpliedTransfersMarshal {
 		this.schedulesManagerFactory = schedulesManagerFactory;
 	}
 
-	public ImpliedTransfers unmarshalFromGrpc(CryptoTransferTransactionBody op) {
+	public ImpliedTransfers unmarshalFromGrpc(CryptoTransferTransactionBody op, HederaLedger ledger) {
 		final var props = currentProps();
 		final var validity = checks.fullPureValidation(op.getTransfers(), op.getTokenTransfersList(), props);
 		if (validity != OK) {
@@ -90,7 +91,7 @@ public class ImpliedTransfersMarshal {
 		final List<FcAssessedCustomFee> fees = new ArrayList<>();
 		var change = changeManager.nextAssessableChange();
 		while (change != null) {
-			final var status = feeAssessor.assess(change, schedulesManager, changeManager, fees, props);
+			final var status = feeAssessor.assess(change, schedulesManager, changeManager, fees, props, ledger);
 			if (status != OK) {
 				return ImpliedTransfers.invalid(props, schedulesManager.metaUsed(), status);
 			}

--- a/hedera-node/src/main/java/com/hedera/services/ledger/BalanceChange.java
+++ b/hedera-node/src/main/java/com/hedera/services/ledger/BalanceChange.java
@@ -134,14 +134,6 @@ public class BalanceChange {
 		return token == null;
 	}
 
-	public boolean isCustomFeeFractional() {
-		return customFeeFractional;
-	}
-
-	public void setCustomFeeFractional(boolean val) {
-		this.customFeeFractional = val;
-	}
-
 	public boolean isForNft() {
 		return token != null && counterPartyAccountId != null;
 	}

--- a/hedera-node/src/main/java/com/hedera/services/ledger/BalanceChange.java
+++ b/hedera-node/src/main/java/com/hedera/services/ledger/BalanceChange.java
@@ -61,6 +61,7 @@ public class BalanceChange {
 	private TokenID tokenId = null;
 	private AccountID accountId;
 	private AccountID counterPartyAccountId = null;
+	private boolean customFeeFractional = false;
 
 	private BalanceChange(Id token, AccountAmount aa, ResponseCodeEnum code) {
 		this.token = token;
@@ -131,6 +132,14 @@ public class BalanceChange {
 
 	public boolean isForHbar() {
 		return token == null;
+	}
+
+	public boolean isCustomFeeFractional() {
+		return customFeeFractional;
+	}
+
+	public void setCustomFeeFractional(boolean val) {
+		this.customFeeFractional = val;
 	}
 
 	public boolean isForNft() {

--- a/hedera-node/src/main/java/com/hedera/services/txns/crypto/CryptoTransferTransitionLogic.java
+++ b/hedera-node/src/main/java/com/hedera/services/txns/crypto/CryptoTransferTransitionLogic.java
@@ -93,7 +93,7 @@ public class CryptoTransferTransitionLogic implements TransitionLogic {
 		var impliedTransfers = spanMapAccessor.getImpliedTransfers(accessor);
 		if (impliedTransfers == null) {
 			final var op = accessor.getTxn().getCryptoTransfer();
-			impliedTransfers = impliedTransfersMarshal.unmarshalFromGrpc(op);
+			impliedTransfers = impliedTransfersMarshal.unmarshalFromGrpc(op, ledger);
 		}
 		return impliedTransfers;
 	}

--- a/hedera-node/src/main/java/com/hedera/services/txns/span/SpanMapManager.java
+++ b/hedera-node/src/main/java/com/hedera/services/txns/span/SpanMapManager.java
@@ -23,6 +23,7 @@ package com.hedera.services.txns.span;
 import com.hedera.services.context.properties.GlobalDynamicProperties;
 import com.hedera.services.grpc.marshalling.ImpliedTransfers;
 import com.hedera.services.grpc.marshalling.ImpliedTransfersMarshal;
+import com.hedera.services.ledger.HederaLedger;
 import com.hedera.services.state.submerkle.EntityId;
 import com.hedera.services.txns.customfees.CustomFeeSchedules;
 import com.hedera.services.utils.TxnAccessor;
@@ -56,15 +57,18 @@ public class SpanMapManager {
 	private final GlobalDynamicProperties dynamicProperties;
 	private final ImpliedTransfersMarshal impliedTransfersMarshal;
 	private final ExpandHandleSpanMapAccessor spanMapAccessor = new ExpandHandleSpanMapAccessor();
+	private final HederaLedger ledger;
 
 	public SpanMapManager(
 			ImpliedTransfersMarshal impliedTransfersMarshal,
 			GlobalDynamicProperties dynamicProperties,
-			CustomFeeSchedules customFeeSchedules
+			CustomFeeSchedules customFeeSchedules,
+			final  HederaLedger ledger
 	) {
 		this.impliedTransfersMarshal = impliedTransfersMarshal;
 		this.dynamicProperties = dynamicProperties;
 		this.customFeeSchedules = customFeeSchedules;
+		this.ledger = ledger;
 	}
 
 	public void expandSpan(TxnAccessor accessor) {
@@ -89,7 +93,7 @@ public class SpanMapManager {
 
 	private void expandImpliedTransfers(TxnAccessor accessor) {
 		final var op = accessor.getTxn().getCryptoTransfer();
-		final var impliedTransfers = impliedTransfersMarshal.unmarshalFromGrpc(op);
+		final var impliedTransfers = impliedTransfersMarshal.unmarshalFromGrpc(op, ledger);
 		reCalculateXferMeta(accessor, impliedTransfers);
 		spanMapAccessor.setImpliedTransfers(accessor, impliedTransfers);
 	}

--- a/hedera-node/src/test/java/com/hedera/services/fees/calculation/AccessorBasedUsagesTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/fees/calculation/AccessorBasedUsagesTest.java
@@ -204,9 +204,9 @@ class AccessorBasedUsagesTest {
 				fixedFee(1, null, collector),
 				fixedFee(2, aDenom, collector),
 				fixedFee(2, bDenom, collector),
-				fractionalFee(1, 2, 1, 2, collector),
-				fractionalFee(1, 3, 1, 2, collector),
-				fractionalFee(1, 4, 1, 2, collector)
+				fractionalFee(1, 2, 1, 2, false, collector),
+				fractionalFee(1, 3, 1, 2, false, collector),
+				fractionalFee(1, 4, 1, 2, false, collector)
 		).stream().map(FcCustomFee::asGrpc).collect(toList());
 	}
 }

--- a/hedera-node/src/test/java/com/hedera/services/fees/calculation/utils/OpUsageCtxHelperTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/fees/calculation/utils/OpUsageCtxHelperTest.java
@@ -106,9 +106,9 @@ class OpUsageCtxHelperTest {
 				fixedFee(1, null, collector),
 				fixedFee(2, aDenom, collector),
 				fixedFee(2, bDenom, collector),
-				fractionalFee(1, 2, 1, 2, collector),
-				fractionalFee(1, 3, 1, 2, collector),
-				fractionalFee(1, 4, 1, 2, collector)
+				fractionalFee(1, 2, 1, 2, false, collector),
+				fractionalFee(1, 3, 1, 2, false, collector),
+				fractionalFee(1, 4, 1, 2, false, collector)
 		);
 	}
 }

--- a/hedera-node/src/test/java/com/hedera/services/grpc/marshalling/AdjustmentUtilsTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/grpc/marshalling/AdjustmentUtilsTest.java
@@ -47,7 +47,7 @@ class AdjustmentUtilsTest {
 		final var expectedChange = BalanceChange.tokenAdjust(account, denom, amount);
 
 		// when:
-		final var change = AdjustmentUtils.adjustedChange(account, denom, amount, changeManager);
+		final var change = AdjustmentUtils.adjustedChange(account, denom, amount, changeManager, false);
 
 		// then:
 		Assertions.assertEquals(expectedChange, change);
@@ -64,7 +64,7 @@ class AdjustmentUtilsTest {
 		final var expectedChange = BalanceChange.tokenAdjust(account, denom, amount);
 
 		// when:
-		final var change = AdjustmentUtils.adjustedChange(account, denom, amount, changeManager);
+		final var change = AdjustmentUtils.adjustedChange(account, denom, amount, changeManager, false);
 
 		// then:
 		Assertions.assertEquals(expectedChange, change);

--- a/hedera-node/src/test/java/com/hedera/services/grpc/marshalling/BalanceChangeManagerTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/grpc/marshalling/BalanceChangeManagerTest.java
@@ -55,7 +55,11 @@ class BalanceChangeManagerTest {
 	void understandsTriggerCandidates() {
 		// expect:
 		assertSame(firstFungibleTrigger, subject.nextAssessableChange());
+//		assertSame(secondFungibleTrigger, subject.nextAssessableChange());
+		assertSame(firstFungibleNonTrigger, subject.nextAssessableChange());
+		//assertSame(firstFungibleNonTrigger, subject.nextAssessableChange());
 		assertSame(secondFungibleTrigger, subject.nextAssessableChange());
+		assertSame(secondFungibleNonTrigger, subject.nextAssessableChange());
 		assertSame(firstNonFungibleTrigger, subject.nextAssessableChange());
 		assertNull(subject.nextAssessableChange());
 	}
@@ -116,7 +120,8 @@ class BalanceChangeManagerTest {
 		subject.includeChange(secondNonFungibleTrigger);
 		subject.includeChange(firstCredit);
 		subject.includeChange(secondCredit);
-		assertSame(secondNonFungibleTrigger, subject.nextAssessableChange());
+		//assertSame(secondNonFungibleTrigger, subject.nextAssessableChange());
+		assertSame(firstCredit, subject.nextAssessableChange());
 
 		// expect:
 		bothCreditsInCurrentLevel();
@@ -154,7 +159,8 @@ class BalanceChangeManagerTest {
 		subject.includeChange(secondFungibleTrigger);
 		subject.includeChange(secondFungibleNonTrigger);
 		// and:
-		assertSame(secondFungibleTrigger, subject.nextAssessableChange());
+		//assertSame(secondFungibleTrigger, subject.nextAssessableChange());
+		assertSame(firstFungibleNonTrigger, subject.nextAssessableChange());
 
 		// then:
 		assertEquals(2, subject.getLevelNo());

--- a/hedera-node/src/test/java/com/hedera/services/grpc/marshalling/BalanceChangeManagerTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/grpc/marshalling/BalanceChangeManagerTest.java
@@ -55,11 +55,7 @@ class BalanceChangeManagerTest {
 	void understandsTriggerCandidates() {
 		// expect:
 		assertSame(firstFungibleTrigger, subject.nextAssessableChange());
-//		assertSame(secondFungibleTrigger, subject.nextAssessableChange());
-		assertSame(firstFungibleNonTrigger, subject.nextAssessableChange());
-		//assertSame(firstFungibleNonTrigger, subject.nextAssessableChange());
 		assertSame(secondFungibleTrigger, subject.nextAssessableChange());
-		assertSame(secondFungibleNonTrigger, subject.nextAssessableChange());
 		assertSame(firstNonFungibleTrigger, subject.nextAssessableChange());
 		assertNull(subject.nextAssessableChange());
 	}
@@ -120,8 +116,7 @@ class BalanceChangeManagerTest {
 		subject.includeChange(secondNonFungibleTrigger);
 		subject.includeChange(firstCredit);
 		subject.includeChange(secondCredit);
-		//assertSame(secondNonFungibleTrigger, subject.nextAssessableChange());
-		assertSame(firstCredit, subject.nextAssessableChange());
+		assertSame(secondNonFungibleTrigger, subject.nextAssessableChange());
 
 		// expect:
 		bothCreditsInCurrentLevel();
@@ -159,8 +154,7 @@ class BalanceChangeManagerTest {
 		subject.includeChange(secondFungibleTrigger);
 		subject.includeChange(secondFungibleNonTrigger);
 		// and:
-		//assertSame(secondFungibleTrigger, subject.nextAssessableChange());
-		assertSame(firstFungibleNonTrigger, subject.nextAssessableChange());
+		assertSame(secondFungibleTrigger, subject.nextAssessableChange());
 
 		// then:
 		assertEquals(2, subject.getLevelNo());

--- a/hedera-node/src/test/java/com/hedera/services/grpc/marshalling/FeeAssessorTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/grpc/marshalling/FeeAssessorTest.java
@@ -330,5 +330,6 @@ class FeeAssessorTest {
 			denominator,
 			minAmountOfFractionalFee,
 			maxAmountOfFractionalFee,
+			false,
 			fractionalFeeCollector);
 }

--- a/hedera-node/src/test/java/com/hedera/services/grpc/marshalling/FractionalFeeAssessorTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/grpc/marshalling/FractionalFeeAssessorTest.java
@@ -83,7 +83,7 @@ class FractionalFeeAssessorTest {
 
 		// when:
 		final var result =
-				subject.assessAllFractional(vanillaTrigger, fees, changeManager, accumulator);
+				subject.assessAllFractional(vanillaTriggerForReceiver, fees, changeManager, accumulator);
 
 		// then:
 		assertEquals(OK, result);
@@ -112,7 +112,7 @@ class FractionalFeeAssessorTest {
 
 		// when:
 		final var result =
-				subject.assessAllFractional(vanillaTrigger, fees, changeManager, accumulator);
+				subject.assessAllFractional(vanillaTriggerForReceiver, fees, changeManager, accumulator);
 
 		// then:
 		assertEquals(CUSTOM_FEE_OUTSIDE_NUMERIC_RANGE, result);
@@ -125,7 +125,7 @@ class FractionalFeeAssessorTest {
 
 		// when:
 		final var result =
-				subject.assessAllFractional(vanillaTrigger, fees, changeManager, accumulator);
+				subject.assessAllFractional(vanillaTriggerForReceiver, fees, changeManager, accumulator);
 
 		// then:
 		assertEquals(CUSTOM_FEE_OUTSIDE_NUMERIC_RANGE, result);
@@ -138,7 +138,7 @@ class FractionalFeeAssessorTest {
 
 		// when:
 		final var result =
-				subject.assessAllFractional(wildlyInsufficientChange, fees, changeManager, accumulator);
+				subject.assessAllFractional(wildlyInsufficientChangeForReceiver, fees, changeManager, accumulator);
 
 		// then:
 		assertEquals(INSUFFICIENT_PAYER_BALANCE_FOR_CUSTOM_FEE, result);
@@ -286,31 +286,40 @@ class FractionalFeeAssessorTest {
 			firstDenominator,
 			firstMinAmountOfFractionalFee,
 			firstMaxAmountOfFractionalFee,
+			false,
 			firstFractionalFeeCollector);
 	private final FcCustomFee secondFractionalFee = FcCustomFee.fractionalFee(
 			secondNumerator,
 			secondDenominator,
 			secondMinAmountOfFractionalFee,
 			secondMaxAmountOfFractionalFee,
+			false,
 			secondFractionalFeeCollector);
 	private final FcCustomFee exemptFractionalFee = FcCustomFee.fractionalFee(
 			firstNumerator,
 			secondDenominator,
 			firstMinAmountOfFractionalFee,
 			secondMaxAmountOfFractionalFee,
+			false,
 			payer.asEntityId());
 	private final FcCustomFee nonsenseFee = FcCustomFee.fractionalFee(
 			nonsenseNumerator,
 			nonsenseDenominator,
 			0,
 			0,
+			false,
 			secondFractionalFeeCollector);
 	private final BalanceChange vanillaTrigger = BalanceChange.tokenAdjust(
 			payer, tokenWithFractionalFee, -vanillaTriggerAmount);
+	private final BalanceChange vanillaTriggerForReceiver = BalanceChange.tokenAdjust(
+			payer, tokenWithFractionalFee, vanillaTriggerAmount);
+
 	private final BalanceChange firstVanillaReclaim = BalanceChange.tokenAdjust(
 			firstReclaimedAcount, tokenWithFractionalFee, +firstCreditAmount);
 	private final BalanceChange secondVanillaReclaim = BalanceChange.tokenAdjust(
 			secondReclaimedAcount, tokenWithFractionalFee, +secondCreditAmount);
 	private final BalanceChange wildlyInsufficientChange = BalanceChange.tokenAdjust(
 			payer, tokenWithFractionalFee, -1);
+	private final BalanceChange wildlyInsufficientChangeForReceiver = BalanceChange.tokenAdjust(
+			payer, tokenWithFractionalFee, 1);
 }

--- a/hedera-node/src/test/java/com/hedera/services/grpc/marshalling/FractionalFeeAssessorTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/grpc/marshalling/FractionalFeeAssessorTest.java
@@ -21,6 +21,7 @@ package com.hedera.services.grpc.marshalling;
  */
 
 import com.hedera.services.ledger.BalanceChange;
+import com.hedera.services.ledger.HederaLedger;
 import com.hedera.services.state.submerkle.EntityId;
 import com.hedera.services.state.submerkle.FcAssessedCustomFee;
 import com.hedera.services.state.submerkle.FcCustomFee;
@@ -49,6 +50,8 @@ class FractionalFeeAssessorTest {
 
 	@Mock
 	private BalanceChangeManager changeManager;
+	@Mock
+	private HederaLedger ledger;
 
 	@Test
 	void appliesFeesAsExpected() {
@@ -83,7 +86,7 @@ class FractionalFeeAssessorTest {
 
 		// when:
 		final var result =
-				subject.assessAllFractional(vanillaTriggerForReceiver, fees, changeManager, accumulator);
+				subject.assessAllFractional(vanillaTrigger, fees, changeManager, accumulator, ledger);
 
 		// then:
 		assertEquals(OK, result);
@@ -112,7 +115,7 @@ class FractionalFeeAssessorTest {
 
 		// when:
 		final var result =
-				subject.assessAllFractional(vanillaTriggerForReceiver, fees, changeManager, accumulator);
+				subject.assessAllFractional(vanillaTrigger, fees, changeManager, accumulator, ledger);
 
 		// then:
 		assertEquals(CUSTOM_FEE_OUTSIDE_NUMERIC_RANGE, result);
@@ -125,7 +128,7 @@ class FractionalFeeAssessorTest {
 
 		// when:
 		final var result =
-				subject.assessAllFractional(vanillaTriggerForReceiver, fees, changeManager, accumulator);
+				subject.assessAllFractional(vanillaTrigger, fees, changeManager, accumulator, ledger);
 
 		// then:
 		assertEquals(CUSTOM_FEE_OUTSIDE_NUMERIC_RANGE, result);
@@ -138,7 +141,7 @@ class FractionalFeeAssessorTest {
 
 		// when:
 		final var result =
-				subject.assessAllFractional(wildlyInsufficientChangeForReceiver, fees, changeManager, accumulator);
+				subject.assessAllFractional(wildlyInsufficientChange, fees, changeManager, accumulator, ledger);
 
 		// then:
 		assertEquals(INSUFFICIENT_PAYER_BALANCE_FOR_CUSTOM_FEE, result);
@@ -151,7 +154,7 @@ class FractionalFeeAssessorTest {
 
 		// expect:
 		assertThrows(IllegalArgumentException.class,
-				() -> subject.assessAllFractional(vanillaTrigger, List.of(), changeManager, accumulator));
+				() -> subject.assessAllFractional(vanillaTrigger, List.of(), changeManager, accumulator, ledger));
 	}
 
 	@Test
@@ -311,15 +314,15 @@ class FractionalFeeAssessorTest {
 			secondFractionalFeeCollector);
 	private final BalanceChange vanillaTrigger = BalanceChange.tokenAdjust(
 			payer, tokenWithFractionalFee, -vanillaTriggerAmount);
-	private final BalanceChange vanillaTriggerForReceiver = BalanceChange.tokenAdjust(
-			payer, tokenWithFractionalFee, vanillaTriggerAmount);
-
+//	private final BalanceChange vanillaTriggerForReceiver = BalanceChange.tokenAdjust(
+//			payer, tokenWithFractionalFee, vanillaTriggerAmount);
+//
 	private final BalanceChange firstVanillaReclaim = BalanceChange.tokenAdjust(
 			firstReclaimedAcount, tokenWithFractionalFee, +firstCreditAmount);
 	private final BalanceChange secondVanillaReclaim = BalanceChange.tokenAdjust(
 			secondReclaimedAcount, tokenWithFractionalFee, +secondCreditAmount);
 	private final BalanceChange wildlyInsufficientChange = BalanceChange.tokenAdjust(
 			payer, tokenWithFractionalFee, -1);
-	private final BalanceChange wildlyInsufficientChangeForReceiver = BalanceChange.tokenAdjust(
-			payer, tokenWithFractionalFee, 1);
+//	private final BalanceChange wildlyInsufficientChangeForReceiver = BalanceChange.tokenAdjust(
+//			payer, tokenWithFractionalFee, 1);
 }

--- a/hedera-node/src/test/java/com/hedera/services/state/merkle/MerkleTokenTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/state/merkle/MerkleTokenTest.java
@@ -663,7 +663,7 @@ class MerkleTokenTest {
 				"tokenDenomination=1" +
 				".2.3}, feeCollector=EntityId{shard=4, realm=5, num=6}}, FcCustomFee{feeType=FRACTIONAL_FEE, " +
 				"fractionalFee=FractionalFeeSpec{numerator=5, denominator=100, minimumUnitsToCollect=1, " +
-				"maximumUnitsToCollect=55}, feeCollector=EntityId{shard=4, realm=5, num=6}}], " +
+				"maximumUnitsToCollect=55, netOfTransfers=false}, feeCollector=EntityId{shard=4, realm=5, num=6}}], " +
 				"feeScheduleKey=<JEd25519Key: ed25519 hex=6e6f742d612d7265616c2d6665652d7363686564756c652d6b6579>}";
 
 		// expect:

--- a/hedera-node/src/test/java/com/hedera/services/state/submerkle/FcCustomFeeTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/state/submerkle/FcCustomFeeTest.java
@@ -468,12 +468,12 @@ class FcCustomFeeTest {
 		long d = 7;
 		long min = 22;
 		long max = 99;
-		final var aFractionalSpec = new FcCustomFee.FractionalFeeSpec(n, d, min, max,false);
-		final var bFractionalSpec = new FcCustomFee.FractionalFeeSpec(n + 1, d, min, max,false);
-		final var cFractionalSpec = new FcCustomFee.FractionalFeeSpec(n, d + 1, min, max,true);
-		final var dFractionalSpec = new FcCustomFee.FractionalFeeSpec(n, d, min + 1, max,false);
-		final var eFractionalSpec = new FcCustomFee.FractionalFeeSpec(n, d, min, max + 1,true);
-		final var fFractionalSpec = new FcCustomFee.FractionalFeeSpec(n, d, min, max,false);
+		final var aFractionalSpec = new FcCustomFee.FractionalFeeSpec(n, d, min, max, false);
+		final var bFractionalSpec = new FcCustomFee.FractionalFeeSpec(n + 1, d, min, max, false);
+		final var cFractionalSpec = new FcCustomFee.FractionalFeeSpec(n, d + 1, min, max, true);
+		final var dFractionalSpec = new FcCustomFee.FractionalFeeSpec(n, d, min + 1, max, false);
+		final var eFractionalSpec = new FcCustomFee.FractionalFeeSpec(n, d, min, max + 1, true);
+		final var fFractionalSpec = new FcCustomFee.FractionalFeeSpec(n, d, min, max, false);
 		final var gFractionalSpec = aFractionalSpec;
 
 		assertEquals(aFractionalSpec, fFractionalSpec);

--- a/hedera-node/src/test/java/com/hedera/services/state/submerkle/FcCustomFeeTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/state/submerkle/FcCustomFeeTest.java
@@ -55,6 +55,7 @@ class FcCustomFeeTest {
 	private final long fixedUnitsToCollect = 7;
 	private final long minimumUnitsToCollect = 1;
 	private final long maximumUnitsToCollect = 55;
+	private final boolean netOfTransfers = false;
 	private final EntityId denom = new EntityId(1, 2, 3);
 	private final TokenID grpcDenom = denom.toGrpcTokenId();
 	private final EntityId feeCollector = new EntityId(4, 5, 6);
@@ -116,6 +117,7 @@ class FcCustomFeeTest {
 				validDenominator,
 				minimumUnitsToCollect,
 				maximumUnitsToCollect,
+				netOfTransfers,
 				feeCollector);
 
 		final var actual = fractionalFee.asGrpc();
@@ -133,6 +135,7 @@ class FcCustomFeeTest {
 				validDenominator,
 				minimumUnitsToCollect,
 				Long.MAX_VALUE,
+				netOfTransfers,
 				feeCollector);
 
 		final var actual = fractionalFee.asGrpc();
@@ -147,12 +150,14 @@ class FcCustomFeeTest {
 				validDenominator,
 				minimumUnitsToCollect,
 				maximumUnitsToCollect,
+				netOfTransfers,
 				feeCollector);
 		final var expectedNoExplicitMaxSubject = FcCustomFee.fractionalFee(
 				validNumerator,
 				validDenominator,
 				minimumUnitsToCollect,
 				Long.MAX_VALUE,
+				netOfTransfers,
 				feeCollector);
 		final var grpcWithExplicitMax = builder.withFractionalFee(
 				fractional(validNumerator, validDenominator)
@@ -176,6 +181,7 @@ class FcCustomFeeTest {
 				validDenominator,
 				minimumUnitsToCollect,
 				maximumUnitsToCollect,
+				netOfTransfers,
 				feeCollector);
 		final ByteArrayOutputStream baos = new ByteArrayOutputStream();
 		final var dos = new SerializableDataOutputStream(baos);
@@ -250,7 +256,8 @@ class FcCustomFeeTest {
 				validNumerator,
 				validDenominator,
 				minimumUnitsToCollect,
-				maximumUnitsToCollect);
+				maximumUnitsToCollect,
+				netOfTransfers);
 		given(din.readByte()).willReturn(FcCustomFee.FRACTIONAL_CODE);
 		given(din.readLong())
 				.willReturn(validNumerator)
@@ -276,6 +283,7 @@ class FcCustomFeeTest {
 				validDenominator,
 				minimumUnitsToCollect,
 				maximumUnitsToCollect,
+				netOfTransfers,
 				feeCollector);
 
 		subject.serialize(dos);
@@ -327,12 +335,14 @@ class FcCustomFeeTest {
 				validNumerator,
 				validDenominator,
 				minimumUnitsToCollect,
-				maximumUnitsToCollect);
+				maximumUnitsToCollect,
+				netOfTransfers);
 		final var fractionalSubject = FcCustomFee.fractionalFee(
 				validNumerator,
 				validDenominator,
 				minimumUnitsToCollect,
 				maximumUnitsToCollect,
+				netOfTransfers,
 				feeCollector);
 
 		assertEquals(FcCustomFee.FeeType.FRACTIONAL_FEE, fractionalSubject.getFeeType());
@@ -347,10 +357,11 @@ class FcCustomFeeTest {
 				validNumerator,
 				validDenominator,
 				minimumUnitsToCollect,
-				maximumUnitsToCollect);
+				maximumUnitsToCollect,
+				netOfTransfers);
 		final var fixedSpec = new FcCustomFee.FixedFeeSpec(fixedUnitsToCollect, denom);
 		final var desiredFracRepr = "FractionalFeeSpec{numerator=5, denominator=100, " +
-				"minimumUnitsToCollect=1, maximumUnitsToCollect=55}";
+				"minimumUnitsToCollect=1, maximumUnitsToCollect=55, netOfTransfers=false}";
 		final var desiredFixedRepr = "FixedFeeSpec{unitsToCollect=7, tokenDenomination=1.2.3}";
 
 		assertEquals(desiredFixedRepr, fixedSpec.toString());
@@ -369,32 +380,38 @@ class FcCustomFeeTest {
 				validNumerator,
 				invalidDenominator,
 				minimumUnitsToCollect,
-				maximumUnitsToCollect));
+				maximumUnitsToCollect,
+				netOfTransfers));
 		assertThrows(IllegalArgumentException.class, () -> new FcCustomFee.FractionalFeeSpec(
 				-validNumerator,
 				validDenominator,
 				minimumUnitsToCollect,
-				maximumUnitsToCollect));
+				maximumUnitsToCollect,
+				netOfTransfers));
 		assertThrows(IllegalArgumentException.class, () -> new FcCustomFee.FractionalFeeSpec(
 				validNumerator,
 				-validDenominator,
 				minimumUnitsToCollect,
-				maximumUnitsToCollect));
+				maximumUnitsToCollect,
+				netOfTransfers));
 		assertThrows(IllegalArgumentException.class, () -> new FcCustomFee.FractionalFeeSpec(
 				validNumerator,
 				validDenominator,
 				-minimumUnitsToCollect,
-				maximumUnitsToCollect));
+				maximumUnitsToCollect,
+				netOfTransfers));
 		assertThrows(IllegalArgumentException.class, () -> new FcCustomFee.FractionalFeeSpec(
 				validNumerator,
 				validDenominator,
 				minimumUnitsToCollect,
-				-maximumUnitsToCollect));
+				-maximumUnitsToCollect,
+				netOfTransfers));
 		assertThrows(IllegalArgumentException.class, () -> new FcCustomFee.FractionalFeeSpec(
 				validNumerator,
 				validDenominator,
 				maximumUnitsToCollect,
-				minimumUnitsToCollect));
+				minimumUnitsToCollect,
+				netOfTransfers));
 	}
 
 	@Test
@@ -403,7 +420,8 @@ class FcCustomFeeTest {
 				validNumerator,
 				validDenominator,
 				minimumUnitsToCollect,
-				maximumUnitsToCollect);
+				maximumUnitsToCollect,
+				netOfTransfers);
 		final var fixedSpec = new FcCustomFee.FixedFeeSpec(fixedUnitsToCollect, denom);
 
 		assertEquals(validNumerator, fractionalSpec.getNumerator());
@@ -420,7 +438,8 @@ class FcCustomFeeTest {
 				validNumerator,
 				validDenominator,
 				minimumUnitsToCollect,
-				maximumUnitsToCollect);
+				maximumUnitsToCollect,
+				netOfTransfers);
 		final var fixedSpec = new FcCustomFee.FixedFeeSpec(fixedUnitsToCollect, denom);
 
 		assertDoesNotThrow(fractionalSpec::hashCode);
@@ -449,12 +468,12 @@ class FcCustomFeeTest {
 		long d = 7;
 		long min = 22;
 		long max = 99;
-		final var aFractionalSpec = new FcCustomFee.FractionalFeeSpec(n, d, min, max);
-		final var bFractionalSpec = new FcCustomFee.FractionalFeeSpec(n + 1, d, min, max);
-		final var cFractionalSpec = new FcCustomFee.FractionalFeeSpec(n, d + 1, min, max);
-		final var dFractionalSpec = new FcCustomFee.FractionalFeeSpec(n, d, min + 1, max);
-		final var eFractionalSpec = new FcCustomFee.FractionalFeeSpec(n, d, min, max + 1);
-		final var fFractionalSpec = new FcCustomFee.FractionalFeeSpec(n, d, min, max);
+		final var aFractionalSpec = new FcCustomFee.FractionalFeeSpec(n, d, min, max,false);
+		final var bFractionalSpec = new FcCustomFee.FractionalFeeSpec(n + 1, d, min, max,false);
+		final var cFractionalSpec = new FcCustomFee.FractionalFeeSpec(n, d + 1, min, max,true);
+		final var dFractionalSpec = new FcCustomFee.FractionalFeeSpec(n, d, min + 1, max,false);
+		final var eFractionalSpec = new FcCustomFee.FractionalFeeSpec(n, d, min, max + 1,true);
+		final var fFractionalSpec = new FcCustomFee.FractionalFeeSpec(n, d, min, max,false);
 		final var gFractionalSpec = aFractionalSpec;
 
 		assertEquals(aFractionalSpec, fFractionalSpec);
@@ -478,7 +497,7 @@ class FcCustomFeeTest {
 		final var aCustomFee = FcCustomFee.fixedFee(fixedUnitsToCollect, denom, aFeeCollector);
 		final var bCustomFee = FcCustomFee.fixedFee(fixedUnitsToCollect + 1, denom, aFeeCollector);
 		final var cCustomFee = FcCustomFee.fixedFee(fixedUnitsToCollect, denom, bFeeCollector);
-		final var dCustomFee = FcCustomFee.fractionalFee(n, d, min, max, aFeeCollector);
+		final var dCustomFee = FcCustomFee.fractionalFee(n, d, min, max, false, aFeeCollector);
 		final var eCustomFee = aCustomFee;
 		final var fCustomFee = FcCustomFee.fixedFee(fixedUnitsToCollect, denom, aFeeCollector);
 
@@ -500,12 +519,13 @@ class FcCustomFeeTest {
 				validDenominator,
 				minimumUnitsToCollect,
 				maximumUnitsToCollect,
+				netOfTransfers,
 				feeCollector);
 		final var fixedHbarFee = FcCustomFee.fixedFee(fixedUnitsToCollect, null, feeCollector);
 		final var fixedHtsFee = FcCustomFee.fixedFee(fixedUnitsToCollect, denom, feeCollector);
 		final var expectedFractional = "FcCustomFee{feeType=FRACTIONAL_FEE, " +
 				"fractionalFee=FractionalFeeSpec{numerator=5, " +
-				"denominator=100, minimumUnitsToCollect=1, maximumUnitsToCollect=55}, " +
+				"denominator=100, minimumUnitsToCollect=1, maximumUnitsToCollect=55, netOfTransfers=false}, " +
 				"feeCollector=EntityId{shard=4, realm=5, num=6}}";
 		final var expectedFixedHbar = "FcCustomFee{feeType=FIXED_FEE, fixedFee=FixedFeeSpec{unitsToCollect=7, " +
 				"tokenDenomination=ℏ}, feeCollector=EntityId{shard=4, realm=5, num=6}}";

--- a/hedera-node/src/test/java/com/hedera/services/txns/crypto/CryptoTransferTransitionLogicTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/txns/crypto/CryptoTransferTransitionLogicTest.java
@@ -150,7 +150,7 @@ class CryptoTransferTransitionLogicTest {
 		givenValidTxnCtx();
 		given(accessor.getTxn()).willReturn(cryptoTransferTxn);
 		// and:
-		given(impliedTransfersMarshal.unmarshalFromGrpc(cryptoTransferTxn.getCryptoTransfer()))
+		given(impliedTransfersMarshal.unmarshalFromGrpc(cryptoTransferTxn.getCryptoTransfer(), ledger))
 				.willReturn(impliedTransfers);
 
 		// when:
@@ -184,7 +184,7 @@ class CryptoTransferTransitionLogicTest {
 		givenValidTxnCtx();
 		given(accessor.getTxn()).willReturn(cryptoTransferTxn);
 		// and:
-		given(impliedTransfersMarshal.unmarshalFromGrpc(cryptoTransferTxn.getCryptoTransfer()))
+		given(impliedTransfersMarshal.unmarshalFromGrpc(cryptoTransferTxn.getCryptoTransfer(), ledger))
 				.willReturn(impliedTransfers);
 
 		// when:
@@ -204,7 +204,7 @@ class CryptoTransferTransitionLogicTest {
 		givenValidTxnCtx();
 		given(accessor.getTxn()).willReturn(cryptoTransferTxn);
 		// and:
-		given(impliedTransfersMarshal.unmarshalFromGrpc(cryptoTransferTxn.getCryptoTransfer()))
+		given(impliedTransfersMarshal.unmarshalFromGrpc(cryptoTransferTxn.getCryptoTransfer(), ledger))
 				.willReturn(impliedTransfers);
 
 		// when & then:

--- a/hedera-node/src/test/java/com/hedera/services/utils/SignedTxnAccessorTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/utils/SignedTxnAccessorTest.java
@@ -355,9 +355,9 @@ class SignedTxnAccessorTest {
 				fixedFee(1, null, collector),
 				fixedFee(2, aDenom, collector),
 				fixedFee(2, bDenom, collector),
-				fractionalFee(1, 2, 1, 2, collector),
-				fractionalFee(1, 3, 1, 2, collector),
-				fractionalFee(1, 4, 1, 2, collector)
+				fractionalFee(1, 2, 1, 2, false, collector),
+				fractionalFee(1, 3, 1, 2, false, collector),
+				fractionalFee(1, 4, 1, 2, false, collector)
 		).stream().map(FcCustomFee::asGrpc).collect(toList());
 	}
 

--- a/hedera-node/src/test/java/com/hedera/test/factories/scenarios/TokenCreateScenarios.java
+++ b/hedera-node/src/test/java/com/hedera/test/factories/scenarios/TokenCreateScenarios.java
@@ -105,6 +105,7 @@ public enum TokenCreateScenarios implements TxnHandlingScenario {
 							.plusCustomFee(fractionalFee(
 									1, 2,
 									3, 4,
+									false,
 									collector))
 							.get()
 			));

--- a/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/token/CustomFeeSpecs.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/token/CustomFeeSpecs.java
@@ -51,9 +51,21 @@ public class CustomFeeSpecs {
 			long denominator,
 			long min,
 			OptionalLong max,
+			boolean netOfTransfers,
 			String collector
 	) {
-		return spec -> builtFractional(numerator, denominator, min, max, collector, spec);
+		return spec -> builtFractional(numerator, denominator, min, max, false, collector, spec);
+	}
+
+	public static Function<HapiApiSpec, CustomFee> fractionalFeeTemp(
+			long numerator,
+			long denominator,
+			long min,
+			OptionalLong max,
+			boolean netOfTransfers,
+			String collector
+	) {
+		return spec -> builtFractional(numerator, denominator, min, max, netOfTransfers, collector, spec);
 	}
 
 	public static Function<HapiApiSpec, CustomFee> incompleteCustomFee(String collector) {
@@ -91,6 +103,7 @@ public class CustomFeeSpecs {
 			long denominator,
 			long min,
 			OptionalLong max,
+			boolean netOfTransfer,
 			String collector,
 			HapiApiSpec spec
 	) {
@@ -99,7 +112,8 @@ public class CustomFeeSpecs {
 				.setFractionalAmount(Fraction.newBuilder()
 						.setNumerator(numerator)
 						.setDenominator(denominator))
-				.setMinimumAmount(min);
+				.setMinimumAmount(min)
+				.setNetOfTransfers(netOfTransfer);
 		max.ifPresent(fractionalBuilder::setMaximumAmount);
 		return  CustomFee.newBuilder()
 				.setFractionalFee(fractionalBuilder)

--- a/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/token/CustomFeeSpecs.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/token/CustomFeeSpecs.java
@@ -54,20 +54,9 @@ public class CustomFeeSpecs {
 			boolean netOfTransfers,
 			String collector
 	) {
-		return spec -> builtFractional(numerator, denominator, min, max, false, collector, spec);
-	}
-
-	public static Function<HapiApiSpec, CustomFee> fractionalFeeTemp(
-			long numerator,
-			long denominator,
-			long min,
-			OptionalLong max,
-			boolean netOfTransfers,
-			String collector
-	) {
 		return spec -> builtFractional(numerator, denominator, min, max, netOfTransfers, collector, spec);
 	}
-
+	
 	public static Function<HapiApiSpec, CustomFee> incompleteCustomFee(String collector) {
 		return spec -> buildIncompleteCustomFee(collector, spec);
 	}

--- a/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/token/CustomFeeTests.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/token/CustomFeeTests.java
@@ -61,7 +61,7 @@ public class CustomFeeTests {
 			String collector
 	) {
 		return (spec, actual) -> {
-			final var expected = builtFractional(numerator, denominator, min, max, collector, spec);
+			final var expected = builtFractional(numerator, denominator, min, max, false, collector, spec);
 			failUnlessPresent("fractional", actual, expected);
 		};
 	}

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/TransferWithCustomFees.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/TransferWithCustomFees.java
@@ -135,6 +135,7 @@ public class TransferWithCustomFees extends HapiApiSuite {
 								.withCustom(fractionalFee(
 										numerator, denominator,
 										minHtsFee, OptionalLong.of(maxHtsFee),
+										false,
 										htsCollector)),
 
 						tokenAssociate(tokenReceiver, token),

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/token/Hip18TransactSpecs.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/token/Hip18TransactSpecs.java
@@ -1,0 +1,740 @@
+package com.hedera.services.bdd.suites.token;
+
+/*-
+ * ‌
+ * Hedera Services Test Clients
+ * ​
+ * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import com.google.protobuf.ByteString;
+import com.hedera.services.bdd.spec.HapiApiSpec;
+import com.hedera.services.bdd.suites.HapiApiSuite;
+import com.hederahashgraph.api.proto.java.TokenType;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.List;
+import java.util.OptionalLong;
+
+import static com.hedera.services.bdd.spec.HapiApiSpec.defaultHapiSpec;
+import static com.hedera.services.bdd.spec.assertions.AccountInfoAsserts.changeFromSnapshot;
+import static com.hedera.services.bdd.spec.queries.QueryVerbs.getAccountBalance;
+import static com.hedera.services.bdd.spec.queries.QueryVerbs.getContractInfo;
+import static com.hedera.services.bdd.spec.queries.QueryVerbs.getTxnRecord;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.contractCreate;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoCreate;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoTransfer;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.mintToken;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.tokenAssociate;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.tokenCreate;
+import static com.hedera.services.bdd.spec.transactions.token.CustomFeeSpecs.fixedHbarFee;
+import static com.hedera.services.bdd.spec.transactions.token.CustomFeeSpecs.fixedHtsFee;
+import static com.hedera.services.bdd.spec.transactions.token.CustomFeeSpecs.fractionalFee;
+import static com.hedera.services.bdd.spec.transactions.token.CustomFeeSpecs.fractionalFeeTemp;
+import static com.hedera.services.bdd.spec.transactions.token.TokenMovement.moving;
+import static com.hedera.services.bdd.spec.transactions.token.TokenMovement.movingUnique;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.balanceSnapshot;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.newKeyNamed;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INSUFFICIENT_PAYER_BALANCE_FOR_CUSTOM_FEE;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SUCCESS;
+
+public class Hip18TransactSpecs extends HapiApiSuite {
+	private static final Logger log = LogManager.getLogger(Hip18TransactSpecs.class);
+
+	private static final String SUPPLY_KEY = "antique";
+
+	private static final String TOKEN_TREASURY = "treasury";
+	private static final String ALICE = "Alice";
+	private static final String BOB = "Bob";
+	private static final String CLAIRE = "Claire";
+	private static final String DEBBIE = "Debbie";
+	private static final String EDGAR = "Edgar";
+	private static final String FERN = "Fern";
+
+	private static final String TOKEN_WITH_FRACTIONAL_FEE = "TokenWithFractionalFee";
+	private static final String TOKEN_WITH_HBAR_FEE = "TokenWithHbarFee";
+	private static final String SIMPLE_HTS_FEE_TOKEN = "SimpleHtsFeeToken";
+	private static final String COMMISSION_PAYMENT_TOKEN = "commissionPaymentToken";
+	private static final String TOKEN_WITH_NESTED_FEE = "TokenWithNestedFee";
+	private static final String FEE_TOKEN = "FeeToken";
+	private static final String TOKEN_WITH_HTS_FEE = "TokenWithHtsFee";
+	private static final String TOP_LEVEL_TOKEN = "TopLevelToken";
+
+	private static final String FIRST_COLLECTOR_FOR_TOP_LEVEL = "AFeeCollector";
+	private static final String SECOND_COLLECTOR_FOR_TOP_LEVEL = "BFeeCollector";
+	private static final String TREASURY_FOR_TOKEN = "TokenTreasury";
+	private static final String COLLECTOR_FOR_TOKEN = "AnotherTokenTreasury";
+	private static final String TREASURY_FOR_TOP_LEVEL_COLLECTION = "TokenTreasury";
+	private static final String TREASURY_FOR_NESTED_COLLECTION = "NestedTokenTreasury";
+	private static final String TREASURY_FOR_TOP_LEVEL = "TokenTreasury";
+	private static final String COLLECTOR_FOR_TOP_LEVEL = "FeeCollector";
+	private static final String NON_TREASURY = "nonTreasury";
+
+	private static final String TXN_FROM_TREASURY = "txnFromTreasury";
+	private static final String TXN_FROM_BOB = "txnFromBob";
+	private static final String TXN_FROM_ALICE = "txnFromAlice";
+	private static final String TXN_FROM_CLAIRE = "txnFromClaire";
+	private static final String TXN_FROM_DEBBIE = "txnFromDebbie";
+	private static final String TXN_FROM_EDGAR = "txnFromEdgar";
+	private static final String TXN_FROM_NON_TREASURY = "txnFromNonTreasury";
+	private static final String TXN_FROM_COLLECTOR = "txnFromCollector";
+	
+	public static void main(String... args) {
+		new Hip18TransactSpecs().runSuiteSync();
+	}
+
+	@Override
+	protected List<HapiApiSpec> getSpecsInSuite() {
+		return List.of(new HapiApiSpec[] {
+						fixedHbarCaseStudy(),
+						fractionalChargeFeeToReceiver(),
+						fractionalChargeFeeToSenderNotEnough(),
+						fractionalChargeFeeToSenderHappy(),
+						simpleHtsFeeCaseStudy(),
+						nestedHbarCaseStudy(),
+						nestedFractionalCaseStudy(),
+						nestedHtsCaseStudy(),
+						treasuriesAreExemptFromAllCustomFees(),
+						collectorsAreExemptFromTheirOwnFeesButNotOthers(),
+				}
+		);
+	}
+
+	public HapiApiSpec fixedHbarCaseStudy() {
+		return defaultHapiSpec("FixedHbarCaseStudy")
+				.given(
+						newKeyNamed(SUPPLY_KEY),
+						cryptoCreate(ALICE).balance(ONE_HUNDRED_HBARS),
+						cryptoCreate(BOB),
+						cryptoCreate(TREASURY_FOR_TOKEN).balance(ONE_HUNDRED_HBARS),
+						tokenCreate(TOKEN_WITH_HBAR_FEE)
+								.tokenType(TokenType.NON_FUNGIBLE_UNIQUE)
+								.supplyKey(SUPPLY_KEY)
+								.initialSupply(0L)
+								.treasury(TREASURY_FOR_TOKEN)
+								.withCustom(fixedHbarFee(ONE_HBAR, TREASURY_FOR_TOKEN)),
+						mintToken(TOKEN_WITH_HBAR_FEE, List.of(ByteString.copyFromUtf8("First!"))),
+						mintToken(TOKEN_WITH_HBAR_FEE, List.of(ByteString.copyFromUtf8("Second!"))),
+						tokenAssociate(ALICE, TOKEN_WITH_HBAR_FEE),
+						tokenAssociate(BOB, TOKEN_WITH_HBAR_FEE),
+						cryptoTransfer(movingUnique(TOKEN_WITH_HBAR_FEE, 2L).between(TREASURY_FOR_TOKEN, ALICE))
+								.payingWith(GENESIS)
+								.fee(ONE_HBAR)
+								.via(TXN_FROM_TREASURY)
+				).when(
+						cryptoTransfer(
+								movingUnique(TOKEN_WITH_HBAR_FEE, 2L).between(ALICE, BOB)
+						)
+								.payingWith(GENESIS)
+								.fee(ONE_HBAR)
+								.via(TXN_FROM_ALICE)
+				).then(
+						getTxnRecord(TXN_FROM_TREASURY)
+								.hasNftTransfer(TOKEN_WITH_HBAR_FEE, TREASURY_FOR_TOKEN, ALICE, 2L),
+						getTxnRecord(TXN_FROM_ALICE)
+								.hasNftTransfer(TOKEN_WITH_HBAR_FEE, ALICE, BOB, 2L)
+								.hasAssessedCustomFee(HBAR_TOKEN_SENTINEL, TREASURY_FOR_TOKEN, ONE_HBAR)
+								.hasHbarAmount(TREASURY_FOR_TOKEN, ONE_HBAR)
+								.hasHbarAmount(ALICE, -ONE_HBAR),
+						getAccountBalance(BOB)
+								.hasTokenBalance(TOKEN_WITH_HBAR_FEE, 1L),
+						getAccountBalance(ALICE)
+								.hasTokenBalance(TOKEN_WITH_HBAR_FEE, 0L)
+								.hasTinyBars(ONE_HUNDRED_HBARS - ONE_HBAR),
+						getAccountBalance(TREASURY_FOR_TOKEN)
+								.hasTokenBalance(TOKEN_WITH_HBAR_FEE, 1L)
+								.hasTinyBars(ONE_HUNDRED_HBARS + ONE_HBAR)
+				);
+	}
+
+	public HapiApiSpec fractionalChargeFeeToSenderHappy() {
+		return defaultHapiSpec("fractionalChargeFeeToSenderHappy")
+				.given(
+						cryptoCreate(ALICE),
+						cryptoCreate(BOB),
+						cryptoCreate(TREASURY_FOR_TOKEN),
+						cryptoCreate(COLLECTOR_FOR_TOKEN),
+						tokenCreate(TOKEN_WITH_FRACTIONAL_FEE)
+								.initialSupply(Long.MAX_VALUE)
+								.treasury(TREASURY_FOR_TOKEN)
+								.withCustom(fractionalFeeTemp(1L, 100L, 1L,
+										OptionalLong.of(5L), true, TREASURY_FOR_TOKEN)),
+
+						tokenAssociate(ALICE, TOKEN_WITH_FRACTIONAL_FEE),
+						tokenAssociate(COLLECTOR_FOR_TOKEN, TOKEN_WITH_FRACTIONAL_FEE),
+						tokenAssociate(BOB, TOKEN_WITH_FRACTIONAL_FEE),
+						cryptoTransfer(moving(1_000_000L, TOKEN_WITH_FRACTIONAL_FEE).between(TREASURY_FOR_TOKEN, BOB))
+								.payingWith(TREASURY_FOR_TOKEN)
+								.fee(ONE_HBAR)
+								.via(TXN_FROM_TREASURY)
+				).when(
+						cryptoTransfer(
+								moving(1_000L, TOKEN_WITH_FRACTIONAL_FEE).between(BOB, ALICE)
+						)
+								.payingWith(BOB)
+								.fee(ONE_HBAR)
+								.via(TXN_FROM_BOB)
+						.hasKnownStatus(SUCCESS)
+				).then(
+						getTxnRecord(TXN_FROM_TREASURY).logged()
+								.hasTokenAmount(TOKEN_WITH_FRACTIONAL_FEE, BOB, 1_000_000L)
+								.hasTokenAmount(TOKEN_WITH_FRACTIONAL_FEE, TREASURY_FOR_TOKEN, -1_000_000L),
+						getTxnRecord(TXN_FROM_BOB)
+								.hasTokenAmount(TOKEN_WITH_FRACTIONAL_FEE, BOB, -1_005L)
+								.hasTokenAmount(TOKEN_WITH_FRACTIONAL_FEE, ALICE, 1000L)
+								.hasAssessedCustomFee(TOKEN_WITH_FRACTIONAL_FEE, TREASURY_FOR_TOKEN, 5L)
+								.hasTokenAmount(TOKEN_WITH_FRACTIONAL_FEE, TREASURY_FOR_TOKEN, 5L),
+						getAccountBalance(ALICE)
+								.hasTokenBalance(TOKEN_WITH_FRACTIONAL_FEE, 1_000L),
+						getAccountBalance(BOB)
+								.hasTokenBalance(TOKEN_WITH_FRACTIONAL_FEE, 1_000_000L - 1_005L),
+						getAccountBalance(TREASURY_FOR_TOKEN)
+								.hasTokenBalance(TOKEN_WITH_FRACTIONAL_FEE, Long.MAX_VALUE - 1_000_000L + 5L)
+				);
+	}
+
+
+	public HapiApiSpec fractionalChargeFeeToSenderNotEnough() {
+		return defaultHapiSpec("fractionalChargeFeeToSenderNotEnough")
+				.given(
+						cryptoCreate(ALICE),
+						cryptoCreate(BOB),
+						cryptoCreate(TREASURY_FOR_TOKEN),
+						cryptoCreate(COLLECTOR_FOR_TOKEN),
+						tokenCreate(TOKEN_WITH_FRACTIONAL_FEE)
+								.initialSupply(Long.MAX_VALUE)
+								.treasury(TREASURY_FOR_TOKEN)
+								.withCustom(fractionalFeeTemp(1L, 100L, 1L,
+										OptionalLong.of(5L), true, TREASURY_FOR_TOKEN)),
+
+						tokenAssociate(ALICE, TOKEN_WITH_FRACTIONAL_FEE),
+						tokenAssociate(COLLECTOR_FOR_TOKEN, TOKEN_WITH_FRACTIONAL_FEE),
+						tokenAssociate(BOB, TOKEN_WITH_FRACTIONAL_FEE),
+						cryptoTransfer(moving(1_000L, TOKEN_WITH_FRACTIONAL_FEE).between(TREASURY_FOR_TOKEN, BOB))
+								.payingWith(TREASURY_FOR_TOKEN)
+								.fee(ONE_HBAR)
+								.via(TXN_FROM_TREASURY)
+				).when(
+						cryptoTransfer(
+								moving(1_000L, TOKEN_WITH_FRACTIONAL_FEE).between(BOB, ALICE)
+						)
+								.payingWith(BOB)
+								.fee(ONE_HBAR)
+								.via(TXN_FROM_BOB)
+								.hasKnownStatus(INSUFFICIENT_PAYER_BALANCE_FOR_CUSTOM_FEE)
+				).then(
+						getTxnRecord(TXN_FROM_TREASURY).logged()
+								.hasTokenAmount(TOKEN_WITH_FRACTIONAL_FEE, BOB, 1_000L)
+								.hasTokenAmount(TOKEN_WITH_FRACTIONAL_FEE, TREASURY_FOR_TOKEN, -1_000L),
+						getAccountBalance(ALICE)
+								.hasTokenBalance(TOKEN_WITH_FRACTIONAL_FEE, 0L),
+						getAccountBalance(BOB)
+								.hasTokenBalance(TOKEN_WITH_FRACTIONAL_FEE,  1_000L),
+						getAccountBalance(TREASURY_FOR_TOKEN)
+								.hasTokenBalance(TOKEN_WITH_FRACTIONAL_FEE, Long.MAX_VALUE - 1_000L)
+				);
+	}
+
+
+
+	public HapiApiSpec fractionalChargeFeeToSenderHappyPath() {
+		return defaultHapiSpec("fractionalChargeFeeToSender")
+				.given(
+						cryptoCreate(ALICE),
+						cryptoCreate(BOB),
+						cryptoCreate(TREASURY_FOR_TOKEN),
+						cryptoCreate(COLLECTOR_FOR_TOKEN),
+						tokenCreate(TOKEN_WITH_FRACTIONAL_FEE)
+								.initialSupply(Long.MAX_VALUE)
+								.treasury(TREASURY_FOR_TOKEN)
+								.withCustom(fractionalFeeTemp(1L, 100L, 1L,
+										OptionalLong.of(5L), true, TREASURY_FOR_TOKEN)),
+
+						tokenAssociate(ALICE, TOKEN_WITH_FRACTIONAL_FEE),
+						tokenAssociate(COLLECTOR_FOR_TOKEN, TOKEN_WITH_FRACTIONAL_FEE),
+						tokenAssociate(BOB, TOKEN_WITH_FRACTIONAL_FEE),
+						cryptoTransfer(moving(1_000L, TOKEN_WITH_FRACTIONAL_FEE).between(TREASURY_FOR_TOKEN, BOB))
+								.payingWith(TREASURY_FOR_TOKEN)
+								.fee(ONE_HBAR)
+								.via(TXN_FROM_TREASURY)
+				).when(
+						cryptoTransfer(
+								moving(1_000L, TOKEN_WITH_FRACTIONAL_FEE).between(BOB, ALICE)
+						)
+								.payingWith(BOB)
+								.fee(ONE_HBAR)
+								.via(TXN_FROM_BOB)
+								.hasKnownStatus(INSUFFICIENT_PAYER_BALANCE_FOR_CUSTOM_FEE)
+				).then(
+						getTxnRecord(TXN_FROM_TREASURY).logged()
+								.hasTokenAmount(TOKEN_WITH_FRACTIONAL_FEE, BOB, 1_000L)
+								.hasTokenAmount(TOKEN_WITH_FRACTIONAL_FEE, TREASURY_FOR_TOKEN, -1_000L),
+						getTxnRecord(TXN_FROM_BOB)
+								.hasTokenAmount(TOKEN_WITH_FRACTIONAL_FEE, BOB, -1_000L)
+								.hasTokenAmount(TOKEN_WITH_FRACTIONAL_FEE, ALICE, 1000L)
+								.hasAssessedCustomFee(TOKEN_WITH_FRACTIONAL_FEE, TREASURY_FOR_TOKEN, 5L)
+								.hasTokenAmount(TOKEN_WITH_FRACTIONAL_FEE, TREASURY_FOR_TOKEN, 5L),
+						getAccountBalance(ALICE)
+								.hasTokenBalance(TOKEN_WITH_FRACTIONAL_FEE, 0L),
+						getAccountBalance(BOB)
+								.hasTokenBalance(TOKEN_WITH_FRACTIONAL_FEE,  1_000L),
+						getAccountBalance(TREASURY_FOR_TOKEN)
+								.hasTokenBalance(TOKEN_WITH_FRACTIONAL_FEE, Long.MAX_VALUE - 1_000L)
+				);
+	}
+
+
+
+	public HapiApiSpec fractionalChargeFeeToReceiver() {
+		return defaultHapiSpec("fractionalChargeFeeToReceiver")
+				.given(
+						cryptoCreate(ALICE),
+						cryptoCreate(BOB),
+						cryptoCreate(TREASURY_FOR_TOKEN),
+						cryptoCreate(COLLECTOR_FOR_TOKEN),
+						tokenCreate(TOKEN_WITH_FRACTIONAL_FEE)
+								.initialSupply(Long.MAX_VALUE)
+								.treasury(TREASURY_FOR_TOKEN)
+								.withCustom(fractionalFeeTemp(1L, 100L, 1L, OptionalLong.of(5L), false,
+										TREASURY_FOR_TOKEN)),
+
+
+						tokenAssociate(ALICE, TOKEN_WITH_FRACTIONAL_FEE),
+						tokenAssociate(COLLECTOR_FOR_TOKEN, TOKEN_WITH_FRACTIONAL_FEE),
+						tokenAssociate(BOB, TOKEN_WITH_FRACTIONAL_FEE),
+						cryptoTransfer(moving(1_000_000L, TOKEN_WITH_FRACTIONAL_FEE).between(TREASURY_FOR_TOKEN, BOB))
+								.payingWith(TREASURY_FOR_TOKEN)
+								.fee(ONE_HBAR)
+								.via(TXN_FROM_TREASURY)
+				).when(
+						cryptoTransfer(
+								moving(1_000L, TOKEN_WITH_FRACTIONAL_FEE).between(BOB, ALICE)
+						)
+								.payingWith(BOB)
+								.fee(ONE_HBAR)
+								.via(TXN_FROM_BOB)
+								.hasKnownStatus(SUCCESS)
+				).then(
+						getTxnRecord(TXN_FROM_TREASURY).logged()
+								.hasTokenAmount(TOKEN_WITH_FRACTIONAL_FEE, BOB, 1_000_000L)
+								.hasTokenAmount(TOKEN_WITH_FRACTIONAL_FEE, TREASURY_FOR_TOKEN, -1_000_000L),
+						getTxnRecord(TXN_FROM_BOB)
+								.hasTokenAmount(TOKEN_WITH_FRACTIONAL_FEE, BOB, -1_000L)
+								.hasTokenAmount(TOKEN_WITH_FRACTIONAL_FEE, ALICE, 995L)
+								.hasAssessedCustomFee(TOKEN_WITH_FRACTIONAL_FEE, TREASURY_FOR_TOKEN, 5L)
+								.hasTokenAmount(TOKEN_WITH_FRACTIONAL_FEE, TREASURY_FOR_TOKEN, 5L),
+						getAccountBalance(ALICE)
+								.hasTokenBalance(TOKEN_WITH_FRACTIONAL_FEE, 995L),
+						getAccountBalance(BOB)
+								.hasTokenBalance(TOKEN_WITH_FRACTIONAL_FEE, 1_000_000L - 1_000L),
+						getAccountBalance(TREASURY_FOR_TOKEN)
+								.hasTokenBalance(TOKEN_WITH_FRACTIONAL_FEE, Long.MAX_VALUE - 1_000_000L + 5L)
+				);
+	}
+
+
+	public HapiApiSpec simpleHtsFeeCaseStudy() {
+		return defaultHapiSpec("SimpleHtsFeeCaseStudy")
+				.given(
+						cryptoCreate(CLAIRE),
+						cryptoCreate(DEBBIE),
+						cryptoCreate(TREASURY_FOR_TOKEN),
+						tokenCreate(COMMISSION_PAYMENT_TOKEN)
+								.initialSupply(Long.MAX_VALUE)
+								.treasury(TREASURY_FOR_TOKEN),
+						tokenCreate(SIMPLE_HTS_FEE_TOKEN)
+								.initialSupply(Long.MAX_VALUE)
+								.treasury(TREASURY_FOR_TOKEN)
+								.withCustom(fixedHtsFee(2L, COMMISSION_PAYMENT_TOKEN, TREASURY_FOR_TOKEN)),
+						tokenAssociate(CLAIRE, List.of(SIMPLE_HTS_FEE_TOKEN, COMMISSION_PAYMENT_TOKEN)),
+						tokenAssociate(DEBBIE, SIMPLE_HTS_FEE_TOKEN),
+						cryptoTransfer(
+								moving(1_000L, COMMISSION_PAYMENT_TOKEN).between(TREASURY_FOR_TOKEN, CLAIRE),
+								moving(1_000L, SIMPLE_HTS_FEE_TOKEN).between(TREASURY_FOR_TOKEN, CLAIRE)
+						)
+								.payingWith(TREASURY_FOR_TOKEN)
+								.fee(ONE_HBAR)
+								.via(TXN_FROM_TREASURY)
+				).when(
+						cryptoTransfer(
+								moving(100L, SIMPLE_HTS_FEE_TOKEN).between(CLAIRE, DEBBIE)
+						)
+								//.payingWith(claire)
+								.fee(ONE_HBAR)
+								.via(TXN_FROM_CLAIRE)
+				).then(
+						getTxnRecord(TXN_FROM_TREASURY)
+								.hasTokenAmount(COMMISSION_PAYMENT_TOKEN, CLAIRE, 1_000L)
+								.hasTokenAmount(COMMISSION_PAYMENT_TOKEN, TREASURY_FOR_TOKEN, -1_000L)
+								.hasTokenAmount(SIMPLE_HTS_FEE_TOKEN, CLAIRE, 1_000L)
+								.hasTokenAmount(SIMPLE_HTS_FEE_TOKEN, TREASURY_FOR_TOKEN, -1_000L),
+						getTxnRecord(TXN_FROM_CLAIRE)
+								.hasTokenAmount(SIMPLE_HTS_FEE_TOKEN, DEBBIE, 100L)
+								.hasTokenAmount(SIMPLE_HTS_FEE_TOKEN, CLAIRE, -100L)
+								.hasAssessedCustomFee(COMMISSION_PAYMENT_TOKEN, TREASURY_FOR_TOKEN, 2L)
+								.hasTokenAmount(COMMISSION_PAYMENT_TOKEN, TREASURY_FOR_TOKEN, 2L)
+								.hasTokenAmount(COMMISSION_PAYMENT_TOKEN, CLAIRE, -2L),
+						getAccountBalance(DEBBIE)
+								.hasTokenBalance(SIMPLE_HTS_FEE_TOKEN, 100L),
+						getAccountBalance(CLAIRE)
+								.hasTokenBalance(SIMPLE_HTS_FEE_TOKEN, 1_000L - 100L)
+								.hasTokenBalance(COMMISSION_PAYMENT_TOKEN, 1_000L - 2L),
+						getAccountBalance(TREASURY_FOR_TOKEN)
+								.hasTokenBalance(SIMPLE_HTS_FEE_TOKEN, Long.MAX_VALUE - 1_000L)
+								.hasTokenBalance(COMMISSION_PAYMENT_TOKEN, Long.MAX_VALUE - 1_000L + 2L)
+				);
+	}
+
+	public HapiApiSpec nestedHbarCaseStudy() {
+		return defaultHapiSpec("NestedHbarCaseStudy")
+				.given(
+						cryptoCreate(DEBBIE).balance(ONE_HUNDRED_HBARS),
+						cryptoCreate(EDGAR),
+						cryptoCreate(TREASURY_FOR_TOP_LEVEL_COLLECTION),
+						cryptoCreate(TREASURY_FOR_NESTED_COLLECTION).balance(ONE_HUNDRED_HBARS),
+						tokenCreate(TOKEN_WITH_HBAR_FEE)
+								.initialSupply(Long.MAX_VALUE)
+								.treasury(TREASURY_FOR_NESTED_COLLECTION)
+								.withCustom(fixedHbarFee(ONE_HBAR, TREASURY_FOR_NESTED_COLLECTION)),
+						tokenAssociate(TREASURY_FOR_TOP_LEVEL_COLLECTION, TOKEN_WITH_HBAR_FEE),
+						tokenCreate(TOKEN_WITH_NESTED_FEE)
+								.initialSupply(Long.MAX_VALUE)
+								.treasury(TREASURY_FOR_TOP_LEVEL_COLLECTION)
+								.withCustom(fixedHtsFee(1L, TOKEN_WITH_HBAR_FEE, TREASURY_FOR_TOP_LEVEL_COLLECTION)),
+						tokenAssociate(DEBBIE, List.of(TOKEN_WITH_HBAR_FEE, TOKEN_WITH_NESTED_FEE)),
+						tokenAssociate(EDGAR, TOKEN_WITH_NESTED_FEE),
+						cryptoTransfer(
+								moving(1_000L, TOKEN_WITH_HBAR_FEE)
+										.between(TREASURY_FOR_NESTED_COLLECTION, DEBBIE),
+								moving(1_000L, TOKEN_WITH_NESTED_FEE)
+										.between(TREASURY_FOR_TOP_LEVEL_COLLECTION, DEBBIE)
+						)
+								.payingWith(GENESIS)
+								.fee(ONE_HBAR)
+								.via(TXN_FROM_TREASURY)
+				).when(
+						cryptoTransfer(
+								moving(1L, TOKEN_WITH_NESTED_FEE).between(DEBBIE, EDGAR)
+						)
+								.payingWith(GENESIS)
+								.fee(ONE_HBAR)
+								.via(TXN_FROM_DEBBIE)
+				).then(
+						getTxnRecord(TXN_FROM_TREASURY)
+								.hasTokenAmount(TOKEN_WITH_HBAR_FEE, DEBBIE, 1_000L)
+								.hasTokenAmount(TOKEN_WITH_HBAR_FEE, TREASURY_FOR_NESTED_COLLECTION, -1_000L)
+								.hasTokenAmount(TOKEN_WITH_NESTED_FEE, DEBBIE, 1_000L)
+								.hasTokenAmount(TOKEN_WITH_NESTED_FEE, TREASURY_FOR_TOP_LEVEL_COLLECTION, -1_000L),
+						getTxnRecord(TXN_FROM_DEBBIE)
+								.hasTokenAmount(TOKEN_WITH_NESTED_FEE, EDGAR, 1L)
+								.hasTokenAmount(TOKEN_WITH_NESTED_FEE, DEBBIE, -1L)
+								.hasAssessedCustomFee(TOKEN_WITH_HBAR_FEE, TREASURY_FOR_TOP_LEVEL_COLLECTION, 1L)
+								.hasTokenAmount(TOKEN_WITH_HBAR_FEE, TREASURY_FOR_TOP_LEVEL_COLLECTION, 1L)
+								.hasTokenAmount(TOKEN_WITH_HBAR_FEE, DEBBIE, -1L)
+								.hasAssessedCustomFee(HBAR_TOKEN_SENTINEL, TREASURY_FOR_NESTED_COLLECTION, ONE_HBAR)
+								.hasHbarAmount(TREASURY_FOR_NESTED_COLLECTION, ONE_HBAR)
+								.hasHbarAmount(DEBBIE, -ONE_HBAR),
+						getAccountBalance(EDGAR)
+								.hasTokenBalance(TOKEN_WITH_NESTED_FEE, 1L),
+						getAccountBalance(DEBBIE)
+								.hasTinyBars(ONE_HUNDRED_HBARS - ONE_HBAR)
+								.hasTokenBalance(TOKEN_WITH_HBAR_FEE, 1_000L - 1L)
+								.hasTokenBalance(TOKEN_WITH_NESTED_FEE, 1_000L - 1L),
+						getAccountBalance(TREASURY_FOR_TOP_LEVEL_COLLECTION)
+								.hasTokenBalance(TOKEN_WITH_NESTED_FEE, Long.MAX_VALUE - 1_000L)
+								.hasTokenBalance(TOKEN_WITH_HBAR_FEE, 1L),
+						getAccountBalance(TREASURY_FOR_NESTED_COLLECTION)
+								.hasTinyBars(ONE_HUNDRED_HBARS + ONE_HBAR)
+								.hasTokenBalance(TOKEN_WITH_HBAR_FEE, Long.MAX_VALUE - 1_000L)
+				);
+	}
+
+	public HapiApiSpec nestedFractionalCaseStudy() {
+		return defaultHapiSpec("NestedFractionalCaseStudy")
+				.given(
+						cryptoCreate(EDGAR),
+						cryptoCreate(FERN),
+						cryptoCreate(TREASURY_FOR_TOP_LEVEL_COLLECTION),
+						cryptoCreate(TREASURY_FOR_NESTED_COLLECTION),
+						tokenCreate(TOKEN_WITH_FRACTIONAL_FEE)
+								.initialSupply(Long.MAX_VALUE)
+								.treasury(TREASURY_FOR_NESTED_COLLECTION)
+								.withCustom(fractionalFee(1L, 100L, 1L, OptionalLong.of(5L),
+										false,
+										TREASURY_FOR_NESTED_COLLECTION)),
+						tokenAssociate(TREASURY_FOR_TOP_LEVEL_COLLECTION, TOKEN_WITH_FRACTIONAL_FEE),
+						tokenCreate(TOKEN_WITH_NESTED_FEE)
+								.initialSupply(Long.MAX_VALUE)
+								.treasury(TREASURY_FOR_TOP_LEVEL_COLLECTION)
+								.withCustom(fixedHtsFee(50L, TOKEN_WITH_FRACTIONAL_FEE,
+										TREASURY_FOR_TOP_LEVEL_COLLECTION)),
+						tokenAssociate(EDGAR, List.of(TOKEN_WITH_FRACTIONAL_FEE, TOKEN_WITH_NESTED_FEE)),
+						tokenAssociate(FERN, TOKEN_WITH_NESTED_FEE),
+						cryptoTransfer(
+								moving(1_000L, TOKEN_WITH_FRACTIONAL_FEE)
+										.between(TREASURY_FOR_NESTED_COLLECTION, EDGAR),
+								moving(1_000L, TOKEN_WITH_NESTED_FEE)
+										.between(TREASURY_FOR_TOP_LEVEL_COLLECTION, EDGAR)
+						)
+								.payingWith(TREASURY_FOR_NESTED_COLLECTION)
+								.fee(ONE_HBAR)
+								.via(TXN_FROM_TREASURY)
+				).when(
+						cryptoTransfer(
+								moving(10L, TOKEN_WITH_NESTED_FEE).between(EDGAR, FERN)
+						)
+								.payingWith(EDGAR)
+								.fee(ONE_HBAR)
+								.via(TXN_FROM_EDGAR)
+				).then(
+						getTxnRecord(TXN_FROM_TREASURY)
+								.hasTokenAmount(TOKEN_WITH_FRACTIONAL_FEE, EDGAR, 1_000L)
+								.hasTokenAmount(TOKEN_WITH_FRACTIONAL_FEE, TREASURY_FOR_NESTED_COLLECTION, -1_000L)
+								.hasTokenAmount(TOKEN_WITH_NESTED_FEE, EDGAR, 1_000L)
+								.hasTokenAmount(TOKEN_WITH_NESTED_FEE, TREASURY_FOR_TOP_LEVEL_COLLECTION, -1_000L),
+						getTxnRecord(TXN_FROM_EDGAR)
+								.hasTokenAmount(TOKEN_WITH_NESTED_FEE, FERN, 10L)
+								.hasTokenAmount(TOKEN_WITH_NESTED_FEE, EDGAR, -10L)
+								.hasAssessedCustomFee(TOKEN_WITH_FRACTIONAL_FEE, TREASURY_FOR_TOP_LEVEL_COLLECTION, 50L)
+								.hasTokenAmount(TOKEN_WITH_FRACTIONAL_FEE, TREASURY_FOR_TOP_LEVEL_COLLECTION, 49L)
+								.hasTokenAmount(TOKEN_WITH_FRACTIONAL_FEE, EDGAR, -50L)
+								.hasAssessedCustomFee(TOKEN_WITH_FRACTIONAL_FEE, TREASURY_FOR_NESTED_COLLECTION, 1L)
+								.hasTokenAmount(TOKEN_WITH_FRACTIONAL_FEE, TREASURY_FOR_NESTED_COLLECTION, 1L),
+						getAccountBalance(FERN)
+								.hasTokenBalance(TOKEN_WITH_NESTED_FEE, 10L),
+						getAccountBalance(EDGAR)
+								.hasTokenBalance(TOKEN_WITH_NESTED_FEE, 1_000L - 10L)
+								.hasTokenBalance(TOKEN_WITH_FRACTIONAL_FEE, 1_000L - 50L),
+						getAccountBalance(TREASURY_FOR_TOP_LEVEL_COLLECTION)
+								.hasTokenBalance(TOKEN_WITH_NESTED_FEE, Long.MAX_VALUE - 1_000L)
+								.hasTokenBalance(TOKEN_WITH_FRACTIONAL_FEE, 49L),
+						getAccountBalance(TREASURY_FOR_NESTED_COLLECTION)
+								.hasTokenBalance(TOKEN_WITH_FRACTIONAL_FEE, Long.MAX_VALUE - 1_000L + 1L)
+				);
+	}
+
+	public HapiApiSpec nestedHtsCaseStudy() {
+		return defaultHapiSpec("NestedHtsCaseStudy")
+				.given(
+						cryptoCreate(DEBBIE),
+						cryptoCreate(EDGAR),
+						cryptoCreate(TREASURY_FOR_TOP_LEVEL_COLLECTION),
+						cryptoCreate(TREASURY_FOR_NESTED_COLLECTION),
+						tokenCreate(FEE_TOKEN)
+								.treasury(DEFAULT_PAYER)
+								.initialSupply(Long.MAX_VALUE),
+						tokenAssociate(TREASURY_FOR_NESTED_COLLECTION, FEE_TOKEN),
+						tokenCreate(TOKEN_WITH_HTS_FEE)
+								.initialSupply(Long.MAX_VALUE)
+								.treasury(TREASURY_FOR_NESTED_COLLECTION)
+								.withCustom(fixedHtsFee(1L, FEE_TOKEN, TREASURY_FOR_NESTED_COLLECTION)),
+						tokenAssociate(TREASURY_FOR_TOP_LEVEL_COLLECTION, TOKEN_WITH_HTS_FEE),
+						tokenCreate(TOKEN_WITH_NESTED_FEE)
+								.initialSupply(Long.MAX_VALUE)
+								.treasury(TREASURY_FOR_TOP_LEVEL_COLLECTION)
+								.withCustom(fixedHtsFee(1L, TOKEN_WITH_HTS_FEE, TREASURY_FOR_TOP_LEVEL_COLLECTION)),
+						tokenAssociate(DEBBIE, List.of(FEE_TOKEN, TOKEN_WITH_HTS_FEE, TOKEN_WITH_NESTED_FEE)),
+						tokenAssociate(EDGAR, TOKEN_WITH_NESTED_FEE),
+						cryptoTransfer(
+								moving(1_000L, FEE_TOKEN)
+										.between(DEFAULT_PAYER, DEBBIE),
+								moving(1_000L, TOKEN_WITH_HTS_FEE)
+										.between(TREASURY_FOR_NESTED_COLLECTION, DEBBIE),
+								moving(1_000L, TOKEN_WITH_NESTED_FEE)
+										.between(TREASURY_FOR_TOP_LEVEL_COLLECTION, DEBBIE)
+						)
+								.payingWith(TREASURY_FOR_NESTED_COLLECTION)
+								.fee(ONE_HBAR)
+								.via(TXN_FROM_TREASURY)
+				).when(
+						cryptoTransfer(
+								moving(1L, TOKEN_WITH_NESTED_FEE).between(DEBBIE, EDGAR)
+						)
+								.payingWith(DEBBIE)
+								.fee(ONE_HBAR)
+								.via(TXN_FROM_DEBBIE)
+				).then(
+						getTxnRecord(TXN_FROM_TREASURY)
+								.hasTokenAmount(FEE_TOKEN, DEBBIE, 1_000L)
+								.hasTokenAmount(FEE_TOKEN, DEFAULT_PAYER, -1_000L)
+								.hasTokenAmount(TOKEN_WITH_HTS_FEE, DEBBIE, 1_000L)
+								.hasTokenAmount(TOKEN_WITH_HTS_FEE, TREASURY_FOR_NESTED_COLLECTION, -1_000L)
+								.hasTokenAmount(TOKEN_WITH_NESTED_FEE, DEBBIE, 1_000L)
+								.hasTokenAmount(TOKEN_WITH_NESTED_FEE, TREASURY_FOR_TOP_LEVEL_COLLECTION, -1_000L),
+						getTxnRecord(TXN_FROM_DEBBIE)
+								.hasTokenAmount(TOKEN_WITH_NESTED_FEE, EDGAR, 1L)
+								.hasTokenAmount(TOKEN_WITH_NESTED_FEE, DEBBIE, -1L)
+								.hasAssessedCustomFee(TOKEN_WITH_HTS_FEE, TREASURY_FOR_TOP_LEVEL_COLLECTION, 1L)
+								.hasTokenAmount(TOKEN_WITH_HTS_FEE, TREASURY_FOR_TOP_LEVEL_COLLECTION, 1L)
+								.hasTokenAmount(TOKEN_WITH_HTS_FEE, DEBBIE, -1L)
+								.hasAssessedCustomFee(FEE_TOKEN, TREASURY_FOR_NESTED_COLLECTION, 1L)
+								.hasTokenAmount(FEE_TOKEN, TREASURY_FOR_NESTED_COLLECTION, 1L)
+								.hasTokenAmount(FEE_TOKEN, DEBBIE, -1L),
+						getAccountBalance(EDGAR)
+								.hasTokenBalance(TOKEN_WITH_NESTED_FEE, 1L),
+						getAccountBalance(DEBBIE)
+								.hasTokenBalance(FEE_TOKEN, 1_000L - 1L)
+								.hasTokenBalance(TOKEN_WITH_HTS_FEE, 1_000L - 1L)
+								.hasTokenBalance(TOKEN_WITH_NESTED_FEE, 1_000L - 1L),
+						getAccountBalance(TREASURY_FOR_TOP_LEVEL_COLLECTION)
+								.hasTokenBalance(TOKEN_WITH_HTS_FEE, 1L)
+								.hasTokenBalance(TOKEN_WITH_NESTED_FEE, Long.MAX_VALUE - 1_000L),
+						getAccountBalance(TREASURY_FOR_NESTED_COLLECTION)
+								.hasTokenBalance(FEE_TOKEN, 1L)
+								.hasTokenBalance(TOKEN_WITH_HTS_FEE, Long.MAX_VALUE - 1_000L),
+						getAccountBalance(DEFAULT_PAYER)
+								.hasTokenBalance(FEE_TOKEN, Long.MAX_VALUE - 1_000L)
+				);
+	}
+
+	public HapiApiSpec treasuriesAreExemptFromAllCustomFees() {
+		return defaultHapiSpec("TreasuriesAreExemptFromAllFees")
+				.given(
+						cryptoCreate(EDGAR),
+						cryptoCreate(NON_TREASURY),
+						cryptoCreate(TOKEN_TREASURY),
+						cryptoCreate(TREASURY_FOR_TOP_LEVEL),
+						cryptoCreate(COLLECTOR_FOR_TOP_LEVEL).balance(0L),
+						tokenCreate(FEE_TOKEN)
+								.initialSupply(Long.MAX_VALUE)
+								.treasury(TOKEN_TREASURY),
+						tokenAssociate(COLLECTOR_FOR_TOP_LEVEL, FEE_TOKEN),
+						tokenAssociate(TREASURY_FOR_TOP_LEVEL, FEE_TOKEN),
+						tokenCreate(TOP_LEVEL_TOKEN)
+								.initialSupply(Long.MAX_VALUE)
+								.treasury(TREASURY_FOR_TOP_LEVEL)
+								.withCustom(fixedHbarFee(ONE_HBAR, COLLECTOR_FOR_TOP_LEVEL))
+								.withCustom(fixedHtsFee(50L, FEE_TOKEN, COLLECTOR_FOR_TOP_LEVEL))
+								.withCustom(fractionalFee(1L, 10L, 5L, OptionalLong.of(50L),
+										false, COLLECTOR_FOR_TOP_LEVEL))
+								.signedBy(DEFAULT_PAYER, TREASURY_FOR_TOP_LEVEL, COLLECTOR_FOR_TOP_LEVEL),
+						tokenAssociate(NON_TREASURY, List.of(TOP_LEVEL_TOKEN, FEE_TOKEN)),
+						tokenAssociate(EDGAR, TOP_LEVEL_TOKEN),
+						cryptoTransfer(
+								moving(2_000L, FEE_TOKEN)
+										.distributing(TOKEN_TREASURY, TREASURY_FOR_TOP_LEVEL, NON_TREASURY)
+						).payingWith(TOKEN_TREASURY).fee(ONE_HBAR)
+				).when(
+						cryptoTransfer(
+								moving(1_000L, TOP_LEVEL_TOKEN)
+										.between(TREASURY_FOR_TOP_LEVEL, NON_TREASURY)
+						)
+								.payingWith(TREASURY_FOR_TOP_LEVEL)
+								.fee(ONE_HBAR)
+								.via(TXN_FROM_TREASURY)
+				).then(
+						getTxnRecord(TXN_FROM_TREASURY)
+								.hasTokenAmount(TOP_LEVEL_TOKEN, NON_TREASURY, 1_000L)
+								.hasTokenAmount(TOP_LEVEL_TOKEN, TREASURY_FOR_TOP_LEVEL, -1_000L)
+								.hasAssessedCustomFeesSize(0),
+						getAccountBalance(COLLECTOR_FOR_TOP_LEVEL)
+								.hasTinyBars(0L)
+								.hasTokenBalance(FEE_TOKEN, 0L)
+								.hasTokenBalance(TOP_LEVEL_TOKEN, 0L),
+						getAccountBalance(TREASURY_FOR_TOP_LEVEL)
+								.hasTokenBalance(TOP_LEVEL_TOKEN, Long.MAX_VALUE - 1_000L)
+								.hasTokenBalance(FEE_TOKEN, 1_000L),
+						getAccountBalance(NON_TREASURY)
+								.hasTokenBalance(TOP_LEVEL_TOKEN, 1_000L)
+								.hasTokenBalance(FEE_TOKEN, 1_000L),
+						/* Now we perform the same transfer from a non-treasury and see all three fees charged */
+						cryptoTransfer(
+								moving(1_000L, TOP_LEVEL_TOKEN)
+										.between(NON_TREASURY, EDGAR)
+						)
+								.payingWith(TOKEN_TREASURY)
+								.fee(ONE_HBAR)
+								.via(TXN_FROM_NON_TREASURY),
+						getTxnRecord(TXN_FROM_NON_TREASURY)
+								.hasAssessedCustomFeesSize(3)
+								.hasTokenAmount(TOP_LEVEL_TOKEN, EDGAR, 1_000L - 50L)
+								.hasTokenAmount(TOP_LEVEL_TOKEN, NON_TREASURY, -1_000L)
+								.hasAssessedCustomFee(TOP_LEVEL_TOKEN, COLLECTOR_FOR_TOP_LEVEL, 50L)
+								.hasTokenAmount(TOP_LEVEL_TOKEN, COLLECTOR_FOR_TOP_LEVEL, 50L)
+								.hasAssessedCustomFee(HBAR_TOKEN_SENTINEL, COLLECTOR_FOR_TOP_LEVEL, ONE_HBAR)
+								.hasHbarAmount(COLLECTOR_FOR_TOP_LEVEL, ONE_HBAR)
+								.hasHbarAmount(NON_TREASURY, -ONE_HBAR)
+								.hasAssessedCustomFee(FEE_TOKEN, COLLECTOR_FOR_TOP_LEVEL, 50L)
+								.hasTokenAmount(FEE_TOKEN, COLLECTOR_FOR_TOP_LEVEL, 50L)
+								.hasTokenAmount(FEE_TOKEN, NON_TREASURY, -50L),
+						getAccountBalance(COLLECTOR_FOR_TOP_LEVEL)
+								.hasTinyBars(ONE_HBAR)
+								.hasTokenBalance(FEE_TOKEN, 50L)
+								.hasTokenBalance(TOP_LEVEL_TOKEN, 50L),
+						getAccountBalance(EDGAR)
+								.hasTokenBalance(TOP_LEVEL_TOKEN, 1_000L - 50L),
+						getAccountBalance(NON_TREASURY)
+								.hasTokenBalance(TOP_LEVEL_TOKEN, 1_000L - 1_000L)
+								.hasTokenBalance(FEE_TOKEN, 1_000L - 50L)
+				);
+	}
+
+	public HapiApiSpec collectorsAreExemptFromTheirOwnFeesButNotOthers() {
+		return defaultHapiSpec("CollectorsAreExemptFromTheirOwnFeesButNotOthers")
+				.given(
+						cryptoCreate(EDGAR),
+						cryptoCreate(TOKEN_TREASURY),
+						cryptoCreate(TREASURY_FOR_TOP_LEVEL),
+						cryptoCreate(FIRST_COLLECTOR_FOR_TOP_LEVEL).balance(10 * ONE_HBAR),
+						cryptoCreate(SECOND_COLLECTOR_FOR_TOP_LEVEL).balance(10 * ONE_HBAR),
+						tokenCreate(TOP_LEVEL_TOKEN)
+								.initialSupply(Long.MAX_VALUE)
+								.treasury(TREASURY_FOR_TOP_LEVEL)
+								.withCustom(fixedHbarFee(ONE_HBAR, FIRST_COLLECTOR_FOR_TOP_LEVEL))
+								.withCustom(fixedHbarFee(2 * ONE_HBAR, SECOND_COLLECTOR_FOR_TOP_LEVEL))
+								.withCustom(fractionalFee(1L, 20L, 0L, OptionalLong.of(0L),
+										false, FIRST_COLLECTOR_FOR_TOP_LEVEL))
+								.withCustom(fractionalFee(1L, 10L, 0L, OptionalLong.of(0L),
+										false, SECOND_COLLECTOR_FOR_TOP_LEVEL))
+								.signedBy(DEFAULT_PAYER, TREASURY_FOR_TOP_LEVEL, FIRST_COLLECTOR_FOR_TOP_LEVEL,
+										SECOND_COLLECTOR_FOR_TOP_LEVEL),
+						tokenAssociate(EDGAR, TOP_LEVEL_TOKEN),
+						cryptoTransfer(moving(2_000L, TOP_LEVEL_TOKEN)
+								.distributing(TREASURY_FOR_TOP_LEVEL, FIRST_COLLECTOR_FOR_TOP_LEVEL,
+										SECOND_COLLECTOR_FOR_TOP_LEVEL))
+				).when(
+						cryptoTransfer(
+								moving(1_000L, TOP_LEVEL_TOKEN)
+										.between(FIRST_COLLECTOR_FOR_TOP_LEVEL, EDGAR)
+						)
+								.payingWith(FIRST_COLLECTOR_FOR_TOP_LEVEL)
+								.fee(ONE_HBAR)
+								.via(TXN_FROM_COLLECTOR)
+				).then(
+						getTxnRecord(TXN_FROM_COLLECTOR)
+								.hasAssessedCustomFeesSize(2)
+								.hasTokenAmount(TOP_LEVEL_TOKEN, EDGAR, 1_000L - 100L)
+								.hasTokenAmount(TOP_LEVEL_TOKEN, FIRST_COLLECTOR_FOR_TOP_LEVEL, -1_000L)
+								.hasAssessedCustomFee(TOP_LEVEL_TOKEN, SECOND_COLLECTOR_FOR_TOP_LEVEL, 100L)
+								.hasTokenAmount(TOP_LEVEL_TOKEN, SECOND_COLLECTOR_FOR_TOP_LEVEL, 100L)
+								.hasAssessedCustomFee(HBAR_TOKEN_SENTINEL, SECOND_COLLECTOR_FOR_TOP_LEVEL, 2 * ONE_HBAR)
+								.hasHbarAmount(SECOND_COLLECTOR_FOR_TOP_LEVEL, 2 * ONE_HBAR),
+						getAccountBalance(FIRST_COLLECTOR_FOR_TOP_LEVEL)
+								.hasTokenBalance(TOP_LEVEL_TOKEN, 1_000L - 1_000L),
+						getAccountBalance(SECOND_COLLECTOR_FOR_TOP_LEVEL)
+								.hasTinyBars((10 + 2) * ONE_HBAR)
+								.hasTokenBalance(TOP_LEVEL_TOKEN, 1_000L + 100L),
+						getAccountBalance(EDGAR)
+								.hasTokenBalance(TOP_LEVEL_TOKEN, 1_000L - 100L)
+				);
+	}
+
+	@Override
+	protected Logger getResultsLogger() {
+		return log;
+	}
+}

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/token/Hip18TransactSpecs.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/token/Hip18TransactSpecs.java
@@ -31,11 +31,8 @@ import java.util.List;
 import java.util.OptionalLong;
 
 import static com.hedera.services.bdd.spec.HapiApiSpec.defaultHapiSpec;
-import static com.hedera.services.bdd.spec.assertions.AccountInfoAsserts.changeFromSnapshot;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getAccountBalance;
-import static com.hedera.services.bdd.spec.queries.QueryVerbs.getContractInfo;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getTxnRecord;
-import static com.hedera.services.bdd.spec.transactions.TxnVerbs.contractCreate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoCreate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoTransfer;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.mintToken;
@@ -44,10 +41,8 @@ import static com.hedera.services.bdd.spec.transactions.TxnVerbs.tokenCreate;
 import static com.hedera.services.bdd.spec.transactions.token.CustomFeeSpecs.fixedHbarFee;
 import static com.hedera.services.bdd.spec.transactions.token.CustomFeeSpecs.fixedHtsFee;
 import static com.hedera.services.bdd.spec.transactions.token.CustomFeeSpecs.fractionalFee;
-import static com.hedera.services.bdd.spec.transactions.token.CustomFeeSpecs.fractionalFeeTemp;
 import static com.hedera.services.bdd.spec.transactions.token.TokenMovement.moving;
 import static com.hedera.services.bdd.spec.transactions.token.TokenMovement.movingUnique;
-import static com.hedera.services.bdd.spec.utilops.UtilVerbs.balanceSnapshot;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.newKeyNamed;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INSUFFICIENT_PAYER_BALANCE_FOR_CUSTOM_FEE;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SUCCESS;
@@ -171,7 +166,7 @@ public class Hip18TransactSpecs extends HapiApiSuite {
 						tokenCreate(TOKEN_WITH_FRACTIONAL_FEE)
 								.initialSupply(Long.MAX_VALUE)
 								.treasury(TREASURY_FOR_TOKEN)
-								.withCustom(fractionalFeeTemp(1L, 100L, 1L,
+								.withCustom(fractionalFee(1L, 100L, 1L,
 										OptionalLong.of(5L), true, TREASURY_FOR_TOKEN)),
 
 						tokenAssociate(ALICE, TOKEN_WITH_FRACTIONAL_FEE),
@@ -218,7 +213,7 @@ public class Hip18TransactSpecs extends HapiApiSuite {
 						tokenCreate(TOKEN_WITH_FRACTIONAL_FEE)
 								.initialSupply(Long.MAX_VALUE)
 								.treasury(TREASURY_FOR_TOKEN)
-								.withCustom(fractionalFeeTemp(1L, 100L, 1L,
+								.withCustom(fractionalFee(1L, 100L, 1L,
 										OptionalLong.of(5L), true, TREASURY_FOR_TOKEN)),
 
 						tokenAssociate(ALICE, TOKEN_WITH_FRACTIONAL_FEE),
@@ -261,7 +256,7 @@ public class Hip18TransactSpecs extends HapiApiSuite {
 						tokenCreate(TOKEN_WITH_FRACTIONAL_FEE)
 								.initialSupply(Long.MAX_VALUE)
 								.treasury(TREASURY_FOR_TOKEN)
-								.withCustom(fractionalFeeTemp(1L, 100L, 1L,
+								.withCustom(fractionalFee(1L, 100L, 1L,
 										OptionalLong.of(5L), true, TREASURY_FOR_TOKEN)),
 
 						tokenAssociate(ALICE, TOKEN_WITH_FRACTIONAL_FEE),
@@ -309,7 +304,7 @@ public class Hip18TransactSpecs extends HapiApiSuite {
 						tokenCreate(TOKEN_WITH_FRACTIONAL_FEE)
 								.initialSupply(Long.MAX_VALUE)
 								.treasury(TREASURY_FOR_TOKEN)
-								.withCustom(fractionalFeeTemp(1L, 100L, 1L, OptionalLong.of(5L), false,
+								.withCustom(fractionalFee(1L, 100L, 1L, OptionalLong.of(5L), false,
 										TREASURY_FOR_TOKEN)),
 
 

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenCreateSpecs.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenCreateSpecs.java
@@ -547,7 +547,7 @@ public class TokenCreateSpecs extends HapiApiSuite {
 								.withCustom(fractionalFee(
 										numerator, 0,
 										minimumToCollect, OptionalLong.of(maximumToCollect),
-										tokenCollector))
+										false, tokenCollector))
 								.hasKnownStatus(FRACTION_DIVIDES_BY_ZERO),
 						tokenCreate(token)
 								.treasury(tokenCollector)
@@ -580,6 +580,7 @@ public class TokenCreateSpecs extends HapiApiSuite {
 								.withCustom(fractionalFee(
 										numerator, -denominator,
 										minimumToCollect, OptionalLong.of(maximumToCollect),
+										false,
 										tokenCollector))
 								.hasKnownStatus(CUSTOM_FEE_MUST_BE_POSITIVE),
 						tokenCreate(token)
@@ -587,6 +588,7 @@ public class TokenCreateSpecs extends HapiApiSuite {
 								.withCustom(fractionalFee(
 										numerator, denominator,
 										-minimumToCollect, OptionalLong.of(maximumToCollect),
+										false,
 										tokenCollector))
 								.hasKnownStatus(CUSTOM_FEE_MUST_BE_POSITIVE),
 						tokenCreate(token)
@@ -594,6 +596,7 @@ public class TokenCreateSpecs extends HapiApiSuite {
 								.withCustom(fractionalFee(
 										numerator, denominator,
 										minimumToCollect, OptionalLong.of(-maximumToCollect),
+										false,
 										tokenCollector))
 								.hasKnownStatus(CUSTOM_FEE_MUST_BE_POSITIVE),
 						tokenCreate(token)
@@ -601,6 +604,7 @@ public class TokenCreateSpecs extends HapiApiSuite {
 								.withCustom(fractionalFee(
 										-numerator, -denominator,
 										minimumToCollect, OptionalLong.of(maximumToCollect),
+										false,
 										tokenCollector))
 								.hasKnownStatus(CUSTOM_FEE_MUST_BE_POSITIVE),
 						tokenCreate(token)
@@ -608,6 +612,7 @@ public class TokenCreateSpecs extends HapiApiSuite {
 								.withCustom(fractionalFee(
 										numerator, denominator,
 										minimumToCollect, OptionalLong.of(minimumToCollect - 1),
+										false,
 										tokenCollector))
 								.hasKnownStatus(FRACTIONAL_FEE_MAX_AMOUNT_LESS_THAN_MIN_AMOUNT),
 						tokenCreate(token)
@@ -615,6 +620,7 @@ public class TokenCreateSpecs extends HapiApiSuite {
 								.withCustom(fractionalFee(
 										numerator, denominator,
 										minimumToCollect, OptionalLong.of(minimumToCollect),
+										false,
 										tokenCollector))
 								.hasKnownStatus(SUCCESS),
 						fileUpdate(APP_PROPERTIES)
@@ -628,6 +634,7 @@ public class TokenCreateSpecs extends HapiApiSuite {
 								.withCustom(fractionalFee(
 										numerator, denominator,
 										minimumToCollect, OptionalLong.of(maximumToCollect),
+										false,
 										tokenCollector))
 				).then(
 						getTokenInfo(token)
@@ -656,7 +663,7 @@ public class TokenCreateSpecs extends HapiApiSuite {
 								.withCustom(fractionalFee(
 										numerator, 0,
 										minimumToCollect, OptionalLong.of(maximumToCollect),
-										tokenCollector))
+										false, tokenCollector))
 								.hasKnownStatus(INVALID_SIGNATURE),
 						tokenCreate(token)
 								.treasury(TOKEN_TREASURY)
@@ -667,6 +674,7 @@ public class TokenCreateSpecs extends HapiApiSuite {
 								.withCustom(fractionalFee(
 										numerator, -denominator,
 										minimumToCollect, OptionalLong.of(maximumToCollect),
+										false,
 										tokenCollector))
 								.hasKnownStatus(INVALID_SIGNATURE),
 						tokenCreate(token)
@@ -676,6 +684,7 @@ public class TokenCreateSpecs extends HapiApiSuite {
 								.withCustom(fractionalFee(
 										numerator, denominator,
 										minimumToCollect, OptionalLong.of(maximumToCollect),
+										false,
 										tokenCollector))
 								.signedBy(DEFAULT_PAYER, TOKEN_TREASURY, htsCollector, tokenCollector)
 				).then(

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenFeeScheduleUpdateSpecs.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenFeeScheduleUpdateSpecs.java
@@ -158,7 +158,8 @@ public class TokenFeeScheduleUpdateSpecs extends HapiApiSuite {
 								.withCustom(fractionalFee(
 										numerator, denominator,
 										minimumToCollect, OptionalLong.of(maximumToCollect),
-										false,tokenCollector)),
+										false,
+										tokenCollector)),
 						tokenCreate(immutableTokenWithFeeScheduleKey)
 								.feeScheduleKey(feeScheduleKey)
 								.treasury(tokenCollector)

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenFeeScheduleUpdateSpecs.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenFeeScheduleUpdateSpecs.java
@@ -158,7 +158,7 @@ public class TokenFeeScheduleUpdateSpecs extends HapiApiSuite {
 								.withCustom(fractionalFee(
 										numerator, denominator,
 										minimumToCollect, OptionalLong.of(maximumToCollect),
-										tokenCollector)),
+										false,tokenCollector)),
 						tokenCreate(immutableTokenWithFeeScheduleKey)
 								.feeScheduleKey(feeScheduleKey)
 								.treasury(tokenCollector)
@@ -167,6 +167,7 @@ public class TokenFeeScheduleUpdateSpecs extends HapiApiSuite {
 								.withCustom(fractionalFee(
 										numerator, denominator,
 										minimumToCollect, OptionalLong.of(maximumToCollect),
+										false,
 										tokenCollector)),
 						tokenCreate(noFeeScheduleKeyToken)
 								.adminKey(adminKey)
@@ -176,6 +177,7 @@ public class TokenFeeScheduleUpdateSpecs extends HapiApiSuite {
 								.withCustom(fractionalFee(
 										numerator, denominator,
 										minimumToCollect, OptionalLong.of(maximumToCollect),
+										false,
 										tokenCollector)),
 						fileUpdate(APP_PROPERTIES)
 								.payingWith(GENESIS)
@@ -186,36 +188,42 @@ public class TokenFeeScheduleUpdateSpecs extends HapiApiSuite {
 								.withCustom(fractionalFee(
 										numerator, 0,
 										minimumToCollect, OptionalLong.of(maximumToCollect),
+										false,
 										tokenCollector))
 								.hasKnownStatus(FRACTION_DIVIDES_BY_ZERO),
 						tokenFeeScheduleUpdate(noFeeScheduleKeyToken)
 								.withCustom(fractionalFee(
 										numerator, denominator,
 										minimumToCollect, OptionalLong.of(maximumToCollect),
+										false,
 										tokenCollector))
 								.hasKnownStatus(TOKEN_HAS_NO_FEE_SCHEDULE_KEY),
 						tokenFeeScheduleUpdate(token)
 								.withCustom(fractionalFee(
 										numerator, 0,
 										minimumToCollect, OptionalLong.of(maximumToCollect),
+										false,
 										tokenCollector))
 								.hasKnownStatus(FRACTION_DIVIDES_BY_ZERO),
 						tokenFeeScheduleUpdate(token)
 								.withCustom(fractionalFee(
 										-numerator, denominator,
 										minimumToCollect, OptionalLong.of(maximumToCollect),
+										false,
 										tokenCollector))
 								.hasKnownStatus(CUSTOM_FEE_MUST_BE_POSITIVE),
 						tokenFeeScheduleUpdate(token)
 								.withCustom(fractionalFee(
 										numerator, denominator,
 										-minimumToCollect, OptionalLong.of(maximumToCollect),
+										false,
 										tokenCollector))
 								.hasKnownStatus(CUSTOM_FEE_MUST_BE_POSITIVE),
 						tokenFeeScheduleUpdate(token)
 								.withCustom(fractionalFee(
 										numerator, denominator,
 										minimumToCollect, OptionalLong.of(-maximumToCollect),
+										false,
 										tokenCollector))
 								.hasKnownStatus(CUSTOM_FEE_MUST_BE_POSITIVE),
 						tokenFeeScheduleUpdate(token)
@@ -248,6 +256,7 @@ public class TokenFeeScheduleUpdateSpecs extends HapiApiSuite {
 								.withCustom(fractionalFee(
 										newNumerator, newDenominator,
 										newMinimumToCollect, OptionalLong.of(newMaximumToCollect),
+										false,
 										newTokenCollector))
 				).then(
 						getTokenInfo(token)

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenTransactSpecs.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenTransactSpecs.java
@@ -87,7 +87,7 @@ public class TokenTransactSpecs extends HapiApiSuite {
 	private static final String FIRST_USER = "Client1";
 	private static final String SECOND_USER = "Client2";
 	private static final String TOKEN_TREASURY = "treasury";
-	
+
 	public static void main(String... args) {
 		new TokenTransactSpecs().runSuiteSync();
 	}

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenTransactSpecs.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenTransactSpecs.java
@@ -126,7 +126,6 @@ public class TokenTransactSpecs extends HapiApiSuite {
 						fixedHbarCaseStudy(),
 						fractionalChargeFeeToReceiver(),
 						fractionalChargeFeeToSender(),
-
 						simpleHtsFeeCaseStudy(),
 						nestedHbarCaseStudy(),
 						nestedFractionalCaseStudy(),
@@ -971,7 +970,6 @@ public class TokenTransactSpecs extends HapiApiSuite {
 		final var tokenWithFractionalFee = "TokenWithFractionalFee";
 		final var treasuryForToken = "TokenTreasury";
 		final var collectorForToken = "AnotherTokenTreasury";
-
 		final var txnFromTreasury = "txnFromTreasury";
 		final var txnFromBob = "txnFromBob";
 
@@ -984,8 +982,8 @@ public class TokenTransactSpecs extends HapiApiSuite {
 						tokenCreate(tokenWithFractionalFee)
 								.initialSupply(Long.MAX_VALUE)
 								.treasury(treasuryForToken)
-								.withCustom(fractionalFeeTemp(1L, 100L, 1L, OptionalLong.of(5L), true,treasuryForToken)),
-
+								.withCustom(fractionalFeeTemp(1L, 100L, 1L,
+										OptionalLong.of(5L), true,treasuryForToken)),
 
 						tokenAssociate(alice, tokenWithFractionalFee),
 						tokenAssociate(collectorForToken, tokenWithFractionalFee),
@@ -1009,7 +1007,7 @@ public class TokenTransactSpecs extends HapiApiSuite {
 						getTxnRecord(txnFromBob)
 								.hasTokenAmount(tokenWithFractionalFee, bob, -1_005L)
 								.hasTokenAmount(tokenWithFractionalFee, alice, 1000L)
-								.hasAssessedCustomFee(tokenWithFractionalFee, treasuryForToken, -5L)
+								.hasAssessedCustomFee(tokenWithFractionalFee, treasuryForToken, 5L)
 								.hasTokenAmount(tokenWithFractionalFee, treasuryForToken, 5L),
 						getAccountBalance(alice)
 								.hasTokenBalance(tokenWithFractionalFee, 1_000L),
@@ -1019,8 +1017,6 @@ public class TokenTransactSpecs extends HapiApiSuite {
 								.hasTokenBalance(tokenWithFractionalFee, Long.MAX_VALUE - 1_000_000L + 5L)
 				);
 	}
-
-
 
 	public HapiApiSpec fractionalChargeFeeToReceiver() {
 		final var alice = "Alice";
@@ -1061,8 +1057,8 @@ public class TokenTransactSpecs extends HapiApiSuite {
 								.hasKnownStatus(SUCCESS)
 				).then(
 						getTxnRecord(txnFromTreasury).logged()
-								.hasTokenAmount(tokenWithFractionalFee, bob, 1_000_000L - 5L)
-								.hasTokenAmount(tokenWithFractionalFee, treasuryForToken, -1_000_000L + 5L),
+								.hasTokenAmount(tokenWithFractionalFee, bob, 1_000_000L)
+								.hasTokenAmount(tokenWithFractionalFee, treasuryForToken, -1_000_000L),
 						getTxnRecord(txnFromBob)
 								.hasTokenAmount(tokenWithFractionalFee, bob, -1_000L)
 								.hasTokenAmount(tokenWithFractionalFee, alice, 995L)
@@ -1072,9 +1068,9 @@ public class TokenTransactSpecs extends HapiApiSuite {
 						getAccountBalance(alice)
 								.hasTokenBalance(tokenWithFractionalFee, 995L),
 						getAccountBalance(bob)
-								.hasTokenBalance(tokenWithFractionalFee, 1_000_000L - 1_000L -5L),
+								.hasTokenBalance(tokenWithFractionalFee, 1_000_000L - 1_000L ),
 						getAccountBalance(treasuryForToken)
-								.hasTokenBalance(tokenWithFractionalFee, Long.MAX_VALUE - 1_000_000L + 10L)
+								.hasTokenBalance(tokenWithFractionalFee, Long.MAX_VALUE - 1_000_000L + 5L)
 				);
 	}
 

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenTransactSpecs.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenTransactSpecs.java
@@ -29,7 +29,6 @@ import org.apache.logging.log4j.Logger;
 
 import java.util.List;
 import java.util.Map;
-import java.util.OptionalLong;
 
 import static com.hedera.services.bdd.spec.HapiApiSpec.defaultHapiSpec;
 import static com.hedera.services.bdd.spec.assertions.AccountInfoAsserts.changeFromSnapshot;
@@ -54,15 +53,12 @@ import static com.hedera.services.bdd.spec.transactions.TxnVerbs.tokenCreate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.tokenDelete;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.tokenDissociate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.tokenUpdate;
-import static com.hedera.services.bdd.spec.transactions.token.CustomFeeSpecs.fixedHbarFee;
-import static com.hedera.services.bdd.spec.transactions.token.CustomFeeSpecs.fixedHtsFee;
-import static com.hedera.services.bdd.spec.transactions.token.CustomFeeSpecs.fractionalFee;
-import static com.hedera.services.bdd.spec.transactions.token.CustomFeeSpecs.fractionalFeeTemp;
 import static com.hedera.services.bdd.spec.transactions.token.TokenMovement.moving;
 import static com.hedera.services.bdd.spec.transactions.token.TokenMovement.movingHbar;
 import static com.hedera.services.bdd.spec.transactions.token.TokenMovement.movingUnique;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.balanceSnapshot;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.newKeyNamed;
+import static com.hedera.services.bdd.suites.perf.PerfUtilOps.tokenOpsEnablement;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.ACCOUNT_AMOUNT_TRANSFERS_ONLY_ALLOWED_FOR_FUNGIBLE_COMMON;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.ACCOUNT_DELETED;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.ACCOUNT_FROZEN_FOR_TOKEN;
@@ -91,7 +87,7 @@ public class TokenTransactSpecs extends HapiApiSuite {
 	private static final String FIRST_USER = "Client1";
 	private static final String SECOND_USER = "Client2";
 	private static final String TOKEN_TREASURY = "treasury";
-
+	
 	public static void main(String... args) {
 		new TokenTransactSpecs().runSuiteSync();
 	}
@@ -99,39 +95,31 @@ public class TokenTransactSpecs extends HapiApiSuite {
 	@Override
 	protected List<HapiApiSpec> getSpecsInSuite() {
 		return List.of(new HapiApiSpec[] {
-						balancesChangeOnTokenTransfer(),
-						accountsMustBeExplicitlyUnfrozenOnlyIfDefaultFreezeIsTrue(),
-						senderSigsAreValid(),
-						balancesAreChecked(),
-						duplicateAccountsInTokenTransferRejected(),
-						tokenOnlyTxnsAreAtomic(),
-						tokenPlusHbarTxnsAreAtomic(),
-						nonZeroTransfersRejected(),
-						prechecksWork(),
-						missingEntitiesRejected(),
-						allRequiredSigsAreChecked(),
-						uniqueTokenTxnAccountBalance(),
-						uniqueTokenTxnAccountBalancesForTreasury(),
-						uniqueTokenTxnWithNoAssociation(),
-						uniqueTokenTxnWithFrozenAccount(),
-						uniqueTokenTxnWithSenderNotSigned(),
-						uniqueTokenTxnWithReceiverNotSigned(),
-						uniqueTokenTxnsAreAtomic(),
-						uniqueTokenDeletedTxn(),
-						cannotSendFungibleToDissociatedContractsOrAccounts(),
-						cannotGiveNftsToDissociatedContractsOrAccounts(),
-						recordsIncludeBothFungibleTokenChangesAndOwnershipChange(),
-						transferListsEnforceTokenTypeRestrictions(),
-						/* HIP-18 charging case studies */
-						fixedHbarCaseStudy(),
-						fractionalChargeFeeToReceiver(),
-						fractionalChargeFeeToSender(),
-						simpleHtsFeeCaseStudy(),
-						nestedHbarCaseStudy(),
-						nestedFractionalCaseStudy(),
-						nestedHtsCaseStudy(),
-						treasuriesAreExemptFromAllCustomFees(),
-						collectorsAreExemptFromTheirOwnFeesButNotOthers(),
+				balancesChangeOnTokenTransfer(),
+				accountsMustBeExplicitlyUnfrozenOnlyIfDefaultFreezeIsTrue(),
+				senderSigsAreValid(),
+				balancesAreChecked(),
+				duplicateAccountsInTokenTransferRejected(),
+				tokenOnlyTxnsAreAtomic(),
+				tokenPlusHbarTxnsAreAtomic(),
+				nonZeroTransfersRejected(),
+				prechecksWork(),
+				missingEntitiesRejected(),
+				allRequiredSigsAreChecked(),
+
+				uniqueTokenTxnAccountBalance(),
+				uniqueTokenTxnAccountBalancesForTreasury(),
+				uniqueTokenTxnWithNoAssociation(),
+				uniqueTokenTxnWithFrozenAccount(),
+				uniqueTokenTxnWithSenderNotSigned(),
+				uniqueTokenTxnWithReceiverNotSigned(),
+				uniqueTokenTxnsAreAtomic(),
+				uniqueTokenDeletedTxn(),
+
+				cannotSendFungibleToDissociatedContractsOrAccounts(),
+				cannotGiveNftsToDissociatedContractsOrAccounts(),
+				recordsIncludeBothFungibleTokenChangesAndOwnershipChange(),
+				transferListsEnforceTokenTypeRestrictions(),
 				}
 		);
 	}
@@ -207,6 +195,7 @@ public class TokenTransactSpecs extends HapiApiSuite {
 		final var theKey = "multipurpose";
 		return defaultHapiSpec("CannotGiveNftsToDissociatedContractsOrAccounts")
 				.given(
+						tokenOpsEnablement(),
 						newKeyNamed(theKey),
 						contractCreate(theContract),
 						cryptoCreate(theAccount),
@@ -645,6 +634,7 @@ public class TokenTransactSpecs extends HapiApiSuite {
 	public HapiApiSpec uniqueTokenTxnAccountBalance() {
 		return defaultHapiSpec("UniqueTokenTxnAccountBalance")
 				.given(
+						tokenOpsEnablement(),
 						newKeyNamed("supplyKey"),
 						newKeyNamed("signingKeyTreasury"),
 						newKeyNamed("signingKeyFirstUser"),
@@ -682,6 +672,7 @@ public class TokenTransactSpecs extends HapiApiSuite {
 	public HapiApiSpec uniqueTokenTxnAccountBalancesForTreasury() {
 		return defaultHapiSpec("UniqueTokenTxnAccountBalancesForTreasury")
 				.given(
+						tokenOpsEnablement(),
 						newKeyNamed("supplyKey"),
 						cryptoCreate("newTreasury"),
 						cryptoCreate("oldTreasury"),
@@ -734,6 +725,7 @@ public class TokenTransactSpecs extends HapiApiSuite {
 	public HapiApiSpec uniqueTokenTxnWithNoAssociation() {
 		return defaultHapiSpec("UniqueTokenTxnWithNoAssociation")
 				.given(
+						tokenOpsEnablement(),
 						cryptoCreate(TOKEN_TREASURY),
 						cryptoCreate(FIRST_USER),
 						newKeyNamed("supplyKey"),
@@ -905,616 +897,6 @@ public class TokenTransactSpecs extends HapiApiSuite {
 						)
 								.signedBy("signingKeyTreasury", "signingKeyFirstUser", DEFAULT_PAYER)
 								.hasKnownStatus(TOKEN_WAS_DELETED)
-				);
-	}
-
-	public HapiApiSpec fixedHbarCaseStudy() {
-		final var alice = "Alice";
-		final var bob = "Bob";
-		final var tokenWithHbarFee = "TokenWithHbarFee";
-		final var treasuryForToken = "TokenTreasury";
-		final var supplyKey = "antique";
-
-		final var txnFromTreasury = "txnFromTreasury";
-		final var txnFromAlice = "txnFromAlice";
-
-		return defaultHapiSpec("FixedHbarCaseStudy")
-				.given(
-						newKeyNamed(supplyKey),
-						cryptoCreate(alice).balance(ONE_HUNDRED_HBARS),
-						cryptoCreate(bob),
-						cryptoCreate(treasuryForToken).balance(ONE_HUNDRED_HBARS),
-						tokenCreate(tokenWithHbarFee)
-								.tokenType(TokenType.NON_FUNGIBLE_UNIQUE)
-								.supplyKey(supplyKey)
-								.initialSupply(0L)
-								.treasury(treasuryForToken)
-								.withCustom(fixedHbarFee(ONE_HBAR, treasuryForToken)),
-						mintToken(tokenWithHbarFee, List.of(ByteString.copyFromUtf8("First!"))),
-						mintToken(tokenWithHbarFee, List.of(ByteString.copyFromUtf8("Second!"))),
-						tokenAssociate(alice, tokenWithHbarFee),
-						tokenAssociate(bob, tokenWithHbarFee),
-						cryptoTransfer(movingUnique(tokenWithHbarFee, 2L).between(treasuryForToken, alice))
-								.payingWith(GENESIS)
-								.fee(ONE_HBAR)
-								.via(txnFromTreasury)
-				).when(
-						cryptoTransfer(
-								movingUnique(tokenWithHbarFee, 2L).between(alice, bob)
-						)
-								.payingWith(GENESIS)
-								.fee(ONE_HBAR)
-								.via(txnFromAlice)
-				).then(
-						getTxnRecord(txnFromTreasury)
-								.hasNftTransfer(tokenWithHbarFee, treasuryForToken, alice, 2L),
-						getTxnRecord(txnFromAlice)
-								.hasNftTransfer(tokenWithHbarFee, alice, bob, 2L)
-								.hasAssessedCustomFee(HBAR_TOKEN_SENTINEL, treasuryForToken, ONE_HBAR)
-								.hasHbarAmount(treasuryForToken, ONE_HBAR)
-								.hasHbarAmount(alice, -ONE_HBAR),
-						getAccountBalance(bob)
-								.hasTokenBalance(tokenWithHbarFee, 1L),
-						getAccountBalance(alice)
-								.hasTokenBalance(tokenWithHbarFee, 0L)
-								.hasTinyBars(ONE_HUNDRED_HBARS - ONE_HBAR),
-						getAccountBalance(treasuryForToken)
-								.hasTokenBalance(tokenWithHbarFee, 1L)
-								.hasTinyBars(ONE_HUNDRED_HBARS + ONE_HBAR)
-				);
-	}
-
-	public HapiApiSpec fractionalChargeFeeToSender() {
-		final var alice = "Alice";
-		final var bob = "Bob";
-		final var tokenWithFractionalFee = "TokenWithFractionalFee";
-		final var treasuryForToken = "TokenTreasury";
-		final var collectorForToken = "AnotherTokenTreasury";
-		final var txnFromTreasury = "txnFromTreasury";
-		final var txnFromBob = "txnFromBob";
-
-		return defaultHapiSpec("fractionalChargeFeeToSender")
-				.given(
-						cryptoCreate(alice),
-						cryptoCreate(bob),
-						cryptoCreate(treasuryForToken),
-						cryptoCreate(collectorForToken),
-						tokenCreate(tokenWithFractionalFee)
-								.initialSupply(Long.MAX_VALUE)
-								.treasury(treasuryForToken)
-								.withCustom(fractionalFeeTemp(1L, 100L, 1L,
-										OptionalLong.of(5L), true,treasuryForToken)),
-
-						tokenAssociate(alice, tokenWithFractionalFee),
-						tokenAssociate(collectorForToken, tokenWithFractionalFee),
-						tokenAssociate(bob, tokenWithFractionalFee),
-						cryptoTransfer(moving(1_000_000L, tokenWithFractionalFee).between(treasuryForToken, bob))
-								.payingWith(treasuryForToken)
-								.fee(ONE_HBAR)
-								.via(txnFromTreasury)
-				).when(
-						cryptoTransfer(
-								moving(1_000L, tokenWithFractionalFee).between(bob, alice)
-						)
-								.payingWith(bob)
-								.fee(ONE_HBAR)
-								.via(txnFromBob)
-						.hasKnownStatus(SUCCESS)
-				).then(
-						getTxnRecord(txnFromTreasury).logged()
-								.hasTokenAmount(tokenWithFractionalFee, bob, 1_000_000L)
-								.hasTokenAmount(tokenWithFractionalFee, treasuryForToken, -1_000_000L),
-						getTxnRecord(txnFromBob)
-								.hasTokenAmount(tokenWithFractionalFee, bob, -1_005L)
-								.hasTokenAmount(tokenWithFractionalFee, alice, 1000L)
-								.hasAssessedCustomFee(tokenWithFractionalFee, treasuryForToken, 5L)
-								.hasTokenAmount(tokenWithFractionalFee, treasuryForToken, 5L),
-						getAccountBalance(alice)
-								.hasTokenBalance(tokenWithFractionalFee, 1_000L),
-						getAccountBalance(bob)
-								.hasTokenBalance(tokenWithFractionalFee, 1_000_000L - 1_005L),
-						getAccountBalance(treasuryForToken)
-								.hasTokenBalance(tokenWithFractionalFee, Long.MAX_VALUE - 1_000_000L + 5L)
-				);
-	}
-
-	public HapiApiSpec fractionalChargeFeeToReceiver() {
-		final var alice = "Alice";
-		final var bob = "Bob";
-		final var tokenWithFractionalFee = "TokenWithFractionalFee";
-		final var treasuryForToken = "TokenTreasury";
-		final var collectorForToken = "AnotherTokenTreasury";
-
-		final var txnFromTreasury = "txnFromTreasury";
-		final var txnFromBob = "txnFromBob";
-
-		return defaultHapiSpec("fractionalChargeFeeToReceiver")
-				.given(
-						cryptoCreate(alice),
-						cryptoCreate(bob),
-						cryptoCreate(treasuryForToken),
-						cryptoCreate(collectorForToken),
-						tokenCreate(tokenWithFractionalFee)
-								.initialSupply(Long.MAX_VALUE)
-								.treasury(treasuryForToken)
-								.withCustom(fractionalFeeTemp(1L, 100L, 1L, OptionalLong.of(5L), false,treasuryForToken)),
-
-
-						tokenAssociate(alice, tokenWithFractionalFee),
-						tokenAssociate(collectorForToken, tokenWithFractionalFee),
-						tokenAssociate(bob, tokenWithFractionalFee),
-						cryptoTransfer(moving(1_000_000L, tokenWithFractionalFee).between(treasuryForToken, bob))
-								.payingWith(treasuryForToken)
-								.fee(ONE_HBAR)
-								.via(txnFromTreasury)
-				).when(
-						cryptoTransfer(
-								moving(1_000L, tokenWithFractionalFee).between(bob, alice)
-						)
-								.payingWith(bob)
-								.fee(ONE_HBAR)
-								.via(txnFromBob)
-								.hasKnownStatus(SUCCESS)
-				).then(
-						getTxnRecord(txnFromTreasury).logged()
-								.hasTokenAmount(tokenWithFractionalFee, bob, 1_000_000L)
-								.hasTokenAmount(tokenWithFractionalFee, treasuryForToken, -1_000_000L),
-						getTxnRecord(txnFromBob)
-								.hasTokenAmount(tokenWithFractionalFee, bob, -1_000L)
-								.hasTokenAmount(tokenWithFractionalFee, alice, 995L)
-								.hasAssessedCustomFee(tokenWithFractionalFee, treasuryForToken, 5L)
-								.hasTokenAmount(tokenWithFractionalFee, treasuryForToken, 5L) ,
-
-						getAccountBalance(alice)
-								.hasTokenBalance(tokenWithFractionalFee, 995L),
-						getAccountBalance(bob)
-								.hasTokenBalance(tokenWithFractionalFee, 1_000_000L - 1_000L ),
-						getAccountBalance(treasuryForToken)
-								.hasTokenBalance(tokenWithFractionalFee, Long.MAX_VALUE - 1_000_000L + 5L)
-				);
-	}
-
-
-	public HapiApiSpec simpleHtsFeeCaseStudy() {
-		final var claire = "Claire";
-		final var debbie = "Debbie";
-		final var simpleHtsFeeToken = "SimpleHtsFeeToken";
-		final var commissionPaymentToken = "commissionPaymentToken";
-		final var treasuryForToken = "TokenTreasury";
-
-		final var txnFromTreasury = "txnFromTreasury";
-		final var txnFromClaire = "txnFromClaire";
-
-		return defaultHapiSpec("SimpleHtsFeeCaseStudy")
-				.given(
-						cryptoCreate(claire),
-						cryptoCreate(debbie),
-						cryptoCreate(treasuryForToken),
-						tokenCreate(commissionPaymentToken)
-								.initialSupply(Long.MAX_VALUE)
-								.treasury(treasuryForToken),
-						tokenCreate(simpleHtsFeeToken)
-								.initialSupply(Long.MAX_VALUE)
-								.treasury(treasuryForToken)
-								.withCustom(fixedHtsFee(2L, commissionPaymentToken, treasuryForToken)),
-						tokenAssociate(claire, List.of(simpleHtsFeeToken, commissionPaymentToken)),
-						tokenAssociate(debbie, simpleHtsFeeToken),
-						cryptoTransfer(
-								moving(1_000L, commissionPaymentToken).between(treasuryForToken, claire),
-								moving(1_000L, simpleHtsFeeToken).between(treasuryForToken, claire)
-						)
-								.payingWith(treasuryForToken)
-								.fee(ONE_HBAR)
-								.via(txnFromTreasury)
-				).when(
-						cryptoTransfer(
-								moving(100L, simpleHtsFeeToken).between(claire, debbie)
-						)
-								//.payingWith(claire)
-								.fee(ONE_HBAR)
-								.via(txnFromClaire)
-				).then(
-						getTxnRecord(txnFromTreasury)
-								.hasTokenAmount(commissionPaymentToken, claire, 1_000L)
-								.hasTokenAmount(commissionPaymentToken, treasuryForToken, -1_000L)
-								.hasTokenAmount(simpleHtsFeeToken, claire, 1_000L)
-								.hasTokenAmount(simpleHtsFeeToken, treasuryForToken, -1_000L),
-						getTxnRecord(txnFromClaire)
-								.hasTokenAmount(simpleHtsFeeToken, debbie, 100L)
-								.hasTokenAmount(simpleHtsFeeToken, claire, -100L)
-								.hasAssessedCustomFee(commissionPaymentToken, treasuryForToken, 2L)
-								.hasTokenAmount(commissionPaymentToken, treasuryForToken, 2L)
-								.hasTokenAmount(commissionPaymentToken, claire, -2L),
-						getAccountBalance(debbie)
-								.hasTokenBalance(simpleHtsFeeToken, 100L),
-						getAccountBalance(claire)
-								.hasTokenBalance(simpleHtsFeeToken, 1_000L - 100L)
-								.hasTokenBalance(commissionPaymentToken, 1_000L - 2L),
-						getAccountBalance(treasuryForToken)
-								.hasTokenBalance(simpleHtsFeeToken, Long.MAX_VALUE - 1_000L)
-								.hasTokenBalance(commissionPaymentToken, Long.MAX_VALUE - 1_000L + 2L)
-				);
-	}
-
-	public HapiApiSpec nestedHbarCaseStudy() {
-		final var debbie = "Debbie";
-		final var edgar = "Edgar";
-		final var tokenWithHbarFee = "TokenWithHbarFee";
-		final var tokenWithNestedFee = "TokenWithNestedFee";
-		final var treasuryForTopLevelCollection = "TokenTreasury";
-		final var treasuryForNestedCollection = "NestedTokenTreasury";
-
-		final var txnFromTreasury = "txnFromTreasury";
-		final var txnFromDebbie = "txnFromDebbie";
-
-		return defaultHapiSpec("NestedHbarCaseStudy")
-				.given(
-						cryptoCreate(debbie).balance(ONE_HUNDRED_HBARS),
-						cryptoCreate(edgar),
-						cryptoCreate(treasuryForTopLevelCollection),
-						cryptoCreate(treasuryForNestedCollection).balance(ONE_HUNDRED_HBARS),
-						tokenCreate(tokenWithHbarFee)
-								.initialSupply(Long.MAX_VALUE)
-								.treasury(treasuryForNestedCollection)
-								.withCustom(fixedHbarFee(ONE_HBAR, treasuryForNestedCollection)),
-						tokenAssociate(treasuryForTopLevelCollection, tokenWithHbarFee),
-						tokenCreate(tokenWithNestedFee)
-								.initialSupply(Long.MAX_VALUE)
-								.treasury(treasuryForTopLevelCollection)
-								.withCustom(fixedHtsFee(1L, tokenWithHbarFee, treasuryForTopLevelCollection)),
-						tokenAssociate(debbie, List.of(tokenWithHbarFee, tokenWithNestedFee)),
-						tokenAssociate(edgar, tokenWithNestedFee),
-						cryptoTransfer(
-								moving(1_000L, tokenWithHbarFee)
-										.between(treasuryForNestedCollection, debbie),
-								moving(1_000L, tokenWithNestedFee)
-										.between(treasuryForTopLevelCollection, debbie)
-						)
-								.payingWith(GENESIS)
-								.fee(ONE_HBAR)
-								.via(txnFromTreasury)
-				).when(
-						cryptoTransfer(
-								moving(1L, tokenWithNestedFee).between(debbie, edgar)
-						)
-								.payingWith(GENESIS)
-								.fee(ONE_HBAR)
-								.via(txnFromDebbie)
-				).then(
-						getTxnRecord(txnFromTreasury)
-								.hasTokenAmount(tokenWithHbarFee, debbie, 1_000L)
-								.hasTokenAmount(tokenWithHbarFee, treasuryForNestedCollection, -1_000L)
-								.hasTokenAmount(tokenWithNestedFee, debbie, 1_000L)
-								.hasTokenAmount(tokenWithNestedFee, treasuryForTopLevelCollection, -1_000L),
-						getTxnRecord(txnFromDebbie)
-								.hasTokenAmount(tokenWithNestedFee, edgar, 1L)
-								.hasTokenAmount(tokenWithNestedFee, debbie, -1L)
-								.hasAssessedCustomFee(tokenWithHbarFee, treasuryForTopLevelCollection, 1L)
-								.hasTokenAmount(tokenWithHbarFee, treasuryForTopLevelCollection, 1L)
-								.hasTokenAmount(tokenWithHbarFee, debbie, -1L)
-								.hasAssessedCustomFee(HBAR_TOKEN_SENTINEL, treasuryForNestedCollection, ONE_HBAR)
-								.hasHbarAmount(treasuryForNestedCollection, ONE_HBAR)
-								.hasHbarAmount(debbie, -ONE_HBAR),
-						getAccountBalance(edgar)
-								.hasTokenBalance(tokenWithNestedFee, 1L),
-						getAccountBalance(debbie)
-								.hasTinyBars(ONE_HUNDRED_HBARS - ONE_HBAR)
-								.hasTokenBalance(tokenWithHbarFee, 1_000L - 1L)
-								.hasTokenBalance(tokenWithNestedFee, 1_000L - 1L),
-						getAccountBalance(treasuryForTopLevelCollection)
-								.hasTokenBalance(tokenWithNestedFee, Long.MAX_VALUE - 1_000L)
-								.hasTokenBalance(tokenWithHbarFee, 1L),
-						getAccountBalance(treasuryForNestedCollection)
-								.hasTinyBars(ONE_HUNDRED_HBARS + ONE_HBAR)
-								.hasTokenBalance(tokenWithHbarFee, Long.MAX_VALUE - 1_000L)
-				);
-	}
-
-	public HapiApiSpec nestedFractionalCaseStudy() {
-		final var edgar = "Edgar";
-		final var fern = "Fern";
-		final var tokenWithFractionalFee = "TokenWithFractionalFee";
-		final var tokenWithNestedFee = "TokenWithNestedFee";
-		final var treasuryForTopLevelCollection = "TokenTreasury";
-		final var treasuryForNestedCollection = "NestedTokenTreasury";
-
-		final var txnFromTreasury = "txnFromTreasury";
-		final var txnFromEdgar = "txnFromEdgar";
-
-		return defaultHapiSpec("NestedFractionalCaseStudy")
-				.given(
-						cryptoCreate(edgar),
-						cryptoCreate(fern),
-						cryptoCreate(treasuryForTopLevelCollection),
-						cryptoCreate(treasuryForNestedCollection),
-						tokenCreate(tokenWithFractionalFee)
-								.initialSupply(Long.MAX_VALUE)
-								.treasury(treasuryForNestedCollection)
-								.withCustom(fractionalFee(1L, 100L, 1L, OptionalLong.of(5L),
-										false,
-										treasuryForNestedCollection)),
-						tokenAssociate(treasuryForTopLevelCollection, tokenWithFractionalFee),
-						tokenCreate(tokenWithNestedFee)
-								.initialSupply(Long.MAX_VALUE)
-								.treasury(treasuryForTopLevelCollection)
-								.withCustom(fixedHtsFee(50L, tokenWithFractionalFee, treasuryForTopLevelCollection)),
-						tokenAssociate(edgar, List.of(tokenWithFractionalFee, tokenWithNestedFee)),
-						tokenAssociate(fern, tokenWithNestedFee),
-						cryptoTransfer(
-								moving(1_000L, tokenWithFractionalFee)
-										.between(treasuryForNestedCollection, edgar),
-								moving(1_000L, tokenWithNestedFee)
-										.between(treasuryForTopLevelCollection, edgar)
-						)
-								.payingWith(treasuryForNestedCollection)
-								.fee(ONE_HBAR)
-								.via(txnFromTreasury)
-				).when(
-						cryptoTransfer(
-								moving(10L, tokenWithNestedFee).between(edgar, fern)
-						)
-								.payingWith(edgar)
-								.fee(ONE_HBAR)
-								.via(txnFromEdgar)
-				).then(
-						getTxnRecord(txnFromTreasury)
-								.hasTokenAmount(tokenWithFractionalFee, edgar, 1_000L)
-								.hasTokenAmount(tokenWithFractionalFee, treasuryForNestedCollection, -1_000L)
-								.hasTokenAmount(tokenWithNestedFee, edgar, 1_000L)
-								.hasTokenAmount(tokenWithNestedFee, treasuryForTopLevelCollection, -1_000L),
-						getTxnRecord(txnFromEdgar)
-								.hasTokenAmount(tokenWithNestedFee, fern, 10L)
-								.hasTokenAmount(tokenWithNestedFee, edgar, -10L)
-								.hasAssessedCustomFee(tokenWithFractionalFee, treasuryForTopLevelCollection, 50L)
-								.hasTokenAmount(tokenWithFractionalFee, treasuryForTopLevelCollection, 49L)
-								.hasTokenAmount(tokenWithFractionalFee, edgar, -50L)
-								.hasAssessedCustomFee(tokenWithFractionalFee, treasuryForNestedCollection, 1L)
-								.hasTokenAmount(tokenWithFractionalFee, treasuryForNestedCollection, 1L),
-						getAccountBalance(fern)
-								.hasTokenBalance(tokenWithNestedFee, 10L),
-						getAccountBalance(edgar)
-								.hasTokenBalance(tokenWithNestedFee, 1_000L - 10L)
-								.hasTokenBalance(tokenWithFractionalFee, 1_000L - 50L),
-						getAccountBalance(treasuryForTopLevelCollection)
-								.hasTokenBalance(tokenWithNestedFee, Long.MAX_VALUE - 1_000L)
-								.hasTokenBalance(tokenWithFractionalFee, 49L),
-						getAccountBalance(treasuryForNestedCollection)
-								.hasTokenBalance(tokenWithFractionalFee, Long.MAX_VALUE - 1_000L + 1L)
-				);
-	}
-
-	public HapiApiSpec nestedHtsCaseStudy() {
-		final var debbie = "Debbie";
-		final var edgar = "Edgar";
-		final var feeToken = "FeeToken";
-		final var tokenWithHtsFee = "TokenWithHtsFee";
-		final var tokenWithNestedFee = "TokenWithNestedFee";
-		final var treasuryForTopLevelCollection = "TokenTreasury";
-		final var treasuryForNestedCollection = "NestedTokenTreasury";
-
-		final var txnFromTreasury = "txnFromTreasury";
-		final var txnFromDebbie = "txnFromDebbie";
-
-		return defaultHapiSpec("NestedHtsCaseStudy")
-				.given(
-						cryptoCreate(debbie),
-						cryptoCreate(edgar),
-						cryptoCreate(treasuryForTopLevelCollection),
-						cryptoCreate(treasuryForNestedCollection),
-						tokenCreate(feeToken)
-								.treasury(DEFAULT_PAYER)
-								.initialSupply(Long.MAX_VALUE),
-						tokenAssociate(treasuryForNestedCollection, feeToken),
-						tokenCreate(tokenWithHtsFee)
-								.initialSupply(Long.MAX_VALUE)
-								.treasury(treasuryForNestedCollection)
-								.withCustom(fixedHtsFee(1L, feeToken, treasuryForNestedCollection)),
-						tokenAssociate(treasuryForTopLevelCollection, tokenWithHtsFee),
-						tokenCreate(tokenWithNestedFee)
-								.initialSupply(Long.MAX_VALUE)
-								.treasury(treasuryForTopLevelCollection)
-								.withCustom(fixedHtsFee(1L, tokenWithHtsFee, treasuryForTopLevelCollection)),
-						tokenAssociate(debbie, List.of(feeToken, tokenWithHtsFee, tokenWithNestedFee)),
-						tokenAssociate(edgar, tokenWithNestedFee),
-						cryptoTransfer(
-								moving(1_000L, feeToken)
-										.between(DEFAULT_PAYER, debbie),
-								moving(1_000L, tokenWithHtsFee)
-										.between(treasuryForNestedCollection, debbie),
-								moving(1_000L, tokenWithNestedFee)
-										.between(treasuryForTopLevelCollection, debbie)
-						)
-								.payingWith(treasuryForNestedCollection)
-								.fee(ONE_HBAR)
-								.via(txnFromTreasury)
-				).when(
-						cryptoTransfer(
-								moving(1L, tokenWithNestedFee).between(debbie, edgar)
-						)
-								.payingWith(debbie)
-								.fee(ONE_HBAR)
-								.via(txnFromDebbie)
-				).then(
-						getTxnRecord(txnFromTreasury)
-								.hasTokenAmount(feeToken, debbie, 1_000L)
-								.hasTokenAmount(feeToken, DEFAULT_PAYER, -1_000L)
-								.hasTokenAmount(tokenWithHtsFee, debbie, 1_000L)
-								.hasTokenAmount(tokenWithHtsFee, treasuryForNestedCollection, -1_000L)
-								.hasTokenAmount(tokenWithNestedFee, debbie, 1_000L)
-								.hasTokenAmount(tokenWithNestedFee, treasuryForTopLevelCollection, -1_000L),
-						getTxnRecord(txnFromDebbie)
-								.hasTokenAmount(tokenWithNestedFee, edgar, 1L)
-								.hasTokenAmount(tokenWithNestedFee, debbie, -1L)
-								.hasAssessedCustomFee(tokenWithHtsFee, treasuryForTopLevelCollection, 1L)
-								.hasTokenAmount(tokenWithHtsFee, treasuryForTopLevelCollection, 1L)
-								.hasTokenAmount(tokenWithHtsFee, debbie, -1L)
-								.hasAssessedCustomFee(feeToken, treasuryForNestedCollection, 1L)
-								.hasTokenAmount(feeToken, treasuryForNestedCollection, 1L)
-								.hasTokenAmount(feeToken, debbie, -1L),
-						getAccountBalance(edgar)
-								.hasTokenBalance(tokenWithNestedFee, 1L),
-						getAccountBalance(debbie)
-								.hasTokenBalance(feeToken, 1_000L - 1L)
-								.hasTokenBalance(tokenWithHtsFee, 1_000L - 1L)
-								.hasTokenBalance(tokenWithNestedFee, 1_000L - 1L),
-						getAccountBalance(treasuryForTopLevelCollection)
-								.hasTokenBalance(tokenWithHtsFee, 1L)
-								.hasTokenBalance(tokenWithNestedFee, Long.MAX_VALUE - 1_000L),
-						getAccountBalance(treasuryForNestedCollection)
-								.hasTokenBalance(feeToken, 1L)
-								.hasTokenBalance(tokenWithHtsFee, Long.MAX_VALUE - 1_000L),
-						getAccountBalance(DEFAULT_PAYER)
-								.hasTokenBalance(feeToken, Long.MAX_VALUE - 1_000L)
-				);
-	}
-
-	public HapiApiSpec treasuriesAreExemptFromAllCustomFees() {
-		final var edgar = "Edgar";
-		final var feeToken = "FeeToken";
-		final var topLevelToken = "TopLevelToken";
-		final var treasuryForTopLevel = "TokenTreasury";
-		final var collectorForTopLevel = "FeeCollector";
-		final var nonTreasury = "nonTreasury";
-
-		final var txnFromTreasury = "txnFromTreasury";
-		final var txnFromNonTreasury = "txnFromNonTreasury";
-
-		return defaultHapiSpec("TreasuriesAreExemptFromAllFees")
-				.given(
-						cryptoCreate(edgar),
-						cryptoCreate(nonTreasury),
-						cryptoCreate(TOKEN_TREASURY),
-						cryptoCreate(treasuryForTopLevel),
-						cryptoCreate(collectorForTopLevel).balance(0L),
-						tokenCreate(feeToken)
-								.initialSupply(Long.MAX_VALUE)
-								.treasury(TOKEN_TREASURY),
-						tokenAssociate(collectorForTopLevel, feeToken),
-						tokenAssociate(treasuryForTopLevel, feeToken),
-						tokenCreate(topLevelToken)
-								.initialSupply(Long.MAX_VALUE)
-								.treasury(treasuryForTopLevel)
-								.withCustom(fixedHbarFee(ONE_HBAR, collectorForTopLevel))
-								.withCustom(fixedHtsFee(50L, feeToken, collectorForTopLevel))
-								.withCustom(fractionalFee(1L, 10L, 5L, OptionalLong.of(50L),
-										false, collectorForTopLevel))
-								.signedBy(DEFAULT_PAYER, treasuryForTopLevel, collectorForTopLevel),
-						tokenAssociate(nonTreasury, List.of(topLevelToken, feeToken)),
-						tokenAssociate(edgar, topLevelToken),
-						cryptoTransfer(
-								moving(2_000L, feeToken)
-										.distributing(TOKEN_TREASURY, treasuryForTopLevel, nonTreasury)
-						).payingWith(TOKEN_TREASURY).fee(ONE_HBAR)
-				).when(
-						cryptoTransfer(
-								moving(1_000L, topLevelToken)
-										.between(treasuryForTopLevel, nonTreasury)
-						)
-								.payingWith(treasuryForTopLevel)
-								.fee(ONE_HBAR)
-								.via(txnFromTreasury)
-				).then(
-						getTxnRecord(txnFromTreasury)
-								.hasTokenAmount(topLevelToken, nonTreasury, 1_000L)
-								.hasTokenAmount(topLevelToken, treasuryForTopLevel, -1_000L)
-								.hasAssessedCustomFeesSize(0),
-						getAccountBalance(collectorForTopLevel)
-								.hasTinyBars(0L)
-								.hasTokenBalance(feeToken, 0L)
-								.hasTokenBalance(topLevelToken, 0L),
-						getAccountBalance(treasuryForTopLevel)
-								.hasTokenBalance(topLevelToken, Long.MAX_VALUE - 1_000L)
-								.hasTokenBalance(feeToken, 1_000L),
-						getAccountBalance(nonTreasury)
-								.hasTokenBalance(topLevelToken, 1_000L)
-								.hasTokenBalance(feeToken, 1_000L),
-						/* Now we perform the same transfer from a non-treasury and see all three fees charged */
-						cryptoTransfer(
-								moving(1_000L, topLevelToken)
-										.between(nonTreasury, edgar)
-						)
-								.payingWith(TOKEN_TREASURY)
-								.fee(ONE_HBAR)
-								.via(txnFromNonTreasury),
-						getTxnRecord(txnFromNonTreasury)
-								.hasAssessedCustomFeesSize(3)
-								.hasTokenAmount(topLevelToken, edgar, 1_000L - 50L)
-								.hasTokenAmount(topLevelToken, nonTreasury, -1_000L)
-								.hasAssessedCustomFee(topLevelToken, collectorForTopLevel, 50L)
-								.hasTokenAmount(topLevelToken, collectorForTopLevel, 50L)
-								.hasAssessedCustomFee(HBAR_TOKEN_SENTINEL, collectorForTopLevel, ONE_HBAR)
-								.hasHbarAmount(collectorForTopLevel, ONE_HBAR)
-								.hasHbarAmount(nonTreasury, -ONE_HBAR)
-								.hasAssessedCustomFee(feeToken, collectorForTopLevel, 50L)
-								.hasTokenAmount(feeToken, collectorForTopLevel, 50L)
-								.hasTokenAmount(feeToken, nonTreasury, -50L),
-						getAccountBalance(collectorForTopLevel)
-								.hasTinyBars(ONE_HBAR)
-								.hasTokenBalance(feeToken, 50L)
-								.hasTokenBalance(topLevelToken, 50L),
-						getAccountBalance(edgar)
-								.hasTokenBalance(topLevelToken, 1_000L - 50L),
-						getAccountBalance(nonTreasury)
-								.hasTokenBalance(topLevelToken, 1_000L - 1_000L)
-								.hasTokenBalance(feeToken, 1_000L - 50L)
-				);
-	}
-
-	public HapiApiSpec collectorsAreExemptFromTheirOwnFeesButNotOthers() {
-		final var edgar = "Edgar";
-		final var topLevelToken = "TopLevelToken";
-		final var treasuryForTopLevel = "TokenTreasury";
-		final var firstCollectorForTopLevel = "AFeeCollector";
-		final var secondCollectorForTopLevel = "BFeeCollector";
-
-		final var txnFromCollector = "txnFromCollector";
-
-		return defaultHapiSpec("CollectorsAreExemptFromTheirOwnFeesButNotOthers")
-				.given(
-						cryptoCreate(edgar),
-						cryptoCreate(TOKEN_TREASURY),
-						cryptoCreate(treasuryForTopLevel),
-						cryptoCreate(firstCollectorForTopLevel).balance(10 * ONE_HBAR),
-						cryptoCreate(secondCollectorForTopLevel).balance(10 * ONE_HBAR),
-						tokenCreate(topLevelToken)
-								.initialSupply(Long.MAX_VALUE)
-								.treasury(treasuryForTopLevel)
-								.withCustom(fixedHbarFee(ONE_HBAR, firstCollectorForTopLevel))
-								.withCustom(fixedHbarFee(2 * ONE_HBAR, secondCollectorForTopLevel))
-								.withCustom(fractionalFee(1L, 20L, 0L, OptionalLong.of(0L),
-										false, firstCollectorForTopLevel))
-								.withCustom(fractionalFee(1L, 10L, 0L, OptionalLong.of(0L),
-										false, secondCollectorForTopLevel))
-								.signedBy(DEFAULT_PAYER, treasuryForTopLevel, firstCollectorForTopLevel,
-										secondCollectorForTopLevel),
-						tokenAssociate(edgar, topLevelToken),
-						cryptoTransfer(moving(2_000L, topLevelToken)
-								.distributing(treasuryForTopLevel, firstCollectorForTopLevel,
-										secondCollectorForTopLevel))
-				).when(
-						cryptoTransfer(
-								moving(1_000L, topLevelToken)
-										.between(firstCollectorForTopLevel, edgar)
-						)
-								.payingWith(firstCollectorForTopLevel)
-								.fee(ONE_HBAR)
-								.via(txnFromCollector)
-				).then(
-						getTxnRecord(txnFromCollector)
-								.hasAssessedCustomFeesSize(2)
-								.hasTokenAmount(topLevelToken, edgar, 1_000L - 100L)
-								.hasTokenAmount(topLevelToken, firstCollectorForTopLevel, -1_000L)
-								.hasAssessedCustomFee(topLevelToken, secondCollectorForTopLevel, 100L)
-								.hasTokenAmount(topLevelToken, secondCollectorForTopLevel, 100L)
-								.hasAssessedCustomFee(HBAR_TOKEN_SENTINEL, secondCollectorForTopLevel, 2 * ONE_HBAR)
-								.hasHbarAmount(secondCollectorForTopLevel, 2 * ONE_HBAR),
-						getAccountBalance(firstCollectorForTopLevel)
-								.hasTokenBalance(topLevelToken, 1_000L - 1_000L),
-						getAccountBalance(secondCollectorForTopLevel)
-								.hasTinyBars((10 + 2) * ONE_HBAR)
-								.hasTokenBalance(topLevelToken, 1_000L + 100L),
-						getAccountBalance(edgar)
-								.hasTokenBalance(topLevelToken, 1_000L - 100L)
 				);
 	}
 


### PR DESCRIPTION
**Description**:
This PR enhances the fractional custom fee to be able to assessed to either the sender or receiver of the token transfer based on each custom fee schedule's setting.

**Related issue(s)**:

Fixes #1926

**Notes for reviewer**:

Still need the protobufs change to commit for completion.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
