### PR TITLE
Don't recurse when assessing self-denominated fixed fees 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2250,6 +2250,7 @@ workflows:
             filters:
               branches:
                 ignore:
+                  - 01925-M-TrackFeeExemptBalanceChanges
                   - NONE
             workflow-name: "Continuous-integration"
         - sonar-check:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2250,7 +2250,6 @@ workflows:
             filters:
               branches:
                 ignore:
-                  - 01925-M-TrackFeeExemptBalanceChanges
                   - NONE
             workflow-name: "Continuous-integration"
         - sonar-check:

--- a/hedera-node/src/main/java/com/hedera/services/grpc/marshalling/AdjustmentUtils.java
+++ b/hedera-node/src/main/java/com/hedera/services/grpc/marshalling/AdjustmentUtils.java
@@ -23,25 +23,58 @@ package com.hedera.services.grpc.marshalling;
 import com.hedera.services.ledger.BalanceChange;
 import com.hedera.services.store.models.Id;
 
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INSUFFICIENT_PAYER_BALANCE_FOR_CUSTOM_FEE;
+import static com.hedera.services.store.models.Id.MISSING_ID;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INSUFFICIENT_SENDER_ACCOUNT_BALANCE_FOR_CUSTOM_FEE;
 
 public class AdjustmentUtils {
-	static void adjustForAssessed(Id payer, Id collector, Id denom, long amount, BalanceChangeManager manager) {
-		final var payerChange = adjustedChange(payer, denom, -amount, manager);
-		payerChange.setCodeForInsufficientBalance(INSUFFICIENT_PAYER_BALANCE_FOR_CUSTOM_FEE);
-		adjustedChange(collector, denom, +amount, manager);
+	static void adjustForAssessedHbar(Id payer, Id collector, long amount, BalanceChangeManager manager) {
+		adjustForAssessed(payer, MISSING_ID, collector, MISSING_ID, amount, manager);
 	}
 
-	static BalanceChange adjustedChange(Id account, Id denom, long amount, BalanceChangeManager manager) {
+	static void adjustForAssessed(
+			Id payer,
+			Id chargingToken,
+			Id collector,
+			Id denom,
+			long amount,
+			BalanceChangeManager manager
+	) {
+		final var payerChange = adjustedChange(payer, chargingToken, denom, -amount, manager);
+		payerChange.setCodeForInsufficientBalance(INSUFFICIENT_SENDER_ACCOUNT_BALANCE_FOR_CUSTOM_FEE);
+		adjustedChange(collector, chargingToken, denom, +amount, manager);
+	}
+
+	static BalanceChange adjustedFractionalChange(
+			Id account,
+			Id denom,
+			long amount,
+			BalanceChangeManager manager
+	) {
+		return adjustedChange(account, MISSING_ID, denom, amount, manager);
+	}
+
+	static BalanceChange adjustedChange(
+			Id account,
+			Id chargingToken,
+			Id denom,
+			long amount,
+			BalanceChangeManager manager
+	) {
 		/* Always append a new change for an HTS debit since it could trigger another assessed fee */
-		if (denom != Id.MISSING_ID && amount < 0) {
-			return includedHtsChange(account, denom, amount, manager);
+		if (denom != MISSING_ID && amount < 0) {
+			final var htsDebit = includedHtsChange(account, denom, amount, manager);
+			/* But self-denominated fees are exempt from further custom fee charging,
+			   c.f. https://github.com/hashgraph/hedera-services/issues/1925 */
+			if (chargingToken.equals(denom)) {
+				htsDebit.setExemptFromCustomFees(true);
+			}
+			return htsDebit;
 		}
 
 		/* Otherwise, just update the existing change for this account denomination if present */
 		final var extantChange = manager.changeFor(account, denom);
 		if (extantChange == null) {
-			if (denom == Id.MISSING_ID) {
+			if (denom == MISSING_ID) {
 				final var newHbarChange = BalanceChange.hbarAdjust(account, amount);
 				manager.includeChange(newHbarChange);
 				return newHbarChange;

--- a/hedera-node/src/main/java/com/hedera/services/grpc/marshalling/BalanceChangeManager.java
+++ b/hedera-node/src/main/java/com/hedera/services/grpc/marshalling/BalanceChangeManager.java
@@ -72,14 +72,14 @@ public class BalanceChangeManager {
 		}
 		while (nextCandidateChange < numChanges) {
 			final var candidate = changesSoFar.get(nextCandidateChange);
-			final var changeIsNftOwnerOrHtsDebit = couldTriggerCustomFees(candidate);
-			if (changeIsNftOwnerOrHtsDebit && nextCandidateChange >= levelEnd) {
+			final var changeIsTrigger = couldTriggerCustomFees(candidate);
+			if (changeIsTrigger && nextCandidateChange >= levelEnd) {
 				levelNo++;
 				levelStart = levelEnd;
 				levelEnd = numChanges;
 			}
 			nextCandidateChange++;
-			if (changeIsNftOwnerOrHtsDebit) {
+			if (changeIsTrigger) {
 				return candidate;
 			}
 		}
@@ -123,10 +123,10 @@ public class BalanceChangeManager {
 	}
 
 	private boolean couldTriggerCustomFees(BalanceChange candidate) {
-		return candidate.isForNft() || (!candidate.isForHbar() && candidate.units() < 0);
-	}
-
-	private boolean matches(BalanceChange change, Id account, Id denom) {
-		return account.equals(change.getAccount()) && denom.equals(change.getToken());
+		if (candidate.isExemptFromCustomFees()) {
+			return false;
+		} else {
+			return candidate.isForNft() || (!candidate.isForHbar() && candidate.units() < 0);
+		}
 	}
 }

--- a/hedera-node/src/main/java/com/hedera/services/grpc/marshalling/FeeAssessor.java
+++ b/hedera-node/src/main/java/com/hedera/services/grpc/marshalling/FeeAssessor.java
@@ -9,9 +9,9 @@ package com.hedera.services.grpc.marshalling;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -28,6 +28,9 @@ import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
 
 import java.util.List;
 
+import static com.hedera.services.grpc.marshalling.FeeAssessor.FixedFeeResult.NO_MORE_FEES;
+import static com.hedera.services.grpc.marshalling.FeeAssessor.FixedFeeResult.FRACTIONAL_FEES_PENDING;
+import static com.hedera.services.grpc.marshalling.FeeAssessor.FixedFeeResult.TOO_MANY_CHANGES_REQUIRED_FOR_FIXED_FEES;
 import static com.hedera.services.state.submerkle.FcCustomFee.FeeType.FIXED_FEE;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.CUSTOM_FEE_CHARGING_EXCEEDED_MAX_ACCOUNT_AMOUNTS;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.CUSTOM_FEE_CHARGING_EXCEEDED_MAX_RECURSION_DEPTH;
@@ -38,10 +41,10 @@ public class FeeAssessor {
 	private final HbarFeeAssessor hbarFeeAssessor;
 	private final FractionalFeeAssessor fractionalFeeAssessor;
 
-	enum FixedFeeProcessingResult {
-		ASSESSMENT_FINISHED,
-		FRACTIONAL_FEE_ASSESSMENT_PENDING,
-		ASSESSMENT_FAILED_WITH_TOO_MANY_ADJUSTMENTS_REQUIRED
+	enum FixedFeeResult {
+		NO_MORE_FEES,
+		FRACTIONAL_FEES_PENDING,
+		TOO_MANY_CHANGES_REQUIRED_FOR_FIXED_FEES
 	}
 
 	public FeeAssessor(
@@ -71,15 +74,16 @@ public class FeeAssessor {
 		if (fees.isEmpty() || feeMeta.getTreasuryId().equals(payer)) {
 			return OK;
 		}
-		FixedFeeProcessingResult fixedFeeProcessingResult;
+
 		final var maxBalanceChanges = props.getMaxXferBalanceChanges();
 
-		fixedFeeProcessingResult = processFixedCustomFees(fees, payer, balanceChangeManager, accumulator, maxBalanceChanges);
-		if(fixedFeeProcessingResult == FixedFeeProcessingResult.ASSESSMENT_FAILED_WITH_TOO_MANY_ADJUSTMENTS_REQUIRED) {
+		FixedFeeResult result;
+		result = processFixedCustomFees(fees, payer, balanceChangeManager, accumulator, maxBalanceChanges);
+		if (result == TOO_MANY_CHANGES_REQUIRED_FOR_FIXED_FEES) {
 			return CUSTOM_FEE_CHARGING_EXCEEDED_MAX_ACCOUNT_AMOUNTS;
 		}
 
-		if (fixedFeeProcessingResult == FixedFeeProcessingResult.FRACTIONAL_FEE_ASSESSMENT_PENDING) {
+		if (result == FRACTIONAL_FEES_PENDING) {
 			final var fractionalValidity =
 					fractionalFeeAssessor.assessAllFractional(change, fees, balanceChangeManager, accumulator);
 			if (fractionalValidity != OK) {
@@ -90,12 +94,14 @@ public class FeeAssessor {
 				? CUSTOM_FEE_CHARGING_EXCEEDED_MAX_ACCOUNT_AMOUNTS : OK;
 	}
 
-	private FixedFeeProcessingResult processFixedCustomFees(final List<FcCustomFee> fees,
+	private FixedFeeResult processFixedCustomFees(
+			final List<FcCustomFee> fees,
 			final Id payer,
 			final BalanceChangeManager balanceChangeManager,
 			final List<FcAssessedCustomFee> accumulator,
-			final int maxBalanceChanges) {
-		FixedFeeProcessingResult result = FixedFeeProcessingResult.ASSESSMENT_FINISHED;
+			final int maxBalanceChanges
+	) {
+		var result = NO_MORE_FEES;
 		for (var fee : fees) {
 			final var collector = fee.getFeeCollectorAsId();
 			if (payer.equals(collector)) {
@@ -109,10 +115,10 @@ public class FeeAssessor {
 					htsFeeAssessor.assess(payer, fee, balanceChangeManager, accumulator);
 				}
 				if (balanceChangeManager.numChangesSoFar() > maxBalanceChanges) {
-					return FixedFeeProcessingResult.ASSESSMENT_FAILED_WITH_TOO_MANY_ADJUSTMENTS_REQUIRED;
+					return TOO_MANY_CHANGES_REQUIRED_FOR_FIXED_FEES;
 				}
 			} else {
-				 result = FixedFeeProcessingResult.FRACTIONAL_FEE_ASSESSMENT_PENDING;
+				result = FRACTIONAL_FEES_PENDING;
 			}
 		}
 		return result;

--- a/hedera-node/src/main/java/com/hedera/services/grpc/marshalling/FractionalFeeAssessor.java
+++ b/hedera-node/src/main/java/com/hedera/services/grpc/marshalling/FractionalFeeAssessor.java
@@ -28,10 +28,10 @@ import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
 import java.math.BigInteger;
 import java.util.List;
 
-import static com.hedera.services.grpc.marshalling.AdjustmentUtils.adjustedChange;
+import static com.hedera.services.grpc.marshalling.AdjustmentUtils.adjustedFractionalChange;
 import static com.hedera.services.state.submerkle.FcCustomFee.FeeType.FRACTIONAL_FEE;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.CUSTOM_FEE_OUTSIDE_NUMERIC_RANGE;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INSUFFICIENT_PAYER_BALANCE_FOR_CUSTOM_FEE;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INSUFFICIENT_SENDER_ACCOUNT_BALANCE_FOR_CUSTOM_FEE;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OK;
 
 public class FractionalFeeAssessor {
@@ -64,7 +64,7 @@ public class FractionalFeeAssessor {
 
 			unitsLeft -= assessedAmount;
 			if (unitsLeft < 0) {
-				return INSUFFICIENT_PAYER_BALANCE_FOR_CUSTOM_FEE;
+				return INSUFFICIENT_SENDER_ACCOUNT_BALANCE_FOR_CUSTOM_FEE;
 			}
 			final var creditsToReclaimFrom = changeManager.creditsInCurrentLevel(denom);
 			try {
@@ -73,7 +73,7 @@ public class FractionalFeeAssessor {
 				return CUSTOM_FEE_OUTSIDE_NUMERIC_RANGE;
 			}
 
-			adjustedChange(collector, denom, assessedAmount, changeManager);
+			adjustedFractionalChange(collector, denom, assessedAmount, changeManager);
 			final var assessed = new FcAssessedCustomFee(collector.asEntityId(), denom.asEntityId(), assessedAmount);
 			accumulator.add(assessed);
 		}

--- a/hedera-node/src/main/java/com/hedera/services/grpc/marshalling/HbarFeeAssessor.java
+++ b/hedera-node/src/main/java/com/hedera/services/grpc/marshalling/HbarFeeAssessor.java
@@ -27,12 +27,12 @@ import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
 
 import java.util.List;
 
-import static com.hedera.services.grpc.marshalling.AdjustmentUtils.adjustForAssessed;
+import static com.hedera.services.grpc.marshalling.AdjustmentUtils.adjustForAssessedHbar;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OK;
 
 public class HbarFeeAssessor {
 	public ResponseCodeEnum assess(
-			Id account,
+			Id payer,
 			FcCustomFee hbarFee,
 			BalanceChangeManager changeManager,
 			List<FcAssessedCustomFee> accumulator
@@ -40,7 +40,7 @@ public class HbarFeeAssessor {
 		final var collector = hbarFee.getFeeCollectorAsId();
 		final var fixedSpec = hbarFee.getFixedFeeSpec();
 		final var amount = fixedSpec.getUnitsToCollect();
-		adjustForAssessed(account, collector, Id.MISSING_ID, amount, changeManager);
+		adjustForAssessedHbar(payer, collector, amount, changeManager);
 		final var assessed = new FcAssessedCustomFee(collector.asEntityId(), amount);
 		accumulator.add(assessed);
 		return OK;

--- a/hedera-node/src/main/java/com/hedera/services/grpc/marshalling/HtsFeeAssessor.java
+++ b/hedera-node/src/main/java/com/hedera/services/grpc/marshalling/HtsFeeAssessor.java
@@ -33,6 +33,7 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OK;
 public class HtsFeeAssessor {
 	public ResponseCodeEnum assess(
 			Id account,
+			Id chargingToken,
 			FcCustomFee htsFee,
 			BalanceChangeManager changeManager,
 			List<FcAssessedCustomFee> accumulator
@@ -41,7 +42,7 @@ public class HtsFeeAssessor {
 		final var fixedSpec = htsFee.getFixedFeeSpec();
 		final var amount = fixedSpec.getUnitsToCollect();
 		final var denominatingToken = fixedSpec.getTokenDenomination().asId();
-		adjustForAssessed(account, collector, denominatingToken, amount, changeManager);
+		adjustForAssessed(account, chargingToken, collector, denominatingToken, amount, changeManager);
 
 		final var assessed = new FcAssessedCustomFee(
 				htsFee.getFeeCollector(),

--- a/hedera-node/src/main/java/com/hedera/services/ledger/BalanceChange.java
+++ b/hedera-node/src/main/java/com/hedera/services/ledger/BalanceChange.java
@@ -55,12 +55,13 @@ public class BalanceChange {
 
 	private Id account;
 	private long units;
-	private ResponseCodeEnum codeForInsufficientBalance;
 	private long newBalance;
+	private boolean exemptFromCustomFees = false;
 	private NftId nftId = null;
 	private TokenID tokenId = null;
 	private AccountID accountId;
 	private AccountID counterPartyAccountId = null;
+	private ResponseCodeEnum codeForInsufficientBalance;
 
 	private BalanceChange(Id token, AccountAmount aa, ResponseCodeEnum code) {
 		this.token = token;
@@ -215,5 +216,13 @@ public class BalanceChange {
 
 	public void setCodeForInsufficientBalance(ResponseCodeEnum codeForInsufficientBalance) {
 		this.codeForInsufficientBalance = codeForInsufficientBalance;
+	}
+
+	public void setExemptFromCustomFees(boolean exemptFromCustomFees) {
+		this.exemptFromCustomFees = exemptFromCustomFees;
+	}
+
+	public boolean isExemptFromCustomFees() {
+		return exemptFromCustomFees;
 	}
 }

--- a/hedera-node/src/test/java/com/hedera/services/grpc/marshalling/BalanceChangeManagerTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/grpc/marshalling/BalanceChangeManagerTest.java
@@ -48,7 +48,7 @@ class BalanceChangeManagerTest {
 		// expect:
 		assertEquals(0, subject.getLevelNo());
 		assertEquals(0, subject.getLevelStart());
-		assertEquals(7, subject.getLevelEnd());
+		assertEquals(8, subject.getLevelEnd());
 	}
 
 	@Test
@@ -63,7 +63,7 @@ class BalanceChangeManagerTest {
 	@Test
 	void changesSoFarAreSized() {
 		// expect:
-		assertEquals(7, subject.numChangesSoFar());
+		assertEquals(8, subject.numChangesSoFar());
 	}
 
 	@Test
@@ -74,8 +74,8 @@ class BalanceChangeManagerTest {
 		final var newChanges = subject.getChangesSoFar();
 
 		// then:
-		assertEquals(8, newChanges.size());
-		assertSame(miscHbarAdjust, newChanges.get(7));
+		assertEquals(9, newChanges.size());
+		assertSame(miscHbarAdjust, newChanges.get(8));
 		assertSame(miscHbarAdjust, subject.changeFor(misc, Id.MISSING_ID));
 	}
 

--- a/hedera-node/src/test/java/com/hedera/services/grpc/marshalling/BalanceChangeManagerTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/grpc/marshalling/BalanceChangeManagerTest.java
@@ -189,6 +189,11 @@ class BalanceChangeManagerTest {
 			.build();
 	private final BalanceChange firstFungibleTrigger = BalanceChange.changingFtUnits(
 			firstFungibleTokenId, firstFungibleTokenId.asGrpcToken(), firstFungibleDebit);
+	private final BalanceChange exemptFungibleTrigger = BalanceChange.changingFtUnits(
+			firstFungibleTokenId, firstFungibleTokenId.asGrpcToken(), firstFungibleDebit);
+	{
+		exemptFungibleTrigger.setExemptFromCustomFees(true);
+	}
 	private final BalanceChange firstFungibleNonTrigger = BalanceChange.changingFtUnits(
 			firstFungibleTokenId, firstFungibleTokenId.asGrpcToken(), firstFungibleCredit);
 	private final BalanceChange secondFungibleTrigger = BalanceChange.changingFtUnits(
@@ -215,6 +220,7 @@ class BalanceChangeManagerTest {
 	{
 		startingList.add(payerHbarAdjust);
 		startingList.add(fundingHbarAdjust);
+		startingList.add(exemptFungibleTrigger);
 		startingList.add(firstFungibleTrigger);
 		startingList.add(firstFungibleNonTrigger);
 		startingList.add(secondFungibleTrigger);

--- a/hedera-node/src/test/java/com/hedera/services/grpc/marshalling/FeeAssessorTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/grpc/marshalling/FeeAssessorTest.java
@@ -132,7 +132,8 @@ class FeeAssessorTest {
 
 		// then:
 		verify(hbarFeeAssessor).assess(payer, hbarFee, balanceChangeManager, accumulator);
-		verify(htsFeeAssessor, times(2)).assess(payer, htsFee, balanceChangeManager, accumulator);
+		verify(htsFeeAssessor, times(2))
+				.assess(payer, fungibleTokenId, htsFee, balanceChangeManager, accumulator);
 		assertEquals(OK, result);
 	}
 
@@ -151,7 +152,8 @@ class FeeAssessorTest {
 
 		// then:
 		verify(hbarFeeAssessor).assess(payer, hbarFee, balanceChangeManager, accumulator);
-		verify(htsFeeAssessor, times(2)).assess(payer, htsFee, balanceChangeManager, accumulator);
+		verify(htsFeeAssessor, times(2))
+				.assess(payer, fungibleTokenId, htsFee, balanceChangeManager, accumulator);
 		verify(fractionalFeeAssessor).assessAllFractional(fungibleTrigger, fees, balanceChangeManager, accumulator);
 		assertEquals(OK, result);
 	}
@@ -212,7 +214,7 @@ class FeeAssessorTest {
 				subject.assess(fungibleTrigger, customSchedulesManager, balanceChangeManager, accumulator, props);
 
 		// then:
-		verify(htsFeeAssessor).assess(payer, htsFee, balanceChangeManager, accumulator);
+		verify(htsFeeAssessor).assess(payer, fungibleTokenId, htsFee, balanceChangeManager, accumulator);
 		assertEquals(OK, result);
 	}
 
@@ -231,7 +233,7 @@ class FeeAssessorTest {
 
 		// then:
 		verify(hbarFeeAssessor).assess(payer, hbarFee, balanceChangeManager, accumulator);
-		verify(htsFeeAssessor).assess(payer, htsFee, balanceChangeManager, accumulator);
+		verify(htsFeeAssessor).assess(payer, fungibleTokenId, htsFee, balanceChangeManager, accumulator);
 		verify(fractionalFeeAssessor, never())
 				.assessAllFractional(fungibleTrigger, fees, balanceChangeManager, accumulator);
 		assertEquals(CUSTOM_FEE_CHARGING_EXCEEDED_MAX_ACCOUNT_AMOUNTS, result);
@@ -251,7 +253,7 @@ class FeeAssessorTest {
 
 		// then:
 		verify(hbarFeeAssessor).assess(payer, hbarFee, balanceChangeManager, accumulator);
-		verify(htsFeeAssessor).assess(payer, htsFee, balanceChangeManager, accumulator);
+		verify(htsFeeAssessor).assess(payer, fungibleTokenId, htsFee, balanceChangeManager, accumulator);
 		verify(fractionalFeeAssessor).assessAllFractional(fungibleTrigger, fees, balanceChangeManager, accumulator);
 		assertEquals(CUSTOM_FEE_OUTSIDE_NUMERIC_RANGE, result);
 	}
@@ -274,7 +276,7 @@ class FeeAssessorTest {
 
 		// then:
 		verify(hbarFeeAssessor).assess(payer, hbarFee, balanceChangeManager, accumulator);
-		verify(htsFeeAssessor).assess(payer, htsFee, balanceChangeManager, accumulator);
+		verify(htsFeeAssessor).assess(payer, fungibleTokenId, htsFee, balanceChangeManager, accumulator);
 		verify(fractionalFeeAssessor)
 				.assessAllFractional(fungibleTrigger, fees, balanceChangeManager, accumulator);
 		assertEquals(CUSTOM_FEE_CHARGING_EXCEEDED_MAX_ACCOUNT_AMOUNTS, result);

--- a/hedera-node/src/test/java/com/hedera/services/grpc/marshalling/FractionalFeeAssessorTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/grpc/marshalling/FractionalFeeAssessorTest.java
@@ -35,7 +35,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.CUSTOM_FEE_OUTSIDE_NUMERIC_RANGE;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INSUFFICIENT_PAYER_BALANCE_FOR_CUSTOM_FEE;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INSUFFICIENT_SENDER_ACCOUNT_BALANCE_FOR_CUSTOM_FEE;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OK;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -141,7 +141,7 @@ class FractionalFeeAssessorTest {
 				subject.assessAllFractional(wildlyInsufficientChange, fees, changeManager, accumulator);
 
 		// then:
-		assertEquals(INSUFFICIENT_PAYER_BALANCE_FOR_CUSTOM_FEE, result);
+		assertEquals(INSUFFICIENT_SENDER_ACCOUNT_BALANCE_FOR_CUSTOM_FEE, result);
 	}
 
 	@Test

--- a/hedera-node/src/test/java/com/hedera/services/grpc/marshalling/HbarFeeAssessorTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/grpc/marshalling/HbarFeeAssessorTest.java
@@ -33,7 +33,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.util.ArrayList;
 import java.util.List;
 
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INSUFFICIENT_PAYER_BALANCE_FOR_CUSTOM_FEE;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INSUFFICIENT_SENDER_ACCOUNT_BALANCE_FOR_CUSTOM_FEE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
@@ -65,7 +65,7 @@ class HbarFeeAssessorTest {
 
 		// then:
 		verify(payerChange).adjustUnits(-amountOfHbarFee);
-		verify(payerChange).setCodeForInsufficientBalance(INSUFFICIENT_PAYER_BALANCE_FOR_CUSTOM_FEE);
+		verify(payerChange).setCodeForInsufficientBalance(INSUFFICIENT_SENDER_ACCOUNT_BALANCE_FOR_CUSTOM_FEE);
 		// and:
 		verify(collectorChange).adjustUnits(+amountOfHbarFee);
 		// and:
@@ -77,7 +77,7 @@ class HbarFeeAssessorTest {
 	void addsNewChangesIfNotPresent() {
 		// given:
 		final var expectedPayerChange = BalanceChange.hbarAdjust(payer, -amountOfHbarFee);
-		expectedPayerChange.setCodeForInsufficientBalance(INSUFFICIENT_PAYER_BALANCE_FOR_CUSTOM_FEE);
+		expectedPayerChange.setCodeForInsufficientBalance(INSUFFICIENT_SENDER_ACCOUNT_BALANCE_FOR_CUSTOM_FEE);
 
 		// when:
 		subject.assess(payer, hbarFee, balanceChangeManager, accumulator);

--- a/test-clients/src/main/java/com/hedera/services/bdd/spec/assertions/NoFungibleTransfers.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/spec/assertions/NoFungibleTransfers.java
@@ -1,0 +1,32 @@
+package com.hedera.services.bdd.spec.assertions;
+
+import com.hedera.services.bdd.spec.HapiApiSpec;
+import com.hederahashgraph.api.proto.java.TokenTransferList;
+import org.junit.jupiter.api.Assertions;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class NoFungibleTransfers implements ErroringAssertsProvider<List<TokenTransferList>> {
+	public static NoFungibleTransfers changingNoFungibleBalances() {
+		return new NoFungibleTransfers();
+	}
+
+	@Override
+	public ErroringAsserts<List<TokenTransferList>> assertsFor(HapiApiSpec spec) {
+		final List<Throwable> unexpectedFungibleChanges = new ArrayList<>();
+		return tokenTransfers -> {
+			for (var tokenTransfer : tokenTransfers) {
+				try {
+					final var fungibleChanges = tokenTransfer.getTransfersList();
+					Assertions.assertTrue(
+							fungibleChanges.isEmpty(),
+							() -> "Expected no fungible balance changes, were: " + fungibleChanges);
+				} catch (Throwable t) {
+					unexpectedFungibleChanges.add(t);
+				}
+			}
+			return unexpectedFungibleChanges;
+		};
+	}
+}

--- a/test-clients/src/main/java/com/hedera/services/bdd/spec/assertions/NoNftTransfers.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/spec/assertions/NoNftTransfers.java
@@ -1,0 +1,32 @@
+package com.hedera.services.bdd.spec.assertions;
+
+import com.hedera.services.bdd.spec.HapiApiSpec;
+import com.hederahashgraph.api.proto.java.TokenTransferList;
+import org.junit.jupiter.api.Assertions;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class NoNftTransfers implements ErroringAssertsProvider<List<TokenTransferList>>  {
+	public static NoNftTransfers changingNoNftOwners() {
+		return new NoNftTransfers();
+	}
+
+	@Override
+	public ErroringAsserts<List<TokenTransferList>> assertsFor(HapiApiSpec spec) {
+		final List<Throwable> unexpectedOwnershipChanges = new ArrayList<>();
+		return tokenTransfers -> {
+			for (var tokenTransfer : tokenTransfers) {
+				try {
+					final var ownershipChanges = tokenTransfer.getNftTransfersList();
+					Assertions.assertTrue(
+							ownershipChanges.isEmpty(),
+							() -> "Expected no NFT transfers, were: " + ownershipChanges);
+				} catch (Throwable t) {
+					unexpectedOwnershipChanges.add(t);
+				}
+			}
+			return unexpectedOwnershipChanges;
+		};
+	}
+}

--- a/test-clients/src/main/java/com/hedera/services/bdd/spec/assertions/SomeFungibleTransfers.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/spec/assertions/SomeFungibleTransfers.java
@@ -1,0 +1,139 @@
+package com.hedera.services.bdd.spec.assertions;
+
+import com.hedera.services.bdd.spec.HapiApiSpec;
+import com.hederahashgraph.api.proto.java.AccountID;
+import com.hederahashgraph.api.proto.java.TokenID;
+import com.hederahashgraph.api.proto.java.TokenTransferList;
+import org.apache.commons.lang3.tuple.Pair;
+import org.junit.jupiter.api.Assertions;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static com.hedera.services.bdd.spec.HapiPropertySource.asAccountString;
+import static com.hedera.services.bdd.spec.HapiPropertySource.asTokenString;
+
+public class SomeFungibleTransfers implements ErroringAssertsProvider<List<TokenTransferList>> {
+	private final Map<String, List<Pair<String, Long>>> changes = new HashMap<>();
+	private boolean noOtherChangesTolerated = false;
+
+	public static SomeFungibleTransfers changingSomeFungibleBalances() {
+		return new SomeFungibleTransfers();
+	}
+
+	public SomeFungibleTransfers including(String token, String account, long delta) {
+		changes.computeIfAbsent(token, ignore -> new ArrayList<>()).add(Pair.of(account, delta));
+		return this;
+	}
+
+	@Override
+	public ErroringAsserts<List<TokenTransferList>> assertsFor(HapiApiSpec spec) {
+		final List<Throwable> wrongFungibleChanges = new ArrayList<>();
+
+		final Map<TokenID, String> tokenNameLookup = new HashMap<>();
+		final Map<AccountID, String> accountNameLookup = new HashMap<>();
+		final var registry = spec.registry();
+		for (var entry : changes.entrySet()) {
+			final var tokenName = entry.getKey();
+			tokenNameLookup.put(registry.getTokenID(tokenName), tokenName);
+			for (var change : entry.getValue()) {
+				final var accountName = change.getLeft();
+				accountNameLookup.put(registry.getAccountID(accountName), accountName);
+			}
+		}
+
+		return tokenTransfers -> {
+			for (var tokenTransfer : tokenTransfers) {
+				final var token = tokenTransfer.getToken();
+				if (!tokenNameLookup.containsKey(token)) {
+					if (noOtherChangesTolerated) {
+						try {
+							Assertions.fail(
+									"Unexpected changes for token "
+											+ asTokenString(token) + " --> "
+											+ tokenTransfer.getTransfersList());
+						} catch (Throwable t) {
+							wrongFungibleChanges.add(t);
+						}
+					}
+					continue;
+				}
+				final var fungibleChanges = tokenTransfer.getTransfersList();
+				for (var fChange : fungibleChanges) {
+					final var account = fChange.getAccountID();
+					if (!accountNameLookup.containsKey(account)) {
+						if (noOtherChangesTolerated) {
+							try {
+								Assertions.fail(
+										"Unexpected change to balance of account "
+												+ asAccountString(account) + " for token "
+												+ asTokenString(token) + " --> "
+												+ fChange.getAmount());
+							} catch (Throwable t) {
+								wrongFungibleChanges.add(t);
+							}
+						}
+						continue;
+					}
+					final var tokenName = tokenNameLookup.get(token);
+					final var accountName = accountNameLookup.get(account);
+					final var actual = fChange.getAmount();
+					final var expected = expectedChange(tokenName, accountName);
+					try {
+						Assertions.assertEquals(
+								expected,
+								actual,
+								"Wrong change in account '"
+										+ accountName + "' for token '" + tokenName + "'");
+					} catch (Throwable t) {
+						wrongFungibleChanges.add(t);
+					}
+					forgetExpectation(tokenName, accountName);
+				}
+			}
+
+			for (var entry : changes.entrySet()) {
+				final var token = entry.getKey();
+				final var expectations = entry.getValue();
+				try {
+					Assertions.assertTrue(
+							expectations.isEmpty(),
+							() -> "Expected changes for token '" + token + "', but got none of: " + expectations);
+				} catch (Throwable t) {
+					wrongFungibleChanges.add(t);
+				}
+			}
+			return wrongFungibleChanges;
+		};
+	}
+
+	private long expectedChange(String token, String account) {
+		final var expectations = changes.get(token);
+		if (expectations == null) {
+			throw new IllegalStateException("No expected change in account '" + account + "' for token '" + token +
+					"'");
+		}
+		for (var change : expectations) {
+			if (change.getKey().equals(account)) {
+				return change.getValue();
+			}
+		}
+		throw new IllegalStateException("No expected change in account '" + account + "' for token '" + token + "'");
+	}
+
+	private void forgetExpectation(String token, String account) {
+		final var expectations = changes.get(token);
+		if (expectations == null) {
+			throw new IllegalStateException("No expected change in account '" + account + "' for token '" + token + "'");
+		}
+		for (var iter = expectations.iterator(); iter.hasNext(); ) {
+			final var change = iter.next();
+			if (change.getKey().equals(account)) {
+				iter.remove();
+				break;
+			}
+		}
+	}
+}

--- a/test-clients/src/main/java/com/hedera/services/bdd/spec/assertions/TransactionRecordAsserts.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/spec/assertions/TransactionRecordAsserts.java
@@ -131,6 +131,11 @@ public class TransactionRecordAsserts extends BaseErroringAssertsProvider<Transa
 		return this;
 	}
 
+	public TransactionRecordAsserts tokenTransfers(ErroringAssertsProvider<List<TokenTransferList>> provider) {
+		registerTypedProvider("tokenTransferListsList", provider);
+		return this;
+	}
+
 	private <T> void registerTypedProvider(String forField, ErroringAssertsProvider<T> provider) {
 		try {
 			Method m = TransactionRecord.class.getMethod(QueryUtils.asGetter(forField));

--- a/test-clients/src/main/java/com/hedera/services/bdd/spec/fees/FeesAndRatesProvider.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/spec/fees/FeesAndRatesProvider.java
@@ -154,7 +154,6 @@ public class FeesAndRatesProvider {
 		byte[] bytes = response.getFileContents().getContents().toByteArray();
 		CurrentAndNextFeeSchedule wrapper = CurrentAndNextFeeSchedule.parseFrom(bytes);
 		feeSchedule = typePatching.withPatchedTypesIfNecessary(wrapper.getCurrentFeeSchedule());
-		log.info("The patched fee schedule is {}", feeSchedule);
 		log.info("The fee schedule covers " + feeSchedule.getTransactionFeeScheduleList().size() + " ops.");
 	}
 

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/TransferWithCustomFees.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/TransferWithCustomFees.java
@@ -179,7 +179,7 @@ public class TransferWithCustomFees extends HapiApiSuite {
 						cryptoTransfer(moving(1, token).between(tokenOwner, tokenReceiver))
 								.fee(ONE_HUNDRED_HBARS)
 								.payingWith(tokenOwner)
-								.hasKnownStatus(ResponseCodeEnum.INSUFFICIENT_PAYER_BALANCE_FOR_CUSTOM_FEE)
+								.hasKnownStatus(ResponseCodeEnum.INSUFFICIENT_SENDER_ACCOUNT_BALANCE_FOR_CUSTOM_FEE)
 				);
 	}
 

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenTransactSpecs.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenTransactSpecs.java
@@ -1344,9 +1344,10 @@ public class TokenTransactSpecs extends HapiApiSuite {
 	*   2. Create non-fungible "artToken" with custom fee of 1 unit protocolToken.
 	*   3. Use account "gabriella" as treasury for both tokens.
 	*   4. Create account "harry" associated ONLY to artToken.
-	*   5. Mint serial no 1 for art token, transfer to harry (no custom fee since gabriella is treasury and exempt)
-	*   6. Transfer serial no 1 back to gabriella from harry
-	*     - Transfer fails (correctly) with TOKEN_NOT_ASSOCIATED_TO_ACCOUNT, as harry isn't associated to protocolToken
+	*   5. Mint serial no 1 for art token, transfer to harry (no custom fee since gabriella is treasury and exempt).
+	*   6. Transfer serial no 1 back to gabriella from harry.
+	*     - Transfer fails (correctly) with TOKEN_NOT_ASSOCIATED_TO_ACCOUNT, as harry
+	*       isn't associated to protocolToken and can't pay the custom fee
 	*     - But...a following getTokenNftInfo query shows that harry is no longer the owner of serial no 1!
 	*     - This is because nftsLedger.rollback() wasn't actually called, even thought the transfer failed.
 	* */

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenTransactSpecs.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenTransactSpecs.java
@@ -1313,7 +1313,6 @@ public class TokenTransactSpecs extends HapiApiSuite {
 		final var protocolToken = "protocolToken";
 		final var gabriella = "gabriella";
 		final var harry = "harry";
-		final var feeExemptTxn = "feeExemptTxn";
 		final var nonExemptUnderfundedTxn = "nonExemptUnderfundedTxn";
 		final var nonExemptFundedTxn = "nonExemptFundedTxn";
 
@@ -1331,16 +1330,16 @@ public class TokenTransactSpecs extends HapiApiSuite {
 				).when(
 						tokenAssociate(harry, protocolToken),
 						cryptoTransfer(moving(100, protocolToken).between(gabriella, harry))
-								.via(feeExemptTxn),
-						getTxnRecord(feeExemptTxn).logged()
 				).then(
 						cryptoTransfer(moving(100, protocolToken).between(harry, gabriella))
 								.via(nonExemptUnderfundedTxn)
+								.fee(ONE_HBAR)
 								.hasKnownStatus(INSUFFICIENT_SENDER_ACCOUNT_BALANCE_FOR_CUSTOM_FEE),
 						getTxnRecord(nonExemptUnderfundedTxn)
 								.hasPriority(recordWith()
 										.tokenTransfers(changingNoFungibleBalances())),
 						cryptoTransfer(moving(99, protocolToken).between(harry, gabriella))
+								.fee(ONE_HBAR)
 								.via(nonExemptFundedTxn),
 						getTxnRecord(nonExemptFundedTxn)
 								.hasPriority(recordWith()

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenTransactSpecs.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenTransactSpecs.java
@@ -33,7 +33,9 @@ import java.util.OptionalLong;
 
 import static com.hedera.services.bdd.spec.HapiApiSpec.defaultHapiSpec;
 import static com.hedera.services.bdd.spec.assertions.AccountInfoAsserts.changeFromSnapshot;
+import static com.hedera.services.bdd.spec.assertions.NoFungibleTransfers.changingNoFungibleBalances;
 import static com.hedera.services.bdd.spec.assertions.NoNftTransfers.changingNoNftOwners;
+import static com.hedera.services.bdd.spec.assertions.SomeFungibleTransfers.changingSomeFungibleBalances;
 import static com.hedera.services.bdd.spec.assertions.TransactionRecordAsserts.recordWith;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getAccountBalance;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getAccountInfo;
@@ -70,6 +72,7 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.ACCOUNT_FROZEN
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.ACCOUNT_REPEATED_IN_ACCOUNT_AMOUNTS;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.EMPTY_TOKEN_TRANSFER_ACCOUNT_AMOUNTS;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INSUFFICIENT_ACCOUNT_BALANCE;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INSUFFICIENT_SENDER_ACCOUNT_BALANCE_FOR_CUSTOM_FEE;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INSUFFICIENT_TOKEN_BALANCE;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_ACCOUNT_AMOUNTS;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_ACCOUNT_ID;
@@ -100,38 +103,38 @@ public class TokenTransactSpecs extends HapiApiSuite {
 	@Override
 	protected List<HapiApiSpec> getSpecsInSuite() {
 		return List.of(new HapiApiSpec[] {
-//						balancesChangeOnTokenTransfer(),
-//						accountsMustBeExplicitlyUnfrozenOnlyIfDefaultFreezeIsTrue(),
-//						senderSigsAreValid(),
-//						balancesAreChecked(),
-//						duplicateAccountsInTokenTransferRejected(),
-//						tokenOnlyTxnsAreAtomic(),
-//						tokenPlusHbarTxnsAreAtomic(),
-//						nonZeroTransfersRejected(),
-//						prechecksWork(),
-//						missingEntitiesRejected(),
-//						allRequiredSigsAreChecked(),
-//						uniqueTokenTxnAccountBalance(),
-//						uniqueTokenTxnAccountBalancesForTreasury(),
-//						uniqueTokenTxnWithNoAssociation(),
-//						uniqueTokenTxnWithFrozenAccount(),
-//						uniqueTokenTxnWithSenderNotSigned(),
-//						uniqueTokenTxnWithReceiverNotSigned(),
-//						uniqueTokenTxnsAreAtomic(),
-//						uniqueTokenDeletedTxn(),
-//						cannotSendFungibleToDissociatedContractsOrAccounts(),
-//						cannotGiveNftsToDissociatedContractsOrAccounts(),
-//						recordsIncludeBothFungibleTokenChangesAndOwnershipChange(),
-//						transferListsEnforceTokenTypeRestrictions(),
-//						/* HIP-18 charging case studies */
-//						fixedHbarCaseStudy(),
-//						fractionalCaseStudy(),
-//						simpleHtsFeeCaseStudy(),
-//						nestedHbarCaseStudy(),
-//						nestedFractionalCaseStudy(),
-//						nestedHtsCaseStudy(),
-//						treasuriesAreExemptFromAllCustomFees(),
-//						collectorsAreExemptFromTheirOwnFeesButNotOthers(),
+						balancesChangeOnTokenTransfer(),
+						accountsMustBeExplicitlyUnfrozenOnlyIfDefaultFreezeIsTrue(),
+						senderSigsAreValid(),
+						balancesAreChecked(),
+						duplicateAccountsInTokenTransferRejected(),
+						tokenOnlyTxnsAreAtomic(),
+						tokenPlusHbarTxnsAreAtomic(),
+						nonZeroTransfersRejected(),
+						prechecksWork(),
+						missingEntitiesRejected(),
+						allRequiredSigsAreChecked(),
+						uniqueTokenTxnAccountBalance(),
+						uniqueTokenTxnAccountBalancesForTreasury(),
+						uniqueTokenTxnWithNoAssociation(),
+						uniqueTokenTxnWithFrozenAccount(),
+						uniqueTokenTxnWithSenderNotSigned(),
+						uniqueTokenTxnWithReceiverNotSigned(),
+						uniqueTokenTxnsAreAtomic(),
+						uniqueTokenDeletedTxn(),
+						cannotSendFungibleToDissociatedContractsOrAccounts(),
+						cannotGiveNftsToDissociatedContractsOrAccounts(),
+						recordsIncludeBothFungibleTokenChangesAndOwnershipChange(),
+						transferListsEnforceTokenTypeRestrictions(),
+						/* HIP-18 charging case studies */
+						fixedHbarCaseStudy(),
+						fractionalCaseStudy(),
+						simpleHtsFeeCaseStudy(),
+						nestedHbarCaseStudy(),
+						nestedFractionalCaseStudy(),
+						nestedHtsCaseStudy(),
+						treasuriesAreExemptFromAllCustomFees(),
+						collectorsAreExemptFromTheirOwnFeesButNotOthers(),
 						canTransactInTokenWithSelfDenominatedFixedFee(),
 //						nftOwnersChangeAtomically(),
 				}
@@ -1311,7 +1314,8 @@ public class TokenTransactSpecs extends HapiApiSuite {
 		final var gabriella = "gabriella";
 		final var harry = "harry";
 		final var feeExemptTxn = "feeExemptTxn";
-		final var nonExemptTxn = "nonExemptTxn";
+		final var nonExemptUnderfundedTxn = "nonExemptUnderfundedTxn";
+		final var nonExemptFundedTxn = "nonExemptFundedTxn";
 
 		return defaultHapiSpec("CanTransactInTokenWithSelfDenominatedFixedFee")
 				.given(
@@ -1331,26 +1335,36 @@ public class TokenTransactSpecs extends HapiApiSuite {
 						getTxnRecord(feeExemptTxn).logged()
 				).then(
 						cryptoTransfer(moving(100, protocolToken).between(harry, gabriella))
-								.via(nonExemptTxn),
-						getTxnRecord(nonExemptTxn).logged()
+								.via(nonExemptUnderfundedTxn)
+								.hasKnownStatus(INSUFFICIENT_SENDER_ACCOUNT_BALANCE_FOR_CUSTOM_FEE),
+						getTxnRecord(nonExemptUnderfundedTxn)
+								.hasPriority(recordWith()
+										.tokenTransfers(changingNoFungibleBalances())),
+						cryptoTransfer(moving(99, protocolToken).between(harry, gabriella))
+								.via(nonExemptFundedTxn),
+						getTxnRecord(nonExemptFundedTxn)
+								.hasPriority(recordWith()
+										.tokenTransfers(changingSomeFungibleBalances()
+												.including(protocolToken, gabriella, +100L)
+												.including(protocolToken, harry, -100L)))
 				);
 	}
 
 	/* ⛔️ Should pass after fix for https://github.com/hashgraph/hedera-services/issues/1919 ⛔️
 	 *
-	* SCENARIO:
-	* ---------
-	*   1. Create fungible "protocolToken" to use for a custom fee.
-	*   2. Create non-fungible "artToken" with custom fee of 1 unit protocolToken.
-	*   3. Use account "gabriella" as treasury for both tokens.
-	*   4. Create account "harry" associated ONLY to artToken.
-	*   5. Mint serial no 1 for art token, transfer to harry (no custom fee since gabriella is treasury and exempt).
-	*   6. Transfer serial no 1 back to gabriella from harry.
-	*     - Transfer fails (correctly) with TOKEN_NOT_ASSOCIATED_TO_ACCOUNT, as harry
-	*       isn't associated to protocolToken and can't pay the custom fee
-	*     - But...a following getTokenNftInfo query shows that harry is no longer the owner of serial no 1!
-	*     - This is because nftsLedger.rollback() wasn't actually called, even thought the transfer failed.
-	* */
+	 * SCENARIO:
+	 * ---------
+	 *   1. Create fungible "protocolToken" to use for a custom fee.
+	 *   2. Create non-fungible "artToken" with custom fee of 1 unit protocolToken.
+	 *   3. Use account "gabriella" as treasury for both tokens.
+	 *   4. Create account "harry" associated ONLY to artToken.
+	 *   5. Mint serial no 1 for art token, transfer to harry (no custom fee since gabriella is treasury and exempt).
+	 *   6. Transfer serial no 1 back to gabriella from harry.
+	 *     - Transfer fails (correctly) with TOKEN_NOT_ASSOCIATED_TO_ACCOUNT, as harry
+	 *       isn't associated to protocolToken and can't pay the custom fee
+	 *     - But...a following getTokenNftInfo query shows that harry is no longer the owner of serial no 1!
+	 *     - This is because nftsLedger.rollback() wasn't actually called, even thought the transfer failed.
+	 * */
 	public HapiApiSpec nftOwnersChangeAtomically() {
 		final var artToken = "artToken";
 		final var protocolToken = "protocolToken";
@@ -1358,6 +1372,7 @@ public class TokenTransactSpecs extends HapiApiSuite {
 		final var harry = "harry";
 		final var uncompletableTxn = "uncompletableTxn";
 		final var supplyKey = "supplyKey";
+		final var serialNo1Meta = ByteString.copyFromUtf8("PRICELESS");
 
 		return defaultHapiSpec("CanTransactInTokenWithSelfDenominatedFixedFee")
 				.given(
@@ -1380,7 +1395,7 @@ public class TokenTransactSpecs extends HapiApiSuite {
 								.treasury(gabriella)
 								.withCustom(fixedHtsFee(1, protocolToken, gabriella))
 				).when(
-						mintToken(artToken, List.of(ByteString.copyFromUtf8("PRICELESS"))),
+						mintToken(artToken, List.of(serialNo1Meta)),
 						tokenAssociate(harry, artToken),
 						cryptoTransfer(movingUnique(artToken, 1L).between(gabriella, harry))
 				).then(
@@ -1388,11 +1403,13 @@ public class TokenTransactSpecs extends HapiApiSuite {
 								.via(uncompletableTxn)
 								.hasKnownStatus(TOKEN_NOT_ASSOCIATED_TO_ACCOUNT),
 						getTxnRecord(uncompletableTxn)
-								.logged()
 								.hasPriority(recordWith().tokenTransfers(changingNoNftOwners())),
 						getTokenNftInfo(artToken, 1L)
 								.hasAccountID(harry)
-								.logged()
+						/* ⛔️ Should pass after fix for https://github.com/hashgraph/hedera-services/issues/1918 ⛔️ */
+//						getAccountNftInfos(harry, 0, 1)
+//								.hasNfts(newTokenNftInfo(artToken, 1L, harry, serialNo1Meta))
+
 				);
 	}
 

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenTransactSpecs.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenTransactSpecs.java
@@ -132,8 +132,8 @@ public class TokenTransactSpecs extends HapiApiSuite {
 //						nestedHtsCaseStudy(),
 //						treasuriesAreExemptFromAllCustomFees(),
 //						collectorsAreExemptFromTheirOwnFeesButNotOthers(),
-//						canTransactInTokenWithSelfDenominatedFixedFee(),
-						nftOwnersChangeAtomically(),
+						canTransactInTokenWithSelfDenominatedFixedFee(),
+//						nftOwnersChangeAtomically(),
 				}
 		);
 	}


### PR DESCRIPTION
**Related issue(s)**:
- Closes #1925
- Closes #1825

**Description**:
- Add an [`exemptFromCustomFees` field](https://github.com/hashgraph/hedera-services/blob/01925-M-TrackFeeExemptBalanceChanges/hedera-node/src/main/java/com/hedera/services/ledger/BalanceChange.java#L59) in `BalanceChange`.
- Pass the `chargingToken` id to the [`HtsFeeAssessor.assess()` method](https://github.com/hashgraph/hedera-services/blob/01925-M-TrackFeeExemptBalanceChanges/hedera-node/src/main/java/com/hedera/services/grpc/marshalling/FeeAssessor.java#L83). 
- When the `chargingToken` matches an HTS fee `denom`, [set `exemptFromCustomFees=true`](https://github.com/hashgraph/hedera-services/blob/01925-M-TrackFeeExemptBalanceChanges/hedera-node/src/main/java/com/hedera/services/grpc/marshalling/AdjustmentUtils.java#L63).
- In `BalanceChangeManager.nextAssessableChange()`, [ignore any `BalanceChange`](https://github.com/hashgraph/hedera-services/blob/01925-M-TrackFeeExemptBalanceChanges/hedera-node/src/main/java/com/hedera/services/grpc/marshalling/BalanceChangeManager.java#L125) marked exempt.
- Add [`TokenTransactSpecs.canTransactInTokenWithSelfDenominatedFixedFee()` EET](https://github.com/hashgraph/hedera-services/blob/01925-M-TrackFeeExemptBalanceChanges/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenTransactSpecs.java#L1312), along with some improvements to assertions on `tokenTransferLists` in records.
- Switch to `INSUFFICIENT_SENDER_ACCOUNT_BALANCE_FOR_CUSTOM_FEE` response code.