### PR TITLE
Downgrade `Jackson-databind` from `v2.12.4` to `v2.11.2`

### DIFF
--- a/hedera-node/pom.xml
+++ b/hedera-node/pom.xml
@@ -25,6 +25,7 @@
     <git-commit-id.version>2.2.4</git-commit-id.version>
     <ant-contrib.version>1.0b3</ant-contrib.version>
     <ant-nodeps.version>1.8.1</ant-nodeps.version>
+    <jackson-databind.version>2.11.0</jackson-databind.version>
   </properties>
 
   <build>
@@ -264,10 +265,12 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
+      <version>${jackson-databind.version}</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>
       <artifactId>jackson-datatype-jsr310</artifactId>
+      <version>${jackson-databind.version}</version>
     </dependency>
     <dependency>
       <groupId>io.grpc</groupId>

--- a/hedera-node/pom.xml
+++ b/hedera-node/pom.xml
@@ -25,7 +25,7 @@
     <git-commit-id.version>2.2.4</git-commit-id.version>
     <ant-contrib.version>1.0b3</ant-contrib.version>
     <ant-nodeps.version>1.8.1</ant-nodeps.version>
-    <jackson-databind.version>2.11.0</jackson-databind.version>
+    <jackson.version>2.11.2</jackson.version>
   </properties>
 
   <build>
@@ -265,12 +265,12 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>${jackson-databind.version}</version>
+      <version>${jackson.version}</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>
       <artifactId>jackson-datatype-jsr310</artifactId>
-      <version>${jackson-databind.version}</version>
+      <version>${jackson.version}</version>
     </dependency>
     <dependency>
       <groupId>io.grpc</groupId>

--- a/hedera-node/pom.xml
+++ b/hedera-node/pom.xml
@@ -266,6 +266,10 @@
       <artifactId>jackson-databind</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.fasterxml.jackson.datatype</groupId>
+      <artifactId>jackson-datatype-jsr310</artifactId>
+    </dependency>
+    <dependency>
       <groupId>io.grpc</groupId>
       <artifactId>grpc-netty</artifactId>
     </dependency>

--- a/hedera-node/pom.xml
+++ b/hedera-node/pom.xml
@@ -268,11 +268,6 @@
       <version>${jackson.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.fasterxml.jackson.datatype</groupId>
-      <artifactId>jackson-datatype-jsr310</artifactId>
-      <version>${jackson.version}</version>
-    </dependency>
-    <dependency>
       <groupId>io.grpc</groupId>
       <artifactId>grpc-netty</artifactId>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -409,16 +409,6 @@ ${git.signoff}
         <version>${swirlds.version}</version>
       </dependency>
       <dependency>
-        <groupId>com.fasterxml.jackson.core</groupId>
-        <artifactId>jackson-databind</artifactId>
-        <version>${jackson-databind.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>com.fasterxml.jackson.datatype</groupId>
-        <artifactId>jackson-datatype-jsr310</artifactId>
-        <version>${jackson-databind.version}</version>
-      </dependency>
-      <dependency>
         <groupId>org.junit</groupId>
         <artifactId>junit-bom</artifactId>
         <version>${junit5.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -163,7 +163,6 @@
     <grpc.version>1.39.0</grpc.version>
     <guava.version>30.1.1-jre</guava.version>
     <hapi-proto.version>0.17.0-SNAPSHOT</hapi-proto.version>
-    <jackson-databind.version>2.12.4</jackson-databind.version>
     <javax.annotation-api.version>1.3.2</javax.annotation-api.version>
     <javax-inject.version>1</javax-inject.version>
     <log4j.version>2.14.1</log4j.version>


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->

**Related issue(s)**:
Use the same `Jackson-databind` version as Platform by downgrading from `v2.12.4` to `v2.11.2`

Fixes #1954 

**Notes for reviewer**:
Moved the `Jackson-databind` dependency from `services` to `Hedera-node` and it is used just there.

Test Result:
[HTS-Restart-AccountBalances-2k-20m](https://hedera-hashgraph.slack.com/archives/C018CBQBTGB/p1628608618041700)
[Crypto-Migration-Testnet-100-7m](https://hedera-hashgraph.slack.com/archives/C018CBQBTGB/p1628611721042200)

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
