### PR TITLE
Extract transfer list from HederaLedger

### DIFF
--- a/hedera-node/src/main/java/com/hedera/services/context/ServicesContext.java
+++ b/hedera-node/src/main/java/com/hedera/services/context/ServicesContext.java
@@ -1744,7 +1744,8 @@ public class ServicesContext {
 					validator(),
 					recordsHistorian(),
 					globalDynamicProperties(),
-					accountsLedger);
+					accountsLedger,
+					new TransactionRecordService(txnCtx()));
 			ledger.setTokenViewsManager(uniqTokenViewsManager());
 			scheduleStore().setAccountsLedger(accountsLedger);
 			scheduleStore().setHederaLedger(ledger);
@@ -2120,7 +2121,8 @@ public class ServicesContext {
 					validator(),
 					NOOP_RECORDS_HISTORIAN,
 					globalDynamicProperties(),
-					pureDelegate);
+					pureDelegate,
+					new TransactionRecordService(txnCtx()));
 			Source<byte[], AccountState> pureAccountSource = new LedgerAccountsSource(pureLedger);
 			newPureRepo = () -> {
 				var pureRepository = new ServicesRepositoryRoot(pureAccountSource, bytecodeDb());

--- a/hedera-node/src/main/java/com/hedera/services/records/TransactionRecordService.java
+++ b/hedera-node/src/main/java/com/hedera/services/records/TransactionRecordService.java
@@ -154,7 +154,11 @@ public class TransactionRecordService {
 	}
 
 	/**
+	 * Given a list of {@link BalanceChange}, constructs a transfer list for the records
+	 * of the active crypto transaction.
 	 *
+	 * @param changes
+	 * 		A list of {@link BalanceChange}
 	 * */
 	public void includeAdjustmentsFrom(List<BalanceChange> changes) {
 		for (var change : changes) {

--- a/hedera-node/src/test/java/com/hedera/services/ledger/BaseHederaLedgerTestHelper.java
+++ b/hedera-node/src/test/java/com/hedera/services/ledger/BaseHederaLedgerTestHelper.java
@@ -29,6 +29,7 @@ import com.hedera.services.ledger.properties.NftProperty;
 import com.hedera.services.ledger.properties.TokenRelProperty;
 import com.hedera.services.legacy.core.jproto.JEd25519Key;
 import com.hedera.services.records.AccountRecordsHistorian;
+import com.hedera.services.records.TransactionRecordService;
 import com.hedera.services.state.expiry.ExpiringCreations;
 import com.hedera.services.state.merkle.MerkleAccount;
 import com.hedera.services.state.merkle.MerkleAccountTokens;
@@ -81,6 +82,7 @@ public class BaseHederaLedgerTestHelper {
 	protected EntityIdSource ids;
 	protected ExpiringCreations creator;
 	protected AccountRecordsHistorian historian;
+	protected TransactionRecordService transactionRecordService;
 	protected TransactionalLedger<NftId, NftProperty, MerkleUniqueToken> nftsLedger;
 	protected TransactionalLedger<AccountID, AccountProperty, MerkleAccount> accountsLedger;
 	protected TransactionalLedger<Pair<AccountID, TokenID>, TokenRelProperty, MerkleTokenRelStatus> tokenRelsLedger;
@@ -103,6 +105,7 @@ public class BaseHederaLedgerTestHelper {
 	protected void commonSetup() {
 		creator = mock(ExpiringCreations.class);
 		historian = mock(AccountRecordsHistorian.class);
+		transactionRecordService = mock(TransactionRecordService.class);
 
 		ids = new EntityIdSource() {
 			long nextId = NEXT_ID;
@@ -184,6 +187,8 @@ public class BaseHederaLedgerTestHelper {
 		token = mock(MerkleToken.class);
 		given(token.freezeKey()).willReturn(Optional.empty());
 
+		transactionRecordService = mock(TransactionRecordService.class);
+
 		nftsLedger = mock(TransactionalLedger.class);
 		accountsLedger = mock(TransactionalLedger.class);
 		tokenRelsLedger = mock(TransactionalLedger.class);
@@ -211,7 +216,8 @@ public class BaseHederaLedgerTestHelper {
 				.willReturn(tokenId);
 		given(tokenStore.get(frozenId)).willReturn(frozenToken);
 
-		subject = new HederaLedger(tokenStore, ids, creator, validator, historian, dynamicProps, accountsLedger);
+		subject = new HederaLedger(tokenStore, ids, creator, validator, historian,
+				dynamicProps, accountsLedger, transactionRecordService);
 		subject.setTokenRelsLedger(tokenRelsLedger);
 		subject.setNftsLedger(nftsLedger);
 	}

--- a/hedera-node/src/test/java/com/hedera/services/ledger/HederaLedgerLiveTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/ledger/HederaLedgerLiveTest.java
@@ -105,7 +105,8 @@ public class HederaLedgerLiveTest extends BaseHederaLedgerTestHelper {
 				() -> tokens,
 				tokenRelsLedger,
 				nftsLedger);
-		subject = new HederaLedger(tokenStore, ids, creator, validator, historian, dynamicProps, accountsLedger);
+		subject = new HederaLedger(tokenStore, ids, creator, validator, historian,
+				dynamicProps, accountsLedger, transactionRecordService);
 	}
 
 	@Test

--- a/hedera-node/src/test/java/com/hedera/services/ledger/HederaLedgerTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/ledger/HederaLedgerTest.java
@@ -173,7 +173,8 @@ public class HederaLedgerTest extends BaseHederaLedgerTestHelper {
 		given(validator.isAfterConsensusSecond(anyLong())).willReturn(false);
 		given(accountsLedger.get(genesis, BALANCE)).willReturn(0L);
 		// and:
-		subject = new HederaLedger(tokenStore, ids, creator, validator, historian, dynamicProps, accountsLedger);
+		subject = new HederaLedger(tokenStore, ids, creator, validator, historian,
+				dynamicProps, accountsLedger, transactionRecordService);
 
 		// when:
 		var result = subject.isDetached(genesis);
@@ -190,7 +191,8 @@ public class HederaLedgerTest extends BaseHederaLedgerTestHelper {
 		given(accountsLedger.get(genesis, BALANCE)).willReturn(0L);
 		given(accountsLedger.get(genesis, IS_SMART_CONTRACT)).willReturn(true);
 		// and:
-		subject = new HederaLedger(tokenStore, ids, creator, validator, historian, dynamicProps, accountsLedger);
+		subject = new HederaLedger(tokenStore, ids, creator, validator, historian,
+				dynamicProps, accountsLedger, transactionRecordService);
 
 		// when:
 		var result = subject.isDetached(genesis);
@@ -206,7 +208,8 @@ public class HederaLedgerTest extends BaseHederaLedgerTestHelper {
 		given(validator.isAfterConsensusSecond(anyLong())).willReturn(false);
 		given(accountsLedger.get(genesis, BALANCE)).willReturn(0L);
 		// and:
-		subject = new HederaLedger(tokenStore, ids, creator, validator, historian, dynamicProps, accountsLedger);
+		subject = new HederaLedger(tokenStore, ids, creator, validator, historian,
+				dynamicProps, accountsLedger, transactionRecordService);
 		// and:
 		dynamicProps.disableAutoRenew();
 

--- a/hedera-node/src/test/java/com/hedera/services/ledger/HederaLedgerXfersTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/ledger/HederaLedgerXfersTest.java
@@ -124,7 +124,8 @@ public class HederaLedgerXfersTest extends BaseHederaLedgerTestHelper {
 		given(mockValidator.isAfterConsensusSecond(1_234_567_890L)).willReturn(true);
 		given(mockValidator.isAfterConsensusSecond(666L)).willReturn(false);
 
-		subject = new HederaLedger(tokenStore, ids, creator, mockValidator, historian, dynamicProps, accountsLedger);
+		subject = new HederaLedger(tokenStore, ids, creator, mockValidator, historian,
+				dynamicProps, accountsLedger, transactionRecordService);
 		subject.setTokenRelsLedger(tokenRelsLedger);
 
 		// expect:
@@ -151,7 +152,8 @@ public class HederaLedgerXfersTest extends BaseHederaLedgerTestHelper {
 		given(mockValidator.isAfterConsensusSecond(1_234_567_890L)).willReturn(true);
 		given(mockValidator.isAfterConsensusSecond(666L)).willReturn(false);
 
-		subject = new HederaLedger(tokenStore, ids, creator, mockValidator, historian, dynamicProps, accountsLedger);
+		subject = new HederaLedger(tokenStore, ids, creator, mockValidator, historian,
+				dynamicProps, accountsLedger, transactionRecordService);
 		subject.setTokenRelsLedger(tokenRelsLedger);
 
 		// expect:

--- a/hedera-node/src/test/java/com/hedera/services/ledger/LedgerBalanceChangesTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/ledger/LedgerBalanceChangesTest.java
@@ -33,6 +33,7 @@ import com.hedera.services.ledger.properties.ChangeSummaryManager;
 import com.hedera.services.ledger.properties.NftProperty;
 import com.hedera.services.ledger.properties.TokenRelProperty;
 import com.hedera.services.records.AccountRecordsHistorian;
+import com.hedera.services.records.TransactionRecordService;
 import com.hedera.services.state.enums.TokenType;
 import com.hedera.services.state.expiry.ExpiringCreations;
 import com.hedera.services.state.merkle.MerkleAccount;
@@ -113,6 +114,8 @@ class LedgerBalanceChangesTest {
 	private AccountRecordsHistorian historian;
 	@Mock
 	private UniqTokenViewsManager tokenViewsManager;
+	@Mock
+	private TransactionRecordService transactionRecordService;
 
 	private HederaLedger subject;
 
@@ -147,7 +150,8 @@ class LedgerBalanceChangesTest {
 				tokenRelsLedger,
 				nftsLedger);
 
-		subject = new HederaLedger(tokenStore, ids, creator, validator, historian, dynamicProperties, accountsLedger);
+		subject = new HederaLedger(tokenStore, ids, creator, validator, historian,
+				dynamicProperties, accountsLedger, transactionRecordService);
 		subject.setTokenRelsLedger(tokenRelsLedger);
 		subject.setTokenViewsManager(tokenViewsManager);
 	}
@@ -246,7 +250,8 @@ class LedgerBalanceChangesTest {
 				tokenRelsLedger,
 				nftsLedger);
 
-		subject = new HederaLedger(tokenStore, ids, creator, validator, historian, dynamicProperties, accountsLedger);
+		subject = new HederaLedger(tokenStore, ids, creator, validator, historian,
+				dynamicProperties, accountsLedger, transactionRecordService);
 		subject.setTokenRelsLedger(tokenRelsLedger);
 		subject.setTokenViewsManager(viewManager);
 

--- a/hedera-node/src/test/java/com/hedera/services/legacy/RepoNewCacheTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/legacy/RepoNewCacheTest.java
@@ -31,6 +31,7 @@ import com.hedera.services.ledger.properties.AccountProperty;
 import com.hedera.services.ledger.properties.ChangeSummaryManager;
 import com.hedera.services.legacy.core.jproto.JContractIDKey;
 import com.hedera.services.records.AccountRecordsHistorian;
+import com.hedera.services.records.TransactionRecordService;
 import com.hedera.services.state.expiry.ExpiringCreations;
 import com.hedera.services.state.merkle.MerkleAccount;
 import com.hedera.services.state.merkle.MerkleBlobMeta;
@@ -78,7 +79,8 @@ class RepoNewCacheTest {
 				TestContextValidator.TEST_VALIDATOR,
 				mock(AccountRecordsHistorian.class),
 				new MockGlobalDynamicProps(),
-				delegate);
+				delegate,
+				mock(TransactionRecordService.class));
 		Source<byte[], AccountState> repDatabase = new LedgerAccountsSource(ledger);
 		ServicesRepositoryRoot repository = new ServicesRepositoryRoot(repDatabase, repDBFile);
 		String key = CommonUtils.hex(EntityIdUtils.asSolidityAddress(0, 0, 1));
@@ -175,7 +177,8 @@ class RepoNewCacheTest {
 				TestContextValidator.TEST_VALIDATOR,
 				mock(AccountRecordsHistorian.class),
 				new MockGlobalDynamicProps(),
-				delegate);
+				delegate,
+				mock(TransactionRecordService.class));
 		Source<byte[], AccountState> accountSource = new LedgerAccountsSource(ledger);
 		ServicesRepositoryRoot repository = new ServicesRepositoryRoot(accountSource, repDBFile);
 

--- a/hedera-node/src/test/java/com/hedera/services/legacy/unit/handler/SmartContractRequestHandlerMiscTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/legacy/unit/handler/SmartContractRequestHandlerMiscTest.java
@@ -39,6 +39,7 @@ import com.hedera.services.legacy.unit.FCStorageWrapper;
 import com.hedera.services.legacy.unit.StorageKeyNotFoundException;
 import com.hedera.services.legacy.util.SCEncoding;
 import com.hedera.services.records.AccountRecordsHistorian;
+import com.hedera.services.records.TransactionRecordService;
 import com.hedera.services.state.expiry.ExpiringCreations;
 import com.hedera.services.state.merkle.MerkleAccount;
 import com.hedera.services.state.merkle.MerkleBlobMeta;
@@ -50,24 +51,7 @@ import com.hedera.services.utils.EntityIdUtils;
 import com.hedera.test.mocks.SolidityLifecycleFactory;
 import com.hedera.test.mocks.StorageSourceFactory;
 import com.hedera.test.mocks.TestContextValidator;
-import com.hederahashgraph.api.proto.java.AccountID;
-import com.hederahashgraph.api.proto.java.ContractCallLocalQuery;
-import com.hederahashgraph.api.proto.java.ContractCallLocalResponse;
-import com.hederahashgraph.api.proto.java.ContractID;
-import com.hederahashgraph.api.proto.java.Duration;
-import com.hederahashgraph.api.proto.java.ExchangeRateSet;
-import com.hederahashgraph.api.proto.java.FeeData;
-import com.hederahashgraph.api.proto.java.FileID;
-import com.hederahashgraph.api.proto.java.HederaFunctionality;
-import com.hederahashgraph.api.proto.java.Key;
-import com.hederahashgraph.api.proto.java.Query;
-import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
-import com.hederahashgraph.api.proto.java.ResponseType;
-import com.hederahashgraph.api.proto.java.SubType;
-import com.hederahashgraph.api.proto.java.Timestamp;
-import com.hederahashgraph.api.proto.java.Transaction;
-import com.hederahashgraph.api.proto.java.TransactionBody;
-import com.hederahashgraph.api.proto.java.TransactionRecord;
+import com.hederahashgraph.api.proto.java.*;
 import com.hederahashgraph.builder.RequestBuilder;
 import com.hederahashgraph.fee.FeeBuilder;
 import com.swirlds.common.CommonUtils;
@@ -80,11 +64,7 @@ import org.ethereum.crypto.HashUtil;
 import org.ethereum.datasource.DbSource;
 import org.ethereum.datasource.Source;
 import org.ethereum.db.ServicesRepositoryRoot;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -164,7 +144,8 @@ class SmartContractRequestHandlerMiscTest {
             TestContextValidator.TEST_VALIDATOR,
             mock(AccountRecordsHistorian.class),
             new MockGlobalDynamicProps(),
-            delegate);
+            delegate,
+            mock(TransactionRecordService.class));
     ledgerSource = new LedgerAccountsSource(ledger);
     Source<byte[], AccountState> repDatabase = ledgerSource;
     ServicesRepositoryRoot repository = new ServicesRepositoryRoot(repDatabase, repDBFile);

--- a/hedera-node/src/test/java/com/hedera/services/legacy/unit/handler/SmartContractRequestHandlerPayableTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/legacy/unit/handler/SmartContractRequestHandlerPayableTest.java
@@ -37,6 +37,7 @@ import com.hedera.services.legacy.handler.SmartContractRequestHandler;
 import com.hedera.services.legacy.unit.FCStorageWrapper;
 import com.hedera.services.legacy.util.SCEncoding;
 import com.hedera.services.records.AccountRecordsHistorian;
+import com.hedera.services.records.TransactionRecordService;
 import com.hedera.services.state.expiry.ExpiringCreations;
 import com.hedera.services.state.merkle.MerkleAccount;
 import com.hedera.services.state.merkle.MerkleBlobMeta;
@@ -49,21 +50,7 @@ import com.hedera.test.mocks.SolidityLifecycleFactory;
 import com.hedera.test.mocks.StorageSourceFactory;
 import com.hedera.test.mocks.TestContextValidator;
 import com.hedera.test.mocks.TestUsagePricesProvider;
-import com.hederahashgraph.api.proto.java.AccountID;
-import com.hederahashgraph.api.proto.java.ContractCallLocalQuery;
-import com.hederahashgraph.api.proto.java.ContractCallLocalResponse;
-import com.hederahashgraph.api.proto.java.ContractID;
-import com.hederahashgraph.api.proto.java.Duration;
-import com.hederahashgraph.api.proto.java.ExchangeRateSet;
-import com.hederahashgraph.api.proto.java.FileID;
-import com.hederahashgraph.api.proto.java.Key;
-import com.hederahashgraph.api.proto.java.Query;
-import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
-import com.hederahashgraph.api.proto.java.ResponseType;
-import com.hederahashgraph.api.proto.java.Timestamp;
-import com.hederahashgraph.api.proto.java.Transaction;
-import com.hederahashgraph.api.proto.java.TransactionBody;
-import com.hederahashgraph.api.proto.java.TransactionRecord;
+import com.hederahashgraph.api.proto.java.*;
 import com.hederahashgraph.builder.RequestBuilder;
 import com.swirlds.common.CommonUtils;
 import com.swirlds.common.constructable.ClassConstructorPair;
@@ -76,11 +63,7 @@ import org.ethereum.core.AccountState;
 import org.ethereum.datasource.DbSource;
 import org.ethereum.datasource.Source;
 import org.ethereum.db.ServicesRepositoryRoot;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -149,7 +132,8 @@ class SmartContractRequestHandlerPayableTest {
             TestContextValidator.TEST_VALIDATOR,
             mock(AccountRecordsHistorian.class),
             new MockGlobalDynamicProps(),
-            delegate);
+            delegate,
+            mock(TransactionRecordService.class));
     ledgerSource = new LedgerAccountsSource(ledger);
     Source<byte[], AccountState> repDatabase = ledgerSource;
     ServicesRepositoryRoot repository = new ServicesRepositoryRoot(repDatabase, repDBFile);

--- a/hedera-node/src/test/java/com/hedera/services/legacy/unit/handler/SmartContractRequestHandlerStorageTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/legacy/unit/handler/SmartContractRequestHandlerStorageTest.java
@@ -39,6 +39,7 @@ import com.hedera.services.legacy.unit.FCStorageWrapper;
 import com.hedera.services.legacy.unit.StorageKeyNotFoundException;
 import com.hedera.services.legacy.util.SCEncoding;
 import com.hedera.services.records.AccountRecordsHistorian;
+import com.hedera.services.records.TransactionRecordService;
 import com.hedera.services.state.expiry.ExpiringCreations;
 import com.hedera.services.state.merkle.MerkleAccount;
 import com.hedera.services.state.merkle.MerkleBlobMeta;
@@ -51,23 +52,7 @@ import com.hedera.test.mocks.SolidityLifecycleFactory;
 import com.hedera.test.mocks.StorageSourceFactory;
 import com.hedera.test.mocks.TestContextValidator;
 import com.hedera.test.mocks.TestUsagePricesProvider;
-import com.hederahashgraph.api.proto.java.AccountID;
-import com.hederahashgraph.api.proto.java.ContractCallLocalQuery;
-import com.hederahashgraph.api.proto.java.ContractCallLocalResponse;
-import com.hederahashgraph.api.proto.java.ContractFunctionResult;
-import com.hederahashgraph.api.proto.java.ContractID;
-import com.hederahashgraph.api.proto.java.ContractLoginfo;
-import com.hederahashgraph.api.proto.java.Duration;
-import com.hederahashgraph.api.proto.java.ExchangeRateSet;
-import com.hederahashgraph.api.proto.java.FileID;
-import com.hederahashgraph.api.proto.java.Key;
-import com.hederahashgraph.api.proto.java.Query;
-import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
-import com.hederahashgraph.api.proto.java.ResponseType;
-import com.hederahashgraph.api.proto.java.Timestamp;
-import com.hederahashgraph.api.proto.java.Transaction;
-import com.hederahashgraph.api.proto.java.TransactionBody;
-import com.hederahashgraph.api.proto.java.TransactionRecord;
+import com.hederahashgraph.api.proto.java.*;
 import com.hederahashgraph.builder.RequestBuilder;
 import com.swirlds.common.CommonUtils;
 import com.swirlds.common.constructable.ClassConstructorPair;
@@ -83,11 +68,7 @@ import org.ethereum.datasource.Source;
 import org.ethereum.db.ServicesRepositoryRoot;
 import org.ethereum.solidity.Abi;
 import org.ethereum.solidity.Abi.Event;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -99,9 +80,7 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 
-import static com.hedera.services.legacy.util.SCEncoding.GET_MY_VALUE_ABI;
-import static com.hedera.services.legacy.util.SCEncoding.GROW_CHILD_ABI;
-import static com.hedera.services.legacy.util.SCEncoding.encodeVia;
+import static com.hedera.services.legacy.util.SCEncoding.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
@@ -156,7 +135,8 @@ class SmartContractRequestHandlerStorageTest {
             TestContextValidator.TEST_VALIDATOR,
             mock(AccountRecordsHistorian.class),
             new MockGlobalDynamicProps(),
-            delegate);
+            delegate,
+            mock(TransactionRecordService.class));
     ledgerSource = new LedgerAccountsSource(ledger);
     Source<byte[], AccountState> repDatabase = ledgerSource;
     ServicesRepositoryRoot repository = new ServicesRepositoryRoot(repDatabase, repDBFile);


### PR DESCRIPTION
Signed-off-by: abhishek-hedera <abhishek.pandey@hedera.com>

**Description**:
Removed `netTransfers`, `updateXfers`, `aaBuilderWith`, `purgeZeroAdjustments`, `adjustHbarUnchecked` from `HederaLedger` and instead handle in `TransactionRecordService`.

**Related issue(s)**:

Fixes #1852 

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
