### PR TITLE
Initialize `deserializedVersion = StateVersions.CURRENT_VERSION` instead of `-1`

### DIFF
--- a/hedera-node/src/main/java/com/hedera/services/ServicesState.java
+++ b/hedera-node/src/main/java/com/hedera/services/ServicesState.java
@@ -98,8 +98,8 @@ public class ServicesState extends AbstractNaryMerkleInternal implements SwirldS
 				PubKeyToSigBytes pkToSigFn);
 	}
 
-	/* If positive, the version of the saved state loaded to create this instance; if -1, this is the genesis state */
-	private int deserializedVersion = -1;
+	/* Will only be over-written when Platform deserializes a legacy version of the state */
+	private int deserializedVersion = StateVersions.CURRENT_VERSION;
 	/* All of the state that is not itself hashed or serialized, but only derived from such state */
 	private StateMetadata metadata;
 
@@ -151,11 +151,11 @@ public class ServicesState extends AbstractNaryMerkleInternal implements SwirldS
 
 	@Override
 	public void initialize() {
-		if (deserializedVersion <= StateVersions.RELEASE_0160_VERSION) {
+		if (deserializedVersion < StateVersions.CURRENT_VERSION) {
 			if (deserializedVersion < StateVersions.RELEASE_0160_VERSION) {
 				setChild(LegacyStateChildIndices.UNIQUE_TOKENS, new FCMap<>());
 			}
-			moveLargeFcmsToBinaryRoutePositions(this);
+			moveLargeFcmsToBinaryRoutePositions(this, deserializedVersion);
 		}
 	}
 

--- a/hedera-node/src/main/java/com/hedera/services/state/migration/Release0170Migration.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/migration/Release0170Migration.java
@@ -45,9 +45,9 @@ public class Release0170Migration {
 
 	private static TreeCopier treeCopier = MerkleCopy::copyTreeToLocation;
 
-	public static void moveLargeFcmsToBinaryRoutePositions(ServicesState initializingState) {
+	public static void moveLargeFcmsToBinaryRoutePositions(ServicesState initializingState, int deserializedVersion) {
 		log.info("Migrating from 0.16.0 state (version {} to {})",
-				StateVersions.RELEASE_0160_VERSION, StateVersions.RELEASE_0170_VERSION);
+				deserializedVersion, StateVersions.RELEASE_0170_VERSION);
 
 		/* First swap the address book and unique tokens */
 		final var movableBook = initializingState.getChild(LegacyStateChildIndices.ADDRESS_BOOK).copy();

--- a/hedera-node/src/test/java/com/hedera/services/state/migration/Release0170MigrationTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/state/migration/Release0170MigrationTest.java
@@ -28,6 +28,7 @@ import com.hedera.services.state.merkle.MerkleNetworkContext;
 import com.hedera.services.state.merkle.MerkleTokenRelStatus;
 import com.hedera.services.state.merkle.MerkleUniqueToken;
 import com.hedera.services.state.merkle.MerkleUniqueTokenId;
+import com.hedera.services.state.org.StateVersions;
 import com.swirlds.common.AddressBook;
 import com.swirlds.common.merkle.copy.MerkleCopy;
 import com.swirlds.fcmap.FCMap;
@@ -80,7 +81,7 @@ class Release0170MigrationTest {
 		given(state.getChild(LegacyStateChildIndices.TOKEN_ASSOCIATIONS)).willReturn(tokenRels);
 
 		// when:
-		moveLargeFcmsToBinaryRoutePositions(state);
+		moveLargeFcmsToBinaryRoutePositions(state, StateVersions.RELEASE_0160_VERSION);
 
 		// then:
 		verify(addressBook).copy();


### PR DESCRIPTION
We currently depend on `.addDeserializedChildren(List<MerkleNode> children, int version)` to be called to correctly trigger the [release 0.17.0 state migration](https://github.com/hashgraph/hedera-services/blob/master/hedera-node/src/main/java/com/hedera/services/ServicesState.java#L154). 

This is a bug, since during a reconnect `.addDeserializedChildren()` is never called; so we should instead initialize `deserializedVersion = StateVersions.CURRENT_VERSION`.