### PR TITLE
Only deserialize `netOfTransfers` if reading from 0.17.x state

### DIFF
--- a/hedera-node/src/main/java/com/hedera/services/state/submerkle/FcCustomFee.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/submerkle/FcCustomFee.java
@@ -68,7 +68,9 @@ public class FcCustomFee implements SelfSerializable {
 	static final byte FRACTIONAL_CODE = (byte) (1 << 1);
 	static final byte ROYALTY_CODE = (byte) (1 << 2);
 
-	static final int MERKLE_VERSION = 1;
+	static final int RELEASE_016x_VERSION = 1;
+	static final int RELEASE_017x_VERSION = 2;
+	static final int CURRENT_VERSION = RELEASE_017x_VERSION;
 	static final long RUNTIME_CONSTRUCTABLE_ID = 0xf65baa433940f137L;
 
 	private FeeType feeType;
@@ -274,7 +276,7 @@ public class FcCustomFee implements SelfSerializable {
 			var denominator = din.readLong();
 			var minimumUnitsToCollect = din.readLong();
 			var maximumUnitsToCollect = din.readLong();
-			var netOfTransfers = din.readBoolean();
+			var netOfTransfers = (version >= RELEASE_017x_VERSION) ? din.readBoolean() : false;
 			fractionalFeeSpec = new FractionalFeeSpec(
 					numerator, denominator, minimumUnitsToCollect, maximumUnitsToCollect, netOfTransfers);
 		} else {
@@ -328,7 +330,7 @@ public class FcCustomFee implements SelfSerializable {
 
 	@Override
 	public int getVersion() {
-		return MERKLE_VERSION;
+		return CURRENT_VERSION;
 	}
 
 	private void serializeFixed(FixedFeeSpec fee, SerializableDataOutputStream dos) throws IOException {

--- a/hedera-node/src/main/java/com/hedera/services/state/submerkle/FcCustomFee.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/submerkle/FcCustomFee.java
@@ -68,9 +68,9 @@ public class FcCustomFee implements SelfSerializable {
 	static final byte FRACTIONAL_CODE = (byte) (1 << 1);
 	static final byte ROYALTY_CODE = (byte) (1 << 2);
 
-	static final int RELEASE_016x_VERSION = 1;
-	static final int RELEASE_017x_VERSION = 2;
-	static final int CURRENT_VERSION = RELEASE_017x_VERSION;
+	static final int RELEASE_016X_VERSION = 1;
+	static final int RELEASE_017X_VERSION = 2;
+	static final int CURRENT_VERSION = RELEASE_017X_VERSION;
 	static final long RUNTIME_CONSTRUCTABLE_ID = 0xf65baa433940f137L;
 
 	private FeeType feeType;
@@ -276,7 +276,7 @@ public class FcCustomFee implements SelfSerializable {
 			var denominator = din.readLong();
 			var minimumUnitsToCollect = din.readLong();
 			var maximumUnitsToCollect = din.readLong();
-			var netOfTransfers = (version >= RELEASE_017x_VERSION) ? din.readBoolean() : false;
+			var netOfTransfers = version >= RELEASE_017X_VERSION && din.readBoolean();
 			fractionalFeeSpec = new FractionalFeeSpec(
 					numerator, denominator, minimumUnitsToCollect, maximumUnitsToCollect, netOfTransfers);
 		} else {

--- a/hedera-node/src/test/java/com/hedera/services/state/submerkle/FcCustomFeeTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/state/submerkle/FcCustomFeeTest.java
@@ -50,6 +50,8 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
 class FcCustomFeeTest {
@@ -283,7 +285,7 @@ class FcCustomFeeTest {
 		final var din = new SerializableDataInputStream(bais);
 
 		final var newSubject = new FcCustomFee();
-		newSubject.deserialize(din, FcCustomFee.MERKLE_VERSION);
+		newSubject.deserialize(din, FcCustomFee.CURRENT_VERSION);
 
 		assertEquals(subject.getRoyaltyFeeSpec(), newSubject.getRoyaltyFeeSpec());
 		assertEquals(subject.getFeeCollector(), newSubject.getFeeCollector());
@@ -305,7 +307,7 @@ class FcCustomFeeTest {
 		final var din = new SerializableDataInputStream(bais);
 
 		final var newSubject = new FcCustomFee();
-		newSubject.deserialize(din, FcCustomFee.MERKLE_VERSION);
+		newSubject.deserialize(din, FcCustomFee.CURRENT_VERSION);
 
 		assertEquals(subject.getRoyaltyFeeSpec(), newSubject.getRoyaltyFeeSpec());
 		assertEquals(subject.getFeeCollector(), newSubject.getFeeCollector());
@@ -329,7 +331,7 @@ class FcCustomFeeTest {
 		final var din = new SerializableDataInputStream(bais);
 
 		final var newSubject = new FcCustomFee();
-		newSubject.deserialize(din, FcCustomFee.MERKLE_VERSION);
+		newSubject.deserialize(din, FcCustomFee.CURRENT_VERSION);
 
 		assertEquals(subject.getFractionalFeeSpec(), newSubject.getFractionalFeeSpec());
 		assertEquals(subject.getFeeCollector(), newSubject.getFeeCollector());
@@ -347,7 +349,7 @@ class FcCustomFeeTest {
 		final var din = new SerializableDataInputStream(bais);
 
 		final var newSubject = new FcCustomFee();
-		newSubject.deserialize(din, FcCustomFee.MERKLE_VERSION);
+		newSubject.deserialize(din, FcCustomFee.CURRENT_VERSION);
 
 		assertEquals(fixedSubject.getFixedFeeSpec(), newSubject.getFixedFeeSpec());
 		assertEquals(fixedSubject.getFeeCollector(), newSubject.getFeeCollector());
@@ -365,7 +367,7 @@ class FcCustomFeeTest {
 		final var din = new SerializableDataInputStream(bais);
 
 		final var newSubject = new FcCustomFee();
-		newSubject.deserialize(din, FcCustomFee.MERKLE_VERSION);
+		newSubject.deserialize(din, FcCustomFee.CURRENT_VERSION);
 
 		assertEquals(fixedSubject.getFixedFeeSpec(), newSubject.getFixedFeeSpec());
 		assertEquals(fixedSubject.getFeeCollector(), newSubject.getFeeCollector());
@@ -379,7 +381,7 @@ class FcCustomFeeTest {
 		given(din.readSerializable(anyBoolean(), Mockito.any())).willReturn(denom).willReturn(feeCollector);
 
 		final var subject = new FcCustomFee();
-		subject.deserialize(din, FcCustomFee.MERKLE_VERSION);
+		subject.deserialize(din, FcCustomFee.CURRENT_VERSION);
 
 		assertEquals(FcCustomFee.FeeType.FIXED_FEE, subject.getFeeType());
 		assertEquals(expectedFixedSpec, subject.getFixedFeeSpec());
@@ -405,12 +407,39 @@ class FcCustomFeeTest {
 		given(din.readSerializable(anyBoolean(), Mockito.any())).willReturn(feeCollector);
 
 		final var subject = new FcCustomFee();
-		subject.deserialize(din, FcCustomFee.MERKLE_VERSION);
+		subject.deserialize(din, FcCustomFee.CURRENT_VERSION);
 
 		assertEquals(FcCustomFee.FeeType.FRACTIONAL_FEE, subject.getFeeType());
 		assertEquals(expectedFractionalSpec, subject.getFractionalFeeSpec());
 		assertNull(subject.getFixedFeeSpec());
 		assertEquals(feeCollector, subject.getFeeCollector());
+	}
+
+	@Test
+	void deserializeWorksAsExpectedForFractionalFromRelease016x() throws IOException {
+		final var expectedFractionalSpec = new FractionalFeeSpec(
+				validNumerator,
+				validDenominator,
+				minimumUnitsToCollect,
+				maximumUnitsToCollect,
+				!netOfTransfers);
+		given(din.readByte()).willReturn(FcCustomFee.FRACTIONAL_CODE);
+		given(din.readLong())
+				.willReturn(validNumerator)
+				.willReturn(validDenominator)
+				.willReturn(minimumUnitsToCollect)
+				.willReturn(maximumUnitsToCollect);
+		given(din.readSerializable(anyBoolean(), Mockito.any())).willReturn(feeCollector);
+
+		final var subject = new FcCustomFee();
+		subject.deserialize(din, FcCustomFee.RELEASE_016x_VERSION);
+
+		assertEquals(FcCustomFee.FeeType.FRACTIONAL_FEE, subject.getFeeType());
+		assertEquals(expectedFractionalSpec, subject.getFractionalFeeSpec());
+		assertNull(subject.getFixedFeeSpec());
+		assertEquals(feeCollector, subject.getFeeCollector());
+		// and:
+		verify(din, never()).readBoolean();
 	}
 
 	@Test
@@ -452,7 +481,7 @@ class FcCustomFeeTest {
 	void merkleMethodsWork() {
 		final var subject = FcCustomFee.fixedFee(fixedUnitsToCollect, denom, feeCollector);
 
-		assertEquals(FcCustomFee.MERKLE_VERSION, subject.getVersion());
+		assertEquals(FcCustomFee.CURRENT_VERSION, subject.getVersion());
 		assertEquals(FcCustomFee.RUNTIME_CONSTRUCTABLE_ID, subject.getClassId());
 	}
 

--- a/hedera-node/src/test/java/com/hedera/services/state/submerkle/FcCustomFeeTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/state/submerkle/FcCustomFeeTest.java
@@ -432,7 +432,7 @@ class FcCustomFeeTest {
 		given(din.readSerializable(anyBoolean(), Mockito.any())).willReturn(feeCollector);
 
 		final var subject = new FcCustomFee();
-		subject.deserialize(din, FcCustomFee.RELEASE_016x_VERSION);
+		subject.deserialize(din, FcCustomFee.RELEASE_016X_VERSION);
 
 		assertEquals(FcCustomFee.FeeType.FRACTIONAL_FEE, subject.getFeeType());
 		assertEquals(expectedFractionalSpec, subject.getFractionalFeeSpec());


### PR DESCRIPTION
- Fix `FcCustomFee.deserialize()` to only read the `netOfTransfers` flag from a release 0.17.x saved state.