### PR TITLE
Add effective payers for assessed custom fees

### DIFF
--- a/hedera-node/src/main/java/com/hedera/services/grpc/marshalling/FractionalFeeAssessor.java
+++ b/hedera-node/src/main/java/com/hedera/services/grpc/marshalling/FractionalFeeAssessor.java
@@ -57,6 +57,9 @@ public class FractionalFeeAssessor {
 		final var payer = change.getAccount();
 		final var denom = change.getToken();
 		final var creditsToReclaimFrom = changeManager.creditsInCurrentLevel(denom);
+		/* These accounts receiving the reclaimed credits are the
+		effective payers unless the net-of-transfers flag is set. */
+		final var effPayerAccountNums = effPayerAccountNumsOf(creditsToReclaimFrom);
 		for (var fee : feesWithFractional) {
 			final var collector = fee.getFeeCollectorAsId();
 			if (fee.getFeeType() != FRACTIONAL_FEE || payer.equals(collector)) {
@@ -89,11 +92,20 @@ public class FractionalFeeAssessor {
 						collector.asEntityId(),
 						denom.asEntityId(),
 						assessedAmount,
-						null);
+						effPayerAccountNums);
 				accumulator.add(assessed);
 			}
 		}
 		return OK;
+	}
+
+	private long[] effPayerAccountNumsOf(List<BalanceChange> credits) {
+		int n = credits.size();
+		final var nums = new long[n];
+		for (int i = 0; i < n; i++) {
+			nums[i] = credits.get(i).getAccount().getNum();
+		}
+		return nums;
 	}
 
 	void reclaim(long amount, List<BalanceChange> credits) {
@@ -133,5 +145,4 @@ public class FractionalFeeAssessor {
 		}
 		return effectiveFee;
 	}
-
 }

--- a/hedera-node/src/main/java/com/hedera/services/grpc/marshalling/FractionalFeeAssessor.java
+++ b/hedera-node/src/main/java/com/hedera/services/grpc/marshalling/FractionalFeeAssessor.java
@@ -85,7 +85,11 @@ public class FractionalFeeAssessor {
 					return CUSTOM_FEE_OUTSIDE_NUMERIC_RANGE;
 				}
 				adjustedFractionalChange(collector, denom, assessedAmount, changeManager);
-				final var assessed = new FcAssessedCustomFee(collector.asEntityId(), denom.asEntityId(), assessedAmount);
+				final var assessed = new FcAssessedCustomFee(
+						collector.asEntityId(),
+						denom.asEntityId(),
+						assessedAmount,
+						null);
 				accumulator.add(assessed);
 			}
 		}

--- a/hedera-node/src/main/java/com/hedera/services/grpc/marshalling/HbarFeeAssessor.java
+++ b/hedera-node/src/main/java/com/hedera/services/grpc/marshalling/HbarFeeAssessor.java
@@ -41,7 +41,7 @@ public class HbarFeeAssessor {
 		final var fixedSpec = hbarFee.getFixedFeeSpec();
 		final var amount = fixedSpec.getUnitsToCollect();
 		adjustForAssessedHbar(payer, collector, amount, changeManager);
-		final var assessed = new FcAssessedCustomFee(collector.asEntityId(), amount);
+		final var assessed = new FcAssessedCustomFee(collector.asEntityId(), amount, null);
 		accumulator.add(assessed);
 		return OK;
 	}

--- a/hedera-node/src/main/java/com/hedera/services/grpc/marshalling/HbarFeeAssessor.java
+++ b/hedera-node/src/main/java/com/hedera/services/grpc/marshalling/HbarFeeAssessor.java
@@ -41,7 +41,8 @@ public class HbarFeeAssessor {
 		final var fixedSpec = hbarFee.getFixedFeeSpec();
 		final var amount = fixedSpec.getUnitsToCollect();
 		adjustForAssessedHbar(payer, collector, amount, changeManager);
-		final var assessed = new FcAssessedCustomFee(collector.asEntityId(), amount, null);
+		final var effPayerAccountNums = new long[] { payer.getNum() };
+		final var assessed = new FcAssessedCustomFee(collector.asEntityId(), amount, effPayerAccountNums);
 		accumulator.add(assessed);
 		return OK;
 	}

--- a/hedera-node/src/main/java/com/hedera/services/grpc/marshalling/HtsFeeAssessor.java
+++ b/hedera-node/src/main/java/com/hedera/services/grpc/marshalling/HtsFeeAssessor.java
@@ -32,7 +32,7 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OK;
 
 public class HtsFeeAssessor {
 	public ResponseCodeEnum assess(
-			Id account,
+			Id payer,
 			Id chargingToken,
 			FcCustomFee htsFee,
 			BalanceChangeManager changeManager,
@@ -42,13 +42,14 @@ public class HtsFeeAssessor {
 		final var fixedSpec = htsFee.getFixedFeeSpec();
 		final var amount = fixedSpec.getUnitsToCollect();
 		final var denominatingToken = fixedSpec.getTokenDenomination().asId();
-		adjustForAssessed(account, chargingToken, collector, denominatingToken, amount, changeManager);
+		adjustForAssessed(payer, chargingToken, collector, denominatingToken, amount, changeManager);
 
+		final var effPayerAccountNums = new long[] { payer.getNum() };
 		final var assessed = new FcAssessedCustomFee(
 				htsFee.getFeeCollector(),
 				fixedSpec.getTokenDenomination(),
 				amount,
-				null);
+				effPayerAccountNums);
 		accumulator.add(assessed);
 
 		return OK;

--- a/hedera-node/src/main/java/com/hedera/services/grpc/marshalling/HtsFeeAssessor.java
+++ b/hedera-node/src/main/java/com/hedera/services/grpc/marshalling/HtsFeeAssessor.java
@@ -47,7 +47,8 @@ public class HtsFeeAssessor {
 		final var assessed = new FcAssessedCustomFee(
 				htsFee.getFeeCollector(),
 				fixedSpec.getTokenDenomination(),
-				amount);
+				amount,
+				null);
 		accumulator.add(assessed);
 
 		return OK;

--- a/hedera-node/src/main/java/com/hedera/services/grpc/marshalling/RoyaltyFeeAssessor.java
+++ b/hedera-node/src/main/java/com/hedera/services/grpc/marshalling/RoyaltyFeeAssessor.java
@@ -108,10 +108,12 @@ public class RoyaltyFeeAssessor {
 			 on fees charged in the units of their denominating token; but this is a credit,
 			 hence the id is irrelevant and we can use MISSING_ID. */
 			fungibleAdjuster.adjustedChange(collector, MISSING_ID, denom, royaltyFee, changeManager);
+			final var effPayerAccountNum = new long[] { exchange.getAccount().getNum() };
+			final var collectorId = collector.asEntityId();
 			final var assessed =
 					exchange.isForHbar()
-							? new FcAssessedCustomFee(collector.asEntityId(), royaltyFee, null)
-							: new FcAssessedCustomFee(collector.asEntityId(), denom.asEntityId(), royaltyFee, null);
+							? new FcAssessedCustomFee(collectorId, royaltyFee, effPayerAccountNum)
+							: new FcAssessedCustomFee(collectorId, denom.asEntityId(), royaltyFee, effPayerAccountNum);
 			accumulator.add(assessed);
 		}
 		return OK;

--- a/hedera-node/src/main/java/com/hedera/services/grpc/marshalling/RoyaltyFeeAssessor.java
+++ b/hedera-node/src/main/java/com/hedera/services/grpc/marshalling/RoyaltyFeeAssessor.java
@@ -110,8 +110,8 @@ public class RoyaltyFeeAssessor {
 			fungibleAdjuster.adjustedChange(collector, MISSING_ID, denom, royaltyFee, changeManager);
 			final var assessed =
 					exchange.isForHbar()
-							? new FcAssessedCustomFee(collector.asEntityId(), royaltyFee)
-							: new FcAssessedCustomFee(collector.asEntityId(), denom.asEntityId(), royaltyFee);
+							? new FcAssessedCustomFee(collector.asEntityId(), royaltyFee, null)
+							: new FcAssessedCustomFee(collector.asEntityId(), denom.asEntityId(), royaltyFee, null);
 			accumulator.add(assessed);
 		}
 		return OK;

--- a/hedera-node/src/main/java/com/hedera/services/state/submerkle/FcAssessedCustomFee.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/submerkle/FcAssessedCustomFee.java
@@ -30,6 +30,7 @@ import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 import java.io.IOException;
+import java.util.Arrays;
 
 /**
  * Process self serializable object that represents an assessed custom fee, which may or may not result in a balance
@@ -37,33 +38,56 @@ import java.io.IOException;
  * This is useful for setting custom fees balance changes in {@link ExpirableTxnRecord}.
  */
 public class FcAssessedCustomFee implements SelfSerializable {
-	static final int MERKLE_VERSION = 1;
+	static final long[] UNKNOWN_EFFECTIVE_PAYER_ACCOUNT_NUMS = new long[0];
+
+	static final int RELEASE_0170_VERSION = 1;
+	static final int RELEASE_0171_VERSION = 2;
+
+	static final int CURRENT_VERSION = RELEASE_0171_VERSION;
+
 	static final long RUNTIME_CONSTRUCTABLE_ID = 0xd8b56ce46e56a466L;
 
 	private EntityId token;
 	private EntityId account;
 	private long units;
+	private long[] effPayerAccountNums;
 
 	public FcAssessedCustomFee() {
 		/* For RuntimeConstructable */
 	}
 
-	private FcAssessedCustomFee(final EntityId token, final AccountAmount aa) {
+	private FcAssessedCustomFee(
+			final EntityId token,
+			final AccountAmount aa,
+			final long[] effPayerAccountNums
+	) {
 		this.token = token;
 		this.account = EntityId.fromGrpcAccountId(aa.getAccountID());
 		this.units = aa.getAmount();
+		this.effPayerAccountNums = effPayerAccountNums;
 	}
 
-	public FcAssessedCustomFee(final EntityId account, final long amount) {
+	public FcAssessedCustomFee(
+			final EntityId account,
+			final long amount,
+			final long[] effPayerAccountNums
+	) {
 		this.token = null;
 		this.account = account;
 		this.units = amount;
+		this.effPayerAccountNums = effPayerAccountNums;
 	}
 
-	public FcAssessedCustomFee(final EntityId account, final EntityId token, final long amount) {
+	public FcAssessedCustomFee(
+			final EntityId account,
+			final EntityId token,
+			final long amount,
+			final long[] effPayerAccountNums
+	) {
 		this.token = token;
 		this.account = account;
 		this.units = amount;
+		this.effPayerAccountNums = effPayerAccountNums;
 	}
 
 	public boolean isForHbar() {
@@ -82,17 +106,24 @@ public class FcAssessedCustomFee implements SelfSerializable {
 		return account;
 	}
 
-	public static FcAssessedCustomFee assessedHbarFeeFrom(final AccountAmount aa) {
-		return new FcAssessedCustomFee(null, aa);
+	public long[] effPayerAccountNums() {
+		return effPayerAccountNums;
 	}
 
-	public static FcAssessedCustomFee assessedHtsFeeFrom(final EntityId token, final AccountAmount aa) {
-		return new FcAssessedCustomFee(token, aa);
+	public static FcAssessedCustomFee assessedHbarFeeFrom(
+			final AccountAmount aa,
+			final long[] effPayerAccountNums
+	) {
+		return new FcAssessedCustomFee(null, aa, effPayerAccountNums);
 	}
 
-	// NOTE: The object methods below are only overridden to improve readability of unit tests;
-	// this model object is not used in hash-based collections, so the performance of these
-	// methods doesn't matter.
+	public static FcAssessedCustomFee assessedHtsFeeFrom(
+			final EntityId token,
+			final AccountAmount aa,
+			final long[] effPayerAccountNums
+	) {
+		return new FcAssessedCustomFee(token, aa, effPayerAccountNums);
+	}
 
 	@Override
 	public boolean equals(final Object obj) {
@@ -110,6 +141,7 @@ public class FcAssessedCustomFee implements SelfSerializable {
 				.add("token", token == null ? "ℏ" : token)
 				.add("account", account)
 				.add("units", units)
+				.add("effective payer accounts", Arrays.toString(effPayerAccountNums))
 				.toString();
 	}
 
@@ -130,9 +162,9 @@ public class FcAssessedCustomFee implements SelfSerializable {
 				.setAmount(assessedFee.getAmount())
 				.build();
 		if (assessedFee.hasTokenId()) {
-			return assessedHtsFeeFrom(EntityId.fromGrpcTokenId(assessedFee.getTokenId()), aa);
+			return assessedHtsFeeFrom(EntityId.fromGrpcTokenId(assessedFee.getTokenId()), aa, null);
 		}
-		return assessedHbarFeeFrom(aa);
+		return assessedHbarFeeFrom(aa, null);
 	}
 
 	/* ----- SelfSerializable methods ------ */
@@ -141,6 +173,11 @@ public class FcAssessedCustomFee implements SelfSerializable {
 		account = in.readSerializable();
 		token = in.readSerializable();
 		units = in.readLong();
+		if (version >= CURRENT_VERSION) {
+			effPayerAccountNums = in.readLongArray(Integer.MAX_VALUE);
+		} else {
+			effPayerAccountNums = UNKNOWN_EFFECTIVE_PAYER_ACCOUNT_NUMS;
+		}
 	}
 
 	@Override
@@ -148,6 +185,7 @@ public class FcAssessedCustomFee implements SelfSerializable {
 		out.writeSerializable(account, true);
 		out.writeSerializable(token, true);
 		out.writeLong(units);
+		out.writeLongArray(effPayerAccountNums);
 	}
 
 	@Override
@@ -157,6 +195,6 @@ public class FcAssessedCustomFee implements SelfSerializable {
 
 	@Override
 	public int getVersion() {
-		return MERKLE_VERSION;
+		return CURRENT_VERSION;
 	}
 }

--- a/hedera-node/src/main/java/com/hedera/services/utils/MiscUtils.java
+++ b/hedera-node/src/main/java/com/hedera/services/utils/MiscUtils.java
@@ -668,11 +668,15 @@ public class MiscUtils {
 	}
 
 	/**
-	 A permutation (invertible function) on 64 bits. The constants were found
-	 by automated search, to optimize avalanche. Avalanche means that for a
-	 random number x, flipping bit i of x has about a 50 percent chance of
-	 flipping bit j of perm64(x). For each possible pair (i,j), this function
-	 achieves a probability between 49.8 and 50.2 percent. */
+	 * A permutation (invertible function) on 64 bits. The constants were found
+	 * by automated search, to optimize avalanche. Avalanche means that for a
+	 * random number x, flipping bit i of x has about a 50 percent chance of
+	 * flipping bit j of perm64(x). For each possible pair (i,j), this function
+	 * achieves a probability between 49.8 and 50.2 percent.
+	 *
+	 * @param x the value to permute
+	 * @return the avalanche-optimized permutation
+	 */
 	public static long perm64(long x) {
 		// Shifts: {30, 27, 16, 20, 5, 18, 10, 24, 30}
 		x += x <<  30;

--- a/hedera-node/src/main/java/com/hedera/services/utils/MiscUtils.java
+++ b/hedera-node/src/main/java/com/hedera/services/utils/MiscUtils.java
@@ -668,30 +668,24 @@ public class MiscUtils {
 	}
 
 	/**
-	 * A permutation (invertible function) on 64 bits.
-	 * The constants were found by automated search, to optimize avalanche.
-	 * This means that for a random number x, flipping bit i of x has about
-	 * a 50% chance of flipping bit j in perm64(x). And this is close to 50%
-	 * for every choice of (i,j).
-	 *
-	 * @param x
-	 * 		the value to permute
-	 * @return
-	 * 		the avalanche-optimized permutation
-	 */
+	 A permutation (invertible function) on 64 bits. The constants were found
+	 by automated search, to optimize avalanche. Avalanche means that for a
+	 random number x, flipping bit i of x has about a 50 percent chance of
+	 flipping bit j of perm64(x). For each possible pair (i,j), this function
+	 achieves a probability between 49.8 and 50.2 percent. */
 	public static long perm64(long x) {
-		x += x << 10;
-		x ^= x >> 15;
-		x += x << 22;
-		x ^= x >> 2;
-		x += x << 3;
-		x ^= x >> 38;
-		x += x << 7;
-		x ^= x >> 11;
-		x += x << 22;
+		// Shifts: {30, 27, 16, 20, 5, 18, 10, 24, 30}
+		x += x <<  30;
+		x ^= x >>> 27;
+		x += x <<  16;
+		x ^= x >>> 20;
+		x += x <<   5;
+		x ^= x >>> 18;
+		x += x <<  10;
+		x ^= x >>> 24;
+		x += x <<  30;
 		return x;
 	}
-
 	public static <K extends MerkleNode, V extends MerkleNode> void forEach(
 			FCMap<K, V> map,
 			BiConsumer<? super K, ? super V> action

--- a/hedera-node/src/test/java/com/hedera/services/grpc/marshalling/FractionalFeeAssessorTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/grpc/marshalling/FractionalFeeAssessorTest.java
@@ -86,12 +86,12 @@ class FractionalFeeAssessorTest {
 				firstFractionalFeeCollector,
 				tokenWithFractionalFee.asEntityId(),
 				firstExpectedFee,
-				null);
+				effPayerAccountNums);
 		final var expSecondAssess = new FcAssessedCustomFee(
 				secondFractionalFeeCollector,
 				tokenWithFractionalFee.asEntityId(),
 				secondExpectedFee,
-				null);
+				effPayerAccountNums);
 
 		given(changeManager.changeFor(firstFractionalFeeCollector.asId(), tokenWithFractionalFee))
 				.willReturn(firstCollectorChange);
@@ -263,7 +263,6 @@ class FractionalFeeAssessorTest {
 	@Test
 	void reclaimsRemainderAsExpected() {
 		// setup:
-		final long reclaimAmount = 1000L;
 		final List<BalanceChange> credits = List.of(firstVanillaReclaim, secondVanillaReclaim);
 		firstVanillaReclaim.adjustUnits(12_345L);
 		secondVanillaReclaim.adjustUnits(2_345L);
@@ -284,6 +283,7 @@ class FractionalFeeAssessorTest {
 	private final Id payer = new Id(0, 1, 2);
 	private final Id firstReclaimedAcount = new Id(6, 7, 8);
 	private final Id secondReclaimedAcount = new Id(7, 8, 9);
+	private final long[] effPayerAccountNums = new long[] { 8L, 9L };
 	private final long vanillaTriggerAmount = 5000L;
 	private final long firstCreditAmount = 4000L;
 	private final long secondCreditAmount = 1000L;

--- a/hedera-node/src/test/java/com/hedera/services/grpc/marshalling/FractionalFeeAssessorTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/grpc/marshalling/FractionalFeeAssessorTest.java
@@ -85,11 +85,13 @@ class FractionalFeeAssessorTest {
 		final var expFirstAssess = new FcAssessedCustomFee(
 				firstFractionalFeeCollector,
 				tokenWithFractionalFee.asEntityId(),
-				firstExpectedFee);
+				firstExpectedFee,
+				null);
 		final var expSecondAssess = new FcAssessedCustomFee(
 				secondFractionalFeeCollector,
 				tokenWithFractionalFee.asEntityId(),
-				secondExpectedFee);
+				secondExpectedFee,
+				null);
 
 		given(changeManager.changeFor(firstFractionalFeeCollector.asId(), tokenWithFractionalFee))
 				.willReturn(firstCollectorChange);

--- a/hedera-node/src/test/java/com/hedera/services/grpc/marshalling/HbarFeeAssessorTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/grpc/marshalling/HbarFeeAssessorTest.java
@@ -55,7 +55,7 @@ class HbarFeeAssessorTest {
 	@Test
 	void updatesExistingChangesIfPresent() {
 		// setup:
-		final var expectedFee = new FcAssessedCustomFee(hbarFeeCollector, amountOfHbarFee);
+		final var expectedFee = new FcAssessedCustomFee(hbarFeeCollector, amountOfHbarFee, null);
 
 		given(balanceChangeManager.changeFor(payer, Id.MISSING_ID)).willReturn(payerChange);
 		given(balanceChangeManager.changeFor(feeCollector, Id.MISSING_ID)).willReturn(collectorChange);

--- a/hedera-node/src/test/java/com/hedera/services/grpc/marshalling/HbarFeeAssessorTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/grpc/marshalling/HbarFeeAssessorTest.java
@@ -55,7 +55,7 @@ class HbarFeeAssessorTest {
 	@Test
 	void updatesExistingChangesIfPresent() {
 		// setup:
-		final var expectedFee = new FcAssessedCustomFee(hbarFeeCollector, amountOfHbarFee, null);
+		final var expectedFee = new FcAssessedCustomFee(hbarFeeCollector, amountOfHbarFee, effPayerNums);
 
 		given(balanceChangeManager.changeFor(payer, Id.MISSING_ID)).willReturn(payerChange);
 		given(balanceChangeManager.changeFor(feeCollector, Id.MISSING_ID)).willReturn(collectorChange);
@@ -89,6 +89,7 @@ class HbarFeeAssessorTest {
 
 	private final long amountOfHbarFee = 100_000L;
 	private final Id payer = new Id(0, 1, 2);
+	private final long[] effPayerNums = new long[] { 2L };
 	private final Id feeCollector = new Id(1, 2, 3);
 	private final EntityId hbarFeeCollector = feeCollector.asEntityId();
 	private final FcCustomFee hbarFee = FcCustomFee.fixedFee(amountOfHbarFee, null, hbarFeeCollector);

--- a/hedera-node/src/test/java/com/hedera/services/grpc/marshalling/HtsFeeAssessorTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/grpc/marshalling/HtsFeeAssessorTest.java
@@ -52,7 +52,7 @@ class HtsFeeAssessorTest {
 	@Test
 	void updatesExistingChangesIfPresent() {
 		// setup:
-		final var expectedAssess = new FcAssessedCustomFee(htsFeeCollector, feeDenom, amountOfHtsFee);
+		final var expectedAssess = new FcAssessedCustomFee(htsFeeCollector, feeDenom, amountOfHtsFee, null);
 		// and:
 		final var expectedPayerChange = BalanceChange.tokenAdjust(payer, denom, -amountOfHtsFee);
 		expectedPayerChange.setCodeForInsufficientBalance(INSUFFICIENT_SENDER_ACCOUNT_BALANCE_FOR_CUSTOM_FEE);
@@ -73,7 +73,7 @@ class HtsFeeAssessorTest {
 	@Test
 	void addsNewChangesIfNotPresent() {
 		// setup:
-		final var expectedAssess = new FcAssessedCustomFee(htsFeeCollector, feeDenom, amountOfHtsFee);
+		final var expectedAssess = new FcAssessedCustomFee(htsFeeCollector, feeDenom, amountOfHtsFee, null);
 
 		// given:
 		final var expectedPayerChange = BalanceChange.tokenAdjust(payer, denom, -amountOfHtsFee);
@@ -93,7 +93,7 @@ class HtsFeeAssessorTest {
 	@Test
 	void addsExemptNewChangesForSelfDenominatedFee() {
 		// setup:
-		final var expectedAssess = new FcAssessedCustomFee(htsFeeCollector, feeDenom, amountOfHtsFee);
+		final var expectedAssess = new FcAssessedCustomFee(htsFeeCollector, feeDenom, amountOfHtsFee, null);
 
 		// given:
 		final var expectedPayerChange = BalanceChange.tokenAdjust(payer, denom, -amountOfHtsFee);

--- a/hedera-node/src/test/java/com/hedera/services/grpc/marshalling/HtsFeeAssessorTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/grpc/marshalling/HtsFeeAssessorTest.java
@@ -52,7 +52,7 @@ class HtsFeeAssessorTest {
 	@Test
 	void updatesExistingChangesIfPresent() {
 		// setup:
-		final var expectedAssess = new FcAssessedCustomFee(htsFeeCollector, feeDenom, amountOfHtsFee, null);
+		final var expectedAssess = new FcAssessedCustomFee(htsFeeCollector, feeDenom, amountOfHtsFee, effPayerNums);
 		// and:
 		final var expectedPayerChange = BalanceChange.tokenAdjust(payer, denom, -amountOfHtsFee);
 		expectedPayerChange.setCodeForInsufficientBalance(INSUFFICIENT_SENDER_ACCOUNT_BALANCE_FOR_CUSTOM_FEE);
@@ -73,7 +73,7 @@ class HtsFeeAssessorTest {
 	@Test
 	void addsNewChangesIfNotPresent() {
 		// setup:
-		final var expectedAssess = new FcAssessedCustomFee(htsFeeCollector, feeDenom, amountOfHtsFee, null);
+		final var expectedAssess = new FcAssessedCustomFee(htsFeeCollector, feeDenom, amountOfHtsFee, effPayerNums);
 
 		// given:
 		final var expectedPayerChange = BalanceChange.tokenAdjust(payer, denom, -amountOfHtsFee);
@@ -93,7 +93,7 @@ class HtsFeeAssessorTest {
 	@Test
 	void addsExemptNewChangesForSelfDenominatedFee() {
 		// setup:
-		final var expectedAssess = new FcAssessedCustomFee(htsFeeCollector, feeDenom, amountOfHtsFee, null);
+		final var expectedAssess = new FcAssessedCustomFee(htsFeeCollector, feeDenom, amountOfHtsFee, effPayerNums);
 
 		// given:
 		final var expectedPayerChange = BalanceChange.tokenAdjust(payer, denom, -amountOfHtsFee);
@@ -119,4 +119,5 @@ class HtsFeeAssessorTest {
 	private final EntityId feeDenom = new EntityId(6, 6, 6);
 	private final EntityId htsFeeCollector = feeCollector.asEntityId();
 	private final FcCustomFee htsFee = FcCustomFee.fixedFee(amountOfHtsFee, feeDenom, htsFeeCollector);
+	private final long[] effPayerNums = new long[] { 2L };
 }

--- a/hedera-node/src/test/java/com/hedera/services/grpc/marshalling/ImpliedTransfersTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/grpc/marshalling/ImpliedTransfersTest.java
@@ -175,5 +175,5 @@ class ImpliedTransfersTest {
 			someTreasuryId,
 			List.of(FcCustomFee.fixedFee(10L, customFeeToken, customFeeCollector)));
 	private final List<FcAssessedCustomFee> assessedCustomFees = List.of(
-			new FcAssessedCustomFee(customFeeCollector, customFeeToken, 123L));
+			new FcAssessedCustomFee(customFeeCollector, customFeeToken, 123L, null));
 }

--- a/hedera-node/src/test/java/com/hedera/services/grpc/marshalling/ImpliedTransfersTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/grpc/marshalling/ImpliedTransfersTest.java
@@ -77,7 +77,7 @@ class ImpliedTransfersTest {
 				"account=Id{shard=4, realm=5, num=6}, units=7}], tokenFeeSchedules=[" +
 				"CustomFeeMeta{tokenId=Id{shard=0, realm=0, num=123}, treasuryId=Id{shard=2, realm=3, num=4}, " +
 				"customFees=[]}], assessedCustomFees=[FcAssessedCustomFee{token=EntityId{shard=0, realm=0, num=123}, " +
-				"account=EntityId{shard=0, realm=0, num=124}, units=123}]}";
+				"account=EntityId{shard=0, realm=0, num=124}, units=123, effective payer accounts=[123]}]}";
 
 		// expect:
 		assertNotEquals(oneImpliedXfers, twoImpliedXfers);
@@ -175,5 +175,5 @@ class ImpliedTransfersTest {
 			someTreasuryId,
 			List.of(FcCustomFee.fixedFee(10L, customFeeToken, customFeeCollector)));
 	private final List<FcAssessedCustomFee> assessedCustomFees = List.of(
-			new FcAssessedCustomFee(customFeeCollector, customFeeToken, 123L, null));
+			new FcAssessedCustomFee(customFeeCollector, customFeeToken, 123L, new long[] { 123L }));
 }

--- a/hedera-node/src/test/java/com/hedera/services/grpc/marshalling/RoyaltyFeeAssessorTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/grpc/marshalling/RoyaltyFeeAssessorTest.java
@@ -234,7 +234,11 @@ class RoyaltyFeeAssessorTest {
 	private final BalanceChange trigger = BalanceChange.changingNftOwnership(
 			nonFungibleTokenId, nonFungibleTokenId.asGrpcToken(), ownershipChange);
 	private final FcAssessedCustomFee hbarAssessed =
-			new FcAssessedCustomFee(targetCollector, originalUnits / 2);
+			new FcAssessedCustomFee(targetCollector, originalUnits / 2, null);
 	private final FcAssessedCustomFee htsAssessed =
-			new FcAssessedCustomFee(targetCollector, firstFungibleTokenId.asEntityId(), originalUnits / 2);
+			new FcAssessedCustomFee(
+					targetCollector,
+					firstFungibleTokenId.asEntityId(),
+					originalUnits / 2,
+					null);
 }

--- a/hedera-node/src/test/java/com/hedera/services/grpc/marshalling/RoyaltyFeeAssessorTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/grpc/marshalling/RoyaltyFeeAssessorTest.java
@@ -233,12 +233,16 @@ class RoyaltyFeeAssessorTest {
 	private final Id nonFungibleTokenId = new Id(7, 4, 7);
 	private final BalanceChange trigger = BalanceChange.changingNftOwnership(
 			nonFungibleTokenId, nonFungibleTokenId.asGrpcToken(), ownershipChange);
+	private final long[] effPayerNum = new long[] { payer.getNum() };
 	private final FcAssessedCustomFee hbarAssessed =
-			new FcAssessedCustomFee(targetCollector, originalUnits / 2, null);
+			new FcAssessedCustomFee(
+					targetCollector,
+					originalUnits / 2,
+					effPayerNum);
 	private final FcAssessedCustomFee htsAssessed =
 			new FcAssessedCustomFee(
 					targetCollector,
 					firstFungibleTokenId.asEntityId(),
 					originalUnits / 2,
-					null);
+					effPayerNum);
 }

--- a/hedera-node/src/test/java/com/hedera/services/state/expiry/ExpiringCreationsTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/state/expiry/ExpiringCreationsTest.java
@@ -123,7 +123,7 @@ class ExpiringCreationsTest {
 	private final EntityId customFeeToken = new EntityId(0, 0, 123);
 	private final EntityId customFeeCollector = new EntityId(0, 0, 124);
 	private final List<FcAssessedCustomFee> customFeesCharged = List.of(
-			new FcAssessedCustomFee(customFeeCollector, customFeeToken, 123L));
+			new FcAssessedCustomFee(customFeeCollector, customFeeToken, 123L, null));
 
 
 	@BeforeEach

--- a/hedera-node/src/test/java/com/hedera/services/state/expiry/ExpiringCreationsTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/state/expiry/ExpiringCreationsTest.java
@@ -123,7 +123,7 @@ class ExpiringCreationsTest {
 	private final EntityId customFeeToken = new EntityId(0, 0, 123);
 	private final EntityId customFeeCollector = new EntityId(0, 0, 124);
 	private final List<FcAssessedCustomFee> customFeesCharged = List.of(
-			new FcAssessedCustomFee(customFeeCollector, customFeeToken, 123L, null));
+			new FcAssessedCustomFee(customFeeCollector, customFeeToken, 123L, new long[] { 123L }));
 
 
 	@BeforeEach

--- a/hedera-node/src/test/java/com/hedera/services/state/submerkle/ExpirableTxnRecordTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/state/submerkle/ExpirableTxnRecordTest.java
@@ -85,7 +85,7 @@ class ExpirableTxnRecordTest {
 					withAdjustments(sponsor, -1L, beneficiary, 1L, magician, 1000L).getAccountAmountsList())
 			.build();
 	ScheduleID scheduleID = IdUtils.asSchedule("5.6.7");
-	FcAssessedCustomFee balanceChange = new FcAssessedCustomFee(feeCollector, token, units);
+	FcAssessedCustomFee balanceChange = new FcAssessedCustomFee(feeCollector, token, units, null);
 
 	ExpirableTxnRecord subject;
 

--- a/hedera-node/src/test/java/com/hedera/services/state/submerkle/ExpirableTxnRecordTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/state/submerkle/ExpirableTxnRecordTest.java
@@ -85,7 +85,7 @@ class ExpirableTxnRecordTest {
 					withAdjustments(sponsor, -1L, beneficiary, 1L, magician, 1000L).getAccountAmountsList())
 			.build();
 	ScheduleID scheduleID = IdUtils.asSchedule("5.6.7");
-	FcAssessedCustomFee balanceChange = new FcAssessedCustomFee(feeCollector, token, units, null);
+	FcAssessedCustomFee balanceChange = new FcAssessedCustomFee(feeCollector, token, units, new long[] { 234L });
 
 	ExpirableTxnRecord subject;
 
@@ -321,7 +321,7 @@ class ExpirableTxnRecordTest {
 				"readable=[1.2.5 -> -1, 1.2.6 <- +1, 1.2.7 <- +1000]}), assessedCustomFees=(" +
 				"FcAssessedCustomFee{token=EntityId{shard=1, realm=2, num=9}, account=EntityId{shard=1, realm=2, " +
 				"num=8}, " +
-				"units=123})}";
+				"units=123, effective payer accounts=[234]})}";
 
 		// expect:
 		assertEquals(desired, subject.toString());

--- a/hedera-node/src/test/java/com/hedera/services/txns/crypto/CryptoTransferTransitionLogicTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/txns/crypto/CryptoTransferTransitionLogicTest.java
@@ -170,7 +170,7 @@ class CryptoTransferTransitionLogicTest {
 
 		// and :
 		final var customFeesBalanceChange = List.of(
-				new FcAssessedCustomFee(a.asEntityId(), 10L, null));
+				new FcAssessedCustomFee(a.asEntityId(), 10L, new long[] { 123L }));
 		final var customFee = List.of(FcCustomFee.fixedFee(20L, null, a.asEntityId()));
 		final List<CustomFeeMeta> customFees = List.of(new CustomFeeMeta(c, d, customFee));
 		final var impliedTransfers = ImpliedTransfers.valid(

--- a/hedera-node/src/test/java/com/hedera/services/txns/crypto/CryptoTransferTransitionLogicTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/txns/crypto/CryptoTransferTransitionLogicTest.java
@@ -170,7 +170,7 @@ class CryptoTransferTransitionLogicTest {
 
 		// and :
 		final var customFeesBalanceChange = List.of(
-				new FcAssessedCustomFee(a.asEntityId(), 10L));
+				new FcAssessedCustomFee(a.asEntityId(), 10L, null));
 		final var customFee = List.of(FcCustomFee.fixedFee(20L, null, a.asEntityId()));
 		final List<CustomFeeMeta> customFees = List.of(new CustomFeeMeta(c, d, customFee));
 		final var impliedTransfers = ImpliedTransfers.valid(

--- a/hedera-node/src/test/java/com/hedera/services/txns/span/SpanMapManagerTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/txns/span/SpanMapManagerTest.java
@@ -80,9 +80,10 @@ class SpanMapManagerTest {
 			new CustomFeeMeta(
 					customFeeToken, treasury, List.of(FcCustomFee.fixedFee(
 							10L, customFeeToken.asEntityId(), customFeeCollector.asEntityId()))));
+	private final long [] effPayerNum = new long[] { 123L };
 	private final List<FcAssessedCustomFee> assessedCustomFees = List.of(
-			new FcAssessedCustomFee(customFeeCollector.asEntityId(), customFeeToken.asEntityId(), 123L, null),
-			new FcAssessedCustomFee(customFeeCollector.asEntityId(), 123L, null)
+			new FcAssessedCustomFee(customFeeCollector.asEntityId(), customFeeToken.asEntityId(), 123L, effPayerNum),
+			new FcAssessedCustomFee(customFeeCollector.asEntityId(), 123L, effPayerNum)
 	);
 
 	private final ImpliedTransfers validImpliedTransfers = ImpliedTransfers.valid(

--- a/hedera-node/src/test/java/com/hedera/services/txns/span/SpanMapManagerTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/txns/span/SpanMapManagerTest.java
@@ -81,8 +81,8 @@ class SpanMapManagerTest {
 					customFeeToken, treasury, List.of(FcCustomFee.fixedFee(
 							10L, customFeeToken.asEntityId(), customFeeCollector.asEntityId()))));
 	private final List<FcAssessedCustomFee> assessedCustomFees = List.of(
-			new FcAssessedCustomFee(customFeeCollector.asEntityId(), customFeeToken.asEntityId(), 123L),
-			new FcAssessedCustomFee(customFeeCollector.asEntityId(), 123L)
+			new FcAssessedCustomFee(customFeeCollector.asEntityId(), customFeeToken.asEntityId(), 123L, null),
+			new FcAssessedCustomFee(customFeeCollector.asEntityId(), 123L, null)
 	);
 
 	private final ImpliedTransfers validImpliedTransfers = ImpliedTransfers.valid(

--- a/hedera-node/src/test/java/com/hedera/test/utils/IdUtils.java
+++ b/hedera-node/src/test/java/com/hedera/test/utils/IdUtils.java
@@ -22,8 +22,6 @@ package com.hedera.test.utils;
 
 import com.hedera.services.ledger.BalanceChange;
 import com.hedera.services.state.merkle.MerkleEntityId;
-import com.hedera.services.state.submerkle.FcAssessedCustomFee;
-import com.hedera.services.state.submerkle.EntityId;
 import com.hedera.services.store.models.Id;
 import com.hederahashgraph.api.proto.java.AccountAmount;
 import com.hederahashgraph.api.proto.java.AccountID;
@@ -128,14 +126,6 @@ public class IdUtils {
 				.build();
 	}
 
-	public static NftTransfer adjustFromNft(AccountID from, AccountID to, long serialNumber) {
-		return NftTransfer.newBuilder()
-				.setSenderAccountID(from)
-				.setReceiverAccountID(to)
-				.setSerialNumber(serialNumber)
-				.build();
-	}
-
 	public static BalanceChange hbarChange(final AccountID account, final long amount) {
 		return BalanceChange.changingHbar(adjustFrom(account, amount));
 	}
@@ -144,25 +134,11 @@ public class IdUtils {
 		return BalanceChange.changingFtUnits(token, token.asGrpcToken(), adjustFrom(account, amount));
 	}
 
-	public static BalanceChange nftChange(final Id token, final AccountID from, final AccountID to,
-			final long serialNumber) {
-		return BalanceChange.changingNftOwnership(token, token.asGrpcToken(), adjustFromNft(from, to, serialNumber));
-	}
-
 	public static NftTransfer nftXfer(AccountID from, AccountID to, long serialNo) {
 		return NftTransfer.newBuilder()
 				.setSenderAccountID(from)
 				.setReceiverAccountID(to)
 				.setSerialNumber(serialNo)
 				.build();
-	}
-
-	public static FcAssessedCustomFee hbarChangeForCustomFees(final AccountID account, final long amount) {
-		return FcAssessedCustomFee.assessedHbarFeeFrom(adjustFrom(account, amount));
-	}
-
-	public static FcAssessedCustomFee tokenChangeForCustomFees(final EntityId token, final AccountID account,
-			final long amount) {
-		return FcAssessedCustomFee.assessedHtsFeeFrom(token, adjustFrom(account, amount));
 	}
 }

--- a/pom.xml
+++ b/pom.xml
@@ -162,7 +162,7 @@
     <ethereum-core.version>1.12.0-v0.5.0</ethereum-core.version>
     <grpc.version>1.39.0</grpc.version>
     <guava.version>30.1.1-jre</guava.version>
-    <hapi-proto.version>0.17.0-SNAPSHOT</hapi-proto.version>
+    <hapi-proto.version>0.17.1</hapi-proto.version>
     <javax.annotation-api.version>1.3.2</javax.annotation-api.version>
     <javax-inject.version>1</javax-inject.version>
     <log4j.version>2.14.1</log4j.version>

--- a/pom.xml
+++ b/pom.xml
@@ -162,7 +162,7 @@
     <ethereum-core.version>1.12.0-v0.5.0</ethereum-core.version>
     <grpc.version>1.39.0</grpc.version>
     <guava.version>30.1.1-jre</guava.version>
-    <hapi-proto.version>0.17.1</hapi-proto.version>
+    <hapi-proto.version>0.17.2-SNAPSHOT</hapi-proto.version>
     <javax.annotation-api.version>1.3.2</javax.annotation-api.version>
     <javax-inject.version>1</javax-inject.version>
     <log4j.version>2.14.1</log4j.version>


### PR DESCRIPTION
**Description**:
- In the `assessed_custom_fee`s record list, include the "effective payer(s)" for each fee; that is, the accounts whose final balances would have been higher in the absence of the fee.

**Related issue(s)**:
- Fixes #1938
