### PR TITLE
Provide FCOTMR toggle via static `tokens.nfts.areQueriesEnabled` property

### DIFF
--- a/hedera-node/src/main/java/com/hedera/services/context/ServicesContext.java
+++ b/hedera-node/src/main/java/com/hedera/services/context/ServicesContext.java
@@ -254,7 +254,6 @@ import com.hedera.services.state.merkle.MerkleUniqueToken;
 import com.hedera.services.state.merkle.MerkleUniqueTokenId;
 import com.hedera.services.state.submerkle.EntityId;
 import com.hedera.services.state.submerkle.ExchangeRates;
-import com.hedera.services.state.submerkle.FixedFeeSpec;
 import com.hedera.services.state.submerkle.SequenceNumber;
 import com.hedera.services.state.validation.BasedLedgerValidator;
 import com.hedera.services.state.validation.LedgerValidator;
@@ -964,15 +963,18 @@ public class ServicesContext {
 
 	public UniqTokenViewsManager uniqTokenViewsManager() {
 		if (uniqTokenViewsManager == null) {
+			final var shouldNoop = shouldNoopFcotmrUsage();
 			if (shouldUseTreasuryWildcards()) {
 				uniqTokenViewsManager = new UniqTokenViewsManager(
 						this::uniqueTokenAssociations,
 						this::uniqueOwnershipAssociations,
-						this::uniqueOwnershipTreasuryAssociations);
+						this::uniqueOwnershipTreasuryAssociations,
+						shouldNoop);
 			} else {
 				uniqTokenViewsManager = new UniqTokenViewsManager(
 						this::uniqueTokenAssociations,
-						this::uniqueOwnershipAssociations);
+						this::uniqueOwnershipAssociations,
+						shouldNoop);
 			}
 		}
 		return uniqTokenViewsManager;
@@ -980,6 +982,10 @@ public class ServicesContext {
 
 	private boolean shouldUseTreasuryWildcards() {
 		return properties().getBooleanProperty("tokens.nfts.useTreasuryWildcards");
+	}
+
+	private boolean shouldNoopFcotmrUsage() {
+		return !properties().getBooleanProperty("tokens.nfts.areQueriesEnabled");
 	}
 
 	public HederaNumbers hederaNums() {

--- a/hedera-node/src/main/java/com/hedera/services/context/properties/BootstrapProperties.java
+++ b/hedera-node/src/main/java/com/hedera/services/context/properties/BootstrapProperties.java
@@ -180,7 +180,8 @@ public class BootstrapProperties implements PropertySource {
 			"hedera.realm",
 			"hedera.shard",
 			"ledger.numSystemAccounts",
-			"ledger.totalTinyBarFloat"
+			"ledger.totalTinyBarFloat",
+			"tokens.nfts.areQueriesEnabled"
 	);
 
 	static final Set<String> GLOBAL_DYNAMIC_PROPS = Set.of(
@@ -370,6 +371,7 @@ public class BootstrapProperties implements PropertySource {
 			entry("tokens.nfts.maxAllowedMints", AS_LONG),
 			entry("tokens.nfts.maxQueryRange", AS_LONG),
 			entry("tokens.nfts.useTreasuryWildcards", AS_BOOLEAN),
+			entry("tokens.nfts.areQueriesEnabled", AS_BOOLEAN),
 			entry("contracts.localCall.estRetBytes", AS_INT),
 			entry("contracts.maxStorageKb", AS_INT),
 			entry("contracts.defaultLifetime", AS_LONG),

--- a/hedera-node/src/main/resources/bootstrap.properties
+++ b/hedera-node/src/main/resources/bootstrap.properties
@@ -37,6 +37,7 @@ hedera.realm=0
 hedera.shard=0
 ledger.numSystemAccounts=100
 ledger.totalTinyBarFloat=5000000000000000000
+tokens.nfts.areQueriesEnabled=true
 # Dynamic properties
 balances.exportDir.path=/opt/hgcapp/accountBalances/
 balances.exportEnabled=true

--- a/hedera-node/src/test/java/com/hedera/services/context/properties/BootstrapPropertiesTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/context/properties/BootstrapPropertiesTest.java
@@ -162,6 +162,7 @@ class BootstrapPropertiesTest {
 			entry("ledger.nftTransfers.maxLen", 10),
 			entry("ledger.xferBalanceChanges.maxLen", 20),
 			entry("tokens.nfts.areEnabled", true),
+			entry("tokens.nfts.areQueriesEnabled", true),
 			entry("tokens.nfts.useTreasuryWildcards", true),
 			entry("tokens.nfts.maxQueryRange", 100L),
 			entry("tokens.nfts.maxBatchSizeWipe", 10),

--- a/hedera-node/src/test/java/com/hedera/services/ledger/HederaLedgerLiveTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/ledger/HederaLedgerLiveTest.java
@@ -96,7 +96,8 @@ public class HederaLedgerLiveTest extends BaseHederaLedgerTestHelper {
 		final var viewManager = new UniqTokenViewsManager(
 				() -> uniqueTokenOwnerships,
 				() -> uniqueTokenAccountOwnerships,
-				() -> uniqueTokenTreasuryOwnerships);
+				() -> uniqueTokenTreasuryOwnerships,
+				false);
 		tokenStore = new HederaTokenStore(
 				ids,
 				TestContextValidator.TEST_VALIDATOR,

--- a/hedera-node/src/test/java/com/hedera/services/ledger/LedgerBalanceChangesTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/ledger/LedgerBalanceChangesTest.java
@@ -137,7 +137,8 @@ class LedgerBalanceChangesTest {
 		final var viewManager = new UniqTokenViewsManager(
 				() -> uniqueTokenOwnerships,
 				() -> uniqueOwnershipAssociations,
-				() -> uniqueOwnershipTreasuryAssociations);
+				() -> uniqueOwnershipTreasuryAssociations,
+				false);
 		tokenStore = new HederaTokenStore(
 				ids,
 				validator,
@@ -236,7 +237,8 @@ class LedgerBalanceChangesTest {
 		final var viewManager = new UniqTokenViewsManager(
 				() -> uniqueTokenOwnerships,
 				() -> uniqueOwnershipAssociations,
-				() -> uniqueOwnershipTreasuryAssociations);
+				() -> uniqueOwnershipTreasuryAssociations,
+				false);
 		tokenStore = new HederaTokenStore(
 				ids,
 				validator,

--- a/hedera-node/src/test/java/com/hedera/services/store/tokens/views/UniqTokenViewsManagerTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/store/tokens/views/UniqTokenViewsManagerTest.java
@@ -50,6 +50,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 @ExtendWith(MockitoExtension.class)
@@ -65,6 +66,60 @@ class UniqTokenViewsManagerTest {
 	private FCMap<MerkleUniqueTokenId, MerkleUniqueToken> realNfts;
 
 	private UniqTokenViewsManager subject;
+
+	@Test
+	void everythingNoopsWithTreasuryTrackingSubject() {
+		setupNoopTreasuryTrackingSubject();
+
+		// expect:
+		assertFalse(subject.isInTransaction());
+		assertTrue(subject.isUsingTreasuryWildcards());
+
+		// and when:
+		subject.begin();
+		subject.commit();
+		subject.rollback();
+		// and:
+		subject.rebuildNotice(null, null);
+		subject.mintNotice(null, null);
+		subject.wipeNotice(null, null);
+		subject.burnNotice(null, null);
+		subject.exchangeNotice(null, null, null);
+		subject.treasuryExitNotice(null, null, null);
+		subject.treasuryReturnNotice(null, null, null);
+
+		// then:
+		verifyNoInteractions(nftsByType);
+		verifyNoInteractions(nftsByOwner);
+		verifyNoInteractions(treasuryNftsByType);
+	}
+
+	@Test
+	void everythingNoopsWithNonTreasuryTrackingSubject() {
+		setupNoopNonTreasuryTrackingSubject();
+
+		// expect:
+		assertFalse(subject.isInTransaction());
+		assertFalse(subject.isUsingTreasuryWildcards());
+
+		// and when:
+		subject.begin();
+		subject.commit();
+		subject.rollback();
+		// and:
+		subject.rebuildNotice(null, null);
+		subject.mintNotice(null, null);
+		subject.wipeNotice(null, null);
+		subject.burnNotice(null, null);
+		subject.exchangeNotice(null, null, null);
+		subject.treasuryExitNotice(null, null, null);
+		subject.treasuryReturnNotice(null, null, null);
+
+		// then:
+		verifyNoInteractions(nftsByType);
+		verifyNoInteractions(nftsByOwner);
+		verifyNoInteractions(treasuryNftsByType);
+	}
 
 	@Test
 	void beginWorks() {
@@ -423,11 +478,19 @@ class UniqTokenViewsManagerTest {
 	}
 
 	private void setupTreasuryTrackingSubject() {
-		subject = new UniqTokenViewsManager(() -> nftsByType, () -> nftsByOwner, () -> treasuryNftsByType);
+		subject = new UniqTokenViewsManager(() -> nftsByType, () -> nftsByOwner, () -> treasuryNftsByType, false);
 	}
 
 	private void setupNonTreasuryTrackingSubject() {
-		subject = new UniqTokenViewsManager(() -> nftsByType, () -> nftsByOwner);
+		subject = new UniqTokenViewsManager(() -> nftsByType, () -> nftsByOwner, false);
+	}
+
+	private void setupNoopTreasuryTrackingSubject() {
+		subject = new UniqTokenViewsManager(() -> nftsByType, () -> nftsByOwner, () -> treasuryNftsByType, true);
+	}
+
+	private void setupNoopNonTreasuryTrackingSubject() {
+		subject = new UniqTokenViewsManager(() -> nftsByType, () -> nftsByOwner, true);
 	}
 
 	private UniqTokenViewsManager.PendingChange change(

--- a/hedera-node/src/test/resources/bootstrap/standard.properties
+++ b/hedera-node/src/test/resources/bootstrap/standard.properties
@@ -37,6 +37,7 @@ hedera.realm=0
 hedera.shard=0
 ledger.numSystemAccounts=100
 ledger.totalTinyBarFloat=5000000000000000000
+tokens.nfts.areQueriesEnabled=true
 # Dynamic properties
 balances.exportDir.path=/opt/hgcapp/accountBalances/
 balances.exportEnabled=true


### PR DESCRIPTION
**Description**:
- Add static `tokens.nfts.areQueriesEnabled=true` that determines if the `UniqTokenViewsManager` actually maintains NFT views via FCOTMR; or just does no-ops for all methods.
- This property will likely be set to `false` for the `v0.17.1` tag on the release branch; but will be left `true` in `master`.

**Related issue(s)**:
- Closes #2024
