### PR TITLE
Add `TokenGetNftInfo` prices being used in public fee estimator

### DIFF
--- a/hedera-node/src/main/resources/feeSchedules.json
+++ b/hedera-node/src/main/resources/feeSchedules.json
@@ -1909,6 +1909,51 @@
 	  },
 	  {
 		"transactionFeeSchedule": {
+		  "hederaFunctionality": "TokenGetNftInfo",
+		  "fees": [
+			{
+			  "nodedata": {
+				"constant": 54605,
+				"bpt": 87,
+				"vpt": 218244,
+				"rbh": 0,
+				"sbh": 0,
+				"gas": 1,
+				"bpr": 87,
+				"sbpr": 2,
+				"min": 0,
+				"max": 1000000000000000
+			  },
+			  "networkdata": {
+				"constant": 0,
+				"bpt": 0,
+				"vpt": 0,
+				"rbh": 0,
+				"sbh": 0,
+				"gas": 0,
+				"bpr": 0,
+				"sbpr": 0,
+				"min": 0,
+				"max": 0
+			  },
+			  "servicedata": {
+				"constant": 0,
+				"bpt": 0,
+				"vpt": 0,
+				"rbh": 0,
+				"sbh": 0,
+				"gas": 0,
+				"bpr": 0,
+				"sbpr": 0,
+				"min": 0,
+				"max": 0
+			  }
+			}
+		  ]
+		}
+	  },
+	  {
+		"transactionFeeSchedule": {
 		  "hederaFunctionality": "ScheduleCreate",
 		  "fees": [
 			{
@@ -5030,6 +5075,51 @@
 				"sbpr": 360355,
 				"min": 0,
 				"max": 1000000000000000
+			  }
+			}
+		  ]
+		}
+	  },
+	  {
+		"transactionFeeSchedule": {
+		  "hederaFunctionality": "TokenGetNftInfo",
+		  "fees": [
+			{
+			  "nodedata": {
+				"constant": 54605,
+				"bpt": 87,
+				"vpt": 218244,
+				"rbh": 0,
+				"sbh": 0,
+				"gas": 1,
+				"bpr": 87,
+				"sbpr": 2,
+				"min": 0,
+				"max": 1000000000000000
+			  },
+			  "networkdata": {
+				"constant": 0,
+				"bpt": 0,
+				"vpt": 0,
+				"rbh": 0,
+				"sbh": 0,
+				"gas": 0,
+				"bpr": 0,
+				"sbpr": 0,
+				"min": 0,
+				"max": 0
+			  },
+			  "servicedata": {
+				"constant": 0,
+				"bpt": 0,
+				"vpt": 0,
+				"rbh": 0,
+				"sbh": 0,
+				"gas": 0,
+				"bpr": 0,
+				"sbpr": 0,
+				"min": 0,
+				"max": 0
 			  }
 			}
 		  ]


### PR DESCRIPTION
Add non-default `TokenGetNftInfo` prices being used in the public fee estimator.