### PR TITLE
Fix test ServicesAppTest

### DIFF
--- a/hedera-node/configuration/compose/node.properties
+++ b/hedera-node/configuration/compose/node.properties
@@ -1,2 +1,2 @@
-hedera.recordStream.logDir=data/recordstreams/
+hedera.recordStream.logDir=data/recordStreams
 netty.mode=TEST

--- a/hedera-node/configuration/dev/application.properties
+++ b/hedera-node/configuration/dev/application.properties
@@ -1,7 +1,7 @@
 balances.exportDir.path=data/accountBalances/
 balances.exportPeriodSecs=900
 contracts.defaultLifetime=31536000
-hedera.recordStream.logDir=data/recordstreams/
+hedera.recordStream.logDir=data/recordStreams
 ledger.autoRenewPeriod.minDuration=10
 ledger.autoRenewPeriod.maxDuration=1000000000
 rates.intradayChangeLimitPercent=5

--- a/hedera-node/configuration/dev/node.properties
+++ b/hedera-node/configuration/dev/node.properties
@@ -1,2 +1,2 @@
 hedera.profiles.active=DEV
-hedera.recordStream.logDir=data/recordstreams/
+hedera.recordStream.logDir=data/recordStreams

--- a/hedera-node/src/test/java/com/hedera/services/ServicesAppTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/ServicesAppTest.java
@@ -117,7 +117,7 @@ class ServicesAppTest {
 		given(runningHash.getHash()).willReturn(hash);
 		given(platform.getCryptography()).willReturn(cryptography);
 		given(platform.getSelfId()).willReturn(selfNodeId);
-		if (!nodeProps.containsProperty(logDirKey) || !nodeProps.getStringProperty(logDirKey).matches(logDirVal)) {
+		if (!nodeProps.containsProperty(logDirKey)) {
 			given(overridingProps.containsProperty(any())).willReturn(false);
 			given(overridingProps.containsProperty(logDirKey)).willReturn(true);
 			given(overridingProps.getProperty(logDirKey)).willReturn(logDirVal);

--- a/hedera-node/src/test/java/com/hedera/services/ServicesAppTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/ServicesAppTest.java
@@ -104,7 +104,8 @@ class ServicesAppTest {
 	void setUp() {
 		final var bootstrapProps = new BootstrapProperties();
 		final var props = new ChainedSources(overridingProps, bootstrapProps);
-		final var logDir = "hedera.recordStream.logDir";
+		final var logDirKey = "hedera.recordStream.logDir";
+		final var logDirVal = "data/recordStreams";
 
 		given(address.getStake()).willReturn(123_456_789L);
 		given(addressBook.getAddress(selfId)).willReturn(address);
@@ -114,9 +115,6 @@ class ServicesAppTest {
 		given(runningHash.getHash()).willReturn(hash);
 		given(platform.getCryptography()).willReturn(cryptography);
 		given(platform.getSelfId()).willReturn(selfNodeId);
-		given(overridingProps.containsProperty(any())).willReturn(false);
-		given(overridingProps.containsProperty(logDir)).willReturn(true);
-		given(overridingProps.getProperty(logDir)).willReturn("data/recordStreams");
 
 		subject = DaggerServicesApp.builder()
 				.bootstrapProps(props)
@@ -124,6 +122,12 @@ class ServicesAppTest {
 				.platform(platform)
 				.selfId(selfId)
 				.build();
+
+		if (!subject.nodeLocalProperties().recordLogDir().matches(logDirVal)) {
+			given(overridingProps.containsProperty(any())).willReturn(false);
+			given(overridingProps.containsProperty(logDirKey)).willReturn(true);
+			given(overridingProps.getProperty(logDirKey)).willReturn(logDirVal);
+		}
 	}
 
 	@Test


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->
**Problem**
This test fails when local environment already has `node.properties` with `hedera.recordStream.logDir` value set to `data/recordStreams` with `UnnecessaryStubbing` failure.

Modified such that:
Test only passes if the node.propertis file has `hedera.recordStream.logDir=data/recordStreams` or no `hedera.recordStream.logDir` at all