### PR TITLE
Fail when max automatic associations requested is more than `token.maxPerAccount`

### DIFF
--- a/hedera-node/src/main/java/com/hedera/services/store/models/Account.java
+++ b/hedera-node/src/main/java/com/hedera/services/store/models/Account.java
@@ -39,7 +39,7 @@ import static com.hedera.services.state.merkle.internals.IdentityCodeUtils.getMa
 import static com.hedera.services.state.merkle.internals.IdentityCodeUtils.setAlreadyUsedAutomaticAssociationsTo;
 import static com.hedera.services.state.merkle.internals.IdentityCodeUtils.setMaxAutomaticAssociationsTo;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.FAIL_INVALID;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.NO_REMAINING_AUTO_ASSOCIATIONS;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.NO_REMAINING_AUTOMATIC_ASSOCIATIONS;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TOKENS_PER_ACCOUNT_LIMIT_EXCEEDED;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TOKEN_ALREADY_ASSOCIATED_TO_ACCOUNT;
 
@@ -112,7 +112,7 @@ public class Account {
 	}
 
 	public void setAlreadyUsedAutomaticAssociations(int alreadyUsedCount) {
-		validateTrue(alreadyUsedCount >= 0 && alreadyUsedCount <= getMaxAutomaticAssociations(), NO_REMAINING_AUTO_ASSOCIATIONS );
+		validateTrue(alreadyUsedCount >= 0 && alreadyUsedCount <= getMaxAutomaticAssociations(), NO_REMAINING_AUTOMATIC_ASSOCIATIONS );
 		autoAssociationMetadata = setAlreadyUsedAutomaticAssociationsTo(autoAssociationMetadata, alreadyUsedCount);
 	}
 

--- a/hedera-node/src/main/java/com/hedera/services/store/tokens/HederaTokenStore.java
+++ b/hedera-node/src/main/java/com/hedera/services/store/tokens/HederaTokenStore.java
@@ -105,7 +105,7 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_NFT_ID
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_RENEWAL_PERIOD;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_TOKEN_ID;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_TOKEN_ID_IN_CUSTOM_FEES;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.NO_REMAINING_AUTO_ASSOCIATIONS;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.NO_REMAINING_AUTOMATIC_ASSOCIATIONS;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OK;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.ROYALTY_FRACTION_CANNOT_EXCEED_ONE;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SENDER_DOES_NOT_OWN_NFT_SERIAL_NO;
@@ -221,7 +221,7 @@ public class HederaTokenStore extends HederaStore implements TokenStore {
 				var alreadyUsedAutomaticAssociations = hederaLedger.alreadyUsedAutomaticAssociations(aId);
 
 				if (automaticAssociation && alreadyUsedAutomaticAssociations >= maxAutomaticAssociations) {
-					validity = NO_REMAINING_AUTO_ASSOCIATIONS;
+					validity = NO_REMAINING_AUTOMATIC_ASSOCIATIONS;
 				}
 
 				if (validity == OK) {

--- a/hedera-node/src/main/java/com/hedera/services/txns/crypto/CryptoCreateTransitionLogic.java
+++ b/hedera-node/src/main/java/com/hedera/services/txns/crypto/CryptoCreateTransitionLogic.java
@@ -21,6 +21,7 @@ package com.hedera.services.txns.crypto;
  */
 
 import com.hedera.services.context.TransactionContext;
+import com.hedera.services.context.properties.GlobalDynamicProperties;
 import com.hedera.services.exceptions.InsufficientFundsException;
 import com.hedera.services.ledger.HederaLedger;
 import com.hedera.services.ledger.accounts.HederaAccountCustomizer;
@@ -51,6 +52,7 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_RENEWA
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_SEND_RECORD_THRESHOLD;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.KEY_REQUIRED;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OK;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.REQUESTED_NUM_AUTOMATIC_ASSOCIATIONS_EXCEEDS_ASSOCIATION_LIMIT;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SUCCESS;
 
 /**
@@ -69,16 +71,19 @@ public class CryptoCreateTransitionLogic implements TransitionLogic {
 	private final HederaLedger ledger;
 	private final OptionValidator validator;
 	private final TransactionContext txnCtx;
+	private final GlobalDynamicProperties dynamicProperties;
 
 	@Inject
 	public CryptoCreateTransitionLogic(
 			HederaLedger ledger,
 			OptionValidator validator,
-			TransactionContext txnCtx
+			TransactionContext txnCtx,
+			GlobalDynamicProperties dynamicProperties
 	) {
 		this.ledger = ledger;
 		this.txnCtx = txnCtx;
 		this.validator = validator;
+		this.dynamicProperties = dynamicProperties;
 	}
 
 	@Override
@@ -164,6 +169,9 @@ public class CryptoCreateTransitionLogic implements TransitionLogic {
 		}
 		if (op.getReceiveRecordThreshold() < 0L) {
 			return INVALID_RECEIVE_RECORD_THRESHOLD;
+		}
+		if (op.getMaxAutomaticTokenAssociations() > dynamicProperties.maxTokensPerAccount()) {
+			return REQUESTED_NUM_AUTOMATIC_ASSOCIATIONS_EXCEEDS_ASSOCIATION_LIMIT;
 		}
 
 		return OK;

--- a/hedera-node/src/test/java/com/hedera/services/ServicesAppTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/ServicesAppTest.java
@@ -115,8 +115,8 @@ class ServicesAppTest {
 		given(platform.getCryptography()).willReturn(cryptography);
 		given(platform.getSelfId()).willReturn(selfNodeId);
 		given(overridingProps.containsProperty(any())).willReturn(false);
-		given(overridingProps.containsProperty(logDir)).willReturn(true);
-		given(overridingProps.getProperty(logDir)).willReturn("data/recordStreams");
+//		given(overridingProps.containsProperty(logDir)).willReturn(true);
+//		given(overridingProps.getProperty(logDir)).willReturn("data/recordStreams");
 
 		subject = DaggerServicesApp.builder()
 				.bootstrapProps(props)

--- a/hedera-node/src/test/java/com/hedera/services/ServicesAppTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/ServicesAppTest.java
@@ -115,8 +115,8 @@ class ServicesAppTest {
 		given(platform.getCryptography()).willReturn(cryptography);
 		given(platform.getSelfId()).willReturn(selfNodeId);
 		given(overridingProps.containsProperty(any())).willReturn(false);
-//		given(overridingProps.containsProperty(logDir)).willReturn(true);
-//		given(overridingProps.getProperty(logDir)).willReturn("data/recordStreams");
+		given(overridingProps.containsProperty(logDir)).willReturn(true);
+		given(overridingProps.getProperty(logDir)).willReturn("data/recordStreams");
 
 		subject = DaggerServicesApp.builder()
 				.bootstrapProps(props)

--- a/hedera-node/src/test/java/com/hedera/services/store/models/AccountTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/store/models/AccountTest.java
@@ -33,7 +33,7 @@ import java.util.List;
 
 import static com.hedera.services.state.merkle.internals.IdentityCodeUtils.buildAutomaticAssociationMetaData;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.FAIL_INVALID;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.NO_REMAINING_AUTO_ASSOCIATIONS;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.NO_REMAINING_AUTOMATIC_ASSOCIATIONS;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TOKENS_PER_ACCOUNT_LIMIT_EXCEEDED;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TOKEN_ALREADY_ASSOCIATED_TO_ACCOUNT;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -208,7 +208,7 @@ class AccountTest {
 
 		assertFailsWith(
 				() -> subject.associateWith(List.of(firstNewToken), 10, true),
-				NO_REMAINING_AUTO_ASSOCIATIONS);
+				NO_REMAINING_AUTOMATIC_ASSOCIATIONS);
 	}
 
 	@Test
@@ -226,19 +226,19 @@ class AccountTest {
 	void invalidValuesToAlreadyUsedAutoAssociationsFailAsExpected() {
 		assertFailsWith(
 				() -> subject.setAlreadyUsedAutomaticAssociations(maxAutoAssociations+1),
-				NO_REMAINING_AUTO_ASSOCIATIONS);
+				NO_REMAINING_AUTOMATIC_ASSOCIATIONS);
 
 		subject.setAlreadyUsedAutomaticAssociations(maxAutoAssociations);
 
 		assertFailsWith(
 				() -> subject.incrementUsedAutomaticAssocitions(),
-				NO_REMAINING_AUTO_ASSOCIATIONS);
+				NO_REMAINING_AUTOMATIC_ASSOCIATIONS);
 
 		subject.setAlreadyUsedAutomaticAssociations(0);
 
 		assertFailsWith(
 				() -> subject.decrementUsedAutomaticAssocitions(),
-				NO_REMAINING_AUTO_ASSOCIATIONS);
+				NO_REMAINING_AUTOMATIC_ASSOCIATIONS);
 	}
 
 	private void assertFailsWith(Runnable something, ResponseCodeEnum status) {

--- a/hedera-node/src/test/java/com/hedera/services/store/tokens/HederaTokenStoreTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/store/tokens/HederaTokenStoreTest.java
@@ -118,7 +118,7 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_NFT_ID
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_RENEWAL_PERIOD;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_TOKEN_ID;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_TOKEN_ID_IN_CUSTOM_FEES;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.NO_REMAINING_AUTO_ASSOCIATIONS;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.NO_REMAINING_AUTOMATIC_ASSOCIATIONS;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OK;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.ROYALTY_FRACTION_CANNOT_EXCEED_ONE;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SENDER_DOES_NOT_OWN_NFT_SERIAL_NO;
@@ -594,12 +594,12 @@ class HederaTokenStoreTest {
 		// auto associate a fungible token
 		var status = subject.associate(sponsor, List.of(misc), true);
 
-		assertEquals(NO_REMAINING_AUTO_ASSOCIATIONS, status);
+		assertEquals(NO_REMAINING_AUTOMATIC_ASSOCIATIONS, status);
 
 		// auto associate a fungibleUnique token
 		status = subject.associate(sponsor, List.of(nonfungible), true);
 
-		assertEquals(NO_REMAINING_AUTO_ASSOCIATIONS, status);
+		assertEquals(NO_REMAINING_AUTOMATIC_ASSOCIATIONS, status);
 	}
 
 	@Test
@@ -1412,7 +1412,7 @@ class HederaTokenStoreTest {
 
 		var status = subject.adjustBalance(anotherFeeCollector, misc, 1);
 
-		assertEquals(NO_REMAINING_AUTO_ASSOCIATIONS, status);
+		assertEquals(NO_REMAINING_AUTOMATIC_ASSOCIATIONS, status);
 		verify(tokenRelsLedger, never()).set(anotherFeeCollectorMisc, TOKEN_BALANCE, 1L);
 		verify(hederaLedger, never()).setAlreadyUsedAutomaticAssociations(anotherFeeCollector, 4);
 	}

--- a/pom.xml
+++ b/pom.xml
@@ -163,7 +163,7 @@
     <ethereum-core.version>1.12.0-v0.5.0</ethereum-core.version>
     <grpc.version>1.39.0</grpc.version>
     <guava.version>30.1.1-jre</guava.version>
-    <hapi-proto.version>0.18.0-SNAPSHOT</hapi-proto.version>
+    <hapi-proto.version>0.18.0-alpha.2-SNAPSHOT</hapi-proto.version>
     <javax.annotation-api.version>1.3.2</javax.annotation-api.version>
     <javax-inject.version>1</javax-inject.version>
     <log4j.version>2.14.1</log4j.version>

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoCreateSuite.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoCreateSuite.java
@@ -34,6 +34,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.List;
+import java.util.Map;
 
 import static com.hedera.services.bdd.spec.HapiApiSpec.defaultHapiSpec;
 import static com.hedera.services.bdd.spec.keys.ControlForKey.forKey;
@@ -44,12 +45,14 @@ import static com.hedera.services.bdd.spec.keys.KeyShape.threshOf;
 import static com.hedera.services.bdd.spec.keys.SigControl.OFF;
 import static com.hedera.services.bdd.spec.keys.SigControl.ON;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getAccountBalance;
+import static com.hedera.services.bdd.spec.queries.QueryVerbs.getAccountInfo;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getTxnRecord;
 import static com.hedera.services.bdd.spec.transactions.TxnUtils.randomUtf8Bytes;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.contractCreate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoCreate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoTransfer;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.fileCreate;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.fileUpdate;
 import static com.hedera.services.bdd.spec.transactions.crypto.HapiCryptoTransfer.tinyBarsFromTo;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.validateChargedUsd;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.withOpContext;
@@ -60,6 +63,7 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_ACCOUN
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_SIGNATURE;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_ZERO_BYTE_IN_STRING;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.KEY_REQUIRED;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.REQUESTED_NUM_AUTOMATIC_ASSOCIATIONS_EXCEEDS_ASSOCIATION_LIMIT;
 
 public class CryptoCreateSuite extends HapiApiSuite {
 	private static final Logger log = LogManager.getLogger(CryptoCreateSuite.class);
@@ -88,8 +92,39 @@ public class CryptoCreateSuite extends HapiApiSuite {
 				createAnAccountInvalidED25519(),
 				syntaxChecksAreAsExpected(),
 				xferRequiresCrypto(),
-				usdFeeAsExpected()
+				usdFeeAsExpected(),
+				maxAutoAssociationSpec()
 		);
+	}
+
+	private HapiApiSpec maxAutoAssociationSpec() {
+		final int MONOGAMOUS_NETWORK = 1;
+		final int maxAutoAssociations = 100;
+		final int ADVENTUROUS_NETWORK = 1_000;
+		final String user = "user";
+		return defaultHapiSpec("MaxAutoAssociationSpec")
+				.given(
+						fileUpdate(APP_PROPERTIES)
+								.payingWith(ADDRESS_BOOK_CONTROL)
+								.overridingProps(Map.of("tokens.maxPerAccount", "" + MONOGAMOUS_NETWORK))
+				)
+				.when()
+				.then(
+						cryptoCreate(user)
+								.balance(ONE_HBAR)
+								.maxAutomaticTokenAssociations(maxAutoAssociations)
+								.hasPrecheck(REQUESTED_NUM_AUTOMATIC_ASSOCIATIONS_EXCEEDS_ASSOCIATION_LIMIT),
+						fileUpdate(APP_PROPERTIES)
+								.payingWith(ADDRESS_BOOK_CONTROL)
+								.overridingProps(Map.of(
+										"tokens.maxPerAccount", "" + ADVENTUROUS_NETWORK
+								)),
+						cryptoCreate(user)
+								.balance(ONE_HBAR)
+								.maxAutomaticTokenAssociations(maxAutoAssociations),
+						getAccountInfo(user)
+								.hasMaxAutomaticAssociations(maxAutoAssociations)
+				);
 	}
 
 	/* Prior to 0.13.0, a "canonical" CryptoCreate (one sig, 3 month auto-renew) cost 1¢. */

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoTransferSuite.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoTransferSuite.java
@@ -64,7 +64,7 @@ import static com.hedera.services.bdd.spec.utilops.UtilVerbs.sourcing;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.validateChargedUsdWithin;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.withOpContext;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_ACCOUNT_ID;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.NO_REMAINING_AUTO_ASSOCIATIONS;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.NO_REMAINING_AUTOMATIC_ASSOCIATIONS;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SUCCESS;
 import static com.hederahashgraph.api.proto.java.TokenType.FUNGIBLE_COMMON;
 import static com.hederahashgraph.api.proto.java.TokenType.NON_FUNGIBLE_UNIQUE;
@@ -150,7 +150,7 @@ public class CryptoTransferSuite extends HapiApiSuite {
 				)
 				.then(
 						cryptoTransfer(moving(1, tokenB).between(treasury, firstUser))
-								.hasKnownStatus(NO_REMAINING_AUTO_ASSOCIATIONS)
+								.hasKnownStatus(NO_REMAINING_AUTOMATIC_ASSOCIATIONS)
 								.via("failedTransfer"),
 						getAccountInfo(firstUser)
 								.hasAlreadyUsedAutomaticAssociations(1)


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->
Added appropriate checks during `semanticCheck`[precheck] in CryptoCreateTransitionLogic and `sanityCheck` in CryptoUpdateTransitionLogic
**Related issue(s)**:

Fixes #2093 

Ran a JRS CI regression locally 
Results : https://hedera-hashgraph.slack.com/archives/C018CBQBTGB/p1630517846014900

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
