### PR TITLE
Updating correct loggers for classes

### DIFF
--- a/hedera-node/src/main/java/com/hedera/services/records/RecordCacheFactory.java
+++ b/hedera-node/src/main/java/com/hedera/services/records/RecordCacheFactory.java
@@ -38,7 +38,7 @@ import java.util.concurrent.TimeUnit;
  */
 @Singleton
 public class RecordCacheFactory {
-	private static final Logger log = LogManager.getLogger(RecordCache.class);
+	private static final Logger log = LogManager.getLogger(RecordCacheFactory.class);
 
 	private final PropertySource properties;
 
@@ -48,7 +48,7 @@ public class RecordCacheFactory {
 	}
 
 	public Cache<TransactionID, Boolean> getCache() {
-		int ttl = properties.getIntProperty("cache.records.ttl");
+		final int ttl = properties.getIntProperty("cache.records.ttl");
 
 		log.info("Constructing the node-local txn id cache with ttl={}s", ttl);
 		return CacheBuilder

--- a/hedera-node/src/main/java/com/hedera/services/records/RecordCacheFactory.java
+++ b/hedera-node/src/main/java/com/hedera/services/records/RecordCacheFactory.java
@@ -37,7 +37,7 @@ import java.util.concurrent.TimeUnit;
  * configured in the Hedera Services properties.
  */
 @Singleton
-public class RecordCacheFactory {
+public final class RecordCacheFactory {
 	private static final Logger log = LogManager.getLogger(RecordCacheFactory.class);
 
 	private final PropertySource properties;

--- a/hedera-node/src/main/java/com/hedera/services/records/RecordCacheFactory.java
+++ b/hedera-node/src/main/java/com/hedera/services/records/RecordCacheFactory.java
@@ -9,9 +9,9 @@ package com.hedera.services.records;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -43,12 +43,12 @@ public class RecordCacheFactory {
 	private final PropertySource properties;
 
 	@Inject
-	public RecordCacheFactory(@CompositeProps PropertySource properties) {
+	public RecordCacheFactory(final @CompositeProps PropertySource properties) {
 		this.properties = properties;
 	}
 
 	public Cache<TransactionID, Boolean> getCache() {
-		final int ttl = properties.getIntProperty("cache.records.ttl");
+		final var ttl = properties.getIntProperty("cache.records.ttl");
 
 		log.info("Constructing the node-local txn id cache with ttl={}s", ttl);
 		return CacheBuilder

--- a/hedera-node/src/main/java/com/hedera/services/txns/schedule/ScheduleDeleteTransitionLogic.java
+++ b/hedera-node/src/main/java/com/hedera/services/txns/schedule/ScheduleDeleteTransitionLogic.java
@@ -46,13 +46,13 @@ public class ScheduleDeleteTransitionLogic implements TransitionLogic {
 
 	private final Function<TransactionBody, ResponseCodeEnum> SEMANTIC_CHECK = this::validate;
 
-	ScheduleStore store;
-	TransactionContext txnCtx;
+	private final ScheduleStore store;
+	private final TransactionContext txnCtx;
 
 	@Inject
 	public ScheduleDeleteTransitionLogic(
-			ScheduleStore store,
-			TransactionContext txnCtx
+			final ScheduleStore store,
+			final TransactionContext txnCtx
 	) {
 		this.store = store;
 		this.txnCtx = txnCtx;
@@ -68,7 +68,7 @@ public class ScheduleDeleteTransitionLogic implements TransitionLogic {
 		}
 	}
 
-	private void transitionFor(ScheduleDeleteTransactionBody op, Instant consensusTime) {
+	private void transitionFor(final ScheduleDeleteTransactionBody op, final Instant consensusTime) {
 		final var outcome = store.deleteAt(op.getScheduleID(), consensusTime);
 		txnCtx.setStatus((outcome == OK) ? SUCCESS : outcome);
 	}
@@ -83,7 +83,7 @@ public class ScheduleDeleteTransitionLogic implements TransitionLogic {
 		return SEMANTIC_CHECK;
 	}
 
-	public ResponseCodeEnum validate(TransactionBody txnBody) {
+	public ResponseCodeEnum validate(final TransactionBody txnBody) {
 		ScheduleDeleteTransactionBody op = txnBody.getScheduleDelete();
 		if (!op.hasScheduleID()) {
 			return INVALID_SCHEDULE_ID;

--- a/hedera-node/src/main/java/com/hedera/services/txns/schedule/ScheduleDeleteTransitionLogic.java
+++ b/hedera-node/src/main/java/com/hedera/services/txns/schedule/ScheduleDeleteTransitionLogic.java
@@ -42,7 +42,7 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SUCCESS;
 
 @Singleton
 public class ScheduleDeleteTransitionLogic implements TransitionLogic {
-	private static final Logger log = LogManager.getLogger(ScheduleCreateTransitionLogic.class);
+	private static final Logger log = LogManager.getLogger(ScheduleDeleteTransitionLogic.class);
 
 	private final Function<TransactionBody, ResponseCodeEnum> SEMANTIC_CHECK = this::validate;
 
@@ -69,7 +69,7 @@ public class ScheduleDeleteTransitionLogic implements TransitionLogic {
 	}
 
 	private void transitionFor(ScheduleDeleteTransactionBody op, Instant consensusTime) {
-		var outcome = store.deleteAt(op.getScheduleID(), consensusTime);
+		final var outcome = store.deleteAt(op.getScheduleID(), consensusTime);
 		txnCtx.setStatus((outcome == OK) ? SUCCESS : outcome);
 	}
 

--- a/hedera-node/src/main/java/com/hedera/services/txns/schedule/ScheduleDeleteTransitionLogic.java
+++ b/hedera-node/src/main/java/com/hedera/services/txns/schedule/ScheduleDeleteTransitionLogic.java
@@ -41,10 +41,8 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OK;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SUCCESS;
 
 @Singleton
-public class ScheduleDeleteTransitionLogic implements TransitionLogic {
+public final class ScheduleDeleteTransitionLogic implements TransitionLogic {
 	private static final Logger log = LogManager.getLogger(ScheduleDeleteTransitionLogic.class);
-
-	private final Function<TransactionBody, ResponseCodeEnum> SEMANTIC_CHECK = this::validate;
 
 	private final ScheduleStore store;
 	private final TransactionContext txnCtx;
@@ -62,7 +60,7 @@ public class ScheduleDeleteTransitionLogic implements TransitionLogic {
 	public void doStateTransition() {
 		try {
 			transitionFor(txnCtx.accessor().getTxn().getScheduleDelete(), txnCtx.consensusTime());
-		} catch (Exception e) {
+		} catch (final Exception e) {
 			log.warn("Unhandled error while processing :: {}!", txnCtx.accessor().getSignedTxnWrapper(), e);
 			txnCtx.setStatus(FAIL_INVALID);
 		}
@@ -80,11 +78,11 @@ public class ScheduleDeleteTransitionLogic implements TransitionLogic {
 
 	@Override
 	public Function<TransactionBody, ResponseCodeEnum> semanticCheck() {
-		return SEMANTIC_CHECK;
+		return this::validate;
 	}
 
-	public ResponseCodeEnum validate(final TransactionBody txnBody) {
-		ScheduleDeleteTransactionBody op = txnBody.getScheduleDelete();
+	private ResponseCodeEnum validate(final TransactionBody txnBody) {
+		final var op = txnBody.getScheduleDelete();
 		if (!op.hasScheduleID()) {
 			return INVALID_SCHEDULE_ID;
 		}

--- a/hedera-node/src/main/java/com/hedera/services/txns/submission/TxnResponseHelper.java
+++ b/hedera-node/src/main/java/com/hedera/services/txns/submission/TxnResponseHelper.java
@@ -9,9 +9,9 @@ package com.hedera.services.txns.submission;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -37,7 +37,7 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.FAIL_INVALID;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OK;
 
 @Singleton
-public class TxnResponseHelper {
+public final class TxnResponseHelper {
 	private static final Logger log = LogManager.getLogger(TxnResponseHelper.class);
 
 	static final TransactionResponse FAIL_INVALID_RESPONSE = TransactionResponse.newBuilder()
@@ -76,8 +76,8 @@ public class TxnResponseHelper {
 
 		try {
 			response = submissionFlow.submit(signedTxn);
-		} catch (Exception surprising) {
-			SignedTxnAccessor accessor = SignedTxnAccessor.uncheckedFrom(signedTxn);
+		} catch (final Exception surprising) {
+			final var accessor = SignedTxnAccessor.uncheckedFrom(signedTxn);
 			log.warn("Submission flow unable to submit {}!", accessor.getSignedTxnWrapper(), surprising);
 			response = FAIL_INVALID_RESPONSE;
 		}

--- a/hedera-node/src/main/java/com/hedera/services/txns/submission/TxnResponseHelper.java
+++ b/hedera-node/src/main/java/com/hedera/services/txns/submission/TxnResponseHelper.java
@@ -20,7 +20,6 @@ package com.hedera.services.txns.submission;
  * ‍
  */
 
-import com.hedera.services.queries.answering.QueryResponseHelper;
 import com.hedera.services.stats.HapiOpCounters;
 import com.hedera.services.txns.SubmissionFlow;
 import com.hedera.services.utils.SignedTxnAccessor;
@@ -39,7 +38,7 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OK;
 
 @Singleton
 public class TxnResponseHelper {
-	private static final Logger log = LogManager.getLogger(QueryResponseHelper.class);
+	private static final Logger log = LogManager.getLogger(TxnResponseHelper.class);
 
 	static final TransactionResponse FAIL_INVALID_RESPONSE = TransactionResponse.newBuilder()
 			.setNodeTransactionPrecheckCode(FAIL_INVALID)

--- a/hedera-node/src/main/java/com/hedera/services/txns/submission/TxnResponseHelper.java
+++ b/hedera-node/src/main/java/com/hedera/services/txns/submission/TxnResponseHelper.java
@@ -48,15 +48,15 @@ public class TxnResponseHelper {
 	private final HapiOpCounters opCounters;
 
 	@Inject
-	public TxnResponseHelper(SubmissionFlow submissionFlow, HapiOpCounters opCounters) {
+	public TxnResponseHelper(final SubmissionFlow submissionFlow, final HapiOpCounters opCounters) {
 		this.opCounters = opCounters;
 		this.submissionFlow = submissionFlow;
 	}
 
 	public void submit(
-			Transaction signedTxn,
-			StreamObserver<TransactionResponse> observer,
-			HederaFunctionality statedFunction
+			final Transaction signedTxn,
+			final StreamObserver<TransactionResponse> observer,
+			final HederaFunctionality statedFunction
 	) {
 		respondWithMetrics(
 				signedTxn,
@@ -66,10 +66,10 @@ public class TxnResponseHelper {
 	}
 
 	private void respondWithMetrics(
-			Transaction signedTxn,
-			StreamObserver<TransactionResponse> observer,
-			Runnable incReceivedCount,
-			Runnable incSubmittedCount
+			final Transaction signedTxn,
+			final StreamObserver<TransactionResponse> observer,
+			final Runnable incReceivedCount,
+			final Runnable incSubmittedCount
 	) {
 		incReceivedCount.run();
 		TransactionResponse response;

--- a/hedera-node/src/test/java/com/hedera/services/records/RecordCacheFactoryTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/records/RecordCacheFactoryTest.java
@@ -32,10 +32,10 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.mock;
 
 class RecordCacheFactoryTest {
-	private TransactionID txnIdA = TransactionID.newBuilder()
+	private final TransactionID txnIdA = TransactionID.newBuilder()
 			.setAccountID(asAccount("0.0.2"))
 			.build();
-	private TransactionID txnIdB = TransactionID.newBuilder()
+	private final TransactionID txnIdB = TransactionID.newBuilder()
 			.setAccountID(asAccount("2.2.0"))
 			.build();
 
@@ -44,17 +44,14 @@ class RecordCacheFactoryTest {
 
 	@Test
 	void hasExpectedExpiry() {
-		// setup:
 		properties = mock(PropertySource.class);
 		subject = new RecordCacheFactory(properties);
 
 		given(properties.getIntProperty("cache.records.ttl")).willReturn(1);
 
-		// when:
 		var cache = subject.getCache();
 		cache.put(txnIdA, RecordCache.MARKER);
 
-		// then:
 		assertEquals(RecordCache.MARKER, cache.getIfPresent(txnIdA));
 		assertNull(cache.getIfPresent(txnIdB));
 		SLEEPING_PAUSE.forMs(50L);

--- a/hedera-node/src/test/java/com/hedera/services/records/RecordCacheFactoryTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/records/RecordCacheFactoryTest.java
@@ -9,9 +9,9 @@ package com.hedera.services.records;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -21,35 +21,52 @@ package com.hedera.services.records;
  */
 
 import com.hedera.services.context.properties.PropertySource;
+import com.hedera.test.extensions.LogCaptor;
+import com.hedera.test.extensions.LogCaptureExtension;
+import com.hedera.test.extensions.LoggingSubject;
+import com.hedera.test.extensions.LoggingTarget;
 import com.hederahashgraph.api.proto.java.TransactionID;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import static com.hedera.services.utils.SleepingPause.SLEEPING_PAUSE;
 import static com.hedera.test.utils.IdUtils.asAccount;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.collection.IsIterableContainingInOrder.contains;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.mock;
 
+@ExtendWith({ LogCaptureExtension.class })
 class RecordCacheFactoryTest {
-	private final TransactionID txnIdA = TransactionID.newBuilder()
+	private static final TransactionID txnIdA = TransactionID.newBuilder()
 			.setAccountID(asAccount("0.0.2"))
 			.build();
-	private final TransactionID txnIdB = TransactionID.newBuilder()
+	private static final TransactionID txnIdB = TransactionID.newBuilder()
 			.setAccountID(asAccount("2.2.0"))
 			.build();
 
-	private PropertySource properties;
+	@LoggingTarget
+	private LogCaptor logCaptor;
+
+	@LoggingSubject
 	private RecordCacheFactory subject;
+
+	private PropertySource properties;
+
+	@BeforeEach
+	void setUp() {
+		properties = mock(PropertySource.class);
+		given(properties.getIntProperty("cache.records.ttl")).willReturn(1);
+
+		subject = new RecordCacheFactory(properties);
+	}
 
 	@Test
 	void hasExpectedExpiry() {
-		properties = mock(PropertySource.class);
-		subject = new RecordCacheFactory(properties);
-
-		given(properties.getIntProperty("cache.records.ttl")).willReturn(1);
-
-		var cache = subject.getCache();
+		final var cache = subject.getCache();
 		cache.put(txnIdA, RecordCache.MARKER);
 
 		assertEquals(RecordCache.MARKER, cache.getIfPresent(txnIdA));
@@ -58,5 +75,6 @@ class RecordCacheFactoryTest {
 		assertEquals(RecordCache.MARKER, cache.getIfPresent(txnIdA));
 		SLEEPING_PAUSE.forMs(1000L);
 		assertNull(cache.getIfPresent(txnIdA));
+		assertThat(logCaptor.infoLogs(), contains("Constructing the node-local txn id cache with ttl=1s"));
 	}
 }

--- a/hedera-node/src/test/java/com/hedera/services/txns/schedule/ScheduleDeleteTransitionLogicTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/txns/schedule/ScheduleDeleteTransitionLogicTest.java
@@ -9,9 +9,9 @@ package com.hedera.services.txns.schedule;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -42,126 +42,116 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.FAIL_INVALID;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_SCHEDULE_ID;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OK;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SUCCESS;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.collection.IsIterableContainingInOrder.contains;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.collection.IsIterableContainingInOrder.contains;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith({ LogCaptureExtension.class })
 class ScheduleDeleteTransitionLogicTest {
-    private final Instant consensusNow = Instant.ofEpochSecond(1_234_567L, 890);
+	private static final Instant consensusNow = Instant.ofEpochSecond(1_234_567L, 890);
+	private static final ResponseCodeEnum NOT_OK = null;
+	private static final ScheduleID schedule = IdUtils.asSchedule("1.2.3");
 
-    private ScheduleStore store;
-    private PlatformTxnAccessor accessor;
-    private TransactionContext txnCtx;
-    private final ResponseCodeEnum NOT_OK = null;
+	private ScheduleStore store;
+	private PlatformTxnAccessor accessor;
+	private TransactionContext txnCtx;
 
-    private final ScheduleID schedule = IdUtils.asSchedule("1.2.3");
+	private TransactionBody scheduleDeleteTxn;
 
-    private TransactionBody scheduleDeleteTxn;
+	@LoggingTarget
+	private LogCaptor logCaptor;
 
-    @LoggingTarget
-    private LogCaptor logCaptor;
+	@LoggingSubject
+	private ScheduleDeleteTransitionLogic subject;
 
-    @LoggingSubject
-    private ScheduleDeleteTransitionLogic subject;
+	@BeforeEach
+	private void setup() {
+		store = mock(ScheduleStore.class);
+		accessor = mock(PlatformTxnAccessor.class);
+		txnCtx = mock(TransactionContext.class);
+		subject = new ScheduleDeleteTransitionLogic(store, txnCtx);
+	}
 
-    @BeforeEach
-    private void setup() {
-        store = mock(ScheduleStore.class);
-        accessor = mock(PlatformTxnAccessor.class);
-        txnCtx = mock(TransactionContext.class);
-        subject = new ScheduleDeleteTransitionLogic(store, txnCtx);
-    }
+	@Test
+	void followsHappyPath() {
+		givenValidTxnCtx();
+		given(store.deleteAt(schedule, consensusNow)).willReturn(OK);
 
-    @Test
-    void followsHappyPath() {
-        givenValidTxnCtx();
-        given(store.deleteAt(schedule, consensusNow)).willReturn(OK);
+		subject.doStateTransition();
 
-        subject.doStateTransition();
+		verify(store).deleteAt(schedule, consensusNow);
+		verify(txnCtx).setStatus(SUCCESS);
+	}
 
-        verify(store).deleteAt(schedule, consensusNow);
-        verify(txnCtx).setStatus(SUCCESS);
-    }
+	@Test
+	void capturesInvalidSchedule() {
+		givenValidTxnCtx();
+		given(store.deleteAt(schedule, consensusNow)).willReturn(NOT_OK);
 
-    @Test
-    void capturesInvalidSchedule() {
-        givenValidTxnCtx();
-        given(store.deleteAt(schedule, consensusNow)).willReturn(NOT_OK);
+		subject.doStateTransition();
 
-        subject.doStateTransition();
+		verify(store).deleteAt(schedule, consensusNow);
+		verify(txnCtx).setStatus(NOT_OK);
+	}
 
-        verify(store).deleteAt(schedule, consensusNow);
-        verify(txnCtx).setStatus(NOT_OK);
-    }
+	@Test
+	void setsFailInvalidIfUnhandledException() {
+		givenValidTxnCtx();
+		given(store.deleteAt(schedule, consensusNow)).willThrow(IllegalArgumentException.class);
 
-    @Test
-    void setsFailInvalidIfUnhandledException() {
-        givenValidTxnCtx();
-        given(store.deleteAt(schedule, consensusNow)).willThrow(IllegalArgumentException.class);
+		subject.doStateTransition();
 
-        subject.doStateTransition();
+		verify(store).deleteAt(schedule, consensusNow);
+		assertThat(logCaptor.warnLogs(), contains("Unhandled error while processing :: null! " +
+				"java.lang.IllegalArgumentException: null"));
+		verify(txnCtx).setStatus(FAIL_INVALID);
+	}
 
-        verify(store).deleteAt(schedule, consensusNow);
-        assertThat(logCaptor.warnLogs(), contains("Unhandled error while processing :: null! " +
-                "java.lang.IllegalArgumentException: null"));
-        verify(txnCtx).setStatus(FAIL_INVALID);
-    }
+	@Test
+	void hasCorrectApplicability() {
+		givenValidTxnCtx();
 
-    @Test
-    void hasCorrectApplicability() {
-        givenValidTxnCtx();
+		assertTrue(subject.applicability().test(scheduleDeleteTxn));
+		assertFalse(subject.applicability().test(TransactionBody.getDefaultInstance()));
+	}
 
-        assertTrue(subject.applicability().test(scheduleDeleteTxn));
-        assertFalse(subject.applicability().test(TransactionBody.getDefaultInstance()));
-    }
+	@Test
+	void acceptsValidTxn() {
+		givenValidTxnCtx();
 
-    @Test
-    void failsOnInvalidSchedule() {
-        givenCtx(true);
+		assertEquals(OK, subject.semanticCheck().apply(scheduleDeleteTxn));
+	}
 
-        assertEquals(INVALID_SCHEDULE_ID, subject.validate(scheduleDeleteTxn));
-    }
+	@Test
+	void rejectsInvalidScheduleId() {
+		givenCtx(true);
 
-    @Test
-    void acceptsValidTxn() {
-        givenValidTxnCtx();
+		assertEquals(INVALID_SCHEDULE_ID, subject.semanticCheck().apply(scheduleDeleteTxn));
+	}
 
-        assertEquals(OK, subject.semanticCheck().apply(scheduleDeleteTxn));
-    }
+	private void givenValidTxnCtx() {
+		givenCtx(false);
+	}
 
-    @Test
-    void rejectsInvalidScheduleId() {
-        givenCtx(true);
+	private void givenCtx(final boolean invalidScheduleId) {
+		final var builder = TransactionBody.newBuilder();
+		final var scheduleDelete = ScheduleDeleteTransactionBody.newBuilder()
+				.setScheduleID(schedule);
 
-        assertEquals(INVALID_SCHEDULE_ID, subject.semanticCheck().apply(scheduleDeleteTxn));
-    }
+		if (invalidScheduleId) {
+			scheduleDelete.clearScheduleID();
+		}
 
-    private void givenValidTxnCtx() {
-        givenCtx(false);
-    }
+		builder.setScheduleDelete(scheduleDelete);
 
-    private void givenCtx(
-            boolean invalidScheduleId
-    ) {
-        final var builder = TransactionBody.newBuilder();
-        final var scheduleDelete = ScheduleDeleteTransactionBody.newBuilder()
-                .setScheduleID(schedule);
-
-        if (invalidScheduleId) {
-            scheduleDelete.clearScheduleID();
-        }
-
-        builder.setScheduleDelete(scheduleDelete);
-
-        scheduleDeleteTxn = builder.build();
-        given(accessor.getTxn()).willReturn(scheduleDeleteTxn);
-        given(txnCtx.accessor()).willReturn(accessor);
-        given(txnCtx.consensusTime()).willReturn(consensusNow);
-    }
+		scheduleDeleteTxn = builder.build();
+		given(accessor.getTxn()).willReturn(scheduleDeleteTxn);
+		given(txnCtx.accessor()).willReturn(accessor);
+		given(txnCtx.consensusTime()).willReturn(consensusNow);
+	}
 }

--- a/hedera-node/src/test/java/com/hedera/services/txns/schedule/ScheduleDeleteTransitionLogicTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/txns/schedule/ScheduleDeleteTransitionLogicTest.java
@@ -52,7 +52,7 @@ class ScheduleDeleteTransitionLogicTest {
     private TransactionContext txnCtx;
     private final ResponseCodeEnum NOT_OK = null;
 
-    private ScheduleID schedule = IdUtils.asSchedule("1.2.3");
+    private final ScheduleID schedule = IdUtils.asSchedule("1.2.3");
 
     private TransactionBody scheduleDeleteTxn;
     private ScheduleDeleteTransitionLogic subject;
@@ -67,32 +67,22 @@ class ScheduleDeleteTransitionLogicTest {
 
     @Test
     void followsHappyPath() {
-        // given:
         givenValidTxnCtx();
-
-        // and:
         given(store.deleteAt(schedule, consensusNow)).willReturn(OK);
 
-        // when:
         subject.doStateTransition();
 
-        // then
         verify(store).deleteAt(schedule, consensusNow);
         verify(txnCtx).setStatus(SUCCESS);
     }
 
     @Test
     void capturesInvalidSchedule() {
-        // given:
         givenValidTxnCtx();
-
-        // and:
         given(store.deleteAt(schedule, consensusNow)).willReturn(NOT_OK);
 
-        // when:
         subject.doStateTransition();
 
-        // then
         verify(store).deleteAt(schedule, consensusNow);
         verify(txnCtx).setStatus(NOT_OK);
     }
@@ -100,15 +90,11 @@ class ScheduleDeleteTransitionLogicTest {
     @Test
     void setsFailInvalidIfUnhandledException() {
         givenValidTxnCtx();
-        // and:
         given(store.deleteAt(schedule, consensusNow)).willThrow(IllegalArgumentException.class);
 
-        // when:
         subject.doStateTransition();
 
-        // then:
         verify(store).deleteAt(schedule, consensusNow);
-        // and:
         verify(txnCtx).setStatus(FAIL_INVALID);
     }
 
@@ -116,7 +102,6 @@ class ScheduleDeleteTransitionLogicTest {
     void hasCorrectApplicability() {
         givenValidTxnCtx();
 
-        // expect:
         assertTrue(subject.applicability().test(scheduleDeleteTxn));
         assertFalse(subject.applicability().test(TransactionBody.getDefaultInstance()));
     }
@@ -125,7 +110,6 @@ class ScheduleDeleteTransitionLogicTest {
     void failsOnInvalidSchedule() {
         givenCtx(true);
 
-        // expect:
         assertEquals(INVALID_SCHEDULE_ID, subject.validate(scheduleDeleteTxn));
     }
 
@@ -143,23 +127,15 @@ class ScheduleDeleteTransitionLogicTest {
         assertEquals(INVALID_SCHEDULE_ID, subject.semanticCheck().apply(scheduleDeleteTxn));
     }
 
-    void syntaxCheckWorks() {
-        givenValidTxnCtx();
-
-        // expect:
-        assertEquals(OK, subject.semanticCheck().apply(scheduleDeleteTxn));
-    }
-
     private void givenValidTxnCtx() {
         givenCtx(false);
     }
 
-
     private void givenCtx(
             boolean invalidScheduleId
     ) {
-        var builder = TransactionBody.newBuilder();
-        var scheduleDelete = ScheduleDeleteTransactionBody.newBuilder()
+        final var builder = TransactionBody.newBuilder();
+        final var scheduleDelete = ScheduleDeleteTransactionBody.newBuilder()
                 .setScheduleID(schedule);
 
         if (invalidScheduleId) {

--- a/hedera-node/src/test/java/com/hedera/services/txns/submission/TxnResponseHelperTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/txns/submission/TxnResponseHelperTest.java
@@ -22,28 +22,34 @@ package com.hedera.services.txns.submission;
 
 import com.hedera.services.stats.HapiOpCounters;
 import com.hedera.services.txns.SubmissionFlow;
+import com.hedera.services.utils.SignedTxnAccessor;
 import com.hederahashgraph.api.proto.java.Transaction;
 import com.hederahashgraph.api.proto.java.TransactionResponse;
 import io.grpc.stub.StreamObserver;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.InOrder;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
+import static com.hedera.services.txns.submission.TxnResponseHelper.FAIL_INVALID_RESPONSE;
 import static com.hederahashgraph.api.proto.java.HederaFunctionality.CryptoTransfer;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OK;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.inOrder;
 import static org.mockito.BDDMockito.mock;
 import static org.mockito.BDDMockito.never;
+import static org.mockito.Mockito.times;
 
 class TxnResponseHelperTest {
-	Transaction txn = Transaction.getDefaultInstance();
+	final Transaction txn = Transaction.getDefaultInstance();
 	TransactionResponse okResponse;
 	TransactionResponse notOkResponse;
 
 	SubmissionFlow submissionFlow;
 	HapiOpCounters opCounters;
 	StreamObserver<TransactionResponse> observer;
+	SignedTxnAccessor accessor;
 	TxnResponseHelper subject;
 
 	@BeforeEach
@@ -54,21 +60,19 @@ class TxnResponseHelperTest {
 		okResponse = mock(TransactionResponse.class);
 		given(okResponse.getNodeTransactionPrecheckCode()).willReturn(OK);
 		notOkResponse = mock(TransactionResponse.class);
+		accessor = mock(SignedTxnAccessor.class);
+		given(accessor.getSignedTxnWrapper()).willReturn(null);
 
 		subject = new TxnResponseHelper(submissionFlow, opCounters);
 	}
 
 	@Test
 	void helpsWithSubmitHappyPath() {
-		// setup:
 		InOrder inOrder = inOrder(submissionFlow, opCounters, observer);
-
 		given(submissionFlow.submit(txn)).willReturn(okResponse);
 
-		// when:
 		subject.submit(txn, observer, CryptoTransfer);
 
-		// then:
 		inOrder.verify(opCounters).countReceived(CryptoTransfer);
 		inOrder.verify(submissionFlow).submit(txn);
 		inOrder.verify(observer).onNext(okResponse);
@@ -78,19 +82,35 @@ class TxnResponseHelperTest {
 
 	@Test
 	void helpsWithSubmitUnhappyPath() {
-		// setup:
 		InOrder inOrder = inOrder(submissionFlow, opCounters, observer);
-
 		given(submissionFlow.submit(txn)).willReturn(notOkResponse);
 
-		// when:
 		subject.submit(txn, observer, CryptoTransfer);
 
-		// then:
 		inOrder.verify(opCounters).countReceived(CryptoTransfer);
 		inOrder.verify(submissionFlow).submit(txn);
 		inOrder.verify(observer).onNext(notOkResponse);
 		inOrder.verify(observer).onCompleted();
 		inOrder.verify(opCounters, never()).countSubmitted(CryptoTransfer);
+	}
+
+	@Test
+	void helpsWithExceptionOnSubmit() {
+		InOrder inOrder = inOrder(submissionFlow, opCounters, accessor, observer);
+
+		try (MockedStatic<SignedTxnAccessor> accessors = Mockito.mockStatic(SignedTxnAccessor.class)) {
+			accessors.when(() -> SignedTxnAccessor.uncheckedFrom(txn))
+					.thenReturn(accessor);
+			given(submissionFlow.submit(txn)).willThrow(IllegalArgumentException.class);
+
+			subject.submit(txn, observer, CryptoTransfer);
+
+			inOrder.verify(opCounters).countReceived(CryptoTransfer);
+			inOrder.verify(submissionFlow).submit(txn);
+			inOrder.verify(accessor, times(1)).getSignedTxnWrapper();
+			inOrder.verify(observer).onNext(FAIL_INVALID_RESPONSE);
+			inOrder.verify(observer).onCompleted();
+			inOrder.verify(opCounters, never()).countSubmitted(CryptoTransfer);
+		}
 	}
 }


### PR DESCRIPTION
**Description**:
This PR modifies `RecordCacheFactory`, `ScheduleDeleteTransitionLogic`, `TxnResponseHelper` to use their own loggers as described [here](https://sonarcloud.io/project/issues?id=com.hedera.hashgraph%3Ahedera-services&resolved=false&rules=java%3AS3416&types=CODE_SMELL)

**Related issue(s)**:

Fixes #2168 

**Notes for reviewer**:
Modified tests to add more coverage and made variables `final` as appropriate.

**Checklist**

- [X] Documented (Code comments, README, etc.)
- [X] Tested (unit, integration, etc.)
