### PR TITLE
Avoid unnecessary `ArrayList` creations

### DIFF
--- a/hedera-node/src/main/java/com/hedera/services/txns/token/TokenBurnTransitionLogic.java
+++ b/hedera-node/src/main/java/com/hedera/services/txns/token/TokenBurnTransitionLogic.java
@@ -35,7 +35,6 @@ import com.hederahashgraph.api.proto.java.TransactionBody;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -122,7 +121,7 @@ public class TokenBurnTransitionLogic implements TransitionLogic {
 				op.getAmount(),
 				dynamicProperties.areNftsEnabled(),
 				INVALID_TOKEN_BURN_AMOUNT,
-				new ArrayList<>(op.getSerialNumbersList()),
+				op.getSerialNumbersList(),
 				validator::maxBatchSizeBurnCheck,
 				null
 		);

--- a/hedera-node/src/main/java/com/hedera/services/txns/token/TokenMintTransitionLogic.java
+++ b/hedera-node/src/main/java/com/hedera/services/txns/token/TokenMintTransitionLogic.java
@@ -36,7 +36,6 @@ import com.hederahashgraph.api.proto.java.TransactionBody;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -135,7 +134,7 @@ public class TokenMintTransitionLogic implements TransitionLogic {
 				op.getAmount(),
 				dynamicProperties.areNftsEnabled(),
 				INVALID_TOKEN_MINT_AMOUNT,
-				new ArrayList<>(op.getMetadataList()),
+				op.getMetadataList(),
 				validator::maxBatchSizeMintCheck,
 				validator::nftMetadataCheck
 		);

--- a/hedera-node/src/main/java/com/hedera/services/txns/token/TokenOpsValidator.java
+++ b/hedera-node/src/main/java/com/hedera/services/txns/token/TokenOpsValidator.java
@@ -37,32 +37,32 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OK;
 public final class TokenOpsValidator {
 	/**
 	 * Validate the token operations mint/wipe/burn  given the attributes of the transaction.
+	 *
 	 * @param nftCount
-	 *			The number of unique nfts to mint/wipe/burn.
+	 * 		The number of unique nfts to mint/wipe/burn.
 	 * @param fungibleCount
-	 * 			The number of fungible common token to mint/wipe/burn.
+	 * 		The number of fungible common token to mint/wipe/burn.
 	 * @param areNftEnabled
-	 * 			A boolean that specifies if NFTs are enabled in the network.
+	 * 		A boolean that specifies if NFTs are enabled in the network.
 	 * @param invalidTokenAmount
-	 * 			Respective response code for invalid token amount in mint/wipe/burn operations.
+	 * 		Respective response code for invalid token amount in mint/wipe/burn operations.
 	 * @param metaDataList
-	 * 			metadata of the nfts  being minted / serialNumber list of the burn/wipe operations.
+	 * 		either metadata of the nfts being minted or serialNumber list of the burn/wipe operations.
 	 * @param batchSizeCheck
-	 * 			validation method to check if the batch size of requested nfts is valid.
+	 * 		validation method to check if the batch size of requested nfts is valid.
 	 * @param nftMetaDataCheck
-	 * 			validation method to check if the metadata of minted nft is valid.
-	 * @return
-	 * 			The validity of the token operation.
+	 * 		validation method to check if the metadata of minted nft is valid.
+	 * @return The validity of the token operation.
 	 */
 	public static ResponseCodeEnum validateTokenOpsWith(
 			final int nftCount,
 			final long fungibleCount,
 			final boolean areNftEnabled,
 			final ResponseCodeEnum invalidTokenAmount,
-			final List<Object> metaDataList,
+			final List<?> metaDataList,
 			final IntFunction<ResponseCodeEnum> batchSizeCheck,
-			@Nullable Function<byte[], ResponseCodeEnum> nftMetaDataCheck)  {
-
+			@Nullable Function<byte[], ResponseCodeEnum> nftMetaDataCheck
+	) {
 		if (nftCount > 0 && !areNftEnabled) {
 			return NOT_SUPPORTED;
 		}
@@ -83,15 +83,19 @@ public final class TokenOpsValidator {
 				return validity;
 			}
 			if (nftMetaDataCheck != null) {
-				for (Object bytes : metaDataList) {
-					validity = nftMetaDataCheck.apply( ((ByteString) bytes).toByteArray());
+				@SuppressWarnings("unchecked")
+				final List<ByteString> metadata = (List<ByteString>) metaDataList;
+				for (var bytes : metadata) {
+					validity = nftMetaDataCheck.apply(bytes.toByteArray());
 					if (validity != OK) {
 						return validity;
 					}
 				}
 			} else {
-				for (Object serialNum : metaDataList) {
-					if ((long) serialNum <= 0) {
+				@SuppressWarnings("unchecked")
+				final List<Long> serialNos = (List<Long>) metaDataList;
+				for (var serialNum : serialNos) {
+					if (serialNum <= 0) {
 						return INVALID_NFT_ID;
 					}
 				}
@@ -100,7 +104,7 @@ public final class TokenOpsValidator {
 		return OK;
 	}
 
-	private TokenOpsValidator()  {
+	private TokenOpsValidator() {
 		throw new UnsupportedOperationException("Utility Class");
 	}
 }

--- a/hedera-node/src/main/java/com/hedera/services/txns/token/TokenWipeTransitionLogic.java
+++ b/hedera-node/src/main/java/com/hedera/services/txns/token/TokenWipeTransitionLogic.java
@@ -35,7 +35,6 @@ import com.hederahashgraph.api.proto.java.TransactionBody;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -126,7 +125,7 @@ public class TokenWipeTransitionLogic implements TransitionLogic {
 				op.getAmount(),
 				dynamicProperties.areNftsEnabled(),
 				INVALID_WIPING_AMOUNT,
-				new ArrayList<>(op.getSerialNumbersList()),
+				op.getSerialNumbersList(),
 				validator::maxBatchSizeWipeCheck,
 				null
 		);

--- a/hedera-node/src/test/java/com/hedera/services/stats/ExecutionTimeTrackerTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/stats/ExecutionTimeTrackerTest.java
@@ -70,7 +70,7 @@ class ExecutionTimeTrackerTest {
 	@Test
 	void tracksAtMostConfigured() {
 		final var busyNanos = 5_000_000;
-		final var epsilonNanos = 50_000;
+		final var epsilonNanos = 500_000;
 
 		given(nodeLocalProperties.numExecutionTimesToTrack()).willReturn(1);
 		withImpliedSubject();

--- a/hedera-node/src/test/java/com/hedera/services/txns/token/TokenOpsValidatorTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/txns/token/TokenOpsValidatorTest.java
@@ -24,7 +24,6 @@ package com.hedera.services.txns.token;
 import com.google.protobuf.ByteString;
 import com.hedera.services.txns.validation.OptionValidator;
 import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -48,14 +47,8 @@ import static org.mockito.BDDMockito.given;
 
 @ExtendWith(MockitoExtension.class)
 class TokenOpsValidatorTest {
-
 	@Mock
 	private OptionValidator validator;
-
-	@BeforeEach
-	private void setup() {
-
-	}
 
 	@Test
 	void validateNftTokenMintHappyPath() {


### PR DESCRIPTION
**Description**:
Instead of passing a `List<Object> metadataList` to `TokenOpsValidator.validateTokenOpsWith()`, pass a `List<?>` and explicitly cast to `List<ByteString>` or `List<Long>` as appropriate.