### PR TITLE
Replace implementation type with interface type

### DIFF
--- a/hedera-node/src/main/java/com/hedera/services/ledger/accounts/AccountCustomizer.java
+++ b/hedera-node/src/main/java/com/hedera/services/ledger/accounts/AccountCustomizer.java
@@ -75,16 +75,16 @@ public abstract class AccountCustomizer<
 	protected abstract T self();
 
 	protected AccountCustomizer(
-			Class<P> propertyType,
-			Map<Option, P> optionProperties,
-			ChangeSummaryManager<A, P> changeManager
+			final Class<P> propertyType,
+			final Map<Option, P> optionProperties,
+			final ChangeSummaryManager<A, P> changeManager
 	) {
 		this.changeManager = changeManager;
 		this.optionProperties = optionProperties;
 		this.changes = new EnumMap<>(propertyType);
 	}
 
-	public EnumMap<P, Object> getChanges() {
+	public Map<P, Object> getChanges() {
 		return changes;
 	}
 
@@ -92,61 +92,61 @@ public abstract class AccountCustomizer<
 		return unmodifiableMap(optionProperties);
 	}
 
-	public A customizing(A account) {
+	public A customizing(final A account) {
 		changeManager.persist(changes, account);
 		return account;
 	}
 
-	public void customize(K id, TransactionalLedger<K, P, A> ledger) {
+	public void customize(final K id, final TransactionalLedger<K, P, A> ledger) {
 		changes.entrySet().forEach(change -> ledger.set(id, change.getKey(), change.getValue()));
 	}
 
-	public T key(JKey option) {
+	public T key(final JKey option) {
 		changeManager.update(changes, optionProperties.get(KEY), option);
 		return self();
 	}
 
-	public T memo(String option) {
+	public T memo(final String option) {
 		changeManager.update(changes, optionProperties.get(MEMO), option);
 		return self();
 	}
 
-	public T proxy(EntityId option) {
+	public T proxy(final EntityId option) {
 		changeManager.update(changes, optionProperties.get(PROXY), option);
 		return self();
 	}
 
-	public T expiry(long option) {
+	public T expiry(final long option) {
 		changeManager.update(changes, optionProperties.get(EXPIRY), option);
 		return self();
 	}
 
-	public T isDeleted(boolean option) {
+	public T isDeleted(final boolean option) {
 		changeManager.update(changes, optionProperties.get(IS_DELETED), option);
 		return self();
 	}
 
-	public T autoRenewPeriod(long option) {
+	public T autoRenewPeriod(final long option) {
 		changeManager.update(changes, optionProperties.get(AUTO_RENEW_PERIOD), option);
 		return self();
 	}
 
-	public T isSmartContract(boolean option) {
+	public T isSmartContract(final boolean option) {
 		changeManager.update(changes, optionProperties.get(IS_SMART_CONTRACT), option);
 		return self();
 	}
 
-	public T isReceiverSigRequired(boolean option) {
+	public T isReceiverSigRequired(final boolean option) {
 		changeManager.update(changes, optionProperties.get(IS_RECEIVER_SIG_REQUIRED), option);
 		return self();
 	}
 
-	public T maxAutomaticAssociations(int option) {
+	public T maxAutomaticAssociations(final int option) {
 		changeManager.update(changes, optionProperties.get(MAX_AUTOMATIC_ASSOCIATIONS), option);
 		return self();
 	}
 
-	public T alreadyUsedAutomaticAssociations(int option) {
+	public T alreadyUsedAutomaticAssociations(final int option) {
 		changeManager.update(changes, optionProperties.get(ALREADY_USED_AUTOMATIC_ASSOCIATIONS), option);
 		return self();
 	}

--- a/hedera-node/src/main/java/com/hedera/services/ledger/accounts/AccountCustomizer.java
+++ b/hedera-node/src/main/java/com/hedera/services/ledger/accounts/AccountCustomizer.java
@@ -9,9 +9,9 @@ package com.hedera.services.ledger.accounts;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -46,10 +46,14 @@ import static java.util.Collections.unmodifiableMap;
  * relevant to any account on a ledger, no matter the id, account, and
  * property types.
  *
- * @param <K> the type of the id used by the ledger.
- * @param <A> the type of the account stored in the ledger.
- * @param <P> the type of the properties applicable to the account.
- * @param <T> the type of a customizer appropriate to {@code K}, {@code A}, {@code P}.
+ * @param <K>
+ * 		the type of the id used by the ledger.
+ * @param <A>
+ * 		the type of the account stored in the ledger.
+ * @param <P>
+ * 		the type of the properties applicable to the account.
+ * @param <T>
+ * 		the type of a customizer appropriate to {@code K}, {@code A}, {@code P}.
  */
 public abstract class AccountCustomizer<
 		K,
@@ -66,7 +70,7 @@ public abstract class AccountCustomizer<
 		IS_RECEIVER_SIG_REQUIRED,
 		MAX_AUTOMATIC_ASSOCIATIONS,
 		ALREADY_USED_AUTOMATIC_ASSOCIATIONS
-	};
+	}
 
 	private final Map<Option, P> optionProperties;
 	private final EnumMap<P, Object> changes;

--- a/hedera-node/src/main/java/com/hedera/services/ledger/accounts/HederaAccountCustomizer.java
+++ b/hedera-node/src/main/java/com/hedera/services/ledger/accounts/HederaAccountCustomizer.java
@@ -9,9 +9,9 @@ package com.hedera.services.ledger.accounts;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -27,7 +27,7 @@ import com.hederahashgraph.api.proto.java.AccountID;
 
 import java.util.Map;
 
-public class HederaAccountCustomizer extends
+public final class HederaAccountCustomizer extends
 		AccountCustomizer<AccountID, MerkleAccount, AccountProperty, HederaAccountCustomizer> {
 	private static final Map<Option, AccountProperty> OPTION_PROPERTIES = Map.of(
 			Option.KEY, AccountProperty.KEY,

--- a/hedera-node/src/main/java/com/hedera/services/ledger/properties/ChangeSummaryManager.java
+++ b/hedera-node/src/main/java/com/hedera/services/ledger/properties/ChangeSummaryManager.java
@@ -20,7 +20,7 @@ package com.hedera.services.ledger.properties;
  * ‍
  */
 
-import java.util.EnumMap;
+import java.util.Map;
 
 /**
  * Minimal implementation of a helper that manages summary changesets.
@@ -29,25 +29,22 @@ import java.util.EnumMap;
  * @param <A> the type of account being changed.
  * @param <P> the property family whose changesets are to be summarized.
  */
-public class ChangeSummaryManager<A, P extends Enum<P> & BeanProperty<A>> {
+public final class ChangeSummaryManager<A, P extends Enum<P> & BeanProperty<A>> {
 	/**
 	 * Updates the changeset summary for the given property to the given value.
-	 *
-	 * @param changes the total changeset summary so far.
+	 *  @param changes the total changeset summary so far.
 	 * @param property the property in the family whose changeset should be updated.
 	 * @param value the new value that summarizes the changeset.
 	 */
-	public void update(EnumMap<P, Object> changes, P property, Object value) {
+	public void update(final Map<P, Object> changes, P property, final Object value) {
 		changes.put(property, value);
 	}
 
 	/**
 	 * Flush a changeset summary to a given object.
-	 *
-	 * @param changes the summary of changes made to the relevant property family.
-	 * @param account the account to receive the net changes.
-	 */
-	public void persist(EnumMap<P, Object> changes, A account) {
+	 *  @param changes the summary of changes made to the relevant property family.
+	 * @param account the account to receive the net changes.*/
+	public void persist(final Map<P, Object> changes, final A account) {
 		changes.entrySet().forEach(entry ->
 			entry.getKey().setter().accept(account, entry.getValue())
 		);

--- a/hedera-node/src/main/java/com/hedera/services/ledger/properties/ChangeSummaryManager.java
+++ b/hedera-node/src/main/java/com/hedera/services/ledger/properties/ChangeSummaryManager.java
@@ -9,9 +9,9 @@ package com.hedera.services.ledger.properties;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -26,27 +26,37 @@ import java.util.Map;
  * Minimal implementation of a helper that manages summary changesets.
  * An extension point for possible future performance optimizations.
  *
- * @param <A> the type of account being changed.
- * @param <P> the property family whose changesets are to be summarized.
+ * @param <A>
+ * 		the type of account being changed.
+ * @param <P>
+ * 		the property family whose changesets are to be summarized.
  */
 public final class ChangeSummaryManager<A, P extends Enum<P> & BeanProperty<A>> {
 	/**
 	 * Updates the changeset summary for the given property to the given value.
-	 *  @param changes the total changeset summary so far.
-	 * @param property the property in the family whose changeset should be updated.
-	 * @param value the new value that summarizes the changeset.
+	 *
+	 * @param changes
+	 * 		the total changeset summary so far.
+	 * @param property
+	 * 		the property in the family whose changeset should be updated.
+	 * @param value
+	 * 		the new value that summarizes the changeset.
 	 */
-	public void update(final Map<P, Object> changes, P property, final Object value) {
+	public void update(final Map<P, Object> changes, final P property, final Object value) {
 		changes.put(property, value);
 	}
 
 	/**
 	 * Flush a changeset summary to a given object.
-	 *  @param changes the summary of changes made to the relevant property family.
-	 * @param account the account to receive the net changes.*/
+	 *
+	 * @param changes
+	 * 		the summary of changes made to the relevant property family.
+	 * @param account
+	 * 		the account to receive the net changes.
+	 */
 	public void persist(final Map<P, Object> changes, final A account) {
 		changes.entrySet().forEach(entry ->
-			entry.getKey().setter().accept(account, entry.getValue())
+				entry.getKey().setter().accept(account, entry.getValue())
 		);
 	}
 }

--- a/hedera-node/src/test/java/com/hedera/services/ledger/accounts/AccountCustomizerTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/ledger/accounts/AccountCustomizerTest.java
@@ -23,31 +23,18 @@ package com.hedera.services.ledger.accounts;
 import com.hedera.services.ledger.TransactionalLedger;
 import com.hedera.services.ledger.properties.ChangeSummaryManager;
 import com.hedera.services.ledger.properties.TestAccountProperty;
-import com.hedera.services.legacy.core.jproto.JKey;
 import com.hedera.services.legacy.core.jproto.JKeyList;
 import com.hedera.services.state.submerkle.EntityId;
 import org.junit.jupiter.api.Test;
 
 import java.util.EnumMap;
 
-import static com.hedera.services.ledger.accounts.AccountCustomizer.Option.AUTO_RENEW_PERIOD;
-import static com.hedera.services.ledger.accounts.AccountCustomizer.Option.EXPIRY;
-import static com.hedera.services.ledger.accounts.AccountCustomizer.Option.IS_DELETED;
-import static com.hedera.services.ledger.accounts.AccountCustomizer.Option.IS_RECEIVER_SIG_REQUIRED;
-import static com.hedera.services.ledger.accounts.AccountCustomizer.Option.IS_SMART_CONTRACT;
-import static com.hedera.services.ledger.accounts.AccountCustomizer.Option.KEY;
-import static com.hedera.services.ledger.accounts.AccountCustomizer.Option.MAX_AUTOMATIC_ASSOCIATIONS;
-import static com.hedera.services.ledger.accounts.AccountCustomizer.Option.MEMO;
-import static com.hedera.services.ledger.accounts.AccountCustomizer.Option.PROXY;
-import static com.hedera.services.ledger.accounts.AccountCustomizer.Option.ALREADY_USED_AUTOMATIC_ASSOCIATIONS;
+import static com.hedera.services.ledger.accounts.AccountCustomizer.Option.*;
 import static com.hedera.services.ledger.properties.TestAccountProperty.FLAG;
 import static com.hedera.services.ledger.properties.TestAccountProperty.OBJ;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.BDDMockito.any;
-import static org.mockito.BDDMockito.argThat;
-import static org.mockito.BDDMockito.mock;
-import static org.mockito.BDDMockito.verify;
+import static org.mockito.BDDMockito.*;
 
 class AccountCustomizerTest {
 	private TestAccountCustomizer subject;
@@ -79,10 +66,10 @@ class AccountCustomizerTest {
 	@Test
 	void setsCustomizedProperties() {
 		setupWithLiveChangeManager();
-		final Long id = 1L;
+		final var id = 1L;
 		final TransactionalLedger<Long, TestAccountProperty, TestAccount> ledger = mock(TransactionalLedger.class);
-		final String customMemo = "alpha bravo charlie";
-		final boolean customIsReceiverSigRequired = true;
+		final var customMemo = "alpha bravo charlie";
+		final var customIsReceiverSigRequired = true;
 
 		subject
 				.isReceiverSigRequired(customIsReceiverSigRequired)
@@ -96,7 +83,7 @@ class AccountCustomizerTest {
 	@Test
 	void changesExpectedKeyProperty() {
 		setupWithMockChangeManager();
-		final JKey key = new JKeyList();
+		final var key = new JKeyList();
 
 		subject.key(key);
 
@@ -109,7 +96,7 @@ class AccountCustomizerTest {
 	@Test
 	void changesExpectedMemoProperty() {
 		setupWithMockChangeManager();
-		final String memo = "standardization ftw?";
+		final var memo = "standardization ftw?";
 
 		subject.memo(memo);
 

--- a/hedera-node/src/test/java/com/hedera/services/ledger/accounts/AccountCustomizerTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/ledger/accounts/AccountCustomizerTest.java
@@ -29,12 +29,24 @@ import org.junit.jupiter.api.Test;
 
 import java.util.EnumMap;
 
-import static com.hedera.services.ledger.accounts.AccountCustomizer.Option.*;
+import static com.hedera.services.ledger.accounts.AccountCustomizer.Option.ALREADY_USED_AUTOMATIC_ASSOCIATIONS;
+import static com.hedera.services.ledger.accounts.AccountCustomizer.Option.AUTO_RENEW_PERIOD;
+import static com.hedera.services.ledger.accounts.AccountCustomizer.Option.EXPIRY;
+import static com.hedera.services.ledger.accounts.AccountCustomizer.Option.IS_DELETED;
+import static com.hedera.services.ledger.accounts.AccountCustomizer.Option.IS_RECEIVER_SIG_REQUIRED;
+import static com.hedera.services.ledger.accounts.AccountCustomizer.Option.IS_SMART_CONTRACT;
+import static com.hedera.services.ledger.accounts.AccountCustomizer.Option.KEY;
+import static com.hedera.services.ledger.accounts.AccountCustomizer.Option.MAX_AUTOMATIC_ASSOCIATIONS;
+import static com.hedera.services.ledger.accounts.AccountCustomizer.Option.MEMO;
+import static com.hedera.services.ledger.accounts.AccountCustomizer.Option.PROXY;
 import static com.hedera.services.ledger.properties.TestAccountProperty.FLAG;
 import static com.hedera.services.ledger.properties.TestAccountProperty.OBJ;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.BDDMockito.*;
+import static org.mockito.BDDMockito.any;
+import static org.mockito.BDDMockito.argThat;
+import static org.mockito.BDDMockito.mock;
+import static org.mockito.BDDMockito.verify;
 
 class AccountCustomizerTest {
 	private TestAccountCustomizer subject;
@@ -186,7 +198,7 @@ class AccountCustomizerTest {
 
 	@Test
 	void changesAutoAssociationFieldsAsExpected() {
-		setupWithMockChangeManager();;
+		setupWithMockChangeManager();
 		final Integer maxAutoAssociations = 1234;
 		final Integer alreadyUsedAutoAssociations = 123;
 

--- a/hedera-node/src/test/java/com/hedera/services/ledger/accounts/TestAccountCustomizer.java
+++ b/hedera-node/src/test/java/com/hedera/services/ledger/accounts/TestAccountCustomizer.java
@@ -9,9 +9,9 @@ package com.hedera.services.ledger.accounts;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -39,9 +39,9 @@ import static com.hedera.services.ledger.properties.TestAccountProperty.FLAG;
 import static com.hedera.services.ledger.properties.TestAccountProperty.LONG;
 import static com.hedera.services.ledger.properties.TestAccountProperty.OBJ;
 
-public class TestAccountCustomizer extends
+public final class TestAccountCustomizer extends
 		AccountCustomizer<Long, TestAccount, TestAccountProperty, TestAccountCustomizer> {
-	public static final Map<Option, TestAccountProperty> OPTION_PROPERTIES = Map.of(
+	protected static final Map<Option, TestAccountProperty> OPTION_PROPERTIES = Map.of(
 			KEY, OBJ,
 			MEMO, OBJ,
 			PROXY, OBJ,

--- a/hedera-node/src/test/java/com/hedera/services/ledger/accounts/TestAccountCustomizer.java
+++ b/hedera-node/src/test/java/com/hedera/services/ledger/accounts/TestAccountCustomizer.java
@@ -54,7 +54,7 @@ public class TestAccountCustomizer extends
 			ALREADY_USED_AUTOMATIC_ASSOCIATIONS, LONG
 	);
 
-	public TestAccountCustomizer(ChangeSummaryManager<TestAccount, TestAccountProperty> changeManager) {
+	public TestAccountCustomizer(final ChangeSummaryManager<TestAccount, TestAccountProperty> changeManager) {
 		super(TestAccountProperty.class, OPTION_PROPERTIES, changeManager);
 	}
 

--- a/hedera-node/src/test/java/com/hedera/services/ledger/properties/ChangeSummaryManagerTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/ledger/properties/ChangeSummaryManagerTest.java
@@ -9,9 +9,9 @@ package com.hedera.services.ledger.properties;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -42,8 +42,8 @@ class ChangeSummaryManagerTest {
 
 	@Test
 	void persistsExpectedChanges() {
-		final Object thing = new Object();
-		final TestAccount testAccount = new TestAccount(1L, thing, false);
+		final var thing = new Object();
+		final var testAccount = new TestAccount(1L, thing, false);
 
 		subject.update(changes, LONG, 5L);
 		subject.update(changes, FLAG, true);
@@ -68,7 +68,7 @@ class ChangeSummaryManagerTest {
 
 	@Test
 	void setsThing() {
-		final Object thing = new Object();
+		final var thing = new Object();
 
 		subject.update(changes, OBJ, thing);
 

--- a/hedera-node/src/test/java/com/hedera/services/ledger/properties/ChangeSummaryManagerTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/ledger/properties/ChangeSummaryManagerTest.java
@@ -32,8 +32,8 @@ import static com.hedera.services.ledger.properties.TestAccountProperty.OBJ;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class ChangeSummaryManagerTest {
-	private ChangeSummaryManager<TestAccount, TestAccountProperty> subject = new ChangeSummaryManager<>();
-	private EnumMap<TestAccountProperty, Object> changes = new EnumMap<>(TestAccountProperty.class);
+	private static final ChangeSummaryManager<TestAccount, TestAccountProperty> subject = new ChangeSummaryManager<>();
+	private static final EnumMap<TestAccountProperty, Object> changes = new EnumMap<>(TestAccountProperty.class);
 
 	@BeforeEach
 	private void setup() {
@@ -42,47 +42,36 @@ class ChangeSummaryManagerTest {
 
 	@Test
 	void persistsExpectedChanges() {
-		// given:
-		Object thing = new Object();
-		TestAccount a = new TestAccount(1L, thing, false);
+		final Object thing = new Object();
+		final TestAccount testAccount = new TestAccount(1L, thing, false);
 
-		// when:
 		subject.update(changes, LONG, 5L);
 		subject.update(changes, FLAG, true);
-		// and:
-		subject.persist(changes, a);
+		subject.persist(changes, testAccount);
 
-		// then:
-		assertEquals(new TestAccount(5L, thing, true), a);
+		assertEquals(new TestAccount(5L, thing, true), testAccount);
 	}
 
 	@Test
 	void setsFlagWithPrimitiveArg() {
-		// when:
 		subject.update(changes, FLAG, true);
 
-		// then:
 		assertEquals(Boolean.TRUE, changes.get(FLAG));
 	}
 
 	@Test
 	void setsValueWithPrimitiveArg() {
-		// when:
 		subject.update(changes, LONG, 5L);
 
-		// then:
 		assertEquals(Long.valueOf(5L), changes.get(LONG));
 	}
 
 	@Test
 	void setsThing() {
-		// given:
-		Object thing = new Object();
+		final Object thing = new Object();
 
-		// when:
 		subject.update(changes, OBJ, thing);
 
-		// then:
 		assertEquals(thing, changes.get(OBJ));
 	}
 }

--- a/hedera-node/src/test/java/com/hedera/services/txns/crypto/CryptoCreateTransitionLogicTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/txns/crypto/CryptoCreateTransitionLogicTest.java
@@ -44,15 +44,11 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
 import java.time.Instant;
-import java.util.EnumMap;
 
 import static com.hedera.services.ledger.properties.AccountProperty.AUTO_RENEW_PERIOD;
 import static com.hedera.services.ledger.properties.AccountProperty.EXPIRY;
 import static com.hedera.services.ledger.properties.AccountProperty.IS_RECEIVER_SIG_REQUIRED;
-import static com.hedera.services.ledger.properties.AccountProperty.KEY;
 import static com.hedera.services.ledger.properties.AccountProperty.MAX_AUTOMATIC_ASSOCIATIONS;
-import static com.hedera.services.ledger.properties.AccountProperty.MEMO;
-import static com.hedera.services.ledger.properties.AccountProperty.PROXY;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.AUTORENEW_DURATION_NOT_IN_RANGE;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.BAD_ENCODING;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.FAIL_INVALID;
@@ -78,27 +74,27 @@ import static org.mockito.BDDMockito.mock;
 import static org.mockito.BDDMockito.verify;
 
 class CryptoCreateTransitionLogicTest {
-	final private Key key = SignedTxnFactory.DEFAULT_PAYER_KT.asKey();
-	final private long customAutoRenewPeriod = 100_001L;
-	final private long customSendThreshold = 49_000L;
-	final private long customReceiveThreshold = 51_001L;
-	final private Long balance = 1_234L;
-	final private String memo = "The particular is pounded til it is man";
-	final private int maxAutoAssociations = 1234;
-	final private int maxTokenAssociations = 12345;
-	final private AccountID proxy = AccountID.newBuilder().setAccountNum(4_321L).build();
-	final private AccountID payer = AccountID.newBuilder().setAccountNum(1_234L).build();
-	final private AccountID created = AccountID.newBuilder().setAccountNum(9_999L).build();
+	private static final Key KEY = SignedTxnFactory.DEFAULT_PAYER_KT.asKey();
+	private static final long CUSTOM_AUTO_RENEW_PERIOD = 100_001L;
+	private static final long CUSTOM_SEND_THRESHOLD = 49_000L;
+	private static final long CUSTOM_RECEIVE_THRESHOLD = 51_001L;
+	private static final Long BALANCE = 1_234L;
+	private static final String MEMO = "The particular is pounded til it is man";
+	private static final int MAX_AUTO_ASSOCIATIONS = 1234;
+	private static final int MAX_TOKEN_ASSOCIATIONS = 12345;
+	private static final AccountID PROXY = AccountID.newBuilder().setAccountNum(4_321L).build();
+	private static final AccountID PAYER = AccountID.newBuilder().setAccountNum(1_234L).build();
+	private static final AccountID CREATED = AccountID.newBuilder().setAccountNum(9_999L).build();
 
-	private long expiry;
-	private Instant consensusTime;
-	private HederaLedger ledger;
-	private OptionValidator validator;
-	private TransactionBody cryptoCreateTxn;
-	private TransactionContext txnCtx;
-	private PlatformTxnAccessor accessor;
-	private CryptoCreateTransitionLogic subject;
-	private GlobalDynamicProperties dynamicProperties;
+	private static long expiry;
+	private static Instant consensusTime;
+	private static HederaLedger ledger;
+	private static OptionValidator validator;
+	private static TransactionBody cryptoCreateTxn;
+	private static TransactionContext txnCtx;
+	private static PlatformTxnAccessor accessor;
+	private static CryptoCreateTransitionLogic subject;
+	private static GlobalDynamicProperties dynamicProperties;
 
 	@BeforeEach
 	private void setup() {
@@ -110,7 +106,7 @@ class CryptoCreateTransitionLogicTest {
 		accessor = mock(PlatformTxnAccessor.class);
 		validator = mock(OptionValidator.class);
 		dynamicProperties = mock(GlobalDynamicProperties.class);
-		given(dynamicProperties.maxTokensPerAccount()).willReturn(maxTokenAssociations);
+		given(dynamicProperties.maxTokensPerAccount()).willReturn(MAX_TOKEN_ASSOCIATIONS);
 		withRubberstampingValidator();
 
 		subject = new CryptoCreateTransitionLogic(ledger, validator, txnCtx, dynamicProperties);
@@ -120,7 +116,6 @@ class CryptoCreateTransitionLogicTest {
 	void hasCorrectApplicability() {
 		givenValidTxnCtx();
 
-		// expect:
 		assertTrue(subject.applicability().test(cryptoCreateTxn));
 		assertFalse(subject.applicability().test(TransactionBody.getDefaultInstance()));
 	}
@@ -128,9 +123,8 @@ class CryptoCreateTransitionLogicTest {
 	@Test
 	void returnsMemoTooLongWhenValidatorSays() {
 		givenValidTxnCtx();
-		given(validator.memoCheck(memo)).willReturn(MEMO_TOO_LONG);
+		given(validator.memoCheck(MEMO)).willReturn(MEMO_TOO_LONG);
 
-		// expect:
 		assertEquals(MEMO_TOO_LONG, subject.semanticCheck().apply(cryptoCreateTxn));
 	}
 
@@ -138,7 +132,6 @@ class CryptoCreateTransitionLogicTest {
 	void returnsKeyRequiredOnEmptyKey() {
 		givenValidTxnCtx(Key.newBuilder().setKeyList(KeyList.getDefaultInstance()).build());
 
-		// expect:
 		assertEquals(KEY_REQUIRED, subject.semanticCheck().apply(cryptoCreateTxn));
 	}
 
@@ -146,7 +139,6 @@ class CryptoCreateTransitionLogicTest {
 	void requiresKey() {
 		givenMissingKey();
 
-		// expect:
 		assertEquals(KEY_REQUIRED, subject.semanticCheck().apply(cryptoCreateTxn));
 	}
 
@@ -154,7 +146,6 @@ class CryptoCreateTransitionLogicTest {
 	void rejectsMissingAutoRenewPeriod() {
 		givenMissingAutoRenewPeriod();
 
-		// expect:
 		assertEquals(INVALID_RENEWAL_PERIOD, subject.semanticCheck().apply(cryptoCreateTxn));
 	}
 
@@ -162,7 +153,6 @@ class CryptoCreateTransitionLogicTest {
 	void rejectsNegativeBalance() {
 		givenAbsurdInitialBalance();
 
-		// expect:
 		assertEquals(INVALID_INITIAL_BALANCE, subject.semanticCheck().apply(cryptoCreateTxn));
 	}
 
@@ -170,7 +160,6 @@ class CryptoCreateTransitionLogicTest {
 	void rejectsNegativeSendThreshold() {
 		givenAbsurdSendThreshold();
 
-		// expect:
 		assertEquals(INVALID_SEND_RECORD_THRESHOLD, subject.semanticCheck().apply(cryptoCreateTxn));
 	}
 
@@ -178,7 +167,6 @@ class CryptoCreateTransitionLogicTest {
 	void rejectsNegativeReceiveThreshold() {
 		givenAbsurdReceiveThreshold();
 
-		// expect:
 		assertEquals(INVALID_RECEIVE_RECORD_THRESHOLD, subject.semanticCheck().apply(cryptoCreateTxn));
 	}
 
@@ -187,7 +175,6 @@ class CryptoCreateTransitionLogicTest {
 		givenValidTxnCtx();
 		given(validator.hasGoodEncoding(any())).willReturn(false);
 
-		// expect:
 		assertEquals(BAD_ENCODING, subject.semanticCheck().apply(cryptoCreateTxn));
 	}
 
@@ -196,7 +183,6 @@ class CryptoCreateTransitionLogicTest {
 		givenValidTxnCtx();
 		given(validator.isValidAutoRenewPeriod(any())).willReturn(false);
 
-		// expect:
 		assertEquals(AUTORENEW_DURATION_NOT_IN_RANGE, subject.semanticCheck().apply(cryptoCreateTxn));
 	}
 
@@ -204,7 +190,6 @@ class CryptoCreateTransitionLogicTest {
 	void acceptsValidTxn() {
 		givenValidTxnCtx();
 
-		// expect:
 		assertEquals(OK, subject.semanticCheck().apply(cryptoCreateTxn));
 	}
 
@@ -218,31 +203,27 @@ class CryptoCreateTransitionLogicTest {
 
 	@Test
 	void followsHappyPathWithOverrides() throws Throwable {
-		// setup:
 		ArgumentCaptor<HederaAccountCustomizer> captor = ArgumentCaptor.forClass(HederaAccountCustomizer.class);
-		expiry = consensusTime.getEpochSecond() + customAutoRenewPeriod;
+		expiry = consensusTime.getEpochSecond() + CUSTOM_AUTO_RENEW_PERIOD;
 
 		givenValidTxnCtx();
-		// and:
-		given(ledger.create(any(), anyLong(), any())).willReturn(created);
+		given(ledger.create(any(), anyLong(), any())).willReturn(CREATED);
 
-		// when:
 		subject.doStateTransition();
 
-		// then:
-		verify(ledger).create(argThat(payer::equals), longThat(balance::equals), captor.capture());
-		verify(txnCtx).setCreated(created);
+		verify(ledger).create(argThat(PAYER::equals), longThat(BALANCE::equals), captor.capture());
+		verify(txnCtx).setCreated(CREATED);
 		verify(txnCtx).setStatus(SUCCESS);
-		// and:
-		EnumMap<AccountProperty, Object> changes = captor.getValue().getChanges();
+
+		final var changes = captor.getValue().getChanges();
 		assertEquals(7, changes.size());
-		assertEquals(customAutoRenewPeriod, (long)changes.get(AUTO_RENEW_PERIOD));
-		assertEquals(expiry, (long)changes.get(EXPIRY));
-		assertEquals(key, JKey.mapJKey((JKey)changes.get(KEY)));
+		assertEquals(CUSTOM_AUTO_RENEW_PERIOD, (long) changes.get(AUTO_RENEW_PERIOD));
+		assertEquals(expiry, (long) changes.get(EXPIRY));
+		assertEquals(KEY, JKey.mapJKey((JKey)changes.get(AccountProperty.KEY)));
 		assertEquals(true, changes.get(IS_RECEIVER_SIG_REQUIRED));
-		assertEquals(EntityId.fromGrpcAccountId(proxy), changes.get(PROXY));
-		assertEquals(memo, changes.get(MEMO));
-		assertEquals(maxAutoAssociations, changes.get(MAX_AUTOMATIC_ASSOCIATIONS));
+		assertEquals(EntityId.fromGrpcAccountId(PROXY), changes.get(AccountProperty.PROXY));
+		assertEquals(MEMO, changes.get(AccountProperty.MEMO));
+		assertEquals(MAX_AUTO_ASSOCIATIONS, changes.get(MAX_AUTOMATIC_ASSOCIATIONS));
 	}
 
 	@Test
@@ -250,10 +231,8 @@ class CryptoCreateTransitionLogicTest {
 		givenValidTxnCtx();
 		given(ledger.create(any(), anyLong(), any())).willThrow(InsufficientFundsException.class);
 
-		// when:
 		subject.doStateTransition();
 
-		// then:
 		verify(txnCtx).setStatus(INSUFFICIENT_PAYER_BALANCE);
 	}
 
@@ -266,10 +245,8 @@ class CryptoCreateTransitionLogicTest {
 		given(accessor.getTxn()).willReturn(cryptoCreateTxn);
 		given(txnCtx.accessor()).willReturn(accessor);
 
-		// when:
 		subject.doStateTransition();
 
-		// then:
 		verify(txnCtx).setStatus(FAIL_INVALID);
 	}
 
@@ -282,7 +259,7 @@ class CryptoCreateTransitionLogicTest {
 				.setTransactionID(ourTxnId())
 				.setCryptoCreateAccount(
 						CryptoCreateTransactionBody.newBuilder()
-								.setInitialBalance(balance)
+								.setInitialBalance(BALANCE)
 								.build()
 				).build();
 	}
@@ -292,8 +269,8 @@ class CryptoCreateTransitionLogicTest {
 				.setTransactionID(ourTxnId())
 				.setCryptoCreateAccount(
 						CryptoCreateTransactionBody.newBuilder()
-								.setKey(key)
-								.setInitialBalance(balance)
+								.setKey(KEY)
+								.setInitialBalance(BALANCE)
 								.build()
 				).build();
 	}
@@ -304,7 +281,7 @@ class CryptoCreateTransitionLogicTest {
 				.setCryptoCreateAccount(
 						CryptoCreateTransactionBody.newBuilder()
 								.setAutoRenewPeriod(Duration.newBuilder().setSeconds(1L))
-								.setKey(key)
+								.setKey(KEY)
 								.setSendRecordThreshold(-1L)
 								.build()
 				).build();
@@ -316,7 +293,7 @@ class CryptoCreateTransitionLogicTest {
 				.setCryptoCreateAccount(
 						CryptoCreateTransactionBody.newBuilder()
 								.setAutoRenewPeriod(Duration.newBuilder().setSeconds(1L))
-								.setKey(key)
+								.setKey(KEY)
 								.setReceiveRecordThreshold(-1L)
 								.build()
 				).build();
@@ -328,7 +305,7 @@ class CryptoCreateTransitionLogicTest {
 				.setCryptoCreateAccount(
 						CryptoCreateTransactionBody.newBuilder()
 								.setAutoRenewPeriod(Duration.newBuilder().setSeconds(1L))
-								.setKey(key)
+								.setKey(KEY)
 								.setInitialBalance(-1L)
 								.build()
 				).build();
@@ -339,21 +316,21 @@ class CryptoCreateTransitionLogicTest {
 				.setTransactionID(ourTxnId())
 				.setCryptoCreateAccount(
 						CryptoCreateTransactionBody.newBuilder()
-								.setMemo(memo)
-								.setInitialBalance(balance)
-								.setProxyAccountID(proxy)
+								.setMemo(MEMO)
+								.setInitialBalance(BALANCE)
+								.setProxyAccountID(PROXY)
 								.setReceiverSigRequired(true)
-								.setAutoRenewPeriod(Duration.newBuilder().setSeconds(customAutoRenewPeriod))
-								.setReceiveRecordThreshold(customReceiveThreshold)
-								.setSendRecordThreshold(customSendThreshold)
-								.setKey(key)
-								.setMaxAutomaticTokenAssociations(maxTokenAssociations+1)
+								.setAutoRenewPeriod(Duration.newBuilder().setSeconds(CUSTOM_AUTO_RENEW_PERIOD))
+								.setReceiveRecordThreshold(CUSTOM_RECEIVE_THRESHOLD)
+								.setSendRecordThreshold(CUSTOM_SEND_THRESHOLD)
+								.setKey(KEY)
+								.setMaxAutomaticTokenAssociations(MAX_TOKEN_ASSOCIATIONS +1)
 								.build()
 				).build();
 	}
 
 	private void givenValidTxnCtx() {
-		givenValidTxnCtx(key);
+		givenValidTxnCtx(KEY);
 	}
 
 	private void givenValidTxnCtx(Key toUse) {
@@ -361,15 +338,15 @@ class CryptoCreateTransitionLogicTest {
 				.setTransactionID(ourTxnId())
 				.setCryptoCreateAccount(
 						CryptoCreateTransactionBody.newBuilder()
-								.setMemo(memo)
-								.setInitialBalance(balance)
-								.setProxyAccountID(proxy)
+								.setMemo(MEMO)
+								.setInitialBalance(BALANCE)
+								.setProxyAccountID(PROXY)
 								.setReceiverSigRequired(true)
-								.setAutoRenewPeriod(Duration.newBuilder().setSeconds(customAutoRenewPeriod))
-								.setReceiveRecordThreshold(customReceiveThreshold)
-								.setSendRecordThreshold(customSendThreshold)
+								.setAutoRenewPeriod(Duration.newBuilder().setSeconds(CUSTOM_AUTO_RENEW_PERIOD))
+								.setReceiveRecordThreshold(CUSTOM_RECEIVE_THRESHOLD)
+								.setSendRecordThreshold(CUSTOM_SEND_THRESHOLD)
 								.setKey(toUse)
-								.setMaxAutomaticTokenAssociations(maxAutoAssociations)
+								.setMaxAutomaticTokenAssociations(MAX_AUTO_ASSOCIATIONS)
 								.build()
 				).build();
 		given(accessor.getTxn()).willReturn(cryptoCreateTxn);
@@ -378,7 +355,7 @@ class CryptoCreateTransitionLogicTest {
 
 	private TransactionID ourTxnId() {
 		return TransactionID.newBuilder()
-				.setAccountID(payer)
+				.setAccountID(PAYER)
 				.setTransactionValidStart(
 						Timestamp.newBuilder().setSeconds(consensusTime.getEpochSecond()))
 				.build();

--- a/hedera-node/src/test/java/com/hedera/services/txns/crypto/CryptoCreateTransitionLogicTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/txns/crypto/CryptoCreateTransitionLogicTest.java
@@ -9,9 +9,9 @@ package com.hedera.services.txns.crypto;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -62,9 +62,9 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.MEMO_TOO_LONG;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OK;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.REQUESTED_NUM_AUTOMATIC_ASSOCIATIONS_EXCEEDS_ASSOCIATION_LIMIT;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SUCCESS;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.BDDMockito.any;
 import static org.mockito.BDDMockito.anyLong;
 import static org.mockito.BDDMockito.argThat;
@@ -85,21 +85,18 @@ class CryptoCreateTransitionLogicTest {
 	private static final AccountID PROXY = AccountID.newBuilder().setAccountNum(4_321L).build();
 	private static final AccountID PAYER = AccountID.newBuilder().setAccountNum(1_234L).build();
 	private static final AccountID CREATED = AccountID.newBuilder().setAccountNum(9_999L).build();
+	private static final Instant consensusTime = Instant.now();
 
-	private static long expiry;
-	private static Instant consensusTime;
-	private static HederaLedger ledger;
-	private static OptionValidator validator;
-	private static TransactionBody cryptoCreateTxn;
-	private static TransactionContext txnCtx;
-	private static PlatformTxnAccessor accessor;
-	private static CryptoCreateTransitionLogic subject;
-	private static GlobalDynamicProperties dynamicProperties;
+	private HederaLedger ledger;
+	private OptionValidator validator;
+	private TransactionBody cryptoCreateTxn;
+	private TransactionContext txnCtx;
+	private PlatformTxnAccessor accessor;
+	private CryptoCreateTransitionLogic subject;
+	private GlobalDynamicProperties dynamicProperties;
 
 	@BeforeEach
 	private void setup() {
-		consensusTime = Instant.now();
-
 		txnCtx = mock(TransactionContext.class);
 		given(txnCtx.consensusTime()).willReturn(consensusTime);
 		ledger = mock(HederaLedger.class);
@@ -195,7 +192,7 @@ class CryptoCreateTransitionLogicTest {
 
 	@Test
 	void rejectsInvalidMaxAutomaticAssociations() {
-		givenInvalidMaxAutoAssociations();;
+		givenInvalidMaxAutoAssociations();
 
 		assertEquals(REQUESTED_NUM_AUTOMATIC_ASSOCIATIONS_EXCEEDS_ASSOCIATION_LIMIT,
 				subject.semanticCheck().apply(cryptoCreateTxn));
@@ -203,9 +200,8 @@ class CryptoCreateTransitionLogicTest {
 
 	@Test
 	void followsHappyPathWithOverrides() throws Throwable {
-		ArgumentCaptor<HederaAccountCustomizer> captor = ArgumentCaptor.forClass(HederaAccountCustomizer.class);
-		expiry = consensusTime.getEpochSecond() + CUSTOM_AUTO_RENEW_PERIOD;
-
+		final var expiry = consensusTime.getEpochSecond() + CUSTOM_AUTO_RENEW_PERIOD;
+		final var captor = ArgumentCaptor.forClass(HederaAccountCustomizer.class);
 		givenValidTxnCtx();
 		given(ledger.create(any(), anyLong(), any())).willReturn(CREATED);
 
@@ -219,7 +215,7 @@ class CryptoCreateTransitionLogicTest {
 		assertEquals(7, changes.size());
 		assertEquals(CUSTOM_AUTO_RENEW_PERIOD, (long) changes.get(AUTO_RENEW_PERIOD));
 		assertEquals(expiry, (long) changes.get(EXPIRY));
-		assertEquals(KEY, JKey.mapJKey((JKey)changes.get(AccountProperty.KEY)));
+		assertEquals(KEY, JKey.mapJKey((JKey) changes.get(AccountProperty.KEY)));
 		assertEquals(true, changes.get(IS_RECEIVER_SIG_REQUIRED));
 		assertEquals(EntityId.fromGrpcAccountId(PROXY), changes.get(AccountProperty.PROXY));
 		assertEquals(MEMO, changes.get(AccountProperty.MEMO));
@@ -260,7 +256,6 @@ class CryptoCreateTransitionLogicTest {
 				.setCryptoCreateAccount(
 						CryptoCreateTransactionBody.newBuilder()
 								.setInitialBalance(BALANCE)
-								.build()
 				).build();
 	}
 
@@ -271,7 +266,6 @@ class CryptoCreateTransitionLogicTest {
 						CryptoCreateTransactionBody.newBuilder()
 								.setKey(KEY)
 								.setInitialBalance(BALANCE)
-								.build()
 				).build();
 	}
 
@@ -283,7 +277,6 @@ class CryptoCreateTransitionLogicTest {
 								.setAutoRenewPeriod(Duration.newBuilder().setSeconds(1L))
 								.setKey(KEY)
 								.setSendRecordThreshold(-1L)
-								.build()
 				).build();
 	}
 
@@ -295,7 +288,6 @@ class CryptoCreateTransitionLogicTest {
 								.setAutoRenewPeriod(Duration.newBuilder().setSeconds(1L))
 								.setKey(KEY)
 								.setReceiveRecordThreshold(-1L)
-								.build()
 				).build();
 	}
 
@@ -307,7 +299,6 @@ class CryptoCreateTransitionLogicTest {
 								.setAutoRenewPeriod(Duration.newBuilder().setSeconds(1L))
 								.setKey(KEY)
 								.setInitialBalance(-1L)
-								.build()
 				).build();
 	}
 
@@ -324,8 +315,7 @@ class CryptoCreateTransitionLogicTest {
 								.setReceiveRecordThreshold(CUSTOM_RECEIVE_THRESHOLD)
 								.setSendRecordThreshold(CUSTOM_SEND_THRESHOLD)
 								.setKey(KEY)
-								.setMaxAutomaticTokenAssociations(MAX_TOKEN_ASSOCIATIONS +1)
-								.build()
+								.setMaxAutomaticTokenAssociations(MAX_TOKEN_ASSOCIATIONS + 1)
 				).build();
 	}
 
@@ -333,7 +323,7 @@ class CryptoCreateTransitionLogicTest {
 		givenValidTxnCtx(KEY);
 	}
 
-	private void givenValidTxnCtx(Key toUse) {
+	private void givenValidTxnCtx(final Key toUse) {
 		cryptoCreateTxn = TransactionBody.newBuilder()
 				.setTransactionID(ourTxnId())
 				.setCryptoCreateAccount(
@@ -347,7 +337,6 @@ class CryptoCreateTransitionLogicTest {
 								.setSendRecordThreshold(CUSTOM_SEND_THRESHOLD)
 								.setKey(toUse)
 								.setMaxAutomaticTokenAssociations(MAX_AUTO_ASSOCIATIONS)
-								.build()
 				).build();
 		given(accessor.getTxn()).willReturn(cryptoCreateTxn);
 		given(txnCtx.accessor()).willReturn(accessor);

--- a/hedera-node/src/test/java/com/hedera/services/txns/crypto/CryptoUpdateTransitionLogicTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/txns/crypto/CryptoUpdateTransitionLogicTest.java
@@ -9,9 +9,9 @@ package com.hedera.services.txns.crypto;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -94,14 +94,14 @@ class CryptoUpdateTransitionLogicTest {
 	private static final AccountID TARGET = AccountID.newBuilder().setAccountNum(9_999L).build();
 	private static final String MEMO = "Not since life began";
 
-	private static boolean useLegacyFields;
-	private static HederaLedger ledger;
-	private static OptionValidator validator;
-	private static TransactionBody cryptoUpdateTxn;
-	private static TransactionContext txnCtx;
-	private static PlatformTxnAccessor accessor;
-	private static CryptoUpdateTransitionLogic subject;
-	private static GlobalDynamicProperties dynamicProperties;
+	private boolean useLegacyFields;
+	private HederaLedger ledger;
+	private OptionValidator validator;
+	private TransactionBody cryptoUpdateTxn;
+	private TransactionContext txnCtx;
+	private PlatformTxnAccessor accessor;
+	private CryptoUpdateTransitionLogic subject;
+	private GlobalDynamicProperties dynamicProperties;
 
 	@BeforeEach
 	private void setup() {
@@ -122,7 +122,6 @@ class CryptoUpdateTransitionLogicTest {
 	@Test
 	void updatesProxyIfPresent() {
 		final var captor = ArgumentCaptor.forClass(HederaAccountCustomizer.class);
-
 		givenTxnCtx(EnumSet.of(AccountCustomizer.Option.PROXY));
 
 		subject.doStateTransition();
@@ -138,7 +137,6 @@ class CryptoUpdateTransitionLogicTest {
 	@Test
 	void updatesReceiverSigReqIfPresent() {
 		final var captor = ArgumentCaptor.forClass(HederaAccountCustomizer.class);
-
 		givenTxnCtx(EnumSet.of(IS_RECEIVER_SIG_REQUIRED));
 
 		subject.doStateTransition();
@@ -154,7 +152,6 @@ class CryptoUpdateTransitionLogicTest {
 	void updatesReceiverSigReqIfTrueInLegacy() {
 		useLegacyFields = true;
 		final var captor = ArgumentCaptor.forClass(HederaAccountCustomizer.class);
-
 		givenTxnCtx(EnumSet.of(IS_RECEIVER_SIG_REQUIRED));
 
 		subject.doStateTransition();
@@ -169,7 +166,6 @@ class CryptoUpdateTransitionLogicTest {
 	@Test
 	void updatesExpiryIfPresent() {
 		final var captor = ArgumentCaptor.forClass(HederaAccountCustomizer.class);
-
 		givenTxnCtx(EnumSet.of(EXPIRY));
 
 		subject.doStateTransition();
@@ -178,7 +174,7 @@ class CryptoUpdateTransitionLogicTest {
 		verify(txnCtx).setStatus(SUCCESS);
 		final var changes = captor.getValue().getChanges();
 		assertEquals(1, changes.size());
-		assertEquals(NEW_EXPIRY, (long)changes.get(AccountProperty.EXPIRY));
+		assertEquals(NEW_EXPIRY, (long) changes.get(AccountProperty.EXPIRY));
 	}
 
 	@Test
@@ -193,14 +189,14 @@ class CryptoUpdateTransitionLogicTest {
 		verify(txnCtx).setStatus(SUCCESS);
 		final var changes = captor.getValue().getChanges();
 		assertEquals(1, changes.size());
-		assertEquals(NEW_MAX_AUTOMATIC_ASSOCIATIONS, (int)changes.get(AccountProperty.MAX_AUTOMATIC_ASSOCIATIONS));
+		assertEquals(NEW_MAX_AUTOMATIC_ASSOCIATIONS, (int) changes.get(AccountProperty.MAX_AUTOMATIC_ASSOCIATIONS));
 	}
 
 	@Test
 	void updateMaxAutomaticAssociationsFailAsExpectedWithMaxLessThanAlreadyExisting() {
 		final var captor = ArgumentCaptor.forClass(HederaAccountCustomizer.class);
 		givenTxnCtx(EnumSet.of(MAX_AUTOMATIC_ASSOCIATIONS));
-		given(ledger.alreadyUsedAutomaticAssociations(any())).willReturn(NEW_MAX_AUTOMATIC_ASSOCIATIONS +1);
+		given(ledger.alreadyUsedAutomaticAssociations(any())).willReturn(NEW_MAX_AUTOMATIC_ASSOCIATIONS + 1);
 
 		subject.doStateTransition();
 
@@ -213,7 +209,7 @@ class CryptoUpdateTransitionLogicTest {
 		final var captor = ArgumentCaptor.forClass(HederaAccountCustomizer.class);
 		givenTxnCtx(EnumSet.of(MAX_AUTOMATIC_ASSOCIATIONS));
 		given(ledger.alreadyUsedAutomaticAssociations(any())).willReturn(CUR_MAX_AUTOMATIC_ASSOCIATIONS);
-		given(dynamicProperties.maxTokensPerAccount()).willReturn(NEW_MAX_AUTOMATIC_ASSOCIATIONS -1);
+		given(dynamicProperties.maxTokensPerAccount()).willReturn(NEW_MAX_AUTOMATIC_ASSOCIATIONS - 1);
 
 		subject.doStateTransition();
 
@@ -224,7 +220,6 @@ class CryptoUpdateTransitionLogicTest {
 	@Test
 	void updatesMemoIfPresent() {
 		final var captor = ArgumentCaptor.forClass(HederaAccountCustomizer.class);
-
 		givenTxnCtx(EnumSet.of(AccountCustomizer.Option.MEMO));
 
 		subject.doStateTransition();
@@ -238,7 +233,6 @@ class CryptoUpdateTransitionLogicTest {
 	@Test
 	void updatesAutoRenewIfPresent() {
 		final var captor = ArgumentCaptor.forClass(HederaAccountCustomizer.class);
-
 		givenTxnCtx(EnumSet.of(AccountCustomizer.Option.AUTO_RENEW_PERIOD));
 
 		subject.doStateTransition();
@@ -252,7 +246,6 @@ class CryptoUpdateTransitionLogicTest {
 	@Test
 	void updatesKeyIfPresent() throws Throwable {
 		final var captor = ArgumentCaptor.forClass(HederaAccountCustomizer.class);
-
 		givenTxnCtx(EnumSet.of(AccountCustomizer.Option.KEY));
 
 		subject.doStateTransition();
@@ -260,7 +253,7 @@ class CryptoUpdateTransitionLogicTest {
 		verify(ledger).customize(argThat(TARGET::equals), captor.capture());
 		final var changes = captor.getValue().getChanges();
 		assertEquals(1, changes.size());
-		assertEquals(KEY, JKey.mapJKey((JKey)changes.get(AccountProperty.KEY)));
+		assertEquals(KEY, JKey.mapJKey((JKey) changes.get(AccountProperty.KEY)));
 	}
 
 	@Test
@@ -411,7 +404,7 @@ class CryptoUpdateTransitionLogicTest {
 		).build();
 	}
 
-	private void rejectsKey(Key key) {
+	private void rejectsKey(final Key key) {
 		givenTxnCtx();
 		cryptoUpdateTxn = cryptoUpdateTxn.toBuilder()
 				.setCryptoUpdateAccount(cryptoUpdateTxn.getCryptoUpdateAccount().toBuilder().setKey(key))
@@ -431,17 +424,15 @@ class CryptoUpdateTransitionLogicTest {
 		), EnumSet.noneOf(AccountCustomizer.Option.class));
 	}
 
-	private void givenTxnCtx(
-			EnumSet<AccountCustomizer.Option> updating
-	) {
+	private void givenTxnCtx(final EnumSet<AccountCustomizer.Option> updating) {
 		givenTxnCtx(updating, EnumSet.noneOf(AccountCustomizer.Option.class));
 	}
 
 	private void givenTxnCtx(
-			EnumSet<AccountCustomizer.Option> updating,
-			EnumSet<AccountCustomizer.Option> misconfiguring
+			final EnumSet<AccountCustomizer.Option> updating,
+			final EnumSet<AccountCustomizer.Option> misconfiguring
 	) {
-		CryptoUpdateTransactionBody.Builder op = CryptoUpdateTransactionBody.newBuilder();
+		final var op = CryptoUpdateTransactionBody.newBuilder();
 		if (updating.contains(AccountCustomizer.Option.MEMO)) {
 			op.setMemo(StringValue.newBuilder().setValue(MEMO).build());
 		}

--- a/hedera-node/src/test/java/com/hedera/services/txns/crypto/CryptoUpdateTransitionLogicTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/txns/crypto/CryptoUpdateTransitionLogicTest.java
@@ -50,16 +50,11 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
 import java.time.Instant;
-import java.util.EnumMap;
 import java.util.EnumSet;
 
-import static com.hedera.services.ledger.accounts.AccountCustomizer.Option.AUTO_RENEW_PERIOD;
 import static com.hedera.services.ledger.accounts.AccountCustomizer.Option.EXPIRY;
 import static com.hedera.services.ledger.accounts.AccountCustomizer.Option.IS_RECEIVER_SIG_REQUIRED;
-import static com.hedera.services.ledger.accounts.AccountCustomizer.Option.KEY;
 import static com.hedera.services.ledger.accounts.AccountCustomizer.Option.MAX_AUTOMATIC_ASSOCIATIONS;
-import static com.hedera.services.ledger.accounts.AccountCustomizer.Option.MEMO;
-import static com.hedera.services.ledger.accounts.AccountCustomizer.Option.PROXY;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.ACCOUNT_DELETED;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.ACCOUNT_EXPIRED_AND_PENDING_REMOVAL;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.AUTORENEW_DURATION_NOT_IN_RANGE;
@@ -80,45 +75,45 @@ import static org.mockito.BDDMockito.any;
 import static org.mockito.BDDMockito.argThat;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.mock;
+import static org.mockito.BDDMockito.never;
 import static org.mockito.BDDMockito.verify;
 import static org.mockito.BDDMockito.willThrow;
-import static org.mockito.Mockito.never;
 
 class CryptoUpdateTransitionLogicTest {
-	final private Instant consensusTime = Instant.ofEpochSecond(1_234_567L);
-	final private long curExpiry = consensusTime.getEpochSecond() + 2L;
-	final private long newExpiry = consensusTime.getEpochSecond() + 7776000L;
-	final private int curMaxAutomaticAssociations = 10;
-	final private int newMaxAutomaticAssociations = 15;
-	final private int maxTokenAssociations = 12345;
+	private static final Instant CONSENSUS_TIME = Instant.ofEpochSecond(1_234_567L);
+	private static final long CUR_EXPIRY = CONSENSUS_TIME.getEpochSecond() + 2L;
+	private static final long NEW_EXPIRY = CONSENSUS_TIME.getEpochSecond() + 7776000L;
+	private static final int CUR_MAX_AUTOMATIC_ASSOCIATIONS = 10;
+	private static final int NEW_MAX_AUTOMATIC_ASSOCIATIONS = 15;
+	private static final int MAX_TOKEN_ASSOCIATIONS = 12345;
 
-	final private Key key = SignedTxnFactory.DEFAULT_PAYER_KT.asKey();
-	final private long autoRenewPeriod = 100_001L;
-	final private AccountID proxy = AccountID.newBuilder().setAccountNum(4_321L).build();
-	final private AccountID payer = AccountID.newBuilder().setAccountNum(1_234L).build();
-	final private AccountID target = AccountID.newBuilder().setAccountNum(9_999L).build();
+	private static final Key KEY = SignedTxnFactory.DEFAULT_PAYER_KT.asKey();
+	private static final long AUTO_RENEW_PERIOD = 100_001L;
+	private static final AccountID PROXY = AccountID.newBuilder().setAccountNum(4_321L).build();
+	private static final AccountID PAYER = AccountID.newBuilder().setAccountNum(1_234L).build();
+	private static final AccountID TARGET = AccountID.newBuilder().setAccountNum(9_999L).build();
+	private static final String MEMO = "Not since life began";
 
-	private String memo = "Not since life began";
-	private boolean useLegacyFields;
-	private HederaLedger ledger;
-	private OptionValidator validator;
-	private TransactionBody cryptoUpdateTxn;
-	private TransactionContext txnCtx;
-	private PlatformTxnAccessor accessor;
-	private CryptoUpdateTransitionLogic subject;
-	private GlobalDynamicProperties dynamicProperties;
+	private static boolean useLegacyFields;
+	private static HederaLedger ledger;
+	private static OptionValidator validator;
+	private static TransactionBody cryptoUpdateTxn;
+	private static TransactionContext txnCtx;
+	private static PlatformTxnAccessor accessor;
+	private static CryptoUpdateTransitionLogic subject;
+	private static GlobalDynamicProperties dynamicProperties;
 
 	@BeforeEach
 	private void setup() {
 		useLegacyFields = false;
 
 		txnCtx = mock(TransactionContext.class);
-		given(txnCtx.consensusTime()).willReturn(consensusTime);
+		given(txnCtx.consensusTime()).willReturn(CONSENSUS_TIME);
 		ledger = mock(HederaLedger.class);
 		accessor = mock(PlatformTxnAccessor.class);
 		validator = mock(OptionValidator.class);
 		dynamicProperties = mock(GlobalDynamicProperties.class);
-		given(dynamicProperties.maxTokensPerAccount()).willReturn(maxTokenAssociations);
+		given(dynamicProperties.maxTokensPerAccount()).willReturn(MAX_TOKEN_ASSOCIATIONS);
 		withRubberstampingValidator();
 
 		subject = new CryptoUpdateTransitionLogic(ledger, validator, txnCtx, dynamicProperties);
@@ -126,181 +121,152 @@ class CryptoUpdateTransitionLogicTest {
 
 	@Test
 	void updatesProxyIfPresent() {
-		// setup:
-		ArgumentCaptor<HederaAccountCustomizer> captor = ArgumentCaptor.forClass(HederaAccountCustomizer.class);
+		final var captor = ArgumentCaptor.forClass(HederaAccountCustomizer.class);
 
-		givenTxnCtx(EnumSet.of(PROXY));
+		givenTxnCtx(EnumSet.of(AccountCustomizer.Option.PROXY));
 
-		// when:
 		subject.doStateTransition();
 
-		// then:
-		verify(ledger).customize(argThat(target::equals), captor.capture());
+		verify(ledger).customize(argThat(TARGET::equals), captor.capture());
 		verify(txnCtx).setStatus(SUCCESS);
-		// and:
-		EnumMap<AccountProperty, Object> changes = captor.getValue().getChanges();
+		final var changes = captor.getValue().getChanges();
 		assertEquals(1, changes.size());
-		assertEquals(EntityId.fromGrpcAccountId(proxy), changes.get(AccountProperty.PROXY));
+		assertEquals(EntityId.fromGrpcAccountId(PROXY), changes.get(AccountProperty.PROXY));
 	}
 
 
 	@Test
 	void updatesReceiverSigReqIfPresent() {
-		// setup:
-		ArgumentCaptor<HederaAccountCustomizer> captor = ArgumentCaptor.forClass(HederaAccountCustomizer.class);
+		final var captor = ArgumentCaptor.forClass(HederaAccountCustomizer.class);
 
 		givenTxnCtx(EnumSet.of(IS_RECEIVER_SIG_REQUIRED));
 
-		// when:
 		subject.doStateTransition();
 
-		// then:
-		verify(ledger).customize(argThat(target::equals), captor.capture());
+		verify(ledger).customize(argThat(TARGET::equals), captor.capture());
 		verify(txnCtx).setStatus(SUCCESS);
-		// and:
-		EnumMap<AccountProperty, Object> changes = captor.getValue().getChanges();
+		final var changes = captor.getValue().getChanges();
 		assertEquals(1, changes.size());
 		assertEquals(true, changes.get(AccountProperty.IS_RECEIVER_SIG_REQUIRED));
 	}
 
 	@Test
 	void updatesReceiverSigReqIfTrueInLegacy() {
-		// setup:
 		useLegacyFields = true;
-		ArgumentCaptor<HederaAccountCustomizer> captor = ArgumentCaptor.forClass(HederaAccountCustomizer.class);
+		final var captor = ArgumentCaptor.forClass(HederaAccountCustomizer.class);
 
 		givenTxnCtx(EnumSet.of(IS_RECEIVER_SIG_REQUIRED));
 
-		// when:
 		subject.doStateTransition();
 
-		// then:
-		verify(ledger).customize(argThat(target::equals), captor.capture());
+		verify(ledger).customize(argThat(TARGET::equals), captor.capture());
 		verify(txnCtx).setStatus(SUCCESS);
-		// and:
-		EnumMap<AccountProperty, Object> changes = captor.getValue().getChanges();
+		final var changes = captor.getValue().getChanges();
 		assertEquals(1, changes.size());
 		assertEquals(true, changes.get(AccountProperty.IS_RECEIVER_SIG_REQUIRED));
 	}
 
 	@Test
 	void updatesExpiryIfPresent() {
-		// setup:
-		ArgumentCaptor<HederaAccountCustomizer> captor = ArgumentCaptor.forClass(HederaAccountCustomizer.class);
+		final var captor = ArgumentCaptor.forClass(HederaAccountCustomizer.class);
 
 		givenTxnCtx(EnumSet.of(EXPIRY));
 
-		// when:
 		subject.doStateTransition();
 
-		// then:
-		verify(ledger).customize(argThat(target::equals), captor.capture());
+		verify(ledger).customize(argThat(TARGET::equals), captor.capture());
 		verify(txnCtx).setStatus(SUCCESS);
-		// and:
-		EnumMap<AccountProperty, Object> changes = captor.getValue().getChanges();
+		final var changes = captor.getValue().getChanges();
 		assertEquals(1, changes.size());
-		assertEquals(newExpiry, (long)changes.get(AccountProperty.EXPIRY));
+		assertEquals(NEW_EXPIRY, (long)changes.get(AccountProperty.EXPIRY));
 	}
 
 	@Test
 	void updatesMaxAutomaticAssociationsIfPresent() {
-		ArgumentCaptor<HederaAccountCustomizer> captor = ArgumentCaptor.forClass(HederaAccountCustomizer.class);
+		final var captor = ArgumentCaptor.forClass(HederaAccountCustomizer.class);
 		givenTxnCtx(EnumSet.of(MAX_AUTOMATIC_ASSOCIATIONS));
-		given(ledger.alreadyUsedAutomaticAssociations(any())).willReturn(curMaxAutomaticAssociations);
+		given(ledger.alreadyUsedAutomaticAssociations(any())).willReturn(CUR_MAX_AUTOMATIC_ASSOCIATIONS);
 
 		subject.doStateTransition();
 
-		verify(ledger).customize(argThat(target::equals), captor.capture());
+		verify(ledger).customize(argThat(TARGET::equals), captor.capture());
 		verify(txnCtx).setStatus(SUCCESS);
-		EnumMap<AccountProperty, Object> changes = captor.getValue().getChanges();
+		final var changes = captor.getValue().getChanges();
 		assertEquals(1, changes.size());
-		assertEquals(newMaxAutomaticAssociations, (int)changes.get(AccountProperty.MAX_AUTOMATIC_ASSOCIATIONS));
+		assertEquals(NEW_MAX_AUTOMATIC_ASSOCIATIONS, (int)changes.get(AccountProperty.MAX_AUTOMATIC_ASSOCIATIONS));
 	}
 
 	@Test
 	void updateMaxAutomaticAssociationsFailAsExpectedWithMaxLessThanAlreadyExisting() {
-		ArgumentCaptor<HederaAccountCustomizer> captor = ArgumentCaptor.forClass(HederaAccountCustomizer.class);
+		final var captor = ArgumentCaptor.forClass(HederaAccountCustomizer.class);
 		givenTxnCtx(EnumSet.of(MAX_AUTOMATIC_ASSOCIATIONS));
-		given(ledger.alreadyUsedAutomaticAssociations(any())).willReturn(newMaxAutomaticAssociations+1);
+		given(ledger.alreadyUsedAutomaticAssociations(any())).willReturn(NEW_MAX_AUTOMATIC_ASSOCIATIONS +1);
 
 		subject.doStateTransition();
 
-		verify(ledger, never()).customize(argThat(target::equals), captor.capture());
+		verify(ledger, never()).customize(argThat(TARGET::equals), captor.capture());
 		verify(txnCtx).setStatus(EXISTING_AUTOMATIC_ASSOCIATIONS_EXCEED_GIVEN_LIMIT);
 	}
 
 	@Test
 	void updateMaxAutomaticAssociationsFailAsExpectedWithMaxMoreThanAllowedTokenAssociations() {
-		ArgumentCaptor<HederaAccountCustomizer> captor = ArgumentCaptor.forClass(HederaAccountCustomizer.class);
+		final var captor = ArgumentCaptor.forClass(HederaAccountCustomizer.class);
 		givenTxnCtx(EnumSet.of(MAX_AUTOMATIC_ASSOCIATIONS));
-		given(ledger.alreadyUsedAutomaticAssociations(any())).willReturn(curMaxAutomaticAssociations);
-		given(dynamicProperties.maxTokensPerAccount()).willReturn(newMaxAutomaticAssociations-1);
+		given(ledger.alreadyUsedAutomaticAssociations(any())).willReturn(CUR_MAX_AUTOMATIC_ASSOCIATIONS);
+		given(dynamicProperties.maxTokensPerAccount()).willReturn(NEW_MAX_AUTOMATIC_ASSOCIATIONS -1);
 
 		subject.doStateTransition();
 
-		verify(ledger, never()).customize(argThat(target::equals), captor.capture());
+		verify(ledger, never()).customize(argThat(TARGET::equals), captor.capture());
 		verify(txnCtx).setStatus(REQUESTED_NUM_AUTOMATIC_ASSOCIATIONS_EXCEEDS_ASSOCIATION_LIMIT);
 	}
 
 	@Test
-	void updatesMemoIfPresent() throws Throwable {
-		// setup:
-		ArgumentCaptor<HederaAccountCustomizer> captor = ArgumentCaptor.forClass(HederaAccountCustomizer.class);
+	void updatesMemoIfPresent() {
+		final var captor = ArgumentCaptor.forClass(HederaAccountCustomizer.class);
 
-		givenTxnCtx(EnumSet.of(MEMO));
+		givenTxnCtx(EnumSet.of(AccountCustomizer.Option.MEMO));
 
-		// when:
 		subject.doStateTransition();
 
-		// then:
-		verify(ledger).customize(argThat(target::equals), captor.capture());
-		// and:
-		EnumMap<AccountProperty, Object> changes = captor.getValue().getChanges();
+		verify(ledger).customize(argThat(TARGET::equals), captor.capture());
+		final var changes = captor.getValue().getChanges();
 		assertEquals(1, changes.size());
-		assertEquals(memo, changes.get(AccountProperty.MEMO));
+		assertEquals(MEMO, changes.get(AccountProperty.MEMO));
 	}
 
 	@Test
-	void updatesAutoRenewIfPresent() throws Throwable {
-		// setup:
-		ArgumentCaptor<HederaAccountCustomizer> captor = ArgumentCaptor.forClass(HederaAccountCustomizer.class);
+	void updatesAutoRenewIfPresent() {
+		final var captor = ArgumentCaptor.forClass(HederaAccountCustomizer.class);
 
-		givenTxnCtx(EnumSet.of(AUTO_RENEW_PERIOD));
+		givenTxnCtx(EnumSet.of(AccountCustomizer.Option.AUTO_RENEW_PERIOD));
 
-		// when:
 		subject.doStateTransition();
 
-		// then:
-		verify(ledger).customize(argThat(target::equals), captor.capture());
-		// and:
-		EnumMap<AccountProperty, Object> changes = captor.getValue().getChanges();
+		verify(ledger).customize(argThat(TARGET::equals), captor.capture());
+		final var changes = captor.getValue().getChanges();
 		assertEquals(1, changes.size());
-		assertEquals(autoRenewPeriod, changes.get(AccountProperty.AUTO_RENEW_PERIOD));
+		assertEquals(AUTO_RENEW_PERIOD, changes.get(AccountProperty.AUTO_RENEW_PERIOD));
 	}
 
 	@Test
 	void updatesKeyIfPresent() throws Throwable {
-		// setup:
-		ArgumentCaptor<HederaAccountCustomizer> captor = ArgumentCaptor.forClass(HederaAccountCustomizer.class);
+		final var captor = ArgumentCaptor.forClass(HederaAccountCustomizer.class);
 
-		givenTxnCtx(EnumSet.of(KEY));
+		givenTxnCtx(EnumSet.of(AccountCustomizer.Option.KEY));
 
-		// when:
 		subject.doStateTransition();
 
-		// then:
-		verify(ledger).customize(argThat(target::equals), captor.capture());
-		// and:
-		EnumMap<AccountProperty, Object> changes = captor.getValue().getChanges();
+		verify(ledger).customize(argThat(TARGET::equals), captor.capture());
+		final var changes = captor.getValue().getChanges();
 		assertEquals(1, changes.size());
-		assertEquals(key, JKey.mapJKey((JKey)changes.get(AccountProperty.KEY)));
+		assertEquals(KEY, JKey.mapJKey((JKey)changes.get(AccountProperty.KEY)));
 	}
 
 	@Test
 	void hasCorrectApplicability() {
 		givenTxnCtx();
 
-		// expect:
 		assertTrue(subject.applicability().test(cryptoUpdateTxn));
 		assertFalse(subject.applicability().test(TransactionBody.getDefaultInstance()));
 	}
@@ -317,10 +283,9 @@ class CryptoUpdateTransitionLogicTest {
 
 	@Test
 	void rejectsInvalidMemo() {
-		givenTxnCtx(EnumSet.of(MEMO));
-		given(validator.memoCheck(memo)).willReturn(MEMO_TOO_LONG);
+		givenTxnCtx(EnumSet.of(AccountCustomizer.Option.MEMO));
+		given(validator.memoCheck(MEMO)).willReturn(MEMO_TOO_LONG);
 
-		// expect:
 		assertEquals(MEMO_TOO_LONG, subject.semanticCheck().apply(cryptoUpdateTxn));
 	}
 
@@ -329,7 +294,6 @@ class CryptoUpdateTransitionLogicTest {
 		givenTxnCtx();
 		given(validator.isValidAutoRenewPeriod(any())).willReturn(false);
 
-		// expect:
 		assertEquals(AUTORENEW_DURATION_NOT_IN_RANGE, subject.semanticCheck().apply(cryptoUpdateTxn));
 	}
 
@@ -337,19 +301,16 @@ class CryptoUpdateTransitionLogicTest {
 	void acceptsValidTxn() {
 		givenTxnCtx();
 
-		// expect:
 		assertEquals(OK, subject.semanticCheck().apply(cryptoUpdateTxn));
 	}
 
 	@Test
 	void rejectsDetachedAccount() {
 		givenTxnCtx();
-		given(ledger.isDetached(target)).willReturn(true);
+		given(ledger.isDetached(TARGET)).willReturn(true);
 
-		// when:
 		subject.doStateTransition();
 
-		// then:
 		verify(txnCtx).setStatus(ACCOUNT_EXPIRED_AND_PENDING_REMOVAL);
 	}
 
@@ -358,59 +319,49 @@ class CryptoUpdateTransitionLogicTest {
 		givenTxnCtx();
 		given(validator.isValidExpiry(any())).willReturn(false);
 
-		// when:
 		subject.doStateTransition();
 
-		// then:
 		verify(txnCtx).setStatus(INVALID_EXPIRATION_TIME);
 	}
 
 	@Test
 	void permitsDetachedIfOnlyExtendingExpiry() {
 		givenTxnCtx(EnumSet.of(EXPIRY));
-		given(ledger.isDetached(target)).willReturn(true);
+		given(ledger.isDetached(TARGET)).willReturn(true);
 
-		// when:
 		subject.doStateTransition();
 
-		// then:
 		verify(txnCtx).setStatus(SUCCESS);
 	}
 
 	@Test
 	void rejectsInvalidExpiryForDetached() {
 		givenTxnCtx(EnumSet.of(EXPIRY), EnumSet.of(EXPIRY));
-		given(ledger.isDetached(target)).willReturn(true);
-		given(ledger.expiry(target)).willReturn(curExpiry);
+		given(ledger.isDetached(TARGET)).willReturn(true);
+		given(ledger.expiry(TARGET)).willReturn(CUR_EXPIRY);
 
-		// when:
 		subject.doStateTransition();
 
-		// then:
 		verify(txnCtx).setStatus(EXPIRATION_REDUCTION_NOT_ALLOWED);
 	}
 
 	@Test
 	void rejectsSmartContract() {
 		givenTxnCtx();
-		given(ledger.isSmartContract(target)).willReturn(true);
+		given(ledger.isSmartContract(TARGET)).willReturn(true);
 
-		// when:
 		subject.doStateTransition();
 
-		// then:
 		verify(txnCtx).setStatus(INVALID_ACCOUNT_ID);
 	}
 
 	@Test
 	void preemptsMissingAccountException() {
 		givenTxnCtx();
-		given(ledger.exists(target)).willReturn(false);
+		given(ledger.exists(TARGET)).willReturn(false);
 
-		// when:
 		subject.doStateTransition();
 
-		// then:
 		verify(txnCtx).setStatus(INVALID_ACCOUNT_ID);
 	}
 
@@ -419,10 +370,8 @@ class CryptoUpdateTransitionLogicTest {
 		givenTxnCtx();
 		willThrow(MissingAccountException.class).given(ledger).customize(any(), any());
 
-		// when:
 		subject.doStateTransition();
 
-		// then:
 		verify(txnCtx).setStatus(INVALID_ACCOUNT_ID);
 	}
 
@@ -431,10 +380,8 @@ class CryptoUpdateTransitionLogicTest {
 		givenTxnCtx();
 		willThrow(DeletedAccountException.class).given(ledger).customize(any(), any());
 
-		// when:
 		subject.doStateTransition();
 
-		// then:
 		verify(txnCtx).setStatus(ACCOUNT_DELETED);
 	}
 
@@ -447,11 +394,8 @@ class CryptoUpdateTransitionLogicTest {
 		given(accessor.getTxn()).willReturn(cryptoUpdateTxn);
 		given(txnCtx.accessor()).willReturn(accessor);
 
-
-		// when:
 		subject.doStateTransition();
 
-		// then:
 		verify(txnCtx).setStatus(FAIL_INVALID);
 	}
 
@@ -473,18 +417,17 @@ class CryptoUpdateTransitionLogicTest {
 				.setCryptoUpdateAccount(cryptoUpdateTxn.getCryptoUpdateAccount().toBuilder().setKey(key))
 				.build();
 
-		// expect:
 		assertEquals(BAD_ENCODING, subject.semanticCheck().apply(cryptoUpdateTxn));
 	}
 
 	private void givenTxnCtx() {
 		givenTxnCtx(EnumSet.of(
-				KEY,
-				MEMO,
-				PROXY,
+				AccountCustomizer.Option.KEY,
+				AccountCustomizer.Option.MEMO,
+				AccountCustomizer.Option.PROXY,
 				EXPIRY,
 				IS_RECEIVER_SIG_REQUIRED,
-				AUTO_RENEW_PERIOD
+				AccountCustomizer.Option.AUTO_RENEW_PERIOD
 		), EnumSet.noneOf(AccountCustomizer.Option.class));
 	}
 
@@ -499,20 +442,20 @@ class CryptoUpdateTransitionLogicTest {
 			EnumSet<AccountCustomizer.Option> misconfiguring
 	) {
 		CryptoUpdateTransactionBody.Builder op = CryptoUpdateTransactionBody.newBuilder();
-		if (updating.contains(MEMO)) {
-			op.setMemo(StringValue.newBuilder().setValue(memo).build());
+		if (updating.contains(AccountCustomizer.Option.MEMO)) {
+			op.setMemo(StringValue.newBuilder().setValue(MEMO).build());
 		}
-		if (updating.contains(KEY)) {
-			op.setKey(key);
+		if (updating.contains(AccountCustomizer.Option.KEY)) {
+			op.setKey(KEY);
 		}
-		if (updating.contains(PROXY)) {
-			op.setProxyAccountID(proxy);
+		if (updating.contains(AccountCustomizer.Option.PROXY)) {
+			op.setProxyAccountID(PROXY);
 		}
 		if (updating.contains(EXPIRY)) {
 			if (misconfiguring.contains(EXPIRY)) {
-				op.setExpirationTime(Timestamp.newBuilder().setSeconds(curExpiry - 1));
+				op.setExpirationTime(Timestamp.newBuilder().setSeconds(CUR_EXPIRY - 1));
 			} else {
-				op.setExpirationTime(Timestamp.newBuilder().setSeconds(newExpiry));
+				op.setExpirationTime(Timestamp.newBuilder().setSeconds(NEW_EXPIRY));
 			}
 		}
 		if (updating.contains(IS_RECEIVER_SIG_REQUIRED)) {
@@ -522,24 +465,24 @@ class CryptoUpdateTransitionLogicTest {
 				op.setReceiverSigRequired(true);
 			}
 		}
-		if (updating.contains(AUTO_RENEW_PERIOD)) {
-			op.setAutoRenewPeriod(Duration.newBuilder().setSeconds(autoRenewPeriod));
+		if (updating.contains(AccountCustomizer.Option.AUTO_RENEW_PERIOD)) {
+			op.setAutoRenewPeriod(Duration.newBuilder().setSeconds(AUTO_RENEW_PERIOD));
 		}
 		if (updating.contains(MAX_AUTOMATIC_ASSOCIATIONS)) {
-			op.setMaxAutomaticTokenAssociations(Int32Value.of(newMaxAutomaticAssociations));
+			op.setMaxAutomaticTokenAssociations(Int32Value.of(NEW_MAX_AUTOMATIC_ASSOCIATIONS));
 		}
-		op.setAccountIDToUpdate(target);
+		op.setAccountIDToUpdate(TARGET);
 		cryptoUpdateTxn = TransactionBody.newBuilder().setTransactionID(ourTxnId()).setCryptoUpdateAccount(op).build();
 		given(accessor.getTxn()).willReturn(cryptoUpdateTxn);
 		given(txnCtx.accessor()).willReturn(accessor);
-		given(ledger.exists(target)).willReturn(true);
+		given(ledger.exists(TARGET)).willReturn(true);
 	}
 
 	private TransactionID ourTxnId() {
 		return TransactionID.newBuilder()
-				.setAccountID(payer)
+				.setAccountID(PAYER)
 				.setTransactionValidStart(
-						Timestamp.newBuilder().setSeconds(consensusTime.getEpochSecond()))
+						Timestamp.newBuilder().setSeconds(CONSENSUS_TIME.getEpochSecond()))
 				.build();
 	}
 


### PR DESCRIPTION
**Description**:
Resolves Sonar cloud [issue](https://sonarcloud.io/project/issues?id=com.hedera.hashgraph%3Ahedera-services&resolved=false&rules=java%3AS1319&types=CODE_SMELL) and modifies `AccountCustomizer` and `ChangeSummaryManager` to use interface type instead of implementation type. This PR also modifies the variable types and tests to resolve other Sonar cloud smells.

**Related issue(s)**:

Fixes #2167

**Checklist**

- [X] Documented (Code comments, README, etc.)
- [X] Tested (unit, integration, etc.)
