### PR TITLE
`TopicCreate` Refactoring 

### DIFF
--- a/hedera-node/src/main/java/com/hedera/services/records/TransactionRecordService.java
+++ b/hedera-node/src/main/java/com/hedera/services/records/TransactionRecordService.java
@@ -25,6 +25,7 @@ import com.hedera.services.store.models.Id;
 import com.hedera.services.store.models.OwnershipTracker;
 import com.hedera.services.store.models.Token;
 import com.hedera.services.store.models.TokenRelationship;
+import com.hedera.services.store.models.Topic;
 import com.hedera.services.store.models.UniqueToken;
 import com.hederahashgraph.api.proto.java.AccountAmount;
 import com.hederahashgraph.api.proto.java.NftTransfer;
@@ -149,5 +150,18 @@ public class TransactionRecordService {
 					.build());
 		}
 		txnCtx.setTokenTransferLists(transferLists);
+	}
+
+	/**
+	 * Updates the record of the current transaction with the changes in the given {@link Topic}.
+	 * Currently, the only operation refactored is the TopicCreate.
+	 * This function should be updated correspondingly while refactoring the other Topic operations.
+	 * 
+	 * @param topic - the Topic, whose changes have to be included in the receipt
+	 */
+	public void includeChangesToTopic(Topic topic) {
+		if (topic.isNew()) {
+			txnCtx.setCreated(topic.getId().asGrpcTopic());
+		}
 	}
 }

--- a/hedera-node/src/main/java/com/hedera/services/store/AccountStore.java
+++ b/hedera-node/src/main/java/com/hedera/services/store/AccountStore.java
@@ -106,7 +106,7 @@ public class AccountStore {
 		account.setOwnedNfts(merkleAccount.getNftsOwned());
 		account.setMaxAutomaticAssociations(merkleAccount.getMaxAutomaticAssociations());
 		account.setAlreadyUsedAutomaticAssociations(merkleAccount.getAlreadyUsedAutoAssociations());
-
+		account.setSmartContract(merkleAccount.isSmartContract());
 		return account;
 	}
 

--- a/hedera-node/src/main/java/com/hedera/services/store/TopicStore.java
+++ b/hedera-node/src/main/java/com/hedera/services/store/TopicStore.java
@@ -1,0 +1,84 @@
+package com.hedera.services.store;
+
+/*
+ * -
+ * ‌
+ * Hedera Services Node
+ * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import com.hedera.services.records.TransactionRecordService;
+import com.hedera.services.state.merkle.MerkleTopic;
+import com.hedera.services.store.models.Topic;
+import com.hedera.services.utils.EntityNum;
+import com.swirlds.merkle.map.MerkleMap;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import java.util.function.Supplier;
+
+/**
+ * A store which interacts with the state topics, represented in a {@link MerkleMap}.
+ * 
+ * @author Yoan Sredkov
+ */
+@Singleton
+public class TopicStore {
+	
+	private final Supplier<MerkleMap<EntityNum, MerkleTopic>> topics;
+	private final TransactionRecordService transactionRecordService;
+
+	@Inject
+	public TopicStore(
+			final Supplier<MerkleMap<EntityNum, MerkleTopic>> topics,
+			final TransactionRecordService transactionRecordService
+	) {
+		this.topics = topics;
+		this.transactionRecordService = transactionRecordService;
+	}
+
+	/**
+	 * Persists a new {@link Topic} into the state, as well as exporting its ID to the transaction receipt.
+	 *
+	 * @param model
+	 * 		- the model to be mapped onto a new {@link MerkleTopic} and persisted.
+	 */
+	public void persistNew(Topic model) {
+		final var id = model.getId().asEntityNum();
+		final var currentTopics = topics.get();
+		final var merkleTopic = new MerkleTopic();
+		mapModelToMerkle(model, merkleTopic);
+		merkleTopic.setSequenceNumber(0);
+		currentTopics.put(id, merkleTopic);
+		transactionRecordService.includeChangesToTopic(model);
+	}
+
+	/**
+	 * Maps properties between a model {@link Topic} and a {@link MerkleTopic}
+	 * 
+	 * @param model - the Topic model which will be used to map into a MerkleTopic
+	 * @param merkle - the merkle topic
+	 */
+	private void mapModelToMerkle(Topic model, MerkleTopic merkle) {
+		merkle.setAdminKey(model.getAdminKey());
+		merkle.setSubmitKey(model.getSubmitKey());
+		merkle.setMemo(model.getMemo());
+		if (model.getAutoRenewAccountId() != null) {
+			merkle.setAutoRenewAccountId(model.getAutoRenewAccountId().asEntityId());
+		}
+		merkle.setAutoRenewDurationSeconds(model.getAutoRenewDurationSeconds());
+		merkle.setExpirationTimestamp(model.getExpirationTimestamp());
+		merkle.setDeleted(model.isDeleted());
+		merkle.setSequenceNumber(model.getSequenceNumber());
+	}
+
+}

--- a/hedera-node/src/main/java/com/hedera/services/store/models/Account.java
+++ b/hedera-node/src/main/java/com/hedera/services/store/models/Account.java
@@ -62,6 +62,7 @@ public class Account {
 	private CopyOnWriteIds associatedTokens;
 	private long ownedNfts;
 	private int autoAssociationMetadata;
+	private boolean isSmartContract = false;
 
 	public Account(Id id) {
 		this.id = id;
@@ -204,5 +205,13 @@ public class Account {
 				.add("alreadyUsedAutoAssociations", getAlreadyUsedAutomaticAssociations())
 				.add("maxAutoAssociations", getMaxAutomaticAssociations())
 				.toString();
+	}
+
+	public boolean isSmartContract() {
+		return isSmartContract;
+	}
+
+	public void setSmartContract(final boolean smartContract) {
+		isSmartContract = smartContract;
 	}
 }

--- a/hedera-node/src/main/java/com/hedera/services/store/models/Id.java
+++ b/hedera-node/src/main/java/com/hedera/services/store/models/Id.java
@@ -9,9 +9,9 @@ package com.hedera.services.store.models;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -22,8 +22,10 @@ package com.hedera.services.store.models;
 
 import com.google.common.base.MoreObjects;
 import com.hedera.services.state.submerkle.EntityId;
+import com.hedera.services.utils.EntityNum;
 import com.hederahashgraph.api.proto.java.AccountID;
 import com.hederahashgraph.api.proto.java.TokenID;
+import com.hederahashgraph.api.proto.java.TopicID;
 
 import java.util.Comparator;
 
@@ -36,17 +38,31 @@ public class Id {
 			.comparingLong(Id::getNum)
 			.thenComparingLong(Id::getShard)
 			.thenComparingLong(Id::getRealm);
-
+	public static final Id MISSING_ID = new Id(0, 0, 0);
 	private final long shard;
 	private final long realm;
 	private final long num;
-
-	public static final Id MISSING_ID = new Id(0, 0, 0);
 
 	public Id(long shard, long realm, long num) {
 		this.shard = shard;
 		this.realm = realm;
 		this.num = num;
+	}
+
+	public static Id fromGrpcAccount(final AccountID id) {
+		return new Id(id.getShardNum(), id.getRealmNum(), id.getAccountNum());
+	}
+
+	public static Id fromGrpcToken(final TokenID id) {
+		return new Id(id.getShardNum(), id.getRealmNum(), id.getTokenNum());
+	}
+
+	public static Id fromGrpcTopic(final TopicID id) {
+		return new Id(id.getShardNum(), id.getRealmNum(), id.getTopicNum());
+	}
+
+	public EntityNum asEntityNum() {
+		return EntityNum.fromLong(num);
 	}
 
 	public AccountID asGrpcAccount() {
@@ -65,12 +81,12 @@ public class Id {
 				.build();
 	}
 
-	public static Id fromGrpcAccount(final AccountID id) {
-		return new Id(id.getShardNum(), id.getRealmNum(), id.getAccountNum());
-	}
-
-	public static Id fromGrpcToken(final TokenID id) {
-		return new Id(id.getShardNum(), id.getRealmNum(), id.getTokenNum());
+	public TopicID asGrpcTopic() {
+		return TopicID.newBuilder()
+				.setShardNum(shard)
+				.setRealmNum(realm)
+				.setTopicNum(num)
+				.build();
 	}
 
 	public long getShard() {

--- a/hedera-node/src/main/java/com/hedera/services/store/models/Topic.java
+++ b/hedera-node/src/main/java/com/hedera/services/store/models/Topic.java
@@ -1,0 +1,165 @@
+package com.hedera.services.store.models;
+
+/*
+ * -
+ * ‌
+ * Hedera Services Node
+ * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import com.hedera.services.legacy.core.jproto.JKey;
+import com.hedera.services.state.submerkle.RichInstant;
+
+import javax.annotation.Nullable;
+import java.time.Instant;
+
+/**
+ * Represents the model of a {@link com.hedera.services.state.merkle.MerkleTopic}.
+ *
+ * @author Yoan Sredkov
+ */
+public class Topic {
+
+	private final Id id;
+	private String memo;
+	private JKey adminKey;
+	private JKey submitKey;
+	private Id autoRenewAccountId;
+	private long autoRenewDurationSeconds;
+	private boolean deleted;
+	private boolean isNew;
+	private RichInstant expirationTimestamp;
+
+	private long sequenceNumber;
+	private byte[] runningHash;
+
+	public Topic(final Id id) {
+		this.id = id;
+	}
+
+	/**
+	 * Creates a new {@link Topic} from the given body.
+	 * Note: The created model is not added to state, and must be explicitly persisted via {@link com.hedera.services.store.TopicStore#persistNew(Topic)}
+	 *
+	 * @param id
+	 * 		- the id generated in the transition logic
+	 * @param submitKey
+	 * 		- the key which permits submitting messages
+	 * @param adminKey
+	 * @param autoRenewAccount
+	 * 		- the account which pays for the automatic renewal of the topic
+	 * @param memo
+	 * @param autoRenewPeriod
+	 * 		- the period of automatic renewal
+	 * @param expirationTime
+	 * 		- expiration time of the topic,
+	 * 		or when {@link com.hedera.services.txns.consensus.SubmitMessageTransitionLogic} will start failing.
+	 * @return - the new topic
+	 */
+	public static Topic fromGrpcTopicCreate(
+			Id id,
+			@Nullable JKey submitKey,
+			@Nullable JKey adminKey,
+			@Nullable Account autoRenewAccount,
+			String memo,
+			long autoRenewPeriod,
+			Instant expirationTime) {
+		final var topic = new Topic(id);
+
+		topic.setMemo(memo);
+		topic.setDeleted(false);
+		topic.setAutoRenewDurationSeconds(autoRenewPeriod);
+		topic.setAutoRenewAccountId(autoRenewAccount != null ? autoRenewAccount.getId() : null);
+		topic.setSubmitKey(submitKey);
+		topic.setAdminKey(adminKey);
+		topic.setExpirationTimestamp(RichInstant.fromJava(expirationTime));
+		topic.setNew(true);
+		return topic;
+	}
+
+
+	public Id getId() {
+		return id;
+	}
+
+	public String getMemo() {
+		return memo;
+	}
+
+	public void setMemo(final String memo) {
+		this.memo = memo;
+	}
+
+	public JKey getAdminKey() {
+		return adminKey;
+	}
+
+	public void setAdminKey(final JKey adminKey) {
+		this.adminKey = adminKey;
+	}
+
+	public JKey getSubmitKey() {
+		return submitKey;
+	}
+
+	public void setSubmitKey(final JKey submitKey) {
+		this.submitKey = submitKey;
+	}
+
+	public Id getAutoRenewAccountId() {
+		return autoRenewAccountId;
+	}
+
+	public void setAutoRenewAccountId(final Id autoRenewAccountId) {
+		this.autoRenewAccountId = autoRenewAccountId;
+	}
+
+	public long getAutoRenewDurationSeconds() {
+		return autoRenewDurationSeconds;
+	}
+
+	public void setAutoRenewDurationSeconds(final long autoRenewDurationSeconds) {
+		this.autoRenewDurationSeconds = autoRenewDurationSeconds;
+	}
+
+	public RichInstant getExpirationTimestamp() {
+		return expirationTimestamp;
+	}
+
+	public void setExpirationTimestamp(final RichInstant expirationTimestamp) {
+		this.expirationTimestamp = expirationTimestamp;
+	}
+
+	public boolean isDeleted() {
+		return deleted;
+	}
+
+	public void setDeleted(final boolean deleted) {
+		this.deleted = deleted;
+	}
+
+	public long getSequenceNumber() {
+		return sequenceNumber;
+	}
+
+	public void setSequenceNumber(final long sequenceNumber) {
+		this.sequenceNumber = sequenceNumber;
+	}
+
+	public boolean isNew() {
+		return isNew;
+	}
+
+	public void setNew(final boolean aNew) {
+		isNew = aNew;
+	}
+}

--- a/hedera-node/src/main/java/com/hedera/services/txns/TransitionRunner.java
+++ b/hedera-node/src/main/java/com/hedera/services/txns/TransitionRunner.java
@@ -32,13 +32,15 @@ import javax.inject.Inject;
 import javax.inject.Singleton;
 import java.util.EnumSet;
 
+import static com.hederahashgraph.api.proto.java.HederaFunctionality.ConsensusCreateTopic;
 import static com.hederahashgraph.api.proto.java.HederaFunctionality.CryptoTransfer;
 import static com.hederahashgraph.api.proto.java.HederaFunctionality.TokenAccountWipe;
 import static com.hederahashgraph.api.proto.java.HederaFunctionality.TokenAssociateToAccount;
 import static com.hederahashgraph.api.proto.java.HederaFunctionality.TokenBurn;
-import static com.hederahashgraph.api.proto.java.HederaFunctionality.TokenDelete;
 import static com.hederahashgraph.api.proto.java.HederaFunctionality.TokenCreate;
+import static com.hederahashgraph.api.proto.java.HederaFunctionality.TokenDelete;
 import static com.hederahashgraph.api.proto.java.HederaFunctionality.TokenDissociateFromAccount;
+import static com.hederahashgraph.api.proto.java.HederaFunctionality.TokenFeeScheduleUpdate;
 import static com.hederahashgraph.api.proto.java.HederaFunctionality.TokenFreezeAccount;
 import static com.hederahashgraph.api.proto.java.HederaFunctionality.TokenGrantKycToAccount;
 import static com.hederahashgraph.api.proto.java.HederaFunctionality.TokenMint;
@@ -47,7 +49,6 @@ import static com.hederahashgraph.api.proto.java.HederaFunctionality.TokenUnfree
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.FAIL_INVALID;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OK;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SUCCESS;
-import static com.hederahashgraph.api.proto.java.HederaFunctionality.TokenFeeScheduleUpdate;
 
 @Singleton
 public class TransitionRunner {
@@ -62,7 +63,8 @@ public class TransitionRunner {
 			TokenCreate,
 			TokenFeeScheduleUpdate,
 			CryptoTransfer,
-			TokenDelete
+			TokenDelete,
+			ConsensusCreateTopic
 	);
 
 	private final TransactionContext txnCtx;

--- a/hedera-node/src/main/java/com/hedera/services/txns/consensus/TopicCreateTransitionLogic.java
+++ b/hedera-node/src/main/java/com/hedera/services/txns/consensus/TopicCreateTransitionLogic.java
@@ -9,9 +9,9 @@ package com.hedera.services.txns.consensus;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -21,21 +21,16 @@ package com.hedera.services.txns.consensus;
  */
 
 import com.hedera.services.context.TransactionContext;
-import com.hedera.services.ledger.HederaLedger;
 import com.hedera.services.ledger.ids.EntityIdSource;
-import com.hedera.services.legacy.core.jproto.JKey;
-import com.hedera.services.state.merkle.MerkleAccount;
-import com.hedera.services.state.merkle.MerkleTopic;
-import com.hedera.services.state.submerkle.EntityId;
-import com.hedera.services.state.submerkle.RichInstant;
-import com.hedera.services.utils.EntityNum;
+import com.hedera.services.store.AccountStore;
+import com.hedera.services.store.TopicStore;
+import com.hedera.services.store.models.Account;
+import com.hedera.services.store.models.Id;
+import com.hedera.services.store.models.Topic;
 import com.hedera.services.txns.TransitionLogic;
 import com.hedera.services.txns.validation.OptionValidator;
 import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
-import com.hederahashgraph.api.proto.java.TopicID;
 import com.hederahashgraph.api.proto.java.TransactionBody;
-import com.swirlds.merkle.map.MerkleMap;
-import org.apache.commons.codec.DecoderException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -43,16 +38,15 @@ import javax.inject.Inject;
 import javax.inject.Singleton;
 import java.util.function.Function;
 import java.util.function.Predicate;
-import java.util.function.Supplier;
 
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.ACCOUNT_EXPIRED_AND_PENDING_REMOVAL;
+import static com.hedera.services.exceptions.ValidationUtils.validateFalse;
+import static com.hedera.services.exceptions.ValidationUtils.validateTrue;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.AUTORENEW_ACCOUNT_NOT_ALLOWED;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.AUTORENEW_DURATION_NOT_IN_RANGE;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.BAD_ENCODING;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_AUTORENEW_ACCOUNT;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_RENEWAL_PERIOD;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OK;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SUCCESS;
 
 /**
  * The syntax check pre-consensus validates the adminKey's structure as signature validation occurs before
@@ -60,30 +54,25 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SUCCESS;
  */
 @Singleton
 public class TopicCreateTransitionLogic implements TransitionLogic {
-	private static final Logger log = LogManager.getLogger(TopicCreateTransitionLogic.class);
+	private final static Logger log = LogManager.getLogger(TopicCreateTransitionLogic.class);
 
-	private final Function<TransactionBody, ResponseCodeEnum> PRE_SIGNATURE_VALIDATION_SEMANTIC_CHECK =
-			this::validatePreSignatureValidation;
-
-	private final HederaLedger ledger;
-	private final Supplier<MerkleMap<EntityNum, MerkleAccount>> accounts;
-	private final Supplier<MerkleMap<EntityNum, MerkleTopic>> topics;
+	private final AccountStore accountStore;
+	private final TopicStore topicStore;
 	private final EntityIdSource entityIdSource;
 	private final OptionValidator validator;
+	private final Function<TransactionBody, ResponseCodeEnum> SEMANTIC_CHECK = this::validate;
 	private final TransactionContext transactionContext;
 
 	@Inject
 	public TopicCreateTransitionLogic(
-			Supplier<MerkleMap<EntityNum, MerkleAccount>> accounts,
-			Supplier<MerkleMap<EntityNum, MerkleTopic>> topics,
-			EntityIdSource entityIdSource,
-			OptionValidator validator,
-			TransactionContext transactionContext,
-			HederaLedger ledger
+			final TopicStore topicStore,
+			final EntityIdSource entityIdSource,
+			final OptionValidator validator,
+			final TransactionContext transactionContext,
+			final AccountStore accountStore
 	) {
-		this.accounts = accounts;
-		this.topics = topics;
-		this.ledger = ledger;
+		this.accountStore = accountStore;
+		this.topicStore = topicStore;
 		this.entityIdSource = entityIdSource;
 		this.validator = validator;
 		this.transactionContext = transactionContext;
@@ -91,43 +80,42 @@ public class TopicCreateTransitionLogic implements TransitionLogic {
 
 	@Override
 	public void doStateTransition() {
-		var postConsensusValidationResult = validatePreStateTransition();
-		if (OK != postConsensusValidationResult) {
-			transactionContext.setStatus(postConsensusValidationResult);
-			return;
+		/* --- Extract gRPC --- */
+		final var transactionBody = transactionContext.accessor().getTxn();
+		final var payerAccountId = transactionBody.getTransactionID().getAccountID();
+		final var op = transactionBody.getConsensusCreateTopic();
+		final var submitKey = op.hasSubmitKey() ? validator.attemptDecodeOrThrow(op.getSubmitKey()) : null;
+		final var adminKey = op.hasAdminKey() ? validator.attemptDecodeOrThrow(op.getAdminKey()) : null;
+		final var memo = op.getMemo();
+		final var autoRenewPeriod = op.getAutoRenewPeriod();
+		final var autoRenewAccountId = Id.fromGrpcAccount(op.getAutoRenewAccount());
+
+		/* --- Validate --- */
+		final var memoValidationResult = validator.memoCheck(memo);
+		validateTrue(OK == memoValidationResult, memoValidationResult);
+		validateTrue(op.hasAutoRenewPeriod(), INVALID_RENEWAL_PERIOD);
+		validateTrue(validator.isValidAutoRenewPeriod(autoRenewPeriod), AUTORENEW_DURATION_NOT_IN_RANGE);
+		Account autoRenewAccount = null;
+		if (op.hasAutoRenewAccount()) {
+			autoRenewAccount = accountStore.loadAccountOrFailWith(autoRenewAccountId, INVALID_AUTORENEW_ACCOUNT);
+			validateFalse(autoRenewAccount.isSmartContract(), INVALID_AUTORENEW_ACCOUNT);
+			validateTrue(op.hasAdminKey(), AUTORENEW_ACCOUNT_NOT_ALLOWED);
 		}
 
-		var transactionBody = transactionContext.accessor().getTxn();
-		var payerAccountId = transactionBody.getTransactionID().getAccountID();
-		var op = transactionBody.getConsensusCreateTopic();
+		/* --- Do business logic --- */
+		final var expirationTime = transactionContext.consensusTime().plusSeconds(op.getAutoRenewPeriod().getSeconds());
+		final var topicId = entityIdSource.newAccountId(payerAccountId);
+		final var topic = Topic.fromGrpcTopicCreate(
+				Id.fromGrpcAccount(topicId),
+				submitKey,
+				adminKey,
+				autoRenewAccount,
+				memo,
+				autoRenewPeriod.getSeconds(),
+				expirationTime);
 
-		try {
-			// expirationTime (currently un-enforced) is consensus timestamp of create plus the specified required
-			// autoRenewPeriod->seconds.
-			var expirationTime = transactionContext.consensusTime().plusSeconds(op.getAutoRenewPeriod().getSeconds());
-
-			var topic = new MerkleTopic(op.getMemo(),
-					op.hasAdminKey() ? JKey.mapKey(op.getAdminKey()) : null,
-					op.hasSubmitKey() ? JKey.mapKey(op.getSubmitKey()) : null,
-					op.getAutoRenewPeriod().getSeconds(),
-					op.hasAutoRenewAccount() ? EntityId.fromGrpcAccountId(op.getAutoRenewAccount()) : null,
-					new RichInstant(expirationTime.getEpochSecond(), expirationTime.getNano()));
-
-			var newEntityId = entityIdSource.newAccountId(payerAccountId);
-			var newTopicId = TopicID.newBuilder()
-					.setShardNum(newEntityId.getShardNum())
-					.setRealmNum(newEntityId.getRealmNum())
-					.setTopicNum(newEntityId.getAccountNum())
-					.build();
-
-			topics.get().put(EntityNum.fromTopicId(newTopicId), topic);
-			transactionContext.setCreated(newTopicId);
-			transactionContext.setStatus(SUCCESS);
-		} catch (DecoderException e) {
-			log.error("DecoderException should have been hit in validatePostConsensus().", e);
-			// Should not hit this - validatePostConsensus() should fail first on hasGoodEncoding(key).
-			transactionContext.setStatus(BAD_ENCODING);
-		}
+		/* --- Persist the topic --- */
+		topicStore.persistNew(topic);
 	}
 
 	@Override
@@ -137,53 +125,23 @@ public class TopicCreateTransitionLogic implements TransitionLogic {
 
 	@Override
 	public Function<TransactionBody, ResponseCodeEnum> semanticCheck() {
-		return PRE_SIGNATURE_VALIDATION_SEMANTIC_CHECK;
+		return SEMANTIC_CHECK;
 	}
 
 	/**
 	 * Pre-consensus (and post-consensus-pre-doStateTransition) validation validates the encoding of the optional
 	 * adminKey; this check occurs before signature validation which occurs before doStateTransition.
+	 *
 	 * @param transactionBody
+	 * 		- the gRPC body
 	 * @return the validity
 	 */
-	private ResponseCodeEnum validatePreSignatureValidation(TransactionBody transactionBody) {
+	private ResponseCodeEnum validate(TransactionBody transactionBody) {
 		var op = transactionBody.getConsensusCreateTopic();
-
 		if (op.hasAdminKey() && !validator.hasGoodEncoding(op.getAdminKey())) {
 			return BAD_ENCODING;
 		}
-
 		return OK;
 	}
 
-	/**
-	 * Validation of the post-consensus transaction just prior to state transition.
-	 * @return the validity
-	 */
-	private ResponseCodeEnum validatePreStateTransition() {
-		var op = transactionContext.accessor().getTxn().getConsensusCreateTopic();
-
-		ResponseCodeEnum validationResult = validator.memoCheck(op.getMemo());
-
-		if (op.hasSubmitKey() && !validator.hasGoodEncoding(op.getSubmitKey())) {
-			validationResult = BAD_ENCODING;
-		} else if (!op.hasAutoRenewPeriod()) {
-			validationResult = INVALID_RENEWAL_PERIOD;
-		} else if (!validator.isValidAutoRenewPeriod(op.getAutoRenewPeriod())) {
-			validationResult = AUTORENEW_DURATION_NOT_IN_RANGE;
-		} else if (op.hasAutoRenewAccount()) {
-			final var reqAutoRenew = op.getAutoRenewAccount();
-			final var sanityCheck = validator.queryableAccountStatus(reqAutoRenew, accounts.get());
-			if (sanityCheck != OK) {
-				return INVALID_AUTORENEW_ACCOUNT;
-			}
-			if (ledger.isDetached(reqAutoRenew)) {
-				validationResult = ACCOUNT_EXPIRED_AND_PENDING_REMOVAL;
-			} else if (!op.hasAdminKey()) {
-				validationResult = AUTORENEW_ACCOUNT_NOT_ALLOWED;
-			}
-		}
-
-		return validationResult;
-	}
 }

--- a/hedera-node/src/main/java/com/hedera/services/txns/validation/ContextOptionValidator.java
+++ b/hedera-node/src/main/java/com/hedera/services/txns/validation/ContextOptionValidator.java
@@ -24,6 +24,8 @@ import com.hedera.services.context.TransactionContext;
 import com.hedera.services.context.annotations.CompositeProps;
 import com.hedera.services.context.properties.GlobalDynamicProperties;
 import com.hedera.services.context.properties.PropertySource;
+import com.hedera.services.exceptions.InvalidTransactionException;
+import com.hedera.services.legacy.core.jproto.JKey;
 import com.hedera.services.state.merkle.MerkleTopic;
 import com.hedera.services.utils.EntityNum;
 import com.hederahashgraph.api.proto.java.AccountID;
@@ -122,6 +124,16 @@ public class ContextOptionValidator implements OptionValidator {
 	public boolean isAcceptableTransfersLength(TransferList accountAmounts) {
 		return accountAmounts.getAccountAmountsCount() <= dynamicProperties.maxTransferListSize();
 	}
+
+	@Override
+	public JKey attemptDecodeOrThrow(final Key k) {
+		try {
+			return JKey.mapKey(k);
+		} catch (DecoderException e) {
+			throw new InvalidTransactionException(ResponseCodeEnum.BAD_ENCODING);
+		}
+	}
+	
 
 	@Override
 	public ResponseCodeEnum nftMetadataCheck(byte[] metadata) {

--- a/hedera-node/src/main/java/com/hedera/services/txns/validation/OptionValidator.java
+++ b/hedera-node/src/main/java/com/hedera/services/txns/validation/OptionValidator.java
@@ -21,6 +21,7 @@ package com.hedera.services.txns.validation;
  */
 
 import com.hedera.services.context.primitives.StateView;
+import com.hedera.services.legacy.core.jproto.JKey;
 import com.hedera.services.state.merkle.MerkleAccount;
 import com.hedera.services.state.merkle.MerkleTopic;
 import com.hedera.services.utils.EntityNum;
@@ -50,6 +51,7 @@ public interface OptionValidator {
 	boolean isAfterConsensusSecond(long now);
 	boolean isValidAutoRenewPeriod(Duration autoRenewPeriod);
 	boolean isAcceptableTransfersLength(TransferList accountAmounts);
+	JKey attemptDecodeOrThrow(Key k);
 
 	ResponseCodeEnum memoCheck(String cand);
 	ResponseCodeEnum rawMemoCheck(byte[] cand);

--- a/hedera-node/src/test/java/com/hedera/services/records/TransactionRecordServiceTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/records/TransactionRecordServiceTest.java
@@ -29,6 +29,7 @@ import com.hedera.services.store.models.Id;
 import com.hedera.services.store.models.OwnershipTracker;
 import com.hedera.services.store.models.Token;
 import com.hedera.services.store.models.TokenRelationship;
+import com.hedera.services.store.models.Topic;
 import com.hedera.test.factories.scenarios.TxnHandlingScenario;
 import com.hedera.test.utils.IdUtils;
 import com.hederahashgraph.api.proto.java.AccountAmount;
@@ -183,5 +184,12 @@ class TransactionRecordServiceTest {
 		subject.includeChangesToToken(token);
 		verify(txnCtx).setCreated(Id.DEFAULT.asGrpcToken());
 	}
-
+	
+	@Test
+	void updatesReceiptForNewTopic() {
+		final var topic = new Topic(Id.DEFAULT);
+		topic.setNew(true);
+		subject.includeChangesToTopic(topic);
+		verify(txnCtx).setCreated(Id.DEFAULT.asGrpcTopic());
+	}
 }

--- a/hedera-node/src/test/java/com/hedera/services/store/TopicStoreTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/store/TopicStoreTest.java
@@ -1,0 +1,67 @@
+package com.hedera.services.store;
+
+/*
+ * -
+ * ‌
+ * Hedera Services Node
+ * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import com.hedera.services.records.TransactionRecordService;
+import com.hedera.services.state.merkle.MerkleTopic;
+import com.hedera.services.state.submerkle.EntityId;
+import com.hedera.services.store.models.Id;
+import com.hedera.services.store.models.Topic;
+import com.hedera.services.utils.EntityNum;
+import com.swirlds.merkle.map.MerkleMap;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class TopicStoreTest {
+	@Mock
+	private MerkleMap<EntityNum, MerkleTopic> topics;
+	@Mock
+	private TransactionRecordService transactionRecordService;
+	
+	private TopicStore subject;
+	
+	@BeforeEach
+	void setup() {
+		subject	= new TopicStore(() -> topics, transactionRecordService);
+	}
+	
+	@Test
+	void persistNewAsExpected() {
+		final var mockAutoRenewId = mock(Id.class);
+		final var topic = new Topic(Id.DEFAULT);
+		topic.setAutoRenewAccountId(mockAutoRenewId);
+		given(mockAutoRenewId.asEntityId()).willReturn(EntityId.MISSING_ENTITY_ID);
+		subject.persistNew(topic);
+		
+		verify(topics).put(any(), any());
+		verify(mockAutoRenewId).asEntityId();
+	}
+	
+	@Test
+	void persistsAsExpected() {
+		
+	}
+}

--- a/hedera-node/src/test/java/com/hedera/services/store/models/IdTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/store/models/IdTest.java
@@ -70,12 +70,15 @@ class IdTest {
 		final var merkleEntityId = new MerkleEntityId(1, 2, 3);
 		final var grpcAccount = IdUtils.asAccount("1.2.3");
 		final var grpcToken = IdUtils.asToken("1.2.3");
+		final var grpcTopic = IdUtils.asTopic("1.2.3");
 
 		assertEquals(entityId, id.asEntityId());
 		assertEquals(grpcAccount, id.asGrpcAccount());
 		assertEquals(grpcToken, id.asGrpcToken());
 		assertEquals(id, Id.fromGrpcAccount(grpcAccount));
 		assertEquals(id, Id.fromGrpcToken(grpcToken));
+		assertEquals(id, Id.fromGrpcTopic(grpcTopic));
+		assertEquals(grpcTopic, id.asGrpcTopic());
 	}
 
 	@Test

--- a/hedera-node/src/test/java/com/hedera/services/store/models/TopicTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/store/models/TopicTest.java
@@ -1,0 +1,82 @@
+package com.hedera.services.store.models;
+
+/*
+ * -
+ * ‌
+ * Hedera Services Node
+ * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import com.hedera.services.state.submerkle.RichInstant;
+import com.hedera.test.factories.scenarios.TxnHandlingScenario;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class TopicTest {
+
+
+	@Test
+	void createsOkTopic() {
+		final var id = Id.DEFAULT;
+		final var autoRenew = new Account(new Id(1, 2, 3));
+		final var topic = Topic.fromGrpcTopicCreate(
+				id,
+				TxnHandlingScenario.MISC_TOPIC_SUBMIT_KT.asJKeyUnchecked(),
+				TxnHandlingScenario.MISC_TOPIC_ADMIN_KT.asJKeyUnchecked(),
+				autoRenew,
+				"memo",
+				100,
+				Instant.MAX);
+		assertNotNull(topic);
+		assertEquals(topic.getAutoRenewAccountId(), new Id(1, 2, 3));
+		assertEquals(topic.getMemo(), "memo");
+		assertEquals(topic.getId(), Id.DEFAULT);
+		assertEquals(topic.getExpirationTimestamp(), RichInstant.fromJava(Instant.MAX));
+		assertEquals(topic.getAutoRenewDurationSeconds(), 100);
+		assertEquals(topic.getSequenceNumber(), 0);
+	}
+
+	@Test
+	void objectContractWorks() {
+		final var topic = new Topic(Id.DEFAULT);
+		assertEquals(Id.DEFAULT, topic.getId());
+
+		topic.setDeleted(true);
+		assertTrue(topic.isDeleted());
+
+		topic.setAutoRenewAccountId(Id.DEFAULT);
+		assertEquals(Id.DEFAULT, topic.getAutoRenewAccountId());
+
+		topic.setMemo("memo");
+		assertEquals("memo", topic.getMemo());
+
+		topic.setExpirationTimestamp(RichInstant.MISSING_INSTANT);
+		assertEquals(RichInstant.MISSING_INSTANT, topic.getExpirationTimestamp());
+
+		assertEquals(0, topic.getSequenceNumber());
+		topic.setSequenceNumber(10);
+		assertEquals(10, topic.getSequenceNumber());
+
+		final var submitKey = TxnHandlingScenario.TOKEN_ADMIN_KT.asJKeyUnchecked();
+		topic.setSubmitKey(submitKey);
+		assertEquals(submitKey, topic.getSubmitKey());
+
+		topic.setAutoRenewDurationSeconds(10L);
+		assertEquals(10L, topic.getAutoRenewDurationSeconds());
+	}
+
+}

--- a/hedera-node/src/test/java/com/hedera/services/txns/validation/ContextOptionValidatorTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/txns/validation/ContextOptionValidatorTest.java
@@ -9,9 +9,9 @@ package com.hedera.services.txns.validation;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -58,8 +58,10 @@ import java.util.Optional;
 
 import static com.hedera.services.utils.EntityNum.fromContractId;
 import static com.hedera.test.utils.IdUtils.asFile;
+import static com.hedera.test.utils.TxnUtils.assertFailsWith;
 import static com.hedera.test.utils.TxnUtils.withAdjustments;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.ACCOUNT_DELETED;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.BAD_ENCODING;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.BATCH_SIZE_LIMIT_EXCEEDED;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.CONTRACT_DELETED;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_ACCOUNT_ID;
@@ -105,7 +107,8 @@ class ContextOptionValidatorTest {
 	final private TopicID deletedTopicId = TopicID.newBuilder().setTopicNum(2_345L).build();
 	final private TopicID expiredTopicId = TopicID.newBuilder().setTopicNum(3_456L).build();
 	final private TopicID topicId = TopicID.newBuilder().setTopicNum(4_567L).build();
-
+	PropertySource properties;
+	GlobalDynamicProperties dynamicProperties;
 	private MerkleTopic deletedMerkleTopic;
 	private MerkleTopic expiredMerkleTopic;
 	private MerkleTopic merkleTopic;
@@ -120,9 +123,6 @@ class ContextOptionValidatorTest {
 	private long expiry = 2_000_000L;
 	private long maxLifetime = 3_000_000L;
 	private FileID target = asFile("0.0.123");
-
-	PropertySource properties;
-	GlobalDynamicProperties dynamicProperties;
 
 	@BeforeEach
 	private void setup() throws Exception {
@@ -162,6 +162,12 @@ class ContextOptionValidatorTest {
 				.setDeleted(meta.isDeleted())
 				.setKeys(JKey.mapJKey(meta.getWacl()).getKeyList())
 				.build();
+	}
+
+	@Test
+	void throwsOnInvalidKey() {
+		final var k = Key.getDefaultInstance();
+		assertFailsWith(() -> subject.attemptDecodeOrThrow(k), BAD_ENCODING);
 	}
 
 	@Test
@@ -621,7 +627,7 @@ class ContextOptionValidatorTest {
 	}
 
 	@Test
-	void rejectsInvalidBurnBatchSize(){
+	void rejectsInvalidBurnBatchSize() {
 		given(dynamicProperties.maxBatchSizeBurn()).willReturn(10);
 		assertEquals(BATCH_SIZE_LIMIT_EXCEEDED, subject.maxBatchSizeBurnCheck(12));
 	}


### PR DESCRIPTION
## Description:

This **PR** introduces models to the `Topic` service. 

**New classes**:
- `TopicStore` - a store, used for loading and persisting topics
- `Topic` - a model of a `MerkleTopic`

**Checklist**:
- [ ] Documented
- [ ] E2E tested
- [ ] Unit test coverage
- [ ] Legacy code removed (if applicable)

### Note for the reviewers:
There is 1 failing e2e spec - `TopicCreateSuite.autoRenewAccountIsValidated`. It fails after the recent introduction of the `EntityNum` class. It's currently being handled in a separate **PR** - #2199 .    