### PR TITLE
Remove redundant tests to use @ParameterizedTest

### DIFF
--- a/hapi-utils/src/test/java/com/hedera/services/sysfiles/domain/throttling/ThrottleBucketTest.java
+++ b/hapi-utils/src/test/java/com/hedera/services/sysfiles/domain/throttling/ThrottleBucketTest.java
@@ -29,7 +29,6 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
-import org.junit.jupiter.params.provider.ValueSource;
 
 import java.io.IOException;
 import java.util.List;
@@ -37,6 +36,7 @@ import java.util.List;
 import static com.hederahashgraph.api.proto.java.HederaFunctionality.ContractCall;
 import static com.hederahashgraph.api.proto.java.HederaFunctionality.CryptoTransfer;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class ThrottleBucketTest {
 	@Test
@@ -62,89 +62,50 @@ class ThrottleBucketTest {
 	}
 
 	@ParameterizedTest
-	@CsvSource({"2, bootstrap/insufficient-capacity-throttles.json", "24, bootstrap/overdone-throttles.json"})
-	void failsWhenConstructingThrottlesThatNeverPermitAnOperationAtNodeLevel(final int n, final String string)
-			throws IOException {
-		final var defs = TestUtils.pojoDefs(string);
-		final var subject = defs.getBuckets().get(0);
+	@CsvSource({
+			"2, bootstrap/insufficient-capacity-throttles.json",
+			"24, bootstrap/overdone-throttles.json",
+			"1, bootstrap/undersupplied-throttles.json",
+			"1, bootstrap/never-true-throttles.json",
+			"1, bootstrap/overflow-throttles.json",
+			"1, bootstrap/repeated-op-throttles.json"
+	})
+	void failsWhenConstructingThrottlesThatNeverPermitAnOperationAtNodeLevel(
+			final int networkSize,
+			final String path
+	) throws IOException {
+		final var subject = bucketFrom(path);
 
-		Assertions.assertThrows(IllegalStateException.class, () -> subject.asThrottleMapping(n));
+		assertThrows(IllegalStateException.class, () -> subject.asThrottleMapping(networkSize));
 	}
 
 	@Test
 	void failsWhenConstructingThrottlesWithZeroGroups() {
-		Assertions.assertThrows(IllegalStateException.class, () -> new ThrottleBucket().asThrottleMapping(1));
+		final var subject = new ThrottleBucket();
+
+		assertThrows(IllegalStateException.class, () -> subject.asThrottleMapping(1));
 	}
 
-	@Test
-	void failsWhenConstructingThrottlesWithZeroOpsPerSecForAGroup() throws IOException {
-		final var n = 1;
-		final var defs = TestUtils.pojoDefs("bootstrap/undersupplied-throttles.json");
-		final var subject = defs.getBuckets().get(0);
-
-		Assertions.assertThrows(IllegalStateException.class, () -> subject.asThrottleMapping(n));
-	}
-
-	@Test
-	void constructsExpectedABucketMappingForGlobalThrottle() throws IOException {
-		final var defs = TestUtils.pojoDefs("bootstrap/throttles.json");
-		final var subject = defs.getBuckets().get(0);
+	@ParameterizedTest
+	@CsvSource({
+			"1, bootstrap/throttles.json",
+			"1, bootstrap/throttles-repeating.json",
+			"24, bootstrap/throttles.json"
+	})
+	void constructsExpectedBucketMapping(final int networkSize, final String path) throws IOException {
+		final var subject = bucketFrom(path);
 
 		/* Bucket A includes groups with opsPerSec of 12, 3000, and 10_000 so the
 		logical operations are, respectively, 30_000 / 12 = 2500, 30_000 / 3_000 = 10,
 		and 30_000 / 10_000 = 3. */
-		final var expectedThrottle = DeterministicThrottle.withTpsAndBurstPeriod(30_000, 2);
+		final var expectedThrottle = DeterministicThrottle.withTpsAndBurstPeriod(30_000 / networkSize, 2);
 		final var expectedReqs = List.of(
 				Pair.of(HederaFunctionality.CryptoTransfer, 3),
 				Pair.of(HederaFunctionality.CryptoCreate, 3),
 				Pair.of(ContractCall, 2500),
 				Pair.of(HederaFunctionality.TokenMint, 10));
 
-		final var mapping = subject.asThrottleMapping(1);
-		final var actualThrottle = mapping.getLeft();
-		final var actualReqs = mapping.getRight();
-
-		assertEquals(expectedThrottle, actualThrottle);
-		assertEquals(expectedReqs, actualReqs);
-	}
-
-	@Test
-	void constructsExpectedABucketMappingEvenWithRepetitions() throws IOException {
-		final var defs = TestUtils.pojoDefs("bootstrap/throttles-repeating.json");
-		final var subject = defs.getBuckets().get(0);
-
-		/* Bucket A includes groups with opsPerSec of 12, 3000, and 10_000 so the
-		logical operations are, respectively, 30_000 / 12 = 2500, 30_000 / 3_000 = 10,
-		and 30_000 / 10_000 = 3. */
-		final var expectedThrottle = DeterministicThrottle.withTpsAndBurstPeriod(30_000, 2);
-		final var expectedReqs = List.of(
-				Pair.of(HederaFunctionality.CryptoTransfer, 3),
-				Pair.of(HederaFunctionality.CryptoCreate, 3),
-				Pair.of(ContractCall, 2500),
-				Pair.of(HederaFunctionality.TokenMint, 10));
-
-		final var mapping = subject.asThrottleMapping(1);
-		final var actualThrottle = mapping.getLeft();
-		final var actualReqs = mapping.getRight();
-
-		assertEquals(expectedThrottle, actualThrottle);
-		assertEquals(expectedReqs, actualReqs);
-	}
-
-	@Test
-	void constructsExpectedABucketMappingForNetworkWith24Nodes() throws IOException {
-		final var n = 24;
-		final var defs = TestUtils.pojoDefs("bootstrap/throttles.json");
-
-		final var subject = defs.getBuckets().get(0);
-		final var expectedThrottle = DeterministicThrottle.withMtpsAndBurstPeriod((30_000 * 1_000) / n, 2);
-		final var expectedReqs = List.of(
-				Pair.of(HederaFunctionality.CryptoTransfer, 3),
-				Pair.of(HederaFunctionality.CryptoCreate, 3),
-				Pair.of(ContractCall, 2500),
-				Pair.of(HederaFunctionality.TokenMint, 10));
-
-		final var mapping = subject.asThrottleMapping(n);
+		final var mapping = subject.asThrottleMapping(networkSize);
 		final var actualThrottle = mapping.getLeft();
 		final var actualReqs = mapping.getRight();
 
@@ -154,9 +115,7 @@ class ThrottleBucketTest {
 
 	@Test
 	void constructedThrottleWorksAsExpected() throws InterruptedException, IOException {
-		final var defs = TestUtils.pojoDefs("bootstrap/throttles.json");
-
-		final var subject = defs.getBuckets().get(0);
+		final var subject = bucketFrom("bootstrap/throttles.json");
 		final var n = 14;
 		final var expectedXferTps = (1.0 * subject.getThrottleGroups().get(0).getOpsPerSec()) / n;
 		final var mapping = subject.asThrottleMapping(n);
@@ -172,26 +131,21 @@ class ThrottleBucketTest {
 		helper.assertTolerableTps(expectedXferTps, 1.00, opsForXfer);
 	}
 
-	private int opsForFunction(final List<Pair<HederaFunctionality, Integer>> source,
-							   final HederaFunctionality function) {
-		for (var pair : source) {
+	private static final ThrottleBucket bucketFrom(final String path) throws IOException {
+		final var defs = TestUtils.pojoDefs(path);
+		return defs.getBuckets().get(0);
+	}
+
+	private static final int opsForFunction(
+			final List<Pair<HederaFunctionality, Integer>> source,
+			final HederaFunctionality function
+	) {
+		for (final var pair : source) {
 			if (pair.getLeft() == function) {
 				return pair.getRight();
 			}
 		}
 		Assertions.fail("Function " + function + " was missing!");
 		return 0;
-	}
-
-	@ParameterizedTest
-	@ValueSource(strings = {"bootstrap/never-true-throttles.json",
-			"bootstrap/overflow-throttles.json",
-			"bootstrap/repeated-op-throttles.json"})
-	void throwOnBucketWithSmallCapacityOrOverflowingLogicalOpsOrRepeatedOp(final String string) throws IOException {
-		final var defs = TestUtils.pojoDefs(string);
-
-		final var subject = defs.getBuckets().get(0);
-
-		Assertions.assertThrows(IllegalStateException.class, () -> subject.asThrottleMapping(1));
 	}
 }

--- a/hapi-utils/src/test/java/com/hedera/services/sysfiles/domain/throttling/ThrottleBucketTest.java
+++ b/hapi-utils/src/test/java/com/hedera/services/sysfiles/domain/throttling/ThrottleBucketTest.java
@@ -27,6 +27,9 @@ import com.hederahashgraph.api.proto.java.HederaFunctionality;
 import org.apache.commons.lang3.tuple.Pair;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.io.IOException;
 import java.util.List;
@@ -38,14 +41,12 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 class ThrottleBucketTest {
 	@Test
 	void beanMethodsWork() {
-		var subject = new ThrottleBucket();
+		final var subject = new ThrottleBucket();
 
-		// when:
 		subject.setBurstPeriod(123);
 		subject.setBurstPeriodMs(123L);
 		subject.setName("Thom");
 
-		// then:
 		assertEquals(123, subject.getBurstPeriod());
 		assertEquals(123L, subject.getBurstPeriodMs());
 		assertEquals("Thom", subject.getName());
@@ -53,167 +54,126 @@ class ThrottleBucketTest {
 
 	@Test
 	void factoryWorks() throws IOException {
-		// given:
-		var proto = TestUtils.protoDefs("bootstrap/throttles.json");
+		final var proto = TestUtils.protoDefs("bootstrap/throttles.json");
 
-		// setup:
-		var bucketA = proto.getThrottleBuckets(0);
+		final var bucketA = proto.getThrottleBuckets(0);
 
-		// expect:
 		assertEquals(bucketA, ThrottleBucket.fromProto(bucketA).toProto());
 	}
 
-	@Test
-	void failsWhenConstructingMilliOpsThrottlesThatNeverPermitAnOperationAtNodeLevel() throws IOException {
-		// setup:
-		int n = 2;
-		var defs = TestUtils.pojoDefs("bootstrap/insufficient-capacity-throttles.json");
-		// and:
-		var subject = defs.getBuckets().get(0);
+	@ParameterizedTest
+	@CsvSource({"2, bootstrap/insufficient-capacity-throttles.json", "24, bootstrap/overdone-throttles.json"})
+	void failsWhenConstructingThrottlesThatNeverPermitAnOperationAtNodeLevel(final int n, final String string)
+			throws IOException {
+		final var defs = TestUtils.pojoDefs(string);
+		final var subject = defs.getBuckets().get(0);
 
-		// expect:
-		Assertions.assertThrows(IllegalStateException.class, () -> subject.asThrottleMapping(n));
-	}
-
-	@Test
-	void failsWhenConstructingThrottlesThatNeverPermitAnOperationAtNodeLevel() throws IOException {
-		// setup:
-		int n = 24;
-		var defs = TestUtils.pojoDefs("bootstrap/overdone-throttles.json");
-		// and:
-		var subject = defs.getBuckets().get(0);
-
-		// expect:
 		Assertions.assertThrows(IllegalStateException.class, () -> subject.asThrottleMapping(n));
 	}
 
 	@Test
 	void failsWhenConstructingThrottlesWithZeroGroups() {
-		// expect:
 		Assertions.assertThrows(IllegalStateException.class, () -> new ThrottleBucket().asThrottleMapping(1));
 	}
 
 	@Test
 	void failsWhenConstructingThrottlesWithZeroOpsPerSecForAGroup() throws IOException {
-		// setup:
-		int n = 1;
-		var defs = TestUtils.pojoDefs("bootstrap/undersupplied-throttles.json");
-		// and:
-		var subject = defs.getBuckets().get(0);
+		final var n = 1;
+		final var defs = TestUtils.pojoDefs("bootstrap/undersupplied-throttles.json");
+		final var subject = defs.getBuckets().get(0);
 
-		// expect:
 		Assertions.assertThrows(IllegalStateException.class, () -> subject.asThrottleMapping(n));
 	}
 
 	@Test
 	void constructsExpectedABucketMappingForGlobalThrottle() throws IOException {
-		// setup:
-		var defs = TestUtils.pojoDefs("bootstrap/throttles.json");
-		// and:
-		var subject = defs.getBuckets().get(0);
+		final var defs = TestUtils.pojoDefs("bootstrap/throttles.json");
+		final var subject = defs.getBuckets().get(0);
 
-		// and:
 		/* Bucket A includes groups with opsPerSec of 12, 3000, and 10_000 so the
 		logical operations are, respectively, 30_000 / 12 = 2500, 30_000 / 3_000 = 10,
 		and 30_000 / 10_000 = 3. */
-		var expectedThrottle = DeterministicThrottle.withTpsAndBurstPeriod(30_000, 2);
-		var expectedReqs = List.of(
+		final var expectedThrottle = DeterministicThrottle.withTpsAndBurstPeriod(30_000, 2);
+		final var expectedReqs = List.of(
 				Pair.of(HederaFunctionality.CryptoTransfer, 3),
 				Pair.of(HederaFunctionality.CryptoCreate, 3),
 				Pair.of(ContractCall, 2500),
 				Pair.of(HederaFunctionality.TokenMint, 10));
 
-		// when:
-		var mapping = subject.asThrottleMapping(1);
-		// and:
-		var actualThrottle = mapping.getLeft();
-		var actualReqs = mapping.getRight();
-		// then:
+		final var mapping = subject.asThrottleMapping(1);
+		final var actualThrottle = mapping.getLeft();
+		final var actualReqs = mapping.getRight();
+
 		assertEquals(expectedThrottle, actualThrottle);
 		assertEquals(expectedReqs, actualReqs);
 	}
 
 	@Test
 	void constructsExpectedABucketMappingEvenWithRepetitions() throws IOException {
-		// setup:
-		var defs = TestUtils.pojoDefs("bootstrap/throttles-repeating.json");
-		// and:
-		var subject = defs.getBuckets().get(0);
+		final var defs = TestUtils.pojoDefs("bootstrap/throttles-repeating.json");
+		final var subject = defs.getBuckets().get(0);
 
-		// and:
 		/* Bucket A includes groups with opsPerSec of 12, 3000, and 10_000 so the
 		logical operations are, respectively, 30_000 / 12 = 2500, 30_000 / 3_000 = 10,
 		and 30_000 / 10_000 = 3. */
-		var expectedThrottle = DeterministicThrottle.withTpsAndBurstPeriod(30_000, 2);
-		var expectedReqs = List.of(
+		final var expectedThrottle = DeterministicThrottle.withTpsAndBurstPeriod(30_000, 2);
+		final var expectedReqs = List.of(
 				Pair.of(HederaFunctionality.CryptoTransfer, 3),
 				Pair.of(HederaFunctionality.CryptoCreate, 3),
 				Pair.of(ContractCall, 2500),
 				Pair.of(HederaFunctionality.TokenMint, 10));
 
-		// when:
-		var mapping = subject.asThrottleMapping(1);
-		// and:
-		var actualThrottle = mapping.getLeft();
-		var actualReqs = mapping.getRight();
-		// then:
+		final var mapping = subject.asThrottleMapping(1);
+		final var actualThrottle = mapping.getLeft();
+		final var actualReqs = mapping.getRight();
+
 		assertEquals(expectedThrottle, actualThrottle);
 		assertEquals(expectedReqs, actualReqs);
 	}
 
 	@Test
 	void constructsExpectedABucketMappingForNetworkWith24Nodes() throws IOException {
-		// setup:
-		int n = 24;
-		var defs = TestUtils.pojoDefs("bootstrap/throttles.json");
+		final var n = 24;
+		final var defs = TestUtils.pojoDefs("bootstrap/throttles.json");
 
-		// given:
-		var subject = defs.getBuckets().get(0);
-		// and:
-		var expectedThrottle = DeterministicThrottle.withMtpsAndBurstPeriod((30_000 * 1_000) / n, 2);
-		var expectedReqs = List.of(
+		final var subject = defs.getBuckets().get(0);
+		final var expectedThrottle = DeterministicThrottle.withMtpsAndBurstPeriod((30_000 * 1_000) / n, 2);
+		final var expectedReqs = List.of(
 				Pair.of(HederaFunctionality.CryptoTransfer, 3),
 				Pair.of(HederaFunctionality.CryptoCreate, 3),
 				Pair.of(ContractCall, 2500),
 				Pair.of(HederaFunctionality.TokenMint, 10));
 
-		// when:
-		var mapping = subject.asThrottleMapping(n);
-		// and:
-		var actualThrottle = mapping.getLeft();
-		var actualReqs = mapping.getRight();
-		// then:
+		final var mapping = subject.asThrottleMapping(n);
+		final var actualThrottle = mapping.getLeft();
+		final var actualReqs = mapping.getRight();
+
 		assertEquals(expectedThrottle, actualThrottle);
 		assertEquals(expectedReqs, actualReqs);
 	}
 
 	@Test
 	void constructedThrottleWorksAsExpected() throws InterruptedException, IOException {
-		// setup:
-		var defs = TestUtils.pojoDefs("bootstrap/throttles.json");
+		final var defs = TestUtils.pojoDefs("bootstrap/throttles.json");
 
-		// given:
-		var subject = defs.getBuckets().get(0);
-		int n = 14;
-		double expectedXferTps = (1.0 * subject.getThrottleGroups().get(0).getOpsPerSec()) / n;
-		// and:
-		var mapping = subject.asThrottleMapping(n);
-		var throttle = mapping.getLeft();
-		int opsForXfer = opsForFunction(mapping.getRight(), CryptoTransfer);
+		final var subject = defs.getBuckets().get(0);
+		final var n = 14;
+		final var expectedXferTps = (1.0 * subject.getThrottleGroups().get(0).getOpsPerSec()) / n;
+		final var mapping = subject.asThrottleMapping(n);
+		final var throttle = mapping.getLeft();
+		final var opsForXfer = opsForFunction(mapping.getRight(), CryptoTransfer);
 		throttle.resetUsageTo(new DeterministicThrottle.UsageSnapshot(
 				throttle.capacity() - DeterministicThrottle.capacityRequiredFor(opsForXfer),
 				null));
 
-		// when:
-		var helper = new ConcurrentThrottleTestHelper(3, 10, opsForXfer);
-		// and:
+		final var helper = new ConcurrentThrottleTestHelper(3, 10, opsForXfer);
 		helper.runWith(throttle);
 
-		// then:
 		helper.assertTolerableTps(expectedXferTps, 1.00, opsForXfer);
 	}
 
-	private int opsForFunction(List<Pair<HederaFunctionality, Integer>> source, HederaFunctionality function) {
+	private int opsForFunction(final List<Pair<HederaFunctionality, Integer>> source,
+							   final HederaFunctionality function) {
 		for (var pair : source) {
 			if (pair.getLeft() == function) {
 				return pair.getRight();
@@ -223,39 +183,15 @@ class ThrottleBucketTest {
 		return 0;
 	}
 
-	@Test
-	void throwOnBucketWithHopelesslySmallCapacity() throws IOException {
-		// setup:
-		var defs = TestUtils.pojoDefs("bootstrap/never-true-throttles.json");
+	@ParameterizedTest
+	@ValueSource(strings = {"bootstrap/never-true-throttles.json",
+			"bootstrap/overflow-throttles.json",
+			"bootstrap/repeated-op-throttles.json"})
+	void throwOnBucketWithSmallCapacityOrOverflowingLogicalOpsOrRepeatedOp(final String string) throws IOException {
+		final var defs = TestUtils.pojoDefs(string);
 
-		// given:
-		var subject = defs.getBuckets().get(0);
+		final var subject = defs.getBuckets().get(0);
 
-		// expect:
-		Assertions.assertThrows(IllegalStateException.class, () -> subject.asThrottleMapping(1));
-	}
-
-	@Test
-	void throwOnBucketWithOverflowingLogicalOps() throws IOException {
-		// setup:
-		var defs = TestUtils.pojoDefs("bootstrap/overflow-throttles.json");
-
-		// given:
-		var subject = defs.getBuckets().get(0);
-
-		// expect:
-		Assertions.assertThrows(IllegalStateException.class, () -> subject.asThrottleMapping(1));
-	}
-
-	@Test
-	void throwOnBucketWithRepeatedOp() throws IOException {
-		// setup:
-		var defs = TestUtils.pojoDefs("bootstrap/repeated-op-throttles.json");
-
-		// given:
-		var subject = defs.getBuckets().get(0);
-
-		// expect:
 		Assertions.assertThrows(IllegalStateException.class, () -> subject.asThrottleMapping(1));
 	}
 }

--- a/hedera-node/src/main/java/com/hedera/services/fees/calculation/CongestionMultipliers.java
+++ b/hedera-node/src/main/java/com/hedera/services/fees/calculation/CongestionMultipliers.java
@@ -29,9 +29,9 @@ public class CongestionMultipliers {
 	private final int[] usagePercentTriggers;
 	private final long[] multipliers;
 
-	public static CongestionMultipliers from(String csv) {
-		List<Integer> triggers = new ArrayList<>();
-		List<Long> multipliers = new ArrayList<>();
+	public static CongestionMultipliers from(final String csv) {
+		final List<Integer> triggers = new ArrayList<>();
+		final List<Long> multipliers = new ArrayList<>();
 
 		var sb = new StringBuilder();
 		boolean nextTokenIsTrigger = true;
@@ -61,10 +61,10 @@ public class CongestionMultipliers {
 	}
 
 	private static void append(
-			List<Integer> triggers,
-			List<Long> multipliers,
-			String token,
-			boolean nextTokenIsTrigger
+			final List<Integer> triggers,
+			final List<Long> multipliers,
+			final String token,
+			final boolean nextTokenIsTrigger
 	) {
 		if (nextTokenIsTrigger) {
 			triggers.add(triggerFrom(token));
@@ -73,7 +73,7 @@ public class CongestionMultipliers {
 		}
 	}
 
-	private static <T extends Comparable<T>> void assertIncreasing(List<T> vals, String desc) {
+	private static <T extends Comparable<T>> void assertIncreasing(final List<T> vals, final String desc) {
 		for (int i = 0, n = vals.size() - 1; i < n; i++) {
 			T a = vals.get(i);
 			T b = vals.get(i + 1);
@@ -83,8 +83,8 @@ public class CongestionMultipliers {
 		}
 	}
 
-	private static Long multiplierFrom(String s) {
-		var multiplier = s.endsWith("x") ?
+	private static Long multiplierFrom(final String s) {
+		final var multiplier = s.endsWith("x") ?
 				Long.valueOf(sansDecimals(s.substring(0, s.length() - 1))) :
 				Long.valueOf(sansDecimals(s));
 		if (multiplier <= 0) {
@@ -93,15 +93,15 @@ public class CongestionMultipliers {
 		return multiplier;
 	}
 
-	private static Integer triggerFrom(String s) {
-		var trigger = Integer.valueOf(sansDecimals(s));
+	private static Integer triggerFrom(final String s) {
+		final var trigger = Integer.valueOf(sansDecimals(s));
 		if (trigger <= 0 || trigger > 100) {
 			throw new IllegalArgumentException("Cannot use trigger value " + trigger + "!");
 		}
 		return trigger;
 	}
 
-	private static String sansDecimals(String s) {
+	private static String sansDecimals(final String s) {
 		int i;
 		if ((i = s.indexOf(".")) == -1) {
 			return s;
@@ -110,7 +110,7 @@ public class CongestionMultipliers {
 		}
 	}
 
-	private CongestionMultipliers(int[] usagePercentTriggers, long[] multipliers) {
+	private CongestionMultipliers(final int[] usagePercentTriggers, final long[] multipliers) {
 		this.usagePercentTriggers = usagePercentTriggers;
 		this.multipliers = multipliers;
 	}
@@ -129,21 +129,21 @@ public class CongestionMultipliers {
 	}
 
 	@Override
-	public boolean equals(Object o) {
+	public boolean equals(final Object o) {
 		if (o == this) {
 			return true;
 		}
 		if (o == null || !o.getClass().equals(CongestionMultipliers.class)) {
 			return false;
 		}
-		CongestionMultipliers that = (CongestionMultipliers) o;
+		final var that = (CongestionMultipliers) o;
 		return Arrays.equals(this.multipliers, that.multipliers) &&
 				Arrays.equals(this.usagePercentTriggers, that.usagePercentTriggers);
 	}
 
 	@Override
 	public String toString() {
-		var sb = new StringBuilder("CongestionMultipliers{");
+		final var sb = new StringBuilder("CongestionMultipliers{");
 		for (int i = 0; i < multipliers.length; i++) {
 			sb.append(multipliers[i]).append("x @ >=").append(usagePercentTriggers[i]).append("%")
 					.append((i == multipliers.length - 1) ? "" : ", ");

--- a/hedera-node/src/main/java/com/hedera/services/fees/calculation/CongestionMultipliers.java
+++ b/hedera-node/src/main/java/com/hedera/services/fees/calculation/CongestionMultipliers.java
@@ -9,9 +9,9 @@ package com.hedera.services.fees.calculation;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -25,7 +25,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 
-public class CongestionMultipliers {
+public final class CongestionMultipliers {
 	private final int[] usagePercentTriggers;
 	private final long[] multipliers;
 
@@ -36,7 +36,7 @@ public class CongestionMultipliers {
 		var sb = new StringBuilder();
 		boolean nextTokenIsTrigger = true;
 		for (int i = 0, n = csv.length(); i < n; i++) {
-			char here = csv.charAt(i);
+			final var here = csv.charAt(i);
 			if (here == ',') {
 				append(triggers, multipliers, sb.toString(), nextTokenIsTrigger);
 				nextTokenIsTrigger = !nextTokenIsTrigger;
@@ -75,8 +75,8 @@ public class CongestionMultipliers {
 
 	private static <T extends Comparable<T>> void assertIncreasing(final List<T> vals, final String desc) {
 		for (int i = 0, n = vals.size() - 1; i < n; i++) {
-			T a = vals.get(i);
-			T b = vals.get(i + 1);
+			final var a = vals.get(i);
+			final var b = vals.get(i + 1);
 			if (a.compareTo(b) >= 0) {
 				throw new IllegalArgumentException("Given " + desc + " are not strictly increasing!");
 			}
@@ -84,9 +84,9 @@ public class CongestionMultipliers {
 	}
 
 	private static Long multiplierFrom(final String s) {
-		final var multiplier = s.endsWith("x") ?
-				Long.valueOf(sansDecimals(s.substring(0, s.length() - 1))) :
-				Long.valueOf(sansDecimals(s));
+		final var multiplier = s.endsWith("x")
+				? Long.valueOf(sansDecimals(s.substring(0, s.length() - 1)))
+				: Long.valueOf(sansDecimals(s));
 		if (multiplier <= 0) {
 			throw new IllegalArgumentException("Cannot use multiplier value " + multiplier + "!");
 		}
@@ -102,12 +102,11 @@ public class CongestionMultipliers {
 	}
 
 	private static String sansDecimals(final String s) {
-		int i;
-		if ((i = s.indexOf(".")) == -1) {
+		final var i = s.indexOf(".");
+		if (-1 == i) {
 			return s;
-		} else {
-			return s.substring(0, i);
 		}
+		return s.substring(0, i);
 	}
 
 	private CongestionMultipliers(final int[] usagePercentTriggers, final long[] multipliers) {

--- a/hedera-node/src/test/java/com/hedera/services/fees/calculation/CongestionMultipliersTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/fees/calculation/CongestionMultipliersTest.java
@@ -52,10 +52,18 @@ class CongestionMultipliersTest {
 	}
 
 	@ParameterizedTest
-	@ValueSource(strings = {"90,10x,95,25x,99,-100", "90,10x,95,25x,99", "90,x,95,25x,99,100x",
-			"90,10x,950,25x,99,100x", "90,10x,95,25x,,100x", "90,10x,95,25x,99x,100x", "90,10y,95,25x,99,100x",
-			"90,10,95,25,94,100", "90,10,95,25,99,24"})
-	void throwsOnVariousMultipliersAndTriggers(final String prop) {
+	@ValueSource(strings = {
+			"90,10x,95,25x,99,-100",
+			"90,10x,95,25x,99",
+			"90,x,95,25x,99,100x",
+			"90,10x,950,25x,99,100x",
+			"90,10x,95,25x,,100x",
+			"90,10x,95,25x,99x,100x",
+			"90,10y,95,25x,99,100x",
+			"90,10,95,25,94,100",
+			"90,10,95,25,99,24"
+	})
+	void throwsOnMalformedProps(final String prop) {
 		assertThrows(IllegalArgumentException.class, () -> CongestionMultipliers.from(prop));
 	}
 

--- a/hedera-node/src/test/java/com/hedera/services/fees/calculation/CongestionMultipliersTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/fees/calculation/CongestionMultipliersTest.java
@@ -21,6 +21,8 @@ package com.hedera.services.fees.calculation;
  */
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -49,66 +51,11 @@ class CongestionMultipliersTest {
 		assertEquals(cm, cmFloat);
 	}
 
-	@Test
-	void throwsOnNonPositiveMultiplier() {
-		final var prop = "90,10x,95,25x,99,-100";
-
-		assertThrows(IllegalArgumentException.class, () -> CongestionMultipliers.from(prop));
-	}
-
-	@Test
-	void throwsOnOmittedLastMultiplier() {
-		final var prop = "90,10x,95,25x,99";
-
-		assertThrows(IllegalArgumentException.class, () -> CongestionMultipliers.from(prop));
-	}
-
-	@Test
-	void throwsOnMissingMultiplier() {
-		final var prop = "90,x,95,25x,99,100x";
-
-		assertThrows(IllegalArgumentException.class, () -> CongestionMultipliers.from(prop));
-	}
-
-	@Test
-	void throwsOnNonsenseTrigger() {
-		final var prop = "90,10x,950,25x,99,100x";
-
-		assertThrows(IllegalArgumentException.class, () -> CongestionMultipliers.from(prop));
-	}
-
-	@Test
-	void throwsOnMissingTrigger() {
-		final var prop = "90,10x,95,25x,,100x";
-
-		assertThrows(IllegalArgumentException.class, () -> CongestionMultipliers.from(prop));
-	}
-
-	@Test
-	void throwsOnMalformedTrigger() {
-		final var prop = "90,10x,95,25x,99x,100x";
-
-		assertThrows(IllegalArgumentException.class, () -> CongestionMultipliers.from(prop));
-	}
-
-	@Test
-	void throwsOnUnparseableMultiplier() {
-		final var prop = "90,10y,95,25x,99,100x";
-
-		assertThrows(IllegalArgumentException.class, () -> CongestionMultipliers.from(prop));
-	}
-
-	@Test
-	void throwsOnNonincreasingTriggers() {
-		final var prop = "90,10,95,25,94,100";
-
-		assertThrows(IllegalArgumentException.class, () -> CongestionMultipliers.from(prop));
-	}
-
-	@Test
-	void throwsOnNonincreasingMultipliers() {
-		final var prop = "90,10,95,25,99,24";
-
+	@ParameterizedTest
+	@ValueSource(strings = {"90,10x,95,25x,99,-100", "90,10x,95,25x,99", "90,x,95,25x,99,100x",
+			"90,10x,950,25x,99,100x", "90,10x,95,25x,,100x", "90,10x,95,25x,99x,100x", "90,10y,95,25x,99,100x",
+			"90,10,95,25,94,100", "90,10,95,25,99,24"})
+	void throwsOnVariousMultipliersAndTriggers(final String prop) {
 		assertThrows(IllegalArgumentException.class, () -> CongestionMultipliers.from(prop));
 	}
 


### PR DESCRIPTION
**Description**:
This PR adds @ParameterizedTest to similar test functions that vary simply by arguments. Also modifies `ThrottleBucket` and `CongestionMultipliers` to make variables `final` and `private`.

**Related issue(s)**:

Fixes #2169 

**Checklist**

- [X] Documented (Code comments, README, etc.)
- [X] Tested (unit, integration, etc.)
