### PR TITLE
Replace non-compliant charsets with StandardCharsets.UTF_8

### DIFF
--- a/hapi-fees/src/main/java/com/hedera/services/usage/contract/ContractGetInfoUsage.java
+++ b/hapi-fees/src/main/java/com/hedera/services/usage/contract/ContractGetInfoUsage.java
@@ -24,35 +24,35 @@ import com.hedera.services.usage.QueryUsage;
 import com.hederahashgraph.api.proto.java.Key;
 import com.hederahashgraph.api.proto.java.Query;
 
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 import static com.hedera.services.usage.contract.entities.ContractEntitySizes.CONTRACT_ENTITY_SIZES;
 import static com.hedera.services.usage.crypto.entities.CryptoEntitySizes.CRYPTO_ENTITY_SIZES;
 import static com.hederahashgraph.fee.FeeBuilder.BASIC_ENTITY_ID_SIZE;
 import static com.hederahashgraph.fee.FeeBuilder.getAccountKeyStorageSize;
 
-public class ContractGetInfoUsage extends QueryUsage {
-	private ContractGetInfoUsage(Query query) {
+public final class ContractGetInfoUsage extends QueryUsage {
+	private ContractGetInfoUsage(final Query query) {
 		super(query.getContractGetInfo().getHeader().getResponseType());
 		addTb(BASIC_ENTITY_ID_SIZE);
 		addRb(CONTRACT_ENTITY_SIZES.fixedBytesInContractRepr());
 	}
 
-	public static ContractGetInfoUsage newEstimate(Query query) {
+	public static ContractGetInfoUsage newEstimate(final Query query) {
 		return new ContractGetInfoUsage(query);
 	}
 
-	public ContractGetInfoUsage givenCurrentKey(Key key) {
+	public ContractGetInfoUsage givenCurrentKey(final Key key) {
 		addRb(getAccountKeyStorageSize(key));
 		return this;
 	}
 
-	public ContractGetInfoUsage givenCurrentMemo(String memo) {
-		addRb(memo.getBytes(Charset.forName("UTF-8")).length);
+	public ContractGetInfoUsage givenCurrentMemo(final String memo) {
+		addRb(memo.getBytes(StandardCharsets.UTF_8).length);
 		return this;
 	}
 
-	public ContractGetInfoUsage givenCurrentTokenAssocs(int count) {
+	public ContractGetInfoUsage givenCurrentTokenAssocs(final int count) {
 		addRb(count * CRYPTO_ENTITY_SIZES.bytesInTokenAssocRepr());
 		return this;
 	}

--- a/hapi-fees/src/main/java/com/hedera/services/usage/crypto/CryptoGetInfoUsage.java
+++ b/hapi-fees/src/main/java/com/hedera/services/usage/crypto/CryptoGetInfoUsage.java
@@ -24,34 +24,34 @@ import com.hedera.services.usage.QueryUsage;
 import com.hederahashgraph.api.proto.java.Key;
 import com.hederahashgraph.api.proto.java.Query;
 
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 import static com.hedera.services.usage.crypto.entities.CryptoEntitySizes.CRYPTO_ENTITY_SIZES;
 import static com.hederahashgraph.fee.FeeBuilder.BASIC_ENTITY_ID_SIZE;
 import static com.hederahashgraph.fee.FeeBuilder.getAccountKeyStorageSize;
 
-public class CryptoGetInfoUsage extends QueryUsage {
-	private CryptoGetInfoUsage(Query query) {
+public final class CryptoGetInfoUsage extends QueryUsage {
+	private CryptoGetInfoUsage(final Query query) {
 		super(query.getCryptoGetInfo().getHeader().getResponseType());
 		addTb(BASIC_ENTITY_ID_SIZE);
 		addRb(CRYPTO_ENTITY_SIZES.fixedBytesInAccountRepr());
 	}
 
-	public static CryptoGetInfoUsage newEstimate(Query query) {
+	public static CryptoGetInfoUsage newEstimate(final Query query) {
 		return new CryptoGetInfoUsage(query);
 	}
 
-	public CryptoGetInfoUsage givenCurrentKey(Key key) {
+	public CryptoGetInfoUsage givenCurrentKey(final Key key) {
 		addRb(getAccountKeyStorageSize(key));
 		return this;
 	}
 
-	public CryptoGetInfoUsage givenCurrentMemo(String memo) {
-		addRb(memo.getBytes(Charset.forName("UTF-8")).length);
+	public CryptoGetInfoUsage givenCurrentMemo(final String memo) {
+		addRb(memo.getBytes(StandardCharsets.UTF_8).length);
 		return this;
 	}
 
-	public CryptoGetInfoUsage givenCurrentTokenAssocs(int count) {
+	public CryptoGetInfoUsage givenCurrentTokenAssocs(final int count) {
 		addRb(count * CRYPTO_ENTITY_SIZES.bytesInTokenAssocRepr());
 		return this;
 	}

--- a/hapi-fees/src/test/java/com/hedera/services/usage/contract/ContractGetInfoUsageTest.java
+++ b/hapi-fees/src/test/java/com/hedera/services/usage/contract/ContractGetInfoUsageTest.java
@@ -37,7 +37,7 @@ import static com.hederahashgraph.fee.FeeBuilder.getAccountKeyStorageSize;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class ContractGetInfoUsageTest {
-	private Query query = Query.newBuilder().setContractGetInfo(ContractGetInfoQuery.getDefaultInstance()).build();
+	private final Query query = Query.newBuilder().setContractGetInfo(ContractGetInfoQuery.getDefaultInstance()).build();
 
 	private static final int NUM_TOKEN_ASSOCS = 3;
 	private static final Key KEY = KeyUtils.A_CONTRACT_KEY;

--- a/hapi-fees/src/test/java/com/hedera/services/usage/contract/ContractGetInfoUsageTest.java
+++ b/hapi-fees/src/test/java/com/hedera/services/usage/contract/ContractGetInfoUsageTest.java
@@ -39,37 +39,32 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 class ContractGetInfoUsageTest {
 	private Query query = Query.newBuilder().setContractGetInfo(ContractGetInfoQuery.getDefaultInstance()).build();
 
-	private int numTokenAssocs = 3;
-	private Key key = KeyUtils.A_CONTRACT_KEY;
-	private String memo = "Hey there!";
+	private static final int NUM_TOKEN_ASSOCS = 3;
+	private static final Key KEY = KeyUtils.A_CONTRACT_KEY;
+	private static final String MEMO = "Hey there!";
 
 	private ContractGetInfoUsage subject;
 
 	@Test
 	void getsExpectedUsage() {
-		// setup:
-		long expectedTb = BASIC_QUERY_HEADER + BASIC_ENTITY_ID_SIZE;
-		long expectedRb = BASIC_QUERY_RES_HEADER + numTokenAssocs * CRYPTO_ENTITY_SIZES.bytesInTokenAssocRepr()
+		final var expectedTb = BASIC_QUERY_HEADER + BASIC_ENTITY_ID_SIZE;
+		final var expectedRb = BASIC_QUERY_RES_HEADER + NUM_TOKEN_ASSOCS * CRYPTO_ENTITY_SIZES.bytesInTokenAssocRepr()
 				+ CONTRACT_ENTITY_SIZES.fixedBytesInContractRepr()
-				+ getAccountKeyStorageSize(key)
-				+ memo.length();
-		// and:
-		var usage = FeeComponents.newBuilder()
+				+ getAccountKeyStorageSize(KEY)
+				+ MEMO.length();
+		final var usage = FeeComponents.newBuilder()
 				.setBpt(expectedTb)
 				.setBpr(expectedRb)
 				.build();
-		var expected = ESTIMATOR_UTILS.withDefaultQueryPartitioning(usage);
+		final var expected = ESTIMATOR_UTILS.withDefaultQueryPartitioning(usage);
 
-		// given:
 		subject = ContractGetInfoUsage.newEstimate(query);
 
-		// when:
-		var actual = subject.givenCurrentKey(key)
-				.givenCurrentMemo(memo)
-				.givenCurrentTokenAssocs(numTokenAssocs)
+		final var actual = subject.givenCurrentKey(KEY)
+				.givenCurrentMemo(MEMO)
+				.givenCurrentTokenAssocs(NUM_TOKEN_ASSOCS)
 				.get();
 
-		// then:
 		assertEquals(expected, actual);
 	}
 }

--- a/hapi-fees/src/test/java/com/hedera/services/usage/crypto/CryptoGetInfoUsageTest.java
+++ b/hapi-fees/src/test/java/com/hedera/services/usage/crypto/CryptoGetInfoUsageTest.java
@@ -36,41 +36,36 @@ import static com.hederahashgraph.fee.FeeBuilder.getAccountKeyStorageSize;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class CryptoGetInfoUsageTest {
-	private Query query = Query.newBuilder().setCryptoGetInfo(CryptoGetInfoQuery.getDefaultInstance()).build();
+	private final Query query = Query.newBuilder().setCryptoGetInfo(CryptoGetInfoQuery.getDefaultInstance()).build();
 
-	private int numTokenAssocs = 3;
-	private Key key = KeyUtils.A_COMPLEX_KEY;
-	private String memo = "Hey there!";
+	private static final int NUM_TOKEN_ASSOCS = 3;
+	private static final Key KEY = KeyUtils.A_COMPLEX_KEY;
+	private static final String MEMO = "Hey there!";
 
 	private CryptoGetInfoUsage subject;
 
 	@Test
 	void getsExpectedUsage() {
-		// setup:
-		long expectedTb = BASIC_QUERY_HEADER + BASIC_ENTITY_ID_SIZE;
-		long expectedRb = BASIC_QUERY_RES_HEADER + numTokenAssocs * CRYPTO_ENTITY_SIZES.bytesInTokenAssocRepr()
+		final var expectedTb = BASIC_QUERY_HEADER + BASIC_ENTITY_ID_SIZE;
+		final var expectedRb = BASIC_QUERY_RES_HEADER + NUM_TOKEN_ASSOCS * CRYPTO_ENTITY_SIZES.bytesInTokenAssocRepr()
 				+ CRYPTO_ENTITY_SIZES.fixedBytesInAccountRepr()
-				+ getAccountKeyStorageSize(key)
-				+ memo.length()
+				+ getAccountKeyStorageSize(KEY)
+				+ MEMO.length()
 				+ BASIC_ENTITY_ID_SIZE;
-		// and:
-		var usage = FeeComponents.newBuilder()
+		final var usage = FeeComponents.newBuilder()
 				.setBpt(expectedTb)
 				.setBpr(expectedRb)
 				.build();
-		var expected = ESTIMATOR_UTILS.withDefaultQueryPartitioning(usage);
+		final var expected = ESTIMATOR_UTILS.withDefaultQueryPartitioning(usage);
 
-		// given:
 		subject = CryptoGetInfoUsage.newEstimate(query);
 
-		// when:
-		var actual = subject.givenCurrentKey(key)
+		var actual = subject.givenCurrentKey(KEY)
 				.givenCurrentlyUsingProxy()
-				.givenCurrentMemo(memo)
-				.givenCurrentTokenAssocs(numTokenAssocs)
+				.givenCurrentMemo(MEMO)
+				.givenCurrentTokenAssocs(NUM_TOKEN_ASSOCS)
 				.get();
 
-		// then:
 		assertEquals(expected, actual);
 	}
 }

--- a/hapi-utils/src/main/java/com/hederahashgraph/fee/ConsensusServiceFeeBuilder.java
+++ b/hapi-utils/src/main/java/com/hederahashgraph/fee/ConsensusServiceFeeBuilder.java
@@ -37,6 +37,9 @@ import java.time.Duration;
  * Fee builder for Consensus service transactions.
  */
 public final class ConsensusServiceFeeBuilder extends FeeBuilder {
+    private ConsensusServiceFeeBuilder() {
+        throw new UnsupportedOperationException("Utility Class");
+    }
 
     /**
      * Computes fee for ConsensusCreateTopic transaction

--- a/hapi-utils/src/main/java/com/hederahashgraph/fee/ConsensusServiceFeeBuilder.java
+++ b/hapi-utils/src/main/java/com/hederahashgraph/fee/ConsensusServiceFeeBuilder.java
@@ -20,9 +20,7 @@ package com.hederahashgraph.fee;
  * ‍
  */
 
-import com.google.common.base.Charsets;
 import com.hederahashgraph.api.proto.java.AccountID;
-import com.hederahashgraph.api.proto.java.ConsensusCreateTopicTransactionBody;
 import com.hederahashgraph.api.proto.java.ConsensusUpdateTopicTransactionBody;
 import com.hederahashgraph.api.proto.java.FeeComponents;
 import com.hederahashgraph.api.proto.java.FeeData;
@@ -32,30 +30,33 @@ import com.hederahashgraph.api.proto.java.TransactionBody;
 import com.hederahashgraph.builder.RequestBuilder;
 import com.hederahashgraph.exception.InvalidTxBodyException;
 
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
-import java.time.Instant;
 
 /**
  * Fee builder for Consensus service transactions.
  */
-public class ConsensusServiceFeeBuilder extends FeeBuilder {
+public final class ConsensusServiceFeeBuilder extends FeeBuilder {
 
     /**
      * Computes fee for ConsensusCreateTopic transaction
      *
-     * @param txBody transaction body
-     * @param sigValObj signature value object
+     * @param txBody
+     *     transaction body
+     * @param sigValObj
+     *     signature value object
      *
      * @return fee data
-     * @throws InvalidTxBodyException when transaction body is invalid
+     * @throws InvalidTxBodyException
+     *     when transaction body is invalid
      */
-    public static FeeData getConsensusCreateTopicFee(TransactionBody txBody, SigValueObj sigValObj)
+    public static FeeData getConsensusCreateTopicFee(final TransactionBody txBody, final SigValueObj sigValObj)
             throws InvalidTxBodyException {
         if (txBody == null || !txBody.hasConsensusCreateTopic()) {
             throw new InvalidTxBodyException("consensusCreateTopic field not available for Fee Calculation");
         }
-        ConsensusCreateTopicTransactionBody createTopicTxBody = txBody.getConsensusCreateTopic();
-        int variableSize = computeVariableSizedFieldsUsage(createTopicTxBody.getAdminKey(),
+        final var createTopicTxBody = txBody.getConsensusCreateTopic();
+        final var variableSize = computeVariableSizedFieldsUsage(createTopicTxBody.getAdminKey(),
                 createTopicTxBody.getSubmitKey(), createTopicTxBody.getMemo(), createTopicTxBody.hasAutoRenewAccount());
         long extraRbsServices = 0;
         if (createTopicTxBody.hasAutoRenewPeriod()) {
@@ -69,19 +70,27 @@ public class ConsensusServiceFeeBuilder extends FeeBuilder {
     }
 
     /**
-     * Computes fee for consensus update topic transaction
+     * Computes fee for ConsensusUpdateTopic transaction
      *
-     * @param txBody transaction body
-     * @param rbsIncrease rbs increase
-     * @param sigValObj signature value object
+     * @param txBody
+     *     transaction body
+     * @param rbsIncrease
+     *     rbs increase
+     * @param sigValObj
+     *     signature value object
      *
      * @return fee data
-     * @throws InvalidTxBodyException when transaction body is invalid
+     * @throws InvalidTxBodyException
+     *     when transaction body is invalid
      */
-    public static FeeData getConsensusUpdateTopicFee(TransactionBody txBody, long rbsIncrease, SigValueObj sigValObj)
+    public static FeeData getConsensusUpdateTopicFee(
+            final TransactionBody txBody, final long rbsIncrease, final SigValueObj sigValObj)
             throws InvalidTxBodyException {
-        ConsensusUpdateTopicTransactionBody updateTopicTxBody = txBody.getConsensusUpdateTopic();
-        int variableSize = computeVariableSizedFieldsUsage(updateTopicTxBody.getAdminKey(),
+        if (txBody == null || !txBody.hasConsensusUpdateTopic()) {
+            throw new InvalidTxBodyException("consensusUpdateTopic field not available for Fee Calculation");
+        }
+        final var updateTopicTxBody = txBody.getConsensusUpdateTopic();
+        final var variableSize = computeVariableSizedFieldsUsage(updateTopicTxBody.getAdminKey(),
                 updateTopicTxBody.getSubmitKey(), updateTopicTxBody.getMemo().getValue(),
                 updateTopicTxBody.hasAutoRenewAccount());
         return getTxFeeMatrices(txBody, sigValObj,
@@ -90,7 +99,7 @@ public class ConsensusServiceFeeBuilder extends FeeBuilder {
     }
 
     private static int getConsensusUpdateTopicTransactionBodySize(
-            ConsensusUpdateTopicTransactionBody updateTopicTxBody, int variableSize) {
+            final ConsensusUpdateTopicTransactionBody updateTopicTxBody, int variableSize) {
         variableSize += BASIC_ENTITY_ID_SIZE; // topicID
         if (updateTopicTxBody.hasExpirationTime()) {
             variableSize += LONG_SIZE;
@@ -105,25 +114,32 @@ public class ConsensusServiceFeeBuilder extends FeeBuilder {
      * Computes additional rbs (services) for update topic transaction. If any of the variable sized fields change,
      * or the expiration time changes, rbs for the topic may increase
      *
-     * @param txValidStartTimestamp transaction valid start timestamp
-     * @param oldAdminKey old admin key
-     * @param oldSubmitKey old submit key
-     * @param oldMemo old memo
-     * @param hasOldAutoRenewAccount boolean representing old auto renew account
-     * @param oldExpirationTimeStamp old expiration timestamp
-     * @param updateTopicTxBody update topic transaction body
+     * @param txValidStartTimestamp
+     *     transaction valid start timestamp
+     * @param oldAdminKey
+     *     old admin key
+     * @param oldSubmitKey
+     *     old submit key
+     * @param oldMemo
+     *     old memo
+     * @param hasOldAutoRenewAccount
+     *     boolean representing old auto renew account
+     * @param oldExpirationTimeStamp
+     *     old expiration timestamp
+     * @param updateTopicTxBody
+     *     update topic transaction body
      *
      * @return long representing rbs increase
      */
     public static long getUpdateTopicRbsIncrease(
-            Timestamp txValidStartTimestamp,
-            Key oldAdminKey, Key oldSubmitKey, String oldMemo, boolean hasOldAutoRenewAccount, Timestamp oldExpirationTimeStamp,
-            ConsensusUpdateTopicTransactionBody updateTopicTxBody) {
-        int oldRamBytes = getTopicRamBytes(
+            final Timestamp txValidStartTimestamp,
+            final Key oldAdminKey, final Key oldSubmitKey, final String oldMemo, final boolean hasOldAutoRenewAccount,
+            final Timestamp oldExpirationTimeStamp, final ConsensusUpdateTopicTransactionBody updateTopicTxBody) {
+        final var oldRamBytes = getTopicRamBytes(
                 computeVariableSizedFieldsUsage(oldAdminKey, oldSubmitKey, oldMemo, hasOldAutoRenewAccount));
         // If value is null, do not update memo field
-        String newMemo = updateTopicTxBody.hasMemo() ? updateTopicTxBody.getMemo().getValue() : oldMemo;
-        boolean hasNewAutoRenewAccount = hasOldAutoRenewAccount;
+        final var newMemo = updateTopicTxBody.hasMemo() ? updateTopicTxBody.getMemo().getValue() : oldMemo;
+        var hasNewAutoRenewAccount = hasOldAutoRenewAccount;
         if (updateTopicTxBody.hasAutoRenewAccount()) {  // no change if unspecified
             hasNewAutoRenewAccount = true;
             AccountID account = updateTopicTxBody.getAutoRenewAccount();
@@ -131,55 +147,60 @@ public class ConsensusServiceFeeBuilder extends FeeBuilder {
                 hasNewAutoRenewAccount = false; // cleared if set to 0.0.0
             }
         }
-        Key newAdminKey = oldAdminKey;
+        var newAdminKey = oldAdminKey;
         if (updateTopicTxBody.hasAdminKey()) { // no change if unspecified
             newAdminKey = updateTopicTxBody.getAdminKey();
             if (newAdminKey.hasKeyList() && newAdminKey.getKeyList().getKeysCount() == 0) {
                 newAdminKey = null;  // cleared if set to empty KeyList
             }
         }
-        Key newSubmitKey = oldSubmitKey;
+        var newSubmitKey = oldSubmitKey;
         if (updateTopicTxBody.hasSubmitKey()) { // no change if unspecified
             newSubmitKey = updateTopicTxBody.getSubmitKey();
             if (newSubmitKey.hasKeyList() && newSubmitKey.getKeyList().getKeysCount() == 0) {
                 newSubmitKey = null;  // cleared if set to empty KeyList
             }
         }
-        int newRamBytes = getTopicRamBytes(
+        final var newRamBytes = getTopicRamBytes(
                 computeVariableSizedFieldsUsage(newAdminKey, newSubmitKey, newMemo, hasNewAutoRenewAccount));
 
-        Timestamp newExpirationTimeStamp =
+        final var newExpirationTimeStamp =
                 updateTopicTxBody.hasExpirationTime() ? updateTopicTxBody.getExpirationTime() : oldExpirationTimeStamp;
         return calculateRbsIncrease(txValidStartTimestamp, oldRamBytes, oldExpirationTimeStamp,
                 newRamBytes, newExpirationTimeStamp);
     }
 
     private static long calculateRbsIncrease(
-            Timestamp txValidStartTimestamp, long oldRamBytes, Timestamp oldExpirationTimeStamp,
-            long newRamBytes, Timestamp newExpirationTimeStamp) {
-        Instant txValidStart = RequestBuilder.convertProtoTimeStamp(txValidStartTimestamp);
-        Instant oldExpiration = RequestBuilder.convertProtoTimeStamp(oldExpirationTimeStamp);
-        Instant newExpiration = RequestBuilder.convertProtoTimeStamp(newExpirationTimeStamp);
+            final Timestamp txValidStartTimestamp, final long oldRamBytes, final Timestamp oldExpirationTimeStamp,
+            final long newRamBytes, final Timestamp newExpirationTimeStamp) {
+        final var txValidStart = RequestBuilder.convertProtoTimeStamp(txValidStartTimestamp);
+        final var oldExpiration = RequestBuilder.convertProtoTimeStamp(oldExpirationTimeStamp);
+        final var newExpiration = RequestBuilder.convertProtoTimeStamp(newExpirationTimeStamp);
 
         // RBS which has already been paid for.
-        long oldLifetime = Math.min(MAX_ENTITY_LIFETIME, Duration.between(txValidStart, oldExpiration).getSeconds());
-        long newLifetime = Math.min(MAX_ENTITY_LIFETIME, Duration.between(txValidStart, newExpiration).getSeconds());
-        long rbsRefund = oldRamBytes * oldLifetime;
-        long rbsCharge = newRamBytes * newLifetime;
-        long netRbs = rbsCharge - rbsRefund;
+        final var oldLifetime = Math.min(MAX_ENTITY_LIFETIME,
+                Duration.between(txValidStart, oldExpiration).getSeconds());
+        final var newLifetime = Math.min(MAX_ENTITY_LIFETIME,
+                Duration.between(txValidStart, newExpiration).getSeconds());
+        final var rbsRefund = oldRamBytes * oldLifetime;
+        final var rbsCharge = newRamBytes * newLifetime;
+        final var netRbs = rbsCharge - rbsRefund;
         return netRbs > 0 ? netRbs : 0;
     }
 
     /**
      * Computes fee for consensus delete topic transaction
      *
-     * @param txBody transaction body
-     * @param sigValObj signature value object
+     * @param txBody
+     *     transaction body
+     * @param sigValObj
+     *     signature value object
      *
      * @return fee data
-     * @throws InvalidTxBodyException when transaction body is invalid
+     * @throws InvalidTxBodyException
+     *     when transaction body is invalid
      */
-    public static FeeData getConsensusDeleteTopicFee(TransactionBody txBody, SigValueObj sigValObj)
+    public static FeeData getConsensusDeleteTopicFee(final TransactionBody txBody, final SigValueObj sigValObj)
             throws InvalidTxBodyException {
         if (txBody == null || !txBody.hasConsensusDeleteTopic()) {
             throw new InvalidTxBodyException("consensusDeleteTopic field not available for Fee Calculation");
@@ -190,13 +211,14 @@ public class ConsensusServiceFeeBuilder extends FeeBuilder {
     /**
      * Given transaction specific additional rbh and bpt components, computes fee components for node, network
      * and services.
+     *
      * @throws InvalidTxBodyException
+     *     when transaction body is invalid
      */
     private static FeeData getTxFeeMatrices(
-            TransactionBody txBody, SigValueObj sigValObj, int txBodyDataSize, long extraRbsServices,
-            long extraRbsNetwork)
-            throws InvalidTxBodyException {
-        FeeComponents.Builder feeComponentsBuilder = FeeComponents.newBuilder()
+            final TransactionBody txBody, final SigValueObj sigValObj, final int txBodyDataSize,
+            final long extraRbsServices, final long extraRbsNetwork) throws InvalidTxBodyException {
+        final var feeComponentsBuilder = FeeComponents.newBuilder()
                 .setVpt(sigValObj.getTotalSigCount())
                 .setSbh(0)
                 .setGas(0)
@@ -209,15 +231,16 @@ public class ConsensusServiceFeeBuilder extends FeeBuilder {
         feeComponentsBuilder.setRbh(
                 getBaseTransactionRecordSize(txBody) * RECEIPT_STORAGE_TIME_SEC
                 + extraRbsServices);
-        long rbsNetwork = getDefaultRBHNetworkSize() + extraRbsNetwork;
+        final var rbsNetwork = getDefaultRBHNetworkSize() + extraRbsNetwork;
         return getFeeDataMatrices(feeComponentsBuilder.build(), sigValObj.getPayerAcctSigCount(), rbsNetwork);
     }
 
     /**
-     * @param variableSize value returned by {@link #computeVariableSizedFieldsUsage(Key, Key, String, boolean)}.
+     * @param variableSize
+     *     value returned by {@link #computeVariableSizedFieldsUsage(Key, Key, String, boolean)}.
      * @return Estimation of size (in bytes) used by Topic in memory.
      */
-    public static int getTopicRamBytes(int variableSize) {
+    public static int getTopicRamBytes(final int variableSize) {
         return BASIC_ENTITY_ID_SIZE +  // topicID
                 3 * LONG_SIZE +  // expirationTime, sequenceNumber, autoRenewPeriod
                 BOOL_SIZE +  // deleted
@@ -228,18 +251,22 @@ public class ConsensusServiceFeeBuilder extends FeeBuilder {
     /**
      * Compute variable sized fields usage
      *
-     * @param adminKey admin key
-     * @param submitKey submit key
-     * @param memo memo
-     * @param hasAutoRenewAccount boolean representing an auto renew account
+     * @param adminKey
+     *     admin key
+     * @param submitKey
+     *     submit key
+     * @param memo
+     *     memo
+     * @param hasAutoRenewAccount
+     *     boolean representing an auto renew account
      *
      * @return size (in bytes) used by variable sized fields in topic
      */
     public static int computeVariableSizedFieldsUsage(
-            Key adminKey, Key submitKey, String memo, boolean hasAutoRenewAccount) {
+            final Key adminKey, final Key submitKey, final String memo, final boolean hasAutoRenewAccount) {
         int size = 0;
         if (memo != null) {
-            size += memo.getBytes(Charsets.UTF_8).length;
+            size += memo.getBytes(StandardCharsets.UTF_8).length;
         }
         size += getAccountKeyStorageSize(adminKey);
         size += getAccountKeyStorageSize(submitKey);

--- a/hapi-utils/src/test/java/com/hedera/services/UtilsConstructorTest.java
+++ b/hapi-utils/src/test/java/com/hedera/services/UtilsConstructorTest.java
@@ -27,6 +27,7 @@ import com.hedera.services.sysfiles.serdes.ThrottlesJsonToProtoSerde;
 import com.hedera.services.sysfiles.validation.ErrorCodeUtils;
 import com.hedera.services.sysfiles.validation.ExpectedCustomThrottles;
 import com.hederahashgraph.builder.RequestBuilder;
+import com.hederahashgraph.fee.ConsensusServiceFeeBuilder;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -43,7 +44,8 @@ class UtilsConstructorTest {
 			ThrottlesJsonToProtoSerde.class,
 			ErrorCodeUtils.class,
 			ExpectedCustomThrottles.class,
-			RequestBuilder.class
+			RequestBuilder.class,
+			ConsensusServiceFeeBuilder.class
 	));
 
 	@Test

--- a/hapi-utils/src/test/java/com/hederahashgraph/fee/ConsensusServiceFeeBuilderTest.java
+++ b/hapi-utils/src/test/java/com/hederahashgraph/fee/ConsensusServiceFeeBuilderTest.java
@@ -22,10 +22,23 @@ package com.hederahashgraph.fee;
 
 import com.google.protobuf.ByteString;
 import com.google.protobuf.StringValue;
-import com.hederahashgraph.api.proto.java.*;
+import com.hederahashgraph.api.proto.java.AccountID;
+import com.hederahashgraph.api.proto.java.ConsensusCreateTopicTransactionBody;
+import com.hederahashgraph.api.proto.java.ConsensusDeleteTopicTransactionBody;
+import com.hederahashgraph.api.proto.java.ConsensusUpdateTopicTransactionBody;
+import com.hederahashgraph.api.proto.java.Duration;
+import com.hederahashgraph.api.proto.java.FeeComponents;
+import com.hederahashgraph.api.proto.java.FeeData;
+import com.hederahashgraph.api.proto.java.Key;
+import com.hederahashgraph.api.proto.java.KeyList;
+import com.hederahashgraph.api.proto.java.Timestamp;
+import com.hederahashgraph.api.proto.java.TopicID;
+import com.hederahashgraph.api.proto.java.TransactionBody;
 import com.hederahashgraph.exception.InvalidTxBodyException;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class ConsensusServiceFeeBuilderTest {
     private static final Key A_KEY = Key.newBuilder()
@@ -42,17 +55,17 @@ class ConsensusServiceFeeBuilderTest {
     void builderMethodsThrowException() {
         final var txnBody = TransactionBody.newBuilder().build();
 
-        Assertions.assertThrows(InvalidTxBodyException.class,
+        assertThrows(InvalidTxBodyException.class,
                 () -> ConsensusServiceFeeBuilder.getConsensusCreateTopicFee(null, null));
-        Assertions.assertThrows(InvalidTxBodyException.class,
+        assertThrows(InvalidTxBodyException.class,
                 () -> ConsensusServiceFeeBuilder.getConsensusCreateTopicFee(txnBody, null));
-        Assertions.assertThrows(InvalidTxBodyException.class,
+        assertThrows(InvalidTxBodyException.class,
                 () -> ConsensusServiceFeeBuilder.getConsensusUpdateTopicFee(null, 100L, null));
-        Assertions.assertThrows(InvalidTxBodyException.class,
+        assertThrows(InvalidTxBodyException.class,
                 () -> ConsensusServiceFeeBuilder.getConsensusUpdateTopicFee(txnBody, 100L, null));
-        Assertions.assertThrows(InvalidTxBodyException.class,
+        assertThrows(InvalidTxBodyException.class,
                 () -> ConsensusServiceFeeBuilder.getConsensusDeleteTopicFee(null, null));
-        Assertions.assertThrows(InvalidTxBodyException.class,
+        assertThrows(InvalidTxBodyException.class,
                 () -> ConsensusServiceFeeBuilder.getConsensusDeleteTopicFee(txnBody, null));
     }
 
@@ -81,8 +94,8 @@ class ConsensusServiceFeeBuilderTest {
         final var actualA = ConsensusServiceFeeBuilder.getConsensusCreateTopicFee(txnBodyA, SIG_VALUE_OBJ);
         final var actualB = ConsensusServiceFeeBuilder.getConsensusCreateTopicFee(txnBodyB, SIG_VALUE_OBJ);
 
-        Assertions.assertEquals(expectedA, actualA);
-        Assertions.assertEquals(expectedB, actualB);
+        assertEquals(expectedA, actualA);
+        assertEquals(expectedB, actualB);
     }
 
     @Test
@@ -109,8 +122,8 @@ class ConsensusServiceFeeBuilderTest {
         final var actualB = ConsensusServiceFeeBuilder.getConsensusUpdateTopicFee(txnBodyB,
                 100L, SIG_VALUE_OBJ);
 
-        Assertions.assertEquals(expectedA, actualA);
-        Assertions.assertEquals(expectedB, actualB);
+        assertEquals(expectedA, actualA);
+        assertEquals(expectedB, actualB);
     }
 
     @Test
@@ -139,8 +152,8 @@ class ConsensusServiceFeeBuilderTest {
         final var actualB = ConsensusServiceFeeBuilder.getUpdateTopicRbsIncrease(TIMESTAMP, A_KEY, A_KEY,
                 MEMO, true, TIMESTAMP, txnBodyB);
 
-        Assertions.assertEquals(0L, actualA);
-        Assertions.assertEquals(0L, actualB);
+        assertEquals(0L, actualA);
+        assertEquals(0L, actualB);
     }
 
     @Test
@@ -155,26 +168,26 @@ class ConsensusServiceFeeBuilderTest {
         final var expected = getFeeData(1L, 101L, 1L, 4L, 1L, 6L);
         final var actual = ConsensusServiceFeeBuilder.getConsensusDeleteTopicFee(txnBody, SIG_VALUE_OBJ);
 
-        Assertions.assertEquals(expected, actual);
+        assertEquals(expected, actual);
     }
 
     @Test
     void helperMethodsWork() {
         final var baseTopicRamByteSize = 100;
 
-        Assertions.assertEquals(baseTopicRamByteSize, ConsensusServiceFeeBuilder.getTopicRamBytes(0));
-        Assertions.assertEquals(baseTopicRamByteSize + 20, ConsensusServiceFeeBuilder.getTopicRamBytes(20));
+        assertEquals(baseTopicRamByteSize, ConsensusServiceFeeBuilder.getTopicRamBytes(0));
+        assertEquals(baseTopicRamByteSize + 20, ConsensusServiceFeeBuilder.getTopicRamBytes(20));
 
         final var actualWithAutoRenewAccountAndMemo = ConsensusServiceFeeBuilder.computeVariableSizedFieldsUsage(
                 A_KEY, A_KEY, MEMO, true);
         final var actualWithoutAutRenewAccountAndMemo = ConsensusServiceFeeBuilder.computeVariableSizedFieldsUsage(
                 A_KEY, A_KEY, null, false);
 
-        Assertions.assertEquals(103, actualWithAutoRenewAccountAndMemo);
-        Assertions.assertEquals(64, actualWithoutAutRenewAccountAndMemo);
+        assertEquals(103, actualWithAutoRenewAccountAndMemo);
+        assertEquals(64, actualWithoutAutRenewAccountAndMemo);
     }
 
-    private static FeeData getFeeData(final long constant, final long bpt, final long vpt,
+    private static final FeeData getFeeData(final long constant, final long bpt, final long vpt,
                                       final long bpr, final long rbhNetwork, final long rbhService) {
         return FeeData.newBuilder()
                 .setNodedata(FeeComponents.newBuilder()

--- a/hapi-utils/src/test/java/com/hederahashgraph/fee/ConsensusServiceFeeBuilderTest.java
+++ b/hapi-utils/src/test/java/com/hederahashgraph/fee/ConsensusServiceFeeBuilderTest.java
@@ -38,7 +38,7 @@ import com.hederahashgraph.exception.InvalidTxBodyException;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-public class ConsensusServiceFeeBuilderTest {
+class ConsensusServiceFeeBuilderTest {
     private static final Key A_KEY = Key.newBuilder()
             .setEd25519(ByteString.copyFromUtf8("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"))
             .build();

--- a/hapi-utils/src/test/java/com/hederahashgraph/fee/ConsensusServiceFeeBuilderTest.java
+++ b/hapi-utils/src/test/java/com/hederahashgraph/fee/ConsensusServiceFeeBuilderTest.java
@@ -22,18 +22,7 @@ package com.hederahashgraph.fee;
 
 import com.google.protobuf.ByteString;
 import com.google.protobuf.StringValue;
-import com.hederahashgraph.api.proto.java.Key;
-import com.hederahashgraph.api.proto.java.KeyList;
-import com.hederahashgraph.api.proto.java.Timestamp;
-import com.hederahashgraph.api.proto.java.AccountID;
-import com.hederahashgraph.api.proto.java.Duration;
-import com.hederahashgraph.api.proto.java.TransactionBody;
-import com.hederahashgraph.api.proto.java.FeeData;
-import com.hederahashgraph.api.proto.java.FeeComponents;
-import com.hederahashgraph.api.proto.java.ConsensusCreateTopicTransactionBody;
-import com.hederahashgraph.api.proto.java.ConsensusUpdateTopicTransactionBody;
-import com.hederahashgraph.api.proto.java.TopicID;
-import com.hederahashgraph.api.proto.java.ConsensusDeleteTopicTransactionBody;
+import com.hederahashgraph.api.proto.java.*;
 import com.hederahashgraph.exception.InvalidTxBodyException;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -69,7 +58,7 @@ class ConsensusServiceFeeBuilderTest {
 
     @Test
     void getConsensusCreateTopicFeeHappyPath() throws InvalidTxBodyException {
-        final var txnBody = TransactionBody.newBuilder()
+        final var txnBodyA = TransactionBody.newBuilder()
                 .setConsensusCreateTopic(ConsensusCreateTopicTransactionBody.newBuilder()
                         .setAdminKey(A_KEY)
                         .setSubmitKey(A_KEY)
@@ -78,62 +67,50 @@ class ConsensusServiceFeeBuilderTest {
                         .setAutoRenewPeriod(DURATION)
                         .build())
                 .build();
-
-        final var expected = FeeData.newBuilder()
-                .setNodedata(FeeComponents.newBuilder()
-                        .setConstant(1L)
-                        .setBpt(188L)
-                        .setVpt(1L)
-                        .setBpr(4L)
-                        .build())
-                .setNetworkdata(FeeComponents.newBuilder()
-                        .setConstant(1L)
-                        .setBpt(188L)
-                        .setVpt(1L)
-                        .setRbh(3L)
-                        .build())
-                .setServicedata(FeeComponents.newBuilder()
-                        .setConstant(1L)
-                        .setRbh(62L)
+        final var txnBodyB = TransactionBody.newBuilder()
+                .setConsensusCreateTopic(ConsensusCreateTopicTransactionBody.newBuilder()
+                        .setAdminKey(A_KEY)
+                        .setSubmitKey(A_KEY)
+                        .setMemo(MEMO)
+                        .setAutoRenewAccount(ACCOUNT_A)
                         .build())
                 .build();
-        final var actual = ConsensusServiceFeeBuilder.getConsensusCreateTopicFee(txnBody, SIG_VALUE_OBJ);
 
-        Assertions.assertEquals(expected, actual);
+        final var expectedA = getFeeData(1L, 188L, 1L, 4L, 3L, 62L);
+        final var expectedB = getFeeData(1L, 188L, 1L, 4L, 3L, 6L);
+        final var actualA = ConsensusServiceFeeBuilder.getConsensusCreateTopicFee(txnBodyA, SIG_VALUE_OBJ);
+        final var actualB = ConsensusServiceFeeBuilder.getConsensusCreateTopicFee(txnBodyB, SIG_VALUE_OBJ);
+
+        Assertions.assertEquals(expectedA, actualA);
+        Assertions.assertEquals(expectedB, actualB);
     }
 
     @Test
     void getConsensusUpdateTopicFeeHappyPath() throws InvalidTxBodyException {
-        final var txnBody = TransactionBody.newBuilder()
+        final var txnBodyA = TransactionBody.newBuilder()
                 .setConsensusUpdateTopic(ConsensusUpdateTopicTransactionBody.newBuilder()
                         .setMemo(StringValue.of(MEMO))
                         .setAdminKey(A_KEY)
+                        .setExpirationTime(TIMESTAMP)
                         .setAutoRenewPeriod(DURATION)
                         .build())
                 .build();
-
-        final var expected = FeeData.newBuilder()
-                .setNodedata(FeeComponents.newBuilder()
-                        .setConstant(1L)
-                        .setBpt(156L)
-                        .setVpt(1L)
-                        .setBpr(4L)
-                        .build())
-                .setNetworkdata(FeeComponents.newBuilder()
-                        .setConstant(1L)
-                        .setBpt(156L)
-                        .setVpt(1L)
-                        .setRbh(1L)
-                        .build())
-                .setServicedata(FeeComponents.newBuilder()
-                        .setConstant(1L)
-                        .setRbh(6L)
+        final var txnBodyB = TransactionBody.newBuilder()
+                .setConsensusUpdateTopic(ConsensusUpdateTopicTransactionBody.newBuilder()
+                        .setMemo(StringValue.of(MEMO))
+                        .setAdminKey(A_KEY)
                         .build())
                 .build();
-        final var actual = ConsensusServiceFeeBuilder.getConsensusUpdateTopicFee(txnBody,
+
+        final var expectedA = getFeeData(1L, 164L, 1L, 4L, 1L, 6L);
+        final var expectedB = getFeeData(1L, 148L, 1L, 4L, 1L, 6L);
+        final var actualA = ConsensusServiceFeeBuilder.getConsensusUpdateTopicFee(txnBodyA,
+                100L, SIG_VALUE_OBJ);
+        final var actualB = ConsensusServiceFeeBuilder.getConsensusUpdateTopicFee(txnBodyB,
                 100L, SIG_VALUE_OBJ);
 
-        Assertions.assertEquals(expected, actual);
+        Assertions.assertEquals(expectedA, actualA);
+        Assertions.assertEquals(expectedB, actualB);
     }
 
     @Test
@@ -144,19 +121,26 @@ class ConsensusServiceFeeBuilderTest {
                 .build();
         final var emptyAccount = AccountID.newBuilder().setAccountNum(0L).setRealmNum(0L)
                 .setShardNum(0L).build();
-        final var txnBody = ConsensusUpdateTopicTransactionBody.newBuilder()
+        final var txnBodyA = ConsensusUpdateTopicTransactionBody.newBuilder()
                 .setMemo(StringValue.of(MEMO))
                 .setAdminKey(bKey)
                 .setSubmitKey(bKey)
                 .setAutoRenewPeriod(DURATION)
                 .setAutoRenewAccount(emptyAccount)
+                .setExpirationTime(TIMESTAMP)
+                .build();
+        final var txnBodyB = ConsensusUpdateTopicTransactionBody.newBuilder()
+                .setAutoRenewPeriod(DURATION)
                 .build();
 
 
-        final var actual = ConsensusServiceFeeBuilder.getUpdateTopicRbsIncrease(TIMESTAMP, A_KEY, A_KEY,
-                MEMO, true, TIMESTAMP, txnBody);
+        final var actualA = ConsensusServiceFeeBuilder.getUpdateTopicRbsIncrease(TIMESTAMP, A_KEY, A_KEY,
+                MEMO, true, TIMESTAMP, txnBodyA);
+        final var actualB = ConsensusServiceFeeBuilder.getUpdateTopicRbsIncrease(TIMESTAMP, A_KEY, A_KEY,
+                MEMO, true, TIMESTAMP, txnBodyB);
 
-        Assertions.assertEquals(0L, actual);
+        Assertions.assertEquals(0L, actualA);
+        Assertions.assertEquals(0L, actualB);
     }
 
     @Test
@@ -168,24 +152,7 @@ class ConsensusServiceFeeBuilderTest {
                         .build())
                 .build();
 
-        final var expected = FeeData.newBuilder()
-                .setNodedata(FeeComponents.newBuilder()
-                        .setConstant(1L)
-                        .setBpt(101L)
-                        .setVpt(1L)
-                        .setBpr(4L)
-                        .build())
-                .setNetworkdata(FeeComponents.newBuilder()
-                        .setConstant(1L)
-                        .setBpt(101L)
-                        .setVpt(1L)
-                        .setRbh(1L)
-                        .build())
-                .setServicedata(FeeComponents.newBuilder()
-                        .setConstant(1L)
-                        .setRbh(6L)
-                        .build())
-                .build();
+        final var expected = getFeeData(1L, 101L, 1L, 4L, 1L, 6L);
         final var actual = ConsensusServiceFeeBuilder.getConsensusDeleteTopicFee(txnBody, SIG_VALUE_OBJ);
 
         Assertions.assertEquals(expected, actual);
@@ -194,14 +161,38 @@ class ConsensusServiceFeeBuilderTest {
     @Test
     void helperMethodsWork() {
         final var baseTopicRamByteSize = 100;
+
         Assertions.assertEquals(baseTopicRamByteSize, ConsensusServiceFeeBuilder.getTopicRamBytes(0));
         Assertions.assertEquals(baseTopicRamByteSize + 20, ConsensusServiceFeeBuilder.getTopicRamBytes(20));
 
-        final var actualWithAutoRenewAccount = ConsensusServiceFeeBuilder.computeVariableSizedFieldsUsage(
+        final var actualWithAutoRenewAccountAndMemo = ConsensusServiceFeeBuilder.computeVariableSizedFieldsUsage(
                 A_KEY, A_KEY, MEMO, true);
-        final var actualWithoutAutRenewAccount = ConsensusServiceFeeBuilder.computeVariableSizedFieldsUsage(
-                A_KEY, A_KEY, MEMO, false);
-        Assertions.assertEquals(103, actualWithAutoRenewAccount);
-        Assertions.assertEquals(79, actualWithoutAutRenewAccount);
+        final var actualWithoutAutRenewAccountAndMemo = ConsensusServiceFeeBuilder.computeVariableSizedFieldsUsage(
+                A_KEY, A_KEY, null, false);
+
+        Assertions.assertEquals(103, actualWithAutoRenewAccountAndMemo);
+        Assertions.assertEquals(64, actualWithoutAutRenewAccountAndMemo);
+    }
+
+    private static FeeData getFeeData(final long constant, final long bpt, final long vpt,
+                                      final long bpr, final long rbhNetwork, final long rbhService) {
+        return FeeData.newBuilder()
+                .setNodedata(FeeComponents.newBuilder()
+                        .setConstant(constant)
+                        .setBpt(bpt)
+                        .setVpt(vpt)
+                        .setBpr(bpr)
+                        .build())
+                .setNetworkdata(FeeComponents.newBuilder()
+                        .setConstant(constant)
+                        .setBpt(bpt)
+                        .setVpt(vpt)
+                        .setRbh(rbhNetwork)
+                        .build())
+                .setServicedata(FeeComponents.newBuilder()
+                        .setConstant(constant)
+                        .setRbh(rbhService)
+                        .build())
+                .build();
     }
 }

--- a/hapi-utils/src/test/java/com/hederahashgraph/fee/ConsensusServiceFeeBuilderTest.java
+++ b/hapi-utils/src/test/java/com/hederahashgraph/fee/ConsensusServiceFeeBuilderTest.java
@@ -1,0 +1,207 @@
+package com.hederahashgraph.fee;
+
+/*-
+ * ‌
+ * Hedera Services API Utilities
+ * ​
+ * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import com.google.protobuf.ByteString;
+import com.google.protobuf.StringValue;
+import com.hederahashgraph.api.proto.java.Key;
+import com.hederahashgraph.api.proto.java.KeyList;
+import com.hederahashgraph.api.proto.java.Timestamp;
+import com.hederahashgraph.api.proto.java.AccountID;
+import com.hederahashgraph.api.proto.java.Duration;
+import com.hederahashgraph.api.proto.java.TransactionBody;
+import com.hederahashgraph.api.proto.java.FeeData;
+import com.hederahashgraph.api.proto.java.FeeComponents;
+import com.hederahashgraph.api.proto.java.ConsensusCreateTopicTransactionBody;
+import com.hederahashgraph.api.proto.java.ConsensusUpdateTopicTransactionBody;
+import com.hederahashgraph.api.proto.java.TopicID;
+import com.hederahashgraph.api.proto.java.ConsensusDeleteTopicTransactionBody;
+import com.hederahashgraph.exception.InvalidTxBodyException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class ConsensusServiceFeeBuilderTest {
+    private static final Key A_KEY = Key.newBuilder()
+            .setEd25519(ByteString.copyFromUtf8("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"))
+            .build();
+    private static final String MEMO = "This is a memo.";
+    private static final Timestamp TIMESTAMP = Timestamp.newBuilder().setSeconds(100L).setNanos(100).build();
+    private static final AccountID ACCOUNT_A = AccountID.newBuilder().setAccountNum(3L).setRealmNum(0L)
+            .setShardNum(0L).build();
+    private static final Duration DURATION = Duration.newBuilder().setSeconds(1000L).build();
+    private static final SigValueObj SIG_VALUE_OBJ = new SigValueObj(1, 1, 1);
+
+    @Test
+    void builderMethodsThrowException() {
+        final var txnBody = TransactionBody.newBuilder().build();
+
+        Assertions.assertThrows(InvalidTxBodyException.class,
+                () -> ConsensusServiceFeeBuilder.getConsensusCreateTopicFee(null, null));
+        Assertions.assertThrows(InvalidTxBodyException.class,
+                () -> ConsensusServiceFeeBuilder.getConsensusCreateTopicFee(txnBody, null));
+        Assertions.assertThrows(InvalidTxBodyException.class,
+                () -> ConsensusServiceFeeBuilder.getConsensusUpdateTopicFee(null, 100L, null));
+        Assertions.assertThrows(InvalidTxBodyException.class,
+                () -> ConsensusServiceFeeBuilder.getConsensusUpdateTopicFee(txnBody, 100L, null));
+        Assertions.assertThrows(InvalidTxBodyException.class,
+                () -> ConsensusServiceFeeBuilder.getConsensusDeleteTopicFee(null, null));
+        Assertions.assertThrows(InvalidTxBodyException.class,
+                () -> ConsensusServiceFeeBuilder.getConsensusDeleteTopicFee(txnBody, null));
+    }
+
+    @Test
+    void getConsensusCreateTopicFeeHappyPath() throws InvalidTxBodyException {
+        final var txnBody = TransactionBody.newBuilder()
+                .setConsensusCreateTopic(ConsensusCreateTopicTransactionBody.newBuilder()
+                        .setAdminKey(A_KEY)
+                        .setSubmitKey(A_KEY)
+                        .setMemo(MEMO)
+                        .setAutoRenewAccount(ACCOUNT_A)
+                        .setAutoRenewPeriod(DURATION)
+                        .build())
+                .build();
+
+        final var expected = FeeData.newBuilder()
+                .setNodedata(FeeComponents.newBuilder()
+                        .setConstant(1L)
+                        .setBpt(188L)
+                        .setVpt(1L)
+                        .setBpr(4L)
+                        .build())
+                .setNetworkdata(FeeComponents.newBuilder()
+                        .setConstant(1L)
+                        .setBpt(188L)
+                        .setVpt(1L)
+                        .setRbh(3L)
+                        .build())
+                .setServicedata(FeeComponents.newBuilder()
+                        .setConstant(1L)
+                        .setRbh(62L)
+                        .build())
+                .build();
+        final var actual = ConsensusServiceFeeBuilder.getConsensusCreateTopicFee(txnBody, SIG_VALUE_OBJ);
+
+        Assertions.assertEquals(expected, actual);
+    }
+
+    @Test
+    void getConsensusUpdateTopicFeeHappyPath() throws InvalidTxBodyException {
+        final var txnBody = TransactionBody.newBuilder()
+                .setConsensusUpdateTopic(ConsensusUpdateTopicTransactionBody.newBuilder()
+                        .setMemo(StringValue.of(MEMO))
+                        .setAdminKey(A_KEY)
+                        .setAutoRenewPeriod(DURATION)
+                        .build())
+                .build();
+
+        final var expected = FeeData.newBuilder()
+                .setNodedata(FeeComponents.newBuilder()
+                        .setConstant(1L)
+                        .setBpt(156L)
+                        .setVpt(1L)
+                        .setBpr(4L)
+                        .build())
+                .setNetworkdata(FeeComponents.newBuilder()
+                        .setConstant(1L)
+                        .setBpt(156L)
+                        .setVpt(1L)
+                        .setRbh(1L)
+                        .build())
+                .setServicedata(FeeComponents.newBuilder()
+                        .setConstant(1L)
+                        .setRbh(6L)
+                        .build())
+                .build();
+        final var actual = ConsensusServiceFeeBuilder.getConsensusUpdateTopicFee(txnBody,
+                100L, SIG_VALUE_OBJ);
+
+        Assertions.assertEquals(expected, actual);
+    }
+
+    @Test
+    void getUpdateTopicRbsIncreaseHappyPath() {
+        final var bKey = Key.newBuilder()
+                .setEd25519(ByteString.copyFromUtf8("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"))
+                .setKeyList(KeyList.newBuilder().build())
+                .build();
+        final var emptyAccount = AccountID.newBuilder().setAccountNum(0L).setRealmNum(0L)
+                .setShardNum(0L).build();
+        final var txnBody = ConsensusUpdateTopicTransactionBody.newBuilder()
+                .setMemo(StringValue.of(MEMO))
+                .setAdminKey(bKey)
+                .setSubmitKey(bKey)
+                .setAutoRenewPeriod(DURATION)
+                .setAutoRenewAccount(emptyAccount)
+                .build();
+
+
+        final var actual = ConsensusServiceFeeBuilder.getUpdateTopicRbsIncrease(TIMESTAMP, A_KEY, A_KEY,
+                MEMO, true, TIMESTAMP, txnBody);
+
+        Assertions.assertEquals(0L, actual);
+    }
+
+    @Test
+    void getConsensusDeleteTopicFeeHappyPath() throws InvalidTxBodyException {
+        final var topicId = TopicID.newBuilder().setTopicNum(5L).setRealmNum(0L).setShardNum(0L).build();
+        final var txnBody = TransactionBody.newBuilder()
+                .setConsensusDeleteTopic(ConsensusDeleteTopicTransactionBody.newBuilder()
+                        .setTopicID(topicId)
+                        .build())
+                .build();
+
+        final var expected = FeeData.newBuilder()
+                .setNodedata(FeeComponents.newBuilder()
+                        .setConstant(1L)
+                        .setBpt(101L)
+                        .setVpt(1L)
+                        .setBpr(4L)
+                        .build())
+                .setNetworkdata(FeeComponents.newBuilder()
+                        .setConstant(1L)
+                        .setBpt(101L)
+                        .setVpt(1L)
+                        .setRbh(1L)
+                        .build())
+                .setServicedata(FeeComponents.newBuilder()
+                        .setConstant(1L)
+                        .setRbh(6L)
+                        .build())
+                .build();
+        final var actual = ConsensusServiceFeeBuilder.getConsensusDeleteTopicFee(txnBody, SIG_VALUE_OBJ);
+
+        Assertions.assertEquals(expected, actual);
+    }
+
+    @Test
+    void helperMethodsWork() {
+        final var baseTopicRamByteSize = 100;
+        Assertions.assertEquals(baseTopicRamByteSize, ConsensusServiceFeeBuilder.getTopicRamBytes(0));
+        Assertions.assertEquals(baseTopicRamByteSize + 20, ConsensusServiceFeeBuilder.getTopicRamBytes(20));
+
+        final var actualWithAutoRenewAccount = ConsensusServiceFeeBuilder.computeVariableSizedFieldsUsage(
+                A_KEY, A_KEY, MEMO, true);
+        final var actualWithoutAutRenewAccount = ConsensusServiceFeeBuilder.computeVariableSizedFieldsUsage(
+                A_KEY, A_KEY, MEMO, false);
+        Assertions.assertEquals(103, actualWithAutoRenewAccount);
+        Assertions.assertEquals(79, actualWithoutAutRenewAccount);
+    }
+}

--- a/test-clients/src/main/java/com/hedera/services/bdd/spec/HapiSpecOperation.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/spec/HapiSpecOperation.java
@@ -46,7 +46,6 @@ import com.hederahashgraph.api.proto.java.Transaction;
 import com.hederahashgraph.api.proto.java.TransactionBody;
 import com.hederahashgraph.api.proto.java.TransactionID;
 import com.hederahashgraph.api.proto.java.TransactionRecord;
-import com.hederahashgraph.fee.ConsensusServiceFeeBuilder;
 import com.hederahashgraph.fee.CryptoFeeBuilder;
 import com.hederahashgraph.fee.FeeBuilder;
 import com.hederahashgraph.fee.FileFeeBuilder;
@@ -92,7 +91,6 @@ public abstract class HapiSpecOperation {
 	protected FileFeeBuilder fileFees = new FileFeeBuilder();
 	protected CryptoFeeBuilder cryptoFees = new CryptoFeeBuilder();
 	protected SmartContractFeeBuilder scFees = new SmartContractFeeBuilder();
-	protected ConsensusServiceFeeBuilder hcsFees = new ConsensusServiceFeeBuilder();
 
 	protected boolean omitTxnId = false;
 	protected boolean loggingOff = false;
@@ -300,7 +298,7 @@ public abstract class HapiSpecOperation {
 					/ spec.ratesProvider().rates().getCentEquiv()
 					* spec.ratesProvider().rates().getHbarEquiv()
 					* HapiApiSuite.ONE_HBAR;
-			fee = Optional.of((long)tinybarFee);
+			fee = Optional.of((long) tinybarFee);
 		}
 		Consumer<TransactionBody.Builder> netDef = fee
 				.map(amount -> minDef.andThen(b -> b.setTransactionFee(amount)))

--- a/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/consensus/HapiTopicUpdate.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/consensus/HapiTopicUpdate.java
@@ -9,9 +9,9 @@ package com.hedera.services.bdd.spec.transactions.consensus;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -78,7 +78,7 @@ public class HapiTopicUpdate extends HapiTxnOp<HapiTopicUpdate> {
 	}
 
 	public HapiTopicUpdate adminKey(Key key) {
-	    newAdminKey = Optional.of(key);
+		newAdminKey = Optional.of(key);
 		return this;
 	}
 
@@ -136,7 +136,7 @@ public class HapiTopicUpdate extends HapiTxnOp<HapiTopicUpdate> {
 				spec.registry().saveKey(submitKeyName(), k);
 			}
 		});
-		try{
+		try {
 			TransactionBody txn = CommonUtils.extractTransactionBody(txnSubmitted);
 			spec.registry().saveTopicMeta(topic, txn.getConsensusUpdateTopic());
 		} catch (Exception impossible) {
@@ -151,15 +151,15 @@ public class HapiTopicUpdate extends HapiTxnOp<HapiTopicUpdate> {
 		ConsensusUpdateTopicTransactionBody opBody = spec
 				.txns()
 				.<ConsensusUpdateTopicTransactionBody, ConsensusUpdateTopicTransactionBody.Builder>body(
-					ConsensusUpdateTopicTransactionBody.class, b -> {
-						b.setTopicID(asTopicId(topic, spec));
-						topicMemo.ifPresent(memo -> b.setMemo(StringValue.of(memo)));
-						newAdminKey.ifPresent(b::setAdminKey);
-						newSubmitKey.ifPresent(b::setSubmitKey);
-						newExpiry.ifPresent(s -> b.setExpirationTime(asTimestamp(s)));
-						newAutoRenewPeriod.ifPresent(s -> b.setAutoRenewPeriod(asDuration(s)));
-						newAutoRenewAccount.ifPresent(id -> b.setAutoRenewAccount(asId(id, spec)));
-					});
+						ConsensusUpdateTopicTransactionBody.class, b -> {
+							b.setTopicID(asTopicId(topic, spec));
+							topicMemo.ifPresent(memo -> b.setMemo(StringValue.of(memo)));
+							newAdminKey.ifPresent(b::setAdminKey);
+							newSubmitKey.ifPresent(b::setSubmitKey);
+							newExpiry.ifPresent(s -> b.setExpirationTime(asTimestamp(s)));
+							newAutoRenewPeriod.ifPresent(s -> b.setAutoRenewPeriod(asDuration(s)));
+							newAutoRenewAccount.ifPresent(id -> b.setAutoRenewAccount(asId(id, spec)));
+						});
 		return b -> b.setConsensusUpdateTopic(opBody);
 	}
 
@@ -168,7 +168,9 @@ public class HapiTopicUpdate extends HapiTxnOp<HapiTopicUpdate> {
 		List<Function<HapiApiSpec, Key>> signers = new ArrayList<>();
 		signers.add(spec -> spec.registry().getKey(effectivePayer(spec)));
 		signers.add(spec -> {
-			return spec.registry().hasKey(topic) ? spec.registry().getKey(topic) : Key.getDefaultInstance();  // same as no key
+			return spec.registry().hasKey(topic)
+					? spec.registry().getKey(topic)
+					: Key.getDefaultInstance();  // same as no key
 		});
 		newAdminKey.ifPresent(key -> {
 			if (key != EMPTY_KEY) {
@@ -217,7 +219,7 @@ public class HapiTopicUpdate extends HapiTxnOp<HapiTopicUpdate> {
 			/* Create a custom activity metrics calculator based on the rbsIncrease. */
 			final long rbsIncrease = tentativeRbsIncrease;
 			FeeCalculator.ActivityMetrics metricsCalc = (txBody, sigUsage) ->
-					hcsFees.getConsensusUpdateTopicFee(txBody, rbsIncrease, sigUsage);
+					ConsensusServiceFeeBuilder.getConsensusUpdateTopicFee(txBody, rbsIncrease, sigUsage);
 
 			/* Return the net fee. */
 			return spec.fees().forActivityBasedOp(ConsensusUpdateTopic, metricsCalc, txn, numPayerKeys);


### PR DESCRIPTION
**Description**:
This PR replaces the use of `Charset.forName()` with `StandardCharsets.UTF_8`. Also added `ConsensusServiceFeeBuilderTest` and modified variables, class and their modifiers.

**Related issue(s)**:

Fixes #2166 

**Notes for reviewer**:

**Checklist**

- [X] Documented (Code comments, README, etc.)
- [X] Tested (unit, integration, etc.)
