### PR TITLE
Reorder Modifiers

### DIFF
--- a/hedera-node/src/main/java/com/hedera/services/ledger/properties/AccountProperty.java
+++ b/hedera-node/src/main/java/com/hedera/services/ledger/properties/AccountProperty.java
@@ -193,8 +193,8 @@ public enum AccountProperty implements BeanProperty<MerkleAccount> {
 	};
 
 	@Override
-	abstract public BiConsumer<MerkleAccount, Object> setter();
+	public abstract BiConsumer<MerkleAccount, Object> setter();
 
 	@Override
-	abstract public Function<MerkleAccount, Object> getter();
+	public abstract Function<MerkleAccount, Object> getter();
 }

--- a/hedera-node/src/main/java/com/hedera/services/sigs/metadata/DelegatingSigMetadataLookup.java
+++ b/hedera-node/src/main/java/com/hedera/services/sigs/metadata/DelegatingSigMetadataLookup.java
@@ -39,8 +39,6 @@ import com.hedera.services.state.merkle.MerkleTopic;
 import com.hedera.services.stats.MiscRunningAvgs;
 import com.hedera.services.stats.MiscSpeedometers;
 import com.hedera.services.utils.EntityNum;
-import com.hedera.services.utils.Pause;
-import com.hedera.services.utils.SleepingPause;
 import com.hederahashgraph.api.proto.java.AccountID;
 import com.hederahashgraph.api.proto.java.ContractID;
 import com.hederahashgraph.api.proto.java.FileID;
@@ -52,13 +50,13 @@ import com.swirlds.merkle.map.MerkleMap;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
+import static com.hedera.services.utils.SleepingPause.SLEEPING_PAUSE;
+
 /**
  * Convenience class that gives unified access to Hedera signing metadata by
  * delegating to type-specific lookups.
  */
-public class DelegatingSigMetadataLookup implements SigMetadataLookup {
-	private static final Pause pause = SleepingPause.SLEEPING_PAUSE;
-
+public final class DelegatingSigMetadataLookup implements SigMetadataLookup {
 	private final FileSigMetaLookup fileSigMetaLookup;
 	private final AccountSigMetaLookup accountSigMetaLookup;
 	private final ContractSigMetaLookup contractSigMetaLookup;
@@ -115,7 +113,7 @@ public class DelegatingSigMetadataLookup implements SigMetadataLookup {
 				accounts,
 				maxRetries,
 				retryWaitIncrementMs,
-				pause,
+				SLEEPING_PAUSE,
 				runningAvgs,
 				speedometers);
 		return new DelegatingSigMetadataLookup(
@@ -137,7 +135,8 @@ public class DelegatingSigMetadataLookup implements SigMetadataLookup {
 			final MiscRunningAvgs runningAvgs,
 			final MiscSpeedometers speedometers
 	) {
-		final var accountLookup = new RetryingAccountLookup(pause, properties, accounts, runningAvgs, speedometers);
+		final var accountLookup =
+				new RetryingAccountLookup(SLEEPING_PAUSE, properties, accounts, runningAvgs, speedometers);
 		return new DelegatingSigMetadataLookup(
 				new HfsSigMetaLookup(hfs),
 				accountLookup,

--- a/hedera-node/src/main/java/com/hedera/services/sigs/metadata/DelegatingSigMetadataLookup.java
+++ b/hedera-node/src/main/java/com/hedera/services/sigs/metadata/DelegatingSigMetadataLookup.java
@@ -57,7 +57,7 @@ import java.util.function.Supplier;
  * delegating to type-specific lookups.
  */
 public class DelegatingSigMetadataLookup implements SigMetadataLookup {
-	private final static Pause pause = SleepingPause.SLEEPING_PAUSE;
+	private static final Pause pause = SleepingPause.SLEEPING_PAUSE;
 
 	private final FileSigMetaLookup fileSigMetaLookup;
 	private final AccountSigMetaLookup accountSigMetaLookup;
@@ -68,12 +68,12 @@ public class DelegatingSigMetadataLookup implements SigMetadataLookup {
 	private final Function<ScheduleID, SafeLookupResult<ScheduleSigningMetadata>> scheduleSigMetaLookup;
 
 	public static DelegatingSigMetadataLookup backedLookupsFor(
-			HederaFs hfs,
-			BackingStore<AccountID, MerkleAccount> backingAccounts,
-			Supplier<MerkleMap<EntityNum, MerkleTopic>> topics,
-			Supplier<MerkleMap<EntityNum, MerkleAccount>> accounts,
-			Function<TokenID, SafeLookupResult<TokenSigningMetadata>> tokenLookup,
-			Function<ScheduleID, SafeLookupResult<ScheduleSigningMetadata>> scheduleSigMetaLookup
+			final HederaFs hfs,
+			final BackingStore<AccountID, MerkleAccount> backingAccounts,
+			final Supplier<MerkleMap<EntityNum, MerkleTopic>> topics,
+			final Supplier<MerkleMap<EntityNum, MerkleAccount>> accounts,
+			final Function<TokenID, SafeLookupResult<TokenSigningMetadata>> tokenLookup,
+			final Function<ScheduleID, SafeLookupResult<ScheduleSigningMetadata>> scheduleSigMetaLookup
 	) {
 		return new DelegatingSigMetadataLookup(
 				new HfsSigMetaLookup(hfs),
@@ -85,11 +85,11 @@ public class DelegatingSigMetadataLookup implements SigMetadataLookup {
 	}
 
 	public static DelegatingSigMetadataLookup defaultLookupsFor(
-			HederaFs hfs,
-			Supplier<MerkleMap<EntityNum, MerkleAccount>> accounts,
-			Supplier<MerkleMap<EntityNum, MerkleTopic>> topics,
-			Function<TokenID, SafeLookupResult<TokenSigningMetadata>> tokenLookup,
-			Function<ScheduleID, SafeLookupResult<ScheduleSigningMetadata>> scheduleLookup
+			final HederaFs hfs,
+			final Supplier<MerkleMap<EntityNum, MerkleAccount>> accounts,
+			final Supplier<MerkleMap<EntityNum, MerkleTopic>> topics,
+			final Function<TokenID, SafeLookupResult<TokenSigningMetadata>> tokenLookup,
+			final Function<ScheduleID, SafeLookupResult<ScheduleSigningMetadata>> scheduleLookup
 	) {
 		return new DelegatingSigMetadataLookup(
 				new HfsSigMetaLookup(hfs),
@@ -101,17 +101,17 @@ public class DelegatingSigMetadataLookup implements SigMetadataLookup {
 	}
 
 	public static DelegatingSigMetadataLookup defaultLookupsPlusAccountRetriesFor(
-			HederaFs hfs,
-			Supplier<MerkleMap<EntityNum, MerkleAccount>> accounts,
-			Supplier<MerkleMap<EntityNum, MerkleTopic>> topics,
-			Function<TokenID, SafeLookupResult<TokenSigningMetadata>> tokenLookup,
-			Function<ScheduleID, SafeLookupResult<ScheduleSigningMetadata>> scheduleLookup,
-			int maxRetries,
-			int retryWaitIncrementMs,
-			MiscRunningAvgs runningAvgs,
-			MiscSpeedometers speedometers
+			final HederaFs hfs,
+			final Supplier<MerkleMap<EntityNum, MerkleAccount>> accounts,
+			final Supplier<MerkleMap<EntityNum, MerkleTopic>> topics,
+			final Function<TokenID, SafeLookupResult<TokenSigningMetadata>> tokenLookup,
+			final Function<ScheduleID, SafeLookupResult<ScheduleSigningMetadata>> scheduleLookup,
+			final int maxRetries,
+			final int retryWaitIncrementMs,
+			final MiscRunningAvgs runningAvgs,
+			final MiscSpeedometers speedometers
 	) {
-		var accountLookup = new RetryingAccountLookup(
+		final var accountLookup = new RetryingAccountLookup(
 				accounts,
 				maxRetries,
 				retryWaitIncrementMs,
@@ -128,16 +128,16 @@ public class DelegatingSigMetadataLookup implements SigMetadataLookup {
 	}
 
 	public static DelegatingSigMetadataLookup defaultAccountRetryingLookupsFor(
-			HederaFs hfs,
-			NodeLocalProperties properties,
-			Supplier<MerkleMap<EntityNum, MerkleAccount>> accounts,
-			Supplier<MerkleMap<EntityNum, MerkleTopic>> topics,
-			Function<TokenID, SafeLookupResult<TokenSigningMetadata>> tokenLookup,
-			Function<ScheduleID, SafeLookupResult<ScheduleSigningMetadata>> scheduleLookup,
-			MiscRunningAvgs runningAvgs,
-			MiscSpeedometers speedometers
+			final HederaFs hfs,
+			final NodeLocalProperties properties,
+			final Supplier<MerkleMap<EntityNum, MerkleAccount>> accounts,
+			final Supplier<MerkleMap<EntityNum, MerkleTopic>> topics,
+			final Function<TokenID, SafeLookupResult<TokenSigningMetadata>> tokenLookup,
+			final Function<ScheduleID, SafeLookupResult<ScheduleSigningMetadata>> scheduleLookup,
+			final MiscRunningAvgs runningAvgs,
+			final MiscSpeedometers speedometers
 	) {
-		var accountLookup = new RetryingAccountLookup(pause, properties, accounts, runningAvgs, speedometers);
+		final var accountLookup = new RetryingAccountLookup(pause, properties, accounts, runningAvgs, speedometers);
 		return new DelegatingSigMetadataLookup(
 				new HfsSigMetaLookup(hfs),
 				accountLookup,
@@ -148,12 +148,12 @@ public class DelegatingSigMetadataLookup implements SigMetadataLookup {
 	}
 
 	public DelegatingSigMetadataLookup(
-			FileSigMetaLookup fileSigMetaLookup,
-			AccountSigMetaLookup accountSigMetaLookup,
-			ContractSigMetaLookup contractSigMetaLookup,
-			TopicSigMetaLookup topicSigMetaLookup,
-			Function<TokenID, SafeLookupResult<TokenSigningMetadata>> tokenSigMetaLookup,
-			Function<ScheduleID, SafeLookupResult<ScheduleSigningMetadata>> scheduleSigMetaLookup
+			final FileSigMetaLookup fileSigMetaLookup,
+			final AccountSigMetaLookup accountSigMetaLookup,
+			final ContractSigMetaLookup contractSigMetaLookup,
+			final TopicSigMetaLookup topicSigMetaLookup,
+			final Function<TokenID, SafeLookupResult<TokenSigningMetadata>> tokenSigMetaLookup,
+			final Function<ScheduleID, SafeLookupResult<ScheduleSigningMetadata>> scheduleSigMetaLookup
 	) {
 		this.fileSigMetaLookup = fileSigMetaLookup;
 		this.accountSigMetaLookup = accountSigMetaLookup;
@@ -164,32 +164,32 @@ public class DelegatingSigMetadataLookup implements SigMetadataLookup {
 	}
 
 	@Override
-	public SafeLookupResult<ContractSigningMetadata> contractSigningMetaFor(ContractID id) {
+	public SafeLookupResult<ContractSigningMetadata> contractSigningMetaFor(final ContractID id) {
 		return contractSigMetaLookup.safeLookup(id);
 	}
 
 	@Override
-	public SafeLookupResult<FileSigningMetadata> fileSigningMetaFor(FileID id) {
+	public SafeLookupResult<FileSigningMetadata> fileSigningMetaFor(final FileID id) {
 		return fileSigMetaLookup.safeLookup(id);
 	}
 
 	@Override
-	public SafeLookupResult<ScheduleSigningMetadata> scheduleSigningMetaFor(ScheduleID id) {
+	public SafeLookupResult<ScheduleSigningMetadata> scheduleSigningMetaFor(final ScheduleID id) {
 		return scheduleSigMetaLookup.apply(id);
 	}
 
 	@Override
-	public SafeLookupResult<AccountSigningMetadata> accountSigningMetaFor(AccountID id) {
+	public SafeLookupResult<AccountSigningMetadata> accountSigningMetaFor(final AccountID id) {
 		return accountSigMetaLookup.safeLookup(id);
 	}
 
 	@Override
-	public SafeLookupResult<TopicSigningMetadata> topicSigningMetaFor(TopicID id) {
+	public SafeLookupResult<TopicSigningMetadata> topicSigningMetaFor(final TopicID id) {
 		return topicSigMetaLookup.safeLookup(id);
 	}
 
 	@Override
-	public SafeLookupResult<TokenSigningMetadata> tokenSigningMetaFor(TokenID id) {
+	public SafeLookupResult<TokenSigningMetadata> tokenSigningMetaFor(final TokenID id) {
 		return tokenSigMetaLookup.apply(id);
 	}
 }

--- a/hedera-node/src/main/java/com/hedera/services/state/logic/AwareNodeDiligenceScreen.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/logic/AwareNodeDiligenceScreen.java
@@ -44,7 +44,7 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OK;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.PAYER_ACCOUNT_DELETED;
 
 @Singleton
-public class AwareNodeDiligenceScreen {
+public final class AwareNodeDiligenceScreen {
 	private static final Logger log = LogManager.getLogger(AwareNodeDiligenceScreen.class);
 
 	private static final String WRONG_NODE_LOG_TPL =
@@ -168,5 +168,4 @@ public class AwareNodeDiligenceScreen {
 				readableId(relatedAccount),
 				accessor.getSignedTxnWrapper());
 	}
-
 }

--- a/hedera-node/src/main/java/com/hedera/services/state/logic/AwareNodeDiligenceScreen.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/logic/AwareNodeDiligenceScreen.java
@@ -47,8 +47,10 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.PAYER_ACCOUNT_
 public class AwareNodeDiligenceScreen {
 	private static final Logger log = LogManager.getLogger(AwareNodeDiligenceScreen.class);
 
-	final static String WRONG_NODE_LOG_TPL = "Node {} (member #{}) submitted a txn meant for node account {} :: {}";
-	final static String MISSING_NODE_LOG_TPL = "Node {} (member #{}) submitted a txn w/ missing node account {} :: {}";
+	private static final String WRONG_NODE_LOG_TPL =
+			"Node {} (member #{}) submitted a txn meant for node account {} :: {}";
+	private static final String MISSING_NODE_LOG_TPL =
+			"Node {} (member #{}) submitted a txn w/ missing node account {} :: {}";
 
 	private final OptionValidator validator;
 	private final TransactionContext txnCtx;
@@ -56,21 +58,21 @@ public class AwareNodeDiligenceScreen {
 
 	@Inject
 	public AwareNodeDiligenceScreen(
-			OptionValidator validator,
-			TransactionContext txnCtx,
-			BackingStore<AccountID, MerkleAccount> backingAccounts
+			final OptionValidator validator,
+			final TransactionContext txnCtx,
+			final BackingStore<AccountID, MerkleAccount> backingAccounts
 	) {
 		this.txnCtx = txnCtx;
 		this.validator = validator;
 		this.backingAccounts = backingAccounts;
 	}
 
-	public boolean nodeIgnoredDueDiligence(DuplicateClassification duplicity) {
-		var accessor = txnCtx.accessor();
+	public boolean nodeIgnoredDueDiligence(final DuplicateClassification duplicity) {
+		final var accessor = txnCtx.accessor();
 
-		var submittingAccount = txnCtx.submittingNodeAccount();
-		var designatedAccount = accessor.getTxn().getNodeAccountID();
-		boolean designatedNodeExists = backingAccounts.contains(designatedAccount);
+		final var submittingAccount = txnCtx.submittingNodeAccount();
+		final var designatedAccount = accessor.getTxn().getNodeAccountID();
+		final var designatedNodeExists = backingAccounts.contains(designatedAccount);
 		if (!designatedNodeExists) {
 			logAccountWarning(
 					MISSING_NODE_LOG_TPL,
@@ -82,15 +84,15 @@ public class AwareNodeDiligenceScreen {
 			return true;
 		}
 
-		var payerAccountId = accessor.getPayer();
-		boolean payerAccountExists = backingAccounts.contains(payerAccountId);
+		final var payerAccountId = accessor.getPayer();
+		final var payerAccountExists = backingAccounts.contains(payerAccountId);
 
 		if (!payerAccountExists) {
 			txnCtx.setStatus(ACCOUNT_ID_DOES_NOT_EXIST);
 			return true;
 		}
 
-		var payerAccountRef = backingAccounts.getImmutableRef(payerAccountId);
+		final var payerAccountRef = backingAccounts.getImmutableRef(payerAccountId);
 
 		if (payerAccountRef.isDeleted()) {
 			txnCtx.setStatus(PAYER_ACCOUNT_DELETED);
@@ -118,19 +120,19 @@ public class AwareNodeDiligenceScreen {
 			return true;
 		}
 
-		long txnDuration = accessor.getTxn().getTransactionValidDuration().getSeconds();
+		final var txnDuration = accessor.getTxn().getTransactionValidDuration().getSeconds();
 		if (!validator.isValidTxnDuration(txnDuration)) {
 			txnCtx.setStatus(INVALID_TRANSACTION_DURATION);
 			return true;
 		}
 
-		var cronStatus = validator.chronologyStatus(accessor, txnCtx.consensusTime());
+		final var cronStatus = validator.chronologyStatus(accessor, txnCtx.consensusTime());
 		if (cronStatus != OK) {
 			txnCtx.setStatus(cronStatus);
 			return true;
 		}
 
-		var memoValidity = validator.rawMemoCheck(accessor.getMemoUtf8Bytes(), accessor.memoHasZeroByte());
+		final var memoValidity = validator.rawMemoCheck(accessor.getMemoUtf8Bytes(), accessor.memoHasZeroByte());
 		if (memoValidity != OK) {
 			txnCtx.setStatus(memoValidity);
 			return true;
@@ -154,11 +156,11 @@ public class AwareNodeDiligenceScreen {
 	 * 		transaction accessor
 	 */
 	private void logAccountWarning(
-			String message,
-			AccountID submittingNodeAccount,
-			long submittingMember,
-			AccountID relatedAccount,
-			TxnAccessor accessor
+			final String message,
+			final AccountID submittingNodeAccount,
+			final long submittingMember,
+			final AccountID relatedAccount,
+			final TxnAccessor accessor
 	) {
 		log.warn(message,
 				readableId(submittingNodeAccount),

--- a/hedera-node/src/test/java/com/hedera/services/ledger/properties/MerkleAccountPropertyTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/ledger/properties/MerkleAccountPropertyTest.java
@@ -74,7 +74,6 @@ class MerkleAccountPropertyTest {
 	void tokenGetterWorksWithNewFcmParadigm() {
 		final var ids = new CopyOnWriteIds(new long[] { 1, 2, 3 });
 		final var copyResult = new MerkleAccountTokens(ids);
-
 		given(mockAccountTokens.tmpNonMerkleCopy()).willReturn(copyResult);
 		given(mockAccount.tokens()).willReturn(mockAccountTokens);
 
@@ -87,7 +86,6 @@ class MerkleAccountPropertyTest {
 	void tokenSetterWorksWithNewFcmParadigm() {
 		final var ids = new CopyOnWriteIds(new long[] { 1, 2, 3, 4, 5, 6 });
 		final var newTokens = new MerkleAccountTokens(ids);
-
 		given(mockAccount.tokens()).willReturn(mockAccountTokens);
 
 		TOKENS.setter().accept(mockAccount, newTokens);
@@ -116,7 +114,7 @@ class MerkleAccountPropertyTest {
 		final boolean origIsContract = false;
 		final long origBalance = 1L;
 		final long origAutoRenew = 1L;
-		final long origNumNfts = 123;
+		final long origNumNfts = 123L;
 		final long origExpiry = 1L;
 		final int origMaxAutoAssociations = 10;
 		final int origAlreadyUsedAutoAssociations = 7;
@@ -135,7 +133,7 @@ class MerkleAccountPropertyTest {
 		final long newBalance = 2L;
 		final long newAutoRenew = 2L;
 		final long newExpiry = 2L;
-		final long newNumNfts = 321;
+		final long newNumNfts = 321L;
 		final int newMaxAutoAssociations = 15;
 		final int newAlreadyUsedAutoAssociations = 11;
 		final JKey newKey = new JKeyList();

--- a/hedera-node/src/test/java/com/hedera/services/ledger/properties/MerkleAccountPropertyTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/ledger/properties/MerkleAccountPropertyTest.java
@@ -31,7 +31,6 @@ import com.hedera.services.state.submerkle.EntityId;
 import com.hedera.services.state.submerkle.ExpirableTxnRecord;
 import com.hedera.test.factories.txns.SignedTxnFactory;
 import com.hederahashgraph.api.proto.java.AccountID;
-import com.hederahashgraph.api.proto.java.Key;
 import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
 import com.hederahashgraph.api.proto.java.TransactionReceipt;
 import com.hederahashgraph.api.proto.java.TransactionRecord;
@@ -73,38 +72,31 @@ class MerkleAccountPropertyTest {
 
 	@Test
 	void tokenGetterWorksWithNewFcmParadigm() {
-		// setup:
 		final var ids = new CopyOnWriteIds(new long[] { 1, 2, 3 });
 		final var copyResult = new MerkleAccountTokens(ids);
 
 		given(mockAccountTokens.tmpNonMerkleCopy()).willReturn(copyResult);
 		given(mockAccount.tokens()).willReturn(mockAccountTokens);
 
-		// when:
 		final var result = TOKENS.getter().apply(mockAccount);
 
-		// then:
 		assertSame(copyResult, result);
 	}
 
 	@Test
 	void tokenSetterWorksWithNewFcmParadigm() {
-		// setup:
 		final var ids = new CopyOnWriteIds(new long[] { 1, 2, 3, 4, 5, 6 });
 		final var newTokens = new MerkleAccountTokens(ids);
 
 		given(mockAccount.tokens()).willReturn(mockAccountTokens);
 
-		// when:
 		TOKENS.setter().accept(mockAccount, newTokens);
 
-		// then:
 		verify(mockAccountTokens).shareTokensOf(newTokens);
 	}
 
 	@Test
 	void cannotSetNegativeBalance() {
-		// expect:
 		assertThrows(
 				IllegalArgumentException.class,
 				() -> BALANCE.setter().accept(new MerkleAccount(), -1L));
@@ -112,7 +104,6 @@ class MerkleAccountPropertyTest {
 
 	@Test
 	void cannotConvertNonNumericObjectToBalance() {
-		// expect:
 		assertThrows(
 				IllegalArgumentException.class,
 				() -> BALANCE.setter().accept(new MerkleAccount(), "NotNumeric"));
@@ -120,40 +111,38 @@ class MerkleAccountPropertyTest {
 
 	@Test
 	void gettersAndSettersWork() throws Exception {
-		// given:
-		boolean origIsDeleted = false;
-		boolean origIsReceiverSigReq = false;
-		boolean origIsContract = false;
-		long origBalance = 1L;
-		long origAutoRenew = 1L;
-		long origNumNfts = 123;
-		long origExpiry = 1L;
-		int origMaxAutoAssociations = 10;
-		int origAlreadyUsedAutoAssociations = 7;
-		Key origKey = SignedTxnFactory.DEFAULT_PAYER_KT.asKey();
-		String origMemo = "a";
-		AccountID origProxy = AccountID.getDefaultInstance();
-		List<ExpirableTxnRecord> origRecords = new ArrayList<>();
+		final boolean origIsDeleted = false;
+		final boolean origIsReceiverSigReq = false;
+		final boolean origIsContract = false;
+		final long origBalance = 1L;
+		final long origAutoRenew = 1L;
+		final long origNumNfts = 123;
+		final long origExpiry = 1L;
+		final int origMaxAutoAssociations = 10;
+		final int origAlreadyUsedAutoAssociations = 7;
+		final var origKey = SignedTxnFactory.DEFAULT_PAYER_KT.asKey();
+		final String origMemo = "a";
+		final var origProxy = AccountID.getDefaultInstance();
+		final List<ExpirableTxnRecord> origRecords = new ArrayList<>();
 		origRecords.add(expirableRecord(ResponseCodeEnum.MODIFYING_IMMUTABLE_CONTRACT));
 		origRecords.add(expirableRecord(ResponseCodeEnum.INVALID_PAYER_SIGNATURE));
-		List<ExpirableTxnRecord> origPayerRecords = new ArrayList<>();
+		final List<ExpirableTxnRecord> origPayerRecords = new ArrayList<>();
 		origPayerRecords.add(expirableRecord(ResponseCodeEnum.INVALID_CHUNK_NUMBER));
 		origPayerRecords.add(expirableRecord(ResponseCodeEnum.INSUFFICIENT_TX_FEE));
-		// and:
-		boolean newIsDeleted = true;
-		boolean newIsReceiverSigReq = true;
-		boolean newIsContract = true;
-		long newBalance = 2L;
-		long newAutoRenew = 2L;
-		long newExpiry = 2L;
-		long newNumNfts = 321;
-		int newMaxAutoAssociations = 15;
-		int newAlreadyUsedAutoAssociations = 11;
-		JKey newKey = new JKeyList();
-		String newMemo = "b";
-		EntityId newProxy = new EntityId(0, 0, 2);
-		// and:
-		MerkleAccount account = new HederaAccountCustomizer()
+		final boolean newIsDeleted = true;
+		final boolean newIsReceiverSigReq = true;
+		final boolean newIsContract = true;
+		final long newBalance = 2L;
+		final long newAutoRenew = 2L;
+		final long newExpiry = 2L;
+		final long newNumNfts = 321;
+		final int newMaxAutoAssociations = 15;
+		final int newAlreadyUsedAutoAssociations = 11;
+		final JKey newKey = new JKeyList();
+		final String newMemo = "b";
+		final EntityId newProxy = new EntityId(0, 0, 2);
+
+		final var account = new HederaAccountCustomizer()
 				.key(JKey.mapKey(origKey))
 				.expiry(origExpiry)
 				.proxy(EntityId.fromGrpcAccountId(origProxy))
@@ -169,22 +158,21 @@ class MerkleAccountPropertyTest {
 		account.records().offer(origPayerRecords.get(1));
 		account.setMaxAutomaticAssociations(origMaxAutoAssociations);
 		account.setAlreadyUsedAutomaticAssociations(origAlreadyUsedAutoAssociations);
-		// and:
-		var adminKey = TOKEN_ADMIN_KT.asJKeyUnchecked();
-		var unfrozenToken = new MerkleToken(
+
+		final var adminKey = TOKEN_ADMIN_KT.asJKeyUnchecked();
+		final var unfrozenToken = new MerkleToken(
 				Long.MAX_VALUE, 100, 1,
 				"UnfrozenToken", "UnfrozenTokenName", false, true,
 				new EntityId(1, 2, 3));
 		unfrozenToken.setFreezeKey(adminKey);
 		unfrozenToken.setKycKey(adminKey);
-		var frozenToken = new MerkleToken(
+		final var frozenToken = new MerkleToken(
 				Long.MAX_VALUE, 100, 1,
 				"FrozenToken", "FrozenTokenName", true, false,
 				new EntityId(1, 2, 3));
 		frozenToken.setFreezeKey(adminKey);
 		frozenToken.setKycKey(adminKey);
 
-		// expect:
 		IS_DELETED.setter().accept(account, newIsDeleted);
 		IS_RECEIVER_SIG_REQUIRED.setter().accept(account, newIsReceiverSigReq);
 		IS_SMART_CONTRACT.setter().accept(account, newIsContract);
@@ -198,7 +186,6 @@ class MerkleAccountPropertyTest {
 		MAX_AUTOMATIC_ASSOCIATIONS.setter().accept(account, newMaxAutoAssociations);
 		ALREADY_USED_AUTOMATIC_ASSOCIATIONS.setter().accept(account, newAlreadyUsedAutoAssociations);
 
-		// then:
 		assertEquals(newIsDeleted, IS_DELETED.getter().apply(account));
 		assertEquals(newIsReceiverSigReq, IS_RECEIVER_SIG_REQUIRED.getter().apply(account));
 		assertEquals(newIsContract, IS_SMART_CONTRACT.getter().apply(account));
@@ -213,7 +200,7 @@ class MerkleAccountPropertyTest {
 		assertEquals(newMaxAutoAssociations, MAX_AUTOMATIC_ASSOCIATIONS.getter().apply(account));
 	}
 
-	private ExpirableTxnRecord expirableRecord(ResponseCodeEnum status) {
+	private ExpirableTxnRecord expirableRecord(final ResponseCodeEnum status) {
 		return fromGprc(
 				TransactionRecord.newBuilder()
 						.setReceipt(TransactionReceipt.newBuilder().setStatus(status))

--- a/hedera-node/src/test/java/com/hedera/services/sigs/metadata/DelegatingSigMetadataLookupTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/sigs/metadata/DelegatingSigMetadataLookupTest.java
@@ -36,7 +36,7 @@ import java.util.function.Function;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.BDDMockito.mock;
+import static org.mockito.Mockito.mock;
 
 class DelegatingSigMetadataLookupTest {
 	private static final String SYMBOL = "NotAnHbar";
@@ -46,21 +46,20 @@ class DelegatingSigMetadataLookupTest {
 	private static final boolean FREEZE_DEFAULT = true;
 	private static final boolean ACCOUNTS_KYC_GRANTED_BY_DEFAULT = true;
 
-	private final EntityId treasury = new EntityId(1,2, 3);
-	private final TokenID id = IdUtils.asToken("1.2.666");
+	private static final EntityId treasury = new EntityId(1,2, 3);
+	private static final TokenID id = IdUtils.asToken("1.2.666");
 
-	private MerkleToken token;
+	private static final MerkleToken token = new MerkleToken(
+			Long.MAX_VALUE, TOTAL_SUPPLY, DECIMALS, SYMBOL, TOKEN_NAME,
+			FREEZE_DEFAULT, ACCOUNTS_KYC_GRANTED_BY_DEFAULT, treasury);
+	private static final JKey freezeKey = new JEd25519Key("not-a-real-freeze-key".getBytes());
+
 	private TokenStore tokenStore;
-	private JKey freezeKey;
 
 	private Function<TokenID, SafeLookupResult<TokenSigningMetadata>> subject;
 
 	@BeforeEach
 	void setup() {
-		freezeKey = new JEd25519Key("not-a-real-freeze-key".getBytes());
-
-		token = new MerkleToken(Long.MAX_VALUE, TOTAL_SUPPLY, DECIMALS, SYMBOL, TOKEN_NAME, FREEZE_DEFAULT, ACCOUNTS_KYC_GRANTED_BY_DEFAULT, treasury);
-
 		tokenStore = mock(TokenStore.class);
 
 		subject = SigMetadataLookup.REF_LOOKUP_FACTORY.apply(tokenStore);
@@ -92,7 +91,6 @@ class DelegatingSigMetadataLookupTest {
 	void returnsExpectedMetaIfPresent() {
 		token.setFreezeKey(freezeKey);
 		final var expected = TokenSigningMetadata.from(token);
-
 		given(tokenStore.resolve(id)).willReturn(id);
 		given(tokenStore.get(id)).willReturn(token);
 

--- a/hedera-node/src/test/java/com/hedera/services/sigs/metadata/DelegatingSigMetadataLookupTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/sigs/metadata/DelegatingSigMetadataLookupTest.java
@@ -39,18 +39,19 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.mock;
 
 class DelegatingSigMetadataLookupTest {
-	private JKey freezeKey;
-	private String symbol = "NotAnHbar";
-	private String tokenName = "TokenName";
-	private int decimals = 2;
-	private long totalSupply = 1_000_000;
-	private boolean freezeDefault = true;
-	private boolean accountsKycGrantedByDefault = true;
-	private EntityId treasury = new EntityId(1,2, 3);
-	private TokenID id = IdUtils.asToken("1.2.666");
+	private static final String SYMBOL = "NotAnHbar";
+	private static final String TOKEN_NAME = "TokenName";
+	private static final int DECIMALS = 2;
+	private static final long TOTAL_SUPPLY = 1_000_000;
+	private static final boolean FREEZE_DEFAULT = true;
+	private static final boolean ACCOUNTS_KYC_GRANTED_BY_DEFAULT = true;
+
+	private final EntityId treasury = new EntityId(1,2, 3);
+	private final TokenID id = IdUtils.asToken("1.2.666");
 
 	private MerkleToken token;
 	private TokenStore tokenStore;
+	private JKey freezeKey;
 
 	private Function<TokenID, SafeLookupResult<TokenSigningMetadata>> subject;
 
@@ -58,7 +59,7 @@ class DelegatingSigMetadataLookupTest {
 	void setup() {
 		freezeKey = new JEd25519Key("not-a-real-freeze-key".getBytes());
 
-		token = new MerkleToken(Long.MAX_VALUE, totalSupply, decimals, symbol, tokenName,  freezeDefault, accountsKycGrantedByDefault, treasury);
+		token = new MerkleToken(Long.MAX_VALUE, TOTAL_SUPPLY, DECIMALS, SYMBOL, TOKEN_NAME, FREEZE_DEFAULT, ACCOUNTS_KYC_GRANTED_BY_DEFAULT, treasury);
 
 		tokenStore = mock(TokenStore.class);
 
@@ -73,10 +74,8 @@ class DelegatingSigMetadataLookupTest {
 				.setTokenNum(0L)
 				.build());
 
-		// when:
-		var result = subject.apply(id);
+		final var result = subject.apply(id);
 
-		// then:
 		assertEquals(KeyOrderingFailure.MISSING_TOKEN, result.failureIfAny());
 	}
 
@@ -84,28 +83,22 @@ class DelegatingSigMetadataLookupTest {
 	void returnsExpectedFailIfMissing() {
 		given(tokenStore.resolve(id)).willReturn(TokenStore.MISSING_TOKEN);
 
-		// when:
-		var result = subject.apply(id);
+		final var result = subject.apply(id);
 
-		// then:
 		assertEquals(KeyOrderingFailure.MISSING_TOKEN, result.failureIfAny());
 	}
 
 	@Test
 	void returnsExpectedMetaIfPresent() {
-		// setup:
 		token.setFreezeKey(freezeKey);
-		var expected = TokenSigningMetadata.from(token);
+		final var expected = TokenSigningMetadata.from(token);
 
 		given(tokenStore.resolve(id)).willReturn(id);
 		given(tokenStore.get(id)).willReturn(token);
 
-		// when:
-		var result = subject.apply(id);
+		final var result = subject.apply(id);
 
-		// then:
 		assertEquals(KeyOrderingFailure.NONE, result.failureIfAny());
-		// and:
 		assertEquals(expected.adminKey(), result.metadata().adminKey());
 		assertEquals(expected.optionalFreezeKey(), result.metadata().optionalFreezeKey());
 	}


### PR DESCRIPTION
**Description**:
This PR reorders modifiers in `AccountProperty`, `DelegatingSigMetadaLookup` and `AwareNodeDiligenceScreen`. Closes other code smells.

**Related issue(s)**:

Fixes #2163 

**Checklist**

- [X] Documented (Code comments, README, etc.)
- [X] Tested (unit, integration, etc.)
