### PR TITLE
Commit two helper scripts 

### DIFF
--- a/run/gen-explicit-fee-schedules.py
+++ b/run/gen-explicit-fee-schedules.py
@@ -1,0 +1,29 @@
+### 
+# A script to convert the Services-consumable feeSchedules.json 
+# into the "typed" format used by the public pricing calculator.
+### 
+
+import json
+
+providers = ['nodedata', 'networkdata', 'servicedata']
+typed_schedules = {}
+with open('hedera-node/src/main/resources/feeSchedules.json', 'r') as fin:
+    cur_and_next_schedules = json.load(fin)
+    schedules = cur_and_next_schedules[0]['currentFeeSchedule']
+    for tfs in schedules:
+        if 'expiryTime' in tfs:
+            break
+        tfs = tfs['transactionFeeSchedule']
+        function = tfs['hederaFunctionality']
+        prices_list = tfs['fees']
+        prices_by_type = {}
+        for typed_prices in prices_list:
+            this_type = typed_prices.get('subType', 'DEFAULT')
+            this_type_prices = {}
+            for provider in providers:
+                this_type_prices[provider] = typed_prices[provider]
+            prices_by_type[this_type] = this_type_prices
+        typed_schedules[function] = prices_by_type
+
+with open('typedFeeSchedules.json', 'w') as fout:
+    json.dump(typed_schedules, fout, indent=2)

--- a/test-clients/yahcli/run/test/local/sysfiles-down.sh
+++ b/test-clients/yahcli/run/test/local/sysfiles-down.sh
@@ -1,5 +1,5 @@
 #! /bin/sh
 
-TAG=${1:-'0.1.4'}
+TAG=${1:-'0.1.3'}
 
 docker run -v $(pwd):/launch yahcli:$TAG -p 2 sysfiles download all

--- a/test-clients/yahcli/run/test/local/sysfiles-down.sh
+++ b/test-clients/yahcli/run/test/local/sysfiles-down.sh
@@ -1,5 +1,5 @@
 #! /bin/sh
 
-TAG=${1:-'0.1.3'}
+TAG=${1:-'0.1.4'}
 
 docker run -v $(pwd):/launch yahcli:$TAG -p 2 sysfiles download all

--- a/test-clients/yahcli/run/with-service-endpoints.py
+++ b/test-clients/yahcli/run/with-service-endpoints.py
@@ -1,3 +1,8 @@
+### 
+# A script to augment deprecated-format 0.0.101 and 0.0.102 system 
+# files with ServiceEndpoint fields.
+### 
+
 import sys
 import json
 from collections import defaultdict

--- a/test-clients/yahcli/run/with-service-endpoints.py
+++ b/test-clients/yahcli/run/with-service-endpoints.py
@@ -1,0 +1,41 @@
+import sys
+import json
+from collections import defaultdict
+
+hashes = {}
+ips_by_id = defaultdict(list)
+
+def svc_endpoint_with(ip, port):
+    return { 'ipAddressV4': ip, 'port': port }
+
+def book_enriched(entry):
+    node_id = entry['nodeId']
+    all_ips = ips_by_id[node_id]
+    all_endpoints = []
+    for ip in all_ips:
+        for port in [ 50211, 50212 ]:
+            all_endpoints.append(svc_endpoint_with(ip, port))
+    entry['endpoints'] = all_endpoints
+    entry['certHash'] = hashes[node_id]
+    return entry
+
+book_loc, details_loc = sys.argv[1], sys.argv[2]
+with open(book_loc, 'r') as fin:
+    wrapper = json.load(fin)
+    entries = wrapper['entries']
+    for entry in entries:
+        node_id = entry['nodeId']
+        ips_by_id[node_id].append(entry['deprecatedIp'])
+        hashes[node_id] = entry['certHash']
+    mod_book_loc = book_loc[(book_loc.rindex('/') + 1):]
+    with open(mod_book_loc, 'w') as fout:
+        new_wrapper = { 'entries': [ book_enriched(entry) for entry in entries ] }
+        json.dump(new_wrapper, fout, indent=2)
+
+with open(details_loc, 'r') as fin:
+    wrapper = json.load(fin)
+    entries = wrapper['entries']
+    mod_details_loc = details_loc[(details_loc.rindex('/') + 1):]
+    with open(mod_details_loc, 'w') as fout:
+        new_wrapper = { 'entries': [ book_enriched(entry) for entry in entries ] }
+        json.dump(new_wrapper, fout, indent=2)


### PR DESCRIPTION
**Description**:
Add two useful Python scripts:

1. _run/gen-explicit-fee-schedules.py_ to translate a Services _feeSchedules.json_ into the format used by the public pricing calculator.
2. _test-clients/yahcli/run/with-service-endpoints.py_ to augment a `(0.0.101, 0.0.102)` pair of deprecated-style yahcli JSON with the new `ServiceEndpoint` fields [as documented in the protobufs](https://hashgraph.github.io/hedera-protobufs/#proto.NodeAddress).