### PR TITLE
File Delete refactoring (#536)

### DIFF
--- a/hedera-node/src/main/java/com/hedera/services/files/HederaFs.java
+++ b/hedera-node/src/main/java/com/hedera/services/files/HederaFs.java
@@ -147,11 +147,10 @@ public interface HederaFs {
 	 * Marks the given file as deleted and removes its data from the system.
 	 *
 	 * @param id the file to delete
-	 * @return an {@link UpdateResult} summarizing the result of the delete attempt
 	 * @throws IllegalArgumentException with {@link IllegalArgumentType#UNKNOWN_FILE} if the file is missing
 	 * @throws IllegalArgumentException with {@link IllegalArgumentType#DELETED_FILE} if the file is deleted
 	 */
-	UpdateResult delete(FileID id);
+	void delete(FileID id);
 
 	/**
 	 * Removes the given file from the system (both metadata and data).

--- a/hedera-node/src/main/java/com/hedera/services/txns/TransitionRunner.java
+++ b/hedera-node/src/main/java/com/hedera/services/txns/TransitionRunner.java
@@ -33,12 +33,14 @@ import javax.inject.Singleton;
 import java.util.EnumSet;
 
 import static com.hederahashgraph.api.proto.java.HederaFunctionality.CryptoTransfer;
+import static com.hederahashgraph.api.proto.java.HederaFunctionality.FileDelete;
 import static com.hederahashgraph.api.proto.java.HederaFunctionality.TokenAccountWipe;
 import static com.hederahashgraph.api.proto.java.HederaFunctionality.TokenAssociateToAccount;
 import static com.hederahashgraph.api.proto.java.HederaFunctionality.TokenBurn;
-import static com.hederahashgraph.api.proto.java.HederaFunctionality.TokenDelete;
 import static com.hederahashgraph.api.proto.java.HederaFunctionality.TokenCreate;
+import static com.hederahashgraph.api.proto.java.HederaFunctionality.TokenDelete;
 import static com.hederahashgraph.api.proto.java.HederaFunctionality.TokenDissociateFromAccount;
+import static com.hederahashgraph.api.proto.java.HederaFunctionality.TokenFeeScheduleUpdate;
 import static com.hederahashgraph.api.proto.java.HederaFunctionality.TokenFreezeAccount;
 import static com.hederahashgraph.api.proto.java.HederaFunctionality.TokenGrantKycToAccount;
 import static com.hederahashgraph.api.proto.java.HederaFunctionality.TokenMint;
@@ -47,7 +49,6 @@ import static com.hederahashgraph.api.proto.java.HederaFunctionality.TokenUnfree
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.FAIL_INVALID;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OK;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SUCCESS;
-import static com.hederahashgraph.api.proto.java.HederaFunctionality.TokenFeeScheduleUpdate;
 
 @Singleton
 public class TransitionRunner {
@@ -62,7 +63,8 @@ public class TransitionRunner {
 			TokenCreate,
 			TokenFeeScheduleUpdate,
 			CryptoTransfer,
-			TokenDelete
+			TokenDelete,
+			FileDelete
 	);
 
 	private final TransactionContext txnCtx;

--- a/hedera-node/src/test/java/com/hedera/services/txns/file/FileDeleteTransitionLogicTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/txns/file/FileDeleteTransitionLogicTest.java
@@ -22,6 +22,7 @@ package com.hedera.services.txns.file;
 
 import com.hedera.services.context.TransactionContext;
 import com.hedera.services.context.primitives.StateView;
+import com.hedera.services.exceptions.InvalidTransactionException;
 import com.hedera.services.files.HFileMeta;
 import com.hedera.services.files.HederaFs;
 import com.hedera.services.files.TieredHederaFs;
@@ -56,6 +57,7 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.inOrder;
 import static org.mockito.BDDMockito.mock;
 import static org.mockito.BDDMockito.verify;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 
 class FileDeleteTransitionLogicTest {
@@ -147,6 +149,7 @@ class FileDeleteTransitionLogicTest {
 	void resultIsRespected() {
 		givenTxnCtxDeleting(TargetType.VALID);
 
+		doThrow(new InvalidTransactionException(ENTITY_NOT_ALLOWED_TO_DELETE)).when(hfs).delete(any());
 		// when & then:
 		assertFailsWith(
 				() -> subject.doStateTransition(),


### PR DESCRIPTION
Description:
This PR refactors `FileDeleteTransitionLogic` to use the new transition logic pattern.

Changes:

All invalid assertions regarding a given file ID are now translated to `InvalidTransactionException` and thrown to the `TransitionRunner`.

**Checklist**:
- [x] No failing E2E
- [x] Unit tests with no less coverage than the previous implementation