### PR TITLE
updated TopicUpdateSuite to use the right autorenew values

### DIFF
--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/consensus/TopicUpdateSuite.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/consensus/TopicUpdateSuite.java
@@ -84,7 +84,7 @@ public class TopicUpdateSuite extends HapiApiSuite {
 
 	@Override
 	public boolean canRunAsync() {
-		return true;
+		return false;
 	}
 
 	private HapiApiSpec updateToMissingTopicFails() {
@@ -225,7 +225,7 @@ public class TopicUpdateSuite extends HapiApiSuite {
 	}
 
 	private HapiApiSpec updateMultipleFields() {
-		long updateAutoRenewPeriod = 1200L;
+		long updateAutoRenewPeriod = 7_000_000L;
 		long expirationTimestamp = Instant.now().getEpochSecond() + 10000000; // more than default.autorenew
 		// .secs=7000000
 		return defaultHapiSpec("updateMultipleFields")
@@ -249,7 +249,7 @@ public class TopicUpdateSuite extends HapiApiSuite {
 								.submitKey("submitKey")
 								.adminKey("adminKey2")
 								.expiry(expirationTimestamp)
-								.autoRenewPeriod(updateAutoRenewPeriod * 2)
+								.autoRenewPeriod(updateAutoRenewPeriod + 5_000L)
 								.autoRenewAccountId("nextAutoRenewAccount")
 								.hasKnownStatus(SUCCESS)
 				)
@@ -259,7 +259,7 @@ public class TopicUpdateSuite extends HapiApiSuite {
 								.hasSubmitKey("submitKey")
 								.hasAdminKey("adminKey2")
 								.hasExpiry(expirationTimestamp)
-								.hasAutoRenewPeriod(updateAutoRenewPeriod * 2)
+								.hasAutoRenewPeriod(updateAutoRenewPeriod + 5_000L)
 								.hasAutoRenewAccount("nextAutoRenewAccount")
 								.logged()
 				);
@@ -270,7 +270,7 @@ public class TopicUpdateSuite extends HapiApiSuite {
 		return defaultHapiSpec("expirationTimestampIsValidated")
 				.given(
 						createTopic("testTopic")
-								.autoRenewPeriod(3600)
+								.autoRenewPeriod(7_000_000L)
 				)
 				.when()
 				.then(

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/consensus/TopicUpdateSuite.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/consensus/TopicUpdateSuite.java
@@ -55,6 +55,7 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.UNAUTHORIZED;
 public class TopicUpdateSuite extends HapiApiSuite {
 	private static final Logger log = LogManager.getLogger(TopicUpdateSuite.class);
 
+	private static final long validAutoRenewPeriod = 7_000_000L;
 	private static final long defaultMaxLifetime =
 			Long.parseLong(HapiSpecSetup.getDefaultNodeProps().get("entities.maxLifetime"));
 
@@ -89,7 +90,7 @@ public class TopicUpdateSuite extends HapiApiSuite {
 
 	private HapiApiSpec updateToMissingTopicFails() {
 		return defaultHapiSpec("UpdateTopicHandlesMissingTopicGracefully")
-				.given( ).when( ).then(
+				.given().when().then(
 						updateTopic("1.2.3").hasKnownStatus(INVALID_TOPIC_ID)
 				);
 	}
@@ -153,8 +154,8 @@ public class TopicUpdateSuite extends HapiApiSuite {
 								.hasKnownStatus(INVALID_SIGNATURE),
 						updateTopicSignedBy.apply(new String[] { "payer", "newAdminKey", "newAutoRenewAccount" })
 								.hasKnownStatus(INVALID_SIGNATURE),
-						updateTopicSignedBy.apply(
-								new String[] { "payer", "oldAdminKey", "newAdminKey", "newAutoRenewAccount" })
+						updateTopicSignedBy
+								.apply(new String[] { "payer", "oldAdminKey", "newAdminKey", "newAutoRenewAccount" })
 								.hasKnownStatus(SUCCESS)
 				).then(
 						getTopicInfo("testTopic")
@@ -225,7 +226,6 @@ public class TopicUpdateSuite extends HapiApiSuite {
 	}
 
 	private HapiApiSpec updateMultipleFields() {
-		long updateAutoRenewPeriod = 7_000_000L;
 		long expirationTimestamp = Instant.now().getEpochSecond() + 10000000; // more than default.autorenew
 		// .secs=7000000
 		return defaultHapiSpec("updateMultipleFields")
@@ -240,7 +240,7 @@ public class TopicUpdateSuite extends HapiApiSuite {
 						createTopic("testTopic")
 								.topicMemo("initialmemo")
 								.adminKeyName("adminKey")
-								.autoRenewPeriod(updateAutoRenewPeriod)
+								.autoRenewPeriod(validAutoRenewPeriod)
 								.autoRenewAccountId("autoRenewAccount")
 				)
 				.when(
@@ -249,7 +249,7 @@ public class TopicUpdateSuite extends HapiApiSuite {
 								.submitKey("submitKey")
 								.adminKey("adminKey2")
 								.expiry(expirationTimestamp)
-								.autoRenewPeriod(updateAutoRenewPeriod + 5_000L)
+								.autoRenewPeriod(validAutoRenewPeriod + 5_000L)
 								.autoRenewAccountId("nextAutoRenewAccount")
 								.hasKnownStatus(SUCCESS)
 				)
@@ -259,7 +259,7 @@ public class TopicUpdateSuite extends HapiApiSuite {
 								.hasSubmitKey("submitKey")
 								.hasAdminKey("adminKey2")
 								.hasExpiry(expirationTimestamp)
-								.hasAutoRenewPeriod(updateAutoRenewPeriod + 5_000L)
+								.hasAutoRenewPeriod(validAutoRenewPeriod + 5_000L)
 								.hasAutoRenewAccount("nextAutoRenewAccount")
 								.logged()
 				);
@@ -270,7 +270,7 @@ public class TopicUpdateSuite extends HapiApiSuite {
 		return defaultHapiSpec("expirationTimestampIsValidated")
 				.given(
 						createTopic("testTopic")
-								.autoRenewPeriod(7_000_000L)
+								.autoRenewPeriod(validAutoRenewPeriod)
 				)
 				.when()
 				.then(


### PR DESCRIPTION
Signed-off-by: anighanta <anirudh.ghanta@hedera.com>

**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->

**Related issue(s)**:

Fixes #2261 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->
Slack Results : 
[`GCP-Daily-Comp-NetError-4N-1C`](https://hedera-hashgraph.slack.com/archives/C018CBQBTGB/p1633017158222800)
[`GCP-Weekly-Services-Comp-NetDelay-15N-1C`](https://hedera-hashgraph.slack.com/archives/C018CBQBTGB/p1633020489223300)
**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
