### PR TITLE
Prevent automatic associations

### DIFF
--- a/hedera-node/src/main/java/com/hedera/services/store/tokens/HederaTokenStore.java
+++ b/hedera-node/src/main/java/com/hedera/services/store/tokens/HederaTokenStore.java
@@ -845,9 +845,6 @@ public class HederaTokenStore extends HederaStore implements TokenStore {
 	}
 
 	private ResponseCodeEnum validateAndAutoAssociate(AccountID aId, TokenID tId) {
-		if (hederaLedger.maxAutomaticAssociations(aId) > 0) {
-			return associate(aId, List.of(tId), true);
-		}
 		return TOKEN_NOT_ASSOCIATED_TO_ACCOUNT;
 	}
 


### PR DESCRIPTION
Hard-code a HIP-24 toggle by always returning `TOKEN_NOT_ASSOCIATED_TO_ACCOUNT` from `HederaTokenStore.validateAndAutoAssociate()`.