### PR TITLE
Fix `DuplicateManagementTest.hasExpectedDuplicates()` for new node behavior

### DIFF
--- a/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/meta/HapiGetTxnRecord.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/meta/HapiGetTxnRecord.java
@@ -524,6 +524,8 @@ public class HapiGetTxnRecord extends HapiQueryOp<HapiGetTxnRecord> {
 				var rates = spec.ratesProvider();
 				var priceInUsd = sdec(rates.toUsdWithActiveRates(fee), 5);
 				log.info("Record (charged ${}): {}", priceInUsd, record);
+				log.info("Duplicates: {}",
+						response.getTransactionGetRecord().getDuplicateTransactionRecordsList());
 			}
 		}
 		if (response.getTransactionGetRecord().getHeader().getNodeTransactionPrecheckCode() == OK) {

--- a/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/TxnUtils.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/TxnUtils.java
@@ -49,6 +49,7 @@ import com.hederahashgraph.api.proto.java.TopicID;
 import com.hederahashgraph.api.proto.java.Transaction;
 import com.hederahashgraph.api.proto.java.TransactionBody;
 import com.hederahashgraph.api.proto.java.TransactionID;
+import com.hederahashgraph.api.proto.java.TransactionRecord;
 import com.hederahashgraph.api.proto.java.TransferList;
 import com.hederahashgraph.fee.SigValueObj;
 import com.swirlds.common.CommonUtils;
@@ -424,6 +425,13 @@ public class TxnUtils {
 				))
 				.collect(toList())
 				.toString();
+	}
+
+	public static OptionalLong getNonFeeDeduction(final TransactionRecord record) {
+		final var payer = record.getTransactionID().getAccountID();
+		final var txnFee = record.getTransactionFee();
+		final var totalDeduction = getDeduction(record.getTransferList(), payer);
+		return totalDeduction.isPresent() ? OptionalLong.of(totalDeduction.getAsLong() + txnFee) : totalDeduction;
 	}
 
 	public static OptionalLong getDeduction(TransferList accountAmounts, AccountID payer) {


### PR DESCRIPTION
**Description**:
Before release 0.18.0, if a superuser account (`0.0.2` or `0.0.50`) paid for a query, the node would still submit its `CryptoTransfer` payment to the network.

Although query node payments are tiny (8-10 tinybars), all superuser operations are supposed to be free, so this behavior was not really correct.

In release 0.18.0 this was fixed, but the `DuplicateManagementTest.hasExpectedDuplicates()` EET spec was not updated with the new behavior.

This PR reworks the spec to pass.