### PR TITLE
Add `HapiApiSuite` lifecycle hooks

### DIFF
--- a/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/UtilVerbs.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/UtilVerbs.java
@@ -270,6 +270,18 @@ public class UtilVerbs {
 				.overridingProps(Map.of(property, "" + value));
 	}
 
+	public static HapiSpecOperation overriding(
+			String firstProperty, String firstValue,
+			String secondProperty, String secondValue
+	) {
+		return fileUpdate(APP_PROPERTIES)
+				.payingWith(ADDRESS_BOOK_CONTROL)
+				.overridingProps(Map.of(
+						firstProperty, firstValue,
+						secondProperty, secondValue
+				));
+	}
+
 	public static CustomSpecAssert exportAccountBalances(Supplier<String> acctBalanceFile) {
 		return new CustomSpecAssert((spec, log) -> {
 			spec.exportAccountBalances(acctBalanceFile);
@@ -513,7 +525,9 @@ public class UtilVerbs {
 			OptionalLong tinyBarsToOffer
 	) {
 		return updateLargeFile(payer, fileName, byteString, signOnlyWithPayer, tinyBarsToOffer,
-				op -> {}, op -> {});
+				op -> {
+				}, op -> {
+				});
 	}
 
 	public static HapiSpecOperation updateLargeFile(

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/HapiApiSuite.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/HapiApiSuite.java
@@ -161,7 +161,23 @@ public abstract class HapiApiSuite {
 		}
 		List<HapiApiSpec> specs = getSpecsInSuite();
 		specs.forEach(spec -> spec.setSuitePrefix(name()));
+
+		if (setupSpec != null) {
+			setupSpec.run();
+			if (setupSpec.getStatus() != HapiApiSpec.SpecStatus.PASSED) {
+				return SUITE_FAILED;
+			}
+		}
+
 		runner.accept(specs);
+
+		if (teardownSpec != null) {
+			teardownSpec.run();
+			if (teardownSpec.getStatus() != HapiApiSpec.SpecStatus.PASSED) {
+				return SUITE_FAILED;
+			}
+		}
+
 		finalSpecs = specs;
 		summarizeResults(getResultsLogger());
 		if (tearDownClientsAfter) {

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/HapiApiSuite.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/HapiApiSuite.java
@@ -90,6 +90,8 @@ public abstract class HapiApiSuite {
 
 	private boolean deferResultsSummary = false;
 	private boolean tearDownClientsAfter = true;
+	private HapiApiSpec setupSpec = null;
+	private HapiApiSpec teardownSpec = null;
 	private List<HapiApiSpec> finalSpecs = Collections.emptyList();
 
 	public String name() {
@@ -125,6 +127,20 @@ public abstract class HapiApiSuite {
 			deferResultsSummary = false;
 			summarizeResults(getResultsLogger());
 		}
+	}
+
+	public HapiApiSuite setup(HapiSpecOperation... setupOps) {
+		if (setupOps != null && setupOps.length > 0) {
+			setupSpec = HapiApiSpec.defaultHapiSpec("setup").given(setupOps).when().then();
+		}
+		return this;
+	}
+
+	public HapiApiSuite teardown(HapiSpecOperation... teardownOps) {
+		if (teardownOps != null && teardownOps.length > 0) {
+			teardownSpec = HapiApiSpec.defaultHapiSpec("teardown").given(teardownOps).when().then();
+		}
+		return this;
 	}
 
 	public FinalOutcome runSuiteAsync() {

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/schedule/ScheduleSignSpecs.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/schedule/ScheduleSignSpecs.java
@@ -78,13 +78,19 @@ public class ScheduleSignSpecs extends HapiApiSuite {
 			HapiSpecSetup.getDefaultNodeProps().get("scheduling.whitelist");
 
 	public static void main(String... args) {
-		new ScheduleSignSpecs().runSuiteSync();
+		new ScheduleSignSpecs()
+				.setup(
+						overriding("scheduling.whitelist", suiteWhitelist)
+				).teardown(
+						overriding(
+						"ledger.schedule.txExpiryTimeSecs", defaultTxExpiry,
+						"scheduling.whitelist", defaultWhitelist)
+				).runSuiteSync();
 	}
 
 	@Override
 	protected List<HapiApiSpec> getSpecsInSuite() {
 		return List.of(new HapiApiSpec[] {
-						suiteSetup(),
 						signFailsDueToDeletedExpiration(),
 						triggersUponAdditionalNeededSig(),
 						sharedKeyWorksAsExpected(),
@@ -105,7 +111,6 @@ public class ScheduleSignSpecs extends HapiApiSuite {
 						nestedSigningReqsWorkAsExpected(),
 						changeInNestedSigningReqsRespected(),
 						signingDeletedSchedulesHasNoEffect(),
-						suiteCleanup(),
 				}
 		);
 	}


### PR DESCRIPTION
**Description**:
Add `.setup(HapiSpecOperation...)` and `.teardown(HapiSpecOperation...)` hooks to the `HapiApiSuite` so that operations can be run predictably at suite lifecycle boundaries.

In some cases this simplifies use of `.runSuiteAsync()`, and may prevent state "leaking" in CI and causing hard-to-diagnose downstream failures.