### PR TITLE
HIP-23 testing plan and fixes

### DIFF
--- a/docs/test-plans/hip-23.md
+++ b/docs/test-plans/hip-23.md
@@ -1,0 +1,28 @@
+# HIP-23 (automatic token associations)
+
+This feature adds a new field `maxAutoAssociations` to the account entity, and a 
+side-effect to any transaction that sends units/NFTs of a not-yet-associated token 
+to an account with `maxAutoAssociations > 0`. 
+
+It also adds a `TransactionRecord` field named `automatic_token_associations`.
+This field lists all token associations that were created as "side-effects" of 
+any transaction that is not an explicit `TokenAssociate`. (Since an existing 
+`TokenCreate` _already_ auto-associates the new token treasury, and any fee 
+collectors for fractional or self-denominated fixed fees, this feature also
+"retrofits" the record of a `TokenCreate` with the `automatic_token_associations` 
+field.)
+
+:warning:&nbsp; Notice that right now, _only_ a `CryptoTransfer` or `TokenCreate` 
+can have auto-associations as a side-effect. But after deployment of HTS precompiled 
+contracts, any `ContractCreate` or `ContractCall` could also have auto-associations 
+as side-effects.
+
+## Scope of test plan
+
+This feature 
+
+This feature has the following top-level impacts:
+  1. **User-facing HAPI**: `CryptoCreate`, `CryptoUpdate`, `CryptoGetInfo`
+  2. **Transaction Records**: `CryptoTransfer`, `TokenCreate`
+  3. **`handleTransaction` Flow**: `CryptoCreate`, `CryptoUpdate`, `CryptoTransfer`
+

--- a/docs/test-plans/hip-23.md
+++ b/docs/test-plans/hip-23.md
@@ -17,12 +17,69 @@ can have auto-associations as a side-effect. But after deployment of HTS precomp
 contracts, any `ContractCreate` or `ContractCall` could also have auto-associations 
 as side-effects.
 
-## Scope of test plan
-
-This feature 
+## Scope
 
 This feature has the following top-level impacts:
-  1. **User-facing HAPI**: `CryptoCreate`, `CryptoUpdate`, `CryptoGetInfo`
-  2. **Transaction Records**: `CryptoTransfer`, `TokenCreate`
-  3. **`handleTransaction` Flow**: `CryptoCreate`, `CryptoUpdate`, `CryptoTransfer`
+  - **State**: `MerkleAccountState`
+  - **User-facing HAPI**: `CryptoCreate`, `CryptoUpdate`, `CryptoGetInfo`
+  - **Transaction Records**: `CryptoTransfer`s that transfer tokens, `TokenCreate`
+  - **`handleTransaction` Flow**: `CryptoCreate`, `CryptoUpdate`, `CryptoTransfer`
 
+:small_blue_diamond:&nbsp;Since this feature affects token transfers, we should 
+consider possible intersections with custom fees, and ensure that our tests give 
+equal attention to transfers of both fungible token units _and_ NFTs.
+
+:currency_exchange:&nbsp;Since this feature adds side-effects to parties in a 
+`CryptoTransfer`, and multi-party `CryptoTransfer`s must commit or rollback 
+atomically, we should validate that HIP-23 side-effects respect these semantics
+across a variety of failure modes.
+
+:paperclips:&nbsp;Since this feature has no rebuilt data structures, it has 
+no special reconnect testing requirements.
+
+So the high-level scope for this plan includes,
+  1. Migration tests.
+  2. Positive functional tests, especially with multiple accounts being 
+  auto-associated, and accounts receiving multiple auto-associations.
+  3. Negative functional tests, especially of multi-party `CryptoTransfer`s
+  whose HIP-23 side-effects occur before a later problem with the flow.
+  4. Record validation for all these positive and negative tests.
+  5. State validation for all these positive and negative tests.
+  6. Testing any possible interplay with custom fees.
+
+## Methodology
+
+We can now sketch what type of tests will be needed to meet the above scope.
+
+:cactus:&nbsp;Careful unit testing should suffice for **migration** tests, as
+the change to state is very small---a single field added to the 
+`MerkleAccountState` leaf. 
+
+:white_check_mark:&nbsp;**Positive functional** testing will require EET specs 
+that perform all variants of `TokenCreate`s with implied auto-associations, and 
+all variants of `CryptoTransfer`s that trigger one or more auto-associations for
+one or more accounts.
+
+:x:&nbsp;**Negative functional** testing will require EET specs that perform all
+variants of `CryptoTransfer`s in which auto-associations are attempted, but do 
+not succeed; and all variants of multi-party `CryptoTransfer`s in which 
+auto-associations succeed, but must be rolled back due to a later failure in the
+`CryptoTransfer` flow.
+
+:fountain_pen:&nbsp;**Record validation** will require new EET assertions as
+qualifiers on the [`TransactionRecordAsserts` class](https://github.com/hashgraph/hedera-services/blob/master/test-clients/src/main/java/com/hedera/services/bdd/spec/assertions/TransactionRecordAsserts.java#L43). Given these assertions, 
+the above functional tests can be easily enhanced to validate their records.
+
+:sparkle:&nbsp;**State validation** will require a new assert built-in for the 
+EET `HapiGetAccountInfo` query, to assert on auto-association state. Given this, 
+the above functional tests can be easily enhanced to validate state is 
+changed (or unchanged) as appropriate.
+
+:receipt:&nbsp;**Custom fee interplay** should provide an EET that dissociates
+a custom fee collector from its denominating token; and then triggers a custom
+fee payment to that collector. If the collector has open auto-association slots,
+the custom fee payment should go through (by using a slot).
+
+## Deliverables
+
+We 

--- a/docs/test-plans/hip-23.md
+++ b/docs/test-plans/hip-23.md
@@ -96,7 +96,7 @@ EET framework:
 ###:sparkle:&nbsp;State validation
 EET framework:
   - [x] `GetAccountInfo` asserts for max and in-use automatic association fields.
-  - [ ] Account snapshot and change-vs-snapshot asserts.
+  - [x] Account snapshot and change-vs-snapshot asserts.
 
 ###:cactus:&nbsp;Migration tests
 Unit tests:
@@ -106,17 +106,19 @@ Unit tests:
 
 ###:white_check_mark:&nbsp;Positive functional
 EETs (all with post-transaction record and state validation):
-  - [ ] A `TokenCreate` record includes the treasury auto-association.
-  - [ ] A `TokenCreate` record includes all fractional fee collector auto-associations.
-  - [ ] A `TokenCreate` record includes all self-denominated fee collector auto-associations.
-  - [ ] An account created with 1 auto-association slot can receive units of an unassociated fungible token.
-  - [ ] An account created with 1 auto-association slot can receive an NFT of an unassociated unique token.
-  - [ ] An account created with 3 auto-association slots can receive units and NFTs from three unassociated tokens.
+  - [x] A `TokenCreate` record includes the treasury auto-association.
+  - [x] A `TokenCreate` record includes all fractional fee collector auto-associations.
+  - [x] A `TokenCreate` record includes all self-denominated fee collector auto-associations.
+  - [x] An account with open auto-association slots can receive units of an unassociated fungible token.
+  - [x] An account with open auto-association slot can receive an NFT of an unassociated unique token.
   - [ ] An account updated to have 3 more auto-association slots can receive 3 more units and NFTs from unassociated tokens.
 
 ###:x:&nbsp;Negative functional
 EETs (all with post-transaction record and state validation):
-  - [ ] A failed `TokenCreate` performs and records no auto-associations.
+  - [x] A failed `TokenCreate` performs and records no auto-associations.
+  - [ ] A `CryptoCreate` cannot allocate more auto-association slots than the max-per-account limit.
+  - [ ] A `CryptoUpdate` cannot allocate more auto-association slots than the max-per-account limit.
+  - [ ] A `CryptoUpdate` cannot renounce more auto-association slots than it has already used.
   - [ ] A two-party `CryptoTransfer` rolls back all side-effects if an auto-association fails.
   - [ ] A multi-party `CryptoTransfer` rolls back all auto-association side-effects if it fails.
 

--- a/hapi-fees/src/main/java/com/hedera/services/usage/token/meta/TokenFreezeMeta.java
+++ b/hapi-fees/src/main/java/com/hedera/services/usage/token/meta/TokenFreezeMeta.java
@@ -1,5 +1,25 @@
 package com.hedera.services.usage.token.meta;
 
+/*-
+ * ‌
+ * Hedera Services API Fees
+ * ​
+ * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
 import com.google.common.base.MoreObjects;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;

--- a/hapi-fees/src/main/java/com/hedera/services/usage/token/meta/TokenOpMetaBase.java
+++ b/hapi-fees/src/main/java/com/hedera/services/usage/token/meta/TokenOpMetaBase.java
@@ -1,5 +1,25 @@
 package com.hedera.services.usage.token.meta;
 
+/*-
+ * ‌
+ * Hedera Services API Fees
+ * ​
+ * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
 import com.google.common.base.MoreObjects;
 import com.hederahashgraph.api.proto.java.SubType;
 

--- a/hapi-fees/src/main/java/com/hedera/services/usage/token/meta/TokenUnfreezeMeta.java
+++ b/hapi-fees/src/main/java/com/hedera/services/usage/token/meta/TokenUnfreezeMeta.java
@@ -1,5 +1,25 @@
 package com.hedera.services.usage.token.meta;
 
+/*-
+ * ‌
+ * Hedera Services API Fees
+ * ​
+ * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
 /**
  *  This is simply to get rid of code duplication with {@link TokenFreezeMeta} class.
  */

--- a/hapi-fees/src/test/java/com/hedera/services/usage/crypto/CryptoUpdateMetaTest.java
+++ b/hapi-fees/src/test/java/com/hedera/services/usage/crypto/CryptoUpdateMetaTest.java
@@ -1,5 +1,25 @@
 package com.hedera.services.usage.crypto;
 
+/*-
+ * ‌
+ * Hedera Services API Fees
+ * ​
+ * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
 import com.google.protobuf.Int32Value;
 import com.google.protobuf.StringValue;
 import com.hederahashgraph.api.proto.java.AccountID;

--- a/hedera-node/src/main/java/com/hedera/services/ledger/HederaLedger.java
+++ b/hedera-node/src/main/java/com/hedera/services/ledger/HederaLedger.java
@@ -102,6 +102,8 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OK;
 public class HederaLedger {
 	private static final int MAX_CONCEIVABLE_TOKENS_PER_TXN = 1_000;
 	private static final long[] NO_NEW_BALANCES = new long[0];
+	private static final List<AccountProperty> TOKEN_TRANSFER_SIDE_EFFECTS =
+			List.of(TOKENS, NUM_NFTS_OWNED, ALREADY_USED_AUTOMATIC_ASSOCIATIONS);
 
 	static final String NO_ACTIVE_TXN_CHANGE_SET = "{*NO ACTIVE TXN*}";
 	public static final Comparator<AccountID> ACCOUNT_ID_COMPARATOR = Comparator
@@ -395,7 +397,8 @@ public class HederaLedger {
 		if (tokenViewsManager.isInTransaction()) {
 			tokenViewsManager.rollback();
 		}
-		accountsLedger.undoChangesOfType(NUM_NFTS_OWNED);
+		accountsLedger.undoChangesOfType(TOKEN_TRANSFER_SIDE_EFFECTS);
+		newTokenAssociations.clear();
 		clearNetTokenTransfers();
 	}
 

--- a/hedera-node/src/main/java/com/hedera/services/ledger/TransactionalLedger.java
+++ b/hedera-node/src/main/java/com/hedera/services/ledger/TransactionalLedger.java
@@ -102,7 +102,7 @@ public class TransactionalLedger<K, P extends Enum<P> & BeanProperty<A>, A> impl
 		isInTransaction = true;
 	}
 
-	void undoChangesOfType(P property) {
+	void undoChangesOfType(List<P> properties) {
 		if (!isInTransaction) {
 			throw new IllegalStateException("Cannot undo changes, no transaction is active");
 		}
@@ -110,7 +110,9 @@ public class TransactionalLedger<K, P extends Enum<P> & BeanProperty<A>, A> impl
 			for (var key : changedKeys) {
 				final var delta = changes.get(key);
 				if (delta != null) {
-					delta.remove(property);
+					for (final var property : properties) {
+						delta.remove(property);
+					}
 				}
 			}
 		}

--- a/hedera-node/src/test/java/com/hedera/services/ledger/TransactionalLedgerTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/ledger/TransactionalLedgerTest.java
@@ -345,7 +345,7 @@ class TransactionalLedgerTest {
 		ArgumentCaptor<TestAccount> captor = ArgumentCaptor.forClass(TestAccount.class);
 
 		// expect:
-		assertThrows(IllegalStateException.class, () -> subject.undoChangesOfType(FLAG));
+		assertThrows(IllegalStateException.class, () -> subject.undoChangesOfType(List.of(FLAG)));
 		// given:
 		subject.begin();
 
@@ -353,7 +353,7 @@ class TransactionalLedgerTest {
 		subject.set(1L, OBJ, things[0]);
 		subject.set(1L, FLAG, true);
 		// and:
-		subject.undoChangesOfType(FLAG);
+		subject.undoChangesOfType(List.of(FLAG));
 		// and:
 		subject.commit();
 

--- a/hedera-node/src/test/java/com/hedera/services/sigs/metadata/lookups/DefaultTopicLookupTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/sigs/metadata/lookups/DefaultTopicLookupTest.java
@@ -1,5 +1,25 @@
 package com.hedera.services.sigs.metadata.lookups;
 
+/*-
+ * ‌
+ * Hedera Services Node
+ * ​
+ * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
 import com.hedera.services.legacy.core.jproto.JEd25519Key;
 import com.hedera.services.legacy.core.jproto.JKey;
 import com.hedera.services.state.merkle.MerkleTopic;

--- a/hedera-node/src/test/java/com/hedera/services/utils/EntityNumPairTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/utils/EntityNumPairTest.java
@@ -1,5 +1,25 @@
 package com.hedera.services.utils;
 
+/*-
+ * ‌
+ * Hedera Services Node
+ * ​
+ * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
 import com.hedera.services.state.merkle.internals.BitPackUtils;
 import com.hedera.services.store.models.Account;
 import com.hedera.services.store.models.Id;

--- a/hedera-node/src/test/java/com/hedera/services/utils/FcLong.java
+++ b/hedera-node/src/test/java/com/hedera/services/utils/FcLong.java
@@ -1,5 +1,25 @@
 package com.hedera.services.utils;
 
+/*-
+ * ‌
+ * Hedera Services Node
+ * ​
+ * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
 import com.swirlds.common.FastCopyable;
 import com.swirlds.common.io.SelfSerializable;
 import com.swirlds.common.io.SerializableDataInputStream;

--- a/test-clients/src/main/java/com/hedera/services/bdd/spec/assertions/AutoAssocAsserts.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/spec/assertions/AutoAssocAsserts.java
@@ -1,5 +1,25 @@
 package com.hedera.services.bdd.spec.assertions;
 
+/*-
+ * ‌
+ * Hedera Services Test Clients
+ * ​
+ * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
 import com.hederahashgraph.api.proto.java.TokenAssociation;
 import org.apache.commons.lang3.tuple.Pair;
 

--- a/test-clients/src/main/java/com/hedera/services/bdd/spec/assertions/AutoAssocAsserts.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/spec/assertions/AutoAssocAsserts.java
@@ -1,0 +1,44 @@
+package com.hedera.services.bdd.spec.assertions;
+
+import com.hederahashgraph.api.proto.java.TokenAssociation;
+import org.apache.commons.lang3.tuple.Pair;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class AutoAssocAsserts {
+	public static ErroringAssertsProvider<List<TokenAssociation>> accountTokenPairs(
+			final List<Pair<String, String>> expectedAssociations
+	) {
+		return spec -> actual -> {
+			try {
+				final var actualNum = actual.size();
+				final var expectedNum = expectedAssociations.size();
+				assertEquals(
+						expectedNum,
+						actualNum, "Expected " + expectedNum
+								+ " auto-associations, got " + actualNum
+								+ " (" + actual + ")");
+				int nextActual = 0;
+				final var registry = spec.registry();
+				for (final var expectedAssoc : expectedAssociations) {
+					final var actualAssoc = actual.get(nextActual++);
+					final var actualPair = Pair.of(
+							actualAssoc.getAccountId(),
+							actualAssoc.getTokenId());
+					final var expectedPair = Pair.of(
+							registry.getAccountID(expectedAssoc.getLeft()),
+							registry.getTokenID(expectedAssoc.getRight()));
+					assertEquals(expectedPair, actualPair,
+							"Wrong auto-association at index " + (nextActual - 1));
+				}
+
+				return Collections.emptyList();
+			} catch (Throwable t) {
+				return List.of(t);
+			}
+		};
+	}
+}

--- a/test-clients/src/main/java/com/hedera/services/bdd/spec/assertions/BaseErroringAsserts.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/spec/assertions/BaseErroringAsserts.java
@@ -23,8 +23,8 @@ package com.hedera.services.bdd.spec.assertions;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
+
+import static java.util.stream.Collectors.toList;
 
 public class BaseErroringAsserts<T> implements ErroringAsserts<T> {
 	private final List<Function<T, Optional<Throwable>>> tests;
@@ -37,7 +37,7 @@ public class BaseErroringAsserts<T> implements ErroringAsserts<T> {
 	public List<Throwable> errorsIn(T instance) {
 		return tests
 				.stream()
-				.flatMap(t -> t.apply(instance).map(Stream::of).orElse(Stream.empty()))
-				.collect(Collectors.toList());
+				.flatMap(t -> t.apply(instance).stream())
+				.collect(toList());
 	}
 }

--- a/test-clients/src/main/java/com/hedera/services/bdd/spec/assertions/TransactionRecordAsserts.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/spec/assertions/TransactionRecordAsserts.java
@@ -24,6 +24,7 @@ import com.hedera.services.bdd.spec.HapiApiSpec;
 import com.hedera.services.bdd.spec.queries.QueryUtils;
 import com.hederahashgraph.api.proto.java.AccountID;
 import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
+import com.hederahashgraph.api.proto.java.TokenAssociation;
 import com.hederahashgraph.api.proto.java.TokenTransferList;
 import com.hederahashgraph.api.proto.java.TransactionID;
 import com.hederahashgraph.api.proto.java.TransactionReceipt;
@@ -133,6 +134,11 @@ public class TransactionRecordAsserts extends BaseErroringAssertsProvider<Transa
 
 	public TransactionRecordAsserts tokenTransfers(ErroringAssertsProvider<List<TokenTransferList>> provider) {
 		registerTypedProvider("tokenTransferListsList", provider);
+		return this;
+	}
+
+	public TransactionRecordAsserts autoAssociated(ErroringAssertsProvider<List<TokenAssociation>> provider) {
+		registerTypedProvider("automaticTokenAssociationsList", provider);
 		return this;
 	}
 

--- a/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/HapiSpecRegistry.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/HapiSpecRegistry.java
@@ -158,7 +158,7 @@ public class HapiSpecRegistry {
 		return Key.getDefaultInstance();
 	}
 
-	private Key asPublicKey(String pubKeyHex) throws Exception {
+	private Key asPublicKey(String pubKeyHex) {
 		return Key.newBuilder()
 				.setEd25519(ByteString.copyFrom(CommonUtils.unhex(pubKeyHex)))
 				.build();

--- a/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/QueryVerbs.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/QueryVerbs.java
@@ -47,7 +47,6 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 
 import static com.hedera.services.bdd.spec.queries.contract.HapiContractCallLocal.fromDetails;
-import static com.hedera.services.bdd.suites.HapiApiSuite.GENESIS;
 
 public class QueryVerbs {
 	public static HapiGetReceipt getReceipt(String txn) {
@@ -133,7 +132,7 @@ public class QueryVerbs {
 	}
 
 	public static HapiGetExecTime getExecTime(String... txnIds) {
-		return new HapiGetExecTime(List.of(txnIds)).payingWith(GENESIS);
+		return new HapiGetExecTime(List.of(txnIds)).nodePayment(1234L);
 	}
 
 	public static HapiGetTokenInfo getTokenInfo(String token) {

--- a/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/QueryVerbs.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/QueryVerbs.java
@@ -47,6 +47,7 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 
 import static com.hedera.services.bdd.spec.queries.contract.HapiContractCallLocal.fromDetails;
+import static com.hedera.services.bdd.suites.HapiApiSuite.GENESIS;
 
 public class QueryVerbs {
 	public static HapiGetReceipt getReceipt(String txn) {
@@ -132,7 +133,7 @@ public class QueryVerbs {
 	}
 
 	public static HapiGetExecTime getExecTime(String... txnIds) {
-		return new HapiGetExecTime(List.of(txnIds));
+		return new HapiGetExecTime(List.of(txnIds)).payingWith(GENESIS);
 	}
 
 	public static HapiGetTokenInfo getTokenInfo(String token) {

--- a/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/crypto/HapiGetAccountInfo.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/crypto/HapiGetAccountInfo.java
@@ -142,8 +142,8 @@ public class HapiGetAccountInfo extends HapiQueryOp<HapiGetAccountInfo> {
 		ownedNfts.ifPresent(nftsOwned -> Assertions.assertEquals((long) nftsOwned, actualOwnedNfts));
 
 		var actualMaxAutoAssociations = actualInfo.getMaxAutomaticTokenAssociations();
-		maxAutomaticAssociations.ifPresent(maxAutoAssiations ->
-				Assertions.assertEquals((int) maxAutoAssiations , actualMaxAutoAssociations));
+		maxAutomaticAssociations.ifPresent(maxAutoAssociations ->
+				Assertions.assertEquals((int) maxAutoAssociations, actualMaxAutoAssociations));
 		alreadyUsedAutomaticAssociations.ifPresent(usedCount -> {
 			int actualCount = 0;
 			for (var rel : actualTokenRels) {

--- a/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/crypto/HapiGetAccountInfo.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/crypto/HapiGetAccountInfo.java
@@ -91,7 +91,7 @@ public class HapiGetAccountInfo extends HapiQueryOp<HapiGetAccountInfo> {
 		return this;
 	}
 
-	public HapiGetAccountInfo saveToRegistry(String registryEntry) {
+	public HapiGetAccountInfo savingSnapshot(String registryEntry) {
 		this.registryEntry = Optional.of(registryEntry);
 		return this;
 	}

--- a/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/token/TokenMovement.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/token/TokenMovement.java
@@ -102,6 +102,10 @@ public class TokenMovement {
 		receiverFn = Optional.empty();
 	}
 
+	public String getToken() {
+		return token;
+	}
+
 	public boolean isTrulyToken() {
 		return token != HapiApiSuite.HBAR_TOKEN_SENTINEL;
 	}

--- a/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/inventory/SpecKeyFromFile.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/inventory/SpecKeyFromFile.java
@@ -1,5 +1,25 @@
 package com.hedera.services.bdd.spec.utilops.inventory;
 
+/*-
+ * ‌
+ * Hedera Services Test Clients
+ * ​
+ * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
 
 import com.google.common.base.MoreObjects;
 import com.hedera.services.bdd.spec.HapiApiSpec;

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/autorenew/AccountAutoRenewalSuite.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/autorenew/AccountAutoRenewalSuite.java
@@ -114,7 +114,7 @@ public class AccountAutoRenewalSuite extends HapiApiSuite {
 								.autoRenewSecs(briefAutoRenew)
 								.balance(initialBalance),
 						getAccountInfo(autoRenewedAccount)
-								.saveToRegistry(autoRenewedAccount)
+								.savingSnapshot(autoRenewedAccount)
 								.logged()
 				).when(
 						sleepFor(briefAutoRenew * 1_000L + 500L),

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/ContractCallSuite.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/ContractCallSuite.java
@@ -156,11 +156,11 @@ public class ContractCallSuite extends HapiApiSuite {
 						cryptoCreate("Carol").balance(10_000_000_000L).payingWith("tokenIssuer"),
 						cryptoCreate("Dave").balance(10_000_000_000L).payingWith("tokenIssuer"),
 
-						getAccountInfo("tokenIssuer").saveToRegistry("tokenIssuerAcctInfo"),
-						getAccountInfo("Alice").saveToRegistry("AliceAcctInfo"),
-						getAccountInfo("Bob").saveToRegistry("BobAcctInfo"),
-						getAccountInfo("Carol").saveToRegistry("CarolAcctInfo"),
-						getAccountInfo("Dave").saveToRegistry("DaveAcctInfo"),
+						getAccountInfo("tokenIssuer").savingSnapshot("tokenIssuerAcctInfo"),
+						getAccountInfo("Alice").savingSnapshot("AliceAcctInfo"),
+						getAccountInfo("Bob").savingSnapshot("BobAcctInfo"),
+						getAccountInfo("Carol").savingSnapshot("CarolAcctInfo"),
+						getAccountInfo("Dave").savingSnapshot("DaveAcctInfo"),
 
 						fileCreate("bytecode")
 								.path(OC_TOKEN_BYTECODE_PATH),
@@ -412,7 +412,7 @@ public class ContractCallSuite extends HapiApiSuite {
 									.saveToRegistry("simpleStorageKey");
 
 							var subop2 = getAccountInfo("payer")
-									.saveToRegistry("payerAccountInfo");
+									.savingSnapshot("payerAccountInfo");
 							CustomSpecAssert.allRunFor(spec, subop1, subop2);
 
 							ContractGetInfoResponse.ContractInfo simpleStorageContractInfo = spec.registry().getContractInfo(

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/ContractPerformanceSuite.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/ContractPerformanceSuite.java
@@ -1,5 +1,25 @@
 package com.hedera.services.bdd.suites.contract;
 
+/*-
+ * ‌
+ * Hedera Services Test Clients
+ * ​
+ * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
 import com.google.common.io.Files;
 import com.google.common.primitives.Ints;
 import com.google.common.primitives.Longs;

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/SmartContractPaySpec.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/SmartContractPaySpec.java
@@ -83,7 +83,7 @@ public class SmartContractPaySpec extends HapiApiSuite {
 									.saveToRegistry("payReceivableKey");
 
 							var subop2 = getAccountInfo("receiver")
-									.saveToRegistry("receiverAccountInfoKey");
+									.savingSnapshot("receiverAccountInfoKey");
 							CustomSpecAssert.allRunFor(spec, subop1, subop2);
 
 							ContractGetInfoResponse.ContractInfo payReceivableContratInfo =
@@ -134,7 +134,7 @@ public class SmartContractPaySpec extends HapiApiSuite {
 
 							// check final receiver balance
 							var subop6 = getAccountInfo("receiver")
-									.saveToRegistry("receiverAccountInfoKey");
+									.savingSnapshot("receiverAccountInfoKey");
 							CustomSpecAssert.allRunFor(spec, subop6);
 
 							receiverAccountInfo = spec.registry().getAccountInfo("receiverAccountInfoKey");

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoCreateForSuiteRunner.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoCreateForSuiteRunner.java
@@ -124,7 +124,7 @@ public class CryptoCreateForSuiteRunner extends HapiApiSuite {
 									while (!gotPayerInfo) {
 										try {
 											var payerAccountInfo = getAccountInfo("payerAccount")
-													.saveToRegistry("payerAccountInfo")
+													.savingSnapshot("payerAccountInfo")
 													.logged();
 											allRunFor(spec, payerAccountInfo);
 											gotPayerInfo = true;

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/records/MigrationValidationPreSteps.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/records/MigrationValidationPreSteps.java
@@ -108,8 +108,8 @@ public class MigrationValidationPreSteps extends HapiApiSuite {
                 .then(
                         QueryVerbs.getFileInfo(MIGRATION_FILE).logged().saveToRegistry("migrationFile"),
                         QueryVerbs.getFileContents(MIGRATION_FILE).logged(),
-                        QueryVerbs.getAccountInfo(MIGRATION_ACCOUNT_A).logged().saveToRegistry("migrationAccountA"),
-                        QueryVerbs.getAccountInfo(MIGRATION_ACCOUNT_B).logged().saveToRegistry("migrationAccountB"),
+                        QueryVerbs.getAccountInfo(MIGRATION_ACCOUNT_A).logged().savingSnapshot("migrationAccountA"),
+                        QueryVerbs.getAccountInfo(MIGRATION_ACCOUNT_B).logged().savingSnapshot("migrationAccountB"),
                         QueryVerbs.getContractInfo(MIGRATION_SMART_CONTRACT).logged().saveToRegistry("migrationContract"),
                         UtilVerbs.withOpContext((spec, ctxLog ) -> {
                             FileWriter fw = null;

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenCreateSpecs.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenCreateSpecs.java
@@ -22,7 +22,6 @@ package com.hedera.services.bdd.suites.token;
 
 import com.hedera.services.bdd.spec.HapiApiSpec;
 import com.hedera.services.bdd.spec.HapiSpecSetup;
-import com.hedera.services.bdd.spec.queries.crypto.ExpectedTokenRel;
 import com.hedera.services.bdd.spec.transactions.TxnUtils;
 import com.hedera.services.bdd.spec.utilops.UtilVerbs;
 import com.hedera.services.bdd.suites.HapiApiSuite;
@@ -31,6 +30,7 @@ import com.hederahashgraph.api.proto.java.TokenKycStatus;
 import com.hederahashgraph.api.proto.java.TokenPauseStatus;
 import com.hederahashgraph.api.proto.java.TokenSupplyType;
 import com.hederahashgraph.api.proto.java.TokenType;
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -43,6 +43,9 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import static com.hedera.services.bdd.spec.HapiApiSpec.defaultHapiSpec;
+import static com.hedera.services.bdd.spec.assertions.AccountInfoAsserts.accountWith;
+import static com.hedera.services.bdd.spec.assertions.AutoAssocAsserts.accountTokenPairs;
+import static com.hedera.services.bdd.spec.assertions.TransactionRecordAsserts.recordWith;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getAccountBalance;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getAccountInfo;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getTokenInfo;
@@ -119,64 +122,130 @@ public class TokenCreateSpecs extends HapiApiSuite {
 	@Override
 	protected List<HapiApiSpec> getSpecsInSuite() {
 		return List.of(new HapiApiSpec[] {
-						creationValidatesNonFungiblePrechecks(),
-						creationValidatesMaxSupply(),
-						creationValidatesMemo(),
-						creationValidatesName(),
-						creationValidatesSymbol(),
-						treasuryHasCorrectBalance(),
-						creationRequiresAppropriateSigs(),
-						creationRequiresAppropriateSigsHappyPath(),
-						initialSupplyMustBeSane(),
-						creationYieldsExpectedToken(),
-						creationSetsExpectedName(),
-						creationValidatesTreasuryAccount(),
-						autoRenewValidationWorks(),
-						creationWithoutKYCSetsCorrectStatus(),
-						creationValidatesExpiry(),
-						creationValidatesFreezeDefaultWithNoFreezeKey(),
-						creationSetsCorrectExpiry(),
-						creationHappyPath(),
-						numAccountsAllowedIsDynamic(),
-						worksAsExpectedWithDefaultTokenId(),
-						cannotCreateWithExcessiveLifetime(),
+//						creationValidatesNonFungiblePrechecks(),
+//						creationValidatesMaxSupply(),
+//						creationValidatesMemo(),
+//						creationValidatesName(),
+//						creationValidatesSymbol(),
+//						treasuryHasCorrectBalance(),
+//						creationRequiresAppropriateSigs(),
+//						creationRequiresAppropriateSigsHappyPath(),
+//						initialSupplyMustBeSane(),
+//						creationYieldsExpectedToken(),
+//						creationSetsExpectedName(),
+//						creationValidatesTreasuryAccount(),
+//						autoRenewValidationWorks(),
+//						creationWithoutKYCSetsCorrectStatus(),
+//						creationValidatesExpiry(),
+//						creationValidatesFreezeDefaultWithNoFreezeKey(),
+//						creationSetsCorrectExpiry(),
+//						creationHappyPath(),
+//						numAccountsAllowedIsDynamic(),
+//						worksAsExpectedWithDefaultTokenId(),
+//						cannotCreateWithExcessiveLifetime(),
+//						/* HIP-18 */
+//						onlyValidCustomFeeScheduleCanBeCreated(),
+//						feeCollectorSigningReqsWorkForTokenCreate(),
+//						createsFungibleInfiniteByDefault(),
+//						baseCreationsHaveExpectedPrices(),
+						/* HIP-23 */
 						validateNewTokenAssociations(),
-						/* HIP-18 */
-						onlyValidCustomFeeScheduleCanBeCreated(),
-						feeCollectorSigningReqsWorkForTokenCreate(),
-						createsFungibleInfiniteByDefault(),
-						baseCreationsHaveExpectedPrices(),
 				}
 		);
 	}
 
 	private HapiApiSpec validateNewTokenAssociations() {
 		final String aToken = "TokenA";
-		final String firstUser = "Client1";
-		final String secondUser = "Client2";
+		final String notToBeToken = "notToBeToken";
+		final String hbarCollector = "hbarCollector";
+		final String fractionalCollector = "fractionalCollector";
+		final String selfDenominatedFixedCollector = "selfDenominatedFixedCollector";
+		final String otherSelfDenominatedFixedCollector = "otherSelfDenominatedFixedCollector";
 		final String treasury = "treasury";
+		final String tbd = "toBeDeletd";
+		final String creationTxn = "creationTxn";
+		final String failedCreationTxn = "failedCreationTxn";
+
 		return defaultHapiSpec("ValidateNewTokenAssociations")
 				.given(
-						cryptoCreate(firstUser),
-						cryptoCreate(secondUser),
-						cryptoCreate(treasury).balance(ONE_HUNDRED_HBARS)
-				)
-				.when(
+						cryptoCreate(tbd),
+						cryptoDelete(tbd),
+						cryptoCreate(hbarCollector),
+						cryptoCreate(fractionalCollector),
+						cryptoCreate(selfDenominatedFixedCollector),
+						cryptoCreate(otherSelfDenominatedFixedCollector),
+						cryptoCreate(treasury)
+								.maxAutomaticTokenAssociations(10)
+								.balance(ONE_HUNDRED_HBARS)
+				).when(
+						getAccountInfo(treasury)
+								.savingSnapshot(treasury),
+						getAccountInfo(hbarCollector)
+								.savingSnapshot(hbarCollector),
+						getAccountInfo(fractionalCollector)
+								.savingSnapshot(fractionalCollector),
+						getAccountInfo(selfDenominatedFixedCollector)
+								.savingSnapshot(selfDenominatedFixedCollector),
+						getAccountInfo(otherSelfDenominatedFixedCollector)
+								.savingSnapshot(otherSelfDenominatedFixedCollector),
 						tokenCreate(aToken)
 								.tokenType(TokenType.FUNGIBLE_COMMON)
 								.initialSupply(Long.MAX_VALUE)
 								.treasury(treasury)
-								.withCustom(fractionalFee(1L, 100L, 1L, OptionalLong.of(5L), firstUser))
-								.withCustom(fixedHtsFee(2L, "0.0.0", secondUser))
-								.signedBy(DEFAULT_PAYER, treasury, firstUser, secondUser)
-								.via("tokenCreateTxn")
-				)
-				.then(
-						getTxnRecord("tokenCreateTxn")
-								.hasNewTokenAssociation(aToken, treasury)
-								.hasNewTokenAssociation(aToken, firstUser)
-								.hasNewTokenAssociation(aToken, secondUser)
-								.logged()
+								.withCustom(fixedHbarFee(
+										20L,
+										hbarCollector))
+								.withCustom(fractionalFee(
+										1L, 100L, 1L, OptionalLong.of(5L),
+										fractionalCollector))
+								.withCustom(fixedHtsFee(
+										2L, "0.0.0",
+										selfDenominatedFixedCollector))
+								.withCustom(fixedHtsFee(
+										3L, "0.0.0",
+										otherSelfDenominatedFixedCollector))
+								.signedBy(
+										DEFAULT_PAYER,
+										treasury,
+										fractionalCollector,
+										selfDenominatedFixedCollector, otherSelfDenominatedFixedCollector)
+								.via(creationTxn),
+						tokenCreate(notToBeToken)
+								.treasury(tbd)
+								.hasKnownStatus(INVALID_TREASURY_ACCOUNT_FOR_TOKEN)
+								.via(failedCreationTxn)
+				).then(
+						/* Validate records */
+						getTxnRecord(creationTxn)
+								.hasPriority(recordWith()
+										.autoAssociated(accountTokenPairs(List.of(
+												Pair.of(treasury, aToken),
+												Pair.of(fractionalCollector, aToken),
+												Pair.of(selfDenominatedFixedCollector, aToken),
+												Pair.of(otherSelfDenominatedFixedCollector, aToken)
+										)))),
+						getTxnRecord(failedCreationTxn)
+								.hasPriority(recordWith()
+										.autoAssociated(accountTokenPairs(List.of()))),
+						/* Validate state */
+						getAccountInfo(hbarCollector).has(accountWith()
+								.noChangesFromSnapshot(hbarCollector)),
+						getAccountInfo(treasury)
+								.hasMaxAutomaticAssociations(10)
+								/* TokenCreate auto-associations aren't part of the HIP-23 paradigm */
+								.hasAlreadyUsedAutomaticAssociations(0)
+								.has(accountWith()
+										.newAssociationsFromSnapshot(treasury,
+												List.of(relationshipWith(aToken)))),
+						getAccountInfo(fractionalCollector).has(accountWith()
+								.newAssociationsFromSnapshot(fractionalCollector,
+										List.of(relationshipWith(aToken)))),
+						getAccountInfo(selfDenominatedFixedCollector).has(accountWith()
+								.newAssociationsFromSnapshot(selfDenominatedFixedCollector,
+										List.of(relationshipWith(aToken)))),
+						getAccountInfo(otherSelfDenominatedFixedCollector).has(accountWith()
+								.newAssociationsFromSnapshot(otherSelfDenominatedFixedCollector,
+										List.of(relationshipWith(aToken))))
 				);
 	}
 
@@ -475,7 +544,7 @@ public class TokenCreateSpecs extends HapiApiSuite {
 												.freeze(TokenFreezeStatus.Unfrozen)
 								)
 								.hasToken(
-										ExpectedTokenRel.relationshipWith("non-fungible-unique-finite")
+										relationshipWith("non-fungible-unique-finite")
 												.balance(0)
 												.kyc(TokenKycStatus.KycNotApplicable)
 												.freeze(TokenFreezeStatus.FreezeNotApplicable)
@@ -557,7 +626,7 @@ public class TokenCreateSpecs extends HapiApiSuite {
 
 	public HapiApiSpec creationValidatesMaxSupply() {
 		return defaultHapiSpec("CreationValidatesMaxSupply")
-				.given( ).when( ).then(
+				.given().when().then(
 						tokenCreate("primary")
 								.maxSupply(-1)
 								.hasPrecheck(INVALID_TOKEN_MAX_SUPPLY),

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenPauseSpecs.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenPauseSpecs.java
@@ -1,5 +1,25 @@
 package com.hedera.services.bdd.suites.token;
 
+/*-
+ * ‌
+ * Hedera Services Test Clients
+ * ​
+ * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
 import com.hedera.services.bdd.spec.HapiApiSpec;
 import com.hedera.services.bdd.suites.HapiApiSuite;
 import com.hederahashgraph.api.proto.java.ResponseCodeEnum;

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenTransactSpecs.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenTransactSpecs.java
@@ -197,11 +197,13 @@ public class TokenTransactSpecs extends HapiApiSuite {
 								.autoAssociated(accountTokenPairs(List.of()))),
 						getAccountInfo(beneficiary)
 								.hasAlreadyUsedAutomaticAssociations(0)
-								.has(accountWith().newAssociationsFromSnapshot(
-										beneficiary, List.of(
-												relationshipWith(fungibleToken).balance(500),
-												relationshipWith(uniqueToken).balance(1)
-										)))
+								.has(accountWith().noChangesFromSnapshot(beneficiary)),
+						/* The beneficiary should still have two open auto-association slots */
+						cryptoTransfer(
+								movingUnique(uniqueToken, 1L)
+										.between(treasury, beneficiary),
+								moving(500, fungibleToken).between(treasury, beneficiary)
+						)
 				);
 	}
 
@@ -476,7 +478,6 @@ public class TokenTransactSpecs extends HapiApiSuite {
 						).payingWith("payer").via("successfulTransfer")
 				).then(
 						getAccountBalance("randomBeneficiary")
-								.logged()
 								.hasTokenBalance(B_TOKEN, 100),
 						getTxnRecord("successfulTransfer").logged()
 				);
@@ -565,7 +566,7 @@ public class TokenTransactSpecs extends HapiApiSuite {
 						getAccountBalance("beneficiary")
 								.hasTinyBars(changeFromSnapshot("beneBefore", -1 * ONE_HBAR))
 								.hasTokenBalance(A_TOKEN, 100),
-						getTxnRecord("transactTxn").logged()
+						getTxnRecord("transactTxn")
 				);
 	}
 

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenTransactSpecs.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenTransactSpecs.java
@@ -20,18 +20,21 @@ package com.hedera.services.bdd.suites.token;
  * ‍
  */
 
-import com.google.protobuf.ByteString;
 import com.hedera.services.bdd.spec.HapiApiSpec;
 import com.hedera.services.bdd.suites.HapiApiSuite;
 import com.hederahashgraph.api.proto.java.TokenType;
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.List;
 import java.util.OptionalLong;
 
+import static com.google.protobuf.ByteString.copyFromUtf8;
 import static com.hedera.services.bdd.spec.HapiApiSpec.defaultHapiSpec;
+import static com.hedera.services.bdd.spec.assertions.AccountInfoAsserts.accountWith;
 import static com.hedera.services.bdd.spec.assertions.AccountInfoAsserts.changeFromSnapshot;
+import static com.hedera.services.bdd.spec.assertions.AutoAssocAsserts.accountTokenPairs;
 import static com.hedera.services.bdd.spec.assertions.NoFungibleTransfers.changingNoFungibleBalances;
 import static com.hedera.services.bdd.spec.assertions.NoNftTransfers.changingNoNftOwners;
 import static com.hedera.services.bdd.spec.assertions.SomeFungibleTransfers.changingFungibleBalances;
@@ -80,6 +83,7 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_ACCOUN
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_NFT_ID;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_SIGNATURE;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_TOKEN_ID;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SENDER_DOES_NOT_OWN_NFT_SERIAL_NO;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SUCCESS;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TOKEN_NOT_ASSOCIATED_TO_ACCOUNT;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TOKEN_WAS_DELETED;
@@ -108,45 +112,142 @@ public class TokenTransactSpecs extends HapiApiSuite {
 	@Override
 	protected List<HapiApiSpec> getSpecsInSuite() {
 		return List.of(new HapiApiSpec[] {
-						balancesChangeOnTokenTransfer(),
-						accountsMustBeExplicitlyUnfrozenOnlyIfDefaultFreezeIsTrue(),
-						senderSigsAreValid(),
-						balancesAreChecked(),
-						duplicateAccountsInTokenTransferRejected(),
-						tokenOnlyTxnsAreAtomic(),
-						tokenPlusHbarTxnsAreAtomic(),
-						nonZeroTransfersRejected(),
-						missingEntitiesRejected(),
-						allRequiredSigsAreChecked(),
-						uniqueTokenTxnAccountBalance(),
-						uniqueTokenTxnAccountBalancesForTreasury(),
-						uniqueTokenTxnWithNoAssociation(),
-						uniqueTokenTxnWithFrozenAccount(),
-						uniqueTokenTxnWithSenderNotSigned(),
-						uniqueTokenTxnWithReceiverNotSigned(),
-						uniqueTokenTxnsAreAtomic(),
-						uniqueTokenDeletedTxn(),
-						cannotSendFungibleToDissociatedContractsOrAccounts(),
-						cannotGiveNftsToDissociatedContractsOrAccounts(),
-						recordsIncludeBothFungibleTokenChangesAndOwnershipChange(),
-						transferListsEnforceTokenTypeRestrictions(),
-						/* HIP-18 charging case studies */
-						fixedHbarCaseStudy(),
-						fractionalCaseStudy(),
-						simpleHtsFeeCaseStudy(),
-						nestedHbarCaseStudy(),
-						nestedFractionalCaseStudy(),
-						nestedHtsCaseStudy(),
-						treasuriesAreExemptFromAllCustomFees(),
-						collectorsAreExemptFromTheirOwnFeesButNotOthers(),
-						multipleRoyaltyFallbackCaseStudy(),
-						normalRoyaltyCaseStudy(),
-						canTransactInTokenWithSelfDenominatedFixedFee(),
-						nftOwnersChangeAtomically(),
-						fractionalNetOfTransfersCaseStudy(),
-						royaltyAndFractionalTogetherCaseStudy(),
+//						balancesChangeOnTokenTransfer(),
+//						accountsMustBeExplicitlyUnfrozenOnlyIfDefaultFreezeIsTrue(),
+//						senderSigsAreValid(),
+//						balancesAreChecked(),
+//						duplicateAccountsInTokenTransferRejected(),
+//						tokenOnlyTxnsAreAtomic(),
+//						tokenPlusHbarTxnsAreAtomic(),
+//						nonZeroTransfersRejected(),
+//						missingEntitiesRejected(),
+//						allRequiredSigsAreChecked(),
+//						uniqueTokenTxnAccountBalance(),
+//						uniqueTokenTxnAccountBalancesForTreasury(),
+//						uniqueTokenTxnWithNoAssociation(),
+//						uniqueTokenTxnWithFrozenAccount(),
+//						uniqueTokenTxnWithSenderNotSigned(),
+//						uniqueTokenTxnWithReceiverNotSigned(),
+//						uniqueTokenTxnsAreAtomic(),
+//						uniqueTokenDeletedTxn(),
+//						cannotSendFungibleToDissociatedContractsOrAccounts(),
+//						cannotGiveNftsToDissociatedContractsOrAccounts(),
+//						recordsIncludeBothFungibleTokenChangesAndOwnershipChange(),
+//						transferListsEnforceTokenTypeRestrictions(),
+//						/* HIP-18 charging case studies */
+//						fixedHbarCaseStudy(),
+//						fractionalCaseStudy(),
+//						simpleHtsFeeCaseStudy(),
+//						nestedHbarCaseStudy(),
+//						nestedFractionalCaseStudy(),
+//						nestedHtsCaseStudy(),
+//						treasuriesAreExemptFromAllCustomFees(),
+//						collectorsAreExemptFromTheirOwnFeesButNotOthers(),
+//						multipleRoyaltyFallbackCaseStudy(),
+//						normalRoyaltyCaseStudy(),
+//						canTransactInTokenWithSelfDenominatedFixedFee(),
+//						nftOwnersChangeAtomically(),
+//						fractionalNetOfTransfersCaseStudy(),
+//						royaltyAndFractionalTogetherCaseStudy(),
+						/* HIP-23 */
+//						happyPathAutoAssociationsWorkForBothTokenTypes(),
+						failedAutoAssociationHasNoSideEffectsOrHistory(),
 				}
 		);
+	}
+
+	public HapiApiSpec failedAutoAssociationHasNoSideEffectsOrHistory() {
+		final var treasury = "treasury";
+		final var beneficiary = "beneficiary";
+		final var unluckyBeneficiary = "unluckyBeneficiary";
+		final var uniqueToken = "unique";
+		final var fungibleToken = "fungible";
+		final var multiPurpose = "multiPurpose";
+		final var transferTxn = "transferTxn";
+
+		return defaultHapiSpec("failedAutoAssociationHasNoSideEffectsOrHistory")
+				.given(
+						newKeyNamed(multiPurpose),
+						cryptoCreate(treasury),
+						tokenCreate(fungibleToken)
+								.tokenType(TokenType.FUNGIBLE_COMMON)
+								.initialSupply(1_000L)
+								.treasury(treasury),
+						tokenCreate(uniqueToken)
+								.tokenType(NON_FUNGIBLE_UNIQUE)
+								.supplyKey(multiPurpose)
+								.initialSupply(0L)
+								.treasury(treasury),
+						mintToken(uniqueToken, List.of(copyFromUtf8("ONE"), copyFromUtf8("TWO"))),
+						cryptoCreate(beneficiary).maxAutomaticTokenAssociations(2),
+						cryptoCreate(unluckyBeneficiary),
+						tokenAssociate(unluckyBeneficiary, uniqueToken),
+						getAccountInfo(beneficiary).savingSnapshot(beneficiary),
+						getAccountInfo(unluckyBeneficiary).savingSnapshot(unluckyBeneficiary)
+				).when(
+						cryptoTransfer(
+								movingUnique(uniqueToken, 1L)
+										.between(treasury, beneficiary),
+								moving(500, fungibleToken).between(treasury, beneficiary),
+								movingUnique(uniqueToken, 1L)
+										.between(treasury, unluckyBeneficiary)
+						).via(transferTxn).hasKnownStatus(SENDER_DOES_NOT_OWN_NFT_SERIAL_NO)
+				).then(
+						getTxnRecord(transferTxn).hasPriority(recordWith()
+								.autoAssociated(accountTokenPairs(List.of()))),
+						getAccountInfo(beneficiary)
+								.hasAlreadyUsedAutomaticAssociations(0)
+								.has(accountWith().newAssociationsFromSnapshot(
+										beneficiary, List.of(
+												relationshipWith(fungibleToken).balance(500),
+												relationshipWith(uniqueToken).balance(1)
+										)))
+				);
+	}
+
+	public HapiApiSpec happyPathAutoAssociationsWorkForBothTokenTypes() {
+		final var treasury = "treasury";
+		final var beneficiary = "beneficiary";
+		final var uniqueToken = "unique";
+		final var fungibleToken = "fungible";
+		final var multiPurpose = "multiPurpose";
+		final var transferTxn = "transferTxn";
+
+		return defaultHapiSpec("HappyPathAutoAssociationsWorkForBothTokenTypes")
+				.given(
+						newKeyNamed(multiPurpose),
+						cryptoCreate(treasury),
+						tokenCreate(fungibleToken)
+								.tokenType(TokenType.FUNGIBLE_COMMON)
+								.initialSupply(1_000L)
+								.treasury(treasury),
+						tokenCreate(uniqueToken)
+								.tokenType(NON_FUNGIBLE_UNIQUE)
+								.supplyKey(multiPurpose)
+								.initialSupply(0L)
+								.treasury(treasury),
+						mintToken(uniqueToken, List.of(copyFromUtf8("ONE"), copyFromUtf8("TWO"))),
+						cryptoCreate(beneficiary).maxAutomaticTokenAssociations(2),
+						getAccountInfo(beneficiary).savingSnapshot(beneficiary)
+				).when(
+						cryptoTransfer(
+								movingUnique(uniqueToken, 1L)
+										.between(treasury, beneficiary),
+								moving(500, fungibleToken).between(treasury, beneficiary)
+						).via(transferTxn)
+				).then(
+						getTxnRecord(transferTxn).hasPriority(recordWith()
+								.autoAssociated(accountTokenPairs(List.of(
+										Pair.of(beneficiary, fungibleToken),
+										Pair.of(beneficiary, uniqueToken))))),
+						getAccountInfo(beneficiary)
+								.hasAlreadyUsedAutomaticAssociations(2)
+								.has(accountWith().newAssociationsFromSnapshot(
+										beneficiary, List.of(
+												relationshipWith(fungibleToken).balance(500),
+												relationshipWith(uniqueToken).balance(1)
+										)))
+				);
 	}
 
 	public HapiApiSpec transferListsEnforceTokenTypeRestrictions() {
@@ -168,7 +269,7 @@ public class TokenTransactSpecs extends HapiApiSuite {
 								.initialSupply(0L)
 								.treasury(TOKEN_TREASURY)
 				).when(
-						mintToken(B_TOKEN, List.of(ByteString.copyFromUtf8("dark"))),
+						mintToken(B_TOKEN, List.of(copyFromUtf8("dark"))),
 						tokenAssociate(theAccount, List.of(A_TOKEN, B_TOKEN))
 				).then(
 						cryptoTransfer(
@@ -201,7 +302,7 @@ public class TokenTransactSpecs extends HapiApiSuite {
 								.tokenType(TokenType.NON_FUNGIBLE_UNIQUE)
 								.initialSupply(0L)
 								.treasury(TOKEN_TREASURY),
-						mintToken(theUniqueToken, List.of(ByteString.copyFromUtf8("Doesn't matter"))),
+						mintToken(theUniqueToken, List.of(copyFromUtf8("Doesn't matter"))),
 						tokenAssociate(theAccount, theUniqueToken),
 						tokenAssociate(theAccount, theCommonToken)
 				).when(
@@ -231,7 +332,7 @@ public class TokenTransactSpecs extends HapiApiSuite {
 								.treasury(TOKEN_TREASURY),
 						tokenAssociate(theContract, A_TOKEN),
 						tokenAssociate(theAccount, A_TOKEN),
-						mintToken(A_TOKEN, List.of(ByteString.copyFromUtf8("dark"), ByteString.copyFromUtf8("matter")))
+						mintToken(A_TOKEN, List.of(copyFromUtf8("dark"), copyFromUtf8("matter")))
 				).when(
 						getContractInfo(theContract).hasToken(relationshipWith(A_TOKEN)),
 						getAccountInfo(theAccount).hasToken(relationshipWith(A_TOKEN)),
@@ -255,11 +356,11 @@ public class TokenTransactSpecs extends HapiApiSuite {
 						getAccountNftInfos(theAccount, 0, 1)
 								.hasNfts(
 										newTokenNftInfo(A_TOKEN,
-												2, theAccount, ByteString.copyFromUtf8("matter"))),
+												2, theAccount, copyFromUtf8("matter"))),
 						getAccountNftInfos(theContract, 0, 1)
 								.hasNfts(
 										newTokenNftInfo(A_TOKEN,
-												1, theContract, ByteString.copyFromUtf8("dark")))
+												1, theContract, copyFromUtf8("dark")))
 				);
 	}
 
@@ -610,7 +711,7 @@ public class TokenTransactSpecs extends HapiApiSuite {
 								.initialSupply(0)
 								.supplyKey("supplyKey")
 								.treasury(TOKEN_TREASURY),
-						mintToken(A_TOKEN, List.of(ByteString.copyFromUtf8("memo"))),
+						mintToken(A_TOKEN, List.of(copyFromUtf8("memo"))),
 						tokenAssociate(FIRST_USER, A_TOKEN)
 				).when(
 						cryptoTransfer(
@@ -624,12 +725,12 @@ public class TokenTransactSpecs extends HapiApiSuite {
 						getTokenInfo(A_TOKEN),
 						getTokenNftInfo(A_TOKEN, 1)
 								.hasSerialNum(1)
-								.hasMetadata(ByteString.copyFromUtf8("memo"))
+								.hasMetadata(copyFromUtf8("memo"))
 								.hasTokenID(A_TOKEN)
 								.hasAccountID(FIRST_USER),
 						getAccountNftInfos(FIRST_USER, 0, 1)
 								.hasNfts(
-										newTokenNftInfo(A_TOKEN, 1, FIRST_USER, ByteString.copyFromUtf8("memo"))),
+										newTokenNftInfo(A_TOKEN, 1, FIRST_USER, copyFromUtf8("memo"))),
 						getTxnRecord("cryptoTransferTxn").logged()
 				);
 	}
@@ -651,8 +752,8 @@ public class TokenTransactSpecs extends HapiApiSuite {
 								.adminKey("supplyKey")
 								.supplyKey("supplyKey")
 								.treasury("oldTreasury"),
-						mintToken(A_TOKEN, List.of(ByteString.copyFromUtf8("memo"))),
-						mintToken(B_TOKEN, List.of(ByteString.copyFromUtf8("memo2"))),
+						mintToken(A_TOKEN, List.of(copyFromUtf8("memo"))),
+						mintToken(B_TOKEN, List.of(copyFromUtf8("memo2"))),
 						tokenAssociate("newTreasury", A_TOKEN, B_TOKEN),
 						tokenUpdate(B_TOKEN)
 								.treasury("newTreasury")
@@ -670,17 +771,17 @@ public class TokenTransactSpecs extends HapiApiSuite {
 								.hasTokenBalance(B_TOKEN, 1),
 						getTokenNftInfo(A_TOKEN, 1)
 								.hasSerialNum(1)
-								.hasMetadata(ByteString.copyFromUtf8("memo"))
+								.hasMetadata(copyFromUtf8("memo"))
 								.hasTokenID(A_TOKEN)
 								.hasAccountID("newTreasury"),
 						getTokenNftInfos(A_TOKEN, 0, 1)
 								.hasNfts(
-										newTokenNftInfo(A_TOKEN, 1, "newTreasury", ByteString.copyFromUtf8("memo"))
+										newTokenNftInfo(A_TOKEN, 1, "newTreasury", copyFromUtf8("memo"))
 								).logged(),
 						getAccountNftInfos("newTreasury", 0, 2)
 								.hasNfts(
-										newTokenNftInfo(A_TOKEN, 1, "newTreasury", ByteString.copyFromUtf8("memo")),
-										newTokenNftInfo(B_TOKEN, 1, "newTreasury", ByteString.copyFromUtf8("memo2"))
+										newTokenNftInfo(A_TOKEN, 1, "newTreasury", copyFromUtf8("memo")),
+										newTokenNftInfo(B_TOKEN, 1, "newTreasury", copyFromUtf8("memo2"))
 								).logged(),
 						getTxnRecord("cryptoTransferTxn").logged()
 				);
@@ -699,7 +800,7 @@ public class TokenTransactSpecs extends HapiApiSuite {
 								.treasury(TOKEN_TREASURY)
 				)
 				.when(
-						mintToken(A_TOKEN, List.of(ByteString.copyFromUtf8("memo")))
+						mintToken(A_TOKEN, List.of(copyFromUtf8("memo")))
 				)
 				.then(
 						cryptoTransfer(
@@ -709,7 +810,7 @@ public class TokenTransactSpecs extends HapiApiSuite {
 						getAccountNftInfos(TOKEN_TREASURY, 0, 1)
 								.hasNfts(
 										newTokenNftInfo(A_TOKEN, 1, TOKEN_TREASURY,
-												ByteString.copyFromUtf8("memo"))
+												copyFromUtf8("memo"))
 								)
 				);
 	}
@@ -731,7 +832,7 @@ public class TokenTransactSpecs extends HapiApiSuite {
 						tokenAssociate(FIRST_USER, A_TOKEN)
 				)
 				.when(
-						mintToken(A_TOKEN, List.of(ByteString.copyFromUtf8("memo")))
+						mintToken(A_TOKEN, List.of(copyFromUtf8("memo")))
 				)
 				.then(
 						cryptoTransfer(
@@ -756,7 +857,7 @@ public class TokenTransactSpecs extends HapiApiSuite {
 						tokenAssociate(FIRST_USER, A_TOKEN)
 				)
 				.when(
-						mintToken(A_TOKEN, List.of(ByteString.copyFromUtf8("memo")))
+						mintToken(A_TOKEN, List.of(copyFromUtf8("memo")))
 				)
 				.then(
 						cryptoTransfer(
@@ -783,7 +884,7 @@ public class TokenTransactSpecs extends HapiApiSuite {
 						tokenAssociate(FIRST_USER, A_TOKEN)
 				)
 				.when(
-						mintToken(A_TOKEN, List.of(ByteString.copyFromUtf8("memo")))
+						mintToken(A_TOKEN, List.of(copyFromUtf8("memo")))
 				)
 				.then(
 						cryptoTransfer(
@@ -811,7 +912,7 @@ public class TokenTransactSpecs extends HapiApiSuite {
 						tokenCreate(B_TOKEN)
 								.initialSupply(100)
 								.treasury(TOKEN_TREASURY),
-						mintToken(A_TOKEN, List.of(ByteString.copyFromUtf8("memo"))),
+						mintToken(A_TOKEN, List.of(copyFromUtf8("memo"))),
 						tokenAssociate(FIRST_USER, A_TOKEN),
 						tokenAssociate(FIRST_USER, B_TOKEN),
 						tokenAssociate(SECOND_USER, A_TOKEN)
@@ -850,7 +951,7 @@ public class TokenTransactSpecs extends HapiApiSuite {
 								.supplyKey("supplyKey")
 								.adminKey("nftAdmin")
 								.treasury(TOKEN_TREASURY),
-						mintToken(A_TOKEN, List.of(ByteString.copyFromUtf8("memo"))),
+						mintToken(A_TOKEN, List.of(copyFromUtf8("memo"))),
 						tokenAssociate(FIRST_USER, A_TOKEN)
 				).when(
 						tokenDelete(A_TOKEN)
@@ -885,8 +986,8 @@ public class TokenTransactSpecs extends HapiApiSuite {
 								.initialSupply(0L)
 								.treasury(treasuryForToken)
 								.withCustom(fixedHbarFee(ONE_HBAR, treasuryForToken)),
-						mintToken(tokenWithHbarFee, List.of(ByteString.copyFromUtf8("First!"))),
-						mintToken(tokenWithHbarFee, List.of(ByteString.copyFromUtf8("Second!"))),
+						mintToken(tokenWithHbarFee, List.of(copyFromUtf8("First!"))),
+						mintToken(tokenWithHbarFee, List.of(copyFromUtf8("Second!"))),
 						tokenAssociate(alice, tokenWithHbarFee),
 						tokenAssociate(bob, tokenWithHbarFee),
 						cryptoTransfer(movingUnique(tokenWithHbarFee, 2L).between(treasuryForToken, alice))
@@ -1270,7 +1371,7 @@ public class TokenTransactSpecs extends HapiApiSuite {
 										westWindOwner)),
 						tokenAssociate(amelie, List.of(westWindArt, usdc)),
 						tokenAssociate(zephyr, List.of(westWindArt, usdc)),
-						mintToken(westWindArt, List.of(ByteString.copyFromUtf8("Fugues and fantastics")))
+						mintToken(westWindArt, List.of(copyFromUtf8("Fugues and fantastics")))
 				).when(
 						cryptoTransfer(
 								movingUnique(westWindArt, 1L)
@@ -1347,7 +1448,7 @@ public class TokenTransactSpecs extends HapiApiSuite {
 										westWindTreasury)),
 						tokenAssociate(amelie, List.of(westWindArt, usdc)),
 						tokenAssociate(alice, List.of(westWindArt, usdc)),
-						mintToken(westWindArt, List.of(ByteString.copyFromUtf8("Fugues and fantastics"))),
+						mintToken(westWindArt, List.of(copyFromUtf8("Fugues and fantastics"))),
 						cryptoTransfer(
 								moving(200, usdc)
 										.between(usdcTreasury, alice)
@@ -1409,7 +1510,7 @@ public class TokenTransactSpecs extends HapiApiSuite {
 										westWindTreasury)),
 						tokenAssociate(amelie, List.of(westWindArt, usdc)),
 						tokenAssociate(alice, List.of(westWindArt, usdc)),
-						mintToken(westWindArt, List.of(ByteString.copyFromUtf8("Fugues and fantastics"))),
+						mintToken(westWindArt, List.of(copyFromUtf8("Fugues and fantastics"))),
 						cryptoTransfer(
 								moving(200, usdc)
 										.between(usdcTreasury, alice)
@@ -1583,7 +1684,7 @@ public class TokenTransactSpecs extends HapiApiSuite {
 		final var harry = "harry";
 		final var uncompletableTxn = "uncompletableTxn";
 		final var supplyKey = "supplyKey";
-		final var serialNo1Meta = ByteString.copyFromUtf8("PRICELESS");
+		final var serialNo1Meta = copyFromUtf8("PRICELESS");
 
 		return defaultHapiSpec("NftOwnersChangeAtomically")
 				.given(

--- a/test-clients/src/main/java/com/hedera/services/yahcli/commands/accounts/RekeyCommand.java
+++ b/test-clients/src/main/java/com/hedera/services/yahcli/commands/accounts/RekeyCommand.java
@@ -1,5 +1,25 @@
 package com.hedera.services.yahcli.commands.accounts;
 
+/*-
+ * ‌
+ * Hedera Services Test Clients
+ * ​
+ * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
 import com.google.common.io.Files;
 import com.hedera.services.yahcli.config.ConfigManager;
 import com.hedera.services.yahcli.config.ConfigUtils;

--- a/test-clients/src/main/java/com/hedera/services/yahcli/suites/RekeySuite.java
+++ b/test-clients/src/main/java/com/hedera/services/yahcli/suites/RekeySuite.java
@@ -1,5 +1,25 @@
 package com.hedera.services.yahcli.suites;
 
+/*-
+ * ‌
+ * Hedera Services Test Clients
+ * ​
+ * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
 import com.hedera.services.bdd.spec.HapiApiSpec;
 import com.hedera.services.bdd.spec.transactions.TxnUtils;
 import com.hedera.services.bdd.suites.HapiApiSuite;


### PR DESCRIPTION
**Description**:
- Provides a (retrospective) testing plan for HIP-23.
- Rolls back all side-effects caused by caused by auto-associations during an unsuccessful `CryptoTransfer`, namely:
    1. Side-effects on the `accounts` map.
    2. Side-effects on the transaction record.

Below are the deliverables from the testing plan.

---

:fountain_pen:&nbsp;**Record validation**
EET framework:
  - [x] `TransactionRecordAsserts` for the `automatic_token_associations` field.

:sparkle:&nbsp;**State validation**
EET framework:
  - [x] `GetAccountInfo` asserts for max and in-use automatic association fields.
  - [x] Account snapshot and change-vs-snapshot asserts.

:cactus:&nbsp;**Migration tests**
Unit tests:
  - [x] A `MerkleAccountState` now serializes its account field.
  - [x] A `MerkleAccountState` can be deserialized from a prior-version state.
  - [x] A `MerkleAccountState` can be deserialized from a current-version state.

:white_check_mark:&nbsp;**Positive functional**
EETs (all with post-transaction record and state validation):
  - [x] A `TokenCreate` record includes the treasury auto-association.
  - [x] A `TokenCreate` record includes all fractional fee collector auto-associations.
  - [x] A `TokenCreate` record includes all self-denominated fee collector auto-associations.
  - [x] An account with open auto-association slots can receive units of an unassociated fungible token.
  - [x] An account with open auto-association slot can receive an NFT of an unassociated unique token.
  - [ ] An account updated to have 3 more auto-association slots can receive 3 more units and NFTs from unassociated tokens.

:x:&nbsp;**Negative functional**
EETs (all with post-transaction record and state validation):
  - [x] A failed `TokenCreate` performs and records no auto-associations.
  - [ ] A `CryptoCreate` cannot allocate more auto-association slots than the max-per-account limit.
  - [ ] A `CryptoUpdate` cannot allocate more auto-association slots than the max-per-account limit.
  - [ ] A `CryptoUpdate` cannot renounce more auto-association slots than it has already used.
  - [ ] A two-party `CryptoTransfer` rolls back all side-effects if an auto-association fails.
  - [ ] A multi-party `CryptoTransfer` rolls back all auto-association side-effects if it fails.

:receipt:&nbsp;**Custom fee interplays**
EETs (all with post-transaction record and state validation):
  - [ ] A royalty fee collector with free auto-association slots can capture exchanged value from unassociated tokens.
  - [ ] A royalty fee collector with no auto-association slots cannnot capture exchanged value from unassociated tokens.
  - [ ] A manually dissociated fixed fee collector with auto-association slots can use auto-association to still receive fees.
  - [ ] A manually dissociated fractional fee collector with auto-association slots can use auto-association to still receive fees.