### PR TITLE
Avoid throwing exceptions in gRPC/transaction submission layer

### DIFF
--- a/hedera-node/src/main/java/com/hedera/services/state/merkle/internals/BitPackUtils.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/merkle/internals/BitPackUtils.java
@@ -204,10 +204,7 @@ public class BitPackUtils {
 	 * @return true if valid, else returns false
 	 */
 	public static boolean isValidLong(long num) {
-		if (num < 0 || num > MAX_NUM_ALLOWED) {
-			return false;
-		}
-		return true;
+		return num >= 0 || num <= MAX_NUM_ALLOWED;
 	}
 
 	BitPackUtils() {

--- a/hedera-node/src/main/java/com/hedera/services/state/merkle/internals/BitPackUtils.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/merkle/internals/BitPackUtils.java
@@ -196,6 +196,20 @@ public class BitPackUtils {
 		return (alreadyUsedAutoAssociations << 16) | getMaxAutomaticAssociationsFrom(autoAssociationMetadata);
 	}
 
+	/**
+	 * Checks if the given long is not a number in the allowed range
+	 *
+	 * @param num
+	 * 		given long number to check
+	 * @return true if valid, else returns false
+	 */
+	public static boolean isValidLong(long num) {
+		if (num < 0 || num > MAX_NUM_ALLOWED) {
+			return false;
+		}
+		return true;
+	}
+
 	BitPackUtils() {
 		throw new UnsupportedOperationException("Utility Class");
 	}

--- a/hedera-node/src/main/java/com/hedera/services/state/merkle/internals/BitPackUtils.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/merkle/internals/BitPackUtils.java
@@ -203,7 +203,7 @@ public class BitPackUtils {
 	 * 		given long number to check
 	 * @return true if valid, else returns false
 	 */
-	public static boolean isValidLong(long num) {
+	public static boolean isValidNum(long num) {
 		return num >= 0 && num <= MAX_NUM_ALLOWED;
 	}
 

--- a/hedera-node/src/main/java/com/hedera/services/state/merkle/internals/BitPackUtils.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/merkle/internals/BitPackUtils.java
@@ -204,7 +204,7 @@ public class BitPackUtils {
 	 * @return true if valid, else returns false
 	 */
 	public static boolean isValidLong(long num) {
-		return num >= 0 || num <= MAX_NUM_ALLOWED;
+		return num >= 0 && num <= MAX_NUM_ALLOWED;
 	}
 
 	BitPackUtils() {

--- a/hedera-node/src/main/java/com/hedera/services/state/submerkle/EntityId.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/submerkle/EntityId.java
@@ -173,42 +173,42 @@ public class EntityId implements SelfSerializable {
 	/* --- Helpers --- */
 	public static EntityId fromGrpcAccountId(AccountID id) {
 		if (id == null) {
-			throw new IllegalArgumentException("Given account id was null!");
+			return MISSING_ENTITY_ID;
 		}
 		return new EntityId(id.getShardNum(), id.getRealmNum(), id.getAccountNum());
 	}
 
 	public static EntityId fromGrpcFileId(FileID id) {
 		if (id == null) {
-			throw new IllegalArgumentException("Given file id was null!");
+			return MISSING_ENTITY_ID;
 		}
 		return new EntityId(id.getShardNum(), id.getRealmNum(), id.getFileNum());
 	}
 
 	public static EntityId fromGrpcTopicId(TopicID id) {
 		if (id == null) {
-			throw new IllegalArgumentException("Given topic id was null!");
+			return MISSING_ENTITY_ID;
 		}
 		return new EntityId(id.getShardNum(), id.getRealmNum(), id.getTopicNum());
 	}
 
 	public static EntityId fromGrpcTokenId(TokenID id) {
 		if (id == null) {
-			throw new IllegalArgumentException("Given token id was null!");
+			return MISSING_ENTITY_ID;
 		}
 		return new EntityId(id.getShardNum(), id.getRealmNum(), id.getTokenNum());
 	}
 
 	public static EntityId fromGrpcScheduleId(ScheduleID id) {
 		if (id == null) {
-			throw new IllegalArgumentException("Given schedule id was null!");
+			return MISSING_ENTITY_ID;
 		}
 		return new EntityId(id.getShardNum(), id.getRealmNum(), id.getScheduleNum());
 	}
 
 	public static EntityId fromGrpcContractId(ContractID id) {
 		if (id == null) {
-			throw new IllegalArgumentException("Given contract id was null!");
+			return MISSING_ENTITY_ID;
 		}
 		return new EntityId(id.getShardNum(), id.getRealmNum(), id.getContractNum());
 	}

--- a/hedera-node/src/main/java/com/hedera/services/state/submerkle/RichInstant.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/submerkle/RichInstant.java
@@ -30,8 +30,6 @@ import java.time.Instant;
 import java.util.Objects;
 import java.util.Optional;
 
-import static com.hedera.services.state.merkle.internals.BitPackUtils.isValidLong;
-
 public class RichInstant {
 	public static final RichInstant MISSING_INSTANT = new RichInstant(0L, 0);
 

--- a/hedera-node/src/main/java/com/hedera/services/state/submerkle/RichInstant.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/submerkle/RichInstant.java
@@ -96,11 +96,9 @@ public class RichInstant {
 	/* --- Helpers --- */
 
 	public static RichInstant fromGrpc(Timestamp grpc) {
-		if (!isValidLong(grpc.getSeconds()) || !isValidLong(grpc.getNanos()) ||
-				grpc.equals(Timestamp.getDefaultInstance())) {
-			return MISSING_INSTANT;
-		}
-		return new RichInstant(grpc.getSeconds(), grpc.getNanos());
+		return grpc.equals(Timestamp.getDefaultInstance())
+				? MISSING_INSTANT
+				: new RichInstant(grpc.getSeconds(), grpc.getNanos());
 	}
 
 	public Timestamp toGrpc() {

--- a/hedera-node/src/main/java/com/hedera/services/state/submerkle/RichInstant.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/submerkle/RichInstant.java
@@ -30,6 +30,8 @@ import java.time.Instant;
 import java.util.Objects;
 import java.util.Optional;
 
+import static com.hedera.services.state.merkle.internals.BitPackUtils.isValidLong;
+
 public class RichInstant {
 	public static final RichInstant MISSING_INSTANT = new RichInstant(0L, 0);
 
@@ -94,9 +96,11 @@ public class RichInstant {
 	/* --- Helpers --- */
 
 	public static RichInstant fromGrpc(Timestamp grpc) {
-		return grpc.equals(Timestamp.getDefaultInstance())
-				? MISSING_INSTANT
-				: new RichInstant(grpc.getSeconds(), grpc.getNanos());
+		if (!isValidLong(grpc.getSeconds()) || !isValidLong(grpc.getNanos()) ||
+				grpc.equals(Timestamp.getDefaultInstance())) {
+			return MISSING_INSTANT;
+		}
+		return new RichInstant(grpc.getSeconds(), grpc.getNanos());
 	}
 
 	public Timestamp toGrpc() {

--- a/hedera-node/src/main/java/com/hedera/services/store/schedule/HederaScheduleStore.java
+++ b/hedera-node/src/main/java/com/hedera/services/store/schedule/HederaScheduleStore.java
@@ -44,6 +44,7 @@ import java.util.function.Supplier;
 import static com.hedera.services.store.CreationResult.failure;
 import static com.hedera.services.store.CreationResult.success;
 import static com.hedera.services.utils.EntityIdUtils.readableId;
+import static com.hedera.services.utils.EntityNum.fromLong;
 import static com.hedera.services.utils.EntityNum.fromScheduleId;
 import static com.hedera.services.utils.MiscUtils.forEach;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_SCHEDULE_ACCOUNT_ID;
@@ -216,7 +217,7 @@ public final class HederaScheduleStore extends HederaStore implements ScheduleSt
 					readableId(id)));
 		}
 		var schedule = get(id);
-		schedules.get().remove(EntityNum.fromLong(entityId.num()));
+		schedules.get().remove(fromLong(entityId.num()));
 		extantSchedules.remove(schedule);
 	}
 

--- a/hedera-node/src/main/java/com/hedera/services/utils/EntityNum.java
+++ b/hedera-node/src/main/java/com/hedera/services/utils/EntityNum.java
@@ -29,7 +29,7 @@ import com.hederahashgraph.api.proto.java.TopicID;
 
 import static com.hedera.services.context.properties.StaticPropertiesHolder.STATIC_PROPERTIES;
 import static com.hedera.services.state.merkle.internals.BitPackUtils.codeFromNum;
-import static com.hedera.services.state.merkle.internals.BitPackUtils.isValidLong;
+import static com.hedera.services.state.merkle.internals.BitPackUtils.isValidNum;
 import static com.hedera.services.state.merkle.internals.BitPackUtils.numFromCode;
 
 /**
@@ -51,7 +51,7 @@ public class EntityNum {
 	}
 
 	public static EntityNum fromLong(long l) {
-		if (!isValidLong(l)) {
+		if (!isValidNum(l)) {
 			return MISSING_NUM;
 		}
 		final var value = codeFromNum(l);

--- a/hedera-node/src/main/java/com/hedera/services/utils/EntityNum.java
+++ b/hedera-node/src/main/java/com/hedera/services/utils/EntityNum.java
@@ -29,6 +29,7 @@ import com.hederahashgraph.api.proto.java.TopicID;
 
 import static com.hedera.services.context.properties.StaticPropertiesHolder.STATIC_PROPERTIES;
 import static com.hedera.services.state.merkle.internals.BitPackUtils.codeFromNum;
+import static com.hedera.services.state.merkle.internals.BitPackUtils.isValidLong;
 import static com.hedera.services.state.merkle.internals.BitPackUtils.numFromCode;
 
 /**
@@ -50,6 +51,9 @@ public class EntityNum {
 	}
 
 	public static EntityNum fromLong(long l) {
+		if (!isValidLong(l)) {
+			return MISSING_NUM;
+		}
 		final var value = codeFromNum(l);
 		return new EntityNum(value);
 	}

--- a/hedera-node/src/main/java/com/hedera/services/utils/EntityNumPair.java
+++ b/hedera-node/src/main/java/com/hedera/services/utils/EntityNumPair.java
@@ -28,7 +28,7 @@ import com.hederahashgraph.api.proto.java.TokenID;
 import org.apache.commons.lang3.tuple.Pair;
 
 import static com.hedera.services.context.properties.StaticPropertiesHolder.STATIC_PROPERTIES;
-import static com.hedera.services.state.merkle.internals.BitPackUtils.isValidLong;
+import static com.hedera.services.state.merkle.internals.BitPackUtils.isValidNum;
 import static com.hedera.services.state.merkle.internals.BitPackUtils.packedNums;
 import static com.hedera.services.state.merkle.internals.BitPackUtils.unsignedHighOrder32From;
 import static com.hedera.services.state.merkle.internals.BitPackUtils.unsignedLowOrder32From;
@@ -44,7 +44,7 @@ public class EntityNumPair {
 	}
 
 	public static EntityNumPair fromLongs(long hi, long lo) {
-		if (!isValidLong(hi) || !isValidLong(lo)) {
+		if (!isValidNum(hi) || !isValidNum(lo)) {
 			return MISSING_NUM_PAIR;
 		}
 		final var value = packedNums(hi, lo);

--- a/hedera-node/src/main/java/com/hedera/services/utils/EntityNumPair.java
+++ b/hedera-node/src/main/java/com/hedera/services/utils/EntityNumPair.java
@@ -9,9 +9,9 @@ package com.hedera.services.utils;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -28,6 +28,7 @@ import com.hederahashgraph.api.proto.java.TokenID;
 import org.apache.commons.lang3.tuple.Pair;
 
 import static com.hedera.services.context.properties.StaticPropertiesHolder.STATIC_PROPERTIES;
+import static com.hedera.services.state.merkle.internals.BitPackUtils.isValidLong;
 import static com.hedera.services.state.merkle.internals.BitPackUtils.packedNums;
 import static com.hedera.services.state.merkle.internals.BitPackUtils.unsignedHighOrder32From;
 import static com.hedera.services.state.merkle.internals.BitPackUtils.unsignedLowOrder32From;
@@ -43,6 +44,9 @@ public class EntityNumPair {
 	}
 
 	public static EntityNumPair fromLongs(long hi, long lo) {
+		if (!isValidLong(hi) || !isValidLong(lo)) {
+			return MISSING_NUM_PAIR;
+		}
 		final var value = packedNums(hi, lo);
 		return new EntityNumPair(value);
 	}

--- a/hedera-node/src/test/java/com/hedera/services/state/merkle/internals/BitPackUtilsTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/state/merkle/internals/BitPackUtilsTest.java
@@ -28,6 +28,7 @@ import static com.hedera.services.state.merkle.internals.BitPackUtils.MAX_NUM_AL
 import static com.hedera.services.state.merkle.internals.BitPackUtils.buildAutomaticAssociationMetaData;
 import static com.hedera.services.state.merkle.internals.BitPackUtils.getAlreadyUsedAutomaticAssociationsFrom;
 import static com.hedera.services.state.merkle.internals.BitPackUtils.getMaxAutomaticAssociationsFrom;
+import static com.hedera.services.state.merkle.internals.BitPackUtils.isValidNum;
 import static com.hedera.services.state.merkle.internals.BitPackUtils.setAlreadyUsedAutomaticAssociationsTo;
 import static com.hedera.services.state.merkle.internals.BitPackUtils.setMaxAutomaticAssociationsTo;
 import static com.hedera.services.state.merkle.internals.BitPackUtils.signedLowOrder32From;
@@ -35,7 +36,9 @@ import static com.hedera.services.state.merkle.internals.BitPackUtils.packedTime
 import static com.hedera.services.state.merkle.internals.BitPackUtils.unsignedHighOrder32From;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class BitPackUtilsTest {
 	private final int maxAutoAssociations = 123;
@@ -139,5 +142,13 @@ class BitPackUtilsTest {
 
 		assertEquals(newMax, getMaxAutomaticAssociationsFrom(metadata));
 		assertEquals(newAlreadyAutoAssociations, getAlreadyUsedAutomaticAssociationsFrom(metadata));
+	}
+
+	@Test
+	void validateLong() {
+		assertFalse(isValidNum(MAX_NUM_ALLOWED + 10));
+		assertTrue(isValidNum(MAX_NUM_ALLOWED));
+		assertTrue(isValidNum(0L));
+		assertFalse(isValidNum(-1L));
 	}
 }

--- a/hedera-node/src/test/java/com/hedera/services/state/submerkle/EntityIdTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/state/submerkle/EntityIdTest.java
@@ -31,11 +31,14 @@ import com.hederahashgraph.api.proto.java.TokenID;
 import com.hederahashgraph.api.proto.java.TopicID;
 import com.swirlds.common.io.SerializableDataInputStream;
 import com.swirlds.common.io.SerializableDataOutputStream;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
+import static com.hedera.services.state.submerkle.EntityId.MISSING_ENTITY_ID;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -103,7 +106,7 @@ class EntityIdTest {
 	@Test
 	void objectContractWorks() {
 		final var one = subject;
-		final var two = EntityId.MISSING_ENTITY_ID;
+		final var two = MISSING_ENTITY_ID;
 		final var three = subject.copy();
 
 		assertNotEquals(null, one);
@@ -144,12 +147,19 @@ class EntityIdTest {
 
 	@Test
 	void factoriesWork() {
-		assertThrows(IllegalArgumentException.class, () -> EntityId.fromGrpcAccountId(null));
-		assertThrows(IllegalArgumentException.class, () -> EntityId.fromGrpcFileId(null));
-		assertThrows(IllegalArgumentException.class, () -> EntityId.fromGrpcTopicId(null));
-		assertThrows(IllegalArgumentException.class, () -> EntityId.fromGrpcTokenId(null));
-		assertThrows(IllegalArgumentException.class, () -> EntityId.fromGrpcScheduleId(null));
-		assertThrows(IllegalArgumentException.class, () -> EntityId.fromGrpcContractId(null));
+		assertDoesNotThrow(() -> EntityId.fromGrpcAccountId(null));
+		assertDoesNotThrow(() -> EntityId.fromGrpcFileId(null));
+		assertDoesNotThrow(() -> EntityId.fromGrpcTopicId(null));
+		assertDoesNotThrow(() -> EntityId.fromGrpcTokenId(null));
+		assertDoesNotThrow(() -> EntityId.fromGrpcScheduleId(null));
+		assertDoesNotThrow(() -> EntityId.fromGrpcContractId(null));
+
+		assertEquals(MISSING_ENTITY_ID, EntityId.fromGrpcAccountId(null));
+		assertEquals(MISSING_ENTITY_ID, EntityId.fromGrpcContractId(null));
+		assertEquals(MISSING_ENTITY_ID, EntityId.fromGrpcTopicId(null));
+		assertEquals(MISSING_ENTITY_ID, EntityId.fromGrpcFileId(null));
+		assertEquals(MISSING_ENTITY_ID, EntityId.fromGrpcTokenId(null));
+		assertEquals(MISSING_ENTITY_ID, EntityId.fromGrpcScheduleId(null));
 
 		assertEquals(subject, EntityId.fromGrpcAccountId(accountId));
 		assertEquals(subject, EntityId.fromGrpcContractId(contractId));

--- a/hedera-node/src/test/java/com/hedera/services/utils/EntityNumPairTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/utils/EntityNumPairTest.java
@@ -9,6 +9,7 @@ import com.hedera.services.store.models.TokenRelationship;
 import org.junit.jupiter.api.Test;
 
 import static com.hedera.services.utils.EntityNumPair.MISSING_NUM_PAIR;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
@@ -55,6 +56,15 @@ class EntityNumPairTest {
 
 		// expect:
 		assertEquals(expected, actual);
+	}
+
+	@Test
+	void returnsMissingNumPairIfInvalidLong() {
+		// given:
+		assertDoesNotThrow(() -> EntityNumPair.fromLongs(Long.MAX_VALUE, 2));
+
+		// expect:
+		assertEquals(MISSING_NUM_PAIR, EntityNumPair.fromLongs(Long.MAX_VALUE, 2));
 	}
 
 	@Test

--- a/hedera-node/src/test/java/com/hedera/services/utils/EntityNumPairTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/utils/EntityNumPairTest.java
@@ -9,10 +9,12 @@ import com.hedera.services.store.models.TokenRelationship;
 import org.junit.jupiter.api.Test;
 
 import static com.hedera.services.utils.EntityNumPair.MISSING_NUM_PAIR;
+import static com.hedera.services.utils.EntityNumPair.fromLongs;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class EntityNumPairTest {
 	@Test
@@ -60,11 +62,11 @@ class EntityNumPairTest {
 
 	@Test
 	void returnsMissingNumPairIfInvalidLong() {
-		// given:
 		assertDoesNotThrow(() -> EntityNumPair.fromLongs(Long.MAX_VALUE, 2));
-
-		// expect:
 		assertEquals(MISSING_NUM_PAIR, EntityNumPair.fromLongs(Long.MAX_VALUE, 2));
+		assertEquals(MISSING_NUM_PAIR, EntityNumPair.fromLongs(Long.MAX_VALUE, Long.MAX_VALUE));
+		assertEquals(MISSING_NUM_PAIR, EntityNumPair.fromLongs(-1L, 2));
+		assertEquals(MISSING_NUM_PAIR, EntityNumPair.fromLongs(-1L, Long.MAX_VALUE));
 	}
 
 	@Test
@@ -127,5 +129,11 @@ class EntityNumPairTest {
 
 		// expect:
 		assertEquals("PermHashLong(1, 2)", subject.toString());
+	}
+
+	@Test
+	void validateLongNumsInRange(){
+		assertDoesNotThrow(() -> EntityNumPair.fromLongs(Long.MAX_VALUE, 2));
+		assertEquals(MISSING_NUM_PAIR, EntityNumPair.fromLongs(Long.MAX_VALUE, 2));
 	}
 }

--- a/hedera-node/src/test/java/com/hedera/services/utils/EntityNumTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/utils/EntityNumTest.java
@@ -25,6 +25,7 @@ import com.hedera.test.utils.IdUtils;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import static com.hedera.services.utils.EntityNum.MISSING_NUM;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -52,9 +53,10 @@ class EntityNumTest {
 	}
 
 	@Test
-	void throwsOnUnusableNum() {
+	void doesntThrowOnUnusableNum() {
 		// expect:
-		Assertions.assertThrows(IllegalArgumentException.class, () -> EntityNum.fromLong(Long.MAX_VALUE));
+		Assertions.assertDoesNotThrow(() -> EntityNum.fromLong(Long.MAX_VALUE));
+		assertEquals(MISSING_NUM, EntityNum.fromLong(Long.MAX_VALUE));
 	}
 
 	@Test
@@ -75,7 +77,7 @@ class EntityNumTest {
 	@Test
 	void factoriesWorkForInvalidShard() {
 		// setup:
-		final var expectedVal = EntityNum.MISSING_NUM;
+		final var expectedVal = MISSING_NUM;
 
 		// expect:
 		assertEquals(expectedVal, EntityNum.fromAccountId(IdUtils.asAccount("1.0.123")));
@@ -89,7 +91,7 @@ class EntityNumTest {
 	@Test
 	void factoriesWorkForInvalidRealm() {
 		// setup:
-		final var expectedVal = EntityNum.MISSING_NUM;
+		final var expectedVal = MISSING_NUM;
 
 		// expect:
 		assertEquals(expectedVal, EntityNum.fromAccountId(IdUtils.asAccount("0.1.123")));


### PR DESCRIPTION
Closes #2300 

Currently many logs are generated when some invalid input is submitted because of the exceptions thrown. Avoid throwing exceptions and return `MISSING_*` .
