### PR TITLE
Return appropriate responseCode for NetworkGetExecutionTime query

### DIFF
--- a/hedera-node/src/main/java/com/hedera/services/context/domain/security/PermissionFileUtils.java
+++ b/hedera-node/src/main/java/com/hedera/services/context/domain/security/PermissionFileUtils.java
@@ -63,6 +63,7 @@ import static com.hederahashgraph.api.proto.java.HederaFunctionality.FileUpdate;
 import static com.hederahashgraph.api.proto.java.HederaFunctionality.Freeze;
 import static com.hederahashgraph.api.proto.java.HederaFunctionality.GetBySolidityID;
 import static com.hederahashgraph.api.proto.java.HederaFunctionality.GetVersionInfo;
+import static com.hederahashgraph.api.proto.java.HederaFunctionality.NetworkGetExecutionTime;
 import static com.hederahashgraph.api.proto.java.HederaFunctionality.ScheduleCreate;
 import static com.hederahashgraph.api.proto.java.HederaFunctionality.ScheduleDelete;
 import static com.hederahashgraph.api.proto.java.HederaFunctionality.ScheduleGetInfo;
@@ -174,6 +175,7 @@ public final class PermissionFileUtils {
 		permissionKeys.put(TransactionGetReceipt, "getTransactionReceipts");
 		permissionKeys.put(TransactionGetRecord, "getTxRecordByTxID");
 		permissionKeys.put(GetVersionInfo, "getVersionInfo");
+		permissionKeys.put(NetworkGetExecutionTime, "networkGetExecutionTime");
 		permissionKeys.put(TokenGetInfo, "tokenGetInfo");
 		permissionKeys.put(ScheduleGetInfo, "scheduleGetInfo");
 		permissionKeys.put(TokenGetNftInfo, "tokenGetNftInfo");

--- a/hedera-node/src/main/java/com/hedera/services/queries/answering/StakedAnswerFlow.java
+++ b/hedera-node/src/main/java/com/hedera/services/queries/answering/StakedAnswerFlow.java
@@ -115,13 +115,6 @@ public final class StakedAnswerFlow implements AnswerFlow {
 			}
 		}
 
-		// if its a COST_ANSWER query for a restricted function just return NOT_SUPPORTED
-		if (service.needsAnswerOnlyCost(query)
-				&& RESTRICTED_FUNCTIONALITY.contains(service.canonicalFunction())
-				&& allegedPayment.isPresent() && !IS_THROTTLE_EXEMPT.test(allegedPayment.get().getPayer().getAccountNum())) {
-			return service.responseGiven(query, view, NOT_SUPPORTED);
-		}
-
 		final var hygieneStatus = hygieneCheck(query, view, service, optionalPayment);
 		if (hygieneStatus != OK) {
 			return service.responseGiven(query, view, hygieneStatus);
@@ -170,6 +163,12 @@ public final class StakedAnswerFlow implements AnswerFlow {
 		final var isPaymentRequired = service.requiresNodePayment(query);
 		if (isPaymentRequired && null == optionalPayment) {
 			return INSUFFICIENT_TX_FEE;
+		}
+
+		if (service.needsAnswerOnlyCost(query)
+				&& RESTRICTED_FUNCTIONALITY.contains(service.canonicalFunction())
+				&& optionalPayment != null && !IS_THROTTLE_EXEMPT.test(optionalPayment.getPayer().getAccountNum())) {
+			return NOT_SUPPORTED;
 		}
 
 		final var screenStatus = systemScreen(service.canonicalFunction(), optionalPayment);

--- a/hedera-node/src/main/java/com/hedera/services/txns/submission/SystemPrecheck.java
+++ b/hedera-node/src/main/java/com/hedera/services/txns/submission/SystemPrecheck.java
@@ -24,12 +24,15 @@ import com.hedera.services.context.domain.security.HapiOpPermissions;
 import com.hedera.services.txns.auth.SystemOpPolicies;
 import com.hedera.services.throttling.TransactionThrottling;
 import com.hedera.services.utils.SignedTxnAccessor;
+import com.hederahashgraph.api.proto.java.HederaFunctionality;
 import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
+import java.util.List;
 import java.util.function.LongPredicate;
 
+import static com.hederahashgraph.api.proto.java.HederaFunctionality.NetworkGetExecutionTime;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.BUSY;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OK;
 
@@ -43,6 +46,7 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OK;
 @Singleton
 public class SystemPrecheck {
 	public static final LongPredicate IS_THROTTLE_EXEMPT = num -> num >= 1 && num <= 100L;
+	public static final List<HederaFunctionality> RESTRICTED_FUNCTIONALITY = List.of(NetworkGetExecutionTime);
 
 	private final SystemOpPolicies systemOpPolicies;
 	private final HapiOpPermissions hapiOpPermissions;

--- a/hedera-node/src/test/java/com/hedera/services/context/domain/security/PermissionFileUtilsTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/context/domain/security/PermissionFileUtilsTest.java
@@ -51,6 +51,7 @@ import com.hederahashgraph.api.proto.java.FileGetInfoQuery;
 import com.hederahashgraph.api.proto.java.FileUpdateTransactionBody;
 import com.hederahashgraph.api.proto.java.FreezeTransactionBody;
 import com.hederahashgraph.api.proto.java.GetBySolidityIDQuery;
+import com.hederahashgraph.api.proto.java.NetworkGetExecutionTimeQuery;
 import com.hederahashgraph.api.proto.java.NetworkGetVersionInfoQuery;
 import com.hederahashgraph.api.proto.java.Query;
 import com.hederahashgraph.api.proto.java.ScheduleCreateTransactionBody;
@@ -315,6 +316,15 @@ class PermissionFileUtilsTest {
 	}
 
 	@Test
+	void worksForNetworkGetExecutionTime() {
+		var op = NetworkGetExecutionTimeQuery.getDefaultInstance();
+		var query = Query.newBuilder()
+				.setNetworkGetExecutionTime(op)
+				.build();
+		assertEquals(legacyKeyForQuery(query), permissionFileKeyForQuery(query));
+	}
+
+	@Test
 	void worksForGetVersionInfo() {
 		var op = NetworkGetVersionInfoQuery.getDefaultInstance();
 		var query = Query.newBuilder()
@@ -452,6 +462,9 @@ class PermissionFileUtilsTest {
 	private String legacyKeyForQuery(Query request) {
 		String queryBody = null;
 		switch (request.getQueryCase()) {
+			case NETWORKGETEXECUTIONTIME:
+				queryBody = "networkGetExecutionTime";
+				break;
 			case NETWORKGETVERSIONINFO:
 				queryBody = "getVersionInfo";
 				break;

--- a/hedera-node/src/test/java/com/hedera/services/queries/answering/StakedAnswerFlowTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/queries/answering/StakedAnswerFlowTest.java
@@ -57,6 +57,7 @@ import java.util.Collections;
 import java.util.Optional;
 
 import static com.hederahashgraph.api.proto.java.HederaFunctionality.ConsensusGetTopicInfo;
+import static com.hederahashgraph.api.proto.java.HederaFunctionality.NetworkGetExecutionTime;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.BUSY;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INSUFFICIENT_PAYER_BALANCE;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INSUFFICIENT_TX_FEE;
@@ -133,6 +134,20 @@ class StakedAnswerFlowTest {
 	void immediatelyRejectsQueryHeaderProblem() {
 		setupServiceResponse(NOT_SUPPORTED);
 		given(queryHeaderValidity.checkHeader(query)).willReturn(NOT_SUPPORTED);
+
+		final var actual = subject.satisfyUsing(service, query);
+
+		assertEquals(response, actual);
+	}
+
+	@Test
+	void rejectsNonPrivilegedCostAnswerQueries() {
+		setupServiceResponse(NOT_SUPPORTED);
+		givenValidHeader();
+		givenExtractablePayment();
+		given(service.needsAnswerOnlyCost(query)).willReturn(true);
+		given(service.canonicalFunction()).willReturn(NetworkGetExecutionTime);
+
 
 		final var actual = subject.satisfyUsing(service, query);
 

--- a/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/QueryVerbs.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/QueryVerbs.java
@@ -135,6 +135,10 @@ public class QueryVerbs {
 		return new HapiGetExecTime(List.of(txnIds)).nodePayment(1234L);
 	}
 
+	public static HapiGetExecTime getExecTimeNoPayment(String... txnIds) {
+		return new HapiGetExecTime(List.of(txnIds));
+	}
+
 	public static HapiGetTokenInfo getTokenInfo(String token) {
 		return new HapiGetTokenInfo(token);
 	}

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/RandomOps.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/RandomOps.java
@@ -35,10 +35,12 @@ import static com.hedera.services.bdd.spec.HapiApiSpec.customHapiSpec;
 import static com.hedera.services.bdd.spec.HapiApiSpec.defaultHapiSpec;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getAccountInfo;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getExecTime;
+import static com.hedera.services.bdd.spec.queries.QueryVerbs.getExecTimeNoPayment;
 import static com.hedera.services.bdd.spec.transactions.TxnUtils.randomUppercase;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.contractCall;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.contractCreate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.createTopic;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoCreate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoTransfer;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.fileCreate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.submitMessageTo;
@@ -46,6 +48,8 @@ import static com.hedera.services.bdd.spec.transactions.crypto.HapiCryptoTransfe
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.freeze;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.inParallel;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.sleepFor;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_TRANSACTION_ID;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.NOT_SUPPORTED;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OK;
 
 public class RandomOps extends HapiApiSuite {
@@ -71,6 +75,7 @@ public class RandomOps extends HapiApiSuite {
 		final var submitMessage = "submitMessage";
 		final var contractCall = "contractCall";
 
+		final var humbleUser = "aamAdmi";
 		final var topic = "ofGeneralInterest";
 		final var contract = "binding";
 		final var bytecode = "bytecode";
@@ -83,6 +88,7 @@ public class RandomOps extends HapiApiSuite {
 										.noLogging())
 								.toArray(HapiSpecOperation[]::new)),
 						sleepFor(5_000),
+						cryptoCreate(humbleUser).balance(ONE_HUNDRED_HBARS),
 						createTopic(topic),
 						fileCreate(bytecode)
 								.path(ContractResources.MULTIPURPOSE_BYTECODE_PATH),
@@ -102,9 +108,20 @@ public class RandomOps extends HapiApiSuite {
 						/* NetworkGetExecutionTime requires superuser payer */
 						getExecTime(cryptoTransfer, submitMessage, contractCall)
 								.payingWith(GENESIS)
+								.hasAnswerOnlyPrecheck(INVALID_TRANSACTION_ID),
 								/* Uncomment to validate failure message */
 //								.assertingNoneLongerThan(1, ChronoUnit.MILLIS)
-								.logged()
+//								.logged(),
+						getExecTimeNoPayment(cryptoTransfer, submitMessage, contractCall)
+								.payingWith(GENESIS)
+								.hasCostAnswerPrecheck(NOT_SUPPORTED),
+						getExecTime(cryptoTransfer, submitMessage, contractCall)
+								.payingWith(humbleUser)
+								.hasCostAnswerPrecheck(NOT_SUPPORTED)
+								.hasAnswerOnlyPrecheck(NOT_SUPPORTED),
+						getExecTimeNoPayment(cryptoTransfer, submitMessage, contractCall)
+								.payingWith(humbleUser)
+								.hasCostAnswerPrecheck(NOT_SUPPORTED)
 				);
 	}
 


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->

**Related issue(s)**:

Fixes #2298 

**Notes for reviewer**:
Implemented the following scenarios:

| query type      | result |
| ----------- | ----------- |
|`NetworkGetExecutionTimeQueriesWithNoPayment`| gives `NOT_SUPPORTED` be it a superUser or not|
|`UnprivilegedNetworkGetExecutionTimeQueriesWithPayment`|gives `NOT_SUPPORTED`|
|`PrivilegedNetworkGetExecutionTimeQueriesWithPayment`|gives `INVALID_TRANSACTION_ID` as its a noop currently|


- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
