### PR TITLE
Codecov with GitHub actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,40 @@
+name: Hedera Services CI
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:latest
+        env:
+          POSTGRES_DB: fcfs
+          POSTGRES_PASSWORD: password
+          POSTGRES_USER: swirlds
+          PGDATA: /var/lib/postgresql/data/pgdata
+          POSTGRES_PORT: 5432
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 12
+        uses: actions/setup-java@v2
+        with:
+          java-version: '12'
+          distribution: 'adopt'
+          cache: maven
+      - name: Build with Maven
+        run: mvn install
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v2
+        with:
+          root_dir: '/home/runner/work/hedera-services/'
+          files: 'jacoco.xml'


### PR DESCRIPTION
Codecov Integration with GitHub actions.
There are failing tests `expandOnTracking`, `tracksAtMostConfigured`, `givesUpIfMaxRetriesExhaustedAndPropagatesIOException`. We are working to solve this in separate issue.