### PR TITLE
Add CI_PARAMETERS to continuous integration workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -571,7 +571,8 @@ commands:
 
             CI_PARAMETERS=""
             if [[ "<< parameters.continuous_integration >>" == "true" ]]; then
-              CI_PARAMETERS="${CI_PARAMETERS} $CIRCLE_USERNAME $CIRCLE_BUILD_URL"
+              CI_PARAMETERS="${CI_PARAMETERS} ${JRS_USER}"
+              CI_PARAMETERS="${CI_PARAMETERS}_${CIRCLE_BUILD_URL}"
             fi
 
             pushd "${REGRESSION_PATH}" > /dev/null 2>&1
@@ -596,7 +597,7 @@ commands:
               ${JRS_OPTIONS} \
               -Dlog4j.configurationFile=log4j2-jrs.xml \
               -Dspring.output.ansi.enabled=ALWAYS \
-              -jar regression.jar "${CONFIG_PATH}" -r "<< parameters.hedera_services_path >>" -w DOCKER_REMOTE
+              -jar regression.jar "${CONFIG_PATH}" -r "<< parameters.hedera_services_path >>" -w DOCKER_REMOTE -ci "${CI_PARAMETERS}"
             popd > /dev/null 2>&1
           no_output_timeout: 30m
 


### PR DESCRIPTION
Signed-off-by: Neeharika-Sompalli <neeharika.sompalli@hedera.com>

Closes #2339 

Currently after changing to docker regression flow, hedera commit id and the username, CI job link doesn't appear on the services tests. Added 
1. Hedera Commit for all services tests
2. JRS user name and CircleCI job link for the continuous integration workflow

Related regression PR 