### PR TITLE
Bump coverage for `store` package 

### DIFF
--- a/hedera-node/src/test/java/com/hedera/services/records/EarliestEntryExpiryTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/records/EarliestEntryExpiryTest.java
@@ -55,4 +55,11 @@ class EarliestEntryExpiryTest {
 
 		assertEquals(expectedHashCode, ere.hashCode());
 	}
+
+	@Test
+	void comparisonWorks() {
+		final var ere = new EarliestRecordExpiry(5L, asAccount("0.0.5"));
+		final var ere2 = new EarliestRecordExpiry(4L, asAccount("0.0.1"));
+		assertEquals(1, ere.compareTo(ere2));
+	}
 }

--- a/hedera-node/src/test/java/com/hedera/services/store/models/IdTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/store/models/IdTest.java
@@ -32,6 +32,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 class IdTest {
@@ -62,6 +63,7 @@ class IdTest {
 		assertNotEquals(dId, aId);
 		assertEquals(eId, aId);
 		assertNotEquals(null, aId);
+		assertFalse(aId.equals(null));
 		assertNotEquals(new Object(), aId);
 		assertEquals(aId, aId);
 	}

--- a/hedera-node/src/test/java/com/hedera/services/store/models/NftIdTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/store/models/NftIdTest.java
@@ -95,5 +95,6 @@ class NftIdTest {
 		final var subject = new NftId(shard, realm, num, serialNo);
 
 		assertNotEquals(null, subject);
+		assertFalse(subject.equals(null));
 	}
 }

--- a/hedera-node/src/test/java/com/hedera/services/store/models/TokenTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/store/models/TokenTest.java
@@ -583,6 +583,13 @@ class TokenTest {
 		hmap.put(1L, new UniqueToken(new Id(1, 2, 3), 4));
 		subject.setLoadedUniqueTokens(hmap);
 		assertEquals(hmap, subject.getLoadedUniqueTokens());
+
+		subject.setType(TokenType.FUNGIBLE_COMMON);
+		assertTrue(subject.isFungibleCommon());
+		assertFalse(subject.isNonFungibleUnique());
+
+		subject.setNew(true);
+		assertTrue(subject.isNew());
 	}
 
 	@Test

--- a/hedera-node/src/test/java/com/hedera/services/store/models/TopicTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/store/models/TopicTest.java
@@ -58,6 +58,9 @@ class TopicTest {
 		topic.setDeleted(true);
 		assertTrue(topic.isDeleted());
 
+		topic.setNew(true);
+		assertTrue(topic.isNew());
+
 		topic.setAutoRenewAccountId(Id.DEFAULT);
 		assertEquals(Id.DEFAULT, topic.getAutoRenewAccountId());
 


### PR DESCRIPTION
This **PR** provides increased coverage for the `store` package, as well as some tests for the `record` package.