### PR TITLE
Discard prepared upgrade when `DualState` freeze/last-frozen times match

### DIFF
--- a/hedera-node/src/main/java/com/hedera/services/ServicesState.java
+++ b/hedera-node/src/main/java/com/hedera/services/ServicesState.java
@@ -67,6 +67,7 @@ import org.apache.logging.log4j.Logger;
 
 import java.time.Instant;
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -459,7 +460,7 @@ public class ServicesState extends AbstractNaryMerkleInternal implements SwirldS
 					StateVersions.CURRENT_VERSION);
 			app.systemExits().fail(1);
 		} else {
-			if (stateVersion < StateVersions.CURRENT_VERSION) {
+			if (Objects.equals(dualState.getFreezeTime(), dualState.getLastFrozenTime())) {
 				/* This was an upgrade, discard now-obsolete preparation history */
 				networkCtx().discardPreparedUpgradeMeta();
 			}

--- a/hedera-node/src/test/java/com/hedera/services/ServicesStateTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/ServicesStateTest.java
@@ -583,11 +583,14 @@ class ServicesStateTest {
 	}
 
 	@Test
-	void nonGenesisInitClearsPreparedUpgradeIfStateVersionLessThanCurrentSoftware() {
+	void nonGenesisInitClearsPreparedUpgradeIfLastFrozenMatchesFreezeTime() {
 		subject.setChild(StateChildIndices.SPECIAL_FILES, diskFs);
 		subject.setChild(StateChildIndices.NETWORK_CTX, networkContext);
 
-		given(networkContext.getStateVersion()).willReturn(StateVersions.CURRENT_VERSION - 1);
+		final var when = Instant.ofEpochSecond(1_234_567L, 890);
+		given(dualState.getFreezeTime()).willReturn(when);
+		given(dualState.getLastFrozenTime()).willReturn(when);
+		given(networkContext.getStateVersion()).willReturn(StateVersions.CURRENT_VERSION);
 
 		given(app.hashLogger()).willReturn(hashLogger);
 		given(app.initializationFlow()).willReturn(initFlow);


### PR DESCRIPTION
Instead of requiring the `StateVersions.CURRENT_VERSION` to increment, identify post-upgrade restarts by thee freeze time meta in `DualState`.

Closes #2377 