### PR TITLE
Use payer key for file WACL in ERC721/1155 contract interactions suites

### DIFF
--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/openzeppelin/ERC1155ContractInteractions.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/openzeppelin/ERC1155ContractInteractions.java
@@ -44,6 +44,8 @@ import static com.hedera.services.bdd.spec.transactions.TxnVerbs.contractCreate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoCreate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.fileCreate;
 import static com.hedera.services.bdd.spec.utilops.CustomSpecAssert.allRunFor;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.newKeyListNamed;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.newKeyNamed;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.updateLargeFile;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.withOpContext;
 
@@ -77,11 +79,15 @@ public class ERC1155ContractInteractions extends HapiApiSuite {
 
 	private HapiApiSpec erc1155() {
 		final var contents = getFileContents(ContractResources.ERC_1155_BYTECODE_PATH);
+		final var PAYER_KEY = "payerKey";
+		final var FILE_KEY_LIST = "fileKeyList";
 		return defaultHapiSpec(CONTRACT_NAME)
 				.given(
+						newKeyNamed(PAYER_KEY),
+						newKeyListNamed(FILE_KEY_LIST, List.of(PAYER_KEY)),
 						cryptoCreate(ACCOUNT1),
-						cryptoCreate(OPERATIONS_PAYER).balance(ONE_MILLION_HBARS),
-						fileCreate(CONTRACT_FILE_NAME).payingWith(OPERATIONS_PAYER),
+						cryptoCreate(OPERATIONS_PAYER).balance(ONE_MILLION_HBARS).key(PAYER_KEY),
+						fileCreate(CONTRACT_FILE_NAME).payingWith(OPERATIONS_PAYER).key(FILE_KEY_LIST),
 						updateLargeFile(OPERATIONS_PAYER, CONTRACT_FILE_NAME, contents)
 				)
 				.when()

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/openzeppelin/ERC721ContractInteractions.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/openzeppelin/ERC721ContractInteractions.java
@@ -42,6 +42,8 @@ import static com.hedera.services.bdd.spec.transactions.TxnVerbs.contractCreate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoCreate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.fileCreate;
 import static com.hedera.services.bdd.spec.utilops.CustomSpecAssert.allRunFor;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.newKeyListNamed;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.newKeyNamed;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.updateLargeFile;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.withOpContext;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SUCCESS;
@@ -76,14 +78,18 @@ public class ERC721ContractInteractions extends HapiApiSuite {
         final var MINT_TX = "mint";
         final var APPROVE_TX = "approve";
         final var TRANSFER_FROM_TX = "transferFrom";
+        final var PAYER_KEY = "payerKey";
+        final var FILE_KEY_LIST = "fileKeyList";
 
         return defaultHapiSpec("CallsERC721ContractInteractions")
                 .given(
-                        cryptoCreate(PAYER).balance(ONE_HUNDRED_HBARS),
+                        newKeyNamed(PAYER_KEY),
+                        newKeyListNamed(FILE_KEY_LIST, List.of(PAYER_KEY)),
+                        cryptoCreate(PAYER).balance(ONE_HUNDRED_HBARS).key(PAYER_KEY),
                         cryptoCreate(CONTRACT_CREATOR),
                         cryptoCreate(NFT_SENDER),
                         QueryVerbs.getAccountBalance(PAYER).logged(),
-                        fileCreate(CONTRACT_FILE_NAME).payingWith(PAYER),
+                        fileCreate(CONTRACT_FILE_NAME).payingWith(PAYER).key(FILE_KEY_LIST),
                         updateLargeFile(PAYER, CONTRACT_FILE_NAME, extractByteCode(ERC721_BYTECODE_PATH))
                 ).when(
                         QueryVerbs.getAccountBalance(PAYER).logged(),


### PR DESCRIPTION
**Description**:
After `UtilVerbs.updateLargeFile()` was tweaked to avoid submitting `getFileInfo()` queries for `File{Update,Append}` fee calculation, this broke some contract suites that relied on the default `HapiFileUpdate` behavior of automatically signing with the target file WACL.