### PR TITLE
Only write now_frozen.mf if upgrade is pending

### DIFF
--- a/hedera-node/src/main/java/com/hedera/services/ServicesMain.java
+++ b/hedera-node/src/main/java/com/hedera/services/ServicesMain.java
@@ -77,7 +77,7 @@ public class ServicesMain implements SwirldMain {
 			app.recordStreamManager().setInFreeze(false);
 		} else if (status == MAINTENANCE) {
 			app.recordStreamManager().setInFreeze(true);
-			app.upgradeActions().externalizeFreeze();
+			app.upgradeActions().externalizeFreezeIfUpgradePending();
 		} else {
 			log.info("Platform {} status set to : {}", nodeId, status);
 		}

--- a/hedera-node/src/main/java/com/hedera/services/txns/network/UpgradeActions.java
+++ b/hedera-node/src/main/java/com/hedera/services/txns/network/UpgradeActions.java
@@ -89,8 +89,10 @@ public class UpgradeActions {
 		this.dynamicProperties = dynamicProperties;
 	}
 
-	public void externalizeFreeze() {
-		writeCheckMarker(NOW_FROZEN_MARKER);
+	public void externalizeFreezeIfUpgradePending() {
+		if (networkCtx.get().hasPreparedUpgrade()) {
+			writeCheckMarker(NOW_FROZEN_MARKER);
+		}
 	}
 
 	public CompletableFuture<Void> extractTelemetryUpgrade(final byte[] archiveData, final Instant now) {

--- a/hedera-node/src/test/java/com/hedera/services/ServicesMainTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/ServicesMainTest.java
@@ -255,7 +255,7 @@ class ServicesMainTest {
 
 		// then:
 		verify(currentPlatformStatus).set(MAINTENANCE);
-		verify(upgradeActions).externalizeFreeze();
+		verify(upgradeActions).externalizeFreezeIfUpgradePending();
 		verify(recordStreamManager).setInFreeze(true);
 	}
 

--- a/hedera-node/src/test/java/com/hedera/services/txns/network/UpgradeActionsTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/txns/network/UpgradeActionsTest.java
@@ -269,11 +269,23 @@ class UpgradeActionsTest {
 	void externalizesFreeze() throws IOException {
 		rmIfPresent(NOW_FROZEN_MARKER);
 
+		given(networkCtx.hasPreparedUpgrade()).willReturn(true);
 		given(dynamicProperties.upgradeArtifactsLoc()).willReturn(markerFilesLoc);
 
-		subject.externalizeFreeze();
+		subject.externalizeFreezeIfUpgradePending();
 
 		assertMarkerCreated(NOW_FROZEN_MARKER, null);
+	}
+
+	@Test
+	void doesntExternalizeFreezeIfNoUpgradeIsPrepared() {
+		rmIfPresent(NOW_FROZEN_MARKER);
+
+		subject.externalizeFreezeIfUpgradePending();
+
+		assertFalse(
+				Paths.get(markerFilesLoc, NOW_FROZEN_MARKER).toFile().exists(),
+				"Should not create " + NOW_FROZEN_MARKER + " if no upgrade is prepared");
 	}
 
 	@Test


### PR DESCRIPTION
**Description**:
- Only write _now_frozen.mf_ on platform change to `MAINTENANCE` if upgrade is prepared.