### PR TITLE
Only discard prepared upgrade if freeze time is non-null

### DIFF
--- a/hedera-node/src/main/java/com/hedera/services/ServicesState.java
+++ b/hedera-node/src/main/java/com/hedera/services/ServicesState.java
@@ -67,7 +67,6 @@ import org.apache.logging.log4j.Logger;
 
 import java.time.Instant;
 import java.util.List;
-import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -460,7 +459,8 @@ public class ServicesState extends AbstractNaryMerkleInternal implements SwirldS
 					StateVersions.CURRENT_VERSION);
 			app.systemExits().fail(1);
 		} else {
-			if (Objects.equals(dualState.getFreezeTime(), dualState.getLastFrozenTime())) {
+			final var maybePostUpgrade = dualState.getFreezeTime() != null;
+			if (maybePostUpgrade && dualState.getFreezeTime().equals(dualState.getLastFrozenTime())) {
 				/* This was an upgrade, discard now-obsolete preparation history */
 				networkCtx().discardPreparedUpgradeMeta();
 			}

--- a/hedera-node/src/test/java/com/hedera/services/ServicesStateTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/ServicesStateTest.java
@@ -105,6 +105,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willCallRealMethod;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.internal.verification.VerificationModeFactory.times;
@@ -583,7 +584,7 @@ class ServicesStateTest {
 	}
 
 	@Test
-	void nonGenesisInitClearsPreparedUpgradeIfLastFrozenMatchesFreezeTime() {
+	void nonGenesisInitClearsPreparedUpgradeIfNonNullLastFrozenMatchesFreezeTime() {
 		subject.setChild(StateChildIndices.SPECIAL_FILES, diskFs);
 		subject.setChild(StateChildIndices.NETWORK_CTX, networkContext);
 
@@ -603,6 +604,26 @@ class ServicesStateTest {
 		subject.init(platform, addressBook, dualState);
 
 		verify(networkContext).discardPreparedUpgradeMeta();
+	}
+
+	@Test
+	void nonGenesisInitDoesntClearPreparedUpgradeIfBothFreezeAndLastFrozenAreNull() {
+		subject.setChild(StateChildIndices.SPECIAL_FILES, diskFs);
+		subject.setChild(StateChildIndices.NETWORK_CTX, networkContext);
+
+		given(networkContext.getStateVersion()).willReturn(StateVersions.CURRENT_VERSION);
+
+		given(app.hashLogger()).willReturn(hashLogger);
+		given(app.initializationFlow()).willReturn(initFlow);
+		given(app.dualStateAccessor()).willReturn(dualStateAccessor);
+		given(platform.getSelfId()).willReturn(selfId);
+		// and:
+		APPS.save(selfId.getId(), app);
+
+		// when:
+		subject.init(platform, addressBook, dualState);
+
+		verify(networkContext, never()).discardPreparedUpgradeMeta();
 	}
 
 	@Test


### PR DESCRIPTION
**Description**:
A reconnected node should _not_ discard a prepared upgrade if both `freezeTime()` and `lastFrozenTime()` are non-null.