### PR TITLE
Fix(contracts): do not use ledger.get due to internal persistence

### DIFF
--- a/hedera-node/src/main/java/com/hedera/services/ledger/HederaLedger.java
+++ b/hedera-node/src/main/java/com/hedera/services/ledger/HederaLedger.java
@@ -31,6 +31,7 @@ import com.hedera.services.ledger.ids.EntityIdSource;
 import com.hedera.services.ledger.properties.AccountProperty;
 import com.hedera.services.ledger.properties.NftProperty;
 import com.hedera.services.ledger.properties.TokenRelProperty;
+import com.hedera.services.legacy.core.jproto.JKey;
 import com.hedera.services.records.AccountRecordsHistorian;
 import com.hedera.services.state.EntityCreator;
 import com.hedera.services.state.merkle.MerkleAccount;
@@ -70,7 +71,9 @@ import static com.hedera.services.ledger.properties.AccountProperty.EXPIRY;
 import static com.hedera.services.ledger.properties.AccountProperty.IS_DELETED;
 import static com.hedera.services.ledger.properties.AccountProperty.IS_RECEIVER_SIG_REQUIRED;
 import static com.hedera.services.ledger.properties.AccountProperty.IS_SMART_CONTRACT;
+import static com.hedera.services.ledger.properties.AccountProperty.KEY;
 import static com.hedera.services.ledger.properties.AccountProperty.MAX_AUTOMATIC_ASSOCIATIONS;
+import static com.hedera.services.ledger.properties.AccountProperty.MEMO;
 import static com.hedera.services.ledger.properties.AccountProperty.NUM_NFTS_OWNED;
 import static com.hedera.services.ledger.properties.AccountProperty.PROXY;
 import static com.hedera.services.ledger.properties.AccountProperty.TOKENS;
@@ -537,6 +540,14 @@ public class HederaLedger {
 				&& !(boolean) accountsLedger.get(id, IS_SMART_CONTRACT)
 				&& (long) accountsLedger.get(id, BALANCE) == 0L
 				&& !validator.isAfterConsensusSecond((long) accountsLedger.get(id, EXPIRY));
+	}
+
+	public JKey key(AccountID id) {
+		return (JKey) accountsLedger.get(id, KEY);
+	}
+
+	public String memo(AccountID id) {
+		return (String) accountsLedger.get(id, MEMO);
 	}
 
 	public boolean isPendingCreation(AccountID id) {

--- a/hedera-node/src/main/java/com/hedera/services/store/contracts/EntityAccess.java
+++ b/hedera-node/src/main/java/com/hedera/services/store/contracts/EntityAccess.java
@@ -23,7 +23,8 @@ package com.hedera.services.store.contracts;
  */
 
 import com.hedera.services.ledger.accounts.HederaAccountCustomizer;
-import com.hedera.services.state.merkle.MerkleAccount;
+import com.hedera.services.legacy.core.jproto.JKey;
+import com.hedera.services.state.submerkle.EntityId;
 import com.hederahashgraph.api.proto.java.AccountID;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.units.bigints.UInt256;
@@ -31,18 +32,34 @@ import org.apache.tuweni.units.bigints.UInt256;
 public interface EntityAccess {
 	/* --- Account access --- */
 	void spawn(AccountID id, long balance, HederaAccountCustomizer customizer);
+
 	void customize(AccountID id, HederaAccountCustomizer customizer);
+
 	void adjustBalance(AccountID id, long adjustment);
+
+	long getAutoRenew(AccountID id);
+
 	long getBalance(AccountID id);
+
+	long getExpiry(AccountID id);
+
+	JKey getKey(AccountID id);
+
+	String getMemo(AccountID id);
+
+	EntityId getProxy(AccountID id);
+
 	boolean isDeleted(AccountID id);
+
 	boolean isExtant(AccountID id);
-	MerkleAccount lookup(AccountID id);
 
 	/* --- Storage access --- */
-	void put(AccountID id,UInt256 key, UInt256 value);
+	void put(AccountID id, UInt256 key, UInt256 value);
+
 	UInt256 get(AccountID id, UInt256 key);
 
 	/* --- Bytecode access --- */
 	void store(AccountID id, Bytes code);
+
 	Bytes fetch(AccountID id);
 }

--- a/hedera-node/src/main/java/com/hedera/services/store/contracts/MutableEntityAccess.java
+++ b/hedera-node/src/main/java/com/hedera/services/store/contracts/MutableEntityAccess.java
@@ -24,7 +24,8 @@ package com.hedera.services.store.contracts;
 
 import com.hedera.services.ledger.HederaLedger;
 import com.hedera.services.ledger.accounts.HederaAccountCustomizer;
-import com.hedera.services.state.merkle.MerkleAccount;
+import com.hedera.services.legacy.core.jproto.JKey;
+import com.hedera.services.state.submerkle.EntityId;
 import com.hedera.services.state.virtual.ContractKey;
 import com.hedera.services.state.virtual.ContractValue;
 import com.hedera.services.state.virtual.VirtualBlobKey;
@@ -72,8 +73,33 @@ public class MutableEntityAccess implements EntityAccess {
 	}
 
 	@Override
+	public long getAutoRenew(AccountID id) {
+		return ledger.autoRenewPeriod(id);
+	}
+
+	@Override
 	public long getBalance(AccountID id) {
 		return ledger.getBalance(id);
+	}
+
+	@Override
+	public long getExpiry(AccountID id) {
+		return ledger.expiry(id);
+	}
+
+	@Override
+	public JKey getKey(AccountID id) {
+		return ledger.key(id);
+	}
+
+	@Override
+	public String getMemo(AccountID id) {
+		return ledger.memo(id);
+	}
+
+	@Override
+	public EntityId getProxy(AccountID id) {
+		return ledger.proxy(id);
 	}
 
 	@Override
@@ -84,11 +110,6 @@ public class MutableEntityAccess implements EntityAccess {
 	@Override
 	public boolean isExtant(AccountID id) {
 		return ledger.exists(id);
-	}
-
-	@Override
-	public MerkleAccount lookup(AccountID id) {
-		return ledger.get(id);
 	}
 
 	@Override

--- a/hedera-node/src/main/java/com/hedera/services/store/contracts/StaticEntityAccess.java
+++ b/hedera-node/src/main/java/com/hedera/services/store/contracts/StaticEntityAccess.java
@@ -24,7 +24,9 @@ package com.hedera.services.store.contracts;
 
 import com.hedera.services.context.primitives.StateView;
 import com.hedera.services.ledger.accounts.HederaAccountCustomizer;
+import com.hedera.services.legacy.core.jproto.JKey;
 import com.hedera.services.state.merkle.MerkleAccount;
+import com.hedera.services.state.submerkle.EntityId;
 import com.hedera.services.state.virtual.ContractKey;
 import com.hedera.services.state.virtual.ContractValue;
 import com.hedera.services.state.virtual.VirtualBlobKey;
@@ -66,8 +68,33 @@ public class StaticEntityAccess implements EntityAccess {
 	}
 
 	@Override
+	public long getAutoRenew(AccountID id) {
+		return accounts.get(fromAccountId(id)).getAutoRenewSecs();
+	}
+
+	@Override
 	public long getBalance(AccountID id) {
 		return accounts.get(fromAccountId(id)).getBalance();
+	}
+
+	@Override
+	public long getExpiry(AccountID id) {
+		return accounts.get(fromAccountId(id)).getExpiry();
+	}
+
+	@Override
+	public JKey getKey(AccountID id) {
+		return accounts.get(fromAccountId(id)).getAccountKey();
+	}
+
+	@Override
+	public String getMemo(AccountID id) {
+		return accounts.get(fromAccountId(id)).getMemo();
+	}
+
+	@Override
+	public EntityId getProxy(AccountID id) {
+		return accounts.get(fromAccountId(id)).getProxy();
 	}
 
 	@Override
@@ -78,11 +105,6 @@ public class StaticEntityAccess implements EntityAccess {
 	@Override
 	public boolean isExtant(AccountID id) {
 		return accounts.get(fromAccountId(id)) != null;
-	}
-
-	@Override
-	public MerkleAccount lookup(AccountID id) {
-		return accounts.get(fromAccountId(id));
 	}
 
 	@Override

--- a/hedera-node/src/test/java/com/hedera/services/ledger/HederaLedgerTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/ledger/HederaLedgerTest.java
@@ -38,7 +38,9 @@ import static com.hedera.services.ledger.properties.AccountProperty.EXPIRY;
 import static com.hedera.services.ledger.properties.AccountProperty.IS_DELETED;
 import static com.hedera.services.ledger.properties.AccountProperty.IS_RECEIVER_SIG_REQUIRED;
 import static com.hedera.services.ledger.properties.AccountProperty.IS_SMART_CONTRACT;
+import static com.hedera.services.ledger.properties.AccountProperty.KEY;
 import static com.hedera.services.ledger.properties.AccountProperty.MAX_AUTOMATIC_ASSOCIATIONS;
+import static com.hedera.services.ledger.properties.AccountProperty.MEMO;
 import static com.hedera.services.ledger.properties.AccountProperty.PROXY;
 import static com.hedera.test.utils.IdUtils.asAccount;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -203,6 +205,20 @@ class HederaLedgerTest extends BaseHederaLedgerTestHelper {
 		subject.proxy(genesis);
 
 		verify(accountsLedger).get(genesis, PROXY);
+	}
+
+	@Test
+	void delegatesToCorrectMemoProperty() {
+		subject.memo(genesis);
+
+		verify(accountsLedger).get(genesis, MEMO);
+	}
+
+	@Test
+	void delegatesToCorrectKeyProperty() {
+		subject.key(genesis);
+
+		verify(accountsLedger).get(genesis, KEY);
 	}
 
 	@Test

--- a/hedera-node/src/test/java/com/hedera/services/store/contracts/StaticEntityAccessTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/store/contracts/StaticEntityAccessTest.java
@@ -22,6 +22,8 @@ package com.hedera.services.store.contracts;
 
 import com.hedera.services.context.primitives.StateView;
 import com.hedera.services.ledger.accounts.HederaAccountCustomizer;
+import com.hedera.services.legacy.core.jproto.JEd25519Key;
+import com.hedera.services.legacy.core.jproto.JKey;
 import com.hedera.services.state.merkle.MerkleAccount;
 import com.hedera.services.state.submerkle.EntityId;
 import com.hedera.services.state.virtual.ContractKey;
@@ -71,12 +73,13 @@ class StaticEntityAccessTest {
 	private ContractKey contractKey = new ContractKey(id.getAccountNum(), uint256Key.toArray());
 	private VirtualBlobKey blobKey = new VirtualBlobKey(VirtualBlobKey.Type.CONTRACT_BYTECODE,
 			(int) id.getAccountNum());
+	private static final JKey key = new JEd25519Key("aBcDeFgHiJkLmNoPqRsTuVwXyZ012345".getBytes());
 	private ContractValue contractVal = new ContractValue(BigInteger.ONE);
 	private VirtualBlobValue blobVal = new VirtualBlobValue("data".getBytes());
 
-
 	private MerkleAccount someAccount = new HederaAccountCustomizer()
 			.isReceiverSigRequired(false)
+			.key(key)
 			.proxy(EntityId.MISSING_ENTITY_ID)
 			.isDeleted(false)
 			.expiry(1234L)
@@ -111,7 +114,11 @@ class StaticEntityAccessTest {
 		assertEquals(someAccount.isDeleted(), subject.isDeleted(id));
 		assertTrue(subject.isExtant(id));
 		assertFalse(subject.isExtant(nonExtantId));
-		assertEquals(someAccount, subject.lookup(id));
+		assertEquals(someAccount.getMemo(), subject.getMemo(id));
+		assertEquals(someAccount.getExpiry(), subject.getExpiry(id));
+		assertEquals(someAccount.getAutoRenewSecs(), subject.getAutoRenew(id));
+		assertEquals(someAccount.getAccountKey(), subject.getKey(id));
+		assertEquals(someAccount.getProxy(), subject.getProxy(id));
 	}
 
 	@Test


### PR DESCRIPTION
**Description**:
* Do not use `ledger.get` in contracts due to internal persistence when calling the method

**Related issue(s)**:

Fixes #none

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
