### PR TITLE
Move `UpgradeActions.catchUpOnMissedSideEffects()` into the `ReconnectCompleteListener`

### DIFF
--- a/hedera-node/src/main/java/com/hedera/services/ServicesState.java
+++ b/hedera-node/src/main/java/com/hedera/services/ServicesState.java
@@ -461,8 +461,9 @@ public class ServicesState extends AbstractNaryMerkleInternal implements SwirldS
 		} else {
 			final var maybePostUpgrade = dualState.getFreezeTime() != null;
 			if (maybePostUpgrade && dualState.getFreezeTime().equals(dualState.getLastFrozenTime())) {
-				/* This was an upgrade, discard now-obsolete preparation history */
+				/* This was an upgrade, discard now-obsolete preparation state */
 				networkCtx().discardPreparedUpgradeMeta();
+				dualState.setFreezeTime(null);
 			}
 			networkCtx().setStateVersion(StateVersions.CURRENT_VERSION);
 

--- a/hedera-node/src/main/java/com/hedera/services/context/init/StateInitializationFlow.java
+++ b/hedera-node/src/main/java/com/hedera/services/context/init/StateInitializationFlow.java
@@ -27,7 +27,6 @@ import com.hedera.services.files.HederaFs;
 import com.hedera.services.state.StateAccessor;
 import com.hedera.services.state.annotations.WorkingState;
 import com.hedera.services.stream.RecordStreamManager;
-import com.hedera.services.txns.network.UpgradeActions;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -45,7 +44,6 @@ public class StateInitializationFlow {
 	private final HederaFs hfs;
 	private final HederaNumbers hederaNums;
 	private final StateAccessor stateAccessor;
-	private final UpgradeActions upgradeActions;
 	private final RecordStreamManager recordStreamManager;
 	private final Set<FileUpdateInterceptor> fileUpdateInterceptors;
 
@@ -53,7 +51,6 @@ public class StateInitializationFlow {
 	public StateInitializationFlow(
 			final HederaFs hfs,
 			final HederaNumbers hederaNums,
-			final UpgradeActions upgradeActions,
 			final RecordStreamManager recordStreamManager,
 			final @WorkingState StateAccessor stateAccessor,
 			final Set<FileUpdateInterceptor> fileUpdateInterceptors
@@ -61,7 +58,6 @@ public class StateInitializationFlow {
 		this.hfs = hfs;
 		this.hederaNums = hederaNums;
 		this.stateAccessor = stateAccessor;
-		this.upgradeActions = upgradeActions;
 		this.recordStreamManager = recordStreamManager;
 		this.fileUpdateInterceptors = fileUpdateInterceptors;
 	}
@@ -71,8 +67,6 @@ public class StateInitializationFlow {
 
 		stateAccessor.updateFrom(activeState);
 		log.info("Context updated with working state");
-
-		upgradeActions.catchUpOnMissedSideEffects();
 
 		final var activeHash = activeState.runningHashLeaf().getRunningHash().getHash();
 		recordStreamManager.setInitialHash(activeHash);

--- a/hedera-node/src/main/java/com/hedera/services/state/logic/NetworkCtxManager.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/logic/NetworkCtxManager.java
@@ -98,7 +98,7 @@ public class NetworkCtxManager {
 			var networkCtxNow = networkCtx.get();
 			log.info("Observable files not yet loaded, doing now.");
 			systemFilesManager.loadObservableSystemFiles();
-			log.info("Loaded observable files. {}", networkCtxNow);
+			log.info("Loaded observable files");
 			networkCtxNow.resetThrottlingFromSavedSnapshots(handleThrottling);
 			feeMultiplierSource.resetExpectations();
 			networkCtxNow.resetMultiplierSourceFromSavedCongestionStarts(feeMultiplierSource);

--- a/hedera-node/src/main/java/com/hedera/services/state/logic/ReconnectListener.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/logic/ReconnectListener.java
@@ -22,6 +22,7 @@ package com.hedera.services.state.logic;
 
 import com.hedera.services.ServicesState;
 import com.hedera.services.stream.RecordStreamManager;
+import com.hedera.services.txns.network.UpgradeActions;
 import com.swirlds.common.notification.listeners.ReconnectCompleteListener;
 import com.swirlds.common.notification.listeners.ReconnectCompleteNotification;
 import org.apache.logging.log4j.LogManager;
@@ -34,10 +35,12 @@ import javax.inject.Singleton;
 public class ReconnectListener implements ReconnectCompleteListener {
 	private static final Logger log = LogManager.getLogger(ReconnectListener.class);
 
+	private final UpgradeActions upgradeActions;
 	private final RecordStreamManager recordStreamManager;
 
 	@Inject
-	public ReconnectListener(RecordStreamManager recordStreamManager) {
+	public ReconnectListener(final UpgradeActions upgradeActions, final RecordStreamManager recordStreamManager) {
+		this.upgradeActions = upgradeActions;
 		this.recordStreamManager = recordStreamManager;
 	}
 
@@ -52,5 +55,6 @@ public class ReconnectListener implements ReconnectCompleteListener {
 		ServicesState state = (ServicesState) notification.getState();
 		state.logSummary();
 		recordStreamManager.setStartWriteAtCompleteWindow(true);
+		upgradeActions.catchUpOnMissedSideEffects();
 	}
 }

--- a/hedera-node/src/main/java/com/hedera/services/state/merkle/MerkleSpecialFiles.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/merkle/MerkleSpecialFiles.java
@@ -160,6 +160,7 @@ public class MerkleSpecialFiles extends AbstractMerkleLeaf {
 			return;
 		}
 		fileByParts.add(new FilePart(extraContents));
+		hashCache.remove(fid);
 	}
 
 	/**
@@ -173,6 +174,7 @@ public class MerkleSpecialFiles extends AbstractMerkleLeaf {
 	public synchronized void update(FileID fid, byte[] newContents) {
 		throwIfImmutable();
 		fileContents.put(fid, newFcqWith(newContents));
+		hashCache.remove(fid);
 	}
 
 	/**
@@ -250,6 +252,10 @@ public class MerkleSpecialFiles extends AbstractMerkleLeaf {
 	/* --- Only used by unit tests --- */
 	Map<FileID, FCQueue<FilePart>> getFileContents() {
 		return fileContents;
+	}
+
+	public Map<FileID, byte[]> getHashCache() {
+		return hashCache;
 	}
 
 	static void setBaosSupplier(Supplier<ByteArrayOutputStream> baosSupplier) {

--- a/hedera-node/src/main/java/com/hedera/services/txns/network/FreezeTransitionLogic.java
+++ b/hedera-node/src/main/java/com/hedera/services/txns/network/FreezeTransitionLogic.java
@@ -50,7 +50,6 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.FREEZE_UPDATE_
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.FREEZE_UPDATE_FILE_HASH_DOES_NOT_MATCH;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.FREEZE_UPGRADE_IN_PROGRESS;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_FREEZE_TRANSACTION_BODY;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.NO_FREEZE_IS_SCHEDULED;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.NO_UPGRADE_HAS_BEEN_PREPARED;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OK;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.UPDATE_FILE_HASH_CHANGED_SINCE_PREPARE_UPGRADE;
@@ -185,7 +184,8 @@ public class FreezeTransitionLogic implements TransitionLogic {
 				assertValidFreezeOnly(op);
 				break;
 			case FREEZE_ABORT:
-				assertValidFreezeAbort();
+				/* Nothing to do here; FREEZE_ABORT is idempotent to allow DevOps to submit
+				multiple such transactions if disconnected nodes missed the previous. */
 				break;
 			case PREPARE_UPGRADE:
 				assertValidPrepareUpgrade(op);
@@ -198,11 +198,6 @@ public class FreezeTransitionLogic implements TransitionLogic {
 						"Transaction type '" + freezeType + "' should have been rejected in precheck",
 						FAIL_INVALID);
 		}
-	}
-
-	private void assertValidFreezeAbort() {
-		final var isSomethingToAbort = upgradeActions.isFreezeScheduled() || networkCtx.get().hasPreparedUpgrade();
-		validateTrue(isSomethingToAbort, NO_FREEZE_IS_SCHEDULED);
 	}
 
 	private void assertValidFreezeOnly(final FreezeTransactionBody op) {

--- a/hedera-node/src/main/java/com/hedera/services/txns/network/UpgradeActions.java
+++ b/hedera-node/src/main/java/com/hedera/services/txns/network/UpgradeActions.java
@@ -162,18 +162,11 @@ public class UpgradeActions {
 		final var isUpgradePrepared = networkCtx.get().hasPreparedUpgrade();
 		if (isFreezeScheduled() && isUpgradePrepared) {
 			writeMarker(FREEZE_SCHEDULED_MARKER, dualState.get().getFreezeTime());
-		} else {
-			/* Must be non-null or isFreezeScheduled() would have thrown */
-			final var ds = dualState.get();
-			if (ds.getFreezeTime() == null && !isUpgradePrepared) {
-				/* Under normal conditions, this implies we are initializing after a reconnect. Write a
-				freeze aborted marker just in case we missed handling a FREEZE_ABORT while away. */
-				writeCheckMarker(FREEZE_ABORTED_MARKER);
-			} else {
-				/* We just restarted after a freeze, so can null out the freeze time. */
-				ds.setFreezeTime(null);
-			}
 		}
+		/* If we missed a FREEZE_ABORT, we are at risk of having a problem down the road.
+		But writing a "defensive" freeze_aborted.mf is itself too risky, as it will keep
+		us from correctly (1) catching up on a missed PREPARE_UPGRADE; or (2) handling an
+		imminent PREPARE_UPGRADE. */
 	}
 
 	private void catchUpOnMissedUpgradePrep() {

--- a/hedera-node/src/test/java/com/hedera/services/ServicesStateTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/ServicesStateTest.java
@@ -604,6 +604,7 @@ class ServicesStateTest {
 		subject.init(platform, addressBook, dualState);
 
 		verify(networkContext).discardPreparedUpgradeMeta();
+		verify(dualState).setFreezeTime(null);
 	}
 
 	@Test

--- a/hedera-node/src/test/java/com/hedera/services/context/init/StateInitializationFlowTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/context/init/StateInitializationFlowTest.java
@@ -28,7 +28,6 @@ import com.hedera.services.files.HederaFs;
 import com.hedera.services.state.StateAccessor;
 import com.hedera.services.stream.RecordStreamManager;
 import com.hedera.services.stream.RecordsRunningHashLeaf;
-import com.hedera.services.txns.network.UpgradeActions;
 import com.swirlds.common.crypto.Hash;
 import com.swirlds.common.crypto.RunningHash;
 import org.junit.jupiter.api.BeforeEach;
@@ -59,8 +58,6 @@ class StateInitializationFlowTest {
 	@Mock
 	private ServicesState activeState;
 	@Mock
-	private UpgradeActions upgradeActions;
-	@Mock
 	private RecordsRunningHashLeaf runningHashLeaf;
 	@Mock
 	private StateAccessor stateAccessor;
@@ -80,7 +77,6 @@ class StateInitializationFlowTest {
 		subject = new StateInitializationFlow(
 				hfs,
 				defaultNumbers,
-				upgradeActions,
 				recordStreamManager,
 				stateAccessor,
 				Set.of(aFileInterceptor, bFileInterceptor));
@@ -100,7 +96,6 @@ class StateInitializationFlowTest {
 		// then:
 		verify(staticNumbersHolder).accept(defaultNumbers);
 		verify(stateAccessor).updateFrom(activeState);
-		verify(upgradeActions).catchUpOnMissedSideEffects();
 		verify(recordStreamManager).setInitialHash(hash);
 		verify(hfs).register(aFileInterceptor);
 		verify(hfs).register(bFileInterceptor);

--- a/hedera-node/src/test/java/com/hedera/services/state/logic/ReconnectListenerTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/state/logic/ReconnectListenerTest.java
@@ -22,6 +22,7 @@ package com.hedera.services.state.logic;
 
 import com.hedera.services.ServicesState;
 import com.hedera.services.stream.RecordStreamManager;
+import com.hedera.services.txns.network.UpgradeActions;
 import com.hedera.test.extensions.LogCaptor;
 import com.hedera.test.extensions.LogCaptureExtension;
 import com.hedera.test.extensions.LoggingSubject;
@@ -51,6 +52,8 @@ class ReconnectListenerTest {
 	@Mock
 	private ServicesState servicesState;
 	@Mock
+	private UpgradeActions upgradeActions;
+	@Mock
 	private RecordStreamManager recordStreamManager;
 
 	@LoggingTarget
@@ -60,7 +63,7 @@ class ReconnectListenerTest {
 
 	@BeforeEach
 	void setUp() {
-		subject = new ReconnectListener(recordStreamManager);
+		subject = new ReconnectListener(upgradeActions, recordStreamManager);
 	}
 
 	@Test
@@ -80,5 +83,6 @@ class ReconnectListenerTest {
 		// and:
 		verify(servicesState).logSummary();
 		verify(recordStreamManager).setStartWriteAtCompleteWindow(true);
+		verify(upgradeActions).catchUpOnMissedSideEffects();
 	}
 }

--- a/hedera-node/src/test/java/com/hedera/services/state/merkle/MerkleSpecialFilesTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/state/merkle/MerkleSpecialFilesTest.java
@@ -102,6 +102,22 @@ class MerkleSpecialFilesTest {
 	}
 
 	@Test
+	void updateClearsHashCache() {
+		subject.update(fid, stuff);
+		assertTrue(subject.hashMatches(fid, stuffHash), "Updated stuff should have SHA-384 hash");
+		subject.update(fid, stuffHash);
+		assertFalse(subject.getHashCache().containsKey(fid));
+	}
+
+	@Test
+	void appendClearsHashCache() {
+		subject.update(fid, stuff);
+		assertTrue(subject.hashMatches(fid, stuffHash), "Updated stuff should have SHA-384 hash");
+		subject.append(fid, stuffHash);
+		assertFalse(subject.getHashCache().containsKey(fid));
+	}
+
+	@Test
 	void updateAccomplishesTheExpected() {
 		subject.update(fid, stuff);
 

--- a/hedera-node/src/test/java/com/hedera/services/txns/network/FreezeTransitionLogicTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/txns/network/FreezeTransitionLogicTest.java
@@ -58,7 +58,6 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.FREEZE_UPDATE_
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.FREEZE_UPDATE_FILE_HASH_DOES_NOT_MATCH;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.FREEZE_UPGRADE_IN_PROGRESS;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_FREEZE_TRANSACTION_BODY;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.NO_FREEZE_IS_SCHEDULED;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.NO_UPGRADE_HAS_BEEN_PREPARED;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OK;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.UPDATE_FILE_HASH_CHANGED_SINCE_PREPARE_UPGRADE;
@@ -265,31 +264,12 @@ class FreezeTransitionLogicTest {
 	}
 
 	@Test
-	void rejectsPostConsensusFreezeAbortWithNoPendingFreezeOrPreparedUpgrade() {
+	void acceptsFreezeAbortEvenWithNoPendingFreezeOrPreparedUpgrade() {
 		givenTypicalTxnInCtx(false, FREEZE_ABORT, Optional.empty(), Optional.empty());
-
-		assertFailsWith(() -> subject.doStateTransition(), NO_FREEZE_IS_SCHEDULED);
-	}
-
-	@Test
-	void performsFreezeAbortWithJustPreparedUpgrade() {
-		givenTypicalTxnInCtx(false, FREEZE_ABORT, Optional.empty(), Optional.empty());
-		given(networkCtx.hasPreparedUpgrade()).willReturn(true);
 
 		subject.doStateTransition();
 
 		verify(upgradeActions).abortScheduledFreeze();
-	}
-
-	@Test
-	void freezeAbortWithPendingFreezeWorks() {
-		givenTypicalTxnInCtx(false, FREEZE_ABORT, Optional.empty(), Optional.empty());
-		given(upgradeActions.isFreezeScheduled()).willReturn(true);
-
-		subject.doStateTransition();
-
-		verify(upgradeActions).abortScheduledFreeze();
-		verify(networkCtx).discardPreparedUpgradeMeta();
 	}
 
 	@Test

--- a/hedera-node/src/test/java/com/hedera/services/txns/network/UpgradeActionsTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/txns/network/UpgradeActionsTest.java
@@ -141,7 +141,6 @@ class UpgradeActionsTest {
 	void catchUpIsNoopWithNothingToDo() {
 		rmIfPresent(FREEZE_SCHEDULED_MARKER);
 		rmIfPresent(EXEC_IMMEDIATE_MARKER);
-		given(dynamicProperties.upgradeArtifactsLoc()).willReturn(markerFilesLoc);
 
 		subject.catchUpOnMissedSideEffects();
 
@@ -180,7 +179,7 @@ class UpgradeActionsTest {
 	}
 
 	@Test
-	void freezeCatchUpClearsDualAndWritesNoMarkersIfJustUnfrozen() {
+	void freezeCatchUpWritesNoMarkersIfJustUnfrozen() {
 		rmIfPresent(FREEZE_ABORTED_MARKER);
 		rmIfPresent(FREEZE_SCHEDULED_MARKER);
 
@@ -195,7 +194,6 @@ class UpgradeActionsTest {
 		assertFalse(
 				Paths.get(markerFilesLoc, FREEZE_SCHEDULED_MARKER).toFile().exists(),
 				"Should not create " + FREEZE_SCHEDULED_MARKER + " if dual last frozen time is freeze time");
-		verify(dualState).setFreezeTime(null);
 	}
 
 	@Test
@@ -209,17 +207,6 @@ class UpgradeActionsTest {
 		assertFalse(
 				Paths.get(markerFilesLoc, FREEZE_ABORTED_MARKER).toFile().exists(),
 				"Should not create defensive " + FREEZE_ABORTED_MARKER + " if upgrade is prepared");
-	}
-
-	@Test
-	void catchesUpOnFreezeAbortIfNullInDual() throws IOException {
-		rmIfPresent(FREEZE_ABORTED_MARKER);
-
-		given(dynamicProperties.upgradeArtifactsLoc()).willReturn(markerFilesLoc);
-
-		subject.catchUpOnMissedSideEffects();
-
-		assertMarkerCreated(FREEZE_ABORTED_MARKER, null);
 	}
 
 	@Test


### PR DESCRIPTION
**Description**:
1. Moves`UpgradeActions.catchUpOnMissedSideEffects()` from `ServicesState.init()` to `ReconnectCompleteListener.notify()`.
    - This prevents triggering NMT side-effects based on a out-of-date saved state during `ServicesState.init()`.
    - But `ServicesState.init()` is still responsible for nulling out the `DualState` freeze time when `freezeTime == lastFrozen`.
2. 🛑 Stops writing a "defensive" _freeze_aborted.mf_, even when reconnecting to a state without a prepared upgrade and a null `DualState.getFreezeTime()`.
3. Makes `FREEZE_ABORT` handling idempotent (i.e., stop resolving to `NO_FREEZE_IS_SCHEDULED ` if no freeze is scheduled or upgrade prepared; and always write the _freeze_aborted.mf_).
4. Fixes a bug in the `MerkleSpecialFiles` that didn't invalidate cached hashes. 
5. Updates the EET `UpgradeSuite` to test the new behavior.