### PR TITLE
Add blob hashing stress test

### DIFF
--- a/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/file/HapiFileCreate.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/file/HapiFileCreate.java
@@ -52,6 +52,7 @@ import java.util.OptionalLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.function.LongConsumer;
 
 import static com.hedera.services.bdd.spec.transactions.TxnFactory.bannerWith;
 import static com.hedera.services.bdd.spec.transactions.TxnUtils.suFrom;
@@ -69,14 +70,19 @@ public class HapiFileCreate extends HapiTxnOp<HapiFileCreate> {
 	Optional<String> contentsPath = Optional.empty();
 	Optional<byte[]> contents = Optional.empty();
 	Optional<String> memo = Optional.empty();
-	Optional<SigControl> waclControl = Optional.empty();
 	Optional<String> keyName = Optional.empty();
-	Optional<String> resourceName = Optional.empty();
+	Optional<SigControl> waclControl = Optional.empty();
+	Optional<LongConsumer> newNumObserver = Optional.empty();
 	AtomicReference<Timestamp> expiryUsed = new AtomicReference<>();
 	Optional<Function<HapiApiSpec, String>> contentsPathFn = Optional.empty();
 
 	public HapiFileCreate(String fileName) {
 		this.fileName = fileName;
+	}
+
+	public HapiFileCreate exposingNumTo(LongConsumer obs) {
+		newNumObserver = Optional.of(obs);
+		return this;
 	}
 
 	public HapiFileCreate advertisingCreation() {
@@ -224,10 +230,13 @@ public class HapiFileCreate extends HapiTxnOp<HapiFileCreate> {
 		if (actualStatus != SUCCESS) {
 			return;
 		}
+		final var newId = lastReceipt.getFileID();
+		newNumObserver.ifPresent(obs -> obs.accept(newId.getFileNum()));
+
 		if (!immutable) {
 			spec.registry().saveKey(fileName, waclKey);
 		}
-		spec.registry().saveFileId(fileName, lastReceipt.getFileID());
+		spec.registry().saveFileId(fileName, newId);
 		spec.registry().saveTimestamp(fileName, expiryUsed.get());
 		if (verboseLoggingOn) {
 			log.info("Created file {} with ID {}.", fileName, lastReceipt.getFileID());

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/file/FileExpansionLoadProvider.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/file/FileExpansionLoadProvider.java
@@ -1,0 +1,127 @@
+package com.hedera.services.bdd.suites.perf.file;
+
+
+/*-
+ * ‌
+ * Hedera Services Test Clients
+ * ​
+ * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import com.hedera.services.bdd.spec.HapiApiSpec;
+import com.hedera.services.bdd.spec.HapiSpecOperation;
+import com.hedera.services.bdd.spec.infrastructure.OpProvider;
+import com.hedera.services.bdd.spec.transactions.token.TokenMovement;
+import com.hedera.services.bdd.suites.HapiApiSuite;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
+
+import static com.hedera.services.bdd.spec.queries.QueryVerbs.getAccountBalance;
+import static com.hedera.services.bdd.spec.transactions.TxnUtils.NOISY_RETRY_PRECHECKS;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoTransfer;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.fileCreate;
+import static com.hedera.services.bdd.spec.transactions.token.TokenMovement.moving;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.freezeOnly;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.runWithProvider;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.sleepFor;
+import static com.hedera.services.bdd.suites.perf.PerfUtilOps.stdMgmtOf;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.DUPLICATE_TRANSACTION;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INSUFFICIENT_PAYER_BALANCE;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OK;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.PLATFORM_NOT_ACTIVE;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SUCCESS;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.UNKNOWN;
+import static java.util.concurrent.TimeUnit.MINUTES;
+
+public class FileExpansionLoadProvider extends HapiApiSuite {
+	private static final Logger log = LogManager.getLogger(FileExpansionLoadProvider.class);
+
+	private AtomicLong duration = new AtomicLong(5);
+	private AtomicReference<TimeUnit> unit = new AtomicReference<>(MINUTES);
+	private AtomicInteger maxOpsPerSec = new AtomicInteger(13);
+
+	public static void main(String... args) {
+		new FileExpansionLoadProvider().runSuiteSync();
+	}
+
+	@Override
+	protected List<HapiApiSpec> getSpecsInSuite() {
+		return List.of(
+				new HapiApiSpec[] {
+						runFileExpansions(),
+				}
+		);
+	}
+
+	private HapiApiSpec runFileExpansions() {
+		return HapiApiSpec.defaultHapiSpec("RunFileExpansions")
+				.given(
+						getAccountBalance(DEFAULT_PAYER).logged(),
+						stdMgmtOf(duration, unit, maxOpsPerSec)
+				).when(
+						runWithProvider(fileExpansionsFactory())
+								.lasting(duration::get, unit::get)
+								.maxOpsPerSec(maxOpsPerSec::get)
+				).then(
+						getAccountBalance(DEFAULT_PAYER).logged(),
+						// The freeze and long wait after freeze means to keep the server in MAINTENANCE state till test
+						// end to prevent it from making new export files that may cause account balances validator to
+						// be inconsistent. The freeze shouldn't cause normal perf test any issue.
+						freezeOnly().payingWith(GENESIS)
+								.startingIn(30).seconds()
+								.hasKnownStatusFrom(SUCCESS, UNKNOWN)
+								.hasAnyPrecheck(),
+						sleepFor(60_000)
+				);
+	}
+
+	private Function<HapiApiSpec, OpProvider> fileExpansionsFactory() {
+		final AtomicLong currentTarget = new AtomicLong();
+		final AtomicBoolean timeForNewTarget = new AtomicBoolean(Boolean.TRUE);
+
+		return spec -> new OpProvider() {
+			@Override
+			public List<HapiSpecOperation> suggestedInitializers() {
+				return Collections.emptyList();
+			}
+
+			@Override
+			public Optional<HapiSpecOperation> get() {
+				HapiSpecOperation op;
+				if (timeForNewTarget.get()) {
+				} else {
+
+				}
+				return Optional.of(op);
+			}
+		};
+	}
+
+	@Override
+	protected Logger getResultsLogger() {
+		return log;
+	}
+}

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/file/FileExpansionLoadProvider.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/file/FileExpansionLoadProvider.java
@@ -24,44 +24,59 @@ package com.hedera.services.bdd.suites.perf.file;
 import com.hedera.services.bdd.spec.HapiApiSpec;
 import com.hedera.services.bdd.spec.HapiSpecOperation;
 import com.hedera.services.bdd.spec.infrastructure.OpProvider;
-import com.hedera.services.bdd.spec.transactions.token.TokenMovement;
+import com.hedera.services.bdd.spec.keys.KeyShape;
+import com.hedera.services.bdd.spec.transactions.TxnUtils;
 import com.hedera.services.bdd.suites.HapiApiSuite;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import java.util.Collections;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
+import java.util.SplittableRandom;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
+import java.util.function.LongFunction;
 
-import static com.hedera.services.bdd.spec.queries.QueryVerbs.getAccountBalance;
-import static com.hedera.services.bdd.spec.transactions.TxnUtils.NOISY_RETRY_PRECHECKS;
-import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoTransfer;
+import static com.hedera.services.bdd.spec.HapiSpecSetup.getDefaultNodeProps;
+import static com.hedera.services.bdd.spec.keys.KeyShape.SIMPLE;
+import static com.hedera.services.bdd.spec.keys.KeyShape.listOf;
+import static com.hedera.services.bdd.spec.keys.KeyShape.threshOf;
+import static com.hedera.services.bdd.spec.transactions.TxnUtils.BYTES_4K;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.fileAppend;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.fileCreate;
-import static com.hedera.services.bdd.spec.transactions.token.TokenMovement.moving;
-import static com.hedera.services.bdd.spec.utilops.UtilVerbs.freezeOnly;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.newKeyNamed;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.noOp;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.overriding;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.runWithProvider;
-import static com.hedera.services.bdd.spec.utilops.UtilVerbs.sleepFor;
+import static com.hedera.services.bdd.suites.perf.PerfUtilOps.mgmtOfIntProp;
 import static com.hedera.services.bdd.suites.perf.PerfUtilOps.stdMgmtOf;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.DUPLICATE_TRANSACTION;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INSUFFICIENT_PAYER_BALANCE;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OK;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.PLATFORM_NOT_ACTIVE;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.MAX_FILE_SIZE_EXCEEDED;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SUCCESS;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.UNKNOWN;
 import static java.util.concurrent.TimeUnit.MINUTES;
 
 public class FileExpansionLoadProvider extends HapiApiSuite {
 	private static final Logger log = LogManager.getLogger(FileExpansionLoadProvider.class);
 
+	private static final String MAX_FILE_SIZE_KB_PROP = "files.maxSizeKb";
+	private static final String DEFAULT_MAX_FILE_SIZE_KB = getDefaultNodeProps().get(MAX_FILE_SIZE_KB_PROP);
+	/* Useful for manipulating the # of FileCreates vs # of FileAppends */
+	private static final String OVERRIDE_MAX_FILE_SIZE_KB = "512";
+
+	private static final int DEFAULT_OPS_PER_SEC = 5;
+	private static final int DEFAULT_NUM_FILES_BEING_EXPANDED = 1;
+
+	private static final byte[] DATA_CHUNK = TxnUtils.randomUtf8Bytes(BYTES_4K / 4 * 5);
+
 	private AtomicLong duration = new AtomicLong(5);
 	private AtomicReference<TimeUnit> unit = new AtomicReference<>(MINUTES);
-	private AtomicInteger maxOpsPerSec = new AtomicInteger(13);
+	private AtomicInteger maxOpsPerSec = new AtomicInteger(DEFAULT_OPS_PER_SEC);
+	private AtomicInteger numActiveTargets = new AtomicInteger(DEFAULT_NUM_FILES_BEING_EXPANDED);
 
 	public static void main(String... args) {
 		new FileExpansionLoadProvider().runSuiteSync();
@@ -79,41 +94,78 @@ public class FileExpansionLoadProvider extends HapiApiSuite {
 	private HapiApiSpec runFileExpansions() {
 		return HapiApiSpec.defaultHapiSpec("RunFileExpansions")
 				.given(
-						getAccountBalance(DEFAULT_PAYER).logged(),
-						stdMgmtOf(duration, unit, maxOpsPerSec)
+						overriding(MAX_FILE_SIZE_KB_PROP, OVERRIDE_MAX_FILE_SIZE_KB),
+						stdMgmtOf(duration, unit, maxOpsPerSec),
+						mgmtOfIntProp(numActiveTargets, "numActiveTargets")
 				).when(
 						runWithProvider(fileExpansionsFactory())
 								.lasting(duration::get, unit::get)
 								.maxOpsPerSec(maxOpsPerSec::get)
 				).then(
-						getAccountBalance(DEFAULT_PAYER).logged(),
-						// The freeze and long wait after freeze means to keep the server in MAINTENANCE state till test
-						// end to prevent it from making new export files that may cause account balances validator to
-						// be inconsistent. The freeze shouldn't cause normal perf test any issue.
-						freezeOnly().payingWith(GENESIS)
-								.startingIn(30).seconds()
-								.hasKnownStatusFrom(SUCCESS, UNKNOWN)
-								.hasAnyPrecheck(),
-						sleepFor(60_000)
+						overriding(MAX_FILE_SIZE_KB_PROP, DEFAULT_MAX_FILE_SIZE_KB)
 				);
 	}
 
 	private Function<HapiApiSpec, OpProvider> fileExpansionsFactory() {
-		final AtomicLong currentTarget = new AtomicLong();
-		final AtomicBoolean timeForNewTarget = new AtomicBoolean(Boolean.TRUE);
+		final SplittableRandom r = new SplittableRandom();
+		final Set<String> usableTargets = ConcurrentHashMap.newKeySet();
+		final LongFunction<String> targetNameFn = i -> "expandingFile" + i;
+		final AtomicInteger nextTargetNum = new AtomicInteger(numActiveTargets.get());
+		final var key = "multi";
+		final var waclShape = KeyShape.listOf(SIMPLE, threshOf(1, 3), listOf(2));
 
 		return spec -> new OpProvider() {
 			@Override
 			public List<HapiSpecOperation> suggestedInitializers() {
-				return Collections.emptyList();
+				final List<HapiSpecOperation> ops = new ArrayList<>();
+				ops.add(newKeyNamed(key).shape(waclShape));
+				for (int i = 0, n = numActiveTargets.get(); i < n; i++) {
+					ops.add(fileCreate(targetNameFn.apply(i))
+							.key(key)
+							.noLogging()
+							.contents(DATA_CHUNK)
+							.payingWith(GENESIS));
+				}
+				return ops;
 			}
 
 			@Override
 			public Optional<HapiSpecOperation> get() {
 				HapiSpecOperation op;
-				if (timeForNewTarget.get()) {
+				if (usableTargets.size() < numActiveTargets.get()) {
+					final var name = targetNameFn.apply(nextTargetNum.getAndIncrement());
+					op = fileCreate(name)
+							.noLogging()
+							.key(key)
+							.contents(DATA_CHUNK)
+							.payingWith(GENESIS)
+							.deferStatusResolution()
+							.exposingNumTo(num -> {
+								usableTargets.add(name);
+							});
 				} else {
-
+					final var skips  = r.nextInt(usableTargets.size());
+					final var iter = usableTargets.iterator();
+					try {
+						for (int i = 0; i < skips; i++) {
+							iter.next();
+						}
+						final var target = iter.next();
+						op = fileAppend(target)
+								.noLogging()
+								.deferStatusResolution()
+								.payingWith(GENESIS)
+								.content(DATA_CHUNK)
+								.hasKnownStatusFrom(MAX_FILE_SIZE_EXCEEDED, SUCCESS)
+								.alertingPost(code -> {
+									if (code == MAX_FILE_SIZE_EXCEEDED)	{
+										log.info("File {} reached max size, no longer in rotation", target);
+										usableTargets.remove(target);
+									}
+								});
+					} catch (Exception ignore) {
+						op = noOp();
+					}
 				}
 				return Optional.of(op);
 			}

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/file/FileExpansionLoadProvider.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/file/FileExpansionLoadProvider.java
@@ -60,6 +60,17 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.MAX_FILE_SIZE_
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SUCCESS;
 import static java.util.concurrent.TimeUnit.MINUTES;
 
+/**
+ * Load provider that continually appends 5kb chunks to a random choice of one of a set of target files.
+ *
+ * Along with the standard {@code duration}, {@code unit}, and {@code maxOpsPerSec} parameters, the
+ * client supports configuration based on:
+ * <ul>
+ *     <li>An override for the {@code files.maxSizeKb} property.</li>
+ *     <li>The number of target files to maintain (once a file reaches the maximum size, it is
+ *     "taken out of rotation" and a new target file created).</li>
+ * </ul>
+ */
 public class FileExpansionLoadProvider extends HapiApiSuite {
 	private static final Logger log = LogManager.getLogger(FileExpansionLoadProvider.class);
 


### PR DESCRIPTION
**Description**:
- Adds the `FileExpansionLoadProvider` to serve as a client that puts maximum pressure on the hashing of blobs in state, by continually appending 5kb chunks to a rotating set of "targets".

**Related issue(s)**:
- Closes #2374
