### PR TITLE
FREEZE_ALREADY_SCHEDULED should be an acceptable response in multi client scenario

### DIFF
--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/autorenew/AccountAutoRenewalSuite.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/autorenew/AccountAutoRenewalSuite.java
@@ -266,7 +266,7 @@ public class AccountAutoRenewalSuite extends HapiApiSuite {
 		return defaultHapiSpec("freezeAtTheEnd")
 				.given()
 				.when(
-						freezeOnly().startingIn(0).minutes().payingWith(GENESIS)
+						freezeOnly().startingIn(30).seconds().payingWith(GENESIS)
 				)
 				.then(
 						// sleep for a while to wait for this freeze transaction be handled

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/freeze/CryptoTransferThenFreezeTest.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/freeze/CryptoTransferThenFreezeTest.java
@@ -55,7 +55,12 @@ public class CryptoTransferThenFreezeTest extends CryptoTransferLoadTest {
 				.given(
 						withOpContext((spec, ignore) -> settings.setFrom(spec.setup().ciPropertiesMap())),
 						logIt(ignore -> settings.toString()))
-				.when(freezeOnly().startingIn(0).minutes().payingWith(GENESIS)).then(
+				.when(
+						freezeOnly()
+								.startingIn(30)
+								.seconds()
+								.payingWith(GENESIS))
+				.then(
 						// sleep for a while to wait for this freeze transaction be handled
 						UtilVerbs.sleepFor(75_000)
 				);

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/token/TokenTransfersLoadProvider.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/token/TokenTransfersLoadProvider.java
@@ -63,6 +63,7 @@ import static com.hedera.services.bdd.spec.utilops.UtilVerbs.withOpContext;
 import static com.hedera.services.bdd.suites.perf.PerfUtilOps.stdMgmtOf;
 import static com.hedera.services.bdd.suites.perf.PerfUtilOps.tokenOpsEnablement;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.DUPLICATE_TRANSACTION;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.FREEZE_ALREADY_SCHEDULED;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INSUFFICIENT_PAYER_BALANCE;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OK;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.PLATFORM_NOT_ACTIVE;
@@ -111,7 +112,7 @@ public class TokenTransfersLoadProvider extends HapiApiSuite {
 						// be inconsistent. The freeze shouldn't cause normal perf test any issue.
 						freezeOnly().payingWith(GENESIS)
 								.startingIn(30).seconds()
-								.hasKnownStatusFrom(SUCCESS, UNKNOWN)
+								.hasKnownStatusFrom(SUCCESS, UNKNOWN, FREEZE_ALREADY_SCHEDULED)
 								.hasAnyPrecheck(),
 						sleepFor(60_000)
 				);


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->

**Related issue(s)**:

Fixes #2398 , #2399 

**Notes for reviewer**:
Set a future time for all freeze txns as the starting time and 
make `FREEZE_ALREADY_SCHEDULED` as acceptable response in multi client scenario

Test Results:
[HTS-Restart-Performance-Hotspot-10k-61m](https://hedera-hashgraph.slack.com/archives/C018CBQBTGB/p1635872796042800) multiple clients will no longer fail with `FREEZE_ALREADY_SCHEDULED`

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
