### PR TITLE
Write now_frozen marker based on StateWriteToDiskCompleteNotification

### DIFF
--- a/hedera-node/src/main/java/com/hedera/services/ServicesApp.java
+++ b/hedera-node/src/main/java/com/hedera/services/ServicesApp.java
@@ -77,6 +77,7 @@ import com.swirlds.common.NodeId;
 import com.swirlds.common.Platform;
 import com.swirlds.common.notification.NotificationEngine;
 import com.swirlds.common.notification.listeners.ReconnectCompleteListener;
+import com.swirlds.common.notification.listeners.StateWriteToDiskCompleteListener;
 import dagger.BindsInstance;
 import dagger.Component;
 
@@ -146,6 +147,7 @@ public interface ServicesApp {
 	SystemAccountsCreator sysAccountsCreator();
 	Optional<PrintStream> consoleOut();
 	ReconnectCompleteListener reconnectListener();
+	StateWriteToDiskCompleteListener stateWriteToDiskListener();
 	InvalidSignedStateListener issListener();
 	Supplier<NotificationEngine> notificationEngine();
 	BackingStore<AccountID, MerkleAccount> backingAccounts();

--- a/hedera-node/src/main/java/com/hedera/services/ServicesMain.java
+++ b/hedera-node/src/main/java/com/hedera/services/ServicesMain.java
@@ -26,6 +26,7 @@ import com.swirlds.common.PlatformStatus;
 import com.swirlds.common.SwirldMain;
 import com.swirlds.common.SwirldState;
 import com.swirlds.common.notification.listeners.ReconnectCompleteListener;
+import com.swirlds.common.notification.listeners.StateWriteToDiskCompleteListener;
 import com.swirlds.platform.Browser;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -178,6 +179,7 @@ public class ServicesMain implements SwirldMain {
 		app.ledgerValidator().validate(app.workingState().accounts());
 		app.nodeInfo().validateSelfAccountIfStaked();
 		app.notificationEngine().get().register(ReconnectCompleteListener.class, app.reconnectListener());
+		app.notificationEngine().get().register(StateWriteToDiskCompleteListener.class, app.stateWriteToDiskListener());
 	}
 
 	private boolean defaultCharsetIsCorrect() {

--- a/hedera-node/src/main/java/com/hedera/services/ServicesMain.java
+++ b/hedera-node/src/main/java/com/hedera/services/ServicesMain.java
@@ -78,7 +78,6 @@ public class ServicesMain implements SwirldMain {
 			app.recordStreamManager().setInFreeze(false);
 		} else if (status == MAINTENANCE) {
 			app.recordStreamManager().setInFreeze(true);
-			app.upgradeActions().externalizeFreezeIfUpgradePending();
 		} else {
 			log.info("Platform {} status set to : {}", nodeId, status);
 		}

--- a/hedera-node/src/main/java/com/hedera/services/state/StateModule.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/StateModule.java
@@ -46,6 +46,7 @@ import com.hedera.services.state.initialization.SystemAccountsCreator;
 import com.hedera.services.state.initialization.SystemFilesManager;
 import com.hedera.services.state.logic.HandleLogicModule;
 import com.hedera.services.state.logic.ReconnectListener;
+import com.hedera.services.state.logic.StateWriteToDiskListener;
 import com.hedera.services.state.merkle.MerkleAccount;
 import com.hedera.services.state.merkle.MerkleNetworkContext;
 import com.hedera.services.state.merkle.MerkleOptionalBlob;
@@ -77,6 +78,7 @@ import com.swirlds.common.Platform;
 import com.swirlds.common.notification.NotificationEngine;
 import com.swirlds.common.notification.NotificationFactory;
 import com.swirlds.common.notification.listeners.ReconnectCompleteListener;
+import com.swirlds.common.notification.listeners.StateWriteToDiskCompleteListener;
 import com.swirlds.fchashmap.FCOneToManyRelation;
 import com.swirlds.merkle.map.MerkleMap;
 import dagger.Binds;
@@ -104,6 +106,11 @@ public abstract class StateModule {
 	@Binds
 	@Singleton
 	public abstract ReconnectCompleteListener bindReconnectListener(ReconnectListener reconnectListener);
+
+	@Binds
+	@Singleton
+	public abstract StateWriteToDiskCompleteListener bindStateWrittenToDiskListener(
+			StateWriteToDiskListener stateWriteToDiskListener);
 
 	@Binds
 	@Singleton

--- a/hedera-node/src/main/java/com/hedera/services/state/logic/StateWriteToDiskListener.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/logic/StateWriteToDiskListener.java
@@ -1,0 +1,60 @@
+package com.hedera.services.state.logic;
+
+/*-
+ * ‌
+ * Hedera Services Node
+ * ​
+ * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import com.hedera.services.txns.network.UpgradeActions;
+import com.swirlds.common.notification.listeners.StateWriteToDiskCompleteListener;
+import com.swirlds.common.notification.listeners.StateWriteToDiskCompleteNotification;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+/**
+ * Listener that will be notified with
+ * {@link com.swirlds.common.notification.listeners.StateWriteToDiskCompleteNotification}
+ * when state is written to disk. This writes {@code NOW_FROZEN_MARKER} to disk when upgrade is pending
+ */
+@Singleton
+public class StateWriteToDiskListener implements StateWriteToDiskCompleteListener {
+	private static final Logger log = LogManager.getLogger(StateWriteToDiskListener.class);
+
+	private final UpgradeActions upgradeActions;
+
+	@Inject
+	public StateWriteToDiskListener(final UpgradeActions upgradeActions) {
+		this.upgradeActions = upgradeActions;
+	}
+
+	@Override
+	public void notify(final StateWriteToDiskCompleteNotification notification) {
+		if (notification.isFreezeState()) {
+			log.info(
+					"Notification Received: Freeze State Finished. " +
+							"consensusTimestamp: {}, roundNumber: {}, sequence: {}",
+					notification.getConsensusTimestamp(),
+					notification.getRoundNumber(),
+					notification.getSequence());
+			upgradeActions.externalizeFreezeIfUpgradePending();
+		}
+	}
+}

--- a/hedera-node/src/test/java/com/hedera/services/ServicesMainTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/ServicesMainTest.java
@@ -249,7 +249,6 @@ class ServicesMainTest {
 		withRunnableApp();
 		withChangeableApp();
 
-		given(app.upgradeActions()).willReturn(upgradeActions);
 		given(app.recordStreamManager()).willReturn(recordStreamManager);
 		// and:
 		subject.init(platform, nodeId);

--- a/hedera-node/src/test/java/com/hedera/services/ServicesMainTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/ServicesMainTest.java
@@ -45,6 +45,7 @@ import com.swirlds.common.NodeId;
 import com.swirlds.common.Platform;
 import com.swirlds.common.notification.NotificationEngine;
 import com.swirlds.common.notification.listeners.ReconnectCompleteListener;
+import com.swirlds.common.notification.listeners.StateWriteToDiskCompleteListener;
 import com.swirlds.merkle.map.MerkleMap;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -112,6 +113,8 @@ class ServicesMainTest {
 	private NodeInfo nodeInfo;
 	@Mock
 	private ReconnectCompleteListener reconnectListener;
+	@Mock
+	private StateWriteToDiskCompleteListener stateToDiskListener;
 	@Mock
 	private InvalidSignedStateListener issListener;
 	@Mock
@@ -192,6 +195,7 @@ class ServicesMainTest {
 		verify(statsManager).initializeFor(platform);
 		verify(accountsExporter).toFile(accounts);
 		verify(notificationEngine).register(ReconnectCompleteListener.class, reconnectListener);
+		verify(notificationEngine).register(StateWriteToDiskCompleteListener.class, stateToDiskListener);
 		verify(grpcStarter).startIfAppropriate();
 	}
 
@@ -255,7 +259,6 @@ class ServicesMainTest {
 
 		// then:
 		verify(currentPlatformStatus).set(MAINTENANCE);
-		verify(upgradeActions).externalizeFreezeIfUpgradePending();
 		verify(recordStreamManager).setInFreeze(true);
 	}
 
@@ -344,6 +347,7 @@ class ServicesMainTest {
 		given(app.issListener()).willReturn(issListener);
 		given(app.notificationEngine()).willReturn(() -> notificationEngine);
 		given(app.reconnectListener()).willReturn(reconnectListener);
+		given(app.stateWriteToDiskListener()).willReturn(stateToDiskListener);
 		given(app.statsManager()).willReturn(statsManager);
 		given(app.accountsExporter()).willReturn(accountsExporter);
 		given(app.grpcStarter()).willReturn(grpcStarter);

--- a/hedera-node/src/test/java/com/hedera/services/state/logic/StateWriteToDiskListenerTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/state/logic/StateWriteToDiskListenerTest.java
@@ -20,7 +20,6 @@ package com.hedera.services.state.logic;
  * ‍
  */
 
-import com.hedera.services.ServicesState;
 import com.hedera.services.txns.network.UpgradeActions;
 import com.hedera.test.extensions.LogCaptor;
 import com.hedera.test.extensions.LogCaptureExtension;
@@ -43,9 +42,9 @@ import static org.mockito.Mockito.verify;
 
 @ExtendWith({ MockitoExtension.class, LogCaptureExtension.class })
 class StateWriteToDiskListenerTest {
-	private final long round = 234L;
-	private final long sequence = 123L;
-	private final Instant consensusNow = Instant.ofEpochSecond(1_234_567L, 890);
+	private static final long round = 234L;
+	private static final long sequence = 123L;
+	private static final Instant consensusNow = Instant.ofEpochSecond(1_234_567L, 890);
 
 	@Mock
 	private StateWriteToDiskCompleteNotification notification;
@@ -69,14 +68,11 @@ class StateWriteToDiskListenerTest {
 		given(notification.getConsensusTimestamp()).willReturn(consensusNow);
 		given(notification.isFreezeState()).willReturn(true);
 
-		// when:
 		subject.notify(notification);
 
-		// then:
 		assertThat(logCaptor.infoLogs(),
 				contains("Notification Received: Freeze State Finished. consensusTimestamp: 1970-01-15T06:56:07.000000890Z, " +
 						"roundNumber: 234, sequence: 123"));
-		// and:
 		verify(upgradeActions).externalizeFreezeIfUpgradePending();
 	}
 
@@ -84,10 +80,8 @@ class StateWriteToDiskListenerTest {
 	void doesntNotifyForEverySignedStateWritten() {
 		given(notification.isFreezeState()).willReturn(false);
 
-		// when:
 		subject.notify(notification);
 
-		// then:
 		verify(upgradeActions, never()).externalizeFreezeIfUpgradePending();
 	}
 }

--- a/hedera-node/src/test/java/com/hedera/services/state/logic/StateWriteToDiskListenerTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/state/logic/StateWriteToDiskListenerTest.java
@@ -1,0 +1,93 @@
+package com.hedera.services.state.logic;
+
+/*-
+ * ‌
+ * Hedera Services Node
+ * ​
+ * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import com.hedera.services.ServicesState;
+import com.hedera.services.txns.network.UpgradeActions;
+import com.hedera.test.extensions.LogCaptor;
+import com.hedera.test.extensions.LogCaptureExtension;
+import com.hedera.test.extensions.LoggingSubject;
+import com.hedera.test.extensions.LoggingTarget;
+import com.swirlds.common.notification.listeners.StateWriteToDiskCompleteNotification;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Instant;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.collection.IsIterableContainingInOrder.contains;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith({ MockitoExtension.class, LogCaptureExtension.class })
+class StateWriteToDiskListenerTest {
+	private final long round = 234L;
+	private final long sequence = 123L;
+	private final Instant consensusNow = Instant.ofEpochSecond(1_234_567L, 890);
+
+	@Mock
+	private StateWriteToDiskCompleteNotification notification;
+	@Mock
+	private UpgradeActions upgradeActions;
+
+	@LoggingTarget
+	private LogCaptor logCaptor;
+	@LoggingSubject
+	private StateWriteToDiskListener subject;
+
+	@BeforeEach
+	void setUp() {
+		subject = new StateWriteToDiskListener(upgradeActions);
+	}
+
+	@Test
+	void notifiesWhenFrozen() {
+		given(notification.getSequence()).willReturn(sequence);
+		given(notification.getRoundNumber()).willReturn(round);
+		given(notification.getConsensusTimestamp()).willReturn(consensusNow);
+		given(notification.isFreezeState()).willReturn(true);
+
+		// when:
+		subject.notify(notification);
+
+		// then:
+		assertThat(logCaptor.infoLogs(),
+				contains("Notification Received: Freeze State Finished. consensusTimestamp: 1970-01-15T06:56:07.000000890Z, " +
+						"roundNumber: 234, sequence: 123"));
+		// and:
+		verify(upgradeActions).externalizeFreezeIfUpgradePending();
+	}
+
+	@Test
+	void doesntNotifyForEverySignedStateWritten() {
+		given(notification.isFreezeState()).willReturn(false);
+
+		// when:
+		subject.notify(notification);
+
+		// then:
+		verify(upgradeActions, never()).externalizeFreezeIfUpgradePending();
+	}
+}


### PR DESCRIPTION
Closes #2423 

1. Added `StateWriteToDiskListener` that listens to `StateWriteToDiskCompleteNotification`
2. Modified the `now_frozen.mf` marker to be written when the StateWriteToDiskCompleteNotification is received and state is frozen


Passed update Migration test