### PR TITLE
Track deprecated transactions received in precheck

### DIFF
--- a/hedera-node/src/main/java/com/hedera/services/stats/HapiOpCounters.java
+++ b/hedera-node/src/main/java/com/hedera/services/stats/HapiOpCounters.java
@@ -35,6 +35,8 @@ import static com.hedera.services.stats.ServicesStatsConfig.COUNTER_ANSWERED_DES
 import static com.hedera.services.stats.ServicesStatsConfig.COUNTER_ANSWERED_NAME_TPL;
 import static com.hedera.services.stats.ServicesStatsConfig.COUNTER_HANDLED_DESC_TPL;
 import static com.hedera.services.stats.ServicesStatsConfig.COUNTER_HANDLED_NAME_TPL;
+import static com.hedera.services.stats.ServicesStatsConfig.COUNTER_RECEIVED_DEPRECATED_DESC_TPL;
+import static com.hedera.services.stats.ServicesStatsConfig.COUNTER_RECEIVED_DEPRECATED_NAME_TPL;
 import static com.hedera.services.stats.ServicesStatsConfig.COUNTER_RECEIVED_DESC_TPL;
 import static com.hedera.services.stats.ServicesStatsConfig.COUNTER_RECEIVED_NAME_TPL;
 import static com.hedera.services.stats.ServicesStatsConfig.COUNTER_SUBMITTED_DESC_TPL;
@@ -55,6 +57,7 @@ public class HapiOpCounters {
 	EnumMap<HederaFunctionality, AtomicLong> handledTxns = new EnumMap<>(HederaFunctionality.class);
 	EnumMap<HederaFunctionality, AtomicLong> submittedTxns = new EnumMap<>(HederaFunctionality.class);
 	EnumMap<HederaFunctionality, AtomicLong> answeredQueries = new EnumMap<>(HederaFunctionality.class);
+	EnumMap<HederaFunctionality, AtomicLong> receivedDeprecatedTxns = new EnumMap<>(HederaFunctionality.class);
 
 	public HapiOpCounters(
 			final CounterFactory counter,
@@ -70,14 +73,15 @@ public class HapiOpCounters {
 		Arrays.stream(allFunctions.get())
 				.filter(function -> !IGNORED_FUNCTIONS.contains(function))
 				.forEach(function -> {
-			receivedOps.put(function, new AtomicLong());
-			if (QUERY_FUNCTIONS.contains(function)) {
-				answeredQueries.put(function, new AtomicLong());
-			} else {
-				submittedTxns.put(function, new AtomicLong());
-				handledTxns.put(function, new AtomicLong());
-			}
-		});
+					receivedOps.put(function, new AtomicLong());
+					if (QUERY_FUNCTIONS.contains(function)) {
+						answeredQueries.put(function, new AtomicLong());
+					} else {
+						submittedTxns.put(function, new AtomicLong());
+						handledTxns.put(function, new AtomicLong());
+						receivedDeprecatedTxns.put(function, new AtomicLong());
+					}
+				});
 	}
 
 	public void registerWith(final Platform platform) {
@@ -85,6 +89,8 @@ public class HapiOpCounters {
 		registerCounters(platform, submittedTxns, COUNTER_SUBMITTED_NAME_TPL, COUNTER_SUBMITTED_DESC_TPL);
 		registerCounters(platform, handledTxns, COUNTER_HANDLED_NAME_TPL, COUNTER_HANDLED_DESC_TPL);
 		registerCounters(platform, answeredQueries, COUNTER_ANSWERED_NAME_TPL, COUNTER_ANSWERED_DESC_TPL);
+		registerCounters(platform, receivedDeprecatedTxns, COUNTER_RECEIVED_DEPRECATED_NAME_TPL,
+				COUNTER_RECEIVED_DEPRECATED_DESC_TPL);
 	}
 
 	private void registerCounters(
@@ -93,7 +99,7 @@ public class HapiOpCounters {
 			final String nameTpl,
 			final String descTpl
 	) {
-		for (final var entry : counters.entrySet())	{
+		for (final var entry : counters.entrySet()) {
 			final var baseName = statNameFn.apply(entry.getKey());
 			final var fullName = String.format(nameTpl, baseName);
 			final var description = String.format(descTpl, baseName);
@@ -144,5 +150,13 @@ public class HapiOpCounters {
 		if (!IGNORED_FUNCTIONS.contains(function)) {
 			counters.get(function).getAndIncrement();
 		}
+	}
+
+	public void countDeprecatedTxnReceived(final HederaFunctionality txn) {
+		safeIncrement(receivedDeprecatedTxns, txn);
+	}
+
+	public long receivedDeprecatedTxnSoFar(final HederaFunctionality txn) {
+		return IGNORED_FUNCTIONS.contains(txn) ? 0 : receivedDeprecatedTxns.get(txn).get();
 	}
 }

--- a/hedera-node/src/main/java/com/hedera/services/stats/HapiOpCounters.java
+++ b/hedera-node/src/main/java/com/hedera/services/stats/HapiOpCounters.java
@@ -89,8 +89,17 @@ public class HapiOpCounters {
 		registerCounters(platform, submittedTxns, COUNTER_SUBMITTED_NAME_TPL, COUNTER_SUBMITTED_DESC_TPL);
 		registerCounters(platform, handledTxns, COUNTER_HANDLED_NAME_TPL, COUNTER_HANDLED_DESC_TPL);
 		registerCounters(platform, answeredQueries, COUNTER_ANSWERED_NAME_TPL, COUNTER_ANSWERED_DESC_TPL);
+		registerCounter(platform, receivedDeprecatedTxns, COUNTER_RECEIVED_DEPRECATED_NAME_TPL,
+				COUNTER_RECEIVED_DEPRECATED_DESC_TPL);
+	}
 
-		platform.addAppStatEntry(counter.from(COUNTER_RECEIVED_DEPRECATED_NAME_TPL, COUNTER_RECEIVED_DEPRECATED_DESC_TPL, receivedDeprecatedTxns::get));
+	private void registerCounter(
+			final Platform platform,
+			final AtomicLong counters,
+			final String nameTpl,
+			final String descTpl
+	) {
+		platform.addAppStatEntry(counter.from(nameTpl, descTpl, counters::get));
 	}
 
 	private void registerCounters(

--- a/hedera-node/src/main/java/com/hedera/services/stats/HapiOpCounters.java
+++ b/hedera-node/src/main/java/com/hedera/services/stats/HapiOpCounters.java
@@ -26,7 +26,6 @@ import com.swirlds.common.Platform;
 
 import java.util.Arrays;
 import java.util.EnumMap;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Function;

--- a/hedera-node/src/main/java/com/hedera/services/stats/HapiOpSpeedometers.java
+++ b/hedera-node/src/main/java/com/hedera/services/stats/HapiOpSpeedometers.java
@@ -37,6 +37,8 @@ import static com.hedera.services.stats.ServicesStatsConfig.SPEEDOMETER_ANSWERED
 import static com.hedera.services.stats.ServicesStatsConfig.SPEEDOMETER_ANSWERED_NAME_TPL;
 import static com.hedera.services.stats.ServicesStatsConfig.SPEEDOMETER_HANDLED_DESC_TPL;
 import static com.hedera.services.stats.ServicesStatsConfig.SPEEDOMETER_HANDLED_NAME_TPL;
+import static com.hedera.services.stats.ServicesStatsConfig.SPEEDOMETER_RECEIVED_DEPRECATED_DESC_TPL;
+import static com.hedera.services.stats.ServicesStatsConfig.SPEEDOMETER_RECEIVED_DEPRECATED_NAME_TPL;
 import static com.hedera.services.stats.ServicesStatsConfig.SPEEDOMETER_RECEIVED_DESC_TPL;
 import static com.hedera.services.stats.ServicesStatsConfig.SPEEDOMETER_RECEIVED_NAME_TPL;
 import static com.hedera.services.stats.ServicesStatsConfig.SPEEDOMETER_SUBMITTED_DESC_TPL;
@@ -54,11 +56,13 @@ public class HapiOpSpeedometers {
 	final Map<HederaFunctionality, Long> lastHandledTxnsCount = new HashMap<>();
 	final Map<HederaFunctionality, Long> lastSubmittedTxnsCount = new HashMap<>();
 	final Map<HederaFunctionality, Long> lastAnsweredQueriesCount = new HashMap<>();
+	final Map<HederaFunctionality, Long> lastReceivedDeprecatedTxnCount = new HashMap<>();
 
 	final EnumMap<HederaFunctionality, StatsSpeedometer> receivedOps = new EnumMap<>(HederaFunctionality.class);
 	final EnumMap<HederaFunctionality, StatsSpeedometer> handledTxns = new EnumMap<>(HederaFunctionality.class);
 	final EnumMap<HederaFunctionality, StatsSpeedometer> submittedTxns = new EnumMap<>(HederaFunctionality.class);
 	final EnumMap<HederaFunctionality, StatsSpeedometer> answeredQueries = new EnumMap<>(HederaFunctionality.class);
+	final EnumMap<HederaFunctionality, StatsSpeedometer> receivedDeprecatedTxns = new EnumMap<>(HederaFunctionality.class);
 
 	public HapiOpSpeedometers(
 			HapiOpCounters counters,
@@ -84,6 +88,8 @@ public class HapiOpSpeedometers {
 				lastSubmittedTxnsCount.put(function, 0L);
 				handledTxns.put(function, new StatsSpeedometer(halfLife));
 				lastHandledTxnsCount.put(function, 0L);
+				receivedDeprecatedTxns.put(function, new StatsSpeedometer(halfLife));
+				lastReceivedDeprecatedTxnCount.put(function, 0L);
 			}
 		});
 	}
@@ -93,6 +99,7 @@ public class HapiOpSpeedometers {
 		registerSpeedometers(platform, submittedTxns, SPEEDOMETER_SUBMITTED_NAME_TPL, SPEEDOMETER_SUBMITTED_DESC_TPL);
 		registerSpeedometers(platform, handledTxns, SPEEDOMETER_HANDLED_NAME_TPL, SPEEDOMETER_HANDLED_DESC_TPL);
 		registerSpeedometers(platform, answeredQueries, SPEEDOMETER_ANSWERED_NAME_TPL, SPEEDOMETER_ANSWERED_DESC_TPL);
+		registerSpeedometers(platform, receivedDeprecatedTxns, SPEEDOMETER_RECEIVED_DEPRECATED_NAME_TPL, SPEEDOMETER_RECEIVED_DEPRECATED_DESC_TPL);
 	}
 
 	private void registerSpeedometers(
@@ -114,6 +121,7 @@ public class HapiOpSpeedometers {
 		updateSpeedometers(submittedTxns, lastSubmittedTxnsCount, counters::submittedSoFar);
 		updateSpeedometers(handledTxns, lastHandledTxnsCount, counters::handledSoFar);
 		updateSpeedometers(answeredQueries, lastAnsweredQueriesCount, counters::answeredSoFar);
+		updateSpeedometers(receivedDeprecatedTxns, lastReceivedDeprecatedTxnCount, counters::receivedDeprecatedTxnSoFar);
 	}
 
 	private void updateSpeedometers(

--- a/hedera-node/src/main/java/com/hedera/services/stats/HapiOpSpeedometers.java
+++ b/hedera-node/src/main/java/com/hedera/services/stats/HapiOpSpeedometers.java
@@ -99,9 +99,17 @@ public class HapiOpSpeedometers {
 		registerSpeedometers(platform, submittedTxns, SPEEDOMETER_SUBMITTED_NAME_TPL, SPEEDOMETER_SUBMITTED_DESC_TPL);
 		registerSpeedometers(platform, handledTxns, SPEEDOMETER_HANDLED_NAME_TPL, SPEEDOMETER_HANDLED_DESC_TPL);
 		registerSpeedometers(platform, answeredQueries, SPEEDOMETER_ANSWERED_NAME_TPL, SPEEDOMETER_ANSWERED_DESC_TPL);
+		registerSpeedometer(platform, receivedDeprecatedTxns, SPEEDOMETER_RECEIVED_DEPRECATED_NAME_TPL,
+				SPEEDOMETER_RECEIVED_DEPRECATED_DESC_TPL);
+	}
 
-		platform.addAppStatEntry(speedometer.from(SPEEDOMETER_RECEIVED_DEPRECATED_NAME_TPL,
-				SPEEDOMETER_RECEIVED_DEPRECATED_DESC_TPL, receivedDeprecatedTxns));
+	private void registerSpeedometer(
+			Platform platform,
+			StatsSpeedometer speedometers,
+			String nameTpl,
+			String descTpl
+	) {
+		platform.addAppStatEntry(speedometer.from(nameTpl, descTpl, speedometers));
 	}
 
 	private void registerSpeedometers(

--- a/hedera-node/src/main/java/com/hedera/services/stats/HapiOpSpeedometers.java
+++ b/hedera-node/src/main/java/com/hedera/services/stats/HapiOpSpeedometers.java
@@ -78,39 +78,39 @@ public class HapiOpSpeedometers {
 		Arrays.stream(allFunctions.get())
 				.filter(function -> !IGNORED_FUNCTIONS.contains(function))
 				.forEach(function -> {
-					receivedOps.put(function, new StatsSpeedometer(halfLife));
-					lastReceivedOpsCount.put(function, 0L);
-					if (QUERY_FUNCTIONS.contains(function)) {
-						answeredQueries.put(function, new StatsSpeedometer(halfLife));
-						lastAnsweredQueriesCount.put(function, 0L);
-					} else {
-						submittedTxns.put(function, new StatsSpeedometer(halfLife));
-						lastSubmittedTxnsCount.put(function, 0L);
-						handledTxns.put(function, new StatsSpeedometer(halfLife));
-						lastHandledTxnsCount.put(function, 0L);
-					}
-				});
+			receivedOps.put(function, new StatsSpeedometer(halfLife));
+			lastReceivedOpsCount.put(function, 0L);
+			if (QUERY_FUNCTIONS.contains(function)) {
+				answeredQueries.put(function, new StatsSpeedometer(halfLife));
+				lastAnsweredQueriesCount.put(function, 0L);
+			} else {
+				submittedTxns.put(function, new StatsSpeedometer(halfLife));
+				lastSubmittedTxnsCount.put(function, 0L);
+				handledTxns.put(function, new StatsSpeedometer(halfLife));
+				lastHandledTxnsCount.put(function, 0L);
+			}
+		});
 		receivedDeprecatedTxns = new StatsSpeedometer(halfLife);
 		lastReceivedDeprecatedTxnCount = 0L;
 	}
 
 	public void registerWith(Platform platform) {
-		registerSpeedometer(platform, receivedOps, SPEEDOMETER_RECEIVED_NAME_TPL, SPEEDOMETER_RECEIVED_DESC_TPL);
-		registerSpeedometer(platform, submittedTxns, SPEEDOMETER_SUBMITTED_NAME_TPL, SPEEDOMETER_SUBMITTED_DESC_TPL);
-		registerSpeedometer(platform, handledTxns, SPEEDOMETER_HANDLED_NAME_TPL, SPEEDOMETER_HANDLED_DESC_TPL);
-		registerSpeedometer(platform, answeredQueries, SPEEDOMETER_ANSWERED_NAME_TPL, SPEEDOMETER_ANSWERED_DESC_TPL);
+		registerSpeedometers(platform, receivedOps, SPEEDOMETER_RECEIVED_NAME_TPL, SPEEDOMETER_RECEIVED_DESC_TPL);
+		registerSpeedometers(platform, submittedTxns, SPEEDOMETER_SUBMITTED_NAME_TPL, SPEEDOMETER_SUBMITTED_DESC_TPL);
+		registerSpeedometers(platform, handledTxns, SPEEDOMETER_HANDLED_NAME_TPL, SPEEDOMETER_HANDLED_DESC_TPL);
+		registerSpeedometers(platform, answeredQueries, SPEEDOMETER_ANSWERED_NAME_TPL, SPEEDOMETER_ANSWERED_DESC_TPL);
 
 		platform.addAppStatEntry(speedometer.from(SPEEDOMETER_RECEIVED_DEPRECATED_NAME_TPL,
 				SPEEDOMETER_RECEIVED_DEPRECATED_DESC_TPL, receivedDeprecatedTxns));
 	}
 
-	private void registerSpeedometer(
+	private void registerSpeedometers(
 			Platform platform,
 			Map<HederaFunctionality, StatsSpeedometer> speedometers,
 			String nameTpl,
 			String descTpl
 	) {
-		for (Map.Entry<HederaFunctionality, StatsSpeedometer> entry : speedometers.entrySet()) {
+		for (Map.Entry<HederaFunctionality, StatsSpeedometer> entry : speedometers.entrySet())	{
 			var baseName = statNameFn.apply(entry.getKey());
 			var fullName = String.format(nameTpl, baseName);
 			var description = String.format(descTpl, baseName);
@@ -133,8 +133,7 @@ public class HapiOpSpeedometers {
 			Map<HederaFunctionality, Long> lastMeasurements,
 			Function<HederaFunctionality, Long> currMeasurement
 	) {
-
-		for (Map.Entry<HederaFunctionality, StatsSpeedometer> entry : speedometers.entrySet()) {
+		for (Map.Entry<HederaFunctionality, StatsSpeedometer> entry : speedometers.entrySet())	{
 			var function = entry.getKey();
 			long last = lastMeasurements.get(function);
 			long curr = currMeasurement.apply(function);

--- a/hedera-node/src/main/java/com/hedera/services/stats/ServicesStatsConfig.java
+++ b/hedera-node/src/main/java/com/hedera/services/stats/ServicesStatsConfig.java
@@ -38,21 +38,25 @@ public final class ServicesStatsConfig {
 
 	static final String COUNTER_HANDLED_NAME_TPL = "%sHdl";
 	static final String COUNTER_RECEIVED_NAME_TPL = "%sRcv";
+	static final String COUNTER_RECEIVED_DEPRECATED_NAME_TPL = "%sDeprRcv";
 	static final String COUNTER_ANSWERED_NAME_TPL = "%sSub";
 	static final String COUNTER_SUBMITTED_NAME_TPL = "%sSub";
 	static final String SPEEDOMETER_HANDLED_NAME_TPL = "%sHdl/sec";
 	static final String SPEEDOMETER_RECEIVED_NAME_TPL = "%sRcv/sec";
 	static final String SPEEDOMETER_ANSWERED_NAME_TPL = "%sSub/sec";
 	static final String SPEEDOMETER_SUBMITTED_NAME_TPL = "%sSub/sec";
+	static final String SPEEDOMETER_RECEIVED_DEPRECATED_NAME_TPL = "%sDeprRcv/sec";
 
 	static final String COUNTER_HANDLED_DESC_TPL = "number of %s handled";
 	static final String COUNTER_RECEIVED_DESC_TPL = "number of %s received";
+	static final String COUNTER_RECEIVED_DEPRECATED_DESC_TPL = "number of %s deprecated received";
 	static final String COUNTER_ANSWERED_DESC_TPL = "number of %s answered";
 	static final String COUNTER_SUBMITTED_DESC_TPL = "number of %s submitted";
 	static final String SPEEDOMETER_HANDLED_DESC_TPL = "number of %s handled per second";
 	static final String SPEEDOMETER_RECEIVED_DESC_TPL = "number of %s received per second";
 	static final String SPEEDOMETER_ANSWERED_DESC_TPL = "number of %s answered per second";
 	static final String SPEEDOMETER_SUBMITTED_DESC_TPL = "number of %s submitted per second";
+	static final String SPEEDOMETER_RECEIVED_DEPRECATED_DESC_TPL = "number of %s deprecated received per second";
 
 	public static final String SYSTEM_DELETE_METRIC = "systemDelete";
 	public static final String SYSTEM_UNDELETE_METRIC = "systemUndelete";

--- a/hedera-node/src/main/java/com/hedera/services/stats/ServicesStatsConfig.java
+++ b/hedera-node/src/main/java/com/hedera/services/stats/ServicesStatsConfig.java
@@ -38,25 +38,25 @@ public final class ServicesStatsConfig {
 
 	static final String COUNTER_HANDLED_NAME_TPL = "%sHdl";
 	static final String COUNTER_RECEIVED_NAME_TPL = "%sRcv";
-	static final String COUNTER_RECEIVED_DEPRECATED_NAME_TPL = "%sDeprRcv";
+	static final String COUNTER_RECEIVED_DEPRECATED_NAME_TPL = "DeprTxnsRcv";
 	static final String COUNTER_ANSWERED_NAME_TPL = "%sSub";
 	static final String COUNTER_SUBMITTED_NAME_TPL = "%sSub";
 	static final String SPEEDOMETER_HANDLED_NAME_TPL = "%sHdl/sec";
 	static final String SPEEDOMETER_RECEIVED_NAME_TPL = "%sRcv/sec";
 	static final String SPEEDOMETER_ANSWERED_NAME_TPL = "%sSub/sec";
 	static final String SPEEDOMETER_SUBMITTED_NAME_TPL = "%sSub/sec";
-	static final String SPEEDOMETER_RECEIVED_DEPRECATED_NAME_TPL = "%sDeprRcv/sec";
+	static final String SPEEDOMETER_RECEIVED_DEPRECATED_NAME_TPL = "DeprTxnsRcv/sec";
 
 	static final String COUNTER_HANDLED_DESC_TPL = "number of %s handled";
 	static final String COUNTER_RECEIVED_DESC_TPL = "number of %s received";
-	static final String COUNTER_RECEIVED_DEPRECATED_DESC_TPL = "number of %s deprecated received";
+	static final String COUNTER_RECEIVED_DEPRECATED_DESC_TPL = "number of deprecated txns received";
 	static final String COUNTER_ANSWERED_DESC_TPL = "number of %s answered";
 	static final String COUNTER_SUBMITTED_DESC_TPL = "number of %s submitted";
 	static final String SPEEDOMETER_HANDLED_DESC_TPL = "number of %s handled per second";
 	static final String SPEEDOMETER_RECEIVED_DESC_TPL = "number of %s received per second";
 	static final String SPEEDOMETER_ANSWERED_DESC_TPL = "number of %s answered per second";
 	static final String SPEEDOMETER_SUBMITTED_DESC_TPL = "number of %s submitted per second";
-	static final String SPEEDOMETER_RECEIVED_DEPRECATED_DESC_TPL = "number of %s deprecated received per second";
+	static final String SPEEDOMETER_RECEIVED_DEPRECATED_DESC_TPL = "number of deprecated txns received per second";
 
 	public static final String SYSTEM_DELETE_METRIC = "systemDelete";
 	public static final String SYSTEM_UNDELETE_METRIC = "systemUndelete";

--- a/hedera-node/src/main/java/com/hedera/services/txns/submission/StructuralPrecheck.java
+++ b/hedera-node/src/main/java/com/hedera/services/txns/submission/StructuralPrecheck.java
@@ -35,7 +35,6 @@ import javax.inject.Singleton;
 import java.util.List;
 
 import static com.hedera.services.txns.submission.PresolvencyFlaws.WELL_KNOWN_FLAWS;
-import static com.hedera.services.utils.SignedTxnAccessor.functionExtractor;
 import static com.hederahashgraph.api.proto.java.HederaFunctionality.NONE;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_TRANSACTION;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_TRANSACTION_BODY;

--- a/hedera-node/src/main/java/com/hedera/services/txns/submission/StructuralPrecheck.java
+++ b/hedera-node/src/main/java/com/hedera/services/txns/submission/StructuralPrecheck.java
@@ -78,7 +78,7 @@ public final class StructuralPrecheck {
 		final var hasDeprecatedSigs = signedTxn.hasSigs();
 
 		if (hasDeprecatedBody || hasDeprecatedSigs || hasDeprecatedSigMap || hasDeprecatedBodyBytes) {
-			opCounters.countDeprecatedTxnReceived(functionExtractor.apply(signedTxn.getBody()));
+			opCounters.countDeprecatedTxnReceived();
 		}
 
 		if (hasSignedTxnBytes) {

--- a/hedera-node/src/main/java/com/hedera/services/utils/SignedTxnAccessor.java
+++ b/hedera-node/src/main/java/com/hedera/services/utils/SignedTxnAccessor.java
@@ -101,7 +101,7 @@ public class SignedTxnAccessor implements TxnAccessor {
 	private BaseTransactionMeta txnUsageMeta;
 	private HederaFunctionality function;
 
-	public static Function<TransactionBody, HederaFunctionality> functionExtractor = txn -> {
+	static Function<TransactionBody, HederaFunctionality> functionExtractor = txn -> {
 		try {
 			return functionOf(txn);
 		} catch (UnknownHederaFunctionality ignore) {

--- a/hedera-node/src/main/java/com/hedera/services/utils/SignedTxnAccessor.java
+++ b/hedera-node/src/main/java/com/hedera/services/utils/SignedTxnAccessor.java
@@ -101,7 +101,7 @@ public class SignedTxnAccessor implements TxnAccessor {
 	private BaseTransactionMeta txnUsageMeta;
 	private HederaFunctionality function;
 
-	static Function<TransactionBody, HederaFunctionality> functionExtractor = txn -> {
+	public static Function<TransactionBody, HederaFunctionality> functionExtractor = txn -> {
 		try {
 			return functionOf(txn);
 		} catch (UnknownHederaFunctionality ignore) {

--- a/hedera-node/src/test/java/com/hedera/services/stats/HapiOpCountersTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/stats/HapiOpCountersTest.java
@@ -84,20 +84,18 @@ class HapiOpCountersTest {
 		assertTrue(subject.receivedOps.containsKey(CryptoTransfer));
 		assertTrue(subject.submittedTxns.containsKey(CryptoTransfer));
 		assertTrue(subject.handledTxns.containsKey(CryptoTransfer));
-		assertTrue(subject.receivedDeprecatedTxns.containsKey(CryptoTransfer));
+		assertEquals(0, subject.receivedDeprecatedTxns.get());
 		assertFalse(subject.answeredQueries.containsKey(CryptoTransfer));
 
 		assertTrue(subject.receivedOps.containsKey(TokenGetInfo));
 		assertTrue(subject.answeredQueries.containsKey(TokenGetInfo));
 		assertFalse(subject.submittedTxns.containsKey(TokenGetInfo));
 		assertFalse(subject.handledTxns.containsKey(TokenGetInfo));
-		assertFalse(subject.receivedDeprecatedTxns.containsKey(TokenGetInfo));
 
 		assertFalse(subject.receivedOps.containsKey(NONE));
 		assertFalse(subject.submittedTxns.containsKey(NONE));
 		assertFalse(subject.answeredQueries.containsKey(NONE));
 		assertFalse(subject.handledTxns.containsKey(NONE));
-		assertFalse(subject.receivedDeprecatedTxns.containsKey(NONE));
 	}
 
 	@Test
@@ -111,11 +109,11 @@ class HapiOpCountersTest {
 		final var xferRcvName = String.format(ServicesStatsConfig.COUNTER_RECEIVED_NAME_TPL, "CryptoTransfer");
 		final var xferSubName = String.format(ServicesStatsConfig.COUNTER_SUBMITTED_NAME_TPL, "CryptoTransfer");
 		final var xferHdlName = String.format(ServicesStatsConfig.COUNTER_HANDLED_NAME_TPL, "CryptoTransfer");
-		final var xferRcvDeprecatedName = String.format(ServicesStatsConfig.COUNTER_RECEIVED_DEPRECATED_NAME_TPL, "CryptoTransfer");
+		final var xferRcvDeprecatedName = String.format(ServicesStatsConfig.COUNTER_RECEIVED_DEPRECATED_NAME_TPL);
 		final var xferRcvDesc = String.format(ServicesStatsConfig.COUNTER_RECEIVED_DESC_TPL, "CryptoTransfer");
 		final var xferSubDesc = String.format(ServicesStatsConfig.COUNTER_SUBMITTED_DESC_TPL, "CryptoTransfer");
 		final var xferHdlDesc = String.format(ServicesStatsConfig.COUNTER_HANDLED_DESC_TPL, "CryptoTransfer");
-		final var xferRcvDeprecatedDesc = String.format(ServicesStatsConfig.COUNTER_RECEIVED_DEPRECATED_DESC_TPL, "CryptoTransfer");
+		final var xferRcvDeprecatedDesc = String.format(ServicesStatsConfig.COUNTER_RECEIVED_DEPRECATED_DESC_TPL);
 		final var infoRcvName = String.format(ServicesStatsConfig.COUNTER_RECEIVED_NAME_TPL, "TokenGetInfo");
 		final var infoAnsName = String.format(ServicesStatsConfig.COUNTER_ANSWERED_NAME_TPL, "TokenGetInfo");
 		final var infoRcvDesc = String.format(ServicesStatsConfig.COUNTER_RECEIVED_DESC_TPL, "TokenGetInfo");
@@ -192,7 +190,7 @@ class HapiOpCountersTest {
 		subject.countSubmitted(CryptoTransfer);
 		subject.countSubmitted(CryptoTransfer);
 		subject.countHandled(CryptoTransfer);
-		subject.countDeprecatedTxnReceived(CryptoTransfer);
+		subject.countDeprecatedTxnReceived();
 		subject.countReceived(TokenGetInfo);
 		subject.countReceived(TokenGetInfo);
 		subject.countReceived(TokenGetInfo);
@@ -202,7 +200,7 @@ class HapiOpCountersTest {
 		assertEquals(3L, subject.receivedSoFar(CryptoTransfer));
 		assertEquals(2L, subject.submittedSoFar(CryptoTransfer));
 		assertEquals(1L, subject.handledSoFar(CryptoTransfer));
-		assertEquals(1L, subject.receivedDeprecatedTxnSoFar(CryptoTransfer));
+		assertEquals(1L, subject.receivedDeprecatedTxnSoFar());
 		assertEquals(3L, subject.receivedSoFar(TokenGetInfo));
 		assertEquals(2L, subject.answeredSoFar(TokenGetInfo));
 	}
@@ -213,12 +211,16 @@ class HapiOpCountersTest {
 		assertDoesNotThrow(() -> subject.countSubmitted(NONE));
 		assertDoesNotThrow(() -> subject.countHandled(NONE));
 		assertDoesNotThrow(() -> subject.countAnswered(NONE));
-		assertDoesNotThrow(() -> subject.countDeprecatedTxnReceived(NONE));
 
 		assertEquals(0L, subject.receivedSoFar(NONE));
 		assertEquals(0L, subject.submittedSoFar(NONE));
 		assertEquals(0L, subject.handledSoFar(NONE));
 		assertEquals(0L, subject.answeredSoFar(NONE));
-		assertEquals(0L, subject.receivedDeprecatedTxnSoFar(NONE));
+	}
+
+	@Test
+	void deprecatedTxnsCountIncrementsByOne() {
+		subject.countDeprecatedTxnReceived();
+		assertEquals(1L, subject.receivedDeprecatedTxnSoFar());
 	}
 }

--- a/hedera-node/src/test/java/com/hedera/services/stats/HapiOpCountersTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/stats/HapiOpCountersTest.java
@@ -84,17 +84,20 @@ class HapiOpCountersTest {
 		assertTrue(subject.receivedOps.containsKey(CryptoTransfer));
 		assertTrue(subject.submittedTxns.containsKey(CryptoTransfer));
 		assertTrue(subject.handledTxns.containsKey(CryptoTransfer));
+		assertTrue(subject.receivedDeprecatedTxns.containsKey(CryptoTransfer));
 		assertFalse(subject.answeredQueries.containsKey(CryptoTransfer));
 
 		assertTrue(subject.receivedOps.containsKey(TokenGetInfo));
 		assertTrue(subject.answeredQueries.containsKey(TokenGetInfo));
 		assertFalse(subject.submittedTxns.containsKey(TokenGetInfo));
 		assertFalse(subject.handledTxns.containsKey(TokenGetInfo));
+		assertFalse(subject.receivedDeprecatedTxns.containsKey(TokenGetInfo));
 
 		assertFalse(subject.receivedOps.containsKey(NONE));
 		assertFalse(subject.submittedTxns.containsKey(NONE));
 		assertFalse(subject.answeredQueries.containsKey(NONE));
 		assertFalse(subject.handledTxns.containsKey(NONE));
+		assertFalse(subject.receivedDeprecatedTxns.containsKey(NONE));
 	}
 
 	@Test
@@ -102,14 +105,17 @@ class HapiOpCountersTest {
 		final var transferRcv = mock(StatEntry.class);
 		final var transferSub = mock(StatEntry.class);
 		final var transferHdl = mock(StatEntry.class);
+		final var transferDeprecatedRcv = mock(StatEntry.class);
 		final var tokenInfoRcv = mock(StatEntry.class);
 		final var tokenInfoAns = mock(StatEntry.class);
 		final var xferRcvName = String.format(ServicesStatsConfig.COUNTER_RECEIVED_NAME_TPL, "CryptoTransfer");
 		final var xferSubName = String.format(ServicesStatsConfig.COUNTER_SUBMITTED_NAME_TPL, "CryptoTransfer");
 		final var xferHdlName = String.format(ServicesStatsConfig.COUNTER_HANDLED_NAME_TPL, "CryptoTransfer");
+		final var xferRcvDeprecatedName = String.format(ServicesStatsConfig.COUNTER_RECEIVED_DEPRECATED_NAME_TPL, "CryptoTransfer");
 		final var xferRcvDesc = String.format(ServicesStatsConfig.COUNTER_RECEIVED_DESC_TPL, "CryptoTransfer");
 		final var xferSubDesc = String.format(ServicesStatsConfig.COUNTER_SUBMITTED_DESC_TPL, "CryptoTransfer");
 		final var xferHdlDesc = String.format(ServicesStatsConfig.COUNTER_HANDLED_DESC_TPL, "CryptoTransfer");
+		final var xferRcvDeprecatedDesc = String.format(ServicesStatsConfig.COUNTER_RECEIVED_DEPRECATED_DESC_TPL, "CryptoTransfer");
 		final var infoRcvName = String.format(ServicesStatsConfig.COUNTER_RECEIVED_NAME_TPL, "TokenGetInfo");
 		final var infoAnsName = String.format(ServicesStatsConfig.COUNTER_ANSWERED_NAME_TPL, "TokenGetInfo");
 		final var infoRcvDesc = String.format(ServicesStatsConfig.COUNTER_RECEIVED_DESC_TPL, "TokenGetInfo");
@@ -127,6 +133,10 @@ class HapiOpCountersTest {
 				argThat(xferHdlDesc::equals),
 				any())).willReturn(transferHdl);
 		given(factory.from(
+				argThat(xferRcvDeprecatedName::equals),
+				argThat(xferRcvDeprecatedDesc::equals),
+				any())).willReturn(transferDeprecatedRcv);
+		given(factory.from(
 				argThat(infoRcvName::equals),
 				argThat(infoRcvDesc::equals),
 				any())).willReturn(tokenInfoRcv);
@@ -140,6 +150,7 @@ class HapiOpCountersTest {
 		verify(platform).addAppStatEntry(transferRcv);
 		verify(platform).addAppStatEntry(transferSub);
 		verify(platform).addAppStatEntry(transferHdl);
+		verify(platform).addAppStatEntry(transferDeprecatedRcv);
 		verify(platform).addAppStatEntry(tokenInfoRcv);
 		verify(platform).addAppStatEntry(tokenInfoAns);
 	}
@@ -181,6 +192,7 @@ class HapiOpCountersTest {
 		subject.countSubmitted(CryptoTransfer);
 		subject.countSubmitted(CryptoTransfer);
 		subject.countHandled(CryptoTransfer);
+		subject.countDeprecatedTxnReceived(CryptoTransfer);
 		subject.countReceived(TokenGetInfo);
 		subject.countReceived(TokenGetInfo);
 		subject.countReceived(TokenGetInfo);
@@ -190,6 +202,7 @@ class HapiOpCountersTest {
 		assertEquals(3L, subject.receivedSoFar(CryptoTransfer));
 		assertEquals(2L, subject.submittedSoFar(CryptoTransfer));
 		assertEquals(1L, subject.handledSoFar(CryptoTransfer));
+		assertEquals(1L, subject.receivedDeprecatedTxnSoFar(CryptoTransfer));
 		assertEquals(3L, subject.receivedSoFar(TokenGetInfo));
 		assertEquals(2L, subject.answeredSoFar(TokenGetInfo));
 	}
@@ -200,10 +213,12 @@ class HapiOpCountersTest {
 		assertDoesNotThrow(() -> subject.countSubmitted(NONE));
 		assertDoesNotThrow(() -> subject.countHandled(NONE));
 		assertDoesNotThrow(() -> subject.countAnswered(NONE));
+		assertDoesNotThrow(() -> subject.countDeprecatedTxnReceived(NONE));
 
 		assertEquals(0L, subject.receivedSoFar(NONE));
 		assertEquals(0L, subject.submittedSoFar(NONE));
 		assertEquals(0L, subject.handledSoFar(NONE));
 		assertEquals(0L, subject.answeredSoFar(NONE));
+		assertEquals(0L, subject.receivedDeprecatedTxnSoFar(NONE));
 	}
 }

--- a/hedera-node/src/test/java/com/hedera/services/stats/HapiOpSpeedometersTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/stats/HapiOpSpeedometersTest.java
@@ -54,7 +54,7 @@ class HapiOpSpeedometersTest {
 	HapiOpSpeedometers subject;
 
 	@BeforeEach
-	void setup() throws Exception {
+	void setup() {
 		HapiOpSpeedometers.allFunctions = () -> new HederaFunctionality[] {
 				CryptoTransfer,
 				TokenGetInfo
@@ -82,25 +82,23 @@ class HapiOpSpeedometersTest {
 		assertTrue(subject.submittedTxns.containsKey(CryptoTransfer));
 		assertTrue(subject.handledTxns.containsKey(CryptoTransfer));
 		assertFalse(subject.answeredQueries.containsKey(CryptoTransfer));
-		assertTrue(subject.receivedDeprecatedTxns.containsKey(CryptoTransfer));
 		// and:
 		assertTrue(subject.lastReceivedOpsCount.containsKey(CryptoTransfer));
 		assertTrue(subject.lastSubmittedTxnsCount.containsKey(CryptoTransfer));
 		assertTrue(subject.lastHandledTxnsCount.containsKey(CryptoTransfer));
 		assertFalse(subject.lastAnsweredQueriesCount.containsKey(CryptoTransfer));
-		assertTrue(subject.lastReceivedDeprecatedTxnCount.containsKey(CryptoTransfer));
+
 		// and:
 		assertTrue(subject.receivedOps.containsKey(TokenGetInfo));
 		assertTrue(subject.answeredQueries.containsKey(TokenGetInfo));
 		assertFalse(subject.submittedTxns.containsKey(TokenGetInfo));
 		assertFalse(subject.handledTxns.containsKey(TokenGetInfo));
-		assertFalse(subject.receivedDeprecatedTxns.containsKey(TokenGetInfo));
 		// and:
 		assertTrue(subject.lastReceivedOpsCount.containsKey(TokenGetInfo));
 		assertTrue(subject.lastAnsweredQueriesCount.containsKey(TokenGetInfo));
 		assertFalse(subject.lastSubmittedTxnsCount.containsKey(TokenGetInfo));
 		assertFalse(subject.lastHandledTxnsCount.containsKey(TokenGetInfo));
-		assertFalse(subject.lastReceivedDeprecatedTxnCount.containsKey(TokenGetInfo));
+		assertEquals(0L, subject.lastReceivedDeprecatedTxnCount);
 	}
 
 	@Test
@@ -116,12 +114,12 @@ class HapiOpSpeedometersTest {
 		var xferRcvName = String.format(ServicesStatsConfig.SPEEDOMETER_RECEIVED_NAME_TPL, "CryptoTransfer");
 		var xferSubName = String.format(ServicesStatsConfig.SPEEDOMETER_SUBMITTED_NAME_TPL, "CryptoTransfer");
 		var xferHdlName = String.format(ServicesStatsConfig.SPEEDOMETER_HANDLED_NAME_TPL, "CryptoTransfer");
-		var xferDeprecatedRcvName = String.format(ServicesStatsConfig.SPEEDOMETER_RECEIVED_DEPRECATED_NAME_TPL, "CryptoTransfer");
+		var xferDeprecatedRcvName = ServicesStatsConfig.SPEEDOMETER_RECEIVED_DEPRECATED_NAME_TPL;
 		// and:
 		var xferRcvDesc = String.format(ServicesStatsConfig.SPEEDOMETER_RECEIVED_DESC_TPL, "CryptoTransfer");
 		var xferSubDesc = String.format(ServicesStatsConfig.SPEEDOMETER_SUBMITTED_DESC_TPL, "CryptoTransfer");
 		var xferHdlDesc = String.format(ServicesStatsConfig.SPEEDOMETER_HANDLED_DESC_TPL, "CryptoTransfer");
-		var xferDeprecatedRcvDesc = String.format(ServicesStatsConfig.SPEEDOMETER_RECEIVED_DEPRECATED_DESC_TPL, "CryptoTransfer");
+		var xferDeprecatedRcvDesc = ServicesStatsConfig.SPEEDOMETER_RECEIVED_DEPRECATED_DESC_TPL;
 		// and:
 		var infoRcvName = String.format(ServicesStatsConfig.SPEEDOMETER_RECEIVED_NAME_TPL, "TokenGetInfo");
 		var infoAnsName = String.format(ServicesStatsConfig.SPEEDOMETER_ANSWERED_NAME_TPL, "TokenGetInfo");
@@ -173,7 +171,7 @@ class HapiOpSpeedometersTest {
 		subject.lastReceivedOpsCount.put(CryptoTransfer, 1L);
 		subject.lastSubmittedTxnsCount.put(CryptoTransfer, 2L);
 		subject.lastHandledTxnsCount.put(CryptoTransfer, 3L);
-		subject.lastReceivedDeprecatedTxnCount.put(CryptoTransfer, 4L);
+		subject.lastReceivedDeprecatedTxnCount = 4L;
 		// and:
 		subject.lastReceivedOpsCount.put(TokenGetInfo, 4L);
 		subject.lastAnsweredQueriesCount.put(TokenGetInfo, 5L);
@@ -190,14 +188,14 @@ class HapiOpSpeedometersTest {
 		given(counters.handledSoFar(CryptoTransfer)).willReturn(6L);
 		given(counters.receivedSoFar(TokenGetInfo)).willReturn(8L);
 		given(counters.answeredSoFar(TokenGetInfo)).willReturn(10L);
-		given(counters.receivedDeprecatedTxnSoFar(CryptoTransfer)).willReturn(12L);
+		given(counters.receivedDeprecatedTxnSoFar()).willReturn(12L);
 		// and:
 		subject.receivedOps.put(CryptoTransfer, xferReceived);
 		subject.submittedTxns.put(CryptoTransfer, xferSubmitted);
 		subject.handledTxns.put(CryptoTransfer, xferHandled);
 		subject.receivedOps.put(TokenGetInfo, infoReceived);
 		subject.answeredQueries.put(TokenGetInfo, infoAnswered);
-		subject.receivedDeprecatedTxns.put(CryptoTransfer, xferDeprecatedRcvd);
+		subject.receivedDeprecatedTxns = xferDeprecatedRcvd;
 
 		// when:
 		subject.updateAll();
@@ -208,13 +206,12 @@ class HapiOpSpeedometersTest {
 		assertEquals(6L, subject.lastHandledTxnsCount.get(CryptoTransfer));
 		assertEquals(8L, subject.lastReceivedOpsCount.get(TokenGetInfo));
 		assertEquals(10L, subject.lastAnsweredQueriesCount.get(TokenGetInfo));
-		assertEquals(12L, subject.lastReceivedDeprecatedTxnCount.get(CryptoTransfer));
+		assertEquals(12L, subject.lastReceivedDeprecatedTxnCount);
 		// and:
 		verify(xferReceived).update(1);
 		verify(xferSubmitted).update(2);
 		verify(xferHandled).update(3);
 		verify(infoReceived).update(4);
 		verify(infoAnswered).update(5);
-		verify(xferDeprecatedRcvd).update(8);
 	}
 }

--- a/hedera-node/src/test/java/com/hedera/services/stats/HapiOpSpeedometersTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/stats/HapiOpSpeedometersTest.java
@@ -82,21 +82,25 @@ class HapiOpSpeedometersTest {
 		assertTrue(subject.submittedTxns.containsKey(CryptoTransfer));
 		assertTrue(subject.handledTxns.containsKey(CryptoTransfer));
 		assertFalse(subject.answeredQueries.containsKey(CryptoTransfer));
+		assertTrue(subject.receivedDeprecatedTxns.containsKey(CryptoTransfer));
 		// and:
 		assertTrue(subject.lastReceivedOpsCount.containsKey(CryptoTransfer));
 		assertTrue(subject.lastSubmittedTxnsCount.containsKey(CryptoTransfer));
 		assertTrue(subject.lastHandledTxnsCount.containsKey(CryptoTransfer));
 		assertFalse(subject.lastAnsweredQueriesCount.containsKey(CryptoTransfer));
+		assertTrue(subject.lastReceivedDeprecatedTxnCount.containsKey(CryptoTransfer));
 		// and:
 		assertTrue(subject.receivedOps.containsKey(TokenGetInfo));
 		assertTrue(subject.answeredQueries.containsKey(TokenGetInfo));
 		assertFalse(subject.submittedTxns.containsKey(TokenGetInfo));
 		assertFalse(subject.handledTxns.containsKey(TokenGetInfo));
+		assertFalse(subject.receivedDeprecatedTxns.containsKey(TokenGetInfo));
 		// and:
 		assertTrue(subject.lastReceivedOpsCount.containsKey(TokenGetInfo));
 		assertTrue(subject.lastAnsweredQueriesCount.containsKey(TokenGetInfo));
 		assertFalse(subject.lastSubmittedTxnsCount.containsKey(TokenGetInfo));
 		assertFalse(subject.lastHandledTxnsCount.containsKey(TokenGetInfo));
+		assertFalse(subject.lastReceivedDeprecatedTxnCount.containsKey(TokenGetInfo));
 	}
 
 	@Test
@@ -105,16 +109,19 @@ class HapiOpSpeedometersTest {
 		StatEntry transferRcv = mock(StatEntry.class);
 		StatEntry transferSub = mock(StatEntry.class);
 		StatEntry transferHdl = mock(StatEntry.class);
+		StatEntry deprecatedTxnRcv = mock(StatEntry.class);
 		StatEntry tokenInfoRcv = mock(StatEntry.class);
 		StatEntry tokenInfoAns = mock(StatEntry.class);
 		// and:
 		var xferRcvName = String.format(ServicesStatsConfig.SPEEDOMETER_RECEIVED_NAME_TPL, "CryptoTransfer");
 		var xferSubName = String.format(ServicesStatsConfig.SPEEDOMETER_SUBMITTED_NAME_TPL, "CryptoTransfer");
 		var xferHdlName = String.format(ServicesStatsConfig.SPEEDOMETER_HANDLED_NAME_TPL, "CryptoTransfer");
+		var xferDeprecatedRcvName = String.format(ServicesStatsConfig.SPEEDOMETER_RECEIVED_DEPRECATED_NAME_TPL, "CryptoTransfer");
 		// and:
 		var xferRcvDesc = String.format(ServicesStatsConfig.SPEEDOMETER_RECEIVED_DESC_TPL, "CryptoTransfer");
 		var xferSubDesc = String.format(ServicesStatsConfig.SPEEDOMETER_SUBMITTED_DESC_TPL, "CryptoTransfer");
 		var xferHdlDesc = String.format(ServicesStatsConfig.SPEEDOMETER_HANDLED_DESC_TPL, "CryptoTransfer");
+		var xferDeprecatedRcvDesc = String.format(ServicesStatsConfig.SPEEDOMETER_RECEIVED_DEPRECATED_DESC_TPL, "CryptoTransfer");
 		// and:
 		var infoRcvName = String.format(ServicesStatsConfig.SPEEDOMETER_RECEIVED_NAME_TPL, "TokenGetInfo");
 		var infoAnsName = String.format(ServicesStatsConfig.SPEEDOMETER_ANSWERED_NAME_TPL, "TokenGetInfo");
@@ -134,6 +141,10 @@ class HapiOpSpeedometersTest {
 				argThat(xferHdlName::equals),
 				argThat(xferHdlDesc::equals),
 				any())).willReturn(transferHdl);
+		given(factory.from(
+				argThat(xferDeprecatedRcvName::equals),
+				argThat(xferDeprecatedRcvDesc::equals),
+				any())).willReturn(deprecatedTxnRcv);
 		// and:
 		given(factory.from(
 				argThat(infoRcvName::equals),
@@ -153,6 +164,7 @@ class HapiOpSpeedometersTest {
 		verify(platform).addAppStatEntry(transferHdl);
 		verify(platform).addAppStatEntry(tokenInfoRcv);
 		verify(platform).addAppStatEntry(tokenInfoAns);
+		verify(platform).addAppStatEntry(deprecatedTxnRcv);
 	}
 
 	@Test
@@ -161,6 +173,7 @@ class HapiOpSpeedometersTest {
 		subject.lastReceivedOpsCount.put(CryptoTransfer, 1L);
 		subject.lastSubmittedTxnsCount.put(CryptoTransfer, 2L);
 		subject.lastHandledTxnsCount.put(CryptoTransfer, 3L);
+		subject.lastReceivedDeprecatedTxnCount.put(CryptoTransfer, 4L);
 		// and:
 		subject.lastReceivedOpsCount.put(TokenGetInfo, 4L);
 		subject.lastAnsweredQueriesCount.put(TokenGetInfo, 5L);
@@ -170,18 +183,21 @@ class HapiOpSpeedometersTest {
 		StatsSpeedometer xferHandled = mock(StatsSpeedometer.class);
 		StatsSpeedometer infoReceived = mock(StatsSpeedometer.class);
 		StatsSpeedometer infoAnswered = mock(StatsSpeedometer.class);
+		StatsSpeedometer xferDeprecatedRcvd = mock(StatsSpeedometer.class);
 
 		given(counters.receivedSoFar(CryptoTransfer)).willReturn(2L);
 		given(counters.submittedSoFar(CryptoTransfer)).willReturn(4L);
 		given(counters.handledSoFar(CryptoTransfer)).willReturn(6L);
 		given(counters.receivedSoFar(TokenGetInfo)).willReturn(8L);
 		given(counters.answeredSoFar(TokenGetInfo)).willReturn(10L);
+		given(counters.receivedDeprecatedTxnSoFar(CryptoTransfer)).willReturn(12L);
 		// and:
 		subject.receivedOps.put(CryptoTransfer, xferReceived);
 		subject.submittedTxns.put(CryptoTransfer, xferSubmitted);
 		subject.handledTxns.put(CryptoTransfer, xferHandled);
 		subject.receivedOps.put(TokenGetInfo, infoReceived);
 		subject.answeredQueries.put(TokenGetInfo, infoAnswered);
+		subject.receivedDeprecatedTxns.put(CryptoTransfer, xferDeprecatedRcvd);
 
 		// when:
 		subject.updateAll();
@@ -192,11 +208,13 @@ class HapiOpSpeedometersTest {
 		assertEquals(6L, subject.lastHandledTxnsCount.get(CryptoTransfer));
 		assertEquals(8L, subject.lastReceivedOpsCount.get(TokenGetInfo));
 		assertEquals(10L, subject.lastAnsweredQueriesCount.get(TokenGetInfo));
+		assertEquals(12L, subject.lastReceivedDeprecatedTxnCount.get(CryptoTransfer));
 		// and:
 		verify(xferReceived).update(1);
 		verify(xferSubmitted).update(2);
 		verify(xferHandled).update(3);
 		verify(infoReceived).update(4);
 		verify(infoAnswered).update(5);
+		verify(xferDeprecatedRcvd).update(8);
 	}
 }

--- a/hedera-node/src/test/java/com/hedera/services/txns/submission/StructuralPrecheckTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/txns/submission/StructuralPrecheckTest.java
@@ -60,9 +60,7 @@ class StructuralPrecheckTest {
 	private static final int pretendSizeLimit = 1_000;
 	private static final int pretendMaxMessageDepth = 42;
 	private StructuralPrecheck subject;
-
-	@Mock
-	HapiOpCounters counters;
+	private HapiOpCounters counters;
 
 	@BeforeEach
 	void setUp() {


### PR DESCRIPTION
Closes #2415 

1. Added a new counter `receivedDeprecatedTxns` to count number of transactions with deprecated fields are received
2. The counter is incremented in `StructuralPrecheck.assess`

Testing:
1. Added unit tests
2. Ran a test locally and submitted transactions with deprecated fields. Observed the change in stats in CSV files.