### PR TITLE
Fix code smell, add value screen for `contracts.maxRefundPercentOfGasLimit` 

### DIFF
--- a/hedera-node/src/main/java/com/hedera/services/context/properties/GlobalDynamicProperties.java
+++ b/hedera-node/src/main/java/com/hedera/services/context/properties/GlobalDynamicProperties.java
@@ -356,15 +356,15 @@ public class GlobalDynamicProperties {
 		return throttleByGas;
 	}
 
-	public int getContractMaxRefundPercentOfGasLimit() {
+	public int maxGasRefundPercentage() {
 		return contractMaxRefundPercentOfGasLimit;
 	}
 
-	public long getFrontendThrottleMaxGasLimit() {
+	public long frontendThrottleGasLimit() {
 		return frontendThrottleMaxGasLimit;
 	}
 
-	public long getConsensusThrottleMaxGasLimit() {
+	public long consensusThrottleGasLimit() {
 		return consensusThrottleMaxGasLimit;
 	}
 }

--- a/hedera-node/src/main/java/com/hedera/services/context/properties/ScreenedSysFileProps.java
+++ b/hedera-node/src/main/java/com/hedera/services/context/properties/ScreenedSysFileProps.java
@@ -99,7 +99,10 @@ public final class ScreenedSysFileProps implements PropertySource {
 					maxLen -> (int) maxLen >= 2),
 			entry(
 					"ledger.tokenTransfers.maxLen",
-					maxLen -> (int) maxLen >= 2)
+					maxLen -> (int) maxLen >= 2),
+			entry(
+					"contracts.maxRefundPercentOfGasLimit",
+					maxRefundPercentage -> (int) maxRefundPercentage >= 0 && (int) maxRefundPercentage <= 100)
 	);
 
 	Map<String, Object> from121 = Collections.emptyMap();

--- a/hedera-node/src/main/java/com/hedera/services/contracts/execution/EvmTxProcessor.java
+++ b/hedera-node/src/main/java/com/hedera/services/contracts/execution/EvmTxProcessor.java
@@ -263,12 +263,10 @@ abstract class EvmTxProcessor {
 
 		gasUsedByTransaction = gasUsedByTransaction.minus(selfDestructRefund).minus(initialFrame.getGasRefund());
 
-		var maxRefundPercent = dynamicProperties.getContractMaxRefundPercentOfGasLimit();
-		if(maxRefundPercent >= 0 && maxRefundPercent <= 100) {
-			gasUsedByTransaction = Gas.of(
-					Math.max(gasUsedByTransaction.toLong(),
-							txGasLimit - txGasLimit * maxRefundPercent / 100));
-		}
+		var maxRefundPercent = dynamicProperties.maxGasRefundPercentage();
+		gasUsedByTransaction = Gas.of(
+				Math.max(gasUsedByTransaction.toLong(),
+						txGasLimit - txGasLimit * maxRefundPercent / 100));
 
 		return gasUsedByTransaction;
 	}

--- a/hedera-node/src/main/java/com/hedera/services/throttling/DeterministicThrottling.java
+++ b/hedera-node/src/main/java/com/hedera/services/throttling/DeterministicThrottling.java
@@ -164,18 +164,18 @@ public class DeterministicThrottling implements TimedFunctionalityThrottling {
 	public void applyGasConfig() {
 		int n = capacitySplitSource.getAsInt();
 		if (consensusThrottled) {
-			if (dynamicProperties.getConsensusThrottleMaxGasLimit() == 0 && dynamicProperties.shouldThrottleByGas()) {
+			if (dynamicProperties.consensusThrottleGasLimit() == 0 && dynamicProperties.shouldThrottleByGas()) {
 				log.error("ThrottleByGas global dynamic property is set to true but contracts.consensusThrottleMaxGasLimit is not set in throttles.json or is set to 0.");
 				return;
 			} else {
-				gasThrottle = new GasLimitDeterministicThrottle(dynamicProperties.getConsensusThrottleMaxGasLimit() / n);
+				gasThrottle = new GasLimitDeterministicThrottle(dynamicProperties.consensusThrottleGasLimit() / n);
 			}
 		} else {
-			if (dynamicProperties.getFrontendThrottleMaxGasLimit() == 0 && dynamicProperties.shouldThrottleByGas()) {
+			if (dynamicProperties.frontendThrottleGasLimit() == 0 && dynamicProperties.shouldThrottleByGas()) {
 				log.error("ThrottleByGas global dynamic property is set to true but contracts.frontendThrottleMaxGasLimit is not set in throttles.json or is set to 0.");
 				return;
 			} else {
-				gasThrottle = new GasLimitDeterministicThrottle(dynamicProperties.getFrontendThrottleMaxGasLimit() / n);
+				gasThrottle = new GasLimitDeterministicThrottle(dynamicProperties.frontendThrottleGasLimit() / n);
 			}
 		}
 		var sb = new StringBuilder("Resolved gas throttle limit (after splitting capacity " + n + " ways) - \n");

--- a/hedera-node/src/main/java/com/hedera/services/throttling/DeterministicThrottling.java
+++ b/hedera-node/src/main/java/com/hedera/services/throttling/DeterministicThrottling.java
@@ -45,6 +45,7 @@ import static com.hederahashgraph.api.proto.java.HederaFunctionality.TokenMint;
 
 public class DeterministicThrottling implements TimedFunctionalityThrottling {
 	private static final Logger log = LogManager.getLogger(DeterministicThrottling.class);
+	private static final String GAS_THROTTLE_AT_ZERO_WARNING_TPL = "{} gas throttling enabled, but limited to 0 gas/sec";
 
 	private final IntSupplier capacitySplitSource;
 	private final GlobalDynamicProperties dynamicProperties;
@@ -165,14 +166,14 @@ public class DeterministicThrottling implements TimedFunctionalityThrottling {
 		int n = capacitySplitSource.getAsInt();
 		if (consensusThrottled) {
 			if (dynamicProperties.consensusThrottleGasLimit() == 0 && dynamicProperties.shouldThrottleByGas()) {
-				log.error("ThrottleByGas global dynamic property is set to true but contracts.consensusThrottleMaxGasLimit is not set in throttles.json or is set to 0.");
+				log.warn(GAS_THROTTLE_AT_ZERO_WARNING_TPL, "Consensus");
 				return;
 			} else {
 				gasThrottle = new GasLimitDeterministicThrottle(dynamicProperties.consensusThrottleGasLimit() / n);
 			}
 		} else {
 			if (dynamicProperties.frontendThrottleGasLimit() == 0 && dynamicProperties.shouldThrottleByGas()) {
-				log.error("ThrottleByGas global dynamic property is set to true but contracts.frontendThrottleMaxGasLimit is not set in throttles.json or is set to 0.");
+				log.warn(GAS_THROTTLE_AT_ZERO_WARNING_TPL, "Frontend");
 				return;
 			} else {
 				gasThrottle = new GasLimitDeterministicThrottle(dynamicProperties.frontendThrottleGasLimit() / n);

--- a/hedera-node/src/test/java/com/hedera/services/context/properties/GlobalDynamicPropertiesTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/context/properties/GlobalDynamicPropertiesTest.java
@@ -80,7 +80,7 @@ class GlobalDynamicPropertiesTest {
 	}
 
 	@Test
-	void nftPropertiesTest(){
+	void nftPropertiesTest() {
 		givenPropsWithSeed(1);
 		subject = new GlobalDynamicProperties(numbers, properties);
 
@@ -95,7 +95,30 @@ class GlobalDynamicPropertiesTest {
 	}
 
 	@Test
-	void constructsIntsAsExpected() {
+	void constructsNonMaxIntsAsExpected() {
+		givenPropsWithSeed(1);
+
+		// when:
+		subject = new GlobalDynamicProperties(numbers, properties);
+
+		// then:
+		assertEquals(8, subject.cacheRecordsTtl());
+		assertEquals(10, subject.ratesIntradayChangeLimitPercent());
+		assertEquals(11, subject.balancesExportPeriodSecs());
+		assertEquals(20, subject.minValidityBuffer());
+		assertEquals(22, subject.getChainId());
+		assertEquals(24, subject.feesTokenTransferUsageMultiplier());
+		assertEquals(26, subject.minAutoRenewDuration());
+		assertEquals(27, subject.localCallEstRetBytes());
+		assertEquals(28, subject.scheduledTxExpiryTimeSecs());
+		assertEquals(29, subject.messageMaxBytesAllowed());
+		assertEquals(30, subject.feesMinCongestionPeriod());
+		assertEquals(32, subject.autoRenewNumberOfEntitiesToScan());
+		assertEquals(33, subject.autoRenewMaxNumberOfEntitiesToRenewOrDelete());
+	}
+
+	@Test
+	void constructsMaxIntsAsExpected() {
 		givenPropsWithSeed(1);
 
 		// when:
@@ -105,29 +128,16 @@ class GlobalDynamicPropertiesTest {
 		assertEquals(1, subject.maxTokensPerAccount());
 		assertEquals(2, subject.maxTokenSymbolUtf8Bytes());
 		assertEquals(6, subject.maxFileSizeKb());
-		assertEquals(8, subject.cacheRecordsTtl());
 		assertEquals(9, subject.maxContractStorageKb());
-		assertEquals(10, subject.ratesIntradayChangeLimitPercent());
-		assertEquals(11, subject.balancesExportPeriodSecs());
 		assertEquals(15, subject.maxTransferListSize());
 		assertEquals(16, subject.maxTokenTransferListSize());
 		assertEquals(17, subject.maxMemoUtf8Bytes());
-		assertEquals(20, subject.minValidityBuffer());
 		assertEquals(21, subject.maxGas());
-		assertEquals(22, subject.getChainId());
-		assertEquals(24, subject.feesTokenTransferUsageMultiplier());
 		assertEquals(25, subject.maxAutoRenewDuration());
-		assertEquals(26, subject.minAutoRenewDuration());
-		assertEquals(27, subject.localCallEstRetBytes());
-		assertEquals(28, subject.scheduledTxExpiryTimeSecs());
-		assertEquals(29, subject.messageMaxBytesAllowed());
-		assertEquals(30, subject.feesMinCongestionPeriod());
-		assertEquals(32, subject.autoRenewNumberOfEntitiesToScan());
-		assertEquals(33, subject.autoRenewMaxNumberOfEntitiesToRenewOrDelete());
 		assertEquals(36, subject.maxCustomFeesAllowed());
 		assertEquals(46, subject.maxXferBalanceChanges());
 		assertEquals(47, subject.maxCustomFeeDepth());
-		assertEquals(48, subject.getContractMaxRefundPercentOfGasLimit());
+		assertEquals(48, subject.maxGasRefundPercentage());
 	}
 
 	@Test
@@ -146,8 +156,8 @@ class GlobalDynamicPropertiesTest {
 		assertEquals(34L, subject.autoRenewGracePeriod());
 		assertEquals(35L, subject.ratesMidnightCheckInterval());
 		assertEquals(44L, subject.maxNftMints());
-		assertEquals(49L, subject.getFrontendThrottleMaxGasLimit());
-		assertEquals(50L, subject.getConsensusThrottleMaxGasLimit());
+		assertEquals(49L, subject.frontendThrottleGasLimit());
+		assertEquals(50L, subject.consensusThrottleGasLimit());
 	}
 
 	@Test
@@ -212,7 +222,7 @@ class GlobalDynamicPropertiesTest {
 		assertEquals(37, subject.maxCustomFeesAllowed());
 		assertEquals(47, subject.maxXferBalanceChanges());
 		assertEquals(48, subject.maxCustomFeeDepth());
-		assertEquals(49, subject.getContractMaxRefundPercentOfGasLimit());
+		assertEquals(49, subject.maxGasRefundPercentage());
 	}
 
 	@Test
@@ -231,8 +241,8 @@ class GlobalDynamicPropertiesTest {
 		assertEquals(35L, subject.autoRenewGracePeriod());
 		assertEquals(36L, subject.ratesMidnightCheckInterval());
 		assertEquals(45L, subject.maxNftMints());
-		assertEquals(50L, subject.getFrontendThrottleMaxGasLimit());
-		assertEquals(51L, subject.getConsensusThrottleMaxGasLimit());
+		assertEquals(50L, subject.frontendThrottleGasLimit());
+		assertEquals(51L, subject.consensusThrottleGasLimit());
 	}
 
 	@Test
@@ -255,9 +265,9 @@ class GlobalDynamicPropertiesTest {
 		given(properties.getIntProperty("tokens.maxPerAccount")).willReturn(i);
 		given(properties.getIntProperty("tokens.maxSymbolUtf8Bytes")).willReturn(i + 1);
 		given(properties.getBooleanProperty("ledger.keepRecordsInState")).willReturn((i % 2) == 0);
-		given(properties.getLongProperty("ledger.maxAccountNum")).willReturn((long)i + 2);
+		given(properties.getLongProperty("ledger.maxAccountNum")).willReturn((long) i + 2);
 		given(properties.getIntProperty("files.maxSizeKb")).willReturn(i + 5);
-		given(properties.getLongProperty("ledger.fundingAccount")).willReturn((long)i + 6);
+		given(properties.getLongProperty("ledger.fundingAccount")).willReturn((long) i + 6);
 		given(properties.getIntProperty("cache.records.ttl")).willReturn(i + 7);
 		given(properties.getIntProperty("contracts.maxStorageKb")).willReturn(i + 8);
 		given(properties.getIntProperty("rates.intradayChangeLimitPercent")).willReturn(i + 9);

--- a/hedera-node/src/test/java/com/hedera/services/context/properties/ScreenedSysFilePropsTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/context/properties/ScreenedSysFilePropsTest.java
@@ -84,9 +84,15 @@ class ScreenedSysFilePropsTest {
 	void incorporatesStandardGlobalDynamic() {
 		final var oldMap = subject.from121;
 
-		subject.screenNew(withJust("tokens.maxPerAccount", "42"));
+		subject.screenNew(withAllOf(Map.of(
+				"tokens.maxPerAccount", "42",
+				"ledger.transfers.maxLen", "42",
+				"contracts.maxRefundPercentOfGasLimit", "42"
+		)));
 
-		assertEquals(Map.of("tokens.maxPerAccount", 42), subject.from121);
+		assertEquals(42, subject.from121.get("tokens.maxPerAccount"));
+		assertEquals(42, subject.from121.get("ledger.transfers.maxLen"));
+		assertEquals(42, subject.from121.get("contracts.maxRefundPercentOfGasLimit"));
 		assertNotSame(oldMap, subject.from121);
 	}
 
@@ -153,13 +159,19 @@ class ScreenedSysFilePropsTest {
 				"Property 'defaultFeeCollectionAccount' is not global/dynamic, please find it a proper home!"));
 	}
 
-	private static final ServicesConfigurationList withJust(final String name, final String value) {
+	private static ServicesConfigurationList withJust(final String name, final String value) {
 		return ServicesConfigurationList.newBuilder()
 				.addNameValue(from(name, value))
 				.build();
 	}
 
-	private static final Setting from(final String name, final String value) {
+	private static ServicesConfigurationList withAllOf(final Map<String, String> settings) {
+		final var builder = ServicesConfigurationList.newBuilder();
+		settings.forEach((key, value) -> builder.addNameValue(from(key, value)));
+		return builder.build();
+	}
+
+	private static Setting from(final String name, final String value) {
 		return Setting.newBuilder().setName(name).setValue(value).build();
 	}
 }

--- a/hedera-node/src/test/java/com/hedera/services/context/properties/ScreenedSysFilePropsTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/context/properties/ScreenedSysFilePropsTest.java
@@ -119,7 +119,9 @@ class ScreenedSysFilePropsTest {
 			"1, ledger.transfers.maxLen, true,",
 			"1, ledger.tokenTransfers.maxLen, true,",
 			(MerkleToken.UPPER_BOUND_SYMBOL_UTF8_BYTES + 1) + ", tokens.maxSymbolUtf8Bytes, true,",
-			"-1, rates.intradayChangeLimitPercent, true,"
+			"-1, rates.intradayChangeLimitPercent, true,",
+			"-1, contracts.maxRefundPercentOfGasLimit, true,",
+			"101, contracts.maxRefundPercentOfGasLimit, true,",
 	})
 	void warnsOfUnusableOrUnparseable(
 			String unsupported,

--- a/hedera-node/src/test/java/com/hedera/services/contracts/execution/CreateEvmTxProcessorTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/contracts/execution/CreateEvmTxProcessorTest.java
@@ -124,7 +124,7 @@ class CreateEvmTxProcessorTest {
 	@Test
 	void assertSuccessExecutionChargesCorrectMinimumGas() {
 		givenValidMock(true);
-		given(globalDynamicProperties.getContractMaxRefundPercentOfGasLimit()).willReturn(MAX_REFUND_PERCENT);
+		given(globalDynamicProperties.maxGasRefundPercentage()).willReturn(MAX_REFUND_PERCENT);
 		sender.initBalance(350_000L);
 		var result = createEvmTxProcessor.execute(sender, receiver.getId().asEvmAddress(),
 				GAS_LIMIT, 1234L, Bytes.EMPTY, consensusTime, expiry);
@@ -136,7 +136,7 @@ class CreateEvmTxProcessorTest {
 	@Test
 	void assertSuccessExecutionChargesCorrectGasWhenGasUsedIsLargerThanMinimum() {
 		givenValidMock(true);
-		given(globalDynamicProperties.getContractMaxRefundPercentOfGasLimit()).willReturn(5);
+		given(globalDynamicProperties.maxGasRefundPercentage()).willReturn(5);
 		given(gasCalculator.transactionIntrinsicGasCost(Bytes.EMPTY, true)).willReturn(Gas.of(INTRINSIC_GAS_COST));
 		sender.initBalance(350_000L);
 		var result = createEvmTxProcessor.execute(sender, receiver.getId().asEvmAddress(),

--- a/hedera-node/src/test/java/com/hedera/services/throttling/DeterministicThrottlingTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/throttling/DeterministicThrottlingTest.java
@@ -241,7 +241,7 @@ class DeterministicThrottlingTest {
 	void alwaysThrottlesContractCallWhenGasThrottleIsNotDefined() {
 		givenFunction(ContractCall);
 		given(dynamicProperties.shouldThrottleByGas()).willReturn(true);
-		given(dynamicProperties.getConsensusThrottleMaxGasLimit()).willReturn(0L);
+		given(dynamicProperties.consensusThrottleGasLimit()).willReturn(0L);
 		subject.setConsensusThrottled(true);
 		subject.applyGasConfig();
 		// expect:
@@ -252,7 +252,7 @@ class DeterministicThrottlingTest {
 	void alwaysThrottlesContractCallWhenGasThrottleReturnsTrue() {
 		givenFunction(ContractCall);
 		given(dynamicProperties.shouldThrottleByGas()).willReturn(true);
-		given(dynamicProperties.getConsensusThrottleMaxGasLimit()).willReturn(0L);
+		given(dynamicProperties.consensusThrottleGasLimit()).willReturn(0L);
 		subject.setConsensusThrottled(true);
 		subject.applyGasConfig();
 		// expect:
@@ -263,7 +263,7 @@ class DeterministicThrottlingTest {
 	void alwaysThrottlesContractCreateWhenGasThrottleIsNotDefined() {
 		givenFunction(ContractCreate);
 		given(dynamicProperties.shouldThrottleByGas()).willReturn(true);
-		given(dynamicProperties.getConsensusThrottleMaxGasLimit()).willReturn(0L);
+		given(dynamicProperties.consensusThrottleGasLimit()).willReturn(0L);
 		subject.setConsensusThrottled(true);
 		subject.applyGasConfig();
 		// expect:
@@ -274,7 +274,7 @@ class DeterministicThrottlingTest {
 	void alwaysThrottlesContractCreateWhenGasThrottleReturnsTrue() {
 		givenFunction(ContractCreate);
 		given(dynamicProperties.shouldThrottleByGas()).willReturn(true);
-		given(dynamicProperties.getConsensusThrottleMaxGasLimit()).willReturn(0L);
+		given(dynamicProperties.consensusThrottleGasLimit()).willReturn(0L);
 		subject.setConsensusThrottled(true);
 		subject.applyGasConfig();
 		// expect:
@@ -284,7 +284,7 @@ class DeterministicThrottlingTest {
 	@Test
 	void gasLimitThrottleReturnsCorrectObject() {
 		var capacity = 10L;
-		given(dynamicProperties.getConsensusThrottleMaxGasLimit()).willReturn(capacity);
+		given(dynamicProperties.consensusThrottleGasLimit()).willReturn(capacity);
 		subject.setConsensusThrottled(true);
 		subject.applyGasConfig();
 		// expect:
@@ -294,7 +294,7 @@ class DeterministicThrottlingTest {
 	@Test
 	void gasLimitFrontendThrottleReturnsCorrectObject() {
 		long capacity = 3423423423L;
-		given(dynamicProperties.getFrontendThrottleMaxGasLimit()).willReturn(capacity);
+		given(dynamicProperties.frontendThrottleGasLimit()).willReturn(capacity);
 		subject.setConsensusThrottled(false);
 		subject.applyGasConfig();
 		// expect:
@@ -327,7 +327,7 @@ class DeterministicThrottlingTest {
 	void logsGasThrottleAsExpected() {
 		var capacity = 1000L;
 		// setup:
-		given(dynamicProperties.getConsensusThrottleMaxGasLimit()).willReturn(capacity);
+		given(dynamicProperties.consensusThrottleGasLimit()).willReturn(capacity);
 		given(dynamicProperties.shouldThrottleByGas()).willReturn(true);
 
 		var desired = "Resolved gas throttle limit (after splitting capacity " + n + " ways) - \n" +
@@ -483,7 +483,7 @@ class DeterministicThrottlingTest {
 		//setup:
 		givenFunction(ContractCreate);
 		given(dynamicProperties.shouldThrottleByGas()).willReturn(true);
-		given(dynamicProperties.getConsensusThrottleMaxGasLimit()).willReturn(10L);
+		given(dynamicProperties.consensusThrottleGasLimit()).willReturn(10L);
 		given(accessor.getGasLimitForContractTx()).willReturn(11L);
 		subject.setConsensusThrottled(true);
 
@@ -501,7 +501,7 @@ class DeterministicThrottlingTest {
 		//setup:
 		givenFunction(ContractCall);
 		given(dynamicProperties.shouldThrottleByGas()).willReturn(true);
-		given(dynamicProperties.getConsensusThrottleMaxGasLimit()).willReturn(10L);
+		given(dynamicProperties.consensusThrottleGasLimit()).willReturn(10L);
 		given(accessor.getGasLimitForContractTx()).willReturn(11L);
 		subject.setConsensusThrottled(true);
 
@@ -530,7 +530,7 @@ class DeterministicThrottlingTest {
 	void verifyLeakUnusedGas() throws IOException {
 		Instant now = Instant.now();
 		given(dynamicProperties.shouldThrottleByGas()).willReturn(true);
-		given(dynamicProperties.getConsensusThrottleMaxGasLimit()).willReturn(10L);
+		given(dynamicProperties.consensusThrottleGasLimit()).willReturn(10L);
 		given(query.getContractCallLocal()).willReturn(callLocalQuery);
 		given(callLocalQuery.getGas()).willReturn(100L);
 

--- a/hedera-node/src/test/java/com/hedera/services/throttling/DeterministicThrottlingTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/throttling/DeterministicThrottlingTest.java
@@ -139,14 +139,12 @@ class DeterministicThrottlingTest {
 
 		// then:
 		assertEquals(0L, gasLimitDeterministicThrottle.getCapacity());
-		assertThat(logCaptor.errorLogs(),
-				contains("ThrottleByGas global dynamic property is set to true but contracts.consensusThrottleMaxGasLimit is not set in throttles.json or is set to 0."));
+		assertThat(logCaptor.warnLogs(), contains("Consensus gas throttling enabled, but limited to 0 gas/sec"));
 	}
 
 	@Test
 	void shouldThrottleByGasAndTotalAllowedGasPerSecNotSetOrZeroFrontend() throws IOException {
 		// setup:
-		var defs = SerdeUtils.pojoDefs("bootstrap/throttles.json");
 		given(dynamicProperties.shouldThrottleByGas()).willReturn(true);
 		subject.setConsensusThrottled(false);
 
@@ -155,8 +153,7 @@ class DeterministicThrottlingTest {
 
 		// then:
 		assertEquals(0L, gasLimitDeterministicThrottle.getCapacity());
-		assertThat(logCaptor.errorLogs(),
-				contains("ThrottleByGas global dynamic property is set to true but contracts.frontendThrottleMaxGasLimit is not set in throttles.json or is set to 0."));
+		assertThat(logCaptor.warnLogs(), contains("Frontend gas throttling enabled, but limited to 0 gas/sec"));
 	}
 
 	@Test

--- a/hedera-node/src/test/java/com/hedera/services/throttling/DeterministicThrottlingTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/throttling/DeterministicThrottlingTest.java
@@ -129,7 +129,7 @@ class DeterministicThrottlingTest {
 	}
 
 	@Test
-	void shouldThrottleByGasAndTotalAllowedGasPerSecNotSetOrZero() throws IOException {
+	void shouldThrottleByGasAndTotalAllowedGasPerSecNotSetOrZero() {
 		// setup:
 		given(dynamicProperties.shouldThrottleByGas()).willReturn(true);
 		subject.setConsensusThrottled(true);
@@ -143,7 +143,7 @@ class DeterministicThrottlingTest {
 	}
 
 	@Test
-	void shouldThrottleByGasAndTotalAllowedGasPerSecNotSetOrZeroFrontend() throws IOException {
+	void shouldThrottleByGasAndTotalAllowedGasPerSecNotSetOrZeroFrontend() {
 		// setup:
 		given(dynamicProperties.shouldThrottleByGas()).willReturn(true);
 		subject.setConsensusThrottled(false);
@@ -321,14 +321,67 @@ class DeterministicThrottlingTest {
 	}
 
 	@Test
-	void logsGasThrottleAsExpected() {
+	void logsActiveConsensusGasThrottlesAsExpected() {
 		var capacity = 1000L;
 		// setup:
 		given(dynamicProperties.consensusThrottleGasLimit()).willReturn(capacity);
 		given(dynamicProperties.shouldThrottleByGas()).willReturn(true);
 
-		var desired = "Resolved gas throttle limit (after splitting capacity " + n + " ways) - \n" +
-				"  ThrottleByGasLimit: " + capacity / n + " throttleByGas true";
+		final var desired = "Resolved consensus gas throttle (after splitting capacity 2 ways) -" +
+				"\n  500 gas/sec (throttling ON)";
+
+		// when:
+		subject.applyGasConfig();
+
+		// then:
+		assertThat(logCaptor.infoLogs(), contains(desired));
+	}
+
+	@Test
+	void logsInertConsensusGasThrottlesAsExpected() {
+		var capacity = 1000L;
+		// setup:
+		given(dynamicProperties.consensusThrottleGasLimit()).willReturn(capacity);
+
+		final var desired = "Resolved consensus gas throttle (after splitting capacity 2 ways) -" +
+				"\n  500 gas/sec (throttling OFF)";
+
+		// when:
+		subject.applyGasConfig();
+
+		// then:
+		assertThat(logCaptor.infoLogs(), contains(desired));
+	}
+
+	@Test
+	void logsActiveFrontendGasThrottlesAsExpected() {
+		subject = new DeterministicThrottling(() -> 4, dynamicProperties, false);
+
+		var capacity = 1000L;
+		// setup:
+		given(dynamicProperties.frontendThrottleGasLimit()).willReturn(capacity);
+		given(dynamicProperties.shouldThrottleByGas()).willReturn(true);
+
+		final var desired = "Resolved frontend gas throttle (after splitting capacity 4 ways) -" +
+				"\n  250 gas/sec (throttling ON)";
+
+		// when:
+		subject.applyGasConfig();
+
+		// then:
+		assertThat(logCaptor.infoLogs(), contains(desired));
+	}
+
+	@Test
+	void logsInertFrontendGasThrottlesAsExpected() {
+		subject = new DeterministicThrottling(() -> 4, dynamicProperties, false);
+
+		var capacity = 1000L;
+		// setup:
+		given(dynamicProperties.frontendThrottleGasLimit()).willReturn(capacity);
+
+		final var desired = "Resolved frontend gas throttle (after splitting capacity 4 ways) -" +
+				"\n  250 gas/sec (throttling OFF)";
 
 		// when:
 		subject.applyGasConfig();
@@ -474,7 +527,7 @@ class DeterministicThrottlingTest {
 	}
 
 	@Test
-	void contractCreateTXCallsConsensusGasThrottleWithDefinitions() throws IOException {
+	void contractCreateTXCallsConsensusGasThrottleWithDefinitions() {
 		Instant now = Instant.now();
 
 		//setup:
@@ -492,7 +545,7 @@ class DeterministicThrottlingTest {
 	}
 
 	@Test
-	void contractCallTXCallsConsensusGasThrottleWithDefinitions() throws IOException {
+	void contractCallTXCallsConsensusGasThrottleWithDefinitions() {
 		Instant now = Instant.now();
 
 		//setup:


### PR DESCRIPTION
**Description**:
- Add a [value screen for `contracts.maxRefundPercentOfGasLimit`](https://github.com/hashgraph/hedera-services/blob/ci-enabled-2373/hedera-node/src/main/java/com/hedera/services/context/properties/ScreenedSysFileProps.java#L103) so that values outside the range `[0, 100]` will be ignored for this property. 
- Split `GlobalDynamicPropertiesTest` methods up to get fewer assertions per method and fix Sonar code smell.
- Add unit tests to `DeterministicThrottling`, tweak log messages to improve readability.