### PR TITLE
Extend `TransactionalLedger` to implement `BackingStore` 

### DIFF
--- a/hedera-node/src/main/java/com/hedera/services/ledger/LedgerCheck.java
+++ b/hedera-node/src/main/java/com/hedera/services/ledger/LedgerCheck.java
@@ -24,7 +24,9 @@ package com.hedera.services.ledger;
 import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
 
 import java.util.Map;
+import java.util.function.Function;
 
 public interface LedgerCheck<A, P>  {
 	ResponseCodeEnum checkUsing(A account, Map<P, Object> changeSet);
+	ResponseCodeEnum checkUsing(Function<P, Object> extantProps, Map<P, Object> changeSet);
 }

--- a/hedera-node/src/main/java/com/hedera/services/ledger/MerkleAccountScopedCheck.java
+++ b/hedera-node/src/main/java/com/hedera/services/ledger/MerkleAccountScopedCheck.java
@@ -26,7 +26,9 @@ import com.hedera.services.state.merkle.MerkleAccount;
 import com.hedera.services.txns.validation.OptionValidator;
 import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
 
+import javax.annotation.Nullable;
 import java.util.Map;
+import java.util.function.Function;
 
 import static com.hedera.services.ledger.properties.AccountProperty.BALANCE;
 import static com.hedera.services.ledger.properties.AccountProperty.EXPIRY;
@@ -47,20 +49,40 @@ public class MerkleAccountScopedCheck implements LedgerCheck<MerkleAccount, Acco
 	}
 
 	@Override
+	public ResponseCodeEnum checkUsing(
+			final Function<AccountProperty, Object> extantProps,
+			final Map<AccountProperty, Object> changeSet
+	) {
+		return internalCheck(null, extantProps, changeSet);
+	}
+
+	@Override
 	public ResponseCodeEnum checkUsing(final MerkleAccount account, final Map<AccountProperty, Object> changeSet) {
-		if ((boolean) getEffective(IS_SMART_CONTRACT, account, changeSet)) {
+		return internalCheck(account, null, changeSet);
+	}
+
+	public MerkleAccountScopedCheck setBalanceChange(final BalanceChange balanceChange) {
+		this.balanceChange = balanceChange;
+		return this;
+	}
+
+	private ResponseCodeEnum internalCheck(
+			@Nullable final MerkleAccount account,
+			@Nullable final Function<AccountProperty, Object> extantProps,
+			final Map<AccountProperty, Object> changeSet
+	) {
+		if ((boolean) getEffective(IS_SMART_CONTRACT, account, extantProps, changeSet)) {
 			return ResponseCodeEnum.INVALID_ACCOUNT_ID;
 		}
 
-		if ((boolean) getEffective(IS_DELETED, account, changeSet)) {
+		if ((boolean) getEffective(IS_DELETED, account, extantProps, changeSet)) {
 			return ResponseCodeEnum.ACCOUNT_DELETED;
 		}
 
-		final var balance = (long) getEffective(BALANCE, account, changeSet);
-
+		final var balance = (long) getEffective(BALANCE, account, extantProps, changeSet);
 		final var isDetached = dynamicProperties.autoRenewEnabled() &&
-						balance == 0L &&
-						!validator.isAfterConsensusSecond((long) getEffective(EXPIRY, account, changeSet));
+				balance == 0L &&
+				!validator.isAfterConsensusSecond((long) getEffective(EXPIRY, account, extantProps, changeSet));
 		if (isDetached) {
 			return ACCOUNT_EXPIRED_AND_PENDING_REMOVAL;
 		}
@@ -74,28 +96,28 @@ public class MerkleAccountScopedCheck implements LedgerCheck<MerkleAccount, Acco
 		return OK;
 	}
 
-	public MerkleAccountScopedCheck setBalanceChange(final BalanceChange balanceChange) {
-		this.balanceChange = balanceChange;
-		return this;
-	}
-
 	Object getEffective(
 			final AccountProperty prop,
-			final MerkleAccount account,
+			@Nullable final MerkleAccount account,
+			@Nullable final Function<AccountProperty, Object> extantProps,
 			final Map<AccountProperty, Object> changeSet
 	) {
 		if (changeSet != null && changeSet.containsKey(prop)) {
 			return changeSet.get(prop);
 		}
+		final var useExtantProps = extantProps != null;
+		if (!useExtantProps) {
+			assert account != null;
+		}
 		switch (prop) {
 			case IS_SMART_CONTRACT:
-				return account.isSmartContract();
+				return useExtantProps ? extantProps.apply(IS_SMART_CONTRACT) : account.isSmartContract();
 			case IS_DELETED:
-				return account.isDeleted();
+				return useExtantProps ? extantProps.apply(IS_DELETED) : account.isDeleted();
 			case BALANCE:
-				return account.getBalance();
+				return useExtantProps ? extantProps.apply(BALANCE) : account.getBalance();
 			case EXPIRY:
-				return account.getExpiry();
+				return useExtantProps ? extantProps.apply(EXPIRY) : account.getExpiry();
 		}
 		throw new IllegalArgumentException("Property " + prop + " cannot be validated in scoped check");
 	}

--- a/hedera-node/src/main/java/com/hedera/services/ledger/accounts/BackingStore.java
+++ b/hedera-node/src/main/java/com/hedera/services/ledger/accounts/BackingStore.java
@@ -43,16 +43,16 @@ public interface BackingStore<K, A> {
 	/**
 	 * Gets a possibly mutable reference to the account with the specified id.
 	 *
-	 * @param id the id of the relevant account.
-	 * @return a reference to the account.
+	 * @param id the id of the relevant account
+	 * @return a reference to the account
 	 */
 	A getRef(K id);
 
 	/**
 	 * Gets a reference to the account with the specified id which should not be mutated.
 	 *
-	 * @param id the id of the relevant account.
-	 * @return a reference to the account.
+	 * @param id the id of the relevant account
+	 * @return a reference to the account
 	 */
 	A getImmutableRef(K id);
 
@@ -60,30 +60,30 @@ public interface BackingStore<K, A> {
 	 * Updates (or creates, if absent) the account with the given id
 	 * to the accompanying account.
 	 *
-	 * @param id the id of the relevant account.
-	 * @param account the account that should have this id.
+	 * @param id the id of the relevant account
+	 * @param account the account that should have this id
 	 */
 	void put(K id, A account);
 
 	/**
 	 * Frees the account with the given id for reclamation.
 	 *
-	 * @param id the id of the relevant account.
+	 * @param id the id of the relevant account
 	 */
 	void remove(K id);
 
 	/**
 	 * Checks if the collection contains the account with the given id.
 	 *
-	 * @param id the account in question.
-	 * @return a flag for existence.
+	 * @param id the account in question
+	 * @return a flag for existence
 	 */
 	boolean contains(K id);
 
 	/**
 	 * Returns the set of extant account ids.
 	 *
-	 * @return the set of extant account ids.
+	 * @return the set of extant account ids
 	 */
 	Set<K> idSet();
 }

--- a/hedera-node/src/main/java/com/hedera/services/ledger/accounts/BackingStore.java
+++ b/hedera-node/src/main/java/com/hedera/services/ledger/accounts/BackingStore.java
@@ -44,7 +44,7 @@ public interface BackingStore<K, A> {
 	 * Gets a possibly mutable reference to the account with the specified id.
 	 *
 	 * @param id the id of the relevant account
-	 * @return a reference to the account
+	 * @return a reference to the account, or null if it is missing
 	 */
 	A getRef(K id);
 

--- a/hedera-node/src/main/java/com/hedera/services/store/TopicStore.java
+++ b/hedera-node/src/main/java/com/hedera/services/store/TopicStore.java
@@ -1,19 +1,23 @@
 package com.hedera.services.store;
 
-/*
- * -
+/*-
  * ‌
  * Hedera Services Node
+ * ​
  * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
+ * ​
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *       http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * ‍
  */
 
 import com.hedera.services.records.TransactionRecordService;
@@ -35,7 +39,6 @@ import static com.hedera.services.store.models.TopicConversion.fromModel;
  */
 @Singleton
 public class TopicStore {
-	
 	private final Supplier<MerkleMap<EntityNum, MerkleTopic>> topics;
 	private final TransactionRecordService transactionRecordService;
 

--- a/hedera-node/src/test/java/com/hedera/services/ledger/LedgerImplBackingStoreTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/ledger/LedgerImplBackingStoreTest.java
@@ -1,0 +1,246 @@
+package com.hedera.services.ledger;
+
+/*-
+ * ‌
+ * Hedera Services Node
+ * ​
+ * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import com.hedera.services.ledger.accounts.BackingStore;
+import com.hedera.services.ledger.accounts.HashMapTestAccounts;
+import com.hedera.services.ledger.accounts.TestAccount;
+import com.hedera.services.ledger.properties.ChangeSummaryManager;
+import com.hedera.services.ledger.properties.TestAccountProperty;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.util.Map;
+import java.util.function.Function;
+
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_TOKEN_MINT_AMOUNT;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+class LedgerImplBackingStoreTest {
+	private static final TestAccountProperty[] ALL_PROPS = TestAccountProperty.class.getEnumConstants();
+
+	private final TestAccount aTestAccount = new TestAccount(1L, new Object(), true, 9L);
+
+	private BackingStore<Long, TestAccount> backingTestAccounts;
+	private TransactionalLedger<Long, TestAccountProperty, TestAccount> firstOrder;
+
+	private TransactionalLedger<Long, TestAccountProperty, TestAccount> subject;
+
+	@BeforeEach
+	void setUp() {
+		backingTestAccounts = new HashMapTestAccounts();
+
+		firstOrder = new TransactionalLedger<>(
+				TestAccountProperty.class,
+				TestAccount::new,
+				backingTestAccounts,
+				new ChangeSummaryManager<>());
+	}
+
+	@Test
+	void doesntSupportIdSet() {
+		givenFirstOrderSubject();
+
+		assertThrows(UnsupportedOperationException.class, subject::idSet);
+	}
+
+	@Test
+	void doesntSupportGettingImmutableRefs() {
+		givenFirstOrderSubject();
+
+		assertThrows(UnsupportedOperationException.class, () -> subject.getImmutableRef(1L));
+	}
+
+	@Test
+	void containsDelegatesToExists() {
+		givenMockSubject();
+
+		given(subject.exists(1L)).willReturn(true);
+		doCallRealMethod().when(subject).contains(1L);
+
+		assertTrue(subject.contains(1L));
+		verify(subject).exists(1L);
+	}
+
+	@Test
+	void removeDelegatesToDestroy() {
+		givenMockSubject();
+
+		doCallRealMethod().when(subject).remove(1L);
+
+		subject.remove(1L);
+
+		verify(subject).destroy(1L);
+	}
+
+	@Test
+	void putThrowsIfNotInTxn() {
+		givenFirstOrderSubject();
+
+		assertThrows(IllegalStateException.class, () -> subject.put(1L, aTestAccount));
+	}
+
+	@Test
+	void putAccumulatesAllChangesFromReceivedEntityButDoesNotAffectStore() {
+		givenFirstOrderSubject();
+		subject.begin();
+
+		subject.create(1L);
+		subject.put(1L, aTestAccount);
+
+		final var changeSet = subject.getChanges().get(1L);
+		for (final var prop : ALL_PROPS) {
+			assertEquals(prop.getter().apply(aTestAccount), changeSet.get(prop));
+		}
+
+		assertFalse(backingTestAccounts.contains(1L));
+	}
+
+	@Test
+	void putCreatesMissingIdIfNeededToAccumulatesAllChangesFromReceivedEntity() {
+		givenFirstOrderSubject();
+		subject.begin();
+
+		subject.put(1L, aTestAccount);
+
+		final var changeSet = subject.getChanges().get(1L);
+		for (final var prop : ALL_PROPS) {
+			assertEquals(prop.getter().apply(aTestAccount), changeSet.get(prop));
+		}
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	void usesScopedPropertyGetterToValidateExtantEntityIfBackedByLedger() {
+		givenSecondOrderSubject();
+
+		backingTestAccounts.put(1L, aTestAccount);
+		firstOrder.begin();
+		firstOrder.set(1L, TestAccountProperty.LONG, 2L);
+
+		final var captor = ArgumentCaptor.forClass(Function.class);
+		final var mockCheck = (LedgerCheck<TestAccount, TestAccountProperty>) mock(LedgerCheck.class);
+		given(mockCheck.checkUsing(any(Function.class), any(Map.class))).willReturn(INVALID_TOKEN_MINT_AMOUNT);
+
+		subject.begin();
+		subject.set(1L, TestAccountProperty.FLAG, false);
+		final var actual = subject.validate(1L, mockCheck);
+
+		assertEquals(INVALID_TOKEN_MINT_AMOUNT, actual);
+
+		verify(mockCheck).checkUsing(captor.capture(), any(Map.class));
+		final var extantProps = (Function<TestAccountProperty, Object>) captor.getValue();
+		assertEquals(2L, extantProps.apply(TestAccountProperty.LONG));
+		assertEquals(aTestAccount.isFlag(), extantProps.apply(TestAccountProperty.FLAG));
+		assertSame(aTestAccount.getThing(), extantProps.apply(TestAccountProperty.OBJ));
+		assertEquals(aTestAccount.getTokenThing(), extantProps.apply(TestAccountProperty.TOKEN_LONG));
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	void usesDefaultPropertyGetterToValidateNewEntityIfBackedByLedger() {
+		givenSecondOrderSubject();
+
+		final var aDefaultAccount = new TestAccount();
+
+		final var captor = ArgumentCaptor.forClass(Function.class);
+		final var mockCheck = (LedgerCheck<TestAccount, TestAccountProperty>) mock(LedgerCheck.class);
+		given(mockCheck.checkUsing(any(Function.class), any(Map.class))).willReturn(INVALID_TOKEN_MINT_AMOUNT);
+
+		subject.begin();
+		subject.create(1L);
+		subject.set(1L, TestAccountProperty.FLAG, false);
+		final var actual = subject.validate(1L, mockCheck);
+
+		assertEquals(INVALID_TOKEN_MINT_AMOUNT, actual);
+
+		verify(mockCheck).checkUsing(captor.capture(), any(Map.class));
+		final var extantProps = (Function<TestAccountProperty, Object>) captor.getValue();
+		assertEquals(aDefaultAccount.getValue(), extantProps.apply(TestAccountProperty.LONG));
+		assertEquals(aDefaultAccount.isFlag(), extantProps.apply(TestAccountProperty.FLAG));
+		assertNull(extantProps.apply(TestAccountProperty.OBJ));
+		assertEquals(aDefaultAccount.getTokenThing(), extantProps.apply(TestAccountProperty.TOKEN_LONG));
+	}
+
+	@Test
+	void usesScopedPropertyGetterWithExtantEntityIfBackedByLedger() {
+		final var expected = new Object();
+		final var mockLedger = mockLedger();
+		givenSecondOrderSubjectBackedBy(mockLedger);
+
+		given(mockLedger.contains(1L)).willReturn(true);
+		given(mockLedger.get(1L, TestAccountProperty.OBJ)).willReturn(expected);
+
+		final var actual = subject.get(1L, TestAccountProperty.OBJ);
+
+		assertSame(expected, actual);
+	}
+
+	@Test
+	void usesDefaultPropertyWithNewlyCreatedEntityIfBackedByLedger() {
+		final var expected = new Object();
+		final var mockLedger = mockLedger();
+		givenSecondOrderSubjectBackedBy(mockLedger);
+
+		subject.begin();
+		subject.create(1L);
+
+		final var actual = subject.get(1L, TestAccountProperty.TOKEN_LONG);
+
+		assertEquals(TestAccount.DEFAULT_TOKEN_THING, actual);
+	}
+
+	private void givenFirstOrderSubject() {
+		subject = firstOrder;
+	}
+
+	private void givenSecondOrderSubject() {
+		givenSecondOrderSubjectBackedBy(firstOrder);
+	}
+
+	private void givenSecondOrderSubjectBackedBy(TransactionalLedger<Long, TestAccountProperty, TestAccount> ledger) {
+		subject = new TransactionalLedger<>(
+				TestAccountProperty.class,
+				TestAccount::new,
+				ledger,
+				new ChangeSummaryManager<>());
+	}
+
+	private void givenMockSubject() {
+		subject = mockLedger();
+	}
+
+	@SuppressWarnings("unchecked")
+	private TransactionalLedger<Long, TestAccountProperty, TestAccount> mockLedger() {
+		return (TransactionalLedger<Long, TestAccountProperty, TestAccount>) mock(TransactionalLedger.class);
+	}
+}

--- a/hedera-node/src/test/java/com/hedera/services/ledger/MerkleAccountScopedCheckTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/ledger/MerkleAccountScopedCheckTest.java
@@ -32,9 +32,13 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.function.Function;
 
 import static com.hedera.services.ledger.properties.AccountProperty.AUTO_RENEW_PERIOD;
+import static com.hedera.services.ledger.properties.AccountProperty.BALANCE;
+import static com.hedera.services.ledger.properties.AccountProperty.EXPIRY;
 import static com.hedera.services.ledger.properties.AccountProperty.IS_DELETED;
+import static com.hedera.services.ledger.properties.AccountProperty.IS_SMART_CONTRACT;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.ACCOUNT_DELETED;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.ACCOUNT_EXPIRED_AND_PENDING_REMOVAL;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INSUFFICIENT_ACCOUNT_BALANCE;
@@ -42,27 +46,25 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_ACCOUN
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OK;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class MerkleAccountScopedCheckTest {
 	@Mock
-	GlobalDynamicProperties dynamicProperties;
-
+	private GlobalDynamicProperties dynamicProperties;
 	@Mock
-	OptionValidator validator;
-
+	private OptionValidator validator;
 	@Mock
-	BalanceChange balanceChange;
-
+	private BalanceChange balanceChange;
 	@Mock
-	MerkleAccount account;
-
+	private MerkleAccount account;
 	@Mock
-	Map<AccountProperty, Object> changeSet;
+	private Map<AccountProperty, Object> changeSet;
+	@Mock
+	private Function<AccountProperty, Object> extantProps;
 
-	long expiry = 1234L;
-	MerkleAccountScopedCheck subject;
+	private MerkleAccountScopedCheck subject;
 
 	@BeforeEach
 	void setUp() {
@@ -73,16 +75,21 @@ class MerkleAccountScopedCheckTest {
 	@Test
 	void failsAsExpectedForSmartContacts() {
 		when(account.isSmartContract()).thenReturn(true);
-
 		assertEquals(INVALID_ACCOUNT_ID, subject.checkUsing(account, changeSet));
+
+		given(extantProps.apply(AccountProperty.IS_SMART_CONTRACT)).willReturn(true);
+		assertEquals(INVALID_ACCOUNT_ID, subject.checkUsing(extantProps, changeSet));
 	}
 
 	@Test
 	void failsAsExpectedForDeletedAccount() {
 		when(account.isSmartContract()).thenReturn(false);
 		when(account.isDeleted()).thenReturn(true);
-
 		assertEquals(ACCOUNT_DELETED, subject.checkUsing(account, changeSet));
+
+		given(extantProps.apply(IS_SMART_CONTRACT)).willReturn(false);
+		given(extantProps.apply(IS_DELETED)).willReturn(true);
+		assertEquals(ACCOUNT_DELETED, subject.checkUsing(extantProps, changeSet));
 	}
 
 	@Test
@@ -96,14 +103,21 @@ class MerkleAccountScopedCheckTest {
 
 	@Test
 	void failsAsExpectedForExpiredAccount() {
+		final var expiry = 1234L;
+
 		when(account.isSmartContract()).thenReturn(false);
 		when(account.isDeleted()).thenReturn(false);
 		when(dynamicProperties.autoRenewEnabled()).thenReturn(true);
 		when(account.getBalance()).thenReturn(0L);
 		when(account.getExpiry()).thenReturn(expiry);
 		when(validator.isAfterConsensusSecond(expiry)).thenReturn(false);
-
 		assertEquals(ACCOUNT_EXPIRED_AND_PENDING_REMOVAL, subject.checkUsing(account, changeSet));
+
+		given(extantProps.apply(IS_SMART_CONTRACT)).willReturn(false);
+		given(extantProps.apply(IS_DELETED)).willReturn(false);
+		given(extantProps.apply(BALANCE)).willReturn(0L);
+		given(extantProps.apply(EXPIRY)).willReturn(expiry);
+		assertEquals(ACCOUNT_EXPIRED_AND_PENDING_REMOVAL, subject.checkUsing(extantProps, changeSet));
 	}
 
 	@Test
@@ -133,7 +147,7 @@ class MerkleAccountScopedCheckTest {
 	@Test
 	void throwsAsExpected() {
 		var iae = assertThrows(IllegalArgumentException.class,
-				() -> subject.getEffective(AUTO_RENEW_PERIOD, account, changeSet));
+				() -> subject.getEffective(AUTO_RENEW_PERIOD, account, null, changeSet));
 		assertEquals("Property "+ AUTO_RENEW_PERIOD + " cannot be validated in scoped check", iae.getMessage());
 	}
 }

--- a/hedera-node/src/test/java/com/hedera/services/ledger/TestAccountScopedCheck.java
+++ b/hedera-node/src/test/java/com/hedera/services/ledger/TestAccountScopedCheck.java
@@ -36,7 +36,6 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.ACCOUNT_STILL_
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OK;
 
 class TestAccountScopedCheck implements LedgerCheck<TestAccount, TestAccountProperty> {
-
 	@Override
 	public ResponseCodeEnum checkUsing(final TestAccount account, final Map<TestAccountProperty, Object> changeSet) {
 		Function<TestAccountProperty, Object> getter = prop -> {
@@ -46,18 +45,24 @@ class TestAccountScopedCheck implements LedgerCheck<TestAccount, TestAccountProp
 				return prop.getter().apply(account);
 			}
 		};
+		return checkUsing(getter, changeSet);
+	}
 
-		if ((boolean) getter.apply(FLAG)) {
+	@Override
+	public ResponseCodeEnum checkUsing(
+			final Function<TestAccountProperty, Object> extantProps,
+			final Map<TestAccountProperty, Object> changeSet
+	) {
+		if ((boolean) extantProps.apply(FLAG)) {
 			return ACCOUNT_IS_TREASURY;
 		}
-
-		if ((long)getter.apply(LONG) != 123L) {
+		if ((long) extantProps.apply(LONG) != 123L) {
 			return ACCOUNT_IS_NOT_GENESIS_ACCOUNT;
 		}
-
-		if (!getter.apply(OBJ).equals("DEFAULT")) {
+		if (!extantProps.apply(OBJ).equals("DEFAULT")) {
 			return ACCOUNT_STILL_OWNS_NFTS;
 		}
 		return OK;
 	}
+
 }

--- a/hedera-node/src/test/java/com/hedera/services/ledger/accounts/HashMapTestAccounts.java
+++ b/hedera-node/src/test/java/com/hedera/services/ledger/accounts/HashMapTestAccounts.java
@@ -1,0 +1,59 @@
+package com.hedera.services.ledger.accounts;
+
+/*-
+ * ‌
+ * Hedera Services Node
+ * ​
+ * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+public class HashMapTestAccounts implements BackingStore<Long, TestAccount> {
+	private Map<Long, TestAccount> testAccounts = new HashMap<>();
+
+	@Override
+	public TestAccount getRef(Long id) {
+		return testAccounts.get(id);
+	}
+
+	@Override
+	public TestAccount getImmutableRef(Long id) {
+		return testAccounts.get(id);
+	}
+
+	@Override
+	public void put(Long id, TestAccount testAccount) {
+		testAccounts.put(id, testAccount);
+	}
+
+	@Override
+	public void remove(Long id) {
+		testAccounts.remove(id);
+	}
+
+	@Override
+	public boolean contains(Long id) {
+		return testAccounts.containsKey(id);
+	}
+
+	@Override
+	public Set<Long> idSet() {
+		return testAccounts.keySet();
+	}
+}

--- a/hedera-node/src/test/java/com/hedera/services/ledger/accounts/TestAccount.java
+++ b/hedera-node/src/test/java/com/hedera/services/ledger/accounts/TestAccount.java
@@ -23,7 +23,7 @@ package com.hedera.services.ledger.accounts;
 import com.google.common.base.MoreObjects;
 
 public class TestAccount {
-	private static final long DEFAULT_TOKEN_THING = 123L;
+	public static final long DEFAULT_TOKEN_THING = 123L;
 
 	public long value;
 	public long tokenThing;
@@ -44,7 +44,6 @@ public class TestAccount {
 	public TestAccount(long value, Object thing, boolean flag) {
 		this(value, thing, flag, DEFAULT_TOKEN_THING);
 	}
-
 
 	public Object getThing() {
 		return thing;

--- a/hedera-node/src/test/java/com/hedera/services/ledger/properties/TestAccountProperty.java
+++ b/hedera-node/src/test/java/com/hedera/services/ledger/properties/TestAccountProperty.java
@@ -9,9 +9,9 @@ package com.hedera.services.ledger.properties;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -29,7 +29,7 @@ public enum TestAccountProperty implements BeanProperty<TestAccount> {
 	FLAG {
 		@Override
 		public BiConsumer<TestAccount, Object> setter() {
-			return (a, f) -> a.setFlag((boolean)f);
+			return (a, f) -> a.setFlag((boolean) f);
 		}
 
 		@Override
@@ -40,7 +40,7 @@ public enum TestAccountProperty implements BeanProperty<TestAccount> {
 	LONG {
 		@Override
 		public BiConsumer<TestAccount, Object> setter() {
-			return (a, v) -> a.setValue((long)v);
+			return (a, v) -> a.setValue((long) v);
 		}
 
 		@Override
@@ -57,6 +57,17 @@ public enum TestAccountProperty implements BeanProperty<TestAccount> {
 		@Override
 		public Function<TestAccount, Object> getter() {
 			return TestAccount::getThing;
+		}
+	},
+	TOKEN_LONG {
+		@Override
+		public BiConsumer<TestAccount, Object> setter() {
+			return (a, v) -> a.setTokenThing((long) v);
+		}
+
+		@Override
+		public Function<TestAccount, Object> getter() {
+			return TestAccount::getTokenThing;
 		}
 	},
 }

--- a/hedera-node/src/test/java/com/hedera/services/store/TopicStoreTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/store/TopicStoreTest.java
@@ -1,19 +1,23 @@
 package com.hedera.services.store;
 
-/*
- * -
+/*-
  * ‌
  * Hedera Services Node
+ * ​
  * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
+ * ​
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *       http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * ‍
  */
 
 import com.hedera.services.records.TransactionRecordService;

--- a/hedera-node/src/test/java/com/hedera/services/store/models/TopicTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/store/models/TopicTest.java
@@ -1,19 +1,23 @@
 package com.hedera.services.store.models;
 
-/*
- * -
+/*-
  * ‌
  * Hedera Services Node
+ * ​
  * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
+ * ​
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *       http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * ‍
  */
 
 import com.hedera.services.state.submerkle.RichInstant;
@@ -27,8 +31,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class TopicTest {
-
-
 	@Test
 	void createsOkTopic() {
 		final var id = Id.DEFAULT;

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/misc/MemoValidation.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/misc/MemoValidation.java
@@ -1,5 +1,25 @@
 package com.hedera.services.bdd.suites.misc;
 
+/*-
+ * ‌
+ * Hedera Services Test Clients
+ * ​
+ * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
 import com.hedera.services.bdd.spec.HapiApiSpec;
 import com.hedera.services.bdd.spec.HapiSpecSetup;
 import com.hedera.services.bdd.spec.infrastructure.meta.ContractResources;


### PR DESCRIPTION
**Related issues**:
- Addresses #2411 

**Description**:
- Allows a `TransactionalLedger<K, P, A>` to be used as a `BackingStore<K, A>`. 
- This makes it easy to "wrap" one ledger in another, so that a `HederaWorldUpdater` implemented in terms of `TransactionLedger`s can execute HTS precompiles without affecting any `Updater`s below it in the call stack.
- ➡️ &nbsp;When a ledger is wrapping another ledger, it is far more efficient to get entity properties using the wrapped ledger's `get(K id, P property)` method instead of going through its `BackingStore.getRef(K id)` implementation.
    * So this PR also updates the `LedgerCheck<A, P>` interface to have a `checkUsing()` variant that accepts a `Function<P, Object>` instead of an `A` instance.
    * A ledger wrapping another ledger chooses this variant, passing in a `Function<P, Object>` that delegates to its wrapped ledger's `get()` method.