### PR TITLE
Revert #2442

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 ##  * Configuration from /opt/hedera/services/config-mount; and, 
 ##  * Logs at /opt/hedera/services/output; and, 
 ##  * Saved states under /opt/hedera/services/output
-FROM ubuntu:22.04 AS base-runtime
+FROM ubuntu:20.10 AS base-runtime
 RUN apt-get update && \
     apt-get upgrade -y && \
     apt-get install -y dos2unix openssl openjdk-15-jdk libsodium23 postgresql-client


### PR DESCRIPTION
`Unable to locate package openjdk-15-jdk` when building with ubuntu `22.04`