### PR TITLE
02446: Consolidate equals function

### DIFF
--- a/hedera-node/src/main/java/com/hedera/services/state/merkle/MerkleAccount.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/merkle/MerkleAccount.java
@@ -27,6 +27,7 @@ import com.hedera.services.state.serdes.DomainSerdes;
 import com.hedera.services.state.submerkle.EntityId;
 import com.hedera.services.state.submerkle.ExpirableTxnRecord;
 import com.hedera.services.utils.EntityNum;
+import com.hedera.services.utils.MiscUtils;
 import com.swirlds.common.merkle.MerkleInternal;
 import com.swirlds.common.merkle.MerkleNode;
 import com.swirlds.common.merkle.utility.AbstractNaryMerkleInternal;
@@ -134,18 +135,15 @@ public class MerkleAccount extends AbstractNaryMerkleInternal implements MerkleI
 	}
 
 	/* ---- Object ---- */
-	@Override
-	public boolean equals(final Object o) {
-		if (o == this) {
-			return true;
-		}
-		if (o == null || MerkleAccount.class != o.getClass()) {
-			return false;
-		}
-		final var that = (MerkleAccount) o;
+	private boolean sameClassEquals(final MerkleAccount that) {
 		return this.state().equals(that.state()) &&
 				this.records().equals(that.records()) &&
 				this.tokens().equals(that.tokens());
+	}
+
+	@Override
+	public boolean equals(final Object o) {
+		return MiscUtils.compare(this, o, this::sameClassEquals);
 	}
 
 	@Override
@@ -302,7 +300,8 @@ public class MerkleAccount extends AbstractNaryMerkleInternal implements MerkleI
 
 	public void setAlreadyUsedAutomaticAssociations(int alreadyUsedAutoAssociations) {
 		if (alreadyUsedAutoAssociations < 0 || alreadyUsedAutoAssociations > getMaxAutomaticAssociations()) {
-			throw new IllegalArgumentException("Cannot set alreadyUsedAutoAssociations to " + alreadyUsedAutoAssociations);
+			throw new IllegalArgumentException(
+					"Cannot set alreadyUsedAutoAssociations to " + alreadyUsedAutoAssociations);
 		}
 		state().setAlreadyUsedAutomaticAssociations(alreadyUsedAutoAssociations);
 	}

--- a/hedera-node/src/main/java/com/hedera/services/utils/MiscUtils.java
+++ b/hedera-node/src/main/java/com/hedera/services/utils/MiscUtils.java
@@ -56,6 +56,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.BiConsumer;
+import java.util.function.Predicate;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
@@ -770,5 +771,16 @@ public final class MiscUtils {
 		if (null != map) {
 			map.put(key, value);
 		}
+	}
+
+	public static <T> boolean compare(final T self, @Nullable final Object o, final Predicate<T> sameClassEquals) {
+		if (self == o) {
+			return true;
+		}
+		if (o == null || self.getClass() != o.getClass()) {
+			return false;
+		}
+		final var that = (T) o;
+		return sameClassEquals.test(that);
 	}
 }

--- a/hedera-node/src/test/java/com/hedera/services/state/merkle/MerkleAccountTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/state/merkle/MerkleAccountTest.java
@@ -99,8 +99,8 @@ class MerkleAccountTest {
 				memo,
 				deleted, smartContract, receiverSigRequired,
 				proxy,
-				number, 
-                                autoAssociationMetadata);
+				number,
+				autoAssociationMetadata);
 
 		subject = new MerkleAccount(List.of(state, payerRecords, tokens));
 		subject.setNftsOwned(2L);
@@ -149,7 +149,6 @@ class MerkleAccountTest {
 
 	@Test
 	void gettersDelegate() {
-		// expect:
 		assertEquals(new EntityNum(number), subject.getKey());
 		assertEquals(state.expiry(), subject.getExpiry());
 		assertEquals(state.balance(), subject.getBalance());
@@ -224,8 +223,6 @@ class MerkleAccountTest {
 
 		verify(payerRecords).copy();
 		verify(tokens).copy();
-		assertNotEquals(null, one);
-		assertNotEquals(new Object(), one);
 		assertNotEquals(two, one);
 		assertEquals(two, three);
 
@@ -252,7 +249,7 @@ class MerkleAccountTest {
 	void throwsOnInvalidAlreadyUsedAtoAssociations() {
 		assertThrows(IllegalArgumentException.class, () -> subject.setAlreadyUsedAutomaticAssociations(-1));
 		assertThrows(IllegalArgumentException.class, () -> subject.setAlreadyUsedAutomaticAssociations(
-				maxAutoAssociations +1));
+				maxAutoAssociations + 1));
 	}
 
 	@Test


### PR DESCRIPTION
Close #2446

Tried an abstract class
```
public abstract class SameClassComparable<T> {
	protected abstract boolean sameClassEquals(final T t);

	@Override
	public boolean equals(final Object o) {
		if (this == o) {
			return true;
		}
		if (o == null || this.getClass() != o.getClass()) {
			return false;
		}
		final var that = (T) o;
		return sameClassEquals(that);
	}
}

```
but it didn't work well as some class was extending another class already (java does not allow multiple extensions)

So the solution here is to introduce a helper function with the following advantages:
- Remove code duplicate
- Consolidate testing as we don't need to force call `equals` on `null`
- Allow testing only the core of `sameClassEquals`