### PR TITLE
Use `0.20.0` SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ nodes in the Hedera public network, which is built on the Platform.
 OpenJDK12 is strongly recommended.
 
 ## Solidity 
-Hedera Contracts support `pragma solidity <=0.5.9`.
+Hedera Contracts support `pragma solidity <=0.8.9`.
 
 ## Docker Compose quickstart 
 

--- a/pom.xml
+++ b/pom.xml
@@ -169,7 +169,7 @@
     <log4j.version>2.14.1</log4j.version>
     <netty.version>4.1.66.Final</netty.version>
     <protobuf-java.version>3.19.1</protobuf-java.version>
-    <swirlds.version>0.19.0</swirlds.version>
+    <swirlds.version>0.20.0</swirlds.version>
     <!-- Test dependency properties in alphabetical order -->
     <hamcrest.version>2.2</hamcrest.version>
     <junit5.version>5.8.1</junit5.version>


### PR DESCRIPTION
**Description**:
Switch to non-alpha SDK in preparation for `0.20.0-rc.1` tag.