### PR TITLE
Update yahcli tag to `0.1.7`, fix `defaultNodeAccount`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1551,3 +1551,13 @@ jobs:
           result_path: << parameters.result_path >>
       - store_artifacts:
           path: /results.tar.gz
+      - run:
+          name: Check for CI test failures
+          command: |
+            CI_RESULTS_LOG=$(find . -name hapi-client-combined.log)
+            grep $CI_RESULTS -e 'status=ERROR' -e 'status=FAILED'
+            if [ "$?" -eq "0" ]; then
+              exit 1
+            else
+              exit 0
+            fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1557,9 +1557,9 @@ jobs:
             set -x;
             set +e;
             cd /swirlds-platform/regression
-            CI_RESULTS_LOG=$(find . -name hapi-client-combined.log)
+            CI_RESULTS_LOG=$(find results/4N_1C -name hapi-client-combined.log)
             echo $CI_RESULTS_LOG
-            grep $CI_RESULTS -e 'status=ERROR' -e 'status=FAILED'
+            grep $CI_RESULTS_LOG -e 'status=ERROR' -e 'status=FAILED'
             if [ "$?" -eq "0" ]; then
               exit 1
             else

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1558,7 +1558,6 @@ jobs:
             set +e;
             cd /swirlds-platform/regression
             CI_RESULTS_LOG=$(find results/4N_1C -name hapi-client-combined.log)
-            echo $CI_RESULTS_LOG
             grep $CI_RESULTS_LOG -e 'status=ERROR' -e 'status=FAILED'
             if [ "$?" -eq "0" ]; then
               exit 1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1554,7 +1554,11 @@ jobs:
       - run:
           name: Check for CI test failures
           command: |
+            set -x;
+            set +e;
+            cd /swirlds-platform/regression
             CI_RESULTS_LOG=$(find . -name hapi-client-combined.log)
+            echo $CI_RESULTS_LOG
             grep $CI_RESULTS -e 'status=ERROR' -e 'status=FAILED'
             if [ "$?" -eq "0" ]; then
               exit 1

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenTransactSpecs.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenTransactSpecs.java
@@ -1835,7 +1835,7 @@ public class TokenTransactSpecs extends HapiApiSuite {
 								.via(txnFromDebbie)
 				).then(
 						getTxnRecord(txnFromTreasury)
-								.hasTokenAmount(feeToken, debbie, 1_000L)
+								.hasTokenAmount(feeToken, debbie, 666L)
 								.hasTokenAmount(feeToken, DEFAULT_PAYER, -1_000L)
 								.hasTokenAmount(tokenWithHtsFee, debbie, 1_000L)
 								.hasTokenAmount(tokenWithHtsFee, treasuryForNestedCollection, -1_000L)

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenTransactSpecs.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenTransactSpecs.java
@@ -1835,7 +1835,7 @@ public class TokenTransactSpecs extends HapiApiSuite {
 								.via(txnFromDebbie)
 				).then(
 						getTxnRecord(txnFromTreasury)
-								.hasTokenAmount(feeToken, debbie, 666L)
+								.hasTokenAmount(feeToken, debbie, 1_000L)
 								.hasTokenAmount(feeToken, DEFAULT_PAYER, -1_000L)
 								.hasTokenAmount(tokenWithHtsFee, debbie, 1_000L)
 								.hasTokenAmount(tokenWithHtsFee, treasuryForNestedCollection, -1_000L)

--- a/test-clients/src/main/java/com/hedera/services/yahcli/Yahcli.java
+++ b/test-clients/src/main/java/com/hedera/services/yahcli/Yahcli.java
@@ -85,6 +85,10 @@ public class Yahcli implements Callable<Integer> {
 			paramLabel = "network")
 	String net;
 
+	@Option(names = { "-a", "--node-account" },
+			paramLabel = "node account")
+	String nodeAccount;
+
 	@Option(names = { "-p", "--payer" },
 			paramLabel = "payer")
 	String payer;
@@ -123,6 +127,10 @@ public class Yahcli implements Callable<Integer> {
 
 	public Long getFixedFee() {
 		return fixedFee;
+	}
+
+	public String getNodeAccount() {
+		return nodeAccount == null ? nodeAccount : ("0.0." + nodeAccount);
 	}
 
 	private static void setLogLevelsToLessNoisy() {

--- a/test-clients/src/main/java/com/hedera/services/yahcli/Yahcli.java
+++ b/test-clients/src/main/java/com/hedera/services/yahcli/Yahcli.java
@@ -32,7 +32,7 @@ import com.hedera.services.yahcli.commands.files.SysFilesCommand;
 import com.hedera.services.yahcli.commands.system.FreezeAbortCommand;
 import com.hedera.services.yahcli.commands.system.FreezeOnlyCommand;
 import com.hedera.services.yahcli.commands.system.FreezeUpgradeCommand;
-import com.hedera.services.yahcli.commands.system.StageUpgradeCommand;
+import com.hedera.services.yahcli.commands.system.PrepareUpgradeCommand;
 import com.hedera.services.yahcli.commands.system.TelemetryUpgradeCommand;
 import com.hedera.services.yahcli.commands.validation.ValidationCommand;
 import com.hedera.services.yahcli.suites.BalanceSuite;
@@ -65,7 +65,7 @@ import java.util.concurrent.Callable;
 				FeesCommand.class,
 				FreezeAbortCommand.class,
 				FreezeOnlyCommand.class,
-				StageUpgradeCommand.class,
+				PrepareUpgradeCommand.class,
 				FreezeUpgradeCommand.class,
 				TelemetryUpgradeCommand.class
 		},

--- a/test-clients/src/main/java/com/hedera/services/yahcli/commands/system/PrepareUpgradeCommand.java
+++ b/test-clients/src/main/java/com/hedera/services/yahcli/commands/system/PrepareUpgradeCommand.java
@@ -36,7 +36,7 @@ import static com.hedera.services.yahcli.output.CommonMessages.COMMON_MESSAGES;
 		name = "prepare-upgrade",
 		subcommands = { picocli.CommandLine.HelpCommand.class },
 		description = "Stages artifacts prior to an NMT software upgrade")
-public class StageUpgradeCommand implements Callable<Integer> {
+public class PrepareUpgradeCommand implements Callable<Integer> {
 	@CommandLine.ParentCommand
 	private Yahcli yahcli;
 

--- a/test-clients/src/main/java/com/hedera/services/yahcli/config/ConfigManager.java
+++ b/test-clients/src/main/java/com/hedera/services/yahcli/config/ConfigManager.java
@@ -48,6 +48,7 @@ public class ConfigManager {
 	private final GlobalConfig global;
 
 	private String defaultPayer;
+	private String defaultNodeAccount;
 	private String targetName;
 	private NetConfig targetNet;
 
@@ -81,6 +82,7 @@ public class ConfigManager {
 		} else {
 			fail("Named accounts not yet supported!");
 		}
+		specConfig.put("default.node", defaultNodeAccount);
 		return specConfig;
 	}
 
@@ -151,6 +153,12 @@ public class ConfigManager {
 	public void assertNoMissingDefaults() {
 		assertTargetNetIsKnown();
 		assertDefaultPayerIsKnown();
+		assertDefaultNodeAccountIsKnown();
+	}
+
+	private void assertDefaultNodeAccountIsKnown() {
+		final var configDefault = "0.0." + targetNet.getDefaultNodeAccount();
+		defaultNodeAccount = Optional.ofNullable(yahcli.getNodeAccount()).orElse(configDefault);
 	}
 
 	private void assertDefaultPayerIsKnown() {

--- a/test-clients/src/main/java/com/hedera/services/yahcli/config/domain/NetConfig.java
+++ b/test-clients/src/main/java/com/hedera/services/yahcli/config/domain/NetConfig.java
@@ -30,10 +30,10 @@ import java.util.Map;
 import static java.util.stream.Collectors.joining;
 
 public class NetConfig {
-	public static final Integer TRAD_DEFAULT_NODE_ACCOUNT = 3;
+	public static final Integer TRADITIONAL_DEFAULT_NODE_ACCOUNT = 3;
 
 	private String defaultPayer;
-	private Integer defaultNodeAccount = TRAD_DEFAULT_NODE_ACCOUNT;
+	private Integer defaultNodeAccount = TRADITIONAL_DEFAULT_NODE_ACCOUNT;
 	private List<NodeConfig> nodes;
 
 	public String getDefaultPayer() {

--- a/test-clients/yahcli/README.md
+++ b/test-clients/yahcli/README.md
@@ -1,4 +1,4 @@
-# Yahcli v0.1.5
+# Yahcli v0.1.7
 Yahcli (_Yet Another Hedera Command Line Interface_) supports DevOps
 actions against the Hedera networks listed in a _config.yml_ file.
 
@@ -64,7 +64,7 @@ use with that network. :guard: &nbsp; If there is no corresponding
 `account{num}.pass` for a PEM file, please be ready to enter 
 the passphrase interactively in the console. For example,
 ```
-$ docker run -it -v $(pwd):/launch yahcli:0.1.5 -p 2 sysfiles download all 
+$ docker run -it -v $(pwd):/launch yahcli:0.1.7 -p 2 sysfiles download all 
 Targeting localhost, paying with 0.0.2
 Please enter the passphrase for key file localhost/keys/account2.pem: 
 ```
@@ -82,7 +82,7 @@ Note that yahcli does not support multi-sig accounts.
 
 To list all available commands,
 ```
-$ docker run -it -v $(pwd):/launch gcr.io/hedera-registry/yahcli:0.1.5 help
+$ docker run -it -v $(pwd):/launch gcr.io/hedera-registry/yahcli:0.1.7 help
 ``` 
 
 :information_desk_person: &nbsp; Since the only key we have for previewnet
@@ -91,7 +91,7 @@ when running against this network.
 
 To download the fee schedules from previewnet given the config above, we run,
 ```
-$ docker run -it -v $(pwd):/launch gcr.io/hedera-registry/yahcli:0.1.5 -p 2 -n previewnet sysfiles download fees
+$ docker run -it -v $(pwd):/launch gcr.io/hedera-registry/yahcli:0.1.7 -p 2 -n previewnet sysfiles download fees
 Targeting previewnet, paying with 0.0.2
 Downloading the fees...OK
 $ ls previewnet/sysfiles/
@@ -102,14 +102,14 @@ The fee schedules were downloaded in JSON form to _previewnet/sysfiles/feeSchedu
 To see more options for the `download` subcommand (including a custom download directory), 
 we run,
 ```
-$ docker run -it -v $(pwd):/launch gcr.io/hedera-registry/yahcli:0.1.5 sysfiles download help
+$ docker run -it -v $(pwd):/launch gcr.io/hedera-registry/yahcli:0.1.7 sysfiles download help
 ```
 
 The remaining sections of this document focus on specific use cases.
 
 # Getting account balances
 ```
-$ docker run -it -v $(pwd):/launch gcr.io/hedera-registry/yahcli:0.1.5 -n previewnet -p 2 accounts balance 56 50
+$ docker run -it -v $(pwd):/launch gcr.io/hedera-registry/yahcli:0.1.7 -n previewnet -p 2 accounts balance 56 50
 ```
 
 # Updating system files
@@ -134,7 +134,7 @@ localhost
 
 We first download the existing address book,
 ```
-$ docker run -it -v $(pwd):/launch gcr.io/hedera-registry/yahcli:0.1.5 -n localhost -p 2 sysfiles download address-book
+$ docker run -it -v $(pwd):/launch gcr.io/hedera-registry/yahcli:0.1.7 -n localhost -p 2 sysfiles download address-book
 Targeting localhost, paying with 0.0.2
 Downloading the address-book...OK
 ```
@@ -167,12 +167,12 @@ files, respectively.
 
 And now we upload the new address book, this time using the address book admin `0.0.55` as the payer:
 ```
-$ docker run -it -v $(pwd):/launch gcr.io/hedera-registry/yahcli:0.1.5 -n localhost -p 55 sysfiles upload address-book
+$ docker run -it -v $(pwd):/launch gcr.io/hedera-registry/yahcli:0.1.7 -n localhost -p 55 sysfiles upload address-book
 ```
 
 Finally we re-download the book to see that the hex-encoded cert hash and RSA public key were uploaded as expected:
 ```
-$ docker run -it -v $(pwd):/launch gcr.io/hedera-registry/yahcli:0.1.5 -n localhost -p 2 sysfiles download address-book
+$ docker run -it -v $(pwd):/launch gcr.io/hedera-registry/yahcli:0.1.7 -n localhost -p 2 sysfiles download address-book
 Targeting localhost, paying with 0.0.2
 Downloading the address-book...OK
 $ tail -17 localhost/sysfiles/addressBook.json 
@@ -182,7 +182,7 @@ $ tail -17 localhost/sysfiles/addressBook.json
     "deprecatedPortNo" : 50207,
     "nodeId" : 3,
     "certHash" : "0ae05bde15d216781a40e7bce5303bf68926f9440eec3cb20fabe9df06b0091a205fdea86911facb4e51e46c3890c803",
-    "rsaPubKey" : "36363038393964383435373539336535373965653638613332633036303365353939366661626135303864393434383063336562363464636135383738353264613338303537303239336365353365643939326664653438353332346361623564333535653734383133343935346231396332316333663038633631613165356439653335303163343332343539376563346465386464353838666662666464346135663336343662623763353938306362643231646436343031613763393131336631636533313864636134616635373732323462646538396332633137336633666538643039326534623866383030373130376138643965323633333166353335356135383464383037373661306162636139326530303438646433373163666530353936656464366261303737303338313432383866313039613832383035383630363562376262663238353432303434376134343336383830633361393336613666666663646162313031353335633864666561306461306537353035383530346661396163333036396438653166643762623333343530663761346261303439310a",
+    "rsaPubKey" : "363630383939643834353735393365353739656536386133326330363033653539393666616261353038643934343830633365623634646361353837383532646133383035373032393363653533656439393266646534383533323463616235643335356537343831333439353462313963323163336630386336316131653564396533353031633433323435393765633464653864643538386666626664643461356633363436626237633539383063626432316464363430316137633931313366316365333138646361346166353737323234626465383963326331373366336665386430393265346238663830303731303761386439653236333331663533353561353834643830373736613061626361393265303034386464333731636665303539366564643662613037373033383134323838663130396138323830353836303635623762626632383534323034343761343433363838306333613933366136666666636461623130.1.73335633864666561306461306537353035383530346661396163333036396438653166643762623333343530663761346261303439310a",
     "nodeAccount" : "0.0.6",
     "endpoints" : [ {
       "ipAddressV4" : "127.0.0.1",
@@ -212,7 +212,7 @@ values. Suppose we try to update the address book again, changing the
 We then get a messy error and the update aborts before sending
 any `FileUpdate` transaction to the network:
 ```
-$ docker run -it -v $(pwd):/launch gcr.io/hedera-registry/yahcli:0.1.5 -n localhost -p 55 sysfiles upload address-book
+$ docker run -it -v $(pwd):/launch gcr.io/hedera-registry/yahcli:0.1.7 -n localhost -p 55 sysfiles upload address-book
 Targeting localhost, paying with 0.0.55
 java.lang.IllegalStateException: Deprecated memo field cannot be set to 'This node is the best!'
 	at com.hedera.services.bdd.suites.utils.sysfiles.serdes.AddrBkJsonToGrpcBytes.toValidatedRawFile(AddrBkJsonToGrpcBytes.java:70)
@@ -241,9 +241,9 @@ localhost/sysfiles/
 
 Then proceed as with any other `sysfiles upload` command, 
 ```
-$ docker run -it -v $(pwd):/launch gcr.io/hedera-registry/yahcli:0.1.5 -n localhost -p 58 sysfiles upload software-zip
+$ docker run -it -v $(pwd):/launch gcr.io/hedera-registry/yahcli:0.1.7 -n localhost -p 58 sysfiles upload software-zip
 ...
-$ docker run -it -v $(pwd):/launch gcr.io/hedera-registry/yahcli:0.1.5 -n localhost -p 58 sysfiles upload telemetry-zip
+$ docker run -it -v $(pwd):/launch gcr.io/hedera-registry/yahcli:0.1.7 -n localhost -p 58 sysfiles upload telemetry-zip
 ...
 ```
 
@@ -254,7 +254,7 @@ $ docker run -it -v $(pwd):/launch gcr.io/hedera-registry/yahcli:0.1.5 -n localh
 Services will be validated by type; to see all supported options, run,
 
 ```
-$ docker run -it -v $(pwd):/launch gcr.io/hedera-registry/yahcli:0.1.5 -n localhost -p 2 validate help
+$ docker run -it -v $(pwd):/launch gcr.io/hedera-registry/yahcli:0.1.7 -n localhost -p 2 validate help
 ```
 
 # Preparing an NMT software upgrade
@@ -265,7 +265,7 @@ SHA-384 hash of this ZIP must be given so the nodes can validate the integrity o
 staging its artifacts for NMT to use. This looks like,
 
 ```
-$ docker run -it -v $(pwd):/launch gcr.io/hedera-registry/yahcli:0.1.5 -n localhost -p 58 prepare-upgrade \
+$ docker run -it -v $(pwd):/launch gcr.io/hedera-registry/yahcli:0.1.7 -n localhost -p 58 prepare-upgrade \
 > --upgrade-zip-hash 5d3b0e619d8513dfbf606ef00a2e83ba97d736f5f5ba61561d895ea83a6d4c34fce05d6cd74c83ec171f710e37e12aab
 ```
 
@@ -277,7 +277,7 @@ SHA-384 hash of this ZIP must be known so the nodes can validate the integrity o
 staging its artifacts for NMT to use.  This looks like,
 
 ```
-$ docker run -it -v $(pwd):/launch gcr.io/hedera-registry/yahcli:0.1.5 -n localhost -p 58 upgrade-telemetry \
+$ docker run -it -v $(pwd):/launch gcr.io/hedera-registry/yahcli:0.1.7 -n localhost -p 58 upgrade-telemetry \
 > --upgrade-zip-hash 8ec75ab44b6c8ccac4a6e7f7d77b5a66280cad8d8a86ed961975a3bea597613f83af9075f65786bf9101d50047ca768f \
 > --start-time 2022-01-01.00:00:00
 ```
@@ -290,21 +290,21 @@ software upgrade.
 
 A vanilla freeze with no NMT upgrade only includes the start time, 
 ```
-$ docker run -it -v $(pwd):/launch gcr.io/hedera-registry/yahcli:0.1.5 -n localhost -p 58 freeze \
+$ docker run -it -v $(pwd):/launch gcr.io/hedera-registry/yahcli:0.1.7 -n localhost -p 58 freeze \
 > --start-time 2022-01-01.00:00:00
 ```
 
 While a freeze that should trigger a staged NMT upgrade uses the `freeze-upgrade` variant,
 which **must** repeat the hash of the intended update, 
 ```
-$ docker run -it -v $(pwd):/launch gcr.io/hedera-registry/yahcli:0.1.5 -n localhost -p 58 freeze-upgrade \
+$ docker run -it -v $(pwd):/launch gcr.io/hedera-registry/yahcli:0.1.7 -n localhost -p 58 freeze-upgrade \
 > --upgrade-zip-hash 5d3b0e619d8513dfbf606ef00a2e83ba97d736f5f5ba61561d895ea83a6d4c34fce05d6cd74c83ec171f710e37e12aab
 > --start-time 2021-09-09.20:11:13 
 ```
 
 To abort a scheduled freeze, simply use the `freeze-abort` command,
 ```
-$ docker run -it -v $(pwd):/launch gcr.io/hedera-registry/yahcli:0.1.5 -n localhost -p 58 freeze-abort 
+$ docker run -it -v $(pwd):/launch gcr.io/hedera-registry/yahcli:0.1.7 -n localhost -p 58 freeze-abort 
 ```
 
 # Updating account keys
@@ -314,7 +314,7 @@ can be either PEM files or BIP-39 mnemonics.)
 
 Our first example uses a randomly generated new key,
 ```
-$ docker run -it -v $(pwd):/launch gcr.io/hedera-registry/yahcli:0.1.5 -p 2 -n localhost \
+$ docker run -it -v $(pwd):/launch gcr.io/hedera-registry/yahcli:0.1.7 -p 2 -n localhost \
 > accounts rekey --gen-new-key 57
 Targeting localhost, paying with 0.0.2
 .i. Exported a newly generated key in PEM format to localhost/keys/account57.pem
@@ -336,7 +336,7 @@ localhost/keys
 
 For the next example, we specify an existing PEM file, and enter its passphrase when prompted,
 ```
-$ docker run -it -v $(pwd):/launch gcr.io/hedera-registry/yahcli:0.1.5 -p 57 -n localhost \
+$ docker run -it -v $(pwd):/launch gcr.io/hedera-registry/yahcli:0.1.7 -p 57 -n localhost \
 > accounts rekey -k new-account57.pem 57
 Targeting localhost, paying with 0.0.2
 Please enter the passphrase for key file new-account55.pem: 
@@ -348,7 +348,7 @@ In our final example, we replace the `0.0.57` key from a mnemonic,
 ```
 $ cat new-account57.words
 goddess maze eternal small normal october ... author
-$ docker run -it -v $(pwd):/launch gcr.io/hedera-registry/yahcli:0.1.5 -p 57 -n localhost \
+$ docker run -it -v $(pwd):/launch gcr.io/hedera-registry/yahcli:0.1.7 -p 57 -n localhost \
 > accounts rekey -k new-account57.words 57
 Targeting localhost, paying with 0.0.2
 .i. Exported key from new-account55 to localhost/keys/account57.pem

--- a/test-clients/yahcli/README.md
+++ b/test-clients/yahcli/README.md
@@ -44,7 +44,11 @@ networks:
 ```
 
 We can add details for multiple networks to this config file; for example,
-we could add information about stabletestnet.
+we can add information about the stable testnet. And we can override the 
+default payer account or default node account for any network using the 
+`defaultPayer` and `defaultNodeAccount` fields, respectively. (Where we 
+have the command line option `-p` to override `defaultPayer`, and the 
+command line option `-a` to override `defaultNodeAccount`.)
 ```
 defaultNetwork: previewnet
 
@@ -53,6 +57,8 @@ networks:
     nodes:
       - { id: 0, account: 3, ipv4Addr: 35.231.208.148 }
   stabletestnet:
+    defaultPayer: 50
+    defaultNodeAccount: 4
     nodes:
       - { id: 0, account: 3, ipv4Addr: 34.94.106.61 }
       - { id: 1, account: 4, ipv4Addr: 35.237.119.55 }

--- a/test-clients/yahcli/config.yml
+++ b/test-clients/yahcli/config.yml
@@ -6,6 +6,7 @@ networks:
   previewnet:
     nodes:
       - { id: 0, account: 3, ipv4Addr: 35.231.208.148 }
+      - { id: 1, account: 4, ipv4Addr: 35.199.15.177 }
   stabletestnet:
     nodes:
       - { id: 0, account: 3, ipv4Addr: 34.94.106.61 }

--- a/test-clients/yahcli/run/build.sh
+++ b/test-clients/yahcli/run/build.sh
@@ -1,5 +1,5 @@
 #! /bin/sh
-TAG=${1:-'0.1.6'}
+TAG=${1:-'0.1.7'}
 
 cd ..
 mvn clean compile assembly:single@yahcli-jar


### PR DESCRIPTION
**Related issues**
 - Closes #2511 

**Description**:
- Make `defaultNodeAccount` take effect; also provide `-a/--node-account` options to override the target node account.
- Update yahcli _README_, reference tag `0.1.7`.
- Add a step to _.circleci/config.yml_ to ensure `run-continuous-integration-gcp` fails if an EET fails.