### PR TITLE
Fix contract payer balance edge case

### DIFF
--- a/hedera-node/src/main/java/com/hedera/services/contracts/execution/EvmTxProcessor.java
+++ b/hedera-node/src/main/java/com/hedera/services/contracts/execution/EvmTxProcessor.java
@@ -161,7 +161,7 @@ abstract class EvmTxProcessor {
 		final var updater = worldState.updater();
 		final var senderEvmAddress = sender.getId().asEvmAddress();
 		final var senderAccount = updater.getOrCreateSenderAccount(senderEvmAddress);
-		final MutableAccount mutableSender = updater.getOrCreateSenderAccount(senderEvmAddress).getMutable();
+		final MutableAccount mutableSender = senderAccount.getMutable();
 
 		if (!isStatic) {
 			validateFalse(upfrontCost.compareTo(mutableSender.getBalance()) > 0, INSUFFICIENT_PAYER_BALANCE);

--- a/hedera-node/src/main/java/com/hedera/services/contracts/execution/EvmTxProcessor.java
+++ b/hedera-node/src/main/java/com/hedera/services/contracts/execution/EvmTxProcessor.java
@@ -31,7 +31,6 @@ import com.hedera.services.store.models.Account;
 import com.hedera.services.store.models.Id;
 import com.hederahashgraph.api.proto.java.FeeData;
 import com.hederahashgraph.api.proto.java.HederaFunctionality;
-import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
 import com.hederahashgraph.api.proto.java.Timestamp;
 import com.hederahashgraph.fee.FeeBuilder;
 import org.apache.tuweni.bytes.Bytes;
@@ -65,6 +64,7 @@ import java.util.Set;
 
 import static com.hedera.services.exceptions.ValidationUtils.validateFalse;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INSUFFICIENT_GAS;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INSUFFICIENT_PAYER_BALANCE;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.MAX_GAS_LIMIT_EXCEEDED;
 import static org.hyperledger.besu.evm.MainnetEVMs.registerLondonOperations;
 
@@ -157,11 +157,13 @@ abstract class EvmTxProcessor {
 		final Wei upfrontCost = gasCost.add(value);
 		final Gas intrinsicGas =
 				gasCalculator.transactionIntrinsicGasCost(Bytes.EMPTY, contractCreation);
+
 		final var updater = worldState.updater();
+		final var senderEvmAddress = sender.getId().asEvmAddress();
+		final MutableAccount mutableSender = updater.getOrCreateSenderAccount(senderEvmAddress).getMutable();
 
 		if (!isStatic) {
-			validateFalse(upfrontCost.compareTo(Wei.of(sender.getBalance())) > 0,
-					ResponseCodeEnum.INSUFFICIENT_PAYER_BALANCE);
+			validateFalse(upfrontCost.compareTo(mutableSender.getBalance()) > 0, INSUFFICIENT_PAYER_BALANCE);
 			if (intrinsicGas.toLong() > gasLimit) {
 				throw new InvalidTransactionException(
 						gasLimit < dynamicProperties.maxGas()
@@ -171,10 +173,7 @@ abstract class EvmTxProcessor {
 		}
 
 		final Address coinbase = Id.fromGrpcAccount(dynamicProperties.fundingAccount()).asEvmAddress();
-		final HederaBlockValues blockValues = new HederaBlockValues(gasLimit,
-				consensusTime.getEpochSecond());
-		Address senderEvmAddress = sender.getId().asEvmAddress();
-		final MutableAccount mutableSender = updater.getOrCreateSenderAccount(senderEvmAddress).getMutable();
+		final HederaBlockValues blockValues = new HederaBlockValues(gasLimit, consensusTime.getEpochSecond());
 		if (!isStatic) {
 			mutableSender.decrementBalance(gasCost);
 		}

--- a/hedera-node/src/main/java/com/hedera/services/contracts/execution/EvmTxProcessor.java
+++ b/hedera-node/src/main/java/com/hedera/services/contracts/execution/EvmTxProcessor.java
@@ -160,6 +160,7 @@ abstract class EvmTxProcessor {
 
 		final var updater = worldState.updater();
 		final var senderEvmAddress = sender.getId().asEvmAddress();
+		final var senderAccount = updater.getOrCreateSenderAccount(senderEvmAddress);
 		final MutableAccount mutableSender = updater.getOrCreateSenderAccount(senderEvmAddress).getMutable();
 
 		if (!isStatic) {

--- a/hedera-node/src/main/java/com/hedera/services/store/contracts/HederaWorldState.java
+++ b/hedera-node/src/main/java/com/hedera/services/store/contracts/HederaWorldState.java
@@ -188,7 +188,6 @@ public class HederaWorldState implements HederaMutableWorldState {
 	}
 
 	public class WorldStateAccount implements Account {
-
 		private final Wei balance;
 		private final Address address;
 

--- a/hedera-node/src/test/java/com/hedera/services/contracts/execution/CallLocalEvmTxProcessorTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/contracts/execution/CallLocalEvmTxProcessorTest.java
@@ -23,7 +23,6 @@ package com.hedera.services.contracts.execution;
  */
 
 import com.hedera.services.context.properties.GlobalDynamicProperties;
-import com.hedera.services.exceptions.InvalidTransactionException;
 import com.hedera.services.fees.HbarCentExchange;
 import com.hedera.services.fees.calculation.UsagePricesProvider;
 import com.hedera.services.store.contracts.HederaWorldState;
@@ -58,7 +57,6 @@ import java.util.Optional;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
@@ -67,7 +65,6 @@ import static org.mockito.Mockito.mock;
 
 @ExtendWith(MockitoExtension.class)
 class CallLocalEvmTxProcessorTest {
-
 	private static final int MAX_STACK_SIZE = 1024;
 
 	@Mock
@@ -101,17 +98,6 @@ class CallLocalEvmTxProcessorTest {
 
 		callLocalEvmTxProcessor = new CallLocalEvmTxProcessor(worldState, hbarCentExchange, usagePricesProvider,
 				globalDynamicProperties, gasCalculator, operations);
-	}
-
-	@Test
-	void assertThatExecuteMethodThrowsInvalidTransactionException() {
-		var consensusTime = Instant.ofEpochSecond(1631778674L);
-
-		//expect:
-		Address receiver = this.receiver.getId().asEvmAddress();
-		assertThrows(InvalidTransactionException.class, () ->
-				callLocalEvmTxProcessor.execute(sender, receiver, 1234L, 1_000_000, 15,
-						Bytes.EMPTY, false, consensusTime, false, Optional.empty()));
 	}
 
 	@Test

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/ContractCreateSuite.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/ContractCreateSuite.java
@@ -93,7 +93,7 @@ public class ContractCreateSuite extends HapiApiSuite {
 						createsVanillaContractAsExpectedWithOmittedAdminKey(),
 						childCreationsHaveExpectedKeysWithOmittedAdminKey(),
 						cannotCreateTooLargeContract(),
-						getsInsufficientPayerBalanceIfSendingAccountJustInsolventAfterPayingFees(),
+						getsInsufficientPayerBalanceIfSendingAccountCanPayEverythingButServiceFee(),
 				}
 		);
 	}
@@ -276,7 +276,7 @@ public class ContractCreateSuite extends HapiApiSuite {
 				);
 	}
 
-	private HapiApiSpec getsInsufficientPayerBalanceIfSendingAccountJustInsolventAfterPayingFees() {
+	private HapiApiSpec getsInsufficientPayerBalanceIfSendingAccountCanPayEverythingButServiceFee() {
 		final var initcode = "initcode";
 		final var firstContract = "firstContract";
 		final var secondContract = "secondContract";
@@ -284,7 +284,7 @@ public class ContractCreateSuite extends HapiApiSuite {
 		final var creation = "creation";
 		final AtomicLong baseCreationFee = new AtomicLong();
 
-		return defaultHapiSpec("GetsInsufficientPayerBalanceIfSendingAccountJustInsolventAfterPayingFees")
+		return defaultHapiSpec("GetsInsufficientPayerBalanceIfSendingAccountCanPayEverythingButServiceFee")
 				.given(
 						cryptoCreate(civilian).balance(ONE_HUNDRED_HBARS),
 						fileCreate(initcode)
@@ -300,7 +300,7 @@ public class ContractCreateSuite extends HapiApiSuite {
 				).then(
 						sourcing(() -> contractCreate(secondContract)
 								.bytecode(initcode)
-								.gas(300_000L)
+								.gas(100_000L)
 								.payingWith(civilian)
 								.balance(ONE_HUNDRED_HBARS - 2 * baseCreationFee.get()))
 				);


### PR DESCRIPTION
**Description**:
- Instead of checking payer balance in `EvmTxProcessor` using a model object from the `AccountStore` (which will not reflect fees _already charged to the account_), [uses an `EvmAccount` from the `WorldState.updater()`](https://github.com/hashgraph/hedera-services/blob/02490-M-FixContractPayerBalanceEdgeCase/hedera-node/src/main/java/com/hedera/services/contracts/execution/EvmTxProcessor.java#L163).
    * Since `WorldStateAccount`s are sourced from the `HederLedger`, they reflect fees already charged.

**Related issue(s)**:
- Fixes #2490 
