### PR TITLE
Make `ledger.rollback()` the default on a process failure

### DIFF
--- a/hedera-node/src/main/java/com/hedera/services/state/logic/ServicesTxnManager.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/logic/ServicesTxnManager.java
@@ -66,11 +66,10 @@ public class ServicesTxnManager {
 		this.scopedTriggeredProcessing = scopedTriggeredProcessing;
 	}
 
-	private boolean processFailed;
 	private boolean createdStreamableRecord;
 
 	public void process(TxnAccessor accessor, Instant consensusTime, long submittingMember) {
-		processFailed = false;
+		var processFailed = false;
 		createdStreamableRecord = false;
 
 		try {

--- a/hedera-node/src/main/java/com/hedera/services/txns/TransitionRunner.java
+++ b/hedera-node/src/main/java/com/hedera/services/txns/TransitionRunner.java
@@ -122,10 +122,10 @@ public class TransitionRunner {
 					log.warn("Avoidable failure in transition logic for {}", accessor.getSignedTxnWrapper(), ite);
 				}
 				logic.get().reclaimCreatedIds();
-			} catch (Exception e) {
+			} catch (Exception processFailure) {
 				logic.get().reclaimCreatedIds();
 
-				throw e;
+				throw processFailure;
 			}
 			return true;
 		}

--- a/hedera-node/src/test/java/com/hedera/services/state/logic/ServicesTxnManagerTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/state/logic/ServicesTxnManagerTest.java
@@ -141,8 +141,8 @@ class ServicesTxnManagerTest {
 		// then:
 		inOrder.verify(ledger).begin();
 		inOrder.verify(txnCtx).setStatus(ResponseCodeEnum.FAIL_INVALID);
-		inOrder.verify(ledger).commit();
-		inOrder.verify(recordStreaming).run();
+		inOrder.verify(ledger).rollback();
+		inOrder.verify(recordStreaming, never()).run();
 		// and:
 		assertThat(logCaptor.errorLogs(), contains(
 				Matchers.startsWith("Possibly CATASTROPHIC failure in txn processing")));


### PR DESCRIPTION
**Description**:
 - Makes `ServicesTxnManager.process()` react to an internal `Exception` in a way that is logically consistent with the `TransitionRunner` reclaiming of all created ids.
 - That is, on a process failure, calls `ledger.rollback()` instead of attempting `ledger.commit()` to collect fees.

**Related issue(s)**:
- Fixes #2492
