### PR TITLE
Avoid redundant signature expansions

### DIFF
--- a/hedera-node/src/main/java/com/hedera/services/legacy/core/jproto/JEd25519Key.java
+++ b/hedera-node/src/main/java/com/hedera/services/legacy/core/jproto/JEd25519Key.java
@@ -22,6 +22,9 @@ package com.hedera.services.legacy.core.jproto;
 
 import com.swirlds.common.CommonUtils;
 
+import java.util.Arrays;
+import java.util.Objects;
+
 /**
  * Maps to proto Key of type ed25519.
  */
@@ -64,5 +67,22 @@ public class JEd25519Key extends JKey {
 				return true;
 			}
 		}
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (o == this) {
+			return true;
+		}
+		if (o == null || JEd25519Key.class != o.getClass()) {
+			return false;
+		}
+		final var that = (JEd25519Key) o;
+		return Arrays.equals(this.ed25519, that.ed25519);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(Arrays.hashCode(ed25519));
 	}
 }

--- a/hedera-node/src/main/java/com/hedera/services/legacy/core/jproto/JEd25519Key.java
+++ b/hedera-node/src/main/java/com/hedera/services/legacy/core/jproto/JEd25519Key.java
@@ -83,6 +83,6 @@ public class JEd25519Key extends JKey {
 
 	@Override
 	public int hashCode() {
-		return Objects.hash(Arrays.hashCode(ed25519));
+		return Objects.hash(ed25519);
 	}
 }

--- a/hedera-node/src/main/java/com/hedera/services/legacy/core/jproto/JEd25519Key.java
+++ b/hedera-node/src/main/java/com/hedera/services/legacy/core/jproto/JEd25519Key.java
@@ -23,7 +23,6 @@ package com.hedera.services.legacy.core.jproto;
 import com.swirlds.common.CommonUtils;
 
 import java.util.Arrays;
-import java.util.Objects;
 
 /**
  * Maps to proto Key of type ed25519.
@@ -83,6 +82,6 @@ public class JEd25519Key extends JKey {
 
 	@Override
 	public int hashCode() {
-		return Objects.hash(ed25519);
+		return Arrays.hashCode(ed25519);
 	}
 }

--- a/hedera-node/src/main/java/com/hedera/services/sigs/order/SigRequirements.java
+++ b/hedera-node/src/main/java/com/hedera/services/sigs/order/SigRequirements.java
@@ -68,7 +68,6 @@ import static com.hedera.services.sigs.order.KeyOrderingFailure.MISSING_ACCOUNT;
 import static com.hedera.services.sigs.order.KeyOrderingFailure.MISSING_AUTORENEW_ACCOUNT;
 import static com.hedera.services.sigs.order.KeyOrderingFailure.MISSING_TOKEN;
 import static com.hedera.services.sigs.order.KeyOrderingFailure.NONE;
-import static com.hedera.services.state.submerkle.EntityId.MISSING_ENTITY_ID;
 import static com.hedera.services.utils.MiscUtils.asUsableFcKey;
 import static java.util.Collections.EMPTY_LIST;
 
@@ -84,8 +83,6 @@ public class SigRequirements {
 	private final SignatureWaivers signatureWaivers;
 	private final SigMetadataLookup sigMetaLookup;
 	private final GlobalDynamicProperties properties;
-
-	private static AccountID payer = MISSING_ENTITY_ID.toGrpcAccountId();
 
 	public SigRequirements(
 			SigMetadataLookup sigMetaLookup,
@@ -127,7 +124,6 @@ public class SigRequirements {
 	 * @return a {@link SigningOrderResult} summarizing the listing attempt
 	 */
 	public <T> SigningOrderResult<T> keysForOtherParties(TransactionBody txn, SigningOrderResultFactory<T> factory) {
-		payer = txn.getTransactionID().getAccountID();
 		final var cryptoOrder = forCrypto(txn, factory);
 		if (cryptoOrder != null) {
 			return cryptoOrder;
@@ -156,8 +152,8 @@ public class SigRequirements {
 	}
 
 	private <T> SigningOrderResult<T> orderForPayer(TransactionBody txn, SigningOrderResultFactory<T> factory) {
-		var payer = txn.getTransactionID().getAccountID();
-		var result = sigMetaLookup.accountSigningMetaFor(payer);
+		final var payer = txn.getTransactionID().getAccountID();
+		final var result = sigMetaLookup.accountSigningMetaFor(payer);
 		if (result.succeeded()) {
 			return factory.forValidOrder(List.of(result.metadata().getKey()));
 		} else {
@@ -182,22 +178,24 @@ public class SigRequirements {
 	}
 
 	private <T> SigningOrderResult<T> forCrypto(TransactionBody txn, SigningOrderResultFactory<T> factory) {
+		final var payer = txn.getTransactionID().getAccountID();
 		if (txn.hasCryptoCreateAccount()) {
 			return cryptoCreate(txn.getCryptoCreateAccount(), factory);
 		} else if (txn.hasCryptoTransfer()) {
-			return cryptoTransfer(txn.getCryptoTransfer(), factory);
+			return cryptoTransfer(payer, txn.getCryptoTransfer(), factory);
 		} else if (txn.hasCryptoUpdateAccount()) {
-			return cryptoUpdate(txn, factory);
+			return cryptoUpdate(payer, txn, factory);
 		} else if (txn.hasCryptoDelete()) {
-			return cryptoDelete(txn.getCryptoDelete(), factory);
+			return cryptoDelete(payer, txn.getCryptoDelete(), factory);
 		} else {
 			return null;
 		}
 	}
 
 	private <T> SigningOrderResult<T> forSchedule(TransactionBody txn, SigningOrderResultFactory<T> factory) {
+		final var payer = txn.getTransactionID().getAccountID();
 		if (txn.hasScheduleCreate()) {
-			return scheduleCreate(txn.getScheduleCreate(), factory);
+			return scheduleCreate(payer, txn.getScheduleCreate(), factory);
 		} else if (txn.hasScheduleSign()) {
 			return scheduleSign(txn.getScheduleSign().getScheduleID(), factory);
 		} else if (txn.hasScheduleDelete()) {
@@ -208,12 +206,13 @@ public class SigRequirements {
 	}
 
 	private <T> SigningOrderResult<T> forToken(TransactionBody txn, SigningOrderResultFactory<T> factory) {
+		final var payer = txn.getTransactionID().getAccountID();
 		if (txn.hasTokenCreation()) {
-			return tokenCreate(txn.getTokenCreation(), factory);
+			return tokenCreate(payer, txn.getTokenCreation(), factory);
 		} else if (txn.hasTokenAssociate()) {
-			return tokenAssociate(txn.getTokenAssociate(), factory);
+			return tokenAssociate(payer, txn.getTokenAssociate(), factory);
 		} else if (txn.hasTokenDissociate()) {
-			return tokenDissociate(txn.getTokenDissociate(), factory);
+			return tokenDissociate(payer, txn.getTokenDissociate(), factory);
 		} else if (txn.hasTokenFreeze()) {
 			return tokenFreezing(txn.getTokenFreeze().getToken(), factory);
 		} else if (txn.hasTokenUnfreeze()) {
@@ -231,9 +230,9 @@ public class SigRequirements {
 		} else if (txn.hasTokenDeletion()) {
 			return tokenMutates(txn.getTokenDeletion().getToken(), factory);
 		} else if (txn.hasTokenUpdate()) {
-			return tokenUpdates(txn.getTokenUpdate(), factory);
+			return tokenUpdates(payer, txn.getTokenUpdate(), factory);
 		} else if (txn.hasTokenFeeScheduleUpdate()) {
-			return tokenFeeScheduleUpdates(txn.getTokenFeeScheduleUpdate(), factory);
+			return tokenFeeScheduleUpdates(payer, txn.getTokenFeeScheduleUpdate(), factory);
 		} else if (txn.hasTokenPause()) {
 			return tokenPausing(txn.getTokenPause().getToken(), factory);
 		} else if (txn.hasTokenUnpause()) {
@@ -258,12 +257,13 @@ public class SigRequirements {
 	}
 
 	private <T> SigningOrderResult<T> forConsensus(TransactionBody txn, SigningOrderResultFactory<T> factory) {
+		final var payer = txn.getTransactionID().getAccountID();
 		if (txn.hasConsensusCreateTopic()) {
-			return topicCreate(txn.getConsensusCreateTopic(), factory);
+			return topicCreate(payer, txn.getConsensusCreateTopic(), factory);
 		} else if (txn.hasConsensusSubmitMessage()) {
 			return messageSubmit(txn.getConsensusSubmitMessage(), factory);
 		} else if (txn.hasConsensusUpdateTopic()) {
-			return topicUpdate(txn.getConsensusUpdateTopic(), factory);
+			return topicUpdate(payer, txn.getConsensusUpdateTopic(), factory);
 		} else if (txn.hasConsensusDeleteTopic()) {
 			return topicDelete(txn.getConsensusDeleteTopic(), factory);
 		} else {
@@ -423,13 +423,14 @@ public class SigRequirements {
 	}
 
 	private <T> SigningOrderResult<T> cryptoDelete(
+			AccountID payer,
 			CryptoDeleteTransactionBody op,
 			SigningOrderResultFactory<T> factory
 	) {
 		List<JKey> required = EMPTY_LIST;
 
 		var target = op.getDeleteAccountID();
-		if (!doesMatchPayer(target)) {
+		if (!payer.equals(target)) {
 			var targetResult = sigMetaLookup.accountSigningMetaFor(target);
 			if (!targetResult.succeeded()) {
 				return accountFailure(targetResult.failureIfAny(), factory);
@@ -439,7 +440,7 @@ public class SigRequirements {
 		}
 
 		var beneficiary = op.getTransferAccountID();
-		if (!doesMatchPayer(beneficiary)) {
+		if (!payer.equals(beneficiary)) {
 			var beneficiaryResult = sigMetaLookup.accountSigningMetaFor(beneficiary);
 			if (!beneficiaryResult.succeeded()) {
 				return accountFailure(beneficiaryResult.failureIfAny(), factory);
@@ -453,6 +454,7 @@ public class SigRequirements {
 	}
 
 	private <T> SigningOrderResult<T> cryptoUpdate(
+			AccountID payer,
 			TransactionBody cryptoUpdateTxn,
 			SigningOrderResultFactory<T> factory
 	) {
@@ -465,7 +467,7 @@ public class SigRequirements {
 		if (!result.succeeded()) {
 			return accountFailure(result.failureIfAny(), factory);
 		} else {
-			if (targetAccountKeyMustSign && !doesMatchPayer(target)) {
+			if (targetAccountKeyMustSign && !payer.equals(target)) {
 				required = mutable(required);
 				required.add(result.metadata().getKey());
 			}
@@ -480,6 +482,7 @@ public class SigRequirements {
 	}
 
 	private <T> SigningOrderResult<T> cryptoTransfer(
+			AccountID payer,
 			CryptoTransferTransactionBody op,
 			SigningOrderResultFactory<T> factory) {
 		List<JKey> required = new ArrayList<>();
@@ -487,24 +490,24 @@ public class SigRequirements {
 		KeyOrderingFailure failure;
 		for (TokenTransferList xfers : op.getTokenTransfersList()) {
 			for (AccountAmount adjust : xfers.getTransfersList()) {
-				if ((failure = includeIfNecessary(adjust, required)) != NONE) {
+				if ((failure = includeIfNecessary(payer, adjust, required)) != NONE) {
 					return accountFailure(failure, factory);
 				}
 			}
 			final var token = xfers.getToken();
 			for (NftTransfer adjust : xfers.getNftTransfersList()) {
 				final var sender = adjust.getSenderAccountID();
-				if ((failure = nftIncludeIfNecessary(sender, null, required, token, op)) != NONE) {
+				if ((failure = nftIncludeIfNecessary(payer, sender, null, required, token, op)) != NONE) {
 					return accountFailure(failure, factory);
 				}
 				final var receiver = adjust.getReceiverAccountID();
-				if ((failure = nftIncludeIfNecessary(receiver, sender, required, token, op)) != NONE) {
+				if ((failure = nftIncludeIfNecessary(payer, receiver, sender, required, token, op)) != NONE) {
 					return (failure == MISSING_TOKEN) ? factory.forMissingToken() : accountFailure(failure, factory);
 				}
 			}
 		}
 		for (AccountAmount adjust : op.getTransfers().getAccountAmountsList()) {
-			if ((failure = includeIfNecessary(adjust, required)) != NONE) {
+			if ((failure = includeIfNecessary(payer, adjust, required)) != NONE) {
 				return accountFailure(failure, factory);
 			}
 		}
@@ -561,6 +564,7 @@ public class SigRequirements {
 	}
 
 	private <T> SigningOrderResult<T> topicCreate(
+			AccountID payer,
 			ConsensusCreateTopicTransactionBody op,
 			SigningOrderResultFactory<T> factory
 	) {
@@ -572,6 +576,7 @@ public class SigRequirements {
 				ConsensusCreateTopicTransactionBody::getAdminKey,
 				required);
 		if (!addAccount(
+				payer,
 				op,
 				ConsensusCreateTopicTransactionBody::hasAutoRenewAccount,
 				ConsensusCreateTopicTransactionBody::getAutoRenewAccount,
@@ -583,11 +588,13 @@ public class SigRequirements {
 	}
 
 	private <T> SigningOrderResult<T> tokenCreate(
+			AccountID payer,
 			TokenCreateTransactionBody op,
 			SigningOrderResultFactory<T> factory) {
 		final List<JKey> required = new ArrayList<>();
 
 		final var couldAddTreasury = addAccount(
+				payer,
 				op,
 				TokenCreateTransactionBody::hasTreasury,
 				TokenCreateTransactionBody::getTreasury,
@@ -596,6 +603,7 @@ public class SigRequirements {
 			return accountFailure(MISSING_ACCOUNT, factory);
 		}
 		final var couldAddAutoRenew = addAccount(
+				payer,
 				op,
 				TokenCreateTransactionBody::hasAutoRenewAccount,
 				TokenCreateTransactionBody::getAutoRenewAccount,
@@ -618,9 +626,9 @@ public class SigRequirements {
 				final var fixedFee = customFee.getFixedFee();
 				final var alwaysAdd = fixedFee.hasDenominatingTokenId()
 						&& fixedFee.getDenominatingTokenId().getTokenNum() == 0L;
-				couldAddCollector = addAccount(collector, required, alwaysAdd);
+				couldAddCollector = addAccount(payer, collector, required, alwaysAdd);
 			} else if (customFee.hasFractionalFee()) {
-				couldAddCollector = addAccount(collector, required, true);
+				couldAddCollector = addAccount(payer, collector, required, true);
 			} else {
 				final var royaltyFee = customFee.getRoyaltyFee();
 				var alwaysAdd = false;
@@ -628,7 +636,7 @@ public class SigRequirements {
 					final var fFee = royaltyFee.getFallbackFee();
 					alwaysAdd = fFee.hasDenominatingTokenId() && fFee.getDenominatingTokenId().getTokenNum() == 0;
 				}
-				couldAddCollector = addAccount(collector, required, alwaysAdd);
+				couldAddCollector = addAccount(payer, collector, required, alwaysAdd);
 			}
 			if (!couldAddCollector) {
 				return factory.forMissingFeeCollector();
@@ -665,6 +673,7 @@ public class SigRequirements {
 	}
 
 	private <T> SigningOrderResult<T> tokenFeeScheduleUpdates(
+			AccountID payer,
 			TokenFeeScheduleUpdateTransactionBody op,
 			SigningOrderResultFactory<T> factory
 	) {
@@ -677,7 +686,7 @@ public class SigRequirements {
 				required.add(feeScheduleKey.get());
 				for (var customFee : op.getCustomFeesList()) {
 					final var collector = customFee.getFeeCollectorAccountId();
-					final var couldAddCollector = addAccountIfReceiverSigRequired(collector, required);
+					final var couldAddCollector = addAccountIfReceiverSigRequired(payer, collector, required);
 					if (!couldAddCollector) {
 						return factory.forMissingFeeCollector();
 					}
@@ -693,6 +702,7 @@ public class SigRequirements {
 	}
 
 	private <T> SigningOrderResult<T> tokenUpdates(
+			AccountID payer,
 			TokenUpdateTransactionBody op,
 			SigningOrderResultFactory<T> factory
 	) {
@@ -700,6 +710,7 @@ public class SigRequirements {
 		var basic = tokenMutates(op.getToken(), factory, nonAdminReqs);
 		var required = basic.getOrderedKeys();
 		if (!addAccount(
+				payer,
 				op,
 				TokenUpdateTransactionBody::hasAutoRenewAccount,
 				TokenUpdateTransactionBody::getAutoRenewAccount,
@@ -707,6 +718,7 @@ public class SigRequirements {
 			return accountFailure(MISSING_AUTORENEW_ACCOUNT, factory);
 		}
 		if (!addAccount(
+				payer,
 				op,
 				TokenUpdateTransactionBody::hasTreasury,
 				TokenUpdateTransactionBody::getTreasury,
@@ -721,25 +733,27 @@ public class SigRequirements {
 		return basic;
 	}
 
-	private boolean addAccountIfReceiverSigRequired(AccountID id, List<JKey> reqs) {
-		return addAccount(id, reqs, false);
+	private boolean addAccountIfReceiverSigRequired(AccountID payer, AccountID id, List<JKey> reqs) {
+		return addAccount(payer, id, reqs, false);
 	}
 
 	private <T> boolean addAccount(
+			AccountID payer,
 			T op, Predicate<T> isPresent,
 			Function<T, AccountID> getter, List<JKey> reqs) {
 		if (isPresent.test(op)) {
-			return addAccount(getter.apply(op), reqs, true);
+			return addAccount(payer, getter.apply(op), reqs, true);
 		}
 		return true;
 	}
 
 	private boolean addAccount(
+			AccountID payer,
 			AccountID id,
 			List<JKey> reqs,
 			boolean alwaysAdd
 	) {
-		if (!doesMatchPayer(id)) {
+		if (!payer.equals(id)) {
 			var result = sigMetaLookup.accountSigningMetaFor(id);
 			if (result.succeeded()) {
 				final var metadata = result.metadata();
@@ -801,20 +815,23 @@ public class SigRequirements {
 	}
 
 	private <T> SigningOrderResult<T> tokenAssociate(
+			AccountID payer,
 			TokenAssociateTransactionBody op,
 			SigningOrderResultFactory<T> factory
 	) {
-		return forSingleAccount(op.getAccount(), factory);
+		return forSingleAccount(payer, op.getAccount(), factory);
 	}
 
 	private <T> SigningOrderResult<T> tokenDissociate(
+			AccountID payer,
 			TokenDissociateTransactionBody op,
 			SigningOrderResultFactory<T> factory
 	) {
-		return forSingleAccount(op.getAccount(), factory);
+		return forSingleAccount(payer, op.getAccount(), factory);
 	}
 
 	private <T> SigningOrderResult<T> scheduleCreate(
+			AccountID payer,
 			ScheduleCreateTransactionBody op,
 			SigningOrderResultFactory<T> factory
 	) {
@@ -828,6 +845,7 @@ public class SigRequirements {
 
 		int before = required.size();
 		var couldAddPayer = addAccount(
+				payer,
 				op,
 				ScheduleCreateTransactionBody::hasPayerAccountID,
 				ScheduleCreateTransactionBody::getPayerAccountID,
@@ -918,11 +936,12 @@ public class SigRequirements {
 	}
 
 	private <T> SigningOrderResult<T> forSingleAccount(
+			AccountID payer,
 			AccountID target,
 			SigningOrderResultFactory<T> factory) {
 		List<JKey> required = EMPTY_LIST;
 
-		if (!doesMatchPayer(target)) {
+		if (!payer.equals(target)) {
 			var result = sigMetaLookup.accountSigningMetaFor(target);
 			if (result.succeeded()) {
 				var meta = result.metadata();
@@ -936,9 +955,9 @@ public class SigRequirements {
 		return factory.forValidOrder(required);
 	}
 
-	private KeyOrderingFailure includeIfNecessary(AccountAmount adjust, List<JKey> required) {
+	private KeyOrderingFailure includeIfNecessary(AccountID payer, AccountAmount adjust, List<JKey> required) {
 		var account = adjust.getAccountID();
-		if (!doesMatchPayer(account)) {
+		if (!payer.equals(account)) {
 			var result = sigMetaLookup.accountSigningMetaFor(account);
 			if (result.succeeded()) {
 				var meta = result.metadata();
@@ -952,12 +971,13 @@ public class SigRequirements {
 	}
 
 	private KeyOrderingFailure nftIncludeIfNecessary(
+			AccountID payer,
 			AccountID party,
 			AccountID counterparty,
 			List<JKey> required,
 			TokenID token,
 			CryptoTransferTransactionBody op) {
-		if (!doesMatchPayer(party)) {
+		if (!payer.equals(party)) {
 			var result = sigMetaLookup.accountSigningMetaFor(party);
 			if (!result.succeeded()) {
 				return result.failureIfAny();
@@ -1033,6 +1053,7 @@ public class SigRequirements {
 	}
 
 	private <T> SigningOrderResult<T> topicUpdate(
+			AccountID payer,
 			ConsensusUpdateTopicTransactionBody op,
 			SigningOrderResultFactory<T> factory
 	) {
@@ -1059,7 +1080,7 @@ public class SigRequirements {
 		}
 		if (op.hasAutoRenewAccount() && !isEliding(op.getAutoRenewAccount())) {
 			var account = op.getAutoRenewAccount();
-			if (!doesMatchPayer(account)) {
+			if (!payer.equals(account)) {
 				var autoRenewResult = sigMetaLookup.accountSigningMetaFor(account);
 				if (autoRenewResult.succeeded()) {
 					required = mutable(required);
@@ -1103,7 +1124,7 @@ public class SigRequirements {
 		return factory.forValidOrder(required);
 	}
 
-	private Boolean doesMatchPayer(AccountID subject) {
+	private Boolean doesMatchPayer(AccountID subject, AccountID payer) {
 		return payer.equals(subject);
 	}
 }

--- a/hedera-node/src/main/java/com/hedera/services/sigs/order/SigRequirements.java
+++ b/hedera-node/src/main/java/com/hedera/services/sigs/order/SigRequirements.java
@@ -1123,8 +1123,4 @@ public class SigRequirements {
 		}
 		return factory.forValidOrder(required);
 	}
-
-	private Boolean doesMatchPayer(AccountID subject, AccountID payer) {
-		return payer.equals(subject);
-	}
 }

--- a/hedera-node/src/main/java/com/hedera/services/sigs/verification/PrecheckKeyReqs.java
+++ b/hedera-node/src/main/java/com/hedera/services/sigs/verification/PrecheckKeyReqs.java
@@ -35,7 +35,6 @@ import java.util.EnumSet;
 import java.util.List;
 import java.util.Set;
 import java.util.function.Predicate;
-import java.util.stream.Collectors;
 
 import static com.hedera.services.sigs.order.CodeOrderResultFactory.CODE_ORDER_RESULT_FACTORY;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.ACCOUNT_ID_DOES_NOT_EXIST;
@@ -87,7 +86,7 @@ public class PrecheckKeyReqs {
 			addQueryPaymentKeys(txn, keys);
 		}
 
-		return keys.stream().distinct().collect(Collectors.toList());
+		return keys;
 	}
 
 	private void addPayerKeys(TransactionBody txn, List<JKey> keys) throws Exception {
@@ -108,6 +107,11 @@ public class PrecheckKeyReqs {
 				throw new Exception();
 			}
 		}
-		keys.addAll(otherResult.getOrderedKeys());
+
+		for (var nonPayerKey : otherResult.getOrderedKeys()) {
+			if (!nonPayerKey.equals(keys.get(0))) {
+				keys.add(nonPayerKey);
+			}
+		}
 	}
 }

--- a/hedera-node/src/main/java/com/hedera/services/sigs/verification/PrecheckKeyReqs.java
+++ b/hedera-node/src/main/java/com/hedera/services/sigs/verification/PrecheckKeyReqs.java
@@ -35,6 +35,7 @@ import java.util.EnumSet;
 import java.util.List;
 import java.util.Set;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 import static com.hedera.services.sigs.order.CodeOrderResultFactory.CODE_ORDER_RESULT_FACTORY;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.ACCOUNT_ID_DOES_NOT_EXIST;
@@ -86,7 +87,7 @@ public class PrecheckKeyReqs {
 			addQueryPaymentKeys(txn, keys);
 		}
 
-		return keys;
+		return keys.stream().distinct().collect(Collectors.toList());
 	}
 
 	private void addPayerKeys(TransactionBody txn, List<JKey> keys) throws Exception {

--- a/hedera-node/src/test/java/com/hedera/services/legacy/core/jproto/JEd25519KeyTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/legacy/core/jproto/JEd25519KeyTest.java
@@ -22,7 +22,9 @@ package com.hedera.services.legacy.core.jproto;
 
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class JEd25519KeyTest {
@@ -52,6 +54,22 @@ class JEd25519KeyTest {
   void validJEd25519KeyTest() {
     JEd25519Key key = new JEd25519Key(new byte[JEd25519Key.ED25519_BYTE_LENGTH]);
     assertTrue(key.isValid());
+  }
+  @Test
+  void equalsWorks() {
+    JEd25519Key key1 = new JEd25519Key("firstKey".getBytes());
+    JEd25519Key key2 = new JEd25519Key("secondKey".getBytes());
+    JEd25519Key key3 = new JEd25519Key("firstKey".getBytes());
+
+    assertNotEquals(key1, key2);
+    assertNotEquals(key1.hashCode(), key2.hashCode());
+    assertEquals(key1, key3);
+    assertEquals(key1.hashCode(), key3.hashCode());
+    assertEquals(key1, key1);
+    boolean forceEquals = key2.equals("sampleText");
+    assertFalse(forceEquals);
+    forceEquals = key1.equals(null);
+    assertFalse(forceEquals);
   }
 
 }

--- a/hedera-node/src/test/java/com/hedera/services/sigs/order/SigRequirementsTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/sigs/order/SigRequirementsTest.java
@@ -42,8 +42,8 @@ import com.hedera.services.state.merkle.MerkleAccount;
 import com.hedera.services.state.merkle.MerkleTopic;
 import com.hedera.services.store.schedule.ScheduleStore;
 import com.hedera.services.store.tokens.TokenStore;
-import com.hedera.services.utils.EntityNum;
 import com.hedera.services.txns.auth.SystemOpPolicies;
+import com.hedera.services.utils.EntityNum;
 import com.hedera.test.factories.scenarios.TxnHandlingScenario;
 import com.hederahashgraph.api.proto.java.AccountID;
 import com.hederahashgraph.api.proto.java.ContractID;
@@ -61,6 +61,7 @@ import java.util.function.Function;
 import static com.hedera.services.sigs.metadata.DelegatingSigMetadataLookup.defaultLookupsFor;
 import static com.hedera.services.sigs.order.CodeOrderResultFactory.CODE_ORDER_RESULT_FACTORY;
 import static com.hedera.test.factories.scenarios.BadPayerScenarios.INVALID_PAYER_ID_SCENARIO;
+import static com.hedera.test.factories.scenarios.ConsensusCreateTopicScenarios.CONSENSUS_CREATE_TOPIC_ADMIN_KEY_AND_AUTORENEW_ACCOUNT_AS_PAYER_SCENARIO;
 import static com.hedera.test.factories.scenarios.ConsensusCreateTopicScenarios.CONSENSUS_CREATE_TOPIC_ADMIN_KEY_AND_AUTORENEW_ACCOUNT_SCENARIO;
 import static com.hedera.test.factories.scenarios.ConsensusCreateTopicScenarios.CONSENSUS_CREATE_TOPIC_ADMIN_KEY_SCENARIO;
 import static com.hedera.test.factories.scenarios.ConsensusCreateTopicScenarios.CONSENSUS_CREATE_TOPIC_MISSING_AUTORENEW_ACCOUNT_SCENARIO;
@@ -86,15 +87,16 @@ import static com.hedera.test.factories.scenarios.ConsensusSubmitMessageScenario
 import static com.hedera.test.factories.scenarios.ConsensusSubmitMessageScenarios.TOKEN_ADMIN_KT;
 import static com.hedera.test.factories.scenarios.ConsensusSubmitMessageScenarios.TOKEN_FREEZE_KT;
 import static com.hedera.test.factories.scenarios.ConsensusSubmitMessageScenarios.TOKEN_KYC_KT;
+import static com.hedera.test.factories.scenarios.ConsensusSubmitMessageScenarios.TOKEN_PAUSE_KT;
 import static com.hedera.test.factories.scenarios.ConsensusSubmitMessageScenarios.TOKEN_REPLACE_KT;
 import static com.hedera.test.factories.scenarios.ConsensusSubmitMessageScenarios.TOKEN_SUPPLY_KT;
 import static com.hedera.test.factories.scenarios.ConsensusSubmitMessageScenarios.TOKEN_TREASURY_KT;
 import static com.hedera.test.factories.scenarios.ConsensusSubmitMessageScenarios.TOKEN_WIPE_KT;
-import static com.hedera.test.factories.scenarios.ConsensusSubmitMessageScenarios.TOKEN_PAUSE_KT;
 import static com.hedera.test.factories.scenarios.ConsensusSubmitMessageScenarios.UPDATE_TOPIC_ADMIN_KT;
 import static com.hedera.test.factories.scenarios.ConsensusUpdateTopicScenarios.CONSENSUS_UPDATE_TOPIC_EXPIRY_ONLY_SCENARIO;
 import static com.hedera.test.factories.scenarios.ConsensusUpdateTopicScenarios.CONSENSUS_UPDATE_TOPIC_MISSING_AUTORENEW_ACCOUNT_SCENARIO;
 import static com.hedera.test.factories.scenarios.ConsensusUpdateTopicScenarios.CONSENSUS_UPDATE_TOPIC_MISSING_TOPIC_SCENARIO;
+import static com.hedera.test.factories.scenarios.ConsensusUpdateTopicScenarios.CONSENSUS_UPDATE_TOPIC_NEW_ADMIN_KEY_AND_AUTORENEW_ACCOUNT_AS_PAYER_SCENARIO;
 import static com.hedera.test.factories.scenarios.ConsensusUpdateTopicScenarios.CONSENSUS_UPDATE_TOPIC_NEW_ADMIN_KEY_AND_AUTORENEW_ACCOUNT_SCENARIO;
 import static com.hedera.test.factories.scenarios.ConsensusUpdateTopicScenarios.CONSENSUS_UPDATE_TOPIC_NEW_ADMIN_KEY_SCENARIO;
 import static com.hedera.test.factories.scenarios.ConsensusUpdateTopicScenarios.CONSENSUS_UPDATE_TOPIC_SCENARIO;
@@ -119,7 +121,10 @@ import static com.hedera.test.factories.scenarios.CryptoCreateScenarios.CRYPTO_C
 import static com.hedera.test.factories.scenarios.CryptoDeleteScenarios.CRYPTO_DELETE_MISSING_RECEIVER_SIG_SCENARIO;
 import static com.hedera.test.factories.scenarios.CryptoDeleteScenarios.CRYPTO_DELETE_MISSING_TARGET;
 import static com.hedera.test.factories.scenarios.CryptoDeleteScenarios.CRYPTO_DELETE_NO_TARGET_RECEIVER_SIG_SCENARIO;
+import static com.hedera.test.factories.scenarios.CryptoDeleteScenarios.CRYPTO_DELETE_NO_TARGET_RECEIVER_SIG_SELF_PAID_SCENARIO;
+import static com.hedera.test.factories.scenarios.CryptoDeleteScenarios.CRYPTO_DELETE_TARGET_RECEIVER_SIG_RECEIVER_PAID_SCENARIO;
 import static com.hedera.test.factories.scenarios.CryptoDeleteScenarios.CRYPTO_DELETE_TARGET_RECEIVER_SIG_SCENARIO;
+import static com.hedera.test.factories.scenarios.CryptoDeleteScenarios.CRYPTO_DELETE_TARGET_RECEIVER_SIG_SELF_PAID_SCENARIO;
 import static com.hedera.test.factories.scenarios.CryptoTransferScenarios.CRYPTO_TRANSFER_MISSING_ACCOUNT_SCENARIO;
 import static com.hedera.test.factories.scenarios.CryptoTransferScenarios.CRYPTO_TRANSFER_NO_RECEIVER_SIG_SCENARIO;
 import static com.hedera.test.factories.scenarios.CryptoTransferScenarios.CRYPTO_TRANSFER_RECEIVER_SIG_SCENARIO;
@@ -140,12 +145,14 @@ import static com.hedera.test.factories.scenarios.CryptoTransferScenarios.TOKEN_
 import static com.hedera.test.factories.scenarios.CryptoTransferScenarios.TOKEN_TRANSACT_WITH_RECEIVER_SIG_REQ_AND_EXTANT_SENDERS;
 import static com.hedera.test.factories.scenarios.CryptoUpdateScenarios.CRYPTO_UPDATE_MISSING_ACCOUNT_SCENARIO;
 import static com.hedera.test.factories.scenarios.CryptoUpdateScenarios.CRYPTO_UPDATE_NO_NEW_KEY_SCENARIO;
+import static com.hedera.test.factories.scenarios.CryptoUpdateScenarios.CRYPTO_UPDATE_NO_NEW_KEY_SELF_PAID_SCENARIO;
 import static com.hedera.test.factories.scenarios.CryptoUpdateScenarios.CRYPTO_UPDATE_SYS_ACCOUNT_WITH_NEW_KEY_SCENARIO;
 import static com.hedera.test.factories.scenarios.CryptoUpdateScenarios.CRYPTO_UPDATE_SYS_ACCOUNT_WITH_NO_NEW_KEY_SCENARIO;
 import static com.hedera.test.factories.scenarios.CryptoUpdateScenarios.CRYPTO_UPDATE_SYS_ACCOUNT_WITH_PRIVILEGED_PAYER;
 import static com.hedera.test.factories.scenarios.CryptoUpdateScenarios.CRYPTO_UPDATE_TREASURY_ACCOUNT_WITH_TREASURY_AND_NEW_KEY;
 import static com.hedera.test.factories.scenarios.CryptoUpdateScenarios.CRYPTO_UPDATE_TREASURY_ACCOUNT_WITH_TREASURY_AND_NO_NEW_KEY;
 import static com.hedera.test.factories.scenarios.CryptoUpdateScenarios.CRYPTO_UPDATE_WITH_NEW_KEY_SCENARIO;
+import static com.hedera.test.factories.scenarios.CryptoUpdateScenarios.CRYPTO_UPDATE_WITH_NEW_KEY_SELF_PAID_SCENARIO;
 import static com.hedera.test.factories.scenarios.FileAppendScenarios.FILE_APPEND_MISSING_TARGET_SCENARIO;
 import static com.hedera.test.factories.scenarios.FileAppendScenarios.IMMUTABLE_FILE_APPEND_SCENARIO;
 import static com.hedera.test.factories.scenarios.FileAppendScenarios.MASTER_SYS_FILE_APPEND_SCENARIO;
@@ -168,6 +175,7 @@ import static com.hedera.test.factories.scenarios.ScheduleCreateScenarios.SCHEDU
 import static com.hedera.test.factories.scenarios.ScheduleCreateScenarios.SCHEDULE_CREATE_XFER_NO_ADMIN;
 import static com.hedera.test.factories.scenarios.ScheduleCreateScenarios.SCHEDULE_CREATE_XFER_WITH_ADMIN;
 import static com.hedera.test.factories.scenarios.ScheduleCreateScenarios.SCHEDULE_CREATE_XFER_WITH_ADMIN_AND_PAYER;
+import static com.hedera.test.factories.scenarios.ScheduleCreateScenarios.SCHEDULE_CREATE_XFER_WITH_ADMIN_AND_PAYER_AS_SELF;
 import static com.hedera.test.factories.scenarios.ScheduleCreateScenarios.SCHEDULE_CREATE_XFER_WITH_MISSING_PAYER;
 import static com.hedera.test.factories.scenarios.ScheduleDeleteScenarios.SCHEDULE_DELETE_WITH_KNOWN_SCHEDULE;
 import static com.hedera.test.factories.scenarios.ScheduleDeleteScenarios.SCHEDULE_DELETE_WITH_MISSING_SCHEDULE;
@@ -180,12 +188,15 @@ import static com.hedera.test.factories.scenarios.SystemDeleteScenarios.SYSTEM_D
 import static com.hedera.test.factories.scenarios.SystemUndeleteScenarios.SYSTEM_UNDELETE_FILE_SCENARIO;
 import static com.hedera.test.factories.scenarios.TokenAssociateScenarios.TOKEN_ASSOCIATE_WITH_KNOWN_TARGET;
 import static com.hedera.test.factories.scenarios.TokenAssociateScenarios.TOKEN_ASSOCIATE_WITH_MISSING_TARGET;
+import static com.hedera.test.factories.scenarios.TokenAssociateScenarios.TOKEN_ASSOCIATE_WITH_SELF_PAID_KNOWN_TARGET;
 import static com.hedera.test.factories.scenarios.TokenBurnScenarios.BURN_WITH_SUPPLY_KEYED_TOKEN;
 import static com.hedera.test.factories.scenarios.TokenCreateScenarios.TOKEN_CREATE_MISSING_ADMIN;
 import static com.hedera.test.factories.scenarios.TokenCreateScenarios.TOKEN_CREATE_WITH_ADMIN_AND_FREEZE;
 import static com.hedera.test.factories.scenarios.TokenCreateScenarios.TOKEN_CREATE_WITH_ADMIN_ONLY;
 import static com.hedera.test.factories.scenarios.TokenCreateScenarios.TOKEN_CREATE_WITH_AUTO_RENEW;
+import static com.hedera.test.factories.scenarios.TokenCreateScenarios.TOKEN_CREATE_WITH_AUTO_RENEW_AS_PAYER;
 import static com.hedera.test.factories.scenarios.TokenCreateScenarios.TOKEN_CREATE_WITH_FIXED_FEE_COLLECTOR_SIG_REQ;
+import static com.hedera.test.factories.scenarios.TokenCreateScenarios.TOKEN_CREATE_WITH_FIXED_FEE_COLLECTOR_SIG_REQ_AND_AS_PAYER;
 import static com.hedera.test.factories.scenarios.TokenCreateScenarios.TOKEN_CREATE_WITH_FIXED_FEE_NO_COLLECTOR_SIG_REQ;
 import static com.hedera.test.factories.scenarios.TokenCreateScenarios.TOKEN_CREATE_WITH_FIXED_FEE_NO_COLLECTOR_SIG_REQ_BUT_USING_WILDCARD_DENOM;
 import static com.hedera.test.factories.scenarios.TokenCreateScenarios.TOKEN_CREATE_WITH_FRACTIONAL_FEE_COLLECTOR_NO_SIG_REQ;
@@ -196,13 +207,17 @@ import static com.hedera.test.factories.scenarios.TokenCreateScenarios.TOKEN_CRE
 import static com.hedera.test.factories.scenarios.TokenCreateScenarios.TOKEN_CREATE_WITH_ROYALTY_FEE_COLLECTOR_FALLBACK_WILDCARD_AND_NO_SIG_REQ;
 import static com.hedera.test.factories.scenarios.TokenCreateScenarios.TOKEN_CREATE_WITH_ROYALTY_FEE_COLLECTOR_NO_SIG_REQ_NO_FALLBACK;
 import static com.hedera.test.factories.scenarios.TokenCreateScenarios.TOKEN_CREATE_WITH_ROYALTY_FEE_COLLECTOR_SIG_REQ_NO_FALLBACK;
+import static com.hedera.test.factories.scenarios.TokenCreateScenarios.TOKEN_CREATE_WITH_TREASURY_AS_PAYER;
 import static com.hedera.test.factories.scenarios.TokenDeleteScenarios.DELETE_WITH_KNOWN_TOKEN;
 import static com.hedera.test.factories.scenarios.TokenDeleteScenarios.DELETE_WITH_MISSING_TOKEN;
 import static com.hedera.test.factories.scenarios.TokenDeleteScenarios.DELETE_WITH_MISSING_TOKEN_ADMIN_KEY;
 import static com.hedera.test.factories.scenarios.TokenDissociateScenarios.TOKEN_DISSOCIATE_WITH_KNOWN_TARGET;
 import static com.hedera.test.factories.scenarios.TokenDissociateScenarios.TOKEN_DISSOCIATE_WITH_MISSING_TARGET;
+import static com.hedera.test.factories.scenarios.TokenDissociateScenarios.TOKEN_DISSOCIATE_WITH_SELF_PAID_KNOWN_TARGET;
 import static com.hedera.test.factories.scenarios.TokenFeeScheduleUpdateScenarios.UPDATE_TOKEN_FEE_SCHEDULE_BUT_TOKEN_DOESNT_EXIST;
 import static com.hedera.test.factories.scenarios.TokenFeeScheduleUpdateScenarios.UPDATE_TOKEN_WITH_FEE_SCHEDULE_KEY_NO_FEE_COLLECTOR_SIG_REQ;
+import static com.hedera.test.factories.scenarios.TokenFeeScheduleUpdateScenarios.UPDATE_TOKEN_WITH_FEE_SCHEDULE_KEY_WITH_FEE_COLLECTOR_SIG_REQ;
+import static com.hedera.test.factories.scenarios.TokenFeeScheduleUpdateScenarios.UPDATE_TOKEN_WITH_FEE_SCHEDULE_KEY_WITH_FEE_COLLECTOR_SIG_REQ_AND_AS_PAYER;
 import static com.hedera.test.factories.scenarios.TokenFeeScheduleUpdateScenarios.UPDATE_TOKEN_WITH_FEE_SCHEDULE_KEY_WITH_MISSING_FEE_COLLECTOR;
 import static com.hedera.test.factories.scenarios.TokenFeeScheduleUpdateScenarios.UPDATE_TOKEN_WITH_NO_FEE_SCHEDULE_KEY;
 import static com.hedera.test.factories.scenarios.TokenFreezeScenarios.VALID_FREEZE_WITH_EXTANT_TOKEN;
@@ -216,8 +231,10 @@ import static com.hedera.test.factories.scenarios.TokenUnfreezeScenarios.VALID_U
 import static com.hedera.test.factories.scenarios.TokenUnpauseScenarios.VALID_UNPAUSE_WITH_EXTANT_TOKEN;
 import static com.hedera.test.factories.scenarios.TokenUpdateScenarios.TOKEN_UPDATE_WITH_MISSING_AUTO_RENEW_ACCOUNT;
 import static com.hedera.test.factories.scenarios.TokenUpdateScenarios.TOKEN_UPDATE_WITH_NEW_AUTO_RENEW_ACCOUNT;
+import static com.hedera.test.factories.scenarios.TokenUpdateScenarios.TOKEN_UPDATE_WITH_NEW_AUTO_RENEW_ACCOUNT_AS_PAYER;
 import static com.hedera.test.factories.scenarios.TokenUpdateScenarios.UPDATE_REPLACING_ADMIN_KEY;
 import static com.hedera.test.factories.scenarios.TokenUpdateScenarios.UPDATE_REPLACING_TREASURY;
+import static com.hedera.test.factories.scenarios.TokenUpdateScenarios.UPDATE_REPLACING_TREASURY_AS_PAYER;
 import static com.hedera.test.factories.scenarios.TokenUpdateScenarios.UPDATE_REPLACING_WITH_MISSING_TREASURY;
 import static com.hedera.test.factories.scenarios.TokenUpdateScenarios.UPDATE_WITH_FREEZE_KEYED_TOKEN;
 import static com.hedera.test.factories.scenarios.TokenUpdateScenarios.UPDATE_WITH_KYC_KEYED_TOKEN;
@@ -392,7 +409,7 @@ class SigRequirementsTest {
 
 		// then:
 		assertThat(sanityRestored(payerSummary.getOrderedKeys()), contains(DEFAULT_PAYER_KT.asKey()));
-		assertThat(sanityRestored(nonPayerSummary.getOrderedKeys()), contains(DEFAULT_PAYER_KT.asKey()));
+		assertTrue(sanityRestored(nonPayerSummary.getOrderedKeys()).isEmpty());
 	}
 
 	@Test
@@ -404,9 +421,8 @@ class SigRequirementsTest {
 		final var summary = subject.keysForOtherParties(txn, summaryFactory);
 
 		// then:
-		assertThat(
-				sanityRestored(summary.getOrderedKeys()),
-				contains(DEFAULT_PAYER_KT.asKey(), RECEIVER_SIG_KT.asKey()));
+		assertThat(sanityRestored(summary.getOrderedKeys()), contains(RECEIVER_SIG_KT.asKey()));
+		assertFalse(sanityRestored(summary.getOrderedKeys()).contains(DEFAULT_PAYER_KT.asKey()));
 	}
 
 	@Test
@@ -460,7 +476,8 @@ class SigRequirementsTest {
 		// then:
 		assertThat(
 				sanityRestored(summary.getOrderedKeys()),
-				contains(FIRST_TOKEN_SENDER_KT.asKey(), RECEIVER_SIG_KT.asKey()));
+				contains(SECOND_TOKEN_SENDER_KT.asKey(), FIRST_TOKEN_SENDER_KT.asKey(), RECEIVER_SIG_KT.asKey()));
+		assertFalse(sanityRestored(summary.getOrderedKeys()).contains(DEFAULT_PAYER_KT.asKey()));
 	}
 
 	@Test
@@ -603,6 +620,19 @@ class SigRequirementsTest {
 	}
 
 	@Test
+	void getsCryptoUpdateNewKeySelfPaidReturnsJustTheNewKey() throws Throwable {
+		// given:
+		setupFor(CRYPTO_UPDATE_WITH_NEW_KEY_SELF_PAID_SCENARIO);
+
+		// when:
+		final var summary = subject.keysForOtherParties(txn, summaryFactory);
+
+		// then:
+		assertThat(sanityRestored(summary.getOrderedKeys()), contains(NEW_ACCOUNT_KT.asKey()));
+		assertFalse(sanityRestored(summary.getOrderedKeys()).contains(DEFAULT_PAYER_KT.asKey()));
+	}
+
+	@Test
 	void getsCryptoUpdateProtectedSysAccountNewKey() throws Throwable {
 		setupFor(CRYPTO_UPDATE_SYS_ACCOUNT_WITH_NEW_KEY_SCENARIO);
 
@@ -671,6 +701,17 @@ class SigRequirementsTest {
 	}
 
 	@Test
+	void getsCryptoUpdateNoNewKeySelfPaidReturnsEmptyKeyList() throws Throwable {
+		setupFor(CRYPTO_UPDATE_NO_NEW_KEY_SELF_PAID_SCENARIO);
+
+		// when:
+		final var summary = subject.keysForOtherParties(txn, summaryFactory);
+
+		// then:
+		assertTrue(sanityRestored(summary.getOrderedKeys()).isEmpty());
+	}
+
+	@Test
 	void reportsCryptoUpdateMissingAccount() throws Throwable {
 		setupFor(CRYPTO_UPDATE_MISSING_ACCOUNT_SCENARIO);
 		// and:
@@ -697,6 +738,18 @@ class SigRequirementsTest {
 
 		// then:
 		assertThat(sanityRestored(summary.getOrderedKeys()), contains(MISC_ACCOUNT_KT.asKey()));
+	}
+
+	@Test
+	void getsCryptoDeleteNoTransferSigRequiredSelfPaidWillReturnEmptyKeyList() throws Throwable {
+		// given:
+		setupFor(CRYPTO_DELETE_NO_TARGET_RECEIVER_SIG_SELF_PAID_SCENARIO);
+
+		// when:
+		final var summary = subject.keysForOtherParties(txn, summaryFactory);
+
+		// then:
+		assertTrue(sanityRestored(summary.getOrderedKeys()).isEmpty());
 	}
 
 	@Test
@@ -737,6 +790,32 @@ class SigRequirementsTest {
 		assertThat(
 				sanityRestored(summary.getOrderedKeys()),
 				contains(MISC_ACCOUNT_KT.asKey(), RECEIVER_SIG_KT.asKey()));
+	}
+
+	@Test
+	void getsCryptoDeleteTransferSigRequiredPaidByReceiverReturnsJustAccountKey() throws Throwable {
+		// given:
+		setupFor(CRYPTO_DELETE_TARGET_RECEIVER_SIG_RECEIVER_PAID_SCENARIO);
+
+		// when:
+		final var summary = subject.keysForOtherParties(txn, summaryFactory);
+
+		// then:
+		assertThat(sanityRestored(summary.getOrderedKeys()), contains(MISC_ACCOUNT_KT.asKey()));
+		assertFalse(sanityRestored(summary.getOrderedKeys()).contains(RECEIVER_SIG_KT.asKey()));
+	}
+
+	@Test
+	void getsCryptoDeleteTransferSigRequiredSelfPaidReturnsJustReceiverKey() throws Throwable {
+		// given:
+		setupFor(CRYPTO_DELETE_TARGET_RECEIVER_SIG_SELF_PAID_SCENARIO);
+
+		// when:
+		final var summary = subject.keysForOtherParties(txn, summaryFactory);
+
+		// then:
+		assertThat(sanityRestored(summary.getOrderedKeys()), contains(RECEIVER_SIG_KT.asKey()));
+		assertFalse(sanityRestored(summary.getOrderedKeys()).contains(DEFAULT_PAYER_KT.asKey()));
 	}
 
 	@Test
@@ -1275,6 +1354,19 @@ class SigRequirementsTest {
 	}
 
 	@Test
+	void getsConsensusCreateTopicAdminKeyAndAutoRenewAccountAsPayer() throws Throwable {
+		// given:
+		setupFor(CONSENSUS_CREATE_TOPIC_ADMIN_KEY_AND_AUTORENEW_ACCOUNT_AS_PAYER_SCENARIO);
+
+		// when:
+		final var summary = subject.keysForOtherParties(txn, summaryFactory);
+
+		// then:
+		assertThat(sanityRestored(summary.getOrderedKeys()), contains(SIMPLE_TOPIC_ADMIN_KEY.asKey()));
+		assertFalse(sanityRestored(summary.getOrderedKeys()).contains(DEFAULT_PAYER_KT.asKey()));
+	}
+
+	@Test
 	void invalidAutoRenewAccountOnConsensusCreateTopicThrows() throws Throwable {
 		// given:
 		setupFor(CONSENSUS_CREATE_TOPIC_MISSING_AUTORENEW_ACCOUNT_SCENARIO);
@@ -1476,6 +1568,21 @@ class SigRequirementsTest {
 	}
 
 	@Test
+	void getsConsensusUpdateTopicNewAdminKeyAndAutoRenewAccountAsPayer() throws Throwable {
+		// given:
+		setupForNonStdLookup(CONSENSUS_UPDATE_TOPIC_NEW_ADMIN_KEY_AND_AUTORENEW_ACCOUNT_AS_PAYER_SCENARIO,
+				hcsMetadataLookup(MISC_TOPIC_ADMIN_KT.asJKey(), null));
+
+		// when:
+		final var summary = subject.keysForOtherParties(txn, summaryFactory);
+
+		// then:
+		assertThat(sanityRestored(summary.getOrderedKeys()), contains(MISC_TOPIC_ADMIN_KT.asKey(),
+				UPDATE_TOPIC_ADMIN_KT.asKey()));
+		assertFalse(sanityRestored(summary.getOrderedKeys()).contains(DEFAULT_PAYER_KT.asKey()));
+	}
+
+	@Test
 	void getsTokenCreateAdminKeyOnly() throws Throwable {
 		// given:
 		setupFor(TOKEN_CREATE_WITH_ADMIN_ONLY);
@@ -1500,6 +1607,18 @@ class SigRequirementsTest {
 		// then:
 		assertTrue(summary.hasErrorReport());
 		assertEquals(ACCOUNT_ID_DOES_NOT_EXIST, summary.getErrorReport());
+	}
+
+	@Test
+	void getsTokenCreateTreasuryAsPayer() throws Throwable {
+		// given:
+		setupFor(TOKEN_CREATE_WITH_TREASURY_AS_PAYER);
+
+		// when:
+		var summary = subject.keysForOtherParties(txn, summaryFactory);
+
+		// then:
+		assertTrue(sanityRestored(summary.getOrderedKeys()).isEmpty());
 	}
 
 	@Test
@@ -1569,6 +1688,19 @@ class SigRequirementsTest {
 		assertThat(
 				sanityRestored(summary.getOrderedKeys()),
 				contains(TOKEN_TREASURY_KT.asKey(), RECEIVER_SIG_KT.asKey()));
+	}
+
+	@Test
+	void getsTokenCreateCustomFixedFeeAndCollectorSigReqAndAsPayer() throws Throwable {
+		// given:
+		setupFor(TOKEN_CREATE_WITH_FIXED_FEE_COLLECTOR_SIG_REQ_AND_AS_PAYER);
+
+		// when:
+		var summary = subject.keysForOtherParties(txn, summaryFactory);
+
+		// then:
+		assertThat(sanityRestored(summary.getOrderedKeys()), contains(TOKEN_TREASURY_KT.asKey()));
+		assertFalse(sanityRestored(summary.getOrderedKeys()).contains(DEFAULT_PAYER_KT.asKey()));
 	}
 
 	@Test
@@ -1677,9 +1809,8 @@ class SigRequirementsTest {
 		var summary = subject.keysForOtherParties(txn, summaryFactory);
 
 		// then:
-		assertThat(
-				sanityRestored(summary.getOrderedKeys()),
-				contains(FIRST_TOKEN_SENDER_KT.asKey(), SECOND_TOKEN_SENDER_KT.asKey()));
+		assertThat(sanityRestored(summary.getOrderedKeys()), contains(SECOND_TOKEN_SENDER_KT.asKey()));
+		assertFalse(sanityRestored(summary.getOrderedKeys()).contains(DEFAULT_PAYER_KT.asKey()));
 	}
 
 	@Test
@@ -1754,6 +1885,18 @@ class SigRequirementsTest {
 	}
 
 	@Test
+	void getsAssociateWithSelfPaidKnownTargetGivesEmptyKeyList() throws Throwable {
+		// given:
+		setupFor(TOKEN_ASSOCIATE_WITH_SELF_PAID_KNOWN_TARGET);
+
+		// when:
+		var summary = subject.keysForOtherParties(txn, summaryFactory);
+
+		// then:
+		assertTrue(sanityRestored(summary.getOrderedKeys()).isEmpty());
+	}
+
+	@Test
 	void getsAssociateWithMissingTarget() throws Throwable {
 		// given:
 		setupFor(TOKEN_ASSOCIATE_WITH_MISSING_TARGET);
@@ -1777,6 +1920,18 @@ class SigRequirementsTest {
 		assertThat(
 				sanityRestored(summary.getOrderedKeys()),
 				contains(MISC_ACCOUNT_KT.asKey()));
+	}
+
+	@Test
+	void getsDissociateWithSelfPaidKnownTargetGivesEmptyKeyList() throws Throwable {
+		// given:
+		setupFor(TOKEN_DISSOCIATE_WITH_SELF_PAID_KNOWN_TARGET);
+
+		// when:
+		var summary = subject.keysForOtherParties(txn, summaryFactory);
+
+		// then:
+		assertTrue(sanityRestored(summary.getOrderedKeys()).isEmpty());
 	}
 
 	@Test
@@ -2059,6 +2214,19 @@ class SigRequirementsTest {
 	}
 
 	@Test
+	void getsUpdateWithNewTreasuryAsPayer() throws Throwable {
+		// given:
+		setupFor(UPDATE_REPLACING_TREASURY_AS_PAYER);
+
+		// when:
+		var summary = subject.keysForOtherParties(txn, summaryFactory);
+
+		// then:
+		assertThat(sanityRestored(summary.getOrderedKeys()), contains(TOKEN_ADMIN_KT.asKey()));
+		assertFalse(sanityRestored(summary.getOrderedKeys()).contains(DEFAULT_PAYER_KT.asKey()));
+	}
+
+	@Test
 	void getsUpdateWithFreeze() throws Throwable {
 		// given:
 		setupFor(UPDATE_WITH_FREEZE_KEYED_TOKEN);
@@ -2126,6 +2294,19 @@ class SigRequirementsTest {
 	}
 
 	@Test
+	void getsTokenCreateWithAutoRenewAsPayer() throws Throwable {
+		// given:
+		setupFor(TOKEN_CREATE_WITH_AUTO_RENEW_AS_PAYER);
+
+		// when:
+		var summary = subject.keysForOtherParties(txn, summaryFactory);
+
+		// then:
+		assertThat(sanityRestored(summary.getOrderedKeys()), contains(TOKEN_TREASURY_KT.asKey()));
+		assertFalse(sanityRestored(summary.getOrderedKeys()).contains(DEFAULT_PAYER_KT.asKey()));
+	}
+
+	@Test
 	void getsTokenCreateWithMissingAutoRenew() throws Throwable {
 		// given:
 		setupFor(TOKEN_CREATE_WITH_MISSING_AUTO_RENEW);
@@ -2151,6 +2332,19 @@ class SigRequirementsTest {
 		assertThat(
 				sanityRestored(summary.getOrderedKeys()),
 				contains(TOKEN_ADMIN_KT.asKey(), MISC_ACCOUNT_KT.asKey()));
+	}
+
+	@Test
+	void getsTokenUpdateWithAutoRenewAsPayer() throws Throwable {
+		// given:
+		setupFor(TOKEN_UPDATE_WITH_NEW_AUTO_RENEW_ACCOUNT_AS_PAYER);
+
+		// when:
+		var summary = subject.keysForOtherParties(txn, summaryFactory);
+
+		// then:
+		assertThat(sanityRestored(summary.getOrderedKeys()), contains(TOKEN_ADMIN_KT.asKey()));
+		assertFalse(sanityRestored(summary.getOrderedKeys()).contains(DEFAULT_PAYER_KT.asKey()));
 	}
 
 	@Test
@@ -2192,7 +2386,7 @@ class SigRequirementsTest {
 	}
 
 	@Test
-	void getsTokenFeeScheduleUpdateWithFeeScheduleKey() throws Throwable {
+	void getsTokenFeeScheduleUpdateWithFeeScheduleKeyAndFeeCollectorWithReceiverSigReqOff() throws Throwable {
 		// given:
 		setupFor(UPDATE_TOKEN_WITH_FEE_SCHEDULE_KEY_NO_FEE_COLLECTOR_SIG_REQ);
 
@@ -2203,6 +2397,33 @@ class SigRequirementsTest {
 		assertThat(
 				sanityRestored(summary.getOrderedKeys()),
 				contains(TOKEN_FEE_SCHEDULE_KT.asKey()));
+	}
+
+	@Test
+	void getsTokenFeeScheduleUpdateWithFeeScheduleKeyAndFeeCollectorWithReceiverSigReqON() throws Throwable {
+		// given:
+		setupFor(UPDATE_TOKEN_WITH_FEE_SCHEDULE_KEY_WITH_FEE_COLLECTOR_SIG_REQ);
+
+		// when:
+		var summary = subject.keysForOtherParties(txn, summaryFactory);
+
+		// then:
+		assertThat(
+				sanityRestored(summary.getOrderedKeys()),
+				contains(TOKEN_FEE_SCHEDULE_KT.asKey(), RECEIVER_SIG_KT.asKey()));
+	}
+
+	@Test
+	void getsTokenFeeScheduleUpdateWithFeeScheduleKeyAndFeeCollectorAsPayer() throws Throwable {
+		// given:
+		setupFor(UPDATE_TOKEN_WITH_FEE_SCHEDULE_KEY_WITH_FEE_COLLECTOR_SIG_REQ_AND_AS_PAYER);
+
+		// when:
+		var summary = subject.keysForOtherParties(txn, summaryFactory);
+
+		// then:
+		assertThat(sanityRestored(summary.getOrderedKeys()), contains(TOKEN_FEE_SCHEDULE_KT.asKey()));
+		assertFalse(sanityRestored(summary.getOrderedKeys()).contains(DEFAULT_PAYER_KT.asKey()));
 	}
 
 	@Test
@@ -2329,6 +2550,28 @@ class SigRequirementsTest {
 		assertTrue(summary.getOrderedKeys().get(1).isForScheduledTxn());
 		assertTrue(summary.getOrderedKeys().get(2).isForScheduledTxn());
 		assertTrue(summary.getOrderedKeys().get(3).isForScheduledTxn());
+	}
+
+	@Test
+	void getsScheduleCreateWithAdminAndDesignatedPayerAsSelf() throws Throwable {
+		// given:
+		setupFor(SCHEDULE_CREATE_XFER_WITH_ADMIN_AND_PAYER_AS_SELF);
+
+		// when:
+		var summary = subject.keysForOtherParties(txn, summaryFactory);
+
+		// then:
+		assertThat(
+				sanityRestored(summary.getOrderedKeys()),
+				contains(
+						SCHEDULE_ADMIN_KT.asKey(),
+						MISC_ACCOUNT_KT.asKey(),
+						RECEIVER_SIG_KT.asKey()));
+		assertFalse(sanityRestored(summary.getOrderedKeys()).contains(DEFAULT_PAYER_KT.asKey()));
+		// and:
+		assertFalse(summary.getOrderedKeys().get(0).isForScheduledTxn());
+		assertTrue(summary.getOrderedKeys().get(1).isForScheduledTxn());
+		assertTrue(summary.getOrderedKeys().get(2).isForScheduledTxn());
 	}
 
 	@Test

--- a/hedera-node/src/test/java/com/hedera/services/sigs/order/SigRequirementsTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/sigs/order/SigRequirementsTest.java
@@ -474,9 +474,9 @@ class SigRequirementsTest {
 		final var summary = subject.keysForOtherParties(txn, summaryFactory);
 
 		// then:
-		assertThat(
-				sanityRestored(summary.getOrderedKeys()),
-				contains(SECOND_TOKEN_SENDER_KT.asKey(), FIRST_TOKEN_SENDER_KT.asKey(), RECEIVER_SIG_KT.asKey()));
+		assertTrue(sanityRestored(summary.getOrderedKeys()).contains(SECOND_TOKEN_SENDER_KT.asKey()));
+		assertTrue(sanityRestored(summary.getOrderedKeys()).contains(RECEIVER_SIG_KT.asKey()));
+		assertTrue(sanityRestored(summary.getOrderedKeys()).contains(FIRST_TOKEN_SENDER_KT.asKey()));
 		assertFalse(sanityRestored(summary.getOrderedKeys()).contains(DEFAULT_PAYER_KT.asKey()));
 	}
 

--- a/hedera-node/src/test/java/com/hedera/services/sigs/verification/PrecheckKeyReqsTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/sigs/verification/PrecheckKeyReqsTest.java
@@ -34,7 +34,6 @@ import com.hederahashgraph.api.proto.java.TransactionID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
@@ -125,11 +124,11 @@ class PrecheckKeyReqsTest {
 		final JKey key1 = new JEd25519Key("firstKey".getBytes());
 		final JKey key2 = new JEd25519Key("secondKey".getBytes());
 		final JKey key3 = new JEd25519Key("thirdKey".getBytes());
-		final JKey key4 = new JEd25519Key("secondKey".getBytes());
+		final JKey key4 = new JEd25519Key("firstKey".getBytes());
 		given(keyOrder.keysForPayer(txn, CODE_ORDER_RESULT_FACTORY))
 				.willReturn(new SigningOrderResult<>(List.of(key1)));
 		given(keyOrderModuloRetry.keysForOtherParties(txn, CODE_ORDER_RESULT_FACTORY))
-				.willReturn(new SigningOrderResult<>(List.of(key1, key2, key2, key3, key4)));
+				.willReturn(new SigningOrderResult<>(List.of(key2, key3, key4)));
 		givenImpliedSubject(FOR_QUERY_PAYMENT);
 
 		// when:

--- a/hedera-node/src/test/java/com/hedera/services/sigs/verification/PrecheckKeyReqsTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/sigs/verification/PrecheckKeyReqsTest.java
@@ -124,10 +124,11 @@ class PrecheckKeyReqsTest {
 	void usesBothOrderForQueryPayments() throws Exception {
 		final JKey key1 = new JEd25519Key("firstKey".getBytes());
 		final JKey key2 = new JEd25519Key("secondKey".getBytes());
+		final JKey key3 = new JEd25519Key("thirdKey".getBytes());
 		given(keyOrder.keysForPayer(txn, CODE_ORDER_RESULT_FACTORY))
 				.willReturn(new SigningOrderResult<>(List.of(key1)));
 		given(keyOrderModuloRetry.keysForOtherParties(txn, CODE_ORDER_RESULT_FACTORY))
-				.willReturn(new SigningOrderResult<>(List.of(key1, key2, key2, key2, key1)));
+				.willReturn(new SigningOrderResult<>(List.of(key1, key2, key2, key3, key1)));
 		givenImpliedSubject(FOR_QUERY_PAYMENT);
 
 		// when:
@@ -138,9 +139,10 @@ class PrecheckKeyReqsTest {
 		verifyNoMoreInteractions(keyOrder);
 		verify(keyOrderModuloRetry).keysForOtherParties(txn, CODE_ORDER_RESULT_FACTORY);
 		verifyNoMoreInteractions(keyOrderModuloRetry);
-		assertEquals(2, keys.size());
+		assertEquals(3, keys.size());
 		assertTrue(keys.contains(key1));
 		assertTrue(keys.contains(key2));
+		assertTrue(keys.contains(key3));
 	}
 
 	private void givenImpliedSubject(Predicate<TransactionBody> isQueryPayment) {

--- a/hedera-node/src/test/java/com/hedera/services/sigs/verification/PrecheckKeyReqsTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/sigs/verification/PrecheckKeyReqsTest.java
@@ -122,8 +122,8 @@ class PrecheckKeyReqsTest {
 
 	@Test
 	void usesBothOrderForQueryPayments() throws Exception {
-		final var key1 = new JEd25519Key("firstKey".getBytes());
-		final var key2 = new JEd25519Key("secondKey".getBytes());
+		final JKey key1 = new JEd25519Key("firstKey".getBytes());
+		final JKey key2 = new JEd25519Key("secondKey".getBytes());
 		given(keyOrder.keysForPayer(txn, CODE_ORDER_RESULT_FACTORY))
 				.willReturn(new SigningOrderResult<>(List.of(key1)));
 		given(keyOrderModuloRetry.keysForOtherParties(txn, CODE_ORDER_RESULT_FACTORY))

--- a/hedera-node/src/test/java/com/hedera/services/sigs/verification/PrecheckKeyReqsTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/sigs/verification/PrecheckKeyReqsTest.java
@@ -33,6 +33,7 @@ import com.hederahashgraph.api.proto.java.TransactionID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
@@ -119,10 +120,13 @@ class PrecheckKeyReqsTest {
 
 	@Test
 	void usesBothOrderForQueryPayments() throws Exception {
+		final List<JKey> duplicateKeys = new ArrayList<>();
+		duplicateKeys.addAll(PAYER_KEYS);
+		duplicateKeys.addAll(OTHER_KEYS);
 		given(keyOrder.keysForPayer(txn, CODE_ORDER_RESULT_FACTORY))
 				.willReturn(new SigningOrderResult<>(PAYER_KEYS));
 		given(keyOrderModuloRetry.keysForOtherParties(txn, CODE_ORDER_RESULT_FACTORY))
-				.willReturn(new SigningOrderResult<>(OTHER_KEYS));
+				.willReturn(new SigningOrderResult<>(duplicateKeys));
 		givenImpliedSubject(FOR_QUERY_PAYMENT);
 
 		// when:
@@ -134,6 +138,7 @@ class PrecheckKeyReqsTest {
 		verify(keyOrderModuloRetry).keysForOtherParties(txn, CODE_ORDER_RESULT_FACTORY);
 		verifyNoMoreInteractions(keyOrderModuloRetry);
 		assertEquals(keys, ALL_KEYS);
+		assertEquals(3, keys.size());
 	}
 
 	private void givenImpliedSubject(Predicate<TransactionBody> isQueryPayment) {

--- a/hedera-node/src/test/java/com/hedera/services/sigs/verification/PrecheckKeyReqsTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/sigs/verification/PrecheckKeyReqsTest.java
@@ -125,10 +125,11 @@ class PrecheckKeyReqsTest {
 		final JKey key1 = new JEd25519Key("firstKey".getBytes());
 		final JKey key2 = new JEd25519Key("secondKey".getBytes());
 		final JKey key3 = new JEd25519Key("thirdKey".getBytes());
+		final JKey key4 = new JEd25519Key("secondKey".getBytes());
 		given(keyOrder.keysForPayer(txn, CODE_ORDER_RESULT_FACTORY))
 				.willReturn(new SigningOrderResult<>(List.of(key1)));
 		given(keyOrderModuloRetry.keysForOtherParties(txn, CODE_ORDER_RESULT_FACTORY))
-				.willReturn(new SigningOrderResult<>(List.of(key1, key2, key2, key3, key1)));
+				.willReturn(new SigningOrderResult<>(List.of(key1, key2, key2, key3, key4)));
 		givenImpliedSubject(FOR_QUERY_PAYMENT);
 
 		// when:

--- a/hedera-node/src/test/java/com/hedera/test/factories/scenarios/ConsensusCreateTopicScenarios.java
+++ b/hedera-node/src/test/java/com/hedera/test/factories/scenarios/ConsensusCreateTopicScenarios.java
@@ -25,6 +25,7 @@ import com.hedera.services.utils.PlatformTxnAccessor;
 import static com.hedera.test.factories.txns.ConsensusCreateTopicFactory.SIMPLE_TOPIC_ADMIN_KEY;
 import static com.hedera.test.factories.txns.ConsensusCreateTopicFactory.newSignedConsensusCreateTopic;
 import static com.hedera.test.factories.txns.PlatformTxnFactory.from;
+import static com.hedera.test.factories.txns.SignedTxnFactory.DEFAULT_PAYER_ID;
 
 public enum ConsensusCreateTopicScenarios implements TxnHandlingScenario {
 	CONSENSUS_CREATE_TOPIC_NO_ADDITIONAL_KEYS_SCENARIO {
@@ -51,6 +52,18 @@ public enum ConsensusCreateTopicScenarios implements TxnHandlingScenario {
 							.adminKey(SIMPLE_TOPIC_ADMIN_KEY)
 							.autoRenewAccountId(MISC_ACCOUNT_ID)
 							.nonPayerKts(SIMPLE_TOPIC_ADMIN_KEY, MISC_ACCOUNT_KT)
+							.get()
+			));
+		}
+	},
+
+	CONSENSUS_CREATE_TOPIC_ADMIN_KEY_AND_AUTORENEW_ACCOUNT_AS_PAYER_SCENARIO {
+		public PlatformTxnAccessor platformTxn() throws Throwable {
+			return new PlatformTxnAccessor(from(
+					newSignedConsensusCreateTopic()
+							.adminKey(SIMPLE_TOPIC_ADMIN_KEY)
+							.autoRenewAccountId(DEFAULT_PAYER_ID)
+							.nonPayerKts(SIMPLE_TOPIC_ADMIN_KEY)
 							.get()
 			));
 		}

--- a/hedera-node/src/test/java/com/hedera/test/factories/scenarios/ConsensusUpdateTopicScenarios.java
+++ b/hedera-node/src/test/java/com/hedera/test/factories/scenarios/ConsensusUpdateTopicScenarios.java
@@ -26,6 +26,7 @@ import java.time.Instant;
 
 import static com.hedera.test.factories.txns.ConsensusUpdateTopicFactory.newSignedConsensusUpdateTopic;
 import static com.hedera.test.factories.txns.PlatformTxnFactory.from;
+import static com.hedera.test.factories.txns.SignedTxnFactory.DEFAULT_PAYER_ID;
 
 public enum ConsensusUpdateTopicScenarios implements TxnHandlingScenario {
 	CONSENSUS_UPDATE_TOPIC_SCENARIO {
@@ -54,6 +55,14 @@ public enum ConsensusUpdateTopicScenarios implements TxnHandlingScenario {
 			return new PlatformTxnAccessor(from(
 					newSignedConsensusUpdateTopic(EXISTING_TOPIC_ID).adminKey(UPDATE_TOPIC_ADMIN_KT)
 							.autoRenewAccountId(MISC_ACCOUNT_ID).get()
+			));
+		}
+	},
+	CONSENSUS_UPDATE_TOPIC_NEW_ADMIN_KEY_AND_AUTORENEW_ACCOUNT_AS_PAYER_SCENARIO {
+		public PlatformTxnAccessor platformTxn() throws Throwable {
+			return new PlatformTxnAccessor(from(
+					newSignedConsensusUpdateTopic(EXISTING_TOPIC_ID).adminKey(UPDATE_TOPIC_ADMIN_KT)
+							.autoRenewAccountId(DEFAULT_PAYER_ID).get()
 			));
 		}
 	},

--- a/hedera-node/src/test/java/com/hedera/test/factories/scenarios/CryptoDeleteScenarios.java
+++ b/hedera-node/src/test/java/com/hedera/test/factories/scenarios/CryptoDeleteScenarios.java
@@ -24,8 +24,16 @@ import com.hedera.services.utils.PlatformTxnAccessor;
 
 import static com.hedera.test.factories.txns.CryptoDeleteFactory.newSignedCryptoDelete;
 import static com.hedera.test.factories.txns.PlatformTxnFactory.from;
+import static com.hedera.test.factories.txns.SignedTxnFactory.DEFAULT_PAYER_ID;
 
 public enum CryptoDeleteScenarios implements TxnHandlingScenario {
+	CRYPTO_DELETE_NO_TARGET_RECEIVER_SIG_SELF_PAID_SCENARIO {
+		public PlatformTxnAccessor platformTxn() throws Throwable {
+			return new PlatformTxnAccessor(from(
+					newSignedCryptoDelete(DEFAULT_PAYER_ID, NO_RECEIVER_SIG_ID).get()
+			));
+		}
+	},
 	CRYPTO_DELETE_NO_TARGET_RECEIVER_SIG_SCENARIO {
 		public PlatformTxnAccessor platformTxn() throws Throwable {
 			return new PlatformTxnAccessor(from(
@@ -37,6 +45,20 @@ public enum CryptoDeleteScenarios implements TxnHandlingScenario {
 		public PlatformTxnAccessor platformTxn() throws Throwable {
 			return new PlatformTxnAccessor(from(
 					newSignedCryptoDelete(MISC_ACCOUNT_ID, RECEIVER_SIG_ID).get()
+			));
+		}
+	},
+	CRYPTO_DELETE_TARGET_RECEIVER_SIG_RECEIVER_PAID_SCENARIO {
+		public PlatformTxnAccessor platformTxn() throws Throwable {
+			return new PlatformTxnAccessor(from(
+					newSignedCryptoDelete(MISC_ACCOUNT_ID, DEFAULT_PAYER_ID).get()
+			));
+		}
+	},
+	CRYPTO_DELETE_TARGET_RECEIVER_SIG_SELF_PAID_SCENARIO {
+		public PlatformTxnAccessor platformTxn() throws Throwable {
+			return new PlatformTxnAccessor(from(
+					newSignedCryptoDelete(DEFAULT_PAYER_ID, RECEIVER_SIG_ID).get()
 			));
 		}
 	},

--- a/hedera-node/src/test/java/com/hedera/test/factories/scenarios/CryptoTransferScenarios.java
+++ b/hedera-node/src/test/java/com/hedera/test/factories/scenarios/CryptoTransferScenarios.java
@@ -25,6 +25,7 @@ import com.hedera.services.utils.PlatformTxnAccessor;
 import static com.hedera.test.factories.txns.CryptoTransferFactory.newSignedCryptoTransfer;
 import static com.hedera.test.factories.txns.PlatformTxnFactory.from;
 import static com.hedera.test.factories.txns.SignedTxnFactory.DEFAULT_NODE_ID;
+import static com.hedera.test.factories.txns.SignedTxnFactory.DEFAULT_PAYER;
 import static com.hedera.test.factories.txns.SignedTxnFactory.DEFAULT_PAYER_ID;
 import static com.hedera.test.factories.txns.SignedTxnFactory.DEFAULT_PAYER_KT;
 import static com.hedera.test.factories.txns.TinyBarsFromTo.tinyBarsFromTo;
@@ -101,10 +102,10 @@ public enum CryptoTransferScenarios implements TxnHandlingScenario {
 		public PlatformTxnAccessor platformTxn() throws Throwable {
 			return new PlatformTxnAccessor(from(
 					newSignedCryptoTransfer()
-							.adjusting(FIRST_TOKEN_SENDER, KNOWN_TOKEN_NO_SPECIAL_KEYS, -1_000)
+							.adjusting(DEFAULT_PAYER, KNOWN_TOKEN_NO_SPECIAL_KEYS, -1_000)
 							.adjusting(SECOND_TOKEN_SENDER, KNOWN_TOKEN_NO_SPECIAL_KEYS, -1_000)
 							.adjusting(TOKEN_RECEIVER, KNOWN_TOKEN_NO_SPECIAL_KEYS, +2_000)
-							.nonPayerKts(FIRST_TOKEN_SENDER_KT, SECOND_TOKEN_SENDER_KT)
+							.nonPayerKts(SECOND_TOKEN_SENDER_KT)
 							.get()
 			));
 		}
@@ -178,6 +179,7 @@ public enum CryptoTransferScenarios implements TxnHandlingScenario {
 			return new PlatformTxnAccessor(from(
 					newSignedCryptoTransfer()
 							.changingOwner(KNOWN_TOKEN_NFT, FIRST_TOKEN_SENDER, RECEIVER_SIG)
+							.changingOwner(ROYALTY_TOKEN_NFT, SECOND_TOKEN_SENDER, DEFAULT_PAYER)
 							.get()
 			));
 		}

--- a/hedera-node/src/test/java/com/hedera/test/factories/scenarios/CryptoUpdateScenarios.java
+++ b/hedera-node/src/test/java/com/hedera/test/factories/scenarios/CryptoUpdateScenarios.java
@@ -24,10 +24,18 @@ import com.hedera.services.utils.PlatformTxnAccessor;
 
 import static com.hedera.test.factories.txns.CryptoUpdateFactory.newSignedCryptoUpdate;
 import static com.hedera.test.factories.txns.PlatformTxnFactory.from;
+import static com.hedera.test.factories.txns.SignedTxnFactory.DEFAULT_PAYER_ID;
 import static com.hedera.test.factories.txns.SignedTxnFactory.MASTER_PAYER_ID;
 import static com.hedera.test.factories.txns.SignedTxnFactory.TREASURY_PAYER_ID;
 
 public enum CryptoUpdateScenarios implements TxnHandlingScenario {
+	CRYPTO_UPDATE_NO_NEW_KEY_SELF_PAID_SCENARIO {
+		public PlatformTxnAccessor platformTxn() throws Throwable {
+			return new PlatformTxnAccessor(from(
+					newSignedCryptoUpdate(DEFAULT_PAYER_ID).get()
+			));
+		}
+	},
 	CRYPTO_UPDATE_NO_NEW_KEY_SCENARIO {
 		public PlatformTxnAccessor platformTxn() throws Throwable {
 			return new PlatformTxnAccessor(from(
@@ -57,6 +65,15 @@ public enum CryptoUpdateScenarios implements TxnHandlingScenario {
 					newSignedCryptoUpdate(COMPLEX_KEY_ACCOUNT_ID)
 							.newAccountKt(NEW_ACCOUNT_KT)
 							.nonPayerKts(COMPLEX_KEY_ACCOUNT_KT, NEW_ACCOUNT_KT)
+							.get()
+			));
+		}
+	},
+	CRYPTO_UPDATE_WITH_NEW_KEY_SELF_PAID_SCENARIO {
+		public PlatformTxnAccessor platformTxn() throws Throwable {
+			return new PlatformTxnAccessor(from(
+					newSignedCryptoUpdate(DEFAULT_PAYER_ID)
+							.newAccountKt(NEW_ACCOUNT_KT)
 							.get()
 			));
 		}

--- a/hedera-node/src/test/java/com/hedera/test/factories/scenarios/ScheduleCreateScenarios.java
+++ b/hedera-node/src/test/java/com/hedera/test/factories/scenarios/ScheduleCreateScenarios.java
@@ -26,6 +26,7 @@ import static com.hedera.test.factories.txns.CryptoTransferFactory.newSignedCryp
 import static com.hedera.test.factories.txns.PlatformTxnFactory.from;
 import static com.hedera.test.factories.txns.ScheduleCreateFactory.newSignedScheduleCreate;
 import static com.hedera.test.factories.txns.ScheduleSignFactory.newSignedScheduleSign;
+import static com.hedera.test.factories.txns.SignedTxnFactory.DEFAULT_PAYER;
 import static com.hedera.test.factories.txns.TinyBarsFromTo.tinyBarsFromTo;
 import static com.hedera.test.factories.txns.TokenMintFactory.newSignedTokenMint;
 
@@ -102,6 +103,19 @@ public enum ScheduleCreateScenarios implements TxnHandlingScenario {
 			return new PlatformTxnAccessor(from(
 					newSignedScheduleCreate()
 							.designatingPayer(DILIGENT_SIGNING_PAYER)
+							.creating(newSignedCryptoTransfer()
+									.skipPayerSig()
+									.transfers(tinyBarsFromTo(MISC_ACCOUNT_ID, RECEIVER_SIG_ID, 1_000L))
+									.get())
+							.get()
+			));
+		}
+	},
+	SCHEDULE_CREATE_XFER_WITH_ADMIN_AND_PAYER_AS_SELF {
+		public PlatformTxnAccessor platformTxn() throws Throwable {
+			return new PlatformTxnAccessor(from(
+					newSignedScheduleCreate()
+							.designatingPayer(DEFAULT_PAYER)
 							.creating(newSignedCryptoTransfer()
 									.skipPayerSig()
 									.transfers(tinyBarsFromTo(MISC_ACCOUNT_ID, RECEIVER_SIG_ID, 1_000L))

--- a/hedera-node/src/test/java/com/hedera/test/factories/scenarios/TokenAssociateScenarios.java
+++ b/hedera-node/src/test/java/com/hedera/test/factories/scenarios/TokenAssociateScenarios.java
@@ -23,6 +23,7 @@ package com.hedera.test.factories.scenarios;
 import com.hedera.services.utils.PlatformTxnAccessor;
 
 import static com.hedera.test.factories.txns.PlatformTxnFactory.from;
+import static com.hedera.test.factories.txns.SignedTxnFactory.DEFAULT_PAYER;
 import static com.hedera.test.factories.txns.TokenAssociateFactory.newSignedTokenAssociate;
 
 public enum TokenAssociateScenarios implements TxnHandlingScenario {
@@ -35,6 +36,18 @@ public enum TokenAssociateScenarios implements TxnHandlingScenario {
 							.associating(KNOWN_TOKEN_WITH_KYC)
 							.associating(KNOWN_TOKEN_NO_SPECIAL_KEYS)
 							.nonPayerKts(MISC_ACCOUNT_KT)
+							.get()
+			));
+		}
+	},
+	TOKEN_ASSOCIATE_WITH_SELF_PAID_KNOWN_TARGET {
+		@Override
+		public PlatformTxnAccessor platformTxn() throws Throwable {
+			return new PlatformTxnAccessor(from(
+					newSignedTokenAssociate()
+							.targeting(DEFAULT_PAYER)
+							.associating(KNOWN_TOKEN_WITH_KYC)
+							.associating(KNOWN_TOKEN_NO_SPECIAL_KEYS)
 							.get()
 			));
 		}

--- a/hedera-node/src/test/java/com/hedera/test/factories/scenarios/TokenCreateScenarios.java
+++ b/hedera-node/src/test/java/com/hedera/test/factories/scenarios/TokenCreateScenarios.java
@@ -29,6 +29,7 @@ import static com.hedera.services.state.submerkle.FcCustomFee.fixedFee;
 import static com.hedera.services.state.submerkle.FcCustomFee.fractionalFee;
 import static com.hedera.services.state.submerkle.FcCustomFee.royaltyFee;
 import static com.hedera.test.factories.txns.PlatformTxnFactory.from;
+import static com.hedera.test.factories.txns.SignedTxnFactory.DEFAULT_PAYER;
 import static com.hedera.test.factories.txns.TokenCreateFactory.newSignedTokenCreate;
 
 public enum TokenCreateScenarios implements TxnHandlingScenario {
@@ -63,6 +64,16 @@ public enum TokenCreateScenarios implements TxnHandlingScenario {
 					newSignedTokenCreate()
 							.missingAdmin()
 							.autoRenew(MISC_ACCOUNT)
+							.get()
+			));
+		}
+	},
+	TOKEN_CREATE_WITH_AUTO_RENEW_AS_PAYER {
+		public PlatformTxnAccessor platformTxn() throws Throwable {
+			return new PlatformTxnAccessor(from(
+					newSignedTokenCreate()
+							.missingAdmin()
+							.autoRenew(DEFAULT_PAYER)
 							.get()
 			));
 		}
@@ -102,6 +113,17 @@ public enum TokenCreateScenarios implements TxnHandlingScenario {
 	TOKEN_CREATE_WITH_FIXED_FEE_COLLECTOR_SIG_REQ {
 		public PlatformTxnAccessor platformTxn() throws Throwable {
 			final var collector = EntityId.fromGrpcAccountId(RECEIVER_SIG);
+			return new PlatformTxnAccessor(from(
+					newSignedTokenCreate()
+							.missingAdmin()
+							.plusCustomFee(fixedFee(123L, null, collector))
+							.get()
+			));
+		}
+	},
+	TOKEN_CREATE_WITH_FIXED_FEE_COLLECTOR_SIG_REQ_AND_AS_PAYER {
+		public PlatformTxnAccessor platformTxn() throws Throwable {
+			final var collector = EntityId.fromGrpcAccountId(DEFAULT_PAYER);
 			return new PlatformTxnAccessor(from(
 					newSignedTokenCreate()
 							.missingAdmin()
@@ -195,6 +217,16 @@ public enum TokenCreateScenarios implements TxnHandlingScenario {
 					newSignedTokenCreate()
 							.missingAdmin()
 							.treasury(MISSING_ACCOUNT)
+							.get()
+			));
+		}
+	},
+	TOKEN_CREATE_WITH_TREASURY_AS_PAYER {
+		public PlatformTxnAccessor platformTxn() throws Throwable {
+			return new PlatformTxnAccessor(from(
+					newSignedTokenCreate()
+							.missingAdmin()
+							.treasury(DEFAULT_PAYER)
 							.get()
 			));
 		}

--- a/hedera-node/src/test/java/com/hedera/test/factories/scenarios/TokenDissociateScenarios.java
+++ b/hedera-node/src/test/java/com/hedera/test/factories/scenarios/TokenDissociateScenarios.java
@@ -23,6 +23,7 @@ package com.hedera.test.factories.scenarios;
 import com.hedera.services.utils.PlatformTxnAccessor;
 
 import static com.hedera.test.factories.txns.PlatformTxnFactory.from;
+import static com.hedera.test.factories.txns.SignedTxnFactory.DEFAULT_PAYER;
 import static com.hedera.test.factories.txns.TokenDissociateFactory.newSignedTokenDissociate;
 
 public enum TokenDissociateScenarios implements TxnHandlingScenario {
@@ -35,6 +36,18 @@ public enum TokenDissociateScenarios implements TxnHandlingScenario {
 							.dissociating(KNOWN_TOKEN_WITH_KYC)
 							.dissociating(KNOWN_TOKEN_NO_SPECIAL_KEYS)
 							.nonPayerKts(MISC_ACCOUNT_KT)
+							.get()
+			));
+		}
+	},
+	TOKEN_DISSOCIATE_WITH_SELF_PAID_KNOWN_TARGET {
+		@Override
+		public PlatformTxnAccessor platformTxn() throws Throwable {
+			return new PlatformTxnAccessor(from(
+					newSignedTokenDissociate()
+							.targeting(DEFAULT_PAYER)
+							.dissociating(KNOWN_TOKEN_WITH_KYC)
+							.dissociating(KNOWN_TOKEN_NO_SPECIAL_KEYS)
 							.get()
 			));
 		}

--- a/hedera-node/src/test/java/com/hedera/test/factories/scenarios/TokenFeeScheduleUpdateScenarios.java
+++ b/hedera-node/src/test/java/com/hedera/test/factories/scenarios/TokenFeeScheduleUpdateScenarios.java
@@ -26,6 +26,7 @@ import com.hedera.services.utils.PlatformTxnAccessor;
 import static com.hedera.services.state.submerkle.EntityId.MISSING_ENTITY_ID;
 import static com.hedera.services.state.submerkle.FcCustomFee.fixedFee;
 import static com.hedera.test.factories.txns.PlatformTxnFactory.from;
+import static com.hedera.test.factories.txns.SignedTxnFactory.DEFAULT_PAYER;
 import static com.hedera.test.factories.txns.TokenFeeScheduleUpdateFactory.newSignedTokenFeeScheduleUpdate;
 
 public enum TokenFeeScheduleUpdateScenarios implements TxnHandlingScenario {
@@ -68,6 +69,21 @@ public enum TokenFeeScheduleUpdateScenarios implements TxnHandlingScenario {
 		public PlatformTxnAccessor platformTxn() throws Throwable {
 			final var feeCollectorNoSigReq = EntityId.fromGrpcAccountId(NO_RECEIVER_SIG);
 			final var feeCollectorWithSigReq = EntityId.fromGrpcAccountId(RECEIVER_SIG);
+			return new PlatformTxnAccessor(from(
+					newSignedTokenFeeScheduleUpdate()
+							.updating(KNOWN_TOKEN_WITH_FEE_SCHEDULE_KEY)
+							.withCustom(fixedFee(1, null, feeCollectorNoSigReq))
+							.withCustom(fixedFee(2, null, feeCollectorWithSigReq))
+							.get()
+			));
+		}
+	},
+
+	UPDATE_TOKEN_WITH_FEE_SCHEDULE_KEY_WITH_FEE_COLLECTOR_SIG_REQ_AND_AS_PAYER {
+		@Override
+		public PlatformTxnAccessor platformTxn() throws Throwable {
+			final var feeCollectorNoSigReq = EntityId.fromGrpcAccountId(NO_RECEIVER_SIG);
+			final var feeCollectorWithSigReq = EntityId.fromGrpcAccountId(DEFAULT_PAYER);
 			return new PlatformTxnAccessor(from(
 					newSignedTokenFeeScheduleUpdate()
 							.updating(KNOWN_TOKEN_WITH_FEE_SCHEDULE_KEY)

--- a/hedera-node/src/test/java/com/hedera/test/factories/scenarios/TokenUpdateScenarios.java
+++ b/hedera-node/src/test/java/com/hedera/test/factories/scenarios/TokenUpdateScenarios.java
@@ -23,6 +23,7 @@ package com.hedera.test.factories.scenarios;
 import com.hedera.services.utils.PlatformTxnAccessor;
 
 import static com.hedera.test.factories.txns.PlatformTxnFactory.from;
+import static com.hedera.test.factories.txns.SignedTxnFactory.DEFAULT_PAYER;
 import static com.hedera.test.factories.txns.TokenUpdateFactory.newSignedTokenUpdate;
 
 public enum TokenUpdateScenarios implements TxnHandlingScenario {
@@ -43,6 +44,17 @@ public enum TokenUpdateScenarios implements TxnHandlingScenario {
 					newSignedTokenUpdate()
 							.updating(KNOWN_TOKEN_NO_SPECIAL_KEYS)
 							.newTreasury(TOKEN_TREASURY)
+							.get()
+			));
+		}
+	},
+	UPDATE_REPLACING_TREASURY_AS_PAYER {
+		@Override
+		public PlatformTxnAccessor platformTxn() throws Throwable {
+			return new PlatformTxnAccessor(from(
+					newSignedTokenUpdate()
+							.updating(KNOWN_TOKEN_NO_SPECIAL_KEYS)
+							.newTreasury(DEFAULT_PAYER)
 							.get()
 			));
 		}
@@ -140,6 +152,17 @@ public enum TokenUpdateScenarios implements TxnHandlingScenario {
 					newSignedTokenUpdate()
 							.updating(KNOWN_TOKEN_NO_SPECIAL_KEYS)
 							.newAutoRenew(MISC_ACCOUNT)
+							.get()
+			));
+		}
+	},
+	TOKEN_UPDATE_WITH_NEW_AUTO_RENEW_ACCOUNT_AS_PAYER {
+		@Override
+		public PlatformTxnAccessor platformTxn() throws Throwable {
+			return new PlatformTxnAccessor(from(
+					newSignedTokenUpdate()
+							.updating(KNOWN_TOKEN_NO_SPECIAL_KEYS)
+							.newAutoRenew(DEFAULT_PAYER)
 							.get()
 			));
 		}


### PR DESCRIPTION
Skip the signature expansion of other party keys if the party matches the payer

Signed-off-by: anighanta <anirudh.ghanta@hedera.com>

**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->

**Related issue(s)**:

Fixes #2287, #2291, #2292 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->
Currently we repeat the signature expansion of the payer if it is also involved in the transaction other than just paying for it. 
 one Example : 
 ```
cryptoTransfer(
					tinyBarsFromTo(sender, receiver , 1L))
					.payingWith(sender)
``` 
we repeat for `sender` 

Added checks to avoid this.


**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
