### PR TITLE
Enhance YAHCLI to set log level

### DIFF
--- a/test-clients/src/main/java/com/hedera/services/bdd/spec/HapiSpecSetup.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/spec/HapiSpecSetup.java
@@ -35,7 +35,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.List;
-import java.util.Map;
 import java.util.Random;
 import java.util.function.Function;
 import java.util.stream.Stream;
@@ -45,7 +44,6 @@ import static com.hedera.services.bdd.spec.HapiPropertySource.asSources;
 import static com.hedera.services.bdd.spec.HapiPropertySource.inPriorityOrder;
 import static com.hedera.services.bdd.spec.keys.KeyFactory.KeyType;
 import static java.util.stream.Collectors.toList;
-import static java.util.stream.Collectors.toMap;
 
 public class HapiSpecSetup {
 	private static final Logger log = LogManager.getLogger(HapiSpecSetup.class);

--- a/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/LoadTest.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/LoadTest.java
@@ -177,7 +177,7 @@ public class LoadTest extends HapiApiSuite {
 
 	@Override
 	protected Logger getResultsLogger() {
-		return null;
+		return log;
 	}
 
 	@Override

--- a/test-clients/src/main/java/com/hedera/services/yahcli/Yahcli.java
+++ b/test-clients/src/main/java/com/hedera/services/yahcli/Yahcli.java
@@ -20,12 +20,6 @@ package com.hedera.services.yahcli;
  * ‍
  */
 
-import com.hedera.services.bdd.spec.HapiApiSpec;
-import com.hedera.services.bdd.spec.fees.FeesAndRatesProvider;
-import com.hedera.services.bdd.spec.infrastructure.HapiApiClients;
-import com.hedera.services.bdd.spec.props.MapPropertySource;
-import com.hedera.services.bdd.spec.queries.HapiQueryOp;
-import com.hedera.services.bdd.spec.queries.file.HapiGetFileContents;
 import com.hedera.services.yahcli.commands.accounts.AccountsCommand;
 import com.hedera.services.yahcli.commands.fees.FeesCommand;
 import com.hedera.services.yahcli.commands.files.SysFilesCommand;
@@ -35,15 +29,7 @@ import com.hedera.services.yahcli.commands.system.FreezeUpgradeCommand;
 import com.hedera.services.yahcli.commands.system.PrepareUpgradeCommand;
 import com.hedera.services.yahcli.commands.system.TelemetryUpgradeCommand;
 import com.hedera.services.yahcli.commands.validation.ValidationCommand;
-import com.hedera.services.yahcli.suites.BalanceSuite;
-import com.hedera.services.yahcli.suites.FreezeHelperSuite;
-import com.hedera.services.yahcli.suites.RekeySuite;
-import com.hedera.services.yahcli.suites.SchedulesValidationSuite;
-import com.hedera.services.yahcli.suites.SysFileDownloadSuite;
-import com.hedera.services.yahcli.suites.SysFileUploadSuite;
-import com.hedera.services.yahcli.suites.UpgradeHelperSuite;
 import org.apache.logging.log4j.Level;
-import org.apache.logging.log4j.LogManager;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.HelpCommand;
@@ -52,7 +38,6 @@ import picocli.CommandLine.Option;
 import picocli.CommandLine.ParameterException;
 import picocli.CommandLine.Spec;
 
-import java.util.List;
 import java.util.concurrent.Callable;
 
 @Command(
@@ -72,6 +57,7 @@ import java.util.concurrent.Callable;
 		description = "Performs DevOps-type actions against a Hedera Services network")
 public class Yahcli implements Callable<Integer> {
 	public static final long NO_FIXED_FEE = Long.MIN_VALUE;
+	public static final String DEFAULT_LOG_LEVEL = "WARN";
 
 	@Spec
 	CommandSpec spec;
@@ -98,13 +84,18 @@ public class Yahcli implements Callable<Integer> {
 			defaultValue = "config.yml")
 	String configLoc;
 
+	@Option(names = {"-v", "--verbose"},
+			paramLabel = "log level",
+			description = "one of : WARN, INFO and DEBUG",
+			defaultValue = DEFAULT_LOG_LEVEL)
+	String loglevel;
+
 	@Override
 	public Integer call() throws Exception {
 		throw new ParameterException(spec.commandLine(), "Please specify a subcommand!");
 	}
 
 	public static void main(String... args) {
-		setLogLevelsToLessNoisy();
 		int rc = new CommandLine(new Yahcli()).execute(args);
 		System.exit(rc);
 	}
@@ -133,25 +124,8 @@ public class Yahcli implements Callable<Integer> {
 		return nodeAccount == null ? nodeAccount : ("0.0." + nodeAccount);
 	}
 
-	private static void setLogLevelsToLessNoisy() {
-		List.of(
-				BalanceSuite.class,
-				RekeySuite.class,
-				SysFileUploadSuite.class,
-				SysFileDownloadSuite.class,
-				SchedulesValidationSuite.class,
-				FreezeHelperSuite.class,
-				UpgradeHelperSuite.class,
-				MapPropertySource.class,
-				HapiApiClients.class,
-				FeesAndRatesProvider.class,
-				HapiQueryOp.class,
-				HapiGetFileContents.class,
-				HapiApiSpec.class
-		).forEach(Yahcli::setToLessNoisy);
-	}
-
-	private static void setToLessNoisy(Class<?> cls) {
-		((org.apache.logging.log4j.core.Logger) LogManager.getLogger(cls)).setLevel(Level.WARN);
+	public Level getLogLevel() {
+		Level level = Level.getLevel(loglevel);
+		return level == null ? Level.WARN : level;
 	}
 }

--- a/test-clients/src/main/java/com/hedera/services/yahcli/commands/accounts/BalanceCommand.java
+++ b/test-clients/src/main/java/com/hedera/services/yahcli/commands/accounts/BalanceCommand.java
@@ -20,7 +20,6 @@ package com.hedera.services.yahcli.commands.accounts;
  * ‍
  */
 
-import com.hedera.services.yahcli.config.ConfigManager;
 import com.hedera.services.yahcli.suites.BalanceSuite;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.HelpCommand;
@@ -29,7 +28,7 @@ import picocli.CommandLine.ParentCommand;
 
 import java.util.concurrent.Callable;
 
-import static com.hedera.services.yahcli.output.CommonMessages.COMMON_MESSAGES;
+import static com.hedera.services.yahcli.config.ConfigUtils.configFrom;
 
 @Command(
 		name = "balance",
@@ -47,9 +46,7 @@ public class BalanceCommand implements Callable<Integer> {
 
 	@Override
 	public Integer call() throws Exception {
-		var config = ConfigManager.from(accountsCommand.getYahcli());
-		config.assertNoMissingDefaults();
-		COMMON_MESSAGES.printGlobalInfo(config);
+		var config = configFrom(accountsCommand.getYahcli());
 
 		StringBuilder balanceRegister = new StringBuilder();
 		String serviceBorder = "---------------------|----------------------|";

--- a/test-clients/src/main/java/com/hedera/services/yahcli/commands/accounts/RekeyCommand.java
+++ b/test-clients/src/main/java/com/hedera/services/yahcli/commands/accounts/RekeyCommand.java
@@ -33,6 +33,7 @@ import java.util.Optional;
 import java.util.concurrent.Callable;
 
 import static com.hedera.services.bdd.spec.HapiApiSpec.SpecStatus.PASSED;
+import static com.hedera.services.yahcli.config.ConfigUtils.configFrom;
 import static com.hedera.services.yahcli.output.CommonMessages.COMMON_MESSAGES;
 
 @CommandLine.Command(
@@ -61,9 +62,7 @@ public class RekeyCommand implements Callable<Integer> {
 
 	@Override
 	public Integer call() throws Exception {
-		var config = ConfigManager.from(accountsCommand.getYahcli());
-		config.assertNoMissingDefaults();
-		COMMON_MESSAGES.printGlobalInfo(config);
+		var config = configFrom(accountsCommand.getYahcli());
 
 		if ("<N/A>".equals(replKeyLoc) && !genNewKey) {
 			throw new CommandLine.ParameterException(

--- a/test-clients/src/main/java/com/hedera/services/yahcli/commands/fees/FeeBasePriceCommand.java
+++ b/test-clients/src/main/java/com/hedera/services/yahcli/commands/fees/FeeBasePriceCommand.java
@@ -20,13 +20,12 @@ package com.hedera.services.yahcli.commands.fees;
  * ‍
  */
 
-import com.hedera.services.yahcli.config.ConfigManager;
 import com.hedera.services.yahcli.suites.CostOfEveryThingSuite;
 import picocli.CommandLine;
 
 import java.util.concurrent.Callable;
 
-import static com.hedera.services.yahcli.output.CommonMessages.COMMON_MESSAGES;
+import static com.hedera.services.yahcli.config.ConfigUtils.configFrom;
 
 @CommandLine.Command(
 		name = "list-base-prices",
@@ -45,9 +44,7 @@ public class FeeBasePriceCommand implements Callable<Integer> {
 
 	@Override
 	public Integer call() throws Exception {
-		var config = ConfigManager.from(feesCommand.getYahcli());
-		config.assertNoMissingDefaults();
-		COMMON_MESSAGES.printGlobalInfo(config);
+		var config = configFrom(feesCommand.getYahcli());
 
 		StringBuilder feeTableSB = new StringBuilder();
 		String serviceBorder = "-------------------------------|-----------------|\n";

--- a/test-clients/src/main/java/com/hedera/services/yahcli/config/ConfigManager.java
+++ b/test-clients/src/main/java/com/hedera/services/yahcli/config/ConfigManager.java
@@ -57,7 +57,7 @@ public class ConfigManager {
 		this.global = global;
 	}
 
-	public static ConfigManager from(Yahcli yahcli) throws IOException {
+	static ConfigManager from(Yahcli yahcli) throws IOException {
 		var yamlLoc = yahcli.getConfigLoc();
 		var yamlIn = new Yaml(new Constructor(GlobalConfig.class));
 		try (InputStream fin = Files.newInputStream(Paths.get(yamlLoc))) {

--- a/test-clients/src/main/java/com/hedera/services/yahcli/config/ConfigUtils.java
+++ b/test-clients/src/main/java/com/hedera/services/yahcli/config/ConfigUtils.java
@@ -20,13 +20,31 @@ package com.hedera.services.yahcli.config;
  * ‍
  */
 
+import com.hedera.services.bdd.spec.HapiApiSpec;
+import com.hedera.services.bdd.spec.fees.FeesAndRatesProvider;
+import com.hedera.services.bdd.spec.infrastructure.HapiApiClients;
+import com.hedera.services.bdd.spec.props.MapPropertySource;
+import com.hedera.services.bdd.spec.queries.HapiQueryOp;
+import com.hedera.services.bdd.spec.queries.file.HapiGetFileContents;
+import com.hedera.services.bdd.spec.transactions.HapiTxnOp;
 import com.hedera.services.yahcli.Yahcli;
+import com.hedera.services.yahcli.suites.BalanceSuite;
+import com.hedera.services.yahcli.suites.CostOfEveryThingSuite;
+import com.hedera.services.yahcli.suites.FreezeHelperSuite;
+import com.hedera.services.yahcli.suites.RekeySuite;
+import com.hedera.services.yahcli.suites.SchedulesValidationSuite;
+import com.hedera.services.yahcli.suites.SysFileDownloadSuite;
+import com.hedera.services.yahcli.suites.SysFileUploadSuite;
+import com.hedera.services.yahcli.suites.UpgradeHelperSuite;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
 
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.nio.file.Paths;
+import java.util.List;
 import java.util.Optional;
 
 import static com.hedera.services.bdd.spec.persistence.SpecKey.readFirstKpFromPem;
@@ -124,9 +142,35 @@ public class ConfigUtils {
 	}
 
 	public static ConfigManager configFrom(Yahcli yahcli) throws IOException {
+		System.out.println("setting loglevel to : " + yahcli.getLogLevel());
+		setLogLevels(yahcli.getLogLevel());
 		var config = ConfigManager.from(yahcli);
 		config.assertNoMissingDefaults();
 		COMMON_MESSAGES.printGlobalInfo(config);
 		return config;
+	}
+
+	private static void setLogLevels(Level logLevel) {
+		List.of(
+				BalanceSuite.class,
+				RekeySuite.class,
+				SysFileUploadSuite.class,
+				SysFileDownloadSuite.class,
+				SchedulesValidationSuite.class,
+				FreezeHelperSuite.class,
+				UpgradeHelperSuite.class,
+				CostOfEveryThingSuite.class,
+				MapPropertySource.class,
+				HapiApiClients.class,
+				FeesAndRatesProvider.class,
+				HapiQueryOp.class,
+				HapiTxnOp.class,
+				HapiGetFileContents.class,
+				HapiApiSpec.class
+		).forEach(cls -> setLogLevel(cls, logLevel));
+	}
+
+	private static void setLogLevel(Class<?> cls, Level logLevel) {
+		((org.apache.logging.log4j.core.Logger) LogManager.getLogger(cls)).setLevel(logLevel);
 	}
 }

--- a/test-clients/yahcli/config.yml
+++ b/test-clients/yahcli/config.yml
@@ -2,7 +2,7 @@ defaultNetwork: localhost
 networks:
   localhost:
     nodes:
-      - { id: 0, account: 3, ipv4Addr: localhost }
+      - { id: 0, account: 3, ipv4Addr: host.docker.internal }
   previewnet:
     nodes:
       - { id: 0, account: 3, ipv4Addr: 35.231.208.148 }

--- a/test-clients/yahcli/config.yml
+++ b/test-clients/yahcli/config.yml
@@ -2,7 +2,7 @@ defaultNetwork: localhost
 networks:
   localhost:
     nodes:
-      - { id: 0, account: 3, ipv4Addr: host.docker.internal }
+      - { id: 0, account: 3, ipv4Addr: localhost }
   previewnet:
     nodes:
       - { id: 0, account: 3, ipv4Addr: 35.231.208.148 }


### PR DESCRIPTION
Signed-off-by: anighanta <anirudh.ghanta@hedera.com>

**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->

**Related issue(s)**:

Fixes #2512 

**Notes for reviewer**:
Now you can set the log level using -v --verbose option like this 
```
java -jar assets/yahcli.jar -n localhost -p 2 -v INFO fees list-base-prices all
```

levels you can set are WARN , INFO and DEBUG. You have to specify these string literals in the command line.
By default its WARN.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
