### PR TITLE
Fixed issue with prefetch task submission (#2427)

### DIFF
--- a/hedera-node/src/main/java/com/hedera/services/ServicesState.java
+++ b/hedera-node/src/main/java/com/hedera/services/ServicesState.java
@@ -230,7 +230,7 @@ public class ServicesState extends AbstractNaryMerkleInternal implements SwirldS
 			// Submit the transaction for any prepare stage processing that can be performed
 			// such as pre-fetching of contract bytecode. This step is performed asynchronously
 			// so get this step started before synchronous signature expansion.
-			app.prefetchProcessor().offer(accessor);
+			app.prefetchProcessor().submit(accessor);
 
 			app.expansionHelper().expandIn(accessor, app.retryingSigReqs(), accessor.getPkToSigsFn());
 		} catch (InvalidProtocolBufferException e) {

--- a/hedera-node/src/test/java/com/hedera/services/ServicesStateTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/ServicesStateTest.java
@@ -271,7 +271,7 @@ class ServicesStateTest {
 
 		// then:
 		verify(expansionHelper).expandIn(txnAccessor, retryingKeyOrder, pubKeyToSigBytes);
-		verify(prefetchProcessor).offer(txnAccessor);
+		verify(prefetchProcessor).submit(txnAccessor);
 	}
 
 	@Test

--- a/pom.xml
+++ b/pom.xml
@@ -182,6 +182,7 @@
     <hamcrest.version>2.2</hamcrest.version>
     <junit5.version>5.8.1</junit5.version>
     <mockito.version>3.12.4</mockito.version>
+    <awaitility.version>3.0.0</awaitility.version>
 
     <!-- SonarCloud properties -->
     <jacoco.version>0.8.7</jacoco.version>
@@ -592,6 +593,12 @@ ${git.signoff}
       <groupId>org.mockito</groupId>
       <artifactId>mockito-junit-jupiter</artifactId>
       <version>${mockito.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <version>${awaitility.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
**Description**:
Fix use of ExecutorService when scheduling pre-fetch EVM bytecode task.

**Related issue(s)**:
Fixes #2427

**Notes for reviewer**:
This PR is a duplicate of a previous one that was targeted for smart-contracts/virtual-map. That PR ran into merge conflicts with the base layer and was abandoned. This PR is targeted to vm-plus-020-test.3.

The sonar errors are caused by files with duplication rates > 1% in the `com.hedera.services.state.virtual` package (in the base layer). Michael has suggested to ignore them as those files are reworked in the hts-contracts branch.

In unit tests, kept one use of Thread.sleep() to add latency during task performing. This delay helps when trying to reproduce scenario when queue fills up. Without the delay, the performing of the tasks can be too quick and the queue empties before the check.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
