### PR TITLE
HTS Precompile fixes

### DIFF
--- a/hedera-node/src/main/java/com/hedera/services/store/contracts/precompile/HTSPrecompiledContract.java
+++ b/hedera-node/src/main/java/com/hedera/services/store/contracts/precompile/HTSPrecompiledContract.java
@@ -599,7 +599,7 @@ public class HTSPrecompiledContract extends AbstractPrecompiledContract {
 			final List<BalanceChange> changes = constructBalanceChanges(transferOp);
 			var validated = impliedTransfersMarshal.assessCustomFeesAndValidate(
 					changes,
-					changes.size(),
+					0,
 					impliedTransfersMarshal.currentProps()
 			);
 

--- a/hedera-node/src/main/java/com/hedera/services/store/contracts/precompile/SyntheticTxnFactory.java
+++ b/hedera-node/src/main/java/com/hedera/services/store/contracts/precompile/SyntheticTxnFactory.java
@@ -86,10 +86,16 @@ public class SyntheticTxnFactory {
 					.addNftTransfers(nftExchange.nftTransfer()));
 		}
 		for (final var fungibleTransfer : fungibleTransfers) {
-			builder.addTokenTransfers(TokenTransferList.newBuilder()
-					.setToken(fungibleTransfer.getDenomination())
-					.addTransfers(fungibleTransfer.senderAdjustment())
-					.addTransfers(fungibleTransfer.receiverAdjustment()));
+			final var tokenTransferList = TokenTransferList.newBuilder()
+					.setToken(fungibleTransfer.getDenomination());
+
+			if (fungibleTransfer.sender != null) {
+				tokenTransferList.addTransfers(fungibleTransfer.senderAdjustment());
+			}
+			if (fungibleTransfer.receiver != null) {
+				tokenTransferList.addTransfers(fungibleTransfer.receiverAdjustment());
+			}
+			builder.addTokenTransfers(tokenTransferList);
 		}
 
 		return TransactionBody.newBuilder().setCryptoTransfer(builder);


### PR DESCRIPTION
Fix numHbar arg we use for assessing custom fees - in the context of a precompile it is always 0
Only add receiver/sender transfers to balance changes if they're present

Signed-off-by: Stoyan Panayotov <stoyan.panayotov@limechain.tech>

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
