### PR TITLE
Add JASPER_DB marker to log4j2 files

### DIFF
--- a/hedera-node/configuration/compose/log4j2.xml
+++ b/hedera-node/configuration/compose/log4j2.xml
@@ -134,6 +134,9 @@
         <MarkerFilter marker="MERKLE_LOCKS"           onMatch="DENY"   onMismatch="NEUTRAL"/>
 
         <MarkerFilter marker="DISABLED"               onMatch="DENY"   onMismatch="DENY" />
+
+        <!-- Jasper DB -->
+        <MarkerFilter marker="JASPER_DB"               onMatch="ACCEPT"   onMismatch="NEUTRAL" />
       </Filters>
     </Logger>
 

--- a/hedera-node/configuration/dev/log4j2.xml
+++ b/hedera-node/configuration/dev/log4j2.xml
@@ -134,6 +134,9 @@
         <MarkerFilter marker="MERKLE_LOCKS"           onMatch="DENY"   onMismatch="NEUTRAL"/>
 
         <MarkerFilter marker="DISABLED"               onMatch="DENY"   onMismatch="DENY" />
+
+        <!-- Jasper DB -->
+        <MarkerFilter marker="JASPER_DB"               onMatch="ACCEPT"   onMismatch="NEUTRAL" />
       </Filters>
     </Logger>
 

--- a/hedera-node/configuration/mainnet/log4j2.xml
+++ b/hedera-node/configuration/mainnet/log4j2.xml
@@ -134,6 +134,9 @@
         <MarkerFilter marker="MERKLE_LOCKS"           onMatch="DENY"   onMismatch="NEUTRAL"/>
 
         <MarkerFilter marker="DISABLED"               onMatch="DENY"   onMismatch="DENY" />
+
+        <!-- Jasper DB -->
+        <MarkerFilter marker="JASPER_DB"               onMatch="ACCEPT"   onMismatch="NEUTRAL" />
       </Filters>
     </Logger>
 

--- a/hedera-node/configuration/preprod/log4j2.xml
+++ b/hedera-node/configuration/preprod/log4j2.xml
@@ -134,6 +134,9 @@
         <MarkerFilter marker="MERKLE_LOCKS"           onMatch="DENY"   onMismatch="NEUTRAL"/>
 
         <MarkerFilter marker="DISABLED"               onMatch="DENY"   onMismatch="DENY" />
+
+        <!-- Jasper DB -->
+        <MarkerFilter marker="JASPER_DB"               onMatch="ACCEPT"   onMismatch="NEUTRAL" />
       </Filters>
     </Logger>
 

--- a/hedera-node/configuration/previewnet/log4j2.xml
+++ b/hedera-node/configuration/previewnet/log4j2.xml
@@ -134,6 +134,9 @@
         <MarkerFilter marker="MERKLE_LOCKS"           onMatch="DENY"   onMismatch="NEUTRAL"/>
 
         <MarkerFilter marker="DISABLED"               onMatch="DENY"   onMismatch="DENY" />
+
+        <!-- Jasper DB -->
+        <MarkerFilter marker="JASPER_DB"               onMatch="ACCEPT"   onMismatch="NEUTRAL" />
       </Filters>
     </Logger>
 

--- a/hedera-node/configuration/testnet/log4j2.xml
+++ b/hedera-node/configuration/testnet/log4j2.xml
@@ -134,6 +134,9 @@
         <MarkerFilter marker="MERKLE_LOCKS"           onMatch="DENY"   onMismatch="NEUTRAL"/>
 
         <MarkerFilter marker="DISABLED"               onMatch="DENY"   onMismatch="DENY" />
+
+        <!-- Jasper DB -->
+        <MarkerFilter marker="JASPER_DB"               onMatch="ACCEPT"   onMismatch="NEUTRAL" />
       </Filters>
     </Logger>
 

--- a/hedera-node/log4j2.xml
+++ b/hedera-node/log4j2.xml
@@ -133,6 +133,9 @@
         <MarkerFilter marker="MERKLE_LOCKS"           onMatch="DENY"   onMismatch="NEUTRAL"/>
 
         <MarkerFilter marker="DISABLED"               onMatch="DENY"   onMismatch="DENY" />
+
+        <!-- Jasper DB -->
+        <MarkerFilter marker="JASPER_DB"               onMatch="ACCEPT"   onMismatch="NEUTRAL" />
       </Filters>
     </Logger>
 


### PR DESCRIPTION
Closes #2567 

Enabled `JASPER_DB` marker in all `log4j2.xml` files to have the related logs appear in `swirlds.log`