### PR TITLE
Final 0.21.x cleanup

### DIFF
--- a/hedera-node/src/main/java/com/hedera/services/fees/FeesModule.java
+++ b/hedera-node/src/main/java/com/hedera/services/fees/FeesModule.java
@@ -37,6 +37,7 @@ import com.hedera.services.fees.calculation.meta.queries.GetExecTimeResourceUsag
 import com.hedera.services.fees.calculation.meta.queries.GetVersionInfoResourceUsage;
 import com.hedera.services.fees.calculation.schedule.ScheduleFeesModule;
 import com.hedera.services.fees.calculation.system.txns.FreezeResourceUsage;
+import com.hedera.services.fees.calculation.system.txns.UncheckedSubmitResourceUsage;
 import com.hedera.services.fees.calculation.token.TokenFeesModule;
 import com.hedera.services.fees.charging.NarratedCharging;
 import com.hedera.services.fees.charging.NarratedLedgerCharging;
@@ -53,6 +54,7 @@ import java.util.Set;
 import static com.hederahashgraph.api.proto.java.HederaFunctionality.Freeze;
 import static com.hederahashgraph.api.proto.java.HederaFunctionality.SystemDelete;
 import static com.hederahashgraph.api.proto.java.HederaFunctionality.SystemUndelete;
+import static com.hederahashgraph.api.proto.java.HederaFunctionality.UncheckedSubmit;
 
 @Module(includes = {
 		FileFeesModule.class,
@@ -104,6 +106,15 @@ public abstract class FeesModule {
 			FreezeResourceUsage freezeResourceUsage
 	) {
 		return List.of(freezeResourceUsage);
+	}
+
+	@Provides
+	@IntoMap
+	@FunctionKey(UncheckedSubmit)
+	public static List<TxnResourceUsageEstimator> provideUncheckedSubmitEstimator(
+			UncheckedSubmitResourceUsage uncheckedResourceUsage
+	) {
+		return List.of(uncheckedResourceUsage);
 	}
 
 	@Provides

--- a/hedera-node/src/main/java/com/hedera/services/fees/calculation/system/txns/UncheckedSubmitResourceUsage.java
+++ b/hedera-node/src/main/java/com/hedera/services/fees/calculation/system/txns/UncheckedSubmitResourceUsage.java
@@ -1,0 +1,54 @@
+package com.hedera.services.fees.calculation.system.txns;
+
+
+/*-
+ * ‌
+ * Hedera Services Node
+ * ​
+ * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import com.hedera.services.context.primitives.StateView;
+import com.hedera.services.fees.calculation.TxnResourceUsageEstimator;
+import com.hederahashgraph.api.proto.java.FeeData;
+import com.hederahashgraph.api.proto.java.TransactionBody;
+import com.hederahashgraph.exception.InvalidTxBodyException;
+import com.hederahashgraph.fee.SigValueObj;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+@Singleton
+public final class UncheckedSubmitResourceUsage implements TxnResourceUsageEstimator {
+	@Inject
+	public UncheckedSubmitResourceUsage() {
+		/* No-op */
+	}
+
+	@Override
+	public boolean applicableTo(final TransactionBody txn) {
+		return txn.hasUncheckedSubmit();
+	}
+
+	@Override
+	public FeeData usageGiven(
+			final TransactionBody txn,
+			final SigValueObj sigUsage,
+			final StateView view
+	) throws InvalidTxBodyException {
+		return FeeData.getDefaultInstance();
+	}
+}

--- a/hedera-node/src/main/java/com/hedera/services/records/TxnAwareRecordsHistorian.java
+++ b/hedera-node/src/main/java/com/hedera/services/records/TxnAwareRecordsHistorian.java
@@ -204,6 +204,11 @@ public class TxnAwareRecordsHistorian implements AccountRecordsHistorian {
 			child.setTxnId(parentId.withNonce(nextNonce++));
 			final var childConsTime = nonNegativeNanosOffset(consensusNow, sigNum * (i + 1));
 			child.setConsensusTime(RichInstant.fromJava(childConsTime));
+			/* Mirror node team prefers we only set a parent consensus time for records that FOLLOW
+			 * the top-level transaction. This might change for future use cases. */
+			if (sigNum > 0) {
+				child.setParentConsensusTime(consensusNow);
+			}
 
 			final var synthTxn = synthFrom(inProgress.getSyntheticBody(), child);
 			final var synthHash = noThrowSha384HashOf(synthTxn.getSignedTransactionBytes().toByteArray());
@@ -246,9 +251,10 @@ public class TxnAwareRecordsHistorian implements AccountRecordsHistorian {
 			final AccountID effPayer,
 			final TransactionID txnId,
 			final long submittingMember,
-			final long expiry
+			final long consensusSecond
 	) {
-		final var expiringRecord = creator.saveExpiringRecord(effPayer, baseRecord, expiry, submittingMember);
+		final var expiringRecord = creator.saveExpiringRecord(
+				effPayer, baseRecord, consensusSecond, submittingMember);
 		recordCache.setPostConsensus(txnId, baseRecord.getEnumStatus(), expiringRecord);
 	}
 }

--- a/hedera-node/src/main/java/com/hedera/services/state/submerkle/ExpirableTxnRecord.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/submerkle/ExpirableTxnRecord.java
@@ -45,6 +45,7 @@ import java.util.Objects;
 import java.util.stream.IntStream;
 
 import static com.hedera.services.state.merkle.internals.BitPackUtils.packedTime;
+import static com.hedera.services.utils.MiscUtils.asTimestamp;
 import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.toList;
 
@@ -501,7 +502,6 @@ public class ExpirableTxnRecord implements FCQueueElement {
 		var grpc = TransactionRecord.newBuilder();
 
 		grpc.setTransactionFee(fee);
-
 		if (receipt != null) {
 			grpc.setReceipt(TxnReceipt.convert(receipt));
 		}
@@ -529,23 +529,22 @@ public class ExpirableTxnRecord implements FCQueueElement {
 		if (tokens != NO_TOKENS) {
 			setGrpcTokens(grpc, tokens, tokenAdjustments, nftTokenAdjustments);
 		}
-
 		if (scheduleRef != NO_SCHEDULE_REF) {
 			grpc.setScheduleRef(scheduleRef.toGrpcScheduleId());
 		}
-
 		if (assessedCustomFees != NO_CUSTOM_FEES) {
 			grpc.addAllAssessedCustomFees(
 					assessedCustomFees.stream().map(FcAssessedCustomFee::toGrpc).collect(toList()));
 		}
-
 		if (newTokenAssociations != NO_NEW_TOKEN_ASSOCIATIONS) {
 			grpc.addAllAutomaticTokenAssociations(
 					newTokenAssociations.stream().map(FcTokenAssociation::toGrpc).collect(toList()));
 		}
-
 		if (alias != MISSING_ALIAS) {
 			grpc.setAlias(alias);
+		}
+		if (packedParentConsensusTime != MISSING_PARENT_CONSENSUS_TIMESTAMP) {
+			grpc.setParentConsensusTimestamp(asTimestamp(packedParentConsensusTime));
 		}
 
 		return grpc.build();

--- a/hedera-node/src/main/java/com/hedera/services/utils/MiscUtils.java
+++ b/hedera-node/src/main/java/com/hedera/services/utils/MiscUtils.java
@@ -98,6 +98,8 @@ import static com.hedera.services.grpc.controllers.NetworkController.GET_EXECUTI
 import static com.hedera.services.grpc.controllers.NetworkController.GET_VERSION_INFO_METRIC;
 import static com.hedera.services.grpc.controllers.NetworkController.UNCHECKED_SUBMIT_METRIC;
 import static com.hedera.services.legacy.core.jproto.JKey.mapJKey;
+import static com.hedera.services.state.merkle.internals.BitPackUtils.signedLowOrder32From;
+import static com.hedera.services.state.merkle.internals.BitPackUtils.unsignedHighOrder32From;
 import static com.hedera.services.stats.ServicesStatsConfig.SYSTEM_DELETE_METRIC;
 import static com.hedera.services.stats.ServicesStatsConfig.SYSTEM_UNDELETE_METRIC;
 import static com.hedera.services.utils.EntityIdUtils.parseAccount;
@@ -438,6 +440,13 @@ public final class MiscUtils {
 		} catch (Exception impossible) {
 			return Key.getDefaultInstance();
 		}
+	}
+
+	public static Timestamp asTimestamp(final long packedTime) {
+		return Timestamp.newBuilder()
+				.setSeconds(unsignedHighOrder32From(packedTime))
+				.setNanos(signedLowOrder32From(packedTime))
+				.build();
 	}
 
 	public static Timestamp asTimestamp(final Instant when) {

--- a/hedera-node/src/test/java/com/hedera/services/fees/calculation/system/txns/UncheckedSubmitResourceUsageTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/fees/calculation/system/txns/UncheckedSubmitResourceUsageTest.java
@@ -1,0 +1,59 @@
+package com.hedera.services.fees.calculation.system.txns;
+
+/*-
+ * ‌
+ * Hedera Services Node
+ * ​
+ * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import com.hederahashgraph.api.proto.java.FeeData;
+import com.hederahashgraph.api.proto.java.TransactionBody;
+import com.hederahashgraph.exception.InvalidTxBodyException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+class UncheckedSubmitResourceUsageTest {
+	private UncheckedSubmitResourceUsage subject;
+
+	@BeforeEach
+	private void setup() {
+		subject = new UncheckedSubmitResourceUsage();
+	}
+
+	@Test
+	void recognizesApplicability() {
+		final var txn = mock(TransactionBody.class);
+		given(txn.hasUncheckedSubmit()).willReturn(true, false);
+
+		assertTrue(subject.applicableTo(txn));
+		assertFalse(subject.applicableTo(txn));
+		verify(txn, times(2)).hasUncheckedSubmit();
+	}
+
+	@Test
+	void delegatesToCorrectEstimate() throws InvalidTxBodyException {
+		assertEquals(FeeData.getDefaultInstance(), subject.usageGiven(null, null, null));
+	}
+}

--- a/hedera-node/src/test/java/com/hedera/services/records/TxnAwareRecordsHistorianTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/records/TxnAwareRecordsHistorianTest.java
@@ -21,7 +21,6 @@ package com.hedera.services.records;
  */
 
 import com.hedera.services.context.TransactionContext;
-import com.hedera.services.legacy.core.jproto.JKey;
 import com.hedera.services.legacy.core.jproto.TxnReceipt;
 import com.hedera.services.state.expiry.ExpiringCreations;
 import com.hedera.services.state.expiry.ExpiringEntity;
@@ -32,7 +31,6 @@ import com.hedera.services.state.submerkle.ExpirableTxnRecord;
 import com.hedera.services.state.submerkle.RichInstant;
 import com.hedera.services.state.submerkle.TxnId;
 import com.hedera.services.utils.PlatformTxnAccessor;
-import com.hedera.test.factories.scenarios.TxnHandlingScenario;
 import com.hederahashgraph.api.proto.java.AccountID;
 import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
 import com.hederahashgraph.api.proto.java.SignedTransaction;
@@ -77,7 +75,6 @@ class TxnAwareRecordsHistorianTest {
 	final private AccountID b = asAccount("0.0.2222");
 	final private AccountID c = asAccount("0.0.3333");
 	final private AccountID effPayer = asAccount("0.0.5555");
-	final private JKey effPayerKey = TxnHandlingScenario.MISC_ACCOUNT_KT.asJKeyUnchecked();
 	final private long nows = 1_234_567L;
 	final private int nanos = 999_999_999;
 	final private Instant topLevelNow = Instant.ofEpochSecond(nows, 999_999_999);
@@ -220,6 +217,7 @@ class TxnAwareRecordsHistorianTest {
 		verify(topLevelRecord).excludeHbarChangesFrom(precedingBuilder);
 		verify(topLevelRecord).setNumChildRecords((short) 2);
 		verify(followingBuilder).setConsensusTime(RichInstant.fromJava(expectedFollowTime));
+		verify(followingBuilder).setParentConsensusTime(topLevelNow);
 		verify(precedingBuilder).setConsensusTime(RichInstant.fromJava(expectedPrecedingTime));
 		verify(precedingBuilder).setTxnId(expectedPrecedingChildId);
 		verify(followingBuilder).setTxnId(expectedFollowingChildId);

--- a/hedera-node/src/test/java/com/hedera/services/state/submerkle/ExpirableTxnRecordTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/state/submerkle/ExpirableTxnRecordTest.java
@@ -23,6 +23,7 @@ package com.hedera.services.state.submerkle;
 import com.google.protobuf.ByteString;
 import com.hedera.services.state.serdes.DomainSerdes;
 import com.hedera.services.state.serdes.DomainSerdesTest;
+import com.hedera.services.utils.MiscUtils;
 import com.hedera.test.utils.IdUtils;
 import com.hederahashgraph.api.proto.java.AccountID;
 import com.hederahashgraph.api.proto.java.ScheduleID;
@@ -60,7 +61,6 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.mock;
 import static org.mockito.Mockito.times;
@@ -488,7 +488,11 @@ class ExpirableTxnRecordTest {
 
 	@Test
 	void asGrpcWorks() {
-		final var expected = grpcRecordWithTokenTransfersScheduleRefCustomFeesAndTokenAssociations();
+		final var expected = grpcRecordWithTokenTransfersScheduleRefCustomFeesAndTokenAssociations()
+				.toBuilder()
+				.setParentConsensusTimestamp(MiscUtils.asTimestamp(packedParentConsTime))
+				.build();
+
 		subject = subjectRecordWithTokenTransfersScheduleRefCustomFeesAndTokenAssociations();
 		subject.setExpiry(0L);
 		subject.setSubmittingMember(UNKNOWN_SUBMITTING_MEMBER);

--- a/hedera-node/src/test/java/com/hedera/services/state/submerkle/ExpirableTxnRecordTestHelper.java
+++ b/hedera-node/src/test/java/com/hedera/services/state/submerkle/ExpirableTxnRecordTestHelper.java
@@ -62,13 +62,12 @@ public class ExpirableTxnRecordTestHelper {
 				: null;
 		final var newTokenAssociations =
 				 record.getAutomaticTokenAssociationsList().stream().map(FcTokenAssociation::fromGrpc).collect(toList());
-		return ExpirableTxnRecord.newBuilder()
+		final var builder = ExpirableTxnRecord.newBuilder()
 				.setReceipt(TxnReceipt.fromGrpc(record.getReceipt()))
 				.setTxnHash(record.getTransactionHash().toByteArray())
 				.setTxnId(TxnId.fromGrpc(record.getTransactionID()))
 				.setConsensusTime(RichInstant.fromGrpc(record.getConsensusTimestamp()))
 				.setMemo(record.getMemo())
-				.setParentConsensusTime(MiscUtils.timestampToInstant(record.getParentConsensusTimestamp()))
 				.setFee(record.getTransactionFee())
 				.setTransferList(
 						record.hasTransferList() ? CurrencyAdjustments.fromGrpc(record.getTransferList()) : null)
@@ -82,7 +81,10 @@ public class ExpirableTxnRecordTestHelper {
 				.setScheduleRef(record.hasScheduleRef() ? fromGrpcScheduleId(record.getScheduleRef()) : null)
 				.setAssessedCustomFees(fcAssessedFees)
 				.setNewTokenAssociations(newTokenAssociations)
-				.setAlias(record.getAlias())
-				.build();
+				.setAlias(record.getAlias());
+		if (record.hasParentConsensusTimestamp()) {
+			builder.setParentConsensusTime(MiscUtils.timestampToInstant(record.getParentConsensusTimestamp()));
+		}
+		return builder.build();
 	}
 }

--- a/hedera-node/src/test/java/com/hedera/services/state/submerkle/ExpirableTxnRecordTestHelper.java
+++ b/hedera-node/src/test/java/com/hedera/services/state/submerkle/ExpirableTxnRecordTestHelper.java
@@ -20,6 +20,7 @@ package com.hedera.services.state.submerkle;
  * ‍
  */
 import com.hedera.services.legacy.core.jproto.TxnReceipt;
+import com.hedera.services.utils.MiscUtils;
 import com.hederahashgraph.api.proto.java.TokenTransferList;
 import com.hederahashgraph.api.proto.java.TransactionRecord;
 
@@ -67,6 +68,7 @@ public class ExpirableTxnRecordTestHelper {
 				.setTxnId(TxnId.fromGrpc(record.getTransactionID()))
 				.setConsensusTime(RichInstant.fromGrpc(record.getConsensusTimestamp()))
 				.setMemo(record.getMemo())
+				.setParentConsensusTime(MiscUtils.timestampToInstant(record.getParentConsensusTimestamp()))
 				.setFee(record.getTransactionFee())
 				.setTransferList(
 						record.hasTransferList() ? CurrencyAdjustments.fromGrpc(record.getTransferList()) : null)

--- a/hedera-node/src/test/java/com/hedera/services/utils/MiscUtilsTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/utils/MiscUtilsTest.java
@@ -35,6 +35,7 @@ import com.hedera.services.legacy.core.KeyPairObj;
 import com.hedera.services.legacy.core.jproto.JEd25519Key;
 import com.hedera.services.legacy.core.jproto.JKey;
 import com.hedera.services.legacy.proto.utils.CommonUtils;
+import com.hedera.services.state.merkle.internals.BitPackUtils;
 import com.hedera.services.state.submerkle.ExpirableTxnRecord;
 import com.hedera.services.stats.ServicesStatsConfig;
 import com.hedera.test.utils.IdUtils;
@@ -258,6 +259,15 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
 class MiscUtilsTest {
+	@Test
+	void canUnpackTime() {
+		final long seconds = 1_234_567L;
+		final int nanos = 890;
+		final var packedTime = BitPackUtils.packedTime(seconds, nanos);
+		final var expected = Timestamp.newBuilder().setSeconds(seconds).setNanos(nanos).build();
+		assertEquals(expected, MiscUtils.asTimestamp(packedTime));
+	}
+
 	@Test
 	void forEachDropInWorksAsExpected() {
 		// setup:

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/AutoAccountCreationSuite.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/AutoAccountCreationSuite.java
@@ -113,6 +113,7 @@ public class AutoAccountCreationSuite extends HapiApiSuite {
 								.payingWith(GENESIS)
 								.via(autoCreation)
 				).then(
+						getTxnRecord(autoCreation).andAllChildRecords().logged(),
 						getAliasedAccountBalance(ed25519SourceKey),
 						getAliasedAccountBalance(secp256k1SourceKey),
 						getAliasedAccountInfo(ed25519SourceKey).hasExpectedAliasKey(),

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/records/DuplicateManagementTest.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/records/DuplicateManagementTest.java
@@ -46,6 +46,7 @@ import static com.hedera.services.bdd.spec.utilops.UtilVerbs.withOpContext;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.DUPLICATE_TRANSACTION;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_NODE_ACCOUNT;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_PAYER_SIGNATURE;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.NOT_SUPPORTED;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SUCCESS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -70,9 +71,16 @@ public class DuplicateManagementTest extends HapiApiSuite {
 	private HapiApiSpec hasExpectedDuplicates() {
 		return defaultHapiSpec("HasExpectedDuplicates")
 				.given(
-						cryptoCreate("civilian").balance(100 * 100_000_000L),
+						cryptoCreate("civilian").balance(ONE_HUNDRED_HBARS),
 						usableTxnIdNamed("txnId").payerId("civilian")
 				).when(
+						uncheckedSubmit(
+								cryptoCreate("repeated")
+										.payingWith("civilian")
+										.txnId("txnId"))
+								.payingWith("civilian")
+								.fee(ONE_HBAR)
+								.hasPrecheck(NOT_SUPPORTED),
 						uncheckedSubmit(
 								cryptoCreate("repeated")
 										.payingWith("civilian")


### PR DESCRIPTION
**Description**:
- Adds an `UncheckedSubmitResourceUsage` estimator to avoid a `FAIL_FEE` response in precheck when an unauthorized payer tries this operation.
- Updates `ExpirableTxnRecord.asGrpc()` to translate the `packedParentConsensusTime` field, and makes explicit in `AccountRecordsHistorian` the `parentConsensusTimestamp` is only set for child records that _follow_ the top-level transaction.
