### PR TITLE
Add CodeCache to HederaWorldState

### DIFF
--- a/hedera-node/src/main/java/com/hedera/services/store/contracts/HederaWorldState.java
+++ b/hedera-node/src/main/java/com/hedera/services/store/contracts/HederaWorldState.java
@@ -63,14 +63,17 @@ public class HederaWorldState implements HederaMutableWorldState {
 	private final EntityAccess entityAccess;
 	private final Map<Address, Address> sponsorMap = new LinkedHashMap<>();
 	private final List<ContractID> provisionalContractCreations = new LinkedList<>();
+	private final CodeCache codeCache;
 
 	@Inject
 	public HederaWorldState(
 			final EntityIdSource ids,
-			final EntityAccess entityAccess
+			final EntityAccess entityAccess,
+			final CodeCache codeCache
 	) {
 		this.ids = ids;
 		this.entityAccess = entityAccess;
+		this.codeCache = codeCache;
 	}
 
 	@Override
@@ -204,7 +207,7 @@ public class HederaWorldState implements HederaMutableWorldState {
 
 		@Override
 		public Bytes getCode() {
-			return entityAccess.fetchCode(account);
+			return codeCache.get(address).getBytes();
 		}
 
 		public EntityId getProxyAccount() {
@@ -222,7 +225,7 @@ public class HederaWorldState implements HederaMutableWorldState {
 
 		@Override
 		public Hash getCodeHash() {
-			return Hash.hash(this.getCode());
+			return codeCache.get(address).getCodeHash();
 		}
 
 		@Override

--- a/hedera-node/src/test/java/com/hedera/services/fees/calculation/contract/queries/ContractCallLocalResourceUsageTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/fees/calculation/contract/queries/ContractCallLocalResourceUsageTest.java
@@ -24,6 +24,7 @@ import com.google.protobuf.ByteString;
 import com.hedera.services.config.MockGlobalDynamicProps;
 import com.hedera.services.context.primitives.StateView;
 import com.hedera.services.context.properties.GlobalDynamicProperties;
+import com.hedera.services.context.properties.NodeLocalProperties;
 import com.hedera.services.contracts.execution.CallLocalEvmTxProcessor;
 import com.hedera.services.contracts.execution.TransactionProcessingResult;
 import com.hedera.services.ledger.ids.EntityIdSource;
@@ -97,6 +98,8 @@ class ContractCallLocalResourceUsageTest {
 	private EntityIdSource ids;
 	@Mock
 	private OptionValidator validator;
+	@Mock
+	private NodeLocalProperties nodeLocalProperties;
 
 	@LoggingTarget
 	private LogCaptor logCaptor;
@@ -107,7 +110,7 @@ class ContractCallLocalResourceUsageTest {
 	@BeforeEach
 	private void setup() {
 		subject = new ContractCallLocalResourceUsage(
-				usageEstimator, properties, accountStore, evmTxProcessor, ids, validator);
+				usageEstimator, properties, nodeLocalProperties, accountStore, evmTxProcessor, ids, validator);
 	}
 
 	@Test

--- a/hedera-node/src/test/java/com/hedera/services/queries/contract/ContractCallLocalAnswerTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/queries/contract/ContractCallLocalAnswerTest.java
@@ -23,6 +23,7 @@ package com.hedera.services.queries.contract;
 import com.google.protobuf.ByteString;
 import com.hedera.services.context.primitives.StateView;
 import com.hedera.services.context.properties.GlobalDynamicProperties;
+import com.hedera.services.context.properties.NodeLocalProperties;
 import com.hedera.services.contracts.execution.CallLocalEvmTxProcessor;
 import com.hedera.services.contracts.execution.TransactionProcessingResult;
 import com.hedera.services.ledger.ids.EntityIdSource;
@@ -101,12 +102,15 @@ class ContractCallLocalAnswerTest {
 	private CallLocalEvmTxProcessor evmTxProcessor;
 	@Mock
 	private MerkleMap<EntityNum, MerkleAccount> contracts;
+	@Mock
+	private NodeLocalProperties nodeLocalProperties;
+
 
 	private ContractCallLocalAnswer subject;
 
 	@BeforeEach
 	private void setup() throws Throwable {
-		subject = new ContractCallLocalAnswer(ids, accountStore, validator, dynamicProperties, evmTxProcessor);
+		subject = new ContractCallLocalAnswer(ids, accountStore, validator, dynamicProperties, nodeLocalProperties, evmTxProcessor);
 	}
 
 	@Test

--- a/hedera-node/src/test/java/com/hedera/services/store/contracts/HederaWorldStateTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/store/contracts/HederaWorldStateTest.java
@@ -85,7 +85,8 @@ class HederaWorldStateTest {
 
 	@BeforeEach
 	void setUp() {
-		subject = new HederaWorldState(ids, entityAccess);
+		CodeCache codeCache = new CodeCache(0, entityAccess);
+	 	subject = new HederaWorldState(ids, entityAccess, codeCache);
 	}
 
 	@Test

--- a/hedera-node/src/test/java/com/hedera/services/store/contracts/UpdateTrackingLedgerAccountTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/store/contracts/UpdateTrackingLedgerAccountTest.java
@@ -69,7 +69,8 @@ class UpdateTrackingLedgerAccountTest {
 
 	@BeforeEach
 	void setUp() {
-		parentState = new HederaWorldState(ids, entityAccess);
+		CodeCache codeCache = new CodeCache(0, entityAccess);
+		parentState = new HederaWorldState(ids, entityAccess, codeCache);
 	}
 
 	@Test


### PR DESCRIPTION
**Description**:
Add the CodeCache to HederaWorldState. This improves speed of
repetative calls and hashing of the code in CALL* and EXTCODE* ops.


**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
