### PR TITLE
Use `MerkleMap` for existence check in `BackingTokenRels`

### DIFF
--- a/hedera-node/src/main/java/com/hedera/services/context/init/StateInitializationFlow.java
+++ b/hedera-node/src/main/java/com/hedera/services/context/init/StateInitializationFlow.java
@@ -26,6 +26,7 @@ import com.hedera.services.files.FileUpdateInterceptor;
 import com.hedera.services.files.HederaFs;
 import com.hedera.services.state.StateAccessor;
 import com.hedera.services.state.annotations.WorkingState;
+import com.hedera.services.state.migration.StateChildIndices;
 import com.hedera.services.stream.RecordStreamManager;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -67,6 +68,27 @@ public class StateInitializationFlow {
 
 		stateAccessor.updateFrom(activeState);
 		log.info("Context updated with working state");
+		log.info("  (@ {}) # NFTs               = {}",
+				StateChildIndices.UNIQUE_TOKENS,
+				activeState.uniqueTokens().size());
+		log.info("  (@ {}) # token associations = {}",
+				StateChildIndices.TOKEN_ASSOCIATIONS,
+				activeState.tokenAssociations().size());
+		log.info("  (@ {}) # topics             = {}",
+				StateChildIndices.TOPICS,
+				activeState.topics().size());
+		log.info("  (@ {}) # blobs              = {}",
+				StateChildIndices.STORAGE,
+				activeState.storage().size());
+		log.info("  (@ {}) # accounts/contracts = {}",
+				StateChildIndices.ACCOUNTS,
+				activeState.accounts().size());
+		log.info("  (@ {}) # tokens             = {}",
+				StateChildIndices.TOKENS,
+				activeState.tokens().size());
+		log.info("  (@ {}) # scheduled txns     = {}",
+				StateChildIndices.SCHEDULE_TXS,
+				activeState.scheduleTxs().size());
 
 		final var activeHash = activeState.runningHashLeaf().getRunningHash().getHash();
 		recordStreamManager.setInitialHash(activeHash);

--- a/hedera-node/src/main/java/com/hedera/services/store/TypedTokenStore.java
+++ b/hedera-node/src/main/java/com/hedera/services/store/TypedTokenStore.java
@@ -91,7 +91,6 @@ public class TypedTokenStore {
 	private final Supplier<MerkleMap<EntityNumPair, MerkleTokenRelStatus>> tokenRels;
 
 	/* Only needed for interoperability with legacy HTS during refactor */
-	private final BackingTokenRels backingTokenRels;
 	private final LegacyTreasuryRemover delegate;
 	private final LegacyTreasuryAdder addKnownTreasury;
 
@@ -101,7 +100,6 @@ public class TypedTokenStore {
 			final Supplier<MerkleMap<EntityNum, MerkleToken>> tokens,
 			final Supplier<MerkleMap<EntityNumPair, MerkleUniqueToken>> uniqueTokens,
 			final Supplier<MerkleMap<EntityNumPair, MerkleTokenRelStatus>> tokenRels,
-			final BackingTokenRels backingTokenRels,
 			final UniqTokenViewsManager uniqTokenViewsManager,
 			final LegacyTreasuryAdder legacyStoreDelegate,
 			final LegacyTreasuryRemover delegate,
@@ -114,7 +112,6 @@ public class TypedTokenStore {
 		this.accountStore = accountStore;
 		this.sideEffectsTracker = sideEffectsTracker;
 		this.delegate = delegate;
-		this.backingTokenRels = backingTokenRels;
 		this.addKnownTreasury = legacyStoreDelegate;
 	}
 
@@ -213,7 +210,6 @@ public class TypedTokenStore {
 			final var key = EntityNumPair.fromModelRel(tokenRelationship);
 			if (tokenRelationship.isDestroyed()) {
 				currentTokenRels.remove(key);
-				backingTokenRels.removeFromExistingRels(legacyReprOf(tokenRelationship));
 			} else {
 				persistNonDestroyed(tokenRelationship, key, currentTokenRels);
 			}
@@ -257,7 +253,6 @@ public class TypedTokenStore {
 		mutableTokenRel.setAutomaticAssociation(modelRel.isAutomaticAssociation());
 		if (isNewRel) {
 			currentTokenRels.put(key, mutableTokenRel);
-			alertTokenBackingStoreOfNew(modelRel);
 		}
 	}
 
@@ -567,10 +562,6 @@ public class TypedTokenStore {
 		uniqueToken.setCreationTime(immutableUniqueToken.getCreationTime());
 		uniqueToken.setMetadata(immutableUniqueToken.getMetadata());
 		uniqueToken.setOwner(immutableUniqueToken.getOwner().asId());
-	}
-
-	private void alertTokenBackingStoreOfNew(TokenRelationship newRel) {
-		backingTokenRels.addToExistingRels(legacyReprOf(newRel));
 	}
 
 	@FunctionalInterface

--- a/hedera-node/src/main/java/com/hedera/services/store/TypedTokenStore.java
+++ b/hedera-node/src/main/java/com/hedera/services/store/TypedTokenStore.java
@@ -22,7 +22,6 @@ package com.hedera.services.store;
 
 import com.hedera.services.context.SideEffectsTracker;
 import com.hedera.services.exceptions.InvalidTransactionException;
-import com.hedera.services.ledger.accounts.BackingTokenRels;
 import com.hedera.services.records.TransactionRecordService;
 import com.hedera.services.state.merkle.MerkleToken;
 import com.hedera.services.state.merkle.MerkleTokenRelStatus;

--- a/hedera-node/src/test/java/com/hedera/services/context/init/StateInitializationFlowTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/context/init/StateInitializationFlowTest.java
@@ -26,10 +26,20 @@ import com.hedera.services.config.MockHederaNumbers;
 import com.hedera.services.files.FileUpdateInterceptor;
 import com.hedera.services.files.HederaFs;
 import com.hedera.services.state.StateAccessor;
+import com.hedera.services.state.merkle.MerkleAccount;
+import com.hedera.services.state.merkle.MerkleOptionalBlob;
+import com.hedera.services.state.merkle.MerkleSchedule;
+import com.hedera.services.state.merkle.MerkleToken;
+import com.hedera.services.state.merkle.MerkleTokenRelStatus;
+import com.hedera.services.state.merkle.MerkleTopic;
+import com.hedera.services.state.merkle.MerkleUniqueToken;
 import com.hedera.services.stream.RecordStreamManager;
 import com.hedera.services.stream.RecordsRunningHashLeaf;
+import com.hedera.services.utils.EntityNum;
+import com.hedera.services.utils.EntityNumPair;
 import com.swirlds.common.crypto.Hash;
 import com.swirlds.common.crypto.RunningHash;
+import com.swirlds.merkle.map.MerkleMap;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -69,6 +79,20 @@ class StateInitializationFlowTest {
 	private FileUpdateInterceptor bFileInterceptor;
 	@Mock
 	private Consumer<HederaNumbers> staticNumbersHolder;
+	@Mock
+	private MerkleMap<EntityNum, MerkleAccount> accounts;
+	@Mock
+	private MerkleMap<EntityNum, MerkleTopic> topics;
+	@Mock
+	private MerkleMap<EntityNum, MerkleToken> tokens;
+	@Mock
+	private MerkleMap<EntityNumPair, MerkleUniqueToken> uniqueTokens;
+	@Mock
+	private MerkleMap<EntityNum, MerkleSchedule> schedules;
+	@Mock
+	private MerkleMap<String, MerkleOptionalBlob> storage;
+	@Mock
+	private MerkleMap<EntityNumPair, MerkleTokenRelStatus> tokenAssociations;
 
 	private StateInitializationFlow subject;
 
@@ -89,6 +113,7 @@ class StateInitializationFlowTest {
 		given(runningHash.getHash()).willReturn(hash);
 		given(runningHashLeaf.getRunningHash()).willReturn(runningHash);
 		given(activeState.runningHashLeaf()).willReturn(runningHashLeaf);
+		givenMockMerkleMaps();
 
 		// when:
 		subject.runWith(activeState);
@@ -111,6 +136,7 @@ class StateInitializationFlowTest {
 		given(runningHashLeaf.getRunningHash()).willReturn(runningHash);
 		given(activeState.runningHashLeaf()).willReturn(runningHashLeaf);
 		given(hfs.numRegisteredInterceptors()).willReturn(5);
+		givenMockMerkleMaps();
 
 		// when:
 		subject.runWith(activeState);
@@ -122,6 +148,16 @@ class StateInitializationFlowTest {
 		verify(staticNumbersHolder).accept(defaultNumbers);
 
 		cleanupMockNumInitialization();
+	}
+
+	private void givenMockMerkleMaps() {
+		given (activeState.accounts()).willReturn(accounts);
+		given (activeState.uniqueTokens()).willReturn(uniqueTokens);
+		given (activeState.tokenAssociations()).willReturn(tokenAssociations);
+		given (activeState.topics()).willReturn(topics);
+		given (activeState.tokens()).willReturn(tokens);
+		given (activeState.storage()).willReturn(storage);
+		given (activeState.scheduleTxs()).willReturn(schedules);
 	}
 
 	private void setupMockNumInitialization() {

--- a/hedera-node/src/test/java/com/hedera/services/ledger/accounts/BackingTokenRelsTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/ledger/accounts/BackingTokenRelsTest.java
@@ -24,13 +24,17 @@ import com.hedera.services.state.merkle.MerkleTokenRelStatus;
 import com.hedera.services.utils.EntityNumPair;
 import com.hederahashgraph.api.proto.java.AccountID;
 import com.hederahashgraph.api.proto.java.TokenID;
+import com.swirlds.common.constructable.ClassConstructorPair;
+import com.swirlds.common.constructable.ConstructableRegistry;
 import com.swirlds.common.constructable.ConstructableRegistryException;
 import com.swirlds.merkle.map.MerkleMap;
+import org.apache.commons.lang3.time.StopWatch;
 import org.apache.commons.lang3.tuple.Pair;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
+import java.util.concurrent.TimeUnit;
 
 import static com.hedera.services.ledger.accounts.BackingTokenRels.asTokenRel;
 import static com.hedera.services.ledger.accounts.BackingTokenRels.readableTokenRel;
@@ -81,30 +85,6 @@ class BackingTokenRelsTest {
 	}
 
 	@Test
-	void manualAddToExistingWorks() {
-		// given:
-		final var aNewPair = Pair.of(c, ct);
-
-		// when:
-		subject.addToExistingRels(aNewPair);
-
-		// then:
-		assertTrue(subject.contains(aNewPair));
-	}
-
-	@Test
-	void manualRemoveFromExistingWorks() {
-		// given:
-		final var destroyedPair = Pair.of(a, at);
-
-		// when:
-		subject.removeFromExistingRels(destroyedPair);
-
-		// then:
-		assertFalse(subject.contains(destroyedPair));
-	}
-
-	@Test
 	void relToStringWorks() {
 		// expect:
 		assertEquals("0.0.3 <-> 0.0.7", readableTokenRel(asTokenRel(a, at)));
@@ -118,7 +98,7 @@ class BackingTokenRelsTest {
 		// then:
 		assertEquals(cValue, rels.get(fromAccountTokenRel(c, ct)));
 		// and:
-		assertTrue(subject.existingRels.contains(asTokenRel(c, ct)));
+		assertTrue(subject.contains(asTokenRel(c, ct)));
 	}
 
 	@Test
@@ -138,7 +118,7 @@ class BackingTokenRelsTest {
 		// then:
 		assertFalse(rels.containsKey(fromAccountTokenRel(a, at)));
 		// and:
-		assertFalse(subject.existingRels.contains(asTokenRel(a, at)));
+		assertFalse(subject.contains(asTokenRel(a, at)));
 	}
 
 	@Test
@@ -150,10 +130,10 @@ class BackingTokenRelsTest {
 		subject.rebuildFromSources();
 
 		// then:
-		assertFalse(subject.existingRels.contains(asTokenRel(a, at)));
-		assertFalse(subject.existingRels.contains(asTokenRel(b, bt)));
+		assertFalse(subject.contains(asTokenRel(a, at)));
+		assertFalse(subject.contains(asTokenRel(b, bt)));
 		// and:
-		assertTrue(subject.existingRels.contains(asTokenRel(c, ct)));
+		assertTrue(subject.contains(asTokenRel(c, ct)));
 	}
 
 	@Test

--- a/hedera-node/src/test/java/com/hedera/services/store/TypedTokenStoreTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/store/TypedTokenStoreTest.java
@@ -107,7 +107,6 @@ class TypedTokenStoreTest {
 				() -> tokens,
 				() -> uniqueTokens,
 				() -> tokenRels,
-				backingTokenRels,
 				uniqTokenViewsManager,
 				tokenStore::addKnownTreasury,
 				legacyStore::removeKnownTreasuryForToken,
@@ -182,7 +181,6 @@ class TypedTokenStoreTest {
 
 		// then:
 		verify(tokenRels).remove(miscTokenRelId);
-		verify(backingTokenRels).removeFromExistingRels(legacyReprOf(destroyedRel));
 		verify(sideEffectsTracker).trackTokenBalanceChanges(List.of(destroyedRel));
 	}
 


### PR DESCRIPTION
**Description**:
- Instead of building a separate `HashSet` to do existence checks for token relationships, accept the small overhead of `MerkleMap.containsKey()` and use that directly.