### PR TITLE
Resolve Sonar issues after moving to JDK 17

### DIFF
--- a/hapi-fees/src/main/java/com/hedera/services/pricing/AssetsLoader.java
+++ b/hapi-fees/src/main/java/com/hedera/services/pricing/AssetsLoader.java
@@ -9,9 +9,9 @@ package com.hedera.services.pricing;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -52,7 +52,8 @@ class AssetsLoader {
 	 * 0.9 for operations that create new entities, and 0.2 for other operations.
 	 *
 	 * @return the "weight" of the constant term for each operation
-	 * @throws IOException if the backing JSON resource cannot be loaded
+	 * @throws IOException
+	 * 		if the backing JSON resource cannot be loaded
 	 */
 	Map<HederaFunctionality, BigDecimal> loadConstWeights() throws IOException {
 		if (cachedConstWeights != null) {
@@ -80,7 +81,8 @@ class AssetsLoader {
 	 * and are just compared to infer the relative scarcity of each resource.
 	 *
 	 * @return the network "capacity" of each resource type
-	 * @throws IOException if the backing JSON resource cannot be loaded
+	 * @throws IOException
+	 * 		if the backing JSON resource cannot be loaded
 	 */
 	Map<UsableResource, BigDecimal> loadCapacities() throws IOException {
 		if (cachedCapacities != null) {
@@ -93,8 +95,8 @@ class AssetsLoader {
 			final Map<UsableResource, BigDecimal> typedCapacities = new EnumMap<>(UsableResource.class);
 			capacities.forEach((resourceName, amount) -> {
 				final var resource = UsableResource.valueOf((String) resourceName);
-				final var bdAmount = (amount instanceof Long)
-						? BigDecimal.valueOf((Long) amount)
+				final var bdAmount = (amount instanceof Long val)
+						? BigDecimal.valueOf(val)
 						: BigDecimal.valueOf((Integer) amount);
 				typedCapacities.put(resource, bdAmount);
 			});
@@ -111,7 +113,8 @@ class AssetsLoader {
 	 * TOKEN_NON_FUNGIBLE_UNIQUE, and TOKEN_FUNGIBLE_COMMON.)
 	 *
 	 * @return the desired per-type prices, in USD
-	 * @throws IOException if the backing JSON resource cannot be loaded
+	 * @throws IOException
+	 * 		if the backing JSON resource cannot be loaded
 	 */
 	Map<HederaFunctionality, Map<SubType, BigDecimal>> loadCanonicalPrices() throws IOException {
 		if (cachedCanonicalPrices != null) {
@@ -128,8 +131,8 @@ class AssetsLoader {
 				final Map<SubType, BigDecimal> scopedPrices = new EnumMap<>(SubType.class);
 				((Map) priceMap).forEach((typeName, price) -> {
 					final var type = SubType.valueOf((String) typeName);
-					final var bdPrice = (price instanceof Double)
-							? BigDecimal.valueOf((Double) price)
+					final var bdPrice = (price instanceof Double val)
+							? BigDecimal.valueOf(val)
 							: BigDecimal.valueOf((Integer) price);
 					scopedPrices.put(type, bdPrice);
 				});

--- a/hapi-fees/src/main/java/com/hedera/services/usage/BaseTransactionMeta.java
+++ b/hapi-fees/src/main/java/com/hedera/services/usage/BaseTransactionMeta.java
@@ -9,9 +9,9 @@ package com.hedera.services.usage;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,33 +20,5 @@ package com.hedera.services.usage;
  * ‍
  */
 
-import org.apache.commons.lang3.builder.EqualsBuilder;
-import org.apache.commons.lang3.builder.HashCodeBuilder;
-
-public class BaseTransactionMeta {
-	private final int memoUtf8Bytes;
-	private final int numExplicitTransfers;
-
-	public BaseTransactionMeta(int memoUtf8Bytes, int numExplicitTransfers) {
-		this.memoUtf8Bytes = memoUtf8Bytes;
-		this.numExplicitTransfers = numExplicitTransfers;
-	}
-
-	public int getMemoUtf8Bytes() {
-		return memoUtf8Bytes;
-	}
-
-	public int getNumExplicitTransfers() {
-		return numExplicitTransfers;
-	}
-
-	@Override
-	public boolean equals(Object obj) {
-		return EqualsBuilder.reflectionEquals(this, obj);
-	}
-
-	@Override
-	public int hashCode() {
-		return HashCodeBuilder.reflectionHashCode(this);
-	}
+public record BaseTransactionMeta(int memoUtf8Bytes, int numExplicitTransfers) {
 }

--- a/hapi-fees/src/main/java/com/hedera/services/usage/SigUsage.java
+++ b/hapi-fees/src/main/java/com/hedera/services/usage/SigUsage.java
@@ -9,9 +9,9 @@ package com.hedera.services.usage;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,50 +20,5 @@ package com.hedera.services.usage;
  * ‍
  */
 
-import java.util.Objects;
-
-public class SigUsage {
-	private final int numSigs;
-	private final int sigsSize;
-	private final int numPayerKeys;
-
-	public SigUsage(int numSigs, int sigsSize, int numPayerKeys) {
-		this.numSigs = numSigs;
-		this.sigsSize = sigsSize;
-		this.numPayerKeys = numPayerKeys;
-	}
-
-	public int numSigs() {
-		return numSigs;
-	}
-
-	public int sigsSize() {
-		return sigsSize;
-	}
-
-	public int numPayerKeys() {
-		return numPayerKeys;
-	}
-
-	@Override
-	public boolean equals(Object o) {
-		if (this == o) {
-			return true;
-		}
-		if (o == null || o.getClass() != SigUsage.class) {
-			return false;
-		}
-		SigUsage that = (SigUsage)o;
-		return this.numSigs == that.numSigs && this.sigsSize == that.sigsSize && this.numPayerKeys == that.numPayerKeys;
-	}
-
-	@Override
-	public int hashCode() {
-		return Objects.hash(numSigs, sigsSize, numPayerKeys);
-	}
-
-	@Override
-	public String toString() {
-		return String.format("SigUsage{numSigs=%d, sigsSize=%d, numPayerKeys=%d}", numSigs, sigsSize, numPayerKeys);
-	}
+public record SigUsage(int numSigs, int sigsSize, int numPayerKeys) {
 }

--- a/hapi-fees/src/main/java/com/hedera/services/usage/TxnUsage.java
+++ b/hapi-fees/src/main/java/com/hedera/services/usage/TxnUsage.java
@@ -34,7 +34,7 @@ public abstract class TxnUsage {
 	protected static final int AMOUNT_REPR_BYTES = 8;
 
 	public static EstimatorFactory estimatorFactory = TxnUsageEstimator::new;
-	protected static UsageProperties usageProperties = USAGE_PROPERTIES;
+	protected static final UsageProperties usageProperties = USAGE_PROPERTIES;
 
 	protected final TransactionBody op;
 	protected final TxnUsageEstimator usageEstimator;

--- a/hapi-fees/src/main/java/com/hedera/services/usage/consensus/ConsensusOpsUsage.java
+++ b/hapi-fees/src/main/java/com/hedera/services/usage/consensus/ConsensusOpsUsage.java
@@ -48,7 +48,7 @@ public final class ConsensusOpsUsage {
 			final UsageAccumulator accumulator
 	) {
 		accumulator.resetForTransaction(baseMeta, sigUsage);
-		accumulator.addBpt(LONG_BASIC_ENTITY_ID_SIZE + submitMeta.getNumMsgBytes());
+		accumulator.addBpt(LONG_BASIC_ENTITY_ID_SIZE + submitMeta.numMsgBytes());
 		/* SubmitMessage receipts include a sequence number and running hash */
 		final var extraReceiptBytes = LONG_SIZE + TX_HASH_SIZE;
 		accumulator.addNetworkRbs(extraReceiptBytes * RECEIPT_STORAGE_TIME_SEC);

--- a/hapi-fees/src/main/java/com/hedera/services/usage/consensus/SubmitMessageMeta.java
+++ b/hapi-fees/src/main/java/com/hedera/services/usage/consensus/SubmitMessageMeta.java
@@ -9,9 +9,9 @@ package com.hedera.services.usage.consensus;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,14 +20,5 @@ package com.hedera.services.usage.consensus;
  * ‍
  */
 
-public class SubmitMessageMeta {
-	private final int numMsgBytes;
-
-	public SubmitMessageMeta(int numMsgBytes) {
-		this.numMsgBytes = numMsgBytes;
-	}
-
-	public int getNumMsgBytes() {
-		return numMsgBytes;
-	}
+public record SubmitMessageMeta(int numMsgBytes) {
 }

--- a/hapi-fees/src/main/java/com/hedera/services/usage/crypto/CryptoOpsUsage.java
+++ b/hapi-fees/src/main/java/com/hedera/services/usage/crypto/CryptoOpsUsage.java
@@ -71,7 +71,7 @@ public class CryptoOpsUsage {
 		final int tokenMultiplier = xferMeta.getTokenMultiplier();
 
 		/* BPT calculations shouldn't include any custom fee payment usage */
-		int totalXfers = baseMeta.getNumExplicitTransfers();
+		int totalXfers = baseMeta.numExplicitTransfers();
 		int weightedTokensInvolved = tokenMultiplier * xferMeta.getNumTokensInvolved();
 		int weightedTokenXfers = tokenMultiplier * xferMeta.getNumFungibleTokenTransfers();
 		long incBpt = weightedTokensInvolved * LONG_BASIC_ENTITY_ID_SIZE;
@@ -166,7 +166,7 @@ public class CryptoOpsUsage {
 
 		var lifeTime = cryptoCreateMeta.getLifeTime();
 
-		if(maxAutomaticTokenAssociations > 0) {
+		if (maxAutomaticTokenAssociations > 0) {
 			baseSize += INT_SIZE;
 		}
 

--- a/hapi-fees/src/main/java/com/hedera/services/usage/file/FileAppendMeta.java
+++ b/hapi-fees/src/main/java/com/hedera/services/usage/file/FileAppendMeta.java
@@ -9,9 +9,9 @@ package com.hedera.services.usage.file;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,20 +20,5 @@ package com.hedera.services.usage.file;
  * ‍
  */
 
-public class FileAppendMeta {
-	private final int bytesAdded;
-	private final long lifetime;
-
-	public FileAppendMeta(int bytesAdded, long lifetime) {
-		this.bytesAdded = bytesAdded;
-		this.lifetime = lifetime;
-	}
-
-	public int getBytesAdded() {
-		return bytesAdded;
-	}
-
-	public long getLifetime() {
-		return lifetime;
-	}
+public record FileAppendMeta(int bytesAdded, long lifetime) {
 }

--- a/hapi-fees/src/main/java/com/hedera/services/usage/file/FileOpsUsage.java
+++ b/hapi-fees/src/main/java/com/hedera/services/usage/file/FileOpsUsage.java
@@ -77,9 +77,9 @@ public class FileOpsUsage {
 	) {
 		accumulator.resetForTransaction(baseMeta, sigUsage);
 
-		final var bytesAdded = appendMeta.getBytesAdded();
+		final var bytesAdded = appendMeta.bytesAdded();
 		accumulator.addBpt(LONG_BASIC_ENTITY_ID_SIZE + bytesAdded);
-		accumulator.addSbs(bytesAdded * appendMeta.getLifetime());
+		accumulator.addSbs(bytesAdded * appendMeta.lifetime());
 	}
 
 	public FeeData fileCreateUsage(TransactionBody fileCreation, SigUsage sigUsage) {

--- a/hapi-fees/src/main/java/com/hedera/services/usage/state/UsageAccumulator.java
+++ b/hapi-fees/src/main/java/com/hedera/services/usage/state/UsageAccumulator.java
@@ -110,8 +110,8 @@ public class UsageAccumulator {
 	}
 
 	public void resetForTransaction(BaseTransactionMeta baseMeta, SigUsage sigUsage) {
-		final int memoBytes = baseMeta.getMemoUtf8Bytes();
-		final int numTransfers = baseMeta.getNumExplicitTransfers();
+		final int memoBytes = baseMeta.memoUtf8Bytes();
+		final int numTransfers = baseMeta.numExplicitTransfers();
 
 		gas = sbs = sbpr = 0;
 

--- a/hapi-fees/src/main/java/com/hedera/services/usage/token/meta/ExtantFeeScheduleContext.java
+++ b/hapi-fees/src/main/java/com/hedera/services/usage/token/meta/ExtantFeeScheduleContext.java
@@ -9,9 +9,9 @@ package com.hedera.services.usage.token.meta;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,34 +20,5 @@ package com.hedera.services.usage.token.meta;
  * ‍
  */
 
-import org.apache.commons.lang3.builder.EqualsBuilder;
-import org.apache.commons.lang3.builder.HashCodeBuilder;
-
-public class ExtantFeeScheduleContext {
-	private final long expiry;
-	private final int numBytesInFeeScheduleRepr;
-
-	public ExtantFeeScheduleContext(long expiry, int numBytesInFeeScheduleRepr) {
-		this.expiry = expiry;
-		this.numBytesInFeeScheduleRepr = numBytesInFeeScheduleRepr;
-	}
-
-	public long expiry() {
-		return expiry;
-	}
-
-	public int numBytesInFeeScheduleRepr() {
-		return numBytesInFeeScheduleRepr;
-	}
-
-
-	@Override
-	public boolean equals(Object obj) {
-		return EqualsBuilder.reflectionEquals(this, obj);
-	}
-
-	@Override
-	public int hashCode() {
-		return HashCodeBuilder.reflectionHashCode(this);
-	}
+public record ExtantFeeScheduleContext(long expiry, int numBytesInFeeScheduleRepr) {
 }

--- a/hapi-fees/src/main/java/com/hedera/services/usage/token/meta/FeeScheduleUpdateMeta.java
+++ b/hapi-fees/src/main/java/com/hedera/services/usage/token/meta/FeeScheduleUpdateMeta.java
@@ -9,9 +9,9 @@ package com.hedera.services.usage.token.meta;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,42 +20,6 @@ package com.hedera.services.usage.token.meta;
  * ‍
  */
 
-import com.google.common.base.MoreObjects;
-import org.apache.commons.lang3.builder.EqualsBuilder;
-import org.apache.commons.lang3.builder.HashCodeBuilder;
+public record FeeScheduleUpdateMeta(long effConsensusTime, int numBytesInNewFeeScheduleRepr) {
 
-public class FeeScheduleUpdateMeta {
-	private final long effConsensusTime;
-	private final int numBytesInNewFeeScheduleRepr;
-
-	public FeeScheduleUpdateMeta(long effConsensusTime, int numBytesInNewFeeScheduleRepr) {
-		this.effConsensusTime = effConsensusTime;
-		this.numBytesInNewFeeScheduleRepr = numBytesInNewFeeScheduleRepr;
-	}
-
-	public long effConsensusTime() {
-		return effConsensusTime;
-	}
-
-	public int numBytesInNewFeeScheduleRepr() {
-		return numBytesInNewFeeScheduleRepr;
-	}
-
-	@Override
-	public boolean equals(Object obj) {
-		return EqualsBuilder.reflectionEquals(this, obj);
-	}
-
-	@Override
-	public int hashCode() {
-		return HashCodeBuilder.reflectionHashCode(this);
-	}
-
-	@Override
-	public String toString() {
-		return MoreObjects.toStringHelper(this)
-				.add("effConsensusTime", effConsensusTime)
-				.add("numBytesInNewFeeScheduleRepr", numBytesInNewFeeScheduleRepr)
-				.toString();
-	}
 }

--- a/hapi-fees/src/test/java/com/hedera/services/usage/token/meta/FeeScheduleUpdateMetaTest.java
+++ b/hapi-fees/src/test/java/com/hedera/services/usage/token/meta/FeeScheduleUpdateMetaTest.java
@@ -9,9 +9,9 @@ package com.hedera.services.usage.token.meta;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -22,7 +22,7 @@ package com.hedera.services.usage.token.meta;
 
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class FeeScheduleUpdateMetaTest {
 	@Test
@@ -49,8 +49,7 @@ class FeeScheduleUpdateMetaTest {
 	@Test
 	void toStringWorks() {
 		// given:
-		final var desired = "FeeScheduleUpdateMeta{effConsensusTime=1234567, " +
-				"numBytesInNewFeeScheduleRepr=22}";
+		final var desired = "FeeScheduleUpdateMeta[effConsensusTime=1234567, numBytesInNewFeeScheduleRepr=22]";
 
 		// when:
 		final var subject = new FeeScheduleUpdateMeta(1_234_567L, 22);

--- a/hapi-utils/src/main/java/com/hedera/services/legacy/proto/utils/CommonUtils.java
+++ b/hapi-utils/src/main/java/com/hedera/services/legacy/proto/utils/CommonUtils.java
@@ -293,8 +293,8 @@ public final class CommonUtils {
 		try {
 			return extractSignatureMap(transaction);
 		} catch (InvalidProtocolBufferException ignoreToReturnDefault) {
+			return SignatureMap.getDefaultInstance();
 		}
-		return SignatureMap.getDefaultInstance();
 	}
 
 	public static Transaction.Builder toTransactionBuilder(TransactionOrBuilder transactionOrBuilder) {
@@ -313,8 +313,8 @@ public final class CommonUtils {
 		try {
 			return getSha384Hash().digest(byteArray);
 		} catch (NoSuchAlgorithmException ignoreToReturnEmptyByteArray) {
+			return new byte[0];
 		}
-		return new byte[0];
 	}
 
 	public static ByteString sha384HashOf(byte[] byteArray) {

--- a/hapi-utils/src/main/java/com/hedera/services/legacy/proto/utils/CommonUtils.java
+++ b/hapi-utils/src/main/java/com/hedera/services/legacy/proto/utils/CommonUtils.java
@@ -48,260 +48,288 @@ import java.util.Base64;
  * Common utilities.
  */
 public final class CommonUtils {
-  private CommonUtils() {
-    throw new UnsupportedOperationException("Utility Class");
-  }
+	private CommonUtils() {
+		throw new UnsupportedOperationException("Utility Class");
+	}
 
-  /**
-   * Sleep given seconds.
-   *
-   * @param timeInMillis time to sleep in milliseconds
-   * @throws InterruptedException when thread sleep interruption
-   */
-  public static void napMillis(long timeInMillis) throws InterruptedException {
-    Thread.sleep(timeInMillis);
-  }
+	/**
+	 * Sleep given seconds.
+	 *
+	 * @param timeInMillis
+	 * 		time to sleep in milliseconds
+	 * @throws InterruptedException
+	 * 		when thread sleep interruption
+	 */
+	public static void napMillis(long timeInMillis) throws InterruptedException {
+		Thread.sleep(timeInMillis);
+	}
 
-  /**
-   * Sleep given seconds.
-   *
-   * @param timeInSec time to sleep in seconds
-   *
-   * @throws InterruptedException when thread sleep interruption
-   */
-  public static void nap(int timeInSec)  throws InterruptedException {
-    Thread.sleep(timeInSec * 1000L);
-   }
+	/**
+	 * Sleep given seconds.
+	 *
+	 * @param timeInSec
+	 * 		time to sleep in seconds
+	 * @throws InterruptedException
+	 * 		when thread sleep interruption
+	 */
+	public static void nap(int timeInSec) throws InterruptedException {
+		Thread.sleep(timeInSec * 1000L);
+	}
 
-  public static void nap(double timeInSec)  throws InterruptedException {
-    Thread.sleep((long) timeInSec * 1000);
-  }
+	public static void nap(double timeInSec) throws InterruptedException {
+		Thread.sleep((long) timeInSec * 1000);
+	}
 
 
-  /**
-   * Write bytes to a file.
-   *
-   * @param path the file path to write bytes
-   * @param data the byte array data
-   *
-   * @throws IOException when error with IO
-   */
-  public static void writeToFile(String path, byte[] data) throws IOException {
-    writeToFile(path, data, false);
-  }
+	/**
+	 * Write bytes to a file.
+	 *
+	 * @param path
+	 * 		the file path to write bytes
+	 * @param data
+	 * 		the byte array data
+	 * @throws IOException
+	 * 		when error with IO
+	 */
+	public static void writeToFile(String path, byte[] data) throws IOException {
+		writeToFile(path, data, false);
+	}
 
-  /**
-   * Write bytes to a file.
-   *
-   * @param path file write path
-   * @param data byte array representation of data to write
-   * @param append append to existing file if true
-   *
-   * @throws IOException when error with IO
-   */
-  public static void writeToFile(String path, byte[] data, boolean append) throws IOException {
-    File f = new File(path);
-    File parent = f.getParentFile();
-    if (!parent.exists()) {
-      parent.mkdirs();
-    }
-    try (FileOutputStream fos = new FileOutputStream(f, append)) {
-      fos.write(data);
-      fos.flush();
-    } catch (IOException e) {
-      throw e;
-    }
-  }
+	/**
+	 * Write bytes to a file.
+	 *
+	 * @param path
+	 * 		file write path
+	 * @param data
+	 * 		byte array representation of data to write
+	 * @param append
+	 * 		append to existing file if true
+	 * @throws IOException
+	 * 		when error with IO
+	 */
+	public static void writeToFile(String path, byte[] data, boolean append) throws IOException {
+		File f = new File(path);
+		File parent = f.getParentFile();
+		if (!parent.exists()) {
+			parent.mkdirs();
+		}
+		try (FileOutputStream fos = new FileOutputStream(f, append)) {
+			fos.write(data);
+			fos.flush();
+		} catch (IOException e) {
+			throw e;
+		}
+	}
 
-  /**
-   * Write string to a file using UTF_8 encoding.
-   *
-   * @param path the file path to write bytes
-   * @param data the byte array data
-   * @throws IOException when error with IO
-   */
-  public static void writeToFileUTF8(String path, String data) throws IOException {
-    byte[] bytes = data.getBytes(StandardCharsets.UTF_8);
-    writeToFile(path, bytes);
-  }
+	/**
+	 * Write string to a file using UTF_8 encoding.
+	 *
+	 * @param path
+	 * 		the file path to write bytes
+	 * @param data
+	 * 		the byte array data
+	 * @throws IOException
+	 * 		when error with IO
+	 */
+	public static void writeToFileUTF8(String path, String data) throws IOException {
+		byte[] bytes = data.getBytes(StandardCharsets.UTF_8);
+		writeToFile(path, bytes);
+	}
 
-  /**
-   * Write string to a file using UTF_8 encoding.
-   *
-   * @param data data represented as string
-   * @param path file write path
-   * @param append append to existing file if true
-   * @throws IOException when error with IO
-   */
-  public static void writeToFileUTF8(String path, String data, boolean append) throws IOException {
-    byte[] bytes = data.getBytes(StandardCharsets.UTF_8);
-    writeToFile(path, bytes, append);
-  }
+	/**
+	 * Write string to a file using UTF_8 encoding.
+	 *
+	 * @param data
+	 * 		data represented as string
+	 * @param path
+	 * 		file write path
+	 * @param append
+	 * 		append to existing file if true
+	 * @throws IOException
+	 * 		when error with IO
+	 */
+	public static void writeToFileUTF8(String path, String data, boolean append) throws IOException {
+		byte[] bytes = data.getBytes(StandardCharsets.UTF_8);
+		writeToFile(path, bytes, append);
+	}
 
-  /**
-   * Encode bytes as base64.
-   *
-   * @param bytes to be encoded
-   * @return base64 string
-   */
-  public static String base64encode(byte[] bytes) {
-    String rv = null;
-    rv = Base64.getEncoder().encodeToString(bytes);
-    return rv;
-  }
+	/**
+	 * Encode bytes as base64.
+	 *
+	 * @param bytes
+	 * 		to be encoded
+	 * @return base64 string
+	 */
+	public static String base64encode(byte[] bytes) {
+		String rv = null;
+		rv = Base64.getEncoder().encodeToString(bytes);
+		return rv;
+	}
 
-  /**
-   * Serialize a Java object to bytes.
-   *
-   * @param object the Java object to be serialized
-   * @return converted bytes
-   * @throws IOException when error with IO
-   */
-  public static byte[] convertToBytes(Object object) throws IOException {
-    try (ByteArrayOutputStream bos = new ByteArrayOutputStream();
-         ObjectOutput out = new ObjectOutputStream(bos)) {
-      out.writeObject(object);
-      return bos.toByteArray();
-    }
-  }
+	/**
+	 * Serialize a Java object to bytes.
+	 *
+	 * @param object
+	 * 		the Java object to be serialized
+	 * @return converted bytes
+	 * @throws IOException
+	 * 		when error with IO
+	 */
+	public static byte[] convertToBytes(Object object) throws IOException {
+		try (ByteArrayOutputStream bos = new ByteArrayOutputStream();
+			 ObjectOutput out = new ObjectOutputStream(bos)) {
+			out.writeObject(object);
+			return bos.toByteArray();
+		}
+	}
 
-  /**
-   * Copy bytes.
-   *
-   * @param start from position
-   * @param length number of bytes to copy
-   * @param bytes source byte array
-   *
-   * @return copied byte array
-   */
-  public static byte[] copyBytes(int start, int length, byte[] bytes) {
-    byte[] rv = new byte[length];
-    for (int i = 0; i < length; i++) {
-      rv[i] = bytes[start + i];
-    }
-    return rv;
-  }
+	/**
+	 * Copy bytes.
+	 *
+	 * @param start
+	 * 		from position
+	 * @param length
+	 * 		number of bytes to copy
+	 * @param bytes
+	 * 		source byte array
+	 * @return copied byte array
+	 */
+	public static byte[] copyBytes(int start, int length, byte[] bytes) {
+		byte[] rv = new byte[length];
+		for (int i = 0; i < length; i++) {
+			rv[i] = bytes[start + i];
+		}
+		return rv;
+	}
 
-  /**
-   * Reads a resource file
-   *
-   * @param filePath the resource file to be read
-   * @param myClass the calling class
-   * @param <T> type to read binary into
-   *
-   * @return type T from the binary input
-   * @throws IOException when error with IO
-   * @throws URISyntaxException when invalid URI syntax
-   */
-  public static <T> byte[] readBinaryFileAsResource(String filePath, Class<T> myClass)
-      throws IOException, URISyntaxException {
-    Path path = Paths.get(myClass.getClassLoader().getResource(filePath).toURI());
-    return Files.readAllBytes(path);
-  }
+	/**
+	 * Reads a resource file
+	 *
+	 * @param filePath
+	 * 		the resource file to be read
+	 * @param myClass
+	 * 		the calling class
+	 * @param <T>
+	 * 		type to read binary into
+	 * @return type T from the binary input
+	 * @throws IOException
+	 * 		when error with IO
+	 * @throws URISyntaxException
+	 * 		when invalid URI syntax
+	 */
+	public static <T> byte[] readBinaryFileAsResource(String filePath, Class<T> myClass)
+			throws IOException, URISyntaxException {
+		Path path = Paths.get(myClass.getClassLoader().getResource(filePath).toURI());
+		return Files.readAllBytes(path);
+	}
 
-  /**
-   * Generates a human readable string for grpc transaction.
-   *
-   * @param grpcTransaction GRPC transaction
-   *
-   * @return generated readable string
-   * @throws InvalidProtocolBufferException when protocol buffer is invalid
-   */
-  public static String toReadableString(Transaction grpcTransaction) throws InvalidProtocolBufferException {
-    String rv = null;
-    try {
-      TransactionBody body = extractTransactionBody(grpcTransaction);
-      rv = "body=" + TextFormat.shortDebugString(body) + "; sigs="
-              + TextFormat.shortDebugString(extractSignatureMap(grpcTransaction));
-    } catch (InvalidProtocolBufferException e) {
-      throw e;
-    }
-    return rv;
-  }
+	/**
+	 * Generates a human readable string for grpc transaction.
+	 *
+	 * @param grpcTransaction
+	 * 		GRPC transaction
+	 * @return generated readable string
+	 * @throws InvalidProtocolBufferException
+	 * 		when protocol buffer is invalid
+	 */
+	public static String toReadableString(Transaction grpcTransaction) throws InvalidProtocolBufferException {
+		String rv = null;
+		try {
+			TransactionBody body = extractTransactionBody(grpcTransaction);
+			rv = "body=" + TextFormat.shortDebugString(body) + "; sigs="
+					+ TextFormat.shortDebugString(extractSignatureMap(grpcTransaction));
+		} catch (InvalidProtocolBufferException e) {
+			throw e;
+		}
+		return rv;
+	}
 
-  /**
-   * Generates a short human readable string for grpc transaction.
-   *
-   * @param grpcTransaction GRPC transaction
-   *
-   * @return generated readable string
-   * @throws InvalidProtocolBufferException when protocol buffer is invalid
-   */
-  public static String toReadableTransactionID(
-          Transaction grpcTransaction) throws InvalidProtocolBufferException {
-    TransactionBody body = extractTransactionBody(grpcTransaction);
-    return "txID=" + TextFormat.shortDebugString(body.getTransactionID());
-  }
+	/**
+	 * Generates a short human readable string for grpc transaction.
+	 *
+	 * @param grpcTransaction
+	 * 		GRPC transaction
+	 * @return generated readable string
+	 * @throws InvalidProtocolBufferException
+	 * 		when protocol buffer is invalid
+	 */
+	public static String toReadableTransactionID(
+			Transaction grpcTransaction) throws InvalidProtocolBufferException {
+		TransactionBody body = extractTransactionBody(grpcTransaction);
+		return "txID=" + TextFormat.shortDebugString(body.getTransactionID());
+	}
 
-  public static ByteString extractTransactionBodyByteString(TransactionOrBuilder transaction)
-      throws InvalidProtocolBufferException {
-    ByteString signedTransactionBytes = transaction.getSignedTransactionBytes();
-    if (!signedTransactionBytes.isEmpty()) {
-      return SignedTransaction.parseFrom(signedTransactionBytes).getBodyBytes();
-    }
+	public static ByteString extractTransactionBodyByteString(TransactionOrBuilder transaction)
+			throws InvalidProtocolBufferException {
+		ByteString signedTransactionBytes = transaction.getSignedTransactionBytes();
+		if (!signedTransactionBytes.isEmpty()) {
+			return SignedTransaction.parseFrom(signedTransactionBytes).getBodyBytes();
+		}
 
-    return transaction.getBodyBytes();
-  }
+		return transaction.getBodyBytes();
+	}
 
-  public static byte[] extractTransactionBodyBytes(TransactionOrBuilder transaction)
-          throws InvalidProtocolBufferException {
-    return extractTransactionBodyByteString(transaction).toByteArray();
-  }
+	public static byte[] extractTransactionBodyBytes(TransactionOrBuilder transaction)
+			throws InvalidProtocolBufferException {
+		return extractTransactionBodyByteString(transaction).toByteArray();
+	}
 
-  public static TransactionBody extractTransactionBody(TransactionOrBuilder transaction)
-          throws InvalidProtocolBufferException {
-    return TransactionBody.parseFrom(extractTransactionBodyByteString(transaction));
-  }
+	public static TransactionBody extractTransactionBody(TransactionOrBuilder transaction)
+			throws InvalidProtocolBufferException {
+		return TransactionBody.parseFrom(extractTransactionBodyByteString(transaction));
+	}
 
-  public static SignatureMap extractSignatureMap(TransactionOrBuilder transaction)
-          throws InvalidProtocolBufferException {
-    ByteString signedTransactionBytes = transaction.getSignedTransactionBytes();
-    if (!signedTransactionBytes.isEmpty()) {
-      return SignedTransaction.parseFrom(signedTransactionBytes).getSigMap();
-    }
+	public static SignatureMap extractSignatureMap(TransactionOrBuilder transaction)
+			throws InvalidProtocolBufferException {
+		ByteString signedTransactionBytes = transaction.getSignedTransactionBytes();
+		if (!signedTransactionBytes.isEmpty()) {
+			return SignedTransaction.parseFrom(signedTransactionBytes).getSigMap();
+		}
 
-    return transaction.getSigMap();
-  }
+		return transaction.getSigMap();
+	}
 
-  public static SignatureMap extractSignatureMapOrUseDefault(TransactionOrBuilder transaction) {
-    try {
-      return extractSignatureMap(transaction);
-    } catch (InvalidProtocolBufferException ignoreToReturnDefault) { }
-    return SignatureMap.getDefaultInstance();
-  }
+	public static SignatureMap extractSignatureMapOrUseDefault(TransactionOrBuilder transaction) {
+		try {
+			return extractSignatureMap(transaction);
+		} catch (InvalidProtocolBufferException ignoreToReturnDefault) {
+		}
+		return SignatureMap.getDefaultInstance();
+	}
 
-  public static Transaction.Builder toTransactionBuilder(TransactionOrBuilder transactionOrBuilder) {
-    if (transactionOrBuilder instanceof Transaction) {
-      return ((Transaction) transactionOrBuilder).toBuilder();
-    }
+	public static Transaction.Builder toTransactionBuilder(TransactionOrBuilder transactionOrBuilder) {
+		if (transactionOrBuilder instanceof Transaction transaction) {
+			return transaction.toBuilder();
+		}
 
-    return (Transaction.Builder) transactionOrBuilder;
-  }
+		return (Transaction.Builder) transactionOrBuilder;
+	}
 
-  public static MessageDigest getSha384Hash() throws NoSuchAlgorithmException {
-    return MessageDigest.getInstance("SHA-384");
-  }
+	public static MessageDigest getSha384Hash() throws NoSuchAlgorithmException {
+		return MessageDigest.getInstance("SHA-384");
+	}
 
-  public static byte[] noThrowSha384HashOf(byte[] byteArray) {
-    try {
-      return getSha384Hash().digest(byteArray);
-    } catch (NoSuchAlgorithmException ignoreToReturnEmptyByteArray) { }
-    return new byte[0];
-  }
+	public static byte[] noThrowSha384HashOf(byte[] byteArray) {
+		try {
+			return getSha384Hash().digest(byteArray);
+		} catch (NoSuchAlgorithmException ignoreToReturnEmptyByteArray) {
+		}
+		return new byte[0];
+	}
 
-  public static ByteString sha384HashOf(byte[] byteArray) {
-    return ByteString.copyFrom(noThrowSha384HashOf(byteArray));
-  }
+	public static ByteString sha384HashOf(byte[] byteArray) {
+		return ByteString.copyFrom(noThrowSha384HashOf(byteArray));
+	}
 
-  public static ByteString sha384HashOf(Transaction transaction) {
-    if (transaction.getSignedTransactionBytes().isEmpty()) {
-      return sha384HashOf(transaction.toByteArray());
-    }
+	public static ByteString sha384HashOf(Transaction transaction) {
+		if (transaction.getSignedTransactionBytes().isEmpty()) {
+			return sha384HashOf(transaction.toByteArray());
+		}
 
-    return sha384HashOf(transaction.getSignedTransactionBytes().toByteArray());
-  }
+		return sha384HashOf(transaction.getSignedTransactionBytes().toByteArray());
+	}
 
-  public static void writeTxId2File(String txIdString) throws IOException {
-    writeToFileUTF8("output/txIds.txt", ProtoCommonUtils.getCurrentInstantUTC() + "-->" + txIdString + "\n", true);
-  }
+	public static void writeTxId2File(String txIdString) throws IOException {
+		writeToFileUTF8("output/txIds.txt", ProtoCommonUtils.getCurrentInstantUTC() + "-->" + txIdString + "\n", true);
+	}
 }

--- a/hapi-utils/src/main/java/com/hedera/services/sysfiles/domain/throttling/ThrottleBucket.java
+++ b/hapi-utils/src/main/java/com/hedera/services/sysfiles/domain/throttling/ThrottleBucket.java
@@ -37,7 +37,6 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.NODE_CAPACITY_
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OPERATION_REPEATED_IN_BUCKET_GROUPS;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.THROTTLE_GROUP_HAS_ZERO_OPS_PER_SEC;
 import static java.util.Collections.disjoint;
-import static java.util.stream.Collectors.toList;
 
 public final class ThrottleBucket {
 	private int burstPeriod;
@@ -81,7 +80,7 @@ public final class ThrottleBucket {
 		pojo.burstPeriodMs = bucket.getBurstPeriodMs();
 		pojo.throttleGroups.addAll(bucket.getThrottleGroupsList().stream()
 				.map(ThrottleGroup::fromProto)
-				.collect(toList()));
+				.toList());
 		return pojo;
 	}
 
@@ -91,7 +90,7 @@ public final class ThrottleBucket {
 				.setBurstPeriodMs(impliedBurstPeriodMs())
 				.addAllThrottleGroups(throttleGroups.stream()
 						.map(ThrottleGroup::toProto)
-						.collect(toList()))
+						.toList())
 				.build();
 	}
 

--- a/hapi-utils/src/main/java/com/hedera/services/sysfiles/domain/throttling/ThrottleDefinitions.java
+++ b/hapi-utils/src/main/java/com/hedera/services/sysfiles/domain/throttling/ThrottleDefinitions.java
@@ -9,9 +9,9 @@ package com.hedera.services.sysfiles.domain.throttling;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -22,8 +22,6 @@ package com.hedera.services.sysfiles.domain.throttling;
 
 import java.util.ArrayList;
 import java.util.List;
-
-import static java.util.stream.Collectors.toList;
 
 public class ThrottleDefinitions {
 	List<ThrottleBucket> buckets = new ArrayList<>();
@@ -40,13 +38,13 @@ public class ThrottleDefinitions {
 		var pojo = new ThrottleDefinitions();
 		pojo.buckets.addAll(defs.getThrottleBucketsList().stream()
 				.map(ThrottleBucket::fromProto)
-				.collect(toList()));
+				.toList());
 		return pojo;
 	}
 
 	public com.hederahashgraph.api.proto.java.ThrottleDefinitions toProto() {
 		return com.hederahashgraph.api.proto.java.ThrottleDefinitions.newBuilder()
-				.addAllThrottleBuckets(buckets.stream().map(ThrottleBucket::toProto).collect(toList()))
+				.addAllThrottleBuckets(buckets.stream().map(ThrottleBucket::toProto).toList())
 				.build();
 	}
 }

--- a/hapi-utils/src/main/java/com/hedera/services/sysfiles/domain/throttling/ThrottleReqOpsScaleFactor.java
+++ b/hapi-utils/src/main/java/com/hedera/services/sysfiles/domain/throttling/ThrottleReqOpsScaleFactor.java
@@ -9,9 +9,9 @@ package com.hedera.services.sysfiles.domain.throttling;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -22,15 +22,7 @@ package com.hedera.services.sysfiles.domain.throttling;
 
 import com.google.common.base.MoreObjects;
 
-public class ThrottleReqOpsScaleFactor {
-	private final int numerator;
-	private final int denominator;
-
-	private ThrottleReqOpsScaleFactor(int numerator, int denominator) {
-		this.numerator = numerator;
-		this.denominator = denominator;
-	}
-
+public record ThrottleReqOpsScaleFactor(int numerator, int denominator) {
 	public static ThrottleReqOpsScaleFactor from(String literal) {
 		final var splitIndex = literal.indexOf(':');
 		if (splitIndex == -1) {
@@ -66,25 +58,5 @@ public class ThrottleReqOpsScaleFactor {
 	public int hashCode() {
 		var result = Integer.hashCode(numerator);
 		return 31 * result + Integer.hashCode(denominator);
-	}
-
-	@Override
-	public boolean equals(Object o) {
-		if (o == this) {
-			return true;
-		}
-		if (o == null || ThrottleReqOpsScaleFactor.class != o.getClass()) {
-			return false;
-		}
-		var that = (ThrottleReqOpsScaleFactor) o;
-		return this.numerator == that.numerator && this.denominator == that.denominator;
-	}
-
-	public int getNumerator() {
-		return numerator;
-	}
-
-	public int getDenominator() {
-		return denominator;
 	}
 }

--- a/hapi-utils/src/main/java/com/hedera/services/throttles/DeterministicThrottle.java
+++ b/hapi-utils/src/main/java/com/hedera/services/throttles/DeterministicThrottle.java
@@ -194,23 +194,7 @@ public class DeterministicThrottle {
 				.toString();
 	}
 
-	public static class UsageSnapshot {
-		private final long used;
-		private final Instant lastDecisionTime;
-
-		public UsageSnapshot(final long used, final Instant lastDecisionTime) {
-			this.used = used;
-			this.lastDecisionTime = lastDecisionTime;
-		}
-
-		public long used() {
-			return used;
-		}
-
-		public Instant lastDecisionTime() {
-			return lastDecisionTime;
-		}
-
+	public static record UsageSnapshot(long used, Instant lastDecisionTime) {
 		@Override
 		public String toString() {
 			final var sb = new StringBuilder("DeterministicThrottle.UsageSnapshot{");
@@ -220,23 +204,6 @@ public class DeterministicThrottle {
 					.append(lastDecisionTime == NEVER ? "<N/A>" : lastDecisionTime)
 					.append("}")
 					.toString();
-		}
-
-		@Override
-		public boolean equals(Object o) {
-			if (o == this) {
-				return true;
-			}
-			if (o == null || !o.getClass().equals(UsageSnapshot.class)) {
-				return false;
-			}
-			final var that = (UsageSnapshot) o;
-			return this.used == that.used && Objects.equals(this.lastDecisionTime, that.lastDecisionTime);
-		}
-
-		@Override
-		public int hashCode() {
-			return Objects.hash(used, lastDecisionTime);
 		}
 	}
 

--- a/hapi-utils/src/test/java/com/hedera/services/sysfiles/domain/throttling/ThrottleReqOpsScaleFactorTest.java
+++ b/hapi-utils/src/test/java/com/hedera/services/sysfiles/domain/throttling/ThrottleReqOpsScaleFactorTest.java
@@ -34,8 +34,8 @@ class ThrottleReqOpsScaleFactorTest {
 	void parsesValidAsExpected(String literal, int numerator, int denominator) {
 		final var subject = ThrottleReqOpsScaleFactor.from(literal);
 
-		assertEquals(numerator, subject.getNumerator());
-		assertEquals(denominator, subject.getDenominator());
+		assertEquals(numerator, subject.numerator());
+		assertEquals(denominator, subject.denominator());
 	}
 
 	@CsvSource({ "3:0", "15", "9223372036854775807:100", "1:-1", "-2:3" })

--- a/hedera-node/src/main/java/com/hedera/services/context/domain/trackers/ConsensusStatusCounts.java
+++ b/hedera-node/src/main/java/com/hedera/services/context/domain/trackers/ConsensusStatusCounts.java
@@ -9,9 +9,9 @@ package com.hedera.services.context.domain.trackers;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -30,7 +30,6 @@ import org.apache.logging.log4j.Logger;
 import java.util.EnumMap;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.stream.Collectors;
 
 public class ConsensusStatusCounts {
 	private static final Logger log = LogManager.getLogger(ConsensusStatusCounts.class);
@@ -51,7 +50,7 @@ public class ConsensusStatusCounts {
 						.map(entry -> Map.of(
 								String.format("%s:%s", entries.getKey(), entry.getKey()),
 								entry.getValue().get())))
-				.collect(Collectors.toList());
+				.toList();
 		try {
 			return om.writerWithDefaultPrettyPrinter().writeValueAsString(asList);
 		} catch (JsonProcessingException unlikely) {

--- a/hedera-node/src/main/java/com/hedera/services/context/properties/BootstrapProperties.java
+++ b/hedera-node/src/main/java/com/hedera/services/context/properties/BootstrapProperties.java
@@ -41,7 +41,6 @@ import java.util.stream.Stream;
 import static com.hedera.services.context.properties.PropUtils.loadOverride;
 import static java.util.Collections.unmodifiableSet;
 import static java.util.Map.entry;
-import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toSet;
 
 @Singleton
@@ -97,7 +96,7 @@ public final class BootstrapProperties implements PropertySource {
 		final var missingProps = BOOTSTRAP_PROP_NAMES.stream()
 				.filter(name -> !resourceProps.containsKey(name))
 				.sorted()
-				.collect(toList());
+				.toList();
 		if (!missingProps.isEmpty()) {
 			final var msg = String.format(
 					"'%s' is missing properties: %s!",
@@ -110,8 +109,8 @@ public final class BootstrapProperties implements PropertySource {
 	private void resolveBootstrapProps(final Properties resourceProps) {
 		bootstrapProps = new HashMap<>();
 		BOOTSTRAP_PROP_NAMES.forEach(prop -> bootstrapProps.put(
-						prop,
-						transformFor(prop).apply(resourceProps.getProperty(prop))));
+				prop,
+				transformFor(prop).apply(resourceProps.getProperty(prop))));
 
 		final var msg = "Resolved bootstrap properties:\n  " + BOOTSTRAP_PROP_NAMES.stream()
 				.sorted()
@@ -130,7 +129,7 @@ public final class BootstrapProperties implements PropertySource {
 		}
 	}
 
-	void ensureProps() throws IllegalStateException{
+	void ensureProps() throws IllegalStateException {
 		if (bootstrapProps == MISSING_PROPS) {
 			initPropsFromResource();
 		}

--- a/hedera-node/src/main/java/com/hedera/services/contracts/sources/TxnAwareSoliditySigsVerifier.java
+++ b/hedera-node/src/main/java/com/hedera/services/contracts/sources/TxnAwareSoliditySigsVerifier.java
@@ -40,7 +40,6 @@ import java.util.stream.Stream;
 import static com.hedera.services.keys.HederaKeyActivation.ONLY_IF_SIG_IS_VALID;
 import static com.hedera.services.keys.HederaKeyActivation.isActive;
 import static com.hedera.services.utils.EntityNum.fromAccountId;
-import static java.util.stream.Collectors.toList;
 
 public class TxnAwareSoliditySigsVerifier implements SoliditySigsVerifier {
 	private final SyncVerifier syncVerifier;
@@ -66,7 +65,7 @@ public class TxnAwareSoliditySigsVerifier implements SoliditySigsVerifier {
 		var requiredKeys = touched.stream()
 				.filter(id -> !payer.equals(id))
 				.flatMap(this::keyRequirement)
-				.collect(toList());
+				.toList();
 		if (requiredKeys.isEmpty()) {
 			return true;
 		} else {

--- a/hedera-node/src/main/java/com/hedera/services/fees/FeeCalculator.java
+++ b/hedera-node/src/main/java/com/hedera/services/fees/FeeCalculator.java
@@ -21,7 +21,7 @@ package com.hedera.services.fees;
  */
 
 import com.hedera.services.context.primitives.StateView;
-import com.hedera.services.fees.calculation.AutoRenewCalcs;
+import com.hedera.services.fees.calculation.RenewAssessment;
 import com.hedera.services.legacy.core.jproto.JKey;
 import com.hedera.services.state.merkle.MerkleAccount;
 import com.hedera.services.utils.TxnAccessor;
@@ -78,7 +78,7 @@ public interface FeeCalculator {
 	 * 		the consensus time of expiration
 	 * @return the corresponding RenewAssessment
 	 */
-	AutoRenewCalcs.RenewAssessment assessCryptoAutoRenewal(
+	RenewAssessment assessCryptoAutoRenewal(
 			MerkleAccount expiredAccount,
 			long requestedRenewal,
 			Instant now);

--- a/hedera-node/src/main/java/com/hedera/services/fees/calculation/AutoRenewCalcs.java
+++ b/hedera-node/src/main/java/com/hedera/services/fees/calculation/AutoRenewCalcs.java
@@ -143,7 +143,4 @@ public class AutoRenewCalcs {
 				+ prices.getNetworkdata().getConstant()
 				+ prices.getServicedata().getConstant();
 	}
-
-	public static record RenewAssessment(long fee, long renewalPeriod) {
-	}
 }

--- a/hedera-node/src/main/java/com/hedera/services/fees/calculation/AutoRenewCalcs.java
+++ b/hedera-node/src/main/java/com/hedera/services/fees/calculation/AutoRenewCalcs.java
@@ -144,21 +144,6 @@ public class AutoRenewCalcs {
 				+ prices.getServicedata().getConstant();
 	}
 
-	public static class RenewAssessment {
-		private final long fee;
-		private final long renewalPeriod;
-
-		public RenewAssessment(long fee, long renewalPeriod) {
-			this.fee = fee;
-			this.renewalPeriod = renewalPeriod;
-		}
-
-		public long fee() {
-			return fee;
-		}
-
-		public long renewalPeriod() {
-			return renewalPeriod;
-		}
+	public static record RenewAssessment(long fee, long renewalPeriod) {
 	}
 }

--- a/hedera-node/src/main/java/com/hedera/services/fees/calculation/CongestionMultipliers.java
+++ b/hedera-node/src/main/java/com/hedera/services/fees/calculation/CongestionMultipliers.java
@@ -21,7 +21,9 @@ package com.hedera.services.fees.calculation;
  */
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 
 public final record CongestionMultipliers(int[] usagePercentTriggers, long[] multipliers) {
 	public static CongestionMultipliers from(final String csv) {
@@ -102,6 +104,25 @@ public final record CongestionMultipliers(int[] usagePercentTriggers, long[] mul
 			return s;
 		}
 		return s.substring(0, i);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(Arrays.hashCode(usagePercentTriggers), Arrays.hashCode(multipliers));
+	}
+
+
+	@Override
+	public boolean equals(final Object o) {
+		if (o == this) {
+			return true;
+		}
+		if (o == null || !o.getClass().equals(CongestionMultipliers.class)) {
+			return false;
+		}
+		final var that = (CongestionMultipliers) o;
+		return Arrays.equals(this.multipliers, that.multipliers) &&
+				Arrays.equals(this.usagePercentTriggers, that.usagePercentTriggers);
 	}
 
 	@Override

--- a/hedera-node/src/main/java/com/hedera/services/fees/calculation/CongestionMultipliers.java
+++ b/hedera-node/src/main/java/com/hedera/services/fees/calculation/CongestionMultipliers.java
@@ -21,14 +21,9 @@ package com.hedera.services.fees.calculation;
  */
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
-import java.util.Objects;
 
-public final class CongestionMultipliers {
-	private final int[] usagePercentTriggers;
-	private final long[] multipliers;
-
+public final record CongestionMultipliers(int[] usagePercentTriggers, long[] multipliers) {
 	public static CongestionMultipliers from(final String csv) {
 		final List<Integer> triggers = new ArrayList<>();
 		final List<Long> multipliers = new ArrayList<>();
@@ -107,37 +102,6 @@ public final class CongestionMultipliers {
 			return s;
 		}
 		return s.substring(0, i);
-	}
-
-	private CongestionMultipliers(final int[] usagePercentTriggers, final long[] multipliers) {
-		this.usagePercentTriggers = usagePercentTriggers;
-		this.multipliers = multipliers;
-	}
-
-	public int[] usagePercentTriggers() {
-		return usagePercentTriggers;
-	}
-
-	public long[] multipliers() {
-		return multipliers;
-	}
-
-	@Override
-	public int hashCode() {
-		return Objects.hash(Arrays.hashCode(usagePercentTriggers), Arrays.hashCode(multipliers));
-	}
-
-	@Override
-	public boolean equals(final Object o) {
-		if (o == this) {
-			return true;
-		}
-		if (o == null || !o.getClass().equals(CongestionMultipliers.class)) {
-			return false;
-		}
-		final var that = (CongestionMultipliers) o;
-		return Arrays.equals(this.multipliers, that.multipliers) &&
-				Arrays.equals(this.usagePercentTriggers, that.usagePercentTriggers);
 	}
 
 	@Override

--- a/hedera-node/src/main/java/com/hedera/services/fees/calculation/RenewAssessment.java
+++ b/hedera-node/src/main/java/com/hedera/services/fees/calculation/RenewAssessment.java
@@ -1,4 +1,4 @@
-package com.hedera.services.queries.schedule;
+package com.hedera.services.fees.calculation;
 
 /*-
  * ‌
@@ -6,7 +6,8 @@ package com.hedera.services.queries.schedule;
  * ​
  * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
  * ​
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Apache License, Version 2com.hedera.services.store.tokens.views.UniqTokenViewsManager
+ * .PendingChange.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
@@ -20,19 +21,6 @@ package com.hedera.services.queries.schedule;
  * ‍
  */
 
-import javax.inject.Inject;
-import javax.inject.Singleton;
 
-@Singleton
-public class ScheduleAnswers {
-	private final GetScheduleInfoAnswer scheduleInfo;
-
-	@Inject
-	public ScheduleAnswers(GetScheduleInfoAnswer scheduleInfo) {
-		this.scheduleInfo = scheduleInfo;
-	}
-
-	public GetScheduleInfoAnswer getScheduleInfo() {
-		return scheduleInfo;
-	}
+public record RenewAssessment(long fee, long renewalPeriod) {
 }

--- a/hedera-node/src/main/java/com/hedera/services/fees/calculation/UsageBasedFeeCalculator.java
+++ b/hedera-node/src/main/java/com/hedera/services/fees/calculation/UsageBasedFeeCalculator.java
@@ -110,7 +110,7 @@ public class UsageBasedFeeCalculator implements FeeCalculator {
 	}
 
 	@Override
-	public AutoRenewCalcs.RenewAssessment assessCryptoAutoRenewal(
+	public RenewAssessment assessCryptoAutoRenewal(
 			MerkleAccount expiredAccount,
 			long requestedRenewal,
 			Instant now

--- a/hedera-node/src/main/java/com/hedera/services/fees/calculation/utils/OpUsageCtxHelper.java
+++ b/hedera-node/src/main/java/com/hedera/services/fees/calculation/utils/OpUsageCtxHelper.java
@@ -30,12 +30,12 @@ import com.hedera.services.usage.crypto.ExtantCryptoContext;
 import com.hedera.services.usage.file.FileAppendMeta;
 import com.hedera.services.usage.token.TokenOpsUsage;
 import com.hedera.services.usage.token.meta.ExtantFeeScheduleContext;
-import com.hederahashgraph.api.proto.java.Key;
 import com.hedera.services.usage.token.meta.TokenBurnMeta;
 import com.hedera.services.usage.token.meta.TokenMintMeta;
 import com.hedera.services.usage.token.meta.TokenWipeMeta;
 import com.hedera.services.utils.EntityNum;
 import com.hedera.services.utils.TxnAccessor;
+import com.hederahashgraph.api.proto.java.Key;
 import com.hederahashgraph.api.proto.java.TokenFeeScheduleUpdateTransactionBody;
 import com.hederahashgraph.api.proto.java.TransactionBody;
 import com.swirlds.merkle.map.MerkleMap;
@@ -173,7 +173,7 @@ public class OpUsageCtxHelper {
 				numFractionalFees++;
 			} else {
 				final var royaltyFee = fee.getRoyaltyFeeSpec();
-				final var fallbackFee = royaltyFee.getFallbackFee();
+				final var fallbackFee = royaltyFee.fallbackFee();
 				if (fallbackFee != null) {
 					if (fallbackFee.getTokenDenomination() != null) {
 						numRoyaltyHtsFallbackFees++;

--- a/hedera-node/src/main/java/com/hedera/services/files/SimpleUpdateResult.java
+++ b/hedera-node/src/main/java/com/hedera/services/files/SimpleUpdateResult.java
@@ -1,0 +1,29 @@
+package com.hedera.services.files;
+
+/*
+ * -
+ *  * ‌
+ *  * Hedera Services Node
+ *  * ​
+ *  * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
+ *  * ​
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *      http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *  * ‍
+ *
+ */
+
+import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
+
+public record SimpleUpdateResult(boolean attrChanged, boolean fileReplaced,
+								 ResponseCodeEnum outcome) implements HederaFs.UpdateResult {
+}

--- a/hedera-node/src/main/java/com/hedera/services/files/TieredHederaFs.java
+++ b/hedera-node/src/main/java/com/hedera/services/files/TieredHederaFs.java
@@ -51,7 +51,6 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_FILE_I
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SUCCESS;
 import static java.util.Comparator.comparingInt;
 import static java.util.function.Predicate.not;
-import static java.util.stream.Collectors.toList;
 
 /**
  * A {@link HederaFs} that stores the contents and metadata of its files in
@@ -234,35 +233,8 @@ public final class TieredHederaFs implements HederaFs {
 		data.remove(id);
 	}
 
-	public static final class SimpleUpdateResult implements UpdateResult {
-		private final boolean attrChanged;
-		private final boolean fileReplaced;
-		private final ResponseCodeEnum outcome;
-
-		public SimpleUpdateResult(
-				final boolean attrChanged,
-				final boolean fileReplaced,
-				final ResponseCodeEnum outcome
-		) {
-			this.attrChanged = attrChanged;
-			this.fileReplaced = fileReplaced;
-			this.outcome = outcome;
-		}
-
-		@Override
-		public boolean fileReplaced() {
-			return fileReplaced;
-		}
-
-		@Override
-		public ResponseCodeEnum outcome() {
-			return outcome;
-		}
-
-		@Override
-		public boolean attrChanged() {
-			return attrChanged;
-		}
+	public static final record SimpleUpdateResult(boolean attrChanged, boolean fileReplaced,
+												  ResponseCodeEnum outcome) implements UpdateResult {
 	}
 
 	private boolean isSpecialFile(FileID fid) {
@@ -313,7 +285,7 @@ public final class TieredHederaFs implements HederaFs {
 				.stream()
 				.filter(interceptor -> interceptor.priorityForCandidate(id).isPresent())
 				.sorted(comparingInt(interceptor -> interceptor.priorityForCandidate(id).getAsInt()))
-				.collect(toList());
+				.toList();
 	}
 
 	public static ResponseCodeEnum firstUnsuccessful(final ResponseCodeEnum... outcomes) {

--- a/hedera-node/src/main/java/com/hedera/services/files/TieredHederaFs.java
+++ b/hedera-node/src/main/java/com/hedera/services/files/TieredHederaFs.java
@@ -233,10 +233,6 @@ public final class TieredHederaFs implements HederaFs {
 		data.remove(id);
 	}
 
-	public static final record SimpleUpdateResult(boolean attrChanged, boolean fileReplaced,
-												  ResponseCodeEnum outcome) implements UpdateResult {
-	}
-
 	private boolean isSpecialFile(FileID fid) {
 		return specialFiles.get().contains(fid);
 	}

--- a/hedera-node/src/main/java/com/hedera/services/grpc/controllers/ScheduleController.java
+++ b/hedera-node/src/main/java/com/hedera/services/grpc/controllers/ScheduleController.java
@@ -72,6 +72,6 @@ public class ScheduleController extends ScheduleServiceGrpc.ScheduleServiceImplB
 
 	@Override
 	public void getScheduleInfo(Query query, StreamObserver<Response> observer) {
-		queryHelper.answer(query, observer, scheduleAnswers.getScheduleInfo(), ScheduleGetInfo);
+		queryHelper.answer(query, observer, scheduleAnswers.scheduleInfo(), ScheduleGetInfo);
 	}
 }

--- a/hedera-node/src/main/java/com/hedera/services/grpc/controllers/ScheduleController.java
+++ b/hedera-node/src/main/java/com/hedera/services/grpc/controllers/ScheduleController.java
@@ -72,6 +72,6 @@ public class ScheduleController extends ScheduleServiceGrpc.ScheduleServiceImplB
 
 	@Override
 	public void getScheduleInfo(Query query, StreamObserver<Response> observer) {
-		queryHelper.answer(query, observer, scheduleAnswers.scheduleInfo(), ScheduleGetInfo);
+		queryHelper.answer(query, observer, scheduleAnswers.getScheduleInfo(), ScheduleGetInfo);
 	}
 }

--- a/hedera-node/src/main/java/com/hedera/services/grpc/marshalling/CustomFeeMeta.java
+++ b/hedera-node/src/main/java/com/hedera/services/grpc/marshalling/CustomFeeMeta.java
@@ -22,65 +22,11 @@ package com.hedera.services.grpc.marshalling;
 
 import com.hedera.services.state.submerkle.FcCustomFee;
 import com.hedera.services.store.models.Id;
-import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.Objects;
 
-public class CustomFeeMeta {
+public record CustomFeeMeta(Id tokenId, Id treasuryId, List<FcCustomFee> customFees) {
 	public static final CustomFeeMeta MISSING_META =
 			new CustomFeeMeta(Id.MISSING_ID, Id.MISSING_ID, Collections.emptyList());
-
-	private final Id tokenId;
-	private final Id treasuryId;
-	private final List<FcCustomFee> customFees;
-
-	public CustomFeeMeta(Id tokenId, Id treasuryId, List<FcCustomFee> customFees) {
-		this.tokenId = tokenId;
-		this.treasuryId = treasuryId;
-		this.customFees = customFees;
-	}
-
-	public Id getTokenId() {
-		return tokenId;
-	}
-
-	public Id getTreasuryId() {
-		return treasuryId;
-	}
-
-	public List<FcCustomFee> getCustomFees() {
-		return customFees;
-	}
-
-	@Override
-	public boolean equals(Object o) {
-		if (this == o) {
-			return true;
-		}
-		if (o == null || CustomFeeMeta.class != o.getClass()) {
-			return false;
-		}
-
-		var that = (CustomFeeMeta) o;
-
-		return Objects.equals(this.tokenId, that.tokenId)
-				&& Objects.equals(this.treasuryId, that.treasuryId)
-				&& Objects.equals(this.customFees, that.customFees);
-	}
-
-	@Override
-	public String toString() {
-		return "CustomFeeMeta{" +
-				"tokenId=" + tokenId +
-				", treasuryId=" + treasuryId +
-				", customFees=" + customFees +
-				'}';
-	}
-
-	@Override
-	public int hashCode() {
-		return HashCodeBuilder.reflectionHashCode(this);
-	}
 }

--- a/hedera-node/src/main/java/com/hedera/services/grpc/marshalling/CustomSchedulesManager.java
+++ b/hedera-node/src/main/java/com/hedera/services/grpc/marshalling/CustomSchedulesManager.java
@@ -38,7 +38,7 @@ public class CustomSchedulesManager {
 		CustomFeeMeta extantMeta = null;
 		if (!allManagedMeta.isEmpty()) {
 			for (var meta : allManagedMeta) {
-				if (token.equals(meta.getTokenId())) {
+				if (token.equals(meta.tokenId())) {
 					extantMeta = meta;
 					break;
 				}

--- a/hedera-node/src/main/java/com/hedera/services/grpc/marshalling/FeeAssessor.java
+++ b/hedera-node/src/main/java/com/hedera/services/grpc/marshalling/FeeAssessor.java
@@ -64,20 +64,20 @@ public class FeeAssessor {
 			List<FcAssessedCustomFee> accumulator,
 			ImpliedTransfersMeta.ValidationProps props
 	) {
-		if (changeManager.getLevelNo() > props.getMaxNestedCustomFees()) {
+		if (changeManager.getLevelNo() > props.maxNestedCustomFees()) {
 			return CUSTOM_FEE_CHARGING_EXCEEDED_MAX_RECURSION_DEPTH;
 		}
 		final var chargingToken = change.getToken();
 
 		final var feeMeta = customSchedulesManager.managedSchedulesFor(chargingToken);
 		final var payer = change.getAccount();
-		final var fees = feeMeta.getCustomFees();
+		final var fees = feeMeta.customFees();
 		/* Token treasuries are exempt from all custom fees */
-		if (fees.isEmpty() || feeMeta.getTreasuryId().equals(payer)) {
+		if (fees.isEmpty() || feeMeta.treasuryId().equals(payer)) {
 			return OK;
 		}
 
-		final var maxBalanceChanges = props.getMaxXferBalanceChanges();
+		final var maxBalanceChanges = props.maxXferBalanceChanges();
 		final var fixedFeeResult =
 				assessFixedFees(chargingToken, fees, payer, changeManager, accumulator, maxBalanceChanges);
 		if (fixedFeeResult == ASSESSMENT_FAILED_WITH_TOO_MANY_ADJUSTMENTS_REQUIRED) {

--- a/hedera-node/src/main/java/com/hedera/services/grpc/marshalling/FractionalFeeAssessor.java
+++ b/hedera-node/src/main/java/com/hedera/services/grpc/marshalling/FractionalFeeAssessor.java
@@ -107,7 +107,7 @@ public class FractionalFeeAssessor {
 		int n = credits.size();
 		final var nums = new long[n];
 		for (int i = 0; i < n; i++) {
-			nums[i] = credits.get(i).getAccount().getNum();
+			nums[i] = credits.get(i).getAccount().num();
 		}
 		return nums;
 	}
@@ -142,7 +142,8 @@ public class FractionalFeeAssessor {
 	}
 
 	long amountOwedGiven(long initialUnits, FractionalFeeSpec spec) {
-		final var nominalFee = AdjustmentUtils.safeFractionMultiply(spec.getNumerator(), spec.getDenominator(), initialUnits);
+		final var nominalFee = AdjustmentUtils.safeFractionMultiply(spec.getNumerator(), spec.getDenominator(),
+				initialUnits);
 		long effectiveFee = Math.max(nominalFee, spec.getMinimumAmount());
 		if (spec.getMaximumUnitsToCollect() > 0) {
 			effectiveFee = Math.min(effectiveFee, spec.getMaximumUnitsToCollect());

--- a/hedera-node/src/main/java/com/hedera/services/grpc/marshalling/HbarFeeAssessor.java
+++ b/hedera-node/src/main/java/com/hedera/services/grpc/marshalling/HbarFeeAssessor.java
@@ -9,9 +9,9 @@ package com.hedera.services.grpc.marshalling;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -48,7 +48,7 @@ public class HbarFeeAssessor {
 		final var fixedSpec = hbarFee.getFixedFeeSpec();
 		final var amount = fixedSpec.getUnitsToCollect();
 		adjustForAssessedHbar(payer, collector, amount, changeManager);
-		final var effPayerAccountNums = new long[] { payer.getNum() };
+		final var effPayerAccountNums = new long[] { payer.num() };
 		final var assessed = new FcAssessedCustomFee(collector.asEntityId(), amount, effPayerAccountNums);
 		accumulator.add(assessed);
 		return OK;

--- a/hedera-node/src/main/java/com/hedera/services/grpc/marshalling/HtsFeeAssessor.java
+++ b/hedera-node/src/main/java/com/hedera/services/grpc/marshalling/HtsFeeAssessor.java
@@ -9,9 +9,9 @@ package com.hedera.services.grpc.marshalling;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -51,7 +51,7 @@ public class HtsFeeAssessor {
 		final var denominatingToken = fixedSpec.getTokenDenomination().asId();
 		adjustForAssessed(payer, chargingToken, collector, denominatingToken, amount, changeManager);
 
-		final var effPayerAccountNums = new long[] { payer.getNum() };
+		final var effPayerAccountNums = new long[] { payer.num() };
 		final var assessed = new FcAssessedCustomFee(
 				htsFee.getFeeCollector(),
 				fixedSpec.getTokenDenomination(),

--- a/hedera-node/src/main/java/com/hedera/services/grpc/marshalling/ImpliedTransfersMeta.java
+++ b/hedera-node/src/main/java/com/hedera/services/grpc/marshalling/ImpliedTransfersMeta.java
@@ -118,7 +118,7 @@ public class ImpliedTransfersMeta {
 			return false;
 		}
 		for (var meta : customFeeMeta) {
-			final var tokenId = meta.getTokenId();
+			final var tokenId = meta.tokenId();
 			var newCustomMeta = customFeeSchedules.lookupMetaFor(tokenId);
 			if (!meta.equals(newCustomMeta)) {
 				return false;
@@ -155,62 +155,7 @@ public class ImpliedTransfersMeta {
 				.toString();
 	}
 
-	public static class ValidationProps {
-		private final int maxHbarAdjusts;
-		private final int maxTokenAdjusts;
-		private final int maxOwnershipChanges;
-		private final int maxNestedCustomFees;
-		private final int maxXferBalanceChanges;
-		private final boolean areNftsEnabled;
-
-		public ValidationProps(
-				int maxHbarAdjusts,
-				int maxTokenAdjusts,
-				int maxOwnershipChanges,
-				int maxNestedCustomFees,
-				int maxXferBalanceChanges,
-				boolean areNftsEnabled
-		) {
-			this.maxHbarAdjusts = maxHbarAdjusts;
-			this.maxTokenAdjusts = maxTokenAdjusts;
-			this.maxOwnershipChanges = maxOwnershipChanges;
-			this.maxNestedCustomFees = maxNestedCustomFees;
-			this.maxXferBalanceChanges = maxXferBalanceChanges;
-			this.areNftsEnabled = areNftsEnabled;
-		}
-
-		public int getMaxHbarAdjusts() {
-			return maxHbarAdjusts;
-		}
-
-		public int getMaxTokenAdjusts() {
-			return maxTokenAdjusts;
-		}
-
-		public int getMaxOwnershipChanges() {
-			return maxOwnershipChanges;
-		}
-
-		public int getMaxNestedCustomFees() {
-			return maxNestedCustomFees;
-		}
-
-		public int getMaxXferBalanceChanges() {
-			return maxXferBalanceChanges;
-		}
-
-		public boolean areNftsEnabled() {
-			return areNftsEnabled;
-                }
-
-		@Override
-		public boolean equals(Object obj) {
-			return EqualsBuilder.reflectionEquals(this, obj);
-		}
-
-		@Override
-		public int hashCode() {
-			return HashCodeBuilder.reflectionHashCode(this);
-		}
+	public static record ValidationProps(int maxHbarAdjusts, int maxTokenAdjusts, int maxOwnershipChanges,
+										 int maxNestedCustomFees, int maxXferBalanceChanges, boolean areNftsEnabled) {
 	}
 }

--- a/hedera-node/src/main/java/com/hedera/services/grpc/marshalling/RoyaltyFeeAssessor.java
+++ b/hedera-node/src/main/java/com/hedera/services/grpc/marshalling/RoyaltyFeeAssessor.java
@@ -75,7 +75,7 @@ public class RoyaltyFeeAssessor {
 			final var spec = fee.getRoyaltyFeeSpec();
 
 			if (exchangedValue.isEmpty()) {
-				final var fallback = spec.getFallbackFee();
+				final var fallback = spec.fallbackFee();
 				if (fallback != null) {
 					final var receiver = Id.fromGrpcAccount(change.counterPartyAccountId());
 					final var fallbackFee = FcCustomFee.fixedFee(
@@ -111,7 +111,7 @@ public class RoyaltyFeeAssessor {
 	) {
 		for (var exchange : exchangedValue) {
 			long value = exchange.originalUnits();
-			long royaltyFee = safeFractionMultiply(spec.getNumerator(), spec.getDenominator(), value);
+			long royaltyFee = safeFractionMultiply(spec.numerator(), spec.denominator(), value);
 			if (exchange.units() < royaltyFee) {
 				return INSUFFICIENT_SENDER_ACCOUNT_BALANCE_FOR_CUSTOM_FEE;
 			}
@@ -121,7 +121,7 @@ public class RoyaltyFeeAssessor {
 			 on fees charged in the units of their denominating token; but this is a credit,
 			 hence the id is irrelevant and we can use MISSING_ID. */
 			fungibleAdjuster.adjustedChange(collector, MISSING_ID, denom, royaltyFee, changeManager);
-			final var effPayerAccountNum = new long[] { exchange.getAccount().getNum() };
+			final var effPayerAccountNum = new long[] { exchange.getAccount().num() };
 			final var collectorId = collector.asEntityId();
 			final var assessed =
 					exchange.isForHbar()

--- a/hedera-node/src/main/java/com/hedera/services/ledger/BalanceChange.java
+++ b/hedera-node/src/main/java/com/hedera/services/ledger/BalanceChange.java
@@ -88,7 +88,7 @@ public class BalanceChange {
 				nftTransfer.getReceiverAccountID(),
 				serialNo,
 				SENDER_DOES_NOT_OWN_NFT_SERIAL_NO);
-		nftChange.nftId = new NftId(token.getShard(), token.getRealm(), token.getNum(), serialNo);
+		nftChange.nftId = new NftId(token.shard(), token.realm(), token.num(), serialNo);
 		nftChange.tokenId = tokenId;
 		return nftChange;
 	}

--- a/hedera-node/src/main/java/com/hedera/services/ledger/PureTransferSemanticChecks.java
+++ b/hedera-node/src/main/java/com/hedera/services/ledger/PureTransferSemanticChecks.java
@@ -68,9 +68,9 @@ public class PureTransferSemanticChecks {
 			List<TokenTransferList> tokenAdjustsList,
 			ImpliedTransfersMeta.ValidationProps validationProps
 	) {
-		final var maxHbarAdjusts = validationProps.getMaxHbarAdjusts();
-		final var maxTokenAdjusts = validationProps.getMaxTokenAdjusts();
-		final var maxOwnershipChanges = validationProps.getMaxOwnershipChanges();
+		final var maxHbarAdjusts = validationProps.maxHbarAdjusts();
+		final var maxTokenAdjusts = validationProps.maxTokenAdjusts();
+		final var maxOwnershipChanges = validationProps.maxOwnershipChanges();
 		final var areNftsEnabled = validationProps.areNftsEnabled();
 
 		final var hbarAdjusts = hbarAdjustsWrapper.getAccountAmountsList();

--- a/hedera-node/src/main/java/com/hedera/services/legacy/core/jproto/TxnReceipt.java
+++ b/hedera-node/src/main/java/com/hedera/services/legacy/core/jproto/TxnReceipt.java
@@ -38,7 +38,6 @@ import com.swirlds.common.io.SerializableDataOutputStream;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Objects;
-import java.util.stream.Collectors;
 
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.REVERTED_SUCCESS;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SUCCESS;
@@ -390,7 +389,7 @@ public class TxnReceipt implements SelfSerializable {
 
 		if (txReceipt.getSerialNumbers() != MISSING_SERIAL_NUMBERS) {
 			builder.addAllSerialNumbers(
-					Arrays.stream(txReceipt.getSerialNumbers()).boxed().collect(Collectors.toList()));
+					Arrays.stream(txReceipt.getSerialNumbers()).boxed().toList());
 		}
 		return builder.build();
 	}

--- a/hedera-node/src/main/java/com/hedera/services/queries/crypto/CryptoAnswers.java
+++ b/hedera-node/src/main/java/com/hedera/services/queries/crypto/CryptoAnswers.java
@@ -24,13 +24,45 @@ import javax.inject.Inject;
 import javax.inject.Singleton;
 
 @Singleton
-public record CryptoAnswers(GetLiveHashAnswer liveHash,
-							GetStakersAnswer stakers,
-							GetAccountInfoAnswer accountInfo,
-							GetAccountBalanceAnswer accountBalance,
-							GetAccountRecordsAnswer accountRecords) {
+public class CryptoAnswers {
+	private final GetLiveHashAnswer liveHash;
+	private final GetStakersAnswer stakers;
+	private final GetAccountInfoAnswer accountInfo;
+	private final GetAccountBalanceAnswer accountBalance;
+	private final GetAccountRecordsAnswer accountRecords;
 
 	@Inject
-	public CryptoAnswers {
+	public CryptoAnswers(
+			final GetLiveHashAnswer liveHash,
+			final GetStakersAnswer stakers,
+			final GetAccountInfoAnswer accountInfo,
+			final GetAccountBalanceAnswer accountBalance,
+			final GetAccountRecordsAnswer accountRecords
+	) {
+		this.liveHash = liveHash;
+		this.stakers = stakers;
+		this.accountInfo = accountInfo;
+		this.accountBalance = accountBalance;
+		this.accountRecords = accountRecords;
+	}
+
+	public GetLiveHashAnswer getLiveHash() {
+		return liveHash;
+	}
+
+	public GetStakersAnswer getStakers() {
+		return stakers;
+	}
+
+	public GetAccountBalanceAnswer getAccountBalance() {
+		return accountBalance;
+	}
+
+	public GetAccountInfoAnswer getAccountInfo() {
+		return accountInfo;
+	}
+
+	public GetAccountRecordsAnswer getAccountRecords() {
+		return accountRecords;
 	}
 }

--- a/hedera-node/src/main/java/com/hedera/services/queries/crypto/CryptoAnswers.java
+++ b/hedera-node/src/main/java/com/hedera/services/queries/crypto/CryptoAnswers.java
@@ -24,45 +24,13 @@ import javax.inject.Inject;
 import javax.inject.Singleton;
 
 @Singleton
-public class CryptoAnswers {
-	private final GetLiveHashAnswer liveHash;
-	private final GetStakersAnswer stakers;
-	private final GetAccountInfoAnswer accountInfo;
-	private final GetAccountBalanceAnswer accountBalance;
-	private final GetAccountRecordsAnswer accountRecords;
+public record CryptoAnswers(GetLiveHashAnswer liveHash,
+							GetStakersAnswer stakers,
+							GetAccountInfoAnswer accountInfo,
+							GetAccountBalanceAnswer accountBalance,
+							GetAccountRecordsAnswer accountRecords) {
 
 	@Inject
-	public CryptoAnswers(
-			final GetLiveHashAnswer liveHash,
-			final GetStakersAnswer stakers,
-			final GetAccountInfoAnswer accountInfo,
-			final GetAccountBalanceAnswer accountBalance,
-			final GetAccountRecordsAnswer accountRecords
-	) {
-		this.liveHash = liveHash;
-		this.stakers = stakers;
-		this.accountInfo = accountInfo;
-		this.accountBalance = accountBalance;
-		this.accountRecords = accountRecords;
-	}
-
-	public GetLiveHashAnswer getLiveHash() {
-		return liveHash;
-	}
-
-	public GetStakersAnswer getStakers() {
-		return stakers;
-	}
-
-	public GetAccountBalanceAnswer getAccountBalance() {
-		return accountBalance;
-	}
-
-	public GetAccountInfoAnswer getAccountInfo() {
-		return accountInfo;
-	}
-
-	public GetAccountRecordsAnswer getAccountRecords() {
-		return accountRecords;
+	public CryptoAnswers {
 	}
 }

--- a/hedera-node/src/main/java/com/hedera/services/queries/meta/MetaAnswers.java
+++ b/hedera-node/src/main/java/com/hedera/services/queries/meta/MetaAnswers.java
@@ -24,14 +24,45 @@ import javax.inject.Inject;
 import javax.inject.Singleton;
 
 @Singleton
-public record MetaAnswers(GetExecTimeAnswer execTime,
-						  GetTxnRecordAnswer txnRecord,
-						  GetTxnReceiptAnswer txnReceipt,
-						  GetVersionInfoAnswer versionInfo,
-						  GetFastTxnRecordAnswer fastTxnRecord) {
-
+public class MetaAnswers {
+	private final GetExecTimeAnswer execTime;
+	private final GetTxnRecordAnswer txnRecord;
+	private final GetTxnReceiptAnswer txnReceipt;
+	private final GetVersionInfoAnswer versionInfo;
+	private final GetFastTxnRecordAnswer fastTxnRecord;
 
 	@Inject
-	public MetaAnswers {
+	public MetaAnswers(
+			GetExecTimeAnswer execTime,
+			GetTxnRecordAnswer txnRecord,
+			GetTxnReceiptAnswer txnReceipt,
+			GetVersionInfoAnswer versionInfo,
+			GetFastTxnRecordAnswer fastTxnRecord
+	) {
+		this.execTime = execTime;
+		this.txnRecord = txnRecord;
+		this.txnReceipt = txnReceipt;
+		this.versionInfo = versionInfo;
+		this.fastTxnRecord = fastTxnRecord;
+	}
+
+	public GetVersionInfoAnswer getVersionInfo() {
+		return versionInfo;
+	}
+
+	public GetTxnReceiptAnswer getTxnReceipt() {
+		return txnReceipt;
+	}
+
+	public GetTxnRecordAnswer getTxnRecord() {
+		return txnRecord;
+	}
+
+	public GetFastTxnRecordAnswer getFastTxnRecord() {
+		return fastTxnRecord;
+	}
+
+	public GetExecTimeAnswer getExecTime() {
+		return execTime;
 	}
 }

--- a/hedera-node/src/main/java/com/hedera/services/queries/meta/MetaAnswers.java
+++ b/hedera-node/src/main/java/com/hedera/services/queries/meta/MetaAnswers.java
@@ -9,9 +9,9 @@ package com.hedera.services.queries.meta;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -24,45 +24,14 @@ import javax.inject.Inject;
 import javax.inject.Singleton;
 
 @Singleton
-public class MetaAnswers {
-	private final GetExecTimeAnswer execTime;
-	private final GetTxnRecordAnswer txnRecord;
-	private final GetTxnReceiptAnswer txnReceipt;
-	private final GetVersionInfoAnswer versionInfo;
-	private final GetFastTxnRecordAnswer fastTxnRecord;
+public record MetaAnswers(GetExecTimeAnswer execTime,
+						  GetTxnRecordAnswer txnRecord,
+						  GetTxnReceiptAnswer txnReceipt,
+						  GetVersionInfoAnswer versionInfo,
+						  GetFastTxnRecordAnswer fastTxnRecord) {
+
 
 	@Inject
-	public MetaAnswers(
-			GetExecTimeAnswer execTime,
-			GetTxnRecordAnswer txnRecord,
-			GetTxnReceiptAnswer txnReceipt,
-			GetVersionInfoAnswer versionInfo,
-			GetFastTxnRecordAnswer fastTxnRecord
-	) {
-		this.execTime = execTime;
-		this.txnRecord = txnRecord;
-		this.txnReceipt = txnReceipt;
-		this.versionInfo = versionInfo;
-		this.fastTxnRecord = fastTxnRecord;
-	}
-
-	public GetVersionInfoAnswer getVersionInfo() {
-		return versionInfo;
-	}
-
-	public GetTxnReceiptAnswer getTxnReceipt() {
-		return txnReceipt;
-	}
-
-	public GetTxnRecordAnswer getTxnRecord() {
-		return txnRecord;
-	}
-
-	public GetFastTxnRecordAnswer getFastTxnRecord() {
-		return fastTxnRecord;
-	}
-
-	public GetExecTimeAnswer getExecTime() {
-		return execTime;
+	public MetaAnswers {
 	}
 }

--- a/hedera-node/src/main/java/com/hedera/services/queries/schedule/ScheduleAnswers.java
+++ b/hedera-node/src/main/java/com/hedera/services/queries/schedule/ScheduleAnswers.java
@@ -24,15 +24,9 @@ import javax.inject.Inject;
 import javax.inject.Singleton;
 
 @Singleton
-public class ScheduleAnswers {
-    private final GetScheduleInfoAnswer scheduleInfo;
+public record ScheduleAnswers(GetScheduleInfoAnswer scheduleInfo) {
 
-    @Inject
-    public ScheduleAnswers(GetScheduleInfoAnswer scheduleInfo) {
-        this.scheduleInfo = scheduleInfo;
-    }
-
-    public GetScheduleInfoAnswer getScheduleInfo() {
-        return scheduleInfo;
-    }
+	@Inject
+	public ScheduleAnswers {
+	}
 }

--- a/hedera-node/src/main/java/com/hedera/services/records/InProgressChildRecord.java
+++ b/hedera-node/src/main/java/com/hedera/services/records/InProgressChildRecord.java
@@ -23,30 +23,7 @@ package com.hedera.services.records;
 import com.hedera.services.state.submerkle.ExpirableTxnRecord;
 import com.hederahashgraph.api.proto.java.TransactionBody;
 
-public class InProgressChildRecord {
-	private final int sourceId;
-	private final TransactionBody.Builder syntheticBody;
-	private final ExpirableTxnRecord.Builder recordBuilder;
-
-	public InProgressChildRecord(
-			final int sourceId,
-			final TransactionBody.Builder syntheticBody,
-			final ExpirableTxnRecord.Builder recordBuilder
-	) {
-		this.sourceId = sourceId;
-		this.syntheticBody = syntheticBody;
-		this.recordBuilder = recordBuilder;
-	}
-
-	public int getSourceId() {
-		return sourceId;
-	}
-
-	public TransactionBody.Builder getSyntheticBody() {
-		return syntheticBody;
-	}
-
-	public ExpirableTxnRecord.Builder getRecordBuilder() {
-		return recordBuilder;
-	}
+public record InProgressChildRecord(int sourceId,
+									TransactionBody.Builder syntheticBody,
+									ExpirableTxnRecord.Builder recordBuilder) {
 }

--- a/hedera-node/src/main/java/com/hedera/services/records/RecordCache.java
+++ b/hedera-node/src/main/java/com/hedera/services/records/RecordCache.java
@@ -43,7 +43,6 @@ import java.util.function.Function;
 
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.FAIL_INVALID;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.UNKNOWN;
-import static java.util.stream.Collectors.toList;
 
 @Singleton
 public class RecordCache {
@@ -115,7 +114,7 @@ public class RecordCache {
 	}
 
 	public List<TransactionReceipt> getDuplicateReceipts(final TransactionID txnId) {
-		return duplicatesOf(txnId).stream().map(TransactionRecord::getReceipt).collect(toList());
+		return duplicatesOf(txnId).stream().map(TransactionRecord::getReceipt).toList();
 	}
 
 	public List<TransactionReceipt> getChildReceipts(final TransactionID txnId) {
@@ -161,7 +160,7 @@ public class RecordCache {
 			return recentHistory.duplicateRecords()
 					.stream()
 					.map(ExpirableTxnRecord::asGrpc)
-					.collect(toList());
+					.toList();
 		}
 	}
 

--- a/hedera-node/src/main/java/com/hedera/services/records/TxnAwareRecordsHistorian.java
+++ b/hedera-node/src/main/java/com/hedera/services/records/TxnAwareRecordsHistorian.java
@@ -177,8 +177,8 @@ public class TxnAwareRecordsHistorian implements AccountRecordsHistorian {
 
 	private void revert(final int sourceId, final List<InProgressChildRecord> childRecords) {
 		for (final var inProgress : childRecords) {
-			if (inProgress.getSourceId() == sourceId) {
-				inProgress.getRecordBuilder().revert();
+			if (inProgress.sourceId() == sourceId) {
+				inProgress.recordBuilder().revert();
 			}
 		}
 	}
@@ -198,7 +198,7 @@ public class TxnAwareRecordsHistorian implements AccountRecordsHistorian {
 		final var parentId = topLevel.getTxnId();
 		for (int i = 0, n = childRecords.size(); i < n; i++) {
 			final var inProgress = childRecords.get(i);
-			final var child = inProgress.getRecordBuilder();
+			final var child = inProgress.recordBuilder();
 			topLevel.excludeHbarChangesFrom(child);
 
 			child.setTxnId(parentId.withNonce(nextNonce++));
@@ -210,7 +210,7 @@ public class TxnAwareRecordsHistorian implements AccountRecordsHistorian {
 				child.setParentConsensusTime(consensusNow);
 			}
 
-			final var synthTxn = synthFrom(inProgress.getSyntheticBody(), child);
+			final var synthTxn = synthFrom(inProgress.syntheticBody(), child);
 			final var synthHash = noThrowSha384HashOf(synthTxn.getSignedTransactionBytes().toByteArray());
 			child.setTxnHash(synthHash);
 			recordObjs.add(new RecordStreamObject(child.build(), synthTxn, childConsTime));

--- a/hedera-node/src/main/java/com/hedera/services/records/TxnIdRecentHistory.java
+++ b/hedera-node/src/main/java/com/hedera/services/records/TxnIdRecentHistory.java
@@ -40,7 +40,6 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_NODE_A
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_PAYER_SIGNATURE;
 import static java.util.Comparator.comparing;
 import static java.util.Comparator.comparingLong;
-import static java.util.stream.Collectors.toList;
 
 public class TxnIdRecentHistory {
 	private static final Comparator<RichInstant> RI_CMP =
@@ -69,7 +68,7 @@ public class TxnIdRecentHistory {
 	public List<ExpirableTxnRecord> duplicateRecords() {
 		return Stream.concat(classifiableDuplicates(), unclassifiableDuplicates())
 				.sorted(CONSENSUS_TIME_COMPARATOR)
-				.collect(toList());
+				.toList();
 	}
 
 	private Stream<ExpirableTxnRecord> classifiableDuplicates() {

--- a/hedera-node/src/main/java/com/hedera/services/sigs/metadata/AccountSigningMetadata.java
+++ b/hedera-node/src/main/java/com/hedera/services/sigs/metadata/AccountSigningMetadata.java
@@ -9,9 +9,9 @@ package com.hedera.services.sigs.metadata;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -25,28 +25,5 @@ import com.hedera.services.legacy.core.jproto.JKey;
 /**
  * Represents metadata about the signing activities of a Hedera cryptocurrency account.
  */
-public class AccountSigningMetadata {
-	private final JKey key;
-	private final boolean receiverSigRequired;
-
-	public AccountSigningMetadata(JKey key, boolean receiverSigRequired) {
-		this.key = key;
-		this.receiverSigRequired = receiverSigRequired;
-	}
-
-	public JKey getKey() {
-		return key;
-	}
-
-	public boolean isReceiverSigRequired() {
-		return receiverSigRequired;
-	}
-
-	@Override
-	public String toString() {
-		return "AccountSigningMetadata{" +
-				"key=" + key +
-				", receiverSigRequired=" + receiverSigRequired +
-				'}';
-	}
+public record AccountSigningMetadata(JKey key, boolean receiverSigRequired) {
 }

--- a/hedera-node/src/main/java/com/hedera/services/sigs/metadata/ContractSigningMetadata.java
+++ b/hedera-node/src/main/java/com/hedera/services/sigs/metadata/ContractSigningMetadata.java
@@ -9,9 +9,9 @@ package com.hedera.services.sigs.metadata;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -26,24 +26,8 @@ import com.hedera.services.legacy.core.jproto.JKey;
 /**
  * Represents metadata about the signing activities of a Hedera smart contract.
  */
-public class ContractSigningMetadata {
-	private final JKey key;
-	private final boolean receiverSigRequired;
-
-	public ContractSigningMetadata(JKey key, boolean receiverSigRequired) {
-		this.key = key;
-		this.receiverSigRequired = receiverSigRequired;
-	}
-
+public record ContractSigningMetadata(JKey key, boolean receiverSigRequired) {
 	public boolean hasAdminKey() {
 		return !(key instanceof JContractIDKey);
-	}
-
-	public JKey getKey() {
-		return key;
-	}
-
-	public boolean isReceiverSigRequired() {
-		return receiverSigRequired;
 	}
 }

--- a/hedera-node/src/main/java/com/hedera/services/sigs/metadata/FileSigningMetadata.java
+++ b/hedera-node/src/main/java/com/hedera/services/sigs/metadata/FileSigningMetadata.java
@@ -9,9 +9,9 @@ package com.hedera.services.sigs.metadata;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -25,14 +25,5 @@ import com.hedera.services.legacy.core.jproto.JKey;
 /**
  * Represents metadata about the signing activities of a Hedera file.
  */
-public class FileSigningMetadata {
-	private final JKey wacl;
-
-	public FileSigningMetadata(JKey wacl) {
-		this.wacl = wacl;
-	}
-
-	public JKey getWacl() {
-		return wacl;
-	}
+public record FileSigningMetadata(JKey wacl) {
 }

--- a/hedera-node/src/main/java/com/hedera/services/sigs/metadata/TokenSigningMetadata.java
+++ b/hedera-node/src/main/java/com/hedera/services/sigs/metadata/TokenSigningMetadata.java
@@ -71,7 +71,7 @@ public class TokenSigningMetadata {
 				if (fee.getFeeType() != FcCustomFee.FeeType.ROYALTY_FEE) {
 					continue;
 				}
-				if (fee.getRoyaltyFeeSpec().getFallbackFee() != null) {
+				if (fee.getRoyaltyFeeSpec().fallbackFee() != null) {
 					hasRoyaltyWithFallback = true;
 					break;
 				}

--- a/hedera-node/src/main/java/com/hedera/services/sigs/metadata/TopicSigningMetadata.java
+++ b/hedera-node/src/main/java/com/hedera/services/sigs/metadata/TopicSigningMetadata.java
@@ -9,9 +9,9 @@ package com.hedera.services.sigs.metadata;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -22,21 +22,12 @@ package com.hedera.services.sigs.metadata;
 
 import com.hedera.services.legacy.core.jproto.JKey;
 
-public class TopicSigningMetadata {
-	private final JKey adminKey;
-	private final JKey submitKey;
-
-	public TopicSigningMetadata(JKey adminKey, JKey submitKey) {
-		this.adminKey = adminKey;
-		this.submitKey = submitKey;
+public record TopicSigningMetadata(JKey adminKey, JKey submitKey) {
+	public boolean hasAdminKey() {
+		return null != adminKey;
 	}
 
-	public boolean hasAdminKey() { return null != adminKey; }
-	public JKey getAdminKey() {
-		return adminKey;
-	}
-	public boolean hasSubmitKey() { return null != submitKey; }
-	public JKey getSubmitKey() {
-		return submitKey;
+	public boolean hasSubmitKey() {
+		return null != submitKey;
 	}
 }

--- a/hedera-node/src/main/java/com/hedera/services/sigs/order/SigRequirements.java
+++ b/hedera-node/src/main/java/com/hedera/services/sigs/order/SigRequirements.java
@@ -156,7 +156,7 @@ public class SigRequirements {
 		final var payer = txn.getTransactionID().getAccountID();
 		final var result = sigMetaLookup.accountSigningMetaFor(payer);
 		if (result.succeeded()) {
-			return factory.forValidOrder(List.of(result.metadata().getKey()));
+			return factory.forValidOrder(List.of(result.metadata().key()));
 		} else {
 			if (result.failureIfAny() == MISSING_ACCOUNT) {
 				return factory.forInvalidAccount();
@@ -284,23 +284,23 @@ public class SigRequirements {
 			return contractFailure(targetResult.failureIfAny(), factory);
 		}
 		required = mutable(required);
-		required.add(targetResult.metadata().getKey());
+		required.add(targetResult.metadata().key());
 
 		if (op.hasTransferAccountID()) {
 			var beneficiary = op.getTransferAccountID();
 			var beneficiaryResult = sigMetaLookup.accountSigningMetaFor(beneficiary);
 			if (!beneficiaryResult.succeeded()) {
 				return factory.forInvalidAccount();
-			} else if (beneficiaryResult.metadata().isReceiverSigRequired()) {
-				required.add(beneficiaryResult.metadata().getKey());
+			} else if (beneficiaryResult.metadata().receiverSigRequired()) {
+				required.add(beneficiaryResult.metadata().key());
 			}
 		} else if (op.hasTransferContractID()) {
 			var beneficiary = op.getTransferContractID();
 			var beneficiaryResult = sigMetaLookup.contractSigningMetaFor(beneficiary);
 			if (!beneficiaryResult.succeeded()) {
 				return factory.forInvalidContract();
-			} else if (beneficiaryResult.metadata().isReceiverSigRequired()) {
-				required.add(beneficiaryResult.metadata().getKey());
+			} else if (beneficiaryResult.metadata().receiverSigRequired()) {
+				required.add(beneficiaryResult.metadata().key());
 			}
 		}
 
@@ -320,7 +320,7 @@ public class SigRequirements {
 				return contractFailure(result.failureIfAny(), factory);
 			}
 			required = mutable(required);
-			required.add(result.metadata().getKey());
+			required.add(result.metadata().key());
 		}
 		if (hasNondeprecatedAdminKey(op)) {
 			var candidate = asUsableFcKey(op.getAdminKey());
@@ -364,7 +364,7 @@ public class SigRequirements {
 		if (!targetResult.succeeded()) {
 			return factory.forMissingFile();
 		} else {
-			var wacl = targetResult.metadata().getWacl();
+			var wacl = targetResult.metadata().wacl();
 			return wacl.isEmpty() ? SigningOrderResult.noKnownKeys() : factory.forValidOrder(List.of(wacl));
 		}
 	}
@@ -383,7 +383,7 @@ public class SigRequirements {
 		} else {
 			List<JKey> required = new ArrayList<>();
 			if (targetWaclMustSign) {
-				var wacl = targetResult.metadata().getWacl();
+				var wacl = targetResult.metadata().wacl();
 				if (!wacl.isEmpty()) {
 					required.add(wacl);
 				}
@@ -405,7 +405,7 @@ public class SigRequirements {
 			return factory.forMissingFile();
 		} else {
 			if (targetWaclMustSign) {
-				var wacl = targetResult.metadata().getWacl();
+				var wacl = targetResult.metadata().wacl();
 				return wacl.isEmpty() ? SigningOrderResult.noKnownKeys() : factory.forValidOrder(List.of(wacl));
 			} else {
 				return SigningOrderResult.noKnownKeys();
@@ -437,7 +437,7 @@ public class SigRequirements {
 				return accountFailure(targetResult.failureIfAny(), factory);
 			}
 			required = mutable(required);
-			required.add(targetResult.metadata().getKey());
+			required.add(targetResult.metadata().key());
 		}
 
 		var beneficiary = op.getTransferAccountID();
@@ -445,9 +445,9 @@ public class SigRequirements {
 			var beneficiaryResult = sigMetaLookup.accountSigningMetaFor(beneficiary);
 			if (!beneficiaryResult.succeeded()) {
 				return accountFailure(beneficiaryResult.failureIfAny(), factory);
-			} else if (beneficiaryResult.metadata().isReceiverSigRequired()) {
+			} else if (beneficiaryResult.metadata().receiverSigRequired()) {
 				required = mutable(required);
-				required.add(beneficiaryResult.metadata().getKey());
+				required.add(beneficiaryResult.metadata().key());
 			}
 		}
 
@@ -470,7 +470,7 @@ public class SigRequirements {
 		} else {
 			if (targetAccountKeyMustSign && !payer.equals(target)) {
 				required = mutable(required);
-				required.add(result.metadata().getKey());
+				required.add(result.metadata().key());
 			}
 			if (newAccountKeyMustSign && op.hasKey()) {
 				required = mutable(required);
@@ -758,8 +758,8 @@ public class SigRequirements {
 			var result = sigMetaLookup.accountSigningMetaFor(id);
 			if (result.succeeded()) {
 				final var metadata = result.metadata();
-				if (alwaysAdd || metadata.isReceiverSigRequired()) {
-					reqs.add(metadata.getKey());
+				if (alwaysAdd || metadata.receiverSigRequired()) {
+					reqs.add(metadata.key());
 				}
 			} else {
 				return false;
@@ -882,7 +882,7 @@ public class SigRequirements {
 			if (!payerResult.succeeded()) {
 				return accountFailure(INVALID_ACCOUNT, factory);
 			} else {
-				var dupKey = payerResult.metadata().getKey().duplicate();
+				var dupKey = payerResult.metadata().key().duplicate();
 				dupKey.setForScheduledTxn(true);
 				required.add(dupKey);
 			}
@@ -947,7 +947,7 @@ public class SigRequirements {
 			if (result.succeeded()) {
 				var meta = result.metadata();
 				required = mutable(required);
-				required.add(meta.getKey());
+				required.add(meta.key());
 			} else {
 				return factory.forMissingAccount();
 			}
@@ -967,8 +967,8 @@ public class SigRequirements {
 			var result = sigMetaLookup.aliasableAccountSigningMetaFor(account);
 			if (result.succeeded()) {
 				var meta = result.metadata();
-				if (adjust.getAmount() < 0 || meta.isReceiverSigRequired()) {
-					required.add(meta.getKey());
+				if (adjust.getAmount() < 0 || meta.receiverSigRequired()) {
+					required.add(meta.key());
 				}
 			} else {
 				final var reason = result.failureIfAny();
@@ -1000,8 +1000,8 @@ public class SigRequirements {
 			}
 			var meta = result.metadata();
 			final var isSender = counterparty == null;
-			if (isSender || meta.isReceiverSigRequired()) {
-				required.add(meta.getKey());
+			if (isSender || meta.receiverSigRequired()) {
+				required.add(meta.key());
 			} else {
 				final var tokenResult = sigMetaLookup.tokenSigningMetaFor(token);
 				if (!tokenResult.succeeded()) {
@@ -1012,7 +1012,7 @@ public class SigRequirements {
 						final var fallbackApplies = !receivesFungibleValue(counterparty, op) &&
 								counterparty.getAccountNum() != tokenMeta.treasury().num();
 						if (fallbackApplies) {
-							required.add(meta.getKey());
+							required.add(meta.key());
 						}
 					}
 				}
@@ -1030,7 +1030,7 @@ public class SigRequirements {
 			}
 		}
 		for (var transfers : op.getTokenTransfersList()) {
-			for (var adjust : transfers.getTransfersList())	 {
+			for (var adjust : transfers.getTransfersList()) {
 				if (adjust.getAmount() > 0 && adjust.getAccountID().equals(target)) {
 					return true;
 				}
@@ -1063,7 +1063,7 @@ public class SigRequirements {
 		}
 		if (result.metadata().hasSubmitKey()) {
 			required = mutable(required);
-			required.add(result.metadata().getSubmitKey());
+			required.add(result.metadata().submitKey());
 		}
 		return factory.forValidOrder(required);
 	}
@@ -1086,7 +1086,7 @@ public class SigRequirements {
 		var meta = targetResult.metadata();
 		if (meta.hasAdminKey()) {
 			required = mutable(required);
-			required.add(meta.getAdminKey());
+			required.add(meta.adminKey());
 		}
 
 		if (op.hasAdminKey()) {
@@ -1100,7 +1100,7 @@ public class SigRequirements {
 				var autoRenewResult = sigMetaLookup.accountSigningMetaFor(account);
 				if (autoRenewResult.succeeded()) {
 					required = mutable(required);
-					required.add(autoRenewResult.metadata().getKey());
+					required.add(autoRenewResult.metadata().key());
 				} else {
 					return accountFailure(MISSING_AUTORENEW_ACCOUNT, factory);
 				}
@@ -1135,7 +1135,7 @@ public class SigRequirements {
 			return topicFailure(targetResult.failureIfAny(), factory);
 		} else if (targetResult.metadata().hasAdminKey()) {
 			required = mutable(required);
-			required.add(targetResult.metadata().getAdminKey());
+			required.add(targetResult.metadata().adminKey());
 		}
 		return factory.forValidOrder(required);
 	}

--- a/hedera-node/src/main/java/com/hedera/services/state/expiry/ExpiryEvent.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/expiry/ExpiryEvent.java
@@ -21,37 +21,11 @@ package com.hedera.services.state.expiry;
  * ‍
  */
 
-import com.google.common.base.MoreObjects;
-
 /**
  * Expiry event with the id and expiration time
  */
-public class ExpiryEvent<K> {
-	private final K id;
-	private final long expiry;
-
-	ExpiryEvent(K id, long expiry) {
-		this.id = id;
-		this.expiry = expiry;
-	}
-
+public record ExpiryEvent<K>(K id, long expiry) {
 	boolean isExpiredAt(long now) {
 		return expiry <= now;
-	}
-
-	public K getId() {
-		return id;
-	}
-
-	public long getExpiry() {
-		return expiry;
-	}
-
-	@Override
-	public String toString() {
-		return MoreObjects.toStringHelper(ExpiryEvent.class)
-				.add("id", id)
-				.add("expiry", expiry)
-				.toString();
 	}
 }

--- a/hedera-node/src/main/java/com/hedera/services/state/expiry/ExpiryManager.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/expiry/ExpiryManager.java
@@ -63,8 +63,8 @@ public class ExpiryManager {
 	ordering for ExpiryEvents with the same expiry. The reason for different scheduled entities having
 	the same expiry is that we round expiration times to a consensus second. */
 	private static final Comparator<ExpiryEvent<Pair<Long, Consumer<EntityId>>>> PQ_CMP = Comparator
-			.comparingLong(ExpiryEvent<Pair<Long, Consumer<EntityId>>>::getExpiry)
-			.thenComparingLong(ee -> ee.getId().getKey());
+			.comparingLong(ExpiryEvent<Pair<Long, Consumer<EntityId>>>::expiry)
+			.thenComparingLong(ee -> ee.id().getKey());
 
 	private final long shard;
 	private final long realm;

--- a/hedera-node/src/main/java/com/hedera/services/state/expiry/MonotonicFullQueueExpiries.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/expiry/MonotonicFullQueueExpiries.java
@@ -39,7 +39,8 @@ public class MonotonicFullQueueExpiries<K> implements KeyedExpirations<K> {
 	@Override
 	public void track(K id, long expiry) {
 		if (expiry < now) {
-			throw new IllegalArgumentException(String.format("Track time %d for %s not later than %d", expiry, id, now));
+			throw new IllegalArgumentException(String.format("Track time %d for %s not later than %d", expiry, id,
+					now));
 		}
 		now = expiry;
 		allExpiries.add(new ExpiryEvent<>(id, expiry));
@@ -59,7 +60,7 @@ public class MonotonicFullQueueExpiries<K> implements KeyedExpirations<K> {
 			throw new IllegalArgumentException(String.format("Argument 'now=%d' is earlier than the next expiry!",
 					now));
 		}
-		return allExpiries.removeFirst().getId();
+		return allExpiries.removeFirst().id();
 	}
 
 	Deque<ExpiryEvent<K>> getAllExpiries() {

--- a/hedera-node/src/main/java/com/hedera/services/state/expiry/PriorityQueueExpiries.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/expiry/PriorityQueueExpiries.java
@@ -43,7 +43,7 @@ public class PriorityQueueExpiries<K> implements KeyedExpirations<K> {
 	@Override
 	public void track(K id, long expiry) {
 		allExpiries.offer(new ExpiryEvent<>(id, expiry));
-		now = allExpiries.peek().getExpiry();
+		now = allExpiries.peek().expiry();
 	}
 
 	@Override
@@ -57,9 +57,10 @@ public class PriorityQueueExpiries<K> implements KeyedExpirations<K> {
 			throw new IllegalStateException("No ids are queued for expiration!");
 		}
 		if (!allExpiries.peek().isExpiredAt(now)) {
-			throw new IllegalArgumentException(String.format("Argument 'now=%d' is earlier than the next expiry!", now));
+			throw new IllegalArgumentException(String.format("Argument 'now=%d' is earlier than the next expiry!",
+					now));
 		}
-		return allExpiries.remove().getId();
+		return allExpiries.remove().id();
 	}
 
 	PriorityQueue<ExpiryEvent<K>> getAllExpiries() {

--- a/hedera-node/src/main/java/com/hedera/services/state/expiry/renewal/RenewalProcess.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/expiry/renewal/RenewalProcess.java
@@ -73,9 +73,7 @@ public class RenewalProcess {
 			log.debug("Terminal classification entity num {} ({})", entityNum, classification);
 		}
 		switch (classification) {
-			case OTHER:
-			case DETACHED_ACCOUNT:
-			case DETACHED_TREASURY_GRACE_PERIOD_OVER_BEFORE_TOKEN:
+			case OTHER, DETACHED_ACCOUNT, DETACHED_TREASURY_GRACE_PERIOD_OVER_BEFORE_TOKEN:
 				break;
 			case DETACHED_ACCOUNT_GRACE_PERIOD_OVER:
 				processDetachedAccountGracePeriodOver(EntityNum.fromLong(entityNum));

--- a/hedera-node/src/main/java/com/hedera/services/state/expiry/renewal/RenewalProcess.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/expiry/renewal/RenewalProcess.java
@@ -81,6 +81,8 @@ public class RenewalProcess {
 			case EXPIRED_ACCOUNT_READY_TO_RENEW:
 				processExpiredAccountReadyToRenew(EntityNum.fromLong(entityNum));
 				return true;
+			default:
+				return false;
 		}
 		return false;
 	}

--- a/hedera-node/src/main/java/com/hedera/services/state/exports/BalancesSummary.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/exports/BalancesSummary.java
@@ -1,0 +1,51 @@
+/*
+ * -
+ *  * ‌
+ *  * Hedera Services Node
+ *  * ​
+ *  * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
+ *  * ​
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *      http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *  * ‍
+ *
+ */
+
+package com.hedera.services.state.exports;
+
+/*-
+ * ‌
+ * Hedera Services Node
+ * ​
+ * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import com.hedera.services.stream.proto.SingleAccountBalances;
+
+import java.math.BigInteger;
+import java.util.List;
+
+public record BalancesSummary(BigInteger totalFloat, List<SingleAccountBalances> orderedBalances) {
+}

--- a/hedera-node/src/main/java/com/hedera/services/state/exports/SignedStateBalancesExporter.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/exports/SignedStateBalancesExporter.java
@@ -27,11 +27,11 @@ import com.hedera.services.context.properties.PropertySource;
 import com.hedera.services.state.merkle.MerkleAccount;
 import com.hedera.services.state.merkle.MerkleToken;
 import com.hedera.services.state.merkle.MerkleTokenRelStatus;
-import com.hedera.services.utils.EntityNum;
-import com.hedera.services.utils.EntityNumPair;
 import com.hedera.services.stream.proto.AllAccountBalances;
 import com.hedera.services.stream.proto.SingleAccountBalances;
 import com.hedera.services.stream.proto.TokenUnitBalance;
+import com.hedera.services.utils.EntityNum;
+import com.hedera.services.utils.EntityNumPair;
 import com.hedera.services.utils.MiscUtils;
 import com.hedera.services.utils.SystemExits;
 import com.hederahashgraph.api.proto.java.AccountID;
@@ -60,8 +60,8 @@ import java.util.function.UnaryOperator;
 
 import static com.hedera.services.ledger.HederaLedger.ACCOUNT_ID_COMPARATOR;
 import static com.hedera.services.state.merkle.MerkleEntityAssociation.fromAccountTokenRel;
-import static com.hedera.services.utils.EntityNum.fromTokenId;
 import static com.hedera.services.utils.EntityIdUtils.readableId;
+import static com.hedera.services.utils.EntityNum.fromTokenId;
 
 @Singleton
 public class SignedStateBalancesExporter implements BalancesExporter {
@@ -143,13 +143,13 @@ public class SignedStateBalancesExporter implements BalancesExporter {
 		var watch = StopWatch.createStarted();
 		summary = summarized(signedState);
 		final var expected = BigInteger.valueOf(expectedFloat);
-		if (expected.equals(summary.getTotalFloat())) {
+		if (expected.equals(summary.totalFloat())) {
 			log.info("Took {}ms to summarize signed state balances", watch.getTime(TimeUnit.MILLISECONDS));
 			toProtoFile(consensusTime);
 		} else {
 			log.error(
 					"Signed state @ {} had total balance {} not {}; exiting",
-					consensusTime, summary.getTotalFloat(), expectedFloat);
+					consensusTime, summary.totalFloat(), expectedFloat);
 			systemExits.fail(1);
 		}
 	}
@@ -187,7 +187,7 @@ public class SignedStateBalancesExporter implements BalancesExporter {
 		builder.setConsensusTimestamp(Timestamp.newBuilder()
 				.setSeconds(exportTimeStamp.getEpochSecond())
 				.setNanos(exportTimeStamp.getNano()));
-		builder.addAllAllAccounts(summary.getOrderedBalances());
+		builder.addAllAllAccounts(summary.orderedBalances());
 	}
 
 	private boolean exportBalancesProtoFile(AllAccountBalances.Builder allAccountsBuilder, String protoLoc) {
@@ -272,27 +272,6 @@ public class SignedStateBalancesExporter implements BalancesExporter {
 			}
 		}
 		return true;
-	}
-
-	static class BalancesSummary {
-		private final BigInteger totalFloat;
-		private final List<SingleAccountBalances> orderedBalances;
-
-		BalancesSummary(
-				BigInteger totalFloat,
-				List<SingleAccountBalances> orderedBalances
-		) {
-			this.totalFloat = totalFloat;
-			this.orderedBalances = orderedBalances;
-		}
-
-		public BigInteger getTotalFloat() {
-			return totalFloat;
-		}
-
-		public List<SingleAccountBalances> getOrderedBalances() {
-			return orderedBalances;
-		}
 	}
 }
 

--- a/hedera-node/src/main/java/com/hedera/services/state/forensics/HashLogger.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/forensics/HashLogger.java
@@ -9,9 +9,9 @@ package com.hedera.services.state.forensics;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -36,20 +36,22 @@ public class HashLogger {
 	}
 
 	public void logHashesFor(ServicesState state) {
-		log.info("[SwirldState Hashes]\n" +
-						"  Overall                :: {}\n" +
-						"  Accounts               :: {}\n" +
-						"  Storage                :: {}\n" +
-						"  Topics                 :: {}\n" +
-						"  Tokens                 :: {}\n" +
-						"  TokenAssociations      :: {}\n" +
-						"  SpecialFiles           :: {}\n" +
-						"  ScheduledTxs           :: {}\n" +
-						"  NetworkContext         :: {}\n" +
-						"  AddressBook            :: {}\n" +
-						"  RecordsRunningHashLeaf :: {}\n" +
-						"    ↪ Running hash       :: {}\n" +
-						"  UniqueTokens           :: {}\n",
+		String textBlock = """
+				[SwirldState Hashes] 
+				Overall                :: {}
+				Accounts               :: {}
+				Storage                :: {}
+				Topics                 :: {}
+				Tokens                 :: {}
+				TokenAssociations      :: {}
+				SpecialFiles           :: {}
+				ScheduledTxs           :: {}
+				NetworkContext         :: {}
+				AddressBook            :: {}
+				RecordsRunningHashLeaf :: {}
+				  ↪ Running hash       :: {}
+				UniqueTokens           :: {}""";
+		log.info(textBlock,
 				state.getHash(),
 				state.accounts().getHash(),
 				state.storage().getHash(),

--- a/hedera-node/src/main/java/com/hedera/services/state/merkle/MerkleNetworkContext.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/merkle/MerkleNetworkContext.java
@@ -44,7 +44,6 @@ import java.util.function.Supplier;
 
 import static com.hedera.services.context.properties.StaticPropertiesHolder.STATIC_PROPERTIES;
 import static com.hedera.services.state.submerkle.RichInstant.fromJava;
-import static java.util.stream.Collectors.toList;
 
 public class MerkleNetworkContext extends AbstractMerkleLeaf {
 	private static final Logger log = LogManager.getLogger(MerkleNetworkContext.class);
@@ -369,7 +368,7 @@ public class MerkleNetworkContext extends AbstractMerkleLeaf {
 	}
 
 	private String congestionStartsDesc() {
-		if (congestionLevelStarts.length == 0)	 {
+		if (congestionLevelStarts.length == 0) {
 			return NOT_AVAILABLE_SUFFIX;
 		} else {
 			final var sb = new StringBuilder();
@@ -464,7 +463,7 @@ public class MerkleNetworkContext extends AbstractMerkleLeaf {
 	private void reset(List<DeterministicThrottle> throttles) {
 		var currUsageSnapshots = throttles.stream()
 				.map(DeterministicThrottle::usageSnapshot)
-				.collect(toList());
+				.toList();
 		for (int i = 0, n = usageSnapshots.length; i < n; i++) {
 			var savedUsageSnapshot = usageSnapshots[i];
 			var throttle = throttles.get(i);

--- a/hedera-node/src/main/java/com/hedera/services/state/merkle/MerkleSchedule.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/merkle/MerkleSchedule.java
@@ -27,8 +27,8 @@ import com.hedera.services.legacy.core.jproto.JKey;
 import com.hedera.services.state.serdes.DomainSerdes;
 import com.hedera.services.state.submerkle.EntityId;
 import com.hedera.services.state.submerkle.RichInstant;
-import com.hedera.services.utils.EntityNum;
 import com.hedera.services.utils.EntityIdUtils;
+import com.hedera.services.utils.EntityNum;
 import com.hedera.services.utils.MiscUtils;
 import com.hederahashgraph.api.proto.java.Key;
 import com.hederahashgraph.api.proto.java.SchedulableTransactionBody;
@@ -55,7 +55,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import static com.google.protobuf.ByteString.copyFrom;
 import static com.hedera.services.utils.MiscUtils.asTimestamp;
 import static com.hedera.services.utils.MiscUtils.describe;
-import static java.util.stream.Collectors.toList;
 
 public class MerkleSchedule extends AbstractMerkleLeaf implements Keyed<EntityNum> {
 	static final int PRE_RELEASE_0180_VERSION = 1;
@@ -149,12 +148,14 @@ public class MerkleSchedule extends AbstractMerkleLeaf implements Keyed<EntityNu
 	}
 
 	/* Object */
+
 	/**
 	 * Two {@code MerkleSchedule}s are identical as long as they agree on
 	 * the transaction being scheduled, the admin key used to manage it,
 	 * and the memo to accompany it.
 	 *
-	 * @param o the object to check for equality
+	 * @param o
+	 * 		the object to check for equality
 	 * @return whether {@code this} and {@code o} are identical
 	 */
 	@Override
@@ -189,7 +190,7 @@ public class MerkleSchedule extends AbstractMerkleLeaf implements Keyed<EntityNu
 				.add("payer", readablePayer())
 				.add("schedulingAccount", schedulingAccount)
 				.add("schedulingTXValidStart", schedulingTXValidStart)
-				.add("signatories", signatories.stream().map(CommonUtils::hex).collect(toList()))
+				.add("signatories", signatories.stream().map(CommonUtils::hex).toList())
 				.add("adminKey", describe(adminKey));
 		if (resolutionTime != null) {
 			helper.add("resolutionTime", resolutionTime);

--- a/hedera-node/src/main/java/com/hedera/services/state/merkle/MerkleToken.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/merkle/MerkleToken.java
@@ -46,7 +46,6 @@ import static com.hedera.services.legacy.core.jproto.JKey.equalUpToDecodability;
 import static com.hedera.services.state.merkle.MerkleAccountState.DEFAULT_MEMO;
 import static com.hedera.services.utils.MiscUtils.describe;
 import static java.util.Collections.unmodifiableList;
-import static java.util.stream.Collectors.toList;
 
 public class MerkleToken extends AbstractMerkleLeaf implements Keyed<EntityNum> {
 	static final int PRE_RELEASE_0120_VERSION = 1;
@@ -679,7 +678,7 @@ public class MerkleToken extends AbstractMerkleLeaf implements Keyed<EntityNum> 
 
 	public void setFeeScheduleFrom(List<CustomFee> grpcFeeSchedule) {
 		throwIfImmutable("Cannot change this token's fee schedule from grpc if it's immutable.");
-		feeSchedule = grpcFeeSchedule.stream().map(FcCustomFee::fromGrpc).collect(toList());
+		feeSchedule = grpcFeeSchedule.stream().map(FcCustomFee::fromGrpc).toList();
 	}
 
 	public void setFeeScheduleKey(final JKey feeScheduleKey) {

--- a/hedera-node/src/main/java/com/hedera/services/state/merkle/MerkleTokenRelStatus.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/merkle/MerkleTokenRelStatus.java
@@ -203,6 +203,6 @@ public class MerkleTokenRelStatus extends AbstractMerkleLeaf implements Keyed<En
 
 	@Override
 	public void setKey(EntityNumPair numbers) {
-		this.numbers = numbers.getValue();
+		this.numbers = numbers.value();
 	}
 }

--- a/hedera-node/src/main/java/com/hedera/services/state/merkle/MerkleUniqueToken.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/merkle/MerkleUniqueToken.java
@@ -24,8 +24,8 @@ import com.google.common.base.MoreObjects;
 import com.hedera.services.state.merkle.internals.BitPackUtils;
 import com.hedera.services.state.submerkle.EntityId;
 import com.hedera.services.state.submerkle.RichInstant;
-import com.hedera.services.utils.EntityNumPair;
 import com.hedera.services.utils.EntityIdUtils;
+import com.hedera.services.utils.EntityNumPair;
 import com.swirlds.common.io.SerializableDataInputStream;
 import com.swirlds.common.io.SerializableDataOutputStream;
 import com.swirlds.common.merkle.utility.AbstractMerkleLeaf;
@@ -36,8 +36,8 @@ import java.time.Instant;
 import java.util.Arrays;
 import java.util.Objects;
 
-import static com.hedera.services.state.merkle.internals.BitPackUtils.signedLowOrder32From;
 import static com.hedera.services.state.merkle.internals.BitPackUtils.packedTime;
+import static com.hedera.services.state.merkle.internals.BitPackUtils.signedLowOrder32From;
 import static com.hedera.services.state.merkle.internals.BitPackUtils.unsignedHighOrder32From;
 
 /**
@@ -82,10 +82,14 @@ public class MerkleUniqueToken extends AbstractMerkleLeaf implements Keyed<Entit
 	/**
 	 * Constructs a Merkle-usable unique token (NFT) from primitive values.
 	 *
-	 * @param ownerCode the number of the owning entity as an unsigned {@code int}
-	 * @param metadata the metadata of the unique token
-	 * @param packedCreationTime the "packed" representation of the consensus time at which the token was minted
-	 * @param numbers the packed representation of the token type number and serial number
+	 * @param ownerCode
+	 * 		the number of the owning entity as an unsigned {@code int}
+	 * @param metadata
+	 * 		the metadata of the unique token
+	 * @param packedCreationTime
+	 * 		the "packed" representation of the consensus time at which the token was minted
+	 * @param numbers
+	 * 		the packed representation of the token type number and serial number
 	 */
 	public MerkleUniqueToken(
 			int ownerCode,
@@ -206,6 +210,6 @@ public class MerkleUniqueToken extends AbstractMerkleLeaf implements Keyed<Entit
 
 	@Override
 	public void setKey(EntityNumPair phl) {
-		this.numbers = phl.getValue();
+		this.numbers = phl.value();
 	}
 }

--- a/hedera-node/src/main/java/com/hedera/services/state/merkle/internals/CopyOnWriteIds.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/merkle/internals/CopyOnWriteIds.java
@@ -9,9 +9,9 @@ package com.hedera.services.state.merkle.internals;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -160,7 +160,8 @@ public class CopyOnWriteIds {
 	/**
 	 * Overwrite the managed multiset with the given sequence of {@code (num, realm, shard)} ids.
 	 *
-	 * @param ids the sequence of {@code (num, realm, shard)} ids to overwrite
+	 * @param ids
+	 * 		the sequence of {@code (num, realm, shard)} ids to overwrite
 	 */
 	public void setNativeIds(long[] ids) {
 		this.ids = ids;
@@ -276,7 +277,7 @@ public class CopyOnWriteIds {
 	}
 
 	private long[] asNativeId(Id id) {
-		return new long[] { id.getNum(), id.getRealm(), id.getShard() };
+		return new long[] { id.num(), id.realm(), id.shard() };
 	}
 
 	private List<long[]> asNativeIds(Set<TokenID> grpcIds) {

--- a/hedera-node/src/main/java/com/hedera/services/state/submerkle/EntityId.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/submerkle/EntityId.java
@@ -56,9 +56,9 @@ public class EntityId implements SelfSerializable {
 	}
 
 	public EntityId(Id id) {
-		this.shard = id.getShard();
-		this.realm = id.getRealm();
-		this.num = id.getNum();
+		this.shard = id.shard();
+		this.realm = id.realm();
+		this.num = id.num();
 	}
 
 	public EntityId(long shard, long realm, long num) {
@@ -79,7 +79,8 @@ public class EntityId implements SelfSerializable {
 	/**
 	 * Builds an entity id from its encoded format.
 	 *
-	 * @param code the compressed representation
+	 * @param code
+	 * 		the compressed representation
 	 * @return the equivalent entity id
 	 */
 	public static EntityId fromIdentityCode(int code) {
@@ -129,7 +130,7 @@ public class EntityId implements SelfSerializable {
 	}
 
 	public boolean matches(Id id) {
-		return shard == id.getShard() && realm == id.getRealm() && num == id.getNum();
+		return shard == id.shard() && realm == id.realm() && num == id.num();
 	}
 
 	@Override

--- a/hedera-node/src/main/java/com/hedera/services/state/submerkle/ExpirableTxnRecord.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/submerkle/ExpirableTxnRecord.java
@@ -47,7 +47,6 @@ import java.util.stream.IntStream;
 import static com.hedera.services.state.merkle.internals.BitPackUtils.packedTime;
 import static com.hedera.services.utils.MiscUtils.asTimestamp;
 import static java.util.stream.Collectors.joining;
-import static java.util.stream.Collectors.toList;
 
 public class ExpirableTxnRecord implements FCQueueElement {
 	public static final long UNKNOWN_SUBMITTING_MEMBER = -1;
@@ -495,7 +494,7 @@ public class ExpirableTxnRecord implements FCQueueElement {
 	public static List<TransactionRecord> allToGrpc(List<ExpirableTxnRecord> records) {
 		return records.stream()
 				.map(ExpirableTxnRecord::asGrpc)
-				.collect(toList());
+				.toList();
 	}
 
 	public TransactionRecord asGrpc() {
@@ -534,11 +533,11 @@ public class ExpirableTxnRecord implements FCQueueElement {
 		}
 		if (assessedCustomFees != NO_CUSTOM_FEES) {
 			grpc.addAllAssessedCustomFees(
-					assessedCustomFees.stream().map(FcAssessedCustomFee::toGrpc).collect(toList()));
+					assessedCustomFees.stream().map(FcAssessedCustomFee::toGrpc).toList());
 		}
 		if (newTokenAssociations != NO_NEW_TOKEN_ASSOCIATIONS) {
 			grpc.addAllAutomaticTokenAssociations(
-					newTokenAssociations.stream().map(FcTokenAssociation::toGrpc).collect(toList()));
+					newTokenAssociations.stream().map(FcTokenAssociation::toGrpc).toList());
 		}
 		if (alias != MISSING_ALIAS) {
 			grpc.setAlias(alias);

--- a/hedera-node/src/main/java/com/hedera/services/state/submerkle/FcCustomFee.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/submerkle/FcCustomFee.java
@@ -121,7 +121,7 @@ public class FcCustomFee implements SelfSerializable {
 				return fixedFeeSpec.usedDenomWildcard();
 			case ROYALTY_FEE:
 				if (royaltyFeeSpec.hasFallbackFee()) {
-					return royaltyFeeSpec.getFallbackFee().usedDenomWildcard();
+					return royaltyFeeSpec.fallbackFee().usedDenomWildcard();
 				}
 		}
 		return false;
@@ -268,9 +268,9 @@ public class FcCustomFee implements SelfSerializable {
 			final var spec = royaltyFeeSpec;
 			final var royaltyBuilder = RoyaltyFee.newBuilder()
 					.setExchangeValueFraction(Fraction.newBuilder()
-							.setNumerator(spec.getNumerator())
-							.setDenominator(spec.getDenominator()));
-			final var fallback = spec.getFallbackFee();
+							.setNumerator(spec.numerator())
+							.setDenominator(spec.denominator()));
+			final var fallback = spec.fallbackFee();
 			if (fallback != null) {
 				royaltyBuilder.setFallbackFee(fallback.asGrpc());
 			}
@@ -394,13 +394,13 @@ public class FcCustomFee implements SelfSerializable {
 			dos.writeBoolean(fractionalFeeSpec.isNetOfTransfers());
 		} else {
 			dos.writeByte(ROYALTY_CODE);
-			dos.writeLong(royaltyFeeSpec.getNumerator());
-			dos.writeLong(royaltyFeeSpec.getDenominator());
-			if (royaltyFeeSpec.getFallbackFee() == null) {
+			dos.writeLong(royaltyFeeSpec.numerator());
+			dos.writeLong(royaltyFeeSpec.denominator());
+			if (royaltyFeeSpec.fallbackFee() == null) {
 				dos.writeBoolean(false);
 			} else {
 				dos.writeBoolean(true);
-				serializeFixed(royaltyFeeSpec.getFallbackFee(), dos);
+				serializeFixed(royaltyFeeSpec.fallbackFee(), dos);
 			}
 		}
 		dos.writeSerializable(feeCollector, true);

--- a/hedera-node/src/main/java/com/hedera/services/state/submerkle/FixedFeeSpec.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/submerkle/FixedFeeSpec.java
@@ -9,9 +9,9 @@ package com.hedera.services.state.submerkle;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -60,7 +60,7 @@ public class FixedFeeSpec {
 		if (tokenDenomination != null) {
 			if (tokenDenomination.num() == 0L) {
 				validateTrue(provisionalToken.isFungibleCommon(), CUSTOM_FEE_DENOMINATION_MUST_BE_FUNGIBLE_COMMON);
-				tokenDenomination.setNum(provisionalToken.getId().getNum());
+				tokenDenomination.setNum(provisionalToken.getId().num());
 				usedDenomWildcard = true;
 			} else {
 				validateExplicitlyDenominatedWith(feeCollector, tokenStore);

--- a/hedera-node/src/main/java/com/hedera/services/state/submerkle/NftAdjustments.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/submerkle/NftAdjustments.java
@@ -35,7 +35,6 @@ import java.util.List;
 import java.util.stream.IntStream;
 
 import static com.hedera.services.utils.MiscUtils.readableNftTransferList;
-import static java.util.stream.Collectors.toList;
 
 public class NftAdjustments implements SelfSerializable {
 	private static final int MERKLE_VERSION = 1;
@@ -128,11 +127,11 @@ public class NftAdjustments implements SelfSerializable {
 				.filter(nftTransfer -> nftTransfer.getSenderAccountID() != null)
 				.map(NftTransfer::getSenderAccountID)
 				.map(EntityId::fromGrpcAccountId)
-				.collect(toList());
+				.toList();
 		pojo.receiverAccIds = grpc.stream()
 				.map(NftTransfer::getReceiverAccountID)
 				.map(EntityId::fromGrpcAccountId)
-				.collect(toList());
+				.toList();
 
 		return pojo;
 	}

--- a/hedera-node/src/main/java/com/hedera/services/state/submerkle/RoyaltyFeeSpec.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/submerkle/RoyaltyFeeSpec.java
@@ -9,9 +9,9 @@ package com.hedera.services.state.submerkle;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,13 +20,9 @@ package com.hedera.services.state.submerkle;
  * ‍
  */
 
-import com.google.common.base.MoreObjects;
 import com.hedera.services.store.TypedTokenStore;
 import com.hedera.services.store.models.Account;
 import com.hedera.services.store.models.Token;
-import org.apache.commons.lang3.builder.HashCodeBuilder;
-
-import java.util.Objects;
 
 import static com.hedera.services.exceptions.ValidationUtils.validateTrue;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.CUSTOM_FEE_MUST_BE_POSITIVE;
@@ -34,18 +30,11 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.CUSTOM_ROYALTY
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.FRACTION_DIVIDES_BY_ZERO;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.ROYALTY_FRACTION_CANNOT_EXCEED_ONE;
 
-public class RoyaltyFeeSpec {
-	private final long numerator;
-	private final long denominator;
-	private final FixedFeeSpec fallbackFee;
-
-	public RoyaltyFeeSpec(long numerator, long denominator, FixedFeeSpec fallbackFee) {
+public record RoyaltyFeeSpec(long numerator, long denominator, FixedFeeSpec fallbackFee) {
+	public RoyaltyFeeSpec {
 		validateTrue(denominator != 0, FRACTION_DIVIDES_BY_ZERO);
 		validateTrue(bothPositive(numerator, denominator), CUSTOM_FEE_MUST_BE_POSITIVE);
 		validateTrue(numerator <= denominator, ROYALTY_FRACTION_CANNOT_EXCEED_ONE);
-		this.numerator = numerator;
-		this.denominator = denominator;
-		this.fallbackFee = fallbackFee;
 	}
 
 	public void validateWith(final Token owningToken, final Account feeCollector, final TypedTokenStore tokenStore) {
@@ -74,47 +63,6 @@ public class RoyaltyFeeSpec {
 				fallbackFee.validateWith(feeCollector, tokenStore);
 			}
 		}
-	}
-
-	@Override
-	public boolean equals(Object obj) {
-		if (this == obj) {
-			return true;
-		}
-		if (obj == null || !obj.getClass().equals(RoyaltyFeeSpec.class)) {
-			return false;
-		}
-
-		final var that = (RoyaltyFeeSpec) obj;
-		return this.numerator == that.numerator &&
-				this.denominator == that.denominator &&
-				Objects.equals(this.fallbackFee, that.fallbackFee);
-	}
-
-	@Override
-	public int hashCode() {
-		return HashCodeBuilder.reflectionHashCode(this);
-	}
-
-	@Override
-	public String toString() {
-		return MoreObjects.toStringHelper(RoyaltyFeeSpec.class)
-				.add("numerator", numerator)
-				.add("denominator", denominator)
-				.add("fallbackFee", fallbackFee)
-				.toString();
-	}
-
-	public long getNumerator() {
-		return numerator;
-	}
-
-	public long getDenominator() {
-		return denominator;
-	}
-
-	public FixedFeeSpec getFallbackFee() {
-		return fallbackFee;
 	}
 
 	public boolean hasFallbackFee() {

--- a/hedera-node/src/main/java/com/hedera/services/state/submerkle/SolidityFnResult.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/submerkle/SolidityFnResult.java
@@ -35,7 +35,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 
-import static java.util.stream.Collectors.toList;
 import static org.apache.commons.collections4.CollectionUtils.isNotEmpty;
 
 public class SolidityFnResult implements SelfSerializable {
@@ -193,8 +192,8 @@ public class SolidityFnResult implements SelfSerializable {
 				!that.getContractCallResult().isEmpty() ? that.getErrorMessage() : null,
 				that.getBloom().isEmpty() ? MISSING_BYTES : that.getBloom().toByteArray(),
 				that.getGasUsed(),
-				that.getLogInfoList().stream().map(SolidityLog::fromGrpc).collect(toList()),
-				that.getCreatedContractIDsList().stream().map(EntityId::fromGrpcContractId).collect(toList()));
+				that.getLogInfoList().stream().map(SolidityLog::fromGrpc).toList(),
+				that.getCreatedContractIDsList().stream().map(EntityId::fromGrpcContractId).toList());
 	}
 
 	public ContractFunctionResult toGrpc() {
@@ -209,10 +208,10 @@ public class SolidityFnResult implements SelfSerializable {
 			grpc.setContractID(contractId.toGrpcContractId());
 		}
 		if (isNotEmpty(logs)) {
-			grpc.addAllLogInfo(logs.stream().map(SolidityLog::toGrpc).collect(toList()));
+			grpc.addAllLogInfo(logs.stream().map(SolidityLog::toGrpc).toList());
 		}
 		if (isNotEmpty(createdContractIds)) {
-			grpc.addAllCreatedContractIDs(createdContractIds.stream().map(EntityId::toGrpcContractId).collect(toList()));
+			grpc.addAllCreatedContractIDs(createdContractIds.stream().map(EntityId::toGrpcContractId).toList());
 		}
 		return grpc.build();
 	}

--- a/hedera-node/src/main/java/com/hedera/services/state/submerkle/SolidityLog.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/submerkle/SolidityLog.java
@@ -37,8 +37,6 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
-import static java.util.stream.Collectors.toList;
-
 public class SolidityLog implements SelfSerializable {
 	static final int MERKLE_VERSION = 1;
 	static final long RUNTIME_CONSTRUCTABLE_ID = 0x2af05aa9c7ff917L;
@@ -56,7 +54,8 @@ public class SolidityLog implements SelfSerializable {
 	public static final int MAX_BLOOM_BYTES = 256;
 	public static final int MAX_TOPIC_BYTES = 1024;
 
-	public SolidityLog() { }
+	public SolidityLog() {
+	}
 
 	public SolidityLog(
 			EntityId contractId,
@@ -152,7 +151,7 @@ public class SolidityLog implements SelfSerializable {
 				.add("data", CommonUtils.hex(data))
 				.add("bloom", CommonUtils.hex(bloom))
 				.add("contractId", contractId)
-				.add("topics", topics.stream().map(CommonUtils::hex).collect(toList()))
+				.add("topics", topics.stream().map(CommonUtils::hex).toList())
 				.toString();
 	}
 
@@ -180,7 +179,7 @@ public class SolidityLog implements SelfSerializable {
 		return new SolidityLog(
 				grpc.hasContractID() ? EntityId.fromGrpcContractId(grpc.getContractID()) : null,
 				grpc.getBloom().isEmpty() ? MISSING_BYTES : grpc.getBloom().toByteArray(),
-				grpc.getTopicList().stream().map(ByteString::toByteArray).collect(toList()),
+				grpc.getTopicList().stream().map(ByteString::toByteArray).toList(),
 				grpc.getData().isEmpty() ? MISSING_BYTES : grpc.getData().toByteArray());
 	}
 
@@ -191,7 +190,7 @@ public class SolidityLog implements SelfSerializable {
 		}
 		grpc.setBloom(ByteString.copyFrom(bloom));
 		grpc.setData(ByteString.copyFrom(data));
-		grpc.addAllTopic(topics.stream().map(ByteString::copyFrom).collect(toList()));
+		grpc.addAllTopic(topics.stream().map(ByteString::copyFrom).toList());
 		return grpc.build();
 	}
 }

--- a/hedera-node/src/main/java/com/hedera/services/store/AccountStore.java
+++ b/hedera-node/src/main/java/com/hedera/services/store/AccountStore.java
@@ -169,7 +169,7 @@ public class AccountStore {
 	 */
 	public void persistAccount(Account account) {
 		final var id = account.getId();
-		final var key = EntityNum.fromLong(id.getNum());
+		final var key = EntityNum.fromLong(id.num());
 
 		final var mutableAccount = accounts.get().getForModify(key);
 		mapModelToMutable(account, mutableAccount);

--- a/hedera-node/src/main/java/com/hedera/services/store/CreationResult.java
+++ b/hedera-node/src/main/java/com/hedera/services/store/CreationResult.java
@@ -29,47 +29,33 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OK;
 /**
  * A summary of the result of trying to create a store member, such as a token or scheduled entity.
  *
- * @param <T> the type of the store member.
+ * @param <T>
+ * 		the type of the store member.
  */
-public final class CreationResult<T> {
-    private final ResponseCodeEnum status;
-    @Nullable private final T created;
+public record CreationResult<T>(ResponseCodeEnum status, @Nullable T created) {
+	/**
+	 * Factory to summarize the result of a failed store member creation.
+	 *
+	 * @param type
+	 * 		the kind of failure that occurred.
+	 * @param <T>
+	 * 		the type of store member being created.
+	 * @return the summary constructed.
+	 */
+	public static <T> CreationResult<T> failure(final ResponseCodeEnum type) {
+		return new CreationResult<>(type, null);
+	}
 
-    private CreationResult(
-            final ResponseCodeEnum status,
-            @Nullable final T created
-    ) {
-        this.status = status;
-        this.created = created;
-    }
-
-    /**
-     * Factory to summarize the result of a failed store member creation.
-     *
-     * @param type the kind of failure that occurred.
-     * @param <T> the type of store member being created.
-     * @return the summary constructed.
-     */
-    public static <T> CreationResult<T> failure(final ResponseCodeEnum type) {
-        return new CreationResult<>(type, null);
-    }
-
-    /**
-     * Factory to summarize the result of a successful store member creation.
-     *
-     * @param created the resulting store member.
-     * @param <T> the type of store member being created.
-     * @return the summary constructed.
-     */
-    public static <T> CreationResult<T> success(final T created) {
-        return new CreationResult<>(OK, created);
-    }
-
-    public ResponseCodeEnum getStatus() {
-        return status;
-    }
-
-    public @Nullable T getCreated() {
-        return created;
-    }
+	/**
+	 * Factory to summarize the result of a successful store member creation.
+	 *
+	 * @param created
+	 * 		the resulting store member.
+	 * @param <T>
+	 * 		the type of store member being created.
+	 * @return the summary constructed.
+	 */
+	public static <T> CreationResult<T> success(final T created) {
+		return new CreationResult<>(OK, created);
+	}
 }

--- a/hedera-node/src/main/java/com/hedera/services/store/TypedTokenStore.java
+++ b/hedera-node/src/main/java/com/hedera/services/store/TypedTokenStore.java
@@ -402,7 +402,7 @@ public class TypedTokenStore {
 	 * 		the token to save
 	 */
 	public void persistToken(Token token) {
-		final var key = EntityNum.fromLong(token.getId().getNum());
+		final var key = EntityNum.fromLong(token.getId().num());
 		final var mutableToken = tokens.get().getForModify(key);
 		mapModelChangesToMutable(token, mutableToken);
 
@@ -434,7 +434,7 @@ public class TypedTokenStore {
 	 */
 	public void persistNew(Token token) {
 		/* create new merkle token */
-		final var newMerkleTokenId = EntityNum.fromLong(token.getId().getNum());
+		final var newMerkleTokenId = EntityNum.fromLong(token.getId().num());
 		final var newMerkleToken = new MerkleToken(
 				token.getExpiry(),
 				token.getTotalSupply(),
@@ -457,7 +457,7 @@ public class TypedTokenStore {
 	private void destroyRemoved(List<UniqueToken> nfts, EntityId treasury) {
 		final var curNfts = uniqueTokens.get();
 		for (var nft : nfts) {
-			final var merkleNftId = EntityNumPair.fromLongs(nft.getTokenId().getNum(), nft.getSerialNumber());
+			final var merkleNftId = EntityNumPair.fromLongs(nft.getTokenId().num(), nft.getSerialNumber());
 			curNfts.remove(merkleNftId);
 			if (treasury.matches(nft.getOwner())) {
 				uniqTokenViewsManager.burnNotice(merkleNftId, treasury);
@@ -470,7 +470,7 @@ public class TypedTokenStore {
 	private void persistMinted(List<UniqueToken> nfts, EntityId treasury) {
 		final var curNfts = uniqueTokens.get();
 		for (var nft : nfts) {
-			final var merkleNftId = EntityNumPair.fromLongs(nft.getTokenId().getNum(), nft.getSerialNumber());
+			final var merkleNftId = EntityNumPair.fromLongs(nft.getTokenId().num(), nft.getSerialNumber());
 			final var merkleNft = new MerkleUniqueToken(MISSING_ENTITY_ID, nft.getMetadata(), nft.getCreationTime());
 			curNfts.put(merkleNftId, merkleNft);
 			uniqTokenViewsManager.mintNotice(merkleNftId, treasury);

--- a/hedera-node/src/main/java/com/hedera/services/store/models/Account.java
+++ b/hedera-node/src/main/java/com/hedera/services/store/models/Account.java
@@ -121,7 +121,7 @@ public class Account {
 	}
 
 	public void setAlreadyUsedAutomaticAssociations(int alreadyUsedCount) {
-		validateTrue(isValidAlreadyUsedCount(alreadyUsedCount), NO_REMAINING_AUTOMATIC_ASSOCIATIONS );
+		validateTrue(isValidAlreadyUsedCount(alreadyUsedCount), NO_REMAINING_AUTOMATIC_ASSOCIATIONS);
 		autoAssociationMetadata = setAlreadyUsedAutomaticAssociationsTo(autoAssociationMetadata, alreadyUsedCount);
 	}
 
@@ -219,7 +219,7 @@ public class Account {
 				.add("ownedNfts", ownedNfts)
 				.add("alreadyUsedAutoAssociations", getAlreadyUsedAutomaticAssociations())
 				.add("maxAutoAssociations", getMaxAutomaticAssociations())
-				.add("alias", getAlias())
+				.add("alias", getAlias().toStringUtf8())
 				.toString();
 	}
 

--- a/hedera-node/src/main/java/com/hedera/services/store/models/Id.java
+++ b/hedera-node/src/main/java/com/hedera/services/store/models/Id.java
@@ -20,7 +20,6 @@ package com.hedera.services.store.models;
  * ‍
  */
 
-import com.google.common.base.MoreObjects;
 import com.hedera.services.state.submerkle.EntityId;
 import com.hedera.services.utils.EntityIdUtils;
 import com.hedera.services.utils.EntityNum;
@@ -35,23 +34,13 @@ import java.util.Comparator;
 /**
  * Represents the id of a Hedera entity (account, topic, token, contract, file, or schedule).
  */
-public class Id {
+public record Id(long shard, long realm, long num) {
 	public static final Id DEFAULT = new Id(0, 0, 0);
 	public static final Comparator<Id> ID_COMPARATOR = Comparator
-			.comparingLong(Id::getNum)
-			.thenComparingLong(Id::getShard)
-			.thenComparingLong(Id::getRealm);
+			.comparingLong(Id::num)
+			.thenComparingLong(Id::shard)
+			.thenComparingLong(Id::realm);
 	public static final Id MISSING_ID = new Id(0, 0, 0);
-
-	private final long shard;
-	private final long realm;
-	private final long num;
-
-	public Id(long shard, long realm, long num) {
-		this.shard = shard;
-		this.realm = realm;
-		this.num = num;
-	}
 
 	public static Id fromGrpcAccount(final AccountID id) {
 		return new Id(id.getShardNum(), id.getRealmNum(), id.getAccountNum());
@@ -105,45 +94,11 @@ public class Id {
 				.build();
 	}
 
-	public long getShard() {
-		return shard;
-	}
-
-	public long getRealm() {
-		return realm;
-	}
-
-	public long getNum() {
-		return num;
-	}
-
-	@Override
-	public boolean equals(Object obj) {
-		if (obj == this) {
-			return true;
-		}
-		if (obj == null || !Id.class.equals(obj.getClass())) {
-			return false;
-		}
-		final Id that = (Id) obj;
-
-		return this.shard == that.shard && this.realm == that.realm && this.num == that.num;
-	}
-
 	@Override
 	public int hashCode() {
 		int result = Long.hashCode(shard);
 		result = 31 * result + Long.hashCode(realm);
 		return 31 * result + Long.hashCode(num);
-	}
-
-	@Override
-	public String toString() {
-		return MoreObjects.toStringHelper(Id.class)
-				.add("shard", shard)
-				.add("realm", realm)
-				.add("num", num)
-				.toString();
 	}
 
 	public EntityId asEntityId() {
@@ -152,6 +107,7 @@ public class Id {
 
 	/**
 	 * Returns the EVM representation of the Account
+	 *
 	 * @return {@link Address} evm representation
 	 */
 	public Address asEvmAddress() {

--- a/hedera-node/src/main/java/com/hedera/services/store/models/NftId.java
+++ b/hedera-node/src/main/java/com/hedera/services/store/models/NftId.java
@@ -9,9 +9,9 @@ package com.hedera.services.store.models;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,38 +20,9 @@ package com.hedera.services.store.models;
  * ‍
  */
 
-import com.google.common.base.MoreObjects;
 import com.hederahashgraph.api.proto.java.TokenID;
 
-public class NftId {
-	private final long shard;
-	private final long realm;
-	private final long num;
-	private final long serialNo;
-
-	public NftId(long shard, long realm, long num, long serialNo) {
-		this.shard = shard;
-		this.realm = realm;
-		this.num = num;
-		this.serialNo = serialNo;
-	}
-
-	public long shard() {
-		return shard;
-	}
-
-	public long realm() {
-		return realm;
-	}
-
-	public long num() {
-		return num;
-	}
-
-	public long serialNo() {
-		return serialNo;
-	}
-
+public record NftId(long shard, long realm, long num, long serialNo) {
 	public TokenID tokenId() {
 		return TokenID.newBuilder()
 				.setShardNum(shard)
@@ -61,36 +32,10 @@ public class NftId {
 	}
 
 	@Override
-	public String toString() {
-		return MoreObjects.toStringHelper(NftId.class)
-				.add("shard", shard)
-				.add("realm", realm)
-				.add("num", num)
-				.add("serialNo", serialNo)
-				.toString();
-	}
-
-	@Override
 	public int hashCode() {
 		int result = Long.hashCode(shard);
 		result = 31 * result + Long.hashCode(realm);
 		result = 31 * result + Long.hashCode(num);
 		return 31 * result + Long.hashCode(serialNo);
-	}
-
-	@Override
-	public boolean equals(Object o) {
-		if (this == o) {
-			return true;
-		}
-		if (o == null || NftId.class != o.getClass()) {
-			return false;
-		}
-
-		var that = (NftId) o;
-		return this.shard == that.shard &&
-				this.realm == that.realm &&
-				this.num == that.num &&
-				this.serialNo == that.serialNo;
 	}
 }

--- a/hedera-node/src/main/java/com/hedera/services/store/models/Token.java
+++ b/hedera-node/src/main/java/com/hedera/services/store/models/Token.java
@@ -60,7 +60,6 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TOKEN_HAS_NO_W
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TOKEN_IS_IMMUTABLE;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TOKEN_MAX_SUPPLY_REACHED;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TREASURY_MUST_OWN_BURNED_NFT;
-import static java.util.stream.Collectors.toList;
 
 /**
  * Encapsulates the state and operations of a Hedera token.
@@ -71,7 +70,8 @@ import static java.util.stream.Collectors.toList;
  * <b>NOTE:</b> Some operations only apply to specific token types.
  * For example, a {@link Token#mint(TokenRelationship, long, boolean)}
  * call only makes sense for a token of type {@code FUNGIBLE_COMMON}; the
- * signature for a {@code NON_FUNGIBLE_UNIQUE} is {@link Token#mint(OwnershipTracker, TokenRelationship, List, RichInstant)}.
+ * signature for a {@code NON_FUNGIBLE_UNIQUE} is {@link Token#mint(OwnershipTracker, TokenRelationship, List,
+ * RichInstant)}.
  */
 public class Token {
 	private final Id id;
@@ -168,7 +168,7 @@ public class Token {
 		token.setDecimals(op.getDecimals());
 		token.setName(op.getName());
 		token.setFrozenByDefault(op.getFreezeDefault());
-		token.setCustomFees(op.getCustomFeesList().stream().map(FcCustomFee::fromGrpc).collect(toList()));
+		token.setCustomFees(op.getCustomFeesList().stream().map(FcCustomFee::fromGrpc).toList());
 		token.setPaused(false);
 
 		token.setNew(true);
@@ -497,6 +497,7 @@ public class Token {
 	public void setPauseKey(final JKey pauseKey) {
 		this.pauseKey = pauseKey;
 	}
+
 	/* supply is changed only after the token is created */
 	public boolean hasChangedSupply() {
 		return supplyHasChanged && !isNew;

--- a/hedera-node/src/main/java/com/hedera/services/store/models/TokenRelationship.java
+++ b/hedera-node/src/main/java/com/hedera/services/store/models/TokenRelationship.java
@@ -67,7 +67,7 @@ public class TokenRelationship {
 	}
 
 	public FcTokenAssociation asAutoAssociation() {
-		return new FcTokenAssociation(token.getId().getNum(), account.getId().getNum());
+		return new FcTokenAssociation(token.getId().num(), account.getId().num());
 	}
 
 	public long getBalance() {

--- a/hedera-node/src/main/java/com/hedera/services/store/tokens/HederaTokenStore.java
+++ b/hedera-node/src/main/java/com/hedera/services/store/tokens/HederaTokenStore.java
@@ -104,7 +104,6 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TOKEN_IS_PAUSE
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TOKEN_NOT_ASSOCIATED_TO_ACCOUNT;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TOKEN_WAS_DELETED;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TRANSACTION_REQUIRES_ZERO_TOKEN_BALANCES;
-import static java.util.stream.Collectors.toList;
 
 /**
  * Provides a managing store for arbitrary tokens.
@@ -174,7 +173,7 @@ public class HederaTokenStore extends HederaStore implements TokenStore {
 		} else {
 			return knownTreasuries.get(treasury).stream()
 					.sorted(HederaLedger.TOKEN_ID_COMPARATOR)
-					.collect(toList());
+					.toList();
 		}
 	}
 

--- a/hedera-node/src/main/java/com/hedera/services/store/tokens/views/PendingChange.java
+++ b/hedera-node/src/main/java/com/hedera/services/store/tokens/views/PendingChange.java
@@ -1,0 +1,30 @@
+package com.hedera.services.store.tokens.views;
+
+/*
+ * -
+ *  * ‌
+ *  * Hedera Services Node
+ *  * ​
+ *  * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
+ *  * ​
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *      http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *  * ‍
+ *
+ */
+
+public record PendingChange(UniqTokenViewsManager.TargetFcotmr targetFcotmr,
+							int keyCode,
+							long valueCode,
+							boolean associate) {
+}
+

--- a/hedera-node/src/main/java/com/hedera/services/store/tokens/views/UniqTokenViewsManager.java
+++ b/hedera-node/src/main/java/com/hedera/services/store/tokens/views/UniqTokenViewsManager.java
@@ -139,11 +139,11 @@ public class UniqTokenViewsManager {
 		}
 
 		final var tokenId = nftId.getHiPhi();
-		nftsByType.get().associate(tokenId, nftId.getValue());
+		nftsByType.get().associate(tokenId, nftId.value());
 		if (isUsingTreasuryWildcards()) {
-			curTreasuryNftsByType().associate(tokenId, nftId.getValue());
+			curTreasuryNftsByType().associate(tokenId, nftId.value());
 		} else {
-			nftsByOwner.get().associate(EntityNum.fromInt(treasury.identityCode()), nftId.getValue());
+			nftsByOwner.get().associate(EntityNum.fromInt(treasury.identityCode()), nftId.value());
 		}
 	}
 
@@ -162,8 +162,8 @@ public class UniqTokenViewsManager {
 		}
 
 		/* The treasury account cannot be wiped, so both cases are the same */
-		nftsByType.get().disassociate(nftId.getHiPhi(), nftId.getValue());
-		nftsByOwner.get().disassociate(fromInt(fromAccount.identityCode()), nftId.getValue());
+		nftsByType.get().disassociate(nftId.getHiPhi(), nftId.value());
+		nftsByOwner.get().disassociate(fromInt(fromAccount.identityCode()), nftId.value());
 	}
 
 	/**
@@ -181,11 +181,11 @@ public class UniqTokenViewsManager {
 		}
 
 		final var tokenId = nftId.getHiPhi();
-		nftsByType.get().disassociate(tokenId, nftId.getValue());
+		nftsByType.get().disassociate(tokenId, nftId.value());
 		if (isUsingTreasuryWildcards()) {
-			curTreasuryNftsByType().disassociate(tokenId, nftId.getValue());
+			curTreasuryNftsByType().disassociate(tokenId, nftId.value());
 		} else {
-			nftsByOwner.get().disassociate(EntityNum.fromInt(treasury.identityCode()), nftId.getValue());
+			nftsByOwner.get().disassociate(EntityNum.fromInt(treasury.identityCode()), nftId.value());
 		}
 	}
 
@@ -205,8 +205,8 @@ public class UniqTokenViewsManager {
 			return;
 		}
 
-		changeOrStage(NFTS_BY_OWNER, prevOwner.identityCode(), nftId.getValue(), false);
-		changeOrStage(NFTS_BY_OWNER, newOwner.identityCode(), nftId.getValue(), true);
+		changeOrStage(NFTS_BY_OWNER, prevOwner.identityCode(), nftId.value(), false);
+		changeOrStage(NFTS_BY_OWNER, newOwner.identityCode(), nftId.value(), true);
 	}
 
 	/**
@@ -227,11 +227,11 @@ public class UniqTokenViewsManager {
 		}
 
 		if (isUsingTreasuryWildcards()) {
-			changeOrStage(TREASURY_NFTS_BY_TYPE, nftId.getHiPhi().intValue(), nftId.getValue(), false);
+			changeOrStage(TREASURY_NFTS_BY_TYPE, nftId.getHiPhi().intValue(), nftId.value(), false);
 		} else {
-			changeOrStage(NFTS_BY_OWNER, treasury.identityCode(), nftId.getValue(), false);
+			changeOrStage(NFTS_BY_OWNER, treasury.identityCode(), nftId.value(), false);
 		}
-		changeOrStage(NFTS_BY_OWNER, newOwner.identityCode(), nftId.getValue(), true);
+		changeOrStage(NFTS_BY_OWNER, newOwner.identityCode(), nftId.value(), true);
 	}
 
 	/**
@@ -251,11 +251,11 @@ public class UniqTokenViewsManager {
 			return;
 		}
 
-		changeOrStage(NFTS_BY_OWNER, prevOwner.identityCode(), nftId.getValue(), false);
+		changeOrStage(NFTS_BY_OWNER, prevOwner.identityCode(), nftId.value(), false);
 		if (isUsingTreasuryWildcards()) {
-			changeOrStage(TREASURY_NFTS_BY_TYPE, nftId.getHiPhi().intValue(), nftId.getValue(), true);
+			changeOrStage(TREASURY_NFTS_BY_TYPE, nftId.getHiPhi().intValue(), nftId.value(), true);
 		} else {
-			changeOrStage(NFTS_BY_OWNER, treasury.identityCode(), nftId.getValue(), true);
+			changeOrStage(NFTS_BY_OWNER, treasury.identityCode(), nftId.value(), true);
 		}
 	}
 
@@ -313,7 +313,7 @@ public class UniqTokenViewsManager {
 		}
 		if (!changesInTxn.isEmpty()) {
 			for (var change : changesInTxn) {
-				doChange(change.targetFcotmr(), change.keyCode(), change.valueCode(), change.isAssociate());
+				doChange(change.targetFcotmr(), change.keyCode(), change.valueCode(), change.associate());
 			}
 			changesInTxn.clear();
 		}
@@ -407,7 +407,7 @@ public class UniqTokenViewsManager {
 				if (!tokens.containsKey(tokenId)) {
 					return;
 				}
-				curTreasuryNftsByType.associate(tokenId, nftId.getValue());
+				curTreasuryNftsByType.associate(tokenId, nftId.value());
 			}
 		});
 	}
@@ -422,7 +422,7 @@ public class UniqTokenViewsManager {
 				return;
 			}
 			if (!nft.isTreasuryOwned()) {
-				curNftsByOwner.associate(fromInt(nft.getOwner().identityCode()), nftId.getValue());
+				curNftsByOwner.associate(fromInt(nft.getOwner().identityCode()), nftId.value());
 			}
 		});
 	}
@@ -439,9 +439,9 @@ public class UniqTokenViewsManager {
 			}
 			if (nft.isTreasuryOwned()) {
 				final var token = tokens.get(tokenId);
-				curNftsByOwner.associate(fromInt(token.treasury().identityCode()), nftId.getValue());
+				curNftsByOwner.associate(fromInt(token.treasury().identityCode()), nftId.value());
 			} else {
-				curNftsByOwner.associate(fromInt(nft.getOwner().identityCode()), nftId.getValue());
+				curNftsByOwner.associate(fromInt(nft.getOwner().identityCode()), nftId.value());
 			}
 		});
 	}
@@ -456,48 +456,11 @@ public class UniqTokenViewsManager {
 			if (!tokens.containsKey(tokenId)) {
 				return;
 			}
-			curNftsByType.associate(tokenId, nftId.getValue());
+			curNftsByType.associate(tokenId, nftId.value());
 		});
 	}
 
-	static class PendingChange {
-		private final TargetFcotmr targetFcotmr;
-		private final int keyCode;
-		private final long valueCode;
-		private final boolean associate;
-
-		public PendingChange(TargetFcotmr targetFcotmr, int keyCode, long valueCode, boolean associate) {
-			this.targetFcotmr = targetFcotmr;
-			this.keyCode = keyCode;
-			this.valueCode = valueCode;
-			this.associate = associate;
-		}
-
-		public TargetFcotmr targetFcotmr() {
-			return targetFcotmr;
-		}
-
-		public int keyCode() {
-			return keyCode;
-		}
-
-		public long valueCode() {
-			return valueCode;
-		}
-
-		public boolean isAssociate() {
-			return associate;
-		}
-
-		@Override
-		public String toString() {
-			return "PendingChange{" +
-					"targetFcotmr=" + targetFcotmr +
-					", keyCode=" + keyCode +
-					", valueCode=" + valueCode +
-					", associate=" + associate +
-					'}';
-		}
+	static record PendingChange(TargetFcotmr targetFcotmr, int keyCode, long valueCode, boolean associate) {
 	}
 
 	/* --- Only used by unit tests --- */

--- a/hedera-node/src/main/java/com/hedera/services/store/tokens/views/UniqTokenViewsManager.java
+++ b/hedera-node/src/main/java/com/hedera/services/store/tokens/views/UniqTokenViewsManager.java
@@ -460,9 +460,6 @@ public class UniqTokenViewsManager {
 		});
 	}
 
-	static record PendingChange(TargetFcotmr targetFcotmr, int keyCode, long valueCode, boolean associate) {
-	}
-
 	/* --- Only used by unit tests --- */
 	List<PendingChange> getChangesInTxn() {
 		return changesInTxn;

--- a/hedera-node/src/main/java/com/hedera/services/throttling/ThrottleReqsManager.java
+++ b/hedera-node/src/main/java/com/hedera/services/throttling/ThrottleReqsManager.java
@@ -9,9 +9,9 @@ package com.hedera.services.throttling;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -78,7 +78,7 @@ public class ThrottleReqsManager {
 	}
 
 	List<DeterministicThrottle> managedThrottles() {
-		return allReqs.stream().map(Pair::getLeft).collect(Collectors.toList());
+		return allReqs.stream().map(Pair::getLeft).toList();
 	}
 
 	String asReadableRequirements() {

--- a/hedera-node/src/main/java/com/hedera/services/txns/crypto/AutoCreationLogic.java
+++ b/hedera-node/src/main/java/com/hedera/services/txns/crypto/AutoCreationLogic.java
@@ -116,7 +116,7 @@ public class AutoCreationLogic {
 	public boolean reclaimPendingAliases() {
 		if (!pendingCreations.isEmpty()) {
 			for (final var pendingCreation : pendingCreations) {
-				final var alias = pendingCreation.getRecordBuilder().getAlias();
+				final var alias = pendingCreation.recordBuilder().getAlias();
 				aliasManager.getAliases().remove(alias);
 			}
 			return true;
@@ -129,12 +129,13 @@ public class AutoCreationLogic {
 	 * Notifies the given {@link AccountRecordsHistorian} of the child records for any
 	 * provisionally created accounts since the last call to {@link AutoCreationLogic#reset()}.
 	 *
-	 * @param recordsHistorian the records historian that should track the child records
+	 * @param recordsHistorian
+	 * 		the records historian that should track the child records
 	 */
 	public void submitRecordsTo(final AccountRecordsHistorian recordsHistorian) {
 		for (final var pendingCreation : pendingCreations) {
-			final var syntheticCreation = pendingCreation.getSyntheticBody();
-			final var childRecord = pendingCreation.getRecordBuilder();
+			final var syntheticCreation = pendingCreation.syntheticBody();
+			final var childRecord = pendingCreation.recordBuilder();
 			recordsHistorian.trackPrecedingChildRecord(DEFAULT_SOURCE_ID, syntheticCreation, childRecord);
 		}
 	}

--- a/hedera-node/src/main/java/com/hedera/services/txns/customfees/FcmCustomFeeSchedules.java
+++ b/hedera-node/src/main/java/com/hedera/services/txns/customfees/FcmCustomFeeSchedules.java
@@ -25,6 +25,8 @@ import com.hedera.services.state.merkle.MerkleToken;
 import com.hedera.services.store.models.Id;
 import com.hedera.services.utils.EntityNum;
 import com.swirlds.merkle.map.MerkleMap;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -34,10 +36,12 @@ import java.util.function.Supplier;
  * Active CustomFeeSchedules for an entity in the tokens FCMap
  */
 @Singleton
-public record FcmCustomFeeSchedules(Supplier<MerkleMap<EntityNum, MerkleToken>> tokens) implements CustomFeeSchedules {
+public class FcmCustomFeeSchedules implements CustomFeeSchedules {
+	private final Supplier<MerkleMap<EntityNum, MerkleToken>> tokens;
 
 	@Inject
-	public FcmCustomFeeSchedules {
+	public FcmCustomFeeSchedules(Supplier<MerkleMap<EntityNum, MerkleToken>> tokens) {
+		this.tokens = tokens;
 	}
 
 	@Override
@@ -49,5 +53,19 @@ public record FcmCustomFeeSchedules(Supplier<MerkleMap<EntityNum, MerkleToken>> 
 		}
 		final var merkleToken = currentTokens.get(key);
 		return new CustomFeeMeta(tokenId, merkleToken.treasury().asId(), merkleToken.customFeeSchedule());
+	}
+
+	public Supplier<MerkleMap<EntityNum, MerkleToken>> getTokens() {
+		return tokens;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		return EqualsBuilder.reflectionEquals(this, obj);
+	}
+
+	@Override
+	public int hashCode() {
+		return HashCodeBuilder.reflectionHashCode(this);
 	}
 }

--- a/hedera-node/src/main/java/com/hedera/services/txns/customfees/FcmCustomFeeSchedules.java
+++ b/hedera-node/src/main/java/com/hedera/services/txns/customfees/FcmCustomFeeSchedules.java
@@ -9,9 +9,9 @@ package com.hedera.services.txns.customfees;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -25,8 +25,6 @@ import com.hedera.services.state.merkle.MerkleToken;
 import com.hedera.services.store.models.Id;
 import com.hedera.services.utils.EntityNum;
 import com.swirlds.merkle.map.MerkleMap;
-import org.apache.commons.lang3.builder.EqualsBuilder;
-import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -36,12 +34,10 @@ import java.util.function.Supplier;
  * Active CustomFeeSchedules for an entity in the tokens FCMap
  */
 @Singleton
-public class FcmCustomFeeSchedules implements CustomFeeSchedules {
-	private final Supplier<MerkleMap<EntityNum, MerkleToken>> tokens;
+public record FcmCustomFeeSchedules(Supplier<MerkleMap<EntityNum, MerkleToken>> tokens) implements CustomFeeSchedules {
 
 	@Inject
-	public FcmCustomFeeSchedules(Supplier<MerkleMap<EntityNum, MerkleToken>> tokens) {
-		this.tokens = tokens;
+	public FcmCustomFeeSchedules {
 	}
 
 	@Override
@@ -53,19 +49,5 @@ public class FcmCustomFeeSchedules implements CustomFeeSchedules {
 		}
 		final var merkleToken = currentTokens.get(key);
 		return new CustomFeeMeta(tokenId, merkleToken.treasury().asId(), merkleToken.customFeeSchedule());
-	}
-
-	public Supplier<MerkleMap<EntityNum, MerkleToken>> getTokens() {
-		return tokens;
-	}
-
-	@Override
-	public boolean equals(Object obj) {
-		return EqualsBuilder.reflectionEquals(this, obj);
-	}
-
-	@Override
-	public int hashCode() {
-		return HashCodeBuilder.reflectionHashCode(this);
 	}
 }

--- a/hedera-node/src/main/java/com/hedera/services/txns/network/FreezeTransitionLogic.java
+++ b/hedera-node/src/main/java/com/hedera/services/txns/network/FreezeTransitionLogic.java
@@ -133,8 +133,7 @@ public class FreezeTransitionLogic implements TransitionLogic {
 				return validate(op, effectiveNow, false);
 			case PREPARE_UPGRADE:
 				return validate(op, null, true);
-			case FREEZE_UPGRADE:
-			case TELEMETRY_UPGRADE:
+			case FREEZE_UPGRADE, TELEMETRY_UPGRADE:
 				return validate(op, effectiveNow, true);
 			default:
 				return INVALID_FREEZE_TRANSACTION_BODY;
@@ -225,7 +224,8 @@ public class FreezeTransitionLogic implements TransitionLogic {
 
 		final var fileMatches = op.getUpdateFile().getFileNum() == curNetworkCtx.getPreparedUpdateFileNum();
 		validateTrue(fileMatches, UPDATE_FILE_ID_DOES_NOT_MATCH_PREPARED);
-		final var hashMatches = Arrays.equals(op.getFileHash().toByteArray(), curNetworkCtx.getPreparedUpdateFileHash());
+		final var hashMatches = Arrays.equals(op.getFileHash().toByteArray(),
+				curNetworkCtx.getPreparedUpdateFileHash());
 		validateTrue(hashMatches, UPDATE_FILE_HASH_DOES_NOT_MATCH_PREPARED);
 
 		final var isHashUnchanged = curNetworkCtx.isPreparedFileHashValidGiven(specialFiles.get());

--- a/hedera-node/src/main/java/com/hedera/services/txns/schedule/ScheduleCreateTransitionLogic.java
+++ b/hedera-node/src/main/java/com/hedera/services/txns/schedule/ScheduleCreateTransitionLogic.java
@@ -107,9 +107,9 @@ public class ScheduleCreateTransitionLogic implements TransitionLogic {
 		}
 
 		final var result = store.createProvisionally(schedule, fromJava(txnCtx.consensusTime()));
-		final var scheduleId = result.getCreated();
+		final var scheduleId = result.created();
 		if (null == scheduleId) {
-			abortWith(result.getStatus());
+			abortWith(result.status());
 			return;
 		}
 

--- a/hedera-node/src/main/java/com/hedera/services/txns/submission/StructuralPrecheck.java
+++ b/hedera-node/src/main/java/com/hedera/services/txns/submission/StructuralPrecheck.java
@@ -111,8 +111,8 @@ public final class StructuralPrecheck {
 		for (final var field : msg.getAllFields().values()) {
 			if (isProtoMsg(field)) {
 				depth = Math.max(depth, 1 + protoDepthOf((GeneratedMessageV3) field));
-			} else if (field instanceof List) {
-				for (final var item : (List) field) {
+			} else if (field instanceof List list) {
+				for (final var item : list) {
 					depth = Math.max(depth, isProtoMsg(item) ? 1 + protoDepthOf((GeneratedMessageV3) item) : 0);
 				}
 			}

--- a/hedera-node/src/main/java/com/hedera/services/txns/submission/StructuralPrecheck.java
+++ b/hedera-node/src/main/java/com/hedera/services/txns/submission/StructuralPrecheck.java
@@ -111,7 +111,7 @@ public final class StructuralPrecheck {
 		for (final var field : msg.getAllFields().values()) {
 			if (isProtoMsg(field)) {
 				depth = Math.max(depth, 1 + protoDepthOf((GeneratedMessageV3) field));
-			} else if (field instanceof List list) {
+			} else if (field instanceof List<? extends Object> list) {
 				for (final var item : list) {
 					depth = Math.max(depth, isProtoMsg(item) ? 1 + protoDepthOf((GeneratedMessageV3) item) : 0);
 				}

--- a/hedera-node/src/main/java/com/hedera/services/txns/token/TokenFeeScheduleUpdateTransitionLogic.java
+++ b/hedera-node/src/main/java/com/hedera/services/txns/token/TokenFeeScheduleUpdateTransitionLogic.java
@@ -42,7 +42,6 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.CUSTOM_FEES_LI
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_TOKEN_ID;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OK;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TOKEN_HAS_NO_FEE_SCHEDULE_KEY;
-import static java.util.stream.Collectors.toList;
 
 /**
  * Provides the state transition for updating token fee schedule.
@@ -88,7 +87,7 @@ public class TokenFeeScheduleUpdateTransitionLogic implements TransitionLogic {
 		final var customFees = op.getCustomFeesList()
 				.stream()
 				.map(grpcFeeConverter)
-				.collect(toList());
+				.toList();
 		customFees.forEach(fee -> {
 			fee.validateWith(token, accountStore, tokenStore);
 			fee.nullOutCollector();

--- a/hedera-node/src/main/java/com/hedera/services/txns/token/process/Creation.java
+++ b/hedera-node/src/main/java/com/hedera/services/txns/token/process/Creation.java
@@ -9,9 +9,9 @@ package com.hedera.services.txns.token.process;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -42,7 +42,6 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.CUSTOM_FEES_LI
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_AUTORENEW_ACCOUNT;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_EXPIRATION_TIME;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_TREASURY_ACCOUNT_FOR_TOKEN;
-import static java.util.stream.Collectors.toList;
 
 /**
  * A process object to help discriminate the stages of token creation.
@@ -135,7 +134,7 @@ public class Creation {
 	}
 
 	public List<FcTokenAssociation> newAssociations() {
-		return newRels.stream().map(TokenRelationship::asAutoAssociation).collect(toList());
+		return newRels.stream().map(TokenRelationship::asAutoAssociation).toList();
 	}
 
 	/* --- Only used by unit tests --- */

--- a/hedera-node/src/main/java/com/hedera/services/utils/EntityIdUtils.java
+++ b/hedera-node/src/main/java/com/hedera/services/utils/EntityIdUtils.java
@@ -53,32 +53,25 @@ public final class EntityIdUtils {
 	}
 
 	public static String readableId(final Object o) {
-		if (o instanceof Id) {
-			final var id = (Id) o;
+		if (o instanceof Id id) {
 			return String.format(ENTITY_ID_FORMAT, id.getShard(), id.getRealm(), id.getNum());
 		}
-		if (o instanceof AccountID) {
-			final var id = (AccountID) o;
+		if (o instanceof AccountID id) {
 			return String.format(ENTITY_ID_FORMAT, id.getShardNum(), id.getRealmNum(), id.getAccountNum());
 		}
-		if (o instanceof FileID) {
-			final var id = (FileID) o;
+		if (o instanceof FileID id) {
 			return String.format(ENTITY_ID_FORMAT, id.getShardNum(), id.getRealmNum(), id.getFileNum());
 		}
-		if (o instanceof TopicID) {
-			final var id = (TopicID) o;
+		if (o instanceof TopicID id) {
 			return String.format(ENTITY_ID_FORMAT, id.getShardNum(), id.getRealmNum(), id.getTopicNum());
 		}
-		if (o instanceof TokenID) {
-			final var id = (TokenID) o;
+		if (o instanceof TokenID id) {
 			return String.format(ENTITY_ID_FORMAT, id.getShardNum(), id.getRealmNum(), id.getTokenNum());
 		}
-		if (o instanceof ScheduleID) {
-			final var id = (ScheduleID) o;
+		if (o instanceof ScheduleID id) {
 			return String.format(ENTITY_ID_FORMAT, id.getShardNum(), id.getRealmNum(), id.getScheduleNum());
 		}
-		if (o instanceof NftID) {
-			final var id = (NftID) o;
+		if (o instanceof NftID id) {
 			final var tokenID = id.getTokenID();
 			return String.format(ENTITY_ID_FORMAT + ".%d",
 					tokenID.getShardNum(), tokenID.getRealmNum(), tokenID.getTokenNum(), id.getSerialNumber());
@@ -193,9 +186,11 @@ public final class EntityIdUtils {
 	public static byte[] asSolidityAddress(final ContractID id) {
 		return asSolidityAddress((int) id.getShardNum(), id.getRealmNum(), id.getContractNum());
 	}
+
 	public static byte[] asSolidityAddress(final AccountID id) {
 		return asSolidityAddress((int) id.getShardNum(), id.getRealmNum(), id.getAccountNum());
 	}
+
 	public static String asSolidityAddressHex(Id id) {
 		return CommonUtils.hex(asSolidityAddress((int) id.getShard(), id.getRealm(), id.getNum()));
 	}

--- a/hedera-node/src/main/java/com/hedera/services/utils/EntityIdUtils.java
+++ b/hedera-node/src/main/java/com/hedera/services/utils/EntityIdUtils.java
@@ -54,7 +54,7 @@ public final class EntityIdUtils {
 
 	public static String readableId(final Object o) {
 		if (o instanceof Id id) {
-			return String.format(ENTITY_ID_FORMAT, id.getShard(), id.getRealm(), id.getNum());
+			return String.format(ENTITY_ID_FORMAT, id.shard(), id.realm(), id.num());
 		}
 		if (o instanceof AccountID id) {
 			return String.format(ENTITY_ID_FORMAT, id.getShardNum(), id.getRealmNum(), id.getAccountNum());
@@ -192,7 +192,7 @@ public final class EntityIdUtils {
 	}
 
 	public static String asSolidityAddressHex(Id id) {
-		return CommonUtils.hex(asSolidityAddress((int) id.getShard(), id.getRealm(), id.getNum()));
+		return CommonUtils.hex(asSolidityAddress((int) id.shard(), id.realm(), id.num()));
 	}
 
 	public static byte[] asSolidityAddress(final int shard, final long realm, final long num) {

--- a/hedera-node/src/main/java/com/hedera/services/utils/EntityNum.java
+++ b/hedera-node/src/main/java/com/hedera/services/utils/EntityNum.java
@@ -59,10 +59,10 @@ public class EntityNum {
 	}
 
 	public static EntityNum fromModel(Id id) {
-		if (!areValidNums(id.getShard(), id.getRealm())) {
+		if (!areValidNums(id.shard(), id.realm())) {
 			return MISSING_NUM;
 		}
-		return fromLong(id.getNum());
+		return fromLong(id.num());
 	}
 
 	public static EntityNum fromAccountId(AccountID grpc) {

--- a/hedera-node/src/main/java/com/hedera/services/utils/EntityNumPair.java
+++ b/hedera-node/src/main/java/com/hedera/services/utils/EntityNumPair.java
@@ -27,6 +27,8 @@ import com.hederahashgraph.api.proto.java.AccountID;
 import com.hederahashgraph.api.proto.java.TokenID;
 import org.apache.commons.lang3.tuple.Pair;
 
+import java.util.Objects;
+
 import static com.hedera.services.context.properties.StaticPropertiesHolder.STATIC_PROPERTIES;
 import static com.hedera.services.state.merkle.internals.BitPackUtils.isValidNum;
 import static com.hedera.services.state.merkle.internals.BitPackUtils.packedNums;
@@ -34,13 +36,11 @@ import static com.hedera.services.state.merkle.internals.BitPackUtils.unsignedHi
 import static com.hedera.services.state.merkle.internals.BitPackUtils.unsignedLowOrder32From;
 import static com.hedera.services.utils.EntityNum.areValidNums;
 
-public class EntityNumPair {
+public record EntityNumPair(long value) {
 	static final EntityNumPair MISSING_NUM_PAIR = new EntityNumPair(0);
 
-	private final long value;
-
-	public EntityNumPair(long value) {
-		this.value = value;
+	public EntityNumPair {
+		Objects.requireNonNull(value);
 	}
 
 	public static EntityNumPair fromLongs(long hi, long lo) {
@@ -72,29 +72,6 @@ public class EntityNumPair {
 		return Pair.of(
 				STATIC_PROPERTIES.scopedAccountWith(unsignedHighOrder32From(value)),
 				STATIC_PROPERTIES.scopedTokenWith(unsignedLowOrder32From(value)));
-	}
-
-	@Override
-	public int hashCode() {
-		return (int) MiscUtils.perm64(value);
-	}
-
-	public long getValue() {
-		return value;
-	}
-
-	@Override
-	public boolean equals(Object o) {
-		if (this == o) {
-			return true;
-		}
-		if (o == null || EntityNumPair.class != o.getClass()) {
-			return false;
-		}
-
-		var that = (EntityNumPair) o;
-
-		return this.value == that.value;
 	}
 
 	@Override

--- a/hedera-node/src/main/java/com/hedera/services/utils/EntityNumPair.java
+++ b/hedera-node/src/main/java/com/hedera/services/utils/EntityNumPair.java
@@ -65,7 +65,7 @@ public record EntityNumPair(long value) {
 	public static EntityNumPair fromModelRel(TokenRelationship tokenRelationship) {
 		final var token = tokenRelationship.getToken();
 		final var account = tokenRelationship.getAccount();
-		return fromLongs(account.getId().getNum(), token.getId().getNum());
+		return fromLongs(account.getId().num(), token.getId().num());
 	}
 
 	public Pair<AccountID, TokenID> asAccountTokenRel() {

--- a/hedera-node/src/main/java/com/hedera/services/utils/EntityNumPair.java
+++ b/hedera-node/src/main/java/com/hedera/services/utils/EntityNumPair.java
@@ -75,6 +75,11 @@ public record EntityNumPair(long value) {
 	}
 
 	@Override
+	public int hashCode() {
+		return (int) MiscUtils.perm64(value);
+	}
+
+	@Override
 	public String toString() {
 		return "PermHashLong("
 				+ BitPackUtils.unsignedHighOrder32From(value)

--- a/hedera-node/src/main/java/com/hedera/services/utils/MiscUtils.java
+++ b/hedera-node/src/main/java/com/hedera/services/utils/MiscUtils.java
@@ -189,7 +189,6 @@ import static com.hederahashgraph.api.proto.java.Query.QueryCase.TOKENGETNFTINFO
 import static com.hederahashgraph.api.proto.java.Query.QueryCase.TRANSACTIONGETRECEIPT;
 import static com.hederahashgraph.api.proto.java.Query.QueryCase.TRANSACTIONGETRECORD;
 import static java.util.Comparator.comparing;
-import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toMap;
 import static java.util.stream.Collectors.toSet;
 
@@ -364,7 +363,7 @@ public final class MiscUtils {
 				.filter(e -> e.getValue() != 0)
 				.sorted(comparing(Map.Entry::getKey, HederaLedger.ACCOUNT_ID_COMPARATOR))
 				.map(e -> AccountAmount.newBuilder().setAccountID(e.getKey()).setAmount(e.getValue()).build())
-				.collect(toList());
+				.toList();
 	}
 
 	public static String readableTransferList(final TransferList accountAmounts) {
@@ -376,7 +375,7 @@ public final class MiscUtils {
 						aa.getAmount() < 0 ? "->" : "<-",
 						aa.getAmount() < 0 ? "-" : "+",
 						BigInteger.valueOf(aa.getAmount()).abs().toString()))
-				.collect(toList())
+				.toList()
 				.toString();
 	}
 
@@ -388,7 +387,7 @@ public final class MiscUtils {
 						Long.valueOf(nftTransfer.getSerialNumber()).toString(),
 						EntityIdUtils.readableId(nftTransfer.getSenderAccountID()),
 						EntityIdUtils.readableId(nftTransfer.getReceiverAccountID())))
-				.collect(toList())
+				.toList()
 				.toString();
 	}
 

--- a/hedera-node/src/main/java/com/hedera/services/utils/MiscUtils.java
+++ b/hedera-node/src/main/java/com/hedera/services/utils/MiscUtils.java
@@ -350,7 +350,7 @@ public final class MiscUtils {
 	}
 
 	public static List<AccountAmount> canonicalDiffRepr(final List<AccountAmount> a, final List<AccountAmount> b) {
-		return canonicalRepr(Stream.concat(a.stream(), b.stream().map(MiscUtils::negationOf)).collect(toList()));
+		return canonicalRepr(Stream.concat(a.stream(), b.stream().map(MiscUtils::negationOf)).toList());
 	}
 
 	private static AccountAmount negationOf(final AccountAmount adjustment) {

--- a/hedera-node/src/test/java/com/hedera/services/fees/calculation/UsageBasedFeeCalculatorTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/fees/calculation/UsageBasedFeeCalculatorTest.java
@@ -57,10 +57,10 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Function;
-import java.util.Optional;
 
 import static com.hedera.services.fees.calculation.BasicFcfsUsagePrices.DEFAULT_RESOURCE_PRICES;
 import static com.hedera.test.factories.txns.ContractCallFactory.newSignedContractCall;
@@ -181,7 +181,7 @@ class UsageBasedFeeCalculatorTest {
 	@Test
 	void delegatesAutoRenewCalcs() {
 		// setup:
-		final var expected = new AutoRenewCalcs.RenewAssessment(456L, 123L);
+		final var expected = new RenewAssessment(456L, 123L);
 
 		given(autoRenewCalcs.maxRenewalAndFeeFor(any(), anyLong(), any(), any())).willReturn(expected);
 
@@ -289,7 +289,8 @@ class UsageBasedFeeCalculatorTest {
 	@Test
 	void loadPriceSchedulesOnInit() {
 		// setup:
-		final var seq = Triple.of(Map.of(SubType.DEFAULT, FeeData.getDefaultInstance()), Instant.now(), Map.of(SubType.DEFAULT, FeeData.getDefaultInstance()));
+		final var seq = Triple.of(Map.of(SubType.DEFAULT, FeeData.getDefaultInstance()), Instant.now(),
+				Map.of(SubType.DEFAULT, FeeData.getDefaultInstance()));
 
 		given(usagePrices.activePricingSequence(CryptoAccountAutoRenew)).willReturn(seq);
 
@@ -333,7 +334,8 @@ class UsageBasedFeeCalculatorTest {
 		// expect:
 		assertThrows(NoSuchElementException.class, () -> subject.computeFee(accessor, payerKey, view, consensusNow));
 		assertThrows(NoSuchElementException.class,
-				() -> subject.computePayment(query, currentPrices.get(SubType.DEFAULT), view, at, Collections.emptyMap()));
+				() -> subject.computePayment(query, currentPrices.get(SubType.DEFAULT), view, at,
+						Collections.emptyMap()));
 	}
 
 	@Test
@@ -351,7 +353,8 @@ class UsageBasedFeeCalculatorTest {
 		given(exchange.rate(at)).willReturn(currentRate);
 
 		// when:
-		FeeObject fees = subject.computePayment(query, currentPrices.get(SubType.DEFAULT), view, at, Collections.emptyMap());
+		FeeObject fees = subject.computePayment(query, currentPrices.get(SubType.DEFAULT), view, at,
+				Collections.emptyMap());
 
 		// then:
 		assertEquals(fees.getNodeFee(), expectedFees.getNodeFee());
@@ -387,7 +390,8 @@ class UsageBasedFeeCalculatorTest {
 				FeeBuilder.getSignatureCount(signedTxn),
 				9,
 				FeeBuilder.getSignatureSize(signedTxn));
-		FeeObject expectedFees = getFeeObject(currentPrices.get(SubType.DEFAULT), resourceUsage, currentRate, multiplier);
+		FeeObject expectedFees = getFeeObject(currentPrices.get(SubType.DEFAULT), resourceUsage, currentRate,
+				multiplier);
 		suggestedMultiplier.set(multiplier);
 
 		given(correctOpEstimator.applicableTo(accessor.getTxn())).willReturn(true);
@@ -466,7 +470,8 @@ class UsageBasedFeeCalculatorTest {
 				.burning(tokenId)
 				.txnValidStart(at)
 				.get();
-		invokesAccessorBasedUsagesForTxnInHandle(signedTxn, TokenBurn, SubType.TOKEN_NON_FUNGIBLE_UNIQUE, TokenType.NON_FUNGIBLE_UNIQUE );
+		invokesAccessorBasedUsagesForTxnInHandle(signedTxn, TokenBurn, SubType.TOKEN_NON_FUNGIBLE_UNIQUE,
+				TokenType.NON_FUNGIBLE_UNIQUE);
 	}
 
 
@@ -479,7 +484,8 @@ class UsageBasedFeeCalculatorTest {
 				.txnValidStart(at)
 				.get();
 
-		invokesAccessorBasedUsagesForTxnInHandle(signedTxn, TokenAccountWipe , SubType.TOKEN_NON_FUNGIBLE_UNIQUE, TokenType.NON_FUNGIBLE_UNIQUE );
+		invokesAccessorBasedUsagesForTxnInHandle(signedTxn, TokenAccountWipe, SubType.TOKEN_NON_FUNGIBLE_UNIQUE,
+				TokenType.NON_FUNGIBLE_UNIQUE);
 	}
 
 	@Test
@@ -491,9 +497,9 @@ class UsageBasedFeeCalculatorTest {
 				.txnValidStart(at)
 				.get();
 
-		invokesAccessorBasedUsagesForTxnInHandle(signedTxn, TokenMint, SubType.TOKEN_FUNGIBLE_COMMON, TokenType.FUNGIBLE_COMMON);
+		invokesAccessorBasedUsagesForTxnInHandle(signedTxn, TokenMint, SubType.TOKEN_FUNGIBLE_COMMON,
+				TokenType.FUNGIBLE_COMMON);
 	}
-
 
 
 	@Test

--- a/hedera-node/src/test/java/com/hedera/services/fees/calculation/utils/OpUsageCtxHelperTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/fees/calculation/utils/OpUsageCtxHelperTest.java
@@ -102,16 +102,16 @@ class OpUsageCtxHelperTest {
 		final var opMeta = subject.metaForFileAppend(stdAppendTxn);
 
 		// then:
-		assertEquals(newFileBytes, opMeta.getBytesAdded());
-		assertEquals(then - now, opMeta.getLifetime());
+		assertEquals(newFileBytes, opMeta.bytesAdded());
+		assertEquals(then - now, opMeta.lifetime());
 	}
 
 	@Test
 	void shortCircuitsFileAppendMetaForSpecialFile() {
 		final var opMeta = subject.metaForFileAppend(specialAppendTxn);
 
-		assertEquals(newFileBytes, opMeta.getBytesAdded());
-		assertEquals(7776000L, opMeta.getLifetime());
+		assertEquals(newFileBytes, opMeta.bytesAdded());
+		assertEquals(7776000L, opMeta.lifetime());
 	}
 
 	@Test
@@ -120,8 +120,8 @@ class OpUsageCtxHelperTest {
 		final var opMeta = subject.metaForFileAppend(stdAppendTxn);
 
 		// then:
-		assertEquals(newFileBytes, opMeta.getBytesAdded());
-		assertEquals(0, opMeta.getLifetime());
+		assertEquals(newFileBytes, opMeta.bytesAdded());
+		assertEquals(0, opMeta.lifetime());
 	}
 
 	@Test
@@ -306,6 +306,7 @@ class OpUsageCtxHelperTest {
 				.setTokenBurn(op)
 				.build();
 	}
+
 	private TransactionBody getTxnBody(final TokenWipeAccountTransactionBody op) {
 		return TransactionBody.newBuilder()
 				.setTransactionID(TransactionID.newBuilder()

--- a/hedera-node/src/test/java/com/hedera/services/grpc/marshalling/CustomFeeMetaTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/grpc/marshalling/CustomFeeMetaTest.java
@@ -60,11 +60,11 @@ class CustomFeeMetaTest {
 		final var subject = new CustomFeeMeta(aToken, aTreasury, List.of(hbarFee, htsFee));
 
 		// given:
-		final var desired = "CustomFeeMeta{tokenId=Id{shard=1, realm=1, num=1}, treasuryId=Id{shard=9, realm=9, num=9}, " +
-				"customFees=[FcCustomFee{feeType=FIXED_FEE, fixedFee=FixedFeeSpec{unitsToCollect=100000, " +
-				"tokenDenomination=ℏ}, feeCollector=EntityId{shard=2, realm=3, num=4}}, " +
-				"FcCustomFee{feeType=FIXED_FEE, fixedFee=FixedFeeSpec{unitsToCollect=10, tokenDenomination=6.6.6}, " +
-				"feeCollector=EntityId{shard=3, realm=4, num=5}}]}";
+		final var desired = "CustomFeeMeta[tokenId=Id[shard=1, realm=1, num=1], treasuryId=Id[shard=9, realm=9, num=9]," +
+				" customFees=[FcCustomFee{feeType=FIXED_FEE, fixedFee=FixedFeeSpec{unitsToCollect=100000, " +
+				"tokenDenomination=ℏ}, feeCollector=EntityId{shard=2, realm=3, num=4}}, FcCustomFee{feeType=FIXED_FEE, " +
+				"fixedFee=FixedFeeSpec{unitsToCollect=10, tokenDenomination=6.6.6}, feeCollector=EntityId{shard=3, " +
+				"realm=4, num=5}}]]";
 
 		// expect:
 		assertEquals(desired, subject.toString());

--- a/hedera-node/src/test/java/com/hedera/services/grpc/marshalling/ImpliedTransfersTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/grpc/marshalling/ImpliedTransfersTest.java
@@ -71,18 +71,20 @@ class ImpliedTransfersTest {
 		final var twoImpliedXfers = ImpliedTransfers.valid(
 				props, twoChanges, entityCustomFees, assessedCustomFees);
 		// and:
-		final var oneRepr = "ImpliedTransfers{meta=ImpliedTransfersMeta{code=TOKEN_WAS_DELETED, maxExplicitHbarAdjusts=5, " +
+		final var oneRepr = "ImpliedTransfers{meta=ImpliedTransfersMeta{code=TOKEN_WAS_DELETED, " +
+				"maxExplicitHbarAdjusts=5, " +
 				"maxExplicitTokenAdjusts=50, maxExplicitOwnershipChanges=12, maxNestedCustomFees=1, " +
 				"maxXferBalanceChanges=20, areNftsEnabled=true, tokenFeeSchedules=[]}, changes=[], " +
 				"tokenFeeSchedules=[], assessedCustomFees=[], resolvedAliases={}, numAutoCreations=0}";
 		final var twoRepr = "ImpliedTransfers{meta=ImpliedTransfersMeta{code=OK, maxExplicitHbarAdjusts=5, " +
 				"maxExplicitTokenAdjusts=50, maxExplicitOwnershipChanges=12, maxNestedCustomFees=1, " +
-				"maxXferBalanceChanges=20, areNftsEnabled=true, tokenFeeSchedules=[" +
-				"CustomFeeMeta{tokenId=Id{shard=0, realm=0, num=123}, treasuryId=Id{shard=2, realm=3, num=4}, " +
-				"customFees=[]}]}, changes=[BalanceChange{token=Id{shard=1, realm=2, num=3}, " +
-				"account=Id{shard=4, realm=5, num=6}, alias=, units=7}], tokenFeeSchedules=[" +
-				"CustomFeeMeta{tokenId=Id{shard=0, realm=0, num=123}, treasuryId=Id{shard=2, realm=3, num=4}, " +
-				"customFees=[]}], assessedCustomFees=[FcAssessedCustomFee{token=EntityId{shard=0, realm=0, num=123}, " +
+				"maxXferBalanceChanges=20, areNftsEnabled=true, tokenFeeSchedules=[CustomFeeMeta[tokenId=Id[shard=0, " +
+				"realm=0, num=123], treasuryId=Id[shard=2, realm=3, num=4], customFees=[]]]}, " +
+				"changes=[BalanceChange{token=Id[shard=1, realm=2, num=3], account=Id[shard=4, realm=5, num=6], " +
+				"alias=," +
+				" units=7}], tokenFeeSchedules=[CustomFeeMeta[tokenId=Id[shard=0, realm=0, num=123], " +
+				"treasuryId=Id[shard=2, realm=3, num=4], customFees=[]]], " +
+				"assessedCustomFees=[FcAssessedCustomFee{token=EntityId{shard=0, realm=0, num=123}, " +
 				"account=EntityId{shard=0, realm=0, num=124}, units=123, effective payer accounts=[123]}], " +
 				"resolvedAliases={}, numAutoCreations=0}";
 

--- a/hedera-node/src/test/java/com/hedera/services/grpc/marshalling/RoyaltyFeeAssessorTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/grpc/marshalling/RoyaltyFeeAssessorTest.java
@@ -9,9 +9,9 @@ package com.hedera.services.grpc.marshalling;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -246,7 +246,7 @@ class RoyaltyFeeAssessorTest {
 	private final Id nonFungibleTokenId = new Id(7, 4, 7);
 	private final BalanceChange trigger = BalanceChange.changingNftOwnership(
 			nonFungibleTokenId, nonFungibleTokenId.asGrpcToken(), ownershipChange);
-	private final long[] effPayerNum = new long[] { payer.getNum() };
+	private final long[] effPayerNum = new long[] { payer.num() };
 	private final FcAssessedCustomFee hbarAssessed =
 			new FcAssessedCustomFee(
 					targetCollector,

--- a/hedera-node/src/test/java/com/hedera/services/ledger/BalanceChangeTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/ledger/BalanceChangeTest.java
@@ -143,7 +143,7 @@ class BalanceChangeTest {
 		assertEquals(serialNo, nftChange.serialNo());
 		// and:
 		assertTrue(nftChange.isForNft());
-		assertEquals(new NftId(t.getShard(), t.getRealm(), t.getNum(), serialNo), nftChange.nftId());
+		assertEquals(new NftId(t.shard(), t.realm(), t.num(), serialNo), nftChange.nftId());
 	}
 
 	@Test

--- a/hedera-node/src/test/java/com/hedera/services/ledger/BalanceChangeTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/ledger/BalanceChangeTest.java
@@ -54,11 +54,11 @@ class BalanceChangeTest {
 		final var tokenChange = IdUtils.tokenChange(t, a, delta);
 		final var nftChange = changingNftOwnership(t, t.asGrpcToken(), nftXfer(a, b, serialNo));
 		// and:
-		final var hbarRepr = "BalanceChange{token=ℏ, account=Id{shard=1, realm=2, num=3}, alias=, units=-1234}";
-		final var tokenRepr = "BalanceChange{token=Id{shard=1, realm=2, num=3}, account=Id{shard=1, realm=2, num=3}, " +
+		final var hbarRepr = "BalanceChange{token=ℏ, account=Id[shard=1, realm=2, num=3], alias=, units=-1234}";
+		final var tokenRepr = "BalanceChange{token=Id[shard=1, realm=2, num=3], account=Id[shard=1, realm=2, num=3], " +
 				"alias=, units=-1234}";
-		final var nftRepr = "BalanceChange{nft=Id{shard=1, realm=2, num=3}, serialNo=1234, " +
-				"from=Id{shard=1, realm=2, num=3}, to=Id{shard=2, realm=3, num=4}}";
+		final var nftRepr = "BalanceChange{nft=Id[shard=1, realm=2, num=3], serialNo=1234, " +
+				"from=Id[shard=1, realm=2, num=3], to=Id[shard=2, realm=3, num=4]}";
 
 		// expect:
 		assertNotEquals(hbarChange, tokenChange);

--- a/hedera-node/src/test/java/com/hedera/services/ledger/LedgerBalanceChangesTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/ledger/LedgerBalanceChangesTest.java
@@ -631,9 +631,9 @@ class LedgerBalanceChangesTest {
 
 	private TokenID asGprcToken(Id id) {
 		return TokenID.newBuilder()
-				.setShardNum(id.getShard())
-				.setRealmNum(id.getRealm())
-				.setTokenNum(id.getNum())
+				.setShardNum(id.shard())
+				.setRealmNum(id.realm())
+				.setTokenNum(id.num())
 				.build();
 	}
 
@@ -666,9 +666,9 @@ class LedgerBalanceChangesTest {
 	private final Id yetAnotherToken = new Id(0, 0, 75233);
 	private final Id aNft = new Id(0, 0, 9999);
 	private final Id bNft = new Id(0, 0, 10000);
-	private final NftId aaNft = new NftId(aNft.getShard(), aNft.getRealm(), aNft.getNum(), aSerialNo);
-	private final NftId baNft = new NftId(bNft.getShard(), bNft.getRealm(), bNft.getNum(), aSerialNo);
-	private final NftId bbNft = new NftId(bNft.getShard(), bNft.getRealm(), bNft.getNum(), bSerialNo);
+	private final NftId aaNft = new NftId(aNft.shard(), aNft.realm(), aNft.num(), aSerialNo);
+	private final NftId baNft = new NftId(bNft.shard(), bNft.realm(), bNft.num(), aSerialNo);
+	private final NftId bbNft = new NftId(bNft.shard(), bNft.realm(), bNft.num(), bSerialNo);
 	private final EntityNum aNftKey = EntityNum.fromLong(9999);
 	private final EntityNum bNftKey = EntityNum.fromLong(10000);
 	private final EntityNum tokenKey = EntityNum.fromLong(75231);

--- a/hedera-node/src/test/java/com/hedera/services/queries/meta/MetaAnswersTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/queries/meta/MetaAnswersTest.java
@@ -9,9 +9,9 @@ package com.hedera.services.queries.meta;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/hedera-node/src/test/java/com/hedera/services/sigs/metadata/lookups/BackedAccountLookupTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/sigs/metadata/lookups/BackedAccountLookupTest.java
@@ -81,8 +81,9 @@ class BackedAccountLookupTest {
 		given(accounts.getImmutableRef(id)).willReturn(account);
 
 		final var result = subject.safeLookup(id);
+		System.out.println(result.toString());
 
-		assertTrue(result.toString().startsWith("SafeLookupResult{failure=NONE, metadata=AccountSigningMetadata{"));
+		assertTrue(result.toString().startsWith("SafeLookupResult{failure=NONE, metadata=AccountSigningMetadata["));
 	}
 
 	@Test

--- a/hedera-node/src/test/java/com/hedera/services/sigs/metadata/lookups/BackedAccountLookupTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/sigs/metadata/lookups/BackedAccountLookupTest.java
@@ -9,9 +9,9 @@ package com.hedera.services.sigs.metadata.lookups;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -71,8 +71,8 @@ class BackedAccountLookupTest {
 
 		final var result = subject.safeLookup(id);
 
-		assertTrue(result.metadata().isReceiverSigRequired());
-		assertSame(account.getAccountKey(), result.metadata().getKey());
+		assertTrue(result.metadata().receiverSigRequired());
+		assertSame(account.getAccountKey(), result.metadata().key());
 	}
 
 	@Test
@@ -111,10 +111,10 @@ class BackedAccountLookupTest {
 		final var unmatchedResult = subject.aliasableSafeLookup(unmatchedAlias);
 
 		assertTrue(explicitResult.succeeded());
-		Assertions.assertSame(account.getAccountKey(), explicitResult.metadata().getKey());
+		Assertions.assertSame(account.getAccountKey(), explicitResult.metadata().key());
 
 		assertTrue(matchedResult.succeeded());
-		Assertions.assertSame(account.getAccountKey(), matchedResult.metadata().getKey());
+		Assertions.assertSame(account.getAccountKey(), matchedResult.metadata().key());
 
 		assertFalse(unmatchedResult.succeeded());
 		assertEquals(KeyOrderingFailure.MISSING_ACCOUNT, unmatchedResult.failureIfAny());

--- a/hedera-node/src/test/java/com/hedera/services/sigs/metadata/lookups/DefaultAccountLookupTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/sigs/metadata/lookups/DefaultAccountLookupTest.java
@@ -9,9 +9,9 @@ package com.hedera.services.sigs.metadata.lookups;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -47,7 +47,7 @@ class DefaultAccountLookupTest {
 	private AliasManager aliasManager;
 	@Mock
 	private MerkleMap<EntityNum, MerkleAccount> accounts;
-	
+
 	private DefaultAccountLookup subject;
 
 	@BeforeEach
@@ -74,10 +74,10 @@ class DefaultAccountLookupTest {
 		final var unmatchedResult = subject.aliasableSafeLookup(unmatchedAlias);
 
 		assertTrue(explicitResult.succeeded());
-		Assertions.assertSame(EMPTY_KEY, explicitResult.metadata().getKey());
+		Assertions.assertSame(EMPTY_KEY, explicitResult.metadata().key());
 
 		assertTrue(matchedResult.succeeded());
-		Assertions.assertSame(EMPTY_KEY, matchedResult.metadata().getKey());
+		Assertions.assertSame(EMPTY_KEY, matchedResult.metadata().key());
 
 		assertFalse(unmatchedResult.succeeded());
 		assertEquals(KeyOrderingFailure.MISSING_ACCOUNT, unmatchedResult.failureIfAny());

--- a/hedera-node/src/test/java/com/hedera/services/sigs/metadata/lookups/DefaultTopicLookupTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/sigs/metadata/lookups/DefaultTopicLookupTest.java
@@ -9,9 +9,9 @@ package com.hedera.services.sigs.metadata.lookups;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -74,7 +74,8 @@ class DefaultTopicLookupTest {
 
 		final var result = subject.safeLookup(target);
 
-		Assertions.assertEquals(INVALID_TOPIC, result.failureIfAny()); }
+		Assertions.assertEquals(INVALID_TOPIC, result.failureIfAny());
+	}
 
 	@Test
 	void getsExtantSubmitKey() {
@@ -85,7 +86,7 @@ class DefaultTopicLookupTest {
 		final var result = subject.safeLookup(target);
 
 		assertTrue(result.succeeded());
-		assertSame(multi, result.metadata().getSubmitKey());
+		assertSame(multi, result.metadata().submitKey());
 	}
 
 	@Test
@@ -108,7 +109,7 @@ class DefaultTopicLookupTest {
 		final var result = subject.safeLookup(target);
 
 		assertTrue(result.succeeded());
-		assertSame(multi, result.metadata().getAdminKey());
+		assertSame(multi, result.metadata().adminKey());
 	}
 
 	@Test

--- a/hedera-node/src/test/java/com/hedera/services/sigs/metadata/lookups/HfsSigMetaLookupTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/sigs/metadata/lookups/HfsSigMetaLookupTest.java
@@ -9,9 +9,9 @@ package com.hedera.services.sigs.metadata.lookups;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -73,7 +73,7 @@ class HfsSigMetaLookupTest {
 
 		// then:
 		assertTrue(safeSigMeta.succeeded());
-		assertEquals(wacl.toString(), safeSigMeta.metadata().getWacl().toString());
+		assertEquals(wacl.toString(), safeSigMeta.metadata().wacl().toString());
 	}
 
 	@Test
@@ -85,7 +85,7 @@ class HfsSigMetaLookupTest {
 
 		// then:
 		assertTrue(safeSigMeta.succeeded());
-		assertSame(StateView.EMPTY_WACL, safeSigMeta.metadata().getWacl());
+		assertSame(StateView.EMPTY_WACL, safeSigMeta.metadata().wacl());
 	}
 
 	@Test
@@ -98,7 +98,7 @@ class HfsSigMetaLookupTest {
 
 		// then:
 		assertTrue(safeSigMeta.succeeded());
-		assertTrue(safeSigMeta.metadata().getWacl().isEmpty());
+		assertTrue(safeSigMeta.metadata().wacl().isEmpty());
 	}
 
 	@Test

--- a/hedera-node/src/test/java/com/hedera/services/sigs/metadata/lookups/RetryingAccountLookupTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/sigs/metadata/lookups/RetryingAccountLookupTest.java
@@ -9,9 +9,9 @@ package com.hedera.services.sigs.metadata.lookups;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -98,8 +98,8 @@ class RetryingAccountLookupTest {
 
 		// then:
 		verifyZeroInteractions(pause);
-		assertTrue(meta.isReceiverSigRequired());
-		assertEquals(JKey.mapJKey(accountKeys), JKey.mapJKey(meta.getKey()));
+		assertTrue(meta.receiverSigRequired());
+		assertEquals(JKey.mapJKey(accountKeys), JKey.mapJKey(meta.key()));
 	}
 
 	@Test
@@ -122,15 +122,16 @@ class RetryingAccountLookupTest {
 		inOrder.verify(runningAvgs).recordAccountLookupRetries(captor.capture());
 		inOrder.verify(runningAvgs).recordAccountRetryWaitMs(anyDouble());
 		assertEquals(2, captor.getValue().intValue());
-		assertTrue(meta.isReceiverSigRequired());
-		assertEquals(JKey.mapJKey(accountKeys), JKey.mapJKey(meta.getKey()));
+		assertTrue(meta.receiverSigRequired());
+		assertEquals(JKey.mapJKey(accountKeys), JKey.mapJKey(meta.key()));
 	}
 
 	@Test
 	void retriesOnceWithSleepingPause() throws Exception {
 		given(accounts.get(accountKey)).willReturn(null).willReturn(accountValue);
 		// and:
-		subject = new RetryingAccountLookup(defaultPause, aliases, properties, () -> accounts, runningAvgs, speedometers);
+		subject = new RetryingAccountLookup(defaultPause, aliases, properties, () -> accounts, runningAvgs,
+				speedometers);
 		// and:
 		InOrder inOrder = inOrder(runningAvgs, speedometers);
 
@@ -143,8 +144,8 @@ class RetryingAccountLookupTest {
 		inOrder.verify(runningAvgs).recordAccountLookupRetries(captor.capture());
 		inOrder.verify(runningAvgs).recordAccountRetryWaitMs(anyDouble());
 		assertEquals(1, captor.getValue().intValue());
-		assertTrue(meta.isReceiverSigRequired());
-		assertEquals(JKey.mapJKey(accountKeys), JKey.mapJKey(meta.getKey()));
+		assertTrue(meta.receiverSigRequired());
+		assertEquals(JKey.mapJKey(accountKeys), JKey.mapJKey(meta.key()));
 	}
 
 	@Test

--- a/hedera-node/src/test/java/com/hedera/services/state/expiry/ExpiryEventTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/state/expiry/ExpiryEventTest.java
@@ -29,7 +29,7 @@ class ExpiryEventTest {
 
 	@Test
 	void expiryEventToStringWorks() {
-		var desired = "ExpiryEvent{id=something, expiry=1234567}";
+		var desired = "ExpiryEvent[id=something, expiry=1234567]";
 
 		// when:
 		var actual = expiryEvent.toString();

--- a/hedera-node/src/test/java/com/hedera/services/state/expiry/PriorityQueueExpiriesTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/state/expiry/PriorityQueueExpiriesTest.java
@@ -39,8 +39,8 @@ class PriorityQueueExpiriesTest {
 	private PriorityQueueExpiries<String> subject;
 	private Comparator<ExpiryEvent<String>> testCmp = (aEvent, bEvent) -> {
 		int order;
-		return (order = Long.compare(aEvent.getExpiry(), bEvent.getExpiry())) != 0
-				? order : aEvent.getId().compareTo(bEvent.getId());
+		return (order = Long.compare(aEvent.expiry(), bEvent.expiry())) != 0
+				? order : aEvent.id().compareTo(bEvent.id());
 	};
 
 	@BeforeEach
@@ -59,8 +59,8 @@ class PriorityQueueExpiriesTest {
 		//expect:
 		assertTrue(subject.hasExpiringAt(expiry1 - 1));
 		assertEquals(expiry1 - 1, subject.getNow());
-		assertEquals(expiry1-1, subject.getAllExpiries().peek().getExpiry());
-		assertEquals(k2, subject.expireNextAt(expiry1 -1));
+		assertEquals(expiry1 - 1, subject.getAllExpiries().peek().expiry());
+		assertEquals(k2, subject.expireNextAt(expiry1 - 1));
 	}
 
 	@Test
@@ -142,7 +142,7 @@ class PriorityQueueExpiriesTest {
 
 		// when:
 		for (int i = 0; i < entitiesToRemoveBeforeRebuild; i++) {
-			long now = events.get(i).getExpiry();
+			long now = events.get(i).expiry();
 			fullPq.expireNextAt(now);
 		}
 		// and:
@@ -150,7 +150,7 @@ class PriorityQueueExpiriesTest {
 
 		// then:
 		for (int i = entitiesToRemoveBeforeRebuild; i < entitiesToTrack; i++) {
-			long now = events.get(i).getExpiry();
+			long now = events.get(i).expiry();
 			var fromFull = fullPq.expireNextAt(now);
 			var fromPartial = partialPq.expireNextAt(now);
 			assertEquals(fromFull, fromPartial,
@@ -161,7 +161,7 @@ class PriorityQueueExpiriesTest {
 	private PriorityQueueExpiries<String> pqFrom(List<ExpiryEvent<String>> events) {
 		var pq = new PriorityQueueExpiries<>(testCmp);
 		for (var event : events) {
-			pq.track(event.getId(), event.getExpiry());
+			pq.track(event.id(), event.expiry());
 		}
 		return pq;
 	}

--- a/hedera-node/src/test/java/com/hedera/services/state/expiry/renewal/RenewalProcessTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/state/expiry/renewal/RenewalProcessTest.java
@@ -9,9 +9,9 @@ package com.hedera.services.state.expiry.renewal;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -21,7 +21,7 @@ package com.hedera.services.state.expiry.renewal;
  */
 
 import com.hedera.services.fees.FeeCalculator;
-import com.hedera.services.fees.calculation.AutoRenewCalcs;
+import com.hedera.services.fees.calculation.RenewAssessment;
 import com.hedera.services.state.merkle.MerkleAccount;
 import com.hedera.services.state.submerkle.CurrencyAdjustments;
 import com.hedera.services.state.submerkle.EntityId;
@@ -197,7 +197,7 @@ class RenewalProcessTest {
 		given(helper.classify(fundedExpiredAccountNum, now)).willReturn(EXPIRED_ACCOUNT_READY_TO_RENEW);
 		given(helper.getLastClassifiedAccount()).willReturn(expiredAccountNonZeroBalance);
 		given(fees.assessCryptoAutoRenewal(expiredAccountNonZeroBalance, requestedRenewalPeriod, instantNow))
-				.willReturn(new AutoRenewCalcs.RenewAssessment(fee, actualRenewalPeriod));
+				.willReturn(new RenewAssessment(fee, actualRenewalPeriod));
 
 		// when:
 		subject.beginRenewalCycle(instantNow);

--- a/hedera-node/src/test/java/com/hedera/services/state/exports/SignedStateBalancesExporterTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/state/exports/SignedStateBalancesExporterTest.java
@@ -27,11 +27,11 @@ import com.hedera.services.exceptions.NegativeAccountBalanceException;
 import com.hedera.services.state.merkle.MerkleAccount;
 import com.hedera.services.state.merkle.MerkleToken;
 import com.hedera.services.state.merkle.MerkleTokenRelStatus;
-import com.hedera.services.utils.EntityNum;
-import com.hedera.services.utils.EntityNumPair;
 import com.hedera.services.stream.proto.AllAccountBalances;
 import com.hedera.services.stream.proto.SingleAccountBalances;
 import com.hedera.services.stream.proto.TokenUnitBalance;
+import com.hedera.services.utils.EntityNum;
+import com.hedera.services.utils.EntityNumPair;
 import com.hedera.services.utils.SystemExits;
 import com.hedera.test.extensions.LogCaptor;
 import com.hedera.test.extensions.LogCaptureExtension;
@@ -114,7 +114,8 @@ class SignedStateBalancesExporterTest {
 	private static final byte[] sig = "not-really-a-sig".getBytes();
 	private static final byte[] fileHash = "not-really-a-hash".getBytes();
 
-	private MerkleAccount thisNodeAccount, anotherNodeAccount, firstNonNodeAccount, secondNonNodeAccount, deletedAccount;
+	private MerkleAccount thisNodeAccount, anotherNodeAccount, firstNonNodeAccount, secondNonNodeAccount,
+			deletedAccount;
 
 	private MockGlobalDynamicProps dynamicProperties = new MockGlobalDynamicProps();
 
@@ -326,8 +327,8 @@ class SignedStateBalancesExporterTest {
 
 		final var summary = subject.summarized(state);
 
-		assertEquals(ledgerFloat, summary.getTotalFloat().longValue());
-		assertEquals(expectedBalances, summary.getOrderedBalances());
+		assertEquals(ledgerFloat, summary.totalFloat().longValue());
+		assertEquals(expectedBalances, summary.orderedBalances());
 		assertThat(logCaptor.warnLogs(), contains(desiredWarning));
 	}
 

--- a/hedera-node/src/test/java/com/hedera/services/state/forensics/HashLoggerTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/state/forensics/HashLoggerTest.java
@@ -9,9 +9,9 @@ package com.hedera.services.state.forensics;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -30,9 +30,9 @@ import com.hedera.services.state.merkle.MerkleToken;
 import com.hedera.services.state.merkle.MerkleTokenRelStatus;
 import com.hedera.services.state.merkle.MerkleTopic;
 import com.hedera.services.state.merkle.MerkleUniqueToken;
+import com.hedera.services.stream.RecordsRunningHashLeaf;
 import com.hedera.services.utils.EntityNum;
 import com.hedera.services.utils.EntityNumPair;
-import com.hedera.services.stream.RecordsRunningHashLeaf;
 import com.hedera.test.extensions.LogCaptor;
 import com.hedera.test.extensions.LogCaptureExtension;
 import com.hedera.test.extensions.LoggingSubject;
@@ -88,31 +88,31 @@ class HashLoggerTest {
 	@Test
 	void logsAsExpected() {
 		final var desired = "[SwirldState Hashes]\n" +
-				"  Overall                :: " +
+				"Overall                :: " +
 				"303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030\n" +
-				"  Accounts               :: " +
+				"Accounts               :: " +
 				"313131313131313131313131313131313131313131313131313131313131313131313131313131313131313131313131\n" +
-				"  Storage                :: " +
+				"Storage                :: " +
 				"363636363636363636363636363636363636363636363636363636363636363636363636363636363636363636363636\n" +
-				"  Topics                 :: " +
+				"Topics                 :: " +
 				"323232323232323232323232323232323232323232323232323232323232323232323232323232323232323232323232\n" +
-				"  Tokens                 :: " +
+				"Tokens                 :: " +
 				"333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333\n" +
-				"  TokenAssociations      :: " +
+				"TokenAssociations      :: " +
 				"373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737\n" +
-				"  SpecialFiles           :: " +
+				"SpecialFiles           :: " +
 				"5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a\n" +
-				"  ScheduledTxs           :: " +
+				"ScheduledTxs           :: " +
 				"353535353535353535353535353535353535353535353535353535353535353535353535353535353535353535353535\n" +
-				"  NetworkContext         :: " +
+				"NetworkContext         :: " +
 				"383838383838383838383838383838383838383838383838383838383838383838383838383838383838383838383838\n" +
-				"  AddressBook            :: " +
+				"AddressBook            :: " +
 				"393939393939393939393939393939393939393939393939393939393939393939393939393939393939393939393939\n" +
-				"  RecordsRunningHashLeaf :: " +
+				"RecordsRunningHashLeaf :: " +
 				"585858585858585858585858585858585858585858585858585858585858585858585858585858585858585858585858\n" +
-				"    ↪ Running hash       :: " +
+				"  ↪ Running hash       :: " +
 				"595959595959595959595959595959595959595959595959595959595959595959595959595959595959595959595959\n" +
-				"  UniqueTokens           :: " +
+				"UniqueTokens           :: " +
 				"343434343434343434343434343434343434343434343434343434343434343434343434343434343434343434343434";
 
 		given(state.getHash()).willReturn(hashOf('0'));

--- a/hedera-node/src/test/java/com/hedera/services/state/submerkle/EntityIdTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/state/submerkle/EntityIdTest.java
@@ -170,9 +170,9 @@ class EntityIdTest {
 
 		var subject = new EntityId(id);
 
-		assertEquals(id.getShard(), subject.shard());
-		assertEquals(id.getRealm(), subject.realm());
-		assertEquals(id.getNum(), subject.num());
+		assertEquals(id.shard(), subject.shard());
+		assertEquals(id.realm(), subject.realm());
+		assertEquals(id.num(), subject.num());
 		assertTrue(subject.matches(id));
 	}
 

--- a/hedera-node/src/test/java/com/hedera/services/state/submerkle/FcCustomFeeTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/state/submerkle/FcCustomFeeTest.java
@@ -147,7 +147,7 @@ class FcCustomFeeTest {
 		assertFalse(subject.requiresCollectorAutoAssociation());
 
 		given(royaltyFeeSpec.hasFallbackFee()).willReturn(true);
-		given(royaltyFeeSpec.getFallbackFee()).willReturn(fixedFeeSpec);
+		given(royaltyFeeSpec.fallbackFee()).willReturn(fixedFeeSpec);
 		given(fixedFeeSpec.usedDenomWildcard()).willReturn(true);
 
 		assertTrue(subject.requiresCollectorAutoAssociation());

--- a/hedera-node/src/test/java/com/hedera/services/state/submerkle/FixedFeeSpecTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/state/submerkle/FixedFeeSpecTest.java
@@ -140,7 +140,7 @@ class FixedFeeSpecTest {
 		selfDenomSubject.validateAndFinalizeWith(token, feeCollector, tokenStore);
 
 		verifyNoInteractions(tokenStore);
-		assertEquals(provisionalId.getNum(), selfDenomSubject.getTokenDenomination().num());
+		assertEquals(provisionalId.num(), selfDenomSubject.getTokenDenomination().num());
 		assertTrue(selfDenomSubject.usedDenomWildcard());
 	}
 

--- a/hedera-node/src/test/java/com/hedera/services/state/submerkle/RoyaltyFeeSpecTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/state/submerkle/RoyaltyFeeSpecTest.java
@@ -127,8 +127,8 @@ class RoyaltyFeeSpecTest {
 	void toStringWorks() {
 		final var fallback = new FixedFeeSpec(1, MISSING_ENTITY_ID);
 		final var a = new RoyaltyFeeSpec(1, 10, fallback);
-		final var desired = "RoyaltyFeeSpec{numerator=1, denominator=10, " +
-				"fallbackFee=FixedFeeSpec{unitsToCollect=1, tokenDenomination=0.0.0}}";
+		final var desired = "RoyaltyFeeSpec[numerator=1, denominator=10, " +
+				"fallbackFee=FixedFeeSpec{unitsToCollect=1, tokenDenomination=0.0.0}]";
 
 		assertEquals(desired, a.toString());
 	}

--- a/hedera-node/src/test/java/com/hedera/services/state/submerkle/RoyaltyFeeSpecTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/state/submerkle/RoyaltyFeeSpecTest.java
@@ -117,9 +117,9 @@ class RoyaltyFeeSpecTest {
 		final var fallback = new FixedFeeSpec(1, MISSING_ENTITY_ID);
 		final var a = new RoyaltyFeeSpec(1, 10, fallback);
 
-		assertEquals(1, a.getNumerator());
-		assertEquals(10, a.getDenominator());
-		assertSame(fallback, a.getFallbackFee());
+		assertEquals(1, a.numerator());
+		assertEquals(10, a.denominator());
+		assertSame(fallback, a.fallbackFee());
 		assertTrue(a.hasFallbackFee());
 	}
 

--- a/hedera-node/src/test/java/com/hedera/services/store/models/AccountTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/store/models/AccountTest.java
@@ -9,9 +9,9 @@ package com.hedera.services.store.models;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -51,7 +51,8 @@ class AccountTest {
 	private final long ownedNfts = 5;
 	private final int alreadyUsedAutoAssociations = 123;
 	private final int maxAutoAssociations = 1234;
-	private final int autoAssociationMetadata = buildAutomaticAssociationMetaData(maxAutoAssociations, alreadyUsedAutoAssociations);
+	private final int autoAssociationMetadata = buildAutomaticAssociationMetaData(maxAutoAssociations,
+			alreadyUsedAutoAssociations);
 
 	private Account subject;
 	private OptionValidator validator;
@@ -110,9 +111,10 @@ class AccountTest {
 	@Test
 	void toStringAsExpected() {
 		// given:
-		final var desired = "Account{id=Id{shard=0, realm=0, num=12345}, expiry=0, balance=0, deleted=false, " +
-				"tokens=[0.0.666, 0.0.777], ownedNfts=5, alreadyUsedAutoAssociations=123, maxAutoAssociations=1234, alias=" +
-				subject.getAlias() + "}";
+		final var desired = "Account{id=Id[shard=0, realm=0, num=12345], expiry=0, balance=0, deleted=false, " +
+				"tokens=[0" +
+				".0.666, 0.0.777], ownedNfts=5, alreadyUsedAutoAssociations=123, maxAutoAssociations=1234, " +
+				"alias=" + subject.getAlias() + "}";
 
 		// expect:
 		assertEquals(desired, subject.toString());
@@ -138,7 +140,7 @@ class AccountTest {
 		// then:
 		verify(dissociationRel).updateModelRelsSubjectTo(validator);
 		assertEquals(expectedFinalTokens, assocTokens.toReadableIdList());
-		assertEquals(alreadyUsedAutoAssociations-1, subject.getAlreadyUsedAutomaticAssociations());
+		assertEquals(alreadyUsedAutoAssociations - 1, subject.getAlreadyUsedAutomaticAssociations());
 	}
 
 	@Test
@@ -259,7 +261,7 @@ class AccountTest {
 	void incrementsTheAlreadyUsedAutoAssociationAsExpected() {
 		final var firstNewToken = new Token(new Id(0, 0, 888));
 		subject.setMaxAutomaticAssociations(maxAutoAssociations);
-		subject.setAlreadyUsedAutomaticAssociations(maxAutoAssociations-1);
+		subject.setAlreadyUsedAutomaticAssociations(maxAutoAssociations - 1);
 
 		subject.associateWith(List.of(firstNewToken), 10, true);
 
@@ -269,7 +271,7 @@ class AccountTest {
 	@Test
 	void invalidValuesToAlreadyUsedAutoAssociationsFailAsExpected() {
 		assertFailsWith(
-				() -> subject.setAlreadyUsedAutomaticAssociations(maxAutoAssociations+1),
+				() -> subject.setAlreadyUsedAutomaticAssociations(maxAutoAssociations + 1),
 				NO_REMAINING_AUTOMATIC_ASSOCIATIONS);
 
 		subject.setAlreadyUsedAutomaticAssociations(maxAutoAssociations);

--- a/hedera-node/src/test/java/com/hedera/services/store/models/AccountTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/store/models/AccountTest.java
@@ -114,7 +114,7 @@ class AccountTest {
 		final var desired = "Account{id=Id[shard=0, realm=0, num=12345], expiry=0, balance=0, deleted=false, " +
 				"tokens=[0" +
 				".0.666, 0.0.777], ownedNfts=5, alreadyUsedAutoAssociations=123, maxAutoAssociations=1234, " +
-				"alias=" + subject.getAlias() + "}";
+				"alias=" + subject.getAlias().toStringUtf8() + "}";
 
 		// expect:
 		assertEquals(desired, subject.toString());

--- a/hedera-node/src/test/java/com/hedera/services/store/models/IdTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/store/models/IdTest.java
@@ -100,7 +100,7 @@ class IdTest {
 	void toStringWorks() {
 		final var id = new Id(4, 5, 6);
 
-		assertEquals("Id{shard=4, realm=5, num=6}", id.toString());
+		assertEquals("Id[shard=4, realm=5, num=6]", id.toString());
 	}
 
 	@Test

--- a/hedera-node/src/test/java/com/hedera/services/store/models/IdTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/store/models/IdTest.java
@@ -91,9 +91,9 @@ class IdTest {
 	void gettersWork() {
 		final var id = new Id(11, 22, 33);
 
-		assertEquals(11, id.getShard());
-		assertEquals(22, id.getRealm());
-		assertEquals(33, id.getNum());
+		assertEquals(11, id.shard());
+		assertEquals(22, id.realm());
+		assertEquals(33, id.num());
 	}
 
 	@Test

--- a/hedera-node/src/test/java/com/hedera/services/store/models/NftIdTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/store/models/NftIdTest.java
@@ -23,7 +23,8 @@ package com.hedera.services.store.models;
 import com.hederahashgraph.api.proto.java.TokenID;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 class NftIdTest {
 	private long shard = 1;
@@ -63,7 +64,7 @@ class NftIdTest {
 	@Test
 	void toStringWorks() {
 		// setup:
-		final var desired = "NftId{shard=1, realm=2, num=3, serialNo=4}";
+		final var desired = "NftId[shard=1, realm=2, num=3, serialNo=4]";
 
 		// given:
 		final var subject = new NftId(shard, realm, num, serialNo);

--- a/hedera-node/src/test/java/com/hedera/services/store/models/TokenRelationshipTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/store/models/TokenRelationshipTest.java
@@ -97,16 +97,12 @@ class TokenRelationshipTest {
 	@Test
 	void toStringAsExpected() {
 		// given:
-		final var desired = "TokenRelationship{notYetPersisted=true, account=Account{id=Id[shard=1, realm=0, " +
-				"num=4321]," +
+		final var desired = "TokenRelationship{notYetPersisted=true, account=Account{id=Id[shard=1, realm=0, num=4321]," +
 				" expiry=0, balance=0, deleted=false, tokens=<N/A>, ownedNfts=0, alreadyUsedAutoAssociations=0, " +
-				"maxAutoAssociations=0, alias=<ByteString@6c372fe6 size=0 contents=\"\">}, token=Token{id=Id[shard=0," +
-				" " +
-				"realm=0, num=1234], type=null, deleted=false, autoRemoved=false, treasury=null, " +
-				"autoRenewAccount=null," +
-				" kycKey=<N/A>, freezeKey=<N/A>, frozenByDefault=false, supplyKey=<N/A>, currentSerialNumber=0, " +
-				"pauseKey=<N/A>, paused=false}, balance=1234, balanceChange=0, frozen=false, kycGranted=false, " +
-				"isAutomaticAssociation=false}";
+				"maxAutoAssociations=0, alias=}, token=Token{id=Id[shard=0, realm=0, num=1234], type=null, " +
+				"deleted=false, autoRemoved=false, treasury=null, autoRenewAccount=null, kycKey=<N/A>, freezeKey=<N/A>," +
+				" frozenByDefault=false, supplyKey=<N/A>, currentSerialNumber=0, pauseKey=<N/A>, paused=false}, " +
+				"balance=1234, balanceChange=0, frozen=false, kycGranted=false, isAutomaticAssociation=false}";
 
 		// expect:
 		assertEquals(desired, subject.toString());

--- a/hedera-node/src/test/java/com/hedera/services/store/models/TokenRelationshipTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/store/models/TokenRelationshipTest.java
@@ -62,7 +62,7 @@ class TokenRelationshipTest {
 	@Test
 	void ofRecordInterestIfFungibleBalanceChanges() {
 		token.setType(TokenType.FUNGIBLE_COMMON);
-		
+
 		subject.setBalance(balance - 1);
 
 		assertTrue(subject.hasChangesForRecord());
@@ -97,12 +97,15 @@ class TokenRelationshipTest {
 	@Test
 	void toStringAsExpected() {
 		// given:
-		final var desired = "TokenRelationship{notYetPersisted=true, account=Account{id=Id{shard=1, realm=0, num=4321}," +
+		final var desired = "TokenRelationship{notYetPersisted=true, account=Account{id=Id[shard=1, realm=0, " +
+				"num=4321]," +
 				" expiry=0, balance=0, deleted=false, tokens=<N/A>, ownedNfts=0, alreadyUsedAutoAssociations=0, " +
-				"maxAutoAssociations=0, alias=" + account.getAlias() + "}, token=Token{id=Id{shard=0, realm=0, num=1234}, " +
-				"type=null, deleted=false, autoRemoved=false, treasury=null, autoRenewAccount=null, kycKey=<N/A>, " +
-				"freezeKey=<N/A>, frozenByDefault=false, supplyKey=<N/A>, currentSerialNumber=0, pauseKey=<N/A>," +
-				" paused=false}, balance=1234, balanceChange=0, frozen=false, kycGranted=false, " +
+				"maxAutoAssociations=0, alias=<ByteString@6c372fe6 size=0 contents=\"\">}, token=Token{id=Id[shard=0," +
+				" " +
+				"realm=0, num=1234], type=null, deleted=false, autoRemoved=false, treasury=null, " +
+				"autoRenewAccount=null," +
+				" kycKey=<N/A>, freezeKey=<N/A>, frozenByDefault=false, supplyKey=<N/A>, currentSerialNumber=0, " +
+				"pauseKey=<N/A>, paused=false}, balance=1234, balanceChange=0, frozen=false, kycGranted=false, " +
 				"isAutomaticAssociation=false}";
 
 		// expect:

--- a/hedera-node/src/test/java/com/hedera/services/store/models/TokenTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/store/models/TokenTest.java
@@ -106,7 +106,7 @@ class TokenTest {
 		assertFalse(subject.hasFeeScheduleKey());
 
 		subject.setFeeScheduleKey(TxnHandlingScenario.TOKEN_FEE_SCHEDULE_KT.asJKeyUnchecked());
-		
+
 		assertTrue(subject.hasFeeScheduleKey());
 	}
 
@@ -161,7 +161,7 @@ class TokenTest {
 						.setFeeScheduleKey(feeScheduleKey)
 						.setPauseKey(pauseKey)
 						.addAllCustomFees(List.of(CustomFee.newBuilder().setFixedFee(
-								FixedFee.newBuilder().setAmount(10).build())
+										FixedFee.newBuilder().setAmount(10).build())
 								.setFeeCollectorAccountId(IdUtils.asAccount("1.2.3")).build()))
 						.setAutoRenewAccount(nonTreasuryAccount.getId().asGrpcAccount())
 						.setExpiry(Timestamp.newBuilder().setSeconds(1000L).build())
@@ -602,11 +602,12 @@ class TokenTest {
 
 	@Test
 	void toStringWorks() {
-		final var desired = "Token{id=Id{shard=1, realm=2, num=3}, type=null, deleted=false, autoRemoved=false, " +
-				"treasury=Account{id=Id{shard=0, realm=0, num=0}, expiry=0, balance=0, deleted=false, tokens=<N/A>, " +
-				"ownedNfts=0, alreadyUsedAutoAssociations=0, maxAutoAssociations=0, alias=" + treasuryAccount.getAlias() +
-				"}, autoRenewAccount=null, kycKey=<N/A>, freezeKey=<N/A>, frozenByDefault=false, supplyKey=<N/A>, " +
-				"currentSerialNumber=0, pauseKey=<N/A>, paused=false}";
+		final var desired = "Token{id=Id[shard=1, realm=2, num=3], type=null, deleted=false, autoRemoved=false, " +
+				"treasury=Account{id=Id[shard=0, realm=0, num=0], expiry=0, balance=0, deleted=false, tokens=<N/A>, " +
+				"ownedNfts=0, alreadyUsedAutoAssociations=0, maxAutoAssociations=0, alias=<ByteString@11d8ae8b size=0" +
+				" " +
+				"contents=\"\">}, autoRenewAccount=null, kycKey=<N/A>, freezeKey=<N/A>, frozenByDefault=false, " +
+				"supplyKey=<N/A>, currentSerialNumber=0, pauseKey=<N/A>, paused=false}";
 
 		assertEquals(desired, subject.toString());
 	}

--- a/hedera-node/src/test/java/com/hedera/services/store/models/TokenTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/store/models/TokenTest.java
@@ -604,10 +604,9 @@ class TokenTest {
 	void toStringWorks() {
 		final var desired = "Token{id=Id[shard=1, realm=2, num=3], type=null, deleted=false, autoRemoved=false, " +
 				"treasury=Account{id=Id[shard=0, realm=0, num=0], expiry=0, balance=0, deleted=false, tokens=<N/A>, " +
-				"ownedNfts=0, alreadyUsedAutoAssociations=0, maxAutoAssociations=0, alias=<ByteString@11d8ae8b size=0" +
-				" " +
-				"contents=\"\">}, autoRenewAccount=null, kycKey=<N/A>, freezeKey=<N/A>, frozenByDefault=false, " +
-				"supplyKey=<N/A>, currentSerialNumber=0, pauseKey=<N/A>, paused=false}";
+				"ownedNfts=0, alreadyUsedAutoAssociations=0, maxAutoAssociations=0, alias=}, autoRenewAccount=null, " +
+				"kycKey=<N/A>, freezeKey=<N/A>, frozenByDefault=false, supplyKey=<N/A>, currentSerialNumber=0, " +
+				"pauseKey=<N/A>, paused=false}";
 
 		assertEquals(desired, subject.toString());
 	}

--- a/hedera-node/src/test/java/com/hedera/services/store/models/TopicConversionTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/store/models/TopicConversionTest.java
@@ -69,7 +69,7 @@ class TopicConversionTest {
 		model.setAutoRenewAccountId(EntityId.MISSING_ENTITY_ID.asId());
 
 		final var mappedMerkle = TopicConversion.fromModel(model);
-		assertEquals(Id.DEFAULT.getNum(), mappedMerkle.getKey().longValue());
+		assertEquals(Id.DEFAULT.num(), mappedMerkle.getKey().longValue());
 		assertEquals(10, mappedMerkle.getSequenceNumber());
 		assertEquals("memo", mappedMerkle.getMemo());
 		assertEquals(SUBMIT_KEY, mappedMerkle.getSubmitKey());

--- a/hedera-node/src/test/java/com/hedera/services/store/schedule/HederaScheduleStoreTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/store/schedule/HederaScheduleStoreTest.java
@@ -264,8 +264,8 @@ class HederaScheduleStoreTest {
 
 		final var outcome = subject.createProvisionally(expected, consensusTime);
 
-		assertEquals(OK, outcome.getStatus());
-		assertEquals(created, outcome.getCreated());
+		assertEquals(OK, outcome.status());
+		assertEquals(created, outcome.created());
 		assertEquals(created, subject.pendingId);
 		assertSame(expected, subject.pendingCreation);
 		assertEquals(expectedExpiry, expected.expiry());
@@ -283,8 +283,8 @@ class HederaScheduleStoreTest {
 		final var outcome = subject.createProvisionally(
 				MerkleSchedule.from(parentTxn.toByteArray(), 0L), consensusTime);
 
-		assertEquals(INVALID_SCHEDULE_PAYER_ID, outcome.getStatus());
-		assertNull(outcome.getCreated());
+		assertEquals(INVALID_SCHEDULE_PAYER_ID, outcome.status());
+		assertNull(outcome.created());
 	}
 
 	@Test
@@ -479,8 +479,8 @@ class HederaScheduleStoreTest {
 		final var outcome = subject.createProvisionally(
 				MerkleSchedule.from(parentTxn.toByteArray(), 0L), consensusTime);
 
-		assertEquals(expectedCode, outcome.getStatus());
-		assertNull(outcome.getCreated());
+		assertEquals(expectedCode, outcome.status());
+		assertNull(outcome.created());
 		assertNull(subject.pendingCreation);
 		assertEquals(ScheduleID.getDefaultInstance(), subject.pendingId);
 	}

--- a/hedera-node/src/test/java/com/hedera/services/store/tokens/views/AbstractUniqTokenViewTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/store/tokens/views/AbstractUniqTokenViewTest.java
@@ -24,9 +24,9 @@ import com.hedera.services.state.merkle.MerkleToken;
 import com.hedera.services.state.merkle.MerkleUniqueToken;
 import com.hedera.services.state.submerkle.EntityId;
 import com.hedera.services.state.submerkle.RichInstant;
+import com.hedera.services.store.tokens.views.utils.GrpcUtils;
 import com.hedera.services.utils.EntityNum;
 import com.hedera.services.utils.EntityNumPair;
-import com.hedera.services.store.tokens.views.utils.GrpcUtils;
 import com.hederahashgraph.api.proto.java.AccountID;
 import com.hederahashgraph.api.proto.java.TokenID;
 import com.hederahashgraph.api.proto.java.TokenNftInfo;
@@ -123,8 +123,8 @@ class AbstractUniqTokenViewTest {
 	private void setupFirstMockRange() {
 		willAnswer(invocationOnMock -> {
 			final Consumer<Long> consumer = invocationOnMock.getArgument(0);
-			consumer.accept(someExplicitNftId.getValue());
-			consumer.accept(wildcardNftId.getValue());
+			consumer.accept(someExplicitNftId.value());
+			consumer.accept(wildcardNftId.value());
 			return null;
 		}).given(firstMockRange).forEachRemaining(any());
 	}

--- a/hedera-node/src/test/java/com/hedera/services/store/tokens/views/ExplicitOwnersUniqTokenViewTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/store/tokens/views/ExplicitOwnersUniqTokenViewTest.java
@@ -24,9 +24,9 @@ import com.hedera.services.state.merkle.MerkleToken;
 import com.hedera.services.state.merkle.MerkleUniqueToken;
 import com.hedera.services.state.submerkle.EntityId;
 import com.hedera.services.state.submerkle.RichInstant;
+import com.hedera.services.store.tokens.views.utils.GrpcUtils;
 import com.hedera.services.utils.EntityNum;
 import com.hedera.services.utils.EntityNumPair;
-import com.hedera.services.store.tokens.views.utils.GrpcUtils;
 import com.hederahashgraph.api.proto.java.AccountID;
 import com.swirlds.fchashmap.FCOneToManyRelation;
 import com.swirlds.merkle.map.MerkleMap;
@@ -86,8 +86,8 @@ class ExplicitOwnersUniqTokenViewTest {
 	private void setupFirstMockRange() {
 		willAnswer(invocationOnMock -> {
 			final Consumer<Long> consumer = invocationOnMock.getArgument(0);
-			consumer.accept(someExplicitNftId.getValue());
-			consumer.accept(wildcardNftId.getValue());
+			consumer.accept(someExplicitNftId.value());
+			consumer.accept(wildcardNftId.value());
 			return null;
 		}).given(firstMockRange).forEachRemaining(any());
 	}

--- a/hedera-node/src/test/java/com/hedera/services/store/tokens/views/TreasuryWildcardsUniqTokenViewTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/store/tokens/views/TreasuryWildcardsUniqTokenViewTest.java
@@ -25,9 +25,9 @@ import com.hedera.services.state.merkle.MerkleUniqueToken;
 import com.hedera.services.state.submerkle.EntityId;
 import com.hedera.services.state.submerkle.RichInstant;
 import com.hedera.services.store.tokens.TokenStore;
+import com.hedera.services.store.tokens.views.utils.GrpcUtils;
 import com.hedera.services.utils.EntityNum;
 import com.hedera.services.utils.EntityNumPair;
-import com.hedera.services.store.tokens.views.utils.GrpcUtils;
 import com.hederahashgraph.api.proto.java.AccountID;
 import com.hederahashgraph.api.proto.java.TokenNftInfo;
 import com.swirlds.fchashmap.FCOneToManyRelation;
@@ -127,7 +127,7 @@ class TreasuryWildcardsUniqTokenViewTest {
 				.willReturn(List.of(treasuryTokenId.toGrpcTokenId()));
 
 		// when:
-		final var actual = subject.ownedAssociations(grpcOwnerId, start, end+1);
+		final var actual = subject.ownedAssociations(grpcOwnerId, start, end + 1);
 
 		// then:
 		Assertions.assertEquals(List.of(explicitInfo, interpolatedInfo, treasuryInfo), actual);
@@ -136,8 +136,8 @@ class TreasuryWildcardsUniqTokenViewTest {
 	private void setupFirstMockRange() {
 		willAnswer(invocationOnMock -> {
 			final Consumer<Long> consumer = invocationOnMock.getArgument(0);
-			consumer.accept(someExplicitNftId.getValue());
-			consumer.accept(wildcardNftId.getValue());
+			consumer.accept(someExplicitNftId.value());
+			consumer.accept(wildcardNftId.value());
 			return null;
 		}).given(firstMockRange).forEachRemaining(any());
 	}
@@ -145,7 +145,7 @@ class TreasuryWildcardsUniqTokenViewTest {
 	private void setupSecondMockRange() {
 		willAnswer(invocationOnMock -> {
 			final Consumer<Long> consumer = invocationOnMock.getArgument(0);
-			consumer.accept(otherWildcardNftId.getValue());
+			consumer.accept(otherWildcardNftId.value());
 			return null;
 		}).given(secondMockRange).forEachRemaining(any());
 	}

--- a/hedera-node/src/test/java/com/hedera/services/store/tokens/views/UniqTokenViewsManagerTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/store/tokens/views/UniqTokenViewsManagerTest.java
@@ -449,7 +449,7 @@ class UniqTokenViewsManagerTest {
 	@Test
 	void toStringAsExpected() {
 		// setup:
-		final var desired = "PendingChange{targetFcotmr=NFTS_BY_TYPE, keyCode=1, valueCode=2, associate=true}";
+		final var desired = "PendingChange[targetFcotmr=NFTS_BY_TYPE, keyCode=1, valueCode=2, associate=true]";
 
 		// given:
 		final var c = change(NFTS_BY_TYPE, 1, 2L, true);

--- a/hedera-node/src/test/java/com/hedera/services/store/tokens/views/UniqTokenViewsManagerTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/store/tokens/views/UniqTokenViewsManagerTest.java
@@ -197,8 +197,8 @@ class UniqTokenViewsManagerTest {
 		subject.treasuryExitNotice(aOneNftId, firstOwner, secondOwner);
 
 		// then:
-		verify(nftsByOwner).disassociate(asPhi(firstOwner.identityCode()), aOneNftId.getValue());
-		verify(nftsByOwner).associate(asPhi(secondOwner.identityCode()), aOneNftId.getValue());
+		verify(nftsByOwner).disassociate(asPhi(firstOwner.identityCode()), aOneNftId.value());
+		verify(nftsByOwner).associate(asPhi(secondOwner.identityCode()), aOneNftId.value());
 	}
 
 	@Test
@@ -212,15 +212,15 @@ class UniqTokenViewsManagerTest {
 		subject.treasuryExitNotice(aOneNftId, firstOwner, secondOwner);
 
 		// then:
-		verify(nftsByOwner, never()).disassociate(asPhi(firstOwner.identityCode()), aOneNftId.getValue());
-		verify(nftsByOwner, never()).associate(asPhi(secondOwner.identityCode()), aOneNftId.getValue());
+		verify(nftsByOwner, never()).disassociate(asPhi(firstOwner.identityCode()), aOneNftId.value());
+		verify(nftsByOwner, never()).associate(asPhi(secondOwner.identityCode()), aOneNftId.value());
 
 		// and when:
 		subject.commit();
 
 		// then:
-		verify(nftsByOwner).disassociate(asPhi(firstOwner.identityCode()), aOneNftId.getValue());
-		verify(nftsByOwner).associate(asPhi(secondOwner.identityCode()), aOneNftId.getValue());
+		verify(nftsByOwner).disassociate(asPhi(firstOwner.identityCode()), aOneNftId.value());
+		verify(nftsByOwner).associate(asPhi(secondOwner.identityCode()), aOneNftId.value());
 	}
 
 	@Test
@@ -231,8 +231,8 @@ class UniqTokenViewsManagerTest {
 		subject.treasuryExitNotice(aOneNftId, firstOwner, secondOwner);
 
 		// then:
-		verify(treasuryNftsByType).disassociate(asPhi(aTokenId.identityCode()), aOneNftId.getValue());
-		verify(nftsByOwner).associate(asPhi(secondOwner.identityCode()), aOneNftId.getValue());
+		verify(treasuryNftsByType).disassociate(asPhi(aTokenId.identityCode()), aOneNftId.value());
+		verify(nftsByOwner).associate(asPhi(secondOwner.identityCode()), aOneNftId.value());
 	}
 
 	@Test
@@ -243,8 +243,8 @@ class UniqTokenViewsManagerTest {
 		subject.treasuryReturnNotice(aOneNftId, firstOwner, secondOwner);
 
 		// then:
-		verify(nftsByOwner).disassociate(asPhi(firstOwner.identityCode()), aOneNftId.getValue());
-		verify(nftsByOwner).associate(asPhi(secondOwner.identityCode()), aOneNftId.getValue());
+		verify(nftsByOwner).disassociate(asPhi(firstOwner.identityCode()), aOneNftId.value());
+		verify(nftsByOwner).associate(asPhi(secondOwner.identityCode()), aOneNftId.value());
 	}
 
 	@Test
@@ -255,8 +255,8 @@ class UniqTokenViewsManagerTest {
 		subject.treasuryReturnNotice(aOneNftId, firstOwner, secondOwner);
 
 		// then:
-		verify(nftsByOwner).disassociate(asPhi(firstOwner.identityCode()), aOneNftId.getValue());
-		verify(treasuryNftsByType).associate(asPhi(aTokenId.identityCode()), aOneNftId.getValue());
+		verify(nftsByOwner).disassociate(asPhi(firstOwner.identityCode()), aOneNftId.value());
+		verify(treasuryNftsByType).associate(asPhi(aTokenId.identityCode()), aOneNftId.value());
 	}
 
 	@Test
@@ -270,15 +270,15 @@ class UniqTokenViewsManagerTest {
 		subject.treasuryReturnNotice(aOneNftId, firstOwner, secondOwner);
 
 		// then:
-		verify(nftsByOwner, never()).disassociate(asPhi(firstOwner.identityCode()), aOneNftId.getValue());
-		verify(treasuryNftsByType, never()).associate(asPhi(aTokenId.identityCode()), aOneNftId.getValue());
+		verify(nftsByOwner, never()).disassociate(asPhi(firstOwner.identityCode()), aOneNftId.value());
+		verify(treasuryNftsByType, never()).associate(asPhi(aTokenId.identityCode()), aOneNftId.value());
 
 		// and when:
 		subject.commit();
 
 		// then:
-		verify(nftsByOwner).disassociate(asPhi(firstOwner.identityCode()), aOneNftId.getValue());
-		verify(treasuryNftsByType).associate(asPhi(aTokenId.identityCode()), aOneNftId.getValue());
+		verify(nftsByOwner).disassociate(asPhi(firstOwner.identityCode()), aOneNftId.value());
+		verify(treasuryNftsByType).associate(asPhi(aTokenId.identityCode()), aOneNftId.value());
 	}
 
 	@Test
@@ -289,8 +289,8 @@ class UniqTokenViewsManagerTest {
 		subject.exchangeNotice(aOneNftId, firstOwner, secondOwner);
 
 		// then:
-		verify(nftsByOwner).disassociate(asPhi(firstOwner.identityCode()), aOneNftId.getValue());
-		verify(nftsByOwner).associate(asPhi(secondOwner.identityCode()), aOneNftId.getValue());
+		verify(nftsByOwner).disassociate(asPhi(firstOwner.identityCode()), aOneNftId.value());
+		verify(nftsByOwner).associate(asPhi(secondOwner.identityCode()), aOneNftId.value());
 	}
 
 	@Test
@@ -301,8 +301,8 @@ class UniqTokenViewsManagerTest {
 		subject.exchangeNotice(aOneNftId, firstOwner, secondOwner);
 
 		// then:
-		verify(nftsByOwner).disassociate(asPhi(firstOwner.identityCode()), aOneNftId.getValue());
-		verify(nftsByOwner).associate(asPhi(secondOwner.identityCode()), aOneNftId.getValue());
+		verify(nftsByOwner).disassociate(asPhi(firstOwner.identityCode()), aOneNftId.value());
+		verify(nftsByOwner).associate(asPhi(secondOwner.identityCode()), aOneNftId.value());
 	}
 
 	@Test
@@ -315,15 +315,15 @@ class UniqTokenViewsManagerTest {
 		// when:
 		subject.exchangeNotice(aOneNftId, firstOwner, secondOwner);
 		// then:
-		verify(nftsByOwner, never()).disassociate(asPhi(firstOwner.identityCode()), aOneNftId.getValue());
-		verify(nftsByOwner, never()).associate(asPhi(secondOwner.identityCode()), aOneNftId.getValue());
+		verify(nftsByOwner, never()).disassociate(asPhi(firstOwner.identityCode()), aOneNftId.value());
+		verify(nftsByOwner, never()).associate(asPhi(secondOwner.identityCode()), aOneNftId.value());
 
 		// and when:
 		subject.commit();
 
 		// then:
-		verify(nftsByOwner).disassociate(EntityNum.fromLong(firstOwner.num()), aOneNftId.getValue());
-		verify(nftsByOwner).associate(EntityNum.fromLong(secondOwner.num()), aOneNftId.getValue());
+		verify(nftsByOwner).disassociate(EntityNum.fromLong(firstOwner.num()), aOneNftId.value());
+		verify(nftsByOwner).associate(EntityNum.fromLong(secondOwner.num()), aOneNftId.value());
 	}
 
 	@Test
@@ -334,8 +334,8 @@ class UniqTokenViewsManagerTest {
 		subject.burnNotice(aOneNftId, firstOwner);
 
 		// then:
-		verify(nftsByType).disassociate(EntityNum.fromLong(aTokenId.num()), aOneNftId.getValue());
-		verify(nftsByOwner).disassociate(EntityNum.fromLong(firstOwner.num()), aOneNftId.getValue());
+		verify(nftsByType).disassociate(EntityNum.fromLong(aTokenId.num()), aOneNftId.value());
+		verify(nftsByOwner).disassociate(EntityNum.fromLong(firstOwner.num()), aOneNftId.value());
 	}
 
 	@Test
@@ -346,8 +346,8 @@ class UniqTokenViewsManagerTest {
 		subject.burnNotice(aOneNftId, firstOwner);
 
 		// then:
-		verify(nftsByType).disassociate(EntityNum.fromLong(aTokenId.num()), aOneNftId.getValue());
-		verify(treasuryNftsByType).disassociate(EntityNum.fromLong(aTokenId.num()), aOneNftId.getValue());
+		verify(nftsByType).disassociate(EntityNum.fromLong(aTokenId.num()), aOneNftId.value());
+		verify(treasuryNftsByType).disassociate(EntityNum.fromLong(aTokenId.num()), aOneNftId.value());
 	}
 
 	@Test
@@ -358,8 +358,8 @@ class UniqTokenViewsManagerTest {
 		subject.mintNotice(aOneNftId, firstOwner);
 
 		// then:
-		verify(nftsByType).associate(EntityNum.fromLong(aTokenId.num()), aOneNftId.getValue());
-		verify(nftsByOwner).associate(EntityNum.fromLong(firstOwner.num()), aOneNftId.getValue());
+		verify(nftsByType).associate(EntityNum.fromLong(aTokenId.num()), aOneNftId.value());
+		verify(nftsByOwner).associate(EntityNum.fromLong(firstOwner.num()), aOneNftId.value());
 	}
 
 	@Test
@@ -370,8 +370,8 @@ class UniqTokenViewsManagerTest {
 		subject.mintNotice(aOneNftId, firstOwner);
 
 		// then:
-		verify(nftsByType).associate(EntityNum.fromLong(aTokenId.identityCode()), aOneNftId.getValue());
-		verify(treasuryNftsByType).associate(EntityNum.fromLong(aTokenId.identityCode()), aOneNftId.getValue());
+		verify(nftsByType).associate(EntityNum.fromLong(aTokenId.identityCode()), aOneNftId.value());
+		verify(treasuryNftsByType).associate(EntityNum.fromLong(aTokenId.identityCode()), aOneNftId.value());
 	}
 
 	@Test
@@ -382,8 +382,8 @@ class UniqTokenViewsManagerTest {
 		subject.wipeNotice(aOneNftId, firstOwner);
 
 		// then:
-		verify(nftsByType).disassociate(EntityNum.fromLong(aTokenId.num()), aOneNftId.getValue());
-		verify(nftsByOwner).disassociate(EntityNum.fromLong(firstOwner.num()), aOneNftId.getValue());
+		verify(nftsByType).disassociate(EntityNum.fromLong(aTokenId.num()), aOneNftId.value());
+		verify(nftsByOwner).disassociate(EntityNum.fromLong(firstOwner.num()), aOneNftId.value());
 	}
 
 	@Test
@@ -394,8 +394,8 @@ class UniqTokenViewsManagerTest {
 		subject.wipeNotice(aOneNftId, firstOwner);
 
 		// then:
-		verify(nftsByType).disassociate(EntityNum.fromLong(aTokenId.num()), aOneNftId.getValue());
-		verify(nftsByOwner).disassociate(EntityNum.fromLong(firstOwner.num()), aOneNftId.getValue());
+		verify(nftsByType).disassociate(EntityNum.fromLong(aTokenId.num()), aOneNftId.value());
+		verify(nftsByOwner).disassociate(EntityNum.fromLong(firstOwner.num()), aOneNftId.value());
 	}
 
 	@Test
@@ -412,11 +412,11 @@ class UniqTokenViewsManagerTest {
 		subject.rebuildNotice(realTokens, realNfts);
 
 		// then:
-		verify(nftsByType).associate(EntityNum.fromLong(aTokenId.num()), aOneNftId.getValue());
-		verify(treasuryNftsByType).associate(EntityNum.fromLong(aTokenId.num()), aOneNftId.getValue());
+		verify(nftsByType).associate(EntityNum.fromLong(aTokenId.num()), aOneNftId.value());
+		verify(treasuryNftsByType).associate(EntityNum.fromLong(aTokenId.num()), aOneNftId.value());
 		// and:
-		verify(nftsByType).associate(EntityNum.fromLong(bTokenId.num()), bOneNftId.getValue());
-		verify(nftsByOwner).associate(EntityNum.fromLong(firstOwner.num()), bOneNftId.getValue());
+		verify(nftsByType).associate(EntityNum.fromLong(bTokenId.num()), bOneNftId.value());
+		verify(nftsByOwner).associate(EntityNum.fromLong(firstOwner.num()), bOneNftId.value());
 		// and:
 		verifyNoMoreInteractions(nftsByType);
 		verifyNoMoreInteractions(treasuryNftsByType);
@@ -436,11 +436,11 @@ class UniqTokenViewsManagerTest {
 		subject.rebuildNotice(realTokens, realNfts);
 
 		// then:
-		verify(nftsByType).associate(EntityNum.fromLong(aTokenId.num()), aOneNftId.getValue());
-		verify(nftsByOwner).associate(EntityNum.fromLong(firstOwner.num()), aOneNftId.getValue());
+		verify(nftsByType).associate(EntityNum.fromLong(aTokenId.num()), aOneNftId.value());
+		verify(nftsByOwner).associate(EntityNum.fromLong(firstOwner.num()), aOneNftId.value());
 		// and:
-		verify(nftsByType).associate(EntityNum.fromLong(bTokenId.num()), bOneNftId.getValue());
-		verify(nftsByOwner).associate(EntityNum.fromLong(firstOwner.num()), bOneNftId.getValue());
+		verify(nftsByType).associate(EntityNum.fromLong(bTokenId.num()), bOneNftId.value());
+		verify(nftsByOwner).associate(EntityNum.fromLong(firstOwner.num()), bOneNftId.value());
 		// and:
 		verifyNoMoreInteractions(nftsByType);
 		verifyNoMoreInteractions(nftsByOwner);
@@ -489,13 +489,13 @@ class UniqTokenViewsManagerTest {
 				() -> nftsByType, () -> nftsByOwner, () -> treasuryNftsByType, true, false);
 	}
 
-	private UniqTokenViewsManager.PendingChange change(
+	private PendingChange change(
 			UniqTokenViewsManager.TargetFcotmr target,
 			int keyCode,
 			long valueCode,
 			boolean associate
 	) {
-		return new UniqTokenViewsManager.PendingChange(target, keyCode, valueCode, associate);
+		return new PendingChange(target, keyCode, valueCode, associate);
 	}
 
 	private final EntityId firstOwner = new EntityId(0, 0, 3);

--- a/hedera-node/src/test/java/com/hedera/services/txns/contract/ContractCreateTransitionLogicTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/txns/contract/ContractCreateTransitionLogicTest.java
@@ -264,7 +264,7 @@ class ContractCreateTransitionLogicTest {
 		final var accountKey = standin.getAccountKey();
 		assertThat(accountKey, instanceOf(JContractIDKey.class));
 		assertEquals(
-				contractAccount.getId().getNum(),
+				contractAccount.getId().num(),
 				((JContractIDKey) accountKey).getContractID().getContractNum());
 	}
 

--- a/hedera-node/src/test/java/com/hedera/services/txns/customfees/FcmCustomFeeSchedulesTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/txns/customfees/FcmCustomFeeSchedulesTest.java
@@ -45,10 +45,10 @@ class FcmCustomFeeSchedulesTest {
 
 	private final EntityId aTreasury = new EntityId(0, 0, 12);
 	private final EntityId bTreasury = new EntityId(0, 0, 13);
-	private final EntityId tokenA = new EntityId(0,0,1);
-	private final EntityId tokenB = new EntityId(0,0,2);
-	private final EntityId feeCollector = new EntityId(0,0,3);
-	private final EntityId missingToken = new EntityId(0,0,4);
+	private final EntityId tokenA = new EntityId(0, 0, 1);
+	private final EntityId tokenB = new EntityId(0, 0, 2);
+	private final EntityId feeCollector = new EntityId(0, 0, 3);
+	private final EntityId missingToken = new EntityId(0, 0, 4);
 	private final MerkleToken aToken = new MerkleToken();
 	private final MerkleToken bToken = new MerkleToken();
 
@@ -75,11 +75,11 @@ class FcmCustomFeeSchedulesTest {
 		final var missingTokenFees = subject.lookupMetaFor(missingToken.asId());
 
 		// expect:
-		assertEquals(aToken.customFeeSchedule(), tokenAFees.getCustomFees());
-		assertEquals(aTreasury, tokenAFees.getTreasuryId().asEntityId());
-		assertEquals(bToken.customFeeSchedule(), tokenBFees.getCustomFees());
-		assertEquals(bTreasury, tokenBFees.getTreasuryId().asEntityId());
-		assertSame(Collections.emptyList(), missingTokenFees.getCustomFees());
+		assertEquals(aToken.customFeeSchedule(), tokenAFees.customFees());
+		assertEquals(aTreasury, tokenAFees.treasuryId().asEntityId());
+		assertEquals(bToken.customFeeSchedule(), tokenBFees.customFees());
+		assertEquals(bTreasury, tokenBFees.treasuryId().asEntityId());
+		assertSame(Collections.emptyList(), missingTokenFees.customFees());
 	}
 
 	@Test

--- a/hedera-node/src/test/java/com/hedera/services/txns/file/FileAppendTransitionLogicTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/txns/file/FileAppendTransitionLogicTest.java
@@ -27,6 +27,7 @@ import com.hedera.services.context.TransactionContext;
 import com.hedera.services.context.primitives.StateView;
 import com.hedera.services.files.HFileMeta;
 import com.hedera.services.files.HederaFs;
+import com.hedera.services.files.SimpleUpdateResult;
 import com.hedera.services.files.TieredHederaFs;
 import com.hedera.services.legacy.core.jproto.JKey;
 import com.hedera.services.state.merkle.MerkleNetworkContext;
@@ -55,9 +56,9 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.MAX_FILE_SIZE_
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.PREPARED_UPDATE_FILE_IS_IMMUTABLE;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SUCCESS;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.UNAUTHORIZED;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.BDDMockito.any;
 import static org.mockito.BDDMockito.argThat;
 import static org.mockito.BDDMockito.given;
@@ -76,11 +77,11 @@ class FileAppendTransitionLogicTest {
 	FileID immutable = IdUtils.asFile("0.0.667");
 	FileID special = IdUtils.asFile("0.0.150");
 
-	HederaFs.UpdateResult success = new TieredHederaFs.SimpleUpdateResult(
+	HederaFs.UpdateResult success = new SimpleUpdateResult(
 			false,
 			true,
 			SUCCESS);
-	HederaFs.UpdateResult okWithCaveat = new TieredHederaFs.SimpleUpdateResult(
+	HederaFs.UpdateResult okWithCaveat = new SimpleUpdateResult(
 			false,
 			true,
 			ResponseCodeEnum.FEE_SCHEDULE_FILE_PART_UPLOADED);

--- a/hedera-node/src/test/java/com/hedera/services/txns/file/FileSysDelTransitionLogicTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/txns/file/FileSysDelTransitionLogicTest.java
@@ -9,9 +9,9 @@ package com.hedera.services.txns.file;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -23,7 +23,7 @@ package com.hedera.services.txns.file;
 import com.hedera.services.context.TransactionContext;
 import com.hedera.services.files.HFileMeta;
 import com.hedera.services.files.HederaFs;
-import com.hedera.services.files.TieredHederaFs;
+import com.hedera.services.files.SimpleUpdateResult;
 import com.hedera.services.legacy.core.jproto.JKey;
 import com.hedera.services.state.submerkle.EntityId;
 import com.hedera.services.utils.MiscUtils;
@@ -48,9 +48,9 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.FAIL_INVALID;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.FILE_DELETED;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_FILE_ID;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SUCCESS;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.BDDMockito.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.inOrder;
@@ -60,8 +60,9 @@ import static org.mockito.BDDMockito.verify;
 import static org.mockito.BDDMockito.willThrow;
 
 class FileSysDelTransitionLogicTest {
-	enum TargetType { VALID, MISSING, DELETED }
-	enum NewExpiryType { NONE, FUTURE, PAST }
+	enum TargetType {VALID, MISSING, DELETED}
+
+	enum NewExpiryType {NONE, FUTURE, PAST}
 
 	long now = Instant.now().getEpochSecond();
 	long lifetime = 1_000_000L;
@@ -72,7 +73,7 @@ class FileSysDelTransitionLogicTest {
 	FileID missing = IdUtils.asFile("0.0.75231");
 	FileID deleted = IdUtils.asFile("0.0.666");
 
-	HederaFs.UpdateResult success = new TieredHederaFs.SimpleUpdateResult(
+	HederaFs.UpdateResult success = new SimpleUpdateResult(
 			true,
 			false,
 			SUCCESS);
@@ -135,7 +136,8 @@ class FileSysDelTransitionLogicTest {
 		subject.doStateTransition();
 
 		// then:
-		assertTrue(attr.isDeleted());;
+		assertTrue(attr.isDeleted());
+		;
 		assertEquals(oldExpiry, attr.getExpiry());
 		inOrder.verify(hfs).setattr(tbd, attr);
 		inOrder.verify(oldExpiries).put(EntityId.fromGrpcFileId(tbd), Long.valueOf(oldExpiry));
@@ -167,7 +169,8 @@ class FileSysDelTransitionLogicTest {
 		subject.doStateTransition();
 
 		// then:
-		assertTrue(attr.isDeleted());;
+		assertTrue(attr.isDeleted());
+		;
 		assertEquals(newExpiry, attr.getExpiry());
 		inOrder.verify(hfs).setattr(tbd, attr);
 		inOrder.verify(oldExpiries).put(EntityId.fromGrpcFileId(tbd), Long.valueOf(oldExpiry));

--- a/hedera-node/src/test/java/com/hedera/services/txns/file/FileSysUndelTransitionLogicTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/txns/file/FileSysUndelTransitionLogicTest.java
@@ -9,9 +9,9 @@ package com.hedera.services.txns.file;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -23,7 +23,7 @@ package com.hedera.services.txns.file;
 import com.hedera.services.context.TransactionContext;
 import com.hedera.services.files.HFileMeta;
 import com.hedera.services.files.HederaFs;
-import com.hedera.services.files.TieredHederaFs;
+import com.hedera.services.files.SimpleUpdateResult;
 import com.hedera.services.legacy.core.jproto.JKey;
 import com.hedera.services.state.submerkle.EntityId;
 import com.hedera.services.utils.MiscUtils;
@@ -45,9 +45,9 @@ import java.util.Map;
 
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_FILE_ID;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SUCCESS;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.BDDMockito.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.inOrder;
@@ -56,8 +56,9 @@ import static org.mockito.BDDMockito.never;
 import static org.mockito.BDDMockito.verify;
 
 class FileSysUndelTransitionLogicTest {
-	enum TargetType { VALID, MISSING, DELETED }
-	enum OldExpiryType { NONE, FUTURE, PAST }
+	enum TargetType {VALID, MISSING, DELETED}
+
+	enum OldExpiryType {NONE, FUTURE, PAST}
 
 	long now = Instant.now().getEpochSecond();
 	long lifetime = 1_000_000L;
@@ -69,7 +70,7 @@ class FileSysUndelTransitionLogicTest {
 	FileID missing = IdUtils.asFile("0.0.75231");
 	FileID deleted = IdUtils.asFile("0.0.666");
 
-	HederaFs.UpdateResult success = new TieredHederaFs.SimpleUpdateResult(
+	HederaFs.UpdateResult success = new SimpleUpdateResult(
 			true,
 			false,
 			SUCCESS);

--- a/hedera-node/src/test/java/com/hedera/services/txns/file/FileUpdateTransitionLogicTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/txns/file/FileUpdateTransitionLogicTest.java
@@ -9,9 +9,9 @@ package com.hedera.services.txns.file;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -28,6 +28,7 @@ import com.hedera.services.context.TransactionContext;
 import com.hedera.services.context.primitives.StateView;
 import com.hedera.services.files.HFileMeta;
 import com.hedera.services.files.HederaFs;
+import com.hedera.services.files.SimpleUpdateResult;
 import com.hedera.services.files.TieredHederaFs;
 import com.hedera.services.legacy.core.jproto.JKey;
 import com.hedera.services.state.merkle.MerkleNetworkContext;
@@ -80,7 +81,7 @@ import static org.mockito.BDDMockito.verify;
 import static org.mockito.BDDMockito.willThrow;
 
 class FileUpdateTransitionLogicTest {
-	enum UpdateTarget { KEY, EXPIRY, CONTENTS, MEMO }
+	enum UpdateTarget {KEY, EXPIRY, CONTENTS, MEMO}
 
 	long lifetime = 1_234_567L;
 	long txnValidDuration = 180;
@@ -186,9 +187,9 @@ class FileUpdateTransitionLogicTest {
 		given(hfs.getattr(sysFileTarget)).willReturn(immutableAttr);
 		// and:
 		given(hfs.overwrite(any(), any()))
-				.willReturn(new TieredHederaFs.SimpleUpdateResult(false, true, SUCCESS));
+				.willReturn(new SimpleUpdateResult(false, true, SUCCESS));
 		given(hfs.setattr(any(), any()))
-				.willReturn(new TieredHederaFs.SimpleUpdateResult(true, false, SUCCESS));
+				.willReturn(new SimpleUpdateResult(true, false, SUCCESS));
 
 		// when:
 		subject.doStateTransition();
@@ -209,9 +210,9 @@ class FileUpdateTransitionLogicTest {
 		given(hfs.getattr(nonSysFileTarget)).willReturn(immutableAttr);
 		// and:
 		given(hfs.overwrite(any(), any()))
-				.willReturn(new TieredHederaFs.SimpleUpdateResult(false, true, SUCCESS));
+				.willReturn(new SimpleUpdateResult(false, true, SUCCESS));
 		given(hfs.setattr(any(), any()))
-				.willReturn(new TieredHederaFs.SimpleUpdateResult(true, false, SUCCESS));
+				.willReturn(new SimpleUpdateResult(true, false, SUCCESS));
 
 		// when:
 		subject.doStateTransition();
@@ -258,7 +259,7 @@ class FileUpdateTransitionLogicTest {
 		givenTxnCtxUpdating(EnumSet.of(UpdateTarget.EXPIRY));
 		// and:
 		given(hfs.setattr(any(), any()))
-				.willReturn(new TieredHederaFs.SimpleUpdateResult(true, false, SUCCESS));
+				.willReturn(new SimpleUpdateResult(true, false, SUCCESS));
 		given(hfs.getattr(nonSysFileTarget)).willReturn(immutableAttr);
 
 		// when:
@@ -294,7 +295,7 @@ class FileUpdateTransitionLogicTest {
 		// and:
 		given(hfs.getattr(nonSysFileTarget)).willReturn(oldAttr);
 		given(hfs.overwrite(any(), any()))
-				.willReturn(new TieredHederaFs.SimpleUpdateResult(
+				.willReturn(new SimpleUpdateResult(
 						false,
 						false,
 						AUTHORIZATION_FAILED));
@@ -315,9 +316,9 @@ class FileUpdateTransitionLogicTest {
 		givenTxnCtxUpdating(EnumSet.allOf(UpdateTarget.class));
 		// and:
 		given(hfs.overwrite(any(), any()))
-				.willReturn(new TieredHederaFs.SimpleUpdateResult(false, true, SUCCESS));
+				.willReturn(new SimpleUpdateResult(false, true, SUCCESS));
 		given(hfs.setattr(any(), any()))
-				.willReturn(new TieredHederaFs.SimpleUpdateResult(true, false, SUCCESS));
+				.willReturn(new SimpleUpdateResult(true, false, SUCCESS));
 		given(hfs.getattr(nonSysFileTarget)).willReturn(oldAttr);
 
 		// when:

--- a/hedera-node/src/test/java/com/hedera/services/txns/token/process/DissociationTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/txns/token/process/DissociationTest.java
@@ -273,9 +273,9 @@ class DissociationTest {
 
 	@Test
 	void toStringWorks() {
-		final var desired = "Dissociation{dissociatingAccountId=Id{shard=1, realm=2, num=3}, " +
-				"dissociatedTokenId=Id{shard=2, realm=3, num=4}, dissociatedTokenTreasuryId=Id{shard=3, realm=4, " +
-				"num=5}, expiredTokenTreasuryReceivedBalance=false}";
+		final var desired = "Dissociation{dissociatingAccountId=Id[shard=1, realm=2, num=3], " +
+				"dissociatedTokenId=Id[shard=2, realm=3, num=4], dissociatedTokenTreasuryId=Id[shard=3, realm=4, " +
+				"num=5], expiredTokenTreasuryReceivedBalance=false}";
 
 		final var subject = new Dissociation(dissociatingAccountRel, dissociatedTokenTreasuryRel);
 

--- a/hedera-node/src/test/java/com/hedera/services/utils/EntityNumPairTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/utils/EntityNumPairTest.java
@@ -85,7 +85,7 @@ class EntityNumPairTest {
 	@Test
 	void returnsCorrectNumPairIfValidLong() {
 		final var expectedVal = BitPackUtils.packedNums(2, 2);
-		assertEquals(expectedVal, fromLongs(2, 2).getValue());
+		assertEquals(expectedVal, fromLongs(2, 2).value());
 	}
 
 	@Test

--- a/hedera-node/src/test/java/com/hedera/services/utils/SignedTxnAccessorTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/utils/SignedTxnAccessorTest.java
@@ -167,7 +167,7 @@ class SignedTxnAccessorTest {
 				Duration.getDefaultInstance(),
 				false,
 				zeroByteMemo,
-				5678l, 5555l,-70000l,
+				5678l, 5555l, -70000l,
 				ByteString.copyFromUtf8("aaaa"), 70000l);
 		xferWithAliasesNoAutoCreation = xferWithAliasesNoAutoCreation.toBuilder()
 				.setSigMap(expectedMap)
@@ -197,7 +197,7 @@ class SignedTxnAccessorTest {
 		assertEquals(false, accessor.isTriggeredTxn());
 		assertEquals(false, accessor.canTriggerTxn());
 		assertEquals(0, accessor.getNumAutoCreations());
-		assertEquals(memoUtf8Bytes.length, txnUsageMeta.getMemoUtf8Bytes());
+		assertEquals(memoUtf8Bytes.length, txnUsageMeta.memoUtf8Bytes());
 
 		accessor = SignedTxnAccessor.uncheckedFrom(xferWithAutoCreation);
 		accessor.countAutoCreationsWith(aliasManager);
@@ -382,7 +382,7 @@ class SignedTxnAccessorTest {
 
 		final var submitMeta = subject.availSubmitUsageMeta();
 
-		assertEquals(message.length(), submitMeta.getNumMsgBytes());
+		assertEquals(message.length(), submitMeta.numMsgBytes());
 	}
 
 	@Test

--- a/hedera-node/src/test/java/com/hedera/test/mocks/TestAutoRenewCalcs.java
+++ b/hedera-node/src/test/java/com/hedera/test/mocks/TestAutoRenewCalcs.java
@@ -9,9 +9,9 @@ package com.hedera.test.mocks;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -21,6 +21,7 @@ package com.hedera.test.mocks;
  */
 
 import com.hedera.services.fees.calculation.AutoRenewCalcs;
+import com.hedera.services.fees.calculation.RenewAssessment;
 import com.hedera.services.state.merkle.MerkleAccount;
 import com.hederahashgraph.api.proto.java.ExchangeRate;
 import com.hederahashgraph.api.proto.java.FeeData;
@@ -36,17 +37,18 @@ public class TestAutoRenewCalcs extends AutoRenewCalcs {
 	}
 
 	@Override
-	public AutoRenewCalcs.RenewAssessment maxRenewalAndFeeFor(
+	public RenewAssessment maxRenewalAndFeeFor(
 			MerkleAccount expiredAccount,
 			long reqPeriod,
 			Instant at,
 			ExchangeRate active
 	) {
-		return new AutoRenewCalcs.RenewAssessment(0L, Long.MAX_VALUE);
+		return new RenewAssessment(0L, Long.MAX_VALUE);
 	}
 
 	@Override
-	public void setCryptoAutoRenewPriceSeq(Triple<Map<SubType, FeeData>, Instant, Map<SubType, FeeData>> cryptoAutoRenewPriceSeq) {
+	public void setCryptoAutoRenewPriceSeq(
+			Triple<Map<SubType, FeeData>, Instant, Map<SubType, FeeData>> cryptoAutoRenewPriceSeq) {
 		/* No-op */
 	}
 }


### PR DESCRIPTION
Closes #2628 

After moving to JDK 17 , there are sonar issues related to using
1. `Records` wherever needed,  and removing the boilerplate code in classes (i.e., getters, setters, equals, hashCode, toString methods)
2. Using Streams `toList()` instead of `collect(Collectors.tolist())`
3. Pattern matching for `instanceof`

The PR majorly has the above  two changes


[6 more sonar issues ](https://sonarcloud.io/project/issues?branch=branch-2628-M-resolve-sonar-issues&createdAfter=2021-12-15&createdBefore=2021-12-17&id=com.hedera.hashgraph%3Ahedera-services&resolved=false&types=CODE_SMELL) could not be resolved as `Dagger` has an issue open in supporting records and fails with this [error](https://github.com/google/dagger/issues/2106)