### PR TITLE
Bumped Dockerfile JDK and Maven versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,13 @@
 FROM ubuntu:20.10 AS base-runtime
 RUN apt-get update && \
     apt-get upgrade -y && \
-    apt-get install -y dos2unix openssl openjdk-15-jdk libsodium23 postgresql-client
+    apt-get install -y dos2unix openssl libsodium23 postgresql-client
+
+# JDK
+RUN apt-get install -y software-properties-common && \
+    add-apt-repository -y ppa:openjdk-r/ppa && \
+    apt-get install -y openjdk-17-jdk
+
 # Services runtime
 RUN mkdir -p /opt/hedera/services/data/lib
 RUN mkdir -p /opt/hedera/services/data/backup
@@ -21,8 +27,16 @@ RUN mkdir /opt/hedera/services/config-mount
 ## Builds the HederaNode.jar from the current source tree and creates 
 ## the /opt/hedera/services/.VERSION file
 FROM base-runtime AS services-builder
+
 # Maven
-RUN apt-get update && apt-get install -y maven
+# Note: Java 17 requires Maven 3.8+ so the distro provided one just won't do
+RUN apt-get update && \
+    apt-get install -y wget unzip && \
+    wget https://dlcdn.apache.org/maven/maven-3/3.8.4/binaries/apache-maven-3.8.4-bin.zip && \
+    unzip apache-maven-3.8.4-bin.zip -d /opt && \
+    rm apache-maven-3.8.4-bin.zip
+ENV PATH=/opt/apache-maven-3.8.4/bin:$PATH
+
 WORKDIR /opt/hedera/services
 # Install Services
 COPY .env /opt/hedera/services


### PR DESCRIPTION
**Description**:
Following the upgrade to [use JDK 17 for the Maven Compiler plugin](https://github.com/hashgraph/hedera-services/commit/65089b67e1fd8c6761b716d1f668e6d0a4a6c226), this PR intends to update the Dockerfile definition to do the same when generating the hedera-services Docker image.

Maven needed also to be bumped to work with JDK 17 otherwise compilation would fail with the following message:
![image](https://user-images.githubusercontent.com/210908/146891505-926b7a9b-7ee6-4822-9a14-0eae0bce4d3e.png)

Maven 3.8 is not part of Ubuntu's package manager so it had to be brought in.

A deployed instance of the build can be obtained [from here](https://hub.docker.com/r/buidlerlabs/hedera-services).

<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
