### PR TITLE
Fix AccountInfo to return AccountID instead of Alias

### DIFF
--- a/hedera-node/src/main/java/com/hedera/services/context/primitives/StateView.java
+++ b/hedera-node/src/main/java/com/hedera/services/context/primitives/StateView.java
@@ -411,7 +411,7 @@ public class StateView {
 			return Optional.empty();
 		}
 
-		final AccountID accountID = id.getAlias().isEmpty() ? id : accountEntityNum.toGrpcAccountId();
+		final AccountID accountID = accountEntityNum.toGrpcAccountId();
 
 		var info = CryptoGetInfoResponse.AccountInfo.newBuilder()
 				.setKey(asKeyUnchecked(account.getAccountKey()))

--- a/hedera-node/src/main/java/com/hedera/services/context/primitives/StateView.java
+++ b/hedera-node/src/main/java/com/hedera/services/context/primitives/StateView.java
@@ -411,7 +411,7 @@ public class StateView {
 			return Optional.empty();
 		}
 
-		final AccountID accountID = accountEntityNum.toGrpcAccountId();
+		final AccountID accountID = id.getAlias().isEmpty() ? id : accountEntityNum.toGrpcAccountId();
 
 		var info = CryptoGetInfoResponse.AccountInfo.newBuilder()
 				.setKey(asKeyUnchecked(account.getAccountKey()))

--- a/hedera-node/src/main/java/com/hedera/services/context/primitives/StateView.java
+++ b/hedera-node/src/main/java/com/hedera/services/context/primitives/StateView.java
@@ -28,9 +28,9 @@ import com.hedera.services.files.DataMapFactory;
 import com.hedera.services.files.HFileMeta;
 import com.hedera.services.files.MetadataMapFactory;
 import com.hedera.services.files.store.FcBlobsBytesStore;
+import com.hedera.services.ledger.accounts.AliasManager;
 import com.hedera.services.legacy.core.jproto.JKey;
 import com.hedera.services.legacy.core.jproto.JKeyList;
-import com.hedera.services.ledger.accounts.AliasManager;
 import com.hedera.services.state.merkle.MerkleAccount;
 import com.hedera.services.state.merkle.MerkleOptionalBlob;
 import com.hedera.services.state.merkle.MerkleToken;
@@ -88,12 +88,12 @@ import static com.hedera.services.state.submerkle.EntityId.MISSING_ENTITY_ID;
 import static com.hedera.services.store.schedule.ScheduleStore.MISSING_SCHEDULE;
 import static com.hedera.services.store.tokens.TokenStore.MISSING_TOKEN;
 import static com.hedera.services.store.tokens.views.EmptyUniqTokenViewFactory.EMPTY_UNIQ_TOKEN_VIEW_FACTORY;
-import static com.hedera.services.utils.EntityNum.fromAccountId;
-import static com.hedera.services.utils.EntityNum.fromContractId;
 import static com.hedera.services.utils.EntityIdUtils.asAccount;
 import static com.hedera.services.utils.EntityIdUtils.asSolidityAddress;
 import static com.hedera.services.utils.EntityIdUtils.asSolidityAddressHex;
 import static com.hedera.services.utils.EntityIdUtils.readableId;
+import static com.hedera.services.utils.EntityNum.fromAccountId;
+import static com.hedera.services.utils.EntityNum.fromContractId;
 import static com.hedera.services.utils.MiscUtils.asKeyUnchecked;
 import static java.util.Collections.unmodifiableMap;
 
@@ -404,15 +404,18 @@ public class StateView {
 	}
 
 	public Optional<CryptoGetInfoResponse.AccountInfo> infoForAccount(AccountID id, AliasManager aliasManager) {
-		final var accountId = id.getAlias().isEmpty() ? fromAccountId(id) : aliasManager.lookupIdBy(id.getAlias());
-		final var account = accounts().get(accountId);
+		final var accountEntityNum = id.getAlias().isEmpty() ? fromAccountId(id) : aliasManager.lookupIdBy(
+				id.getAlias());
+		final var account = accounts().get(accountEntityNum);
 		if (account == null) {
 			return Optional.empty();
 		}
 
+		final AccountID accountID = id.getAlias().isEmpty() ? id : accountEntityNum.toGrpcAccountId();
+
 		var info = CryptoGetInfoResponse.AccountInfo.newBuilder()
 				.setKey(asKeyUnchecked(account.getAccountKey()))
-				.setAccountID(id)
+				.setAccountID(accountID)
 				.setAlias(account.getAlias())
 				.setReceiverSigRequired(account.isReceiverSigRequired())
 				.setDeleted(account.isDeleted())
@@ -420,13 +423,13 @@ public class StateView {
 				.setAutoRenewPeriod(Duration.newBuilder().setSeconds(account.getAutoRenewSecs()))
 				.setBalance(account.getBalance())
 				.setExpirationTime(Timestamp.newBuilder().setSeconds(account.getExpiry()))
-				.setContractAccountID(asSolidityAddressHex(id))
+				.setContractAccountID(asSolidityAddressHex(accountID))
 				.setOwnedNfts(account.getNftsOwned())
 				.setMaxAutomaticTokenAssociations(account.getMaxAutomaticAssociations());
 		Optional.ofNullable(account.getProxy())
 				.map(EntityId::toGrpcAccountId)
 				.ifPresent(info::setProxyAccountID);
-		final var tokenRels = tokenRelsFn.apply(this, accountId);
+		final var tokenRels = tokenRelsFn.apply(this, accountEntityNum);
 		if (!tokenRels.isEmpty()) {
 			info.addAllTokenRelationships(tokenRels);
 		}

--- a/hedera-node/src/test/java/com/hedera/services/context/primitives/StateViewTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/context/primitives/StateViewTest.java
@@ -654,7 +654,7 @@ class StateViewTest {
 
 		final var expectedResponse = CryptoGetInfoResponse.AccountInfo.newBuilder()
 				.setKey(asKeyUnchecked(tokenAccount.getAccountKey()))
-				.setAccountID(accountWithAlias)
+				.setAccountID(tokenAccountId)
 				.setAlias(tokenAccount.getAlias())
 				.setReceiverSigRequired(tokenAccount.isReceiverSigRequired())
 				.setDeleted(tokenAccount.isDeleted())
@@ -662,7 +662,7 @@ class StateViewTest {
 				.setAutoRenewPeriod(Duration.newBuilder().setSeconds(tokenAccount.getAutoRenewSecs()))
 				.setBalance(tokenAccount.getBalance())
 				.setExpirationTime(Timestamp.newBuilder().setSeconds(tokenAccount.getExpiry()))
-				.setContractAccountID(asSolidityAddressHex(accountWithAlias))
+				.setContractAccountID(asSolidityAddressHex(tokenAccountId))
 				.setOwnedNfts(tokenAccount.getNftsOwned())
 				.setMaxAutomaticTokenAssociations(tokenAccount.getMaxAutomaticAssociations())
 				.build();

--- a/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/crypto/HapiGetAccountInfo.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/crypto/HapiGetAccountInfo.java
@@ -159,6 +159,7 @@ public class HapiGetAccountInfo extends HapiQueryOp<HapiGetAccountInfo> {
 			Objects.requireNonNull(aliasKeySource);
 			final var expected = spec.registry().getKey(aliasKeySource).toByteString();
 			Assertions.assertEquals(expected, actualInfo.getAlias());
+			Assertions.assertNotEquals(actualInfo.getAlias(), actualInfo.getAccountID());
 		}
 		if (expectations.isPresent()) {
 			ErroringAsserts<AccountInfo> asserts = expectations.get().assertsFor(spec);

--- a/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/crypto/HapiGetAccountInfo.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/crypto/HapiGetAccountInfo.java
@@ -67,6 +67,7 @@ public class HapiGetAccountInfo extends HapiQueryOp<HapiGetAccountInfo> {
 	Optional<Integer> alreadyUsedAutomaticAssociations = Optional.empty();
 	private Optional<Consumer<AccountID>> idObserver = Optional.empty();
 	private boolean assertAliasKeyMatches = false;
+	private boolean assertAccountIDIsNotAlias = false;
 	private ReferenceType referenceType;
 
 	public HapiGetAccountInfo(String account) {
@@ -94,6 +95,11 @@ public class HapiGetAccountInfo extends HapiQueryOp<HapiGetAccountInfo> {
 
 	public HapiGetAccountInfo hasExpectedAliasKey() {
 		assertAliasKeyMatches = true;
+		return this;
+	}
+
+	public HapiGetAccountInfo hasExpectedAccountID() {
+		assertAccountIDIsNotAlias = true;
 		return this;
 	}
 
@@ -159,7 +165,13 @@ public class HapiGetAccountInfo extends HapiQueryOp<HapiGetAccountInfo> {
 			Objects.requireNonNull(aliasKeySource);
 			final var expected = spec.registry().getKey(aliasKeySource).toByteString();
 			Assertions.assertEquals(expected, actualInfo.getAlias());
-			Assertions.assertNotEquals(actualInfo.getAlias(), actualInfo.getAccountID());
+		}
+		if (assertAccountIDIsNotAlias) {
+			Objects.requireNonNull(aliasKeySource);
+			final var expectedKeyForAccount = spec.registry().getKey(aliasKeySource).toByteString().toStringUtf8();
+			final var expectedID = spec.registry().getAccountID(expectedKeyForAccount);
+			Assertions.assertNotEquals(actualInfo.getAlias(), actualInfo.getAccountID().getAccountNum());
+			Assertions.assertEquals(expectedID, actualInfo.getAccountID());
 		}
 		if (expectations.isPresent()) {
 			ErroringAsserts<AccountInfo> asserts = expectations.get().assertsFor(spec);

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/AutoAccountCreationSuite.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/AutoAccountCreationSuite.java
@@ -78,17 +78,17 @@ public class AutoAccountCreationSuite extends HapiApiSuite {
 	@Override
 	protected List<HapiApiSpec> getSpecsInSuite() {
 		return List.of(new HapiApiSpec[] {
-//						autoAccountCreationsHappyPath(),
-//						autoAccountCreationBadAlias(),
-//						autoAccountCreationUnsupportedAlias(),
-//						transferToAccountAutoCreatedUsingAlias(),
-//						transferToAccountAutoCreatedUsingAccount(),
-//						transferFromAliasToAlias(),
-//						transferFromAliasToAccount(),
-//						multipleAutoAccountCreations(),
-//						accountCreatedIfAliasUsedAsPubKey(),
-//						aliasCanBeUsedOnManyAccountsNotAsAlias(),
-//						autoAccountCreationWorksWhenUsingAliasOfDeletedAccount(),
+						autoAccountCreationsHappyPath(),
+						autoAccountCreationBadAlias(),
+						autoAccountCreationUnsupportedAlias(),
+						transferToAccountAutoCreatedUsingAlias(),
+						transferToAccountAutoCreatedUsingAccount(),
+						transferFromAliasToAlias(),
+						transferFromAliasToAccount(),
+						multipleAutoAccountCreations(),
+						accountCreatedIfAliasUsedAsPubKey(),
+						aliasCanBeUsedOnManyAccountsNotAsAlias(),
+						autoAccountCreationWorksWhenUsingAliasOfDeletedAccount(),
 						canGetBalanceAndInfoViaAlias()
 				}
 		);

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/AutoAccountCreationSuite.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/AutoAccountCreationSuite.java
@@ -78,17 +78,17 @@ public class AutoAccountCreationSuite extends HapiApiSuite {
 	@Override
 	protected List<HapiApiSpec> getSpecsInSuite() {
 		return List.of(new HapiApiSpec[] {
-						autoAccountCreationsHappyPath(),
-						autoAccountCreationBadAlias(),
-						autoAccountCreationUnsupportedAlias(),
-						transferToAccountAutoCreatedUsingAlias(),
-						transferToAccountAutoCreatedUsingAccount(),
-						transferFromAliasToAlias(),
-						transferFromAliasToAccount(),
-						multipleAutoAccountCreations(),
-						accountCreatedIfAliasUsedAsPubKey(),
-						aliasCanBeUsedOnManyAccountsNotAsAlias(),
-						autoAccountCreationWorksWhenUsingAliasOfDeletedAccount(),
+//						autoAccountCreationsHappyPath(),
+//						autoAccountCreationBadAlias(),
+//						autoAccountCreationUnsupportedAlias(),
+//						transferToAccountAutoCreatedUsingAlias(),
+//						transferToAccountAutoCreatedUsingAccount(),
+//						transferFromAliasToAlias(),
+//						transferFromAliasToAccount(),
+//						multipleAutoAccountCreations(),
+//						accountCreatedIfAliasUsedAsPubKey(),
+//						aliasCanBeUsedOnManyAccountsNotAsAlias(),
+//						autoAccountCreationWorksWhenUsingAliasOfDeletedAccount(),
 						canGetBalanceAndInfoViaAlias()
 				}
 		);
@@ -114,10 +114,10 @@ public class AutoAccountCreationSuite extends HapiApiSuite {
 								.via(autoCreation)
 				).then(
 						getTxnRecord(autoCreation).andAllChildRecords().logged(),
-						getAliasedAccountBalance(ed25519SourceKey),
-						getAliasedAccountBalance(secp256k1SourceKey),
-						getAliasedAccountInfo(ed25519SourceKey).hasExpectedAliasKey(),
-						getAliasedAccountInfo(secp256k1SourceKey).hasExpectedAliasKey()
+						getAliasedAccountBalance(ed25519SourceKey).logged(),
+						getAliasedAccountBalance(secp256k1SourceKey).logged(),
+						getAliasedAccountInfo(ed25519SourceKey).hasExpectedAliasKey().logged(),
+						getAliasedAccountInfo(secp256k1SourceKey).hasExpectedAliasKey().logged()
 				);
 	}
 

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/AutoAccountCreationSuite.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/AutoAccountCreationSuite.java
@@ -113,11 +113,25 @@ public class AutoAccountCreationSuite extends HapiApiSuite {
 								.payingWith(GENESIS)
 								.via(autoCreation)
 				).then(
-						getTxnRecord(autoCreation).andAllChildRecords().logged(),
-						getAliasedAccountBalance(ed25519SourceKey).logged(),
-						getAliasedAccountBalance(secp256k1SourceKey).logged(),
-						getAliasedAccountInfo(ed25519SourceKey).hasExpectedAliasKey().logged(),
-						getAliasedAccountInfo(secp256k1SourceKey).hasExpectedAliasKey().logged()
+						getTxnRecord(autoCreation).andAllChildRecords()
+								.hasAliasInChildRecord(ed25519SourceKey, 0)
+								.hasAliasInChildRecord(secp256k1SourceKey, 1).logged(),
+						getAliasedAccountBalance(ed25519SourceKey)
+								.hasExpectedAccountID()
+								.logged(),
+						getAliasedAccountBalance(secp256k1SourceKey)
+								.hasExpectedAccountID()
+								.logged(),
+						getAliasedAccountInfo(ed25519SourceKey)
+								.hasExpectedAliasKey()
+								.hasExpectedAccountID()
+								.has(accountWith().expectedBalanceWithChargedUsd(ONE_HUNDRED_HBARS, 0.05, 0.5))
+								.logged(),
+						getAliasedAccountInfo(secp256k1SourceKey)
+								.hasExpectedAliasKey()
+								.hasExpectedAccountID()
+								.has(accountWith().expectedBalanceWithChargedUsd(ONE_HUNDRED_HBARS, 0.05, 0.5))
+								.logged()
 				);
 	}
 


### PR DESCRIPTION
Closes #2653 

Changes `AccountInfo` query while querying with alias to return accountID in the form of `0.0.accountNum` instead of `0.0.alias`