### PR TITLE
Update Dockerfile with Ubuntu 21.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-## Installs OpenJDK12 and openssl (used by Swirlds Platform to 
+## Installs OpenJDK17 and openssl (used by Swirlds Platform to 
 ## generate node keys for e.g. signing states), then copies 
 ## required libraries and startup assets for a node with:
 ##  * Configuration from /opt/hedera/services/config-mount; and, 
 ##  * Logs at /opt/hedera/services/output; and, 
 ##  * Saved states under /opt/hedera/services/output
-FROM ubuntu:20.10 AS base-runtime
+FROM ubuntu:21.10 AS base-runtime
 RUN apt-get update && \
     apt-get upgrade -y && \
     apt-get install -y dos2unix openssl libsodium23 postgresql-client


### PR DESCRIPTION
**Description**:
- Update Dockerfile to use Ubuntu 21.10.
- Note that an [issue with older versions of `runc`](https://stackoverflow.com/questions/66319610/gpg-error-in-ubuntu-21-04-after-second-apt-get-update-during-docker-build) may require updating your local Docker to use this new image.

**Related issues**:
- Closes #2669 