### PR TITLE
Add the `@LatestSignedState` accessor + implement `SignedStateSigReqs`

### DIFF
--- a/hedera-node/src/main/java/com/hedera/services/ServicesApp.java
+++ b/hedera-node/src/main/java/com/hedera/services/ServicesApp.java
@@ -48,6 +48,7 @@ import com.hedera.services.sigs.order.SigRequirements;
 import com.hedera.services.state.DualStateAccessor;
 import com.hedera.services.state.StateAccessor;
 import com.hedera.services.state.StateModule;
+import com.hedera.services.state.annotations.LatestSignedState;
 import com.hedera.services.state.annotations.WorkingState;
 import com.hedera.services.state.exports.AccountsExporter;
 import com.hedera.services.state.exports.BalancesExporter;
@@ -147,6 +148,7 @@ public interface ServicesApp {
 	SystemAccountsCreator sysAccountsCreator();
 	Optional<PrintStream> consoleOut();
 	ReconnectCompleteListener reconnectListener();
+	@LatestSignedState StateAccessor latestSignedState();
 	StateWriteToDiskCompleteListener stateWriteToDiskListener();
 	InvalidSignedStateListener issListener();
 	Supplier<NotificationEngine> notificationEngine();

--- a/hedera-node/src/main/java/com/hedera/services/ServicesMain.java
+++ b/hedera-node/src/main/java/com/hedera/services/ServicesMain.java
@@ -95,6 +95,8 @@ public class ServicesMain implements SwirldMain {
 		if (balancesExporter.isTimeToExport(consensusTime)) {
 			balancesExporter.exportBalancesFrom(servicesState, consensusTime, app.nodeId());
 		}
+
+		app.latestSignedState().replaceChildrenFrom(servicesState, consensusTime);
 	}
 
 	@Override

--- a/hedera-node/src/main/java/com/hedera/services/ServicesState.java
+++ b/hedera-node/src/main/java/com/hedera/services/ServicesState.java
@@ -209,7 +209,7 @@ public class ServicesState extends AbstractNaryMerkleInternal implements SwirldS
 
 		final var that = new ServicesState(this);
 		if (metadata != null) {
-			metadata.app().workingState().updateFrom(that);
+			metadata.app().workingState().updateChildrenFrom(that);
 		}
 
 		return that;

--- a/hedera-node/src/main/java/com/hedera/services/context/StateChildren.java
+++ b/hedera-node/src/main/java/com/hedera/services/context/StateChildren.java
@@ -29,13 +29,14 @@ import com.hedera.services.state.merkle.MerkleToken;
 import com.hedera.services.state.merkle.MerkleTokenRelStatus;
 import com.hedera.services.state.merkle.MerkleTopic;
 import com.hedera.services.state.merkle.MerkleUniqueToken;
+import com.hedera.services.stream.RecordsRunningHashLeaf;
 import com.hedera.services.utils.EntityNum;
 import com.hedera.services.utils.EntityNumPair;
-import com.hedera.services.stream.RecordsRunningHashLeaf;
 import com.swirlds.common.AddressBook;
 import com.swirlds.fchashmap.FCOneToManyRelation;
 import com.swirlds.merkle.map.MerkleMap;
 
+import java.time.Instant;
 import java.util.Objects;
 
 /**
@@ -58,6 +59,27 @@ public class StateChildren {
 	private AddressBook addressBook;
 	private MerkleSpecialFiles specialFiles;
 	private RecordsRunningHashLeaf runningHashLeaf;
+	private Instant signedAt = Instant.EPOCH;
+
+	public StateChildren() {
+		/* No-op */
+	}
+
+	public StateChildren(final Instant signedAt) {
+		this.signedAt = signedAt;
+	}
+
+	public boolean isSignedAfter(final StateChildren children) {
+		return signedAt.isAfter(children.signedAt);
+	}
+
+	public boolean isSigned() {
+		return signedAt.isAfter(Instant.EPOCH);
+	}
+
+	public Instant getSignedAt() {
+		return signedAt;
+	}
 
 	public MerkleMap<EntityNum, MerkleAccount> getAccounts() {
 		Objects.requireNonNull(accounts);

--- a/hedera-node/src/main/java/com/hedera/services/context/init/StateInitializationFlow.java
+++ b/hedera-node/src/main/java/com/hedera/services/context/init/StateInitializationFlow.java
@@ -66,7 +66,7 @@ public class StateInitializationFlow {
 	public void runWith(ServicesState activeState) {
 		staticNumbersHolder.accept(hederaNums);
 
-		stateAccessor.updateFrom(activeState);
+		stateAccessor.updateChildrenFrom(activeState);
 		log.info("Context updated with working state");
 		log.info("  (@ {}) # NFTs               = {}",
 				StateChildIndices.UNIQUE_TOKENS,

--- a/hedera-node/src/main/java/com/hedera/services/fees/calculation/RenewAssessment.java
+++ b/hedera-node/src/main/java/com/hedera/services/fees/calculation/RenewAssessment.java
@@ -6,13 +6,12 @@ package com.hedera.services.fees.calculation;
  * ​
  * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
  * ​
- * Licensed under the Apache License, Version 2com.hedera.services.store.tokens.views.UniqTokenViewsManager
- * .PendingChange.0 (the "License");
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/hedera-node/src/main/java/com/hedera/services/files/SimpleUpdateResult.java
+++ b/hedera-node/src/main/java/com/hedera/services/files/SimpleUpdateResult.java
@@ -3,22 +3,24 @@ package com.hedera.services.files;
 /*
  * -
  *  * ‌
- *  * Hedera Services Node
- *  * ​
- *  * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
- *  * ​
- *  * Licensed under the Apache License, Version 2.0 (the "License");
- *  * you may not use this file except in compliance with the License.
- *  * You may obtain a copy of the License at
+ * * Hedera Services Node
  *  *
- *  *      http://www.apache.org/licenses/LICENSE-2.0
+ * ​
+ * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
  *  *
- *  * Unless required by applicable law or agreed to in writing, software
- *  * distributed under the License is distributed on an "AS IS" BASIS,
- *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  * See the License for the specific language governing permissions and
- *  * limitations under the License.
- *  * ‍
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
  *
  */
 

--- a/hedera-node/src/main/java/com/hedera/services/sigs/metadata/StateChildrenSigMetadataLookup.java
+++ b/hedera-node/src/main/java/com/hedera/services/sigs/metadata/StateChildrenSigMetadataLookup.java
@@ -1,5 +1,25 @@
 package com.hedera.services.sigs.metadata;
 
+/*-
+ * ‌
+ * Hedera Services Node
+ * ​
+ * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
 import com.hedera.services.config.FileNumbers;
 import com.hedera.services.context.StateChildren;
 import com.hedera.services.files.HFileMeta;

--- a/hedera-node/src/main/java/com/hedera/services/sigs/metadata/TokenMetaUtils.java
+++ b/hedera-node/src/main/java/com/hedera/services/sigs/metadata/TokenMetaUtils.java
@@ -1,5 +1,25 @@
 package com.hedera.services.sigs.metadata;
 
+/*-
+ * ‌
+ * Hedera Services Node
+ * ​
+ * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
 import com.hedera.services.state.merkle.MerkleToken;
 import com.hedera.services.state.submerkle.FcCustomFee;
 

--- a/hedera-node/src/main/java/com/hedera/services/sigs/order/SignedStateSigReqs.java
+++ b/hedera-node/src/main/java/com/hedera/services/sigs/order/SignedStateSigReqs.java
@@ -1,0 +1,149 @@
+package com.hedera.services.sigs.order;
+
+/*-
+ * ‌
+ * Hedera Services Node
+ * ​
+ * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import com.hedera.services.config.FileNumbers;
+import com.hedera.services.context.StateChildren;
+import com.hedera.services.context.properties.GlobalDynamicProperties;
+import com.hedera.services.ledger.accounts.AliasManager;
+import com.hedera.services.sigs.Rationalization;
+import com.hedera.services.sigs.metadata.SigMetadataLookup;
+import com.hedera.services.sigs.metadata.StateChildrenSigMetadataLookup;
+import com.hedera.services.sigs.metadata.TokenMetaUtils;
+import com.hedera.services.sigs.metadata.TokenSigningMetadata;
+import com.hedera.services.state.StateAccessor;
+import com.hedera.services.state.annotations.LatestSignedState;
+import com.hedera.services.state.annotations.WorkingState;
+import com.hedera.services.state.merkle.MerkleToken;
+import com.hedera.services.utils.TxnAccessor;
+import com.swirlds.common.SwirldState;
+import com.swirlds.common.SwirldTransaction;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import java.time.Instant;
+import java.util.function.Function;
+
+/**
+ * Will be used by {@link com.hedera.services.ServicesState#expandSignatures(SwirldTransaction)} to get the
+ * "best available" implementation of {@link SigRequirements} when expanding signatures.
+ *
+ * (We prefer to expand from the latest signed state so that---<b>once</b> logic is in place to detect keys
+ * that changed between {@code expandSignatures} and {@code handleTransaction}---it is no longer necessary to
+ * call {@link Rationalization#performFor(TxnAccessor)} during {@code handleTransaction}.)
+ */
+@Singleton
+public class SignedStateSigReqs {
+	public static final Function<MerkleToken, TokenSigningMetadata> TOKEN_META_TRANSFORM =
+			TokenMetaUtils::signingMetaFrom;
+
+	private final FileNumbers fileNumbers;
+	private final AliasManager aliasManager;
+	private final StateAccessor workingState;
+	private final StateAccessor latestSignedState;
+	private final SignatureWaivers signatureWaivers;
+	private final GlobalDynamicProperties dynamicProperties;
+
+	private SigReqsFactory sigReqsFactory = SigRequirements::new;
+	private StateChildrenLookupsFactory lookupsFactory = StateChildrenSigMetadataLookup::new;
+
+	private StateChildren signedChildren = new StateChildren();
+	private SigRequirements signedSigReqs;
+	/* Before we have a first signed state, we must use the working state's children to expand signatures. */
+	private SigRequirements workingSigReqs;
+
+	@Inject
+	public SignedStateSigReqs(
+			final FileNumbers fileNumbers,
+			final AliasManager aliasManager,
+			final SignatureWaivers signatureWaivers,
+			final GlobalDynamicProperties dynamicProperties,
+			final @WorkingState StateAccessor workingState,
+			final @LatestSignedState StateAccessor latestSignedState
+	) {
+		this.fileNumbers = fileNumbers;
+		this.aliasManager = aliasManager;
+		this.workingState = workingState;
+		this.signatureWaivers = signatureWaivers;
+		this.latestSignedState = latestSignedState;
+		this.dynamicProperties = dynamicProperties;
+	}
+
+	/**
+	 * Returns the "best available" implementation of {@link SigRequirements} for use in expanding
+	 * signatures; prefers the implementation backed by the latest signed state received in
+	 * {@link com.hedera.services.ServicesMain#newSignedState(SwirldState, Instant, long)}.
+	 *
+	 * @return the best available signing requirements
+	 */
+	public SigRequirements getBestAvailable() {
+		final var latestSignedChildren = latestSignedState.children();
+		if (latestSignedChildren.isSigned()) {
+			if (latestSignedChildren.isSignedAfter(signedChildren)) {
+				signedChildren = latestSignedChildren;
+				final var lookup = lookupsFactory.from(
+						fileNumbers, aliasManager, signedChildren, TOKEN_META_TRANSFORM);
+				signedSigReqs = sigReqsFactory.from(lookup, dynamicProperties, signatureWaivers);
+
+				/* Once we have a signed state, we won't go back to the working state */
+				workingSigReqs = null;
+			}
+			return signedSigReqs;
+		} else {
+			return provideWorkingSigReqs();
+		}
+	}
+
+	private SigRequirements provideWorkingSigReqs() {
+		if (workingSigReqs == null) {
+			final var lookup = lookupsFactory.from(
+					fileNumbers, aliasManager, workingState.children(), TOKEN_META_TRANSFORM);
+			workingSigReqs = sigReqsFactory.from(lookup, dynamicProperties, signatureWaivers);
+		}
+		return workingSigReqs;
+	}
+
+	@FunctionalInterface
+	interface SigReqsFactory {
+		SigRequirements from(
+				SigMetadataLookup sigMetaLookup,
+				GlobalDynamicProperties properties,
+				SignatureWaivers signatureWaivers);
+	}
+
+	@FunctionalInterface
+	interface StateChildrenLookupsFactory {
+		SigMetadataLookup from(
+				FileNumbers fileNumbers,
+				AliasManager aliasManager,
+				StateChildren stateChildren,
+				Function<MerkleToken, TokenSigningMetadata> tokenMetaTransform);
+	}
+
+	/* --- Only used by unit tests --- */
+	void setSigReqsFactory(final SigReqsFactory sigReqsFactory) {
+		this.sigReqsFactory = sigReqsFactory;
+	}
+
+	void setLookupsFactory(final StateChildrenLookupsFactory lookupsFactory) {
+		this.lookupsFactory = lookupsFactory;
+	}
+}

--- a/hedera-node/src/main/java/com/hedera/services/state/StateModule.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/StateModule.java
@@ -30,6 +30,7 @@ import com.hedera.services.keys.LegacyEd25519KeyReader;
 import com.hedera.services.ledger.ids.EntityIdSource;
 import com.hedera.services.ledger.ids.SeqNoEntityIdSource;
 import com.hedera.services.legacy.core.jproto.JKey;
+import com.hedera.services.state.annotations.LatestSignedState;
 import com.hedera.services.state.annotations.NftsByOwner;
 import com.hedera.services.state.annotations.NftsByType;
 import com.hedera.services.state.annotations.TreasuryNftsByType;
@@ -233,6 +234,13 @@ public abstract class StateModule {
 	@WorkingState
 	public static StateAccessor provideWorkingState(ServicesState initialState) {
 		return new StateAccessor(initialState);
+	}
+
+	@Provides
+	@Singleton
+	@LatestSignedState
+	public static StateAccessor provideLatestSignedState() {
+		return new StateAccessor();
 	}
 
 	@Provides

--- a/hedera-node/src/main/java/com/hedera/services/state/annotations/LatestSignedState.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/annotations/LatestSignedState.java
@@ -1,32 +1,34 @@
-package com.hedera.services.store.tokens.views;
+package com.hedera.services.state.annotations;
 
-/*
- * -
- *  * ‌
- * * Hedera Services Node
- *  *
+/*-
+ * ‌
+ * Hedera Services Node
  * ​
  * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
- *  *
  * ​
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
  * ‍
- *
  */
 
-public record PendingChange(UniqTokenViewsManager.TargetFcotmr targetFcotmr,
-							int keyCode,
-							long valueCode,
-							boolean associate) {
-}
+import javax.inject.Qualifier;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
 
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Target({ ElementType.METHOD, ElementType.PARAMETER })
+@Qualifier
+@Retention(RUNTIME)
+public @interface LatestSignedState {
+}

--- a/hedera-node/src/test/java/com/hedera/services/ServicesAppTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/ServicesAppTest.java
@@ -137,6 +137,7 @@ class ServicesAppTest {
 		assertThat(subject.logic(), instanceOf(StandardProcessLogic.class));
 		assertThat(subject.hashLogger(), instanceOf(HashLogger.class));
 		assertThat(subject.workingState(), instanceOf(StateAccessor.class));
+		assertThat(subject.latestSignedState(), instanceOf(StateAccessor.class));
 		assertThat(subject.expansionHelper(), instanceOf(ExpansionHelper.class));
 		assertThat(subject.expandHandleSpan(), instanceOf(ExpandHandleSpan.class));
 		assertThat(subject.dualStateAccessor(), instanceOf(DualStateAccessor.class));

--- a/hedera-node/src/test/java/com/hedera/services/ServicesMainTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/ServicesMainTest.java
@@ -34,7 +34,6 @@ import com.hedera.services.state.merkle.MerkleAccount;
 import com.hedera.services.state.validation.LedgerValidator;
 import com.hedera.services.stats.ServicesStatsManager;
 import com.hedera.services.stream.RecordStreamManager;
-import com.hedera.services.txns.network.UpgradeActions;
 import com.hedera.services.utils.EntityNum;
 import com.hedera.services.utils.NamedDigestFactory;
 import com.hedera.services.utils.SystemExits;
@@ -128,13 +127,13 @@ class ServicesMainTest {
 	@Mock
 	private CurrentPlatformStatus currentPlatformStatus;
 	@Mock
-	private UpgradeActions upgradeActions;
-	@Mock
 	private RecordStreamManager recordStreamManager;
 	@Mock
 	private ServicesState signedState;
 	@Mock
 	private BalancesExporter balancesExporter;
+	@Mock
+	private StateAccessor latestSignedState;
 
 	private ServicesMain subject = new ServicesMain();
 
@@ -267,6 +266,7 @@ class ServicesMainTest {
 
 		given(app.platformStatus()).willReturn(currentPlatformStatus);
 		given(app.balancesExporter()).willReturn(balancesExporter);
+		given(app.latestSignedState()).willReturn(latestSignedState);
 		given(currentPlatformStatus.get()).willReturn(MAINTENANCE);
 		// and:
 		subject.init(platform, nodeId);
@@ -276,6 +276,7 @@ class ServicesMainTest {
 
 		// then:
 		verify(signedState).logSummary();
+		verify(latestSignedState).replaceChildrenFrom(signedState, consensusNow);
 	}
 
 	@Test

--- a/hedera-node/src/test/java/com/hedera/services/ServicesMainTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/ServicesMainTest.java
@@ -285,6 +285,7 @@ class ServicesMainTest {
 
 		given(app.platformStatus()).willReturn(currentPlatformStatus);
 		given(app.balancesExporter()).willReturn(balancesExporter);
+		given(app.latestSignedState()).willReturn(latestSignedState);
 		given(app.nodeId()).willReturn(nodeId);
 		given(balancesExporter.isTimeToExport(consensusNow)).willReturn(true);
 		given(currentPlatformStatus.get()).willReturn(ACTIVE);

--- a/hedera-node/src/test/java/com/hedera/services/ServicesStateTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/ServicesStateTest.java
@@ -577,7 +577,7 @@ class ServicesStateTest {
 		final var copy = subject.copy();
 
 		// then:
-		verify(workingState).updateFrom(copy);
+		verify(workingState).updateChildrenFrom(copy);
 	}
 
 	@Test

--- a/hedera-node/src/test/java/com/hedera/services/context/init/StateInitializationFlowTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/context/init/StateInitializationFlowTest.java
@@ -120,7 +120,7 @@ class StateInitializationFlowTest {
 
 		// then:
 		verify(staticNumbersHolder).accept(defaultNumbers);
-		verify(stateAccessor).updateFrom(activeState);
+		verify(stateAccessor).updateChildrenFrom(activeState);
 		verify(recordStreamManager).setInitialHash(hash);
 		verify(hfs).register(aFileInterceptor);
 		verify(hfs).register(bFileInterceptor);
@@ -142,7 +142,7 @@ class StateInitializationFlowTest {
 		subject.runWith(activeState);
 
 		// then:
-		verify(stateAccessor).updateFrom(activeState);
+		verify(stateAccessor).updateChildrenFrom(activeState);
 		verify(recordStreamManager).setInitialHash(hash);
 		verify(hfs, never()).register(any());
 		verify(staticNumbersHolder).accept(defaultNumbers);

--- a/hedera-node/src/test/java/com/hedera/services/sigs/metadata/StateChildrenSigMetadataLookupTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/sigs/metadata/StateChildrenSigMetadataLookupTest.java
@@ -1,5 +1,25 @@
 package com.hedera.services.sigs.metadata;
 
+/*-
+ * ‌
+ * Hedera Services Node
+ * ​
+ * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
 import com.hedera.services.config.MockFileNumbers;
 import com.hedera.services.context.StateChildren;
 import com.hedera.services.context.primitives.StateView;

--- a/hedera-node/src/test/java/com/hedera/services/sigs/metadata/TokenMetaUtilsTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/sigs/metadata/TokenMetaUtilsTest.java
@@ -1,5 +1,25 @@
 package com.hedera.services.sigs.metadata;
 
+/*-
+ * ‌
+ * Hedera Services Node
+ * ​
+ * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
 import com.hedera.services.state.merkle.MerkleToken;
 import com.hedera.services.state.submerkle.EntityId;
 import com.hedera.services.state.submerkle.FcCustomFee;

--- a/hedera-node/src/test/java/com/hedera/services/sigs/order/SignedStateSigReqsTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/sigs/order/SignedStateSigReqsTest.java
@@ -1,0 +1,126 @@
+package com.hedera.services.sigs.order;
+
+/*-
+ * ‌
+ * Hedera Services Node
+ * ​
+ * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import com.hedera.services.config.FileNumbers;
+import com.hedera.services.context.StateChildren;
+import com.hedera.services.context.properties.GlobalDynamicProperties;
+import com.hedera.services.ledger.accounts.AliasManager;
+import com.hedera.services.sigs.metadata.SigMetadataLookup;
+import com.hedera.services.state.StateAccessor;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Instant;
+
+import static com.hedera.services.sigs.order.SignedStateSigReqs.TOKEN_META_TRANSFORM;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.mockito.internal.verification.VerificationModeFactory.times;
+
+@ExtendWith(MockitoExtension.class)
+class SignedStateSigReqsTest {
+	@Mock
+	private FileNumbers fileNumbers;
+	@Mock
+	private AliasManager aliasManager;
+	@Mock
+	private StateAccessor workingState;
+	@Mock
+	private StateAccessor latestSignedState;
+	@Mock
+	private SignatureWaivers signatureWaivers;
+	@Mock
+	private GlobalDynamicProperties properties;
+	@Mock
+	private SigMetadataLookup sigMetadataLookup;
+	@Mock
+	private SigRequirements sigRequirements;
+	@Mock
+	private SigRequirements otherSigRequirements;
+	@Mock
+	private SignedStateSigReqs.SigReqsFactory sigReqsFactory;
+	@Mock
+	private SignedStateSigReqs.StateChildrenLookupsFactory lookupsFactory;
+
+	private SignedStateSigReqs subject;
+
+	@BeforeEach
+	void setUp() {
+		subject = new SignedStateSigReqs(
+				fileNumbers, aliasManager, signatureWaivers, properties, workingState, latestSignedState);
+	}
+
+	@Test
+	void usesWorkingStateLookupIfNoSignedState() {
+		given(latestSignedState.children()).willReturn(unsignedChildren);
+		given(workingState.children()).willReturn(workingChildren);
+		given(lookupsFactory.from(fileNumbers, aliasManager, workingChildren, TOKEN_META_TRANSFORM))
+				.willReturn(sigMetadataLookup);
+		given(sigReqsFactory.from(sigMetadataLookup, properties, signatureWaivers))
+				.willReturn(sigRequirements);
+		subject.setLookupsFactory(lookupsFactory);
+		subject.setSigReqsFactory(sigReqsFactory);
+
+		final var firstAns = subject.getBestAvailable();
+		final var secondAns = subject.getBestAvailable();
+
+		assertSame(sigRequirements, firstAns);
+		assertSame(sigRequirements, secondAns);
+		verify(sigReqsFactory, times(1)).from(sigMetadataLookup, properties, signatureWaivers);
+	}
+
+	@Test
+	void usesLatestSignedStateChildrenIfChanged() {
+		given(latestSignedState.children()).willReturn(firstSignedChildren);
+		given(lookupsFactory.from(fileNumbers, aliasManager, firstSignedChildren, TOKEN_META_TRANSFORM))
+				.willReturn(sigMetadataLookup);
+		given(sigReqsFactory.from(sigMetadataLookup, properties, signatureWaivers))
+				.willReturn(sigRequirements);
+		subject.setLookupsFactory(lookupsFactory);
+		subject.setSigReqsFactory(sigReqsFactory);
+
+		final var firstAns = subject.getBestAvailable();
+		final var secondAns = subject.getBestAvailable();
+		assertSame(sigRequirements, firstAns);
+		assertSame(sigRequirements, secondAns);
+
+		given(latestSignedState.children()).willReturn(secondSignedChildren);
+		given(lookupsFactory.from(fileNumbers, aliasManager, secondSignedChildren, TOKEN_META_TRANSFORM))
+				.willReturn(sigMetadataLookup);
+		given(sigReqsFactory.from(sigMetadataLookup, properties, signatureWaivers))
+				.willReturn(otherSigRequirements);
+		final var thirdAns = subject.getBestAvailable();
+		assertSame(otherSigRequirements, thirdAns);
+
+		verify(sigReqsFactory, times(2)).from(sigMetadataLookup, properties, signatureWaivers);
+	}
+
+	private static final Instant signedAt = Instant.ofEpochSecond(1_234_567, 890);
+	private static final StateChildren unsignedChildren = new StateChildren();
+	private static final StateChildren workingChildren = new StateChildren();
+	private static final StateChildren firstSignedChildren = new StateChildren(signedAt);
+	private static final StateChildren secondSignedChildren = new StateChildren(signedAt.plusSeconds(3));
+}

--- a/hedera-node/src/test/java/com/hedera/services/txns/crypto/AutoCreationLogicTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/txns/crypto/AutoCreationLogicTest.java
@@ -1,5 +1,25 @@
 package com.hedera.services.txns.crypto;
 
+/*-
+ * ‌
+ * Hedera Services Node
+ * ​
+ * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
 import com.google.protobuf.ByteString;
 import com.hedera.services.context.TransactionContext;
 import com.hedera.services.context.primitives.StateView;

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/AutoCreateUtils.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/AutoCreateUtils.java
@@ -1,5 +1,25 @@
 package com.hedera.services.bdd.suites.crypto;
 
+/*-
+ * ‌
+ * Hedera Services Test Clients
+ * ​
+ * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
 import com.google.protobuf.ByteString;
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.hederahashgraph.api.proto.java.Key;


### PR DESCRIPTION
**Description**:
- Adds to the context [a `StateAccessor`](https://github.com/hashgraph/hedera-services/blob/02019-M-ImplSignedStateSigReqsMgr/hedera-node/src/main/java/com/hedera/services/state/StateModule.java#L239) whose children are [continually updated from the latest signed state](https://github.com/hashgraph/hedera-services/blob/02019-M-ImplSignedStateSigReqsMgr/hedera-node/src/main/java/com/hedera/services/ServicesMain.java#L99) by `ServicesMain.newSignedState()`.
- Pro-actively implements the [`SignedStateSigReqs`](https://github.com/hashgraph/hedera-services/blob/02019-M-ImplSignedStateSigReqsMgr/hedera-node/src/main/java/com/hedera/services/sigs/order/SignedStateSigReqs.java#L45) that will use the `@LatestSignedState` accessor to help `ServicesState.expandSignatures()` use the latest signed state for signature metadata lookups.
- Adds missing license headers. 😞 

**Related issue(s)**:
- Fulfills a second architectural pre-req to #2019 