### PR TITLE
Distinguish `0.0.<alias>` from the removal sentinel AccountID `0.0.0`

### DIFF
--- a/hapi-fees/src/main/java/com/hedera/services/usage/token/TokenUpdateUsage.java
+++ b/hapi-fees/src/main/java/com/hedera/services/usage/token/TokenUpdateUsage.java
@@ -168,7 +168,11 @@ public class TokenUpdateUsage extends TokenTxnUsage<TokenUpdateUsage> {
 	}
 
 	private boolean removesAutoRenewAccount(TokenUpdateTransactionBody op) {
-		return op.hasAutoRenewAccount() && op.getAutoRenewAccount().equals(AccountID.getDefaultInstance());
+		return op.hasAutoRenewAccount() && designatesAccountRemoval(op.getAutoRenewAccount());
+	}
+
+	private boolean designatesAccountRemoval(AccountID id) {
+		return id.getShardNum() == 0 && id.getRealmNum() == 0 && id.getAccountNum() == 0 && id.getAlias().isEmpty();
 	}
 
 	private void updateCurrentRb(long amount) {

--- a/hedera-node/src/main/java/com/hedera/services/context/primitives/StateView.java
+++ b/hedera-node/src/main/java/com/hedera/services/context/primitives/StateView.java
@@ -101,7 +101,7 @@ import static java.util.Collections.unmodifiableMap;
 public class StateView {
 	private static final Logger log = LogManager.getLogger(StateView.class);
 
-	private static final AccountID WILDCARD_OWNER = AccountID.newBuilder()
+	public static final AccountID WILDCARD_OWNER = AccountID.newBuilder()
 			.setAccountNum(0L)
 			.build();
 

--- a/hedera-node/src/main/java/com/hedera/services/store/tokens/HederaTokenStore.java
+++ b/hedera-node/src/main/java/com/hedera/services/store/tokens/HederaTokenStore.java
@@ -333,7 +333,7 @@ public class HederaTokenStore extends HederaStore implements TokenStore {
 			}
 
 			var owner = (EntityId) nftsLedger.get(nftId, OWNER);
-			if (owner.equals(fromGrpcAccountId(AccountID.getDefaultInstance()))) {
+			if (owner.equals(EntityId.MISSING_ENTITY_ID)) {
 				final var tid = nftId.tokenId();
 				final var key = EntityNum.fromTokenId(tid);
 				owner = this.tokens.get().get(key).treasury();

--- a/hedera-node/src/main/java/com/hedera/services/txns/consensus/TopicUpdateTransitionLogic.java
+++ b/hedera-node/src/main/java/com/hedera/services/txns/consensus/TopicUpdateTransitionLogic.java
@@ -233,7 +233,7 @@ public class TopicUpdateTransitionLogic implements TransitionLogic {
 	}
 
 	private boolean designatesAccountRemoval(AccountID id) {
-		return id.getShardNum() == 0 && id.getRealmNum() == 0 && id.getAccountNum() == 0;
+		return id.getShardNum() == 0 && id.getRealmNum() == 0 && id.getAccountNum() == 0 && id.getAlias().isEmpty();
 	}
 
 	private boolean canApplyNewKeys(ConsensusUpdateTopicTransactionBody op, MerkleTopic topic) {

--- a/hedera-node/src/main/java/com/hedera/services/utils/EntityIdUtils.java
+++ b/hedera-node/src/main/java/com/hedera/services/utils/EntityIdUtils.java
@@ -22,6 +22,7 @@ package com.hedera.services.utils;
 
 import com.google.common.primitives.Ints;
 import com.google.common.primitives.Longs;
+import com.hedera.services.context.primitives.StateView;
 import com.hedera.services.state.submerkle.EntityId;
 import com.hedera.services.store.models.Id;
 import com.hederahashgraph.api.proto.java.AccountID;
@@ -170,7 +171,7 @@ public final class EntityIdUtils {
 
 	public static AccountID asAccount(final EntityId jId) {
 		if (jId == null || jId.equals(EntityId.MISSING_ENTITY_ID)) {
-			return AccountID.getDefaultInstance();
+			return StateView.WILDCARD_OWNER;
 		}
 		return AccountID.newBuilder()
 				.setRealmNum(jId.realm())

--- a/hedera-node/src/test/java/com/hedera/services/txns/consensus/MerkleTopicUpdateTransitionLogicTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/txns/consensus/MerkleTopicUpdateTransitionLogicTest.java
@@ -20,6 +20,7 @@ package com.hedera.services.txns.consensus;
  * ‍
  */
 
+import com.google.protobuf.ByteString;
 import com.google.protobuf.StringValue;
 import com.hedera.services.context.TransactionContext;
 import com.hedera.services.ledger.HederaLedger;
@@ -316,7 +317,7 @@ class MerkleTopicUpdateTransitionLogicTest {
 	}
 
 	@Test
-	void failsOnInvalidTopic() throws Throwable {
+	void failsOnInvalidTopic() {
 		// given:
 		givenValidTransactionInvalidTopic();
 
@@ -382,7 +383,7 @@ class MerkleTopicUpdateTransitionLogicTest {
 	}
 
 	@Test
-	void clearsAutoRenewAccount() throws Throwable {
+	void clearsAutoRenewAccountIfCorrectSentinelUsed() throws Throwable {
 		// given:
 		givenExistingTopicWithAutoRenewAccount();
 		givenTransactionClearingAutoRenewAccount();
@@ -394,6 +395,21 @@ class MerkleTopicUpdateTransitionLogicTest {
 		var topic = topics.get(EntityNum.fromTopicId(TOPIC_ID));
 		verify(transactionContext).setStatus(SUCCESS);
 		assertFalse(topic.hasAutoRenewAccountId());
+	}
+
+	@Test
+	void doesntClearAutoRenewAccountIfSentinelWithAliasUsed() throws Throwable {
+		// given:
+		givenExistingTopicWithAutoRenewAccount();
+		givenTransactionChangingAutoRenewAccountWithAliasId();
+
+		// when:
+		subject.doStateTransition();
+
+		// then:
+		var topic = topics.get(EntityNum.fromTopicId(TOPIC_ID));
+		verify(transactionContext).setStatus(INVALID_AUTORENEW_ACCOUNT);
+		assertTrue(topic.hasAutoRenewAccountId());
 	}
 
 	private void assertTopicNotUpdated(MerkleTopic originalMerkleTopic, MerkleTopic originalMerkleTopicClone) {
@@ -487,6 +503,14 @@ class MerkleTopicUpdateTransitionLogicTest {
 				getBasicValidTransactionBodyBuilder()
 						.setAutoRenewAccount(
 								AccountID.newBuilder().setShardNum(0).setRealmNum(0).setAccountNum(0).build())
+		);
+	}
+
+	private void givenTransactionChangingAutoRenewAccountWithAliasId() {
+		givenTransaction(
+				getBasicValidTransactionBodyBuilder()
+						.setAutoRenewAccount(
+								AccountID.newBuilder().setAlias(ByteString.copyFromUtf8("pretend")).build())
 		);
 	}
 

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/AccountBalancesClientSaveLoadTest.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/AccountBalancesClientSaveLoadTest.java
@@ -174,7 +174,7 @@ public class AccountBalancesClientSaveLoadTest extends LoadTest  {
 						withOpContext( (spec, log) -> {
 							if(settings.getBooleanProperty("clientToExportBalances", false)) {
 								log.info("Now get all {} accounts created and save them", totalAccounts);
-								AccountID acctID = AccountID.getDefaultInstance();
+								AccountID acctID;
 								String lastGoodAcct = null;
 								int acctProcessed = 0;
 								int batchSize = 10000;


### PR DESCRIPTION
**Description**:
- In a `TopicUpdate`, if the auto-renew account is set to an alias `AccountID`, returns `INVALID_ACCOUNT_ID`.

**Related issue(s)**:
- Fixes #2688
