### PR TITLE
Add javadoc to `TxnIdRecentHistory` and counting of `numDuplicatesFromDifferentNodes`

### DIFF
--- a/hedera-node/src/main/java/com/hedera/services/records/RecordCache.java
+++ b/hedera-node/src/main/java/com/hedera/services/records/RecordCache.java
@@ -157,7 +157,7 @@ public class RecordCache {
 		if (recentHistory == null) {
 			return Collections.emptyList();
 		} else {
-			return recentHistory.duplicateRecords()
+			return recentHistory.allDuplicateRecords()
 					.stream()
 					.map(ExpirableTxnRecord::asGrpc)
 					.toList();

--- a/hedera-node/src/main/java/com/hedera/services/records/TxnIdRecentHistory.java
+++ b/hedera-node/src/main/java/com/hedera/services/records/TxnIdRecentHistory.java
@@ -41,13 +41,40 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_PAYER_
 import static java.util.Comparator.comparing;
 import static java.util.Comparator.comparingLong;
 
+/**
+ * Manages the recent history of a {@code TransactionID}. This history consists of records, where
+ * each record gives the result of a transaction reaching consensus and being handled. There are
+ * two types of records:
+ * <ol>
+ *     <li><b>Unclassifiable records</b> - records whose final status was {@code INVALID_NODE_ACCOUNT} or
+ *     {@code INVALID_PAYER_SIGNATURE}. These statuses are inherently suspicious, and suggest a malicious
+ *     node (since under normal conditions a node should never submit a transaction that ends with either
+ *     status). So they do not cause other transactions to be classified as a duplicate.</li>
+ *     <li><b>Classifiable records</b> - records whose final status was anything other than the two suspicious
+ *     results above. All classifiable records after the first are either <i>duplicates</i> or
+ *     <i>node duplicates</i>. (A node duplicate is a duplicate that reached consensus <i>after</i> a previous
+ *     classifiable transaction submitted by the same node.)</li>
+ * </ol>
+ *
+ * <p>The implementation uses two linked lists of records, one for classifiable records and one for
+ * unclassifiable. We ensure node duplicates can be identified in constant time (depending only on
+ * the number of nodes in the network) by keeping all the non-node duplicates at the start of the
+ * classifiable record list in a prefix of length {@code numDuplicatesFromDifferentNodes}.</p>
+ *
+ * <p>So to classify a new record from node X as either unique, duplicate, or node duplicate, we only
+ * need to iterate through the first {@code numDuplicatesFromDifferentNodes} records in the classifiable
+ * list. If none of these records were submitted by node X, the new record cannot be a node duplicate.
+ * We then insert it at position {@code numDuplicatesFromDifferentNodes}, and increment {@code numDuplicatesFromDifferentNodes++}.
+ * (If any <i>were</i> submitted by node X, of course the new record is a node duplicate; and we just
+ * add it to the very end of the classifiable list, leaving {@code numDuplicatesFromDifferentNodes} unchanged.)</p>
+ */
 public class TxnIdRecentHistory {
 	private static final Comparator<RichInstant> RI_CMP =
 			comparingLong(RichInstant::getSeconds).thenComparingInt(RichInstant::getNanos);
 	private static final Comparator<ExpirableTxnRecord> CONSENSUS_TIME_COMPARATOR =
 			comparing(r -> r.getConsensusTimestamp(), RI_CMP);
 
-	private int numDuplicates = 0;
+	private int numDuplicatesFromDifferentNodes = 0;
 
 	List<ExpirableTxnRecord> memory = null;
 	List<ExpirableTxnRecord> classifiableRecords = null;
@@ -57,6 +84,13 @@ public class TxnIdRecentHistory {
 			INVALID_NODE_ACCOUNT,
 			INVALID_PAYER_SIGNATURE);
 
+	/**
+	 * Returns the "highest-priority" record with this transaction id, which is defined
+	 * as either the oldest classifiable record, if one exists; or the oldest unclassifiable
+	 * record, if one exists.
+	 *
+	 * @return the highest-priority record if any exists, null otherwise
+	 */
 	public ExpirableTxnRecord priorityRecord() {
 		if (areForgotten(classifiableRecords)) {
 			return areForgotten(unclassifiableRecords) ? null : unclassifiableRecords.get(0);
@@ -65,37 +99,32 @@ public class TxnIdRecentHistory {
 		}
 	}
 
-	public List<ExpirableTxnRecord> duplicateRecords() {
-		return Stream.concat(classifiableDuplicates(), unclassifiableDuplicates())
+	/**
+	 * Returns all the duplicate records in this recent history, ordered by consensus time.
+	 *
+	 * @return all the duplicate historical records in chronological order
+	 */
+	public List<ExpirableTxnRecord> allDuplicateRecords() {
+		return Stream.concat(duplicateClassifiableRecords(), duplicateUnclassifiableRecords())
 				.sorted(CONSENSUS_TIME_COMPARATOR)
 				.toList();
 	}
 
-	private Stream<ExpirableTxnRecord> classifiableDuplicates() {
-		if (areForgotten(classifiableRecords) || classifiableRecords.size() == 1) {
-			return Stream.empty();
-		} else {
-			return classifiableRecords.subList(1, classifiableRecords.size()).stream();
-		}
-	}
-
-	private Stream<ExpirableTxnRecord> unclassifiableDuplicates() {
-		final var startIndex = areForgotten(classifiableRecords) ? 1 : 0;
-		if (areForgotten(unclassifiableRecords) || unclassifiableRecords.size() <= startIndex) {
-			return Stream.empty();
-		} else {
-			return unclassifiableRecords.subList(startIndex, unclassifiableRecords.size()).stream();
-		}
-	}
-
+	/**
+	 * Indicates if there are any records in this recent history.
+	 *
+	 * @return true if there are no records in the recent history, false otherwise
+	 */
 	public boolean isForgotten() {
 		return areForgotten(classifiableRecords) && areForgotten(unclassifiableRecords);
 	}
 
-	private boolean areForgotten(final List<ExpirableTxnRecord> records) {
-		return records == null || records.isEmpty();
-	}
-
+	/**
+	 * Adds a record to the recent history based on the provided final status of {@code handleTransaction}.
+	 *
+	 * @param expirableTxnRecord a record belonging to this history
+	 * @param status the final status of the associated transaction
+	 */
 	public void observe(final ExpirableTxnRecord expirableTxnRecord, final ResponseCodeEnum status) {
 		if (UNCLASSIFIABLE_STATUSES.contains(status)) {
 			addUnclassifiable(expirableTxnRecord);
@@ -104,18 +133,82 @@ public class TxnIdRecentHistory {
 		}
 	}
 
-	public void stage(ExpirableTxnRecord unorderedRecord) {
+	/**
+	 * Used during a reconnect or restart to "stage" a collection of records which can then be sorted by
+	 * consensus time and replayed with a call to {@link TxnIdRecentHistory#observeStaged()}. This is
+	 * critical so that the reconnected node will classify any future records in exactly the same way
+	 * as nodes that did not reconnect.
+	 *
+	 * @param unorderedRecord a record from a saved state that belongs to this recent history
+	 */
+	public void stage(final ExpirableTxnRecord unorderedRecord) {
 		if (memory == null) {
 			memory = new ArrayList<>();
 		}
 		memory.add(unorderedRecord);
 	}
 
+	/**
+	 * Replays all the records given to {@link TxnIdRecentHistory#stage} as if they had been given to
+	 * {@link TxnIdRecentHistory#observe(ExpirableTxnRecord, ResponseCodeEnum)} in consensus order.
+	 */
 	public void observeStaged() {
 		memory.sort(CONSENSUS_TIME_COMPARATOR);
 		memory.forEach(expirableTxnRecord -> this.observe(expirableTxnRecord,
 				ResponseCodeEnum.valueOf(expirableTxnRecord.getReceipt().getStatus())));
 		memory = null;
+	}
+
+	/**
+	 * Expires from the history any record with an expiration that is <b>not after</b> the given consensus second.
+	 *
+	 * @param now the current consensus second
+	 */
+	public void forgetExpiredAt(final long now) {
+		if (classifiableRecords != null) {
+			forgetFromClassifiableList(now);
+		}
+		if (unclassifiableRecords != null) {
+			forgetFromUnclassifiableList(now);
+		}
+	}
+
+	/**
+	 * Classifies the duplicate status that a new classifiable record from the given member would receive, given the
+	 * current history.
+	 *
+	 * @param submittingMember a node id
+	 * @return the duplicate status of a classifiable record from the given node
+	 */
+	public DuplicateClassification currentDuplicityFor(final long submittingMember) {
+		if (numDuplicatesFromDifferentNodes == 0) {
+			return BELIEVED_UNIQUE;
+		}
+		final var iter = classifiableRecords.listIterator();
+		for (int i = 0; i < numDuplicatesFromDifferentNodes; i++) {
+			if (iter.next().getSubmittingMember() == submittingMember) {
+				return NODE_DUPLICATE;
+			}
+		}
+		return DUPLICATE;
+	}
+
+	/* --- Internal helpers --- */
+	private Stream<ExpirableTxnRecord> duplicateClassifiableRecords() {
+		if (areForgotten(classifiableRecords) || classifiableRecords.size() == 1) {
+			return Stream.empty();
+		} else {
+			return classifiableRecords.subList(1, classifiableRecords.size()).stream();
+		}
+	}
+
+	private Stream<ExpirableTxnRecord> duplicateUnclassifiableRecords() {
+		final var startIndex = areForgotten(classifiableRecords) ? 1 : 0;
+		if (areForgotten(unclassifiableRecords) || unclassifiableRecords.size() <= startIndex) {
+			return Stream.empty();
+		} else {
+			return unclassifiableRecords.subList(startIndex, unclassifiableRecords.size()).stream();
+		}
 	}
 
 	private void addClassifiable(final ExpirableTxnRecord expirableTxnRecord) {
@@ -126,7 +219,7 @@ public class TxnIdRecentHistory {
 		final var submittingMember = expirableTxnRecord.getSubmittingMember();
 		final var iter = classifiableRecords.listIterator();
 		boolean isNodeDuplicate = false;
-		while (i < numDuplicates) {
+		while (i < numDuplicatesFromDifferentNodes) {
 			if (submittingMember == iter.next().getSubmittingMember()) {
 				isNodeDuplicate = true;
 				break;
@@ -136,7 +229,7 @@ public class TxnIdRecentHistory {
 		if (isNodeDuplicate) {
 			classifiableRecords.add(expirableTxnRecord);
 		} else {
-			numDuplicates++;
+			numDuplicatesFromDifferentNodes++;
 			iter.add(expirableTxnRecord);
 		}
 	}
@@ -148,37 +241,43 @@ public class TxnIdRecentHistory {
 		unclassifiableRecords.add(expirableTxnRecord);
 	}
 
-	public void forgetExpiredAt(final long now) {
-		if (classifiableRecords != null) {
-			forgetFromList(classifiableRecords, now);
-		}
-		if (unclassifiableRecords != null) {
-			forgetFromList(unclassifiableRecords, now);
-		}
+	private boolean areForgotten(final List<ExpirableTxnRecord> records) {
+		return records == null || records.isEmpty();
 	}
 
-	private void forgetFromList(final List<ExpirableTxnRecord> records, final long now) {
-		final var size = records.size();
+	private void forgetFromUnclassifiableList(final long now) {
+		final var size = unclassifiableRecords.size();
 		if (size > 1) {
-			records.removeIf(expirableTxnRecord -> expirableTxnRecord.getExpiry() <= now);
+			unclassifiableRecords.removeIf(expirableTxnRecord -> expirableTxnRecord.getExpiry() <= now);
 		} else if (size == 1) {
-			final var onlyRecord = records.get(0);
+			final var onlyRecord = unclassifiableRecords.get(0);
 			if (onlyRecord.getExpiry() <= now) {
-				records.clear();
+				unclassifiableRecords.clear();
 			}
 		}
 	}
 
-	public DuplicateClassification currentDuplicityFor(final long submittingMember) {
-		if (numDuplicates == 0) {
-			return BELIEVED_UNIQUE;
-		}
-		final var iter = classifiableRecords.listIterator();
-		for (int i = 0; i < numDuplicates; i++) {
-			if (iter.next().getSubmittingMember() == submittingMember) {
-				return NODE_DUPLICATE;
+	private void forgetFromClassifiableList(final long now) {
+		final var size = classifiableRecords.size();
+		if (size > 1) {
+			final var iter = classifiableRecords.iterator();
+			var discardedDuplicatesFromDifferentNodes = 0;
+			for (int i = 0; iter.hasNext(); i++) {
+				final var record = iter.next();
+				if (record.getExpiry() <= now) {
+					iter.remove();
+					if (i < numDuplicatesFromDifferentNodes) {
+						discardedDuplicatesFromDifferentNodes++;
+					}
+				}
+			}
+			numDuplicatesFromDifferentNodes -= discardedDuplicatesFromDifferentNodes;
+		} else if (size == 1) {
+			final var onlyRecord = classifiableRecords.get(0);
+			if (onlyRecord.getExpiry() <= now) {
+				classifiableRecords.clear();
+				numDuplicatesFromDifferentNodes = 0;
 			}
 		}
-		return DUPLICATE;
 	}
 }

--- a/hedera-node/src/main/java/com/hedera/services/records/TxnIdRecentHistory.java
+++ b/hedera-node/src/main/java/com/hedera/services/records/TxnIdRecentHistory.java
@@ -263,8 +263,8 @@ public class TxnIdRecentHistory {
 			final var iter = classifiableRecords.iterator();
 			var discardedDuplicatesFromDifferentNodes = 0;
 			for (int i = 0; iter.hasNext(); i++) {
-				final var record = iter.next();
-				if (record.getExpiry() <= now) {
+				final var nextRecord = iter.next();
+				if (nextRecord.getExpiry() <= now) {
 					iter.remove();
 					if (i < numDuplicatesFromDifferentNodes) {
 						discardedDuplicatesFromDifferentNodes++;

--- a/hedera-node/src/test/java/com/hedera/services/records/RecordCacheTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/records/RecordCacheTest.java
@@ -105,7 +105,7 @@ class RecordCacheTest {
 	@Test
 	void getsDuplicateRecordsAsExpected() {
 		final var duplicateRecords = List.of(aRecord);
-		given(recentHistory.duplicateRecords()).willReturn(duplicateRecords);
+		given(recentHistory.allDuplicateRecords()).willReturn(duplicateRecords);
 		given(histories.get(txnIdA)).willReturn(recentHistory);
 
 		final var actual = subject.getDuplicateRecords(txnIdA);
@@ -172,7 +172,7 @@ class RecordCacheTest {
 	void getsDuplicateReceiptsAsExpected() {
 		final var history = mock(TxnIdRecentHistory.class);
 		final var duplicateRecords = List.of(aRecord);
-		given(history.duplicateRecords()).willReturn(duplicateRecords);
+		given(history.allDuplicateRecords()).willReturn(duplicateRecords);
 		given(histories.get(txnIdA)).willReturn(history);
 
 		final var duplicateReceipts = subject.getDuplicateReceipts(txnIdA);

--- a/hedera-node/src/test/java/com/hedera/services/records/TxnIdRecentHistoryTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/records/TxnIdRecentHistoryTest.java
@@ -132,7 +132,7 @@ class TxnIdRecentHistoryTest {
 
 	@Test
 	void recognizesEmptyDuplicates() {
-		assertTrue(subject.duplicateRecords().isEmpty());
+		assertTrue(subject.allDuplicateRecords().isEmpty());
 	}
 
 	@Test
@@ -171,6 +171,16 @@ class TxnIdRecentHistoryTest {
 	}
 
 	@Test
+	void canStillClassifyDuplicatesAfterSomeHistoryIsExpired() {
+		givenSomeWellKnownHistoryWithListOfSizeGreaterThanOne();
+
+		subject.forgetExpiredAt(expiryAtOffset(4));
+
+		assertEquals(DUPLICATE, subject.currentDuplicityFor(2));
+		assertEquals(NODE_DUPLICATE, subject.currentDuplicityFor(3));
+	}
+
+	@Test
 	void forgetsAsExpectedFromListOfSizeOne() {
 		givenSomeWellKnownHistoryWithListOfSizeOne();
 
@@ -201,7 +211,7 @@ class TxnIdRecentHistoryTest {
 				recordOf(2, 1, INVALID_NODE_ACCOUNT),
 				INVALID_NODE_ACCOUNT);
 
-		final var duplicates = subject.duplicateRecords();
+		final var duplicates = subject.allDuplicateRecords();
 
 		assertEquals(
 				List.of(
@@ -213,7 +223,7 @@ class TxnIdRecentHistoryTest {
 	void returnsOrderedDuplicates() {
 		givenSomeWellKnownHistoryWithListOfSizeGreaterThanOne();
 
-		final var records = subject.duplicateRecords();
+		final var records = subject.allDuplicateRecords();
 
 		assertEquals(
 				List.of(
@@ -225,6 +235,23 @@ class TxnIdRecentHistoryTest {
 						memoIdentifying(1, 6, INVALID_PAYER_SIGNATURE),
 						memoIdentifying(2, 7, INVALID_NODE_ACCOUNT)
 				), records.stream().map(ExpirableTxnRecord::getMemo).collect(toList()));
+	}
+
+	@Test
+	void forgetsFromExpiredClassifiableListOfSizeOne() {
+		subject.observe(
+				recordOf(1, 1, SUCCESS),
+				SUCCESS);
+
+		subject.forgetExpiredAt(expiryAtOffset(1));
+
+		assertTrue(subject.isForgotten());
+
+		subject.observe(
+				recordOf(1, 1, SUCCESS),
+				SUCCESS);
+		subject.forgetExpiredAt(expiryAtOffset(0));
+		assertEquals(NODE_DUPLICATE, subject.currentDuplicityFor(1));
 	}
 
 	private void givenSomeWellKnownHistoryWithListOfSizeGreaterThanOne() {

--- a/hedera-node/src/test/java/com/hedera/services/records/TxnIdRecentHistoryTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/records/TxnIdRecentHistoryTest.java
@@ -57,6 +57,21 @@ class TxnIdRecentHistoryTest {
 		subject = new TxnIdRecentHistory();
 	}
 
+
+	@Test
+	void safeToExpireFromEmptyHistory() {
+		subject.observe(
+				recordOf(0, 0, INVALID_NODE_ACCOUNT),
+				INVALID_NODE_ACCOUNT);
+		assertEquals(BELIEVED_UNIQUE, subject.currentDuplicityFor(1));
+		subject.observe(
+				recordOf(1, 0, SUCCESS),
+				SUCCESS);
+
+		subject.forgetExpiredAt(expiryAtOffset(0));
+		assertDoesNotThrow(() -> subject.forgetExpiredAt(expiryAtOffset(1)));
+	}
+
 	@Test
 	void getsMemory() {
 		subject.classifiableRecords = List.of(mock(ExpirableTxnRecord.class));

--- a/hedera-node/src/test/java/com/hedera/services/state/expiry/ExpiryManagerTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/state/expiry/ExpiryManagerTest.java
@@ -136,7 +136,7 @@ class ExpiryManagerTest {
 		// then:
 		assertFalse(liveTxnHistories.containsKey(leftoverTxnId));
 		assertEquals(firstThen, liveTxnHistories.get(newTxnId).priorityRecord().getExpiry());
-		assertEquals(secondThen, liveTxnHistories.get(newTxnId).duplicateRecords().get(0).getExpiry());
+		assertEquals(secondThen, liveTxnHistories.get(newTxnId).allDuplicateRecords().get(0).getExpiry());
 	}
 
 	@Test


### PR DESCRIPTION
**Description**:
- Adds javadoc to `TxnIdRecentHistory`.
- Fixes `TxnIdRecentHistory.forgetFromClassifiableList()` so that it decrements `numDuplicatesFromDifferentNodes` for each expired record that was not a node duplicate.

**Notes for reviewer**:
- Comment out [this line](https://github.com/hashgraph/hedera-services/blob/fix-recent-history-dup-counting/hedera-node/src/main/java/com/hedera/services/records/TxnIdRecentHistory.java#L274) and run [this unit test](https://github.com/hashgraph/hedera-services/blob/fix-recent-history-dup-counting/hedera-node/src/test/java/com/hedera/services/records/TxnIdRecentHistoryTest.java#L173) to see the previous failure mode.
- It's nearly impossible to write a system-level test to trigger this bug, since a node must be more than 100 seconds behind in handling consensus transactions **without the platform having switched to `PlatformStatus.BEHIND`** in order to submit a duplicate that can trigger the bug.
    * If the node is _not_ so far behind, it will recognize the duplicate transaction as expired, and reject it in precheck with `TRANSACTION_EXPIRED`.
    * So the node must receive the duplicate transaction exactly at the end of an extremely long sync that has blocked gossip. 