### PR TITLE
Update nightly regression on `hts-contracts`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -663,7 +663,7 @@ workflows:
   GCP-Weekly-Services-Crypto-Restart-Performance-15N-15C:
     triggers:
       - schedule:
-          cron: "5 5 * * 6"
+          cron: "5 2 * * 4"
           filters:
             branches:
               only:
@@ -685,7 +685,7 @@ workflows:
   GCP-Weekly-Services-MixedOps-Restart-Performance-21N-21C:
     triggers:
       - schedule:
-          cron: "0 2 * * 3"
+          cron: "0 23 * * 4"
           filters:
             branches:
               only:
@@ -708,7 +708,7 @@ workflows:
   GCP-Weekly-Services-HCS-Restart-Performance-15N-15C:
     triggers:
       - schedule:
-          cron: "5 10 * * 6"
+          cron: "5 7 * * 4"
           filters:
             branches:
               only:
@@ -731,7 +731,7 @@ workflows:
   GCP-Weekly-Services-HTS-Restart-Performance-15N-15C:
     triggers:
       - schedule:
-          cron: "5 15 * * 6"
+          cron: "5 12 * * 4"
           filters:
             branches:
               only:
@@ -754,7 +754,7 @@ workflows:
   GCP-Daily-Services-Comp-NetError-4N-1C:
     triggers:
       - schedule:
-          cron: "30 9 * * *"
+          cron: "30 2 * * *"
           filters:
             branches:
               only:
@@ -779,7 +779,7 @@ workflows:
   GCP-Create-Large-Volume-NFTs-SavedState:
     triggers:
       - schedule:
-          cron: "58 3 * * *"
+          cron: "58 0 * * *"
           filters:
             branches:
               only:
@@ -807,7 +807,7 @@ workflows:
   GCP-Daily-Services-Crypto-Migration-7N-1C:
     triggers:
       - schedule:
-          cron: "45 9 * * *"
+          cron: "45 2 * * *"
           filters:
             branches:
               only:
@@ -833,7 +833,7 @@ workflows:
   GCP-Daily-Services-Crypto-Migration-18N-1C:
     triggers:
           - schedule:
-              cron: "0 23,8 * * *"
+              cron: "0 20 * * *"
               filters:
                 branches:
                   only:
@@ -859,7 +859,7 @@ workflows:
   GCP-Daily-Services-Crypto-Restart-4N-1C:
     triggers:
       - schedule:
-          cron: "15 10 * * *"
+          cron: "15 3 * * *"
           filters:
             branches:
               only:
@@ -882,7 +882,7 @@ workflows:
   GCP-Daily-Services-Update-Ubuntu1804-4N-2C:
     triggers:
       - schedule:
-          cron: "0 3 * * *"
+          cron: "0 0 * * *"
           filters:
             branches:
               only:
@@ -905,7 +905,7 @@ workflows:
   GCP-Daily-Services-Update-Rhel7-4N-2C:
     triggers:
       - schedule:
-          cron: "15 3 * * *"
+          cron: "15 0 * * *"
           filters:
             branches:
               only:
@@ -928,7 +928,7 @@ workflows:
   GCP-Daily-Services-Update-Rhel8-4N-2C:
     triggers:
       - schedule:
-          cron: "30 3 * * *"
+          cron: "30 0 * * *"
           filters:
             branches:
               only:
@@ -951,7 +951,7 @@ workflows:
   GCP-Daily-Services-Update-CentOS7-4N-2C:
     triggers:
       - schedule:
-          cron: "45 3 * * *"
+          cron: "45 0 * * *"
           filters:
             branches:
               only:
@@ -974,7 +974,7 @@ workflows:
   GCP-Daily-Services-Crypto-Invalid-Accounts-4N-4C:
     triggers:
       - schedule:
-          cron: "0 4 * * *"
+          cron: "0 1 * * *"
           filters:
             branches:
               only:
@@ -997,7 +997,7 @@ workflows:
   GCP-Daily-Services-Update-4N-2C:
     triggers:
       - schedule:
-          cron: "30 22 * * *"
+          cron: "30 19 * * *"
           filters:
             branches:
               only:
@@ -1020,7 +1020,7 @@ workflows:
   GCP-Daily-Services-Comp-Update-DisPreUpdate-4N-2C:
     triggers:
       - schedule:
-          cron: "45 22 * * *"
+          cron: "45 19 * * *"
           filters:
             branches:
               only:
@@ -1043,7 +1043,7 @@ workflows:
   GCP-Daily-Services-Update-Reconnect-4N-2C:
     triggers:
       - schedule:
-          cron: "15 22 * * *"
+          cron: "15 19 * * *"
           filters:
             branches:
               only:
@@ -1066,7 +1066,7 @@ workflows:
   GCP-Daily-Services-Comp-Update-Reconnect-Abort-4N-2C:
     triggers:
       - schedule:
-          cron: "15 23 * * *"
+          cron: "15 20 * * *"
           filters:
             branches:
               only:
@@ -1089,7 +1089,7 @@ workflows:
   GCP-Daily-Services-Comp-Update-Reconnect-Abort-DisPreUpdate-4N-2C:
     triggers:
       - schedule:
-          cron: "30 23 * * *"
+          cron: "30 20 * * *"
           filters:
             branches:
               only:
@@ -1112,7 +1112,7 @@ workflows:
   GCP-Daily-Services-Account-Balances-client-validation-6N-1C:
     triggers:
       - schedule:
-          cron: "30 10 * * *"
+          cron: "30 3 * * *"
           filters:
             branches:
               only:
@@ -1136,7 +1136,7 @@ workflows:
   GCP-Daily-Services-Reconnect-6N-4C:
     triggers:
       - schedule:
-          cron: "40 9 * * *"
+          cron: "40 2 * * *"
           filters:
             branches:
               only:
@@ -1160,7 +1160,7 @@ workflows:
   GCP-Daily-Services-Global-3NReconnect-15N-4C:
     triggers:
       - schedule:
-          cron: "40 11 * * *"
+          cron: "40 4 * * *"
           filters:
             branches:
               only:
@@ -1183,7 +1183,7 @@ workflows:
   GCP-Weekly-Services-NetDelay-15N-1C:
     triggers:
       - schedule:
-          cron: "0 9 * * *"
+          cron: "0 2 * * *"
           filters:
             branches:
               only:
@@ -1206,7 +1206,7 @@ workflows:
   GCP-Daily-Services-Recovery-4N-1C:
     triggers:
       - schedule:
-          cron: "55 10 * * *"
+          cron: "55 3 * * *"
           filters:
             branches:
               only:
@@ -1229,7 +1229,7 @@ workflows:
   GCP-Weekly-Services-Query-Restart-Performance-7N-7C:
     triggers:
       - schedule:
-          cron: "0 10 * * 2"
+          cron: "0 3 * * 4"
           filters:
             branches:
               only:
@@ -1252,7 +1252,7 @@ workflows:
   GCP-Daily-Services-Comp-Restart-Performance-Hotspot-6N-6C:
     triggers:
       - schedule:
-          cron: "35 11 * * *"
+          cron: "35 4 * * *"
           filters:
             branches:
               only:
@@ -1275,7 +1275,7 @@ workflows:
   GCP-Daily-Services-Comp-Restart-Performance-Random-7N-7C:
     triggers:
       - schedule:
-          cron: "40 8 * * *"
+          cron: "40 1 * * *"
           filters:
             branches:
               only:
@@ -1299,7 +1299,7 @@ workflows:
   GCP-Daily-Services-HTS-Restart-Performance-7N-7C:
     triggers:
       - schedule:
-          cron: "30 8 * * *"
+          cron: "30 1 * * *"
           filters:
             branches:
               only:
@@ -1322,7 +1322,7 @@ workflows:
   GCP-Daily-Services-Comp-Reconnect-6N-1C:
     triggers:
       - schedule:
-          cron: "15 11 * * *"
+          cron: "15 4 * * *"
           filters:
             branches:
               only:
@@ -1345,7 +1345,7 @@ workflows:
   GCP-Daily-Services-Comp-NI-Reconnect-Correctness-6N-1C:
     triggers:
       - schedule:
-          cron: "25 11 * * *"
+          cron: "25 4 * * *"
           filters:
             branches:
               only:
@@ -1368,7 +1368,7 @@ workflows:
   GCP-Daily-Services-Comp-ND-Reconnect-Correctness-6N-1C:
     triggers:
       - schedule:
-          cron: "25 8 * * *"
+          cron: "25 5 * * *"
           filters:
             branches:
               only:
@@ -1391,7 +1391,7 @@ workflows:
   GCP-Daily-Services-Comp-3NReconnect-15N-4C:
     triggers:
       - schedule:
-          cron: "25 12 * * *"
+          cron: "25 5 * * *"
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -649,7 +649,7 @@ workflows:
           filters:
             branches:
               only:
-                - master
+                - hts-contracts
     jobs:
       - jrs_gcp_machine_cleanup:
           name: GCP-Machine-Cleanup
@@ -667,7 +667,7 @@ workflows:
           filters:
             branches:
               only:
-                - master
+                - hts-contracts
     jobs:
       - build-platform-and-services
       - jrs-regression:
@@ -689,7 +689,7 @@ workflows:
           filters:
             branches:
               only:
-                - master
+                - hts-contracts
     jobs:
       - build-platform-and-services
       - jrs-regression:
@@ -712,7 +712,7 @@ workflows:
           filters:
             branches:
               only:
-                - master
+                - hts-contracts
     jobs:
       - build-platform-and-services
       - jrs-regression:
@@ -735,7 +735,7 @@ workflows:
           filters:
             branches:
               only:
-                - master
+                - hts-contracts
     jobs:
       - build-platform-and-services
       - jrs-regression:
@@ -758,7 +758,7 @@ workflows:
           filters:
             branches:
               only:
-                - vm-plus-020-test.3
+                - hts-contracts
     jobs:
       - build-platform-and-services
       - jrs-regression:
@@ -811,7 +811,7 @@ workflows:
           filters:
             branches:
               only:
-                - vm-plus-020-test.3
+                - hts-contracts
     jobs:
       - build-platform-and-services
       - jrs-regression:
@@ -863,7 +863,7 @@ workflows:
           filters:
             branches:
               only:
-                - vm-plus-020-test.3
+                - hts-contracts
     jobs:
       - build-platform-and-services
       - jrs-regression:
@@ -886,7 +886,7 @@ workflows:
           filters:
             branches:
               only:
-                - master
+                - hts-contracts
     jobs:
       - build-platform-and-services
       - jrs-regression:
@@ -909,7 +909,7 @@ workflows:
           filters:
             branches:
               only:
-                - master
+                - hts-contracts
     jobs:
       - build-platform-and-services
       - jrs-regression:
@@ -932,7 +932,7 @@ workflows:
           filters:
             branches:
               only:
-                - master
+                - hts-contracts
     jobs:
       - build-platform-and-services
       - jrs-regression:
@@ -955,7 +955,7 @@ workflows:
           filters:
             branches:
               only:
-                - master
+                - hts-contracts
     jobs:
       - build-platform-and-services
       - jrs-regression:
@@ -978,7 +978,7 @@ workflows:
           filters:
             branches:
               only:
-                - master
+                - hts-contracts
     jobs:
       - build-platform-and-services
       - jrs-regression:
@@ -1001,7 +1001,7 @@ workflows:
           filters:
             branches:
               only:
-                - master
+                - hts-contracts
     jobs:
       - build-platform-and-services
       - jrs-regression:
@@ -1024,7 +1024,7 @@ workflows:
           filters:
             branches:
               only:
-                - master
+                - hts-contracts
     jobs:
       - build-platform-and-services
       - jrs-regression:
@@ -1047,7 +1047,7 @@ workflows:
           filters:
             branches:
               only:
-                - vm-plus-020-test.3
+                - hts-contracts
     jobs:
       - build-platform-and-services
       - jrs-regression:
@@ -1070,7 +1070,7 @@ workflows:
           filters:
             branches:
               only:
-                - master
+                - hts-contracts
     jobs:
       - build-platform-and-services
       - jrs-regression:
@@ -1093,7 +1093,7 @@ workflows:
           filters:
             branches:
               only:
-                - master
+                - hts-contracts
     jobs:
       - build-platform-and-services
       - jrs-regression:
@@ -1116,7 +1116,7 @@ workflows:
           filters:
             branches:
               only:
-                - vm-plus-020-test.3
+                - hts-contracts
     jobs:
       - build-platform-and-services
       - jrs-regression:
@@ -1140,7 +1140,7 @@ workflows:
           filters:
             branches:
               only:
-                - vm-plus-020-test.3
+                - hts-contracts
     jobs:
       - build-platform-and-services
       - jrs-regression:
@@ -1164,7 +1164,7 @@ workflows:
           filters:
             branches:
               only:
-                - vm-plus-020-test.3
+                - hts-contracts
     jobs:
       - build-platform-and-services
       - jrs-regression:
@@ -1187,7 +1187,7 @@ workflows:
           filters:
             branches:
               only:
-                - vm-plus-020-test.3
+                - hts-contracts
     jobs:
       - build-platform-and-services
       - jrs-regression:
@@ -1210,7 +1210,7 @@ workflows:
           filters:
             branches:
               only:
-                - vm-plus-020-test.3
+                - hts-contracts
     jobs:
       - build-platform-and-services
       - jrs-regression:
@@ -1233,7 +1233,7 @@ workflows:
           filters:
             branches:
               only:
-                - vm-plus-020-test.3
+                - hts-contracts
     jobs:
       - build-platform-and-services
       - jrs-regression:
@@ -1256,7 +1256,7 @@ workflows:
           filters:
             branches:
               only:
-                - vm-plus-020-test.3
+                - hts-contracts
     jobs:
       - build-platform-and-services
       - jrs-regression:
@@ -1279,7 +1279,7 @@ workflows:
           filters:
             branches:
               only:
-                - vm-plus-020-test.3
+                - hts-contracts
     jobs:
       - build-platform-and-services
       - jrs-regression:
@@ -1303,7 +1303,7 @@ workflows:
           filters:
             branches:
               only:
-                - vm-plus-020-test.3
+                - hts-contracts
     jobs:
       - build-platform-and-services
       - jrs-regression:
@@ -1326,7 +1326,7 @@ workflows:
           filters:
             branches:
               only:
-                - vm-plus-020-test.3
+                - hts-contracts
     jobs:
       - build-platform-and-services
       - jrs-regression:
@@ -1349,7 +1349,7 @@ workflows:
           filters:
             branches:
               only:
-                - vm-plus-020-test.3
+                - hts-contracts
     jobs:
       - build-platform-and-services
       - jrs-regression:
@@ -1372,7 +1372,7 @@ workflows:
           filters:
             branches:
               only:
-                - master
+                - hts-contracts
     jobs:
       - build-platform-and-services
       - jrs-regression:
@@ -1395,7 +1395,7 @@ workflows:
           filters:
             branches:
               only:
-                - vm-plus-020-test.3
+                - hts-contracts
     jobs:
       - build-platform-and-services
       - jrs-regression:

--- a/run/set-cron-times.py
+++ b/run/set-cron-times.py
@@ -1,0 +1,85 @@
+import re
+import sys
+
+cron_day_nums = [
+    'sun', 'mon', 'tue', 'wed', 'thu', 'fri', 'sat'
+]
+
+master_cron_formats = [
+    "5 5 * * 6",
+    "0 2 * * 3",
+    "5 10 * * 6",
+    "5 15 * * 6",
+    "30 5 * * *",
+    "58 3 * * *",
+    "45 5 * * *",
+    "0 23,8 * * *",
+    "15 6 * * *",
+    "0 3 * * *",
+    "15 3 * * *",
+    "30 3 * * *",
+    "45 3 * * *",
+    "0 4 * * *",
+    "30 22 * * *",
+    "45 22 * * *",
+    "15 22 * * *",
+    "15 23 * * *",
+    "30 23 * * *",
+    "30 6 * * *",
+    "40 5 * * *",
+    "40 7 * * *",
+    "0 5 * * *",
+    "55 6 * * *",
+    "0 6 * * 2",
+    "35 7 * * *",
+    "40 4 * * *",
+    "30 4 * * *",
+    "15 7 * * *",
+    "25 7 * * *",
+    "25 8 * * *",
+    "25 8 * * *",
+]
+
+p = r'(.+) (.+) (.+) (.+) (.+)'
+def parse_cron_format(f):
+    m = re.match(p, f)
+    minute, hour, day_of_week  = m.group(1), m.group(2), m.group(5)
+    if ',' in hour:
+        hour = hour[:hour.index(',')]
+    return { 
+        'min': int(minute), 
+        'hour': int(hour), 
+        'wday': day_of_week
+    }
+
+master_cron_tabs = [ parse_cron_format(f) for f in master_cron_formats ]
+
+if __name__ == '__main__':
+    if len(sys.argv) < 2:
+        print('USAGE: python3 {} <start-day> <hour-offset-from-master>'.format(sys.argv[0]))
+        sys.exit(1)
+    day = cron_day_nums.index(sys.argv[1])
+    hour_offset = int(sys.argv[2])
+    crons_parsed, cron_i = 0, 0
+    print('Using (cron) day={}, {} hours offset from master'.format(day, hour_offset))
+    with open('.circleci/config.yml', 'r') as fin, open ('config.yml', 'w') as fout:
+        for line in fin.readlines():
+            if 'cron' in line:
+                crons_parsed += 1
+                if crons_parsed <= 2:
+                    first_cron = False
+                    fout.write(line)
+                else:
+                    master_cron = master_cron_tabs[cron_i]
+                    prefix = line[:line.index('"')] + '"'
+                    if master_cron['wday'] != '*':
+                        master_cron['wday'] = day
+                    master_cron['hour'] += hour_offset
+                    if master_cron['hour'] < 0:
+                        master_cron['hour'] += 24
+                    adjusted_line = prefix + '{} {} * * {}'.format(
+                        master_cron['min'], master_cron['hour'], master_cron['wday']) + '"\n'
+                    fout.write(adjusted_line)
+                    cron_i += 1
+            else:
+                fout.write(line)


### PR DESCRIPTION
**Description**:
- Update _config.yml_ to run all jobs offset `-3` hours before `master`.
- Include a _run/set-cron-times.py_ script to automate changing _config.yml_ `cron` formats.