### PR TITLE
Restrict `CodeCache` read-throughs to non-empty bytecode

### DIFF
--- a/hedera-node/src/main/java/com/hedera/services/store/contracts/CodeCache.java
+++ b/hedera-node/src/main/java/com/hedera/services/store/contracts/CodeCache.java
@@ -20,9 +20,8 @@ package com.hedera.services.store.contracts;
  * ‍
  */
 
-import com.github.benmanes.caffeine.cache.CacheLoader;
+import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
-import com.github.benmanes.caffeine.cache.LoadingCache;
 import com.hedera.services.context.properties.NodeLocalProperties;
 import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.datatypes.Hash;
@@ -47,28 +46,34 @@ import static com.hedera.services.utils.EntityIdUtils.accountParsedFromSolidityA
  */
 @Singleton
 public class CodeCache {
-    LoadingCache<BytesKey, Code> cache;
+    private final EntityAccess entityAccess;
+    private final Cache<BytesKey, Code> cache;
 
     @Inject
-    public CodeCache(NodeLocalProperties properties, EntityAccess entityAccess) {
+    public CodeCache(final NodeLocalProperties properties, final EntityAccess entityAccess) {
         this(properties.prefetchCodeCacheTtlSecs(), entityAccess);
     }
 
-    public CodeCache(int cacheTTL, EntityAccess entityAccess) {
-        CacheLoader<BytesKey, Code> loader = key -> {
-            final var acctId = accountParsedFromSolidityAddress(key.getArray());
-            var codeBytes = entityAccess.fetchCode(acctId);
-            return new Code(codeBytes, Hash.hash(codeBytes));
-        };
-
+    public CodeCache(final int cacheTTL, final EntityAccess entityAccess) {
+        this.entityAccess = entityAccess;
         this.cache = Caffeine.newBuilder()
                 .expireAfterAccess(cacheTTL, TimeUnit.SECONDS)
                 .softValues()
-                .build(loader);
+                .build();
     }
 
-    public Code get(Address address) {
-        return cache.get(new BytesKey(address.toArray()));
+    public Code getIfPresent(final Address address) {
+        final var cacheKey = new BytesKey(address.toArray());
+
+        var code = cache.getIfPresent(cacheKey);
+        if (code == null) {
+            final var bytecode = entityAccess.fetchCodeIfPresent(accountParsedFromSolidityAddress(address));
+            if (bytecode != null) {
+                code = new Code(bytecode, Hash.hash(bytecode));
+                cache.put(cacheKey, code);
+            }
+        }
+        return code;
     }
 
     public void invalidate(Address address) {
@@ -101,5 +106,10 @@ public class CodeCache {
         public int hashCode() {
             return Arrays.hashCode(array);
         }
+    }
+
+    /* --- Only used by unit tests --- */
+    Cache<BytesKey, Code> getCache() {
+        return cache;
     }
 }

--- a/hedera-node/src/main/java/com/hedera/services/store/contracts/EntityAccess.java
+++ b/hedera-node/src/main/java/com/hedera/services/store/contracts/EntityAccess.java
@@ -84,5 +84,12 @@ public interface EntityAccess {
 	/* --- Bytecode access --- */
 	void storeCode(AccountID id, Bytes code);
 
-	Bytes fetchCode(AccountID id);
+	/**
+	 * Returns the bytecode for the contract with the given account id; or null
+	 * if there is no byte present for this contract.
+	 *
+	 * @param id the account id of the target contract
+	 * @return the target contract's bytecode, or null if it is not present
+	 */
+	Bytes fetchCodeIfPresent(AccountID id);
 }

--- a/hedera-node/src/main/java/com/hedera/services/store/contracts/HederaWorldState.java
+++ b/hedera-node/src/main/java/com/hedera/services/store/contracts/HederaWorldState.java
@@ -35,6 +35,7 @@ import org.apache.tuweni.units.bigints.UInt256;
 import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.datatypes.Wei;
+import org.hyperledger.besu.evm.Code;
 import org.hyperledger.besu.evm.Gas;
 import org.hyperledger.besu.evm.account.Account;
 import org.hyperledger.besu.evm.account.AccountStorageEntry;
@@ -59,6 +60,8 @@ import static com.hedera.services.utils.EntityIdUtils.asTypedSolidityAddress;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.FAIL_INVALID;
 
 public class HederaWorldState implements HederaMutableWorldState {
+	private static final Code EMPTY_CODE = new Code(Bytes.EMPTY, Hash.hash(Bytes.EMPTY));
+
 	private final EntityIdSource ids;
 	private final EntityAccess entityAccess;
 	private final Map<Address, Address> sponsorMap = new LinkedHashMap<>();
@@ -207,7 +210,7 @@ public class HederaWorldState implements HederaMutableWorldState {
 
 		@Override
 		public Bytes getCode() {
-			return codeCache.getIfPresent(address).getBytes();
+			return getCodeInternal().getBytes();
 		}
 
 		public EntityId getProxyAccount() {
@@ -225,7 +228,7 @@ public class HederaWorldState implements HederaMutableWorldState {
 
 		@Override
 		public Hash getCodeHash() {
-			return codeCache.getIfPresent(address).getCodeHash();
+			return getCodeInternal().getCodeHash();
 		}
 
 		@Override
@@ -290,6 +293,11 @@ public class HederaWorldState implements HederaMutableWorldState {
 
 		public AccountID getAccount() {
 			return account;
+		}
+
+		private Code getCodeInternal() {
+			final var code = codeCache.getIfPresent(address);
+			return (code == null) ? EMPTY_CODE : code;
 		}
 	}
 

--- a/hedera-node/src/main/java/com/hedera/services/store/contracts/HederaWorldState.java
+++ b/hedera-node/src/main/java/com/hedera/services/store/contracts/HederaWorldState.java
@@ -207,7 +207,7 @@ public class HederaWorldState implements HederaMutableWorldState {
 
 		@Override
 		public Bytes getCode() {
-			return codeCache.get(address).getBytes();
+			return codeCache.getIfPresent(address).getBytes();
 		}
 
 		public EntityId getProxyAccount() {
@@ -225,7 +225,7 @@ public class HederaWorldState implements HederaMutableWorldState {
 
 		@Override
 		public Hash getCodeHash() {
-			return codeCache.get(address).getCodeHash();
+			return codeCache.getIfPresent(address).getCodeHash();
 		}
 
 		@Override

--- a/hedera-node/src/main/java/com/hedera/services/store/contracts/MutableEntityAccess.java
+++ b/hedera-node/src/main/java/com/hedera/services/store/contracts/MutableEntityAccess.java
@@ -47,6 +47,7 @@ import javax.inject.Inject;
 import javax.inject.Singleton;
 import java.util.function.Supplier;
 
+import static com.hedera.services.store.contracts.StaticEntityAccess.explicitCodeFetch;
 import static com.hederahashgraph.api.proto.java.HederaFunctionality.ContractCall;
 import static com.hederahashgraph.api.proto.java.HederaFunctionality.ContractCreate;
 
@@ -205,10 +206,8 @@ public class MutableEntityAccess implements EntityAccess {
 	}
 
 	@Override
-	public Bytes fetchCode(final AccountID id) {
-		final var blobKey = new VirtualBlobKey(VirtualBlobKey.Type.CONTRACT_BYTECODE, (int) id.getAccountNum());
-		final var bytes = bytecode.get().get(blobKey);
-		return bytes == null ? Bytes.EMPTY : Bytes.of(bytes.getData());
+	public Bytes fetchCodeIfPresent(final AccountID id) {
+		return explicitCodeFetch(bytecode.get(), id);
 	}
 
 	private boolean isActiveContractOp() {

--- a/hedera-node/src/main/java/com/hedera/services/store/contracts/StaticEntityAccess.java
+++ b/hedera-node/src/main/java/com/hedera/services/store/contracts/StaticEntityAccess.java
@@ -43,6 +43,7 @@ import org.apache.tuweni.units.bigints.UInt256;
 
 import java.util.Objects;
 
+import static com.hedera.services.state.merkle.internals.BitPackUtils.codeFromNum;
 import static com.hedera.services.utils.EntityNum.fromAccountId;
 
 public class StaticEntityAccess implements EntityAccess {
@@ -50,7 +51,7 @@ public class StaticEntityAccess implements EntityAccess {
 	private final GlobalDynamicProperties dynamicProperties;
 	private final MerkleMap<EntityNum, MerkleAccount> accounts;
 	private final VirtualMap<ContractKey, ContractValue> storage;
-	private final VirtualMap<VirtualBlobKey, VirtualBlobValue> blobs;
+	private final VirtualMap<VirtualBlobKey, VirtualBlobValue> bytecode;
 
 	public StaticEntityAccess(
 			final StateView stateView,
@@ -60,7 +61,7 @@ public class StaticEntityAccess implements EntityAccess {
 		this.validator = validator;
 		this.dynamicProperties = dynamicProperties;
 
-		this.blobs = stateView.storage();
+		this.bytecode = stateView.storage();
 		this.storage = stateView.contractStorage();
 		this.accounts = stateView.accounts();
 	}
@@ -170,11 +171,16 @@ public class StaticEntityAccess implements EntityAccess {
 	}
 
 	@Override
-	public Bytes fetchCode(AccountID id) {
-		final var blobKey = new VirtualBlobKey(VirtualBlobKey.Type.CONTRACT_BYTECODE, (int) id.getAccountNum());
-		var bytes = blobs
-				.get(blobKey);
+	public Bytes fetchCodeIfPresent(final AccountID id) {
+		return explicitCodeFetch(bytecode, id);
+	}
 
-		return bytes == null ? Bytes.EMPTY : Bytes.of(bytes.getData());
+	static Bytes explicitCodeFetch(
+			final VirtualMap<VirtualBlobKey, VirtualBlobValue> bytecode,
+			final AccountID id
+	) {
+		final var key = new VirtualBlobKey(VirtualBlobKey.Type.CONTRACT_BYTECODE, codeFromNum(id.getAccountNum()));
+		final var value = bytecode.get(key);
+		return (value != null) ? Bytes.of(value.getData()) : null;
 	}
 }

--- a/hedera-node/src/main/java/com/hedera/services/txns/contract/ContractCallTransitionLogic.java
+++ b/hedera-node/src/main/java/com/hedera/services/txns/contract/ContractCallTransitionLogic.java
@@ -151,7 +151,7 @@ public class ContractCallTransitionLogic implements PreFetchableTransition {
 		final var address = contractId.asEvmAddress();
 
 		try {
-			codeCache.get(address);
+			codeCache.getIfPresent(address);
 		} catch(RuntimeException e) {
 			log.warn("Exception while attempting to pre-fetch code for {}", address);
 		}

--- a/hedera-node/src/test/java/com/hedera/services/contracts/execution/CallEvmTxProcessorTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/contracts/execution/CallEvmTxProcessorTest.java
@@ -133,8 +133,6 @@ class CallEvmTxProcessorTest {
 		given(updater.getOrCreateSenderAccount(sender.getId().asEvmAddress())).willReturn(evmAccount);
 		given(worldState.updater()).willReturn(updater);
 
-		given(codeCache.get(any())).willThrow(new RuntimeException("oh no"));
-
 		givenSenderWithBalance(350_000L);
 		assertFailsWith(() ->
 						callEvmTxProcessor.execute(
@@ -222,7 +220,7 @@ class CallEvmTxProcessorTest {
 		// setup:
 		doReturn(Optional.of(receiver.getId().asEvmAddress())).when(transaction).getTo();
 		given(worldState.updater()).willReturn(mock(HederaWorldState.Updater.class));
-		given(codeCache.get(any())).willReturn(new Code());
+		given(codeCache.getIfPresent(any())).willReturn(new Code());
 		given(transaction.getSender()).willReturn(sender.getId().asEvmAddress());
 		given(transaction.getValue()).willReturn(Wei.of(1L));
 		final MessageFrame.Builder commonInitialFrame =
@@ -267,7 +265,7 @@ class CallEvmTxProcessorTest {
 
 		given(updater.getOrCreateSenderAccount(sender.getId().asEvmAddress())).willReturn(evmAccount);
 		given(worldState.updater()).willReturn(updater);
-		given(codeCache.get(any())).willReturn(new Code());
+		given(codeCache.getIfPresent(any())).willReturn(new Code());
 
 		given(gasCalculator.getSelfDestructRefundAmount()).willReturn(Gas.ZERO);
 		given(gasCalculator.getMaxRefundQuotient()).willReturn(2L);

--- a/hedera-node/src/test/java/com/hedera/services/contracts/execution/CallLocalEvmTxProcessorTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/contracts/execution/CallLocalEvmTxProcessorTest.java
@@ -55,7 +55,7 @@ import java.util.Optional;
 import java.util.Set;
 
 import static com.hedera.test.utils.TxnUtils.assertFailsWith;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.FAIL_INVALID;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_CONTRACT_ID;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -127,7 +127,6 @@ class CallLocalEvmTxProcessorTest {
 		given(updater.getOrCreateSenderAccount(sender.getId().asEvmAddress()).getMutable()).willReturn(
 				mock(MutableAccount.class));
 		given(worldState.updater()).willReturn(updater);
-		given(codeCache.get(any())).willReturn(new Code());
 
 		var senderMutableAccount = mock(MutableAccount.class);
 
@@ -136,12 +135,10 @@ class CallLocalEvmTxProcessorTest {
 		given(updater.getOrCreate(any())).willReturn(evmAccount);
 		given(updater.getOrCreate(any()).getMutable()).willReturn(senderMutableAccount);
 
-		given(codeCache.get(any())).willThrow(new RuntimeException("oh no"));
-
 		assertFailsWith(() ->
 						callLocalEvmTxProcessor.execute(
 								sender, receiverAddress, 33_333L, 1234L, Bytes.EMPTY, consensusTime),
-				FAIL_INVALID);
+				INVALID_CONTRACT_ID);
 	}
 
 	@Test
@@ -155,7 +152,7 @@ class CallLocalEvmTxProcessorTest {
 		// setup:
 		doReturn(Optional.of(receiver.getId().asEvmAddress())).when(transaction).getTo();
 		given(worldState.updater()).willReturn(mock(HederaWorldState.Updater.class));
-		given(codeCache.get(any())).willReturn(new Code());
+		given(codeCache.getIfPresent(any())).willReturn(new Code());
 		given(transaction.getSender()).willReturn(sender.getId().asEvmAddress());
 		given(transaction.getValue()).willReturn(Wei.of(1L));
 		final MessageFrame.Builder commonInitialFrame =
@@ -197,7 +194,7 @@ class CallLocalEvmTxProcessorTest {
 		given(updater.getOrCreateSenderAccount(sender.getId().asEvmAddress()).getMutable()).willReturn(
 				mock(MutableAccount.class));
 		given(worldState.updater()).willReturn(updater);
-		given(codeCache.get(any())).willReturn(new Code());
+		given(codeCache.getIfPresent(any())).willReturn(new Code());
 
 
 		var senderMutableAccount = mock(MutableAccount.class);

--- a/hedera-node/src/test/java/com/hedera/services/store/contracts/CodeCacheTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/store/contracts/CodeCacheTest.java
@@ -55,29 +55,29 @@ class CodeCacheTest {
 
     @Test
     void successfulCreate() {
-        assertNotNull(codeCache.cache);
+        assertNotNull(codeCache.getCache());
     }
 
     @Test
     void getTriggeringLoad() {
-        given(entityAccess.fetchCode(any())).willReturn(Bytes.of("abc".getBytes()));
-        Code code = codeCache.get(Address.fromHexString("0xabc"));
+        given(entityAccess.fetchCodeIfPresent(any())).willReturn(Bytes.of("abc".getBytes()));
+        Code code = codeCache.getIfPresent(Address.fromHexString("0xabc"));
 
         assertEquals(Hash.fromHexString("0x4e03657aea45a94fc7d47ba826c8d667c0d1e6e33a64a036ec44f58fa12d6c45"), code.getCodeHash());
     }
 
     @Test
     void getContractNotFound() {
-        given(entityAccess.fetchCode(any())).willReturn(Bytes.EMPTY);
-        Code code = codeCache.get(Address.fromHexString("0xabc"));
+        given(entityAccess.fetchCodeIfPresent(any())).willReturn(Bytes.EMPTY);
+        Code code = codeCache.getIfPresent(Address.fromHexString("0xabc"));
 
         assertTrue(code.getBytes().isEmpty());
     }
 
     @Test
     void invalidateSuccess() {
-        given(entityAccess.fetchCode(any())).willReturn(Bytes.of("abc".getBytes()));
-        Code code = codeCache.get(Address.fromHexString("0xabc"));
+        given(entityAccess.fetchCodeIfPresent(any())).willReturn(Bytes.of("abc".getBytes()));
+        Code code = codeCache.getIfPresent(Address.fromHexString("0xabc"));
 
         assertEquals(1L, codeCache.size());
         codeCache.invalidate(Address.fromHexString("0xabc"));

--- a/hedera-node/src/test/java/com/hedera/services/store/contracts/HederaWorldStateTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/store/contracts/HederaWorldStateTest.java
@@ -208,7 +208,7 @@ class HederaWorldStateTest {
 		given(entityAccess.getAutoRenew(account)).willReturn(100L);
 		given(entityAccess.isExtant(any())).willReturn(true);
 		given(entityAccess.isDeleted(any())).willReturn(false);
-		given(entityAccess.fetchCode(any())).willReturn(Bytes.EMPTY);
+		given(entityAccess.fetchCodeIfPresent(any())).willReturn(Bytes.EMPTY);
 		given(entityAccess.getStorage(any(), any())).willReturn(UInt256.ZERO);
 
 		final var acc = subject.get(Address.RIPEMD160);

--- a/hedera-node/src/test/java/com/hedera/services/store/contracts/HederaWorldStateTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/store/contracts/HederaWorldStateTest.java
@@ -201,14 +201,33 @@ class HederaWorldStateTest {
 	}
 
 	@Test
+	void returnsEmptyCodeIfNotPresent() {
+		final var address = Address.RIPEMD160;
+		final var ripeAccountId = accountParsedFromSolidityAddress(address.toArrayUnsafe());
+		givenWellKnownAccountWithCode(ripeAccountId, null);
+
+		final var account = subject.get(address);
+
+		assertTrue(account.getCode().isEmpty());
+		assertFalse(account.hasCode());
+	}
+
+	@Test
+	void returnsExpectedCodeIfPresent() {
+		final var address = Address.RIPEMD160;
+		final var ripeAccountId = accountParsedFromSolidityAddress(address.toArrayUnsafe());
+		givenWellKnownAccountWithCode(ripeAccountId, code);
+
+		final var account = subject.get(address);
+
+		assertEquals(code, account.getCode());
+		assertTrue(account.hasCode());
+	}
+
+	@Test
 	void getsAsExpected() {
 		final var account = accountParsedFromSolidityAddress(Address.RIPEMD160.toArray());
-		given(entityAccess.getProxy(account)).willReturn(new EntityId(0, 0, 1));
-		given(entityAccess.getBalance(account)).willReturn(balance);
-		given(entityAccess.getAutoRenew(account)).willReturn(100L);
-		given(entityAccess.isExtant(any())).willReturn(true);
-		given(entityAccess.isDeleted(any())).willReturn(false);
-		given(entityAccess.fetchCodeIfPresent(any())).willReturn(Bytes.EMPTY);
+		givenWellKnownAccountWithCode(account, Bytes.EMPTY);
 		given(entityAccess.getStorage(any(), any())).willReturn(UInt256.ZERO);
 
 		final var acc = subject.get(Address.RIPEMD160);
@@ -228,6 +247,17 @@ class HederaWorldStateTest {
 		given(entityAccess.isDeleted(any())).willReturn(true);
 		nonExistent = subject.get(Address.RIPEMD160);
 		assertNull(nonExistent);
+	}
+
+	private void givenWellKnownAccountWithCode(final AccountID account, final Bytes bytecode) {
+		given(entityAccess.getProxy(account)).willReturn(new EntityId(0, 0, 1));
+		given(entityAccess.getBalance(account)).willReturn(balance);
+		given(entityAccess.getAutoRenew(account)).willReturn(100L);
+		given(entityAccess.isExtant(any())).willReturn(true);
+		given(entityAccess.isDeleted(any())).willReturn(false);
+		if (bytecode != null) {
+			given(entityAccess.fetchCodeIfPresent(any())).willReturn(bytecode);
+		}
 	}
 
 	/*

--- a/hedera-node/src/test/java/com/hedera/services/store/contracts/MutableEntityAccessTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/store/contracts/MutableEntityAccessTest.java
@@ -70,6 +70,7 @@ import static com.hederahashgraph.api.proto.java.HederaFunctionality.TokenMint;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.collection.IsIterableContainingInOrder.contains;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -77,7 +78,6 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
-
 
 @ExtendWith({ MockitoExtension.class, LogCaptureExtension.class })
 class MutableEntityAccessTest {
@@ -420,16 +420,9 @@ class MutableEntityAccessTest {
 
 	@Test
 	void fetchesEmptyBytecode() {
-		// given:
 		given(supplierBytecode.get()).willReturn(bytecodeStorage);
 
-		// when:
-		final var result = subject.fetchCode(id);
-
-		// then:
-		assertEquals(Bytes.EMPTY, result);
-		// and:
-		verify(bytecodeStorage).get(expectedBytecodeKey);
+		assertNull(subject.fetchCodeIfPresent(id));
 	}
 
 	@Test
@@ -437,7 +430,7 @@ class MutableEntityAccessTest {
 		given(supplierBytecode.get()).willReturn(bytecodeStorage);
 		given(bytecodeStorage.get(expectedBytecodeKey)).willReturn(expectedBytecodeValue);
 
-		final var result = subject.fetchCode(id);
+		final var result = subject.fetchCodeIfPresent(id);
 
 		assertEquals(bytecode, result);
 		verify(bytecodeStorage).get(expectedBytecodeKey);

--- a/hedera-node/src/test/java/com/hedera/services/store/contracts/StaticEntityAccessTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/store/contracts/StaticEntityAccessTest.java
@@ -51,6 +51,7 @@ import java.math.BigInteger;
 import static com.hedera.services.state.virtual.VirtualBlobKey.Type.CONTRACT_BYTECODE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -205,7 +206,7 @@ class StaticEntityAccessTest {
 	void fetchWithValueWorks() {
 		given(blobs.get(blobKey)).willReturn(blobVal);
 
-		final var blobBytes = subject.fetchCode(id);
+		final var blobBytes = subject.fetchCodeIfPresent(id);
 
 		final var expectedVal = Bytes.of(blobVal.getData());
 		assertEquals(expectedVal, blobBytes);
@@ -213,8 +214,7 @@ class StaticEntityAccessTest {
 
 	@Test
 	void fetchWithoutValueReturnsNull() {
-		final var blobBytes = subject.fetchCode(id);
-		assertEquals(Bytes.EMPTY, blobBytes);
+		assertNull(subject.fetchCodeIfPresent(id));
 	}
 
 	@Test

--- a/hedera-node/src/test/java/com/hedera/services/store/contracts/UpdateTrackingLedgerAccountTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/store/contracts/UpdateTrackingLedgerAccountTest.java
@@ -123,7 +123,7 @@ class UpdateTrackingLedgerAccountTest {
 	@Test
 	void getsWrappedCodeHashIfConstructedWithAccount() {
 		final var mockCode = Bytes.minimalBytes(4321L);
-		given(entityAccess.fetchCode(targetId)).willReturn(mockCode);
+		given(entityAccess.fetchCodeIfPresent(targetId)).willReturn(mockCode);
 
 		final var account = parentState.new WorldStateAccount(
 				targetAddress, Wei.of(initialBalance), expiry, autoRenewPeriod, proxyId);
@@ -151,7 +151,7 @@ class UpdateTrackingLedgerAccountTest {
 
 	@Test
 	void hasCodeDelegatesToWrappedIfNotUpdated() {
-		given(entityAccess.fetchCode(targetId)).willReturn(Bytes.EMPTY);
+		given(entityAccess.fetchCodeIfPresent(targetId)).willReturn(Bytes.EMPTY);
 
 		final var account = parentState.new WorldStateAccount(
 				targetAddress, Wei.of(initialBalance), expiry, autoRenewPeriod, proxyId);

--- a/hedera-node/src/test/java/com/hedera/services/txns/contract/ContractCallTransitionLogicTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/txns/contract/ContractCallTransitionLogicTest.java
@@ -185,7 +185,7 @@ class ContractCallTransitionLogicTest {
 		subject.preFetch(accessor);
 
 		// expect:
-		verify(codeCache).get(any(Address.class));
+		verify(codeCache).getIfPresent(any(Address.class));
 	}
 
 	@Test
@@ -196,13 +196,13 @@ class ContractCallTransitionLogicTest {
 		given(accessor.getTxn()).willReturn(txnBody);
 		given(txnBody.getContractCall()).willReturn(ccTxnBody);
 		given(ccTxnBody.getContractID()).willReturn(ContractID.getDefaultInstance());
-		given(codeCache.get(any(Address.class))).willThrow(new RuntimeException("oh no"));
+		given(codeCache.getIfPresent(any(Address.class))).willThrow(new RuntimeException("oh no"));
 
 		// when:
 		subject.preFetch(accessor);
 
 		// expect:
-		verify(codeCache).get(any(Address.class));
+		verify(codeCache).getIfPresent(any(Address.class));
 	}
 
 	@Test


### PR DESCRIPTION
**Description**:
 - Replaces the `LoadingCache` previously used by `CodeCache` with a vanilla `Cache` that is only populated after finding non-`null` bytecode for a requested contract.
