### PR TITLE
Use weak refs for `MutableStateChildren` members

### DIFF
--- a/hedera-node/src/main/java/com/hedera/services/context/MutableStateChildren.java
+++ b/hedera-node/src/main/java/com/hedera/services/context/MutableStateChildren.java
@@ -37,6 +37,7 @@ import com.swirlds.common.AddressBook;
 import com.swirlds.fchashmap.FCOneToManyRelation;
 import com.swirlds.merkle.map.MerkleMap;
 
+import java.lang.ref.WeakReference;
 import java.time.Instant;
 import java.util.Objects;
 
@@ -48,20 +49,20 @@ import java.util.Objects;
  * methods {@code init()}, {@code copy()}, and {@code handleTransaction()}.
  */
 public class MutableStateChildren implements StateChildren {
-	private MerkleMap<EntityNum, MerkleAccount> accounts;
-	private MerkleMap<EntityNum, MerkleTopic> topics;
-	private MerkleMap<EntityNum, MerkleToken> tokens;
-	private MerkleMap<EntityNumPair, MerkleUniqueToken> uniqueTokens;
-	private MerkleMap<EntityNum, MerkleSchedule> schedules;
-	private MerkleMap<String, MerkleOptionalBlob> storage;
-	private MerkleMap<EntityNumPair, MerkleTokenRelStatus> tokenAssociations;
-	private FCOneToManyRelation<EntityNum, Long> uniqueTokenAssociations;
-	private FCOneToManyRelation<EntityNum, Long> uniqueOwnershipAssociations;
-	private FCOneToManyRelation<EntityNum, Long> uniqueOwnershipTreasuryAssociations;
-	private MerkleNetworkContext networkCtx;
-	private AddressBook addressBook;
-	private MerkleSpecialFiles specialFiles;
-	private RecordsRunningHashLeaf runningHashLeaf;
+	private WeakReference<MerkleMap<EntityNum, MerkleAccount>> accounts;
+	private WeakReference<MerkleMap<EntityNum, MerkleTopic>> topics;
+	private WeakReference<MerkleMap<EntityNum, MerkleToken>> tokens;
+	private WeakReference<MerkleMap<EntityNumPair, MerkleUniqueToken>> uniqueTokens;
+	private WeakReference<MerkleMap<EntityNum, MerkleSchedule>> schedules;
+	private WeakReference<MerkleMap<String, MerkleOptionalBlob>> storage;
+	private WeakReference<MerkleMap<EntityNumPair, MerkleTokenRelStatus>> tokenAssociations;
+	private WeakReference<FCOneToManyRelation<EntityNum, Long>> uniqueTokenAssociations;
+	private WeakReference<FCOneToManyRelation<EntityNum, Long>> uniqueOwnershipAssociations;
+	private WeakReference<FCOneToManyRelation<EntityNum, Long>> uniqueOwnershipTreasuryAssociations;
+	private WeakReference<MerkleNetworkContext> networkCtx;
+	private WeakReference<AddressBook> addressBook;
+	private WeakReference<MerkleSpecialFiles> specialFiles;
+	private WeakReference<RecordsRunningHashLeaf> runningHashLeaf;
 	private Instant signedAt = Instant.EPOCH;
 
 	public MutableStateChildren() {
@@ -79,166 +80,161 @@ public class MutableStateChildren implements StateChildren {
 
 	@Override
 	public MerkleMap<EntityNum, MerkleAccount> accounts() {
-		Objects.requireNonNull(accounts);
-		return accounts;
+		final var refAccounts = accounts.get();
+		Objects.requireNonNull(refAccounts);
+		return refAccounts;
 	}
 
 	public void setAccounts(MerkleMap<EntityNum, MerkleAccount> accounts) {
-		this.accounts = accounts;
+		this.accounts = new WeakReference<>(accounts);
 	}
 
 	@Override
 	public MerkleMap<EntityNum, MerkleTopic> topics() {
-		Objects.requireNonNull(topics);
-		return topics;
+		final var refTopics = topics.get();
+		Objects.requireNonNull(refTopics);
+		return refTopics;
 	}
 
 	public void setTopics(MerkleMap<EntityNum, MerkleTopic> topics) {
-		this.topics = topics;
+		this.topics = new WeakReference<>(topics);
 	}
 
 	@Override
 	public MerkleMap<EntityNum, MerkleToken> tokens() {
-		Objects.requireNonNull(tokens);
-		return tokens;
+		final var refTokens = tokens.get();
+		Objects.requireNonNull(refTokens);
+		return refTokens;
 	}
 
 	public void setTokens(MerkleMap<EntityNum, MerkleToken> tokens) {
-		this.tokens = tokens;
+		this.tokens = new WeakReference<>(tokens);
 	}
 
 	@Override
 	public MerkleMap<EntityNum, MerkleSchedule> schedules() {
-		Objects.requireNonNull(schedules);
-		return schedules;
+		final var refSchedules = schedules.get();
+		Objects.requireNonNull(refSchedules);
+		return refSchedules;
 	}
 
 	public void setSchedules(MerkleMap<EntityNum, MerkleSchedule> schedules) {
-		this.schedules = schedules;
+		this.schedules = new WeakReference<>(schedules);
 	}
 
 	@Override
 	public MerkleMap<String, MerkleOptionalBlob> storage() {
-		Objects.requireNonNull(storage);
-		return storage;
+		final var refStorage = storage.get();
+		Objects.requireNonNull(refStorage);
+		return refStorage;
 	}
 
 	public void setStorage(MerkleMap<String, MerkleOptionalBlob> storage) {
-		this.storage = storage;
+		this.storage = new WeakReference<>(storage);
 	}
 
 	@Override
 	public MerkleMap<EntityNumPair, MerkleTokenRelStatus> tokenAssociations() {
-		Objects.requireNonNull(tokenAssociations);
-		return tokenAssociations;
+		final var refTokenAssociations = tokenAssociations.get();
+		Objects.requireNonNull(refTokenAssociations);
+		return refTokenAssociations;
 	}
 
 	public void setTokenAssociations(MerkleMap<EntityNumPair, MerkleTokenRelStatus> tokenAssociations) {
-		this.tokenAssociations = tokenAssociations;
+		this.tokenAssociations = new WeakReference<>(tokenAssociations);
 	}
 
 	@Override
 	public MerkleNetworkContext networkCtx() {
-		Objects.requireNonNull(networkCtx);
-		return networkCtx;
+		final var refNetworkCtx = networkCtx.get();
+		Objects.requireNonNull(refNetworkCtx);
+		return refNetworkCtx;
 	}
 
 	public void setNetworkCtx(MerkleNetworkContext networkCtx) {
-		this.networkCtx = networkCtx;
+		this.networkCtx = new WeakReference<>(networkCtx);
 	}
 
 	@Override
 	public AddressBook addressBook() {
-		Objects.requireNonNull(addressBook);
-		return addressBook;
+		final var refAddressBook = addressBook.get();
+		Objects.requireNonNull(refAddressBook);
+		return refAddressBook;
 	}
 
 	public void setAddressBook(AddressBook addressBook) {
-		this.addressBook = addressBook;
+		this.addressBook = new WeakReference<>(addressBook);
 	}
 
 	@Override
 	public MerkleSpecialFiles specialFiles() {
-		Objects.requireNonNull(specialFiles);
-		return specialFiles;
+		final var refSpecialFiles = specialFiles.get();
+		Objects.requireNonNull(refSpecialFiles);
+		return refSpecialFiles;
 	}
 
 	public void setSpecialFiles(MerkleSpecialFiles specialFiles) {
-		this.specialFiles = specialFiles;
+		this.specialFiles = new WeakReference<>(specialFiles);
 	}
 
 	@Override
 	public MerkleMap<EntityNumPair, MerkleUniqueToken> uniqueTokens() {
-		Objects.requireNonNull(uniqueTokens);
-		return uniqueTokens;
+		final var refUniqueTokens = uniqueTokens.get();
+		Objects.requireNonNull(refUniqueTokens);
+		return refUniqueTokens;
 	}
 
 	public void setUniqueTokens(MerkleMap<EntityNumPair, MerkleUniqueToken> uniqueTokens) {
-		this.uniqueTokens = uniqueTokens;
+		this.uniqueTokens = new WeakReference<>(uniqueTokens);
 	}
 
 	@Override
 	public FCOneToManyRelation<EntityNum, Long> uniqueTokenAssociations() {
-		Objects.requireNonNull(uniqueTokenAssociations);
-		return uniqueTokenAssociations;
+		final var refUniqueTokenAssociations = uniqueTokenAssociations.get();
+		Objects.requireNonNull(refUniqueTokenAssociations);
+		return refUniqueTokenAssociations;
 	}
 
 	public void setUniqueTokenAssociations(FCOneToManyRelation<EntityNum, Long> uniqueTokenAssociations) {
-		this.uniqueTokenAssociations = uniqueTokenAssociations;
+		this.uniqueTokenAssociations = new WeakReference<>(uniqueTokenAssociations);
 	}
 
 	@Override
 	public FCOneToManyRelation<EntityNum, Long> uniqueOwnershipAssociations() {
-		Objects.requireNonNull(uniqueOwnershipAssociations);
-		return uniqueOwnershipAssociations;
+		final var refUniqueOwnershipAssociations = uniqueOwnershipAssociations.get();
+		Objects.requireNonNull(refUniqueOwnershipAssociations);
+		return refUniqueOwnershipAssociations;
 	}
 
 	public void setUniqueOwnershipAssociations(
 			FCOneToManyRelation<EntityNum, Long> uniqueOwnershipAssociations
 	) {
-		this.uniqueOwnershipAssociations = uniqueOwnershipAssociations;
+		this.uniqueOwnershipAssociations = new WeakReference<>(uniqueOwnershipAssociations);
 	}
 
 	@Override
 	public FCOneToManyRelation<EntityNum, Long> uniqueOwnershipTreasuryAssociations() {
-		Objects.requireNonNull(uniqueOwnershipTreasuryAssociations);
-		return uniqueOwnershipTreasuryAssociations;
+		final var refUniqueOwnershipTreasuryAssociations = uniqueOwnershipTreasuryAssociations.get();
+		Objects.requireNonNull(refUniqueOwnershipTreasuryAssociations);
+		return refUniqueOwnershipTreasuryAssociations;
 	}
 
 	public void setUniqueOwnershipTreasuryAssociations(
 			FCOneToManyRelation<EntityNum, Long> uniqueOwnershipTreasuryAssociations
 	) {
-		this.uniqueOwnershipTreasuryAssociations = uniqueOwnershipTreasuryAssociations;
+		this.uniqueOwnershipTreasuryAssociations = new WeakReference<>(uniqueOwnershipTreasuryAssociations);
 	}
 
 	@Override
 	public RecordsRunningHashLeaf runningHashLeaf() {
-		Objects.requireNonNull(runningHashLeaf);
-		return runningHashLeaf;
+		final var refRunningHashLeaf = runningHashLeaf.get();
+		Objects.requireNonNull(refRunningHashLeaf);
+		return refRunningHashLeaf;
 	}
 
 
 	public void setRunningHashLeaf(RecordsRunningHashLeaf runningHashLeaf) {
-		this.runningHashLeaf = runningHashLeaf;
-	}
-
-	@Override
-	public void nullOutRefs() {
-		signedAt = Instant.EPOCH;
-		accounts = null;
-		topics = null;
-		storage = null;
-		tokens = null;
-		tokenAssociations = null;
-		schedules = null;
-		networkCtx = null;
-		addressBook = null;
-		specialFiles = null;
-		uniqueTokens = null;
-		uniqueTokenAssociations = null;
-		uniqueOwnershipAssociations = null;
-		uniqueOwnershipTreasuryAssociations = null;
-		runningHashLeaf = null;
+		this.runningHashLeaf = new WeakReference<>(runningHashLeaf);
 	}
 
 	public void updateFrom(final ServicesState signedState, final Instant signingTime) {
@@ -247,20 +243,20 @@ public class MutableStateChildren implements StateChildren {
 	}
 
 	public void updateFrom(final ServicesState state) {
-		accounts = state.accounts();
-		topics = state.topics();
-		storage = state.storage();
-		tokens = state.tokens();
-		tokenAssociations = state.tokenAssociations();
-		schedules = state.scheduleTxs();
-		networkCtx = state.networkCtx();
-		addressBook = state.addressBook();
-		specialFiles = state.specialFiles();
-		uniqueTokens = state.uniqueTokens();
-		uniqueTokenAssociations = state.uniqueTokenAssociations();
-		uniqueOwnershipAssociations = state.uniqueOwnershipAssociations();
-		uniqueOwnershipTreasuryAssociations = state.uniqueTreasuryOwnershipAssociations();
-		runningHashLeaf = state.runningHashLeaf();
+		accounts = new WeakReference<>(state.accounts());
+		topics = new WeakReference<>(state.topics());
+		storage = new WeakReference<>(state.storage());
+		tokens = new WeakReference<>(state.tokens());
+		tokenAssociations = new WeakReference<>(state.tokenAssociations());
+		schedules = new WeakReference<>(state.scheduleTxs());
+		networkCtx = new WeakReference<>(state.networkCtx());
+		addressBook = new WeakReference<>(state.addressBook());
+		specialFiles = new WeakReference<>(state.specialFiles());
+		uniqueTokens = new WeakReference<>(state.uniqueTokens());
+		uniqueTokenAssociations = new WeakReference<>(state.uniqueTokenAssociations());
+		uniqueOwnershipAssociations = new WeakReference<>(state.uniqueOwnershipAssociations());
+		uniqueOwnershipTreasuryAssociations = new WeakReference<>(state.uniqueTreasuryOwnershipAssociations());
+		runningHashLeaf = new WeakReference<>(state.runningHashLeaf());
 	}
 }
 

--- a/hedera-node/src/main/java/com/hedera/services/context/StateChildren.java
+++ b/hedera-node/src/main/java/com/hedera/services/context/StateChildren.java
@@ -68,6 +68,4 @@ public interface StateChildren {
 	FCOneToManyRelation<EntityNum, Long> uniqueOwnershipTreasuryAssociations();
 
 	RecordsRunningHashLeaf runningHashLeaf();
-
-	void nullOutRefs();
 }

--- a/hedera-node/src/main/java/com/hedera/services/sigs/order/SigReqsManager.java
+++ b/hedera-node/src/main/java/com/hedera/services/sigs/order/SigReqsManager.java
@@ -174,18 +174,14 @@ public class SigReqsManager {
 			final Instant earliestSigningTime,
 			final PlatformTxnAccessor accessor
 	) {
-		try {
-			/* Update our children (e.g., MerkleMaps and VirtualMaps) from the current signed state.
-			 * Because event intake is single-threaded, there's no risk of another thread getting
-			 * inconsistent results while we are doing this. */
-			signedChildren.updateFrom(signedState, earliestSigningTime);
-			ensureSignedStateSigReqsIsConstructed();
-			expansionHelper.expandIn(accessor, signedSigReqs, accessor.getPkToSigsFn());
-			return true;
-		} finally {
-			/* Make sure we don't hold references to any part of state that would otherwise be eligible for GC. */
-			signedChildren.nullOutRefs();
-		}
+		/* Update our children (e.g., MerkleMaps and VirtualMaps) from the current signed state.
+		 * Because event intake is single-threaded, there's no risk of another thread getting
+		 * inconsistent results while we are doing this. Also, note that MutableStateChildren
+		 * uses weak references, so we won't keep this signed state from GC eligibility. */
+		signedChildren.updateFrom(signedState, earliestSigningTime);
+		ensureSignedStateSigReqsIsConstructed();
+		expansionHelper.expandIn(accessor, signedSigReqs, accessor.getPkToSigsFn());
+		return true;
 	}
 
 	private void ensureWorkingStateSigReqsIsConstructed() {
@@ -227,9 +223,5 @@ public class SigReqsManager {
 
 	void setLookupsFactory(final StateChildrenLookupsFactory lookupsFactory) {
 		this.lookupsFactory = lookupsFactory;
-	}
-
-	MutableStateChildren getSignedChildren() {
-		return signedChildren;
 	}
 }

--- a/hedera-node/src/test/java/com/hedera/services/sigs/order/SigReqsManagerTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/sigs/order/SigReqsManagerTest.java
@@ -67,8 +67,6 @@ class SigReqsManagerTest {
 	@Mock
 	private SigMetadataLookup lookup;
 	@Mock
-	private SigMetadataLookup failingLookup;
-	@Mock
 	private SigRequirements workingStateSigReqs;
 	@Mock
 	private SigRequirements signedStateSigReqs;
@@ -178,7 +176,7 @@ class SigReqsManagerTest {
 		verify(sigReqsFactory).from(lookup, signatureWaivers);
 		verify(expansionHelper, times(3)).expandIn(accessor, signedStateSigReqs, pubKeyToSigBytes);
 		final var capturedStateChildren = captor.getValue();
-		assertSame(Instant.EPOCH, capturedStateChildren.signedAt());
+		assertSame(nextLastHandleTime, capturedStateChildren.signedAt());
 		assertThrows(NullPointerException.class, capturedStateChildren::accounts);
 	}
 

--- a/hedera-node/src/test/java/com/hedera/services/state/StateAccessorTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/state/StateAccessorTest.java
@@ -47,7 +47,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.time.Instant;
 
 import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.BDDMockito.given;
 
 @ExtendWith(MockitoExtension.class)
@@ -101,15 +100,27 @@ class StateAccessorTest {
 	}
 
 	@Test
-	void nullsOutChildrenAsExpected() {
-		final var anInstant = Instant.ofEpochSecond(1_234_567L, 890);
+	void settersWorkAsExpected() {
 		givenStateWithMockChildren();
-		((MutableStateChildren) subject.children()).updateFrom(state, anInstant);
 
-		subject.children().nullOutRefs();
+		final var mutableChildren = (MutableStateChildren) subject.children();
 
-		assertChildrenAreNull();
-		assertSame(Instant.EPOCH, subject.children().signedAt());
+		mutableChildren.setAccounts(state.accounts());
+		mutableChildren.setStorage(state.storage());
+		mutableChildren.setTopics(state.topics());
+		mutableChildren.setTokens(state.tokens());
+		mutableChildren.setTokenAssociations(state.tokenAssociations());
+		mutableChildren.setSchedules(state.scheduleTxs());
+		mutableChildren.setNetworkCtx(state.networkCtx());
+		mutableChildren.setAddressBook(state.addressBook());
+		mutableChildren.setSpecialFiles(state.specialFiles());
+		mutableChildren.setUniqueTokens(state.uniqueTokens());
+		mutableChildren.setUniqueTokenAssociations(state.uniqueTokenAssociations());
+		mutableChildren.setUniqueOwnershipAssociations(state.uniqueOwnershipAssociations());
+		mutableChildren.setUniqueOwnershipTreasuryAssociations(state.uniqueTreasuryOwnershipAssociations());
+		mutableChildren.setRunningHashLeaf(state.runningHashLeaf());
+
+		assertChildrenAreExpectedMocks();
 	}
 
 	private void assertChildrenAreExpectedMocks() {
@@ -127,23 +138,6 @@ class StateAccessorTest {
 		assertSame(uniqueOwnershipAssociations, subject.uniqueOwnershipAssociations());
 		assertSame(uniqueTreasuryOwnershipAssociations, subject.uniqueOwnershipTreasuryAssociations());
 		assertSame(runningHashLeaf, subject.runningHashLeaf());
-	}
-
-	private void assertChildrenAreNull() {
-		assertThrows(NullPointerException.class, subject::accounts);
-		assertThrows(NullPointerException.class, subject::storage);
-		assertThrows(NullPointerException.class, subject::topics);
-		assertThrows(NullPointerException.class, subject::tokens);
-		assertThrows(NullPointerException.class, subject::tokenAssociations);
-		assertThrows(NullPointerException.class, subject::schedules);
-		assertThrows(NullPointerException.class, subject::networkCtx);
-		assertThrows(NullPointerException.class, subject::addressBook);
-		assertThrows(NullPointerException.class, subject::specialFiles);
-		assertThrows(NullPointerException.class, subject::uniqueTokens);
-		assertThrows(NullPointerException.class, subject::uniqueTokenAssociations);
-		assertThrows(NullPointerException.class, subject::uniqueOwnershipAssociations);
-		assertThrows(NullPointerException.class, subject::uniqueOwnershipTreasuryAssociations);
-		assertThrows(NullPointerException.class, subject::runningHashLeaf);
 	}
 
 	private void givenStateWithMockChildren() {


### PR DESCRIPTION
**Description**:
- Per @nathanklick recommendation, eliminate need for `MutableStateChildren.nullOutRefs()` by just holding `WeakReference`s to the various state children.