### PR TITLE
Use weak refs in `MutableStateChildren`, check signed state version before expanding sigs

### DIFF
--- a/hedera-node/src/main/java/com/hedera/services/ServicesState.java
+++ b/hedera-node/src/main/java/com/hedera/services/ServicesState.java
@@ -286,6 +286,10 @@ public class ServicesState extends AbstractNaryMerkleInternal implements SwirldS
 		return networkCtx().consensusTimeOfLastHandledTxn();
 	}
 
+	public int getStateVersion() {
+		return networkCtx().getStateVersion();
+	}
+
 	public void logSummary() {
 		String ctxSummary;
 		if (metadata != null) {
@@ -420,18 +424,6 @@ public class ServicesState extends AbstractNaryMerkleInternal implements SwirldS
 
 	int getDeserializedVersion() {
 		return deserializedVersion;
-	}
-
-	Platform getPlatformForDeferredInit() {
-		return platformForDeferredInit;
-	}
-
-	AddressBook getAddressBookForDeferredInit() {
-		return addressBookForDeferredInit;
-	}
-
-	SwirldDualState getDualStateForDeferredInit() {
-		return dualStateForDeferredInit;
 	}
 
 	void createGenesisChildren(AddressBook addressBook, long seqStart) {

--- a/hedera-node/src/main/java/com/hedera/services/ServicesState.java
+++ b/hedera-node/src/main/java/com/hedera/services/ServicesState.java
@@ -426,6 +426,18 @@ public class ServicesState extends AbstractNaryMerkleInternal implements SwirldS
 		return deserializedVersion;
 	}
 
+	Platform getPlatformForDeferredInit() {
+		return platformForDeferredInit;
+	}
+
+	AddressBook getAddressBookForDeferredInit() {
+		return addressBookForDeferredInit;
+	}
+
+	SwirldDualState getDualStateForDeferredInit() {
+		return dualStateForDeferredInit;
+	}
+
 	void createGenesisChildren(AddressBook addressBook, long seqStart) {
 		final var virtualMapFactory = new VirtualMapFactory(JasperDbBuilder::new);
 

--- a/hedera-node/src/main/java/com/hedera/services/context/MutableStateChildren.java
+++ b/hedera-node/src/main/java/com/hedera/services/context/MutableStateChildren.java
@@ -262,6 +262,7 @@ public class MutableStateChildren implements StateChildren {
 		accounts = new WeakReference<>(state.accounts());
 		topics = new WeakReference<>(state.topics());
 		storage = new WeakReference<>(state.storage());
+		contractStorage = new WeakReference<>(state.contractStorage());
 		tokens = new WeakReference<>(state.tokens());
 		tokenAssociations = new WeakReference<>(state.tokenAssociations());
 		schedules = new WeakReference<>(state.scheduleTxs());

--- a/hedera-node/src/main/java/com/hedera/services/context/MutableStateChildren.java
+++ b/hedera-node/src/main/java/com/hedera/services/context/MutableStateChildren.java
@@ -129,8 +129,9 @@ public class MutableStateChildren implements StateChildren {
 
 	@Override
 	public VirtualMap<ContractKey, ContractValue> contractStorage() {
-		Objects.requireNonNull(contractStorage);
-		return contractStorage;
+		final var refContractStorage = contractStorage.get();
+		Objects.requireNonNull(refContractStorage);
+		return refContractStorage;
 	}
 
 	public void setContractStorage(VirtualMap<ContractKey, ContractValue> contractStorage) {

--- a/hedera-node/src/main/java/com/hedera/services/context/MutableStateChildren.java
+++ b/hedera-node/src/main/java/com/hedera/services/context/MutableStateChildren.java
@@ -41,6 +41,7 @@ import com.swirlds.fchashmap.FCOneToManyRelation;
 import com.swirlds.merkle.map.MerkleMap;
 import com.swirlds.virtualmap.VirtualMap;
 
+import java.lang.ref.WeakReference;
 import java.time.Instant;
 import java.util.Objects;
 
@@ -52,21 +53,21 @@ import java.util.Objects;
  * methods {@code init()}, {@code copy()}, and {@code handleTransaction()}.
  */
 public class MutableStateChildren implements StateChildren {
-	private MerkleMap<EntityNum, MerkleAccount> accounts;
-	private MerkleMap<EntityNum, MerkleTopic> topics;
-	private MerkleMap<EntityNum, MerkleToken> tokens;
-	private MerkleMap<EntityNumPair, MerkleUniqueToken> uniqueTokens;
-	private MerkleMap<EntityNum, MerkleSchedule> schedules;
-	private VirtualMap<VirtualBlobKey, VirtualBlobValue> storage;
-	private VirtualMap<ContractKey, ContractValue> contractStorage;
-	private MerkleMap<EntityNumPair, MerkleTokenRelStatus> tokenAssociations;
-	private FCOneToManyRelation<EntityNum, Long> uniqueTokenAssociations;
-	private FCOneToManyRelation<EntityNum, Long> uniqueOwnershipAssociations;
-	private FCOneToManyRelation<EntityNum, Long> uniqueOwnershipTreasuryAssociations;
-	private MerkleNetworkContext networkCtx;
-	private AddressBook addressBook;
-	private MerkleSpecialFiles specialFiles;
-	private RecordsRunningHashLeaf runningHashLeaf;
+	private WeakReference<MerkleMap<EntityNum, MerkleAccount>> accounts;
+	private WeakReference<MerkleMap<EntityNum, MerkleTopic>> topics;
+	private WeakReference<MerkleMap<EntityNum, MerkleToken>> tokens;
+	private WeakReference<MerkleMap<EntityNumPair, MerkleUniqueToken>> uniqueTokens;
+	private WeakReference<MerkleMap<EntityNum, MerkleSchedule>> schedules;
+	private WeakReference<VirtualMap<VirtualBlobKey, VirtualBlobValue>> storage;
+	private WeakReference<VirtualMap<ContractKey, ContractValue>> contractStorage;
+	private WeakReference<MerkleMap<EntityNumPair, MerkleTokenRelStatus>> tokenAssociations;
+	private WeakReference<FCOneToManyRelation<EntityNum, Long>> uniqueTokenAssociations;
+	private WeakReference<FCOneToManyRelation<EntityNum, Long>> uniqueOwnershipAssociations;
+	private WeakReference<FCOneToManyRelation<EntityNum, Long>> uniqueOwnershipTreasuryAssociations;
+	private WeakReference<MerkleNetworkContext> networkCtx;
+	private WeakReference<AddressBook> addressBook;
+	private WeakReference<MerkleSpecialFiles> specialFiles;
+	private WeakReference<RecordsRunningHashLeaf> runningHashLeaf;
 	private Instant signedAt = Instant.EPOCH;
 
 	public MutableStateChildren() {
@@ -84,52 +85,46 @@ public class MutableStateChildren implements StateChildren {
 
 	@Override
 	public MerkleMap<EntityNum, MerkleAccount> accounts() {
-		Objects.requireNonNull(accounts);
-		return accounts;
+		final var refAccounts = accounts.get();
+		Objects.requireNonNull(refAccounts);
+		return refAccounts;
 	}
 
 	public void setAccounts(MerkleMap<EntityNum, MerkleAccount> accounts) {
-		this.accounts = accounts;
+		this.accounts = new WeakReference<>(accounts);
 	}
 
 	@Override
 	public MerkleMap<EntityNum, MerkleTopic> topics() {
-		Objects.requireNonNull(topics);
-		return topics;
+		final var refTopics = topics.get();
+		Objects.requireNonNull(refTopics);
+		return refTopics;
 	}
 
 	public void setTopics(MerkleMap<EntityNum, MerkleTopic> topics) {
-		this.topics = topics;
+		this.topics = new WeakReference<>(topics);
 	}
 
 	@Override
 	public MerkleMap<EntityNum, MerkleToken> tokens() {
-		Objects.requireNonNull(tokens);
-		return tokens;
+		final var refTokens = tokens.get();
+		Objects.requireNonNull(refTokens);
+		return refTokens;
 	}
 
 	public void setTokens(MerkleMap<EntityNum, MerkleToken> tokens) {
-		this.tokens = tokens;
-	}
-
-	@Override
-	public MerkleMap<EntityNum, MerkleSchedule> schedules() {
-		Objects.requireNonNull(schedules);
-		return schedules;
-	}
-
-	public void setSchedules(MerkleMap<EntityNum, MerkleSchedule> schedules) {
-		this.schedules = schedules;
+		this.tokens = new WeakReference<>(tokens);
 	}
 
 	@Override
 	public VirtualMap<VirtualBlobKey, VirtualBlobValue> storage() {
-		Objects.requireNonNull(storage);
-		return storage;
+                final var refStorage = storage.get();
+		Objects.requireNonNull(refStorage);
+		return refStorage;
 	}
 
 	public void setStorage(VirtualMap<VirtualBlobKey, VirtualBlobValue> storage) {
-		this.storage = storage;
+		this.storage = new WeakReference<>(storage);
 	}
 
 	@Override
@@ -139,121 +134,122 @@ public class MutableStateChildren implements StateChildren {
 	}
 
 	public void setContractStorage(VirtualMap<ContractKey, ContractValue> contractStorage) {
-		this.contractStorage = contractStorage;
+		this.contractStorage = new WeakReference<>(contractStorage);
+        }
+
+	@Override
+	public MerkleMap<EntityNum, MerkleSchedule> schedules() {
+		final var refSchedules = schedules.get();
+		Objects.requireNonNull(refSchedules);
+		return refSchedules;
+	}
+
+	public void setSchedules(MerkleMap<EntityNum, MerkleSchedule> schedules) {
+		this.schedules = new WeakReference<>(schedules);
 	}
 
 	@Override
 	public MerkleMap<EntityNumPair, MerkleTokenRelStatus> tokenAssociations() {
-		Objects.requireNonNull(tokenAssociations);
-		return tokenAssociations;
+		final var refTokenAssociations = tokenAssociations.get();
+		Objects.requireNonNull(refTokenAssociations);
+		return refTokenAssociations;
 	}
 
 	public void setTokenAssociations(MerkleMap<EntityNumPair, MerkleTokenRelStatus> tokenAssociations) {
-		this.tokenAssociations = tokenAssociations;
+		this.tokenAssociations = new WeakReference<>(tokenAssociations);
 	}
 
 	@Override
 	public MerkleNetworkContext networkCtx() {
-		Objects.requireNonNull(networkCtx);
-		return networkCtx;
+		final var refNetworkCtx = networkCtx.get();
+		Objects.requireNonNull(refNetworkCtx);
+		return refNetworkCtx;
 	}
 
 	public void setNetworkCtx(MerkleNetworkContext networkCtx) {
-		this.networkCtx = networkCtx;
+		this.networkCtx = new WeakReference<>(networkCtx);
 	}
 
 	@Override
 	public AddressBook addressBook() {
-		Objects.requireNonNull(addressBook);
-		return addressBook;
+		final var refAddressBook = addressBook.get();
+		Objects.requireNonNull(refAddressBook);
+		return refAddressBook;
 	}
 
 	public void setAddressBook(AddressBook addressBook) {
-		this.addressBook = addressBook;
+		this.addressBook = new WeakReference<>(addressBook);
 	}
 
 	@Override
 	public MerkleSpecialFiles specialFiles() {
-		Objects.requireNonNull(specialFiles);
-		return specialFiles;
+		final var refSpecialFiles = specialFiles.get();
+		Objects.requireNonNull(refSpecialFiles);
+		return refSpecialFiles;
 	}
 
 	public void setSpecialFiles(MerkleSpecialFiles specialFiles) {
-		this.specialFiles = specialFiles;
+		this.specialFiles = new WeakReference<>(specialFiles);
 	}
 
 	@Override
 	public MerkleMap<EntityNumPair, MerkleUniqueToken> uniqueTokens() {
-		Objects.requireNonNull(uniqueTokens);
-		return uniqueTokens;
+		final var refUniqueTokens = uniqueTokens.get();
+		Objects.requireNonNull(refUniqueTokens);
+		return refUniqueTokens;
 	}
 
 	public void setUniqueTokens(MerkleMap<EntityNumPair, MerkleUniqueToken> uniqueTokens) {
-		this.uniqueTokens = uniqueTokens;
+		this.uniqueTokens = new WeakReference<>(uniqueTokens);
 	}
 
 	@Override
 	public FCOneToManyRelation<EntityNum, Long> uniqueTokenAssociations() {
-		Objects.requireNonNull(uniqueTokenAssociations);
-		return uniqueTokenAssociations;
+		final var refUniqueTokenAssociations = uniqueTokenAssociations.get();
+		Objects.requireNonNull(refUniqueTokenAssociations);
+		return refUniqueTokenAssociations;
 	}
 
 	public void setUniqueTokenAssociations(FCOneToManyRelation<EntityNum, Long> uniqueTokenAssociations) {
-		this.uniqueTokenAssociations = uniqueTokenAssociations;
+		this.uniqueTokenAssociations = new WeakReference<>(uniqueTokenAssociations);
 	}
 
 	@Override
 	public FCOneToManyRelation<EntityNum, Long> uniqueOwnershipAssociations() {
-		Objects.requireNonNull(uniqueOwnershipAssociations);
-		return uniqueOwnershipAssociations;
+		final var refUniqueOwnershipAssociations = uniqueOwnershipAssociations.get();
+		Objects.requireNonNull(refUniqueOwnershipAssociations);
+		return refUniqueOwnershipAssociations;
 	}
 
 	public void setUniqueOwnershipAssociations(
 			FCOneToManyRelation<EntityNum, Long> uniqueOwnershipAssociations
 	) {
-		this.uniqueOwnershipAssociations = uniqueOwnershipAssociations;
+		this.uniqueOwnershipAssociations = new WeakReference<>(uniqueOwnershipAssociations);
 	}
 
 	@Override
 	public FCOneToManyRelation<EntityNum, Long> uniqueOwnershipTreasuryAssociations() {
-		Objects.requireNonNull(uniqueOwnershipTreasuryAssociations);
-		return uniqueOwnershipTreasuryAssociations;
+		final var refUniqueOwnershipTreasuryAssociations = uniqueOwnershipTreasuryAssociations.get();
+		Objects.requireNonNull(refUniqueOwnershipTreasuryAssociations);
+		return refUniqueOwnershipTreasuryAssociations;
 	}
 
 	public void setUniqueOwnershipTreasuryAssociations(
 			FCOneToManyRelation<EntityNum, Long> uniqueOwnershipTreasuryAssociations
 	) {
-		this.uniqueOwnershipTreasuryAssociations = uniqueOwnershipTreasuryAssociations;
+		this.uniqueOwnershipTreasuryAssociations = new WeakReference<>(uniqueOwnershipTreasuryAssociations);
 	}
 
 	@Override
 	public RecordsRunningHashLeaf runningHashLeaf() {
-		Objects.requireNonNull(runningHashLeaf);
-		return runningHashLeaf;
+		final var refRunningHashLeaf = runningHashLeaf.get();
+		Objects.requireNonNull(refRunningHashLeaf);
+		return refRunningHashLeaf;
 	}
+
 
 	public void setRunningHashLeaf(RecordsRunningHashLeaf runningHashLeaf) {
-		this.runningHashLeaf = runningHashLeaf;
-	}
-
-	@Override
-	public void nullOutRefs() {
-		signedAt = Instant.EPOCH;
-		accounts = null;
-		topics = null;
-		storage = null;
-		contractStorage = null;
-		tokens = null;
-		tokenAssociations = null;
-		schedules = null;
-		networkCtx = null;
-		addressBook = null;
-		specialFiles = null;
-		uniqueTokens = null;
-		uniqueTokenAssociations = null;
-		uniqueOwnershipAssociations = null;
-		uniqueOwnershipTreasuryAssociations = null;
-		runningHashLeaf = null;
+		this.runningHashLeaf = new WeakReference<>(runningHashLeaf);
 	}
 
 	public void updateFrom(final ServicesState signedState, final Instant signingTime) {
@@ -262,20 +258,19 @@ public class MutableStateChildren implements StateChildren {
 	}
 
 	public void updateFrom(final ServicesState state) {
-		accounts = state.accounts();
-		topics = state.topics();
-		storage = state.storage();
-		contractStorage = state.contractStorage();
-		tokens = state.tokens();
-		tokenAssociations = state.tokenAssociations();
-		schedules = state.scheduleTxs();
-		networkCtx = state.networkCtx();
-		addressBook = state.addressBook();
-		specialFiles = state.specialFiles();
-		uniqueTokens = state.uniqueTokens();
-		uniqueTokenAssociations = state.uniqueTokenAssociations();
-		uniqueOwnershipAssociations = state.uniqueOwnershipAssociations();
-		uniqueOwnershipTreasuryAssociations = state.uniqueTreasuryOwnershipAssociations();
-		runningHashLeaf = state.runningHashLeaf();
+		accounts = new WeakReference<>(state.accounts());
+		topics = new WeakReference<>(state.topics());
+		storage = new WeakReference<>(state.storage());
+		tokens = new WeakReference<>(state.tokens());
+		tokenAssociations = new WeakReference<>(state.tokenAssociations());
+		schedules = new WeakReference<>(state.scheduleTxs());
+		networkCtx = new WeakReference<>(state.networkCtx());
+		addressBook = new WeakReference<>(state.addressBook());
+		specialFiles = new WeakReference<>(state.specialFiles());
+		uniqueTokens = new WeakReference<>(state.uniqueTokens());
+		uniqueTokenAssociations = new WeakReference<>(state.uniqueTokenAssociations());
+		uniqueOwnershipAssociations = new WeakReference<>(state.uniqueOwnershipAssociations());
+		uniqueOwnershipTreasuryAssociations = new WeakReference<>(state.uniqueTreasuryOwnershipAssociations());
+		runningHashLeaf = new WeakReference<>(state.runningHashLeaf());
 	}
 }

--- a/hedera-node/src/main/java/com/hedera/services/context/StateChildren.java
+++ b/hedera-node/src/main/java/com/hedera/services/context/StateChildren.java
@@ -74,6 +74,4 @@ public interface StateChildren {
 	FCOneToManyRelation<EntityNum, Long> uniqueOwnershipTreasuryAssociations();
 
 	RecordsRunningHashLeaf runningHashLeaf();
-
-	void nullOutRefs();
 }

--- a/hedera-node/src/test/java/com/hedera/services/ServicesStateTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/ServicesStateTest.java
@@ -168,6 +168,7 @@ class ServicesStateTest {
 		given(metadata.app()).willReturn(app);
 		given(app.hashLogger()).willReturn(hashLogger);
 		given(app.dualStateAccessor()).willReturn(dualStateAccessor);
+		given(networkContext.getStateVersion()).willReturn(StateVersions.CURRENT_VERSION);
 		given(networkContext.consensusTimeOfLastHandledTxn()).willReturn(consTime);
 		given(networkContext.summarizedWith(dualStateAccessor)).willReturn("IMAGINE");
 
@@ -178,6 +179,7 @@ class ServicesStateTest {
 		verify(hashLogger).logHashesFor(subject);
 		assertEquals("IMAGINE", logCaptor.infoLogs().get(0));
 		assertEquals(consTime, subject.getTimeOfLastHandledTxn());
+		assertEquals(StateVersions.CURRENT_VERSION, subject.getStateVersion());
 	}
 
 	@Test

--- a/hedera-node/src/test/java/com/hedera/services/ledger/TransactionalLedgerTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/ledger/TransactionalLedgerTest.java
@@ -9,9 +9,9 @@ package com.hedera.services.ledger;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -63,7 +63,6 @@ import static org.mockito.BDDMockito.verifyNoMoreInteractions;
 import static org.mockito.BDDMockito.willThrow;
 import static org.mockito.Mockito.when;
 
-
 @ExtendWith(MockitoExtension.class)
 class TransactionalLedgerTest {
 	private final Object[] things = { "a", "b", "c", "d" };
@@ -99,24 +98,6 @@ class TransactionalLedgerTest {
 		verify(commitObserver).newProperty(1L, OBJ, things);
 		verify(commitObserver).newProperty(1L, FLAG, true);
 		verifyNoMoreInteractions(commitObserver);
-	}
-
-	@Test
-	void canUndoCreations() {
-		subject.begin();
-
-		subject.create(2L);
-
-		subject.undoCreations();
-
-		subject.commit();
-
-		verify(backingAccounts, never()).put(any(), any());
-	}
-
-	@Test
-	void canUndoCreationsOnlyInTxn() {
-		assertThrows(IllegalStateException.class, subject::undoCreations);
 	}
 
 	@Test
@@ -353,7 +334,7 @@ class TransactionalLedgerTest {
 		subject.set(1L, LONG, 3L);
 
 		// when:
-		long value = (long)subject.get(1L, LONG);
+		long value = (long) subject.get(1L, LONG);
 
 		// then:
 		verify(backingAccounts, times(2)).contains(1L);
@@ -396,7 +377,7 @@ class TransactionalLedgerTest {
 		subject.set(2L, OBJ, things[2]);
 
 		// when:
-		boolean flag = (boolean)subject.get(2L, FLAG);
+		boolean flag = (boolean) subject.get(2L, FLAG);
 
 		// then:
 		assertFalse(flag);

--- a/hedera-node/src/test/java/com/hedera/services/ledger/TransactionalLedgerTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/ledger/TransactionalLedgerTest.java
@@ -120,6 +120,24 @@ class TransactionalLedgerTest {
 	}
 
 	@Test
+	void canUndoCreations() {
+		subject.begin();
+
+		subject.create(2L);
+
+		subject.undoCreations();
+
+		subject.commit();
+
+		verify(backingAccounts, never()).put(any(), any());
+	}
+
+	@Test
+	void canUndoCreationsOnlyInTxn() {
+		assertThrows(IllegalStateException.class, subject::undoCreations);
+	}
+
+	@Test
 	void rollbackClearsChanges() {
 		given(backingAccounts.contains(1L)).willReturn(true);
 

--- a/hedera-node/src/test/java/com/hedera/services/legacy/core/jproto/JKeyTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/legacy/core/jproto/JKeyTest.java
@@ -99,13 +99,10 @@ class JKeyTest {
 
 		assertSame(mockEd25519.getEd25519(), mockEd25519.primitiveKeyIfPresent());
 		assertSame(mockSecp256k1.getECDSASecp256k1Key(), mockSecp256k1.primitiveKeyIfPresent());
-<<<<<<< HEAD
 		assertEquals(0, mockEd25519.getECDSASecp256k1Key().length);
 		assertEquals(0, mockSecp256k1.getEd25519().length);
 		assertEquals(0, mockSecp256k1.getECDSA384().length);
 		assertEquals(0, mockSecp256k1.getRSA3072().length);
-=======
->>>>>>> origin/master
 	}
 
 	@Test

--- a/hedera-node/src/test/java/com/hedera/services/legacy/core/jproto/JKeyTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/legacy/core/jproto/JKeyTest.java
@@ -99,10 +99,13 @@ class JKeyTest {
 
 		assertSame(mockEd25519.getEd25519(), mockEd25519.primitiveKeyIfPresent());
 		assertSame(mockSecp256k1.getECDSASecp256k1Key(), mockSecp256k1.primitiveKeyIfPresent());
+<<<<<<< HEAD
 		assertEquals(0, mockEd25519.getECDSASecp256k1Key().length);
 		assertEquals(0, mockSecp256k1.getEd25519().length);
 		assertEquals(0, mockSecp256k1.getECDSA384().length);
 		assertEquals(0, mockSecp256k1.getRSA3072().length);
+=======
+>>>>>>> origin/master
 	}
 
 	@Test

--- a/hedera-node/src/test/java/com/hedera/services/state/StateAccessorTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/state/StateAccessorTest.java
@@ -98,11 +98,6 @@ class StateAccessorTest {
 	}
 
 	@Test
-	void childrenNonNull() {
-		Assertions.assertNotNull(subject.children());
-	}
-
-	@Test
 	void childrenGetUpdatedAsExpected() {
 		givenStateWithMockChildren();
 
@@ -112,15 +107,28 @@ class StateAccessorTest {
 	}
 
 	@Test
-	void nullsOutChildrenAsExpected() {
-		final var anInstant = Instant.ofEpochSecond(1_234_567L, 890);
+	void settersWorkAsExpected() {
 		givenStateWithMockChildren();
-		((MutableStateChildren) subject.children()).updateFrom(state, anInstant);
 
-		subject.children().nullOutRefs();
+		final var mutableChildren = (MutableStateChildren) subject.children();
 
-		assertChildrenAreNull();
-		assertSame(Instant.EPOCH, subject.children().signedAt());
+		mutableChildren.setAccounts(state.accounts());
+		mutableChildren.setContractStorage(state.contractStorage());
+		mutableChildren.setStorage(state.storage());
+		mutableChildren.setTopics(state.topics());
+		mutableChildren.setTokens(state.tokens());
+		mutableChildren.setTokenAssociations(state.tokenAssociations());
+		mutableChildren.setSchedules(state.scheduleTxs());
+		mutableChildren.setNetworkCtx(state.networkCtx());
+		mutableChildren.setAddressBook(state.addressBook());
+		mutableChildren.setSpecialFiles(state.specialFiles());
+		mutableChildren.setUniqueTokens(state.uniqueTokens());
+		mutableChildren.setUniqueTokenAssociations(state.uniqueTokenAssociations());
+		mutableChildren.setUniqueOwnershipAssociations(state.uniqueOwnershipAssociations());
+		mutableChildren.setUniqueOwnershipTreasuryAssociations(state.uniqueTreasuryOwnershipAssociations());
+		mutableChildren.setRunningHashLeaf(state.runningHashLeaf());
+
+		assertChildrenAreExpectedMocks();
 	}
 
 	private void assertChildrenAreExpectedMocks() {
@@ -159,22 +167,10 @@ class StateAccessorTest {
 		given(state.contractStorage()).willReturn(contractStorage);
 	}
 
-	private void assertChildrenAreNull() {
-		assertThrows(NullPointerException.class, subject::accounts);
-		assertThrows(NullPointerException.class, subject::storage);
-		assertThrows(NullPointerException.class, subject::contractStorage);
-		assertThrows(NullPointerException.class, subject::topics);
-		assertThrows(NullPointerException.class, subject::tokens);
-		assertThrows(NullPointerException.class, subject::tokenAssociations);
-		assertThrows(NullPointerException.class, subject::schedules);
-		assertThrows(NullPointerException.class, subject::networkCtx);
-		assertThrows(NullPointerException.class, subject::addressBook);
-		assertThrows(NullPointerException.class, subject::specialFiles);
-		assertThrows(NullPointerException.class, subject::uniqueTokens);
-		assertThrows(NullPointerException.class, subject::uniqueTokenAssociations);
-		assertThrows(NullPointerException.class, subject::uniqueOwnershipAssociations);
-		assertThrows(NullPointerException.class, subject::uniqueOwnershipTreasuryAssociations);
-		assertThrows(NullPointerException.class, subject::runningHashLeaf);
+	@Test
+	void childrenNonNull() {
+		// expect:
+		Assertions.assertNotNull(subject.children());
 	}
 
 	private static final Instant signedAt = Instant.ofEpochSecond(1_234_567, 890);

--- a/pom.xml
+++ b/pom.xml
@@ -178,7 +178,7 @@
 		<javax-inject.version>1</javax-inject.version>
 		<log4j.version>2.17.1</log4j.version>
 		<netty.version>4.1.66.Final</netty.version>
-		<protobuf-java.version>3.19.1</protobuf-java.version>
+		<protobuf-java.version>3.19.2</protobuf-java.version>
 		<swirlds.version>0.22.0-alpha.3</swirlds.version>
 		<!-- Test dependency properties in alphabetical order -->
 		<hamcrest.version>2.2</hamcrest.version>


### PR DESCRIPTION
**Description**:
- Simplifies `SigReqsManager` by using weak references for `MutableStateChildren`.
- Checks the version of a signed state before using it to expand sigs (possible after upgrade that we have an old version).