### PR TITLE
Add primitive-only `MutableStateChildren` update

### DIFF
--- a/hedera-node/src/main/java/com/hedera/services/context/MutableStateChildren.java
+++ b/hedera-node/src/main/java/com/hedera/services/context/MutableStateChildren.java
@@ -237,11 +237,6 @@ public class MutableStateChildren implements StateChildren {
 		this.runningHashLeaf = new WeakReference<>(runningHashLeaf);
 	}
 
-	public void updateFrom(final ServicesState signedState, final Instant signingTime) {
-		signedAt = signingTime;
-		updateFrom(signedState);
-	}
-
 	public void updateFromMaybeUninitializedState(final ServicesState state, final Instant signingTime) {
 		signedAt = signingTime;
 		updatePrimitiveChildrenFrom(state);

--- a/hedera-node/src/main/java/com/hedera/services/context/MutableStateChildren.java
+++ b/hedera-node/src/main/java/com/hedera/services/context/MutableStateChildren.java
@@ -242,7 +242,22 @@ public class MutableStateChildren implements StateChildren {
 		updateFrom(signedState);
 	}
 
+	public void updateFromMaybeUninitializedState(final ServicesState state, final Instant signingTime) {
+		signedAt = signingTime;
+		updatePrimitiveChildrenFrom(state);
+		uniqueTokenAssociations = new WeakReference<>(null);
+		uniqueOwnershipAssociations = new WeakReference<>(null);
+		uniqueOwnershipTreasuryAssociations = new WeakReference<>(null);
+	}
+
 	public void updateFrom(final ServicesState state) {
+		updatePrimitiveChildrenFrom(state);
+		uniqueTokenAssociations = new WeakReference<>(state.uniqueTokenAssociations());
+		uniqueOwnershipAssociations = new WeakReference<>(state.uniqueOwnershipAssociations());
+		uniqueOwnershipTreasuryAssociations = new WeakReference<>(state.uniqueTreasuryOwnershipAssociations());
+	}
+
+	private void updatePrimitiveChildrenFrom(final ServicesState state) {
 		accounts = new WeakReference<>(state.accounts());
 		topics = new WeakReference<>(state.topics());
 		storage = new WeakReference<>(state.storage());
@@ -253,9 +268,6 @@ public class MutableStateChildren implements StateChildren {
 		addressBook = new WeakReference<>(state.addressBook());
 		specialFiles = new WeakReference<>(state.specialFiles());
 		uniqueTokens = new WeakReference<>(state.uniqueTokens());
-		uniqueTokenAssociations = new WeakReference<>(state.uniqueTokenAssociations());
-		uniqueOwnershipAssociations = new WeakReference<>(state.uniqueOwnershipAssociations());
-		uniqueOwnershipTreasuryAssociations = new WeakReference<>(state.uniqueTreasuryOwnershipAssociations());
 		runningHashLeaf = new WeakReference<>(state.runningHashLeaf());
 	}
 }

--- a/hedera-node/src/main/java/com/hedera/services/sigs/order/SigReqsManager.java
+++ b/hedera-node/src/main/java/com/hedera/services/sigs/order/SigReqsManager.java
@@ -183,8 +183,13 @@ public class SigReqsManager {
 		/* Update our children (e.g., MerkleMaps and VirtualMaps) from the current signed state.
 		 * Because event intake is single-threaded, there's no risk of another thread getting
 		 * inconsistent results while we are doing this. Also, note that MutableStateChildren
-		 * uses weak references, so we won't keep this signed state from GC eligibility. */
-		signedChildren.updateFrom(signedState, earliestSigningTime);
+		 * uses weak references, so we won't keep this signed state from GC eligibility.
+		 *
+		 * We use the updateFromMaybeUninitializedState() variant here, because during a
+		 * reconnect the latest signed state may have never received an init() call. In that
+		 * case, any "rebuilt" children of the ServicesState will be null. (This isn't a
+		 * problem for any existing SigRequirements code, however.) */
+		signedChildren.updateFromMaybeUninitializedState(signedState, earliestSigningTime);
 		ensureSignedStateSigReqsIsConstructed();
 		expansionHelper.expandIn(accessor, signedSigReqs, accessor.getPkToSigsFn());
 	}

--- a/hedera-node/src/test/java/com/hedera/services/context/MutableStateChildrenTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/context/MutableStateChildrenTest.java
@@ -1,0 +1,101 @@
+package com.hedera.services.context;
+
+import com.hedera.services.ServicesState;
+import com.hedera.services.state.merkle.MerkleAccount;
+import com.hedera.services.state.merkle.MerkleNetworkContext;
+import com.hedera.services.state.merkle.MerkleOptionalBlob;
+import com.hedera.services.state.merkle.MerkleSchedule;
+import com.hedera.services.state.merkle.MerkleSpecialFiles;
+import com.hedera.services.state.merkle.MerkleToken;
+import com.hedera.services.state.merkle.MerkleTokenRelStatus;
+import com.hedera.services.state.merkle.MerkleTopic;
+import com.hedera.services.state.merkle.MerkleUniqueToken;
+import com.hedera.services.stream.RecordsRunningHashLeaf;
+import com.hedera.services.utils.EntityNum;
+import com.hedera.services.utils.EntityNumPair;
+import com.swirlds.common.AddressBook;
+import com.swirlds.merkle.map.MerkleMap;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Instant;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class MutableStateChildrenTest {
+	@Mock
+	private ServicesState state;
+	@Mock
+	private MerkleMap<EntityNum, MerkleAccount> accounts;
+	@Mock
+	private MerkleMap<String, MerkleOptionalBlob> storage;
+	@Mock
+	private MerkleMap<EntityNum, MerkleTopic> topics;
+	@Mock
+	private MerkleMap<EntityNum, MerkleToken> tokens;
+	@Mock
+	private MerkleMap<EntityNumPair, MerkleTokenRelStatus> tokenAssociations;
+	@Mock
+	private MerkleMap<EntityNum, MerkleSchedule> scheduleTxs;
+	@Mock
+	private MerkleNetworkContext networkCtx;
+	@Mock
+	private AddressBook addressBook;
+	@Mock
+	private MerkleSpecialFiles specialFiles;
+	@Mock
+	private MerkleMap<EntityNumPair, MerkleUniqueToken> uniqueTokens;
+	@Mock
+	private RecordsRunningHashLeaf runningHashLeaf;
+
+	private MutableStateChildren subject = new MutableStateChildren();
+
+	@Test
+	void childrenGetUpdatedAsExpected() {
+		givenStateWithMockChildren();
+
+		subject.updateFromMaybeUninitializedState(state, signedAt);
+
+		assertChildrenAreExpectedMocks();
+		assertEquals(signedAt, subject.signedAt());
+		assertThrows(NullPointerException.class, subject::uniqueTokenAssociations);
+		assertThrows(NullPointerException.class, subject::uniqueOwnershipAssociations);
+		assertThrows(NullPointerException.class, subject::uniqueOwnershipTreasuryAssociations);
+	}
+
+	private void givenStateWithMockChildren() {
+		given(state.accounts()).willReturn(accounts);
+		given(state.storage()).willReturn(storage);
+		given(state.topics()).willReturn(topics);
+		given(state.tokens()).willReturn(tokens);
+		given(state.tokenAssociations()).willReturn(tokenAssociations);
+		given(state.scheduleTxs()).willReturn(scheduleTxs);
+		given(state.networkCtx()).willReturn(networkCtx);
+		given(state.addressBook()).willReturn(addressBook);
+		given(state.specialFiles()).willReturn(specialFiles);
+		given(state.uniqueTokens()).willReturn(uniqueTokens);
+		given(state.runningHashLeaf()).willReturn(runningHashLeaf);
+	}
+
+	private void assertChildrenAreExpectedMocks() {
+		assertSame(accounts, subject.accounts());
+		assertSame(storage, subject.storage());
+		assertSame(topics, subject.topics());
+		assertSame(tokens, subject.tokens());
+		assertSame(tokenAssociations, subject.tokenAssociations());
+		assertSame(scheduleTxs, subject.schedules());
+		assertSame(networkCtx, subject.networkCtx());
+		assertSame(addressBook, subject.addressBook());
+		assertSame(specialFiles, subject.specialFiles());
+		assertSame(uniqueTokens, subject.uniqueTokens());
+		assertSame(runningHashLeaf, subject.runningHashLeaf());
+	}
+
+	private static final Instant signedAt = Instant.ofEpochSecond(1_234_567, 890);
+}

--- a/hedera-node/src/test/java/com/hedera/services/state/StateAccessorTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/state/StateAccessorTest.java
@@ -162,6 +162,4 @@ class StateAccessorTest {
 		// expect:
 		Assertions.assertNotNull(subject.children());
 	}
-
-	private static final Instant signedAt = Instant.ofEpochSecond(1_234_567, 890);
 }


### PR DESCRIPTION
**Description**:
- Adds `MutableStateChildren.updateFromMaybeUninitializedState()` for use by `SigReqsManager` to update children from a signed state which may not have received an `init()` call (e.g., because it was received from a teacher during reconnect).