### PR TITLE
Adjust NFT treasury check in burn

### DIFF
--- a/hedera-node/src/main/java/com/hedera/services/store/models/Token.java
+++ b/hedera-node/src/main/java/com/hedera/services/store/models/Token.java
@@ -250,7 +250,7 @@ public class Token {
 			final var uniqueToken = loadedUniqueTokens.get(serialNum);
 			validateTrue(uniqueToken != null, FAIL_INVALID);
 
-			final var treasuryIsOwner = uniqueToken.getOwner().equals(Id.DEFAULT);
+			final var treasuryIsOwner = uniqueToken.getOwner().equals(treasuryId);
 			validateTrue(treasuryIsOwner, TREASURY_MUST_OWN_BURNED_NFT);
 			ownershipTracker.add(id, OwnershipTracker.forRemoving(treasuryId, serialNum));
 			removedUniqueTokens.add(new UniqueToken(id, serialNum, treasuryId));

--- a/hedera-node/src/test/java/com/hedera/services/store/models/TokenTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/store/models/TokenTest.java
@@ -74,7 +74,7 @@ class TokenTest {
 	private final long initialSupply = 1_000L;
 	private final long initialTreasuryBalance = 500L;
 	private final Id id = new Id(1, 2, 3);
-	private final Id treasuryId = new Id(0, 0, 0);
+	private final Id treasuryId = new Id(0, 0, 1337);
 	private final Id nonTreasuryId = new Id(3, 2, 3);
 	private final Account treasuryAccount = new Account(treasuryId);
 	private final Account nonTreasuryAccount = new Account(nonTreasuryId);
@@ -603,7 +603,7 @@ class TokenTest {
 	@Test
 	void toStringWorks() {
 		final var desired = "Token{id=Id[shard=1, realm=2, num=3], type=null, deleted=false, autoRemoved=false, " +
-				"treasury=Account{id=Id[shard=0, realm=0, num=0], expiry=0, balance=0, deleted=false, tokens=<N/A>, " +
+				"treasury=Account{id=Id[shard=0, realm=0, num=1337], expiry=0, balance=0, deleted=false, tokens=<N/A>, " +
 				"ownedNfts=0, alreadyUsedAutoAssociations=0, maxAutoAssociations=0, alias=}, autoRenewAccount=null, " +
 				"kycKey=<N/A>, freezeKey=<N/A>, frozenByDefault=false, supplyKey=<N/A>, currentSerialNumber=0, " +
 				"pauseKey=<N/A>, paused=false}";


### PR DESCRIPTION


**Description**:
Change the treasuryIsOwner check to validate against the token's
treasury account rather than 0.0.0.  Adjust unit test to use non-0.0.0
treasury account.

Signed-off-by: Danno Ferrin <danno.ferrin@hedera.com>

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
