### PR TITLE
Allow existing accounts to update their alias

### DIFF
--- a/hedera-node/src/main/java/com/hedera/services/ledger/HederaLedger.java
+++ b/hedera-node/src/main/java/com/hedera/services/ledger/HederaLedger.java
@@ -20,6 +20,7 @@ package com.hedera.services.ledger;
  * ‍
  */
 
+import com.google.protobuf.ByteString;
 import com.hedera.services.context.SideEffectsTracker;
 import com.hedera.services.context.properties.GlobalDynamicProperties;
 import com.hedera.services.exceptions.DeletedAccountException;
@@ -60,6 +61,7 @@ import java.util.List;
 
 import static com.hedera.services.ledger.TransferLogic.dropTokenChanges;
 import static com.hedera.services.ledger.backing.BackingTokenRels.asTokenRel;
+import static com.hedera.services.ledger.properties.AccountProperty.ALIAS;
 import static com.hedera.services.ledger.properties.AccountProperty.ALREADY_USED_AUTOMATIC_ASSOCIATIONS;
 import static com.hedera.services.ledger.properties.AccountProperty.AUTO_RENEW_PERIOD;
 import static com.hedera.services.ledger.properties.AccountProperty.BALANCE;
@@ -74,6 +76,7 @@ import static com.hedera.services.ledger.properties.AccountProperty.PROXY;
 import static com.hedera.services.ledger.properties.AccountProperty.TOKENS;
 import static com.hedera.services.ledger.properties.TokenRelProperty.TOKEN_BALANCE;
 import static com.hedera.services.txns.validation.TransferListChecks.isNetZeroAdjustment;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_ACCOUNT_ID;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OK;
 
 /**
@@ -466,6 +469,10 @@ public class HederaLedger {
 		return (String) accountsLedger.get(id, MEMO);
 	}
 
+	public ByteString alias(AccountID id) {
+		return (ByteString) accountsLedger.get(id, ALIAS);
+	}
+
 	public boolean isPendingCreation(AccountID id) {
 		return accountsLedger.existsPending(id);
 	}
@@ -505,6 +512,10 @@ public class HederaLedger {
 
 
 	/* ---- Alias lookup helpers */
+	public AliasLookup lookupAliasedId(final AccountID grpcId) {
+		return tokenStore.lookupAliasedId(grpcId, INVALID_ACCOUNT_ID);
+	}
+
 	public AliasLookup lookupAliasedId(final AccountID grpcId, final ResponseCodeEnum errResponse) {
 		return tokenStore.lookupAliasedId(grpcId, errResponse);
 	}

--- a/hedera-node/src/main/java/com/hedera/services/ledger/HederaLedger.java
+++ b/hedera-node/src/main/java/com/hedera/services/ledger/HederaLedger.java
@@ -76,7 +76,6 @@ import static com.hedera.services.ledger.properties.AccountProperty.PROXY;
 import static com.hedera.services.ledger.properties.AccountProperty.TOKENS;
 import static com.hedera.services.ledger.properties.TokenRelProperty.TOKEN_BALANCE;
 import static com.hedera.services.txns.validation.TransferListChecks.isNetZeroAdjustment;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_ACCOUNT_ID;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OK;
 
 /**
@@ -512,10 +511,6 @@ public class HederaLedger {
 
 
 	/* ---- Alias lookup helpers */
-	public AliasLookup lookupAliasedId(final AccountID grpcId) {
-		return tokenStore.lookUpAliasedId(grpcId, INVALID_ACCOUNT_ID);
-	}
-
 	public AliasLookup lookUpAliasedId(final AccountID grpcId, final ResponseCodeEnum errResponse) {
 		return tokenStore.lookUpAliasedId(grpcId, errResponse);
 	}

--- a/hedera-node/src/main/java/com/hedera/services/sigs/order/PolicyBasedSigWaivers.java
+++ b/hedera-node/src/main/java/com/hedera/services/sigs/order/PolicyBasedSigWaivers.java
@@ -9,9 +9,9 @@ package com.hedera.services.sigs.order;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -92,6 +92,18 @@ public class PolicyBasedSigWaivers implements SignatureWaivers {
 		} else {
 			final var targetNum = cryptoUpdateTxn.getCryptoUpdateAccount().getAccountIDToUpdate().getAccountNum();
 			return targetNum != accountNums.treasury();
+		}
+	}
+
+	@Override
+	public boolean isAliasKeyWaived(TransactionBody cryptoUpdateTxn) {
+		assertTypeExpectation(cryptoUpdateTxn.hasCryptoUpdateAccount());
+		final var isAuthorized = opPolicies.checkKnownTxn(cryptoUpdateTxn, CryptoUpdate) == AUTHORIZED;
+		if (!isAuthorized) {
+			return false;
+		} else {
+			final var targetAlias = cryptoUpdateTxn.getCryptoUpdateAccount().getAlias();
+			return targetAlias.isEmpty();
 		}
 	}
 

--- a/hedera-node/src/main/java/com/hedera/services/sigs/order/SignatureWaivers.java
+++ b/hedera-node/src/main/java/com/hedera/services/sigs/order/SignatureWaivers.java
@@ -9,9 +9,9 @@ package com.hedera.services.sigs.order;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -29,7 +29,8 @@ public interface SignatureWaivers {
 	/**
 	 * Advises if the target file's WACL must sign a given file append.
 	 *
-	 * @param fileAppendTxn a file append transaction
+	 * @param fileAppendTxn
+	 * 		a file append transaction
 	 * @return whether the target file's WACL must sign
 	 */
 	boolean isAppendFileWaclWaived(TransactionBody fileAppendTxn);
@@ -37,7 +38,8 @@ public interface SignatureWaivers {
 	/**
 	 * Advises if the target file's WACL must sign a given file update.
 	 *
-	 * @param fileUpdateTxn a file update transaction
+	 * @param fileUpdateTxn
+	 * 		a file update transaction
 	 * @return whether the target file's WACL must sign
 	 */
 	boolean isTargetFileWaclWaived(TransactionBody fileUpdateTxn);
@@ -45,7 +47,8 @@ public interface SignatureWaivers {
 	/**
 	 * Advises if the new WACL in a given file update transaction must sign.
 	 *
-	 * @param fileUpdateTxn a file update transaction
+	 * @param fileUpdateTxn
+	 * 		a file update transaction
 	 * @return whether the new WACL from the transaction must sign
 	 */
 	boolean isNewFileWaclWaived(TransactionBody fileUpdateTxn);
@@ -53,7 +56,8 @@ public interface SignatureWaivers {
 	/**
 	 * Advises if the target account's key must sign a given crypto update.
 	 *
-	 * @param cryptoUpdateTxn a crypto update transaction
+	 * @param cryptoUpdateTxn
+	 * 		a crypto update transaction
 	 * @return whether the target account's key must sign
 	 */
 	boolean isTargetAccountKeyWaived(TransactionBody cryptoUpdateTxn);
@@ -61,8 +65,17 @@ public interface SignatureWaivers {
 	/**
 	 * Advises if the new key for an account must sign a given crypto update.
 	 *
-	 * @param cryptoUpdateTxn a crypto update transaction
+	 * @param cryptoUpdateTxn
+	 * 		a crypto update transaction
 	 * @return whether the new key from the transaction must sign
 	 */
 	boolean isNewAccountKeyWaived(TransactionBody cryptoUpdateTxn);
+
+	/**
+	 * Advises if key of the alias being updated should sign the given crypto update.
+	 *
+	 * @param cryptoUpdateTxn a crypto update transaction
+	 * @return whether the key of the alias being updated must sign
+	 */
+	boolean isAliasKeyWaived(TransactionBody cryptoUpdateTxn);
 }

--- a/hedera-node/src/main/java/com/hedera/services/txns/crypto/AutoCreationLogic.java
+++ b/hedera-node/src/main/java/com/hedera/services/txns/crypto/AutoCreationLogic.java
@@ -211,7 +211,7 @@ public class AutoCreationLogic {
 		return fees.getServiceFee() + fees.getNetworkFee() + fees.getNodeFee();
 	}
 
-	private Key asPrimitiveKeyUnchecked(final ByteString alias) {
+	public static Key asPrimitiveKeyUnchecked(final ByteString alias) {
 		try {
 			return Key.parseFrom(alias);
 		} catch (InvalidProtocolBufferException internal) {

--- a/hedera-node/src/main/java/com/hedera/services/txns/validation/ContextOptionValidator.java
+++ b/hedera-node/src/main/java/com/hedera/services/txns/validation/ContextOptionValidator.java
@@ -21,7 +21,6 @@ package com.hedera.services.txns.validation;
  */
 
 import com.google.protobuf.ByteString;
-import com.google.protobuf.InvalidProtocolBufferException;
 import com.hedera.services.context.NodeInfo;
 import com.hedera.services.context.TransactionContext;
 import com.hedera.services.context.annotations.CompositeProps;

--- a/hedera-node/src/main/java/com/hedera/services/txns/validation/ContextOptionValidator.java
+++ b/hedera-node/src/main/java/com/hedera/services/txns/validation/ContextOptionValidator.java
@@ -20,6 +20,8 @@ package com.hedera.services.txns.validation;
  * ‍
  */
 
+import com.google.protobuf.ByteString;
+import com.google.protobuf.InvalidProtocolBufferException;
 import com.hedera.services.context.NodeInfo;
 import com.hedera.services.context.TransactionContext;
 import com.hedera.services.context.annotations.CompositeProps;
@@ -47,6 +49,7 @@ import java.time.Instant;
 import java.util.Optional;
 
 import static com.hedera.services.legacy.core.jproto.JKey.mapKey;
+import static com.hedera.services.utils.MiscUtils.isSerializedProtoKey;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_TOPIC_ID;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_ZERO_BYTE_IN_STRING;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.MEMO_TOO_LONG;
@@ -126,6 +129,11 @@ public class ContextOptionValidator implements OptionValidator {
 	@Override
 	public boolean isAcceptableTransfersLength(TransferList accountAmounts) {
 		return accountAmounts.getAccountAmountsCount() <= dynamicProperties.maxTransferListSize();
+	}
+
+	@Override
+	public boolean isValidAlias(final ByteString alias) {
+		return isSerializedProtoKey(alias);
 	}
 
 	@Override

--- a/hedera-node/src/main/java/com/hedera/services/txns/validation/OptionValidator.java
+++ b/hedera-node/src/main/java/com/hedera/services/txns/validation/OptionValidator.java
@@ -20,6 +20,7 @@ package com.hedera.services.txns.validation;
  * ‍
  */
 
+import com.google.protobuf.ByteString;
 import com.hedera.services.context.primitives.StateView;
 import com.hedera.services.legacy.core.jproto.JKey;
 import com.hedera.services.state.merkle.MerkleAccount;
@@ -57,6 +58,8 @@ public interface OptionValidator {
 	boolean isValidAutoRenewPeriod(Duration autoRenewPeriod);
 
 	boolean isAcceptableTransfersLength(TransferList accountAmounts);
+
+	boolean isValidAlias(ByteString alias);
 
 	JKey attemptDecodeOrThrow(Key k);
 

--- a/hedera-node/src/test/java/com/hedera/services/ledger/BaseHederaLedgerTestHelper.java
+++ b/hedera-node/src/test/java/com/hedera/services/ledger/BaseHederaLedgerTestHelper.java
@@ -114,7 +114,6 @@ public class BaseHederaLedgerTestHelper {
 	protected AccountID deletable = AccountID.newBuilder().setAccountNum(666).build();
 	protected AccountID rand = AccountID.newBuilder().setAccountNum(2_345).build();
 	protected AccountID aliasAccountId = AccountID.newBuilder().setAlias(alias).build();
-	protected EntityNum aliasEntityNum = new EntityNum(5_432);
 	protected AccountID deleted = AccountID.newBuilder().setAccountNum(3_456).build();
 	protected AccountID detached = AccountID.newBuilder().setAccountNum(4_567).build();
 

--- a/hedera-node/src/test/java/com/hedera/services/ledger/HederaLedgerTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/ledger/HederaLedgerTest.java
@@ -39,6 +39,7 @@ import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 
 import static com.hedera.services.exceptions.InsufficientFundsException.messageFor;
+import static com.hedera.services.ledger.properties.AccountProperty.ALIAS;
 import static com.hedera.services.ledger.properties.AccountProperty.ALREADY_USED_AUTOMATIC_ASSOCIATIONS;
 import static com.hedera.services.ledger.properties.AccountProperty.AUTO_RENEW_PERIOD;
 import static com.hedera.services.ledger.properties.AccountProperty.BALANCE;
@@ -79,14 +80,18 @@ class HederaLedgerTest extends BaseHederaLedgerTestHelper {
 	}
 
 	@Test
-	void deligatesAccountLookUp() {
+	void delegatesAccountLookUp() {
 		final AccountID testId = AccountID.newBuilder().setAccountNum(123L).build();
 		subject.lookupAliasedId(testId, INVALID_ACCOUNT_ID);
 		verify(tokenStore).lookupAliasedId(testId, INVALID_ACCOUNT_ID);
 
 		subject.lookupAndValidateAliasedId(testId, INVALID_ACCOUNT_ID);
 		verify(tokenStore).lookupAndValidateAliasedId(testId, INVALID_ACCOUNT_ID);
+
+		subject.lookupAliasedId(testId);
+		verify(tokenStore, times(2)).lookupAliasedId(testId, INVALID_ACCOUNT_ID);
 	}
+
 
 	@Test
 	void ledgerGettersWork() {
@@ -242,6 +247,13 @@ class HederaLedgerTest extends BaseHederaLedgerTestHelper {
 		subject.memo(genesis);
 
 		verify(accountsLedger).get(genesis, MEMO);
+	}
+
+	@Test
+	void delegatesToCorrectAliasProperty() {
+		subject.alias(aliasAccountId);
+
+		verify(accountsLedger).get(aliasAccountId, ALIAS);
 	}
 
 	@Test

--- a/hedera-node/src/test/java/com/hedera/services/ledger/HederaLedgerTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/ledger/HederaLedgerTest.java
@@ -88,7 +88,7 @@ class HederaLedgerTest extends BaseHederaLedgerTestHelper {
 		subject.lookUpAndValidateAliasedId(testId, INVALID_ACCOUNT_ID);
 		verify(tokenStore).lookUpAndValidateAliasedId(testId, INVALID_ACCOUNT_ID);
 
-		subject.lookupAliasedId(testId);
+		subject.lookUpAliasedId(testId, INVALID_ACCOUNT_ID);
 		verify(tokenStore, times(2)).lookUpAliasedId(testId, INVALID_ACCOUNT_ID);
 	}
 

--- a/hedera-node/src/test/java/com/hedera/services/sigs/order/SigRequirementsTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/sigs/order/SigRequirementsTest.java
@@ -151,6 +151,8 @@ import static com.hedera.test.factories.scenarios.CryptoTransferScenarios.TOKEN_
 import static com.hedera.test.factories.scenarios.CryptoTransferScenarios.TOKEN_TRANSACT_WITH_OWNERSHIP_CHANGE_USING_ALIAS;
 import static com.hedera.test.factories.scenarios.CryptoTransferScenarios.TOKEN_TRANSACT_WITH_RECEIVER_SIG_REQ_AND_EXTANT_SENDERS;
 import static com.hedera.test.factories.scenarios.CryptoUpdateScenarios.CRYPTO_UPDATE_MISSING_ACCOUNT_SCENARIO;
+import static com.hedera.test.factories.scenarios.CryptoUpdateScenarios.CRYPTO_UPDATE_NEW_ALIAS_KEY_SCENARIO;
+import static com.hedera.test.factories.scenarios.CryptoUpdateScenarios.CRYPTO_UPDATE_NEW_ALIAS_SELF_PAID_SCENARIO;
 import static com.hedera.test.factories.scenarios.CryptoUpdateScenarios.CRYPTO_UPDATE_NO_NEW_KEY_SCENARIO;
 import static com.hedera.test.factories.scenarios.CryptoUpdateScenarios.CRYPTO_UPDATE_NO_NEW_KEY_SELF_PAID_SCENARIO;
 import static com.hedera.test.factories.scenarios.CryptoUpdateScenarios.CRYPTO_UPDATE_SYS_ACCOUNT_WITH_NEW_KEY_SCENARIO;
@@ -264,6 +266,7 @@ import static com.hedera.test.factories.txns.ConsensusCreateTopicFactory.SIMPLE_
 import static com.hedera.test.factories.txns.ContractCreateFactory.DEFAULT_ADMIN_KT;
 import static com.hedera.test.factories.txns.CryptoCreateFactory.DEFAULT_ACCOUNT_KT;
 import static com.hedera.test.factories.txns.FileCreateFactory.DEFAULT_WACL_KT;
+import static com.hedera.test.factories.txns.SignedTxnFactory.ALIAS_KEY;
 import static com.hedera.test.factories.txns.SignedTxnFactory.DEFAULT_PAYER_KT;
 import static com.hedera.test.utils.IdUtils.asAccount;
 import static com.hedera.test.utils.IdUtils.asAccountWithAlias;
@@ -479,6 +482,24 @@ class SigRequirementsTest {
 		// then:
 		assertThat(sanityRestored(summary.getOrderedKeys()), contains(RECEIVER_SIG_KT.asKey()));
 		assertFalse(sanityRestored(summary.getOrderedKeys()).contains(DEFAULT_PAYER_KT.asKey()));
+	}
+
+	@Test
+	void getsUpdateAlias() throws Throwable {
+		setupFor(CRYPTO_UPDATE_NEW_ALIAS_SELF_PAID_SCENARIO);
+
+		final var summary = subject.keysForOtherParties(txn, summaryFactory);
+
+		assertTrue(sanityRestored(summary.getOrderedKeys()).contains(ALIAS_KEY));
+	}
+
+	@Test
+	void getsUpdateAliasOnMiscAccount() throws Throwable {
+		setupFor(CRYPTO_UPDATE_NEW_ALIAS_KEY_SCENARIO);
+
+		final var summary = subject.keysForOtherParties(txn, summaryFactory);
+
+		assertThat(sanityRestored(summary.getOrderedKeys()), contains(MISC_ACCOUNT_KT.asKey(), ALIAS_KEY));
 	}
 
 	@Test

--- a/hedera-node/src/test/java/com/hedera/services/txns/crypto/AutoCreationLogicTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/txns/crypto/AutoCreationLogicTest.java
@@ -9,9 +9,9 @@ package com.hedera.services.txns.crypto;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -38,6 +38,7 @@ import com.hedera.services.state.submerkle.EntityId;
 import com.hedera.services.state.submerkle.ExpirableTxnRecord;
 import com.hedera.services.store.contracts.precompile.SyntheticTxnFactory;
 import com.hedera.services.utils.EntityNum;
+import com.hedera.test.factories.keys.KeyFactory;
 import com.hedera.test.utils.IdUtils;
 import com.hederahashgraph.api.proto.java.AccountAmount;
 import com.hederahashgraph.api.proto.java.AccountID;
@@ -45,6 +46,7 @@ import com.hederahashgraph.api.proto.java.Key;
 import com.hederahashgraph.api.proto.java.TransactionBody;
 import com.hederahashgraph.fee.FeeObject;
 import org.apache.commons.lang3.tuple.Pair;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -58,7 +60,9 @@ import static com.hedera.services.context.BasicTransactionContext.EMPTY_KEY;
 import static com.hedera.services.records.TxnAwareRecordsHistorian.DEFAULT_SOURCE_ID;
 import static com.hedera.services.txns.crypto.AutoCreationLogic.AUTO_MEMO;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OK;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
@@ -113,6 +117,14 @@ class AutoCreationLogicTest {
 		verify(sigImpactHistorian).markEntityChanged(createdNum.longValue());
 		verify(recordsHistorian).trackPrecedingChildRecord(DEFAULT_SOURCE_ID, mockSyntheticCreation, mockBuilder);
 		assertEquals(Pair.of(OK, totalFee), result);
+	}
+
+	@Test
+	void validatePrimitiveKeyCheck() {
+		final var key = KeyFactory.getDefaultInstance().newEd25519();
+		assertDoesNotThrow(() -> AutoCreationLogic.asPrimitiveKeyUnchecked(key.toByteString()));
+		assertThrows(IllegalStateException.class,
+				() -> AutoCreationLogic.asPrimitiveKeyUnchecked(key.toByteString().substring(0, 10)));
 	}
 
 	private void givenCollaborators() {

--- a/hedera-node/src/test/java/com/hedera/services/txns/crypto/AutoCreationLogicTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/txns/crypto/AutoCreationLogicTest.java
@@ -122,8 +122,8 @@ class AutoCreationLogicTest {
 	void validatePrimitiveKeyCheck() {
 		final var key = KeyFactory.getDefaultInstance().newEd25519();
 		assertDoesNotThrow(() -> AutoCreationLogic.asPrimitiveKeyUnchecked(key.toByteString()));
-		assertThrows(IllegalStateException.class,
-				() -> AutoCreationLogic.asPrimitiveKeyUnchecked(key.toByteString().substring(0, 10)));
+		final var invalidKey = key.toByteString().substring(0, 10);
+		assertThrows(IllegalStateException.class, () -> AutoCreationLogic.asPrimitiveKeyUnchecked(invalidKey));
 	}
 
 	private void givenCollaborators() {

--- a/hedera-node/src/test/java/com/hedera/services/txns/crypto/AutoCreationLogicTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/txns/crypto/AutoCreationLogicTest.java
@@ -46,7 +46,6 @@ import com.hederahashgraph.api.proto.java.Key;
 import com.hederahashgraph.api.proto.java.TransactionBody;
 import com.hederahashgraph.fee.FeeObject;
 import org.apache.commons.lang3.tuple.Pair;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;

--- a/hedera-node/src/test/java/com/hedera/services/txns/crypto/CryptoUpdateTransitionLogicTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/txns/crypto/CryptoUpdateTransitionLogicTest.java
@@ -483,27 +483,6 @@ class CryptoUpdateTransitionLogicTest {
 	}
 
 	@Test
-	void failsTryingToUpdateAlias() {
-		givenTxnCtx(EnumSet.of(ALIAS));
-		cryptoUpdateTxn = cryptoUpdateTxn.toBuilder()
-				.setCryptoUpdateAccount(cryptoUpdateTxn.getCryptoUpdateAccount().toBuilder()
-						.setAccountIDToUpdate(aliasAccountPayer))
-				.build();
-		given(ledger.exists(PAYER)).willReturn(true);
-		given(ledger.lookUpAliasedId(aliasAccountPayer, INVALID_ACCOUNT_ID)).willReturn(AliasLookup.of(PAYER, OK));
-		given(ledger.lookUpAndValidateAliasedId(aliasAccountPayer, INVALID_ACCOUNT_ID)).willReturn(
-				AliasLookup.of(PAYER, OK));
-
-		given(accessor.getTxn()).willReturn(cryptoUpdateTxn);
-		given(txnCtx.accessor()).willReturn(accessor);
-		given(ledger.alias(PAYER)).willReturn(aliasAccountPayer.getAlias());
-
-		subject.doStateTransition();
-
-		verify(txnCtx).setStatus(ALIAS_IS_IMMUTABLE);
-	}
-
-	@Test
 	void acceptsAliasedProxyAccountIDToUpdate() {
 		givenTxnCtx();
 		cryptoUpdateTxn = cryptoUpdateTxn.toBuilder()

--- a/hedera-node/src/test/java/com/hedera/services/txns/validation/ContextOptionValidatorTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/txns/validation/ContextOptionValidatorTest.java
@@ -34,6 +34,7 @@ import com.hedera.services.state.merkle.MerkleTopic;
 import com.hedera.services.utils.EntityNum;
 import com.hedera.services.utils.SignedTxnAccessor;
 import com.hedera.test.factories.accounts.MerkleAccountFactory;
+import com.hedera.test.factories.keys.KeyFactory;
 import com.hedera.test.factories.scenarios.TxnHandlingScenario;
 import com.hedera.test.factories.topics.TopicFactory;
 import com.hedera.test.factories.txns.SignedTxnFactory;
@@ -178,22 +179,23 @@ class ContextOptionValidatorTest {
 				.build();
 	}
 
-	private TransactionBody buildValidTransaction() {
-		final var creationOp = CryptoCreateTransactionBody.getDefaultInstance();
-		return TransactionBody.newBuilder()
-				.setTransactionID(TransactionID.newBuilder()
-						.setTransactionValidStart(Timestamp.newBuilder()
-								.setSeconds(Instant.now().getEpochSecond()))
-						.setAccountID(a))
-				.setCryptoCreateAccount(creationOp)
-				.build();
-	}
-
 	@Test
 	void decodesKeyAsExpected() throws Exception {
 		final var key = TxnHandlingScenario.SIMPLE_NEW_WACL_KT.asKey();
 		wacl = TxnHandlingScenario.SIMPLE_NEW_WACL_KT.asJKey();
 		assertTrue(equalUpToDecodability(wacl, subject.attemptDecodeOrThrow(key)));
+	}
+
+	@Test
+	void validatesAliasAsExpected() {
+		final var keylist = TxnHandlingScenario.SIMPLE_NEW_WACL_KT.asKey();
+		assertFalse(subject.isValidAlias(keylist.toByteString()));
+
+		final var ed25519Key = KeyFactory.getDefaultInstance().newEd25519();
+		assertTrue(subject.isValidAlias(ed25519Key.toByteString()));
+
+		final var ecdsaKey = KeyFactory.getDefaultInstance().newEcdsaSecp256k1();
+		assertTrue(subject.isValidAlias(ecdsaKey.toByteString()));
 	}
 
 	@Test

--- a/hedera-node/src/test/java/com/hedera/test/factories/scenarios/CryptoUpdateScenarios.java
+++ b/hedera-node/src/test/java/com/hedera/test/factories/scenarios/CryptoUpdateScenarios.java
@@ -24,6 +24,7 @@ import com.hedera.services.utils.PlatformTxnAccessor;
 
 import static com.hedera.test.factories.txns.CryptoUpdateFactory.newSignedCryptoUpdate;
 import static com.hedera.test.factories.txns.PlatformTxnFactory.from;
+import static com.hedera.test.factories.txns.SignedTxnFactory.ALIAS_PUBKEY_BYTESTRING;
 import static com.hedera.test.factories.txns.SignedTxnFactory.DEFAULT_PAYER_ID;
 import static com.hedera.test.factories.txns.SignedTxnFactory.MASTER_PAYER_ID;
 import static com.hedera.test.factories.txns.SignedTxnFactory.TREASURY_PAYER_ID;
@@ -128,6 +129,24 @@ public enum CryptoUpdateScenarios implements TxnHandlingScenario {
 					newSignedCryptoUpdate(TREASURY_PAYER_ID)
 							.payer(TREASURY_PAYER_ID)
 							.newAccountKt(NEW_ACCOUNT_KT)
+							.get()
+			));
+		}
+	},
+	CRYPTO_UPDATE_NEW_ALIAS_SELF_PAID_SCENARIO {
+		public PlatformTxnAccessor platformTxn() throws Throwable {
+			return new PlatformTxnAccessor(from(
+					newSignedCryptoUpdate(DEFAULT_PAYER_ID)
+							.newAlias(ALIAS_PUBKEY_BYTESTRING)
+							.get()
+			));
+		}
+	},
+	CRYPTO_UPDATE_NEW_ALIAS_KEY_SCENARIO {
+		public PlatformTxnAccessor platformTxn() throws Throwable {
+			return new PlatformTxnAccessor(from(
+					newSignedCryptoUpdate(MISC_ACCOUNT_ID)
+							.newAlias(ALIAS_PUBKEY_BYTESTRING)
 							.get()
 			));
 		}

--- a/hedera-node/src/test/java/com/hedera/test/factories/txns/CryptoUpdateFactory.java
+++ b/hedera-node/src/test/java/com/hedera/test/factories/txns/CryptoUpdateFactory.java
@@ -20,6 +20,7 @@ package com.hedera.test.factories.txns;
  * ‍
  */
 
+import com.google.protobuf.ByteString;
 import com.hedera.test.factories.keys.KeyTree;
 import com.hederahashgraph.api.proto.java.CryptoUpdateTransactionBody;
 import com.hederahashgraph.api.proto.java.Transaction;
@@ -32,6 +33,7 @@ import static com.hedera.test.utils.IdUtils.asAccount;
 public class CryptoUpdateFactory extends SignedTxnFactory<CryptoUpdateFactory> {
 	private final String account;
 	private Optional<KeyTree> newAccountKt = Optional.empty();
+	private Optional<ByteString> newAlias = Optional.empty();
 
 	public CryptoUpdateFactory(String account) {
 		this.account = account;
@@ -55,11 +57,17 @@ public class CryptoUpdateFactory extends SignedTxnFactory<CryptoUpdateFactory> {
 		CryptoUpdateTransactionBody.Builder op = CryptoUpdateTransactionBody.newBuilder()
 				.setAccountIDToUpdate(asAccount(account));
 		newAccountKt.ifPresent(kt -> op.setKey(kt.asKey(keyFactory)));
+		newAlias.ifPresent(alias -> op.setAlias(alias));
 		txn.setCryptoUpdateAccount(op);
 	}
 
 	public CryptoUpdateFactory newAccountKt(KeyTree newAccountKt) {
 		this.newAccountKt = Optional.of(newAccountKt);
+		return this;
+	}
+
+	public CryptoUpdateFactory newAlias(ByteString alias) {
+		this.newAlias = Optional.of(alias);
 		return this;
 	}
 }

--- a/hedera-node/src/test/java/com/hedera/test/factories/txns/SignedTxnFactory.java
+++ b/hedera-node/src/test/java/com/hedera/test/factories/txns/SignedTxnFactory.java
@@ -27,6 +27,7 @@ import com.hedera.test.factories.sigs.SigFactory;
 import com.hedera.test.factories.sigs.SigMapGenerator;
 import com.hederahashgraph.api.proto.java.AccountID;
 import com.hederahashgraph.api.proto.java.Duration;
+import com.hederahashgraph.api.proto.java.Key;
 import com.hederahashgraph.api.proto.java.Timestamp;
 import com.hederahashgraph.api.proto.java.Transaction;
 import com.hederahashgraph.api.proto.java.TransactionBody;
@@ -57,6 +58,8 @@ public abstract class SignedTxnFactory<T extends SignedTxnFactory<T>> {
 	public static final Instant DEFAULT_VALID_START = Instant.now();
 	public static final Integer DEFAULT_VALID_DURATION = 60;
 	public static final SigFactory DEFAULT_SIG_FACTORY = new SigFactory();
+	public static Key ALIAS_KEY =  KeyFactory.getDefaultInstance().newEd25519();
+	public static ByteString ALIAS_PUBKEY_BYTESTRING =  ALIAS_KEY.toByteString();
 
 	protected KeyFactory keyFactory = KeyFactory.getDefaultInstance();
 	protected FeeBuilder fees = new FeeBuilder();

--- a/hedera-node/src/test/java/com/hedera/test/mocks/TestContextValidator.java
+++ b/hedera-node/src/test/java/com/hedera/test/mocks/TestContextValidator.java
@@ -20,6 +20,8 @@ package com.hedera.test.mocks;
  * ‍
  */
 
+import com.google.protobuf.ByteString;
+import com.google.protobuf.InvalidProtocolBufferException;
 import com.hedera.services.legacy.core.jproto.JKey;
 import com.hedera.services.state.merkle.MerkleTopic;
 import com.hedera.services.txns.validation.OptionValidator;
@@ -84,6 +86,16 @@ public enum TestContextValidator implements OptionValidator {
 	@Override
 	public boolean isAcceptableTransfersLength(TransferList accountAmounts) {
 		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public boolean isValidAlias(final ByteString alias) {
+		try {
+			final var key = Key.parseFrom(alias);
+			return !key.getECDSASecp256K1().isEmpty() || !key.getEd25519().isEmpty();
+		} catch (InvalidProtocolBufferException ignore) {
+			return false;
+		}
 	}
 
 	@Override

--- a/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/TxnUtils.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/TxnUtils.java
@@ -195,6 +195,10 @@ public class TxnUtils {
 						lookupSpec.registry().getAccountID(s) : lookUpAccount(lookupSpec, s));
 	}
 
+	public static ByteString aliasKeyNamed(String alias, HapiApiSpec lookupSpec){
+		return lookupSpec.registry().getKey(alias).toByteString();
+	}
+
 	private static AccountID lookUpAccount(HapiApiSpec spec, String alias) {
 		final var key = spec.registry().getKey(alias);
 		return asIdWithAlias(key.toByteString());

--- a/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/crypto/HapiCryptoUpdate.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/crypto/HapiCryptoUpdate.java
@@ -59,6 +59,7 @@ import java.util.function.Function;
 
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getAccountInfo;
 import static com.hedera.services.bdd.spec.queries.QueryVerbsWithAlias.getAliasedAccountInfo;
+import static com.hedera.services.bdd.spec.transactions.TxnUtils.aliasKeyNamed;
 import static com.hedera.services.bdd.spec.transactions.TxnUtils.asIdForKeyLookUp;
 import static com.hedera.services.bdd.spec.transactions.TxnUtils.defaultUpdateSigners;
 import static com.hedera.services.bdd.spec.transactions.TxnUtils.suFrom;
@@ -77,6 +78,7 @@ public class HapiCryptoUpdate extends HapiTxnOp<HapiCryptoUpdate> {
 	private OptionalLong newAutoRenewPeriod = OptionalLong.empty();
 	private Optional<Long> lifetimeSecs = Optional.empty();
 	private Optional<String> newProxy = Optional.empty();
+	private Optional<String> newAlias = Optional.empty();
 	private Optional<String> entityMemo = Optional.empty();
 	private Optional<String> updKeyName = Optional.empty();
 	private Optional<Boolean> updSigRequired = Optional.empty();
@@ -109,6 +111,11 @@ public class HapiCryptoUpdate extends HapiTxnOp<HapiCryptoUpdate> {
 
 	public HapiCryptoUpdate newProxy(String name) {
 		newProxy = Optional.of(name);
+		return this;
+	}
+
+	public HapiCryptoUpdate newAlias(String name) {
+		newAlias = Optional.of(name);
 		return this;
 	}
 
@@ -216,6 +223,7 @@ public class HapiCryptoUpdate extends HapiTxnOp<HapiCryptoUpdate> {
 									builder.setExpirationTime(Timestamp.newBuilder().setSeconds(l).build()));
 							newMaxAutomaticAssociations.ifPresent(p ->
 									builder.setMaxAutomaticTokenAssociations(Int32Value.of(p)));
+							newAlias.ifPresent(p -> builder.setAlias(aliasKeyNamed(p, spec)));
 						}
 				);
 		return builder -> builder.setCryptoUpdateAccount(opBody);

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoUpdateSuite.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoUpdateSuite.java
@@ -20,6 +20,7 @@ package com.hedera.services.bdd.suites.crypto;
  * ‍
  */
 
+import com.google.protobuf.ByteString;
 import com.hedera.services.bdd.spec.HapiApiSpec;
 import com.hedera.services.bdd.spec.HapiSpecSetup;
 import com.hedera.services.bdd.spec.keys.KeyLabel;
@@ -59,9 +60,11 @@ import static com.hedera.services.bdd.spec.transactions.token.TokenMovement.movi
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.newKeyNamed;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.sourcing;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.validateChargedUsd;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.ALIAS_IS_IMMUTABLE;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.BAD_ENCODING;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.EXISTING_AUTOMATIC_ASSOCIATIONS_EXCEED_GIVEN_LIMIT;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_ACCOUNT_ID;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_ALIAS_KEY;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_EXPIRATION_TIME;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_PROXY_ACCOUNT_ID;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_SIGNATURE;
@@ -107,41 +110,97 @@ public class CryptoUpdateSuite extends HapiApiSuite {
 	@Override
 	protected List<HapiApiSpec> getSpecsInSuite() {
 		return List.of(new HapiApiSpec[] {
-//						updateWithUniqueSigs(),
-//						updateWithOverlappingSigs(),
-//						updateWithOneEffectiveSig(),
-//						canUpdateMemo(),
-//						updateFailsWithInsufficientSigs(),
-//						cannotSetThresholdNegative(),
-//						updateWithEmptyKeyFails(),
-//						updateFailsIfMissingSigs(),
-//						sysAccountKeyUpdateBySpecialWontNeedNewKeyTxnSign(),
-//						updateFailsWithContractKey(),
-//						updateFailsWithOverlyLongLifetime(),
-//						updateFailsWithInvalidMaxAutoAssociations(),
-//						usdFeeAsExpected(),
-//						canUpdateUsingAlias(),
-//						canUpdateProxyUsingAlias(),
-//				        failsWhenInvalidAliasedIdGiven(),
-//				        invalidProxyAliasFails(),
-				        canUpdateIfAliasNotPresent()
+						updateWithUniqueSigs(),
+						updateWithOverlappingSigs(),
+						updateWithOneEffectiveSig(),
+						canUpdateMemo(),
+						updateFailsWithInsufficientSigs(),
+						cannotSetThresholdNegative(),
+						updateWithEmptyKeyFails(),
+						updateFailsIfMissingSigs(),
+						sysAccountKeyUpdateBySpecialWontNeedNewKeyTxnSign(),
+						updateFailsWithContractKey(),
+						updateFailsWithOverlyLongLifetime(),
+						updateFailsWithInvalidMaxAutoAssociations(),
+						usdFeeAsExpected(),
+						canUpdateUsingAlias(),
+						canUpdateProxyUsingAlias(),
+				        failsWhenInvalidAliasedIdGiven(),
+				        invalidProxyAliasFails(),
+						canUpdateIfAliasNotPresent(),
+						failsUpdatingAliasIfPresent(),
+						failsUpdatingNonPrimitiveKeyAlias()
 				}
 		);
 	}
 
-	private HapiApiSpec canUpdateIfAliasNotPresent() {
+	private HapiApiSpec failsUpdatingNonPrimitiveKeyAlias() {
 		final var alias = "alias";
-		return defaultHapiSpec("UpdateWithUniqueSigs")
+		return defaultHapiSpec("failsUpdatingNonPrimitiveKeyAlias")
 				.given(
-						newKeyNamed(alias).shape(SIMPLE),
-						newKeyNamed(TARGET_KEY).shape(SIMPLE),
+						newKeyNamed(alias).shape(TWO_LEVEL_THRESH),
+						newKeyNamed(TARGET_KEY),
 						cryptoCreate(TARGET_ACCOUNT).key(TARGET_KEY)
 				).when(
+						getAccountInfo(TARGET_ACCOUNT)
+								.has(accountWith().noAlias())
+								.has(accountWith().key(TARGET_KEY))
+								.logged(),
 						cryptoUpdate(TARGET_ACCOUNT)
-								.signedBy(alias, TARGET_KEY)
+								.signedBy(alias, DEFAULT_PAYER, TARGET_KEY)
+								.newAlias(alias)
+								.hasPrecheck(INVALID_ALIAS_KEY)
+				).then(
+						getAccountInfo(TARGET_ACCOUNT)
+								.has(accountWith().noAlias())
+								.has(accountWith().key(TARGET_KEY))
+								.logged()
+				);
+	}
+
+	private HapiApiSpec failsUpdatingAliasIfPresent() {
+		final var alias = "alias";
+		return defaultHapiSpec("failsUpdatingAliasIfPresent")
+				.given(
+						newKeyNamed(alias),
+						newKeyNamed(TARGET_KEY)
+				).when(
+						cryptoTransfer(tinyBarsFromToWithAlias(DEFAULT_PAYER, alias, ONE_HUNDRED_HBARS))
+								.via("autoCreation"),
+						getTxnRecord("autoCreation").andAllChildRecords(),
+						getAliasedAccountInfo(alias)
+								.has(accountWith().alias(alias)),
+
+						cryptoUpdateAliased(alias)
+								.newAlias(TARGET_KEY)
+								.signedBy(TARGET_KEY, DEFAULT_PAYER, alias)
+								.hasKnownStatus(ALIAS_IS_IMMUTABLE)
+				).then(
+						getAliasedAccountInfo(alias)
+								.has(accountWith().alias(alias))
+				);
+	}
+
+	private HapiApiSpec canUpdateIfAliasNotPresent() {
+		final var alias = "alias";
+		return defaultHapiSpec("canUpdateIfAliasNotPresent")
+				.given(
+						newKeyNamed(alias),
+						newKeyNamed(TARGET_KEY),
+						cryptoCreate(TARGET_ACCOUNT).key(TARGET_KEY)
+				).when(
+						getAccountInfo(TARGET_ACCOUNT)
+								.has(accountWith().noAlias())
+								.has(accountWith().key(TARGET_KEY))
+								.logged(),
+						cryptoUpdate(TARGET_ACCOUNT)
+								.signedBy(alias, DEFAULT_PAYER, TARGET_KEY)
 								.newAlias(alias)
 				).then(
-						getAccountInfo(TARGET_ACCOUNT).logged()
+						getAccountInfo(TARGET_ACCOUNT)
+								.has(accountWith().alias(alias))
+								.has(accountWith().key(TARGET_KEY))
+								.logged()
 				);
 	}
 

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoUpdateSuite.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoUpdateSuite.java
@@ -107,31 +107,48 @@ public class CryptoUpdateSuite extends HapiApiSuite {
 	@Override
 	protected List<HapiApiSpec> getSpecsInSuite() {
 		return List.of(new HapiApiSpec[] {
-						updateWithUniqueSigs(),
-						updateWithOverlappingSigs(),
-						updateWithOneEffectiveSig(),
-						canUpdateMemo(),
-						updateFailsWithInsufficientSigs(),
-						cannotSetThresholdNegative(),
-						updateWithEmptyKeyFails(),
-						updateFailsIfMissingSigs(),
-						sysAccountKeyUpdateBySpecialWontNeedNewKeyTxnSign(),
-						updateFailsWithContractKey(),
-						updateFailsWithOverlyLongLifetime(),
-						updateFailsWithInvalidMaxAutoAssociations(),
-						usdFeeAsExpected(),
-						canUpdateUsingAlias(),
-						canUpdateProxyUsingAlias(),
-						failsWhenInvalidAlias(),
-				        invalidProxyAliasFails()
+//						updateWithUniqueSigs(),
+//						updateWithOverlappingSigs(),
+//						updateWithOneEffectiveSig(),
+//						canUpdateMemo(),
+//						updateFailsWithInsufficientSigs(),
+//						cannotSetThresholdNegative(),
+//						updateWithEmptyKeyFails(),
+//						updateFailsIfMissingSigs(),
+//						sysAccountKeyUpdateBySpecialWontNeedNewKeyTxnSign(),
+//						updateFailsWithContractKey(),
+//						updateFailsWithOverlyLongLifetime(),
+//						updateFailsWithInvalidMaxAutoAssociations(),
+//						usdFeeAsExpected(),
+//						canUpdateUsingAlias(),
+//						canUpdateProxyUsingAlias(),
+//				        failsWhenInvalidAliasedIdGiven(),
+//				        invalidProxyAliasFails(),
+				        canUpdateIfAliasNotPresent()
 				}
 		);
 	}
 
-	private HapiApiSpec failsWhenInvalidAlias() {
+	private HapiApiSpec canUpdateIfAliasNotPresent() {
+		final var alias = "alias";
+		return defaultHapiSpec("UpdateWithUniqueSigs")
+				.given(
+						newKeyNamed(alias).shape(SIMPLE),
+						newKeyNamed(TARGET_KEY).shape(SIMPLE),
+						cryptoCreate(TARGET_ACCOUNT).key(TARGET_KEY)
+				).when(
+						cryptoUpdate(TARGET_ACCOUNT)
+								.signedBy(alias, TARGET_KEY)
+								.newAlias(alias)
+				).then(
+						getAccountInfo(TARGET_ACCOUNT).logged()
+				);
+	}
+
+	private HapiApiSpec failsWhenInvalidAliasedIdGiven() {
 		String alias = "alias";
 		String memo = "Second";
-		return defaultHapiSpec("failsWhenInvalidAlias")
+		return defaultHapiSpec("failsWhenInvalidAliasedIdGiven")
 				.given(
 						newKeyNamed(alias)
 				).when(


### PR DESCRIPTION
Related to #2691 

1. Allow existing accounts without an `alias` set to update their `alias`, when signed with the alias private key. Otherwise fails with `INVALID_SIGNATURE`
2. If `alias` key to be updated is not a primitive Key , returns `INVALID_ALIAS_KEY` response
3. When trying to update an account with an alias set on it , will return `ALIAS_IS_IMMUTABLE`response.