### PR TITLE
Add Allowances Info to CryptoGetInfo Query

### DIFF
--- a/test-clients/src/main/java/com/hedera/services/bdd/spec/assertions/AccountInfoAsserts.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/spec/assertions/AccountInfoAsserts.java
@@ -181,6 +181,15 @@ public class AccountInfoAsserts extends BaseErroringAssertsProvider<AccountInfo>
 		return this;
 	}
 
+	public AccountInfoAsserts noAllowances() {
+		registerProvider((spec, o) -> {
+			assertEquals(((AccountInfo) o).getCryptoAllowancesCount(), 0, "Bad CryptoAllowances count!");
+			assertEquals(((AccountInfo) o).getTokenAllowancesCount(), 0, "Bad TokenAllowances count!");
+			assertEquals(((AccountInfo) o).getNftAllowancesCount(), 0, "Bad NftAllowances count!");
+		});
+		return this;
+	}
+
 	public AccountInfoAsserts balanceLessThan(long amount) {
 		registerProvider((spec, o) -> {
 			long actual = ((AccountInfo) o).getBalance();

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoTransferSuite.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoTransferSuite.java
@@ -95,22 +95,22 @@ public class CryptoTransferSuite extends HapiApiSuite {
 	@Override
 	protected List<HapiApiSpec> getSpecsInSuite() {
 		return List.of(new HapiApiSpec[] {
-//						transferWithMissingAccountGetsInvalidAccountId(),
+						transferWithMissingAccountGetsInvalidAccountId(),
 						vanillaTransferSucceeds(),
-//						complexKeyAcctPaysForOwnTransfer(),
-//						twoComplexKeysRequired(),
-//						specialAccountsBalanceCheck(),
-//						tokenTransferFeesScaleAsExpected(),
-//						okToSetInvalidPaymentHeaderForCostAnswer(),
-//						baseCryptoTransferFeeChargedAsExpected(),
-//						autoAssociationRequiresOpenSlots(),
-//						royaltyCollectorsCanUseAutoAssociation(),
-//						royaltyCollectorsCannotUseAutoAssociationWithoutOpenSlots(),
-//						dissociatedRoyaltyCollectorsCanUseAutoAssociation(),
-//						hbarAndFungibleSelfTransfersRejectedBothInPrecheckAndHandle(),
-//						transferToNonAccountEntitiesReturnsInvalidAccountId(),
-//						nftSelfTransfersRejectedBothInPrecheckAndHandle(),
-//						checksExpectedDecimalsForFungibleTokenTransferList()
+						complexKeyAcctPaysForOwnTransfer(),
+						twoComplexKeysRequired(),
+						specialAccountsBalanceCheck(),
+						tokenTransferFeesScaleAsExpected(),
+						okToSetInvalidPaymentHeaderForCostAnswer(),
+						baseCryptoTransferFeeChargedAsExpected(),
+						autoAssociationRequiresOpenSlots(),
+						royaltyCollectorsCanUseAutoAssociation(),
+						royaltyCollectorsCannotUseAutoAssociationWithoutOpenSlots(),
+						dissociatedRoyaltyCollectorsCanUseAutoAssociation(),
+						hbarAndFungibleSelfTransfersRejectedBothInPrecheckAndHandle(),
+						transferToNonAccountEntitiesReturnsInvalidAccountId(),
+						nftSelfTransfersRejectedBothInPrecheckAndHandle(),
+						checksExpectedDecimalsForFungibleTokenTransferList()
 				}
 		);
 	}

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoTransferSuite.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoTransferSuite.java
@@ -95,22 +95,22 @@ public class CryptoTransferSuite extends HapiApiSuite {
 	@Override
 	protected List<HapiApiSpec> getSpecsInSuite() {
 		return List.of(new HapiApiSpec[] {
-						transferWithMissingAccountGetsInvalidAccountId(),
+//						transferWithMissingAccountGetsInvalidAccountId(),
 						vanillaTransferSucceeds(),
-						complexKeyAcctPaysForOwnTransfer(),
-						twoComplexKeysRequired(),
-						specialAccountsBalanceCheck(),
-						tokenTransferFeesScaleAsExpected(),
-						okToSetInvalidPaymentHeaderForCostAnswer(),
-						baseCryptoTransferFeeChargedAsExpected(),
-						autoAssociationRequiresOpenSlots(),
-						royaltyCollectorsCanUseAutoAssociation(),
-						royaltyCollectorsCannotUseAutoAssociationWithoutOpenSlots(),
-						dissociatedRoyaltyCollectorsCanUseAutoAssociation(),
-						hbarAndFungibleSelfTransfersRejectedBothInPrecheckAndHandle(),
-						transferToNonAccountEntitiesReturnsInvalidAccountId(),
-						nftSelfTransfersRejectedBothInPrecheckAndHandle(),
-						checksExpectedDecimalsForFungibleTokenTransferList()
+//						complexKeyAcctPaysForOwnTransfer(),
+//						twoComplexKeysRequired(),
+//						specialAccountsBalanceCheck(),
+//						tokenTransferFeesScaleAsExpected(),
+//						okToSetInvalidPaymentHeaderForCostAnswer(),
+//						baseCryptoTransferFeeChargedAsExpected(),
+//						autoAssociationRequiresOpenSlots(),
+//						royaltyCollectorsCanUseAutoAssociation(),
+//						royaltyCollectorsCannotUseAutoAssociationWithoutOpenSlots(),
+//						dissociatedRoyaltyCollectorsCanUseAutoAssociation(),
+//						hbarAndFungibleSelfTransfersRejectedBothInPrecheckAndHandle(),
+//						transferToNonAccountEntitiesReturnsInvalidAccountId(),
+//						nftSelfTransfersRejectedBothInPrecheckAndHandle(),
+//						checksExpectedDecimalsForFungibleTokenTransferList()
 				}
 		);
 	}
@@ -941,7 +941,8 @@ public class CryptoTransferSuite extends HapiApiSuite {
 								.hasExpectedLedgerId("0x03")
 								.has(accountWith().balance(initialBalance - 3_000L)),
 						getAccountInfo("payeeSigReq").has(accountWith().balance(initialBalance + 1_000L)),
-						getAccountInfo("payeeNoSigReq").has(accountWith().balance(initialBalance + 2_000L))
+						getAccountInfo("payeeNoSigReq").has(
+								accountWith().balance(initialBalance + 2_000L).noAllowances())
 				);
 	}
 

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoUpdateSuite.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoUpdateSuite.java
@@ -230,7 +230,8 @@ public class CryptoUpdateSuite extends HapiApiSuite {
 				.then(
 						getAccountInfo(firstUser)
 								.hasAlreadyUsedAutomaticAssociations(originalMax)
-								.hasMaxAutomaticAssociations(originalMax),
+								.hasMaxAutomaticAssociations(originalMax)
+								.has(accountWith().noAllowances()),
 						cryptoUpdate(firstUser)
 								.maxAutomaticAssociations(newBadMax)
 								.hasKnownStatus(EXISTING_AUTOMATIC_ASSOCIATIONS_EXCEED_GIVEN_LIMIT),


### PR DESCRIPTION
Closes #2817 

Related to #2747 

Add `CryptoAllowance`, `TokenAllowance` and `NftAllowance` values to cryptoGetInfo Query by looking into the maps in `account.state()`