### PR TITLE
Port `0.22.4` fixes

### DIFF
--- a/hedera-node/src/main/java/com/hedera/services/files/store/FcBlobsBytesStore.java
+++ b/hedera-node/src/main/java/com/hedera/services/files/store/FcBlobsBytesStore.java
@@ -33,6 +33,8 @@ import java.util.function.Supplier;
 import static java.lang.Long.parseLong;
 
 public class FcBlobsBytesStore extends AbstractMap<String, byte[]> {
+	private static final VirtualBlobValue EMPTY_BLOB = new VirtualBlobValue(new byte[0]);
+
 	private final Supplier<VirtualMap<VirtualBlobKey, VirtualBlobValue>> blobSupplier;
 
 	public static final int LEGACY_BLOB_CODE_INDEX = 3;
@@ -78,7 +80,7 @@ public class FcBlobsBytesStore extends AbstractMap<String, byte[]> {
 	 */
 	@Override
 	public byte[] remove(Object path) {
-		blobSupplier.get().remove(at(path));
+		blobSupplier.get().put(at(path), EMPTY_BLOB);
 		return null;
 	}
 

--- a/hedera-node/src/main/java/com/hedera/services/store/contracts/SizeLimitedStorage.java
+++ b/hedera-node/src/main/java/com/hedera/services/store/contracts/SizeLimitedStorage.java
@@ -299,7 +299,7 @@ public class SizeLimitedStorage {
 			return;
 		}
 		final var curStorage = storage.get();
-		removedKeys.forEach((id, zeroedOut) -> zeroedOut.forEach(curStorage::remove));
+		removedKeys.forEach((id, zeroedOut) -> zeroedOut.forEach(key -> curStorage.put(key, ZERO_VALUE)));
 	}
 
 	static Function<Long, TreeSet<ContractKey>> treeSetFactory = ignore -> new TreeSet<>();

--- a/hedera-node/src/main/java/com/hedera/services/txns/token/TokenFeeScheduleUpdateTransitionLogic.java
+++ b/hedera-node/src/main/java/com/hedera/services/txns/token/TokenFeeScheduleUpdateTransitionLogic.java
@@ -22,6 +22,7 @@ package com.hedera.services.txns.token;
 
 import com.hedera.services.context.TransactionContext;
 import com.hedera.services.context.properties.GlobalDynamicProperties;
+import com.hedera.services.ledger.SigImpactHistorian;
 import com.hedera.services.state.submerkle.FcCustomFee;
 import com.hedera.services.store.AccountStore;
 import com.hedera.services.store.TypedTokenStore;
@@ -51,6 +52,7 @@ public class TokenFeeScheduleUpdateTransitionLogic implements TransitionLogic {
 	private final AccountStore accountStore;
 	private final TypedTokenStore tokenStore;
 	private final TransactionContext txnCtx;
+	private final SigImpactHistorian sigImpactHistorian;
 	private final GlobalDynamicProperties dynamicProperties;
 
 	private Function<CustomFee, FcCustomFee> grpcFeeConverter = FcCustomFee::fromGrpc;
@@ -60,12 +62,14 @@ public class TokenFeeScheduleUpdateTransitionLogic implements TransitionLogic {
 			final TypedTokenStore tokenStore,
 			final TransactionContext txnCtx,
 			final AccountStore accountStore,
+			final SigImpactHistorian sigImpactHistorian,
 			final GlobalDynamicProperties dynamicProperties
 	) {
 		this.txnCtx = txnCtx;
 		this.tokenStore = tokenStore;
 		this.accountStore = accountStore;
 		this.dynamicProperties = dynamicProperties;
+		this.sigImpactHistorian = sigImpactHistorian;
 	}
 
 	@Override
@@ -93,6 +97,7 @@ public class TokenFeeScheduleUpdateTransitionLogic implements TransitionLogic {
 		token.setCustomFees(customFees);
 
 		/* --- Persist the updated models --- */
+		sigImpactHistorian.markEntityChanged(targetTokenId.num());
 		tokenStore.commitToken(token);
 	}
 

--- a/hedera-node/src/test/java/com/hedera/services/files/store/FcBlobsBytesStoreTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/files/store/FcBlobsBytesStoreTest.java
@@ -72,9 +72,9 @@ class FcBlobsBytesStoreTest {
 
 	@Test
 	void delegatesRemoveOfMissing() {
-		given(pathedBlobs.remove(subject.at(dataPath))).willReturn(null);
-
 		assertNull(subject.remove(dataPath));
+
+		verify(pathedBlobs).put(subject.at(dataPath), new VirtualBlobValue(new byte[0]));
 	}
 
 	@Test

--- a/hedera-node/src/test/java/com/hedera/services/store/contracts/SizeLimitedStorageTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/store/contracts/SizeLimitedStorageTest.java
@@ -101,9 +101,9 @@ class SizeLimitedStorageTest {
 		subject.validateAndCommit();
 		subject.recordNewKvUsageTo(accountsLedger);
 
-		inOrder.verify(storage).remove(firstAKey);
-		inOrder.verify(storage).remove(firstBKey);
-		inOrder.verify(storage).remove(nextAKey);
+		inOrder.verify(storage).put(firstAKey, ZERO_VALUE);
+		inOrder.verify(storage).put(firstBKey, ZERO_VALUE);
+		inOrder.verify(storage).put(nextAKey, ZERO_VALUE);
 		// and:
 		inOrder.verify(accountsLedger).set(firstAccount, NUM_CONTRACT_KV_PAIRS, firstKvPairs - 2);
 		inOrder.verify(accountsLedger).set(nextAccount, NUM_CONTRACT_KV_PAIRS, nextKvPairs - 1);

--- a/hedera-node/src/test/java/com/hedera/services/txns/token/TokenFeeScheduleUpdateTransitionLogicTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/txns/token/TokenFeeScheduleUpdateTransitionLogicTest.java
@@ -22,6 +22,7 @@ package com.hedera.services.txns.token;
 
 import com.hedera.services.context.TransactionContext;
 import com.hedera.services.context.properties.GlobalDynamicProperties;
+import com.hedera.services.ledger.SigImpactHistorian;
 import com.hedera.services.state.submerkle.FcCustomFee;
 import com.hedera.services.store.AccountStore;
 import com.hedera.services.store.TypedTokenStore;
@@ -76,12 +77,15 @@ class TokenFeeScheduleUpdateTransitionLogicTest {
 	private FcCustomFee firstMockFee;
 	@Mock
 	private FcCustomFee secondMockFee;
+	@Mock
+	private SigImpactHistorian sigImpactHistorian;
 
 	private TokenFeeScheduleUpdateTransitionLogic subject;
 
 	@BeforeEach
 	public void setup() {
-		subject = new TokenFeeScheduleUpdateTransitionLogic(tokenStore, txnCtx, accountStore, dynamicProperties);
+		subject = new TokenFeeScheduleUpdateTransitionLogic(
+				tokenStore, txnCtx, accountStore, sigImpactHistorian, dynamicProperties);
 	}
 
 	@Test
@@ -118,6 +122,7 @@ class TokenFeeScheduleUpdateTransitionLogicTest {
 		verify(secondMockFee).nullOutCollector();
 		verify(token).setCustomFees(List.of(firstMockFee, secondMockFee));
 		verify(tokenStore).commitToken(token);
+		verify(sigImpactHistorian).markEntityChanged(target.getTokenNum());
 	}
 
 	@Test


### PR DESCRIPTION
**Description**:
- Revert use of `VirtualMap.remove()` in favor of `put(, <empty value>)`.
- Mark signing requirement impact of `TokenFeeScheduleUpdate` (fallback fees require NFT receiver to sign).