### PR TITLE
Add failing EET + fix for missing sig impact in `TokenFeeScheduleUpdate`

### DIFF
--- a/hedera-node/src/main/java/com/hedera/services/txns/token/TokenFeeScheduleUpdateTransitionLogic.java
+++ b/hedera-node/src/main/java/com/hedera/services/txns/token/TokenFeeScheduleUpdateTransitionLogic.java
@@ -22,6 +22,7 @@ package com.hedera.services.txns.token;
 
 import com.hedera.services.context.TransactionContext;
 import com.hedera.services.context.properties.GlobalDynamicProperties;
+import com.hedera.services.ledger.SigImpactHistorian;
 import com.hedera.services.state.submerkle.FcCustomFee;
 import com.hedera.services.store.AccountStore;
 import com.hedera.services.store.TypedTokenStore;
@@ -51,6 +52,7 @@ public class TokenFeeScheduleUpdateTransitionLogic implements TransitionLogic {
 	private final AccountStore accountStore;
 	private final TypedTokenStore tokenStore;
 	private final TransactionContext txnCtx;
+	private final SigImpactHistorian sigImpactHistorian;
 	private final GlobalDynamicProperties dynamicProperties;
 
 	private Function<CustomFee, FcCustomFee> grpcFeeConverter = FcCustomFee::fromGrpc;
@@ -60,12 +62,14 @@ public class TokenFeeScheduleUpdateTransitionLogic implements TransitionLogic {
 			final TypedTokenStore tokenStore,
 			final TransactionContext txnCtx,
 			final AccountStore accountStore,
+			final SigImpactHistorian sigImpactHistorian,
 			final GlobalDynamicProperties dynamicProperties
 	) {
 		this.txnCtx = txnCtx;
 		this.tokenStore = tokenStore;
 		this.accountStore = accountStore;
 		this.dynamicProperties = dynamicProperties;
+		this.sigImpactHistorian = sigImpactHistorian;
 	}
 
 	@Override
@@ -93,6 +97,7 @@ public class TokenFeeScheduleUpdateTransitionLogic implements TransitionLogic {
 		token.setCustomFees(customFees);
 
 		/* --- Persist the updated models --- */
+		sigImpactHistorian.markEntityChanged(targetTokenId.num());
 		tokenStore.commitToken(token);
 	}
 

--- a/hedera-node/src/test/java/com/hedera/services/txns/token/TokenFeeScheduleUpdateTransitionLogicTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/txns/token/TokenFeeScheduleUpdateTransitionLogicTest.java
@@ -22,6 +22,7 @@ package com.hedera.services.txns.token;
 
 import com.hedera.services.context.TransactionContext;
 import com.hedera.services.context.properties.GlobalDynamicProperties;
+import com.hedera.services.ledger.SigImpactHistorian;
 import com.hedera.services.state.submerkle.FcCustomFee;
 import com.hedera.services.store.AccountStore;
 import com.hedera.services.store.TypedTokenStore;
@@ -76,12 +77,15 @@ class TokenFeeScheduleUpdateTransitionLogicTest {
 	private FcCustomFee firstMockFee;
 	@Mock
 	private FcCustomFee secondMockFee;
+	@Mock
+	private SigImpactHistorian sigImpactHistorian;
 
 	private TokenFeeScheduleUpdateTransitionLogic subject;
 
 	@BeforeEach
 	public void setup() {
-		subject = new TokenFeeScheduleUpdateTransitionLogic(tokenStore, txnCtx, accountStore, dynamicProperties);
+		subject = new TokenFeeScheduleUpdateTransitionLogic(
+				tokenStore, txnCtx, accountStore, sigImpactHistorian, dynamicProperties);
 	}
 
 	@Test
@@ -118,6 +122,7 @@ class TokenFeeScheduleUpdateTransitionLogicTest {
 		verify(secondMockFee).nullOutCollector();
 		verify(token).setCustomFees(List.of(firstMockFee, secondMockFee));
 		verify(tokenStore).commitToken(token);
+		verify(sigImpactHistorian).markEntityChanged(target.getTokenNum());
 	}
 
 	@Test

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenUpdateSpecs.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenUpdateSpecs.java
@@ -63,7 +63,9 @@ import static com.hedera.services.bdd.spec.transactions.token.CustomFeeSpecs.roy
 import static com.hedera.services.bdd.spec.transactions.token.CustomFeeTests.fixedHbarFeeInSchedule;
 import static com.hedera.services.bdd.spec.transactions.token.TokenMovement.moving;
 import static com.hedera.services.bdd.spec.transactions.token.TokenMovement.movingUnique;
+import static com.hedera.services.bdd.spec.utilops.CustomSpecAssert.allRunFor;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.newKeyNamed;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.withOpContext;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_ADMIN_KEY;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_AUTORENEW_ACCOUNT;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_CUSTOM_FEE_SCHEDULE_KEY;
@@ -123,9 +125,11 @@ public class TokenUpdateSpecs extends HapiApiSuite {
 						validatesMissingRef(),
 						validatesNewExpiry(),
 						/* HIP-18 */
-						canUpdateFeeScheduleKeyWithAdmin(),
+						customFeesOnlyUpdatableWithKey(),
 						updateUniqueTreasuryWithNfts(),
 						updateHappyPath(),
+						safeToUpdateCustomFeesWithNewFallbackWhileTransferring(),
+
 				}
 		);
 	}
@@ -677,14 +681,65 @@ public class TokenUpdateSpecs extends HapiApiSuite {
 								.logged(),
 						getTokenNftInfos("primary", 0, 1)
 								.hasNfts(
-										newTokenNftInfo("primary", 1, "newTokenTreasury", ByteString.copyFromUtf8("memo1"))
+										newTokenNftInfo("primary", 1, "newTokenTreasury",
+												ByteString.copyFromUtf8("memo1"))
 								)
 								.logged(),
 						getTxnRecord("tokenUpdateTxn").logged()
 				);
 	}
 
-	private HapiApiSpec canUpdateFeeScheduleKeyWithAdmin() {
+	private HapiApiSpec safeToUpdateCustomFeesWithNewFallbackWhileTransferring() {
+		final var uniqueTokenFeeKey = "uniqueTokenFeeKey";
+		final var hbarCollector = "hbarFee";
+		final var beneficiary = "luckyOne";
+		final var multiKey = "allSeasons";
+		final var sender = "sender";
+		final var numRaces = 3;
+
+		return defaultHapiSpec("SafeToUpdateCustomFeesWithNewFallbackWhileTransferring")
+				.given(
+						newKeyNamed(multiKey),
+						cryptoCreate(hbarCollector),
+						cryptoCreate(TOKEN_TREASURY),
+						cryptoCreate(sender).maxAutomaticTokenAssociations(100),
+						cryptoCreate(beneficiary).maxAutomaticTokenAssociations(100)
+				).when().then(
+						withOpContext((spec, opLog) -> {
+							for (int i = 0; i < 3; i++) {
+								final var name = uniqueTokenFeeKey + i;
+								final var creation = tokenCreate(name)
+										.tokenType(NON_FUNGIBLE_UNIQUE)
+										.treasury(TOKEN_TREASURY)
+										.supplyKey(multiKey)
+										.feeScheduleKey(multiKey)
+										.initialSupply(0);
+								final var mint = mintToken(name, List.of(ByteString.copyFromUtf8("SOLO")));
+								final var normalXfer = cryptoTransfer(movingUnique(name, 1L)
+										.between(TOKEN_TREASURY, sender)
+								)
+										.fee(ONE_HBAR);
+								final var update = tokenFeeScheduleUpdate(name)
+										.withCustom(royaltyFeeWithFallback(
+												1, 10,
+												fixedHbarFeeInheritingRoyaltyCollector(1),
+												hbarCollector))
+										.deferStatusResolution();
+								final var raceXfer = cryptoTransfer(movingUnique(name, 1L)
+										.between(sender, beneficiary)
+								)
+										.signedBy(DEFAULT_PAYER, sender)
+										.fee(ONE_HBAR)
+										/* The beneficiary needs to sign now b/c of the fallback fee (and the
+										 * lack of any fungible value going back to the treasury for this NFT). */
+										.hasKnownStatus(INVALID_SIGNATURE);
+								allRunFor(spec, creation, mint, normalXfer, update, raceXfer);
+							}
+						})
+				);
+	}
+
+	private HapiApiSpec customFeesOnlyUpdatableWithKey() {
 		final var origHbarFee = 1_234L;
 		final var newHbarFee = 4_321L;
 


### PR DESCRIPTION
**Description**:
- `TokenFeeScheduleUpdate` can have an impact on signing requirements if it adds (or removes) a fallback fee.
- This PR supplies an [EET that fails reliably on `master`](https://github.com/hashgraph/hedera-services/blob/add-fee-schedule-update-sig-impact-test/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenUpdateSpecs.java#L692), but passes with the needed [call to `sigImpactHistorian.markEntityChanged()`](TokenFeeScheduleUpdateTransitionLogic) in `TokenFeeScheduleUpdateTransitionLogic`.