### PR TITLE
Use non-`SNAPSHOT` proto artifact

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -165,7 +165,7 @@
 		<ethereum-core.version>1.12.0-v0.5.0</ethereum-core.version>
 		<grpc.version>1.39.0</grpc.version>
 		<guava.version>31.0.1-jre</guava.version>
-		<hapi-proto.version>0.23.0-SNAPSHOT</hapi-proto.version>
+		<hapi-proto.version>0.23.1</hapi-proto.version>
 		<headlong.version>5.7.0</headlong.version>
 		<javax.annotation-api.version>1.3.2</javax.annotation-api.version>
 		<javax-inject.version>1</javax-inject.version>


### PR DESCRIPTION
**Description**:
- Use `0.23.1` version of protobufs to prepare for release tag.