### PR TITLE
Split ci jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -755,7 +755,7 @@ workflows:
   GCP-Daily-Services-Comp-NetError-4N-1C:
     triggers:
       - schedule:
-          cron: "30 5 * * *"
+          cron: "00 3 * * *"
           filters:
             branches:
               only:
@@ -780,7 +780,7 @@ workflows:
   GCP-Create-Large-Volume-NFTs-SavedState:
     triggers:
       - schedule:
-          cron: "58 3 * * *"
+          cron: "00 3 * * *"
           filters:
             branches:
               only:
@@ -808,7 +808,7 @@ workflows:
   GCP-Daily-Services-Crypto-Migration-7N-1C:
     triggers:
       - schedule:
-          cron: "45 5 * * *"
+          cron: "00 3 * * *"
           filters:
             branches:
               only:
@@ -860,7 +860,7 @@ workflows:
   GCP-Daily-Services-Crypto-Restart-4N-1C:
     triggers:
       - schedule:
-          cron: "15 6 * * *"
+          cron: "15 4 * * *"
           filters:
             branches:
               only:
@@ -883,7 +883,7 @@ workflows:
   GCP-Daily-Services-Update-Ubuntu1804-4N-2C:
     triggers:
       - schedule:
-          cron: "0 3 * * *"
+          cron: "15 4 * * *"
           filters:
             branches:
               only:
@@ -906,7 +906,7 @@ workflows:
   GCP-Daily-Services-Update-Rhel7-4N-2C:
     triggers:
       - schedule:
-          cron: "15 3 * * *"
+          cron: "15 4 * * *"
           filters:
             branches:
               only:
@@ -929,7 +929,7 @@ workflows:
   GCP-Daily-Services-Update-Rhel8-4N-2C:
     triggers:
       - schedule:
-          cron: "30 3 * * *"
+          cron: "30 5 * * *"
           filters:
             branches:
               only:
@@ -952,7 +952,7 @@ workflows:
   GCP-Daily-Services-Update-CentOS7-4N-2C:
     triggers:
       - schedule:
-          cron: "45 3 * * *"
+          cron: "35 5 * * *"
           filters:
             branches:
               only:
@@ -975,7 +975,7 @@ workflows:
   GCP-Daily-Services-Crypto-Invalid-Accounts-4N-4C:
     triggers:
       - schedule:
-          cron: "0 4 * * *"
+          cron: "40 5 * * *"
           filters:
             branches:
               only:
@@ -998,7 +998,7 @@ workflows:
   GCP-Daily-Services-Update-4N-2C:
     triggers:
       - schedule:
-          cron: "30 22 * * *"
+          cron: "00 7 * * *"
           filters:
             branches:
               only:
@@ -1021,7 +1021,7 @@ workflows:
   GCP-Daily-Services-Comp-Update-DisPreUpdate-4N-2C:
     triggers:
       - schedule:
-          cron: "45 22 * * *"
+          cron: "05 7 * * *"
           filters:
             branches:
               only:
@@ -1044,7 +1044,7 @@ workflows:
   GCP-Daily-Services-Update-Reconnect-4N-2C:
     triggers:
       - schedule:
-          cron: "15 22 * * *"
+          cron: "10 7 * * *"
           filters:
             branches:
               only:
@@ -1067,7 +1067,7 @@ workflows:
   GCP-Daily-Services-Comp-Update-Reconnect-Abort-4N-2C:
     triggers:
       - schedule:
-          cron: "15 23 * * *"
+          cron: "15 8 * * *"
           filters:
             branches:
               only:
@@ -1090,7 +1090,7 @@ workflows:
   GCP-Daily-Services-Comp-Update-Reconnect-Abort-DisPreUpdate-4N-2C:
     triggers:
       - schedule:
-          cron: "30 23 * * *"
+          cron: "20 8 * * *"
           filters:
             branches:
               only:
@@ -1113,7 +1113,7 @@ workflows:
   GCP-Daily-Services-Account-Balances-client-validation-6N-1C:
     triggers:
       - schedule:
-          cron: "30 6 * * *"
+          cron: "25 8 * * *"
           filters:
             branches:
               only:
@@ -1137,7 +1137,7 @@ workflows:
   GCP-Daily-Services-Reconnect-6N-4C:
     triggers:
       - schedule:
-          cron: "40 5 * * *"
+          cron: "45 9 * * *"
           filters:
             branches:
               only:
@@ -1161,7 +1161,7 @@ workflows:
   GCP-Daily-Services-Global-3NReconnect-15N-4C:
     triggers:
       - schedule:
-          cron: "40 7 * * *"
+          cron: "50 9 * * *"
           filters:
             branches:
               only:
@@ -1183,7 +1183,7 @@ workflows:
   GCP-Daily-Services-Global-3NReconnect2-15N-4C:
     triggers:
       - schedule:
-          cron: "40 7 * * *"
+          cron: "55 9 * * *"
           filters:
             branches:
               only:
@@ -1205,7 +1205,7 @@ workflows:
   GCP-Weekly-Services-NetDelay-15N-1C:
     triggers:
       - schedule:
-          cron: "0 5 * * *"
+          cron: "00 10 * * *"
           filters:
             branches:
               only:
@@ -1228,7 +1228,7 @@ workflows:
   GCP-Daily-Services-Recovery-4N-1C:
     triggers:
       - schedule:
-          cron: "55 6 * * *"
+          cron: "05 10 * * *"
           filters:
             branches:
               only:
@@ -1250,7 +1250,7 @@ workflows:
   GCP-Daily-Services-Recovery2-4N-1C:
     triggers:
       - schedule:
-          cron: "55 6 * * *"
+          cron: "10 10 * * *"
           filters:
             branches:
               only:
@@ -1272,7 +1272,7 @@ workflows:
   GCP-Daily-Services-Recovery3-4N-1C:
     triggers:
       - schedule:
-          cron: "55 6 * * *"
+          cron: "15 10 * * *"
           filters:
             branches:
               only:
@@ -1294,7 +1294,7 @@ workflows:
   GCP-Daily-Services-Recovery4-4N-1C:
     triggers:
       - schedule:
-          cron: "55 6 * * *"
+          cron: "20 10 * * *"
           filters:
             branches:
               only:
@@ -1339,7 +1339,7 @@ workflows:
   GCP-Daily-Services-Comp-Restart-Performance-Hotspot-6N-6C:
     triggers:
       - schedule:
-          cron: "35 7 * * *"
+          cron: "25 10 * * *"
           filters:
             branches:
               only:
@@ -1362,7 +1362,7 @@ workflows:
   GCP-Daily-Services-Comp-Restart-Performance-Random-7N-7C:
     triggers:
       - schedule:
-          cron: "40 4 * * *"
+          cron: "30 11 * * *"
           filters:
             branches:
               only:
@@ -1386,7 +1386,7 @@ workflows:
   GCP-Daily-Services-HTS-Restart-Performance-7N-7C:
     triggers:
       - schedule:
-          cron: "30 4 * * *"
+          cron: "30 12 * * *"
           filters:
             branches:
               only:
@@ -1409,7 +1409,7 @@ workflows:
   GCP-Daily-Services-Comp-Reconnect-6N-1C:
     triggers:
       - schedule:
-          cron: "15 7 * * *"
+          cron: "35 12 * * *"
           filters:
             branches:
               only:
@@ -1431,7 +1431,7 @@ workflows:
   GCP-Daily-Services-Comp-Reconnect2-6N-1C:
     triggers:
       - schedule:
-          cron: "15 7 * * *"
+          cron: "40 12 * * *"
           filters:
             branches:
               only:
@@ -1453,7 +1453,7 @@ workflows:
   GCP-Daily-Services-Comp-NI-Reconnect-Correctness-6N-1C:
     triggers:
       - schedule:
-          cron: "25 7 * * *"
+          cron: "45 13 * * *"
           filters:
             branches:
               only:
@@ -1475,7 +1475,7 @@ workflows:
   GCP-Daily-Services-Comp-NI-Reconnect-Correctness2-6N-1C:
     triggers:
       - schedule:
-          cron: "25 7 * * *"
+          cron: "50 13 * * *"
           filters:
             branches:
               only:
@@ -1497,7 +1497,7 @@ workflows:
   GCP-Daily-Services-Comp-ND-Reconnect-Correctness-6N-1C:
     triggers:
       - schedule:
-          cron: "25 8 * * *"
+          cron: "55 13 * * *"
           filters:
             branches:
               only:
@@ -1519,7 +1519,7 @@ workflows:
   GCP-Daily-Services-Comp-ND-Reconnect-Correctness2-6N-1C:
     triggers:
       - schedule:
-          cron: "25 8 * * *"
+          cron: "0 14 * * *"
           filters:
             branches:
               only:
@@ -1541,7 +1541,7 @@ workflows:
   GCP-Daily-Services-Comp-3NReconnect-15N-4C:
     triggers:
       - schedule:
-          cron: "25 8 * * *"
+          cron: "05 14 * * *"
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1180,7 +1180,28 @@ workflows:
             - install-tools
             - attach_workspace:
                 at: /
-
+  GCP-Daily-Services-Global-3NReconnect2-15N-4C:
+    triggers:
+      - schedule:
+          cron: "40 7 * * *"
+          filters:
+            branches:
+              only:
+                - master
+    jobs:
+      - build-platform-and-services
+      - jrs-regression:
+          context: Slack
+          regression_path: /swirlds-platform/regression
+          result_path: results/15N_4C/Global3NReconnect
+          config_type: "daily"
+          workflow-name: "GCP-Daily-Services-Global-3NReconnect2-15N-4C"
+          requires:
+            - build-platform-and-services
+          pre-steps:
+            - install-tools
+            - attach_workspace:
+                at: /
   GCP-Weekly-Services-NetDelay-15N-1C:
     triggers:
       - schedule:
@@ -1226,7 +1247,72 @@ workflows:
             - install-tools
             - attach_workspace:
                 at: /
-
+  GCP-Daily-Services-Recovery2-4N-1C:
+    triggers:
+      - schedule:
+          cron: "55 6 * * *"
+          filters:
+            branches:
+              only:
+                - master
+    jobs:
+      - build-platform-and-services
+      - jrs-regression:
+          context: Slack
+          regression_path: /swirlds-platform/regression
+          result_path: results/4N_1C/Recovery
+          config_type: "daily"
+          workflow-name: "GCP-Daily-Services-Recovery2-4N-1C"
+          requires:
+            - build-platform-and-services
+          pre-steps:
+            - install-tools
+            - attach_workspace:
+                at: /
+  GCP-Daily-Services-Recovery3-4N-1C:
+    triggers:
+      - schedule:
+          cron: "55 6 * * *"
+          filters:
+            branches:
+              only:
+                - master
+    jobs:
+      - build-platform-and-services
+      - jrs-regression:
+          context: Slack
+          regression_path: /swirlds-platform/regression
+          result_path: results/4N_1C/Recovery
+          config_type: "daily"
+          workflow-name: "GCP-Daily-Services-Recovery3-4N-1C"
+          requires:
+            - build-platform-and-services
+          pre-steps:
+            - install-tools
+            - attach_workspace:
+                at: /
+  GCP-Daily-Services-Recovery4-4N-1C:
+    triggers:
+      - schedule:
+          cron: "55 6 * * *"
+          filters:
+            branches:
+              only:
+                - master
+    jobs:
+      - build-platform-and-services
+      - jrs-regression:
+          context: Slack
+          regression_path: /swirlds-platform/regression
+          result_path: results/4N_1C/Recovery
+          config_type: "daily"
+          workflow-name: "GCP-Daily-Services-Recovery4-4N-1C"
+          requires:
+            - build-platform-and-services
+          pre-steps:
+            - install-tools
+            - attach_workspace:
+                at: /
   GCP-Weekly-Services-Query-Restart-Performance-7N-7C:
     triggers:
       - schedule:
@@ -1342,7 +1428,28 @@ workflows:
             - install-tools
             - attach_workspace:
                 at: /
-
+  GCP-Daily-Services-Comp-Reconnect2-6N-1C:
+    triggers:
+      - schedule:
+          cron: "15 7 * * *"
+          filters:
+            branches:
+              only:
+                - master
+    jobs:
+      - build-platform-and-services
+      - jrs-regression:
+          context: Slack
+          regression_path: /swirlds-platform/regression
+          result_path: results/6N_1C/Reconnect
+          config_type: "daily"
+          workflow-name: "GCP-Daily-Services-Comp-Reconnect2-6N-1C"
+          requires:
+            - build-platform-and-services
+          pre-steps:
+            - install-tools
+            - attach_workspace:
+                at: /
   GCP-Daily-Services-Comp-NI-Reconnect-Correctness-6N-1C:
     triggers:
       - schedule:
@@ -1365,7 +1472,28 @@ workflows:
             - install-tools
             - attach_workspace:
                 at: /
-
+  GCP-Daily-Services-Comp-NI-Reconnect-Correctness2-6N-1C:
+    triggers:
+      - schedule:
+          cron: "25 7 * * *"
+          filters:
+            branches:
+              only:
+                - master
+    jobs:
+      - build-platform-and-services
+      - jrs-regression:
+          context: Slack
+          regression_path: /swirlds-platform/regression
+          result_path: results/6N_1C/NIReconnectCorrectness
+          config_type: "daily"
+          workflow-name: "GCP-Daily-Services-Comp-NI-Reconnect-Correctness2-6N-1C"
+          requires:
+            - build-platform-and-services
+          pre-steps:
+            - install-tools
+            - attach_workspace:
+                at: /
   GCP-Daily-Services-Comp-ND-Reconnect-Correctness-6N-1C:
     triggers:
       - schedule:
@@ -1388,7 +1516,28 @@ workflows:
             - install-tools
             - attach_workspace:
                 at: /
-
+  GCP-Daily-Services-Comp-ND-Reconnect-Correctness2-6N-1C:
+    triggers:
+      - schedule:
+          cron: "25 8 * * *"
+          filters:
+            branches:
+              only:
+                - master
+    jobs:
+      - build-platform-and-services
+      - jrs-regression:
+          context: Slack
+          regression_path: /swirlds-platform/regression
+          result_path: results/6N_1C/NDReconnectCorrectness
+          config_type: "daily"
+          workflow-name: "GCP-Daily-Services-Comp-ND-Reconnect-Correctness2-6N-1C"
+          requires:
+            - build-platform-and-services
+          pre-steps:
+            - install-tools
+            - attach_workspace:
+                at: /
   GCP-Daily-Services-Comp-3NReconnect-15N-4C:
     triggers:
       - schedule:
@@ -1598,6 +1747,7 @@ jobs:
             cd /swirlds-platform;
             sed -i -e 's/github.com/services-jrs-regression/g' .gitmodules;
             git submodule update --init --recursive --checkout;
+            cd regression/; git checkout -b 02051-split-ci-jobs origin/02051-split-ci-jobs; git pull; cd -          
             mvn --no-transfer-progress clean install -DskipTests;
 
       - run:


### PR DESCRIPTION
Split some jobs to multiple smaller ones to less than 1 hour,
a work around to current circle ci issue.

Did not split all long jobs, some single test is longer than 1hours, could not split,
in addition, some are already failing due to known
pending bugs before this circle ci issue.

Changes to the JSON config files can be found here:

https://github.com/swirlds/swirlds-platform-regression/pull/2052/files
