### PR TITLE
Still defer `remove()` usage, and return unresolved aliases from `AliasManager.resolveForEvm()`

### DIFF
--- a/hedera-node/src/main/java/com/hedera/services/files/store/FcBlobsBytesStore.java
+++ b/hedera-node/src/main/java/com/hedera/services/files/store/FcBlobsBytesStore.java
@@ -33,6 +33,8 @@ import java.util.function.Supplier;
 import static java.lang.Long.parseLong;
 
 public class FcBlobsBytesStore extends AbstractMap<String, byte[]> {
+	private static final VirtualBlobValue EMPTY_BLOB = new VirtualBlobValue(new byte[0]);
+
 	private final Supplier<VirtualMap<VirtualBlobKey, VirtualBlobValue>> blobSupplier;
 
 	public static final int LEGACY_BLOB_CODE_INDEX = 3;
@@ -78,7 +80,7 @@ public class FcBlobsBytesStore extends AbstractMap<String, byte[]> {
 	 */
 	@Override
 	public byte[] remove(Object path) {
-		blobSupplier.get().remove(at(path));
+		blobSupplier.get().put(at(path), EMPTY_BLOB);
 		return null;
 	}
 

--- a/hedera-node/src/main/java/com/hedera/services/ledger/accounts/AliasManager.java
+++ b/hedera-node/src/main/java/com/hedera/services/ledger/accounts/AliasManager.java
@@ -88,7 +88,10 @@ public class AliasManager extends AbstractContractAliases implements ContractAli
 		}
 		final var aliasKey = ByteString.copyFrom(addressOrAlias.toArrayUnsafe());
 		final var contractNum = aliases.get(aliasKey);
-		return (contractNum == null) ? null : contractNum.toEvmAddress();
+		// If we cannot resolve to a mirror address, we return the missing alias and let a
+		// downstream component fail the transaction by returning null from its get() method.
+		// Cf. the address validator provided by ContractsModule#provideAddressValidator().
+		return (contractNum == null) ? addressOrAlias : contractNum.toEvmAddress();
 	}
 
 	@Override

--- a/hedera-node/src/main/java/com/hedera/services/ledger/accounts/AliasManager.java
+++ b/hedera-node/src/main/java/com/hedera/services/ledger/accounts/AliasManager.java
@@ -89,7 +89,7 @@ public class AliasManager extends AbstractContractAliases implements ContractAli
 		final var aliasKey = ByteString.copyFrom(addressOrAlias.toArrayUnsafe());
 		final var contractNum = aliases.get(aliasKey);
 		// If we cannot resolve to a mirror address, we return the missing alias and let a
-		// downstream component fail the transaction by returning null from its get() method.
+		// downstream WorldUpdater fail the transaction by returning null from its get() method.
 		// Cf. the address validator provided by ContractsModule#provideAddressValidator().
 		return (contractNum == null) ? addressOrAlias : contractNum.toEvmAddress();
 	}

--- a/hedera-node/src/main/java/com/hedera/services/store/contracts/SizeLimitedStorage.java
+++ b/hedera-node/src/main/java/com/hedera/services/store/contracts/SizeLimitedStorage.java
@@ -299,7 +299,7 @@ public class SizeLimitedStorage {
 			return;
 		}
 		final var curStorage = storage.get();
-		removedKeys.forEach((id, zeroedOut) -> zeroedOut.forEach(curStorage::remove));
+		removedKeys.forEach((id, zeroedOut) -> zeroedOut.forEach(key -> curStorage.put(key, ZERO_VALUE)));
 	}
 
 	static Function<Long, TreeSet<ContractKey>> treeSetFactory = ignore -> new TreeSet<>();

--- a/hedera-node/src/test/java/com/hedera/services/files/store/FcBlobsBytesStoreTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/files/store/FcBlobsBytesStoreTest.java
@@ -72,9 +72,9 @@ class FcBlobsBytesStoreTest {
 
 	@Test
 	void delegatesRemoveOfMissing() {
-		given(pathedBlobs.remove(subject.at(dataPath))).willReturn(null);
-
 		assertNull(subject.remove(dataPath));
+
+		verify(pathedBlobs).put(subject.at(dataPath), new VirtualBlobValue(new byte[0]));
 	}
 
 	@Test

--- a/hedera-node/src/test/java/com/hedera/services/ledger/accounts/AliasManagerTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/ledger/accounts/AliasManagerTest.java
@@ -35,7 +35,6 @@ import java.util.Map;
 import static com.swirlds.common.CommonUtils.unhex;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -63,7 +62,7 @@ class AliasManagerTest {
 
 	@Test
 	void resolvesUnlinkedNonMirrorAsExpected() {
-		assertNull(subject.resolveForEvm(nonMirrorAddress));
+		assertSame(nonMirrorAddress, subject.resolveForEvm(nonMirrorAddress));
 	}
 
 	@Test

--- a/hedera-node/src/test/java/com/hedera/services/store/contracts/SizeLimitedStorageTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/store/contracts/SizeLimitedStorageTest.java
@@ -101,9 +101,9 @@ class SizeLimitedStorageTest {
 		subject.validateAndCommit();
 		subject.recordNewKvUsageTo(accountsLedger);
 
-		inOrder.verify(storage).remove(firstAKey);
-		inOrder.verify(storage).remove(firstBKey);
-		inOrder.verify(storage).remove(nextAKey);
+		inOrder.verify(storage).put(firstAKey, ZERO_VALUE);
+		inOrder.verify(storage).put(firstBKey, ZERO_VALUE);
+		inOrder.verify(storage).put(nextAKey, ZERO_VALUE);
 		// and:
 		inOrder.verify(accountsLedger).set(firstAccount, NUM_CONTRACT_KV_PAIRS, firstKvPairs - 2);
 		inOrder.verify(accountsLedger).set(nextAccount, NUM_CONTRACT_KV_PAIRS, nextKvPairs - 1);


### PR DESCRIPTION
**Description**:
- Merges fixes for `v0.23.1` tag:
    * Continue to `put()` a tombstone rather than calling `VirtualMap.remove()` (pending 0.24.x upgrade).
    * Make `AliasManager.resolveForEvm()` return an unresolved contract alias instead of `null` to get the expected `INVALID_SOLIDITY_ADDRESS` failure status.