### PR TITLE
Add E2E test for HTS precompile key verification logic when transfering tokens from the active contract

### DIFF
--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/CryptoTransferHTSSuite.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/CryptoTransferHTSSuite.java
@@ -56,6 +56,7 @@ import static com.hedera.services.bdd.spec.transactions.TxnVerbs.mintToken;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.tokenAssociate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.tokenCreate;
 import static com.hedera.services.bdd.spec.transactions.token.TokenMovement.moving;
+import static com.hedera.services.bdd.spec.transactions.token.TokenMovement.movingUnique;
 import static com.hedera.services.bdd.spec.utilops.CustomSpecAssert.allRunFor;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.accountAmount;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.childRecordsCheck;
@@ -68,6 +69,8 @@ import static com.hedera.services.bdd.spec.utilops.UtilVerbs.updateLargeFile;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.withOpContext;
 import static com.hedera.services.bdd.suites.contract.Utils.extractByteCode;
 import static com.hedera.services.bdd.suites.utils.MiscEETUtils.metadata;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.CONTRACT_REVERT_EXECUTED;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_SIGNATURE;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SUCCESS;
 
 public class CryptoTransferHTSSuite extends HapiApiSuite {
@@ -104,7 +107,8 @@ public class CryptoTransferHTSSuite extends HapiApiSuite {
 						nonNestedCryptoTransferForMultipleNonFungibleTokens(),
 //						nonNestedCryptoTransferForFungibleAndNonFungibleToken(),
 //						nonNestedCryptoTransferForFungibleTokenWithMultipleSendersAndReceiversAndNonFungibleTokens(),
-//						repeatedTokenIdsAreAutomaticallyConsolidated()
+//						repeatedTokenIdsAreAutomaticallyConsolidated(),
+						activeContractInFrameIsVerifiedWithoutNeedForSignature()
 				}
 		);
 	}
@@ -354,7 +358,7 @@ public class CryptoTransferHTSSuite extends HapiApiSuite {
 						mintToken(NFT_TOKEN, List.of(metadata("firstMemo"), metadata("secondMemo"))),
 						tokenAssociate(RECEIVER, List.of(NFT_TOKEN)),
 						cryptoTransfer(
-								TokenMovement.movingUnique(NFT_TOKEN, 1).between(TOKEN_TREASURY, SENDER)).payingWith(
+								movingUnique(NFT_TOKEN, 1).between(TOKEN_TREASURY, SENDER)).payingWith(
 								SENDER)
 				).when(
 						sourcing(() -> contractCreate(theContract, CRYPTO_TRANSFER_CONS_ABI)
@@ -428,10 +432,10 @@ public class CryptoTransferHTSSuite extends HapiApiSuite {
 						tokenAssociate(RECEIVER, List.of(NFT_TOKEN)),
 						tokenAssociate(RECEIVER2, List.of(NFT_TOKEN)),
 						cryptoTransfer(
-								TokenMovement.movingUnique(NFT_TOKEN, 1).between(TOKEN_TREASURY, SENDER)).payingWith(
+								movingUnique(NFT_TOKEN, 1).between(TOKEN_TREASURY, SENDER)).payingWith(
 								SENDER),
 						cryptoTransfer(
-								TokenMovement.movingUnique(NFT_TOKEN, 2).between(TOKEN_TREASURY, SENDER2)).payingWith(
+								movingUnique(NFT_TOKEN, 2).between(TOKEN_TREASURY, SENDER2)).payingWith(
 								SENDER2)
 				).when(
 						sourcing(() -> contractCreate(theContract, CRYPTO_TRANSFER_CONS_ABI)
@@ -521,7 +525,7 @@ public class CryptoTransferHTSSuite extends HapiApiSuite {
 						tokenAssociate(RECEIVER2, List.of(NFT_TOKEN)),
 						cryptoTransfer(moving(200, FUNGIBLE_TOKEN).between(TOKEN_TREASURY, SENDER)).payingWith(SENDER),
 						cryptoTransfer(
-								TokenMovement.movingUnique(NFT_TOKEN, 1).between(TOKEN_TREASURY, SENDER2)).payingWith(
+								movingUnique(NFT_TOKEN, 1).between(TOKEN_TREASURY, SENDER2)).payingWith(
 								SENDER2)
 				).when(
 						sourcing(() -> contractCreate(theContract, CRYPTO_TRANSFER_CONS_ABI)
@@ -627,10 +631,10 @@ public class CryptoTransferHTSSuite extends HapiApiSuite {
 						cryptoTransfer(moving(200, FUNGIBLE_TOKEN).between(TOKEN_TREASURY, SENDER)).payingWith(SENDER),
 						cryptoTransfer(moving(100, FUNGIBLE_TOKEN).between(TOKEN_TREASURY, SENDER2)).payingWith(SENDER2),
 						cryptoTransfer(
-								TokenMovement.movingUnique(NFT_TOKEN, 1).between(TOKEN_TREASURY, SENDER)).payingWith(
+								movingUnique(NFT_TOKEN, 1).between(TOKEN_TREASURY, SENDER)).payingWith(
 								SENDER),
 						cryptoTransfer(
-								TokenMovement.movingUnique(NFT_TOKEN, 2).between(TOKEN_TREASURY, SENDER2)).payingWith(
+								movingUnique(NFT_TOKEN, 2).between(TOKEN_TREASURY, SENDER2)).payingWith(
 								SENDER2)
 				).when(
 						sourcing(() -> contractCreate(theContract, CRYPTO_TRANSFER_CONS_ABI)
@@ -709,6 +713,183 @@ public class CryptoTransferHTSSuite extends HapiApiSuite {
 										.including(NFT_TOKEN, SENDER2, RECEIVER2, 2L)))
 				);
 	}
+
+	private HapiApiSpec activeContractInFrameIsVerifiedWithoutNeedForSignature() {
+		final var initcode = "cryptoTransferFileByteCode";
+		final var cryptoTransferContract = "cryptoTransferContract";
+		final var revertedFungibleTransferTxn = "revertedFungibleTransferTxn";
+		final var successfulFungibleTransferTxn = "successfulFungibleTransferTxn";
+		final var revertedNftTransferTxn = "revertedNftTransferTxn";
+		final var successfulNftTransferTxn = "successfulNftTransferTxn";
+		final var senderStartBalance = 200L;
+		final var receiverStartBalance = 0L;
+		final var toSendEachTuple = 50L;
+		final var multiKey = "purpose";
+		final var senderKey = "senderKey";
+		final var contractKey = "contractAdminKey";
+
+		return defaultHapiSpec("ActiveContractIsVerifiedWithoutCheckingSignatures")
+				.given(
+						newKeyNamed(multiKey),
+						newKeyNamed(senderKey),
+						newKeyNamed(contractKey),
+						cryptoCreate(SENDER).balance(10 * ONE_HUNDRED_HBARS).key(senderKey),
+						cryptoCreate(RECEIVER).balance(2 * ONE_HUNDRED_HBARS),
+						cryptoCreate(TOKEN_TREASURY),
+						fileCreate(initcode),
+						updateLargeFile(SENDER, initcode,
+								extractByteCode(ContractResources.CRYPTO_TRANSFER_CONTRACT)),
+						contractCreate(cryptoTransferContract, CRYPTO_TRANSFER_CONS_ABI)
+								.bytecode(initcode)
+								.payingWith(GENESIS)
+								.adminKey(contractKey)
+								.gas(GAS_TO_OFFER),
+						tokenCreate(FUNGIBLE_TOKEN)
+								.tokenType(TokenType.FUNGIBLE_COMMON)
+								.initialSupply(TOTAL_SUPPLY)
+								.treasury(TOKEN_TREASURY),
+						tokenCreate(NFT_TOKEN)
+								.tokenType(TokenType.NON_FUNGIBLE_UNIQUE)
+								.adminKey(multiKey)
+								.supplyKey(multiKey)
+								.supplyType(TokenSupplyType.INFINITE)
+								.initialSupply(0)
+								.treasury(TOKEN_TREASURY),
+						mintToken(NFT_TOKEN, List.of(metadata("firstMemo"), metadata("secondMemo"))),
+						tokenAssociate(SENDER, List.of(FUNGIBLE_TOKEN, NFT_TOKEN)),
+						tokenAssociate(RECEIVER, List.of(FUNGIBLE_TOKEN, NFT_TOKEN)),
+						tokenAssociate(cryptoTransferContract, List.of(FUNGIBLE_TOKEN, NFT_TOKEN)),
+						cryptoTransfer(moving(senderStartBalance, FUNGIBLE_TOKEN).between(TOKEN_TREASURY, SENDER)),
+						cryptoTransfer(movingUnique(NFT_TOKEN, 1L).between(TOKEN_TREASURY, SENDER)),
+						cryptoTransfer(moving(senderStartBalance, FUNGIBLE_TOKEN).between(TOKEN_TREASURY,
+								cryptoTransferContract), movingUnique(NFT_TOKEN, 2L).between(TOKEN_TREASURY,
+								cryptoTransferContract))
+				).when(
+						withOpContext((spec, opLog) -> {
+							final var token = spec.registry().getTokenID(FUNGIBLE_TOKEN);
+							final var nftToken = spec.registry().getTokenID(NFT_TOKEN);
+							final var sender = spec.registry().getAccountID(SENDER);
+							final var receiver = spec.registry().getAccountID(RECEIVER);
+							final var contractId = spec.registry().getAccountID(cryptoTransferContract);
+							allRunFor(
+									spec,
+									contractCall(cryptoTransferContract, CRYPTO_TRANSFER_FUNGIBLE_TOKENS_LIST, Tuple.singleton(
+											new Tuple[] {
+													tokenTransferList()
+															.forToken(token)
+															.isSingleList(false)
+															.withAccountAmounts(
+																	accountAmount(contractId, -toSendEachTuple),
+																	accountAmount(receiver, toSendEachTuple)
+															).build(),
+													tokenTransferList()
+															.forToken(token)
+															.isSingleList(false)
+															.withAccountAmounts(
+																	accountAmount(sender, -toSendEachTuple),
+																	accountAmount(receiver, toSendEachTuple)
+															).build()
+											}
+									))
+											.payingWith(GENESIS)
+											.via(revertedFungibleTransferTxn)
+											.gas(GAS_TO_OFFER)
+											.hasKnownStatus(CONTRACT_REVERT_EXECUTED),
+									contractCall(cryptoTransferContract, CRYPTO_TRANSFER_FUNGIBLE_TOKENS_LIST, Tuple.singleton(
+											new Tuple[] {
+													tokenTransferList()
+															.forToken(token)
+															.isSingleList(false)
+															.withAccountAmounts(
+																	accountAmount(contractId, -toSendEachTuple),
+																	accountAmount(receiver, toSendEachTuple)
+															).build(),
+													tokenTransferList()
+															.forToken(token)
+															.isSingleList(false)
+															.withAccountAmounts(
+																	accountAmount(sender, -toSendEachTuple),
+																	accountAmount(receiver, toSendEachTuple)
+															).build()
+											}
+									))
+											.payingWith(GENESIS)
+											.alsoSigningWithFullPrefix(senderKey)
+											.via(successfulFungibleTransferTxn)
+											.gas(GAS_TO_OFFER)
+											.hasKnownStatus(SUCCESS),
+									contractCall(cryptoTransferContract, CRYPTO_TRANSFER_FUNGIBLE_TOKENS_LIST, Tuple.singleton(
+											new Tuple[] {
+													tokenTransferList()
+															.forToken(nftToken)
+															.isSingleList(false)
+															.withNftTransfers(nftTransfer(contractId, receiver, 2L))
+															.build(),
+													tokenTransferList()
+															.forToken(nftToken)
+															.isSingleList(false)
+															.withNftTransfers(nftTransfer(sender, receiver, 1L))
+															.build()
+											}
+									))
+											.payingWith(GENESIS)
+											.via(revertedNftTransferTxn)
+											.gas(GAS_TO_OFFER)
+											.hasKnownStatus(CONTRACT_REVERT_EXECUTED),
+									contractCall(cryptoTransferContract, CRYPTO_TRANSFER_FUNGIBLE_TOKENS_LIST, Tuple.singleton(
+											new Tuple[] {
+													tokenTransferList()
+															.forToken(nftToken)
+															.isSingleList(false)
+															.withNftTransfers(nftTransfer(contractId, receiver, 2L))
+															.build(),
+													tokenTransferList()
+															.forToken(nftToken)
+															.isSingleList(false)
+															.withNftTransfers(nftTransfer(sender, receiver, 1L))
+															.build()
+											}
+									))
+											.payingWith(GENESIS)
+											.via(successfulNftTransferTxn)
+											.alsoSigningWithFullPrefix(senderKey)
+											.gas(GAS_TO_OFFER)
+											.hasKnownStatus(SUCCESS));
+						})
+				).then(
+						getAccountBalance(RECEIVER)
+								.hasTokenBalance(FUNGIBLE_TOKEN, receiverStartBalance + 2 * toSendEachTuple)
+								.hasTokenBalance(NFT_TOKEN, 2L),
+						getAccountBalance(SENDER)
+								.hasTokenBalance(FUNGIBLE_TOKEN, senderStartBalance - toSendEachTuple)
+								.hasTokenBalance(NFT_TOKEN, 0L),
+						getAccountBalance(cryptoTransferContract)
+								.hasTokenBalance(FUNGIBLE_TOKEN, senderStartBalance - toSendEachTuple)
+								.hasTokenBalance(NFT_TOKEN, 0L),
+						childRecordsCheck(revertedFungibleTransferTxn, CONTRACT_REVERT_EXECUTED, recordWith()
+								.status(INVALID_SIGNATURE)),
+						childRecordsCheck(successfulFungibleTransferTxn, SUCCESS, recordWith()
+								.status(SUCCESS)
+								.tokenTransfers(
+										SomeFungibleTransfers.changingFungibleBalances()
+												.including(FUNGIBLE_TOKEN, SENDER, -toSendEachTuple)
+												.including(FUNGIBLE_TOKEN, cryptoTransferContract, -toSendEachTuple)
+												.including(FUNGIBLE_TOKEN, RECEIVER, 2 * toSendEachTuple)
+								)
+						),
+						childRecordsCheck(revertedNftTransferTxn, CONTRACT_REVERT_EXECUTED, recordWith()
+								.status(INVALID_SIGNATURE)),
+						childRecordsCheck(successfulNftTransferTxn, SUCCESS, recordWith()
+								.status(SUCCESS)
+								.tokenTransfers(
+										NonFungibleTransfers.changingNFTBalances()
+												.including(NFT_TOKEN, SENDER, RECEIVER, 1L)
+												.including(NFT_TOKEN, cryptoTransferContract, RECEIVER, 2L)
+								)
+						)
+				);
+	}
+
 
 	@Override
 	protected Logger getResultsLogger() {


### PR DESCRIPTION
**Description**:
This PR adds an E2E that verifies the changes made from the [key-verification-logic-refactor PR.](https://github.com/hashgraph/hedera-services/pull/2900)


**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
