### PR TITLE
refactor: overload wrapped() method without sideEffectsTracker

### DIFF
--- a/hedera-node/src/main/java/com/hedera/services/store/contracts/HederaStackedWorldStateUpdater.java
+++ b/hedera-node/src/main/java/com/hedera/services/store/contracts/HederaStackedWorldStateUpdater.java
@@ -22,7 +22,6 @@ package com.hedera.services.store.contracts;
  *
  */
 
-import com.hedera.services.context.SideEffectsTracker;
 import com.hederahashgraph.api.proto.java.ContractID;
 import org.apache.tuweni.bytes.Bytes;
 import org.hyperledger.besu.datatypes.Address;
@@ -144,7 +143,7 @@ public class HederaStackedWorldStateUpdater
 		return new HederaStackedWorldStateUpdater(
 				(AbstractLedgerWorldUpdater) this,
 				worldState,
-				trackingLedgers().wrapped(new SideEffectsTracker()));
+				trackingLedgers().wrapped());
 	}
 
 	/* --- Internal helpers --- */

--- a/hedera-node/src/main/java/com/hedera/services/store/contracts/HederaWorldState.java
+++ b/hedera-node/src/main/java/com/hedera/services/store/contracts/HederaWorldState.java
@@ -22,7 +22,6 @@ package com.hedera.services.store.contracts;
  *
  */
 
-import com.hedera.services.context.SideEffectsTracker;
 import com.hedera.services.context.properties.GlobalDynamicProperties;
 import com.hedera.services.ledger.SigImpactHistorian;
 import com.hedera.services.ledger.accounts.HederaAccountCustomizer;
@@ -198,7 +197,7 @@ public class HederaWorldState implements HederaMutableWorldState {
 
 	@Override
 	public Updater updater() {
-		return new Updater(this, entityAccess.worldLedgers().wrapped(new SideEffectsTracker()));
+		return new Updater(this, entityAccess.worldLedgers().wrapped());
 	}
 
 	@Override
@@ -542,7 +541,7 @@ public class HederaWorldState implements HederaMutableWorldState {
 		@Override
 		public WorldUpdater updater() {
 			return new HederaStackedWorldStateUpdater(this, wrappedWorldView(),
-					trackingLedgers().wrapped(new SideEffectsTracker()));
+					trackingLedgers().wrapped());
 		}
 
 		@Override

--- a/hedera-node/src/main/java/com/hedera/services/store/contracts/WorldLedgers.java
+++ b/hedera-node/src/main/java/com/hedera/services/store/contracts/WorldLedgers.java
@@ -163,6 +163,19 @@ public class WorldLedgers {
 				tokenRelsLedger != null;
 	}
 
+	public WorldLedgers wrapped() {
+		if (!areMutable()) {
+			return staticLedgersWith(StackedContractAliases.wrapping(aliases), staticEntityAccess);
+		}
+
+		return new WorldLedgers(
+				StackedContractAliases.wrapping(aliases),
+				activeLedgerWrapping(tokenRelsLedger),
+				activeLedgerWrapping(accountsLedger),
+				activeLedgerWrapping(nftsLedger),
+				activeLedgerWrapping(tokensLedger));
+	}
+
 	public WorldLedgers wrapped(final SideEffectsTracker sideEffectsTracker) {
 		if (!areMutable()) {
 			return staticLedgersWith(StackedContractAliases.wrapping(aliases), staticEntityAccess);

--- a/hedera-node/src/test/java/com/hedera/services/store/contracts/HederaWorldStateTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/store/contracts/HederaWorldStateTest.java
@@ -663,7 +663,7 @@ class HederaWorldStateTest {
 	}
 
 	private void givenNonNullWorldLedgers() {
-		given(worldLedgers.wrapped(any())).willReturn(worldLedgers);
+		given(worldLedgers.wrapped()).willReturn(worldLedgers);
 		given(entityAccess.worldLedgers()).willReturn(worldLedgers);
 	}
 }

--- a/hedera-node/src/test/java/com/hedera/services/store/contracts/MockLedgerWorldUpdater.java
+++ b/hedera-node/src/test/java/com/hedera/services/store/contracts/MockLedgerWorldUpdater.java
@@ -20,7 +20,6 @@ package com.hedera.services.store.contracts;
  * ‍
  */
 
-import com.hedera.services.context.SideEffectsTracker;
 import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.evm.worldstate.WorldUpdater;
 
@@ -44,6 +43,6 @@ public class MockLedgerWorldUpdater
 
 	@Override
 	public WorldUpdater updater() {
-		return new MockStackedLedgerUpdater(this, trackingLedgers().wrapped(new SideEffectsTracker()));
+		return new MockStackedLedgerUpdater(this, trackingLedgers().wrapped());
 	}
 }

--- a/hedera-node/src/test/java/com/hedera/services/store/contracts/WorldLedgersTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/store/contracts/WorldLedgersTest.java
@@ -177,7 +177,7 @@ class WorldLedgersTest {
 	}
 
 	@Test
-	void wrapsAsExpected() {
+	void wrapsAsExpectedWithCommitInterceptors() {
 		final var liveTokenRels = new TransactionalLedger<>(
 				TokenRelProperty.class,
 				MerkleTokenRelStatus::new,
@@ -216,6 +216,55 @@ class WorldLedgersTest {
 		assertFalse(wrappedUnusable.areMutable());
 
 		final var wrappedSource = source.wrapped(sideEffectsTracker);
+
+		assertSame(liveTokenRels, wrappedSource.tokenRels().getEntitiesLedger());
+		assertSame(liveAccounts, wrappedSource.accounts().getEntitiesLedger());
+		assertSame(liveNfts, wrappedSource.nfts().getEntitiesLedger());
+		assertSame(liveTokens, wrappedSource.tokens().getEntitiesLedger());
+		final var stackedAliases = (StackedContractAliases) wrappedSource.aliases();
+		assertSame(liveAliases, stackedAliases.wrappedAliases());
+	}
+
+	@Test
+	void wrapsAsExpectedWithoutCommitInterceptors() {
+		final var liveTokenRels = new TransactionalLedger<>(
+				TokenRelProperty.class,
+				MerkleTokenRelStatus::new,
+				new HashMapBackingTokenRels(),
+				new ChangeSummaryManager<>());
+		final var liveAccounts = new TransactionalLedger<>(
+				AccountProperty.class,
+				MerkleAccount::new,
+				new HashMapBackingAccounts(),
+				new ChangeSummaryManager<>());
+		final var liveNfts = new TransactionalLedger<>(
+				NftProperty.class,
+				MerkleUniqueToken::new,
+				new HashMapBackingNfts(),
+				new ChangeSummaryManager<>());
+		final var liveTokens = new TransactionalLedger<>(
+				TokenProperty.class,
+				MerkleToken::new,
+				new HashMapBackingTokens(),
+				new ChangeSummaryManager<>());
+		final var liveAliases = new AliasManager();
+
+		final var source = new WorldLedgers(liveAliases, liveTokenRels, liveAccounts, liveNfts, liveTokens);
+		assertTrue(source.areMutable());
+		final var nullTokenRels = new WorldLedgers(liveAliases, null, liveAccounts, liveNfts, liveTokens);
+		final var nullAccounts = new WorldLedgers(liveAliases, liveTokenRels, null, liveNfts, liveTokens);
+		final var nullNfts = new WorldLedgers(liveAliases, liveTokenRels, liveAccounts, null, liveTokens);
+		final var nullTokens = new WorldLedgers(liveAliases, liveTokenRels, liveAccounts, liveNfts, null);
+		assertFalse(nullTokenRels.areMutable());
+		assertFalse(nullAccounts.areMutable());
+		assertFalse(nullNfts.areMutable());
+		assertFalse(nullTokens.areMutable());
+
+		final var wrappedUnusable = nullAccounts.wrapped();
+		assertSame(((StackedContractAliases) wrappedUnusable.aliases()).wrappedAliases(), nullAccounts.aliases());
+		assertFalse(wrappedUnusable.areMutable());
+
+		final var wrappedSource = source.wrapped();
 
 		assertSame(liveTokenRels, wrappedSource.tokenRels().getEntitiesLedger());
 		assertSame(liveAccounts, wrappedSource.accounts().getEntitiesLedger());


### PR DESCRIPTION
**Description**:
Overload WorldLedgers.wrapped() to remove SideEffectsTracker as argument, so that we can initialize new ledgers without commit interceptors, when they are not needed.

**Related issue(s)**:

Fixes #


**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
