### PR TITLE
Fixes issue with incorrect nft allowances lists in account info query…

### DIFF
--- a/hedera-node/src/main/java/com/hedera/services/txns/crypto/helpers/AllowanceHelpers.java
+++ b/hedera-node/src/main/java/com/hedera/services/txns/crypto/helpers/AllowanceHelpers.java
@@ -150,8 +150,8 @@ public class AllowanceHelpers {
 	public static List<GrantedNftAllowance> getNftAllowancesList(final MerkleAccount account) {
 		if (!account.state().getNftAllowances().isEmpty()) {
 			List<GrantedNftAllowance> nftAllowances = new ArrayList<>();
-			final var nftAllowance = GrantedNftAllowance.newBuilder();
 			for (var a : account.state().getNftAllowances().entrySet()) {
+				final var nftAllowance = GrantedNftAllowance.newBuilder();
 				nftAllowance.setTokenId(a.getKey().getTokenNum().toGrpcTokenId());
 				nftAllowance.setSpender(a.getKey().getSpenderNum().toGrpcAccountId());
 				nftAllowance.setApprovedForAll(a.getValue().isApprovedForAll());


### PR DESCRIPTION
… result

Adds a test case to CryptoApproveAllowanceSuite proving we can approve two different spenders for the same NFT

Signed-off-by: Stoyan Panayotov <stoyan.panayotov@limechain.tech>

**Description**:
Since the GrantedNftAllowance object in AllowanceHelpers.getNftAllowancesList() is instantiated before entering the for cycle and we set the serial numbers via 'addAllSerialNumbers', incorrect values were returned by the get account info query when multiple allowances exist - old values for previous result were not cleared.

Also adds a test case proving we can have multiple approved accounts for the same NFT.

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
