### PR TITLE
Fix approve/allowance issue with INFINITE supply type fungible tokens

### DIFF
--- a/hedera-node/src/main/java/com/hedera/services/txns/crypto/validators/AdjustAllowanceChecks.java
+++ b/hedera-node/src/main/java/com/hedera/services/txns/crypto/validators/AdjustAllowanceChecks.java
@@ -21,6 +21,7 @@ package com.hedera.services.txns.crypto.validators;
  */
 
 import com.hedera.services.context.properties.GlobalDynamicProperties;
+import com.hedera.services.state.enums.TokenSupplyType;
 import com.hedera.services.state.merkle.MerkleUniqueToken;
 import com.hedera.services.state.submerkle.FcTokenAllowanceId;
 import com.hedera.services.store.AccountStore;
@@ -312,7 +313,8 @@ public class AdjustAllowanceChecks implements AllowanceChecks {
 			return NEGATIVE_ALLOWANCE_AMOUNT;
 		}
 
-		if (aggregatedAmount > fungibleToken.getMaxSupply()) {
+		if (fungibleToken.getSupplyType().equals(TokenSupplyType.FINITE) &&
+				aggregatedAmount > fungibleToken.getMaxSupply()) {
 			return AMOUNT_EXCEEDS_TOKEN_MAX_SUPPLY;
 		}
 		return OK;

--- a/hedera-node/src/main/java/com/hedera/services/txns/crypto/validators/ApproveAllowanceChecks.java
+++ b/hedera-node/src/main/java/com/hedera/services/txns/crypto/validators/ApproveAllowanceChecks.java
@@ -21,6 +21,7 @@ package com.hedera.services.txns.crypto.validators;
  */
 
 import com.hedera.services.context.properties.GlobalDynamicProperties;
+import com.hedera.services.state.enums.TokenSupplyType;
 import com.hedera.services.state.merkle.MerkleUniqueToken;
 import com.hedera.services.store.AccountStore;
 import com.hedera.services.store.TypedTokenStore;
@@ -271,8 +272,9 @@ public class ApproveAllowanceChecks implements AllowanceChecks {
 			return NEGATIVE_ALLOWANCE_AMOUNT;
 		}
 
-		if (fungibleToken != null && amount > fungibleToken.getMaxSupply()) {
-			return AMOUNT_EXCEEDS_TOKEN_MAX_SUPPLY;
+		if (fungibleToken.getSupplyType().equals(TokenSupplyType.FINITE) &&
+				amount > fungibleToken.getMaxSupply()) {
+ 			return AMOUNT_EXCEEDS_TOKEN_MAX_SUPPLY;
 		}
 		return OK;
 	}

--- a/hedera-node/src/test/java/com/hedera/services/txns/crypto/validators/AdjustAllowanceChecksTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/txns/crypto/validators/AdjustAllowanceChecksTest.java
@@ -23,6 +23,7 @@ package com.hedera.services.txns.crypto.validators;
 import com.google.protobuf.BoolValue;
 import com.hedera.services.context.properties.GlobalDynamicProperties;
 import com.hedera.services.exceptions.InvalidTransactionException;
+import com.hedera.services.state.enums.TokenSupplyType;
 import com.hedera.services.state.enums.TokenType;
 import com.hedera.services.state.merkle.MerkleUniqueToken;
 import com.hedera.services.state.submerkle.EntityId;
@@ -149,9 +150,9 @@ class AdjustAllowanceChecksTest {
 	@BeforeEach
 	void setUp() {
 		resetAllowances();
-		token1Model.setMaxSupply(5000L);
+		token1Model.initSupplyConstraints(TokenSupplyType.FINITE, 5000L);
 		token1Model.setType(TokenType.FUNGIBLE_COMMON);
-		token2Model.setMaxSupply(5000L);
+		token2Model.initSupplyConstraints(TokenSupplyType.FINITE, 5000L);
 		token2Model.setType(TokenType.NON_FUNGIBLE_UNIQUE);
 
 		cryptoAllowances.add(cryptoAllowance1);

--- a/hedera-node/src/test/java/com/hedera/services/txns/crypto/validators/ApproveAllowanceChecksTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/txns/crypto/validators/ApproveAllowanceChecksTest.java
@@ -23,6 +23,7 @@ package com.hedera.services.txns.crypto.validators;
 import com.google.protobuf.BoolValue;
 import com.hedera.services.context.properties.GlobalDynamicProperties;
 import com.hedera.services.exceptions.InvalidTransactionException;
+import com.hedera.services.state.enums.TokenSupplyType;
 import com.hedera.services.state.enums.TokenType;
 import com.hedera.services.state.merkle.MerkleUniqueToken;
 import com.hedera.services.state.submerkle.EntityId;
@@ -139,9 +140,9 @@ class ApproveAllowanceChecksTest {
 
 	@BeforeEach
 	void setUp() {
-		token1Model.setMaxSupply(5000L);
+		token1Model.initSupplyConstraints(TokenSupplyType.FINITE, 5000L);
 		token1Model.setType(TokenType.FUNGIBLE_COMMON);
-		token2Model.setMaxSupply(5000L);
+		token2Model.initSupplyConstraints(TokenSupplyType.FINITE, 5000L);
 		token2Model.setType(TokenType.NON_FUNGIBLE_UNIQUE);
 
 		cryptoAllowances.add(cryptoAllowance1);


### PR DESCRIPTION
Signed-off-by: Stoyan Panayotov <stoyan.panayotov@limechain.tech>

**Description**:
If Token Supply Type is set to INFINITE, than the maxSupply field is always 0.
This PR fixes a check for approve allowance and adjust allowance when the tokenSupplyType is INFINITe.

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
