### PR TITLE
fixed the check comapring alias address to skip prefixed 0s

### DIFF
--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/DynamicGasCostSuite.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/DynamicGasCostSuite.java
@@ -154,6 +154,7 @@ import static com.swirlds.common.CommonUtils.unhex;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class DynamicGasCostSuite extends HapiApiSuite {
 	private static final Logger log = LogManager.getLogger(DynamicGasCostSuite.class);

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/DynamicGasCostSuite.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/DynamicGasCostSuite.java
@@ -953,9 +953,8 @@ public class DynamicGasCostSuite extends HapiApiSuite {
 									staticCallAliasAns.get(),
 									staticCallMirrorAns.get(),
 									"Static call with mirror address should be same as call with alias");
-							assertEquals(
-									staticCallAliasAns.get().toString(16),
-									aliasAddr.get(),
+							assertTrue(
+									aliasAddr.get().endsWith(staticCallAliasAns.get().toString(16)),
 									"Alias should get priority over mirror address");
 						}),
 						sourcing(() -> contractCall(

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/DynamicGasCostSuite.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/DynamicGasCostSuite.java
@@ -154,7 +154,6 @@ import static com.swirlds.common.CommonUtils.unhex;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class DynamicGasCostSuite extends HapiApiSuite {
 	private static final Logger log = LogManager.getLogger(DynamicGasCostSuite.class);
@@ -954,8 +953,7 @@ public class DynamicGasCostSuite extends HapiApiSuite {
 									staticCallAliasAns.get(),
 									staticCallMirrorAns.get(),
 									"Static call with mirror address should be same as call with alias");
-							assertTrue(
-									aliasAddr.get().endsWith(staticCallAliasAns.get().toString(16)),
+							assertEquals(new BigInteger(aliasAddr.get(), 16), staticCallAliasAns.get(),
 									"Alias should get priority over mirror address");
 						}),
 						sourcing(() -> contractCall(


### PR DESCRIPTION
When comparing alias address [here](https://github.com/hashgraph/hedera-services/blob/429da77e60df51c0c2dbf22c065906f91e2ab84f/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/DynamicGasCostSuite.java#L956)

the BigInteger.toString(radix) strips off the leading zeros and could cause this equals check to fail, like this : 

```
2022-03-09 06:30:17.420 INFO   321  HapiApiSpec - 'PriorityAddressIsCreate2ForStaticHapiCalls' finished initial execution of SourcedOp
2022-03-09 06:30:17.423 WARN   217  HapiSpecOperation - 'PriorityAddressIsCreate2ForStaticHapiCalls' - CustomSpecAssert failed Alias should get priority over mirror address ==> expected: <2d1e1af40c39b322fca7b4f7301ce525920a8af> but was: <02d1e1af40c39b322fca7b4f7301ce525920a8af>!
2022-03-09 06:30:17.859 INFO   340  HapiApiSpec - 'PriorityAddressIsCreate2ForStaticHapiCalls' - final status: FAILED!
```

where you can see that the only difference is the leading zeros.

Fixing this by skipping check on leading `0`s