### PR TITLE
Update maven version in Dockerfile 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,10 +32,10 @@ FROM base-runtime AS services-builder
 # Note: Java 17 requires Maven 3.8+ so the distro provided one just won't do
 RUN apt-get update && \
     apt-get install -y wget unzip && \
-    wget https://dlcdn.apache.org/maven/maven-3/3.8.4/binaries/apache-maven-3.8.4-bin.zip && \
-    unzip apache-maven-3.8.4-bin.zip -d /opt && \
-    rm apache-maven-3.8.4-bin.zip
-ENV PATH=/opt/apache-maven-3.8.4/bin:$PATH
+    wget https://dlcdn.apache.org/maven/maven-3/3.8.5/binaries/apache-maven-3.8.5-bin.zip && \
+    unzip apache-maven-3.8.5-bin.zip -d /opt && \
+    rm apache-maven-3.8.5-bin.zip
+ENV PATH=/opt/apache-maven-3.8.5/bin:$PATH
 
 WORKDIR /opt/hedera/services
 # Install Services


### PR DESCRIPTION
Maven version 3.8.4 is missing from https://dlcdn.apache.org/maven/maven-3/
Changed version in dockerfile to 3.8.5

Signed-off-by: Stoyan Panayotov <stoyan.panayotov@limechain.tech>

**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
