### PR TITLE
Add fee to record, expiry to new account in `AutoCreationLogic`

### DIFF
--- a/hedera-node/src/main/java/com/hedera/services/state/submerkle/ExpirableTxnRecord.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/submerkle/ExpirableTxnRecord.java
@@ -1034,6 +1034,10 @@ public class ExpirableTxnRecord implements FCQueueElement {
 					!TxnReceipt.SUCCESS_LITERAL.equals(receiptBuilder.getStatus());
 		}
 
+		public long getFee() {
+			return fee;
+		}
+
 		public void onlyExternalizeIfSuccessful() {
 			onlyExternalizedIfSuccessful = true;
 		}

--- a/hedera-node/src/main/java/com/hedera/services/txns/crypto/AutoCreationLogic.java
+++ b/hedera-node/src/main/java/com/hedera/services/txns/crypto/AutoCreationLogic.java
@@ -182,13 +182,14 @@ public class AutoCreationLogic {
 				.key(asFcKeyUnchecked(key))
 				.memo(AUTO_MEMO)
 				.autoRenewPeriod(THREE_MONTHS_IN_SECONDS)
+				.expiry(txnCtx.consensusTime().getEpochSecond() + THREE_MONTHS_IN_SECONDS)
 				.isReceiverSigRequired(false)
 				.isSmartContract(false)
 				.alias(alias);
 		customizer.customize(newAccountId, accountsLedger);
-
 		sideEffects.trackAutoCreation(newAccountId, alias);
 		final var childRecord = creator.createSuccessfulSyntheticRecord(NO_CUSTOM_FEES, sideEffects, AUTO_MEMO);
+		childRecord.setFee(fee);
 		final var inProgress = new InProgressChildRecord(DEFAULT_SOURCE_ID, syntheticCreation, childRecord);
 		pendingCreations.add(inProgress);
 		/* If the transaction fails, we will get an opportunity to unlink this alias in reclaimPendingAliases() */

--- a/hedera-node/src/test/java/com/hedera/services/txns/crypto/AutoCreationLogicTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/txns/crypto/AutoCreationLogicTest.java
@@ -57,6 +57,7 @@ import java.util.Collections;
 import static com.hedera.services.context.BasicTransactionContext.EMPTY_KEY;
 import static com.hedera.services.records.TxnAwareRecordsHistorian.DEFAULT_SOURCE_ID;
 import static com.hedera.services.txns.crypto.AutoCreationLogic.AUTO_MEMO;
+import static com.hedera.services.txns.crypto.AutoCreationLogic.THREE_MONTHS_IN_SECONDS;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OK;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
@@ -102,6 +103,7 @@ class AutoCreationLogicTest {
 		givenCollaborators();
 
 		final var input = wellKnownChange();
+		final var expectedExpiry = consensusNow.getEpochSecond() + THREE_MONTHS_IN_SECONDS;
 
 		final var result = subject.create(input, accountsLedger);
 		subject.submitRecordsTo(recordsHistorian);
@@ -111,7 +113,9 @@ class AutoCreationLogicTest {
 		verify(aliasManager).link(alias, createdNum);
 		verify(sigImpactHistorian).markAliasChanged(alias);
 		verify(sigImpactHistorian).markEntityChanged(createdNum.longValue());
+		verify(accountsLedger).set(createdNum.toGrpcAccountId(), AccountProperty.EXPIRY, expectedExpiry);
 		verify(recordsHistorian).trackPrecedingChildRecord(DEFAULT_SOURCE_ID, mockSyntheticCreation, mockBuilder);
+		assertEquals(totalFee, mockBuilder.getFee());
 		assertEquals(Pair.of(OK, totalFee), result);
 	}
 

--- a/test-clients/src/main/java/com/hedera/services/bdd/spec/assertions/AccountInfoAsserts.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/spec/assertions/AccountInfoAsserts.java
@@ -279,7 +279,7 @@ public class AccountInfoAsserts extends BaseErroringAssertsProvider<AccountInfo>
 		registerProvider((spec, o) -> {
 			long expiry = ((AccountInfo) o).getExpirationTime().getSeconds();
 			assertTrue(Math.abs(approxTime - expiry) <= epsilon,
-					String.format("Expiry %d not in [%d, %d]!", approxTime, expiry - epsilon, expiry + epsilon));
+					String.format("Expiry %d not in [%d, %d]!", expiry, approxTime - epsilon, approxTime + epsilon));
 		});
 		return this;
 	}

--- a/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/meta/HapiGetTxnRecord.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/meta/HapiGetTxnRecord.java
@@ -372,6 +372,10 @@ public class HapiGetTxnRecord extends HapiQueryOp<HapiGetTxnRecord> {
 		return response.getTransactionGetRecord().getTransactionRecord();
 	}
 
+	public TransactionRecord getChildRecord(final int i) {
+		return response.getTransactionGetRecord().getChildTransactionRecords(i);
+	}
+
 	private void assertPriority(HapiApiSpec spec, TransactionRecord actualRecord) throws Throwable {
 		if (priorityExpectations.isPresent()) {
 			ErroringAsserts<TransactionRecord> asserts = priorityExpectations.get().assertsFor(spec);


### PR DESCRIPTION
**Description**:
 - Sets the charged `CryptoCreate` fee on a child auto-creation record.
 - Sets the expiration on an auto-created account.

**Related issue(s)**:
- Fixes #2963
