### PR TITLE
Fix use of `release()` for aliases `FCHashMap`

### DIFF
--- a/hedera-node/src/main/java/com/hedera/services/ServicesState.java
+++ b/hedera-node/src/main/java/com/hedera/services/ServicesState.java
@@ -258,7 +258,7 @@ public class ServicesState extends AbstractNaryMerkleInternal implements SwirldS
 
 	/* --- Archivable --- */
 	@Override
-	public void archive() {
+	public synchronized void archive() {
 		if (metadata != null) {
 			metadata.archive();
 		}
@@ -273,7 +273,7 @@ public class ServicesState extends AbstractNaryMerkleInternal implements SwirldS
 
 	/* --- MerkleNode --- */
 	@Override
-	protected void onRelease() {
+	protected synchronized void onRelease() {
 		if (metadata != null) {
 			metadata.release();
 		}

--- a/hedera-node/src/main/java/com/hedera/services/state/org/StateMetadata.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/org/StateMetadata.java
@@ -60,7 +60,9 @@ public class StateMetadata implements FastCopyable, Archivable {
 
 	@Override
 	public void release() {
-		aliases.release();
+		if (!aliases.isReleased()) {
+			aliases.release();
+		}
 	}
 
 	public ServicesApp app() {

--- a/hedera-node/src/test/java/com/hedera/services/state/org/StateMetadataTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/state/org/StateMetadataTest.java
@@ -32,6 +32,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
@@ -61,10 +62,19 @@ class StateMetadataTest {
 	}
 
 	@Test
-	void releasesAliasesOnRelease() {
+	void releasesUnreleasedAliasesOnRelease() {
 		subject.release();
 
 		verify(aliases).release();
+	}
+
+	@Test
+	void doesntReleaseAlreadyReleasedAliasesOnRelease() {
+		given(aliases.isReleased()).willReturn(true);
+
+		subject.release();
+
+		verify(aliases, never()).release();
 	}
 
 	@Test


### PR DESCRIPTION
**Description**:
- Adopt (currently) idiomatic pattern for archiving/releasing state metadata for the aliases `FCHashMap`.