### PR TITLE
Fix service regression by bring back postgres support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1598,6 +1598,7 @@ jobs:
             cd /swirlds-platform;
             sed -i -e 's/github.com/services-jrs-regression/g' .gitmodules;
             git submodule update --init --recursive --checkout;
+            git checkout -b 02132-D-fix-service-regression origin/02132-D-fix-service-regression;            
             mvn --no-transfer-progress clean install -DskipTests;
 
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1590,8 +1590,8 @@ jobs:
             git clone ssh://git@services-jrs-regression/swirlds/swirlds-platform.git;
             cd /swirlds-platform;
             sed -i -e 's/github.com/services-jrs-regression/g' .gitmodules;
-            git submodule update --init --recursive --checkout;
             git checkout -b 02132-D-fix-service-regression origin/02132-D-fix-service-regression;            
+            git submodule update --init --recursive --checkout;
             mvn --no-transfer-progress clean install -DskipTests;
 
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -996,13 +996,6 @@ workflows:
                 at: /
 
   GCP-Daily-Services-Update-4N-2C:
-    triggers:
-      - schedule:
-          cron: "30 22 * * *"
-          filters:
-            branches:
-              only:
-                - master
     jobs:
       - build-platform-and-services
       - jrs-regression:
@@ -1675,10 +1668,10 @@ jobs:
         default: true
       slack_results_channel:
         type: string
-        default: "hedera-regression"
+        default: "regression-test"
       slack_summary_channel:
         type: string
-        default: "hedera-regression-summary"
+        default: "regression-test"
       workflow-name:
         type: string
         default: ""

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -996,6 +996,13 @@ workflows:
                 at: /
 
   GCP-Daily-Services-Update-4N-2C:
+    triggers:
+      - schedule:
+          cron: "30 22 * * *"
+          filters:
+            branches:
+              only:
+                - master
     jobs:
       - build-platform-and-services
       - jrs-regression:
@@ -1668,10 +1675,10 @@ jobs:
         default: true
       slack_results_channel:
         type: string
-        default: "regression-test"
+        default: "hedera-regression"
       slack_summary_channel:
         type: string
-        default: "regression-test"
+        default: "hedera-regression-summary"
       workflow-name:
         type: string
         default: ""


### PR DESCRIPTION
Use an old platform commit before removing blob feature to fix regression tests of service side,
also cherry picked  some fixes to service test from regression repo develop branch.

Once later a new sdk released to master branch, 
we need to revert this change.

Test result:

https://hedera-hashgraph.slack.com/archives/CJ1P4A2NS/p1647387065758839

The work flow started working, some test still failing need further debug
