### PR TITLE
Drop async verifications `Speedometer`; create new `ArrayList` only on new auto-associations

### DIFF
--- a/hedera-node/src/main/java/com/hedera/services/context/SideEffectsTracker.java
+++ b/hedera-node/src/main/java/com/hedera/services/context/SideEffectsTracker.java
@@ -20,6 +20,7 @@ package com.hedera.services.context;
  * ‍
  */
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.protobuf.ByteString;
 import com.hedera.services.state.submerkle.CurrencyAdjustments;
 import com.hedera.services.state.submerkle.FcTokenAllowance;
@@ -293,7 +294,7 @@ public class SideEffectsTracker {
 	 * @return the created auto-associations
 	 */
 	public List<FcTokenAssociation> getTrackedAutoAssociations() {
-		return autoAssociations;
+		return autoAssociations.isEmpty() ? Collections.emptyList() : new ArrayList<>(autoAssociations);
 	}
 
 	/**
@@ -581,7 +582,8 @@ public class SideEffectsTracker {
 	 * 		an additional change to incorporate into the target account's balance
 	 * @return how many slots in the accountNums array are now actually touched
 	 */
-	public static int includeOrderedFungibleChange(
+	@VisibleForTesting
+	static int includeOrderedFungibleChange(
 			final long[] accountNums,
 			final long[] balanceChanges,
 			final int touchedSoFar,
@@ -624,7 +626,8 @@ public class SideEffectsTracker {
 	 * 		how many slots in the accountNums array were actually touched so far
 	 * @return how many slots in the accountNums array are now actually touched
 	 */
-	public static int purgeZeroChanges(
+	@VisibleForTesting
+	static int purgeZeroChanges(
 			final long[] accountNums,
 			final long[] balanceChanges,
 			final int touchedSoFar
@@ -644,7 +647,13 @@ public class SideEffectsTracker {
 		return touchedSoFar - zerosSkippedSoFar;
 	}
 
-	public int getNumHbarChangesSoFar() {
+	@VisibleForTesting
+	int getNumHbarChangesSoFar() {
 		return numHbarChangesSoFar;
+	}
+
+	@VisibleForTesting
+	List<FcTokenAssociation> getInternalAutoAssociations() {
+		return autoAssociations;
 	}
 }

--- a/hedera-node/src/main/java/com/hedera/services/state/logic/SigsAndPayerKeyScreen.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/logic/SigsAndPayerKeyScreen.java
@@ -9,9 +9,9 @@ package com.hedera.services.state.logic;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -65,10 +65,8 @@ public class SigsAndPayerKeyScreen {
 		rationalization.performFor(accessor);
 
 		final var sigStatus = rationalization.finalStatus();
-		if (sigStatus == OK) {
-			if (rationalization.usedSyncVerification()) {
-				speedometers.cycleSyncVerifications();
-			}
+		if (sigStatus == OK && rationalization.usedSyncVerification()) {
+			speedometers.cycleSyncVerifications();
 		}
 
 		if (hasActivePayerSig(accessor)) {

--- a/hedera-node/src/main/java/com/hedera/services/state/logic/SigsAndPayerKeyScreen.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/logic/SigsAndPayerKeyScreen.java
@@ -68,8 +68,6 @@ public class SigsAndPayerKeyScreen {
 		if (sigStatus == OK) {
 			if (rationalization.usedSyncVerification()) {
 				speedometers.cycleSyncVerifications();
-			} else {
-				speedometers.cycleAsyncVerifications();
 			}
 		}
 

--- a/hedera-node/src/main/java/com/hedera/services/state/submerkle/ExpirableTxnRecord.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/submerkle/ExpirableTxnRecord.java
@@ -146,7 +146,7 @@ public class ExpirableTxnRecord implements FCQueueElement {
 		this.nftTokenAdjustments = builder.nftTokenAdjustments;
 		this.scheduleRef = builder.scheduleRef;
 		this.assessedCustomFees = builder.assessedCustomFees;
-		this.newTokenAssociations = new ArrayList<>(builder.newTokenAssociations);
+		this.newTokenAssociations = builder.newTokenAssociations;
 		this.packedParentConsensusTime = builder.packedParentConsensusTime;
 		this.numChildRecords = builder.numChildRecords;
 		this.alias = builder.alias;

--- a/hedera-node/src/main/java/com/hedera/services/stats/MiscSpeedometers.java
+++ b/hedera-node/src/main/java/com/hedera/services/stats/MiscSpeedometers.java
@@ -27,14 +27,12 @@ public class MiscSpeedometers {
 	private final SpeedometerFactory speedometer;
 
 	StatsSpeedometer syncVerifications;
-	StatsSpeedometer accountLookupRetries;
 	StatsSpeedometer platformTxnRejections;
 
 	public MiscSpeedometers(final SpeedometerFactory speedometer, final double halfLife) {
 		this.speedometer = speedometer;
 
 		syncVerifications = new StatsSpeedometer(halfLife);
-		accountLookupRetries = new StatsSpeedometer(halfLife);
 		platformTxnRejections = new StatsSpeedometer(halfLife);
 	}
 
@@ -46,11 +44,6 @@ public class MiscSpeedometers {
 						syncVerifications));
 		platform.addAppStatEntry(
 				speedometer.from(
-						Names.ACCOUNT_LOOKUP_RETRIES,
-						Descriptions.ACCOUNT_LOOKUP_RETRIES,
-						accountLookupRetries));
-		platform.addAppStatEntry(
-				speedometer.from(
 						Names.PLATFORM_TXN_REJECTIONS,
 						Descriptions.PLATFORM_TXN_REJECTIONS,
 						platformTxnRejections));
@@ -60,17 +53,12 @@ public class MiscSpeedometers {
 		syncVerifications.update(1);
 	}
 
-	public void cycleAccountLookupRetries() {
-		accountLookupRetries.update(1);
-	}
-
 	public void cyclePlatformTxnRejections() {
 		platformTxnRejections.update(1);
 	}
 
 	public static final class Names {
 		static final String SYNC_VERIFICATIONS = "sigVerifySync/sec";
-		static final String ACCOUNT_LOOKUP_RETRIES = "acctLookupRetries/sec";
 		static final String PLATFORM_TXN_REJECTIONS = "platformTxnNotCreated/sec";
 
 		private Names() {
@@ -81,8 +69,6 @@ public class MiscSpeedometers {
 	public static final class Descriptions {
 		static final String SYNC_VERIFICATIONS =
 				"number of transactions received per second that must be verified synchronously in handleTransaction";
-		static final String ACCOUNT_LOOKUP_RETRIES =
-				"number of times per second that an account lookup must be retried";
 		static final String PLATFORM_TXN_REJECTIONS =
 				"number of platform transactions not created per second";
 

--- a/hedera-node/src/main/java/com/hedera/services/stats/MiscSpeedometers.java
+++ b/hedera-node/src/main/java/com/hedera/services/stats/MiscSpeedometers.java
@@ -27,7 +27,6 @@ public class MiscSpeedometers {
 	private final SpeedometerFactory speedometer;
 
 	StatsSpeedometer syncVerifications;
-	StatsSpeedometer asyncVerifications;
 	StatsSpeedometer accountLookupRetries;
 	StatsSpeedometer platformTxnRejections;
 
@@ -35,7 +34,6 @@ public class MiscSpeedometers {
 		this.speedometer = speedometer;
 
 		syncVerifications = new StatsSpeedometer(halfLife);
-		asyncVerifications = new StatsSpeedometer(halfLife);
 		accountLookupRetries = new StatsSpeedometer(halfLife);
 		platformTxnRejections = new StatsSpeedometer(halfLife);
 	}
@@ -46,11 +44,6 @@ public class MiscSpeedometers {
 						Names.SYNC_VERIFICATIONS,
 						Descriptions.SYNC_VERIFICATIONS,
 						syncVerifications));
-		platform.addAppStatEntry(
-				speedometer.from(
-						Names.ASYNC_VERIFICATIONS,
-						Descriptions.ASYNC_VERIFICATIONS,
-						asyncVerifications));
 		platform.addAppStatEntry(
 				speedometer.from(
 						Names.ACCOUNT_LOOKUP_RETRIES,
@@ -67,10 +60,6 @@ public class MiscSpeedometers {
 		syncVerifications.update(1);
 	}
 
-	public void cycleAsyncVerifications() {
-		asyncVerifications.update(1);
-	}
-
 	public void cycleAccountLookupRetries() {
 		accountLookupRetries.update(1);
 	}
@@ -81,7 +70,6 @@ public class MiscSpeedometers {
 
 	public static final class Names {
 		static final String SYNC_VERIFICATIONS = "sigVerifySync/sec";
-		static final String ASYNC_VERIFICATIONS = "sigVerifyAsync/sec";
 		static final String ACCOUNT_LOOKUP_RETRIES = "acctLookupRetries/sec";
 		static final String PLATFORM_TXN_REJECTIONS = "platformTxnNotCreated/sec";
 
@@ -93,8 +81,6 @@ public class MiscSpeedometers {
 	public static final class Descriptions {
 		static final String SYNC_VERIFICATIONS =
 				"number of transactions received per second that must be verified synchronously in handleTransaction";
-		static final String ASYNC_VERIFICATIONS =
-				"number of transactions received per second that were verified asynchronously via expandSignatures";
 		static final String ACCOUNT_LOOKUP_RETRIES =
 				"number of times per second that an account lookup must be retried";
 		static final String PLATFORM_TXN_REJECTIONS =

--- a/hedera-node/src/test/java/com/hedera/services/context/SideEffectsTrackerTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/context/SideEffectsTrackerTest.java
@@ -47,6 +47,7 @@ import java.util.TreeMap;
 import static com.hedera.services.state.enums.TokenType.FUNGIBLE_COMMON;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -119,6 +120,11 @@ class SideEffectsTrackerTest {
 	}
 
 	@Test
+	void usesSingletonForNoAutoAssociations() {
+		assertSame(Collections.emptyList(), subject.getTrackedAutoAssociations());
+	}
+
+	@Test
 	void tracksAndResetsAutoAssociationsAsExpected() {
 		final var expected = List.of(
 				new FcTokenAssociation(aToken.getTokenNum(), aAccount.getAccountNum()),
@@ -128,6 +134,7 @@ class SideEffectsTrackerTest {
 		subject.trackExplicitAutoAssociation(expected.get(1));
 
 		assertEquals(expected, subject.getTrackedAutoAssociations());
+		assertNotSame(subject.getInternalAutoAssociations(), subject.getTrackedAutoAssociations());
 
 		subject.reset();
 

--- a/hedera-node/src/test/java/com/hedera/services/state/logic/SigsAndPayerKeyScreenTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/state/logic/SigsAndPayerKeyScreenTest.java
@@ -127,14 +127,12 @@ class SigsAndPayerKeyScreenTest {
 	}
 
 	@Test
-	void cyclesAsyncWhenUsed() {
+	void doesntCyclesAsyncAnymore() {
 		givenOkRationalization();
 
-		// when:
 		subject.applyTo(accessor);
 
-		// then:
-		verify(speedometers).cycleAsyncVerifications();
+		verifyNoInteractions(speedometers);
 	}
 
 	private void givenOkRationalization() {

--- a/hedera-node/src/test/java/com/hedera/services/stats/MiscSpeedometersTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/stats/MiscSpeedometersTest.java
@@ -41,7 +41,7 @@ class MiscSpeedometersTest {
 	private MiscSpeedometers subject;
 
 	@BeforeEach
-	void setup() throws Exception {
+	void setup() {
 		factory = mock(SpeedometerFactory.class);
 		platform = mock(Platform.class);
 
@@ -51,17 +51,12 @@ class MiscSpeedometersTest {
 	@Test
 	void registersExpectedStatEntries() {
 		final var sync = mock(StatEntry.class);
-		final var async = mock(StatEntry.class);
 		final var retries = mock(StatEntry.class);
 		final var rejections = mock(StatEntry.class);
 		given(factory.from(
 				argThat(MiscSpeedometers.Names.SYNC_VERIFICATIONS::equals),
 				argThat(MiscSpeedometers.Descriptions.SYNC_VERIFICATIONS::equals),
 				any())).willReturn(sync);
-		given(factory.from(
-				argThat(MiscSpeedometers.Names.ASYNC_VERIFICATIONS::equals),
-				argThat(MiscSpeedometers.Descriptions.ASYNC_VERIFICATIONS::equals),
-				any())).willReturn(async);
 		given(factory.from(
 				argThat(MiscSpeedometers.Names.ACCOUNT_LOOKUP_RETRIES::equals),
 				argThat(MiscSpeedometers.Descriptions.ACCOUNT_LOOKUP_RETRIES::equals),
@@ -75,7 +70,6 @@ class MiscSpeedometersTest {
 
 		verify(platform).addAppStatEntry(retries);
 		verify(platform).addAppStatEntry(sync);
-		verify(platform).addAppStatEntry(async);
 		verify(platform).addAppStatEntry(rejections);
 	}
 
@@ -83,21 +77,17 @@ class MiscSpeedometersTest {
 	void cyclesExpectedSpeedometers() {
 		final var retries = mock(StatsSpeedometer.class);
 		final var sync = mock(StatsSpeedometer.class);
-		final var async = mock(StatsSpeedometer.class);
 		final var rejections = mock(StatsSpeedometer.class);
 		subject.accountLookupRetries = retries;
 		subject.syncVerifications = sync;
 		subject.platformTxnRejections = rejections;
-		subject.asyncVerifications = async;
 
 		subject.cycleAccountLookupRetries();
-		subject.cycleAsyncVerifications();
 		subject.cycleSyncVerifications();
 		subject.cyclePlatformTxnRejections();
 
 		verify(retries).update(1.0);
 		verify(rejections).update(1.0);
 		verify(sync).update(1.0);
-		verify(async).update(1.0);
 	}
 }

--- a/hedera-node/src/test/java/com/hedera/services/stats/MiscSpeedometersTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/stats/MiscSpeedometersTest.java
@@ -51,16 +51,11 @@ class MiscSpeedometersTest {
 	@Test
 	void registersExpectedStatEntries() {
 		final var sync = mock(StatEntry.class);
-		final var retries = mock(StatEntry.class);
 		final var rejections = mock(StatEntry.class);
 		given(factory.from(
 				argThat(MiscSpeedometers.Names.SYNC_VERIFICATIONS::equals),
 				argThat(MiscSpeedometers.Descriptions.SYNC_VERIFICATIONS::equals),
 				any())).willReturn(sync);
-		given(factory.from(
-				argThat(MiscSpeedometers.Names.ACCOUNT_LOOKUP_RETRIES::equals),
-				argThat(MiscSpeedometers.Descriptions.ACCOUNT_LOOKUP_RETRIES::equals),
-				any())).willReturn(retries);
 		given(factory.from(
 				argThat(MiscSpeedometers.Names.PLATFORM_TXN_REJECTIONS::equals),
 				argThat(MiscSpeedometers.Descriptions.PLATFORM_TXN_REJECTIONS::equals),
@@ -68,25 +63,20 @@ class MiscSpeedometersTest {
 
 		subject.registerWith(platform);
 
-		verify(platform).addAppStatEntry(retries);
 		verify(platform).addAppStatEntry(sync);
 		verify(platform).addAppStatEntry(rejections);
 	}
 
 	@Test
 	void cyclesExpectedSpeedometers() {
-		final var retries = mock(StatsSpeedometer.class);
 		final var sync = mock(StatsSpeedometer.class);
 		final var rejections = mock(StatsSpeedometer.class);
-		subject.accountLookupRetries = retries;
 		subject.syncVerifications = sync;
 		subject.platformTxnRejections = rejections;
 
-		subject.cycleAccountLookupRetries();
 		subject.cycleSyncVerifications();
 		subject.cyclePlatformTxnRejections();
 
-		verify(retries).update(1.0);
 		verify(rejections).update(1.0);
 		verify(sync).update(1.0);
 	}


### PR DESCRIPTION
**Description**:
- Removes the [`sigVerifyAsync/sec` stat](https://github.com/hashgraph/hedera-services/blob/master/hedera-node/src/main/java/com/hedera/services/stats/MiscSpeedometers.java#L84), as I have never seen it used---and in any case, its value is exactly `transH/sec - sigVerifySync/sec`. (Plus JProfiler claims updating this speedometer is now ~1% of the time spent in handling a simple `CryptoTransfer`!)
- Removes the [vestigial `acctLookupRetries/sec` stat](https://github.com/hashgraph/hedera-services/blob/master/hedera-node/src/main/java/com/hedera/services/stats/MiscSpeedometers.java#L85); no existing code path uses this speedometer.
- Stops creating a [new auto-associations `ArrayList` for **every** record](https://github.com/hashgraph/hedera-services/blob/master/hedera-node/src/main/java/com/hedera/services/state/submerkle/ExpirableTxnRecord.java#L149); instead updates `SideEffectsTracker` to return [an `ArrayList` that is safe](https://github.com/hashgraph/hedera-services/blob/skip-unnecessary-work/hedera-node/src/main/java/com/hedera/services/context/SideEffectsTracker.java#L296) for the `ExpirableTxnRecord` to use directly.
 