### PR TITLE
Call `FileUtils.cleanDirectory()` before extracting upgrade ZIP

### DIFF
--- a/hedera-node/src/main/java/com/hedera/services/txns/network/UpgradeActions.java
+++ b/hedera-node/src/main/java/com/hedera/services/txns/network/UpgradeActions.java
@@ -24,12 +24,14 @@ import com.hedera.services.context.properties.GlobalDynamicProperties;
 import com.hedera.services.state.merkle.MerkleNetworkContext;
 import com.hedera.services.state.merkle.MerkleSpecialFiles;
 import com.swirlds.common.SwirldDualState;
+import org.apache.commons.io.FileUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import javax.annotation.Nullable;
 import javax.inject.Inject;
 import javax.inject.Singleton;
+import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.OpenOption;
@@ -148,6 +150,7 @@ public class UpgradeActions {
 		log.info("About to unzip {} bytes for {} update into {}", size, desc, artifactsLoc);
 		return runAsync(() -> {
 			try {
+				FileUtils.cleanDirectory(new File(artifactsLoc));
 				unzipAction.unzip(archiveData, artifactsLoc);
 				log.info("Finished unzipping {} bytes for {} update into {}", size, desc, artifactsLoc);
 				writeSecondMarker(marker, now);

--- a/hedera-node/src/test/java/com/hedera/services/txns/network/UpgradeActionsTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/txns/network/UpgradeActionsTest.java
@@ -29,6 +29,7 @@ import com.hedera.test.extensions.LoggingSubject;
 import com.hedera.test.extensions.LoggingTarget;
 import com.hedera.test.utils.IdUtils;
 import com.swirlds.platform.state.DualStateImpl;
+import org.apache.commons.io.FileUtils;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -96,12 +97,8 @@ class UpgradeActionsTest {
 	}
 
 	@AfterAll
-	static void cleanup() {
-		List.of(
-				EXEC_IMMEDIATE_MARKER,
-				FREEZE_ABORTED_MARKER,
-				FREEZE_SCHEDULED_MARKER,
-				NOW_FROZEN_MARKER).forEach(UpgradeActionsTest::rmIfPresent);
+	static void cleanup() throws IOException {
+		FileUtils.deleteDirectory(new File(markerFilesLoc));
 	}
 
 	@Test
@@ -215,6 +212,7 @@ class UpgradeActionsTest {
 
 	@Test
 	void complainsLoudlyWhenUnableToUnzipArchive() throws IOException {
+		new File(markerFilesLoc).mkdirs();
 		rmIfPresent(EXEC_IMMEDIATE_MARKER);
 
 		given(dynamicProperties.upgradeArtifactsLoc()).willReturn(markerFilesLoc);
@@ -433,7 +431,7 @@ class UpgradeActionsTest {
 
 	private void setupNoiseFiles() throws IOException {
 		final var noiseDir = new File(noiseDirLoc);
-		noiseDir.mkdir();
+		noiseDir.mkdirs();
 		Files.write(Paths.get(noiseFileLoc),
 				List.of("There, the eyes are", "Sunlight on a broken column", "There, is a tree swinging"));
 		Files.write(Paths.get(noiseSubFileLoc),

--- a/hedera-node/src/test/java/com/hedera/services/txns/network/UpgradeActionsTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/txns/network/UpgradeActionsTest.java
@@ -38,6 +38,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import javax.annotation.Nullable;
+import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -65,6 +66,9 @@ import static org.mockito.Mockito.verify;
 class UpgradeActionsTest {
 	private static final Instant then = Instant.ofEpochSecond(1_234_567L, 890);
 	private static final String markerFilesLoc = "src/test/resources/upgrade";
+	private static final String noiseDirLoc = markerFilesLoc + "/outdated";
+	private static final String noiseFileLoc = markerFilesLoc + "/old-config.txt";
+	private static final String noiseSubFileLoc = noiseDirLoc + "/forgotten.cfg";
 	private static final String otherMarkerFilesLoc = "src/test/resources/upgrade/edargpu";
 	private static final byte[] PRETEND_ARCHIVE =
 			"This is missing something. Hard to put a finger on what...".getBytes(StandardCharsets.UTF_8);
@@ -230,6 +234,7 @@ class UpgradeActionsTest {
 
 	@Test
 	void preparesForUpgrade() throws IOException {
+		setupNoiseFiles();
 		rmIfPresent(EXEC_IMMEDIATE_MARKER);
 
 		given(dynamicProperties.upgradeArtifactsLoc()).willReturn(markerFilesLoc);
@@ -238,6 +243,7 @@ class UpgradeActionsTest {
 
 		verify(unzipAction).unzip(PRETEND_ARCHIVE, markerFilesLoc);
 		assertMarkerCreated(EXEC_IMMEDIATE_MARKER, null);
+		assertNoiseFilesAreGone();
 	}
 
 	@Test
@@ -423,5 +429,20 @@ class UpgradeActionsTest {
 		} else {
 			assertEquals(UpgradeActions.MARK, contents);
 		}
+	}
+
+	private void setupNoiseFiles() throws IOException {
+		final var noiseDir = new File(noiseDirLoc);
+		noiseDir.mkdir();
+		Files.write(Paths.get(noiseFileLoc),
+				List.of("There, the eyes are", "Sunlight on a broken column", "There, is a tree swinging"));
+		Files.write(Paths.get(noiseSubFileLoc),
+				List.of("And voices are", "In the wind's singing", "More distant and more solemn", "Than a fading star"));
+	}
+
+	private void assertNoiseFilesAreGone() {
+		assertFalse(new File(noiseDirLoc).exists());
+		assertFalse(new File(noiseFileLoc).exists());
+		assertFalse(new File(noiseSubFileLoc).exists());
 	}
 }


### PR DESCRIPTION
**Description**:
- Before extracting an upgrade ZIP---either software or telemetry---calls [`FileUtils.cleanDirectory()`](https://commons.apache.org/proper/commons-io/apidocs/org/apache/commons/io/FileUtils.html#cleanDirectory-java.io.File-) on the `upgrade.artifacts.path` location. (I.e., _/opt/hgcapp/services-hedera/HapiApp2.0/data/upgrade/current_ in prod environments.)

**Related issue(s)**:
 - Closes #2846
