### PR TITLE
Fix incorrect +1 for key update in contract with simultaneous removal

### DIFF
--- a/hedera-node/src/main/java/com/hedera/services/store/contracts/SizeLimitedStorage.java
+++ b/hedera-node/src/main/java/com/hedera/services/store/contracts/SizeLimitedStorage.java
@@ -30,6 +30,8 @@ import com.hedera.services.utils.EntityNum;
 import com.hederahashgraph.api.proto.java.AccountID;
 import com.swirlds.merkle.map.MerkleMap;
 import com.swirlds.virtualmap.VirtualMap;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.units.bigints.UInt256;
 
 import javax.inject.Inject;
@@ -48,7 +50,6 @@ import static com.hedera.services.ledger.properties.AccountProperty.NUM_CONTRACT
 import static com.hedera.services.utils.EntityNum.fromLong;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.MAX_CONTRACT_STORAGE_EXCEEDED;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.MAX_STORAGE_IN_PRICE_REGIME_HAS_BEEN_USED;
-import static java.util.Objects.requireNonNull;
 import static org.apache.tuweni.units.bigints.UInt256.ZERO;
 
 /**
@@ -61,6 +62,8 @@ import static org.apache.tuweni.units.bigints.UInt256.ZERO;
  */
 @Singleton
 public class SizeLimitedStorage {
+	private static final Logger log = LogManager.getLogger(SizeLimitedStorage.class);
+
 	public static final ContractValue ZERO_VALUE = ContractValue.from(ZERO);
 
 	/* Used to get the key/value storage limits */
@@ -223,19 +226,18 @@ public class SizeLimitedStorage {
 		final Long contractId = key.getContractId();
 		final var hasPendingUpdate = newMappings.containsKey(key);
 		final var wasAlreadyPresent = storage.containsKey(key);
-		/* We always buffer the new mapping. */
+		// We always buffer the new mapping
 		newMappings.put(key, value);
 		if (hasPendingUpdate) {
-			/* If there was already a pending update, nothing has changed. */
+			// If there was already a pending update, net storage usage hasn't changed
 			return 0;
 		} else {
-			/* Otherwise update the contract's change set. */
+			// Otherwise update the contract's change set
 			updatedKeys.computeIfAbsent(contractId, treeSetFactory).add(key);
-			/* And drop any pending removal, returning 1 since a pending removal implies we
-			 * were about to reduce the storage used by a mapping. */
+			// Was this key about to be removed?
 			final var scopedRemovals = removedKeys.get(contractId);
-			if (scopedRemovals != null) {
-				scopedRemovals.remove(key);
+			if (scopedRemovals != null && scopedRemovals.remove(key)) {
+				// No longer, and net storage usage goes back up by 1
 				return 1;
 			}
 			return wasAlreadyPresent ? 0 : 1;
@@ -254,23 +256,25 @@ public class SizeLimitedStorage {
 		final var wasAlreadyPresent = storage.containsKey(key);
 		if (hasPendingUpdate || wasAlreadyPresent) {
 			if (hasPendingUpdate) {
-				/* We need to drop any pending update from our auxiliary data structures. */
+				// We need to drop any pending update from our auxiliary data structures.
 				final var scopedAdditions = updatedKeys.get(contractId);
-				requireNonNull(scopedAdditions,
-						() -> "A new mapping " + key + " -> " + newMappings.get(key)
-								+ " did not belong to a key addition set");
+				if (scopedAdditions == null) {
+					final var detailMsg = "A new mapping " + key + " -> " + newMappings.get(key)
+							+ " did not belong to a key addition set";
+					throw new IllegalStateException(detailMsg);
+				}
 				scopedAdditions.remove(key);
 				newMappings.remove(key);
 			}
 			if (wasAlreadyPresent) {
-				/* If there was no extant mapping for this key, no reason to explicitly remove it when we commit. */
+				// If there was no extant mapping for this key, no reason to explicitly remove it when we commit.
 				removedKeys.computeIfAbsent(key.getContractId(), treeSetFactory).add(key);
 			}
-			/* But no matter what, relative to our existing change set, this removed one mapping. */
+			// But no matter what, relative to our existing change set, this removed one mapping.
 			return -1;
 		} else {
-			/* If this key didn't have a mapping or a pending change, it doesn't affect the size,
-			 * and there is also no reason to explicitly remove it when we commit. */
+			// If this key didn't have a mapping or a pending change, it doesn't affect the size,
+			// and there is also no reason to explicitly remove it when we commit
 			return 0;
 		}
 	}

--- a/hedera-node/src/test/java/com/hedera/services/store/contracts/SizeLimitedStorageTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/store/contracts/SizeLimitedStorageTest.java
@@ -265,6 +265,22 @@ class SizeLimitedStorageTest {
 	}
 
 	@Test
+	void incorporatesNewUpdateWithOtherContractKeyBeingRemoved() {
+		given(storage.containsKey(firstAKey)).willReturn(true);
+		removedKeys.computeIfAbsent(firstAKey.getContractId(), treeSetFactory).add(firstBKey);
+		final var kvImpact = incorporateKvImpact(
+				firstAKey, aValue,
+				updatedKeys, removedKeys, newMappings,
+				storage);
+
+		assertEquals(0, kvImpact);
+		assertEquals(aValue, newMappings.get(firstAKey));
+		assertTrue(updatedKeys.containsKey(firstAKey.getContractId()));
+		assertEquals(firstAKey, updatedKeys.get(firstAKey.getContractId()).first());
+		assertFalse(removedKeys.get(firstAKey.getContractId()).contains(firstAKey));
+	}
+
+	@Test
 	void incorporatesOverwriteOfPendingUpdate() {
 		given(storage.containsKey(firstAKey)).willReturn(true);
 		newMappings.put(firstAKey, aValue);
@@ -335,7 +351,7 @@ class SizeLimitedStorageTest {
 	@Test
 	void aPendingChangeMustBeReflectedInAnAdditionSet() {
 		newMappings.put(firstAKey, aValue);
-		assertThrows(NullPointerException.class, () -> incorporateKvImpact(
+		assertThrows(IllegalStateException.class, () -> incorporateKvImpact(
 				firstAKey, ZERO_VALUE,
 				updatedKeys, removedKeys, newMappings,
 				storage));


### PR DESCRIPTION
**Description**:
 - Only add 1 to contract storage usage if a key update for a contract with simultaneous removals actually restores a pending removal.

**Related issue(s)**:
- Fixes #3028
