### PR TITLE
Include additional fields needed for traceability in precompile ContractFunctionResult #2933 

### DIFF
--- a/hedera-node/src/main/java/com/hedera/services/store/contracts/precompile/HTSPrecompiledContract.java
+++ b/hedera-node/src/main/java/com/hedera/services/store/contracts/precompile/HTSPrecompiledContract.java
@@ -538,9 +538,6 @@ public class HTSPrecompiledContract extends AbstractPrecompiledContract {
 			final Optional<ResponseCodeEnum> errorStatus,
 			final MessageFrame messageFrame
 	) {
-		// Add additional values for traceability when the transaction body is not ContractCall or ContractCreate
-		// Currently, all but the `ERCReadOnlyAbstractPrecompile` precompiles fall into this category
-		final var shouldEnrichForTraceability = !(this.precompile instanceof ERCReadOnlyAbstractPrecompile);
 		if (dynamicProperties.shouldExportPrecompileResults()) {
 			final var evmFnResult = new EvmFnResult(
 					HTS_PRECOMPILE_MIRROR_ENTITY_ID,
@@ -552,9 +549,10 @@ public class HTSPrecompiledContract extends AbstractPrecompiledContract {
 					Collections.emptyList(),
 					EvmFnResult.EMPTY,
 					Collections.emptyMap(),
-					shouldEnrichForTraceability ? messageFrame.getRemainingGas().toLong() : 0L,
-					shouldEnrichForTraceability ? messageFrame.getValue().toLong() : 0L,
-					shouldEnrichForTraceability ? messageFrame.getInputData().toArrayUnsafe() : EvmFnResult.EMPTY);
+					precompile.shouldAddTraceabilityFieldsToRecord() ? messageFrame.getRemainingGas().toLong() : 0L,
+					precompile.shouldAddTraceabilityFieldsToRecord() ? messageFrame.getValue().toLong() : 0L,
+					precompile.shouldAddTraceabilityFieldsToRecord() ? messageFrame.getInputData().toArrayUnsafe() :
+							EvmFnResult.EMPTY);
 			childRecord.setContractCallResult(evmFnResult);
 		}
 	}
@@ -655,6 +653,10 @@ public class HTSPrecompiledContract extends AbstractPrecompiledContract {
 
 		default List<FcAssessedCustomFee> getCustomFees() {
 			return NO_CUSTOM_FEES;
+		}
+
+		default boolean shouldAddTraceabilityFieldsToRecord() {
+			return true;
 		}
 	}
 
@@ -1079,6 +1081,11 @@ public class HTSPrecompiledContract extends AbstractPrecompiledContract {
 		@Override
 		public long getMinimumFeeInTinybars(final Timestamp consensusTime) {
 			return 100;
+		}
+
+		@Override
+		public boolean shouldAddTraceabilityFieldsToRecord() {
+			return false;
 		}
 	}
 

--- a/hedera-node/src/test/java/com/hedera/services/state/serdes/DomainSerdesTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/state/serdes/DomainSerdesTest.java
@@ -426,7 +426,9 @@ public class DomainSerdesTest {
 						.setErrorMessage("Couldn't figure it out immediately!")
 						.setGasUsed(55L)
 						.addLogInfo(ContractLoginfo.newBuilder()
-								.setData(ByteString.copyFrom("Nonsensical!".getBytes()))).build()))
+								.setData(ByteString.copyFrom("Nonsensical!".getBytes())))
+						.setGas(1_000_000L)
+						.setFunctionParameters(ByteString.copyFrom("Sensible!".getBytes())).build()))
 				.build();
 	}
 }

--- a/hedera-node/src/test/java/com/hedera/services/state/submerkle/EvmFnResultSerdeTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/state/submerkle/EvmFnResultSerdeTest.java
@@ -32,6 +32,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 
+import static com.hedera.services.state.submerkle.EvmFnResult.RELEASE_0250_VERSION;
 import static com.hedera.test.utils.TxnUtils.assertSerdeWorks;
 import static com.hedera.services.state.submerkle.ExpirableTxnRecordSerdeTest.randomAddress;
 import static com.hedera.services.state.submerkle.ExpirableTxnRecordSerdeTest.randomBytes;
@@ -39,7 +40,6 @@ import static com.hedera.services.state.submerkle.ExpirableTxnRecordSerdeTest.ra
 import static com.hedera.services.state.submerkle.ExpirableTxnRecordSerdeTest.randomEvmWord;
 import static com.hedera.services.state.submerkle.ExpirableTxnRecordSerdeTest.randomStateChangePair;
 import static com.hedera.services.state.submerkle.ExpirableTxnRecordSerdeTest.registerRecordConstructables;
-import static com.hedera.services.state.submerkle.EvmFnResult.RELEASE_0240_VERSION;
 
 class EvmFnResultSerdeTest {
 	@Test
@@ -55,9 +55,12 @@ class EvmFnResultSerdeTest {
 				List.of(),
 				List.of(),
 				randomBytes(20),
-				Collections.emptyMap());
+				Collections.emptyMap(),
+				123321,
+				1233211233,
+				randomBytes(64));
 
-		assertSerdeWorks(subject, EvmFnResult::new, RELEASE_0240_VERSION);
+		assertSerdeWorks(subject, EvmFnResult::new, RELEASE_0250_VERSION);
 	}
 
 	@Test
@@ -74,9 +77,12 @@ class EvmFnResultSerdeTest {
 					List.of(),
 					List.of(),
 					randomBytes(20),
-					randomStateChanges(5, 10));
+					randomStateChanges(5, 10),
+					123321,
+					1233211233,
+					randomBytes(64));
 
-			assertSerdeWorks(subject, EvmFnResult::new, RELEASE_0240_VERSION);
+			assertSerdeWorks(subject, EvmFnResult::new, RELEASE_0250_VERSION);
 		}
 	}
 

--- a/hedera-node/src/test/java/com/hedera/services/state/submerkle/EvmFnResultTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/state/submerkle/EvmFnResultTest.java
@@ -298,12 +298,82 @@ class EvmFnResultTest {
 				stateChanges,
 				gas,
 				amount,
-				"randomFunctionParameters".getBytes());
+				functionParameters);
+		final var five = new EvmFnResult(
+				contractId,
+				result,
+				"AnotherError",
+				bloom,
+				gasUsed,
+				logs,
+				createdContractIds,
+				evmAddress,
+				stateChanges,
+				gas,
+				amount,
+				functionParameters);
+		final var six = new EvmFnResult(
+				contractId,
+				result,
+				error,
+				bloom,
+				gasUsed,
+				List.of(logFrom(1)),
+				createdContractIds,
+				evmAddress,
+				stateChanges,
+				gas,
+				amount,
+				functionParameters);
+		final var seven = new EvmFnResult(
+				contractId,
+				result,
+				error,
+				bloom,
+				gasUsed,
+				logs,
+				List.of(new EntityId(1L, 1L, 42L)),
+				evmAddress,
+				stateChanges,
+				gas,
+				amount,
+				functionParameters);
+		final var eight = new EvmFnResult(
+				contractId,
+				result,
+				error,
+				bloom,
+				gasUsed,
+				logs,
+				createdContractIds,
+				evmAddress,
+				Collections.emptyMap(),
+				gas,
+				amount,
+				functionParameters);
+		final var nine = new EvmFnResult(
+				contractId,
+				result,
+				error,
+				bloom,
+				gasUsed,
+				logs,
+				createdContractIds,
+				evmAddress,
+				stateChanges,
+				gas,
+				amount,
+				"randomParameters".getBytes());
 
 		assertNotEquals(null, one);
 		assertNotEquals(new Object(), one);
 		assertNotEquals(one, two);
 		assertNotEquals(one, four);
+		assertNotEquals(one, five);
+		assertNotEquals(one, six);
+		assertNotEquals(one, seven);
+		assertNotEquals(one, eight);
+		assertNotEquals(one, nine);
 		assertEquals(one, three);
 
 		assertNotEquals(one.hashCode(), two.hashCode());

--- a/hedera-node/src/test/java/com/hedera/services/state/submerkle/ExpirableTxnRecordTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/state/submerkle/ExpirableTxnRecordTest.java
@@ -695,7 +695,7 @@ class ExpirableTxnRecordTest {
 				" " +
 				"contractId=EntityId{shard=4, realm=3, num=2}, createdContractIds=[], " +
 				"logs=[EvmLog{data=4e6f6e73656e736963616c21, bloom=, contractId=null, topics=[]}], " +
-				"stateChanges={}, evmAddress=}, " +
+				"stateChanges={}, evmAddress=, gas=1000000, amount=0, functionParameters=53656e7369626c6521}, " +
 				"hbarAdjustments=CurrencyAdjustments{readable=[0.0.2 -> -4, 0.0.1001 <- +2, 0.0.1002 <- +2]}, " +
 				"scheduleRef=EntityId{shard=5, realm=6, num=7}, alias=test, parentConsensusTime=1970-01-15T06:56:07" +
 				".000000890Z, tokenAdjustments=0.0.3(CurrencyAdjustments{readable=[0.0.5 -> -1, 0.0.6 <- +1, 0.0.7 <-" +
@@ -721,7 +721,7 @@ class ExpirableTxnRecordTest {
 				"memo=Alpha bravo charlie, contractCreation=EvmFnResult{gasUsed=55, bloom=, result=, error=null, " +
 				"contractId=EntityId{shard=4, realm=3, num=2}, createdContractIds=[], " +
 				"logs=[EvmLog{data=4e6f6e73656e736963616c21, bloom=, contractId=null, topics=[]}], " +
-				"stateChanges={}, evmAddress=}, " +
+				"stateChanges={}, evmAddress=, gas=1000000, amount=0, functionParameters=53656e7369626c6521}, " +
 				"hbarAdjustments=CurrencyAdjustments{readable=[0.0.2 -> -4, 0.0.1001 <- +2, 0.0.1002 <- +2]}, " +
 				"scheduleRef=EntityId{shard=5, realm=6, num=7}, alias=test, tokenAdjustments=0.0.3" +
 				"(CurrencyAdjustments{readable=[0.0.5 -> -1, 0.0.6 <- +1, 0.0.7 <- +1000]}), 0.0.4" +
@@ -748,7 +748,7 @@ class ExpirableTxnRecordTest {
 				" " +
 				"contractId=EntityId{shard=4, realm=3, num=2}, createdContractIds=[], " +
 				"logs=[EvmLog{data=4e6f6e73656e736963616c21, bloom=, contractId=null, topics=[]}], " +
-				"stateChanges={}, evmAddress=}, " +
+				"stateChanges={}, evmAddress=, gas=1000000, amount=0, functionParameters=53656e7369626c6521}, " +
 				"hbarAdjustments=CurrencyAdjustments{readable=[0.0.2 -> -4, 0.0.1001 <- +2, 0.0.1002 <- +2]}, " +
 				"scheduleRef=EntityId{shard=5, realm=6, num=7}, alias=test, parentConsensusTime=1970-01-15T06:56:07" +
 				".000000890Z, tokenAdjustments=0.0.3(CurrencyAdjustments{readable=[0.0.5 -> -1, 0.0.6 <- +1, 0.0.7 <-" +

--- a/hedera-node/src/test/java/com/hedera/services/store/contracts/precompile/ERC20PrecompilesTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/store/contracts/precompile/ERC20PrecompilesTest.java
@@ -44,6 +44,7 @@ import com.hedera.services.state.merkle.MerkleAccount;
 import com.hedera.services.state.merkle.MerkleToken;
 import com.hedera.services.state.merkle.MerkleTokenRelStatus;
 import com.hedera.services.state.merkle.MerkleUniqueToken;
+import com.hedera.services.state.submerkle.EvmFnResult;
 import com.hedera.services.state.submerkle.ExpirableTxnRecord;
 import com.hedera.services.store.contracts.HederaStackedWorldStateUpdater;
 import com.hedera.services.store.contracts.WorldLedgers;
@@ -70,6 +71,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
@@ -367,6 +369,8 @@ class ERC20PrecompilesTest {
                 .willReturn(1L);
         given(encoder.encodeName(any())).willReturn(successResult);
         given(tokens.get(token, TOKEN_TYPE)).willReturn(TokenType.FUNGIBLE_COMMON);
+        given(dynamicProperties.shouldExportPrecompileResults()).willReturn(true);
+
         // when:
         subject.prepareFields(frame);
         subject.prepareComputation(pretendArguments, а -> а);
@@ -378,6 +382,11 @@ class ERC20PrecompilesTest {
         // and:
         verify(wrappedLedgers).commit();
         verify(worldUpdater).manageInProgressRecord(recordsHistorian, mockRecordBuilder, mockSynthBodyBuilder);
+        ArgumentCaptor<EvmFnResult> captor = ArgumentCaptor.forClass(EvmFnResult.class);
+        verify(mockRecordBuilder).setContractCallResult(captor.capture());
+        assertEquals(0L, captor.getValue().getGas());
+        assertEquals(0L, captor.getValue().getAmount());
+        assertEquals(EvmFnResult.EMPTY, captor.getValue().getFunctionParameters());
     }
 
     @Test

--- a/hedera-node/src/test/java/com/hedera/services/store/contracts/precompile/TransferPrecompilesTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/store/contracts/precompile/TransferPrecompilesTest.java
@@ -65,8 +65,9 @@ import com.hederahashgraph.fee.FeeObject;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.units.bigints.UInt256;
-import org.hamcrest.Matchers;
 import org.hyperledger.besu.datatypes.Address;
+import org.hyperledger.besu.datatypes.Wei;
+import org.hyperledger.besu.evm.Gas;
 import org.hyperledger.besu.evm.frame.MessageFrame;
 import org.hyperledger.besu.evm.gascalculator.GasCalculator;
 import org.hyperledger.besu.evm.worldstate.WorldUpdater;
@@ -252,6 +253,9 @@ class TransferPrecompilesTest {
 		given(creator.createUnsuccessfulSyntheticRecord(TRANSFERS_NOT_ZERO_SUM_FOR_TOKEN))
 				.willReturn(mockRecordBuilder);
 		given(dynamicProperties.shouldExportPrecompileResults()).willReturn(true);
+		given(frame.getRemainingGas()).willReturn(Gas.of(100L));
+		given(frame.getValue()).willReturn(Wei.ONE);
+		given(frame.getInputData()).willReturn(pretendArguments);
 
 		// when:
 		subject.prepareFields(frame);
@@ -264,6 +268,9 @@ class TransferPrecompilesTest {
 		ArgumentCaptor<EvmFnResult> captor = ArgumentCaptor.forClass(EvmFnResult.class);
 		verify(mockRecordBuilder).setContractCallResult(captor.capture());
 		assertEquals(TRANSFERS_NOT_ZERO_SUM_FOR_TOKEN.name(), captor.getValue().getError());
+		assertEquals(100L, captor.getValue().getGas());
+		assertEquals(1L, captor.getValue().getAmount());
+		assertEquals(pretendArguments.toArrayUnsafe(), captor.getValue().getFunctionParameters());
 	}
 
 	@Test

--- a/hedera-node/src/test/java/com/hedera/test/utils/SerdeUtils.java
+++ b/hedera-node/src/test/java/com/hedera/test/utils/SerdeUtils.java
@@ -103,7 +103,10 @@ public class SerdeUtils {
 								() -> new TreeMap<>(BytesComparator.INSTANCE)
 						)),
 						(l, r) -> l,
-						() -> new TreeMap<>(BytesComparator.INSTANCE)))
+						() -> new TreeMap<>(BytesComparator.INSTANCE))),
+				that.getGas(),
+				that.getAmount(),
+				that.getFunctionParameters().isEmpty() ? EvmFnResult.EMPTY : that.getFunctionParameters().toByteArray()
 		);
 	}
 

--- a/pom.xml
+++ b/pom.xml
@@ -122,7 +122,7 @@
 			</snapshots>
 			<id>proto-staging</id>
 			<name>0.24.x Protobufs</name>
-			<url>https://oss.sonatype.org/content/repositories/comhederahashgraph-1410</url>
+			<url>https://oss.sonatype.org/content/repositories/comhederahashgraph-1418</url>
 		</repository>
 	</repositories>
 	<distributionManagement>
@@ -172,7 +172,7 @@
 		<ethereum-core.version>1.12.0-v0.5.0</ethereum-core.version>
 		<grpc.version>1.39.0</grpc.version>
 		<guava.version>31.1-jre</guava.version>
-		<hapi-proto.version>0.24.0-alpha.3</hapi-proto.version>
+		<hapi-proto.version>0.25.0-alpha.2</hapi-proto.version>
 		<headlong.version>6.0.2</headlong.version>
 		<javax.annotation-api.version>1.3.2</javax.annotation-api.version>
 		<javax-inject.version>1</javax-inject.version>

--- a/test-clients/src/main/java/com/hedera/services/bdd/spec/assertions/ContractFnResultAsserts.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/spec/assertions/ContractFnResultAsserts.java
@@ -32,6 +32,7 @@ import com.hederahashgraph.api.proto.java.ContractLoginfo;
 import com.swirlds.common.CommonUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.tuweni.bytes.Bytes;
 import org.ethereum.core.CallTransaction;
 import org.junit.jupiter.api.Assertions;
 
@@ -135,6 +136,36 @@ public class ContractFnResultAsserts extends BaseErroringAssertsProvider<Contrac
 					ByteString.copyFrom(contractCallResult.getBytes().toArray()),
 					result.getContractCallResult(),
 					"Wrong contract call result!");
+		});
+		return this;
+	}
+
+	public ContractFnResultAsserts gas(long gas) {
+		registerProvider((spec, o) -> {
+			ContractFunctionResult result = (ContractFunctionResult) o;
+			Assertions.assertEquals(
+					gas, result.getGas(),
+					"Wrong amount of initial Gas!");
+		});
+		return this;
+	}
+
+	public ContractFnResultAsserts amount(long amount) {
+		registerProvider((spec, o) -> {
+			ContractFunctionResult result = (ContractFunctionResult) o;
+			Assertions.assertEquals(
+					amount, result.getAmount(),
+					"Wrong amount of tinybars!");
+		});
+		return this;
+	}
+
+	public ContractFnResultAsserts functionParameters(Bytes functionParameters) {
+		registerProvider((spec, o) -> {
+			ContractFunctionResult result = (ContractFunctionResult) o;
+			Assertions.assertEquals(
+					ByteString.copyFrom(functionParameters.toArray()), result.getFunctionParameters(),
+					"Wrong function parameters!");
 		});
 		return this;
 	}

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/ContractMintHTSSuite.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/ContractMintHTSSuite.java
@@ -20,10 +20,12 @@ package com.hedera.services.bdd.suites.contract.precompile;
  * ‍
  */
 
+import com.google.protobuf.ByteString;
 import com.hedera.services.bdd.spec.HapiApiSpec;
 import com.hedera.services.bdd.spec.assertions.NonFungibleTransfers;
 import com.hedera.services.bdd.spec.infrastructure.meta.ContractResources;
 import com.hedera.services.bdd.spec.keys.KeyShape;
+import com.hedera.services.bdd.spec.utilops.CustomSpecAssert;
 import com.hedera.services.bdd.suites.HapiApiSuite;
 import com.hedera.services.bdd.suites.utils.contracts.precompile.HTSPrecompileResult;
 import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
@@ -68,6 +70,7 @@ import static com.hedera.services.bdd.spec.transactions.TxnVerbs.tokenCreate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.tokenUpdate;
 import static com.hedera.services.bdd.spec.transactions.token.TokenMovement.moving;
 import static com.hedera.services.bdd.spec.utilops.CustomSpecAssert.allRunFor;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.assertionsHold;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.childRecordsCheck;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.newKeyNamed;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.sourcing;
@@ -76,8 +79,10 @@ import static com.hedera.services.bdd.spec.utilops.UtilVerbs.withOpContext;
 import static com.hedera.services.bdd.suites.contract.Utils.asAddress;
 import static com.hedera.services.bdd.suites.contract.Utils.extractByteCode;
 import static com.hedera.services.bdd.suites.contract.Utils.parsedToByteString;
+import static com.hedera.services.bdd.suites.utils.contracts.FunctionParameters.functionParameters;
 import static com.hedera.services.bdd.suites.utils.contracts.precompile.HTSPrecompileResult.htsPrecompileResult;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SUCCESS;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ContractMintHTSSuite extends HapiApiSuite {
 	private static final Logger log = LogManager.getLogger(ContractMintHTSSuite.class);
@@ -381,6 +386,8 @@ public class ContractMintHTSSuite extends HapiApiSuite {
 										)
 						)
 				).then(
+						assertTxnRecordHasNoTraceabilityEnrichedContractFnResult(nestedTransferTxn),
+						withOpContext((spec, opLog) -> allRunFor(spec,
 						getTxnRecord(nestedTransferTxn).andAllChildRecords().logged(),
 						childRecordsCheck(nestedTransferTxn, SUCCESS,
 								recordWith()
@@ -394,6 +401,15 @@ public class ContractMintHTSSuite extends HapiApiSuite {
 																.withTotalSupply(1L)
 																.withSerialNumbers(1L)
 														)
+														.gas(3_838_735L)
+														.amount(0L)
+														.functionParameters(functionParameters()
+																.forMintToken(
+																		asAddress(spec.registry()
+																				.getTokenID(nonFungibleToken)),
+																		0L,
+																		Arrays.asList("Test metadata 1"))
+														)
 										),
 								recordWith()
 										.status(SUCCESS)
@@ -401,7 +417,7 @@ public class ContractMintHTSSuite extends HapiApiSuite {
 												.changingNFTBalances()
 												.including(nonFungibleToken, TOKEN_TREASURY, theRecipient, 1)
 										)
-						)
+						)))
 				);
 	}
 
@@ -513,6 +529,22 @@ public class ContractMintHTSSuite extends HapiApiSuite {
 				).then(
 						getAccountBalance(TOKEN_TREASURY).hasTokenBalance(nonFungibleToken, 0)
 				);
+	}
+
+	@NotNull
+	private CustomSpecAssert assertTxnRecordHasNoTraceabilityEnrichedContractFnResult(final String nestedTransferTxn) {
+		return assertionsHold((spec, log) -> {
+			var subOp = getTxnRecord(nestedTransferTxn);
+			allRunFor(spec, subOp);
+
+			var record = subOp.getResponseRecord();
+
+			final var contractCallResult =
+					record.getContractCallResult();
+			assertEquals(0L, contractCallResult.getGas());
+			assertEquals(0L, contractCallResult.getAmount());
+			assertEquals(ByteString.EMPTY, contractCallResult.getFunctionParameters());
+		});
 	}
 
 	@NotNull

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/ContractMintHTSSuite.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/ContractMintHTSSuite.java
@@ -27,6 +27,7 @@ import com.hedera.services.bdd.spec.infrastructure.meta.ContractResources;
 import com.hedera.services.bdd.spec.keys.KeyShape;
 import com.hedera.services.bdd.spec.utilops.CustomSpecAssert;
 import com.hedera.services.bdd.suites.HapiApiSuite;
+import com.hedera.services.bdd.suites.utils.contracts.FunctionParameters;
 import com.hedera.services.bdd.suites.utils.contracts.precompile.HTSPrecompileResult;
 import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
 import com.hederahashgraph.api.proto.java.TokenSupplyType;
@@ -404,11 +405,12 @@ public class ContractMintHTSSuite extends HapiApiSuite {
 														.gas(3_838_735L)
 														.amount(0L)
 														.functionParameters(functionParameters()
-																.forMintToken(
-																		asAddress(spec.registry()
-																				.getTokenID(nonFungibleToken)),
-																		0L,
-																		Arrays.asList("Test metadata 1"))
+																.forFunction(FunctionParameters.PrecompileFunction.MINT)
+																.withTokenAddress(asAddress(spec.registry()
+																		.getTokenID(nonFungibleToken)))
+																.withAmount(0L)
+																.withMetadata(Arrays.asList("Test metadata 1"))
+																.build()
 														)
 										),
 								recordWith()

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/utils/contracts/FunctionParameters.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/utils/contracts/FunctionParameters.java
@@ -28,6 +28,9 @@ import org.apache.tuweni.bytes.Bytes;
 import java.math.BigInteger;
 import java.util.List;
 
+import static com.hedera.services.bdd.suites.utils.contracts.FunctionParameters.PrecompileFunction.MINT;
+
+// To be extended for the rest of the precompile functions
 public class FunctionParameters {
 	public static FunctionParameters functionParameters() {
 		return new FunctionParameters();
@@ -36,25 +39,53 @@ public class FunctionParameters {
 	private static final int ABI_ID_MINT_TOKEN = 0x278e0b88;
 	private static final TupleType mintTokenType = TupleType.parse("(address,uint64,bytes[])");
 
-	private int functionHash;
-	private Bytes functionParams;
+	public enum PrecompileFunction {
+		MINT
+	}
+
+	private PrecompileFunction precompileFunction;
+	private long amount;
+	private byte[] tokenAddress;
+	private List<String> metadata;
 
 	private FunctionParameters() {
 	}
 
-	public Bytes forMintToken(final byte[] address, final long amount, final List<String> metadata) {
-		this.functionHash = ABI_ID_MINT_TOKEN;
-		final var result = Tuple.of(
-				convertBesuAddressToHeadlongAddress(address),
-				BigInteger.valueOf(amount),
-				metadata.stream().map(String::getBytes).toArray(byte[][]::new)
-		);
-		this.functionParams = Bytes.wrap(mintTokenType.encode(result).array());
-		return getBytes();
+	public FunctionParameters forFunction(final PrecompileFunction precompileFunction) {
+		this.precompileFunction = precompileFunction;
+		return this;
 	}
 
-	private Bytes getBytes() {
-		return Bytes.concatenate(Bytes.ofUnsignedInt(functionHash), functionParams);
+	public FunctionParameters withTokenAddress(final byte[] tokenAddress) {
+		this.tokenAddress = tokenAddress;
+		return this;
+	}
+
+	public FunctionParameters withAmount(final long amount) {
+		this.amount = amount;
+		return this;
+	}
+
+	public FunctionParameters withMetadata(final List<String> metadata) {
+		this.metadata = metadata;
+		return this;
+	}
+
+	public Bytes build() {
+		var functionHash = Bytes.EMPTY;
+		var functionParams = Bytes.EMPTY;
+
+		if (MINT.equals(precompileFunction)) {
+			functionHash = Bytes.ofUnsignedInt(ABI_ID_MINT_TOKEN);
+			final var result = Tuple.of(
+					convertBesuAddressToHeadlongAddress(tokenAddress),
+					BigInteger.valueOf(amount),
+					metadata.stream().map(String::getBytes).toArray(byte[][]::new)
+			);
+			functionParams = Bytes.wrap(mintTokenType.encode(result).array());
+		}
+
+		return Bytes.concatenate(functionHash, functionParams);
 	}
 
 	private Address convertBesuAddressToHeadlongAddress(final byte[] address) {

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/utils/contracts/FunctionParameters.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/utils/contracts/FunctionParameters.java
@@ -1,0 +1,63 @@
+package com.hedera.services.bdd.suites.utils.contracts;
+
+/*-
+ * ‌
+ * Hedera Services Test Clients
+ * ​
+ * Copyright (C) 2018 - 2022 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import com.esaulpaugh.headlong.abi.Address;
+import com.esaulpaugh.headlong.abi.Tuple;
+import com.esaulpaugh.headlong.abi.TupleType;
+import org.apache.tuweni.bytes.Bytes;
+
+import java.math.BigInteger;
+import java.util.List;
+
+public class FunctionParameters {
+	public static FunctionParameters functionParameters() {
+		return new FunctionParameters();
+	}
+
+	private static final int ABI_ID_MINT_TOKEN = 0x278e0b88;
+	private static final TupleType mintTokenType = TupleType.parse("(address,uint64,bytes[])");
+
+	private int functionHash;
+	private Bytes functionParams;
+
+	private FunctionParameters() {
+	}
+
+	public Bytes forMintToken(final byte[] address, final long amount, final List<String> metadata) {
+		this.functionHash = ABI_ID_MINT_TOKEN;
+		final var result = Tuple.of(
+				convertBesuAddressToHeadlongAddress(address),
+				BigInteger.valueOf(amount),
+				metadata.stream().map(String::getBytes).toArray(byte[][]::new)
+		);
+		this.functionParams = Bytes.wrap(mintTokenType.encode(result).array());
+		return getBytes();
+	}
+
+	private Bytes getBytes() {
+		return Bytes.concatenate(Bytes.ofUnsignedInt(functionHash), functionParams);
+	}
+
+	private Address convertBesuAddressToHeadlongAddress(final byte[] address) {
+		return Address.wrap(Address.toChecksumAddress(new BigInteger(address)));
+	}
+}


### PR DESCRIPTION
**Description**:
This PR modifies `HTSPrecompiledContract` to include additional fields in the `ContractFunctionResult` of its transaction records in order to support precompile traceability from the mirror nodes.
* `gas`, `amount` and `functionParameters` fields have been added to `EvmFnResult` 
  - `gas` specifies the amount of gas available for the call
  - `amount` specifies the number of tinybars sent.  **NOTE** that currently EVM value transfers are not allowed.
  - `functionParameters` specifies the called called function and the parameters passed into the contract call
* Precompile calls to `HTSPrecompiledContract` now include the three fields in their transaction records whenever their corresponding transaction body is not of type `ContractCallTransactionBody` or `ContractCreateTransactionBody` (currently, this applies to all precompiles, except for those extending the `ERCReadOnlyAbstractPrecompile`

**Related issue(s)**:

Fixes #2933 


**Notes for reviewer**:
The E2E framework extension here is not complete. Extending it to support all precompile functions and adding their corresponding assertions to the rest of the precompile suites should be completed as part of this [issue](https://github.com/LimeChain/hedera-services/issues/830).

