### PR TITLE
Still use `Key{contractID=0.0.X}` form for explicit immutable contract creation

### DIFF
--- a/hedera-node/src/main/java/com/hedera/services/txns/contract/ContractCreateTransitionLogic.java
+++ b/hedera-node/src/main/java/com/hedera/services/txns/contract/ContractCreateTransitionLogic.java
@@ -111,6 +111,10 @@ public class ContractCreateTransitionLogic implements TransitionLogic {
 		var key = op.hasAdminKey()
 				? validator.attemptToDecodeOrThrow(op.getAdminKey(), SERIALIZATION_FAILED)
 				: STANDIN_CONTRACT_ID_KEY;
+		// Standardize immutable contract key format; c.f. https://github.com/hashgraph/hedera-services/issues/3037
+		if (key.isEmpty()) {
+			key = STANDIN_CONTRACT_ID_KEY;
+		}
 
 		/* --- Load the model objects --- */
 		final var sender = accountStore.loadAccount(senderId);

--- a/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/contract/HapiContractCreate.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/contract/HapiContractCreate.java
@@ -290,9 +290,7 @@ public class HapiContractCreate extends HapiTxnOp<HapiContractCreate> {
 								b.setAdminKey(DEPRECATED_CID_ADMIN_KEY);
 							} else if (omitAdminKey) {
 								if (makeImmutable) {
-//									b.setAdminKey(Key.newBuilder().setKeyList(KeyList.getDefaultInstance()));
-									b.setAdminKey(Key.newBuilder().setKeyList(KeyList.newBuilder()
-											.addKeys(Key.newBuilder().setKeyList(KeyList.newBuilder()))));
+									b.setAdminKey(Key.newBuilder().setKeyList(KeyList.getDefaultInstance()));
 								}
 							} else {
 								b.setAdminKey(adminKey);

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hapi/ContractUpdateSuite.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hapi/ContractUpdateSuite.java
@@ -98,6 +98,7 @@ public class ContractUpdateSuite extends HapiApiSuite {
 						fridayThe13thSpec(),
 						updateDoesNotChangeBytecode(),
 						eip1014AddressAlwaysHasPriority(),
+						immutableContractKeyFormIsStandard(),
 				}
 		);
 	}
@@ -136,10 +137,11 @@ public class ContractUpdateSuite extends HapiApiSuite {
 										VARIOUS_CALLS_STATIC_ABI,
 										isLiteralResult(new Object[] { unhex(childEip1014.get()) }))))),
 						contractCall(contract, VARIOUS_CALLS_DELEGATE_ABI).via(delegatecallTxn),
-						sourcing(() -> getTxnRecord(delegatecallTxn).logged().hasPriority(recordWith().contractCallResult(
-								resultWith().resultThruAbi(
-										VARIOUS_CALLS_DELEGATE_ABI,
-										isLiteralResult(new Object[] { unhex(childEip1014.get()) }))))),
+						sourcing(
+								() -> getTxnRecord(delegatecallTxn).logged().hasPriority(recordWith().contractCallResult(
+										resultWith().resultThruAbi(
+												VARIOUS_CALLS_DELEGATE_ABI,
+												isLiteralResult(new Object[] { unhex(childEip1014.get()) }))))),
 						contractCall(contract, VARIOUS_CALLS_CODE_ABI).via(callcodeTxn),
 						sourcing(() -> getTxnRecord(callcodeTxn).logged().hasPriority(recordWith().contractCallResult(
 								resultWith().resultThruAbi(
@@ -238,6 +240,19 @@ public class ContractUpdateSuite extends HapiApiSuite {
 								.has(contractWith()
 										.adminKey("newAdminKey")
 										.memo("some new memo"))
+				);
+	}
+
+	// https://github.com/hashgraph/hedera-services/issues/3037
+	private HapiApiSpec immutableContractKeyFormIsStandard() {
+		final var immutableContract = "immutable";
+
+		return defaultHapiSpec("ImmutableContractKeyFormIsStandard")
+				.given(
+						contractCreate(immutableContract).immutable()
+				).when( ).then(
+						getContractInfo(immutableContract)
+								.has(contractWith().immutableContractKey(immutableContract))
 				);
 	}
 


### PR DESCRIPTION
**Description**:
- Still use `Key{contractID=0.0.X}` for a `ContractCreate` that explicitly provides an empty key. 

**Related issue(s)**:

- Fixes #3037