### PR TITLE
Merkle account copy patch

### DIFF
--- a/hedera-node/src/main/java/com/hedera/services/state/merkle/MerkleAccount.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/merkle/MerkleAccount.java
@@ -93,15 +93,12 @@ public class MerkleAccount extends AbstractNaryMerkleInternal implements MerkleI
 	}
 
 	public MerkleAccount(final List<MerkleNode> children) {
-		super(ChildIndices.NUM_090_CHILDREN);
+		super(ChildIndices.NUM_0240_CHILDREN);
 		addDeserializedChildren(children, MERKLE_VERSION);
 	}
 
 	public MerkleAccount() {
-		addDeserializedChildren(List.of(
-				new MerkleAccountState(),
-				new FCQueue<ExpirableTxnRecord>(),
-				new MerkleAccountTokens()), MERKLE_VERSION);
+		addDeserializedChildren(List.of(new MerkleAccountState(), new FCQueue<ExpirableTxnRecord>()), MERKLE_VERSION);
 	}
 
 	/* --- MerkleInternal --- */

--- a/hedera-node/src/main/java/com/hedera/services/state/merkle/MerkleAccount.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/merkle/MerkleAccount.java
@@ -135,10 +135,9 @@ public class MerkleAccount extends AbstractNaryMerkleInternal implements MerkleI
 		}
 
 		setImmutable(true);
-		return new MerkleAccount(List.of(
-				state().copy(),
-				records().copy(),
-				tokens().copy()), this);
+		return getNumberOfChildren() == ChildIndices.NUM_090_CHILDREN ?
+				new MerkleAccount(List.of(state().copy(), records().copy(), tokens().copy()), this) :
+				new MerkleAccount(List.of(state().copy(), records().copy()), this);
 	}
 
 	/* ---- Object ---- */
@@ -152,13 +151,12 @@ public class MerkleAccount extends AbstractNaryMerkleInternal implements MerkleI
 		}
 		final var that = (MerkleAccount) o;
 		return this.state().equals(that.state()) &&
-				this.records().equals(that.records()) &&
-				this.tokens().equals(that.tokens());
+				this.records().equals(that.records());
 	}
 
 	@Override
 	public int hashCode() {
-		return Objects.hash(state(), records(), tokens());
+		return Objects.hash(state(), records());
 	}
 
 	@Override
@@ -166,7 +164,6 @@ public class MerkleAccount extends AbstractNaryMerkleInternal implements MerkleI
 		return MoreObjects.toStringHelper(MerkleAccount.class)
 				.add("state", state())
 				.add("# records", records().size())
-				.add("tokens", tokens().readableTokenIds())
 				.toString();
 	}
 

--- a/hedera-node/src/main/java/com/hedera/services/state/merkle/MerkleAccount.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/merkle/MerkleAccount.java
@@ -147,8 +147,7 @@ public class MerkleAccount extends AbstractNaryMerkleInternal implements MerkleI
 			return false;
 		}
 		final var that = (MerkleAccount) o;
-		return this.state().equals(that.state()) &&
-				this.records().equals(that.records());
+		return this.state().equals(that.state()) && this.records().equals(that.records());
 	}
 
 	@Override
@@ -171,11 +170,6 @@ public class MerkleAccount extends AbstractNaryMerkleInternal implements MerkleI
 
 	public FCQueue<ExpirableTxnRecord> records() {
 		return getChild(ChildIndices.RELEASE_090_RECORDS);
-	}
-
-	public void setRecords(final FCQueue<ExpirableTxnRecord> payerRecords) {
-		throwIfImmutable("Cannot change this account's transaction records if it's immutable.");
-		setChild(ChildIndices.RELEASE_090_RECORDS, payerRecords);
 	}
 
 	public MerkleAccountTokens tokens() {

--- a/hedera-node/src/test/java/com/hedera/services/state/exports/ToStringAccountsExporterTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/state/exports/ToStringAccountsExporterTest.java
@@ -136,12 +136,12 @@ class ToStringAccountsExporterTest {
 				"alreadyUsedAutoAssociations=7, maxAutoAssociations=10, alias=, " +
 				"cryptoAllowances={EntityNum{value=1}=10}, fungibleTokenAllowances={}, approveForAllNfts=[], " +
 				"numAssociations=3, numZeroBalances=0, lastAssociation=0<->(0.0.0, 0.0.0)}, # " +
-				"records=0, tokens=[]}\n\n0.0.2\n---\nMerkleAccount{state=MerkleAccountState{number=2 <-> 0.0.2, key=ed25519: " +
+				"records=0}\n\n0.0.2\n---\nMerkleAccount{state=MerkleAccountState{number=2 <-> 0.0.2, key=ed25519: " +
 				"\"second-fake\"\n, expiry=7654321, balance=2, autoRenewSecs=444444, memo=" +
 				"We said, and show us what we love, deleted=true, smartContract=false, numContractKvPairs=0, " +
 				"receiverSigRequired=false, proxy=EntityId{shard=0, realm=0, num=0}, nftsOwned=0, alreadyUsedAutoAssociations=0, " +
 				"maxAutoAssociations=0, alias=, cryptoAllowances={}, fungibleTokenAllowances={}, approveForAllNfts=[], " +
-				"numAssociations=1, numZeroBalances=0, lastAssociation=0<->(0.0.0, 0.0.0)}, # records=0, tokens=[]}\n";
+				"numAssociations=1, numZeroBalances=0, lastAssociation=0<->(0.0.0, 0.0.0)}, # records=0}\n";
 
 		// given:
 		MerkleMap<EntityNum, MerkleAccount> accounts = new MerkleMap<>();

--- a/hedera-node/src/test/java/com/hedera/services/state/merkle/MerkleAccountTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/state/merkle/MerkleAccountTest.java
@@ -151,6 +151,8 @@ class MerkleAccountTest {
 		subject.forgetAssociatedTokens();
 
 		assertNull(subject.tokens());
+		assertEquals(2, subject.getNumberOfChildren());
+		assertEquals(2, subject.copy().getNumberOfChildren());
 	}
 
 	@Test
@@ -292,7 +294,7 @@ class MerkleAccountTest {
 	}
 
 	@Test
-	void objectContractMet() {
+	void copyStillWorksWithPre0250() {
 		final var one = new MerkleAccount();
 		final var two = new MerkleAccount(List.of(state, payerRecords, tokens));
 		final var three = two.copy();
@@ -305,6 +307,16 @@ class MerkleAccountTest {
 		assertEquals(two, three);
 
 		assertNotEquals(one.hashCode(), two.hashCode());
+		assertEquals(two.hashCode(), three.hashCode());
+	}
+
+	@Test
+	void copyWorksWith0250() {
+		final var two = new MerkleAccount(List.of(state, payerRecords));
+		final var three = two.copy();
+
+		verify(payerRecords).copy();
+		assertEquals(two, three);
 		assertEquals(two.hashCode(), three.hashCode());
 	}
 

--- a/hedera-node/src/test/java/com/hedera/services/state/merkle/MerkleAccountTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/state/merkle/MerkleAccountTest.java
@@ -200,7 +200,6 @@ class MerkleAccountTest {
 		assertEquals(
 				"MerkleAccount{state=" + state.toString()
 						+ ", # records=" + 3
-						+ ", tokens=" + "[1.2.3, 2.3.4]"
 						+ "}",
 				subject.toString());
 	}

--- a/hedera-node/src/test/java/com/hedera/services/state/merkle/MerkleAccountTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/state/merkle/MerkleAccountTest.java
@@ -145,6 +145,15 @@ class MerkleAccountTest {
 	}
 
 	@Test
+	void equalsIncorporatesRecords() {
+		final var otherRecords = mock(FCQueue.class);
+
+		final var otherSubject = new MerkleAccount(List.of(state, otherRecords, tokens));
+
+		assertNotEquals(otherSubject, subject);
+	}
+
+	@Test
 	void forgetsTokensChildAsExpected() {
 		assertNotNull(subject.tokens());
 


### PR DESCRIPTION
Merkle account copy method should copy based on the no of children it has