### PR TITLE
Refactor SelfSerializableDataTest to register all constructables in the classpath automatically making the registerConstructables method optional.

### DIFF
--- a/hedera-node/src/test/java/com/hedera/services/ServicesStateE2ETest.java
+++ b/hedera-node/src/test/java/com/hedera/services/ServicesStateE2ETest.java
@@ -5,6 +5,7 @@ import com.swirlds.platform.SignedStateFileManager;
 import com.swirlds.platform.state.SignedState;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;

--- a/hedera-node/src/test/java/com/hedera/services/state/merkle/MerkleAccountStateSerdeTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/state/merkle/MerkleAccountStateSerdeTest.java
@@ -41,14 +41,6 @@ public class MerkleAccountStateSerdeTest extends SelfSerializableDataTest<Merkle
 	}
 
 	@Override
-	protected void registerConstructables() throws ConstructableRegistryException {
-		ConstructableRegistry.registerConstructable(
-				new ClassConstructorPair(EntityId.class, EntityId::new));
-		ConstructableRegistry.registerConstructable(
-				new ClassConstructorPair(FcTokenAllowanceId.class, FcTokenAllowanceId::new));
-	}
-
-	@Override
 	protected int getNumTestCasesFor(int version) {
 		return version == RELEASE_0230_VERSION ? num0240Forms : hexedForms.length - num0240Forms;
 	}

--- a/hedera-node/src/test/java/com/hedera/services/state/submerkle/ExpirableTxnRecordSerdeTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/state/submerkle/ExpirableTxnRecordSerdeTest.java
@@ -40,30 +40,6 @@ public class ExpirableTxnRecordSerdeTest extends SelfSerializableDataTest<Expira
 	}
 
 	@Override
-	protected void registerConstructables() throws ConstructableRegistryException {
-		ConstructableRegistry.registerConstructable(
-				new ClassConstructorPair(TxnId.class, TxnId::new));
-		ConstructableRegistry.registerConstructable(
-				new ClassConstructorPair(TxnReceipt.class, TxnReceipt::new));
-		ConstructableRegistry.registerConstructable(
-				new ClassConstructorPair(FcTokenAssociation.class, FcTokenAssociation::new));
-		ConstructableRegistry.registerConstructable(
-				new ClassConstructorPair(FcAssessedCustomFee.class, FcAssessedCustomFee::new));
-		ConstructableRegistry.registerConstructable(
-				new ClassConstructorPair(NftAdjustments.class, NftAdjustments::new));
-		ConstructableRegistry.registerConstructable(
-				new ClassConstructorPair(CurrencyAdjustments.class, CurrencyAdjustments::new));
-		ConstructableRegistry.registerConstructable(
-				new ClassConstructorPair(EvmFnResult.class, EvmFnResult::new));
-		ConstructableRegistry.registerConstructable(
-				new ClassConstructorPair(EntityId.class, EntityId::new));
-		ConstructableRegistry.registerConstructable(
-				new ClassConstructorPair(FcTokenAllowance.class, FcTokenAllowance::new));
-		ConstructableRegistry.registerConstructable(
-				new ClassConstructorPair(FcTokenAllowanceId.class, FcTokenAllowanceId::new));
-	}
-
-	@Override
 	protected int getNumTestCasesFor(int version) {
 		return version == RELEASE_0230_VERSION ? num0240Forms : hexedForms.length - num0240Forms;
 	}

--- a/hedera-node/src/test/java/com/hedera/test/serde/SelfSerializableDataTest.java
+++ b/hedera-node/src/test/java/com/hedera/test/serde/SelfSerializableDataTest.java
@@ -20,11 +20,13 @@ package com.hedera.test.serde;
  * ‍
  */
 
+import com.hedera.test.utils.ClassLoaderHelper;
 import com.swirlds.common.constructable.ConstructableRegistryException;
 import com.swirlds.common.io.SelfSerializable;
 import com.swirlds.common.io.SerializableDataInputStream;
 import com.swirlds.common.io.SerializableDet;
 import com.swirlds.common.io.Versioned;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -71,8 +73,8 @@ public abstract class SelfSerializableDataTest<T extends SelfSerializable> {
 	 *
 	 * @throws ConstructableRegistryException
 	 */
-	protected void registerConstructables() throws ConstructableRegistryException {
-		// No-op
+	protected void registerConstructables() {
+		// No-op. By default, all classes in the classpath will be registered.
 	}
 
 	/**
@@ -112,8 +114,13 @@ public abstract class SelfSerializableDataTest<T extends SelfSerializable> {
 	protected abstract T getExpectedObject(final int version, final int testCaseNo);
 
 	@BeforeEach
-	void setUp() throws ConstructableRegistryException {
+	void setUp() {
 		registerConstructables();
+	}
+
+	@BeforeAll
+	static void setUpClass() {
+		ClassLoaderHelper.loadClassPathDependencies();
 	}
 
 	@ParameterizedTest


### PR DESCRIPTION
Refactor SelfSerializableDataTest to register all constructables in the classpath automatically making the registerConstructables method optional. 

**Related issue(s)**:
https://github.com/hashgraph/hedera-services/issues/3114