### PR TITLE
Fix `treasuryBecomesDeletableAfterTokenDelete()` EET

### DIFF
--- a/hedera-node/src/main/java/com/hedera/services/ledger/HederaLedger.java
+++ b/hedera-node/src/main/java/com/hedera/services/ledger/HederaLedger.java
@@ -272,7 +272,6 @@ public class HederaLedger {
 		if (tokenRelsLedger == null) {
 			throw new IllegalStateException("Ledger has no manageable token relationships!");
 		}
-
 		final var positiveBalances = (int) accountsLedger.get(aId, NUM_POSITIVE_BALANCES);
 		return positiveBalances == 0;
 	}

--- a/hedera-node/src/main/java/com/hedera/services/store/tokens/HederaTokenStore.java
+++ b/hedera-node/src/main/java/com/hedera/services/store/tokens/HederaTokenStore.java
@@ -426,7 +426,7 @@ public class HederaTokenStore extends HederaStore implements TokenStore {
 		final var updatedToNumPositiveBalances = toThisNftsOwned == 0 ?
 				toNumPositiveBalances + 1 : toNumPositiveBalances;
 
-		/* Note correctness here depends on rejecting self-transfers */
+		// Note correctness here depends on rejecting self-transfers
 		accountsLedger.set(from, NUM_NFTS_OWNED, fromNftsOwned - 1);
 		accountsLedger.set(to, NUM_NFTS_OWNED, toNftsOwned + 1);
 		accountsLedger.set(from, NUM_POSITIVE_BALANCES, updatedFromPositiveBalances);

--- a/hedera-node/src/test/java/com/hedera/services/store/AccountStoreTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/store/AccountStoreTest.java
@@ -227,7 +227,7 @@ class AccountStoreTest {
 		model.setMaxAutomaticAssociations(newMax);
 		// decrease the already Used automatic associations by 10
 		for (int i = 0; i < 11; i++) {
-			model.decrementUsedAutomaticAssocitions();
+			model.decrementUsedAutomaticAssociations();
 		}
 		model.incrementUsedAutomaticAssocitions();
 

--- a/hedera-node/src/test/java/com/hedera/services/store/models/AccountTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/store/models/AccountTest.java
@@ -194,6 +194,7 @@ class AccountTest {
 		given(dissociationRel.dissociatingAccountRel()).willReturn(tokenRel);
 		given(dissociationRel.dissociatingToken()).willReturn(firstToken);
 		given(tokenRel.isAutomaticAssociation()).willReturn(true);
+		given(tokenRel.getBalanceChange()).willReturn(-1L);
 		given(tokenStore.loadPossiblyDeletedOrAutoRemovedToken(any())).willReturn(secondToken);
 		given(tokenStore.getLatestTokenRelationship(any())).willReturn(firstRel);
 		given(tokenStore.loadTokenRelationship(any(), any())).willReturn(secondRel);
@@ -203,6 +204,7 @@ class AccountTest {
 
 		// then:
 		verify(dissociationRel).updateModelRelsSubjectTo(validator);
+		assertEquals(numPositiveBalances - 1 , subject.getNumPositiveBalances());
 		assertEquals(numAssociations - 1 , subject.getNumAssociations());
 		assertEquals(alreadyUsedAutoAssociations - 1, subject.getAlreadyUsedAutomaticAssociations());
 	}
@@ -495,7 +497,7 @@ class AccountTest {
 		subject.setAlreadyUsedAutomaticAssociations(0);
 
 		assertFailsWith(
-				() -> subject.decrementUsedAutomaticAssocitions(),
+				() -> subject.decrementUsedAutomaticAssociations(),
 				NO_REMAINING_AUTOMATIC_ASSOCIATIONS);
 	}
 

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/misc/CannotDeleteSystemEntitiesSuite.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/misc/CannotDeleteSystemEntitiesSuite.java
@@ -62,13 +62,13 @@ public class CannotDeleteSystemEntitiesSuite extends HapiApiSuite {
 				ensureSystemAccountsHaveSomeFunds(),
 
 				systemUserCannotDeleteSystemAccounts(1, 100, GENESIS),
-				systemUserCannotDeleteSystemAccounts(900, 999, GENESIS),
+				systemUserCannotDeleteSystemAccounts(700, 750, GENESIS),
 				systemUserCannotDeleteSystemAccounts(1, 100, SYSTEM_ADMIN),
-				systemUserCannotDeleteSystemAccounts(900, 999, SYSTEM_ADMIN),
+				systemUserCannotDeleteSystemAccounts(700, 750, SYSTEM_ADMIN),
 				systemUserCannotDeleteSystemAccounts(1, 100, SYSTEM_DELETE_ADMIN),
-				systemUserCannotDeleteSystemAccounts(900, 999, SYSTEM_DELETE_ADMIN),
+				systemUserCannotDeleteSystemAccounts(700, 750, SYSTEM_DELETE_ADMIN),
 				normalUserCannotDeleteSystemAccounts(1, 100),
-				normalUserCannotDeleteSystemAccounts(900, 999),
+				normalUserCannotDeleteSystemAccounts(700, 750),
 
 				systemUserCannotDeleteSystemFiles(sysFileIds, GENESIS),
 				systemUserCannotDeleteSystemFiles(sysFileIds, SYSTEM_ADMIN),
@@ -84,9 +84,9 @@ public class CannotDeleteSystemEntitiesSuite extends HapiApiSuite {
 	private HapiApiSpec ensureSystemAccountsHaveSomeFunds() {
 		return defaultHapiSpec("EnsureSystemAccountsHaveSomeFunds")
 				.given().when().then(
-						cryptoTransfer(tinyBarsFromTo(GENESIS, SYSTEM_ADMIN, ONE_HUNDRED_HBARS))
+						cryptoTransfer(tinyBarsFromTo(GENESIS, SYSTEM_ADMIN, 10 * ONE_HUNDRED_HBARS))
 								.payingWith(GENESIS),
-						cryptoTransfer(tinyBarsFromTo(GENESIS, SYSTEM_DELETE_ADMIN, ONE_HUNDRED_HBARS))
+						cryptoTransfer(tinyBarsFromTo(GENESIS, SYSTEM_DELETE_ADMIN, 10 * ONE_HUNDRED_HBARS))
 								.payingWith(GENESIS)
 				);
 	}

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenDeleteSpecs.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenDeleteSpecs.java
@@ -96,6 +96,7 @@ public class TokenDeleteSpecs extends HapiApiSuite {
 								.hasKnownStatus(ACCOUNT_IS_TREASURY),
 						tokenDelete("secondTbd")
 				).then(
+						tokenDissociate(TOKEN_TREASURY, "secondTbd"),
 						cryptoDelete(TOKEN_TREASURY)
 				);
 	}

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenManagementSpecs.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenManagementSpecs.java
@@ -77,7 +77,7 @@ public class TokenManagementSpecs extends HapiApiSuite {
 	private static final Logger log = LogManager.getLogger(TokenManagementSpecs.class);
 
 	public static void main(String... args) {
-		new TokenManagementSpecs().runSuiteSync();
+		new TokenManagementSpecs().runSuiteAsync();
 	}
 
 	@Override

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenPauseSpecs.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenPauseSpecs.java
@@ -75,6 +75,8 @@ import static com.hedera.services.bdd.suites.token.TokenPauseSpecs.TokenIdOrderi
 import static com.hedera.services.bdd.suites.utils.MiscEETUtils.metadata;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_SIGNATURE;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_TOKEN_ID_IN_CUSTOM_FEES;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.REQUESTED_NUM_AUTOMATIC_ASSOCIATIONS_EXCEEDS_ASSOCIATION_LIMIT;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TOKENS_PER_ACCOUNT_LIMIT_EXCEEDED;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TOKEN_HAS_NO_PAUSE_KEY;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TOKEN_IS_IMMUTABLE;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TOKEN_IS_PAUSED;
@@ -120,8 +122,84 @@ public final class TokenPauseSpecs extends HapiApiSuite {
 				pausedTokenInCustomFeeCaseStudy(),
 				cannotAddPauseKeyViaTokenUpdate(),
 				canDissociateFromMultipleExpiredTokens(),
+				cannotAssociateMoreThanTheLimit(),
 		});
 	}
+
+	private HapiApiSpec cannotAssociateMoreThanTheLimit() {
+		final String treasury1 = "treasury1";
+		final String treasury2 = "treasury2";
+		final String user1 = "user1";
+		final String user2 = "user2";
+		final String key = "key";
+		final String token1 = "token1";
+		final String token2 = "token2";
+		final String token3 = "token3";
+		return defaultHapiSpec("CannotAssociateMoreThanTheLimit")
+				.given(
+						newKeyNamed(key),
+						cryptoCreate(treasury1),
+						cryptoCreate(treasury2),
+						tokenCreate(token1)
+								.supplyType(TokenSupplyType.FINITE)
+								.tokenType(FUNGIBLE_COMMON)
+								.treasury(treasury1)
+								.maxSupply(500)
+								.kycKey(key)
+								.initialSupply(100),
+						tokenCreate(token2)
+								.supplyType(TokenSupplyType.FINITE)
+								.tokenType(FUNGIBLE_COMMON)
+								.treasury(treasury2)
+								.maxSupply(500)
+								.kycKey(key)
+								.initialSupply(100),
+						fileUpdate(APP_PROPERTIES)
+								.payingWith(ADDRESS_BOOK_CONTROL)
+								.overridingProps(Map.of("tokens.maxPerAccount", "0"))
+				)
+				.when(
+						tokenCreate(token3)
+								.supplyType(TokenSupplyType.FINITE)
+								.tokenType(FUNGIBLE_COMMON)
+								.treasury(treasury2)
+								.maxSupply(500)
+								.kycKey(key)
+								.initialSupply(100)
+								.hasKnownStatus(TOKENS_PER_ACCOUNT_LIMIT_EXCEEDED),
+						cryptoCreate(user1)
+								.maxAutomaticTokenAssociations(1)
+								.hasPrecheck(REQUESTED_NUM_AUTOMATIC_ASSOCIATIONS_EXCEEDS_ASSOCIATION_LIMIT),
+						cryptoCreate(user1),
+						tokenAssociate(user1, token1)
+								.hasKnownStatus(TOKENS_PER_ACCOUNT_LIMIT_EXCEEDED),
+						tokenAssociate(treasury1, token2)
+								.hasKnownStatus(TOKENS_PER_ACCOUNT_LIMIT_EXCEEDED)
+				)
+				.then(
+						fileUpdate(APP_PROPERTIES)
+								.payingWith(ADDRESS_BOOK_CONTROL)
+								.overridingProps(Map.of("accounts.limitTokenAssociations", "false")),
+						tokenCreate(token3)
+								.supplyType(TokenSupplyType.FINITE)
+								.tokenType(FUNGIBLE_COMMON)
+								.treasury(treasury2)
+								.maxSupply(500)
+								.kycKey(key)
+								.initialSupply(100),
+						cryptoCreate(user2)
+								.maxAutomaticTokenAssociations(10_000),
+						tokenAssociate(user1, token1),
+						tokenAssociate(treasury1, token2),
+						fileUpdate(APP_PROPERTIES)
+								.payingWith(ADDRESS_BOOK_CONTROL)
+								.overridingProps(Map.of("tokens.maxPerAccount", "1000")),
+						fileUpdate(APP_PROPERTIES)
+								.payingWith(ADDRESS_BOOK_CONTROL)
+								.overridingProps(Map.of("accounts.limitTokenAssociations", "true"))
+				);
+	}
+
 
 	private HapiApiSpec cannotAddPauseKeyViaTokenUpdate() {
 		final String token1 = "primary";
@@ -558,16 +636,16 @@ public final class TokenPauseSpecs extends HapiApiSuite {
 						cryptoCreate(TOKEN_TREASURY),
 						cryptoCreate(civilian).balance(0L),
 						blockingOrder(IntStream.range(0, numTokens).mapToObj(i ->
-								tokenCreate(tokenNameFn.apply(i))
-										.autoRenewAccount(DEFAULT_PAYER)
-										.autoRenewPeriod(1L)
-										.initialSupply(initialSupply)
-										.treasury(TOKEN_TREASURY))
+										tokenCreate(tokenNameFn.apply(i))
+												.autoRenewAccount(DEFAULT_PAYER)
+												.autoRenewPeriod(1L)
+												.initialSupply(initialSupply)
+												.treasury(TOKEN_TREASURY))
 								.toArray(HapiSpecOperation[]::new)),
 						tokenAssociate(civilian, List.of(assocOrder)),
 						blockingOrder(IntStream.range(0, numTokens).mapToObj(i ->
-								cryptoTransfer(moving(nonZeroXfer, tokenNameFn.apply(i))
-										.between(TOKEN_TREASURY, civilian)))
+										cryptoTransfer(moving(nonZeroXfer, tokenNameFn.apply(i))
+												.between(TOKEN_TREASURY, civilian)))
 								.toArray(HapiSpecOperation[]::new))
 				).when(
 						sleepFor(1_000L),
@@ -599,7 +677,7 @@ public final class TokenPauseSpecs extends HapiApiSuite {
 				try {
 					assertEquals(expectedTokenIds.length, tokenTransfers.size(), "Wrong # of token ids");
 					var nextI = 0;
-					for (final var expected : expectedTokenIds)	{
+					for (final var expected : expectedTokenIds) {
 						final var expectedId = registry.getTokenID(expected);
 						final var actualId = tokenTransfers.get(nextI++).getToken();
 						assertEquals(expectedId, actualId, "Wrong token at index " + (nextI - 1));


### PR DESCRIPTION
**Description**:
- Ensure `numPositiveBalances` is decremented when dissociating from a deleted token w/ positive balance.
- Move `TokenAssociationSpecs.cannotAssociateMoreThanTheLimit()` out of async run section---it sets `tokens.maxPerAccount=0`.
- Update the `CannotDeleteSystemEntitiesSuite` to the new lower # of system entities (750).
