### PR TITLE
Update yahcli for deprecated address book fields

### DIFF
--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/utils/sysfiles/serdes/AddrBkJsonToGrpcBytes.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/utils/sysfiles/serdes/AddrBkJsonToGrpcBytes.java
@@ -62,21 +62,21 @@ public class AddrBkJsonToGrpcBytes implements SysFileSerde<String> {
 		return grpcBytesFromPojo(pojo);
 	}
 
-	private void validateIPandPort(String IpV4Address, Integer portNo) {
+	private void validateIPandPort(String IpV4Address, Integer portNum) {
 		try {
 			BookEntryPojo.asOctets(IpV4Address);
 		} catch (Exception e) {
 			throw new IllegalStateException(
-					"Endpoint" + " IP field cannot be set to '" + IpV4Address + "'", e);
+					"Endpoint IP field cannot be set to '" + IpV4Address + "'", e);
 		}
 
 		try {
-			if (portNo <= 0) {
+			if (portNum <= 0) {
 				throw new IllegalStateException(
-						"Endpoint" + " portno field cannot be set to '" + portNo + "'");
+						"Endpoint port field cannot be set to '" + portNum + "'");
 			}
 		} catch (NullPointerException e) {
-			throw new IllegalStateException("Endpoint" + " portno field is not set", e);
+			throw new IllegalStateException("Endpoint port field is not set", e);
 		}
 	}
 

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/utils/sysfiles/serdes/AddrBkJsonToGrpcBytes.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/utils/sysfiles/serdes/AddrBkJsonToGrpcBytes.java
@@ -23,7 +23,6 @@ package com.hedera.services.bdd.suites.utils.sysfiles.serdes;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.protobuf.InvalidProtocolBufferException;
-import com.hedera.services.bdd.spec.HapiPropertySource;
 import com.hedera.services.bdd.suites.utils.sysfiles.AddressBookPojo;
 import com.hedera.services.bdd.suites.utils.sysfiles.BookEntryPojo;
 import com.hederahashgraph.api.proto.java.NodeAddressBook;
@@ -56,37 +55,28 @@ public class AddrBkJsonToGrpcBytes implements SysFileSerde<String> {
 	public byte[] toValidatedRawFile(String styledFile) {
 		var pojo = pojoFrom(styledFile);
 		for (var entry : pojo.getEntries()) {
-			validateIPandPort(entry.getDeprecatedIp(), entry.getDeprecatedPortNo(), "Deprecated");
-
-			try {
-				HapiPropertySource.asAccount(entry.getDeprecatedMemo());
-			} catch (Exception e) {
-				throw new IllegalStateException(
-						"Deprecated memo field cannot be set to '" + entry.getDeprecatedMemo() + "'", e);
-			}
-
-			for(BookEntryPojo.EndpointPojo endpointPojo : entry.getEndpoints()) {
-				validateIPandPort(endpointPojo.getIpAddressV4(), endpointPojo.getPort(), "Endpoint");
+			for (BookEntryPojo.EndpointPojo endpointPojo : entry.getEndpoints()) {
+				validateIPandPort(endpointPojo.getIpAddressV4(), endpointPojo.getPort());
 			}
 		}
 		return grpcBytesFromPojo(pojo);
 	}
 
-	private void validateIPandPort(String IpV4Address, Integer portNo, String type) {
+	private void validateIPandPort(String IpV4Address, Integer portNo) {
 		try {
 			BookEntryPojo.asOctets(IpV4Address);
 		} catch (Exception e) {
 			throw new IllegalStateException(
-					type + " IP field cannot be set to '" + IpV4Address + "'", e);
+					"Endpoint" + " IP field cannot be set to '" + IpV4Address + "'", e);
 		}
 
 		try {
 			if (portNo <= 0) {
 				throw new IllegalStateException(
-						type + " portno field cannot be set to '" + portNo + "'");
+						"Endpoint" + " portno field cannot be set to '" + portNo + "'");
 			}
 		} catch (NullPointerException e) {
-			throw new IllegalStateException(type + " portno field is not set", e);
+			throw new IllegalStateException("Endpoint" + " portno field is not set", e);
 		}
 	}
 

--- a/test-clients/yahcli/README.md
+++ b/test-clients/yahcli/README.md
@@ -1,4 +1,4 @@
-# Yahcli v0.1.10
+# Yahcli v0.1.12
 Yahcli (_Yet Another Hedera Command Line Interface_) supports DevOps
 actions against the Hedera networks listed in a _config.yml_ file.
 
@@ -58,14 +58,14 @@ node by its IP adress. However, if the IP address given to the `-i` option does
 not appear in the _config.yml_, then we **must** explicitly give its node
 account via the `-a` option. So with the above _config.yml_, it is enough to do,
 ```
-$ docker run -it -v $(pwd):/launch gcr.io/hedera-registry/yahcli:0.1.10 -p 2 -n previewnet \
+$ docker run -it -v $(pwd):/launch gcr.io/hedera-registry/yahcli:0.1.12 -p 2 -n previewnet \
 > -i 35.231.208.148
 ```
 
 ...since the ip `35.231.208.148` is in the _config.yml_. But to use an IP not
 in the _config.yml_, we must also specify the node account, 
 ```
-$ docker run -it -v $(pwd):/launch gcr.io/hedera-registry/yahcli:0.1.10 -p 2 -n previewnet \
+$ docker run -it -v $(pwd):/launch gcr.io/hedera-registry/yahcli:0.1.12 -p 2 -n previewnet \
 > -i 35.199.15.177 -a 4
 ```
 
@@ -90,7 +90,7 @@ use with that network. :guard: &nbsp; If there is no corresponding
 `account{num}.pass` for a PEM file, please be ready to enter 
 the passphrase interactively in the console. For example,
 ```
-$ docker run -it -v $(pwd):/launch yahcli:0.1.10 -p 2 sysfiles download all 
+$ docker run -it -v $(pwd):/launch yahcli:0.1.12 -p 2 sysfiles download all 
 Targeting localhost, paying with 0.0.2
 Please enter the passphrase for key file localhost/keys/account2.pem: 
 ```
@@ -108,7 +108,7 @@ Note that yahcli does not support multi-sig accounts.
 
 To list all available commands,
 ```
-$ docker run -it -v $(pwd):/launch gcr.io/hedera-registry/yahcli:0.1.10 help
+$ docker run -it -v $(pwd):/launch gcr.io/hedera-registry/yahcli:0.1.12 help
 ``` 
 
 :information_desk_person: &nbsp; Since the only key we have for previewnet
@@ -117,7 +117,7 @@ when running against this network.
 
 To download the fee schedules from previewnet given the config above, we run,
 ```
-$ docker run -it -v $(pwd):/launch gcr.io/hedera-registry/yahcli:0.1.10 -p 2 -n previewnet sysfiles download fees
+$ docker run -it -v $(pwd):/launch gcr.io/hedera-registry/yahcli:0.1.12 -p 2 -n previewnet sysfiles download fees
 Targeting previewnet, paying with 0.0.2
 Downloading the fees...OK
 $ ls previewnet/sysfiles/
@@ -128,14 +128,14 @@ The fee schedules were downloaded in JSON form to _previewnet/sysfiles/feeSchedu
 To see more options for the `download` subcommand (including a custom download directory), 
 we run,
 ```
-$ docker run -it -v $(pwd):/launch gcr.io/hedera-registry/yahcli:0.1.10 sysfiles download help
+$ docker run -it -v $(pwd):/launch gcr.io/hedera-registry/yahcli:0.1.12 sysfiles download help
 ```
 
 The remaining sections of this document focus on specific use cases.
 
 # Getting account balances
 ```
-$ docker run -it -v $(pwd):/launch gcr.io/hedera-registry/yahcli:0.1.10 -n previewnet -p 2 accounts balance 56 50
+$ docker run -it -v $(pwd):/launch gcr.io/hedera-registry/yahcli:0.1.12 -n previewnet -p 2 accounts balance 56 50
 ```
 
 # Sending account funds
@@ -144,7 +144,7 @@ You can send funds from the default payer's account to a beneficiary account, in
 The default denomination is `hbar`.
 
 ```
-$ docker run -it -v $(pwd):/launch gcr.io/hedera-registry/yahcli:0.1.10 -n previewnet -p 2 accounts send --denomination hbar --to 58 1_000_000
+$ docker run -it -v $(pwd):/launch gcr.io/hedera-registry/yahcli:0.1.12 -n previewnet -p 2 accounts send --denomination hbar --to 58 1_000_000
 
 ```
 
@@ -170,7 +170,7 @@ localhost
 
 We first download the existing address book,
 ```
-$ docker run -it -v $(pwd):/launch gcr.io/hedera-registry/yahcli:0.1.10 -n localhost -p 2 sysfiles download address-book
+$ docker run -it -v $(pwd):/launch gcr.io/hedera-registry/yahcli:0.1.12 -n localhost -p 2 sysfiles download address-book
 Targeting localhost, paying with 0.0.2
 Downloading the address-book...OK
 ```
@@ -184,9 +184,6 @@ files, respectively.
 ```
 ...
   }, {
-    "deprecatedIp" : "127.0.0.1",
-    "deprecatedMemo" : "0.0.6",
-    "deprecatedPortNo" : 50207,
     "nodeId" : 3,
     "certHash" : "!",
     "rsaPubKey" : "!",
@@ -203,22 +200,19 @@ files, respectively.
 
 And now we upload the new address book, this time using the address book admin `0.0.55` as the payer:
 ```
-$ docker run -it -v $(pwd):/launch gcr.io/hedera-registry/yahcli:0.1.10 -n localhost -p 55 sysfiles upload address-book
+$ docker run -it -v $(pwd):/launch gcr.io/hedera-registry/yahcli:0.1.12 -n localhost -p 55 sysfiles upload address-book
 ```
 
 Finally we re-download the book to see that the hex-encoded cert hash and RSA public key were uploaded as expected:
 ```
-$ docker run -it -v $(pwd):/launch gcr.io/hedera-registry/yahcli:0.1.10 -n localhost -p 2 sysfiles download address-book
+$ docker run -it -v $(pwd):/launch gcr.io/hedera-registry/yahcli:0.1.12 -n localhost -p 2 sysfiles download address-book
 Targeting localhost, paying with 0.0.2
 Downloading the address-book...OK
 $ tail -17 localhost/sysfiles/addressBook.json 
   }, {
-    "deprecatedIp" : "127.0.0.1",
-    "deprecatedMemo" : "0.0.6",
-    "deprecatedPortNo" : 50207,
     "nodeId" : 3,
     "certHash" : "0ae05bde15d216781a40e7bce5303bf68926f9440eec3cb20fabe9df06b0091a205fdea86911facb4e51e46c3890c803",
-    "rsaPubKey" : "363630383939643834353735393365353739656536386133326330363033653539393666616261353038643934343830633365623634646361353837383532646133383035373032393363653533656439393266646534383533323463616235643335356537343831333439353462313963323163336630386336316131653564396533353031633433323435393765633464653864643538386666626664643461356633363436626237633539383063626432316464363430316137633931313366316365333138646361346166353737323234626465383963326331373366336665386430393265346238663830303731303761386439653236333331663533353561353834643830373736613061626361393265303034386464333731636665303539366564643662613037373033383134323838663130396138323830353836303635623762626632383534323034343761343433363838306333613933366136666666636461623130.1.103335633864666561306461306537353035383530346661396163333036396438653166643762623333343530663761346261303439310a",
+    "rsaPubKey" : "363630383939643834353735393365353739656536386133326330363033653539393666616261353038643934343830633365623634646361353837383532646133383035373032393363653533656439393266646534383533323463616235643335356537343831333439353462313963323163336630386336316131653564396533353031633433323435393765633464653864643538386666626664643461356633363436626237633539383063626432316464363430316137633931313366316365333138646361346166353737323234626465383963326331373366336665386430393265346238663830303731303761386439653236333331663533353561353834643830373736613061626361393265303034386464333731636665303539366564643662613037373033383134323838663130396138323830353836303635623762626632383534323034343761343433363838306333613933366136666666636461623130.1.123335633864666561306461306537353035383530346661396163333036396438653166643762623333343530663761346261303439310a",
     "nodeAccount" : "0.0.6",
     "endpoints" : [ {
       "ipAddressV4" : "127.0.0.1",
@@ -231,34 +225,6 @@ $ tail -17 localhost/sysfiles/addressBook.json
 }
 ```
  
-In some cases, yahcli does client-side validation to catch errors early. 
-For example, **all three** of the `deprecated*` fields must be set to "reasonable"
-values. Suppose we try to update the address book again, changing the 
-`deprecatedMemo` field to something other than an account literal,
-```
-...
-  }, {
-    "deprecatedIp" : "127.0.0.1",
-    "deprecatedMemo" : "This node is the best!",
-    "deprecatedPortNo" : 50207,
-    "nodeId" : 3,
-...
-```
-
-We then get a messy error and the update aborts before sending
-any `FileUpdate` transaction to the network:
-```
-$ docker run -it -v $(pwd):/launch gcr.io/hedera-registry/yahcli:0.1.10 -n localhost -p 55 sysfiles upload address-book
-Targeting localhost, paying with 0.0.55
-java.lang.IllegalStateException: Deprecated memo field cannot be set to 'This node is the best!'
-	at com.hedera.services.bdd.suites.utils.sysfiles.serdes.AddrBkJsonToGrpcBytes.toValidatedRawFile(AddrBkJsonToGrpcBytes.java:70)
-	at com.hedera.services.bdd.suites.utils.sysfiles.serdes.AddrBkJsonToGrpcBytes.toValidatedRawFile(AddrBkJsonToGrpcBytes.java:35)
-	at com.hedera.services.yahcli.suites.SysFileUploadSuite.appropriateContents(SysFileUploadSuite.java:97)
-	at com.hedera.services.yahcli.suites.SysFileUploadSuite.uploadSysFiles(SysFileUploadSuite.java:70)
-	at com.hedera.services.yahcli.suites.SysFileUploadSuite.getSpecsInSuite(SysFileUploadSuite.java:65)
-...
-```
-
 ## Uploading special files
 
 System files in the range `0.0.150-159` are _special files_ that do not have the normal 1MB size limit. 
@@ -277,9 +243,9 @@ localhost/sysfiles/
 
 Then proceed as with any other `sysfiles upload` command, 
 ```
-$ docker run -it -v $(pwd):/launch gcr.io/hedera-registry/yahcli:0.1.10 -n localhost -p 58 sysfiles upload software-zip
+$ docker run -it -v $(pwd):/launch gcr.io/hedera-registry/yahcli:0.1.12 -n localhost -p 58 sysfiles upload software-zip
 ...
-$ docker run -it -v $(pwd):/launch gcr.io/hedera-registry/yahcli:0.1.10 -n localhost -p 58 sysfiles upload telemetry-zip
+$ docker run -it -v $(pwd):/launch gcr.io/hedera-registry/yahcli:0.1.12 -n localhost -p 58 sysfiles upload telemetry-zip
 ...
 ```
 
@@ -290,7 +256,7 @@ $ docker run -it -v $(pwd):/launch gcr.io/hedera-registry/yahcli:0.1.10 -n local
 Services will be validated by type; to see all supported options, run,
 
 ```
-$ docker run -it -v $(pwd):/launch gcr.io/hedera-registry/yahcli:0.1.10 -n localhost -p 2 validate help
+$ docker run -it -v $(pwd):/launch gcr.io/hedera-registry/yahcli:0.1.12 -n localhost -p 2 validate help
 ```
 
 # Preparing an NMT software upgrade
@@ -301,7 +267,7 @@ SHA-384 hash of this ZIP must be given so the nodes can validate the integrity o
 staging its artifacts for NMT to use. This looks like,
 
 ```
-$ docker run -it -v $(pwd):/launch gcr.io/hedera-registry/yahcli:0.1.10 -n localhost -p 58 prepare-upgrade \
+$ docker run -it -v $(pwd):/launch gcr.io/hedera-registry/yahcli:0.1.12 -n localhost -p 58 prepare-upgrade \
 > --upgrade-zip-hash 5d3b0e619d8513dfbf606ef00a2e83ba97d736f5f5ba61561d895ea83a6d4c34fce05d6cd74c83ec171f710e37e12aab
 ```
 
@@ -313,7 +279,7 @@ SHA-384 hash of this ZIP must be known so the nodes can validate the integrity o
 staging its artifacts for NMT to use.  This looks like,
 
 ```
-$ docker run -it -v $(pwd):/launch gcr.io/hedera-registry/yahcli:0.1.10 -n localhost -p 58 upgrade-telemetry \
+$ docker run -it -v $(pwd):/launch gcr.io/hedera-registry/yahcli:0.1.12 -n localhost -p 58 upgrade-telemetry \
 > --upgrade-zip-hash 8ec75ab44b6c8ccac4a6e7f7d77b5a66280cad8d8a86ed961975a3bea597613f83af9075f65786bf9101d50047ca768f \
 > --start-time 2022-01-01.00:00:00
 ```
@@ -326,21 +292,21 @@ software upgrade.
 
 A vanilla freeze with no NMT upgrade only includes the start time, 
 ```
-$ docker run -it -v $(pwd):/launch gcr.io/hedera-registry/yahcli:0.1.10 -n localhost -p 58 freeze \
+$ docker run -it -v $(pwd):/launch gcr.io/hedera-registry/yahcli:0.1.12 -n localhost -p 58 freeze \
 > --start-time 2022-01-01.00:00:00
 ```
 
 While a freeze that should trigger a staged NMT upgrade uses the `freeze-upgrade` variant,
 which **must** repeat the hash of the intended update, 
 ```
-$ docker run -it -v $(pwd):/launch gcr.io/hedera-registry/yahcli:0.1.10 -n localhost -p 58 freeze-upgrade \
+$ docker run -it -v $(pwd):/launch gcr.io/hedera-registry/yahcli:0.1.12 -n localhost -p 58 freeze-upgrade \
 > --upgrade-zip-hash 5d3b0e619d8513dfbf606ef00a2e83ba97d736f5f5ba61561d895ea83a6d4c34fce05d6cd74c83ec171f710e37e12aab
 > --start-time 2021-09-09.20:11:13 
 ```
 
 To abort a scheduled freeze, simply use the `freeze-abort` command,
 ```
-$ docker run -it -v $(pwd):/launch gcr.io/hedera-registry/yahcli:0.1.10 -n localhost -p 58 freeze-abort 
+$ docker run -it -v $(pwd):/launch gcr.io/hedera-registry/yahcli:0.1.12 -n localhost -p 58 freeze-abort 
 ```
 
 # Updating account keys
@@ -350,7 +316,7 @@ can be either PEM files or BIP-39 mnemonics.)
 
 Our first example uses a randomly generated new key,
 ```
-$ docker run -it -v $(pwd):/launch gcr.io/hedera-registry/yahcli:0.1.10 -p 2 -n localhost \
+$ docker run -it -v $(pwd):/launch gcr.io/hedera-registry/yahcli:0.1.12 -p 2 -n localhost \
 > accounts rekey --gen-new-key 57
 Targeting localhost, paying with 0.0.2
 .i. Exported a newly generated key in PEM format to localhost/keys/account57.pem
@@ -372,7 +338,7 @@ localhost/keys
 
 For the next example, we specify an existing PEM file, and enter its passphrase when prompted,
 ```
-$ docker run -it -v $(pwd):/launch gcr.io/hedera-registry/yahcli:0.1.10 -p 57 -n localhost \
+$ docker run -it -v $(pwd):/launch gcr.io/hedera-registry/yahcli:0.1.12 -p 57 -n localhost \
 > accounts rekey -k new-account57.pem 57
 Targeting localhost, paying with 0.0.2
 Please enter the passphrase for key file new-account55.pem: 
@@ -384,7 +350,7 @@ In our final example, we replace the `0.0.57` key from a mnemonic,
 ```
 $ cat new-account57.words
 goddess maze eternal small normal october ... author
-$ docker run -it -v $(pwd):/launch gcr.io/hedera-registry/yahcli:0.1.10 -p 57 -n localhost \
+$ docker run -it -v $(pwd):/launch gcr.io/hedera-registry/yahcli:0.1.12 -p 57 -n localhost \
 > accounts rekey -k new-account57.words 57
 Targeting localhost, paying with 0.0.2
 .i. Exported key from new-account55 to localhost/keys/account57.pem
@@ -393,5 +359,5 @@ Targeting localhost, paying with 0.0.2
 
 # Get version info
 ```
-$ docker run -it -v $(pwd):/launch gcr.io/hedera-registry/yahcli:0.1.10 -n previewnet -p 2 version
+$ docker run -it -v $(pwd):/launch gcr.io/hedera-registry/yahcli:0.1.12 -n previewnet -p 2 version
 ```

--- a/test-clients/yahcli/run/build.sh
+++ b/test-clients/yahcli/run/build.sh
@@ -1,5 +1,5 @@
 #! /bin/sh
-TAG=${1:-'0.1.8'}
+TAG=${1:-'0.1.12'}
 
 cd ..
 mvn clean compile assembly:single@yahcli-jar


### PR DESCRIPTION
**Description**:
- Stops rejecting `FileUpdate`s to `0.0.101/2` that omit the [deprecated `NodeAddress` fields](https://hashgraph.github.io/hedera-protobufs/#proto.NodeAddress) (`ipAddress`, `portno`, `memo`).
- Bumps yahcli version to `0.1.12`
