### PR TITLE
Adjust timing for token reconnect tests

### DIFF
--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/reconnect/ValidateDuplicateTransactionAfterReconnect.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/reconnect/ValidateDuplicateTransactionAfterReconnect.java
@@ -75,7 +75,7 @@ public class ValidateDuplicateTransactionAfterReconnect extends HapiApiSuite {
 				)
 				.then(
 						withLiveNode("0.0.8")
-								.within(60, TimeUnit.SECONDS)
+								.within(90, TimeUnit.SECONDS)
 								.loggingAvailabilityEvery(10)
 								.sleepingBetweenRetriesFor(5),
 						UtilVerbs.sleepFor(30 * 1000),

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/reconnect/ValidateTokensStateAfterReconnect.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/reconnect/ValidateTokensStateAfterReconnect.java
@@ -101,6 +101,7 @@ public class ValidateTokensStateAfterReconnect extends HapiApiSuite {
 						cryptoCreate(anotherAccount).balance(ONE_HUNDRED_HBARS).logging()
 				)
 				.when(
+						sleepFor(Duration.ofSeconds(25).toMillis()),
 						getAccountBalance(GENESIS)
 								.setNode(reconnectingNode)
 								.unavailableNode(),


### PR DESCRIPTION

Close regression test 2253 and 2146

https://github.com/swirlds/swirlds-platform-regression/issues/2253
https://github.com/swirlds/swirlds-platform-regression/issues/2146


TokenDeleteValidate-NIReconnect-1-16m
TransactionHistory-NIReconnect-1-16m


Test result:

https://hedera-hashgraph.slack.com/archives/C018CBQBTGB/p1649736945502569

