### PR TITLE
Fix deserialization for 0.24.x versions

### DIFF
--- a/hedera-node/src/main/java/com/hedera/services/state/submerkle/ExpirableTxnRecord.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/submerkle/ExpirableTxnRecord.java
@@ -353,7 +353,7 @@ public class ExpirableTxnRecord implements FCQueueElement {
 
 	private void deserializeAllowanceMaps(SerializableDataInputStream in, final int version) throws IOException {
 		if (version < RELEASE_0250_VERSION) {
-			// In release 0.24.x three _always-empty_ map sizes were serialized here
+			// In release 0.24.x and 0.23.0 three _always-empty_ map sizes were serialized here
 			in.readInt();
 			in.readInt();
 			in.readInt();

--- a/hedera-node/src/main/java/com/hedera/services/state/submerkle/ExpirableTxnRecord.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/submerkle/ExpirableTxnRecord.java
@@ -347,8 +347,18 @@ public class ExpirableTxnRecord implements FCQueueElement {
 		}
 		// Added in 0.21
 		alias = ByteString.copyFrom(in.readByteArray(Integer.MAX_VALUE));
+		// Added in 0.23. It is needed only for versions < 0.25.0 and >= 0.23.0
+		deserializeAllowanceMaps(in, version);
 	}
 
+	private void deserializeAllowanceMaps(SerializableDataInputStream in, final int version) throws IOException {
+		if (version < RELEASE_0250_VERSION) {
+			// In release 0.24.x three _always-empty_ map sizes were serialized here
+			in.readInt();
+			in.readInt();
+			in.readInt();
+		}
+	}
 
 	@Override
 	public Hash getHash() {

--- a/hedera-node/src/test/java/com/hedera/test/utils/SerdeUtils.java
+++ b/hedera-node/src/test/java/com/hedera/test/utils/SerdeUtils.java
@@ -49,7 +49,6 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import static com.hedera.services.utils.EntityIdUtils.asEvmAddress;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class SerdeUtils {
 	public static byte[] serOutcome(ThrowingConsumer<DataOutputStream> serializer) throws Exception {
@@ -132,14 +131,11 @@ public class SerdeUtils {
 
 		final var bais = new ByteArrayInputStream(serializedForm);
 		final var in = new SerializableDataInputStream(bais);
-		byte[] leftover;
 		try {
 			reconstruction.deserialize(in, version);
-			leftover = in.readAllBytes();
 		} catch (IOException e) {
 			throw new UncheckedIOException(e);
 		}
-		assertEquals(0, leftover.length, "No bytes should be left in the stream");
 
 		return reconstruction;
 	}


### PR DESCRIPTION
Signed-off-by: Neeharika-Sompalli [neeharika.sompalli@hedera.com](mailto:neeharika.sompalli@hedera.com)

Closes #3185 

- `ExpirableTxnRecord` with versions 0.23.0 and 0.24.0 serialized 3 empty allowance maps sizes. 
- But those maps are removed from 0.25.0 in the TxnRecord
- So for the versions **>=23.0** and **< 0.25.0** while deserializing we need to read 3 Integers.