### PR TITLE
Improve serde tests by de-serializing the same object from the same stream multiple times.

### DIFF
--- a/hedera-node/src/test/java/com/hedera/services/state/submerkle/ExpirableTxnRecordSerdeTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/state/submerkle/ExpirableTxnRecordSerdeTest.java
@@ -23,15 +23,8 @@ package com.hedera.services.state.submerkle;
 import com.hedera.test.serde.SelfSerializableDataTest;
 import com.hedera.test.serde.SerializedForms;
 import com.hedera.test.utils.SeededPropertySource;
-import com.swirlds.common.io.SerializableDataInputStream;
-import org.bouncycastle.util.Arrays;
-import org.junit.jupiter.api.Test;
-
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
 
 import static com.hedera.services.state.submerkle.ExpirableTxnRecord.RELEASE_0230_VERSION;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ExpirableTxnRecordSerdeTest extends SelfSerializableDataTest<ExpirableTxnRecord> {
 	public static final int NUM_TEST_CASES = 4 * MIN_TEST_CASES_PER_VERSION;

--- a/hedera-node/src/test/java/com/hedera/services/state/submerkle/ExpirableTxnRecordSerdeTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/state/submerkle/ExpirableTxnRecordSerdeTest.java
@@ -60,19 +60,4 @@ public class ExpirableTxnRecordSerdeTest extends SelfSerializableDataTest<Expira
 	protected ExpirableTxnRecord getExpectedObject(final SeededPropertySource propertySource) {
 		return propertySource.nextRecord();
 	}
-
-	@Test
-	void testDeserializingMultipleExpirableTxnRecords() throws IOException {
-		byte[] objectBytes = getSerializedForm(RELEASE_0230_VERSION, 1);
-		byte[] bytes = Arrays.concatenate(objectBytes, objectBytes);
-		SerializableDataInputStream inputStream = new SerializableDataInputStream(new ByteArrayInputStream(bytes));
-		ExpirableTxnRecord record1 = new ExpirableTxnRecord();
-		ExpirableTxnRecord record2 = new ExpirableTxnRecord();
-		record1.deserialize(inputStream, RELEASE_0230_VERSION);
-		record2.deserialize(inputStream, RELEASE_0230_VERSION);
-
-		ExpirableTxnRecord expected = getExpectedObject(RELEASE_0230_VERSION, 1);
-		assertEquals(expected, record1);
-		assertEquals(expected, record2);
-	}
 }

--- a/hedera-node/src/test/java/com/hedera/test/utils/SerdeUtils.java
+++ b/hedera-node/src/test/java/com/hedera/test/utils/SerdeUtils.java
@@ -122,15 +122,13 @@ public class SerdeUtils {
 				grpc.getData().isEmpty() ? EvmLog.MISSING_BYTES : grpc.getData().toByteArray());
 	}
 
-	public static <T extends SelfSerializable> T deserializeFromBytes(
+	public static <T extends SelfSerializable> T deserializeFromInputStream(
 			final Supplier<T> factory,
 			final int version,
-			final byte[] serializedForm
+			final InputStream inputStream
 	) {
 		final var reconstruction = factory.get();
-
-		final var bais = new ByteArrayInputStream(serializedForm);
-		final var in = new SerializableDataInputStream(bais);
+		final var in = new SerializableDataInputStream(inputStream);
 		try {
 			reconstruction.deserialize(in, version);
 		} catch (IOException e) {


### PR DESCRIPTION
**Description**:
Improve serde tests by concatenating serialized byte data multiple times and de-serializing the same object multiple times. This is to ensure that de-serialization doesn't leave extra bytes lying around which caused de-serialization failures in the past.

**Related issue(s)**:
https://github.com/hashgraph/hedera-services/issues/3114
https://github.com/hashgraph/hedera-services/issues/3185