### PR TITLE
Prefer `put()` to `getForModify()` in blob store

### DIFF
--- a/hedera-node/src/main/java/com/hedera/services/files/store/FcBlobsBytesStore.java
+++ b/hedera-node/src/main/java/com/hedera/services/files/store/FcBlobsBytesStore.java
@@ -98,14 +98,8 @@ public class FcBlobsBytesStore extends AbstractMap<String, byte[]> {
 	 */
 	@Override
 	public byte[] put(String path, byte[] value) {
-		var meta = at(path);
-		if (blobSupplier.get().containsKey(meta)) {
-			final var blob = blobSupplier.get().getForModify(meta);
-			blob.setData(value);
-		} else {
-			final VirtualBlobValue blob = new VirtualBlobValue(value);
-			blobSupplier.get().put(at(path), blob);
-		}
+		final VirtualBlobValue blob = new VirtualBlobValue(value);
+		blobSupplier.get().put(at(path), blob);
 		return null;
 	}
 

--- a/hedera-node/src/test/java/com/hedera/services/files/store/FcBlobsBytesStoreTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/files/store/FcBlobsBytesStoreTest.java
@@ -82,27 +82,12 @@ class FcBlobsBytesStoreTest {
 	}
 
 	@Test
-	void delegatesPutUsingGetForModifyIfExtantBlob() {
-		given(pathedBlobs.containsKey(pathAKey)).willReturn(true);
-		given(pathedBlobs.getForModify(pathAKey)).willReturn(blobA);
-
-		final var oldBytes = subject.put(dataPath, aData);
-
-		verify(pathedBlobs).containsKey(pathAKey);
-		verify(pathedBlobs).getForModify(pathAKey);
-
-		assertNull(oldBytes);
-	}
-
-	@Test
 	void delegatesPutUsingGetAndFactoryIfNewBlob() {
 		final var keyCaptor = ArgumentCaptor.forClass(VirtualBlobKey.class);
 		final var valueCaptor = ArgumentCaptor.forClass(VirtualBlobValue.class);
-		given(pathedBlobs.containsKey(pathAKey)).willReturn(false);
 
 		final var oldBytes = subject.put(dataPath, aData);
 
-		verify(pathedBlobs).containsKey(pathAKey);
 		verify(pathedBlobs).put(keyCaptor.capture(), valueCaptor.capture());
 
 		assertEquals(pathAKey, keyCaptor.getValue());


### PR DESCRIPTION
**Description**:
- Uses a more performant `VirtualMap` path in `FcBlobsByteStore`.