### PR TITLE
Zero Fungible/NFT Balances before Contract delete/selfdestruct operations

### DIFF
--- a/hedera-node/src/main/java/com/hedera/services/contracts/operation/HederaExceptionalHaltReason.java
+++ b/hedera-node/src/main/java/com/hedera/services/contracts/operation/HederaExceptionalHaltReason.java
@@ -50,6 +50,11 @@ public class HederaExceptionalHaltReason {
 	 */
 	public static final ExceptionalHaltReason CONTRACT_IS_TREASURY = HederaExceptionalHalt.CONTRACT_IS_TREASURY;
 	/**
+	 * Used when the target of a {@code selfdestruct} has positive fungible unit balances.
+	 */
+	public static final ExceptionalHaltReason CONTRACT_STILL_OWNS_NFTS =
+			HederaExceptionalHalt.CONTRACT_STILL_OWNS_NFTS;
+	/**
 	 * Used when the target of a {@code selfdestruct} has positive balances.
 	 */
 	public static final ExceptionalHaltReason TRANSACTION_REQUIRES_ZERO_TOKEN_BALANCES =
@@ -60,7 +65,8 @@ public class HederaExceptionalHaltReason {
 		SELF_DESTRUCT_TO_SELF("Self destruct to the same address"),
 		CONTRACT_IS_TREASURY("Token treasuries cannot be deleted"),
 		INVALID_SIGNATURE("Invalid signature"),
-		TRANSACTION_REQUIRES_ZERO_TOKEN_BALANCES("Accounts with positive balances cannot be deleted");
+		TRANSACTION_REQUIRES_ZERO_TOKEN_BALANCES("Accounts with positive fungible token balances cannot be deleted"),
+		CONTRACT_STILL_OWNS_NFTS("Accounts who own nfts cannot be deleted");
 
 		final String description;
 

--- a/hedera-node/src/main/java/com/hedera/services/contracts/operation/HederaExceptionalHaltReason.java
+++ b/hedera-node/src/main/java/com/hedera/services/contracts/operation/HederaExceptionalHaltReason.java
@@ -49,12 +49,18 @@ public class HederaExceptionalHaltReason {
 	 * Used when the target of a {@code selfdestruct} is a token treasury.
 	 */
 	public static final ExceptionalHaltReason CONTRACT_IS_TREASURY = HederaExceptionalHalt.CONTRACT_IS_TREASURY;
+	/**
+	 * Used when the target of a {@code selfdestruct} has positive balances.
+	 */
+	public static final ExceptionalHaltReason TRANSACTION_REQUIRES_ZERO_TOKEN_BALANCES =
+			HederaExceptionalHalt.TRANSACTION_REQUIRES_ZERO_TOKEN_BALANCES;
 
 	enum HederaExceptionalHalt implements ExceptionalHaltReason {
 		INVALID_SOLIDITY_ADDRESS("Invalid account reference"),
 		SELF_DESTRUCT_TO_SELF("Self destruct to the same address"),
 		CONTRACT_IS_TREASURY("Token treasuries cannot be deleted"),
-		INVALID_SIGNATURE("Invalid signature");
+		INVALID_SIGNATURE("Invalid signature"),
+		TRANSACTION_REQUIRES_ZERO_TOKEN_BALANCES("Accounts with positive balances cannot be deleted");
 
 		final String description;
 

--- a/hedera-node/src/main/java/com/hedera/services/contracts/operation/HederaSelfDestructOperation.java
+++ b/hedera-node/src/main/java/com/hedera/services/contracts/operation/HederaSelfDestructOperation.java
@@ -72,6 +72,9 @@ public class HederaSelfDestructOperation extends SelfDestructOperation {
 		if (updater.contractIsTokenTreasury(address)) {
 			return reversionWith(updater.get(beneficiaryAddress), HederaExceptionalHaltReason.CONTRACT_IS_TREASURY);
 		}
+		if (updater.contractHasAnyBalance(address)) {
+			return reversionWith(updater.get(beneficiaryAddress), HederaExceptionalHaltReason.CONTRACT_IS_TREASURY);
+		}
 		if (address.equals(beneficiaryAddress)) {
 			return reversionWith(updater.get(beneficiaryAddress), HederaExceptionalHaltReason.SELF_DESTRUCT_TO_SELF);
 		} else {

--- a/hedera-node/src/main/java/com/hedera/services/contracts/operation/HederaSelfDestructOperation.java
+++ b/hedera-node/src/main/java/com/hedera/services/contracts/operation/HederaSelfDestructOperation.java
@@ -75,6 +75,9 @@ public class HederaSelfDestructOperation extends SelfDestructOperation {
 		if (updater.contractHasAnyBalance(address)) {
 			return reversionWith(updater.get(beneficiaryAddress), HederaExceptionalHaltReason.TRANSACTION_REQUIRES_ZERO_TOKEN_BALANCES);
 		}
+		if (updater.contractOwnsNfts(address)) {
+			return reversionWith(updater.get(beneficiaryAddress), HederaExceptionalHaltReason.CONTRACT_STILL_OWNS_NFTS);
+		}
 		if (address.equals(beneficiaryAddress)) {
 			return reversionWith(updater.get(beneficiaryAddress), HederaExceptionalHaltReason.SELF_DESTRUCT_TO_SELF);
 		} else {

--- a/hedera-node/src/main/java/com/hedera/services/contracts/operation/HederaSelfDestructOperation.java
+++ b/hedera-node/src/main/java/com/hedera/services/contracts/operation/HederaSelfDestructOperation.java
@@ -68,21 +68,26 @@ public class HederaSelfDestructOperation extends SelfDestructOperation {
 		if (!addressValidator.test(beneficiaryAddress, frame)) {
 			return reversionWith(null, HederaExceptionalHaltReason.INVALID_SOLIDITY_ADDRESS);
 		}
-		final var address = frame.getRecipientAddress();
-		if (updater.contractIsTokenTreasury(address)) {
-			return reversionWith(updater.get(beneficiaryAddress), HederaExceptionalHaltReason.CONTRACT_IS_TREASURY);
+		final var toBeDeleted = frame.getRecipientAddress();
+		final var beneficiary = updater.get(beneficiaryAddress);
+
+		if (toBeDeleted.equals(beneficiaryAddress)) {
+			return reversionWith(beneficiary,
+					HederaExceptionalHaltReason.SELF_DESTRUCT_TO_SELF);
 		}
-		if (updater.contractHasAnyBalance(address)) {
-			return reversionWith(updater.get(beneficiaryAddress), HederaExceptionalHaltReason.TRANSACTION_REQUIRES_ZERO_TOKEN_BALANCES);
+		if (updater.contractIsTokenTreasury(toBeDeleted)) {
+			return reversionWith(beneficiary,
+					HederaExceptionalHaltReason.CONTRACT_IS_TREASURY);
 		}
-		if (updater.contractOwnsNfts(address)) {
-			return reversionWith(updater.get(beneficiaryAddress), HederaExceptionalHaltReason.CONTRACT_STILL_OWNS_NFTS);
+		if (updater.contractHasAnyBalance(toBeDeleted)) {
+			return reversionWith(beneficiary,
+					HederaExceptionalHaltReason.TRANSACTION_REQUIRES_ZERO_TOKEN_BALANCES);
 		}
-		if (address.equals(beneficiaryAddress)) {
-			return reversionWith(updater.get(beneficiaryAddress), HederaExceptionalHaltReason.SELF_DESTRUCT_TO_SELF);
-		} else {
-			return super.execute(frame, evm);
+		if (updater.contractOwnsNfts(toBeDeleted)) {
+			return reversionWith(beneficiary,
+					HederaExceptionalHaltReason.CONTRACT_STILL_OWNS_NFTS);
 		}
+		return super.execute(frame, evm);
 	}
 
 	private OperationResult reversionWith(final Account beneficiary, final ExceptionalHaltReason reason) {

--- a/hedera-node/src/main/java/com/hedera/services/contracts/operation/HederaSelfDestructOperation.java
+++ b/hedera-node/src/main/java/com/hedera/services/contracts/operation/HederaSelfDestructOperation.java
@@ -73,7 +73,7 @@ public class HederaSelfDestructOperation extends SelfDestructOperation {
 			return reversionWith(updater.get(beneficiaryAddress), HederaExceptionalHaltReason.CONTRACT_IS_TREASURY);
 		}
 		if (updater.contractHasAnyBalance(address)) {
-			return reversionWith(updater.get(beneficiaryAddress), HederaExceptionalHaltReason.CONTRACT_IS_TREASURY);
+			return reversionWith(updater.get(beneficiaryAddress), HederaExceptionalHaltReason.TRANSACTION_REQUIRES_ZERO_TOKEN_BALANCES);
 		}
 		if (address.equals(beneficiaryAddress)) {
 			return reversionWith(updater.get(beneficiaryAddress), HederaExceptionalHaltReason.SELF_DESTRUCT_TO_SELF);

--- a/hedera-node/src/main/java/com/hedera/services/ledger/HederaLedger.java
+++ b/hedera-node/src/main/java/com/hedera/services/ledger/HederaLedger.java
@@ -287,6 +287,10 @@ public class HederaLedger {
 		return (int) accountsLedger.get(aId, NUM_TREASURY_TITLES) > 0;
 	}
 
+	public boolean hasAnyBalance(final AccountID aId) {
+		return (int) accountsLedger.get(aId, NUM_POSITIVE_BALANCES) > 0;
+	}
+
 	public ResponseCodeEnum adjustTokenBalance(AccountID aId, TokenID tId, long adjustment) {
 		return tokenStore.adjustBalance(aId, tId, adjustment);
 	}

--- a/hedera-node/src/main/java/com/hedera/services/ledger/HederaLedger.java
+++ b/hedera-node/src/main/java/com/hedera/services/ledger/HederaLedger.java
@@ -293,7 +293,7 @@ public class HederaLedger {
 	}
 
 	public boolean hasAnyNfts(final AccountID aId) {
-		return (int) accountsLedger.get(aId, NUM_NFTS_OWNED) > 0;
+		return (long) accountsLedger.get(aId, NUM_NFTS_OWNED) > 0;
 	}
 
 	public ResponseCodeEnum adjustTokenBalance(AccountID aId, TokenID tId, long adjustment) {

--- a/hedera-node/src/main/java/com/hedera/services/ledger/HederaLedger.java
+++ b/hedera-node/src/main/java/com/hedera/services/ledger/HederaLedger.java
@@ -65,6 +65,7 @@ import static com.hedera.services.ledger.properties.AccountProperty.IS_SMART_CON
 import static com.hedera.services.ledger.properties.AccountProperty.KEY;
 import static com.hedera.services.ledger.properties.AccountProperty.MAX_AUTOMATIC_ASSOCIATIONS;
 import static com.hedera.services.ledger.properties.AccountProperty.MEMO;
+import static com.hedera.services.ledger.properties.AccountProperty.NUM_NFTS_OWNED;
 import static com.hedera.services.ledger.properties.AccountProperty.NUM_POSITIVE_BALANCES;
 import static com.hedera.services.ledger.properties.AccountProperty.NUM_TREASURY_TITLES;
 import static com.hedera.services.ledger.properties.AccountProperty.USED_AUTOMATIC_ASSOCIATIONS;
@@ -287,8 +288,12 @@ public class HederaLedger {
 		return (int) accountsLedger.get(aId, NUM_TREASURY_TITLES) > 0;
 	}
 
-	public boolean hasAnyBalance(final AccountID aId) {
+	public boolean hasAnyFungibleTokenBalance(final AccountID aId) {
 		return (int) accountsLedger.get(aId, NUM_POSITIVE_BALANCES) > 0;
+	}
+
+	public boolean hasAnyNfts(final AccountID aId) {
+		return (int) accountsLedger.get(aId, NUM_NFTS_OWNED) > 0;
 	}
 
 	public ResponseCodeEnum adjustTokenBalance(AccountID aId, TokenID tId, long adjustment) {

--- a/hedera-node/src/main/java/com/hedera/services/ledger/HederaLedger.java
+++ b/hedera-node/src/main/java/com/hedera/services/ledger/HederaLedger.java
@@ -293,7 +293,7 @@ public class HederaLedger {
 	}
 
 	public boolean hasAnyNfts(final AccountID aId) {
-		return (long) accountsLedger.get(aId, NUM_NFTS_OWNED) > 0;
+		return (long) accountsLedger.get(aId, NUM_NFTS_OWNED) > 0L;
 	}
 
 	public ResponseCodeEnum adjustTokenBalance(AccountID aId, TokenID tId, long adjustment) {

--- a/hedera-node/src/main/java/com/hedera/services/store/contracts/HederaStackedWorldStateUpdater.java
+++ b/hedera-node/src/main/java/com/hedera/services/store/contracts/HederaStackedWorldStateUpdater.java
@@ -38,6 +38,7 @@ import org.hyperledger.besu.evm.account.EvmAccount;
 import org.hyperledger.besu.evm.worldstate.WorldUpdater;
 import org.hyperledger.besu.evm.worldstate.WrappedEvmAccount;
 
+import static com.hedera.services.ledger.properties.AccountProperty.NUM_POSITIVE_BALANCES;
 import static com.hedera.services.ledger.properties.AccountProperty.NUM_TREASURY_TITLES;
 import static com.hedera.services.utils.EntityIdUtils.accountIdFromEvmAddress;
 import static com.hedera.services.utils.EntityIdUtils.contractIdFromEvmAddress;
@@ -75,6 +76,12 @@ public class HederaStackedWorldStateUpdater
 		final var address = aliases().resolveForEvm(addressOrAlias);
 		final var accountId = accountIdFromEvmAddress(address);
 		return (int) trackingAccounts().get(accountId, NUM_TREASURY_TITLES) > 0;
+	}
+
+	public boolean contractHasAnyBalance(final Address addressOrAlias) {
+		final var address = aliases().resolveForEvm(addressOrAlias);
+		final var accountId = accountIdFromEvmAddress(address);
+		return (int) trackingAccounts().get(accountId, NUM_POSITIVE_BALANCES) > 0;
 	}
 
 	public byte[] unaliased(final byte[] evmAddress) {

--- a/hedera-node/src/main/java/com/hedera/services/store/contracts/HederaStackedWorldStateUpdater.java
+++ b/hedera-node/src/main/java/com/hedera/services/store/contracts/HederaStackedWorldStateUpdater.java
@@ -88,7 +88,7 @@ public class HederaStackedWorldStateUpdater
 	public boolean contractOwnsNfts(final Address addressOrAlias) {
 		final var address = aliases().resolveForEvm(addressOrAlias);
 		final var accountId = accountIdFromEvmAddress(address);
-		return (int) trackingAccounts().get(accountId, NUM_NFTS_OWNED) > 0;
+		return (long) trackingAccounts().get(accountId, NUM_NFTS_OWNED) > 0;
 	}
 
 	public byte[] unaliased(final byte[] evmAddress) {

--- a/hedera-node/src/main/java/com/hedera/services/store/contracts/HederaStackedWorldStateUpdater.java
+++ b/hedera-node/src/main/java/com/hedera/services/store/contracts/HederaStackedWorldStateUpdater.java
@@ -38,6 +38,7 @@ import org.hyperledger.besu.evm.account.EvmAccount;
 import org.hyperledger.besu.evm.worldstate.WorldUpdater;
 import org.hyperledger.besu.evm.worldstate.WrappedEvmAccount;
 
+import static com.hedera.services.ledger.properties.AccountProperty.NUM_NFTS_OWNED;
 import static com.hedera.services.ledger.properties.AccountProperty.NUM_POSITIVE_BALANCES;
 import static com.hedera.services.ledger.properties.AccountProperty.NUM_TREASURY_TITLES;
 import static com.hedera.services.utils.EntityIdUtils.accountIdFromEvmAddress;
@@ -82,6 +83,12 @@ public class HederaStackedWorldStateUpdater
 		final var address = aliases().resolveForEvm(addressOrAlias);
 		final var accountId = accountIdFromEvmAddress(address);
 		return (int) trackingAccounts().get(accountId, NUM_POSITIVE_BALANCES) > 0;
+	}
+
+	public boolean contractOwnsNfts(final Address addressOrAlias) {
+		final var address = aliases().resolveForEvm(addressOrAlias);
+		final var accountId = accountIdFromEvmAddress(address);
+		return (int) trackingAccounts().get(accountId, NUM_NFTS_OWNED) > 0;
 	}
 
 	public byte[] unaliased(final byte[] evmAddress) {

--- a/hedera-node/src/main/java/com/hedera/services/store/contracts/HederaStackedWorldStateUpdater.java
+++ b/hedera-node/src/main/java/com/hedera/services/store/contracts/HederaStackedWorldStateUpdater.java
@@ -88,7 +88,7 @@ public class HederaStackedWorldStateUpdater
 	public boolean contractOwnsNfts(final Address addressOrAlias) {
 		final var address = aliases().resolveForEvm(addressOrAlias);
 		final var accountId = accountIdFromEvmAddress(address);
-		return (long) trackingAccounts().get(accountId, NUM_NFTS_OWNED) > 0;
+		return (long) trackingAccounts().get(accountId, NUM_NFTS_OWNED) > 0L;
 	}
 
 	public byte[] unaliased(final byte[] evmAddress) {

--- a/hedera-node/src/main/java/com/hedera/services/txns/contract/helpers/DeletionLogic.java
+++ b/hedera-node/src/main/java/com/hedera/services/txns/contract/helpers/DeletionLogic.java
@@ -40,6 +40,7 @@ import static com.hedera.services.exceptions.ValidationUtils.validateTrue;
 import static com.hedera.services.utils.EntityIdUtils.unaliased;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.ACCOUNT_EXPIRED_AND_PENDING_REMOVAL;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.ACCOUNT_IS_TREASURY;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.ACCOUNT_STILL_OWNS_NFTS;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OBTAINER_DOES_NOT_EXIST;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OBTAINER_REQUIRED;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OBTAINER_SAME_CONTRACT_ID;
@@ -76,7 +77,8 @@ public class DeletionLogic {
 		final var id = unaliased(op.getContractID(), aliasManager);
 		final var tbd = id.toGrpcAccountId();
 		validateFalse(ledger.isKnownTreasury(tbd), ACCOUNT_IS_TREASURY);
-		validateFalse(ledger.hasAnyBalance(tbd), TRANSACTION_REQUIRES_ZERO_TOKEN_BALANCES);
+		validateFalse(ledger.hasAnyFungibleTokenBalance(tbd), TRANSACTION_REQUIRES_ZERO_TOKEN_BALANCES);
+		validateFalse(ledger.hasAnyNfts(tbd), ACCOUNT_STILL_OWNS_NFTS);
 
 		final var obtainer = obtainerOf(op);
 		validateFalse(tbd.equals(obtainer), OBTAINER_SAME_CONTRACT_ID);

--- a/hedera-node/src/main/java/com/hedera/services/txns/contract/helpers/DeletionLogic.java
+++ b/hedera-node/src/main/java/com/hedera/services/txns/contract/helpers/DeletionLogic.java
@@ -43,6 +43,7 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.ACCOUNT_IS_TRE
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OBTAINER_DOES_NOT_EXIST;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OBTAINER_REQUIRED;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OBTAINER_SAME_CONTRACT_ID;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TRANSACTION_REQUIRES_ZERO_TOKEN_BALANCES;
 
 public class DeletionLogic {
 	private final HederaLedger ledger;
@@ -75,6 +76,7 @@ public class DeletionLogic {
 		final var id = unaliased(op.getContractID(), aliasManager);
 		final var tbd = id.toGrpcAccountId();
 		validateFalse(ledger.isKnownTreasury(tbd), ACCOUNT_IS_TREASURY);
+		validateFalse(ledger.hasAnyBalance(tbd), TRANSACTION_REQUIRES_ZERO_TOKEN_BALANCES);
 
 		final var obtainer = obtainerOf(op);
 		validateFalse(tbd.equals(obtainer), OBTAINER_SAME_CONTRACT_ID);

--- a/hedera-node/src/test/java/com/hedera/services/contracts/operation/HederaSelfDestructOperationTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/contracts/operation/HederaSelfDestructOperationTest.java
@@ -48,7 +48,9 @@ import static org.mockito.BDDMockito.given;
 class HederaSelfDestructOperationTest {
 	private static final EntityNum beneficiary = EntityNum.fromLong(2_345);
 	private static final String ethAddress = "0xc257274276a4e539741ca11b590b9447b26a8051";
+	private static final String anotherEthAddress = "0xc257274276a4e539741ca11b590b9447b26a8052";
 	private static final Address eip1014Address = Address.fromHexString(ethAddress);
+	private static final Address anotherEip1014Address = Address.fromHexString(anotherEthAddress);
 
 	@Mock
 	private HederaStackedWorldStateUpdater worldUpdater;
@@ -114,7 +116,7 @@ class HederaSelfDestructOperationTest {
 
 		final var beneficiaryMirror = beneficiary.toEvmAddress();
 		given(frame.getStackItem(0)).willReturn(beneficiaryMirror);
-		given(worldUpdater.priorityAddress(beneficiaryMirror)).willReturn(eip1014Address);
+		given(worldUpdater.priorityAddress(beneficiaryMirror)).willReturn(anotherEip1014Address);
 		given(frame.getRecipientAddress()).willReturn(eip1014Address);
 		given(worldUpdater.contractIsTokenTreasury(eip1014Address)).willReturn(true);
 
@@ -130,7 +132,7 @@ class HederaSelfDestructOperationTest {
 
 		final var beneficiaryMirror = beneficiary.toEvmAddress();
 		given(frame.getStackItem(0)).willReturn(beneficiaryMirror);
-		given(worldUpdater.priorityAddress(beneficiaryMirror)).willReturn(eip1014Address);
+		given(worldUpdater.priorityAddress(beneficiaryMirror)).willReturn(anotherEip1014Address);
 		given(frame.getRecipientAddress()).willReturn(eip1014Address);
 		given(worldUpdater.contractHasAnyBalance(eip1014Address)).willReturn(true);
 
@@ -146,7 +148,7 @@ class HederaSelfDestructOperationTest {
 
 		final var beneficiaryMirror = beneficiary.toEvmAddress();
 		given(frame.getStackItem(0)).willReturn(beneficiaryMirror);
-		given(worldUpdater.priorityAddress(beneficiaryMirror)).willReturn(eip1014Address);
+		given(worldUpdater.priorityAddress(beneficiaryMirror)).willReturn(anotherEip1014Address);
 		given(frame.getRecipientAddress()).willReturn(eip1014Address);
 		given(worldUpdater.contractOwnsNfts(eip1014Address)).willReturn(true);
 

--- a/hedera-node/src/test/java/com/hedera/services/contracts/operation/HederaSelfDestructOperationTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/contracts/operation/HederaSelfDestructOperationTest.java
@@ -125,6 +125,22 @@ class HederaSelfDestructOperationTest {
 	}
 
 	@Test
+	void rejectsSelfDestructIfContractHasAnyBalance() {
+		givenRubberstampValidator();
+
+		final var beneficiaryMirror = beneficiary.toEvmAddress();
+		given(frame.getStackItem(0)).willReturn(beneficiaryMirror);
+		given(worldUpdater.priorityAddress(beneficiaryMirror)).willReturn(eip1014Address);
+		given(frame.getRecipientAddress()).willReturn(eip1014Address);
+		given(worldUpdater.contractHasAnyBalance(eip1014Address)).willReturn(true);
+
+		final var opResult = subject.execute(frame, evm);
+
+		assertEquals(Optional.of(HederaExceptionalHaltReason.TRANSACTION_REQUIRES_ZERO_TOKEN_BALANCES), opResult.getHaltReason());
+		assertEquals(Optional.of(Gas.of(2L)), opResult.getGasCost());
+	}
+
+	@Test
 	void executeInvalidSolidityAddress() {
 		givenRejectingValidator();
 

--- a/hedera-node/src/test/java/com/hedera/services/contracts/operation/HederaSelfDestructOperationTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/contracts/operation/HederaSelfDestructOperationTest.java
@@ -125,7 +125,7 @@ class HederaSelfDestructOperationTest {
 	}
 
 	@Test
-	void rejectsSelfDestructIfContractHasAnyBalance() {
+	void rejectsSelfDestructIfContractHasAnyTokenBalance() {
 		givenRubberstampValidator();
 
 		final var beneficiaryMirror = beneficiary.toEvmAddress();
@@ -137,6 +137,22 @@ class HederaSelfDestructOperationTest {
 		final var opResult = subject.execute(frame, evm);
 
 		assertEquals(Optional.of(HederaExceptionalHaltReason.TRANSACTION_REQUIRES_ZERO_TOKEN_BALANCES), opResult.getHaltReason());
+		assertEquals(Optional.of(Gas.of(2L)), opResult.getGasCost());
+	}
+
+	@Test
+	void rejectsSelfDestructIfContractHasAnyNfts() {
+		givenRubberstampValidator();
+
+		final var beneficiaryMirror = beneficiary.toEvmAddress();
+		given(frame.getStackItem(0)).willReturn(beneficiaryMirror);
+		given(worldUpdater.priorityAddress(beneficiaryMirror)).willReturn(eip1014Address);
+		given(frame.getRecipientAddress()).willReturn(eip1014Address);
+		given(worldUpdater.contractOwnsNfts(eip1014Address)).willReturn(true);
+
+		final var opResult = subject.execute(frame, evm);
+
+		assertEquals(Optional.of(HederaExceptionalHaltReason.CONTRACT_STILL_OWNS_NFTS), opResult.getHaltReason());
 		assertEquals(Optional.of(Gas.of(2L)), opResult.getGasCost());
 	}
 

--- a/hedera-node/src/test/java/com/hedera/services/ledger/HederaLedgerTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/ledger/HederaLedgerTest.java
@@ -48,6 +48,7 @@ import static com.hedera.services.ledger.properties.AccountProperty.IS_SMART_CON
 import static com.hedera.services.ledger.properties.AccountProperty.KEY;
 import static com.hedera.services.ledger.properties.AccountProperty.MAX_AUTOMATIC_ASSOCIATIONS;
 import static com.hedera.services.ledger.properties.AccountProperty.MEMO;
+import static com.hedera.services.ledger.properties.AccountProperty.NUM_POSITIVE_BALANCES;
 import static com.hedera.services.ledger.properties.AccountProperty.NUM_TREASURY_TITLES;
 import static com.hedera.services.ledger.properties.AccountProperty.USED_AUTOMATIC_ASSOCIATIONS;
 import static com.hedera.test.utils.IdUtils.asAccount;
@@ -83,6 +84,14 @@ class HederaLedgerTest extends BaseHederaLedgerTestHelper {
 		assertFalse(subject.isKnownTreasury(misc));
 		given(accountsLedger.get(misc, NUM_TREASURY_TITLES)).willReturn(1);
 		assertTrue(subject.isKnownTreasury(misc));
+	}
+
+	@Test
+	void understandsNonZeroBalanceValidation() {
+		given(accountsLedger.get(misc, NUM_POSITIVE_BALANCES)).willReturn(0);
+		assertFalse(subject.hasAnyBalance(misc));
+		given(accountsLedger.get(misc, NUM_POSITIVE_BALANCES)).willReturn(1);
+		assertTrue(subject.hasAnyBalance(misc));
 	}
 
 	@Test

--- a/hedera-node/src/test/java/com/hedera/services/ledger/HederaLedgerTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/ledger/HederaLedgerTest.java
@@ -48,6 +48,7 @@ import static com.hedera.services.ledger.properties.AccountProperty.IS_SMART_CON
 import static com.hedera.services.ledger.properties.AccountProperty.KEY;
 import static com.hedera.services.ledger.properties.AccountProperty.MAX_AUTOMATIC_ASSOCIATIONS;
 import static com.hedera.services.ledger.properties.AccountProperty.MEMO;
+import static com.hedera.services.ledger.properties.AccountProperty.NUM_NFTS_OWNED;
 import static com.hedera.services.ledger.properties.AccountProperty.NUM_POSITIVE_BALANCES;
 import static com.hedera.services.ledger.properties.AccountProperty.NUM_TREASURY_TITLES;
 import static com.hedera.services.ledger.properties.AccountProperty.USED_AUTOMATIC_ASSOCIATIONS;
@@ -89,9 +90,13 @@ class HederaLedgerTest extends BaseHederaLedgerTestHelper {
 	@Test
 	void understandsNonZeroBalanceValidation() {
 		given(accountsLedger.get(misc, NUM_POSITIVE_BALANCES)).willReturn(0);
-		assertFalse(subject.hasAnyBalance(misc));
+		assertFalse(subject.hasAnyFungibleTokenBalance(misc));
 		given(accountsLedger.get(misc, NUM_POSITIVE_BALANCES)).willReturn(1);
-		assertTrue(subject.hasAnyBalance(misc));
+		assertTrue(subject.hasAnyFungibleTokenBalance(misc));
+		given(accountsLedger.get(misc, NUM_NFTS_OWNED)).willReturn(0);
+		assertFalse(subject.hasAnyNfts(misc));
+		given(accountsLedger.get(misc, NUM_NFTS_OWNED)).willReturn(1);
+		assertTrue(subject.hasAnyNfts(misc));
 	}
 
 	@Test

--- a/hedera-node/src/test/java/com/hedera/services/ledger/HederaLedgerTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/ledger/HederaLedgerTest.java
@@ -93,9 +93,9 @@ class HederaLedgerTest extends BaseHederaLedgerTestHelper {
 		assertFalse(subject.hasAnyFungibleTokenBalance(misc));
 		given(accountsLedger.get(misc, NUM_POSITIVE_BALANCES)).willReturn(1);
 		assertTrue(subject.hasAnyFungibleTokenBalance(misc));
-		given(accountsLedger.get(misc, NUM_NFTS_OWNED)).willReturn(0);
+		given(accountsLedger.get(misc, NUM_NFTS_OWNED)).willReturn(0L);
 		assertFalse(subject.hasAnyNfts(misc));
-		given(accountsLedger.get(misc, NUM_NFTS_OWNED)).willReturn(1);
+		given(accountsLedger.get(misc, NUM_NFTS_OWNED)).willReturn(1L);
 		assertTrue(subject.hasAnyNfts(misc));
 	}
 

--- a/hedera-node/src/test/java/com/hedera/services/store/contracts/HederaStackedWorldStateUpdaterTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/store/contracts/HederaStackedWorldStateUpdaterTest.java
@@ -41,6 +41,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import static com.hedera.services.ledger.properties.AccountProperty.NUM_POSITIVE_BALANCES;
 import static com.hedera.services.ledger.properties.AccountProperty.NUM_TREASURY_TITLES;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -95,6 +96,19 @@ class HederaStackedWorldStateUpdaterTest {
 		assertTrue(subject.contractIsTokenTreasury(treasuryAddress));
 		given(accountsLedger.get(treasuryAddressId, NUM_TREASURY_TITLES)).willReturn(0);
 		assertFalse(subject.contractIsTokenTreasury(treasuryAddress));
+	}
+
+	@Test
+	void recognizesNonZeroBalanceAccount() {
+		final var treasuryAddress = Address.BLS12_MAP_FP2_TO_G2;
+		final var positiveBalanceId = EntityIdUtils.accountIdFromEvmAddress(treasuryAddress);
+		given(aliases.resolveForEvm(treasuryAddress)).willReturn(treasuryAddress);
+		given(trackingLedgers.accounts()).willReturn(accountsLedger);
+		given(trackingLedgers.aliases()).willReturn(aliases);
+		given(accountsLedger.get(positiveBalanceId, NUM_POSITIVE_BALANCES)).willReturn(1);
+		assertTrue(subject.contractHasAnyBalance(treasuryAddress));
+		given(accountsLedger.get(positiveBalanceId, NUM_POSITIVE_BALANCES)).willReturn(0);
+		assertFalse(subject.contractHasAnyBalance(treasuryAddress));
 	}
 
 	@Test

--- a/hedera-node/src/test/java/com/hedera/services/store/contracts/HederaStackedWorldStateUpdaterTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/store/contracts/HederaStackedWorldStateUpdaterTest.java
@@ -119,9 +119,9 @@ class HederaStackedWorldStateUpdaterTest {
 		given(aliases.resolveForEvm(treasuryAddress)).willReturn(treasuryAddress);
 		given(trackingLedgers.accounts()).willReturn(accountsLedger);
 		given(trackingLedgers.aliases()).willReturn(aliases);
-		given(accountsLedger.get(positiveBalanceId, NUM_NFTS_OWNED)).willReturn(1);
+		given(accountsLedger.get(positiveBalanceId, NUM_NFTS_OWNED)).willReturn(1L);
 		assertTrue(subject.contractOwnsNfts(treasuryAddress));
-		given(accountsLedger.get(positiveBalanceId, NUM_NFTS_OWNED)).willReturn(0);
+		given(accountsLedger.get(positiveBalanceId, NUM_NFTS_OWNED)).willReturn(0L);
 		assertFalse(subject.contractOwnsNfts(treasuryAddress));
 	}
 

--- a/hedera-node/src/test/java/com/hedera/services/store/contracts/HederaStackedWorldStateUpdaterTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/store/contracts/HederaStackedWorldStateUpdaterTest.java
@@ -41,6 +41,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import static com.hedera.services.ledger.properties.AccountProperty.NUM_NFTS_OWNED;
 import static com.hedera.services.ledger.properties.AccountProperty.NUM_POSITIVE_BALANCES;
 import static com.hedera.services.ledger.properties.AccountProperty.NUM_TREASURY_TITLES;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
@@ -99,7 +100,7 @@ class HederaStackedWorldStateUpdaterTest {
 	}
 
 	@Test
-	void recognizesNonZeroBalanceAccount() {
+	void recognizesNonZeroTokenBalanceAccount() {
 		final var treasuryAddress = Address.BLS12_MAP_FP2_TO_G2;
 		final var positiveBalanceId = EntityIdUtils.accountIdFromEvmAddress(treasuryAddress);
 		given(aliases.resolveForEvm(treasuryAddress)).willReturn(treasuryAddress);
@@ -109,6 +110,19 @@ class HederaStackedWorldStateUpdaterTest {
 		assertTrue(subject.contractHasAnyBalance(treasuryAddress));
 		given(accountsLedger.get(positiveBalanceId, NUM_POSITIVE_BALANCES)).willReturn(0);
 		assertFalse(subject.contractHasAnyBalance(treasuryAddress));
+	}
+
+	@Test
+	void recognizesAccountWhoStillOwnsNfts() {
+		final var treasuryAddress = Address.BLS12_MAP_FP2_TO_G2;
+		final var positiveBalanceId = EntityIdUtils.accountIdFromEvmAddress(treasuryAddress);
+		given(aliases.resolveForEvm(treasuryAddress)).willReturn(treasuryAddress);
+		given(trackingLedgers.accounts()).willReturn(accountsLedger);
+		given(trackingLedgers.aliases()).willReturn(aliases);
+		given(accountsLedger.get(positiveBalanceId, NUM_NFTS_OWNED)).willReturn(1);
+		assertTrue(subject.contractOwnsNfts(treasuryAddress));
+		given(accountsLedger.get(positiveBalanceId, NUM_NFTS_OWNED)).willReturn(0);
+		assertFalse(subject.contractOwnsNfts(treasuryAddress));
 	}
 
 	@Test

--- a/hedera-node/src/test/java/com/hedera/services/txns/contract/helpers/DeletionLogicTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/txns/contract/helpers/DeletionLogicTest.java
@@ -41,6 +41,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import static com.hedera.test.utils.TxnUtils.assertFailsWith;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.ACCOUNT_EXPIRED_AND_PENDING_REMOVAL;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.ACCOUNT_IS_TREASURY;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.ACCOUNT_STILL_OWNS_NFTS;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.CONTRACT_DELETED;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OBTAINER_DOES_NOT_EXIST;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OBTAINER_REQUIRED;
@@ -173,8 +174,15 @@ class DeletionLogicTest {
 	@Test
 	void rejectsPositiveBalanceContract() {
 		final var op = opWithAccountObtainer(mirrorId, obtainer);
-		given(ledger.hasAnyBalance(target)).willReturn(true);
+		given(ledger.hasAnyFungibleTokenBalance(target)).willReturn(true);
 		assertFailsWith(() -> subject.performFor(op), TRANSACTION_REQUIRES_ZERO_TOKEN_BALANCES);
+	}
+
+	@Test
+	void rejectsContractWhoOwnsNfts() {
+		final var op = opWithAccountObtainer(mirrorId, obtainer);
+		given(ledger.hasAnyNfts(target)).willReturn(true);
+		assertFailsWith(() -> subject.performFor(op), ACCOUNT_STILL_OWNS_NFTS);
 	}
 
 	@Test

--- a/hedera-node/src/test/java/com/hedera/services/txns/contract/helpers/DeletionLogicTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/txns/contract/helpers/DeletionLogicTest.java
@@ -45,6 +45,7 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.CONTRACT_DELET
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OBTAINER_DOES_NOT_EXIST;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OBTAINER_REQUIRED;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OBTAINER_SAME_CONTRACT_ID;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TRANSACTION_REQUIRES_ZERO_TOKEN_BALANCES;
 import static com.swirlds.common.CommonUtils.unhex;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
@@ -167,6 +168,13 @@ class DeletionLogicTest {
 		final var op = opWithAccountObtainer(mirrorId, obtainer);
 		given(ledger.isKnownTreasury(target)).willReturn(true);
 		assertFailsWith(() -> subject.performFor(op), ACCOUNT_IS_TREASURY);
+	}
+
+	@Test
+	void rejectsPositiveBalanceContract() {
+		final var op = opWithAccountObtainer(mirrorId, obtainer);
+		given(ledger.hasAnyBalance(target)).willReturn(true);
+		assertFailsWith(() -> subject.performFor(op), TRANSACTION_REQUIRES_ZERO_TOKEN_BALANCES);
 	}
 
 	@Test

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hapi/ContractDeleteSuite.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hapi/ContractDeleteSuite.java
@@ -20,10 +20,13 @@ package com.hedera.services.bdd.suites.contract.hapi;
  * ‍
  */
 
+import com.google.protobuf.ByteString;
 import com.hedera.services.bdd.spec.HapiApiSpec;
 import com.hedera.services.bdd.spec.infrastructure.meta.ContractResources;
 import com.hedera.services.bdd.spec.transactions.token.TokenMovement;
 import com.hedera.services.bdd.suites.HapiApiSuite;
+import com.hederahashgraph.api.proto.java.TokenSupplyType;
+import com.hederahashgraph.api.proto.java.TokenType;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -41,6 +44,7 @@ import static com.hedera.services.bdd.spec.transactions.TxnVerbs.contractDelete;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoCreate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoTransfer;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.fileCreate;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.mintToken;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.systemContractDelete;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.systemContractUndelete;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.tokenAssociate;
@@ -77,7 +81,8 @@ public class ContractDeleteSuite extends HapiApiSuite {
 						deleteTransfersToAccount(),
 						deleteTransfersToContract(),
 						cannotDeleteOrSelfDestructTokenTreasury(),
-						cannotDeleteOrSelfDestructContractWithNonZeroBalance()
+						cannotDeleteOrSelfDestructContractWithNonZeroTokenBalance(),
+						cannotDeleteOrSelfDestructContractWhoOwnsNfts()
 				}
 		);
 	}
@@ -122,14 +127,14 @@ public class ContractDeleteSuite extends HapiApiSuite {
 				);
 	}
 
-	HapiApiSpec cannotDeleteOrSelfDestructContractWithNonZeroBalance() {
+	HapiApiSpec cannotDeleteOrSelfDestructContractWithNonZeroTokenBalance() {
 		final var firstContractTreasury = "contract1";
 		final var nonZeroBalanceContract = "contract2";
 		final var someToken = "someToken";
 		final var initcode = "initcode";
 		final var multiKey = "multi";
 
-		return defaultHapiSpec("CannotDeleteOrSelfDestructContractWithNonZeroBalance")
+		return defaultHapiSpec("CannotDeleteOrSelfDestructContractWithNonZeroTokenBalance")
 				.given(
 						newKeyNamed(multiKey),
 						fileCreate(initcode)
@@ -149,6 +154,46 @@ public class ContractDeleteSuite extends HapiApiSuite {
 				).when(
 						tokenAssociate(nonZeroBalanceContract, someToken),
 						cryptoTransfer(TokenMovement.moving(5, someToken)
+								.between(firstContractTreasury, nonZeroBalanceContract))
+				).then(
+						contractDelete(nonZeroBalanceContract)
+								.hasKnownStatus(TRANSACTION_REQUIRES_ZERO_TOKEN_BALANCES),
+						contractCall(nonZeroBalanceContract, SELF_DESTRUCT_CALL_ABI)
+								.hasKnownStatus(CONTRACT_EXECUTION_EXCEPTION)
+				);
+	}
+
+	HapiApiSpec cannotDeleteOrSelfDestructContractWhoOwnsNfts() {
+		final var firstContractTreasury = "contract1";
+		final var nonZeroBalanceContract = "contract2";
+		final var someToken = "someToken";
+		final var initcode = "initcode";
+		final var multiKey = "multi";
+
+		return defaultHapiSpec("CannotDeleteOrSelfDestructContractWhoOwnsNfts")
+				.given(
+						newKeyNamed(multiKey),
+						fileCreate(initcode)
+								.path(ContractResources.SELF_DESTRUCT_CALLABLE),
+						contractCreate(firstContractTreasury)
+								.adminKey(multiKey)
+								.bytecode(initcode)
+								.balance(123),
+						contractCreate(nonZeroBalanceContract)
+								.adminKey(multiKey)
+								.bytecode(initcode)
+								.balance(321),
+						tokenCreate(someToken)
+								.initialSupply(0L)
+								.adminKey(multiKey)
+								.supplyKey(multiKey)
+								.treasury(firstContractTreasury)
+								.supplyType(TokenSupplyType.INFINITE)
+								.tokenType(TokenType.NON_FUNGIBLE_UNIQUE)
+				).when(
+						mintToken(someToken, List.of(ByteString.copyFromUtf8("somemetadata"))),
+						tokenAssociate(nonZeroBalanceContract, someToken),
+						cryptoTransfer(TokenMovement.movingUnique(someToken, 1)
 								.between(firstContractTreasury, nonZeroBalanceContract))
 				).then(
 						contractDelete(nonZeroBalanceContract)


### PR DESCRIPTION
**Description**:
In this PR I added non-zero balance checks inside ContractDeleteTransitionLogic and HederaSelfDestructOperation so that both through HAPI and through EVM we validate that when deleting a contract it has already sent all of its token balances somewhere else.

**Related issue(s)**:
Addresses zero balance check for selfdestruct/delete operations on contracts.

Fixes #3087

**Checklist**
- [x] Tested (unit, integration, etc.)
