### PR TITLE
Self Destruct Operation Address Filtering

### DIFF
--- a/hedera-node/src/main/java/com/hedera/services/contracts/operation/HederaSelfDestructOperation.java
+++ b/hedera-node/src/main/java/com/hedera/services/contracts/operation/HederaSelfDestructOperation.java
@@ -66,7 +66,7 @@ public class HederaSelfDestructOperation extends SelfDestructOperation {
 		final var beneficiaryAddress = Words.toAddress(frame.getStackItem(0));
 		final var toBeDeleted = frame.getRecipientAddress();
 		final var beneficiary = updater.get(beneficiaryAddress);
-		if (!addressValidator.test(beneficiaryAddress, frame) || !toBeDeleted.equals(updater.priorityAddress(toBeDeleted))) {
+		if (!addressValidator.test(beneficiaryAddress, frame)) {
 			return reversionWith(null, HederaExceptionalHaltReason.INVALID_SOLIDITY_ADDRESS);
 		}
 

--- a/hedera-node/src/main/java/com/hedera/services/contracts/operation/HederaSelfDestructOperation.java
+++ b/hedera-node/src/main/java/com/hedera/services/contracts/operation/HederaSelfDestructOperation.java
@@ -63,13 +63,12 @@ public class HederaSelfDestructOperation extends SelfDestructOperation {
 	@Override
 	public OperationResult execute(final MessageFrame frame, final EVM evm) {
 		final var updater = (HederaStackedWorldStateUpdater) frame.getWorldUpdater();
-		final var beneficiaryAddressOrAlias = Words.toAddress(frame.getStackItem(0));
-		final var beneficiaryAddress = updater.priorityAddress(beneficiaryAddressOrAlias);
-		if (!addressValidator.test(beneficiaryAddress, frame)) {
-			return reversionWith(null, HederaExceptionalHaltReason.INVALID_SOLIDITY_ADDRESS);
-		}
+		final var beneficiaryAddress = Words.toAddress(frame.getStackItem(0));
 		final var toBeDeleted = frame.getRecipientAddress();
 		final var beneficiary = updater.get(beneficiaryAddress);
+		if (!addressValidator.test(beneficiaryAddress, frame) || !toBeDeleted.equals(updater.priorityAddress(toBeDeleted))) {
+			return reversionWith(null, HederaExceptionalHaltReason.INVALID_SOLIDITY_ADDRESS);
+		}
 
 		if (toBeDeleted.equals(beneficiaryAddress)) {
 			return reversionWith(beneficiary,

--- a/hedera-node/src/test/java/com/hedera/services/contracts/operation/HederaSelfDestructOperationTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/contracts/operation/HederaSelfDestructOperationTest.java
@@ -82,7 +82,6 @@ class HederaSelfDestructOperationTest {
 		final var beneficiaryMirror = beneficiary.toEvmAddress();
 		given(frame.getStackItem(0)).willReturn(beneficiaryMirror);
 		given(frame.popStackItem()).willReturn(beneficiaryMirror);
-		given(worldUpdater.priorityAddress(eip1014Address)).willReturn(eip1014Address);
 		given(frame.getRecipientAddress()).willReturn(eip1014Address);
 		given(worldUpdater.get(any())).willReturn(account);
 		given(account.getBalance()).willReturn(Wei.ONE);
@@ -100,7 +99,6 @@ class HederaSelfDestructOperationTest {
 		givenRubberstampValidator();
 
 		given(frame.getStackItem(0)).willReturn(eip1014Address);
-		given(worldUpdater.priorityAddress(eip1014Address)).willReturn(eip1014Address);
 		given(frame.getRecipientAddress()).willReturn(eip1014Address);
 
 		final var opResult = subject.execute(frame, evm);
@@ -110,27 +108,11 @@ class HederaSelfDestructOperationTest {
 	}
 
 	@Test
-	void rejectsSelfDestructOfAliasWithMirrorAddressUsage() {
-		givenRubberstampValidator();
-
-		final var passedBeneficiaryAddress = beneficiary.toEvmAddress();
-		given(frame.getStackItem(0)).willReturn(eip1014Address);
-		given(worldUpdater.priorityAddress(passedBeneficiaryAddress)).willReturn(eip1014Address);
-		given(frame.getRecipientAddress()).willReturn(passedBeneficiaryAddress);
-
-		final var opResult = subject.execute(frame, evm);
-
-		assertEquals(Optional.of(HederaExceptionalHaltReason.INVALID_SOLIDITY_ADDRESS), opResult.getHaltReason());
-		assertEquals(Optional.of(Gas.of(2L)), opResult.getGasCost());
-	}
-
-	@Test
 	void rejectsSelfDestructIfTreasury() {
 		givenRubberstampValidator();
 
 		final var beneficiaryMirror = beneficiary.toEvmAddress();
 		given(frame.getStackItem(0)).willReturn(beneficiaryMirror);
-		given(worldUpdater.priorityAddress(eip1014Address)).willReturn(eip1014Address);
 		given(frame.getRecipientAddress()).willReturn(eip1014Address);
 		given(worldUpdater.contractIsTokenTreasury(eip1014Address)).willReturn(true);
 
@@ -146,7 +128,6 @@ class HederaSelfDestructOperationTest {
 
 		final var beneficiaryMirror = beneficiary.toEvmAddress();
 		given(frame.getStackItem(0)).willReturn(beneficiaryMirror);
-		given(worldUpdater.priorityAddress(eip1014Address)).willReturn(eip1014Address);
 		given(frame.getRecipientAddress()).willReturn(eip1014Address);
 		given(worldUpdater.contractHasAnyBalance(eip1014Address)).willReturn(true);
 
@@ -162,7 +143,6 @@ class HederaSelfDestructOperationTest {
 
 		final var beneficiaryMirror = beneficiary.toEvmAddress();
 		given(frame.getStackItem(0)).willReturn(beneficiaryMirror);
-		given(worldUpdater.priorityAddress(eip1014Address)).willReturn(eip1014Address);
 		given(frame.getRecipientAddress()).willReturn(eip1014Address);
 		given(worldUpdater.contractOwnsNfts(eip1014Address)).willReturn(true);
 

--- a/hedera-node/src/test/java/com/hedera/services/contracts/operation/HederaSelfDestructOperationTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/contracts/operation/HederaSelfDestructOperationTest.java
@@ -82,7 +82,7 @@ class HederaSelfDestructOperationTest {
 		final var beneficiaryMirror = beneficiary.toEvmAddress();
 		given(frame.getStackItem(0)).willReturn(beneficiaryMirror);
 		given(frame.popStackItem()).willReturn(beneficiaryMirror);
-		given(worldUpdater.priorityAddress(beneficiaryMirror)).willReturn(beneficiaryMirror);
+		given(worldUpdater.priorityAddress(eip1014Address)).willReturn(eip1014Address);
 		given(frame.getRecipientAddress()).willReturn(eip1014Address);
 		given(worldUpdater.get(any())).willReturn(account);
 		given(account.getBalance()).willReturn(Wei.ONE);
@@ -99,9 +99,8 @@ class HederaSelfDestructOperationTest {
 	void rejectsSelfDestructToSelf() {
 		givenRubberstampValidator();
 
-		final var beneficiaryMirror = beneficiary.toEvmAddress();
-		given(frame.getStackItem(0)).willReturn(beneficiaryMirror);
-		given(worldUpdater.priorityAddress(beneficiaryMirror)).willReturn(eip1014Address);
+		given(frame.getStackItem(0)).willReturn(eip1014Address);
+		given(worldUpdater.priorityAddress(eip1014Address)).willReturn(eip1014Address);
 		given(frame.getRecipientAddress()).willReturn(eip1014Address);
 
 		final var opResult = subject.execute(frame, evm);
@@ -111,12 +110,27 @@ class HederaSelfDestructOperationTest {
 	}
 
 	@Test
+	void rejectsSelfDestructOfAliasWithMirrorAddressUsage() {
+		givenRubberstampValidator();
+
+		final var passedBeneficiaryAddress = beneficiary.toEvmAddress();
+		given(frame.getStackItem(0)).willReturn(eip1014Address);
+		given(worldUpdater.priorityAddress(passedBeneficiaryAddress)).willReturn(eip1014Address);
+		given(frame.getRecipientAddress()).willReturn(passedBeneficiaryAddress);
+
+		final var opResult = subject.execute(frame, evm);
+
+		assertEquals(Optional.of(HederaExceptionalHaltReason.INVALID_SOLIDITY_ADDRESS), opResult.getHaltReason());
+		assertEquals(Optional.of(Gas.of(2L)), opResult.getGasCost());
+	}
+
+	@Test
 	void rejectsSelfDestructIfTreasury() {
 		givenRubberstampValidator();
 
 		final var beneficiaryMirror = beneficiary.toEvmAddress();
 		given(frame.getStackItem(0)).willReturn(beneficiaryMirror);
-		given(worldUpdater.priorityAddress(beneficiaryMirror)).willReturn(anotherEip1014Address);
+		given(worldUpdater.priorityAddress(eip1014Address)).willReturn(eip1014Address);
 		given(frame.getRecipientAddress()).willReturn(eip1014Address);
 		given(worldUpdater.contractIsTokenTreasury(eip1014Address)).willReturn(true);
 
@@ -132,7 +146,7 @@ class HederaSelfDestructOperationTest {
 
 		final var beneficiaryMirror = beneficiary.toEvmAddress();
 		given(frame.getStackItem(0)).willReturn(beneficiaryMirror);
-		given(worldUpdater.priorityAddress(beneficiaryMirror)).willReturn(anotherEip1014Address);
+		given(worldUpdater.priorityAddress(eip1014Address)).willReturn(eip1014Address);
 		given(frame.getRecipientAddress()).willReturn(eip1014Address);
 		given(worldUpdater.contractHasAnyBalance(eip1014Address)).willReturn(true);
 
@@ -148,7 +162,7 @@ class HederaSelfDestructOperationTest {
 
 		final var beneficiaryMirror = beneficiary.toEvmAddress();
 		given(frame.getStackItem(0)).willReturn(beneficiaryMirror);
-		given(worldUpdater.priorityAddress(beneficiaryMirror)).willReturn(anotherEip1014Address);
+		given(worldUpdater.priorityAddress(eip1014Address)).willReturn(eip1014Address);
 		given(frame.getRecipientAddress()).willReturn(eip1014Address);
 		given(worldUpdater.contractOwnsNfts(eip1014Address)).willReturn(true);
 
@@ -164,7 +178,6 @@ class HederaSelfDestructOperationTest {
 
 		final var beneficiaryMirror = beneficiary.toEvmAddress();
 		given(frame.getStackItem(0)).willReturn(beneficiaryMirror);
-		given(worldUpdater.priorityAddress(beneficiaryMirror)).willReturn(eip1014Address);
 
 		final var opResult = subject.execute(frame, evm);
 

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/DynamicGasCostSuite.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/DynamicGasCostSuite.java
@@ -742,7 +742,7 @@ public class DynamicGasCostSuite extends HapiApiSuite {
 						sourcing(() -> contractCallWithFunctionAbi(
 								donorAliasAddr.get(),
 								getABIFor(FUNCTION, "relinquishFundsTo", donorContract),
-								donorMirrorAddr.get()).hasKnownStatus(OBTAINER_SAME_CONTRACT_ID))
+								donorMirrorAddr.get()).hasKnownStatus(INVALID_SOLIDITY_ADDRESS))
 				).then(
 						contractCall(contract, "buildThenRevertThenBuild", otherSalt)
 								.sending(1_000)


### PR DESCRIPTION
**Description**:
Hedera Self Destruct Operation needed to filter mirror address usage for aliased contract deletion.

- [x] Tested (unit, integration, etc.)
