### PR TITLE
Hardcode range of enums for Seeded SerDes tests

### DIFF
--- a/hedera-node/src/test/java/com/hedera/test/utils/SeededPropertySource.java
+++ b/hedera-node/src/test/java/com/hedera/test/utils/SeededPropertySource.java
@@ -203,18 +203,33 @@ public class SeededPropertySource {
 	}
 
 	public FcCustomFee.FeeType nextFeeType() {
+		// size of FcCustomFee.FeeType.class.getEnumConstants() in 0.25
+		return nextFeeType(3);  
+	}
+	
+	public FcCustomFee.FeeType nextFeeType(final int range) {
 		final var choices = FcCustomFee.FeeType.class.getEnumConstants();
-		return choices[SEEDED_RANDOM.nextInt(choices.length)];
+		return choices[SEEDED_RANDOM.nextInt(range)];
 	}
 
 	public TokenType nextTokenType() {
+		// size of TokenType.class.getEnumConstants() in 0.25
+		return nextTokenType(2);
+	}
+	
+	public TokenType nextTokenType(final int range) {
 		final var choices = TokenType.class.getEnumConstants();
-		return choices[SEEDED_RANDOM.nextInt(choices.length)];
+		return choices[SEEDED_RANDOM.nextInt(range)];
 	}
 
 	public TokenSupplyType nextTokenSupplyType() {
+		// size of TokenSupplyType.class.getEnumConstants() in 0.25
+		return nextTokenSupplyType(2);
+	}
+	
+	public TokenSupplyType nextTokenSupplyType(final int range) {
 		final var choices = TokenSupplyType.class.getEnumConstants();
-		return choices[SEEDED_RANDOM.nextInt(choices.length)];
+		return choices[SEEDED_RANDOM.nextInt(range)];
 	}
 
 	public MerkleSchedule nextSchedule() {
@@ -584,8 +599,13 @@ public class SeededPropertySource {
 	}
 
 	public ResponseCodeEnum nextStatus() {
+		// size of ResponseCodeEnum.class.getEnumConstants() in 0.25
+		return nextStatus(265);
+	}
+
+	public ResponseCodeEnum nextStatus(final int range) {
 		final var choices = ResponseCodeEnum.class.getEnumConstants();
-		return choices[SEEDED_RANDOM.nextInt(choices.length)];
+		return choices[SEEDED_RANDOM.nextInt(range)];
 	}
 
 	public ExchangeRates nextExchangeRates() {
@@ -595,8 +615,13 @@ public class SeededPropertySource {
 	}
 
 	public EntityType nextEntityType() {
+		// size of EntityType.class.getEnumConstants() in 0.25
+		return nextEntityType(6);
+	}
+
+	public EntityType nextEntityType(final int range) {
 		final var choices = EntityType.class.getEnumConstants();
-		return choices[SEEDED_RANDOM.nextInt(choices.length)];
+		return choices[SEEDED_RANDOM.nextInt(range)];
 	}
 
 	public Map<EntityNum, Map<FcTokenAllowanceId, Long>> nextFungibleAllowances(


### PR DESCRIPTION
**Description**:

The seeded generation of objects for the large scale serdes test
depends on selecting some constants from a large range of values.
However, when protobuf upgrades occur that range can grow and hence the
values selected for those fields will change.

To address this the default range selector of the objects is fixed to
the 0.25 length. A second form of the call allowing future upgrades to
request values from a larger range is also supplied in the event future
serialization structures depend on the new value.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
