### PR TITLE
Support HTS / HIP-218 precompile for direct calls

### DIFF
--- a/hedera-node/src/main/java/com/hedera/services/store/contracts/CodeCache.java
+++ b/hedera-node/src/main/java/com/hedera/services/store/contracts/CodeCache.java
@@ -98,4 +98,8 @@ public class CodeCache {
     Cache<BytesKey, Code> getCache() {
         return cache;
     }
+
+    void cacheValue(BytesKey key, Code value) {
+        cache.put(key, value);
+    }
 }

--- a/hedera-node/src/main/java/com/hedera/services/store/contracts/CodeCache.java
+++ b/hedera-node/src/main/java/com/hedera/services/store/contracts/CodeCache.java
@@ -32,6 +32,7 @@ import javax.inject.Inject;
 import javax.inject.Singleton;
 import java.util.concurrent.TimeUnit;
 
+import static com.hedera.services.store.contracts.WorldStateTokenAccount.proxyBytecodeFor;
 import static com.hedera.services.utils.EntityIdUtils.accountIdFromEvmAddress;
 
 /**
@@ -66,13 +67,24 @@ public class CodeCache {
         final var cacheKey = new BytesKey(address.toArray());
 
         var code = cache.getIfPresent(cacheKey);
-        if (code == null) {
-            final var bytecode = entityAccess.fetchCodeIfPresent(accountIdFromEvmAddress(address));
-            if (bytecode != null) {
-                code = new Code(bytecode, Hash.hash(bytecode));
-                cache.put(cacheKey, code);
-            }
+
+        if (code != null) {
+            return code;
         }
+
+        if (entityAccess.isTokenAccount(address)) {
+            final var interpolatedBytecode = proxyBytecodeFor(address);
+            code = new Code(interpolatedBytecode, Hash.hash(interpolatedBytecode));
+            cache.put(cacheKey, code);
+            return code;
+        }
+
+        final var bytecode = entityAccess.fetchCodeIfPresent(accountIdFromEvmAddress(address));
+        if (bytecode != null) {
+            code = new Code(bytecode, Hash.hash(bytecode));
+            cache.put(cacheKey, code);
+        }
+
         return code;
     }
 

--- a/hedera-node/src/test/java/com/hedera/services/store/contracts/CodeCacheTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/store/contracts/CodeCacheTest.java
@@ -34,6 +34,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import static com.hedera.services.store.contracts.WorldStateTokenAccount.proxyBytecodeFor;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -75,6 +76,14 @@ class CodeCacheTest {
 		Code code = codeCache.getIfPresent(Address.fromHexString("0xabc"));
 
 		assertTrue(code.getBytes().isEmpty());
+	}
+
+	@Test
+	void getTokenCodeReturnsRedirectCode() {
+		given(entityAccess.isTokenAccount(any())).willReturn(true);
+
+		assertEquals(proxyBytecodeFor(Address.fromHexString("0xabc")), codeCache.getIfPresent(Address.fromHexString(
+				"0xabc")).getBytes());
 	}
 
 	@Test

--- a/hedera-node/src/test/java/com/hedera/services/store/contracts/CodeCacheTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/store/contracts/CodeCacheTest.java
@@ -25,6 +25,7 @@ package com.hedera.services.store.contracts;
 import com.hedera.services.context.properties.NodeLocalProperties;
 import com.hedera.services.utils.BytesKey;
 import org.apache.tuweni.bytes.Bytes;
+import org.checkerframework.checker.units.qual.A;
 import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.evm.Code;
@@ -41,6 +42,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.BDDMockito.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verifyNoInteractions;
 
 @ExtendWith(MockitoExtension.class)
 class CodeCacheTest {
@@ -53,7 +55,7 @@ class CodeCacheTest {
 
 	@BeforeEach
 	void setup() {
-		codeCache = new CodeCache(properties, entityAccess);
+		codeCache = new CodeCache(100, entityAccess);
 	}
 
 	@Test
@@ -76,6 +78,20 @@ class CodeCacheTest {
 		Code code = codeCache.getIfPresent(Address.fromHexString("0xabc"));
 
 		assertTrue(code.getBytes().isEmpty());
+	}
+
+	@Test
+	void returnsCachedValue() {
+		Address demoAddress = Address.fromHexString("aaa");
+		BytesKey key = new BytesKey(demoAddress.toArray());
+		Code code = new Code();
+
+		codeCache.cacheValue(key, code);
+
+		Code codeResult = codeCache.getIfPresent(demoAddress);
+
+		assertEquals(code, codeResult);
+		verifyNoInteractions(entityAccess);
 	}
 
 	@Test

--- a/hedera-node/src/test/java/com/hedera/services/txns/contract/ContractCallTransitionLogicTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/txns/contract/ContractCallTransitionLogicTest.java
@@ -30,12 +30,12 @@ import com.hedera.services.ledger.accounts.AliasManager;
 import com.hedera.services.records.TransactionRecordService;
 import com.hedera.services.store.AccountStore;
 import com.hedera.services.store.contracts.CodeCache;
+import com.hedera.services.store.contracts.EntityAccess;
 import com.hedera.services.store.contracts.HederaWorldState;
 import com.hedera.services.store.models.Account;
 import com.hedera.services.store.models.Id;
 import com.hedera.services.utils.EntityNum;
 import com.hedera.services.utils.accessors.PlatformTxnAccessor;
-import com.hedera.services.utils.accessors.SignedTxnAccessor;
 import com.hedera.test.utils.IdUtils;
 import com.hederahashgraph.api.proto.java.ContractCallTransactionBody;
 import com.hederahashgraph.api.proto.java.ContractID;
@@ -94,6 +94,8 @@ class ContractCallTransitionLogicTest {
 	private SigImpactHistorian sigImpactHistorian;
 	@Mock
 	private AliasManager aliasManager;
+	@Mock
+	private EntityAccess entityAccess;
 
 	private TransactionBody contractCallTxn;
 	private final Instant consensusTime = Instant.now();
@@ -105,7 +107,7 @@ class ContractCallTransitionLogicTest {
 	private void setup() {
 		subject = new ContractCallTransitionLogic(
 				txnCtx, accountStore, worldState, recordService,
-				evmTxProcessor, properties, codeCache, sigImpactHistorian, aliasManager);
+				evmTxProcessor, properties, codeCache, sigImpactHistorian, aliasManager, entityAccess);
 	}
 
 	@Test

--- a/hedera-node/src/test/java/com/hedera/services/txns/ethereum/EthereumTransactionTransitionLogicTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/txns/ethereum/EthereumTransactionTransitionLogicTest.java
@@ -35,6 +35,7 @@ import com.hedera.services.records.TransactionRecordService;
 import com.hedera.services.state.merkle.MerkleAccount;
 import com.hedera.services.store.AccountStore;
 import com.hedera.services.store.contracts.CodeCache;
+import com.hedera.services.store.contracts.EntityAccess;
 import com.hedera.services.store.contracts.HederaWorldState;
 import com.hedera.services.store.models.Account;
 import com.hedera.services.store.models.Id;
@@ -45,7 +46,6 @@ import com.hedera.services.txns.validation.OptionValidator;
 import com.hedera.services.utils.EntityIdUtils;
 import com.hedera.services.utils.EntityNum;
 import com.hedera.services.utils.accessors.SignedTxnAccessor;
-import com.swirlds.common.utility.CommonUtils;
 import com.hedera.test.utils.IdUtils;
 import com.hederahashgraph.api.proto.java.AccountID;
 import com.hederahashgraph.api.proto.java.ContractID;
@@ -55,6 +55,7 @@ import com.hederahashgraph.api.proto.java.FileID;
 import com.hederahashgraph.api.proto.java.Timestamp;
 import com.hederahashgraph.api.proto.java.TransactionBody;
 import com.hederahashgraph.api.proto.java.TransactionID;
+import com.swirlds.common.utility.CommonUtils;
 import org.apache.tuweni.bytes.Bytes;
 import org.bouncycastle.util.encoders.Hex;
 import org.hyperledger.besu.datatypes.Address;
@@ -137,6 +138,8 @@ class EthereumTransactionTransitionLogicTest {
 	TransactionalLedger<AccountID, AccountProperty, MerkleAccount> accountsLedger;
 	@Mock
 	private HederaFs hfs;
+	@Mock
+	private EntityAccess entityAccess;
 	private TransactionBody ethTxTxn;
 	private EthTxData ethTxData;
 
@@ -144,7 +147,7 @@ class EthereumTransactionTransitionLogicTest {
 	private void setup() {
 		contractCallTransitionLogic = new ContractCallTransitionLogic(
 				txnCtx, accountStore, worldState, recordService,
-				evmTxProcessor, globalDynamicProperties, codeCache, sigImpactHistorian, aliasManager);
+				evmTxProcessor, globalDynamicProperties, codeCache, sigImpactHistorian, aliasManager, entityAccess);
 		contractCreateTransitionLogic = new ContractCreateTransitionLogic(hfs, txnCtx, accountStore, optionValidator,
 				worldState, recordService, createEvmTxProcessor, globalDynamicProperties, sigImpactHistorian);
 		given(globalDynamicProperties.getChainId()).willReturn(0x128);

--- a/test-clients/src/main/java/com/hedera/services/bdd/spec/HapiPropertySource.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/spec/HapiPropertySource.java
@@ -291,6 +291,10 @@ public interface HapiPropertySource {
 		return CommonUtils.hex(asSolidityAddress(contractId));
 	}
 
+	static String asHexedSolidityAddress(final TokenID tokenId) {
+		return CommonUtils.hex(asSolidityAddress(tokenId));
+	}
+
 	static byte[] asSolidityAddress(final ContractID contractId) {
 		return asSolidityAddress((int) contractId.getShardNum(), contractId.getRealmNum(), contractId.getContractNum());
 	}


### PR DESCRIPTION
**Description**:
Calls to `ERC20` or `ERC721` functions of HTS tokens are possible after `HIP-218` implementation through the EVM.
Direct calls with `HAPI` contract call transactions however are failing. This PR fixes that.

**Related issue(s)**:

Fixes #3222 

**Notes for reviewer**:

- CodeCache to return redirectBytecode if the address we're querying is a token account address
- ContractCallTransitionLogic to not load target from accountStore if target is a token
- E2E tests with direct calls to Fungible and NFT tokens


**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
