### PR TITLE
Inherit sender properties when performing ContractCreate with ETH txn

### DIFF
--- a/hedera-node/src/main/java/com/hedera/services/txns/ethereum/EthereumTransitionLogic.java
+++ b/hedera-node/src/main/java/com/hedera/services/txns/ethereum/EthereumTransitionLogic.java
@@ -118,6 +118,7 @@ public class EthereumTransitionLogic implements PreFetchableTransition {
 			final var synthOp =
 					addInheritablePropertiesToContractCreate(syntheticTxBody.getContractCreateInstance(), callingAccount.toGrpcAccountId());
 			syntheticTxBody = TransactionBody.newBuilder().setContractCreateInstance(synthOp).build();
+			spanMapAccessor.setEthTxBodyMeta(txnCtx.accessor(), syntheticTxBody);
 			contractCreateTransitionLogic.doStateTransitionOperation(syntheticTxBody, callingAccount.toId(), true);
 		}
 		recordService.updateFromEvmCallContext(ethTxData);

--- a/hedera-node/src/main/java/com/hedera/services/txns/ethereum/EthereumTransitionLogic.java
+++ b/hedera-node/src/main/java/com/hedera/services/txns/ethereum/EthereumTransitionLogic.java
@@ -24,12 +24,15 @@ import com.esaulpaugh.headlong.util.Integers;
 import com.google.protobuf.ByteString;
 import com.hedera.services.context.TransactionContext;
 import com.hedera.services.context.properties.GlobalDynamicProperties;
+import com.hedera.services.exceptions.InvalidTransactionException;
 import com.hedera.services.files.HederaFs;
 import com.hedera.services.ledger.TransactionalLedger;
 import com.hedera.services.ledger.accounts.AliasManager;
 import com.hedera.services.ledger.properties.AccountProperty;
+import com.hedera.services.legacy.core.jproto.JKey;
 import com.hedera.services.records.TransactionRecordService;
 import com.hedera.services.state.merkle.MerkleAccount;
+import com.hedera.services.state.submerkle.EntityId;
 import com.hedera.services.txns.PreFetchableTransition;
 import com.hedera.services.txns.contract.ContractCallTransitionLogic;
 import com.hedera.services.txns.contract.ContractCreateTransitionLogic;
@@ -41,8 +44,10 @@ import com.hederahashgraph.api.proto.java.ContractCallTransactionBody;
 import com.hederahashgraph.api.proto.java.ContractCreateTransactionBody;
 import com.hederahashgraph.api.proto.java.Duration;
 import com.hederahashgraph.api.proto.java.EthereumTransactionBody;
+import com.hederahashgraph.api.proto.java.Key;
 import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
 import com.hederahashgraph.api.proto.java.TransactionBody;
+import org.apache.commons.codec.DecoderException;
 import org.bouncycastle.util.encoders.Hex;
 
 import javax.inject.Inject;
@@ -53,6 +58,10 @@ import java.util.function.Predicate;
 
 import static com.hedera.services.exceptions.ValidationUtils.validateFalse;
 import static com.hedera.services.exceptions.ValidationUtils.validateTrue;
+import static com.hedera.services.ledger.properties.AccountProperty.AUTO_RENEW_PERIOD;
+import static com.hedera.services.ledger.properties.AccountProperty.KEY;
+import static com.hedera.services.ledger.properties.AccountProperty.MEMO;
+import static com.hedera.services.ledger.properties.AccountProperty.PROXY;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.CONTRACT_FILE_EMPTY;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_FILE_ID;
 
@@ -69,6 +78,7 @@ public class EthereumTransitionLogic implements PreFetchableTransition {
 	private final HederaFs hfs;
 	private final byte[] chainId;
 	private final TransactionalLedger<AccountID, AccountProperty, MerkleAccount> accountsLedger;
+	private final GlobalDynamicProperties globalDynamicProperties;
 
 	@Inject
 	public EthereumTransitionLogic(
@@ -78,8 +88,8 @@ public class EthereumTransitionLogic implements PreFetchableTransition {
 			final ContractCreateTransitionLogic contractCreateTransitionLogic,
 			final TransactionRecordService recordService,
 			final HederaFs hfs,
-			GlobalDynamicProperties globalDynamicProperties,
-			AliasManager aliasManager,
+			final GlobalDynamicProperties globalDynamicProperties,
+			final AliasManager aliasManager,
 			final TransactionalLedger<AccountID, AccountProperty, MerkleAccount> accountsLedger) {
 		this.txnCtx = txnCtx;
 		this.spanMapAccessor = spanMapAccessor;
@@ -90,6 +100,7 @@ public class EthereumTransitionLogic implements PreFetchableTransition {
 		this.chainId = Integers.toBytes(globalDynamicProperties.getChainId());
 		this.aliasManager = aliasManager;
 		this.accountsLedger = accountsLedger;
+		this.globalDynamicProperties = globalDynamicProperties;
 	}
 
 	@Override
@@ -104,6 +115,9 @@ public class EthereumTransitionLogic implements PreFetchableTransition {
 		if (syntheticTxBody.hasContractCall()) {
 			contractCallTransitionLogic.doStateTransitionOperation(syntheticTxBody, callingAccount.toId(), true);
 		} else if (syntheticTxBody.hasContractCreateInstance()) {
+			final var synthOp =
+					addInheritablePropertiesToContractCreate(syntheticTxBody.getContractCreateInstance(), callingAccount.toGrpcAccountId());
+			syntheticTxBody = TransactionBody.newBuilder().setContractCreateInstance(synthOp).build();
 			contractCreateTransitionLogic.doStateTransitionOperation(syntheticTxBody, callingAccount.toId(), true);
 		}
 		recordService.updateFromEvmCallContext(ethTxData);
@@ -215,16 +229,41 @@ public class EthereumTransitionLogic implements PreFetchableTransition {
 					.setContractID(EntityIdUtils.contractIdFromEvmAddress(ethTxData.to())).build();
 			return TransactionBody.newBuilder().setContractCall(synthOp).build();
 		} else {
-			//FIXME we need a better solution.  Something like for precheck it's the default
-			//FIXME but in consensus we get the renewal of the calling account and update the operation?
-			var autoRenewPeriod = Duration.newBuilder().setSeconds(
-					java.time.Duration.ofDays(90).getSeconds()).build();
+			final var autoRenewPeriod =
+					Duration.newBuilder().setSeconds(globalDynamicProperties.minAutoRenewDuration()).build();
 			var synthOp = ContractCreateTransactionBody.newBuilder()
 					.setInitcode(ByteString.copyFrom(ethTxData.callData()))
 					.setGas(ethTxData.gasLimit())
 					.setInitialBalance(ethTxData.value().divide(WEIBARS_TO_TINYBARS).longValueExact())
 					.setAutoRenewPeriod(autoRenewPeriod);
 			return TransactionBody.newBuilder().setContractCreateInstance(synthOp).build();
+		}
+	}
+
+	public ContractCreateTransactionBody addInheritablePropertiesToContractCreate(
+			final ContractCreateTransactionBody contractCreateTxnBody,
+			final AccountID sender
+	) {
+		final var synthOp = ContractCreateTransactionBody
+				.newBuilder(contractCreateTxnBody)
+				.setAdminKey(attemptToDecodeOrThrow((JKey) accountsLedger.get(sender, KEY)))
+				.setAutoRenewPeriod(Duration.newBuilder().setSeconds((long) accountsLedger.get(sender, AUTO_RENEW_PERIOD)));
+		final var senderMemo = (String) accountsLedger.get(sender, MEMO);
+		if (senderMemo != null) {
+			synthOp.setMemo(senderMemo);
+		}
+		final var senderProxy = (EntityId) accountsLedger.get(sender, PROXY);
+		if (senderProxy != null && !senderProxy.equals(EntityId.MISSING_ENTITY_ID)) {
+			synthOp.setProxyAccountID(senderProxy.toGrpcAccountId());
+		}
+		return synthOp.build();
+	}
+
+	private Key attemptToDecodeOrThrow(final JKey key) {
+		try {
+			return JKey.mapJKey(key);
+		} catch (DecoderException e) {
+			throw new InvalidTransactionException(ResponseCodeEnum.SERIALIZATION_FAILED);
 		}
 	}
 }

--- a/hedera-node/src/test/java/com/hedera/services/txns/ethereum/EthereumTransactionTransitionLogicTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/txns/ethereum/EthereumTransactionTransitionLogicTest.java
@@ -268,11 +268,14 @@ class EthereumTransactionTransitionLogicTest {
 				.setMemo(senderMemo)
 				.setProxyAccountID(senderAccount.getId().asGrpcAccount())
 				.build();
+		final var expectedTxnBody =
+				TransactionBody.newBuilder().setContractCreateInstance(expectedSyntheticCreateBody).build();
 		verify(contractCreateTransitionLogic).doStateTransitionOperation(
-				TransactionBody.newBuilder().setContractCreateInstance(expectedSyntheticCreateBody).build(),
+				expectedTxnBody,
 				senderAccount.getId(),
 				true
 		);
+		verify(spanMapAccessor).setEthTxBodyMeta(accessor, expectedTxnBody);
 		verify(recordService).externalizeSuccessfulEvmCreate(any(), any());
 		verify(recordService).updateFromEvmCallContext(any());
 		verify(worldState).getCreatedContractIds();
@@ -326,11 +329,14 @@ class EthereumTransactionTransitionLogicTest {
 				.setGas(ethTxData.gasLimit())
 				.setInitialBalance(ethTxData.value().divide(WEIBARS_TO_TINYBARS).longValueExact())
 				.build();
+		final var expectedTxnBody =
+				TransactionBody.newBuilder().setContractCreateInstance(expectedSyntheticCreateBody).build();
 		verify(contractCreateTransitionLogic).doStateTransitionOperation(
-				TransactionBody.newBuilder().setContractCreateInstance(expectedSyntheticCreateBody).build(),
+				expectedTxnBody,
 				senderAccount.getId(),
 				true
 		);
+		verify(spanMapAccessor).setEthTxBodyMeta(accessor, expectedTxnBody);
 		verify(recordService).externalizeSuccessfulEvmCreate(any(), any());
 		verify(recordService).updateFromEvmCallContext(any());
 		verify(worldState).getCreatedContractIds();

--- a/hedera-node/src/test/java/com/hedera/services/txns/ethereum/EthereumTransactionTransitionLogicTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/txns/ethereum/EthereumTransactionTransitionLogicTest.java
@@ -26,6 +26,7 @@ import com.hedera.services.context.properties.GlobalDynamicProperties;
 import com.hedera.services.contracts.execution.CallEvmTxProcessor;
 import com.hedera.services.contracts.execution.CreateEvmTxProcessor;
 import com.hedera.services.contracts.execution.TransactionProcessingResult;
+import com.hedera.services.exceptions.InvalidTransactionException;
 import com.hedera.services.files.HederaFs;
 import com.hedera.services.ledger.SigImpactHistorian;
 import com.hedera.services.ledger.TransactionalLedger;
@@ -60,7 +61,6 @@ import com.hederahashgraph.api.proto.java.FileID;
 import com.hederahashgraph.api.proto.java.Timestamp;
 import com.hederahashgraph.api.proto.java.TransactionBody;
 import com.hederahashgraph.api.proto.java.TransactionID;
-import com.swirlds.common.utility.CommonUtils;
 import com.swirlds.common.utility.CommonUtils;
 import org.apache.commons.codec.DecoderException;
 import org.apache.tuweni.bytes.Bytes;
@@ -98,10 +98,14 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.WRONG_NONCE;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
@@ -263,6 +267,64 @@ class EthereumTransactionTransitionLogicTest {
 				.setInitialBalance(ethTxData.value().divide(WEIBARS_TO_TINYBARS).longValueExact())
 				.setMemo(senderMemo)
 				.setProxyAccountID(senderAccount.getId().asGrpcAccount())
+				.build();
+		verify(contractCreateTransitionLogic).doStateTransitionOperation(
+				TransactionBody.newBuilder().setContractCreateInstance(expectedSyntheticCreateBody).build(),
+				senderAccount.getId(),
+				true
+		);
+		verify(recordService).externalizeSuccessfulEvmCreate(any(), any());
+		verify(recordService).updateFromEvmCallContext(any());
+		verify(worldState).getCreatedContractIds();
+		verify(txnCtx).setTargetedContract(contractAccount.getId().asGrpcContract());
+	}
+
+	@Test
+	void verifyExternaliseContractResultCreateWithoutMemoAndProxy() throws DecoderException {
+		// setup:
+		target = null;
+		givenValidTxnCtx();
+		// and:
+		given(accessor.getTxn()).willReturn(ethTxTxn);
+		given(txnCtx.accessor()).willReturn(accessor);
+		given(txnCtx.consensusTime()).willReturn(consensusTime);
+		// and:
+		given(accountStore.loadAccount(senderAccount.getId())).willReturn(senderAccount);
+		given(worldState.newContractAddress(senderAccount.getId().asEvmAddress())).willReturn(
+				contractAccount.getId().asEvmAddress());
+
+		// and:
+		final var results = TransactionProcessingResult.successful(
+				null, 1234L, 0L, 124L, Bytes.EMPTY,
+				contractAccount.getId().asEvmAddress(), Map.of());
+		given(createEvmTxProcessor.execute(senderAccount, contractAccount.getId().asEvmAddress(), gas, sent,
+				Bytes.EMPTY,
+				txnCtx.consensusTime(), consensusTime.getEpochSecond() + AUTO_RENEW_PERIOD))
+				.willReturn(results);
+		given(worldState.getCreatedContractIds()).willReturn(List.of(contractAccount.getId().asGrpcContract()));
+
+		given(spanMapAccessor.getEthTxDataMeta(accessor)).willReturn(ethTxData);
+		given(aliasManager.lookupIdBy(ByteString.copyFrom(TRUFFLE0_ADDRESS))).willReturn(
+				senderAccount.getId().asEntityNum());
+
+		given(globalDynamicProperties.minAutoRenewDuration()).willReturn(1L);
+		final var senderKey = new JContractIDKey(contractAccount.getId().asGrpcContract());
+		given(accountsLedger.get(senderAccount.getId().asGrpcAccount(), KEY)).willReturn(senderKey);
+		given(accountsLedger.get(senderAccount.getId().asGrpcAccount(), AccountProperty.AUTO_RENEW_PERIOD)).willReturn(AUTO_RENEW_PERIOD);
+		given(accountsLedger.get(senderAccount.getId().asGrpcAccount(), MEMO)).willReturn(null);
+		given(accountsLedger.get(senderAccount.getId().asGrpcAccount(), PROXY)).willReturn(EntityId.MISSING_ENTITY_ID);
+		given(optionValidator.attemptToDecodeOrThrow(any(), any())).willReturn(senderKey);
+
+		// when:
+		subject.doStateTransition();
+
+		// then:
+		final var expectedSyntheticCreateBody = ContractCreateTransactionBody.newBuilder()
+				.setAdminKey(JKey.mapJKey(senderKey))
+				.setAutoRenewPeriod(Duration.newBuilder().setSeconds(AUTO_RENEW_PERIOD).build())
+				.setInitcode(ByteString.copyFrom(ethTxData.callData()))
+				.setGas(ethTxData.gasLimit())
+				.setInitialBalance(ethTxData.value().divide(WEIBARS_TO_TINYBARS).longValueExact())
 				.build();
 		verify(contractCreateTransitionLogic).doStateTransitionOperation(
 				TransactionBody.newBuilder().setContractCreateInstance(expectedSyntheticCreateBody).build(),
@@ -513,6 +575,54 @@ class EthereumTransactionTransitionLogicTest {
 		// expect:
 		assertEquals(INVALID_ACCOUNT_ID, subject.validateSemantics(accessor));
 	}
+
+	@Test
+	void invalidSenderJKeyOnContractCreateThrows() {
+		// setup:
+		target = null;
+		givenValidTxnCtx();
+		// and:
+		given(accessor.getTxn()).willReturn(ethTxTxn);
+		given(txnCtx.accessor()).willReturn(accessor);
+
+		// and:
+		given(spanMapAccessor.getEthTxDataMeta(accessor)).willReturn(ethTxData);
+		given(aliasManager.lookupIdBy(ByteString.copyFrom(TRUFFLE0_ADDRESS))).willReturn(
+				senderAccount.getId().asEntityNum());
+		given(globalDynamicProperties.minAutoRenewDuration()).willReturn(1L);
+		given(accountsLedger.get(senderAccount.getId().asGrpcAccount(), KEY)).willReturn(new JKey() {
+			@Override
+			public boolean isEmpty() {
+				return false;
+			}
+
+			@Override
+			public boolean isValid() {
+				return false;
+			}
+
+			@Override
+			public void setForScheduledTxn(boolean flag) {
+			}
+
+			@Override
+			public boolean isForScheduledTxn() {
+				return false;
+			}
+		});
+
+		// when:
+		assertThrows(InvalidTransactionException.class, () -> subject.doStateTransition());
+
+		// then:
+		verify(contractCreateTransitionLogic, never()).doStateTransitionOperation(
+				any(),
+				any(),
+				anyBoolean()
+		);
+		verify(recordService, never()).updateFromEvmCallContext(any());
+	}
+
 
 	private void givenValidTxnCtx() {
 		var unsignedTx = new EthTxData(


### PR DESCRIPTION
**Description**:
* Adds logic in `EthereumTransitionLogic` that inherits the following sender account properties in a synthetic `ContractCreate` transaction body:
  * `adminKey`
  * `autoRenewPeriod`
  * `memo` (if present)
  * `proxy` (if present)
* Adds unit tests that verify proper synthetic body translation

**Related issue(s)**:

Fixes #3223 
Fixes #3210  
