### PR TITLE
Use `put()` not `getForModify()` with `VirtualMap`s

### DIFF
--- a/benchmarks/src/main/java/com/hedera/hashgraph/SizeLimitedStorageBench.java
+++ b/benchmarks/src/main/java/com/hedera/hashgraph/SizeLimitedStorageBench.java
@@ -84,7 +84,7 @@ public class SizeLimitedStorageBench {
     	initializeInfrastructure();
 
         subject = new SizeLimitedStorage(
-				IterableStorageUtils::upsertMapping,
+				IterableStorageUtils::overwritingUpsertMapping,
 				IterableStorageUtils::removeMapping,
                 mockPropertiesWith(maxContractKvPairs, maxAggregateKvPairs),
                 infrastructure.accounts()::get,

--- a/benchmarks/src/main/java/com/hedera/hashgraph/setup/InfrastructureInitializer.java
+++ b/benchmarks/src/main/java/com/hedera/hashgraph/setup/InfrastructureInitializer.java
@@ -26,7 +26,7 @@ import com.hedera.services.state.virtual.IterableContractValue;
 import com.hedera.services.utils.EntityNum;
 import com.hederahashgraph.api.proto.java.AccountID;
 
-import static com.hedera.services.state.virtual.IterableStorageUtils.upsertMapping;
+import static com.hedera.services.state.virtual.IterableStorageUtils.overwritingUpsertMapping;
 
 public class InfrastructureInitializer {
 	private final int initNumContracts;
@@ -53,7 +53,7 @@ public class InfrastructureInitializer {
 				final var evmKey = EvmKeyValueSource.uniqueKey(j);
 				final var vmKey = ContractKey.from(contractId, evmKey);
 				final var vmValue = IterableContractValue.from(evmKey);
-				firstKey = upsertMapping(vmKey, vmValue, firstKey, firstValue, curStorage);
+				firstKey = overwritingUpsertMapping(vmKey, vmValue, firstKey, firstValue, curStorage);
 				firstValue = vmValue;
 			}
 

--- a/hedera-node/src/main/java/com/hedera/services/contracts/ContractsModule.java
+++ b/hedera-node/src/main/java/com/hedera/services/contracts/ContractsModule.java
@@ -110,7 +110,7 @@ public interface ContractsModule {
 	@Provides
 	@Singleton
 	static SizeLimitedStorage.IterableStorageUpserter provideStorageUpserter() {
-		return IterableStorageUtils::upsertMapping;
+		return IterableStorageUtils::overwritingUpsertMapping;
 	}
 
 	@Provides

--- a/hedera-node/src/main/java/com/hedera/services/state/expiry/TokenRelsListRemoval.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/expiry/TokenRelsListRemoval.java
@@ -64,6 +64,14 @@ public class TokenRelsListRemoval implements MapValueListRemoval<EntityNumPair, 
 	 * {@inheritDoc}
 	 */
 	@Override
+	public void put(final EntityNumPair key, final MerkleTokenRelStatus value) {
+		tokenRels.put(key, value);
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
 	public void remove(final EntityNumPair key) {
 		tokenRels.remove(key);
 	}

--- a/hedera-node/src/main/java/com/hedera/services/state/expiry/removal/AccountGC.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/expiry/removal/AccountGC.java
@@ -65,7 +65,7 @@ public class AccountGC {
 	private final BackingStore<AccountID, MerkleAccount> backingAccounts;
 	private final Supplier<MerkleMap<EntityNumPair, MerkleTokenRelStatus>> tokenRels;
 
-	private RemovalFacilitation removalFacilitation = MapValueListUtils::removeFromMapValueList;
+	private RemovalFacilitation removalFacilitation = MapValueListUtils::inPlaceRemoveFromMapValueList;
 
 	@Inject
 	public AccountGC(

--- a/hedera-node/src/main/java/com/hedera/services/state/expiry/removal/ContractGC.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/expiry/removal/ContractGC.java
@@ -47,7 +47,8 @@ public class ContractGC {
 	private final Supplier<VirtualMap<ContractKey, IterableContractValue>> storage;
 	private final Supplier<VirtualMap<VirtualBlobKey, VirtualBlobValue>> bytecode;
 
-	private ContractGC.RemovalFacilitation removalFacilitation = MapValueListUtils::removeFromMapValueList;
+	// Revisit after release 0.27 to see if VirtualMap.getForModify() has been rehabilitated
+	private ContractGC.RemovalFacilitation removalFacilitation = MapValueListUtils::overwritingRemoveFromMapValueList;
 
 	@Inject
 	public ContractGC(

--- a/hedera-node/src/main/java/com/hedera/services/state/migration/ReleaseTwentySixMigration.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/migration/ReleaseTwentySixMigration.java
@@ -55,7 +55,7 @@ public class ReleaseTwentySixMigration {
 		final var contracts = initializingState.accounts();
 		final VirtualMap<ContractKey, ContractValue> contractStorage = initializingState.getChild(CONTRACT_STORAGE);
 		final var migrator = migratorFactory.from(
-				INSERTIONS_PER_COPY, contracts, IterableStorageUtils::upsertMapping, iterableContractStorage);
+				INSERTIONS_PER_COPY, contracts, IterableStorageUtils::overwritingUpsertMapping, iterableContractStorage);
 		try {
 			log.info("Migrating contract storage into iterable VirtualMap with {} threads", THREAD_COUNT);
 			final var watch = StopWatch.createStarted();

--- a/hedera-node/src/main/java/com/hedera/services/state/virtual/ContractStorageListRemoval.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/virtual/ContractStorageListRemoval.java
@@ -58,6 +58,14 @@ public class ContractStorageListRemoval implements MapValueListRemoval<ContractK
 	 * {@inheritDoc}
 	 */
 	@Override
+	public void put(final ContractKey key, final IterableContractValue value) {
+		storage.put(key, value);
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
 	public void remove(final ContractKey key) {
 		storage.remove(key);
 	}

--- a/hedera-node/src/main/java/com/hedera/services/utils/MapValueListRemoval.java
+++ b/hedera-node/src/main/java/com/hedera/services/utils/MapValueListRemoval.java
@@ -9,9 +9,9 @@ package com.hedera.services.utils;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -19,6 +19,8 @@ package com.hedera.services.utils;
  * limitations under the License.
  * ‍
  */
+
+import com.swirlds.common.FastCopyable;
 
 import javax.annotation.Nullable;
 
@@ -32,7 +34,7 @@ import javax.annotation.Nullable;
  * @param <V>
  * 		type of value in the linked-values map
  */
-public interface MapValueListRemoval<K, V> {
+public interface MapValueListRemoval<K, V extends FastCopyable> {
 	/**
 	 * Gets the value for the specified key.
 	 *
@@ -60,6 +62,16 @@ public interface MapValueListRemoval<K, V> {
 	 * 		the key of interest
 	 */
 	void remove(K key);
+
+	/**
+	 * Adds the given mapping.
+	 *
+	 * @param key
+	 * 		the key of interest
+	 * @param value
+	 * 		the corresponding value
+	 */
+	void put(K key, V value);
 
 	/**
 	 * Updates the given node as the root of its containing linked list.

--- a/hedera-node/src/test/java/com/hedera/services/state/expiry/TokenRelsListRemovalTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/state/expiry/TokenRelsListRemovalTest.java
@@ -65,6 +65,13 @@ class TokenRelsListRemovalTest {
 	}
 
 	@Test
+	void delegatesPut() {
+		subject.put(rootRelKey, rootRel);
+
+		verify(tokenRels).put(rootRelKey, rootRel);
+	}
+
+	@Test
 	void delegatesRemove() {
 		subject.remove(rootRelKey);
 

--- a/hedera-node/src/test/java/com/hedera/services/state/virtual/ContractStorageListRemovalTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/state/virtual/ContractStorageListRemovalTest.java
@@ -68,6 +68,12 @@ class ContractStorageListRemovalTest {
 	}
 
 	@Test
+	void delegatesPut() {
+		subject.put(rootKey, rootValue);
+		verify(storage).put(rootKey, rootValue);
+	}
+
+	@Test
 	void knowsHowToMakeListNodeHead() {
 		targetValue.setPrevKey(rootKey.getKey());
 

--- a/hedera-node/src/test/java/com/hedera/services/utils/MapValueListUtilsTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/utils/MapValueListUtilsTest.java
@@ -25,6 +25,8 @@ import com.hedera.services.state.merkle.MerkleTokenRelStatus;
 import com.swirlds.merkle.map.MerkleMap;
 import org.junit.jupiter.api.Test;
 
+import static com.hedera.services.utils.MapValueListUtils.inPlaceRemoveFromMapValueList;
+import static com.hedera.services.utils.MapValueListUtils.overwritingRemoveFromMapValueList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -34,42 +36,83 @@ class MapValueListUtilsTest {
 	private MerkleMap<EntityNumPair, MerkleTokenRelStatus> tokenRels = new MerkleMap<>();
 
 	@Test
-	void sequentialRemovalWorksAsExpected() {
+	void sequentialRemovalWorksAsExpectedOverwriting() {
 		initializeRels();
 
 		final var relsListRemoval = new TokenRelsListRemoval(accountNum.longValue(), tokenRels);
 
-		final var k1 = MapValueListUtils.removeFromMapValueList(aRelKey, aRelKey, relsListRemoval);
+		final var k1 = overwritingRemoveFromMapValueList(aRelKey, aRelKey, relsListRemoval);
 		assertEquals(bRelKey, k1);
 		assertFalse(tokenRels.containsKey(aRelKey));
 
-		final var k2 = MapValueListUtils.removeFromMapValueList(k1, k1, relsListRemoval);
+		final var k2 = overwritingRemoveFromMapValueList(k1, k1, relsListRemoval);
 		assertEquals(cRelKey, k2);
 		assertFalse(tokenRels.containsKey(bRelKey));
 
-		final var k3 = MapValueListUtils.removeFromMapValueList(k2, k2, relsListRemoval);
+		final var k3 = overwritingRemoveFromMapValueList(k2, k2, relsListRemoval);
 		assertNull(k3);
 		assertTrue(tokenRels.isEmpty());
 	}
 
 	@Test
-	void interiorRemovalWorksAsExpected() {
+	void interiorRemovalWorksAsExpectedOverwriting() {
 		initializeRels();
 
 		final var relsListRemoval = new TokenRelsListRemoval(accountNum.longValue(), tokenRels);
 
-		final var k1 = MapValueListUtils.removeFromMapValueList(bRelKey, aRelKey, relsListRemoval);
+		final var k1 = overwritingRemoveFromMapValueList(bRelKey, aRelKey, relsListRemoval);
 		assertEquals(aRelKey, k1);
 		assertFalse(tokenRels.containsKey(bRelKey));
 	}
 
 	@Test
-	void tailRemovalWorksAsExpected() {
+	void tailRemovalWorksAsExpectedOverwriting() {
 		initializeRels();
 
 		final var relsListRemoval = new TokenRelsListRemoval(accountNum.longValue(), tokenRels);
 
-		final var k1 = MapValueListUtils.removeFromMapValueList(cRelKey, aRelKey, relsListRemoval);
+		final var k1 = overwritingRemoveFromMapValueList(cRelKey, aRelKey, relsListRemoval);
+		assertEquals(aRelKey, k1);
+		assertFalse(tokenRels.containsKey(cRelKey));
+	}
+
+	@Test
+	void sequentialRemovalWorksAsExpectedInPlace() {
+		initializeRels();
+
+		final var relsListRemoval = new TokenRelsListRemoval(accountNum.longValue(), tokenRels);
+
+		final var k1 = inPlaceRemoveFromMapValueList(aRelKey, aRelKey, relsListRemoval);
+		assertEquals(bRelKey, k1);
+		assertFalse(tokenRels.containsKey(aRelKey));
+
+		final var k2 = inPlaceRemoveFromMapValueList(k1, k1, relsListRemoval);
+		assertEquals(cRelKey, k2);
+		assertFalse(tokenRels.containsKey(bRelKey));
+
+		final var k3 = inPlaceRemoveFromMapValueList(k2, k2, relsListRemoval);
+		assertNull(k3);
+		assertTrue(tokenRels.isEmpty());
+	}
+
+	@Test
+	void interiorRemovalWorksAsExpectedInPlace() {
+		initializeRels();
+
+		final var relsListRemoval = new TokenRelsListRemoval(accountNum.longValue(), tokenRels);
+
+		final var k1 = inPlaceRemoveFromMapValueList(bRelKey, aRelKey, relsListRemoval);
+		assertEquals(aRelKey, k1);
+		assertFalse(tokenRels.containsKey(bRelKey));
+	}
+
+	@Test
+	void tailRemovalWorksAsExpectedInPlace() {
+		initializeRels();
+
+		final var relsListRemoval = new TokenRelsListRemoval(accountNum.longValue(), tokenRels);
+
+		final var k1 = inPlaceRemoveFromMapValueList(cRelKey, aRelKey, relsListRemoval);
 		assertEquals(aRelKey, k1);
 		assertFalse(tokenRels.containsKey(cRelKey));
 	}


### PR DESCRIPTION
**Description**:
- Renames methods that mutate a `VirtualMap` via `getForModify()` with an `inPlace` prefix.
   * E.g., `MapValueListUtils.removeFromMapValueList()` becomes `inPlaceRemoveFromMapValueList()`.
- Provides `overwriting*` variants of these methods that use a `get() -> copy() -> put()` idiom instead of `getForModify()`.