### PR TITLE
Check for MISSING_NUM in validation

### DIFF
--- a/hedera-node/src/main/java/com/hedera/services/txns/ethereum/EthereumTransitionLogic.java
+++ b/hedera-node/src/main/java/com/hedera/services/txns/ethereum/EthereumTransitionLogic.java
@@ -62,6 +62,7 @@ import static com.hedera.services.ledger.properties.AccountProperty.AUTO_RENEW_P
 import static com.hedera.services.ledger.properties.AccountProperty.KEY;
 import static com.hedera.services.ledger.properties.AccountProperty.MEMO;
 import static com.hedera.services.ledger.properties.AccountProperty.PROXY;
+import static com.hedera.services.utils.EntityNum.MISSING_NUM;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.CONTRACT_FILE_EMPTY;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_FILE_ID;
 
@@ -161,7 +162,7 @@ public class EthereumTransitionLogic implements PreFetchableTransition {
 			maybeUpdateCallData(accessor, ethTxData, accessor.getTxn().getEthereumTransaction());
 			var ethTxSigs = getOrCreateEthSigs(txnCtx.accessor(), ethTxData);
 			var callingAccount = aliasManager.lookupIdBy(ByteString.copyFrom(ethTxSigs.address()));
-			if (callingAccount == null) {
+			if (callingAccount == MISSING_NUM) {
 				return ResponseCodeEnum.INVALID_ACCOUNT_ID; 
 			}
 

--- a/hedera-node/src/test/java/com/hedera/services/txns/ethereum/EthereumTransactionTransitionLogicTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/txns/ethereum/EthereumTransactionTransitionLogicTest.java
@@ -569,56 +569,19 @@ class EthereumTransactionTransitionLogicTest {
 		assertEquals(OK, subject.validateSemantics(accessor));
 	}
 
-//	@Test
-//	void acceptsConsensusDecoded() {
-//		givenValidTxnCtx();
-//		given(spanMapAccessor.getEthTxDataMeta(accessor)).willReturn(ethTxData);
-//		given(optionValidator.isValidAutoRenewPeriod(any())).willReturn(true);
-//		given(globalDynamicProperties.maxGas()).willReturn(gas+1);
-//		given(optionValidator.memoCheck(any())).willReturn(OK);
-//		given(accessor.getExpandedSigStatus()).willReturn(OK);
-//		given(accessor.getTxn()).willReturn(ethTxTxn);
-//		given(hfs.exists(callDataFile)).willReturn(true);
-//		given(hfs.cat(callDataFile)).willReturn(new byte[] {0x30, 0x31, 0x32, 0x33});
-//		given(aliasManager.lookupIdBy(ByteString.copyFrom(TRUFFLE0_ADDRESS))).willReturn(EntityNum.fromInt(4321));
-//
-//		// expect:
-//		assertEquals(OK, subject.validateSemantics(accessor));
-//	}
-//
-//	@Test
-//	void rejectsConsensusNoContract() {
-//		givenValidTxnCtx();
-//		given(spanMapAccessor.getEthTxDataMeta(accessor)).willReturn(ethTxData);
-//		given(optionValidator.isValidAutoRenewPeriod(any())).willReturn(true);
-//		given(globalDynamicProperties.maxGas()).willReturn(gas+1);
-//		given(optionValidator.memoCheck(any())).willReturn(OK);
-//		given(accessor.getExpandedSigStatus()).willReturn(OK);
-//		given(accessor.getTxn()).willReturn(ethTxTxn);
-//		given(hfs.exists(callDataFile)).willReturn(true);
-//		given(hfs.cat(callDataFile)).willReturn(new byte[] {0x30, 0x31, 0x32, 0x33});
-//		given(aliasManager.lookupIdBy(ByteString.copyFrom(TRUFFLE0_ADDRESS))).willReturn(EntityNum.fromInt(4321));
-//
-//		// expect:
-//		assertEquals(OK, subject.validateSemantics(accessor));
-//	}
-//
-//	@Test
-//	void rejectsConsensusWrongNonce() {
-//		givenValidTxnCtx();
-//		given(spanMapAccessor.getEthTxDataMeta(accessor)).willReturn(ethTxData);
-//		given(optionValidator.isValidAutoRenewPeriod(any())).willReturn(true);
-//		given(globalDynamicProperties.maxGas()).willReturn(gas+1);
-//		given(optionValidator.memoCheck(any())).willReturn(OK);
-//		given(accessor.getExpandedSigStatus()).willReturn(OK);
-//		given(accessor.getTxn()).willReturn(ethTxTxn);
-//		given(hfs.exists(callDataFile)).willReturn(true);
-//		given(hfs.cat(callDataFile)).willReturn(new byte[] {0x30, 0x31, 0x32, 0x33});
-//		given(aliasManager.lookupIdBy(ByteString.copyFrom(TRUFFLE0_ADDRESS))).willReturn(EntityNum.fromInt(4321));
-//
-//		// expect:
-//		assertEquals(OK, subject.validateSemantics(accessor));
-//	}
+	@Test
+	void acceptsConsensusDecoded() {
+		givenValidTxnCtx();
+		given(spanMapAccessor.getEthTxDataMeta(accessor)).willReturn(ethTxData);
+		given(globalDynamicProperties.maxGas()).willReturn(gas+1);
+		given(accessor.getExpandedSigStatus()).willReturn(OK);
+		given(accessor.getTxn()).willReturn(ethTxTxn);
+		given(aliasManager.lookupIdBy(ByteString.copyFrom(TRUFFLE0_ADDRESS))).willReturn(EntityNum.fromInt(4321));
+		given(accountsLedger.get(any(), eq(AccountProperty.ETHEREUM_NONCE))).willReturn(ethTxData.nonce());
+
+		// expect:
+		assertEquals(OK, subject.validateSemantics(accessor));
+	}
 
 	@Test
 	void rejectWrongTransactionBody() {
@@ -695,6 +658,7 @@ class EthereumTransactionTransitionLogicTest {
 		given(accessor.getExpandedSigStatus()).willReturn(OK);
 		given(spanMapAccessor.getEthTxDataMeta(accessor)).willReturn(ethTxData);
 		given(accessor.getTxn()).willReturn(ethTxTxn);
+		given(aliasManager.lookupIdBy(any())).willReturn(EntityNum.MISSING_NUM);
 
 		// expect:
 		assertEquals(INVALID_ACCOUNT_ID, subject.validateSemantics(accessor));


### PR DESCRIPTION
AliasManager.lookupById never returns null, instead check for
MISSING_NUM.

Also, delete two duplicate tests and uncomment a third.

Signed-off-by: Danno Ferrin <danno.ferrin@hedera.com>

**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
