### PR TITLE
Fix failing/flakey E2E tests

### DIFF
--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/consensus/TopicCreateSuite.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/consensus/TopicCreateSuite.java
@@ -29,10 +29,10 @@ import java.util.List;
 
 import static com.hedera.services.bdd.spec.HapiApiSpec.defaultHapiSpec;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getTopicInfo;
-import static com.hedera.services.bdd.spec.transactions.TxnVerbs.contractCreate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.createDefaultContract;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.createTopic;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoCreate;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.fileCreate;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.newKeyNamed;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.validateChargedUsd;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.AUTORENEW_ACCOUNT_NOT_ALLOWED;
@@ -158,6 +158,7 @@ public class TopicCreateSuite extends HapiApiSuite {
 						newKeyNamed("wrongKey"),
 						cryptoCreate("payer").balance(PAYER_BALANCE),
 						cryptoCreate("autoRenewAccount"),
+						fileCreate("nonCryptoAccount"),
 						createDefaultContract("nonCryptoAccount")
 				)
 				.when(

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/CreatePrecompileSuite.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/CreatePrecompileSuite.java
@@ -900,10 +900,10 @@ public class CreatePrecompileSuite extends HapiApiSuite {
 						getContractInfo(TOKEN_CREATE_CONTRACT).logged(),
 						childRecordsCheck(FIRST_CREATE_TXN, CONTRACT_REVERT_EXECUTED,
 								TransactionRecordAsserts.recordWith()
-										.status(INVALID_ACCOUNT_ID)
+										.status(INVALID_SIGNATURE)
 										.contractCallResult(
 												ContractFnResultAsserts.resultWith()
-														.error(INVALID_ACCOUNT_ID.name()))),
+														.error(INVALID_SIGNATURE.name()))),
 						UtilVerbs.resetAppPropertiesTo("src/main/resource/bootstrap.properties")
 				);
 	}


### PR DESCRIPTION
**Description**:
Fix failing/flakey E2E tests in:
- TopicCreateSuite
- CreatePrecompileSuite
- CryptoGetInfoRegression

This is due to erroneous setup or use of deprecated API.

**Related issue(s)**:

https://github.com/hashgraph/hedera-services/issues/1191