### PR TITLE
Create Child Record for Child Transactions

### DIFF
--- a/hedera-node/src/main/java/com/hedera/services/txns/ethereum/EthereumTransitionLogic.java
+++ b/hedera-node/src/main/java/com/hedera/services/txns/ethereum/EthereumTransitionLogic.java
@@ -118,11 +118,12 @@ public class EthereumTransitionLogic implements PreFetchableTransition {
 		if (syntheticTxBody.hasContractCall()) {
 			contractCallTransitionLogic.doStateTransitionOperation(syntheticTxBody, callingAccount.toId(), true);
 		} else if (syntheticTxBody.hasContractCreateInstance()) {
-			final var synthOp =
-					addInheritablePropertiesToContractCreate(syntheticTxBody.getContractCreateInstance(), callingAccount.toGrpcAccountId());
+			final var synthOp = addInheritablePropertiesToContractCreate(syntheticTxBody.getContractCreateInstance(),
+					callingAccount.toGrpcAccountId());
 			syntheticTxBody = TransactionBody.newBuilder().setContractCreateInstance(synthOp).build();
 			spanMapAccessor.setEthTxBodyMeta(txnCtx.accessor(), syntheticTxBody);
-			contractCreateTransitionLogic.doStateTransitionOperation(syntheticTxBody, callingAccount.toId(), true);
+			contractCreateTransitionLogic.doStateTransitionOperation(syntheticTxBody, callingAccount.toId(), true,
+					true);
 		}
 		recordService.updateForEvmCall(ethTxData, callingAccount.toEntityId());
 	}

--- a/hedera-node/src/test/java/com/hedera/services/txns/contract/ContractCreateTransitionLogicTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/txns/contract/ContractCreateTransitionLogicTest.java
@@ -29,9 +29,12 @@ import com.hedera.services.exceptions.InvalidTransactionException;
 import com.hedera.services.files.HederaFs;
 import com.hedera.services.ledger.SigImpactHistorian;
 import com.hedera.services.legacy.core.jproto.JEd25519Key;
+import com.hedera.services.records.RecordsHistorian;
 import com.hedera.services.records.TransactionRecordService;
+import com.hedera.services.state.EntityCreator;
 import com.hedera.services.store.AccountStore;
 import com.hedera.services.store.contracts.HederaWorldState;
+import com.hedera.services.store.contracts.precompile.SyntheticTxnFactory;
 import com.hedera.services.store.models.Account;
 import com.hedera.services.store.models.Id;
 import com.hedera.services.txns.validation.OptionValidator;
@@ -106,6 +109,10 @@ class ContractCreateTransitionLogicTest {
 	@Mock
 	private HederaWorldState worldState;
 	@Mock
+	private EntityCreator entityCreator;
+	@Mock
+	private RecordsHistorian recordsHistorian;
+	@Mock
 	private TransactionRecordService recordServices;
 	@Mock
 	private CreateEvmTxProcessor evmTxProcessor;
@@ -115,6 +122,8 @@ class ContractCreateTransitionLogicTest {
 	private GlobalDynamicProperties properties;
 	@Mock
 	private SigImpactHistorian sigImpactHistorian;
+	@Mock
+	SyntheticTxnFactory syntheticTxnFactory;
 	@Mock
 	private Account autoRenewModel;
 
@@ -127,11 +136,8 @@ class ContractCreateTransitionLogicTest {
 
 	@BeforeEach
 	private void setup() {
-		subject = new ContractCreateTransitionLogic(
-				hfs,
-				txnCtx, accountStore, validator,
-				worldState, recordServices, evmTxProcessor,
-				properties, sigImpactHistorian);
+		subject = new ContractCreateTransitionLogic(hfs, txnCtx, accountStore, validator, worldState, entityCreator,
+				recordsHistorian, recordServices, evmTxProcessor, properties, sigImpactHistorian, syntheticTxnFactory);
 	}
 
 	@Test


### PR DESCRIPTION
When executing a create (to address is empty) ethereum transaction, add
a child record containing the synthetic transaction data.

Signed-off-by: Danno Ferrin <danno.ferrin@hedera.com>

**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
