### PR TITLE
3216 ethtx calldata noethdata

### DIFF
--- a/hedera-node/src/main/java/com/hedera/services/txns/ethereum/EthereumTransitionLogic.java
+++ b/hedera-node/src/main/java/com/hedera/services/txns/ethereum/EthereumTransitionLogic.java
@@ -154,8 +154,7 @@ public class EthereumTransitionLogic implements PreFetchableTransition {
 	public ResponseCodeEnum validateSemantics(TxnAccessor accessor) {
 		var ethTxData = spanMapAccessor.getEthTxDataMeta(accessor);
 		if (ethTxData == null) {
-			// TODO: Figure out better response code
-			return ResponseCodeEnum.FAIL_INVALID;
+			return ResponseCodeEnum.INVALID_ETHEREUM_TRANSACTION;
 		}
 
 		var txBody = getOrCreateTransactionBody(accessor);

--- a/hedera-node/src/main/java/com/hedera/services/txns/ethereum/EthereumTransitionLogic.java
+++ b/hedera-node/src/main/java/com/hedera/services/txns/ethereum/EthereumTransitionLogic.java
@@ -153,6 +153,11 @@ public class EthereumTransitionLogic implements PreFetchableTransition {
 	@Override
 	public ResponseCodeEnum validateSemantics(TxnAccessor accessor) {
 		var ethTxData = spanMapAccessor.getEthTxDataMeta(accessor);
+		if (ethTxData == null) {
+			// TODO: Figure out better response code
+			return ResponseCodeEnum.FAIL_INVALID;
+		}
+
 		var txBody = getOrCreateTransactionBody(accessor);
 
 		if (ethTxData.chainId().length == 0 || Arrays.compare(chainId, ethTxData.chainId()) != 0) {

--- a/hedera-node/src/test/java/com/hedera/services/txns/ethereum/EthereumTransactionTransitionLogicTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/txns/ethereum/EthereumTransactionTransitionLogicTest.java
@@ -616,6 +616,15 @@ class EthereumTransactionTransitionLogicTest {
 	}
 
 	@Test
+	void missingEthDataPrecheck() {
+		givenValidTxnCtx();
+		given(spanMapAccessor.getEthTxDataMeta(accessor)).willReturn(null);
+
+		// expect:
+		assertEquals(FAIL_INVALID, subject.validateSemantics(accessor));
+	}
+
+	@Test
 	void wrongChainId() {
 		chainId = new byte[] { 1, 42 };
 		givenValidTxnCtx();

--- a/hedera-node/src/test/java/com/hedera/services/txns/ethereum/EthereumTransactionTransitionLogicTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/txns/ethereum/EthereumTransactionTransitionLogicTest.java
@@ -92,6 +92,7 @@ import static com.hedera.services.txns.ethereum.TestingConstants.TRUFFLE0_PRIVAT
 import static com.hedera.services.txns.ethereum.TestingConstants.WEIBARS_IN_TINYBAR;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.FAIL_INVALID;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_ACCOUNT_ID;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_ETHEREUM_TRANSACTION;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.MAX_GAS_LIMIT_EXCEEDED;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.NOT_SUPPORTED;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OK;
@@ -621,7 +622,7 @@ class EthereumTransactionTransitionLogicTest {
 		given(spanMapAccessor.getEthTxDataMeta(accessor)).willReturn(null);
 
 		// expect:
-		assertEquals(FAIL_INVALID, subject.validateSemantics(accessor));
+		assertEquals(INVALID_ETHEREUM_TRANSACTION, subject.validateSemantics(accessor));
 	}
 
 	@Test

--- a/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/contract/HapiEthereumContractCreate.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/contract/HapiEthereumContractCreate.java
@@ -47,6 +47,7 @@ public class HapiEthereumContractCreate extends HapiBaseContractCreate<HapiEther
     private long gasPrice = 20L;
     private long maxPriorityGas = 20_000L;
     private Optional<FileID> ethFileID = Optional.empty();
+    private boolean invalidateEthData = false;
     private Optional<Long> maxGasAllowance = Optional.of(2_000_000L);
     private String privateKeyRef = SECP_256K1_SOURCE_KEY;
 
@@ -112,6 +113,11 @@ public class HapiEthereumContractCreate extends HapiBaseContractCreate<HapiEther
 
     public HapiEthereumContractCreate bytecode(String fileName) {
         bytecodeFile = Optional.of(fileName);
+        return this;
+    }
+
+    public HapiEthereumContractCreate invalidateEthereumData() {
+        invalidateEthData = true;
         return this;
     }
 
@@ -245,7 +251,9 @@ public class HapiEthereumContractCreate extends HapiBaseContractCreate<HapiEther
                 .txns()
                 .<EthereumTransactionBody, EthereumTransactionBody.Builder>body(
                         EthereumTransactionBody.class, builder -> {
-                            builder.setEthereumData(ByteString.copyFrom(ethData.encodeTx()));
+                            if (!invalidateEthData) {
+                                builder.setEthereumData(ByteString.copyFrom(ethData.encodeTx()));
+                            }
                             ethFileID.ifPresent(builder::setCallData);
                             maxGasAllowance.ifPresent(builder::setMaxGasAllowance);
                         }

--- a/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/contract/HapiEthereumContractCreate.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/contract/HapiEthereumContractCreate.java
@@ -251,7 +251,9 @@ public class HapiEthereumContractCreate extends HapiBaseContractCreate<HapiEther
                 .txns()
                 .<EthereumTransactionBody, EthereumTransactionBody.Builder>body(
                         EthereumTransactionBody.class, builder -> {
-                            if (!invalidateEthData) {
+                            if (invalidateEthData) {
+                                builder.setEthereumData(ByteString.EMPTY);
+                            } else {
                                 builder.setEthereumData(ByteString.copyFrom(ethData.encodeTx()));
                             }
                             ethFileID.ifPresent(builder::setCallData);

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/ethereum/EthereumSuite.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/ethereum/EthereumSuite.java
@@ -1,0 +1,69 @@
+package com.hedera.services.bdd.suites.ethereum;
+
+import com.hedera.services.bdd.spec.HapiApiSpec;
+import com.hedera.services.bdd.suites.HapiApiSuite;
+import com.hedera.services.ethereum.EthTxData;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.List;
+
+import static com.hedera.services.bdd.spec.HapiApiSpec.defaultHapiSpec;
+import static com.hedera.services.bdd.spec.keys.KeyFactory.KeyType.THRESHOLD;
+import static com.hedera.services.bdd.spec.queries.QueryVerbs.getTxnRecord;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoCreate;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoTransfer;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.ethereumContractCreate;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.uploadInitCode;
+import static com.hedera.services.bdd.spec.transactions.crypto.HapiCryptoTransfer.tinyBarsFromAccountToAlias;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.newKeyNamed;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.FAIL_INVALID;
+
+public class EthereumSuite extends HapiApiSuite {
+
+	private static final Logger log = LogManager.getLogger(EthereumSuite.class);
+
+	private static final String PAY_RECEIVABLE_CONTRACT = "PayReceivable";
+
+	public static void main(String... args) {
+		new EthereumSuite().runSuiteSync();
+	}
+
+	@Override
+	public List<HapiApiSpec> getSpecsInSuite() {
+		return List.of(
+				invalidTxData()
+		);
+	}
+
+	HapiApiSpec invalidTxData() {
+		return defaultHapiSpec("InvalidTxData")
+				.given(
+						newKeyNamed(SECP_256K1_SOURCE_KEY).shape(SECP_256K1_SHAPE),
+						cryptoCreate(RELAYER).balance(6 * ONE_MILLION_HBARS),
+						cryptoTransfer(tinyBarsFromAccountToAlias(GENESIS, SECP_256K1_SOURCE_KEY, ONE_HUNDRED_HBARS))    .via("autoAccount"),
+						getTxnRecord("autoAccount").andAllChildRecords(),
+
+
+						uploadInitCode(PAY_RECEIVABLE_CONTRACT)
+				).when(
+						ethereumContractCreate(PAY_RECEIVABLE_CONTRACT)
+								.adminKey(THRESHOLD)
+								.type(EthTxData.EthTransactionType.EIP1559)
+								.signingWith(SECP_256K1_SOURCE_KEY)
+								.payingWith(RELAYER)
+								.nonce(0)
+								.gasPrice(10L)
+								.maxGasAllowance(5L)
+								.maxPriorityGas(2L)
+								.invalidateEthereumData()
+								.gasLimit(1_000_000L).hasPrecheck(FAIL_INVALID)
+								.via("payTxn")
+				).then();
+	}
+
+	@Override
+	protected Logger getResultsLogger() {
+		return log;
+	}
+}

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/ethereum/EthereumSuite.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/ethereum/EthereumSuite.java
@@ -17,7 +17,7 @@ import static com.hedera.services.bdd.spec.transactions.TxnVerbs.ethereumContrac
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.uploadInitCode;
 import static com.hedera.services.bdd.spec.transactions.crypto.HapiCryptoTransfer.tinyBarsFromAccountToAlias;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.newKeyNamed;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.FAIL_INVALID;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_ETHEREUM_TRANSACTION;
 
 public class EthereumSuite extends HapiApiSuite {
 
@@ -57,7 +57,7 @@ public class EthereumSuite extends HapiApiSuite {
 								.maxGasAllowance(5L)
 								.maxPriorityGas(2L)
 								.invalidateEthereumData()
-								.gasLimit(1_000_000L).hasPrecheck(FAIL_INVALID)
+								.gasLimit(1_000_000L).hasPrecheck(INVALID_ETHEREUM_TRANSACTION)
 								.via("payTxn")
 				).then();
 	}

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/ethereum/HelloWorldEthereumSuite.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/ethereum/HelloWorldEthereumSuite.java
@@ -8,7 +8,6 @@ import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import java.math.BigInteger;
 import java.util.List;
 
 import static com.hedera.services.bdd.spec.HapiApiSpec.defaultHapiSpec;


### PR DESCRIPTION
**Description**:
In this PR I am adding an E2E Scenario where no eth data is passed to the EthereumTxBody. This started to produce exceptions so I had to add an explicit precheck whether the EthTxData is present. I think we need to come up with a proper response code so I added a TODO and we can discuss that.

**Related issue(s)**:

Fixes #3216 

**Checklist**

- [x] Tested (unit, integration, etc.)
