### PR TITLE
Adjust timing for a few occasionally failed NI reconnect tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -418,7 +418,7 @@ commands:
           name: Saving JRS Regression Results
           command: |
             set -x
-            cd /swirlds-platform/regression/assets;
+            cd /swirlds-platform/regression;
 
             if [[ ! -d "<< parameters.result_path >>" ]]; then exit 13; fi
 
@@ -437,9 +437,10 @@ commands:
             else
               JRS_BRANCH="${CIRCLE_BRANCH}"
             fi
-
-            gsutil -m rsync -r "<< parameters.result_path >>" "gs://<< parameters.bucket_name >>/${JRS_USER}/${JRS_BRANCH}/<< parameters.result_path >>/"
-
+            cd assets
+            remove_prefix=${"<< parameters.result_path >>"#"assets"}
+            gsutil -m rsync -r ${remove_prefix} "gs://<< parameters.bucket_name >>/${JRS_USER}/${JRS_BRANCH}/${remove_prefix}/"
+            cd
             tar -czvf /results.tar.gz  /swirlds-platform/regression/<< parameters.result_path >>
           when: always
 
@@ -1353,7 +1354,7 @@ workflows:
       - jrs-regression:
           context: Slack
           regression_path: /swirlds-platform/regression/assets
-          result_path: results/6N_1C/NIReconnectCorrectness
+          result_path: assets/results/6N_1C/NIReconnectCorrectness
           config_type: "daily"
           workflow-name: "GCP-Daily-Services-Comp-NI-Reconnect-Correctness-6N-1C"
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -437,11 +437,13 @@ commands:
             else
               JRS_BRANCH="${CIRCLE_BRANCH}"
             fi
+
             cd assets
             original_path="<< parameters.result_path >>"
             prefix_removed=${original_path//assets\//}
             gsutil -m rsync -r ${prefix_removed} "gs://<< parameters.bucket_name >>/${JRS_USER}/${JRS_BRANCH}/${prefix_removed}/"
             cd -
+
             tar -czvf /results.tar.gz  /swirlds-platform/regression/<< parameters.result_path >>
           when: always
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1348,13 +1348,6 @@ workflows:
                 at: /
 
   GCP-Daily-Services-Comp-NI-Reconnect-Correctness-6N-1C:
-    triggers:
-      - schedule:
-          cron: "25 7 * * *"
-          filters:
-            branches:
-              only:
-                - master
     jobs:
       - build-platform-and-services
       - jrs-regression:
@@ -1602,6 +1595,7 @@ jobs:
             cd /swirlds-platform;
             sed -i -e 's/github.com/services-jrs-regression/g' .gitmodules;
             git submodule update --init --recursive --checkout;
+            cd regression; git checkout -b 02346-fix-AllProtectedFilesUpdate origin/02346-fix-AllProtectedFilesUpdate; cd -;
             mvn --no-transfer-progress clean install -DskipTests;
 
       - run:
@@ -1679,10 +1673,10 @@ jobs:
         default: true
       slack_results_channel:
         type: string
-        default: "hedera-regression"
+        default: "hedera-regression-test"
       slack_summary_channel:
         type: string
-        default: "hedera-regression-summary"
+        default: "hedera-regression-test"
       workflow-name:
         type: string
         default: ""

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -438,8 +438,9 @@ commands:
               JRS_BRANCH="${CIRCLE_BRANCH}"
             fi
             cd assets
-            remove_prefix=${"<< parameters.result_path >>"//assets/}
-            gsutil -m rsync -r ${remove_prefix} "gs://<< parameters.bucket_name >>/${JRS_USER}/${JRS_BRANCH}/${remove_prefix}/"
+            original_path="<< parameters.result_path >>"
+            prefix_removed=${original_path//assets\//}
+            gsutil -m rsync -r ${prefix_removed} "gs://<< parameters.bucket_name >>/${JRS_USER}/${JRS_BRANCH}/${prefix_removed}/"
             cd -
             tar -czvf /results.tar.gz  /swirlds-platform/regression/<< parameters.result_path >>
           when: always

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -438,9 +438,9 @@ commands:
               JRS_BRANCH="${CIRCLE_BRANCH}"
             fi
             cd assets
-            remove_prefix=${"<< parameters.result_path >>"#"assets"}
+            remove_prefix=${"<< parameters.result_path >>"//assets/}
             gsutil -m rsync -r ${remove_prefix} "gs://<< parameters.bucket_name >>/${JRS_USER}/${JRS_BRANCH}/${remove_prefix}/"
-            cd
+            cd -
             tar -czvf /results.tar.gz  /swirlds-platform/regression/<< parameters.result_path >>
           when: always
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1350,6 +1350,13 @@ workflows:
                 at: /
 
   GCP-Daily-Services-Comp-NI-Reconnect-Correctness-6N-1C:
+    triggers:
+      - schedule:
+          cron: "25 7 * * *"
+          filters:
+            branches:
+              only:
+                - master
     jobs:
       - build-platform-and-services
       - jrs-regression:
@@ -1597,7 +1604,6 @@ jobs:
             cd /swirlds-platform;
             sed -i -e 's/github.com/services-jrs-regression/g' .gitmodules;
             git submodule update --init --recursive --checkout;
-            cd regression; git checkout -b 02346-fix-AllProtectedFilesUpdate origin/02346-fix-AllProtectedFilesUpdate; cd -;
             mvn --no-transfer-progress clean install -DskipTests;
 
       - run:
@@ -1675,10 +1681,10 @@ jobs:
         default: true
       slack_results_channel:
         type: string
-        default: "hedera-regression-test"
+        default: "hedera-regression"
       slack_summary_channel:
         type: string
-        default: "hedera-regression-test"
+        default: "hedera-regression-summary"
       workflow-name:
         type: string
         default: ""

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -437,13 +437,13 @@ commands:
             else
               JRS_BRANCH="${CIRCLE_BRANCH}"
             fi
-
+            
             cd assets
             original_path="<< parameters.result_path >>"
             prefix_removed=${original_path//assets\//}
             gsutil -m rsync -r ${prefix_removed} "gs://<< parameters.bucket_name >>/${JRS_USER}/${JRS_BRANCH}/${prefix_removed}/"
             cd -
-
+            
             tar -czvf /results.tar.gz  /swirlds-platform/regression/<< parameters.result_path >>
           when: always
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -418,7 +418,7 @@ commands:
           name: Saving JRS Regression Results
           command: |
             set -x
-            cd /swirlds-platform/regression;
+            cd /swirlds-platform/regression/assets;
 
             if [[ ! -d "<< parameters.result_path >>" ]]; then exit 13; fi
 
@@ -1353,7 +1353,7 @@ workflows:
       - jrs-regression:
           context: Slack
           regression_path: /swirlds-platform/regression/assets
-          result_path: assets/results/6N_1C/NIReconnectCorrectness
+          result_path: results/6N_1C/NIReconnectCorrectness
           config_type: "daily"
           workflow-name: "GCP-Daily-Services-Comp-NI-Reconnect-Correctness-6N-1C"
           requires:

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/reconnect/UpdateAllProtectedFilesDuringReconnect.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/reconnect/UpdateAllProtectedFilesDuringReconnect.java
@@ -89,7 +89,7 @@ public class UpdateAllProtectedFilesDuringReconnect extends HapiApiSuite {
 						saveFileToRegistry(EXCHANGE_RATES, RATES_FILE_REGISTRY),
 						saveFileToRegistry(FEE_SCHEDULE, FEES_FILE_REGISTRY),
 
-						sleepFor(Duration.ofSeconds(25).toMillis()),
+						sleepFor(Duration.ofSeconds(50).toMillis()),
 						getAccountBalance(GENESIS)
 								.setNode("0.0.8")
 								.unavailableNode()

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/reconnect/ValidateCongestionPricingAfterReconnect.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/reconnect/ValidateCongestionPricingAfterReconnect.java
@@ -114,6 +114,7 @@ public class ValidateCongestionPricingAfterReconnect extends HapiApiSuite {
 								.via("cheapCallBeforeCongestionPricing"),
 						getTxnRecord("cheapCallBeforeCongestionPricing")
 								.providingFeeTo(normalPrice::set),
+						sleepFor(30000),
 						getAccountBalance(GENESIS)
 								.setNode(reconnectingNode)
 								.unavailableNode()

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/reconnect/ValidateDuplicateTransactionAfterReconnect.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/reconnect/ValidateDuplicateTransactionAfterReconnect.java
@@ -61,7 +61,7 @@ public class ValidateDuplicateTransactionAfterReconnect extends HapiApiSuite {
 						"txn.start.offset.secs", "-5")
 				)
 				.given(
-						sleepFor(Duration.ofSeconds(25).toMillis()),
+						sleepFor(Duration.ofSeconds(50).toMillis()),
 						getAccountBalance(GENESIS)
 								.setNode("0.0.8")
 								.unavailableNode()


### PR DESCRIPTION
Use test AllProtectedFilesUpdate-NIReconnect-1-16m as an example.

After analyzing some test logs, 
The last node became disconnected after about 9 minutes 50 seconds of node start.

The client is expecting node to be disconnected after the 9 minutes 30 seconds of client start.

Since there is a little delay between client start and node start,  so sometimes
client's check time is after the disconnection time,
client's check time is a few second earlier than disconnection time.
and caused the client to report disconnection not happening yet.

```
Node start -------------------------------> Node disconnect
      Client Start ---------------------------> client check if disconnect happened
```

Added some delay to make sure the check time a after actual disconnection time.

```
Node start -------------------------------> Node disconnect
      Client Start -----------------------------------------> client check if disconnect happened
```

For the test CongestionPricing-NIReconnect-1-16m, it is similar story but for the reconnect check.
The client is expecting the last node back online, but the check point sometimes a little earlier before
the node became active again.


Test result 

https://hedera-hashgraph.slack.com/archives/C018CBQBTGB/p1651639031184239
https://hedera-hashgraph.slack.com/archives/C018CBQBTGB/p1651639029509599
https://hedera-hashgraph.slack.com/archives/C018CBQBTGB/p1651626450586099
