### PR TITLE
Fix ethereum contract create

### DIFF
--- a/hedera-node/src/main/java/com/hedera/services/ledger/accounts/AccountCustomizer.java
+++ b/hedera-node/src/main/java/com/hedera/services/ledger/accounts/AccountCustomizer.java
@@ -121,7 +121,9 @@ public abstract class AccountCustomizer<
 	}
 
 	public T proxy(final EntityId option) {
-		changeManager.update(changes, optionProperties.get(PROXY), option);
+		if(option != null) {
+			changeManager.update(changes, optionProperties.get(PROXY), option);
+		}
 		return self();
 	}
 
@@ -166,7 +168,9 @@ public abstract class AccountCustomizer<
 	}
 
 	public T autoRenewAccount(final EntityId option) {
-		changeManager.update(changes, optionProperties.get(AUTO_RENEW_ACCOUNT_ID), option);
+		if(option != null) {
+			changeManager.update(changes, optionProperties.get(AUTO_RENEW_ACCOUNT_ID), option);
+		}
 		return self();
 	}
 }

--- a/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/contract/HapiEthereumCall.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/contract/HapiEthereumCall.java
@@ -115,7 +115,6 @@ public class HapiEthereumCall extends HapiBaseCall<HapiEthereumCall> {
         this.txnName = contractCall.getTxnName();
         this.gas = contractCall.getGas();
         this.expectedStatus = Optional.of(contractCall.getExpectedStatus());
-        this.otherSigs = contractCall.getOtherSigs();
         this.payer = contractCall.getPayer();
         this.expectedPrecheck = Optional.of(contractCall.getExpectedPrecheck());
         this.fiddler = contractCall.getFiddler();

--- a/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/contract/HapiEthereumContractCreate.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/contract/HapiEthereumContractCreate.java
@@ -43,6 +43,8 @@ import com.hederahashgraph.api.proto.java.TransactionResponse;
 import org.apache.tuweni.bytes.Bytes;
 
 import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 import java.util.OptionalLong;
 import java.util.function.Consumer;
@@ -281,6 +283,17 @@ public class HapiEthereumContractCreate extends HapiBaseContractCreate<HapiEther
                         }
                 );
         return b -> b.setEthereumTransaction(opBody);
+    }
+
+    @Override
+    protected List<Function<HapiApiSpec, Key>> defaultSigners() {
+        if (omitAdminKey || useDeprecatedAdminKey) {
+            return super.defaultSigners();
+        }
+        List<Function<HapiApiSpec, Key>> signers =
+                new ArrayList<>(List.of(spec -> spec.registry().getKey(effectivePayer(spec))));
+        Optional.ofNullable(adminKey).ifPresent(k -> signers.add(ignore -> k));
+        return signers;
     }
 
     @Override

--- a/test-clients/src/test/java/E2EPackageRunner.java
+++ b/test-clients/src/test/java/E2EPackageRunner.java
@@ -294,22 +294,13 @@ class E2EPackageRunner {
 	@TestFactory
 	Collection<DynamicContainer> contractPrecompileEth() {
 		return List.of(
-				extractSpecsFromSuiteForEth(AssociatePrecompileSuite::new)
-		);
-	}
-
-	@Tag("contract")
-	@Tag("contract.precompile")
-	@Tag("contract.precompile.part1.eth.failing")
-	@TestFactory
-	Collection<DynamicContainer> contractPrecompileEthFailing() {
-		return List.of(new DynamicContainer[] {
+				extractSpecsFromSuiteForEth(AssociatePrecompileSuite::new),
 				extractSpecsFromSuiteForEth(ContractBurnHTSSuite::new),
 				extractSpecsFromSuiteForEth(ContractHTSSuite::new),
 				extractSpecsFromSuiteForEth(ContractKeysHTSSuite::new),
 				extractSpecsFromSuiteForEth(ContractMintHTSSuite::new),
 				extractSpecsFromSuiteForEth(CreatePrecompileSuite::new)
-		});
+		);
 	}
 
 	@Tag("contract")
@@ -332,7 +323,9 @@ class E2EPackageRunner {
 	@TestFactory
 	Collection<DynamicContainer> contractPrecompile2Eth() {
 		return List.of(
-				extractSpecsFromSuiteForEth(DissociatePrecompileSuite::new)
+				extractSpecsFromSuiteForEth(DissociatePrecompileSuite::new),
+				extractSpecsFromSuiteForEth(CryptoTransferHTSSuite::new),
+				extractSpecsFromSuiteForEth(DelegatePrecompileSuite::new)
 		);
 	}
 
@@ -342,8 +335,6 @@ class E2EPackageRunner {
 	@TestFactory
 	Collection<DynamicContainer> contractPrecompile2EthFailing() {
 		return List.of(
-				extractSpecsFromSuiteForEth(CryptoTransferHTSSuite::new),
-				extractSpecsFromSuiteForEth(DelegatePrecompileSuite::new),
 				extractSpecsFromSuiteForEth(DynamicGasCostSuite::new),
 				extractSpecsFromSuiteForEth(MixedHTSPrecompileTestsSuite::new)
 		);
@@ -425,15 +416,7 @@ class E2EPackageRunner {
 				extractSpecsFromSuiteForEth(ExtCodeHashOperationSuite::new),
 				extractSpecsFromSuiteForEth(ExtCodeSizeOperationSuite::new),
 				extractSpecsFromSuiteForEth(GlobalPropertiesSuite::new),
-				extractSpecsFromSuiteForEth(StaticCallOperationSuite::new)
-		);
-	}
-
-	@Tag("contract")
-	@Tag("contract.opcodes.eth.failing")
-	@TestFactory
-	Collection<DynamicContainer> contractOpcodesEthFailing() {
-		return List.of(
+				extractSpecsFromSuiteForEth(StaticCallOperationSuite::new),
 				extractSpecsFromSuiteForEth(SelfDestructSuite::new),
 				extractSpecsFromSuiteForEth(SStoreSuite::new)
 		);
@@ -463,7 +446,9 @@ class E2EPackageRunner {
 				extractSpecsFromSuiteForEth(ContractCallLocalSuite::new),
 				extractSpecsFromSuiteForEth(ContractGetBytecodeSuite::new),
 				extractSpecsFromSuiteForEth(ContractGetInfoSuite::new),
-				extractSpecsFromSuiteForEth(ContractUpdateSuite::new)
+				extractSpecsFromSuiteForEth(ContractUpdateSuite::new),
+				extractSpecsFromSuiteForEth(ContractCreateSuite::new),
+				extractSpecsFromSuiteForEth(ContractDeleteSuite::new)
 		);
 	}
 
@@ -473,8 +458,6 @@ class E2EPackageRunner {
 	Collection<DynamicContainer> contractHapiEthFailing() {
 		return List.of(
 				extractSpecsFromSuiteForEth(ContractCallSuite::new),
-				extractSpecsFromSuiteForEth(ContractCreateSuite::new),
-				extractSpecsFromSuiteForEth(ContractDeleteSuite::new),
 				extractSpecsFromSuiteForEth(ContractMusicalChairsSuite::new)
 		);
 	}


### PR DESCRIPTION
**Description**:

- Fix an issue for creating contracts via ethereum txns. In `ContractCustomizer.fromSponsorContract()` we set `proxy` and `autoRenewAccount` as changes even if they might not be set. This caused exceptions in `HederaAccountCustomizer.customizeSynthetic()` since we try to invoke `toGrpcAccountId()` on null.

- Add now passing tests to correct `@TestFactories` in `E2EPackageRunner`

**Related issue(s)**:

Fixes #

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
