### PR TITLE
Adjust timing of TokenDeleteValidate-NIReconnect-1-16m

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1352,6 +1352,13 @@ workflows:
                 at: /
 
   GCP-Daily-Services-Comp-NI-Reconnect-Correctness-6N-1C:
+    triggers:
+      - schedule:
+          cron: "25 7 * * *"
+          filters:
+            branches:
+              only:
+                - master
     jobs:
       - build-platform-and-services
       - jrs-regression:
@@ -1676,10 +1683,10 @@ jobs:
         default: true
       slack_results_channel:
         type: string
-        default: "hedera-regression-test"
+        default: "hedera-regression"
       slack_summary_channel:
         type: string
-        default: "hedera-regression-test"
+        default: "hedera-regression-summary"
       workflow-name:
         type: string
         default: ""

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1352,13 +1352,6 @@ workflows:
                 at: /
 
   GCP-Daily-Services-Comp-NI-Reconnect-Correctness-6N-1C:
-    triggers:
-      - schedule:
-          cron: "25 7 * * *"
-          filters:
-            branches:
-              only:
-                - master
     jobs:
       - build-platform-and-services
       - jrs-regression:
@@ -1683,10 +1676,10 @@ jobs:
         default: true
       slack_results_channel:
         type: string
-        default: "hedera-regression"
+        default: "hedera-regression-test"
       slack_summary_channel:
         type: string
-        default: "hedera-regression-summary"
+        default: "hedera-regression-test"
       workflow-name:
         type: string
         default: ""

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/reconnect/ValidateTokensDeleteAfterReconnect.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/reconnect/ValidateTokensDeleteAfterReconnect.java
@@ -88,6 +88,7 @@ public class ValidateTokensDeleteAfterReconnect extends HapiApiSuite {
 								.logging()
 				)
 				.when(
+						sleepFor(30000),
 						getAccountBalance(GENESIS)
 								.setNode(reconnectingNode)
 								.unavailableNode(),


### PR DESCRIPTION
Client check if the node 0.0.8 is offline at time 10:07:40

```
2022-05-05 10:07:40.925 ERROR  225  HapiSpecOperation - Node 0.0.8 is NOT unavailable as expected!!!
```

The node actually became disconnected at 10:07:53

```
2022-05-05 10:07:53.691 54       ERROR SOCKET_EXCEPTIONS <<platform-core: listener 5 to 4 #0>> NetworkUtils: Connection broken: 5 <- 4
```


Test results:

https://hedera-hashgraph.slack.com/archives/C018CBQBTGB/p1651783705388629

