### PR TITLE
Address failing EETs

### DIFF
--- a/test-clients/src/main/java/com/hedera/services/bdd/spec/assertions/ContractFnResultAsserts.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/spec/assertions/ContractFnResultAsserts.java
@@ -130,6 +130,18 @@ public class ContractFnResultAsserts extends BaseErroringAssertsProvider<Contrac
 		return this;
 	}
 
+	public ContractFnResultAsserts approxGasUsed(final long expected, final double allowedPercentDeviation) {
+		registerProvider((spec, o) -> {
+			ContractFunctionResult result = (ContractFunctionResult) o;
+			final var actual = result.getGasUsed();
+			final var epsilon = allowedPercentDeviation * actual / 100.0;
+			Assertions.assertEquals(
+					expected, (double) result.getGasUsed(), epsilon,
+					"Wrong amount of gas used");
+		});
+		return this;
+	}
+
 	public ContractFnResultAsserts gasUsed(long gasUsed) {
 		registerProvider((spec, o) -> {
 			ContractFunctionResult result = (ContractFunctionResult) o;

--- a/test-clients/src/main/java/com/hedera/services/bdd/spec/fees/FeeCalculator.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/spec/fees/FeeCalculator.java
@@ -62,6 +62,10 @@ public class FeeCalculator {
 		this.provider = provider;
 	}
 
+	public Map<HederaFunctionality, Map<SubType, FeeData>> getCurrentOpFeeData() {
+		return opFeeData;
+	}
+
 	public void init() {
 		if (setup.useFixedFee()) {
 			usingFixedFee = true;
@@ -75,7 +79,7 @@ public class FeeCalculator {
 		tokenTransferUsageMultiplier = setup.feesTokenTransferUsageMultiplier();
 	}
 
-	private Map<SubType, FeeData> feesListToMap(List<FeeData> feesList) {
+	public static Map<SubType, FeeData> feesListToMap(List<FeeData> feesList) {
 		Map<SubType, FeeData> feeDataMap = new HashMap<>();
 		for (FeeData feeData : feesList) {
 			feeDataMap.put(feeData.getSubType(), feeData);

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/ContractMintHTSSuite.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/ContractMintHTSSuite.java
@@ -28,12 +28,18 @@ import com.hedera.services.bdd.spec.utilops.CustomSpecAssert;
 import com.hedera.services.bdd.suites.HapiApiSuite;
 import com.hedera.services.bdd.suites.utils.contracts.FunctionParameters;
 import com.hedera.services.bdd.suites.utils.contracts.precompile.HTSPrecompileResult;
+import com.hedera.services.pricing.AssetsLoader;
+import com.hederahashgraph.api.proto.java.HederaFunctionality;
+import com.hederahashgraph.api.proto.java.SubType;
 import com.hederahashgraph.api.proto.java.TokenSupplyType;
 import com.hederahashgraph.api.proto.java.TokenType;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.math.BigDecimal;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
@@ -74,11 +80,16 @@ import static com.hedera.services.bdd.suites.contract.Utils.asAddress;
 import static com.hedera.services.bdd.suites.contract.Utils.parsedToByteString;
 import static com.hedera.services.bdd.suites.utils.contracts.FunctionParameters.functionParameters;
 import static com.hedera.services.bdd.suites.utils.contracts.precompile.HTSPrecompileResult.htsPrecompileResult;
+import static com.hederahashgraph.api.proto.java.HederaFunctionality.ContractCall;
+import static com.hederahashgraph.api.proto.java.HederaFunctionality.TokenMint;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.CONTRACT_REVERT_EXECUTED;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INSUFFICIENT_GAS;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_TOKEN_ID;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.REVERTED_SUCCESS;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SUCCESS;
+import static com.hederahashgraph.api.proto.java.SubType.DEFAULT;
+import static com.hederahashgraph.api.proto.java.SubType.TOKEN_FUNGIBLE_COMMON;
+import static com.hederahashgraph.api.proto.java.SubType.TOKEN_NON_FUNGIBLE_UNIQUE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ContractMintHTSSuite extends HapiApiSuite {
@@ -379,7 +390,6 @@ public class ContractMintHTSSuite extends HapiApiSuite {
 		final var multiKey = "purpose";
 		final var nestedTransferTxn = "nestedTransferTxn";
 
-		final long expectedGasUsage = 1_063_830L;
 		return defaultHapiSpec("TransferNftAfterNestedMint")
 				.given(
 						newKeyNamed(multiKey),
@@ -430,50 +440,55 @@ public class ContractMintHTSSuite extends HapiApiSuite {
 										assertTxnRecordHasNoTraceabilityEnrichedContractFnResult(nestedTransferTxn));
 							}
 						}),
-						withOpContext((spec, opLog) -> allRunFor(spec,
-										childRecordsCheck(nestedTransferTxn, SUCCESS,
-												recordWith()
-														.status(SUCCESS)
-														.contractCallResult(
-																resultWith()
-																		.gasUsed(expectedGasUsage)
-																		.contractCallResult(htsPrecompileResult()
-																				.forFunction(
-																						HTSPrecompileResult.FunctionType.MINT)
-																				.withStatus(SUCCESS)
-																				.withTotalSupply(1L)
-																				.withSerialNumbers(1L)
-																		)
-																		.gas(3_838_738L)
-																		.amount(0L)
-																		.functionParameters(functionParameters()
-																				.forFunction(
-																						FunctionParameters.PrecompileFunction.MINT)
-																				.withTokenAddress(asAddress(spec.registry()
-																						.getTokenID(nonFungibleToken)))
-																				.withAmount(0L)
-																				.withMetadata(List.of("Test metadata " +
-																						"1"))
-																				.build()
-																		)
-														),
-												recordWith()
-														.status(SUCCESS)
-														.contractCallResult(
-																resultWith()
-																		.contractCallResult(htsPrecompileResult()
-																				.forFunction(
-																						HTSPrecompileResult.FunctionType.SUCCESS)
-																				.withStatus(SUCCESS)
-																		)
-														)
-														.tokenTransfers(NonFungibleTransfers
-																.changingNFTBalances()
-																.including(nonFungibleToken, TOKEN_TREASURY,
-																		theRecipient, 1)
-														)
-										)
-								)
+						withOpContext((spec, opLog) -> {
+									final var expectedGasUsage = expectedPrecompileGasFor(
+											spec, TokenMint, TOKEN_NON_FUNGIBLE_UNIQUE);
+									allRunFor(spec,
+											childRecordsCheck(nestedTransferTxn, SUCCESS,
+													recordWith()
+															.status(SUCCESS)
+															.contractCallResult(
+																	resultWith()
+																			.approxGasUsed(expectedGasUsage, 5)
+																			.contractCallResult(htsPrecompileResult()
+																					.forFunction(
+																							HTSPrecompileResult.FunctionType.MINT)
+																					.withStatus(SUCCESS)
+																					.withTotalSupply(1L)
+																					.withSerialNumbers(1L)
+																			)
+																			.gas(3_838_738L)
+																			.amount(0L)
+																			.functionParameters(functionParameters()
+																					.forFunction(
+																							FunctionParameters.PrecompileFunction.MINT)
+																					.withTokenAddress(asAddress(spec.registry()
+																							.getTokenID(nonFungibleToken)))
+																					.withAmount(0L)
+																					.withMetadata(List.of("Test " +
+																							"metadata " +
+																							"1"))
+																					.build()
+																			)
+															),
+													recordWith()
+															.status(SUCCESS)
+															.contractCallResult(
+																	resultWith()
+																			.contractCallResult(htsPrecompileResult()
+																					.forFunction(
+																							HTSPrecompileResult.FunctionType.SUCCESS)
+																					.withStatus(SUCCESS)
+																			)
+															)
+															.tokenTransfers(NonFungibleTransfers
+																	.changingNFTBalances()
+																	.including(nonFungibleToken, TOKEN_TREASURY,
+																			theRecipient, 1)
+															)
+											)
+									);
+								}
 						)
 				);
 	}
@@ -648,14 +663,15 @@ public class ContractMintHTSSuite extends HapiApiSuite {
 	}
 
 	private HapiApiSpec gasCostNotMetSetsInsufficientGasStatusInChildRecord() {
-
 		final var theAccount = "anybody";
 		final var amount = 10L;
 		final var fungibleToken = "fungibleToken";
 		final var multiKey = "purpose";
 		final var theContract = "MintContract";
 		final var firstMintTxn = "firstMintTxn";
+		final var baselineMintWithEnoughGas = "baselineMintWithEnoughGas";
 
+		final AtomicLong expectedInsufficientGas = new AtomicLong();
 		final AtomicLong fungibleNum = new AtomicLong();
 
 		return defaultHapiSpec("gasCostNotMetSetsInsufficientGasStatusInChildRecord")
@@ -677,14 +693,34 @@ public class ContractMintHTSSuite extends HapiApiSuite {
 								.gas(GAS_TO_OFFER))
 				).then(
 						contractCall(theContract, "mintFungibleToken", amount)
-								.via(firstMintTxn)
+								.via(baselineMintWithEnoughGas)
 								.payingWith(theAccount)
 								.alsoSigningWithFullPrefix(multiKey)
-								.gas(48_000),
+								.gas(48_000L),
+						withOpContext((spec, opLog) -> {
+							final var expectedPrecompileGas = expectedPrecompileGasFor(
+									spec, TokenMint, TOKEN_FUNGIBLE_COMMON);
+							final var baselineCostLookup = getTxnRecord(baselineMintWithEnoughGas)
+									.andAllChildRecords()
+									.logged()
+									.assertingNothing();
+							allRunFor(spec, baselineCostLookup);
+							final var baselineGas = baselineCostLookup.getResponseRecord()
+									.getContractCallResult()
+									.getGasUsed();
+							expectedInsufficientGas.set(baselineGas - expectedPrecompileGas);
+						}),
+						sourcing(() ->
+								contractCall(theContract, "mintFungibleToken", amount)
+										.via(firstMintTxn)
+										.payingWith(theAccount)
+										.alsoSigningWithFullPrefix(multiKey)
+										.gas(expectedInsufficientGas.get())
+										.hasKnownStatus(INSUFFICIENT_GAS)),
 						getTxnRecord(firstMintTxn).andAllChildRecords().logged(),
-						getTokenInfo(fungibleToken).hasTotalSupply(0),
-						getAccountBalance(TOKEN_TREASURY).hasTokenBalance(fungibleToken, 0),
-						childRecordsCheck(firstMintTxn, SUCCESS,
+						getTokenInfo(fungibleToken).hasTotalSupply(amount),
+						getAccountBalance(TOKEN_TREASURY).hasTokenBalance(fungibleToken, amount),
+						childRecordsCheck(firstMintTxn, INSUFFICIENT_GAS,
 								recordWith()
 										.contractCallResult(
 												resultWith()
@@ -697,6 +733,33 @@ public class ContractMintHTSSuite extends HapiApiSuite {
 										)
 						)
 				);
+	}
+
+	private long expectedPrecompileGasFor(
+			final HapiApiSpec spec,
+			final HederaFunctionality function,
+			final SubType type
+	) {
+		final var gasThousandthsOfTinycentPrice = spec.fees()
+				.getCurrentOpFeeData()
+				.get(ContractCall)
+				.get(DEFAULT)
+				.getServicedata()
+				.getGas();
+		final var assetsLoader = new AssetsLoader();
+		final BigDecimal hapiUsdPrice;
+		try {
+			hapiUsdPrice = assetsLoader.loadCanonicalPrices()
+					.get(function)
+					.get(type);
+		} catch (IOException e) {
+			throw new UncheckedIOException(e);
+		}
+		final var precompileTinycentPrice = hapiUsdPrice
+				.multiply(BigDecimal.valueOf(1.2))
+				.multiply(BigDecimal.valueOf(100 * 100_000_000L))
+				.longValueExact();
+		return (precompileTinycentPrice * 1000 / gasThousandthsOfTinycentPrice);
 	}
 
 	@NotNull


### PR DESCRIPTION
**Description**:
 - For `GetsInsufficientPayerBalanceIfSendingAccountCanPayEverythingButServiceFee`, since there is no longer a fixed `service` fee, use a fire-and-forget `CryptoTransfer` to ensure the `ContractCreate` can get through precheck, but payer's balance will be just below the amount needed to pay `gas` at consensus.
 - For `TransferNftAfterNestedMint` and `GasCostNotMetSetsInsufficientGasStatusInChildRecord`, add a helper method to compute the expected gas cost of a precompile based on active `gas` price and canonical price loaded from _hapi-fees/_ assets.