### PR TITLE
Re-initialize `MutableStateChildren` after 0.26 migrations

### DIFF
--- a/hedera-node/src/main/java/com/hedera/services/ServicesState.java
+++ b/hedera-node/src/main/java/com/hedera/services/ServicesState.java
@@ -170,6 +170,9 @@ public class ServicesState extends AbstractNaryMerkleInternal implements SwirldS
 			// Grant all contracts one free ~90 day auto-renewal upon enabling contract expiry
 			autoRenewalMigrator.grantFreeAutoRenew(this, getTimeOfLastHandledTxn());
 			ownedNftsLinkMigrator.buildAccountNftsOwnedLinkedList(accounts(), uniqueTokens());
+			// Give the MutableStateChildren up-to-date WeakReferences
+			final var app = getMetadata().app();
+			app.workingState().updatePrimitiveChildrenFrom(this);
 		}
 	}
 
@@ -493,12 +496,6 @@ public class ServicesState extends AbstractNaryMerkleInternal implements SwirldS
 				ReleaseTwentySixMigration.MigratorFactory migratorFactory,
 				ReleaseTwentySixMigration.MigrationUtility migrationUtility,
 				VirtualMap<ContractKey, IterableContractValue> iterableContractStorage);
-	}
-
-	@FunctionalInterface
-	interface IterableStorageFactory {
-		Supplier<VirtualMap<ContractKey, IterableContractValue>> newFactory(
-				JasperDbBuilderFactory jdbBuilder);
 	}
 
 	@VisibleForTesting

--- a/hedera-node/src/main/java/com/hedera/services/state/migration/KvPairIterationMigrator.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/migration/KvPairIterationMigrator.java
@@ -104,7 +104,7 @@ public class KvPairIterationMigrator implements InterruptableConsumer<Pair<Contr
 			if (rootKey != null) {
 				contract.setFirstUint256StorageKey(rootKey.getKey());
 			}
-			log.info("Migrated {} k/v pairs from contract {}",
+			log.debug("Migrated {} k/v pairs from contract {}",
 					contract.getNumContractKvPairs(), contractNum.toIdString());
 		});
 	}

--- a/hedera-node/src/main/java/com/hedera/services/state/migration/ReleaseTwentySixMigration.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/migration/ReleaseTwentySixMigration.java
@@ -84,7 +84,8 @@ public class ReleaseTwentySixMigration {
 			final MerkleMap<EntityNum, MerkleAccount> accounts,
 			final MerkleMap<EntityNumPair, MerkleUniqueToken> uniqueTokens
 	) {
-
+		log.info("Migrating {} NFTs into iterable form with threads", uniqueTokens.size());
+		final var watch = StopWatch.createStarted();
 		for (final var nftId : uniqueTokens.keySet()) {
 			var nft = uniqueTokens.getForModify(nftId);
 			final var owner = nft.getOwner();
@@ -107,6 +108,7 @@ public class ReleaseTwentySixMigration {
 				merkleAccount.setHeadNftSerialNum(serialNum);
 			}
 		}
+		log.info("Done in {}ms", watch.getTime(TimeUnit.MILLISECONDS));
 	}
 
 	public static void grantFreeAutoRenew(

--- a/hedera-node/src/main/java/com/hedera/services/state/migration/ReleaseTwentySixMigration.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/migration/ReleaseTwentySixMigration.java
@@ -70,7 +70,7 @@ public class ReleaseTwentySixMigration {
 			log.info("Migrating contract storage into iterable VirtualMap with {} threads", THREAD_COUNT);
 			final var watch = StopWatch.createStarted();
 			migrationUtility.extractVirtualMapData(contractStorage, migrator, THREAD_COUNT);
-			log.info("Done in {}ms", watch.getTime(TimeUnit.MILLISECONDS));
+			logDone(watch);
 		} catch (InterruptedException e) {
 			log.error("Interrupted while making contract storage iterable", e);
 			Thread.currentThread().interrupt();
@@ -108,7 +108,7 @@ public class ReleaseTwentySixMigration {
 				merkleAccount.setHeadNftSerialNum(serialNum);
 			}
 		}
-		log.info("Done in {}ms", watch.getTime(TimeUnit.MILLISECONDS));
+		logDone(watch);
 	}
 
 	public static void grantFreeAutoRenew(
@@ -123,6 +123,10 @@ public class ReleaseTwentySixMigration {
 				setNewExpiry(upgradeTime, contracts, id, random);
 			}
 		});
+		logDone(watch);
+	}
+
+	private static void logDone(final StopWatch watch) {
 		log.info("Done in {}ms", watch.getTime(TimeUnit.MILLISECONDS));
 	}
 

--- a/hedera-node/src/main/java/com/hedera/services/state/migration/ReleaseTwentySixMigration.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/migration/ReleaseTwentySixMigration.java
@@ -84,7 +84,7 @@ public class ReleaseTwentySixMigration {
 			final MerkleMap<EntityNum, MerkleAccount> accounts,
 			final MerkleMap<EntityNumPair, MerkleUniqueToken> uniqueTokens
 	) {
-		log.info("Migrating {} NFTs into iterable form with threads", uniqueTokens.size());
+		log.info("Migrating {} NFTs into iterable form", uniqueTokens.size());
 		final var watch = StopWatch.createStarted();
 		for (final var nftId : uniqueTokens.keySet()) {
 			var nft = uniqueTokens.getForModify(nftId);

--- a/hedera-node/src/test/java/com/hedera/services/ServicesStateE2ETest.java
+++ b/hedera-node/src/test/java/com/hedera/services/ServicesStateE2ETest.java
@@ -48,9 +48,8 @@ public class ServicesStateE2ETest {
 	}
 
 	@Test
-	void testNftsFromSignedStateV24() throws IOException {
-		final var signedState = loadSignedState(signedStateDir + "v0.24.2-nfts/SignedState.swh");
-		signedState.getSwirldState().migrate();
+	void testNftsFromSignedStateV24() {
+		Assertions.assertDoesNotThrow(() -> loadSignedState(signedStateDir + "v0.24.2-nfts/SignedState.swh"));
 	}
 
 	private static SignedState loadSignedState(final String path) throws IOException {

--- a/hedera-node/src/test/java/com/hedera/services/ServicesStateTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/ServicesStateTest.java
@@ -200,13 +200,17 @@ class ServicesStateTest {
 	void doesAllMigrationsFromRelease024Version() {
 		mockMigrators();
 		final var inOrder = inOrder(
-				autoRenewalMigrator, titleCountsMigrator, iterableStorageMigrator, tokenRelsLinkMigrator, vmf);
+				autoRenewalMigrator, titleCountsMigrator,
+				iterableStorageMigrator, tokenRelsLinkMigrator, vmf, workingState);
 
 		subject = mock(ServicesState.class);
 
 		doCallRealMethod().when(subject).migrate();
 		given(subject.accounts()).willReturn(accounts);
 		given(subject.tokenAssociations()).willReturn(tokenAssociations);
+		given(subject.getMetadata()).willReturn(metadata);
+		given(metadata.app()).willReturn(app);
+		given(app.workingState()).willReturn(workingState);
 		given(subject.getDeserializedVersion()).willReturn(StateVersions.RELEASE_024X_VERSION);
 		given(virtualMapFactory.newVirtualizedIterableStorage()).willReturn(iterableStorage);
 		given(vmf.apply(any())).willReturn(virtualMapFactory);
@@ -219,6 +223,7 @@ class ServicesStateTest {
 		inOrder.verify(iterableStorageMigrator).makeStorageIterable(
 				eq(subject), any(), any(), eq(iterableStorage));
 		inOrder.verify(autoRenewalMigrator).grantFreeAutoRenew(subject, consensusTime);
+		inOrder.verify(workingState).updatePrimitiveChildrenFrom(subject);
 
 		unmockMigrators();
 	}


### PR DESCRIPTION
**Description**:
 - Since `ReleaseTwentySixMigration` replaces the contract storage `VirtualMap` at child index 11, we must re-initialize the `WeakReference`s in the `MutableStateChildren` before proceeding to `ServicesMain.init()`.