### PR TITLE
Add ETX-SVC-001 from the Ethereum Test Plan

### DIFF
--- a/test-clients/src/main/java/com/hedera/services/bdd/spec/assertions/AccountInfoAsserts.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/spec/assertions/AccountInfoAsserts.java
@@ -293,4 +293,12 @@ public class AccountInfoAsserts extends BaseErroringAssertsProvider<AccountInfo>
 		});
 		return this;
 	}
+
+	public AccountInfoAsserts nonce(long nonce) {
+		registerProvider((spec, o) -> {
+			assertEquals(nonce, ((AccountInfo) o).getEthereumNonce(),
+					"Bad nonce!");
+		});
+		return this;
+	}
 }

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/ethereum/HelloWorldEthereumSuite.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/ethereum/HelloWorldEthereumSuite.java
@@ -36,11 +36,13 @@ import static com.hedera.services.bdd.spec.HapiApiSpec.defaultHapiSpec;
 import static com.hedera.services.bdd.spec.HapiPropertySource.asAccountString;
 import static com.hedera.services.bdd.spec.HapiPropertySource.asHexedSolidityAddress;
 import static com.hedera.services.bdd.spec.HapiPropertySource.asToken;
+import static com.hedera.services.bdd.spec.assertions.AccountInfoAsserts.accountWith;
 import static com.hedera.services.bdd.spec.assertions.AssertUtils.inOrder;
 import static com.hedera.services.bdd.spec.assertions.ContractFnResultAsserts.resultWith;
 import static com.hedera.services.bdd.spec.assertions.TransactionRecordAsserts.recordWith;
 import static com.hedera.services.bdd.spec.keys.KeyFactory.KeyType.THRESHOLD;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getAccountBalance;
+import static com.hedera.services.bdd.spec.queries.QueryVerbs.getAliasedAccountInfo;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getTxnRecord;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.contractCreate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoCreate;
@@ -161,7 +163,9 @@ public class HelloWorldEthereumSuite extends HapiApiSuite {
                         sourcing(() -> getAccountBalance(maliciousEOAId.get())
                                 .hasTinyBars(spec -> amount -> (amount > maliciousStartBalance)
                                         ? Optional.of("Malicious EOA balance increased")
-                                        : Optional.empty()))
+                                        : Optional.empty())),
+                        getAliasedAccountInfo(maliciousEOA)
+                                .has(accountWith().nonce(1L))
                 );
     }
 
@@ -208,7 +212,9 @@ public class HelloWorldEthereumSuite extends HapiApiSuite {
                                                         .senderId(spec.registry().getAccountID(
                                                                 spec.registry().aliasIdFor(SECP_256K1_SOURCE_KEY)
                                                                         .getAlias().toStringUtf8())))
-                                        .ethereumHash(ByteString.copyFrom(spec.registry().getBytes(ETH_HASH_KEY))))))
+                                        .ethereumHash(ByteString.copyFrom(spec.registry().getBytes(ETH_HASH_KEY)))))),
+                        getAliasedAccountInfo(SECP_256K1_SOURCE_KEY)
+                                .has(accountWith().nonce(2L))
                 );
     }
 
@@ -232,7 +238,6 @@ public class HelloWorldEthereumSuite extends HapiApiSuite {
                                 .gasLimit(1_000_000L).hasKnownStatus(SUCCESS)
                                 .via("payTxn")
                 ).then(
-//                        getAliasedAccountInfo()
                         withOpContext((spec, opLog) -> allRunFor(spec, getTxnRecord("payTxn")
                                 .logged()
                                 .hasPriority(recordWith()
@@ -242,7 +247,9 @@ public class HelloWorldEthereumSuite extends HapiApiSuite {
                                                         .senderId(spec.registry().getAccountID(
                                                                 spec.registry().aliasIdFor(SECP_256K1_SOURCE_KEY)
                                                                         .getAlias().toStringUtf8())))
-                                        .ethereumHash(ByteString.copyFrom(spec.registry().getBytes(ETH_HASH_KEY))))))
+                                        .ethereumHash(ByteString.copyFrom(spec.registry().getBytes(ETH_HASH_KEY)))))),
+                        getAliasedAccountInfo(SECP_256K1_SOURCE_KEY)
+                                .has(accountWith().nonce(1L))
                 );
     }
 
@@ -279,7 +286,9 @@ public class HelloWorldEthereumSuite extends HapiApiSuite {
                                                         .senderId(spec.registry().getAccountID(
                                                                 spec.registry().aliasIdFor(SECP_256K1_SOURCE_KEY)
                                                                         .getAlias().toStringUtf8())))
-                                        .ethereumHash(ByteString.copyFrom(spec.registry().getBytes(ETH_HASH_KEY))))))
+                                        .ethereumHash(ByteString.copyFrom(spec.registry().getBytes(ETH_HASH_KEY)))))),
+                        getAliasedAccountInfo(SECP_256K1_SOURCE_KEY)
+                                .has(accountWith().nonce(1L))
                 );
     }
 


### PR DESCRIPTION
Signed-off-by: Dimitar Dinev <mitkojc@gmail.com>

**Description**:
Adds `nonce` assertions to the E2Es in `HelloWorldEthereumSuite` 


**Related issue(s)**:

Fixes #3322 

**Notes for reviewer**:
ETX-017 (`EthTx works when presented with correct nonce in transaction `) is implicitly verified by each Ethereum E2E test (nonce is supplied when creating `HapiEthereumCalls`)

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
