### PR TITLE
Update AccountBalancesClientSaveLoadTest 

### DIFF
--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/AccountBalancesClientSaveLoadTest.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/AccountBalancesClientSaveLoadTest.java
@@ -135,7 +135,7 @@ public class AccountBalancesClientSaveLoadTest extends LoadTest  {
 										String.format("%d",settings.getBalancesExportPeriodSecs()) ))
 								.erasingProps(Set.of("accountBalanceExportPeriodMinutes"))),
 						fileUpdate(THROTTLE_DEFS)
-								.payingWith(EXCHANGE_RATE_CONTROL)
+								.payingWith(GENESIS)
 								.contents(throttlesForJRS.toByteArray())
 				).when(
 


### PR DESCRIPTION
Part of regression PR

https://github.com/swirlds/swirlds-platform-regression/pull/2375

One of balance test loads state file from test net, 
uses EXCHANGE_RATE_CONTROL for updating throttle file leads to INVALID_SIGNATURE error.

So change it to genesis account