### PR TITLE
Update CircleCI Pipelines to support the submodule removal in Platform

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1601,12 +1601,23 @@ jobs:
           name: Checkout swirlds-platform repos and build
           command: |
             sed -i -e 's/Host services-jrs-regression/Host services-jrs-regression\n HostName github.com/g' ~/.ssh/config
-            cd /; GIT_SSH_COMMAND="ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no" \
+            
+            # Git Clone for Platform
+            cd /
+            export GIT_SSH_COMMAND="ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no"
             git clone ssh://git@services-jrs-regression/swirlds/swirlds-platform.git;
-            cd /swirlds-platform;
-            sed -i -e 's/github.com/services-jrs-regression/g' .gitmodules;
-            git submodule update --init --recursive --checkout;
-            mvn --no-transfer-progress clean install -DskipTests;
+            
+            # Git Clone JRS Separately
+            mkdir -p /swirlds-platform/regression >/dev/null 2>&1 || true
+            git clone ssh://git@services-jrs-regression/swirlds/swirlds-platform-regression.git /swirlds-platform/regression
+            
+            # Build Platform
+            cd /swirlds-platform
+            ./mvnw clean install -DskipTests;
+            
+            # Build JRS
+            cd /swirlds-platform/regression
+            ./mvnw clean install
 
       - run:
           name: Save PEM file to keys folder


### PR DESCRIPTION
**Description**:

Updates the CCI pipelines to properly handle the removal of the Git submodules from the `swirlds/swirlds-platform` repository.

**Related issue(s)**:

Fixes #3387 


