### PR TITLE
adding assertion of ContractCallResult for e2e tests

### DIFF
--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/CryptoTransferHTSSuite.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/CryptoTransferHTSSuite.java
@@ -28,6 +28,7 @@ import com.hedera.services.bdd.spec.assertions.SomeFungibleTransfers;
 import com.hedera.services.bdd.spec.keys.KeyShape;
 import com.hedera.services.bdd.spec.transactions.token.TokenMovement;
 import com.hedera.services.bdd.suites.HapiApiSuite;
+import com.hedera.services.bdd.suites.utils.contracts.precompile.HTSPrecompileResult;
 import com.hederahashgraph.api.proto.java.TokenSupplyType;
 import com.hederahashgraph.api.proto.java.TokenType;
 import org.apache.commons.lang3.tuple.Pair;
@@ -38,6 +39,7 @@ import java.util.List;
 
 import static com.hedera.services.bdd.spec.HapiApiSpec.defaultHapiSpec;
 import static com.hedera.services.bdd.spec.assertions.AutoAssocAsserts.accountTokenPairs;
+import static com.hedera.services.bdd.spec.assertions.ContractFnResultAsserts.resultWith;
 import static com.hedera.services.bdd.spec.assertions.TransactionRecordAsserts.recordWith;
 import static com.hedera.services.bdd.spec.keys.KeyShape.DELEGATE_CONTRACT;
 import static com.hedera.services.bdd.spec.keys.KeyShape.sigs;
@@ -67,6 +69,7 @@ import static com.hedera.services.bdd.spec.utilops.UtilVerbs.tokenTransferList;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.tokenTransferLists;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.withOpContext;
 import static com.hedera.services.bdd.suites.utils.MiscEETUtils.metadata;
+import static com.hedera.services.bdd.suites.utils.contracts.precompile.HTSPrecompileResult.htsPrecompileResult;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.CONTRACT_REVERT_EXECUTED;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_SIGNATURE;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SUCCESS;
@@ -179,15 +182,19 @@ public class CryptoTransferHTSSuite extends HapiApiSuite {
 								.hasTokenBalance(FUNGIBLE_TOKEN, receiverStartBalance + 2 * toSendEachTuple),
 						getAccountBalance(SENDER)
 								.hasTokenBalance(FUNGIBLE_TOKEN, senderStartBalance - 2 * toSendEachTuple),
-						childRecordsCheck(repeatedIdsPrecompileXferTxn, SUCCESS, recordWith()
-								.status(SUCCESS)
-								.tokenTransfers(
-										SomeFungibleTransfers.changingFungibleBalances()
-												.including(FUNGIBLE_TOKEN, SENDER, -2 * toSendEachTuple)
-												.including(FUNGIBLE_TOKEN, RECEIVER, 2 * toSendEachTuple)
-								)
-						)
-				);
+						childRecordsCheck(repeatedIdsPrecompileXferTxn, SUCCESS,
+                                recordWith()
+                                        .status(SUCCESS)
+                                        .contractCallResult(
+                                                resultWith()
+                                                        .contractCallResult(htsPrecompileResult()
+                                                                .withStatus(SUCCESS)
+                                                        )
+                                        )
+                                        .tokenTransfers(
+                                                SomeFungibleTransfers.changingFungibleBalances()
+                                                        .including(FUNGIBLE_TOKEN, SENDER, -2 * toSendEachTuple)
+                                                        .including(FUNGIBLE_TOKEN, RECEIVER, 2 * toSendEachTuple))));
 	}
 
 	private HapiApiSpec nonNestedCryptoTransferForFungibleToken() {
@@ -244,15 +251,19 @@ public class CryptoTransferHTSSuite extends HapiApiSuite {
 						getAccountBalance(SENDER)
 								.hasTokenBalance(FUNGIBLE_TOKEN, 150),
 						getTokenInfo(FUNGIBLE_TOKEN).logged(),
-						childRecordsCheck(cryptoTransferTxn, SUCCESS, recordWith()
-								.status(SUCCESS)
-								.tokenTransfers(
-										SomeFungibleTransfers.changingFungibleBalances()
-												.including(FUNGIBLE_TOKEN, SENDER, -50)
-												.including(FUNGIBLE_TOKEN, RECEIVER, 50)
-								)
-						)
-				);
+						childRecordsCheck(cryptoTransferTxn, SUCCESS,
+								recordWith()
+										.status(SUCCESS)
+										.contractCallResult(
+												resultWith()
+														.contractCallResult(htsPrecompileResult()
+																.withStatus(SUCCESS)
+														)
+										)
+										.tokenTransfers(
+												SomeFungibleTransfers.changingFungibleBalances()
+														.including(FUNGIBLE_TOKEN, SENDER, -50)
+														.including(FUNGIBLE_TOKEN, RECEIVER, 50))));
 	}
 
 	private HapiApiSpec nonNestedCryptoTransferForFungibleTokenWithMultipleReceivers() {
@@ -312,16 +323,20 @@ public class CryptoTransferHTSSuite extends HapiApiSuite {
 						getAccountBalance(SENDER)
 								.hasTokenBalance(FUNGIBLE_TOKEN, 150),
 						getTokenInfo(FUNGIBLE_TOKEN).logged(),
-						childRecordsCheck(cryptoTransferTxn, SUCCESS, recordWith()
-								.status(SUCCESS)
-								.tokenTransfers(
-										SomeFungibleTransfers.changingFungibleBalances()
-												.including(FUNGIBLE_TOKEN, SENDER, -50)
-												.including(FUNGIBLE_TOKEN, RECEIVER, 30)
-												.including(FUNGIBLE_TOKEN, RECEIVER2, 20)
-								)
-						)
-				);
+						childRecordsCheck(cryptoTransferTxn, SUCCESS,
+								recordWith()
+										.status(SUCCESS)
+										.contractCallResult(
+												resultWith()
+														.contractCallResult(htsPrecompileResult()
+																.withStatus(SUCCESS)
+														)
+										)
+										.tokenTransfers(
+												SomeFungibleTransfers.changingFungibleBalances()
+														.including(FUNGIBLE_TOKEN, SENDER, -50)
+														.including(FUNGIBLE_TOKEN, RECEIVER, 30)
+														.including(FUNGIBLE_TOKEN, RECEIVER2, 20))));
 	}
 
 	private HapiApiSpec nonNestedCryptoTransferForNonFungibleToken() {
@@ -383,14 +398,18 @@ public class CryptoTransferHTSSuite extends HapiApiSuite {
 						getAccountInfo(SENDER).hasOwnedNfts(0),
 						getAccountBalance(SENDER).hasTokenBalance(NFT_TOKEN, 0),
 						getTokenInfo(NFT_TOKEN).logged(),
-						childRecordsCheck("cryptoTransferTxn", SUCCESS, recordWith()
-								.status(SUCCESS)
-								.tokenTransfers(
-										NonFungibleTransfers.changingNFTBalances()
-												.including(NFT_TOKEN, SENDER, RECEIVER, 1L)
-								)
-						)
-				);
+						childRecordsCheck("cryptoTransferTxn", SUCCESS,
+								recordWith()
+										.status(SUCCESS)
+										.contractCallResult(
+												resultWith()
+														.contractCallResult(htsPrecompileResult()
+																.withStatus(SUCCESS)
+														)
+										)
+										.tokenTransfers(
+												NonFungibleTransfers.changingNFTBalances()
+														.including(NFT_TOKEN, SENDER, RECEIVER, 1L))));
 	}
 
 	private HapiApiSpec nonNestedCryptoTransferForMultipleNonFungibleTokens() {
@@ -466,15 +485,19 @@ public class CryptoTransferHTSSuite extends HapiApiSuite {
 						getAccountInfo(SENDER2).hasOwnedNfts(0),
 						getAccountBalance(SENDER2).hasTokenBalance(NFT_TOKEN, 0),
 						getTokenInfo(NFT_TOKEN).logged(),
-						childRecordsCheck(cryptoTransferTxn, SUCCESS, recordWith()
-								.status(SUCCESS)
-								.tokenTransfers(
-										NonFungibleTransfers.changingNFTBalances()
-												.including(NFT_TOKEN, SENDER, RECEIVER, 1L)
-												.including(NFT_TOKEN, SENDER2, RECEIVER2, 2L)
-								)
-						)
-				);
+						childRecordsCheck(cryptoTransferTxn, SUCCESS,
+								recordWith()
+										.status(SUCCESS)
+										.contractCallResult(
+												resultWith()
+														.contractCallResult(htsPrecompileResult()
+																.withStatus(SUCCESS)
+														)
+										)
+										.tokenTransfers(
+												NonFungibleTransfers.changingNFTBalances()
+														.including(NFT_TOKEN, SENDER, RECEIVER, 1L)
+														.including(NFT_TOKEN, SENDER2, RECEIVER2, 2L))));
 	}
 
 	private HapiApiSpec nonNestedCryptoTransferForFungibleAndNonFungibleToken() {
@@ -566,16 +589,19 @@ public class CryptoTransferHTSSuite extends HapiApiSuite {
 						getAccountInfo(SENDER2).hasOwnedNfts(0),
 						getAccountBalance(SENDER2).hasTokenBalance(NFT_TOKEN, 0),
 						getTokenInfo(NFT_TOKEN).logged(),
-						childRecordsCheck(cryptoTransferTxn, SUCCESS, recordWith()
-								.status(SUCCESS)
-								.tokenTransfers(
-										SomeFungibleTransfers.changingFungibleBalances()
-												.including(FUNGIBLE_TOKEN, SENDER, -45L)
-												.including(FUNGIBLE_TOKEN, RECEIVER, 45L)
-								).tokenTransfers(NonFungibleTransfers.changingNFTBalances()
-										.including(NFT_TOKEN, SENDER2, RECEIVER2, 1L))
-						)
-				);
+						childRecordsCheck(cryptoTransferTxn, SUCCESS,
+								recordWith()
+										.status(SUCCESS)
+										.contractCallResult(
+												resultWith()
+														.contractCallResult(htsPrecompileResult()
+																.withStatus(SUCCESS)))
+										.tokenTransfers(
+												SomeFungibleTransfers.changingFungibleBalances()
+														.including(FUNGIBLE_TOKEN, SENDER, -45L)
+														.including(FUNGIBLE_TOKEN, RECEIVER, 45L)
+										).tokenTransfers(NonFungibleTransfers.changingNFTBalances()
+												.including(NFT_TOKEN, SENDER2, RECEIVER2, 1L))));
 	}
 
 	private HapiApiSpec nonNestedCryptoTransferForFungibleTokenWithMultipleSendersAndReceiversAndNonFungibleTokens() {
@@ -683,20 +709,24 @@ public class CryptoTransferHTSSuite extends HapiApiSuite {
 						getAccountInfo(SENDER2).hasOwnedNfts(0),
 						getAccountBalance(SENDER2).hasTokenBalance(NFT_TOKEN, 0),
 						getTokenInfo(NFT_TOKEN).logged(),
-						childRecordsCheck(cryptoTransferTxn, SUCCESS, recordWith()
-								.status(SUCCESS)
-								.tokenTransfers(
-										SomeFungibleTransfers.changingFungibleBalances()
-												.including(FUNGIBLE_TOKEN, SENDER, -45L)
-												.including(FUNGIBLE_TOKEN, RECEIVER, 45L)
-												.including(FUNGIBLE_TOKEN, SENDER2, -32L)
-												.including(FUNGIBLE_TOKEN, RECEIVER2, 32L)
-								).tokenTransfers(NonFungibleTransfers.changingNFTBalances()
-										.including(NFT_TOKEN, SENDER, RECEIVER, 1L)
-										.including(NFT_TOKEN, SENDER2, RECEIVER2, 2L)
-								)
-						)
-				);
+						childRecordsCheck(cryptoTransferTxn, SUCCESS,
+								recordWith()
+										.status(SUCCESS)
+										.contractCallResult(
+												resultWith()
+														.contractCallResult(htsPrecompileResult()
+																.withStatus(SUCCESS)
+														)
+										)
+										.tokenTransfers(
+												SomeFungibleTransfers.changingFungibleBalances()
+														.including(FUNGIBLE_TOKEN, SENDER, -45L)
+														.including(FUNGIBLE_TOKEN, RECEIVER, 45L)
+														.including(FUNGIBLE_TOKEN, SENDER2, -32L)
+														.including(FUNGIBLE_TOKEN, RECEIVER2, 32L)
+										).tokenTransfers(NonFungibleTransfers.changingNFTBalances()
+												.including(NFT_TOKEN, SENDER, RECEIVER, 1L)
+												.including(NFT_TOKEN, SENDER2, RECEIVER2, 2L))));
 	}
 
 	private HapiApiSpec activeContractInFrameIsVerifiedWithoutNeedForSignature() {
@@ -846,28 +876,45 @@ public class CryptoTransferHTSSuite extends HapiApiSuite {
 						getAccountBalance(CONTRACT)
 								.hasTokenBalance(FUNGIBLE_TOKEN, senderStartBalance - toSendEachTuple)
 								.hasTokenBalance(NFT_TOKEN, 0L),
-						childRecordsCheck(revertedFungibleTransferTxn, CONTRACT_REVERT_EXECUTED, recordWith()
-								.status(INVALID_SIGNATURE)),
-						childRecordsCheck(successfulFungibleTransferTxn, SUCCESS, recordWith()
-								.status(SUCCESS)
-								.tokenTransfers(
-										SomeFungibleTransfers.changingFungibleBalances()
-												.including(FUNGIBLE_TOKEN, SENDER, -toSendEachTuple)
-												.including(FUNGIBLE_TOKEN, CONTRACT, -toSendEachTuple)
-												.including(FUNGIBLE_TOKEN, RECEIVER, 2 * toSendEachTuple)
-								)
-						),
-						childRecordsCheck(revertedNftTransferTxn, CONTRACT_REVERT_EXECUTED, recordWith()
-								.status(INVALID_SIGNATURE)),
-						childRecordsCheck(successfulNftTransferTxn, SUCCESS, recordWith()
-								.status(SUCCESS)
-								.tokenTransfers(
-										NonFungibleTransfers.changingNFTBalances()
-												.including(NFT_TOKEN, SENDER, RECEIVER, 1L)
-												.including(NFT_TOKEN, CONTRACT, RECEIVER, 2L)
-								)
-						)
-				);
+                        childRecordsCheck(revertedFungibleTransferTxn, CONTRACT_REVERT_EXECUTED,
+								recordWith()
+										.status(INVALID_SIGNATURE)
+										.contractCallResult(
+												resultWith()
+														.contractCallResult(htsPrecompileResult()
+																.withStatus(INVALID_SIGNATURE)))),
+                        childRecordsCheck(successfulFungibleTransferTxn, SUCCESS,
+                                recordWith()
+                                        .status(SUCCESS)
+                                        .contractCallResult(
+                                                resultWith()
+                                                        .contractCallResult(htsPrecompileResult()
+                                                                .withStatus(SUCCESS)
+                                                        )
+                                        )
+                                        .tokenTransfers(
+                                                SomeFungibleTransfers.changingFungibleBalances()
+                                                        .including(FUNGIBLE_TOKEN, SENDER, -toSendEachTuple)
+                                                        .including(FUNGIBLE_TOKEN, CONTRACT, -toSendEachTuple)
+                                                        .including(FUNGIBLE_TOKEN, RECEIVER, 2 * toSendEachTuple))),
+						childRecordsCheck(revertedNftTransferTxn, CONTRACT_REVERT_EXECUTED,
+								recordWith()
+										.status(INVALID_SIGNATURE)
+										.contractCallResult(
+												resultWith()
+														.contractCallResult(htsPrecompileResult()
+																.withStatus(INVALID_SIGNATURE)))),
+						childRecordsCheck(successfulNftTransferTxn, SUCCESS,
+								recordWith()
+										.status(SUCCESS)
+										.contractCallResult(
+												resultWith()
+														.contractCallResult(htsPrecompileResult()
+																.withStatus(SUCCESS)))
+										.tokenTransfers(
+												NonFungibleTransfers.changingNFTBalances()
+														.including(NFT_TOKEN, SENDER, RECEIVER, 1L)
+														.including(NFT_TOKEN, CONTRACT, RECEIVER, 2L))));
 	}
 
 

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/DelegatePrecompileSuite.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/DelegatePrecompileSuite.java
@@ -23,6 +23,7 @@ package com.hedera.services.bdd.suites.contract.precompile;
 import com.hedera.services.bdd.spec.HapiApiSpec;
 import com.hedera.services.bdd.spec.keys.KeyShape;
 import com.hedera.services.bdd.suites.HapiApiSuite;
+import com.hedera.services.bdd.suites.utils.contracts.precompile.HTSPrecompileResult;
 import com.hederahashgraph.api.proto.java.AccountID;
 import com.hederahashgraph.api.proto.java.TokenID;
 import com.hederahashgraph.api.proto.java.TokenType;
@@ -36,6 +37,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import static com.google.protobuf.ByteString.copyFromUtf8;
 import static com.hedera.services.bdd.spec.HapiApiSpec.defaultHapiSpec;
 import static com.hedera.services.bdd.spec.HapiPropertySource.asToken;
+import static com.hedera.services.bdd.spec.assertions.ContractFnResultAsserts.resultWith;
 import static com.hedera.services.bdd.spec.assertions.SomeFungibleTransfers.changingFungibleBalances;
 import static com.hedera.services.bdd.spec.assertions.TransactionRecordAsserts.recordWith;
 import static com.hedera.services.bdd.spec.keys.KeyShape.DELEGATE_CONTRACT;
@@ -59,6 +61,7 @@ import static com.hedera.services.bdd.spec.utilops.UtilVerbs.newKeyNamed;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.withOpContext;
 import static com.hedera.services.bdd.suites.contract.Utils.asAddress;
 import static com.hedera.services.bdd.suites.token.TokenAssociationSpecs.VANILLA_TOKEN;
+import static com.hedera.services.bdd.suites.utils.contracts.precompile.HTSPrecompileResult.htsPrecompileResult;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SUCCESS;
 
 public class DelegatePrecompileSuite extends HapiApiSuite {
@@ -154,8 +157,12 @@ public class DelegatePrecompileSuite extends HapiApiSuite {
 						)
 				).then(
 						childRecordsCheck("delegateTransferCallWithDelegateContractKeyTxn", SUCCESS,
-								recordWith().status(SUCCESS)
-						),
+								recordWith()
+										.status(SUCCESS)
+										.contractCallResult(
+												resultWith()
+														.contractCallResult(htsPrecompileResult()
+																.withStatus(SUCCESS)))),
 						getAccountBalance(ACCOUNT).hasTokenBalance(VANILLA_TOKEN, 0),
 						getAccountBalance(RECEIVER).hasTokenBalance(VANILLA_TOKEN, 1)
 
@@ -200,10 +207,16 @@ public class DelegatePrecompileSuite extends HapiApiSuite {
 				)
 				.then(
 						childRecordsCheck("delegateBurnCallWithDelegateContractKeyTxn", SUCCESS,
-								recordWith().status(SUCCESS).newTotalSupply(1)
-						),
-						getAccountBalance(TOKEN_TREASURY).hasTokenBalance(VANILLA_TOKEN, 1)
-				);
+								recordWith()
+										.status(SUCCESS)
+										.contractCallResult(
+												resultWith()
+														.contractCallResult(htsPrecompileResult()
+																.forFunction(HTSPrecompileResult.FunctionType.BURN)
+																.withStatus(SUCCESS)
+																.withTotalSupply(1)))
+										.newTotalSupply(1)),
+						getAccountBalance(TOKEN_TREASURY).hasTokenBalance(VANILLA_TOKEN, 1));
 	}
 
 	private HapiApiSpec delegateCallForMint() {
@@ -240,16 +253,22 @@ public class DelegatePrecompileSuite extends HapiApiSuite {
 						)
 				)
 				.then(
-						childRecordsCheck("delegateBurnCallWithDelegateContractKeyTxn", SUCCESS, recordWith()
-								.status(SUCCESS)
-								.tokenTransfers(
-										changingFungibleBalances()
-												.including(VANILLA_TOKEN, TOKEN_TREASURY, 1)
-								)
-								.newTotalSupply(51)
-						),
-						getAccountBalance(TOKEN_TREASURY).hasTokenBalance(VANILLA_TOKEN, 51)
-				);
+						childRecordsCheck("delegateBurnCallWithDelegateContractKeyTxn", SUCCESS,
+								recordWith()
+										.status(SUCCESS)
+										.contractCallResult(
+												resultWith()
+														.contractCallResult(htsPrecompileResult()
+																.forFunction(HTSPrecompileResult.FunctionType.MINT)
+																.withStatus(SUCCESS)
+																.withTotalSupply(51)
+																.withSerialNumbers()))
+										.tokenTransfers(
+												changingFungibleBalances()
+														.including(VANILLA_TOKEN, TOKEN_TREASURY, 1)
+										)
+										.newTotalSupply(51)),
+						getAccountBalance(TOKEN_TREASURY).hasTokenBalance(VANILLA_TOKEN, 51));
 	}
 
 

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/DissociatePrecompileSuite.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/DissociatePrecompileSuite.java
@@ -23,6 +23,7 @@ package com.hedera.services.bdd.suites.contract.precompile;
 import com.google.protobuf.ByteString;
 import com.hedera.services.bdd.spec.HapiApiSpec;
 import com.hedera.services.bdd.suites.HapiApiSuite;
+import com.hedera.services.bdd.suites.utils.contracts.precompile.HTSPrecompileResult;
 import com.hederahashgraph.api.proto.java.AccountID;
 import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
 import com.hederahashgraph.api.proto.java.TokenID;
@@ -37,6 +38,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import static com.hedera.services.bdd.spec.HapiApiSpec.defaultHapiSpec;
 import static com.hedera.services.bdd.spec.HapiPropertySource.asDotDelimitedLongArray;
+import static com.hedera.services.bdd.spec.assertions.ContractFnResultAsserts.resultWith;
 import static com.hedera.services.bdd.spec.assertions.TransactionRecordAsserts.recordWith;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getAccountBalance;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getAccountInfo;
@@ -63,6 +65,7 @@ import static com.hedera.services.bdd.suites.token.TokenAssociationSpecs.FREEZAB
 import static com.hedera.services.bdd.suites.token.TokenAssociationSpecs.KNOWABLE_TOKEN;
 import static com.hedera.services.bdd.suites.token.TokenAssociationSpecs.TBD_TOKEN;
 import static com.hedera.services.bdd.suites.token.TokenAssociationSpecs.VANILLA_TOKEN;
+import static com.hedera.services.bdd.suites.utils.contracts.precompile.HTSPrecompileResult.htsPrecompileResult;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SUCCESS;
 import static com.hederahashgraph.api.proto.java.TokenType.FUNGIBLE_COMMON;
 
@@ -238,10 +241,34 @@ public class DissociatePrecompileSuite extends HapiApiSuite {
 										)
 						)
 				).then(
-						childRecordsCheck("dissociateZeroBalanceFrozenTxn", SUCCESS, recordWith().status(SUCCESS)),
-						childRecordsCheck("dissociateZeroBalanceUnfrozenTxn", SUCCESS, recordWith().status(SUCCESS)),
-						childRecordsCheck("dissociateNonZeroBalanceFrozenTxn", SUCCESS, recordWith().status(SUCCESS)),
-						childRecordsCheck("dissociateNonZeroBalanceUnfrozenTxn", SUCCESS, recordWith().status(SUCCESS)),
+						childRecordsCheck("dissociateZeroBalanceFrozenTxn", SUCCESS,
+								recordWith()
+										.status(SUCCESS)
+										.contractCallResult(
+												resultWith()
+														.contractCallResult(htsPrecompileResult()
+																.withStatus(SUCCESS)))),
+						childRecordsCheck("dissociateZeroBalanceUnfrozenTxn", SUCCESS,
+								recordWith()
+										.status(SUCCESS)
+										.contractCallResult(
+												resultWith()
+														.contractCallResult(htsPrecompileResult()
+																.withStatus(SUCCESS)))),
+						childRecordsCheck("dissociateNonZeroBalanceFrozenTxn", SUCCESS,
+								recordWith()
+										.status(SUCCESS)
+										.contractCallResult(
+												resultWith()
+														.contractCallResult(htsPrecompileResult()
+																.withStatus(SUCCESS)))),
+						childRecordsCheck("dissociateNonZeroBalanceUnfrozenTxn", SUCCESS,
+								recordWith()
+										.status(SUCCESS)
+										.contractCallResult(
+												resultWith()
+														.contractCallResult(htsPrecompileResult()
+																.withStatus(SUCCESS)))),
 						getAccountInfo(zeroBalanceFrozen).hasNoTokenRelationship(TBD_TOKEN),
 						getAccountInfo(zeroBalanceUnfrozen).hasNoTokenRelationship(TBD_TOKEN),
 						getAccountInfo(nonZeroBalanceFrozen).hasNoTokenRelationship(TBD_TOKEN),
@@ -292,10 +319,19 @@ public class DissociatePrecompileSuite extends HapiApiSuite {
 						)
 				).then(
 						childRecordsCheck("nestedDissociateTxn", SUCCESS,
-								recordWith().status(SUCCESS),
-								recordWith().status(SUCCESS)),
-						getAccountInfo(ACCOUNT).hasToken(relationshipWith(VANILLA_TOKEN))
-				);
+								recordWith()
+										.status(SUCCESS)
+										.contractCallResult(
+												resultWith()
+														.contractCallResult(htsPrecompileResult()
+																.withStatus(SUCCESS))),
+								recordWith()
+										.status(SUCCESS)
+										.contractCallResult(
+												resultWith()
+														.contractCallResult(htsPrecompileResult()
+																.withStatus(SUCCESS)))),
+						getAccountInfo(ACCOUNT).hasToken(relationshipWith(VANILLA_TOKEN)));
 	}
 
 	/* -- HSCS-PREC-007 from HTS Precompile Test Plan -- */
@@ -347,10 +383,15 @@ public class DissociatePrecompileSuite extends HapiApiSuite {
 										)
 						)
 				).then(
-						childRecordsCheck("multipleDissociationTxn", SUCCESS, recordWith().status(SUCCESS)),
+						childRecordsCheck("multipleDissociationTxn", SUCCESS,
+								recordWith()
+										.status(SUCCESS)
+										.contractCallResult(
+												resultWith()
+														.contractCallResult(htsPrecompileResult()
+																.withStatus(SUCCESS)))),
 						getAccountInfo(ACCOUNT).hasNoTokenRelationship(FREEZABLE_TOKEN_ON_BY_DEFAULT),
-						getAccountInfo(ACCOUNT).hasNoTokenRelationship(KNOWABLE_TOKEN)
-				);
+						getAccountInfo(ACCOUNT).hasNoTokenRelationship(KNOWABLE_TOKEN));
 	}
 
 	@Override

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/DynamicGasCostSuite.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/DynamicGasCostSuite.java
@@ -751,14 +751,35 @@ public class DynamicGasCostSuite extends HapiApiSuite {
 				).then(
 						childRecordsCheck(helperMintFail, SUCCESS,
 								/* First record is of helper creation */
-								recordWith().status(SUCCESS),
-								recordWith().status(INVALID_SIGNATURE)),
+								recordWith()
+										.status(SUCCESS),
+								recordWith()
+										.status(INVALID_SIGNATURE)
+										.contractCallResult(
+												resultWith()
+														.contractCallResult(htsPrecompileResult()
+																.forFunction(HTSPrecompileResult.FunctionType.MINT)
+																.withTotalSupply(0)
+																.withSerialNumbers()
+																.withStatus(INVALID_SIGNATURE)))),
 						childRecordsCheck(ftFail, CONTRACT_REVERT_EXECUTED,
-								recordWith().status(REVERTED_SUCCESS),
-								recordWith().status(TRANSACTION_REQUIRES_ZERO_TOKEN_BALANCES)),
+								recordWith()
+										.status(REVERTED_SUCCESS),
+								recordWith()
+										.status(TRANSACTION_REQUIRES_ZERO_TOKEN_BALANCES)
+										.contractCallResult(
+												resultWith()
+														.contractCallResult(htsPrecompileResult()
+																.withStatus(TRANSACTION_REQUIRES_ZERO_TOKEN_BALANCES)))),
 						childRecordsCheck(nftFail, CONTRACT_REVERT_EXECUTED,
-								recordWith().status(REVERTED_SUCCESS),
-								recordWith().status(ACCOUNT_STILL_OWNS_NFTS)),
+								recordWith()
+										.status(REVERTED_SUCCESS),
+								recordWith()
+										.status(ACCOUNT_STILL_OWNS_NFTS)
+										.contractCallResult(
+												resultWith()
+														.contractCallResult(htsPrecompileResult()
+																.withStatus(ACCOUNT_STILL_OWNS_NFTS)))),
 						getAccountBalance(TOKEN_TREASURY).hasTokenBalance(nft, 1),
 
 						// https://github.com/hashgraph/hedera-services/issues/2876 (mint via delegatable_contract_id)

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/ERCPrecompileSuite.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/ERCPrecompileSuite.java
@@ -1999,7 +1999,12 @@ public class ERCPrecompileSuite extends HapiApiSuite {
 						)
 								.via("MISSING_TO").gas(4_000_000).hasKnownStatus(CONTRACT_REVERT_EXECUTED)),
 						childRecordsCheck("MISSING_TO", CONTRACT_REVERT_EXECUTED,
-								recordWith().status(INVALID_ALLOWANCE_SPENDER_ID)),
+								recordWith()
+										.status(INVALID_ALLOWANCE_SPENDER_ID)
+										.contractCallResult(
+												resultWith()
+														.contractCallResult(htsPrecompileResult()
+																.withStatus(INVALID_ALLOWANCE_SPENDER_ID)))),
 						// * Can't approve if msg.sender != owner and not an operator
 						cryptoTransfer(movingUnique(nfToken, 1L, 2L).between(someERC721Scenarios, aCivilian)),
 						cryptoTransfer(movingUnique(nfToken, 3L, 4L).between(someERC721Scenarios, bCivilian)),

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/MixedHTSPrecompileTestsSuite.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/MixedHTSPrecompileTestsSuite.java
@@ -29,6 +29,7 @@ import org.apache.logging.log4j.Logger;
 import java.util.List;
 
 import static com.hedera.services.bdd.spec.HapiApiSpec.defaultHapiSpec;
+import static com.hedera.services.bdd.spec.assertions.ContractFnResultAsserts.resultWith;
 import static com.hedera.services.bdd.spec.assertions.TransactionRecordAsserts.recordWith;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getAccountInfo;
 import static com.hedera.services.bdd.spec.queries.crypto.ExpectedTokenRel.relationshipWith;
@@ -43,6 +44,7 @@ import static com.hedera.services.bdd.spec.utilops.CustomSpecAssert.allRunFor;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.childRecordsCheck;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.withOpContext;
 import static com.hedera.services.bdd.suites.contract.Utils.asAddress;
+import static com.hedera.services.bdd.suites.utils.contracts.precompile.HTSPrecompileResult.htsPrecompileResult;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SUCCESS;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TOKEN_ALREADY_ASSOCIATED_TO_ACCOUNT;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TOKEN_NOT_ASSOCIATED_TO_ACCOUNT;
@@ -103,12 +105,19 @@ public class MixedHTSPrecompileTestsSuite extends HapiApiSuite {
 								.gas(GAS_TO_OFFER)
 								.via("associateMethodCall")
 				).then(
-						childRecordsCheck("associateMethodCall",
-								SUCCESS,
+						childRecordsCheck("associateMethodCall", SUCCESS,
 								recordWith()
-										.status(SUCCESS),
+										.status(SUCCESS)
+										.contractCallResult(
+												resultWith()
+														.contractCallResult(htsPrecompileResult()
+																.withStatus(SUCCESS))),
 								recordWith()
-										.status(TOKEN_ALREADY_ASSOCIATED_TO_ACCOUNT)),
+										.status(TOKEN_ALREADY_ASSOCIATED_TO_ACCOUNT)
+										.contractCallResult(
+												resultWith()
+														.contractCallResult(htsPrecompileResult()
+																.withStatus(TOKEN_ALREADY_ASSOCIATED_TO_ACCOUNT)))),
 						getAccountInfo(theAccount).hasToken(relationshipWith(token)),
 						cryptoTransfer(moving(200, token).between(TOKEN_TREASURY, theAccount))
 								.hasKnownStatus(SUCCESS)


### PR DESCRIPTION
Assertions for ContractCallResult on child records for the following e2e test suites:

Dissociate
Mixed
Transfer
ERC