### PR TITLE
Fix CI results path; move stateful `updateMaxAutoAssociationsWorks()` out of async run section

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1755,14 +1755,14 @@ jobs:
             set -x;
             set +e;
             cd /swirlds-platform/regression
-            CI_RESULTS_LOG=$(find results/4N_1C -name hapi-client-combined.log)
+            CI_RESULTS_LOG=$(find assets/results/4N_1C -name hapi-client-combined.log)
             grep $CI_RESULTS_LOG -e 'status=ERROR' -e 'status=FAILED'
             if [ "$?" -eq "0" ]; then
               exit 1
             else
               exit 0
             fi
-            SAMPLE_NODE_LOG=$(find results/4N_1C -name hgcaa.log | head -1)
+            SAMPLE_NODE_LOG=$(find assets/results/4N_1C -name hgcaa.log | head -1)
             grep $SAMPLE_NODE_LOG -e 'IssListener - In round'
             if [ "$?" -eq "0" ]; then
               exit 1

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hapi/ContractCallSuite.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hapi/ContractCallSuite.java
@@ -1186,111 +1186,86 @@ public class ContractCallSuite extends HapiApiSuite {
 	}
 
 	HapiApiSpec smartContractFailFirst() {
+		final var civilian = "civilian";
 		return defaultHapiSpec("smartContractFailFirst")
 				.given(
-						uploadInitCode(SIMPLE_STORAGE_CONTRACT)
+						uploadInitCode(SIMPLE_STORAGE_CONTRACT),
+						cryptoCreate(civilian).balance(ONE_MILLION_HBARS).payingWith(GENESIS)
 				).when(
 						withOpContext((spec, ignore) -> {
-							final var subop1 = balanceSnapshot("balanceBefore0", DEFAULT_CONTRACT_SENDER);
-
+							final var subop1 = balanceSnapshot("balanceBefore0", civilian);
 							final var subop2 =
 									contractCreate(SIMPLE_STORAGE_CONTRACT)
 											.balance(0)
-											.payingWith(DEFAULT_CONTRACT_SENDER)
+											.payingWith(civilian)
 											.gas(1)
 											.hasKnownStatus(INSUFFICIENT_GAS)
 											.via("failInsufficientGas");
-
 							final var subop3 = getTxnRecord("failInsufficientGas");
 							allRunFor(spec, subop1, subop2, subop3);
 							final var delta = subop3.getResponseRecord().getTransactionFee();
-
-							final var subop4 = getAccountBalance(DEFAULT_CONTRACT_SENDER).hasTinyBars(
+							final var subop4 = getAccountBalance(civilian).hasTinyBars(
 									changeFromSnapshot("balanceBefore0", -delta));
 							allRunFor(spec, subop4);
-
 						}),
-
 						withOpContext((spec, ignore) -> {
-
-							final var subop1 = balanceSnapshot("balanceBefore1", DEFAULT_CONTRACT_SENDER);
-
+							final var subop1 = balanceSnapshot("balanceBefore1", civilian);
 							final var subop2 = contractCreate(SIMPLE_STORAGE_CONTRACT)
 									.balance(100_000_000_000L)
-									.payingWith(DEFAULT_CONTRACT_SENDER)
+									.payingWith(civilian)
 									.gas(250_000L)
 									.via("failInvalidInitialBalance")
 									.hasKnownStatus(CONTRACT_REVERT_EXECUTED);
-
 							final var subop3 = getTxnRecord("failInvalidInitialBalance");
 							allRunFor(spec, subop1, subop2, subop3);
 							final var delta = subop3.getResponseRecord().getTransactionFee();
-
-							final var subop4 = getAccountBalance(DEFAULT_CONTRACT_SENDER).hasTinyBars(
+							final var subop4 = getAccountBalance(civilian).hasTinyBars(
 									changeFromSnapshot("balanceBefore1", -delta));
 							allRunFor(spec, subop4);
-
 						}),
-
 						withOpContext((spec, ignore) -> {
-
-							final var subop1 = balanceSnapshot("balanceBefore2", DEFAULT_CONTRACT_SENDER);
-
+							final var subop1 = balanceSnapshot("balanceBefore2", civilian);
 							final var subop2 = contractCreate(SIMPLE_STORAGE_CONTRACT)
 									.balance(0L)
-									.payingWith(DEFAULT_CONTRACT_SENDER)
+									.payingWith(civilian)
 									.gas(250_000L)
 									.hasKnownStatus(SUCCESS)
 									.via("successWithZeroInitialBalance");
-
 							final var subop3 = getTxnRecord("successWithZeroInitialBalance");
 							allRunFor(spec, subop1, subop2, subop3);
 							final var delta = subop3.getResponseRecord().getTransactionFee();
-
-							final var subop4 = getAccountBalance(DEFAULT_CONTRACT_SENDER).hasTinyBars(
+							final var subop4 = getAccountBalance(civilian).hasTinyBars(
 									changeFromSnapshot("balanceBefore2", -delta));
 							allRunFor(spec, subop4);
-
 						}),
-
 						withOpContext((spec, ignore) -> {
-
-							final var subop1 = balanceSnapshot("balanceBefore3", DEFAULT_CONTRACT_SENDER);
-
+							final var subop1 = balanceSnapshot("balanceBefore3", civilian);
 							final var subop2 = contractCall(SIMPLE_STORAGE_CONTRACT, "set", 999_999L)
-									.payingWith(DEFAULT_CONTRACT_SENDER)
+									.payingWith(civilian)
 									.gas(300_000L)
 									.hasKnownStatus(SUCCESS)
 									.via("setValue");
-
 							final var subop3 = getTxnRecord("setValue");
 							allRunFor(spec, subop1, subop2, subop3);
 							final var delta = subop3.getResponseRecord().getTransactionFee();
-
-							final var subop4 = getAccountBalance(DEFAULT_CONTRACT_SENDER).hasTinyBars(
+							final var subop4 = getAccountBalance(civilian).hasTinyBars(
 									changeFromSnapshot("balanceBefore3", -delta));
 							allRunFor(spec, subop4);
-
 						}),
-
 						withOpContext((spec, ignore) -> {
-
-							final var subop1 = balanceSnapshot("balanceBefore4", DEFAULT_CONTRACT_SENDER);
-
+							final var subop1 = balanceSnapshot("balanceBefore4", civilian);
 							final var subop2 = contractCall(SIMPLE_STORAGE_CONTRACT, "get")
-									.payingWith(DEFAULT_CONTRACT_SENDER)
+									.payingWith(civilian)
 									.gas(300_000L)
 									.hasKnownStatus(SUCCESS)
 									.via("getValue");
-
 							final var subop3 = getTxnRecord("getValue");
 							allRunFor(spec, subop1, subop2, subop3);
 							final var delta = subop3.getResponseRecord().getTransactionFee();
 
-							final var subop4 = getAccountBalance(DEFAULT_CONTRACT_SENDER).hasTinyBars(
+							final var subop4 = getAccountBalance(civilian).hasTinyBars(
 									changeFromSnapshot("balanceBefore4", -delta));
 							allRunFor(spec, subop4);
-
 						})
 				).then(
 						getTxnRecord("failInsufficientGas"),

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hapi/ContractUpdateSuite.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hapi/ContractUpdateSuite.java
@@ -25,7 +25,6 @@ import com.hedera.services.bdd.spec.HapiSpecSetup;
 import com.hedera.services.bdd.spec.assertions.ContractInfoAsserts;
 import com.hedera.services.bdd.spec.keys.KeyShape;
 import com.hedera.services.bdd.suites.HapiApiSuite;
-import com.hederahashgraph.api.proto.java.TokenType;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -39,7 +38,6 @@ import static com.hedera.services.bdd.spec.assertions.ContractFnResultAsserts.re
 import static com.hedera.services.bdd.spec.assertions.ContractInfoAsserts.contractWith;
 import static com.hedera.services.bdd.spec.assertions.TransactionRecordAsserts.recordWith;
 import static com.hedera.services.bdd.spec.keys.KeyShape.listOf;
-import static com.hedera.services.bdd.spec.queries.QueryVerbs.getAccountBalance;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getContractBytecode;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getContractInfo;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getTxnRecord;
@@ -49,28 +47,20 @@ import static com.hedera.services.bdd.spec.transactions.TxnVerbs.contractCustomC
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.contractDelete;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.contractUpdate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoCreate;
-import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoTransfer;
-import static com.hedera.services.bdd.spec.transactions.TxnVerbs.tokenCreate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.uploadInitCode;
-import static com.hedera.services.bdd.spec.transactions.token.TokenMovement.moving;
 import static com.hedera.services.bdd.spec.utilops.CustomSpecAssert.allRunFor;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.newKeyNamed;
-import static com.hedera.services.bdd.spec.utilops.UtilVerbs.overriding;
-import static com.hedera.services.bdd.spec.utilops.UtilVerbs.overridingTwo;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.sourcing;
-import static com.hedera.services.bdd.spec.utilops.UtilVerbs.validateChargedUsd;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.withOpContext;
 import static com.hedera.services.bdd.suites.contract.Utils.FunctionType.FUNCTION;
 import static com.hedera.services.bdd.suites.contract.Utils.getABIFor;
 import static com.hedera.services.bdd.suites.contract.precompile.DynamicGasCostSuite.captureChildCreate2MetaFor;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.EXISTING_AUTOMATIC_ASSOCIATIONS_EXCEED_GIVEN_LIMIT;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.EXPIRATION_REDUCTION_NOT_ALLOWED;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_ADMIN_KEY;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_EXPIRATION_TIME;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_SIGNATURE;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_ZERO_BYTE_IN_STRING;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.MODIFYING_IMMUTABLE_CONTRACT;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.REQUESTED_NUM_AUTOMATIC_ASSOCIATIONS_EXCEEDS_ASSOCIATION_LIMIT;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SUCCESS;
 import static com.swirlds.common.utility.CommonUtils.unhex;
 
@@ -109,7 +99,6 @@ public class ContractUpdateSuite extends HapiApiSuite {
 						eip1014AddressAlwaysHasPriority(),
 						immutableContractKeyFormIsStandard(),
 						updateAutoRenewAccountWorks(),
-						updateMaxAutoAssociationsWorks()
 				}
 		);
 	}
@@ -234,83 +223,6 @@ public class ContractUpdateSuite extends HapiApiSuite {
 						getContractInfo(CONTRACT)
 								.has(contractWith()
 										.autoRenew(THREE_MONTHS_IN_SECONDS + ONE_DAY))
-				);
-	}
-
-	private HapiApiSpec updateMaxAutoAssociationsWorks() {
-		final int tokenAssociations_restrictedNetwork = 10;
-		final int tokenAssociations_adventurousNetwork = 1_000;
-		final int originalMax = 2;
-		final int newBadMax = originalMax - 1;
-		final int newGoodMax = originalMax + 1;
-		final String tokenA = "tokenA";
-		final String tokenB = "tokenB";
-
-		final String treasury = "treasury";
-		final String tokenACreate = "tokenACreate";
-		final String tokenBCreate = "tokenBCreate";
-		final String transferAToC = "transferAToC";
-		final String transferBToC = "transferBToC";
-
-		return defaultHapiSpec("updateMaxAutoAssociationsWorks")
-				.given(
-						overridingTwo(
-								"entities.limitTokenAssociations", "true",
-								"tokens.maxPerAccount", "" + 10),
-						cryptoCreate(treasury)
-								.balance(ONE_HUNDRED_HBARS),
-						newKeyNamed(ADMIN_KEY),
-						uploadInitCode(CONTRACT),
-						contractCreate(CONTRACT)
-								.adminKey(ADMIN_KEY)
-								.maxAutomaticTokenAssociations(originalMax),
-						tokenCreate(tokenA)
-								.tokenType(TokenType.FUNGIBLE_COMMON)
-								.initialSupply(Long.MAX_VALUE)
-								.treasury(treasury)
-								.via(tokenACreate),
-						getTxnRecord(tokenACreate)
-								.hasNewTokenAssociation(tokenA, treasury),
-						tokenCreate(tokenB)
-								.tokenType(TokenType.FUNGIBLE_COMMON)
-								.initialSupply(Long.MAX_VALUE)
-								.treasury(treasury)
-								.via(tokenBCreate),
-						getTxnRecord(tokenBCreate)
-								.hasNewTokenAssociation(tokenB, treasury),
-						getContractInfo(CONTRACT)
-								.has(ContractInfoAsserts.contractWith().maxAutoAssociations(originalMax))
-								.logged()
-				)
-				.when(
-						cryptoTransfer(moving(1, tokenA).between(treasury, CONTRACT))
-								.via(transferAToC),
-						getTxnRecord(transferAToC)
-								.hasNewTokenAssociation(tokenA, CONTRACT),
-						cryptoTransfer(moving(1, tokenB).between(treasury, CONTRACT))
-								.via(transferBToC),
-						getTxnRecord(transferBToC)
-								.hasNewTokenAssociation(tokenB, CONTRACT)
-				)
-				.then(
-						getContractInfo(CONTRACT)
-								.payingWith(GENESIS)
-								.has(contractWith()
-										.hasAlreadyUsedAutomaticAssociations(originalMax)
-										.maxAutoAssociations(originalMax)),
-						contractUpdate(CONTRACT)
-								.newMaxAutomaticAssociations(newBadMax)
-								.hasKnownStatus(EXISTING_AUTOMATIC_ASSOCIATIONS_EXCEED_GIVEN_LIMIT),
-						contractUpdate(CONTRACT)
-								.newMaxAutomaticAssociations(newGoodMax),
-						contractUpdate(CONTRACT)
-								.newMaxAutomaticAssociations(tokenAssociations_restrictedNetwork + 1)
-								.hasKnownStatus(REQUESTED_NUM_AUTOMATIC_ASSOCIATIONS_EXCEEDS_ASSOCIATION_LIMIT),
-
-						overriding("entities.limitTokenAssociations", "false"),
-						contractUpdate(CONTRACT)
-								.newMaxAutomaticAssociations(tokenAssociations_restrictedNetwork + 1),
-						overriding("tokens.maxPerAccount", "" + tokenAssociations_adventurousNetwork)
 				);
 	}
 

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/ContractMintHTSSuite.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/ContractMintHTSSuite.java
@@ -130,20 +130,20 @@ public class ContractMintHTSSuite extends HapiApiSuite {
 
 	List<HapiApiSpec> negativeSpecs() {
 		return List.of(new HapiApiSpec[] {
-//				rollbackOnFailedMintAfterFungibleTransfer(),
-//				rollbackOnFailedAssociateAfterNonFungibleMint(),
-//				fungibleTokenMintFailure(),
+				rollbackOnFailedMintAfterFungibleTransfer(),
+				rollbackOnFailedAssociateAfterNonFungibleMint(),
+				fungibleTokenMintFailure(),
 				gasCostNotMetSetsInsufficientGasStatusInChildRecord()
 		});
 	}
 
 	List<HapiApiSpec> positiveSpecs() {
 		return List.of(new HapiApiSpec[] {
-//				helloWorldFungibleMint(),
-//				helloWorldNftMint(),
-//				happyPathFungibleTokenMint(),
-//				happyPathNonFungibleTokenMint(),
-//				transferNftAfterNestedMint()
+				helloWorldFungibleMint(),
+				helloWorldNftMint(),
+				happyPathFungibleTokenMint(),
+				happyPathNonFungibleTokenMint(),
+				transferNftAfterNestedMint()
 		});
 	}
 

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/ContractMintHTSSuite.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/ContractMintHTSSuite.java
@@ -130,20 +130,20 @@ public class ContractMintHTSSuite extends HapiApiSuite {
 
 	List<HapiApiSpec> negativeSpecs() {
 		return List.of(new HapiApiSpec[] {
-				rollbackOnFailedMintAfterFungibleTransfer(),
-				rollbackOnFailedAssociateAfterNonFungibleMint(),
-				fungibleTokenMintFailure(),
+//				rollbackOnFailedMintAfterFungibleTransfer(),
+//				rollbackOnFailedAssociateAfterNonFungibleMint(),
+//				fungibleTokenMintFailure(),
 				gasCostNotMetSetsInsufficientGasStatusInChildRecord()
 		});
 	}
 
 	List<HapiApiSpec> positiveSpecs() {
 		return List.of(new HapiApiSpec[] {
-				helloWorldFungibleMint(),
-				helloWorldNftMint(),
-				happyPathFungibleTokenMint(),
-				happyPathNonFungibleTokenMint(),
-				transferNftAfterNestedMint()
+//				helloWorldFungibleMint(),
+//				helloWorldNftMint(),
+//				happyPathFungibleTokenMint(),
+//				happyPathNonFungibleTokenMint(),
+//				transferNftAfterNestedMint()
 		});
 	}
 

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/ContractMintHTSSuite.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/ContractMintHTSSuite.java
@@ -696,7 +696,7 @@ public class ContractMintHTSSuite extends HapiApiSuite {
 								.via(baselineMintWithEnoughGas)
 								.payingWith(theAccount)
 								.alsoSigningWithFullPrefix(multiKey)
-								.gas(48_000L),
+								.gas(64_000L),
 						withOpContext((spec, opLog) -> {
 							final var expectedPrecompileGas = expectedPrecompileGasFor(
 									spec, TokenMint, TOKEN_FUNGIBLE_COMMON);

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoUpdateSuite.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoUpdateSuite.java
@@ -22,6 +22,7 @@ package com.hedera.services.bdd.suites.crypto;
 
 import com.hedera.services.bdd.spec.HapiApiSpec;
 import com.hedera.services.bdd.spec.HapiSpecSetup;
+import com.hedera.services.bdd.spec.assertions.ContractInfoAsserts;
 import com.hedera.services.bdd.spec.keys.KeyLabel;
 import com.hedera.services.bdd.spec.keys.KeyShape;
 import com.hedera.services.bdd.spec.keys.SigControl;
@@ -36,6 +37,7 @@ import java.util.concurrent.atomic.AtomicLong;
 
 import static com.hedera.services.bdd.spec.HapiApiSpec.defaultHapiSpec;
 import static com.hedera.services.bdd.spec.assertions.AccountDetailsAsserts.accountWith;
+import static com.hedera.services.bdd.spec.assertions.ContractInfoAsserts.contractWith;
 import static com.hedera.services.bdd.spec.keys.ControlForKey.forKey;
 import static com.hedera.services.bdd.spec.keys.KeyLabel.complex;
 import static com.hedera.services.bdd.spec.keys.KeyShape.SIMPLE;
@@ -45,11 +47,15 @@ import static com.hedera.services.bdd.spec.keys.SigControl.OFF;
 import static com.hedera.services.bdd.spec.keys.SigControl.ON;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getAccountDetails;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getAccountInfo;
+import static com.hedera.services.bdd.spec.queries.QueryVerbs.getContractInfo;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getTxnRecord;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.contractCreate;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.contractUpdate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoCreate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoTransfer;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoUpdate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.tokenCreate;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.uploadInitCode;
 import static com.hedera.services.bdd.spec.transactions.token.TokenMovement.moving;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.newKeyNamed;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.overriding;
@@ -115,6 +121,7 @@ public class CryptoUpdateSuite extends HapiApiSuite {
 						updateFailsWithInvalidMaxAutoAssociations(),
 						usdFeeAsExpected(),
 						sysAccountKeyUpdateBySpecialWontNeedNewKeyTxnSign(),
+						updateMaxAutoAssociationsWorks()
 				}
 		);
 	}
@@ -432,6 +439,86 @@ public class CryptoUpdateSuite extends HapiApiSuite {
 								.hasPrecheck(BAD_ENCODING)
 				);
 	}
+
+	private HapiApiSpec updateMaxAutoAssociationsWorks() {
+		final int tokenAssociations_restrictedNetwork = 10;
+		final int tokenAssociations_adventurousNetwork = 1_000;
+		final int originalMax = 2;
+		final int newBadMax = originalMax - 1;
+		final int newGoodMax = originalMax + 1;
+		final String tokenA = "tokenA";
+		final String tokenB = "tokenB";
+
+		final String treasury = "treasury";
+		final String tokenACreate = "tokenACreate";
+		final String tokenBCreate = "tokenBCreate";
+		final String transferAToC = "transferAToC";
+		final String transferBToC = "transferBToC";
+		final String CONTRACT = "Multipurpose";
+		final String ADMIN_KEY = "adminKey";
+
+		return defaultHapiSpec("updateMaxAutoAssociationsWorks")
+				.given(
+						overridingTwo(
+								"entities.limitTokenAssociations", "true",
+								"tokens.maxPerAccount", "" + 10),
+						cryptoCreate(treasury)
+								.balance(ONE_HUNDRED_HBARS),
+						newKeyNamed(ADMIN_KEY),
+						uploadInitCode(CONTRACT),
+						contractCreate(CONTRACT)
+								.adminKey(ADMIN_KEY)
+								.maxAutomaticTokenAssociations(originalMax),
+						tokenCreate(tokenA)
+								.tokenType(TokenType.FUNGIBLE_COMMON)
+								.initialSupply(Long.MAX_VALUE)
+								.treasury(treasury)
+								.via(tokenACreate),
+						getTxnRecord(tokenACreate)
+								.hasNewTokenAssociation(tokenA, treasury),
+						tokenCreate(tokenB)
+								.tokenType(TokenType.FUNGIBLE_COMMON)
+								.initialSupply(Long.MAX_VALUE)
+								.treasury(treasury)
+								.via(tokenBCreate),
+						getTxnRecord(tokenBCreate)
+								.hasNewTokenAssociation(tokenB, treasury),
+						getContractInfo(CONTRACT)
+								.has(ContractInfoAsserts.contractWith().maxAutoAssociations(originalMax))
+								.logged()
+				)
+				.when(
+						cryptoTransfer(moving(1, tokenA).between(treasury, CONTRACT))
+								.via(transferAToC),
+						getTxnRecord(transferAToC)
+								.hasNewTokenAssociation(tokenA, CONTRACT),
+						cryptoTransfer(moving(1, tokenB).between(treasury, CONTRACT))
+								.via(transferBToC),
+						getTxnRecord(transferBToC)
+								.hasNewTokenAssociation(tokenB, CONTRACT)
+				)
+				.then(
+						getContractInfo(CONTRACT)
+								.payingWith(GENESIS)
+								.has(contractWith()
+										.hasAlreadyUsedAutomaticAssociations(originalMax)
+										.maxAutoAssociations(originalMax)),
+						contractUpdate(CONTRACT)
+								.newMaxAutomaticAssociations(newBadMax)
+								.hasKnownStatus(EXISTING_AUTOMATIC_ASSOCIATIONS_EXCEED_GIVEN_LIMIT),
+						contractUpdate(CONTRACT)
+								.newMaxAutomaticAssociations(newGoodMax),
+						contractUpdate(CONTRACT)
+								.newMaxAutomaticAssociations(tokenAssociations_restrictedNetwork + 1)
+								.hasKnownStatus(REQUESTED_NUM_AUTOMATIC_ASSOCIATIONS_EXCEEDS_ASSOCIATION_LIMIT),
+
+						overriding("entities.limitTokenAssociations", "false"),
+						contractUpdate(CONTRACT)
+								.newMaxAutomaticAssociations(tokenAssociations_restrictedNetwork + 1),
+						overriding("tokens.maxPerAccount", "" + tokenAssociations_adventurousNetwork)
+				);
+	}
+
 
 	@Override
 	protected Logger getResultsLogger() {


### PR DESCRIPTION
**Description**:
 - Updates CI test failure check to include new _assets/_ path segment.
 - Tries to stabilize `TokenTransactSpecs` by moving `ContractUpdateSuite.updateMaxAutoAssociationsWorks()` out of async run section.
 - Tries to stabilize a couple other specs by using a non-default payer.