### PR TITLE
Fixes issue with MISSING_NFT_NUM_PAIR comparison in UniqueTokenListRemoval

### DIFF
--- a/hedera-node/src/main/java/com/hedera/services/state/expiry/UniqueTokensListRemoval.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/expiry/UniqueTokensListRemoval.java
@@ -84,13 +84,13 @@ public class UniqueTokensListRemoval implements MapValueListMutation<EntityNumPa
 	@Override
 	public EntityNumPair next(final MerkleUniqueToken node) {
 		final var nextKey = node.getNext();
-		return nextKey == MISSING_NFT_NUM_PAIR ? null : nextKey.asEntityNumPair();
+		return nextKey.equals(MISSING_NFT_NUM_PAIR) ? null : nextKey.asEntityNumPair();
 	}
 
 	@Nullable
 	@Override
 	public EntityNumPair prev(final MerkleUniqueToken node) {
 		final var prevKey = node.getPrev();
-		return prevKey == MISSING_NFT_NUM_PAIR ? null : prevKey.asEntityNumPair();
+		return prevKey.equals(MISSING_NFT_NUM_PAIR) ? null : prevKey.asEntityNumPair();
 	}
 }

--- a/hedera-node/src/test/java/com/hedera/services/state/expiry/UniqueTokensListRemovalTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/state/expiry/UniqueTokensListRemovalTest.java
@@ -137,6 +137,14 @@ class UniqueTokensListRemovalTest {
 		assertNull(ans);
 	}
 
+	@Test
+	void nextAndPrevReturnsNullForCopies() {
+		targetNft.setNext(NftNumPair.fromLongs(0, 0));
+		targetNft.setPrev(NftNumPair.fromLongs(0, 0));
+		assertNull(subject.next(targetNft));
+		assertNull(subject.prev(targetNft));
+	}
+
 	private final long tokenNum = 1_234L;
 	private final int ownerNum = 1_235;
 	private final long rootNum = 2L;


### PR DESCRIPTION
Fixes issue with UniqueTokensListRemoval that can happen if next/prev fields are stored (serialized) and then loaded (deserialized). This can lead to next/prev returning a valid pair instead of null.

**Related issue(s)**:

Fixes #: https://github.com/hashgraph/hedera-services/issues/3421
