### PR TITLE
Add E2E unit tests for migration and genesis init.

### DIFF
--- a/hedera-node/src/test/java/com/hedera/services/ServicesStateE2ETest.java
+++ b/hedera-node/src/test/java/com/hedera/services/ServicesStateE2ETest.java
@@ -20,10 +20,7 @@ package com.hedera.services;
  * ‍
  */
 
-import com.hedera.services.context.MutableStateChildren;
-import com.hedera.services.context.init.ServicesInitFlow;
-import com.hedera.services.state.DualStateAccessor;
-import com.hedera.services.state.forensics.HashLogger;
+import com.hedera.services.context.properties.BootstrapProperties;
 import com.hedera.services.state.migration.StateChildIndices;
 import com.hedera.services.state.org.StateMetadata;
 import com.hedera.services.stream.RecordsRunningHashLeaf;
@@ -31,11 +28,11 @@ import com.hedera.test.utils.ClassLoaderHelper;
 import com.swirlds.common.crypto.Hash;
 import com.swirlds.common.crypto.RunningHash;
 import com.swirlds.common.crypto.SerializablePublicKey;
+import com.swirlds.common.crypto.engine.CryptoEngine;
 import com.swirlds.common.system.Address;
 import com.swirlds.common.system.AddressBook;
 import com.swirlds.common.system.NodeId;
 import com.swirlds.common.system.Platform;
-import com.swirlds.common.system.SwirldDualState;
 import com.swirlds.fchashmap.FCHashMap;
 import com.swirlds.platform.SignedStateFileManager;
 import com.swirlds.platform.state.DualStateImpl;
@@ -46,6 +43,7 @@ import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.IOException;
+import java.security.NoSuchAlgorithmException;
 import java.util.List;
 
 import static com.hedera.services.ServicesState.EMPTY_HASH;
@@ -83,7 +81,7 @@ public class ServicesStateE2ETest {
 	}
 
 	@Test
-	void testGenesisState() {
+	void testGenesisState() throws NoSuchAlgorithmException, IOException {
 		final var swirldDualState = new DualStateImpl();
 		final var servicesState = new ServicesState();
 		final var recordsRunningHashLeaf = new RecordsRunningHashLeaf();
@@ -95,13 +93,13 @@ public class ServicesStateE2ETest {
 				nodeId, "", "", 1L, false, null, -1, null, -1, null, -1, null, -1,
 				null, null, (SerializablePublicKey)null, "");
 		final var addressBook = new AddressBook(List.of(address));
-		final var mockApp = createMockApp();
+		final var app = createApp(platform);
 
-		APPS.save(platform.getSelfId().getId(), mockApp);
+		APPS.save(platform.getSelfId().getId(), app);
 		assertDoesNotThrow(() -> servicesState.genesisInit(platform, addressBook, swirldDualState));
 	}
 
-	private static Hash migrate(String dataPath) throws IOException, InterruptedException {
+	private static Hash migrate(String dataPath) throws IOException, InterruptedException, NoSuchAlgorithmException {
 		final var signedState = loadSignedState(dataPath);
 		final var addressBook = signedState.getAddressBook();
 		final var swirldDualState = signedState.getState().getSwirldDualState();
@@ -109,23 +107,25 @@ public class ServicesStateE2ETest {
 		final var platform = createMockPlatform();
 		final var servicesState = (ServicesState) signedState.getSwirldState();
 		servicesState.init(platform, addressBook, swirldDualState);
-		servicesState.setMetadata(new StateMetadata(createMockApp(), new FCHashMap<>()));
+		servicesState.setMetadata(new StateMetadata(createApp(platform), new FCHashMap<>()));
 		servicesState.migrate();
 		return servicesState.runningHashLeaf().currentRunningHash();
 	}
 
-	private static ServicesApp createMockApp() {
-		final var mockApp = mock(ServicesApp.class);
-		when(mockApp.dualStateAccessor()).thenReturn(new DualStateAccessor());
-		when(mockApp.initializationFlow()).thenReturn(mock(ServicesInitFlow.class));
-		when(mockApp.hashLogger()).thenReturn(new HashLogger());
-		when(mockApp.workingState()).thenReturn(new MutableStateChildren());
-		return mockApp;
+	private static ServicesApp createApp(Platform platform) throws NoSuchAlgorithmException, IOException {
+		return DaggerServicesApp.builder()
+				.initialHash(new Hash())
+				.platform(platform)
+				.selfId(platform.getSelfId().getId())
+				.staticAccountMemo("memo")
+				.bootstrapProps(new BootstrapProperties())
+				.build();
 	}
 
 	private static Platform createMockPlatform() {
 		final var platform = mock(Platform.class);
 		when(platform.getSelfId()).thenReturn(new NodeId(false, 0));
+		when(platform.getCryptography()).thenReturn(new CryptoEngine());
 		return platform;
 	}
 

--- a/hedera-node/src/test/java/com/hedera/services/ServicesStateE2ETest.java
+++ b/hedera-node/src/test/java/com/hedera/services/ServicesStateE2ETest.java
@@ -77,12 +77,12 @@ public class ServicesStateE2ETest {
 
 	@Test
 	void testMigrationFromSignedStateV24() throws IOException {
-		SignedState signedState = loadSignedState(signedStateDir + "v0.24.2-nfts/SignedState.swh");
-		AddressBook addressBook = signedState.getAddressBook();
-		SwirldDualState swirldDualState = signedState.getState().getSwirldDualState();
+		final var signedState = loadSignedState(signedStateDir + "v0.24.2-nfts/SignedState.swh");
+		final var addressBook = signedState.getAddressBook();
+		final var swirldDualState = signedState.getState().getSwirldDualState();
 
-		Platform platform = createMockPlatform();
-		ServicesState servicesState = (ServicesState) signedState.getSwirldState();
+		final var platform = createMockPlatform();
+		final var servicesState = (ServicesState) signedState.getSwirldState();
 		servicesState.init(platform, addressBook, swirldDualState);
 		servicesState.setMetadata(new StateMetadata(createMockApp(), new FCHashMap<>()));
 		servicesState.migrate();
@@ -90,41 +90,40 @@ public class ServicesStateE2ETest {
 
 	@Test
 	void testGenesisState() {
-		SwirldDualState swirldDualState = new DualStateImpl();
-		ServicesState servicesState = new ServicesState();
-		RecordsRunningHashLeaf recordsRunningHashLeaf = new RecordsRunningHashLeaf();
+		final var swirldDualState = new DualStateImpl();
+		final var servicesState = new ServicesState();
+		final var recordsRunningHashLeaf = new RecordsRunningHashLeaf();
 		recordsRunningHashLeaf.setRunningHash(new RunningHash(new Hash()));
 		servicesState.setChild(StateChildIndices.RECORD_STREAM_RUNNING_HASH, recordsRunningHashLeaf);
-		Platform platform = createMockPlatform();
-		long nodeId = platform.getSelfId().getId();
-		Address address;
-		address = new Address(
+		final var platform = createMockPlatform();
+		final var nodeId = platform.getSelfId().getId();
+		final var address = new Address(
 				nodeId, "", "", 1L, false, null, -1, null, -1, null, -1, null, -1,
 				null, null, (SerializablePublicKey)null, "");
-		AddressBook addressBook = new AddressBook(List.of(address));
-		ServicesApp mockApp = createMockApp();
+		final var addressBook = new AddressBook(List.of(address));
+		final var mockApp = createMockApp();
 
 		APPS.save(platform.getSelfId().getId(), mockApp);
 		assertDoesNotThrow(() -> servicesState.genesisInit(platform, addressBook, swirldDualState));
 	}
 
-
 	private static ServicesApp createMockApp() {
-		ServicesApp mockApp = mock(ServicesApp.class);
+		final var mockApp = mock(ServicesApp.class);
 		when(mockApp.dualStateAccessor()).thenReturn(new DualStateAccessor());
 		when(mockApp.initializationFlow()).thenReturn(mock(ServicesInitFlow.class));
 		when(mockApp.hashLogger()).thenReturn(new HashLogger());
 		when(mockApp.workingState()).thenReturn(new MutableStateChildren());
 		return mockApp;
 	}
+
 	private static Platform createMockPlatform() {
-		Platform platform = mock(Platform.class);
+		final var platform = mock(Platform.class);
 		when(platform.getSelfId()).thenReturn(new NodeId(false, 0));
 		return platform;
 	}
 
 	private static SignedState loadSignedState(final String path) throws IOException {
-		var signedPair = SignedStateFileManager.readSignedStateFromFile(new File(path));
+		final var signedPair = SignedStateFileManager.readSignedStateFromFile(new File(path));
 		// Because it's possible we are loading old data, we cannot check equivalence of the hash.
 		Assertions.assertNotNull(signedPair.getRight());
 		return signedPair.getRight();

--- a/hedera-node/src/test/java/com/hedera/services/ServicesStateE2ETest.java
+++ b/hedera-node/src/test/java/com/hedera/services/ServicesStateE2ETest.java
@@ -20,8 +20,25 @@ package com.hedera.services;
  * ‍
  */
 
+import com.hedera.services.context.MutableStateChildren;
+import com.hedera.services.context.init.ServicesInitFlow;
+import com.hedera.services.state.DualStateAccessor;
+import com.hedera.services.state.forensics.HashLogger;
+import com.hedera.services.state.migration.StateChildIndices;
+import com.hedera.services.state.org.StateMetadata;
+import com.hedera.services.stream.RecordsRunningHashLeaf;
 import com.hedera.test.utils.ClassLoaderHelper;
+import com.swirlds.common.crypto.Hash;
+import com.swirlds.common.crypto.RunningHash;
+import com.swirlds.common.crypto.SerializablePublicKey;
+import com.swirlds.common.system.Address;
+import com.swirlds.common.system.AddressBook;
+import com.swirlds.common.system.NodeId;
+import com.swirlds.common.system.Platform;
+import com.swirlds.common.system.SwirldDualState;
+import com.swirlds.fchashmap.FCHashMap;
 import com.swirlds.platform.SignedStateFileManager;
+import com.swirlds.platform.state.DualStateImpl;
 import com.swirlds.platform.state.SignedState;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
@@ -29,6 +46,12 @@ import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.List;
+
+import static com.hedera.services.context.AppsManager.APPS;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * These tests are responsible for testing loading of signed state data generated for various scenarios from various
@@ -49,7 +72,55 @@ public class ServicesStateE2ETest {
 
 	@Test
 	void testNftsFromSignedStateV24() {
-		Assertions.assertDoesNotThrow(() -> loadSignedState(signedStateDir + "v0.24.2-nfts/SignedState.swh"));
+		assertDoesNotThrow(() -> loadSignedState(signedStateDir + "v0.24.2-nfts/SignedState.swh"));
+	}
+
+	@Test
+	void testMigrationFromSignedStateV24() throws IOException {
+		SignedState signedState = loadSignedState(signedStateDir + "v0.24.2-nfts/SignedState.swh");
+		AddressBook addressBook = signedState.getAddressBook();
+		SwirldDualState swirldDualState = signedState.getState().getSwirldDualState();
+
+		Platform platform = createMockPlatform();
+		ServicesState servicesState = (ServicesState) signedState.getSwirldState();
+		servicesState.init(platform, addressBook, swirldDualState);
+		servicesState.setMetadata(new StateMetadata(createMockApp(), new FCHashMap<>()));
+		servicesState.migrate();
+	}
+
+	@Test
+	void testGenesisState() {
+		SwirldDualState swirldDualState = new DualStateImpl();
+		ServicesState servicesState = new ServicesState();
+		RecordsRunningHashLeaf recordsRunningHashLeaf = new RecordsRunningHashLeaf();
+		recordsRunningHashLeaf.setRunningHash(new RunningHash(new Hash()));
+		servicesState.setChild(StateChildIndices.RECORD_STREAM_RUNNING_HASH, recordsRunningHashLeaf);
+		Platform platform = createMockPlatform();
+		long nodeId = platform.getSelfId().getId();
+		Address address;
+		address = new Address(
+				nodeId, "", "", 1L, false, null, -1, null, -1, null, -1, null, -1,
+				null, null, (SerializablePublicKey)null, "");
+		AddressBook addressBook = new AddressBook(List.of(address));
+		ServicesApp mockApp = createMockApp();
+
+		APPS.save(platform.getSelfId().getId(), mockApp);
+		assertDoesNotThrow(() -> servicesState.genesisInit(platform, addressBook, swirldDualState));
+	}
+
+
+	private static ServicesApp createMockApp() {
+		ServicesApp mockApp = mock(ServicesApp.class);
+		when(mockApp.dualStateAccessor()).thenReturn(new DualStateAccessor());
+		when(mockApp.initializationFlow()).thenReturn(mock(ServicesInitFlow.class));
+		when(mockApp.hashLogger()).thenReturn(new HashLogger());
+		when(mockApp.workingState()).thenReturn(new MutableStateChildren());
+		return mockApp;
+	}
+	private static Platform createMockPlatform() {
+		Platform platform = mock(Platform.class);
+		when(platform.getSelfId()).thenReturn(new NodeId(false, 0));
+		return platform;
 	}
 
 	private static SignedState loadSignedState(final String path) throws IOException {


### PR DESCRIPTION
**Description**:

Modifies ServicesStateE2ETest to add migration and genesis state generation tests to ensure no crashes occur during migration.

**Related issue(s)**:
Fixes:  https://github.com/hashgraph/hedera-services/issues/3423