### PR TITLE
Clean files produced by Gradle application run

### DIFF
--- a/docs/gradle-quickstart.md
+++ b/docs/gradle-quickstart.md
@@ -64,5 +64,4 @@ instance. You can start one in one terminal with `./gradlew run` and then execut
 Finally, you can use `./gradlew run` to run the project. It will compile (but not test) if needed. Running the project
 produces various files within `hedera-node`. To clean these, you can use `./gradlew cleanRun`.
 
-There is also `./gradlew clean` to clean everything up. This will also clean out any temp stuff created for the sake of
-running (logs, etc.).
+There is also `./gradlew clean` to clean everything up.

--- a/docs/gradle-quickstart.md
+++ b/docs/gradle-quickstart.md
@@ -61,7 +61,8 @@ Finally, end-to-end tests (defined in `test-clients`) can be run with `./gradlew
 instance. You can start one in one terminal with `./gradlew run` and then execute the tests from a second terminal with
 `./gradlew eet`. Or you can use JRS to start an instance, or use some existing environment like previewnet.
 
-Finally, you can use `./gradlew run` to run the project. It will compile (but not test) if needed.
+Finally, you can use `./gradlew run` to run the project. It will compile (but not test) if needed. Running the project
+produces various files within `hedera-node`. To clean these, you can use `./gradlew cleanRun`.
 
 There is also `./gradlew clean` to clean everything up. This will also clean out any temp stuff created for the sake of
 running (logs, etc.).

--- a/hedera-node/build.gradle.kts
+++ b/hedera-node/build.gradle.kts
@@ -107,7 +107,3 @@ val cleanRun = tasks.register("cleanRun") {
     project.delete(File(dataDir, "recordstreams"))
     project.delete(File(dataDir, "saved"))
 }
-
-tasks.clean {
-    dependsOn(cleanRun)
-}

--- a/hedera-node/build.gradle.kts
+++ b/hedera-node/build.gradle.kts
@@ -90,3 +90,24 @@ tasks.register<JavaExec>("run") {
     dependsOn(tasks.findByName("copyApp"), tasks.findByName("copyLib"))
     classpath("data/apps/HederaNode.jar")
 }
+
+val cleanRun = tasks.register("cleanRun") {
+    project.delete(File(project.projectDir, "database"))
+    project.delete(File(project.projectDir, "output"))
+    project.delete(File(project.projectDir, "settingsUsed.txt"))
+    project.delete(File(project.projectDir, "swirlds.jar"))
+    project.projectDir.list { file, fileName -> fileName.startsWith("MainNetStats") }.forEach { file ->
+        project.delete(file)
+    }
+
+    val dataDir = File(project.projectDir, "data")
+    project.delete(File(dataDir, "accountBalances"))
+    project.delete(File(dataDir, "apps"))
+    project.delete(File(dataDir, "lib"))
+    project.delete(File(dataDir, "recordstreams"))
+    project.delete(File(dataDir, "saved"))
+}
+
+tasks.clean {
+    dependsOn(cleanRun)
+}

--- a/pom.xml
+++ b/pom.xml
@@ -265,6 +265,7 @@
 		<module>hapi-fees</module>
 		<module>hedera-node</module>
 		<module>test-clients</module>
+		<module>benchmarks</module>
 	</modules>
 
 	<build>

--- a/pom.xml
+++ b/pom.xml
@@ -265,7 +265,6 @@
 		<module>hapi-fees</module>
 		<module>hedera-node</module>
 		<module>test-clients</module>
-		<module>benchmarks</module>
 	</modules>
 
 	<build>


### PR DESCRIPTION
Closes #3380. Adds a task called `cleanRun` to clean up files produced as part of `./gradlew run` (or any other method used to run the app). Plumbs this into `./gradlew clean` so that a clean gets this too.