### PR TITLE
Upgrade Besu EVM to 22.4.1

### DIFF
--- a/hedera-node/src/main/java/com/hedera/services/context/properties/GlobalDynamicProperties.java
+++ b/hedera-node/src/main/java/com/hedera/services/context/properties/GlobalDynamicProperties.java
@@ -29,7 +29,6 @@ import com.hedera.services.sysfiles.domain.throttling.ThrottleReqOpsScaleFactor;
 import com.hederahashgraph.api.proto.java.AccountID;
 import com.hederahashgraph.api.proto.java.Duration;
 import com.hederahashgraph.api.proto.java.HederaFunctionality;
-import org.hyperledger.besu.evm.Gas;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -121,7 +120,7 @@ public class GlobalDynamicProperties {
 	private int maxPurgedKvPairsPerTouch;
 	private KnownBlockValues knownBlockValues;
 	private int maxReturnedNftsPerTouch;
-	private Gas exchangeRateGasReq;
+	private long exchangeRateGasReq;
 
 	@Inject
 	public GlobalDynamicProperties(
@@ -219,7 +218,7 @@ public class GlobalDynamicProperties {
 		maxPurgedKvPairsPerTouch = properties.getIntProperty("autoRemove.maxPurgedKvPairsPerTouch");
 		maxReturnedNftsPerTouch = properties.getIntProperty("autoRemove.maxReturnedNftsPerTouch");
 		knownBlockValues = properties.getBlockValuesProperty("contracts.knownBlockHash");
-		exchangeRateGasReq = Gas.of(properties.getLongProperty("contracts.precompile.exchangeRateGasCost"));
+		exchangeRateGasReq = properties.getLongProperty("contracts.precompile.exchangeRateGasCost");
 	}
 
 	public int maxTokensPerAccount() {
@@ -534,7 +533,7 @@ public class GlobalDynamicProperties {
 		return maxReturnedNftsPerTouch;
 	}
 
-	public Gas exchangeRateGasReq() {
+	public long exchangeRateGasReq() {
 		return exchangeRateGasReq;
 	}
 }

--- a/hedera-node/src/main/java/com/hedera/services/contracts/execution/CreateEvmTxProcessor.java
+++ b/hedera-node/src/main/java/com/hedera/services/contracts/execution/CreateEvmTxProcessor.java
@@ -154,7 +154,7 @@ public class CreateEvmTxProcessor extends EvmTxProcessor {
 				.address(to)
 				.contract(to)
 				.inputData(Bytes.EMPTY)
-				.code(new Code(payload, Hash.hash(payload)))
+				.code(Code.createLegacyCode(payload, Hash.hash(payload)))
 				.build();
 	}
 }

--- a/hedera-node/src/main/java/com/hedera/services/contracts/execution/HederaBlockValues.java
+++ b/hedera-node/src/main/java/com/hedera/services/contracts/execution/HederaBlockValues.java
@@ -24,6 +24,7 @@ package com.hedera.services.contracts.execution;
 
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.units.bigints.UInt256;
+import org.hyperledger.besu.datatypes.Wei;
 import org.hyperledger.besu.evm.frame.BlockValues;
 
 import java.time.Instant;
@@ -54,8 +55,8 @@ public class HederaBlockValues implements BlockValues {
 	}
 
 	@Override
-	public Optional<Long> getBaseFee() {
-		return Optional.of(0L);
+	public Optional<Wei> getBaseFee() {
+		return Optional.of(Wei.ZERO);
 	}
 
 	@Override

--- a/hedera-node/src/main/java/com/hedera/services/contracts/execution/HederaMessageCallProcessor.java
+++ b/hedera-node/src/main/java/com/hedera/services/contracts/execution/HederaMessageCallProcessor.java
@@ -24,7 +24,6 @@ import com.hedera.services.store.contracts.precompile.HTSPrecompiledContract;
 import org.apache.tuweni.bytes.Bytes;
 import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.evm.EVM;
-import org.hyperledger.besu.evm.Gas;
 import org.hyperledger.besu.evm.frame.MessageFrame;
 import org.hyperledger.besu.evm.precompile.PrecompileContractRegistry;
 import org.hyperledger.besu.evm.precompile.PrecompiledContract;
@@ -75,7 +74,7 @@ public class HederaMessageCallProcessor extends MessageCallProcessor {
 			final MessageFrame frame,
 			final OperationTracer operationTracer
 	) {
-		final Gas gasRequirement;
+		final long gasRequirement;
 		final Bytes output;
 		if (contract instanceof HTSPrecompiledContract htsPrecompile) {
 			final var costedResult = htsPrecompile.computeCosted(frame.getInputData(), frame);
@@ -89,7 +88,7 @@ public class HederaMessageCallProcessor extends MessageCallProcessor {
 			gasRequirement = contract.gasRequirement(frame.getInputData());
 		}
 		operationTracer.tracePrecompileCall(frame, gasRequirement, output);
-		if (frame.getRemainingGas().compareTo(gasRequirement) < 0) {
+		if (frame.getRemainingGas() < gasRequirement) {
 			frame.decrementRemainingGas(frame.getRemainingGas());
 			frame.setExceptionalHaltReason(Optional.of(INSUFFICIENT_GAS));
 			frame.setState(EXCEPTIONAL_HALT);

--- a/hedera-node/src/main/java/com/hedera/services/contracts/gascalculator/GasCalculatorHederaUtil.java
+++ b/hedera-node/src/main/java/com/hedera/services/contracts/gascalculator/GasCalculatorHederaUtil.java
@@ -29,7 +29,6 @@ import com.hederahashgraph.api.proto.java.FeeData;
 import com.hederahashgraph.api.proto.java.HederaFunctionality;
 import com.hederahashgraph.api.proto.java.Timestamp;
 import com.hederahashgraph.fee.FeeBuilder;
-import org.hyperledger.besu.evm.Gas;
 import org.hyperledger.besu.evm.frame.MessageFrame;
 
 /**
@@ -77,7 +76,7 @@ public final class GasCalculatorHederaUtil {
 	}
 
 	@SuppressWarnings("unused")
-	public static Gas logOperationGasCost(
+	public static long logOperationGasCost(
 			final UsagePricesProvider usagePrices,
 			final HbarCentExchange exchange,
 			final MessageFrame frame,
@@ -96,6 +95,6 @@ public final class GasCalculatorHederaUtil {
 				GasCalculatorHederaUtil.ramByteHoursTinyBarsGiven(usagePrices, exchange, timestamp, functionType),
 				gasPrice);
 
-		return Gas.of(gasCost);
+		return gasCost;
 	}
 }

--- a/hedera-node/src/main/java/com/hedera/services/contracts/gascalculator/GasCalculatorHederaV18.java
+++ b/hedera-node/src/main/java/com/hedera/services/contracts/gascalculator/GasCalculatorHederaV18.java
@@ -27,7 +27,6 @@ import com.hedera.services.fees.HbarCentExchange;
 import com.hedera.services.fees.calculation.UsagePricesProvider;
 import org.apache.tuweni.bytes.Bytes;
 import org.hyperledger.besu.datatypes.Wei;
-import org.hyperledger.besu.evm.Gas;
 import org.hyperledger.besu.evm.account.Account;
 import org.hyperledger.besu.evm.frame.MessageFrame;
 import org.hyperledger.besu.evm.gascalculator.PetersburgGasCalculator;
@@ -54,17 +53,17 @@ public class GasCalculatorHederaV18 extends PetersburgGasCalculator {
 	}
 
 	@Override
-	public Gas codeDepositGasCost(final int codeSize) {
-		return Gas.ZERO;
+	public long codeDepositGasCost(final int codeSize) {
+		return 0L;
 	}
 
 	@Override
-	public Gas transactionIntrinsicGasCost(final Bytes payload, final boolean isContractCreate) {
-		return Gas.ZERO;
+	public long transactionIntrinsicGasCost(final Bytes payload, final boolean isContractCreate) {
+		return 0L;
 	}
 
 	@Override
-	public Gas logOperationGasCost(
+	public long logOperationGasCost(
 			final MessageFrame frame,
 			final long dataOffset,
 			final long dataLength,
@@ -73,51 +72,51 @@ public class GasCalculatorHederaV18 extends PetersburgGasCalculator {
 	}
 
 	@Override
-	public Gas getBalanceOperationGasCost() {
+	public long getBalanceOperationGasCost() {
 		// Frontier gas cost
-		return Gas.of(20L);
+		return 20L;
 	}
 
 	@Override
-	protected Gas expOperationByteGasCost() {
+	protected long expOperationByteGasCost() {
 		// Frontier gas cost
-		return Gas.of(10L);
+		return 10L;
 	}
 
 	@Override
-	protected Gas extCodeBaseGasCost() {
+	protected long extCodeBaseGasCost() {
 		// Frontier gas cost
-		return Gas.of(20L);
+		return 20L;
 	}
 
 	@Override
-	public Gas getSloadOperationGasCost() {
+	public long getSloadOperationGasCost() {
 		// Frontier gas cost
-		return Gas.of(50L);
+		return 50L;
 	}
 
 	@Override
-	public Gas callOperationBaseGasCost() {
+	public long callOperationBaseGasCost() {
 		// Frontier gas cost
-		return Gas.of(40L);
+		return 40L;
 	}
 
 	@Override
-	public Gas getExtCodeSizeOperationGasCost() {
+	public long getExtCodeSizeOperationGasCost() {
 		// Frontier gas cost
-		return Gas.of(20L);
+		return 20L;
 	}
 
 	@Override
-	public Gas extCodeHashOperationGasCost() {
+	public long extCodeHashOperationGasCost() {
 		// Constantinople gas cost
-		return Gas.of(400L);
+		return 400L;
 	}
 
 	@Override
-	public Gas selfDestructOperationGasCost(final Account recipient, final Wei inheritance) {
+	public long selfDestructOperationGasCost(final Account recipient, final Wei inheritance) {
 		// Frontier gas cost
-		return Gas.of(0);
+		return 0;
 	}
 
 	private long getLogStorageDuration() {

--- a/hedera-node/src/main/java/com/hedera/services/contracts/gascalculator/GasCalculatorHederaV19.java
+++ b/hedera-node/src/main/java/com/hedera/services/contracts/gascalculator/GasCalculatorHederaV19.java
@@ -26,7 +26,6 @@ import com.hedera.services.context.properties.GlobalDynamicProperties;
 import com.hedera.services.fees.HbarCentExchange;
 import com.hedera.services.fees.calculation.UsagePricesProvider;
 import org.apache.tuweni.bytes.Bytes;
-import org.hyperledger.besu.evm.Gas;
 import org.hyperledger.besu.evm.frame.MessageFrame;
 import org.hyperledger.besu.evm.gascalculator.LondonGasCalculator;
 
@@ -53,24 +52,24 @@ public class GasCalculatorHederaV19 extends LondonGasCalculator {
 	}
 
 	@Override
-	public Gas transactionIntrinsicGasCost(final Bytes payload, final boolean isContractCreate) {
-		return Gas.ZERO;
+	public long transactionIntrinsicGasCost(final Bytes payload, final boolean isContractCreate) {
+		return 0L;
 	}
 
 	@Override
-	public Gas codeDepositGasCost(final int codeSize) {
-		return Gas.ZERO;
+	public long codeDepositGasCost(final int codeSize) {
+		return 0L;
 	}
 
 	@Override
-	public Gas logOperationGasCost(
+	public long logOperationGasCost(
 			final MessageFrame frame,
 			final long dataOffset,
 			final long dataLength,
 			final int numTopics) {
 		final var gasCost = GasCalculatorHederaUtil.
 				logOperationGasCost(usagePrices, exchange, frame, getLogStorageDuration(), dataOffset, dataLength, numTopics);
-		return super.logOperationGasCost(frame, dataOffset, dataLength, numTopics).max(gasCost);
+		return Math.max(super.logOperationGasCost(frame, dataOffset, dataLength, numTopics), gasCost);
 	}
 
 	long getLogStorageDuration() {

--- a/hedera-node/src/main/java/com/hedera/services/contracts/gascalculator/GasCalculatorHederaV22.java
+++ b/hedera-node/src/main/java/com/hedera/services/contracts/gascalculator/GasCalculatorHederaV22.java
@@ -26,7 +26,6 @@ import com.hedera.services.context.properties.GlobalDynamicProperties;
 import com.hedera.services.fees.HbarCentExchange;
 import com.hedera.services.fees.calculation.UsagePricesProvider;
 import org.apache.tuweni.bytes.Bytes;
-import org.hyperledger.besu.evm.Gas;
 
 import javax.inject.Inject;
 
@@ -35,18 +34,18 @@ import javax.inject.Inject;
  */
 public class GasCalculatorHederaV22 extends GasCalculatorHederaV19 {
 
-	private static final Gas TX_DATA_ZERO_COST = Gas.of(4L);
-	private static final Gas ISTANBUL_TX_DATA_NON_ZERO_COST = Gas.of(16L);
-	private static final Gas TX_BASE_COST = Gas.of(21_000L);
+	private static final long TX_DATA_ZERO_COST = 4L;
+	private static final long ISTANBUL_TX_DATA_NON_ZERO_COST = 16L;
+	private static final long TX_BASE_COST = 21_000L;
 
 	@Inject
 	public GasCalculatorHederaV22(final GlobalDynamicProperties dynamicProperties,
-								  final UsagePricesProvider usagePrices, final HbarCentExchange exchange) {
+			final UsagePricesProvider usagePrices, final HbarCentExchange exchange) {
 		super(dynamicProperties, usagePrices, exchange);
 	}
 
 	@Override
-	public Gas transactionIntrinsicGasCost(final Bytes payload, final boolean isContractCreation) {
+	public long transactionIntrinsicGasCost(final Bytes payload, final boolean isContractCreation) {
 		int zeros = 0;
 		for (int i = 0; i < payload.size(); i++) {
 			if (payload.get(i) == 0) {
@@ -55,11 +54,8 @@ public class GasCalculatorHederaV22 extends GasCalculatorHederaV19 {
 		}
 		final int nonZeros = payload.size() - zeros;
 
-		Gas cost =
-				TX_BASE_COST
-						.plus(TX_DATA_ZERO_COST.times(zeros))
-						.plus(ISTANBUL_TX_DATA_NON_ZERO_COST.times(nonZeros));
+		long cost = TX_BASE_COST + TX_DATA_ZERO_COST * zeros + ISTANBUL_TX_DATA_NON_ZERO_COST * nonZeros;
 
-		return isContractCreation ? cost.plus(txCreateExtraGasCost()) : cost;
+		return isContractCreation ? (cost + txCreateExtraGasCost()) : cost;
 	}
 }

--- a/hedera-node/src/main/java/com/hedera/services/contracts/operation/HederaCreate2Operation.java
+++ b/hedera-node/src/main/java/com/hedera/services/contracts/operation/HederaCreate2Operation.java
@@ -30,7 +30,6 @@ import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import org.apache.tuweni.units.bigints.UInt256;
 import org.hyperledger.besu.datatypes.Address;
-import org.hyperledger.besu.evm.Gas;
 import org.hyperledger.besu.evm.frame.MessageFrame;
 import org.hyperledger.besu.evm.gascalculator.GasCalculator;
 
@@ -69,10 +68,9 @@ public class HederaCreate2Operation extends AbstractRecordingCreateOperation {
 	}
 
 	@Override
-	protected Gas cost(final MessageFrame frame) {
+	protected long cost(final MessageFrame frame) {
 		final var calculator = gasCalculator();
-		return calculator.create2OperationGasCost(frame)
-				.plus(storageGasCalculator.creationGasCost(frame, calculator));
+		return calculator.create2OperationGasCost(frame) + storageGasCalculator.creationGasCost(frame, calculator);
 	}
 
 	@Override

--- a/hedera-node/src/main/java/com/hedera/services/contracts/operation/HederaCreateOperation.java
+++ b/hedera-node/src/main/java/com/hedera/services/contracts/operation/HederaCreateOperation.java
@@ -28,7 +28,6 @@ import com.hedera.services.state.EntityCreator;
 import com.hedera.services.store.contracts.HederaWorldUpdater;
 import com.hedera.services.store.contracts.precompile.SyntheticTxnFactory;
 import org.hyperledger.besu.datatypes.Address;
-import org.hyperledger.besu.evm.Gas;
 import org.hyperledger.besu.evm.frame.MessageFrame;
 import org.hyperledger.besu.evm.gascalculator.GasCalculator;
 
@@ -66,10 +65,9 @@ public class HederaCreateOperation extends AbstractRecordingCreateOperation {
 	}
 
 	@Override
-	public Gas cost(final MessageFrame frame) {
+	public long cost(final MessageFrame frame) {
 		final var calculator = gasCalculator();
-		return calculator.createOperationGasCost(frame)
-				.plus(storageGasCalculator.creationGasCost(frame, calculator));
+		return calculator.createOperationGasCost(frame) + storageGasCalculator.creationGasCost(frame, calculator);
 	}
 
 	@Override

--- a/hedera-node/src/main/java/com/hedera/services/contracts/operation/HederaLogOperation.java
+++ b/hedera-node/src/main/java/com/hedera/services/contracts/operation/HederaLogOperation.java
@@ -28,7 +28,6 @@ import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes;
 import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.evm.EVM;
-import org.hyperledger.besu.evm.Gas;
 import org.hyperledger.besu.evm.frame.ExceptionalHaltReason;
 import org.hyperledger.besu.evm.frame.MessageFrame;
 import org.hyperledger.besu.evm.gascalculator.GasCalculator;
@@ -37,6 +36,7 @@ import org.hyperledger.besu.evm.log.LogTopic;
 import org.hyperledger.besu.evm.operation.AbstractOperation;
 
 import java.util.Optional;
+import java.util.OptionalLong;
 
 import static org.apache.tuweni.bytes.Bytes32.leftPad;
 import static org.hyperledger.besu.evm.internal.Words.clampedToLong;
@@ -58,12 +58,12 @@ public class HederaLogOperation extends AbstractOperation {
 		final long dataLocation = clampedToLong(frame.popStackItem());
 		final long numBytes = clampedToLong(frame.popStackItem());
 
-		final Gas cost = gasCalculator().logOperationGasCost(frame, dataLocation, numBytes, numTopics);
-		final Optional<Gas> optionalCost = Optional.of(cost);
+		final long cost = gasCalculator().logOperationGasCost(frame, dataLocation, numBytes, numTopics);
+		final OptionalLong optionalCost = OptionalLong.of(cost);
 		if (frame.isStatic()) {
 			return new OperationResult(
 					optionalCost, Optional.of(ExceptionalHaltReason.ILLEGAL_STATE_CHANGE));
-		} else if (frame.getRemainingGas().compareTo(cost) < 0) {
+		} else if (frame.getRemainingGas() < cost) {
 			return new OperationResult(optionalCost, Optional.of(ExceptionalHaltReason.INSUFFICIENT_GAS));
 		}
 

--- a/hedera-node/src/main/java/com/hedera/services/contracts/operation/HederaOperationUtil.java
+++ b/hedera-node/src/main/java/com/hedera/services/contracts/operation/HederaOperationUtil.java
@@ -31,7 +31,6 @@ import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import org.apache.tuweni.units.bigints.UInt256;
 import org.hyperledger.besu.datatypes.Address;
-import org.hyperledger.besu.evm.Gas;
 import org.hyperledger.besu.evm.frame.ExceptionalHaltReason;
 import org.hyperledger.besu.evm.frame.MessageFrame;
 import org.hyperledger.besu.evm.internal.FixedStack;
@@ -41,6 +40,7 @@ import org.hyperledger.besu.evm.precompile.PrecompiledContract;
 
 import java.util.Map;
 import java.util.Optional;
+import java.util.OptionalLong;
 import java.util.TreeMap;
 import java.util.function.BiPredicate;
 import java.util.function.Supplier;
@@ -68,21 +68,21 @@ public final class HederaOperationUtil {
 	public static Operation.OperationResult addressCheckExecution(
 			MessageFrame frame,
 			Supplier<Bytes> supplierAddressBytes,
-			Supplier<Gas> supplierHaltGasCost,
+			Supplier<Long> supplierHaltGasCost,
 			Supplier<Operation.OperationResult> supplierExecution,
 			BiPredicate<Address, MessageFrame> addressValidator) {
 		try {
 			final var address = Words.toAddress(supplierAddressBytes.get());
 			if (Boolean.FALSE.equals(addressValidator.test(address, frame))) {
 				return new Operation.OperationResult(
-						Optional.of(supplierHaltGasCost.get()),
+						OptionalLong.of(supplierHaltGasCost.get()),
 						Optional.of(HederaExceptionalHaltReason.INVALID_SOLIDITY_ADDRESS));
 			}
 
 			return supplierExecution.get();
 		} catch (final FixedStack.UnderflowException ufe) {
 			return new Operation.OperationResult(
-					Optional.of(supplierHaltGasCost.get()),
+					OptionalLong.of(supplierHaltGasCost.get()),
 					Optional.of(ExceptionalHaltReason.INSUFFICIENT_STACK_ITEMS));
 		}
 	}
@@ -112,7 +112,7 @@ public final class HederaOperationUtil {
 			final EvmSigsVerifier sigsVerifier,
 			final MessageFrame frame,
 			final Address address,
-			final Supplier<Gas> supplierHaltGasCost,
+			final Supplier<Long> supplierHaltGasCost,
 			final Supplier<Operation.OperationResult> supplierExecution,
 			final BiPredicate<Address, MessageFrame> addressValidator,
 			final Map<String, PrecompiledContract> precompiledContractMap
@@ -126,7 +126,7 @@ public final class HederaOperationUtil {
 		final var account = updater.get(address);
 		if (Boolean.FALSE.equals(addressValidator.test(address, frame))) {
 			return new Operation.OperationResult(
-					Optional.of(supplierHaltGasCost.get()),
+					OptionalLong.of(supplierHaltGasCost.get()),
 					Optional.of(HederaExceptionalHaltReason.INVALID_SOLIDITY_ADDRESS));
 		}
 		boolean isDelegateCall = !frame.getContractAddress().equals(frame.getRecipientAddress());
@@ -146,7 +146,7 @@ public final class HederaOperationUtil {
 		}
 		if (!sigReqIsMet) {
 			return new Operation.OperationResult(
-					Optional.of(supplierHaltGasCost.get()), Optional.of(HederaExceptionalHaltReason.INVALID_SIGNATURE)
+					OptionalLong.of(supplierHaltGasCost.get()), Optional.of(HederaExceptionalHaltReason.INVALID_SIGNATURE)
 			);
 		}
 

--- a/hedera-node/src/main/java/com/hedera/services/contracts/operation/HederaSLoadOperation.java
+++ b/hedera-node/src/main/java/com/hedera/services/contracts/operation/HederaSLoadOperation.java
@@ -28,7 +28,6 @@ import org.apache.tuweni.bytes.Bytes32;
 import org.apache.tuweni.units.bigints.UInt256;
 import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.evm.EVM;
-import org.hyperledger.besu.evm.Gas;
 import org.hyperledger.besu.evm.account.Account;
 import org.hyperledger.besu.evm.frame.ExceptionalHaltReason;
 import org.hyperledger.besu.evm.frame.MessageFrame;
@@ -39,6 +38,7 @@ import org.hyperledger.besu.evm.operation.AbstractOperation;
 
 import javax.inject.Inject;
 import java.util.Optional;
+import java.util.OptionalLong;
 
 /**
  * Hedera adapted version of the {@link org.hyperledger.besu.evm.operation.SLoadOperation}.
@@ -47,8 +47,8 @@ import java.util.Optional;
 public class HederaSLoadOperation extends AbstractOperation {
 
 
-	private final Optional<Gas> warmCost;
-	private final Optional<Gas> coldCost;
+	private final OptionalLong warmCost;
+	private final OptionalLong coldCost;
 
 	private final OperationResult warmSuccess;
 	private final OperationResult coldSuccess;
@@ -57,9 +57,9 @@ public class HederaSLoadOperation extends AbstractOperation {
 	@Inject
 	public HederaSLoadOperation(final GasCalculator gasCalculator, final GlobalDynamicProperties dynamicProperties) {
 		super(0x54, "SLOAD", 1, 1, 1, gasCalculator);
-		final Gas baseCost = gasCalculator.getSloadOperationGasCost();
-		warmCost = Optional.of(baseCost.plus(gasCalculator.getWarmStorageReadCost()));
-		coldCost = Optional.of(baseCost.plus(gasCalculator.getColdSloadCost()));
+		final long baseCost = gasCalculator.getSloadOperationGasCost();
+		warmCost = OptionalLong.of(baseCost + gasCalculator.getWarmStorageReadCost());
+		coldCost = OptionalLong.of(baseCost + gasCalculator.getColdSloadCost());
 
 		warmSuccess = new OperationResult(warmCost, Optional.empty());
 		coldSuccess = new OperationResult(coldCost, Optional.empty());
@@ -75,8 +75,8 @@ public class HederaSLoadOperation extends AbstractOperation {
 			final Address address = account.getAddress();
 			final Bytes32 key = UInt256.fromBytes(frame.popStackItem());
 			final boolean slotIsWarm = frame.warmUpStorage(address, key);
-			final Optional<Gas> optionalCost = slotIsWarm ? warmCost : coldCost;
-			if (frame.getRemainingGas().compareTo(optionalCost.orElse(Gas.ZERO)) < 0) {
+			final OptionalLong optionalCost = slotIsWarm ? warmCost : coldCost;
+			if (frame.getRemainingGas() < optionalCost.orElse(0L)) {
 				return new OperationResult(
 						optionalCost, Optional.of(ExceptionalHaltReason.INSUFFICIENT_GAS));
 			} else {

--- a/hedera-node/src/main/java/com/hedera/services/contracts/operation/HederaSStoreOperation.java
+++ b/hedera-node/src/main/java/com/hedera/services/contracts/operation/HederaSStoreOperation.java
@@ -28,7 +28,6 @@ import com.hedera.services.contracts.gascalculator.StorageGasCalculator;
 import com.hedera.services.store.contracts.HederaWorldUpdater;
 import org.apache.tuweni.units.bigints.UInt256;
 import org.hyperledger.besu.evm.EVM;
-import org.hyperledger.besu.evm.Gas;
 import org.hyperledger.besu.evm.account.MutableAccount;
 import org.hyperledger.besu.evm.frame.ExceptionalHaltReason;
 import org.hyperledger.besu.evm.frame.MessageFrame;
@@ -38,6 +37,7 @@ import org.hyperledger.besu.evm.operation.Operation;
 
 import javax.inject.Inject;
 import java.util.Optional;
+import java.util.OptionalLong;
 
 import static com.hedera.services.contracts.operation.HederaOperationUtil.cacheExistingValue;
 import static org.hyperledger.besu.evm.frame.ExceptionalHaltReason.ILLEGAL_STATE_CHANGE;
@@ -48,7 +48,7 @@ import static org.hyperledger.besu.evm.frame.ExceptionalHaltReason.ILLEGAL_STATE
  */
 public class HederaSStoreOperation extends AbstractOperation {
 	private static final Operation.OperationResult ILLEGAL_STATE_CHANGE_RESULT =
-			new Operation.OperationResult(Optional.empty(), Optional.of(ILLEGAL_STATE_CHANGE));
+			new Operation.OperationResult(OptionalLong.empty(), Optional.of(ILLEGAL_STATE_CHANGE));
 
 	private final boolean checkSuperCost;
 	private final StorageGasCalculator storageGasCalculator;
@@ -80,7 +80,7 @@ public class HederaSStoreOperation extends AbstractOperation {
 		boolean currentZero = currentValue.isZero();
 		boolean newZero = value.isZero();
 		boolean checkCalculator = checkSuperCost;
-		Gas gasCost = Gas.ZERO;
+		long gasCost = 0L;
 		if (currentZero && !newZero) {
 			gasCost = storageGasCalculator.gasCostOfStorageIn(frame);
 			((HederaWorldUpdater) frame.getWorldUpdater()).addSbhRefund(gasCost);
@@ -93,16 +93,16 @@ public class HederaSStoreOperation extends AbstractOperation {
 			final var slotIsWarm = frame.warmUpStorage(address, key);
 			final var calculator = gasCalculator();
 			final var calcGasCost = calculator.calculateStorageCost(account, key, value)
-					.plus(slotIsWarm ? Gas.ZERO : calculator.getColdSloadCost());
-			gasCost = gasCost.max(calcGasCost);
+					 + (slotIsWarm ? 0L : calculator.getColdSloadCost());
+			gasCost = Math.max(gasCost, calcGasCost);
 			frame.incrementGasRefund(gasCalculator().calculateStorageRefundAmount(account, key, value));
 		}
 
-		final var optionalCost = Optional.of(gasCost);
-		final Gas remainingGas = frame.getRemainingGas();
+		final var optionalCost = OptionalLong.of(gasCost);
+		final long remainingGas = frame.getRemainingGas();
 		if (frame.isStatic()) {
 			return new OperationResult(optionalCost, Optional.of(ILLEGAL_STATE_CHANGE));
-		} else if (remainingGas.compareTo(gasCost) < 0) {
+		} else if (remainingGas < gasCost) {
 			return new OperationResult(optionalCost, Optional.of(ExceptionalHaltReason.INSUFFICIENT_GAS));
 		}
 

--- a/hedera-node/src/main/java/com/hedera/services/contracts/operation/HederaSelfDestructOperation.java
+++ b/hedera-node/src/main/java/com/hedera/services/contracts/operation/HederaSelfDestructOperation.java
@@ -26,7 +26,6 @@ import com.hedera.services.store.contracts.HederaStackedWorldStateUpdater;
 import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.datatypes.Wei;
 import org.hyperledger.besu.evm.EVM;
-import org.hyperledger.besu.evm.Gas;
 import org.hyperledger.besu.evm.account.Account;
 import org.hyperledger.besu.evm.frame.ExceptionalHaltReason;
 import org.hyperledger.besu.evm.frame.MessageFrame;
@@ -36,6 +35,7 @@ import org.hyperledger.besu.evm.operation.SelfDestructOperation;
 
 import javax.inject.Inject;
 import java.util.Optional;
+import java.util.OptionalLong;
 import java.util.function.BiPredicate;
 
 /**
@@ -90,7 +90,7 @@ public class HederaSelfDestructOperation extends SelfDestructOperation {
 	}
 
 	private OperationResult reversionWith(final Account beneficiary, final ExceptionalHaltReason reason) {
-		final Gas cost = gasCalculator().selfDestructOperationGasCost(beneficiary, Wei.ONE);
-		return new OperationResult(Optional.of(cost), Optional.of(reason));
+		final long cost = gasCalculator().selfDestructOperationGasCost(beneficiary, Wei.ONE);
+		return new OperationResult(OptionalLong.of(cost), Optional.of(reason));
 	}
 }

--- a/hedera-node/src/main/java/com/hedera/services/store/contracts/CodeCache.java
+++ b/hedera-node/src/main/java/com/hedera/services/store/contracts/CodeCache.java
@@ -74,14 +74,14 @@ public class CodeCache {
 
         if (entityAccess.isTokenAccount(address)) {
             final var interpolatedBytecode = proxyBytecodeFor(address);
-            code = new Code(interpolatedBytecode, Hash.hash(interpolatedBytecode));
+            code = Code.createLegacyCode(interpolatedBytecode, Hash.hash(interpolatedBytecode));
             cache.put(cacheKey, code);
             return code;
         }
 
         final var bytecode = entityAccess.fetchCodeIfPresent(accountIdFromEvmAddress(address));
         if (bytecode != null) {
-            code = new Code(bytecode, Hash.hash(bytecode));
+                code = Code.createLegacyCode(bytecode, Hash.hash(bytecode));
             cache.put(cacheKey, code);
         }
 

--- a/hedera-node/src/main/java/com/hedera/services/store/contracts/HederaStackedWorldStateUpdater.java
+++ b/hedera-node/src/main/java/com/hedera/services/store/contracts/HederaStackedWorldStateUpdater.java
@@ -32,7 +32,6 @@ import com.hederahashgraph.api.proto.java.AccountID;
 import com.hederahashgraph.api.proto.java.ContractID;
 import org.apache.tuweni.bytes.Bytes;
 import org.hyperledger.besu.datatypes.Address;
-import org.hyperledger.besu.evm.Gas;
 import org.hyperledger.besu.evm.account.Account;
 import org.hyperledger.besu.evm.account.EvmAccount;
 import org.hyperledger.besu.evm.worldstate.WorldUpdater;
@@ -55,7 +54,7 @@ public class HederaStackedWorldStateUpdater
 	private final HederaMutableWorldState worldState;
 	private final GlobalDynamicProperties dynamicProperties;
 
-	private Gas sbhRefund = Gas.ZERO;
+	private long sbhRefund = 0L;
 	private int numAllocatedIds = 0;
 	private ContractID lastAllocatedId = null;
 	private ContractCustomizer pendingCreationCustomizer = null;
@@ -198,13 +197,13 @@ public class HederaStackedWorldStateUpdater
 	}
 
 	@Override
-	public Gas getSbhRefund() {
+	public long getSbhRefund() {
 		return sbhRefund;
 	}
 
 	@Override
-	public void addSbhRefund(Gas refund) {
-		sbhRefund = sbhRefund.plus(refund);
+	public void addSbhRefund(long refund) {
+		sbhRefund = sbhRefund + refund;
 	}
 
 	@Override
@@ -217,7 +216,7 @@ public class HederaStackedWorldStateUpdater
 			worldState.reclaimContractId();
 			numAllocatedIds--;
 		}
-		sbhRefund = Gas.ZERO;
+		sbhRefund = 0L;
 	}
 
 	@Override
@@ -226,7 +225,7 @@ public class HederaStackedWorldStateUpdater
 		final var wrappedUpdater = ((HederaWorldUpdater) wrappedWorldView());
 		wrappedUpdater.addSbhRefund(sbhRefund);
 		wrappedUpdater.countIdsAllocatedByStacked(numAllocatedIds);
-		sbhRefund = Gas.ZERO;
+		sbhRefund = 0L;
 	}
 
 	@Override

--- a/hedera-node/src/main/java/com/hedera/services/store/contracts/HederaWorldState.java
+++ b/hedera-node/src/main/java/com/hedera/services/store/contracts/HederaWorldState.java
@@ -37,7 +37,6 @@ import org.apache.tuweni.units.bigints.UInt256;
 import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.datatypes.Wei;
-import org.hyperledger.besu.evm.Gas;
 import org.hyperledger.besu.evm.account.Account;
 import org.hyperledger.besu.evm.worldstate.WorldUpdater;
 
@@ -192,7 +191,7 @@ public class HederaWorldState implements HederaMutableWorldState {
 		GlobalDynamicProperties dynamicProperties;
 
 		private int numAllocatedIds = 0;
-		private Gas sbhRefund = Gas.ZERO;
+		private long sbhRefund = 0L;
 
 		protected Updater(
 				final HederaWorldState world,
@@ -255,13 +254,13 @@ public class HederaWorldState implements HederaMutableWorldState {
 		}
 
 		@Override
-		public Gas getSbhRefund() {
+		public long getSbhRefund() {
 			return sbhRefund;
 		}
 
 		@Override
-		public void addSbhRefund(Gas refund) {
-			sbhRefund = sbhRefund.plus(refund);
+		public void addSbhRefund(long refund) {
+			sbhRefund = sbhRefund + refund;
 		}
 
 		@Override
@@ -272,7 +271,7 @@ public class HederaWorldState implements HederaMutableWorldState {
 				wrapped.reclaimContractId();
 				numAllocatedIds--;
 			}
-			sbhRefund = Gas.ZERO;
+			sbhRefund = 0L;
 		}
 
 		@Override

--- a/hedera-node/src/main/java/com/hedera/services/store/contracts/HederaWorldUpdater.java
+++ b/hedera-node/src/main/java/com/hedera/services/store/contracts/HederaWorldUpdater.java
@@ -23,7 +23,6 @@ package com.hedera.services.store.contracts;
  */
 
 import org.hyperledger.besu.datatypes.Address;
-import org.hyperledger.besu.evm.Gas;
 import org.hyperledger.besu.evm.worldstate.WorldUpdater;
 
 /**
@@ -47,7 +46,7 @@ public interface HederaWorldUpdater extends WorldUpdater {
 	 *
 	 * @return the amount of Gas to refund;
 	 */
-	Gas getSbhRefund();
+	long getSbhRefund();
 
 	/**
 	 * Used to keep track of SBH gas refunds between all instances of HederaWorldUpdater. Lower level updaters should
@@ -56,7 +55,7 @@ public interface HederaWorldUpdater extends WorldUpdater {
 	 * @param refund
 	 * 	the amount of Gas to refund;
 	 */
-	void addSbhRefund(Gas refund);
+	void addSbhRefund(long refund);
 
 	void countIdsAllocatedByStacked(int n);
 }

--- a/hedera-node/src/main/java/com/hedera/services/store/contracts/WorldStateAccount.java
+++ b/hedera-node/src/main/java/com/hedera/services/store/contracts/WorldStateAccount.java
@@ -36,7 +36,7 @@ import java.util.NavigableMap;
 import static com.hedera.services.utils.EntityIdUtils.accountIdFromEvmAddress;
 
 public class WorldStateAccount implements Account {
-	private static final Code EMPTY_CODE = new Code(Bytes.EMPTY, Hash.hash(Bytes.EMPTY));
+	private static final Code EMPTY_CODE = Code.createLegacyCode(Bytes.EMPTY, Hash.hash(Bytes.EMPTY));
 
 	private final Wei balance;
 	private final Address address;

--- a/hedera-node/src/main/java/com/hedera/services/store/contracts/WorldStateTokenAccount.java
+++ b/hedera-node/src/main/java/com/hedera/services/store/contracts/WorldStateTokenAccount.java
@@ -103,7 +103,7 @@ public class WorldStateTokenAccount implements Account {
 	private Code interpolatedCode() {
 		if (interpolatedCode == null) {
 			final var interpolatedBytecode = proxyBytecodeFor(address);
-			interpolatedCode = new Code(interpolatedBytecode, Hash.hash(interpolatedBytecode));
+			interpolatedCode = Code.createLegacyCode(interpolatedBytecode, Hash.hash(interpolatedBytecode));
 		}
 		return interpolatedCode;
 	}

--- a/hedera-node/src/main/java/com/hedera/services/store/contracts/precompile/ExchangeRatePrecompiledContract.java
+++ b/hedera-node/src/main/java/com/hedera/services/store/contracts/precompile/ExchangeRatePrecompiledContract.java
@@ -26,7 +26,6 @@ import com.hedera.services.context.properties.GlobalDynamicProperties;
 import com.hedera.services.fees.HbarCentExchange;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
-import org.hyperledger.besu.evm.Gas;
 import org.hyperledger.besu.evm.frame.MessageFrame;
 import org.hyperledger.besu.evm.gascalculator.GasCalculator;
 import org.hyperledger.besu.evm.precompile.AbstractPrecompiledContract;
@@ -81,7 +80,7 @@ public class ExchangeRatePrecompiledContract extends AbstractPrecompiledContract
 	}
 
 	@Override
-	public Gas gasRequirement(Bytes bytes) {
+	public long gasRequirement(Bytes bytes) {
 		return dynamicProperties.exchangeRateGasReq();
 	}
 

--- a/hedera-node/src/main/java/com/hedera/services/store/contracts/precompile/HTSPrecompiledContract.java
+++ b/hedera-node/src/main/java/com/hedera/services/store/contracts/precompile/HTSPrecompiledContract.java
@@ -105,7 +105,6 @@ import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes;
 import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.datatypes.Wei;
-import org.hyperledger.besu.evm.Gas;
 import org.hyperledger.besu.evm.frame.MessageFrame;
 import org.hyperledger.besu.evm.gascalculator.GasCalculator;
 import org.hyperledger.besu.evm.log.Log;
@@ -245,7 +244,7 @@ public class HTSPrecompiledContract extends AbstractPrecompiledContract {
 	//dissociateToken(address account, address token)
 	protected static final int ABI_ID_DISSOCIATE_TOKEN = 0x099794e8;
 	//redirectForToken(address token, bytes memory data)
-	protected static final int ABI_ID_REDIRECT_FOR_TOKEN = 0x618dc65e;
+	public static final int ABI_ID_REDIRECT_FOR_TOKEN = 0x618dc65e;
 
 	//name()
 	public static final int ABI_ID_NAME = 0x06fdde03;
@@ -305,7 +304,7 @@ public class HTSPrecompiledContract extends AbstractPrecompiledContract {
 	private Precompile precompile;
 	private TransactionBody.Builder transactionBody;
 	private final Provider<FeeCalculator> feeCalculator;
-	private Gas gasRequirement = Gas.ZERO;
+	private long gasRequirement = 0;
 	private final StateView currentView;
 	private SideEffectsTracker sideEffectsTracker;
 	private final PrecompilePricingUtils precompilePricingUtils;
@@ -361,7 +360,7 @@ public class HTSPrecompiledContract extends AbstractPrecompiledContract {
 		this.deleteAllowanceChecks = deleteAllowanceChecks;
 	}
 
-	public Pair<Gas, Bytes> computeCosted(final Bytes input, final MessageFrame frame) {
+	public Pair<Long, Bytes> computeCosted(final Bytes input, final MessageFrame frame) {
 		if (frame.isStatic()) {
 			if (!isTokenProxyRedirect(input)) {
 				frame.setRevertReason(STATIC_CALL_REVERT_REASON);
@@ -380,7 +379,7 @@ public class HTSPrecompiledContract extends AbstractPrecompiledContract {
 	}
 
 	@Override
-	public Gas gasRequirement(final Bytes bytes) {
+	public long gasRequirement(final Bytes bytes) {
 		return gasRequirement;
 	}
 
@@ -399,7 +398,7 @@ public class HTSPrecompiledContract extends AbstractPrecompiledContract {
 		if (isTokenReadOnlyTransaction) {
 			computeViewFunctionGasRequirement(now);
 		} else if (precompile instanceof TokenCreatePrecompile) {
-			gasRequirement = Gas.of(precompile.getMinimumFeeInTinybars(Timestamp.newBuilder().setSeconds(now).build()));
+			gasRequirement = precompile.getMinimumFeeInTinybars(Timestamp.newBuilder().setSeconds(now).build());
 		} else {
 			computeGasRequirement(now);
 		}
@@ -427,10 +426,10 @@ public class HTSPrecompiledContract extends AbstractPrecompiledContract {
 		final long actualFeeInTinybars = Math.max(minimumFeeInTinybars, calculatedFeeInTinybars);
 
 		// convert to gas cost
-		final Gas baseGasCost = Gas.of((actualFeeInTinybars + gasPriceInTinybars - 1) / gasPriceInTinybars);
+		final Long baseGasCost = (actualFeeInTinybars + gasPriceInTinybars - 1L) / gasPriceInTinybars;
 
 		// charge premium
-		gasRequirement = baseGasCost.plus((baseGasCost.dividedBy(5)));
+		gasRequirement = baseGasCost + (baseGasCost/5L);
 	}
 
 	void computeViewFunctionGasRequirement(final long blockTimestamp) {
@@ -438,7 +437,7 @@ public class HTSPrecompiledContract extends AbstractPrecompiledContract {
 		gasRequirement = computeViewFunctionGas(now, precompile.getMinimumFeeInTinybars(now));
 	}
 
-	Gas computeViewFunctionGas(final Timestamp now, final long minimumTinybarCost) {
+	long computeViewFunctionGas(final Timestamp now, final long minimumTinybarCost) {
 		final var calculator = feeCalculator.get();
 		final var usagePrices = resourceCosts.defaultPricesGiven(TokenGetInfo, now);
 		final var fees = calculator.estimatePayment(
@@ -449,10 +448,10 @@ public class HTSPrecompiledContract extends AbstractPrecompiledContract {
 		final long actualFeeInTinybars = Math.max(minimumTinybarCost, calculatedFeeInTinybars);
 
 		// convert to gas cost
-		final Gas baseGasCost = Gas.of((actualFeeInTinybars + gasPriceInTinybars - 1) / gasPriceInTinybars);
+		final long baseGasCost = (actualFeeInTinybars + gasPriceInTinybars - 1L) / gasPriceInTinybars;
 
 		// charge premium
-		return baseGasCost.plus((baseGasCost.dividedBy(5)));
+		return baseGasCost + (baseGasCost/5L);
 	}
 
 	void prepareComputation(final Bytes input, final UnaryOperator<byte[]> aliasResolver) {
@@ -460,7 +459,7 @@ public class HTSPrecompiledContract extends AbstractPrecompiledContract {
 		this.transactionBody = null;
 
 		this.functionId = input.getInt(0);
-		this.gasRequirement = null;
+		this.gasRequirement = 0L;
 
 		this.precompile =
 				switch (functionId) {
@@ -595,7 +594,7 @@ public class HTSPrecompiledContract extends AbstractPrecompiledContract {
 		Bytes result;
 		ExpirableTxnRecord.Builder childRecord;
 		try {
-			validateTrue(frame.getRemainingGas().compareTo(gasRequirement) >= 0, INSUFFICIENT_GAS);
+			validateTrue(frame.getRemainingGas() >= gasRequirement, INSUFFICIENT_GAS);
 
 			precompile.handleSentHbars(frame);
 			precompile.customizeTrackingLedgers(ledgers);
@@ -649,12 +648,12 @@ public class HTSPrecompiledContract extends AbstractPrecompiledContract {
 					result != null ? result.toArrayUnsafe() : EvmFnResult.EMPTY,
 					errorStatus.map(ResponseCodeEnum::name).orElse(null),
 					EvmFnResult.EMPTY,
-					this.gasRequirement.toLong(),
+					this.gasRequirement,
 					Collections.emptyList(),
 					Collections.emptyList(),
 					EvmFnResult.EMPTY,
 					Collections.emptyMap(),
-					precompile.shouldAddTraceabilityFieldsToRecord() ? messageFrame.getRemainingGas().toLong() : 0L,
+					precompile.shouldAddTraceabilityFieldsToRecord() ? messageFrame.getRemainingGas() : 0L,
 					precompile.shouldAddTraceabilityFieldsToRecord() ? messageFrame.getValue().toLong() : 0L,
 					precompile.shouldAddTraceabilityFieldsToRecord() ? messageFrame.getInputData().toArrayUnsafe() :
 							EvmFnResult.EMPTY,
@@ -2065,8 +2064,8 @@ public class HTSPrecompiledContract extends AbstractPrecompiledContract {
 		return !contract.equals(recipient);
 	}
 
-	private Gas defaultGas() {
-		return Gas.of(dynamicProperties.htsDefaultGasCost());
+	private long defaultGas() {
+		return dynamicProperties.htsDefaultGasCost();
 	}
 
 	private long gasFeeInTinybars(final TransactionBody.Builder txBody, final Instant consensusTime) {

--- a/hedera-node/src/main/java/com/hedera/services/store/contracts/precompile/proxy/RedirectGasCalculator.java
+++ b/hedera-node/src/main/java/com/hedera/services/store/contracts/precompile/proxy/RedirectGasCalculator.java
@@ -21,9 +21,8 @@ package com.hedera.services.store.contracts.precompile.proxy;
  */
 
 import com.hederahashgraph.api.proto.java.Timestamp;
-import org.hyperledger.besu.evm.Gas;
 
 @FunctionalInterface
 public interface RedirectGasCalculator {
-	Gas compute(final Timestamp now, final long minimumTinybarCost);
+	long compute(final Timestamp now, final long minimumTinybarCost);
 }

--- a/hedera-node/src/main/java/com/hedera/services/store/contracts/precompile/proxy/RedirectViewExecutor.java
+++ b/hedera-node/src/main/java/com/hedera/services/store/contracts/precompile/proxy/RedirectViewExecutor.java
@@ -28,7 +28,6 @@ import com.hedera.services.store.contracts.precompile.EncodingFacade;
 import com.hedera.services.store.models.NftId;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.tuweni.bytes.Bytes;
-import org.hyperledger.besu.evm.Gas;
 import org.hyperledger.besu.evm.frame.MessageFrame;
 
 import static com.hedera.services.exceptions.ValidationUtils.validateFalse;
@@ -74,7 +73,7 @@ public class RedirectViewExecutor {
 		this.ledgers = updater.trackingLedgers();
 	}
 
-	public Pair<Gas, Bytes> computeCosted() {
+	public Pair<Long, Bytes> computeCosted() {
 		final var target = getRedirectTarget(input);
 		final var tokenId = target.tokenId();
 		final var now = asSecondsTimestamp(frame.getBlockValues().getTimestamp());

--- a/hedera-node/src/test/java/com/hedera/services/context/properties/GlobalDynamicPropertiesTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/context/properties/GlobalDynamicPropertiesTest.java
@@ -27,7 +27,6 @@ import com.hedera.services.sysfiles.domain.KnownBlockValues;
 import com.hedera.services.sysfiles.domain.throttling.ThrottleReqOpsScaleFactor;
 import com.hederahashgraph.api.proto.java.AccountID;
 import com.hederahashgraph.api.proto.java.HederaFunctionality;
-import org.hyperledger.besu.evm.Gas;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -313,7 +312,7 @@ class GlobalDynamicPropertiesTest {
 		assertEquals(evenFactor, subject.nftMintScaleFactor());
 		assertEquals(upgradeArtifactLocs[0], subject.upgradeArtifactsLoc());
 		assertEquals(blockValues, subject.knownBlockValues());
-		assertEquals(Gas.of(66L), subject.exchangeRateGasReq());
+		assertEquals(66L, subject.exchangeRateGasReq());
 	}
 
 	private void givenPropsWithSeed(int i) {

--- a/hedera-node/src/test/java/com/hedera/services/contracts/execution/CallLocalEvmTxProcessorTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/contracts/execution/CallLocalEvmTxProcessorTest.java
@@ -34,7 +34,6 @@ import org.apache.tuweni.bytes.Bytes;
 import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.datatypes.Wei;
 import org.hyperledger.besu.evm.Code;
-import org.hyperledger.besu.evm.Gas;
 import org.hyperledger.besu.evm.account.EvmAccount;
 import org.hyperledger.besu.evm.account.MutableAccount;
 import org.hyperledger.besu.evm.frame.BlockValues;
@@ -141,7 +140,7 @@ class CallLocalEvmTxProcessorTest {
 
 		var evmAccount = mock(EvmAccount.class);
 
-		given(gasCalculator.transactionIntrinsicGasCost(Bytes.EMPTY, false)).willReturn(Gas.ZERO);
+		given(gasCalculator.transactionIntrinsicGasCost(Bytes.EMPTY, false)).willReturn(0L);
 
 		given(updater.getOrCreateSenderAccount(sender.getId().asEvmAddress())).willReturn(evmAccount);
 		given(updater.getOrCreateSenderAccount(sender.getId().asEvmAddress()).getMutable()).willReturn(
@@ -171,7 +170,7 @@ class CallLocalEvmTxProcessorTest {
 	void assertTransactionSenderAndValue() {
 		// setup:
 		doReturn(Optional.of(receiver.getId().asEvmAddress())).when(transaction).getTo();
-		given(codeCache.getIfPresent(any())).willReturn(new Code());
+		given(codeCache.getIfPresent(any())).willReturn(Code.EMPTY);
 		given(transaction.getSender()).willReturn(sender.getId().asEvmAddress());
 		given(transaction.getValue()).willReturn(Wei.of(1L));
 		final MessageFrame.Builder commonInitialFrame =
@@ -179,9 +178,9 @@ class CallLocalEvmTxProcessorTest {
 						.messageFrameStack(mock(Deque.class))
 						.maxStackSize(MAX_STACK_SIZE)
 						.worldUpdater(mock(WorldUpdater.class))
-						.initialGas(mock(Gas.class))
+						.initialGas(1_000_000L)
 						.originator(sender.getId().asEvmAddress())
-						.gasPrice(mock(Wei.class))
+						.gasPrice(Wei.ZERO)
 						.sender(sender.getId().asEvmAddress())
 						.value(Wei.of(transaction.getValue().getAsBigInteger()))
 						.apparentValue(Wei.of(transaction.getValue().getAsBigInteger()))
@@ -189,7 +188,7 @@ class CallLocalEvmTxProcessorTest {
 						.depth(0)
 						.completer(__ -> {
 						})
-						.miningBeneficiary(mock(Address.class))
+						.miningBeneficiary(Address.ZERO)
 						.blockHashLookup(h -> null);
 		//when:
 		MessageFrame buildMessageFrame = callLocalEvmTxProcessor.buildInitialFrame(commonInitialFrame,
@@ -207,26 +206,26 @@ class CallLocalEvmTxProcessorTest {
 
 		var evmAccount = mock(EvmAccount.class);
 
-		given(gasCalculator.transactionIntrinsicGasCost(Bytes.EMPTY, false)).willReturn(Gas.ZERO);
+		given(gasCalculator.transactionIntrinsicGasCost(Bytes.EMPTY, false)).willReturn(0L);
 
 		given(updater.getOrCreateSenderAccount(sender.getId().asEvmAddress())).willReturn(evmAccount);
 		given(updater.getOrCreateSenderAccount(sender.getId().asEvmAddress()).getMutable()).willReturn(
 				mock(MutableAccount.class));
 		given(worldState.updater()).willReturn(updater);
-		given(codeCache.getIfPresent(any())).willReturn(new Code());
+		given(codeCache.getIfPresent(any())).willReturn(Code.EMPTY);
 
 
 		var senderMutableAccount = mock(MutableAccount.class);
 		given(senderMutableAccount.decrementBalance(any())).willReturn(Wei.of(1234L));
 		given(senderMutableAccount.incrementBalance(any())).willReturn(Wei.of(1500L));
 
-		given(gasCalculator.getSelfDestructRefundAmount()).willReturn(Gas.ZERO);
+		given(gasCalculator.getSelfDestructRefundAmount()).willReturn(0L);
 		given(gasCalculator.getMaxRefundQuotient()).willReturn(2L);
 
 		given(updater.getSenderAccount(any())).willReturn(evmAccount);
 		given(updater.getSenderAccount(any()).getMutable()).willReturn(senderMutableAccount);
 		given(updater.getOrCreate(any())).willReturn(evmAccount);
 		given(updater.getOrCreate(any()).getMutable()).willReturn(senderMutableAccount);
-		given(updater.getSbhRefund()).willReturn(Gas.ZERO);
+		given(updater.getSbhRefund()).willReturn(0L);
 	}
 }

--- a/hedera-node/src/test/java/com/hedera/services/contracts/execution/CommonProcessorSetup.java
+++ b/hedera-node/src/test/java/com/hedera/services/contracts/execution/CommonProcessorSetup.java
@@ -22,23 +22,22 @@ package com.hedera.services.contracts.execution;
  *
  */
 
-import org.hyperledger.besu.evm.Gas;
 import org.hyperledger.besu.evm.gascalculator.GasCalculator;
 
 import static org.mockito.BDDMockito.given;
 
 public class CommonProcessorSetup {
 	static void setup(GasCalculator gasCalculator) {
-		given(gasCalculator.getVeryLowTierGasCost()).willReturn(Gas.of(3));
-		given(gasCalculator.getLowTierGasCost()).willReturn(Gas.of(5));
-		given(gasCalculator.getMidTierGasCost()).willReturn(Gas.of(8));
-		given(gasCalculator.getBaseTierGasCost()).willReturn(Gas.of(2));
-		given(gasCalculator.getBlockHashOperationGasCost()).willReturn(Gas.of(20));
-		given(gasCalculator.getWarmStorageReadCost()).willReturn(Gas.of(160));
-		given(gasCalculator.getColdSloadCost()).willReturn(Gas.of(2100));
-		given(gasCalculator.getSloadOperationGasCost()).willReturn(Gas.ZERO);
-		given(gasCalculator.getHighTierGasCost()).willReturn(Gas.of(10));
-		given(gasCalculator.getJumpDestOperationGasCost()).willReturn(Gas.of(1));
-		given(gasCalculator.getZeroTierGasCost()).willReturn(Gas.ZERO);
+		given(gasCalculator.getVeryLowTierGasCost()).willReturn(3L);
+		given(gasCalculator.getLowTierGasCost()).willReturn(5L);
+		given(gasCalculator.getMidTierGasCost()).willReturn(8L);
+		given(gasCalculator.getBaseTierGasCost()).willReturn(2L);
+		given(gasCalculator.getBlockHashOperationGasCost()).willReturn(20L);
+		given(gasCalculator.getWarmStorageReadCost()).willReturn(160L);
+		given(gasCalculator.getColdSloadCost()).willReturn(2100L);
+		given(gasCalculator.getSloadOperationGasCost()).willReturn(0L);
+		given(gasCalculator.getHighTierGasCost()).willReturn(10L);
+		given(gasCalculator.getJumpDestOperationGasCost()).willReturn(1L);
+		given(gasCalculator.getZeroTierGasCost()).willReturn(0L);
 	}
 }

--- a/hedera-node/src/test/java/com/hedera/services/contracts/execution/HederaBlockValuesTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/contracts/execution/HederaBlockValuesTest.java
@@ -24,6 +24,7 @@ package com.hedera.services.contracts.execution;
 
 import com.hedera.services.state.merkle.MerkleNetworkContext;
 import org.apache.tuweni.units.bigints.UInt256;
+import org.hyperledger.besu.datatypes.Wei;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -49,7 +50,7 @@ class HederaBlockValuesTest {
         subject = new HederaBlockValues(gasLimit, blockNo, consTime);
         Assertions.assertEquals(gasLimit, subject.getGasLimit());
         Assertions.assertEquals(consTime.getEpochSecond(), subject.getTimestamp());
-        Assertions.assertEquals(Optional.of(0L), subject.getBaseFee());
+        Assertions.assertEquals(Optional.of(Wei.ZERO), subject.getBaseFee());
         Assertions.assertEquals(UInt256.ZERO, subject.getDifficultyBytes());
         Assertions.assertEquals(blockNo, subject.getNumber());
     }

--- a/hedera-node/src/test/java/com/hedera/services/contracts/execution/HederaMessageCallProcessorTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/contracts/execution/HederaMessageCallProcessorTest.java
@@ -26,7 +26,6 @@ import org.apache.tuweni.bytes.Bytes;
 import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.datatypes.Wei;
 import org.hyperledger.besu.evm.EVM;
-import org.hyperledger.besu.evm.Gas;
 import org.hyperledger.besu.evm.frame.MessageFrame;
 import org.hyperledger.besu.evm.precompile.PrecompileContractRegistry;
 import org.hyperledger.besu.evm.precompile.PrecompiledContract;
@@ -61,9 +60,9 @@ class HederaMessageCallProcessorTest {
 	private static final Address HTS_PRECOMPILE_ADDRESS = Address.fromHexString(HTS_PRECOMPILE_ADDRESS_STRING);
 	private static final Address RECIPIENT_ADDRESS = Address.fromHexString("0xcafecafe01");
 	private static final Address SENDER_ADDRESS = Address.fromHexString("0xcafecafe02");
-	private static final Gas GAS_ONE = Gas.of(1);
-	private static final Gas GAS_ONE_K = Gas.of(1_000);
-	private static final Gas GAS_ONE_M = Gas.of(1_000_000);
+	private static final long GAS_ONE = 1L;
+	private static final long GAS_ONE_K = 1_000L;
+	private static final long GAS_ONE_M = 1_000_000L;
 
 	@Mock
 	private EVM evm;
@@ -92,7 +91,7 @@ class HederaMessageCallProcessorTest {
 
 	@Test
 	void callsHederaPrecompile() {
-		given(frame.getRemainingGas()).willReturn(Gas.of(1337));
+		given(frame.getRemainingGas()).willReturn(1337L);
 		given(frame.getInputData()).willReturn(Bytes.EMPTY);
 		given(frame.getContractAddress()).willReturn(HEDERA_PRECOMPILE_ADDRESS);
 		given(nonHtsPrecompile.gasRequirement(any())).willReturn(GAS_ONE);
@@ -110,7 +109,7 @@ class HederaMessageCallProcessorTest {
 
 	@Test
 	void treatsHtsPrecompileSpecial() {
-		given(frame.getRemainingGas()).willReturn(Gas.of(1337));
+		given(frame.getRemainingGas()).willReturn(1337L);
 		given(frame.getInputData()).willReturn(Bytes.EMPTY);
 		given(frame.getContractAddress()).willReturn(HTS_PRECOMPILE_ADDRESS);
 		given(frame.getState()).willReturn(CODE_SUCCESS);

--- a/hedera-node/src/test/java/com/hedera/services/contracts/gascalculator/GasCalculatorHederaUtilTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/contracts/gascalculator/GasCalculatorHederaUtilTest.java
@@ -28,7 +28,6 @@ import com.hedera.services.fees.calculation.UsagePricesProvider;
 import com.hedera.services.state.merkle.MerkleNetworkContext;
 import com.hederahashgraph.api.proto.java.*;
 import org.hyperledger.besu.datatypes.Wei;
-import org.hyperledger.besu.evm.Gas;
 import org.hyperledger.besu.evm.frame.MessageFrame;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -114,7 +113,7 @@ class GasCalculatorHederaUtilTest {
 		given(usagePricesProvider.defaultPricesGiven(functionality, timestamp)).willReturn(feeData);
 		given(hbarCentExchange.rate(timestamp)).willReturn(ExchangeRate.newBuilder().setHbarEquiv(2000).setCentEquiv(200).build());
 
-		assertEquals(Gas.of(28), GasCalculatorHederaUtil.logOperationGasCost(usagePricesProvider, hbarCentExchange, messageFrame, 1000000, 1L, 2L, 3));
+		assertEquals(28L, GasCalculatorHederaUtil.logOperationGasCost(usagePricesProvider, hbarCentExchange, messageFrame, 1000000, 1L, 2L, 3));
 		verify(messageFrame).getGasPrice();
 		verify(messageFrame).getBlockValues();
 		verify(messageFrame).getContextVariable("HederaFunctionality");

--- a/hedera-node/src/test/java/com/hedera/services/contracts/gascalculator/GasCalculatorHederaV18Test.java
+++ b/hedera-node/src/test/java/com/hedera/services/contracts/gascalculator/GasCalculatorHederaV18Test.java
@@ -30,7 +30,6 @@ import com.hedera.services.state.merkle.MerkleNetworkContext;
 import com.hederahashgraph.api.proto.java.*;
 import org.apache.tuweni.bytes.Bytes;
 import org.hyperledger.besu.datatypes.Wei;
-import org.hyperledger.besu.evm.Gas;
 import org.hyperledger.besu.evm.account.Account;
 import org.hyperledger.besu.evm.frame.MessageFrame;
 import org.junit.jupiter.api.BeforeEach;
@@ -90,7 +89,7 @@ class GasCalculatorHederaV18Test {
 		given(usagePricesProvider.defaultPricesGiven(functionality, timestamp)).willReturn(feeData);
 		given(hbarCentExchange.rate(timestamp)).willReturn(ExchangeRate.newBuilder().setHbarEquiv(2000).setCentEquiv(200).build());
 		given(properties.cacheRecordsTtl()).willReturn(1000000);
-		assertEquals(Gas.of(28), gasCalculatorHedera.logOperationGasCost(messageFrame, 1L, 2L, 3));
+		assertEquals(28L, gasCalculatorHedera.logOperationGasCost(messageFrame, 1L, 2L, 3));
 		verify(messageFrame).getGasPrice();
 		verify(messageFrame).getBlockValues();
 		verify(messageFrame).getContextVariable("HederaFunctionality");
@@ -101,52 +100,52 @@ class GasCalculatorHederaV18Test {
 
 	@Test
 	void assertCodeDepositGasCostIsZero() {
-		assertEquals(Gas.ZERO, gasCalculatorHedera.codeDepositGasCost(10));
+		assertEquals(0L, gasCalculatorHedera.codeDepositGasCost(10));
 	}
 
 	@Test
 	void assertTransactionIntrinsicGasCost() {
-		assertEquals(Gas.ZERO, gasCalculatorHedera.transactionIntrinsicGasCost(Bytes.EMPTY, true));
+		assertEquals(0L, gasCalculatorHedera.transactionIntrinsicGasCost(Bytes.EMPTY, true));
 	}
 
 	@Test
 	void assertGetBalanceOperationGasCost() {
-		assertEquals(Gas.of(20L), gasCalculatorHedera.getBalanceOperationGasCost());
+		assertEquals(20L, gasCalculatorHedera.getBalanceOperationGasCost());
 	}
 
 	@Test
 	void assertExpOperationByteGasCost() {
-		assertEquals(Gas.of(10L), gasCalculatorHedera.expOperationByteGasCost());
+		assertEquals(10L, gasCalculatorHedera.expOperationByteGasCost());
 	}
 
 	@Test
 	void assertExtCodeBaseGasCost() {
-		assertEquals(Gas.of(20L), gasCalculatorHedera.extCodeBaseGasCost());
+		assertEquals(20L, gasCalculatorHedera.extCodeBaseGasCost());
 	}
 
 	@Test
 	void assertCallOperationBaseGasCost() {
-		assertEquals(Gas.of(40L), gasCalculatorHedera.callOperationBaseGasCost());
+		assertEquals(40L, gasCalculatorHedera.callOperationBaseGasCost());
 	}
 
 	@Test
 	void assertGetExtCodeSizeOperationGasCost() {
-		assertEquals(Gas.of(20L), gasCalculatorHedera.getExtCodeSizeOperationGasCost());
+		assertEquals(20L, gasCalculatorHedera.getExtCodeSizeOperationGasCost());
 	}
 
 	@Test
 	void assertExtCodeHashOperationGasCost() {
-		assertEquals(Gas.of(400L), gasCalculatorHedera.extCodeHashOperationGasCost());
+		assertEquals(400L, gasCalculatorHedera.extCodeHashOperationGasCost());
 	}
 
 	@Test
 	void assertSelfDestructOperationGasCost() {
 		Account recipient = mock(Account.class);
-		assertEquals(Gas.of(0), gasCalculatorHedera.selfDestructOperationGasCost(recipient, Wei.of(10L)));
+		assertEquals(0L, gasCalculatorHedera.selfDestructOperationGasCost(recipient, Wei.of(10L)));
 	}
 
 	@Test
 	void assertGetSloadOperationGasCost() {
-		assertEquals(Gas.of(50L), gasCalculatorHedera.getSloadOperationGasCost());
+		assertEquals(50L, gasCalculatorHedera.getSloadOperationGasCost());
 	}
 }

--- a/hedera-node/src/test/java/com/hedera/services/contracts/gascalculator/GasCalculatorHederaV19Test.java
+++ b/hedera-node/src/test/java/com/hedera/services/contracts/gascalculator/GasCalculatorHederaV19Test.java
@@ -30,7 +30,6 @@ import com.hedera.services.state.merkle.MerkleNetworkContext;
 import com.hederahashgraph.api.proto.java.*;
 import org.apache.tuweni.bytes.Bytes;
 import org.hyperledger.besu.datatypes.Wei;
-import org.hyperledger.besu.evm.Gas;
 import org.hyperledger.besu.evm.frame.MessageFrame;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -67,12 +66,12 @@ class GasCalculatorHederaV19Test {
 
     @Test
     void gasDepositCost() {
-        assertEquals(Gas.ZERO, subject.codeDepositGasCost(1));
+        assertEquals(0L, subject.codeDepositGasCost(1));
     }
 
     @Test
     void transactionIntrinsicGasCost() {
-        assertEquals(Gas.ZERO, subject.transactionIntrinsicGasCost(Bytes.of(1, 2, 3), true));
+        assertEquals(0L, subject.transactionIntrinsicGasCost(Bytes.of(1, 2, 3), true));
     }
 
     @Test
@@ -97,7 +96,7 @@ class GasCalculatorHederaV19Test {
         given(usagePricesProvider.defaultPricesGiven(functionality, timestamp)).willReturn(feeData);
         given(hbarCentExchange.rate(timestamp)).willReturn(ExchangeRate.newBuilder().setHbarEquiv(2000).setCentEquiv(200).build());
 
-        assertEquals(Gas.of(1516), subject.logOperationGasCost(messageFrame, 1L, 2L, 3));
+        assertEquals(1516L, subject.logOperationGasCost(messageFrame, 1L, 2L, 3));
         verify(messageFrame).getGasPrice();
         verify(messageFrame).getBlockValues();
         verify(messageFrame).getContextVariable("HederaFunctionality");

--- a/hedera-node/src/test/java/com/hedera/services/contracts/gascalculator/GasCalculatorHederaV22Test.java
+++ b/hedera-node/src/test/java/com/hedera/services/contracts/gascalculator/GasCalculatorHederaV22Test.java
@@ -26,7 +26,6 @@ import com.hedera.services.context.properties.GlobalDynamicProperties;
 import com.hedera.services.fees.HbarCentExchange;
 import com.hedera.services.fees.calculation.UsagePricesProvider;
 import org.apache.tuweni.bytes.Bytes;
-import org.hyperledger.besu.evm.Gas;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -55,22 +54,20 @@ class GasCalculatorHederaV22Test {
 
     @Test
     void gasDepositCost() {
-//        assertEquals(Gas.of(200 * 37), subject.codeDepositGasCost(37));
-        assertEquals(Gas.ZERO, subject.codeDepositGasCost(37));
+//        assertEquals(200 * 37, subject.codeDepositGasCost(37));
+        assertEquals(0L, subject.codeDepositGasCost(37));
     }
 
     @Test
     void transactionIntrinsicGasCost() {
-        assertEquals(Gas.of(
-                4 * 2 +  // zero byte cost
-                16 * 3 +  // non-zero byte cost
-                21_000L   // base TX cost
-        ), subject.transactionIntrinsicGasCost(Bytes.of(0, 1, 2, 3, 0), false));
-        assertEquals(Gas.of(
-                4 * 3 +  // zero byte cost
-                16 * 2 +  // non-zero byte cost
-                21_000L + // base TX cost
-                32_000L   // contract creation base cost
-        ), subject.transactionIntrinsicGasCost(Bytes.of(0, 1, 0, 3, 0), true));
+        assertEquals(4 * 2 +  // zero byte cost
+                     16 * 3 +  // non-zero byte cost
+                     21_000L,   // base TX cost
+                subject.transactionIntrinsicGasCost(Bytes.of(0, 1, 2, 3, 0), false));
+        assertEquals(4 * 3 +  // zero byte cost
+                     16 * 2 +  // non-zero byte cost
+                     21_000L + // base TX cost
+                     32_000L,   // contract creation base cost
+                subject.transactionIntrinsicGasCost(Bytes.of(0, 1, 0, 3, 0), true));
     }
 }

--- a/hedera-node/src/test/java/com/hedera/services/contracts/gascalculator/StorageGasCalculatorTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/contracts/gascalculator/StorageGasCalculatorTest.java
@@ -23,7 +23,6 @@ package com.hedera.services.contracts.gascalculator;
 import com.hedera.services.txns.contract.helpers.StorageExpiry;
 import org.apache.tuweni.bytes.Bytes;
 import org.hyperledger.besu.datatypes.Wei;
-import org.hyperledger.besu.evm.Gas;
 import org.hyperledger.besu.evm.frame.BlockValues;
 import org.hyperledger.besu.evm.frame.MessageFrame;
 import org.hyperledger.besu.evm.gascalculator.GasCalculator;
@@ -62,7 +61,7 @@ class StorageGasCalculatorTest {
 		given(gasCalculator.memoryExpansionGasCost(frame, 10L, 20L))
 				.willReturn(memExpansionCost);
 
-		final var expected = Gas.of(storageCostTinybars / gasPrice.toLong()).plus(memExpansionCost);
+		final var expected = (storageCostTinybars / gasPrice.toLong()) + memExpansionCost;
 		final var actual = subject.creationGasCost(frame, gasCalculator);
 
 		assertEquals(expected, actual);
@@ -75,7 +74,7 @@ class StorageGasCalculatorTest {
 				.willReturn(memExpansionCost);
 		given(oracle.storageExpiryIn(frame)).willReturn(now - 1);
 
-		final var expected = Gas.of(0L).plus(memExpansionCost);
+		final var expected = memExpansionCost;
 		final var actual = subject.creationGasCost(frame, gasCalculator);
 
 		assertEquals(expected, actual);
@@ -97,7 +96,7 @@ class StorageGasCalculatorTest {
 	}
 
 	private static final Wei gasPrice = Wei.of(42);
-	private static final Gas memExpansionCost = Gas.of(1000);
+	private static final long memExpansionCost = 1000L;
 	private static final long sbh = 12;
 	private static final long now = 1_234_567L;
 	private static final long lifetimeSecs = 7776000L;

--- a/hedera-node/src/test/java/com/hedera/services/contracts/operation/HederaCallCodeOperationTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/contracts/operation/HederaCallCodeOperationTest.java
@@ -28,7 +28,6 @@ import org.apache.tuweni.bytes.Bytes;
 import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.datatypes.Wei;
 import org.hyperledger.besu.evm.EVM;
-import org.hyperledger.besu.evm.Gas;
 import org.hyperledger.besu.evm.account.Account;
 import org.hyperledger.besu.evm.frame.MessageFrame;
 import org.hyperledger.besu.evm.gascalculator.GasCalculator;
@@ -46,6 +45,7 @@ import java.util.function.BiPredicate;
 
 import static com.hedera.services.contracts.operation.CommonCallSetup.commonSetup;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -65,16 +65,14 @@ class HederaCallCodeOperationTest {
 	@Mock
 	private Account acc;
 	@Mock
-	private Address accountAddr;
-	@Mock
-	private Gas cost;
-	@Mock
 	private EvmSigsVerifier sigsVerifier;
 	@Mock
 	private BiPredicate<Address, MessageFrame> addressValidator;
 	@Mock
 	private Map<String, PrecompiledContract> precompiledContractMap;
 
+	private final long cost = 100L;
+	
 	private HederaCallCodeOperation subject;
 
 	@BeforeEach
@@ -87,7 +85,7 @@ class HederaCallCodeOperationTest {
 	void haltWithInvalidAddr() {
 		given(worldUpdater.get(any())).willReturn(null);
 		given(calc.callOperationGasCost(
-				any(), any(), anyLong(),
+				any(), anyLong(), anyLong(),
 				anyLong(), anyLong(), anyLong(),
 				any(), any(), any())
 		).willReturn(cost);
@@ -103,13 +101,14 @@ class HederaCallCodeOperationTest {
 		var opRes = subject.execute(evmMsgFrame, evm);
 
 		assertEquals(opRes.getHaltReason(), Optional.of(HederaExceptionalHaltReason.INVALID_SOLIDITY_ADDRESS));
-		assertEquals(opRes.getGasCost().get(), cost);
+		assertTrue(opRes.getGasCost().isPresent());
+		assertEquals(opRes.getGasCost().getAsLong(), cost);
 	}
 
 	@Test
 	void executesAsExpected() {
 		given(calc.callOperationGasCost(
-				any(), any(), anyLong(),
+				any(), anyLong(), anyLong(),
 				anyLong(), anyLong(), anyLong(),
 				any(), any(), any())
 		).willReturn(cost);
@@ -129,25 +128,26 @@ class HederaCallCodeOperationTest {
 		given(evmMsgFrame.getRecipientAddress()).willReturn(Address.ALTBN128_ADD);
 		given(worldUpdater.get(any())).willReturn(acc);
 		given(acc.getBalance()).willReturn(Wei.of(100));
-		given(calc.gasAvailableForChildCall(any(), any(), anyBoolean())).willReturn(Gas.of(10));
-		given(acc.getAddress()).willReturn(accountAddr);
+		given(calc.gasAvailableForChildCall(any(), anyLong(), anyBoolean())).willReturn(10L);
+		given(acc.getAddress()).willReturn(Address.ZERO);
 		given(sigsVerifier.hasActiveKeyOrNoReceiverSigReq(Mockito.anyBoolean(), any(), any(), any())).willReturn(true);
 		given(addressValidator.test(any(), any())).willReturn(true);
 
 		var opRes = subject.execute(evmMsgFrame, evm);
 		assertEquals(Optional.empty(), opRes.getHaltReason());
-		assertEquals(opRes.getGasCost().get(), cost);
+		assertTrue(opRes.getGasCost().isPresent());
+		assertEquals(opRes.getGasCost().getAsLong(), cost);
 	}
 
 	@Test
 	void executeHaltsWithInvalidSignature() {
 		given(calc.callOperationGasCost(
-				any(), any(), anyLong(),
+				any(), anyLong(), anyLong(),
 				anyLong(), anyLong(), anyLong(),
 				any(), any(), any())
 		).willReturn(cost);
 		given(calc.callOperationGasCost(
-				any(), any(), anyLong(),
+				any(), anyLong(), anyLong(),
 				anyLong(), anyLong(), anyLong(),
 				any(), any(), any())
 		).willReturn(cost);
@@ -161,7 +161,7 @@ class HederaCallCodeOperationTest {
 		given(evmMsgFrame.getStackItem(6)).willReturn(Bytes.EMPTY);
 		// and:
 		given(worldUpdater.get(any())).willReturn(acc);
-		given(acc.getAddress()).willReturn(accountAddr);
+		given(acc.getAddress()).willReturn(Address.ZERO);
 		given(sigsVerifier.hasActiveKeyOrNoReceiverSigReq(Mockito.anyBoolean(), any(), any(), any())).willReturn(false);
 		given(addressValidator.test(any(), any())).willReturn(true);
 
@@ -170,6 +170,7 @@ class HederaCallCodeOperationTest {
 
 		var opRes = subject.execute(evmMsgFrame, evm);
 		assertEquals(Optional.of(HederaExceptionalHaltReason.INVALID_SIGNATURE), opRes.getHaltReason());
-		assertEquals(opRes.getGasCost().get(), cost);
+		assertTrue(opRes.getGasCost().isPresent());
+		assertEquals(opRes.getGasCost().getAsLong(), cost);
 	}
 }

--- a/hedera-node/src/test/java/com/hedera/services/contracts/operation/HederaCallOperationTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/contracts/operation/HederaCallOperationTest.java
@@ -28,7 +28,6 @@ import org.apache.tuweni.bytes.Bytes;
 import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.datatypes.Wei;
 import org.hyperledger.besu.evm.EVM;
-import org.hyperledger.besu.evm.Gas;
 import org.hyperledger.besu.evm.account.Account;
 import org.hyperledger.besu.evm.frame.MessageFrame;
 import org.hyperledger.besu.evm.gascalculator.GasCalculator;
@@ -46,6 +45,7 @@ import java.util.function.BiPredicate;
 
 import static com.hedera.services.contracts.operation.CommonCallSetup.commonSetup;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -64,16 +64,13 @@ class HederaCallOperationTest {
 	@Mock
 	private Account acc;
 	@Mock
-	private Address accountAddr;
-	@Mock
-	private Gas cost;
-	@Mock
 	private EvmSigsVerifier sigsVerifier;
 	@Mock
 	private BiPredicate<Address, MessageFrame> addressValidator;
 	@Mock
 	private Map<String, PrecompiledContract> precompiledContractMap;
 
+	private final long cost = 100L;
 	private HederaCallOperation subject;
 
 	@BeforeEach
@@ -86,7 +83,7 @@ class HederaCallOperationTest {
 		commonSetup(evmMsgFrame, worldUpdater, acc);
 		given(worldUpdater.get(any())).willReturn(null);
 		given(calc.callOperationGasCost(
-				any(), any(), anyLong(),
+				any(), anyLong(), anyLong(),
 				anyLong(), anyLong(), anyLong(),
 				any(), any(), any())
 		).willReturn(cost);
@@ -102,14 +99,15 @@ class HederaCallOperationTest {
 		var opRes = subject.execute(evmMsgFrame, evm);
 
 		assertEquals(opRes.getHaltReason(), Optional.of(HederaExceptionalHaltReason.INVALID_SOLIDITY_ADDRESS));
-		assertEquals(opRes.getGasCost().get(), cost);
+		assertTrue(opRes.getGasCost().isPresent());
+		assertEquals(opRes.getGasCost().getAsLong(), cost);
 	}
 
 	@Test
 	void executesAsExpected() {
 		commonSetup(evmMsgFrame, worldUpdater, acc);
 		given(calc.callOperationGasCost(
-				any(), any(), anyLong(),
+				any(), anyLong(), anyLong(),
 				anyLong(), anyLong(), anyLong(),
 				any(), any(), any())
 		).willReturn(cost);
@@ -131,14 +129,15 @@ class HederaCallOperationTest {
 
 		given(worldUpdater.get(any())).willReturn(acc);
 		given(acc.getBalance()).willReturn(Wei.of(100));
-		given(calc.gasAvailableForChildCall(any(), any(), anyBoolean())).willReturn(Gas.of(10));
-		given(acc.getAddress()).willReturn(accountAddr);
+		given(calc.gasAvailableForChildCall(any(), anyLong(), anyBoolean())).willReturn(10L);
+		given(acc.getAddress()).willReturn(Address.ZERO);
 		given(sigsVerifier.hasActiveKeyOrNoReceiverSigReq(Mockito.anyBoolean(), any(), any(), any())).willReturn(true);
 		given(addressValidator.test(any(), any())).willReturn(true);
 
 		var opRes = subject.execute(evmMsgFrame, evm);
 		assertEquals(Optional.empty(), opRes.getHaltReason());
-		assertEquals(opRes.getGasCost().get(), cost);
+		assertTrue(opRes.getGasCost().isPresent());
+		assertEquals(opRes.getGasCost().getAsLong(), cost);
 
 		given(sigsVerifier.hasActiveKeyOrNoReceiverSigReq(Mockito.anyBoolean(), any(),  any(), any())).willReturn(false);
 		var invalidSignaturesRes = subject.execute(evmMsgFrame, evm);

--- a/hedera-node/src/test/java/com/hedera/services/contracts/operation/HederaCreate2OperationTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/contracts/operation/HederaCreate2OperationTest.java
@@ -29,7 +29,6 @@ import com.hedera.services.store.contracts.precompile.SyntheticTxnFactory;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.MutableBytes;
 import org.hyperledger.besu.datatypes.Address;
-import org.hyperledger.besu.evm.Gas;
 import org.hyperledger.besu.evm.frame.MessageFrame;
 import org.hyperledger.besu.evm.gascalculator.GasCalculator;
 import org.hyperledger.besu.evm.operation.Create2Operation;
@@ -46,12 +45,13 @@ import static org.mockito.BDDMockito.given;
 
 @ExtendWith(MockitoExtension.class)
 class HederaCreate2OperationTest {
-	private static final Gas baseGas = Gas.of(100);
-	private static final Gas extraGas = Gas.of(101);
+	private static final long baseGas = 100L;
+	private static final long extraGas = 101L;
 	private static final Bytes salt = Bytes.fromHexString("0x2a");
 	private static final Bytes oneOffsetStackItem = Bytes.of(10);
 	private static final Bytes twoOffsetStackItem = Bytes.of(20);
 	private static final MutableBytes initcode = MutableBytes.of((byte) 0xaa);
+	private Address recipientAddr = Address.fromHexString("0x0102030405060708090a0b0c0d0e0f1011121314");
 
 	@Mock
 	private GlobalDynamicProperties dynamicProperties;
@@ -61,8 +61,6 @@ class HederaCreate2OperationTest {
 	private GasCalculator gasCalculator;
 	@Mock
 	private HederaStackedWorldStateUpdater stackedUpdater;
-	@Mock
-	private Address recipientAddr;
 	@Mock
 	private SyntheticTxnFactory syntheticTxnFactory;
 	@Mock
@@ -87,7 +85,7 @@ class HederaCreate2OperationTest {
 
 		var actualGas = subject.cost(frame);
 
-		assertEquals(baseGas.plus(extraGas), actualGas);
+		assertEquals(baseGas + extraGas, actualGas);
 	}
 
 	@Test

--- a/hedera-node/src/test/java/com/hedera/services/contracts/operation/HederaCreateOperationTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/contracts/operation/HederaCreateOperationTest.java
@@ -29,7 +29,6 @@ import com.hedera.services.state.EntityCreator;
 import com.hedera.services.store.contracts.HederaWorldUpdater;
 import com.hedera.services.store.contracts.precompile.SyntheticTxnFactory;
 import org.hyperledger.besu.datatypes.Address;
-import org.hyperledger.besu.evm.Gas;
 import org.hyperledger.besu.evm.frame.MessageFrame;
 import org.hyperledger.besu.evm.gascalculator.GasCalculator;
 import org.junit.jupiter.api.Assertions;
@@ -44,8 +43,10 @@ import static org.mockito.BDDMockito.given;
 
 @ExtendWith(MockitoExtension.class)
 class HederaCreateOperationTest {
-	private static final Gas baseGas = Gas.of(100);
-	private static final Gas extraGas = Gas.of(101);
+	private static final long baseGas = 100L;
+	private static final long extraGas = 101L;
+	
+	private final Address recipientAddr = Address.fromHexString("0x0102030405060708090a0b0c0d0e0f1011121314");
 
 	@Mock
 	private MessageFrame frame;
@@ -53,8 +54,6 @@ class HederaCreateOperationTest {
 	private GasCalculator gasCalculator;
 	@Mock
 	private HederaWorldUpdater hederaWorldUpdater;
-	@Mock
-	private Address recipientAddr;
 	@Mock
 	private SyntheticTxnFactory syntheticTxnFactory;
 	@Mock
@@ -84,7 +83,7 @@ class HederaCreateOperationTest {
 
 		var actualGas = subject.cost(frame);
 
-		assertEquals(baseGas.plus(extraGas), actualGas);
+		assertEquals(baseGas + extraGas, actualGas);
 	}
 
 	@Test

--- a/hedera-node/src/test/java/com/hedera/services/contracts/operation/HederaExtCodeCopyOperationTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/contracts/operation/HederaExtCodeCopyOperationTest.java
@@ -24,7 +24,6 @@ import org.apache.tuweni.bytes.Bytes;
 import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.datatypes.Wei;
 import org.hyperledger.besu.evm.EVM;
-import org.hyperledger.besu.evm.Gas;
 import org.hyperledger.besu.evm.account.Account;
 import org.hyperledger.besu.evm.fluent.SimpleAccount;
 import org.hyperledger.besu.evm.frame.MessageFrame;
@@ -37,6 +36,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Optional;
+import java.util.OptionalLong;
 import java.util.function.BiPredicate;
 
 import static org.hyperledger.besu.evm.internal.Words.clampedToLong;
@@ -67,9 +67,9 @@ class HederaExtCodeCopyOperationTest {
 	final private Address ETH_ADDRESS_INSTANCE = Address.fromHexString(ETH_ADDRESS);
 	final private Bytes MEM_OFFSET = Bytes.of(5);
 	final private Bytes NUM_BYTES = Bytes.of(10);
-	final private Gas OPERATION_COST = Gas.of(1_000L);
-	final private Gas WARM_READ_COST = Gas.of(100L);
-	final private Gas ACTUAL_COST = OPERATION_COST.plus(WARM_READ_COST);
+	final private long OPERATION_COST = 1_000L;
+	final private long WARM_READ_COST = 100L;
+	final private long ACTUAL_COST = OPERATION_COST + WARM_READ_COST;
 	final private Account account = new SimpleAccount(ETH_ADDRESS_INSTANCE, 0, Wei.ONE);
 
 	@BeforeEach
@@ -92,7 +92,7 @@ class HederaExtCodeCopyOperationTest {
 
 		// then:
 		assertEquals(Optional.of(HederaExceptionalHaltReason.INVALID_SOLIDITY_ADDRESS), opResult.getHaltReason());
-		assertEquals(Optional.of(ACTUAL_COST), opResult.getGasCost());
+		assertEquals(OptionalLong.of(ACTUAL_COST), opResult.getGasCost());
 	}
 
 	@Test
@@ -113,7 +113,7 @@ class HederaExtCodeCopyOperationTest {
 				.willReturn(MEM_OFFSET)
 				.willReturn(NUM_BYTES);
 		given(mf.warmUpAddress(ETH_ADDRESS_INSTANCE)).willReturn(true);
-		given(mf.getRemainingGas()).willReturn(Gas.of(2000));
+		given(mf.getRemainingGas()).willReturn(2000L);
 		given(mf.getWorldUpdater()).willReturn(worldUpdater);
 		// and:
 		given(gasCalculator.extCodeCopyOperationGasCost(mf, clampedToLong(MEM_OFFSET), clampedToLong(NUM_BYTES))).willReturn(OPERATION_COST);
@@ -125,6 +125,6 @@ class HederaExtCodeCopyOperationTest {
 
 		// then:
 		assertEquals(Optional.empty(), opResult.getHaltReason());
-		assertEquals(Optional.of(ACTUAL_COST), opResult.getGasCost());
+		assertEquals(OptionalLong.of(ACTUAL_COST), opResult.getGasCost());
 	}
 }

--- a/hedera-node/src/test/java/com/hedera/services/contracts/operation/HederaExtCodeSizeOperationTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/contracts/operation/HederaExtCodeSizeOperationTest.java
@@ -23,7 +23,6 @@ package com.hedera.services.contracts.operation;
 import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.datatypes.Wei;
 import org.hyperledger.besu.evm.EVM;
-import org.hyperledger.besu.evm.Gas;
 import org.hyperledger.besu.evm.account.Account;
 import org.hyperledger.besu.evm.fluent.SimpleAccount;
 import org.hyperledger.besu.evm.frame.MessageFrame;
@@ -37,6 +36,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Optional;
+import java.util.OptionalLong;
 import java.util.function.BiPredicate;
 
 import static org.hyperledger.besu.evm.frame.ExceptionalHaltReason.INSUFFICIENT_STACK_ITEMS;
@@ -62,18 +62,14 @@ class HederaExtCodeSizeOperationTest {
 	@Mock
 	EVM evm;
 	@Mock
-	private Account acc;
-	@Mock
-	private Address accountAddr;
-	@Mock
 	private BiPredicate<Address, MessageFrame> addressValidator;
 
 	HederaExtCodeSizeOperation subject;
 
 	@BeforeEach
 	void setUp() {
-		given(gasCalculator.getExtCodeSizeOperationGasCost()).willReturn(Gas.of(10L));
-		given(gasCalculator.getWarmStorageReadCost()).willReturn(Gas.of(2L));
+		given(gasCalculator.getExtCodeSizeOperationGasCost()).willReturn(10L);
+		given(gasCalculator.getWarmStorageReadCost()).willReturn(2L);
 
 		subject = new HederaExtCodeSizeOperation(gasCalculator, addressValidator);
 	}
@@ -86,7 +82,7 @@ class HederaExtCodeSizeOperationTest {
 		var opResult = subject.execute(mf, evm);
 
 		assertEquals(Optional.of(HederaExceptionalHaltReason.INVALID_SOLIDITY_ADDRESS), opResult.getHaltReason());
-		assertEquals(Optional.of(Gas.of(12L)), opResult.getGasCost());
+		assertEquals(OptionalLong.of(12L), opResult.getGasCost());
 	}
 
 	@Test
@@ -96,7 +92,7 @@ class HederaExtCodeSizeOperationTest {
 		var opResult = subject.execute(mf, evm);
 
 		assertEquals(Optional.of(INSUFFICIENT_STACK_ITEMS), opResult.getHaltReason());
-		assertEquals(Optional.of(Gas.of(12L)), opResult.getGasCost());
+		assertEquals(OptionalLong.of(12L), opResult.getGasCost());
 	}
 
 	@Test
@@ -109,7 +105,7 @@ class HederaExtCodeSizeOperationTest {
 		// and:
 		given(mf.popStackItem()).willReturn(ethAddressInstance);
 		given(mf.warmUpAddress(ethAddressInstance)).willReturn(true);
-		given(mf.getRemainingGas()).willReturn(Gas.of(100));
+		given(mf.getRemainingGas()).willReturn(100L);
 		given(addressValidator.test(any(), any())).willReturn(true);
 
 		// when:
@@ -117,6 +113,6 @@ class HederaExtCodeSizeOperationTest {
 
 		// then:
 		assertEquals(Optional.empty(), opResult.getHaltReason());
-		assertEquals(Optional.of(Gas.of(12L)), opResult.getGasCost());
+		assertEquals(OptionalLong.of(12L), opResult.getGasCost());
 	}
 }

--- a/hedera-node/src/test/java/com/hedera/services/contracts/operation/HederaLogOperationTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/contracts/operation/HederaLogOperationTest.java
@@ -32,7 +32,6 @@ import org.apache.tuweni.bytes.Bytes32;
 import org.hamcrest.Matchers;
 import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.evm.EVM;
-import org.hyperledger.besu.evm.Gas;
 import org.hyperledger.besu.evm.frame.MessageFrame;
 import org.hyperledger.besu.evm.gascalculator.GasCalculator;
 import org.hyperledger.besu.evm.log.Log;
@@ -47,6 +46,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.OptionalLong;
 
 import static com.swirlds.common.utility.CommonUtils.unhex;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -61,7 +61,7 @@ import static org.mockito.Mockito.verify;
 @ExtendWith({ LogCaptureExtension.class, MockitoExtension.class })
 class HederaLogOperationTest {
 	private static final int numTopics = 2;
-	private static final Gas reqGas = Gas.of(1234);
+	private static final long reqGas = 1234L;
 	private static final long numBytes = 12L;
 	private static final long dataLocation = 13L;
 	private static final Bytes firstLogTopic = Bytes.fromHexString("0xee");
@@ -73,11 +73,11 @@ class HederaLogOperationTest {
 	private static final Address unknownAddress = EntityNum.MISSING_NUM.toEvmAddress();
 	private static final Bytes data = Bytes.fromHexString("0xabcdef");
 	private static final Operation.OperationResult insufficientGasResult =
-			new Operation.OperationResult(Optional.of(reqGas), Optional.of(INSUFFICIENT_GAS));
+			new Operation.OperationResult(OptionalLong.of(reqGas), Optional.of(INSUFFICIENT_GAS));
 	private static final Operation.OperationResult illegalStateChangeResult =
-			new Operation.OperationResult(Optional.of(reqGas), Optional.of(ILLEGAL_STATE_CHANGE));
+			new Operation.OperationResult(OptionalLong.of(reqGas), Optional.of(ILLEGAL_STATE_CHANGE));
 	private static final Operation.OperationResult goodResult =
-			new Operation.OperationResult(Optional.of(reqGas), Optional.empty());
+			new Operation.OperationResult(OptionalLong.of(reqGas), Optional.empty());
 
 	@Mock
 	private GasCalculator gasCalculator;
@@ -119,7 +119,7 @@ class HederaLogOperationTest {
 
 	@Test
 	void failsOnInsufficientGas() {
-		final var insufficientGas = reqGas.minus(Gas.of(1));
+		final var insufficientGas = reqGas - 1L;
 		given(frame.popStackItem())
 				.willReturn(Bytes.ofUnsignedLong(dataLocation))
 				.willReturn(Bytes.ofUnsignedLong(numBytes));
@@ -143,7 +143,7 @@ class HederaLogOperationTest {
 		given(aliases.isMirror(mirrorAddress)).willReturn(true);
 		given(aliases.resolveForEvm(nonMirrorAddress)).willReturn(mirrorAddress);
 
-		final var adequateGas = reqGas.plus(Gas.of(1));
+		final var adequateGas = reqGas + 1L;
 		given(frame.popStackItem())
 				.willReturn(Bytes.ofUnsignedLong(dataLocation))
 				.willReturn(Bytes.ofUnsignedLong(numBytes))
@@ -173,7 +173,7 @@ class HederaLogOperationTest {
 		given(updater.aliases()).willReturn(aliases);
 		given(aliases.resolveForEvm(nonMirrorAddress)).willReturn(nonMirrorAddress);
 
-		final var adequateGas = reqGas.plus(Gas.of(1));
+		final var adequateGas = reqGas + 1L;
 		given(frame.popStackItem())
 				.willReturn(Bytes.ofUnsignedLong(dataLocation))
 				.willReturn(Bytes.ofUnsignedLong(numBytes))

--- a/hedera-node/src/test/java/com/hedera/services/contracts/operation/HederaSLoadOperationTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/contracts/operation/HederaSLoadOperationTest.java
@@ -26,7 +26,6 @@ import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.units.bigints.UInt256;
 import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.evm.EVM;
-import org.hyperledger.besu.evm.Gas;
 import org.hyperledger.besu.evm.account.EvmAccount;
 import org.hyperledger.besu.evm.frame.ExceptionalHaltReason;
 import org.hyperledger.besu.evm.frame.MessageFrame;
@@ -41,10 +40,12 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.ArrayDeque;
 import java.util.Optional;
+import java.util.OptionalLong;
 
 import static org.hyperledger.besu.evm.frame.ExceptionalHaltReason.INSUFFICIENT_STACK_ITEMS;
 import static org.hyperledger.besu.evm.frame.ExceptionalHaltReason.TOO_MANY_STACK_ITEMS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.BDDMockito.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doThrow;
@@ -70,11 +71,8 @@ class HederaSLoadOperationTest {
 	@Mock
 	EvmAccount evmAccount;
 
-	@Mock
-	Bytes keyBytesMock;
-
-	@Mock
-	Bytes valueBytesMock;
+	final Bytes keyBytesMock = Bytes.of(1,2,3,4);
+	final Bytes valueBytesMock = Bytes.of(4,3,2,1);
 
 	@Mock
 	private GlobalDynamicProperties dynamicProperties;
@@ -89,7 +87,7 @@ class HederaSLoadOperationTest {
 	void executesProperlyWithColdSuccess() {
 		givenAdditionalContext(keyBytesMock, valueBytesMock);
 		given(messageFrame.warmUpStorage(any(), any())).willReturn(true);
-		given(messageFrame.getRemainingGas()).willReturn(Gas.of(300));
+		given(messageFrame.getRemainingGas()).willReturn(300L);
 		given(messageFrame.warmUpStorage(any(), any())).willReturn(false);
 		given(dynamicProperties.shouldEnableTraceability()).willReturn(true);
 
@@ -99,7 +97,7 @@ class HederaSLoadOperationTest {
 		given(messageFrame.getMessageFrameStack()).willReturn(frameStack);
 		final var coldResult = subject.execute(messageFrame, evm);
 
-		final var expectedColdResult = new Operation.OperationResult(Optional.of(Gas.of(20L)), Optional.empty());
+		final var expectedColdResult = new Operation.OperationResult(OptionalLong.of(20L), Optional.empty());
 
 		assertEquals(expectedColdResult.getGasCost(), coldResult.getGasCost());
 		assertEquals(expectedColdResult.getHaltReason(), coldResult.getHaltReason());
@@ -112,7 +110,7 @@ class HederaSLoadOperationTest {
 	void executesProperlyWithWarmSuccess() {
 		givenAdditionalContext(keyBytesMock, valueBytesMock);
 		given(messageFrame.warmUpStorage(any(), any())).willReturn(true);
-		given(messageFrame.getRemainingGas()).willReturn(Gas.of(300));
+		given(messageFrame.getRemainingGas()).willReturn(300L);
 		given(dynamicProperties.shouldEnableTraceability()).willReturn(true);
 		var frameStack = new ArrayDeque<MessageFrame>();
 		frameStack.add(messageFrame);
@@ -120,7 +118,7 @@ class HederaSLoadOperationTest {
 		given(messageFrame.getMessageFrameStack()).willReturn(frameStack);
 		final var warmResult = subject.execute(messageFrame, evm);
 
-		final var expectedWarmResult = new Operation.OperationResult(Optional.of(Gas.of(30L)), Optional.empty());
+		final var expectedWarmResult = new Operation.OperationResult(OptionalLong.of(30L), Optional.empty());
 
 		assertEquals(expectedWarmResult.getGasCost(), warmResult.getGasCost());
 		assertEquals(expectedWarmResult.getHaltReason(), warmResult.getHaltReason());
@@ -133,10 +131,10 @@ class HederaSLoadOperationTest {
 	void executeHaltsForInsufficientGas() {
 		givenAdditionalContext(keyBytesMock, valueBytesMock);
 		given(messageFrame.warmUpStorage(any(), any())).willReturn(true);
-		given(messageFrame.getRemainingGas()).willReturn(Gas.of(300));
-		given(messageFrame.getRemainingGas()).willReturn(Gas.of(0));
+		given(messageFrame.getRemainingGas()).willReturn(300L);
+		given(messageFrame.getRemainingGas()).willReturn(0L);
 
-		final var expectedHaltResult = new Operation.OperationResult(Optional.of(Gas.of(30L)),
+		final var expectedHaltResult = new Operation.OperationResult(OptionalLong.of(30L),
 				Optional.of(ExceptionalHaltReason.INSUFFICIENT_GAS));
 
 		final var haltResult = subject.execute(messageFrame, evm);
@@ -158,7 +156,7 @@ class HederaSLoadOperationTest {
 	void executeWithOverFlowException() {
 		givenAdditionalContext(keyBytesMock, valueBytesMock);
 		given(messageFrame.warmUpStorage(any(), any())).willReturn(true);
-		given(messageFrame.getRemainingGas()).willReturn(Gas.of(300));
+		given(messageFrame.getRemainingGas()).willReturn(300L);
 		given(dynamicProperties.shouldEnableTraceability()).willReturn(true);
 		var frameStack = new ArrayDeque<MessageFrame>();
 		frameStack.add(messageFrame);
@@ -167,6 +165,7 @@ class HederaSLoadOperationTest {
 		doThrow(new FixedStack.OverflowException()).when(messageFrame).pushStackItem(any());
 
 		final var result = subject.execute(messageFrame, evm);
+		assertTrue(result.getHaltReason().isPresent());
 		assertEquals(TOO_MANY_STACK_ITEMS, result.getHaltReason().get());
 	}
 
@@ -183,8 +182,8 @@ class HederaSLoadOperationTest {
 		given(messageFrame.getWorldUpdater()).willReturn(worldUpdater);
 		given(messageFrame.getRecipientAddress()).willReturn(recipientAccount);
 
-		given(gasCalculator.getSloadOperationGasCost()).willReturn(Gas.of(10));
-		given(gasCalculator.getWarmStorageReadCost()).willReturn(Gas.of(20));
-		given(gasCalculator.getColdSloadCost()).willReturn(Gas.of(10));
+		given(gasCalculator.getSloadOperationGasCost()).willReturn(10L);
+		given(gasCalculator.getWarmStorageReadCost()).willReturn(20L);
+		given(gasCalculator.getColdSloadCost()).willReturn(10L);
 	}
 }

--- a/hedera-node/src/test/java/com/hedera/services/contracts/operation/HederaSStoreOperationTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/contracts/operation/HederaSStoreOperationTest.java
@@ -27,7 +27,6 @@ import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.units.bigints.UInt256;
 import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.evm.EVM;
-import org.hyperledger.besu.evm.Gas;
 import org.hyperledger.besu.evm.account.EvmAccount;
 import org.hyperledger.besu.evm.account.MutableAccount;
 import org.hyperledger.besu.evm.frame.BlockValues;
@@ -43,6 +42,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.ArrayDeque;
 import java.util.Optional;
+import java.util.OptionalLong;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.BDDMockito.any;
@@ -64,10 +64,8 @@ class HederaSStoreOperationTest {
 	private MutableAccount mutableAccount;
 	@Mock
 	private EvmAccount evmAccount;
-	@Mock
-	private Bytes keyBytesMock;
-	@Mock
-	private Bytes valueBytesMock;
+	final private Bytes keyBytesMock = Bytes.of(1,2,3,4);
+	final private Bytes valueBytesMock = Bytes.of(4,3,2,1);
 	@Mock
 	private BlockValues hederaBlockValues;
 	@Mock
@@ -94,7 +92,7 @@ class HederaSStoreOperationTest {
 
 		final var result = subject.execute(messageFrame, evm);
 
-		final var expected = new Operation.OperationResult(Optional.of(Gas.of(10)), Optional.empty());
+		final var expected = new Operation.OperationResult(OptionalLong.of(10), Optional.empty());
 
 		assertEquals(expected.getGasCost(), result.getGasCost());
 		assertEquals(expected.getHaltReason(), result.getHaltReason());
@@ -111,7 +109,7 @@ class HederaSStoreOperationTest {
 
 		final var result = subject.execute(messageFrame, evm);
 
-		final var expected = new Operation.OperationResult(Optional.of(Gas.of(10)), Optional.of(ExceptionalHaltReason.ILLEGAL_STATE_CHANGE));
+		final var expected = new Operation.OperationResult(OptionalLong.of(10), Optional.of(ExceptionalHaltReason.ILLEGAL_STATE_CHANGE));
 
 		assertEquals(expected.getGasCost(), result.getGasCost());
 		assertEquals(expected.getHaltReason(), result.getHaltReason());
@@ -132,14 +130,14 @@ class HederaSStoreOperationTest {
 		given(worldUpdater.getAccount(recipientAccount)).willReturn(evmAccount);
 		given(evmAccount.getMutable()).willReturn(mutableAccount);
 		given(mutableAccount.getStorageValue(any())).willReturn(keyBytes);
-		given(gasCalculator.calculateStorageCost(any(), any(), any())).willReturn(Gas.of(10));
+		given(gasCalculator.calculateStorageCost(any(), any(), any())).willReturn(10L);
 		given(messageFrame.warmUpStorage(any(), any())).willReturn(true);
 		given(messageFrame.isStatic()).willReturn(false);
-		given(messageFrame.getRemainingGas()).willReturn(Gas.of(0));
+		given(messageFrame.getRemainingGas()).willReturn(0L);
 
 		final var result = subject.execute(messageFrame, evm);
 
-		final var expected = new Operation.OperationResult(Optional.of(Gas.of(10)), Optional.of(ExceptionalHaltReason.INSUFFICIENT_GAS));
+		final var expected = new Operation.OperationResult(OptionalLong.of(10), Optional.of(ExceptionalHaltReason.INSUFFICIENT_GAS));
 
 		assertEquals(expected.getGasCost(), result.getGasCost());
 		assertEquals(expected.getHaltReason(), result.getHaltReason());
@@ -162,7 +160,7 @@ class HederaSStoreOperationTest {
 		final var result = subject.execute(messageFrame, evm);
 
 		final var expected = new Operation.OperationResult(
-				Optional.empty(), Optional.of(ExceptionalHaltReason.ILLEGAL_STATE_CHANGE));
+				OptionalLong.empty(), Optional.of(ExceptionalHaltReason.ILLEGAL_STATE_CHANGE));
 
 		assertEquals(expected.getGasCost(), result.getGasCost());
 		assertEquals(expected.getHaltReason(), result.getHaltReason());
@@ -179,12 +177,12 @@ class HederaSStoreOperationTest {
 		givenValidContext(key, value);
 		given(mutableAccount.getStorageValue(any())).willReturn(UInt256.ZERO);
 
-		final var frameGasCost = Gas.of(10L);
+		final var frameGasCost = 10L;
 		given(storageGasCalculator.gasCostOfStorageIn(messageFrame)).willReturn(frameGasCost);
 
 		final var result = subject.execute(messageFrame, evm);
 
-		final var expected = new Operation.OperationResult(Optional.of(frameGasCost), Optional.empty());
+		final var expected = new Operation.OperationResult(OptionalLong.of(frameGasCost), Optional.empty());
 
 		assertEquals(expected.getGasCost(), result.getGasCost());
 		assertEquals(expected.getHaltReason(), result.getHaltReason());
@@ -204,10 +202,10 @@ class HederaSStoreOperationTest {
 		given(messageFrame.getRecipientAddress()).willReturn(recipientAccount);
 		given(worldUpdater.getAccount(recipientAccount)).willReturn(evmAccount);
 		given(evmAccount.getMutable()).willReturn(mutableAccount);
-		given(gasCalculator.calculateStorageCost(any(), any(), any())).willReturn(Gas.of(10));
+		given(gasCalculator.calculateStorageCost(any(), any(), any())).willReturn(10L);
 		given(messageFrame.warmUpStorage(any(), any())).willReturn(true);
 		given(messageFrame.isStatic()).willReturn(false);
-		given(messageFrame.getRemainingGas()).willReturn(Gas.of(300));
+		given(messageFrame.getRemainingGas()).willReturn(300L);
 
 		given(mutableAccount.getStorageValue(any())).willReturn(keyBytes);
 	}

--- a/hedera-node/src/test/java/com/hedera/services/contracts/operation/HederaSelfDestructOperationTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/contracts/operation/HederaSelfDestructOperationTest.java
@@ -25,7 +25,6 @@ import com.hedera.services.utils.EntityNum;
 import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.datatypes.Wei;
 import org.hyperledger.besu.evm.EVM;
-import org.hyperledger.besu.evm.Gas;
 import org.hyperledger.besu.evm.account.Account;
 import org.hyperledger.besu.evm.frame.ExceptionalHaltReason;
 import org.hyperledger.besu.evm.frame.MessageFrame;
@@ -37,6 +36,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Optional;
+import java.util.OptionalLong;
 import java.util.function.BiPredicate;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -72,7 +72,7 @@ class HederaSelfDestructOperationTest {
 		subject = new HederaSelfDestructOperation(gasCalculator, addressValidator);
 
 		given(frame.getWorldUpdater()).willReturn(worldUpdater);
-		given(gasCalculator.selfDestructOperationGasCost(any(), eq(Wei.ONE))).willReturn(Gas.of(2L));
+		given(gasCalculator.selfDestructOperationGasCost(any(), eq(Wei.ONE))).willReturn(2L);
 	}
 
 	@Test
@@ -86,12 +86,12 @@ class HederaSelfDestructOperationTest {
 		given(worldUpdater.get(any())).willReturn(account);
 		given(account.getBalance()).willReturn(Wei.ONE);
 		given(frame.isStatic()).willReturn(true);
-		given(gasCalculator.getColdAccountAccessCost()).willReturn(Gas.of(1));
+		given(gasCalculator.getColdAccountAccessCost()).willReturn(1L);
 
 		final var opResult = subject.execute(frame, evm);
 
 		assertEquals(Optional.of(ExceptionalHaltReason.ILLEGAL_STATE_CHANGE), opResult.getHaltReason());
-		assertEquals(Optional.of(Gas.of(3L)), opResult.getGasCost());
+		assertEquals(OptionalLong.of(3L), opResult.getGasCost());
 	}
 
 	@Test
@@ -104,7 +104,7 @@ class HederaSelfDestructOperationTest {
 		final var opResult = subject.execute(frame, evm);
 
 		assertEquals(Optional.of(HederaExceptionalHaltReason.SELF_DESTRUCT_TO_SELF), opResult.getHaltReason());
-		assertEquals(Optional.of(Gas.of(2L)), opResult.getGasCost());
+		assertEquals(OptionalLong.of(2L), opResult.getGasCost());
 	}
 
 	@Test
@@ -119,7 +119,7 @@ class HederaSelfDestructOperationTest {
 		final var opResult = subject.execute(frame, evm);
 
 		assertEquals(Optional.of(HederaExceptionalHaltReason.CONTRACT_IS_TREASURY), opResult.getHaltReason());
-		assertEquals(Optional.of(Gas.of(2L)), opResult.getGasCost());
+		assertEquals(OptionalLong.of(2L), opResult.getGasCost());
 	}
 
 	@Test
@@ -134,7 +134,7 @@ class HederaSelfDestructOperationTest {
 		final var opResult = subject.execute(frame, evm);
 
 		assertEquals(Optional.of(HederaExceptionalHaltReason.TRANSACTION_REQUIRES_ZERO_TOKEN_BALANCES), opResult.getHaltReason());
-		assertEquals(Optional.of(Gas.of(2L)), opResult.getGasCost());
+		assertEquals(OptionalLong.of(2L), opResult.getGasCost());
 	}
 
 	@Test
@@ -149,7 +149,7 @@ class HederaSelfDestructOperationTest {
 		final var opResult = subject.execute(frame, evm);
 
 		assertEquals(Optional.of(HederaExceptionalHaltReason.CONTRACT_STILL_OWNS_NFTS), opResult.getHaltReason());
-		assertEquals(Optional.of(Gas.of(2L)), opResult.getGasCost());
+		assertEquals(OptionalLong.of(2L), opResult.getGasCost());
 	}
 
 	@Test
@@ -162,7 +162,7 @@ class HederaSelfDestructOperationTest {
 		final var opResult = subject.execute(frame, evm);
 
 		assertEquals(Optional.of(HederaExceptionalHaltReason.INVALID_SOLIDITY_ADDRESS), opResult.getHaltReason());
-		assertEquals(Optional.of(Gas.of(2L)), opResult.getGasCost());
+		assertEquals(OptionalLong.of(2L), opResult.getGasCost());
 	}
 
 	private void givenRubberstampValidator() {

--- a/hedera-node/src/test/java/com/hedera/services/contracts/operation/HederaStaticCallOperationTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/contracts/operation/HederaStaticCallOperationTest.java
@@ -28,7 +28,6 @@ import org.apache.tuweni.bytes.Bytes;
 import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.datatypes.Wei;
 import org.hyperledger.besu.evm.EVM;
-import org.hyperledger.besu.evm.Gas;
 import org.hyperledger.besu.evm.account.Account;
 import org.hyperledger.besu.evm.frame.MessageFrame;
 import org.hyperledger.besu.evm.gascalculator.GasCalculator;
@@ -46,6 +45,7 @@ import java.util.function.BiPredicate;
 
 import static com.hedera.services.contracts.operation.CommonCallSetup.commonSetup;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -65,16 +65,13 @@ class HederaStaticCallOperationTest {
 	@Mock
 	private Account acc;
 	@Mock
-	private Address accountAddr;
-	@Mock
-	private Gas cost;
-	@Mock
 	private EvmSigsVerifier sigsVerifier;
 	@Mock
 	private BiPredicate<Address, MessageFrame> addressValidator;
 	@Mock
 	private Map<String, PrecompiledContract> precompiledContractMap;
 
+	private final long cost = 100L;
 	private HederaStaticCallOperation subject;
 
 	@BeforeEach
@@ -87,7 +84,7 @@ class HederaStaticCallOperationTest {
 		commonSetup(evmMsgFrame, worldUpdater, acc);
 		given(worldUpdater.get(any())).willReturn(null);
 		given(calc.callOperationGasCost(
-				any(), any(), anyLong(),
+				any(), anyLong(), anyLong(),
 				anyLong(), anyLong(), anyLong(),
 				any(), any(), any())
 		).willReturn(cost);
@@ -102,14 +99,15 @@ class HederaStaticCallOperationTest {
 		var opRes = subject.execute(evmMsgFrame, evm);
 
 		assertEquals(opRes.getHaltReason(), Optional.of(HederaExceptionalHaltReason.INVALID_SOLIDITY_ADDRESS));
-		assertEquals(opRes.getGasCost().get(), cost);
+		assertTrue(opRes.getGasCost().isPresent());
+		assertEquals(opRes.getGasCost().getAsLong(), cost);
 	}
 
 	@Test
 	void executesAsExpected() {
 		commonSetup(evmMsgFrame, worldUpdater, acc);
 		given(calc.callOperationGasCost(
-				any(), any(), anyLong(),
+				any(), anyLong(), anyLong(),
 				anyLong(), anyLong(), anyLong(),
 				any(), any(), any())
 		).willReturn(cost);
@@ -122,9 +120,9 @@ class HederaStaticCallOperationTest {
 		given(evmMsgFrame.getWorldUpdater()).willReturn(worldUpdater);
 		given(worldUpdater.get(any())).willReturn(acc);
 		given(acc.getBalance()).willReturn(Wei.of(100));
-		given(calc.gasAvailableForChildCall(any(), any(), anyBoolean())).willReturn(Gas.of(10));
+		given(calc.gasAvailableForChildCall(any(), anyLong(), anyBoolean())).willReturn(10L);
 		given(sigsVerifier.hasActiveKeyOrNoReceiverSigReq(Mockito.anyBoolean(), any(), any(), any())).willReturn(true);
-		given(acc.getAddress()).willReturn(accountAddr);
+		given(acc.getAddress()).willReturn(Address.ZERO);
 		given(addressValidator.test(any(), any())).willReturn(true);
 
 		given(evmMsgFrame.getContractAddress()).willReturn(Address.ALTBN128_ADD);
@@ -132,6 +130,7 @@ class HederaStaticCallOperationTest {
 		
 		var opRes = subject.execute(evmMsgFrame, evm);
 		assertEquals(Optional.empty(), opRes.getHaltReason());
-		assertEquals(opRes.getGasCost().get(), cost);
+		assertTrue(opRes.getGasCost().isPresent());
+		assertEquals(opRes.getGasCost().getAsLong(), cost);
 	}
 }

--- a/hedera-node/src/test/java/com/hedera/services/store/contracts/CodeCacheTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/store/contracts/CodeCacheTest.java
@@ -84,7 +84,7 @@ class CodeCacheTest {
 	void returnsCachedValue() {
 		Address demoAddress = Address.fromHexString("aaa");
 		BytesKey key = new BytesKey(demoAddress.toArray());
-		Code code = new Code();
+		Code code = Code.EMPTY;
 		
 		codeCache.cacheValue(key, code);
 

--- a/hedera-node/src/test/java/com/hedera/services/store/contracts/HederaStackedWorldStateUpdaterTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/store/contracts/HederaStackedWorldStateUpdaterTest.java
@@ -33,7 +33,6 @@ import com.hederahashgraph.api.proto.java.AccountID;
 import com.hederahashgraph.api.proto.java.ContractID;
 import org.apache.tuweni.bytes.Bytes;
 import org.hyperledger.besu.datatypes.Address;
-import org.hyperledger.besu.evm.Gas;
 import org.hyperledger.besu.evm.account.Account;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -298,10 +297,10 @@ class HederaStackedWorldStateUpdaterTest {
 	@Test
 	void revertBehavesAsExpected() {
 		subject.countIdsAllocatedByStacked(3);
-		subject.addSbhRefund(Gas.of(123L));
-		assertEquals(123L, subject.getSbhRefund().toLong());
+		subject.addSbhRefund(123L);
+		assertEquals(123L, subject.getSbhRefund());
 		subject.revert();
-		assertEquals(0, subject.getSbhRefund().toLong());
+		assertEquals(0L, subject.getSbhRefund());
 		verify(worldState, times(3)).reclaimContractId();
 	}
 

--- a/hedera-node/src/test/java/com/hedera/services/store/contracts/HederaWorldStateTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/store/contracts/HederaWorldStateTest.java
@@ -37,7 +37,6 @@ import org.apache.tuweni.units.bigints.UInt256;
 import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.datatypes.Wei;
-import org.hyperledger.besu.evm.Gas;
 import org.hyperledger.besu.evm.account.Account;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -147,9 +146,7 @@ class HederaWorldStateTest {
 
 	@Test
 	void newContractAddress() {
-		final var sponsor = mock(Address.class);
-		given(sponsor.toArrayUnsafe())
-				.willReturn(new byte[] { 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 });
+		final var sponsor = Address.fromHexString("0x0102030405060708090a0b0c0d0e0f1011121314");
 		given(ids.newContractId(any())).willReturn(ContractID.newBuilder().setContractNum(1).build());
 		var addr = subject.newContractAddress(sponsor);
 		assertNotEquals(addr, sponsor);
@@ -289,7 +286,7 @@ class HederaWorldStateTest {
 		given(aliases.resolveForEvm(tbdAddress)).willReturn(tbdAddress);
 
 		var actualSubject = subject.updater();
-		var mockTbdAccount = mock(Address.class);
+		var mockTbdAccount = Address.fromHexString("0x0102030405060708090a0b0c0d0e0f1011121314");
 		actualSubject.deleteAccount(tbdAddress);
 
 		assertFailsWith(actualSubject::commit, ResponseCodeEnum.FAIL_INVALID);
@@ -317,10 +314,10 @@ class HederaWorldStateTest {
 
 		actualSubject.revert();
 
-		actualSubject.addSbhRefund(Gas.of(234L));
-		assertEquals(234L, actualSubject.getSbhRefund().toLong());
+		actualSubject.addSbhRefund(234L);
+		assertEquals(234L, actualSubject.getSbhRefund());
 		actualSubject.revert();
-		assertEquals(0, actualSubject.getSbhRefund().toLong());
+		assertEquals(0L, actualSubject.getSbhRefund());
 		verify(ids, times(3)).reclaimLastId();
 		assertTrue(actualSubject.getStateChanges().isEmpty());
 	}

--- a/hedera-node/src/test/java/com/hedera/services/store/contracts/precompile/AssociatePrecompileTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/store/contracts/precompile/AssociatePrecompileTest.java
@@ -63,7 +63,6 @@ import com.hederahashgraph.fee.FeeObject;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.tuweni.bytes.Bytes;
 import org.hyperledger.besu.datatypes.Wei;
-import org.hyperledger.besu.evm.Gas;
 import org.hyperledger.besu.evm.frame.MessageFrame;
 import org.hyperledger.besu.evm.gascalculator.GasCalculator;
 import org.hyperledger.besu.evm.worldstate.WorldUpdater;
@@ -106,8 +105,6 @@ import static org.mockito.Mockito.verify;
 @ExtendWith(MockitoExtension.class)
 @SuppressWarnings("rawtypes")
 class AssociatePrecompileTest {
-	@Mock
-	private Bytes pretendArguments;
 	@Mock
 	private OptionValidator validator;
 	@Mock
@@ -213,7 +210,7 @@ class AssociatePrecompileTest {
 	void computeAssociateTokenFailurePathWorks() {
 		// given:
 		givenCommonFrameContext();
-		given(pretendArguments.getInt(0)).willReturn(ABI_ID_ASSOCIATE_TOKEN);
+		Bytes pretendArguments = Bytes.ofUnsignedInt(ABI_ID_ASSOCIATE_TOKEN);
 		given(decoder.decodeAssociation(eq(pretendArguments), any())).willReturn(associateOp);
 		given(syntheticTxnFactory.createAssociate(associateOp)).willReturn(mockSynthBodyBuilder);
 		given(sigsVerifier.hasActiveKey(false,
@@ -247,7 +244,7 @@ class AssociatePrecompileTest {
 	void computeAssociateTokenFailurePathWorksWithNullLedgers() {
 		// given:
 		givenCommonFrameContext();
-		given(pretendArguments.getInt(0)).willReturn(ABI_ID_ASSOCIATE_TOKEN);
+		Bytes pretendArguments = Bytes.ofUnsignedInt(ABI_ID_ASSOCIATE_TOKEN);
 		given(decoder.decodeAssociation(eq(pretendArguments), any())).willReturn(associateOp);
 		given(syntheticTxnFactory.createAssociate(associateOp)).willReturn(mockSynthBodyBuilder);
 		given(sigsVerifier.hasActiveKey(false,
@@ -283,14 +280,14 @@ class AssociatePrecompileTest {
 		given(frame.getRecipientAddress()).willReturn(contractAddress);
 		given(frame.getSenderAddress()).willReturn(senderAddress);
 		given(frame.getWorldUpdater()).willReturn(worldUpdater);
-		given(frame.getRemainingGas()).willReturn(Gas.of(300));
+		given(frame.getRemainingGas()).willReturn(300L);
 		given(frame.getValue()).willReturn(Wei.ZERO);
 		Optional<WorldUpdater> parent = Optional.of(worldUpdater);
 		given(worldUpdater.parentUpdater()).willReturn(parent);
 		given(worldUpdater.wrappedTrackingLedgers(any())).willReturn(wrappedLedgers);
 		given(frame.getRecipientAddress()).willReturn(recipientAddress);
 		givenLedgers();
-		given(pretendArguments.getInt(0)).willReturn(ABI_ID_ASSOCIATE_TOKEN);
+		Bytes pretendArguments = Bytes.ofUnsignedInt(ABI_ID_ASSOCIATE_TOKEN);
 		given(decoder.decodeAssociation(eq(pretendArguments), any()))
 				.willReturn(associateOp);
 		given(syntheticTxnFactory.createAssociate(associateOp))
@@ -337,7 +334,7 @@ class AssociatePrecompileTest {
 	void computeAssociateTokenHappyPathWorksWithDelegateCallFromParentFrame() {
 		givenFrameContextWithDelegateCallFromParent();
 		givenLedgers();
-		given(pretendArguments.getInt(0)).willReturn(ABI_ID_ASSOCIATE_TOKEN);
+		Bytes pretendArguments = Bytes.ofUnsignedInt(ABI_ID_ASSOCIATE_TOKEN);
 		given(decoder.decodeAssociation(eq(pretendArguments), any()))
 				.willReturn(associateOp);
 		given(syntheticTxnFactory.createAssociate(associateOp))
@@ -376,7 +373,7 @@ class AssociatePrecompileTest {
 	void computeAssociateTokenHappyPathWorksWithEmptyMessageFrameStack() {
 		givenFrameContextWithEmptyMessageFrameStack();
 		givenLedgers();
-		given(pretendArguments.getInt(0)).willReturn(ABI_ID_ASSOCIATE_TOKEN);
+		Bytes pretendArguments = Bytes.ofUnsignedInt(ABI_ID_ASSOCIATE_TOKEN);
 		given(decoder.decodeAssociation(eq(pretendArguments), any()))
 				.willReturn(associateOp);
 		given(syntheticTxnFactory.createAssociate(associateOp))
@@ -405,7 +402,7 @@ class AssociatePrecompileTest {
 
 		// when:
 		subject.prepareFields(frame);
-		subject.prepareComputation(pretendArguments, а -> а);
+		subject.prepareComputation(pretendArguments, a -> a);
 		subject.computeGasRequirement(TEST_CONSENSUS_TIME);
 		final var result = subject.computeInternal(frame);
 
@@ -420,7 +417,7 @@ class AssociatePrecompileTest {
 	void computeAssociateTokenHappyPathWorksWithoutParentFrame() {
 		givenFrameContextWithoutParentFrame();
 		givenLedgers();
-		given(pretendArguments.getInt(0)).willReturn(ABI_ID_ASSOCIATE_TOKEN);
+		Bytes pretendArguments = Bytes.ofUnsignedInt(ABI_ID_ASSOCIATE_TOKEN);
 		given(decoder.decodeAssociation(eq(pretendArguments), any()))
 				.willReturn(associateOp);
 		given(syntheticTxnFactory.createAssociate(associateOp))
@@ -464,7 +461,7 @@ class AssociatePrecompileTest {
 	void computeMultiAssociateTokenHappyPathWorks() {
 		givenCommonFrameContext();
 		givenLedgers();
-		given(pretendArguments.getInt(0)).willReturn(ABI_ID_ASSOCIATE_TOKENS);
+		Bytes pretendArguments = Bytes.ofUnsignedInt(ABI_ID_ASSOCIATE_TOKENS);
 		given(decoder.decodeMultipleAssociations(eq(pretendArguments), any()))
 				.willReturn(multiAssociateOp);
 		given(syntheticTxnFactory.createAssociate(multiAssociateOp))
@@ -529,7 +526,7 @@ class AssociatePrecompileTest {
 		given(frame.getMessageFrameStack()).willReturn(frameDeque);
 		given(frame.getMessageFrameStack().descendingIterator()).willReturn(dequeIterator);
 		given(frame.getWorldUpdater()).willReturn(worldUpdater);
-		given(frame.getRemainingGas()).willReturn(Gas.of(300));
+		given(frame.getRemainingGas()).willReturn(300L);
 		given(frame.getValue()).willReturn(Wei.ZERO);
 		given(worldUpdater.aliases()).willReturn(aliases);
 		given(aliases.resolveForEvm(any())).willAnswer(invocationOnMock -> invocationOnMock.getArgument(0));

--- a/hedera-node/src/test/java/com/hedera/services/store/contracts/precompile/BurnPrecompilesTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/store/contracts/precompile/BurnPrecompilesTest.java
@@ -20,6 +20,7 @@ package com.hedera.services.store.contracts.precompile;
  * ‍
  */
 
+import com.esaulpaugh.headlong.util.Integers;
 import com.hedera.services.context.SideEffectsTracker;
 import com.hedera.services.context.primitives.StateView;
 import com.hedera.services.context.properties.GlobalDynamicProperties;
@@ -64,7 +65,6 @@ import com.hederahashgraph.fee.FeeObject;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.tuweni.bytes.Bytes;
 import org.hyperledger.besu.datatypes.Wei;
-import org.hyperledger.besu.evm.Gas;
 import org.hyperledger.besu.evm.frame.MessageFrame;
 import org.hyperledger.besu.evm.gascalculator.GasCalculator;
 import org.hyperledger.besu.evm.worldstate.WorldUpdater;
@@ -113,10 +113,10 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
-@SuppressWarnings("rawtypes")
 class BurnPrecompilesTest {
-	@Mock
-	private Bytes pretendArguments;
+	
+	private final Bytes pretendArguments = Bytes.of(Integers.toBytes(ABI_ID_BURN_TOKEN));
+	
 	@Mock
 	private AccountStore accountStore;
 	@Mock
@@ -233,7 +233,7 @@ class BurnPrecompilesTest {
 		given(encoder.encodeBurnFailure(INVALID_SIGNATURE)).willReturn(invalidSigResult);
 
 		subject.prepareFields(frame);
-		subject.prepareComputation(pretendArguments, а -> а);
+		subject.prepareComputation(pretendArguments, a -> a);
 		subject.computeGasRequirement(TEST_CONSENSUS_TIME);
 		final var result = subject.computeInternal(frame);
 
@@ -263,7 +263,7 @@ class BurnPrecompilesTest {
 		given(encoder.encodeBurnFailure(FAIL_INVALID)).willReturn(failInvalidResult);
 
 		subject.prepareFields(frame);
-		subject.prepareComputation(pretendArguments, а -> а);
+		subject.prepareComputation(pretendArguments, a -> a);
 		subject.computeGasRequirement(TEST_CONSENSUS_TIME);
 		final var result = subject.computeInternal(frame);
 
@@ -295,7 +295,7 @@ class BurnPrecompilesTest {
 		given(encoder.encodeBurnSuccess(123L)).willReturn(successResult);
 
 		subject.prepareFields(frame);
-		subject.prepareComputation(pretendArguments, а -> а);
+		subject.prepareComputation(pretendArguments, a -> a);
 		subject.computeGasRequirement(TEST_CONSENSUS_TIME);
 		final var result = subject.computeInternal(frame);
 
@@ -326,7 +326,7 @@ class BurnPrecompilesTest {
 		given(encoder.encodeBurnSuccess(49)).willReturn(burnSuccessResultWith49Supply);
 
 		subject.prepareFields(frame);
-		subject.prepareComputation(pretendArguments, а -> а);
+		subject.prepareComputation(pretendArguments, a -> a);
 		subject.computeGasRequirement(TEST_CONSENSUS_TIME);
 		final var result = subject.computeInternal(frame);
 
@@ -342,7 +342,6 @@ class BurnPrecompilesTest {
 		given(frame.getSenderAddress()).willReturn(contractAddress);
 		given(frame.getWorldUpdater()).willReturn(worldUpdater);
 		given(worldUpdater.wrappedTrackingLedgers(any())).willReturn(wrappedLedgers);
-		given(pretendArguments.getInt(0)).willReturn(ABI_ID_BURN_TOKEN);
 		doCallRealMethod().when(frame).setRevertReason(any());
 		given(decoder.decodeBurn(pretendArguments)).willReturn(fungibleBurnAmountOversize);
 		// when:
@@ -376,7 +375,7 @@ class BurnPrecompilesTest {
 		given(encoder.encodeBurnSuccess(anyLong())).willReturn(burnSuccessResultWithLongMaxValueSupply);
 
 		subject.prepareFields(frame);
-		subject.prepareComputation(pretendArguments, а -> а);
+		subject.prepareComputation(pretendArguments, a -> a);
 		subject.computeGasRequirement(TEST_CONSENSUS_TIME);
 		final var result = subject.computeInternal(frame);
 
@@ -405,12 +404,11 @@ class BurnPrecompilesTest {
 		given(frame.getContractAddress()).willReturn(contractAddr);
 		given(frame.getRecipientAddress()).willReturn(recipientAddr);
 		given(frame.getWorldUpdater()).willReturn(worldUpdater);
-		given(frame.getRemainingGas()).willReturn(Gas.of(300));
+		given(frame.getRemainingGas()).willReturn(300L);
 		given(frame.getValue()).willReturn(Wei.ZERO);
 		Optional<WorldUpdater> parent = Optional.of(worldUpdater);
 		given(worldUpdater.parentUpdater()).willReturn(parent);
 		given(worldUpdater.wrappedTrackingLedgers(any())).willReturn(wrappedLedgers);
-		given(pretendArguments.getInt(0)).willReturn(ABI_ID_BURN_TOKEN);
 	}
 
 	private void givenLedgers() {

--- a/hedera-node/src/test/java/com/hedera/services/store/contracts/precompile/DissociatePrecompilesTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/store/contracts/precompile/DissociatePrecompilesTest.java
@@ -63,7 +63,6 @@ import com.hederahashgraph.fee.FeeObject;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.tuweni.bytes.Bytes;
 import org.hyperledger.besu.datatypes.Wei;
-import org.hyperledger.besu.evm.Gas;
 import org.hyperledger.besu.evm.frame.MessageFrame;
 import org.hyperledger.besu.evm.gascalculator.GasCalculator;
 import org.hyperledger.besu.evm.worldstate.WorldUpdater;
@@ -104,8 +103,6 @@ import static org.mockito.Mockito.verify;
 @ExtendWith(MockitoExtension.class)
 @SuppressWarnings("rawtypes")
 class DissociatePrecompilesTest {
-	@Mock
-	private Bytes pretendArguments;
 	@Mock
 	private AccountStore accountStore;
 	@Mock
@@ -212,7 +209,7 @@ class DissociatePrecompilesTest {
 	@Test
 	void dissociateTokenFailurePathWorks() {
 		givenFrameContext();
-		given(pretendArguments.getInt(0)).willReturn(ABI_ID_DISSOCIATE_TOKEN);
+		Bytes pretendArguments = Bytes.ofUnsignedInt(ABI_ID_DISSOCIATE_TOKEN);
 
 		given(sigsVerifier.hasActiveKey(false, accountAddr, senderAddr, wrappedLedgers))
 				.willThrow(new InvalidTransactionException(INVALID_SIGNATURE));
@@ -245,7 +242,7 @@ class DissociatePrecompilesTest {
 	void dissociateTokenHappyPathWorks() {
 		givenFrameContext();
 		givenLedgers();
-		given(pretendArguments.getInt(0)).willReturn(ABI_ID_DISSOCIATE_TOKEN);
+		Bytes pretendArguments = Bytes.ofUnsignedInt(ABI_ID_DISSOCIATE_TOKEN);
 
 		given(sigsVerifier.hasActiveKey(false, accountAddr, senderAddr, wrappedLedgers)).willReturn(true);
 		given(accountStoreFactory.newAccountStore(validator, accounts)).willReturn(accountStore);
@@ -270,7 +267,7 @@ class DissociatePrecompilesTest {
 
 		// when:
 		subject.prepareFields(frame);
-		subject.prepareComputation(pretendArguments, а -> а);
+		subject.prepareComputation(pretendArguments, a -> a);
 		subject.computeGasRequirement(TEST_CONSENSUS_TIME);
 		final var result = subject.computeInternal(frame);
 
@@ -286,7 +283,7 @@ class DissociatePrecompilesTest {
 	void computeMultiDissociateTokenHappyPathWorks() {
 		givenFrameContext();
 		givenLedgers();
-		given(pretendArguments.getInt(0)).willReturn(ABI_ID_DISSOCIATE_TOKENS);
+		Bytes pretendArguments = Bytes.ofUnsignedInt(ABI_ID_DISSOCIATE_TOKENS);
 
 		given(decoder.decodeMultipleDissociations(eq(pretendArguments), any()))
 				.willReturn(multiDissociateOp);
@@ -315,7 +312,7 @@ class DissociatePrecompilesTest {
 
 		// when:
 		subject.prepareFields(frame);
-		subject.prepareComputation(pretendArguments, а -> а);
+		subject.prepareComputation(pretendArguments, a -> a);
 		subject.computeGasRequirement(TEST_CONSENSUS_TIME);
 		final var result = subject.computeInternal(frame);
 
@@ -337,7 +334,7 @@ class DissociatePrecompilesTest {
 		given(frame.getMessageFrameStack().descendingIterator().hasNext()).willReturn(true);
 		given(frame.getMessageFrameStack().descendingIterator().next()).willReturn(parentFrame);
 		given(frame.getWorldUpdater()).willReturn(worldUpdater);
-		given(frame.getRemainingGas()).willReturn(Gas.of(300));
+		given(frame.getRemainingGas()).willReturn(300L);
 		given(frame.getValue()).willReturn(Wei.ZERO);
 		Optional<WorldUpdater> parent = Optional.of(worldUpdater);
 		given(worldUpdater.parentUpdater()).willReturn(parent);

--- a/hedera-node/src/test/java/com/hedera/services/store/contracts/precompile/ERC20PrecompilesTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/store/contracts/precompile/ERC20PrecompilesTest.java
@@ -19,6 +19,7 @@ package com.hedera.services.store.contracts.precompile;
  * ‍
  */
 
+import com.esaulpaugh.headlong.util.Integers;
 import com.hedera.services.context.SideEffectsTracker;
 import com.hedera.services.context.primitives.StateView;
 import com.hedera.services.context.properties.GlobalDynamicProperties;
@@ -77,7 +78,6 @@ import org.apache.commons.lang3.tuple.Pair;
 import org.apache.tuweni.bytes.Bytes;
 import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.datatypes.Wei;
-import org.hyperledger.besu.evm.Gas;
 import org.hyperledger.besu.evm.frame.BlockValues;
 import org.hyperledger.besu.evm.frame.MessageFrame;
 import org.hyperledger.besu.evm.gascalculator.GasCalculator;
@@ -149,10 +149,6 @@ import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
 class ERC20PrecompilesTest {
-    @Mock
-    private Bytes pretendArguments;
-    @Mock
-    private Bytes nestedPretendArguments;
     @Mock
     private GlobalDynamicProperties dynamicProperties;
     @Mock
@@ -281,74 +277,88 @@ class ERC20PrecompilesTest {
         given(frame.getWorldUpdater()).willReturn(worldUpdater);
 
         given(worldUpdater.wrappedTrackingLedgers(any())).willReturn(wrappedLedgers);
-        given(pretendArguments.getInt(0)).willReturn(ABI_ID_REDIRECT_FOR_TOKEN);
-        given(pretendArguments.slice(4, 20)).willReturn(fungibleTokenAddr);
-        given(pretendArguments.slice(24)).willReturn(nestedPretendArguments);
-
-        given(nestedPretendArguments.getInt(0)).willReturn(ABI_ID_APPROVE);
-
-        // when:
-        subject.prepareFields(frame);
-
-        assertThrows(InvalidTransactionException.class, () -> subject.prepareComputation(pretendArguments, а -> а));
-
-        given(nestedPretendArguments.getInt(0)).willReturn(ABI_ID_ERC_TRANSFER_FROM);
+        Bytes pretendArgumentsApprove = Bytes.concatenate(
+                Bytes.of(Integers.toBytes(ABI_ID_REDIRECT_FOR_TOKEN)),
+                fungibleTokenAddr,
+                Bytes.of(Integers.toBytes(ABI_ID_APPROVE)));
 
         // when:
         subject.prepareFields(frame);
 
-        assertThrows(InvalidTransactionException.class, () -> subject.prepareComputation(pretendArguments, а -> а));
+        assertThrows(InvalidTransactionException.class, () -> subject.prepareComputation(pretendArgumentsApprove, a -> a));
 
-        given(nestedPretendArguments.getInt(0)).willReturn(ABI_ID_ALLOWANCE);
-
-
-        // when:
-        subject.prepareFields(frame);
-
-        assertThrows(InvalidTransactionException.class, () -> subject.prepareComputation(pretendArguments, а -> а));
-
-        given(nestedPretendArguments.getInt(0)).willReturn(ABI_ID_SET_APPROVAL_FOR_ALL);
+        Bytes pretendArgumentsTransferFrom = Bytes.concatenate(
+                Bytes.of(Integers.toBytes(ABI_ID_REDIRECT_FOR_TOKEN)),
+                fungibleTokenAddr,
+                Bytes.of(Integers.toBytes(ABI_ID_ERC_TRANSFER_FROM)));
 
         // when:
         subject.prepareFields(frame);
 
-        assertThrows(InvalidTransactionException.class, () -> subject.prepareComputation(pretendArguments, а -> а));
+        assertThrows(InvalidTransactionException.class, () -> subject.prepareComputation(pretendArgumentsTransferFrom, a -> a));
 
-        given(nestedPretendArguments.getInt(0)).willReturn(ABI_ID_GET_APPROVED);
-
-        // when:
-        subject.prepareFields(frame);
-
-        assertThrows(InvalidTransactionException.class, () -> subject.prepareComputation(pretendArguments, а -> а));
-
-        given(nestedPretendArguments.getInt(0)).willReturn(ABI_ID_IS_APPROVED_FOR_ALL);
+        Bytes pretendArgumentsAllowance = Bytes.concatenate(
+                Bytes.of(Integers.toBytes(ABI_ID_REDIRECT_FOR_TOKEN)),
+                fungibleTokenAddr,
+                Bytes.of(Integers.toBytes(ABI_ID_ALLOWANCE)));
 
 
         // when:
         subject.prepareFields(frame);
 
-        assertThrows(InvalidTransactionException.class, () -> subject.prepareComputation(pretendArguments, а -> а));
+        assertThrows(InvalidTransactionException.class, () -> subject.prepareComputation(pretendArgumentsAllowance, a -> a));
+
+        Bytes pretendArgumentsApproveForAll = Bytes.concatenate(
+                Bytes.of(Integers.toBytes(ABI_ID_REDIRECT_FOR_TOKEN)),
+                fungibleTokenAddr,
+                Bytes.of(Integers.toBytes(ABI_ID_SET_APPROVAL_FOR_ALL)));
+
+        // when:
+        subject.prepareFields(frame);
+
+        assertThrows(InvalidTransactionException.class, () -> subject.prepareComputation(pretendArgumentsApproveForAll, a -> a));
+
+        Bytes pretendArgumentsGetApproved = Bytes.concatenate(
+                Bytes.of(Integers.toBytes(ABI_ID_REDIRECT_FOR_TOKEN)),
+                fungibleTokenAddr,
+                Bytes.of(Integers.toBytes(ABI_ID_GET_APPROVED)));
+
+        // when:
+        subject.prepareFields(frame);
+
+        assertThrows(InvalidTransactionException.class, () -> subject.prepareComputation(pretendArgumentsGetApproved, a -> a));
+
+        Bytes pretendArgumentsApprovedForAll = Bytes.concatenate(
+                Bytes.of(Integers.toBytes(ABI_ID_REDIRECT_FOR_TOKEN)),
+                fungibleTokenAddr,
+                Bytes.of(Integers.toBytes(ABI_ID_IS_APPROVED_FOR_ALL)));
+
+
+        // when:
+        subject.prepareFields(frame);
+
+        assertThrows(InvalidTransactionException.class, () -> subject.prepareComputation(pretendArgumentsApprovedForAll, a -> a));
     }
 
     @Test
     void invalidNestedFunctionSelector () {
-        givenMinimalFrameContextWithoutParentUpdater();
+        Bytes nestedPretendArguments = Bytes.of(0,0,0,0);
+        Bytes pretendArguments = givenMinimalFrameContextWithoutParentUpdater(nestedPretendArguments);
 
-        given(nestedPretendArguments.getInt(0)).willReturn(0);
         given(wrappedLedgers.typeOf(token)).willReturn(TokenType.FUNGIBLE_COMMON);
 
         subject.prepareFields(frame);
-        subject.prepareComputation(pretendArguments, а -> а);
+        subject.prepareComputation(pretendArguments, a -> a);
         final var result = subject.compute(pretendArguments, frame);
         assertNull(result);
     }
 
     @Test
     void gasCalculationForReadOnlyMethod() {
-        givenMinimalFrameContext();
+        Bytes nestedPretendArguments = Bytes.of(Integers.toBytes(ABI_ID_NAME));
+        Bytes pretendArguments = givenMinimalFrameContext(nestedPretendArguments);
 
         given(syntheticTxnFactory.createTransactionCall(1L, pretendArguments)).willReturn(mockSynthBodyBuilder);
-        given(nestedPretendArguments.getInt(0)).willReturn(ABI_ID_NAME);
         given(creator.createSuccessfulSyntheticRecord(Collections.emptyList(), sideEffects, EMPTY_MEMO))
                 .willReturn(mockRecordBuilder);
         given(feeCalculator.estimatePayment(any(), any(), any(), any(), any())).willReturn(mockFeeObject);
@@ -366,7 +376,7 @@ class ERC20PrecompilesTest {
         given(blockValues.getTimestamp()).willReturn(TEST_CONSENSUS_TIME);
         // when:
         subject.prepareFields(frame);
-        subject.prepareComputation(pretendArguments, а -> а);
+        subject.prepareComputation(pretendArguments, a -> a);
         subject.computeViewFunctionGasRequirement(TEST_CONSENSUS_TIME);
         final var result = subject.compute(pretendArguments, frame);
 
@@ -379,13 +389,13 @@ class ERC20PrecompilesTest {
 
     @Test
     void gasCalculationForModifyingMethod() {
-        givenMinimalFrameContext();
+        Bytes nestedPretendArguments = Bytes.of(Integers.toBytes(ABI_ID_ERC_TRANSFER));
+        Bytes pretendArguments = givenMinimalFrameContext(nestedPretendArguments);
         givenLedgers();
 
         given(frame.getContractAddress()).willReturn(contractAddr);
         given(syntheticTxnFactory.createCryptoTransfer(Collections.singletonList(TOKEN_TRANSFER_WRAPPER)))
                 .willReturn(mockSynthBodyBuilder);
-        given(nestedPretendArguments.getInt(0)).willReturn(ABI_ID_ERC_TRANSFER);
         given(mockSynthBodyBuilder.getCryptoTransfer()).willReturn(cryptoTransferTransactionBody);
         given(impliedTransfersMarshal.validityWithCurrentProps(cryptoTransferTransactionBody)).willReturn(OK);
         given(sigsVerifier.hasActiveKey(Mockito.anyBoolean(), any(), any(), any())).willReturn(true);
@@ -431,7 +441,7 @@ class ERC20PrecompilesTest {
         given(blockValues.getTimestamp()).willReturn(TEST_CONSENSUS_TIME);
         // when:
         subject.prepareFields(frame);
-        subject.prepareComputation(pretendArguments, а -> а);
+        subject.prepareComputation(pretendArguments, a -> a);
         subject.computeGasRequirement(TEST_CONSENSUS_TIME);
         final var result = subject.compute(pretendArguments, frame);
 
@@ -445,10 +455,10 @@ class ERC20PrecompilesTest {
 
     @Test
     void name() {
-        givenMinimalFrameContext();
+        Bytes nestedPretendArguments = Bytes.of(Integers.toBytes(ABI_ID_NAME));
+        Bytes pretendArguments = givenMinimalFrameContext(nestedPretendArguments);
 
         given(syntheticTxnFactory.createTransactionCall(1L, pretendArguments)).willReturn(mockSynthBodyBuilder);
-        given(nestedPretendArguments.getInt(0)).willReturn(ABI_ID_NAME);
         given(creator.createSuccessfulSyntheticRecord(Collections.emptyList(), sideEffects, EMPTY_MEMO))
                 .willReturn(mockRecordBuilder);
         given(feeCalculator.estimatedGasPriceInTinybars(HederaFunctionality.ContractCall, timestamp))
@@ -466,7 +476,7 @@ class ERC20PrecompilesTest {
 
         // when:
         subject.prepareFields(frame);
-        subject.prepareComputation(pretendArguments, а -> а);
+        subject.prepareComputation(pretendArguments, a -> a);
         subject.computeViewFunctionGasRequirement(TEST_CONSENSUS_TIME);
         final var result = subject.computeInternal(frame);
 
@@ -484,10 +494,10 @@ class ERC20PrecompilesTest {
 
     @Test
     void symbol() {
-        givenMinimalFrameContext();
+        Bytes nestedPretendArguments = Bytes.of(Integers.toBytes(ABI_ID_SYMBOL));
+        Bytes pretendArguments = givenMinimalFrameContext(nestedPretendArguments);
 
         given(syntheticTxnFactory.createTransactionCall(1L, pretendArguments)).willReturn(mockSynthBodyBuilder);
-        given(nestedPretendArguments.getInt(0)).willReturn(ABI_ID_SYMBOL);
         given(creator.createSuccessfulSyntheticRecord(Collections.emptyList(), sideEffects, EMPTY_MEMO))
                 .willReturn(mockRecordBuilder);
 
@@ -505,7 +515,7 @@ class ERC20PrecompilesTest {
 
         // when:
         subject.prepareFields(frame);
-        subject.prepareComputation(pretendArguments, а -> а);
+        subject.prepareComputation(pretendArguments, a -> a);
         subject.computeViewFunctionGasRequirement(TEST_CONSENSUS_TIME);
         final var result = subject.computeInternal(frame);
 
@@ -518,10 +528,10 @@ class ERC20PrecompilesTest {
 
     @Test
     void decimals() {
-        givenMinimalFrameContext();
+        Bytes nestedPretendArguments = Bytes.of(Integers.toBytes(ABI_ID_DECIMALS));
+        Bytes pretendArguments = givenMinimalFrameContext(nestedPretendArguments);
 
         given(syntheticTxnFactory.createTransactionCall(1L, pretendArguments)).willReturn(mockSynthBodyBuilder);
-        given(nestedPretendArguments.getInt(0)).willReturn(ABI_ID_DECIMALS);
         given(creator.createSuccessfulSyntheticRecord(Collections.emptyList(), sideEffects, EMPTY_MEMO))
                 .willReturn(mockRecordBuilder);
 
@@ -541,7 +551,7 @@ class ERC20PrecompilesTest {
 
         // when:
         subject.prepareFields(frame);
-        subject.prepareComputation(pretendArguments, а -> а);
+        subject.prepareComputation(pretendArguments, a -> a);
         subject.computeViewFunctionGasRequirement(TEST_CONSENSUS_TIME);
         final var result = subject.computeInternal(frame);
 
@@ -554,9 +564,9 @@ class ERC20PrecompilesTest {
 
     @Test
     void totalSupply() {
-        givenMinimalFrameContext();
+        Bytes nestedPretendArguments = Bytes.of(Integers.toBytes(ABI_ID_TOTAL_SUPPLY_TOKEN));
+        Bytes pretendArguments = givenMinimalFrameContext(nestedPretendArguments);
         given(syntheticTxnFactory.createTransactionCall(1L, pretendArguments)).willReturn(mockSynthBodyBuilder);
-        given(nestedPretendArguments.getInt(0)).willReturn(ABI_ID_TOTAL_SUPPLY_TOKEN);
         given(creator.createSuccessfulSyntheticRecord(Collections.emptyList(), sideEffects, EMPTY_MEMO))
                 .willReturn(mockRecordBuilder);
 
@@ -576,7 +586,7 @@ class ERC20PrecompilesTest {
 
         // when:
         subject.prepareFields(frame);
-        subject.prepareComputation(pretendArguments, а -> а);
+        subject.prepareComputation(pretendArguments, a -> a);
         subject.computeViewFunctionGasRequirement(TEST_CONSENSUS_TIME);
         final var result = subject.computeInternal(frame);
 
@@ -591,12 +601,12 @@ class ERC20PrecompilesTest {
     void allowance() {
         TreeMap<FcTokenAllowanceId, Long> alowances = new TreeMap<>();
         alowances.put(FcTokenAllowanceId.from(EntityNum.fromLong(token.getTokenNum()), EntityNum.fromLong(receiver.getAccountNum())), 10L);
-
-        givenMinimalFrameContext();
+        
+        Bytes nestedPretendArguments = Bytes.of(Integers.toBytes(ABI_ID_ALLOWANCE));
+        Bytes pretendArguments = givenMinimalFrameContext(nestedPretendArguments);
         given(wrappedLedgers.accounts()).willReturn(accounts);
         given(dynamicProperties.areAllowancesEnabled()).willReturn(true);
         given(syntheticTxnFactory.createTransactionCall(1L, pretendArguments)).willReturn(mockSynthBodyBuilder);
-        given(nestedPretendArguments.getInt(0)).willReturn(ABI_ID_ALLOWANCE);
         given(creator.createSuccessfulSyntheticRecord(Collections.emptyList(), sideEffects, EMPTY_MEMO))
                 .willReturn(mockRecordBuilder);
 
@@ -619,7 +629,7 @@ class ERC20PrecompilesTest {
 
         // when:
         subject.prepareFields(frame);
-        subject.prepareComputation(pretendArguments, а -> а);
+        subject.prepareComputation(pretendArguments, a -> a);
         subject.computeViewFunctionGasRequirement(TEST_CONSENSUS_TIME);
         final var result = subject.computeInternal(frame);
 
@@ -633,10 +643,10 @@ class ERC20PrecompilesTest {
 
     @Test
     void balanceOf() {
-        givenMinimalFrameContext();
+        Bytes nestedPretendArguments = Bytes.of(Integers.toBytes(ABI_ID_BALANCE_OF_TOKEN));
+        Bytes pretendArguments = givenMinimalFrameContext(nestedPretendArguments);
 
         given(syntheticTxnFactory.createTransactionCall(1L, pretendArguments)).willReturn(mockSynthBodyBuilder);
-        given(nestedPretendArguments.getInt(0)).willReturn(ABI_ID_BALANCE_OF_TOKEN);
         given(creator.createSuccessfulSyntheticRecord(Collections.emptyList(), sideEffects, EMPTY_MEMO))
                 .willReturn(mockRecordBuilder);
 
@@ -660,7 +670,7 @@ class ERC20PrecompilesTest {
 
         // when:
         subject.prepareFields(frame);
-        subject.prepareComputation(pretendArguments, а -> а);
+        subject.prepareComputation(pretendArguments, a -> a);
         subject.computeViewFunctionGasRequirement(TEST_CONSENSUS_TIME);
         final var result = subject.computeInternal(frame);
 
@@ -677,9 +687,9 @@ class ERC20PrecompilesTest {
         List<TokenAllowance> tokenAllowances = new ArrayList<>();
         List<NftAllowance> nftAllowances = new ArrayList<>();
         Map<FcTokenAllowanceId, Long> allowances = Map.of(fungibleAllowanceId, 0L);
-        givenMinimalFrameContext();
-
-        given(nestedPretendArguments.getInt(0)).willReturn(ABI_ID_APPROVE);
+        
+        Bytes nestedPretendArguments = Bytes.of(Integers.toBytes(ABI_ID_APPROVE));
+        Bytes pretendArguments = givenMinimalFrameContext(nestedPretendArguments);
 
         given(feeCalculator.estimatedGasPriceInTinybars(HederaFunctionality.ContractCall, timestamp))
                 .willReturn(1L);
@@ -703,7 +713,7 @@ class ERC20PrecompilesTest {
 
         // when:
         subject.prepareFields(frame);
-        subject.prepareComputation(pretendArguments, а -> а);
+        subject.prepareComputation(pretendArguments, a -> a);
         subject.computeViewFunctionGasRequirement(TEST_CONSENSUS_TIME);
         final var result = subject.computeInternal(frame);
 
@@ -718,9 +728,10 @@ class ERC20PrecompilesTest {
         List<TokenAllowance> tokenAllowances = new ArrayList<>();
         List<NftAllowance> nftAllowances = new ArrayList<>();
         Map<FcTokenAllowanceId, Long> allowances = Map.of(fungibleAllowanceId, 0L);
-        givenMinimalFrameContext();
 
-        given(nestedPretendArguments.getInt(0)).willReturn(ABI_ID_APPROVE);
+        Bytes nestedPretendArguments = Bytes.of(Integers.toBytes(ABI_ID_APPROVE));
+        Bytes pretendArguments = givenMinimalFrameContext(nestedPretendArguments);
+
         given(wrappedLedgers.tokens()).willReturn(tokens);
         given(wrappedLedgers.accounts()).willReturn(accounts);
         given(creator.createSuccessfulSyntheticRecord(Collections.emptyList(), sideEffects, EMPTY_MEMO))
@@ -755,7 +766,7 @@ class ERC20PrecompilesTest {
 
         // when:
         subject.prepareFields(frame);
-        subject.prepareComputation(pretendArguments, а -> а);
+        subject.prepareComputation(pretendArguments, a -> a);
         subject.computeViewFunctionGasRequirement(TEST_CONSENSUS_TIME);
         final var result = subject.computeInternal(frame);
 
@@ -767,13 +778,13 @@ class ERC20PrecompilesTest {
 
     @Test
     void transfer() {
-        givenMinimalFrameContext();
+        Bytes nestedPretendArguments = Bytes.of(Integers.toBytes(ABI_ID_ERC_TRANSFER));
+        Bytes pretendArguments = givenMinimalFrameContext(nestedPretendArguments);
         givenLedgers();
 
         given(frame.getContractAddress()).willReturn(contractAddr);
         given(syntheticTxnFactory.createCryptoTransfer(Collections.singletonList(TOKEN_TRANSFER_WRAPPER)))
                 .willReturn(mockSynthBodyBuilder);
-        given(nestedPretendArguments.getInt(0)).willReturn(ABI_ID_ERC_TRANSFER);
         given(mockSynthBodyBuilder.getCryptoTransfer()).willReturn(cryptoTransferTransactionBody);
         given(impliedTransfersMarshal.validityWithCurrentProps(cryptoTransferTransactionBody)).willReturn(OK);
         given(sigsVerifier.hasActiveKey(Mockito.anyBoolean(), any(), any(), any())).willReturn(true);
@@ -817,7 +828,7 @@ class ERC20PrecompilesTest {
         given(encoder.encodeEcFungibleTransfer(true)).willReturn(successResult);
         // when:
         subject.prepareFields(frame);
-        subject.prepareComputation(pretendArguments, а -> а);
+        subject.prepareComputation(pretendArguments, a -> a);
         subject.computeGasRequirement(TEST_CONSENSUS_TIME);
         final var result = subject.computeInternal(frame);
 
@@ -831,13 +842,13 @@ class ERC20PrecompilesTest {
 
     @Test
     void transferFrom() {
-        givenMinimalFrameContext();
+        Bytes nestedPretendArguments = Bytes.of(Integers.toBytes(ABI_ID_ERC_TRANSFER_FROM));
+        Bytes pretendArguments = givenMinimalFrameContext(nestedPretendArguments);
         givenLedgers();
 
         given(frame.getContractAddress()).willReturn(contractAddr);
         given(syntheticTxnFactory.createCryptoTransfer(Collections.singletonList(TOKEN_TRANSFER_FROM_WRAPPER)))
                 .willReturn(mockSynthBodyBuilder);
-        given(nestedPretendArguments.getInt(0)).willReturn(ABI_ID_ERC_TRANSFER_FROM);
         given(mockSynthBodyBuilder.getCryptoTransfer()).willReturn(cryptoTransferTransactionBody);
         given(impliedTransfersMarshal.validityWithCurrentProps(cryptoTransferTransactionBody)).willReturn(OK);
         given(sigsVerifier.hasActiveKey(Mockito.anyBoolean(), any(), any(), any())).willReturn(true);
@@ -883,7 +894,7 @@ class ERC20PrecompilesTest {
         given(encoder.encodeEcFungibleTransfer(true)).willReturn(successResult);
         // when:
         subject.prepareFields(frame);
-        subject.prepareComputation(pretendArguments, а -> а);
+        subject.prepareComputation(pretendArguments, a -> a);
         subject.computeGasRequirement(TEST_CONSENSUS_TIME);
         final var result = subject.computeInternal(frame);
 
@@ -897,13 +908,13 @@ class ERC20PrecompilesTest {
 
     @Test
     void transferFails() {
-        givenMinimalFrameContext();
+        Bytes nestedPretendArguments = Bytes.of(Integers.toBytes(ABI_ID_ERC_TRANSFER));
+        Bytes pretendArguments = givenMinimalFrameContext(nestedPretendArguments);
         givenLedgers();
 
         given(frame.getContractAddress()).willReturn(contractAddr);
         given(syntheticTxnFactory.createCryptoTransfer(Collections.singletonList(TOKEN_TRANSFER_WRAPPER)))
                 .willReturn(mockSynthBodyBuilder);
-        given(nestedPretendArguments.getInt(0)).willReturn(ABI_ID_ERC_TRANSFER);
         given(mockSynthBodyBuilder.getCryptoTransfer()).willReturn(cryptoTransferTransactionBody);
         given(impliedTransfersMarshal.validityWithCurrentProps(cryptoTransferTransactionBody)).willReturn(OK);
         given(sigsVerifier.hasActiveKey(Mockito.anyBoolean(), any(), any(), any())).willReturn(false);
@@ -935,7 +946,7 @@ class ERC20PrecompilesTest {
         given(wrappedLedgers.typeOf(token)).willReturn(TokenType.FUNGIBLE_COMMON);
         // when:
         subject.prepareFields(frame);
-        subject.prepareComputation(pretendArguments, а -> а);
+        subject.prepareComputation(pretendArguments, a -> a);
         subject.computeGasRequirement(TEST_CONSENSUS_TIME);
         final var result = subject.computeInternal(frame);
 
@@ -945,50 +956,52 @@ class ERC20PrecompilesTest {
 
     @Test
     void ownerOfNotSupported() {
-        givenMinimalFrameContextWithoutParentUpdater();
+        Bytes nestedPretendArguments = Bytes.of(Integers.toBytes(ABI_ID_OWNER_OF_NFT));
+        Bytes pretendArguments = givenMinimalFrameContextWithoutParentUpdater(nestedPretendArguments);
 
-        given(nestedPretendArguments.getInt(0)).willReturn(ABI_ID_OWNER_OF_NFT);
         given(wrappedLedgers.typeOf(token)).willReturn(TokenType.FUNGIBLE_COMMON);
         subject.prepareFields(frame);
 
         final var exception = assertThrows(InvalidTransactionException.class,
-                () -> subject.prepareComputation(pretendArguments, а -> а));
+                () -> subject.prepareComputation(pretendArguments, a -> a));
         assertEquals(NOT_SUPPORTED_FUNGIBLE_OPERATION_REASON, exception.getMessage());
     }
 
     @Test
     void tokenURINotSupported() {
-        givenMinimalFrameContextWithoutParentUpdater();
+        Bytes nestedPretendArguments = Bytes.of(Integers.toBytes(ABI_ID_TOKEN_URI_NFT));
+        Bytes pretendArguments = givenMinimalFrameContextWithoutParentUpdater(nestedPretendArguments);
 
         given(wrappedLedgers.typeOf(token)).willReturn(TokenType.FUNGIBLE_COMMON);
-        given(nestedPretendArguments.getInt(0)).willReturn(ABI_ID_TOKEN_URI_NFT);
         subject.prepareFields(frame);
 
         final var exception = assertThrows(InvalidTransactionException.class,
-                () -> subject.prepareComputation(pretendArguments, а -> а));
+                () -> subject.prepareComputation(pretendArguments, a -> a));
         assertEquals(NOT_SUPPORTED_FUNGIBLE_OPERATION_REASON, exception.getMessage());
     }
 
-    private void givenMinimalFrameContext() {
+    private Bytes givenMinimalFrameContext(Bytes nestedArg) {
         given(frame.getSenderAddress()).willReturn(contractAddress);
         given(frame.getWorldUpdater()).willReturn(worldUpdater);
-        given(frame.getRemainingGas()).willReturn(Gas.of(300));
+        given(frame.getRemainingGas()).willReturn(300L);
         given(frame.getValue()).willReturn(Wei.ZERO);
         Optional<WorldUpdater> parent = Optional.of(worldUpdater);
         given(worldUpdater.parentUpdater()).willReturn(parent);
         given(worldUpdater.wrappedTrackingLedgers(any())).willReturn(wrappedLedgers);
-        given(pretendArguments.getInt(0)).willReturn(ABI_ID_REDIRECT_FOR_TOKEN);
-        given(pretendArguments.slice(4, 20)).willReturn(fungibleTokenAddr);
-        given(pretendArguments.slice(24)).willReturn(nestedPretendArguments);
+        return Bytes.concatenate(
+                Bytes.of(Integers.toBytes(ABI_ID_REDIRECT_FOR_TOKEN)),
+                fungibleTokenAddr,
+                nestedArg);
     }
 
-    private void givenMinimalFrameContextWithoutParentUpdater() {
+    private Bytes givenMinimalFrameContextWithoutParentUpdater(Bytes nestedArg) {
         given(frame.getSenderAddress()).willReturn(contractAddress);
         given(frame.getWorldUpdater()).willReturn(worldUpdater);
         given(worldUpdater.wrappedTrackingLedgers(any())).willReturn(wrappedLedgers);
-        given(pretendArguments.getInt(0)).willReturn(ABI_ID_REDIRECT_FOR_TOKEN);
-        given(pretendArguments.slice(4, 20)).willReturn(fungibleTokenAddr);
-        given(pretendArguments.slice(24)).willReturn(nestedPretendArguments);
+        return Bytes.concatenate(
+                Bytes.of(Integers.toBytes(ABI_ID_REDIRECT_FOR_TOKEN)),
+                fungibleTokenAddr,
+                nestedArg);
     }
 
     private void givenLedgers() {

--- a/hedera-node/src/test/java/com/hedera/services/store/contracts/precompile/ERC721PrecompilesTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/store/contracts/precompile/ERC721PrecompilesTest.java
@@ -19,6 +19,7 @@ package com.hedera.services.store.contracts.precompile;
  * ‍
  */
 
+import com.esaulpaugh.headlong.util.Integers;
 import com.hedera.services.context.SideEffectsTracker;
 import com.hedera.services.context.primitives.StateView;
 import com.hedera.services.context.properties.GlobalDynamicProperties;
@@ -81,7 +82,6 @@ import org.apache.commons.lang3.tuple.Pair;
 import org.apache.tuweni.bytes.Bytes;
 import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.datatypes.Wei;
-import org.hyperledger.besu.evm.Gas;
 import org.hyperledger.besu.evm.frame.MessageFrame;
 import org.hyperledger.besu.evm.gascalculator.GasCalculator;
 import org.hyperledger.besu.evm.worldstate.WorldUpdater;
@@ -159,8 +159,6 @@ import static org.mockito.Mockito.verify;
 @ExtendWith(MockitoExtension.class)
 class ERC721PrecompilesTest {
 	@Mock
-	private Bytes pretendArguments;
-	@Mock
 	private GlobalDynamicProperties dynamicProperties;
 	@Mock
 	private OptionValidator validator;
@@ -216,8 +214,6 @@ class ERC721PrecompilesTest {
 	private HTSPrecompiledContract.TransferLogicFactory transferLogicFactory;
 	@Mock
 	private HTSPrecompiledContract.HederaTokenStoreFactory hederaTokenStoreFactory;
-	@Mock
-	private Bytes nestedPretendArguments;
 	@Mock
 	private FeeObject mockFeeObject;
 	@Mock
@@ -296,8 +292,7 @@ class ERC721PrecompilesTest {
 
 	@Test
 	void name() {
-		givenMinimalFrameContext();
-		given(pretendArguments.slice(24)).willReturn(Bytes.fromHexString("0" + Integer.toHexString(ABI_ID_NAME)));
+		Bytes pretendArguments = givenMinimalFrameContext(Bytes.of(Integers.toBytes(ABI_ID_NAME)));
 		given(syntheticTxnFactory.createTransactionCall(1L, pretendArguments)).willReturn(mockSynthBodyBuilder);
 		given(creator.createSuccessfulSyntheticRecord(Collections.emptyList(), sideEffects, EMPTY_MEMO))
 				.willReturn(mockRecordBuilder);
@@ -314,7 +309,7 @@ class ERC721PrecompilesTest {
 
 		// when:
 		subject.prepareFields(frame);
-		subject.prepareComputation(pretendArguments, а -> а);
+		subject.prepareComputation(pretendArguments, a -> a);
 		subject.computeViewFunctionGasRequirement(TEST_CONSENSUS_TIME);
 		final var result = subject.computeInternal(frame);
 
@@ -326,8 +321,7 @@ class ERC721PrecompilesTest {
 
 	@Test
 	void symbol() {
-		givenMinimalFrameContext();
-		given(pretendArguments.slice(24)).willReturn(Bytes.fromHexString(Integer.toHexString(ABI_ID_SYMBOL)));
+		Bytes pretendArguments = givenMinimalFrameContext(Bytes.of(Integers.toBytes(ABI_ID_SYMBOL)));
 		given(syntheticTxnFactory.createTransactionCall(1L, pretendArguments)).willReturn(mockSynthBodyBuilder);
 		given(creator.createSuccessfulSyntheticRecord(Collections.emptyList(), sideEffects, EMPTY_MEMO))
 				.willReturn(mockRecordBuilder);
@@ -344,7 +338,7 @@ class ERC721PrecompilesTest {
 
 		// when:
 		subject.prepareFields(frame);
-		subject.prepareComputation(pretendArguments, а -> а);
+		subject.prepareComputation(pretendArguments, a -> a);
 		subject.computeViewFunctionGasRequirement(TEST_CONSENSUS_TIME);
 		final var result = subject.computeInternal(frame);
 
@@ -361,8 +355,8 @@ class ERC721PrecompilesTest {
 				EntityNum.fromLong(receiver.getAccountNum()));
 		allowances.add(fcTokenAllowanceId);
 
-		givenMinimalFrameContext();
-		given(nestedPretendArguments.getInt(0)).willReturn(ABI_ID_IS_APPROVED_FOR_ALL);
+		Bytes nestedPretendArguments = Bytes.of(Integers.toBytes(ABI_ID_IS_APPROVED_FOR_ALL));
+		Bytes pretendArguments = givenMinimalFrameContext(nestedPretendArguments);
 		given(wrappedLedgers.accounts()).willReturn(accounts);
 		given(accounts.contains(IS_APPROVE_FOR_ALL_WRAPPER.owner())).willReturn(true);
 		given(accounts.contains(IS_APPROVE_FOR_ALL_WRAPPER.operator())).willReturn(true);
@@ -388,7 +382,7 @@ class ERC721PrecompilesTest {
 
 		// when:
 		subject.prepareFields(frame);
-		subject.prepareComputation(pretendArguments, а -> а);
+		subject.prepareComputation(pretendArguments, a -> a);
 		subject.computeViewFunctionGasRequirement(TEST_CONSENSUS_TIME);
 		final var result = subject.computeInternal(frame);
 
@@ -400,8 +394,8 @@ class ERC721PrecompilesTest {
 
 	@Test
 	void isApprovedForAllWorksWithOperatorMissing() {
-		givenMinimalFrameContext();
-		given(nestedPretendArguments.getInt(0)).willReturn(ABI_ID_IS_APPROVED_FOR_ALL);
+		Bytes nestedPretendArguments = Bytes.of(Integers.toBytes(ABI_ID_IS_APPROVED_FOR_ALL));
+		Bytes pretendArguments = givenMinimalFrameContext(nestedPretendArguments);
 		given(wrappedLedgers.accounts()).willReturn(accounts);
 		given(accounts.contains(IS_APPROVE_FOR_ALL_WRAPPER.owner())).willReturn(true);
 		given(syntheticTxnFactory.createTransactionCall(1L, pretendArguments)).willReturn(mockSynthBodyBuilder);
@@ -425,7 +419,7 @@ class ERC721PrecompilesTest {
 
 		// when:
 		subject.prepareFields(frame);
-		subject.prepareComputation(pretendArguments, а -> а);
+		subject.prepareComputation(pretendArguments, a -> a);
 		subject.computeViewFunctionGasRequirement(TEST_CONSENSUS_TIME);
 		final var result = subject.computeInternal(frame);
 
@@ -440,9 +434,9 @@ class ERC721PrecompilesTest {
 		List<CryptoAllowance> cryptoAllowances = new ArrayList<>();
 		List<TokenAllowance> tokenAllowances = new ArrayList<>();
 		List<NftAllowance> nftAllowances = new ArrayList<>();
-		givenMinimalFrameContext();
-
-		given(nestedPretendArguments.getInt(0)).willReturn(ABI_ID_APPROVE);
+		Bytes nestedPretendArguments = Bytes.of(Integers.toBytes(ABI_ID_APPROVE));
+		Bytes pretendArguments = givenMinimalFrameContext(nestedPretendArguments);
+		
 		given(wrappedLedgers.tokens()).willReturn(tokens);
 		given(wrappedLedgers.accounts()).willReturn(accounts);
 		given(creator.createSuccessfulSyntheticRecord(Collections.emptyList(), sideEffects, EMPTY_MEMO))
@@ -479,7 +473,7 @@ class ERC721PrecompilesTest {
 
 		// when:
 		subject.prepareFields(frame);
-		subject.prepareComputation(pretendArguments, а -> а);
+		subject.prepareComputation(pretendArguments, a -> a);
 		subject.computeViewFunctionGasRequirement(TEST_CONSENSUS_TIME);
 		final var result = subject.computeInternal(frame);
 
@@ -494,9 +488,9 @@ class ERC721PrecompilesTest {
 		List<CryptoAllowance> cryptoAllowances = new ArrayList<>();
 		List<TokenAllowance> tokenAllowances = new ArrayList<>();
 		List<NftAllowance> nftAllowances = new ArrayList<>();
-		givenMinimalFrameContext();
-
-		given(nestedPretendArguments.getInt(0)).willReturn(ABI_ID_APPROVE);
+		Bytes nestedPretendArguments = Bytes.of(Integers.toBytes(ABI_ID_APPROVE));
+		Bytes pretendArguments = givenMinimalFrameContext(nestedPretendArguments);
+		
 		given(wrappedLedgers.tokens()).willReturn(tokens);
 		given(wrappedLedgers.accounts()).willReturn(accounts);
 
@@ -536,7 +530,7 @@ class ERC721PrecompilesTest {
 
 		// when:
 		subject.prepareFields(frame);
-		subject.prepareComputation(pretendArguments, а -> а);
+		subject.prepareComputation(pretendArguments, a -> a);
 		subject.computeViewFunctionGasRequirement(TEST_CONSENSUS_TIME);
 		final var result = subject.computeInternal(frame);
 		final var expectedFailure = EncodingFacade.resultFrom(SENDER_DOES_NOT_OWN_NFT_SERIAL_NO);
@@ -547,9 +541,9 @@ class ERC721PrecompilesTest {
 
 	@Test
 	void approveSpender0WhenOwner() {
-		givenMinimalFrameContext();
-
-		given(nestedPretendArguments.getInt(0)).willReturn(ABI_ID_APPROVE);
+		Bytes nestedPretendArguments = Bytes.of(Integers.toBytes(ABI_ID_APPROVE));
+		Bytes pretendArguments = givenMinimalFrameContext(nestedPretendArguments);
+		
 		given(wrappedLedgers.tokens()).willReturn(tokens);
 		given(wrappedLedgers.accounts()).willReturn(accounts);
 		given(wrappedLedgers.nfts()).willReturn(nfts);
@@ -593,7 +587,7 @@ class ERC721PrecompilesTest {
 
 		// when:
 		subject.prepareFields(frame);
-		subject.prepareComputation(pretendArguments, а -> а);
+		subject.prepareComputation(pretendArguments, a -> a);
 		subject.computeViewFunctionGasRequirement(TEST_CONSENSUS_TIME);
 		final var result = subject.computeInternal(frame);
 
@@ -605,9 +599,9 @@ class ERC721PrecompilesTest {
 
 	@Test
 	void approveSpender0WhenGrantedApproveForAll() {
-		givenMinimalFrameContext();
-
-		given(nestedPretendArguments.getInt(0)).willReturn(ABI_ID_APPROVE);
+		Bytes nestedPretendArguments = Bytes.of(Integers.toBytes(ABI_ID_APPROVE));
+		Bytes pretendArguments = givenMinimalFrameContext(nestedPretendArguments);
+		
 		given(wrappedLedgers.tokens()).willReturn(tokens);
 		given(wrappedLedgers.accounts()).willReturn(accounts);
 		given(wrappedLedgers.nfts()).willReturn(nfts);
@@ -650,7 +644,7 @@ class ERC721PrecompilesTest {
 
 		// when:
 		subject.prepareFields(frame);
-		subject.prepareComputation(pretendArguments, а -> а);
+		subject.prepareComputation(pretendArguments, a -> a);
 		subject.computeViewFunctionGasRequirement(TEST_CONSENSUS_TIME);
 		final var result = subject.computeInternal(frame);
 
@@ -662,9 +656,8 @@ class ERC721PrecompilesTest {
 
 	@Test
 	void approveSpender0NoGoodIfNotPermissioned() {
-		givenMinimalFrameContext();
-
-		given(nestedPretendArguments.getInt(0)).willReturn(ABI_ID_APPROVE);
+		Bytes nestedPretendArguments = Bytes.of(Integers.toBytes(ABI_ID_APPROVE));
+		Bytes pretendArguments = givenMinimalFrameContext(nestedPretendArguments);
 
 		given(feeCalculator.estimatedGasPriceInTinybars(HederaFunctionality.ContractCall, timestamp))
 				.willReturn(1L);
@@ -690,7 +683,7 @@ class ERC721PrecompilesTest {
 
 		// when:
 		subject.prepareFields(frame);
-		subject.prepareComputation(pretendArguments, а -> а);
+		subject.prepareComputation(pretendArguments, a -> a);
 		subject.computeViewFunctionGasRequirement(TEST_CONSENSUS_TIME);
 		final var result = subject.computeInternal(frame);
 		final var expectedFailure = EncodingFacade.resultFrom(SENDER_DOES_NOT_OWN_NFT_SERIAL_NO);
@@ -701,9 +694,8 @@ class ERC721PrecompilesTest {
 
 	@Test
 	void validatesImpliedNftApprovalDeletion() {
-		givenMinimalFrameContext();
-
-		given(nestedPretendArguments.getInt(0)).willReturn(ABI_ID_APPROVE);
+		Bytes nestedPretendArguments = Bytes.of(Integers.toBytes(ABI_ID_APPROVE));
+		Bytes pretendArguments = givenMinimalFrameContext(nestedPretendArguments);
 		given(wrappedLedgers.tokens()).willReturn(tokens);
 		given(wrappedLedgers.accounts()).willReturn(accounts);
 		given(wrappedLedgers.nfts()).willReturn(nfts);
@@ -740,7 +732,7 @@ class ERC721PrecompilesTest {
 
 		// when:
 		subject.prepareFields(frame);
-		subject.prepareComputation(pretendArguments, а -> а);
+		subject.prepareComputation(pretendArguments, a -> a);
 		subject.computeViewFunctionGasRequirement(TEST_CONSENSUS_TIME);
 		final var result = subject.computeInternal(frame);
 		final var expectedFailure = EncodingFacade.resultFrom(INVALID_ALLOWANCE_OWNER_ID);
@@ -754,9 +746,10 @@ class ERC721PrecompilesTest {
 		List<CryptoAllowance> cryptoAllowances = new ArrayList<>();
 		List<TokenAllowance> tokenAllowances = new ArrayList<>();
 		List<NftAllowance> nftAllowances = new ArrayList<>();
-		givenMinimalFrameContext();
-
-		given(nestedPretendArguments.getInt(0)).willReturn(ABI_ID_APPROVE);
+		
+		Bytes nestedPretendArguments = Bytes.of(Integers.toBytes(ABI_ID_APPROVE));
+		Bytes pretendArguments = givenMinimalFrameContext(nestedPretendArguments);
+		
 		given(wrappedLedgers.tokens()).willReturn(tokens);
 		given(wrappedLedgers.accounts()).willReturn(accounts);
 
@@ -790,7 +783,7 @@ class ERC721PrecompilesTest {
 
 		// when:
 		subject.prepareFields(frame);
-		subject.prepareComputation(pretendArguments, а -> а);
+		subject.prepareComputation(pretendArguments, a -> a);
 		subject.computeViewFunctionGasRequirement(TEST_CONSENSUS_TIME);
 		final var result = subject.computeInternal(frame);
 
@@ -803,9 +796,10 @@ class ERC721PrecompilesTest {
 		List<CryptoAllowance> cryptoAllowances = new ArrayList<>();
 		List<TokenAllowance> tokenAllowances = new ArrayList<>();
 		List<NftAllowance> nftAllowances = new ArrayList<>();
-		givenMinimalFrameContext();
 
-		given(nestedPretendArguments.getInt(0)).willReturn(ABI_ID_SET_APPROVAL_FOR_ALL);
+		Bytes nestedPretendArguments = Bytes.of(Integers.toBytes(ABI_ID_SET_APPROVAL_FOR_ALL));
+		Bytes pretendArguments = givenMinimalFrameContext(nestedPretendArguments);
+		
 		given(wrappedLedgers.tokens()).willReturn(tokens);
 		given(wrappedLedgers.accounts()).willReturn(accounts);
 		given(creator.createSuccessfulSyntheticRecord(Collections.emptyList(), sideEffects, EMPTY_MEMO))
@@ -839,7 +833,7 @@ class ERC721PrecompilesTest {
 
 		// when:
 		subject.prepareFields(frame);
-		subject.prepareComputation(pretendArguments, а -> а);
+		subject.prepareComputation(pretendArguments, a -> a);
 		subject.computeViewFunctionGasRequirement(TEST_CONSENSUS_TIME);
 		final var result = subject.computeInternal(frame);
 
@@ -856,8 +850,9 @@ class ERC721PrecompilesTest {
 				EntityNum.fromLong(receiver.getAccountNum()));
 		allowances.add(fcTokenAllowanceId);
 
-		givenMinimalFrameContext();
-		given(nestedPretendArguments.getInt(0)).willReturn(ABI_ID_GET_APPROVED);
+		Bytes nestedPretendArguments = Bytes.of(Integers.toBytes(ABI_ID_GET_APPROVED));
+		Bytes pretendArguments = givenMinimalFrameContext(nestedPretendArguments);
+		
 		given(wrappedLedgers.nfts()).willReturn(nfts);
 		final var nftId = NftId.fromGrpc(token, GET_APPROVED_WRAPPER.serialNo());
 		given(nfts.contains(nftId)).willReturn(true);
@@ -878,7 +873,7 @@ class ERC721PrecompilesTest {
 
 		// when:
 		subject.prepareFields(frame);
-		subject.prepareComputation(pretendArguments, а -> а);
+		subject.prepareComputation(pretendArguments, a -> a);
 		subject.computeViewFunctionGasRequirement(TEST_CONSENSUS_TIME);
 		final var result = subject.computeInternal(frame);
 
@@ -890,9 +885,7 @@ class ERC721PrecompilesTest {
 
 	@Test
 	void totalSupply() {
-		givenMinimalFrameContext();
-		given(pretendArguments.slice(24)).willReturn(
-				Bytes.fromHexString(Integer.toHexString(ABI_ID_TOTAL_SUPPLY_TOKEN)));
+		Bytes pretendArguments = givenMinimalFrameContext(Bytes.of(Integers.toBytes(ABI_ID_TOTAL_SUPPLY_TOKEN)));
 		given(syntheticTxnFactory.createTransactionCall(1L, pretendArguments)).willReturn(mockSynthBodyBuilder);
 		given(creator.createSuccessfulSyntheticRecord(Collections.emptyList(), sideEffects, EMPTY_MEMO))
 				.willReturn(mockRecordBuilder);
@@ -909,7 +902,7 @@ class ERC721PrecompilesTest {
 		given(encoder.encodeTotalSupply(10L)).willReturn(successResult);
 
 		subject.prepareFields(frame);
-		subject.prepareComputation(pretendArguments, а -> а);
+		subject.prepareComputation(pretendArguments, a -> a);
 		subject.computeViewFunctionGasRequirement(TEST_CONSENSUS_TIME);
 		final var result = subject.computeInternal(frame);
 
@@ -920,9 +913,10 @@ class ERC721PrecompilesTest {
 
 	@Test
 	void balanceOf() {
-		givenMinimalFrameContext();
+		Bytes nestedPretendArguments = Bytes.of(Integers.toBytes(ABI_ID_BALANCE_OF_TOKEN));
+		Bytes pretendArguments = givenMinimalFrameContext(nestedPretendArguments);
+		
 		given(syntheticTxnFactory.createTransactionCall(1L, pretendArguments)).willReturn(mockSynthBodyBuilder);
-		given(nestedPretendArguments.getInt(0)).willReturn(ABI_ID_BALANCE_OF_TOKEN);
 		given(creator.createSuccessfulSyntheticRecord(Collections.emptyList(), sideEffects, EMPTY_MEMO))
 				.willReturn(mockRecordBuilder);
 		given(feeCalculator.estimatedGasPriceInTinybars(HederaFunctionality.ContractCall, timestamp))
@@ -941,7 +935,7 @@ class ERC721PrecompilesTest {
 
 		// when:
 		subject.prepareFields(frame);
-		subject.prepareComputation(pretendArguments, а -> а);
+		subject.prepareComputation(pretendArguments, a -> a);
 		subject.computeViewFunctionGasRequirement(TEST_CONSENSUS_TIME);
 
 		// then:
@@ -952,10 +946,10 @@ class ERC721PrecompilesTest {
 
 	@Test
 	void ownerOfHappyPathWorks() {
-		givenMinimalFrameContext();
-
+		Bytes nestedPretendArguments = Bytes.of(Integers.toBytes(ABI_ID_OWNER_OF_NFT));
+		Bytes pretendArguments = givenMinimalFrameContext(nestedPretendArguments);
+		
 		given(syntheticTxnFactory.createTransactionCall(1L, pretendArguments)).willReturn(mockSynthBodyBuilder);
-		given(nestedPretendArguments.getInt(0)).willReturn(ABI_ID_OWNER_OF_NFT);
 		given(creator.createSuccessfulSyntheticRecord(Collections.emptyList(), sideEffects, EMPTY_MEMO))
 				.willReturn(mockRecordBuilder);
 		given(feeCalculator.estimatedGasPriceInTinybars(HederaFunctionality.ContractCall, timestamp))
@@ -976,7 +970,7 @@ class ERC721PrecompilesTest {
 
 		// when:
 		subject.prepareFields(frame);
-		subject.prepareComputation(pretendArguments, а -> а);
+		subject.prepareComputation(pretendArguments, a -> a);
 		subject.computeViewFunctionGasRequirement(TEST_CONSENSUS_TIME);
 		final var result = subject.computeInternal(frame);
 
@@ -986,10 +980,10 @@ class ERC721PrecompilesTest {
 
 	@Test
 	void ownerOfRevertsWithMissingNft() {
-		givenMinimalFrameContext();
-
+		Bytes nestedPretendArguments = Bytes.of(Integers.toBytes(ABI_ID_OWNER_OF_NFT));
+		Bytes pretendArguments = givenMinimalFrameContext(nestedPretendArguments);
+		
 		given(syntheticTxnFactory.createTransactionCall(1L, pretendArguments)).willReturn(mockSynthBodyBuilder);
-		given(nestedPretendArguments.getInt(0)).willReturn(ABI_ID_OWNER_OF_NFT);
 		given(creator.createSuccessfulSyntheticRecord(Collections.emptyList(), sideEffects, EMPTY_MEMO))
 				.willReturn(mockRecordBuilder);
 		given(feeCalculator.estimatedGasPriceInTinybars(HederaFunctionality.ContractCall, timestamp))
@@ -1006,7 +1000,7 @@ class ERC721PrecompilesTest {
 
 		// when:
 		subject.prepareFields(frame);
-		subject.prepareComputation(pretendArguments, а -> а);
+		subject.prepareComputation(pretendArguments, a -> a);
 		subject.computeViewFunctionGasRequirement(TEST_CONSENSUS_TIME);
 		final var result = subject.computeInternal(frame);
 
@@ -1015,13 +1009,13 @@ class ERC721PrecompilesTest {
 
 	@Test
 	void transferFrom() {
-		givenMinimalFrameContext();
+		Bytes nestedPretendArguments = Bytes.of(Integers.toBytes(ABI_ID_ERC_TRANSFER_FROM));
+		Bytes pretendArguments = givenMinimalFrameContext(nestedPretendArguments);
 		givenLedgers();
 
 		given(frame.getContractAddress()).willReturn(contractAddr);
 		given(syntheticTxnFactory.createCryptoTransfer(Collections.singletonList(TOKEN_TRANSFER_WRAPPER)))
 				.willReturn(mockSynthBodyBuilder);
-		given(nestedPretendArguments.getInt(0)).willReturn(ABI_ID_ERC_TRANSFER_FROM);
 		given(mockSynthBodyBuilder.getCryptoTransfer()).willReturn(cryptoTransferTransactionBody);
 		given(frame.getSenderAddress()).willReturn(senderAddress);
 		given(impliedTransfersMarshal.validityWithCurrentProps(cryptoTransferTransactionBody)).willReturn(OK);
@@ -1068,7 +1062,7 @@ class ERC721PrecompilesTest {
 
 		// when:
 		subject.prepareFields(frame);
-		subject.prepareComputation(pretendArguments, а -> а);
+		subject.prepareComputation(pretendArguments, a -> a);
 		subject.computeGasRequirement(TEST_CONSENSUS_TIME);
 		final var result = subject.computeInternal(frame);
 
@@ -1083,13 +1077,13 @@ class ERC721PrecompilesTest {
 
 	@Test
 	void transferFromFailsForInvalidSig() {
-		givenMinimalFrameContext();
+		Bytes nestedPretendArguments = Bytes.of(Integers.toBytes(ABI_ID_ERC_TRANSFER_FROM));
+		Bytes pretendArguments = givenMinimalFrameContext(nestedPretendArguments);
 		givenLedgers();
 
 		given(frame.getContractAddress()).willReturn(contractAddr);
 		given(syntheticTxnFactory.createCryptoTransfer(Collections.singletonList(TOKEN_TRANSFER_WRAPPER)))
 				.willReturn(mockSynthBodyBuilder);
-		given(nestedPretendArguments.getInt(0)).willReturn(ABI_ID_ERC_TRANSFER_FROM);
 		given(mockSynthBodyBuilder.getCryptoTransfer()).willReturn(cryptoTransferTransactionBody);
 		given(impliedTransfersMarshal.validityWithCurrentProps(cryptoTransferTransactionBody)).willReturn(OK);
 		given(sigsVerifier.hasActiveKey(Mockito.anyBoolean(), any(), any(), any())).willReturn(false);
@@ -1124,7 +1118,7 @@ class ERC721PrecompilesTest {
 		given(worldUpdater.aliases()).willReturn(aliases);
 		// when:
 		subject.prepareFields(frame);
-		subject.prepareComputation(pretendArguments, а -> а);
+		subject.prepareComputation(pretendArguments, a -> a);
 		subject.computeGasRequirement(TEST_CONSENSUS_TIME);
 		final var result = subject.computeInternal(frame);
 
@@ -1134,10 +1128,10 @@ class ERC721PrecompilesTest {
 
 	@Test
 	void erc721SystemFailureSurfacesResult() {
-		givenMinimalFrameContext();
+		Bytes nestedPretendArguments = Bytes.of(Integers.toBytes(ABI_ID_OWNER_OF_NFT));
+		Bytes pretendArguments = givenMinimalFrameContext(nestedPretendArguments);
 
 		given(syntheticTxnFactory.createTransactionCall(1L, pretendArguments)).willReturn(mockSynthBodyBuilder);
-		given(nestedPretendArguments.getInt(0)).willReturn(ABI_ID_OWNER_OF_NFT);
 		given(creator.createSuccessfulSyntheticRecord(Collections.emptyList(), sideEffects, EMPTY_MEMO))
 				.willReturn(mockRecordBuilder);
 		given(feeCalculator.estimatedGasPriceInTinybars(HederaFunctionality.ContractCall, timestamp))
@@ -1153,7 +1147,7 @@ class ERC721PrecompilesTest {
 
 		// when:
 		subject.prepareFields(frame);
-		subject.prepareComputation(pretendArguments, а -> а);
+		subject.prepareComputation(pretendArguments, a -> a);
 		subject.computeViewFunctionGasRequirement(TEST_CONSENSUS_TIME);
 		final var result = subject.computeInternal(frame);
 
@@ -1162,10 +1156,10 @@ class ERC721PrecompilesTest {
 
 	@Test
 	void tokenURI() {
-		givenMinimalFrameContext();
+		Bytes nestedPretendArguments = Bytes.of(Integers.toBytes(ABI_ID_TOKEN_URI_NFT));
+		Bytes pretendArguments = givenMinimalFrameContext(nestedPretendArguments);
 
 		given(syntheticTxnFactory.createTransactionCall(1L, pretendArguments)).willReturn(mockSynthBodyBuilder);
-		given(nestedPretendArguments.getInt(0)).willReturn(ABI_ID_TOKEN_URI_NFT);
 		given(creator.createSuccessfulSyntheticRecord(Collections.emptyList(), sideEffects, EMPTY_MEMO))
 				.willReturn(mockRecordBuilder);
 		given(feeCalculator.estimatedGasPriceInTinybars(HederaFunctionality.ContractCall, timestamp))
@@ -1183,7 +1177,7 @@ class ERC721PrecompilesTest {
 
 		// when:
 		subject.prepareFields(frame);
-		subject.prepareComputation(pretendArguments, а -> а);
+		subject.prepareComputation(pretendArguments, a -> a);
 		subject.computeViewFunctionGasRequirement(TEST_CONSENSUS_TIME);
 		final var result = subject.computeInternal(frame);
 
@@ -1193,48 +1187,48 @@ class ERC721PrecompilesTest {
 
 	@Test
 	void transferNotSupported() {
-		givenMinimalFrameContextWithoutParentUpdater();
-		given(nestedPretendArguments.getInt(0)).willReturn(ABI_ID_ERC_TRANSFER);
+		Bytes pretendArguments = givenMinimalFrameContextWithoutParentUpdater(Bytes.of(Integers.toBytes(ABI_ID_ERC_TRANSFER)));
 		given(wrappedLedgers.typeOf(token)).willReturn(TokenType.NON_FUNGIBLE_UNIQUE);
 		subject.prepareFields(frame);
 
 		final var exception = assertThrows(InvalidTransactionException.class,
-				() -> subject.prepareComputation(pretendArguments, а -> а));
+				() -> subject.prepareComputation(pretendArguments, a -> a));
 		assertEquals(NOT_SUPPORTED_NON_FUNGIBLE_OPERATION_REASON, exception.getMessage());
 	}
 
 	@Test
 	void decimalsNotSupported() {
-		givenMinimalFrameContextWithoutParentUpdater();
-		given(nestedPretendArguments.getInt(0)).willReturn(ABI_ID_DECIMALS);
+		Bytes pretendArguments = givenMinimalFrameContextWithoutParentUpdater(Bytes.of(Integers.toBytes(ABI_ID_DECIMALS)));
 		given(wrappedLedgers.typeOf(token)).willReturn(TokenType.NON_FUNGIBLE_UNIQUE);
 		subject.prepareFields(frame);
 
 		final var exception = assertThrows(InvalidTransactionException.class,
-				() -> subject.prepareComputation(pretendArguments, а -> а));
+				() -> subject.prepareComputation(pretendArguments, a -> a));
 		assertEquals(NOT_SUPPORTED_NON_FUNGIBLE_OPERATION_REASON, exception.getMessage());
 	}
 
-	private void givenMinimalFrameContext() {
+	private Bytes givenMinimalFrameContext(Bytes nestedPretendArguments) {
 		given(frame.getSenderAddress()).willReturn(contractAddress);
 		given(frame.getWorldUpdater()).willReturn(worldUpdater);
-		given(frame.getRemainingGas()).willReturn(Gas.of(300));
+        given(frame.getRemainingGas()).willReturn(300L);
 		given(frame.getValue()).willReturn(Wei.ZERO);
 		Optional<WorldUpdater> parent = Optional.of(worldUpdater);
 		given(worldUpdater.parentUpdater()).willReturn(parent);
 		given(worldUpdater.wrappedTrackingLedgers(any())).willReturn(wrappedLedgers);
-		given(pretendArguments.getInt(0)).willReturn(ABI_ID_REDIRECT_FOR_TOKEN);
-		given(pretendArguments.slice(4, 20)).willReturn(nonFungibleTokenAddr);
-		given(pretendArguments.slice(24)).willReturn(nestedPretendArguments);
+		return Bytes.concatenate(
+				Bytes.of(Integers.toBytes(ABI_ID_REDIRECT_FOR_TOKEN)),
+				nonFungibleTokenAddr,
+				nestedPretendArguments);
 	}
 
-	private void givenMinimalFrameContextWithoutParentUpdater() {
+	private Bytes givenMinimalFrameContextWithoutParentUpdater(Bytes nestedPretendArguments) {
 		given(frame.getSenderAddress()).willReturn(contractAddress);
 		given(frame.getWorldUpdater()).willReturn(worldUpdater);
 		given(worldUpdater.wrappedTrackingLedgers(any())).willReturn(wrappedLedgers);
-		given(pretendArguments.getInt(0)).willReturn(ABI_ID_REDIRECT_FOR_TOKEN);
-		given(pretendArguments.slice(4, 20)).willReturn(nonFungibleTokenAddr);
-		given(pretendArguments.slice(24)).willReturn(nestedPretendArguments);
+		return Bytes.concatenate(
+				Bytes.of(Integers.toBytes(ABI_ID_REDIRECT_FOR_TOKEN)),
+				nonFungibleTokenAddr,
+				nestedPretendArguments);
 	}
 
 	public static final BalanceOfWrapper BALANCE_OF_WRAPPER = new BalanceOfWrapper(sender);

--- a/hedera-node/src/test/java/com/hedera/services/store/contracts/precompile/ExchangeRatePrecompiledContractTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/store/contracts/precompile/ExchangeRatePrecompiledContractTest.java
@@ -26,7 +26,6 @@ import com.hedera.services.fees.HbarCentExchange;
 import com.hederahashgraph.api.proto.java.ExchangeRate;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
-import org.hyperledger.besu.evm.Gas;
 import org.hyperledger.besu.evm.frame.MessageFrame;
 import org.hyperledger.besu.evm.gascalculator.GasCalculator;
 import org.junit.jupiter.api.BeforeEach;
@@ -168,5 +167,5 @@ class ExchangeRatePrecompiledContractTest {
 			.build();
 	private static final long someTinybarAmount = tinycentsToTinybars(someTinycentAmount, someRate);
 	private static final Instant now = Instant.ofEpochSecond(1_234_567, 890);
-	private static final Gas GAS_REQUIREMENT = Gas.of(100L);
+	private static final long GAS_REQUIREMENT = 100L;
 }

--- a/hedera-node/src/test/java/com/hedera/services/store/contracts/precompile/TransferPrecompilesTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/store/contracts/precompile/TransferPrecompilesTest.java
@@ -20,6 +20,7 @@ package com.hedera.services.store.contracts.precompile;
  * ‍
  */
 
+import com.esaulpaugh.headlong.util.Integers;
 import com.hedera.services.context.SideEffectsTracker;
 import com.hedera.services.context.primitives.StateView;
 import com.hedera.services.context.properties.GlobalDynamicProperties;
@@ -71,7 +72,6 @@ import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.units.bigints.UInt256;
 import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.datatypes.Wei;
-import org.hyperledger.besu.evm.Gas;
 import org.hyperledger.besu.evm.frame.MessageFrame;
 import org.hyperledger.besu.evm.gascalculator.GasCalculator;
 import org.hyperledger.besu.evm.worldstate.WorldUpdater;
@@ -132,8 +132,6 @@ import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
 class TransferPrecompilesTest {
-	@Mock
-	private Bytes pretendArguments;
 	@Mock
 	private HederaTokenStore hederaTokenStore;
 	@Mock
@@ -241,9 +239,10 @@ class TransferPrecompilesTest {
 
 	@Test
 	void transferFailsFastGivenWrongSyntheticValidity() {
+		Bytes pretendArguments = Bytes.of(Integers.toBytes(ABI_ID_TRANSFER_TOKENS));
 		given(frame.getWorldUpdater()).willReturn(worldUpdater);
 		given(frame.getSenderAddress()).willReturn(contractAddress);
-		given(frame.getRemainingGas()).willReturn(Gas.of(300));
+		given(frame.getRemainingGas()).willReturn(300L);
 		Optional<WorldUpdater> parent = Optional.of(worldUpdater);
 		given(worldUpdater.parentUpdater()).willReturn(parent);
 		given(worldUpdater.wrappedTrackingLedgers(any())).willReturn(wrappedLedgers);
@@ -256,7 +255,6 @@ class TransferPrecompilesTest {
 		given(impliedTransfersMarshal.validityWithCurrentProps(cryptoTransferTransactionBody))
 				.willReturn(TRANSFERS_NOT_ZERO_SUM_FOR_TOKEN);
 
-		given(pretendArguments.getInt(0)).willReturn(ABI_ID_TRANSFER_TOKENS);
 		given(feeCalculator.estimatedGasPriceInTinybars(HederaFunctionality.ContractCall, timestamp))
 				.willReturn(1L);
 		given(mockSynthBodyBuilder.build()).
@@ -270,13 +268,13 @@ class TransferPrecompilesTest {
 		given(creator.createUnsuccessfulSyntheticRecord(TRANSFERS_NOT_ZERO_SUM_FOR_TOKEN))
 				.willReturn(mockRecordBuilder);
 		given(dynamicProperties.shouldExportPrecompileResults()).willReturn(true);
-		given(frame.getRemainingGas()).willReturn(Gas.of(100L));
+		given(frame.getRemainingGas()).willReturn(100L);
 		given(frame.getValue()).willReturn(Wei.ZERO);
 		given(frame.getInputData()).willReturn(pretendArguments);
 
 		// when:
 		subject.prepareFields(frame);
-		subject.prepareComputation(pretendArguments, а -> а);
+		subject.prepareComputation(pretendArguments, a -> a);
 		subject.computeGasRequirement(TEST_CONSENSUS_TIME);
 		final var result = subject.computeInternal(frame);
 
@@ -292,6 +290,7 @@ class TransferPrecompilesTest {
 
 	@Test
 	void transferTokenHappyPathWorks() {
+		Bytes pretendArguments = Bytes.of(Integers.toBytes(ABI_ID_TRANSFER_TOKENS));
 		givenMinimalFrameContext();
 		givenLedgers();
 
@@ -333,14 +332,13 @@ class TransferPrecompilesTest {
 		given(impliedTransfers.getAllBalanceChanges()).willReturn(tokensTransferChanges);
 		given(impliedTransfers.getMeta()).willReturn(impliedTransfersMeta);
 		given(impliedTransfersMeta.code()).willReturn(OK);
-		given(pretendArguments.getInt(0)).willReturn(ABI_ID_TRANSFER_TOKENS);
 		given(aliases.resolveForEvm(any())).willAnswer(invocationOnMock -> invocationOnMock.getArgument(0));
 		given(worldUpdater.aliases()).willReturn(aliases);
 		given(frame.getSenderAddress()).willReturn(contractAddress);
 
 		// when:
 		subject.prepareFields(frame);
-		subject.prepareComputation(pretendArguments, а -> а);
+		subject.prepareComputation(pretendArguments, a -> a);
 		subject.computeGasRequirement(TEST_CONSENSUS_TIME);
 		final var result = subject.computeInternal(frame);
 
@@ -354,12 +352,14 @@ class TransferPrecompilesTest {
 
 	@Test
 	void abortsIfImpliedCustomFeesCannotBeAssessed() {
+		Bytes pretendArguments = Bytes.of(Integers.toBytes(ABI_ID_TRANSFER_TOKENS));
+
 		given(frame.getWorldUpdater()).willReturn(worldUpdater);
 		given(frame.getValue()).willReturn(Wei.ZERO);
 		given(worldUpdater.wrappedTrackingLedgers(any())).willReturn(wrappedLedgers);
 		given(frame.getWorldUpdater()).willReturn(worldUpdater);
 		given(frame.getSenderAddress()).willReturn(contractAddress);
-		given(frame.getRemainingGas()).willReturn(Gas.of(300));
+		given(frame.getRemainingGas()).willReturn(300L);
 		Optional<WorldUpdater> parent = Optional.of(worldUpdater);
 		given(worldUpdater.parentUpdater()).willReturn(parent);
 
@@ -374,7 +374,6 @@ class TransferPrecompilesTest {
 				.willReturn(impliedTransfers);
 		given(impliedTransfers.getMeta()).willReturn(impliedTransfersMeta);
 		given(impliedTransfersMeta.code()).willReturn(CUSTOM_FEE_CHARGING_EXCEEDED_MAX_ACCOUNT_AMOUNTS);
-		given(pretendArguments.getInt(0)).willReturn(ABI_ID_TRANSFER_TOKENS);
 		given(feeCalculator.estimatedGasPriceInTinybars(HederaFunctionality.ContractCall, timestamp))
 				.willReturn(1L);
 		given(mockSynthBodyBuilder.build())
@@ -399,6 +398,8 @@ class TransferPrecompilesTest {
 
 	@Test
 	void transferTokenWithSenderOnlyHappyPathWorks() {
+		Bytes pretendArguments = Bytes.of(Integers.toBytes(ABI_ID_TRANSFER_TOKENS));
+
 		givenMinimalFrameContext();
 		givenLedgers();
 
@@ -439,14 +440,13 @@ class TransferPrecompilesTest {
 		given(impliedTransfers.getAllBalanceChanges()).willReturn(tokensTransferChangesSenderOnly);
 		given(impliedTransfers.getMeta()).willReturn(impliedTransfersMeta);
 		given(impliedTransfersMeta.code()).willReturn(OK);
-		given(pretendArguments.getInt(0)).willReturn(ABI_ID_TRANSFER_TOKENS);
 		given(aliases.resolveForEvm(any())).willAnswer(invocationOnMock -> invocationOnMock.getArgument(0));
 		given(worldUpdater.aliases()).willReturn(aliases);
 		given(frame.getSenderAddress()).willReturn(contractAddress);
 
 		// when:
 		subject.prepareFields(frame);
-		subject.prepareComputation(pretendArguments, а -> а);
+		subject.prepareComputation(pretendArguments, a -> a);
 		subject.computeGasRequirement(TEST_CONSENSUS_TIME);
 		final var result = subject.computeInternal(frame);
 
@@ -460,6 +460,8 @@ class TransferPrecompilesTest {
 
 	@Test
 	void transferTokenWithReceiverOnlyHappyPathWorks() {
+		Bytes pretendArguments = Bytes.of(Integers.toBytes(ABI_ID_TRANSFER_TOKENS));
+
 		givenMinimalFrameContext();
 		givenLedgers();
 
@@ -501,13 +503,12 @@ class TransferPrecompilesTest {
 		given(impliedTransfers.getAllBalanceChanges()).willReturn(tokensTransferChangesSenderOnly);
 		given(impliedTransfers.getMeta()).willReturn(impliedTransfersMeta);
 		given(impliedTransfersMeta.code()).willReturn(OK);
-		given(pretendArguments.getInt(0)).willReturn(ABI_ID_TRANSFER_TOKENS);
 		given(aliases.resolveForEvm(any())).willAnswer(invocationOnMock -> invocationOnMock.getArgument(0));
 		given(worldUpdater.aliases()).willReturn(aliases);
 
 		// when:
 		subject.prepareFields(frame);
-		subject.prepareComputation(pretendArguments, а -> а);
+		subject.prepareComputation(pretendArguments, a -> a);
 		subject.computeGasRequirement(TEST_CONSENSUS_TIME);
 		final var result = subject.computeInternal(frame);
 
@@ -521,6 +522,8 @@ class TransferPrecompilesTest {
 
 	@Test
 	void transferNftsHappyPathWorks() {
+		Bytes pretendArguments = Bytes.of(Integers.toBytes(ABI_ID_TRANSFER_NFTS));
+
 		givenMinimalFrameContext();
 		givenLedgers();
 
@@ -562,14 +565,13 @@ class TransferPrecompilesTest {
 		given(impliedTransfers.getAllBalanceChanges()).willReturn(nftsTransferChanges);
 		given(impliedTransfers.getMeta()).willReturn(impliedTransfersMeta);
 		given(impliedTransfersMeta.code()).willReturn(OK);
-		given(pretendArguments.getInt(0)).willReturn(ABI_ID_TRANSFER_NFTS);
 		given(aliases.resolveForEvm(any())).willAnswer(invocationOnMock -> invocationOnMock.getArgument(0));
 		given(worldUpdater.aliases()).willReturn(aliases);
 		given(frame.getSenderAddress()).willReturn(contractAddress);
 
 		// when:
 		subject.prepareFields(frame);
-		subject.prepareComputation(pretendArguments, а -> а);
+		subject.prepareComputation(pretendArguments, a -> a);
 		subject.computeGasRequirement(TEST_CONSENSUS_TIME);
 		final var result = subject.computeInternal(frame);
 
@@ -583,6 +585,8 @@ class TransferPrecompilesTest {
 
 	@Test
 	void transferNftHappyPathWorks() {
+		Bytes pretendArguments = Bytes.of(Integers.toBytes(ABI_ID_TRANSFER_NFT));
+
 		final var recipientAddr = Address.ALTBN128_ADD;
 		final var senderId = Id.fromGrpcAccount(sender);
 		final var receiverId = Id.fromGrpcAccount(receiver);
@@ -630,13 +634,12 @@ class TransferPrecompilesTest {
 		given(impliedTransfers.getAllBalanceChanges()).willReturn(nftTransferChanges);
 		given(impliedTransfers.getMeta()).willReturn(impliedTransfersMeta);
 		given(impliedTransfersMeta.code()).willReturn(OK);
-		given(pretendArguments.getInt(0)).willReturn(ABI_ID_TRANSFER_NFT);
 		given(aliases.resolveForEvm(any())).willAnswer(invocationOnMock -> invocationOnMock.getArgument(0));
 		given(worldUpdater.aliases()).willReturn(aliases);
 
 		// when:
 		subject.prepareFields(frame);
-		subject.prepareComputation(pretendArguments, а -> а);
+		subject.prepareComputation(pretendArguments, a -> a);
 		subject.computeGasRequirement(TEST_CONSENSUS_TIME);
 		final var result = subject.computeInternal(frame);
 
@@ -661,6 +664,8 @@ class TransferPrecompilesTest {
 
 	@Test
 	void cryptoTransferHappyPathWorks() {
+		Bytes pretendArguments = Bytes.of(Integers.toBytes(ABI_ID_CRYPTO_TRANSFER));
+
 		givenMinimalFrameContext();
 		givenLedgers();
 
@@ -702,14 +707,13 @@ class TransferPrecompilesTest {
 		given(impliedTransfers.getAllBalanceChanges()).willReturn(nftTransferChanges);
 		given(impliedTransfers.getMeta()).willReturn(impliedTransfersMeta);
 		given(impliedTransfersMeta.code()).willReturn(OK);
-		given(pretendArguments.getInt(0)).willReturn(ABI_ID_CRYPTO_TRANSFER);
 		given(aliases.resolveForEvm(any())).willAnswer(invocationOnMock -> invocationOnMock.getArgument(0));
 		given(worldUpdater.aliases()).willReturn(aliases);
 		given(frame.getSenderAddress()).willReturn(contractAddress);
 
 		// when:
 		subject.prepareFields(frame);
-		subject.prepareComputation(pretendArguments, а -> а);
+		subject.prepareComputation(pretendArguments, a -> a);
 		subject.computeGasRequirement(TEST_CONSENSUS_TIME);
 		final var result = subject.computeInternal(frame);
 
@@ -724,6 +728,8 @@ class TransferPrecompilesTest {
 
 	@Test
 	void transferFailsAndCatchesProperly() {
+		Bytes pretendArguments = Bytes.of(Integers.toBytes(ABI_ID_TRANSFER_TOKEN));
+
 		givenMinimalFrameContext();
 		givenLedgers();
 
@@ -750,7 +756,6 @@ class TransferPrecompilesTest {
 		given(impliedTransfers.getAllBalanceChanges()).willReturn(tokenTransferChanges);
 		given(impliedTransfers.getMeta()).willReturn(impliedTransfersMeta);
 		given(impliedTransfersMeta.code()).willReturn(OK);
-		given(pretendArguments.getInt(0)).willReturn(ABI_ID_TRANSFER_TOKEN);
 		given(syntheticTxnFactory.createCryptoTransfer(any()))
 				.willReturn(mockSynthBodyBuilder);
 		given(mockSynthBodyBuilder.getCryptoTransfer()).willReturn(cryptoTransferTransactionBody);
@@ -776,7 +781,7 @@ class TransferPrecompilesTest {
 
 		// when:
 		subject.prepareFields(frame);
-		subject.prepareComputation(pretendArguments, а -> а);
+		subject.prepareComputation(pretendArguments, a -> a);
 		subject.computeGasRequirement(TEST_CONSENSUS_TIME);
 		final var result = subject.computeInternal(frame);
 
@@ -790,11 +795,12 @@ class TransferPrecompilesTest {
 
 	@Test
 	void transferWithWrongInput() {
+		Bytes pretendArguments = Bytes.of(Integers.toBytes(ABI_ID_TRANSFER_TOKEN));
+
 		given(frame.getSenderAddress()).willReturn(contractAddress);
 		given(frame.getWorldUpdater()).willReturn(worldUpdater);
 		given(worldUpdater.wrappedTrackingLedgers(any())).willReturn(wrappedLedgers);
 		given(decoder.decodeTransferToken(eq(pretendArguments), any())).willThrow(new IndexOutOfBoundsException());
-		given(pretendArguments.getInt(0)).willReturn(ABI_ID_TRANSFER_TOKEN);
 
 		subject.prepareFields(frame);
 		var result = subject.compute(pretendArguments, frame);
@@ -822,7 +828,7 @@ class TransferPrecompilesTest {
 	private void givenMinimalFrameContext() {
 		given(frame.getContractAddress()).willReturn(contractAddr);
 		given(frame.getWorldUpdater()).willReturn(worldUpdater);
-		given(frame.getRemainingGas()).willReturn(Gas.of(300));
+		given(frame.getRemainingGas()).willReturn(300L);
 		given(frame.getValue()).willReturn(Wei.ZERO);
 		Optional<WorldUpdater> parent = Optional.of(worldUpdater);
 		given(worldUpdater.parentUpdater()).willReturn(parent);

--- a/hedera-node/src/test/java/com/hedera/services/store/contracts/precompile/proxy/RedirectViewExecutorTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/store/contracts/precompile/proxy/RedirectViewExecutorTest.java
@@ -20,6 +20,7 @@ package com.hedera.services.store.contracts.precompile.proxy;
  * ‍
  */
 
+import com.esaulpaugh.headlong.util.Integers;
 import com.hedera.services.state.enums.TokenType;
 import com.hedera.services.store.contracts.HederaStackedWorldStateUpdater;
 import com.hedera.services.store.contracts.WorldLedgers;
@@ -38,10 +39,8 @@ import com.hederahashgraph.api.proto.java.TokenID;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.tuweni.bytes.Bytes;
 import org.hyperledger.besu.datatypes.Address;
-import org.hyperledger.besu.evm.Gas;
 import org.hyperledger.besu.evm.frame.BlockValues;
 import org.hyperledger.besu.evm.frame.MessageFrame;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -51,6 +50,7 @@ import static com.hedera.services.store.contracts.precompile.HTSPrecompiledContr
 import static com.hedera.services.store.contracts.precompile.HTSPrecompiledContract.ABI_ID_DECIMALS;
 import static com.hedera.services.store.contracts.precompile.HTSPrecompiledContract.ABI_ID_NAME;
 import static com.hedera.services.store.contracts.precompile.HTSPrecompiledContract.ABI_ID_OWNER_OF_NFT;
+import static com.hedera.services.store.contracts.precompile.HTSPrecompiledContract.ABI_ID_REDIRECT_FOR_TOKEN;
 import static com.hedera.services.store.contracts.precompile.HTSPrecompiledContract.ABI_ID_SYMBOL;
 import static com.hedera.services.store.contracts.precompile.HTSPrecompiledContract.ABI_ID_TOKEN_URI_NFT;
 import static com.hedera.services.store.contracts.precompile.HTSPrecompiledContract.ABI_ID_TOTAL_SUPPLY_TOKEN;
@@ -63,8 +63,6 @@ import static org.mockito.BDDMockito.given;
 @ExtendWith(MockitoExtension.class)
 class RedirectViewExecutorTest {
 	@Mock
-	private Bytes input;
-	@Mock
 	private MessageFrame frame;
 	@Mock
 	private EncodingFacade encodingFacade;
@@ -76,10 +74,6 @@ class RedirectViewExecutorTest {
 	private HederaStackedWorldStateUpdater stackedWorldStateUpdater;
 	@Mock
 	private WorldLedgers worldLedgers;
-	@Mock
-	private Bytes nestedInput;
-	@Mock
-	private Address tokenAddress;
 	@Mock
 	private BlockValues blockValues;
 	@Mock
@@ -95,24 +89,17 @@ class RedirectViewExecutorTest {
 	public static final Id nonfungibleId = Id.fromGrpcToken(nonfungibletoken);
 	public static final Address fungibleTokenAddress = fungibleId.asEvmAddress();
 	public static final Address nonfungibleTokenAddress = nonfungibleId.asEvmAddress();
-
-	private static final long timestamp = 10l;
+	
+	private static final long timestamp = 10L;
 	private static final Timestamp resultingTimestamp = Timestamp.newBuilder().setSeconds(timestamp).build();
-	private static final Gas gas = Gas.of(100L);
+	private static final long gas = 100L;
 	private static final Bytes answer = Bytes.of(1);
 
 	RedirectViewExecutor subject;
 
-	@BeforeEach
-	void setup() {
-		given(frame.getWorldUpdater()).willReturn(stackedWorldStateUpdater);
-		given(stackedWorldStateUpdater.trackingLedgers()).willReturn(worldLedgers);
-		this.subject = new RedirectViewExecutor(input, frame, encodingFacade, decodingFacade, redirectGasCalculator);
-	}
-
 	@Test
 	void computeCostedNAME() {
-		prerequisites(ABI_ID_NAME);
+		prerequisites(ABI_ID_NAME, fungibleTokenAddress);
 
 		final var result = "name";
 
@@ -124,7 +111,7 @@ class RedirectViewExecutorTest {
 
 	@Test
 	void computeCostedSYMBOL() {
-		prerequisites(ABI_ID_SYMBOL);
+		prerequisites(ABI_ID_SYMBOL, fungibleTokenAddress);
 
 		final var result = "symbol";
 
@@ -136,7 +123,7 @@ class RedirectViewExecutorTest {
 
 	@Test
 	void computeCostedDECIMALS() {
-		prerequisites(ABI_ID_DECIMALS);
+		prerequisites(ABI_ID_DECIMALS, fungibleTokenAddress);
 
 		final var result = 1;
 
@@ -149,9 +136,9 @@ class RedirectViewExecutorTest {
 
 	@Test
 	void computeCostedTOTAL_SUPPY_TOKEN() {
-		prerequisites(ABI_ID_TOTAL_SUPPLY_TOKEN);
+		prerequisites(ABI_ID_TOTAL_SUPPLY_TOKEN, fungibleTokenAddress);
 
-		final var result = 1l;
+		final var result = 1L;
 
 		given(worldLedgers.totalSupplyOf(fungible)).willReturn(result);
 		given(encodingFacade.encodeTotalSupply(result)).willReturn(answer);
@@ -161,9 +148,9 @@ class RedirectViewExecutorTest {
 
 	@Test
 	void computeCostedBALANCE_OF_TOKEN() {
-		prerequisites(ABI_ID_BALANCE_OF_TOKEN);
+		Bytes nestedInput = prerequisites(ABI_ID_BALANCE_OF_TOKEN, fungibleTokenAddress);
 
-		final var result = 1l;
+		final var result = 1L;
 
 		given(decodingFacade.decodeBalanceOf(eq(nestedInput), any())).willReturn(balanceOfWrapper);
 		given(balanceOfWrapper.accountId()).willReturn(account);
@@ -175,11 +162,10 @@ class RedirectViewExecutorTest {
 
 	@Test
 	void computeCostedOWNER_OF_NFT() {
-		prerequisites(ABI_ID_OWNER_OF_NFT);
-		given(tokenAddress.toArrayUnsafe()).willReturn(nonfungibleTokenAddress.toArray());
+		Bytes nestedInput = prerequisites(ABI_ID_OWNER_OF_NFT, nonfungibleTokenAddress);
 
 		final var result = Address.fromHexString("0x000000000000013");
-		final var serialNum = 1l;
+		final var serialNum = 1L;
 
 		given(decodingFacade.decodeOwnerOf(nestedInput)).willReturn(ownerOfAndTokenURIWrapper);
 		given(ownerOfAndTokenURIWrapper.serialNo()).willReturn(serialNum);
@@ -192,11 +178,10 @@ class RedirectViewExecutorTest {
 
 	@Test
 	void computeCostedTOKEN_URI_NFT() {
-		prerequisites(ABI_ID_TOKEN_URI_NFT);
-		given(tokenAddress.toArrayUnsafe()).willReturn(nonfungibleTokenAddress.toArray());
+		Bytes nestedInput = prerequisites(ABI_ID_TOKEN_URI_NFT, nonfungibleTokenAddress);
 
 		final var result = "some metadata";
-		final var serialNum = 1l;
+		final var serialNum = 1L;
 
 		given(decodingFacade.decodeTokenUriNFT(nestedInput)).willReturn(ownerOfAndTokenURIWrapper);
 		given(ownerOfAndTokenURIWrapper.serialNo()).willReturn(serialNum);
@@ -208,17 +193,24 @@ class RedirectViewExecutorTest {
 
 	@Test
 	void computeCostedNOT_SUPPORTED() {
-		prerequisites(0);
+		prerequisites(0xffffffff, fungibleTokenAddress);
 		TxnUtils.assertFailsWith(() -> subject.computeCosted(), ResponseCodeEnum.NOT_SUPPORTED);
 	}
 
-	void prerequisites(int descriptor) {
-		given(input.slice(4, 20)).willReturn(tokenAddress);
-		given(tokenAddress.toArrayUnsafe()).willReturn(fungibleTokenAddress.toArray());
-		given(input.slice(24)).willReturn(nestedInput);
-		given(nestedInput.getInt(0)).willReturn(descriptor);
+	Bytes prerequisites(int descriptor, Bytes tokenAddress) {
+		given(frame.getWorldUpdater()).willReturn(stackedWorldStateUpdater);
+		given(stackedWorldStateUpdater.trackingLedgers()).willReturn(worldLedgers);
+		Bytes nestedInput = Bytes.of(Integers.toBytes(descriptor));
+		Bytes input = Bytes.concatenate(
+				Bytes.of(Integers.toBytes(ABI_ID_REDIRECT_FOR_TOKEN)),
+				tokenAddress,
+				nestedInput);
 		given(frame.getBlockValues()).willReturn(blockValues);
 		given(blockValues.getTimestamp()).willReturn(timestamp);
 		given(redirectGasCalculator.compute(resultingTimestamp, MINIMUM_TINYBARS_COST)).willReturn(gas);
+		given(frame.getWorldUpdater()).willReturn(stackedWorldStateUpdater);
+		given(stackedWorldStateUpdater.trackingLedgers()).willReturn(worldLedgers);
+		this.subject = new RedirectViewExecutor(input, frame, encodingFacade, decodingFacade, redirectGasCalculator);
+		return nestedInput;
 	}
 }

--- a/pom.xml
+++ b/pom.xml
@@ -214,7 +214,7 @@
 		<maven-javadoc.version>3.3.2</maven-javadoc.version>
 
 		<!-- Dependency properties in alphabetical order -->
-		<besu.version>21.10.9</besu.version>
+		<besu.version>22.4.1</besu.version>
 		<besu-native.version>0.4.3</besu-native.version>
 		<bouncycastle.version>1.70</bouncycastle.version>
 		<commons-codec.version>1.15</commons-codec.version>
@@ -233,7 +233,7 @@
 		<netty.version>4.1.66.Final</netty.version>
 		<protobuf-java.version>3.19.4</protobuf-java.version>
 		<swirlds.version>0.26.2</swirlds.version>
-		<tuweni.version>2.1.0</tuweni.version>
+		<tuweni.version>2.2.0</tuweni.version>
 
 		<!-- Test dependency properties in alphabetical order -->
 		<hamcrest.version>2.2</hamcrest.version>
@@ -676,7 +676,12 @@
 		<dependency>
 			<groupId>org.apache.tuweni</groupId>
 			<artifactId>tuweni-bytes</artifactId>
-			<version>2.1.0</version>
+			<version>${tuweni.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.tuweni</groupId>
+			<artifactId>tuweni-units</artifactId>
+			<version>${tuweni.version}</version>
 		</dependency>
 		<!-- Test dependencies -->
 		<dependency>

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -34,7 +34,7 @@ dependencyResolutionManagement {
         // distribution. These libs can be depended on during compilation, or bundled as part of runtime.
         create("libs") {
             // Definition of version numbers for all libraries
-            version("besu-version", "21.10.9")
+            version("besu-version", "22.4.1")
             version("besu-native-version", "0.4.3")
             version("bouncycastle-version", "1.70")
             version("caffeine-version", "3.0.6")
@@ -55,7 +55,7 @@ dependencyResolutionManagement {
             version("netty-version", "4.1.66.Final")
             version("protobuf-java-version", "3.19.4")
             version("swirlds-version", "0.26.2")
-            version("tuweni-version", "2.1.0")
+            version("tuweni-version", "2.2.0")
 
             // List of bundles provided for us. When applicable, favor using these over individual libraries.
             // Use when you need to use Besu


### PR DESCRIPTION
Upgrade the Besu EVM library to 22.4.1.
Two changes required some broad reaching changes in service and tests

* Gas object was replaced with a primitive long for performance
* The vertx library was no longer required, requiring changes in
  mocking Tuweni types as some vertex class were no longer in the
  classpath.

Signed-off-by: Danno Ferrin <danno.ferrin@hedera.com>

**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
