### PR TITLE
Add `Multi-Release: true` to JMH JAR manifest

### DIFF
--- a/buildSrc/src/main/kotlin/com.hedera.hashgraph.benchmark-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/com.hedera.hashgraph.benchmark-conventions.gradle.kts
@@ -25,3 +25,9 @@ plugins {
 jmh {
     jmhVersion.set("1.35")
 }
+
+tasks.jmhJar {
+    manifest(Action {
+      attributes(mapOf("Multi-Release" to true))  
+    })
+}


### PR DESCRIPTION
**Description**:
- Fixes issue with `ConstructableRegistry` in JMH benchmarks.