### PR TITLE
Add delay during reconnect test to avoid sending query when reconnect node is updating its state

### DIFF
--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/reconnect/ValidateTokensStateAfterReconnect.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/reconnect/ValidateTokensStateAfterReconnect.java
@@ -166,6 +166,9 @@ public class ValidateTokensStateAfterReconnect extends HapiApiSuite {
 								.loggingAvailabilityEvery(30)
 								.sleepingBetweenRetriesFor(10),
 
+						// wait reconnect node to finish receiving new state, otherwise it may response
+						// with incorrect answer from old state
+						sleepFor(3000),
 						/* validate tokenInfo between reconnecting node and other nodes match*/
 						getTokenInfo(tokenToBeQueried)
 								.setNode(reconnectingNode)


### PR DESCRIPTION
Closes regression issue 2436 

https://github.com/swirlds/swirlds-platform-regression/issues/2436

Test result

https://swirldslabs.slack.com/archives/C03ELH5MUHK/p1653092943924259


