### PR TITLE
Ensure unique `TokenID`s in `AssociateLogic`

### DIFF
--- a/hedera-node/src/main/java/com/hedera/services/txns/token/AssociateLogic.java
+++ b/hedera-node/src/main/java/com/hedera/services/txns/token/AssociateLogic.java
@@ -30,6 +30,10 @@ import javax.inject.Inject;
 import javax.inject.Singleton;
 import java.util.List;
 
+import static com.hedera.services.exceptions.ValidationUtils.validateFalse;
+import static com.hedera.services.txns.validation.TokenListChecks.repeatsItself;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TOKEN_ID_REPEATED_IN_TOKEN_LIST;
+
 @Singleton
 public class AssociateLogic {
 	private final TypedTokenStore tokenStore;
@@ -47,6 +51,12 @@ public class AssociateLogic {
 	}
 
 	public void associate(final Id accountId, final List<TokenID> tokensList) {
+		validateFalse(repeatsItself(tokensList), TOKEN_ID_REPEATED_IN_TOKEN_LIST);
+		associateUniqueTokens(accountId, tokensList);
+	}
+
+	void associateUniqueTokens(final Id accountId, final List<TokenID> tokensList) {
+		validateFalse(repeatsItself(tokensList), TOKEN_ID_REPEATED_IN_TOKEN_LIST);
 		final var tokenIds = tokensList.stream().map(Id::fromGrpcToken).toList();
 
 		/* Load the models */
@@ -60,4 +70,5 @@ public class AssociateLogic {
 		accountStore.commitAccount(account);
 		tokenStore.commitTokenRelationships(newTokenRelationships);
 	}
+
 }

--- a/hedera-node/src/main/java/com/hedera/services/txns/token/AssociateLogic.java
+++ b/hedera-node/src/main/java/com/hedera/services/txns/token/AssociateLogic.java
@@ -56,7 +56,6 @@ public class AssociateLogic {
 	}
 
 	void associateUniqueTokens(final Id accountId, final List<TokenID> tokensList) {
-		validateFalse(repeatsItself(tokensList), TOKEN_ID_REPEATED_IN_TOKEN_LIST);
 		final var tokenIds = tokensList.stream().map(Id::fromGrpcToken).toList();
 
 		/* Load the models */

--- a/hedera-node/src/main/java/com/hedera/services/txns/token/TokenAssociateTransitionLogic.java
+++ b/hedera-node/src/main/java/com/hedera/services/txns/token/TokenAssociateTransitionLogic.java
@@ -56,7 +56,8 @@ public class TokenAssociateTransitionLogic implements TransitionLogic {
 		final var accountId = Id.fromGrpcAccount(op.getAccount());
 
 		/* --- Do the business logic --- */
-		associateLogic.associate(accountId, op.getTokensList());
+		// This is preceded by validate in handleTransaction, so tokens must be unique
+		associateLogic.associateUniqueTokens(accountId, op.getTokensList());
 	}
 
 	@Override

--- a/hedera-node/src/test/java/com/hedera/services/txns/token/AssociateLogicTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/txns/token/AssociateLogicTest.java
@@ -28,6 +28,7 @@ import com.hedera.services.store.models.Id;
 import com.hedera.services.store.models.Token;
 import com.hedera.services.store.models.TokenRelationship;
 import com.hedera.test.utils.IdUtils;
+import com.hedera.test.utils.TxnUtils;
 import com.hederahashgraph.api.proto.java.TokenID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -37,6 +38,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.List;
 
+import static com.hedera.test.utils.TxnUtils.assertFailsWith;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TOKEN_ID_REPEATED_IN_TOKEN_LIST;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 
@@ -80,5 +83,12 @@ class AssociateLogicTest {
 		verify(modelAccount).associateWith(tokens, tokenStore, false, false, dynamicProperties);
 		verify(accountStore).commitAccount(modelAccount);
 		verify(tokenStore).commitTokenRelationships(List.of(firstModelTokenRel, secondModelTokenRel));
+	}
+
+	@Test
+	void rejectsRepeatedTokenId() {
+		assertFailsWith(
+				() -> subject.associate(accountId, List.of(firstToken, secondToken, firstToken)),
+				TOKEN_ID_REPEATED_IN_TOKEN_LIST);
 	}
 }


### PR DESCRIPTION
**Description**:
- Moves `repeatsItself()` check into `AssociateLogic.associate()` as used by HTS system contract.
- Adds [EET](https://github.com/hashgraph/hedera-services/blob/fix-multi-assoc-precompile-check/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenAssociationSpecs.java#L132) verifying the fix.