### PR TITLE
Align precompile error codes with those returned by HAPI

### DIFF
--- a/hedera-node/src/main/java/com/hedera/services/store/contracts/precompile/HTSPrecompiledContract.java
+++ b/hedera-node/src/main/java/com/hedera/services/store/contracts/precompile/HTSPrecompiledContract.java
@@ -685,7 +685,11 @@ public class HTSPrecompiledContract extends AbstractPrecompiledContract {
 
 	@FunctionalInterface
 	interface BurnLogicFactory {
-		BurnLogic newBurnLogic(TypedTokenStore tokenStore, AccountStore accountStore);
+		BurnLogic newBurnLogic(
+				OptionValidator validator,
+				TypedTokenStore tokenStore,
+				AccountStore accountStore,
+				GlobalDynamicProperties dynamicProperties);
 	}
 
 	@FunctionalInterface
@@ -1418,7 +1422,10 @@ public class HTSPrecompiledContract extends AbstractPrecompiledContract {
 			/* --- Build the necessary infrastructure to execute the transaction --- */
 			final var scopedAccountStore = createAccountStore();
 			final var scopedTokenStore = createTokenStore(scopedAccountStore, sideEffectsTracker);
-			final var burnLogic = burnLogicFactory.newBurnLogic(scopedTokenStore, scopedAccountStore);
+			final var burnLogic = burnLogicFactory.newBurnLogic(
+					validator, scopedTokenStore, scopedAccountStore, dynamicProperties);
+			final var validity = burnLogic.validateSyntax(transactionBody.build());
+			validateTrue(validity == OK, validity);
 
 			/* --- Execute the transaction and capture its results --- */
 			if (burnOp.type() == NON_FUNGIBLE_UNIQUE) {

--- a/hedera-node/src/main/java/com/hedera/services/store/contracts/precompile/HTSPrecompiledContract.java
+++ b/hedera-node/src/main/java/com/hedera/services/store/contracts/precompile/HTSPrecompiledContract.java
@@ -665,7 +665,11 @@ public class HTSPrecompiledContract extends AbstractPrecompiledContract {
 	/* --- Constructor functional interfaces for mocking --- */
 	@FunctionalInterface
 	interface MintLogicFactory {
-		MintLogic newMintLogic(OptionValidator validator, TypedTokenStore tokenStore, AccountStore accountStore);
+		MintLogic newMintLogic(
+				OptionValidator validator,
+				TypedTokenStore tokenStore,
+				AccountStore accountStore,
+				GlobalDynamicProperties dynamicProperties);
 	}
 
 	@FunctionalInterface
@@ -788,6 +792,8 @@ public class HTSPrecompiledContract extends AbstractPrecompiledContract {
 			/* --- Execute the transaction and capture its results --- */
 			final var associateLogic = associateLogicFactory.newAssociateLogic(tokenStore, accountStore,
 					dynamicProperties);
+			final var validity = associateLogic.validateSyntax(transactionBody.build());
+			validateTrue(validity == OK, validity);
 			associateLogic.associate(accountId, associateOp.tokenIds());
 		}
 
@@ -834,6 +840,8 @@ public class HTSPrecompiledContract extends AbstractPrecompiledContract {
 			/* --- Execute the transaction and capture its results --- */
 			final var dissociateLogic = dissociateLogicFactory.newDissociateLogic(
 					validator, tokenStore, accountStore, dissociationFactory);
+			final var validity = dissociateLogic.validateSyntax(transactionBody.build());
+			validateTrue(validity == OK, validity);
 			dissociateLogic.dissociate(accountId, dissociateOp.tokenIds());
 		}
 
@@ -880,8 +888,11 @@ public class HTSPrecompiledContract extends AbstractPrecompiledContract {
 			/* --- Build the necessary infrastructure to execute the transaction --- */
 			final var scopedAccountStore = createAccountStore();
 			final var scopedTokenStore = createTokenStore(scopedAccountStore, sideEffectsTracker);
-			final var mintLogic = mintLogicFactory.newMintLogic(validator, scopedTokenStore, scopedAccountStore);
+			final var mintLogic = mintLogicFactory.newMintLogic(
+					validator, scopedTokenStore, scopedAccountStore, dynamicProperties);
 
+			final var validity = mintLogic.validateSyntax(transactionBody.build());
+			validateTrue(validity == OK, validity);
 			/* --- Execute the transaction and capture its results --- */
 			if (mintOp.type() == NON_FUNGIBLE_UNIQUE) {
 				final var newMeta = mintOp.metadata();

--- a/hedera-node/src/main/java/com/hedera/services/txns/token/AssociateLogic.java
+++ b/hedera-node/src/main/java/com/hedera/services/txns/token/AssociateLogic.java
@@ -30,6 +30,10 @@ import javax.inject.Inject;
 import javax.inject.Singleton;
 import java.util.List;
 
+import static com.hedera.services.exceptions.ValidationUtils.validateFalse;
+import static com.hedera.services.txns.validation.TokenListChecks.repeatsItself;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TOKEN_ID_REPEATED_IN_TOKEN_LIST;
+
 @Singleton
 public class AssociateLogic {
 	private final TypedTokenStore tokenStore;
@@ -47,6 +51,12 @@ public class AssociateLogic {
 	}
 
 	public void associate(final Id accountId, final List<TokenID> tokensList) {
+		validateFalse(repeatsItself(tokensList), TOKEN_ID_REPEATED_IN_TOKEN_LIST);
+		associateUniqueTokens(accountId, tokensList);
+	}
+
+	void associateUniqueTokens(final Id accountId, final List<TokenID> tokensList) {
+		validateFalse(repeatsItself(tokensList), TOKEN_ID_REPEATED_IN_TOKEN_LIST);
 		final var tokenIds = tokensList.stream().map(Id::fromGrpcToken).toList();
 
 		/* Load the models */
@@ -60,4 +70,5 @@ public class AssociateLogic {
 		accountStore.commitAccount(account);
 		tokenStore.commitTokenRelationships(newTokenRelationships);
 	}
+
 }

--- a/hedera-node/src/main/java/com/hedera/services/txns/token/AssociateLogic.java
+++ b/hedera-node/src/main/java/com/hedera/services/txns/token/AssociateLogic.java
@@ -56,7 +56,6 @@ public class AssociateLogic {
 	}
 
 	void associateUniqueTokens(final Id accountId, final List<TokenID> tokensList) {
-		validateFalse(repeatsItself(tokensList), TOKEN_ID_REPEATED_IN_TOKEN_LIST);
 		final var tokenIds = tokensList.stream().map(Id::fromGrpcToken).toList();
 
 		/* Load the models */

--- a/hedera-node/src/main/java/com/hedera/services/txns/token/AssociateLogic.java
+++ b/hedera-node/src/main/java/com/hedera/services/txns/token/AssociateLogic.java
@@ -24,7 +24,10 @@ import com.hedera.services.context.properties.GlobalDynamicProperties;
 import com.hedera.services.store.AccountStore;
 import com.hedera.services.store.TypedTokenStore;
 import com.hedera.services.store.models.Id;
+import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
+import com.hederahashgraph.api.proto.java.TokenAssociateTransactionBody;
 import com.hederahashgraph.api.proto.java.TokenID;
+import com.hederahashgraph.api.proto.java.TransactionBody;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -32,6 +35,8 @@ import java.util.List;
 
 import static com.hedera.services.exceptions.ValidationUtils.validateFalse;
 import static com.hedera.services.txns.validation.TokenListChecks.repeatsItself;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_ACCOUNT_ID;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OK;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TOKEN_ID_REPEATED_IN_TOKEN_LIST;
 
 @Singleton
@@ -51,11 +56,6 @@ public class AssociateLogic {
 	}
 
 	public void associate(final Id accountId, final List<TokenID> tokensList) {
-		validateFalse(repeatsItself(tokensList), TOKEN_ID_REPEATED_IN_TOKEN_LIST);
-		associateUniqueTokens(accountId, tokensList);
-	}
-
-	void associateUniqueTokens(final Id accountId, final List<TokenID> tokensList) {
 		final var tokenIds = tokensList.stream().map(Id::fromGrpcToken).toList();
 
 		/* Load the models */
@@ -70,4 +70,15 @@ public class AssociateLogic {
 		tokenStore.commitTokenRelationships(newTokenRelationships);
 	}
 
+	public ResponseCodeEnum validateSyntax(final TransactionBody txn) {
+		final var op = txn.getTokenAssociate();
+		if (!op.hasAccount()) {
+			return INVALID_ACCOUNT_ID;
+		}
+		if (repeatsItself(op.getTokensList())) {
+			return TOKEN_ID_REPEATED_IN_TOKEN_LIST;
+		}
+
+		return OK;
+	}
 }

--- a/hedera-node/src/main/java/com/hedera/services/txns/token/AssociateLogic.java
+++ b/hedera-node/src/main/java/com/hedera/services/txns/token/AssociateLogic.java
@@ -25,7 +25,6 @@ import com.hedera.services.store.AccountStore;
 import com.hedera.services.store.TypedTokenStore;
 import com.hedera.services.store.models.Id;
 import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
-import com.hederahashgraph.api.proto.java.TokenAssociateTransactionBody;
 import com.hederahashgraph.api.proto.java.TokenID;
 import com.hederahashgraph.api.proto.java.TransactionBody;
 
@@ -33,7 +32,6 @@ import javax.inject.Inject;
 import javax.inject.Singleton;
 import java.util.List;
 
-import static com.hedera.services.exceptions.ValidationUtils.validateFalse;
 import static com.hedera.services.txns.validation.TokenListChecks.repeatsItself;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_ACCOUNT_ID;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OK;

--- a/hedera-node/src/main/java/com/hedera/services/txns/token/BurnLogic.java
+++ b/hedera-node/src/main/java/com/hedera/services/txns/token/BurnLogic.java
@@ -20,25 +20,47 @@ package com.hedera.services.txns.token;
  * ‍
  */
 
+import com.hedera.services.context.properties.GlobalDynamicProperties;
 import com.hedera.services.state.enums.TokenType;
 import com.hedera.services.store.AccountStore;
 import com.hedera.services.store.TypedTokenStore;
 import com.hedera.services.store.models.Id;
 import com.hedera.services.store.models.OwnershipTracker;
+import com.hedera.services.txns.validation.OptionValidator;
+import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
+import com.hederahashgraph.api.proto.java.TokenBurnTransactionBody;
+import com.hederahashgraph.api.proto.java.TransactionBody;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import java.util.List;
 
+import static com.hedera.services.txns.token.TokenOpsValidator.validateTokenOpsWith;
+import static com.hedera.services.txns.validation.TokenListChecks.repeatsItself;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_ACCOUNT_ID;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_TOKEN_BURN_AMOUNT;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_TOKEN_ID;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OK;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TOKEN_ID_REPEATED_IN_TOKEN_LIST;
+
 @Singleton
 public class BurnLogic {
+	private final OptionValidator validator;
 	private final TypedTokenStore tokenStore;
 	private final AccountStore accountStore;
+	private final GlobalDynamicProperties dynamicProperties;
 
 	@Inject
-	public BurnLogic(final TypedTokenStore tokenStore, final AccountStore accountStore) {
+	public BurnLogic(
+			final OptionValidator validator,
+			final TypedTokenStore tokenStore,
+			final AccountStore accountStore,
+			final GlobalDynamicProperties dynamicProperties
+	) {
+		this.validator = validator;
 		this.tokenStore = tokenStore;
 		this.accountStore = accountStore;
+		this.dynamicProperties = dynamicProperties;
 	}
 
 	public void burn(
@@ -62,5 +84,21 @@ public class BurnLogic {
 		tokenStore.commitTokenRelationships(List.of(treasuryRel));
 		tokenStore.commitTrackers(ownershipTracker);
 		accountStore.commitAccount(token.getTreasury());
+	}
+
+	public ResponseCodeEnum validateSyntax(final TransactionBody txn) {
+		TokenBurnTransactionBody op = txn.getTokenBurn();
+
+		if (!op.hasToken()) {
+			return INVALID_TOKEN_ID;
+		}
+
+		return validateTokenOpsWith(
+				op.getSerialNumbersCount(),
+				op.getAmount(),
+				dynamicProperties.areNftsEnabled(),
+				INVALID_TOKEN_BURN_AMOUNT,
+				op.getSerialNumbersList(),
+				validator::maxBatchSizeBurnCheck);
 	}
 }

--- a/hedera-node/src/main/java/com/hedera/services/txns/token/BurnLogic.java
+++ b/hedera-node/src/main/java/com/hedera/services/txns/token/BurnLogic.java
@@ -36,12 +36,8 @@ import javax.inject.Singleton;
 import java.util.List;
 
 import static com.hedera.services.txns.token.TokenOpsValidator.validateTokenOpsWith;
-import static com.hedera.services.txns.validation.TokenListChecks.repeatsItself;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_ACCOUNT_ID;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_TOKEN_BURN_AMOUNT;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_TOKEN_ID;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OK;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TOKEN_ID_REPEATED_IN_TOKEN_LIST;
 
 @Singleton
 public class BurnLogic {

--- a/hedera-node/src/main/java/com/hedera/services/txns/token/DissociateLogic.java
+++ b/hedera-node/src/main/java/com/hedera/services/txns/token/DissociateLogic.java
@@ -27,12 +27,20 @@ import com.hedera.services.store.models.TokenRelationship;
 import com.hedera.services.txns.token.process.Dissociation;
 import com.hedera.services.txns.token.process.DissociationFactory;
 import com.hedera.services.txns.validation.OptionValidator;
+import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
+import com.hederahashgraph.api.proto.java.TokenDissociateTransactionBody;
 import com.hederahashgraph.api.proto.java.TokenID;
+import com.hederahashgraph.api.proto.java.TransactionBody;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import java.util.ArrayList;
 import java.util.List;
+
+import static com.hedera.services.txns.validation.TokenListChecks.repeatsItself;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_ACCOUNT_ID;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OK;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TOKEN_ID_REPEATED_IN_TOKEN_LIST;
 
 @Singleton
 public class DissociateLogic {
@@ -72,5 +80,16 @@ public class DissociateLogic {
 			dissociation.addUpdatedModelRelsTo(allUpdatedRels);
 		}
 		tokenStore.commitTokenRelationships(allUpdatedRels);
+	}
+
+	public ResponseCodeEnum validateSyntax(final TransactionBody txn) {
+		TokenDissociateTransactionBody op = txn.getTokenDissociate();
+		if (!op.hasAccount()) {
+			return INVALID_ACCOUNT_ID;
+		}
+		if (repeatsItself(op.getTokensList())) {
+			return TOKEN_ID_REPEATED_IN_TOKEN_LIST;
+		}
+		return OK;
 	}
 }

--- a/hedera-node/src/main/java/com/hedera/services/txns/token/MintLogic.java
+++ b/hedera-node/src/main/java/com/hedera/services/txns/token/MintLogic.java
@@ -9,9 +9,9 @@ package com.hedera.services.txns.token;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -21,6 +21,7 @@ package com.hedera.services.txns.token;
  */
 
 import com.google.protobuf.ByteString;
+import com.hedera.services.context.properties.GlobalDynamicProperties;
 import com.hedera.services.state.enums.TokenType;
 import com.hedera.services.store.AccountStore;
 import com.hedera.services.store.TypedTokenStore;
@@ -28,6 +29,10 @@ import com.hedera.services.store.models.Id;
 import com.hedera.services.store.models.OwnershipTracker;
 import com.hedera.services.store.models.Token;
 import com.hedera.services.txns.validation.OptionValidator;
+import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
+import com.hederahashgraph.api.proto.java.TokenDissociateTransactionBody;
+import com.hederahashgraph.api.proto.java.TokenMintTransactionBody;
+import com.hederahashgraph.api.proto.java.TransactionBody;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -37,26 +42,40 @@ import java.util.List;
 import static com.hedera.services.exceptions.ValidationUtils.validateTrue;
 import static com.hedera.services.state.enums.TokenType.NON_FUNGIBLE_UNIQUE;
 import static com.hedera.services.state.submerkle.RichInstant.fromJava;
+import static com.hedera.services.txns.token.TokenOpsValidator.validateTokenOpsWith;
+import static com.hedera.services.txns.validation.TokenListChecks.repeatsItself;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_ACCOUNT_ID;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_TOKEN_ID;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_TOKEN_MINT_AMOUNT;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.MAX_NFTS_IN_PRICE_REGIME_HAVE_BEEN_MINTED;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OK;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TOKEN_ID_REPEATED_IN_TOKEN_LIST;
 
 @Singleton
 public class MintLogic {
 	private final OptionValidator validator;
 	private final TypedTokenStore tokenStore;
 	private final AccountStore accountStore;
+	private final GlobalDynamicProperties dynamicProperties;
 
 	@Inject
-	public MintLogic(OptionValidator validator, TypedTokenStore tokenStore, AccountStore accountStore) {
+	public MintLogic(
+			OptionValidator validator,
+			TypedTokenStore tokenStore,
+			AccountStore accountStore,
+			GlobalDynamicProperties dynamicProperties
+	) {
 		this.validator = validator;
 		this.tokenStore = tokenStore;
 		this.accountStore = accountStore;
+		this.dynamicProperties = dynamicProperties;
 	}
 
 	public void mint(final Id targetId,
-					 int metaDataCount,
-					 long amount,
-					 List<ByteString> metaDataList,
-					 Instant consensusTime) {
+			int metaDataCount,
+			long amount,
+			List<ByteString> metaDataList,
+			Instant consensusTime) {
 
 		/* --- Load the model objects --- */
 		final var token = tokenStore.loadToken(targetId);
@@ -80,10 +99,27 @@ public class MintLogic {
 		accountStore.commitAccount(token.getTreasury());
 	}
 
+	public ResponseCodeEnum validateSyntax(final TransactionBody txn) {
+		TokenMintTransactionBody op = txn.getTokenMint();
+
+		if (!op.hasToken()) {
+			return INVALID_TOKEN_ID;
+		}
+
+		return validateTokenOpsWith(
+				op.getMetadataCount(),
+				op.getAmount(),
+				dynamicProperties.areNftsEnabled(),
+				INVALID_TOKEN_MINT_AMOUNT,
+				op.getMetadataList(),
+				validator::maxBatchSizeMintCheck,
+				validator::nftMetadataCheck);
+	}
+
 	private void validateMinting(OptionValidator validator,
-								 Token token,
-								 int metaDataCount,
-								 TypedTokenStore tokenStore) {
+			Token token,
+			int metaDataCount,
+			TypedTokenStore tokenStore) {
 		if (token.getType() == NON_FUNGIBLE_UNIQUE) {
 			final var proposedTotal = tokenStore.currentMintedNfts() + metaDataCount;
 			validateTrue(validator.isPermissibleTotalNfts(proposedTotal), MAX_NFTS_IN_PRICE_REGIME_HAVE_BEEN_MINTED);

--- a/hedera-node/src/main/java/com/hedera/services/txns/token/MintLogic.java
+++ b/hedera-node/src/main/java/com/hedera/services/txns/token/MintLogic.java
@@ -30,7 +30,6 @@ import com.hedera.services.store.models.OwnershipTracker;
 import com.hedera.services.store.models.Token;
 import com.hedera.services.txns.validation.OptionValidator;
 import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
-import com.hederahashgraph.api.proto.java.TokenDissociateTransactionBody;
 import com.hederahashgraph.api.proto.java.TokenMintTransactionBody;
 import com.hederahashgraph.api.proto.java.TransactionBody;
 
@@ -43,13 +42,9 @@ import static com.hedera.services.exceptions.ValidationUtils.validateTrue;
 import static com.hedera.services.state.enums.TokenType.NON_FUNGIBLE_UNIQUE;
 import static com.hedera.services.state.submerkle.RichInstant.fromJava;
 import static com.hedera.services.txns.token.TokenOpsValidator.validateTokenOpsWith;
-import static com.hedera.services.txns.validation.TokenListChecks.repeatsItself;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_ACCOUNT_ID;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_TOKEN_ID;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_TOKEN_MINT_AMOUNT;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.MAX_NFTS_IN_PRICE_REGIME_HAVE_BEEN_MINTED;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OK;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TOKEN_ID_REPEATED_IN_TOKEN_LIST;
 
 @Singleton
 public class MintLogic {

--- a/hedera-node/src/main/java/com/hedera/services/txns/token/TokenAssociateTransitionLogic.java
+++ b/hedera-node/src/main/java/com/hedera/services/txns/token/TokenAssociateTransitionLogic.java
@@ -70,16 +70,6 @@ public class TokenAssociateTransitionLogic implements TransitionLogic {
 	}
 
 	public ResponseCodeEnum validate(TransactionBody txnBody) {
-		TokenAssociateTransactionBody op = txnBody.getTokenAssociate();
-
-		if (!op.hasAccount()) {
-			return INVALID_ACCOUNT_ID;
-		}
-
-		if (repeatsItself(op.getTokensList())) {
-			return TOKEN_ID_REPEATED_IN_TOKEN_LIST;
-		}
-
-		return OK;
+		return associateLogic.validateSyntax(txnBody);
 	}
 }

--- a/hedera-node/src/main/java/com/hedera/services/txns/token/TokenAssociateTransitionLogic.java
+++ b/hedera-node/src/main/java/com/hedera/services/txns/token/TokenAssociateTransitionLogic.java
@@ -56,7 +56,8 @@ public class TokenAssociateTransitionLogic implements TransitionLogic {
 		final var accountId = Id.fromGrpcAccount(op.getAccount());
 
 		/* --- Do the business logic --- */
-		associateLogic.associate(accountId, op.getTokensList());
+		// This is preceded by validate in handleTransaction, so tokens must be unique
+		associateLogic.associateUniqueTokens(accountId, op.getTokensList());
 	}
 
 	@Override

--- a/hedera-node/src/main/java/com/hedera/services/txns/token/TokenAssociateTransitionLogic.java
+++ b/hedera-node/src/main/java/com/hedera/services/txns/token/TokenAssociateTransitionLogic.java
@@ -56,8 +56,7 @@ public class TokenAssociateTransitionLogic implements TransitionLogic {
 		final var accountId = Id.fromGrpcAccount(op.getAccount());
 
 		/* --- Do the business logic --- */
-		// This is preceded by validate in handleTransaction, so tokens must be unique
-		associateLogic.associateUniqueTokens(accountId, op.getTokensList());
+		associateLogic.associate(accountId, op.getTokensList());
 	}
 
 	@Override

--- a/hedera-node/src/main/java/com/hedera/services/txns/token/TokenAssociateTransitionLogic.java
+++ b/hedera-node/src/main/java/com/hedera/services/txns/token/TokenAssociateTransitionLogic.java
@@ -24,16 +24,12 @@ import com.hedera.services.context.TransactionContext;
 import com.hedera.services.store.models.Id;
 import com.hedera.services.txns.TransitionLogic;
 import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
-import com.hederahashgraph.api.proto.java.TokenAssociateTransactionBody;
 import com.hederahashgraph.api.proto.java.TransactionBody;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import java.util.function.Function;
 import java.util.function.Predicate;
-
-import static com.hedera.services.txns.validation.TokenListChecks.repeatsItself;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.*;
 
 /**
  * Provides the state transition for associating tokens to an account.

--- a/hedera-node/src/main/java/com/hedera/services/txns/token/TokenBurnTransitionLogic.java
+++ b/hedera-node/src/main/java/com/hedera/services/txns/token/TokenBurnTransitionLogic.java
@@ -21,10 +21,8 @@ package com.hedera.services.txns.token;
  */
 
 import com.hedera.services.context.TransactionContext;
-import com.hedera.services.context.properties.GlobalDynamicProperties;
 import com.hedera.services.store.models.Id;
 import com.hedera.services.txns.TransitionLogic;
-import com.hedera.services.txns.validation.OptionValidator;
 import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
 import com.hederahashgraph.api.proto.java.TransactionBody;
 

--- a/hedera-node/src/main/java/com/hedera/services/txns/token/TokenBurnTransitionLogic.java
+++ b/hedera-node/src/main/java/com/hedera/services/txns/token/TokenBurnTransitionLogic.java
@@ -26,7 +26,6 @@ import com.hedera.services.store.models.Id;
 import com.hedera.services.txns.TransitionLogic;
 import com.hedera.services.txns.validation.OptionValidator;
 import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
-import com.hederahashgraph.api.proto.java.TokenBurnTransactionBody;
 import com.hederahashgraph.api.proto.java.TransactionBody;
 
 import javax.inject.Inject;
@@ -34,30 +33,17 @@ import javax.inject.Singleton;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
-import static com.hedera.services.txns.token.TokenOpsValidator.validateTokenOpsWith;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_TOKEN_BURN_AMOUNT;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_TOKEN_ID;
-
 /**
  * Provides the state transition for token burning.
  */
 @Singleton
 public class TokenBurnTransitionLogic implements TransitionLogic {
-	private final OptionValidator validator;
 	private final TransactionContext txnCtx;
-	private final GlobalDynamicProperties dynamicProperties;
 	private final BurnLogic burnLogic;
 
 	@Inject
-	public TokenBurnTransitionLogic(
-			OptionValidator validator,
-			TransactionContext txnCtx,
-			GlobalDynamicProperties dynamicProperties,
-			BurnLogic burnLogic
-	) {
-		this.validator = validator;
+	public TokenBurnTransitionLogic(final TransactionContext txnCtx, final BurnLogic burnLogic) {
 		this.txnCtx = txnCtx;
-		this.dynamicProperties = dynamicProperties;
 		this.burnLogic = burnLogic;
 	}
 

--- a/hedera-node/src/main/java/com/hedera/services/txns/token/TokenBurnTransitionLogic.java
+++ b/hedera-node/src/main/java/com/hedera/services/txns/token/TokenBurnTransitionLogic.java
@@ -84,19 +84,6 @@ public class TokenBurnTransitionLogic implements TransitionLogic {
 	}
 
 	public ResponseCodeEnum validate(TransactionBody txnBody) {
-		TokenBurnTransactionBody op = txnBody.getTokenBurn();
-
-		if (!op.hasToken()) {
-			return INVALID_TOKEN_ID;
-		}
-
-		return validateTokenOpsWith(
-				op.getSerialNumbersCount(),
-				op.getAmount(),
-				dynamicProperties.areNftsEnabled(),
-				INVALID_TOKEN_BURN_AMOUNT,
-				op.getSerialNumbersList(),
-				validator::maxBatchSizeBurnCheck
-		);
+		return burnLogic.validateSyntax(txnBody);
 	}
 }

--- a/hedera-node/src/main/java/com/hedera/services/txns/token/TokenDissociateTransitionLogic.java
+++ b/hedera-node/src/main/java/com/hedera/services/txns/token/TokenDissociateTransitionLogic.java
@@ -24,18 +24,12 @@ import com.hedera.services.context.TransactionContext;
 import com.hedera.services.store.models.Id;
 import com.hedera.services.txns.TransitionLogic;
 import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
-import com.hederahashgraph.api.proto.java.TokenDissociateTransactionBody;
 import com.hederahashgraph.api.proto.java.TransactionBody;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import java.util.function.Function;
 import java.util.function.Predicate;
-
-import static com.hedera.services.txns.validation.TokenListChecks.repeatsItself;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_ACCOUNT_ID;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OK;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TOKEN_ID_REPEATED_IN_TOKEN_LIST;
 
 /**
  * Provides the state transition for dissociating tokens from an account.

--- a/hedera-node/src/main/java/com/hedera/services/txns/token/TokenDissociateTransitionLogic.java
+++ b/hedera-node/src/main/java/com/hedera/services/txns/token/TokenDissociateTransitionLogic.java
@@ -72,16 +72,6 @@ public class TokenDissociateTransitionLogic implements TransitionLogic {
 	}
 
 	public ResponseCodeEnum validate(TransactionBody txnBody) {
-		TokenDissociateTransactionBody op = txnBody.getTokenDissociate();
-
-		if (!op.hasAccount()) {
-			return INVALID_ACCOUNT_ID;
-		}
-
-		if (repeatsItself(op.getTokensList())) {
-			return TOKEN_ID_REPEATED_IN_TOKEN_LIST;
-		}
-
-		return OK;
+		return dissociateLogic.validateSyntax(txnBody);
 	}
 }

--- a/hedera-node/src/main/java/com/hedera/services/txns/token/TokenMintTransitionLogic.java
+++ b/hedera-node/src/main/java/com/hedera/services/txns/token/TokenMintTransitionLogic.java
@@ -21,12 +21,9 @@ package com.hedera.services.txns.token;
  */
 
 import com.hedera.services.context.TransactionContext;
-import com.hedera.services.context.properties.GlobalDynamicProperties;
 import com.hedera.services.store.models.Id;
 import com.hedera.services.txns.TransitionLogic;
-import com.hedera.services.txns.validation.OptionValidator;
 import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
-import com.hederahashgraph.api.proto.java.TokenMintTransactionBody;
 import com.hederahashgraph.api.proto.java.TransactionBody;
 
 import javax.inject.Inject;
@@ -34,30 +31,17 @@ import javax.inject.Singleton;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
-import static com.hedera.services.txns.token.TokenOpsValidator.validateTokenOpsWith;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_TOKEN_ID;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_TOKEN_MINT_AMOUNT;
-
 /**
  * Provides the state transition for token minting.
  */
 @Singleton
 public class TokenMintTransitionLogic implements TransitionLogic {
-	private final OptionValidator validator;
 	private final TransactionContext txnCtx;
-	private final GlobalDynamicProperties dynamicProperties;
 	private final MintLogic mintLogic;
 
 	@Inject
-	public TokenMintTransitionLogic(
-			final OptionValidator validator,
-			final TransactionContext txnCtx,
-			final GlobalDynamicProperties dynamicProperties,
-			final MintLogic mintLogic
-	) {
-		this.validator = validator;
+	public TokenMintTransitionLogic(final TransactionContext txnCtx, final MintLogic mintLogic) {
 		this.txnCtx = txnCtx;
-		this.dynamicProperties = dynamicProperties;
 		this.mintLogic = mintLogic;
 	}
 

--- a/hedera-node/src/main/java/com/hedera/services/txns/token/TokenMintTransitionLogic.java
+++ b/hedera-node/src/main/java/com/hedera/services/txns/token/TokenMintTransitionLogic.java
@@ -87,20 +87,6 @@ public class TokenMintTransitionLogic implements TransitionLogic {
 	}
 
 	public ResponseCodeEnum validate(TransactionBody txnBody) {
-		TokenMintTransactionBody op = txnBody.getTokenMint();
-
-		if (!op.hasToken()) {
-			return INVALID_TOKEN_ID;
-		}
-
-		return validateTokenOpsWith(
-				op.getMetadataCount(),
-				op.getAmount(),
-				dynamicProperties.areNftsEnabled(),
-				INVALID_TOKEN_MINT_AMOUNT,
-				op.getMetadataList(),
-				validator::maxBatchSizeMintCheck,
-				validator::nftMetadataCheck
-		);
+		return mintLogic.validateSyntax(txnBody);
 	}
 }

--- a/hedera-node/src/test/java/com/hedera/services/store/contracts/precompile/AssociatePrecompileTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/store/contracts/precompile/AssociatePrecompileTest.java
@@ -348,7 +348,6 @@ class AssociatePrecompileTest {
 		given(frame.getRecipientAddress()).willReturn(recipientAddress);
 		givenLedgers();
 		Bytes pretendArguments = Bytes.ofUnsignedInt(ABI_ID_ASSOCIATE_TOKEN);
-		given(pretendArguments.getInt(0)).willReturn(ABI_ID_ASSOCIATE_TOKEN);
 		given(decoder.decodeAssociation(eq(pretendArguments), any()))
 				.willReturn(associateOp);
 		given(syntheticTxnFactory.createAssociate(associateOp))

--- a/hedera-node/src/test/java/com/hedera/services/store/contracts/precompile/AssociatePrecompileTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/store/contracts/precompile/AssociatePrecompileTest.java
@@ -96,6 +96,7 @@ import static com.hedera.services.store.contracts.precompile.HTSTestsUtil.timest
 import static com.hedera.services.store.contracts.precompile.HTSTestsUtil.tokenMerkleId;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.FAIL_INVALID;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_SIGNATURE;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OK;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -316,6 +317,7 @@ class AssociatePrecompileTest {
 				.willReturn(mockRecordBuilder);
 		given(worldUpdater.aliases()).willReturn(aliases);
 		given(aliases.resolveForEvm(any())).willAnswer(invocationOnMock -> invocationOnMock.getArgument(0));
+		given(associateLogic.validateSyntax(any())).willReturn(OK);
 
 		// when:
 		subject.prepareFields(frame);
@@ -348,6 +350,7 @@ class AssociatePrecompileTest {
 				.willReturn(tokenStore);
 		given(associateLogicFactory.newAssociateLogic(tokenStore, accountStore, dynamicProperties))
 				.willReturn(associateLogic);
+		given(associateLogic.validateSyntax(any())).willReturn(OK);
 		given(feeCalculator.estimatedGasPriceInTinybars(HederaFunctionality.ContractCall, timestamp)).willReturn(1L);
 		given(mockSynthBodyBuilder.build()).willReturn(TransactionBody.newBuilder().build());
 		given(mockSynthBodyBuilder.setTransactionID(any(TransactionID.class))).willReturn(mockSynthBodyBuilder);
@@ -387,6 +390,7 @@ class AssociatePrecompileTest {
 				.willReturn(tokenStore);
 		given(associateLogicFactory.newAssociateLogic(tokenStore, accountStore, dynamicProperties))
 				.willReturn(associateLogic);
+		given(associateLogic.validateSyntax(any())).willReturn(OK);
 		given(feeCalculator.estimatedGasPriceInTinybars(HederaFunctionality.ContractCall, timestamp))
 				.willReturn(1L);
 		given(mockSynthBodyBuilder.build()).
@@ -431,6 +435,7 @@ class AssociatePrecompileTest {
 				.willReturn(tokenStore);
 		given(associateLogicFactory.newAssociateLogic(tokenStore, accountStore, dynamicProperties))
 				.willReturn(associateLogic);
+		given(associateLogic.validateSyntax(any())).willReturn(OK);
 		given(feeCalculator.estimatedGasPriceInTinybars(HederaFunctionality.ContractCall, timestamp))
 				.willReturn(1L);
 		given(mockSynthBodyBuilder.build()).
@@ -471,6 +476,7 @@ class AssociatePrecompileTest {
 				.willReturn(true);
 		given(accountStoreFactory.newAccountStore(validator, accounts))
 				.willReturn(accountStore);
+		given(associateLogic.validateSyntax(any())).willReturn(OK);
 		given(tokenStoreFactory.newTokenStore(accountStore, tokens, nfts, tokenRels, sideEffects))
 				.willReturn(tokenStore);
 		given(associateLogicFactory.newAssociateLogic(tokenStore, accountStore, dynamicProperties))

--- a/hedera-node/src/test/java/com/hedera/services/store/contracts/precompile/AssociatePrecompileTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/store/contracts/precompile/AssociatePrecompileTest.java
@@ -97,10 +97,12 @@ import static com.hedera.services.store.contracts.precompile.HTSTestsUtil.tokenM
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.FAIL_INVALID;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_SIGNATURE;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OK;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TOKEN_ID_REPEATED_IN_TOKEN_LIST;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
@@ -330,6 +332,58 @@ class AssociatePrecompileTest {
 		verify(associateLogic).associate(Id.fromGrpcAccount(accountMerkleId), Collections.singletonList(tokenMerkleId));
 		verify(wrappedLedgers).commit();
 		verify(worldUpdater).manageInProgressRecord(recordsHistorian, mockRecordBuilder, mockSynthBodyBuilder);
+	}
+
+	@Test
+	void computeAssociateTokenBadSyntax() {
+		given(frame.getContractAddress()).willReturn(contractAddress);
+		given(frame.getRecipientAddress()).willReturn(contractAddress);
+		given(frame.getSenderAddress()).willReturn(senderAddress);
+		given(frame.getWorldUpdater()).willReturn(worldUpdater);
+		given(frame.getRemainingGas()).willReturn(Gas.of(300));
+		given(frame.getValue()).willReturn(Wei.ZERO);
+		Optional<WorldUpdater> parent = Optional.of(worldUpdater);
+		given(worldUpdater.parentUpdater()).willReturn(parent);
+		given(worldUpdater.wrappedTrackingLedgers(any())).willReturn(wrappedLedgers);
+		given(frame.getRecipientAddress()).willReturn(recipientAddress);
+		givenLedgers();
+		given(pretendArguments.getInt(0)).willReturn(ABI_ID_ASSOCIATE_TOKEN);
+		given(decoder.decodeAssociation(eq(pretendArguments), any()))
+				.willReturn(associateOp);
+		given(syntheticTxnFactory.createAssociate(associateOp))
+				.willReturn(mockSynthBodyBuilder);
+		given(sigsVerifier.hasActiveKey(true,
+				Id.fromGrpcAccount(accountMerkleId).asEvmAddress(), recipientAddress,
+				wrappedLedgers))
+				.willReturn(true);
+		given(accountStoreFactory.newAccountStore(validator, dynamicProperties, accounts))
+				.willReturn(accountStore);
+		given(tokenStoreFactory.newTokenStore(accountStore, tokens, nfts, tokenRels, sideEffects))
+				.willReturn(tokenStore);
+		given(associateLogicFactory.newAssociateLogic(tokenStore, accountStore, dynamicProperties))
+				.willReturn(associateLogic);
+		given(feeCalculator.estimatedGasPriceInTinybars(HederaFunctionality.ContractCall, timestamp))
+				.willReturn(1L);
+		given(mockSynthBodyBuilder.build()).
+				willReturn(TransactionBody.newBuilder().build());
+		given(mockSynthBodyBuilder.setTransactionID(any(TransactionID.class)))
+				.willReturn(mockSynthBodyBuilder);
+		given(feeCalculator.computeFee(any(), any(), any(), any()))
+				.willReturn(mockFeeObject);
+		given(mockFeeObject.getServiceFee())
+				.willReturn(1L);
+		given(worldUpdater.aliases()).willReturn(aliases);
+		given(aliases.resolveForEvm(any())).willAnswer(invocationOnMock -> invocationOnMock.getArgument(0));
+		given(associateLogic.validateSyntax(any())).willReturn(TOKEN_ID_REPEATED_IN_TOKEN_LIST);
+		given(creator.createUnsuccessfulSyntheticRecord(TOKEN_ID_REPEATED_IN_TOKEN_LIST)).willReturn(mockRecordBuilder);
+
+		// when:
+		subject.prepareFields(frame);
+		subject.prepareComputation(pretendArguments, a -> a);
+		subject.computeGasRequirement(TEST_CONSENSUS_TIME);
+		subject.computeInternal(frame);
+
+		verify(wrappedLedgers, never()).commit();
 	}
 
 	@Test

--- a/hedera-node/src/test/java/com/hedera/services/store/contracts/precompile/AssociatePrecompileTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/store/contracts/precompile/AssociatePrecompileTest.java
@@ -340,13 +340,14 @@ class AssociatePrecompileTest {
 		given(frame.getRecipientAddress()).willReturn(contractAddress);
 		given(frame.getSenderAddress()).willReturn(senderAddress);
 		given(frame.getWorldUpdater()).willReturn(worldUpdater);
-		given(frame.getRemainingGas()).willReturn(Gas.of(300));
+		given(frame.getRemainingGas()).willReturn(300L);
 		given(frame.getValue()).willReturn(Wei.ZERO);
 		Optional<WorldUpdater> parent = Optional.of(worldUpdater);
 		given(worldUpdater.parentUpdater()).willReturn(parent);
 		given(worldUpdater.wrappedTrackingLedgers(any())).willReturn(wrappedLedgers);
 		given(frame.getRecipientAddress()).willReturn(recipientAddress);
 		givenLedgers();
+		Bytes pretendArguments = Bytes.ofUnsignedInt(ABI_ID_ASSOCIATE_TOKEN);
 		given(pretendArguments.getInt(0)).willReturn(ABI_ID_ASSOCIATE_TOKEN);
 		given(decoder.decodeAssociation(eq(pretendArguments), any()))
 				.willReturn(associateOp);
@@ -356,7 +357,7 @@ class AssociatePrecompileTest {
 				Id.fromGrpcAccount(accountMerkleId).asEvmAddress(), recipientAddress,
 				wrappedLedgers))
 				.willReturn(true);
-		given(accountStoreFactory.newAccountStore(validator, dynamicProperties, accounts))
+		given(accountStoreFactory.newAccountStore(validator, accounts))
 				.willReturn(accountStore);
 		given(tokenStoreFactory.newTokenStore(accountStore, tokens, nfts, tokenRels, sideEffects))
 				.willReturn(tokenStore);

--- a/hedera-node/src/test/java/com/hedera/services/store/contracts/precompile/BurnPrecompilesTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/store/contracts/precompile/BurnPrecompilesTest.java
@@ -103,6 +103,7 @@ import static com.hedera.services.store.contracts.precompile.HTSTestsUtil.target
 import static com.hedera.services.store.contracts.precompile.HTSTestsUtil.timestamp;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.FAIL_INVALID;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_SIGNATURE;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_TOKEN_ID;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OK;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -306,6 +307,35 @@ class BurnPrecompilesTest {
 		verify(burnLogic).burn(nonFungibleId, 0, targetSerialNos);
 		verify(wrappedLedgers).commit();
 		verify(worldUpdater).manageInProgressRecord(recordsHistorian, mockRecordBuilder, mockSynthBodyBuilder);
+	}
+
+	@Test
+	void nftBurnWorksForInvalidSyntax() {
+		givenNonfungibleFrameContext();
+		givenLedgers();
+
+		given(sigsVerifier.hasActiveSupplyKey(true, nonFungibleTokenAddr, recipientAddr, wrappedLedgers))
+				.willReturn(true);
+		given(accountStoreFactory.newAccountStore(validator, dynamicProperties, accounts)).willReturn(accountStore);
+		given(tokenStoreFactory.newTokenStore(accountStore, tokens, nfts, tokenRels, sideEffects))
+				.willReturn(tokenStore);
+		given(burnLogicFactory.newBurnLogic(validator, tokenStore, accountStore, dynamicProperties))
+				.willReturn(burnLogic);
+		given(feeCalculator.estimatedGasPriceInTinybars(HederaFunctionality.ContractCall, timestamp)).willReturn(1L);
+		given(mockSynthBodyBuilder.build()).willReturn(TransactionBody.newBuilder().build());
+		given(mockSynthBodyBuilder.setTransactionID(any(TransactionID.class))).willReturn(mockSynthBodyBuilder);
+		given(feeCalculator.computeFee(any(), any(), any(), any())).willReturn(mockFeeObject);
+		given(mockFeeObject.getServiceFee()).willReturn(1L);
+		given(burnLogic.validateSyntax(any())).willReturn(INVALID_TOKEN_ID);
+		given(creator.createUnsuccessfulSyntheticRecord(INVALID_TOKEN_ID))
+				.willReturn(mockRecordBuilder);
+
+		subject.prepareFields(frame);
+		subject.prepareComputation(pretendArguments, а -> а);
+		subject.computeGasRequirement(TEST_CONSENSUS_TIME);
+		subject.computeInternal(frame);
+
+		verify(wrappedLedgers, never()).commit();
 	}
 
 	@Test

--- a/hedera-node/src/test/java/com/hedera/services/store/contracts/precompile/BurnPrecompilesTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/store/contracts/precompile/BurnPrecompilesTest.java
@@ -316,7 +316,7 @@ class BurnPrecompilesTest {
 
 		given(sigsVerifier.hasActiveSupplyKey(true, nonFungibleTokenAddr, recipientAddr, wrappedLedgers))
 				.willReturn(true);
-		given(accountStoreFactory.newAccountStore(validator, dynamicProperties, accounts)).willReturn(accountStore);
+		given(accountStoreFactory.newAccountStore(validator, accounts)).willReturn(accountStore);
 		given(tokenStoreFactory.newTokenStore(accountStore, tokens, nfts, tokenRels, sideEffects))
 				.willReturn(tokenStore);
 		given(burnLogicFactory.newBurnLogic(validator, tokenStore, accountStore, dynamicProperties))

--- a/hedera-node/src/test/java/com/hedera/services/store/contracts/precompile/BurnPrecompilesTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/store/contracts/precompile/BurnPrecompilesTest.java
@@ -103,6 +103,7 @@ import static com.hedera.services.store.contracts.precompile.HTSTestsUtil.target
 import static com.hedera.services.store.contracts.precompile.HTSTestsUtil.timestamp;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.FAIL_INVALID;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_SIGNATURE;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OK;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
@@ -281,7 +282,8 @@ class BurnPrecompilesTest {
 		given(accountStoreFactory.newAccountStore(validator, accounts)).willReturn(accountStore);
 		given(tokenStoreFactory.newTokenStore(accountStore, tokens, nfts, tokenRels, sideEffects))
 				.willReturn(tokenStore);
-		given(burnLogicFactory.newBurnLogic(tokenStore, accountStore)).willReturn(burnLogic);
+		given(burnLogicFactory.newBurnLogic(validator, tokenStore, accountStore, dynamicProperties))
+				.willReturn(burnLogic);
 		given(feeCalculator.estimatedGasPriceInTinybars(HederaFunctionality.ContractCall, timestamp)).willReturn(1L);
 		given(mockSynthBodyBuilder.build()).willReturn(TransactionBody.newBuilder().build());
 		given(mockSynthBodyBuilder.setTransactionID(any(TransactionID.class))).willReturn(mockSynthBodyBuilder);
@@ -293,6 +295,7 @@ class BurnPrecompilesTest {
 				.setNewTotalSupply(123L);
 		given(mockRecordBuilder.getReceiptBuilder()).willReturn(receiptBuilder);
 		given(encoder.encodeBurnSuccess(123L)).willReturn(successResult);
+		given(burnLogic.validateSyntax(any())).willReturn(OK);
 
 		subject.prepareFields(frame);
 		subject.prepareComputation(pretendArguments, a -> a);
@@ -315,7 +318,8 @@ class BurnPrecompilesTest {
 		given(accountStoreFactory.newAccountStore(validator, accounts)).willReturn(accountStore);
 		given(tokenStoreFactory.newTokenStore(accountStore, tokens, nfts, tokenRels, sideEffects))
 				.willReturn(tokenStore);
-		given(burnLogicFactory.newBurnLogic(tokenStore, accountStore)).willReturn(burnLogic);
+		given(burnLogicFactory.newBurnLogic(validator, tokenStore, accountStore, dynamicProperties))
+				.willReturn(burnLogic);
 		given(feeCalculator.estimatedGasPriceInTinybars(HederaFunctionality.ContractCall, timestamp)).willReturn(1L);
 		given(mockSynthBodyBuilder.build()).willReturn(TransactionBody.newBuilder().build());
 		given(mockSynthBodyBuilder.setTransactionID(any(TransactionID.class))).willReturn(mockSynthBodyBuilder);
@@ -324,6 +328,7 @@ class BurnPrecompilesTest {
 		given(creator.createSuccessfulSyntheticRecord(Collections.emptyList(), sideEffects, EMPTY_MEMO))
 				.willReturn(expirableTxnRecordBuilder);
 		given(encoder.encodeBurnSuccess(49)).willReturn(burnSuccessResultWith49Supply);
+		given(burnLogic.validateSyntax(any())).willReturn(OK);
 
 		subject.prepareFields(frame);
 		subject.prepareComputation(pretendArguments, a -> a);
@@ -364,7 +369,8 @@ class BurnPrecompilesTest {
 		given(accountStoreFactory.newAccountStore(validator, accounts)).willReturn(accountStore);
 		given(tokenStoreFactory.newTokenStore(accountStore, tokens, nfts, tokenRels, sideEffects))
 				.willReturn(tokenStore);
-		given(burnLogicFactory.newBurnLogic(tokenStore, accountStore)).willReturn(burnLogic);
+		given(burnLogicFactory.newBurnLogic(validator, tokenStore, accountStore, dynamicProperties))
+				.willReturn(burnLogic);
 		given(feeCalculator.estimatedGasPriceInTinybars(HederaFunctionality.ContractCall, timestamp)).willReturn(1L);
 		given(mockSynthBodyBuilder.build()).willReturn(TransactionBody.newBuilder().build());
 		given(mockSynthBodyBuilder.setTransactionID(any(TransactionID.class))).willReturn(mockSynthBodyBuilder);
@@ -373,6 +379,7 @@ class BurnPrecompilesTest {
 		given(creator.createSuccessfulSyntheticRecord(Collections.emptyList(), sideEffects, EMPTY_MEMO))
 				.willReturn(expirableTxnRecordBuilder);
 		given(encoder.encodeBurnSuccess(anyLong())).willReturn(burnSuccessResultWithLongMaxValueSupply);
+		given(burnLogic.validateSyntax(any())).willReturn(OK);
 
 		subject.prepareFields(frame);
 		subject.prepareComputation(pretendArguments, a -> a);

--- a/hedera-node/src/test/java/com/hedera/services/store/contracts/precompile/DissociatePrecompilesTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/store/contracts/precompile/DissociatePrecompilesTest.java
@@ -94,11 +94,13 @@ import static com.hedera.services.store.contracts.precompile.HTSTestsUtil.succes
 import static com.hedera.services.store.contracts.precompile.HTSTestsUtil.timestamp;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_SIGNATURE;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OK;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TOKEN_ID_REPEATED_IN_TOKEN_LIST;
 import static java.util.Collections.singletonList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
@@ -261,24 +263,20 @@ class DissociatePrecompilesTest {
 				.willReturn(mockFeeObject);
 		given(mockFeeObject.getServiceFee())
 				.willReturn(1L);
-		given(creator.createSuccessfulSyntheticRecord(Collections.emptyList(), sideEffects, EMPTY_MEMO))
-				.willReturn(mockRecordBuilder);
 		given(decoder.decodeDissociate(eq(pretendArguments), any())).willReturn(dissociateToken);
 		given(syntheticTxnFactory.createDissociate(dissociateToken)).willReturn(mockSynthBodyBuilder);
-		given(dissociateLogic.validateSyntax(any())).willReturn(OK);
+		given(dissociateLogic.validateSyntax(any())).willReturn(TOKEN_ID_REPEATED_IN_TOKEN_LIST);
+		given(creator.createUnsuccessfulSyntheticRecord(TOKEN_ID_REPEATED_IN_TOKEN_LIST))
+				.willReturn(mockRecordBuilder);
 
 		// when:
 		subject.prepareFields(frame);
 		subject.prepareComputation(pretendArguments, a -> a);
 		subject.computeGasRequirement(TEST_CONSENSUS_TIME);
-		final var result = subject.computeInternal(frame);
+		subject.computeInternal(frame);
 
 		// then:
-		assertEquals(successResult, result);
-		// and:
-		verify(dissociateLogic).dissociate(accountId, singletonList(nonFungible));
-		verify(wrappedLedgers).commit();
-		verify(worldUpdater).manageInProgressRecord(recordsHistorian, mockRecordBuilder, mockSynthBodyBuilder);
+		verify(wrappedLedgers, never()).commit();
 	}
 
 	@Test

--- a/hedera-node/src/test/java/com/hedera/services/store/contracts/precompile/DissociatePrecompilesTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/store/contracts/precompile/DissociatePrecompilesTest.java
@@ -93,6 +93,7 @@ import static com.hedera.services.store.contracts.precompile.HTSTestsUtil.sender
 import static com.hedera.services.store.contracts.precompile.HTSTestsUtil.successResult;
 import static com.hedera.services.store.contracts.precompile.HTSTestsUtil.timestamp;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_SIGNATURE;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OK;
 import static java.util.Collections.singletonList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
@@ -264,6 +265,7 @@ class DissociatePrecompilesTest {
 				.willReturn(mockRecordBuilder);
 		given(decoder.decodeDissociate(eq(pretendArguments), any())).willReturn(dissociateToken);
 		given(syntheticTxnFactory.createDissociate(dissociateToken)).willReturn(mockSynthBodyBuilder);
+		given(dissociateLogic.validateSyntax(any())).willReturn(OK);
 
 		// when:
 		subject.prepareFields(frame);
@@ -309,6 +311,7 @@ class DissociatePrecompilesTest {
 				.willReturn(1L);
 		given(creator.createSuccessfulSyntheticRecord(Collections.emptyList(), sideEffects, EMPTY_MEMO))
 				.willReturn(mockRecordBuilder);
+		given(dissociateLogic.validateSyntax(any())).willReturn(OK);
 
 		// when:
 		subject.prepareFields(frame);

--- a/hedera-node/src/test/java/com/hedera/services/store/contracts/precompile/MintPrecompilesTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/store/contracts/precompile/MintPrecompilesTest.java
@@ -106,6 +106,7 @@ import static com.hedera.services.store.contracts.precompile.HTSTestsUtil.timest
 import static com.hedera.test.utils.TxnUtils.assertFailsWith;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.FAIL_INVALID;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_SIGNATURE;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_TOKEN_ID;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OK;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -320,6 +321,43 @@ class MintPrecompilesTest {
 		verify(mintLogic).mint(nonFungibleId, 3, 0, newMetadata, pendingChildConsTime);
 		verify(wrappedLedgers).commit();
 		verify(worldUpdater).manageInProgressRecord(recordsHistorian, mockRecordBuilder, mockSynthBodyBuilder);
+	}
+
+	@Test
+	void nftMintBadSyntaxWorks() {
+		givenNonFungibleFrameContext();
+		givenLedgers();
+
+		given(sigsVerifier.hasActiveSupplyKey(true, nonFungibleTokenAddr, recipientAddr, wrappedLedgers)).willReturn(true);
+		given(accountStoreFactory.newAccountStore(validator, dynamicProperties, accounts)).willReturn(accountStore);
+		given(tokenStoreFactory.newTokenStore(accountStore, tokens, nfts, tokenRels, sideEffects))
+				.willReturn(tokenStore);
+		given(mintLogicFactory.newMintLogic(validator, tokenStore, accountStore, dynamicProperties))
+				.willReturn(mintLogic);
+		given(feeCalculator.estimatedGasPriceInTinybars(HederaFunctionality.ContractCall, timestamp))
+				.willReturn(1L);
+		given(mockSynthBodyBuilder.build())
+				.willReturn(TransactionBody.newBuilder().build());
+		given(mockSynthBodyBuilder.setTransactionID(any(TransactionID.class)))
+				.willReturn(mockSynthBodyBuilder);
+		given(feeCalculator.computeFee(any(), any(), any(), any()))
+				.willReturn(mockFeeObject);
+		given(mockFeeObject.getServiceFee())
+				.willReturn(1L);
+		given(worldUpdater.aliases()).willReturn(aliases);
+		given(aliases.resolveForEvm(any())).willAnswer(invocationOnMock -> invocationOnMock.getArgument(0));
+		given(mintLogic.validateSyntax(any())).willReturn(INVALID_TOKEN_ID);
+		given(creator.createUnsuccessfulSyntheticRecord(INVALID_TOKEN_ID))
+				.willReturn(mockRecordBuilder);
+
+		// when:
+		subject.prepareFields(frame);
+		subject.prepareComputation(pretendArguments, а -> а);
+		subject.computeGasRequirement(TEST_CONSENSUS_TIME);
+		subject.computeInternal(frame);
+
+		// then:
+		verify(wrappedLedgers, never()).commit();
 	}
 
 	@Test

--- a/hedera-node/src/test/java/com/hedera/services/store/contracts/precompile/MintPrecompilesTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/store/contracts/precompile/MintPrecompilesTest.java
@@ -325,11 +325,11 @@ class MintPrecompilesTest {
 
 	@Test
 	void nftMintBadSyntaxWorks() {
-		givenNonFungibleFrameContext();
+		Bytes pretendArguments = givenNonFungibleFrameContext();
 		givenLedgers();
 
 		given(sigsVerifier.hasActiveSupplyKey(true, nonFungibleTokenAddr, recipientAddr, wrappedLedgers)).willReturn(true);
-		given(accountStoreFactory.newAccountStore(validator, dynamicProperties, accounts)).willReturn(accountStore);
+		given(accountStoreFactory.newAccountStore(validator, accounts)).willReturn(accountStore);
 		given(tokenStoreFactory.newTokenStore(accountStore, tokens, nfts, tokenRels, sideEffects))
 				.willReturn(tokenStore);
 		given(mintLogicFactory.newMintLogic(validator, tokenStore, accountStore, dynamicProperties))

--- a/hedera-node/src/test/java/com/hedera/services/store/contracts/precompile/MintPrecompilesTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/store/contracts/precompile/MintPrecompilesTest.java
@@ -106,6 +106,7 @@ import static com.hedera.services.store.contracts.precompile.HTSTestsUtil.timest
 import static com.hedera.test.utils.TxnUtils.assertFailsWith;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.FAIL_INVALID;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_SIGNATURE;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OK;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
@@ -284,7 +285,8 @@ class MintPrecompilesTest {
 		given(accountStoreFactory.newAccountStore(validator, accounts)).willReturn(accountStore);
 		given(tokenStoreFactory.newTokenStore(accountStore, tokens, nfts, tokenRels, sideEffects))
 				.willReturn(tokenStore);
-		given(mintLogicFactory.newMintLogic(validator, tokenStore, accountStore)).willReturn(mintLogic);
+		given(mintLogicFactory.newMintLogic(validator, tokenStore, accountStore, dynamicProperties))
+				.willReturn(mintLogic);
 		given(feeCalculator.estimatedGasPriceInTinybars(HederaFunctionality.ContractCall, timestamp))
 				.willReturn(1L);
 		given(mockSynthBodyBuilder.build())
@@ -304,6 +306,7 @@ class MintPrecompilesTest {
 		given(recordsHistorian.nextFollowingChildConsensusTime()).willReturn(pendingChildConsTime);
 		given(worldUpdater.aliases()).willReturn(aliases);
 		given(aliases.resolveForEvm(any())).willAnswer(invocationOnMock -> invocationOnMock.getArgument(0));
+		given(mintLogic.validateSyntax(any())).willReturn(OK);
 
 		// when:
 		subject.prepareFields(frame);
@@ -337,6 +340,8 @@ class MintPrecompilesTest {
 				.willReturn(mockFeeObject);
 		given(mockFeeObject.getServiceFee())
 				.willReturn(1L);
+		given(mintLogic.validateSyntax(any())).willReturn(OK);
+
 		// when:
 		subject.prepareFields(frame);
 		subject.prepareComputation(pretendArguments, a -> a);
@@ -369,6 +374,7 @@ class MintPrecompilesTest {
 				.willReturn(mockFeeObject);
 		given(mockFeeObject.getServiceFee())
 				.willReturn(1L);
+		given(mintLogic.validateSyntax(any())).willReturn(OK);
 
 		subject.prepareFields(frame);
 		subject.prepareComputation(pretendArguments, a -> a);
@@ -414,6 +420,8 @@ class MintPrecompilesTest {
 				.willReturn(mockFeeObject);
 		given(mockFeeObject.getServiceFee())
 				.willReturn(1L);
+		given(mintLogic.validateSyntax(any())).willReturn(OK);
+
 		// when:
 		subject.prepareFields(frame);
 		subject.prepareComputation(pretendArguments, a -> a);
@@ -467,7 +475,8 @@ class MintPrecompilesTest {
 		given(accountStoreFactory.newAccountStore(validator, accounts)).willReturn(accountStore);
 		given(tokenStoreFactory.newTokenStore(accountStore, tokens, nfts, tokenRels, sideEffects))
 				.willReturn(tokenStore);
-		given(mintLogicFactory.newMintLogic(validator, tokenStore, accountStore)).willReturn(mintLogic);
+		given(mintLogicFactory.newMintLogic(validator, tokenStore, accountStore, dynamicProperties))
+				.willReturn(mintLogic);
 		given(creator.createSuccessfulSyntheticRecord(Collections.emptyList(), sideEffects, EMPTY_MEMO))
 				.willReturn(expirableTxnRecordBuilder);
 	}

--- a/hedera-node/src/test/java/com/hedera/services/txns/token/AssociateLogicTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/txns/token/AssociateLogicTest.java
@@ -28,7 +28,6 @@ import com.hedera.services.store.models.Id;
 import com.hedera.services.store.models.Token;
 import com.hedera.services.store.models.TokenRelationship;
 import com.hedera.test.utils.IdUtils;
-import com.hedera.test.utils.TxnUtils;
 import com.hederahashgraph.api.proto.java.TokenID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -38,8 +37,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.List;
 
-import static com.hedera.test.utils.TxnUtils.assertFailsWith;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TOKEN_ID_REPEATED_IN_TOKEN_LIST;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 
@@ -83,12 +80,5 @@ class AssociateLogicTest {
 		verify(modelAccount).associateWith(tokens, tokenStore, false, false, dynamicProperties);
 		verify(accountStore).commitAccount(modelAccount);
 		verify(tokenStore).commitTokenRelationships(List.of(firstModelTokenRel, secondModelTokenRel));
-	}
-
-	@Test
-	void rejectsRepeatedTokenId() {
-		assertFailsWith(
-				() -> subject.associate(accountId, List.of(firstToken, secondToken, firstToken)),
-				TOKEN_ID_REPEATED_IN_TOKEN_LIST);
 	}
 }

--- a/hedera-node/src/test/java/com/hedera/services/txns/token/AssociateLogicTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/txns/token/AssociateLogicTest.java
@@ -28,6 +28,7 @@ import com.hedera.services.store.models.Id;
 import com.hedera.services.store.models.Token;
 import com.hedera.services.store.models.TokenRelationship;
 import com.hedera.test.utils.IdUtils;
+import com.hedera.test.utils.TxnUtils;
 import com.hederahashgraph.api.proto.java.TokenID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -37,6 +38,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.List;
 
+import static com.hedera.test.utils.TxnUtils.assertFailsWith;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TOKEN_ID_REPEATED_IN_TOKEN_LIST;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 
@@ -80,5 +83,12 @@ class AssociateLogicTest {
 		verify(modelAccount).associateWith(tokens, tokenStore, false, false, dynamicProperties);
 		verify(accountStore).commitAccount(modelAccount);
 		verify(tokenStore).commitTokenRelationships(List.of(firstModelTokenRel, secondModelTokenRel));
+	}
+
+	@Test
+	void rejectsRepeatedTokenId() {
+		assertFailsWith(
+				() -> subject.associate(accountId, List.of(firstToken, secondToken, firstToken)),
+				TOKEN_ID_REPEATED_IN_TOKEN_LIST);
 	}
 }

--- a/hedera-node/src/test/java/com/hedera/services/txns/token/BurnLogicTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/txns/token/BurnLogicTest.java
@@ -20,10 +20,12 @@ package com.hedera.services.txns.token;
  * ‍
  */
 
+import com.hedera.services.context.properties.GlobalDynamicProperties;
 import com.hedera.services.state.enums.TokenType;
 import com.hedera.services.store.AccountStore;
 import com.hedera.services.store.TypedTokenStore;
 import com.hedera.services.store.models.*;
+import com.hedera.services.txns.validation.OptionValidator;
 import com.hedera.test.utils.IdUtils;
 import com.hederahashgraph.api.proto.java.TokenBurnTransactionBody;
 import com.hederahashgraph.api.proto.java.TokenID;
@@ -51,11 +53,14 @@ class BurnLogicTest {
 
 	@Mock
 	private Token token;
-
 	@Mock
 	private TypedTokenStore store;
 	@Mock
 	private AccountStore accountStore;
+	@Mock
+	private OptionValidator validator;
+	@Mock
+	private GlobalDynamicProperties dynamicProperties;
 
 	private TransactionBody tokenBurnTxn;
 
@@ -63,7 +68,7 @@ class BurnLogicTest {
 
 	@BeforeEach
 	private void setup() {
-		subject = new BurnLogic(store, accountStore);
+		subject = new BurnLogic(validator, store, accountStore, dynamicProperties);
 	}
 
 	@Test

--- a/hedera-node/src/test/java/com/hedera/services/txns/token/MintLogicTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/txns/token/MintLogicTest.java
@@ -22,6 +22,7 @@ package com.hedera.services.txns.token;
 
 import com.google.protobuf.ByteString;
 import com.hedera.services.context.TransactionContext;
+import com.hedera.services.context.properties.GlobalDynamicProperties;
 import com.hedera.services.state.enums.TokenType;
 import com.hedera.services.state.submerkle.RichInstant;
 import com.hedera.services.store.AccountStore;
@@ -73,6 +74,8 @@ class MintLogicTest {
 	private OptionValidator validator;
 	@Mock
 	private AccountStore accountStore;
+	@Mock
+	private GlobalDynamicProperties dynamicProperties;
 
 	private TokenRelationship treasuryRel;
 	private TransactionBody tokenMintTxn;
@@ -81,7 +84,7 @@ class MintLogicTest {
 
 	@BeforeEach
 	private void setup() {
-		subject = new MintLogic(validator, store, accountStore);
+		subject = new MintLogic(validator, store, accountStore, dynamicProperties);
 	}
 
 	@Test

--- a/hedera-node/src/test/java/com/hedera/services/txns/token/TokenAssociateTransitionLogicTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/txns/token/TokenAssociateTransitionLogicTest.java
@@ -79,7 +79,7 @@ class TokenAssociateTransitionLogicTest {
 
 		subject.doStateTransition();
 
-		verify(associateLogic).associateUniqueTokens(
+		verify(associateLogic).associate(
 				Id.fromGrpcAccount(account), List.of(firstToken, secondToken));
 	}
 

--- a/hedera-node/src/test/java/com/hedera/services/txns/token/TokenBurnTransitionLogicTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/txns/token/TokenBurnTransitionLogicTest.java
@@ -24,7 +24,6 @@ import com.hedera.services.context.TransactionContext;
 import com.hedera.services.context.properties.GlobalDynamicProperties;
 import com.hedera.services.store.AccountStore;
 import com.hedera.services.store.TypedTokenStore;
-import com.hedera.services.store.models.Account;
 import com.hedera.services.store.models.Id;
 import com.hedera.services.txns.validation.OptionValidator;
 import com.hedera.services.utils.accessors.SignedTxnAccessor;
@@ -38,7 +37,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.time.Instant;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.LongStream;
@@ -88,7 +86,7 @@ class TokenBurnTransitionLogicTest {
 	@BeforeEach
 	private void setup() {
 		burnLogic = new BurnLogic(validator, tokenStore, accountStore, dynamicProperties);
-		subject = new TokenBurnTransitionLogic(validator, txnCtx, dynamicProperties, burnLogic);
+		subject = new TokenBurnTransitionLogic(txnCtx, burnLogic);
 	}
 
 	@Test
@@ -200,7 +198,7 @@ class TokenBurnTransitionLogicTest {
 	@Test
 	void callsBurnLogicWithCorrectParams() {
 		burnLogic = mock(BurnLogic.class);
-		subject = new TokenBurnTransitionLogic(validator, txnCtx, dynamicProperties, burnLogic);
+		subject = new TokenBurnTransitionLogic(txnCtx, burnLogic);
 
 		var grpcId = IdUtils.asToken("0.0.1");
 		var amount = 4321L;

--- a/hedera-node/src/test/java/com/hedera/services/txns/token/TokenBurnTransitionLogicTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/txns/token/TokenBurnTransitionLogicTest.java
@@ -22,6 +22,8 @@ package com.hedera.services.txns.token;
 
 import com.hedera.services.context.TransactionContext;
 import com.hedera.services.context.properties.GlobalDynamicProperties;
+import com.hedera.services.store.AccountStore;
+import com.hedera.services.store.TypedTokenStore;
 import com.hedera.services.store.models.Account;
 import com.hedera.services.store.models.Id;
 import com.hedera.services.txns.validation.OptionValidator;
@@ -52,15 +54,14 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
 class TokenBurnTransitionLogicTest {
 	private final long amount = 123L;
 	private final TokenID grpcId = IdUtils.asToken("1.2.3");
-	private final Id id = new Id(1, 2, 3);
 	private final Id treasuryId = new Id(2, 4, 6);
-	private final Account treasury = new Account(treasuryId);
 
 	@Mock
 	private TransactionContext txnCtx;
@@ -73,16 +74,20 @@ class TokenBurnTransitionLogicTest {
 	@Mock
 	private OptionValidator validator;
 	@Mock
-	private GlobalDynamicProperties dynamicProperties;
+	private TypedTokenStore tokenStore;
 	@Mock
-	private BurnLogic burnLogic;
+	private AccountStore accountStore;
+	@Mock
+	private GlobalDynamicProperties dynamicProperties;
 
 	private TransactionBody tokenBurnTxn;
 
+	private BurnLogic burnLogic;
 	private TokenBurnTransitionLogic subject;
 
 	@BeforeEach
 	private void setup() {
+		burnLogic = new BurnLogic(validator, tokenStore, accountStore, dynamicProperties);
 		subject = new TokenBurnTransitionLogic(validator, txnCtx, dynamicProperties, burnLogic);
 	}
 
@@ -194,7 +199,9 @@ class TokenBurnTransitionLogicTest {
 
 	@Test
 	void callsBurnLogicWithCorrectParams() {
-		var consensus = Instant.now();
+		burnLogic = mock(BurnLogic.class);
+		subject = new TokenBurnTransitionLogic(validator, txnCtx, dynamicProperties, burnLogic);
+
 		var grpcId = IdUtils.asToken("0.0.1");
 		var amount = 4321L;
 		List<Long> serialNumbersList = List.of(1L, 2L, 3L);

--- a/hedera-node/src/test/java/com/hedera/services/txns/token/TokenDissociateTransitionLogicTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/txns/token/TokenDissociateTransitionLogicTest.java
@@ -21,7 +21,11 @@ package com.hedera.services.txns.token;
  */
 
 import com.hedera.services.context.TransactionContext;
+import com.hedera.services.store.AccountStore;
+import com.hedera.services.store.TypedTokenStore;
 import com.hedera.services.store.models.Id;
+import com.hedera.services.txns.token.process.DissociationFactory;
+import com.hedera.services.txns.validation.OptionValidator;
 import com.hedera.services.utils.accessors.PlatformTxnAccessor;
 import com.hedera.services.utils.accessors.SignedTxnAccessor;
 import com.hedera.test.utils.IdUtils;
@@ -42,6 +46,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
@@ -52,14 +57,22 @@ class TokenDissociateTransitionLogicTest {
 	@Mock
 	private TransactionContext txnCtx;
 	@Mock
-	private DissociateLogic dissociateLogic;
-	@Mock
 	private SignedTxnAccessor accessor;
+	@Mock
+	private OptionValidator validator;
+	@Mock
+	private TypedTokenStore tokenStore;
+	@Mock
+	private AccountStore accountStore;
+	@Mock
+	private DissociationFactory dissociationFactory;
 
+	private DissociateLogic dissociateLogic;
 	private TokenDissociateTransitionLogic subject;
 
 	@BeforeEach
 	void setUp() {
+		dissociateLogic = new DissociateLogic(validator, tokenStore, accountStore, dissociationFactory);
 		subject = new TokenDissociateTransitionLogic(txnCtx, dissociateLogic);
 	}
 
@@ -97,6 +110,8 @@ class TokenDissociateTransitionLogicTest {
 	@Test
 	void callsDissociateLogicWithCorrectParams() {
 		final var accountId = new Id(1, 2, 3);
+		dissociateLogic = mock(DissociateLogic.class);
+		subject = new TokenDissociateTransitionLogic(txnCtx, dissociateLogic);
 
 		given(accessor.getTxn()).willReturn(validDissociateTxn());
 		given(txnCtx.accessor()).willReturn(accessor);

--- a/hedera-node/src/test/java/com/hedera/services/txns/token/TokenMintTransitionLogicTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/txns/token/TokenMintTransitionLogicTest.java
@@ -23,6 +23,8 @@ package com.hedera.services.txns.token;
 import com.google.protobuf.ByteString;
 import com.hedera.services.context.TransactionContext;
 import com.hedera.services.context.properties.GlobalDynamicProperties;
+import com.hedera.services.store.AccountStore;
+import com.hedera.services.store.TypedTokenStore;
 import com.hedera.services.store.models.Id;
 import com.hedera.services.txns.validation.OptionValidator;
 import com.hedera.services.utils.accessors.SignedTxnAccessor;
@@ -51,6 +53,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.BDDMockito.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
@@ -71,14 +74,18 @@ class TokenMintTransitionLogicTest {
 	@Mock
 	private GlobalDynamicProperties dynamicProperties;
 	@Mock
-	private MintLogic mintLogic;
+	private TypedTokenStore tokenStore;
+	@Mock
+	private AccountStore accountStore;
 
 	private TransactionBody tokenMintTxn;
 
+	private MintLogic mintLogic;
 	private TokenMintTransitionLogic subject;
 
 	@BeforeEach
 	private void setup() {
+		mintLogic = new MintLogic(validator, tokenStore, accountStore, dynamicProperties);
 		subject = new TokenMintTransitionLogic(validator, txnCtx, dynamicProperties, mintLogic);
 	}
 
@@ -188,6 +195,9 @@ class TokenMintTransitionLogicTest {
 
 	@Test
 	void callsMintLogicWithCorrectParams() {
+		mintLogic = mock(MintLogic.class);
+		subject = new TokenMintTransitionLogic(validator, txnCtx, dynamicProperties, mintLogic);
+
 		var consensus = Instant.now();
 		var grpcId = IdUtils.asToken("0.0.1");
 		var amount = 4321L;

--- a/hedera-node/src/test/java/com/hedera/services/txns/token/TokenMintTransitionLogicTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/txns/token/TokenMintTransitionLogicTest.java
@@ -86,7 +86,7 @@ class TokenMintTransitionLogicTest {
 	@BeforeEach
 	private void setup() {
 		mintLogic = new MintLogic(validator, tokenStore, accountStore, dynamicProperties);
-		subject = new TokenMintTransitionLogic(validator, txnCtx, dynamicProperties, mintLogic);
+		subject = new TokenMintTransitionLogic(txnCtx, mintLogic);
 	}
 
 	@Test
@@ -196,7 +196,7 @@ class TokenMintTransitionLogicTest {
 	@Test
 	void callsMintLogicWithCorrectParams() {
 		mintLogic = mock(MintLogic.class);
-		subject = new TokenMintTransitionLogic(validator, txnCtx, dynamicProperties, mintLogic);
+		subject = new TokenMintTransitionLogic(txnCtx, mintLogic);
 
 		var consensus = Instant.now();
 		var grpcId = IdUtils.asToken("0.0.1");


### PR DESCRIPTION
**Description**:
 - Inserts precheck syntax checks into `HTSPrecompiledContract` implementations to align error codes with those returned by HAPI.