### PR TITLE
Logging out ServicesState children sizes before and after migration to simplify ensuring consistency pre- and post- migration.

### DIFF
--- a/hedera-node/src/main/java/com/hedera/services/ServicesState.java
+++ b/hedera-node/src/main/java/com/hedera/services/ServicesState.java
@@ -23,6 +23,7 @@ package com.hedera.services;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.InvalidProtocolBufferException;
+import com.hedera.services.context.init.StateInitializationFlow;
 import com.hedera.services.context.properties.BootstrapProperties;
 import com.hedera.services.state.merkle.MerkleAccount;
 import com.hedera.services.state.merkle.MerkleNetworkContext;
@@ -120,6 +121,36 @@ public class ServicesState extends AbstractNaryMerkleInternal implements SwirldS
 		this.metadata = (that.metadata == null) ? null : that.metadata.copy();
 	}
 
+	/**
+	 * Log out the sizes the state children.
+	 */
+	 private void logStateChildrenSizes() {
+		log.info("  (@ {}) # NFTs               = {}",
+				StateChildIndices.UNIQUE_TOKENS,
+				uniqueTokens().size());
+		log.info("  (@ {}) # token associations = {}",
+				StateChildIndices.TOKEN_ASSOCIATIONS,
+				tokenAssociations().size());
+		log.info("  (@ {}) # topics             = {}",
+				StateChildIndices.TOPICS,
+				topics().size());
+		log.info("  (@ {}) # blobs              = {}",
+				StateChildIndices.STORAGE,
+				storage().size());
+		log.info("  (@ {}) # accounts/contracts = {}",
+				StateChildIndices.ACCOUNTS,
+				accounts().size());
+		log.info("  (@ {}) # tokens             = {}",
+				StateChildIndices.TOKENS,
+				tokens().size());
+		log.info("  (@ {}) # scheduled txns     = {}",
+				StateChildIndices.SCHEDULE_TXS,
+				scheduleTxs().size());
+		log.info("  (@ {}) # contract K/V pairs = {}",
+				StateChildIndices.CONTRACT_STORAGE,
+				contractStorage().size());
+	}
+
 	/* --- MerkleInternal --- */
 	@Override
 	public long getClassId() {
@@ -180,6 +211,8 @@ public class ServicesState extends AbstractNaryMerkleInternal implements SwirldS
 			final var app = getMetadata().app();
 			app.workingState().updatePrimitiveChildrenFrom(this);
 		}
+		log.info("Migration completed.");
+		logStateChildrenSizes();
 	}
 
 	/* --- SwirldState --- */
@@ -419,6 +452,8 @@ public class ServicesState extends AbstractNaryMerkleInternal implements SwirldS
 			networkCtx().setStateVersion(CURRENT_VERSION);
 
 			metadata = new StateMetadata(app, new FCHashMap<>());
+			// Log state before migration.
+			logStateChildrenSizes();
 			// This updates the working state accessor with our children
 			app.initializationFlow().runWith(this);
 

--- a/hedera-node/src/main/java/com/hedera/services/ServicesState.java
+++ b/hedera-node/src/main/java/com/hedera/services/ServicesState.java
@@ -23,7 +23,6 @@ package com.hedera.services;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.InvalidProtocolBufferException;
-import com.hedera.services.context.init.StateInitializationFlow;
 import com.hedera.services.context.properties.BootstrapProperties;
 import com.hedera.services.state.merkle.MerkleAccount;
 import com.hedera.services.state.merkle.MerkleNetworkContext;

--- a/hedera-node/src/main/java/com/hedera/services/context/init/StateInitializationFlow.java
+++ b/hedera-node/src/main/java/com/hedera/services/context/init/StateInitializationFlow.java
@@ -25,7 +25,6 @@ import com.hedera.services.config.HederaNumbers;
 import com.hedera.services.context.MutableStateChildren;
 import com.hedera.services.files.FileUpdateInterceptor;
 import com.hedera.services.files.HederaFs;
-import com.hedera.services.state.migration.StateChildIndices;
 import com.hedera.services.stream.RecordStreamManager;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -67,30 +66,6 @@ public class StateInitializationFlow {
 
 		workingState.updateFrom(activeState);
 		log.info("Context updated with working state");
-		log.info("  (@ {}) # NFTs               = {}",
-				StateChildIndices.UNIQUE_TOKENS,
-				activeState.uniqueTokens().size());
-		log.info("  (@ {}) # token associations = {}",
-				StateChildIndices.TOKEN_ASSOCIATIONS,
-				activeState.tokenAssociations().size());
-		log.info("  (@ {}) # topics             = {}",
-				StateChildIndices.TOPICS,
-				activeState.topics().size());
-		log.info("  (@ {}) # blobs              = {}",
-				StateChildIndices.STORAGE,
-				activeState.storage().size());
-		log.info("  (@ {}) # accounts/contracts = {}",
-				StateChildIndices.ACCOUNTS,
-				activeState.accounts().size());
-		log.info("  (@ {}) # tokens             = {}",
-				StateChildIndices.TOKENS,
-				activeState.tokens().size());
-		log.info("  (@ {}) # scheduled txns     = {}",
-				StateChildIndices.SCHEDULE_TXS,
-				activeState.scheduleTxs().size());
-		log.info("  (@ {}) # contract K/V pairs = {}",
-				StateChildIndices.CONTRACT_STORAGE,
-				activeState.contractStorage().size());
 
 		final var activeHash = activeState.runningHashLeaf().getRunningHash().getHash();
 		recordStreamManager.setInitialHash(activeHash);

--- a/hedera-node/src/test/java/com/hedera/services/ServicesStateTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/ServicesStateTest.java
@@ -65,6 +65,7 @@ import com.swirlds.virtualmap.VirtualMap;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -170,7 +171,13 @@ class ServicesStateTest {
 	@LoggingTarget
 	private LogCaptor logCaptor;
 	@LoggingSubject
-	private ServicesState subject = new ServicesState();
+	private ServicesState subject;
+
+	@BeforeEach
+	void setUp() {
+		subject = new ServicesState();
+		setAllChildren();
+	}
 
 	@AfterEach
 	void cleanup() {
@@ -779,5 +786,9 @@ class ServicesStateTest {
 		subject.setChild(StateChildIndices.STORAGE, mockMm);
 		subject.setChild(StateChildIndices.TOPICS, mockMm);
 		subject.setChild(StateChildIndices.SCHEDULE_TXS, mockMm);
+	}
+
+	private void setAllChildren() {
+		subject.createGenesisChildren(addressBook, 0);
 	}
 }

--- a/hedera-node/src/test/java/com/hedera/services/context/init/StateInitializationFlowTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/context/init/StateInitializationFlowTest.java
@@ -119,7 +119,6 @@ class StateInitializationFlowTest {
 		given(runningHash.getHash()).willReturn(hash);
 		given(runningHashLeaf.getRunningHash()).willReturn(runningHash);
 		given(activeState.runningHashLeaf()).willReturn(runningHashLeaf);
-		givenMockMerkleMaps();
 
 		// when:
 		subject.runWith(activeState);
@@ -142,7 +141,6 @@ class StateInitializationFlowTest {
 		given(runningHashLeaf.getRunningHash()).willReturn(runningHash);
 		given(activeState.runningHashLeaf()).willReturn(runningHashLeaf);
 		given(hfs.numRegisteredInterceptors()).willReturn(5);
-		givenMockMerkleMaps();
 
 		// when:
 		subject.runWith(activeState);


### PR DESCRIPTION
**Description**:
- Refactors some of the logging logic into ServicesState.
- Log out ServicesState children sizes before and after migration.
- Update tests to reflect changes.

**Related issue(s)**:

Fixes: https://github.com/hashgraph/hedera-services/issues/3462
