### PR TITLE
Remove spurious logging line back to debug level to avoid log spamming.

### DIFF
--- a/hedera-node/src/main/java/com/hedera/services/state/migration/KvPairIterationMigrator.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/migration/KvPairIterationMigrator.java
@@ -53,6 +53,7 @@ public class KvPairIterationMigrator implements InterruptableConsumer<Pair<Contr
 	private final SizeLimitedStorage.IterableStorageUpserter storageUpserter;
 
 	private int numInsertions = 0;
+	private int numSkipped = 0;
 	private VirtualMap<ContractKey, IterableContractValue> iterableContractStorage;
 
 	public KvPairIterationMigrator(
@@ -79,6 +80,7 @@ public class KvPairIterationMigrator implements InterruptableConsumer<Pair<Contr
 		presentContractNums.add(contractNum);
 		final var nonIterableValue = kvPair.getValue();
 		if (ZERO_VALUE.equals(nonIterableValue)) {
+			numSkipped++;
 			return;
 		}
 		numNonZeroKvPairs.merge(contractNum, 1, Integer::sum);
@@ -108,8 +110,11 @@ public class KvPairIterationMigrator implements InterruptableConsumer<Pair<Contr
 			if (rootKey != null) {
 				contract.setFirstUint256StorageKey(rootKey.getKey());
 			}
-			log.debug("Migrated {} k/v pairs from contract {}",
-					contract.getNumContractKvPairs(), contractNum.toIdString());
+			log.info("Migrated {} k/v pairs from contract {}",
+					contract.getNumContractKvPairs(),
+					contractNum.toIdString());
 		});
+
+		log.info("Migration summary: {} k/v pairs migrated. {} skipped.", numInsertions, numSkipped);
 	}
 }

--- a/hedera-node/src/main/java/com/hedera/services/state/migration/KvPairIterationMigrator.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/migration/KvPairIterationMigrator.java
@@ -110,7 +110,7 @@ public class KvPairIterationMigrator implements InterruptableConsumer<Pair<Contr
 			if (rootKey != null) {
 				contract.setFirstUint256StorageKey(rootKey.getKey());
 			}
-			log.info("Migrated {} k/v pairs from contract {}",
+			log.debug("Migrated {} k/v pairs from contract {}",
 					contract.getNumContractKvPairs(),
 					contractNum.toIdString());
 		});


### PR DESCRIPTION
**Description**:
Changing a log line back to debug level because it generated more logging lines than expected.

Related issue: https://github.com/swirlds/swirlds-platform/issues/5473
