### PR TITLE
Fix NFT link management 

### DIFF
--- a/hedera-node/src/main/java/com/hedera/services/exceptions/MissingEntityException.java
+++ b/hedera-node/src/main/java/com/hedera/services/exceptions/MissingEntityException.java
@@ -22,8 +22,8 @@ package com.hedera.services.exceptions;
 
 import static com.hedera.services.utils.EntityIdUtils.readableId;
 
-public class MissingAccountException extends IllegalArgumentException {
-	public MissingAccountException(Object id) {
+public class MissingEntityException extends IllegalArgumentException {
+	public MissingEntityException(final Object id) {
 		super(readableId(id));
 	}
 }

--- a/hedera-node/src/main/java/com/hedera/services/ledger/TransactionalLedger.java
+++ b/hedera-node/src/main/java/com/hedera/services/ledger/TransactionalLedger.java
@@ -21,7 +21,7 @@ package com.hedera.services.ledger;
  */
 
 import com.google.common.annotations.VisibleForTesting;
-import com.hedera.services.exceptions.MissingAccountException;
+import com.hedera.services.exceptions.MissingEntityException;
 import com.hedera.services.ledger.backing.BackingStore;
 import com.hedera.services.ledger.properties.BeanProperty;
 import com.hedera.services.ledger.properties.ChangeSummaryManager;
@@ -575,7 +575,7 @@ public class TransactionalLedger<K, P extends Enum<P> & BeanProperty<A>, A> impl
 
 	private void throwIfMissing(K id) {
 		if (!exists(id)) {
-			throw new MissingAccountException(id);
+			throw new MissingEntityException(id);
 		}
 	}
 

--- a/hedera-node/src/main/java/com/hedera/services/ledger/interceptors/LinkAwareUniqueTokensCommitInterceptor.java
+++ b/hedera-node/src/main/java/com/hedera/services/ledger/interceptors/LinkAwareUniqueTokensCommitInterceptor.java
@@ -27,11 +27,13 @@ import com.hedera.services.state.merkle.MerkleUniqueToken;
 import com.hedera.services.state.submerkle.EntityId;
 import com.hedera.services.store.models.NftId;
 
+import java.util.Objects;
+
 import static com.hedera.services.ledger.properties.NftProperty.OWNER;
 import static com.hedera.services.state.submerkle.EntityId.MISSING_ENTITY_ID;
 
 /**
- * Placeholder for upcoming work.
+ * Manages the "map value linked list" of each account's owned non-treasury NFTs.
  */
 public class LinkAwareUniqueTokensCommitInterceptor implements CommitInterceptor<NftId, MerkleUniqueToken, NftProperty> {
 	private final UniqueTokensLinkManager uniqueTokensLinkManager;
@@ -58,9 +60,11 @@ public class LinkAwareUniqueTokensCommitInterceptor implements CommitInterceptor
 					// Non-treasury-owned NFT wiped (or burned via a multi-stage contract operation)
 					uniqueTokensLinkManager.updateLinks(fromAccount.asNum(), null, entity.getKey());
 				} else if (changes != null && changes.containsKey(OWNER)) {
-					// NFT owner changed (could be a treasury exit or return)
 					final var toAccount = (EntityId) changes.get(OWNER);
-					uniqueTokensLinkManager.updateLinks(fromAccount.asNum(), toAccount.asNum(), entity.getKey());
+					if (!Objects.equals(fromAccount, toAccount)) {
+						// NFT owner changed (could be a treasury exit or return)
+						uniqueTokensLinkManager.updateLinks(fromAccount.asNum(), toAccount.asNum(), entity.getKey());
+					}
 				}
 			} else if (changes != null) {
 				final var newOwner = (EntityId) changes.get(OWNER);

--- a/hedera-node/src/main/java/com/hedera/services/ledger/properties/AccountProperty.java
+++ b/hedera-node/src/main/java/com/hedera/services/ledger/properties/AccountProperty.java
@@ -271,17 +271,6 @@ public enum AccountProperty implements BeanProperty<MerkleAccount> {
 			return MerkleAccount::getNumPositiveBalances;
 		}
 	},
-	HEAD_TOKEN_NUM {
-		@Override
-		public BiConsumer<MerkleAccount, Object> setter() {
-			return (a, t) -> a.setHeadTokenId((long) t);
-		}
-
-		@Override
-		public Function<MerkleAccount, Object> getter() {
-			return MerkleAccount::getHeadTokenId;
-		}
-	},
 	FIRST_CONTRACT_STORAGE_KEY {
 		@Override
 		public BiConsumer<MerkleAccount, Object> setter() {
@@ -315,26 +304,4 @@ public enum AccountProperty implements BeanProperty<MerkleAccount> {
 			return MerkleAccount::getAutoRenewAccount;
 		}
 	},
-	HEAD_NFT_ID {
-		@Override
-		public BiConsumer<MerkleAccount, Object> setter() {
-			return (a, t) -> a.setHeadNftId((long) t);
-		}
-
-		@Override
-		public Function<MerkleAccount, Object> getter() {
-			return MerkleAccount::getHeadNftId;
-		}
-	},
-	HEAD_NFT_SERIAL_NUM {
-		@Override
-		public BiConsumer<MerkleAccount, Object> setter() {
-			return (a, t) -> a.setHeadNftSerialNum((long) t);
-		}
-
-		@Override
-		public Function<MerkleAccount, Object> getter() {
-			return MerkleAccount::getHeadNftSerialNum;
-		}
-	}
 }

--- a/hedera-node/src/main/java/com/hedera/services/ledger/properties/NftProperty.java
+++ b/hedera-node/src/main/java/com/hedera/services/ledger/properties/NftProperty.java
@@ -22,7 +22,6 @@ package com.hedera.services.ledger.properties;
 
 import com.hedera.services.state.merkle.MerkleUniqueToken;
 import com.hedera.services.state.submerkle.EntityId;
-import com.hedera.services.utils.NftNumPair;
 
 import java.util.function.BiConsumer;
 import java.util.function.Function;

--- a/hedera-node/src/main/java/com/hedera/services/ledger/properties/NftProperty.java
+++ b/hedera-node/src/main/java/com/hedera/services/ledger/properties/NftProperty.java
@@ -72,26 +72,4 @@ public enum NftProperty implements BeanProperty<MerkleUniqueToken> {
 			return MerkleUniqueToken::getSpender;
 		}
 	},
-	PREV {
-		@Override
-		public BiConsumer<MerkleUniqueToken, Object> setter() {
-			return (t, o) -> t.setPrev((NftNumPair) o);
-		}
-
-		@Override
-		public Function<MerkleUniqueToken, Object> getter() {
-			return MerkleUniqueToken::getPrev;
-		}
-	},
-	NEXT {
-		@Override
-		public BiConsumer<MerkleUniqueToken, Object> setter() {
-			return (t, o) -> t.setNext((NftNumPair) o);
-		}
-
-		@Override
-		public Function<MerkleUniqueToken, Object> getter() {
-			return MerkleUniqueToken::getNext;
-		}
-	}
 }

--- a/hedera-node/src/main/java/com/hedera/services/store/models/NftId.java
+++ b/hedera-node/src/main/java/com/hedera/services/store/models/NftId.java
@@ -22,10 +22,13 @@ package com.hedera.services.store.models;
 
 import com.hedera.services.utils.EntityNumPair;
 import com.hederahashgraph.api.proto.java.TokenID;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Comparator;
 
 import static com.hedera.services.context.properties.StaticPropertiesHolder.STATIC_PROPERTIES;
 
-public record NftId(long shard, long realm, long num, long serialNo){
+public record NftId(long shard, long realm, long num, long serialNo) implements Comparable<NftId> {
 	public TokenID tokenId() {
 		return TokenID.newBuilder()
 				.setShardNum(shard)
@@ -45,4 +48,14 @@ public record NftId(long shard, long realm, long num, long serialNo){
 	public EntityNumPair asEntityNumPair() {
 		return EntityNumPair.fromLongs(num, serialNo);
 	}
+
+	@Override
+	public int compareTo(final @NotNull NftId that) {
+		return NATURAL_ORDER.compare(this, that);
+	}
+
+	private static final Comparator<NftId> NATURAL_ORDER = Comparator.comparingLong(NftId::num)
+			.thenComparingLong(NftId::serialNo)
+			.thenComparingLong(NftId::shard)
+			.thenComparingLong(NftId::realm);
 }

--- a/hedera-node/src/main/java/com/hedera/services/store/models/NftId.java
+++ b/hedera-node/src/main/java/com/hedera/services/store/models/NftId.java
@@ -29,6 +29,11 @@ import java.util.Comparator;
 import static com.hedera.services.context.properties.StaticPropertiesHolder.STATIC_PROPERTIES;
 
 public record NftId(long shard, long realm, long num, long serialNo) implements Comparable<NftId> {
+	private static final Comparator<NftId> NATURAL_ORDER = Comparator.comparingLong(NftId::num)
+			.thenComparingLong(NftId::serialNo)
+			.thenComparingLong(NftId::shard)
+			.thenComparingLong(NftId::realm);
+	
 	public TokenID tokenId() {
 		return TokenID.newBuilder()
 				.setShardNum(shard)
@@ -53,9 +58,4 @@ public record NftId(long shard, long realm, long num, long serialNo) implements 
 	public int compareTo(final @NotNull NftId that) {
 		return NATURAL_ORDER.compare(this, that);
 	}
-
-	private static final Comparator<NftId> NATURAL_ORDER = Comparator.comparingLong(NftId::num)
-			.thenComparingLong(NftId::serialNo)
-			.thenComparingLong(NftId::shard)
-			.thenComparingLong(NftId::realm);
 }

--- a/hedera-node/src/main/java/com/hedera/services/txns/crypto/ApproveAllowanceLogic.java
+++ b/hedera-node/src/main/java/com/hedera/services/txns/crypto/ApproveAllowanceLogic.java
@@ -35,9 +35,9 @@ import com.hederahashgraph.api.proto.java.NftAllowance;
 import com.hederahashgraph.api.proto.java.TokenAllowance;
 
 import javax.inject.Inject;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.TreeMap;
 
 import static com.hedera.services.txns.crypto.helpers.AllowanceHelpers.fetchOwnerAccount;
 import static com.hedera.services.txns.crypto.helpers.AllowanceHelpers.updateSpender;
@@ -59,8 +59,8 @@ public class ApproveAllowanceLogic {
 		this.accountStore = accountStore;
 		this.tokenStore = tokenStore;
 		this.dynamicProperties = dynamicProperties;
-		this.entitiesChanged = new HashMap<>();
-		this.nftsTouched = new HashMap<>();
+		this.entitiesChanged = new TreeMap<>();
+		this.nftsTouched = new TreeMap<>();
 	}
 
 	public void approveAllowance(

--- a/hedera-node/src/main/java/com/hedera/services/txns/crypto/CryptoDeleteTransitionLogic.java
+++ b/hedera-node/src/main/java/com/hedera/services/txns/crypto/CryptoDeleteTransitionLogic.java
@@ -22,7 +22,7 @@ package com.hedera.services.txns.crypto;
 
 import com.hedera.services.context.TransactionContext;
 import com.hedera.services.exceptions.DeletedAccountException;
-import com.hedera.services.exceptions.MissingAccountException;
+import com.hedera.services.exceptions.MissingEntityException;
 import com.hedera.services.ledger.SigImpactHistorian;
 import com.hedera.services.ledger.HederaLedger;
 import com.hedera.services.txns.TransitionLogic;
@@ -100,7 +100,7 @@ public class CryptoDeleteTransitionLogic implements TransitionLogic {
 			sigImpactHistorian.markEntityChanged(id.getAccountNum());
 
 			txnCtx.setStatus(SUCCESS);
-		} catch (MissingAccountException mae) {
+		} catch (MissingEntityException mae) {
 			txnCtx.setStatus(INVALID_ACCOUNT_ID);
 		} catch (DeletedAccountException dae) {
 			txnCtx.setStatus(ACCOUNT_DELETED);

--- a/hedera-node/src/main/java/com/hedera/services/txns/crypto/CryptoUpdateTransitionLogic.java
+++ b/hedera-node/src/main/java/com/hedera/services/txns/crypto/CryptoUpdateTransitionLogic.java
@@ -23,7 +23,7 @@ package com.hedera.services.txns.crypto;
 import com.hedera.services.context.TransactionContext;
 import com.hedera.services.context.properties.GlobalDynamicProperties;
 import com.hedera.services.exceptions.DeletedAccountException;
-import com.hedera.services.exceptions.MissingAccountException;
+import com.hedera.services.exceptions.MissingEntityException;
 import com.hedera.services.ledger.HederaLedger;
 import com.hedera.services.ledger.SigImpactHistorian;
 import com.hedera.services.ledger.accounts.HederaAccountCustomizer;
@@ -114,7 +114,7 @@ public class CryptoUpdateTransitionLogic implements TransitionLogic {
 			ledger.customize(target, customizer);
 			sigImpactHistorian.markEntityChanged(target.getAccountNum());
 			txnCtx.setStatus(SUCCESS);
-		} catch (MissingAccountException mae) {
+		} catch (MissingEntityException mae) {
 			txnCtx.setStatus(INVALID_ACCOUNT_ID);
 		} catch (DeletedAccountException aide) {
 			txnCtx.setStatus(ACCOUNT_DELETED);

--- a/hedera-node/src/test/java/com/hedera/services/ledger/TransactionalLedgerTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/ledger/TransactionalLedgerTest.java
@@ -22,7 +22,7 @@ package com.hedera.services.ledger;
 
 import com.google.protobuf.ByteString;
 import com.hedera.services.context.SideEffectsTracker;
-import com.hedera.services.exceptions.MissingAccountException;
+import com.hedera.services.exceptions.MissingEntityException;
 import com.hedera.services.ledger.accounts.TestAccount;
 import com.hedera.services.ledger.backing.BackingStore;
 import com.hedera.services.ledger.interceptors.AccountsCommitInterceptor;
@@ -455,7 +455,7 @@ class TransactionalLedgerTest {
 
 		testLedger.begin();
 
-		assertThrows(MissingAccountException.class, () -> testLedger.set(0L, OBJ, things[0]));
+		assertThrows(MissingEntityException.class, () -> testLedger.set(0L, OBJ, things[0]));
 	}
 
 	@Test

--- a/hedera-node/src/test/java/com/hedera/services/ledger/interceptors/LinkAwareUniqueTokensCommitInterceptorTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/ledger/interceptors/LinkAwareUniqueTokensCommitInterceptorTest.java
@@ -33,6 +33,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.Collections;
 import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.Map;
@@ -80,12 +81,28 @@ class LinkAwareUniqueTokensCommitInterceptorTest {
 	void resultsInNoOpForNoOwnershipChanges() {
 		var changes = (EntityChangeSet<NftId, MerkleUniqueToken, NftProperty>) mock(EntityChangeSet.class);
 		var nft = mock(MerkleUniqueToken.class);
-		var change = (HashMap<NftProperty, Object>) mock(HashMap.class);
 
 		given(changes.size()).willReturn(1);
 		given(changes.entity(0)).willReturn(nft);
-		given(changes.changes(0)).willReturn(change);
-		given(change.containsKey(NftProperty.OWNER)).willReturn(false);
+		given(changes.changes(0)).willReturn(Collections.emptyMap());
+
+		subject.preview(changes);
+
+		verifyNoInteractions(uniqueTokensLinkManager);
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	void resultsInNoOpForSameOwnershipChange() {
+		var changes = (EntityChangeSet<NftId, MerkleUniqueToken, NftProperty>) mock(EntityChangeSet.class);
+		var nft = mock(MerkleUniqueToken.class);
+		final long ownerNum = 1111L;
+		final var owner = EntityNum.fromLong(ownerNum);
+
+		given(changes.size()).willReturn(1);
+		given(changes.entity(0)).willReturn(nft);
+		given(changes.changes(0)).willReturn(Map.of(NftProperty.OWNER, owner.toEntityId()));
+		given(nft.getOwner()).willReturn(owner.toEntityId());
 
 		subject.preview(changes);
 

--- a/hedera-node/src/test/java/com/hedera/services/store/models/NftIdTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/store/models/NftIdTest.java
@@ -28,14 +28,27 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 class NftIdTest {
-	private long shard = 1;
-	private long realm = 2;
-	private long num = 3;
-	private long serialNo = 4;
-	private long bShard = 2;
-	private long bRealm = 3;
-	private long bNum = 4;
-	private long bSerialNo = 5;
+	private final long shard = 1;
+	private final long realm = 2;
+	private final long num = 3;
+	private final long serialNo = 4;
+	private final long bShard = 2;
+	private final long bRealm = 3;
+	private final long bNum = 4;
+	private final long bSerialNo = 5;
+
+	@Test
+	void ordersAsExpected() {
+		final var a = new NftId(shard + 1, realm + 1, num, serialNo + 1);
+		final var b = new NftId(shard, realm, num + 1, serialNo);
+		assertEquals(-1, Integer.signum(a.compareTo(b)));
+		final var c = new NftId(shard + 1, realm, num, serialNo + 1);
+		assertEquals(+1, Integer.signum(a.compareTo(c)));
+		final var d = new NftId(shard + 1, realm + 1, num, serialNo);
+		assertEquals(+1, Integer.signum(a.compareTo(d)));
+		final var e = new NftId(shard, realm + 1, num, serialNo + 1);
+		assertEquals(+1, Integer.signum(a.compareTo(e)));
+	}
 
 	@Test
 	void objectContractWorks() {

--- a/hedera-node/src/test/java/com/hedera/services/store/tokens/HederaTokenStoreTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/store/tokens/HederaTokenStoreTest.java
@@ -68,22 +68,17 @@ import java.util.Set;
 import java.util.function.Consumer;
 
 import static com.hedera.services.ledger.backing.BackingTokenRels.asTokenRel;
-import static com.hedera.services.ledger.properties.AccountProperty.HEAD_NFT_ID;
-import static com.hedera.services.ledger.properties.AccountProperty.HEAD_NFT_SERIAL_NUM;
 import static com.hedera.services.ledger.properties.AccountProperty.IS_DELETED;
 import static com.hedera.services.ledger.properties.AccountProperty.MAX_AUTOMATIC_ASSOCIATIONS;
 import static com.hedera.services.ledger.properties.AccountProperty.NUM_ASSOCIATIONS;
 import static com.hedera.services.ledger.properties.AccountProperty.NUM_NFTS_OWNED;
 import static com.hedera.services.ledger.properties.AccountProperty.NUM_POSITIVE_BALANCES;
 import static com.hedera.services.ledger.properties.AccountProperty.USED_AUTOMATIC_ASSOCIATIONS;
-import static com.hedera.services.ledger.properties.NftProperty.NEXT;
 import static com.hedera.services.ledger.properties.NftProperty.OWNER;
-import static com.hedera.services.ledger.properties.NftProperty.PREV;
 import static com.hedera.services.ledger.properties.TokenRelProperty.IS_FROZEN;
 import static com.hedera.services.ledger.properties.TokenRelProperty.IS_KYC_GRANTED;
 import static com.hedera.services.ledger.properties.TokenRelProperty.TOKEN_BALANCE;
 import static com.hedera.services.state.submerkle.EntityId.MISSING_ENTITY_ID;
-import static com.hedera.services.utils.NftNumPair.MISSING_NFT_NUM_PAIR;
 import static com.hedera.test.factories.scenarios.TxnHandlingScenario.COMPLEX_KEY_ACCOUNT_KT;
 import static com.hedera.test.factories.scenarios.TxnHandlingScenario.MISC_ACCOUNT_KT;
 import static com.hedera.test.factories.scenarios.TxnHandlingScenario.TOKEN_ADMIN_KT;
@@ -655,11 +650,6 @@ class HederaTokenStoreTest {
 		given(accountsLedger.get(sponsor, NUM_POSITIVE_BALANCES)).willReturn(numPositiveBalances);
 		given(accountsLedger.get(counterparty, NUM_ASSOCIATIONS)).willReturn(associatedTokensCount);
 		given(accountsLedger.get(counterparty, NUM_POSITIVE_BALANCES)).willReturn(numPositiveBalances);
-		given(accountsLedger.get(sponsor, HEAD_NFT_ID)).willReturn(aNft.num());
-		given(accountsLedger.get(sponsor, HEAD_NFT_SERIAL_NUM)).willReturn(aNft.serialNo());
-		given(accountsLedger.get(counterparty, HEAD_NFT_ID)).willReturn(0L);
-		given(accountsLedger.get(counterparty, HEAD_NFT_SERIAL_NUM)).willReturn(0L);
-		given(nftsLedger.get(aNft, NEXT)).willReturn(MISSING_NFT_NUM_PAIR);
 
 		final var status = subject.changeOwner(aNft, sponsor, counterparty);
 
@@ -698,12 +688,6 @@ class HederaTokenStoreTest {
 		given(accountsLedger.get(sponsor, NUM_POSITIVE_BALANCES)).willReturn(numPositiveBalances);
 		given(accountsLedger.get(counterparty, NUM_ASSOCIATIONS)).willReturn(associatedTokensCount);
 		given(accountsLedger.get(counterparty, NUM_POSITIVE_BALANCES)).willReturn(numPositiveBalances);
-		given(accountsLedger.get(sponsor, HEAD_NFT_ID)).willReturn(1111L);
-		given(accountsLedger.get(sponsor, HEAD_NFT_SERIAL_NUM)).willReturn(111L);
-		given(accountsLedger.get(counterparty, HEAD_NFT_ID)).willReturn(1113L);
-		given(accountsLedger.get(counterparty, HEAD_NFT_SERIAL_NUM)).willReturn(113L);
-		given(nftsLedger.get(aNft, NEXT)).willReturn(NftNumPair.fromLongs(1112, 112));
-		given(nftsLedger.get(aNft, PREV)).willReturn(NftNumPair.fromLongs(1111, 111));
 
 		final var status = subject.changeOwner(aNft, sponsor, counterparty);
 
@@ -737,9 +721,6 @@ class HederaTokenStoreTest {
 		given(accountsLedger.get(primaryTreasury, NUM_POSITIVE_BALANCES)).willReturn(numPositiveBalances);
 		given(accountsLedger.get(counterparty, NUM_ASSOCIATIONS)).willReturn(associatedTokensCount);
 		given(accountsLedger.get(counterparty, NUM_POSITIVE_BALANCES)).willReturn(numPositiveBalances);
-		given(accountsLedger.get(counterparty, HEAD_NFT_ID)).willReturn(tNft.num());
-		given(accountsLedger.get(counterparty, HEAD_NFT_SERIAL_NUM)).willReturn(tNft.serialNo());
-		given(nftsLedger.get(tNft, NEXT)).willReturn(MISSING_NFT_NUM_PAIR);
 
 		final var status = subject.changeOwner(tNft, counterparty, primaryTreasury);
 
@@ -774,8 +755,6 @@ class HederaTokenStoreTest {
 		given(accountsLedger.get(primaryTreasury, NUM_POSITIVE_BALANCES)).willReturn(numPositiveBalances);
 		given(accountsLedger.get(counterparty, NUM_ASSOCIATIONS)).willReturn(associatedTokensCount);
 		given(accountsLedger.get(counterparty, NUM_POSITIVE_BALANCES)).willReturn(numPositiveBalances);
-		given(accountsLedger.get(counterparty, HEAD_NFT_ID)).willReturn(1113L);
-		given(accountsLedger.get(counterparty, HEAD_NFT_SERIAL_NUM)).willReturn(113L);
 
 		final var status = subject.changeOwner(tNft, primaryTreasury, counterparty);
 

--- a/hedera-node/src/test/java/com/hedera/services/txns/crypto/CryptoDeleteTransitionLogicTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/txns/crypto/CryptoDeleteTransitionLogicTest.java
@@ -22,7 +22,7 @@ package com.hedera.services.txns.crypto;
 
 import com.hedera.services.context.TransactionContext;
 import com.hedera.services.exceptions.DeletedAccountException;
-import com.hedera.services.exceptions.MissingAccountException;
+import com.hedera.services.exceptions.MissingEntityException;
 import com.hedera.services.ledger.HederaLedger;
 import com.hedera.services.ledger.SigImpactHistorian;
 import com.hedera.services.utils.accessors.SignedTxnAccessor;
@@ -123,7 +123,7 @@ class CryptoDeleteTransitionLogicTest {
 	@Test
 	void translatesMissingAccount() {
 		givenValidTxnCtx();
-		willThrow(MissingAccountException.class).given(ledger).delete(any(), any());
+		willThrow(MissingEntityException.class).given(ledger).delete(any(), any());
 
 		// when:
 		subject.doStateTransition();

--- a/hedera-node/src/test/java/com/hedera/services/txns/crypto/CryptoUpdateTransitionLogicTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/txns/crypto/CryptoUpdateTransitionLogicTest.java
@@ -26,7 +26,7 @@ import com.google.protobuf.StringValue;
 import com.hedera.services.context.TransactionContext;
 import com.hedera.services.context.properties.GlobalDynamicProperties;
 import com.hedera.services.exceptions.DeletedAccountException;
-import com.hedera.services.exceptions.MissingAccountException;
+import com.hedera.services.exceptions.MissingEntityException;
 import com.hedera.services.ledger.HederaLedger;
 import com.hedera.services.ledger.SigImpactHistorian;
 import com.hedera.services.ledger.accounts.AccountCustomizer;
@@ -366,7 +366,7 @@ class CryptoUpdateTransitionLogicTest {
 	@Test
 	void translatesMissingAccountException() {
 		givenTxnCtx();
-		willThrow(MissingAccountException.class).given(ledger).customize(any(), any());
+		willThrow(MissingEntityException.class).given(ledger).customize(any(), any());
 
 		subject.doStateTransition();
 


### PR DESCRIPTION
**Description**:
 - Removes `NftProperty` values `PREV`, `NEXT`; and `AccountProperty` values `HEAD_TOKEN_NUM`, `HEAD_NFT_ID`, `HEAD_NFT_SERIAL_NUM`---all these properties should be invisible outside the `CommitInterceptor`s that manage them.
 - Future-proofs `ApproveAllowanceLogic` by making the order of approval persistence deterministic. (Doesn't matter with a `MerkleMap`, but could with `VirtualMap`.)
 - Confirms `OWNER` is actually changing before updating links in `LinkAwareUniqueTokensCommitInterceptor`. 
 - Renames `MissingAccountException` -> `MissingEntityException` for better readability.