### PR TITLE
Isolate stake metadata to interceptor

### DIFF
--- a/hedera-node/src/main/java/com/hedera/services/context/primitives/StateView.java
+++ b/hedera-node/src/main/java/com/hedera/services/context/primitives/StateView.java
@@ -510,9 +510,9 @@ public class StateView {
 			stakingInfo.setStakePeriodStart(Timestamp.newBuilder().setSeconds(account.getStakePeriodStart()).build());
 			if (account.mayHavePendingReward()) {
 				final var info = stateChildren.stakingInfo();
-				rewardCalculator.estimatePendingRewards(account,
-						info.get(EntityNum.fromLong(account.getStakedNodeAddressBookId())));
-				stakingInfo.setPendingReward(rewardCalculator.getAccountReward());
+				final var nodeStakingInfo = info.get(EntityNum.fromLong(account.getStakedNodeAddressBookId()));
+				final var pendingReward = rewardCalculator.estimatePendingRewards(account, nodeStakingInfo);
+				stakingInfo.setPendingReward(pendingReward);
 			}
 		}
 

--- a/hedera-node/src/main/java/com/hedera/services/ledger/CommitInterceptor.java
+++ b/hedera-node/src/main/java/com/hedera/services/ledger/CommitInterceptor.java
@@ -22,6 +22,9 @@ package com.hedera.services.ledger;
 
 import com.hedera.services.ledger.properties.BeanProperty;
 
+import javax.annotation.Nullable;
+import java.util.function.Consumer;
+
 /**
  * Defines an observer to change sets being committed to a {@link TransactionalLedger}. Such an observer
  * might collect information for a record or assert validity of the pending changes, for example.
@@ -53,5 +56,17 @@ public interface CommitInterceptor<K, A, P extends Enum<P> & BeanProperty<A>> {
 	 */
 	default boolean completesPendingRemovals() {
 		return false;
+	}
+
+	/**
+	 * Returns a consumer to apply to the mutable version of the entity at the given index before
+	 * it is persisted; or null if there is no finishing work to do for the entity.
+	 *
+	 * @param i the index of the entity to get finishing logic for
+	 * @return the finisher if applicable
+	 */
+	@Nullable
+	default Consumer<A> finisherFor(final int i) {
+		return null;
 	}
 }

--- a/hedera-node/src/main/java/com/hedera/services/ledger/TransactionalLedger.java
+++ b/hedera-node/src/main/java/com/hedera/services/ledger/TransactionalLedger.java
@@ -530,6 +530,10 @@ public class TransactionalLedger<K, P extends Enum<P> & BeanProperty<A>, A> impl
 			final var cachedEntity = pendingChanges.entity(i);
 			final var entity = (cachedEntity == null) ? newEntity.get() : entities.getRef(id);
 			entities.put(id, finalized(id, entity, pendingChanges.changes(i)));
+			final var finisher = commitInterceptor.finisherFor(i);
+			if (finisher != null) {
+				finisher.accept(entity);
+			}
 		}
 		createdKeys.clear();
 		changedKeys.clear();

--- a/hedera-node/src/main/java/com/hedera/services/ledger/accounts/AccountCustomizer.java
+++ b/hedera-node/src/main/java/com/hedera/services/ledger/accounts/AccountCustomizer.java
@@ -43,8 +43,6 @@ import static com.hedera.services.ledger.accounts.AccountCustomizer.Option.MAX_A
 import static com.hedera.services.ledger.accounts.AccountCustomizer.Option.MEMO;
 import static com.hedera.services.ledger.accounts.AccountCustomizer.Option.PROXY;
 import static com.hedera.services.ledger.accounts.AccountCustomizer.Option.STAKED_ID;
-import static com.hedera.services.ledger.accounts.AccountCustomizer.Option.STAKED_TO_ME;
-import static com.hedera.services.ledger.accounts.AccountCustomizer.Option.STAKE_PERIOD_START;
 import static com.hedera.services.ledger.accounts.AccountCustomizer.Option.USED_AUTOMATIC_ASSOCIATIONS;
 import static java.util.Collections.unmodifiableMap;
 
@@ -80,8 +78,6 @@ public abstract class AccountCustomizer<
 		ALIAS,
 		AUTO_RENEW_ACCOUNT_ID,
 		DECLINE_REWARD,
-		STAKED_TO_ME,
-		STAKE_PERIOD_START,
 		STAKED_ID
 	}
 
@@ -189,16 +185,6 @@ public abstract class AccountCustomizer<
 
 	public T stakedId(final long option) {
 		changeManager.update(changes, optionProperties.get(STAKED_ID), option);
-		return self();
-	}
-
-	public T stakePeriodStart(final long option) {
-		changeManager.update(changes, optionProperties.get(STAKE_PERIOD_START), option);
-		return self();
-	}
-
-	public T stakedToMe(final long option) {
-		changeManager.update(changes, optionProperties.get(STAKED_TO_ME), option);
 		return self();
 	}
 }

--- a/hedera-node/src/main/java/com/hedera/services/ledger/accounts/HederaAccountCustomizer.java
+++ b/hedera-node/src/main/java/com/hedera/services/ledger/accounts/HederaAccountCustomizer.java
@@ -37,7 +37,7 @@ import static com.hedera.services.context.properties.StaticPropertiesHolder.STAT
 public final class HederaAccountCustomizer extends
 		AccountCustomizer<AccountID, MerkleAccount, AccountProperty, HederaAccountCustomizer> {
 	private static final Map<Option, AccountProperty> OPTION_PROPERTIES;
-	public static final String STAKED_ID_NOT_SET_CASE = "STAKEDID_NOT_SET";
+	public static final String STAKED_ID_NOT_SET_CASE = "STAKED_ID_NOT_SET";
 	public static final String STAKED_ACCOUNT_ID_CASE = "STAKED_ACCOUNT_ID";
 	public static final String STAKED_NODE_ID_CASE = "STAKED_NODE_ID";
 
@@ -56,8 +56,6 @@ public final class HederaAccountCustomizer extends
 		optionAccountPropertyMap.put(Option.ALIAS, AccountProperty.ALIAS);
 		optionAccountPropertyMap.put(Option.AUTO_RENEW_ACCOUNT_ID, AccountProperty.AUTO_RENEW_ACCOUNT_ID);
 		optionAccountPropertyMap.put(Option.DECLINE_REWARD, AccountProperty.DECLINE_REWARD);
-		optionAccountPropertyMap.put(Option.STAKED_TO_ME, AccountProperty.STAKED_TO_ME);
-		optionAccountPropertyMap.put(Option.STAKE_PERIOD_START, AccountProperty.STAKE_PERIOD_START);
 		optionAccountPropertyMap.put(Option.STAKED_ID, AccountProperty.STAKED_ID);
 		OPTION_PROPERTIES = Collections.unmodifiableMap(optionAccountPropertyMap);
 	}
@@ -106,7 +104,8 @@ public final class HederaAccountCustomizer extends
 	public void customizeStakedId(
 			final String idCase,
 			final AccountID stakedAccountId,
-			final long stakedNodeId) {
+			final long stakedNodeId
+	) {
 		final var stakedId = getStakedId(idCase, stakedAccountId, stakedNodeId);
 		this.stakedId(stakedId);
 	}

--- a/hedera-node/src/main/java/com/hedera/services/ledger/accounts/HederaAccountCustomizer.java
+++ b/hedera-node/src/main/java/com/hedera/services/ledger/accounts/HederaAccountCustomizer.java
@@ -37,7 +37,7 @@ import static com.hedera.services.context.properties.StaticPropertiesHolder.STAT
 public final class HederaAccountCustomizer extends
 		AccountCustomizer<AccountID, MerkleAccount, AccountProperty, HederaAccountCustomizer> {
 	private static final Map<Option, AccountProperty> OPTION_PROPERTIES;
-	public static final String STAKED_ID_NOT_SET_CASE = "STAKED_ID_NOT_SET";
+	public static final String STAKED_ID_NOT_SET_CASE = "STAKEDID_NOT_SET";
 	public static final String STAKED_ACCOUNT_ID_CASE = "STAKED_ACCOUNT_ID";
 	public static final String STAKED_NODE_ID_CASE = "STAKED_NODE_ID";
 

--- a/hedera-node/src/main/java/com/hedera/services/ledger/accounts/staking/RewardCalculator.java
+++ b/hedera-node/src/main/java/com/hedera/services/ledger/accounts/staking/RewardCalculator.java
@@ -31,95 +31,71 @@ import java.util.Map;
 
 import static com.hedera.services.ledger.accounts.staking.StakingUtils.finalBalanceGiven;
 import static com.hedera.services.ledger.properties.AccountProperty.BALANCE;
-import static com.hedera.services.ledger.properties.AccountProperty.STAKE_PERIOD_START;
 import static com.hedera.services.utils.Units.HBARS_TO_TINYBARS;
+
 @Singleton
 public class RewardCalculator {
-	private final StakePeriodManager stakePeriodManager;
 	private final StakeInfoManager stakeInfoManager;
+	private final StakePeriodManager stakePeriodManager;
 
 	private long rewardsPaid;
-	private long accountReward;
-	private long accountUpdatedStakePeriodStart;
 
 	@Inject
-	public RewardCalculator(final StakePeriodManager stakePeriodManager,
-			final StakeInfoManager stakeInfoManager) {
+	public RewardCalculator(final StakePeriodManager stakePeriodManager, final StakeInfoManager stakeInfoManager) {
 		this.stakePeriodManager = stakePeriodManager;
 		this.stakeInfoManager = stakeInfoManager;
 	}
 
-	public void updateRewardChanges(final MerkleAccount account, final Map<AccountProperty, Object> changes) {
-		computePendingRewards(account);
-
-		if (accountReward > 0) {
-			final var balance = finalBalanceGiven(account, changes);
-			changes.put(BALANCE, balance + accountReward);
-		}
-
-		changes.put(STAKE_PERIOD_START, accountUpdatedStakePeriodStart);
-		rewardsPaid += accountReward; // used for adding balance change for 0.0.800 [stakingRewardAccount]
-	}
-
-	public long estimatePendingRewards(final MerkleAccount account, final MerkleStakingInfo stakingNode) {
-		return computeRewardFromDetails(
-				account,
-				stakingNode,
-				stakePeriodManager.currentStakePeriod(),
-				stakePeriodManager.effectivePeriod(account.getStakePeriodStart()));
-	}
-
-	private final void computePendingRewards(final MerkleAccount account) {
-		final var currentPeriod = stakePeriodManager.currentStakePeriod();
-
-		// Staking rewards only accumulate for a finite # of periods (currently 365 days), so get the effective start
-		var effectiveStart = stakePeriodManager.effectivePeriod(account.getStakePeriodStart());
-
-		// Check if effectiveStart is within the range for receiving rewards
-		if (stakePeriodManager.isRewardable(effectiveStart)) {
-			final long stakedNode = account.getStakedNodeAddressBookId();
-			final var stakedNodeAccount = stakeInfoManager.mutableStakeInfoFor(stakedNode);
-
-			this.accountReward = computeRewardFromDetails(account, stakedNodeAccount, currentPeriod, effectiveStart);
-			// After we've got our rewards till the last full period, it becomes our effective start
-			effectiveStart = currentPeriod - 1;
-		} else {
-			this.accountReward = 0;
-		}
-
-		this.accountUpdatedStakePeriodStart = effectiveStart;
-	}
-
-	private long computeRewardFromDetails(
-			final MerkleAccount account,
-			final MerkleStakingInfo stakedNodeAccount,
-			final long currentStakePeriod,
-			final long effectiveStart) {
-		final var rewardSumHistory = stakedNodeAccount.getRewardSumHistory();
-
-		// stakedNode.rewardSumHistory[0] is the reward for all days up to and including the full day
-		// currentStakePeriod - 1, since today is not finished yet.
-		return account.isDeclinedReward() ? 0 :
-				(account.getBalance() / HBARS_TO_TINYBARS) * (rewardSumHistory[0] - rewardSumHistory[(int) (currentStakePeriod - 1 - (effectiveStart - 1))]);
-	}
-
 	public void reset() {
 		rewardsPaid = 0;
-		accountReward = 0;
-		accountUpdatedStakePeriodStart = 0;
+	}
+
+	public long computeAndApplyReward(final MerkleAccount account, final Map<AccountProperty, Object> changes) {
+		final var reward = computePendingRewards(account);
+		if (reward > 0) {
+			final var balance = finalBalanceGiven(account, changes);
+			changes.put(BALANCE, balance + reward);
+		}
+		rewardsPaid += reward;
+		return reward;
 	}
 
 	public long rewardsPaidInThisTxn() {
 		return rewardsPaid;
 	}
 
-	public long getAccountReward() {
-		return accountReward;
+	public long estimatePendingRewards(final MerkleAccount account, final MerkleStakingInfo nodeStakingInfo) {
+		return computeRewardFromDetails(
+				account,
+				nodeStakingInfo,
+				stakePeriodManager.estimatedCurrentStakePeriod(),
+				stakePeriodManager.effectivePeriod(account.getStakePeriodStart()));
 	}
 
-	@VisibleForTesting
-	public long getAccountUpdatedStakePeriodStart() {
-		return accountUpdatedStakePeriodStart;
+	private long computePendingRewards(final MerkleAccount account) {
+		return computeRewardFromDetails(
+				account,
+				stakeInfoManager.mutableStakeInfoFor(account.getStakedNodeAddressBookId()),
+				stakePeriodManager.currentStakePeriod(),
+				stakePeriodManager.effectivePeriod(account.getStakePeriodStart()));
+	}
+
+	private long computeRewardFromDetails(
+			final MerkleAccount account,
+			final MerkleStakingInfo nodeStakingInfo,
+			final long currentStakePeriod,
+			final long effectiveStart
+	) {
+		if (!stakePeriodManager.isRewardable(effectiveStart)) {
+			return 0L;
+		}
+		final var rewardSumHistory = nodeStakingInfo.getRewardSumHistory();
+
+		// stakedNode.rewardSumHistory[0] is the reward for all periods up to and including the full staking period
+		// (currentStakePeriod - 1); since this period is not finished yet, we do not know how to reward for it
+		return account.isDeclinedReward() ? 0 :
+				(account.getBalance() / HBARS_TO_TINYBARS)
+						* (rewardSumHistory[0] - rewardSumHistory[(int) (currentStakePeriod - 1 - (effectiveStart - 1))]);
 	}
 
 	@VisibleForTesting

--- a/hedera-node/src/main/java/com/hedera/services/ledger/accounts/staking/StakeChangeManager.java
+++ b/hedera-node/src/main/java/com/hedera/services/ledger/accounts/staking/StakeChangeManager.java
@@ -40,8 +40,10 @@ public class StakeChangeManager {
 	private final Supplier<MerkleMap<EntityNum, MerkleAccount>> accounts;
 
 	@Inject
-	public StakeChangeManager(final StakeInfoManager stakeInfoManager,
-			final Supplier<MerkleMap<EntityNum, MerkleAccount>> accounts) {
+	public StakeChangeManager(
+			final StakeInfoManager stakeInfoManager,
+			final Supplier<MerkleMap<EntityNum, MerkleAccount>> accounts
+	) {
 		this.stakeInfoManager = stakeInfoManager;
 		this.accounts = accounts;
 	}
@@ -56,7 +58,7 @@ public class StakeChangeManager {
 		node.addRewardStake(amount, declinedReward);
 	}
 
-	public void setStakePeriodStart(final long todayNumber) {
+	public void initializeAllStakingStartsTo(final long todayNumber) {
 		final var mutableAccounts = accounts.get();
 		for (var key : mutableAccounts.keySet()) {
 			final var account = mutableAccounts.getForModify(key);
@@ -79,7 +81,7 @@ public class StakeChangeManager {
 		// This account wasn't in the current change set
 		pendingChanges.include(
 				STATIC_PROPERTIES.scopedAccountWith(accountNum),
-				accounts.get().getForModify(EntityNum.fromLong(accountNum)),
+				accounts.get().get(EntityNum.fromLong(accountNum)),
 				new EnumMap<>(AccountProperty.class));
 		return n;
 	}

--- a/hedera-node/src/main/java/com/hedera/services/ledger/accounts/staking/StakePeriodManager.java
+++ b/hedera-node/src/main/java/com/hedera/services/ledger/accounts/staking/StakePeriodManager.java
@@ -23,12 +23,15 @@ package com.hedera.services.ledger.accounts.staking;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.hedera.services.context.TransactionContext;
+import com.hedera.services.state.merkle.MerkleAccount;
 import com.hedera.services.state.merkle.MerkleNetworkContext;
 
+import javax.annotation.Nullable;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import java.time.LocalDate;
 import java.time.ZoneId;
+import java.util.function.Consumer;
 import java.util.function.Supplier;
 
 @Singleton
@@ -41,15 +44,35 @@ public class StakePeriodManager {
 	public static final ZoneId zoneUTC = ZoneId.of("UTC");
 
 	@Inject
-	public StakePeriodManager(final TransactionContext txnCtx,
-			final Supplier<MerkleNetworkContext> networkCtx) {
+	public StakePeriodManager(final TransactionContext txnCtx, final Supplier<MerkleNetworkContext> networkCtx) {
 		this.txnCtx = txnCtx;
 		this.networkCtx = networkCtx;
 	}
 
+	@Nullable
+	public Consumer<MerkleAccount> finisherFor(
+			final long curStakedId,
+			final long newStakedId,
+			final long stakedToMeUpdate,
+			final boolean rewarded
+	) {
+		final long stakePeriodStartUpdate = stakePeriodStartUpdateFor(curStakedId, newStakedId, rewarded);
+		if (stakedToMeUpdate == -1 && stakePeriodStartUpdate == -1) {
+			return null;
+		} else {
+			return account -> {
+				if (stakePeriodStartUpdate != -1) {
+					account.setStakePeriodStart(stakePeriodStartUpdate);
+				}
+				if (stakedToMeUpdate != -1) {
+					account.setStakedToMe(stakedToMeUpdate);
+				}
+			};
+		}
+	}
+
 	public long currentStakePeriod() {
 		final var currentConsensusSecs = txnCtx.consensusTime().getEpochSecond();
-
 		if (prevConsensusSecs != currentConsensusSecs) {
 			prevConsensusSecs = currentConsensusSecs;
 			currentStakePeriod = LocalDate.ofInstant(txnCtx.consensusTime(), zoneUTC).toEpochDay();
@@ -57,9 +80,14 @@ public class StakePeriodManager {
 		return currentStakePeriod;
 	}
 
+	public long estimatedCurrentStakePeriod() {
+		return currentStakePeriod;
+	}
+
 	public long firstNonRewardableStakePeriod() {
-		// The latest period by which an account must have started staking, if it can be eligible for a
-		// reward; if staking is not active, this will return Long.MIN_VALUE so no account is eligible
+		// The earliest period by which an account can have started staking, _without_ becoming
+		// eligible for a reward; if staking is not active, this will return Long.MIN_VALUE so
+		// no account can ever be eligible
 		return networkCtx.get().areRewardsActivated() ? currentStakePeriod() - 1 : Long.MIN_VALUE;
 	}
 
@@ -68,8 +96,8 @@ public class StakePeriodManager {
 		// if stakePeriodStart = -1 then it is not staked or staked to an account
 		// If it equals currentStakePeriod, that means the staking changed today (later than the start of today),
 		// so it had no effect on consensus weights today, and should never be rewarded for helping consensus
-		// throughout today.  If it equals currentStakePeriod-1, that means it either started yesterday or has already been
-		// rewarded for yesterday. Either way, it might be rewarded for today after today ends, but shouldn't yet be
+		// throughout today.  If it equals currentStakePeriod-1, that means it either started yesterday or has already
+		// been rewarded for yesterday. Either way, it might be rewarded for today after today ends, but shouldn't yet be
 		// rewarded for today, because today hasn't finished yet.
 		return stakePeriodStart > -1 && stakePeriodStart < firstNonRewardableStakePeriod();
 	}
@@ -82,8 +110,28 @@ public class StakePeriodManager {
 		return stakePeriodStart;
 	}
 
+	private long stakePeriodStartUpdateFor(
+			final long curStakedId,
+			final long newStakedId,
+			final boolean rewarded
+	) {
+		// There's no reason to update stakedPeriodStart for an account not staking to
+		// a node; the value will never be used, since it cannot be eligible for a reward
+		if (newStakedId < 0) {
+			if (curStakedId >= 0) {
+				// We just started staking to a node
+				return currentStakePeriod();
+			} else {
+				// If we were just rewarded, stake period start is yesterday; otherwise, unchanged
+				return !rewarded ? -1 : currentStakePeriod() - 1;
+			}
+		} else {
+			return -1;
+		}
+	}
+
 	@VisibleForTesting
-	public long getPrevConsensusSecs() {
+	long getPrevConsensusSecs() {
 		return prevConsensusSecs;
 	}
 }

--- a/hedera-node/src/main/java/com/hedera/services/ledger/interceptors/StakeAwareAccountsCommitsInterceptor.java
+++ b/hedera-node/src/main/java/com/hedera/services/ledger/interceptors/StakeAwareAccountsCommitsInterceptor.java
@@ -40,6 +40,7 @@ import org.jetbrains.annotations.NotNull;
 import javax.annotation.Nullable;
 import java.util.Arrays;
 import java.util.Map;
+import java.util.function.Consumer;
 import java.util.function.Supplier;
 
 import static com.hedera.services.ledger.accounts.staking.StakingUtils.finalBalanceGiven;
@@ -49,12 +50,11 @@ import static com.hedera.services.ledger.accounts.staking.StakingUtils.hasStakeF
 import static com.hedera.services.ledger.accounts.staking.StakingUtils.updateBalance;
 import static com.hedera.services.ledger.accounts.staking.StakingUtils.updateStakedToMe;
 import static com.hedera.services.ledger.interceptors.StakeChangeScenario.FROM_ACCOUNT_TO_ACCOUNT;
-import static com.hedera.services.ledger.properties.AccountProperty.DECLINE_REWARD;
 import static com.hedera.services.ledger.properties.AccountProperty.STAKED_ID;
 
 public class StakeAwareAccountsCommitsInterceptor extends AccountsCommitInterceptor {
+	private static final int INITIAL_CHANGE_CAPACITY = 32;
 	private static final Logger log = LogManager.getLogger(StakeAwareAccountsCommitsInterceptor.class);
-	private static final int UNREALISTIC_NUM_CHANGES = 64;
 
 	private final StakeChangeManager stakeChangeManager;
 	private final Supplier<MerkleNetworkContext> networkCtx;
@@ -65,14 +65,22 @@ public class StakeAwareAccountsCommitsInterceptor extends AccountsCommitIntercep
 	private final StakeInfoManager stakeInfoManager;
 	private final AccountNumbers accountNumbers;
 
-	// The current and new staked id's of the change being previewed
+	// The current and new staked ids of the account being processed
 	private long curStakedId;
 	private long newStakedId;
+	// If staking is not activated, the new balance of 0.0.800 after the changes
 	private long newFundingBalance;
+	// Whether rewards are no active
 	private boolean rewardsActivated;
-	// Tracks if the account has been rewarded already with one of the pending changes
-	private boolean[] hasBeenRewarded = new boolean[UNREALISTIC_NUM_CHANGES];
-	private StakeChangeScenario[] stakeChangeScenarios = new StakeChangeScenario[UNREALISTIC_NUM_CHANGES];
+	// The new stakedToMe values of accounts in the change set
+	private long[] stakedToMeUpdates = new long[INITIAL_CHANGE_CAPACITY];
+	// Whether each account in the change set has been rewarded yet
+	private boolean[] hasBeenRewarded = new boolean[INITIAL_CHANGE_CAPACITY];
+	// The stake change scenario for each account in the change set
+	private StakeChangeScenario[] stakeChangeScenarios = new StakeChangeScenario[INITIAL_CHANGE_CAPACITY];
+	// Function objects to be used by the ledger to apply final staking changes to a mutable account
+	@SuppressWarnings("unchecked")
+	private Consumer<MerkleAccount>[] finishers = (Consumer<MerkleAccount>[]) new Consumer[INITIAL_CHANGE_CAPACITY];
 
 	public StakeAwareAccountsCommitsInterceptor(
 			final SideEffectsTracker sideEffectsTracker,
@@ -85,14 +93,14 @@ public class StakeAwareAccountsCommitsInterceptor extends AccountsCommitIntercep
 			final AccountNumbers accountNumbers
 	) {
 		super(sideEffectsTracker);
-		this.stakeChangeManager = stakeChangeManager;
 		this.networkCtx = networkCtx;
+		this.accountNumbers = accountNumbers;
+		this.stakeInfoManager = stakeInfoManager;
 		this.rewardCalculator = rewardCalculator;
-		this.sideEffectsTracker = sideEffectsTracker;
 		this.dynamicProperties = dynamicProperties;
 		this.stakePeriodManager = stakePeriodManager;
-		this.stakeInfoManager = stakeInfoManager;
-		this.accountNumbers = accountNumbers;
+		this.stakeChangeManager = stakeChangeManager;
+		this.sideEffectsTracker = sideEffectsTracker;
 	}
 
 	@Override
@@ -105,19 +113,21 @@ public class StakeAwareAccountsCommitsInterceptor extends AccountsCommitIntercep
 
 		// Once rewards are activated, they remain activated
 		rewardsActivated = rewardsActivated || networkCtx.get().areRewardsActivated();
-		// Initialize funding reward balance (will only be updated and consulted if rewards are not active)
+		// Will only be updated and consulted if rewards are not active
 		newFundingBalance = -1;
 
 		// Iterates through the change set, maintaining two invariants:
-		//   1. At the beginning of iteration i, any account in the [0, i) range that is reward-able due to
-		//      change in balance, stakedAccountId, stakedNodeId, declineRewards fields; _has_ been rewarded.
+		//   1. At the beginning of iteration i, any account in the [0, i) range that was reward-able due to
+		//      a change in balance, stakedAccountId, stakedNodeId, or declineRewards fields has been rewarded.
+		//      (IMPORTANT: this reward could be zero if the effective declineRewards is true.)
 		//   2. Any account whose stakedToMe balance was affected by one or more changes in the [0, i) range
-		//      has been, if not already present, added to the pendingChanges; and its changes reflect all
-		//      these stakedToMe change
-		updateAccountStakes(pendingChanges);
-		// Iterates through the change set to update node stakes; requires a separate loop so all stakedToMe are final
-		updateNodeStakes(pendingChanges);
-		finalizeRewardBalanceChange(pendingChanges);
+		//      has been, if not already present, added to the pendingChanges; and its updated stakedToMe is
+		//      reflected in stakedToMeUpdates.
+		updateRewardsAndElections(pendingChanges);
+		// Updates node stakes and constructs any finishers the ledger will use to set stakedToMe and
+		// stakePeriodStart fields on the mutable account instances
+		finalizeStakeMetadata(pendingChanges);
+		finalizeRewardBalance(pendingChanges);
 
 		super.preview(pendingChanges);
 
@@ -126,7 +136,14 @@ public class StakeAwareAccountsCommitsInterceptor extends AccountsCommitIntercep
 		}
 	}
 
-	private void updateAccountStakes(final EntityChangeSet<AccountID, MerkleAccount, AccountProperty> pendingChanges) {
+	@Override
+	public Consumer<MerkleAccount> finisherFor(int i) {
+		return finishers[i];
+	}
+
+	private void updateRewardsAndElections(
+			final EntityChangeSet<AccountID, MerkleAccount, AccountProperty> pendingChanges
+	) {
 		final var origN = pendingChanges.size();
 		// We re-compute pendingChanges.size() in the for condition b/c stakeToMe side effects can increase it
 		for (int i = 0; i < pendingChanges.size(); i++) {
@@ -134,7 +151,7 @@ public class StakeAwareAccountsCommitsInterceptor extends AccountsCommitIntercep
 			final var changes = pendingChanges.changes(i);
 			stakeChangeScenarios[i] = scenarioFor(account, changes);
 
-			if (!hasBeenRewarded[i] && isRewardable(account, changes)) {
+			if (!hasBeenRewarded[i] && isRewardSituation(account, stakedToMeUpdates[i], changes)) {
 				payReward(i, account, changes);
 			}
 			// If we are outside the original change set, this is a stakee account; and its stakedId cannot
@@ -157,20 +174,19 @@ public class StakeAwareAccountsCommitsInterceptor extends AccountsCommitIntercep
 		return StakeChangeScenario.forCase(curStakedId, newStakedId);
 	}
 
-	private void finalizeRewardBalanceChange(
+	private void finalizeRewardBalance(
 			final EntityChangeSet<AccountID, MerkleAccount, AccountProperty> pendingChanges
 	) {
 		final var rewardsPaid = rewardCalculator.rewardsPaidInThisTxn();
 		if (rewardsPaid > 0) {
-			final var rewardAccountI = stakeChangeManager.findOrAdd(
-					accountNumbers.stakingRewardAccount(), pendingChanges);
-			updateBalance(-rewardsPaid, rewardAccountI, pendingChanges);
+			final var fundingI = stakeChangeManager.findOrAdd(accountNumbers.stakingRewardAccount(), pendingChanges);
+			updateBalance(-rewardsPaid, fundingI, pendingChanges);
 			// No need to update newFundingBalance because if rewardsPaid > 0, rewards
 			// are already activated, and we don't need to consult newFundingBalance
 		}
 	}
 
-	private void updateNodeStakes(final EntityChangeSet<AccountID, MerkleAccount, AccountProperty> pendingChanges) {
+	private void finalizeStakeMetadata(final EntityChangeSet<AccountID, MerkleAccount, AccountProperty> pendingChanges) {
 		for (int i = 0, n = pendingChanges.size(); i < n; i++) {
 			final var scenario = stakeChangeScenarios[i];
 			final var account = pendingChanges.entity(i);
@@ -187,9 +203,12 @@ public class StakeAwareAccountsCommitsInterceptor extends AccountsCommitIntercep
 			if (scenario.awardsToNode()) {
 				stakeChangeManager.awardStake(
 						-newStakedId - 1,
-						finalBalanceGiven(account, changes) + finalStakedToMeGiven(account, changes),
+						finalBalanceGiven(account, changes) + finalStakedToMeGiven(i, account, stakedToMeUpdates),
 						finalDeclineRewardGiven(account, changes));
 			}
+			// This will be null if the stake period manager determines there is no metadata to set
+			finishers[i] = stakePeriodManager.finisherFor(
+					curStakedId, newStakedId, stakedToMeUpdates[i], hasBeenRewarded[i]);
 		}
 	}
 
@@ -221,7 +240,7 @@ public class StakeAwareAccountsCommitsInterceptor extends AccountsCommitIntercep
 	) {
 		if (delta != 0) {
 			final var stakeeI = stakeChangeManager.findOrAdd(accountNum, pendingChanges);
-			updateStakedToMe(stakeeI, delta, pendingChanges);
+			updateStakedToMe(stakeeI, delta, stakedToMeUpdates, pendingChanges);
 			if (!hasBeenRewarded[stakeeI]) {
 				// If this stakee has already been previewed, and wasn't rewarded, we should
 				// re-check if this stakedToMe change has now made it eligible for a reward
@@ -236,7 +255,7 @@ public class StakeAwareAccountsCommitsInterceptor extends AccountsCommitIntercep
 	) {
 		final var account = pendingChanges.entity(stakeeI);
 		final var changes = pendingChanges.changes(stakeeI);
-		if (isRewardable(account, changes)) {
+		if (isRewardSituation(account, stakedToMeUpdates[stakeeI], changes)) {
 			payReward(stakeeI, account, changes);
 		}
 	}
@@ -246,30 +265,33 @@ public class StakeAwareAccountsCommitsInterceptor extends AccountsCommitIntercep
 			@NotNull final MerkleAccount account,
 			@NotNull final Map<AccountProperty, Object> changes
 	) {
-		rewardCalculator.updateRewardChanges(account, changes);
-		final var reward = rewardCalculator.getAccountReward();
+		final var reward = rewardCalculator.computeAndApplyReward(account, changes);
 		sideEffectsTracker.trackRewardPayment(account.number(), reward);
 		hasBeenRewarded[accountI] = true;
 	}
 
 	/**
-	 * Checks if the account is eligible for rewards.
+	 * Checks if this is a <i>reward situation</i>, in the terminology of HIP-406; please see
+	 * <a href="URL#value">https://hips.hedera.com/hip/hip-406</a> for details.
 	 *
 	 * @param account
-	 * 		account that is being checked
+	 * 		the account being checked
+	 * @param stakedToMeUpdate
+	 * 		its new stakedToMe field, or -1 if unchanged
 	 * @param changes
-	 * 		account property changes
-	 * @return true if rewardable, false otherwise
+	 * 		all pending user-controlled property changes
+	 * @return true if this is a reward situation, false otherwise
 	 */
 	@VisibleForTesting
-	boolean isRewardable(
+	boolean isRewardSituation(
 			@Nullable final MerkleAccount account,
+			final long stakedToMeUpdate,
 			@NotNull final Map<AccountProperty, Object> changes
 	) {
 		return account != null
 				&& rewardsActivated
 				&& account.getStakedId() < 0
-				&& hasStakeFieldChanges(changes)
+				&& (stakedToMeUpdate != -1 || hasStakeFieldChanges(changes))
 				&& stakePeriodManager.isRewardable(account.getStakePeriodStart());
 	}
 
@@ -281,18 +303,24 @@ public class StakeAwareAccountsCommitsInterceptor extends AccountsCommitIntercep
 
 		networkCtx.get().setStakingRewardsActivated(true);
 		stakeInfoManager.clearRewardsHistory();
-		stakeChangeManager.setStakePeriodStart(todayNumber);
+		stakeChangeManager.initializeAllStakingStartsTo(todayNumber);
 		log.info("Staking rewards is activated and rewardSumHistory is cleared");
 	}
 
+	@SuppressWarnings("unchecked")
 	private void prepareAuxiliaryArraysFor(final int n) {
 		// Each pending change could potentially affect stakedToMe of two accounts not yet included in the
 		// change set; and if rewards were paid without 0.0.800 in the change set, it will be included too
-		if (hasBeenRewarded.length < 3 * n + 1) {
-			hasBeenRewarded = new boolean[3 * n + 1];
-			stakeChangeScenarios = new StakeChangeScenario[3 * n + 1];
+		final var maxImpliedChanges = 3 * n + 1;
+		if (hasBeenRewarded.length < maxImpliedChanges) {
+			hasBeenRewarded = new boolean[maxImpliedChanges];
+			stakedToMeUpdates = new long[maxImpliedChanges];
+			stakeChangeScenarios = new StakeChangeScenario[maxImpliedChanges];
+			finishers = (Consumer<MerkleAccount>[]) new Consumer[maxImpliedChanges];
 		}
+		Arrays.fill(stakedToMeUpdates, -1);
 		Arrays.fill(hasBeenRewarded, false);
+		Arrays.fill(finishers, null);
 	}
 
 	private void setCurrentAndNewIds(
@@ -312,6 +340,11 @@ public class StakeAwareAccountsCommitsInterceptor extends AccountsCommitIntercep
 	@VisibleForTesting
 	boolean[] getHasBeenRewarded() {
 		return hasBeenRewarded;
+	}
+
+	@VisibleForTesting
+	long[] getStakedToMeUpdates() {
+		return stakedToMeUpdates;
 	}
 
 	@VisibleForTesting

--- a/hedera-node/src/main/java/com/hedera/services/ledger/properties/AccountProperty.java
+++ b/hedera-node/src/main/java/com/hedera/services/ledger/properties/AccountProperty.java
@@ -337,28 +337,6 @@ public enum AccountProperty implements BeanProperty<MerkleAccount> {
 			return MerkleAccount::isDeclinedReward;
 		}
 	},
-	STAKED_TO_ME {
-		@Override
-		public BiConsumer<MerkleAccount, Object> setter() {
-			return (a, t) -> a.setStakedToMe((long) t);
-		}
-
-		@Override
-		public Function<MerkleAccount, Object> getter() {
-			return MerkleAccount::getStakedToMe;
-		}
-	},
-	STAKE_PERIOD_START {
-		@Override
-		public BiConsumer<MerkleAccount, Object> setter() {
-			return (a, t) -> a.setStakePeriodStart((long) t);
-		}
-
-		@Override
-		public Function<MerkleAccount, Object> getter() {
-			return MerkleAccount::getStakePeriodStart;
-		}
-	},
 	STAKED_ID {
 		@Override
 		public BiConsumer<MerkleAccount, Object> setter() {

--- a/hedera-node/src/main/java/com/hedera/services/state/merkle/MerkleAccount.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/merkle/MerkleAccount.java
@@ -482,7 +482,7 @@ public class MerkleAccount extends AbstractNaryMerkleInternal implements MerkleI
 		return state().getStakePeriodStart();
 	}
 
-	public void setStakePeriodStart(long stakePeriodStart) {
+	public void setStakePeriodStart(final long stakePeriodStart) {
 		throwIfImmutable("Cannot change this account's stakePeriodStart if it's immutable");
 		state().setStakePeriodStart(stakePeriodStart);
 	}

--- a/hedera-node/src/test/java/com/hedera/services/ledger/accounts/AccountCustomizerTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/ledger/accounts/AccountCustomizerTest.java
@@ -41,8 +41,6 @@ import static com.hedera.services.ledger.accounts.AccountCustomizer.Option.MAX_A
 import static com.hedera.services.ledger.accounts.AccountCustomizer.Option.MEMO;
 import static com.hedera.services.ledger.accounts.AccountCustomizer.Option.PROXY;
 import static com.hedera.services.ledger.accounts.AccountCustomizer.Option.STAKED_ID;
-import static com.hedera.services.ledger.accounts.AccountCustomizer.Option.STAKED_TO_ME;
-import static com.hedera.services.ledger.accounts.AccountCustomizer.Option.STAKE_PERIOD_START;
 import static com.hedera.services.ledger.accounts.AccountCustomizer.Option.USED_AUTOMATIC_ASSOCIATIONS;
 import static com.hedera.services.ledger.properties.TestAccountProperty.FLAG;
 import static com.hedera.services.ledger.properties.TestAccountProperty.OBJ;
@@ -265,33 +263,6 @@ class AccountCustomizerTest {
 				argThat(TestAccountCustomizer.OPTION_PROPERTIES.get(STAKED_ID)::equals),
 				argThat(stakedId::equals));
 	}
-
-	@Test
-	void changesExpectedStakePeriodStartProperty() {
-		setupWithMockChangeManager();
-		final Long stakePeriodStart = 1000L;
-
-		subject.stakePeriodStart(stakePeriodStart);
-
-		verify(changeManager).update(
-				any(EnumMap.class),
-				argThat(TestAccountCustomizer.OPTION_PROPERTIES.get(STAKE_PERIOD_START)::equals),
-				argThat(stakePeriodStart::equals));
-	}
-
-	@Test
-	void changesExpectedStakedToMeProperty() {
-		setupWithMockChangeManager();
-		final Long stakeToMe = 1000L;
-
-		subject.stakedToMe(stakeToMe);
-
-		verify(changeManager).update(
-				any(EnumMap.class),
-				argThat(TestAccountCustomizer.OPTION_PROPERTIES.get(STAKED_TO_ME)::equals),
-				argThat(stakeToMe::equals));
-	}
-
 
 	@Test
 	void changesAutoAssociationFieldsAsExpected() {

--- a/hedera-node/src/test/java/com/hedera/services/ledger/accounts/TestAccountCustomizer.java
+++ b/hedera-node/src/test/java/com/hedera/services/ledger/accounts/TestAccountCustomizer.java
@@ -28,8 +28,6 @@ import java.util.Map;
 
 import static com.hedera.services.ledger.accounts.AccountCustomizer.Option.DECLINE_REWARD;
 import static com.hedera.services.ledger.accounts.AccountCustomizer.Option.STAKED_ID;
-import static com.hedera.services.ledger.accounts.AccountCustomizer.Option.STAKED_TO_ME;
-import static com.hedera.services.ledger.accounts.AccountCustomizer.Option.STAKE_PERIOD_START;
 import static com.hedera.services.ledger.accounts.AccountCustomizer.Option.AUTO_RENEW_ACCOUNT_ID;
 import static com.hedera.services.ledger.accounts.AccountCustomizer.Option.USED_AUTOMATIC_ASSOCIATIONS;
 import static com.hedera.services.ledger.accounts.AccountCustomizer.Option.AUTO_RENEW_PERIOD;
@@ -63,8 +61,6 @@ public final class TestAccountCustomizer extends
 		OPTION_PROPERTIES.put(AUTO_RENEW_ACCOUNT_ID, OBJ);
 		OPTION_PROPERTIES.put(DECLINE_REWARD, FLAG);
 		OPTION_PROPERTIES.put(STAKED_ID, OBJ);
-		OPTION_PROPERTIES.put(STAKED_TO_ME, LONG);
-		OPTION_PROPERTIES.put(STAKE_PERIOD_START, LONG);
 	}
 
 	public TestAccountCustomizer(final ChangeSummaryManager<TestAccount, TestAccountProperty> changeManager) {

--- a/hedera-node/src/test/java/com/hedera/services/ledger/accounts/staking/StakeChangeManagerTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/ledger/accounts/staking/StakeChangeManagerTest.java
@@ -133,7 +133,7 @@ class StakeChangeManagerTest {
 		assertEquals(-1,  accountsMap.get(EntityNum.fromAccountId(partyId)).getStakePeriodStart());
 
 		subject = new StakeChangeManager(stakeInfoManager, () -> accountsMap);
-		subject.setStakePeriodStart(todayNum);
+		subject.initializeAllStakingStartsTo(todayNum);
 
 		assertEquals(todayNum, counterparty.getStakePeriodStart());
 		assertEquals(-1, party.getStakePeriodStart());

--- a/hedera-node/src/test/java/com/hedera/services/ledger/interceptors/StakeChangesInterceptorTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/ledger/interceptors/StakeChangesInterceptorTest.java
@@ -42,7 +42,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.util.EnumMap;
 import java.util.Map;
 
-import static com.hedera.services.ledger.properties.AccountProperty.STAKED_TO_ME;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willAnswer;
@@ -114,8 +113,7 @@ class StakeChangesInterceptorTest {
 		subject.preview(changes);
 
 		verify(stakeChangeManager).awardStake(aNodeNum, oneBalance, true);
-		final var finalBobChanges = changes.changes(1);
-		assertEquals(0L, finalBobChanges.get(STAKED_TO_ME));
+		assertEquals(0L, subject.getStakedToMeUpdates()[1]);
 	}
 
 	@Test
@@ -148,8 +146,7 @@ class StakeChangesInterceptorTest {
 
 		subject.preview(changes);
 
-		final var finalBobChanges = changes.changes(1);
-		assertEquals(oneBalance, finalBobChanges.get(STAKED_TO_ME));
+		assertEquals(oneBalance, subject.getStakedToMeUpdates()[1]);
 	}
 
 	@Test
@@ -163,8 +160,7 @@ class StakeChangesInterceptorTest {
 		subject.preview(changes);
 
 		verify(stakeChangeManager).withdrawStake(aNodeNum, oneBalance, true);
-		final var finalBobChanges = changes.changes(1);
-		assertEquals(oneBalance, finalBobChanges.get(STAKED_TO_ME));
+		assertEquals(oneBalance, subject.getStakedToMeUpdates()[1]);
 	}
 
 	@Test
@@ -181,10 +177,8 @@ class StakeChangesInterceptorTest {
 
 		subject.preview(changes);
 
-		final var finalBobChanges = changes.changes(1);
-		assertEquals(0L, finalBobChanges.get(STAKED_TO_ME));
-		final var finalCarolChanges = changes.changes(2);
-		assertEquals(oneBalance, finalCarolChanges.get(STAKED_TO_ME));
+		assertEquals(0L, subject.getStakedToMeUpdates()[1]);
+		assertEquals(oneBalance, subject.getStakedToMeUpdates()[2]);
 	}
 
 	@Test
@@ -197,8 +191,7 @@ class StakeChangesInterceptorTest {
 
 		subject.preview(changes);
 
-		final var finalBobChanges = changes.changes(1);
-		assertEquals(twoBalance, finalBobChanges.get(STAKED_TO_ME));
+		assertEquals(twoBalance, subject.getStakedToMeUpdates()[1]);
 	}
 
 	@Test
@@ -220,8 +213,7 @@ class StakeChangesInterceptorTest {
 
 		subject.preview(changes);
 
-		final var finalBobChanges = changes.changes(1);
-		assertEquals(0L, finalBobChanges.get(STAKED_TO_ME));
+		assertEquals(0L, subject.getStakedToMeUpdates()[1]);
 	}
 
 	@Test

--- a/hedera-node/src/test/java/com/hedera/services/ledger/interceptors/TokensCommitInterceptorTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/ledger/interceptors/TokensCommitInterceptorTest.java
@@ -21,9 +21,13 @@ package com.hedera.services.ledger.interceptors;
  */
 
 import com.hedera.services.context.SideEffectsTracker;
+import com.hedera.services.ledger.CommitInterceptor;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.doCallRealMethod;
 
 class TokensCommitInterceptorTest {
 	@Test
@@ -31,5 +35,12 @@ class TokensCommitInterceptorTest {
 		final var subject = new TokensCommitInterceptor(new SideEffectsTracker());
 
 		assertDoesNotThrow(() -> subject.preview(null));
+	}
+
+	@Test
+	void defaultFinisherIsNull() {
+		final var subject = Mockito.mock(CommitInterceptor.class);
+		doCallRealMethod().when(subject).finisherFor(0);
+		assertNull(subject.finisherFor(0));
 	}
 }

--- a/hedera-node/src/test/java/com/hedera/services/ledger/properties/AccountPropertyTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/ledger/properties/AccountPropertyTest.java
@@ -73,8 +73,6 @@ import static com.hedera.services.ledger.properties.AccountProperty.NUM_POSITIVE
 import static com.hedera.services.ledger.properties.AccountProperty.NUM_TREASURY_TITLES;
 import static com.hedera.services.ledger.properties.AccountProperty.PROXY;
 import static com.hedera.services.ledger.properties.AccountProperty.STAKED_ID;
-import static com.hedera.services.ledger.properties.AccountProperty.STAKED_TO_ME;
-import static com.hedera.services.ledger.properties.AccountProperty.STAKE_PERIOD_START;
 import static com.hedera.services.ledger.properties.AccountProperty.USED_AUTOMATIC_ASSOCIATIONS;
 import static com.hedera.services.state.submerkle.ExpirableTxnRecordTestHelper.fromGprc;
 import static com.hedera.test.factories.scenarios.TxnHandlingScenario.TOKEN_ADMIN_KT;
@@ -255,8 +253,6 @@ class AccountPropertyTest {
 		NUM_POSITIVE_BALANCES.setter().accept(account, newNumPositiveBalances);
 		NUM_TREASURY_TITLES.setter().accept(account, newNumTreasuryTitles);
 		DECLINE_REWARD.setter().accept(account, newDeclinedReward);
-		STAKED_TO_ME.setter().accept(account, newStakedToMe);
-		STAKE_PERIOD_START.setter().accept(account, newStakePeriodStart);
 		STAKED_ID.setter().accept(account, newStakedNum);
 		ETHEREUM_NONCE.setter().accept(account, newEthereumNonce);
 
@@ -283,8 +279,6 @@ class AccountPropertyTest {
 		assertEquals(newNumTreasuryTitles, NUM_TREASURY_TITLES.getter().apply(account));
 		assertEquals(newEthereumNonce, ETHEREUM_NONCE.getter().apply(account));
 		assertEquals(newDeclinedReward, DECLINE_REWARD.getter().apply(account));
-		assertEquals(newStakedToMe, STAKED_TO_ME.getter().apply(account));
-		assertEquals(newStakePeriodStart, STAKE_PERIOD_START.getter().apply(account));
 		assertEquals(newStakedNum, STAKED_ID.getter().apply(account));
 
 		STAKED_ID.setter().accept(account, origStakedNum);


### PR DESCRIPTION
**Description**:
 - Instead of treating `stakePeriodStart` and `stakedToMe` as user properties (i.e., values of the `enum AccountProperty`), manages these fields exclusively within the `StakeAwareAccountsCommitsInterceptor`.
 - For `stakedToMe`, maintains an [array of pending new values](https://github.com/hashgraph/hedera-services/blob/isolate-stake-metadata-to-interceptor/hedera-node/src/main/java/com/hedera/services/ledger/interceptors/StakeAwareAccountsCommitsInterceptor.java#L75)  (`-1` if not updated).
 - At the [end of `finalizeStakeMetadata()`](https://github.com/hashgraph/hedera-services/blob/isolate-stake-metadata-to-interceptor/hedera-node/src/main/java/com/hedera/services/ledger/interceptors/StakeAwareAccountsCommitsInterceptor.java#L209), packages any `stakedToMe` or `stakePeriodStart` changes in a `Consumer<MerkleAccount>` computed as [here](https://github.com/hashgraph/hedera-services/blob/isolate-stake-metadata-to-interceptor/hedera-node/src/main/java/com/hedera/services/ledger/accounts/staking/StakePeriodManager.java#L53).
 - Returns these (possibly `null`) finishers to the accounts ledger via a new [`CommitInterceptor` method](https://github.com/hashgraph/hedera-services/blob/isolate-stake-metadata-to-interceptor/hedera-node/src/main/java/com/hedera/services/ledger/CommitInterceptor.java#L61) that is called by `TransactionalLedger` [immediately after](https://github.com/hashgraph/hedera-services/blob/isolate-stake-metadata-to-interceptor/hedera-node/src/main/java/com/hedera/services/ledger/TransactionalLedger.java#L533) it finalizes the mutable entity.