### PR TITLE
feat: disable ethereumj log

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1246,13 +1246,6 @@ workflows:
                 at: /
 
   GCP-Daily-Services-Comp-Restart-Performance-Hotspot-6N-6C:
-    triggers:
-      - schedule:
-          cron: "35 7 * * *"
-          filters:
-            branches:
-              only:
-                - master
     jobs:
       - build-platform-and-services
       - jrs-regression:
@@ -1407,50 +1400,6 @@ workflows:
             - attach_workspace:
                 at: /
 
-  continuous-integration-gcp:
-      jobs:
-        - build-artifact:
-            name: "artifact-build"
-            context: SonarCloud
-            filters:
-              branches:
-                ignore:
-                  - NONE
-            workflow-name: "Continuous-integration"
-        - sonar-check:
-            context: SonarCloud
-            requires:
-              - artifact-build
-            workflow-name: "Continuous-integration-GCP"
-
-        - build-platform-and-services:
-            context: SonarCloud
-            requires:
-              - artifact-build
-            workflow-name: "Continuous-integration-GCP"
-        - javadoc-generation:
-            context: Slack
-            requires:
-              - build-platform-and-services
-            pre-steps:
-              - attach_workspace:
-                  at: /
-        - jrs-regression:
-            context: Slack
-            regression_path: /swirlds-platform/regression/assets
-            result_path: assets/results/4N_1C/CI
-            config_type: "ci"
-            workflow-name: "GCP-Commit-Services-Comp-Basic-4N-1C"
-            name: "run-continuous-integration-gcp"
-            continuous_integration: true
-            slack_results_channel: "hedera-cicd"
-            slack_summary_channel: "hedera-cicd"
-            requires:
-              - javadoc-generation
-            pre-steps:
-              - install-tools
-              - attach_workspace:
-                  at: /
 jobs:
   build-artifact:
     parameters:
@@ -1681,10 +1630,10 @@ jobs:
         default: true
       slack_results_channel:
         type: string
-        default: "hedera-regression"
+        default: "hedera-regression-test"
       slack_summary_channel:
         type: string
-        default: "hedera-regression-summary"
+        default: "hedera-regression-test"
       workflow-name:
         type: string
         default: ""

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1246,6 +1246,13 @@ workflows:
                 at: /
 
   GCP-Daily-Services-Comp-Restart-Performance-Hotspot-6N-6C:
+    triggers:
+      - schedule:
+          cron: "35 7 * * *"
+          filters:
+            branches:
+              only:
+                - master
     jobs:
       - build-platform-and-services
       - jrs-regression:
@@ -1400,6 +1407,50 @@ workflows:
             - attach_workspace:
                 at: /
 
+  continuous-integration-gcp:
+      jobs:
+        - build-artifact:
+            name: "artifact-build"
+            context: SonarCloud
+            filters:
+              branches:
+                ignore:
+                  - NONE
+            workflow-name: "Continuous-integration"
+        - sonar-check:
+            context: SonarCloud
+            requires:
+              - artifact-build
+            workflow-name: "Continuous-integration-GCP"
+
+        - build-platform-and-services:
+            context: SonarCloud
+            requires:
+              - artifact-build
+            workflow-name: "Continuous-integration-GCP"
+        - javadoc-generation:
+            context: Slack
+            requires:
+              - build-platform-and-services
+            pre-steps:
+              - attach_workspace:
+                  at: /
+        - jrs-regression:
+            context: Slack
+            regression_path: /swirlds-platform/regression/assets
+            result_path: assets/results/4N_1C/CI
+            config_type: "ci"
+            workflow-name: "GCP-Commit-Services-Comp-Basic-4N-1C"
+            name: "run-continuous-integration-gcp"
+            continuous_integration: true
+            slack_results_channel: "hedera-cicd"
+            slack_summary_channel: "hedera-cicd"
+            requires:
+              - javadoc-generation
+            pre-steps:
+              - install-tools
+              - attach_workspace:
+                  at: /
 jobs:
   build-artifact:
     parameters:
@@ -1553,7 +1604,6 @@ jobs:
             
             # Build JRS
             cd /swirlds-platform/regression
-            git checkout -b 02500-D-upload-logback.xml origin/02500-D-upload-logback.xml
             ./mvnw clean install
 
       - run:
@@ -1631,10 +1681,10 @@ jobs:
         default: true
       slack_results_channel:
         type: string
-        default: "hedera-regression-test"
+        default: "hedera-regression"
       slack_summary_channel:
         type: string
-        default: "hedera-regression-test"
+        default: "hedera-regression-summary"
       workflow-name:
         type: string
         default: ""

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1553,6 +1553,7 @@ jobs:
             
             # Build JRS
             cd /swirlds-platform/regression
+            git checkout -b 02500-D-upload-logback.xml origin/02500-D-upload-logback.xml
             ./mvnw clean install
 
       - run:

--- a/test-clients/src/main/resource/logback.xml
+++ b/test-clients/src/main/resource/logback.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<configuration>
+
+    <!-- Be sure to flush latest logs on exit -->
+    <shutdownHook class="ch.qos.logback.core.hook.DelayingShutdownHook"/>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} %p [%c{1}]  %m%n</pattern>
+        </encoder>
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>OFF</level>
+        </filter>
+    </appender>
+
+    <appender name="ASYNC" class="ch.qos.logback.classic.AsyncAppender">
+        <!-- Don't discard INFO, DEBUG, TRACE events in case of queue is 80% full -->
+        <discardingThreshold>0</discardingThreshold>
+        <!-- Default is 256 -->
+        <!-- Logger will block incoming events (log calls) until queue will free some space -->
+        <!-- (the smaller value -> flush occurs often) -->
+        <queueSize>100</queueSize>
+
+        <appender-ref ref="FILE" />
+    </appender>
+
+    <root level="OFF">
+        <appender-ref ref="STDOUT"/>
+        <appender-ref ref="ASYNC"/>
+    </root>
+</configuration>
+

--- a/test-clients/src/main/resource/logback.xml
+++ b/test-clients/src/main/resource/logback.xml
@@ -14,17 +14,6 @@
         </filter>
     </appender>
 
-    <appender name="ASYNC" class="ch.qos.logback.classic.AsyncAppender">
-        <!-- Don't discard INFO, DEBUG, TRACE events in case of queue is 80% full -->
-        <discardingThreshold>0</discardingThreshold>
-        <!-- Default is 256 -->
-        <!-- Logger will block incoming events (log calls) until queue will free some space -->
-        <!-- (the smaller value -> flush occurs often) -->
-        <queueSize>100</queueSize>
-
-        <appender-ref ref="FILE" />
-    </appender>
-
     <root level="OFF">
         <appender-ref ref="STDOUT"/>
         <appender-ref ref="ASYNC"/>


### PR DESCRIPTION
**Description**:
As @JeffreyDallas recommended in a comment on #3077 , this PR will disable ethereumj library to create log files by overriding the logback.xml from the library. After we completely remove the depedency from test-clients this logback.xml file can also be deleted.

**Related issue(s)**: #3077 

Fixes #

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
