### PR TITLE
Misc cleanup

### DIFF
--- a/hedera-node/src/main/java/com/hedera/services/store/contracts/AbstractStackedLedgerUpdater.java
+++ b/hedera-node/src/main/java/com/hedera/services/store/contracts/AbstractStackedLedgerUpdater.java
@@ -122,5 +122,11 @@ public abstract class AbstractStackedLedgerUpdater<W extends WorldView, A extend
 			}
 			updatedAccount.getUpdatedStorage().forEach(mutable::setStorageValue);
 		}
+		if (thisRecordSourceId != UNKNOWN_RECORD_SOURCE_ID) {
+			wrapped.addCommittedRecordSourceId(thisRecordSourceId, recordsHistorian);
+		}
+		if (!committedRecordSourceIds.isEmpty()) {
+			committedRecordSourceIds.forEach(id -> wrapped.addCommittedRecordSourceId(id, recordsHistorian));
+		}
 	}
 }

--- a/test-clients/src/main/java/com/hedera/services/bdd/spec/fees/FeesAndRatesProvider.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/spec/fees/FeesAndRatesProvider.java
@@ -47,7 +47,6 @@ import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.nio.file.Files;
 import java.time.Instant;
-import java.util.ArrayList;
 import java.util.List;
 
 import static com.hedera.services.bdd.spec.HapiPropertySource.asFileString;
@@ -214,14 +213,14 @@ public class FeesAndRatesProvider {
 						body(CryptoTransferTransactionBody.class, b -> b.setTransfers(transfers));
 		Transaction.Builder txnBuilder = txns.getReadyToSign(b -> {
 			b.setTransactionID(TransactionID.newBuilder().mergeFrom(b.getTransactionID())
-					.setAccountID(setup.genesisAccount()));
+					.setAccountID(setup.defaultPayer()));
 			b.setCryptoTransfer(opBody);
 		});
 
 		return keys.signWithFullPrefixEd25519Keys(
 				txnBuilder,
 				List.of(flattenedMaybeList(registry.getKey(setup.defaultPayerName())),
-				flattenedMaybeList(registry.getKey(setup.genesisAccountName()))));
+				flattenedMaybeList(registry.getKey(setup.defaultPayerName()))));
 	}
 
 	private Key flattenedMaybeList(final Key k) {

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/ContractMintHTSSuite.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/ContractMintHTSSuite.java
@@ -605,9 +605,9 @@ public class ContractMintHTSSuite extends HapiApiSuite {
 						getAccountBalance(TOKEN_TREASURY).hasTokenBalance(nonFungibleToken, 0),
 						childRecordsCheck(nestedMintTxn, CONTRACT_REVERT_EXECUTED,
 								recordWith()
-										.status(SUCCESS)
-										.newTotalSupply(1)
-										.serialNos(List.of(1L)),
+										.status(REVERTED_SUCCESS)
+										.newTotalSupply(0)
+										.serialNos(List.of()),
 								recordWith()
 										.contractCallResult(
 												resultWith()


### PR DESCRIPTION
**Description**:
 - Reverts a change in `FeeAndRatesProvider` to use genesis rather than default payer.
 - Cleans up management of records between parent and child updaters during `commit()`.