### PR TITLE
Set and alias Sender in Local Contract Call Queries

### DIFF
--- a/hedera-node/src/main/java/com/hedera/services/contracts/execution/CallLocalExecutor.java
+++ b/hedera-node/src/main/java/com/hedera/services/contracts/execution/CallLocalExecutor.java
@@ -26,7 +26,6 @@ import com.hedera.services.ledger.accounts.AliasManager;
 import com.hedera.services.store.AccountStore;
 import com.hedera.services.store.contracts.EntityAccess;
 import com.hedera.services.store.models.Account;
-import com.hedera.services.store.models.Id;
 import com.hedera.services.utils.EntityIdUtils;
 import com.hedera.services.utils.ResponseCodeUtil;
 import com.hedera.services.utils.accessors.SignedTxnAccessor;

--- a/hedera-node/src/main/java/com/hedera/services/contracts/execution/CallLocalExecutor.java
+++ b/hedera-node/src/main/java/com/hedera/services/contracts/execution/CallLocalExecutor.java
@@ -23,6 +23,7 @@ package com.hedera.services.contracts.execution;
 import com.google.protobuf.ByteString;
 import com.hedera.services.exceptions.InvalidTransactionException;
 import com.hedera.services.ledger.accounts.AliasManager;
+import com.hedera.services.state.submerkle.EvmFnResult;
 import com.hedera.services.store.AccountStore;
 import com.hedera.services.store.contracts.EntityAccess;
 import com.hedera.services.store.models.Account;
@@ -32,6 +33,7 @@ import com.hedera.services.utils.ResponseCodeUtil;
 import com.hedera.services.utils.accessors.SignedTxnAccessor;
 import com.hederahashgraph.api.proto.java.ContractCallLocalQuery;
 import com.hederahashgraph.api.proto.java.ContractCallLocalResponse;
+import com.hederahashgraph.api.proto.java.ContractFunctionResult;
 import com.hederahashgraph.builder.RequestBuilder;
 import com.swirlds.common.utility.CommonUtils;
 import org.apache.tuweni.bytes.Bytes;
@@ -102,10 +104,14 @@ public class CallLocalExecutor {
 			final var responseHeader = RequestBuilder.getResponseHeader(status, 0L,
 					ANSWER_ONLY, ByteString.EMPTY);
 
+			var evmFnResult = EvmFnResult.fromCall(result);
+			evmFnResult.setGas(op.getGas());
+			evmFnResult.setFunctionParameters(op.getFunctionParameters().toByteArray());
+			evmFnResult.setSenderId(senderId.asEntityId());
 			return ContractCallLocalResponse
 					.newBuilder()
 					.setHeader(responseHeader)
-					.setFunctionResult(result.toGrpc())
+					.setFunctionResult(evmFnResult.toGrpc())
 					.build();
 		} catch (InvalidTransactionException ite) {
 			final var responseHeader = RequestBuilder.getResponseHeader(ite.getResponseCode(), 0L,

--- a/hedera-node/src/main/java/com/hedera/services/contracts/execution/CallLocalExecutor.java
+++ b/hedera-node/src/main/java/com/hedera/services/contracts/execution/CallLocalExecutor.java
@@ -23,7 +23,6 @@ package com.hedera.services.contracts.execution;
 import com.google.protobuf.ByteString;
 import com.hedera.services.exceptions.InvalidTransactionException;
 import com.hedera.services.ledger.accounts.AliasManager;
-import com.hedera.services.state.submerkle.EvmFnResult;
 import com.hedera.services.store.AccountStore;
 import com.hedera.services.store.contracts.EntityAccess;
 import com.hedera.services.store.models.Account;
@@ -33,7 +32,6 @@ import com.hedera.services.utils.ResponseCodeUtil;
 import com.hedera.services.utils.accessors.SignedTxnAccessor;
 import com.hederahashgraph.api.proto.java.ContractCallLocalQuery;
 import com.hederahashgraph.api.proto.java.ContractCallLocalResponse;
-import com.hederahashgraph.api.proto.java.ContractFunctionResult;
 import com.hederahashgraph.builder.RequestBuilder;
 import com.swirlds.common.utility.CommonUtils;
 import org.apache.tuweni.bytes.Bytes;
@@ -104,14 +102,10 @@ public class CallLocalExecutor {
 			final var responseHeader = RequestBuilder.getResponseHeader(status, 0L,
 					ANSWER_ONLY, ByteString.EMPTY);
 
-			var evmFnResult = EvmFnResult.fromCall(result);
-			evmFnResult.setGas(op.getGas());
-			evmFnResult.setFunctionParameters(op.getFunctionParameters().toByteArray());
-			evmFnResult.setSenderId(senderId.asEntityId());
 			return ContractCallLocalResponse
 					.newBuilder()
 					.setHeader(responseHeader)
-					.setFunctionResult(evmFnResult.toGrpc())
+					.setFunctionResult(result.toGrpc())
 					.build();
 		} catch (InvalidTransactionException ite) {
 			final var responseHeader = RequestBuilder.getResponseHeader(ite.getResponseCode(), 0L,

--- a/hedera-node/src/main/java/com/hedera/services/contracts/execution/CallLocalExecutor.java
+++ b/hedera-node/src/main/java/com/hedera/services/contracts/execution/CallLocalExecutor.java
@@ -74,7 +74,9 @@ public class CallLocalExecutor {
 	) {
 		try {
 			final var paymentTxn = SignedTxnAccessor.uncheckedFrom(op.getHeader().getPayment()).getTxn();
-			final var senderId = Id.fromGrpcAccount(paymentTxn.getTransactionID().getAccountID());
+			final var senderId = EntityIdUtils.unaliased(op.hasSenderId()
+					? op.getSenderId()
+					: paymentTxn.getTransactionID().getAccountID(), aliasManager).toId();
 			final var idOrAlias = op.getContractID();
 			final var contractId = EntityIdUtils.unaliased(idOrAlias, aliasManager).toId();
 

--- a/hedera-node/src/main/java/com/hedera/services/utils/EntityIdUtils.java
+++ b/hedera-node/src/main/java/com/hedera/services/utils/EntityIdUtils.java
@@ -357,4 +357,29 @@ public final class EntityIdUtils {
 			return EntityNum.fromContractId(idOrAlias);
 		}
 	}
+
+	public static EntityNum unaliased(final AccountID idOrAlias, final AliasManager aliasManager) {
+		return unaliased(idOrAlias, aliasManager, null);
+	}
+
+	public static EntityNum unaliased(
+			final AccountID idOrAlias,
+			final AliasManager aliasManager,
+			@Nullable final Consumer<ByteString> aliasObs
+	) {
+		if (isAlias(idOrAlias)) {
+			final var alias = idOrAlias.getAlias();
+			final var evmAddress = alias.toByteArray();
+			if (aliasManager.isMirror(evmAddress)) {
+				final var accountNum = Longs.fromByteArray(Arrays.copyOfRange(evmAddress, 12, 20));
+				return EntityNum.fromLong(accountNum);
+			}
+			if (aliasObs != null) {
+				aliasObs.accept(alias);
+			}
+			return aliasManager.lookupIdBy(alias);
+		} else {
+			return EntityNum.fromAccountId(idOrAlias);
+		}
+	}
 }

--- a/hedera-node/src/test/java/com/hedera/services/contracts/execution/CallLocalExecutorTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/contracts/execution/CallLocalExecutorTest.java
@@ -101,8 +101,7 @@ class CallLocalExecutorTest {
 		final var transactionProcessingResult = TransactionProcessingResult
 				.successful(new ArrayList<>(), 0, 0, 1, Bytes.EMPTY,
 						callerID.asEvmAddress(), new TreeMap<>());
-		final var expected = response(OK,
-				transactionProcessingResult, gas, params.toByteArray(),	Id.DEFAULT.asGrpcAccount());
+		final var expected = response(OK, transactionProcessingResult);
 
 		given(accountStore.loadAccount(any())).willReturn(new Account(callerID));
 		given(accountStore.loadContract(contractID)).willReturn(new Account(contractID));
@@ -130,8 +129,7 @@ class CallLocalExecutorTest {
 		final var transactionProcessingResult = TransactionProcessingResult
 				.successful(new ArrayList<>(), 0, 0, 1, Bytes.EMPTY,
 						callerID.asEvmAddress(), new TreeMap<>());
-		final var expected = response(OK, 
-				transactionProcessingResult, gas, params.toByteArray(),	senderID.asGrpcAccount());
+		final var expected = response(OK,transactionProcessingResult);
 
 		given(accountStore.loadAccount(any())).willReturn(new Account(callerID));
 		given(accountStore.loadContract(contractID)).willReturn(new Account(contractID));
@@ -152,8 +150,7 @@ class CallLocalExecutorTest {
 		final var transactionProcessingResult = TransactionProcessingResult
 				.successful(new ArrayList<>(), 0, 0, 1, Bytes.EMPTY, callerID.asEvmAddress(),
 						Collections.emptyMap());
-		final var expected = response(OK,
-				transactionProcessingResult, gas, params.toByteArray(),	Id.DEFAULT.asGrpcAccount());
+		final var expected = response(OK, transactionProcessingResult);
 
 		given(accountStore.loadAccount(any())).willReturn(new Account(callerID));
 		given(accountStore.loadContract(any())).willReturn(new Account(contractID));
@@ -174,8 +171,7 @@ class CallLocalExecutorTest {
 		final var transactionProcessingResult = TransactionProcessingResult
 				.successful(new ArrayList<>(), 0, 0, 1, Bytes.EMPTY, callerID.asEvmAddress(),
 						Collections.emptyMap());
-		final var expected = response(OK,
-				transactionProcessingResult, gas, params.toByteArray(),	Id.DEFAULT.asGrpcAccount());
+		final var expected = response(OK, transactionProcessingResult);
 
 		given(entityAccess.isTokenAccount(any())).willReturn(true);
 		given(evmTxProcessor.execute(any(), any(), anyLong(), anyLong(), any(), any()))
@@ -195,8 +191,7 @@ class CallLocalExecutorTest {
 		final var transactionProcessingResult = TransactionProcessingResult
 				.failed(0, 0, 1, Optional.empty(),
 						Optional.of(ExceptionalHaltReason.ILLEGAL_STATE_CHANGE), Collections.emptyMap());
-		final var expected = response(LOCAL_CALL_MODIFICATION_EXCEPTION, 
-				transactionProcessingResult, gas, params.toByteArray(), Id.DEFAULT.asGrpcAccount());
+		final var expected = response(LOCAL_CALL_MODIFICATION_EXCEPTION, transactionProcessingResult);
 
 		given(accountStore.loadAccount(any())).willReturn(new Account(callerID));
 		given(accountStore.loadContract(any())).willReturn(new Account(contractID));
@@ -217,8 +212,7 @@ class CallLocalExecutorTest {
 		final var transactionProcessingResult = TransactionProcessingResult
 				.failed(0, 0, 1, Optional.empty(),
 						Optional.of(HederaExceptionalHaltReason.INVALID_SOLIDITY_ADDRESS), Collections.emptyMap());
-		final var expected = response(INVALID_SOLIDITY_ADDRESS,
-				transactionProcessingResult, gas, params.toByteArray(),	Id.DEFAULT.asGrpcAccount());
+		final var expected = response(INVALID_SOLIDITY_ADDRESS, transactionProcessingResult);
 
 		given(accountStore.loadAccount(any())).willReturn(new Account(callerID));
 		given(accountStore.loadContract(any())).willReturn(new Account(contractID));
@@ -239,8 +233,7 @@ class CallLocalExecutorTest {
 		final var transactionProcessingResult = TransactionProcessingResult
 				.failed(0, 0, 1, Optional.of(Bytes.of("out of gas".getBytes())),
 						Optional.empty(), Collections.emptyMap());
-		final var expected = response(CONTRACT_REVERT_EXECUTED,
-				transactionProcessingResult, gas, params.toByteArray(),	Id.DEFAULT.asGrpcAccount());
+		final var expected = response(CONTRACT_REVERT_EXECUTED, transactionProcessingResult);
 
 		given(accountStore.loadAccount(any())).willReturn(new Account(callerID));
 		given(accountStore.loadContract(any())).willReturn(new Account(contractID));
@@ -269,14 +262,10 @@ class CallLocalExecutorTest {
 		verifyNoInteractions(evmTxProcessor);
 	}
 
-	private ContractCallLocalResponse response(ResponseCodeEnum status, TransactionProcessingResult result, long gas,
-			byte[] params, AccountID senderId) {
+	private ContractCallLocalResponse response(ResponseCodeEnum status, TransactionProcessingResult result) {
 		return ContractCallLocalResponse.newBuilder()
 				.setHeader(ResponseHeader.newBuilder().setNodeTransactionPrecheckCode(status))
-				.setFunctionResult(result.toGrpc().toBuilder()
-						.setGas(gas)
-						.setFunctionParameters(ByteString.copyFrom(params))
-						.setSenderId(senderId))
+				.setFunctionResult(result.toGrpc())
 				.build();
 	}
 

--- a/hedera-node/src/test/java/com/hedera/services/fees/calculation/contract/queries/ContractCallLocalResourceUsageTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/fees/calculation/contract/queries/ContractCallLocalResourceUsageTest.java
@@ -40,6 +40,7 @@ import com.hedera.test.extensions.LogCaptor;
 import com.hedera.test.extensions.LogCaptureExtension;
 import com.hedera.test.extensions.LoggingSubject;
 import com.hedera.test.extensions.LoggingTarget;
+import com.hederahashgraph.api.proto.java.AccountID;
 import com.hederahashgraph.api.proto.java.ContractCallLocalQuery;
 import com.hederahashgraph.api.proto.java.ContractCallLocalResponse;
 import com.hederahashgraph.api.proto.java.ContractID;

--- a/hedera-node/src/test/java/com/hedera/services/utils/EntityIdUtilsTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/utils/EntityIdUtilsTest.java
@@ -45,6 +45,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Arrays;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static com.hedera.services.utils.EntityIdUtils.asEvmAddress;
 import static com.hedera.services.utils.EntityIdUtils.asLiteralString;
@@ -123,6 +124,18 @@ class EntityIdUtilsTest {
 		given(aliasManager.lookupIdBy(ByteString.copyFrom(mockAddr))).willReturn(extantNum);
 
 		assertEquals(extantNum, unaliased(input, aliasManager));
+	}
+
+	@Test
+	void observesUnalising() {
+		final byte[] mockAddr = unhex("aaaaaaaaaaaaaaaaaaaaaaaa9abcdefabcdefbbb");
+		final var extantNum = EntityNum.fromLong(1_234_567L);
+		final var input = AccountID.newBuilder().setAlias(ByteString.copyFrom(mockAddr)).build();
+		given(aliasManager.lookupIdBy(ByteString.copyFrom(mockAddr))).willReturn(extantNum);
+
+		AtomicReference<ByteString> observer = new AtomicReference<>();
+		unaliased(input, aliasManager, observer::set);
+		assertEquals(ByteString.copyFrom(mockAddr), observer.get()); 
 	}
 
 	@Test


### PR DESCRIPTION
**Description**:

ContractCallLocalQuery was not respecting the sender_id and was not aliasing the sender.  This patch does those two steps.

**Related issue(s)**:

Fixes #3512

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [X] Tested (unit, integration, etc.)
