### PR TITLE
Reset `isTokenReadOnlyTransaction` in `prepareComputation()`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,10 +32,10 @@ FROM base-runtime AS services-builder
 # Note: Java 17 requires Maven 3.8+ so the distro provided one just won't do
 RUN apt-get update && \
     apt-get install -y wget unzip && \
-    wget https://dlcdn.apache.org/maven/maven-3/3.8.5/binaries/apache-maven-3.8.5-bin.zip && \
-    unzip apache-maven-3.8.5-bin.zip -d /opt && \
-    rm apache-maven-3.8.5-bin.zip
-ENV PATH=/opt/apache-maven-3.8.5/bin:$PATH
+    wget https://dlcdn.apache.org/maven/maven-3/3.8.6/binaries/apache-maven-3.8.6-bin.zip && \
+    unzip apache-maven-3.8.6-bin.zip -d /opt && \
+    rm apache-maven-3.8.6-bin.zip
+ENV PATH=/opt/apache-maven-3.8.6/bin:$PATH
 
 WORKDIR /opt/hedera/services
 # Install Services

--- a/hedera-node/src/main/java/com/hedera/services/store/contracts/precompile/HTSPrecompiledContract.java
+++ b/hedera-node/src/main/java/com/hedera/services/store/contracts/precompile/HTSPrecompiledContract.java
@@ -461,6 +461,7 @@ public class HTSPrecompiledContract extends AbstractPrecompiledContract {
 
 		this.functionId = input.getInt(0);
 		this.gasRequirement = 0L;
+		this.isTokenReadOnlyTransaction = false;
 
 		this.precompile =
 				switch (functionId) {
@@ -2152,7 +2153,18 @@ public class HTSPrecompiledContract extends AbstractPrecompiledContract {
 		this.approveAllowanceLogicFactory = approveAllowanceLogicFactory;
 	}
 
+	@VisibleForTesting
 	public Precompile getPrecompile() {
 		return precompile;
+	}
+
+	@VisibleForTesting
+	void setTokenReadOnlyTransaction(final boolean tokenReadOnlyTransaction) {
+		isTokenReadOnlyTransaction = tokenReadOnlyTransaction;
+	}
+
+	@VisibleForTesting
+	boolean isTokenReadOnlyTransaction() {
+		return isTokenReadOnlyTransaction;
 	}
 }

--- a/hedera-node/src/test/java/com/hedera/services/ServicesStateTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/ServicesStateTest.java
@@ -64,6 +64,7 @@ import com.swirlds.common.system.transaction.SwirldTransaction;
 import com.swirlds.fchashmap.FCHashMap;
 import com.swirlds.merkle.map.MerkleMap;
 import com.swirlds.virtualmap.VirtualMap;
+import org.apache.commons.io.FileUtils;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
@@ -73,6 +74,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.io.File;
+import java.io.IOException;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.ConcurrentModificationException;
@@ -97,7 +100,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -867,6 +869,9 @@ class ServicesStateTest {
 	}
 
 	private void setAllChildren() {
+		try {
+			FileUtils.cleanDirectory(new File("database"));
+		} catch (IOException ignore) { }
 		subject.createGenesisChildren(addressBook, 0);
 	}
 }

--- a/hedera-node/src/test/java/com/hedera/services/store/contracts/precompile/TransferPrecompilesTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/store/contracts/precompile/TransferPrecompilesTest.java
@@ -120,6 +120,7 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OK;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TRANSFERS_NOT_ZERO_SUM_FOR_TOKEN;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
@@ -289,10 +290,11 @@ class TransferPrecompilesTest {
 	}
 
 	@Test
-	void transferTokenHappyPathWorks() {
+	void transferTokenHappyPathWorksEvenIfLastCallWasReadOnlyPrecompile() {
 		Bytes pretendArguments = Bytes.of(Integers.toBytes(ABI_ID_TRANSFER_TOKENS));
 		givenMinimalFrameContext();
 		givenLedgers();
+		subject.setTokenReadOnlyTransaction(true);
 
 		given(syntheticTxnFactory.createCryptoTransfer(Collections.singletonList(tokensTransferList)))
 				.willReturn(mockSynthBodyBuilder);
@@ -348,6 +350,7 @@ class TransferPrecompilesTest {
 		verify(transferLogic).doZeroSum(tokensTransferChanges);
 		verify(wrappedLedgers).commit();
 		verify(worldUpdater).manageInProgressRecord(recordsHistorian, mockRecordBuilder, mockSynthBodyBuilder);
+		assertFalse(subject.isTokenReadOnlyTransaction());
 	}
 
 	@Test


### PR DESCRIPTION
**Description**:
 - Reset the `HTSPrecompiledContract.isTokenReadOnlyTransaction` flag every computation.