### PR TITLE
Improve parallelism in HapiApiSpec test clients

### DIFF
--- a/test-clients/src/main/java/com/hedera/services/bdd/spec/HapiApiSpec.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/spec/HapiApiSpec.java
@@ -56,6 +56,8 @@ import java.util.Optional;
 import java.util.Properties;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.PriorityBlockingQueue;
 import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.ThreadPoolExecutor;
@@ -93,6 +95,12 @@ import static java.util.stream.Collectors.toList;
 
 public class HapiApiSpec implements Runnable {
 	private static final String CI_PROPS_FLAG_FOR_NO_UNRECOVERABLE_NETWORK_FAILURES = "suppressNetworkFailures";
+	private static final ThreadPoolExecutor THREAD_POOL = new ThreadPoolExecutor(
+					0,
+					10_000,
+					250,
+					TimeUnit.MILLISECONDS,
+					new SynchronousQueue<>());
 
 	static final Logger log = LogManager.getLogger(HapiApiSpec.class);
 
@@ -129,6 +137,10 @@ public class HapiApiSpec implements Runnable {
 	EnumMap<ResponseCodeEnum, AtomicInteger> finalizedStatusCounts = new EnumMap<>(ResponseCodeEnum.class);
 
 	List<SingleAccountBalances> accountBalances = new ArrayList<>();
+
+	public static ThreadPoolExecutor getCommonThreadPool() {
+		return THREAD_POOL;
+	}
 
 	public void adhocIncrement() {
 		adhoc.getAndIncrement();

--- a/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/grouping/ParallelSpecOps.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/grouping/ParallelSpecOps.java
@@ -48,11 +48,12 @@ public class ParallelSpecOps extends UtilOp {
 	protected boolean submitOp(HapiApiSpec spec) throws Throwable {
 		Map<String, Throwable> subErrors = new HashMap<>();
 
-		CompletableFuture future = CompletableFuture.allOf(
+		CompletableFuture<Void> future = CompletableFuture.allOf(
 				Stream.of(subs)
 						.map(op -> CompletableFuture.runAsync(
-								() -> op.execFor(spec).map(t -> subErrors.put(op.toString(), t))))
-						.toArray(n -> new CompletableFuture[n])
+								() -> op.execFor(spec).map(t -> subErrors.put(op.toString(), t)),
+								HapiApiSpec.getCommonThreadPool()))
+						.toArray(CompletableFuture[]::new)
 		);
 		future.join();
 

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/HapiApiSuite.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/HapiApiSuite.java
@@ -217,7 +217,7 @@ public abstract class HapiApiSuite {
 	private void runAsync(Iterable<HapiApiSpec> specs) {
 		CompletableFuture[] futures = StreamSupport
 				.stream(specs.spliterator(), false)
-				.map(CompletableFuture::runAsync)
+				.map(r -> CompletableFuture.runAsync(r, HapiApiSpec.getCommonThreadPool()))
 				.toArray(n -> new CompletableFuture[n]);
 		CompletableFuture.allOf(futures).join();
 	}

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/SuiteRunner.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/SuiteRunner.java
@@ -724,7 +724,8 @@ public class SuiteRunner {
 		}
 		CompletableFuture<Void> future = CompletableFuture.allOf(
 				IntStream.range(0, inputs.length)
-						.mapToObj(i -> runAsync(() -> outputs.set(i, f.apply(inputs[i]))))
+						.mapToObj(i -> runAsync(() -> outputs.set(i, f.apply(inputs[i])),
+								HapiApiSpec.getCommonThreadPool()))
 						.toArray(n -> new CompletableFuture[n]));
 		future.join();
 		return outputs;


### PR DESCRIPTION
Improve parallelism in HapiApiSpec test clients by creating a common thread pool and avoiding calls to CompletableFuture.runAsync without a thread pool argument.

**Description**:

Calls to CompletableFuture.runAsync without a thread pool uses ForkJoinPool.commonPool which is limited to numCores - 1 threads. This is extremely limited and can lead to I/O bounded threads to be starved. This PR addresses this issue by:
- Creating a common thread pool with a high upper bound to max threads allowed.
- Switching calls to runAsync to include the new thread pool as the thread pool argument.

On a custom test written, the test previously took 233 seconds to run before this change. After these changes it took 12 seconds to complete.

**Related issue(s)**:
Fixes: https://github.com/hashgraph/hedera-services/issues/3534
