### PR TITLE
Fixes flakiness in ServicesStateTest during setup caused by a directory being non-existent.

### DIFF
--- a/hedera-node/src/test/java/com/hedera/services/ServicesStateTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/ServicesStateTest.java
@@ -869,9 +869,16 @@ class ServicesStateTest {
 	}
 
 	private void setAllChildren() {
+		File databaseFolder = new File("database");
 		try {
+			if (!databaseFolder.exists()) {
+				databaseFolder.mkdir();
+			}
 			FileUtils.cleanDirectory(new File("database"));
-		} catch (IOException ignore) { }
+		} catch (IllegalArgumentException | IOException e) {
+			System.err.println("Exception thrown while cleaning up directory");
+			e.printStackTrace();
+		}
 		subject.createGenesisChildren(addressBook, 0);
 	}
 }


### PR DESCRIPTION
**Description**:
ServicesStateTest can fail during test setup if the `database` folder is non-existent. This PR checks for the existence of the folder and creates it if it is missing. This PR also improves the overall logging for when the error occurs (which was non-existent).

**Related issue(s)**:

Fixes #: https://github.com/hashgraph/hedera-services/issues/3540

