### PR TITLE
remove secp256kr1 library

### DIFF
--- a/hedera-node/build.gradle.kts
+++ b/hedera-node/build.gradle.kts
@@ -30,7 +30,10 @@ dependencies {
 
     implementation(project(":hapi-fees"))
     implementation(project(":hapi-utils"))
-    implementation(libs.bundles.besu)
+    implementation(libs.bundles.besu) {
+        exclude(group="org.hyperledger.besu", module="secp256r1")
+        exclude(group="org.hyperledger.besu", module="bls12-381")
+    }
     implementation(libs.bundles.di)
     implementation(libs.bundles.logging)
     implementation(libs.bundles.swirlds)

--- a/hedera-node/build.gradle.kts
+++ b/hedera-node/build.gradle.kts
@@ -31,7 +31,6 @@ dependencies {
     implementation(project(":hapi-fees"))
     implementation(project(":hapi-utils"))
     implementation(libs.bundles.besu) {
-        exclude(group="org.hyperledger.besu", module="secp256r1")
         exclude(group="org.hyperledger.besu", module="bls12-381")
     }
     implementation(libs.bundles.di)

--- a/hedera-node/pom.xml
+++ b/hedera-node/pom.xml
@@ -316,6 +316,10 @@
 		</dependency>
 		<dependency>
 			<groupId>org.hyperledger.besu</groupId>
+			<artifactId>bls12-381</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.hyperledger.besu</groupId>
 			<artifactId>secp256k1</artifactId>
 		</dependency>
 		<dependency>

--- a/hedera-node/pom.xml
+++ b/hedera-node/pom.xml
@@ -316,10 +316,6 @@
 		</dependency>
 		<dependency>
 			<groupId>org.hyperledger.besu</groupId>
-			<artifactId>bls12-381</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.hyperledger.besu</groupId>
 			<artifactId>secp256k1</artifactId>
 		</dependency>
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -477,11 +477,6 @@
 			</dependency>
 			<dependency>
 				<groupId>org.hyperledger.besu</groupId>
-				<artifactId>bls12-381</artifactId>
-				<version>${besu-native.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>org.hyperledger.besu</groupId>
 				<artifactId>secp256k1</artifactId>
 				<version>${besu-native.version}</version>
 			</dependency>
@@ -489,6 +484,16 @@
 				<groupId>org.hyperledger.besu</groupId>
 				<artifactId>evm</artifactId>
 				<version>${besu.version}</version>
+				<exclusions>
+				<exclusion>
+					<groupId>org.hyperledger.besu</groupId>
+					<artifactId>secp256r1</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.hyperledger.besu</groupId>
+					<artifactId>bls12-381</artifactId>
+				</exclusion>
+				</exclusions>
 			</dependency>
 			<dependency>
 				<groupId>org.hyperledger.besu</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -477,6 +477,11 @@
 			</dependency>
 			<dependency>
 				<groupId>org.hyperledger.besu</groupId>
+				<artifactId>bls12-381</artifactId>
+				<version>${besu-native.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.hyperledger.besu</groupId>
 				<artifactId>secp256k1</artifactId>
 				<version>${besu-native.version}</version>
 			</dependency>
@@ -485,14 +490,10 @@
 				<artifactId>evm</artifactId>
 				<version>${besu.version}</version>
 				<exclusions>
-				<exclusion>
-					<groupId>org.hyperledger.besu</groupId>
-					<artifactId>secp256r1</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>org.hyperledger.besu</groupId>
-					<artifactId>bls12-381</artifactId>
-				</exclusion>
+					<exclusion>
+						<groupId>org.hyperledger.besu</groupId>
+						<artifactId>secp256r1</artifactId>
+					</exclusion>
 				</exclusions>
 			</dependency>
 			<dependency>

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -59,7 +59,7 @@ dependencyResolutionManagement {
 
             // List of bundles provided for us. When applicable, favor using these over individual libraries.
             // Use when you need to use Besu
-            bundle("besu", listOf("besu-evm", "besu-datatypes", "besu-secp256k1", "tuweni-units"))
+            bundle("besu", listOf("besu-bls12-381", "besu-evm", "besu-datatypes", "besu-secp256k1", "tuweni-units"))
             // Use when you need to use bouncy castle
             bundle("bouncycastle", listOf("bouncycastle-bcprov-jdk15on", "bouncycastle-bcpkix-jdk15on"))
             // Use when you need to make use of dependency injection.
@@ -73,6 +73,7 @@ dependencyResolutionManagement {
                 "swirlds-merkle", "swirlds-fcqueue", "swirlds-jasperdb", "swirlds-virtualmap"))
 
             // Define the individual libraries
+            library("besu-bls12-381", "org.hyperledger.besu", "bls12-381").versionRef("besu-native-version")
             library("besu-secp256k1", "org.hyperledger.besu", "secp256k1").versionRef("besu-native-version")
             library("besu-evm", "org.hyperledger.besu", "evm").versionRef("besu-version")
             library("besu-datatypes", "org.hyperledger.besu", "besu-datatypes").versionRef("besu-version")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -35,7 +35,7 @@ dependencyResolutionManagement {
         create("libs") {
             // Definition of version numbers for all libraries
             version("besu-version", "22.4.1")
-            version("besu-native-version", "0.4.3")
+            version("besu-native-version", "0.5.0")
             version("bouncycastle-version", "1.70")
             version("caffeine-version", "3.0.6")
             version("commons-codec-version", "1.15")
@@ -59,7 +59,7 @@ dependencyResolutionManagement {
 
             // List of bundles provided for us. When applicable, favor using these over individual libraries.
             // Use when you need to use Besu
-            bundle("besu", listOf("besu-bls12-381", "besu-evm", "besu-datatypes", "besu-secp256k1", "tuweni-units"))
+            bundle("besu", listOf("besu-evm", "besu-datatypes", "besu-secp256k1", "tuweni-units"))
             // Use when you need to use bouncy castle
             bundle("bouncycastle", listOf("bouncycastle-bcprov-jdk15on", "bouncycastle-bcpkix-jdk15on"))
             // Use when you need to make use of dependency injection.
@@ -73,7 +73,6 @@ dependencyResolutionManagement {
                 "swirlds-merkle", "swirlds-fcqueue", "swirlds-jasperdb", "swirlds-virtualmap"))
 
             // Define the individual libraries
-            library("besu-bls12-381", "org.hyperledger.besu", "bls12-381").versionRef("besu-native-version")
             library("besu-secp256k1", "org.hyperledger.besu", "secp256k1").versionRef("besu-native-version")
             library("besu-evm", "org.hyperledger.besu", "evm").versionRef("besu-version")
             library("besu-datatypes", "org.hyperledger.besu", "besu-datatypes").versionRef("besu-version")


### PR DESCRIPTION
**Description**:
The besu-evm brings in the secp256r1 library, which hedera neither needs nor uses.

**Related issue(s)**:

Fixes #3546 

**Notes for reviewer**:
kotlin build didn't get the 0.5.0 version upgrade in the prior PR, adding it here.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
