### PR TITLE
Restore bls12-381 to kotlin build

### DIFF
--- a/hedera-node/build.gradle.kts
+++ b/hedera-node/build.gradle.kts
@@ -31,7 +31,7 @@ dependencies {
     implementation(project(":hapi-fees"))
     implementation(project(":hapi-utils"))
     implementation(libs.bundles.besu) {
-        exclude(group="org.hyperledger.besu", module="bls12-381")
+        exclude(group="org.hyperledger.besu", module="secp256r1")
     }
     implementation(libs.bundles.di)
     implementation(libs.bundles.logging)


### PR DESCRIPTION
**Description**:
Correct exclusion of the bls12-381 lib kotlin build and exclude secp256r1.


**Related issue(s)**:

Fixes #3546

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
