### PR TITLE
Update SDK + proto versions

### DIFF
--- a/buildSrc/src/main/kotlin/com.hedera.hashgraph.hedera-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/com.hedera.hashgraph.hedera-conventions.gradle.kts
@@ -60,6 +60,9 @@ repositories {
     maven {
         url = uri("https://us-maven.pkg.dev/swirlds-registry/maven-develop-snapshots")
     }
+    maven {
+        url = uri("https://oss.sonatype.org/content/repositories/comhederahashgraph-1531")
+    }
 }
 
 // Enable maven publications

--- a/pom.xml
+++ b/pom.xml
@@ -113,7 +113,7 @@
 			</snapshots>
 			<id>proto-staging</id>
 			<name>Protobufs staging</name>
-			<url>https://oss.sonatype.org/content/repositories/comhederahashgraph-1502</url>
+			<url>https://oss.sonatype.org/content/repositories/comhederahashgraph-1531</url>
 		</repository>
 		<repository>
 			<snapshots>
@@ -233,14 +233,14 @@
 		<ethereum-core.version>1.12.0-v0.5.0</ethereum-core.version>
 		<grpc.version>1.39.0</grpc.version>
 		<guava.version>31.1-jre</guava.version>
-		<hapi-proto.version>0.27.0</hapi-proto.version>
+		<hapi-proto.version>0.28.0-alpha.1</hapi-proto.version>
 		<headlong.version>6.1.1</headlong.version>
 		<javax.annotation-api.version>1.3.2</javax.annotation-api.version>
 		<javax-inject.version>1</javax-inject.version>
 		<log4j.version>2.17.2</log4j.version>
 		<netty.version>4.1.66.Final</netty.version>
 		<protobuf-java.version>3.19.4</protobuf-java.version>
-		<swirlds.version>0.27.0</swirlds.version>
+		<swirlds.version>0.27.1</swirlds.version>
 		<tuweni.version>2.2.0</tuweni.version>
 
 		<!-- Test dependency properties in alphabetical order -->

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -45,7 +45,7 @@ dependencyResolutionManagement {
             version("eddsa-version", "0.3.0")
             version("grpc-version", "1.39.0")
             version("guava-version", "31.1-jre")
-            version("hapi-version", "0.27.0")
+            version("hapi-version", "0.28.0-alpha.1")
             version("headlong-version", "6.1.1")
             version("jackson-version", "2.12.6.1")
             version("javax-annotation-version", "1.3.2")


### PR DESCRIPTION
**Description**:
 - Uses `0.28.0-alpha.1` protobuf and `0.27.1` SDK.