### PR TITLE
HTS Tokens emit events with wrong emitter address

### DIFF
--- a/hedera-node/src/main/java/com/hedera/services/store/contracts/precompile/impl/ERCTransferPrecompile.java
+++ b/hedera-node/src/main/java/com/hedera/services/store/contracts/precompile/impl/ERCTransferPrecompile.java
@@ -131,7 +131,7 @@ public class ERCTransferPrecompile extends TransferPrecompile {
 				sender = super.ledgers.canonicalAddress(asTypedEvmAddress(fungibleTransfer.sender()));
 			}
 			if (fungibleTransfer.receiver() != null) {
-				receiver = super.ledgers.canonicalAddress(asTypedEvmAddress(fungibleTransfer.receiver()));;
+				receiver = super.ledgers.canonicalAddress(asTypedEvmAddress(fungibleTransfer.receiver()));
 				amount = BigInteger.valueOf(fungibleTransfer.amount());
 			}
 		}

--- a/hedera-node/src/main/java/com/hedera/services/store/contracts/precompile/impl/ERCTransferPrecompile.java
+++ b/hedera-node/src/main/java/com/hedera/services/store/contracts/precompile/impl/ERCTransferPrecompile.java
@@ -48,7 +48,6 @@ import java.math.BigInteger;
 import java.util.function.UnaryOperator;
 
 import static com.hedera.services.exceptions.ValidationUtils.validateTrueOrRevert;
-import static com.hedera.services.store.contracts.precompile.HTSPrecompiledContract.HTS_PRECOMPILED_CONTRACT_ADDRESS;
 import static com.hedera.services.utils.EntityIdUtils.asTypedEvmAddress;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_TOKEN_NFT_SERIAL_NUMBER;
 
@@ -115,12 +114,10 @@ public class ERCTransferPrecompile extends TransferPrecompile {
 			throw InvalidTransactionException.fromReverting(e.getResponseCode());
 		}
 
-		final var precompileAddress = Address.fromHexString(HTS_PRECOMPILED_CONTRACT_ADDRESS);
-
 		if (isFungible) {
-			frame.addLog(getLogForFungibleTransfer(precompileAddress));
+			frame.addLog(getLogForFungibleTransfer(asTypedEvmAddress(tokenID)));
 		} else {
-			frame.addLog(getLogForNftExchange(precompileAddress));
+			frame.addLog(getLogForNftExchange(asTypedEvmAddress(tokenID)));
 		}
 	}
 
@@ -131,10 +128,10 @@ public class ERCTransferPrecompile extends TransferPrecompile {
 		BigInteger amount = BigInteger.ZERO;
 		for (final var fungibleTransfer : fungibleTransfers) {
 			if (fungibleTransfer.sender() != null) {
-				sender = asTypedEvmAddress(fungibleTransfer.sender());
+				sender = super.ledgers.canonicalAddress(asTypedEvmAddress(fungibleTransfer.sender()));
 			}
 			if (fungibleTransfer.receiver() != null) {
-				receiver = asTypedEvmAddress(fungibleTransfer.receiver());
+				receiver = super.ledgers.canonicalAddress(asTypedEvmAddress(fungibleTransfer.receiver()));;
 				amount = BigInteger.valueOf(fungibleTransfer.amount());
 			}
 		}
@@ -149,8 +146,8 @@ public class ERCTransferPrecompile extends TransferPrecompile {
 	private Log getLogForNftExchange(final Address logger) {
 		final var nftExchanges = transferOp.get(0).nftExchanges();
 		final var nftExchange = nftExchanges.get(0).asGrpc();
-		final var sender = asTypedEvmAddress(nftExchange.getSenderAccountID());
-		final var receiver = asTypedEvmAddress(nftExchange.getReceiverAccountID());
+		final var sender = super.ledgers.canonicalAddress(asTypedEvmAddress(nftExchange.getSenderAccountID()));
+		final var receiver = super.ledgers.canonicalAddress(asTypedEvmAddress(nftExchange.getReceiverAccountID()));
 		final var serialNumber = nftExchange.getSerialNumber();
 
 		return EncodingFacade.LogBuilder.logBuilder().forLogger(logger)

--- a/hedera-node/src/test/java/com/hedera/services/store/contracts/precompile/ERC721PrecompilesTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/store/contracts/precompile/ERC721PrecompilesTest.java
@@ -147,6 +147,7 @@ import static com.hedera.services.store.contracts.precompile.HTSTestsUtil.serial
 import static com.hedera.services.store.contracts.precompile.HTSTestsUtil.successResult;
 import static com.hedera.services.store.contracts.precompile.HTSTestsUtil.timestamp;
 import static com.hedera.services.store.contracts.precompile.HTSTestsUtil.token;
+import static com.hedera.services.store.contracts.precompile.HTSTestsUtil.tokenAddress;
 import static com.hedera.services.store.contracts.precompile.HTSTestsUtil.tokenTransferChanges;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.FAIL_INVALID;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_ALLOWANCE_OWNER_ID;
@@ -267,6 +268,7 @@ class ERC721PrecompilesTest {
         entityIdUtils.when(() -> EntityIdUtils.contractIdFromEvmAddress(Address.fromHexString(HTS_PRECOMPILED_CONTRACT_ADDRESS).toArray()))
                 .thenReturn(precompiledContract);
         entityIdUtils.when(() -> EntityIdUtils.accountIdFromEvmAddress(senderAddress)).thenReturn(sender);
+		entityIdUtils.when(() -> EntityIdUtils.asTypedEvmAddress(token)).thenReturn(tokenAddress);
         entityIdUtils.when(() -> EntityIdUtils.asTypedEvmAddress(sender)).thenReturn(senderAddress);
         entityIdUtils.when(() -> EntityIdUtils.asTypedEvmAddress(receiver)).thenReturn(recipientAddress);
 		entityIdUtils.when(() -> EntityIdUtils.asEvmAddress(0, 0, 3)).thenReturn(RIPEMD160.toArray());
@@ -1043,7 +1045,6 @@ class ERC721PrecompilesTest {
 		given(impliedTransfersMarshal.validityWithCurrentProps(cryptoTransferTransactionBody)).willReturn(OK);
 		given(sigsVerifier.hasActiveKey(Mockito.anyBoolean(), any(), any(), any())).willReturn(true);
 		given(dynamicProperties.areAllowancesEnabled()).willReturn(true);
-
 		given(infrastructureFactory.newHederaTokenStore(sideEffects, tokens, nfts, tokenRels)).willReturn(hederaTokenStore);
 
 		given(infrastructureFactory.newTransferLogic(
@@ -1069,10 +1070,19 @@ class ERC721PrecompilesTest {
 				.willReturn(Collections.singletonList(TOKEN_TRANSFER_WRAPPER));
 		final var nftId = NftId.fromGrpc(token, serialNumber);
 		given(wrappedLedgers.nfts()).willReturn(nfts);
+		given(wrappedLedgers.canonicalAddress(recipientAddress)).willReturn(recipientAddress);
+		given(wrappedLedgers.canonicalAddress(senderAddress)).willReturn(senderAddress);
 		given(nfts.contains(nftId)).willReturn(true);
 
 		given(aliases.resolveForEvm(any())).willAnswer(invocationOnMock -> invocationOnMock.getArgument(0));
 		given(worldUpdater.aliases()).willReturn(aliases);
+
+		final var log = EncodingFacade.LogBuilder.logBuilder().forLogger(tokenAddress)
+				.forEventSignature(AbiConstants.TRANSFER_EVENT)
+				.forIndexedArgument(senderAddress)
+				.forIndexedArgument(recipientAddress)
+				.forIndexedArgument(serialNumber)
+				.build();
 
 		// when:
 		subject.prepareFields(frame);
@@ -1087,6 +1097,7 @@ class ERC721PrecompilesTest {
 		verify(transferLogic).doZeroSum(tokenTransferChanges);
 		verify(wrappedLedgers).commit();
 		verify(worldUpdater).manageInProgressRecord(recordsHistorian, mockRecordBuilder, mockSynthBodyBuilder);
+		verify(frame).addLog(log);
 	}
 
 	@Test

--- a/hedera-node/src/test/java/com/hedera/services/store/contracts/precompile/HTSTestsUtil.java
+++ b/hedera-node/src/test/java/com/hedera/services/store/contracts/precompile/HTSTestsUtil.java
@@ -69,6 +69,7 @@ public class HTSTestsUtil {
 	public static final TokenID tokenMerkleId = IdUtils.asToken("0.0.777");
 	public static final Id accountId = Id.fromGrpcAccount(account);
 	public static final Address recipientAddr = Address.ALTBN128_ADD;
+	public static final Address tokenAddress = Address.ECREC;
 	public static final Address contractAddr = Address.ALTBN128_MUL;
 	public static final Address senderAddress = Address.ALTBN128_PAIRING;
 	public static final Address parentContractAddress = Address.BLAKE2B_F_COMPRESSION;


### PR DESCRIPTION
**Description**:
With this PR we are changing the value of address field in the log of the emitted event after transfer from hts precompiled contract address(0x167) to EVM_ADDRES_OF_HTS_TOKEN.
Also changed the way of loading the addresses of the sender and receiver fields(check whether they're aliased).

**Related issue(s)**: #3530 

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
