### PR TITLE
Add spotless support which also manages license headers automatically.

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -35,4 +35,5 @@ repositories {
 dependencies {
     implementation("org.sonarsource.scanner.gradle:sonarqube-gradle-plugin:3.3")
     implementation("me.champeau.jmh:jmh-gradle-plugin:0.6.6")
+    implementation("com.diffplug.spotless:spotless-plugin-gradle:6.7.2")
 }

--- a/buildSrc/src/main/kotlin/com.hedera.hashgraph.hedera-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/com.hedera.hashgraph.hedera-conventions.gradle.kts
@@ -23,6 +23,7 @@ plugins {
     `maven-publish`
     jacoco
     id("org.sonarqube")
+    id("com.diffplug.spotless")
 }
 
 group = "com.hedera.hashgraph"
@@ -63,6 +64,47 @@ repositories {
     maven {
         url = uri("https://oss.sonatype.org/content/repositories/comhederahashgraph-1531")
     }
+}
+
+spotless {
+    // optional: limit format enforcement to just the files changed by this feature branch
+    ratchetFrom("origin/master")
+
+    format("misc", {
+        // define the files to apply `misc` to
+        target("*.gradle", "*.md", ".gitignore")
+
+        // define the steps to apply to those files
+        trimTrailingWhitespace()
+        indentWithSpaces()
+        endWithNewline()
+    })
+    java({
+        // don't need to set target, it is inferred from java
+
+        // apply a specific flavor of google-java-format
+        googleJavaFormat().aosp().reflowLongStrings()
+        // make sure every file has the following copyright header.
+        // optionally, Spotless can set copyright years by digging
+        // through git history (see "license" section below)
+        licenseHeader("""
+           /*
+            * Copyright (C) ${'$'}YEAR Hedera Hashgraph, LLC
+            *
+            * Licensed under the Apache License, Version 2.0 (the "License");
+            * you may not use this file except in compliance with the License.
+            * You may obtain a copy of the License at
+            *
+            *      http://www.apache.org/licenses/LICENSE-2.0
+            *
+            * Unless required by applicable law or agreed to in writing, software
+            * distributed under the License is distributed on an "AS IS" BASIS,
+            * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+            * See the License for the specific language governing permissions and
+            * limitations under the License.
+            */ 
+        """.trimIndent())
+    })
 }
 
 // Enable maven publications


### PR DESCRIPTION
Signed-off-by: Richard Bair <richard.bair@swirldslabs.com>
