### PR TITLE
Add `contracts.chainId=296` to testnet bootstrap overrides

### DIFF
--- a/hedera-node/configuration/testnet/bootstrap.properties
+++ b/hedera-node/configuration/testnet/bootstrap.properties
@@ -1,1 +1,2 @@
 ledger.id=0x01
+contracts.chainId=296


### PR DESCRIPTION
**Description**:
- Pending merge of https://github.com/hashgraph/hedera-services/pull/3635, update testnet _bootstrap.properties_ to ensure a genesis reconnect yields `EVM` instances with the expected `CHAINID`.