### PR TITLE
Start genesis `blockNo` at 0 since no longer a risk of false numbering

### DIFF
--- a/hedera-node/src/main/java/com/hedera/services/contracts/execution/StaticBlockMetaSource.java
+++ b/hedera-node/src/main/java/com/hedera/services/contracts/execution/StaticBlockMetaSource.java
@@ -9,9 +9,9 @@ package com.hedera.services.contracts.execution;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -53,17 +53,13 @@ public class StaticBlockMetaSource implements BlockMetaSource {
 	@Override
 	public BlockValues computeBlockValues(final long gasLimit) {
 		final var nominalBlockNo = networkCtx.getAlignmentBlockNo();
-		if (nominalBlockNo < 0) {
-			var nominalTimestamp = networkCtx.firstConsTimeOfCurrentBlock();
-			// This is exceedingly unlikely in practice, as it requires a ContractCallLocal query to run
-			// as exactly the first network interaction immediately the 0.26 upgrade; as there's no impact
-			// on consensus state, falling back to Instant.now() is acceptable
-			if (nominalTimestamp == null) {
-				nominalTimestamp = Instant.now();
-			}
-			return new HederaBlockValues(gasLimit, nominalTimestamp.getEpochSecond(), nominalTimestamp);
-		} else {
-			return new HederaBlockValues(gasLimit, nominalBlockNo, networkCtx.firstConsTimeOfCurrentBlock());
+		var nominalTimestamp = networkCtx.firstConsTimeOfCurrentBlock();
+		// This is exceedingly unlikely in practice, as it requires a ContractCallLocal query to run
+		// as exactly the first network interaction immediately after a genesis reset; as there's no
+		// impact on consensus state, falling back to Instant.now() is acceptable
+		if (nominalTimestamp == null) {
+			nominalTimestamp = Instant.now();
 		}
+		return new HederaBlockValues(gasLimit, nominalBlockNo, nominalTimestamp);
 	}
 }

--- a/hedera-node/src/main/java/com/hedera/services/state/logic/BlockManager.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/logic/BlockManager.java
@@ -132,11 +132,7 @@ public class BlockManager {
 	 */
 	public HederaBlockValues computeBlockValues(@NotNull final Instant now, final long gasLimit) {
 		ensureProvisionalBlockMeta(now);
-		if (provisionalBlockNo < 0) {
-			// Must be after 0.26 upgrade, but before the first block re-numbering
-			final var thisSecond = now.getEpochSecond();
-			return new HederaBlockValues(gasLimit, thisSecond, Instant.ofEpochSecond(thisSecond));
-		} else if (provisionalBlockIsNew) {
+		if (provisionalBlockIsNew) {
 			return new HederaBlockValues(gasLimit, provisionalBlockNo, Instant.ofEpochSecond(now.getEpochSecond()));
 		} else {
 			return new HederaBlockValues(gasLimit, provisionalBlockNo, networkCtx.get().firstConsTimeOfCurrentBlock());

--- a/hedera-node/src/main/java/com/hedera/services/state/merkle/MerkleNetworkContext.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/merkle/MerkleNetworkContext.java
@@ -110,7 +110,7 @@ public class MerkleNetworkContext extends AbstractMerkleLeaf {
 	private FunctionalityThrottling throttling = null;
 	private DeterministicThrottle.UsageSnapshot gasThrottleUsageSnapshot = NO_GAS_THROTTLE_SNAPSHOT;
 	private DeterministicThrottle.UsageSnapshot[] usageSnapshots = NO_SNAPSHOTS;
-	private long blockNo = Long.MIN_VALUE;
+	private long blockNo = 0L;
 	private Instant firstConsTimeOfCurrentBlock = null;
 	private FCQueue<BytesElement> blockHashes = new FCQueue<>();
 	private boolean stakingRewardsActivated;
@@ -865,7 +865,7 @@ public class MerkleNetworkContext extends AbstractMerkleLeaf {
 	}
 
 	@VisibleForTesting
-	void setBlockNo(final long blockNo) {
+	public void setBlockNo(final long blockNo) {
 		this.blockNo = blockNo;
 	}
 

--- a/hedera-node/src/test/java/com/hedera/services/contracts/execution/StaticBlockMetaSourceTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/contracts/execution/StaticBlockMetaSourceTest.java
@@ -60,25 +60,13 @@ class StaticBlockMetaSourceTest {
 	}
 
 	@Test
-	void blockValuesAreMixUntilSync() {
-		given(networkCtx.getAlignmentBlockNo()).willReturn(Long.MIN_VALUE);
-		given(networkCtx.firstConsTimeOfCurrentBlock()).willReturn(then);
-
-		final var ans = subject.computeBlockValues(gasLimit);
-
-		assertEquals(gasLimit, ans.getGasLimit());
-		assertEquals(then.getEpochSecond(), ans.getNumber());
-		assertEquals(then.getEpochSecond(), ans.getTimestamp());
-	}
-
-	@Test
 	void usesNowIfFirstConsTimeIsStillSomehowNull() {
-		given(networkCtx.getAlignmentBlockNo()).willReturn(Long.MIN_VALUE);
+		given(networkCtx.getAlignmentBlockNo()).willReturn(someBlockNo);
 
 		final var ans = subject.computeBlockValues(gasLimit);
 
 		assertEquals(gasLimit, ans.getGasLimit());
-		assertNotEquals(0, ans.getNumber());
+		assertEquals(someBlockNo, ans.getNumber());
 		assertNotEquals(0, ans.getTimestamp());
 	}
 

--- a/hedera-node/src/test/java/com/hedera/services/state/logic/BlockManagerTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/state/logic/BlockManagerTest.java
@@ -43,7 +43,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
@@ -137,25 +136,6 @@ class BlockManagerTest {
 		final var someHash = new RunningHash();
 		subject.updateCurrentBlockHash(someHash);
 		verify(runningHashLeaf).setRunningHash(someHash);
-	}
-
-	@Test
-	void keeps025BehaviorIfManagedBlockNumberStillNegative() {
-		given(networkContext.firstConsTimeOfCurrentBlock()).willReturn(aTime);
-		given(networkContext.getAlignmentBlockNo()).willReturn(Long.MIN_VALUE);
-
-		final var firstValues = subject.computeBlockValues(someTime, gasLimit);
-		final var secondValues = subject.computeBlockValues(someTime, gasLimit);
-
-		assertEquals(gasLimit, firstValues.getGasLimit());
-		assertEquals(someTime.getEpochSecond(), firstValues.getNumber());
-		assertEquals(someTime.getEpochSecond(), firstValues.getTimestamp());
-		// and:
-		assertEquals(gasLimit, secondValues.getGasLimit());
-		assertEquals(someTime.getEpochSecond(), secondValues.getNumber());
-		assertEquals(someTime.getEpochSecond(), secondValues.getTimestamp());
-		// and:
-		verify(networkContext, times(1)).getAlignmentBlockNo();
 	}
 
 	@Test

--- a/hedera-node/src/test/java/com/hedera/services/state/merkle/MerkleNetworkContextSerdeTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/state/merkle/MerkleNetworkContextSerdeTest.java
@@ -55,7 +55,7 @@ public class MerkleNetworkContextSerdeTest extends SelfSerializableDataTest<Merk
 		if (version < MerkleNetworkContext.RELEASE_0270_VERSION) {
 			final var seeded = SeededPropertySource.forSerdeTest(version, testCaseNo).next0260NetworkContext();
 			if (version < MerkleNetworkContext.RELEASE_0260_VERSION) {
-				seeded.setBlockNo(Long.MIN_VALUE);
+				seeded.setBlockNo(0L);
 				seeded.setFirstConsTimeOfCurrentBlock(null);
 				seeded.getBlockHashes().clear();
 			}

--- a/hedera-node/src/test/java/com/hedera/test/utils/SeededPropertySource.java
+++ b/hedera-node/src/test/java/com/hedera/test/utils/SeededPropertySource.java
@@ -500,6 +500,7 @@ public class SeededPropertySource {
 	public MerkleNetworkContext next0260NetworkContext() {
 		final var numThrottles = 5;
 		final var seeded = new MerkleNetworkContext();
+		seeded.setBlockNo(Long.MIN_VALUE);
 		seeded.setConsensusTimeOfLastHandledTxn(nextNullableInstant());
 		seeded.setSeqNo(nextSeqNo());
 		seeded.updateLastScannedEntity(nextInRangeLong());
@@ -529,6 +530,7 @@ public class SeededPropertySource {
 	public MerkleNetworkContext next0270NetworkContext() {
 		final var numThrottles = 5;
 		final var seeded = new MerkleNetworkContext();
+		seeded.setBlockNo(Long.MIN_VALUE);
 		seeded.setConsensusTimeOfLastHandledTxn(nextNullableInstant());
 		seeded.setSeqNo(nextSeqNo());
 		seeded.updateLastScannedEntity(nextInRangeLong());


### PR DESCRIPTION
**Description**:
 - Makes block numbers in dev environments more readable by starting from 0 after a reset (which should indeed be the correct number in a true genesis environment!)