### PR TITLE
Fix version management for mixed-release Services 0.27 + 0.26 SDK

### DIFF
--- a/hedera-node/src/main/java/com/hedera/services/ServicesState.java
+++ b/hedera-node/src/main/java/com/hedera/services/ServicesState.java
@@ -91,6 +91,7 @@ import static com.hedera.services.state.migration.StateVersions.CURRENT_VERSION;
 import static com.hedera.services.state.migration.StateVersions.FIRST_026X_VERSION;
 import static com.hedera.services.state.migration.StateVersions.FIRST_027X_VERSION;
 import static com.hedera.services.state.migration.StateVersions.MINIMUM_SUPPORTED_VERSION;
+import static com.hedera.services.state.migration.StateVersions.RELEASE_0270_VERSION;
 import static com.hedera.services.state.migration.StateVersions.lastSoftwareVersionOf;
 import static com.hedera.services.utils.EntityIdUtils.parseAccount;
 import static com.swirlds.common.system.InitTrigger.GENESIS;
@@ -184,9 +185,9 @@ public class ServicesState extends AbstractNaryMerkleInternal implements SwirldS
 
 	@Override
 	public int getMinimumChildCount(int version) {
-		if (version >= MINIMUM_SUPPORTED_VERSION && version < CURRENT_VERSION) {
+		if (version >= MINIMUM_SUPPORTED_VERSION && version < RELEASE_0270_VERSION) {
 			return NUM_POST_0210_CHILDREN;
-		} else if (version == CURRENT_VERSION) {
+		} else if (version >= RELEASE_0270_VERSION && version <= CURRENT_VERSION) {
 			return NUM_POST_0260_CHILDREN;
 		} else {
 			throw new IllegalArgumentException("Argument 'version='" + version + "' is invalid!");

--- a/hedera-node/src/main/java/com/hedera/services/state/migration/StateVersions.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/migration/StateVersions.java
@@ -50,21 +50,23 @@ public final class StateVersions {
 	public static final int RELEASE_025X_VERSION = 18;
 	public static final int RELEASE_0260_VERSION = 19;
 	public static final int RELEASE_0270_VERSION = 20;
+	public static final int RELEASE_0280_VERSION = 21;
 
-	public static final SerializableSemVers FIRST_025X_VERSION = forHapiAndHedera("0.25.1", "0.25.0");
 	public static final SerializableSemVers LAST_025X_VERSION = forHapiAndHedera("0.25.1", "0.25.4");
 	public static final SerializableSemVers FIRST_026X_VERSION = forHapiAndHedera("0.26.0", "0.26.0");
 	public static final SerializableSemVers LAST_026X_VERSION = forHapiAndHedera("0.26.0", "0.26.3");
 	public static final SerializableSemVers FIRST_027X_VERSION = forHapiAndHedera("0.27.0", "0.27.0");
+	public static final SerializableSemVers LAST_027X_VERSION = forHapiAndHedera("0.27.0", "0.27.3");
 
 	public static final int MINIMUM_SUPPORTED_VERSION = RELEASE_025X_VERSION;
-	public static final int CURRENT_VERSION = RELEASE_0270_VERSION;
+	public static final int CURRENT_VERSION = RELEASE_0280_VERSION;
 
 	@Nullable
 	public static SerializableSemVers lastSoftwareVersionOf(final int stateVersion) {
 		return switch (stateVersion) {
 			case RELEASE_025X_VERSION -> LAST_025X_VERSION;
 			case RELEASE_0260_VERSION -> LAST_026X_VERSION;
+			case RELEASE_0270_VERSION -> LAST_027X_VERSION;
 			default -> null;
 		};
 	}

--- a/hedera-node/src/test/java/com/hedera/services/ServicesStateTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/ServicesStateTest.java
@@ -545,6 +545,9 @@ class ServicesStateTest {
 				subject.getMinimumChildCount(StateVersions.RELEASE_0260_VERSION));
 		assertEquals(
 				StateChildIndices.NUM_POST_0260_CHILDREN,
+				subject.getMinimumChildCount(StateVersions.RELEASE_0270_VERSION));
+		assertEquals(
+				StateChildIndices.NUM_POST_0260_CHILDREN,
 				subject.getMinimumChildCount(StateVersions.CURRENT_VERSION));
 		assertThrows(IllegalArgumentException.class,
 				() -> subject.getMinimumChildCount(StateVersions.MINIMUM_SUPPORTED_VERSION - 1));

--- a/hedera-node/src/test/java/com/hedera/services/state/migration/StateVersionsTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/state/migration/StateVersionsTest.java
@@ -24,9 +24,11 @@ import org.junit.jupiter.api.Test;
 
 import static com.hedera.services.state.migration.StateVersions.LAST_025X_VERSION;
 import static com.hedera.services.state.migration.StateVersions.LAST_026X_VERSION;
+import static com.hedera.services.state.migration.StateVersions.LAST_027X_VERSION;
 import static com.hedera.services.state.migration.StateVersions.RELEASE_025X_VERSION;
 import static com.hedera.services.state.migration.StateVersions.RELEASE_0260_VERSION;
 import static com.hedera.services.state.migration.StateVersions.RELEASE_0270_VERSION;
+import static com.hedera.services.state.migration.StateVersions.RELEASE_0280_VERSION;
 import static com.hedera.services.state.migration.StateVersions.lastSoftwareVersionOf;
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -35,6 +37,7 @@ class StateVersionsTest {
 	void getsExpectedLastVersionsForSupportedMigrationsOnly() {
 		assertSame(LAST_025X_VERSION, lastSoftwareVersionOf(RELEASE_025X_VERSION));
 		assertSame(LAST_026X_VERSION, lastSoftwareVersionOf(RELEASE_0260_VERSION));
-		assertNull(lastSoftwareVersionOf(RELEASE_0270_VERSION));
+		assertSame(LAST_027X_VERSION, lastSoftwareVersionOf(RELEASE_0270_VERSION));
+		assertNull(lastSoftwareVersionOf(RELEASE_0280_VERSION));
 	}
 }


### PR DESCRIPTION
**Description**:
- Provide a placeholder `SoftwareVersion` for 0.27.x Services states since they are using an 0.26.x SDK.