### PR TITLE
Make `AddressBook` stakes queryable via `0.0.102`

### DIFF
--- a/hedera-node/src/main/java/com/hedera/services/ServicesMain.java
+++ b/hedera-node/src/main/java/com/hedera/services/ServicesMain.java
@@ -66,7 +66,7 @@ public class ServicesMain implements SwirldMain {
 	}
 
 	@Override
-	public void init(Platform ignore, NodeId nodeId) {
+	public void init(final Platform ignore, final NodeId nodeId) {
 		try {
 			app = APPS.get(nodeId.getId());
 			initApp();

--- a/hedera-node/src/main/java/com/hedera/services/ServicesState.java
+++ b/hedera-node/src/main/java/com/hedera/services/ServicesState.java
@@ -92,10 +92,10 @@ import static com.hedera.services.state.migration.StateVersions.FIRST_026X_VERSI
 import static com.hedera.services.state.migration.StateVersions.FIRST_027X_VERSION;
 import static com.hedera.services.state.migration.StateVersions.FIRST_028X_VERSION;
 import static com.hedera.services.state.migration.StateVersions.MINIMUM_SUPPORTED_VERSION;
-import static com.hedera.services.state.migration.StateVersions.RELEASE_0270_VERSION;
 import static com.hedera.services.state.migration.StateVersions.lastSoftwareVersionOf;
 import static com.hedera.services.utils.EntityIdUtils.parseAccount;
 import static com.swirlds.common.system.InitTrigger.GENESIS;
+import static com.swirlds.common.system.InitTrigger.RECONNECT;
 import static com.swirlds.common.system.InitTrigger.RESTART;
 
 /**
@@ -323,6 +323,10 @@ public class ServicesState extends PartialNaryMerkleInternal implements MerkleIn
 			if (trigger == GENESIS) {
 				app.sysAccountsCreator().ensureSystemAccounts(app.backingAccounts(), app.workingState().addressBook());
 				app.sysFilesManager().createManagedFilesIfMissing();
+			}
+			if (trigger != RECONNECT) {
+				// Once we have a dynamic address book, this will run unconditionally
+				app.sysFilesManager().updateStakeDetails();
 			}
 		}
 	}

--- a/hedera-node/src/main/java/com/hedera/services/context/init/StoreInitializationFlow.java
+++ b/hedera-node/src/main/java/com/hedera/services/context/init/StoreInitializationFlow.java
@@ -84,10 +84,6 @@ public class StoreInitializationFlow {
 		backingNfts.rebuildFromSources();
 		log.info("Backing stores rebuilt");
 
-		tokenStore.rebuildViews();
-		scheduleStore.rebuildViews();
-		log.info("Store internal views rebuilt");
-
 		aliasManager.rebuildAliasesMap(workingState.accounts(), (num, account) -> {
 			if (account.isSmartContract()) {
 				usageLimits.recordContracts(1);

--- a/hedera-node/src/main/java/com/hedera/services/ledger/interceptors/StakingAccountsCommitInterceptor.java
+++ b/hedera-node/src/main/java/com/hedera/services/ledger/interceptors/StakingAccountsCommitInterceptor.java
@@ -248,7 +248,7 @@ public class StakingAccountsCommitInterceptor extends AccountsCommitInterceptor 
 	}
 
 	private long rewardableStartStakeFor(final MerkleAccount account) {
-		if (account.isDeclinedReward()) {
+		if (!rewardsActivated || account.isDeclinedReward()) {
 			return 0;
 		}
 		final var startPeriod = account.getStakePeriodStart();

--- a/hedera-node/src/main/java/com/hedera/services/state/initialization/HfsSystemFilesManager.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/initialization/HfsSystemFilesManager.java
@@ -140,7 +140,6 @@ public final class HfsSystemFilesManager implements SystemFilesManager {
 				log.info("Updated node{} stake to {}", nodeId, stake);
 			}
 			final var replacement = newBuilder.build();
-			System.out.println(replacement);
 			hfs.getData().put(detailsFid, replacement.toByteArray());
 		} catch (Exception e) {
 			log.error("Existing address book was missing or corrupt", e);

--- a/hedera-node/src/main/java/com/hedera/services/state/initialization/HfsSystemFilesManager.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/initialization/HfsSystemFilesManager.java
@@ -37,6 +37,7 @@ import com.hederahashgraph.api.proto.java.ExchangeRate;
 import com.hederahashgraph.api.proto.java.ExchangeRateSet;
 import com.hederahashgraph.api.proto.java.FileID;
 import com.hederahashgraph.api.proto.java.NodeAddress;
+import com.hederahashgraph.api.proto.java.NodeAddressBook;
 import com.hederahashgraph.api.proto.java.ServiceEndpoint;
 import com.hederahashgraph.api.proto.java.ServicesConfigurationList;
 import com.hederahashgraph.api.proto.java.Setting;
@@ -56,7 +57,9 @@ import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
@@ -113,6 +116,35 @@ public final class HfsSystemFilesManager implements SystemFilesManager {
 	@Override
 	public void createNodeDetailsIfMissing() {
 		writeFromBookIfMissing(fileNumbers.nodeDetails(), this::platformAddressBookToGrpc);
+	}
+
+	@Override
+	public void updateStakeDetails() {
+		final var book = bookSupplier.get();
+		final Map<Long, Long> stakes = new HashMap<>();
+		for (int i = 0, n = book.getSize(); i < n; i++) {
+			final var address = book.getAddress(i);
+			stakes.put(address.getId(), address.getStake());
+		}
+
+		final var detailsFid = fileNumbers.toFid(fileNumbers.nodeDetails());
+		final var extant = hfs.getData().get(detailsFid);
+		try {
+			final var oldBook = NodeAddressBook.parseFrom(extant);
+			final var newBuilder = oldBook.toBuilder();
+			for (int i = 0, n = oldBook.getNodeAddressCount(); i < n; i++) {
+				final var entry = oldBook.getNodeAddress(i);
+				final var nodeId = entry.getNodeId();
+				final var stake = stakes.getOrDefault(nodeId, 0L);
+				newBuilder.setNodeAddress(i, entry.toBuilder().setStake(stake).build());
+				log.info("Updated node{} stake to {}", nodeId, stake);
+			}
+			final var replacement = newBuilder.build();
+			System.out.println(replacement);
+			hfs.getData().put(detailsFid, replacement.toByteArray());
+		} catch (Exception e) {
+			log.error("Existing address book was missing or corrupt", e);
+		}
 	}
 
 	@Override
@@ -348,8 +380,8 @@ public final class HfsSystemFilesManager implements SystemFilesManager {
 				.sorted(Comparator.comparing(entry -> String.valueOf(entry.getKey())))
 				.peek(entry -> intoSb.append(String.format(
 						"\n  %s=%s",
-						String.valueOf(entry.getKey()),
-						String.valueOf(entry.getValue()))))
+						entry.getKey(),
+						entry.getValue())))
 				.forEach(entry ->
 						config.addNameValue(Setting.newBuilder()
 								.setName(String.valueOf(entry.getKey()))
@@ -380,7 +412,7 @@ public final class HfsSystemFilesManager implements SystemFilesManager {
 		return basics.build().toByteArray();
 	}
 
-	private NodeAddress.Builder basicBioEntryFrom(final Address address) {
+	static NodeAddress.Builder basicBioEntryFrom(final Address address) {
 		final var builder = NodeAddress.newBuilder()
 				.setIpAddress(ByteString.copyFromUtf8(ipString(address.getAddressExternalIpv4())))
 				.setRSAPubKey(CommonUtils.hex(address.getSigPublicKey().getEncoded()))

--- a/hedera-node/src/main/java/com/hedera/services/state/initialization/SystemFilesManager.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/initialization/SystemFilesManager.java
@@ -23,6 +23,7 @@ package com.hedera.services.state.initialization;
 public interface SystemFilesManager {
 	void createAddressBookIfMissing();
 	void createNodeDetailsIfMissing();
+	void updateStakeDetails();
 	void createUpdateFilesIfMissing();
 
 	default void createManagedFilesIfMissing() {

--- a/hedera-node/src/main/java/com/hedera/services/state/logic/NetworkCtxManager.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/logic/NetworkCtxManager.java
@@ -119,7 +119,7 @@ public class NetworkCtxManager {
 	public void loadObservableSysFilesIfNeeded() {
 		if (!systemFilesManager.areObservableFilesLoaded()) {
 			var networkCtxNow = networkCtx.get();
-			log.info("Observable files not yet loaded, doing now.");
+			log.info("Observable files not yet loaded, doing now");
 			systemFilesManager.loadObservableSystemFiles();
 			log.info("Loaded observable files");
 			networkCtxNow.resetThrottlingFromSavedSnapshots(handleThrottling);

--- a/hedera-node/src/main/java/com/hedera/services/state/merkle/MerkleStakingInfo.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/merkle/MerkleStakingInfo.java
@@ -172,8 +172,8 @@ public class MerkleStakingInfo extends PartialMerkleLeaf implements Keyed<Entity
 	public void increaseUnclaimedStakeRewardStart(final long amount) {
 		unclaimedStakeRewardStart += amount;
 		if (unclaimedStakeRewardStart > stakeRewardStart) {
-			log.warn("Asked to release {} stake reward start for node{}, but only {} was staked",
-					number, unclaimedStakeRewardStart, stakeRewardStart);
+			log.warn("Asked to release {} more rewards for node{} (now {}), but only {} was staked",
+					amount, number, unclaimedStakeRewardStart, stakeRewardStart);
 			unclaimedStakeRewardStart = stakeRewardStart;
 		}
 	}

--- a/hedera-node/src/main/java/com/hedera/services/state/merkle/MerkleStakingInfo.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/merkle/MerkleStakingInfo.java
@@ -40,6 +40,7 @@ import javax.annotation.Nullable;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.math.BigInteger;
 import java.util.Arrays;
 import java.util.Objects;
 
@@ -138,9 +139,13 @@ public class MerkleStakingInfo extends PartialMerkleLeaf implements Keyed<Entity
 			perHbarRateThisNode = perHbarRate;
 			// But if the node had more the maximum stakeRewardStart, "down-scale" its reward rate to
 			// ensure the accounts staking to this node will receive a fraction of the total rewards that
-			// does not exceed node.stakedRewardStart / totalStakedRewardedStart
+			// does not exceed node.stakedRewardStart / totalStakedRewardedStart; use arbitrary-precision
+			// arithmetic because there is no inherent bound on (maxStake * perHbarRateThisNode)
 			if (stakeRewardStart > maxStake) {
-				perHbarRateThisNode = (perHbarRateThisNode * maxStake) / stakeRewardStart;
+				perHbarRateThisNode = BigInteger.valueOf(perHbarRateThisNode)
+						.multiply(BigInteger.valueOf(maxStake))
+						.divide(BigInteger.valueOf(stakeRewardStart))
+						.longValueExact();
 			}
 		}
 		perHbarRateThisNode = Math.min(perHbarRateThisNode, maxPerHbarRate);

--- a/hedera-node/src/main/java/com/hedera/services/store/Store.java
+++ b/hedera-node/src/main/java/com/hedera/services/store/Store.java
@@ -41,10 +41,6 @@ public interface Store<T, K> {
     void setHederaLedger(HederaLedger ledger);
     void setAccountsLedger(TransactionalLedger<AccountID, AccountProperty, MerkleAccount> accountsLedger);
 
-    default void rebuildViews() {
-        // No-op
-    }
-
     void commitCreation();
     void rollbackCreation();
     boolean isCreationPending();

--- a/hedera-node/src/test/java/com/hedera/services/ServicesStateTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/ServicesStateTest.java
@@ -560,6 +560,7 @@ class ServicesStateTest {
 		given(app.hashLogger()).willReturn(hashLogger);
 		given(app.initializationFlow()).willReturn(initFlow);
 		given(app.dualStateAccessor()).willReturn(dualStateAccessor);
+		given(app.sysFilesManager()).willReturn(systemFilesManager);
 		given(platform.getSelfId()).willReturn(selfId);
 
 		APPS.save(selfId.getId(), app);
@@ -682,6 +683,7 @@ class ServicesStateTest {
 		given(app.initializationFlow()).willReturn(initFlow);
 		given(app.dualStateAccessor()).willReturn(dualStateAccessor);
 		given(platform.getSelfId()).willReturn(selfId);
+		given(app.sysFilesManager()).willReturn(systemFilesManager);
 		// and:
 		APPS.save(selfId.getId(), app);
 
@@ -714,6 +716,7 @@ class ServicesStateTest {
 		given(app.initializationFlow()).willReturn(initFlow);
 		given(app.dualStateAccessor()).willReturn(dualStateAccessor);
 		given(platform.getSelfId()).willReturn(selfId);
+		given(app.sysFilesManager()).willReturn(systemFilesManager);
 		// and:
 		APPS.save(selfId.getId(), app);
 
@@ -773,6 +776,7 @@ class ServicesStateTest {
 		given(app.initializationFlow()).willReturn(initFlow);
 		given(app.dualStateAccessor()).willReturn(dualStateAccessor);
 		given(platform.getSelfId()).willReturn(selfId);
+		given(app.sysFilesManager()).willReturn(systemFilesManager);
 		// and:
 		APPS.save(selfId.getId(), app);
 

--- a/hedera-node/src/test/java/com/hedera/services/context/init/StoreInitializationFlowTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/context/init/StoreInitializationFlowTest.java
@@ -104,8 +104,6 @@ class StoreInitializationFlowTest {
 		verify(backingTokenRels).rebuildFromSources();
 		verify(backingAccounts).rebuildFromSources();
 		verify(backingNfts).rebuildFromSources();
-		verify(tokenStore).rebuildViews();
-		verify(scheduleStore).rebuildViews();
 		verify(aliasManager).rebuildAliasesMap(eq(accounts), captor.capture());
 		final var observer = captor.getValue();
 		observer.accept(EntityNum.fromInt(1), MerkleAccountFactory.newAccount().get());

--- a/hedera-node/src/test/java/com/hedera/services/ledger/LedgerBalanceChangesTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/ledger/LedgerBalanceChangesTest.java
@@ -168,7 +168,6 @@ class LedgerBalanceChangesTest {
 				accountsLedger, nftsLedger, tokenRelsLedger, tokenStore,
 				sideEffectsTracker, dynamicProperties, validator,
 				autoCreationLogic, historian);
-		tokenStore.rebuildViews();
 
 		subject = new HederaLedger(
 				tokenStore, ids, creator, validator, sideEffectsTracker,
@@ -270,7 +269,6 @@ class LedgerBalanceChangesTest {
 				historian, tokensLedger, accountsLedger, transferLogic, autoCreationLogic);
 		subject.setTokenRelsLedger(tokenRelsLedger);
 		subject.setMutableEntityAccess(mutableEntityAccess);
-		tokenStore.rebuildViews();
 		givenUnexpiredEntities();
 
 		givenInitialBalancesAndOwnership();

--- a/hedera-node/src/test/java/com/hedera/services/ledger/interceptors/StakingAccountsCommitInterceptorTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/ledger/interceptors/StakingAccountsCommitInterceptorTest.java
@@ -248,6 +248,23 @@ class StakingAccountsCommitInterceptorTest {
 	}
 
 	@Test
+	void anAccountDoesNotUnclaimRewardsIfStakingNotActivated() {
+		given(dynamicProperties.isStakingEnabled()).willReturn(true);
+		final var changes = new EntityChangeSet<AccountID, MerkleAccount, AccountProperty>();
+		final var node0Info = stakingInfo.get(node0Id);
+		node0Info.setStakeRewardStart(2 * counterpartyBalance);
+
+		final Map<AccountProperty, Object> nodeChange = Map.of(AccountProperty.STAKED_ID, -2L);
+		changes.include(counterpartyId, counterparty, nodeChange);
+		counterparty.setStakePeriodStart(stakePeriodStart);
+		counterparty.setStakeAtStartOfLastRewardedPeriod(counterpartyBalance / 5);
+
+		subject.preview(changes);
+
+		assertEquals(0, node0Info.getUnclaimedStakeRewardStart());
+	}
+
+	@Test
 	void anAccountThatStartedStakingAtCurrentPeriodDoesntUnclaimStakeWhenChangingElection() {
 		given(dynamicProperties.isStakingEnabled()).willReturn(true);
 		final var changes = new EntityChangeSet<AccountID, MerkleAccount, AccountProperty>();

--- a/hedera-node/src/test/java/com/hedera/services/state/merkle/MerkleStakingInfoTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/state/merkle/MerkleStakingInfoTest.java
@@ -277,6 +277,9 @@ class MerkleStakingInfoTest {
 	void cannotUnclaimMoreThanStakedRewardStart() {
 		subject.increaseUnclaimedStakeRewardStart(stakeRewardStart - unclaimedStakeRewardStart + 1);
 		assertEquals(stakeRewardStart, subject.getUnclaimedStakeRewardStart());
+		assertEquals(
+				"Asked to release 1112 more rewards for node34 (now 1235), but only 1234 was staked",
+				logCaptor.warnLogs().get(0));
 	}
 
 	@Test

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/utils/sysfiles/BookEntryPojo.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/utils/sysfiles/BookEntryPojo.java
@@ -22,13 +22,14 @@ import com.hedera.services.legacy.proto.utils.CommonUtils;
 import com.hedera.services.yahcli.commands.files.SysFileUploadCommand;
 import com.hederahashgraph.api.proto.java.NodeAddress;
 import com.hederahashgraph.api.proto.java.ServiceEndpoint;
+import org.junit.jupiter.api.Assertions;
+
 import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
-import org.junit.jupiter.api.Assertions;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class BookEntryPojo {
@@ -181,12 +182,23 @@ public class BookEntryPojo {
         if (description != null) {
             grpc.setDescription(description);
         }
+        if (stake != null) {
+            grpc.setStake(stake);
+        }
 
         return Stream.of(grpc.build());
     }
 
     private static void mapEndpoints(NodeAddress from, BookEntryPojo to) {
         to.endpoints = from.getServiceEndpointList().stream().map(EndpointPojo::fromGrpc).toList();
+    }
+
+    public Long getStake() {
+        return stake;
+    }
+
+    public void setStake(Long stake) {
+        this.stake = stake;
     }
 
     public String getDeprecatedIp() {


### PR DESCRIPTION
**Description**:

Closes #3610 
 - On a non-`RECONNECT` initialization, updates the `NodeAddress#stake` fields in file `0.0.102` with the stakes from the platform `AddressBook`. (Post-dynamic `AddressBook`, this needs to be done on reconnect as well.)
 - Fixes the last two bugs mentioned [here](https://www.notion.so/swirldslabs/b6b6a2a1af194e6d95cd541e6ace1031?v=946b21412e9d4caea2d291581d5a5c81).
 - Removes the now-unused `Store.rebuildViews()` method.
 - Updates `BookEntryPojo` to support `stake` in yahcli transactions (does not yet push a `yahcli:0.2.2`).
