### PR TITLE
AOSP Code reformat hedera-node contract dirs

### DIFF
--- a/hedera-node/src/main/java/com/hedera/services/contracts/ContractsModule.java
+++ b/hedera-node/src/main/java/com/hedera/services/contracts/ContractsModule.java
@@ -20,6 +20,13 @@ package com.hedera.services.contracts;
  * ‍
  */
 
+import static com.hedera.services.contracts.sources.AddressKeyedMapFactory.bytecodeMapFrom;
+import static com.hedera.services.contracts.sources.AddressKeyedMapFactory.storageMapFrom;
+import static com.hedera.services.files.EntityExpiryMapFactory.entityExpiryMapFrom;
+import static com.hedera.services.store.contracts.precompile.ExchangeRatePrecompiledContract.EXCHANGE_RATE_SYSTEM_CONTRACT_ADDRESS;
+import static com.hedera.services.store.contracts.precompile.HTSPrecompiledContract.HTS_PRECOMPILED_CONTRACT_ADDRESS;
+import static com.hedera.services.store.contracts.precompile.PrngSystemPrecompiledContract.PRNG_PRECOMPILE_ADDRESS;
+
 import com.hedera.services.context.TransactionContext;
 import com.hedera.services.contracts.annotations.BytecodeSource;
 import com.hedera.services.contracts.annotations.StorageSource;
@@ -64,210 +71,200 @@ import dagger.Provides;
 import dagger.multibindings.IntoMap;
 import dagger.multibindings.IntoSet;
 import dagger.multibindings.StringKey;
+import java.util.Map;
+import java.util.function.BiPredicate;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import javax.inject.Singleton;
 import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.evm.frame.MessageFrame;
 import org.hyperledger.besu.evm.gascalculator.GasCalculator;
 import org.hyperledger.besu.evm.operation.Operation;
 import org.hyperledger.besu.evm.precompile.PrecompiledContract;
 
-import javax.inject.Singleton;
-import java.util.Map;
-import java.util.function.BiPredicate;
-import java.util.function.Supplier;
-import java.util.stream.Collectors;
-
-import static com.hedera.services.contracts.sources.AddressKeyedMapFactory.bytecodeMapFrom;
-import static com.hedera.services.contracts.sources.AddressKeyedMapFactory.storageMapFrom;
-import static com.hedera.services.files.EntityExpiryMapFactory.entityExpiryMapFrom;
-import static com.hedera.services.store.contracts.precompile.ExchangeRatePrecompiledContract.EXCHANGE_RATE_SYSTEM_CONTRACT_ADDRESS;
-import static com.hedera.services.store.contracts.precompile.HTSPrecompiledContract.HTS_PRECOMPILED_CONTRACT_ADDRESS;
-import static com.hedera.services.store.contracts.precompile.PrngSystemPrecompiledContract.PRNG_PRECOMPILE_ADDRESS;
-
-@Module(includes = {
-		StoresModule.class
-})
+@Module(includes = {StoresModule.class})
 public interface ContractsModule {
-	@Binds
-	@Singleton
-	HederaMutableWorldState provideMutableWorldState(HederaWorldState hederaWorldState);
+    @Binds
+    @Singleton
+    HederaMutableWorldState provideMutableWorldState(HederaWorldState hederaWorldState);
 
-	@Provides
-	@Singleton
-	@BytecodeSource
-	static Map<byte[], byte[]> provideBytecodeSource(Map<String, byte[]> blobStore) {
-		return bytecodeMapFrom(blobStore);
-	}
+    @Provides
+    @Singleton
+    @BytecodeSource
+    static Map<byte[], byte[]> provideBytecodeSource(Map<String, byte[]> blobStore) {
+        return bytecodeMapFrom(blobStore);
+    }
 
-	@Provides
-	@Singleton
-	@StorageSource
-	static Map<byte[], byte[]> provideStorageSource(Map<String, byte[]> blobStore) {
-		return storageMapFrom(blobStore);
-	}
+    @Provides
+    @Singleton
+    @StorageSource
+    static Map<byte[], byte[]> provideStorageSource(Map<String, byte[]> blobStore) {
+        return storageMapFrom(blobStore);
+    }
 
-	@Provides
-	@Singleton
-	static Map<EntityId, Long> provideEntityExpiries(Map<String, byte[]> blobStore) {
-		return entityExpiryMapFrom(blobStore);
-	}
+    @Provides
+    @Singleton
+    static Map<EntityId, Long> provideEntityExpiries(Map<String, byte[]> blobStore) {
+        return entityExpiryMapFrom(blobStore);
+    }
 
-	@Provides
-	@Singleton
-	static SizeLimitedStorage.IterableStorageUpserter provideStorageUpserter() {
-		return IterableStorageUtils::overwritingUpsertMapping;
-	}
+    @Provides
+    @Singleton
+    static SizeLimitedStorage.IterableStorageUpserter provideStorageUpserter() {
+        return IterableStorageUtils::overwritingUpsertMapping;
+    }
 
-	@Provides
-	@Singleton
-	static SizeLimitedStorage.IterableStorageRemover provideStorageRemover() {
-		return IterableStorageUtils::removeMapping;
-	}
+    @Provides
+    @Singleton
+    static SizeLimitedStorage.IterableStorageRemover provideStorageRemover() {
+        return IterableStorageUtils::removeMapping;
+    }
 
-	@Provides
-	@Singleton
-	static EntityAccess provideMutableEntityAccess(
-			final AliasManager aliasManager,
-			final HederaLedger ledger,
-			final TransactionContext txnCtx,
-			final SizeLimitedStorage storage,
-			final TransactionalLedger<TokenID, TokenProperty, MerkleToken> tokensLedger,
-			final Supplier<VirtualMap<VirtualBlobKey, VirtualBlobValue>> bytecode
-	) {
-		return new MutableEntityAccess(ledger, aliasManager, txnCtx, storage, tokensLedger, bytecode);
-	}
+    @Provides
+    @Singleton
+    static EntityAccess provideMutableEntityAccess(
+            final AliasManager aliasManager,
+            final HederaLedger ledger,
+            final TransactionContext txnCtx,
+            final SizeLimitedStorage storage,
+            final TransactionalLedger<TokenID, TokenProperty, MerkleToken> tokensLedger,
+            final Supplier<VirtualMap<VirtualBlobKey, VirtualBlobValue>> bytecode) {
+        return new MutableEntityAccess(
+                ledger, aliasManager, txnCtx, storage, tokensLedger, bytecode);
+    }
 
-	@Provides
-	@Singleton
-	@IntoSet
-	static Operation provideLog0Operation(final GasCalculator gasCalculator) {
-		return new HederaLogOperation(0, gasCalculator);
-	}
+    @Provides
+    @Singleton
+    @IntoSet
+    static Operation provideLog0Operation(final GasCalculator gasCalculator) {
+        return new HederaLogOperation(0, gasCalculator);
+    }
 
-	@Provides
-	@Singleton
-	@IntoSet
-	static Operation provideLog1Operation(final GasCalculator gasCalculator) {
-		return new HederaLogOperation(1, gasCalculator);
-	}
+    @Provides
+    @Singleton
+    @IntoSet
+    static Operation provideLog1Operation(final GasCalculator gasCalculator) {
+        return new HederaLogOperation(1, gasCalculator);
+    }
 
-	@Provides
-	@Singleton
-	@IntoSet
-	static Operation provideLog2Operation(final GasCalculator gasCalculator) {
-		return new HederaLogOperation(2, gasCalculator);
-	}
+    @Provides
+    @Singleton
+    @IntoSet
+    static Operation provideLog2Operation(final GasCalculator gasCalculator) {
+        return new HederaLogOperation(2, gasCalculator);
+    }
 
-	@Provides
-	@Singleton
-	@IntoSet
-	static Operation provideLog3Operation(final GasCalculator gasCalculator) {
-		return new HederaLogOperation(3, gasCalculator);
-	}
+    @Provides
+    @Singleton
+    @IntoSet
+    static Operation provideLog3Operation(final GasCalculator gasCalculator) {
+        return new HederaLogOperation(3, gasCalculator);
+    }
 
-	@Provides
-	@Singleton
-	@IntoSet
-	static Operation provideLog4Operation(final GasCalculator gasCalculator) {
-		return new HederaLogOperation(4, gasCalculator);
-	}
+    @Provides
+    @Singleton
+    @IntoSet
+    static Operation provideLog4Operation(final GasCalculator gasCalculator) {
+        return new HederaLogOperation(4, gasCalculator);
+    }
 
-	@Binds
-	@Singleton
-	GasCalculator bindHederaGasCalculatorV20(GasCalculatorHederaV22 gasCalculator);
+    @Binds
+    @Singleton
+    GasCalculator bindHederaGasCalculatorV20(GasCalculatorHederaV22 gasCalculator);
 
-	@Binds
-	@Singleton
-	@IntoSet
-	Operation bindBalanceOperation(HederaBalanceOperation balance);
+    @Binds
+    @Singleton
+    @IntoSet
+    Operation bindBalanceOperation(HederaBalanceOperation balance);
 
-	@Binds
-	@Singleton
-	@IntoSet
-	Operation bindCallCodeOperation(HederaCallCodeOperation callCode);
+    @Binds
+    @Singleton
+    @IntoSet
+    Operation bindCallCodeOperation(HederaCallCodeOperation callCode);
 
-	@Binds
-	@Singleton
-	@IntoSet
-	Operation bindCallOperation(HederaCallOperation call);
+    @Binds
+    @Singleton
+    @IntoSet
+    Operation bindCallOperation(HederaCallOperation call);
 
-	@Binds
-	@Singleton
-	@IntoSet
-	Operation bindCreateOperation(HederaCreateOperation create);
+    @Binds
+    @Singleton
+    @IntoSet
+    Operation bindCreateOperation(HederaCreateOperation create);
 
-	@Binds
-	@Singleton
-	@IntoSet
-	Operation bindCreate2Operation(HederaCreate2Operation create2);
+    @Binds
+    @Singleton
+    @IntoSet
+    Operation bindCreate2Operation(HederaCreate2Operation create2);
 
-	@Binds
-	@Singleton
-	@IntoSet
-	Operation bindDelegateCallOperation(HederaDelegateCallOperation delegateCall);
+    @Binds
+    @Singleton
+    @IntoSet
+    Operation bindDelegateCallOperation(HederaDelegateCallOperation delegateCall);
 
-	@Binds
-	@Singleton
-	@IntoSet
-	Operation bindExtCodeCopyOperation(HederaExtCodeCopyOperation extCodeCopy);
+    @Binds
+    @Singleton
+    @IntoSet
+    Operation bindExtCodeCopyOperation(HederaExtCodeCopyOperation extCodeCopy);
 
-	@Binds
-	@Singleton
-	@IntoSet
-	Operation bindExtCodeHashOperation(HederaExtCodeHashOperation extCodeHash);
+    @Binds
+    @Singleton
+    @IntoSet
+    Operation bindExtCodeHashOperation(HederaExtCodeHashOperation extCodeHash);
 
-	@Binds
-	@Singleton
-	@IntoSet
-	Operation bindExtCodeSizeOperation(HederaExtCodeSizeOperation extCodeSize);
+    @Binds
+    @Singleton
+    @IntoSet
+    Operation bindExtCodeSizeOperation(HederaExtCodeSizeOperation extCodeSize);
 
-	@Binds
-	@Singleton
-	@IntoSet
-	Operation bindSelfDestructOperation(HederaSelfDestructOperation selfDestruct);
+    @Binds
+    @Singleton
+    @IntoSet
+    Operation bindSelfDestructOperation(HederaSelfDestructOperation selfDestruct);
 
-	@Binds
-	@Singleton
-	@IntoSet
-	Operation bindSStoreOperation(HederaSStoreOperation sstore);
+    @Binds
+    @Singleton
+    @IntoSet
+    Operation bindSStoreOperation(HederaSStoreOperation sstore);
 
-	@Binds
-	@Singleton
-	@IntoSet
-	Operation bindHederaSLoadOperation(HederaSLoadOperation sload);
+    @Binds
+    @Singleton
+    @IntoSet
+    Operation bindHederaSLoadOperation(HederaSLoadOperation sload);
 
-	@Binds
-	@Singleton
-	@IntoSet
-	Operation bindStaticCallOperation(HederaStaticCallOperation staticCall);
+    @Binds
+    @Singleton
+    @IntoSet
+    Operation bindStaticCallOperation(HederaStaticCallOperation staticCall);
 
+    @Binds
+    @Singleton
+    @IntoMap
+    @StringKey(HTS_PRECOMPILED_CONTRACT_ADDRESS)
+    PrecompiledContract bindHTSPrecompile(HTSPrecompiledContract htsPrecompiledContract);
 
-	@Binds
-	@Singleton
-	@IntoMap
-	@StringKey(HTS_PRECOMPILED_CONTRACT_ADDRESS)
-	PrecompiledContract bindHTSPrecompile(HTSPrecompiledContract htsPrecompiledContract);
+    @Binds
+    @Singleton
+    @IntoMap
+    @StringKey(EXCHANGE_RATE_SYSTEM_CONTRACT_ADDRESS)
+    PrecompiledContract bindExchangeRatePrecompile(
+            ExchangeRatePrecompiledContract exchangeRateContract);
 
-	@Binds
-	@Singleton
-	@IntoMap
-	@StringKey(EXCHANGE_RATE_SYSTEM_CONTRACT_ADDRESS)
-	PrecompiledContract bindExchangeRatePrecompile(ExchangeRatePrecompiledContract exchangeRateContract);
+    @Binds
+    @Singleton
+    @IntoMap
+    @StringKey(PRNG_PRECOMPILE_ADDRESS)
+    PrecompiledContract bindPrngPrecompile(PrngSystemPrecompiledContract prngSystemContract);
 
-	@Binds
-	@Singleton
-	@IntoMap
-	@StringKey(PRNG_PRECOMPILE_ADDRESS)
-	PrecompiledContract bindPrngPrecompile(PrngSystemPrecompiledContract prngSystemContract);
-
-	@Provides
-	@Singleton
-	static BiPredicate<Address, MessageFrame> provideAddressValidator(
-			final Map<String, PrecompiledContract> precompiledContractMap
-	) {
-		final var precompiles =
-				precompiledContractMap.keySet().stream()
-						.map(Address::fromHexString)
-						.collect(Collectors.toSet());
-		return (address, frame) -> precompiles.contains(address) || frame.getWorldUpdater().get(address) != null;
-	}
+    @Provides
+    @Singleton
+    static BiPredicate<Address, MessageFrame> provideAddressValidator(
+            final Map<String, PrecompiledContract> precompiledContractMap) {
+        final var precompiles =
+                precompiledContractMap.keySet().stream()
+                        .map(Address::fromHexString)
+                        .collect(Collectors.toSet());
+        return (address, frame) ->
+                precompiles.contains(address) || frame.getWorldUpdater().get(address) != null;
+    }
 }

--- a/hedera-node/src/main/java/com/hedera/services/contracts/ContractsModule.java
+++ b/hedera-node/src/main/java/com/hedera/services/contracts/ContractsModule.java
@@ -1,11 +1,6 @@
-package com.hedera.services.contracts;
-
-/*-
- * ‌
- * Hedera Services Node
- * ​
- * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
- * ​
+/*
+ * Copyright (C) 2021-2022 Hedera Hashgraph, LLC
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -17,8 +12,8 @@ package com.hedera.services.contracts;
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- * ‍
  */
+package com.hedera.services.contracts;
 
 import static com.hedera.services.contracts.sources.AddressKeyedMapFactory.bytecodeMapFrom;
 import static com.hedera.services.contracts.sources.AddressKeyedMapFactory.storageMapFrom;

--- a/hedera-node/src/main/java/com/hedera/services/contracts/annotations/BytecodeSource.java
+++ b/hedera-node/src/main/java/com/hedera/services/contracts/annotations/BytecodeSource.java
@@ -1,11 +1,6 @@
-package com.hedera.services.contracts.annotations;
-
-/*-
- * ‌
- * Hedera Services Node
- * ​
- * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
- * ​
+/*
+ * Copyright (C) 2021-2022 Hedera Hashgraph, LLC
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -17,8 +12,8 @@ package com.hedera.services.contracts.annotations;
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- * ‍
  */
+package com.hedera.services.contracts.annotations;
 
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 

--- a/hedera-node/src/main/java/com/hedera/services/contracts/annotations/BytecodeSource.java
+++ b/hedera-node/src/main/java/com/hedera/services/contracts/annotations/BytecodeSource.java
@@ -9,9 +9,9 @@ package com.hedera.services.contracts.annotations;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,15 +20,14 @@ package com.hedera.services.contracts.annotations;
  * ‍
  */
 
-import javax.inject.Qualifier;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
+import javax.inject.Qualifier;
 
-import static java.lang.annotation.RetentionPolicy.RUNTIME;
-
-@Target({ ElementType.METHOD, ElementType.PARAMETER })
+@Target({ElementType.METHOD, ElementType.PARAMETER})
 @Qualifier
 @Retention(RUNTIME)
-public @interface BytecodeSource {
-}
+public @interface BytecodeSource {}

--- a/hedera-node/src/main/java/com/hedera/services/contracts/annotations/StorageSource.java
+++ b/hedera-node/src/main/java/com/hedera/services/contracts/annotations/StorageSource.java
@@ -1,11 +1,6 @@
-package com.hedera.services.contracts.annotations;
-
-/*-
- * ‌
- * Hedera Services Node
- * ​
- * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
- * ​
+/*
+ * Copyright (C) 2021-2022 Hedera Hashgraph, LLC
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -17,8 +12,8 @@ package com.hedera.services.contracts.annotations;
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- * ‍
  */
+package com.hedera.services.contracts.annotations;
 
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 

--- a/hedera-node/src/main/java/com/hedera/services/contracts/annotations/StorageSource.java
+++ b/hedera-node/src/main/java/com/hedera/services/contracts/annotations/StorageSource.java
@@ -9,9 +9,9 @@ package com.hedera.services.contracts.annotations;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,15 +20,14 @@ package com.hedera.services.contracts.annotations;
  * ‍
  */
 
-import javax.inject.Qualifier;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
+import javax.inject.Qualifier;
 
-import static java.lang.annotation.RetentionPolicy.RUNTIME;
-
-@Target({ ElementType.METHOD, ElementType.PARAMETER })
+@Target({ElementType.METHOD, ElementType.PARAMETER})
 @Qualifier
 @Retention(RUNTIME)
-public @interface StorageSource {
-}
+public @interface StorageSource {}

--- a/hedera-node/src/main/java/com/hedera/services/contracts/execution/BlockMetaSource.java
+++ b/hedera-node/src/main/java/com/hedera/services/contracts/execution/BlockMetaSource.java
@@ -1,11 +1,6 @@
-package com.hedera.services.contracts.execution;
-
-/*-
- * ‌
- * Hedera Services Node
- * ​
- * Copyright (C) 2018 - 2022 Hedera Hashgraph, LLC
- * ​
+/*
+ * Copyright (C) 2022 Hedera Hashgraph, LLC
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -17,8 +12,8 @@ package com.hedera.services.contracts.execution;
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- * ‍
  */
+package com.hedera.services.contracts.execution;
 
 import com.hedera.services.state.merkle.MerkleNetworkContext;
 import com.swirlds.common.crypto.DigestType;

--- a/hedera-node/src/main/java/com/hedera/services/contracts/execution/BlockMetaSource.java
+++ b/hedera-node/src/main/java/com/hedera/services/contracts/execution/BlockMetaSource.java
@@ -9,9 +9,9 @@ package com.hedera.services.contracts.execution;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -26,26 +26,26 @@ import com.swirlds.common.crypto.ImmutableHash;
 import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.evm.frame.BlockValues;
 
-/**
- * Provides block information to a {@link EvmTxProcessor}.
- */
+/** Provides block information to a {@link EvmTxProcessor}. */
 public interface BlockMetaSource {
-	Hash UNAVAILABLE_BLOCK_HASH =
-			MerkleNetworkContext.ethHashFrom(new ImmutableHash(new byte[DigestType.SHA_384.digestLength()]));
+    Hash UNAVAILABLE_BLOCK_HASH =
+            MerkleNetworkContext.ethHashFrom(
+                    new ImmutableHash(new byte[DigestType.SHA_384.digestLength()]));
 
-	/**
-	 * Returns the hash of the given block number, or {@link BlockMetaSource#UNAVAILABLE_BLOCK_HASH} if unavailable.
-	 *
-	 * @param blockNo the block number of interest
-	 * @return its hash, if available
-	 */
-	Hash getBlockHash(long blockNo);
+    /**
+     * Returns the hash of the given block number, or {@link BlockMetaSource#UNAVAILABLE_BLOCK_HASH}
+     * if unavailable.
+     *
+     * @param blockNo the block number of interest
+     * @return its hash, if available
+     */
+    Hash getBlockHash(long blockNo);
 
-	/**
-	 * Returns the in-scope block values, given an effective gas limit.
-	 *
-	 * @param gasLimit the effective gas limit
-	 * @return the scoped block values
-	 */
-	BlockValues computeBlockValues(long gasLimit);
+    /**
+     * Returns the in-scope block values, given an effective gas limit.
+     *
+     * @param gasLimit the effective gas limit
+     * @return the scoped block values
+     */
+    BlockValues computeBlockValues(long gasLimit);
 }

--- a/hedera-node/src/main/java/com/hedera/services/contracts/execution/CallEvmTxProcessor.java
+++ b/hedera-node/src/main/java/com/hedera/services/contracts/execution/CallEvmTxProcessor.java
@@ -22,6 +22,8 @@ package com.hedera.services.contracts.execution;
  *
  */
 
+import static com.hedera.services.exceptions.ValidationUtils.validateTrue;
+
 import com.hedera.services.context.properties.GlobalDynamicProperties;
 import com.hedera.services.ledger.accounts.AliasManager;
 import com.hedera.services.store.contracts.CodeCache;
@@ -30,6 +32,12 @@ import com.hedera.services.store.models.Account;
 import com.hedera.services.txns.contract.helpers.StorageExpiry;
 import com.hederahashgraph.api.proto.java.HederaFunctionality;
 import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
+import java.math.BigInteger;
+import java.time.Instant;
+import java.util.Map;
+import java.util.Set;
+import javax.inject.Inject;
+import javax.inject.Singleton;
 import org.apache.tuweni.bytes.Bytes;
 import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.evm.Code;
@@ -38,129 +46,117 @@ import org.hyperledger.besu.evm.gascalculator.GasCalculator;
 import org.hyperledger.besu.evm.operation.Operation;
 import org.hyperledger.besu.evm.precompile.PrecompiledContract;
 
-import javax.inject.Inject;
-import javax.inject.Singleton;
-import java.math.BigInteger;
-import java.time.Instant;
-import java.util.Map;
-import java.util.Set;
-
-import static com.hedera.services.exceptions.ValidationUtils.validateTrue;
-
 @Singleton
 public class CallEvmTxProcessor extends EvmTxProcessor {
-	private final CodeCache codeCache;
-	private final AliasManager aliasManager;
-	private final StorageExpiry storageExpiry;
+    private final CodeCache codeCache;
+    private final AliasManager aliasManager;
+    private final StorageExpiry storageExpiry;
 
-	@Inject
-	public CallEvmTxProcessor(
-			final HederaMutableWorldState worldState,
-			final LivePricesSource livePricesSource,
-			final CodeCache codeCache,
-			final GlobalDynamicProperties dynamicProperties,
-			final GasCalculator gasCalculator,
-			final Set<Operation> hederaOperations,
-			final Map<String, PrecompiledContract> precompiledContractMap,
-			final AliasManager aliasManager,
-			final StorageExpiry storageExpiry,
-			final InHandleBlockMetaSource blockMetaSource
-	) {
-		super(
-				worldState,
-				livePricesSource,
-				dynamicProperties,
-				gasCalculator,
-				hederaOperations,
-				precompiledContractMap,
-				blockMetaSource);
-		this.codeCache = codeCache;
-		this.aliasManager = aliasManager;
-		this.storageExpiry = storageExpiry;
-	}
+    @Inject
+    public CallEvmTxProcessor(
+            final HederaMutableWorldState worldState,
+            final LivePricesSource livePricesSource,
+            final CodeCache codeCache,
+            final GlobalDynamicProperties dynamicProperties,
+            final GasCalculator gasCalculator,
+            final Set<Operation> hederaOperations,
+            final Map<String, PrecompiledContract> precompiledContractMap,
+            final AliasManager aliasManager,
+            final StorageExpiry storageExpiry,
+            final InHandleBlockMetaSource blockMetaSource) {
+        super(
+                worldState,
+                livePricesSource,
+                dynamicProperties,
+                gasCalculator,
+                hederaOperations,
+                precompiledContractMap,
+                blockMetaSource);
+        this.codeCache = codeCache;
+        this.aliasManager = aliasManager;
+        this.storageExpiry = storageExpiry;
+    }
 
-	public TransactionProcessingResult execute(
-			final Account sender,
-			final Address receiver,
-			final long providedGasLimit,
-			final long value,
-			final Bytes callData,
-			final Instant consensusTime
-	) {
-		final long gasPrice = gasPriceTinyBarsGiven(consensusTime, false);
+    public TransactionProcessingResult execute(
+            final Account sender,
+            final Address receiver,
+            final long providedGasLimit,
+            final long value,
+            final Bytes callData,
+            final Instant consensusTime) {
+        final long gasPrice = gasPriceTinyBarsGiven(consensusTime, false);
 
-		return super.execute(
-				sender,
-				receiver,
-				gasPrice,
-				providedGasLimit,
-				value,
-				callData,
-				false,
-				consensusTime,
-				false,
-				storageExpiry.hapiCallOracle(),
-				aliasManager.resolveForEvm(receiver),
-				null,
-				0,
-				null);
-	}
+        return super.execute(
+                sender,
+                receiver,
+                gasPrice,
+                providedGasLimit,
+                value,
+                callData,
+                false,
+                consensusTime,
+                false,
+                storageExpiry.hapiCallOracle(),
+                aliasManager.resolveForEvm(receiver),
+                null,
+                0,
+                null);
+    }
 
-	public TransactionProcessingResult executeEth(
-			final Account sender,
-			final Address receiver,
-			final long providedGasLimit,
-			final long value,
-			final Bytes callData,
-			final Instant consensusTime,
-			final BigInteger userOfferedGasPrice,
-			final Account relayer,
-			final long maxGasAllowanceInTinybars
-	) {
-		final long gasPrice = gasPriceTinyBarsGiven(consensusTime, true);
+    public TransactionProcessingResult executeEth(
+            final Account sender,
+            final Address receiver,
+            final long providedGasLimit,
+            final long value,
+            final Bytes callData,
+            final Instant consensusTime,
+            final BigInteger userOfferedGasPrice,
+            final Account relayer,
+            final long maxGasAllowanceInTinybars) {
+        final long gasPrice = gasPriceTinyBarsGiven(consensusTime, true);
 
-		return super.execute(
-				sender,
-				receiver,
-				gasPrice,
-				providedGasLimit,
-				value,
-				callData,
-				false,
-				consensusTime,
-				false,
-				storageExpiry.hapiCallOracle(),
-				aliasManager.resolveForEvm(receiver),
-				userOfferedGasPrice,
-				maxGasAllowanceInTinybars,
-				relayer);
-	}
+        return super.execute(
+                sender,
+                receiver,
+                gasPrice,
+                providedGasLimit,
+                value,
+                callData,
+                false,
+                consensusTime,
+                false,
+                storageExpiry.hapiCallOracle(),
+                aliasManager.resolveForEvm(receiver),
+                userOfferedGasPrice,
+                maxGasAllowanceInTinybars,
+                relayer);
+    }
 
-	@Override
-	protected HederaFunctionality getFunctionType() {
-		return HederaFunctionality.ContractCall;
-	}
+    @Override
+    protected HederaFunctionality getFunctionType() {
+        return HederaFunctionality.ContractCall;
+    }
 
-	@Override
-	protected MessageFrame buildInitialFrame(
-			final MessageFrame.Builder baseInitialFrame,
-			final Address to,
-			final Bytes payload,
-			final long value) {
-		final var code = codeCache.getIfPresent(aliasManager.resolveForEvm(to));
-		/* The ContractCallTransitionLogic would have rejected a missing or deleted
-		 * contract, so at this point we should have non-null bytecode available.
-		 * If there is no bytecode, it means we have a non-token and non-contract account,
-		 * hence the code should be null and there must be a value transfer.
-		 */
-		validateTrue(code != null || value > 0, ResponseCodeEnum.INVALID_ETHEREUM_TRANSACTION);
+    @Override
+    protected MessageFrame buildInitialFrame(
+            final MessageFrame.Builder baseInitialFrame,
+            final Address to,
+            final Bytes payload,
+            final long value) {
+        final var code = codeCache.getIfPresent(aliasManager.resolveForEvm(to));
+        /* The ContractCallTransitionLogic would have rejected a missing or deleted
+         * contract, so at this point we should have non-null bytecode available.
+         * If there is no bytecode, it means we have a non-token and non-contract account,
+         * hence the code should be null and there must be a value transfer.
+         */
+        validateTrue(code != null || value > 0, ResponseCodeEnum.INVALID_ETHEREUM_TRANSACTION);
 
-		return baseInitialFrame
-				.type(MessageFrame.Type.MESSAGE_CALL)
-				.address(to)
-				.contract(to)
-				.inputData(payload)
-				.code(code == null ? Code.EMPTY : code)
-				.build();
-	}
+        return baseInitialFrame
+                .type(MessageFrame.Type.MESSAGE_CALL)
+                .address(to)
+                .contract(to)
+                .inputData(payload)
+                .code(code == null ? Code.EMPTY : code)
+                .build();
+    }
 }

--- a/hedera-node/src/main/java/com/hedera/services/contracts/execution/CallEvmTxProcessor.java
+++ b/hedera-node/src/main/java/com/hedera/services/contracts/execution/CallEvmTxProcessor.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2021-2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hedera.services.contracts.execution;
 
 /*

--- a/hedera-node/src/main/java/com/hedera/services/contracts/execution/CallLocalEvmTxProcessor.java
+++ b/hedera-node/src/main/java/com/hedera/services/contracts/execution/CallLocalEvmTxProcessor.java
@@ -22,6 +22,9 @@ package com.hedera.services.contracts.execution;
  *
  */
 
+import static com.hedera.services.exceptions.ValidationUtils.validateTrue;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_CONTRACT_ID;
+
 import com.hedera.services.context.properties.GlobalDynamicProperties;
 import com.hedera.services.ledger.accounts.AliasManager;
 import com.hedera.services.store.contracts.CodeCache;
@@ -29,6 +32,11 @@ import com.hedera.services.store.contracts.HederaMutableWorldState;
 import com.hedera.services.store.models.Account;
 import com.hedera.services.txns.contract.helpers.StorageExpiry;
 import com.hederahashgraph.api.proto.java.HederaFunctionality;
+import java.time.Instant;
+import java.util.Map;
+import java.util.Set;
+import javax.inject.Inject;
+import javax.inject.Singleton;
 import org.apache.tuweni.bytes.Bytes;
 import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.evm.frame.MessageFrame;
@@ -36,109 +44,97 @@ import org.hyperledger.besu.evm.gascalculator.GasCalculator;
 import org.hyperledger.besu.evm.operation.Operation;
 import org.hyperledger.besu.evm.precompile.PrecompiledContract;
 
-import javax.inject.Inject;
-import javax.inject.Singleton;
-import java.time.Instant;
-import java.util.Map;
-import java.util.Set;
-
-import static com.hedera.services.exceptions.ValidationUtils.validateTrue;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_CONTRACT_ID;
-
 /**
- * Extension of the base {@link EvmTxProcessor} that provides interface for
- * executing {@link com.hederahashgraph.api.proto.java.ContractCallLocal} queries
+ * Extension of the base {@link EvmTxProcessor} that provides interface for executing {@link
+ * com.hederahashgraph.api.proto.java.ContractCallLocal} queries
  */
 @Singleton
 public class CallLocalEvmTxProcessor extends EvmTxProcessor {
-	private final CodeCache codeCache;
-	private final AliasManager aliasManager;
-	private final StorageExpiry storageExpiry;
+    private final CodeCache codeCache;
+    private final AliasManager aliasManager;
+    private final StorageExpiry storageExpiry;
 
-	@Inject
-	public CallLocalEvmTxProcessor(
-			final CodeCache codeCache,
-			final LivePricesSource livePricesSource,
-			final GlobalDynamicProperties dynamicProperties,
-			final GasCalculator gasCalculator,
-			final Set<Operation> hederaOperations,
-			final Map<String, PrecompiledContract> precompiledContractMap,
-			final AliasManager aliasManager,
-			final StorageExpiry storageExpiry
-	) {
-		super(
-				livePricesSource,
-				dynamicProperties,
-				gasCalculator,
-				hederaOperations,
-				precompiledContractMap);
-		this.codeCache = codeCache;
-		this.aliasManager = aliasManager;
-		this.storageExpiry = storageExpiry;
-	}
+    @Inject
+    public CallLocalEvmTxProcessor(
+            final CodeCache codeCache,
+            final LivePricesSource livePricesSource,
+            final GlobalDynamicProperties dynamicProperties,
+            final GasCalculator gasCalculator,
+            final Set<Operation> hederaOperations,
+            final Map<String, PrecompiledContract> precompiledContractMap,
+            final AliasManager aliasManager,
+            final StorageExpiry storageExpiry) {
+        super(
+                livePricesSource,
+                dynamicProperties,
+                gasCalculator,
+                hederaOperations,
+                precompiledContractMap);
+        this.codeCache = codeCache;
+        this.aliasManager = aliasManager;
+        this.storageExpiry = storageExpiry;
+    }
 
-	@Override
-	public void setWorldState(final HederaMutableWorldState worldState) {
-		super.setWorldState(worldState);
-	}
+    @Override
+    public void setWorldState(final HederaMutableWorldState worldState) {
+        super.setWorldState(worldState);
+    }
 
-	@Override
-	public void setBlockMetaSource(BlockMetaSource blockMetaSource) {
-		super.setBlockMetaSource(blockMetaSource);
-	}
+    @Override
+    public void setBlockMetaSource(BlockMetaSource blockMetaSource) {
+        super.setBlockMetaSource(blockMetaSource);
+    }
 
-	@Override
-	protected HederaFunctionality getFunctionType() {
-		return HederaFunctionality.ContractCallLocal;
-	}
+    @Override
+    protected HederaFunctionality getFunctionType() {
+        return HederaFunctionality.ContractCallLocal;
+    }
 
-	public TransactionProcessingResult execute(
-			final Account sender,
-			final Address receiver,
-			final long providedGasLimit,
-			final long value,
-			final Bytes callData,
-			final Instant consensusTime
-	) {
-		final long gasPrice = 1;
+    public TransactionProcessingResult execute(
+            final Account sender,
+            final Address receiver,
+            final long providedGasLimit,
+            final long value,
+            final Bytes callData,
+            final Instant consensusTime) {
+        final long gasPrice = 1;
 
-		return super.execute(
-				sender,
-				receiver,
-				gasPrice,
-				providedGasLimit,
-				value,
-				callData,
-				false,
-				consensusTime,
-				true,
-				storageExpiry.hapiStaticCallOracle(),
-				aliasManager.resolveForEvm(receiver),
-				null,
-				0,
-				null);
-	}
+        return super.execute(
+                sender,
+                receiver,
+                gasPrice,
+                providedGasLimit,
+                value,
+                callData,
+                false,
+                consensusTime,
+                true,
+                storageExpiry.hapiStaticCallOracle(),
+                aliasManager.resolveForEvm(receiver),
+                null,
+                0,
+                null);
+    }
 
-	@Override
-	protected MessageFrame buildInitialFrame(
-			final MessageFrame.Builder baseInitialFrame,
-			final Address to,
-			final Bytes payload,
-			final long value
-	) {
-		final var code = codeCache.getIfPresent(aliasManager.resolveForEvm(to));
-		/* It's possible we are racing the handleTransaction() thread, and the target contract's
-		 * _account_ has been created, but not yet its _bytecode_. So if `code` is null here,
-		 * it doesn't mean a system invariant has been violated (FAIL_INVALID); instead it means
-		 * the target contract is not yet in a valid state to be queried (INVALID_CONTRACT_ID). */
-		validateTrue(code != null, INVALID_CONTRACT_ID);
+    @Override
+    protected MessageFrame buildInitialFrame(
+            final MessageFrame.Builder baseInitialFrame,
+            final Address to,
+            final Bytes payload,
+            final long value) {
+        final var code = codeCache.getIfPresent(aliasManager.resolveForEvm(to));
+        /* It's possible we are racing the handleTransaction() thread, and the target contract's
+         * _account_ has been created, but not yet its _bytecode_. So if `code` is null here,
+         * it doesn't mean a system invariant has been violated (FAIL_INVALID); instead it means
+         * the target contract is not yet in a valid state to be queried (INVALID_CONTRACT_ID). */
+        validateTrue(code != null, INVALID_CONTRACT_ID);
 
-		return baseInitialFrame
-				.type(MessageFrame.Type.MESSAGE_CALL)
-				.address(to)
-				.contract(to)
-				.inputData(payload)
-				.code(code)
-				.build();
-	}
+        return baseInitialFrame
+                .type(MessageFrame.Type.MESSAGE_CALL)
+                .address(to)
+                .contract(to)
+                .inputData(payload)
+                .code(code)
+                .build();
+    }
 }

--- a/hedera-node/src/main/java/com/hedera/services/contracts/execution/CallLocalEvmTxProcessor.java
+++ b/hedera-node/src/main/java/com/hedera/services/contracts/execution/CallLocalEvmTxProcessor.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2021-2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hedera.services.contracts.execution;
 
 /*

--- a/hedera-node/src/main/java/com/hedera/services/contracts/execution/CallLocalExecutor.java
+++ b/hedera-node/src/main/java/com/hedera/services/contracts/execution/CallLocalExecutor.java
@@ -20,6 +20,9 @@ package com.hedera.services.contracts.execution;
  * ‍
  */
 
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OK;
+import static com.hederahashgraph.api.proto.java.ResponseType.ANSWER_ONLY;
+
 import com.google.protobuf.ByteString;
 import com.hedera.services.exceptions.InvalidTransactionException;
 import com.hedera.services.ledger.accounts.AliasManager;
@@ -33,84 +36,87 @@ import com.hederahashgraph.api.proto.java.ContractCallLocalQuery;
 import com.hederahashgraph.api.proto.java.ContractCallLocalResponse;
 import com.hederahashgraph.builder.RequestBuilder;
 import com.swirlds.common.utility.CommonUtils;
+import java.time.Instant;
+import javax.inject.Singleton;
 import org.apache.tuweni.bytes.Bytes;
 
-import javax.inject.Singleton;
-import java.time.Instant;
-
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OK;
-import static com.hederahashgraph.api.proto.java.ResponseType.ANSWER_ONLY;
-
 /**
- * Utility class for executing static EVM calls for {@link com.hedera.services.queries.contract.ContractCallLocalAnswer}
- * and
- * {@link com.hedera.services.fees.calculation.contract.queries.ContractCallLocalResourceUsage}
+ * Utility class for executing static EVM calls for {@link
+ * com.hedera.services.queries.contract.ContractCallLocalAnswer} and {@link
+ * com.hedera.services.fees.calculation.contract.queries.ContractCallLocalResourceUsage}
  */
 @Singleton
 public class CallLocalExecutor {
-	private CallLocalExecutor() {
-		throw new UnsupportedOperationException("Utility Class");
-	}
+    private CallLocalExecutor() {
+        throw new UnsupportedOperationException("Utility Class");
+    }
 
-	/**
-	 * Executes the specified {@link ContractCallLocalQuery} through a static call. Parses the result from the
-	 * {@link CallLocalEvmTxProcessor} and sets the appropriate {@link com.hederahashgraph.api.proto.java.ResponseCode}
-	 *
-	 * @param accountStore
-	 * 		the account store
-	 * @param evmTxProcessor
-	 * 		the {@link CallLocalEvmTxProcessor} processor
-	 * @param op
-	 * 		the query to answer
-	 * @return {@link ContractCallLocalResponse} result of the execution
-	 */
-	public static ContractCallLocalResponse execute(
-			final AccountStore accountStore,
-			final CallLocalEvmTxProcessor evmTxProcessor,
-			final ContractCallLocalQuery op,
-			final AliasManager aliasManager,
-			final EntityAccess entityAccess
-	) {
-		try {
-			final var paymentTxn = SignedTxnAccessor.uncheckedFrom(op.getHeader().getPayment()).getTxn();
-			final var senderId = EntityIdUtils.unaliased(op.hasSenderId()
-					? op.getSenderId()
-					: paymentTxn.getTransactionID().getAccountID(), aliasManager).toId();
-			final var idOrAlias = op.getContractID();
-			final var contractId = EntityIdUtils.unaliased(idOrAlias, aliasManager).toId();
+    /**
+     * Executes the specified {@link ContractCallLocalQuery} through a static call. Parses the
+     * result from the {@link CallLocalEvmTxProcessor} and sets the appropriate {@link
+     * com.hederahashgraph.api.proto.java.ResponseCode}
+     *
+     * @param accountStore the account store
+     * @param evmTxProcessor the {@link CallLocalEvmTxProcessor} processor
+     * @param op the query to answer
+     * @return {@link ContractCallLocalResponse} result of the execution
+     */
+    public static ContractCallLocalResponse execute(
+            final AccountStore accountStore,
+            final CallLocalEvmTxProcessor evmTxProcessor,
+            final ContractCallLocalQuery op,
+            final AliasManager aliasManager,
+            final EntityAccess entityAccess) {
+        try {
+            final var paymentTxn =
+                    SignedTxnAccessor.uncheckedFrom(op.getHeader().getPayment()).getTxn();
+            final var senderId =
+                    EntityIdUtils.unaliased(
+                                    op.hasSenderId()
+                                            ? op.getSenderId()
+                                            : paymentTxn.getTransactionID().getAccountID(),
+                                    aliasManager)
+                            .toId();
+            final var idOrAlias = op.getContractID();
+            final var contractId = EntityIdUtils.unaliased(idOrAlias, aliasManager).toId();
 
-			/* --- Load the model objects --- */
-			final var sender = accountStore.loadAccount(senderId);
-			var receiver = entityAccess.isTokenAccount(contractId.asEvmAddress()) ?
-					new Account(contractId) :
-					accountStore.loadContract(contractId);
-			final var callData = !op.getFunctionParameters().isEmpty()
-					? Bytes.fromHexString(CommonUtils.hex(op.getFunctionParameters().toByteArray())) : Bytes.EMPTY;
+            /* --- Load the model objects --- */
+            final var sender = accountStore.loadAccount(senderId);
+            var receiver =
+                    entityAccess.isTokenAccount(contractId.asEvmAddress())
+                            ? new Account(contractId)
+                            : accountStore.loadContract(contractId);
+            final var callData =
+                    !op.getFunctionParameters().isEmpty()
+                            ? Bytes.fromHexString(
+                                    CommonUtils.hex(op.getFunctionParameters().toByteArray()))
+                            : Bytes.EMPTY;
 
-			/* --- Do the business logic --- */
-			final var result = evmTxProcessor.execute(
-					sender,
-					receiver.canonicalAddress(),
-					op.getGas(),
-					0,
-					callData,
-					Instant.now());
+            /* --- Do the business logic --- */
+            final var result =
+                    evmTxProcessor.execute(
+                            sender,
+                            receiver.canonicalAddress(),
+                            op.getGas(),
+                            0,
+                            callData,
+                            Instant.now());
 
-			var status = ResponseCodeUtil.getStatus(result, OK);
+            var status = ResponseCodeUtil.getStatus(result, OK);
 
-			final var responseHeader = RequestBuilder.getResponseHeader(status, 0L,
-					ANSWER_ONLY, ByteString.EMPTY);
+            final var responseHeader =
+                    RequestBuilder.getResponseHeader(status, 0L, ANSWER_ONLY, ByteString.EMPTY);
 
-			return ContractCallLocalResponse
-					.newBuilder()
-					.setHeader(responseHeader)
-					.setFunctionResult(result.toGrpc())
-					.build();
-		} catch (InvalidTransactionException ite) {
-			final var responseHeader = RequestBuilder.getResponseHeader(ite.getResponseCode(), 0L,
-					ANSWER_ONLY, ByteString.EMPTY);
+            return ContractCallLocalResponse.newBuilder()
+                    .setHeader(responseHeader)
+                    .setFunctionResult(result.toGrpc())
+                    .build();
+        } catch (InvalidTransactionException ite) {
+            final var responseHeader =
+                    RequestBuilder.getResponseHeader(
+                            ite.getResponseCode(), 0L, ANSWER_ONLY, ByteString.EMPTY);
 
-			return ContractCallLocalResponse.newBuilder().setHeader(responseHeader).build();
-		}
-	}
+            return ContractCallLocalResponse.newBuilder().setHeader(responseHeader).build();
+        }
+    }
 }

--- a/hedera-node/src/main/java/com/hedera/services/contracts/execution/CallLocalExecutor.java
+++ b/hedera-node/src/main/java/com/hedera/services/contracts/execution/CallLocalExecutor.java
@@ -1,11 +1,6 @@
-package com.hedera.services.contracts.execution;
-
-/*-
- * ‌
- * Hedera Services Node
- * ​
- * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
- * ​
+/*
+ * Copyright (C) 2021-2022 Hedera Hashgraph, LLC
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -17,8 +12,8 @@ package com.hedera.services.contracts.execution;
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- * ‍
  */
+package com.hedera.services.contracts.execution;
 
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OK;
 import static com.hederahashgraph.api.proto.java.ResponseType.ANSWER_ONLY;

--- a/hedera-node/src/main/java/com/hedera/services/contracts/execution/CreateEvmTxProcessor.java
+++ b/hedera-node/src/main/java/com/hedera/services/contracts/execution/CreateEvmTxProcessor.java
@@ -28,6 +28,12 @@ import com.hedera.services.store.contracts.HederaMutableWorldState;
 import com.hedera.services.store.models.Account;
 import com.hedera.services.txns.contract.helpers.StorageExpiry;
 import com.hederahashgraph.api.proto.java.HederaFunctionality;
+import java.math.BigInteger;
+import java.time.Instant;
+import java.util.Map;
+import java.util.Set;
+import javax.inject.Inject;
+import javax.inject.Singleton;
 import org.apache.tuweni.bytes.Bytes;
 import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.datatypes.Hash;
@@ -37,124 +43,114 @@ import org.hyperledger.besu.evm.gascalculator.GasCalculator;
 import org.hyperledger.besu.evm.operation.Operation;
 import org.hyperledger.besu.evm.precompile.PrecompiledContract;
 
-import javax.inject.Inject;
-import javax.inject.Singleton;
-import java.math.BigInteger;
-import java.time.Instant;
-import java.util.Map;
-import java.util.Set;
-
 /**
- * Extension of the base {@link EvmTxProcessor} that provides interface for executing
- * {@link com.hederahashgraph.api.proto.java.ContractCreateTransactionBody} transactions
+ * Extension of the base {@link EvmTxProcessor} that provides interface for executing {@link
+ * com.hederahashgraph.api.proto.java.ContractCreateTransactionBody} transactions
  */
 @Singleton
 public class CreateEvmTxProcessor extends EvmTxProcessor {
-	private final CodeCache codeCache;
-	private final StorageExpiry storageExpiry;
+    private final CodeCache codeCache;
+    private final StorageExpiry storageExpiry;
 
-	@Inject
-	public CreateEvmTxProcessor(
-			final HederaMutableWorldState worldState,
-			final LivePricesSource livePricesSource,
-			final CodeCache codeCache,
-			final GlobalDynamicProperties globalDynamicProperties,
-			final GasCalculator gasCalculator,
-			final Set<Operation> hederaOperations,
-			final Map<String, PrecompiledContract> precompiledContractMap,
-			final StorageExpiry storageExpiry,
-			final InHandleBlockMetaSource blockMetaSource
-	) {
-		super(
-				worldState,
-				livePricesSource,
-				globalDynamicProperties,
-				gasCalculator,
-				hederaOperations,
-				precompiledContractMap,
-				blockMetaSource);
-		this.codeCache = codeCache;
-		this.storageExpiry = storageExpiry;
-	}
+    @Inject
+    public CreateEvmTxProcessor(
+            final HederaMutableWorldState worldState,
+            final LivePricesSource livePricesSource,
+            final CodeCache codeCache,
+            final GlobalDynamicProperties globalDynamicProperties,
+            final GasCalculator gasCalculator,
+            final Set<Operation> hederaOperations,
+            final Map<String, PrecompiledContract> precompiledContractMap,
+            final StorageExpiry storageExpiry,
+            final InHandleBlockMetaSource blockMetaSource) {
+        super(
+                worldState,
+                livePricesSource,
+                globalDynamicProperties,
+                gasCalculator,
+                hederaOperations,
+                precompiledContractMap,
+                blockMetaSource);
+        this.codeCache = codeCache;
+        this.storageExpiry = storageExpiry;
+    }
 
-	public TransactionProcessingResult execute(
-			final Account sender,
-			final Address receiver,
-			final long providedGasLimit,
-			final long value,
-			final Bytes code,
-			final Instant consensusTime,
-			final long hapiExpiry
-	) {
-		final long gasPrice = gasPriceTinyBarsGiven(consensusTime, false);
+    public TransactionProcessingResult execute(
+            final Account sender,
+            final Address receiver,
+            final long providedGasLimit,
+            final long value,
+            final Bytes code,
+            final Instant consensusTime,
+            final long hapiExpiry) {
+        final long gasPrice = gasPriceTinyBarsGiven(consensusTime, false);
 
-		return super.execute(
-				sender,
-				receiver,
-				gasPrice,
-				providedGasLimit,
-				value,
-				code,
-				true,
-				consensusTime,
-				false,
-				storageExpiry.hapiCreationOracle(hapiExpiry),
-				receiver,
-				null,
-				0,
-				null);
-	}
+        return super.execute(
+                sender,
+                receiver,
+                gasPrice,
+                providedGasLimit,
+                value,
+                code,
+                true,
+                consensusTime,
+                false,
+                storageExpiry.hapiCreationOracle(hapiExpiry),
+                receiver,
+                null,
+                0,
+                null);
+    }
 
-	public TransactionProcessingResult executeEth(
-			final Account sender,
-			final Address receiver,
-			final long providedGasLimit,
-			final long value,
-			final Bytes code,
-			final Instant consensusTime,
-			final long hapiExpiry,
-			final Account relayer,
-			final BigInteger providedMaxGasPrice,
-			final long maxGasAllowance
-	) {
-		final long gasPrice = gasPriceTinyBarsGiven(consensusTime, true);
+    public TransactionProcessingResult executeEth(
+            final Account sender,
+            final Address receiver,
+            final long providedGasLimit,
+            final long value,
+            final Bytes code,
+            final Instant consensusTime,
+            final long hapiExpiry,
+            final Account relayer,
+            final BigInteger providedMaxGasPrice,
+            final long maxGasAllowance) {
+        final long gasPrice = gasPriceTinyBarsGiven(consensusTime, true);
 
-		return super.execute(
-				sender,
-				receiver,
-				gasPrice,
-				providedGasLimit,
-				value,
-				code,
-				true,
-				consensusTime,
-				false,
-				storageExpiry.hapiCreationOracle(hapiExpiry),
-				receiver,
-				providedMaxGasPrice,
-				maxGasAllowance,
-				relayer);
-	}
+        return super.execute(
+                sender,
+                receiver,
+                gasPrice,
+                providedGasLimit,
+                value,
+                code,
+                true,
+                consensusTime,
+                false,
+                storageExpiry.hapiCreationOracle(hapiExpiry),
+                receiver,
+                providedMaxGasPrice,
+                maxGasAllowance,
+                relayer);
+    }
 
-	@Override
-	protected HederaFunctionality getFunctionType() {
-		return HederaFunctionality.ContractCreate;
-	}
+    @Override
+    protected HederaFunctionality getFunctionType() {
+        return HederaFunctionality.ContractCreate;
+    }
 
-	@Override
-	protected MessageFrame buildInitialFrame(
-			final MessageFrame.Builder commonInitialFrame,
-			final Address to,
-			final Bytes payload,
-			final long value) {
-		codeCache.invalidate(to);
+    @Override
+    protected MessageFrame buildInitialFrame(
+            final MessageFrame.Builder commonInitialFrame,
+            final Address to,
+            final Bytes payload,
+            final long value) {
+        codeCache.invalidate(to);
 
-		return commonInitialFrame
-				.type(MessageFrame.Type.CONTRACT_CREATION)
-				.address(to)
-				.contract(to)
-				.inputData(Bytes.EMPTY)
-				.code(Code.createLegacyCode(payload, Hash.hash(payload)))
-				.build();
-	}
+        return commonInitialFrame
+                .type(MessageFrame.Type.CONTRACT_CREATION)
+                .address(to)
+                .contract(to)
+                .inputData(Bytes.EMPTY)
+                .code(Code.createLegacyCode(payload, Hash.hash(payload)))
+                .build();
+    }
 }

--- a/hedera-node/src/main/java/com/hedera/services/contracts/execution/CreateEvmTxProcessor.java
+++ b/hedera-node/src/main/java/com/hedera/services/contracts/execution/CreateEvmTxProcessor.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2021-2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hedera.services.contracts.execution;
 
 /*

--- a/hedera-node/src/main/java/com/hedera/services/contracts/execution/EvmTxProcessor.java
+++ b/hedera-node/src/main/java/com/hedera/services/contracts/execution/EvmTxProcessor.java
@@ -22,6 +22,13 @@ package com.hedera.services.contracts.execution;
  *
  */
 
+import static com.hedera.services.ethereum.EthTxData.WEIBARS_TO_TINYBARS;
+import static com.hedera.services.exceptions.ValidationUtils.validateTrue;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INSUFFICIENT_GAS;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INSUFFICIENT_PAYER_BALANCE;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INSUFFICIENT_TX_FEE;
+import static org.hyperledger.besu.evm.MainnetEVMs.registerLondonOperations;
+
 import com.hedera.services.context.properties.GlobalDynamicProperties;
 import com.hedera.services.exceptions.InvalidTransactionException;
 import com.hedera.services.store.contracts.HederaMutableWorldState;
@@ -30,6 +37,13 @@ import com.hedera.services.store.models.Account;
 import com.hedera.services.store.models.Id;
 import com.hedera.services.txns.contract.helpers.StorageExpiry;
 import com.hederahashgraph.api.proto.java.HederaFunctionality;
+import java.math.BigInteger;
+import java.time.Instant;
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.tuweni.bytes.Bytes;
 import org.hyperledger.besu.datatypes.Address;
@@ -51,344 +65,346 @@ import org.hyperledger.besu.evm.processor.AbstractMessageProcessor;
 import org.hyperledger.besu.evm.processor.ContractCreationProcessor;
 import org.hyperledger.besu.evm.tracing.OperationTracer;
 
-import java.math.BigInteger;
-import java.time.Instant;
-import java.util.ArrayDeque;
-import java.util.Deque;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-
-import static com.hedera.services.ethereum.EthTxData.WEIBARS_TO_TINYBARS;
-import static com.hedera.services.exceptions.ValidationUtils.validateTrue;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INSUFFICIENT_GAS;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INSUFFICIENT_PAYER_BALANCE;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INSUFFICIENT_TX_FEE;
-import static org.hyperledger.besu.evm.MainnetEVMs.registerLondonOperations;
-
 /**
- * Abstract processor of EVM transactions that prepares the {@link EVM} and all of the peripherals upon
- * instantiation. Provides a base
- * {@link EvmTxProcessor#execute(Account, Address, long, long, long, Bytes, boolean, Instant, boolean, StorageExpiry.Oracle, Address, BigInteger, long, Account)}
- * method that handles the end-to-end execution of a EVM transaction.
+ * Abstract processor of EVM transactions that prepares the {@link EVM} and all of the peripherals
+ * upon instantiation. Provides a base {@link EvmTxProcessor#execute(Account, Address, long, long,
+ * long, Bytes, boolean, Instant, boolean, StorageExpiry.Oracle, Address, BigInteger, long,
+ * Account)} method that handles the end-to-end execution of a EVM transaction.
  */
 abstract class EvmTxProcessor {
-	private static final int MAX_STACK_SIZE = 1024;
-	private static final int MAX_CODE_SIZE = 0x6000;
-	private static final List<ContractValidationRule> VALIDATION_RULES =
-			List.of(MaxCodeSizeRule.of(MAX_CODE_SIZE), PrefixCodeRule.of());
+    private static final int MAX_STACK_SIZE = 1024;
+    private static final int MAX_CODE_SIZE = 0x6000;
+    private static final List<ContractValidationRule> VALIDATION_RULES =
+            List.of(MaxCodeSizeRule.of(MAX_CODE_SIZE), PrefixCodeRule.of());
 
-	public static final String SBH_CONTEXT_KEY = "sbh";
-	public static final String EXPIRY_ORACLE_CONTEXT_KEY = "expiryOracle";
+    public static final String SBH_CONTEXT_KEY = "sbh";
+    public static final String EXPIRY_ORACLE_CONTEXT_KEY = "expiryOracle";
 
-	private BlockMetaSource blockMetaSource;
-	private HederaMutableWorldState worldState;
+    private BlockMetaSource blockMetaSource;
+    private HederaMutableWorldState worldState;
 
-	private final GasCalculator gasCalculator;
-	private final LivePricesSource livePricesSource;
-	private final AbstractMessageProcessor messageCallProcessor;
-	private final AbstractMessageProcessor contractCreationProcessor;
-	protected final GlobalDynamicProperties dynamicProperties;
+    private final GasCalculator gasCalculator;
+    private final LivePricesSource livePricesSource;
+    private final AbstractMessageProcessor messageCallProcessor;
+    private final AbstractMessageProcessor contractCreationProcessor;
+    protected final GlobalDynamicProperties dynamicProperties;
 
-	protected EvmTxProcessor(
-			final LivePricesSource livePricesSource,
-			final GlobalDynamicProperties dynamicProperties,
-			final GasCalculator gasCalculator,
-			final Set<Operation> hederaOperations,
-			final Map<String, PrecompiledContract> precompiledContractMap
-	) {
-		this(
-				null,
-				livePricesSource,
-				dynamicProperties,
-				gasCalculator,
-				hederaOperations,
-				precompiledContractMap,
-				null);
-	}
+    protected EvmTxProcessor(
+            final LivePricesSource livePricesSource,
+            final GlobalDynamicProperties dynamicProperties,
+            final GasCalculator gasCalculator,
+            final Set<Operation> hederaOperations,
+            final Map<String, PrecompiledContract> precompiledContractMap) {
+        this(
+                null,
+                livePricesSource,
+                dynamicProperties,
+                gasCalculator,
+                hederaOperations,
+                precompiledContractMap,
+                null);
+    }
 
-	protected void setBlockMetaSource(final BlockMetaSource blockMetaSource) {
-		this.blockMetaSource = blockMetaSource;
-	}
+    protected void setBlockMetaSource(final BlockMetaSource blockMetaSource) {
+        this.blockMetaSource = blockMetaSource;
+    }
 
-	protected void setWorldState(final HederaMutableWorldState worldState) {
-		this.worldState = worldState;
-	}
+    protected void setWorldState(final HederaMutableWorldState worldState) {
+        this.worldState = worldState;
+    }
 
-	protected EvmTxProcessor(
-			final HederaMutableWorldState worldState,
-			final LivePricesSource livePricesSource,
-			final GlobalDynamicProperties dynamicProperties,
-			final GasCalculator gasCalculator,
-			final Set<Operation> hederaOperations,
-			final Map<String, PrecompiledContract> precompiledContractMap,
-			final BlockMetaSource blockMetaSource
-	) {
-		this.worldState = worldState;
-		this.livePricesSource = livePricesSource;
-		this.dynamicProperties = dynamicProperties;
-		this.gasCalculator = gasCalculator;
+    protected EvmTxProcessor(
+            final HederaMutableWorldState worldState,
+            final LivePricesSource livePricesSource,
+            final GlobalDynamicProperties dynamicProperties,
+            final GasCalculator gasCalculator,
+            final Set<Operation> hederaOperations,
+            final Map<String, PrecompiledContract> precompiledContractMap,
+            final BlockMetaSource blockMetaSource) {
+        this.worldState = worldState;
+        this.livePricesSource = livePricesSource;
+        this.dynamicProperties = dynamicProperties;
+        this.gasCalculator = gasCalculator;
 
-		var operationRegistry = new OperationRegistry();
-		registerLondonOperations(operationRegistry, gasCalculator, BigInteger.valueOf(dynamicProperties.chainId()));
-		hederaOperations.forEach(operationRegistry::put);
+        var operationRegistry = new OperationRegistry();
+        registerLondonOperations(
+                operationRegistry, gasCalculator, BigInteger.valueOf(dynamicProperties.chainId()));
+        hederaOperations.forEach(operationRegistry::put);
 
-		final var evm = new EVM(operationRegistry, gasCalculator, EvmConfiguration.DEFAULT);
-		final var precompileContractRegistry = new PrecompileContractRegistry();
-		MainnetPrecompiledContracts.populateForIstanbul(precompileContractRegistry, this.gasCalculator);
+        final var evm = new EVM(operationRegistry, gasCalculator, EvmConfiguration.DEFAULT);
+        final var precompileContractRegistry = new PrecompileContractRegistry();
+        MainnetPrecompiledContracts.populateForIstanbul(
+                precompileContractRegistry, this.gasCalculator);
 
-		this.messageCallProcessor = new HederaMessageCallProcessor(
-				evm, precompileContractRegistry, precompiledContractMap);
-		this.contractCreationProcessor = new ContractCreationProcessor(
-				gasCalculator, evm, true, VALIDATION_RULES, 1);
-		this.blockMetaSource = blockMetaSource;
-	}
+        this.messageCallProcessor =
+                new HederaMessageCallProcessor(
+                        evm, precompileContractRegistry, precompiledContractMap);
+        this.contractCreationProcessor =
+                new ContractCreationProcessor(gasCalculator, evm, true, VALIDATION_RULES, 1);
+        this.blockMetaSource = blockMetaSource;
+    }
 
-	/**
-	 * Executes the {@link MessageFrame} of the EVM transaction. Returns the result as {@link
-	 * TransactionProcessingResult}
-	 *
-	 * @param sender
-	 * 		The origin {@link Account} that initiates the transaction
-	 * @param receiver
-	 * 		the priority form of the receiving {@link Address} (i.e., EIP-1014 if present); or the newly created address
-	 * @param gasPrice
-	 * 		GasPrice to use for gas calculations
-	 * @param gasLimit
-	 * 		Externally provided gas limit
-	 * @param value
-	 * 		Evm transaction value (HBars)
-	 * @param payload
-	 * 		Transaction payload. For Create transactions, the bytecode + constructor arguments
-	 * @param contractCreation
-	 * 		Whether or not this is a contract creation transaction
-	 * @param consensusTime
-	 * 		Current consensus time
-	 * @param isStatic
-	 * 		Whether the execution is static
-	 * @param expiryOracle
-	 * 		the oracle to use when determining the expiry of newly allocated storage
-	 * @param mirrorReceiver
-	 * 		the mirror form of the receiving {@link Address}; or the newly created address
-	 * @return the result of the EVM execution returned as {@link TransactionProcessingResult}
-	 */
-	protected TransactionProcessingResult execute(
-			final Account sender,
-			final Address receiver,
-			final long gasPrice,
-			final long gasLimit,
-			final long value,
-			final Bytes payload,
-			final boolean contractCreation,
-			final Instant consensusTime,
-			final boolean isStatic,
-			final StorageExpiry.Oracle expiryOracle,
-			final Address mirrorReceiver,
-			final BigInteger userOfferedGasPrice,
-			final long maxGasAllowanceInTinybars,
-			final Account relayer
-	) {
-		final Wei gasCost = Wei.of(Math.multiplyExact(gasLimit, gasPrice));
-		final Wei upfrontCost = gasCost.add(value);
-		final long intrinsicGas = gasCalculator.transactionIntrinsicGasCost(Bytes.EMPTY, contractCreation);
+    /**
+     * Executes the {@link MessageFrame} of the EVM transaction. Returns the result as {@link
+     * TransactionProcessingResult}
+     *
+     * @param sender The origin {@link Account} that initiates the transaction
+     * @param receiver the priority form of the receiving {@link Address} (i.e., EIP-1014 if
+     *     present); or the newly created address
+     * @param gasPrice GasPrice to use for gas calculations
+     * @param gasLimit Externally provided gas limit
+     * @param value Evm transaction value (HBars)
+     * @param payload Transaction payload. For Create transactions, the bytecode + constructor
+     *     arguments
+     * @param contractCreation Whether or not this is a contract creation transaction
+     * @param consensusTime Current consensus time
+     * @param isStatic Whether the execution is static
+     * @param expiryOracle the oracle to use when determining the expiry of newly allocated storage
+     * @param mirrorReceiver the mirror form of the receiving {@link Address}; or the newly created
+     *     address
+     * @return the result of the EVM execution returned as {@link TransactionProcessingResult}
+     */
+    protected TransactionProcessingResult execute(
+            final Account sender,
+            final Address receiver,
+            final long gasPrice,
+            final long gasLimit,
+            final long value,
+            final Bytes payload,
+            final boolean contractCreation,
+            final Instant consensusTime,
+            final boolean isStatic,
+            final StorageExpiry.Oracle expiryOracle,
+            final Address mirrorReceiver,
+            final BigInteger userOfferedGasPrice,
+            final long maxGasAllowanceInTinybars,
+            final Account relayer) {
+        final Wei gasCost = Wei.of(Math.multiplyExact(gasLimit, gasPrice));
+        final Wei upfrontCost = gasCost.add(value);
+        final long intrinsicGas =
+                gasCalculator.transactionIntrinsicGasCost(Bytes.EMPTY, contractCreation);
 
-		final HederaWorldState.Updater updater = (HederaWorldState.Updater) worldState.updater();
-		final var senderAccount = updater.getOrCreateSenderAccount(sender.getId().asEvmAddress());
-		final MutableAccount mutableSender = senderAccount.getMutable();
+        final HederaWorldState.Updater updater = (HederaWorldState.Updater) worldState.updater();
+        final var senderAccount = updater.getOrCreateSenderAccount(sender.getId().asEvmAddress());
+        final MutableAccount mutableSender = senderAccount.getMutable();
 
-		var allowanceCharged = Wei.ZERO;
-		MutableAccount mutableRelayer = null;
-		if (relayer != null) {
-			final var relayerAccount = updater.getOrCreateSenderAccount(relayer.getId().asEvmAddress());
-			mutableRelayer = relayerAccount.getMutable();
-		}
-		if (!isStatic) {
-			if (intrinsicGas > gasLimit) {
-				throw new InvalidTransactionException(INSUFFICIENT_GAS);
-			}
-			if (relayer == null) {
-				final var senderCanAffordGas = mutableSender.getBalance().compareTo(upfrontCost) >= 0;
-				validateTrue(senderCanAffordGas, INSUFFICIENT_PAYER_BALANCE);
-				mutableSender.decrementBalance(gasCost);
-			} else {
-				final var gasAllowance = Wei.of(maxGasAllowanceInTinybars);
-				if (userOfferedGasPrice.equals(BigInteger.ZERO)) {
-					// If sender set gas price to 0, relayer pays all the fees
-					validateTrue(gasAllowance.greaterOrEqualThan(gasCost), INSUFFICIENT_TX_FEE);
-					final var relayerCanAffordGas = mutableRelayer.getBalance().compareTo((gasCost)) >= 0;
-					validateTrue(relayerCanAffordGas, INSUFFICIENT_PAYER_BALANCE);
-					mutableRelayer.decrementBalance(gasCost);
-					allowanceCharged = gasCost;
-				} else if (userOfferedGasPrice.divide(WEIBARS_TO_TINYBARS).compareTo(BigInteger.valueOf(gasPrice)) < 0) {
-					// If sender gas price < current gas price, pay the difference from gas allowance
-					var senderFee =
-							Wei.of(userOfferedGasPrice.multiply(BigInteger.valueOf(gasLimit)).divide(WEIBARS_TO_TINYBARS));
-					validateTrue(mutableSender.getBalance().compareTo(senderFee) >= 0, INSUFFICIENT_PAYER_BALANCE);
-					final var remainingFee = gasCost.subtract(senderFee);
-					validateTrue(gasAllowance.greaterOrEqualThan(remainingFee), INSUFFICIENT_TX_FEE);
-					validateTrue(mutableRelayer.getBalance().compareTo(remainingFee) >= 0, INSUFFICIENT_PAYER_BALANCE);
-					mutableSender.decrementBalance(senderFee);
-					mutableRelayer.decrementBalance(remainingFee);
-					allowanceCharged = remainingFee;
-				} else {
-					// If user gas price >= current gas price, sender pays all fees
-					final var senderCanAffordGas = mutableSender.getBalance().compareTo(gasCost) >= 0;
-					validateTrue(senderCanAffordGas, INSUFFICIENT_PAYER_BALANCE);
-					mutableSender.decrementBalance(gasCost);
-				}
-				// In any case, the sender must have sufficient balance to pay for any value sent
-				final var senderCanAffordValue = mutableSender.getBalance().compareTo(Wei.of(value)) >= 0;
-				validateTrue(senderCanAffordValue, INSUFFICIENT_PAYER_BALANCE);
-			}
-		}
+        var allowanceCharged = Wei.ZERO;
+        MutableAccount mutableRelayer = null;
+        if (relayer != null) {
+            final var relayerAccount =
+                    updater.getOrCreateSenderAccount(relayer.getId().asEvmAddress());
+            mutableRelayer = relayerAccount.getMutable();
+        }
+        if (!isStatic) {
+            if (intrinsicGas > gasLimit) {
+                throw new InvalidTransactionException(INSUFFICIENT_GAS);
+            }
+            if (relayer == null) {
+                final var senderCanAffordGas =
+                        mutableSender.getBalance().compareTo(upfrontCost) >= 0;
+                validateTrue(senderCanAffordGas, INSUFFICIENT_PAYER_BALANCE);
+                mutableSender.decrementBalance(gasCost);
+            } else {
+                final var gasAllowance = Wei.of(maxGasAllowanceInTinybars);
+                if (userOfferedGasPrice.equals(BigInteger.ZERO)) {
+                    // If sender set gas price to 0, relayer pays all the fees
+                    validateTrue(gasAllowance.greaterOrEqualThan(gasCost), INSUFFICIENT_TX_FEE);
+                    final var relayerCanAffordGas =
+                            mutableRelayer.getBalance().compareTo((gasCost)) >= 0;
+                    validateTrue(relayerCanAffordGas, INSUFFICIENT_PAYER_BALANCE);
+                    mutableRelayer.decrementBalance(gasCost);
+                    allowanceCharged = gasCost;
+                } else if (userOfferedGasPrice
+                                .divide(WEIBARS_TO_TINYBARS)
+                                .compareTo(BigInteger.valueOf(gasPrice))
+                        < 0) {
+                    // If sender gas price < current gas price, pay the difference from gas
+                    // allowance
+                    var senderFee =
+                            Wei.of(
+                                    userOfferedGasPrice
+                                            .multiply(BigInteger.valueOf(gasLimit))
+                                            .divide(WEIBARS_TO_TINYBARS));
+                    validateTrue(
+                            mutableSender.getBalance().compareTo(senderFee) >= 0,
+                            INSUFFICIENT_PAYER_BALANCE);
+                    final var remainingFee = gasCost.subtract(senderFee);
+                    validateTrue(
+                            gasAllowance.greaterOrEqualThan(remainingFee), INSUFFICIENT_TX_FEE);
+                    validateTrue(
+                            mutableRelayer.getBalance().compareTo(remainingFee) >= 0,
+                            INSUFFICIENT_PAYER_BALANCE);
+                    mutableSender.decrementBalance(senderFee);
+                    mutableRelayer.decrementBalance(remainingFee);
+                    allowanceCharged = remainingFee;
+                } else {
+                    // If user gas price >= current gas price, sender pays all fees
+                    final var senderCanAffordGas =
+                            mutableSender.getBalance().compareTo(gasCost) >= 0;
+                    validateTrue(senderCanAffordGas, INSUFFICIENT_PAYER_BALANCE);
+                    mutableSender.decrementBalance(gasCost);
+                }
+                // In any case, the sender must have sufficient balance to pay for any value sent
+                final var senderCanAffordValue =
+                        mutableSender.getBalance().compareTo(Wei.of(value)) >= 0;
+                validateTrue(senderCanAffordValue, INSUFFICIENT_PAYER_BALANCE);
+            }
+        }
 
-		final var coinbase = Id.fromGrpcAccount(dynamicProperties.fundingAccount()).asEvmAddress();
-		final var blockValues = blockMetaSource.computeBlockValues(gasLimit);
-		final var gasAvailable = gasLimit - intrinsicGas;
-		final Deque<MessageFrame> messageFrameStack = new ArrayDeque<>();
+        final var coinbase = Id.fromGrpcAccount(dynamicProperties.fundingAccount()).asEvmAddress();
+        final var blockValues = blockMetaSource.computeBlockValues(gasLimit);
+        final var gasAvailable = gasLimit - intrinsicGas;
+        final Deque<MessageFrame> messageFrameStack = new ArrayDeque<>();
 
-		final var valueAsWei = Wei.of(value);
-		final var stackedUpdater = updater.updater();
-		final var senderEvmAddress = sender.canonicalAddress();
-		final MessageFrame.Builder commonInitialFrame =
-				MessageFrame.builder()
-						.messageFrameStack(messageFrameStack)
-						.maxStackSize(MAX_STACK_SIZE)
-						.worldUpdater(stackedUpdater)
-						.initialGas(gasAvailable)
-						.originator(senderEvmAddress)
-						.gasPrice(Wei.of(gasPrice))
-						.sender(senderEvmAddress)
-						.value(valueAsWei)
-						.apparentValue(valueAsWei)
-						.blockValues(blockValues)
-						.depth(0)
-						.completer(unused -> {
-						})
-						.isStatic(isStatic)
-						.miningBeneficiary(coinbase)
-						.blockHashLookup(blockMetaSource::getBlockHash)
-						.contextVariables(Map.of(
-								"sbh", storageByteHoursTinyBarsGiven(consensusTime),
-								"HederaFunctionality", getFunctionType(),
-								EXPIRY_ORACLE_CONTEXT_KEY, expiryOracle));
+        final var valueAsWei = Wei.of(value);
+        final var stackedUpdater = updater.updater();
+        final var senderEvmAddress = sender.canonicalAddress();
+        final MessageFrame.Builder commonInitialFrame =
+                MessageFrame.builder()
+                        .messageFrameStack(messageFrameStack)
+                        .maxStackSize(MAX_STACK_SIZE)
+                        .worldUpdater(stackedUpdater)
+                        .initialGas(gasAvailable)
+                        .originator(senderEvmAddress)
+                        .gasPrice(Wei.of(gasPrice))
+                        .sender(senderEvmAddress)
+                        .value(valueAsWei)
+                        .apparentValue(valueAsWei)
+                        .blockValues(blockValues)
+                        .depth(0)
+                        .completer(unused -> {})
+                        .isStatic(isStatic)
+                        .miningBeneficiary(coinbase)
+                        .blockHashLookup(blockMetaSource::getBlockHash)
+                        .contextVariables(
+                                Map.of(
+                                        "sbh",
+                                        storageByteHoursTinyBarsGiven(consensusTime),
+                                        "HederaFunctionality",
+                                        getFunctionType(),
+                                        EXPIRY_ORACLE_CONTEXT_KEY,
+                                        expiryOracle));
 
-		final MessageFrame initialFrame = buildInitialFrame(commonInitialFrame, receiver, payload, value);
-		messageFrameStack.addFirst(initialFrame);
+        final MessageFrame initialFrame =
+                buildInitialFrame(commonInitialFrame, receiver, payload, value);
+        messageFrameStack.addFirst(initialFrame);
 
-		while (!messageFrameStack.isEmpty()) {
-			process(messageFrameStack.peekFirst(), new HederaTracer());
-		}
+        while (!messageFrameStack.isEmpty()) {
+            process(messageFrameStack.peekFirst(), new HederaTracer());
+        }
 
-		var gasUsedByTransaction = calculateGasUsedByTX(gasLimit, initialFrame);
-		final long sbhRefund = updater.getSbhRefund();
-		final Map<Address, Map<Bytes, Pair<Bytes, Bytes>>> stateChanges;
+        var gasUsedByTransaction = calculateGasUsedByTX(gasLimit, initialFrame);
+        final long sbhRefund = updater.getSbhRefund();
+        final Map<Address, Map<Bytes, Pair<Bytes, Bytes>>> stateChanges;
 
-		if (isStatic) {
-			stateChanges = Map.of();
-		} else {
-			// return gas price to accounts
-			final long refunded = gasLimit - gasUsedByTransaction + sbhRefund;
-			final Wei refundedWei = Wei.of(refunded * gasPrice);
+        if (isStatic) {
+            stateChanges = Map.of();
+        } else {
+            // return gas price to accounts
+            final long refunded = gasLimit - gasUsedByTransaction + sbhRefund;
+            final Wei refundedWei = Wei.of(refunded * gasPrice);
 
-			if (refundedWei.greaterThan(Wei.ZERO)) {
-				if (relayer != null && allowanceCharged.greaterThan(Wei.ZERO)) {
-					// If allowance has been charged, we always try to refund relayer first
-					if (refundedWei.greaterOrEqualThan(allowanceCharged)) {
-						mutableRelayer.incrementBalance(allowanceCharged);
-						mutableSender.incrementBalance(refundedWei.subtract(allowanceCharged));
-					} else {
-						mutableRelayer.incrementBalance(refundedWei);
-					}
-				} else {
-					mutableSender.incrementBalance(refundedWei);
-				}
-			}
+            if (refundedWei.greaterThan(Wei.ZERO)) {
+                if (relayer != null && allowanceCharged.greaterThan(Wei.ZERO)) {
+                    // If allowance has been charged, we always try to refund relayer first
+                    if (refundedWei.greaterOrEqualThan(allowanceCharged)) {
+                        mutableRelayer.incrementBalance(allowanceCharged);
+                        mutableSender.incrementBalance(refundedWei.subtract(allowanceCharged));
+                    } else {
+                        mutableRelayer.incrementBalance(refundedWei);
+                    }
+                } else {
+                    mutableSender.incrementBalance(refundedWei);
+                }
+            }
 
-			// Send fees to coinbase
-			final var mutableCoinbase = updater.getOrCreate(coinbase).getMutable();
-			final long coinbaseFee = gasLimit - refunded;
+            // Send fees to coinbase
+            final var mutableCoinbase = updater.getOrCreate(coinbase).getMutable();
+            final long coinbaseFee = gasLimit - refunded;
 
-			mutableCoinbase.incrementBalance(Wei.of(coinbaseFee * gasPrice));
-			initialFrame.getSelfDestructs().forEach(updater::deleteAccount);
+            mutableCoinbase.incrementBalance(Wei.of(coinbaseFee * gasPrice));
+            initialFrame.getSelfDestructs().forEach(updater::deleteAccount);
 
-			if (dynamicProperties.shouldEnableTraceability()) {
-				stateChanges = updater.getFinalStateChanges();
-			} else {
-				stateChanges = Map.of();
-			}
+            if (dynamicProperties.shouldEnableTraceability()) {
+                stateChanges = updater.getFinalStateChanges();
+            } else {
+                stateChanges = Map.of();
+            }
 
-			// Commit top level updater
-			updater.commit();
-		}
+            // Commit top level updater
+            updater.commit();
+        }
 
-		// Externalise result
-		if (initialFrame.getState() == MessageFrame.State.COMPLETED_SUCCESS) {
-			return TransactionProcessingResult.successful(
-					initialFrame.getLogs(),
-					gasUsedByTransaction,
-					sbhRefund,
-					gasPrice,
-					initialFrame.getOutputData(),
-					mirrorReceiver,
-					stateChanges);
-		} else {
-			return TransactionProcessingResult.failed(
-					gasUsedByTransaction,
-					sbhRefund,
-					gasPrice,
-					initialFrame.getRevertReason(),
-					initialFrame.getExceptionalHaltReason(),
-					stateChanges);
-		}
-	}
+        // Externalise result
+        if (initialFrame.getState() == MessageFrame.State.COMPLETED_SUCCESS) {
+            return TransactionProcessingResult.successful(
+                    initialFrame.getLogs(),
+                    gasUsedByTransaction,
+                    sbhRefund,
+                    gasPrice,
+                    initialFrame.getOutputData(),
+                    mirrorReceiver,
+                    stateChanges);
+        } else {
+            return TransactionProcessingResult.failed(
+                    gasUsedByTransaction,
+                    sbhRefund,
+                    gasPrice,
+                    initialFrame.getRevertReason(),
+                    initialFrame.getExceptionalHaltReason(),
+                    stateChanges);
+        }
+    }
 
-	private long calculateGasUsedByTX(final long txGasLimit, final MessageFrame initialFrame) {
-		long gasUsedByTransaction = txGasLimit - initialFrame.getRemainingGas();
-		/* Return leftover gas */
-		final long selfDestructRefund =
-				gasCalculator.getSelfDestructRefundAmount() *
-				Math.min(
-						initialFrame.getSelfDestructs().size(),
-						gasUsedByTransaction / (gasCalculator.getMaxRefundQuotient()));
+    private long calculateGasUsedByTX(final long txGasLimit, final MessageFrame initialFrame) {
+        long gasUsedByTransaction = txGasLimit - initialFrame.getRemainingGas();
+        /* Return leftover gas */
+        final long selfDestructRefund =
+                gasCalculator.getSelfDestructRefundAmount()
+                        * Math.min(
+                                initialFrame.getSelfDestructs().size(),
+                                gasUsedByTransaction / (gasCalculator.getMaxRefundQuotient()));
 
-		gasUsedByTransaction = gasUsedByTransaction - selfDestructRefund - initialFrame.getGasRefund();
+        gasUsedByTransaction =
+                gasUsedByTransaction - selfDestructRefund - initialFrame.getGasRefund();
 
-		final var maxRefundPercent = dynamicProperties.maxGasRefundPercentage();
-		gasUsedByTransaction = Math.max(gasUsedByTransaction, txGasLimit - txGasLimit * maxRefundPercent / 100);
+        final var maxRefundPercent = dynamicProperties.maxGasRefundPercentage();
+        gasUsedByTransaction =
+                Math.max(gasUsedByTransaction, txGasLimit - txGasLimit * maxRefundPercent / 100);
 
-		return gasUsedByTransaction;
-	}
+        return gasUsedByTransaction;
+    }
 
-	protected long gasPriceTinyBarsGiven(final Instant consensusTime, boolean isEthTxn) {
-		return livePricesSource.currentGasPrice(consensusTime,
-				isEthTxn ? HederaFunctionality.EthereumTransaction : getFunctionType());
-	}
+    protected long gasPriceTinyBarsGiven(final Instant consensusTime, boolean isEthTxn) {
+        return livePricesSource.currentGasPrice(
+                consensusTime,
+                isEthTxn ? HederaFunctionality.EthereumTransaction : getFunctionType());
+    }
 
-	protected long storageByteHoursTinyBarsGiven(final Instant consensusTime) {
-		return livePricesSource.currentGasPrice(consensusTime, getFunctionType());
-	}
+    protected long storageByteHoursTinyBarsGiven(final Instant consensusTime) {
+        return livePricesSource.currentGasPrice(consensusTime, getFunctionType());
+    }
 
-	protected abstract HederaFunctionality getFunctionType();
+    protected abstract HederaFunctionality getFunctionType();
 
-	protected abstract MessageFrame buildInitialFrame(MessageFrame.Builder baseInitialFrame, Address to, Bytes payload,
-			final long value);
+    protected abstract MessageFrame buildInitialFrame(
+            MessageFrame.Builder baseInitialFrame, Address to, Bytes payload, final long value);
 
-	protected void process(final MessageFrame frame, final OperationTracer operationTracer) {
-		final AbstractMessageProcessor executor = getMessageProcessor(frame.getType());
+    protected void process(final MessageFrame frame, final OperationTracer operationTracer) {
+        final AbstractMessageProcessor executor = getMessageProcessor(frame.getType());
 
-		executor.process(frame, operationTracer);
-	}
+        executor.process(frame, operationTracer);
+    }
 
-	private AbstractMessageProcessor getMessageProcessor(final MessageFrame.Type type) {
-		switch (type) {
-			case MESSAGE_CALL:
-				return messageCallProcessor;
-			case CONTRACT_CREATION:
-				return contractCreationProcessor;
-			default:
-				throw new IllegalStateException("Request for unsupported message processor type " + type);
-		}
-	}
+    private AbstractMessageProcessor getMessageProcessor(final MessageFrame.Type type) {
+        switch (type) {
+            case MESSAGE_CALL:
+                return messageCallProcessor;
+            case CONTRACT_CREATION:
+                return contractCreationProcessor;
+            default:
+                throw new IllegalStateException(
+                        "Request for unsupported message processor type " + type);
+        }
+    }
 }
-

--- a/hedera-node/src/main/java/com/hedera/services/contracts/execution/EvmTxProcessor.java
+++ b/hedera-node/src/main/java/com/hedera/services/contracts/execution/EvmTxProcessor.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2021-2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hedera.services.contracts.execution;
 
 /*

--- a/hedera-node/src/main/java/com/hedera/services/contracts/execution/HederaBlockValues.java
+++ b/hedera-node/src/main/java/com/hedera/services/contracts/execution/HederaBlockValues.java
@@ -22,50 +22,47 @@ package com.hedera.services.contracts.execution;
  *
  */
 
+import java.time.Instant;
+import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.units.bigints.UInt256;
 import org.hyperledger.besu.datatypes.Wei;
 import org.hyperledger.besu.evm.frame.BlockValues;
 
-import java.time.Instant;
-import java.util.Optional;
-
-/**
- * Hedera adapted {@link BlockValues}
- */
+/** Hedera adapted {@link BlockValues} */
 public class HederaBlockValues implements BlockValues {
-	protected final long gasLimit;
-	protected final long blockNo;
-	protected final Instant consTimestamp;
+    protected final long gasLimit;
+    protected final long blockNo;
+    protected final Instant consTimestamp;
 
-	public HederaBlockValues(final long gasLimit, final long blockNo, final Instant consTimestamp) {
-		this.gasLimit = gasLimit;
-		this.blockNo = blockNo;
-		this.consTimestamp = consTimestamp;
-	}
+    public HederaBlockValues(final long gasLimit, final long blockNo, final Instant consTimestamp) {
+        this.gasLimit = gasLimit;
+        this.blockNo = blockNo;
+        this.consTimestamp = consTimestamp;
+    }
 
-	@Override
-	public long getGasLimit() {
-		return gasLimit;
-	}
+    @Override
+    public long getGasLimit() {
+        return gasLimit;
+    }
 
-	@Override
-	public long getTimestamp() {
-		return consTimestamp.getEpochSecond();
-	}
+    @Override
+    public long getTimestamp() {
+        return consTimestamp.getEpochSecond();
+    }
 
-	@Override
-	public Optional<Wei> getBaseFee() {
-		return Optional.of(Wei.ZERO);
-	}
+    @Override
+    public Optional<Wei> getBaseFee() {
+        return Optional.of(Wei.ZERO);
+    }
 
-	@Override
-	public Bytes getDifficultyBytes() {
-		return UInt256.ZERO;
-	}
+    @Override
+    public Bytes getDifficultyBytes() {
+        return UInt256.ZERO;
+    }
 
-	@Override
-	public long getNumber() {
-		return blockNo;
-	}
+    @Override
+    public long getNumber() {
+        return blockNo;
+    }
 }

--- a/hedera-node/src/main/java/com/hedera/services/contracts/execution/HederaBlockValues.java
+++ b/hedera-node/src/main/java/com/hedera/services/contracts/execution/HederaBlockValues.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2021-2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hedera.services.contracts.execution;
 
 /*

--- a/hedera-node/src/main/java/com/hedera/services/contracts/execution/HederaMessageCallProcessor.java
+++ b/hedera-node/src/main/java/com/hedera/services/contracts/execution/HederaMessageCallProcessor.java
@@ -1,24 +1,19 @@
-package com.hedera.services.contracts.execution;
-
-/*-
- * ‌
- * Hedera Services Node
- * ​
- * Copyright (C) 2018 - 2022 Hedera Hashgraph, LLC
- * ​
+/*
+ * Copyright (C) 2022 Hedera Hashgraph, LLC
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- * ‍
  */
+package com.hedera.services.contracts.execution;
 
 import static org.hyperledger.besu.evm.frame.ExceptionalHaltReason.INSUFFICIENT_GAS;
 import static org.hyperledger.besu.evm.frame.MessageFrame.State.COMPLETED_SUCCESS;
@@ -39,64 +34,61 @@ import org.hyperledger.besu.evm.precompile.PrecompiledContract;
 import org.hyperledger.besu.evm.processor.MessageCallProcessor;
 import org.hyperledger.besu.evm.tracing.OperationTracer;
 
-/**
- * Overrides Besu precompiler handling, so we can break model layers in Precompile execution
- */
+/** Overrides Besu precompiler handling, so we can break model layers in Precompile execution */
 public class HederaMessageCallProcessor extends MessageCallProcessor {
-	private static final String INVALID_TRANSFER_MSG = "Transfer of Value to Hedera Precompile";
-	public static final Bytes INVALID_TRANSFER = Bytes.of(INVALID_TRANSFER_MSG.getBytes(StandardCharsets.UTF_8));
+    private static final String INVALID_TRANSFER_MSG = "Transfer of Value to Hedera Precompile";
+    public static final Bytes INVALID_TRANSFER =
+            Bytes.of(INVALID_TRANSFER_MSG.getBytes(StandardCharsets.UTF_8));
 
-	private final Map<Address, PrecompiledContract> hederaPrecompiles;
+    private final Map<Address, PrecompiledContract> hederaPrecompiles;
 
-	public HederaMessageCallProcessor(
-			final EVM evm,
-			final PrecompileContractRegistry precompiles,
-			final Map<String, PrecompiledContract> hederaPrecompileList
-	) {
-		super(evm, precompiles);
-		hederaPrecompiles = new HashMap<>();
-		hederaPrecompileList.forEach((k, v) -> hederaPrecompiles.put(Address.fromHexString(k), v));
-	}
+    public HederaMessageCallProcessor(
+            final EVM evm,
+            final PrecompileContractRegistry precompiles,
+            final Map<String, PrecompiledContract> hederaPrecompileList) {
+        super(evm, precompiles);
+        hederaPrecompiles = new HashMap<>();
+        hederaPrecompileList.forEach((k, v) -> hederaPrecompiles.put(Address.fromHexString(k), v));
+    }
 
-	@Override
-	public void start(final MessageFrame frame, final OperationTracer operationTracer) {
-		final var hederaPrecompile = hederaPrecompiles.get(frame.getContractAddress());
-		if (hederaPrecompile != null) {
-			executeHederaPrecompile(hederaPrecompile, frame, operationTracer);
-		} else {
-			super.start(frame, operationTracer);
-		}
-	}
+    @Override
+    public void start(final MessageFrame frame, final OperationTracer operationTracer) {
+        final var hederaPrecompile = hederaPrecompiles.get(frame.getContractAddress());
+        if (hederaPrecompile != null) {
+            executeHederaPrecompile(hederaPrecompile, frame, operationTracer);
+        } else {
+            super.start(frame, operationTracer);
+        }
+    }
 
-	void executeHederaPrecompile(
-			final PrecompiledContract contract,
-			final MessageFrame frame,
-			final OperationTracer operationTracer
-	) {
-		final long gasRequirement;
-		final Bytes output;
-		if (contract instanceof HTSPrecompiledContract htsPrecompile) {
-			final var costedResult = htsPrecompile.computeCosted(frame.getInputData(), frame);
-			if (frame.getState() == REVERT) {
-				return;
-			}
-			output = costedResult.getValue();
-			gasRequirement = costedResult.getKey();
-		} else {
-			output = contract.computePrecompile(frame.getInputData(), frame).getOutput();
-			gasRequirement = contract.gasRequirement(frame.getInputData());
-		}
-		operationTracer.tracePrecompileCall(frame, gasRequirement, output);
-		if (frame.getRemainingGas() < gasRequirement) {
-			frame.decrementRemainingGas(frame.getRemainingGas());
-			frame.setExceptionalHaltReason(Optional.of(INSUFFICIENT_GAS));
-			frame.setState(EXCEPTIONAL_HALT);
-		} else if (output != null) {
-			frame.decrementRemainingGas(gasRequirement);
-			frame.setOutputData(output);
-			frame.setState(COMPLETED_SUCCESS);
-		} else {
-			frame.setState(EXCEPTIONAL_HALT);
-		}
-	}
+    void executeHederaPrecompile(
+            final PrecompiledContract contract,
+            final MessageFrame frame,
+            final OperationTracer operationTracer) {
+        final long gasRequirement;
+        final Bytes output;
+        if (contract instanceof HTSPrecompiledContract htsPrecompile) {
+            final var costedResult = htsPrecompile.computeCosted(frame.getInputData(), frame);
+            if (frame.getState() == REVERT) {
+                return;
+            }
+            output = costedResult.getValue();
+            gasRequirement = costedResult.getKey();
+        } else {
+            output = contract.computePrecompile(frame.getInputData(), frame).getOutput();
+            gasRequirement = contract.gasRequirement(frame.getInputData());
+        }
+        operationTracer.tracePrecompileCall(frame, gasRequirement, output);
+        if (frame.getRemainingGas() < gasRequirement) {
+            frame.decrementRemainingGas(frame.getRemainingGas());
+            frame.setExceptionalHaltReason(Optional.of(INSUFFICIENT_GAS));
+            frame.setState(EXCEPTIONAL_HALT);
+        } else if (output != null) {
+            frame.decrementRemainingGas(gasRequirement);
+            frame.setOutputData(output);
+            frame.setState(COMPLETED_SUCCESS);
+        } else {
+            frame.setState(EXCEPTIONAL_HALT);
+        }
+    }
 }

--- a/hedera-node/src/main/java/com/hedera/services/contracts/execution/HederaMessageCallProcessor.java
+++ b/hedera-node/src/main/java/com/hedera/services/contracts/execution/HederaMessageCallProcessor.java
@@ -20,7 +20,16 @@ package com.hedera.services.contracts.execution;
  * ‍
  */
 
+import static org.hyperledger.besu.evm.frame.ExceptionalHaltReason.INSUFFICIENT_GAS;
+import static org.hyperledger.besu.evm.frame.MessageFrame.State.COMPLETED_SUCCESS;
+import static org.hyperledger.besu.evm.frame.MessageFrame.State.EXCEPTIONAL_HALT;
+import static org.hyperledger.besu.evm.frame.MessageFrame.State.REVERT;
+
 import com.hedera.services.store.contracts.precompile.HTSPrecompiledContract;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes;
 import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.evm.EVM;
@@ -29,16 +38,6 @@ import org.hyperledger.besu.evm.precompile.PrecompileContractRegistry;
 import org.hyperledger.besu.evm.precompile.PrecompiledContract;
 import org.hyperledger.besu.evm.processor.MessageCallProcessor;
 import org.hyperledger.besu.evm.tracing.OperationTracer;
-
-import java.nio.charset.StandardCharsets;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Optional;
-
-import static org.hyperledger.besu.evm.frame.ExceptionalHaltReason.INSUFFICIENT_GAS;
-import static org.hyperledger.besu.evm.frame.MessageFrame.State.COMPLETED_SUCCESS;
-import static org.hyperledger.besu.evm.frame.MessageFrame.State.EXCEPTIONAL_HALT;
-import static org.hyperledger.besu.evm.frame.MessageFrame.State.REVERT;
 
 /**
  * Overrides Besu precompiler handling, so we can break model layers in Precompile execution

--- a/hedera-node/src/main/java/com/hedera/services/contracts/execution/HederaTracer.java
+++ b/hedera-node/src/main/java/com/hedera/services/contracts/execution/HederaTracer.java
@@ -22,26 +22,25 @@ package com.hedera.services.contracts.execution;
  *
  */
 
-
+import java.util.Optional;
 import org.hyperledger.besu.evm.frame.ExceptionalHaltReason;
 import org.hyperledger.besu.evm.frame.MessageFrame;
 import org.hyperledger.besu.evm.tracing.OperationTracer;
 
-import java.util.Optional;
-
 /**
- * Custom {@link OperationTracer} that populates exceptional halt reasons in the {@link MessageFrame}
+ * Custom {@link OperationTracer} that populates exceptional halt reasons in the {@link
+ * MessageFrame}
  */
 public class HederaTracer implements OperationTracer {
 
-	@Override
-	public void traceExecution(MessageFrame frame, ExecuteOperation executeOperation) {
-		executeOperation.execute();
-	}
+    @Override
+    public void traceExecution(MessageFrame frame, ExecuteOperation executeOperation) {
+        executeOperation.execute();
+    }
 
-	@Override
-	public void traceAccountCreationResult(
-			final MessageFrame frame, final Optional<ExceptionalHaltReason> haltReason) {
-		frame.setExceptionalHaltReason(haltReason);
-	}
+    @Override
+    public void traceAccountCreationResult(
+            final MessageFrame frame, final Optional<ExceptionalHaltReason> haltReason) {
+        frame.setExceptionalHaltReason(haltReason);
+    }
 }

--- a/hedera-node/src/main/java/com/hedera/services/contracts/execution/HederaTracer.java
+++ b/hedera-node/src/main/java/com/hedera/services/contracts/execution/HederaTracer.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2020-2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hedera.services.contracts.execution;
 
 /*

--- a/hedera-node/src/main/java/com/hedera/services/contracts/execution/InHandleBlockMetaSource.java
+++ b/hedera-node/src/main/java/com/hedera/services/contracts/execution/InHandleBlockMetaSource.java
@@ -1,11 +1,6 @@
-package com.hedera.services.contracts.execution;
-
-/*-
- * ‌
- * Hedera Services Node
- * ​
- * Copyright (C) 2018 - 2022 Hedera Hashgraph, LLC
- * ​
+/*
+ * Copyright (C) 2020-2022 Hedera Hashgraph, LLC
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -17,8 +12,8 @@ package com.hedera.services.contracts.execution;
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- * ‍
  */
+package com.hedera.services.contracts.execution;
 
 import com.hedera.services.context.TransactionContext;
 import com.hedera.services.state.logic.BlockManager;

--- a/hedera-node/src/main/java/com/hedera/services/contracts/execution/InHandleBlockMetaSource.java
+++ b/hedera-node/src/main/java/com/hedera/services/contracts/execution/InHandleBlockMetaSource.java
@@ -9,9 +9,9 @@ package com.hedera.services.contracts.execution;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -22,30 +22,30 @@ package com.hedera.services.contracts.execution;
 
 import com.hedera.services.context.TransactionContext;
 import com.hedera.services.state.logic.BlockManager;
+import javax.inject.Inject;
+import javax.inject.Singleton;
 import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.evm.frame.BlockValues;
 
-import javax.inject.Inject;
-import javax.inject.Singleton;
-
 @Singleton
 public class InHandleBlockMetaSource implements BlockMetaSource {
-	private final BlockManager blockManager;
-	private final TransactionContext txnCtx;
+    private final BlockManager blockManager;
+    private final TransactionContext txnCtx;
 
-	@Inject
-	public InHandleBlockMetaSource(final BlockManager blockManager, final TransactionContext txnCtx) {
-		this.blockManager = blockManager;
-		this.txnCtx = txnCtx;
-	}
+    @Inject
+    public InHandleBlockMetaSource(
+            final BlockManager blockManager, final TransactionContext txnCtx) {
+        this.blockManager = blockManager;
+        this.txnCtx = txnCtx;
+    }
 
-	@Override
-	public Hash getBlockHash(final long blockNo) {
-		return blockManager.getBlockHash(blockNo);
-	}
+    @Override
+    public Hash getBlockHash(final long blockNo) {
+        return blockManager.getBlockHash(blockNo);
+    }
 
-	@Override
-	public BlockValues computeBlockValues(final long gasLimit) {
-		return blockManager.computeBlockValues(txnCtx.consensusTime(), gasLimit);
-	}
+    @Override
+    public BlockValues computeBlockValues(final long gasLimit) {
+        return blockManager.computeBlockValues(txnCtx.consensusTime(), gasLimit);
+    }
 }

--- a/hedera-node/src/main/java/com/hedera/services/contracts/execution/LivePricesSource.java
+++ b/hedera-node/src/main/java/com/hedera/services/contracts/execution/LivePricesSource.java
@@ -1,11 +1,6 @@
-package com.hedera.services.contracts.execution;
-
-/*-
- * ‌
- * Hedera Services Node
- * ​
- * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
- * ​
+/*
+ * Copyright (C) 2021-2022 Hedera Hashgraph, LLC
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -17,8 +12,8 @@ package com.hedera.services.contracts.execution;
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- * ‍
  */
+package com.hedera.services.contracts.execution;
 
 import static com.hederahashgraph.fee.FeeBuilder.getTinybarsFromTinyCents;
 

--- a/hedera-node/src/main/java/com/hedera/services/contracts/execution/LivePricesSource.java
+++ b/hedera-node/src/main/java/com/hedera/services/contracts/execution/LivePricesSource.java
@@ -20,6 +20,8 @@ package com.hedera.services.contracts.execution;
  * ‍
  */
 
+import static com.hederahashgraph.fee.FeeBuilder.getTinybarsFromTinyCents;
+
 import com.hedera.services.context.TransactionContext;
 import com.hedera.services.fees.FeeMultiplierSource;
 import com.hedera.services.fees.HbarCentExchange;
@@ -27,72 +29,69 @@ import com.hedera.services.fees.calculation.UsagePricesProvider;
 import com.hederahashgraph.api.proto.java.FeeComponents;
 import com.hederahashgraph.api.proto.java.HederaFunctionality;
 import com.hederahashgraph.api.proto.java.Timestamp;
-
-import javax.inject.Inject;
-import javax.inject.Singleton;
 import java.time.Instant;
 import java.util.function.ToLongFunction;
-
-import static com.hederahashgraph.fee.FeeBuilder.getTinybarsFromTinyCents;
+import javax.inject.Inject;
+import javax.inject.Singleton;
 
 @Singleton
 public class LivePricesSource {
-	private final HbarCentExchange exchange;
-	private final UsagePricesProvider usagePrices;
-	private final FeeMultiplierSource feeMultiplierSource;
-	private final TransactionContext txnCtx;
+    private final HbarCentExchange exchange;
+    private final UsagePricesProvider usagePrices;
+    private final FeeMultiplierSource feeMultiplierSource;
+    private final TransactionContext txnCtx;
 
-	@Inject
-	public LivePricesSource(
-			final HbarCentExchange exchange,
-			final UsagePricesProvider usagePrices,
-			final FeeMultiplierSource feeMultiplierSource,
-			final TransactionContext txnCtx) {
-		this.exchange = exchange;
-		this.usagePrices = usagePrices;
-		this.feeMultiplierSource = feeMultiplierSource;
-		this.txnCtx = txnCtx;
-	}
+    @Inject
+    public LivePricesSource(
+            final HbarCentExchange exchange,
+            final UsagePricesProvider usagePrices,
+            final FeeMultiplierSource feeMultiplierSource,
+            final TransactionContext txnCtx) {
+        this.exchange = exchange;
+        this.usagePrices = usagePrices;
+        this.feeMultiplierSource = feeMultiplierSource;
+        this.txnCtx = txnCtx;
+    }
 
-	public long currentGasPrice(final Instant now, final HederaFunctionality function) {
-		return currentPrice(now, function, FeeComponents::getGas);
-	}
+    public long currentGasPrice(final Instant now, final HederaFunctionality function) {
+        return currentPrice(now, function, FeeComponents::getGas);
+    }
 
-	public long currentStorageByteHoursPrice(final Instant now, final HederaFunctionality function) {
-		return currentPrice(now, function, FeeComponents::getSbh);
-	}
+    public long currentStorageByteHoursPrice(
+            final Instant now, final HederaFunctionality function) {
+        return currentPrice(now, function, FeeComponents::getSbh);
+    }
 
-	public long currentGasPriceInTinycents(final Instant now, final HederaFunctionality function) {
-		return currentFeeInTinycents(now, function, FeeComponents::getGas);
-	}
+    public long currentGasPriceInTinycents(final Instant now, final HederaFunctionality function) {
+        return currentFeeInTinycents(now, function, FeeComponents::getGas);
+    }
 
-	private long currentPrice(
-			final Instant now,
-			final HederaFunctionality function,
-			final ToLongFunction<FeeComponents> resourcePriceFn
-	) {
-		final var timestamp = Timestamp.newBuilder().setSeconds(now.getEpochSecond()).build();
-		long feeInTinyCents = currentFeeInTinycents(now, function, resourcePriceFn);
-		long feeInTinyBars = getTinybarsFromTinyCents(exchange.rate(timestamp), feeInTinyCents);
-		final var unscaledPrice = Math.max(1L, feeInTinyBars);
+    private long currentPrice(
+            final Instant now,
+            final HederaFunctionality function,
+            final ToLongFunction<FeeComponents> resourcePriceFn) {
+        final var timestamp = Timestamp.newBuilder().setSeconds(now.getEpochSecond()).build();
+        long feeInTinyCents = currentFeeInTinycents(now, function, resourcePriceFn);
+        long feeInTinyBars = getTinybarsFromTinyCents(exchange.rate(timestamp), feeInTinyCents);
+        final var unscaledPrice = Math.max(1L, feeInTinyBars);
 
-		final var maxMultiplier = Long.MAX_VALUE / feeInTinyBars;
-		final var curMultiplier = feeMultiplierSource.currentMultiplier(txnCtx.accessor());
-		if (curMultiplier > maxMultiplier) {
-			return Long.MAX_VALUE;
-		} else {
-			return unscaledPrice * curMultiplier;
-		}
-	}
+        final var maxMultiplier = Long.MAX_VALUE / feeInTinyBars;
+        final var curMultiplier = feeMultiplierSource.currentMultiplier(txnCtx.accessor());
+        if (curMultiplier > maxMultiplier) {
+            return Long.MAX_VALUE;
+        } else {
+            return unscaledPrice * curMultiplier;
+        }
+    }
 
-	private long currentFeeInTinycents(
-			final Instant now,
-			final HederaFunctionality function,
-			final ToLongFunction<FeeComponents> resourcePriceFn) {
-		final var timestamp = Timestamp.newBuilder().setSeconds(now.getEpochSecond()).build();
-		final var prices = usagePrices.defaultPricesGiven(function, timestamp);
+    private long currentFeeInTinycents(
+            final Instant now,
+            final HederaFunctionality function,
+            final ToLongFunction<FeeComponents> resourcePriceFn) {
+        final var timestamp = Timestamp.newBuilder().setSeconds(now.getEpochSecond()).build();
+        final var prices = usagePrices.defaultPricesGiven(function, timestamp);
 
-		/* Fee schedule prices are set in thousandths of a tinycent */
-		return resourcePriceFn.applyAsLong(prices.getServicedata()) / 1000;
-	}
+        /* Fee schedule prices are set in thousandths of a tinycent */
+        return resourcePriceFn.applyAsLong(prices.getServicedata()) / 1000;
+    }
 }

--- a/hedera-node/src/main/java/com/hedera/services/contracts/execution/StaticBlockMetaProvider.java
+++ b/hedera-node/src/main/java/com/hedera/services/contracts/execution/StaticBlockMetaProvider.java
@@ -1,11 +1,6 @@
-package com.hedera.services.contracts.execution;
-
-/*-
- * ‌
- * Hedera Services Node
- * ​
- * Copyright (C) 2018 - 2022 Hedera Hashgraph, LLC
- * ​
+/*
+ * Copyright (C) 2020-2022 Hedera Hashgraph, LLC
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -17,8 +12,8 @@ package com.hedera.services.contracts.execution;
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- * ‍
  */
+package com.hedera.services.contracts.execution;
 
 import com.hedera.services.context.primitives.SignedStateViewFactory;
 import java.util.Optional;

--- a/hedera-node/src/main/java/com/hedera/services/contracts/execution/StaticBlockMetaProvider.java
+++ b/hedera-node/src/main/java/com/hedera/services/contracts/execution/StaticBlockMetaProvider.java
@@ -9,9 +9,9 @@ package com.hedera.services.contracts.execution;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -21,22 +21,22 @@ package com.hedera.services.contracts.execution;
  */
 
 import com.hedera.services.context.primitives.SignedStateViewFactory;
-
+import java.util.Optional;
 import javax.inject.Inject;
 import javax.inject.Singleton;
-import java.util.Optional;
 
 @Singleton
 public class StaticBlockMetaProvider {
-	private final SignedStateViewFactory stateViewFactory;
+    private final SignedStateViewFactory stateViewFactory;
 
-	@Inject
-	public StaticBlockMetaProvider(final SignedStateViewFactory stateViewFactory) {
-		this.stateViewFactory = stateViewFactory;
-	}
+    @Inject
+    public StaticBlockMetaProvider(final SignedStateViewFactory stateViewFactory) {
+        this.stateViewFactory = stateViewFactory;
+    }
 
-	public Optional<BlockMetaSource> getSource() {
-		return stateViewFactory.childrenOfLatestSignedState()
-				.map(children -> StaticBlockMetaSource.from(children.networkCtx()));
-	}
+    public Optional<BlockMetaSource> getSource() {
+        return stateViewFactory
+                .childrenOfLatestSignedState()
+                .map(children -> StaticBlockMetaSource.from(children.networkCtx()));
+    }
 }

--- a/hedera-node/src/main/java/com/hedera/services/contracts/execution/StaticBlockMetaSource.java
+++ b/hedera-node/src/main/java/com/hedera/services/contracts/execution/StaticBlockMetaSource.java
@@ -21,45 +21,45 @@ package com.hedera.services.contracts.execution;
  */
 
 import com.hedera.services.state.merkle.MerkleNetworkContext;
+import java.time.Instant;
 import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.evm.frame.BlockValues;
 
-import java.time.Instant;
-
 /**
- * A {@link BlockMetaSource} that gets its information from a particular {@link MerkleNetworkContext}, which
- * ideally will be an immutable instance from the latest signed state.
+ * A {@link BlockMetaSource} that gets its information from a particular {@link
+ * MerkleNetworkContext}, which ideally will be an immutable instance from the latest signed state.
  *
- * The important thing is that, unlike {@link InHandleBlockMetaSource}, here the {@code computeBlockValues()}
- * implementation has no side effects on the state of the {@link com.hedera.services.state.logic.BlockManager}
- * singleton that manages block metadata in the working network context.
+ * <p>The important thing is that, unlike {@link InHandleBlockMetaSource}, here the {@code
+ * computeBlockValues()} implementation has no side effects on the state of the {@link
+ * com.hedera.services.state.logic.BlockManager} singleton that manages block metadata in the
+ * working network context.
  */
 public class StaticBlockMetaSource implements BlockMetaSource {
-	private final MerkleNetworkContext networkCtx;
+    private final MerkleNetworkContext networkCtx;
 
-	public StaticBlockMetaSource(final MerkleNetworkContext networkCtx) {
-		this.networkCtx = networkCtx;
-	}
+    public StaticBlockMetaSource(final MerkleNetworkContext networkCtx) {
+        this.networkCtx = networkCtx;
+    }
 
-	public static StaticBlockMetaSource from(final MerkleNetworkContext networkCtx) {
-		return new StaticBlockMetaSource(networkCtx);
-	}
+    public static StaticBlockMetaSource from(final MerkleNetworkContext networkCtx) {
+        return new StaticBlockMetaSource(networkCtx);
+    }
 
-	@Override
-	public Hash getBlockHash(final long blockNo) {
-		return networkCtx.getBlockHashByNumber(blockNo);
-	}
+    @Override
+    public Hash getBlockHash(final long blockNo) {
+        return networkCtx.getBlockHashByNumber(blockNo);
+    }
 
-	@Override
-	public BlockValues computeBlockValues(final long gasLimit) {
-		final var nominalBlockNo = networkCtx.getAlignmentBlockNo();
-		var nominalTimestamp = networkCtx.firstConsTimeOfCurrentBlock();
-		// This is exceedingly unlikely in practice, as it requires a ContractCallLocal query to run
-		// as exactly the first network interaction immediately after a genesis reset; as there's no
-		// impact on consensus state, falling back to Instant.now() is acceptable
-		if (nominalTimestamp == null) {
-			nominalTimestamp = Instant.now();
-		}
-		return new HederaBlockValues(gasLimit, nominalBlockNo, nominalTimestamp);
-	}
+    @Override
+    public BlockValues computeBlockValues(final long gasLimit) {
+        final var nominalBlockNo = networkCtx.getAlignmentBlockNo();
+        var nominalTimestamp = networkCtx.firstConsTimeOfCurrentBlock();
+        // This is exceedingly unlikely in practice, as it requires a ContractCallLocal query to run
+        // as exactly the first network interaction immediately after a genesis reset; as there's no
+        // impact on consensus state, falling back to Instant.now() is acceptable
+        if (nominalTimestamp == null) {
+            nominalTimestamp = Instant.now();
+        }
+        return new HederaBlockValues(gasLimit, nominalBlockNo, nominalTimestamp);
+    }
 }

--- a/hedera-node/src/main/java/com/hedera/services/contracts/execution/StaticBlockMetaSource.java
+++ b/hedera-node/src/main/java/com/hedera/services/contracts/execution/StaticBlockMetaSource.java
@@ -1,11 +1,6 @@
-package com.hedera.services.contracts.execution;
-
-/*-
- * ‌
- * Hedera Services Node
- * ​
- * Copyright (C) 2018 - 2022 Hedera Hashgraph, LLC
- * ​
+/*
+ * Copyright (C) 2022 Hedera Hashgraph, LLC
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -17,8 +12,8 @@ package com.hedera.services.contracts.execution;
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- * ‍
  */
+package com.hedera.services.contracts.execution;
 
 import com.hedera.services.state.merkle.MerkleNetworkContext;
 import java.time.Instant;

--- a/hedera-node/src/main/java/com/hedera/services/contracts/execution/TransactionProcessingResult.java
+++ b/hedera-node/src/main/java/com/hedera/services/contracts/execution/TransactionProcessingResult.java
@@ -25,187 +25,178 @@ package com.hedera.services.contracts.execution;
 import com.hedera.services.state.submerkle.EvmFnResult;
 import com.hederahashgraph.api.proto.java.ContractFunctionResult;
 import com.hederahashgraph.api.proto.java.ContractID;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.tuweni.bytes.Bytes;
 import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.evm.frame.ExceptionalHaltReason;
 import org.hyperledger.besu.evm.log.Log;
 
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-
 /**
- * Model object holding all the necessary data to build and externalise the result of a single EVM transaction
+ * Model object holding all the necessary data to build and externalise the result of a single EVM
+ * transaction
  */
 public class TransactionProcessingResult {
-	/**
-	 * The status of the transaction after being processed.
-	 */
-	public enum Status {
-		/**
-		 * The transaction was successfully processed.
-		 */
-		SUCCESSFUL,
+    /** The status of the transaction after being processed. */
+    public enum Status {
+        /** The transaction was successfully processed. */
+        SUCCESSFUL,
 
-		/**
-		 * The transaction failed to be completely processed.
-		 */
-		FAILED
-	}
+        /** The transaction failed to be completely processed. */
+        FAILED
+    }
 
-	private final long gasUsed;
-	private final long sbhRefund;
-	private final long gasPrice;
-	private final Status status;
-	private final Bytes output;
-	private final List<Log> logs;
-	private final Optional<Bytes> revertReason;
-	private final Optional<Address> recipient;
-	private final Optional<ExceptionalHaltReason> haltReason;
-	private final Map<Address, Map<Bytes, Pair<Bytes, Bytes>>> stateChanges;
+    private final long gasUsed;
+    private final long sbhRefund;
+    private final long gasPrice;
+    private final Status status;
+    private final Bytes output;
+    private final List<Log> logs;
+    private final Optional<Bytes> revertReason;
+    private final Optional<Address> recipient;
+    private final Optional<ExceptionalHaltReason> haltReason;
+    private final Map<Address, Map<Bytes, Pair<Bytes, Bytes>>> stateChanges;
 
-	private List<ContractID> createdContracts = Collections.emptyList();
+    private List<ContractID> createdContracts = Collections.emptyList();
 
-	public static TransactionProcessingResult failed(
-			final long gasUsed,
-			final long sbhRefund,
-			final long gasPrice,
-			final Optional<Bytes> revertReason,
-			final Optional<ExceptionalHaltReason> haltReason,
-			final Map<Address, Map<Bytes, Pair<Bytes, Bytes>>> stateChanges
-	) {
-		return new TransactionProcessingResult(
-				Status.FAILED,
-				Collections.emptyList(),
-				gasUsed,
-				sbhRefund,
-				gasPrice,
-				Bytes.EMPTY,
-				Optional.empty(),
-				revertReason,
-				haltReason,
-				stateChanges);
-	}
+    public static TransactionProcessingResult failed(
+            final long gasUsed,
+            final long sbhRefund,
+            final long gasPrice,
+            final Optional<Bytes> revertReason,
+            final Optional<ExceptionalHaltReason> haltReason,
+            final Map<Address, Map<Bytes, Pair<Bytes, Bytes>>> stateChanges) {
+        return new TransactionProcessingResult(
+                Status.FAILED,
+                Collections.emptyList(),
+                gasUsed,
+                sbhRefund,
+                gasPrice,
+                Bytes.EMPTY,
+                Optional.empty(),
+                revertReason,
+                haltReason,
+                stateChanges);
+    }
 
-	public static TransactionProcessingResult successful(
-			final List<Log> logs,
-			final long gasUsed,
-			final long sbhRefund,
-			final long gasPrice,
-			final Bytes output,
-			final Address recipient,
-			final Map<Address, Map<Bytes, Pair<Bytes, Bytes>>> stateChanges
-	) {
-		return new TransactionProcessingResult(
-				Status.SUCCESSFUL,
-				logs,
-				gasUsed,
-				sbhRefund,
-				gasPrice,
-				output,
-				Optional.of(recipient),
-				Optional.empty(),
-				Optional.empty(),
-				stateChanges);
-	}
+    public static TransactionProcessingResult successful(
+            final List<Log> logs,
+            final long gasUsed,
+            final long sbhRefund,
+            final long gasPrice,
+            final Bytes output,
+            final Address recipient,
+            final Map<Address, Map<Bytes, Pair<Bytes, Bytes>>> stateChanges) {
+        return new TransactionProcessingResult(
+                Status.SUCCESSFUL,
+                logs,
+                gasUsed,
+                sbhRefund,
+                gasPrice,
+                output,
+                Optional.of(recipient),
+                Optional.empty(),
+                Optional.empty(),
+                stateChanges);
+    }
 
-	 private TransactionProcessingResult(
-			final Status status,
-			final List<Log> logs,
-			final long gasUsed,
-			final long sbhRefund,
-			final long gasPrice,
-			final Bytes output,
-			final Optional<Address> recipient,
-			final Optional<Bytes> revertReason,
-			final Optional<ExceptionalHaltReason> haltReason,
-			final Map<Address, Map<Bytes, Pair<Bytes, Bytes>>> stateChanges
-	 ) {
-		this.logs = logs;
-		this.output = output;
-		this.status = status;
-		this.gasUsed = gasUsed;
-		this.sbhRefund = sbhRefund;
-		this.gasPrice = gasPrice;
-		this.recipient = recipient;
-		this.haltReason = haltReason;
-		this.revertReason = revertReason;
-		this.stateChanges = stateChanges;
-	}
+    private TransactionProcessingResult(
+            final Status status,
+            final List<Log> logs,
+            final long gasUsed,
+            final long sbhRefund,
+            final long gasPrice,
+            final Bytes output,
+            final Optional<Address> recipient,
+            final Optional<Bytes> revertReason,
+            final Optional<ExceptionalHaltReason> haltReason,
+            final Map<Address, Map<Bytes, Pair<Bytes, Bytes>>> stateChanges) {
+        this.logs = logs;
+        this.output = output;
+        this.status = status;
+        this.gasUsed = gasUsed;
+        this.sbhRefund = sbhRefund;
+        this.gasPrice = gasPrice;
+        this.recipient = recipient;
+        this.haltReason = haltReason;
+        this.revertReason = revertReason;
+        this.stateChanges = stateChanges;
+    }
 
-	/**
-	 * Adds a list of created contracts to be externalised as part of the
-	 * {@link com.hedera.services.state.submerkle.ExpirableTxnRecord}
-	 *
-	 * @param createdContracts
-	 * 		the list of contractIDs created
-	 */
-	public void setCreatedContracts(List<ContractID> createdContracts) {
-		this.createdContracts = createdContracts;
-	}
+    /**
+     * Adds a list of created contracts to be externalised as part of the {@link
+     * com.hedera.services.state.submerkle.ExpirableTxnRecord}
+     *
+     * @param createdContracts the list of contractIDs created
+     */
+    public void setCreatedContracts(List<ContractID> createdContracts) {
+        this.createdContracts = createdContracts;
+    }
 
-	/**
-	 * Returns whether or not the transaction was successfully processed.
-	 *
-	 * @return {@code true} if the transaction was successfully processed; otherwise {@code false}
-	 */
-	public boolean isSuccessful() {
-		return status == Status.SUCCESSFUL;
-	}
+    /**
+     * Returns whether or not the transaction was successfully processed.
+     *
+     * @return {@code true} if the transaction was successfully processed; otherwise {@code false}
+     */
+    public boolean isSuccessful() {
+        return status == Status.SUCCESSFUL;
+    }
 
-	public long getGasPrice() {
-		return gasPrice;
-	}
+    public long getGasPrice() {
+        return gasPrice;
+    }
 
-	public long getGasUsed() {
-		return gasUsed;
-	}
+    public long getGasUsed() {
+        return gasUsed;
+    }
 
-	public long getSbhRefund() {
-		return sbhRefund;
-	}
+    public long getSbhRefund() {
+        return sbhRefund;
+    }
 
-	public Bytes getOutput() {
-		return output;
-	}
+    public Bytes getOutput() {
+        return output;
+    }
 
-	public List<Log> getLogs() {
-		return logs;
-	}
+    public List<Log> getLogs() {
+        return logs;
+    }
 
-	public Optional<Address> getRecipient() {
-		return recipient;
-	}
+    public Optional<Address> getRecipient() {
+        return recipient;
+    }
 
-	public Map<Address, Map<Bytes, Pair<Bytes, Bytes>>> getStateChanges() {
-		return stateChanges;
-	}
+    public Map<Address, Map<Bytes, Pair<Bytes, Bytes>>> getStateChanges() {
+        return stateChanges;
+    }
 
-	public List<ContractID> getCreatedContracts() {
-		return createdContracts;
-	}
+    public List<ContractID> getCreatedContracts() {
+        return createdContracts;
+    }
 
-	/**
-	 * Returns the exceptional halt reason
-	 *
-	 * @return the halt reason
-	 */
-	public Optional<ExceptionalHaltReason> getHaltReason() {
-		return haltReason;
-	}
+    /**
+     * Returns the exceptional halt reason
+     *
+     * @return the halt reason
+     */
+    public Optional<ExceptionalHaltReason> getHaltReason() {
+        return haltReason;
+    }
 
-	public Optional<Bytes> getRevertReason() {
-		return revertReason;
-	}
+    public Optional<Bytes> getRevertReason() {
+        return revertReason;
+    }
 
-	/**
-	 * Converts the {@link TransactionProcessingResult} into {@link ContractFunctionResult} gRPC model.
-	 *
-	 * @return the {@link ContractFunctionResult} model to externalise
-	 */
-	public ContractFunctionResult toGrpc() {
-		return EvmFnResult.fromCall(this).toGrpc();
-	}
+    /**
+     * Converts the {@link TransactionProcessingResult} into {@link ContractFunctionResult} gRPC
+     * model.
+     *
+     * @return the {@link ContractFunctionResult} model to externalise
+     */
+    public ContractFunctionResult toGrpc() {
+        return EvmFnResult.fromCall(this).toGrpc();
+    }
 }

--- a/hedera-node/src/main/java/com/hedera/services/contracts/execution/TransactionProcessingResult.java
+++ b/hedera-node/src/main/java/com/hedera/services/contracts/execution/TransactionProcessingResult.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2021-2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hedera.services.contracts.execution;
 
 /*

--- a/hedera-node/src/main/java/com/hedera/services/contracts/gascalculator/GasCalculatorHederaUtil.java
+++ b/hedera-node/src/main/java/com/hedera/services/contracts/gascalculator/GasCalculatorHederaUtil.java
@@ -22,7 +22,6 @@ package com.hedera.services.contracts.gascalculator;
  *
  */
 
-
 import com.hedera.services.fees.HbarCentExchange;
 import com.hedera.services.fees.calculation.UsagePricesProvider;
 import com.hederahashgraph.api.proto.java.FeeData;
@@ -32,68 +31,72 @@ import com.hederahashgraph.fee.FeeBuilder;
 import org.hyperledger.besu.evm.frame.MessageFrame;
 
 /**
- * Utility methods used by Hedera adapted {@link org.hyperledger.besu.evm.gascalculator.GasCalculator}
+ * Utility methods used by Hedera adapted {@link
+ * org.hyperledger.besu.evm.gascalculator.GasCalculator}
  */
 public final class GasCalculatorHederaUtil {
-	private static final int LOG_CONTRACT_ID_SIZE = 24;
-	private static final int LOG_TOPIC_SIZE = 32;
-	private static final int LOG_BLOOM_SIZE = 256;
+    private static final int LOG_CONTRACT_ID_SIZE = 24;
+    private static final int LOG_TOPIC_SIZE = 32;
+    private static final int LOG_BLOOM_SIZE = 256;
 
-	private GasCalculatorHederaUtil() {
-		throw new UnsupportedOperationException("Utility Class");
-	}
+    private GasCalculatorHederaUtil() {
+        throw new UnsupportedOperationException("Utility Class");
+    }
 
-	public static long ramByteHoursTinyBarsGiven(
-			final UsagePricesProvider usagePrices,
-			final HbarCentExchange exchange,
-			long consensusTime,
-			HederaFunctionality functionType) {
-		final var timestamp = Timestamp.newBuilder().setSeconds(consensusTime).build();
-		FeeData prices = usagePrices.defaultPricesGiven(functionType, timestamp);
-		long feeInTinyCents = prices.getServicedata().getRbh() / 1000;
-		long feeInTinyBars = FeeBuilder.getTinybarsFromTinyCents(exchange.rate(timestamp), feeInTinyCents);
-		return Math.max(1L, feeInTinyBars);
-	}
+    public static long ramByteHoursTinyBarsGiven(
+            final UsagePricesProvider usagePrices,
+            final HbarCentExchange exchange,
+            long consensusTime,
+            HederaFunctionality functionType) {
+        final var timestamp = Timestamp.newBuilder().setSeconds(consensusTime).build();
+        FeeData prices = usagePrices.defaultPricesGiven(functionType, timestamp);
+        long feeInTinyCents = prices.getServicedata().getRbh() / 1000;
+        long feeInTinyBars =
+                FeeBuilder.getTinybarsFromTinyCents(exchange.rate(timestamp), feeInTinyCents);
+        return Math.max(1L, feeInTinyBars);
+    }
 
-	public static long calculateLogSize(int numberOfTopics, long dataSize) {
-		return LOG_CONTRACT_ID_SIZE + LOG_BLOOM_SIZE + LOG_TOPIC_SIZE * (long) numberOfTopics + dataSize;
-	}
+    public static long calculateLogSize(int numberOfTopics, long dataSize) {
+        return LOG_CONTRACT_ID_SIZE
+                + LOG_BLOOM_SIZE
+                + LOG_TOPIC_SIZE * (long) numberOfTopics
+                + dataSize;
+    }
 
-	@SuppressWarnings("unused")
-	public static long calculateStorageGasNeeded(
-			long numberOfBytes,
-			long durationInSeconds,
-			long byteHourCostInTinyBars,
-			long gasPrice
-	) {
-		long storageCostTinyBars = (durationInSeconds * byteHourCostInTinyBars) / 3600;
-		return Math.round((double) storageCostTinyBars / (double) gasPrice);
-	}
+    @SuppressWarnings("unused")
+    public static long calculateStorageGasNeeded(
+            long numberOfBytes,
+            long durationInSeconds,
+            long byteHourCostInTinyBars,
+            long gasPrice) {
+        long storageCostTinyBars = (durationInSeconds * byteHourCostInTinyBars) / 3600;
+        return Math.round((double) storageCostTinyBars / (double) gasPrice);
+    }
 
-	public static HederaFunctionality getFunctionType(MessageFrame frame) {
-		MessageFrame rootFrame = frame.getMessageFrameStack().getLast();
-		return rootFrame.getContextVariable("HederaFunctionality");
-	}
+    public static HederaFunctionality getFunctionType(MessageFrame frame) {
+        MessageFrame rootFrame = frame.getMessageFrameStack().getLast();
+        return rootFrame.getContextVariable("HederaFunctionality");
+    }
 
-	@SuppressWarnings("unused")
-	public static long logOperationGasCost(
-			final UsagePricesProvider usagePrices,
-			final HbarCentExchange exchange,
-			final MessageFrame frame,
-			final long storageDuration,
-			final long dataOffset,
-			final long dataLength,
-			final int numTopics
-	) {
-		long gasPrice = frame.getGasPrice().toLong();
-		long timestamp = frame.getBlockValues().getTimestamp();
-		long logStorageTotalSize = GasCalculatorHederaUtil.calculateLogSize(numTopics, dataLength);
-		HederaFunctionality functionType = GasCalculatorHederaUtil.getFunctionType(frame);
+    @SuppressWarnings("unused")
+    public static long logOperationGasCost(
+            final UsagePricesProvider usagePrices,
+            final HbarCentExchange exchange,
+            final MessageFrame frame,
+            final long storageDuration,
+            final long dataOffset,
+            final long dataLength,
+            final int numTopics) {
+        long gasPrice = frame.getGasPrice().toLong();
+        long timestamp = frame.getBlockValues().getTimestamp();
+        long logStorageTotalSize = GasCalculatorHederaUtil.calculateLogSize(numTopics, dataLength);
+        HederaFunctionality functionType = GasCalculatorHederaUtil.getFunctionType(frame);
 
-		return GasCalculatorHederaUtil.calculateStorageGasNeeded(
-				logStorageTotalSize,
-				storageDuration,
-				GasCalculatorHederaUtil.ramByteHoursTinyBarsGiven(usagePrices, exchange, timestamp, functionType),
-				gasPrice);
-	}
+        return GasCalculatorHederaUtil.calculateStorageGasNeeded(
+                logStorageTotalSize,
+                storageDuration,
+                GasCalculatorHederaUtil.ramByteHoursTinyBarsGiven(
+                        usagePrices, exchange, timestamp, functionType),
+                gasPrice);
+    }
 }

--- a/hedera-node/src/main/java/com/hedera/services/contracts/gascalculator/GasCalculatorHederaUtil.java
+++ b/hedera-node/src/main/java/com/hedera/services/contracts/gascalculator/GasCalculatorHederaUtil.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2021-2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hedera.services.contracts.gascalculator;
 
 /*

--- a/hedera-node/src/main/java/com/hedera/services/contracts/gascalculator/GasCalculatorHederaV18.java
+++ b/hedera-node/src/main/java/com/hedera/services/contracts/gascalculator/GasCalculatorHederaV18.java
@@ -25,101 +25,107 @@ package com.hedera.services.contracts.gascalculator;
 import com.hedera.services.context.properties.GlobalDynamicProperties;
 import com.hedera.services.fees.HbarCentExchange;
 import com.hedera.services.fees.calculation.UsagePricesProvider;
+import javax.inject.Inject;
 import org.apache.tuweni.bytes.Bytes;
 import org.hyperledger.besu.datatypes.Wei;
 import org.hyperledger.besu.evm.account.Account;
 import org.hyperledger.besu.evm.frame.MessageFrame;
 import org.hyperledger.besu.evm.gascalculator.PetersburgGasCalculator;
 
-import javax.inject.Inject;
-
 /**
  * Provides Hedera adapted gas cost lookups and calculations used during transaction processing.
  * Maps to the gas costs of the Smart Contract Service up until 0.18.0 release
  */
 public class GasCalculatorHederaV18 extends PetersburgGasCalculator {
-	private final GlobalDynamicProperties dynamicProperties;
-	private final UsagePricesProvider usagePrices;
-	private final HbarCentExchange exchange;
+    private final GlobalDynamicProperties dynamicProperties;
+    private final UsagePricesProvider usagePrices;
+    private final HbarCentExchange exchange;
 
-	@Inject
-	public GasCalculatorHederaV18(
-			final GlobalDynamicProperties dynamicProperties,
-			final UsagePricesProvider usagePrices,
-			final HbarCentExchange exchange) {
-		this.dynamicProperties = dynamicProperties;
-		this.usagePrices = usagePrices;
-		this.exchange = exchange;
-	}
+    @Inject
+    public GasCalculatorHederaV18(
+            final GlobalDynamicProperties dynamicProperties,
+            final UsagePricesProvider usagePrices,
+            final HbarCentExchange exchange) {
+        this.dynamicProperties = dynamicProperties;
+        this.usagePrices = usagePrices;
+        this.exchange = exchange;
+    }
 
-	@Override
-	public long codeDepositGasCost(final int codeSize) {
-		return 0L;
-	}
+    @Override
+    public long codeDepositGasCost(final int codeSize) {
+        return 0L;
+    }
 
-	@Override
-	public long transactionIntrinsicGasCost(final Bytes payload, final boolean isContractCreate) {
-		return 0L;
-	}
+    @Override
+    public long transactionIntrinsicGasCost(final Bytes payload, final boolean isContractCreate) {
+        return 0L;
+    }
 
-	@Override
-	public long logOperationGasCost(
-			final MessageFrame frame,
-			final long dataOffset,
-			final long dataLength,
-			final int numTopics) {
-		return GasCalculatorHederaUtil.logOperationGasCost(usagePrices, exchange, frame, getLogStorageDuration(), dataOffset, dataLength, numTopics);
-	}
+    @Override
+    public long logOperationGasCost(
+            final MessageFrame frame,
+            final long dataOffset,
+            final long dataLength,
+            final int numTopics) {
+        return GasCalculatorHederaUtil.logOperationGasCost(
+                usagePrices,
+                exchange,
+                frame,
+                getLogStorageDuration(),
+                dataOffset,
+                dataLength,
+                numTopics);
+    }
 
-	@Override
-	public long getBalanceOperationGasCost() {
-		// Frontier gas cost
-		return 20L;
-	}
+    @Override
+    public long getBalanceOperationGasCost() {
+        // Frontier gas cost
+        return 20L;
+    }
 
-	@Override
-	protected long expOperationByteGasCost() {
-		// Frontier gas cost
-		return 10L;
-	}
+    @Override
+    protected long expOperationByteGasCost() {
+        // Frontier gas cost
+        return 10L;
+    }
 
-	@Override
-	protected long extCodeBaseGasCost() {
-		// Frontier gas cost
-		return 20L;
-	}
+    @Override
+    protected long extCodeBaseGasCost() {
+        // Frontier gas cost
+        return 20L;
+    }
 
-	@Override
-	public long getSloadOperationGasCost() {
-		// Frontier gas cost
-		return 50L;
-	}
+    @Override
+    public long getSloadOperationGasCost() {
+        // Frontier gas cost
+        return 50L;
+    }
 
-	@Override
-	public long callOperationBaseGasCost() {
-		// Frontier gas cost
-		return 40L;
-	}
+    @Override
+    public long callOperationBaseGasCost() {
+        // Frontier gas cost
+        return 40L;
+    }
 
-	@Override
-	public long getExtCodeSizeOperationGasCost() {
-		// Frontier gas cost
-		return 20L;
-	}
+    @Override
+    public long getExtCodeSizeOperationGasCost() {
+        // Frontier gas cost
+        return 20L;
+    }
 
-	@Override
-	public long extCodeHashOperationGasCost() {
-		// Constantinople gas cost
-		return 400L;
-	}
+    @Override
+    public long extCodeHashOperationGasCost() {
+        // Constantinople gas cost
+        return 400L;
+    }
 
-	@Override
-	public long selfDestructOperationGasCost(final Account recipient, final Wei inheritance) {
-		// Frontier gas cost
-		return 0;
-	}
+    @Override
+    public long selfDestructOperationGasCost(final Account recipient, final Wei inheritance) {
+        // Frontier gas cost
+        return 0;
+    }
 
-	private long getLogStorageDuration() {
-		return dynamicProperties.cacheRecordsTtl();
-	}
+    private long getLogStorageDuration() {
+        return dynamicProperties.cacheRecordsTtl();
+    }
 }

--- a/hedera-node/src/main/java/com/hedera/services/contracts/gascalculator/GasCalculatorHederaV18.java
+++ b/hedera-node/src/main/java/com/hedera/services/contracts/gascalculator/GasCalculatorHederaV18.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2021-2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hedera.services.contracts.gascalculator;
 
 /*

--- a/hedera-node/src/main/java/com/hedera/services/contracts/gascalculator/GasCalculatorHederaV19.java
+++ b/hedera-node/src/main/java/com/hedera/services/contracts/gascalculator/GasCalculatorHederaV19.java
@@ -25,11 +25,10 @@ package com.hedera.services.contracts.gascalculator;
 import com.hedera.services.context.properties.GlobalDynamicProperties;
 import com.hedera.services.fees.HbarCentExchange;
 import com.hedera.services.fees.calculation.UsagePricesProvider;
+import javax.inject.Inject;
 import org.apache.tuweni.bytes.Bytes;
 import org.hyperledger.besu.evm.frame.MessageFrame;
 import org.hyperledger.besu.evm.gascalculator.LondonGasCalculator;
-
-import javax.inject.Inject;
 
 /**
  * Provides Hedera adapted gas cost lookups and calculations used during transaction processing.
@@ -37,42 +36,50 @@ import javax.inject.Inject;
  */
 public class GasCalculatorHederaV19 extends LondonGasCalculator {
 
-	private final GlobalDynamicProperties dynamicProperties;
-	private final UsagePricesProvider usagePrices;
-	private final HbarCentExchange exchange;
+    private final GlobalDynamicProperties dynamicProperties;
+    private final UsagePricesProvider usagePrices;
+    private final HbarCentExchange exchange;
 
-	@Inject
-	public GasCalculatorHederaV19(
-			final GlobalDynamicProperties dynamicProperties,
-			final UsagePricesProvider usagePrices,
-			final HbarCentExchange exchange) {
-		this.dynamicProperties = dynamicProperties;
-		this.usagePrices = usagePrices;
-		this.exchange = exchange;
-	}
+    @Inject
+    public GasCalculatorHederaV19(
+            final GlobalDynamicProperties dynamicProperties,
+            final UsagePricesProvider usagePrices,
+            final HbarCentExchange exchange) {
+        this.dynamicProperties = dynamicProperties;
+        this.usagePrices = usagePrices;
+        this.exchange = exchange;
+    }
 
-	@Override
-	public long transactionIntrinsicGasCost(final Bytes payload, final boolean isContractCreate) {
-		return 0L;
-	}
+    @Override
+    public long transactionIntrinsicGasCost(final Bytes payload, final boolean isContractCreate) {
+        return 0L;
+    }
 
-	@Override
-	public long codeDepositGasCost(final int codeSize) {
-		return 0L;
-	}
+    @Override
+    public long codeDepositGasCost(final int codeSize) {
+        return 0L;
+    }
 
-	@Override
-	public long logOperationGasCost(
-			final MessageFrame frame,
-			final long dataOffset,
-			final long dataLength,
-			final int numTopics) {
-		final var gasCost = GasCalculatorHederaUtil.
-				logOperationGasCost(usagePrices, exchange, frame, getLogStorageDuration(), dataOffset, dataLength, numTopics);
-		return Math.max(super.logOperationGasCost(frame, dataOffset, dataLength, numTopics), gasCost);
-	}
+    @Override
+    public long logOperationGasCost(
+            final MessageFrame frame,
+            final long dataOffset,
+            final long dataLength,
+            final int numTopics) {
+        final var gasCost =
+                GasCalculatorHederaUtil.logOperationGasCost(
+                        usagePrices,
+                        exchange,
+                        frame,
+                        getLogStorageDuration(),
+                        dataOffset,
+                        dataLength,
+                        numTopics);
+        return Math.max(
+                super.logOperationGasCost(frame, dataOffset, dataLength, numTopics), gasCost);
+    }
 
-	long getLogStorageDuration() {
-		return dynamicProperties.cacheRecordsTtl();
-	}
+    long getLogStorageDuration() {
+        return dynamicProperties.cacheRecordsTtl();
+    }
 }

--- a/hedera-node/src/main/java/com/hedera/services/contracts/gascalculator/GasCalculatorHederaV19.java
+++ b/hedera-node/src/main/java/com/hedera/services/contracts/gascalculator/GasCalculatorHederaV19.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2021-2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hedera.services.contracts.gascalculator;
 
 /*

--- a/hedera-node/src/main/java/com/hedera/services/contracts/gascalculator/GasCalculatorHederaV22.java
+++ b/hedera-node/src/main/java/com/hedera/services/contracts/gascalculator/GasCalculatorHederaV22.java
@@ -25,37 +25,39 @@ package com.hedera.services.contracts.gascalculator;
 import com.hedera.services.context.properties.GlobalDynamicProperties;
 import com.hedera.services.fees.HbarCentExchange;
 import com.hedera.services.fees.calculation.UsagePricesProvider;
+import javax.inject.Inject;
 import org.apache.tuweni.bytes.Bytes;
 
-import javax.inject.Inject;
-
-/**
- * Updates gas costs enabled by gas-per-second throttling.
- */
+/** Updates gas costs enabled by gas-per-second throttling. */
 public class GasCalculatorHederaV22 extends GasCalculatorHederaV19 {
 
-	private static final long TX_DATA_ZERO_COST = 4L;
-	private static final long ISTANBUL_TX_DATA_NON_ZERO_COST = 16L;
-	private static final long TX_BASE_COST = 21_000L;
+    private static final long TX_DATA_ZERO_COST = 4L;
+    private static final long ISTANBUL_TX_DATA_NON_ZERO_COST = 16L;
+    private static final long TX_BASE_COST = 21_000L;
 
-	@Inject
-	public GasCalculatorHederaV22(final GlobalDynamicProperties dynamicProperties,
-			final UsagePricesProvider usagePrices, final HbarCentExchange exchange) {
-		super(dynamicProperties, usagePrices, exchange);
-	}
+    @Inject
+    public GasCalculatorHederaV22(
+            final GlobalDynamicProperties dynamicProperties,
+            final UsagePricesProvider usagePrices,
+            final HbarCentExchange exchange) {
+        super(dynamicProperties, usagePrices, exchange);
+    }
 
-	@Override
-	public long transactionIntrinsicGasCost(final Bytes payload, final boolean isContractCreation) {
-		int zeros = 0;
-		for (int i = 0; i < payload.size(); i++) {
-			if (payload.get(i) == 0) {
-				++zeros;
-			}
-		}
-		final int nonZeros = payload.size() - zeros;
+    @Override
+    public long transactionIntrinsicGasCost(final Bytes payload, final boolean isContractCreation) {
+        int zeros = 0;
+        for (int i = 0; i < payload.size(); i++) {
+            if (payload.get(i) == 0) {
+                ++zeros;
+            }
+        }
+        final int nonZeros = payload.size() - zeros;
 
-		long cost = TX_BASE_COST + TX_DATA_ZERO_COST * zeros + ISTANBUL_TX_DATA_NON_ZERO_COST * nonZeros;
+        long cost =
+                TX_BASE_COST
+                        + TX_DATA_ZERO_COST * zeros
+                        + ISTANBUL_TX_DATA_NON_ZERO_COST * nonZeros;
 
-		return isContractCreation ? (cost + txCreateExtraGasCost()) : cost;
-	}
+        return isContractCreation ? (cost + txCreateExtraGasCost()) : cost;
+    }
 }

--- a/hedera-node/src/main/java/com/hedera/services/contracts/gascalculator/GasCalculatorHederaV22.java
+++ b/hedera-node/src/main/java/com/hedera/services/contracts/gascalculator/GasCalculatorHederaV22.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2021-2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hedera.services.contracts.gascalculator;
 
 /*

--- a/hedera-node/src/main/java/com/hedera/services/contracts/gascalculator/StorageGasCalculator.java
+++ b/hedera-node/src/main/java/com/hedera/services/contracts/gascalculator/StorageGasCalculator.java
@@ -1,11 +1,6 @@
-package com.hedera.services.contracts.gascalculator;
-
-/*-
- * ‌
- * Hedera Services Node
- * ​
- * Copyright (C) 2018 - 2022 Hedera Hashgraph, LLC
- * ​
+/*
+ * Copyright (C) 2022 Hedera Hashgraph, LLC
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -17,8 +12,8 @@ package com.hedera.services.contracts.gascalculator;
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- * ‍
  */
+package com.hedera.services.contracts.gascalculator;
 
 import static com.hedera.services.contracts.execution.CreateEvmTxProcessor.EXPIRY_ORACLE_CONTEXT_KEY;
 import static com.hedera.services.contracts.execution.CreateEvmTxProcessor.SBH_CONTEXT_KEY;

--- a/hedera-node/src/main/java/com/hedera/services/contracts/gascalculator/StorageGasCalculator.java
+++ b/hedera-node/src/main/java/com/hedera/services/contracts/gascalculator/StorageGasCalculator.java
@@ -9,9 +9,9 @@ package com.hedera.services.contracts.gascalculator;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,87 +20,92 @@ package com.hedera.services.contracts.gascalculator;
  * ‍
  */
 
-import com.hedera.services.txns.contract.helpers.StorageExpiry;
-import org.hyperledger.besu.evm.frame.MessageFrame;
-import org.hyperledger.besu.evm.gascalculator.GasCalculator;
-
-import javax.inject.Inject;
-import javax.inject.Singleton;
-
 import static com.hedera.services.contracts.execution.CreateEvmTxProcessor.EXPIRY_ORACLE_CONTEXT_KEY;
 import static com.hedera.services.contracts.execution.CreateEvmTxProcessor.SBH_CONTEXT_KEY;
 import static org.hyperledger.besu.evm.internal.Words.clampedToLong;
+
+import com.hedera.services.txns.contract.helpers.StorageExpiry;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import org.hyperledger.besu.evm.frame.MessageFrame;
+import org.hyperledger.besu.evm.gascalculator.GasCalculator;
 
 /**
  * Computes the EVM gas cost of using storage in a given {@link MessageFrame} based on the relative
  * Hedera prices of the {@code sbh} and {@code gas} resources in that frame.
  *
- * Recall that,
+ * <p>Recall that,
+ *
  * <ul>
- *     <li>Using one {@code sbh} resource means storing one byte in the off-heap Hedera world state
- *     for one hour.</li>
- *     <li>Using one {@code gas} resource means consuming one unit of EVM gas.</li>
+ *   <li>Using one {@code sbh} resource means storing one byte in the off-heap Hedera world state
+ *       for one hour.
+ *   <li>Using one {@code gas} resource means consuming one unit of EVM gas.
  * </ul>
  *
  * Since we want the price of storing data in the off-heap Hedera state to be consistent between the
- * smart contract service and, e.g., the file service, we need to define the EVM gas cost of a storage
- * operation based the <i>relative prices</i> of the {@code sbh} and {@code gas} resources. (That is,
- * if the Hedera {@code sbh} price is high relative to the Hedera {@code gas} price, we need EVM opcodes
- * that use storage to have a high gas cost. On the other hand, if the {@code sbh} price is low relative
- * to the {@code gas} price, EVM operations that use storage should have a low gas cost.)
+ * smart contract service and, e.g., the file service, we need to define the EVM gas cost of a
+ * storage operation based the <i>relative prices</i> of the {@code sbh} and {@code gas} resources.
+ * (That is, if the Hedera {@code sbh} price is high relative to the Hedera {@code gas} price, we
+ * need EVM opcodes that use storage to have a high gas cost. On the other hand, if the {@code sbh}
+ * price is low relative to the {@code gas} price, EVM operations that use storage should have a low
+ * gas cost.)
  *
  * <p><i>Note:</i> We get the Hedera resource prices from the {@link MessageFrame} as follows:
+ *
  * <ul>
- *     <li>The Hedera {@code gas} price is exactly {@link MessageFrame#getGasPrice()}---but
- *     in tinybar instead of Wei, of course.</li>
- *     <li>The Hedera {@code sbh} price (also in tinybar) is stored in the bottom stack frame's context
- *     under the {@link com.hedera.services.contracts.execution.CreateEvmTxProcessor#SBH_CONTEXT_KEY}.</li>
+ *   <li>The Hedera {@code gas} price is exactly {@link MessageFrame#getGasPrice()}---but in tinybar
+ *       instead of Wei, of course.
+ *   <li>The Hedera {@code sbh} price (also in tinybar) is stored in the bottom stack frame's
+ *       context under the {@link
+ *       com.hedera.services.contracts.execution.CreateEvmTxProcessor#SBH_CONTEXT_KEY}.
  * </ul>
  */
 @Singleton
 public class StorageGasCalculator {
-	private static final int SECONDS_PER_HOUR = 3600;
+    private static final int SECONDS_PER_HOUR = 3600;
 
-	@Inject
-	public StorageGasCalculator() {
-		// Dagger2
-	}
+    @Inject
+    public StorageGasCalculator() {
+        // Dagger2
+    }
 
-	/**
-	 * Computes the gas cost of the storage consumed by the {@code CONTRACT_CREATION} represented by
-	 * the given frame, using the given {@code GasCalculator}.
-	 *
-	 * @param frame the creation frame
-	 * @param gasCalculator the gas calculator
-	 * @return the gas required for the storage and memory usage of this contract creaiton
-	 */
-	public long creationGasCost(final MessageFrame frame, final GasCalculator gasCalculator) {
-		return gasCostOfStorageIn(frame) + memoryExpansionGasCost(frame, gasCalculator);
-	}
+    /**
+     * Computes the gas cost of the storage consumed by the {@code CONTRACT_CREATION} represented by
+     * the given frame, using the given {@code GasCalculator}.
+     *
+     * @param frame the creation frame
+     * @param gasCalculator the gas calculator
+     * @return the gas required for the storage and memory usage of this contract creaiton
+     */
+    public long creationGasCost(final MessageFrame frame, final GasCalculator gasCalculator) {
+        return gasCostOfStorageIn(frame) + memoryExpansionGasCost(frame, gasCalculator);
+    }
 
-	public long gasCostOfStorageIn(final MessageFrame frame) {
-		final var baseFrame = base(frame);
-		final var expectedLifetimeSecs = effStorageLifetime(frame, baseFrame);
-		final long sbhPrice = baseFrame.getContextVariable(SBH_CONTEXT_KEY);
-		final var storagePrice = (expectedLifetimeSecs * sbhPrice) / SECONDS_PER_HOUR;
-		final var gasPrice = frame.getGasPrice().toLong();
-		return storagePrice / gasPrice;
-	}
+    public long gasCostOfStorageIn(final MessageFrame frame) {
+        final var baseFrame = base(frame);
+        final var expectedLifetimeSecs = effStorageLifetime(frame, baseFrame);
+        final long sbhPrice = baseFrame.getContextVariable(SBH_CONTEXT_KEY);
+        final var storagePrice = (expectedLifetimeSecs * sbhPrice) / SECONDS_PER_HOUR;
+        final var gasPrice = frame.getGasPrice().toLong();
+        return storagePrice / gasPrice;
+    }
 
-	private static long effStorageLifetime(final MessageFrame frame, final MessageFrame baseFrame) {
-		final StorageExpiry.Oracle expiryOracle = baseFrame.getContextVariable(EXPIRY_ORACLE_CONTEXT_KEY);
-		final var now = frame.getBlockValues().getTimestamp();
-		final var expectedLifetimeSecs = expiryOracle.storageExpiryIn(frame) - now;
-		return Math.max(0, expectedLifetimeSecs);
-	}
+    private static long effStorageLifetime(final MessageFrame frame, final MessageFrame baseFrame) {
+        final StorageExpiry.Oracle expiryOracle =
+                baseFrame.getContextVariable(EXPIRY_ORACLE_CONTEXT_KEY);
+        final var now = frame.getBlockValues().getTimestamp();
+        final var expectedLifetimeSecs = expiryOracle.storageExpiryIn(frame) - now;
+        return Math.max(0, expectedLifetimeSecs);
+    }
 
-	private static long memoryExpansionGasCost(final MessageFrame frame, final GasCalculator gasCalculator) {
-		final var initCodeOffset = clampedToLong(frame.getStackItem(1));
-		final var initCodeLength = clampedToLong(frame.getStackItem(2));
-		return gasCalculator.memoryExpansionGasCost(frame, initCodeOffset, initCodeLength);
-	}
+    private static long memoryExpansionGasCost(
+            final MessageFrame frame, final GasCalculator gasCalculator) {
+        final var initCodeOffset = clampedToLong(frame.getStackItem(1));
+        final var initCodeLength = clampedToLong(frame.getStackItem(2));
+        return gasCalculator.memoryExpansionGasCost(frame, initCodeOffset, initCodeLength);
+    }
 
-	private static MessageFrame base(final MessageFrame frame) {
-		return frame.getMessageFrameStack().getLast();
-	}
+    private static MessageFrame base(final MessageFrame frame) {
+        return frame.getMessageFrameStack().getLast();
+    }
 }

--- a/hedera-node/src/main/java/com/hedera/services/contracts/operation/AbstractRecordingCreateOperation.java
+++ b/hedera-node/src/main/java/com/hedera/services/contracts/operation/AbstractRecordingCreateOperation.java
@@ -20,11 +20,18 @@ package com.hedera.services.contracts.operation;
  * ‍
  */
 
+import static com.hedera.services.state.EntityCreator.EMPTY_MEMO;
+import static com.hedera.services.state.EntityCreator.NO_CUSTOM_FEES;
+import static org.hyperledger.besu.evm.frame.ExceptionalHaltReason.ILLEGAL_STATE_CHANGE;
+import static org.hyperledger.besu.evm.internal.Words.clampedToLong;
+
 import com.hedera.services.context.SideEffectsTracker;
 import com.hedera.services.records.RecordsHistorian;
 import com.hedera.services.state.EntityCreator;
 import com.hedera.services.store.contracts.HederaStackedWorldStateUpdater;
 import com.hedera.services.store.contracts.precompile.SyntheticTxnFactory;
+import java.util.Optional;
+import java.util.OptionalLong;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.units.bigints.UInt256;
 import org.hyperledger.besu.datatypes.Address;
@@ -40,178 +47,177 @@ import org.hyperledger.besu.evm.internal.Words;
 import org.hyperledger.besu.evm.operation.AbstractOperation;
 import org.hyperledger.besu.evm.operation.Operation;
 
-import java.util.Optional;
-import java.util.OptionalLong;
-
-import static com.hedera.services.state.EntityCreator.EMPTY_MEMO;
-import static com.hedera.services.state.EntityCreator.NO_CUSTOM_FEES;
-import static org.hyperledger.besu.evm.frame.ExceptionalHaltReason.ILLEGAL_STATE_CHANGE;
-import static org.hyperledger.besu.evm.internal.Words.clampedToLong;
-
 public abstract class AbstractRecordingCreateOperation extends AbstractOperation {
-	private static final int MAX_STACK_DEPTH = 1024;
+    private static final int MAX_STACK_DEPTH = 1024;
 
-	protected static final Operation.OperationResult INVALID_RESPONSE = new OperationResult(
-			OptionalLong.of(0L), Optional.of(ExceptionalHaltReason.INVALID_OPERATION));
-	protected static final Operation.OperationResult UNDERFLOW_RESPONSE =
-			new Operation.OperationResult(
-					OptionalLong.empty(), Optional.of(ExceptionalHaltReason.INSUFFICIENT_STACK_ITEMS));
+    protected static final Operation.OperationResult INVALID_RESPONSE =
+            new OperationResult(
+                    OptionalLong.of(0L), Optional.of(ExceptionalHaltReason.INVALID_OPERATION));
+    protected static final Operation.OperationResult UNDERFLOW_RESPONSE =
+            new Operation.OperationResult(
+                    OptionalLong.empty(),
+                    Optional.of(ExceptionalHaltReason.INSUFFICIENT_STACK_ITEMS));
 
-	private final EntityCreator creator;
-	private final SyntheticTxnFactory syntheticTxnFactory;
-	private final RecordsHistorian recordsHistorian;
+    private final EntityCreator creator;
+    private final SyntheticTxnFactory syntheticTxnFactory;
+    private final RecordsHistorian recordsHistorian;
 
-	protected AbstractRecordingCreateOperation(
-			final int opcode,
-			final String name,
-			final int stackItemsConsumed,
-			final int stackItemsProduced,
-			final int opSize,
-			final GasCalculator gasCalculator,
-			final EntityCreator creator,
-			final SyntheticTxnFactory syntheticTxnFactory,
-			final RecordsHistorian recordsHistorian
-	) {
-		super(opcode, name, stackItemsConsumed, stackItemsProduced, opSize, gasCalculator);
-		this.creator = creator;
-		this.recordsHistorian = recordsHistorian;
-		this.syntheticTxnFactory = syntheticTxnFactory;
-	}
+    protected AbstractRecordingCreateOperation(
+            final int opcode,
+            final String name,
+            final int stackItemsConsumed,
+            final int stackItemsProduced,
+            final int opSize,
+            final GasCalculator gasCalculator,
+            final EntityCreator creator,
+            final SyntheticTxnFactory syntheticTxnFactory,
+            final RecordsHistorian recordsHistorian) {
+        super(opcode, name, stackItemsConsumed, stackItemsProduced, opSize, gasCalculator);
+        this.creator = creator;
+        this.recordsHistorian = recordsHistorian;
+        this.syntheticTxnFactory = syntheticTxnFactory;
+    }
 
-	@Override
-	public Operation.OperationResult execute(final MessageFrame frame, final EVM evm) {
-		// We have a feature flag for CREATE2
-		if (!isEnabled()) {
-			return INVALID_RESPONSE;
-		}
+    @Override
+    public Operation.OperationResult execute(final MessageFrame frame, final EVM evm) {
+        // We have a feature flag for CREATE2
+        if (!isEnabled()) {
+            return INVALID_RESPONSE;
+        }
 
-		// manual check because some reads won't come until the "complete" step.
-		if (frame.stackSize() < getStackItemsConsumed()) {
-			return UNDERFLOW_RESPONSE;
-		}
+        // manual check because some reads won't come until the "complete" step.
+        if (frame.stackSize() < getStackItemsConsumed()) {
+            return UNDERFLOW_RESPONSE;
+        }
 
-		final long cost = cost(frame);
-		final OptionalLong optionalCost = OptionalLong.of(cost);
-		if (frame.isStatic()) {
-			return haltWith(optionalCost, ILLEGAL_STATE_CHANGE);
-		} else if (frame.getRemainingGas() < cost) {
-			return new Operation.OperationResult(
-					optionalCost, Optional.of(ExceptionalHaltReason.INSUFFICIENT_GAS));
-		}
-		final Wei value = Wei.wrap(frame.getStackItem(0));
+        final long cost = cost(frame);
+        final OptionalLong optionalCost = OptionalLong.of(cost);
+        if (frame.isStatic()) {
+            return haltWith(optionalCost, ILLEGAL_STATE_CHANGE);
+        } else if (frame.getRemainingGas() < cost) {
+            return new Operation.OperationResult(
+                    optionalCost, Optional.of(ExceptionalHaltReason.INSUFFICIENT_GAS));
+        }
+        final Wei value = Wei.wrap(frame.getStackItem(0));
 
-		final Address address = frame.getRecipientAddress();
-		final MutableAccount account = frame.getWorldUpdater().getAccount(address).getMutable();
+        final Address address = frame.getRecipientAddress();
+        final MutableAccount account = frame.getWorldUpdater().getAccount(address).getMutable();
 
-		frame.clearReturnData();
+        frame.clearReturnData();
 
-		if (value.compareTo(account.getBalance()) > 0 || frame.getMessageStackDepth() >= MAX_STACK_DEPTH) {
-			fail(frame);
-		} else {
-			spawnChildMessage(frame);
-		}
+        if (value.compareTo(account.getBalance()) > 0
+                || frame.getMessageStackDepth() >= MAX_STACK_DEPTH) {
+            fail(frame);
+        } else {
+            spawnChildMessage(frame);
+        }
 
-		return new Operation.OperationResult(optionalCost, Optional.empty());
-	}
+        return new Operation.OperationResult(optionalCost, Optional.empty());
+    }
 
-	static Operation.OperationResult haltWith(final OptionalLong optionalCost, final ExceptionalHaltReason reason) {
-		return new Operation.OperationResult(optionalCost, Optional.of(reason));
-	}
+    static Operation.OperationResult haltWith(
+            final OptionalLong optionalCost, final ExceptionalHaltReason reason) {
+        return new Operation.OperationResult(optionalCost, Optional.of(reason));
+    }
 
-	protected abstract boolean isEnabled();
+    protected abstract boolean isEnabled();
 
-	protected abstract long cost(final MessageFrame frame);
+    protected abstract long cost(final MessageFrame frame);
 
-	protected abstract Address targetContractAddress(MessageFrame frame);
+    protected abstract Address targetContractAddress(MessageFrame frame);
 
-	private void fail(final MessageFrame frame) {
-		final long inputOffset = clampedToLong(frame.getStackItem(1));
-		final long inputSize = clampedToLong(frame.getStackItem(2));
-		frame.readMutableMemory(inputOffset, inputSize);
-		frame.popStackItems(getStackItemsConsumed());
-		frame.pushStackItem(UInt256.ZERO);
-	}
+    private void fail(final MessageFrame frame) {
+        final long inputOffset = clampedToLong(frame.getStackItem(1));
+        final long inputSize = clampedToLong(frame.getStackItem(2));
+        frame.readMutableMemory(inputOffset, inputSize);
+        frame.popStackItems(getStackItemsConsumed());
+        frame.pushStackItem(UInt256.ZERO);
+    }
 
-	private void spawnChildMessage(final MessageFrame frame) {
-		// memory cost needs to be calculated prior to memory expansion
-		final long cost = cost(frame);
-		frame.decrementRemainingGas(cost);
+    private void spawnChildMessage(final MessageFrame frame) {
+        // memory cost needs to be calculated prior to memory expansion
+        final long cost = cost(frame);
+        frame.decrementRemainingGas(cost);
 
-		final Address address = frame.getRecipientAddress();
-		final MutableAccount account = frame.getWorldUpdater().getAccount(address).getMutable();
+        final Address address = frame.getRecipientAddress();
+        final MutableAccount account = frame.getWorldUpdater().getAccount(address).getMutable();
 
-		account.incrementNonce();
+        account.incrementNonce();
 
-		final Wei value = Wei.wrap(frame.getStackItem(0));
-		final long inputOffset = clampedToLong(frame.getStackItem(1));
-		final long inputSize = clampedToLong(frame.getStackItem(2));
-		final Bytes inputData = frame.readMemory(inputOffset, inputSize);
+        final Wei value = Wei.wrap(frame.getStackItem(0));
+        final long inputOffset = clampedToLong(frame.getStackItem(1));
+        final long inputSize = clampedToLong(frame.getStackItem(2));
+        final Bytes inputData = frame.readMemory(inputOffset, inputSize);
 
-		final Address contractAddress = targetContractAddress(frame);
+        final Address contractAddress = targetContractAddress(frame);
 
-		final long childGasStipend = gasCalculator().gasAvailableForChildCreate(frame.getRemainingGas());
-		frame.decrementRemainingGas(childGasStipend);
+        final long childGasStipend =
+                gasCalculator().gasAvailableForChildCreate(frame.getRemainingGas());
+        frame.decrementRemainingGas(childGasStipend);
 
-		final MessageFrame childFrame =
-				MessageFrame.builder()
-						.type(MessageFrame.Type.CONTRACT_CREATION)
-						.messageFrameStack(frame.getMessageFrameStack())
-						.worldUpdater(frame.getWorldUpdater().updater())
-						.initialGas(childGasStipend)
-						.address(contractAddress)
-						.originator(frame.getOriginatorAddress())
-						.contract(contractAddress)
-						.gasPrice(frame.getGasPrice())
-						.inputData(Bytes.EMPTY)
-						.sender(frame.getRecipientAddress())
-						.value(value)
-						.apparentValue(value)
-						.code(Code.createLegacyCode(inputData, Hash.EMPTY))
-						.blockValues(frame.getBlockValues())
-						.depth(frame.getMessageStackDepth() + 1)
-						.completer(child -> complete(frame, child))
-						.miningBeneficiary(frame.getMiningBeneficiary())
-						.blockHashLookup(frame.getBlockHashLookup())
-						.maxStackSize(frame.getMaxStackSize())
-						.build();
+        final MessageFrame childFrame =
+                MessageFrame.builder()
+                        .type(MessageFrame.Type.CONTRACT_CREATION)
+                        .messageFrameStack(frame.getMessageFrameStack())
+                        .worldUpdater(frame.getWorldUpdater().updater())
+                        .initialGas(childGasStipend)
+                        .address(contractAddress)
+                        .originator(frame.getOriginatorAddress())
+                        .contract(contractAddress)
+                        .gasPrice(frame.getGasPrice())
+                        .inputData(Bytes.EMPTY)
+                        .sender(frame.getRecipientAddress())
+                        .value(value)
+                        .apparentValue(value)
+                        .code(Code.createLegacyCode(inputData, Hash.EMPTY))
+                        .blockValues(frame.getBlockValues())
+                        .depth(frame.getMessageStackDepth() + 1)
+                        .completer(child -> complete(frame, child))
+                        .miningBeneficiary(frame.getMiningBeneficiary())
+                        .blockHashLookup(frame.getBlockHashLookup())
+                        .maxStackSize(frame.getMaxStackSize())
+                        .build();
 
-		frame.incrementRemainingGas(cost);
+        frame.incrementRemainingGas(cost);
 
-		frame.getMessageFrameStack().addFirst(childFrame);
-		frame.setState(MessageFrame.State.CODE_SUSPENDED);
-	}
+        frame.getMessageFrameStack().addFirst(childFrame);
+        frame.setState(MessageFrame.State.CODE_SUSPENDED);
+    }
 
-	private void complete(final MessageFrame frame, final MessageFrame childFrame) {
-		frame.setState(MessageFrame.State.CODE_EXECUTING);
+    private void complete(final MessageFrame frame, final MessageFrame childFrame) {
+        frame.setState(MessageFrame.State.CODE_EXECUTING);
 
-		frame.incrementRemainingGas(childFrame.getRemainingGas());
-		frame.addLogs(childFrame.getLogs());
-		frame.addSelfDestructs(childFrame.getSelfDestructs());
-		frame.incrementGasRefund(childFrame.getGasRefund());
-		frame.popStackItems(getStackItemsConsumed());
+        frame.incrementRemainingGas(childFrame.getRemainingGas());
+        frame.addLogs(childFrame.getLogs());
+        frame.addSelfDestructs(childFrame.getSelfDestructs());
+        frame.incrementGasRefund(childFrame.getGasRefund());
+        frame.popStackItems(getStackItemsConsumed());
 
-		if (childFrame.getState() == MessageFrame.State.COMPLETED_SUCCESS) {
-			frame.mergeWarmedUpFields(childFrame);
-			frame.pushStackItem(Words.fromAddress(childFrame.getContractAddress()));
+        if (childFrame.getState() == MessageFrame.State.COMPLETED_SUCCESS) {
+            frame.mergeWarmedUpFields(childFrame);
+            frame.pushStackItem(Words.fromAddress(childFrame.getContractAddress()));
 
-			// Add an in-progress record so that if everything succeeds, we can externalize the newly
-			// created contract in the record stream with both its 0.0.X id and its EVM address.
-			// C.f. https://github.com/hashgraph/hedera-services/issues/2807
-			final var updater = (HederaStackedWorldStateUpdater) frame.getWorldUpdater();
-			final var sideEffects = new SideEffectsTracker();
-			sideEffects.trackNewContract(updater.idOfLastNewAddress(), childFrame.getContractAddress());
-			final var childRecord = creator.createSuccessfulSyntheticRecord(
-					NO_CUSTOM_FEES, sideEffects, EMPTY_MEMO);
-			childRecord.onlyExternalizeIfSuccessful();
-			final var opCustomizer = updater.customizerForPendingCreation();
-			final var syntheticOp = syntheticTxnFactory.contractCreation(opCustomizer);
-			updater.manageInProgressRecord(recordsHistorian, childRecord, syntheticOp);
-		} else {
-			frame.setReturnData(childFrame.getOutputData());
-			frame.pushStackItem(UInt256.ZERO);
-		}
+            // Add an in-progress record so that if everything succeeds, we can externalize the
+            // newly
+            // created contract in the record stream with both its 0.0.X id and its EVM address.
+            // C.f. https://github.com/hashgraph/hedera-services/issues/2807
+            final var updater = (HederaStackedWorldStateUpdater) frame.getWorldUpdater();
+            final var sideEffects = new SideEffectsTracker();
+            sideEffects.trackNewContract(
+                    updater.idOfLastNewAddress(), childFrame.getContractAddress());
+            final var childRecord =
+                    creator.createSuccessfulSyntheticRecord(
+                            NO_CUSTOM_FEES, sideEffects, EMPTY_MEMO);
+            childRecord.onlyExternalizeIfSuccessful();
+            final var opCustomizer = updater.customizerForPendingCreation();
+            final var syntheticOp = syntheticTxnFactory.contractCreation(opCustomizer);
+            updater.manageInProgressRecord(recordsHistorian, childRecord, syntheticOp);
+        } else {
+            frame.setReturnData(childFrame.getOutputData());
+            frame.pushStackItem(UInt256.ZERO);
+        }
 
-		final int currentPC = frame.getPC();
-		frame.setPC(currentPC + 1);
-	}
+        final int currentPC = frame.getPC();
+        frame.setPC(currentPC + 1);
+    }
 }

--- a/hedera-node/src/main/java/com/hedera/services/contracts/operation/AbstractRecordingCreateOperation.java
+++ b/hedera-node/src/main/java/com/hedera/services/contracts/operation/AbstractRecordingCreateOperation.java
@@ -1,11 +1,6 @@
-package com.hedera.services.contracts.operation;
-
-/*-
- * ‌
- * Hedera Services Node
- * ​
- * Copyright (C) 2018 - 2022 Hedera Hashgraph, LLC
- * ​
+/*
+ * Copyright (C) 2022 Hedera Hashgraph, LLC
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -17,8 +12,8 @@ package com.hedera.services.contracts.operation;
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- * ‍
  */
+package com.hedera.services.contracts.operation;
 
 import static com.hedera.services.state.EntityCreator.EMPTY_MEMO;
 import static com.hedera.services.state.EntityCreator.NO_CUSTOM_FEES;

--- a/hedera-node/src/main/java/com/hedera/services/contracts/operation/HederaBalanceOperation.java
+++ b/hedera-node/src/main/java/com/hedera/services/contracts/operation/HederaBalanceOperation.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2021-2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hedera.services.contracts.operation;
 
 /*

--- a/hedera-node/src/main/java/com/hedera/services/contracts/operation/HederaBalanceOperation.java
+++ b/hedera-node/src/main/java/com/hedera/services/contracts/operation/HederaBalanceOperation.java
@@ -22,38 +22,38 @@ package com.hedera.services.contracts.operation;
  *
  */
 
+import java.util.function.BiPredicate;
+import javax.inject.Inject;
 import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.evm.EVM;
 import org.hyperledger.besu.evm.frame.MessageFrame;
 import org.hyperledger.besu.evm.gascalculator.GasCalculator;
 import org.hyperledger.besu.evm.operation.BalanceOperation;
 
-import javax.inject.Inject;
-import java.util.function.BiPredicate;
-
 /**
- * Hedera adapted version of the {@link BalanceOperation}. Performs an existence check on the requested {@link Address}
- * Halts the execution of the EVM transaction with {@link HederaExceptionalHaltReason#INVALID_SOLIDITY_ADDRESS} if
- * the account does not exist or it is deleted.
+ * Hedera adapted version of the {@link BalanceOperation}. Performs an existence check on the
+ * requested {@link Address} Halts the execution of the EVM transaction with {@link
+ * HederaExceptionalHaltReason#INVALID_SOLIDITY_ADDRESS} if the account does not exist or it is
+ * deleted.
  */
 public class HederaBalanceOperation extends BalanceOperation {
 
-	private final BiPredicate<Address, MessageFrame> addressValidator;
+    private final BiPredicate<Address, MessageFrame> addressValidator;
 
-	@Inject
-	public HederaBalanceOperation(GasCalculator gasCalculator,
-								  BiPredicate<Address, MessageFrame> addressValidator) {
-		super(gasCalculator);
-		this.addressValidator = addressValidator;
-	}
+    @Inject
+    public HederaBalanceOperation(
+            GasCalculator gasCalculator, BiPredicate<Address, MessageFrame> addressValidator) {
+        super(gasCalculator);
+        this.addressValidator = addressValidator;
+    }
 
-	@Override
-	public OperationResult execute(MessageFrame frame, EVM evm) {
-		return HederaOperationUtil.addressCheckExecution(
-				frame,
-				() -> frame.getStackItem(0),
-				() -> cost(true),
-				() -> super.execute(frame, evm),
-				addressValidator);
-	}
+    @Override
+    public OperationResult execute(MessageFrame frame, EVM evm) {
+        return HederaOperationUtil.addressCheckExecution(
+                frame,
+                () -> frame.getStackItem(0),
+                () -> cost(true),
+                () -> super.execute(frame, evm),
+                addressValidator);
+    }
 }

--- a/hedera-node/src/main/java/com/hedera/services/contracts/operation/HederaCallCodeOperation.java
+++ b/hedera-node/src/main/java/com/hedera/services/contracts/operation/HederaCallCodeOperation.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2021-2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hedera.services.contracts.operation;
 
 /*

--- a/hedera-node/src/main/java/com/hedera/services/contracts/operation/HederaCallCodeOperation.java
+++ b/hedera-node/src/main/java/com/hedera/services/contracts/operation/HederaCallCodeOperation.java
@@ -24,6 +24,9 @@ package com.hedera.services.contracts.operation;
 
 import com.hedera.services.contracts.sources.EvmSigsVerifier;
 import com.hedera.services.state.merkle.MerkleAccount;
+import java.util.Map;
+import java.util.function.BiPredicate;
+import javax.inject.Inject;
 import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.evm.EVM;
 import org.hyperledger.besu.evm.frame.MessageFrame;
@@ -31,49 +34,43 @@ import org.hyperledger.besu.evm.gascalculator.GasCalculator;
 import org.hyperledger.besu.evm.operation.CallCodeOperation;
 import org.hyperledger.besu.evm.precompile.PrecompiledContract;
 
-import javax.inject.Inject;
-import java.util.Map;
-import java.util.function.BiPredicate;
-
 /**
  * Hedera adapted version of the {@link CallCodeOperation}.
  *
- * Performs an existence check on the {@link Address} to be called
- * Halts the execution of the EVM transaction with {@link HederaExceptionalHaltReason#INVALID_SOLIDITY_ADDRESS} if
- * the account does not exist or it is deleted.
+ * <p>Performs an existence check on the {@link Address} to be called Halts the execution of the EVM
+ * transaction with {@link HederaExceptionalHaltReason#INVALID_SOLIDITY_ADDRESS} if the account does
+ * not exist or it is deleted.
  *
- * If the target {@link Address} has {@link MerkleAccount#isReceiverSigRequired()} set to true, verification of the
- * provided signature is performed. If the signature is not
- * active, the execution is halted with {@link HederaExceptionalHaltReason#INVALID_SIGNATURE}.
+ * <p>If the target {@link Address} has {@link MerkleAccount#isReceiverSigRequired()} set to true,
+ * verification of the provided signature is performed. If the signature is not active, the
+ * execution is halted with {@link HederaExceptionalHaltReason#INVALID_SIGNATURE}.
  */
 public class HederaCallCodeOperation extends CallCodeOperation {
-	private final EvmSigsVerifier sigsVerifier;
-	private final BiPredicate<Address, MessageFrame> addressValidator;
-	private final Map<String, PrecompiledContract> precompiledContractMap;
+    private final EvmSigsVerifier sigsVerifier;
+    private final BiPredicate<Address, MessageFrame> addressValidator;
+    private final Map<String, PrecompiledContract> precompiledContractMap;
 
-	@Inject
-	public HederaCallCodeOperation(
+    @Inject
+    public HederaCallCodeOperation(
             final EvmSigsVerifier sigsVerifier,
-            final GasCalculator gasCalculator, 
+            final GasCalculator gasCalculator,
             final BiPredicate<Address, MessageFrame> addressValidator,
-			final Map<String, PrecompiledContract> precompiledContractMap
-        ) {
-		super(gasCalculator);
-		this.sigsVerifier = sigsVerifier;
-		this.addressValidator = addressValidator;
-		this.precompiledContractMap = precompiledContractMap;
-	}
+            final Map<String, PrecompiledContract> precompiledContractMap) {
+        super(gasCalculator);
+        this.sigsVerifier = sigsVerifier;
+        this.addressValidator = addressValidator;
+        this.precompiledContractMap = precompiledContractMap;
+    }
 
-	@Override
-	public OperationResult execute(final MessageFrame frame, final EVM evm) {
-		return HederaOperationUtil.addressSignatureCheckExecution(
-				sigsVerifier,
-				frame,
-				to(frame),
-				() -> cost(frame),
-				() -> super.execute(frame, evm),
-				addressValidator,
-				precompiledContractMap
-		);
-	}
+    @Override
+    public OperationResult execute(final MessageFrame frame, final EVM evm) {
+        return HederaOperationUtil.addressSignatureCheckExecution(
+                sigsVerifier,
+                frame,
+                to(frame),
+                () -> cost(frame),
+                () -> super.execute(frame, evm),
+                addressValidator,
+                precompiledContractMap);
+    }
 }

--- a/hedera-node/src/main/java/com/hedera/services/contracts/operation/HederaCallOperation.java
+++ b/hedera-node/src/main/java/com/hedera/services/contracts/operation/HederaCallOperation.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2021-2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hedera.services.contracts.operation;
 
 /*

--- a/hedera-node/src/main/java/com/hedera/services/contracts/operation/HederaCallOperation.java
+++ b/hedera-node/src/main/java/com/hedera/services/contracts/operation/HederaCallOperation.java
@@ -24,6 +24,9 @@ package com.hedera.services.contracts.operation;
 
 import com.hedera.services.contracts.sources.EvmSigsVerifier;
 import com.hedera.services.state.merkle.MerkleAccount;
+import java.util.Map;
+import java.util.function.BiPredicate;
+import javax.inject.Inject;
 import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.evm.EVM;
 import org.hyperledger.besu.evm.frame.MessageFrame;
@@ -31,48 +34,43 @@ import org.hyperledger.besu.evm.gascalculator.GasCalculator;
 import org.hyperledger.besu.evm.operation.CallOperation;
 import org.hyperledger.besu.evm.precompile.PrecompiledContract;
 
-import javax.inject.Inject;
-import java.util.Map;
-import java.util.function.BiPredicate;
-
 /**
  * Hedera adapted version of the {@link CallOperation}.
  *
- * Performs an existence check on the {@link Address} to be called
- * Halts the execution of the EVM transaction with {@link HederaExceptionalHaltReason#INVALID_SOLIDITY_ADDRESS} if
- * the account does not exist or it is deleted.
+ * <p>Performs an existence check on the {@link Address} to be called Halts the execution of the EVM
+ * transaction with {@link HederaExceptionalHaltReason#INVALID_SOLIDITY_ADDRESS} if the account does
+ * not exist or it is deleted.
  *
- * If the target {@link Address} has {@link MerkleAccount#isReceiverSigRequired()} set to true, verification of the
- * provided signature is performed. If the signature is not
- * active, the execution is halted with {@link HederaExceptionalHaltReason#INVALID_SIGNATURE}.
+ * <p>If the target {@link Address} has {@link MerkleAccount#isReceiverSigRequired()} set to true,
+ * verification of the provided signature is performed. If the signature is not active, the
+ * execution is halted with {@link HederaExceptionalHaltReason#INVALID_SIGNATURE}.
  */
 public class HederaCallOperation extends CallOperation {
-	private final EvmSigsVerifier sigsVerifier;
-	private final BiPredicate<Address, MessageFrame> addressValidator;
-	private final Map<String, PrecompiledContract> precompiledContractMap;
+    private final EvmSigsVerifier sigsVerifier;
+    private final BiPredicate<Address, MessageFrame> addressValidator;
+    private final Map<String, PrecompiledContract> precompiledContractMap;
 
-	@Inject
-	public HederaCallOperation(
-			final EvmSigsVerifier sigsVerifier,
-			final GasCalculator gasCalculator,
-			final BiPredicate<Address, MessageFrame> addressValidator,
-			final Map<String, PrecompiledContract> precompiledContractMap
-	) {
-		super(gasCalculator);
-		this.sigsVerifier = sigsVerifier;
-		this.addressValidator = addressValidator;
-		this.precompiledContractMap = precompiledContractMap;
-	}
+    @Inject
+    public HederaCallOperation(
+            final EvmSigsVerifier sigsVerifier,
+            final GasCalculator gasCalculator,
+            final BiPredicate<Address, MessageFrame> addressValidator,
+            final Map<String, PrecompiledContract> precompiledContractMap) {
+        super(gasCalculator);
+        this.sigsVerifier = sigsVerifier;
+        this.addressValidator = addressValidator;
+        this.precompiledContractMap = precompiledContractMap;
+    }
 
-	@Override
-	public OperationResult execute(final MessageFrame frame, final EVM evm) {
-		return HederaOperationUtil.addressSignatureCheckExecution(
-				sigsVerifier,
-				frame,
-				to(frame),
-				() -> cost(frame),
-				() -> super.execute(frame, evm),
-				addressValidator,
-				precompiledContractMap);
-	}
+    @Override
+    public OperationResult execute(final MessageFrame frame, final EVM evm) {
+        return HederaOperationUtil.addressSignatureCheckExecution(
+                sigsVerifier,
+                frame,
+                to(frame),
+                () -> cost(frame),
+                () -> super.execute(frame, evm),
+                addressValidator,
+                precompiledContractMap);
+    }
 }

--- a/hedera-node/src/main/java/com/hedera/services/contracts/operation/HederaCreate2Operation.java
+++ b/hedera-node/src/main/java/com/hedera/services/contracts/operation/HederaCreate2Operation.java
@@ -1,11 +1,6 @@
-package com.hedera.services.contracts.operation;
-
-/*-
- * ‌
- * Hedera Services Node
- * ​
- * Copyright (C) 2018 - 2022 Hedera Hashgraph, LLC
- * ​
+/*
+ * Copyright (C) 2021-2022 Hedera Hashgraph, LLC
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -17,8 +12,8 @@ package com.hedera.services.contracts.operation;
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- * ‍
  */
+package com.hedera.services.contracts.operation;
 
 import static com.hedera.services.sigs.utils.MiscCryptoUtils.keccak256DigestOf;
 import static org.hyperledger.besu.evm.internal.Words.clampedToLong;

--- a/hedera-node/src/main/java/com/hedera/services/contracts/operation/HederaCreate2Operation.java
+++ b/hedera-node/src/main/java/com/hedera/services/contracts/operation/HederaCreate2Operation.java
@@ -9,9 +9,9 @@ package com.hedera.services.contracts.operation;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,12 +20,16 @@ package com.hedera.services.contracts.operation;
  * ‍
  */
 
+import static com.hedera.services.sigs.utils.MiscCryptoUtils.keccak256DigestOf;
+import static org.hyperledger.besu.evm.internal.Words.clampedToLong;
+
 import com.hedera.services.context.properties.GlobalDynamicProperties;
 import com.hedera.services.contracts.gascalculator.StorageGasCalculator;
 import com.hedera.services.records.RecordsHistorian;
 import com.hedera.services.state.EntityCreator;
 import com.hedera.services.store.contracts.HederaStackedWorldStateUpdater;
 import com.hedera.services.store.contracts.precompile.SyntheticTxnFactory;
+import javax.inject.Inject;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import org.apache.tuweni.units.bigints.UInt256;
@@ -33,72 +37,67 @@ import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.evm.frame.MessageFrame;
 import org.hyperledger.besu.evm.gascalculator.GasCalculator;
 
-import javax.inject.Inject;
-
-import static com.hedera.services.sigs.utils.MiscCryptoUtils.keccak256DigestOf;
-import static org.hyperledger.besu.evm.internal.Words.clampedToLong;
-
 public class HederaCreate2Operation extends AbstractRecordingCreateOperation {
-	private static final Bytes PREFIX = Bytes.fromHexString("0xFF");
+    private static final Bytes PREFIX = Bytes.fromHexString("0xFF");
 
-	private final StorageGasCalculator storageGasCalculator;
-	private final GlobalDynamicProperties dynamicProperties;
+    private final StorageGasCalculator storageGasCalculator;
+    private final GlobalDynamicProperties dynamicProperties;
 
-	@Inject
-	public HederaCreate2Operation(
-			final GasCalculator gasCalculator,
-			final EntityCreator creator,
-			final SyntheticTxnFactory syntheticTxnFactory,
-			final RecordsHistorian recordsHistorian,
-			final GlobalDynamicProperties dynamicProperties,
-			final StorageGasCalculator storageGasCalculator
-	) {
-		super(
-				0xF5,
-				"ħCREATE2",
-				4,
-				1,
-				1,
-				gasCalculator,
-				creator,
-				syntheticTxnFactory,
-				recordsHistorian);
-		this.storageGasCalculator = storageGasCalculator;
-		this.dynamicProperties = dynamicProperties;
-	}
+    @Inject
+    public HederaCreate2Operation(
+            final GasCalculator gasCalculator,
+            final EntityCreator creator,
+            final SyntheticTxnFactory syntheticTxnFactory,
+            final RecordsHistorian recordsHistorian,
+            final GlobalDynamicProperties dynamicProperties,
+            final StorageGasCalculator storageGasCalculator) {
+        super(
+                0xF5,
+                "ħCREATE2",
+                4,
+                1,
+                1,
+                gasCalculator,
+                creator,
+                syntheticTxnFactory,
+                recordsHistorian);
+        this.storageGasCalculator = storageGasCalculator;
+        this.dynamicProperties = dynamicProperties;
+    }
 
-	@Override
-	protected long cost(final MessageFrame frame) {
-		final var calculator = gasCalculator();
-		return calculator.create2OperationGasCost(frame) + storageGasCalculator.creationGasCost(frame, calculator);
-	}
+    @Override
+    protected long cost(final MessageFrame frame) {
+        final var calculator = gasCalculator();
+        return calculator.create2OperationGasCost(frame)
+                + storageGasCalculator.creationGasCost(frame, calculator);
+    }
 
-	@Override
-	protected boolean isEnabled() {
-		return dynamicProperties.isCreate2Enabled();
-	}
+    @Override
+    protected boolean isEnabled() {
+        return dynamicProperties.isCreate2Enabled();
+    }
 
-	@Override
-	protected Address targetContractAddress(final MessageFrame frame) {
-		final var sourceAddressOrAlias = frame.getRecipientAddress();
-		final var offset = clampedToLong(frame.getStackItem(1));
-		final var length = clampedToLong(frame.getStackItem(2));
+    @Override
+    protected Address targetContractAddress(final MessageFrame frame) {
+        final var sourceAddressOrAlias = frame.getRecipientAddress();
+        final var offset = clampedToLong(frame.getStackItem(1));
+        final var length = clampedToLong(frame.getStackItem(2));
 
-		final var updater = (HederaStackedWorldStateUpdater) frame.getWorldUpdater();
-		final var source = updater.priorityAddress(sourceAddressOrAlias);
+        final var updater = (HederaStackedWorldStateUpdater) frame.getWorldUpdater();
+        final var source = updater.priorityAddress(sourceAddressOrAlias);
 
-		final Bytes32 salt = UInt256.fromBytes(frame.getStackItem(3));
-		final var initCode = frame.readMutableMemory(offset, length);
-		final var hash = keccak256(Bytes.concatenate(PREFIX, source, salt, keccak256(initCode)));
-		final var alias = Address.wrap(hash.slice(12, 20));
+        final Bytes32 salt = UInt256.fromBytes(frame.getStackItem(3));
+        final var initCode = frame.readMutableMemory(offset, length);
+        final var hash = keccak256(Bytes.concatenate(PREFIX, source, salt, keccak256(initCode)));
+        final var alias = Address.wrap(hash.slice(12, 20));
 
-		final Address address = updater.newAliasedContractAddress(sourceAddressOrAlias, alias);
-		frame.warmUpAddress(address);
-		frame.warmUpAddress(alias);
-		return alias;
-	}
+        final Address address = updater.newAliasedContractAddress(sourceAddressOrAlias, alias);
+        frame.warmUpAddress(address);
+        frame.warmUpAddress(alias);
+        return alias;
+    }
 
-	private static Bytes32 keccak256(final Bytes input) {
-		return Bytes32.wrap(keccak256DigestOf(input.toArrayUnsafe()));
-	}
+    private static Bytes32 keccak256(final Bytes input) {
+        return Bytes32.wrap(keccak256DigestOf(input.toArrayUnsafe()));
+    }
 }

--- a/hedera-node/src/main/java/com/hedera/services/contracts/operation/HederaCreateOperation.java
+++ b/hedera-node/src/main/java/com/hedera/services/contracts/operation/HederaCreateOperation.java
@@ -27,59 +27,59 @@ import com.hedera.services.records.RecordsHistorian;
 import com.hedera.services.state.EntityCreator;
 import com.hedera.services.store.contracts.HederaWorldUpdater;
 import com.hedera.services.store.contracts.precompile.SyntheticTxnFactory;
+import javax.inject.Inject;
 import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.evm.frame.MessageFrame;
 import org.hyperledger.besu.evm.gascalculator.GasCalculator;
 
-import javax.inject.Inject;
-
 /**
  * Hedera adapted version of the {@link org.hyperledger.besu.evm.operation.CreateOperation}.
  *
- * Addresses are allocated through {@link HederaWorldUpdater#newContractAddress(Address)}
+ * <p>Addresses are allocated through {@link HederaWorldUpdater#newContractAddress(Address)}
  *
- * Gas costs are based on the expiry of the parent and the provided storage bytes per hour variable
+ * <p>Gas costs are based on the expiry of the parent and the provided storage bytes per hour
+ * variable
  */
 public class HederaCreateOperation extends AbstractRecordingCreateOperation {
-	private final StorageGasCalculator storageGasCalculator;
+    private final StorageGasCalculator storageGasCalculator;
 
-	@Inject
-	public HederaCreateOperation(
-			final GasCalculator gasCalculator,
-			final EntityCreator creator,
-			final SyntheticTxnFactory syntheticTxnFactory,
-			final RecordsHistorian recordsHistorian,
-			final StorageGasCalculator storageGasCalculator
-	) {
-		super(
-				0xF0,
-				"ħCREATE",
-				3,
-				1,
-				1,
-				gasCalculator,
-				creator,
-				syntheticTxnFactory,
-				recordsHistorian);
-		this.storageGasCalculator = storageGasCalculator;
-	}
+    @Inject
+    public HederaCreateOperation(
+            final GasCalculator gasCalculator,
+            final EntityCreator creator,
+            final SyntheticTxnFactory syntheticTxnFactory,
+            final RecordsHistorian recordsHistorian,
+            final StorageGasCalculator storageGasCalculator) {
+        super(
+                0xF0,
+                "ħCREATE",
+                3,
+                1,
+                1,
+                gasCalculator,
+                creator,
+                syntheticTxnFactory,
+                recordsHistorian);
+        this.storageGasCalculator = storageGasCalculator;
+    }
 
-	@Override
-	public long cost(final MessageFrame frame) {
-		final var calculator = gasCalculator();
-		return calculator.createOperationGasCost(frame) + storageGasCalculator.creationGasCost(frame, calculator);
-	}
+    @Override
+    public long cost(final MessageFrame frame) {
+        final var calculator = gasCalculator();
+        return calculator.createOperationGasCost(frame)
+                + storageGasCalculator.creationGasCost(frame, calculator);
+    }
 
-	@Override
-	protected boolean isEnabled() {
-		return true;
-	}
+    @Override
+    protected boolean isEnabled() {
+        return true;
+    }
 
-	@Override
-	protected Address targetContractAddress(final MessageFrame frame) {
-		final var updater = (HederaWorldUpdater) frame.getWorldUpdater();
-		final Address address = updater.newContractAddress(frame.getRecipientAddress());
-		frame.warmUpAddress(address);
-		return address;
-	}
+    @Override
+    protected Address targetContractAddress(final MessageFrame frame) {
+        final var updater = (HederaWorldUpdater) frame.getWorldUpdater();
+        final Address address = updater.newContractAddress(frame.getRecipientAddress());
+        frame.warmUpAddress(address);
+        return address;
+    }
 }

--- a/hedera-node/src/main/java/com/hedera/services/contracts/operation/HederaCreateOperation.java
+++ b/hedera-node/src/main/java/com/hedera/services/contracts/operation/HederaCreateOperation.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2021-2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hedera.services.contracts.operation;
 
 /*

--- a/hedera-node/src/main/java/com/hedera/services/contracts/operation/HederaDelegateCallOperation.java
+++ b/hedera-node/src/main/java/com/hedera/services/contracts/operation/HederaDelegateCallOperation.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2021-2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hedera.services.contracts.operation;
 
 /*

--- a/hedera-node/src/main/java/com/hedera/services/contracts/operation/HederaDelegateCallOperation.java
+++ b/hedera-node/src/main/java/com/hedera/services/contracts/operation/HederaDelegateCallOperation.java
@@ -22,40 +22,39 @@ package com.hedera.services.contracts.operation;
  *
  */
 
+import java.util.function.BiPredicate;
+import javax.inject.Inject;
 import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.evm.EVM;
 import org.hyperledger.besu.evm.frame.MessageFrame;
 import org.hyperledger.besu.evm.gascalculator.GasCalculator;
 import org.hyperledger.besu.evm.operation.DelegateCallOperation;
 
-import javax.inject.Inject;
-import java.util.function.BiPredicate;
-
 /**
  * Hedera adapted version of the {@link DelegateCallOperation}.
  *
- * Performs an existence check on the {@link Address} to be called
- * Halts the execution of the EVM transaction with {@link HederaExceptionalHaltReason#INVALID_SOLIDITY_ADDRESS} if
- * the account does not exist or it is deleted.
+ * <p>Performs an existence check on the {@link Address} to be called Halts the execution of the EVM
+ * transaction with {@link HederaExceptionalHaltReason#INVALID_SOLIDITY_ADDRESS} if the account does
+ * not exist or it is deleted.
  */
 public class HederaDelegateCallOperation extends DelegateCallOperation {
 
-	private final BiPredicate<Address, MessageFrame> addressValidator;
+    private final BiPredicate<Address, MessageFrame> addressValidator;
 
-	@Inject
-	public HederaDelegateCallOperation(GasCalculator gasCalculator,
-									   BiPredicate<Address, MessageFrame> addressValidator) {
-		super(gasCalculator);
-		this.addressValidator = addressValidator;
-	}
+    @Inject
+    public HederaDelegateCallOperation(
+            GasCalculator gasCalculator, BiPredicate<Address, MessageFrame> addressValidator) {
+        super(gasCalculator);
+        this.addressValidator = addressValidator;
+    }
 
-	@Override
-	public OperationResult execute(MessageFrame frame, EVM evm) {
-		return HederaOperationUtil.addressCheckExecution(
-				frame,
-				() -> to(frame),
-				() -> cost(frame),
-				() -> super.execute(frame, evm),
-				addressValidator);
-	}
+    @Override
+    public OperationResult execute(MessageFrame frame, EVM evm) {
+        return HederaOperationUtil.addressCheckExecution(
+                frame,
+                () -> to(frame),
+                () -> cost(frame),
+                () -> super.execute(frame, evm),
+                addressValidator);
+    }
 }

--- a/hedera-node/src/main/java/com/hedera/services/contracts/operation/HederaExceptionalHaltReason.java
+++ b/hedera-node/src/main/java/com/hedera/services/contracts/operation/HederaExceptionalHaltReason.java
@@ -25,59 +25,56 @@ package com.hedera.services.contracts.operation;
 import com.hedera.services.state.merkle.MerkleAccount;
 import org.hyperledger.besu.evm.frame.ExceptionalHaltReason;
 
-/**
- * Hedera adapted {@link ExceptionalHaltReason}
- */
+/** Hedera adapted {@link ExceptionalHaltReason} */
 public class HederaExceptionalHaltReason {
 
-	/**
-	 * Used when the EVM transaction accesses address that does not map to any existing (non-deleted)
-	 * account
-	 */
-	public static final ExceptionalHaltReason INVALID_SOLIDITY_ADDRESS = HederaExceptionalHalt.INVALID_SOLIDITY_ADDRESS;
-	/**
-	 * Used when {@link HederaSelfDestructOperation} is used and the beneficiary is specified to be the same as the
-	 * destructed account
-	 */
-	public static final ExceptionalHaltReason SELF_DESTRUCT_TO_SELF = HederaExceptionalHalt.SELF_DESTRUCT_TO_SELF;
-	/**
-	 * Used when there is no active signature for a given {@link com.hedera.services.state.merkle.MerkleAccount} that
-	 * has {@link MerkleAccount#isReceiverSigRequired()} enabled and the account receives HBars
-	 */
-	public static final ExceptionalHaltReason INVALID_SIGNATURE = HederaExceptionalHalt.INVALID_SIGNATURE;
-	/**
-	 * Used when the target of a {@code selfdestruct} is a token treasury.
-	 */
-	public static final ExceptionalHaltReason CONTRACT_IS_TREASURY = HederaExceptionalHalt.CONTRACT_IS_TREASURY;
-	/**
-	 * Used when the target of a {@code selfdestruct} has positive fungible unit balances.
-	 */
-	public static final ExceptionalHaltReason CONTRACT_STILL_OWNS_NFTS =
-			HederaExceptionalHalt.CONTRACT_STILL_OWNS_NFTS;
-	/**
-	 * Used when the target of a {@code selfdestruct} has positive balances.
-	 */
-	public static final ExceptionalHaltReason TRANSACTION_REQUIRES_ZERO_TOKEN_BALANCES =
-			HederaExceptionalHalt.TRANSACTION_REQUIRES_ZERO_TOKEN_BALANCES;
+    /**
+     * Used when the EVM transaction accesses address that does not map to any existing
+     * (non-deleted) account
+     */
+    public static final ExceptionalHaltReason INVALID_SOLIDITY_ADDRESS =
+            HederaExceptionalHalt.INVALID_SOLIDITY_ADDRESS;
+    /**
+     * Used when {@link HederaSelfDestructOperation} is used and the beneficiary is specified to be
+     * the same as the destructed account
+     */
+    public static final ExceptionalHaltReason SELF_DESTRUCT_TO_SELF =
+            HederaExceptionalHalt.SELF_DESTRUCT_TO_SELF;
+    /**
+     * Used when there is no active signature for a given {@link
+     * com.hedera.services.state.merkle.MerkleAccount} that has {@link
+     * MerkleAccount#isReceiverSigRequired()} enabled and the account receives HBars
+     */
+    public static final ExceptionalHaltReason INVALID_SIGNATURE =
+            HederaExceptionalHalt.INVALID_SIGNATURE;
+    /** Used when the target of a {@code selfdestruct} is a token treasury. */
+    public static final ExceptionalHaltReason CONTRACT_IS_TREASURY =
+            HederaExceptionalHalt.CONTRACT_IS_TREASURY;
+    /** Used when the target of a {@code selfdestruct} has positive fungible unit balances. */
+    public static final ExceptionalHaltReason CONTRACT_STILL_OWNS_NFTS =
+            HederaExceptionalHalt.CONTRACT_STILL_OWNS_NFTS;
+    /** Used when the target of a {@code selfdestruct} has positive balances. */
+    public static final ExceptionalHaltReason TRANSACTION_REQUIRES_ZERO_TOKEN_BALANCES =
+            HederaExceptionalHalt.TRANSACTION_REQUIRES_ZERO_TOKEN_BALANCES;
 
-	enum HederaExceptionalHalt implements ExceptionalHaltReason {
-		INVALID_SOLIDITY_ADDRESS("Invalid account reference"),
-		SELF_DESTRUCT_TO_SELF("Self destruct to the same address"),
-		CONTRACT_IS_TREASURY("Token treasuries cannot be deleted"),
-		INVALID_SIGNATURE("Invalid signature"),
-		TRANSACTION_REQUIRES_ZERO_TOKEN_BALANCES("Accounts with positive fungible token balances cannot be deleted"),
-		CONTRACT_STILL_OWNS_NFTS("Accounts who own nfts cannot be deleted");
+    enum HederaExceptionalHalt implements ExceptionalHaltReason {
+        INVALID_SOLIDITY_ADDRESS("Invalid account reference"),
+        SELF_DESTRUCT_TO_SELF("Self destruct to the same address"),
+        CONTRACT_IS_TREASURY("Token treasuries cannot be deleted"),
+        INVALID_SIGNATURE("Invalid signature"),
+        TRANSACTION_REQUIRES_ZERO_TOKEN_BALANCES(
+                "Accounts with positive fungible token balances cannot be deleted"),
+        CONTRACT_STILL_OWNS_NFTS("Accounts who own nfts cannot be deleted");
 
-		final String description;
+        final String description;
 
-		HederaExceptionalHalt(final String description) {
-			this.description = description;
-		}
+        HederaExceptionalHalt(final String description) {
+            this.description = description;
+        }
 
-		@Override
-		public String getDescription() {
-			return description;
-		}
-	}
-
+        @Override
+        public String getDescription() {
+            return description;
+        }
+    }
 }

--- a/hedera-node/src/main/java/com/hedera/services/contracts/operation/HederaExceptionalHaltReason.java
+++ b/hedera-node/src/main/java/com/hedera/services/contracts/operation/HederaExceptionalHaltReason.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2021-2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hedera.services.contracts.operation;
 
 /*

--- a/hedera-node/src/main/java/com/hedera/services/contracts/operation/HederaExtCodeCopyOperation.java
+++ b/hedera-node/src/main/java/com/hedera/services/contracts/operation/HederaExtCodeCopyOperation.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2021-2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hedera.services.contracts.operation;
 
 /*

--- a/hedera-node/src/main/java/com/hedera/services/contracts/operation/HederaExtCodeCopyOperation.java
+++ b/hedera-node/src/main/java/com/hedera/services/contracts/operation/HederaExtCodeCopyOperation.java
@@ -22,47 +22,44 @@ package com.hedera.services.contracts.operation;
  *
  */
 
+import static org.hyperledger.besu.evm.internal.Words.clampedToLong;
+
+import java.util.function.BiPredicate;
+import javax.inject.Inject;
 import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.evm.EVM;
 import org.hyperledger.besu.evm.frame.MessageFrame;
 import org.hyperledger.besu.evm.gascalculator.GasCalculator;
 import org.hyperledger.besu.evm.operation.ExtCodeCopyOperation;
 
-import javax.inject.Inject;
-import java.util.function.BiPredicate;
-
-import static org.hyperledger.besu.evm.internal.Words.clampedToLong;
-
 /**
  * Hedera adapted version of the {@link ExtCodeCopyOperation}.
  *
- * Performs an existence check on the requested {@link Address}
- * Halts the execution of the EVM transaction with {@link HederaExceptionalHaltReason#INVALID_SOLIDITY_ADDRESS} if
- * the account does not exist or it is deleted.
- *
+ * <p>Performs an existence check on the requested {@link Address} Halts the execution of the EVM
+ * transaction with {@link HederaExceptionalHaltReason#INVALID_SOLIDITY_ADDRESS} if the account does
+ * not exist or it is deleted.
  */
 public class HederaExtCodeCopyOperation extends ExtCodeCopyOperation {
 
-	private final BiPredicate<Address, MessageFrame> addressValidator;
+    private final BiPredicate<Address, MessageFrame> addressValidator;
 
-	@Inject
-	public HederaExtCodeCopyOperation(GasCalculator gasCalculator,
-									  BiPredicate<Address, MessageFrame> addressValidator) {
-		super(gasCalculator);
-		this.addressValidator = addressValidator;
-	}
+    @Inject
+    public HederaExtCodeCopyOperation(
+            GasCalculator gasCalculator, BiPredicate<Address, MessageFrame> addressValidator) {
+        super(gasCalculator);
+        this.addressValidator = addressValidator;
+    }
 
-	@Override
-	public OperationResult execute(MessageFrame frame, EVM evm) {
-		final long memOffset = clampedToLong(frame.getStackItem(1));
-		final long numBytes = clampedToLong(frame.getStackItem(3));
+    @Override
+    public OperationResult execute(MessageFrame frame, EVM evm) {
+        final long memOffset = clampedToLong(frame.getStackItem(1));
+        final long numBytes = clampedToLong(frame.getStackItem(3));
 
-		return HederaOperationUtil.addressCheckExecution(
-				frame,
-				() -> frame.getStackItem(0),
-				() -> cost(frame, memOffset, numBytes, true),
-				() -> super.execute(frame, evm),
-				addressValidator
-		);
-	}
+        return HederaOperationUtil.addressCheckExecution(
+                frame,
+                () -> frame.getStackItem(0),
+                () -> cost(frame, memOffset, numBytes, true),
+                () -> super.execute(frame, evm),
+                addressValidator);
+    }
 }

--- a/hedera-node/src/main/java/com/hedera/services/contracts/operation/HederaExtCodeHashOperation.java
+++ b/hedera-node/src/main/java/com/hedera/services/contracts/operation/HederaExtCodeHashOperation.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2021-2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hedera.services.contracts.operation;
 
 /*

--- a/hedera-node/src/main/java/com/hedera/services/contracts/operation/HederaExtCodeHashOperation.java
+++ b/hedera-node/src/main/java/com/hedera/services/contracts/operation/HederaExtCodeHashOperation.java
@@ -22,6 +22,10 @@ package com.hedera.services.contracts.operation;
  *
  */
 
+import java.util.Optional;
+import java.util.OptionalLong;
+import java.util.function.BiPredicate;
+import javax.inject.Inject;
 import org.apache.tuweni.units.bigints.UInt256;
 import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.evm.EVM;
@@ -32,55 +36,53 @@ import org.hyperledger.besu.evm.internal.FixedStack;
 import org.hyperledger.besu.evm.internal.Words;
 import org.hyperledger.besu.evm.operation.ExtCodeHashOperation;
 
-import javax.inject.Inject;
-import java.util.Optional;
-import java.util.OptionalLong;
-import java.util.function.BiPredicate;
-
 /**
  * Hedera adapted version of the {@link ExtCodeHashOperation}.
  *
- * Performs an existence check on the requested {@link Address}
- * Halts the execution of the EVM transaction with {@link HederaExceptionalHaltReason#INVALID_SOLIDITY_ADDRESS} if
- * the account does not exist or it is deleted.
- *
+ * <p>Performs an existence check on the requested {@link Address} Halts the execution of the EVM
+ * transaction with {@link HederaExceptionalHaltReason#INVALID_SOLIDITY_ADDRESS} if the account does
+ * not exist or it is deleted.
  */
 public class HederaExtCodeHashOperation extends ExtCodeHashOperation {
 
-	private final BiPredicate<Address, MessageFrame> addressValidator;
+    private final BiPredicate<Address, MessageFrame> addressValidator;
 
-	@Inject
-	public HederaExtCodeHashOperation(GasCalculator gasCalculator,
-									  BiPredicate<Address, MessageFrame> addressValidator) {
-		super(gasCalculator);
-		this.addressValidator = addressValidator;
-	}
+    @Inject
+    public HederaExtCodeHashOperation(
+            GasCalculator gasCalculator, BiPredicate<Address, MessageFrame> addressValidator) {
+        super(gasCalculator);
+        this.addressValidator = addressValidator;
+    }
 
-	@Override
-	public OperationResult execute(MessageFrame frame, EVM evm) {
-		try {
-			final Address address = Words.toAddress(frame.popStackItem());
-			if (!addressValidator.test(address, frame)) {
-				return new OperationResult(
-						OptionalLong.of(cost(true)), Optional.of(HederaExceptionalHaltReason.INVALID_SOLIDITY_ADDRESS));
-			}
-			final var account = frame.getWorldUpdater().get(address);
-			boolean accountIsWarm = frame.warmUpAddress(address) || this.gasCalculator().isPrecompile(address);
-			OptionalLong optionalCost = OptionalLong.of(this.cost(accountIsWarm));
-			if (frame.getRemainingGas() < optionalCost.getAsLong()) {
-				return new OperationResult(optionalCost, Optional.of(ExceptionalHaltReason.INSUFFICIENT_GAS));
-			} else {
-				if (!account.isEmpty()) {
-					frame.pushStackItem(UInt256.fromBytes(account.getCodeHash()));
-				} else {
-					frame.pushStackItem(UInt256.ZERO);
-				}
+    @Override
+    public OperationResult execute(MessageFrame frame, EVM evm) {
+        try {
+            final Address address = Words.toAddress(frame.popStackItem());
+            if (!addressValidator.test(address, frame)) {
+                return new OperationResult(
+                        OptionalLong.of(cost(true)),
+                        Optional.of(HederaExceptionalHaltReason.INVALID_SOLIDITY_ADDRESS));
+            }
+            final var account = frame.getWorldUpdater().get(address);
+            boolean accountIsWarm =
+                    frame.warmUpAddress(address) || this.gasCalculator().isPrecompile(address);
+            OptionalLong optionalCost = OptionalLong.of(this.cost(accountIsWarm));
+            if (frame.getRemainingGas() < optionalCost.getAsLong()) {
+                return new OperationResult(
+                        optionalCost, Optional.of(ExceptionalHaltReason.INSUFFICIENT_GAS));
+            } else {
+                if (!account.isEmpty()) {
+                    frame.pushStackItem(UInt256.fromBytes(account.getCodeHash()));
+                } else {
+                    frame.pushStackItem(UInt256.ZERO);
+                }
 
-				return new OperationResult(optionalCost, Optional.empty());
-			}
-		} catch (final FixedStack.UnderflowException ufe) {
-			return new OperationResult(
-					OptionalLong.of(cost(true)), Optional.of(ExceptionalHaltReason.INSUFFICIENT_STACK_ITEMS));
-		}
-	}
+                return new OperationResult(optionalCost, Optional.empty());
+            }
+        } catch (final FixedStack.UnderflowException ufe) {
+            return new OperationResult(
+                    OptionalLong.of(cost(true)),
+                    Optional.of(ExceptionalHaltReason.INSUFFICIENT_STACK_ITEMS));
+        }
+    }
 }

--- a/hedera-node/src/main/java/com/hedera/services/contracts/operation/HederaExtCodeSizeOperation.java
+++ b/hedera-node/src/main/java/com/hedera/services/contracts/operation/HederaExtCodeSizeOperation.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2021-2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hedera.services.contracts.operation;
 
 /*

--- a/hedera-node/src/main/java/com/hedera/services/contracts/operation/HederaExtCodeSizeOperation.java
+++ b/hedera-node/src/main/java/com/hedera/services/contracts/operation/HederaExtCodeSizeOperation.java
@@ -22,39 +22,38 @@ package com.hedera.services.contracts.operation;
  *
  */
 
+import java.util.function.BiPredicate;
+import javax.inject.Inject;
 import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.evm.EVM;
 import org.hyperledger.besu.evm.frame.MessageFrame;
 import org.hyperledger.besu.evm.gascalculator.GasCalculator;
 import org.hyperledger.besu.evm.operation.ExtCodeSizeOperation;
 
-import javax.inject.Inject;
-import java.util.function.BiPredicate;
-
 /**
  * Hedera adapted version of the {@link ExtCodeSizeOperation}.
  *
- * Performs an existence check on the requested {@link Address}
- * Halts the execution of the EVM transaction with {@link HederaExceptionalHaltReason#INVALID_SOLIDITY_ADDRESS} if
- * the account does not exist or it is deleted.
+ * <p>Performs an existence check on the requested {@link Address} Halts the execution of the EVM
+ * transaction with {@link HederaExceptionalHaltReason#INVALID_SOLIDITY_ADDRESS} if the account does
+ * not exist or it is deleted.
  */
 public class HederaExtCodeSizeOperation extends ExtCodeSizeOperation {
-	private final BiPredicate<Address, MessageFrame> addressValidator;
+    private final BiPredicate<Address, MessageFrame> addressValidator;
 
-	@Inject
-	public HederaExtCodeSizeOperation(GasCalculator gasCalculator,
-									  BiPredicate<Address, MessageFrame> addressValidator) {
-		super(gasCalculator);
-		this.addressValidator = addressValidator;
-	}
+    @Inject
+    public HederaExtCodeSizeOperation(
+            GasCalculator gasCalculator, BiPredicate<Address, MessageFrame> addressValidator) {
+        super(gasCalculator);
+        this.addressValidator = addressValidator;
+    }
 
-	@Override
-	public OperationResult execute(MessageFrame frame, EVM evm) {
-		return HederaOperationUtil.addressCheckExecution(
-				frame,
-				() -> frame.getStackItem(0),
-				() -> cost(true),
-				() -> super.execute(frame, evm),
-				addressValidator);
-	}
+    @Override
+    public OperationResult execute(MessageFrame frame, EVM evm) {
+        return HederaOperationUtil.addressCheckExecution(
+                frame,
+                () -> frame.getStackItem(0),
+                () -> cost(true),
+                () -> super.execute(frame, evm),
+                addressValidator);
+    }
 }

--- a/hedera-node/src/main/java/com/hedera/services/contracts/operation/HederaLogOperation.java
+++ b/hedera-node/src/main/java/com/hedera/services/contracts/operation/HederaLogOperation.java
@@ -9,9 +9,9 @@ package com.hedera.services.contracts.operation;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,9 +20,14 @@ package com.hedera.services.contracts.operation;
  * ‍
  */
 
+import static org.apache.tuweni.bytes.Bytes32.leftPad;
+import static org.hyperledger.besu.evm.internal.Words.clampedToLong;
+
 import com.google.common.collect.ImmutableList;
 import com.hedera.services.store.contracts.HederaStackedWorldStateUpdater;
 import com.hedera.services.utils.EntityNum;
+import java.util.Optional;
+import java.util.OptionalLong;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes;
@@ -35,55 +40,53 @@ import org.hyperledger.besu.evm.log.Log;
 import org.hyperledger.besu.evm.log.LogTopic;
 import org.hyperledger.besu.evm.operation.AbstractOperation;
 
-import java.util.Optional;
-import java.util.OptionalLong;
-
-import static org.apache.tuweni.bytes.Bytes32.leftPad;
-import static org.hyperledger.besu.evm.internal.Words.clampedToLong;
-
 public class HederaLogOperation extends AbstractOperation {
-	private static final Logger log = LogManager.getLogger(HederaLogOperation.class);
+    private static final Logger log = LogManager.getLogger(HederaLogOperation.class);
 
-	private static final Address UNRESOLVABLE_ADDRESS_STANDIN = EntityNum.MISSING_NUM.toEvmAddress();
+    private static final Address UNRESOLVABLE_ADDRESS_STANDIN =
+            EntityNum.MISSING_NUM.toEvmAddress();
 
-	private final int numTopics;
+    private final int numTopics;
 
-	public HederaLogOperation(final int numTopics, final GasCalculator gasCalculator) {
-		super(0xA0 + numTopics, "LOG" + numTopics, numTopics + 2, 0, 1, gasCalculator);
-		this.numTopics = numTopics;
-	}
+    public HederaLogOperation(final int numTopics, final GasCalculator gasCalculator) {
+        super(0xA0 + numTopics, "LOG" + numTopics, numTopics + 2, 0, 1, gasCalculator);
+        this.numTopics = numTopics;
+    }
 
-	@Override
-	public OperationResult execute(final MessageFrame frame, final EVM evm) {
-		final long dataLocation = clampedToLong(frame.popStackItem());
-		final long numBytes = clampedToLong(frame.popStackItem());
+    @Override
+    public OperationResult execute(final MessageFrame frame, final EVM evm) {
+        final long dataLocation = clampedToLong(frame.popStackItem());
+        final long numBytes = clampedToLong(frame.popStackItem());
 
-		final long cost = gasCalculator().logOperationGasCost(frame, dataLocation, numBytes, numTopics);
-		final OptionalLong optionalCost = OptionalLong.of(cost);
-		if (frame.isStatic()) {
-			return new OperationResult(
-					optionalCost, Optional.of(ExceptionalHaltReason.ILLEGAL_STATE_CHANGE));
-		} else if (frame.getRemainingGas() < cost) {
-			return new OperationResult(optionalCost, Optional.of(ExceptionalHaltReason.INSUFFICIENT_GAS));
-		}
+        final long cost =
+                gasCalculator().logOperationGasCost(frame, dataLocation, numBytes, numTopics);
+        final OptionalLong optionalCost = OptionalLong.of(cost);
+        if (frame.isStatic()) {
+            return new OperationResult(
+                    optionalCost, Optional.of(ExceptionalHaltReason.ILLEGAL_STATE_CHANGE));
+        } else if (frame.getRemainingGas() < cost) {
+            return new OperationResult(
+                    optionalCost, Optional.of(ExceptionalHaltReason.INSUFFICIENT_GAS));
+        }
 
-		final var addressOrAlias = frame.getRecipientAddress();
-		final var updater = (HederaStackedWorldStateUpdater) frame.getWorldUpdater();
-		final var aliases = updater.aliases();
-		var address = aliases.resolveForEvm(addressOrAlias);
-		if (!aliases.isMirror(address)) {
-			address = UNRESOLVABLE_ADDRESS_STANDIN;
-			log.warn("Could not resolve logger address {}", addressOrAlias);
-		}
+        final var addressOrAlias = frame.getRecipientAddress();
+        final var updater = (HederaStackedWorldStateUpdater) frame.getWorldUpdater();
+        final var aliases = updater.aliases();
+        var address = aliases.resolveForEvm(addressOrAlias);
+        if (!aliases.isMirror(address)) {
+            address = UNRESOLVABLE_ADDRESS_STANDIN;
+            log.warn("Could not resolve logger address {}", addressOrAlias);
+        }
 
-		final Bytes data = frame.readMemory(dataLocation, numBytes);
+        final Bytes data = frame.readMemory(dataLocation, numBytes);
 
-		final ImmutableList.Builder<LogTopic> builder = ImmutableList.builderWithExpectedSize(numTopics);
-		for (int i = 0; i < numTopics; i++) {
-			builder.add(LogTopic.create(leftPad(frame.popStackItem())));
-		}
+        final ImmutableList.Builder<LogTopic> builder =
+                ImmutableList.builderWithExpectedSize(numTopics);
+        for (int i = 0; i < numTopics; i++) {
+            builder.add(LogTopic.create(leftPad(frame.popStackItem())));
+        }
 
-		frame.addLog(new Log(address, data, builder.build()));
-		return new OperationResult(optionalCost, Optional.empty());
-	}
+        frame.addLog(new Log(address, data, builder.build()));
+        return new OperationResult(optionalCost, Optional.empty());
+    }
 }

--- a/hedera-node/src/main/java/com/hedera/services/contracts/operation/HederaLogOperation.java
+++ b/hedera-node/src/main/java/com/hedera/services/contracts/operation/HederaLogOperation.java
@@ -1,11 +1,6 @@
-package com.hedera.services.contracts.operation;
-
-/*-
- * ‌
- * Hedera Services Node
- * ​
- * Copyright (C) 2018 - 2022 Hedera Hashgraph, LLC
- * ​
+/*
+ * Copyright (C) 2022 Hedera Hashgraph, LLC
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -17,8 +12,8 @@ package com.hedera.services.contracts.operation;
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- * ‍
  */
+package com.hedera.services.contracts.operation;
 
 import static org.apache.tuweni.bytes.Bytes32.leftPad;
 import static org.hyperledger.besu.evm.internal.Words.clampedToLong;

--- a/hedera-node/src/main/java/com/hedera/services/contracts/operation/HederaOperationUtil.java
+++ b/hedera-node/src/main/java/com/hedera/services/contracts/operation/HederaOperationUtil.java
@@ -26,6 +26,13 @@ import com.hedera.services.contracts.sources.EvmSigsVerifier;
 import com.hedera.services.store.contracts.HederaStackedWorldStateUpdater;
 import com.hedera.services.store.contracts.HederaWorldState;
 import com.hedera.services.utils.BytesComparator;
+import java.util.Map;
+import java.util.Optional;
+import java.util.OptionalLong;
+import java.util.TreeMap;
+import java.util.function.BiPredicate;
+import java.util.function.LongSupplier;
+import java.util.function.Supplier;
 import org.apache.commons.lang3.tuple.MutablePair;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
@@ -38,135 +45,134 @@ import org.hyperledger.besu.evm.internal.Words;
 import org.hyperledger.besu.evm.operation.Operation;
 import org.hyperledger.besu.evm.precompile.PrecompiledContract;
 
-import java.util.Map;
-import java.util.Optional;
-import java.util.OptionalLong;
-import java.util.TreeMap;
-import java.util.function.BiPredicate;
-import java.util.function.LongSupplier;
-import java.util.function.Supplier;
-
-/**
- * Utility methods used by Hedera adapted {@link org.hyperledger.besu.evm.operation.Operation}
- */
+/** Utility methods used by Hedera adapted {@link org.hyperledger.besu.evm.operation.Operation} */
 public final class HederaOperationUtil {
-	private HederaOperationUtil() {
-		throw new UnsupportedOperationException("Utility Class");
-	}
+    private HederaOperationUtil() {
+        throw new UnsupportedOperationException("Utility Class");
+    }
 
-	/**
-	 * An extracted address check and execution of extended Hedera Operations.
-	 * Halts the execution of the EVM transaction with {@link HederaExceptionalHaltReason#INVALID_SOLIDITY_ADDRESS} if
-	 * the account does not exist, or it is deleted.
-	 *
-	 * @param frame                The current message frame
-	 * @param supplierAddressBytes Supplier for the address bytes
-	 * @param supplierHaltGasCost  Supplier for the gas cost
-	 * @param supplierExecution    Supplier with the execution
-	 * @param addressValidator     Address validator predicate
-	 * @return The operation result of the execution
-	 */
-	public static Operation.OperationResult addressCheckExecution(
-			MessageFrame frame,
-			Supplier<Bytes> supplierAddressBytes,
-			LongSupplier supplierHaltGasCost,
-			Supplier<Operation.OperationResult> supplierExecution,
-			BiPredicate<Address, MessageFrame> addressValidator) {
-		try {
-			final var address = Words.toAddress(supplierAddressBytes.get());
-			if (Boolean.FALSE.equals(addressValidator.test(address, frame))) {
-				return new Operation.OperationResult(
-						OptionalLong.of(supplierHaltGasCost.getAsLong()),
-						Optional.of(HederaExceptionalHaltReason.INVALID_SOLIDITY_ADDRESS));
-			}
+    /**
+     * An extracted address check and execution of extended Hedera Operations. Halts the execution
+     * of the EVM transaction with {@link HederaExceptionalHaltReason#INVALID_SOLIDITY_ADDRESS} if
+     * the account does not exist, or it is deleted.
+     *
+     * @param frame The current message frame
+     * @param supplierAddressBytes Supplier for the address bytes
+     * @param supplierHaltGasCost Supplier for the gas cost
+     * @param supplierExecution Supplier with the execution
+     * @param addressValidator Address validator predicate
+     * @return The operation result of the execution
+     */
+    public static Operation.OperationResult addressCheckExecution(
+            MessageFrame frame,
+            Supplier<Bytes> supplierAddressBytes,
+            LongSupplier supplierHaltGasCost,
+            Supplier<Operation.OperationResult> supplierExecution,
+            BiPredicate<Address, MessageFrame> addressValidator) {
+        try {
+            final var address = Words.toAddress(supplierAddressBytes.get());
+            if (Boolean.FALSE.equals(addressValidator.test(address, frame))) {
+                return new Operation.OperationResult(
+                        OptionalLong.of(supplierHaltGasCost.getAsLong()),
+                        Optional.of(HederaExceptionalHaltReason.INVALID_SOLIDITY_ADDRESS));
+            }
 
-			return supplierExecution.get();
-		} catch (final FixedStack.UnderflowException ufe) {
-			return new Operation.OperationResult(
-					OptionalLong.of(supplierHaltGasCost.getAsLong()),
-					Optional.of(ExceptionalHaltReason.INSUFFICIENT_STACK_ITEMS));
-		}
-	}
+            return supplierExecution.get();
+        } catch (final FixedStack.UnderflowException ufe) {
+            return new Operation.OperationResult(
+                    OptionalLong.of(supplierHaltGasCost.getAsLong()),
+                    Optional.of(ExceptionalHaltReason.INSUFFICIENT_STACK_ITEMS));
+        }
+    }
 
-	/**
-	 * An extracted address and signature check, including a further execution of {@link HederaCallOperation} and {@link
-	 * HederaCallCodeOperation}
-	 * Performs an existence check on the {@link Address} to be called
-	 * Halts the execution of the EVM transaction with {@link HederaExceptionalHaltReason#INVALID_SOLIDITY_ADDRESS} if
-	 * the account does not exist or it is deleted.
-	 * <p>
-	 * If the target {@link Address} has {@link com.hedera.services.state.merkle.MerkleAccount#isReceiverSigRequired()}
-	 * set to true, verification of the
-	 * provided signature is performed. If the signature is not
-	 * active, the execution is halted with {@link HederaExceptionalHaltReason#INVALID_SIGNATURE}.
-	 *
-	 * @param sigsVerifier           The signature
-	 * @param frame                  The current message frame
-	 * @param address                The target address
-	 * @param supplierHaltGasCost    Supplier for the gas cost
-	 * @param supplierExecution      Supplier with the execution
-	 * @param addressValidator       Address validator predicate
-	 * @param precompiledContractMap Map of addresses to contracts
-	 * @return The operation result of the execution
-	 */
-	public static Operation.OperationResult addressSignatureCheckExecution(
-			final EvmSigsVerifier sigsVerifier,
-			final MessageFrame frame,
-			final Address address,
-			final LongSupplier supplierHaltGasCost,
-			final Supplier<Operation.OperationResult> supplierExecution,
-			final BiPredicate<Address, MessageFrame> addressValidator,
-			final Map<String, PrecompiledContract> precompiledContractMap
-	) {
-		// The Precompiled contracts verify their signatures themselves
-		if (precompiledContractMap.containsKey(address.toShortHexString())) {
-			return supplierExecution.get();
-		}
+    /**
+     * An extracted address and signature check, including a further execution of {@link
+     * HederaCallOperation} and {@link HederaCallCodeOperation} Performs an existence check on the
+     * {@link Address} to be called Halts the execution of the EVM transaction with {@link
+     * HederaExceptionalHaltReason#INVALID_SOLIDITY_ADDRESS} if the account does not exist or it is
+     * deleted.
+     *
+     * <p>If the target {@link Address} has {@link
+     * com.hedera.services.state.merkle.MerkleAccount#isReceiverSigRequired()} set to true,
+     * verification of the provided signature is performed. If the signature is not active, the
+     * execution is halted with {@link HederaExceptionalHaltReason#INVALID_SIGNATURE}.
+     *
+     * @param sigsVerifier The signature
+     * @param frame The current message frame
+     * @param address The target address
+     * @param supplierHaltGasCost Supplier for the gas cost
+     * @param supplierExecution Supplier with the execution
+     * @param addressValidator Address validator predicate
+     * @param precompiledContractMap Map of addresses to contracts
+     * @return The operation result of the execution
+     */
+    public static Operation.OperationResult addressSignatureCheckExecution(
+            final EvmSigsVerifier sigsVerifier,
+            final MessageFrame frame,
+            final Address address,
+            final LongSupplier supplierHaltGasCost,
+            final Supplier<Operation.OperationResult> supplierExecution,
+            final BiPredicate<Address, MessageFrame> addressValidator,
+            final Map<String, PrecompiledContract> precompiledContractMap) {
+        // The Precompiled contracts verify their signatures themselves
+        if (precompiledContractMap.containsKey(address.toShortHexString())) {
+            return supplierExecution.get();
+        }
 
-		final var updater = (HederaStackedWorldStateUpdater) frame.getWorldUpdater();
-		final var account = updater.get(address);
-		if (Boolean.FALSE.equals(addressValidator.test(address, frame))) {
-			return new Operation.OperationResult(
-					OptionalLong.of(supplierHaltGasCost.getAsLong()),
-					Optional.of(HederaExceptionalHaltReason.INVALID_SOLIDITY_ADDRESS));
-		}
-		boolean isDelegateCall = !frame.getContractAddress().equals(frame.getRecipientAddress());
-		boolean sigReqIsMet;
-		// if this is a delegate call activeContract should be the recipient address
-		// otherwise it should be the contract address
-		if (isDelegateCall) {
-			sigReqIsMet = sigsVerifier.hasActiveKeyOrNoReceiverSigReq(true,
-					account.getAddress(),
-					frame.getRecipientAddress(),
-					updater.trackingLedgers());
-		} else {
-			sigReqIsMet = sigsVerifier.hasActiveKeyOrNoReceiverSigReq(false,
-					account.getAddress(),
-					frame.getContractAddress(),
-					updater.trackingLedgers());
-		}
-		if (!sigReqIsMet) {
-			return new Operation.OperationResult(
-					OptionalLong.of(supplierHaltGasCost.getAsLong()), Optional.of(HederaExceptionalHaltReason.INVALID_SIGNATURE)
-			);
-		}
+        final var updater = (HederaStackedWorldStateUpdater) frame.getWorldUpdater();
+        final var account = updater.get(address);
+        if (Boolean.FALSE.equals(addressValidator.test(address, frame))) {
+            return new Operation.OperationResult(
+                    OptionalLong.of(supplierHaltGasCost.getAsLong()),
+                    Optional.of(HederaExceptionalHaltReason.INVALID_SOLIDITY_ADDRESS));
+        }
+        boolean isDelegateCall = !frame.getContractAddress().equals(frame.getRecipientAddress());
+        boolean sigReqIsMet;
+        // if this is a delegate call activeContract should be the recipient address
+        // otherwise it should be the contract address
+        if (isDelegateCall) {
+            sigReqIsMet =
+                    sigsVerifier.hasActiveKeyOrNoReceiverSigReq(
+                            true,
+                            account.getAddress(),
+                            frame.getRecipientAddress(),
+                            updater.trackingLedgers());
+        } else {
+            sigReqIsMet =
+                    sigsVerifier.hasActiveKeyOrNoReceiverSigReq(
+                            false,
+                            account.getAddress(),
+                            frame.getContractAddress(),
+                            updater.trackingLedgers());
+        }
+        if (!sigReqIsMet) {
+            return new Operation.OperationResult(
+                    OptionalLong.of(supplierHaltGasCost.getAsLong()),
+                    Optional.of(HederaExceptionalHaltReason.INVALID_SIGNATURE));
+        }
 
-		return supplierExecution.get();
-	}
+        return supplierExecution.get();
+    }
 
-	public static void cacheExistingValue(
-			final MessageFrame frame,
-			final Address address,
-			final Bytes32 key,
-			final UInt256 storageValue
-	) {
-		// Store the read if it is the first read for the slot/address
-		var updater = frame.getMessageFrameStack().getLast().getWorldUpdater().parentUpdater().orElse(null);
-		if (updater != null) {
-			final var addressSlots =
-					((HederaWorldState.Updater) updater).getStateChanges()
-							.computeIfAbsent(address, addr -> new TreeMap<>(BytesComparator.INSTANCE));
-			addressSlots.computeIfAbsent(key, slot -> new MutablePair<>(storageValue, null));
-		}
-	}
+    public static void cacheExistingValue(
+            final MessageFrame frame,
+            final Address address,
+            final Bytes32 key,
+            final UInt256 storageValue) {
+        // Store the read if it is the first read for the slot/address
+        var updater =
+                frame.getMessageFrameStack()
+                        .getLast()
+                        .getWorldUpdater()
+                        .parentUpdater()
+                        .orElse(null);
+        if (updater != null) {
+            final var addressSlots =
+                    ((HederaWorldState.Updater) updater)
+                            .getStateChanges()
+                            .computeIfAbsent(
+                                    address, addr -> new TreeMap<>(BytesComparator.INSTANCE));
+            addressSlots.computeIfAbsent(key, slot -> new MutablePair<>(storageValue, null));
+        }
+    }
 }

--- a/hedera-node/src/main/java/com/hedera/services/contracts/operation/HederaOperationUtil.java
+++ b/hedera-node/src/main/java/com/hedera/services/contracts/operation/HederaOperationUtil.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2021-2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hedera.services.contracts.operation;
 
 /*

--- a/hedera-node/src/main/java/com/hedera/services/contracts/operation/HederaSLoadOperation.java
+++ b/hedera-node/src/main/java/com/hedera/services/contracts/operation/HederaSLoadOperation.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hedera.services.contracts.operation;
 
 /*

--- a/hedera-node/src/main/java/com/hedera/services/contracts/operation/HederaSLoadOperation.java
+++ b/hedera-node/src/main/java/com/hedera/services/contracts/operation/HederaSLoadOperation.java
@@ -24,6 +24,9 @@ package com.hedera.services.contracts.operation;
 
 import com.hedera.services.context.properties.GlobalDynamicProperties;
 import com.hedera.services.store.contracts.HederaStackedWorldStateUpdater;
+import java.util.Optional;
+import java.util.OptionalLong;
+import javax.inject.Inject;
 import org.apache.tuweni.bytes.Bytes32;
 import org.apache.tuweni.units.bigints.UInt256;
 import org.hyperledger.besu.datatypes.Address;
@@ -36,63 +39,60 @@ import org.hyperledger.besu.evm.internal.FixedStack.OverflowException;
 import org.hyperledger.besu.evm.internal.FixedStack.UnderflowException;
 import org.hyperledger.besu.evm.operation.AbstractOperation;
 
-import javax.inject.Inject;
-import java.util.Optional;
-import java.util.OptionalLong;
-
 /**
- * Hedera adapted version of the {@link org.hyperledger.besu.evm.operation.SLoadOperation}.
- * No externally visible changes, the result of sload is stored for the benefit of ther record stream.
+ * Hedera adapted version of the {@link org.hyperledger.besu.evm.operation.SLoadOperation}. No
+ * externally visible changes, the result of sload is stored for the benefit of ther record stream.
  */
 public class HederaSLoadOperation extends AbstractOperation {
 
+    private final OptionalLong warmCost;
+    private final OptionalLong coldCost;
 
-	private final OptionalLong warmCost;
-	private final OptionalLong coldCost;
+    private final OperationResult warmSuccess;
+    private final OperationResult coldSuccess;
+    private final GlobalDynamicProperties dynamicProperties;
 
-	private final OperationResult warmSuccess;
-	private final OperationResult coldSuccess;
-	private final GlobalDynamicProperties dynamicProperties;
+    @Inject
+    public HederaSLoadOperation(
+            final GasCalculator gasCalculator, final GlobalDynamicProperties dynamicProperties) {
+        super(0x54, "SLOAD", 1, 1, 1, gasCalculator);
+        final long baseCost = gasCalculator.getSloadOperationGasCost();
+        warmCost = OptionalLong.of(baseCost + gasCalculator.getWarmStorageReadCost());
+        coldCost = OptionalLong.of(baseCost + gasCalculator.getColdSloadCost());
 
-	@Inject
-	public HederaSLoadOperation(final GasCalculator gasCalculator, final GlobalDynamicProperties dynamicProperties) {
-		super(0x54, "SLOAD", 1, 1, 1, gasCalculator);
-		final long baseCost = gasCalculator.getSloadOperationGasCost();
-		warmCost = OptionalLong.of(baseCost + gasCalculator.getWarmStorageReadCost());
-		coldCost = OptionalLong.of(baseCost + gasCalculator.getColdSloadCost());
+        warmSuccess = new OperationResult(warmCost, Optional.empty());
+        coldSuccess = new OperationResult(coldCost, Optional.empty());
+        this.dynamicProperties = dynamicProperties;
+    }
 
-		warmSuccess = new OperationResult(warmCost, Optional.empty());
-		coldSuccess = new OperationResult(coldCost, Optional.empty());
-		this.dynamicProperties = dynamicProperties;
-	}
+    @Override
+    public OperationResult execute(final MessageFrame frame, final EVM evm) {
+        try {
+            final var addressOrAlias = frame.getRecipientAddress();
+            final var worldUpdater = (HederaStackedWorldStateUpdater) frame.getWorldUpdater();
+            final Account account = worldUpdater.get(addressOrAlias);
+            final Address address = account.getAddress();
+            final Bytes32 key = UInt256.fromBytes(frame.popStackItem());
+            final boolean slotIsWarm = frame.warmUpStorage(address, key);
+            final OptionalLong optionalCost = slotIsWarm ? warmCost : coldCost;
+            if (frame.getRemainingGas() < optionalCost.orElse(0L)) {
+                return new OperationResult(
+                        optionalCost, Optional.of(ExceptionalHaltReason.INSUFFICIENT_GAS));
+            } else {
+                UInt256 storageValue = account.getStorageValue(UInt256.fromBytes(key));
+                if (dynamicProperties.shouldEnableTraceability()) {
+                    HederaOperationUtil.cacheExistingValue(frame, address, key, storageValue);
+                }
 
-	@Override
-	public OperationResult execute(final MessageFrame frame, final EVM evm) {
-		try {
-			final var addressOrAlias = frame.getRecipientAddress();
-			final var worldUpdater = (HederaStackedWorldStateUpdater) frame.getWorldUpdater();
-			final Account account = worldUpdater.get(addressOrAlias);
-			final Address address = account.getAddress();
-			final Bytes32 key = UInt256.fromBytes(frame.popStackItem());
-			final boolean slotIsWarm = frame.warmUpStorage(address, key);
-			final OptionalLong optionalCost = slotIsWarm ? warmCost : coldCost;
-			if (frame.getRemainingGas() < optionalCost.orElse(0L)) {
-				return new OperationResult(
-						optionalCost, Optional.of(ExceptionalHaltReason.INSUFFICIENT_GAS));
-			} else {
-				UInt256 storageValue = account.getStorageValue(UInt256.fromBytes(key));
-				if (dynamicProperties.shouldEnableTraceability()) {
-					HederaOperationUtil.cacheExistingValue(frame, address, key, storageValue);
-				}
-
-				frame.pushStackItem(storageValue);
-				return slotIsWarm ? warmSuccess : coldSuccess;
-			}
-		} catch (final UnderflowException ufe) {
-			return new OperationResult(
-					warmCost, Optional.of(ExceptionalHaltReason.INSUFFICIENT_STACK_ITEMS));
-		} catch (final OverflowException ofe) {
-			return new OperationResult(warmCost, Optional.of(ExceptionalHaltReason.TOO_MANY_STACK_ITEMS));
-		}
-	}
+                frame.pushStackItem(storageValue);
+                return slotIsWarm ? warmSuccess : coldSuccess;
+            }
+        } catch (final UnderflowException ufe) {
+            return new OperationResult(
+                    warmCost, Optional.of(ExceptionalHaltReason.INSUFFICIENT_STACK_ITEMS));
+        } catch (final OverflowException ofe) {
+            return new OperationResult(
+                    warmCost, Optional.of(ExceptionalHaltReason.TOO_MANY_STACK_ITEMS));
+        }
+    }
 }

--- a/hedera-node/src/main/java/com/hedera/services/contracts/operation/HederaSStoreOperation.java
+++ b/hedera-node/src/main/java/com/hedera/services/contracts/operation/HederaSStoreOperation.java
@@ -22,10 +22,16 @@ package com.hedera.services.contracts.operation;
  *
  */
 
+import static com.hedera.services.contracts.operation.HederaOperationUtil.cacheExistingValue;
+import static org.hyperledger.besu.evm.frame.ExceptionalHaltReason.ILLEGAL_STATE_CHANGE;
+
 import com.hedera.services.context.properties.GlobalDynamicProperties;
 import com.hedera.services.contracts.gascalculator.GasCalculatorHederaV18;
 import com.hedera.services.contracts.gascalculator.StorageGasCalculator;
 import com.hedera.services.store.contracts.HederaWorldUpdater;
+import java.util.Optional;
+import java.util.OptionalLong;
+import javax.inject.Inject;
 import org.apache.tuweni.units.bigints.UInt256;
 import org.hyperledger.besu.evm.EVM;
 import org.hyperledger.besu.evm.account.MutableAccount;
@@ -35,83 +41,80 @@ import org.hyperledger.besu.evm.gascalculator.GasCalculator;
 import org.hyperledger.besu.evm.operation.AbstractOperation;
 import org.hyperledger.besu.evm.operation.Operation;
 
-import javax.inject.Inject;
-import java.util.Optional;
-import java.util.OptionalLong;
-
-import static com.hedera.services.contracts.operation.HederaOperationUtil.cacheExistingValue;
-import static org.hyperledger.besu.evm.frame.ExceptionalHaltReason.ILLEGAL_STATE_CHANGE;
-
 /**
- * Hedera adapted version of the {@link org.hyperledger.besu.evm.operation.SStoreOperation}.
- * Gas costs are based on the expiry of the current or parent account and the provided storage bytes per hour variable
+ * Hedera adapted version of the {@link org.hyperledger.besu.evm.operation.SStoreOperation}. Gas
+ * costs are based on the expiry of the current or parent account and the provided storage bytes per
+ * hour variable
  */
 public class HederaSStoreOperation extends AbstractOperation {
-	private static final Operation.OperationResult ILLEGAL_STATE_CHANGE_RESULT =
-			new Operation.OperationResult(OptionalLong.empty(), Optional.of(ILLEGAL_STATE_CHANGE));
+    private static final Operation.OperationResult ILLEGAL_STATE_CHANGE_RESULT =
+            new Operation.OperationResult(OptionalLong.empty(), Optional.of(ILLEGAL_STATE_CHANGE));
 
-	private final boolean checkSuperCost;
-	private final StorageGasCalculator storageGasCalculator;
-	private final GlobalDynamicProperties dynamicProperties;
+    private final boolean checkSuperCost;
+    private final StorageGasCalculator storageGasCalculator;
+    private final GlobalDynamicProperties dynamicProperties;
 
-	@Inject
-	public HederaSStoreOperation(
-			final GasCalculator gasCalculator,
-			final StorageGasCalculator storageGasCalculator,
-			final GlobalDynamicProperties dynamicProperties
-	) {
-		super(0x55, "SSTORE", 2, 0, 1, gasCalculator);
-		checkSuperCost = !(gasCalculator instanceof GasCalculatorHederaV18);
-		this.dynamicProperties = dynamicProperties;
-		this.storageGasCalculator = storageGasCalculator;
-	}
+    @Inject
+    public HederaSStoreOperation(
+            final GasCalculator gasCalculator,
+            final StorageGasCalculator storageGasCalculator,
+            final GlobalDynamicProperties dynamicProperties) {
+        super(0x55, "SSTORE", 2, 0, 1, gasCalculator);
+        checkSuperCost = !(gasCalculator instanceof GasCalculatorHederaV18);
+        this.dynamicProperties = dynamicProperties;
+        this.storageGasCalculator = storageGasCalculator;
+    }
 
-	@Override
-	public Operation.OperationResult execute(final MessageFrame frame, final EVM evm) {
-		final UInt256 key = UInt256.fromBytes(frame.popStackItem());
-		final UInt256 value = UInt256.fromBytes(frame.popStackItem());
+    @Override
+    public Operation.OperationResult execute(final MessageFrame frame, final EVM evm) {
+        final UInt256 key = UInt256.fromBytes(frame.popStackItem());
+        final UInt256 value = UInt256.fromBytes(frame.popStackItem());
 
-		final MutableAccount account = frame.getWorldUpdater().getAccount(frame.getRecipientAddress()).getMutable();
-		if (account == null) {
-			return ILLEGAL_STATE_CHANGE_RESULT;
-		}
+        final MutableAccount account =
+                frame.getWorldUpdater().getAccount(frame.getRecipientAddress()).getMutable();
+        if (account == null) {
+            return ILLEGAL_STATE_CHANGE_RESULT;
+        }
 
-		UInt256 currentValue = account.getStorageValue(key);
-		boolean currentZero = currentValue.isZero();
-		boolean newZero = value.isZero();
-		boolean checkCalculator = checkSuperCost;
-		long gasCost = 0L;
-		if (currentZero && !newZero) {
-			gasCost = storageGasCalculator.gasCostOfStorageIn(frame);
-			((HederaWorldUpdater) frame.getWorldUpdater()).addSbhRefund(gasCost);
-		} else {
-			checkCalculator = true;
-		}
+        UInt256 currentValue = account.getStorageValue(key);
+        boolean currentZero = currentValue.isZero();
+        boolean newZero = value.isZero();
+        boolean checkCalculator = checkSuperCost;
+        long gasCost = 0L;
+        if (currentZero && !newZero) {
+            gasCost = storageGasCalculator.gasCostOfStorageIn(frame);
+            ((HederaWorldUpdater) frame.getWorldUpdater()).addSbhRefund(gasCost);
+        } else {
+            checkCalculator = true;
+        }
 
-		if (checkCalculator) {
-			final var address = account.getAddress();
-			final var slotIsWarm = frame.warmUpStorage(address, key);
-			final var calculator = gasCalculator();
-			final var calcGasCost = calculator.calculateStorageCost(account, key, value)
-					 + (slotIsWarm ? 0L : calculator.getColdSloadCost());
-			gasCost = Math.max(gasCost, calcGasCost);
-			frame.incrementGasRefund(gasCalculator().calculateStorageRefundAmount(account, key, value));
-		}
+        if (checkCalculator) {
+            final var address = account.getAddress();
+            final var slotIsWarm = frame.warmUpStorage(address, key);
+            final var calculator = gasCalculator();
+            final var calcGasCost =
+                    calculator.calculateStorageCost(account, key, value)
+                            + (slotIsWarm ? 0L : calculator.getColdSloadCost());
+            gasCost = Math.max(gasCost, calcGasCost);
+            frame.incrementGasRefund(
+                    gasCalculator().calculateStorageRefundAmount(account, key, value));
+        }
 
-		final var optionalCost = OptionalLong.of(gasCost);
-		final long remainingGas = frame.getRemainingGas();
-		if (frame.isStatic()) {
-			return new OperationResult(optionalCost, Optional.of(ILLEGAL_STATE_CHANGE));
-		} else if (remainingGas < gasCost) {
-			return new OperationResult(optionalCost, Optional.of(ExceptionalHaltReason.INSUFFICIENT_GAS));
-		}
+        final var optionalCost = OptionalLong.of(gasCost);
+        final long remainingGas = frame.getRemainingGas();
+        if (frame.isStatic()) {
+            return new OperationResult(optionalCost, Optional.of(ILLEGAL_STATE_CHANGE));
+        } else if (remainingGas < gasCost) {
+            return new OperationResult(
+                    optionalCost, Optional.of(ExceptionalHaltReason.INSUFFICIENT_GAS));
+        }
 
-		if (dynamicProperties.shouldEnableTraceability()) {
-			cacheExistingValue(frame, account.getAddress(), key, currentValue);
-		}
+        if (dynamicProperties.shouldEnableTraceability()) {
+            cacheExistingValue(frame, account.getAddress(), key, currentValue);
+        }
 
-		account.setStorageValue(key, value);
-		frame.storageWasUpdated(key, value);
-		return new Operation.OperationResult(optionalCost, Optional.empty());
-	}
+        account.setStorageValue(key, value);
+        frame.storageWasUpdated(key, value);
+        return new Operation.OperationResult(optionalCost, Optional.empty());
+    }
 }

--- a/hedera-node/src/main/java/com/hedera/services/contracts/operation/HederaSStoreOperation.java
+++ b/hedera-node/src/main/java/com/hedera/services/contracts/operation/HederaSStoreOperation.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2021-2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hedera.services.contracts.operation;
 
 /*

--- a/hedera-node/src/main/java/com/hedera/services/contracts/operation/HederaSelfDestructOperation.java
+++ b/hedera-node/src/main/java/com/hedera/services/contracts/operation/HederaSelfDestructOperation.java
@@ -22,8 +22,15 @@ package com.hedera.services.contracts.operation;
  *
  */
 
+import static com.hedera.services.utils.EntityIdUtils.numOfMirror;
+
 import com.hedera.services.context.TransactionContext;
 import com.hedera.services.store.contracts.HederaStackedWorldStateUpdater;
+import java.util.Optional;
+import java.util.OptionalLong;
+import java.util.function.BiPredicate;
+import javax.annotation.Nullable;
+import javax.inject.Inject;
 import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.datatypes.Wei;
 import org.hyperledger.besu.evm.EVM;
@@ -34,84 +41,77 @@ import org.hyperledger.besu.evm.gascalculator.GasCalculator;
 import org.hyperledger.besu.evm.internal.Words;
 import org.hyperledger.besu.evm.operation.SelfDestructOperation;
 
-import javax.annotation.Nullable;
-import javax.inject.Inject;
-import java.util.Optional;
-import java.util.OptionalLong;
-import java.util.function.BiPredicate;
-
-import static com.hedera.services.utils.EntityIdUtils.numOfMirror;
-
 /**
  * Hedera adapted version of the {@link SelfDestructOperation}.
- * <p>
- * Performs an existence check on the beneficiary {@link Address}
- * Halts the execution of the EVM transaction with {@link HederaExceptionalHaltReason#INVALID_SOLIDITY_ADDRESS} if
- * the account does not exist or it is deleted.
- * <p>
- * Halts the execution of the EVM transaction with {@link HederaExceptionalHaltReason#SELF_DESTRUCT_TO_SELF} if the
- * beneficiary address is the same as the address being destructed
+ *
+ * <p>Performs an existence check on the beneficiary {@link Address} Halts the execution of the EVM
+ * transaction with {@link HederaExceptionalHaltReason#INVALID_SOLIDITY_ADDRESS} if the account does
+ * not exist or it is deleted.
+ *
+ * <p>Halts the execution of the EVM transaction with {@link
+ * HederaExceptionalHaltReason#SELF_DESTRUCT_TO_SELF} if the beneficiary address is the same as the
+ * address being destructed
  */
 public class HederaSelfDestructOperation extends SelfDestructOperation {
-	private final TransactionContext txnCtx;
+    private final TransactionContext txnCtx;
 
-	private final BiPredicate<Address, MessageFrame> addressValidator;
+    private final BiPredicate<Address, MessageFrame> addressValidator;
 
-	@Inject
-	public HederaSelfDestructOperation(
-			final GasCalculator gasCalculator,
-			final TransactionContext txnCtx,
-			final BiPredicate<Address, MessageFrame> addressValidator
-	) {
-		super(gasCalculator);
-		this.txnCtx = txnCtx;
-		this.addressValidator = addressValidator;
-	}
+    @Inject
+    public HederaSelfDestructOperation(
+            final GasCalculator gasCalculator,
+            final TransactionContext txnCtx,
+            final BiPredicate<Address, MessageFrame> addressValidator) {
+        super(gasCalculator);
+        this.txnCtx = txnCtx;
+        this.addressValidator = addressValidator;
+    }
 
-	@Override
-	public OperationResult execute(final MessageFrame frame, final EVM evm) {
-		final var updater = (HederaStackedWorldStateUpdater) frame.getWorldUpdater();
-		final var beneficiaryAddress = Words.toAddress(frame.getStackItem(0));
-		final var toBeDeleted = frame.getRecipientAddress();
-		if (!addressValidator.test(beneficiaryAddress, frame)) {
-			return reversionWith(null, HederaExceptionalHaltReason.INVALID_SOLIDITY_ADDRESS);
-		}
-		final var beneficiary = updater.get(beneficiaryAddress);
+    @Override
+    public OperationResult execute(final MessageFrame frame, final EVM evm) {
+        final var updater = (HederaStackedWorldStateUpdater) frame.getWorldUpdater();
+        final var beneficiaryAddress = Words.toAddress(frame.getStackItem(0));
+        final var toBeDeleted = frame.getRecipientAddress();
+        if (!addressValidator.test(beneficiaryAddress, frame)) {
+            return reversionWith(null, HederaExceptionalHaltReason.INVALID_SOLIDITY_ADDRESS);
+        }
+        final var beneficiary = updater.get(beneficiaryAddress);
 
-		final var exceptionalHaltReason = reasonToHalt(toBeDeleted, beneficiaryAddress, updater);
-		if (exceptionalHaltReason != null) {
-			return reversionWith(beneficiary, exceptionalHaltReason);
-		}
-		final var tbdNum = numOfMirror(updater.permissivelyUnaliased(toBeDeleted.toArrayUnsafe()));
-		final var beneficiaryNum = numOfMirror(updater.permissivelyUnaliased(beneficiaryAddress.toArrayUnsafe()));
-		txnCtx.recordBeneficiaryOfDeleted(tbdNum, beneficiaryNum);
+        final var exceptionalHaltReason = reasonToHalt(toBeDeleted, beneficiaryAddress, updater);
+        if (exceptionalHaltReason != null) {
+            return reversionWith(beneficiary, exceptionalHaltReason);
+        }
+        final var tbdNum = numOfMirror(updater.permissivelyUnaliased(toBeDeleted.toArrayUnsafe()));
+        final var beneficiaryNum =
+                numOfMirror(updater.permissivelyUnaliased(beneficiaryAddress.toArrayUnsafe()));
+        txnCtx.recordBeneficiaryOfDeleted(tbdNum, beneficiaryNum);
 
-		return super.execute(frame, evm);
-	}
+        return super.execute(frame, evm);
+    }
 
-	@Nullable
-	private ExceptionalHaltReason reasonToHalt(
-			final Address toBeDeleted,
-			final Address beneficiaryAddress,
-			final HederaStackedWorldStateUpdater updater
-	) {
-		if (toBeDeleted.equals(beneficiaryAddress)) {
-			return HederaExceptionalHaltReason.SELF_DESTRUCT_TO_SELF;
-		}
-		if (updater.contractIsTokenTreasury(toBeDeleted)) {
-			return HederaExceptionalHaltReason.CONTRACT_IS_TREASURY;
-		}
-		if (updater.contractHasAnyBalance(toBeDeleted)) {
-			return HederaExceptionalHaltReason.TRANSACTION_REQUIRES_ZERO_TOKEN_BALANCES;
-		}
-		if (updater.contractOwnsNfts(toBeDeleted)) {
-			return HederaExceptionalHaltReason.CONTRACT_STILL_OWNS_NFTS;
-		}
-		return null;
-	}
+    @Nullable
+    private ExceptionalHaltReason reasonToHalt(
+            final Address toBeDeleted,
+            final Address beneficiaryAddress,
+            final HederaStackedWorldStateUpdater updater) {
+        if (toBeDeleted.equals(beneficiaryAddress)) {
+            return HederaExceptionalHaltReason.SELF_DESTRUCT_TO_SELF;
+        }
+        if (updater.contractIsTokenTreasury(toBeDeleted)) {
+            return HederaExceptionalHaltReason.CONTRACT_IS_TREASURY;
+        }
+        if (updater.contractHasAnyBalance(toBeDeleted)) {
+            return HederaExceptionalHaltReason.TRANSACTION_REQUIRES_ZERO_TOKEN_BALANCES;
+        }
+        if (updater.contractOwnsNfts(toBeDeleted)) {
+            return HederaExceptionalHaltReason.CONTRACT_STILL_OWNS_NFTS;
+        }
+        return null;
+    }
 
-	private OperationResult reversionWith(final Account beneficiary, final ExceptionalHaltReason reason) {
-		final long cost = gasCalculator().selfDestructOperationGasCost(beneficiary, Wei.ONE);
-		return new OperationResult(OptionalLong.of(cost), Optional.of(reason));
-	}
+    private OperationResult reversionWith(
+            final Account beneficiary, final ExceptionalHaltReason reason) {
+        final long cost = gasCalculator().selfDestructOperationGasCost(beneficiary, Wei.ONE);
+        return new OperationResult(OptionalLong.of(cost), Optional.of(reason));
+    }
 }

--- a/hedera-node/src/main/java/com/hedera/services/contracts/operation/HederaSelfDestructOperation.java
+++ b/hedera-node/src/main/java/com/hedera/services/contracts/operation/HederaSelfDestructOperation.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2021-2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hedera.services.contracts.operation;
 
 /*

--- a/hedera-node/src/main/java/com/hedera/services/contracts/operation/HederaStaticCallOperation.java
+++ b/hedera-node/src/main/java/com/hedera/services/contracts/operation/HederaStaticCallOperation.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2021-2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hedera.services.contracts.operation;
 
 /*

--- a/hedera-node/src/main/java/com/hedera/services/contracts/operation/HederaStaticCallOperation.java
+++ b/hedera-node/src/main/java/com/hedera/services/contracts/operation/HederaStaticCallOperation.java
@@ -23,6 +23,9 @@ package com.hedera.services.contracts.operation;
  */
 
 import com.hedera.services.contracts.sources.EvmSigsVerifier;
+import java.util.Map;
+import java.util.function.BiPredicate;
+import javax.inject.Inject;
 import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.evm.EVM;
 import org.hyperledger.besu.evm.frame.MessageFrame;
@@ -30,43 +33,39 @@ import org.hyperledger.besu.evm.gascalculator.GasCalculator;
 import org.hyperledger.besu.evm.operation.StaticCallOperation;
 import org.hyperledger.besu.evm.precompile.PrecompiledContract;
 
-import javax.inject.Inject;
-import java.util.Map;
-import java.util.function.BiPredicate;
-
 /**
  * Hedera adapted version of the {@link StaticCallOperation}.
  *
- * Performs an existence check on the {@link Address} to be called
- * Halts the execution of the EVM transaction with {@link HederaExceptionalHaltReason#INVALID_SOLIDITY_ADDRESS} if
- * the account does not exist or it is deleted.
+ * <p>Performs an existence check on the {@link Address} to be called Halts the execution of the EVM
+ * transaction with {@link HederaExceptionalHaltReason#INVALID_SOLIDITY_ADDRESS} if the account does
+ * not exist or it is deleted.
  */
 public class HederaStaticCallOperation extends StaticCallOperation {
-	private final EvmSigsVerifier sigsVerifier;
-	private final BiPredicate<Address, MessageFrame> addressValidator;
-	private final Map<String, PrecompiledContract> precompiledContractMap;
+    private final EvmSigsVerifier sigsVerifier;
+    private final BiPredicate<Address, MessageFrame> addressValidator;
+    private final Map<String, PrecompiledContract> precompiledContractMap;
 
-	@Inject
-	public HederaStaticCallOperation(
-			final GasCalculator gasCalculator,
-			final EvmSigsVerifier sigsVerifier,
-			final BiPredicate<Address, MessageFrame> addressValidator,
-			final Map<String, PrecompiledContract> precompiledContractMap
-	) {
-		super(gasCalculator);
-		this.sigsVerifier = sigsVerifier;
-		this.addressValidator = addressValidator;
-		this.precompiledContractMap = precompiledContractMap;
-	}
+    @Inject
+    public HederaStaticCallOperation(
+            final GasCalculator gasCalculator,
+            final EvmSigsVerifier sigsVerifier,
+            final BiPredicate<Address, MessageFrame> addressValidator,
+            final Map<String, PrecompiledContract> precompiledContractMap) {
+        super(gasCalculator);
+        this.sigsVerifier = sigsVerifier;
+        this.addressValidator = addressValidator;
+        this.precompiledContractMap = precompiledContractMap;
+    }
 
-	@Override
-	public OperationResult execute(final MessageFrame frame, final EVM evm) {
-		return HederaOperationUtil.addressSignatureCheckExecution(
-				sigsVerifier,
-				frame,
-				to(frame),
-				() -> cost(frame),
-				() -> super.execute(frame, evm),
-				addressValidator, precompiledContractMap);
-	}
+    @Override
+    public OperationResult execute(final MessageFrame frame, final EVM evm) {
+        return HederaOperationUtil.addressSignatureCheckExecution(
+                sigsVerifier,
+                frame,
+                to(frame),
+                () -> cost(frame),
+                () -> super.execute(frame, evm),
+                addressValidator,
+                precompiledContractMap);
+    }
 }

--- a/hedera-node/src/main/java/com/hedera/services/contracts/sources/AddressKeyedMapFactory.java
+++ b/hedera-node/src/main/java/com/hedera/services/contracts/sources/AddressKeyedMapFactory.java
@@ -1,11 +1,6 @@
-package com.hedera.services.contracts.sources;
-
-/*-
- * ‌
- * Hedera Services Node
- * ​
- * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
- * ​
+/*
+ * Copyright (C) 2020-2022 Hedera Hashgraph, LLC
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -17,8 +12,8 @@ package com.hedera.services.contracts.sources;
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- * ‍
  */
+package com.hedera.services.contracts.sources;
 
 import static com.hedera.services.utils.EntityIdUtils.asEvmAddress;
 import static java.lang.Long.parseLong;

--- a/hedera-node/src/main/java/com/hedera/services/contracts/sources/EvmSigsVerifier.java
+++ b/hedera-node/src/main/java/com/hedera/services/contracts/sources/EvmSigsVerifier.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2020-2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hedera.services.contracts.sources;
 
 /*

--- a/hedera-node/src/main/java/com/hedera/services/contracts/sources/EvmSigsVerifier.java
+++ b/hedera-node/src/main/java/com/hedera/services/contracts/sources/EvmSigsVerifier.java
@@ -22,98 +22,97 @@ package com.hedera.services.contracts.sources;
  *
  */
 
-import com.hedera.services.store.contracts.WorldLedgers;
 import com.hedera.services.legacy.core.jproto.JKey;
+import com.hedera.services.store.contracts.WorldLedgers;
 import org.hyperledger.besu.datatypes.Address;
 
 public interface EvmSigsVerifier {
-	/**
-	 * Determines if the target account has an active key given the cryptographic signatures from the
-	 * {@link com.hederahashgraph.api.proto.java.SignatureMap} that could be verified asynchronously; plus
-	 * the given recipient and contract of the current {@link org.hyperledger.besu.evm.frame.MessageFrame}.
-	 *
-	 * If the account's key includes a {@code contractID} key matching the contract address, or a
-	 * {@code delegatableContractId} key matching the recipient address, then those keys must be treated
-	 * as active for the purposes of this test.
-	 *
-	 * Does <b>not</b> perform any synchronous signature verification.
-	 *
+    /**
+     * Determines if the target account has an active key given the cryptographic signatures from
+     * the {@link com.hederahashgraph.api.proto.java.SignatureMap} that could be verified
+     * asynchronously; plus the given recipient and contract of the current {@link
+     * org.hyperledger.besu.evm.frame.MessageFrame}.
+     *
+     * <p>If the account's key includes a {@code contractID} key matching the contract address, or a
+     * {@code delegatableContractId} key matching the recipient address, then those keys must be
+     * treated as active for the purposes of this test.
+     *
+     * <p>Does <b>not</b> perform any synchronous signature verification.
+     *
+     * @param isDelegateCall a flag showing if the message represented by the active frame is
+     *     invoked via {@code delegatecall}
+     * @param account the address of the account to test for key activation
+     * @param activeContract the address of the contract that is deemed active
+     * @param worldLedgers the worldLedgers representing current state
+     * @return whether the target account's key has an active signature
+     */
+    boolean hasActiveKey(
+            boolean isDelegateCall,
+            Address account,
+            Address activeContract,
+            WorldLedgers worldLedgers);
 
-	 * @param isDelegateCall
-	 * 		a flag showing if the message represented by the active frame is invoked via {@code delegatecall}
-	 * @param account
-	 *		the address of the account to test for key activation
-	 * @param activeContract
-	 * 		the address of the contract that is deemed active
-	 * @param worldLedgers
-	 * 		the worldLedgers representing current state
-	 * @return whether the target account's key has an active signature
-	 */
-	boolean hasActiveKey(
-			boolean isDelegateCall, Address account, Address activeContract,
-			WorldLedgers worldLedgers);
+    /**
+     * Determines if the target account <b>either</b> has no receiver sig requirement; or an active
+     * key given the cryptographic signatures from the {@link
+     * com.hederahashgraph.api.proto.java.SignatureMap}, plus the given recipient and contract of
+     * the current {@link org.hyperledger.besu.evm.frame.MessageFrame}.
+     *
+     * <p>If the account's key includes a {@code contractID} key matching the contract address, or a
+     * {@code delegatableContractId} key matching the recipient address, then those keys must be
+     * treated as active for the purposes of this test.
+     *
+     * <p>Does <b>not</b> perform any synchronous signature verification.
+     *
+     * @param isDelegateCall a flag showing if the message represented by the active frame is
+     *     invoked via {@code delegatecall}
+     * @param target the account to test for receiver sig requirement and key activation
+     * @param activeContract the address of the contract that is deemed active
+     * @param worldLedgers the worldLedgers representing current state
+     * @return false if the account requires a receiver sig but has no active key; true otherwise
+     */
+    boolean hasActiveKeyOrNoReceiverSigReq(
+            boolean isDelegateCall,
+            Address target,
+            Address activeContract,
+            WorldLedgers worldLedgers);
 
-	/**
-	 * Determines if the target account <b>either</b> has no receiver sig requirement; or an active key given
-	 * the cryptographic signatures from the {@link com.hederahashgraph.api.proto.java.SignatureMap}, plus the
-	 * given recipient and contract of the current {@link org.hyperledger.besu.evm.frame.MessageFrame}.
-	 *
-	 * If the account's key includes a {@code contractID} key matching the contract address, or a
-	 * {@code delegatableContractId} key matching the recipient address, then those keys must be treated
-	 * as active for the purposes of this test.
-	 *
-	 * Does <b>not</b> perform any synchronous signature verification.
-	 *
-	 * @param isDelegateCall
-	 * 		a flag showing if the message represented by the active frame is invoked via {@code delegatecall}
-	 * @param target
-	 * 		the account to test for receiver sig requirement and key activation
-	 * @param activeContract
-	 * 		the address of the contract that is deemed active
-	 * @param worldLedgers
-	 * 		the worldLedgers representing current state
-	 * @return false if the account requires a receiver sig but has no active key; true otherwise
-	 */
-	boolean hasActiveKeyOrNoReceiverSigReq(
-			boolean isDelegateCall, Address target, Address activeContract,
-			WorldLedgers worldLedgers);
+    /**
+     * Determines if the target token has an active supply key given the cryptographic signatures
+     * from the {@link com.hederahashgraph.api.proto.java.SignatureMap} that could be verified
+     * asynchronously; plus the given recipient and contract of the current {@link
+     * org.hyperledger.besu.evm.frame.MessageFrame}.
+     *
+     * <p>If the supply key includes a {@code contractID} key matching the contract address, or a
+     * {@code delegatableContractId} key matching the recipient address, then those keys must be
+     * treated as active for the purposes of this test.
+     *
+     * <p>Does <b>not</b> perform any synchronous signature verification.
+     *
+     * @param isDelegateCall a flag showing if the message represented by the active frame is
+     *     invoked via {@code delegatecall}
+     * @param token the address of the token to test for supply key activation
+     * @param activeContract the address of the contract that should be signed in the key
+     * @param worldLedgers the worldLedgers representing current state
+     * @return whether the target account's key has an active signature
+     */
+    boolean hasActiveSupplyKey(
+            boolean isDelegateCall,
+            Address token,
+            Address activeContract,
+            WorldLedgers worldLedgers);
 
-	/**
-	 * Determines if the target token has an active supply key given the cryptographic signatures from the
-	 * {@link com.hederahashgraph.api.proto.java.SignatureMap} that could be verified asynchronously; plus
-	 * the given recipient and contract of the current {@link org.hyperledger.besu.evm.frame.MessageFrame}.
-	 *
-	 * If the supply key includes a {@code contractID} key matching the contract address, or a
-	 * {@code delegatableContractId} key matching the recipient address, then those keys must be treated
-	 * as active for the purposes of this test.
-	 *
-	 * Does <b>not</b> perform any synchronous signature verification.
-	 *
-	 * @param isDelegateCall
-	 * 		a flag showing if the message represented by the active frame is invoked via {@code delegatecall}
-	 * @param token
-	 * 		the address of the token to test for supply key activation
-	 * @param activeContract
-	 * 		the address of the contract that should be signed in the key
-	 * @param worldLedgers
-	 * 		the worldLedgers representing current state
-	 * @return whether the target account's key has an active signature
-	 */
-	boolean hasActiveSupplyKey(
-			boolean isDelegateCall, Address token, Address activeContract, WorldLedgers worldLedgers);
-
-	/**
-	 * Determines if the supplied key is active in the context of the transaction, i.e. has signed
-	 * the transaction, given the cryptographic signatures from the
-	 * {@link com.hederahashgraph.api.proto.java.SignatureMap} that could be verified asynchronously.
-	 *
-	 * <p><b>IMPORTANT:</b> The supplied key <b>must be of one of the supported crypto keys</b> and not a contractID,
-	 * delegatableContractID or their corresponding alias keys. If a non-crypto key is specified, the result will
-	 * always be false.
-	 *
-	 * @param key
-	 *  	the key to test
-	 * @return whether the key has signed the transaction
-	 */
-	boolean cryptoKeyIsActive(JKey key);
+    /**
+     * Determines if the supplied key is active in the context of the transaction, i.e. has signed
+     * the transaction, given the cryptographic signatures from the {@link
+     * com.hederahashgraph.api.proto.java.SignatureMap} that could be verified asynchronously.
+     *
+     * <p><b>IMPORTANT:</b> The supplied key <b>must be of one of the supported crypto keys</b> and
+     * not a contractID, delegatableContractID or their corresponding alias keys. If a non-crypto
+     * key is specified, the result will always be false.
+     *
+     * @param key the key to test
+     * @return whether the key has signed the transaction
+     */
+    boolean cryptoKeyIsActive(JKey key);
 }

--- a/hedera-node/src/main/java/com/hedera/services/contracts/sources/TxnAwareEvmSigsVerifier.java
+++ b/hedera-node/src/main/java/com/hedera/services/contracts/sources/TxnAwareEvmSigsVerifier.java
@@ -20,6 +20,13 @@ package com.hedera.services.contracts.sources;
  * ‍
  */
 
+import static com.hedera.services.exceptions.ValidationUtils.validateTrue;
+import static com.hedera.services.ledger.properties.AccountProperty.IS_RECEIVER_SIG_REQUIRED;
+import static com.hedera.services.ledger.properties.AccountProperty.KEY;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_ACCOUNT_ID;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_TOKEN_ID;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TOKEN_HAS_NO_SUPPLY_KEY;
+
 import com.hedera.services.context.TransactionContext;
 import com.hedera.services.keys.ActivationTest;
 import com.hedera.services.ledger.TransactionalLedger;
@@ -32,158 +39,149 @@ import com.hedera.services.store.contracts.WorldLedgers;
 import com.hedera.services.utils.EntityIdUtils;
 import com.hederahashgraph.api.proto.java.AccountID;
 import com.swirlds.common.crypto.TransactionSignature;
+import java.util.Optional;
+import java.util.function.BiPredicate;
+import javax.inject.Inject;
+import javax.inject.Singleton;
 import org.hyperledger.besu.datatypes.Address;
 import org.jetbrains.annotations.NotNull;
 
-import javax.inject.Inject;
-import javax.inject.Singleton;
-import java.util.Optional;
-import java.util.function.BiPredicate;
-
-import static com.hedera.services.exceptions.ValidationUtils.validateTrue;
-import static com.hedera.services.ledger.properties.AccountProperty.IS_RECEIVER_SIG_REQUIRED;
-import static com.hedera.services.ledger.properties.AccountProperty.KEY;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_ACCOUNT_ID;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_TOKEN_ID;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TOKEN_HAS_NO_SUPPLY_KEY;
-
 @Singleton
 public class TxnAwareEvmSigsVerifier implements EvmSigsVerifier {
-	private final ActivationTest activationTest;
-	private final TransactionContext txnCtx;
-	private final BiPredicate<JKey, TransactionSignature> cryptoValidity;
+    private final ActivationTest activationTest;
+    private final TransactionContext txnCtx;
+    private final BiPredicate<JKey, TransactionSignature> cryptoValidity;
 
-	@Inject
-	public TxnAwareEvmSigsVerifier(
-			final ActivationTest activationTest,
-			final TransactionContext txnCtx,
-			final BiPredicate<JKey, TransactionSignature> cryptoValidity
-	) {
-		this.txnCtx = txnCtx;
-		this.activationTest = activationTest;
-		this.cryptoValidity = cryptoValidity;
-	}
+    @Inject
+    public TxnAwareEvmSigsVerifier(
+            final ActivationTest activationTest,
+            final TransactionContext txnCtx,
+            final BiPredicate<JKey, TransactionSignature> cryptoValidity) {
+        this.txnCtx = txnCtx;
+        this.activationTest = activationTest;
+        this.cryptoValidity = cryptoValidity;
+    }
 
-	@Override
-	public boolean hasActiveKey(
-			final boolean isDelegateCall,
-			@NotNull final Address accountAddress,
-			@NotNull final Address activeContract,
-			@NotNull final WorldLedgers worldLedgers
-	) {
-		final var accountId = EntityIdUtils.accountIdFromEvmAddress(accountAddress);
-		validateTrue(worldLedgers.accounts().exists(accountId), INVALID_ACCOUNT_ID);
+    @Override
+    public boolean hasActiveKey(
+            final boolean isDelegateCall,
+            @NotNull final Address accountAddress,
+            @NotNull final Address activeContract,
+            @NotNull final WorldLedgers worldLedgers) {
+        final var accountId = EntityIdUtils.accountIdFromEvmAddress(accountAddress);
+        validateTrue(worldLedgers.accounts().exists(accountId), INVALID_ACCOUNT_ID);
 
-		if (accountAddress.equals(activeContract)) {
-			return true;
-		}
+        if (accountAddress.equals(activeContract)) {
+            return true;
+        }
 
-		final var accountKey = (JKey) worldLedgers.accounts().get(accountId, KEY);
-		return accountKey != null && isActiveInFrame(accountKey, isDelegateCall,
-				activeContract,
-				worldLedgers.aliases());
-	}
+        final var accountKey = (JKey) worldLedgers.accounts().get(accountId, KEY);
+        return accountKey != null
+                && isActiveInFrame(
+                        accountKey, isDelegateCall, activeContract, worldLedgers.aliases());
+    }
 
-	@Override
-	public boolean hasActiveSupplyKey(
-			final boolean isDelegateCall,
-			@NotNull final Address tokenAddress,
-			@NotNull final Address activeContract,
-			@NotNull final WorldLedgers worldLedgers
-	) {
-		final var tokenId = EntityIdUtils.tokenIdFromEvmAddress(tokenAddress);
-		validateTrue(worldLedgers.tokens().exists(tokenId), INVALID_TOKEN_ID);
+    @Override
+    public boolean hasActiveSupplyKey(
+            final boolean isDelegateCall,
+            @NotNull final Address tokenAddress,
+            @NotNull final Address activeContract,
+            @NotNull final WorldLedgers worldLedgers) {
+        final var tokenId = EntityIdUtils.tokenIdFromEvmAddress(tokenAddress);
+        validateTrue(worldLedgers.tokens().exists(tokenId), INVALID_TOKEN_ID);
 
-		final var supplyKey = (JKey) worldLedgers.tokens().get(tokenId, TokenProperty.SUPPLY_KEY);
-		validateTrue(supplyKey != null, TOKEN_HAS_NO_SUPPLY_KEY);
+        final var supplyKey = (JKey) worldLedgers.tokens().get(tokenId, TokenProperty.SUPPLY_KEY);
+        validateTrue(supplyKey != null, TOKEN_HAS_NO_SUPPLY_KEY);
 
-		return isActiveInFrame(supplyKey, isDelegateCall, activeContract, worldLedgers.aliases());
-	}
+        return isActiveInFrame(supplyKey, isDelegateCall, activeContract, worldLedgers.aliases());
+    }
 
-	@Override
-	public boolean hasActiveKeyOrNoReceiverSigReq(
-			final boolean isDelegateCall,
-			@NotNull final Address target,
-			@NotNull final Address activeContract,
-			@NotNull final WorldLedgers worldLedgers
-	) {
-		final var accountId = EntityIdUtils.accountIdFromEvmAddress(target);
-		if (txnCtx.activePayer().equals(accountId)) {
-			return true;
-		}
-		final var requiredKey = receiverSigKeyIfAnyOf(accountId, worldLedgers);
-		return requiredKey.map(key ->
-				isActiveInFrame(key, isDelegateCall, activeContract, worldLedgers.aliases())).orElse(true);
-	}
+    @Override
+    public boolean hasActiveKeyOrNoReceiverSigReq(
+            final boolean isDelegateCall,
+            @NotNull final Address target,
+            @NotNull final Address activeContract,
+            @NotNull final WorldLedgers worldLedgers) {
+        final var accountId = EntityIdUtils.accountIdFromEvmAddress(target);
+        if (txnCtx.activePayer().equals(accountId)) {
+            return true;
+        }
+        final var requiredKey = receiverSigKeyIfAnyOf(accountId, worldLedgers);
+        return requiredKey
+                .map(
+                        key ->
+                                isActiveInFrame(
+                                        key,
+                                        isDelegateCall,
+                                        activeContract,
+                                        worldLedgers.aliases()))
+                .orElse(true);
+    }
 
-	@Override
-	public boolean cryptoKeyIsActive(final JKey key) {
-		return key != null && isCryptoKeyActiveInFrame(key);
-	}
+    @Override
+    public boolean cryptoKeyIsActive(final JKey key) {
+        return key != null && isCryptoKeyActiveInFrame(key);
+    }
 
-	private boolean isCryptoKeyActiveInFrame(final JKey key) {
-		final var pkToCryptoSigsFn = txnCtx.swirldsTxnAccessor().getRationalizedPkToCryptoSigFn();
-		return activationTest.test(
-				key,
-				pkToCryptoSigsFn,
-				cryptoValidity);
-	}
+    private boolean isCryptoKeyActiveInFrame(final JKey key) {
+        final var pkToCryptoSigsFn = txnCtx.swirldsTxnAccessor().getRationalizedPkToCryptoSigFn();
+        return activationTest.test(key, pkToCryptoSigsFn, cryptoValidity);
+    }
 
-	private boolean isActiveInFrame(
-			final JKey key,
-			final boolean isDelegateCall,
-			final Address activeContract,
-			final ContractAliases aliases
-	) {
-		final var pkToCryptoSigsFn = txnCtx.swirldsTxnAccessor().getRationalizedPkToCryptoSigFn();
-		return activationTest.test(
-				key,
-				pkToCryptoSigsFn,
-				validityTestFor(isDelegateCall, activeContract, aliases));
-	}
+    private boolean isActiveInFrame(
+            final JKey key,
+            final boolean isDelegateCall,
+            final Address activeContract,
+            final ContractAliases aliases) {
+        final var pkToCryptoSigsFn = txnCtx.swirldsTxnAccessor().getRationalizedPkToCryptoSigFn();
+        return activationTest.test(
+                key, pkToCryptoSigsFn, validityTestFor(isDelegateCall, activeContract, aliases));
+    }
 
-	BiPredicate<JKey, TransactionSignature> validityTestFor(
-			final boolean isDelegateCall,
-			final Address activeContract,
-			final ContractAliases aliases
-	) {
-		// Note that when this observer is used directly above in isActiveInFrame(), it will be
-		// called  with each primitive key in the top-level Hedera key of interest, along with
-		// that key's verified cryptographic signature (if any was available in the sigMap)
-		return (key, sig) -> {
-			if (key.hasDelegatableContractId() || key.hasDelegatableContractAlias()) {
-				final var controllingId = key.hasDelegatableContractId()
-						? key.getDelegatableContractIdKey().getContractID()
-						: key.getDelegatableContractAliasKey().getContractID();
-				final var controllingContract =
-						aliases.currentAddress(controllingId);
-				return controllingContract.equals(activeContract);
-			} else if (key.hasContractID() || key.hasContractAlias()) {
-				final var controllingId = key.hasContractID()
-						? key.getContractIDKey().getContractID()
-						: key.getContractAliasKey().getContractID();
-				final var controllingContract = aliases.currentAddress(controllingId);
-				return !isDelegateCall && controllingContract.equals(activeContract);
-			} else {
-				// Otherwise, apply the standard cryptographic validity test
-				return cryptoValidity.test(key, sig);
-			}
-		};
-	}
+    BiPredicate<JKey, TransactionSignature> validityTestFor(
+            final boolean isDelegateCall,
+            final Address activeContract,
+            final ContractAliases aliases) {
+        // Note that when this observer is used directly above in isActiveInFrame(), it will be
+        // called  with each primitive key in the top-level Hedera key of interest, along with
+        // that key's verified cryptographic signature (if any was available in the sigMap)
+        return (key, sig) -> {
+            if (key.hasDelegatableContractId() || key.hasDelegatableContractAlias()) {
+                final var controllingId =
+                        key.hasDelegatableContractId()
+                                ? key.getDelegatableContractIdKey().getContractID()
+                                : key.getDelegatableContractAliasKey().getContractID();
+                final var controllingContract = aliases.currentAddress(controllingId);
+                return controllingContract.equals(activeContract);
+            } else if (key.hasContractID() || key.hasContractAlias()) {
+                final var controllingId =
+                        key.hasContractID()
+                                ? key.getContractIDKey().getContractID()
+                                : key.getContractAliasKey().getContractID();
+                final var controllingContract = aliases.currentAddress(controllingId);
+                return !isDelegateCall && controllingContract.equals(activeContract);
+            } else {
+                // Otherwise, apply the standard cryptographic validity test
+                return cryptoValidity.test(key, sig);
+            }
+        };
+    }
 
-	private Optional<JKey> receiverSigKeyIfAnyOf(final AccountID id, final WorldLedgers worldLedgers) {
-		final var accounts = worldLedgers.accounts();
-		if (accounts == null) {
-			// This must be a static call, hence cannot contain value and cannot require a signature
-			return Optional.empty();
-		}
-		return isReceiverSigExempt(id, accounts) ? Optional.empty() : Optional.ofNullable((JKey) accounts.get(id, KEY));
-	}
+    private Optional<JKey> receiverSigKeyIfAnyOf(
+            final AccountID id, final WorldLedgers worldLedgers) {
+        final var accounts = worldLedgers.accounts();
+        if (accounts == null) {
+            // This must be a static call, hence cannot contain value and cannot require a signature
+            return Optional.empty();
+        }
+        return isReceiverSigExempt(id, accounts)
+                ? Optional.empty()
+                : Optional.ofNullable((JKey) accounts.get(id, KEY));
+    }
 
-	private boolean isReceiverSigExempt(
-			final AccountID id,
-			final TransactionalLedger<AccountID, AccountProperty, MerkleAccount> accounts
-	) {
-		return !accounts.contains(id) || !(boolean) accounts.get(id, IS_RECEIVER_SIG_REQUIRED);
-	}
+    private boolean isReceiverSigExempt(
+            final AccountID id,
+            final TransactionalLedger<AccountID, AccountProperty, MerkleAccount> accounts) {
+        return !accounts.contains(id) || !(boolean) accounts.get(id, IS_RECEIVER_SIG_REQUIRED);
+    }
 }

--- a/hedera-node/src/main/java/com/hedera/services/contracts/sources/TxnAwareEvmSigsVerifier.java
+++ b/hedera-node/src/main/java/com/hedera/services/contracts/sources/TxnAwareEvmSigsVerifier.java
@@ -1,11 +1,6 @@
-package com.hedera.services.contracts.sources;
-
-/*-
- * ‌
- * Hedera Services Node
- * ​
- * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
- * ​
+/*
+ * Copyright (C) 2020-2022 Hedera Hashgraph, LLC
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -17,8 +12,8 @@ package com.hedera.services.contracts.sources;
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- * ‍
  */
+package com.hedera.services.contracts.sources;
 
 import static com.hedera.services.exceptions.ValidationUtils.validateTrue;
 import static com.hedera.services.ledger.properties.AccountProperty.IS_RECEIVER_SIG_REQUIRED;

--- a/hedera-node/src/test/java/com/hedera/services/contracts/ContractsModuleTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/contracts/ContractsModuleTest.java
@@ -9,9 +9,9 @@ package com.hedera.services.contracts;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,31 +20,30 @@ package com.hedera.services.contracts;
  * ‍
  */
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import org.hyperledger.besu.evm.gascalculator.GasCalculator;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
 @ExtendWith(MockitoExtension.class)
 class ContractsModuleTest {
-	@Mock
-	private GasCalculator gasCalculator;
+    @Mock private GasCalculator gasCalculator;
 
-	@Test
-	void logOperationsAreProvided() {
-		final var log0 = ContractsModule.provideLog0Operation(gasCalculator);
-		final var log1 = ContractsModule.provideLog1Operation(gasCalculator);
-		final var log2 = ContractsModule.provideLog2Operation(gasCalculator);
-		final var log3 = ContractsModule.provideLog3Operation(gasCalculator);
-		final var log4 = ContractsModule.provideLog4Operation(gasCalculator);
+    @Test
+    void logOperationsAreProvided() {
+        final var log0 = ContractsModule.provideLog0Operation(gasCalculator);
+        final var log1 = ContractsModule.provideLog1Operation(gasCalculator);
+        final var log2 = ContractsModule.provideLog2Operation(gasCalculator);
+        final var log3 = ContractsModule.provideLog3Operation(gasCalculator);
+        final var log4 = ContractsModule.provideLog4Operation(gasCalculator);
 
-		assertEquals("LOG0", log0.getName());
-		assertEquals("LOG1", log1.getName());
-		assertEquals("LOG2", log2.getName());
-		assertEquals("LOG3", log3.getName());
-		assertEquals("LOG4", log4.getName());
-	}
+        assertEquals("LOG0", log0.getName());
+        assertEquals("LOG1", log1.getName());
+        assertEquals("LOG2", log2.getName());
+        assertEquals("LOG3", log3.getName());
+        assertEquals("LOG4", log4.getName());
+    }
 }

--- a/hedera-node/src/test/java/com/hedera/services/contracts/ContractsModuleTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/contracts/ContractsModuleTest.java
@@ -1,11 +1,6 @@
-package com.hedera.services.contracts;
-
-/*-
- * ‌
- * Hedera Services Node
- * ​
- * Copyright (C) 2018 - 2022 Hedera Hashgraph, LLC
- * ​
+/*
+ * Copyright (C) 2022 Hedera Hashgraph, LLC
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -17,8 +12,8 @@ package com.hedera.services.contracts;
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- * ‍
  */
+package com.hedera.services.contracts;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 

--- a/hedera-node/src/test/java/com/hedera/services/contracts/execution/CallEvmTxProcessorTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/contracts/execution/CallEvmTxProcessorTest.java
@@ -22,6 +22,21 @@ package com.hedera.services.contracts.execution;
  *
  */
 
+import static com.hedera.services.ethereum.EthTxData.WEIBARS_TO_TINYBARS;
+import static com.hedera.test.utils.TxnUtils.assertFailsWith;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INSUFFICIENT_GAS;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_ETHEREUM_TRANSACTION;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
 import com.google.protobuf.ByteString;
 import com.google.protobuf.BytesValue;
 import com.hedera.services.context.properties.GlobalDynamicProperties;
@@ -35,6 +50,13 @@ import com.hedera.services.txns.contract.helpers.StorageExpiry;
 import com.hedera.services.utils.EntityIdUtils;
 import com.hederahashgraph.api.proto.java.HederaFunctionality;
 import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
+import java.math.BigInteger;
+import java.time.Instant;
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.units.bigints.UInt256;
@@ -56,784 +78,984 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.math.BigInteger;
-import java.time.Instant;
-import java.util.ArrayDeque;
-import java.util.Deque;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
-
-import static com.hedera.services.ethereum.EthTxData.WEIBARS_TO_TINYBARS;
-import static com.hedera.test.utils.TxnUtils.assertFailsWith;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INSUFFICIENT_GAS;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_ETHEREUM_TRANSACTION;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
-
 @ExtendWith(MockitoExtension.class)
 class CallEvmTxProcessorTest {
-	private static final int MAX_STACK_SIZE = 1024;
-	public static final long ONE_HBAR = 100_000_000L;
-
-	@Mock
-	private LivePricesSource livePricesSource;
-	@Mock
-	private HederaWorldState worldState;
-	@Mock
-	private CodeCache codeCache;
-	@Mock
-	private GlobalDynamicProperties globalDynamicProperties;
-	@Mock
-	private GasCalculator gasCalculator;
-	@Mock
-	private Set<Operation> operations;
-	@Mock
-	private Transaction transaction;
-	@Mock
-	private HederaWorldState.Updater updater;
-	@Mock
-	private AliasManager aliasManager;
-	@Mock
-	private Map<String, PrecompiledContract> precompiledContractMap;
-	@Mock
-	private StorageExpiry storageExpiry;
-	@Mock
-	private StorageExpiry.Oracle oracle;
-	@Mock
-	private HederaBlockValues hederaBlockValues;
-	@Mock
-	private BlockValues blockValues;
-	@Mock
-	private InHandleBlockMetaSource blockMetaSource;
-
-	private final Account sender = new Account(new Id(0, 0, 1002));
-	private final Account receiver = new Account(new Id(0, 0, 1006));
-	private final Account relayer = new Account(new Id(0, 0, 1007));
-	private final Address receiverAddress = receiver.getId().asEvmAddress();
-	private final Instant consensusTime = Instant.now();
-	private final int MAX_GAS_LIMIT = 10_000_000;
-	private final int MAX_REFUND_PERCENT = 20;
-	private final long INTRINSIC_GAS_COST = 290_000L;
-	private final long GAS_LIMIT = 300_000L;
-
-	private CallEvmTxProcessor callEvmTxProcessor;
-
-	@BeforeEach
-	private void setup() {
-		CommonProcessorSetup.setup(gasCalculator);
-
-		callEvmTxProcessor = new CallEvmTxProcessor(
-				worldState, livePricesSource,
-				codeCache, globalDynamicProperties, gasCalculator,
-				operations, precompiledContractMap, aliasManager, storageExpiry, blockMetaSource);
-	}
-
-	@Test
-	void assertSuccessExecution() {
-		givenValidMock();
-		given(globalDynamicProperties.fundingAccount()).willReturn(new Id(0, 0, 1010).asGrpcAccount());
-		given(aliasManager.resolveForEvm(receiverAddress)).willReturn(receiverAddress);
-		given(storageExpiry.hapiCallOracle()).willReturn(oracle);
-
-		givenSenderWithBalance(350_000L);
-		var result = callEvmTxProcessor.execute(
-				sender, receiverAddress, 33_333L, 1234L, Bytes.EMPTY, consensusTime);
-		assertTrue(result.isSuccessful());
-		assertEquals(receiver.getId().asGrpcContract(), result.toGrpc().getContractID());
-	}
-
-	@Test
-	void assertSuccessExecutionEth() {
-		givenValidMockEth();
-
-		given(globalDynamicProperties.fundingAccount()).willReturn(new Id(0, 0, 1010).asGrpcAccount());
-		given(aliasManager.resolveForEvm(receiverAddress)).willReturn(receiverAddress);
-		given(storageExpiry.hapiCallOracle()).willReturn(oracle);
-		var evmAccount = mock(EvmAccount.class);
-		given(updater.getOrCreateSenderAccount(any())).willReturn(evmAccount);
-		var senderMutableAccount = mock(MutableAccount.class);
-		given(evmAccount.getMutable()).willReturn(senderMutableAccount);
-
-		givenSenderWithBalance(350_000L);
-		var result = callEvmTxProcessor.executeEth(
-				sender, receiverAddress, 33_333L, 1234L, Bytes.EMPTY, consensusTime, BigInteger.valueOf(10_000L), relayer, 55_555L);
-		assertTrue(result.isSuccessful());
-		assertEquals(receiver.getId().asGrpcContract(), result.toGrpc().getContractID());
-	}
-
-	@Test
-	void nonCodeTxRequiresValue() {
-		assertFailsWith(() ->
-						callEvmTxProcessor.buildInitialFrame(MessageFrame.builder(), receiverAddress, Bytes.EMPTY, 0L),
-				INVALID_ETHEREUM_TRANSACTION);
-	}
-
-	@Test
-	void missingCodeBecomesEmptyInInitialFrame() {
-		MessageFrame.Builder protoFrame = MessageFrame.builder()
-				.messageFrameStack(new ArrayDeque<>())
-				.worldUpdater(updater)
-				.initialGas(1L)
-				.originator(sender.canonicalAddress())
-				.gasPrice(Wei.ZERO)
-				.sender(sender.canonicalAddress())
-				.value(Wei.ONE)
-				.apparentValue(Wei.ONE)
-				.blockValues(blockValues)
-				.depth(1)
-				.completer(frame -> {})
-				.miningBeneficiary(Address.ZERO)
-				.blockHashLookup(hash -> null);
-
-		var messageFrame = callEvmTxProcessor.buildInitialFrame(protoFrame, receiverAddress, Bytes.EMPTY, 33L);
-
-		assertEquals(Code.EMPTY, messageFrame.getCode());
-	}
-
-	@Test
-	void assertSuccessExecutionChargesCorrectMinimumGas() {
-		givenValidMock();
-		given(globalDynamicProperties.maxGasRefundPercentage()).willReturn(MAX_REFUND_PERCENT);
-		given(globalDynamicProperties.fundingAccount()).willReturn(new Id(0, 0, 1010).asGrpcAccount());
-		given(storageExpiry.hapiCallOracle()).willReturn(oracle);
-		givenSenderWithBalance(350_000L);
-		final var receiverAddress = receiver.getId().asEvmAddress();
-		given(aliasManager.resolveForEvm(receiverAddress)).willReturn(receiverAddress);
-		var result = callEvmTxProcessor.execute(
-				sender, receiverAddress, GAS_LIMIT, 1234L, Bytes.EMPTY, consensusTime);
-		assertTrue(result.isSuccessful());
-		assertEquals(result.getGasUsed(), GAS_LIMIT - GAS_LIMIT * MAX_REFUND_PERCENT / 100);
-		assertEquals(receiver.getId().asGrpcContract(), result.toGrpc().getContractID());
-	}
-
-	@Test
-	void assertSuccessExecutionChargesCorrectGasWhenGasUsedIsLargerThanMinimum() {
-		givenValidMock();
-		given(globalDynamicProperties.maxGasRefundPercentage()).willReturn(MAX_REFUND_PERCENT);
-		given(gasCalculator.transactionIntrinsicGasCost(Bytes.EMPTY, false)).willReturn(INTRINSIC_GAS_COST);
-		given(globalDynamicProperties.fundingAccount()).willReturn(new Id(0, 0, 1010).asGrpcAccount());
-		given(storageExpiry.hapiCallOracle()).willReturn(oracle);
-
-		givenSenderWithBalance(350_000L);
-		final var receiverAddress = receiver.getId().asEvmAddress();
-		given(aliasManager.resolveForEvm(receiverAddress)).willReturn(receiverAddress);
-		var result = callEvmTxProcessor.execute(
-				sender, receiverAddress, GAS_LIMIT, 1234L, Bytes.EMPTY, consensusTime);
-		assertTrue(result.isSuccessful());
-		assertEquals(INTRINSIC_GAS_COST, result.getGasUsed());
-		assertEquals(receiver.getId().asGrpcContract(), result.toGrpc().getContractID());
-	}
-
-	@Test
-	void assertSuccessExecutionPopulatesStorageChanges() {
-		givenValidMock();
-		given(globalDynamicProperties.fundingAccount()).willReturn(new Id(0, 0, 1010).asGrpcAccount());
-		given(globalDynamicProperties.shouldEnableTraceability()).willReturn(true);
-		givenSenderWithBalance(350_000L);
-		given(aliasManager.resolveForEvm(receiverAddress)).willReturn(receiverAddress);
-		final var contractAddress = "0xffff";
-		final var slot = 1L;
-		final var oldSlotValue = 4L;
-		final var newSlotValue = 255L;
-		given(updater.getFinalStateChanges())
-				.willReturn(Map.of(Address.fromHexString(contractAddress), Map.of(UInt256.valueOf(slot),
-								Pair.of(UInt256.valueOf(oldSlotValue), UInt256.valueOf(newSlotValue)))));
-		given(storageExpiry.hapiCallOracle()).willReturn(oracle);
-
-		final var result = callEvmTxProcessor.execute(
-				sender, receiverAddress, 33_333L, 1234L, Bytes.EMPTY, consensusTime);
-
-		assertTrue(result.isSuccessful());
-		assertEquals(receiver.getId().asGrpcContract(), result.toGrpc().getContractID());
-		assertEquals(1, result.toGrpc().getStateChangesCount());
-		final var contractStateChange = result.toGrpc().getStateChanges(0);
-		assertEquals(EntityIdUtils.contractIdFromEvmAddress(Address.fromHexString(contractAddress)),
-				contractStateChange.getContractID());
-		assertEquals(ByteString.copyFrom(Bytes.wrap(UInt256.valueOf(slot)).trimLeadingZeros().toArrayUnsafe()),
-				contractStateChange.getStorageChanges(0).getSlot());
-		assertEquals(ByteString.copyFrom(Bytes.wrap(UInt256.valueOf(oldSlotValue)).trimLeadingZeros().toArrayUnsafe()),
-				contractStateChange.getStorageChanges(0).getValueRead());
-		assertEquals(BytesValue.of(ByteString.copyFrom(Bytes.wrap(UInt256.valueOf(newSlotValue)).trimLeadingZeros().toArrayUnsafe())),
-				contractStateChange.getStorageChanges(0).getValueWritten());
-	}
-
-	@Test
-	void assertSuccessExecutionWithDisabledTraceabilityDoNotPopulatesStorageChanges() {
-		givenValidMock();
-		given(globalDynamicProperties.fundingAccount()).willReturn(new Id(0, 0, 1010).asGrpcAccount());
-		given(globalDynamicProperties.shouldEnableTraceability()).willReturn(false);
-		givenSenderWithBalance(350_000L);
-		given(aliasManager.resolveForEvm(receiverAddress)).willReturn(receiverAddress);
-		given(storageExpiry.hapiCallOracle()).willReturn(oracle);
-
-		final var result = callEvmTxProcessor.execute(
-				sender, receiverAddress, 33_333L, 1234L, Bytes.EMPTY, consensusTime);
-
-		assertTrue(result.isSuccessful());
-		assertEquals(receiver.getId().asGrpcContract(), result.toGrpc().getContractID());
-		assertEquals(0, result.toGrpc().getStateChangesCount());
-
-		verify(updater, never()).getFinalStateChanges();
-	}
-
-	@Test
-	void throwsWhenSenderCannotCoverUpfrontCost() {
-		givenInvalidMock();
-		givenSenderWithBalance(123);
-
-		assertFailsWith(
-				() -> callEvmTxProcessor.execute(
-						sender, receiverAddress, 333_333L, 1234L, Bytes.EMPTY, consensusTime),
-				ResponseCodeEnum.INSUFFICIENT_PAYER_BALANCE);
-	}
-
-	@Test
-	void throwsWhenIntrinsicGasCostExceedsGasLimit() {
-		givenInvalidMock();
-		final var wrappedSenderAccount = mock(EvmAccount.class);
-		final var mutableSenderAccount = mock(MutableAccount.class);
-		given(wrappedSenderAccount.getMutable()).willReturn(mutableSenderAccount);
-		given(updater.getOrCreateSenderAccount(sender.getId().asEvmAddress())).willReturn(wrappedSenderAccount);
-
-		assertFailsWith(() ->
-						callEvmTxProcessor.execute(
-								sender, receiverAddress, 33_333L, 1234L, Bytes.EMPTY, consensusTime),
-				INSUFFICIENT_GAS);
-	}
-
-	@Test
-	void throwsWhenIntrinsicGasCostExceedsGasLimitAndGasLimitIsEqualToMaxGasLimit() {
-		givenInvalidMock();
-		final var wrappedSenderAccount = mock(EvmAccount.class);
-		final var mutableSenderAccount = mock(MutableAccount.class);
-		given(wrappedSenderAccount.getMutable()).willReturn(mutableSenderAccount);
-		given(updater.getOrCreateSenderAccount(sender.getId().asEvmAddress())).willReturn(wrappedSenderAccount);
-		given(gasCalculator.transactionIntrinsicGasCost(Bytes.EMPTY, false)).willReturn(MAX_GAS_LIMIT + 1L);
-
-		assertFailsWith(
-				() -> callEvmTxProcessor
-						.execute(sender, receiverAddress, MAX_GAS_LIMIT, 1234L, Bytes.EMPTY, consensusTime),
-				INSUFFICIENT_GAS);
-	}
-
-	@Test
-	void assertIsContractCallFunctionality() {
-		assertEquals(HederaFunctionality.ContractCall, callEvmTxProcessor.getFunctionType());
-	}
-
-
-	@Test
-	void assertTransactionSenderAndValue() {
-		// setup:
-		doReturn(Optional.of(receiver.getId().asEvmAddress())).when(transaction).getTo();
-		given(codeCache.getIfPresent(any())).willReturn(Code.EMPTY);
-		given(transaction.getSender()).willReturn(sender.getId().asEvmAddress());
-		given(transaction.getValue()).willReturn(Wei.of(1L));
-		final MessageFrame.Builder commonInitialFrame =
-				MessageFrame.builder()
-						.messageFrameStack(mock(Deque.class))
-						.maxStackSize(MAX_STACK_SIZE)
-						.worldUpdater(mock(WorldUpdater.class))
-						.initialGas(GAS_LIMIT)
-						.originator(sender.getId().asEvmAddress())
-						.gasPrice(Wei.ZERO)
-						.sender(sender.getId().asEvmAddress())
-						.value(Wei.of(transaction.getValue().getAsBigInteger()))
-						.apparentValue(Wei.of(transaction.getValue().getAsBigInteger()))
-						.blockValues(mock(BlockValues.class))
-						.depth(0)
-						.completer(__ -> {
-						})
-						.miningBeneficiary(Address.ZERO)
-						.blockHashLookup(h -> null);
-		//when:
-		MessageFrame buildMessageFrame = callEvmTxProcessor.buildInitialFrame(commonInitialFrame,
-				(Address) transaction.getTo().get(), Bytes.EMPTY, 0L);
-
-		//expect:
-		assertEquals(transaction.getSender(), buildMessageFrame.getSenderAddress());
-		assertEquals(transaction.getValue(), buildMessageFrame.getApparentValue());
-	}
-
-	@Test
-	void assertSuccessEthereumTransactionExecutionChargesBothSenderAndRelayerWithoutRefunds() {
-		givenValidMockEth();
-		final var MAX_REFUND_PERCENTAGE = 100;
-		given(globalDynamicProperties.maxGasRefundPercentage()).willReturn(MAX_REFUND_PERCENTAGE);
-		given(globalDynamicProperties.fundingAccount()).willReturn(new Id(0, 0, 1010).asGrpcAccount());
-		given(storageExpiry.hapiCallOracle()).willReturn(oracle);
-		final var wrappedSenderAccount = mock(EvmAccount.class);
-		final var mutableSenderAccount = mock(MutableAccount.class);
-		given(wrappedSenderAccount.getMutable()).willReturn(mutableSenderAccount);
-		given(updater.getOrCreateSenderAccount(sender.getId().asEvmAddress())).willReturn(wrappedSenderAccount);
-		given(mutableSenderAccount.getBalance()).willReturn(Wei.of(100* ONE_HBAR));
-		final var wrappedRelayerAccount = mock(EvmAccount.class);
-		final var mutableRelayerAccount = mock(MutableAccount.class);
-		given(wrappedRelayerAccount.getMutable()).willReturn(mutableRelayerAccount);
-		given(updater.getOrCreateSenderAccount(relayer.getId().asEvmAddress())).willReturn(wrappedRelayerAccount);
-		given(mutableRelayerAccount.getBalance()).willReturn(Wei.of(100* ONE_HBAR));
-		final long gasPrice = 40L;
-		given(livePricesSource.currentGasPrice(consensusTime, HederaFunctionality.EthereumTransaction))
-				.willReturn(gasPrice);
-		final var receiverAddress = receiver.getId().asEvmAddress();
-		given(aliasManager.resolveForEvm(receiverAddress)).willReturn(receiverAddress);
-		final long offeredGasPrice = 10L;
-		final long gasLimit = 1000;
-		given(gasCalculator.transactionIntrinsicGasCost(Bytes.EMPTY, false)).willReturn(gasLimit);
-
-		var result = callEvmTxProcessor.executeEth(
-				sender, receiverAddress, gasLimit, 1234L, Bytes.EMPTY, consensusTime,
-				BigInteger.valueOf(offeredGasPrice).multiply(WEIBARS_TO_TINYBARS),
-				relayer, 10 * ONE_HBAR);
-
-		assertTrue(result.isSuccessful());
-		assertEquals(result.getGasUsed(), gasLimit);
-		assertEquals(receiver.getId().asGrpcContract(), result.toGrpc().getContractID());
-		verify(mutableSenderAccount).decrementBalance(Wei.of(offeredGasPrice * gasLimit));
-		verify(mutableRelayerAccount).decrementBalance(Wei.of(gasPrice * gasLimit - offeredGasPrice * gasLimit));
-		verify(mutableRelayerAccount, never()).incrementBalance(any());
-		verify(mutableSenderAccount, never()).incrementBalance(any());
-	}
-
-	@Test
-	void assertSuccessEthereumTransactionExecutionChargesBothSenderAndRelayerAndRefunds() {
-		givenValidMockEth();
-		final var MAX_REFUND_PERCENTAGE = 100;
-		given(globalDynamicProperties.maxGasRefundPercentage()).willReturn(MAX_REFUND_PERCENTAGE);
-		given(globalDynamicProperties.fundingAccount()).willReturn(new Id(0, 0, 1010).asGrpcAccount());
-		given(storageExpiry.hapiCallOracle()).willReturn(oracle);
-		final var wrappedSenderAccount = mock(EvmAccount.class);
-		final var mutableSenderAccount = mock(MutableAccount.class);
-		given(wrappedSenderAccount.getMutable()).willReturn(mutableSenderAccount);
-		given(updater.getOrCreateSenderAccount(sender.getId().asEvmAddress())).willReturn(wrappedSenderAccount);
-		given(mutableSenderAccount.getBalance()).willReturn(Wei.of(100* ONE_HBAR));
-		final var wrappedRelayerAccount = mock(EvmAccount.class);
-		final var mutableRelayerAccount = mock(MutableAccount.class);
-		given(wrappedRelayerAccount.getMutable()).willReturn(mutableRelayerAccount);
-		given(updater.getOrCreateSenderAccount(relayer.getId().asEvmAddress())).willReturn(wrappedRelayerAccount);
-		given(mutableRelayerAccount.getBalance()).willReturn(Wei.of(100* ONE_HBAR));
-		final long gasPrice = 40L;
-		given(livePricesSource.currentGasPrice(consensusTime, HederaFunctionality.EthereumTransaction))
-				.willReturn(gasPrice);
-		final var receiverAddress = receiver.getId().asEvmAddress();
-		given(aliasManager.resolveForEvm(receiverAddress)).willReturn(receiverAddress);
-		final long offeredGasPrice = 10L;
-		final int gasLimit = 1000;
-
-		var result = callEvmTxProcessor.executeEth(
-				sender, receiverAddress, gasLimit, 1234L, Bytes.EMPTY, consensusTime,
-				BigInteger.valueOf(offeredGasPrice).multiply(WEIBARS_TO_TINYBARS),
-				relayer, 10 * ONE_HBAR);
-
-		assertTrue(result.isSuccessful());
-		assertEquals(0, result.getGasUsed());
-		assertEquals(receiver.getId().asGrpcContract(), result.toGrpc().getContractID());
-		verify(mutableSenderAccount).decrementBalance(Wei.of(offeredGasPrice * gasLimit));
-		verify(mutableRelayerAccount).decrementBalance(Wei.of(gasPrice * gasLimit - offeredGasPrice * gasLimit));
-		verify(mutableRelayerAccount).incrementBalance(Wei.of(gasPrice * gasLimit - offeredGasPrice * gasLimit));
-		verify(mutableSenderAccount).incrementBalance(Wei.of(offeredGasPrice * gasLimit));
-	}
-
-	@Test
-	void assertSuccessEthereumTransactionExecutionChargesBothSenderAndRelayerAndRefundsOnlyRelayer() {
-		givenValidMockEth();
-		final var MAX_REFUND_PERCENTAGE = 1;
-		given(globalDynamicProperties.maxGasRefundPercentage()).willReturn(MAX_REFUND_PERCENTAGE);
-		given(globalDynamicProperties.fundingAccount()).willReturn(new Id(0, 0, 1010).asGrpcAccount());
-		given(storageExpiry.hapiCallOracle()).willReturn(oracle);
-		final var wrappedSenderAccount = mock(EvmAccount.class);
-		final var mutableSenderAccount = mock(MutableAccount.class);
-		given(wrappedSenderAccount.getMutable()).willReturn(mutableSenderAccount);
-		given(updater.getOrCreateSenderAccount(sender.getId().asEvmAddress())).willReturn(wrappedSenderAccount);
-		given(mutableSenderAccount.getBalance()).willReturn(Wei.of(100* ONE_HBAR));
-		final var wrappedRelayerAccount = mock(EvmAccount.class);
-		final var mutableRelayerAccount = mock(MutableAccount.class);
-		given(wrappedRelayerAccount.getMutable()).willReturn(mutableRelayerAccount);
-		given(updater.getOrCreateSenderAccount(relayer.getId().asEvmAddress())).willReturn(wrappedRelayerAccount);
-		given(mutableRelayerAccount.getBalance()).willReturn(Wei.of(100* ONE_HBAR));
-		final long gasPrice = 40L;
-		given(livePricesSource.currentGasPrice(consensusTime, HederaFunctionality.EthereumTransaction))
-				.willReturn(gasPrice);
-		final var receiverAddress = receiver.getId().asEvmAddress();
-		given(aliasManager.resolveForEvm(receiverAddress)).willReturn(receiverAddress);
-		final long offeredGasPrice = 10L;
-		final int gasLimit = 1000;
-
-		var result = callEvmTxProcessor.executeEth(
-				sender, receiverAddress, gasLimit, 1234L, Bytes.EMPTY, consensusTime,
-				BigInteger.valueOf(offeredGasPrice).multiply(WEIBARS_TO_TINYBARS),
-				relayer, 10 * ONE_HBAR);
-
-		assertTrue(result.isSuccessful());
-		assertEquals(gasLimit - gasLimit * MAX_REFUND_PERCENTAGE / 100, result.getGasUsed());
-		assertEquals(receiver.getId().asGrpcContract(), result.toGrpc().getContractID());
-		verify(mutableSenderAccount).decrementBalance(Wei.of(offeredGasPrice * gasLimit));
-		verify(mutableRelayerAccount).decrementBalance(Wei.of(gasPrice * gasLimit - offeredGasPrice * gasLimit));
-		verify(mutableRelayerAccount).incrementBalance(any());
-		verify(mutableSenderAccount, never()).incrementBalance(any());
-	}
-
-
-	@Test
-	void assertThrowsEthereumTransactionWhenSenderBalanceNotEnoughToCoverFeeWhenBothPay() {
-		given(worldState.updater()).willReturn(updater);;
-		given(gasCalculator.transactionIntrinsicGasCost(Bytes.EMPTY, false)).willReturn(0L);
-		given(worldState.updater()).willReturn(updater);
-		given(storageExpiry.hapiCallOracle()).willReturn(oracle);
-		final var wrappedSenderAccount = mock(EvmAccount.class);
-		final var mutableSenderAccount = mock(MutableAccount.class);
-		given(wrappedSenderAccount.getMutable()).willReturn(mutableSenderAccount);
-		given(updater.getOrCreateSenderAccount(sender.getId().asEvmAddress())).willReturn(wrappedSenderAccount);
-		given(mutableSenderAccount.getBalance()).willReturn(Wei.ONE);
-		final var wrappedRelayerAccount = mock(EvmAccount.class);
-		final var mutableRelayerAccount = mock(MutableAccount.class);
-		given(wrappedRelayerAccount.getMutable()).willReturn(mutableRelayerAccount);
-		given(updater.getOrCreateSenderAccount(relayer.getId().asEvmAddress())).willReturn(wrappedRelayerAccount);
-		final long gasPrice = 40L;
-		given(livePricesSource.currentGasPrice(consensusTime, HederaFunctionality.EthereumTransaction))
-				.willReturn(gasPrice);
-		final var receiverAddress = receiver.getId().asEvmAddress();
-		given(aliasManager.resolveForEvm(receiverAddress)).willReturn(receiverAddress);
-		final long offeredGasPrice = 10L;
-		final int gasLimit = 1000;
-		final var userOfferedGasPrice = BigInteger.valueOf(offeredGasPrice).multiply(WEIBARS_TO_TINYBARS);
-
-		assertThrows(InvalidTransactionException.class, () -> callEvmTxProcessor.executeEth(
-				sender, receiverAddress, gasLimit, 1234L, Bytes.EMPTY, consensusTime,
-				userOfferedGasPrice, relayer, 10 * ONE_HBAR));
-	}
-
-
-	@Test
-	void assertThrowsEthereumTransactionWhenGasAllowanceNotEnoughWhenBothPay() {
-		given(worldState.updater()).willReturn(updater);;
-		given(gasCalculator.transactionIntrinsicGasCost(Bytes.EMPTY, false)).willReturn(0L);
-		given(worldState.updater()).willReturn(updater);
-		given(storageExpiry.hapiCallOracle()).willReturn(oracle);
-		final var wrappedSenderAccount = mock(EvmAccount.class);
-		final var mutableSenderAccount = mock(MutableAccount.class);
-		given(wrappedSenderAccount.getMutable()).willReturn(mutableSenderAccount);
-		given(updater.getOrCreateSenderAccount(sender.getId().asEvmAddress())).willReturn(wrappedSenderAccount);
-		given(mutableSenderAccount.getBalance()).willReturn(Wei.of(100* ONE_HBAR));
-		final var wrappedRelayerAccount = mock(EvmAccount.class);
-		final var mutableRelayerAccount = mock(MutableAccount.class);
-		given(wrappedRelayerAccount.getMutable()).willReturn(mutableRelayerAccount);
-		given(updater.getOrCreateSenderAccount(relayer.getId().asEvmAddress())).willReturn(wrappedRelayerAccount);
-		final long gasPrice = 40L;
-		given(livePricesSource.currentGasPrice(consensusTime, HederaFunctionality.EthereumTransaction))
-				.willReturn(gasPrice);
-		final var receiverAddress = receiver.getId().asEvmAddress();
-		given(aliasManager.resolveForEvm(receiverAddress)).willReturn(receiverAddress);
-		final long offeredGasPrice = 10L;
-		final int gasLimit = 1000;
-		final var userOfferedGasPrice = BigInteger.valueOf(offeredGasPrice).multiply(WEIBARS_TO_TINYBARS);
-
-		assertThrows(InvalidTransactionException.class, () -> callEvmTxProcessor.executeEth(
-				sender, receiverAddress, gasLimit, 1234L, Bytes.EMPTY, consensusTime,
-				userOfferedGasPrice, relayer, 100));
-	}
-
-
-	@Test
-	void assertThrowsEthereumTransactionWhenRelayerBalanceNotEnoughToCoverAllowanceWhenBothPay() {
-		given(worldState.updater()).willReturn(updater);;
-		given(gasCalculator.transactionIntrinsicGasCost(Bytes.EMPTY, false)).willReturn(0L);
-		given(worldState.updater()).willReturn(updater);
-		given(storageExpiry.hapiCallOracle()).willReturn(oracle);
-		final var wrappedSenderAccount = mock(EvmAccount.class);
-		final var mutableSenderAccount = mock(MutableAccount.class);
-		given(wrappedSenderAccount.getMutable()).willReturn(mutableSenderAccount);
-		given(updater.getOrCreateSenderAccount(sender.getId().asEvmAddress())).willReturn(wrappedSenderAccount);
-		given(mutableSenderAccount.getBalance()).willReturn(Wei.of(ONE_HBAR * 100));
-		final var wrappedRelayerAccount = mock(EvmAccount.class);
-		final var mutableRelayerAccount = mock(MutableAccount.class);
-		given(wrappedRelayerAccount.getMutable()).willReturn(mutableRelayerAccount);
-		given(updater.getOrCreateSenderAccount(relayer.getId().asEvmAddress())).willReturn(wrappedRelayerAccount);
-		given(mutableRelayerAccount.getBalance()).willReturn(Wei.ONE);
-		final long gasPrice = 40L;
-		given(livePricesSource.currentGasPrice(consensusTime, HederaFunctionality.EthereumTransaction))
-				.willReturn(gasPrice);
-		final var receiverAddress = receiver.getId().asEvmAddress();
-		given(aliasManager.resolveForEvm(receiverAddress)).willReturn(receiverAddress);
-		final long offeredGasPrice = 10L;
-		final int gasLimit = 1000;
-		final var userOfferedGasPrice = BigInteger.valueOf(offeredGasPrice).multiply(WEIBARS_TO_TINYBARS);
-
-		assertThrows(InvalidTransactionException.class, () -> callEvmTxProcessor.executeEth(
-				sender, receiverAddress, gasLimit, 1234L, Bytes.EMPTY, consensusTime,
-				userOfferedGasPrice, relayer, 10 * ONE_HBAR));
-	}
-
-	@Test
-	void assertSuccessEthereumTransactionExecutionChargesRelayerWhenSenderGasPriceIs0() {
-		givenValidMockEth();
-		final var MAX_REFUND_PERCENTAGE = 100;
-		given(globalDynamicProperties.maxGasRefundPercentage()).willReturn(MAX_REFUND_PERCENTAGE);
-		given(globalDynamicProperties.fundingAccount()).willReturn(new Id(0, 0, 1010).asGrpcAccount());
-		given(storageExpiry.hapiCallOracle()).willReturn(oracle);
-		final var wrappedSenderAccount = mock(EvmAccount.class);
-		final var mutableSenderAccount = mock(MutableAccount.class);
-		given(wrappedSenderAccount.getMutable()).willReturn(mutableSenderAccount);
-		given(updater.getOrCreateSenderAccount(sender.getId().asEvmAddress())).willReturn(wrappedSenderAccount);
-		given(mutableSenderAccount.getBalance()).willReturn(Wei.of(100* ONE_HBAR));
-		final var wrappedRelayerAccount = mock(EvmAccount.class);
-		final var mutableRelayerAccount = mock(MutableAccount.class);
-		given(wrappedRelayerAccount.getMutable()).willReturn(mutableRelayerAccount);
-		given(updater.getOrCreateSenderAccount(relayer.getId().asEvmAddress())).willReturn(wrappedRelayerAccount);
-		given(mutableRelayerAccount.getBalance()).willReturn(Wei.of(100* ONE_HBAR));
-		final long gasPrice = 40L;
-		given(livePricesSource.currentGasPrice(consensusTime, HederaFunctionality.EthereumTransaction))
-				.willReturn(gasPrice);
-		final var receiverAddress = receiver.getId().asEvmAddress();
-		given(aliasManager.resolveForEvm(receiverAddress)).willReturn(receiverAddress);
-		final long offeredGasPrice = 0L;
-		final long gasLimit = 1000;
-		given(gasCalculator.transactionIntrinsicGasCost(Bytes.EMPTY, false)).willReturn(gasLimit);
-
-		var result = callEvmTxProcessor.executeEth(
-				sender, receiverAddress, gasLimit, 1234L, Bytes.EMPTY, consensusTime,
-				BigInteger.valueOf(offeredGasPrice).multiply(WEIBARS_TO_TINYBARS),
-				relayer, 10 * ONE_HBAR);
-
-		assertTrue(result.isSuccessful());
-		assertEquals(result.getGasUsed(), gasLimit);
-		assertEquals(receiver.getId().asGrpcContract(), result.toGrpc().getContractID());
-		verify(mutableRelayerAccount).decrementBalance(Wei.of(gasPrice * gasLimit));
-	}
-
-	@Test
-	void assertThrowsEthereumTransactionWhenSenderGasPriceIs0AndAllowanceCannotCoverFees() {
-		given(worldState.updater()).willReturn(updater);;
-		given(gasCalculator.transactionIntrinsicGasCost(Bytes.EMPTY, false)).willReturn(0L);
-		given(worldState.updater()).willReturn(updater);
-		given(storageExpiry.hapiCallOracle()).willReturn(oracle);
-		final var wrappedSenderAccount = mock(EvmAccount.class);
-		final var mutableSenderAccount = mock(MutableAccount.class);
-		given(wrappedSenderAccount.getMutable()).willReturn(mutableSenderAccount);
-		given(updater.getOrCreateSenderAccount(sender.getId().asEvmAddress())).willReturn(wrappedSenderAccount);
-		final var wrappedRelayerAccount = mock(EvmAccount.class);
-		final var mutableRelayerAccount = mock(MutableAccount.class);
-		given(wrappedRelayerAccount.getMutable()).willReturn(mutableRelayerAccount);
-		given(updater.getOrCreateSenderAccount(relayer.getId().asEvmAddress())).willReturn(wrappedRelayerAccount);
-		final long gasPrice = 40L;
-		given(livePricesSource.currentGasPrice(consensusTime, HederaFunctionality.EthereumTransaction))
-				.willReturn(gasPrice);
-		final var receiverAddress = receiver.getId().asEvmAddress();
-		given(aliasManager.resolveForEvm(receiverAddress)).willReturn(receiverAddress);
-		final long offeredGasPrice = 0L;
-		final int gasLimit = 1000;
-		final var userOfferedGasPrice = BigInteger.valueOf(offeredGasPrice).multiply(WEIBARS_TO_TINYBARS);
-
-		assertThrows(InvalidTransactionException.class, () -> callEvmTxProcessor.executeEth(
-				sender, receiverAddress, gasLimit, 1234L, Bytes.EMPTY, consensusTime,
-				userOfferedGasPrice, relayer, 100));
-	}
-
-	@Test
-	void assertThrowsEthereumTransactionWhenSenderGasPriceIs0AndRelayerDoesNotHaveBalanceForAllowance() {
-		given(worldState.updater()).willReturn(updater);;
-		given(gasCalculator.transactionIntrinsicGasCost(Bytes.EMPTY, false)).willReturn(0L);
-		given(worldState.updater()).willReturn(updater);
-		given(storageExpiry.hapiCallOracle()).willReturn(oracle);
-		final var wrappedSenderAccount = mock(EvmAccount.class);
-		final var mutableSenderAccount = mock(MutableAccount.class);
-		given(wrappedSenderAccount.getMutable()).willReturn(mutableSenderAccount);
-		given(updater.getOrCreateSenderAccount(sender.getId().asEvmAddress())).willReturn(wrappedSenderAccount);
-		final var wrappedRelayerAccount = mock(EvmAccount.class);
-		final var mutableRelayerAccount = mock(MutableAccount.class);
-		given(wrappedRelayerAccount.getMutable()).willReturn(mutableRelayerAccount);
-		given(updater.getOrCreateSenderAccount(relayer.getId().asEvmAddress())).willReturn(wrappedRelayerAccount);
-		given(mutableRelayerAccount.getBalance()).willReturn(Wei.ONE);
-		final long gasPrice = 40L;
-		given(livePricesSource.currentGasPrice(consensusTime, HederaFunctionality.EthereumTransaction))
-				.willReturn(gasPrice);
-		final var receiverAddress = receiver.getId().asEvmAddress();
-		given(aliasManager.resolveForEvm(receiverAddress)).willReturn(receiverAddress);
-		final long offeredGasPrice = 0L;
-		final int gasLimit = 1000;
-		final var userOfferedGasPrice = BigInteger.valueOf(offeredGasPrice).multiply(WEIBARS_TO_TINYBARS);
-
-		assertThrows(InvalidTransactionException.class, () -> callEvmTxProcessor.executeEth(
-				sender, receiverAddress, gasLimit, 1234L, Bytes.EMPTY, consensusTime,
-				userOfferedGasPrice, relayer, 10 * ONE_HBAR));
-	}
-
-	@Test
-	void assertSuccessEthereumTransactionWhenSenderGasPriceBiggerThanGasPriceAndChargesOnlySender() {
-		givenValidMockEth();
-		final var MAX_REFUND_PERCENTAGE = 100;
-		given(globalDynamicProperties.maxGasRefundPercentage()).willReturn(MAX_REFUND_PERCENTAGE);
-		given(globalDynamicProperties.fundingAccount()).willReturn(new Id(0, 0, 1010).asGrpcAccount());
-		given(storageExpiry.hapiCallOracle()).willReturn(oracle);
-		final var wrappedSenderAccount = mock(EvmAccount.class);
-		final var mutableSenderAccount = mock(MutableAccount.class);
-		given(wrappedSenderAccount.getMutable()).willReturn(mutableSenderAccount);
-		given(updater.getOrCreateSenderAccount(sender.getId().asEvmAddress())).willReturn(wrappedSenderAccount);
-		given(mutableSenderAccount.getBalance()).willReturn(Wei.of(100* ONE_HBAR));
-		final var wrappedRelayerAccount = mock(EvmAccount.class);
-		final var mutableRelayerAccount = mock(MutableAccount.class);
-		given(wrappedRelayerAccount.getMutable()).willReturn(mutableRelayerAccount);
-		given(updater.getOrCreateSenderAccount(relayer.getId().asEvmAddress())).willReturn(wrappedRelayerAccount);
-		final long gasPrice = 40L;
-		given(livePricesSource.currentGasPrice(consensusTime, HederaFunctionality.EthereumTransaction))
-				.willReturn(gasPrice);
-		final var receiverAddress = receiver.getId().asEvmAddress();
-		given(aliasManager.resolveForEvm(receiverAddress)).willReturn(receiverAddress);
-		final long offeredGasPrice = 50L;
-		final long gasLimit = 1000;
-		given(gasCalculator.transactionIntrinsicGasCost(Bytes.EMPTY, false)).willReturn(gasLimit);
-
-		var result = callEvmTxProcessor.executeEth(
-				sender, receiverAddress, gasLimit, 1234L, Bytes.EMPTY, consensusTime,
-				BigInteger.valueOf(offeredGasPrice).multiply(WEIBARS_TO_TINYBARS),
-				relayer, 10 * ONE_HBAR);
-
-		assertTrue(result.isSuccessful());
-		assertEquals(result.getGasUsed(), gasLimit);
-		assertEquals(receiver.getId().asGrpcContract(), result.toGrpc().getContractID());
-		verify(mutableSenderAccount).decrementBalance(Wei.of(gasPrice * gasLimit));
-		verify(mutableRelayerAccount, never()).decrementBalance(Wei.of(gasPrice * gasLimit));
-	}
-
-	@Test
-	void assertThrowsEthereumTransactionWhenSenderGasPriceBiggerThanGasPriceButBalanceNotEnough() {
-		given(worldState.updater()).willReturn(updater);;
-		given(gasCalculator.transactionIntrinsicGasCost(Bytes.EMPTY, false)).willReturn(0L);
-		given(worldState.updater()).willReturn(updater);
-		given(storageExpiry.hapiCallOracle()).willReturn(oracle);
-		final var wrappedSenderAccount = mock(EvmAccount.class);
-		final var mutableSenderAccount = mock(MutableAccount.class);
-		given(wrappedSenderAccount.getMutable()).willReturn(mutableSenderAccount);
-		given(updater.getOrCreateSenderAccount(sender.getId().asEvmAddress())).willReturn(wrappedSenderAccount);
-		given(mutableSenderAccount.getBalance()).willReturn(Wei.ONE);
-		final var wrappedRelayerAccount = mock(EvmAccount.class);
-		final var mutableRelayerAccount = mock(MutableAccount.class);
-		given(wrappedRelayerAccount.getMutable()).willReturn(mutableRelayerAccount);
-		given(updater.getOrCreateSenderAccount(relayer.getId().asEvmAddress())).willReturn(wrappedRelayerAccount);
-		final long gasPrice = 40L;
-		given(livePricesSource.currentGasPrice(consensusTime, HederaFunctionality.EthereumTransaction))
-				.willReturn(gasPrice);
-		final var receiverAddress = receiver.getId().asEvmAddress();
-		given(aliasManager.resolveForEvm(receiverAddress)).willReturn(receiverAddress);
-		final long offeredGasPrice = 50L;
-		final int gasLimit = 1000;
-		final var userOfferedGasPrice = BigInteger.valueOf(offeredGasPrice).multiply(WEIBARS_TO_TINYBARS);
-
-		assertThrows(InvalidTransactionException.class, () -> callEvmTxProcessor.executeEth(
-				sender, receiverAddress, gasLimit, 1234L, Bytes.EMPTY, consensusTime,
-				userOfferedGasPrice, relayer, 10 * ONE_HBAR));
-	}
-
-	@Test
-	void assertSuccessExecutionWithRefund() {
-		givenValidMock();
-		given(globalDynamicProperties.maxGasRefundPercentage()).willReturn(100);
-		given(globalDynamicProperties.fundingAccount()).willReturn(new Id(0, 0, 1010).asGrpcAccount());
-		given(storageExpiry.hapiCallOracle()).willReturn(oracle);
-		givenSenderWithBalance(ONE_HBAR * 10);
-		final var receiverAddress = receiver.getId().asEvmAddress();
-		given(aliasManager.resolveForEvm(receiverAddress)).willReturn(receiverAddress);
-		final long gasPrice = 10L;
-		given(livePricesSource.currentGasPrice(consensusTime, HederaFunctionality.ContractCall))
-				.willReturn(gasPrice);
-
-		var result = callEvmTxProcessor.execute(
-				sender, receiverAddress, GAS_LIMIT, 1234L, Bytes.EMPTY, consensusTime);
-
-		assertTrue(result.isSuccessful());
-		assertEquals(0, result.getGasUsed());
-		assertEquals(receiver.getId().asGrpcContract(), result.toGrpc().getContractID());
-	}
-
-	private void givenInvalidMock() {
-		given(worldState.updater()).willReturn(updater);
-		given(gasCalculator.transactionIntrinsicGasCost(Bytes.EMPTY, false)).willReturn(100_000L);
-	}
-
-	private void givenValidMock() {
-		given(worldState.updater()).willReturn(updater);
-		given(worldState.updater().updater()).willReturn(updater);
-		given(globalDynamicProperties.fundingAccount()).willReturn(new Id(0, 0, 1010).asGrpcAccount());
-
-		var evmAccount = mock(EvmAccount.class);
-
-		given(gasCalculator.transactionIntrinsicGasCost(Bytes.EMPTY, false)).willReturn(0L);
-
-		given(updater.getOrCreateSenderAccount(sender.getId().asEvmAddress())).willReturn(evmAccount);
-		given(worldState.updater()).willReturn(updater);
-		given(codeCache.getIfPresent(any())).willReturn(Code.EMPTY);
-
-		given(gasCalculator.getSelfDestructRefundAmount()).willReturn(0L);
-		given(gasCalculator.getMaxRefundQuotient()).willReturn(2L);
-
-		var senderMutableAccount = mock(MutableAccount.class);
-		given(senderMutableAccount.decrementBalance(any())).willReturn(Wei.of(1234L));
-		given(senderMutableAccount.incrementBalance(any())).willReturn(Wei.of(1500L));
-		given(evmAccount.getMutable()).willReturn(senderMutableAccount);
-
-		given(updater.getSenderAccount(any())).willReturn(evmAccount);
-		given(updater.getSenderAccount(any()).getMutable()).willReturn(senderMutableAccount);
-		given(updater.getOrCreate(any())).willReturn(evmAccount);
-		given(updater.getOrCreate(any()).getMutable()).willReturn(senderMutableAccount);
-		given(updater.getSbhRefund()).willReturn(0L);
-
-		given(blockMetaSource.computeBlockValues(anyLong())).willReturn(hederaBlockValues);
-	}
-
-	private void givenValidMockEth() {
-		given(worldState.updater()).willReturn(updater);
-		given(worldState.updater().updater()).willReturn(updater);
-		given(globalDynamicProperties.fundingAccount()).willReturn(new Id(0, 0, 1010).asGrpcAccount());
-
-		var evmAccount = mock(EvmAccount.class);
-
-		given(gasCalculator.transactionIntrinsicGasCost(Bytes.EMPTY, false)).willReturn(0L);
-
-		given(worldState.updater()).willReturn(updater);
-		given(codeCache.getIfPresent(any())).willReturn(Code.EMPTY);
-
-		given(gasCalculator.getSelfDestructRefundAmount()).willReturn(0L);
-		given(gasCalculator.getMaxRefundQuotient()).willReturn(2L);
-
-		var senderMutableAccount = mock(MutableAccount.class);
-		given(senderMutableAccount.decrementBalance(any())).willReturn(Wei.of(1234L));
-		given(senderMutableAccount.incrementBalance(any())).willReturn(Wei.of(1500L));
-		given(evmAccount.getMutable()).willReturn(senderMutableAccount);
-
-		given(updater.getSenderAccount(any())).willReturn(evmAccount);
-		given(updater.getSenderAccount(any()).getMutable()).willReturn(senderMutableAccount);
-		given(updater.getOrCreate(any())).willReturn(evmAccount);
-		given(updater.getOrCreate(any()).getMutable()).willReturn(senderMutableAccount);
-		given(updater.getSbhRefund()).willReturn(0L);
-		given(blockMetaSource.computeBlockValues(anyLong())).willReturn(hederaBlockValues);
-	}
-
-	private void givenSenderWithBalance(final long amount) {
-		final var wrappedSenderAccount = mock(EvmAccount.class);
-		final var mutableSenderAccount = mock(MutableAccount.class);
-		given(wrappedSenderAccount.getMutable()).willReturn(mutableSenderAccount);
-		given(updater.getOrCreateSenderAccount(sender.getId().asEvmAddress())).willReturn(wrappedSenderAccount);
-
-		given(mutableSenderAccount.getBalance()).willReturn(Wei.of(amount));
-	}
-
-	private void givenRelayerWithBalance(final long amount) {
-		final var wrappedRelayerAccount = mock(EvmAccount.class);
-		final var mutableRelayerAccount = mock(MutableAccount.class);
-		given(wrappedRelayerAccount.getMutable()).willReturn(mutableRelayerAccount);
-		given(updater.getOrCreateSenderAccount(relayer.getId().asEvmAddress())).willReturn(wrappedRelayerAccount);
-
-		given(mutableRelayerAccount.getBalance()).willReturn(Wei.of(amount));
-		given(mutableRelayerAccount.incrementBalance(any())).willCallRealMethod();
-		given(mutableRelayerAccount.decrementBalance(any())).willCallRealMethod();
-	}
+    private static final int MAX_STACK_SIZE = 1024;
+    public static final long ONE_HBAR = 100_000_000L;
+
+    @Mock private LivePricesSource livePricesSource;
+    @Mock private HederaWorldState worldState;
+    @Mock private CodeCache codeCache;
+    @Mock private GlobalDynamicProperties globalDynamicProperties;
+    @Mock private GasCalculator gasCalculator;
+    @Mock private Set<Operation> operations;
+    @Mock private Transaction transaction;
+    @Mock private HederaWorldState.Updater updater;
+    @Mock private AliasManager aliasManager;
+    @Mock private Map<String, PrecompiledContract> precompiledContractMap;
+    @Mock private StorageExpiry storageExpiry;
+    @Mock private StorageExpiry.Oracle oracle;
+    @Mock private HederaBlockValues hederaBlockValues;
+    @Mock private BlockValues blockValues;
+    @Mock private InHandleBlockMetaSource blockMetaSource;
+
+    private final Account sender = new Account(new Id(0, 0, 1002));
+    private final Account receiver = new Account(new Id(0, 0, 1006));
+    private final Account relayer = new Account(new Id(0, 0, 1007));
+    private final Address receiverAddress = receiver.getId().asEvmAddress();
+    private final Instant consensusTime = Instant.now();
+    private final int MAX_GAS_LIMIT = 10_000_000;
+    private final int MAX_REFUND_PERCENT = 20;
+    private final long INTRINSIC_GAS_COST = 290_000L;
+    private final long GAS_LIMIT = 300_000L;
+
+    private CallEvmTxProcessor callEvmTxProcessor;
+
+    @BeforeEach
+    private void setup() {
+        CommonProcessorSetup.setup(gasCalculator);
+
+        callEvmTxProcessor =
+                new CallEvmTxProcessor(
+                        worldState,
+                        livePricesSource,
+                        codeCache,
+                        globalDynamicProperties,
+                        gasCalculator,
+                        operations,
+                        precompiledContractMap,
+                        aliasManager,
+                        storageExpiry,
+                        blockMetaSource);
+    }
+
+    @Test
+    void assertSuccessExecution() {
+        givenValidMock();
+        given(globalDynamicProperties.fundingAccount())
+                .willReturn(new Id(0, 0, 1010).asGrpcAccount());
+        given(aliasManager.resolveForEvm(receiverAddress)).willReturn(receiverAddress);
+        given(storageExpiry.hapiCallOracle()).willReturn(oracle);
+
+        givenSenderWithBalance(350_000L);
+        var result =
+                callEvmTxProcessor.execute(
+                        sender, receiverAddress, 33_333L, 1234L, Bytes.EMPTY, consensusTime);
+        assertTrue(result.isSuccessful());
+        assertEquals(receiver.getId().asGrpcContract(), result.toGrpc().getContractID());
+    }
+
+    @Test
+    void assertSuccessExecutionEth() {
+        givenValidMockEth();
+
+        given(globalDynamicProperties.fundingAccount())
+                .willReturn(new Id(0, 0, 1010).asGrpcAccount());
+        given(aliasManager.resolveForEvm(receiverAddress)).willReturn(receiverAddress);
+        given(storageExpiry.hapiCallOracle()).willReturn(oracle);
+        var evmAccount = mock(EvmAccount.class);
+        given(updater.getOrCreateSenderAccount(any())).willReturn(evmAccount);
+        var senderMutableAccount = mock(MutableAccount.class);
+        given(evmAccount.getMutable()).willReturn(senderMutableAccount);
+
+        givenSenderWithBalance(350_000L);
+        var result =
+                callEvmTxProcessor.executeEth(
+                        sender,
+                        receiverAddress,
+                        33_333L,
+                        1234L,
+                        Bytes.EMPTY,
+                        consensusTime,
+                        BigInteger.valueOf(10_000L),
+                        relayer,
+                        55_555L);
+        assertTrue(result.isSuccessful());
+        assertEquals(receiver.getId().asGrpcContract(), result.toGrpc().getContractID());
+    }
+
+    @Test
+    void nonCodeTxRequiresValue() {
+        assertFailsWith(
+                () ->
+                        callEvmTxProcessor.buildInitialFrame(
+                                MessageFrame.builder(), receiverAddress, Bytes.EMPTY, 0L),
+                INVALID_ETHEREUM_TRANSACTION);
+    }
+
+    @Test
+    void missingCodeBecomesEmptyInInitialFrame() {
+        MessageFrame.Builder protoFrame =
+                MessageFrame.builder()
+                        .messageFrameStack(new ArrayDeque<>())
+                        .worldUpdater(updater)
+                        .initialGas(1L)
+                        .originator(sender.canonicalAddress())
+                        .gasPrice(Wei.ZERO)
+                        .sender(sender.canonicalAddress())
+                        .value(Wei.ONE)
+                        .apparentValue(Wei.ONE)
+                        .blockValues(blockValues)
+                        .depth(1)
+                        .completer(frame -> {})
+                        .miningBeneficiary(Address.ZERO)
+                        .blockHashLookup(hash -> null);
+
+        var messageFrame =
+                callEvmTxProcessor.buildInitialFrame(protoFrame, receiverAddress, Bytes.EMPTY, 33L);
+
+        assertEquals(Code.EMPTY, messageFrame.getCode());
+    }
+
+    @Test
+    void assertSuccessExecutionChargesCorrectMinimumGas() {
+        givenValidMock();
+        given(globalDynamicProperties.maxGasRefundPercentage()).willReturn(MAX_REFUND_PERCENT);
+        given(globalDynamicProperties.fundingAccount())
+                .willReturn(new Id(0, 0, 1010).asGrpcAccount());
+        given(storageExpiry.hapiCallOracle()).willReturn(oracle);
+        givenSenderWithBalance(350_000L);
+        final var receiverAddress = receiver.getId().asEvmAddress();
+        given(aliasManager.resolveForEvm(receiverAddress)).willReturn(receiverAddress);
+        var result =
+                callEvmTxProcessor.execute(
+                        sender, receiverAddress, GAS_LIMIT, 1234L, Bytes.EMPTY, consensusTime);
+        assertTrue(result.isSuccessful());
+        assertEquals(result.getGasUsed(), GAS_LIMIT - GAS_LIMIT * MAX_REFUND_PERCENT / 100);
+        assertEquals(receiver.getId().asGrpcContract(), result.toGrpc().getContractID());
+    }
+
+    @Test
+    void assertSuccessExecutionChargesCorrectGasWhenGasUsedIsLargerThanMinimum() {
+        givenValidMock();
+        given(globalDynamicProperties.maxGasRefundPercentage()).willReturn(MAX_REFUND_PERCENT);
+        given(gasCalculator.transactionIntrinsicGasCost(Bytes.EMPTY, false))
+                .willReturn(INTRINSIC_GAS_COST);
+        given(globalDynamicProperties.fundingAccount())
+                .willReturn(new Id(0, 0, 1010).asGrpcAccount());
+        given(storageExpiry.hapiCallOracle()).willReturn(oracle);
+
+        givenSenderWithBalance(350_000L);
+        final var receiverAddress = receiver.getId().asEvmAddress();
+        given(aliasManager.resolveForEvm(receiverAddress)).willReturn(receiverAddress);
+        var result =
+                callEvmTxProcessor.execute(
+                        sender, receiverAddress, GAS_LIMIT, 1234L, Bytes.EMPTY, consensusTime);
+        assertTrue(result.isSuccessful());
+        assertEquals(INTRINSIC_GAS_COST, result.getGasUsed());
+        assertEquals(receiver.getId().asGrpcContract(), result.toGrpc().getContractID());
+    }
+
+    @Test
+    void assertSuccessExecutionPopulatesStorageChanges() {
+        givenValidMock();
+        given(globalDynamicProperties.fundingAccount())
+                .willReturn(new Id(0, 0, 1010).asGrpcAccount());
+        given(globalDynamicProperties.shouldEnableTraceability()).willReturn(true);
+        givenSenderWithBalance(350_000L);
+        given(aliasManager.resolveForEvm(receiverAddress)).willReturn(receiverAddress);
+        final var contractAddress = "0xffff";
+        final var slot = 1L;
+        final var oldSlotValue = 4L;
+        final var newSlotValue = 255L;
+        given(updater.getFinalStateChanges())
+                .willReturn(
+                        Map.of(
+                                Address.fromHexString(contractAddress),
+                                Map.of(
+                                        UInt256.valueOf(slot),
+                                        Pair.of(
+                                                UInt256.valueOf(oldSlotValue),
+                                                UInt256.valueOf(newSlotValue)))));
+        given(storageExpiry.hapiCallOracle()).willReturn(oracle);
+
+        final var result =
+                callEvmTxProcessor.execute(
+                        sender, receiverAddress, 33_333L, 1234L, Bytes.EMPTY, consensusTime);
+
+        assertTrue(result.isSuccessful());
+        assertEquals(receiver.getId().asGrpcContract(), result.toGrpc().getContractID());
+        assertEquals(1, result.toGrpc().getStateChangesCount());
+        final var contractStateChange = result.toGrpc().getStateChanges(0);
+        assertEquals(
+                EntityIdUtils.contractIdFromEvmAddress(Address.fromHexString(contractAddress)),
+                contractStateChange.getContractID());
+        assertEquals(
+                ByteString.copyFrom(
+                        Bytes.wrap(UInt256.valueOf(slot)).trimLeadingZeros().toArrayUnsafe()),
+                contractStateChange.getStorageChanges(0).getSlot());
+        assertEquals(
+                ByteString.copyFrom(
+                        Bytes.wrap(UInt256.valueOf(oldSlotValue))
+                                .trimLeadingZeros()
+                                .toArrayUnsafe()),
+                contractStateChange.getStorageChanges(0).getValueRead());
+        assertEquals(
+                BytesValue.of(
+                        ByteString.copyFrom(
+                                Bytes.wrap(UInt256.valueOf(newSlotValue))
+                                        .trimLeadingZeros()
+                                        .toArrayUnsafe())),
+                contractStateChange.getStorageChanges(0).getValueWritten());
+    }
+
+    @Test
+    void assertSuccessExecutionWithDisabledTraceabilityDoNotPopulatesStorageChanges() {
+        givenValidMock();
+        given(globalDynamicProperties.fundingAccount())
+                .willReturn(new Id(0, 0, 1010).asGrpcAccount());
+        given(globalDynamicProperties.shouldEnableTraceability()).willReturn(false);
+        givenSenderWithBalance(350_000L);
+        given(aliasManager.resolveForEvm(receiverAddress)).willReturn(receiverAddress);
+        given(storageExpiry.hapiCallOracle()).willReturn(oracle);
+
+        final var result =
+                callEvmTxProcessor.execute(
+                        sender, receiverAddress, 33_333L, 1234L, Bytes.EMPTY, consensusTime);
+
+        assertTrue(result.isSuccessful());
+        assertEquals(receiver.getId().asGrpcContract(), result.toGrpc().getContractID());
+        assertEquals(0, result.toGrpc().getStateChangesCount());
+
+        verify(updater, never()).getFinalStateChanges();
+    }
+
+    @Test
+    void throwsWhenSenderCannotCoverUpfrontCost() {
+        givenInvalidMock();
+        givenSenderWithBalance(123);
+
+        assertFailsWith(
+                () ->
+                        callEvmTxProcessor.execute(
+                                sender,
+                                receiverAddress,
+                                333_333L,
+                                1234L,
+                                Bytes.EMPTY,
+                                consensusTime),
+                ResponseCodeEnum.INSUFFICIENT_PAYER_BALANCE);
+    }
+
+    @Test
+    void throwsWhenIntrinsicGasCostExceedsGasLimit() {
+        givenInvalidMock();
+        final var wrappedSenderAccount = mock(EvmAccount.class);
+        final var mutableSenderAccount = mock(MutableAccount.class);
+        given(wrappedSenderAccount.getMutable()).willReturn(mutableSenderAccount);
+        given(updater.getOrCreateSenderAccount(sender.getId().asEvmAddress()))
+                .willReturn(wrappedSenderAccount);
+
+        assertFailsWith(
+                () ->
+                        callEvmTxProcessor.execute(
+                                sender,
+                                receiverAddress,
+                                33_333L,
+                                1234L,
+                                Bytes.EMPTY,
+                                consensusTime),
+                INSUFFICIENT_GAS);
+    }
+
+    @Test
+    void throwsWhenIntrinsicGasCostExceedsGasLimitAndGasLimitIsEqualToMaxGasLimit() {
+        givenInvalidMock();
+        final var wrappedSenderAccount = mock(EvmAccount.class);
+        final var mutableSenderAccount = mock(MutableAccount.class);
+        given(wrappedSenderAccount.getMutable()).willReturn(mutableSenderAccount);
+        given(updater.getOrCreateSenderAccount(sender.getId().asEvmAddress()))
+                .willReturn(wrappedSenderAccount);
+        given(gasCalculator.transactionIntrinsicGasCost(Bytes.EMPTY, false))
+                .willReturn(MAX_GAS_LIMIT + 1L);
+
+        assertFailsWith(
+                () ->
+                        callEvmTxProcessor.execute(
+                                sender,
+                                receiverAddress,
+                                MAX_GAS_LIMIT,
+                                1234L,
+                                Bytes.EMPTY,
+                                consensusTime),
+                INSUFFICIENT_GAS);
+    }
+
+    @Test
+    void assertIsContractCallFunctionality() {
+        assertEquals(HederaFunctionality.ContractCall, callEvmTxProcessor.getFunctionType());
+    }
+
+    @Test
+    void assertTransactionSenderAndValue() {
+        // setup:
+        doReturn(Optional.of(receiver.getId().asEvmAddress())).when(transaction).getTo();
+        given(codeCache.getIfPresent(any())).willReturn(Code.EMPTY);
+        given(transaction.getSender()).willReturn(sender.getId().asEvmAddress());
+        given(transaction.getValue()).willReturn(Wei.of(1L));
+        final MessageFrame.Builder commonInitialFrame =
+                MessageFrame.builder()
+                        .messageFrameStack(mock(Deque.class))
+                        .maxStackSize(MAX_STACK_SIZE)
+                        .worldUpdater(mock(WorldUpdater.class))
+                        .initialGas(GAS_LIMIT)
+                        .originator(sender.getId().asEvmAddress())
+                        .gasPrice(Wei.ZERO)
+                        .sender(sender.getId().asEvmAddress())
+                        .value(Wei.of(transaction.getValue().getAsBigInteger()))
+                        .apparentValue(Wei.of(transaction.getValue().getAsBigInteger()))
+                        .blockValues(mock(BlockValues.class))
+                        .depth(0)
+                        .completer(__ -> {})
+                        .miningBeneficiary(Address.ZERO)
+                        .blockHashLookup(h -> null);
+        // when:
+        MessageFrame buildMessageFrame =
+                callEvmTxProcessor.buildInitialFrame(
+                        commonInitialFrame, (Address) transaction.getTo().get(), Bytes.EMPTY, 0L);
+
+        // expect:
+        assertEquals(transaction.getSender(), buildMessageFrame.getSenderAddress());
+        assertEquals(transaction.getValue(), buildMessageFrame.getApparentValue());
+    }
+
+    @Test
+    void assertSuccessEthereumTransactionExecutionChargesBothSenderAndRelayerWithoutRefunds() {
+        givenValidMockEth();
+        final var MAX_REFUND_PERCENTAGE = 100;
+        given(globalDynamicProperties.maxGasRefundPercentage()).willReturn(MAX_REFUND_PERCENTAGE);
+        given(globalDynamicProperties.fundingAccount())
+                .willReturn(new Id(0, 0, 1010).asGrpcAccount());
+        given(storageExpiry.hapiCallOracle()).willReturn(oracle);
+        final var wrappedSenderAccount = mock(EvmAccount.class);
+        final var mutableSenderAccount = mock(MutableAccount.class);
+        given(wrappedSenderAccount.getMutable()).willReturn(mutableSenderAccount);
+        given(updater.getOrCreateSenderAccount(sender.getId().asEvmAddress()))
+                .willReturn(wrappedSenderAccount);
+        given(mutableSenderAccount.getBalance()).willReturn(Wei.of(100 * ONE_HBAR));
+        final var wrappedRelayerAccount = mock(EvmAccount.class);
+        final var mutableRelayerAccount = mock(MutableAccount.class);
+        given(wrappedRelayerAccount.getMutable()).willReturn(mutableRelayerAccount);
+        given(updater.getOrCreateSenderAccount(relayer.getId().asEvmAddress()))
+                .willReturn(wrappedRelayerAccount);
+        given(mutableRelayerAccount.getBalance()).willReturn(Wei.of(100 * ONE_HBAR));
+        final long gasPrice = 40L;
+        given(
+                        livePricesSource.currentGasPrice(
+                                consensusTime, HederaFunctionality.EthereumTransaction))
+                .willReturn(gasPrice);
+        final var receiverAddress = receiver.getId().asEvmAddress();
+        given(aliasManager.resolveForEvm(receiverAddress)).willReturn(receiverAddress);
+        final long offeredGasPrice = 10L;
+        final long gasLimit = 1000;
+        given(gasCalculator.transactionIntrinsicGasCost(Bytes.EMPTY, false)).willReturn(gasLimit);
+
+        var result =
+                callEvmTxProcessor.executeEth(
+                        sender,
+                        receiverAddress,
+                        gasLimit,
+                        1234L,
+                        Bytes.EMPTY,
+                        consensusTime,
+                        BigInteger.valueOf(offeredGasPrice).multiply(WEIBARS_TO_TINYBARS),
+                        relayer,
+                        10 * ONE_HBAR);
+
+        assertTrue(result.isSuccessful());
+        assertEquals(result.getGasUsed(), gasLimit);
+        assertEquals(receiver.getId().asGrpcContract(), result.toGrpc().getContractID());
+        verify(mutableSenderAccount).decrementBalance(Wei.of(offeredGasPrice * gasLimit));
+        verify(mutableRelayerAccount)
+                .decrementBalance(Wei.of(gasPrice * gasLimit - offeredGasPrice * gasLimit));
+        verify(mutableRelayerAccount, never()).incrementBalance(any());
+        verify(mutableSenderAccount, never()).incrementBalance(any());
+    }
+
+    @Test
+    void assertSuccessEthereumTransactionExecutionChargesBothSenderAndRelayerAndRefunds() {
+        givenValidMockEth();
+        final var MAX_REFUND_PERCENTAGE = 100;
+        given(globalDynamicProperties.maxGasRefundPercentage()).willReturn(MAX_REFUND_PERCENTAGE);
+        given(globalDynamicProperties.fundingAccount())
+                .willReturn(new Id(0, 0, 1010).asGrpcAccount());
+        given(storageExpiry.hapiCallOracle()).willReturn(oracle);
+        final var wrappedSenderAccount = mock(EvmAccount.class);
+        final var mutableSenderAccount = mock(MutableAccount.class);
+        given(wrappedSenderAccount.getMutable()).willReturn(mutableSenderAccount);
+        given(updater.getOrCreateSenderAccount(sender.getId().asEvmAddress()))
+                .willReturn(wrappedSenderAccount);
+        given(mutableSenderAccount.getBalance()).willReturn(Wei.of(100 * ONE_HBAR));
+        final var wrappedRelayerAccount = mock(EvmAccount.class);
+        final var mutableRelayerAccount = mock(MutableAccount.class);
+        given(wrappedRelayerAccount.getMutable()).willReturn(mutableRelayerAccount);
+        given(updater.getOrCreateSenderAccount(relayer.getId().asEvmAddress()))
+                .willReturn(wrappedRelayerAccount);
+        given(mutableRelayerAccount.getBalance()).willReturn(Wei.of(100 * ONE_HBAR));
+        final long gasPrice = 40L;
+        given(
+                        livePricesSource.currentGasPrice(
+                                consensusTime, HederaFunctionality.EthereumTransaction))
+                .willReturn(gasPrice);
+        final var receiverAddress = receiver.getId().asEvmAddress();
+        given(aliasManager.resolveForEvm(receiverAddress)).willReturn(receiverAddress);
+        final long offeredGasPrice = 10L;
+        final int gasLimit = 1000;
+
+        var result =
+                callEvmTxProcessor.executeEth(
+                        sender,
+                        receiverAddress,
+                        gasLimit,
+                        1234L,
+                        Bytes.EMPTY,
+                        consensusTime,
+                        BigInteger.valueOf(offeredGasPrice).multiply(WEIBARS_TO_TINYBARS),
+                        relayer,
+                        10 * ONE_HBAR);
+
+        assertTrue(result.isSuccessful());
+        assertEquals(0, result.getGasUsed());
+        assertEquals(receiver.getId().asGrpcContract(), result.toGrpc().getContractID());
+        verify(mutableSenderAccount).decrementBalance(Wei.of(offeredGasPrice * gasLimit));
+        verify(mutableRelayerAccount)
+                .decrementBalance(Wei.of(gasPrice * gasLimit - offeredGasPrice * gasLimit));
+        verify(mutableRelayerAccount)
+                .incrementBalance(Wei.of(gasPrice * gasLimit - offeredGasPrice * gasLimit));
+        verify(mutableSenderAccount).incrementBalance(Wei.of(offeredGasPrice * gasLimit));
+    }
+
+    @Test
+    void
+            assertSuccessEthereumTransactionExecutionChargesBothSenderAndRelayerAndRefundsOnlyRelayer() {
+        givenValidMockEth();
+        final var MAX_REFUND_PERCENTAGE = 1;
+        given(globalDynamicProperties.maxGasRefundPercentage()).willReturn(MAX_REFUND_PERCENTAGE);
+        given(globalDynamicProperties.fundingAccount())
+                .willReturn(new Id(0, 0, 1010).asGrpcAccount());
+        given(storageExpiry.hapiCallOracle()).willReturn(oracle);
+        final var wrappedSenderAccount = mock(EvmAccount.class);
+        final var mutableSenderAccount = mock(MutableAccount.class);
+        given(wrappedSenderAccount.getMutable()).willReturn(mutableSenderAccount);
+        given(updater.getOrCreateSenderAccount(sender.getId().asEvmAddress()))
+                .willReturn(wrappedSenderAccount);
+        given(mutableSenderAccount.getBalance()).willReturn(Wei.of(100 * ONE_HBAR));
+        final var wrappedRelayerAccount = mock(EvmAccount.class);
+        final var mutableRelayerAccount = mock(MutableAccount.class);
+        given(wrappedRelayerAccount.getMutable()).willReturn(mutableRelayerAccount);
+        given(updater.getOrCreateSenderAccount(relayer.getId().asEvmAddress()))
+                .willReturn(wrappedRelayerAccount);
+        given(mutableRelayerAccount.getBalance()).willReturn(Wei.of(100 * ONE_HBAR));
+        final long gasPrice = 40L;
+        given(
+                        livePricesSource.currentGasPrice(
+                                consensusTime, HederaFunctionality.EthereumTransaction))
+                .willReturn(gasPrice);
+        final var receiverAddress = receiver.getId().asEvmAddress();
+        given(aliasManager.resolveForEvm(receiverAddress)).willReturn(receiverAddress);
+        final long offeredGasPrice = 10L;
+        final int gasLimit = 1000;
+
+        var result =
+                callEvmTxProcessor.executeEth(
+                        sender,
+                        receiverAddress,
+                        gasLimit,
+                        1234L,
+                        Bytes.EMPTY,
+                        consensusTime,
+                        BigInteger.valueOf(offeredGasPrice).multiply(WEIBARS_TO_TINYBARS),
+                        relayer,
+                        10 * ONE_HBAR);
+
+        assertTrue(result.isSuccessful());
+        assertEquals(gasLimit - gasLimit * MAX_REFUND_PERCENTAGE / 100, result.getGasUsed());
+        assertEquals(receiver.getId().asGrpcContract(), result.toGrpc().getContractID());
+        verify(mutableSenderAccount).decrementBalance(Wei.of(offeredGasPrice * gasLimit));
+        verify(mutableRelayerAccount)
+                .decrementBalance(Wei.of(gasPrice * gasLimit - offeredGasPrice * gasLimit));
+        verify(mutableRelayerAccount).incrementBalance(any());
+        verify(mutableSenderAccount, never()).incrementBalance(any());
+    }
+
+    @Test
+    void assertThrowsEthereumTransactionWhenSenderBalanceNotEnoughToCoverFeeWhenBothPay() {
+        given(worldState.updater()).willReturn(updater);
+        ;
+        given(gasCalculator.transactionIntrinsicGasCost(Bytes.EMPTY, false)).willReturn(0L);
+        given(worldState.updater()).willReturn(updater);
+        given(storageExpiry.hapiCallOracle()).willReturn(oracle);
+        final var wrappedSenderAccount = mock(EvmAccount.class);
+        final var mutableSenderAccount = mock(MutableAccount.class);
+        given(wrappedSenderAccount.getMutable()).willReturn(mutableSenderAccount);
+        given(updater.getOrCreateSenderAccount(sender.getId().asEvmAddress()))
+                .willReturn(wrappedSenderAccount);
+        given(mutableSenderAccount.getBalance()).willReturn(Wei.ONE);
+        final var wrappedRelayerAccount = mock(EvmAccount.class);
+        final var mutableRelayerAccount = mock(MutableAccount.class);
+        given(wrappedRelayerAccount.getMutable()).willReturn(mutableRelayerAccount);
+        given(updater.getOrCreateSenderAccount(relayer.getId().asEvmAddress()))
+                .willReturn(wrappedRelayerAccount);
+        final long gasPrice = 40L;
+        given(
+                        livePricesSource.currentGasPrice(
+                                consensusTime, HederaFunctionality.EthereumTransaction))
+                .willReturn(gasPrice);
+        final var receiverAddress = receiver.getId().asEvmAddress();
+        given(aliasManager.resolveForEvm(receiverAddress)).willReturn(receiverAddress);
+        final long offeredGasPrice = 10L;
+        final int gasLimit = 1000;
+        final var userOfferedGasPrice =
+                BigInteger.valueOf(offeredGasPrice).multiply(WEIBARS_TO_TINYBARS);
+
+        assertThrows(
+                InvalidTransactionException.class,
+                () ->
+                        callEvmTxProcessor.executeEth(
+                                sender,
+                                receiverAddress,
+                                gasLimit,
+                                1234L,
+                                Bytes.EMPTY,
+                                consensusTime,
+                                userOfferedGasPrice,
+                                relayer,
+                                10 * ONE_HBAR));
+    }
+
+    @Test
+    void assertThrowsEthereumTransactionWhenGasAllowanceNotEnoughWhenBothPay() {
+        given(worldState.updater()).willReturn(updater);
+        ;
+        given(gasCalculator.transactionIntrinsicGasCost(Bytes.EMPTY, false)).willReturn(0L);
+        given(worldState.updater()).willReturn(updater);
+        given(storageExpiry.hapiCallOracle()).willReturn(oracle);
+        final var wrappedSenderAccount = mock(EvmAccount.class);
+        final var mutableSenderAccount = mock(MutableAccount.class);
+        given(wrappedSenderAccount.getMutable()).willReturn(mutableSenderAccount);
+        given(updater.getOrCreateSenderAccount(sender.getId().asEvmAddress()))
+                .willReturn(wrappedSenderAccount);
+        given(mutableSenderAccount.getBalance()).willReturn(Wei.of(100 * ONE_HBAR));
+        final var wrappedRelayerAccount = mock(EvmAccount.class);
+        final var mutableRelayerAccount = mock(MutableAccount.class);
+        given(wrappedRelayerAccount.getMutable()).willReturn(mutableRelayerAccount);
+        given(updater.getOrCreateSenderAccount(relayer.getId().asEvmAddress()))
+                .willReturn(wrappedRelayerAccount);
+        final long gasPrice = 40L;
+        given(
+                        livePricesSource.currentGasPrice(
+                                consensusTime, HederaFunctionality.EthereumTransaction))
+                .willReturn(gasPrice);
+        final var receiverAddress = receiver.getId().asEvmAddress();
+        given(aliasManager.resolveForEvm(receiverAddress)).willReturn(receiverAddress);
+        final long offeredGasPrice = 10L;
+        final int gasLimit = 1000;
+        final var userOfferedGasPrice =
+                BigInteger.valueOf(offeredGasPrice).multiply(WEIBARS_TO_TINYBARS);
+
+        assertThrows(
+                InvalidTransactionException.class,
+                () ->
+                        callEvmTxProcessor.executeEth(
+                                sender,
+                                receiverAddress,
+                                gasLimit,
+                                1234L,
+                                Bytes.EMPTY,
+                                consensusTime,
+                                userOfferedGasPrice,
+                                relayer,
+                                100));
+    }
+
+    @Test
+    void assertThrowsEthereumTransactionWhenRelayerBalanceNotEnoughToCoverAllowanceWhenBothPay() {
+        given(worldState.updater()).willReturn(updater);
+        ;
+        given(gasCalculator.transactionIntrinsicGasCost(Bytes.EMPTY, false)).willReturn(0L);
+        given(worldState.updater()).willReturn(updater);
+        given(storageExpiry.hapiCallOracle()).willReturn(oracle);
+        final var wrappedSenderAccount = mock(EvmAccount.class);
+        final var mutableSenderAccount = mock(MutableAccount.class);
+        given(wrappedSenderAccount.getMutable()).willReturn(mutableSenderAccount);
+        given(updater.getOrCreateSenderAccount(sender.getId().asEvmAddress()))
+                .willReturn(wrappedSenderAccount);
+        given(mutableSenderAccount.getBalance()).willReturn(Wei.of(ONE_HBAR * 100));
+        final var wrappedRelayerAccount = mock(EvmAccount.class);
+        final var mutableRelayerAccount = mock(MutableAccount.class);
+        given(wrappedRelayerAccount.getMutable()).willReturn(mutableRelayerAccount);
+        given(updater.getOrCreateSenderAccount(relayer.getId().asEvmAddress()))
+                .willReturn(wrappedRelayerAccount);
+        given(mutableRelayerAccount.getBalance()).willReturn(Wei.ONE);
+        final long gasPrice = 40L;
+        given(
+                        livePricesSource.currentGasPrice(
+                                consensusTime, HederaFunctionality.EthereumTransaction))
+                .willReturn(gasPrice);
+        final var receiverAddress = receiver.getId().asEvmAddress();
+        given(aliasManager.resolveForEvm(receiverAddress)).willReturn(receiverAddress);
+        final long offeredGasPrice = 10L;
+        final int gasLimit = 1000;
+        final var userOfferedGasPrice =
+                BigInteger.valueOf(offeredGasPrice).multiply(WEIBARS_TO_TINYBARS);
+
+        assertThrows(
+                InvalidTransactionException.class,
+                () ->
+                        callEvmTxProcessor.executeEth(
+                                sender,
+                                receiverAddress,
+                                gasLimit,
+                                1234L,
+                                Bytes.EMPTY,
+                                consensusTime,
+                                userOfferedGasPrice,
+                                relayer,
+                                10 * ONE_HBAR));
+    }
+
+    @Test
+    void assertSuccessEthereumTransactionExecutionChargesRelayerWhenSenderGasPriceIs0() {
+        givenValidMockEth();
+        final var MAX_REFUND_PERCENTAGE = 100;
+        given(globalDynamicProperties.maxGasRefundPercentage()).willReturn(MAX_REFUND_PERCENTAGE);
+        given(globalDynamicProperties.fundingAccount())
+                .willReturn(new Id(0, 0, 1010).asGrpcAccount());
+        given(storageExpiry.hapiCallOracle()).willReturn(oracle);
+        final var wrappedSenderAccount = mock(EvmAccount.class);
+        final var mutableSenderAccount = mock(MutableAccount.class);
+        given(wrappedSenderAccount.getMutable()).willReturn(mutableSenderAccount);
+        given(updater.getOrCreateSenderAccount(sender.getId().asEvmAddress()))
+                .willReturn(wrappedSenderAccount);
+        given(mutableSenderAccount.getBalance()).willReturn(Wei.of(100 * ONE_HBAR));
+        final var wrappedRelayerAccount = mock(EvmAccount.class);
+        final var mutableRelayerAccount = mock(MutableAccount.class);
+        given(wrappedRelayerAccount.getMutable()).willReturn(mutableRelayerAccount);
+        given(updater.getOrCreateSenderAccount(relayer.getId().asEvmAddress()))
+                .willReturn(wrappedRelayerAccount);
+        given(mutableRelayerAccount.getBalance()).willReturn(Wei.of(100 * ONE_HBAR));
+        final long gasPrice = 40L;
+        given(
+                        livePricesSource.currentGasPrice(
+                                consensusTime, HederaFunctionality.EthereumTransaction))
+                .willReturn(gasPrice);
+        final var receiverAddress = receiver.getId().asEvmAddress();
+        given(aliasManager.resolveForEvm(receiverAddress)).willReturn(receiverAddress);
+        final long offeredGasPrice = 0L;
+        final long gasLimit = 1000;
+        given(gasCalculator.transactionIntrinsicGasCost(Bytes.EMPTY, false)).willReturn(gasLimit);
+
+        var result =
+                callEvmTxProcessor.executeEth(
+                        sender,
+                        receiverAddress,
+                        gasLimit,
+                        1234L,
+                        Bytes.EMPTY,
+                        consensusTime,
+                        BigInteger.valueOf(offeredGasPrice).multiply(WEIBARS_TO_TINYBARS),
+                        relayer,
+                        10 * ONE_HBAR);
+
+        assertTrue(result.isSuccessful());
+        assertEquals(result.getGasUsed(), gasLimit);
+        assertEquals(receiver.getId().asGrpcContract(), result.toGrpc().getContractID());
+        verify(mutableRelayerAccount).decrementBalance(Wei.of(gasPrice * gasLimit));
+    }
+
+    @Test
+    void assertThrowsEthereumTransactionWhenSenderGasPriceIs0AndAllowanceCannotCoverFees() {
+        given(worldState.updater()).willReturn(updater);
+        ;
+        given(gasCalculator.transactionIntrinsicGasCost(Bytes.EMPTY, false)).willReturn(0L);
+        given(worldState.updater()).willReturn(updater);
+        given(storageExpiry.hapiCallOracle()).willReturn(oracle);
+        final var wrappedSenderAccount = mock(EvmAccount.class);
+        final var mutableSenderAccount = mock(MutableAccount.class);
+        given(wrappedSenderAccount.getMutable()).willReturn(mutableSenderAccount);
+        given(updater.getOrCreateSenderAccount(sender.getId().asEvmAddress()))
+                .willReturn(wrappedSenderAccount);
+        final var wrappedRelayerAccount = mock(EvmAccount.class);
+        final var mutableRelayerAccount = mock(MutableAccount.class);
+        given(wrappedRelayerAccount.getMutable()).willReturn(mutableRelayerAccount);
+        given(updater.getOrCreateSenderAccount(relayer.getId().asEvmAddress()))
+                .willReturn(wrappedRelayerAccount);
+        final long gasPrice = 40L;
+        given(
+                        livePricesSource.currentGasPrice(
+                                consensusTime, HederaFunctionality.EthereumTransaction))
+                .willReturn(gasPrice);
+        final var receiverAddress = receiver.getId().asEvmAddress();
+        given(aliasManager.resolveForEvm(receiverAddress)).willReturn(receiverAddress);
+        final long offeredGasPrice = 0L;
+        final int gasLimit = 1000;
+        final var userOfferedGasPrice =
+                BigInteger.valueOf(offeredGasPrice).multiply(WEIBARS_TO_TINYBARS);
+
+        assertThrows(
+                InvalidTransactionException.class,
+                () ->
+                        callEvmTxProcessor.executeEth(
+                                sender,
+                                receiverAddress,
+                                gasLimit,
+                                1234L,
+                                Bytes.EMPTY,
+                                consensusTime,
+                                userOfferedGasPrice,
+                                relayer,
+                                100));
+    }
+
+    @Test
+    void
+            assertThrowsEthereumTransactionWhenSenderGasPriceIs0AndRelayerDoesNotHaveBalanceForAllowance() {
+        given(worldState.updater()).willReturn(updater);
+        ;
+        given(gasCalculator.transactionIntrinsicGasCost(Bytes.EMPTY, false)).willReturn(0L);
+        given(worldState.updater()).willReturn(updater);
+        given(storageExpiry.hapiCallOracle()).willReturn(oracle);
+        final var wrappedSenderAccount = mock(EvmAccount.class);
+        final var mutableSenderAccount = mock(MutableAccount.class);
+        given(wrappedSenderAccount.getMutable()).willReturn(mutableSenderAccount);
+        given(updater.getOrCreateSenderAccount(sender.getId().asEvmAddress()))
+                .willReturn(wrappedSenderAccount);
+        final var wrappedRelayerAccount = mock(EvmAccount.class);
+        final var mutableRelayerAccount = mock(MutableAccount.class);
+        given(wrappedRelayerAccount.getMutable()).willReturn(mutableRelayerAccount);
+        given(updater.getOrCreateSenderAccount(relayer.getId().asEvmAddress()))
+                .willReturn(wrappedRelayerAccount);
+        given(mutableRelayerAccount.getBalance()).willReturn(Wei.ONE);
+        final long gasPrice = 40L;
+        given(
+                        livePricesSource.currentGasPrice(
+                                consensusTime, HederaFunctionality.EthereumTransaction))
+                .willReturn(gasPrice);
+        final var receiverAddress = receiver.getId().asEvmAddress();
+        given(aliasManager.resolveForEvm(receiverAddress)).willReturn(receiverAddress);
+        final long offeredGasPrice = 0L;
+        final int gasLimit = 1000;
+        final var userOfferedGasPrice =
+                BigInteger.valueOf(offeredGasPrice).multiply(WEIBARS_TO_TINYBARS);
+
+        assertThrows(
+                InvalidTransactionException.class,
+                () ->
+                        callEvmTxProcessor.executeEth(
+                                sender,
+                                receiverAddress,
+                                gasLimit,
+                                1234L,
+                                Bytes.EMPTY,
+                                consensusTime,
+                                userOfferedGasPrice,
+                                relayer,
+                                10 * ONE_HBAR));
+    }
+
+    @Test
+    void
+            assertSuccessEthereumTransactionWhenSenderGasPriceBiggerThanGasPriceAndChargesOnlySender() {
+        givenValidMockEth();
+        final var MAX_REFUND_PERCENTAGE = 100;
+        given(globalDynamicProperties.maxGasRefundPercentage()).willReturn(MAX_REFUND_PERCENTAGE);
+        given(globalDynamicProperties.fundingAccount())
+                .willReturn(new Id(0, 0, 1010).asGrpcAccount());
+        given(storageExpiry.hapiCallOracle()).willReturn(oracle);
+        final var wrappedSenderAccount = mock(EvmAccount.class);
+        final var mutableSenderAccount = mock(MutableAccount.class);
+        given(wrappedSenderAccount.getMutable()).willReturn(mutableSenderAccount);
+        given(updater.getOrCreateSenderAccount(sender.getId().asEvmAddress()))
+                .willReturn(wrappedSenderAccount);
+        given(mutableSenderAccount.getBalance()).willReturn(Wei.of(100 * ONE_HBAR));
+        final var wrappedRelayerAccount = mock(EvmAccount.class);
+        final var mutableRelayerAccount = mock(MutableAccount.class);
+        given(wrappedRelayerAccount.getMutable()).willReturn(mutableRelayerAccount);
+        given(updater.getOrCreateSenderAccount(relayer.getId().asEvmAddress()))
+                .willReturn(wrappedRelayerAccount);
+        final long gasPrice = 40L;
+        given(
+                        livePricesSource.currentGasPrice(
+                                consensusTime, HederaFunctionality.EthereumTransaction))
+                .willReturn(gasPrice);
+        final var receiverAddress = receiver.getId().asEvmAddress();
+        given(aliasManager.resolveForEvm(receiverAddress)).willReturn(receiverAddress);
+        final long offeredGasPrice = 50L;
+        final long gasLimit = 1000;
+        given(gasCalculator.transactionIntrinsicGasCost(Bytes.EMPTY, false)).willReturn(gasLimit);
+
+        var result =
+                callEvmTxProcessor.executeEth(
+                        sender,
+                        receiverAddress,
+                        gasLimit,
+                        1234L,
+                        Bytes.EMPTY,
+                        consensusTime,
+                        BigInteger.valueOf(offeredGasPrice).multiply(WEIBARS_TO_TINYBARS),
+                        relayer,
+                        10 * ONE_HBAR);
+
+        assertTrue(result.isSuccessful());
+        assertEquals(result.getGasUsed(), gasLimit);
+        assertEquals(receiver.getId().asGrpcContract(), result.toGrpc().getContractID());
+        verify(mutableSenderAccount).decrementBalance(Wei.of(gasPrice * gasLimit));
+        verify(mutableRelayerAccount, never()).decrementBalance(Wei.of(gasPrice * gasLimit));
+    }
+
+    @Test
+    void assertThrowsEthereumTransactionWhenSenderGasPriceBiggerThanGasPriceButBalanceNotEnough() {
+        given(worldState.updater()).willReturn(updater);
+        ;
+        given(gasCalculator.transactionIntrinsicGasCost(Bytes.EMPTY, false)).willReturn(0L);
+        given(worldState.updater()).willReturn(updater);
+        given(storageExpiry.hapiCallOracle()).willReturn(oracle);
+        final var wrappedSenderAccount = mock(EvmAccount.class);
+        final var mutableSenderAccount = mock(MutableAccount.class);
+        given(wrappedSenderAccount.getMutable()).willReturn(mutableSenderAccount);
+        given(updater.getOrCreateSenderAccount(sender.getId().asEvmAddress()))
+                .willReturn(wrappedSenderAccount);
+        given(mutableSenderAccount.getBalance()).willReturn(Wei.ONE);
+        final var wrappedRelayerAccount = mock(EvmAccount.class);
+        final var mutableRelayerAccount = mock(MutableAccount.class);
+        given(wrappedRelayerAccount.getMutable()).willReturn(mutableRelayerAccount);
+        given(updater.getOrCreateSenderAccount(relayer.getId().asEvmAddress()))
+                .willReturn(wrappedRelayerAccount);
+        final long gasPrice = 40L;
+        given(
+                        livePricesSource.currentGasPrice(
+                                consensusTime, HederaFunctionality.EthereumTransaction))
+                .willReturn(gasPrice);
+        final var receiverAddress = receiver.getId().asEvmAddress();
+        given(aliasManager.resolveForEvm(receiverAddress)).willReturn(receiverAddress);
+        final long offeredGasPrice = 50L;
+        final int gasLimit = 1000;
+        final var userOfferedGasPrice =
+                BigInteger.valueOf(offeredGasPrice).multiply(WEIBARS_TO_TINYBARS);
+
+        assertThrows(
+                InvalidTransactionException.class,
+                () ->
+                        callEvmTxProcessor.executeEth(
+                                sender,
+                                receiverAddress,
+                                gasLimit,
+                                1234L,
+                                Bytes.EMPTY,
+                                consensusTime,
+                                userOfferedGasPrice,
+                                relayer,
+                                10 * ONE_HBAR));
+    }
+
+    @Test
+    void assertSuccessExecutionWithRefund() {
+        givenValidMock();
+        given(globalDynamicProperties.maxGasRefundPercentage()).willReturn(100);
+        given(globalDynamicProperties.fundingAccount())
+                .willReturn(new Id(0, 0, 1010).asGrpcAccount());
+        given(storageExpiry.hapiCallOracle()).willReturn(oracle);
+        givenSenderWithBalance(ONE_HBAR * 10);
+        final var receiverAddress = receiver.getId().asEvmAddress();
+        given(aliasManager.resolveForEvm(receiverAddress)).willReturn(receiverAddress);
+        final long gasPrice = 10L;
+        given(livePricesSource.currentGasPrice(consensusTime, HederaFunctionality.ContractCall))
+                .willReturn(gasPrice);
+
+        var result =
+                callEvmTxProcessor.execute(
+                        sender, receiverAddress, GAS_LIMIT, 1234L, Bytes.EMPTY, consensusTime);
+
+        assertTrue(result.isSuccessful());
+        assertEquals(0, result.getGasUsed());
+        assertEquals(receiver.getId().asGrpcContract(), result.toGrpc().getContractID());
+    }
+
+    private void givenInvalidMock() {
+        given(worldState.updater()).willReturn(updater);
+        given(gasCalculator.transactionIntrinsicGasCost(Bytes.EMPTY, false)).willReturn(100_000L);
+    }
+
+    private void givenValidMock() {
+        given(worldState.updater()).willReturn(updater);
+        given(worldState.updater().updater()).willReturn(updater);
+        given(globalDynamicProperties.fundingAccount())
+                .willReturn(new Id(0, 0, 1010).asGrpcAccount());
+
+        var evmAccount = mock(EvmAccount.class);
+
+        given(gasCalculator.transactionIntrinsicGasCost(Bytes.EMPTY, false)).willReturn(0L);
+
+        given(updater.getOrCreateSenderAccount(sender.getId().asEvmAddress()))
+                .willReturn(evmAccount);
+        given(worldState.updater()).willReturn(updater);
+        given(codeCache.getIfPresent(any())).willReturn(Code.EMPTY);
+
+        given(gasCalculator.getSelfDestructRefundAmount()).willReturn(0L);
+        given(gasCalculator.getMaxRefundQuotient()).willReturn(2L);
+
+        var senderMutableAccount = mock(MutableAccount.class);
+        given(senderMutableAccount.decrementBalance(any())).willReturn(Wei.of(1234L));
+        given(senderMutableAccount.incrementBalance(any())).willReturn(Wei.of(1500L));
+        given(evmAccount.getMutable()).willReturn(senderMutableAccount);
+
+        given(updater.getSenderAccount(any())).willReturn(evmAccount);
+        given(updater.getSenderAccount(any()).getMutable()).willReturn(senderMutableAccount);
+        given(updater.getOrCreate(any())).willReturn(evmAccount);
+        given(updater.getOrCreate(any()).getMutable()).willReturn(senderMutableAccount);
+        given(updater.getSbhRefund()).willReturn(0L);
+
+        given(blockMetaSource.computeBlockValues(anyLong())).willReturn(hederaBlockValues);
+    }
+
+    private void givenValidMockEth() {
+        given(worldState.updater()).willReturn(updater);
+        given(worldState.updater().updater()).willReturn(updater);
+        given(globalDynamicProperties.fundingAccount())
+                .willReturn(new Id(0, 0, 1010).asGrpcAccount());
+
+        var evmAccount = mock(EvmAccount.class);
+
+        given(gasCalculator.transactionIntrinsicGasCost(Bytes.EMPTY, false)).willReturn(0L);
+
+        given(worldState.updater()).willReturn(updater);
+        given(codeCache.getIfPresent(any())).willReturn(Code.EMPTY);
+
+        given(gasCalculator.getSelfDestructRefundAmount()).willReturn(0L);
+        given(gasCalculator.getMaxRefundQuotient()).willReturn(2L);
+
+        var senderMutableAccount = mock(MutableAccount.class);
+        given(senderMutableAccount.decrementBalance(any())).willReturn(Wei.of(1234L));
+        given(senderMutableAccount.incrementBalance(any())).willReturn(Wei.of(1500L));
+        given(evmAccount.getMutable()).willReturn(senderMutableAccount);
+
+        given(updater.getSenderAccount(any())).willReturn(evmAccount);
+        given(updater.getSenderAccount(any()).getMutable()).willReturn(senderMutableAccount);
+        given(updater.getOrCreate(any())).willReturn(evmAccount);
+        given(updater.getOrCreate(any()).getMutable()).willReturn(senderMutableAccount);
+        given(updater.getSbhRefund()).willReturn(0L);
+        given(blockMetaSource.computeBlockValues(anyLong())).willReturn(hederaBlockValues);
+    }
+
+    private void givenSenderWithBalance(final long amount) {
+        final var wrappedSenderAccount = mock(EvmAccount.class);
+        final var mutableSenderAccount = mock(MutableAccount.class);
+        given(wrappedSenderAccount.getMutable()).willReturn(mutableSenderAccount);
+        given(updater.getOrCreateSenderAccount(sender.getId().asEvmAddress()))
+                .willReturn(wrappedSenderAccount);
+
+        given(mutableSenderAccount.getBalance()).willReturn(Wei.of(amount));
+    }
+
+    private void givenRelayerWithBalance(final long amount) {
+        final var wrappedRelayerAccount = mock(EvmAccount.class);
+        final var mutableRelayerAccount = mock(MutableAccount.class);
+        given(wrappedRelayerAccount.getMutable()).willReturn(mutableRelayerAccount);
+        given(updater.getOrCreateSenderAccount(relayer.getId().asEvmAddress()))
+                .willReturn(wrappedRelayerAccount);
+
+        given(mutableRelayerAccount.getBalance()).willReturn(Wei.of(amount));
+        given(mutableRelayerAccount.incrementBalance(any())).willCallRealMethod();
+        given(mutableRelayerAccount.decrementBalance(any())).willCallRealMethod();
+    }
 }

--- a/hedera-node/src/test/java/com/hedera/services/contracts/execution/CallEvmTxProcessorTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/contracts/execution/CallEvmTxProcessorTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2021-2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hedera.services.contracts.execution;
 
 /*

--- a/hedera-node/src/test/java/com/hedera/services/contracts/execution/CallLocalEvmTxProcessorTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/contracts/execution/CallLocalEvmTxProcessorTest.java
@@ -22,6 +22,16 @@ package com.hedera.services.contracts.execution;
  *
  */
 
+import static com.hedera.test.utils.TxnUtils.assertFailsWith;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_CONTRACT_ID;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+
 import com.hedera.services.context.properties.GlobalDynamicProperties;
 import com.hedera.services.ledger.accounts.AliasManager;
 import com.hedera.services.store.contracts.CodeCache;
@@ -30,6 +40,11 @@ import com.hedera.services.store.models.Account;
 import com.hedera.services.store.models.Id;
 import com.hedera.services.txns.contract.helpers.StorageExpiry;
 import com.hederahashgraph.api.proto.java.HederaFunctionality;
+import java.time.Instant;
+import java.util.Deque;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 import org.apache.tuweni.bytes.Bytes;
 import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.datatypes.Wei;
@@ -49,183 +64,170 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.time.Instant;
-import java.util.Deque;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
-
-import static com.hedera.test.utils.TxnUtils.assertFailsWith;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_CONTRACT_ID;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.mock;
-
 @ExtendWith(MockitoExtension.class)
 class CallLocalEvmTxProcessorTest {
-	private static final int MAX_STACK_SIZE = 1024;
+    private static final int MAX_STACK_SIZE = 1024;
 
-	@Mock
-	private LivePricesSource livePricesSource;
-	@Mock
-	private HederaWorldState worldState;
-	@Mock
-	private CodeCache codeCache;
-	@Mock
-	private GlobalDynamicProperties globalDynamicProperties;
-	@Mock
-	private GasCalculator gasCalculator;
-	@Mock
-	private Set<Operation> operations;
-	@Mock
-	private Transaction transaction;
-	@Mock
-	private HederaWorldState.Updater updater;
-	@Mock
-	private Map<String, PrecompiledContract> precompiledContractMap;
-	@Mock
-	private AliasManager aliasManager;
-	@Mock
-	private StorageExpiry storageExpiry;
-	@Mock
-	private StorageExpiry.Oracle oracle;
-	@Mock
-	private BlockMetaSource blockMetaSource;
-	@Mock
-	private HederaBlockValues hederaBlockValues;
+    @Mock private LivePricesSource livePricesSource;
+    @Mock private HederaWorldState worldState;
+    @Mock private CodeCache codeCache;
+    @Mock private GlobalDynamicProperties globalDynamicProperties;
+    @Mock private GasCalculator gasCalculator;
+    @Mock private Set<Operation> operations;
+    @Mock private Transaction transaction;
+    @Mock private HederaWorldState.Updater updater;
+    @Mock private Map<String, PrecompiledContract> precompiledContractMap;
+    @Mock private AliasManager aliasManager;
+    @Mock private StorageExpiry storageExpiry;
+    @Mock private StorageExpiry.Oracle oracle;
+    @Mock private BlockMetaSource blockMetaSource;
+    @Mock private HederaBlockValues hederaBlockValues;
 
-	private final Account sender = new Account(new Id(0, 0, 1002));
-	private final Account receiver = new Account(new Id(0, 0, 1006));
-	private final Address receiverAddress = receiver.getId().asEvmAddress();
-	private final Instant consensusTime = Instant.now();
+    private final Account sender = new Account(new Id(0, 0, 1002));
+    private final Account receiver = new Account(new Id(0, 0, 1006));
+    private final Address receiverAddress = receiver.getId().asEvmAddress();
+    private final Instant consensusTime = Instant.now();
 
-	private CallLocalEvmTxProcessor callLocalEvmTxProcessor;
+    private CallLocalEvmTxProcessor callLocalEvmTxProcessor;
 
-	@BeforeEach
-	private void setup() {
-		CommonProcessorSetup.setup(gasCalculator);
+    @BeforeEach
+    private void setup() {
+        CommonProcessorSetup.setup(gasCalculator);
 
-		callLocalEvmTxProcessor = new CallLocalEvmTxProcessor(
-				codeCache, livePricesSource, globalDynamicProperties,
-				gasCalculator, operations, precompiledContractMap, aliasManager, storageExpiry);
+        callLocalEvmTxProcessor =
+                new CallLocalEvmTxProcessor(
+                        codeCache,
+                        livePricesSource,
+                        globalDynamicProperties,
+                        gasCalculator,
+                        operations,
+                        precompiledContractMap,
+                        aliasManager,
+                        storageExpiry);
 
-		callLocalEvmTxProcessor.setWorldState(worldState);
-		callLocalEvmTxProcessor.setBlockMetaSource(blockMetaSource);
-	}
+        callLocalEvmTxProcessor.setWorldState(worldState);
+        callLocalEvmTxProcessor.setBlockMetaSource(blockMetaSource);
+    }
 
-	@Test
-	void assertSuccessExecutе() {
-		givenValidMock();
-		given(blockMetaSource.computeBlockValues(anyLong())).willReturn(hederaBlockValues);
-		given(storageExpiry.hapiStaticCallOracle()).willReturn(oracle);
-		final var receiverAddress = receiver.getId().asEvmAddress();
-		given(aliasManager.resolveForEvm(receiverAddress)).willReturn(receiverAddress);
-		var result = callLocalEvmTxProcessor.execute(
-				sender, receiverAddress, 33_333L, 1234L, Bytes.EMPTY, consensusTime);
-		assertTrue(result.isSuccessful());
-		assertEquals(receiver.getId().asGrpcContract(), result.toGrpc().getContractID());
-	}
+    @Test
+    void assertSuccessExecutе() {
+        givenValidMock();
+        given(blockMetaSource.computeBlockValues(anyLong())).willReturn(hederaBlockValues);
+        given(storageExpiry.hapiStaticCallOracle()).willReturn(oracle);
+        final var receiverAddress = receiver.getId().asEvmAddress();
+        given(aliasManager.resolveForEvm(receiverAddress)).willReturn(receiverAddress);
+        var result =
+                callLocalEvmTxProcessor.execute(
+                        sender, receiverAddress, 33_333L, 1234L, Bytes.EMPTY, consensusTime);
+        assertTrue(result.isSuccessful());
+        assertEquals(receiver.getId().asGrpcContract(), result.toGrpc().getContractID());
+    }
 
+    @Test
+    void throwsWhenCodeCacheFailsLoading() {
+        given(worldState.updater()).willReturn(updater);
+        given(worldState.updater().updater()).willReturn(updater);
+        given(storageExpiry.hapiStaticCallOracle()).willReturn(oracle);
+        given(globalDynamicProperties.fundingAccount())
+                .willReturn(new Id(0, 0, 1010).asGrpcAccount());
 
-	@Test
-	void throwsWhenCodeCacheFailsLoading() {
-		given(worldState.updater()).willReturn(updater);
-		given(worldState.updater().updater()).willReturn(updater);
-		given(storageExpiry.hapiStaticCallOracle()).willReturn(oracle);
-		given(globalDynamicProperties.fundingAccount()).willReturn(new Id(0, 0, 1010).asGrpcAccount());
+        var evmAccount = mock(EvmAccount.class);
 
-		var evmAccount = mock(EvmAccount.class);
+        given(gasCalculator.transactionIntrinsicGasCost(Bytes.EMPTY, false)).willReturn(0L);
 
-		given(gasCalculator.transactionIntrinsicGasCost(Bytes.EMPTY, false)).willReturn(0L);
+        given(updater.getOrCreateSenderAccount(sender.getId().asEvmAddress()))
+                .willReturn(evmAccount);
+        given(updater.getOrCreateSenderAccount(sender.getId().asEvmAddress()).getMutable())
+                .willReturn(mock(MutableAccount.class));
+        given(worldState.updater()).willReturn(updater);
 
-		given(updater.getOrCreateSenderAccount(sender.getId().asEvmAddress())).willReturn(evmAccount);
-		given(updater.getOrCreateSenderAccount(sender.getId().asEvmAddress()).getMutable()).willReturn(
-				mock(MutableAccount.class));
-		given(worldState.updater()).willReturn(updater);
+        var senderMutableAccount = mock(MutableAccount.class);
 
-		var senderMutableAccount = mock(MutableAccount.class);
+        given(updater.getSenderAccount(any())).willReturn(evmAccount);
+        given(updater.getSenderAccount(any()).getMutable()).willReturn(senderMutableAccount);
+        given(updater.getOrCreate(any())).willReturn(evmAccount);
+        given(updater.getOrCreate(any()).getMutable()).willReturn(senderMutableAccount);
 
-		given(updater.getSenderAccount(any())).willReturn(evmAccount);
-		given(updater.getSenderAccount(any()).getMutable()).willReturn(senderMutableAccount);
-		given(updater.getOrCreate(any())).willReturn(evmAccount);
-		given(updater.getOrCreate(any()).getMutable()).willReturn(senderMutableAccount);
+        assertFailsWith(
+                () ->
+                        callLocalEvmTxProcessor.execute(
+                                sender,
+                                receiverAddress,
+                                33_333L,
+                                1234L,
+                                Bytes.EMPTY,
+                                consensusTime),
+                INVALID_CONTRACT_ID);
+    }
 
-		assertFailsWith(() ->
-						callLocalEvmTxProcessor.execute(
-								sender, receiverAddress, 33_333L, 1234L, Bytes.EMPTY, consensusTime),
-				INVALID_CONTRACT_ID);
-	}
+    @Test
+    void assertIsContractCallFunctionality() {
+        // expect:
+        assertEquals(
+                HederaFunctionality.ContractCallLocal, callLocalEvmTxProcessor.getFunctionType());
+    }
 
-	@Test
-	void assertIsContractCallFunctionality() {
-		//expect:
-		assertEquals(HederaFunctionality.ContractCallLocal, callLocalEvmTxProcessor.getFunctionType());
-	}
+    @Test
+    void assertTransactionSenderAndValue() {
+        // setup:
+        doReturn(Optional.of(receiver.getId().asEvmAddress())).when(transaction).getTo();
+        given(codeCache.getIfPresent(any())).willReturn(Code.EMPTY);
+        given(transaction.getSender()).willReturn(sender.getId().asEvmAddress());
+        given(transaction.getValue()).willReturn(Wei.of(1L));
+        final MessageFrame.Builder commonInitialFrame =
+                MessageFrame.builder()
+                        .messageFrameStack(mock(Deque.class))
+                        .maxStackSize(MAX_STACK_SIZE)
+                        .worldUpdater(mock(WorldUpdater.class))
+                        .initialGas(1_000_000L)
+                        .originator(sender.getId().asEvmAddress())
+                        .gasPrice(Wei.ZERO)
+                        .sender(sender.getId().asEvmAddress())
+                        .value(Wei.of(transaction.getValue().getAsBigInteger()))
+                        .apparentValue(Wei.of(transaction.getValue().getAsBigInteger()))
+                        .blockValues(mock(BlockValues.class))
+                        .depth(0)
+                        .completer(__ -> {})
+                        .miningBeneficiary(Address.ZERO)
+                        .blockHashLookup(h -> null);
+        // when:
+        MessageFrame buildMessageFrame =
+                callLocalEvmTxProcessor.buildInitialFrame(
+                        commonInitialFrame, (Address) transaction.getTo().get(), Bytes.EMPTY, 0L);
 
-	@Test
-	void assertTransactionSenderAndValue() {
-		// setup:
-		doReturn(Optional.of(receiver.getId().asEvmAddress())).when(transaction).getTo();
-		given(codeCache.getIfPresent(any())).willReturn(Code.EMPTY);
-		given(transaction.getSender()).willReturn(sender.getId().asEvmAddress());
-		given(transaction.getValue()).willReturn(Wei.of(1L));
-		final MessageFrame.Builder commonInitialFrame =
-				MessageFrame.builder()
-						.messageFrameStack(mock(Deque.class))
-						.maxStackSize(MAX_STACK_SIZE)
-						.worldUpdater(mock(WorldUpdater.class))
-						.initialGas(1_000_000L)
-						.originator(sender.getId().asEvmAddress())
-						.gasPrice(Wei.ZERO)
-						.sender(sender.getId().asEvmAddress())
-						.value(Wei.of(transaction.getValue().getAsBigInteger()))
-						.apparentValue(Wei.of(transaction.getValue().getAsBigInteger()))
-						.blockValues(mock(BlockValues.class))
-						.depth(0)
-						.completer(__ -> {
-						})
-						.miningBeneficiary(Address.ZERO)
-						.blockHashLookup(h -> null);
-		//when:
-		MessageFrame buildMessageFrame = callLocalEvmTxProcessor.buildInitialFrame(commonInitialFrame,
-				(Address) transaction.getTo().get(), Bytes.EMPTY, 0L);
+        // expect:
+        assertEquals(transaction.getSender(), buildMessageFrame.getSenderAddress());
+        assertEquals(transaction.getValue(), buildMessageFrame.getApparentValue());
+    }
 
-		//expect:
-		assertEquals(transaction.getSender(), buildMessageFrame.getSenderAddress());
-		assertEquals(transaction.getValue(), buildMessageFrame.getApparentValue());
-	}
+    private void givenValidMock() {
+        given(worldState.updater()).willReturn(updater);
+        given(worldState.updater().updater()).willReturn(updater);
+        given(globalDynamicProperties.fundingAccount())
+                .willReturn(new Id(0, 0, 1010).asGrpcAccount());
 
-	private void givenValidMock() {
-		given(worldState.updater()).willReturn(updater);
-		given(worldState.updater().updater()).willReturn(updater);
-		given(globalDynamicProperties.fundingAccount()).willReturn(new Id(0, 0, 1010).asGrpcAccount());
+        var evmAccount = mock(EvmAccount.class);
 
-		var evmAccount = mock(EvmAccount.class);
+        given(gasCalculator.transactionIntrinsicGasCost(Bytes.EMPTY, false)).willReturn(0L);
 
-		given(gasCalculator.transactionIntrinsicGasCost(Bytes.EMPTY, false)).willReturn(0L);
+        given(updater.getOrCreateSenderAccount(sender.getId().asEvmAddress()))
+                .willReturn(evmAccount);
+        given(updater.getOrCreateSenderAccount(sender.getId().asEvmAddress()).getMutable())
+                .willReturn(mock(MutableAccount.class));
+        given(worldState.updater()).willReturn(updater);
+        given(codeCache.getIfPresent(any())).willReturn(Code.EMPTY);
 
-		given(updater.getOrCreateSenderAccount(sender.getId().asEvmAddress())).willReturn(evmAccount);
-		given(updater.getOrCreateSenderAccount(sender.getId().asEvmAddress()).getMutable()).willReturn(
-				mock(MutableAccount.class));
-		given(worldState.updater()).willReturn(updater);
-		given(codeCache.getIfPresent(any())).willReturn(Code.EMPTY);
+        var senderMutableAccount = mock(MutableAccount.class);
+        given(senderMutableAccount.decrementBalance(any())).willReturn(Wei.of(1234L));
+        given(senderMutableAccount.incrementBalance(any())).willReturn(Wei.of(1500L));
 
+        given(gasCalculator.getSelfDestructRefundAmount()).willReturn(0L);
+        given(gasCalculator.getMaxRefundQuotient()).willReturn(2L);
 
-		var senderMutableAccount = mock(MutableAccount.class);
-		given(senderMutableAccount.decrementBalance(any())).willReturn(Wei.of(1234L));
-		given(senderMutableAccount.incrementBalance(any())).willReturn(Wei.of(1500L));
-
-		given(gasCalculator.getSelfDestructRefundAmount()).willReturn(0L);
-		given(gasCalculator.getMaxRefundQuotient()).willReturn(2L);
-
-		given(updater.getSenderAccount(any())).willReturn(evmAccount);
-		given(updater.getSenderAccount(any()).getMutable()).willReturn(senderMutableAccount);
-		given(updater.getOrCreate(any())).willReturn(evmAccount);
-		given(updater.getOrCreate(any()).getMutable()).willReturn(senderMutableAccount);
-		given(updater.getSbhRefund()).willReturn(0L);
-	}
+        given(updater.getSenderAccount(any())).willReturn(evmAccount);
+        given(updater.getSenderAccount(any()).getMutable()).willReturn(senderMutableAccount);
+        given(updater.getOrCreate(any())).willReturn(evmAccount);
+        given(updater.getOrCreate(any()).getMutable()).willReturn(senderMutableAccount);
+        given(updater.getSbhRefund()).willReturn(0L);
+    }
 }

--- a/hedera-node/src/test/java/com/hedera/services/contracts/execution/CallLocalEvmTxProcessorTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/contracts/execution/CallLocalEvmTxProcessorTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2021-2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hedera.services.contracts.execution;
 
 /*

--- a/hedera-node/src/test/java/com/hedera/services/contracts/execution/CallLocalExecutorTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/contracts/execution/CallLocalExecutorTest.java
@@ -1,11 +1,6 @@
-package com.hedera.services.contracts.execution;
-
-/*-
- * ‌
- * Hedera Services Node
- * ​
- * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
- * ​
+/*
+ * Copyright (C) 2021-2022 Hedera Hashgraph, LLC
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -17,8 +12,8 @@ package com.hedera.services.contracts.execution;
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- * ‍
  */
+package com.hedera.services.contracts.execution;
 
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.CONTRACT_REVERT_EXECUTED;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_ACCOUNT_ID;

--- a/hedera-node/src/test/java/com/hedera/services/contracts/execution/CommonProcessorSetup.java
+++ b/hedera-node/src/test/java/com/hedera/services/contracts/execution/CommonProcessorSetup.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2021-2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hedera.services.contracts.execution;
 
 /*

--- a/hedera-node/src/test/java/com/hedera/services/contracts/execution/CommonProcessorSetup.java
+++ b/hedera-node/src/test/java/com/hedera/services/contracts/execution/CommonProcessorSetup.java
@@ -22,22 +22,22 @@ package com.hedera.services.contracts.execution;
  *
  */
 
-import org.hyperledger.besu.evm.gascalculator.GasCalculator;
-
 import static org.mockito.BDDMockito.given;
 
+import org.hyperledger.besu.evm.gascalculator.GasCalculator;
+
 public class CommonProcessorSetup {
-	static void setup(GasCalculator gasCalculator) {
-		given(gasCalculator.getVeryLowTierGasCost()).willReturn(3L);
-		given(gasCalculator.getLowTierGasCost()).willReturn(5L);
-		given(gasCalculator.getMidTierGasCost()).willReturn(8L);
-		given(gasCalculator.getBaseTierGasCost()).willReturn(2L);
-		given(gasCalculator.getBlockHashOperationGasCost()).willReturn(20L);
-		given(gasCalculator.getWarmStorageReadCost()).willReturn(160L);
-		given(gasCalculator.getColdSloadCost()).willReturn(2100L);
-		given(gasCalculator.getSloadOperationGasCost()).willReturn(0L);
-		given(gasCalculator.getHighTierGasCost()).willReturn(10L);
-		given(gasCalculator.getJumpDestOperationGasCost()).willReturn(1L);
-		given(gasCalculator.getZeroTierGasCost()).willReturn(0L);
-	}
+    static void setup(GasCalculator gasCalculator) {
+        given(gasCalculator.getVeryLowTierGasCost()).willReturn(3L);
+        given(gasCalculator.getLowTierGasCost()).willReturn(5L);
+        given(gasCalculator.getMidTierGasCost()).willReturn(8L);
+        given(gasCalculator.getBaseTierGasCost()).willReturn(2L);
+        given(gasCalculator.getBlockHashOperationGasCost()).willReturn(20L);
+        given(gasCalculator.getWarmStorageReadCost()).willReturn(160L);
+        given(gasCalculator.getColdSloadCost()).willReturn(2100L);
+        given(gasCalculator.getSloadOperationGasCost()).willReturn(0L);
+        given(gasCalculator.getHighTierGasCost()).willReturn(10L);
+        given(gasCalculator.getJumpDestOperationGasCost()).willReturn(1L);
+        given(gasCalculator.getZeroTierGasCost()).willReturn(0L);
+    }
 }

--- a/hedera-node/src/test/java/com/hedera/services/contracts/execution/CreateEvmTxProcessorTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/contracts/execution/CreateEvmTxProcessorTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2021-2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hedera.services.contracts.execution;
 
 /*
@@ -220,15 +235,15 @@ class CreateEvmTxProcessorTest {
                         0,
                         Bytes.fromHexString(
                                 "6080604052348015600f57600080fd5b506000604e576040517f08c379a"
-                                        + "00000000000000000000000000000000000000000000000000000000081"
-                                        + "526004016045906071565b60405180910390fd5b60c9565b6000605d601"
-                                        + "183608f565b915060668260a0565b602082019050919050565b60006020"
-                                        + "8201905081810360008301526088816052565b9050919050565b6000828"
-                                        + "25260208201905092915050565b7f636f756c64206e6f74206578656375"
-                                        + "7465000000000000000000000000000000600082015250565b603f80610"
-                                        + "0d76000396000f3fe6080604052600080fdfea2646970667358221220d8"
-                                        + "2b5e4f0118f9b6972aae9287dfe93930fdbc1e62ca10ea7ac70bde1c0ad"
-                                        + "d2464736f6c63430008070033"),
+                                    + "00000000000000000000000000000000000000000000000000000000081"
+                                    + "526004016045906071565b60405180910390fd5b60c9565b6000605d601"
+                                    + "183608f565b915060668260a0565b602082019050919050565b60006020"
+                                    + "8201905081810360008301526088816052565b9050919050565b6000828"
+                                    + "25260208201905092915050565b7f636f756c64206e6f74206578656375"
+                                    + "7465000000000000000000000000000000600082015250565b603f80610"
+                                    + "0d76000396000f3fe6080604052600080fdfea2646970667358221220d8"
+                                    + "2b5e4f0118f9b6972aae9287dfe93930fdbc1e62ca10ea7ac70bde1c0ad"
+                                    + "d2464736f6c63430008070033"),
                         consensusTime,
                         expiry);
 

--- a/hedera-node/src/test/java/com/hedera/services/contracts/execution/CreateEvmTxProcessorTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/contracts/execution/CreateEvmTxProcessorTest.java
@@ -22,6 +22,18 @@ package com.hedera.services.contracts.execution;
  *
  */
 
+import static com.hedera.test.utils.TxnUtils.assertFailsWith;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INSUFFICIENT_GAS;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
 import com.hedera.services.context.properties.GlobalDynamicProperties;
 import com.hedera.services.store.contracts.CodeCache;
 import com.hedera.services.store.contracts.HederaWorldState;
@@ -30,6 +42,12 @@ import com.hedera.services.store.models.Id;
 import com.hedera.services.txns.contract.helpers.StorageExpiry;
 import com.hederahashgraph.api.proto.java.HederaFunctionality;
 import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
+import java.math.BigInteger;
+import java.time.Instant;
+import java.util.Deque;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 import org.apache.tuweni.bytes.Bytes;
 import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.datatypes.Wei;
@@ -48,331 +66,364 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.math.BigInteger;
-import java.time.Instant;
-import java.util.Deque;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
-
-import static com.hedera.test.utils.TxnUtils.assertFailsWith;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INSUFFICIENT_GAS;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-
 @ExtendWith(MockitoExtension.class)
 class CreateEvmTxProcessorTest {
-	private static final int MAX_STACK_SIZE = 1024;
+    private static final int MAX_STACK_SIZE = 1024;
 
-	@Mock
-	private LivePricesSource livePricesSource;
-	@Mock
-	private HederaWorldState worldState;
-	@Mock
-	private CodeCache codeCache;
-	@Mock
-	private GlobalDynamicProperties globalDynamicProperties;
-	@Mock
-	private GasCalculator gasCalculator;
-	@Mock
-	private Set<Operation> operations;
-	@Mock
-	private Transaction transaction;
-	@Mock
-	private HederaWorldState.Updater updater;
-	@Mock
-	private Map<String, PrecompiledContract> precompiledContractMap;
-	@Mock
-	private StorageExpiry storageExpiry;
-	@Mock
-	private StorageExpiry.Oracle oracle;
-	@Mock
-	private InHandleBlockMetaSource blockMetaSource;
-	@Mock
-	private HederaBlockValues hederaBlockValues;
+    @Mock private LivePricesSource livePricesSource;
+    @Mock private HederaWorldState worldState;
+    @Mock private CodeCache codeCache;
+    @Mock private GlobalDynamicProperties globalDynamicProperties;
+    @Mock private GasCalculator gasCalculator;
+    @Mock private Set<Operation> operations;
+    @Mock private Transaction transaction;
+    @Mock private HederaWorldState.Updater updater;
+    @Mock private Map<String, PrecompiledContract> precompiledContractMap;
+    @Mock private StorageExpiry storageExpiry;
+    @Mock private StorageExpiry.Oracle oracle;
+    @Mock private InHandleBlockMetaSource blockMetaSource;
+    @Mock private HederaBlockValues hederaBlockValues;
 
-	private CreateEvmTxProcessor createEvmTxProcessor;
-	private final Account sender = new Account(new Id(0, 0, 1002));
-	private final Account receiver = new Account(new Id(0, 0, 1006));
-	private final Account relayer = new Account(new Id(0, 0, 1007));
-	private final Instant consensusTime = Instant.now();
-	private final long expiry = 123456L;
-	private final int MAX_GAS_LIMIT = 10_000_000;
-	private final int MAX_REFUND_PERCENT = 20;
-	private final long INTRINSIC_GAS_COST = 290_000L;
-	private final long GAS_LIMIT = 300_000L;
+    private CreateEvmTxProcessor createEvmTxProcessor;
+    private final Account sender = new Account(new Id(0, 0, 1002));
+    private final Account receiver = new Account(new Id(0, 0, 1006));
+    private final Account relayer = new Account(new Id(0, 0, 1007));
+    private final Instant consensusTime = Instant.now();
+    private final long expiry = 123456L;
+    private final int MAX_GAS_LIMIT = 10_000_000;
+    private final int MAX_REFUND_PERCENT = 20;
+    private final long INTRINSIC_GAS_COST = 290_000L;
+    private final long GAS_LIMIT = 300_000L;
 
-	@BeforeEach
-	private void setup() {
-		CommonProcessorSetup.setup(gasCalculator);
+    @BeforeEach
+    private void setup() {
+        CommonProcessorSetup.setup(gasCalculator);
 
-		createEvmTxProcessor = new CreateEvmTxProcessor(
-				worldState,
-				livePricesSource, codeCache, globalDynamicProperties,
-				gasCalculator, operations, precompiledContractMap, storageExpiry, blockMetaSource);
-	}
+        createEvmTxProcessor =
+                new CreateEvmTxProcessor(
+                        worldState,
+                        livePricesSource,
+                        codeCache,
+                        globalDynamicProperties,
+                        gasCalculator,
+                        operations,
+                        precompiledContractMap,
+                        storageExpiry,
+                        blockMetaSource);
+    }
 
-	@Test
-	void assertSuccessfulExecution() {
-		givenValidMock(true);
-		givenSenderWithBalance(350_000L);
-		given(storageExpiry.hapiCreationOracle(expiry)).willReturn(oracle);
-		var result = createEvmTxProcessor.execute(sender, receiver.getId().asEvmAddress(), 33_333L, 1234L, Bytes.EMPTY,
-				consensusTime, expiry);
-		assertTrue(result.isSuccessful());
-		assertEquals(receiver.getId().asGrpcContract(), result.toGrpc().getContractID());
-		verify(codeCache).invalidate(receiver.getId().asEvmAddress());
-	}
+    @Test
+    void assertSuccessfulExecution() {
+        givenValidMock(true);
+        givenSenderWithBalance(350_000L);
+        given(storageExpiry.hapiCreationOracle(expiry)).willReturn(oracle);
+        var result =
+                createEvmTxProcessor.execute(
+                        sender,
+                        receiver.getId().asEvmAddress(),
+                        33_333L,
+                        1234L,
+                        Bytes.EMPTY,
+                        consensusTime,
+                        expiry);
+        assertTrue(result.isSuccessful());
+        assertEquals(receiver.getId().asGrpcContract(), result.toGrpc().getContractID());
+        verify(codeCache).invalidate(receiver.getId().asEvmAddress());
+    }
 
-	@Test
-	void assertSuccessfulExecutionEth() {
-		givenValidMockEth(true);
+    @Test
+    void assertSuccessfulExecutionEth() {
+        givenValidMockEth(true);
 
-		given(storageExpiry.hapiCreationOracle(expiry)).willReturn(oracle);
-		var evmAccount = mock(EvmAccount.class);
-		given(updater.getOrCreateSenderAccount(any())).willReturn(evmAccount);
-		var senderMutableAccount = mock(MutableAccount.class);
-		given(evmAccount.getMutable()).willReturn(senderMutableAccount);
-		given(senderMutableAccount.getBalance()).willReturn(Wei.of(2000L));
+        given(storageExpiry.hapiCreationOracle(expiry)).willReturn(oracle);
+        var evmAccount = mock(EvmAccount.class);
+        given(updater.getOrCreateSenderAccount(any())).willReturn(evmAccount);
+        var senderMutableAccount = mock(MutableAccount.class);
+        given(evmAccount.getMutable()).willReturn(senderMutableAccount);
+        given(senderMutableAccount.getBalance()).willReturn(Wei.of(2000L));
 
+        var result =
+                createEvmTxProcessor.executeEth(
+                        sender,
+                        receiver.getId().asEvmAddress(),
+                        33_333L,
+                        1234L,
+                        Bytes.EMPTY,
+                        consensusTime,
+                        expiry,
+                        relayer,
+                        BigInteger.valueOf(10_000L),
+                        55_555L);
+        assertTrue(result.isSuccessful());
+        assertEquals(receiver.getId().asGrpcContract(), result.toGrpc().getContractID());
+        verify(codeCache).invalidate(receiver.getId().asEvmAddress());
+    }
 
-		var result = createEvmTxProcessor.executeEth(sender, receiver.getId().asEvmAddress(), 33_333L, 1234L, Bytes.EMPTY,
-				consensusTime, expiry,  relayer, BigInteger.valueOf(10_000L) , 55_555L);
-		assertTrue(result.isSuccessful());
-		assertEquals(receiver.getId().asGrpcContract(), result.toGrpc().getContractID());
-		verify(codeCache).invalidate(receiver.getId().asEvmAddress());
-	}
+    @Test
+    void assertSuccessExecutionChargesCorrectMinimumGas() {
+        givenValidMock(true);
+        given(globalDynamicProperties.maxGasRefundPercentage()).willReturn(MAX_REFUND_PERCENT);
+        givenSenderWithBalance(350_000L);
+        given(storageExpiry.hapiCreationOracle(expiry)).willReturn(oracle);
+        var result =
+                createEvmTxProcessor.execute(
+                        sender,
+                        receiver.getId().asEvmAddress(),
+                        GAS_LIMIT,
+                        1234L,
+                        Bytes.EMPTY,
+                        consensusTime,
+                        expiry);
+        assertTrue(result.isSuccessful());
+        assertEquals(result.getGasUsed(), GAS_LIMIT - GAS_LIMIT * MAX_REFUND_PERCENT / 100);
+        assertEquals(receiver.getId().asGrpcContract(), result.toGrpc().getContractID());
+    }
 
-	@Test
-	void assertSuccessExecutionChargesCorrectMinimumGas() {
-		givenValidMock(true);
-		given(globalDynamicProperties.maxGasRefundPercentage()).willReturn(MAX_REFUND_PERCENT);
-		givenSenderWithBalance(350_000L);
-		given(storageExpiry.hapiCreationOracle(expiry)).willReturn(oracle);
-		var result = createEvmTxProcessor.execute(sender, receiver.getId().asEvmAddress(),
-				GAS_LIMIT, 1234L, Bytes.EMPTY, consensusTime, expiry);
-		assertTrue(result.isSuccessful());
-		assertEquals(result.getGasUsed(), GAS_LIMIT - GAS_LIMIT * MAX_REFUND_PERCENT / 100);
-		assertEquals(receiver.getId().asGrpcContract(), result.toGrpc().getContractID());
-	}
+    @Test
+    void assertSuccessExecutionChargesCorrectGasWhenGasUsedIsLargerThanMinimum() {
+        givenValidMock(true);
+        given(globalDynamicProperties.maxGasRefundPercentage()).willReturn(5);
+        given(gasCalculator.transactionIntrinsicGasCost(Bytes.EMPTY, true))
+                .willReturn(INTRINSIC_GAS_COST);
+        givenSenderWithBalance(350_000L);
+        given(storageExpiry.hapiCreationOracle(expiry)).willReturn(oracle);
+        var result =
+                createEvmTxProcessor.execute(
+                        sender,
+                        receiver.getId().asEvmAddress(),
+                        GAS_LIMIT,
+                        1234L,
+                        Bytes.EMPTY,
+                        consensusTime,
+                        expiry);
+        assertTrue(result.isSuccessful());
+        assertEquals(INTRINSIC_GAS_COST, result.getGasUsed());
+        assertEquals(receiver.getId().asGrpcContract(), result.toGrpc().getContractID());
+    }
 
-	@Test
-	void assertSuccessExecutionChargesCorrectGasWhenGasUsedIsLargerThanMinimum() {
-		givenValidMock(true);
-		given(globalDynamicProperties.maxGasRefundPercentage()).willReturn(5);
-		given(gasCalculator.transactionIntrinsicGasCost(Bytes.EMPTY, true)).willReturn(INTRINSIC_GAS_COST);
-		givenSenderWithBalance(350_000L);
-		given(storageExpiry.hapiCreationOracle(expiry)).willReturn(oracle);
-		var result = createEvmTxProcessor.execute(sender, receiver.getId().asEvmAddress(),
-				GAS_LIMIT, 1234L, Bytes.EMPTY, consensusTime, expiry);
-		assertTrue(result.isSuccessful());
-		assertEquals(INTRINSIC_GAS_COST, result.getGasUsed());
-		assertEquals(receiver.getId().asGrpcContract(), result.toGrpc().getContractID());
-	}
+    @Test
+    void assertFailedExecution() {
+        givenValidMock(false);
+        // and:
+        given(gasCalculator.mStoreOperationGasCost(any(), anyLong())).willReturn(200L);
+        given(gasCalculator.mLoadOperationGasCost(any(), anyLong())).willReturn(30L);
+        given(gasCalculator.memoryExpansionGasCost(any(), anyLong(), anyLong())).willReturn(5000L);
+        givenSenderWithBalance(350_000L);
+        given(storageExpiry.hapiCreationOracle(expiry)).willReturn(oracle);
 
-	@Test
-	void assertFailedExecution() {
-		givenValidMock(false);
-		// and:
-		given(gasCalculator.mStoreOperationGasCost(any(), anyLong())).willReturn(200L);
-		given(gasCalculator.mLoadOperationGasCost(any(), anyLong())).willReturn(30L);
-		given(gasCalculator.memoryExpansionGasCost(any(), anyLong(), anyLong())).willReturn(5000L);
-		givenSenderWithBalance(350_000L);
-		given(storageExpiry.hapiCreationOracle(expiry)).willReturn(oracle);
+        // when:
+        var result =
+                createEvmTxProcessor.execute(
+                        sender,
+                        receiver.getId().asEvmAddress(),
+                        33_333L,
+                        0,
+                        Bytes.fromHexString(
+                                "6080604052348015600f57600080fd5b506000604e576040517f08c379a"
+                                        + "00000000000000000000000000000000000000000000000000000000081"
+                                        + "526004016045906071565b60405180910390fd5b60c9565b6000605d601"
+                                        + "183608f565b915060668260a0565b602082019050919050565b60006020"
+                                        + "8201905081810360008301526088816052565b9050919050565b6000828"
+                                        + "25260208201905092915050565b7f636f756c64206e6f74206578656375"
+                                        + "7465000000000000000000000000000000600082015250565b603f80610"
+                                        + "0d76000396000f3fe6080604052600080fdfea2646970667358221220d8"
+                                        + "2b5e4f0118f9b6972aae9287dfe93930fdbc1e62ca10ea7ac70bde1c0ad"
+                                        + "d2464736f6c63430008070033"),
+                        consensusTime,
+                        expiry);
 
-		// when:
-		var result = createEvmTxProcessor.execute(
-				sender,
-				receiver.getId().asEvmAddress(),
-				33_333L,
-				0,
-				Bytes.fromHexString(
-						"6080604052348015600f57600080fd5b506000604e576040517f08c379a" +
-								"00000000000000000000000000000000000000000000000000000000081" +
-								"526004016045906071565b60405180910390fd5b60c9565b6000605d601" +
-								"183608f565b915060668260a0565b602082019050919050565b60006020" +
-								"8201905081810360008301526088816052565b9050919050565b6000828" +
-								"25260208201905092915050565b7f636f756c64206e6f74206578656375" +
-								"7465000000000000000000000000000000600082015250565b603f80610" +
-								"0d76000396000f3fe6080604052600080fdfea2646970667358221220d8" +
-								"2b5e4f0118f9b6972aae9287dfe93930fdbc1e62ca10ea7ac70bde1c0ad" +
-								"d2464736f6c63430008070033"),
-				consensusTime,
-				expiry);
+        // then:
+        assertFalse(result.isSuccessful());
+    }
 
-		// then:
-		assertFalse(result.isSuccessful());
-	}
+    @Test
+    void assertIsContractCallFunctionality() {
+        assertEquals(HederaFunctionality.ContractCreate, createEvmTxProcessor.getFunctionType());
+    }
 
-	@Test
-	void assertIsContractCallFunctionality() {
-		assertEquals(HederaFunctionality.ContractCreate, createEvmTxProcessor.getFunctionType());
-	}
+    @Test
+    void assertTransactionSenderAndValue() {
+        // setup:
+        doReturn(Optional.of(receiver.getId().asEvmAddress())).when(transaction).getTo();
+        given(transaction.getSender()).willReturn(sender.getId().asEvmAddress());
+        given(transaction.getValue()).willReturn(Wei.of(1L));
+        final MessageFrame.Builder commonInitialFrame =
+                MessageFrame.builder()
+                        .messageFrameStack(mock(Deque.class))
+                        .maxStackSize(MAX_STACK_SIZE)
+                        .worldUpdater(mock(WorldUpdater.class))
+                        .initialGas(GAS_LIMIT)
+                        .originator(sender.getId().asEvmAddress())
+                        .gasPrice(Wei.ZERO)
+                        .sender(sender.getId().asEvmAddress())
+                        .value(Wei.of(transaction.getValue().getAsBigInteger()))
+                        .apparentValue(Wei.of(transaction.getValue().getAsBigInteger()))
+                        .blockValues(mock(BlockValues.class))
+                        .depth(0)
+                        .completer(__ -> {})
+                        .miningBeneficiary(Address.ZERO)
+                        .blockHashLookup(h -> null);
+        // when:
+        MessageFrame buildMessageFrame =
+                createEvmTxProcessor.buildInitialFrame(
+                        commonInitialFrame, (Address) transaction.getTo().get(), Bytes.EMPTY, 0L);
 
-	@Test
-	void assertTransactionSenderAndValue() {
-		// setup:
-		doReturn(Optional.of(receiver.getId().asEvmAddress())).when(transaction).getTo();
-		given(transaction.getSender()).willReturn(sender.getId().asEvmAddress());
-		given(transaction.getValue()).willReturn(Wei.of(1L));
-		final MessageFrame.Builder commonInitialFrame =
-				MessageFrame.builder()
-						.messageFrameStack(mock(Deque.class))
-						.maxStackSize(MAX_STACK_SIZE)
-						.worldUpdater(mock(WorldUpdater.class))
-						.initialGas(GAS_LIMIT)
-						.originator(sender.getId().asEvmAddress())
-						.gasPrice(Wei.ZERO)
-						.sender(sender.getId().asEvmAddress())
-						.value(Wei.of(transaction.getValue().getAsBigInteger()))
-						.apparentValue(Wei.of(transaction.getValue().getAsBigInteger()))
-						.blockValues(mock(BlockValues.class))
-						.depth(0)
-						.completer(__ -> {
-						})
-						.miningBeneficiary(Address.ZERO)
-						.blockHashLookup(h -> null);
-		//when:
-		MessageFrame buildMessageFrame = createEvmTxProcessor.buildInitialFrame(commonInitialFrame,
-				(Address) transaction.getTo().get(), Bytes.EMPTY, 0L);
+        // expect:
+        assertEquals(transaction.getSender(), buildMessageFrame.getSenderAddress());
+        assertEquals(transaction.getValue(), buildMessageFrame.getApparentValue());
+    }
 
-		//expect:
-		assertEquals(transaction.getSender(), buildMessageFrame.getSenderAddress());
-		assertEquals(transaction.getValue(), buildMessageFrame.getApparentValue());
-	}
+    @Test
+    void throwsWhenSenderCannotCoverUpfrontCost() {
+        givenInvalidMock();
+        givenSenderWithBalance(123);
 
-	@Test
-	void throwsWhenSenderCannotCoverUpfrontCost() {
-		givenInvalidMock();
-		givenSenderWithBalance(123);
+        Address receiver = this.receiver.getId().asEvmAddress();
+        assertFailsWith(
+                () ->
+                        createEvmTxProcessor.execute(
+                                sender,
+                                receiver,
+                                333_333L,
+                                1234L,
+                                Bytes.EMPTY,
+                                consensusTime,
+                                expiry),
+                ResponseCodeEnum.INSUFFICIENT_PAYER_BALANCE);
+    }
 
-		Address receiver = this.receiver.getId().asEvmAddress();
-		assertFailsWith(
-				() -> createEvmTxProcessor
-						.execute(sender, receiver, 333_333L, 1234L, Bytes.EMPTY, consensusTime, expiry),
-				ResponseCodeEnum.INSUFFICIENT_PAYER_BALANCE);
-	}
+    @Test
+    void throwsWhenIntrinsicGasCostExceedsGasLimit() {
+        givenInvalidMock();
+        givenExtantSender();
 
-	@Test
-	void throwsWhenIntrinsicGasCostExceedsGasLimit() {
-		givenInvalidMock();
-		givenExtantSender();
+        Address receiver = this.receiver.getId().asEvmAddress();
+        assertFailsWith(
+                () ->
+                        createEvmTxProcessor.execute(
+                                sender,
+                                receiver,
+                                33_333L,
+                                1234L,
+                                Bytes.EMPTY,
+                                consensusTime,
+                                expiry),
+                INSUFFICIENT_GAS);
+    }
 
-		Address receiver = this.receiver.getId().asEvmAddress();
-		assertFailsWith(
-				() -> createEvmTxProcessor
-						.execute(sender, receiver, 33_333L, 1234L, Bytes.EMPTY, consensusTime, expiry),
-				INSUFFICIENT_GAS);
-	}
+    @Test
+    void throwsWhenIntrinsicGasCostExceedsGasLimitAndGasLimitIsEqualToMaxGasLimit() {
+        givenInvalidMock();
+        givenExtantSender();
+        given(gasCalculator.transactionIntrinsicGasCost(Bytes.EMPTY, true))
+                .willReturn(MAX_GAS_LIMIT + 1L);
 
-	@Test
-	void throwsWhenIntrinsicGasCostExceedsGasLimitAndGasLimitIsEqualToMaxGasLimit() {
-		givenInvalidMock();
-		givenExtantSender();
-		given(gasCalculator.transactionIntrinsicGasCost(Bytes.EMPTY, true)).willReturn(MAX_GAS_LIMIT + 1L);
+        Address receiver = this.receiver.getId().asEvmAddress();
+        assertFailsWith(
+                () ->
+                        createEvmTxProcessor.execute(
+                                sender,
+                                receiver,
+                                33_333L,
+                                1234L,
+                                Bytes.EMPTY,
+                                consensusTime,
+                                expiry),
+                INSUFFICIENT_GAS);
+    }
 
-		Address receiver = this.receiver.getId().asEvmAddress();
-		assertFailsWith(
-				() -> createEvmTxProcessor
-						.execute(sender, receiver, 33_333L, 1234L, Bytes.EMPTY, consensusTime, expiry),
-				INSUFFICIENT_GAS);
-	}
+    private void givenInvalidMock() {
+        given(worldState.updater()).willReturn(updater);
+        given(gasCalculator.transactionIntrinsicGasCost(Bytes.EMPTY, true)).willReturn(100_000L);
+    }
 
-	private void givenInvalidMock() {
-		given(worldState.updater()).willReturn(updater);
-		given(gasCalculator.transactionIntrinsicGasCost(Bytes.EMPTY, true)).willReturn(100_000L);
-	}
+    private void givenValidMock(boolean expectedSuccess) {
+        given(worldState.updater()).willReturn(updater);
+        given(worldState.updater().updater()).willReturn(updater);
+        given(globalDynamicProperties.fundingAccount())
+                .willReturn(new Id(0, 0, 1010).asGrpcAccount());
 
-	private void givenValidMock(boolean expectedSuccess) {
-		given(worldState.updater()).willReturn(updater);
-		given(worldState.updater().updater()).willReturn(updater);
-		given(globalDynamicProperties.fundingAccount()).willReturn(new Id(0, 0, 1010).asGrpcAccount());
+        var evmAccount = mock(EvmAccount.class);
 
-		var evmAccount = mock(EvmAccount.class);
+        given(updater.getOrCreateSenderAccount(sender.getId().asEvmAddress()))
+                .willReturn(evmAccount);
+        given(worldState.updater()).willReturn(updater);
 
-		given(updater.getOrCreateSenderAccount(sender.getId().asEvmAddress())).willReturn(evmAccount);
-		given(worldState.updater()).willReturn(updater);
+        given(gasCalculator.transactionIntrinsicGasCost(Bytes.EMPTY, true)).willReturn(0L);
 
-		given(gasCalculator.transactionIntrinsicGasCost(Bytes.EMPTY, true)).willReturn(0L);
+        var senderMutableAccount = mock(MutableAccount.class);
+        given(senderMutableAccount.decrementBalance(any())).willReturn(Wei.of(1234L));
+        given(senderMutableAccount.incrementBalance(any())).willReturn(Wei.of(1500L));
+        given(senderMutableAccount.getNonce()).willReturn(0L);
+        given(senderMutableAccount.getCode()).willReturn(Bytes.EMPTY);
 
-		var senderMutableAccount = mock(MutableAccount.class);
-		given(senderMutableAccount.decrementBalance(any())).willReturn(Wei.of(1234L));
-		given(senderMutableAccount.incrementBalance(any())).willReturn(Wei.of(1500L));
-		given(senderMutableAccount.getNonce()).willReturn(0L);
-		given(senderMutableAccount.getCode()).willReturn(Bytes.EMPTY);
+        if (expectedSuccess) {
+            given(gasCalculator.codeDepositGasCost(0)).willReturn(0L);
+        }
+        given(gasCalculator.getSelfDestructRefundAmount()).willReturn(0L);
+        given(gasCalculator.getMaxRefundQuotient()).willReturn(2L);
 
-		if (expectedSuccess) {
-			given(gasCalculator.codeDepositGasCost(0)).willReturn(0L);
-		}
-		given(gasCalculator.getSelfDestructRefundAmount()).willReturn(0L);
-		given(gasCalculator.getMaxRefundQuotient()).willReturn(2L);
+        given(updater.getSenderAccount(any())).willReturn(evmAccount);
+        given(updater.getSenderAccount(any()).getMutable()).willReturn(senderMutableAccount);
+        given(updater.getOrCreate(any())).willReturn(evmAccount);
+        given(updater.getOrCreate(any()).getMutable()).willReturn(senderMutableAccount);
+        given(updater.getSbhRefund()).willReturn(0L);
 
-		given(updater.getSenderAccount(any())).willReturn(evmAccount);
-		given(updater.getSenderAccount(any()).getMutable()).willReturn(senderMutableAccount);
-		given(updater.getOrCreate(any())).willReturn(evmAccount);
-		given(updater.getOrCreate(any()).getMutable()).willReturn(senderMutableAccount);
-		given(updater.getSbhRefund()).willReturn(0L);
+        given(updater.getSenderAccount(any())).willReturn(evmAccount);
+        given(updater.getSenderAccount(any()).getMutable()).willReturn(senderMutableAccount);
+        given(updater.updater().getOrCreate(any()).getMutable()).willReturn(senderMutableAccount);
+        given(blockMetaSource.computeBlockValues(anyLong())).willReturn(hederaBlockValues);
+    }
 
-		given(updater.getSenderAccount(any())).willReturn(evmAccount);
-		given(updater.getSenderAccount(any()).getMutable()).willReturn(senderMutableAccount);
-		given(updater.updater().getOrCreate(any()).getMutable()).willReturn(senderMutableAccount);
-		given(blockMetaSource.computeBlockValues(anyLong())).willReturn(hederaBlockValues);
-	}
+    private void givenValidMockEth(boolean expectedSuccess) {
+        given(worldState.updater()).willReturn(updater);
+        given(worldState.updater().updater()).willReturn(updater);
+        given(globalDynamicProperties.fundingAccount())
+                .willReturn(new Id(0, 0, 1010).asGrpcAccount());
 
-	private void givenValidMockEth(boolean expectedSuccess) {
-		given(worldState.updater()).willReturn(updater);
-		given(worldState.updater().updater()).willReturn(updater);
-		given(globalDynamicProperties.fundingAccount()).willReturn(new Id(0, 0, 1010).asGrpcAccount());
+        var evmAccount = mock(EvmAccount.class);
 
-		var evmAccount = mock(EvmAccount.class);
+        given(worldState.updater()).willReturn(updater);
 
-		given(worldState.updater()).willReturn(updater);
+        given(gasCalculator.transactionIntrinsicGasCost(Bytes.EMPTY, true)).willReturn(0L);
 
-		given(gasCalculator.transactionIntrinsicGasCost(Bytes.EMPTY, true)).willReturn(0L);
+        var senderMutableAccount = mock(MutableAccount.class);
+        given(senderMutableAccount.decrementBalance(any())).willReturn(Wei.of(1234L));
+        given(senderMutableAccount.incrementBalance(any())).willReturn(Wei.of(1500L));
+        given(senderMutableAccount.getNonce()).willReturn(0L);
+        given(senderMutableAccount.getCode()).willReturn(Bytes.EMPTY);
 
-		var senderMutableAccount = mock(MutableAccount.class);
-		given(senderMutableAccount.decrementBalance(any())).willReturn(Wei.of(1234L));
-		given(senderMutableAccount.incrementBalance(any())).willReturn(Wei.of(1500L));
-		given(senderMutableAccount.getNonce()).willReturn(0L);
-		given(senderMutableAccount.getCode()).willReturn(Bytes.EMPTY);
+        if (expectedSuccess) {
+            given(gasCalculator.codeDepositGasCost(0)).willReturn(0L);
+        }
+        given(gasCalculator.getSelfDestructRefundAmount()).willReturn(0L);
+        given(gasCalculator.getMaxRefundQuotient()).willReturn(2L);
 
-		if (expectedSuccess) {
-			given(gasCalculator.codeDepositGasCost(0)).willReturn(0L);
-		}
-		given(gasCalculator.getSelfDestructRefundAmount()).willReturn(0L);
-		given(gasCalculator.getMaxRefundQuotient()).willReturn(2L);
+        given(updater.getSenderAccount(any())).willReturn(evmAccount);
+        given(updater.getSenderAccount(any()).getMutable()).willReturn(senderMutableAccount);
+        given(updater.getOrCreate(any())).willReturn(evmAccount);
+        given(updater.getOrCreate(any()).getMutable()).willReturn(senderMutableAccount);
+        given(updater.getSbhRefund()).willReturn(0L);
 
-		given(updater.getSenderAccount(any())).willReturn(evmAccount);
-		given(updater.getSenderAccount(any()).getMutable()).willReturn(senderMutableAccount);
-		given(updater.getOrCreate(any())).willReturn(evmAccount);
-		given(updater.getOrCreate(any()).getMutable()).willReturn(senderMutableAccount);
-		given(updater.getSbhRefund()).willReturn(0L);
+        given(updater.getSenderAccount(any())).willReturn(evmAccount);
+        given(updater.getSenderAccount(any()).getMutable()).willReturn(senderMutableAccount);
+        given(updater.updater().getOrCreate(any()).getMutable()).willReturn(senderMutableAccount);
+        given(blockMetaSource.computeBlockValues(anyLong())).willReturn(hederaBlockValues);
+    }
 
-		given(updater.getSenderAccount(any())).willReturn(evmAccount);
-		given(updater.getSenderAccount(any()).getMutable()).willReturn(senderMutableAccount);
-		given(updater.updater().getOrCreate(any()).getMutable()).willReturn(senderMutableAccount);
-		given(blockMetaSource.computeBlockValues(anyLong())).willReturn(hederaBlockValues);
-	}
+    private void givenExtantSender() {
+        givenSenderWithBalance(-1L);
+    }
 
-	private void givenExtantSender() {
-		givenSenderWithBalance(-1L);
-	}
+    private void givenSenderWithBalance(final long amount) {
+        final var wrappedSenderAccount = mock(EvmAccount.class);
+        final var mutableSenderAccount = mock(MutableAccount.class);
+        given(wrappedSenderAccount.getMutable()).willReturn(mutableSenderAccount);
+        given(updater.getOrCreateSenderAccount(sender.getId().asEvmAddress()))
+                .willReturn(wrappedSenderAccount);
 
-	private void givenSenderWithBalance(final long amount) {
-		final var wrappedSenderAccount = mock(EvmAccount.class);
-		final var mutableSenderAccount = mock(MutableAccount.class);
-		given(wrappedSenderAccount.getMutable()).willReturn(mutableSenderAccount);
-		given(updater.getOrCreateSenderAccount(sender.getId().asEvmAddress())).willReturn(wrappedSenderAccount);
-
-		if (amount >= 0) {
-			given(mutableSenderAccount.getBalance()).willReturn(Wei.of(amount));
-		}
-	}
+        if (amount >= 0) {
+            given(mutableSenderAccount.getBalance()).willReturn(Wei.of(amount));
+        }
+    }
 }

--- a/hedera-node/src/test/java/com/hedera/services/contracts/execution/HederaBlockValuesTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/contracts/execution/HederaBlockValuesTest.java
@@ -23,6 +23,8 @@ package com.hedera.services.contracts.execution;
  */
 
 import com.hedera.services.state.merkle.MerkleNetworkContext;
+import java.time.Instant;
+import java.util.Optional;
 import org.apache.tuweni.units.bigints.UInt256;
 import org.hyperledger.besu.datatypes.Wei;
 import org.junit.jupiter.api.Assertions;
@@ -31,15 +33,11 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.time.Instant;
-import java.util.Optional;
-
 @ExtendWith(MockitoExtension.class)
 class HederaBlockValuesTest {
     HederaBlockValues subject;
 
-    @Mock
-    private MerkleNetworkContext merkleNetworkContext;
+    @Mock private MerkleNetworkContext merkleNetworkContext;
 
     @Test
     void instancing() {

--- a/hedera-node/src/test/java/com/hedera/services/contracts/execution/HederaBlockValuesTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/contracts/execution/HederaBlockValuesTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2020-2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hedera.services.contracts.execution;
 
 /*

--- a/hedera-node/src/test/java/com/hedera/services/contracts/execution/HederaMessageCallProcessorTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/contracts/execution/HederaMessageCallProcessorTest.java
@@ -20,7 +20,20 @@ package com.hedera.services.contracts.execution;
  * ‍
  */
 
+import static org.hyperledger.besu.evm.frame.ExceptionalHaltReason.INSUFFICIENT_GAS;
+import static org.hyperledger.besu.evm.frame.MessageFrame.State.CODE_SUCCESS;
+import static org.hyperledger.besu.evm.frame.MessageFrame.State.COMPLETED_SUCCESS;
+import static org.hyperledger.besu.evm.frame.MessageFrame.State.EXCEPTIONAL_HALT;
+import static org.hyperledger.besu.evm.frame.MessageFrame.State.REVERT;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
 import com.hedera.services.store.contracts.precompile.HTSPrecompiledContract;
+import java.util.Map;
+import java.util.Optional;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.tuweni.bytes.Bytes;
 import org.hyperledger.besu.datatypes.Address;
@@ -37,153 +50,140 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.util.Map;
-import java.util.Optional;
-
-import static org.hyperledger.besu.evm.frame.ExceptionalHaltReason.INSUFFICIENT_GAS;
-import static org.hyperledger.besu.evm.frame.MessageFrame.State.CODE_SUCCESS;
-import static org.hyperledger.besu.evm.frame.MessageFrame.State.COMPLETED_SUCCESS;
-import static org.hyperledger.besu.evm.frame.MessageFrame.State.EXCEPTIONAL_HALT;
-import static org.hyperledger.besu.evm.frame.MessageFrame.State.REVERT;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
-
 @ExtendWith(MockitoExtension.class)
 class HederaMessageCallProcessorTest {
 
-	private static final String HEDERA_PRECOMPILE_ADDRESS_STRING = "0x1337";
-	private static final String HTS_PRECOMPILE_ADDRESS_STRING = "0x167";
-	private static final Address HEDERA_PRECOMPILE_ADDRESS = Address.fromHexString(HEDERA_PRECOMPILE_ADDRESS_STRING);
-	private static final Address HTS_PRECOMPILE_ADDRESS = Address.fromHexString(HTS_PRECOMPILE_ADDRESS_STRING);
-	private static final Address RECIPIENT_ADDRESS = Address.fromHexString("0xcafecafe01");
-	private static final Address SENDER_ADDRESS = Address.fromHexString("0xcafecafe02");
-	private static final PrecompiledContract.PrecompileContractResult NO_RESULT = new PrecompiledContract.PrecompileContractResult(
-			null, true, MessageFrame.State.COMPLETED_FAILED, Optional.empty());
-	private static final PrecompiledContract.PrecompileContractResult RESULT = new PrecompiledContract.PrecompileContractResult(
-			Bytes.of(1), true, MessageFrame.State.COMPLETED_SUCCESS, Optional.empty());
-	private static final long GAS_ONE = 1L;
-	private static final long GAS_ONE_K = 1_000L;
-	private static final long GAS_ONE_M = 1_000_000L;
+    private static final String HEDERA_PRECOMPILE_ADDRESS_STRING = "0x1337";
+    private static final String HTS_PRECOMPILE_ADDRESS_STRING = "0x167";
+    private static final Address HEDERA_PRECOMPILE_ADDRESS =
+            Address.fromHexString(HEDERA_PRECOMPILE_ADDRESS_STRING);
+    private static final Address HTS_PRECOMPILE_ADDRESS =
+            Address.fromHexString(HTS_PRECOMPILE_ADDRESS_STRING);
+    private static final Address RECIPIENT_ADDRESS = Address.fromHexString("0xcafecafe01");
+    private static final Address SENDER_ADDRESS = Address.fromHexString("0xcafecafe02");
+    private static final PrecompiledContract.PrecompileContractResult NO_RESULT =
+            new PrecompiledContract.PrecompileContractResult(
+                    null, true, MessageFrame.State.COMPLETED_FAILED, Optional.empty());
+    private static final PrecompiledContract.PrecompileContractResult RESULT =
+            new PrecompiledContract.PrecompileContractResult(
+                    Bytes.of(1), true, MessageFrame.State.COMPLETED_SUCCESS, Optional.empty());
+    private static final long GAS_ONE = 1L;
+    private static final long GAS_ONE_K = 1_000L;
+    private static final long GAS_ONE_M = 1_000_000L;
 
-	@Mock
-	private EVM evm;
-	@Mock
-	private PrecompileContractRegistry precompiles;
-	@Mock
-	private MessageFrame frame;
-	@Mock
-	private OperationTracer operationTrace;
-	@Mock
-	private WorldUpdater worldUpdater;
-	@Mock
-	private PrecompiledContract nonHtsPrecompile;
-	@Mock
-	private HTSPrecompiledContract htsPrecompile;
+    @Mock private EVM evm;
+    @Mock private PrecompileContractRegistry precompiles;
+    @Mock private MessageFrame frame;
+    @Mock private OperationTracer operationTrace;
+    @Mock private WorldUpdater worldUpdater;
+    @Mock private PrecompiledContract nonHtsPrecompile;
+    @Mock private HTSPrecompiledContract htsPrecompile;
 
-	HederaMessageCallProcessor subject;
+    HederaMessageCallProcessor subject;
 
-	@BeforeEach
-	void setup() {
-		subject = new HederaMessageCallProcessor(evm, precompiles,
-				Map.of(
-						HEDERA_PRECOMPILE_ADDRESS_STRING, nonHtsPrecompile,
-						HTS_PRECOMPILE_ADDRESS_STRING, htsPrecompile));
-	}
+    @BeforeEach
+    void setup() {
+        subject =
+                new HederaMessageCallProcessor(
+                        evm,
+                        precompiles,
+                        Map.of(
+                                HEDERA_PRECOMPILE_ADDRESS_STRING, nonHtsPrecompile,
+                                HTS_PRECOMPILE_ADDRESS_STRING, htsPrecompile));
+    }
 
-	@Test
-	void callsHederaPrecompile() {
-		given(frame.getRemainingGas()).willReturn(1337L);
-		given(frame.getInputData()).willReturn(Bytes.of(1));
-		given(frame.getContractAddress()).willReturn(HEDERA_PRECOMPILE_ADDRESS);
-		given(nonHtsPrecompile.gasRequirement(any())).willReturn(GAS_ONE);
-		given(nonHtsPrecompile.computePrecompile(any(), eq(frame))).willReturn(RESULT);
+    @Test
+    void callsHederaPrecompile() {
+        given(frame.getRemainingGas()).willReturn(1337L);
+        given(frame.getInputData()).willReturn(Bytes.of(1));
+        given(frame.getContractAddress()).willReturn(HEDERA_PRECOMPILE_ADDRESS);
+        given(nonHtsPrecompile.gasRequirement(any())).willReturn(GAS_ONE);
+        given(nonHtsPrecompile.computePrecompile(any(), eq(frame))).willReturn(RESULT);
 
-		subject.start(frame, operationTrace);
+        subject.start(frame, operationTrace);
 
-		verify(nonHtsPrecompile).computePrecompile(Bytes.of(1), frame);
-		verify(operationTrace).tracePrecompileCall(frame, GAS_ONE, Bytes.of(1));
-		verify(frame).decrementRemainingGas(GAS_ONE);
-		verify(frame).setOutputData(Bytes.of(1));
-		verify(frame).setState(COMPLETED_SUCCESS);
-		verifyNoMoreInteractions(nonHtsPrecompile, frame, operationTrace);
-	}
+        verify(nonHtsPrecompile).computePrecompile(Bytes.of(1), frame);
+        verify(operationTrace).tracePrecompileCall(frame, GAS_ONE, Bytes.of(1));
+        verify(frame).decrementRemainingGas(GAS_ONE);
+        verify(frame).setOutputData(Bytes.of(1));
+        verify(frame).setState(COMPLETED_SUCCESS);
+        verifyNoMoreInteractions(nonHtsPrecompile, frame, operationTrace);
+    }
 
-	@Test
-	void treatsHtsPrecompileSpecial() {
-		given(frame.getRemainingGas()).willReturn(1337L);
-		given(frame.getInputData()).willReturn(Bytes.of(1));
-		given(frame.getContractAddress()).willReturn(HTS_PRECOMPILE_ADDRESS);
-		given(frame.getState()).willReturn(CODE_SUCCESS);
-		given(htsPrecompile.computeCosted(any(), eq(frame))).willReturn(Pair.of(GAS_ONE, Bytes.of(1)));
+    @Test
+    void treatsHtsPrecompileSpecial() {
+        given(frame.getRemainingGas()).willReturn(1337L);
+        given(frame.getInputData()).willReturn(Bytes.of(1));
+        given(frame.getContractAddress()).willReturn(HTS_PRECOMPILE_ADDRESS);
+        given(frame.getState()).willReturn(CODE_SUCCESS);
+        given(htsPrecompile.computeCosted(any(), eq(frame)))
+                .willReturn(Pair.of(GAS_ONE, Bytes.of(1)));
 
-		subject.start(frame, operationTrace);
+        subject.start(frame, operationTrace);
 
-		verify(frame).getState();
-		verify(operationTrace).tracePrecompileCall(frame, GAS_ONE, Bytes.of(1));
-		verify(frame).decrementRemainingGas(GAS_ONE);
-		verify(frame).setOutputData(Bytes.of(1));
-		verify(frame).setState(COMPLETED_SUCCESS);
-		verifyNoMoreInteractions(htsPrecompile, frame, operationTrace);
-	}
+        verify(frame).getState();
+        verify(operationTrace).tracePrecompileCall(frame, GAS_ONE, Bytes.of(1));
+        verify(frame).decrementRemainingGas(GAS_ONE);
+        verify(frame).setOutputData(Bytes.of(1));
+        verify(frame).setState(COMPLETED_SUCCESS);
+        verifyNoMoreInteractions(htsPrecompile, frame, operationTrace);
+    }
 
-	@Test
-	void callsParent() {
-		given(frame.getWorldUpdater()).willReturn(worldUpdater);
-		given(frame.getValue()).willReturn(Wei.ZERO);
-		given(frame.getRecipientAddress()).willReturn(RECIPIENT_ADDRESS);
-		given(frame.getSenderAddress()).willReturn(SENDER_ADDRESS);
-		given(frame.getContractAddress()).willReturn(Address.fromHexString("0x1"));
+    @Test
+    void callsParent() {
+        given(frame.getWorldUpdater()).willReturn(worldUpdater);
+        given(frame.getValue()).willReturn(Wei.ZERO);
+        given(frame.getRecipientAddress()).willReturn(RECIPIENT_ADDRESS);
+        given(frame.getSenderAddress()).willReturn(SENDER_ADDRESS);
+        given(frame.getContractAddress()).willReturn(Address.fromHexString("0x1"));
 
-		subject.start(frame, operationTrace);
+        subject.start(frame, operationTrace);
 
-		verify(frame).setState(MessageFrame.State.CODE_EXECUTING);
-		verifyNoMoreInteractions(nonHtsPrecompile, frame, operationTrace);
-	}
+        verify(frame).setState(MessageFrame.State.CODE_EXECUTING);
+        verifyNoMoreInteractions(nonHtsPrecompile, frame, operationTrace);
+    }
 
-	@Test
-	void insufficientGasReverts() {
-		given(frame.getRemainingGas()).willReturn(GAS_ONE_K);
-		given(frame.getInputData()).willReturn(Bytes.EMPTY);
-		given(nonHtsPrecompile.gasRequirement(any())).willReturn(GAS_ONE_M);
-		given(nonHtsPrecompile.computePrecompile(any(), any())).willReturn(NO_RESULT);
+    @Test
+    void insufficientGasReverts() {
+        given(frame.getRemainingGas()).willReturn(GAS_ONE_K);
+        given(frame.getInputData()).willReturn(Bytes.EMPTY);
+        given(nonHtsPrecompile.gasRequirement(any())).willReturn(GAS_ONE_M);
+        given(nonHtsPrecompile.computePrecompile(any(), any())).willReturn(NO_RESULT);
 
-		subject.executeHederaPrecompile(nonHtsPrecompile, frame, operationTrace);
+        subject.executeHederaPrecompile(nonHtsPrecompile, frame, operationTrace);
 
-		verify(frame).setExceptionalHaltReason(Optional.of(INSUFFICIENT_GAS));
-		verify(frame).setState(EXCEPTIONAL_HALT);
-		verify(frame).decrementRemainingGas(GAS_ONE_K);
-		verify(nonHtsPrecompile).computePrecompile(Bytes.EMPTY, frame);
-		verify(operationTrace).tracePrecompileCall(frame, GAS_ONE_M, null);
-		verifyNoMoreInteractions(nonHtsPrecompile, frame, operationTrace);
-	}
+        verify(frame).setExceptionalHaltReason(Optional.of(INSUFFICIENT_GAS));
+        verify(frame).setState(EXCEPTIONAL_HALT);
+        verify(frame).decrementRemainingGas(GAS_ONE_K);
+        verify(nonHtsPrecompile).computePrecompile(Bytes.EMPTY, frame);
+        verify(operationTrace).tracePrecompileCall(frame, GAS_ONE_M, null);
+        verifyNoMoreInteractions(nonHtsPrecompile, frame, operationTrace);
+    }
 
-	@Test
-	void precompileError() {
-		given(frame.getRemainingGas()).willReturn(GAS_ONE_K);
-		given(frame.getInputData()).willReturn(Bytes.EMPTY);
-		given(nonHtsPrecompile.gasRequirement(any())).willReturn(GAS_ONE);
-		given(nonHtsPrecompile.computePrecompile(any(), any())).willReturn(NO_RESULT);
+    @Test
+    void precompileError() {
+        given(frame.getRemainingGas()).willReturn(GAS_ONE_K);
+        given(frame.getInputData()).willReturn(Bytes.EMPTY);
+        given(nonHtsPrecompile.gasRequirement(any())).willReturn(GAS_ONE);
+        given(nonHtsPrecompile.computePrecompile(any(), any())).willReturn(NO_RESULT);
 
-		subject.executeHederaPrecompile(nonHtsPrecompile, frame, operationTrace);
+        subject.executeHederaPrecompile(nonHtsPrecompile, frame, operationTrace);
 
-		verify(frame).setState(EXCEPTIONAL_HALT);
-		verify(operationTrace).tracePrecompileCall(frame, GAS_ONE, null);
-		verifyNoMoreInteractions(nonHtsPrecompile, frame, operationTrace);
-	}
+        verify(frame).setState(EXCEPTIONAL_HALT);
+        verify(operationTrace).tracePrecompileCall(frame, GAS_ONE, null);
+        verifyNoMoreInteractions(nonHtsPrecompile, frame, operationTrace);
+    }
 
-	@Test
-	void revertedPrecompileReturns() {
-		given(frame.getInputData()).willReturn(Bytes.EMPTY);
-		given(htsPrecompile.computeCosted(any(), any())).willReturn(null);
-		given(frame.getState()).willReturn(REVERT);
+    @Test
+    void revertedPrecompileReturns() {
+        given(frame.getInputData()).willReturn(Bytes.EMPTY);
+        given(htsPrecompile.computeCosted(any(), any())).willReturn(null);
+        given(frame.getState()).willReturn(REVERT);
 
-		subject.executeHederaPrecompile(htsPrecompile, frame, operationTrace);
+        subject.executeHederaPrecompile(htsPrecompile, frame, operationTrace);
 
-		verify(frame).getState();
-		verify(htsPrecompile).computeCosted(Bytes.EMPTY, frame);
-		verifyNoMoreInteractions(htsPrecompile, frame, operationTrace);
-	}
+        verify(frame).getState();
+        verify(htsPrecompile).computeCosted(Bytes.EMPTY, frame);
+        verifyNoMoreInteractions(htsPrecompile, frame, operationTrace);
+    }
 }

--- a/hedera-node/src/test/java/com/hedera/services/contracts/execution/HederaMessageCallProcessorTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/contracts/execution/HederaMessageCallProcessorTest.java
@@ -1,11 +1,6 @@
-package com.hedera.services.contracts.execution;
-
-/*-
- * ‌
- * Hedera Services Node
- * ​
- * Copyright (C) 2018 - 2022 Hedera Hashgraph, LLC
- * ​
+/*
+ * Copyright (C) 2022 Hedera Hashgraph, LLC
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -17,8 +12,8 @@ package com.hedera.services.contracts.execution;
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- * ‍
  */
+package com.hedera.services.contracts.execution;
 
 import static org.hyperledger.besu.evm.frame.ExceptionalHaltReason.INSUFFICIENT_GAS;
 import static org.hyperledger.besu.evm.frame.MessageFrame.State.CODE_SUCCESS;

--- a/hedera-node/src/test/java/com/hedera/services/contracts/execution/HederaTracerTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/contracts/execution/HederaTracerTest.java
@@ -22,6 +22,10 @@ package com.hedera.services.contracts.execution;
  *
  */
 
+import static com.hedera.services.contracts.operation.HederaExceptionalHaltReason.INVALID_SOLIDITY_ADDRESS;
+import static org.mockito.Mockito.verify;
+
+import java.util.Optional;
 import org.hyperledger.besu.evm.frame.MessageFrame;
 import org.hyperledger.besu.evm.tracing.OperationTracer;
 import org.junit.jupiter.api.BeforeEach;
@@ -30,20 +34,13 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.util.Optional;
-
-import static com.hedera.services.contracts.operation.HederaExceptionalHaltReason.INVALID_SOLIDITY_ADDRESS;
-import static org.mockito.Mockito.verify;
-
 @ExtendWith(MockitoExtension.class)
 class HederaTracerTest {
     private HederaTracer subject;
 
-    @Mock
-    private MessageFrame mf;
+    @Mock private MessageFrame mf;
 
-    @Mock
-    private OperationTracer.ExecuteOperation eo;
+    @Mock private OperationTracer.ExecuteOperation eo;
 
     @BeforeEach
     void setUp() {

--- a/hedera-node/src/test/java/com/hedera/services/contracts/execution/HederaTracerTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/contracts/execution/HederaTracerTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2020-2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hedera.services.contracts.execution;
 
 /*

--- a/hedera-node/src/test/java/com/hedera/services/contracts/execution/InHandleBlockMetaSourceTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/contracts/execution/InHandleBlockMetaSourceTest.java
@@ -9,9 +9,9 @@ package com.hedera.services.contracts.execution;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,54 +20,51 @@ package com.hedera.services.contracts.execution;
  * ‍
  */
 
+import static com.hedera.services.contracts.execution.BlockMetaSource.UNAVAILABLE_BLOCK_HASH;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.BDDMockito.given;
+
 import com.hedera.services.context.TransactionContext;
 import com.hedera.services.state.logic.BlockManager;
+import java.time.Instant;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.time.Instant;
-
-import static com.hedera.services.contracts.execution.BlockMetaSource.UNAVAILABLE_BLOCK_HASH;
-import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.mockito.BDDMockito.given;
-
 @ExtendWith(MockitoExtension.class)
 class InHandleBlockMetaSourceTest {
-	@Mock
-	private BlockManager blockManager;
-	@Mock
-	private TransactionContext txnCtx;
+    @Mock private BlockManager blockManager;
+    @Mock private TransactionContext txnCtx;
 
-	private InHandleBlockMetaSource subject;
+    private InHandleBlockMetaSource subject;
 
-	@BeforeEach
-	void setUp() {
-		subject = new InHandleBlockMetaSource(blockManager, txnCtx);
-	}
+    @BeforeEach
+    void setUp() {
+        subject = new InHandleBlockMetaSource(blockManager, txnCtx);
+    }
 
-	@Test
-	void delegatesComputeToManagerAtCurrentTime() {
-		final var values = new HederaBlockValues(gasLimit, someBlockNo, then);
+    @Test
+    void delegatesComputeToManagerAtCurrentTime() {
+        final var values = new HederaBlockValues(gasLimit, someBlockNo, then);
 
-		given(txnCtx.consensusTime()).willReturn(then);
-		given(blockManager.computeBlockValues(then, gasLimit)).willReturn(values);
+        given(txnCtx.consensusTime()).willReturn(then);
+        given(blockManager.computeBlockValues(then, gasLimit)).willReturn(values);
 
-		final var actual = subject.computeBlockValues(gasLimit);
+        final var actual = subject.computeBlockValues(gasLimit);
 
-		assertSame(values, actual);
-	}
+        assertSame(values, actual);
+    }
 
-	@Test
-	void delegatesBlockHashToManager() {
-		given(blockManager.getBlockHash(someBlockNo)).willReturn(UNAVAILABLE_BLOCK_HASH);
+    @Test
+    void delegatesBlockHashToManager() {
+        given(blockManager.getBlockHash(someBlockNo)).willReturn(UNAVAILABLE_BLOCK_HASH);
 
-		assertSame(UNAVAILABLE_BLOCK_HASH, subject.getBlockHash(someBlockNo));
-	}
+        assertSame(UNAVAILABLE_BLOCK_HASH, subject.getBlockHash(someBlockNo));
+    }
 
-	private static final long gasLimit = 888L;
-	private static final long someBlockNo = 123L;
-	private static final Instant then = Instant.ofEpochSecond(1_234_567, 890);
+    private static final long gasLimit = 888L;
+    private static final long someBlockNo = 123L;
+    private static final Instant then = Instant.ofEpochSecond(1_234_567, 890);
 }

--- a/hedera-node/src/test/java/com/hedera/services/contracts/execution/InHandleBlockMetaSourceTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/contracts/execution/InHandleBlockMetaSourceTest.java
@@ -1,11 +1,6 @@
-package com.hedera.services.contracts.execution;
-
-/*-
- * ‌
- * Hedera Services Node
- * ​
- * Copyright (C) 2018 - 2022 Hedera Hashgraph, LLC
- * ​
+/*
+ * Copyright (C) 2020-2022 Hedera Hashgraph, LLC
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -17,8 +12,8 @@ package com.hedera.services.contracts.execution;
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- * ‍
  */
+package com.hedera.services.contracts.execution;
 
 import static com.hedera.services.contracts.execution.BlockMetaSource.UNAVAILABLE_BLOCK_HASH;
 import static org.junit.jupiter.api.Assertions.assertSame;

--- a/hedera-node/src/test/java/com/hedera/services/contracts/execution/LivePricesSourceTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/contracts/execution/LivePricesSourceTest.java
@@ -1,11 +1,6 @@
-package com.hedera.services.contracts.execution;
-
-/*-
- * ‌
- * Hedera Services Node
- * ​
- * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
- * ​
+/*
+ * Copyright (C) 2021-2022 Hedera Hashgraph, LLC
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -17,8 +12,8 @@ package com.hedera.services.contracts.execution;
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- * ‍
  */
+package com.hedera.services.contracts.execution;
 
 import static com.hederahashgraph.api.proto.java.HederaFunctionality.ContractCall;
 import static com.hederahashgraph.fee.FeeBuilder.getTinybarsFromTinyCents;

--- a/hedera-node/src/test/java/com/hedera/services/contracts/execution/LivePricesSourceTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/contracts/execution/LivePricesSourceTest.java
@@ -20,6 +20,11 @@ package com.hedera.services.contracts.execution;
  * ‍
  */
 
+import static com.hederahashgraph.api.proto.java.HederaFunctionality.ContractCall;
+import static com.hederahashgraph.fee.FeeBuilder.getTinybarsFromTinyCents;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.BDDMockito.given;
+
 import com.hedera.services.context.TransactionContext;
 import com.hedera.services.fees.FeeMultiplierSource;
 import com.hedera.services.fees.HbarCentExchange;
@@ -30,100 +35,86 @@ import com.hederahashgraph.api.proto.java.ExchangeRate;
 import com.hederahashgraph.api.proto.java.FeeComponents;
 import com.hederahashgraph.api.proto.java.FeeData;
 import com.hederahashgraph.api.proto.java.Timestamp;
+import java.time.Instant;
+import java.util.function.ToLongFunction;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.time.Instant;
-import java.util.function.ToLongFunction;
-
-import static com.hederahashgraph.api.proto.java.HederaFunctionality.ContractCall;
-import static com.hederahashgraph.fee.FeeBuilder.getTinybarsFromTinyCents;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.BDDMockito.given;
-
-
 @ExtendWith(MockitoExtension.class)
 class LivePricesSourceTest {
-	private static final Instant now = Instant.ofEpochSecond(1_234_567L);
-	private static final Timestamp timeNow = MiscUtils.asTimestamp(now);
-	private static final long gasPriceTinybars = 123;
-	private static final long sbhPriceTinybars = 456;
-	private static final FeeComponents servicePrices = FeeComponents.newBuilder()
-			.setGas(gasPriceTinybars * 1000)
-			.setSbh(sbhPriceTinybars * 1000)
-			.build();
-	private static final FeeData providerPrices = FeeData.newBuilder()
-			.setServicedata(servicePrices)
-			.build();
-	private static final ExchangeRate activeRate = ExchangeRate.newBuilder()
-			.setHbarEquiv(1)
-			.setCentEquiv(12)
-			.build();
-	private static final long reasonableMultiplier = 7;
-	private static final long insaneMultiplier = Long.MAX_VALUE / 2;
+    private static final Instant now = Instant.ofEpochSecond(1_234_567L);
+    private static final Timestamp timeNow = MiscUtils.asTimestamp(now);
+    private static final long gasPriceTinybars = 123;
+    private static final long sbhPriceTinybars = 456;
+    private static final FeeComponents servicePrices =
+            FeeComponents.newBuilder()
+                    .setGas(gasPriceTinybars * 1000)
+                    .setSbh(sbhPriceTinybars * 1000)
+                    .build();
+    private static final FeeData providerPrices =
+            FeeData.newBuilder().setServicedata(servicePrices).build();
+    private static final ExchangeRate activeRate =
+            ExchangeRate.newBuilder().setHbarEquiv(1).setCentEquiv(12).build();
+    private static final long reasonableMultiplier = 7;
+    private static final long insaneMultiplier = Long.MAX_VALUE / 2;
 
-	@Mock
-	private HbarCentExchange exchange;
-	@Mock
-	private UsagePricesProvider usagePrices;
-	@Mock
-	private FeeMultiplierSource feeMultiplierSource;
-	@Mock
-	private TransactionContext txnCtx;
-	@Mock
-	private TxnAccessor accessor;
+    @Mock private HbarCentExchange exchange;
+    @Mock private UsagePricesProvider usagePrices;
+    @Mock private FeeMultiplierSource feeMultiplierSource;
+    @Mock private TransactionContext txnCtx;
+    @Mock private TxnAccessor accessor;
 
-	private LivePricesSource subject;
+    private LivePricesSource subject;
 
-	@BeforeEach
-	void setUp() {
-		subject = new LivePricesSource(exchange, usagePrices, feeMultiplierSource, txnCtx);
-	}
+    @BeforeEach
+    void setUp() {
+        subject = new LivePricesSource(exchange, usagePrices, feeMultiplierSource, txnCtx);
+    }
 
-	@Test
-	void getsExpectedGasPriceWithReasonableMultiplier() {
-		givenCollabsWithMultiplier(reasonableMultiplier);
+    @Test
+    void getsExpectedGasPriceWithReasonableMultiplier() {
+        givenCollabsWithMultiplier(reasonableMultiplier);
 
-		final var expected = getTinybarsFromTinyCents(activeRate, gasPriceTinybars) * reasonableMultiplier;
+        final var expected =
+                getTinybarsFromTinyCents(activeRate, gasPriceTinybars) * reasonableMultiplier;
 
-		assertEquals(expected, subject.currentGasPrice(now, ContractCall));
-	}
+        assertEquals(expected, subject.currentGasPrice(now, ContractCall));
+    }
 
-	@Test
-	void getsCurrentGasPriceInTinyCents() {
-		given(usagePrices.defaultPricesGiven(ContractCall, timeNow)).willReturn(providerPrices);
+    @Test
+    void getsCurrentGasPriceInTinyCents() {
+        given(usagePrices.defaultPricesGiven(ContractCall, timeNow)).willReturn(providerPrices);
 
-		ToLongFunction<FeeComponents> resourcePriceFn = FeeComponents::getGas;
-		final var expected = resourcePriceFn.applyAsLong(providerPrices.getServicedata()) / 1000;
+        ToLongFunction<FeeComponents> resourcePriceFn = FeeComponents::getGas;
+        final var expected = resourcePriceFn.applyAsLong(providerPrices.getServicedata()) / 1000;
 
-		assertEquals(expected, subject.currentGasPriceInTinycents(now, ContractCall));
-	}
+        assertEquals(expected, subject.currentGasPriceInTinycents(now, ContractCall));
+    }
 
+    @Test
+    void getsExpectedSbhPriceWithReasonableMultiplier() {
+        givenCollabsWithMultiplier(reasonableMultiplier);
 
-	@Test
-	void getsExpectedSbhPriceWithReasonableMultiplier() {
-		givenCollabsWithMultiplier(reasonableMultiplier);
+        final var expected =
+                getTinybarsFromTinyCents(activeRate, sbhPriceTinybars) * reasonableMultiplier;
 
-		final var expected = getTinybarsFromTinyCents(activeRate, sbhPriceTinybars) * reasonableMultiplier;
+        assertEquals(expected, subject.currentStorageByteHoursPrice(now, ContractCall));
+    }
 
-		assertEquals(expected, subject.currentStorageByteHoursPrice(now, ContractCall));
-	}
+    @Test
+    void getsExpectedSbhPriceWithInsaneMultiplier() {
+        givenCollabsWithMultiplier(insaneMultiplier);
 
-	@Test
-	void getsExpectedSbhPriceWithInsaneMultiplier() {
-		givenCollabsWithMultiplier(insaneMultiplier);
+        assertEquals(Long.MAX_VALUE, subject.currentStorageByteHoursPrice(now, ContractCall));
+    }
 
-		assertEquals(Long.MAX_VALUE, subject.currentStorageByteHoursPrice(now, ContractCall));
-	}
-
-	private void givenCollabsWithMultiplier(final long multiplier) {
-		given(exchange.rate(timeNow)).willReturn(activeRate);
-		given(usagePrices.defaultPricesGiven(ContractCall, timeNow)).willReturn(providerPrices);
-		given(feeMultiplierSource.currentMultiplier(accessor)).willReturn(multiplier);
-		given(txnCtx.accessor()).willReturn(accessor);
-	}
+    private void givenCollabsWithMultiplier(final long multiplier) {
+        given(exchange.rate(timeNow)).willReturn(activeRate);
+        given(usagePrices.defaultPricesGiven(ContractCall, timeNow)).willReturn(providerPrices);
+        given(feeMultiplierSource.currentMultiplier(accessor)).willReturn(multiplier);
+        given(txnCtx.accessor()).willReturn(accessor);
+    }
 }

--- a/hedera-node/src/test/java/com/hedera/services/contracts/execution/StaticBlockMetaProviderTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/contracts/execution/StaticBlockMetaProviderTest.java
@@ -1,11 +1,6 @@
-package com.hedera.services.contracts.execution;
-
-/*-
- * ‌
- * Hedera Services Node
- * ​
- * Copyright (C) 2018 - 2022 Hedera Hashgraph, LLC
- * ​
+/*
+ * Copyright (C) 2020-2022 Hedera Hashgraph, LLC
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -17,8 +12,8 @@ package com.hedera.services.contracts.execution;
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- * ‍
  */
+package com.hedera.services.contracts.execution;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.BDDMockito.given;

--- a/hedera-node/src/test/java/com/hedera/services/contracts/execution/StaticBlockMetaProviderTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/contracts/execution/StaticBlockMetaProviderTest.java
@@ -9,9 +9,9 @@ package com.hedera.services.contracts.execution;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,47 +20,44 @@ package com.hedera.services.contracts.execution;
  * ‍
  */
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.BDDMockito.given;
+
 import com.hedera.services.context.StateChildren;
 import com.hedera.services.context.primitives.SignedStateViewFactory;
 import com.hedera.services.state.merkle.MerkleNetworkContext;
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.util.Optional;
-
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.BDDMockito.given;
-
 @ExtendWith(MockitoExtension.class)
 class StaticBlockMetaProviderTest {
-	@Mock
-	private SignedStateViewFactory stateViewFactory;
-	@Mock
-	private MerkleNetworkContext networkContext;
-	@Mock
-	private StateChildren stateChildren;
+    @Mock private SignedStateViewFactory stateViewFactory;
+    @Mock private MerkleNetworkContext networkContext;
+    @Mock private StateChildren stateChildren;
 
-	private StaticBlockMetaProvider subject;
+    private StaticBlockMetaProvider subject;
 
-	@BeforeEach
-	void setUp() {
-		subject = new StaticBlockMetaProvider(stateViewFactory);
-	}
+    @BeforeEach
+    void setUp() {
+        subject = new StaticBlockMetaProvider(stateViewFactory);
+    }
 
-	@Test
-	void emptyResultIfNoSignedStateChildren() {
-		final var result = subject.getSource();
-		assertTrue(result.isEmpty());
-	}
+    @Test
+    void emptyResultIfNoSignedStateChildren() {
+        final var result = subject.getSource();
+        assertTrue(result.isEmpty());
+    }
 
-	@Test
-	void usableSourceIfSignedStateChildren() {
-		given(stateViewFactory.childrenOfLatestSignedState()).willReturn(Optional.of(stateChildren));
-		given(stateChildren.networkCtx()).willReturn(networkContext);
-		final var result = subject.getSource();
-		assertTrue(result.isPresent());
-	}
+    @Test
+    void usableSourceIfSignedStateChildren() {
+        given(stateViewFactory.childrenOfLatestSignedState())
+                .willReturn(Optional.of(stateChildren));
+        given(stateChildren.networkCtx()).willReturn(networkContext);
+        final var result = subject.getSource();
+        assertTrue(result.isPresent());
+    }
 }

--- a/hedera-node/src/test/java/com/hedera/services/contracts/execution/StaticBlockMetaSourceTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/contracts/execution/StaticBlockMetaSourceTest.java
@@ -1,11 +1,6 @@
-package com.hedera.services.contracts.execution;
-
-/*-
- * ‌
- * Hedera Services Node
- * ​
- * Copyright (C) 2018 - 2022 Hedera Hashgraph, LLC
- * ​
+/*
+ * Copyright (C) 2022 Hedera Hashgraph, LLC
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -17,8 +12,8 @@ package com.hedera.services.contracts.execution;
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- * ‍
  */
+package com.hedera.services.contracts.execution;
 
 import static com.hedera.services.contracts.execution.BlockMetaSource.UNAVAILABLE_BLOCK_HASH;
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/hedera-node/src/test/java/com/hedera/services/contracts/execution/StaticBlockMetaSourceTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/contracts/execution/StaticBlockMetaSourceTest.java
@@ -9,9 +9,9 @@ package com.hedera.services.contracts.execution;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,64 +20,62 @@ package com.hedera.services.contracts.execution;
  * ‍
  */
 
-import com.hedera.services.state.merkle.MerkleNetworkContext;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
-
-import java.time.Instant;
-
 import static com.hedera.services.contracts.execution.BlockMetaSource.UNAVAILABLE_BLOCK_HASH;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.mockito.BDDMockito.given;
 
+import com.hedera.services.state.merkle.MerkleNetworkContext;
+import java.time.Instant;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
 @ExtendWith(MockitoExtension.class)
 class StaticBlockMetaSourceTest {
-	@Mock
-	private MerkleNetworkContext networkCtx;
+    @Mock private MerkleNetworkContext networkCtx;
 
-	private StaticBlockMetaSource subject;
+    private StaticBlockMetaSource subject;
 
-	@BeforeEach
-	void setUp() {
-		subject = new StaticBlockMetaSource(networkCtx);
-	}
+    @BeforeEach
+    void setUp() {
+        subject = new StaticBlockMetaSource(networkCtx);
+    }
 
-	@Test
-	void blockValuesAreForCurrentBlockAfterSync() {
-		given(networkCtx.getAlignmentBlockNo()).willReturn(someBlockNo);
-		given(networkCtx.firstConsTimeOfCurrentBlock()).willReturn(then);
+    @Test
+    void blockValuesAreForCurrentBlockAfterSync() {
+        given(networkCtx.getAlignmentBlockNo()).willReturn(someBlockNo);
+        given(networkCtx.firstConsTimeOfCurrentBlock()).willReturn(then);
 
-		final var ans = subject.computeBlockValues(gasLimit);
+        final var ans = subject.computeBlockValues(gasLimit);
 
-		assertEquals(gasLimit, ans.getGasLimit());
-		assertEquals(someBlockNo, ans.getNumber());
-		assertEquals(then.getEpochSecond(), ans.getTimestamp());
-	}
+        assertEquals(gasLimit, ans.getGasLimit());
+        assertEquals(someBlockNo, ans.getNumber());
+        assertEquals(then.getEpochSecond(), ans.getTimestamp());
+    }
 
-	@Test
-	void usesNowIfFirstConsTimeIsStillSomehowNull() {
-		given(networkCtx.getAlignmentBlockNo()).willReturn(someBlockNo);
+    @Test
+    void usesNowIfFirstConsTimeIsStillSomehowNull() {
+        given(networkCtx.getAlignmentBlockNo()).willReturn(someBlockNo);
 
-		final var ans = subject.computeBlockValues(gasLimit);
+        final var ans = subject.computeBlockValues(gasLimit);
 
-		assertEquals(gasLimit, ans.getGasLimit());
-		assertEquals(someBlockNo, ans.getNumber());
-		assertNotEquals(0, ans.getTimestamp());
-	}
+        assertEquals(gasLimit, ans.getGasLimit());
+        assertEquals(someBlockNo, ans.getNumber());
+        assertNotEquals(0, ans.getTimestamp());
+    }
 
-	@Test
-	void alwaysDelegatesBlockHashLookup() {
-		given(networkCtx.getBlockHashByNumber(someBlockNo)).willReturn(UNAVAILABLE_BLOCK_HASH);
+    @Test
+    void alwaysDelegatesBlockHashLookup() {
+        given(networkCtx.getBlockHashByNumber(someBlockNo)).willReturn(UNAVAILABLE_BLOCK_HASH);
 
-		assertSame(UNAVAILABLE_BLOCK_HASH, subject.getBlockHash(someBlockNo));
-	}
+        assertSame(UNAVAILABLE_BLOCK_HASH, subject.getBlockHash(someBlockNo));
+    }
 
-	private static final long gasLimit = 888L;
-	private static final long someBlockNo = 123L;
-	private static final Instant then = Instant.ofEpochSecond(1_234_567, 890);
+    private static final long gasLimit = 888L;
+    private static final long someBlockNo = 123L;
+    private static final Instant then = Instant.ofEpochSecond(1_234_567, 890);
 }

--- a/hedera-node/src/test/java/com/hedera/services/contracts/execution/TransactionProcessingResultTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/contracts/execution/TransactionProcessingResultTest.java
@@ -22,6 +22,9 @@ package com.hedera.services.contracts.execution;
  *
  */
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import com.google.protobuf.ByteString;
 import com.google.protobuf.BytesValue;
 import com.hedera.services.store.models.Account;
@@ -31,6 +34,10 @@ import com.hedera.services.utils.EntityIdUtils;
 import com.hederahashgraph.api.proto.java.ContractFunctionResult;
 import com.hederahashgraph.api.proto.java.ContractStateChange;
 import com.hederahashgraph.api.proto.java.StorageChange;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.TreeMap;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.tuweni.bytes.Bytes;
@@ -44,203 +51,261 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.TreeMap;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
 @ExtendWith(MockitoExtension.class)
 class TransactionProcessingResultTest {
 
-	private static final long GAS_USAGE = 1234L;
-	private static final long GAS_REFUND = 345L;
-	private static final long GAS_PRICE = 1234L;
-	private final Account logger = new Account(new Id(0, 0, 1002));
+    private static final long GAS_USAGE = 1234L;
+    private static final long GAS_REFUND = 345L;
+    private static final long GAS_PRICE = 1234L;
+    private final Account logger = new Account(new Id(0, 0, 1002));
 
-	private final Bytes logTopicBytes = Bytes.fromHexString(
-			"0xce8688f853ffa65c042b72302433c25d7a230c322caba0901587534b6551091d");
+    private final Bytes logTopicBytes =
+            Bytes.fromHexString(
+                    "0xce8688f853ffa65c042b72302433c25d7a230c322caba0901587534b6551091d");
 
-	private final LogTopic logTopic = LogTopic.create(logTopicBytes);
+    private final LogTopic logTopic = LogTopic.create(logTopicBytes);
 
-	private final Log log = new Log(logger.getId().asEvmAddress(), Bytes.fromHexString("0x0102"), List.of(
-			logTopic,
-			logTopic,
-			logTopic,
-			logTopic
-	));
+    private final Log log =
+            new Log(
+                    logger.getId().asEvmAddress(),
+                    Bytes.fromHexString("0x0102"),
+                    List.of(logTopic, logTopic, logTopic, logTopic));
 
-	private final Account recipient = new Account(new Id(0, 0, 1002));
+    private final Account recipient = new Account(new Id(0, 0, 1002));
 
-	@Test
-	void assertCorrectDataOnSuccessfulTransaction() {
+    @Test
+    void assertCorrectDataOnSuccessfulTransaction() {
 
-		var firstContract = new Account(new Id(0, 0, 1003));
-		var secondContract = new Account(new Id(0, 0, 1004));
+        var firstContract = new Account(new Id(0, 0, 1003));
+        var secondContract = new Account(new Id(0, 0, 1004));
 
-		var listOfCreatedContracts = List.of(
-				firstContract.getId().asGrpcContract(),
-				secondContract.getId().asGrpcContract()
-		);
+        var listOfCreatedContracts =
+                List.of(
+                        firstContract.getId().asGrpcContract(),
+                        secondContract.getId().asGrpcContract());
 
-		var log = new Log(logger.getId().asEvmAddress(), Bytes.fromHexString("0x0102"), List.of(
-				logTopic,
-				logTopic,
-				logTopic,
-				logTopic
-		));
-		final var logList = List.of(log);
+        var log =
+                new Log(
+                        logger.getId().asEvmAddress(),
+                        Bytes.fromHexString("0x0102"),
+                        List.of(logTopic, logTopic, logTopic, logTopic));
+        final var logList = List.of(log);
 
-		final var firstContractChanges = new TreeMap<Bytes, Pair<Bytes, Bytes>>(BytesComparator.INSTANCE);
-		firstContractChanges.put(UInt256.valueOf(1L), new ImmutablePair<>(UInt256.valueOf(1L), null));
-		final var secondContractChanges = new TreeMap<Bytes, Pair<Bytes, Bytes>>(BytesComparator.INSTANCE);
-		secondContractChanges.put(UInt256.valueOf(1L), new ImmutablePair<>(UInt256.valueOf(1L), UInt256.valueOf(2L)));
-		secondContractChanges.put(UInt256.valueOf(2L), new ImmutablePair<>(UInt256.valueOf(55L),
-				UInt256.valueOf(255L)));
-		final Map<Address, Map<Bytes, Pair<Bytes, Bytes>>> contractStateChanges =
-				new TreeMap<>(BytesComparator.INSTANCE);
-		contractStateChanges.put(firstContract.getId().asEvmAddress(), firstContractChanges);
-		contractStateChanges.put(secondContract.getId().asEvmAddress(), secondContractChanges);
+        final var firstContractChanges =
+                new TreeMap<Bytes, Pair<Bytes, Bytes>>(BytesComparator.INSTANCE);
+        firstContractChanges.put(
+                UInt256.valueOf(1L), new ImmutablePair<>(UInt256.valueOf(1L), null));
+        final var secondContractChanges =
+                new TreeMap<Bytes, Pair<Bytes, Bytes>>(BytesComparator.INSTANCE);
+        secondContractChanges.put(
+                UInt256.valueOf(1L), new ImmutablePair<>(UInt256.valueOf(1L), UInt256.valueOf(2L)));
+        secondContractChanges.put(
+                UInt256.valueOf(2L),
+                new ImmutablePair<>(UInt256.valueOf(55L), UInt256.valueOf(255L)));
+        final Map<Address, Map<Bytes, Pair<Bytes, Bytes>>> contractStateChanges =
+                new TreeMap<>(BytesComparator.INSTANCE);
+        contractStateChanges.put(firstContract.getId().asEvmAddress(), firstContractChanges);
+        contractStateChanges.put(secondContract.getId().asEvmAddress(), secondContractChanges);
 
-		final var expect = ContractFunctionResult.newBuilder()
-				.setGasUsed(GAS_USAGE)
-				.setBloom(ByteString.copyFrom(LogsBloomFilter.builder().insertLogs(logList).build().toArray()));
+        final var expect =
+                ContractFunctionResult.newBuilder()
+                        .setGasUsed(GAS_USAGE)
+                        .setBloom(
+                                ByteString.copyFrom(
+                                        LogsBloomFilter.builder()
+                                                .insertLogs(logList)
+                                                .build()
+                                                .toArray()));
 
-		expect.setContractCallResult(ByteString.copyFrom(Bytes.EMPTY.toArray()));
-		expect.setContractID(EntityIdUtils.contractIdFromEvmAddress(recipient.getId().asEvmAddress().toArray()));
-		expect.addAllCreatedContractIDs(listOfCreatedContracts);
+        expect.setContractCallResult(ByteString.copyFrom(Bytes.EMPTY.toArray()));
+        expect.setContractID(
+                EntityIdUtils.contractIdFromEvmAddress(recipient.getId().asEvmAddress().toArray()));
+        expect.addAllCreatedContractIDs(listOfCreatedContracts);
 
-		final var firstContractChangesRpc = ContractStateChange.newBuilder()
-				.setContractID(firstContract.getId().asGrpcContract())
-				.addStorageChanges(StorageChange.newBuilder()
-						.setSlot(ByteString.copyFrom(UInt256.valueOf(1L).trimLeadingZeros().toArrayUnsafe()))
-						.setValueRead(ByteString.copyFrom(UInt256.valueOf(1L).trimLeadingZeros().toArrayUnsafe()))
-						.build())
-				.build();
-		final var secondContractChangesRpc = ContractStateChange.newBuilder()
-				.setContractID(secondContract.getId().asGrpcContract())
-				.addStorageChanges(StorageChange.newBuilder()
-						.setSlot(ByteString.copyFrom(UInt256.valueOf(1L).trimLeadingZeros().toArrayUnsafe()))
-						.setValueRead(ByteString.copyFrom(UInt256.valueOf(1L).trimLeadingZeros().toArrayUnsafe()))
-						.setValueWritten(BytesValue.newBuilder().setValue(ByteString.copyFrom(UInt256.valueOf(2L).trimLeadingZeros().toArrayUnsafe())))
-						.build())
-				.addStorageChanges(StorageChange.newBuilder()
-						.setSlot(ByteString.copyFrom(UInt256.valueOf(2L).trimLeadingZeros().toArrayUnsafe()))
-						.setValueRead(ByteString.copyFrom(UInt256.valueOf(55L).trimLeadingZeros().toArrayUnsafe()))
-						.setValueWritten(BytesValue.newBuilder().setValue(ByteString.copyFrom(UInt256.valueOf(255L).trimLeadingZeros().toArrayUnsafe())))
-						.build())
-				.build();
-		expect.addAllStateChanges(List.of(firstContractChangesRpc, secondContractChangesRpc));
+        final var firstContractChangesRpc =
+                ContractStateChange.newBuilder()
+                        .setContractID(firstContract.getId().asGrpcContract())
+                        .addStorageChanges(
+                                StorageChange.newBuilder()
+                                        .setSlot(
+                                                ByteString.copyFrom(
+                                                        UInt256.valueOf(1L)
+                                                                .trimLeadingZeros()
+                                                                .toArrayUnsafe()))
+                                        .setValueRead(
+                                                ByteString.copyFrom(
+                                                        UInt256.valueOf(1L)
+                                                                .trimLeadingZeros()
+                                                                .toArrayUnsafe()))
+                                        .build())
+                        .build();
+        final var secondContractChangesRpc =
+                ContractStateChange.newBuilder()
+                        .setContractID(secondContract.getId().asGrpcContract())
+                        .addStorageChanges(
+                                StorageChange.newBuilder()
+                                        .setSlot(
+                                                ByteString.copyFrom(
+                                                        UInt256.valueOf(1L)
+                                                                .trimLeadingZeros()
+                                                                .toArrayUnsafe()))
+                                        .setValueRead(
+                                                ByteString.copyFrom(
+                                                        UInt256.valueOf(1L)
+                                                                .trimLeadingZeros()
+                                                                .toArrayUnsafe()))
+                                        .setValueWritten(
+                                                BytesValue.newBuilder()
+                                                        .setValue(
+                                                                ByteString.copyFrom(
+                                                                        UInt256.valueOf(2L)
+                                                                                .trimLeadingZeros()
+                                                                                .toArrayUnsafe())))
+                                        .build())
+                        .addStorageChanges(
+                                StorageChange.newBuilder()
+                                        .setSlot(
+                                                ByteString.copyFrom(
+                                                        UInt256.valueOf(2L)
+                                                                .trimLeadingZeros()
+                                                                .toArrayUnsafe()))
+                                        .setValueRead(
+                                                ByteString.copyFrom(
+                                                        UInt256.valueOf(55L)
+                                                                .trimLeadingZeros()
+                                                                .toArrayUnsafe()))
+                                        .setValueWritten(
+                                                BytesValue.newBuilder()
+                                                        .setValue(
+                                                                ByteString.copyFrom(
+                                                                        UInt256.valueOf(255L)
+                                                                                .trimLeadingZeros()
+                                                                                .toArrayUnsafe())))
+                                        .build())
+                        .build();
+        expect.addAllStateChanges(List.of(firstContractChangesRpc, secondContractChangesRpc));
 
-		var result = TransactionProcessingResult.successful(
-				logList,
-				GAS_USAGE,
-				GAS_REFUND,
-				1234L,
-				Bytes.EMPTY,
-				recipient.getId().asEvmAddress(),
-				contractStateChanges);
-		result.setCreatedContracts(listOfCreatedContracts);
+        var result =
+                TransactionProcessingResult.successful(
+                        logList,
+                        GAS_USAGE,
+                        GAS_REFUND,
+                        1234L,
+                        Bytes.EMPTY,
+                        recipient.getId().asEvmAddress(),
+                        contractStateChanges);
+        result.setCreatedContracts(listOfCreatedContracts);
 
-		assertEquals(expect.getGasUsed(), result.getGasUsed());
+        assertEquals(expect.getGasUsed(), result.getGasUsed());
 
-		final var resultAsGrpc = result.toGrpc();
-		assertEquals(GAS_REFUND, result.getSbhRefund());
-		assertEquals(Optional.empty(), result.getHaltReason());
-		assertEquals(expect.getBloom(), resultAsGrpc.getBloom());
-		assertEquals(expect.getContractID(), resultAsGrpc.getContractID());
-		assertEquals(ByteString.EMPTY, resultAsGrpc.getContractCallResult());
-		assertEquals(listOfCreatedContracts, resultAsGrpc.getCreatedContractIDsList());
-	}
+        final var resultAsGrpc = result.toGrpc();
+        assertEquals(GAS_REFUND, result.getSbhRefund());
+        assertEquals(Optional.empty(), result.getHaltReason());
+        assertEquals(expect.getBloom(), resultAsGrpc.getBloom());
+        assertEquals(expect.getContractID(), resultAsGrpc.getContractID());
+        assertEquals(ByteString.EMPTY, resultAsGrpc.getContractCallResult());
+        assertEquals(listOfCreatedContracts, resultAsGrpc.getCreatedContractIDsList());
+    }
 
-	@Test
-	void assertCorrectDataOnFailedTransaction() {
+    @Test
+    void assertCorrectDataOnFailedTransaction() {
 
-		var exception = new ExceptionalHaltReason() {
-			@Override
-			public String name() {
-				return "TestExceptionalHaltReason";
-			}
+        var exception =
+                new ExceptionalHaltReason() {
+                    @Override
+                    public String name() {
+                        return "TestExceptionalHaltReason";
+                    }
 
-			@Override
-			public String getDescription() {
-				return "Exception Halt Reason Test Description";
-			}
-		};
-		var revertReason = Optional.of(Bytes.fromHexString("0x43"));
+                    @Override
+                    public String getDescription() {
+                        return "Exception Halt Reason Test Description";
+                    }
+                };
+        var revertReason = Optional.of(Bytes.fromHexString("0x43"));
 
-		final var expect = ContractFunctionResult.newBuilder()
-				.setGasUsed(GAS_USAGE)
-				.setBloom(ByteString.copyFrom(new byte[256]));
-		expect.setContractCallResult(ByteString.copyFrom(Bytes.EMPTY.toArray()));
-		expect.setContractID(EntityIdUtils.contractIdFromEvmAddress(recipient.getId().asEvmAddress().toArray()));
-		expect.setErrorMessageBytes(ByteString.copyFrom(revertReason.get().toArray()));
+        final var expect =
+                ContractFunctionResult.newBuilder()
+                        .setGasUsed(GAS_USAGE)
+                        .setBloom(ByteString.copyFrom(new byte[256]));
+        expect.setContractCallResult(ByteString.copyFrom(Bytes.EMPTY.toArray()));
+        expect.setContractID(
+                EntityIdUtils.contractIdFromEvmAddress(recipient.getId().asEvmAddress().toArray()));
+        expect.setErrorMessageBytes(ByteString.copyFrom(revertReason.get().toArray()));
 
-		var result = TransactionProcessingResult.failed(GAS_USAGE, GAS_REFUND, GAS_PRICE, revertReason,
-				Optional.of(exception),Map.of());
+        var result =
+                TransactionProcessingResult.failed(
+                        GAS_USAGE,
+                        GAS_REFUND,
+                        GAS_PRICE,
+                        revertReason,
+                        Optional.of(exception),
+                        Map.of());
 
-		assertEquals(expect.getGasUsed(), result.getGasUsed());
-		assertEquals(GAS_PRICE, result.getGasPrice());
-		assertEquals(GAS_REFUND, result.getSbhRefund());
-		assertEquals(Optional.of(exception), result.getHaltReason());
-		assertEquals(revertReason.get().toString(), result.toGrpc().getErrorMessage());
-	}
+        assertEquals(expect.getGasUsed(), result.getGasUsed());
+        assertEquals(GAS_PRICE, result.getGasPrice());
+        assertEquals(GAS_REFUND, result.getSbhRefund());
+        assertEquals(Optional.of(exception), result.getHaltReason());
+        assertEquals(revertReason.get().toString(), result.toGrpc().getErrorMessage());
+    }
 
-	@Test
-	void assertGasPrice() {
-		var result = TransactionProcessingResult.successful(
-				List.of(log),
-				GAS_USAGE,
-				GAS_REFUND,
-				GAS_PRICE,
-				Bytes.EMPTY,
-				recipient.getId().asEvmAddress(),
-				Map.of());
+    @Test
+    void assertGasPrice() {
+        var result =
+                TransactionProcessingResult.successful(
+                        List.of(log),
+                        GAS_USAGE,
+                        GAS_REFUND,
+                        GAS_PRICE,
+                        Bytes.EMPTY,
+                        recipient.getId().asEvmAddress(),
+                        Map.of());
 
-		assertEquals(GAS_PRICE, result.getGasPrice());
-	}
+        assertEquals(GAS_PRICE, result.getGasPrice());
+    }
 
-	@Test
-	void assertSbhRefund() {
-		var result = TransactionProcessingResult.successful(
-				List.of(log),
-				GAS_USAGE,
-				GAS_REFUND,
-				GAS_PRICE,
-				Bytes.EMPTY,
-				recipient.getId().asEvmAddress(),
-				Map.of());
+    @Test
+    void assertSbhRefund() {
+        var result =
+                TransactionProcessingResult.successful(
+                        List.of(log),
+                        GAS_USAGE,
+                        GAS_REFUND,
+                        GAS_PRICE,
+                        Bytes.EMPTY,
+                        recipient.getId().asEvmAddress(),
+                        Map.of());
 
-		assertEquals(GAS_REFUND, result.getSbhRefund());
-	}
+        assertEquals(GAS_REFUND, result.getSbhRefund());
+    }
 
-	@Test
-	void assertGasUsage() {
-		var result = TransactionProcessingResult.successful(
-				List.of(log),
-				GAS_USAGE,
-				GAS_REFUND,
-				GAS_PRICE,
-				Bytes.EMPTY,
-				recipient.getId().asEvmAddress(),
-				Map.of());
+    @Test
+    void assertGasUsage() {
+        var result =
+                TransactionProcessingResult.successful(
+                        List.of(log),
+                        GAS_USAGE,
+                        GAS_REFUND,
+                        GAS_PRICE,
+                        Bytes.EMPTY,
+                        recipient.getId().asEvmAddress(),
+                        Map.of());
 
-		assertEquals(GAS_USAGE, result.getGasUsed());
-	}
+        assertEquals(GAS_USAGE, result.getGasUsed());
+    }
 
-	@Test
-	void assertSuccessfulStatus() {
-		var result = TransactionProcessingResult.successful(
-				List.of(log),
-				GAS_USAGE,
-				GAS_REFUND,
-				GAS_PRICE,
-				Bytes.EMPTY,
-				recipient.getId().asEvmAddress(),
-				Map.of());
+    @Test
+    void assertSuccessfulStatus() {
+        var result =
+                TransactionProcessingResult.successful(
+                        List.of(log),
+                        GAS_USAGE,
+                        GAS_REFUND,
+                        GAS_PRICE,
+                        Bytes.EMPTY,
+                        recipient.getId().asEvmAddress(),
+                        Map.of());
 
-		assertTrue(result.isSuccessful());
-	}
+        assertTrue(result.isSuccessful());
+    }
 }

--- a/hedera-node/src/test/java/com/hedera/services/contracts/execution/TransactionProcessingResultTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/contracts/execution/TransactionProcessingResultTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2021-2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hedera.services.contracts.execution;
 
 /*

--- a/hedera-node/src/test/java/com/hedera/services/contracts/gascalculator/GasCalculatorHederaUtilTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/contracts/gascalculator/GasCalculatorHederaUtilTest.java
@@ -22,11 +22,22 @@ package com.hedera.services.contracts.gascalculator;
  *
  */
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
 import com.hedera.services.contracts.execution.HederaBlockValues;
 import com.hedera.services.fees.HbarCentExchange;
 import com.hedera.services.fees.calculation.UsagePricesProvider;
 import com.hedera.services.state.merkle.MerkleNetworkContext;
-import com.hederahashgraph.api.proto.java.*;
+import com.hederahashgraph.api.proto.java.ExchangeRate;
+import com.hederahashgraph.api.proto.java.FeeComponents;
+import com.hederahashgraph.api.proto.java.FeeData;
+import com.hederahashgraph.api.proto.java.HederaFunctionality;
+import com.hederahashgraph.api.proto.java.Timestamp;
+import java.time.Instant;
+import java.util.ArrayDeque;
 import org.hyperledger.besu.datatypes.Wei;
 import org.hyperledger.besu.evm.frame.MessageFrame;
 import org.junit.jupiter.api.Test;
@@ -34,91 +45,94 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.time.Instant;
-import java.util.ArrayDeque;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-
 @ExtendWith(MockitoExtension.class)
 class GasCalculatorHederaUtilTest {
-	@Mock
-	private HbarCentExchange hbarCentExchange;
-	@Mock
-	private UsagePricesProvider usagePricesProvider;
-	@Mock
-	private MerkleNetworkContext merkleNetworkContext;
+    @Mock private HbarCentExchange hbarCentExchange;
+    @Mock private UsagePricesProvider usagePricesProvider;
+    @Mock private MerkleNetworkContext merkleNetworkContext;
 
-	@Test
-	void assertRamByteHoursTinyBarsGiven() {
-		var hbarEquiv = 1000;
-		var centEquiv = 100;
-		var expectedRamResult = hbarEquiv / centEquiv;
-		var consensusTime = Instant.now().getEpochSecond();
-		final var timestamp = Timestamp.newBuilder().setSeconds(consensusTime).build();
-		var feeData = mock(FeeData.class);
-		var exchangeRate = mock(ExchangeRate.class);
-		given(feeData.getServicedata()).willReturn(mock(FeeComponents.class));
-		given(feeData.getServicedata().getRbh()).willReturn(1000L);
-		given(usagePricesProvider.defaultPricesGiven(HederaFunctionality.ContractCall, timestamp)).willReturn(feeData);
-		given(hbarCentExchange.rate(timestamp)).willReturn(exchangeRate);
-		given(exchangeRate.getHbarEquiv()).willReturn(hbarEquiv);
-		given(exchangeRate.getCentEquiv()).willReturn(centEquiv);
+    @Test
+    void assertRamByteHoursTinyBarsGiven() {
+        var hbarEquiv = 1000;
+        var centEquiv = 100;
+        var expectedRamResult = hbarEquiv / centEquiv;
+        var consensusTime = Instant.now().getEpochSecond();
+        final var timestamp = Timestamp.newBuilder().setSeconds(consensusTime).build();
+        var feeData = mock(FeeData.class);
+        var exchangeRate = mock(ExchangeRate.class);
+        given(feeData.getServicedata()).willReturn(mock(FeeComponents.class));
+        given(feeData.getServicedata().getRbh()).willReturn(1000L);
+        given(usagePricesProvider.defaultPricesGiven(HederaFunctionality.ContractCall, timestamp))
+                .willReturn(feeData);
+        given(hbarCentExchange.rate(timestamp)).willReturn(exchangeRate);
+        given(exchangeRate.getHbarEquiv()).willReturn(hbarEquiv);
+        given(exchangeRate.getCentEquiv()).willReturn(centEquiv);
 
-		assertEquals(expectedRamResult, GasCalculatorHederaUtil.ramByteHoursTinyBarsGiven(usagePricesProvider, hbarCentExchange, consensusTime, HederaFunctionality.ContractCall));
-		verify(hbarCentExchange).rate(timestamp);
-		verify(usagePricesProvider).defaultPricesGiven(HederaFunctionality.ContractCall, timestamp);
-	}
+        assertEquals(
+                expectedRamResult,
+                GasCalculatorHederaUtil.ramByteHoursTinyBarsGiven(
+                        usagePricesProvider,
+                        hbarCentExchange,
+                        consensusTime,
+                        HederaFunctionality.ContractCall));
+        verify(hbarCentExchange).rate(timestamp);
+        verify(usagePricesProvider).defaultPricesGiven(HederaFunctionality.ContractCall, timestamp);
+    }
 
-	@Test
-	void assertCalculateLogSize() {
-		var numberOfTopics = 3;
-		var dataSize = 10L;
-		assertEquals(386, GasCalculatorHederaUtil.calculateLogSize(numberOfTopics, dataSize));
-	}
+    @Test
+    void assertCalculateLogSize() {
+        var numberOfTopics = 3;
+        var dataSize = 10L;
+        assertEquals(386, GasCalculatorHederaUtil.calculateLogSize(numberOfTopics, dataSize));
+    }
 
-	@Test
-	void assertCalculateStorageGasNeeded() {
-		var durationInSeconds = 10L;
-		var byteHourCostIntinybars = 1000L;
-		var gasPrice = 1234L;
-		var storageCostTinyBars = (durationInSeconds * byteHourCostIntinybars) / 3600;
-		var expectedResult = Math.round((double) storageCostTinyBars / (double) gasPrice);
-		assertEquals(expectedResult, GasCalculatorHederaUtil.calculateStorageGasNeeded(0, durationInSeconds, byteHourCostIntinybars, gasPrice));
-	}
+    @Test
+    void assertCalculateStorageGasNeeded() {
+        var durationInSeconds = 10L;
+        var byteHourCostIntinybars = 1000L;
+        var gasPrice = 1234L;
+        var storageCostTinyBars = (durationInSeconds * byteHourCostIntinybars) / 3600;
+        var expectedResult = Math.round((double) storageCostTinyBars / (double) gasPrice);
+        assertEquals(
+                expectedResult,
+                GasCalculatorHederaUtil.calculateStorageGasNeeded(
+                        0, durationInSeconds, byteHourCostIntinybars, gasPrice));
+    }
 
-	@Test
-	void assertAndVerifyLogOperationGasCost() {
-		final var messageFrame = mock(MessageFrame.class);
-		final var consensusTime = 123L;
-		final var functionality = HederaFunctionality.ContractCreate;
-		final var timestamp = Timestamp.newBuilder().setSeconds(consensusTime).build();
-		final var returningDeque = new ArrayDeque<MessageFrame>() {
-		};
-		returningDeque.add(messageFrame);
+    @Test
+    void assertAndVerifyLogOperationGasCost() {
+        final var messageFrame = mock(MessageFrame.class);
+        final var consensusTime = 123L;
+        final var functionality = HederaFunctionality.ContractCreate;
+        final var timestamp = Timestamp.newBuilder().setSeconds(consensusTime).build();
+        final var returningDeque = new ArrayDeque<MessageFrame>() {};
+        returningDeque.add(messageFrame);
 
-		final var rbh = 20000L;
-		final var feeComponents = FeeComponents.newBuilder().setRbh(rbh);
-		final var feeData = FeeData.newBuilder().setServicedata(feeComponents).build();
-		final var blockConsTime =  Instant.ofEpochSecond(consensusTime);
-		final var blockNo = 123L;
+        final var rbh = 20000L;
+        final var feeComponents = FeeComponents.newBuilder().setRbh(rbh);
+        final var feeData = FeeData.newBuilder().setServicedata(feeComponents).build();
+        final var blockConsTime = Instant.ofEpochSecond(consensusTime);
+        final var blockNo = 123L;
 
-		given(messageFrame.getGasPrice()).willReturn(Wei.of(2000L));
-		given(messageFrame.getBlockValues()).willReturn(new HederaBlockValues(10L, blockNo, blockConsTime));
-		given(messageFrame.getContextVariable("HederaFunctionality")).willReturn(functionality);
-		given(messageFrame.getMessageFrameStack()).willReturn(returningDeque);
+        given(messageFrame.getGasPrice()).willReturn(Wei.of(2000L));
+        given(messageFrame.getBlockValues())
+                .willReturn(new HederaBlockValues(10L, blockNo, blockConsTime));
+        given(messageFrame.getContextVariable("HederaFunctionality")).willReturn(functionality);
+        given(messageFrame.getMessageFrameStack()).willReturn(returningDeque);
 
-		given(usagePricesProvider.defaultPricesGiven(functionality, timestamp)).willReturn(feeData);
-		given(hbarCentExchange.rate(timestamp)).willReturn(ExchangeRate.newBuilder().setHbarEquiv(2000).setCentEquiv(200).build());
+        given(usagePricesProvider.defaultPricesGiven(functionality, timestamp)).willReturn(feeData);
+        given(hbarCentExchange.rate(timestamp))
+                .willReturn(ExchangeRate.newBuilder().setHbarEquiv(2000).setCentEquiv(200).build());
 
-		assertEquals(28L, GasCalculatorHederaUtil.logOperationGasCost(usagePricesProvider, hbarCentExchange, messageFrame, 1000000, 1L, 2L, 3));
-		verify(messageFrame).getGasPrice();
-		verify(messageFrame).getBlockValues();
-		verify(messageFrame).getContextVariable("HederaFunctionality");
-		verify(messageFrame).getMessageFrameStack();
-		verify(usagePricesProvider).defaultPricesGiven(functionality, timestamp);
-		verify(hbarCentExchange).rate(timestamp);
-	}
+        assertEquals(
+                28L,
+                GasCalculatorHederaUtil.logOperationGasCost(
+                        usagePricesProvider, hbarCentExchange, messageFrame, 1000000, 1L, 2L, 3));
+        verify(messageFrame).getGasPrice();
+        verify(messageFrame).getBlockValues();
+        verify(messageFrame).getContextVariable("HederaFunctionality");
+        verify(messageFrame).getMessageFrameStack();
+        verify(usagePricesProvider).defaultPricesGiven(functionality, timestamp);
+        verify(hbarCentExchange).rate(timestamp);
+    }
 }

--- a/hedera-node/src/test/java/com/hedera/services/contracts/gascalculator/GasCalculatorHederaUtilTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/contracts/gascalculator/GasCalculatorHederaUtilTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2021-2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hedera.services.contracts.gascalculator;
 
 /*

--- a/hedera-node/src/test/java/com/hedera/services/contracts/gascalculator/GasCalculatorHederaV18Test.java
+++ b/hedera-node/src/test/java/com/hedera/services/contracts/gascalculator/GasCalculatorHederaV18Test.java
@@ -22,12 +22,23 @@ package com.hedera.services.contracts.gascalculator;
  *
  */
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
 import com.hedera.services.context.properties.GlobalDynamicProperties;
 import com.hedera.services.contracts.execution.HederaBlockValues;
 import com.hedera.services.fees.HbarCentExchange;
 import com.hedera.services.fees.calculation.UsagePricesProvider;
 import com.hedera.services.state.merkle.MerkleNetworkContext;
-import com.hederahashgraph.api.proto.java.*;
+import com.hederahashgraph.api.proto.java.ExchangeRate;
+import com.hederahashgraph.api.proto.java.FeeComponents;
+import com.hederahashgraph.api.proto.java.FeeData;
+import com.hederahashgraph.api.proto.java.HederaFunctionality;
+import com.hederahashgraph.api.proto.java.Timestamp;
+import java.time.Instant;
+import java.util.ArrayDeque;
 import org.apache.tuweni.bytes.Bytes;
 import org.hyperledger.besu.datatypes.Wei;
 import org.hyperledger.besu.evm.account.Account;
@@ -38,114 +49,104 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.time.Instant;
-import java.util.ArrayDeque;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-
 @ExtendWith(MockitoExtension.class)
 class GasCalculatorHederaV18Test {
 
-	@Mock
-	private GlobalDynamicProperties properties;
-	@Mock
-	private HbarCentExchange hbarCentExchange;
-	@Mock
-	private UsagePricesProvider usagePricesProvider;
-	@Mock
-	private MerkleNetworkContext merkleNetworkContext;
+    @Mock private GlobalDynamicProperties properties;
+    @Mock private HbarCentExchange hbarCentExchange;
+    @Mock private UsagePricesProvider usagePricesProvider;
+    @Mock private MerkleNetworkContext merkleNetworkContext;
 
-	private GasCalculatorHederaV18 gasCalculatorHedera;
+    private GasCalculatorHederaV18 gasCalculatorHedera;
 
-	@BeforeEach
-	private void setup() {
-		gasCalculatorHedera = new GasCalculatorHederaV18(properties, usagePricesProvider, hbarCentExchange);
-	}
+    @BeforeEach
+    private void setup() {
+        gasCalculatorHedera =
+                new GasCalculatorHederaV18(properties, usagePricesProvider, hbarCentExchange);
+    }
 
-	@Test
-	void assertAndVerifyLogOperationGasCost() {
-		final var messageFrame = mock(MessageFrame.class);
-		final var consensusTime = 123L;
-		final var functionality = HederaFunctionality.ContractCreate;
-		final var timestamp = Timestamp.newBuilder().setSeconds(consensusTime).build();
-		final var returningDeque = new ArrayDeque<MessageFrame>() {
-		};
-		returningDeque.add(messageFrame);
+    @Test
+    void assertAndVerifyLogOperationGasCost() {
+        final var messageFrame = mock(MessageFrame.class);
+        final var consensusTime = 123L;
+        final var functionality = HederaFunctionality.ContractCreate;
+        final var timestamp = Timestamp.newBuilder().setSeconds(consensusTime).build();
+        final var returningDeque = new ArrayDeque<MessageFrame>() {};
+        returningDeque.add(messageFrame);
 
-		final var rbh = 20000L;
-		final var feeComponents = FeeComponents.newBuilder().setRbh(rbh);
-		final var feeData = FeeData.newBuilder().setServicedata(feeComponents).build();
-		final var blockConsTime =  Instant.ofEpochSecond(consensusTime);
-		final var blockNo = 123L;
+        final var rbh = 20000L;
+        final var feeComponents = FeeComponents.newBuilder().setRbh(rbh);
+        final var feeData = FeeData.newBuilder().setServicedata(feeComponents).build();
+        final var blockConsTime = Instant.ofEpochSecond(consensusTime);
+        final var blockNo = 123L;
 
-		given(messageFrame.getGasPrice()).willReturn(Wei.of(2000L));
-		given(messageFrame.getBlockValues()).willReturn(new HederaBlockValues(10L, blockNo, blockConsTime));
-		given(messageFrame.getContextVariable("HederaFunctionality")).willReturn(functionality);
-		given(messageFrame.getMessageFrameStack()).willReturn(returningDeque);
+        given(messageFrame.getGasPrice()).willReturn(Wei.of(2000L));
+        given(messageFrame.getBlockValues())
+                .willReturn(new HederaBlockValues(10L, blockNo, blockConsTime));
+        given(messageFrame.getContextVariable("HederaFunctionality")).willReturn(functionality);
+        given(messageFrame.getMessageFrameStack()).willReturn(returningDeque);
 
-		given(usagePricesProvider.defaultPricesGiven(functionality, timestamp)).willReturn(feeData);
-		given(hbarCentExchange.rate(timestamp)).willReturn(ExchangeRate.newBuilder().setHbarEquiv(2000).setCentEquiv(200).build());
-		given(properties.cacheRecordsTtl()).willReturn(1000000);
-		assertEquals(28L, gasCalculatorHedera.logOperationGasCost(messageFrame, 1L, 2L, 3));
-		verify(messageFrame).getGasPrice();
-		verify(messageFrame).getBlockValues();
-		verify(messageFrame).getContextVariable("HederaFunctionality");
-		verify(messageFrame).getMessageFrameStack();
-		verify(usagePricesProvider).defaultPricesGiven(functionality, timestamp);
-		verify(hbarCentExchange).rate(timestamp);
-	}
+        given(usagePricesProvider.defaultPricesGiven(functionality, timestamp)).willReturn(feeData);
+        given(hbarCentExchange.rate(timestamp))
+                .willReturn(ExchangeRate.newBuilder().setHbarEquiv(2000).setCentEquiv(200).build());
+        given(properties.cacheRecordsTtl()).willReturn(1000000);
+        assertEquals(28L, gasCalculatorHedera.logOperationGasCost(messageFrame, 1L, 2L, 3));
+        verify(messageFrame).getGasPrice();
+        verify(messageFrame).getBlockValues();
+        verify(messageFrame).getContextVariable("HederaFunctionality");
+        verify(messageFrame).getMessageFrameStack();
+        verify(usagePricesProvider).defaultPricesGiven(functionality, timestamp);
+        verify(hbarCentExchange).rate(timestamp);
+    }
 
-	@Test
-	void assertCodeDepositGasCostIsZero() {
-		assertEquals(0L, gasCalculatorHedera.codeDepositGasCost(10));
-	}
+    @Test
+    void assertCodeDepositGasCostIsZero() {
+        assertEquals(0L, gasCalculatorHedera.codeDepositGasCost(10));
+    }
 
-	@Test
-	void assertTransactionIntrinsicGasCost() {
-		assertEquals(0L, gasCalculatorHedera.transactionIntrinsicGasCost(Bytes.EMPTY, true));
-	}
+    @Test
+    void assertTransactionIntrinsicGasCost() {
+        assertEquals(0L, gasCalculatorHedera.transactionIntrinsicGasCost(Bytes.EMPTY, true));
+    }
 
-	@Test
-	void assertGetBalanceOperationGasCost() {
-		assertEquals(20L, gasCalculatorHedera.getBalanceOperationGasCost());
-	}
+    @Test
+    void assertGetBalanceOperationGasCost() {
+        assertEquals(20L, gasCalculatorHedera.getBalanceOperationGasCost());
+    }
 
-	@Test
-	void assertExpOperationByteGasCost() {
-		assertEquals(10L, gasCalculatorHedera.expOperationByteGasCost());
-	}
+    @Test
+    void assertExpOperationByteGasCost() {
+        assertEquals(10L, gasCalculatorHedera.expOperationByteGasCost());
+    }
 
-	@Test
-	void assertExtCodeBaseGasCost() {
-		assertEquals(20L, gasCalculatorHedera.extCodeBaseGasCost());
-	}
+    @Test
+    void assertExtCodeBaseGasCost() {
+        assertEquals(20L, gasCalculatorHedera.extCodeBaseGasCost());
+    }
 
-	@Test
-	void assertCallOperationBaseGasCost() {
-		assertEquals(40L, gasCalculatorHedera.callOperationBaseGasCost());
-	}
+    @Test
+    void assertCallOperationBaseGasCost() {
+        assertEquals(40L, gasCalculatorHedera.callOperationBaseGasCost());
+    }
 
-	@Test
-	void assertGetExtCodeSizeOperationGasCost() {
-		assertEquals(20L, gasCalculatorHedera.getExtCodeSizeOperationGasCost());
-	}
+    @Test
+    void assertGetExtCodeSizeOperationGasCost() {
+        assertEquals(20L, gasCalculatorHedera.getExtCodeSizeOperationGasCost());
+    }
 
-	@Test
-	void assertExtCodeHashOperationGasCost() {
-		assertEquals(400L, gasCalculatorHedera.extCodeHashOperationGasCost());
-	}
+    @Test
+    void assertExtCodeHashOperationGasCost() {
+        assertEquals(400L, gasCalculatorHedera.extCodeHashOperationGasCost());
+    }
 
-	@Test
-	void assertSelfDestructOperationGasCost() {
-		Account recipient = mock(Account.class);
-		assertEquals(0L, gasCalculatorHedera.selfDestructOperationGasCost(recipient, Wei.of(10L)));
-	}
+    @Test
+    void assertSelfDestructOperationGasCost() {
+        Account recipient = mock(Account.class);
+        assertEquals(0L, gasCalculatorHedera.selfDestructOperationGasCost(recipient, Wei.of(10L)));
+    }
 
-	@Test
-	void assertGetSloadOperationGasCost() {
-		assertEquals(50L, gasCalculatorHedera.getSloadOperationGasCost());
-	}
+    @Test
+    void assertGetSloadOperationGasCost() {
+        assertEquals(50L, gasCalculatorHedera.getSloadOperationGasCost());
+    }
 }

--- a/hedera-node/src/test/java/com/hedera/services/contracts/gascalculator/GasCalculatorHederaV18Test.java
+++ b/hedera-node/src/test/java/com/hedera/services/contracts/gascalculator/GasCalculatorHederaV18Test.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2021-2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hedera.services.contracts.gascalculator;
 
 /*

--- a/hedera-node/src/test/java/com/hedera/services/contracts/gascalculator/GasCalculatorHederaV19Test.java
+++ b/hedera-node/src/test/java/com/hedera/services/contracts/gascalculator/GasCalculatorHederaV19Test.java
@@ -22,12 +22,22 @@ package com.hedera.services.contracts.gascalculator;
  *
  */
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
 import com.hedera.services.context.properties.GlobalDynamicProperties;
 import com.hedera.services.contracts.execution.HederaBlockValues;
 import com.hedera.services.fees.HbarCentExchange;
 import com.hedera.services.fees.calculation.UsagePricesProvider;
 import com.hedera.services.state.merkle.MerkleNetworkContext;
-import com.hederahashgraph.api.proto.java.*;
+import com.hederahashgraph.api.proto.java.ExchangeRate;
+import com.hederahashgraph.api.proto.java.FeeComponents;
+import com.hederahashgraph.api.proto.java.FeeData;
+import com.hederahashgraph.api.proto.java.HederaFunctionality;
+import com.hederahashgraph.api.proto.java.Timestamp;
+import java.time.Instant;
+import java.util.ArrayDeque;
 import org.apache.tuweni.bytes.Bytes;
 import org.hyperledger.besu.datatypes.Wei;
 import org.hyperledger.besu.evm.frame.MessageFrame;
@@ -37,31 +47,21 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.time.Instant;
-import java.util.ArrayDeque;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.verify;
-
 @ExtendWith(MockitoExtension.class)
 class GasCalculatorHederaV19Test {
     GasCalculatorHederaV19 subject;
 
-    @Mock
-    private GlobalDynamicProperties globalDynamicProperties;
-    @Mock
-    private UsagePricesProvider usagePricesProvider;
-    @Mock
-    private HbarCentExchange hbarCentExchange;
-    @Mock
-    private MessageFrame messageFrame;
-    @Mock
-    private MerkleNetworkContext merkleNetworkContext;
+    @Mock private GlobalDynamicProperties globalDynamicProperties;
+    @Mock private UsagePricesProvider usagePricesProvider;
+    @Mock private HbarCentExchange hbarCentExchange;
+    @Mock private MessageFrame messageFrame;
+    @Mock private MerkleNetworkContext merkleNetworkContext;
 
     @BeforeEach
     void setUp() {
-        subject = new GasCalculatorHederaV19(globalDynamicProperties, usagePricesProvider, hbarCentExchange);
+        subject =
+                new GasCalculatorHederaV19(
+                        globalDynamicProperties, usagePricesProvider, hbarCentExchange);
     }
 
     @Test
@@ -79,22 +79,24 @@ class GasCalculatorHederaV19Test {
         final var consensusTime = 123L;
         final var functionality = HederaFunctionality.ContractCreate;
         final var timestamp = Timestamp.newBuilder().setSeconds(consensusTime).build();
-        final var returningDeque = new ArrayDeque<MessageFrame>(){};
+        final var returningDeque = new ArrayDeque<MessageFrame>() {};
         returningDeque.add(messageFrame);
 
         final var rbh = 20000L;
         final var feeComponents = FeeComponents.newBuilder().setRbh(rbh);
         final var feeData = FeeData.newBuilder().setServicedata(feeComponents).build();
-        final var blockConsTime =  Instant.ofEpochSecond(consensusTime);
+        final var blockConsTime = Instant.ofEpochSecond(consensusTime);
         final var blockNo = 123L;
 
         given(messageFrame.getGasPrice()).willReturn(Wei.of(2000L));
-        given(messageFrame.getBlockValues()).willReturn(new HederaBlockValues(10L, blockNo, blockConsTime));
+        given(messageFrame.getBlockValues())
+                .willReturn(new HederaBlockValues(10L, blockNo, blockConsTime));
         given(messageFrame.getContextVariable("HederaFunctionality")).willReturn(functionality);
         given(messageFrame.getMessageFrameStack()).willReturn(returningDeque);
 
         given(usagePricesProvider.defaultPricesGiven(functionality, timestamp)).willReturn(feeData);
-        given(hbarCentExchange.rate(timestamp)).willReturn(ExchangeRate.newBuilder().setHbarEquiv(2000).setCentEquiv(200).build());
+        given(hbarCentExchange.rate(timestamp))
+                .willReturn(ExchangeRate.newBuilder().setHbarEquiv(2000).setCentEquiv(200).build());
 
         assertEquals(1516L, subject.logOperationGasCost(messageFrame, 1L, 2L, 3));
         verify(messageFrame).getGasPrice();

--- a/hedera-node/src/test/java/com/hedera/services/contracts/gascalculator/GasCalculatorHederaV19Test.java
+++ b/hedera-node/src/test/java/com/hedera/services/contracts/gascalculator/GasCalculatorHederaV19Test.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2021-2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hedera.services.contracts.gascalculator;
 
 /*

--- a/hedera-node/src/test/java/com/hedera/services/contracts/gascalculator/GasCalculatorHederaV22Test.java
+++ b/hedera-node/src/test/java/com/hedera/services/contracts/gascalculator/GasCalculatorHederaV22Test.java
@@ -22,6 +22,8 @@ package com.hedera.services.contracts.gascalculator;
  *
  */
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import com.hedera.services.context.properties.GlobalDynamicProperties;
 import com.hedera.services.fees.HbarCentExchange;
 import com.hedera.services.fees.calculation.UsagePricesProvider;
@@ -32,42 +34,41 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
 @ExtendWith(MockitoExtension.class)
 class GasCalculatorHederaV22Test {
     GasCalculatorHederaV22 subject;
 
-    @Mock
-    GlobalDynamicProperties globalDynamicProperties;
+    @Mock GlobalDynamicProperties globalDynamicProperties;
 
-    @Mock
-    UsagePricesProvider usagePricesProvider;
+    @Mock UsagePricesProvider usagePricesProvider;
 
-    @Mock
-    HbarCentExchange hbarCentExchange;
+    @Mock HbarCentExchange hbarCentExchange;
 
     @BeforeEach
     void setUp() {
-        subject = new GasCalculatorHederaV22(globalDynamicProperties, usagePricesProvider, hbarCentExchange);
+        subject =
+                new GasCalculatorHederaV22(
+                        globalDynamicProperties, usagePricesProvider, hbarCentExchange);
     }
 
     @Test
     void gasDepositCost() {
-//        assertEquals(200 * 37, subject.codeDepositGasCost(37));
+        //        assertEquals(200 * 37, subject.codeDepositGasCost(37));
         assertEquals(0L, subject.codeDepositGasCost(37));
     }
 
     @Test
     void transactionIntrinsicGasCost() {
-        assertEquals(4 * 2 +  // zero byte cost
-                     16 * 3 +  // non-zero byte cost
-                     21_000L,   // base TX cost
+        assertEquals(
+                4 * 2 + // zero byte cost
+                        16 * 3 + // non-zero byte cost
+                        21_000L, // base TX cost
                 subject.transactionIntrinsicGasCost(Bytes.of(0, 1, 2, 3, 0), false));
-        assertEquals(4 * 3 +  // zero byte cost
-                     16 * 2 +  // non-zero byte cost
-                     21_000L + // base TX cost
-                     32_000L,   // contract creation base cost
+        assertEquals(
+                4 * 3 + // zero byte cost
+                        16 * 2 + // non-zero byte cost
+                        21_000L + // base TX cost
+                        32_000L, // contract creation base cost
                 subject.transactionIntrinsicGasCost(Bytes.of(0, 1, 0, 3, 0), true));
     }
 }

--- a/hedera-node/src/test/java/com/hedera/services/contracts/gascalculator/GasCalculatorHederaV22Test.java
+++ b/hedera-node/src/test/java/com/hedera/services/contracts/gascalculator/GasCalculatorHederaV22Test.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2020-2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hedera.services.contracts.gascalculator;
 
 /*

--- a/hedera-node/src/test/java/com/hedera/services/contracts/gascalculator/StorageGasCalculatorTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/contracts/gascalculator/StorageGasCalculatorTest.java
@@ -1,11 +1,6 @@
-package com.hedera.services.contracts.gascalculator;
-
-/*-
- * ‌
- * Hedera Services Node
- * ​
- * Copyright (C) 2018 - 2022 Hedera Hashgraph, LLC
- * ​
+/*
+ * Copyright (C) 2022 Hedera Hashgraph, LLC
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -17,8 +12,8 @@ package com.hedera.services.contracts.gascalculator;
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- * ‍
  */
+package com.hedera.services.contracts.gascalculator;
 
 import static com.hedera.services.contracts.execution.CreateEvmTxProcessor.EXPIRY_ORACLE_CONTEXT_KEY;
 import static com.hedera.services.contracts.execution.CreateEvmTxProcessor.SBH_CONTEXT_KEY;

--- a/hedera-node/src/test/java/com/hedera/services/contracts/gascalculator/StorageGasCalculatorTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/contracts/gascalculator/StorageGasCalculatorTest.java
@@ -9,9 +9,9 @@ package com.hedera.services.contracts.gascalculator;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,7 +20,13 @@ package com.hedera.services.contracts.gascalculator;
  * ‍
  */
 
+import static com.hedera.services.contracts.execution.CreateEvmTxProcessor.EXPIRY_ORACLE_CONTEXT_KEY;
+import static com.hedera.services.contracts.execution.CreateEvmTxProcessor.SBH_CONTEXT_KEY;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.BDDMockito.given;
+
 import com.hedera.services.txns.contract.helpers.StorageExpiry;
+import java.util.Deque;
 import org.apache.tuweni.bytes.Bytes;
 import org.hyperledger.besu.datatypes.Wei;
 import org.hyperledger.besu.evm.frame.BlockValues;
@@ -31,77 +37,62 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.util.Deque;
-
-import static com.hedera.services.contracts.execution.CreateEvmTxProcessor.EXPIRY_ORACLE_CONTEXT_KEY;
-import static com.hedera.services.contracts.execution.CreateEvmTxProcessor.SBH_CONTEXT_KEY;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.BDDMockito.given;
-
 @ExtendWith(MockitoExtension.class)
 class StorageGasCalculatorTest {
-	@Mock
-	private MessageFrame frame;
-	@Mock
-	private MessageFrame lastStackFrame;
-	@Mock
-	private GasCalculator gasCalculator;
-	@Mock
-	private BlockValues blockValues;
-	@Mock
-	private Deque<MessageFrame> stack;
-	@Mock
-	private StorageExpiry.Oracle oracle;
+    @Mock private MessageFrame frame;
+    @Mock private MessageFrame lastStackFrame;
+    @Mock private GasCalculator gasCalculator;
+    @Mock private BlockValues blockValues;
+    @Mock private Deque<MessageFrame> stack;
+    @Mock private StorageExpiry.Oracle oracle;
 
-	private StorageGasCalculator subject = new StorageGasCalculator();
+    private StorageGasCalculator subject = new StorageGasCalculator();
 
-	@Test
-	void computesHappyPathAsExpected() {
-		setupFrame();
-		given(gasCalculator.memoryExpansionGasCost(frame, 10L, 20L))
-				.willReturn(memExpansionCost);
+    @Test
+    void computesHappyPathAsExpected() {
+        setupFrame();
+        given(gasCalculator.memoryExpansionGasCost(frame, 10L, 20L)).willReturn(memExpansionCost);
 
-		final var expected = (storageCostTinybars / gasPrice.toLong()) + memExpansionCost;
-		final var actual = subject.creationGasCost(frame, gasCalculator);
+        final var expected = (storageCostTinybars / gasPrice.toLong()) + memExpansionCost;
+        final var actual = subject.creationGasCost(frame, gasCalculator);
 
-		assertEquals(expected, actual);
-	}
+        assertEquals(expected, actual);
+    }
 
-	@Test
-	void neverChargesNegativeGas() {
-		setupFrame();
-		given(gasCalculator.memoryExpansionGasCost(frame, 10L, 20L))
-				.willReturn(memExpansionCost);
-		given(oracle.storageExpiryIn(frame)).willReturn(now - 1);
+    @Test
+    void neverChargesNegativeGas() {
+        setupFrame();
+        given(gasCalculator.memoryExpansionGasCost(frame, 10L, 20L)).willReturn(memExpansionCost);
+        given(oracle.storageExpiryIn(frame)).willReturn(now - 1);
 
-		final var expected = memExpansionCost;
-		final var actual = subject.creationGasCost(frame, gasCalculator);
+        final var expected = memExpansionCost;
+        final var actual = subject.creationGasCost(frame, gasCalculator);
 
-		assertEquals(expected, actual);
-	}
+        assertEquals(expected, actual);
+    }
 
-	private void setupFrame() {
-		given(blockValues.getTimestamp()).willReturn(now);
-		given(oracle.storageExpiryIn(frame)).willReturn(prophesiedExpiry);
+    private void setupFrame() {
+        given(blockValues.getTimestamp()).willReturn(now);
+        given(oracle.storageExpiryIn(frame)).willReturn(prophesiedExpiry);
 
-		given(frame.getGasPrice()).willReturn(gasPrice);
-		given(frame.getStackItem(1)).willReturn(oneOffsetStackItem);
-		given(frame.getStackItem(2)).willReturn(twoOffsetStackItem);
-		given(frame.getBlockValues()).willReturn(blockValues);
-		given(frame.getMessageFrameStack()).willReturn(stack);
+        given(frame.getGasPrice()).willReturn(gasPrice);
+        given(frame.getStackItem(1)).willReturn(oneOffsetStackItem);
+        given(frame.getStackItem(2)).willReturn(twoOffsetStackItem);
+        given(frame.getBlockValues()).willReturn(blockValues);
+        given(frame.getMessageFrameStack()).willReturn(stack);
 
-		given(stack.getLast()).willReturn(lastStackFrame);
-		given(lastStackFrame.getContextVariable(SBH_CONTEXT_KEY)).willReturn(sbh);
-		given(lastStackFrame.getContextVariable(EXPIRY_ORACLE_CONTEXT_KEY)).willReturn(oracle);
-	}
+        given(stack.getLast()).willReturn(lastStackFrame);
+        given(lastStackFrame.getContextVariable(SBH_CONTEXT_KEY)).willReturn(sbh);
+        given(lastStackFrame.getContextVariable(EXPIRY_ORACLE_CONTEXT_KEY)).willReturn(oracle);
+    }
 
-	private static final Wei gasPrice = Wei.of(42);
-	private static final long memExpansionCost = 1000L;
-	private static final long sbh = 12;
-	private static final long now = 1_234_567L;
-	private static final long lifetimeSecs = 7776000L;
-	private static final long prophesiedExpiry = now + lifetimeSecs;
-	private static final long storageCostTinybars = lifetimeSecs * sbh / 3600;
-	private static final Bytes oneOffsetStackItem = Bytes.of(10);
-	private static final Bytes twoOffsetStackItem = Bytes.of(20);
+    private static final Wei gasPrice = Wei.of(42);
+    private static final long memExpansionCost = 1000L;
+    private static final long sbh = 12;
+    private static final long now = 1_234_567L;
+    private static final long lifetimeSecs = 7776000L;
+    private static final long prophesiedExpiry = now + lifetimeSecs;
+    private static final long storageCostTinybars = lifetimeSecs * sbh / 3600;
+    private static final Bytes oneOffsetStackItem = Bytes.of(10);
+    private static final Bytes twoOffsetStackItem = Bytes.of(20);
 }

--- a/hedera-node/src/test/java/com/hedera/services/contracts/operation/AbstractRecordingCreateOperationTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/contracts/operation/AbstractRecordingCreateOperationTest.java
@@ -1,11 +1,6 @@
-package com.hedera.services.contracts.operation;
-
-/*-
- * ‌
- * Hedera Services Node
- * ​
- * Copyright (C) 2018 - 2022 Hedera Hashgraph, LLC
- * ​
+/*
+ * Copyright (C) 2022 Hedera Hashgraph, LLC
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -17,8 +12,8 @@ package com.hedera.services.contracts.operation;
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- * ‍
  */
+package com.hedera.services.contracts.operation;
 
 import static com.hedera.services.contracts.operation.AbstractRecordingCreateOperation.haltWith;
 import static com.hedera.services.state.EntityCreator.EMPTY_MEMO;

--- a/hedera-node/src/test/java/com/hedera/services/contracts/operation/AbstractRecordingCreateOperationTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/contracts/operation/AbstractRecordingCreateOperationTest.java
@@ -9,9 +9,9 @@ package com.hedera.services.contracts.operation;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -19,6 +19,21 @@ package com.hedera.services.contracts.operation;
  * limitations under the License.
  * ‍
  */
+
+import static com.hedera.services.contracts.operation.AbstractRecordingCreateOperation.haltWith;
+import static com.hedera.services.state.EntityCreator.EMPTY_MEMO;
+import static org.hyperledger.besu.evm.frame.ExceptionalHaltReason.ILLEGAL_STATE_CHANGE;
+import static org.hyperledger.besu.evm.frame.ExceptionalHaltReason.INSUFFICIENT_GAS;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
 
 import com.hedera.services.context.SideEffectsTracker;
 import com.hedera.services.ledger.TransactionalLedger;
@@ -33,12 +48,15 @@ import com.hedera.services.state.submerkle.ExpirableTxnRecord;
 import com.hedera.services.store.contracts.HederaStackedWorldStateUpdater;
 import com.hedera.services.store.contracts.WorldLedgers;
 import com.hedera.services.store.contracts.precompile.SyntheticTxnFactory;
-import com.hedera.services.utils.EntityIdUtils;
 import com.hedera.test.utils.IdUtils;
 import com.hederahashgraph.api.proto.java.AccountID;
 import com.hederahashgraph.api.proto.java.ContractCreateTransactionBody;
 import com.hederahashgraph.api.proto.java.ContractID;
 import com.hederahashgraph.api.proto.java.TransactionBody;
+import java.util.Collections;
+import java.util.Deque;
+import java.util.Optional;
+import java.util.OptionalLong;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.units.bigints.UInt256;
 import org.hyperledger.besu.datatypes.Address;
@@ -59,259 +77,241 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.util.Collections;
-import java.util.Deque;
-import java.util.Optional;
-import java.util.OptionalLong;
-
-import static com.hedera.services.contracts.operation.AbstractRecordingCreateOperation.haltWith;
-import static com.hedera.services.state.EntityCreator.EMPTY_MEMO;
-import static org.hyperledger.besu.evm.frame.ExceptionalHaltReason.ILLEGAL_STATE_CHANGE;
-import static org.hyperledger.besu.evm.frame.ExceptionalHaltReason.INSUFFICIENT_GAS;
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.verify;
-
 @ExtendWith(MockitoExtension.class)
 class AbstractRecordingCreateOperationTest {
-	@Mock
-	private SyntheticTxnFactory syntheticTxnFactory;
-	@Mock
-	private GasCalculator gasCalculator;
-	@Mock
-	private EVM evm;
-	@Mock
-	private MessageFrame frame;
-	@Mock
-	private EvmAccount recipientAccount;
-	@Mock
-	private MutableAccount mutableAccount;
-	@Mock
-	private HederaStackedWorldStateUpdater updater;
-	@Mock
-	private Deque<MessageFrame> stack;
-	@Mock
-	private BlockValues blockValues;
-	@Mock
-	private EntityCreator creator;
-	@Mock
-	private RecordsHistorian recordsHistorian;
-	@Mock
-	private ContractCustomizer contractCustomizer;
-	@Mock
-	private WorldLedgers ledgers;
-	@Mock
-	private TransactionalLedger<AccountID, AccountProperty, MerkleAccount> accountsLedger;
+    @Mock private SyntheticTxnFactory syntheticTxnFactory;
+    @Mock private GasCalculator gasCalculator;
+    @Mock private EVM evm;
+    @Mock private MessageFrame frame;
+    @Mock private EvmAccount recipientAccount;
+    @Mock private MutableAccount mutableAccount;
+    @Mock private HederaStackedWorldStateUpdater updater;
+    @Mock private Deque<MessageFrame> stack;
+    @Mock private BlockValues blockValues;
+    @Mock private EntityCreator creator;
+    @Mock private RecordsHistorian recordsHistorian;
+    @Mock private ContractCustomizer contractCustomizer;
+    @Mock private WorldLedgers ledgers;
+    @Mock private TransactionalLedger<AccountID, AccountProperty, MerkleAccount> accountsLedger;
 
-	private static final long childStipend = 1_000_000L;
-	private static final Wei gasPrice = Wei.of(1000L);
-	private static final long value = 123_456L;
-	private static final ContractID lastAllocated = IdUtils.asContract("0.0.1234");
-	private static final Address recipient = Address.BLAKE2B_F_COMPRESSION;
-	private static final Operation.OperationResult EMPTY_HALT_RESULT =
-			new Operation.OperationResult(Subject.PRETEND_OPTIONAL_COST, Optional.empty());
-	private static final EntityId autoRenewId = new EntityId(0, 0, 8);
+    private static final long childStipend = 1_000_000L;
+    private static final Wei gasPrice = Wei.of(1000L);
+    private static final long value = 123_456L;
+    private static final ContractID lastAllocated = IdUtils.asContract("0.0.1234");
+    private static final Address recipient = Address.BLAKE2B_F_COMPRESSION;
+    private static final Operation.OperationResult EMPTY_HALT_RESULT =
+            new Operation.OperationResult(Subject.PRETEND_OPTIONAL_COST, Optional.empty());
+    private static final EntityId autoRenewId = new EntityId(0, 0, 8);
 
-	private Subject subject;
+    private Subject subject;
 
-	@BeforeEach
-	void setUp() {
-		subject = new Subject(
-				0xF0,
-				"ħCREATE",
-				3,
-				1,
-				1,
-				gasCalculator,
-				creator,
-				syntheticTxnFactory,
-				recordsHistorian);
-	}
+    @BeforeEach
+    void setUp() {
+        subject =
+                new Subject(
+                        0xF0,
+                        "ħCREATE",
+                        3,
+                        1,
+                        1,
+                        gasCalculator,
+                        creator,
+                        syntheticTxnFactory,
+                        recordsHistorian);
+    }
 
-	@Test
-	void returnsUnderflowWhenStackSizeTooSmall() {
-		given(frame.stackSize()).willReturn(2);
+    @Test
+    void returnsUnderflowWhenStackSizeTooSmall() {
+        given(frame.stackSize()).willReturn(2);
 
-		assertSame(Subject.UNDERFLOW_RESPONSE, subject.execute(frame, evm));
-	}
+        assertSame(Subject.UNDERFLOW_RESPONSE, subject.execute(frame, evm));
+    }
 
-	@Test
-	void returnsInvalidWhenDisabled() {
-		subject.isEnabled = false;
+    @Test
+    void returnsInvalidWhenDisabled() {
+        subject.isEnabled = false;
 
-		assertSame(Subject.INVALID_RESPONSE, subject.execute(frame, evm));
-	}
+        assertSame(Subject.INVALID_RESPONSE, subject.execute(frame, evm));
+    }
 
-	@Test
-	void haltsOnStaticFrame() {
-		given(frame.stackSize()).willReturn(3);
-		given(frame.isStatic()).willReturn(true);
+    @Test
+    void haltsOnStaticFrame() {
+        given(frame.stackSize()).willReturn(3);
+        given(frame.isStatic()).willReturn(true);
 
-		final var expected = haltWith(Subject.PRETEND_OPTIONAL_COST, ILLEGAL_STATE_CHANGE);
+        final var expected = haltWith(Subject.PRETEND_OPTIONAL_COST, ILLEGAL_STATE_CHANGE);
 
-		assertSameResult(expected, subject.execute(frame, evm));
-	}
+        assertSameResult(expected, subject.execute(frame, evm));
+    }
 
-	@Test
-	void haltsOnInsufficientGas() {
-		given(frame.stackSize()).willReturn(3);
-		given(frame.getRemainingGas()).willReturn(Subject.PRETEND_GAS_COST - 1);
+    @Test
+    void haltsOnInsufficientGas() {
+        given(frame.stackSize()).willReturn(3);
+        given(frame.getRemainingGas()).willReturn(Subject.PRETEND_GAS_COST - 1);
 
-		final var expected = haltWith(Subject.PRETEND_OPTIONAL_COST, INSUFFICIENT_GAS);
+        final var expected = haltWith(Subject.PRETEND_OPTIONAL_COST, INSUFFICIENT_GAS);
 
-		assertSameResult(expected, subject.execute(frame, evm));
-	}
+        assertSameResult(expected, subject.execute(frame, evm));
+    }
 
-	@Test
-	void failsWithInsufficientRecipientBalanceForValue() {
-		given(frame.stackSize()).willReturn(3);
-		given(frame.getStackItem(anyInt())).willReturn(Bytes.ofUnsignedLong(1));
-		given(frame.getRemainingGas()).willReturn(Subject.PRETEND_GAS_COST);
-		given(frame.getStackItem(0)).willReturn(Bytes.ofUnsignedLong(value));
-		given(frame.getRecipientAddress()).willReturn(recipient);
-		given(frame.getWorldUpdater()).willReturn(updater);
-		given(updater.getAccount(recipient)).willReturn(recipientAccount);
-		given(recipientAccount.getMutable()).willReturn(mutableAccount);
-		given(mutableAccount.getBalance()).willReturn(Wei.ONE);
+    @Test
+    void failsWithInsufficientRecipientBalanceForValue() {
+        given(frame.stackSize()).willReturn(3);
+        given(frame.getStackItem(anyInt())).willReturn(Bytes.ofUnsignedLong(1));
+        given(frame.getRemainingGas()).willReturn(Subject.PRETEND_GAS_COST);
+        given(frame.getStackItem(0)).willReturn(Bytes.ofUnsignedLong(value));
+        given(frame.getRecipientAddress()).willReturn(recipient);
+        given(frame.getWorldUpdater()).willReturn(updater);
+        given(updater.getAccount(recipient)).willReturn(recipientAccount);
+        given(recipientAccount.getMutable()).willReturn(mutableAccount);
+        given(mutableAccount.getBalance()).willReturn(Wei.ONE);
 
-		assertSameResult(EMPTY_HALT_RESULT, subject.execute(frame, evm));
-		verify(frame).pushStackItem(UInt256.ZERO);
-	}
+        assertSameResult(EMPTY_HALT_RESULT, subject.execute(frame, evm));
+        verify(frame).pushStackItem(UInt256.ZERO);
+    }
 
-	@Test
-	void failsWithExcessStackDepth() {
-		givenSpawnPrereqs();
-		given(frame.getMessageStackDepth()).willReturn(1024);
+    @Test
+    void failsWithExcessStackDepth() {
+        givenSpawnPrereqs();
+        given(frame.getMessageStackDepth()).willReturn(1024);
 
-		assertSameResult(EMPTY_HALT_RESULT, subject.execute(frame, evm));
-		verify(frame).pushStackItem(UInt256.ZERO);
-	}
+        assertSameResult(EMPTY_HALT_RESULT, subject.execute(frame, evm));
+        verify(frame).pushStackItem(UInt256.ZERO);
+    }
 
-	@Test
-	void hasExpectedChildCompletionOnSuccess() {
-		final var trackerCaptor = ArgumentCaptor.forClass(SideEffectsTracker.class);
-		final var liveRecord = ExpirableTxnRecord.newBuilder()
-				.setReceiptBuilder(TxnReceipt.newBuilder().setStatus(TxnReceipt.REVERTED_SUCCESS_LITERAL));
-		final var mockCreation = TransactionBody.newBuilder()
-				.setContractCreateInstance(ContractCreateTransactionBody.newBuilder().setAutoRenewAccountId(autoRenewId.toGrpcAccountId()));
-		final var frameCaptor = ArgumentCaptor.forClass(MessageFrame.class);
-		givenSpawnPrereqs();
-		givenBuilderPrereqs();
-		given(updater.customizerForPendingCreation()).willReturn(contractCustomizer);
-		given(syntheticTxnFactory.contractCreation(contractCustomizer)).willReturn(mockCreation);
-		given(creator.createSuccessfulSyntheticRecord(any(), any(), any())).willReturn(liveRecord);
-		given(updater.idOfLastNewAddress()).willReturn(lastAllocated);
+    @Test
+    void hasExpectedChildCompletionOnSuccess() {
+        final var trackerCaptor = ArgumentCaptor.forClass(SideEffectsTracker.class);
+        final var liveRecord =
+                ExpirableTxnRecord.newBuilder()
+                        .setReceiptBuilder(
+                                TxnReceipt.newBuilder()
+                                        .setStatus(TxnReceipt.REVERTED_SUCCESS_LITERAL));
+        final var mockCreation =
+                TransactionBody.newBuilder()
+                        .setContractCreateInstance(
+                                ContractCreateTransactionBody.newBuilder()
+                                        .setAutoRenewAccountId(autoRenewId.toGrpcAccountId()));
+        final var frameCaptor = ArgumentCaptor.forClass(MessageFrame.class);
+        givenSpawnPrereqs();
+        givenBuilderPrereqs();
+        given(updater.customizerForPendingCreation()).willReturn(contractCustomizer);
+        given(syntheticTxnFactory.contractCreation(contractCustomizer)).willReturn(mockCreation);
+        given(creator.createSuccessfulSyntheticRecord(any(), any(), any())).willReturn(liveRecord);
+        given(updater.idOfLastNewAddress()).willReturn(lastAllocated);
 
-		assertSameResult(EMPTY_HALT_RESULT, subject.execute(frame, evm));
+        assertSameResult(EMPTY_HALT_RESULT, subject.execute(frame, evm));
 
-		verify(stack).addFirst(frameCaptor.capture());
-		final var childFrame = frameCaptor.getValue();
-		// when:
-		childFrame.setState(MessageFrame.State.COMPLETED_SUCCESS);
-		childFrame.notifyCompletion();
-		// then:
-		verify(frame).pushStackItem(Words.fromAddress(Subject.PRETEND_CONTRACT_ADDRESS));
-		verify(creator).createSuccessfulSyntheticRecord(
-				eq(Collections.emptyList()), trackerCaptor.capture(), eq(EMPTY_MEMO));
-		verify(updater).manageInProgressRecord(recordsHistorian, liveRecord, mockCreation);
-		// and:
-		final var tracker = trackerCaptor.getValue();
-		assertTrue(tracker.hasTrackedContractCreation());
-		assertEquals(lastAllocated, tracker.getTrackedNewContractId());
-		assertArrayEquals(Subject.PRETEND_CONTRACT_ADDRESS.toArrayUnsafe(), tracker.getNewEntityAlias().toByteArray());
-		// and:
-		assertTrue(liveRecord.shouldNotBeExternalized());
-	}
+        verify(stack).addFirst(frameCaptor.capture());
+        final var childFrame = frameCaptor.getValue();
+        // when:
+        childFrame.setState(MessageFrame.State.COMPLETED_SUCCESS);
+        childFrame.notifyCompletion();
+        // then:
+        verify(frame).pushStackItem(Words.fromAddress(Subject.PRETEND_CONTRACT_ADDRESS));
+        verify(creator)
+                .createSuccessfulSyntheticRecord(
+                        eq(Collections.emptyList()), trackerCaptor.capture(), eq(EMPTY_MEMO));
+        verify(updater).manageInProgressRecord(recordsHistorian, liveRecord, mockCreation);
+        // and:
+        final var tracker = trackerCaptor.getValue();
+        assertTrue(tracker.hasTrackedContractCreation());
+        assertEquals(lastAllocated, tracker.getTrackedNewContractId());
+        assertArrayEquals(
+                Subject.PRETEND_CONTRACT_ADDRESS.toArrayUnsafe(),
+                tracker.getNewEntityAlias().toByteArray());
+        // and:
+        assertTrue(liveRecord.shouldNotBeExternalized());
+    }
 
-	@Test
-	void hasExpectedChildCompletionOnFailure() {
-		final var captor = ArgumentCaptor.forClass(MessageFrame.class);
-		givenSpawnPrereqs();
-		givenBuilderPrereqs();
+    @Test
+    void hasExpectedChildCompletionOnFailure() {
+        final var captor = ArgumentCaptor.forClass(MessageFrame.class);
+        givenSpawnPrereqs();
+        givenBuilderPrereqs();
 
-		assertSameResult(EMPTY_HALT_RESULT, subject.execute(frame, evm));
+        assertSameResult(EMPTY_HALT_RESULT, subject.execute(frame, evm));
 
-		verify(stack).addFirst(captor.capture());
-		final var childFrame = captor.getValue();
-		// when:
-		childFrame.setState(MessageFrame.State.COMPLETED_FAILED);
-		childFrame.notifyCompletion();
-		verify(frame).pushStackItem(UInt256.ZERO);
-	}
+        verify(stack).addFirst(captor.capture());
+        final var childFrame = captor.getValue();
+        // when:
+        childFrame.setState(MessageFrame.State.COMPLETED_FAILED);
+        childFrame.notifyCompletion();
+        verify(frame).pushStackItem(UInt256.ZERO);
+    }
 
-	private void givenBuilderPrereqs() {
-		given(frame.getMessageFrameStack()).willReturn(stack);
-		given(updater.updater()).willReturn(updater);
-		given(gasCalculator.gasAvailableForChildCreate(anyLong())).willReturn(childStipend);
-		given(frame.getOriginatorAddress()).willReturn(recipient);
-		given(frame.getGasPrice()).willReturn(gasPrice);
-		given(frame.getBlockValues()).willReturn(blockValues);
-		given(frame.getMiningBeneficiary()).willReturn(recipient);
-		given(frame.getBlockHashLookup()).willReturn(l -> Hash.ZERO);
-	}
+    private void givenBuilderPrereqs() {
+        given(frame.getMessageFrameStack()).willReturn(stack);
+        given(updater.updater()).willReturn(updater);
+        given(gasCalculator.gasAvailableForChildCreate(anyLong())).willReturn(childStipend);
+        given(frame.getOriginatorAddress()).willReturn(recipient);
+        given(frame.getGasPrice()).willReturn(gasPrice);
+        given(frame.getBlockValues()).willReturn(blockValues);
+        given(frame.getMiningBeneficiary()).willReturn(recipient);
+        given(frame.getBlockHashLookup()).willReturn(l -> Hash.ZERO);
+    }
 
-	private void givenSpawnPrereqs() {
-		given(frame.stackSize()).willReturn(3);
-		given(frame.getStackItem(anyInt())).willReturn(Bytes.ofUnsignedLong(1));
-		given(frame.getRemainingGas()).willReturn(Subject.PRETEND_GAS_COST);
-		given(frame.getStackItem(0)).willReturn(Bytes.ofUnsignedLong(value));
-		given(frame.getRecipientAddress()).willReturn(recipient);
-		given(frame.getWorldUpdater()).willReturn(updater);
-		given(updater.getAccount(recipient)).willReturn(recipientAccount);
-		given(recipientAccount.getMutable()).willReturn(mutableAccount);
-		given(mutableAccount.getBalance()).willReturn(Wei.of(value));
-		given(frame.getMessageStackDepth()).willReturn(1023);
-	}
+    private void givenSpawnPrereqs() {
+        given(frame.stackSize()).willReturn(3);
+        given(frame.getStackItem(anyInt())).willReturn(Bytes.ofUnsignedLong(1));
+        given(frame.getRemainingGas()).willReturn(Subject.PRETEND_GAS_COST);
+        given(frame.getStackItem(0)).willReturn(Bytes.ofUnsignedLong(value));
+        given(frame.getRecipientAddress()).willReturn(recipient);
+        given(frame.getWorldUpdater()).willReturn(updater);
+        given(updater.getAccount(recipient)).willReturn(recipientAccount);
+        given(recipientAccount.getMutable()).willReturn(mutableAccount);
+        given(mutableAccount.getBalance()).willReturn(Wei.of(value));
+        given(frame.getMessageStackDepth()).willReturn(1023);
+    }
 
-	private void assertSameResult(final Operation.OperationResult expected, final Operation.OperationResult actual) {
-		assertEquals(expected.getGasCost(), actual.getGasCost());
-		assertEquals(expected.getHaltReason(), actual.getHaltReason());
-	}
+    private void assertSameResult(
+            final Operation.OperationResult expected, final Operation.OperationResult actual) {
+        assertEquals(expected.getGasCost(), actual.getGasCost());
+        assertEquals(expected.getHaltReason(), actual.getHaltReason());
+    }
 
-	static class Subject extends AbstractRecordingCreateOperation {
-		static final long PRETEND_GAS_COST = 123L;
-		static final Address PRETEND_CONTRACT_ADDRESS = Address.ALTBN128_ADD;
-		static final OptionalLong PRETEND_OPTIONAL_COST = OptionalLong.of(PRETEND_GAS_COST);
+    static class Subject extends AbstractRecordingCreateOperation {
+        static final long PRETEND_GAS_COST = 123L;
+        static final Address PRETEND_CONTRACT_ADDRESS = Address.ALTBN128_ADD;
+        static final OptionalLong PRETEND_OPTIONAL_COST = OptionalLong.of(PRETEND_GAS_COST);
 
-		boolean isEnabled = true;
+        boolean isEnabled = true;
 
-		protected Subject(
-				final int opcode,
-				final String name,
-				final int stackItemsConsumed,
-				final int stackItemsProduced,
-				final int opSize,
-				final GasCalculator gasCalculator,
-				final EntityCreator creator,
-				final SyntheticTxnFactory syntheticTxnFactory,
-				final RecordsHistorian recordsHistorian
-		) {
-			super(
-					opcode, name, stackItemsConsumed, stackItemsProduced, opSize, gasCalculator,
-					creator, syntheticTxnFactory, recordsHistorian);
-		}
+        protected Subject(
+                final int opcode,
+                final String name,
+                final int stackItemsConsumed,
+                final int stackItemsProduced,
+                final int opSize,
+                final GasCalculator gasCalculator,
+                final EntityCreator creator,
+                final SyntheticTxnFactory syntheticTxnFactory,
+                final RecordsHistorian recordsHistorian) {
+            super(
+                    opcode,
+                    name,
+                    stackItemsConsumed,
+                    stackItemsProduced,
+                    opSize,
+                    gasCalculator,
+                    creator,
+                    syntheticTxnFactory,
+                    recordsHistorian);
+        }
 
-		@Override
-		protected boolean isEnabled() {
-			return isEnabled;
-		}
+        @Override
+        protected boolean isEnabled() {
+            return isEnabled;
+        }
 
-		@Override
-		protected long cost(final MessageFrame frame) {
-			return PRETEND_GAS_COST;
-		}
+        @Override
+        protected long cost(final MessageFrame frame) {
+            return PRETEND_GAS_COST;
+        }
 
-		@Override
-		protected Address targetContractAddress(final MessageFrame frame) {
-			return PRETEND_CONTRACT_ADDRESS;
-		}
-
-	}
+        @Override
+        protected Address targetContractAddress(final MessageFrame frame) {
+            return PRETEND_CONTRACT_ADDRESS;
+        }
+    }
 }

--- a/hedera-node/src/test/java/com/hedera/services/contracts/operation/CommonCallSetup.java
+++ b/hedera-node/src/test/java/com/hedera/services/contracts/operation/CommonCallSetup.java
@@ -22,20 +22,16 @@ package com.hedera.services.contracts.operation;
  *
  */
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
 import org.hyperledger.besu.evm.account.Account;
 import org.hyperledger.besu.evm.frame.MessageFrame;
 import org.hyperledger.besu.evm.worldstate.WorldUpdater;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.given;
-
 public class CommonCallSetup {
-	static void commonSetup(
-			MessageFrame evmMsgFrame,
-			WorldUpdater worldUpdater,
-			Account acc
-	) {
-		given(evmMsgFrame.getWorldUpdater()).willReturn(worldUpdater);
-		given(worldUpdater.get(any())).willReturn(acc);
-	}
+    static void commonSetup(MessageFrame evmMsgFrame, WorldUpdater worldUpdater, Account acc) {
+        given(evmMsgFrame.getWorldUpdater()).willReturn(worldUpdater);
+        given(worldUpdater.get(any())).willReturn(acc);
+    }
 }

--- a/hedera-node/src/test/java/com/hedera/services/contracts/operation/CommonCallSetup.java
+++ b/hedera-node/src/test/java/com/hedera/services/contracts/operation/CommonCallSetup.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2020-2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hedera.services.contracts.operation;
 
 /*

--- a/hedera-node/src/test/java/com/hedera/services/contracts/operation/HederaBalanceOperationTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/contracts/operation/HederaBalanceOperationTest.java
@@ -1,11 +1,6 @@
-package com.hedera.services.contracts.operation;
-
-/*-
- * ‌
- * Hedera Services Node
- * ​
- * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
- * ​
+/*
+ * Copyright (C) 2021-2022 Hedera Hashgraph, LLC
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -17,8 +12,8 @@ package com.hedera.services.contracts.operation;
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- * ‍
  */
+package com.hedera.services.contracts.operation;
 
 import static com.hedera.services.contracts.operation.HederaExceptionalHaltReason.INVALID_SOLIDITY_ADDRESS;
 import static org.hyperledger.besu.evm.frame.ExceptionalHaltReason.INSUFFICIENT_GAS;

--- a/hedera-node/src/test/java/com/hedera/services/contracts/operation/HederaBalanceOperationTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/contracts/operation/HederaBalanceOperationTest.java
@@ -20,6 +20,18 @@ package com.hedera.services.contracts.operation;
  * ‍
  */
 
+import static com.hedera.services.contracts.operation.HederaExceptionalHaltReason.INVALID_SOLIDITY_ADDRESS;
+import static org.hyperledger.besu.evm.frame.ExceptionalHaltReason.INSUFFICIENT_GAS;
+import static org.hyperledger.besu.evm.frame.ExceptionalHaltReason.INSUFFICIENT_STACK_ITEMS;
+import static org.hyperledger.besu.evm.frame.ExceptionalHaltReason.TOO_MANY_STACK_ITEMS;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mockStatic;
+
+import java.util.function.BiPredicate;
 import org.apache.tuweni.bytes.Bytes;
 import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.evm.EVM;
@@ -37,109 +49,90 @@ import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.util.function.BiPredicate;
-
-import static com.hedera.services.contracts.operation.HederaExceptionalHaltReason.INVALID_SOLIDITY_ADDRESS;
-import static org.hyperledger.besu.evm.frame.ExceptionalHaltReason.INSUFFICIENT_GAS;
-import static org.hyperledger.besu.evm.frame.ExceptionalHaltReason.INSUFFICIENT_STACK_ITEMS;
-import static org.hyperledger.besu.evm.frame.ExceptionalHaltReason.TOO_MANY_STACK_ITEMS;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.mockStatic;
-
 @ExtendWith(MockitoExtension.class)
 class HederaBalanceOperationTest {
 
-	@Mock
-	private GasCalculator gasCalculator;
-	@Mock
-	private MessageFrame frame;
-	@Mock
-	private EVM evm;
-	@Mock
-	private WorldUpdater worldUpdater;
-	@Mock
-	private Account account;
-	@Mock
-	private BiPredicate<Address, MessageFrame> addressValidator;
-	
-	private final long gas = 100L; 
+    @Mock private GasCalculator gasCalculator;
+    @Mock private MessageFrame frame;
+    @Mock private EVM evm;
+    @Mock private WorldUpdater worldUpdater;
+    @Mock private Account account;
+    @Mock private BiPredicate<Address, MessageFrame> addressValidator;
 
-	private HederaBalanceOperation subject;
+    private final long gas = 100L;
 
-	@BeforeEach
-	void setUp() {
-		subject = new HederaBalanceOperation(gasCalculator, addressValidator);
-		givenAddress();
-		given(gasCalculator.getWarmStorageReadCost()).willReturn(1600L);
-		given(gasCalculator.getBalanceOperationGasCost()).willReturn(100L);
-	}
+    private HederaBalanceOperation subject;
 
-	@Test
-	void haltsWithInsufficientStackItemsOperationResultWhenGetsStackItem() {
-		given(frame.getStackItem(anyInt())).willThrow(new FixedStack.UnderflowException());
-		thenOperationWillFailWithReason(INSUFFICIENT_STACK_ITEMS);
-	}
+    @BeforeEach
+    void setUp() {
+        subject = new HederaBalanceOperation(gasCalculator, addressValidator);
+        givenAddress();
+        given(gasCalculator.getWarmStorageReadCost()).willReturn(1600L);
+        given(gasCalculator.getBalanceOperationGasCost()).willReturn(100L);
+    }
 
-	@Test
-	void haltsWithInsufficientStackItemsWhenPopsStackItem() {
-		given(frame.popStackItem()).willThrow(new FixedStack.UnderflowException());
-		given(addressValidator.test(any(), any())).willReturn(true);
+    @Test
+    void haltsWithInsufficientStackItemsOperationResultWhenGetsStackItem() {
+        given(frame.getStackItem(anyInt())).willThrow(new FixedStack.UnderflowException());
+        thenOperationWillFailWithReason(INSUFFICIENT_STACK_ITEMS);
+    }
 
-		thenOperationWillFailWithReason(INSUFFICIENT_STACK_ITEMS);
-	}
+    @Test
+    void haltsWithInsufficientStackItemsWhenPopsStackItem() {
+        given(frame.popStackItem()).willThrow(new FixedStack.UnderflowException());
+        given(addressValidator.test(any(), any())).willReturn(true);
 
-	@Test
-	void haltsWithTooManyStackItemsWhenPopsStackItem() {
-		given(frame.popStackItem()).willThrow(new FixedStack.OverflowException());
-		given(addressValidator.test(any(), any())).willReturn(true);
+        thenOperationWillFailWithReason(INSUFFICIENT_STACK_ITEMS);
+    }
 
-		thenOperationWillFailWithReason(TOO_MANY_STACK_ITEMS);
-	}
+    @Test
+    void haltsWithTooManyStackItemsWhenPopsStackItem() {
+        given(frame.popStackItem()).willThrow(new FixedStack.OverflowException());
+        given(addressValidator.test(any(), any())).willReturn(true);
 
-	@Test
-	void haltsWithInvalidSolidityAddressOperationResult() {
-		given(addressValidator.test(any(), any())).willReturn(false);
+        thenOperationWillFailWithReason(TOO_MANY_STACK_ITEMS);
+    }
 
-		thenOperationWillFailWithReason(INVALID_SOLIDITY_ADDRESS);
-	}
+    @Test
+    void haltsWithInvalidSolidityAddressOperationResult() {
+        given(addressValidator.test(any(), any())).willReturn(false);
 
-	@Test
-	void haltsWithInsufficientGasOperationResult() {
-		given(frame.popStackItem()).willReturn(Bytes.EMPTY);
-		given(frame.warmUpAddress(any())).willReturn(true);
-		given(frame.getRemainingGas()).willReturn(0L);
-		given(addressValidator.test(any(), any())).willReturn(true);
+        thenOperationWillFailWithReason(INVALID_SOLIDITY_ADDRESS);
+    }
 
-		thenOperationWillFailWithReason(INSUFFICIENT_GAS);
-	}
+    @Test
+    void haltsWithInsufficientGasOperationResult() {
+        given(frame.popStackItem()).willReturn(Bytes.EMPTY);
+        given(frame.warmUpAddress(any())).willReturn(true);
+        given(frame.getRemainingGas()).willReturn(0L);
+        given(addressValidator.test(any(), any())).willReturn(true);
 
-	@Test
-	void returnsOperationResultWithoutException() {
-		given(worldUpdater.get(any())).willReturn(account);
-		given(frame.getWorldUpdater()).willReturn(worldUpdater);
-		given(frame.popStackItem()).willReturn(Bytes.EMPTY);
-		given(frame.warmUpAddress(any())).willReturn(true);
-		given(frame.getRemainingGas()).willReturn(10_000L);
-		given(addressValidator.test(any(), any())).willReturn(true);
+        thenOperationWillFailWithReason(INSUFFICIENT_GAS);
+    }
 
-		final var result = subject.execute(frame, evm);
+    @Test
+    void returnsOperationResultWithoutException() {
+        given(worldUpdater.get(any())).willReturn(account);
+        given(frame.getWorldUpdater()).willReturn(worldUpdater);
+        given(frame.popStackItem()).willReturn(Bytes.EMPTY);
+        given(frame.warmUpAddress(any())).willReturn(true);
+        given(frame.getRemainingGas()).willReturn(10_000L);
+        given(addressValidator.test(any(), any())).willReturn(true);
 
-		assertTrue(result.getHaltReason().isEmpty());
-	}
+        final var result = subject.execute(frame, evm);
 
-	private void givenAddress() {
-		given(frame.getStackItem(anyInt())).willReturn(Bytes.EMPTY);
-		try (MockedStatic<Words> theMock = mockStatic(Words.class)) {
-			theMock.when(() -> Words.toAddress(Bytes.EMPTY)).thenReturn(Address.ZERO);
-		}
-	}
+        assertTrue(result.getHaltReason().isEmpty());
+    }
 
-	private void thenOperationWillFailWithReason(ExceptionalHaltReason reason) {
-		final var result = subject.execute(frame, evm);
-		assertEquals(reason, result.getHaltReason().get());
-	}
+    private void givenAddress() {
+        given(frame.getStackItem(anyInt())).willReturn(Bytes.EMPTY);
+        try (MockedStatic<Words> theMock = mockStatic(Words.class)) {
+            theMock.when(() -> Words.toAddress(Bytes.EMPTY)).thenReturn(Address.ZERO);
+        }
+    }
+
+    private void thenOperationWillFailWithReason(ExceptionalHaltReason reason) {
+        final var result = subject.execute(frame, evm);
+        assertEquals(reason, result.getHaltReason().get());
+    }
 }

--- a/hedera-node/src/test/java/com/hedera/services/contracts/operation/HederaCallCodeOperationTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/contracts/operation/HederaCallCodeOperationTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2021-2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hedera.services.contracts.operation;
 
 /*

--- a/hedera-node/src/test/java/com/hedera/services/contracts/operation/HederaCallOperationTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/contracts/operation/HederaCallOperationTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2021-2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hedera.services.contracts.operation;
 
 /*

--- a/hedera-node/src/test/java/com/hedera/services/contracts/operation/HederaCallOperationTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/contracts/operation/HederaCallOperationTest.java
@@ -22,8 +22,19 @@ package com.hedera.services.contracts.operation;
  *
  */
 
+import static com.hedera.services.contracts.operation.CommonCallSetup.commonSetup;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+
 import com.hedera.services.contracts.sources.EvmSigsVerifier;
 import com.hedera.services.store.contracts.HederaStackedWorldStateUpdater;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.BiPredicate;
 import org.apache.tuweni.bytes.Bytes;
 import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.datatypes.Wei;
@@ -39,108 +50,100 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.util.Map;
-import java.util.Optional;
-import java.util.function.BiPredicate;
-
-import static com.hedera.services.contracts.operation.CommonCallSetup.commonSetup;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyBoolean;
-import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.BDDMockito.given;
-
 @ExtendWith(MockitoExtension.class)
 class HederaCallOperationTest {
-	@Mock
-	private GasCalculator calc;
-	@Mock
-	private MessageFrame evmMsgFrame;
-	@Mock
-	private EVM evm;
-	@Mock
-	private HederaStackedWorldStateUpdater worldUpdater;
-	@Mock
-	private Account acc;
-	@Mock
-	private EvmSigsVerifier sigsVerifier;
-	@Mock
-	private BiPredicate<Address, MessageFrame> addressValidator;
-	@Mock
-	private Map<String, PrecompiledContract> precompiledContractMap;
+    @Mock private GasCalculator calc;
+    @Mock private MessageFrame evmMsgFrame;
+    @Mock private EVM evm;
+    @Mock private HederaStackedWorldStateUpdater worldUpdater;
+    @Mock private Account acc;
+    @Mock private EvmSigsVerifier sigsVerifier;
+    @Mock private BiPredicate<Address, MessageFrame> addressValidator;
+    @Mock private Map<String, PrecompiledContract> precompiledContractMap;
 
-	private final long cost = 100L;
-	private HederaCallOperation subject;
+    private final long cost = 100L;
+    private HederaCallOperation subject;
 
-	@BeforeEach
-	void setup() {
-		subject = new HederaCallOperation(sigsVerifier, calc, addressValidator, precompiledContractMap);
-	}
+    @BeforeEach
+    void setup() {
+        subject =
+                new HederaCallOperation(
+                        sigsVerifier, calc, addressValidator, precompiledContractMap);
+    }
 
-	@Test
-	void haltWithInvalidAddr() {
-		commonSetup(evmMsgFrame, worldUpdater, acc);
-		given(worldUpdater.get(any())).willReturn(null);
-		given(calc.callOperationGasCost(
-				any(), anyLong(), anyLong(),
-				anyLong(), anyLong(), anyLong(),
-				any(), any(), any())
-		).willReturn(cost);
-		given(evmMsgFrame.getStackItem(0)).willReturn(Bytes.EMPTY);
-		given(evmMsgFrame.getStackItem(1)).willReturn(Bytes.EMPTY);
-		given(evmMsgFrame.getStackItem(2)).willReturn(Bytes.EMPTY);
-		given(evmMsgFrame.getStackItem(3)).willReturn(Bytes.EMPTY);
-		given(evmMsgFrame.getStackItem(4)).willReturn(Bytes.EMPTY);
-		given(evmMsgFrame.getStackItem(5)).willReturn(Bytes.EMPTY);
-		given(evmMsgFrame.getStackItem(6)).willReturn(Bytes.EMPTY);
-		given(addressValidator.test(any(), any())).willReturn(false);
+    @Test
+    void haltWithInvalidAddr() {
+        commonSetup(evmMsgFrame, worldUpdater, acc);
+        given(worldUpdater.get(any())).willReturn(null);
+        given(
+                        calc.callOperationGasCost(
+                                any(), anyLong(), anyLong(), anyLong(), anyLong(), anyLong(), any(),
+                                any(), any()))
+                .willReturn(cost);
+        given(evmMsgFrame.getStackItem(0)).willReturn(Bytes.EMPTY);
+        given(evmMsgFrame.getStackItem(1)).willReturn(Bytes.EMPTY);
+        given(evmMsgFrame.getStackItem(2)).willReturn(Bytes.EMPTY);
+        given(evmMsgFrame.getStackItem(3)).willReturn(Bytes.EMPTY);
+        given(evmMsgFrame.getStackItem(4)).willReturn(Bytes.EMPTY);
+        given(evmMsgFrame.getStackItem(5)).willReturn(Bytes.EMPTY);
+        given(evmMsgFrame.getStackItem(6)).willReturn(Bytes.EMPTY);
+        given(addressValidator.test(any(), any())).willReturn(false);
 
-		var opRes = subject.execute(evmMsgFrame, evm);
+        var opRes = subject.execute(evmMsgFrame, evm);
 
-		assertEquals(opRes.getHaltReason(), Optional.of(HederaExceptionalHaltReason.INVALID_SOLIDITY_ADDRESS));
-		assertTrue(opRes.getGasCost().isPresent());
-		assertEquals(opRes.getGasCost().getAsLong(), cost);
-	}
+        assertEquals(
+                opRes.getHaltReason(),
+                Optional.of(HederaExceptionalHaltReason.INVALID_SOLIDITY_ADDRESS));
+        assertTrue(opRes.getGasCost().isPresent());
+        assertEquals(opRes.getGasCost().getAsLong(), cost);
+    }
 
-	@Test
-	void executesAsExpected() {
-		commonSetup(evmMsgFrame, worldUpdater, acc);
-		given(calc.callOperationGasCost(
-				any(), anyLong(), anyLong(),
-				anyLong(), anyLong(), anyLong(),
-				any(), any(), any())
-		).willReturn(cost);
-		// and:
-		given(evmMsgFrame.getStackItem(0)).willReturn(Bytes.EMPTY);
-		given(evmMsgFrame.getStackItem(1)).willReturn(Bytes.EMPTY);
-		given(evmMsgFrame.getStackItem(2)).willReturn(Bytes.EMPTY);
-		given(evmMsgFrame.getStackItem(3)).willReturn(Bytes.EMPTY);
-		given(evmMsgFrame.getStackItem(4)).willReturn(Bytes.EMPTY);
-		given(evmMsgFrame.getStackItem(5)).willReturn(Bytes.EMPTY);
-		given(evmMsgFrame.getStackItem(6)).willReturn(Bytes.EMPTY);
-		// and:
-		given(evmMsgFrame.stackSize()).willReturn(20);
-		given(evmMsgFrame.getRemainingGas()).willReturn(cost);
-		given(evmMsgFrame.getMessageStackDepth()).willReturn(1025);
+    @Test
+    void executesAsExpected() {
+        commonSetup(evmMsgFrame, worldUpdater, acc);
+        given(
+                        calc.callOperationGasCost(
+                                any(), anyLong(), anyLong(), anyLong(), anyLong(), anyLong(), any(),
+                                any(), any()))
+                .willReturn(cost);
+        // and:
+        given(evmMsgFrame.getStackItem(0)).willReturn(Bytes.EMPTY);
+        given(evmMsgFrame.getStackItem(1)).willReturn(Bytes.EMPTY);
+        given(evmMsgFrame.getStackItem(2)).willReturn(Bytes.EMPTY);
+        given(evmMsgFrame.getStackItem(3)).willReturn(Bytes.EMPTY);
+        given(evmMsgFrame.getStackItem(4)).willReturn(Bytes.EMPTY);
+        given(evmMsgFrame.getStackItem(5)).willReturn(Bytes.EMPTY);
+        given(evmMsgFrame.getStackItem(6)).willReturn(Bytes.EMPTY);
+        // and:
+        given(evmMsgFrame.stackSize()).willReturn(20);
+        given(evmMsgFrame.getRemainingGas()).willReturn(cost);
+        given(evmMsgFrame.getMessageStackDepth()).willReturn(1025);
 
-		given(evmMsgFrame.getContractAddress()).willReturn(Address.ALTBN128_ADD);
-		given(evmMsgFrame.getRecipientAddress()).willReturn(Address.ALTBN128_ADD);
+        given(evmMsgFrame.getContractAddress()).willReturn(Address.ALTBN128_ADD);
+        given(evmMsgFrame.getRecipientAddress()).willReturn(Address.ALTBN128_ADD);
 
-		given(worldUpdater.get(any())).willReturn(acc);
-		given(acc.getBalance()).willReturn(Wei.of(100));
-		given(calc.gasAvailableForChildCall(any(), anyLong(), anyBoolean())).willReturn(10L);
-		given(acc.getAddress()).willReturn(Address.ZERO);
-		given(sigsVerifier.hasActiveKeyOrNoReceiverSigReq(Mockito.anyBoolean(), any(), any(), any())).willReturn(true);
-		given(addressValidator.test(any(), any())).willReturn(true);
+        given(worldUpdater.get(any())).willReturn(acc);
+        given(acc.getBalance()).willReturn(Wei.of(100));
+        given(calc.gasAvailableForChildCall(any(), anyLong(), anyBoolean())).willReturn(10L);
+        given(acc.getAddress()).willReturn(Address.ZERO);
+        given(
+                        sigsVerifier.hasActiveKeyOrNoReceiverSigReq(
+                                Mockito.anyBoolean(), any(), any(), any()))
+                .willReturn(true);
+        given(addressValidator.test(any(), any())).willReturn(true);
 
-		var opRes = subject.execute(evmMsgFrame, evm);
-		assertEquals(Optional.empty(), opRes.getHaltReason());
-		assertTrue(opRes.getGasCost().isPresent());
-		assertEquals(opRes.getGasCost().getAsLong(), cost);
+        var opRes = subject.execute(evmMsgFrame, evm);
+        assertEquals(Optional.empty(), opRes.getHaltReason());
+        assertTrue(opRes.getGasCost().isPresent());
+        assertEquals(opRes.getGasCost().getAsLong(), cost);
 
-		given(sigsVerifier.hasActiveKeyOrNoReceiverSigReq(Mockito.anyBoolean(), any(),  any(), any())).willReturn(false);
-		var invalidSignaturesRes = subject.execute(evmMsgFrame, evm);
-		assertEquals(Optional.of(HederaExceptionalHaltReason.INVALID_SIGNATURE), invalidSignaturesRes.getHaltReason());
-	}
+        given(
+                        sigsVerifier.hasActiveKeyOrNoReceiverSigReq(
+                                Mockito.anyBoolean(), any(), any(), any()))
+                .willReturn(false);
+        var invalidSignaturesRes = subject.execute(evmMsgFrame, evm);
+        assertEquals(
+                Optional.of(HederaExceptionalHaltReason.INVALID_SIGNATURE),
+                invalidSignaturesRes.getHaltReason());
+    }
 }

--- a/hedera-node/src/test/java/com/hedera/services/contracts/operation/HederaCreate2OperationTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/contracts/operation/HederaCreate2OperationTest.java
@@ -20,6 +20,11 @@ package com.hedera.services.contracts.operation;
  * ‍
  */
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.BDDMockito.given;
+
 import com.hedera.services.context.properties.GlobalDynamicProperties;
 import com.hedera.services.contracts.gascalculator.StorageGasCalculator;
 import com.hedera.services.records.RecordsHistorian;
@@ -38,89 +43,84 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.BDDMockito.given;
-
 @ExtendWith(MockitoExtension.class)
 class HederaCreate2OperationTest {
-	private static final long baseGas = 100L;
-	private static final long extraGas = 101L;
-	private static final Bytes salt = Bytes.fromHexString("0x2a");
-	private static final Bytes oneOffsetStackItem = Bytes.of(10);
-	private static final Bytes twoOffsetStackItem = Bytes.of(20);
-	private static final MutableBytes initcode = MutableBytes.of((byte) 0xaa);
-	private Address recipientAddr = Address.fromHexString("0x0102030405060708090a0b0c0d0e0f1011121314");
+    private static final long baseGas = 100L;
+    private static final long extraGas = 101L;
+    private static final Bytes salt = Bytes.fromHexString("0x2a");
+    private static final Bytes oneOffsetStackItem = Bytes.of(10);
+    private static final Bytes twoOffsetStackItem = Bytes.of(20);
+    private static final MutableBytes initcode = MutableBytes.of((byte) 0xaa);
+    private Address recipientAddr =
+            Address.fromHexString("0x0102030405060708090a0b0c0d0e0f1011121314");
 
-	@Mock
-	private GlobalDynamicProperties dynamicProperties;
-	@Mock
-	private MessageFrame frame;
-	@Mock
-	private GasCalculator gasCalculator;
-	@Mock
-	private HederaStackedWorldStateUpdater stackedUpdater;
-	@Mock
-	private SyntheticTxnFactory syntheticTxnFactory;
-	@Mock
-	private EntityCreator creator;
-	@Mock
-	private RecordsHistorian recordsHistorian;
-	@Mock
-	private StorageGasCalculator storageGasCalculator;
+    @Mock private GlobalDynamicProperties dynamicProperties;
+    @Mock private MessageFrame frame;
+    @Mock private GasCalculator gasCalculator;
+    @Mock private HederaStackedWorldStateUpdater stackedUpdater;
+    @Mock private SyntheticTxnFactory syntheticTxnFactory;
+    @Mock private EntityCreator creator;
+    @Mock private RecordsHistorian recordsHistorian;
+    @Mock private StorageGasCalculator storageGasCalculator;
 
-	private HederaCreate2Operation subject;
+    private HederaCreate2Operation subject;
 
-	@BeforeEach
-	void setup() {
-		subject = new HederaCreate2Operation(
-				gasCalculator, creator, syntheticTxnFactory, recordsHistorian, dynamicProperties, storageGasCalculator);
-	}
+    @BeforeEach
+    void setup() {
+        subject =
+                new HederaCreate2Operation(
+                        gasCalculator,
+                        creator,
+                        syntheticTxnFactory,
+                        recordsHistorian,
+                        dynamicProperties,
+                        storageGasCalculator);
+    }
 
-	@Test
-	void computesExpectedCost() {
-		given(gasCalculator.create2OperationGasCost(frame)).willReturn(baseGas);
-		given(storageGasCalculator.creationGasCost(frame, gasCalculator)).willReturn(extraGas);
+    @Test
+    void computesExpectedCost() {
+        given(gasCalculator.create2OperationGasCost(frame)).willReturn(baseGas);
+        given(storageGasCalculator.creationGasCost(frame, gasCalculator)).willReturn(extraGas);
 
-		var actualGas = subject.cost(frame);
+        var actualGas = subject.cost(frame);
 
-		assertEquals(baseGas + extraGas, actualGas);
-	}
+        assertEquals(baseGas + extraGas, actualGas);
+    }
 
-	@Test
-	void enabledOnlyIfCreate2IsEnabled() {
-		assertFalse(subject.isEnabled());
+    @Test
+    void enabledOnlyIfCreate2IsEnabled() {
+        assertFalse(subject.isEnabled());
 
-		given(dynamicProperties.isCreate2Enabled()).willReturn(true);
+        given(dynamicProperties.isCreate2Enabled()).willReturn(true);
 
-		assertTrue(subject.isEnabled());
-	}
+        assertTrue(subject.isEnabled());
+    }
 
-	@Test
-	void computesExpectedTargetAddress() {
-		final var expectedAddress = Address.BLS12_G1ADD;
-		final var canonicalSource = Address.BLS12_G1MULTIEXP;
-		final var besuOp = new Create2Operation(gasCalculator);
+    @Test
+    void computesExpectedTargetAddress() {
+        final var expectedAddress = Address.BLS12_G1ADD;
+        final var canonicalSource = Address.BLS12_G1MULTIEXP;
+        final var besuOp = new Create2Operation(gasCalculator);
 
-		givenMemoryStackItems();
-		given(frame.getStackItem(3)).willReturn(salt);
-		given(frame.getRecipientAddress()).willReturn(canonicalSource);
-		given(frame.readMutableMemory(oneOffsetStackItem.toLong(), twoOffsetStackItem.toLong()))
-				.willReturn(initcode);
-		final var expectedAlias = besuOp.targetContractAddress(frame);
+        givenMemoryStackItems();
+        given(frame.getStackItem(3)).willReturn(salt);
+        given(frame.getRecipientAddress()).willReturn(canonicalSource);
+        given(frame.readMutableMemory(oneOffsetStackItem.toLong(), twoOffsetStackItem.toLong()))
+                .willReturn(initcode);
+        final var expectedAlias = besuOp.targetContractAddress(frame);
 
-		given(frame.getWorldUpdater()).willReturn(stackedUpdater);
-		given(frame.getRecipientAddress()).willReturn(recipientAddr);
-		given(stackedUpdater.priorityAddress(recipientAddr)).willReturn(canonicalSource);
-		given(stackedUpdater.newAliasedContractAddress(recipientAddr, expectedAlias)).willReturn(expectedAddress);
+        given(frame.getWorldUpdater()).willReturn(stackedUpdater);
+        given(frame.getRecipientAddress()).willReturn(recipientAddr);
+        given(stackedUpdater.priorityAddress(recipientAddr)).willReturn(canonicalSource);
+        given(stackedUpdater.newAliasedContractAddress(recipientAddr, expectedAlias))
+                .willReturn(expectedAddress);
 
-		final var actualAlias = subject.targetContractAddress(frame);
-		assertEquals(expectedAlias, actualAlias);
-	}
+        final var actualAlias = subject.targetContractAddress(frame);
+        assertEquals(expectedAlias, actualAlias);
+    }
 
-	private void givenMemoryStackItems() {
-		given(frame.getStackItem(1)).willReturn(oneOffsetStackItem);
-		given(frame.getStackItem(2)).willReturn(twoOffsetStackItem);
-	}
+    private void givenMemoryStackItems() {
+        given(frame.getStackItem(1)).willReturn(oneOffsetStackItem);
+        given(frame.getStackItem(2)).willReturn(twoOffsetStackItem);
+    }
 }

--- a/hedera-node/src/test/java/com/hedera/services/contracts/operation/HederaCreate2OperationTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/contracts/operation/HederaCreate2OperationTest.java
@@ -1,11 +1,6 @@
-package com.hedera.services.contracts.operation;
-
-/*-
- * ‌
- * Hedera Services Node
- * ​
- * Copyright (C) 2018 - 2022 Hedera Hashgraph, LLC
- * ​
+/*
+ * Copyright (C) 2021-2022 Hedera Hashgraph, LLC
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -17,8 +12,8 @@ package com.hedera.services.contracts.operation;
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- * ‍
  */
+package com.hedera.services.contracts.operation;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;

--- a/hedera-node/src/test/java/com/hedera/services/contracts/operation/HederaCreateOperationTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/contracts/operation/HederaCreateOperationTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2021-2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hedera.services.contracts.operation;
 
 /*

--- a/hedera-node/src/test/java/com/hedera/services/contracts/operation/HederaCreateOperationTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/contracts/operation/HederaCreateOperationTest.java
@@ -22,6 +22,8 @@ package com.hedera.services.contracts.operation;
  *
  */
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.BDDMockito.given;
 
 import com.hedera.services.contracts.gascalculator.StorageGasCalculator;
 import com.hedera.services.records.RecordsHistorian;
@@ -38,60 +40,56 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.BDDMockito.given;
-
 @ExtendWith(MockitoExtension.class)
 class HederaCreateOperationTest {
-	private static final long baseGas = 100L;
-	private static final long extraGas = 101L;
-	
-	private final Address recipientAddr = Address.fromHexString("0x0102030405060708090a0b0c0d0e0f1011121314");
+    private static final long baseGas = 100L;
+    private static final long extraGas = 101L;
 
-	@Mock
-	private MessageFrame frame;
-	@Mock
-	private GasCalculator gasCalculator;
-	@Mock
-	private HederaWorldUpdater hederaWorldUpdater;
-	@Mock
-	private SyntheticTxnFactory syntheticTxnFactory;
-	@Mock
-	private EntityCreator creator;
-	@Mock
-	private RecordsHistorian recordsHistorian;
-	@Mock
-	private StorageGasCalculator storageGasCalculator;
+    private final Address recipientAddr =
+            Address.fromHexString("0x0102030405060708090a0b0c0d0e0f1011121314");
 
-	private HederaCreateOperation subject;
+    @Mock private MessageFrame frame;
+    @Mock private GasCalculator gasCalculator;
+    @Mock private HederaWorldUpdater hederaWorldUpdater;
+    @Mock private SyntheticTxnFactory syntheticTxnFactory;
+    @Mock private EntityCreator creator;
+    @Mock private RecordsHistorian recordsHistorian;
+    @Mock private StorageGasCalculator storageGasCalculator;
 
-	@BeforeEach
-	void setup() {
-		subject = new HederaCreateOperation(
-				gasCalculator, creator, syntheticTxnFactory, recordsHistorian, storageGasCalculator);
-	}
+    private HederaCreateOperation subject;
 
-	@Test
-	void isAlwaysEnabled() {
-		Assertions.assertTrue(subject.isEnabled());
-	}
+    @BeforeEach
+    void setup() {
+        subject =
+                new HederaCreateOperation(
+                        gasCalculator,
+                        creator,
+                        syntheticTxnFactory,
+                        recordsHistorian,
+                        storageGasCalculator);
+    }
 
-	@Test
-	void computesExpectedCost() {
-		given(gasCalculator.createOperationGasCost(frame)).willReturn(baseGas);
-		given(storageGasCalculator.creationGasCost(frame, gasCalculator)).willReturn(extraGas);
+    @Test
+    void isAlwaysEnabled() {
+        Assertions.assertTrue(subject.isEnabled());
+    }
 
-		var actualGas = subject.cost(frame);
+    @Test
+    void computesExpectedCost() {
+        given(gasCalculator.createOperationGasCost(frame)).willReturn(baseGas);
+        given(storageGasCalculator.creationGasCost(frame, gasCalculator)).willReturn(extraGas);
 
-		assertEquals(baseGas + extraGas, actualGas);
-	}
+        var actualGas = subject.cost(frame);
 
-	@Test
-	void computesExpectedTargetAddress() {
-		given(frame.getWorldUpdater()).willReturn(hederaWorldUpdater);
-		given(frame.getRecipientAddress()).willReturn(recipientAddr);
-		given(hederaWorldUpdater.newContractAddress(recipientAddr)).willReturn(Address.ZERO);
-		var targetAddr = subject.targetContractAddress(frame);
-		assertEquals(Address.ZERO, targetAddr);
-	}
+        assertEquals(baseGas + extraGas, actualGas);
+    }
+
+    @Test
+    void computesExpectedTargetAddress() {
+        given(frame.getWorldUpdater()).willReturn(hederaWorldUpdater);
+        given(frame.getRecipientAddress()).willReturn(recipientAddr);
+        given(hederaWorldUpdater.newContractAddress(recipientAddr)).willReturn(Address.ZERO);
+        var targetAddr = subject.targetContractAddress(frame);
+        assertEquals(Address.ZERO, targetAddr);
+    }
 }

--- a/hedera-node/src/test/java/com/hedera/services/contracts/operation/HederaDelegateCallOperationTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/contracts/operation/HederaDelegateCallOperationTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2021-2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hedera.services.contracts.operation;
 
 /*

--- a/hedera-node/src/test/java/com/hedera/services/contracts/operation/HederaExceptionalHaltReasonTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/contracts/operation/HederaExceptionalHaltReasonTest.java
@@ -1,11 +1,6 @@
-package com.hedera.services.contracts.operation;
-
-/*-
- * ‌
- * Hedera Services Node
- * ​
- * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
- * ​
+/*
+ * Copyright (C) 2020-2022 Hedera Hashgraph, LLC
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -17,8 +12,8 @@ package com.hedera.services.contracts.operation;
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- * ‍
  */
+package com.hedera.services.contracts.operation;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 

--- a/hedera-node/src/test/java/com/hedera/services/contracts/operation/HederaExceptionalHaltReasonTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/contracts/operation/HederaExceptionalHaltReasonTest.java
@@ -20,26 +20,32 @@ package com.hedera.services.contracts.operation;
  * ‍
  */
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
 @ExtendWith(MockitoExtension.class)
 class HederaExceptionalHaltReasonTest {
-	HederaExceptionalHaltReason subject;
+    HederaExceptionalHaltReason subject;
 
-	@BeforeEach
-	void setUp() {
-		subject = new HederaExceptionalHaltReason();
-	}
+    @BeforeEach
+    void setUp() {
+        subject = new HederaExceptionalHaltReason();
+    }
 
-	@Test
-	void instance() {
-		assertEquals("Invalid account reference", HederaExceptionalHaltReason.INVALID_SOLIDITY_ADDRESS.getDescription());
-		assertEquals("Self destruct to the same address", HederaExceptionalHaltReason.SELF_DESTRUCT_TO_SELF.getDescription());
-		assertEquals("Invalid signature", HederaExceptionalHaltReason.INVALID_SIGNATURE.getDescription());
-	}
+    @Test
+    void instance() {
+        assertEquals(
+                "Invalid account reference",
+                HederaExceptionalHaltReason.INVALID_SOLIDITY_ADDRESS.getDescription());
+        assertEquals(
+                "Self destruct to the same address",
+                HederaExceptionalHaltReason.SELF_DESTRUCT_TO_SELF.getDescription());
+        assertEquals(
+                "Invalid signature",
+                HederaExceptionalHaltReason.INVALID_SIGNATURE.getDescription());
+    }
 }

--- a/hedera-node/src/test/java/com/hedera/services/contracts/operation/HederaExtCodeCopyOperationTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/contracts/operation/HederaExtCodeCopyOperationTest.java
@@ -1,11 +1,6 @@
-package com.hedera.services.contracts.operation;
-
-/*-
- * ‌
- * Hedera Services Node
- * ​
- * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
- * ​
+/*
+ * Copyright (C) 2021-2022 Hedera Hashgraph, LLC
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -17,8 +12,8 @@ package com.hedera.services.contracts.operation;
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- * ‍
  */
+package com.hedera.services.contracts.operation;
 
 import static org.hyperledger.besu.evm.internal.Words.clampedToLong;
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/hedera-node/src/test/java/com/hedera/services/contracts/operation/HederaExtCodeCopyOperationTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/contracts/operation/HederaExtCodeCopyOperationTest.java
@@ -20,6 +20,14 @@ package com.hedera.services.contracts.operation;
  * ‍
  */
 
+import static org.hyperledger.besu.evm.internal.Words.clampedToLong;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+import java.util.Optional;
+import java.util.OptionalLong;
+import java.util.function.BiPredicate;
 import org.apache.tuweni.bytes.Bytes;
 import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.datatypes.Wei;
@@ -35,96 +43,93 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.util.Optional;
-import java.util.OptionalLong;
-import java.util.function.BiPredicate;
-
-import static org.hyperledger.besu.evm.internal.Words.clampedToLong;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.given;
-
 @ExtendWith(MockitoExtension.class)
 class HederaExtCodeCopyOperationTest {
 
-	@Mock
-	private WorldUpdater worldUpdater;
+    @Mock private WorldUpdater worldUpdater;
 
-	@Mock
-	private GasCalculator gasCalculator;
+    @Mock private GasCalculator gasCalculator;
 
-	@Mock
-	private MessageFrame mf;
+    @Mock private MessageFrame mf;
 
-	@Mock
-	private EVM evm;
-	@Mock
-	private BiPredicate<Address, MessageFrame> addressValidator;
+    @Mock private EVM evm;
+    @Mock private BiPredicate<Address, MessageFrame> addressValidator;
 
-	private HederaExtCodeCopyOperation subject;
+    private HederaExtCodeCopyOperation subject;
 
-	final private String ETH_ADDRESS = "0xc257274276a4e539741ca11b590b9447b26a8051";
-	final private Address ETH_ADDRESS_INSTANCE = Address.fromHexString(ETH_ADDRESS);
-	final private Bytes MEM_OFFSET = Bytes.of(5);
-	final private Bytes NUM_BYTES = Bytes.of(10);
-	final private long OPERATION_COST = 1_000L;
-	final private long WARM_READ_COST = 100L;
-	final private long ACTUAL_COST = OPERATION_COST + WARM_READ_COST;
-	final private Account account = new SimpleAccount(ETH_ADDRESS_INSTANCE, 0, Wei.ONE);
+    private final String ETH_ADDRESS = "0xc257274276a4e539741ca11b590b9447b26a8051";
+    private final Address ETH_ADDRESS_INSTANCE = Address.fromHexString(ETH_ADDRESS);
+    private final Bytes MEM_OFFSET = Bytes.of(5);
+    private final Bytes NUM_BYTES = Bytes.of(10);
+    private final long OPERATION_COST = 1_000L;
+    private final long WARM_READ_COST = 100L;
+    private final long ACTUAL_COST = OPERATION_COST + WARM_READ_COST;
+    private final Account account = new SimpleAccount(ETH_ADDRESS_INSTANCE, 0, Wei.ONE);
 
-	@BeforeEach
-	void setUp() {
-		subject = new HederaExtCodeCopyOperation(gasCalculator, addressValidator);
-	}
+    @BeforeEach
+    void setUp() {
+        subject = new HederaExtCodeCopyOperation(gasCalculator, addressValidator);
+    }
 
-	@Test
-	void executeResolvesToInvalidSolidityAddress() {
-		// given:
-		given(mf.getStackItem(0)).willReturn(ETH_ADDRESS_INSTANCE);
-		given(mf.getStackItem(1)).willReturn(MEM_OFFSET);
-		given(mf.getStackItem(3)).willReturn(NUM_BYTES);
-		given(gasCalculator.extCodeCopyOperationGasCost(mf, clampedToLong(MEM_OFFSET), clampedToLong(NUM_BYTES))).willReturn(OPERATION_COST);
-		given(gasCalculator.getWarmStorageReadCost()).willReturn(WARM_READ_COST);
-		given(addressValidator.test(any(), any())).willReturn(false);
+    @Test
+    void executeResolvesToInvalidSolidityAddress() {
+        // given:
+        given(mf.getStackItem(0)).willReturn(ETH_ADDRESS_INSTANCE);
+        given(mf.getStackItem(1)).willReturn(MEM_OFFSET);
+        given(mf.getStackItem(3)).willReturn(NUM_BYTES);
+        given(
+                        gasCalculator.extCodeCopyOperationGasCost(
+                                mf, clampedToLong(MEM_OFFSET), clampedToLong(NUM_BYTES)))
+                .willReturn(OPERATION_COST);
+        given(gasCalculator.getWarmStorageReadCost()).willReturn(WARM_READ_COST);
+        given(addressValidator.test(any(), any())).willReturn(false);
 
-		// when:
-		var opResult = subject.execute(mf, evm);
+        // when:
+        var opResult = subject.execute(mf, evm);
 
-		// then:
-		assertEquals(Optional.of(HederaExceptionalHaltReason.INVALID_SOLIDITY_ADDRESS), opResult.getHaltReason());
-		assertEquals(OptionalLong.of(ACTUAL_COST), opResult.getGasCost());
-	}
+        // then:
+        assertEquals(
+                Optional.of(HederaExceptionalHaltReason.INVALID_SOLIDITY_ADDRESS),
+                opResult.getHaltReason());
+        assertEquals(OptionalLong.of(ACTUAL_COST), opResult.getGasCost());
+    }
 
-	@Test
-	void successfulExecution() {
-		// given:
-		given(mf.getStackItem(0)).willReturn(ETH_ADDRESS_INSTANCE);
-		given(mf.getStackItem(1)).willReturn(MEM_OFFSET);
-		given(mf.getStackItem(3)).willReturn(NUM_BYTES);
-		given(mf.getWorldUpdater()).willReturn(worldUpdater);
-		given(gasCalculator.extCodeCopyOperationGasCost(mf, clampedToLong(MEM_OFFSET), clampedToLong(NUM_BYTES))).willReturn(OPERATION_COST);
-		given(gasCalculator.getWarmStorageReadCost()).willReturn(WARM_READ_COST);
-		// and:
-		given(worldUpdater.get(ETH_ADDRESS_INSTANCE)).willReturn(account);
-		// and:
-		given(mf.popStackItem())
-				.willReturn(ETH_ADDRESS_INSTANCE)
-				.willReturn(MEM_OFFSET)
-				.willReturn(MEM_OFFSET)
-				.willReturn(NUM_BYTES);
-		given(mf.warmUpAddress(ETH_ADDRESS_INSTANCE)).willReturn(true);
-		given(mf.getRemainingGas()).willReturn(2000L);
-		given(mf.getWorldUpdater()).willReturn(worldUpdater);
-		// and:
-		given(gasCalculator.extCodeCopyOperationGasCost(mf, clampedToLong(MEM_OFFSET), clampedToLong(NUM_BYTES))).willReturn(OPERATION_COST);
-		given(gasCalculator.getWarmStorageReadCost()).willReturn(WARM_READ_COST);
-		given(addressValidator.test(any(), any())).willReturn(true);
+    @Test
+    void successfulExecution() {
+        // given:
+        given(mf.getStackItem(0)).willReturn(ETH_ADDRESS_INSTANCE);
+        given(mf.getStackItem(1)).willReturn(MEM_OFFSET);
+        given(mf.getStackItem(3)).willReturn(NUM_BYTES);
+        given(mf.getWorldUpdater()).willReturn(worldUpdater);
+        given(
+                        gasCalculator.extCodeCopyOperationGasCost(
+                                mf, clampedToLong(MEM_OFFSET), clampedToLong(NUM_BYTES)))
+                .willReturn(OPERATION_COST);
+        given(gasCalculator.getWarmStorageReadCost()).willReturn(WARM_READ_COST);
+        // and:
+        given(worldUpdater.get(ETH_ADDRESS_INSTANCE)).willReturn(account);
+        // and:
+        given(mf.popStackItem())
+                .willReturn(ETH_ADDRESS_INSTANCE)
+                .willReturn(MEM_OFFSET)
+                .willReturn(MEM_OFFSET)
+                .willReturn(NUM_BYTES);
+        given(mf.warmUpAddress(ETH_ADDRESS_INSTANCE)).willReturn(true);
+        given(mf.getRemainingGas()).willReturn(2000L);
+        given(mf.getWorldUpdater()).willReturn(worldUpdater);
+        // and:
+        given(
+                        gasCalculator.extCodeCopyOperationGasCost(
+                                mf, clampedToLong(MEM_OFFSET), clampedToLong(NUM_BYTES)))
+                .willReturn(OPERATION_COST);
+        given(gasCalculator.getWarmStorageReadCost()).willReturn(WARM_READ_COST);
+        given(addressValidator.test(any(), any())).willReturn(true);
 
-		// when:
-		var opResult = subject.execute(mf, evm);
+        // when:
+        var opResult = subject.execute(mf, evm);
 
-		// then:
-		assertEquals(Optional.empty(), opResult.getHaltReason());
-		assertEquals(OptionalLong.of(ACTUAL_COST), opResult.getGasCost());
-	}
+        // then:
+        assertEquals(Optional.empty(), opResult.getHaltReason());
+        assertEquals(OptionalLong.of(ACTUAL_COST), opResult.getGasCost());
+    }
 }

--- a/hedera-node/src/test/java/com/hedera/services/contracts/operation/HederaExtCodeHashOperationTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/contracts/operation/HederaExtCodeHashOperationTest.java
@@ -20,7 +20,15 @@ package com.hedera.services.contracts.operation;
  * ‍
  */
 
+import static org.hyperledger.besu.evm.frame.ExceptionalHaltReason.INSUFFICIENT_STACK_ITEMS;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
 import com.hedera.services.store.contracts.HederaStackedWorldStateUpdater;
+import java.util.Optional;
+import java.util.OptionalLong;
+import java.util.function.BiPredicate;
 import org.apache.tuweni.bytes.Bytes;
 import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.datatypes.Hash;
@@ -36,122 +44,109 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.util.Optional;
-import java.util.OptionalLong;
-import java.util.function.BiPredicate;
-
-import static org.hyperledger.besu.evm.frame.ExceptionalHaltReason.INSUFFICIENT_STACK_ITEMS;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.given;
-
 @ExtendWith(MockitoExtension.class)
 class HederaExtCodeHashOperationTest {
 
-	@Mock
-	private HederaStackedWorldStateUpdater worldUpdater;
+    @Mock private HederaStackedWorldStateUpdater worldUpdater;
 
-	@Mock
-	private Account account;
+    @Mock private Account account;
 
-	@Mock
-	private GasCalculator gasCalculator;
+    @Mock private GasCalculator gasCalculator;
 
-	@Mock
-	private MessageFrame mf;
+    @Mock private MessageFrame mf;
 
-	@Mock
-	private EVM evm;
+    @Mock private EVM evm;
 
-	@Mock
-	private BiPredicate<Address, MessageFrame> addressValidator;
+    @Mock private BiPredicate<Address, MessageFrame> addressValidator;
 
-	private HederaExtCodeHashOperation subject;
+    private HederaExtCodeHashOperation subject;
 
-	final private String ETH_ADDRESS = "0xc257274276a4e539741ca11b590b9447b26a8051";
-	final private Address ETH_ADDRESS_INSTANCE = Address.fromHexString(ETH_ADDRESS);
-	final private long OPERATION_COST = 1_000L;
-	final private long WARM_READ_COST = 100L;
-	final private long ACTUAL_COST = OPERATION_COST + WARM_READ_COST;
+    private final String ETH_ADDRESS = "0xc257274276a4e539741ca11b590b9447b26a8051";
+    private final Address ETH_ADDRESS_INSTANCE = Address.fromHexString(ETH_ADDRESS);
+    private final long OPERATION_COST = 1_000L;
+    private final long WARM_READ_COST = 100L;
+    private final long ACTUAL_COST = OPERATION_COST + WARM_READ_COST;
 
-	@BeforeEach
-	void setUp() {
-		subject = new HederaExtCodeHashOperation(gasCalculator, addressValidator);
-		given(gasCalculator.extCodeHashOperationGasCost()).willReturn(OPERATION_COST);
-		given(gasCalculator.getWarmStorageReadCost()).willReturn(WARM_READ_COST);
-	}
+    @BeforeEach
+    void setUp() {
+        subject = new HederaExtCodeHashOperation(gasCalculator, addressValidator);
+        given(gasCalculator.extCodeHashOperationGasCost()).willReturn(OPERATION_COST);
+        given(gasCalculator.getWarmStorageReadCost()).willReturn(WARM_READ_COST);
+    }
 
-	@Test
-	void executeResolvesToInvalidSolidityAddress() {
-		given(mf.popStackItem()).willReturn(ETH_ADDRESS_INSTANCE);
-		given(addressValidator.test(any(), any())).willReturn(false);
+    @Test
+    void executeResolvesToInvalidSolidityAddress() {
+        given(mf.popStackItem()).willReturn(ETH_ADDRESS_INSTANCE);
+        given(addressValidator.test(any(), any())).willReturn(false);
 
-		var opResult = subject.execute(mf, evm);
+        var opResult = subject.execute(mf, evm);
 
-		assertEquals(Optional.of(HederaExceptionalHaltReason.INVALID_SOLIDITY_ADDRESS), opResult.getHaltReason());
-		assertEquals(OptionalLong.of(ACTUAL_COST), opResult.getGasCost());
-	}
+        assertEquals(
+                Optional.of(HederaExceptionalHaltReason.INVALID_SOLIDITY_ADDRESS),
+                opResult.getHaltReason());
+        assertEquals(OptionalLong.of(ACTUAL_COST), opResult.getGasCost());
+    }
 
-	@Test
-	void executeResolvesToInsufficientGas() {
-		givenMessageFrameWithRemainingGas(ACTUAL_COST - 1L);
-		given(addressValidator.test(any(), any())).willReturn(true);
+    @Test
+    void executeResolvesToInsufficientGas() {
+        givenMessageFrameWithRemainingGas(ACTUAL_COST - 1L);
+        given(addressValidator.test(any(), any())).willReturn(true);
 
-		var opResult = subject.execute(mf, evm);
+        var opResult = subject.execute(mf, evm);
 
-		assertEquals(Optional.of(ExceptionalHaltReason.INSUFFICIENT_GAS), opResult.getHaltReason());
-		assertEquals(OptionalLong.of(ACTUAL_COST), opResult.getGasCost());
-	}
+        assertEquals(Optional.of(ExceptionalHaltReason.INSUFFICIENT_GAS), opResult.getHaltReason());
+        assertEquals(OptionalLong.of(ACTUAL_COST), opResult.getGasCost());
+    }
 
-	@Test
-	void executeHappyPathWithEmptyAccount() {
-		givenMessageFrameWithRemainingGas(ACTUAL_COST + 1L);
-		given(account.isEmpty()).willReturn(true);
-		given(addressValidator.test(any(), any())).willReturn(true);
+    @Test
+    void executeHappyPathWithEmptyAccount() {
+        givenMessageFrameWithRemainingGas(ACTUAL_COST + 1L);
+        given(account.isEmpty()).willReturn(true);
+        given(addressValidator.test(any(), any())).willReturn(true);
 
-		var opResult = subject.execute(mf, evm);
+        var opResult = subject.execute(mf, evm);
 
-		assertEquals(OptionalLong.of(ACTUAL_COST), opResult.getGasCost());
-	}
+        assertEquals(OptionalLong.of(ACTUAL_COST), opResult.getGasCost());
+    }
 
-	@Test
-	void executeHappyPathWithAccount() {
-		givenMessageFrameWithRemainingGas(ACTUAL_COST + 1L);
-		given(account.getCodeHash()).willReturn(Hash.hash(Bytes.of(1)));
-		given(addressValidator.test(any(), any())).willReturn(true);
+    @Test
+    void executeHappyPathWithAccount() {
+        givenMessageFrameWithRemainingGas(ACTUAL_COST + 1L);
+        given(account.getCodeHash()).willReturn(Hash.hash(Bytes.of(1)));
+        given(addressValidator.test(any(), any())).willReturn(true);
 
-		var opResult = subject.execute(mf, evm);
+        var opResult = subject.execute(mf, evm);
 
-		assertEquals(OptionalLong.of(ACTUAL_COST), opResult.getGasCost());
-	}
+        assertEquals(OptionalLong.of(ACTUAL_COST), opResult.getGasCost());
+    }
 
-	@Test
-	void executeWithGasRemainingAsActualCost() {
-		givenMessageFrameWithRemainingGas(ACTUAL_COST);
-		given(account.isEmpty()).willReturn(false);
-		given(account.getCodeHash()).willReturn(Hash.hash(Bytes.of(1)));
-		given(addressValidator.test(any(), any())).willReturn(true);
+    @Test
+    void executeWithGasRemainingAsActualCost() {
+        givenMessageFrameWithRemainingGas(ACTUAL_COST);
+        given(account.isEmpty()).willReturn(false);
+        given(account.getCodeHash()).willReturn(Hash.hash(Bytes.of(1)));
+        given(addressValidator.test(any(), any())).willReturn(true);
 
-		var opResult = subject.execute(mf, evm);
+        var opResult = subject.execute(mf, evm);
 
-		assertEquals(OptionalLong.of(ACTUAL_COST), opResult.getGasCost());
-	}
+        assertEquals(OptionalLong.of(ACTUAL_COST), opResult.getGasCost());
+    }
 
-	@Test
-	void executeThrowsInsufficientStackItems() {
-		given(mf.popStackItem()).willThrow(FixedStack.UnderflowException.class);
+    @Test
+    void executeThrowsInsufficientStackItems() {
+        given(mf.popStackItem()).willThrow(FixedStack.UnderflowException.class);
 
-		var opResult = subject.execute(mf, evm);
+        var opResult = subject.execute(mf, evm);
 
-		assertEquals(Optional.of(INSUFFICIENT_STACK_ITEMS), opResult.getHaltReason());
-		assertEquals(OptionalLong.of(ACTUAL_COST), opResult.getGasCost());
-	}
+        assertEquals(Optional.of(INSUFFICIENT_STACK_ITEMS), opResult.getHaltReason());
+        assertEquals(OptionalLong.of(ACTUAL_COST), opResult.getGasCost());
+    }
 
-	private void givenMessageFrameWithRemainingGas(long gas) {
-		given(mf.popStackItem()).willReturn(ETH_ADDRESS_INSTANCE);
-		given(mf.getWorldUpdater()).willReturn(worldUpdater);
-		given(mf.warmUpAddress(ETH_ADDRESS_INSTANCE)).willReturn(true);
-		given(mf.getRemainingGas()).willReturn(gas);
-		given(worldUpdater.get(ETH_ADDRESS_INSTANCE)).willReturn(account);
-	}
+    private void givenMessageFrameWithRemainingGas(long gas) {
+        given(mf.popStackItem()).willReturn(ETH_ADDRESS_INSTANCE);
+        given(mf.getWorldUpdater()).willReturn(worldUpdater);
+        given(mf.warmUpAddress(ETH_ADDRESS_INSTANCE)).willReturn(true);
+        given(mf.getRemainingGas()).willReturn(gas);
+        given(worldUpdater.get(ETH_ADDRESS_INSTANCE)).willReturn(account);
+    }
 }

--- a/hedera-node/src/test/java/com/hedera/services/contracts/operation/HederaExtCodeHashOperationTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/contracts/operation/HederaExtCodeHashOperationTest.java
@@ -1,11 +1,6 @@
-package com.hedera.services.contracts.operation;
-
-/*-
- * ‌
- * Hedera Services Node
- * ​
- * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
- * ​
+/*
+ * Copyright (C) 2021-2022 Hedera Hashgraph, LLC
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -17,8 +12,8 @@ package com.hedera.services.contracts.operation;
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- * ‍
  */
+package com.hedera.services.contracts.operation;
 
 import static org.hyperledger.besu.evm.frame.ExceptionalHaltReason.INSUFFICIENT_STACK_ITEMS;
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/hedera-node/src/test/java/com/hedera/services/contracts/operation/HederaExtCodeSizeOperationTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/contracts/operation/HederaExtCodeSizeOperationTest.java
@@ -1,11 +1,6 @@
-package com.hedera.services.contracts.operation;
-
-/*-
- * ‌
- * Hedera Services Node
- * ​
- * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
- * ​
+/*
+ * Copyright (C) 2021-2022 Hedera Hashgraph, LLC
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -17,8 +12,8 @@ package com.hedera.services.contracts.operation;
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- * ‍
  */
+package com.hedera.services.contracts.operation;
 
 import static org.hyperledger.besu.evm.frame.ExceptionalHaltReason.INSUFFICIENT_STACK_ITEMS;
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/hedera-node/src/test/java/com/hedera/services/contracts/operation/HederaLogOperationTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/contracts/operation/HederaLogOperationTest.java
@@ -9,9 +9,9 @@ package com.hedera.services.contracts.operation;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,6 +20,15 @@ package com.hedera.services.contracts.operation;
  * ‍
  */
 
+import static com.swirlds.common.utility.CommonUtils.unhex;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.collection.IsIterableContainingInOrder.contains;
+import static org.hyperledger.besu.evm.frame.ExceptionalHaltReason.ILLEGAL_STATE_CHANGE;
+import static org.hyperledger.besu.evm.frame.ExceptionalHaltReason.INSUFFICIENT_GAS;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
 import com.hedera.services.ledger.accounts.ContractAliases;
 import com.hedera.services.store.contracts.HederaStackedWorldStateUpdater;
 import com.hedera.services.utils.EntityNum;
@@ -27,6 +36,9 @@ import com.hedera.test.extensions.LogCaptor;
 import com.hedera.test.extensions.LogCaptureExtension;
 import com.hedera.test.extensions.LoggingSubject;
 import com.hedera.test.extensions.LoggingTarget;
+import java.util.List;
+import java.util.Optional;
+import java.util.OptionalLong;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import org.hamcrest.Matchers;
@@ -44,159 +56,151 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.util.List;
-import java.util.Optional;
-import java.util.OptionalLong;
-
-import static com.swirlds.common.utility.CommonUtils.unhex;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.collection.IsIterableContainingInOrder.contains;
-import static org.hyperledger.besu.evm.frame.ExceptionalHaltReason.ILLEGAL_STATE_CHANGE;
-import static org.hyperledger.besu.evm.frame.ExceptionalHaltReason.INSUFFICIENT_GAS;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.verify;
-
-
-@ExtendWith({ LogCaptureExtension.class, MockitoExtension.class })
+@ExtendWith({LogCaptureExtension.class, MockitoExtension.class})
 class HederaLogOperationTest {
-	private static final int numTopics = 2;
-	private static final long reqGas = 1234L;
-	private static final long numBytes = 12L;
-	private static final long dataLocation = 13L;
-	private static final Bytes firstLogTopic = Bytes.fromHexString("0xee");
-	private static final Bytes secondLogTopic = Bytes.fromHexString("0xff");
-	private static final byte[] rawNonMirrorAddress = unhex("abcdefabcdefabcdefbabcdefabcdefabcdefbbb");
-	private static final EntityNum num = EntityNum.fromLong(1234L);
-	private static final Address nonMirrorAddress = Address.wrap(Bytes.wrap(rawNonMirrorAddress));
-	private static final Address mirrorAddress = num.toEvmAddress();
-	private static final Address unknownAddress = EntityNum.MISSING_NUM.toEvmAddress();
-	private static final Bytes data = Bytes.fromHexString("0xabcdef");
-	private static final Operation.OperationResult insufficientGasResult =
-			new Operation.OperationResult(OptionalLong.of(reqGas), Optional.of(INSUFFICIENT_GAS));
-	private static final Operation.OperationResult illegalStateChangeResult =
-			new Operation.OperationResult(OptionalLong.of(reqGas), Optional.of(ILLEGAL_STATE_CHANGE));
-	private static final Operation.OperationResult goodResult =
-			new Operation.OperationResult(OptionalLong.of(reqGas), Optional.empty());
+    private static final int numTopics = 2;
+    private static final long reqGas = 1234L;
+    private static final long numBytes = 12L;
+    private static final long dataLocation = 13L;
+    private static final Bytes firstLogTopic = Bytes.fromHexString("0xee");
+    private static final Bytes secondLogTopic = Bytes.fromHexString("0xff");
+    private static final byte[] rawNonMirrorAddress =
+            unhex("abcdefabcdefabcdefbabcdefabcdefabcdefbbb");
+    private static final EntityNum num = EntityNum.fromLong(1234L);
+    private static final Address nonMirrorAddress = Address.wrap(Bytes.wrap(rawNonMirrorAddress));
+    private static final Address mirrorAddress = num.toEvmAddress();
+    private static final Address unknownAddress = EntityNum.MISSING_NUM.toEvmAddress();
+    private static final Bytes data = Bytes.fromHexString("0xabcdef");
+    private static final Operation.OperationResult insufficientGasResult =
+            new Operation.OperationResult(OptionalLong.of(reqGas), Optional.of(INSUFFICIENT_GAS));
+    private static final Operation.OperationResult illegalStateChangeResult =
+            new Operation.OperationResult(
+                    OptionalLong.of(reqGas), Optional.of(ILLEGAL_STATE_CHANGE));
+    private static final Operation.OperationResult goodResult =
+            new Operation.OperationResult(OptionalLong.of(reqGas), Optional.empty());
 
-	@Mock
-	private GasCalculator gasCalculator;
-	@Mock
-	private EVM evm;
-	@Mock
-	private MessageFrame frame;
-	@Mock
-	private HederaStackedWorldStateUpdater updater;
-	@Mock
-	private ContractAliases aliases;
+    @Mock private GasCalculator gasCalculator;
+    @Mock private EVM evm;
+    @Mock private MessageFrame frame;
+    @Mock private HederaStackedWorldStateUpdater updater;
+    @Mock private ContractAliases aliases;
 
-	@LoggingTarget
-	private LogCaptor logCaptor;
-	@LoggingSubject
-	private HederaLogOperation subject;
+    @LoggingTarget private LogCaptor logCaptor;
+    @LoggingSubject private HederaLogOperation subject;
 
-	@BeforeEach
-	void setUp() {
-		subject = new HederaLogOperation(numTopics, gasCalculator);
-	}
+    @BeforeEach
+    void setUp() {
+        subject = new HederaLogOperation(numTopics, gasCalculator);
+    }
 
-	@Test
-	void getsExpectedName() {
-		assertEquals("LOG" + numTopics, subject.getName());
-	}
+    @Test
+    void getsExpectedName() {
+        assertEquals("LOG" + numTopics, subject.getName());
+    }
 
-	@Test
-	void failsOnIllegalStateChange() {
-		given(frame.popStackItem())
-				.willReturn(Bytes.ofUnsignedLong(dataLocation))
-				.willReturn(Bytes.ofUnsignedLong(numBytes));
-		given(gasCalculator.logOperationGasCost(frame, dataLocation, numBytes, numTopics)).willReturn(reqGas);
-		given(frame.isStatic()).willReturn(true);
+    @Test
+    void failsOnIllegalStateChange() {
+        given(frame.popStackItem())
+                .willReturn(Bytes.ofUnsignedLong(dataLocation))
+                .willReturn(Bytes.ofUnsignedLong(numBytes));
+        given(gasCalculator.logOperationGasCost(frame, dataLocation, numBytes, numTopics))
+                .willReturn(reqGas);
+        given(frame.isStatic()).willReturn(true);
 
-		final var result = subject.execute(frame, evm);
-		assertResultMatch(illegalStateChangeResult, result);
-	}
+        final var result = subject.execute(frame, evm);
+        assertResultMatch(illegalStateChangeResult, result);
+    }
 
-	@Test
-	void failsOnInsufficientGas() {
-		final var insufficientGas = reqGas - 1L;
-		given(frame.popStackItem())
-				.willReturn(Bytes.ofUnsignedLong(dataLocation))
-				.willReturn(Bytes.ofUnsignedLong(numBytes));
-		given(gasCalculator.logOperationGasCost(frame, dataLocation, numBytes, numTopics)).willReturn(reqGas);
-		given(frame.getRemainingGas()).willReturn(insufficientGas);
+    @Test
+    void failsOnInsufficientGas() {
+        final var insufficientGas = reqGas - 1L;
+        given(frame.popStackItem())
+                .willReturn(Bytes.ofUnsignedLong(dataLocation))
+                .willReturn(Bytes.ofUnsignedLong(numBytes));
+        given(gasCalculator.logOperationGasCost(frame, dataLocation, numBytes, numTopics))
+                .willReturn(reqGas);
+        given(frame.getRemainingGas()).willReturn(insufficientGas);
 
-		final var result = subject.execute(frame, evm);
-		assertResultMatch(insufficientGasResult, result);
-	}
+        final var result = subject.execute(frame, evm);
+        assertResultMatch(insufficientGasResult, result);
+    }
 
-	@Test
-	void getsExpectedResultForHappyPath() {
-		final var captor = ArgumentCaptor.forClass(Log.class);
-		final var expectedLog = new Log(mirrorAddress, data, List.of(
-				LogTopic.create(Bytes32.leftPad(firstLogTopic)),
-				LogTopic.create(Bytes32.leftPad(secondLogTopic))
-		));
+    @Test
+    void getsExpectedResultForHappyPath() {
+        final var captor = ArgumentCaptor.forClass(Log.class);
+        final var expectedLog =
+                new Log(
+                        mirrorAddress,
+                        data,
+                        List.of(
+                                LogTopic.create(Bytes32.leftPad(firstLogTopic)),
+                                LogTopic.create(Bytes32.leftPad(secondLogTopic))));
 
-		given(frame.getWorldUpdater()).willReturn(updater);
-		given(updater.aliases()).willReturn(aliases);
-		given(aliases.isMirror(mirrorAddress)).willReturn(true);
-		given(aliases.resolveForEvm(nonMirrorAddress)).willReturn(mirrorAddress);
+        given(frame.getWorldUpdater()).willReturn(updater);
+        given(updater.aliases()).willReturn(aliases);
+        given(aliases.isMirror(mirrorAddress)).willReturn(true);
+        given(aliases.resolveForEvm(nonMirrorAddress)).willReturn(mirrorAddress);
 
-		final var adequateGas = reqGas + 1L;
-		given(frame.popStackItem())
-				.willReturn(Bytes.ofUnsignedLong(dataLocation))
-				.willReturn(Bytes.ofUnsignedLong(numBytes))
-				.willReturn(firstLogTopic)
-				.willReturn(secondLogTopic);
-		given(gasCalculator.logOperationGasCost(frame, dataLocation, numBytes, numTopics)).willReturn(reqGas);
-		given(frame.getRemainingGas()).willReturn(adequateGas);
-		given(frame.getRecipientAddress()).willReturn(nonMirrorAddress);
-		given(frame.readMemory(dataLocation, numBytes)).willReturn(data);
+        final var adequateGas = reqGas + 1L;
+        given(frame.popStackItem())
+                .willReturn(Bytes.ofUnsignedLong(dataLocation))
+                .willReturn(Bytes.ofUnsignedLong(numBytes))
+                .willReturn(firstLogTopic)
+                .willReturn(secondLogTopic);
+        given(gasCalculator.logOperationGasCost(frame, dataLocation, numBytes, numTopics))
+                .willReturn(reqGas);
+        given(frame.getRemainingGas()).willReturn(adequateGas);
+        given(frame.getRecipientAddress()).willReturn(nonMirrorAddress);
+        given(frame.readMemory(dataLocation, numBytes)).willReturn(data);
 
-		final var result = subject.execute(frame, evm);
+        final var result = subject.execute(frame, evm);
 
-		assertResultMatch(goodResult, result);
-		verify(frame).addLog(captor.capture());
-		assertEquals(expectedLog, captor.getValue());
-	}
+        assertResultMatch(goodResult, result);
+        verify(frame).addLog(captor.capture());
+        assertEquals(expectedLog, captor.getValue());
+    }
 
-	@Test
-	void getsExpectedResultForHappyPathWithUnresolvable() {
-		final var captor = ArgumentCaptor.forClass(Log.class);
-		final var expectedLog = new Log(unknownAddress, data, List.of(
-				LogTopic.create(Bytes32.leftPad(firstLogTopic)),
-				LogTopic.create(Bytes32.leftPad(secondLogTopic))
-		));
+    @Test
+    void getsExpectedResultForHappyPathWithUnresolvable() {
+        final var captor = ArgumentCaptor.forClass(Log.class);
+        final var expectedLog =
+                new Log(
+                        unknownAddress,
+                        data,
+                        List.of(
+                                LogTopic.create(Bytes32.leftPad(firstLogTopic)),
+                                LogTopic.create(Bytes32.leftPad(secondLogTopic))));
 
-		given(frame.getWorldUpdater()).willReturn(updater);
-		given(updater.aliases()).willReturn(aliases);
-		given(aliases.resolveForEvm(nonMirrorAddress)).willReturn(nonMirrorAddress);
+        given(frame.getWorldUpdater()).willReturn(updater);
+        given(updater.aliases()).willReturn(aliases);
+        given(aliases.resolveForEvm(nonMirrorAddress)).willReturn(nonMirrorAddress);
 
-		final var adequateGas = reqGas + 1L;
-		given(frame.popStackItem())
-				.willReturn(Bytes.ofUnsignedLong(dataLocation))
-				.willReturn(Bytes.ofUnsignedLong(numBytes))
-				.willReturn(firstLogTopic)
-				.willReturn(secondLogTopic);
-		given(gasCalculator.logOperationGasCost(frame, dataLocation, numBytes, numTopics)).willReturn(reqGas);
-		given(frame.getRemainingGas()).willReturn(adequateGas);
-		given(frame.getRecipientAddress()).willReturn(nonMirrorAddress);
-		given(frame.readMemory(dataLocation, numBytes)).willReturn(data);
+        final var adequateGas = reqGas + 1L;
+        given(frame.popStackItem())
+                .willReturn(Bytes.ofUnsignedLong(dataLocation))
+                .willReturn(Bytes.ofUnsignedLong(numBytes))
+                .willReturn(firstLogTopic)
+                .willReturn(secondLogTopic);
+        given(gasCalculator.logOperationGasCost(frame, dataLocation, numBytes, numTopics))
+                .willReturn(reqGas);
+        given(frame.getRemainingGas()).willReturn(adequateGas);
+        given(frame.getRecipientAddress()).willReturn(nonMirrorAddress);
+        given(frame.readMemory(dataLocation, numBytes)).willReturn(data);
 
-		final var result = subject.execute(frame, evm);
+        final var result = subject.execute(frame, evm);
 
-		assertResultMatch(goodResult, result);
-		verify(frame).addLog(captor.capture());
-		assertEquals(expectedLog, captor.getValue());
+        assertResultMatch(goodResult, result);
+        verify(frame).addLog(captor.capture());
+        assertEquals(expectedLog, captor.getValue());
 
-		assertThat(
-				logCaptor.warnLogs(),
-				contains(Matchers.equalTo("Could not resolve logger address " + nonMirrorAddress)));
-	}
+        assertThat(
+                logCaptor.warnLogs(),
+                contains(Matchers.equalTo("Could not resolve logger address " + nonMirrorAddress)));
+    }
 
-	private void assertResultMatch(final Operation.OperationResult expected, final Operation.OperationResult actual) {
-		assertEquals(expected.getGasCost(), actual.getGasCost());
-		assertEquals(expected.getHaltReason(), actual.getHaltReason());
-	}
+    private void assertResultMatch(
+            final Operation.OperationResult expected, final Operation.OperationResult actual) {
+        assertEquals(expected.getGasCost(), actual.getGasCost());
+        assertEquals(expected.getHaltReason(), actual.getHaltReason());
+    }
 }

--- a/hedera-node/src/test/java/com/hedera/services/contracts/operation/HederaLogOperationTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/contracts/operation/HederaLogOperationTest.java
@@ -1,11 +1,6 @@
-package com.hedera.services.contracts.operation;
-
-/*-
- * ‌
- * Hedera Services Node
- * ​
- * Copyright (C) 2018 - 2022 Hedera Hashgraph, LLC
- * ​
+/*
+ * Copyright (C) 2022 Hedera Hashgraph, LLC
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -17,8 +12,8 @@ package com.hedera.services.contracts.operation;
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- * ‍
  */
+package com.hedera.services.contracts.operation;
 
 import static com.swirlds.common.utility.CommonUtils.unhex;
 import static org.hamcrest.MatcherAssert.assertThat;

--- a/hedera-node/src/test/java/com/hedera/services/contracts/operation/HederaOperationUtilTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/contracts/operation/HederaOperationUtilTest.java
@@ -22,12 +22,25 @@ package com.hedera.services.contracts.operation;
  *
  */
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.never;
+import static org.mockito.BDDMockito.verify;
+
 import com.hedera.services.contracts.sources.EvmSigsVerifier;
-import com.hedera.services.ledger.accounts.ContractAliases;
 import com.hedera.services.store.contracts.HederaStackedWorldStateUpdater;
 import com.hedera.services.store.contracts.HederaWorldState;
 import com.hedera.services.store.contracts.WorldLedgers;
 import com.hedera.services.store.contracts.WorldStateAccount;
+import java.util.ArrayDeque;
+import java.util.Map;
+import java.util.Optional;
+import java.util.OptionalLong;
+import java.util.TreeMap;
+import java.util.function.LongSupplier;
+import java.util.function.Supplier;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
@@ -44,306 +57,300 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.util.ArrayDeque;
-import java.util.Map;
-import java.util.Optional;
-import java.util.OptionalLong;
-import java.util.TreeMap;
-import java.util.function.LongSupplier;
-import java.util.function.Supplier;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.BDDMockito.never;
-import static org.mockito.BDDMockito.verify;
-
 @ExtendWith(MockitoExtension.class)
 class HederaOperationUtilTest {
-	private static final Address PRETEND_RECIPIENT_ADDR = Address.ALTBN128_ADD;
-	private static final Address PRETEND_CONTRACT_ADDR = Address.ALTBN128_MUL;
+    private static final Address PRETEND_RECIPIENT_ADDR = Address.ALTBN128_ADD;
+    private static final Address PRETEND_CONTRACT_ADDR = Address.ALTBN128_MUL;
 
-	@Mock
-	private MessageFrame messageFrame;
-	@Mock
-	private HederaStackedWorldStateUpdater hederaWorldUpdater;
-	@Mock
-	private HederaWorldState.Updater updater;
-	@Mock
-	private WorldStateAccount worldStateAccount;
-	@Mock
-	private EvmSigsVerifier sigsVerifier;
-	@Mock
-	private LongSupplier gasSupplier;
-	@Mock
-	private Supplier<Operation.OperationResult> executionSupplier;
-	@Mock
-	private Map<String, PrecompiledContract> precompiledContractMap;
-	@Mock
-	private WorldLedgers ledgers;
+    @Mock private MessageFrame messageFrame;
+    @Mock private HederaStackedWorldStateUpdater hederaWorldUpdater;
+    @Mock private HederaWorldState.Updater updater;
+    @Mock private WorldStateAccount worldStateAccount;
+    @Mock private EvmSigsVerifier sigsVerifier;
+    @Mock private LongSupplier gasSupplier;
+    @Mock private Supplier<Operation.OperationResult> executionSupplier;
+    @Mock private Map<String, PrecompiledContract> precompiledContractMap;
+    @Mock private WorldLedgers ledgers;
 
-	private final long expectedHaltGas = 10L;
-	private final long expectedSuccessfulGas = 100L;
+    private final long expectedHaltGas = 10L;
+    private final long expectedSuccessfulGas = 100L;
 
-	@Test
-	void shortCircuitsForPrecompileSigCheck() {
-		final var degenerateResult =
-				new Operation.OperationResult(OptionalLong.empty(), Optional.empty());
-		given(precompiledContractMap.containsKey(PRETEND_RECIPIENT_ADDR.toShortHexString())).willReturn(true);
-		given(executionSupplier.get()).willReturn(degenerateResult);
+    @Test
+    void shortCircuitsForPrecompileSigCheck() {
+        final var degenerateResult =
+                new Operation.OperationResult(OptionalLong.empty(), Optional.empty());
+        given(precompiledContractMap.containsKey(PRETEND_RECIPIENT_ADDR.toShortHexString()))
+                .willReturn(true);
+        given(executionSupplier.get()).willReturn(degenerateResult);
 
-		final var result = HederaOperationUtil.addressSignatureCheckExecution(
-				sigsVerifier,
-				messageFrame,
-				PRETEND_RECIPIENT_ADDR,
-				gasSupplier,
-				executionSupplier,
-				(a, b) -> false,
-				precompiledContractMap);
-		
-		assertSame(degenerateResult, result);
-	}
+        final var result =
+                HederaOperationUtil.addressSignatureCheckExecution(
+                        sigsVerifier,
+                        messageFrame,
+                        PRETEND_RECIPIENT_ADDR,
+                        gasSupplier,
+                        executionSupplier,
+                        (a, b) -> false,
+                        precompiledContractMap);
 
-	@Test
-	void throwsUnderflowExceptionWhenGettingAddress() {
-		// given:
-		given(messageFrame.getStackItem(0)).willThrow(new FixedStack.UnderflowException());
-		given(gasSupplier.getAsLong()).willReturn(expectedHaltGas);
+        assertSame(degenerateResult, result);
+    }
 
-		// when:
-		final var result = HederaOperationUtil.addressCheckExecution(
-				messageFrame,
-				() -> messageFrame.getStackItem(0),
-				gasSupplier,
-				executionSupplier,
-				(a, b) -> true);
+    @Test
+    void throwsUnderflowExceptionWhenGettingAddress() {
+        // given:
+        given(messageFrame.getStackItem(0)).willThrow(new FixedStack.UnderflowException());
+        given(gasSupplier.getAsLong()).willReturn(expectedHaltGas);
 
-		// then:
-		assertEquals(ExceptionalHaltReason.INSUFFICIENT_STACK_ITEMS, result.getHaltReason().get());
-		assertEquals(expectedHaltGas, result.getGasCost().getAsLong());
-		// and:
-		verify(messageFrame).getStackItem(0);
-		verify(messageFrame, never()).getWorldUpdater();
-		verify(gasSupplier).getAsLong();
-		verify(executionSupplier, never()).get();
-	}
+        // when:
+        final var result =
+                HederaOperationUtil.addressCheckExecution(
+                        messageFrame,
+                        () -> messageFrame.getStackItem(0),
+                        gasSupplier,
+                        executionSupplier,
+                        (a, b) -> true);
 
-	@Test
-	void haltsWithInvalidSolidityAddressWhenAccountCheckExecution() {
-		// given:
-		given(messageFrame.getStackItem(0)).willReturn(Address.ZERO);
-		given(gasSupplier.getAsLong()).willReturn(expectedHaltGas);
+        // then:
+        assertEquals(ExceptionalHaltReason.INSUFFICIENT_STACK_ITEMS, result.getHaltReason().get());
+        assertEquals(expectedHaltGas, result.getGasCost().getAsLong());
+        // and:
+        verify(messageFrame).getStackItem(0);
+        verify(messageFrame, never()).getWorldUpdater();
+        verify(gasSupplier).getAsLong();
+        verify(executionSupplier, never()).get();
+    }
 
-		// when:
-		final var result = HederaOperationUtil.addressCheckExecution(
-				messageFrame,
-				() -> messageFrame.getStackItem(0),
-				gasSupplier,
-				executionSupplier,
-				(a, b) -> false);
+    @Test
+    void haltsWithInvalidSolidityAddressWhenAccountCheckExecution() {
+        // given:
+        given(messageFrame.getStackItem(0)).willReturn(Address.ZERO);
+        given(gasSupplier.getAsLong()).willReturn(expectedHaltGas);
 
-		// then:
-		assertEquals(HederaExceptionalHaltReason.INVALID_SOLIDITY_ADDRESS, result.getHaltReason().get());
-		assertEquals(expectedHaltGas, result.getGasCost().getAsLong());
-		// and:
-		verify(messageFrame).getStackItem(0);
-		verify(gasSupplier).getAsLong();
-		verify(executionSupplier, never()).get();
-	}
+        // when:
+        final var result =
+                HederaOperationUtil.addressCheckExecution(
+                        messageFrame,
+                        () -> messageFrame.getStackItem(0),
+                        gasSupplier,
+                        executionSupplier,
+                        (a, b) -> false);
 
-	@Test
-	void successfulWhenAddressCheckExecution() {
-		// given:
-		given(messageFrame.getStackItem(0)).willReturn(Address.ZERO);
-		given(executionSupplier.get())
-				.willReturn(new Operation.OperationResult(OptionalLong.of(expectedSuccessfulGas), Optional.empty()));
+        // then:
+        assertEquals(
+                HederaExceptionalHaltReason.INVALID_SOLIDITY_ADDRESS, result.getHaltReason().get());
+        assertEquals(expectedHaltGas, result.getGasCost().getAsLong());
+        // and:
+        verify(messageFrame).getStackItem(0);
+        verify(gasSupplier).getAsLong();
+        verify(executionSupplier, never()).get();
+    }
 
-		// when:
-		final var result = HederaOperationUtil.addressCheckExecution(
-				messageFrame,
-				() -> messageFrame.getStackItem(0),
-				gasSupplier,
-				executionSupplier,
-				(a, b) -> true);
+    @Test
+    void successfulWhenAddressCheckExecution() {
+        // given:
+        given(messageFrame.getStackItem(0)).willReturn(Address.ZERO);
+        given(executionSupplier.get())
+                .willReturn(
+                        new Operation.OperationResult(
+                                OptionalLong.of(expectedSuccessfulGas), Optional.empty()));
 
-		// when:
-		assertTrue(result.getHaltReason().isEmpty());
-		assertEquals(expectedSuccessfulGas, result.getGasCost().getAsLong());
-		// and:
-		verify(messageFrame).getStackItem(0);
-		verify(gasSupplier, never()).getAsLong();
-		verify(executionSupplier).get();
-	}
+        // when:
+        final var result =
+                HederaOperationUtil.addressCheckExecution(
+                        messageFrame,
+                        () -> messageFrame.getStackItem(0),
+                        gasSupplier,
+                        executionSupplier,
+                        (a, b) -> true);
 
-	@Test
-	void haltsWithInvalidSolidityAddressWhenAccountSignatureCheckExecution() {
-		// given:
-		given(messageFrame.getWorldUpdater()).willReturn(hederaWorldUpdater);
-		given(gasSupplier.getAsLong()).willReturn(expectedHaltGas);
+        // when:
+        assertTrue(result.getHaltReason().isEmpty());
+        assertEquals(expectedSuccessfulGas, result.getGasCost().getAsLong());
+        // and:
+        verify(messageFrame).getStackItem(0);
+        verify(gasSupplier, never()).getAsLong();
+        verify(executionSupplier).get();
+    }
 
-		// when:
-		final var result = HederaOperationUtil.addressSignatureCheckExecution(
-				sigsVerifier,
-				messageFrame,
-				Address.ZERO,
-				gasSupplier,
-				executionSupplier,
-				(a, b) -> false, precompiledContractMap);
+    @Test
+    void haltsWithInvalidSolidityAddressWhenAccountSignatureCheckExecution() {
+        // given:
+        given(messageFrame.getWorldUpdater()).willReturn(hederaWorldUpdater);
+        given(gasSupplier.getAsLong()).willReturn(expectedHaltGas);
 
-		// then:
-		assertEquals(HederaExceptionalHaltReason.INVALID_SOLIDITY_ADDRESS, result.getHaltReason().get());
-		assertEquals(expectedHaltGas, result.getGasCost().getAsLong());
-		// and:
-		verify(messageFrame).getWorldUpdater();
-		verify(hederaWorldUpdater).get(Address.ZERO);
-		verify(gasSupplier).getAsLong();
-		verify(executionSupplier, never()).get();
-	}
+        // when:
+        final var result =
+                HederaOperationUtil.addressSignatureCheckExecution(
+                        sigsVerifier,
+                        messageFrame,
+                        Address.ZERO,
+                        gasSupplier,
+                        executionSupplier,
+                        (a, b) -> false,
+                        precompiledContractMap);
 
-	@Test
-	void haltsWithInvalidSignatureWhenAccountSignatureCheckExecution() {
-		// given:
-		final var mockTarget = Address.ZERO;
-		given(messageFrame.getRecipientAddress()).willReturn(Address.ALTBN128_ADD);
-		given(messageFrame.getContractAddress()).willReturn(Address.ALTBN128_MUL);
-		given(messageFrame.getWorldUpdater()).willReturn(hederaWorldUpdater);
-		given(hederaWorldUpdater.get(Address.ZERO)).willReturn(worldStateAccount);
-		given(worldStateAccount.getAddress()).willReturn(Address.ZERO);
-		given(sigsVerifier
-				.hasActiveKeyOrNoReceiverSigReq(true,
-						mockTarget, Address.ALTBN128_ADD, ledgers))
-				.willReturn(false);
-		given(gasSupplier.getAsLong()).willReturn(expectedHaltGas);
-		given(hederaWorldUpdater.trackingLedgers()).willReturn(ledgers);
+        // then:
+        assertEquals(
+                HederaExceptionalHaltReason.INVALID_SOLIDITY_ADDRESS, result.getHaltReason().get());
+        assertEquals(expectedHaltGas, result.getGasCost().getAsLong());
+        // and:
+        verify(messageFrame).getWorldUpdater();
+        verify(hederaWorldUpdater).get(Address.ZERO);
+        verify(gasSupplier).getAsLong();
+        verify(executionSupplier, never()).get();
+    }
 
-		// when:
-		final var result = HederaOperationUtil.addressSignatureCheckExecution(
-				sigsVerifier,
-				messageFrame,
-				Address.ZERO,
-				gasSupplier,
-				executionSupplier,
-				(a, b) -> true, precompiledContractMap);
+    @Test
+    void haltsWithInvalidSignatureWhenAccountSignatureCheckExecution() {
+        // given:
+        final var mockTarget = Address.ZERO;
+        given(messageFrame.getRecipientAddress()).willReturn(Address.ALTBN128_ADD);
+        given(messageFrame.getContractAddress()).willReturn(Address.ALTBN128_MUL);
+        given(messageFrame.getWorldUpdater()).willReturn(hederaWorldUpdater);
+        given(hederaWorldUpdater.get(Address.ZERO)).willReturn(worldStateAccount);
+        given(worldStateAccount.getAddress()).willReturn(Address.ZERO);
+        given(
+                        sigsVerifier.hasActiveKeyOrNoReceiverSigReq(
+                                true, mockTarget, Address.ALTBN128_ADD, ledgers))
+                .willReturn(false);
+        given(gasSupplier.getAsLong()).willReturn(expectedHaltGas);
+        given(hederaWorldUpdater.trackingLedgers()).willReturn(ledgers);
 
-		// then:
-		assertEquals(HederaExceptionalHaltReason.INVALID_SIGNATURE, result.getHaltReason().get());
-		assertEquals(expectedHaltGas, result.getGasCost().getAsLong());
-		// and:
-		verify(messageFrame).getWorldUpdater();
-		verify(hederaWorldUpdater).get(Address.ZERO);
-		verify(worldStateAccount).getAddress();
-		verify(sigsVerifier).hasActiveKeyOrNoReceiverSigReq(true,
-				mockTarget, PRETEND_RECIPIENT_ADDR, ledgers);
-		verify(gasSupplier).getAsLong();
-		verify(executionSupplier, never()).get();
-	}
+        // when:
+        final var result =
+                HederaOperationUtil.addressSignatureCheckExecution(
+                        sigsVerifier,
+                        messageFrame,
+                        Address.ZERO,
+                        gasSupplier,
+                        executionSupplier,
+                        (a, b) -> true,
+                        precompiledContractMap);
 
-	@Test
-	void haltsWithInvalidSignatureWhenAccountSignatureCheckExecutionForNonDelegateCall() {
-		// given:
-		final var mockTarget = Address.ZERO;
-		given(messageFrame.getRecipientAddress()).willReturn(Address.ALTBN128_MUL);
-		given(messageFrame.getContractAddress()).willReturn(Address.ALTBN128_MUL);
-		given(messageFrame.getWorldUpdater()).willReturn(hederaWorldUpdater);
-		given(hederaWorldUpdater.get(Address.ZERO)).willReturn(worldStateAccount);
-		given(worldStateAccount.getAddress()).willReturn(Address.ZERO);
-		given(sigsVerifier
-				.hasActiveKeyOrNoReceiverSigReq(false,
-						mockTarget, Address.ALTBN128_MUL, ledgers))
-				.willReturn(false);
-		given(gasSupplier.getAsLong()).willReturn(expectedHaltGas);
-		given(hederaWorldUpdater.trackingLedgers()).willReturn(ledgers);
+        // then:
+        assertEquals(HederaExceptionalHaltReason.INVALID_SIGNATURE, result.getHaltReason().get());
+        assertEquals(expectedHaltGas, result.getGasCost().getAsLong());
+        // and:
+        verify(messageFrame).getWorldUpdater();
+        verify(hederaWorldUpdater).get(Address.ZERO);
+        verify(worldStateAccount).getAddress();
+        verify(sigsVerifier)
+                .hasActiveKeyOrNoReceiverSigReq(true, mockTarget, PRETEND_RECIPIENT_ADDR, ledgers);
+        verify(gasSupplier).getAsLong();
+        verify(executionSupplier, never()).get();
+    }
 
-		// when:
-		final var result = HederaOperationUtil.addressSignatureCheckExecution(
-				sigsVerifier,
-				messageFrame,
-				Address.ZERO,
-				gasSupplier,
-				executionSupplier,
-				(a, b) -> true, precompiledContractMap);
+    @Test
+    void haltsWithInvalidSignatureWhenAccountSignatureCheckExecutionForNonDelegateCall() {
+        // given:
+        final var mockTarget = Address.ZERO;
+        given(messageFrame.getRecipientAddress()).willReturn(Address.ALTBN128_MUL);
+        given(messageFrame.getContractAddress()).willReturn(Address.ALTBN128_MUL);
+        given(messageFrame.getWorldUpdater()).willReturn(hederaWorldUpdater);
+        given(hederaWorldUpdater.get(Address.ZERO)).willReturn(worldStateAccount);
+        given(worldStateAccount.getAddress()).willReturn(Address.ZERO);
+        given(
+                        sigsVerifier.hasActiveKeyOrNoReceiverSigReq(
+                                false, mockTarget, Address.ALTBN128_MUL, ledgers))
+                .willReturn(false);
+        given(gasSupplier.getAsLong()).willReturn(expectedHaltGas);
+        given(hederaWorldUpdater.trackingLedgers()).willReturn(ledgers);
 
-		// then:
-		assertEquals(HederaExceptionalHaltReason.INVALID_SIGNATURE, result.getHaltReason().get());
-		assertEquals(expectedHaltGas, result.getGasCost().getAsLong());
-		// and:
-		verify(messageFrame).getWorldUpdater();
-		verify(hederaWorldUpdater).get(Address.ZERO);
-		verify(worldStateAccount).getAddress();
-		verify(sigsVerifier).hasActiveKeyOrNoReceiverSigReq(false,
-				mockTarget, PRETEND_CONTRACT_ADDR, ledgers);
-		verify(gasSupplier).getAsLong();
-		verify(executionSupplier, never()).get();
-	}
+        // when:
+        final var result =
+                HederaOperationUtil.addressSignatureCheckExecution(
+                        sigsVerifier,
+                        messageFrame,
+                        Address.ZERO,
+                        gasSupplier,
+                        executionSupplier,
+                        (a, b) -> true,
+                        precompiledContractMap);
 
-	@Test
-	void successfulWhenAddressSignatureCheckExecution() {
-		// given:
-		final var mockTarget = Address.ZERO;
-		givenFrameAddresses();
-		given(messageFrame.getWorldUpdater()).willReturn(hederaWorldUpdater);
-		given(hederaWorldUpdater.trackingLedgers()).willReturn(ledgers);
-		given(hederaWorldUpdater.get(Address.ZERO)).willReturn(worldStateAccount);
-		given(worldStateAccount.getAddress()).willReturn(Address.ZERO);
-		given(sigsVerifier
-				.hasActiveKeyOrNoReceiverSigReq(true,
-						mockTarget, PRETEND_RECIPIENT_ADDR, ledgers))
-				.willReturn(true);
-		given(executionSupplier.get())
-				.willReturn(new Operation.OperationResult(OptionalLong.of(expectedSuccessfulGas), Optional.empty()));
+        // then:
+        assertEquals(HederaExceptionalHaltReason.INVALID_SIGNATURE, result.getHaltReason().get());
+        assertEquals(expectedHaltGas, result.getGasCost().getAsLong());
+        // and:
+        verify(messageFrame).getWorldUpdater();
+        verify(hederaWorldUpdater).get(Address.ZERO);
+        verify(worldStateAccount).getAddress();
+        verify(sigsVerifier)
+                .hasActiveKeyOrNoReceiverSigReq(false, mockTarget, PRETEND_CONTRACT_ADDR, ledgers);
+        verify(gasSupplier).getAsLong();
+        verify(executionSupplier, never()).get();
+    }
 
-		// when:
-		final var result = HederaOperationUtil.addressSignatureCheckExecution(
-				sigsVerifier,
-				messageFrame,
-				Address.ZERO,
-				gasSupplier,
-				executionSupplier,
-				(a, b) -> true, precompiledContractMap);
+    @Test
+    void successfulWhenAddressSignatureCheckExecution() {
+        // given:
+        final var mockTarget = Address.ZERO;
+        givenFrameAddresses();
+        given(messageFrame.getWorldUpdater()).willReturn(hederaWorldUpdater);
+        given(hederaWorldUpdater.trackingLedgers()).willReturn(ledgers);
+        given(hederaWorldUpdater.get(Address.ZERO)).willReturn(worldStateAccount);
+        given(worldStateAccount.getAddress()).willReturn(Address.ZERO);
+        given(
+                        sigsVerifier.hasActiveKeyOrNoReceiverSigReq(
+                                true, mockTarget, PRETEND_RECIPIENT_ADDR, ledgers))
+                .willReturn(true);
+        given(executionSupplier.get())
+                .willReturn(
+                        new Operation.OperationResult(
+                                OptionalLong.of(expectedSuccessfulGas), Optional.empty()));
 
-		// then:
-		assertTrue(result.getHaltReason().isEmpty());
-		assertEquals(expectedSuccessfulGas, result.getGasCost().getAsLong());
-		// and:
-		verify(messageFrame).getWorldUpdater();
-		verify(hederaWorldUpdater).get(Address.ZERO);
-		verify(worldStateAccount).getAddress();
-		verify(sigsVerifier).hasActiveKeyOrNoReceiverSigReq(true,
-				mockTarget, PRETEND_RECIPIENT_ADDR, ledgers);
-		verify(gasSupplier, never()).getAsLong();
-		verify(executionSupplier).get();
-	}
+        // when:
+        final var result =
+                HederaOperationUtil.addressSignatureCheckExecution(
+                        sigsVerifier,
+                        messageFrame,
+                        Address.ZERO,
+                        gasSupplier,
+                        executionSupplier,
+                        (a, b) -> true,
+                        precompiledContractMap);
 
-	@Test
-	void setOriginalReadValue() {
-		given(messageFrame.getRecipientAddress()).willReturn(PRETEND_RECIPIENT_ADDR);
-		given(messageFrame.popStackItem()).willReturn(Bytes.of(1));
-		given(messageFrame.getWorldUpdater()).willReturn(hederaWorldUpdater);
-		given(hederaWorldUpdater.parentUpdater()).willReturn(Optional.of(updater));
-		var frameStack = new ArrayDeque<MessageFrame>();
-		frameStack.add(messageFrame);
+        // then:
+        assertTrue(result.getHaltReason().isEmpty());
+        assertEquals(expectedSuccessfulGas, result.getGasCost().getAsLong());
+        // and:
+        verify(messageFrame).getWorldUpdater();
+        verify(hederaWorldUpdater).get(Address.ZERO);
+        verify(worldStateAccount).getAddress();
+        verify(sigsVerifier)
+                .hasActiveKeyOrNoReceiverSigReq(true, mockTarget, PRETEND_RECIPIENT_ADDR, ledgers);
+        verify(gasSupplier, never()).getAsLong();
+        verify(executionSupplier).get();
+    }
 
-		given(messageFrame.getMessageFrameStack()).willReturn(frameStack);
-		TreeMap<Address, Map<Bytes, Pair<Bytes, Bytes>>> map = new TreeMap<>();
-		given(updater.getStateChanges()).willReturn(map);
-		given(hederaWorldUpdater.get(PRETEND_RECIPIENT_ADDR)).willReturn(worldStateAccount);
+    @Test
+    void setOriginalReadValue() {
+        given(messageFrame.getRecipientAddress()).willReturn(PRETEND_RECIPIENT_ADDR);
+        given(messageFrame.popStackItem()).willReturn(Bytes.of(1));
+        given(messageFrame.getWorldUpdater()).willReturn(hederaWorldUpdater);
+        given(hederaWorldUpdater.parentUpdater()).willReturn(Optional.of(updater));
+        var frameStack = new ArrayDeque<MessageFrame>();
+        frameStack.add(messageFrame);
 
-		Bytes32 key = UInt256.fromBytes(messageFrame.popStackItem());
-		Account account = messageFrame.getWorldUpdater().get(messageFrame.getRecipientAddress());
-		HederaOperationUtil.cacheExistingValue(
-				messageFrame,
-				PRETEND_RECIPIENT_ADDR,
-				key,
-				account.getStorageValue(UInt256.fromBytes(key)));
+        given(messageFrame.getMessageFrameStack()).willReturn(frameStack);
+        TreeMap<Address, Map<Bytes, Pair<Bytes, Bytes>>> map = new TreeMap<>();
+        given(updater.getStateChanges()).willReturn(map);
+        given(hederaWorldUpdater.get(PRETEND_RECIPIENT_ADDR)).willReturn(worldStateAccount);
 
-		assertTrue(updater.getStateChanges().containsKey(PRETEND_RECIPIENT_ADDR));
-		assertTrue(updater.getStateChanges().get(PRETEND_RECIPIENT_ADDR).containsKey(UInt256.ONE));
-	}
+        Bytes32 key = UInt256.fromBytes(messageFrame.popStackItem());
+        Account account = messageFrame.getWorldUpdater().get(messageFrame.getRecipientAddress());
+        HederaOperationUtil.cacheExistingValue(
+                messageFrame,
+                PRETEND_RECIPIENT_ADDR,
+                key,
+                account.getStorageValue(UInt256.fromBytes(key)));
 
+        assertTrue(updater.getStateChanges().containsKey(PRETEND_RECIPIENT_ADDR));
+        assertTrue(updater.getStateChanges().get(PRETEND_RECIPIENT_ADDR).containsKey(UInt256.ONE));
+    }
 
-	private void givenFrameAddresses() {
-		given(messageFrame.getRecipientAddress()).willReturn(PRETEND_RECIPIENT_ADDR);
-		given(messageFrame.getContractAddress()).willReturn(PRETEND_CONTRACT_ADDR);
-	}
+    private void givenFrameAddresses() {
+        given(messageFrame.getRecipientAddress()).willReturn(PRETEND_RECIPIENT_ADDR);
+        given(messageFrame.getContractAddress()).willReturn(PRETEND_CONTRACT_ADDR);
+    }
 }

--- a/hedera-node/src/test/java/com/hedera/services/contracts/operation/HederaOperationUtilTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/contracts/operation/HederaOperationUtilTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2021-2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hedera.services.contracts.operation;
 
 /*

--- a/hedera-node/src/test/java/com/hedera/services/contracts/operation/HederaSLoadOperationTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/contracts/operation/HederaSLoadOperationTest.java
@@ -20,8 +20,19 @@ package com.hedera.services.contracts.operation;
  * ‍
  */
 
+import static org.hyperledger.besu.evm.frame.ExceptionalHaltReason.INSUFFICIENT_STACK_ITEMS;
+import static org.hyperledger.besu.evm.frame.ExceptionalHaltReason.TOO_MANY_STACK_ITEMS;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.BDDMockito.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doThrow;
+
 import com.hedera.services.context.properties.GlobalDynamicProperties;
 import com.hedera.services.store.contracts.HederaStackedWorldStateUpdater;
+import java.util.ArrayDeque;
+import java.util.Optional;
+import java.util.OptionalLong;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.units.bigints.UInt256;
 import org.hyperledger.besu.datatypes.Address;
@@ -38,152 +49,137 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.util.ArrayDeque;
-import java.util.Optional;
-import java.util.OptionalLong;
-
-import static org.hyperledger.besu.evm.frame.ExceptionalHaltReason.INSUFFICIENT_STACK_ITEMS;
-import static org.hyperledger.besu.evm.frame.ExceptionalHaltReason.TOO_MANY_STACK_ITEMS;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.BDDMockito.any;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.doThrow;
-
 @ExtendWith(MockitoExtension.class)
 class HederaSLoadOperationTest {
-	final Address recipientAccount = Address.fromHexString("0x0001");
+    final Address recipientAccount = Address.fromHexString("0x0001");
 
-	HederaSLoadOperation subject;
+    HederaSLoadOperation subject;
 
-	@Mock
-	GasCalculator gasCalculator;
+    @Mock GasCalculator gasCalculator;
 
-	@Mock
-	MessageFrame messageFrame;
+    @Mock MessageFrame messageFrame;
 
-	@Mock
-	EVM evm;
+    @Mock EVM evm;
 
-	@Mock
-	HederaStackedWorldStateUpdater worldUpdater;
+    @Mock HederaStackedWorldStateUpdater worldUpdater;
 
-	@Mock
-	EvmAccount evmAccount;
+    @Mock EvmAccount evmAccount;
 
-	final Bytes keyBytesMock = Bytes.of(1,2,3,4);
-	final Bytes valueBytesMock = Bytes.of(4,3,2,1);
+    final Bytes keyBytesMock = Bytes.of(1, 2, 3, 4);
+    final Bytes valueBytesMock = Bytes.of(4, 3, 2, 1);
 
-	@Mock
-	private GlobalDynamicProperties dynamicProperties;
+    @Mock private GlobalDynamicProperties dynamicProperties;
 
-	@BeforeEach
-	void setUp() {
-		givenValidContext();
-		subject = new HederaSLoadOperation(gasCalculator, dynamicProperties);
-	}
+    @BeforeEach
+    void setUp() {
+        givenValidContext();
+        subject = new HederaSLoadOperation(gasCalculator, dynamicProperties);
+    }
 
-	@Test
-	void executesProperlyWithColdSuccess() {
-		givenAdditionalContext(keyBytesMock, valueBytesMock);
-		given(messageFrame.warmUpStorage(any(), any())).willReturn(true);
-		given(messageFrame.getRemainingGas()).willReturn(300L);
-		given(messageFrame.warmUpStorage(any(), any())).willReturn(false);
-		given(dynamicProperties.shouldEnableTraceability()).willReturn(true);
+    @Test
+    void executesProperlyWithColdSuccess() {
+        givenAdditionalContext(keyBytesMock, valueBytesMock);
+        given(messageFrame.warmUpStorage(any(), any())).willReturn(true);
+        given(messageFrame.getRemainingGas()).willReturn(300L);
+        given(messageFrame.warmUpStorage(any(), any())).willReturn(false);
+        given(dynamicProperties.shouldEnableTraceability()).willReturn(true);
 
-		var frameStack = new ArrayDeque<MessageFrame>();
-		frameStack.add(messageFrame);
+        var frameStack = new ArrayDeque<MessageFrame>();
+        frameStack.add(messageFrame);
 
-		given(messageFrame.getMessageFrameStack()).willReturn(frameStack);
-		final var coldResult = subject.execute(messageFrame, evm);
+        given(messageFrame.getMessageFrameStack()).willReturn(frameStack);
+        final var coldResult = subject.execute(messageFrame, evm);
 
-		final var expectedColdResult = new Operation.OperationResult(OptionalLong.of(20L), Optional.empty());
+        final var expectedColdResult =
+                new Operation.OperationResult(OptionalLong.of(20L), Optional.empty());
 
-		assertEquals(expectedColdResult.getGasCost(), coldResult.getGasCost());
-		assertEquals(expectedColdResult.getHaltReason(), coldResult.getHaltReason());
-		assertEquals(expectedColdResult.getPcIncrement(), coldResult.getPcIncrement());
+        assertEquals(expectedColdResult.getGasCost(), coldResult.getGasCost());
+        assertEquals(expectedColdResult.getHaltReason(), coldResult.getHaltReason());
+        assertEquals(expectedColdResult.getPcIncrement(), coldResult.getPcIncrement());
 
-		// TODO: add verify statements
-	}
+        // TODO: add verify statements
+    }
 
-	@Test
-	void executesProperlyWithWarmSuccess() {
-		givenAdditionalContext(keyBytesMock, valueBytesMock);
-		given(messageFrame.warmUpStorage(any(), any())).willReturn(true);
-		given(messageFrame.getRemainingGas()).willReturn(300L);
-		given(dynamicProperties.shouldEnableTraceability()).willReturn(true);
-		var frameStack = new ArrayDeque<MessageFrame>();
-		frameStack.add(messageFrame);
+    @Test
+    void executesProperlyWithWarmSuccess() {
+        givenAdditionalContext(keyBytesMock, valueBytesMock);
+        given(messageFrame.warmUpStorage(any(), any())).willReturn(true);
+        given(messageFrame.getRemainingGas()).willReturn(300L);
+        given(dynamicProperties.shouldEnableTraceability()).willReturn(true);
+        var frameStack = new ArrayDeque<MessageFrame>();
+        frameStack.add(messageFrame);
 
-		given(messageFrame.getMessageFrameStack()).willReturn(frameStack);
-		final var warmResult = subject.execute(messageFrame, evm);
+        given(messageFrame.getMessageFrameStack()).willReturn(frameStack);
+        final var warmResult = subject.execute(messageFrame, evm);
 
-		final var expectedWarmResult = new Operation.OperationResult(OptionalLong.of(30L), Optional.empty());
+        final var expectedWarmResult =
+                new Operation.OperationResult(OptionalLong.of(30L), Optional.empty());
 
-		assertEquals(expectedWarmResult.getGasCost(), warmResult.getGasCost());
-		assertEquals(expectedWarmResult.getHaltReason(), warmResult.getHaltReason());
-		assertEquals(expectedWarmResult.getPcIncrement(), warmResult.getPcIncrement());
+        assertEquals(expectedWarmResult.getGasCost(), warmResult.getGasCost());
+        assertEquals(expectedWarmResult.getHaltReason(), warmResult.getHaltReason());
+        assertEquals(expectedWarmResult.getPcIncrement(), warmResult.getPcIncrement());
 
-		// TODO: add verify statements
-	}
+        // TODO: add verify statements
+    }
 
-	@Test
-	void executeHaltsForInsufficientGas() {
-		givenAdditionalContext(keyBytesMock, valueBytesMock);
-		given(messageFrame.warmUpStorage(any(), any())).willReturn(true);
-		given(messageFrame.getRemainingGas()).willReturn(300L);
-		given(messageFrame.getRemainingGas()).willReturn(0L);
+    @Test
+    void executeHaltsForInsufficientGas() {
+        givenAdditionalContext(keyBytesMock, valueBytesMock);
+        given(messageFrame.warmUpStorage(any(), any())).willReturn(true);
+        given(messageFrame.getRemainingGas()).willReturn(300L);
+        given(messageFrame.getRemainingGas()).willReturn(0L);
 
-		final var expectedHaltResult = new Operation.OperationResult(OptionalLong.of(30L),
-				Optional.of(ExceptionalHaltReason.INSUFFICIENT_GAS));
+        final var expectedHaltResult =
+                new Operation.OperationResult(
+                        OptionalLong.of(30L), Optional.of(ExceptionalHaltReason.INSUFFICIENT_GAS));
 
-		final var haltResult = subject.execute(messageFrame, evm);
+        final var haltResult = subject.execute(messageFrame, evm);
 
-		assertEquals(expectedHaltResult.getGasCost(), haltResult.getGasCost());
-		assertEquals(expectedHaltResult.getHaltReason(), haltResult.getHaltReason());
-		assertEquals(expectedHaltResult.getPcIncrement(), haltResult.getPcIncrement());
-	}
+        assertEquals(expectedHaltResult.getGasCost(), haltResult.getGasCost());
+        assertEquals(expectedHaltResult.getHaltReason(), haltResult.getHaltReason());
+        assertEquals(expectedHaltResult.getPcIncrement(), haltResult.getPcIncrement());
+    }
 
-	@Test
-	void executeWithUnderFlowException() {
-		givenAdditionalContext(keyBytesMock, valueBytesMock);
-		given(messageFrame.popStackItem()).willThrow(new FixedStack.UnderflowException());
-		final var result = subject.execute(messageFrame, evm);
-		assertEquals(INSUFFICIENT_STACK_ITEMS, result.getHaltReason().get());
-	}
+    @Test
+    void executeWithUnderFlowException() {
+        givenAdditionalContext(keyBytesMock, valueBytesMock);
+        given(messageFrame.popStackItem()).willThrow(new FixedStack.UnderflowException());
+        final var result = subject.execute(messageFrame, evm);
+        assertEquals(INSUFFICIENT_STACK_ITEMS, result.getHaltReason().get());
+    }
 
-	@Test
-	void executeWithOverFlowException() {
-		givenAdditionalContext(keyBytesMock, valueBytesMock);
-		given(messageFrame.warmUpStorage(any(), any())).willReturn(true);
-		given(messageFrame.getRemainingGas()).willReturn(300L);
-		given(dynamicProperties.shouldEnableTraceability()).willReturn(true);
-		var frameStack = new ArrayDeque<MessageFrame>();
-		frameStack.add(messageFrame);
+    @Test
+    void executeWithOverFlowException() {
+        givenAdditionalContext(keyBytesMock, valueBytesMock);
+        given(messageFrame.warmUpStorage(any(), any())).willReturn(true);
+        given(messageFrame.getRemainingGas()).willReturn(300L);
+        given(dynamicProperties.shouldEnableTraceability()).willReturn(true);
+        var frameStack = new ArrayDeque<MessageFrame>();
+        frameStack.add(messageFrame);
 
-		given(messageFrame.getMessageFrameStack()).willReturn(frameStack);
-		doThrow(new FixedStack.OverflowException()).when(messageFrame).pushStackItem(any());
+        given(messageFrame.getMessageFrameStack()).willReturn(frameStack);
+        doThrow(new FixedStack.OverflowException()).when(messageFrame).pushStackItem(any());
 
-		final var result = subject.execute(messageFrame, evm);
-		assertTrue(result.getHaltReason().isPresent());
-		assertEquals(TOO_MANY_STACK_ITEMS, result.getHaltReason().get());
-	}
+        final var result = subject.execute(messageFrame, evm);
+        assertTrue(result.getHaltReason().isPresent());
+        assertEquals(TOO_MANY_STACK_ITEMS, result.getHaltReason().get());
+    }
 
-	private void givenAdditionalContext(Bytes key, Bytes value) {
-		final UInt256 keyBytes = UInt256.fromBytes(key);
-		final UInt256 valueBytes = UInt256.fromBytes(value);
+    private void givenAdditionalContext(Bytes key, Bytes value) {
+        final UInt256 keyBytes = UInt256.fromBytes(key);
+        final UInt256 valueBytes = UInt256.fromBytes(value);
 
-		given(messageFrame.popStackItem()).willReturn(keyBytes).willReturn(valueBytes);
-		given(worldUpdater.get(recipientAccount)).willReturn(evmAccount);
-		given(evmAccount.getAddress()).willReturn(Address.fromHexString("0x123"));
-	}
+        given(messageFrame.popStackItem()).willReturn(keyBytes).willReturn(valueBytes);
+        given(worldUpdater.get(recipientAccount)).willReturn(evmAccount);
+        given(evmAccount.getAddress()).willReturn(Address.fromHexString("0x123"));
+    }
 
-	private void givenValidContext() {
-		given(messageFrame.getWorldUpdater()).willReturn(worldUpdater);
-		given(messageFrame.getRecipientAddress()).willReturn(recipientAccount);
+    private void givenValidContext() {
+        given(messageFrame.getWorldUpdater()).willReturn(worldUpdater);
+        given(messageFrame.getRecipientAddress()).willReturn(recipientAccount);
 
-		given(gasCalculator.getSloadOperationGasCost()).willReturn(10L);
-		given(gasCalculator.getWarmStorageReadCost()).willReturn(20L);
-		given(gasCalculator.getColdSloadCost()).willReturn(10L);
-	}
+        given(gasCalculator.getSloadOperationGasCost()).willReturn(10L);
+        given(gasCalculator.getWarmStorageReadCost()).willReturn(20L);
+        given(gasCalculator.getColdSloadCost()).willReturn(10L);
+    }
 }

--- a/hedera-node/src/test/java/com/hedera/services/contracts/operation/HederaSLoadOperationTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/contracts/operation/HederaSLoadOperationTest.java
@@ -1,11 +1,6 @@
-package com.hedera.services.contracts.operation;
-
-/*-
- * ‌
- * Hedera Services Node
- * ​
- * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
- * ​
+/*
+ * Copyright (C) 2022 Hedera Hashgraph, LLC
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -17,8 +12,8 @@ package com.hedera.services.contracts.operation;
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- * ‍
  */
+package com.hedera.services.contracts.operation;
 
 import static org.hyperledger.besu.evm.frame.ExceptionalHaltReason.INSUFFICIENT_STACK_ITEMS;
 import static org.hyperledger.besu.evm.frame.ExceptionalHaltReason.TOO_MANY_STACK_ITEMS;

--- a/hedera-node/src/test/java/com/hedera/services/contracts/operation/HederaSStoreOperationTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/contracts/operation/HederaSStoreOperationTest.java
@@ -9,9 +9,9 @@ package com.hedera.services.contracts.operation;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,9 +20,18 @@ package com.hedera.services.contracts.operation;
  * ‍
  */
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.BDDMockito.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.never;
+import static org.mockito.BDDMockito.verify;
+
 import com.hedera.services.context.properties.GlobalDynamicProperties;
 import com.hedera.services.contracts.gascalculator.StorageGasCalculator;
 import com.hedera.services.store.contracts.HederaWorldUpdater;
+import java.util.ArrayDeque;
+import java.util.Optional;
+import java.util.OptionalLong;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.units.bigints.UInt256;
 import org.hyperledger.besu.datatypes.Address;
@@ -40,173 +49,162 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.util.ArrayDeque;
-import java.util.Optional;
-import java.util.OptionalLong;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.BDDMockito.any;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.BDDMockito.never;
-import static org.mockito.BDDMockito.verify;
-
 @ExtendWith(MockitoExtension.class)
 class HederaSStoreOperationTest {
-	@Mock
-	private GasCalculator gasCalculator;
-	@Mock
-	private MessageFrame messageFrame;
-	@Mock
-	private EVM evm;
-	@Mock
-	private HederaWorldUpdater worldUpdater;
-	@Mock
-	private MutableAccount mutableAccount;
-	@Mock
-	private EvmAccount evmAccount;
-	final private Bytes keyBytesMock = Bytes.of(1,2,3,4);
-	final private Bytes valueBytesMock = Bytes.of(4,3,2,1);
-	@Mock
-	private BlockValues hederaBlockValues;
-	@Mock
-	private StorageGasCalculator storageGasCalculator;
-	@Mock
-	private GlobalDynamicProperties dynamicProperties;
+    @Mock private GasCalculator gasCalculator;
+    @Mock private MessageFrame messageFrame;
+    @Mock private EVM evm;
+    @Mock private HederaWorldUpdater worldUpdater;
+    @Mock private MutableAccount mutableAccount;
+    @Mock private EvmAccount evmAccount;
+    private final Bytes keyBytesMock = Bytes.of(1, 2, 3, 4);
+    private final Bytes valueBytesMock = Bytes.of(4, 3, 2, 1);
+    @Mock private BlockValues hederaBlockValues;
+    @Mock private StorageGasCalculator storageGasCalculator;
+    @Mock private GlobalDynamicProperties dynamicProperties;
 
-	private HederaSStoreOperation subject;
+    private HederaSStoreOperation subject;
 
-	@BeforeEach
-	void setUp() {
-		subject = new HederaSStoreOperation(gasCalculator, storageGasCalculator, dynamicProperties);
-	}
+    @BeforeEach
+    void setUp() {
+        subject = new HederaSStoreOperation(gasCalculator, storageGasCalculator, dynamicProperties);
+    }
 
-	@Test
-	void executesCorrectly() {
-		givenValidContext(keyBytesMock, valueBytesMock);
-		given(dynamicProperties.shouldEnableTraceability()).willReturn(true);
+    @Test
+    void executesCorrectly() {
+        givenValidContext(keyBytesMock, valueBytesMock);
+        given(dynamicProperties.shouldEnableTraceability()).willReturn(true);
 
-		var frameStack = new ArrayDeque<MessageFrame>();
-		frameStack.add(messageFrame);
+        var frameStack = new ArrayDeque<MessageFrame>();
+        frameStack.add(messageFrame);
 
-		given(messageFrame.getMessageFrameStack()).willReturn(frameStack);
+        given(messageFrame.getMessageFrameStack()).willReturn(frameStack);
 
-		final var result = subject.execute(messageFrame, evm);
+        final var result = subject.execute(messageFrame, evm);
 
-		final var expected = new Operation.OperationResult(OptionalLong.of(10), Optional.empty());
+        final var expected = new Operation.OperationResult(OptionalLong.of(10), Optional.empty());
 
-		assertEquals(expected.getGasCost(), result.getGasCost());
-		assertEquals(expected.getHaltReason(), result.getHaltReason());
+        assertEquals(expected.getGasCost(), result.getGasCost());
+        assertEquals(expected.getHaltReason(), result.getHaltReason());
 
-		verify(mutableAccount).setStorageValue(any(), any());
-		verify(messageFrame).storageWasUpdated(any(), any());
-	}
+        verify(mutableAccount).setStorageValue(any(), any());
+        verify(messageFrame).storageWasUpdated(any(), any());
+    }
 
-	@Test
-	void haltsWithIllegalStateChange() {
-		givenValidContext(keyBytesMock, valueBytesMock);
+    @Test
+    void haltsWithIllegalStateChange() {
+        givenValidContext(keyBytesMock, valueBytesMock);
 
-		given(messageFrame.isStatic()).willReturn(true);
+        given(messageFrame.isStatic()).willReturn(true);
 
-		final var result = subject.execute(messageFrame, evm);
+        final var result = subject.execute(messageFrame, evm);
 
-		final var expected = new Operation.OperationResult(OptionalLong.of(10), Optional.of(ExceptionalHaltReason.ILLEGAL_STATE_CHANGE));
+        final var expected =
+                new Operation.OperationResult(
+                        OptionalLong.of(10),
+                        Optional.of(ExceptionalHaltReason.ILLEGAL_STATE_CHANGE));
 
-		assertEquals(expected.getGasCost(), result.getGasCost());
-		assertEquals(expected.getHaltReason(), result.getHaltReason());
+        assertEquals(expected.getGasCost(), result.getGasCost());
+        assertEquals(expected.getHaltReason(), result.getHaltReason());
 
-		verify(mutableAccount, never()).setStorageValue(any(), any());
-		verify(messageFrame, never()).storageWasUpdated(any(), any());
-	}
+        verify(mutableAccount, never()).setStorageValue(any(), any());
+        verify(messageFrame, never()).storageWasUpdated(any(), any());
+    }
 
-	@Test
-	void haltsWithInsufficientGas() {
-		final UInt256 keyBytes = UInt256.fromBytes(keyBytesMock);
-		final UInt256 valueBytes = UInt256.fromBytes(valueBytesMock);
-		final var recipientAccount = Address.fromHexString("0x0001");
+    @Test
+    void haltsWithInsufficientGas() {
+        final UInt256 keyBytes = UInt256.fromBytes(keyBytesMock);
+        final UInt256 valueBytes = UInt256.fromBytes(valueBytesMock);
+        final var recipientAccount = Address.fromHexString("0x0001");
 
-		given(messageFrame.popStackItem()).willReturn(keyBytes).willReturn(valueBytes);
-		given(messageFrame.getWorldUpdater()).willReturn(worldUpdater);
-		given(messageFrame.getRecipientAddress()).willReturn(recipientAccount);
-		given(worldUpdater.getAccount(recipientAccount)).willReturn(evmAccount);
-		given(evmAccount.getMutable()).willReturn(mutableAccount);
-		given(mutableAccount.getStorageValue(any())).willReturn(keyBytes);
-		given(gasCalculator.calculateStorageCost(any(), any(), any())).willReturn(10L);
-		given(messageFrame.warmUpStorage(any(), any())).willReturn(true);
-		given(messageFrame.isStatic()).willReturn(false);
-		given(messageFrame.getRemainingGas()).willReturn(0L);
+        given(messageFrame.popStackItem()).willReturn(keyBytes).willReturn(valueBytes);
+        given(messageFrame.getWorldUpdater()).willReturn(worldUpdater);
+        given(messageFrame.getRecipientAddress()).willReturn(recipientAccount);
+        given(worldUpdater.getAccount(recipientAccount)).willReturn(evmAccount);
+        given(evmAccount.getMutable()).willReturn(mutableAccount);
+        given(mutableAccount.getStorageValue(any())).willReturn(keyBytes);
+        given(gasCalculator.calculateStorageCost(any(), any(), any())).willReturn(10L);
+        given(messageFrame.warmUpStorage(any(), any())).willReturn(true);
+        given(messageFrame.isStatic()).willReturn(false);
+        given(messageFrame.getRemainingGas()).willReturn(0L);
 
-		final var result = subject.execute(messageFrame, evm);
+        final var result = subject.execute(messageFrame, evm);
 
-		final var expected = new Operation.OperationResult(OptionalLong.of(10), Optional.of(ExceptionalHaltReason.INSUFFICIENT_GAS));
+        final var expected =
+                new Operation.OperationResult(
+                        OptionalLong.of(10), Optional.of(ExceptionalHaltReason.INSUFFICIENT_GAS));
 
-		assertEquals(expected.getGasCost(), result.getGasCost());
-		assertEquals(expected.getHaltReason(), result.getHaltReason());
+        assertEquals(expected.getGasCost(), result.getGasCost());
+        assertEquals(expected.getHaltReason(), result.getHaltReason());
 
-		verify(mutableAccount, never()).setStorageValue(any(), any());
-		verify(messageFrame, never()).storageWasUpdated(any(), any());
-	}
+        verify(mutableAccount, never()).setStorageValue(any(), any());
+        verify(messageFrame, never()).storageWasUpdated(any(), any());
+    }
 
-	@Test
-	void haltsWhenMutableAccountIsUnavailable() {
-		final UInt256 keyBytes = UInt256.fromBytes(keyBytesMock);
-		final UInt256 valueBytes = UInt256.fromBytes(valueBytesMock);
-		final var recipientAccount = Address.fromHexString("0x0001");
+    @Test
+    void haltsWhenMutableAccountIsUnavailable() {
+        final UInt256 keyBytes = UInt256.fromBytes(keyBytesMock);
+        final UInt256 valueBytes = UInt256.fromBytes(valueBytesMock);
+        final var recipientAccount = Address.fromHexString("0x0001");
 
-		given(messageFrame.popStackItem()).willReturn(keyBytes).willReturn(valueBytes);
-		given(messageFrame.getWorldUpdater()).willReturn(worldUpdater);
-		given(messageFrame.getRecipientAddress()).willReturn(recipientAccount);
-		given(worldUpdater.getAccount(recipientAccount)).willReturn(evmAccount);
+        given(messageFrame.popStackItem()).willReturn(keyBytes).willReturn(valueBytes);
+        given(messageFrame.getWorldUpdater()).willReturn(worldUpdater);
+        given(messageFrame.getRecipientAddress()).willReturn(recipientAccount);
+        given(worldUpdater.getAccount(recipientAccount)).willReturn(evmAccount);
 
-		final var result = subject.execute(messageFrame, evm);
+        final var result = subject.execute(messageFrame, evm);
 
-		final var expected = new Operation.OperationResult(
-				OptionalLong.empty(), Optional.of(ExceptionalHaltReason.ILLEGAL_STATE_CHANGE));
+        final var expected =
+                new Operation.OperationResult(
+                        OptionalLong.empty(),
+                        Optional.of(ExceptionalHaltReason.ILLEGAL_STATE_CHANGE));
 
-		assertEquals(expected.getGasCost(), result.getGasCost());
-		assertEquals(expected.getHaltReason(), result.getHaltReason());
+        assertEquals(expected.getGasCost(), result.getGasCost());
+        assertEquals(expected.getHaltReason(), result.getHaltReason());
 
-		verify(mutableAccount, never()).setStorageValue(any(), any());
-		verify(messageFrame, never()).storageWasUpdated(any(), any());
-	}
+        verify(mutableAccount, never()).setStorageValue(any(), any());
+        verify(messageFrame, never()).storageWasUpdated(any(), any());
+    }
 
-	@Test
-	void executesWithZero() {
-		final UInt256 key = UInt256.fromBytes(keyBytesMock);
-		final UInt256 value = UInt256.fromBytes(Bytes.fromHexString("0x12345678"));
+    @Test
+    void executesWithZero() {
+        final UInt256 key = UInt256.fromBytes(keyBytesMock);
+        final UInt256 value = UInt256.fromBytes(Bytes.fromHexString("0x12345678"));
 
-		givenValidContext(key, value);
-		given(mutableAccount.getStorageValue(any())).willReturn(UInt256.ZERO);
+        givenValidContext(key, value);
+        given(mutableAccount.getStorageValue(any())).willReturn(UInt256.ZERO);
 
-		final var frameGasCost = 10L;
-		given(storageGasCalculator.gasCostOfStorageIn(messageFrame)).willReturn(frameGasCost);
+        final var frameGasCost = 10L;
+        given(storageGasCalculator.gasCostOfStorageIn(messageFrame)).willReturn(frameGasCost);
 
-		final var result = subject.execute(messageFrame, evm);
+        final var result = subject.execute(messageFrame, evm);
 
-		final var expected = new Operation.OperationResult(OptionalLong.of(frameGasCost), Optional.empty());
+        final var expected =
+                new Operation.OperationResult(OptionalLong.of(frameGasCost), Optional.empty());
 
-		assertEquals(expected.getGasCost(), result.getGasCost());
-		assertEquals(expected.getHaltReason(), result.getHaltReason());
+        assertEquals(expected.getGasCost(), result.getGasCost());
+        assertEquals(expected.getHaltReason(), result.getHaltReason());
 
-		verify(mutableAccount).setStorageValue(key, value);
-		verify(messageFrame).storageWasUpdated(key, value);
-		verify(worldUpdater).addSbhRefund(frameGasCost);
-	}
+        verify(mutableAccount).setStorageValue(key, value);
+        verify(messageFrame).storageWasUpdated(key, value);
+        verify(worldUpdater).addSbhRefund(frameGasCost);
+    }
 
-	private void givenValidContext(Bytes key, Bytes value) {
-		final UInt256 keyBytes = UInt256.fromBytes(key);
-		final UInt256 valueBytes = UInt256.fromBytes(value);
-		final var recipientAccount = Address.fromHexString("0x0001");
+    private void givenValidContext(Bytes key, Bytes value) {
+        final UInt256 keyBytes = UInt256.fromBytes(key);
+        final UInt256 valueBytes = UInt256.fromBytes(value);
+        final var recipientAccount = Address.fromHexString("0x0001");
 
-		given(messageFrame.popStackItem()).willReturn(keyBytes).willReturn(valueBytes);
-		given(messageFrame.getWorldUpdater()).willReturn(worldUpdater);
-		given(messageFrame.getRecipientAddress()).willReturn(recipientAccount);
-		given(worldUpdater.getAccount(recipientAccount)).willReturn(evmAccount);
-		given(evmAccount.getMutable()).willReturn(mutableAccount);
-		given(gasCalculator.calculateStorageCost(any(), any(), any())).willReturn(10L);
-		given(messageFrame.warmUpStorage(any(), any())).willReturn(true);
-		given(messageFrame.isStatic()).willReturn(false);
-		given(messageFrame.getRemainingGas()).willReturn(300L);
+        given(messageFrame.popStackItem()).willReturn(keyBytes).willReturn(valueBytes);
+        given(messageFrame.getWorldUpdater()).willReturn(worldUpdater);
+        given(messageFrame.getRecipientAddress()).willReturn(recipientAccount);
+        given(worldUpdater.getAccount(recipientAccount)).willReturn(evmAccount);
+        given(evmAccount.getMutable()).willReturn(mutableAccount);
+        given(gasCalculator.calculateStorageCost(any(), any(), any())).willReturn(10L);
+        given(messageFrame.warmUpStorage(any(), any())).willReturn(true);
+        given(messageFrame.isStatic()).willReturn(false);
+        given(messageFrame.getRemainingGas()).willReturn(300L);
 
-		given(mutableAccount.getStorageValue(any())).willReturn(keyBytes);
-	}
+        given(mutableAccount.getStorageValue(any())).willReturn(keyBytes);
+    }
 }

--- a/hedera-node/src/test/java/com/hedera/services/contracts/operation/HederaSStoreOperationTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/contracts/operation/HederaSStoreOperationTest.java
@@ -1,11 +1,6 @@
-package com.hedera.services.contracts.operation;
-
-/*-
- * ‌
- * Hedera Services Node
- * ​
- * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
- * ​
+/*
+ * Copyright (C) 2021-2022 Hedera Hashgraph, LLC
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -17,8 +12,8 @@ package com.hedera.services.contracts.operation;
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- * ‍
  */
+package com.hedera.services.contracts.operation;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.BDDMockito.any;

--- a/hedera-node/src/test/java/com/hedera/services/contracts/operation/HederaSelfDestructOperationTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/contracts/operation/HederaSelfDestructOperationTest.java
@@ -1,11 +1,6 @@
-package com.hedera.services.contracts.operation;
-
-/*-
- * ‌
- * Hedera Services Node
- * ​
- * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
- * ​
+/*
+ * Copyright (C) 2021-2022 Hedera Hashgraph, LLC
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -17,8 +12,8 @@ package com.hedera.services.contracts.operation;
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- * ‍
  */
+package com.hedera.services.contracts.operation;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;

--- a/hedera-node/src/test/java/com/hedera/services/contracts/operation/HederaSelfDestructOperationTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/contracts/operation/HederaSelfDestructOperationTest.java
@@ -20,10 +20,19 @@ package com.hedera.services.contracts.operation;
  * ‍
  */
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
 import com.hedera.services.context.TransactionContext;
 import com.hedera.services.store.contracts.HederaStackedWorldStateUpdater;
 import com.hedera.services.utils.EntityIdUtils;
 import com.hedera.services.utils.EntityNum;
+import java.util.Optional;
+import java.util.OptionalLong;
+import java.util.function.BiPredicate;
 import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.datatypes.Wei;
 import org.hyperledger.besu.evm.EVM;
@@ -37,151 +46,145 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.util.Optional;
-import java.util.OptionalLong;
-import java.util.function.BiPredicate;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.verify;
-
 @ExtendWith(MockitoExtension.class)
 class HederaSelfDestructOperationTest {
-	private static final EntityNum beneficiary = EntityNum.fromLong(2_345);
-	private static final String ethAddress = "0xc257274276a4e539741ca11b590b9447b26a8051";
-	private static final String anotherEthAddress = "0xc257274276a4e539741ca11b590b9447b26a8052";
-	private static final Address eip1014Address = Address.fromHexString(ethAddress);
+    private static final EntityNum beneficiary = EntityNum.fromLong(2_345);
+    private static final String ethAddress = "0xc257274276a4e539741ca11b590b9447b26a8051";
+    private static final String anotherEthAddress = "0xc257274276a4e539741ca11b590b9447b26a8052";
+    private static final Address eip1014Address = Address.fromHexString(ethAddress);
 
-	@Mock
-	private HederaStackedWorldStateUpdater worldUpdater;
-	@Mock
-	private GasCalculator gasCalculator;
-	@Mock
-	private TransactionContext txnCtx;
-	@Mock
-	private MessageFrame frame;
-	@Mock
-	private EVM evm;
-	@Mock
-	private Account account;
-	@Mock
-	private BiPredicate<Address, MessageFrame> addressValidator;
+    @Mock private HederaStackedWorldStateUpdater worldUpdater;
+    @Mock private GasCalculator gasCalculator;
+    @Mock private TransactionContext txnCtx;
+    @Mock private MessageFrame frame;
+    @Mock private EVM evm;
+    @Mock private Account account;
+    @Mock private BiPredicate<Address, MessageFrame> addressValidator;
 
-	private HederaSelfDestructOperation subject;
+    private HederaSelfDestructOperation subject;
 
-	@BeforeEach
-	void setUp() {
-		subject = new HederaSelfDestructOperation(gasCalculator, txnCtx, addressValidator);
+    @BeforeEach
+    void setUp() {
+        subject = new HederaSelfDestructOperation(gasCalculator, txnCtx, addressValidator);
 
-		given(frame.getWorldUpdater()).willReturn(worldUpdater);
-		given(gasCalculator.selfDestructOperationGasCost(any(), eq(Wei.ONE))).willReturn(2L);
-	}
+        given(frame.getWorldUpdater()).willReturn(worldUpdater);
+        given(gasCalculator.selfDestructOperationGasCost(any(), eq(Wei.ONE))).willReturn(2L);
+    }
 
-	@Test
-	void delegatesToSuperWhenValid() {
-		givenRubberstampValidator();
+    @Test
+    void delegatesToSuperWhenValid() {
+        givenRubberstampValidator();
 
-		final var tbdMirrorAddress = EntityIdUtils.asEvmAddress(0, 0, 1234L);
-		final var beneficiaryMirrorAddress = EntityIdUtils.asEvmAddress(0, 0, 4567L);
+        final var tbdMirrorAddress = EntityIdUtils.asEvmAddress(0, 0, 1234L);
+        final var beneficiaryMirrorAddress = EntityIdUtils.asEvmAddress(0, 0, 4567L);
 
-		final var beneficiaryMirror = beneficiary.toEvmAddress();
-		given(frame.getStackItem(0)).willReturn(beneficiaryMirror);
-		given(frame.popStackItem()).willReturn(beneficiaryMirror);
-		given(frame.getRecipientAddress()).willReturn(eip1014Address);
-		given(worldUpdater.get(any())).willReturn(account);
-		given(account.getBalance()).willReturn(Wei.ONE);
-		given(frame.isStatic()).willReturn(true);
-		given(gasCalculator.getColdAccountAccessCost()).willReturn(1L);
-		given(worldUpdater.permissivelyUnaliased(eip1014Address.toArrayUnsafe()))
-				.willReturn(tbdMirrorAddress);
-		given(worldUpdater.permissivelyUnaliased(beneficiaryMirror.toArrayUnsafe()))
-				.willReturn(beneficiaryMirrorAddress);
+        final var beneficiaryMirror = beneficiary.toEvmAddress();
+        given(frame.getStackItem(0)).willReturn(beneficiaryMirror);
+        given(frame.popStackItem()).willReturn(beneficiaryMirror);
+        given(frame.getRecipientAddress()).willReturn(eip1014Address);
+        given(worldUpdater.get(any())).willReturn(account);
+        given(account.getBalance()).willReturn(Wei.ONE);
+        given(frame.isStatic()).willReturn(true);
+        given(gasCalculator.getColdAccountAccessCost()).willReturn(1L);
+        given(worldUpdater.permissivelyUnaliased(eip1014Address.toArrayUnsafe()))
+                .willReturn(tbdMirrorAddress);
+        given(worldUpdater.permissivelyUnaliased(beneficiaryMirror.toArrayUnsafe()))
+                .willReturn(beneficiaryMirrorAddress);
 
-		final var opResult = subject.execute(frame, evm);
+        final var opResult = subject.execute(frame, evm);
 
-		verify(txnCtx).recordBeneficiaryOfDeleted(1234L, 4567L);
-		assertEquals(Optional.of(ExceptionalHaltReason.ILLEGAL_STATE_CHANGE), opResult.getHaltReason());
-		assertEquals(OptionalLong.of(3L), opResult.getGasCost());
-	}
+        verify(txnCtx).recordBeneficiaryOfDeleted(1234L, 4567L);
+        assertEquals(
+                Optional.of(ExceptionalHaltReason.ILLEGAL_STATE_CHANGE), opResult.getHaltReason());
+        assertEquals(OptionalLong.of(3L), opResult.getGasCost());
+    }
 
-	@Test
-	void rejectsSelfDestructToSelf() {
-		givenRubberstampValidator();
+    @Test
+    void rejectsSelfDestructToSelf() {
+        givenRubberstampValidator();
 
-		given(frame.getStackItem(0)).willReturn(eip1014Address);
-		given(frame.getRecipientAddress()).willReturn(eip1014Address);
+        given(frame.getStackItem(0)).willReturn(eip1014Address);
+        given(frame.getRecipientAddress()).willReturn(eip1014Address);
 
-		final var opResult = subject.execute(frame, evm);
+        final var opResult = subject.execute(frame, evm);
 
-		assertEquals(Optional.of(HederaExceptionalHaltReason.SELF_DESTRUCT_TO_SELF), opResult.getHaltReason());
-		assertEquals(OptionalLong.of(2L), opResult.getGasCost());
-	}
+        assertEquals(
+                Optional.of(HederaExceptionalHaltReason.SELF_DESTRUCT_TO_SELF),
+                opResult.getHaltReason());
+        assertEquals(OptionalLong.of(2L), opResult.getGasCost());
+    }
 
-	@Test
-	void rejectsSelfDestructIfTreasury() {
-		givenRubberstampValidator();
+    @Test
+    void rejectsSelfDestructIfTreasury() {
+        givenRubberstampValidator();
 
-		final var beneficiaryMirror = beneficiary.toEvmAddress();
-		given(frame.getStackItem(0)).willReturn(beneficiaryMirror);
-		given(frame.getRecipientAddress()).willReturn(eip1014Address);
-		given(worldUpdater.contractIsTokenTreasury(eip1014Address)).willReturn(true);
+        final var beneficiaryMirror = beneficiary.toEvmAddress();
+        given(frame.getStackItem(0)).willReturn(beneficiaryMirror);
+        given(frame.getRecipientAddress()).willReturn(eip1014Address);
+        given(worldUpdater.contractIsTokenTreasury(eip1014Address)).willReturn(true);
 
-		final var opResult = subject.execute(frame, evm);
+        final var opResult = subject.execute(frame, evm);
 
-		assertEquals(Optional.of(HederaExceptionalHaltReason.CONTRACT_IS_TREASURY), opResult.getHaltReason());
-		assertEquals(OptionalLong.of(2L), opResult.getGasCost());
-	}
+        assertEquals(
+                Optional.of(HederaExceptionalHaltReason.CONTRACT_IS_TREASURY),
+                opResult.getHaltReason());
+        assertEquals(OptionalLong.of(2L), opResult.getGasCost());
+    }
 
-	@Test
-	void rejectsSelfDestructIfContractHasAnyTokenBalance() {
-		givenRubberstampValidator();
+    @Test
+    void rejectsSelfDestructIfContractHasAnyTokenBalance() {
+        givenRubberstampValidator();
 
-		final var beneficiaryMirror = beneficiary.toEvmAddress();
-		given(frame.getStackItem(0)).willReturn(beneficiaryMirror);
-		given(frame.getRecipientAddress()).willReturn(eip1014Address);
-		given(worldUpdater.contractHasAnyBalance(eip1014Address)).willReturn(true);
+        final var beneficiaryMirror = beneficiary.toEvmAddress();
+        given(frame.getStackItem(0)).willReturn(beneficiaryMirror);
+        given(frame.getRecipientAddress()).willReturn(eip1014Address);
+        given(worldUpdater.contractHasAnyBalance(eip1014Address)).willReturn(true);
 
-		final var opResult = subject.execute(frame, evm);
+        final var opResult = subject.execute(frame, evm);
 
-		assertEquals(Optional.of(HederaExceptionalHaltReason.TRANSACTION_REQUIRES_ZERO_TOKEN_BALANCES), opResult.getHaltReason());
-		assertEquals(OptionalLong.of(2L), opResult.getGasCost());
-	}
+        assertEquals(
+                Optional.of(HederaExceptionalHaltReason.TRANSACTION_REQUIRES_ZERO_TOKEN_BALANCES),
+                opResult.getHaltReason());
+        assertEquals(OptionalLong.of(2L), opResult.getGasCost());
+    }
 
-	@Test
-	void rejectsSelfDestructIfContractHasAnyNfts() {
-		givenRubberstampValidator();
+    @Test
+    void rejectsSelfDestructIfContractHasAnyNfts() {
+        givenRubberstampValidator();
 
-		final var beneficiaryMirror = beneficiary.toEvmAddress();
-		given(frame.getStackItem(0)).willReturn(beneficiaryMirror);
-		given(frame.getRecipientAddress()).willReturn(eip1014Address);
-		given(worldUpdater.contractOwnsNfts(eip1014Address)).willReturn(true);
+        final var beneficiaryMirror = beneficiary.toEvmAddress();
+        given(frame.getStackItem(0)).willReturn(beneficiaryMirror);
+        given(frame.getRecipientAddress()).willReturn(eip1014Address);
+        given(worldUpdater.contractOwnsNfts(eip1014Address)).willReturn(true);
 
-		final var opResult = subject.execute(frame, evm);
+        final var opResult = subject.execute(frame, evm);
 
-		assertEquals(Optional.of(HederaExceptionalHaltReason.CONTRACT_STILL_OWNS_NFTS), opResult.getHaltReason());
-		assertEquals(OptionalLong.of(2L), opResult.getGasCost());
-	}
+        assertEquals(
+                Optional.of(HederaExceptionalHaltReason.CONTRACT_STILL_OWNS_NFTS),
+                opResult.getHaltReason());
+        assertEquals(OptionalLong.of(2L), opResult.getGasCost());
+    }
 
-	@Test
-	void executeInvalidSolidityAddress() {
-		givenRejectingValidator();
+    @Test
+    void executeInvalidSolidityAddress() {
+        givenRejectingValidator();
 
-		final var beneficiaryMirror = beneficiary.toEvmAddress();
-		given(frame.getStackItem(0)).willReturn(beneficiaryMirror);
+        final var beneficiaryMirror = beneficiary.toEvmAddress();
+        given(frame.getStackItem(0)).willReturn(beneficiaryMirror);
 
-		final var opResult = subject.execute(frame, evm);
+        final var opResult = subject.execute(frame, evm);
 
-		assertEquals(Optional.of(HederaExceptionalHaltReason.INVALID_SOLIDITY_ADDRESS), opResult.getHaltReason());
-		assertEquals(OptionalLong.of(2L), opResult.getGasCost());
-	}
+        assertEquals(
+                Optional.of(HederaExceptionalHaltReason.INVALID_SOLIDITY_ADDRESS),
+                opResult.getHaltReason());
+        assertEquals(OptionalLong.of(2L), opResult.getGasCost());
+    }
 
-	private void givenRubberstampValidator() {
-		given(addressValidator.test(any(), any())).willReturn(true);
-	}
+    private void givenRubberstampValidator() {
+        given(addressValidator.test(any(), any())).willReturn(true);
+    }
 
-	private void givenRejectingValidator() {
-		given(addressValidator.test(any(), any())).willReturn(false);
-	}
+    private void givenRejectingValidator() {
+        given(addressValidator.test(any(), any())).willReturn(false);
+    }
 }

--- a/hedera-node/src/test/java/com/hedera/services/contracts/operation/HederaStaticCallOperationTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/contracts/operation/HederaStaticCallOperationTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2021-2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hedera.services.contracts.operation;
 
 /*

--- a/hedera-node/src/test/java/com/hedera/services/contracts/operation/HederaStaticCallOperationTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/contracts/operation/HederaStaticCallOperationTest.java
@@ -22,8 +22,20 @@ package com.hedera.services.contracts.operation;
  *
  */
 
+import static com.hedera.services.contracts.operation.CommonCallSetup.commonSetup;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.lenient;
+
 import com.hedera.services.contracts.sources.EvmSigsVerifier;
 import com.hedera.services.store.contracts.HederaStackedWorldStateUpdater;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.BiPredicate;
 import org.apache.tuweni.bytes.Bytes;
 import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.datatypes.Wei;
@@ -39,98 +51,84 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.util.Map;
-import java.util.Optional;
-import java.util.function.BiPredicate;
-
-import static com.hedera.services.contracts.operation.CommonCallSetup.commonSetup;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyBoolean;
-import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.lenient;
-
 @ExtendWith(MockitoExtension.class)
 class HederaStaticCallOperationTest {
-	@Mock
-	private GasCalculator calc;
-	@Mock
-	private MessageFrame evmMsgFrame;
-	@Mock
-	private EVM evm;
-	@Mock
-	private HederaStackedWorldStateUpdater worldUpdater;
-	@Mock
-	private Account acc;
-	@Mock
-	private EvmSigsVerifier sigsVerifier;
-	@Mock
-	private BiPredicate<Address, MessageFrame> addressValidator;
-	@Mock
-	private Map<String, PrecompiledContract> precompiledContractMap;
+    @Mock private GasCalculator calc;
+    @Mock private MessageFrame evmMsgFrame;
+    @Mock private EVM evm;
+    @Mock private HederaStackedWorldStateUpdater worldUpdater;
+    @Mock private Account acc;
+    @Mock private EvmSigsVerifier sigsVerifier;
+    @Mock private BiPredicate<Address, MessageFrame> addressValidator;
+    @Mock private Map<String, PrecompiledContract> precompiledContractMap;
 
-	private final long cost = 100L;
-	private HederaStaticCallOperation subject;
+    private final long cost = 100L;
+    private HederaStaticCallOperation subject;
 
-	@BeforeEach
-	void setup() {
-		subject = new HederaStaticCallOperation(calc, sigsVerifier, addressValidator, precompiledContractMap);
-	}
+    @BeforeEach
+    void setup() {
+        subject =
+                new HederaStaticCallOperation(
+                        calc, sigsVerifier, addressValidator, precompiledContractMap);
+    }
 
-	@Test
-	void haltWithInvalidAddr() {
-		commonSetup(evmMsgFrame, worldUpdater, acc);
-		given(worldUpdater.get(any())).willReturn(null);
-		given(calc.callOperationGasCost(
-				any(), anyLong(), anyLong(),
-				anyLong(), anyLong(), anyLong(),
-				any(), any(), any())
-		).willReturn(cost);
-		given(evmMsgFrame.getStackItem(0)).willReturn(Bytes.EMPTY);
-		given(evmMsgFrame.getStackItem(1)).willReturn(Bytes.EMPTY);
-		given(evmMsgFrame.getStackItem(2)).willReturn(Bytes.EMPTY);
-		given(evmMsgFrame.getStackItem(3)).willReturn(Bytes.EMPTY);
-		given(evmMsgFrame.getStackItem(4)).willReturn(Bytes.EMPTY);
-		given(evmMsgFrame.getStackItem(5)).willReturn(Bytes.EMPTY);
-		given(addressValidator.test(any(), any())).willReturn(false);
+    @Test
+    void haltWithInvalidAddr() {
+        commonSetup(evmMsgFrame, worldUpdater, acc);
+        given(worldUpdater.get(any())).willReturn(null);
+        given(
+                        calc.callOperationGasCost(
+                                any(), anyLong(), anyLong(), anyLong(), anyLong(), anyLong(), any(),
+                                any(), any()))
+                .willReturn(cost);
+        given(evmMsgFrame.getStackItem(0)).willReturn(Bytes.EMPTY);
+        given(evmMsgFrame.getStackItem(1)).willReturn(Bytes.EMPTY);
+        given(evmMsgFrame.getStackItem(2)).willReturn(Bytes.EMPTY);
+        given(evmMsgFrame.getStackItem(3)).willReturn(Bytes.EMPTY);
+        given(evmMsgFrame.getStackItem(4)).willReturn(Bytes.EMPTY);
+        given(evmMsgFrame.getStackItem(5)).willReturn(Bytes.EMPTY);
+        given(addressValidator.test(any(), any())).willReturn(false);
 
-		var opRes = subject.execute(evmMsgFrame, evm);
+        var opRes = subject.execute(evmMsgFrame, evm);
 
-		assertEquals(opRes.getHaltReason(), Optional.of(HederaExceptionalHaltReason.INVALID_SOLIDITY_ADDRESS));
-		assertTrue(opRes.getGasCost().isPresent());
-		assertEquals(opRes.getGasCost().getAsLong(), cost);
-	}
+        assertEquals(
+                opRes.getHaltReason(),
+                Optional.of(HederaExceptionalHaltReason.INVALID_SOLIDITY_ADDRESS));
+        assertTrue(opRes.getGasCost().isPresent());
+        assertEquals(opRes.getGasCost().getAsLong(), cost);
+    }
 
-	@Test
-	void executesAsExpected() {
-		commonSetup(evmMsgFrame, worldUpdater, acc);
-		given(calc.callOperationGasCost(
-				any(), anyLong(), anyLong(),
-				anyLong(), anyLong(), anyLong(),
-				any(), any(), any())
-		).willReturn(cost);
-		for (int i = 0; i < 10; i++) {
-			lenient().when(evmMsgFrame.getStackItem(i)).thenReturn(Bytes.ofUnsignedInt(10));
-		}
-		given(evmMsgFrame.stackSize()).willReturn(20);
-		given(evmMsgFrame.getRemainingGas()).willReturn(cost);
-		given(evmMsgFrame.getMessageStackDepth()).willReturn(1025);
-		given(evmMsgFrame.getWorldUpdater()).willReturn(worldUpdater);
-		given(worldUpdater.get(any())).willReturn(acc);
-		given(acc.getBalance()).willReturn(Wei.of(100));
-		given(calc.gasAvailableForChildCall(any(), anyLong(), anyBoolean())).willReturn(10L);
-		given(sigsVerifier.hasActiveKeyOrNoReceiverSigReq(Mockito.anyBoolean(), any(), any(), any())).willReturn(true);
-		given(acc.getAddress()).willReturn(Address.ZERO);
-		given(addressValidator.test(any(), any())).willReturn(true);
+    @Test
+    void executesAsExpected() {
+        commonSetup(evmMsgFrame, worldUpdater, acc);
+        given(
+                        calc.callOperationGasCost(
+                                any(), anyLong(), anyLong(), anyLong(), anyLong(), anyLong(), any(),
+                                any(), any()))
+                .willReturn(cost);
+        for (int i = 0; i < 10; i++) {
+            lenient().when(evmMsgFrame.getStackItem(i)).thenReturn(Bytes.ofUnsignedInt(10));
+        }
+        given(evmMsgFrame.stackSize()).willReturn(20);
+        given(evmMsgFrame.getRemainingGas()).willReturn(cost);
+        given(evmMsgFrame.getMessageStackDepth()).willReturn(1025);
+        given(evmMsgFrame.getWorldUpdater()).willReturn(worldUpdater);
+        given(worldUpdater.get(any())).willReturn(acc);
+        given(acc.getBalance()).willReturn(Wei.of(100));
+        given(calc.gasAvailableForChildCall(any(), anyLong(), anyBoolean())).willReturn(10L);
+        given(
+                        sigsVerifier.hasActiveKeyOrNoReceiverSigReq(
+                                Mockito.anyBoolean(), any(), any(), any()))
+                .willReturn(true);
+        given(acc.getAddress()).willReturn(Address.ZERO);
+        given(addressValidator.test(any(), any())).willReturn(true);
 
-		given(evmMsgFrame.getContractAddress()).willReturn(Address.ALTBN128_ADD);
-		given(evmMsgFrame.getRecipientAddress()).willReturn(Address.ALTBN128_ADD);
-		
-		var opRes = subject.execute(evmMsgFrame, evm);
-		assertEquals(Optional.empty(), opRes.getHaltReason());
-		assertTrue(opRes.getGasCost().isPresent());
-		assertEquals(opRes.getGasCost().getAsLong(), cost);
-	}
+        given(evmMsgFrame.getContractAddress()).willReturn(Address.ALTBN128_ADD);
+        given(evmMsgFrame.getRecipientAddress()).willReturn(Address.ALTBN128_ADD);
+
+        var opRes = subject.execute(evmMsgFrame, evm);
+        assertEquals(Optional.empty(), opRes.getHaltReason());
+        assertTrue(opRes.getGasCost().isPresent());
+        assertEquals(opRes.getGasCost().getAsLong(), cost);
+    }
 }

--- a/hedera-node/src/test/java/com/hedera/services/contracts/sources/AddressKeyedMapFactoryTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/contracts/sources/AddressKeyedMapFactoryTest.java
@@ -1,11 +1,6 @@
-package com.hedera.services.contracts.sources;
-
-/*-
- * ‌
- * Hedera Services Node
- * ​
- * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
- * ​
+/*
+ * Copyright (C) 2020-2022 Hedera Hashgraph, LLC
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -17,8 +12,8 @@ package com.hedera.services.contracts.sources;
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- * ‍
  */
+package com.hedera.services.contracts.sources;
 
 import static com.hedera.services.contracts.sources.AddressKeyedMapFactory.LEGACY_BYTECODE_PATH_PATTERN;
 import static com.hedera.services.contracts.sources.AddressKeyedMapFactory.LEGACY_BYTECODE_PATH_TEMPLATE;

--- a/hedera-node/src/test/java/com/hedera/services/contracts/sources/AddressKeyedMapFactoryTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/contracts/sources/AddressKeyedMapFactoryTest.java
@@ -20,14 +20,6 @@ package com.hedera.services.contracts.sources;
  * ‍
  */
 
-import com.hedera.services.utils.EntityIdUtils;
-import org.junit.jupiter.api.Test;
-
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.stream.Collectors;
-
 import static com.hedera.services.contracts.sources.AddressKeyedMapFactory.LEGACY_BYTECODE_PATH_PATTERN;
 import static com.hedera.services.contracts.sources.AddressKeyedMapFactory.LEGACY_BYTECODE_PATH_TEMPLATE;
 import static com.hedera.services.contracts.sources.AddressKeyedMapFactory.bytecodeMapFrom;
@@ -40,123 +32,148 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.hedera.services.utils.EntityIdUtils;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.Test;
+
 class AddressKeyedMapFactoryTest {
-	@Test
-	void toAddressConversion() {
-		final var mapper = toAddressMapping(LEGACY_BYTECODE_PATH_PATTERN);
-		final var key = "/666/s888";
-		final var expected = EntityIdUtils.asEvmAddress(0, 666, 888);
+    @Test
+    void toAddressConversion() {
+        final var mapper = toAddressMapping(LEGACY_BYTECODE_PATH_PATTERN);
+        final var key = "/666/s888";
+        final var expected = EntityIdUtils.asEvmAddress(0, 666, 888);
 
-		final var actual = mapper.apply(key);
+        final var actual = mapper.apply(key);
 
-		assertArrayEquals(expected, actual);
-	}
+        assertArrayEquals(expected, actual);
+    }
 
-	@Test
-	void toKeyConversionWorks() {
-		final var mapper = toKeyMapping(LEGACY_BYTECODE_PATH_TEMPLATE);
-		final var address = EntityIdUtils.asEvmAddress(0, 666, 888);
-		final var expected = "/666/s888";
+    @Test
+    void toKeyConversionWorks() {
+        final var mapper = toKeyMapping(LEGACY_BYTECODE_PATH_TEMPLATE);
+        final var address = EntityIdUtils.asEvmAddress(0, 666, 888);
+        final var expected = "/666/s888";
 
-		final var actual = mapper.apply(address);
+        final var actual = mapper.apply(address);
 
-		assertEquals(expected, actual);
-	}
+        assertEquals(expected, actual);
+    }
 
-	@Test
-	void isRelevantWorks() {
-		final var realKey = "/666/s888";
-		final var fakeKey = "/a66/s888";
-		final var pred = toRelevancyPredicate(LEGACY_BYTECODE_PATH_PATTERN);
+    @Test
+    void isRelevantWorks() {
+        final var realKey = "/666/s888";
+        final var fakeKey = "/a66/s888";
+        final var pred = toRelevancyPredicate(LEGACY_BYTECODE_PATH_PATTERN);
 
-		assertTrue(pred.test(realKey));
-		assertFalse(pred.test(fakeKey));
-	}
+        assertTrue(pred.test(realKey));
+        assertFalse(pred.test(fakeKey));
+    }
 
-	@Test
-	void bytecodeProductHasMapSemantics() {
-		final Map<String, byte[]> delegate = new HashMap<>();
-		delegate.put(("/2/s7"), "APRIORI".getBytes());
-		final var address1 = EntityIdUtils.asEvmAddress(0, 2, 3);
-		final var address2 = EntityIdUtils.asEvmAddress(0, 3333, 4);
-		final var address3 = EntityIdUtils.asEvmAddress(0, 4, 555555);
-		final var theData = "THE".getBytes();
-		final var someData = "SOME".getBytes();
-		final var moreData = "MORE".getBytes();
-		final var storageMap = bytecodeMapFrom(delegate);
+    @Test
+    void bytecodeProductHasMapSemantics() {
+        final Map<String, byte[]> delegate = new HashMap<>();
+        delegate.put(("/2/s7"), "APRIORI".getBytes());
+        final var address1 = EntityIdUtils.asEvmAddress(0, 2, 3);
+        final var address2 = EntityIdUtils.asEvmAddress(0, 3333, 4);
+        final var address3 = EntityIdUtils.asEvmAddress(0, 4, 555555);
+        final var theData = "THE".getBytes();
+        final var someData = "SOME".getBytes();
+        final var moreData = "MORE".getBytes();
+        final var storageMap = bytecodeMapFrom(delegate);
 
-		storageMap.put(address1, someData);
-		storageMap.put(address2, moreData);
-		storageMap.put(address3, theData);
+        storageMap.put(address1, someData);
+        storageMap.put(address2, moreData);
+        storageMap.put(address3, theData);
 
-		assertFalse(storageMap.isEmpty());
-		assertEquals(4, storageMap.size());
-		storageMap.remove(address2);
-		assertEquals(3, storageMap.size());
-		assertEquals(
-				"/2/s3->SOME, /4/s555555->THE, /2/s7->APRIORI",
-				delegate.entrySet()
-						.stream()
-						.sorted(Comparator.comparingLong(entry ->
-								Long.parseLong(entry.getKey().substring(
-										entry.getKey().indexOf('s') + 1, entry.getKey().indexOf('s') + 2
-								))))
-						.map(entry -> String.format("%s->%s", entry.getKey(), new String(entry.getValue())))
-						.collect(Collectors.joining(", ")));
+        assertFalse(storageMap.isEmpty());
+        assertEquals(4, storageMap.size());
+        storageMap.remove(address2);
+        assertEquals(3, storageMap.size());
+        assertEquals(
+                "/2/s3->SOME, /4/s555555->THE, /2/s7->APRIORI",
+                delegate.entrySet().stream()
+                        .sorted(
+                                Comparator.comparingLong(
+                                        entry ->
+                                                Long.parseLong(
+                                                        entry.getKey()
+                                                                .substring(
+                                                                        entry.getKey().indexOf('s')
+                                                                                + 1,
+                                                                        entry.getKey().indexOf('s')
+                                                                                + 2))))
+                        .map(
+                                entry ->
+                                        String.format(
+                                                "%s->%s",
+                                                entry.getKey(), new String(entry.getValue())))
+                        .collect(Collectors.joining(", ")));
 
-		assertTrue(storageMap.containsKey(address1));
-		assertFalse(storageMap.containsKey(address2));
+        assertTrue(storageMap.containsKey(address1));
+        assertFalse(storageMap.containsKey(address2));
 
-		storageMap.clear();
-		assertTrue(storageMap.isEmpty());
-	}
+        storageMap.clear();
+        assertTrue(storageMap.isEmpty());
+    }
 
-	@Test
-	void productHasFilterSet() {
-		final Map<String, byte[]> delegate = new HashMap<>();
-		delegate.put(("NOT-REAL-KEY"), "APRIORI".getBytes());
+    @Test
+    void productHasFilterSet() {
+        final Map<String, byte[]> delegate = new HashMap<>();
+        delegate.put(("NOT-REAL-KEY"), "APRIORI".getBytes());
 
-		final var storageMap = bytecodeMapFrom(delegate);
+        final var storageMap = bytecodeMapFrom(delegate);
 
-		assertTrue(storageMap.entrySet().isEmpty());
-	}
+        assertTrue(storageMap.entrySet().isEmpty());
+    }
 
-	@Test
-	void storageProductHasMapSemantics() {
-		final Map<String, byte[]> delegate = new HashMap<>();
-		delegate.put(("/2/d7"), "APRIORI".getBytes());
-		final var address1 = EntityIdUtils.asEvmAddress(0, 2, 3);
-		final var address2 = EntityIdUtils.asEvmAddress(0, 3333, 4);
-		final var address3 = EntityIdUtils.asEvmAddress(0, 4, 555555);
-		final var theData = "THE".getBytes();
-		final var someData = "SOME".getBytes();
-		final var moreData = "MORE".getBytes();
+    @Test
+    void storageProductHasMapSemantics() {
+        final Map<String, byte[]> delegate = new HashMap<>();
+        delegate.put(("/2/d7"), "APRIORI".getBytes());
+        final var address1 = EntityIdUtils.asEvmAddress(0, 2, 3);
+        final var address2 = EntityIdUtils.asEvmAddress(0, 3333, 4);
+        final var address3 = EntityIdUtils.asEvmAddress(0, 4, 555555);
+        final var theData = "THE".getBytes();
+        final var someData = "SOME".getBytes();
+        final var moreData = "MORE".getBytes();
 
-		final var storageMap = storageMapFrom(delegate);
+        final var storageMap = storageMapFrom(delegate);
 
-		storageMap.put(address1, someData);
-		storageMap.put(address2, moreData);
-		storageMap.put(address3, theData);
+        storageMap.put(address1, someData);
+        storageMap.put(address2, moreData);
+        storageMap.put(address3, theData);
 
-		assertFalse(storageMap.isEmpty());
-		assertEquals(4, storageMap.size());
-		storageMap.remove(address2);
-		assertEquals(3, storageMap.size());
-		assertEquals(
-				"/2/d3->SOME, /4/d555555->THE, /2/d7->APRIORI",
-				delegate.entrySet()
-						.stream()
-						.sorted(Comparator.comparingLong(entry ->
-								Long.parseLong(entry.getKey().substring(
-										entry.getKey().indexOf('d') + 1, entry.getKey().indexOf('d') + 2
-								))))
-						.map(entry -> String.format("%s->%s", entry.getKey(), new String(entry.getValue())))
-						.collect(Collectors.joining(", ")));
+        assertFalse(storageMap.isEmpty());
+        assertEquals(4, storageMap.size());
+        storageMap.remove(address2);
+        assertEquals(3, storageMap.size());
+        assertEquals(
+                "/2/d3->SOME, /4/d555555->THE, /2/d7->APRIORI",
+                delegate.entrySet().stream()
+                        .sorted(
+                                Comparator.comparingLong(
+                                        entry ->
+                                                Long.parseLong(
+                                                        entry.getKey()
+                                                                .substring(
+                                                                        entry.getKey().indexOf('d')
+                                                                                + 1,
+                                                                        entry.getKey().indexOf('d')
+                                                                                + 2))))
+                        .map(
+                                entry ->
+                                        String.format(
+                                                "%s->%s",
+                                                entry.getKey(), new String(entry.getValue())))
+                        .collect(Collectors.joining(", ")));
 
-		assertTrue(storageMap.containsKey(address1));
-		assertFalse(storageMap.containsKey(address2));
+        assertTrue(storageMap.containsKey(address1));
+        assertFalse(storageMap.containsKey(address2));
 
-		storageMap.clear();
-		assertTrue(storageMap.isEmpty());
-	}
+        storageMap.clear();
+        assertTrue(storageMap.isEmpty());
+    }
 }

--- a/hedera-node/src/test/java/com/hedera/services/contracts/sources/TxnAwareEvmSigsVerifierTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/contracts/sources/TxnAwareEvmSigsVerifierTest.java
@@ -22,6 +22,23 @@ package com.hedera.services.contracts.sources;
  *
  */
 
+import static com.hedera.services.keys.HederaKeyActivation.INVALID_MISSING_SIG;
+import static com.hedera.services.ledger.properties.AccountProperty.IS_RECEIVER_SIG_REQUIRED;
+import static com.hedera.services.ledger.properties.AccountProperty.KEY;
+import static com.hedera.test.utils.TxnUtils.assertFailsWith;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_ACCOUNT_ID;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_TOKEN_ID;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TOKEN_HAS_NO_SUPPLY_KEY;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
 import com.hedera.services.context.TransactionContext;
 import com.hedera.services.keys.ActivationTest;
 import com.hedera.services.ledger.TransactionalLedger;
@@ -45,6 +62,9 @@ import com.hedera.test.utils.IdUtils;
 import com.hederahashgraph.api.proto.java.AccountID;
 import com.hederahashgraph.api.proto.java.TokenID;
 import com.swirlds.common.crypto.TransactionSignature;
+import java.util.function.BiPredicate;
+import java.util.function.Function;
+import javax.annotation.Nullable;
 import org.hyperledger.besu.datatypes.Address;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -52,378 +72,364 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import javax.annotation.Nullable;
-import java.util.function.BiPredicate;
-import java.util.function.Function;
-
-import static com.hedera.services.keys.HederaKeyActivation.INVALID_MISSING_SIG;
-import static com.hedera.services.ledger.properties.AccountProperty.IS_RECEIVER_SIG_REQUIRED;
-import static com.hedera.services.ledger.properties.AccountProperty.KEY;
-import static com.hedera.test.utils.TxnUtils.assertFailsWith;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_ACCOUNT_ID;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_TOKEN_ID;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TOKEN_HAS_NO_SUPPLY_KEY;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.BDDMockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
-
 @ExtendWith(MockitoExtension.class)
 class TxnAwareEvmSigsVerifierTest {
-	private static final Address PRETEND_SENDER_ADDR = Address.ALTBN128_PAIRING;
-	private static final Id tokenId = new Id(0, 0, 666);
-	private static final Id accountId = new Id(0, 0, 1234);
-	private static final Address PRETEND_TOKEN_ADDR = tokenId.asEvmAddress();
-	private static final Address PRETEND_ACCOUNT_ADDR = accountId.asEvmAddress();
-	private final TokenID token = IdUtils.asToken("0.0.666");
-	private final AccountID payer = IdUtils.asAccount("0.0.2");
-	private final AccountID account = IdUtils.asAccount("0.0.1234");
-	private final AccountID sigRequired = IdUtils.asAccount("0.0.555");
-	private final AccountID smartContract = IdUtils.asAccount("0.0.666");
-	private final AccountID noSigRequired = IdUtils.asAccount("0.0.777");
-
-	private JKey expectedKey;
-
-	@Mock
-	private BiPredicate<JKey, TransactionSignature> cryptoValidity;
-	@Mock
-	private ActivationTest activationTest;
-	@Mock
-	private TransactionContext txnCtx;
-	@Mock
-	private PlatformTxnAccessor accessor;
-	@Mock
-	private Function<byte[], TransactionSignature> pkToCryptoSigsFn;
-	@Mock
-	private ContractAliases aliases;
-	@Mock
-	private TransactionalLedger<AccountID, AccountProperty, MerkleAccount> accountsLedger;
-	@Mock
-	private TransactionalLedger<TokenID, TokenProperty, MerkleToken> tokensLedger;
-	@Mock
-	private WorldLedgers ledgers;
-
-	private TxnAwareEvmSigsVerifier subject;
-
-	@BeforeEach
-	private void setup() throws Exception {
-		expectedKey = TxnHandlingScenario.MISC_ACCOUNT_KT.asJKey();
-
-		subject = new TxnAwareEvmSigsVerifier(activationTest, txnCtx, cryptoValidity);
-	}
-
-	@Test
-	void throwsIfAskedToVerifyMissingToken() {
-		given(ledgers.tokens()).willReturn(tokensLedger);
-		given(tokensLedger.exists(token)).willReturn(false);
-
-		assertFailsWith(() ->
-						subject.hasActiveSupplyKey(true,
-								PRETEND_TOKEN_ADDR, PRETEND_SENDER_ADDR,
-								ledgers),
-				INVALID_TOKEN_ID);
-	}
-
-	@Test
-	void throwsIfAskedToVerifyTokenWithoutSupplyKey() {
-		given(ledgers.tokens()).willReturn(tokensLedger);
-		given(tokensLedger.exists(token)).willReturn(true);
-		given(tokensLedger.get(token, TokenProperty.SUPPLY_KEY)).willReturn(null);
-
-		assertFailsWith(() ->
-						subject.hasActiveSupplyKey(true,
-								PRETEND_TOKEN_ADDR,
-								PRETEND_SENDER_ADDR,
-								ledgers),
-				TOKEN_HAS_NO_SUPPLY_KEY);
-	}
-
-	@Test
-	void testsSupplyKeyIfPresent() {
-		given(txnCtx.swirldsTxnAccessor()).willReturn(accessor);
-		given(ledgers.tokens()).willReturn(tokensLedger);
-		given(tokensLedger.exists(token)).willReturn(true);
-		given(tokensLedger.get(token, TokenProperty.SUPPLY_KEY)).willReturn(expectedKey);
-
-		given(accessor.getRationalizedPkToCryptoSigFn()).willReturn(pkToCryptoSigsFn);
-		given(activationTest.test(eq(expectedKey), eq(pkToCryptoSigsFn), any())).willReturn(true);
-
-		final var verdict = subject.hasActiveSupplyKey(true,
-				PRETEND_TOKEN_ADDR, PRETEND_SENDER_ADDR, ledgers);
-
-		assertTrue(verdict);
-	}
-
-	@Test
-	void supplyKeyFailsWhenTokensLedgerIsNull() {
-		given(ledgers.tokens()).willReturn(null);
-
-		assertThrows(NullPointerException.class, () -> subject.hasActiveSupplyKey(true,
-				PRETEND_TOKEN_ADDR,
-				PRETEND_SENDER_ADDR,
-				ledgers));
-	}
-
-	@Test
-	void throwsIfAskedToVerifyMissingAccount() {
-		given(ledgers.accounts()).willReturn(accountsLedger);
-		given(accountsLedger.exists(account)).willReturn(false);
-
-		assertFailsWith(() ->
-						subject.hasActiveKey(true,
-								PRETEND_ACCOUNT_ADDR,
-								PRETEND_SENDER_ADDR,
-								ledgers),
-				INVALID_ACCOUNT_ID);
-	}
-
-	@Test
-	void testsAccountKeyIfPresent() {
-		given(txnCtx.swirldsTxnAccessor()).willReturn(accessor);
-		given(ledgers.accounts()).willReturn(accountsLedger);
-		given(accountsLedger.exists(account)).willReturn(true);
-		given(accountsLedger.get(account, AccountProperty.KEY)).willReturn(expectedKey);
-		given(accessor.getRationalizedPkToCryptoSigFn()).willReturn(pkToCryptoSigsFn);
-		given(activationTest.test(eq(expectedKey), eq(pkToCryptoSigsFn), any())).willReturn(true);
-
-		final var verdict = subject.hasActiveKey(true,
-				PRETEND_ACCOUNT_ADDR, PRETEND_SENDER_ADDR, ledgers);
-
-		assertTrue(verdict);
-	}
-
-	@Test
-	void testsAccountKeyIfPresentButInvalid() {
-		given(txnCtx.swirldsTxnAccessor()).willReturn(accessor);
-		given(ledgers.accounts()).willReturn(accountsLedger);
-		given(accountsLedger.exists(account)).willReturn(true);
-		given(accountsLedger.get(account, AccountProperty.KEY)).willReturn(expectedKey);
-		given(accessor.getRationalizedPkToCryptoSigFn()).willReturn(pkToCryptoSigsFn);
-		given(activationTest.test(eq(expectedKey), eq(pkToCryptoSigsFn), any())).willReturn(false);
-
-		final var verdict = subject.hasActiveKey(true,
-				PRETEND_ACCOUNT_ADDR, PRETEND_SENDER_ADDR, ledgers);
-
-		assertFalse(verdict);
-	}
-
-	@Test
-	void testsMissingAccountKey() {
-		given(ledgers.accounts()).willReturn(accountsLedger);
-		given(accountsLedger.exists(account)).willReturn(true);
-		given(accountsLedger.get(account, AccountProperty.KEY)).willReturn(null);
-
-		final var verdict = subject.hasActiveKey(true,
-				PRETEND_ACCOUNT_ADDR, PRETEND_SENDER_ADDR, ledgers);
-
-		assertFalse(verdict);
-	}
-
-	@Test
-	void testsCryptoKeyIfPresent() {
-		given(txnCtx.swirldsTxnAccessor()).willReturn(accessor);
-		given(accessor.getRationalizedPkToCryptoSigFn()).willReturn(pkToCryptoSigsFn);
-		given(activationTest.test(eq(expectedKey), eq(pkToCryptoSigsFn), any())).willReturn(true);
-
-		final var verdict = subject.cryptoKeyIsActive(expectedKey);
-
-		assertTrue(verdict);
-	}
-
-	@Test
-	void testsCryptoKeyIfPresentButInvalid() {
-		given(txnCtx.swirldsTxnAccessor()).willReturn(accessor);
-		given(accessor.getRationalizedPkToCryptoSigFn()).willReturn(pkToCryptoSigsFn);
-		given(activationTest.test(eq(expectedKey), eq(pkToCryptoSigsFn), any())).willReturn(false);
-
-		final var verdict = subject.cryptoKeyIsActive(expectedKey);
-
-		assertFalse(verdict);
-	}
-
-	@Test
-	void testsNullCryptoKey() {
-		final var verdict = subject.cryptoKeyIsActive(null);
-
-		assertFalse(verdict);
-	}
-
-	@Test
-	void filtersContracts() {
-		given(txnCtx.activePayer()).willReturn(payer);
-		givenSigReqCheckable(smartContract, false, null);
-
-		final var contractFlag = subject.hasActiveKeyOrNoReceiverSigReq(true,
-				EntityIdUtils.asTypedEvmAddress(smartContract), PRETEND_SENDER_ADDR, ledgers);
-
-		assertTrue(contractFlag);
-		verify(activationTest, never()).test(any(), any(), any());
-	}
-
-	private void givenSigReqCheckable(
-			final AccountID id,
-			final boolean receiverSigRequired,
-			@Nullable final JKey key
-	) {
-		given(ledgers.accounts()).willReturn(accountsLedger);
-		given(accountsLedger.contains(id)).willReturn(true);
-		given(accountsLedger.get(id, IS_RECEIVER_SIG_REQUIRED)).willReturn(receiverSigRequired);
-		if (receiverSigRequired) {
-			given(accountsLedger.get(id, KEY)).willReturn(key);
-		}
-	}
-
-	@Test
-	void filtersNoSigRequired() {
-		given(txnCtx.activePayer()).willReturn(payer);
-		givenSigReqCheckable(noSigRequired, false, null);
-
-		final var noSigRequiredFlag = subject.hasActiveKeyOrNoReceiverSigReq(true,
-				EntityIdUtils.asTypedEvmAddress(noSigRequired), PRETEND_SENDER_ADDR, ledgers);
-
-		assertTrue(noSigRequiredFlag);
-		verify(activationTest, never()).test(any(), any(), any());
-	}
-
-	@Test
-	void filtersMissing() {
-		given(txnCtx.activePayer()).willReturn(payer);
-		given(ledgers.accounts()).willReturn(accountsLedger);
-
-		final var noSigRequiredFlag = subject.hasActiveKeyOrNoReceiverSigReq(true,
-				EntityIdUtils.asTypedEvmAddress(noSigRequired), PRETEND_SENDER_ADDR, ledgers);
-
-		assertTrue(noSigRequiredFlag);
-		verify(activationTest, never()).test(any(), any(), any());
-	}
-
-	@Test
-	void filtersNoSigRequiredWhenLedgersAreNotNullButAccountsLedgerIsNull() {
-		given(txnCtx.activePayer()).willReturn(payer);
-		given(ledgers.accounts()).willReturn(null);
-
-		final var noSigRequiredFlag = subject.hasActiveKeyOrNoReceiverSigReq(true,
-				EntityIdUtils.asTypedEvmAddress(noSigRequired), PRETEND_SENDER_ADDR, ledgers);
-
-		assertTrue(noSigRequiredFlag);
-		verify(activationTest, never()).test(any(), any(), any());
-	}
-
-	@Test
-	void testsWhenReceiverSigIsRequired() {
-		givenAccessorInCtx();
-		givenSigReqCheckable(sigRequired, true, expectedKey);
-		given(accessor.getRationalizedPkToCryptoSigFn()).willReturn(pkToCryptoSigsFn);
-
-		given(activationTest.test(eq(expectedKey), eq(pkToCryptoSigsFn), any())).willReturn(true);
-
-		boolean sigRequiredFlag = subject.hasActiveKeyOrNoReceiverSigReq(true,
-				EntityIdUtils.asTypedEvmAddress(sigRequired), PRETEND_SENDER_ADDR, ledgers);
-
-		assertTrue(sigRequiredFlag);
-	}
-
-	@Test
-	void filtersPayerSinceSigIsGuaranteed() {
-		given(txnCtx.activePayer()).willReturn(payer);
-
-		boolean payerFlag = subject.hasActiveKeyOrNoReceiverSigReq(true,
-				EntityIdUtils.asTypedEvmAddress(payer), PRETEND_SENDER_ADDR, ledgers);
-
-		assertTrue(payerFlag);
-
-		verify(activationTest, never()).test(any(), any(), any());
-	}
-
-	@Test
-	void createsValidityTestThatOnlyAcceptsContractIdKeyWhenBothRecipientAndContractAreActive() {
-		final var uncontrolledId = EntityIdUtils.contractIdFromEvmAddress(Address.BLS12_G1ADD);
-		final var controlledId = EntityIdUtils.contractIdFromEvmAddress(PRETEND_SENDER_ADDR);
-		final var controlledKey = new JContractIDKey(controlledId);
-		final var uncontrolledKey = new JContractIDKey(uncontrolledId);
-
-		given(aliases.currentAddress(controlledId)).willReturn(PRETEND_SENDER_ADDR);
-		given(aliases.currentAddress(uncontrolledId)).willReturn(PRETEND_TOKEN_ADDR);
-
-		final var validityTestForNormalCall =
-				subject.validityTestFor(
-						false, PRETEND_SENDER_ADDR, aliases);
-		final var validityTestForDelegateCall =
-				subject.validityTestFor(
-						true, PRETEND_SENDER_ADDR, aliases);
-
-		assertTrue(validityTestForNormalCall.test(controlledKey, INVALID_MISSING_SIG));
-		assertFalse(validityTestForDelegateCall.test(controlledKey, INVALID_MISSING_SIG));
-		assertFalse(validityTestForNormalCall.test(uncontrolledKey, INVALID_MISSING_SIG));
-		assertFalse(validityTestForDelegateCall.test(uncontrolledKey, INVALID_MISSING_SIG));
-	}
-
-	@Test
-	void testsAccountAddressAndActiveContractIfEquals() {
-		given(ledgers.accounts()).willReturn(accountsLedger);
-		given(accountsLedger.exists(smartContract)).willReturn(true);
-
-		final var verdict = subject.hasActiveKey(true,
-				EntityIdUtils.asTypedEvmAddress(smartContract),
-				EntityIdUtils.asTypedEvmAddress(smartContract), ledgers);
-
-		assertTrue(verdict);
-	}
-
-	@Test
-	void createsValidityTestThatAcceptsContractKeysWithJustRecipientActive() {
-		final var uncontrolledId = EntityIdUtils.contractIdFromEvmAddress(Address.BLS12_G1ADD);
-		final var controlledId = EntityIdUtils.contractIdFromEvmAddress(PRETEND_SENDER_ADDR);
-		final var controlledKey = new JDelegatableContractIDKey(controlledId);
-		final var uncontrolledKey = new JContractIDKey(uncontrolledId);
-		final var otherControlledKey = new JContractAliasKey(0, 0, Address.BLS12_G1ADD.toArrayUnsafe());
-		final var otherControlledId = otherControlledKey.getContractID();
-		final var otherControlDelegateKey = new JDelegatableContractAliasKey(0, 0, Address.BLS12_G1ADD.toArrayUnsafe());
-
-		given(aliases.currentAddress(controlledId)).willReturn(PRETEND_SENDER_ADDR);
-		given(aliases.currentAddress(uncontrolledId)).willReturn(PRETEND_TOKEN_ADDR);
-		given(aliases.currentAddress(otherControlledId)).willReturn(PRETEND_SENDER_ADDR);
-
-		final var validityTestForNormalCall =
-				subject.validityTestFor(
-						false, PRETEND_SENDER_ADDR, aliases);
-		final var validityTestForDelegateCall =
-				subject.validityTestFor(
-						true, PRETEND_SENDER_ADDR, aliases);
-
-		assertTrue(validityTestForNormalCall.test(controlledKey, INVALID_MISSING_SIG));
-		assertTrue(validityTestForDelegateCall.test(controlledKey, INVALID_MISSING_SIG));
-		assertFalse(validityTestForNormalCall.test(uncontrolledKey, INVALID_MISSING_SIG));
-		assertFalse(validityTestForDelegateCall.test(uncontrolledKey, INVALID_MISSING_SIG));
-		assertTrue(validityTestForNormalCall.test(otherControlledKey, INVALID_MISSING_SIG));
-		assertFalse(validityTestForDelegateCall.test(otherControlledKey, INVALID_MISSING_SIG));
-		assertTrue(validityTestForDelegateCall.test(otherControlDelegateKey, INVALID_MISSING_SIG));
-	}
-
-	@Test
-	void validityTestsRelyOnCryptoValidityOtherwise() {
-		final var mockSig = mock(TransactionSignature.class);
-		final var mockKey = new JEd25519Key("01234567890123456789012345678901".getBytes());
-		given(cryptoValidity.test(mockKey, mockSig)).willReturn(true);
-
-		final var validityTestForNormalCall =
-				subject.validityTestFor(
-						false, PRETEND_SENDER_ADDR, aliases);
-		final var validityTestForDelegateCall =
-				subject.validityTestFor(
-						true, PRETEND_SENDER_ADDR, aliases);
-
-		assertTrue(validityTestForNormalCall.test(mockKey, mockSig));
-		assertTrue(validityTestForDelegateCall.test(mockKey, mockSig));
-	}
-
-	private void givenAccessorInCtx() {
-		given(txnCtx.swirldsTxnAccessor()).willReturn(accessor);
-		given(txnCtx.activePayer()).willReturn(payer);
-	}
+    private static final Address PRETEND_SENDER_ADDR = Address.ALTBN128_PAIRING;
+    private static final Id tokenId = new Id(0, 0, 666);
+    private static final Id accountId = new Id(0, 0, 1234);
+    private static final Address PRETEND_TOKEN_ADDR = tokenId.asEvmAddress();
+    private static final Address PRETEND_ACCOUNT_ADDR = accountId.asEvmAddress();
+    private final TokenID token = IdUtils.asToken("0.0.666");
+    private final AccountID payer = IdUtils.asAccount("0.0.2");
+    private final AccountID account = IdUtils.asAccount("0.0.1234");
+    private final AccountID sigRequired = IdUtils.asAccount("0.0.555");
+    private final AccountID smartContract = IdUtils.asAccount("0.0.666");
+    private final AccountID noSigRequired = IdUtils.asAccount("0.0.777");
+
+    private JKey expectedKey;
+
+    @Mock private BiPredicate<JKey, TransactionSignature> cryptoValidity;
+    @Mock private ActivationTest activationTest;
+    @Mock private TransactionContext txnCtx;
+    @Mock private PlatformTxnAccessor accessor;
+    @Mock private Function<byte[], TransactionSignature> pkToCryptoSigsFn;
+    @Mock private ContractAliases aliases;
+    @Mock private TransactionalLedger<AccountID, AccountProperty, MerkleAccount> accountsLedger;
+    @Mock private TransactionalLedger<TokenID, TokenProperty, MerkleToken> tokensLedger;
+    @Mock private WorldLedgers ledgers;
+
+    private TxnAwareEvmSigsVerifier subject;
+
+    @BeforeEach
+    private void setup() throws Exception {
+        expectedKey = TxnHandlingScenario.MISC_ACCOUNT_KT.asJKey();
+
+        subject = new TxnAwareEvmSigsVerifier(activationTest, txnCtx, cryptoValidity);
+    }
+
+    @Test
+    void throwsIfAskedToVerifyMissingToken() {
+        given(ledgers.tokens()).willReturn(tokensLedger);
+        given(tokensLedger.exists(token)).willReturn(false);
+
+        assertFailsWith(
+                () ->
+                        subject.hasActiveSupplyKey(
+                                true, PRETEND_TOKEN_ADDR, PRETEND_SENDER_ADDR, ledgers),
+                INVALID_TOKEN_ID);
+    }
+
+    @Test
+    void throwsIfAskedToVerifyTokenWithoutSupplyKey() {
+        given(ledgers.tokens()).willReturn(tokensLedger);
+        given(tokensLedger.exists(token)).willReturn(true);
+        given(tokensLedger.get(token, TokenProperty.SUPPLY_KEY)).willReturn(null);
+
+        assertFailsWith(
+                () ->
+                        subject.hasActiveSupplyKey(
+                                true, PRETEND_TOKEN_ADDR, PRETEND_SENDER_ADDR, ledgers),
+                TOKEN_HAS_NO_SUPPLY_KEY);
+    }
+
+    @Test
+    void testsSupplyKeyIfPresent() {
+        given(txnCtx.swirldsTxnAccessor()).willReturn(accessor);
+        given(ledgers.tokens()).willReturn(tokensLedger);
+        given(tokensLedger.exists(token)).willReturn(true);
+        given(tokensLedger.get(token, TokenProperty.SUPPLY_KEY)).willReturn(expectedKey);
+
+        given(accessor.getRationalizedPkToCryptoSigFn()).willReturn(pkToCryptoSigsFn);
+        given(activationTest.test(eq(expectedKey), eq(pkToCryptoSigsFn), any())).willReturn(true);
+
+        final var verdict =
+                subject.hasActiveSupplyKey(true, PRETEND_TOKEN_ADDR, PRETEND_SENDER_ADDR, ledgers);
+
+        assertTrue(verdict);
+    }
+
+    @Test
+    void supplyKeyFailsWhenTokensLedgerIsNull() {
+        given(ledgers.tokens()).willReturn(null);
+
+        assertThrows(
+                NullPointerException.class,
+                () ->
+                        subject.hasActiveSupplyKey(
+                                true, PRETEND_TOKEN_ADDR, PRETEND_SENDER_ADDR, ledgers));
+    }
+
+    @Test
+    void throwsIfAskedToVerifyMissingAccount() {
+        given(ledgers.accounts()).willReturn(accountsLedger);
+        given(accountsLedger.exists(account)).willReturn(false);
+
+        assertFailsWith(
+                () ->
+                        subject.hasActiveKey(
+                                true, PRETEND_ACCOUNT_ADDR, PRETEND_SENDER_ADDR, ledgers),
+                INVALID_ACCOUNT_ID);
+    }
+
+    @Test
+    void testsAccountKeyIfPresent() {
+        given(txnCtx.swirldsTxnAccessor()).willReturn(accessor);
+        given(ledgers.accounts()).willReturn(accountsLedger);
+        given(accountsLedger.exists(account)).willReturn(true);
+        given(accountsLedger.get(account, AccountProperty.KEY)).willReturn(expectedKey);
+        given(accessor.getRationalizedPkToCryptoSigFn()).willReturn(pkToCryptoSigsFn);
+        given(activationTest.test(eq(expectedKey), eq(pkToCryptoSigsFn), any())).willReturn(true);
+
+        final var verdict =
+                subject.hasActiveKey(true, PRETEND_ACCOUNT_ADDR, PRETEND_SENDER_ADDR, ledgers);
+
+        assertTrue(verdict);
+    }
+
+    @Test
+    void testsAccountKeyIfPresentButInvalid() {
+        given(txnCtx.swirldsTxnAccessor()).willReturn(accessor);
+        given(ledgers.accounts()).willReturn(accountsLedger);
+        given(accountsLedger.exists(account)).willReturn(true);
+        given(accountsLedger.get(account, AccountProperty.KEY)).willReturn(expectedKey);
+        given(accessor.getRationalizedPkToCryptoSigFn()).willReturn(pkToCryptoSigsFn);
+        given(activationTest.test(eq(expectedKey), eq(pkToCryptoSigsFn), any())).willReturn(false);
+
+        final var verdict =
+                subject.hasActiveKey(true, PRETEND_ACCOUNT_ADDR, PRETEND_SENDER_ADDR, ledgers);
+
+        assertFalse(verdict);
+    }
+
+    @Test
+    void testsMissingAccountKey() {
+        given(ledgers.accounts()).willReturn(accountsLedger);
+        given(accountsLedger.exists(account)).willReturn(true);
+        given(accountsLedger.get(account, AccountProperty.KEY)).willReturn(null);
+
+        final var verdict =
+                subject.hasActiveKey(true, PRETEND_ACCOUNT_ADDR, PRETEND_SENDER_ADDR, ledgers);
+
+        assertFalse(verdict);
+    }
+
+    @Test
+    void testsCryptoKeyIfPresent() {
+        given(txnCtx.swirldsTxnAccessor()).willReturn(accessor);
+        given(accessor.getRationalizedPkToCryptoSigFn()).willReturn(pkToCryptoSigsFn);
+        given(activationTest.test(eq(expectedKey), eq(pkToCryptoSigsFn), any())).willReturn(true);
+
+        final var verdict = subject.cryptoKeyIsActive(expectedKey);
+
+        assertTrue(verdict);
+    }
+
+    @Test
+    void testsCryptoKeyIfPresentButInvalid() {
+        given(txnCtx.swirldsTxnAccessor()).willReturn(accessor);
+        given(accessor.getRationalizedPkToCryptoSigFn()).willReturn(pkToCryptoSigsFn);
+        given(activationTest.test(eq(expectedKey), eq(pkToCryptoSigsFn), any())).willReturn(false);
+
+        final var verdict = subject.cryptoKeyIsActive(expectedKey);
+
+        assertFalse(verdict);
+    }
+
+    @Test
+    void testsNullCryptoKey() {
+        final var verdict = subject.cryptoKeyIsActive(null);
+
+        assertFalse(verdict);
+    }
+
+    @Test
+    void filtersContracts() {
+        given(txnCtx.activePayer()).willReturn(payer);
+        givenSigReqCheckable(smartContract, false, null);
+
+        final var contractFlag =
+                subject.hasActiveKeyOrNoReceiverSigReq(
+                        true,
+                        EntityIdUtils.asTypedEvmAddress(smartContract),
+                        PRETEND_SENDER_ADDR,
+                        ledgers);
+
+        assertTrue(contractFlag);
+        verify(activationTest, never()).test(any(), any(), any());
+    }
+
+    private void givenSigReqCheckable(
+            final AccountID id, final boolean receiverSigRequired, @Nullable final JKey key) {
+        given(ledgers.accounts()).willReturn(accountsLedger);
+        given(accountsLedger.contains(id)).willReturn(true);
+        given(accountsLedger.get(id, IS_RECEIVER_SIG_REQUIRED)).willReturn(receiverSigRequired);
+        if (receiverSigRequired) {
+            given(accountsLedger.get(id, KEY)).willReturn(key);
+        }
+    }
+
+    @Test
+    void filtersNoSigRequired() {
+        given(txnCtx.activePayer()).willReturn(payer);
+        givenSigReqCheckable(noSigRequired, false, null);
+
+        final var noSigRequiredFlag =
+                subject.hasActiveKeyOrNoReceiverSigReq(
+                        true,
+                        EntityIdUtils.asTypedEvmAddress(noSigRequired),
+                        PRETEND_SENDER_ADDR,
+                        ledgers);
+
+        assertTrue(noSigRequiredFlag);
+        verify(activationTest, never()).test(any(), any(), any());
+    }
+
+    @Test
+    void filtersMissing() {
+        given(txnCtx.activePayer()).willReturn(payer);
+        given(ledgers.accounts()).willReturn(accountsLedger);
+
+        final var noSigRequiredFlag =
+                subject.hasActiveKeyOrNoReceiverSigReq(
+                        true,
+                        EntityIdUtils.asTypedEvmAddress(noSigRequired),
+                        PRETEND_SENDER_ADDR,
+                        ledgers);
+
+        assertTrue(noSigRequiredFlag);
+        verify(activationTest, never()).test(any(), any(), any());
+    }
+
+    @Test
+    void filtersNoSigRequiredWhenLedgersAreNotNullButAccountsLedgerIsNull() {
+        given(txnCtx.activePayer()).willReturn(payer);
+        given(ledgers.accounts()).willReturn(null);
+
+        final var noSigRequiredFlag =
+                subject.hasActiveKeyOrNoReceiverSigReq(
+                        true,
+                        EntityIdUtils.asTypedEvmAddress(noSigRequired),
+                        PRETEND_SENDER_ADDR,
+                        ledgers);
+
+        assertTrue(noSigRequiredFlag);
+        verify(activationTest, never()).test(any(), any(), any());
+    }
+
+    @Test
+    void testsWhenReceiverSigIsRequired() {
+        givenAccessorInCtx();
+        givenSigReqCheckable(sigRequired, true, expectedKey);
+        given(accessor.getRationalizedPkToCryptoSigFn()).willReturn(pkToCryptoSigsFn);
+
+        given(activationTest.test(eq(expectedKey), eq(pkToCryptoSigsFn), any())).willReturn(true);
+
+        boolean sigRequiredFlag =
+                subject.hasActiveKeyOrNoReceiverSigReq(
+                        true,
+                        EntityIdUtils.asTypedEvmAddress(sigRequired),
+                        PRETEND_SENDER_ADDR,
+                        ledgers);
+
+        assertTrue(sigRequiredFlag);
+    }
+
+    @Test
+    void filtersPayerSinceSigIsGuaranteed() {
+        given(txnCtx.activePayer()).willReturn(payer);
+
+        boolean payerFlag =
+                subject.hasActiveKeyOrNoReceiverSigReq(
+                        true, EntityIdUtils.asTypedEvmAddress(payer), PRETEND_SENDER_ADDR, ledgers);
+
+        assertTrue(payerFlag);
+
+        verify(activationTest, never()).test(any(), any(), any());
+    }
+
+    @Test
+    void createsValidityTestThatOnlyAcceptsContractIdKeyWhenBothRecipientAndContractAreActive() {
+        final var uncontrolledId = EntityIdUtils.contractIdFromEvmAddress(Address.BLS12_G1ADD);
+        final var controlledId = EntityIdUtils.contractIdFromEvmAddress(PRETEND_SENDER_ADDR);
+        final var controlledKey = new JContractIDKey(controlledId);
+        final var uncontrolledKey = new JContractIDKey(uncontrolledId);
+
+        given(aliases.currentAddress(controlledId)).willReturn(PRETEND_SENDER_ADDR);
+        given(aliases.currentAddress(uncontrolledId)).willReturn(PRETEND_TOKEN_ADDR);
+
+        final var validityTestForNormalCall =
+                subject.validityTestFor(false, PRETEND_SENDER_ADDR, aliases);
+        final var validityTestForDelegateCall =
+                subject.validityTestFor(true, PRETEND_SENDER_ADDR, aliases);
+
+        assertTrue(validityTestForNormalCall.test(controlledKey, INVALID_MISSING_SIG));
+        assertFalse(validityTestForDelegateCall.test(controlledKey, INVALID_MISSING_SIG));
+        assertFalse(validityTestForNormalCall.test(uncontrolledKey, INVALID_MISSING_SIG));
+        assertFalse(validityTestForDelegateCall.test(uncontrolledKey, INVALID_MISSING_SIG));
+    }
+
+    @Test
+    void testsAccountAddressAndActiveContractIfEquals() {
+        given(ledgers.accounts()).willReturn(accountsLedger);
+        given(accountsLedger.exists(smartContract)).willReturn(true);
+
+        final var verdict =
+                subject.hasActiveKey(
+                        true,
+                        EntityIdUtils.asTypedEvmAddress(smartContract),
+                        EntityIdUtils.asTypedEvmAddress(smartContract),
+                        ledgers);
+
+        assertTrue(verdict);
+    }
+
+    @Test
+    void createsValidityTestThatAcceptsContractKeysWithJustRecipientActive() {
+        final var uncontrolledId = EntityIdUtils.contractIdFromEvmAddress(Address.BLS12_G1ADD);
+        final var controlledId = EntityIdUtils.contractIdFromEvmAddress(PRETEND_SENDER_ADDR);
+        final var controlledKey = new JDelegatableContractIDKey(controlledId);
+        final var uncontrolledKey = new JContractIDKey(uncontrolledId);
+        final var otherControlledKey =
+                new JContractAliasKey(0, 0, Address.BLS12_G1ADD.toArrayUnsafe());
+        final var otherControlledId = otherControlledKey.getContractID();
+        final var otherControlDelegateKey =
+                new JDelegatableContractAliasKey(0, 0, Address.BLS12_G1ADD.toArrayUnsafe());
+
+        given(aliases.currentAddress(controlledId)).willReturn(PRETEND_SENDER_ADDR);
+        given(aliases.currentAddress(uncontrolledId)).willReturn(PRETEND_TOKEN_ADDR);
+        given(aliases.currentAddress(otherControlledId)).willReturn(PRETEND_SENDER_ADDR);
+
+        final var validityTestForNormalCall =
+                subject.validityTestFor(false, PRETEND_SENDER_ADDR, aliases);
+        final var validityTestForDelegateCall =
+                subject.validityTestFor(true, PRETEND_SENDER_ADDR, aliases);
+
+        assertTrue(validityTestForNormalCall.test(controlledKey, INVALID_MISSING_SIG));
+        assertTrue(validityTestForDelegateCall.test(controlledKey, INVALID_MISSING_SIG));
+        assertFalse(validityTestForNormalCall.test(uncontrolledKey, INVALID_MISSING_SIG));
+        assertFalse(validityTestForDelegateCall.test(uncontrolledKey, INVALID_MISSING_SIG));
+        assertTrue(validityTestForNormalCall.test(otherControlledKey, INVALID_MISSING_SIG));
+        assertFalse(validityTestForDelegateCall.test(otherControlledKey, INVALID_MISSING_SIG));
+        assertTrue(validityTestForDelegateCall.test(otherControlDelegateKey, INVALID_MISSING_SIG));
+    }
+
+    @Test
+    void validityTestsRelyOnCryptoValidityOtherwise() {
+        final var mockSig = mock(TransactionSignature.class);
+        final var mockKey = new JEd25519Key("01234567890123456789012345678901".getBytes());
+        given(cryptoValidity.test(mockKey, mockSig)).willReturn(true);
+
+        final var validityTestForNormalCall =
+                subject.validityTestFor(false, PRETEND_SENDER_ADDR, aliases);
+        final var validityTestForDelegateCall =
+                subject.validityTestFor(true, PRETEND_SENDER_ADDR, aliases);
+
+        assertTrue(validityTestForNormalCall.test(mockKey, mockSig));
+        assertTrue(validityTestForDelegateCall.test(mockKey, mockSig));
+    }
+
+    private void givenAccessorInCtx() {
+        given(txnCtx.swirldsTxnAccessor()).willReturn(accessor);
+        given(txnCtx.activePayer()).willReturn(payer);
+    }
 }

--- a/hedera-node/src/test/java/com/hedera/services/contracts/sources/TxnAwareEvmSigsVerifierTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/contracts/sources/TxnAwareEvmSigsVerifierTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2020-2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hedera.services.contracts.sources;
 
 /*


### PR DESCRIPTION
Signed-off-by: Nana-EC <nana@swirldslabs.com>

**Description**:
PR #3451 introduced a suite of improvements including AOSP reformatting of code.
Due to the complexity of code files it was not possible to run in advance, this has resulted in PRs including the new formatting and making reviews more challenging.

This PR applied the AOSP style reformat to all java file under the following dirs and is aimed to help streamline precompile related PRs
- `hedera-node/src/main/java/com/hedera/services/contracts`
- `hedera-node/src/test/java/com/hedera/services/contracts`

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
I applied the base styling and optimized imports.

All changes are formatting only and include no product code changes.
Existing PRs will benefit from rebasing on top of this

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
