### PR TITLE
Allow staking to contract accounts, only return `stakePeriodStart` if staking to node

### DIFF
--- a/hedera-node/src/main/java/com/hedera/services/context/primitives/StateView.java
+++ b/hedera-node/src/main/java/com/hedera/services/context/primitives/StateView.java
@@ -1,11 +1,6 @@
-package com.hedera.services.context.primitives;
-
-/*-
- * ‌
- * Hedera Services Node
- * ​
- * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
- * ​
+/*
+ * Copyright (C) 2020-2022 Hedera Hashgraph, LLC
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -17,8 +12,25 @@ package com.hedera.services.context.primitives;
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- * ‍
  */
+package com.hedera.services.context.primitives;
+
+import static com.hedera.services.context.properties.StaticPropertiesHolder.STATIC_PROPERTIES;
+import static com.hedera.services.ledger.accounts.AliasManager.tryAddressRecovery;
+import static com.hedera.services.state.submerkle.EntityId.MISSING_ENTITY_ID;
+import static com.hedera.services.store.models.Id.MISSING_ID;
+import static com.hedera.services.store.schedule.ScheduleStore.MISSING_SCHEDULE;
+import static com.hedera.services.txns.crypto.helpers.AllowanceHelpers.getCryptoGrantedAllowancesList;
+import static com.hedera.services.txns.crypto.helpers.AllowanceHelpers.getFungibleGrantedTokenAllowancesList;
+import static com.hedera.services.txns.crypto.helpers.AllowanceHelpers.getNftGrantedAllowancesList;
+import static com.hedera.services.utils.EntityIdUtils.asAccount;
+import static com.hedera.services.utils.EntityIdUtils.asHexedEvmAddress;
+import static com.hedera.services.utils.EntityIdUtils.readableId;
+import static com.hedera.services.utils.EntityIdUtils.unaliased;
+import static com.hedera.services.utils.EntityNum.fromAccountId;
+import static com.hedera.services.utils.MiscUtils.asKeyUnchecked;
+import static com.swirlds.common.utility.CommonUtils.hex;
+import static java.util.Collections.unmodifiableMap;
 
 import com.google.protobuf.ByteString;
 import com.hedera.services.config.NetworkInfo;
@@ -89,733 +101,738 @@ import com.swirlds.merkle.map.MerkleMap;
 import com.swirlds.virtualmap.VirtualKey;
 import com.swirlds.virtualmap.VirtualMap;
 import com.swirlds.virtualmap.VirtualValue;
-import org.apache.commons.lang3.tuple.Pair;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.apache.tuweni.bytes.Bytes;
-
-import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.function.BiConsumer;
-
-import static com.hedera.services.context.properties.StaticPropertiesHolder.STATIC_PROPERTIES;
-import static com.hedera.services.ledger.accounts.AliasManager.tryAddressRecovery;
-import static com.hedera.services.state.submerkle.EntityId.MISSING_ENTITY_ID;
-import static com.hedera.services.store.models.Id.MISSING_ID;
-import static com.hedera.services.store.schedule.ScheduleStore.MISSING_SCHEDULE;
-import static com.hedera.services.txns.crypto.helpers.AllowanceHelpers.getCryptoGrantedAllowancesList;
-import static com.hedera.services.txns.crypto.helpers.AllowanceHelpers.getFungibleGrantedTokenAllowancesList;
-import static com.hedera.services.txns.crypto.helpers.AllowanceHelpers.getNftGrantedAllowancesList;
-import static com.hedera.services.utils.EntityIdUtils.asAccount;
-import static com.hedera.services.utils.EntityIdUtils.asHexedEvmAddress;
-import static com.hedera.services.utils.EntityIdUtils.readableId;
-import static com.hedera.services.utils.EntityIdUtils.unaliased;
-import static com.hedera.services.utils.EntityNum.fromAccountId;
-import static com.hedera.services.utils.MiscUtils.asKeyUnchecked;
-import static com.swirlds.common.utility.CommonUtils.hex;
-import static java.util.Collections.unmodifiableMap;
+import javax.annotation.Nullable;
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.tuweni.bytes.Bytes;
 
 public class StateView {
-	private static final Logger log = LogManager.getLogger(StateView.class);
-
-	/* EVM storage maps from 256-bit (32-byte) keys to 256-bit (32-byte) values */
-	public static final long BYTES_PER_EVM_KEY_VALUE_PAIR = 64L;
-	public static final AccountID WILDCARD_OWNER = AccountID.newBuilder().setAccountNum(0L).build();
-
-	static final byte[] EMPTY_BYTES = new byte[0];
-	static final MerkleMap<?, ?> EMPTY_MM = new MerkleMap<>();
-	static final VirtualMap<?, ?> EMPTY_VM = new VirtualMap<>();
-	static final MerkleNetworkContext EMPTY_CTX = new MerkleNetworkContext();
-
-	public static final JKey EMPTY_WACL = new JKeyList();
-	public static final MerkleToken REMOVED_TOKEN = new MerkleToken(
-			0L, 0L, 0, "", "",
-			false, false, MISSING_ENTITY_ID);
-	public static final StateView EMPTY_VIEW = new StateView(null, new MutableStateChildren(), null);
-
-	private final ScheduleStore scheduleStore;
-	private final StateChildren stateChildren;
-	private final NetworkInfo networkInfo;
-
-	Map<byte[], byte[]> contractBytecode;
-	Map<FileID, byte[]> fileContents;
-	Map<FileID, HFileMeta> fileAttrs;
-
-	private BackingStore<TokenID, MerkleToken> backingTokens = null;
-	private BackingStore<AccountID, MerkleAccount> backingAccounts = null;
-	private BackingStore<NftId, MerkleUniqueToken> backingNfts = null;
-	private BackingStore<Pair<AccountID, TokenID>, MerkleTokenRelStatus> backingRels = null;
-
-	public StateView(
-			@Nullable final ScheduleStore scheduleStore,
-			final StateChildren stateChildren,
-			final NetworkInfo networkInfo
-	) {
-		this.scheduleStore = scheduleStore;
-		this.stateChildren = stateChildren;
-		this.networkInfo = networkInfo;
-
-		final Map<String, byte[]> blobStore = unmodifiableMap(new FcBlobsBytesStore(this::storage));
-
-		fileContents = DataMapFactory.dataMapFrom(blobStore);
-		fileAttrs = MetadataMapFactory.metaMapFrom(blobStore);
-		contractBytecode = AddressKeyedMapFactory.bytecodeMapFrom(blobStore);
-	}
-
-	public Optional<HFileMeta> attrOf(final FileID id) {
-		return Optional.ofNullable(fileAttrs.get(id));
-	}
-
-	public Optional<byte[]> contentsOf(final FileID id) {
-		if (stateChildren == null) {
-			return Optional.empty();
-		}
-		final var specialFiles = stateChildren.specialFiles();
-		if (specialFiles.contains(id)) {
-			return Optional.ofNullable(specialFiles.get(id));
-		} else {
-			return Optional.ofNullable(fileContents.get(id));
-		}
-	}
-
-	public Optional<byte[]> bytecodeOf(final EntityNum contractId) {
-		return Optional.ofNullable(contractBytecode.get(contractId.toRawEvmAddress()));
-	}
-
-	public Optional<MerkleToken> tokenWith(final TokenID id) {
-		if (stateChildren == null) {
-			return Optional.empty();
-		}
-		return Optional.ofNullable(stateChildren.tokens().get(EntityNum.fromTokenId(id)));
-	}
-
-	public Optional<TokenInfo> infoForToken(final TokenID tokenId) {
-		if (stateChildren == null) {
-			return Optional.empty();
-		}
-		try {
-			final var tokens = stateChildren.tokens();
-			final var token = tokens.get(EntityNum.fromTokenId(tokenId));
-			if (token == null) {
-				return Optional.empty();
-			}
-			final var info = TokenInfo.newBuilder()
-					.setLedgerId(networkInfo.ledgerId())
-					.setTokenTypeValue(token.tokenType().ordinal())
-					.setSupplyTypeValue(token.supplyType().ordinal())
-					.setTokenId(tokenId)
-					.setDeleted(token.isDeleted())
-					.setSymbol(token.symbol())
-					.setName(token.name())
-					.setMemo(token.memo())
-					.setTreasury(token.treasury().toGrpcAccountId())
-					.setTotalSupply(token.totalSupply())
-					.setMaxSupply(token.maxSupply())
-					.setDecimals(token.decimals())
-					.setExpiry(Timestamp.newBuilder().setSeconds(token.expiry()));
-
-			final var adminCandidate = token.adminKey();
-			adminCandidate.ifPresent(k -> info.setAdminKey(asKeyUnchecked(k)));
-
-			final var freezeCandidate = token.freezeKey();
-			freezeCandidate.ifPresentOrElse(k -> {
-				info.setDefaultFreezeStatus(tfsFor(token.accountsAreFrozenByDefault()));
-				info.setFreezeKey(asKeyUnchecked(k));
-			}, () -> info.setDefaultFreezeStatus(TokenFreezeStatus.FreezeNotApplicable));
-
-			final var kycCandidate = token.kycKey();
-			kycCandidate.ifPresentOrElse(k -> {
-				info.setDefaultKycStatus(tksFor(token.accountsKycGrantedByDefault()));
-				info.setKycKey(asKeyUnchecked(k));
-			}, () -> info.setDefaultKycStatus(TokenKycStatus.KycNotApplicable));
-
-			final var supplyCandidate = token.supplyKey();
-			supplyCandidate.ifPresent(k -> info.setSupplyKey(asKeyUnchecked(k)));
-			final var wipeCandidate = token.wipeKey();
-			wipeCandidate.ifPresent(k -> info.setWipeKey(asKeyUnchecked(k)));
-			final var feeScheduleCandidate = token.feeScheduleKey();
-			feeScheduleCandidate.ifPresent(k -> info.setFeeScheduleKey(asKeyUnchecked(k)));
-
-			final var pauseCandidate = token.pauseKey();
-			pauseCandidate.ifPresentOrElse(k -> {
-				info.setPauseKey(asKeyUnchecked(k));
-				info.setPauseStatus(tokenPauseStatusOf(token.isPaused()));
-			}, () -> info.setPauseStatus(TokenPauseStatus.PauseNotApplicable));
-
-			if (token.hasAutoRenewAccount()) {
-				info.setAutoRenewAccount(token.autoRenewAccount().toGrpcAccountId());
-				info.setAutoRenewPeriod(Duration.newBuilder().setSeconds(token.autoRenewPeriod()));
-			}
-
-			info.addAllCustomFees(token.grpcFeeSchedule());
-
-			return Optional.of(info.build());
-		} catch (Exception unexpected) {
-			log.warn(
-					"Unexpected failure getting info for token {}!",
-					readableId(tokenId),
-					unexpected);
-			return Optional.empty();
-		}
-	}
-
-	public Optional<ConsensusTopicInfo> infoForTopic(final TopicID topicID) {
-
-		final var merkleTopic = topics().get(EntityNum.fromTopicId(topicID));
-		if (merkleTopic == null) {
-			return Optional.empty();
-		}
-
-		final var info = ConsensusTopicInfo.newBuilder();
-		if (merkleTopic.hasMemo()) {
-			info.setMemo(merkleTopic.getMemo());
-		}
-		if (merkleTopic.hasAdminKey()) {
-			info.setAdminKey(asKeyUnchecked(merkleTopic.getAdminKey()));
-		}
-		if (merkleTopic.hasSubmitKey()) {
-			info.setSubmitKey(asKeyUnchecked(merkleTopic.getSubmitKey()));
-		}
-		info.setAutoRenewPeriod(Duration.newBuilder().setSeconds(merkleTopic.getAutoRenewDurationSeconds()));
-		if (merkleTopic.hasAutoRenewAccountId()) {
-			info.setAutoRenewAccount(asAccount(merkleTopic.getAutoRenewAccountId()));
-		}
-		info.setExpirationTime(merkleTopic.getExpirationTimestamp().toGrpc());
-		info.setSequenceNumber(merkleTopic.getSequenceNumber());
-		info.setRunningHash(ByteString.copyFrom(merkleTopic.getRunningHash()));
-		info.setLedgerId(networkInfo.ledgerId());
-
-		return Optional.of(info.build());
-	}
-
-	public Optional<ScheduleInfo> infoForSchedule(final ScheduleID scheduleID) {
-		if (scheduleStore == null) {
-			return Optional.empty();
-		}
-		try {
-			final var id = scheduleStore.resolve(scheduleID);
-			if (id == MISSING_SCHEDULE) {
-				return Optional.empty();
-			}
-			final var schedule = scheduleStore.get(id);
-			final var signatories = schedule.signatories();
-			final var signatoriesList = KeyList.newBuilder();
-
-			signatories.forEach(pubKey -> signatoriesList.addKeys(grpcKeyReprOf(pubKey)));
-
-			final var info = ScheduleInfo.newBuilder()
-					.setLedgerId(networkInfo.ledgerId())
-					.setScheduleID(id)
-					.setScheduledTransactionBody(schedule.scheduledTxn())
-					.setScheduledTransactionID(schedule.scheduledTransactionId())
-					.setCreatorAccountID(schedule.schedulingAccount().toGrpcAccountId())
-					.setPayerAccountID(schedule.effectivePayer().toGrpcAccountId())
-					.setSigners(signatoriesList)
-					.setExpirationTime(Timestamp.newBuilder()
-							.setSeconds(schedule.calculatedExpirationTime().getSeconds())
-							.setNanos(schedule.calculatedExpirationTime().getNanos()))
-					.setWaitForExpiry(schedule.calculatedWaitForExpiry());
-			schedule.memo().ifPresent(info::setMemo);
-			if (schedule.isDeleted()) {
-				info.setDeletionTime(schedule.deletionTime());
-			} else if (schedule.isExecuted()) {
-				info.setExecutionTime(schedule.executionTime());
-			}
-
-			final var adminCandidate = schedule.adminKey();
-			adminCandidate.ifPresent(k -> info.setAdminKey(asKeyUnchecked(k)));
-
-			return Optional.of(info.build());
-		} catch (Exception unexpected) {
-			log.warn(
-					"Unexpected failure getting info for schedule {}!",
-					readableId(scheduleID),
-					unexpected);
-			return Optional.empty();
-		}
-	}
-
-	private Key grpcKeyReprOf(final byte[] publicKey) {
-		if (publicKey.length == KeyType.ECDSA_SECP256K1.getLength()) {
-			return Key.newBuilder().setECDSASecp256K1(ByteString.copyFrom(publicKey)).build();
-		} else {
-			return Key.newBuilder().setEd25519(ByteString.copyFrom(publicKey)).build();
-		}
-	}
-
-	public Optional<TokenNftInfo> infoForNft(final NftID target) {
-		final var currentNfts = uniqueTokens();
-		final var tokenId = EntityNum.fromTokenId(target.getTokenID());
-		final var targetKey = EntityNumPair.fromLongs(tokenId.longValue(), target.getSerialNumber());
-		if (!currentNfts.containsKey(targetKey)) {
-			return Optional.empty();
-		}
-		final var targetNft = currentNfts.get(targetKey);
-		var accountId = targetNft.getOwner().toGrpcAccountId();
-
-		if (WILDCARD_OWNER.equals(accountId)) {
-			var merkleToken = tokens().get(tokenId);
-			if (merkleToken == null) {
-				return Optional.empty();
-			}
-			accountId = merkleToken.treasury().toGrpcAccountId();
-		}
-
-		final var spenderId = targetNft.getSpender().toGrpcAccountId();
-
-		final var info = TokenNftInfo.newBuilder()
-				.setLedgerId(networkInfo.ledgerId())
-				.setNftID(target)
-				.setAccountID(accountId)
-				.setCreationTime(targetNft.getCreationTime().toGrpc())
-				.setMetadata(ByteString.copyFrom(targetNft.getMetadata()))
-				.setSpenderId(spenderId)
-				.build();
-		return Optional.of(info);
-	}
-
-	public boolean nftExists(final NftID id) {
-		final var tokenNum = EntityNum.fromTokenId(id.getTokenID());
-		final var key = EntityNumPair.fromLongs(tokenNum.longValue(), id.getSerialNumber());
-		return uniqueTokens().containsKey(key);
-	}
-
-	public Optional<TokenType> tokenType(final TokenID tokenId) {
-		try {
-			final var optionalToken = tokenWith(tokenId);
-			if (optionalToken.isEmpty()) {
-				return Optional.empty();
-			}
-			return optionalToken.map(token -> TokenType.forNumber(token.tokenType().ordinal()));
-		} catch (Exception unexpected) {
-			log.warn(
-					"Unexpected failure getting info for token {}!",
-					readableId(tokenId),
-					unexpected);
-			return Optional.empty();
-		}
-	}
-
-	public boolean tokenExists(final TokenID id) {
-		return stateChildren != null && stateChildren.tokens().containsKey(EntityNum.fromTokenId(id));
-	}
-
-	public boolean scheduleExists(final ScheduleID id) {
-		return scheduleStore != null && scheduleStore.resolve(id) != MISSING_SCHEDULE;
-	}
-
-	public Optional<FileGetInfoResponse.FileInfo> infoForFile(final FileID id) {
-		try {
-			return getFileInfo(id);
-		} catch (NullPointerException e) {
-			log.warn("View used without a properly initialized VirtualMap", e);
-			return Optional.empty();
-		}
-	}
-
-	private Optional<FileGetInfoResponse.FileInfo> getFileInfo(final FileID id) {
-		final var attr = fileAttrs.get(id);
-		if (attr == null) {
-			return Optional.empty();
-		}
-		final var info = FileGetInfoResponse.FileInfo.newBuilder()
-				.setLedgerId(networkInfo.ledgerId())
-				.setFileID(id)
-				.setMemo(attr.getMemo())
-				.setDeleted(attr.isDeleted())
-				.setExpirationTime(Timestamp.newBuilder().setSeconds(attr.getExpiry()))
-				.setSize(Optional.ofNullable(fileContents.get(id)).orElse(EMPTY_BYTES).length);
-		if (!attr.getWacl().isEmpty()) {
-			info.setKeys(MiscUtils.asKeyUnchecked(attr.getWacl()).getKeyList());
-		}
-		return Optional.of(info.build());
-	}
-
-	public Optional<CryptoGetInfoResponse.AccountInfo> infoForAccount(
-			final AccountID id,
-			final AliasManager aliasManager,
-			final int maxTokensForAccountInfo,
-			final RewardCalculator rewardCalculator
-	) {
-		final var accountNum = id.getAlias().isEmpty()
-				? fromAccountId(id)
-				: aliasManager.lookupIdBy(id.getAlias());
-		final var account = accounts().get(accountNum);
-		if (account == null) {
-			return Optional.empty();
-		}
-
-		final AccountID accountID = id.getAlias().isEmpty() ? id : accountNum.toGrpcAccountId();
-		final var info = CryptoGetInfoResponse.AccountInfo.newBuilder()
-				.setLedgerId(networkInfo.ledgerId())
-				.setKey(asKeyUnchecked(account.getAccountKey()))
-				.setAccountID(accountID)
-				.setAlias(account.getAlias())
-				.setReceiverSigRequired(account.isReceiverSigRequired())
-				.setDeleted(account.isDeleted())
-				.setMemo(account.getMemo())
-				.setAutoRenewPeriod(Duration.newBuilder().setSeconds(account.getAutoRenewSecs()))
-				.setBalance(account.getBalance())
-				.setExpirationTime(Timestamp.newBuilder().setSeconds(account.getExpiry()))
-				.setContractAccountID(getContractAccountId(account.getAccountKey(), accountID))
-				.setOwnedNfts(account.getNftsOwned())
-				.setMaxAutomaticTokenAssociations(account.getMaxAutomaticAssociations())
-				.setEthereumNonce(account.getEthereumNonce());
-		Optional.ofNullable(account.getProxy())
-				.map(EntityId::toGrpcAccountId)
-				.ifPresent(info::setProxyAccountID);
-		final var tokenRels = tokenRels(this, account, maxTokensForAccountInfo);
-		if (!tokenRels.isEmpty()) {
-			info.addAllTokenRelationships(tokenRels);
-		}
-		info.setStakingInfo(stakingInfo(account, rewardCalculator));
-
-		return Optional.of(info.build());
-	}
-
-	private String getContractAccountId(final JKey key, final AccountID accountID) {
-		// If we can recover an Ethereum EOA address from the account key, we should return that
-		final var evmAddress = tryAddressRecovery(key, EthTxSigs::recoverAddressFromPubKey);
-		if (evmAddress != null) {
-			return Bytes.wrap(evmAddress).toUnprefixedHexString();
-		} else {
-			return asHexedEvmAddress(accountID);
-		}
-	}
-
-	/**
-	 * Builds {@link StakingInfo} object for the {@link com.hederahashgraph.api.proto.java.CryptoGetInfo} and
-	 * {@link com.hederahashgraph.api.proto.java.ContractGetInfo}
-	 *
-	 * @param account
-	 * 		given account for which info is queried
-	 * @return staking info
-	 */
-	public StakingInfo stakingInfo(final MerkleAccount account, final RewardCalculator rewardCalculator) {
-		// will be updated with pending_reward in future PR
-		final var stakingInfo = StakingInfo.newBuilder()
-				.setDeclineReward(account.isDeclinedReward())
-				.setStakedToMe(account.getStakedToMe());
-
-		final var stakedNum = account.getStakedId();
-		if (stakedNum < 0) {
-			// Staked num for a node is (-nodeId -1)
-			stakingInfo.setStakedNodeId(-stakedNum - 1);
-			addNodeStakeMeta(stakingInfo, account, rewardCalculator);
-		} else if (stakedNum > 0) {
-			stakingInfo.setStakedAccountId(STATIC_PROPERTIES.scopedAccountWith(stakedNum));
-		}
-
-		return stakingInfo.build();
-	}
-
-	private void addNodeStakeMeta(
-			final StakingInfo.Builder stakingInfo,
-			final MerkleAccount account,
-			final RewardCalculator rewardCalculator
-	) {
-		final var startSecond = rewardCalculator.epochSecondAtStartOfPeriod(account.getStakePeriodStart());
-		stakingInfo.setStakePeriodStart(Timestamp.newBuilder().setSeconds(startSecond).build());
-		if (account.mayHavePendingReward()) {
-			final var info = stateChildren.stakingInfo();
-			final var nodeStakingInfo = info.get(EntityNum.fromLong(account.getStakedNodeAddressBookId()));
-			final var pendingReward = rewardCalculator.estimatePendingRewards(account, nodeStakingInfo);
-			stakingInfo.setPendingReward(pendingReward);
-		}
-	}
-
-	public Optional<GetAccountDetailsResponse.AccountDetails> accountDetails(
-			final AccountID id,
-			final AliasManager aliasManager,
-			final int maxTokensForAccountInfo
-	) {
-		final var accountNum = id.getAlias().isEmpty()
-				? fromAccountId(id)
-				: aliasManager.lookupIdBy(id.getAlias());
-		final var account = accounts().get(accountNum);
-		if (account == null) {
-			return Optional.empty();
-		}
-
-		final AccountID accountID = id.getAlias().isEmpty() ? id : accountNum.toGrpcAccountId();
-		final var details = GetAccountDetailsResponse.AccountDetails.newBuilder()
-				.setLedgerId(networkInfo.ledgerId())
-				.setKey(asKeyUnchecked(account.getAccountKey()))
-				.setAccountId(accountID)
-				.setAlias(account.getAlias())
-				.setReceiverSigRequired(account.isReceiverSigRequired())
-				.setDeleted(account.isDeleted())
-				.setMemo(account.getMemo())
-				.setAutoRenewPeriod(Duration.newBuilder().setSeconds(account.getAutoRenewSecs()))
-				.setBalance(account.getBalance())
-				.setExpirationTime(Timestamp.newBuilder().setSeconds(account.getExpiry()))
-				.setContractAccountId(asHexedEvmAddress(accountID))
-				.setOwnedNfts(account.getNftsOwned())
-				.setMaxAutomaticTokenAssociations(account.getMaxAutomaticAssociations());
-		Optional.ofNullable(account.getProxy())
-				.map(EntityId::toGrpcAccountId)
-				.ifPresent(details::setProxyAccountId);
-		final var tokenRels = tokenRels(this, account, maxTokensForAccountInfo);
-		if (!tokenRels.isEmpty()) {
-			details.addAllTokenRelationships(tokenRels);
-		}
-		setAllowancesIfAny(details, account);
-		return Optional.of(details.build());
-	}
-
-	private void setAllowancesIfAny(final GetAccountDetailsResponse.AccountDetails.Builder details,
-			final MerkleAccount account) {
-		details.addAllGrantedCryptoAllowances(getCryptoGrantedAllowancesList(account));
-		details.addAllGrantedTokenAllowances(getFungibleGrantedTokenAllowancesList(account));
-		details.addAllGrantedNftAllowances(getNftGrantedAllowancesList(account));
-	}
-
-	public long numNftsOwnedBy(AccountID target) {
-		final var account = accounts().get(fromAccountId(target));
-		if (account == null) {
-			return 0L;
-		}
-		return account.getNftsOwned();
-	}
-
-	public Optional<ContractGetInfoResponse.ContractInfo> infoForContract(
-			final ContractID id,
-			final AliasManager aliasManager,
-			final int maxTokensForAccountInfo,
-			final RewardCalculator rewardCalculator
-	) {
-		final var contractId = unaliased(id, aliasManager);
-		final var contract = contracts().get(contractId);
-		if (contract == null) {
-			return Optional.empty();
-		}
-
-		final var mirrorId = contractId.toGrpcAccountId();
-		final var storageSize = contract.getNumContractKvPairs() * BYTES_PER_EVM_KEY_VALUE_PAIR;
-		final var info = ContractGetInfoResponse.ContractInfo.newBuilder()
-				.setLedgerId(networkInfo.ledgerId())
-				.setAccountID(mirrorId)
-				.setDeleted(contract.isDeleted())
-				.setContractID(contractId.toGrpcContractID())
-				.setMemo(contract.getMemo())
-				.setStorage(storageSize)
-				.setAutoRenewPeriod(Duration.newBuilder().setSeconds(contract.getAutoRenewSecs()))
-				.setBalance(contract.getBalance())
-				.setExpirationTime(Timestamp.newBuilder().setSeconds(contract.getExpiry()))
-				.setMaxAutomaticTokenAssociations(contract.getMaxAutomaticAssociations());
-		if (contract.hasAutoRenewAccount()) {
-			info.setAutoRenewAccountId(Objects.requireNonNull(contract.getAutoRenewAccount()).toGrpcAccountId());
-		}
-		if (contract.hasAlias()) {
-			info.setContractAccountID(hex(contract.getAlias().toByteArray()));
-		} else {
-			info.setContractAccountID(asHexedEvmAddress(mirrorId));
-		}
-		final var tokenRels = tokenRels(this, contract, maxTokensForAccountInfo);
-		if (!tokenRels.isEmpty()) {
-			info.addAllTokenRelationships(tokenRels);
-		}
-
-		info.setStakingInfo(stakingInfo(contract, rewardCalculator));
-
-		try {
-			final var adminKey = JKey.mapJKey(contract.getAccountKey());
-			info.setAdminKey(adminKey);
-		} catch (Exception ignore) {
-			// Leave the admin key empty if it can't be decoded
-		}
-
-		return Optional.of(info.build());
-	}
-
-	public MerkleMap<EntityNum, MerkleTopic> topics() {
-		return stateChildren == null ? emptyMm() : stateChildren.topics();
-	}
-
-	public MerkleMap<EntityNum, MerkleAccount> accounts() {
-		return stateChildren == null ? emptyMm() : stateChildren.accounts();
-	}
-
-	public MerkleMap<EntityNum, MerkleAccount> contracts() {
-		return stateChildren == null ? emptyMm() : stateChildren.accounts();
-	}
-
-	public MerkleMap<EntityNumPair, MerkleTokenRelStatus> tokenAssociations() {
-		return stateChildren == null ? emptyMm() : stateChildren.tokenAssociations();
-	}
-
-	public MerkleMap<EntityNumPair, MerkleUniqueToken> uniqueTokens() {
-		return stateChildren == null ? emptyMm() : stateChildren.uniqueTokens();
-	}
-
-	public VirtualMap<VirtualBlobKey, VirtualBlobValue> storage() {
-		return stateChildren == null ? emptyVm() : stateChildren.storage();
-	}
-
-	public VirtualMap<ContractKey, IterableContractValue> contractStorage() {
-		return stateChildren == null ? emptyVm() : stateChildren.contractStorage();
-	}
-
-	public MerkleMap<EntityNum, MerkleToken> tokens() {
-		return stateChildren == null ? emptyMm() : stateChildren.tokens();
-	}
-
-	public BackingStore<TokenID, MerkleToken> asReadOnlyTokenStore() {
-		if (backingTokens == null) {
-			backingTokens = new BackingTokens(stateChildren::tokens);
-		}
-		return backingTokens;
-	}
-
-	public BackingStore<AccountID, MerkleAccount> asReadOnlyAccountStore() {
-		if (backingAccounts == null) {
-			backingAccounts = new BackingAccounts(stateChildren::accounts);
-		}
-		return backingAccounts;
-	}
-
-	public BackingStore<NftId, MerkleUniqueToken> asReadOnlyNftStore() {
-		if (backingNfts == null) {
-			backingNfts = new BackingNfts(stateChildren::uniqueTokens);
-		}
-		return backingNfts;
-	}
-
-	public BackingStore<Pair<AccountID, TokenID>, MerkleTokenRelStatus> asReadOnlyAssociationStore() {
-		if (backingRels == null) {
-			backingRels = new BackingTokenRels(stateChildren::tokenAssociations);
-		}
-		return backingRels;
-	}
-
-	private TokenFreezeStatus tfsFor(final boolean flag) {
-		return flag ? TokenFreezeStatus.Frozen : TokenFreezeStatus.Unfrozen;
-	}
-
-	private TokenKycStatus tksFor(final boolean flag) {
-		return flag ? TokenKycStatus.Granted : TokenKycStatus.Revoked;
-	}
-
-	private TokenPauseStatus tokenPauseStatusOf(final boolean flag) {
-		return flag ? TokenPauseStatus.Paused : TokenPauseStatus.Unpaused;
-	}
-
-	/**
-	 * Returns the most recent token relationships formed by the given account in the given view
-	 * of the state, up to maximum of {@code maxRels} relationships.
-	 *
-	 * @param view
-	 * 		a view of the world state
-	 * @param account
-	 * 		the account of interest
-	 * @param maxRels
-	 * 		the maximum token relationships to return
-	 * @return a list of the account's newest token relationships up to the given limit
-	 */
-	static List<TokenRelationship> tokenRels(
-			final StateView view,
-			final MerkleAccount account,
-			final int maxRels
-	) {
-		final List<TokenRelationship> grpcRels = new ArrayList<>();
-		var firstRel = account.getLatestAssociation();
-		doBoundedIteration(view.tokenAssociations(), view.tokens(), firstRel, maxRels, (token, rel) -> {
-			final var grpcRel = new RawTokenRelationship(
-					rel.getBalance(),
-					STATIC_PROPERTIES.getShard(),
-					STATIC_PROPERTIES.getRealm(),
-					rel.getRelatedTokenNum(),
-					rel.isFrozen(),
-					rel.isKycGranted(),
-					rel.isAutomaticAssociation()
-			).asGrpcFor(token);
-			grpcRels.add(grpcRel);
-		});
-
-		return grpcRels;
-	}
-
-	/**
-	 * Given tokens and account-token relationships, iterates the "map-value-linked-list" of token relationships
-	 * for the given account, exposing its token relationships to the given Visitor in reverse chronological order.
-	 *
-	 * @param tokenRels
-	 * 		the source of token relationship information
-	 * @param tokens
-	 * 		the source of token information
-	 * @param account
-	 * 		the account of interest
-	 * @param visitor
-	 * 		a consumer of token and token relationship information
-	 */
-	public static void doBoundedIteration(
-			final MerkleMap<EntityNumPair, MerkleTokenRelStatus> tokenRels,
-			final MerkleMap<EntityNum, MerkleToken> tokens,
-			final MerkleAccount account,
-			final BiConsumer<MerkleToken, MerkleTokenRelStatus> visitor
-	) {
-		final var maxRels = account.getNumAssociations();
-		final var firstRel = account.getLatestAssociation();
-		doBoundedIteration(tokenRels, tokens, firstRel, maxRels, visitor);
-	}
-
-	/**
-	 * Given tokens and account-token relationships, iterates the "map-value-linked-list" of token relationships
-	 * starting from a given key exposing token relationships to the given Visitor in reverse chronological order.
-	 * Terminates when there are no more reachable relationships, or the maximum number have been visited.
-	 *
-	 * @param tokenRels
-	 * 		the source of token relationship information
-	 * @param tokens
-	 * 		the source of token information
-	 * @param firstRel
-	 * 		the first relationship of interest
-	 * @param maxRels
-	 * 		the maximum number of relationships to visit
-	 * @param visitor
-	 * 		a consumer of token and token relationship information
-	 */
-	public static void doBoundedIteration(
-			final MerkleMap<EntityNumPair, MerkleTokenRelStatus> tokenRels,
-			final MerkleMap<EntityNum, MerkleToken> tokens,
-			final EntityNumPair firstRel,
-			final int maxRels,
-			final BiConsumer<MerkleToken, MerkleTokenRelStatus> visitor
-	) {
-		final var accountNum = firstRel.getHiOrderAsLong();
-		var tokenNum = firstRel.getLowOrderAsLong();
-		var key = firstRel;
-		var counter = 0;
-		while (tokenNum != MISSING_ID.num() && counter < maxRels) {
-			final var rel = tokenRels.get(key);
-			final var token = tokens.getOrDefault(key.getLowOrderAsNum(), REMOVED_TOKEN);
-			visitor.accept(token, rel);
-			tokenNum = rel.nextKey();
-			key = EntityNumPair.fromLongs(accountNum, tokenNum);
-			counter++;
-		}
-	}
-
-	@SuppressWarnings("unchecked")
-	private static <K, V extends MerkleNode & Keyed<K>> MerkleMap<K, V> emptyMm() {
-		return (MerkleMap<K, V>) EMPTY_MM;
-	}
-
-	@SuppressWarnings("unchecked")
-	private static <K extends VirtualKey<K>, V extends VirtualValue> VirtualMap<K, V> emptyVm() {
-		return (VirtualMap<K, V>) EMPTY_VM;
-	}
-
-	/* --- used only in unit tests ---*/
-	public MerkleNetworkContext networkCtx() {
-		return stateChildren == null ? EMPTY_CTX : stateChildren.networkCtx();
-	}
-
-	public MerkleMap<EntityNum, MerkleStakingInfo> stakingInfo() {
-		return stateChildren == null ? emptyMm() : stateChildren.stakingInfo();
-	}
+    private static final Logger log = LogManager.getLogger(StateView.class);
+
+    /* EVM storage maps from 256-bit (32-byte) keys to 256-bit (32-byte) values */
+    public static final long BYTES_PER_EVM_KEY_VALUE_PAIR = 64L;
+    public static final AccountID WILDCARD_OWNER = AccountID.newBuilder().setAccountNum(0L).build();
+
+    static final byte[] EMPTY_BYTES = new byte[0];
+    static final MerkleMap<?, ?> EMPTY_MM = new MerkleMap<>();
+    static final VirtualMap<?, ?> EMPTY_VM = new VirtualMap<>();
+    static final MerkleNetworkContext EMPTY_CTX = new MerkleNetworkContext();
+
+    public static final JKey EMPTY_WACL = new JKeyList();
+    public static final MerkleToken REMOVED_TOKEN =
+            new MerkleToken(0L, 0L, 0, "", "", false, false, MISSING_ENTITY_ID);
+    public static final StateView EMPTY_VIEW =
+            new StateView(null, new MutableStateChildren(), null);
+
+    private final ScheduleStore scheduleStore;
+    private final StateChildren stateChildren;
+    private final NetworkInfo networkInfo;
+
+    Map<byte[], byte[]> contractBytecode;
+    Map<FileID, byte[]> fileContents;
+    Map<FileID, HFileMeta> fileAttrs;
+
+    private BackingStore<TokenID, MerkleToken> backingTokens = null;
+    private BackingStore<AccountID, MerkleAccount> backingAccounts = null;
+    private BackingStore<NftId, MerkleUniqueToken> backingNfts = null;
+    private BackingStore<Pair<AccountID, TokenID>, MerkleTokenRelStatus> backingRels = null;
+
+    public StateView(
+            @Nullable final ScheduleStore scheduleStore,
+            final StateChildren stateChildren,
+            final NetworkInfo networkInfo) {
+        this.scheduleStore = scheduleStore;
+        this.stateChildren = stateChildren;
+        this.networkInfo = networkInfo;
+
+        final Map<String, byte[]> blobStore = unmodifiableMap(new FcBlobsBytesStore(this::storage));
+
+        fileContents = DataMapFactory.dataMapFrom(blobStore);
+        fileAttrs = MetadataMapFactory.metaMapFrom(blobStore);
+        contractBytecode = AddressKeyedMapFactory.bytecodeMapFrom(blobStore);
+    }
+
+    public Optional<HFileMeta> attrOf(final FileID id) {
+        return Optional.ofNullable(fileAttrs.get(id));
+    }
+
+    public Optional<byte[]> contentsOf(final FileID id) {
+        if (stateChildren == null) {
+            return Optional.empty();
+        }
+        final var specialFiles = stateChildren.specialFiles();
+        if (specialFiles.contains(id)) {
+            return Optional.ofNullable(specialFiles.get(id));
+        } else {
+            return Optional.ofNullable(fileContents.get(id));
+        }
+    }
+
+    public Optional<byte[]> bytecodeOf(final EntityNum contractId) {
+        return Optional.ofNullable(contractBytecode.get(contractId.toRawEvmAddress()));
+    }
+
+    public Optional<MerkleToken> tokenWith(final TokenID id) {
+        if (stateChildren == null) {
+            return Optional.empty();
+        }
+        return Optional.ofNullable(stateChildren.tokens().get(EntityNum.fromTokenId(id)));
+    }
+
+    public Optional<TokenInfo> infoForToken(final TokenID tokenId) {
+        if (stateChildren == null) {
+            return Optional.empty();
+        }
+        try {
+            final var tokens = stateChildren.tokens();
+            final var token = tokens.get(EntityNum.fromTokenId(tokenId));
+            if (token == null) {
+                return Optional.empty();
+            }
+            final var info =
+                    TokenInfo.newBuilder()
+                            .setLedgerId(networkInfo.ledgerId())
+                            .setTokenTypeValue(token.tokenType().ordinal())
+                            .setSupplyTypeValue(token.supplyType().ordinal())
+                            .setTokenId(tokenId)
+                            .setDeleted(token.isDeleted())
+                            .setSymbol(token.symbol())
+                            .setName(token.name())
+                            .setMemo(token.memo())
+                            .setTreasury(token.treasury().toGrpcAccountId())
+                            .setTotalSupply(token.totalSupply())
+                            .setMaxSupply(token.maxSupply())
+                            .setDecimals(token.decimals())
+                            .setExpiry(Timestamp.newBuilder().setSeconds(token.expiry()));
+
+            final var adminCandidate = token.adminKey();
+            adminCandidate.ifPresent(k -> info.setAdminKey(asKeyUnchecked(k)));
+
+            final var freezeCandidate = token.freezeKey();
+            freezeCandidate.ifPresentOrElse(
+                    k -> {
+                        info.setDefaultFreezeStatus(tfsFor(token.accountsAreFrozenByDefault()));
+                        info.setFreezeKey(asKeyUnchecked(k));
+                    },
+                    () -> info.setDefaultFreezeStatus(TokenFreezeStatus.FreezeNotApplicable));
+
+            final var kycCandidate = token.kycKey();
+            kycCandidate.ifPresentOrElse(
+                    k -> {
+                        info.setDefaultKycStatus(tksFor(token.accountsKycGrantedByDefault()));
+                        info.setKycKey(asKeyUnchecked(k));
+                    },
+                    () -> info.setDefaultKycStatus(TokenKycStatus.KycNotApplicable));
+
+            final var supplyCandidate = token.supplyKey();
+            supplyCandidate.ifPresent(k -> info.setSupplyKey(asKeyUnchecked(k)));
+            final var wipeCandidate = token.wipeKey();
+            wipeCandidate.ifPresent(k -> info.setWipeKey(asKeyUnchecked(k)));
+            final var feeScheduleCandidate = token.feeScheduleKey();
+            feeScheduleCandidate.ifPresent(k -> info.setFeeScheduleKey(asKeyUnchecked(k)));
+
+            final var pauseCandidate = token.pauseKey();
+            pauseCandidate.ifPresentOrElse(
+                    k -> {
+                        info.setPauseKey(asKeyUnchecked(k));
+                        info.setPauseStatus(tokenPauseStatusOf(token.isPaused()));
+                    },
+                    () -> info.setPauseStatus(TokenPauseStatus.PauseNotApplicable));
+
+            if (token.hasAutoRenewAccount()) {
+                info.setAutoRenewAccount(token.autoRenewAccount().toGrpcAccountId());
+                info.setAutoRenewPeriod(Duration.newBuilder().setSeconds(token.autoRenewPeriod()));
+            }
+
+            info.addAllCustomFees(token.grpcFeeSchedule());
+
+            return Optional.of(info.build());
+        } catch (Exception unexpected) {
+            log.warn(
+                    "Unexpected failure getting info for token {}!",
+                    readableId(tokenId),
+                    unexpected);
+            return Optional.empty();
+        }
+    }
+
+    public Optional<ConsensusTopicInfo> infoForTopic(final TopicID topicID) {
+
+        final var merkleTopic = topics().get(EntityNum.fromTopicId(topicID));
+        if (merkleTopic == null) {
+            return Optional.empty();
+        }
+
+        final var info = ConsensusTopicInfo.newBuilder();
+        if (merkleTopic.hasMemo()) {
+            info.setMemo(merkleTopic.getMemo());
+        }
+        if (merkleTopic.hasAdminKey()) {
+            info.setAdminKey(asKeyUnchecked(merkleTopic.getAdminKey()));
+        }
+        if (merkleTopic.hasSubmitKey()) {
+            info.setSubmitKey(asKeyUnchecked(merkleTopic.getSubmitKey()));
+        }
+        info.setAutoRenewPeriod(
+                Duration.newBuilder().setSeconds(merkleTopic.getAutoRenewDurationSeconds()));
+        if (merkleTopic.hasAutoRenewAccountId()) {
+            info.setAutoRenewAccount(asAccount(merkleTopic.getAutoRenewAccountId()));
+        }
+        info.setExpirationTime(merkleTopic.getExpirationTimestamp().toGrpc());
+        info.setSequenceNumber(merkleTopic.getSequenceNumber());
+        info.setRunningHash(ByteString.copyFrom(merkleTopic.getRunningHash()));
+        info.setLedgerId(networkInfo.ledgerId());
+
+        return Optional.of(info.build());
+    }
+
+    public Optional<ScheduleInfo> infoForSchedule(final ScheduleID scheduleID) {
+        if (scheduleStore == null) {
+            return Optional.empty();
+        }
+        try {
+            final var id = scheduleStore.resolve(scheduleID);
+            if (id == MISSING_SCHEDULE) {
+                return Optional.empty();
+            }
+            final var schedule = scheduleStore.get(id);
+            final var signatories = schedule.signatories();
+            final var signatoriesList = KeyList.newBuilder();
+
+            signatories.forEach(pubKey -> signatoriesList.addKeys(grpcKeyReprOf(pubKey)));
+
+            final var info =
+                    ScheduleInfo.newBuilder()
+                            .setLedgerId(networkInfo.ledgerId())
+                            .setScheduleID(id)
+                            .setScheduledTransactionBody(schedule.scheduledTxn())
+                            .setScheduledTransactionID(schedule.scheduledTransactionId())
+                            .setCreatorAccountID(schedule.schedulingAccount().toGrpcAccountId())
+                            .setPayerAccountID(schedule.effectivePayer().toGrpcAccountId())
+                            .setSigners(signatoriesList)
+                            .setExpirationTime(
+                                    Timestamp.newBuilder()
+                                            .setSeconds(
+                                                    schedule.calculatedExpirationTime()
+                                                            .getSeconds())
+                                            .setNanos(
+                                                    schedule.calculatedExpirationTime().getNanos()))
+                            .setWaitForExpiry(schedule.calculatedWaitForExpiry());
+            schedule.memo().ifPresent(info::setMemo);
+            if (schedule.isDeleted()) {
+                info.setDeletionTime(schedule.deletionTime());
+            } else if (schedule.isExecuted()) {
+                info.setExecutionTime(schedule.executionTime());
+            }
+
+            final var adminCandidate = schedule.adminKey();
+            adminCandidate.ifPresent(k -> info.setAdminKey(asKeyUnchecked(k)));
+
+            return Optional.of(info.build());
+        } catch (Exception unexpected) {
+            log.warn(
+                    "Unexpected failure getting info for schedule {}!",
+                    readableId(scheduleID),
+                    unexpected);
+            return Optional.empty();
+        }
+    }
+
+    private Key grpcKeyReprOf(final byte[] publicKey) {
+        if (publicKey.length == KeyType.ECDSA_SECP256K1.getLength()) {
+            return Key.newBuilder().setECDSASecp256K1(ByteString.copyFrom(publicKey)).build();
+        } else {
+            return Key.newBuilder().setEd25519(ByteString.copyFrom(publicKey)).build();
+        }
+    }
+
+    public Optional<TokenNftInfo> infoForNft(final NftID target) {
+        final var currentNfts = uniqueTokens();
+        final var tokenId = EntityNum.fromTokenId(target.getTokenID());
+        final var targetKey =
+                EntityNumPair.fromLongs(tokenId.longValue(), target.getSerialNumber());
+        if (!currentNfts.containsKey(targetKey)) {
+            return Optional.empty();
+        }
+        final var targetNft = currentNfts.get(targetKey);
+        var accountId = targetNft.getOwner().toGrpcAccountId();
+
+        if (WILDCARD_OWNER.equals(accountId)) {
+            var merkleToken = tokens().get(tokenId);
+            if (merkleToken == null) {
+                return Optional.empty();
+            }
+            accountId = merkleToken.treasury().toGrpcAccountId();
+        }
+
+        final var spenderId = targetNft.getSpender().toGrpcAccountId();
+
+        final var info =
+                TokenNftInfo.newBuilder()
+                        .setLedgerId(networkInfo.ledgerId())
+                        .setNftID(target)
+                        .setAccountID(accountId)
+                        .setCreationTime(targetNft.getCreationTime().toGrpc())
+                        .setMetadata(ByteString.copyFrom(targetNft.getMetadata()))
+                        .setSpenderId(spenderId)
+                        .build();
+        return Optional.of(info);
+    }
+
+    public boolean nftExists(final NftID id) {
+        final var tokenNum = EntityNum.fromTokenId(id.getTokenID());
+        final var key = EntityNumPair.fromLongs(tokenNum.longValue(), id.getSerialNumber());
+        return uniqueTokens().containsKey(key);
+    }
+
+    public Optional<TokenType> tokenType(final TokenID tokenId) {
+        try {
+            final var optionalToken = tokenWith(tokenId);
+            if (optionalToken.isEmpty()) {
+                return Optional.empty();
+            }
+            return optionalToken.map(token -> TokenType.forNumber(token.tokenType().ordinal()));
+        } catch (Exception unexpected) {
+            log.warn(
+                    "Unexpected failure getting info for token {}!",
+                    readableId(tokenId),
+                    unexpected);
+            return Optional.empty();
+        }
+    }
+
+    public boolean tokenExists(final TokenID id) {
+        return stateChildren != null
+                && stateChildren.tokens().containsKey(EntityNum.fromTokenId(id));
+    }
+
+    public boolean scheduleExists(final ScheduleID id) {
+        return scheduleStore != null && scheduleStore.resolve(id) != MISSING_SCHEDULE;
+    }
+
+    public Optional<FileGetInfoResponse.FileInfo> infoForFile(final FileID id) {
+        try {
+            return getFileInfo(id);
+        } catch (NullPointerException e) {
+            log.warn("View used without a properly initialized VirtualMap", e);
+            return Optional.empty();
+        }
+    }
+
+    private Optional<FileGetInfoResponse.FileInfo> getFileInfo(final FileID id) {
+        final var attr = fileAttrs.get(id);
+        if (attr == null) {
+            return Optional.empty();
+        }
+        final var info =
+                FileGetInfoResponse.FileInfo.newBuilder()
+                        .setLedgerId(networkInfo.ledgerId())
+                        .setFileID(id)
+                        .setMemo(attr.getMemo())
+                        .setDeleted(attr.isDeleted())
+                        .setExpirationTime(Timestamp.newBuilder().setSeconds(attr.getExpiry()))
+                        .setSize(
+                                Optional.ofNullable(fileContents.get(id))
+                                        .orElse(EMPTY_BYTES)
+                                        .length);
+        if (!attr.getWacl().isEmpty()) {
+            info.setKeys(MiscUtils.asKeyUnchecked(attr.getWacl()).getKeyList());
+        }
+        return Optional.of(info.build());
+    }
+
+    public Optional<CryptoGetInfoResponse.AccountInfo> infoForAccount(
+            final AccountID id,
+            final AliasManager aliasManager,
+            final int maxTokensForAccountInfo,
+            final RewardCalculator rewardCalculator) {
+        final var accountNum =
+                id.getAlias().isEmpty()
+                        ? fromAccountId(id)
+                        : aliasManager.lookupIdBy(id.getAlias());
+        final var account = accounts().get(accountNum);
+        if (account == null) {
+            return Optional.empty();
+        }
+
+        final AccountID accountID = id.getAlias().isEmpty() ? id : accountNum.toGrpcAccountId();
+        final var info =
+                CryptoGetInfoResponse.AccountInfo.newBuilder()
+                        .setLedgerId(networkInfo.ledgerId())
+                        .setKey(asKeyUnchecked(account.getAccountKey()))
+                        .setAccountID(accountID)
+                        .setAlias(account.getAlias())
+                        .setReceiverSigRequired(account.isReceiverSigRequired())
+                        .setDeleted(account.isDeleted())
+                        .setMemo(account.getMemo())
+                        .setAutoRenewPeriod(
+                                Duration.newBuilder().setSeconds(account.getAutoRenewSecs()))
+                        .setBalance(account.getBalance())
+                        .setExpirationTime(Timestamp.newBuilder().setSeconds(account.getExpiry()))
+                        .setContractAccountID(
+                                getContractAccountId(account.getAccountKey(), accountID))
+                        .setOwnedNfts(account.getNftsOwned())
+                        .setMaxAutomaticTokenAssociations(account.getMaxAutomaticAssociations())
+                        .setEthereumNonce(account.getEthereumNonce());
+        Optional.ofNullable(account.getProxy())
+                .map(EntityId::toGrpcAccountId)
+                .ifPresent(info::setProxyAccountID);
+        final var tokenRels = tokenRels(this, account, maxTokensForAccountInfo);
+        if (!tokenRels.isEmpty()) {
+            info.addAllTokenRelationships(tokenRels);
+        }
+        info.setStakingInfo(stakingInfo(account, rewardCalculator));
+
+        return Optional.of(info.build());
+    }
+
+    private String getContractAccountId(final JKey key, final AccountID accountID) {
+        // If we can recover an Ethereum EOA address from the account key, we should return that
+        final var evmAddress = tryAddressRecovery(key, EthTxSigs::recoverAddressFromPubKey);
+        if (evmAddress != null) {
+            return Bytes.wrap(evmAddress).toUnprefixedHexString();
+        } else {
+            return asHexedEvmAddress(accountID);
+        }
+    }
+
+    /**
+     * Builds {@link StakingInfo} object for the {@link
+     * com.hederahashgraph.api.proto.java.CryptoGetInfo} and {@link
+     * com.hederahashgraph.api.proto.java.ContractGetInfo}
+     *
+     * @param account given account for which info is queried
+     * @return staking info
+     */
+    public StakingInfo stakingInfo(
+            final MerkleAccount account, final RewardCalculator rewardCalculator) {
+        // will be updated with pending_reward in future PR
+        final var stakingInfo =
+                StakingInfo.newBuilder()
+                        .setDeclineReward(account.isDeclinedReward())
+                        .setStakedToMe(account.getStakedToMe());
+
+        final var stakedNum = account.getStakedId();
+        if (stakedNum < 0) {
+            // Staked num for a node is (-nodeId -1)
+            stakingInfo.setStakedNodeId(-stakedNum - 1);
+            addNodeStakeMeta(stakingInfo, account, rewardCalculator);
+        } else if (stakedNum > 0) {
+            stakingInfo.setStakedAccountId(STATIC_PROPERTIES.scopedAccountWith(stakedNum));
+        }
+
+        return stakingInfo.build();
+    }
+
+    private void addNodeStakeMeta(
+            final StakingInfo.Builder stakingInfo,
+            final MerkleAccount account,
+            final RewardCalculator rewardCalculator) {
+        final var startSecond =
+                rewardCalculator.epochSecondAtStartOfPeriod(account.getStakePeriodStart());
+        stakingInfo.setStakePeriodStart(Timestamp.newBuilder().setSeconds(startSecond).build());
+        if (account.mayHavePendingReward()) {
+            final var info = stateChildren.stakingInfo();
+            final var nodeStakingInfo =
+                    info.get(EntityNum.fromLong(account.getStakedNodeAddressBookId()));
+            final var pendingReward =
+                    rewardCalculator.estimatePendingRewards(account, nodeStakingInfo);
+            stakingInfo.setPendingReward(pendingReward);
+        }
+    }
+
+    public Optional<GetAccountDetailsResponse.AccountDetails> accountDetails(
+            final AccountID id,
+            final AliasManager aliasManager,
+            final int maxTokensForAccountInfo) {
+        final var accountNum =
+                id.getAlias().isEmpty()
+                        ? fromAccountId(id)
+                        : aliasManager.lookupIdBy(id.getAlias());
+        final var account = accounts().get(accountNum);
+        if (account == null) {
+            return Optional.empty();
+        }
+
+        final AccountID accountID = id.getAlias().isEmpty() ? id : accountNum.toGrpcAccountId();
+        final var details =
+                GetAccountDetailsResponse.AccountDetails.newBuilder()
+                        .setLedgerId(networkInfo.ledgerId())
+                        .setKey(asKeyUnchecked(account.getAccountKey()))
+                        .setAccountId(accountID)
+                        .setAlias(account.getAlias())
+                        .setReceiverSigRequired(account.isReceiverSigRequired())
+                        .setDeleted(account.isDeleted())
+                        .setMemo(account.getMemo())
+                        .setAutoRenewPeriod(
+                                Duration.newBuilder().setSeconds(account.getAutoRenewSecs()))
+                        .setBalance(account.getBalance())
+                        .setExpirationTime(Timestamp.newBuilder().setSeconds(account.getExpiry()))
+                        .setContractAccountId(asHexedEvmAddress(accountID))
+                        .setOwnedNfts(account.getNftsOwned())
+                        .setMaxAutomaticTokenAssociations(account.getMaxAutomaticAssociations());
+        Optional.ofNullable(account.getProxy())
+                .map(EntityId::toGrpcAccountId)
+                .ifPresent(details::setProxyAccountId);
+        final var tokenRels = tokenRels(this, account, maxTokensForAccountInfo);
+        if (!tokenRels.isEmpty()) {
+            details.addAllTokenRelationships(tokenRels);
+        }
+        setAllowancesIfAny(details, account);
+        return Optional.of(details.build());
+    }
+
+    private void setAllowancesIfAny(
+            final GetAccountDetailsResponse.AccountDetails.Builder details,
+            final MerkleAccount account) {
+        details.addAllGrantedCryptoAllowances(getCryptoGrantedAllowancesList(account));
+        details.addAllGrantedTokenAllowances(getFungibleGrantedTokenAllowancesList(account));
+        details.addAllGrantedNftAllowances(getNftGrantedAllowancesList(account));
+    }
+
+    public long numNftsOwnedBy(AccountID target) {
+        final var account = accounts().get(fromAccountId(target));
+        if (account == null) {
+            return 0L;
+        }
+        return account.getNftsOwned();
+    }
+
+    public Optional<ContractGetInfoResponse.ContractInfo> infoForContract(
+            final ContractID id,
+            final AliasManager aliasManager,
+            final int maxTokensForAccountInfo,
+            final RewardCalculator rewardCalculator) {
+        final var contractId = unaliased(id, aliasManager);
+        final var contract = contracts().get(contractId);
+        if (contract == null) {
+            return Optional.empty();
+        }
+
+        final var mirrorId = contractId.toGrpcAccountId();
+        final var storageSize = contract.getNumContractKvPairs() * BYTES_PER_EVM_KEY_VALUE_PAIR;
+        final var info =
+                ContractGetInfoResponse.ContractInfo.newBuilder()
+                        .setLedgerId(networkInfo.ledgerId())
+                        .setAccountID(mirrorId)
+                        .setDeleted(contract.isDeleted())
+                        .setContractID(contractId.toGrpcContractID())
+                        .setMemo(contract.getMemo())
+                        .setStorage(storageSize)
+                        .setAutoRenewPeriod(
+                                Duration.newBuilder().setSeconds(contract.getAutoRenewSecs()))
+                        .setBalance(contract.getBalance())
+                        .setExpirationTime(Timestamp.newBuilder().setSeconds(contract.getExpiry()))
+                        .setMaxAutomaticTokenAssociations(contract.getMaxAutomaticAssociations());
+        if (contract.hasAutoRenewAccount()) {
+            info.setAutoRenewAccountId(
+                    Objects.requireNonNull(contract.getAutoRenewAccount()).toGrpcAccountId());
+        }
+        if (contract.hasAlias()) {
+            info.setContractAccountID(hex(contract.getAlias().toByteArray()));
+        } else {
+            info.setContractAccountID(asHexedEvmAddress(mirrorId));
+        }
+        final var tokenRels = tokenRels(this, contract, maxTokensForAccountInfo);
+        if (!tokenRels.isEmpty()) {
+            info.addAllTokenRelationships(tokenRels);
+        }
+
+        info.setStakingInfo(stakingInfo(contract, rewardCalculator));
+
+        try {
+            final var adminKey = JKey.mapJKey(contract.getAccountKey());
+            info.setAdminKey(adminKey);
+        } catch (Exception ignore) {
+            // Leave the admin key empty if it can't be decoded
+        }
+
+        return Optional.of(info.build());
+    }
+
+    public MerkleMap<EntityNum, MerkleTopic> topics() {
+        return stateChildren == null ? emptyMm() : stateChildren.topics();
+    }
+
+    public MerkleMap<EntityNum, MerkleAccount> accounts() {
+        return stateChildren == null ? emptyMm() : stateChildren.accounts();
+    }
+
+    public MerkleMap<EntityNum, MerkleAccount> contracts() {
+        return stateChildren == null ? emptyMm() : stateChildren.accounts();
+    }
+
+    public MerkleMap<EntityNumPair, MerkleTokenRelStatus> tokenAssociations() {
+        return stateChildren == null ? emptyMm() : stateChildren.tokenAssociations();
+    }
+
+    public MerkleMap<EntityNumPair, MerkleUniqueToken> uniqueTokens() {
+        return stateChildren == null ? emptyMm() : stateChildren.uniqueTokens();
+    }
+
+    public VirtualMap<VirtualBlobKey, VirtualBlobValue> storage() {
+        return stateChildren == null ? emptyVm() : stateChildren.storage();
+    }
+
+    public VirtualMap<ContractKey, IterableContractValue> contractStorage() {
+        return stateChildren == null ? emptyVm() : stateChildren.contractStorage();
+    }
+
+    public MerkleMap<EntityNum, MerkleToken> tokens() {
+        return stateChildren == null ? emptyMm() : stateChildren.tokens();
+    }
+
+    public BackingStore<TokenID, MerkleToken> asReadOnlyTokenStore() {
+        if (backingTokens == null) {
+            backingTokens = new BackingTokens(stateChildren::tokens);
+        }
+        return backingTokens;
+    }
+
+    public BackingStore<AccountID, MerkleAccount> asReadOnlyAccountStore() {
+        if (backingAccounts == null) {
+            backingAccounts = new BackingAccounts(stateChildren::accounts);
+        }
+        return backingAccounts;
+    }
+
+    public BackingStore<NftId, MerkleUniqueToken> asReadOnlyNftStore() {
+        if (backingNfts == null) {
+            backingNfts = new BackingNfts(stateChildren::uniqueTokens);
+        }
+        return backingNfts;
+    }
+
+    public BackingStore<Pair<AccountID, TokenID>, MerkleTokenRelStatus>
+            asReadOnlyAssociationStore() {
+        if (backingRels == null) {
+            backingRels = new BackingTokenRels(stateChildren::tokenAssociations);
+        }
+        return backingRels;
+    }
+
+    private TokenFreezeStatus tfsFor(final boolean flag) {
+        return flag ? TokenFreezeStatus.Frozen : TokenFreezeStatus.Unfrozen;
+    }
+
+    private TokenKycStatus tksFor(final boolean flag) {
+        return flag ? TokenKycStatus.Granted : TokenKycStatus.Revoked;
+    }
+
+    private TokenPauseStatus tokenPauseStatusOf(final boolean flag) {
+        return flag ? TokenPauseStatus.Paused : TokenPauseStatus.Unpaused;
+    }
+
+    /**
+     * Returns the most recent token relationships formed by the given account in the given view of
+     * the state, up to maximum of {@code maxRels} relationships.
+     *
+     * @param view a view of the world state
+     * @param account the account of interest
+     * @param maxRels the maximum token relationships to return
+     * @return a list of the account's newest token relationships up to the given limit
+     */
+    static List<TokenRelationship> tokenRels(
+            final StateView view, final MerkleAccount account, final int maxRels) {
+        final List<TokenRelationship> grpcRels = new ArrayList<>();
+        var firstRel = account.getLatestAssociation();
+        doBoundedIteration(
+                view.tokenAssociations(),
+                view.tokens(),
+                firstRel,
+                maxRels,
+                (token, rel) -> {
+                    final var grpcRel =
+                            new RawTokenRelationship(
+                                            rel.getBalance(),
+                                            STATIC_PROPERTIES.getShard(),
+                                            STATIC_PROPERTIES.getRealm(),
+                                            rel.getRelatedTokenNum(),
+                                            rel.isFrozen(),
+                                            rel.isKycGranted(),
+                                            rel.isAutomaticAssociation())
+                                    .asGrpcFor(token);
+                    grpcRels.add(grpcRel);
+                });
+
+        return grpcRels;
+    }
+
+    /**
+     * Given tokens and account-token relationships, iterates the "map-value-linked-list" of token
+     * relationships for the given account, exposing its token relationships to the given Visitor in
+     * reverse chronological order.
+     *
+     * @param tokenRels the source of token relationship information
+     * @param tokens the source of token information
+     * @param account the account of interest
+     * @param visitor a consumer of token and token relationship information
+     */
+    public static void doBoundedIteration(
+            final MerkleMap<EntityNumPair, MerkleTokenRelStatus> tokenRels,
+            final MerkleMap<EntityNum, MerkleToken> tokens,
+            final MerkleAccount account,
+            final BiConsumer<MerkleToken, MerkleTokenRelStatus> visitor) {
+        final var maxRels = account.getNumAssociations();
+        final var firstRel = account.getLatestAssociation();
+        doBoundedIteration(tokenRels, tokens, firstRel, maxRels, visitor);
+    }
+
+    /**
+     * Given tokens and account-token relationships, iterates the "map-value-linked-list" of token
+     * relationships starting from a given key exposing token relationships to the given Visitor in
+     * reverse chronological order. Terminates when there are no more reachable relationships, or
+     * the maximum number have been visited.
+     *
+     * @param tokenRels the source of token relationship information
+     * @param tokens the source of token information
+     * @param firstRel the first relationship of interest
+     * @param maxRels the maximum number of relationships to visit
+     * @param visitor a consumer of token and token relationship information
+     */
+    public static void doBoundedIteration(
+            final MerkleMap<EntityNumPair, MerkleTokenRelStatus> tokenRels,
+            final MerkleMap<EntityNum, MerkleToken> tokens,
+            final EntityNumPair firstRel,
+            final int maxRels,
+            final BiConsumer<MerkleToken, MerkleTokenRelStatus> visitor) {
+        final var accountNum = firstRel.getHiOrderAsLong();
+        var tokenNum = firstRel.getLowOrderAsLong();
+        var key = firstRel;
+        var counter = 0;
+        while (tokenNum != MISSING_ID.num() && counter < maxRels) {
+            final var rel = tokenRels.get(key);
+            final var token = tokens.getOrDefault(key.getLowOrderAsNum(), REMOVED_TOKEN);
+            visitor.accept(token, rel);
+            tokenNum = rel.nextKey();
+            key = EntityNumPair.fromLongs(accountNum, tokenNum);
+            counter++;
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <K, V extends MerkleNode & Keyed<K>> MerkleMap<K, V> emptyMm() {
+        return (MerkleMap<K, V>) EMPTY_MM;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <K extends VirtualKey<K>, V extends VirtualValue> VirtualMap<K, V> emptyVm() {
+        return (VirtualMap<K, V>) EMPTY_VM;
+    }
+
+    /* --- used only in unit tests */
+    public MerkleNetworkContext networkCtx() {
+        return stateChildren == null ? EMPTY_CTX : stateChildren.networkCtx();
+    }
+
+    public MerkleMap<EntityNum, MerkleStakingInfo> stakingInfo() {
+        return stateChildren == null ? emptyMm() : stateChildren.stakingInfo();
+    }
 }

--- a/hedera-node/src/main/java/com/hedera/services/context/primitives/StateView.java
+++ b/hedera-node/src/main/java/com/hedera/services/context/primitives/StateView.java
@@ -505,22 +505,27 @@ public class StateView {
 		if (stakedNum < 0) {
 			// Staked num for a node is (-nodeId -1)
 			stakingInfo.setStakedNodeId(-stakedNum - 1);
+			addNodeStakeMeta(stakingInfo, account, rewardCalculator);
 		} else if (stakedNum > 0) {
 			stakingInfo.setStakedAccountId(STATIC_PROPERTIES.scopedAccountWith(stakedNum));
 		}
 
-		if (account.getStakePeriodStart() > 0) {
-			final var startSecond = rewardCalculator.epochSecondAtStartOfPeriod(account.getStakePeriodStart());
-			stakingInfo.setStakePeriodStart(Timestamp.newBuilder().setSeconds(startSecond).build());
-			if (account.mayHavePendingReward()) {
-				final var info = stateChildren.stakingInfo();
-				final var nodeStakingInfo = info.get(EntityNum.fromLong(account.getStakedNodeAddressBookId()));
-				final var pendingReward = rewardCalculator.estimatePendingRewards(account, nodeStakingInfo);
-				stakingInfo.setPendingReward(pendingReward);
-			}
-		}
-
 		return stakingInfo.build();
+	}
+
+	private void addNodeStakeMeta(
+			final StakingInfo.Builder stakingInfo,
+			final MerkleAccount account,
+			final RewardCalculator rewardCalculator
+	) {
+		final var startSecond = rewardCalculator.epochSecondAtStartOfPeriod(account.getStakePeriodStart());
+		stakingInfo.setStakePeriodStart(Timestamp.newBuilder().setSeconds(startSecond).build());
+		if (account.mayHavePendingReward()) {
+			final var info = stateChildren.stakingInfo();
+			final var nodeStakingInfo = info.get(EntityNum.fromLong(account.getStakedNodeAddressBookId()));
+			final var pendingReward = rewardCalculator.estimatePendingRewards(account, nodeStakingInfo);
+			stakingInfo.setPendingReward(pendingReward);
+		}
 	}
 
 	public Optional<GetAccountDetailsResponse.AccountDetails> accountDetails(

--- a/hedera-node/src/main/java/com/hedera/services/txns/validation/PureValidation.java
+++ b/hedera-node/src/main/java/com/hedera/services/txns/validation/PureValidation.java
@@ -62,7 +62,22 @@ public final class PureValidation {
 		}
 	}
 
+	public static ResponseCodeEnum queryableAccountOrContractStatus(
+			final EntityNum entityNum,
+			final MerkleMap<EntityNum, MerkleAccount> accounts
+	) {
+		return internalQueryableAccountStatus(true, entityNum, accounts);
+	}
+
 	public static ResponseCodeEnum queryableAccountStatus(
+			final EntityNum entityNum,
+			final MerkleMap<EntityNum, MerkleAccount> accounts
+	) {
+		return internalQueryableAccountStatus(false, entityNum, accounts);
+	}
+
+	private static ResponseCodeEnum internalQueryableAccountStatus(
+			final boolean contractIsOk,
 			final EntityNum entityNum,
 			final MerkleMap<EntityNum, MerkleAccount> accounts
 	) {
@@ -73,7 +88,7 @@ public final class PureValidation {
 					if (v.isDeleted()) {
 						return ACCOUNT_DELETED;
 					}
-					return v.isSmartContract() ? INVALID_ACCOUNT_ID : OK;
+					return (contractIsOk || !v.isSmartContract()) ? OK : INVALID_ACCOUNT_ID;
 				})
 				.orElse(INVALID_ACCOUNT_ID);
 	}
@@ -157,7 +172,7 @@ public final class PureValidation {
 			final MerkleMap<EntityNum, MerkleAccount> accounts,
 			final NodeInfo nodeInfo) {
 		if (idCase.matches(STAKED_ACCOUNT_ID_CASE)) {
-			return queryableAccountStatus(EntityNum.fromAccountId(stakedAccountId), accounts) == OK;
+			return queryableAccountOrContractStatus(EntityNum.fromAccountId(stakedAccountId), accounts) == OK;
 		} else {
 			return nodeInfo.isValidId(stakedNodeId);
 		}

--- a/hedera-node/src/main/java/com/hedera/services/txns/validation/PureValidation.java
+++ b/hedera-node/src/main/java/com/hedera/services/txns/validation/PureValidation.java
@@ -1,11 +1,6 @@
-package com.hedera.services.txns.validation;
-
-/*-
- * ‌
- * Hedera Services Node
- * ​
- * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
- * ​
+/*
+ * Copyright (C) 2020-2022 Hedera Hashgraph, LLC
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -17,8 +12,19 @@ package com.hedera.services.txns.validation;
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- * ‍
  */
+package com.hedera.services.txns.validation;
+
+import static com.hedera.services.ledger.accounts.HederaAccountCustomizer.STAKED_ACCOUNT_ID_CASE;
+import static com.hedera.services.utils.EntityNum.fromContractId;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.ACCOUNT_DELETED;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.CONTRACT_DELETED;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_ACCOUNT_ID;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_CONTRACT_ID;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_FILE_ID;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_TRANSACTION_START;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OK;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TRANSACTION_EXPIRED;
 
 import com.hedera.services.context.NodeInfo;
 import com.hedera.services.context.primitives.StateView;
@@ -32,149 +38,127 @@ import com.hederahashgraph.api.proto.java.Key;
 import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
 import com.hederahashgraph.api.proto.java.Timestamp;
 import com.swirlds.merkle.map.MerkleMap;
-import org.apache.commons.codec.DecoderException;
-
 import java.time.Instant;
 import java.util.Optional;
-
-import static com.hedera.services.ledger.accounts.HederaAccountCustomizer.STAKED_ACCOUNT_ID_CASE;
-import static com.hedera.services.utils.EntityNum.fromContractId;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.ACCOUNT_DELETED;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.CONTRACT_DELETED;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_ACCOUNT_ID;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_CONTRACT_ID;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_FILE_ID;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_TRANSACTION_START;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OK;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TRANSACTION_EXPIRED;
+import org.apache.commons.codec.DecoderException;
 
 public final class PureValidation {
-	private PureValidation() {
-		throw new UnsupportedOperationException("Utility Class");
-	}
+    private PureValidation() {
+        throw new UnsupportedOperationException("Utility Class");
+    }
 
-	public static ResponseCodeEnum queryableFileStatus(final FileID id, final StateView view) {
-		final var info = view.infoForFile(id);
-		if (info.isEmpty()) {
-			return INVALID_FILE_ID;
-		} else {
-			return OK;
-		}
-	}
+    public static ResponseCodeEnum queryableFileStatus(final FileID id, final StateView view) {
+        final var info = view.infoForFile(id);
+        if (info.isEmpty()) {
+            return INVALID_FILE_ID;
+        } else {
+            return OK;
+        }
+    }
 
-	public static ResponseCodeEnum queryableAccountOrContractStatus(
-			final EntityNum entityNum,
-			final MerkleMap<EntityNum, MerkleAccount> accounts
-	) {
-		return internalQueryableAccountStatus(true, entityNum, accounts);
-	}
+    public static ResponseCodeEnum queryableAccountOrContractStatus(
+            final EntityNum entityNum, final MerkleMap<EntityNum, MerkleAccount> accounts) {
+        return internalQueryableAccountStatus(true, entityNum, accounts);
+    }
 
-	public static ResponseCodeEnum queryableAccountStatus(
-			final EntityNum entityNum,
-			final MerkleMap<EntityNum, MerkleAccount> accounts
-	) {
-		return internalQueryableAccountStatus(false, entityNum, accounts);
-	}
+    public static ResponseCodeEnum queryableAccountStatus(
+            final EntityNum entityNum, final MerkleMap<EntityNum, MerkleAccount> accounts) {
+        return internalQueryableAccountStatus(false, entityNum, accounts);
+    }
 
-	private static ResponseCodeEnum internalQueryableAccountStatus(
-			final boolean contractIsOk,
-			final EntityNum entityNum,
-			final MerkleMap<EntityNum, MerkleAccount> accounts
-	) {
-		final var account = accounts.get(entityNum);
+    private static ResponseCodeEnum internalQueryableAccountStatus(
+            final boolean contractIsOk,
+            final EntityNum entityNum,
+            final MerkleMap<EntityNum, MerkleAccount> accounts) {
+        final var account = accounts.get(entityNum);
 
-		return Optional.ofNullable(account)
-				.map(v -> {
-					if (v.isDeleted()) {
-						return ACCOUNT_DELETED;
-					}
-					return (contractIsOk || !v.isSmartContract()) ? OK : INVALID_ACCOUNT_ID;
-				})
-				.orElse(INVALID_ACCOUNT_ID);
-	}
+        return Optional.ofNullable(account)
+                .map(
+                        v -> {
+                            if (v.isDeleted()) {
+                                return ACCOUNT_DELETED;
+                            }
+                            return (contractIsOk || !v.isSmartContract()) ? OK : INVALID_ACCOUNT_ID;
+                        })
+                .orElse(INVALID_ACCOUNT_ID);
+    }
 
-	public static ResponseCodeEnum queryableContractStatus(
-			final ContractID cid,
-			final MerkleMap<EntityNum, MerkleAccount> contracts
-	) {
-		return queryableContractStatus(fromContractId(cid), contracts);
-	}
+    public static ResponseCodeEnum queryableContractStatus(
+            final ContractID cid, final MerkleMap<EntityNum, MerkleAccount> contracts) {
+        return queryableContractStatus(fromContractId(cid), contracts);
+    }
 
-	public static ResponseCodeEnum queryableContractStatus(
-			final EntityNum contractId,
-			final MerkleMap<EntityNum, MerkleAccount> contracts
-	) {
-		final var contract = contracts.get(contractId);
+    public static ResponseCodeEnum queryableContractStatus(
+            final EntityNum contractId, final MerkleMap<EntityNum, MerkleAccount> contracts) {
+        final var contract = contracts.get(contractId);
 
-		return Optional.ofNullable(contract)
-				.map(v -> {
-					if (v.isDeleted()) {
-						return CONTRACT_DELETED;
-					}
-					return !v.isSmartContract() ? INVALID_CONTRACT_ID : OK;
-				})
-				.orElse(INVALID_CONTRACT_ID);
-	}
+        return Optional.ofNullable(contract)
+                .map(
+                        v -> {
+                            if (v.isDeleted()) {
+                                return CONTRACT_DELETED;
+                            }
+                            return !v.isSmartContract() ? INVALID_CONTRACT_ID : OK;
+                        })
+                .orElse(INVALID_CONTRACT_ID);
+    }
 
-	public static ResponseCodeEnum chronologyStatus(
-			final Instant consensusTime,
-			final Instant validStart,
-			long validDuration
-	) {
-		validDuration = Math.min(validDuration, Instant.MAX.getEpochSecond() - validStart.getEpochSecond());
-		if (validStart.plusSeconds(validDuration).isBefore(consensusTime)) {
-			return TRANSACTION_EXPIRED;
-		} else if (!validStart.isBefore(consensusTime)) {
-			return INVALID_TRANSACTION_START;
-		} else {
-			return OK;
-		}
-	}
+    public static ResponseCodeEnum chronologyStatus(
+            final Instant consensusTime, final Instant validStart, long validDuration) {
+        validDuration =
+                Math.min(validDuration, Instant.MAX.getEpochSecond() - validStart.getEpochSecond());
+        if (validStart.plusSeconds(validDuration).isBefore(consensusTime)) {
+            return TRANSACTION_EXPIRED;
+        } else if (!validStart.isBefore(consensusTime)) {
+            return INVALID_TRANSACTION_START;
+        } else {
+            return OK;
+        }
+    }
 
-	public static Instant asCoercedInstant(final Timestamp when) {
-		return Instant.ofEpochSecond(
-				Math.min(Math.max(Instant.MIN.getEpochSecond(), when.getSeconds()), Instant.MAX.getEpochSecond()),
-				Math.min(Math.max(Instant.MIN.getNano(), when.getNanos()), Instant.MAX.getNano()));
-	}
+    public static Instant asCoercedInstant(final Timestamp when) {
+        return Instant.ofEpochSecond(
+                Math.min(
+                        Math.max(Instant.MIN.getEpochSecond(), when.getSeconds()),
+                        Instant.MAX.getEpochSecond()),
+                Math.min(Math.max(Instant.MIN.getNano(), when.getNanos()), Instant.MAX.getNano()));
+    }
 
-	public static ResponseCodeEnum checkKey(final Key key, final ResponseCodeEnum failure) {
-		try {
-			final var fcKey = JKey.mapKey(key);
-			if (!fcKey.isValid()) {
-				return failure;
-			}
-			return OK;
-		} catch (DecoderException ignore) {
-			return failure;
-		}
-	}
+    public static ResponseCodeEnum checkKey(final Key key, final ResponseCodeEnum failure) {
+        try {
+            final var fcKey = JKey.mapKey(key);
+            if (!fcKey.isValid()) {
+                return failure;
+            }
+            return OK;
+        } catch (DecoderException ignore) {
+            return failure;
+        }
+    }
 
-	/**
-	 * Validates if the stakedNodeId set in the CryptoCreate, CryptoUpdate, ContractCreate and ContractUpdate operations
-	 * is valid.
-	 *
-	 * @param idCase
-	 * 		case if staked account id or staked node id is set
-	 * @param stakedAccountId
-	 * 		given staked account id
-	 * @param stakedNodeId
-	 * 		given staked node id
-	 * @param accounts
-	 * 		account map
-	 * @param nodeInfo
-	 * 		node Info object
-	 * @return true if valid, false otherwise
-	 */
-	public static boolean isValidStakedId(
-			final String idCase,
-			final AccountID stakedAccountId,
-			final long stakedNodeId,
-			final MerkleMap<EntityNum, MerkleAccount> accounts,
-			final NodeInfo nodeInfo) {
-		if (idCase.matches(STAKED_ACCOUNT_ID_CASE)) {
-			return queryableAccountOrContractStatus(EntityNum.fromAccountId(stakedAccountId), accounts) == OK;
-		} else {
-			return nodeInfo.isValidId(stakedNodeId);
-		}
-	}
+    /**
+     * Validates if the stakedNodeId set in the CryptoCreate, CryptoUpdate, ContractCreate and
+     * ContractUpdate operations is valid.
+     *
+     * @param idCase case if staked account id or staked node id is set
+     * @param stakedAccountId given staked account id
+     * @param stakedNodeId given staked node id
+     * @param accounts account map
+     * @param nodeInfo node Info object
+     * @return true if valid, false otherwise
+     */
+    public static boolean isValidStakedId(
+            final String idCase,
+            final AccountID stakedAccountId,
+            final long stakedNodeId,
+            final MerkleMap<EntityNum, MerkleAccount> accounts,
+            final NodeInfo nodeInfo) {
+        if (idCase.matches(STAKED_ACCOUNT_ID_CASE)) {
+            return queryableAccountOrContractStatus(
+                            EntityNum.fromAccountId(stakedAccountId), accounts)
+                    == OK;
+        } else {
+            return nodeInfo.isValidId(stakedNodeId);
+        }
+    }
 }

--- a/hedera-node/src/test/java/com/hedera/services/context/primitives/StateViewTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/context/primitives/StateViewTest.java
@@ -1,11 +1,6 @@
-package com.hedera.services.context.primitives;
-
-/*-
- * ‌
- * Hedera Services Node
- * ​
- * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
- * ​
+/*
+ * Copyright (C) 2020-2022 Hedera Hashgraph, LLC
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -17,8 +12,51 @@ package com.hedera.services.context.primitives;
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- * ‍
  */
+package com.hedera.services.context.primitives;
+
+import static com.hedera.services.context.primitives.StateView.EMPTY_CTX;
+import static com.hedera.services.context.primitives.StateView.REMOVED_TOKEN;
+import static com.hedera.services.state.submerkle.EntityId.MISSING_ENTITY_ID;
+import static com.hedera.services.state.submerkle.RichInstant.fromJava;
+import static com.hedera.services.state.virtual.schedule.ScheduleVirtualValueTest.scheduleCreateTxnWith;
+import static com.hedera.services.txns.crypto.helpers.AllowanceHelpers.getCryptoGrantedAllowancesList;
+import static com.hedera.services.txns.crypto.helpers.AllowanceHelpers.getFungibleGrantedTokenAllowancesList;
+import static com.hedera.services.txns.crypto.helpers.AllowanceHelpers.getNftGrantedAllowancesList;
+import static com.hedera.services.utils.EntityIdUtils.asAccount;
+import static com.hedera.services.utils.EntityIdUtils.asEvmAddress;
+import static com.hedera.services.utils.MiscUtils.asKeyUnchecked;
+import static com.hedera.test.factories.fees.CustomFeeBuilder.fixedHbar;
+import static com.hedera.test.factories.fees.CustomFeeBuilder.fixedHts;
+import static com.hedera.test.factories.fees.CustomFeeBuilder.fractional;
+import static com.hedera.test.factories.scenarios.TxnHandlingScenario.COMPLEX_KEY_ACCOUNT_KT;
+import static com.hedera.test.factories.scenarios.TxnHandlingScenario.MISC_ACCOUNT_KT;
+import static com.hedera.test.factories.scenarios.TxnHandlingScenario.SCHEDULE_ADMIN_KT;
+import static com.hedera.test.factories.scenarios.TxnHandlingScenario.TOKEN_ADMIN_KT;
+import static com.hedera.test.factories.scenarios.TxnHandlingScenario.TOKEN_FREEZE_KT;
+import static com.hedera.test.factories.scenarios.TxnHandlingScenario.TOKEN_KYC_KT;
+import static com.hedera.test.factories.scenarios.TxnHandlingScenario.TOKEN_PAUSE_KT;
+import static com.hedera.test.utils.IdUtils.asAccount;
+import static com.hedera.test.utils.IdUtils.asAccountWithAlias;
+import static com.hedera.test.utils.IdUtils.asContract;
+import static com.hedera.test.utils.IdUtils.asFile;
+import static com.hedera.test.utils.IdUtils.asSchedule;
+import static com.hedera.test.utils.IdUtils.asToken;
+import static com.hederahashgraph.api.proto.java.TokenPauseStatus.PauseNotApplicable;
+import static com.hederahashgraph.api.proto.java.TokenPauseStatus.Paused;
+import static com.hederahashgraph.api.proto.java.TokenType.FUNGIBLE_COMMON;
+import static com.swirlds.common.utility.CommonUtils.unhex;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.BDDMockito.any;
+import static org.mockito.BDDMockito.argThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.mock;
+import static org.mockito.Mockito.mockStatic;
 
 import com.google.protobuf.ByteString;
 import com.hedera.services.config.NetworkInfo;
@@ -82,6 +120,12 @@ import com.hederahashgraph.api.proto.java.TransactionBody;
 import com.swirlds.common.utility.CommonUtils;
 import com.swirlds.merkle.map.MerkleMap;
 import com.swirlds.virtualmap.VirtualMap;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import org.apache.commons.codec.DecoderException;
 import org.bouncycastle.util.encoders.Hex;
 import org.junit.jupiter.api.BeforeEach;
@@ -91,1132 +135,1167 @@ import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.time.Instant;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-
-import static com.hedera.services.context.primitives.StateView.EMPTY_CTX;
-import static com.hedera.services.context.primitives.StateView.REMOVED_TOKEN;
-import static com.hedera.services.state.submerkle.EntityId.MISSING_ENTITY_ID;
-import static com.hedera.services.state.submerkle.RichInstant.fromJava;
-import static com.hedera.services.state.virtual.schedule.ScheduleVirtualValueTest.scheduleCreateTxnWith;
-import static com.hedera.services.txns.crypto.helpers.AllowanceHelpers.getCryptoGrantedAllowancesList;
-import static com.hedera.services.txns.crypto.helpers.AllowanceHelpers.getFungibleGrantedTokenAllowancesList;
-import static com.hedera.services.txns.crypto.helpers.AllowanceHelpers.getNftGrantedAllowancesList;
-import static com.hedera.services.utils.EntityIdUtils.asAccount;
-import static com.hedera.services.utils.EntityIdUtils.asEvmAddress;
-import static com.hedera.services.utils.MiscUtils.asKeyUnchecked;
-import static com.hedera.test.factories.fees.CustomFeeBuilder.fixedHbar;
-import static com.hedera.test.factories.fees.CustomFeeBuilder.fixedHts;
-import static com.hedera.test.factories.fees.CustomFeeBuilder.fractional;
-import static com.hedera.test.factories.scenarios.TxnHandlingScenario.COMPLEX_KEY_ACCOUNT_KT;
-import static com.hedera.test.factories.scenarios.TxnHandlingScenario.MISC_ACCOUNT_KT;
-import static com.hedera.test.factories.scenarios.TxnHandlingScenario.SCHEDULE_ADMIN_KT;
-import static com.hedera.test.factories.scenarios.TxnHandlingScenario.TOKEN_ADMIN_KT;
-import static com.hedera.test.factories.scenarios.TxnHandlingScenario.TOKEN_FREEZE_KT;
-import static com.hedera.test.factories.scenarios.TxnHandlingScenario.TOKEN_KYC_KT;
-import static com.hedera.test.factories.scenarios.TxnHandlingScenario.TOKEN_PAUSE_KT;
-import static com.hedera.test.utils.IdUtils.asAccount;
-import static com.hedera.test.utils.IdUtils.asAccountWithAlias;
-import static com.hedera.test.utils.IdUtils.asContract;
-import static com.hedera.test.utils.IdUtils.asFile;
-import static com.hedera.test.utils.IdUtils.asSchedule;
-import static com.hedera.test.utils.IdUtils.asToken;
-import static com.hederahashgraph.api.proto.java.TokenPauseStatus.PauseNotApplicable;
-import static com.hederahashgraph.api.proto.java.TokenPauseStatus.Paused;
-import static com.hederahashgraph.api.proto.java.TokenType.FUNGIBLE_COMMON;
-import static com.swirlds.common.utility.CommonUtils.unhex;
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.BDDMockito.any;
-import static org.mockito.BDDMockito.argThat;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.BDDMockito.mock;
-import static org.mockito.Mockito.mockStatic;
-
-@ExtendWith({ MockitoExtension.class })
+@ExtendWith({MockitoExtension.class})
 class StateViewTest {
-	private static final int wellKnownNumKvPairs = 144;
-	private final Instant resolutionTime = Instant.ofEpochSecond(123L);
-	private final RichInstant now = RichInstant.fromGrpc(Timestamp.newBuilder().setNanos(123123213).build());
-	private final int maxTokensFprAccountInfo = 10;
-	private final long expiry = 2_000_000L;
-	private final byte[] data = "SOMETHING".getBytes();
-	private final byte[] expectedBytecode = "A Supermarket in California".getBytes();
-	private final String tokenMemo = "Goodbye and keep cold";
-	private HFileMeta metadata;
-	private HFileMeta immutableMetadata;
-	private final FileID target = asFile("0.0.123");
-	private final TokenID tokenId = asToken("0.0.5");
-	private final TokenID nftTokenId = asToken("0.0.3");
-	private final EntityNum tokenNum = EntityNum.fromTokenId(tokenId);
-	private final TokenID missingTokenId = asToken("0.0.5555");
-	private final AccountID payerAccountId = asAccount("0.0.9");
-	private final AccountID tokenAccountId = asAccount("0.0.10");
-	private final AccountID accountWithAlias = asAccountWithAlias("aaaa");
-	private final AccountID treasuryOwnerId = asAccount("0.0.0");
-	private final AccountID nftOwnerId = asAccount("0.0.44");
-	private final AccountID nftSpenderId = asAccount("0.0.66");
-	private final ScheduleID scheduleId = asSchedule("0.0.8");
-	private final ScheduleID missingScheduleId = asSchedule("0.0.9");
-	private final ContractID cid = asContract("0.0.1");
-	private final EntityNumPair tokenAssociationId = EntityNumPair.fromLongs(tokenAccountId.getAccountNum(),
-			tokenId.getTokenNum());
-	private final EntityNumPair nftAssociationId = EntityNumPair.fromLongs(tokenAccountId.getAccountNum(),
-			nftTokenId.getTokenNum());
-	private final byte[] cidAddress = asEvmAddress(0, 0, cid.getContractNum());
-	private final AccountID autoRenew = asAccount("0.0.6");
-	private final AccountID creatorAccountID = asAccount("0.0.7");
-	private final long autoRenewPeriod = 1_234_567;
-	private final String fileMemo = "Originally she thought";
-	private final ByteString create2Address = ByteString.copyFrom(unhex("aaaaaaaaaaaaaaaaaaaaaaaa9abcdefabcdefbbb"));
-	private final ByteString ledgerId = ByteString.copyFromUtf8("0x03");
-
-	private FileGetInfoResponse.FileInfo expected;
-	private FileGetInfoResponse.FileInfo expectedImmutable;
-
-	private Map<byte[], byte[]> bytecode;
-	private Map<FileID, byte[]> contents;
-	private Map<FileID, HFileMeta> attrs;
-
-	private MerkleMap<EntityNum, MerkleToken> tokens;
-	private MerkleMap<EntityNum, MerkleTopic> topics;
-	private MerkleMap<EntityNum, MerkleAccount> contracts;
-	private MerkleMap<EntityNumPair, MerkleUniqueToken> uniqueTokens;
-	private MerkleMap<EntityNumPair, MerkleTokenRelStatus> tokenRels;
-	private VirtualMap<VirtualBlobKey, VirtualBlobValue> storage;
-	private VirtualMap<ContractKey, IterableContractValue> contractStorage;
-	private MerkleMap<EntityNum, MerkleStakingInfo> stakingInfo;
-	private MerkleNetworkContext networkContext;
-	private ScheduleStore scheduleStore;
-	private TransactionBody parentScheduleCreate;
-	private NetworkInfo networkInfo;
-	private MerkleTokenRelStatus tokenAccountRel;
-	private MerkleTokenRelStatus nftAccountRel;
-
-	private MerkleToken token;
-	private MerkleToken nft;
-	private ScheduleVirtualValue schedule;
-	private MerkleAccount contract;
-	private MerkleAccount tokenAccount;
-	private MerkleSpecialFiles specialFiles;
-	private MutableStateChildren children;
-
-	private MockedStatic<StateView> mockedStatic;
-
-	@Mock
-	private AliasManager aliasManager;
-	@Mock
-	private RewardCalculator rewardCalculator;
-
-	private StateView subject;
-
-	@BeforeEach
-	@SuppressWarnings("unchecked")
-	private void setup() throws Throwable {
-		metadata = new HFileMeta(
-				false,
-				TxnHandlingScenario.MISC_FILE_WACL_KT.asJKey(),
-				expiry,
-				fileMemo);
-		immutableMetadata = new HFileMeta(
-				false,
-				StateView.EMPTY_WACL,
-				expiry);
-
-		expectedImmutable = FileGetInfoResponse.FileInfo.newBuilder()
-				.setLedgerId(ledgerId)
-				.setDeleted(false)
-				.setExpirationTime(Timestamp.newBuilder().setSeconds(expiry))
-				.setFileID(target)
-				.setSize(data.length)
-				.build();
-		expected = expectedImmutable.toBuilder()
-				.setKeys(TxnHandlingScenario.MISC_FILE_WACL_KT.asKey().getKeyList())
-				.setMemo(fileMemo)
-				.build();
-
-		tokenAccount = MerkleAccountFactory.newAccount()
-				.isSmartContract(false)
-				.tokens(tokenId)
-				.get();
-		tokenAccount.setKey(EntityNum.fromAccountId(tokenAccountId));
-		tokenAccount.setNftsOwned(10);
-		tokenAccount.setMaxAutomaticAssociations(123);
-		tokenAccount.setAlias(TxnHandlingScenario.TOKEN_ADMIN_KT.asKey().getEd25519());
-		tokenAccount.setHeadTokenId(tokenId.getTokenNum());
-		tokenAccount.setNumAssociations(1);
-		tokenAccount.setStakePeriodStart(1);
-		tokenAccount.setNumPositiveBalances(0);
-		tokenAccount.setStakedId(10L);
-		tokenAccount.setDeclineReward(true);
-		contract = MerkleAccountFactory.newAccount()
-				.alias(create2Address)
-				.memo("Stay cold...")
-				.numKvPairs(wellKnownNumKvPairs)
-				.isSmartContract(true)
-				.accountKeys(COMPLEX_KEY_ACCOUNT_KT)
-				.proxy(asAccount("0.0.3"))
-				.receiverSigRequired(true)
-				.balance(555L)
-				.autoRenewPeriod(1_000_000L)
-				.deleted(true)
-				.expirationTime(9_999_999L)
-				.autoRenewAccount(asAccount("0.0.4"))
-				.maxAutomaticAssociations(10)
-				.get();
-		contracts = (MerkleMap<EntityNum, MerkleAccount>) mock(MerkleMap.class);
-		topics = (MerkleMap<EntityNum, MerkleTopic>) mock(MerkleMap.class);
-		stakingInfo = (MerkleMap<EntityNum, MerkleStakingInfo>) mock(MerkleMap.class);
-		networkContext = mock(MerkleNetworkContext.class);
-
-		tokenAccountRel = new MerkleTokenRelStatus(123L, false, true, true);
-		tokenAccountRel.setKey(tokenAssociationId);
-		tokenAccountRel.setNext(nftTokenId.getTokenNum());
-
-		nftAccountRel = new MerkleTokenRelStatus(2L, false, true, false);
-		tokenAccountRel.setKey(nftAssociationId);
-		tokenAccountRel.setPrev(tokenId.getTokenNum());
-
-		tokenRels = new MerkleMap<>();
-		tokenRels.put(tokenAssociationId, tokenAccountRel);
-		tokenRels.put(nftAssociationId, nftAccountRel);
-
-		tokens = (MerkleMap<EntityNum, MerkleToken>) mock(MerkleMap.class);
-		token = new MerkleToken(
-				Long.MAX_VALUE, 100, 1,
-				"UnfrozenToken", "UnfrozenTokenName", true, true,
-				EntityId.fromGrpcTokenId(tokenId));
-		setUpToken(token);
-		token.setKey(tokenNum);
-		token.setTokenType(TokenType.FUNGIBLE_COMMON);
-
-		nft = new MerkleToken(Long.MAX_VALUE, 100, 1,
-				"UnfrozenToken", "UnfrozenTokenName", true, true,
-				EntityId.fromGrpcTokenId(nftTokenId));
-		setUpToken(nft);
-		nft.setKey(EntityNum.fromTokenId(nftTokenId));
-		nft.setTokenType(TokenType.NON_FUNGIBLE_UNIQUE);
-
-		token.setSupplyType(TokenSupplyType.FINITE);
-		token.setFeeScheduleFrom(grpcCustomFees);
-
-		scheduleStore = mock(ScheduleStore.class);
-		final var scheduleMemo = "For what but eye and ear";
-		parentScheduleCreate =
-				scheduleCreateTxnWith(
-						SCHEDULE_ADMIN_KT.asKey(),
-						scheduleMemo,
-						payerAccountId,
-						creatorAccountID,
-						MiscUtils.asTimestamp(now.toJava())
-				);
-		schedule = ScheduleVirtualValue.from(parentScheduleCreate.toByteArray(), expiry);
-		schedule.witnessValidSignature("01234567890123456789012345678901".getBytes());
-		schedule.witnessValidSignature("_123456789_123456789_123456789_1".getBytes());
-		schedule.witnessValidSignature("_o23456789_o23456789_o23456789_o".getBytes());
-
-		contents = mock(Map.class);
-		attrs = mock(Map.class);
-		bytecode = mock(Map.class);
-		specialFiles = mock(MerkleSpecialFiles.class);
-
-		uniqueTokens = new MerkleMap<>();
-		uniqueTokens.put(targetNftKey, targetNft);
-		uniqueTokens.put(treasuryNftKey, treasuryNft);
-
-		storage = (VirtualMap<VirtualBlobKey, VirtualBlobValue>) mock(VirtualMap.class);
-		contractStorage = (VirtualMap<ContractKey, IterableContractValue>) mock(VirtualMap.class);
-
-		children = new MutableStateChildren();
-		children.setUniqueTokens(uniqueTokens);
-		children.setAccounts(contracts);
-		children.setTokens(tokens);
-		children.setTokenAssociations(tokenRels);
-		children.setSpecialFiles(specialFiles);
-		children.setTokens(tokens);
-		children.setStakingInfo(stakingInfo);
-
-		networkInfo = mock(NetworkInfo.class);
-
-		subject = new StateView(scheduleStore, children, networkInfo);
-		subject.fileAttrs = attrs;
-		subject.fileContents = contents;
-		subject.contractBytecode = bytecode;
-	}
-
-	private void setUpToken(final MerkleToken token) throws DecoderException {
-		token.setMemo(tokenMemo);
-		token.setAdminKey(TxnHandlingScenario.TOKEN_ADMIN_KT.asJKey());
-		token.setFreezeKey(TxnHandlingScenario.TOKEN_FREEZE_KT.asJKey());
-		token.setKycKey(TxnHandlingScenario.TOKEN_KYC_KT.asJKey());
-		token.setSupplyKey(COMPLEX_KEY_ACCOUNT_KT.asJKey());
-		token.setWipeKey(MISC_ACCOUNT_KT.asJKey());
-		token.setFeeScheduleKey(MISC_ACCOUNT_KT.asJKey());
-		token.setPauseKey(TxnHandlingScenario.TOKEN_PAUSE_KT.asJKey());
-		token.setAutoRenewAccount(EntityId.fromGrpcAccountId(autoRenew));
-		token.setExpiry(expiry);
-		token.setAutoRenewPeriod(autoRenewPeriod);
-		token.setDeleted(true);
-		token.setPaused(true);
-		token.setSupplyType(TokenSupplyType.FINITE);
-		token.setFeeScheduleFrom(grpcCustomFees);
-	}
-
-	@Test
-	void tokenExistsWorks() {
-		given(tokens.containsKey(tokenNum)).willReturn(true);
-		assertTrue(subject.tokenExists(tokenId));
-		assertFalse(subject.tokenExists(missingTokenId));
-	}
-
-	@Test
-	void nftExistsWorks() {
-		assertTrue(subject.nftExists(targetNftId));
-		assertFalse(subject.nftExists(missingNftId));
-	}
-
-	@Test
-	void scheduleExistsWorks() {
-		given(scheduleStore.resolve(scheduleId)).willReturn(scheduleId);
-		given(scheduleStore.resolve(missingScheduleId)).willReturn(ScheduleStore.MISSING_SCHEDULE);
-
-		assertTrue(subject.scheduleExists(scheduleId));
-		assertFalse(subject.scheduleExists(missingScheduleId));
-	}
-
-	@Test
-	void tokenWithWorks() {
-		given(tokens.get(tokenNum)).willReturn(token);
-		assertSame(token, subject.tokenWith(tokenId).get());
-	}
-
-	@Test
-	void tokenWithWorksForMissing() {
-		assertTrue(subject.tokenWith(tokenId).isEmpty());
-	}
-
-	@Test
-	void recognizesMissingSchedule() {
-		given(scheduleStore.resolve(missingScheduleId)).willReturn(ScheduleStore.MISSING_SCHEDULE);
-		final var info = subject.infoForSchedule(missingScheduleId);
-		assertTrue(info.isEmpty());
-	}
-
-	@Test
-	void infoForScheduleFailsGracefully() {
-		given(scheduleStore.get(any())).willThrow(IllegalArgumentException.class);
-		final var info = subject.infoForSchedule(scheduleId);
-		assertTrue(info.isEmpty());
-	}
-
-	@Test
-	void getsScheduleInfoForDeleted() {
-		given(scheduleStore.resolve(scheduleId)).willReturn(scheduleId);
-		given(scheduleStore.get(scheduleId)).willReturn(schedule);
-		given(networkInfo.ledgerId()).willReturn(ledgerId);
-
-		final var expectedScheduledTxn = parentScheduleCreate.getScheduleCreate().getScheduledTransactionBody();
-
-		schedule.markDeleted(resolutionTime);
-		final var gotten = subject.infoForSchedule(scheduleId);
-		final var info = gotten.get();
-
-		assertEquals(scheduleId, info.getScheduleID());
-		assertEquals(schedule.schedulingAccount().toGrpcAccountId(), info.getCreatorAccountID());
-		assertEquals(schedule.payer().toGrpcAccountId(), info.getPayerAccountID());
-		assertEquals(Timestamp.newBuilder().setSeconds(expiry).build(), info.getExpirationTime());
-		final var expectedSignatoryList = KeyList.newBuilder();
-		schedule.signatories()
-				.forEach(a -> expectedSignatoryList.addKeys(Key.newBuilder().setEd25519(ByteString.copyFrom(a))));
-		assertArrayEquals(
-				expectedSignatoryList.build().getKeysList().toArray(),
-				info.getSigners().getKeysList().toArray());
-		assertEquals(SCHEDULE_ADMIN_KT.asKey(), info.getAdminKey());
-		assertEquals(expectedScheduledTxn, info.getScheduledTransactionBody());
-		assertEquals(schedule.scheduledTransactionId(), info.getScheduledTransactionID());
-		assertEquals(fromJava(resolutionTime).toGrpc(), info.getDeletionTime());
-		assertEquals(ledgerId, info.getLedgerId());
-	}
-
-	@Test
-	void getsScheduleInfoForExecuted() {
-		final var mockEd25519Key = new JEd25519Key("a123456789a123456789a123456789a1".getBytes());
-		final var mockSecp256k1Key = new JECDSASecp256k1Key("012345678901234567890123456789012".getBytes());
-		given(scheduleStore.resolve(scheduleId)).willReturn(scheduleId);
-		given(scheduleStore.get(scheduleId)).willReturn(schedule);
-		given(networkInfo.ledgerId()).willReturn(ledgerId);
-		schedule.witnessValidSignature(mockEd25519Key.primitiveKeyIfPresent());
-		schedule.witnessValidSignature(mockSecp256k1Key.primitiveKeyIfPresent());
-
-		schedule.markExecuted(resolutionTime);
-		final var gotten = subject.infoForSchedule(scheduleId);
-		final var info = gotten.get();
-
-		assertEquals(ledgerId, info.getLedgerId());
-		assertEquals(fromJava(resolutionTime).toGrpc(), info.getExecutionTime());
-		final var signatures = info.getSigners().getKeysList();
-		assertEquals(MiscUtils.asKeyUnchecked(mockEd25519Key), signatures.get(3));
-		assertEquals(MiscUtils.asKeyUnchecked(mockSecp256k1Key), signatures.get(4));
-	}
-
-	@Test
-	void recognizesMissingToken() {
-		final var info = subject.infoForToken(missingTokenId);
-
-		assertTrue(info.isEmpty());
-	}
-
-	@Test
-	void infoForTokenFailsGracefully() {
-		given(tokens.get(tokenNum)).willThrow(IllegalArgumentException.class);
-
-		final var info = subject.infoForToken(tokenId);
-
-		assertTrue(info.isEmpty());
-	}
-
-	@Test
-	void getsTokenInfoMinusFreezeIfMissing() {
-		given(networkInfo.ledgerId()).willReturn(ledgerId);
-		given(tokens.get(tokenNum)).willReturn(token);
-
-		token.setFreezeKey(MerkleToken.UNUSED_KEY);
-
-		final var info = subject.infoForToken(tokenId).get();
-
-		assertEquals(tokenId, info.getTokenId());
-		assertEquals(token.symbol(), info.getSymbol());
-		assertEquals(token.name(), info.getName());
-		assertEquals(token.treasury().toGrpcAccountId(), info.getTreasury());
-		assertEquals(token.totalSupply(), info.getTotalSupply());
-		assertEquals(token.decimals(), info.getDecimals());
-		assertEquals(TOKEN_ADMIN_KT.asKey(), info.getAdminKey());
-		assertEquals(TokenFreezeStatus.FreezeNotApplicable, info.getDefaultFreezeStatus());
-		assertFalse(info.hasFreezeKey());
-		assertEquals(ledgerId, info.getLedgerId());
-	}
-
-	@Test
-	void getsTokenInfoMinusPauseIfMissing() {
-		given(networkInfo.ledgerId()).willReturn(ledgerId);
-		given(tokens.get(tokenNum)).willReturn(token);
-
-		token.setPauseKey(MerkleToken.UNUSED_KEY);
-
-		final var info = subject.infoForToken(tokenId).get();
-
-		assertEquals(tokenId, info.getTokenId());
-		assertEquals(token.symbol(), info.getSymbol());
-		assertEquals(token.name(), info.getName());
-		assertEquals(token.treasury().toGrpcAccountId(), info.getTreasury());
-		assertEquals(token.totalSupply(), info.getTotalSupply());
-		assertEquals(token.decimals(), info.getDecimals());
-		assertEquals(TOKEN_ADMIN_KT.asKey(), info.getAdminKey());
-		assertEquals(PauseNotApplicable, info.getPauseStatus());
-		assertFalse(info.hasPauseKey());
-		assertEquals(ledgerId, info.getLedgerId());
-	}
-
-	@Test
-	void getsTokenInfo() {
-		given(networkInfo.ledgerId()).willReturn(ledgerId);
-		given(tokens.get(tokenNum)).willReturn(token);
-		final var miscKey = MISC_ACCOUNT_KT.asKey();
-
-		final var info = subject.infoForToken(tokenId).get();
-
-		assertTrue(info.getDeleted());
-		assertEquals(Paused, info.getPauseStatus());
-		assertEquals(token.memo(), info.getMemo());
-		assertEquals(tokenId, info.getTokenId());
-		assertEquals(token.symbol(), info.getSymbol());
-		assertEquals(token.name(), info.getName());
-		assertEquals(token.treasury().toGrpcAccountId(), info.getTreasury());
-		assertEquals(token.totalSupply(), info.getTotalSupply());
-		assertEquals(token.decimals(), info.getDecimals());
-		assertEquals(token.grpcFeeSchedule(), info.getCustomFeesList());
-		assertEquals(TOKEN_ADMIN_KT.asKey(), info.getAdminKey());
-		assertEquals(TOKEN_FREEZE_KT.asKey(), info.getFreezeKey());
-		assertEquals(TOKEN_KYC_KT.asKey(), info.getKycKey());
-		assertEquals(TOKEN_PAUSE_KT.asKey(), info.getPauseKey());
-		assertEquals(miscKey, info.getWipeKey());
-		assertEquals(miscKey, info.getFeeScheduleKey());
-		assertEquals(autoRenew, info.getAutoRenewAccount());
-		assertEquals(Duration.newBuilder().setSeconds(autoRenewPeriod).build(), info.getAutoRenewPeriod());
-		assertEquals(Timestamp.newBuilder().setSeconds(expiry).build(), info.getExpiry());
-		assertEquals(TokenFreezeStatus.Frozen, info.getDefaultFreezeStatus());
-		assertEquals(TokenKycStatus.Granted, info.getDefaultKycStatus());
-		assertEquals(ledgerId, info.getLedgerId());
-	}
-
-	@Test
-	void getsContractInfo() throws Exception {
-		final var target = EntityNum.fromContractId(cid);
-		given(contracts.get(EntityNum.fromContractId(cid))).willReturn(contract);
-		final var expectedTotalStorage = StateView.BYTES_PER_EVM_KEY_VALUE_PAIR * wellKnownNumKvPairs;
-		given(networkInfo.ledgerId()).willReturn(ledgerId);
-
-		List<TokenRelationship> rels = List.of(
-				TokenRelationship.newBuilder()
-						.setTokenId(TokenID.newBuilder().setTokenNum(123L))
-						.setFreezeStatus(TokenFreezeStatus.FreezeNotApplicable)
-						.setKycStatus(TokenKycStatus.KycNotApplicable)
-						.setBalance(321L)
-						.build());
-		mockedStatic = mockStatic(StateView.class);
-		mockedStatic.when(() -> StateView.tokenRels(subject, contract, maxTokensFprAccountInfo)).thenReturn(rels);
-
-		final var info = subject.infoForContract(cid, aliasManager, maxTokensFprAccountInfo, rewardCalculator).get();
-
-		assertEquals(cid, info.getContractID());
-		assertEquals(asAccount(cid), info.getAccountID());
-		assertEquals(JKey.mapJKey(contract.getAccountKey()), info.getAdminKey());
-		assertEquals(contract.getMemo(), info.getMemo());
-		assertEquals(contract.getAutoRenewSecs(), info.getAutoRenewPeriod().getSeconds());
-		assertEquals(contract.getBalance(), info.getBalance());
-		assertEquals(CommonUtils.hex(create2Address.toByteArray()), info.getContractAccountID());
-		assertEquals(contract.getExpiry(), info.getExpirationTime().getSeconds());
-		assertEquals(EntityId.fromIdentityCode(4), contract.getAutoRenewAccount());
-		assertEquals(rels, info.getTokenRelationshipsList());
-		assertEquals(ledgerId, info.getLedgerId());
-		assertTrue(info.getDeleted());
-		assertEquals(expectedTotalStorage, info.getStorage());
-		assertEquals(contract.getMaxAutomaticAssociations(), info.getMaxAutomaticTokenAssociations());
-		mockedStatic.close();
-	}
-
-	@Test
-	void getsContractInfoWithoutCreate2Address() throws Exception {
-		final var target = EntityNum.fromContractId(cid);
-		given(contracts.get(EntityNum.fromContractId(cid))).willReturn(contract);
-		contract.setAlias(ByteString.EMPTY);
-		final var expectedTotalStorage = StateView.BYTES_PER_EVM_KEY_VALUE_PAIR * wellKnownNumKvPairs;
-		given(networkInfo.ledgerId()).willReturn(ledgerId);
-
-		List<TokenRelationship> rels = List.of(
-				TokenRelationship.newBuilder()
-						.setTokenId(TokenID.newBuilder().setTokenNum(123L))
-						.setFreezeStatus(TokenFreezeStatus.FreezeNotApplicable)
-						.setKycStatus(TokenKycStatus.KycNotApplicable)
-						.setBalance(321L)
-						.build());
-		mockedStatic = mockStatic(StateView.class);
-		mockedStatic.when(() -> StateView.tokenRels(subject, contract, maxTokensFprAccountInfo)).thenReturn(rels);
-
-		final var info = subject.infoForContract(cid, aliasManager, maxTokensFprAccountInfo, rewardCalculator).get();
-
-		assertEquals(cid, info.getContractID());
-		assertEquals(asAccount(cid), info.getAccountID());
-		assertEquals(JKey.mapJKey(contract.getAccountKey()), info.getAdminKey());
-		assertEquals(contract.getMemo(), info.getMemo());
-		assertEquals(contract.getAutoRenewSecs(), info.getAutoRenewPeriod().getSeconds());
-		assertEquals(contract.getBalance(), info.getBalance());
-		assertEquals(EntityIdUtils.asHexedEvmAddress(asAccount(cid)), info.getContractAccountID());
-		assertEquals(contract.getExpiry(), info.getExpirationTime().getSeconds());
-		assertEquals(rels, info.getTokenRelationshipsList());
-		assertEquals(ledgerId, info.getLedgerId());
-		assertTrue(info.getDeleted());
-		assertEquals(expectedTotalStorage, info.getStorage());
-		mockedStatic.close();
-	}
-
-	@Test
-	void getTokenRelationship() {
-		given(tokens.getOrDefault(tokenNum, REMOVED_TOKEN)).willReturn(token);
-		given(tokens.getOrDefault(EntityNum.fromTokenId(nftTokenId), REMOVED_TOKEN)).willReturn(nft);
-
-		List<TokenRelationship> expectedRels = List.of(
-				TokenRelationship.newBuilder()
-						.setTokenId(tokenId)
-						.setSymbol("UnfrozenToken")
-						.setBalance(123L)
-						.setKycStatus(TokenKycStatus.Granted)
-						.setFreezeStatus(TokenFreezeStatus.Unfrozen)
-						.setAutomaticAssociation(true)
-						.setDecimals(1)
-						.build(),
-				TokenRelationship.newBuilder()
-						.setTokenId(nftTokenId)
-						.setSymbol("UnfrozenToken")
-						.setBalance(2L)
-						.setKycStatus(TokenKycStatus.Granted)
-						.setFreezeStatus(TokenFreezeStatus.Unfrozen)
-						.setAutomaticAssociation(false)
-						.setDecimals(1)
-						.build());
-
-		final var actualRels = StateView.tokenRels(subject, tokenAccount, maxTokensFprAccountInfo);
-
-		assertEquals(expectedRels, actualRels);
-	}
-
-	@Test
-	void getInfoForNftMissing() {
-		final var nftID = NftID.newBuilder().setTokenID(tokenId).setSerialNumber(123L).build();
-
-		final var actualTokenNftInfo = subject.infoForNft(nftID);
-
-		assertEquals(Optional.empty(), actualTokenNftInfo);
-	}
-
-	@Test
-	void getTokenType() {
-		given(tokens.get(tokenNum)).willReturn(token);
-		final var actualTokenType = subject.tokenType(tokenId).get();
-
-		assertEquals(FUNGIBLE_COMMON, actualTokenType);
-	}
-
-	@Test
-	void getTokenTypeMissing() {
-		final var actualTokenType = subject.tokenType(tokenId);
-
-		assertEquals(Optional.empty(), actualTokenType);
-	}
-
-	@Test
-	void getTokenTypeException() {
-		given(tokens.get(tokenId)).willThrow(new RuntimeException());
-
-		final var actualTokenType = subject.tokenType(tokenId);
-
-		assertEquals(Optional.empty(), actualTokenType);
-	}
-
-	@Test
-	void infoForRegularAccount() {
-		given(contracts.get(EntityNum.fromAccountId(tokenAccountId))).willReturn(tokenAccount);
-
-		mockedStatic = mockStatic(StateView.class);
-		mockedStatic.when(() -> StateView.tokenRels(subject, tokenAccount, maxTokensFprAccountInfo))
-				.thenReturn(Collections.emptyList());
-		given(networkInfo.ledgerId()).willReturn(ledgerId);
-
-		final var expectedResponse = CryptoGetInfoResponse.AccountInfo.newBuilder()
-				.setLedgerId(ledgerId)
-				.setKey(asKeyUnchecked(tokenAccount.getAccountKey()))
-				.setAccountID(tokenAccountId)
-				.setAlias(tokenAccount.getAlias())
-				.setReceiverSigRequired(tokenAccount.isReceiverSigRequired())
-				.setDeleted(tokenAccount.isDeleted())
-				.setMemo(tokenAccount.getMemo())
-				.setAutoRenewPeriod(Duration.newBuilder().setSeconds(tokenAccount.getAutoRenewSecs()))
-				.setBalance(tokenAccount.getBalance())
-				.setExpirationTime(Timestamp.newBuilder().setSeconds(tokenAccount.getExpiry()))
-				.setContractAccountID(EntityIdUtils.asHexedEvmAddress(tokenAccountId))
-				.setOwnedNfts(tokenAccount.getNftsOwned())
-				.setMaxAutomaticTokenAssociations(tokenAccount.getMaxAutomaticAssociations())
-				.setStakingInfo(StakingInfo.newBuilder()
-						.setDeclineReward(true)
-						.setStakedAccountId(AccountID.newBuilder().setAccountNum(10L).build())
-						.build())
-				.build();
-
-		final var actualResponse = subject.infoForAccount(
-				tokenAccountId, aliasManager, maxTokensFprAccountInfo, rewardCalculator);
-
-		assertEquals(expectedResponse, actualResponse.get());
-		mockedStatic.close();
-	}
-
-	@Test
-	void stakingInfoReturnedCorrectly() {
-		final var startPeriod = 10000L;
-		tokenAccount = MerkleAccountFactory.newAccount()
-				.isSmartContract(false)
-				.tokens(tokenId)
-				.get();
-		tokenAccount.setStakedId(-10L);
-		tokenAccount.setDeclineReward(false);
-		tokenAccount.setStakePeriodStart(startPeriod);
-		given(rewardCalculator.epochSecondAtStartOfPeriod(startPeriod)).willReturn(1_234_567L);
-
-		given(contracts.get(EntityNum.fromAccountId(tokenAccountId))).willReturn(tokenAccount);
-
-		mockedStatic = mockStatic(StateView.class);
-		mockedStatic.when(() -> StateView.tokenRels(subject, tokenAccount, maxTokensFprAccountInfo))
-				.thenReturn(Collections.emptyList());
-		given(networkInfo.ledgerId()).willReturn(ledgerId);
-
-		final var expectedResponse = StakingInfo.newBuilder()
-				.setDeclineReward(false)
-				.setStakedNodeId(9L)
-				.setStakePeriodStart(Timestamp.newBuilder().setSeconds(1_234_567L))
-				.build();
-
-		final var actualResponse = subject.infoForAccount(
-				tokenAccountId, aliasManager, maxTokensFprAccountInfo, rewardCalculator);
-
-		assertEquals(expectedResponse, actualResponse.get().getStakingInfo());
-		mockedStatic.close();
-	}
-
-	@Test
-	void infoForExternallyOperatedAccount() {
-		final byte[] ecdsaKey = Hex.decode(
-				"033a514176466fa815ed481ffad09110a2d344f6c9b78c1d14afc351c3a51be33d");
-		given(contracts.get(EntityNum.fromAccountId(tokenAccountId))).willReturn(tokenAccount);
-		tokenAccount.setAccountKey(new JECDSASecp256k1Key(ecdsaKey));
-		final var expectedAddress = CommonUtils.hex(EthTxSigs.recoverAddressFromPubKey(ecdsaKey));
-
-		mockedStatic = mockStatic(StateView.class);
-		mockedStatic.when(() -> StateView.tokenRels(subject, tokenAccount, maxTokensFprAccountInfo))
-				.thenReturn(Collections.emptyList());
-		given(networkInfo.ledgerId()).willReturn(ledgerId);
-
-		final var expectedResponse = CryptoGetInfoResponse.AccountInfo.newBuilder()
-				.setLedgerId(ledgerId)
-				.setKey(asKeyUnchecked(tokenAccount.getAccountKey()))
-				.setAccountID(tokenAccountId)
-				.setAlias(tokenAccount.getAlias())
-				.setReceiverSigRequired(tokenAccount.isReceiverSigRequired())
-				.setDeleted(tokenAccount.isDeleted())
-				.setMemo(tokenAccount.getMemo())
-				.setAutoRenewPeriod(Duration.newBuilder().setSeconds(tokenAccount.getAutoRenewSecs()))
-				.setBalance(tokenAccount.getBalance())
-				.setExpirationTime(Timestamp.newBuilder().setSeconds(tokenAccount.getExpiry()))
-				.setContractAccountID(expectedAddress)
-				.setOwnedNfts(tokenAccount.getNftsOwned())
-				.setMaxAutomaticTokenAssociations(tokenAccount.getMaxAutomaticAssociations())
-				.setStakingInfo(StakingInfo.newBuilder()
-						.setStakedAccountId(AccountID.newBuilder().setAccountNum(10).build())
-						.setDeclineReward(true)
-						.build())
-				.build();
-
-		final var actualResponse =
-				subject.infoForAccount(tokenAccountId, aliasManager, maxTokensFprAccountInfo, rewardCalculator);
-		mockedStatic.close();
-
-		assertEquals(expectedResponse, actualResponse.get());
-	}
-
-	@Test
-	void accountDetails() {
-		given(contracts.get(EntityNum.fromAccountId(tokenAccountId))).willReturn(tokenAccount);
-
-		mockedStatic = mockStatic(StateView.class);
-		mockedStatic.when(() -> StateView.tokenRels(subject, tokenAccount, maxTokensFprAccountInfo))
-				.thenReturn(Collections.emptyList());
-		given(networkInfo.ledgerId()).willReturn(ledgerId);
-		final var expectedResponse = GetAccountDetailsResponse.AccountDetails.newBuilder()
-				.setLedgerId(ledgerId)
-				.setKey(asKeyUnchecked(tokenAccount.getAccountKey()))
-				.setAccountId(tokenAccountId)
-				.setAlias(tokenAccount.getAlias())
-				.setReceiverSigRequired(tokenAccount.isReceiverSigRequired())
-				.setDeleted(tokenAccount.isDeleted())
-				.setMemo(tokenAccount.getMemo())
-				.setAutoRenewPeriod(Duration.newBuilder().setSeconds(tokenAccount.getAutoRenewSecs()))
-				.setBalance(tokenAccount.getBalance())
-				.setExpirationTime(Timestamp.newBuilder().setSeconds(tokenAccount.getExpiry()))
-				.setContractAccountId(EntityIdUtils.asHexedEvmAddress(tokenAccountId))
-				.setOwnedNfts(tokenAccount.getNftsOwned())
-				.setMaxAutomaticTokenAssociations(tokenAccount.getMaxAutomaticAssociations())
-				.addAllGrantedCryptoAllowances(getCryptoGrantedAllowancesList(tokenAccount))
-				.addAllGrantedTokenAllowances(getFungibleGrantedTokenAllowancesList(tokenAccount))
-				.addAllGrantedNftAllowances(getNftGrantedAllowancesList(tokenAccount))
-				.build();
-
-		final var actualResponse = subject.accountDetails(tokenAccountId, aliasManager, maxTokensFprAccountInfo);
-		mockedStatic.close();
-
-		assertEquals(expectedResponse, actualResponse.get());
-	}
-
-	@Test
-	void infoForAccountWithAlias() {
-		given(aliasManager.lookupIdBy(any())).willReturn(EntityNum.fromAccountId(tokenAccountId));
-		given(contracts.get(EntityNum.fromAccountId(tokenAccountId))).willReturn(tokenAccount);
-		mockedStatic = mockStatic(StateView.class);
-		mockedStatic.when(() -> StateView.tokenRels(subject, tokenAccount, maxTokensFprAccountInfo))
-				.thenReturn(Collections.emptyList());
-		given(networkInfo.ledgerId()).willReturn(ledgerId);
-
-		final var expectedResponse = CryptoGetInfoResponse.AccountInfo.newBuilder()
-				.setLedgerId(ledgerId)
-				.setKey(asKeyUnchecked(tokenAccount.getAccountKey()))
-				.setAccountID(tokenAccountId)
-				.setAlias(tokenAccount.getAlias())
-				.setReceiverSigRequired(tokenAccount.isReceiverSigRequired())
-				.setDeleted(tokenAccount.isDeleted())
-				.setMemo(tokenAccount.getMemo())
-				.setAutoRenewPeriod(Duration.newBuilder().setSeconds(tokenAccount.getAutoRenewSecs()))
-				.setBalance(tokenAccount.getBalance())
-				.setExpirationTime(Timestamp.newBuilder().setSeconds(tokenAccount.getExpiry()))
-				.setContractAccountID(EntityIdUtils.asHexedEvmAddress(tokenAccountId))
-				.setOwnedNfts(tokenAccount.getNftsOwned())
-				.setMaxAutomaticTokenAssociations(tokenAccount.getMaxAutomaticAssociations())
-				.setStakingInfo(StakingInfo.newBuilder()
-						.setDeclineReward(true)
-						.setStakedAccountId(AccountID.newBuilder().setAccountNum(10L).build())
-						.build())
-				.build();
-
-		final var actualResponse = subject.infoForAccount(
-				accountWithAlias, aliasManager, maxTokensFprAccountInfo, rewardCalculator);
-		mockedStatic.close();
-		assertEquals(expectedResponse, actualResponse.get());
-	}
-
-	@Test
-	void numNftsOwnedWorksForExisting() {
-		given(contracts.get(EntityNum.fromAccountId(tokenAccountId))).willReturn(tokenAccount);
-
-		assertEquals(tokenAccount.getNftsOwned(), subject.numNftsOwnedBy(tokenAccountId));
-	}
-
-	@Test
-	void infoForMissingAccount() {
-		given(contracts.get(EntityNum.fromAccountId(tokenAccountId))).willReturn(null);
-
-		final var actualResponse = subject.infoForAccount(tokenAccountId, aliasManager, maxTokensFprAccountInfo,
-				rewardCalculator);
-
-		assertEquals(Optional.empty(), actualResponse);
-	}
-
-	@Test
-	void infoForMissingAccountWithAlias() {
-		EntityNum mockedEntityNum = mock(EntityNum.class);
-
-		given(aliasManager.lookupIdBy(any())).willReturn(mockedEntityNum);
-		given(contracts.get(mockedEntityNum)).willReturn(null);
-
-		final var actualResponse = subject.infoForAccount(accountWithAlias, aliasManager, maxTokensFprAccountInfo,
-				rewardCalculator);
-		assertEquals(Optional.empty(), actualResponse);
-
-	}
-
-	@Test
-	void getTopics() {
-		final var children = new MutableStateChildren();
-		children.setTopics(topics);
-
-		subject = new StateView(null, children, null);
-
-		final var actualTopics = subject.topics();
-
-		assertEquals(topics, actualTopics);
-	}
-
-	@Test
-	void getStorageAndContractStorage() {
-		final var children = new MutableStateChildren();
-		children.setContractStorage(contractStorage);
-		children.setStorage(storage);
-
-		subject = new StateView(null, children, null);
-
-		final var actualStorage = subject.storage();
-		final var actualContractStorage = subject.contractStorage();
-
-		assertEquals(storage, actualStorage);
-		assertEquals(contractStorage, actualContractStorage);
-	}
-
-	@Test
-	void getStakingInfoAndContext() {
-		final var children = new MutableStateChildren();
-		children.setStakingInfo(stakingInfo);
-		children.setNetworkCtx(networkContext);
-
-		subject = new StateView(null, children, null);
-
-		final var actualStakingInfo = subject.stakingInfo();
-		final var actualNetworkContext = subject.networkCtx();
-
-		assertEquals(stakingInfo, actualStakingInfo);
-		assertEquals(networkContext, actualNetworkContext);
-	}
-
-	@Test
-	void returnsEmptyOptionalIfContractMissing() {
-		given(contracts.get(any())).willReturn(null);
-
-		assertTrue(subject.infoForContract(cid, aliasManager, maxTokensFprAccountInfo, rewardCalculator).isEmpty());
-	}
-
-	@Test
-	void handlesNullKey() {
-		given(contracts.get(EntityNum.fromContractId(cid))).willReturn(contract);
-		given(networkInfo.ledgerId()).willReturn(ledgerId);
-		mockedStatic = mockStatic(StateView.class);
-		mockedStatic.when(() -> StateView.tokenRels(any(), any(), anyInt())).thenReturn(Collections.emptyList());
-		contract.setAccountKey(null);
-
-		final var info = subject.infoForContract(cid, aliasManager, maxTokensFprAccountInfo, rewardCalculator).get();
-
-		assertFalse(info.hasAdminKey());
-		mockedStatic.close();
-	}
-
-	@Test
-	void handlesNullAutoRenewAccount() {
-		given(contracts.get(EntityNum.fromContractId(cid))).willReturn(contract);
-		given(networkInfo.ledgerId()).willReturn(ledgerId);
-		mockedStatic = mockStatic(StateView.class);
-		mockedStatic.when(() -> StateView.tokenRels(any(), any(), anyInt())).thenReturn(Collections.emptyList());
-		contract.setAutoRenewAccount(null);
-
-		final var info = subject.infoForContract(cid, aliasManager, maxTokensFprAccountInfo, rewardCalculator).get();
-
-		assertFalse(info.hasAutoRenewAccountId());
-		mockedStatic.close();
-	}
-
-	@Test
-	void getsAttrs() {
-		given(attrs.get(target)).willReturn(metadata);
-
-		final var stuff = subject.attrOf(target);
-
-		assertEquals(metadata.toString(), stuff.get().toString());
-	}
-
-	@Test
-	void getsBytecode() {
-		given(bytecode.get(argThat((byte[] bytes) -> Arrays.equals(cidAddress, bytes)))).willReturn(expectedBytecode);
-
-		final var actual = subject.bytecodeOf(EntityNum.fromContractId(cid));
-
-		assertArrayEquals(expectedBytecode, actual.get());
-	}
-
-	@Test
-	void getsContents() {
-		given(contents.get(target)).willReturn(data);
-
-		final var stuff = subject.contentsOf(target);
-
-		assertTrue(stuff.isPresent());
-		assertArrayEquals(data, stuff.get());
-	}
-
-	@Test
-	void assemblesFileInfo() {
-		given(attrs.get(target)).willReturn(metadata);
-		given(contents.get(target)).willReturn(data);
-		given(networkInfo.ledgerId()).willReturn(ledgerId);
-
-		final var info = subject.infoForFile(target);
-
-		assertTrue(info.isPresent());
-		assertEquals(expected, info.get());
-	}
-
-	@Test
-	void assemblesFileInfoForImmutable() {
-		given(attrs.get(target)).willReturn(immutableMetadata);
-		given(contents.get(target)).willReturn(data);
-		given(networkInfo.ledgerId()).willReturn(ledgerId);
-
-		final var info = subject.infoForFile(target);
-
-		assertTrue(info.isPresent());
-		assertEquals(expectedImmutable, info.get());
-	}
-
-	@Test
-	void assemblesFileInfoForDeleted() {
-		expected = expected.toBuilder()
-				.setDeleted(true)
-				.setSize(0)
-				.build();
-		metadata.setDeleted(true);
-
-		given(attrs.get(target)).willReturn(metadata);
-		given(networkInfo.ledgerId()).willReturn(ledgerId);
-
-		final var info = subject.infoForFile(target);
-
-		assertTrue(info.isPresent());
-		assertEquals(expected, info.get());
-	}
-
-	@Test
-	void returnsEmptyForMissing() {
-		final var info = subject.infoForFile(target);
-
-		assertTrue(info.isEmpty());
-	}
-
-	@Test
-	void returnsEmptyForMissingContent() {
-		final var info = subject.contentsOf(target);
-
-		assertTrue(info.isEmpty());
-	}
-
-	@Test
-	void returnsEmptyForMissingAttr() {
-		final var info = subject.attrOf(target);
-
-		assertTrue(info.isEmpty());
-	}
-
-	@Test
-	void getsSpecialFileContents() {
-		FileID file150 = asFile("0.0.150");
-
-		given(specialFiles.get(file150)).willReturn(data);
-		given(specialFiles.contains(file150)).willReturn(true);
-
-		final var stuff = subject.contentsOf(file150);
-
-		assertTrue(Arrays.equals(data, stuff.get()));
-	}
-
-	@Test
-	void rejectsMissingNft() {
-		final var optionalNftInfo = subject.infoForNft(missingNftId);
-
-		assertTrue(optionalNftInfo.isEmpty());
-	}
-
-	@Test
-	void abortsNftGetWhenMissingTreasuryAsExpected() {
-		tokens = mock(MerkleMap.class);
-		targetNft.setOwner(MISSING_ENTITY_ID);
-
-		final var optionalNftInfo = subject.infoForNft(targetNftId);
-
-		assertTrue(optionalNftInfo.isEmpty());
-	}
-
-	@Test
-	void getsSpenderAsExpected() {
-		given(networkInfo.ledgerId()).willReturn(ledgerId);
-
-		final var optionalNftInfo = subject.infoForNft(targetNftId);
-
-		assertTrue(optionalNftInfo.isPresent());
-		final var info = optionalNftInfo.get();
-		assertEquals(ledgerId, info.getLedgerId());
-		assertEquals(targetNftId, info.getNftID());
-		assertEquals(nftOwnerId, info.getAccountID());
-		assertEquals(MISSING_ENTITY_ID, EntityId.fromGrpcAccountId(info.getSpenderId()));
-		assertEquals(fromJava(nftCreation).toGrpc(), info.getCreationTime());
-		assertArrayEquals(nftMeta, info.getMetadata().toByteArray());
-	}
-
-	@Test
-	void interpolatesTreasuryIdOnNftGet() {
-		targetNft.setOwner(MISSING_ENTITY_ID);
-
-		final var token = new MerkleToken();
-		token.setTreasury(EntityId.fromGrpcAccountId(tokenAccountId));
-		given(tokens.get(targetNftKey.getHiOrderAsNum())).willReturn(token);
-		given(networkInfo.ledgerId()).willReturn(ledgerId);
-
-		final var optionalNftInfo = subject.infoForNft(targetNftId);
-
-		final var info = optionalNftInfo.get();
-		assertEquals(ledgerId, info.getLedgerId());
-		assertEquals(targetNftId, info.getNftID());
-		assertEquals(tokenAccountId, info.getAccountID());
-		assertEquals(fromJava(nftCreation).toGrpc(), info.getCreationTime());
-		assertArrayEquals(nftMeta, info.getMetadata().toByteArray());
-	}
-
-	@Test
-	void getNftsAsExpected() {
-		given(networkInfo.ledgerId()).willReturn(ledgerId);
-		targetNft.setSpender(EntityId.fromGrpcAccountId(nftSpenderId));
-
-		final var optionalNftInfo = subject.infoForNft(targetNftId);
-
-		assertTrue(optionalNftInfo.isPresent());
-		final var info = optionalNftInfo.get();
-		assertEquals(ledgerId, info.getLedgerId());
-		assertEquals(targetNftId, info.getNftID());
-		assertEquals(nftOwnerId, info.getAccountID());
-		assertEquals(nftSpenderId, info.getSpenderId());
-		assertEquals(fromJava(nftCreation).toGrpc(), info.getCreationTime());
-		assertArrayEquals(nftMeta, info.getMetadata().toByteArray());
-	}
-
-	@Test
-	void viewAdaptToNullChildren() {
-		subject = new StateView(null, null, null);
-
-		assertSame(StateView.EMPTY_MM, subject.tokens());
-		assertSame(StateView.EMPTY_VM, subject.storage());
-		assertSame(StateView.EMPTY_VM, subject.contractStorage());
-		assertSame(StateView.EMPTY_MM, subject.uniqueTokens());
-		assertSame(StateView.EMPTY_MM, subject.tokenAssociations());
-		assertSame(StateView.EMPTY_MM, subject.contracts());
-		assertSame(StateView.EMPTY_MM, subject.accounts());
-		assertSame(StateView.EMPTY_MM, subject.topics());
-		assertSame(StateView.EMPTY_MM, subject.stakingInfo());
-		assertSame(EMPTY_CTX, subject.networkCtx());
-		assertTrue(subject.contentsOf(target).isEmpty());
-		assertTrue(subject.infoForFile(target).isEmpty());
-		assertTrue(subject.infoForContract(cid, aliasManager, maxTokensFprAccountInfo, rewardCalculator).isEmpty());
-		assertTrue(subject.infoForAccount(tokenAccountId, aliasManager, maxTokensFprAccountInfo,
-				rewardCalculator).isEmpty());
-		assertTrue(subject.tokenType(tokenId).isEmpty());
-		assertTrue(subject.infoForNft(targetNftId).isEmpty());
-		assertTrue(subject.infoForSchedule(scheduleId).isEmpty());
-		assertTrue(subject.infoForToken(tokenId).isEmpty());
-		assertTrue(subject.tokenWith(tokenId).isEmpty());
-		assertFalse(subject.nftExists(targetNftId));
-		assertFalse(subject.scheduleExists(scheduleId));
-		assertFalse(subject.tokenExists(tokenId));
-		assertEquals(0, subject.numNftsOwnedBy(nftOwnerId));
-	}
-
-	@Test
-	void constructsBackingStores() {
-		assertTrue(subject.asReadOnlyAccountStore() instanceof BackingAccounts);
-		assertTrue(subject.asReadOnlyTokenStore() instanceof BackingTokens);
-		assertTrue(subject.asReadOnlyNftStore() instanceof BackingNfts);
-		assertTrue(subject.asReadOnlyAssociationStore() instanceof BackingTokenRels);
-		assertEquals(tokens, ((BackingTokens) subject.asReadOnlyTokenStore()).getDelegate().get());
-		assertEquals(contracts, ((BackingAccounts) subject.asReadOnlyAccountStore()).getDelegate().get());
-		assertEquals(uniqueTokens, ((BackingNfts) subject.asReadOnlyNftStore()).getDelegate().get());
-		assertEquals(tokenRels, ((BackingTokenRels) subject.asReadOnlyAssociationStore()).getDelegate().get());
-	}
-
-	private final Instant nftCreation = Instant.ofEpochSecond(1_234_567L, 8);
-	private final byte[] nftMeta = "abcdefgh".getBytes();
-	private final NftID targetNftId = NftID.newBuilder()
-			.setTokenID(IdUtils.asToken("0.0.3"))
-			.setSerialNumber(4L)
-			.build();
-	private final NftID missingNftId = NftID.newBuilder()
-			.setTokenID(IdUtils.asToken("0.0.9"))
-			.setSerialNumber(5L)
-			.build();
-	private final EntityNumPair targetNftKey = EntityNumPair.fromLongs(3, 4);
-	private final EntityNumPair treasuryNftKey = EntityNumPair.fromLongs(3, 5);
-	private final MerkleUniqueToken targetNft = new MerkleUniqueToken(EntityId.fromGrpcAccountId(nftOwnerId), nftMeta,
-			fromJava(nftCreation));
-	private final MerkleUniqueToken treasuryNft = new MerkleUniqueToken(EntityId.fromGrpcAccountId(treasuryOwnerId),
-			nftMeta,
-			fromJava(nftCreation));
-
-	private final CustomFeeBuilder builder = new CustomFeeBuilder(payerAccountId);
-	private final CustomFee customFixedFeeInHbar = builder.withFixedFee(fixedHbar(100L));
-	private final CustomFee customFixedFeeInHts = builder.withFixedFee(fixedHts(tokenId, 100L));
-	private final CustomFee customFixedFeeSameToken = builder.withFixedFee(fixedHts(50L));
-	private final CustomFee customFractionalFee = builder.withFractionalFee(
-			fractional(15L, 100L)
-					.setMinimumAmount(10L)
-					.setMaximumAmount(50L));
-	private final List<CustomFee> grpcCustomFees = List.of(
-			customFixedFeeInHbar,
-			customFixedFeeInHts,
-			customFixedFeeSameToken,
-			customFractionalFee
-	);
+    private static final int wellKnownNumKvPairs = 144;
+    private final Instant resolutionTime = Instant.ofEpochSecond(123L);
+    private final RichInstant now =
+            RichInstant.fromGrpc(Timestamp.newBuilder().setNanos(123123213).build());
+    private final int maxTokensFprAccountInfo = 10;
+    private final long expiry = 2_000_000L;
+    private final byte[] data = "SOMETHING".getBytes();
+    private final byte[] expectedBytecode = "A Supermarket in California".getBytes();
+    private final String tokenMemo = "Goodbye and keep cold";
+    private HFileMeta metadata;
+    private HFileMeta immutableMetadata;
+    private final FileID target = asFile("0.0.123");
+    private final TokenID tokenId = asToken("0.0.5");
+    private final TokenID nftTokenId = asToken("0.0.3");
+    private final EntityNum tokenNum = EntityNum.fromTokenId(tokenId);
+    private final TokenID missingTokenId = asToken("0.0.5555");
+    private final AccountID payerAccountId = asAccount("0.0.9");
+    private final AccountID tokenAccountId = asAccount("0.0.10");
+    private final AccountID accountWithAlias = asAccountWithAlias("aaaa");
+    private final AccountID treasuryOwnerId = asAccount("0.0.0");
+    private final AccountID nftOwnerId = asAccount("0.0.44");
+    private final AccountID nftSpenderId = asAccount("0.0.66");
+    private final ScheduleID scheduleId = asSchedule("0.0.8");
+    private final ScheduleID missingScheduleId = asSchedule("0.0.9");
+    private final ContractID cid = asContract("0.0.1");
+    private final EntityNumPair tokenAssociationId =
+            EntityNumPair.fromLongs(tokenAccountId.getAccountNum(), tokenId.getTokenNum());
+    private final EntityNumPair nftAssociationId =
+            EntityNumPair.fromLongs(tokenAccountId.getAccountNum(), nftTokenId.getTokenNum());
+    private final byte[] cidAddress = asEvmAddress(0, 0, cid.getContractNum());
+    private final AccountID autoRenew = asAccount("0.0.6");
+    private final AccountID creatorAccountID = asAccount("0.0.7");
+    private final long autoRenewPeriod = 1_234_567;
+    private final String fileMemo = "Originally she thought";
+    private final ByteString create2Address =
+            ByteString.copyFrom(unhex("aaaaaaaaaaaaaaaaaaaaaaaa9abcdefabcdefbbb"));
+    private final ByteString ledgerId = ByteString.copyFromUtf8("0x03");
+
+    private FileGetInfoResponse.FileInfo expected;
+    private FileGetInfoResponse.FileInfo expectedImmutable;
+
+    private Map<byte[], byte[]> bytecode;
+    private Map<FileID, byte[]> contents;
+    private Map<FileID, HFileMeta> attrs;
+
+    private MerkleMap<EntityNum, MerkleToken> tokens;
+    private MerkleMap<EntityNum, MerkleTopic> topics;
+    private MerkleMap<EntityNum, MerkleAccount> contracts;
+    private MerkleMap<EntityNumPair, MerkleUniqueToken> uniqueTokens;
+    private MerkleMap<EntityNumPair, MerkleTokenRelStatus> tokenRels;
+    private VirtualMap<VirtualBlobKey, VirtualBlobValue> storage;
+    private VirtualMap<ContractKey, IterableContractValue> contractStorage;
+    private MerkleMap<EntityNum, MerkleStakingInfo> stakingInfo;
+    private MerkleNetworkContext networkContext;
+    private ScheduleStore scheduleStore;
+    private TransactionBody parentScheduleCreate;
+    private NetworkInfo networkInfo;
+    private MerkleTokenRelStatus tokenAccountRel;
+    private MerkleTokenRelStatus nftAccountRel;
+
+    private MerkleToken token;
+    private MerkleToken nft;
+    private ScheduleVirtualValue schedule;
+    private MerkleAccount contract;
+    private MerkleAccount tokenAccount;
+    private MerkleSpecialFiles specialFiles;
+    private MutableStateChildren children;
+
+    private MockedStatic<StateView> mockedStatic;
+
+    @Mock private AliasManager aliasManager;
+    @Mock private RewardCalculator rewardCalculator;
+
+    private StateView subject;
+
+    @BeforeEach
+    @SuppressWarnings("unchecked")
+    private void setup() throws Throwable {
+        metadata =
+                new HFileMeta(
+                        false, TxnHandlingScenario.MISC_FILE_WACL_KT.asJKey(), expiry, fileMemo);
+        immutableMetadata = new HFileMeta(false, StateView.EMPTY_WACL, expiry);
+
+        expectedImmutable =
+                FileGetInfoResponse.FileInfo.newBuilder()
+                        .setLedgerId(ledgerId)
+                        .setDeleted(false)
+                        .setExpirationTime(Timestamp.newBuilder().setSeconds(expiry))
+                        .setFileID(target)
+                        .setSize(data.length)
+                        .build();
+        expected =
+                expectedImmutable.toBuilder()
+                        .setKeys(TxnHandlingScenario.MISC_FILE_WACL_KT.asKey().getKeyList())
+                        .setMemo(fileMemo)
+                        .build();
+
+        tokenAccount =
+                MerkleAccountFactory.newAccount().isSmartContract(false).tokens(tokenId).get();
+        tokenAccount.setKey(EntityNum.fromAccountId(tokenAccountId));
+        tokenAccount.setNftsOwned(10);
+        tokenAccount.setMaxAutomaticAssociations(123);
+        tokenAccount.setAlias(TxnHandlingScenario.TOKEN_ADMIN_KT.asKey().getEd25519());
+        tokenAccount.setHeadTokenId(tokenId.getTokenNum());
+        tokenAccount.setNumAssociations(1);
+        tokenAccount.setStakePeriodStart(1);
+        tokenAccount.setNumPositiveBalances(0);
+        tokenAccount.setStakedId(10L);
+        tokenAccount.setDeclineReward(true);
+        contract =
+                MerkleAccountFactory.newAccount()
+                        .alias(create2Address)
+                        .memo("Stay cold...")
+                        .numKvPairs(wellKnownNumKvPairs)
+                        .isSmartContract(true)
+                        .accountKeys(COMPLEX_KEY_ACCOUNT_KT)
+                        .proxy(asAccount("0.0.3"))
+                        .receiverSigRequired(true)
+                        .balance(555L)
+                        .autoRenewPeriod(1_000_000L)
+                        .deleted(true)
+                        .expirationTime(9_999_999L)
+                        .autoRenewAccount(asAccount("0.0.4"))
+                        .maxAutomaticAssociations(10)
+                        .get();
+        contracts = (MerkleMap<EntityNum, MerkleAccount>) mock(MerkleMap.class);
+        topics = (MerkleMap<EntityNum, MerkleTopic>) mock(MerkleMap.class);
+        stakingInfo = (MerkleMap<EntityNum, MerkleStakingInfo>) mock(MerkleMap.class);
+        networkContext = mock(MerkleNetworkContext.class);
+
+        tokenAccountRel = new MerkleTokenRelStatus(123L, false, true, true);
+        tokenAccountRel.setKey(tokenAssociationId);
+        tokenAccountRel.setNext(nftTokenId.getTokenNum());
+
+        nftAccountRel = new MerkleTokenRelStatus(2L, false, true, false);
+        tokenAccountRel.setKey(nftAssociationId);
+        tokenAccountRel.setPrev(tokenId.getTokenNum());
+
+        tokenRels = new MerkleMap<>();
+        tokenRels.put(tokenAssociationId, tokenAccountRel);
+        tokenRels.put(nftAssociationId, nftAccountRel);
+
+        tokens = (MerkleMap<EntityNum, MerkleToken>) mock(MerkleMap.class);
+        token =
+                new MerkleToken(
+                        Long.MAX_VALUE,
+                        100,
+                        1,
+                        "UnfrozenToken",
+                        "UnfrozenTokenName",
+                        true,
+                        true,
+                        EntityId.fromGrpcTokenId(tokenId));
+        setUpToken(token);
+        token.setKey(tokenNum);
+        token.setTokenType(TokenType.FUNGIBLE_COMMON);
+
+        nft =
+                new MerkleToken(
+                        Long.MAX_VALUE,
+                        100,
+                        1,
+                        "UnfrozenToken",
+                        "UnfrozenTokenName",
+                        true,
+                        true,
+                        EntityId.fromGrpcTokenId(nftTokenId));
+        setUpToken(nft);
+        nft.setKey(EntityNum.fromTokenId(nftTokenId));
+        nft.setTokenType(TokenType.NON_FUNGIBLE_UNIQUE);
+
+        token.setSupplyType(TokenSupplyType.FINITE);
+        token.setFeeScheduleFrom(grpcCustomFees);
+
+        scheduleStore = mock(ScheduleStore.class);
+        final var scheduleMemo = "For what but eye and ear";
+        parentScheduleCreate =
+                scheduleCreateTxnWith(
+                        SCHEDULE_ADMIN_KT.asKey(),
+                        scheduleMemo,
+                        payerAccountId,
+                        creatorAccountID,
+                        MiscUtils.asTimestamp(now.toJava()));
+        schedule = ScheduleVirtualValue.from(parentScheduleCreate.toByteArray(), expiry);
+        schedule.witnessValidSignature("01234567890123456789012345678901".getBytes());
+        schedule.witnessValidSignature("_123456789_123456789_123456789_1".getBytes());
+        schedule.witnessValidSignature("_o23456789_o23456789_o23456789_o".getBytes());
+
+        contents = mock(Map.class);
+        attrs = mock(Map.class);
+        bytecode = mock(Map.class);
+        specialFiles = mock(MerkleSpecialFiles.class);
+
+        uniqueTokens = new MerkleMap<>();
+        uniqueTokens.put(targetNftKey, targetNft);
+        uniqueTokens.put(treasuryNftKey, treasuryNft);
+
+        storage = (VirtualMap<VirtualBlobKey, VirtualBlobValue>) mock(VirtualMap.class);
+        contractStorage = (VirtualMap<ContractKey, IterableContractValue>) mock(VirtualMap.class);
+
+        children = new MutableStateChildren();
+        children.setUniqueTokens(uniqueTokens);
+        children.setAccounts(contracts);
+        children.setTokens(tokens);
+        children.setTokenAssociations(tokenRels);
+        children.setSpecialFiles(specialFiles);
+        children.setTokens(tokens);
+        children.setStakingInfo(stakingInfo);
+
+        networkInfo = mock(NetworkInfo.class);
+
+        subject = new StateView(scheduleStore, children, networkInfo);
+        subject.fileAttrs = attrs;
+        subject.fileContents = contents;
+        subject.contractBytecode = bytecode;
+    }
+
+    private void setUpToken(final MerkleToken token) throws DecoderException {
+        token.setMemo(tokenMemo);
+        token.setAdminKey(TxnHandlingScenario.TOKEN_ADMIN_KT.asJKey());
+        token.setFreezeKey(TxnHandlingScenario.TOKEN_FREEZE_KT.asJKey());
+        token.setKycKey(TxnHandlingScenario.TOKEN_KYC_KT.asJKey());
+        token.setSupplyKey(COMPLEX_KEY_ACCOUNT_KT.asJKey());
+        token.setWipeKey(MISC_ACCOUNT_KT.asJKey());
+        token.setFeeScheduleKey(MISC_ACCOUNT_KT.asJKey());
+        token.setPauseKey(TxnHandlingScenario.TOKEN_PAUSE_KT.asJKey());
+        token.setAutoRenewAccount(EntityId.fromGrpcAccountId(autoRenew));
+        token.setExpiry(expiry);
+        token.setAutoRenewPeriod(autoRenewPeriod);
+        token.setDeleted(true);
+        token.setPaused(true);
+        token.setSupplyType(TokenSupplyType.FINITE);
+        token.setFeeScheduleFrom(grpcCustomFees);
+    }
+
+    @Test
+    void tokenExistsWorks() {
+        given(tokens.containsKey(tokenNum)).willReturn(true);
+        assertTrue(subject.tokenExists(tokenId));
+        assertFalse(subject.tokenExists(missingTokenId));
+    }
+
+    @Test
+    void nftExistsWorks() {
+        assertTrue(subject.nftExists(targetNftId));
+        assertFalse(subject.nftExists(missingNftId));
+    }
+
+    @Test
+    void scheduleExistsWorks() {
+        given(scheduleStore.resolve(scheduleId)).willReturn(scheduleId);
+        given(scheduleStore.resolve(missingScheduleId)).willReturn(ScheduleStore.MISSING_SCHEDULE);
+
+        assertTrue(subject.scheduleExists(scheduleId));
+        assertFalse(subject.scheduleExists(missingScheduleId));
+    }
+
+    @Test
+    void tokenWithWorks() {
+        given(tokens.get(tokenNum)).willReturn(token);
+        assertSame(token, subject.tokenWith(tokenId).get());
+    }
+
+    @Test
+    void tokenWithWorksForMissing() {
+        assertTrue(subject.tokenWith(tokenId).isEmpty());
+    }
+
+    @Test
+    void recognizesMissingSchedule() {
+        given(scheduleStore.resolve(missingScheduleId)).willReturn(ScheduleStore.MISSING_SCHEDULE);
+        final var info = subject.infoForSchedule(missingScheduleId);
+        assertTrue(info.isEmpty());
+    }
+
+    @Test
+    void infoForScheduleFailsGracefully() {
+        given(scheduleStore.get(any())).willThrow(IllegalArgumentException.class);
+        final var info = subject.infoForSchedule(scheduleId);
+        assertTrue(info.isEmpty());
+    }
+
+    @Test
+    void getsScheduleInfoForDeleted() {
+        given(scheduleStore.resolve(scheduleId)).willReturn(scheduleId);
+        given(scheduleStore.get(scheduleId)).willReturn(schedule);
+        given(networkInfo.ledgerId()).willReturn(ledgerId);
+
+        final var expectedScheduledTxn =
+                parentScheduleCreate.getScheduleCreate().getScheduledTransactionBody();
+
+        schedule.markDeleted(resolutionTime);
+        final var gotten = subject.infoForSchedule(scheduleId);
+        final var info = gotten.get();
+
+        assertEquals(scheduleId, info.getScheduleID());
+        assertEquals(schedule.schedulingAccount().toGrpcAccountId(), info.getCreatorAccountID());
+        assertEquals(schedule.payer().toGrpcAccountId(), info.getPayerAccountID());
+        assertEquals(Timestamp.newBuilder().setSeconds(expiry).build(), info.getExpirationTime());
+        final var expectedSignatoryList = KeyList.newBuilder();
+        schedule.signatories()
+                .forEach(
+                        a ->
+                                expectedSignatoryList.addKeys(
+                                        Key.newBuilder().setEd25519(ByteString.copyFrom(a))));
+        assertArrayEquals(
+                expectedSignatoryList.build().getKeysList().toArray(),
+                info.getSigners().getKeysList().toArray());
+        assertEquals(SCHEDULE_ADMIN_KT.asKey(), info.getAdminKey());
+        assertEquals(expectedScheduledTxn, info.getScheduledTransactionBody());
+        assertEquals(schedule.scheduledTransactionId(), info.getScheduledTransactionID());
+        assertEquals(fromJava(resolutionTime).toGrpc(), info.getDeletionTime());
+        assertEquals(ledgerId, info.getLedgerId());
+    }
+
+    @Test
+    void getsScheduleInfoForExecuted() {
+        final var mockEd25519Key = new JEd25519Key("a123456789a123456789a123456789a1".getBytes());
+        final var mockSecp256k1Key =
+                new JECDSASecp256k1Key("012345678901234567890123456789012".getBytes());
+        given(scheduleStore.resolve(scheduleId)).willReturn(scheduleId);
+        given(scheduleStore.get(scheduleId)).willReturn(schedule);
+        given(networkInfo.ledgerId()).willReturn(ledgerId);
+        schedule.witnessValidSignature(mockEd25519Key.primitiveKeyIfPresent());
+        schedule.witnessValidSignature(mockSecp256k1Key.primitiveKeyIfPresent());
+
+        schedule.markExecuted(resolutionTime);
+        final var gotten = subject.infoForSchedule(scheduleId);
+        final var info = gotten.get();
+
+        assertEquals(ledgerId, info.getLedgerId());
+        assertEquals(fromJava(resolutionTime).toGrpc(), info.getExecutionTime());
+        final var signatures = info.getSigners().getKeysList();
+        assertEquals(MiscUtils.asKeyUnchecked(mockEd25519Key), signatures.get(3));
+        assertEquals(MiscUtils.asKeyUnchecked(mockSecp256k1Key), signatures.get(4));
+    }
+
+    @Test
+    void recognizesMissingToken() {
+        final var info = subject.infoForToken(missingTokenId);
+
+        assertTrue(info.isEmpty());
+    }
+
+    @Test
+    void infoForTokenFailsGracefully() {
+        given(tokens.get(tokenNum)).willThrow(IllegalArgumentException.class);
+
+        final var info = subject.infoForToken(tokenId);
+
+        assertTrue(info.isEmpty());
+    }
+
+    @Test
+    void getsTokenInfoMinusFreezeIfMissing() {
+        given(networkInfo.ledgerId()).willReturn(ledgerId);
+        given(tokens.get(tokenNum)).willReturn(token);
+
+        token.setFreezeKey(MerkleToken.UNUSED_KEY);
+
+        final var info = subject.infoForToken(tokenId).get();
+
+        assertEquals(tokenId, info.getTokenId());
+        assertEquals(token.symbol(), info.getSymbol());
+        assertEquals(token.name(), info.getName());
+        assertEquals(token.treasury().toGrpcAccountId(), info.getTreasury());
+        assertEquals(token.totalSupply(), info.getTotalSupply());
+        assertEquals(token.decimals(), info.getDecimals());
+        assertEquals(TOKEN_ADMIN_KT.asKey(), info.getAdminKey());
+        assertEquals(TokenFreezeStatus.FreezeNotApplicable, info.getDefaultFreezeStatus());
+        assertFalse(info.hasFreezeKey());
+        assertEquals(ledgerId, info.getLedgerId());
+    }
+
+    @Test
+    void getsTokenInfoMinusPauseIfMissing() {
+        given(networkInfo.ledgerId()).willReturn(ledgerId);
+        given(tokens.get(tokenNum)).willReturn(token);
+
+        token.setPauseKey(MerkleToken.UNUSED_KEY);
+
+        final var info = subject.infoForToken(tokenId).get();
+
+        assertEquals(tokenId, info.getTokenId());
+        assertEquals(token.symbol(), info.getSymbol());
+        assertEquals(token.name(), info.getName());
+        assertEquals(token.treasury().toGrpcAccountId(), info.getTreasury());
+        assertEquals(token.totalSupply(), info.getTotalSupply());
+        assertEquals(token.decimals(), info.getDecimals());
+        assertEquals(TOKEN_ADMIN_KT.asKey(), info.getAdminKey());
+        assertEquals(PauseNotApplicable, info.getPauseStatus());
+        assertFalse(info.hasPauseKey());
+        assertEquals(ledgerId, info.getLedgerId());
+    }
+
+    @Test
+    void getsTokenInfo() {
+        given(networkInfo.ledgerId()).willReturn(ledgerId);
+        given(tokens.get(tokenNum)).willReturn(token);
+        final var miscKey = MISC_ACCOUNT_KT.asKey();
+
+        final var info = subject.infoForToken(tokenId).get();
+
+        assertTrue(info.getDeleted());
+        assertEquals(Paused, info.getPauseStatus());
+        assertEquals(token.memo(), info.getMemo());
+        assertEquals(tokenId, info.getTokenId());
+        assertEquals(token.symbol(), info.getSymbol());
+        assertEquals(token.name(), info.getName());
+        assertEquals(token.treasury().toGrpcAccountId(), info.getTreasury());
+        assertEquals(token.totalSupply(), info.getTotalSupply());
+        assertEquals(token.decimals(), info.getDecimals());
+        assertEquals(token.grpcFeeSchedule(), info.getCustomFeesList());
+        assertEquals(TOKEN_ADMIN_KT.asKey(), info.getAdminKey());
+        assertEquals(TOKEN_FREEZE_KT.asKey(), info.getFreezeKey());
+        assertEquals(TOKEN_KYC_KT.asKey(), info.getKycKey());
+        assertEquals(TOKEN_PAUSE_KT.asKey(), info.getPauseKey());
+        assertEquals(miscKey, info.getWipeKey());
+        assertEquals(miscKey, info.getFeeScheduleKey());
+        assertEquals(autoRenew, info.getAutoRenewAccount());
+        assertEquals(
+                Duration.newBuilder().setSeconds(autoRenewPeriod).build(),
+                info.getAutoRenewPeriod());
+        assertEquals(Timestamp.newBuilder().setSeconds(expiry).build(), info.getExpiry());
+        assertEquals(TokenFreezeStatus.Frozen, info.getDefaultFreezeStatus());
+        assertEquals(TokenKycStatus.Granted, info.getDefaultKycStatus());
+        assertEquals(ledgerId, info.getLedgerId());
+    }
+
+    @Test
+    void getsContractInfo() throws Exception {
+        final var target = EntityNum.fromContractId(cid);
+        given(contracts.get(EntityNum.fromContractId(cid))).willReturn(contract);
+        final var expectedTotalStorage =
+                StateView.BYTES_PER_EVM_KEY_VALUE_PAIR * wellKnownNumKvPairs;
+        given(networkInfo.ledgerId()).willReturn(ledgerId);
+
+        List<TokenRelationship> rels =
+                List.of(
+                        TokenRelationship.newBuilder()
+                                .setTokenId(TokenID.newBuilder().setTokenNum(123L))
+                                .setFreezeStatus(TokenFreezeStatus.FreezeNotApplicable)
+                                .setKycStatus(TokenKycStatus.KycNotApplicable)
+                                .setBalance(321L)
+                                .build());
+        mockedStatic = mockStatic(StateView.class);
+        mockedStatic
+                .when(() -> StateView.tokenRels(subject, contract, maxTokensFprAccountInfo))
+                .thenReturn(rels);
+
+        final var info =
+                subject.infoForContract(
+                                cid, aliasManager, maxTokensFprAccountInfo, rewardCalculator)
+                        .get();
+
+        assertEquals(cid, info.getContractID());
+        assertEquals(asAccount(cid), info.getAccountID());
+        assertEquals(JKey.mapJKey(contract.getAccountKey()), info.getAdminKey());
+        assertEquals(contract.getMemo(), info.getMemo());
+        assertEquals(contract.getAutoRenewSecs(), info.getAutoRenewPeriod().getSeconds());
+        assertEquals(contract.getBalance(), info.getBalance());
+        assertEquals(CommonUtils.hex(create2Address.toByteArray()), info.getContractAccountID());
+        assertEquals(contract.getExpiry(), info.getExpirationTime().getSeconds());
+        assertEquals(EntityId.fromIdentityCode(4), contract.getAutoRenewAccount());
+        assertEquals(rels, info.getTokenRelationshipsList());
+        assertEquals(ledgerId, info.getLedgerId());
+        assertTrue(info.getDeleted());
+        assertEquals(expectedTotalStorage, info.getStorage());
+        assertEquals(
+                contract.getMaxAutomaticAssociations(), info.getMaxAutomaticTokenAssociations());
+        mockedStatic.close();
+    }
+
+    @Test
+    void getsContractInfoWithoutCreate2Address() throws Exception {
+        final var target = EntityNum.fromContractId(cid);
+        given(contracts.get(EntityNum.fromContractId(cid))).willReturn(contract);
+        contract.setAlias(ByteString.EMPTY);
+        final var expectedTotalStorage =
+                StateView.BYTES_PER_EVM_KEY_VALUE_PAIR * wellKnownNumKvPairs;
+        given(networkInfo.ledgerId()).willReturn(ledgerId);
+
+        List<TokenRelationship> rels =
+                List.of(
+                        TokenRelationship.newBuilder()
+                                .setTokenId(TokenID.newBuilder().setTokenNum(123L))
+                                .setFreezeStatus(TokenFreezeStatus.FreezeNotApplicable)
+                                .setKycStatus(TokenKycStatus.KycNotApplicable)
+                                .setBalance(321L)
+                                .build());
+        mockedStatic = mockStatic(StateView.class);
+        mockedStatic
+                .when(() -> StateView.tokenRels(subject, contract, maxTokensFprAccountInfo))
+                .thenReturn(rels);
+
+        final var info =
+                subject.infoForContract(
+                                cid, aliasManager, maxTokensFprAccountInfo, rewardCalculator)
+                        .get();
+
+        assertEquals(cid, info.getContractID());
+        assertEquals(asAccount(cid), info.getAccountID());
+        assertEquals(JKey.mapJKey(contract.getAccountKey()), info.getAdminKey());
+        assertEquals(contract.getMemo(), info.getMemo());
+        assertEquals(contract.getAutoRenewSecs(), info.getAutoRenewPeriod().getSeconds());
+        assertEquals(contract.getBalance(), info.getBalance());
+        assertEquals(EntityIdUtils.asHexedEvmAddress(asAccount(cid)), info.getContractAccountID());
+        assertEquals(contract.getExpiry(), info.getExpirationTime().getSeconds());
+        assertEquals(rels, info.getTokenRelationshipsList());
+        assertEquals(ledgerId, info.getLedgerId());
+        assertTrue(info.getDeleted());
+        assertEquals(expectedTotalStorage, info.getStorage());
+        mockedStatic.close();
+    }
+
+    @Test
+    void getTokenRelationship() {
+        given(tokens.getOrDefault(tokenNum, REMOVED_TOKEN)).willReturn(token);
+        given(tokens.getOrDefault(EntityNum.fromTokenId(nftTokenId), REMOVED_TOKEN))
+                .willReturn(nft);
+
+        List<TokenRelationship> expectedRels =
+                List.of(
+                        TokenRelationship.newBuilder()
+                                .setTokenId(tokenId)
+                                .setSymbol("UnfrozenToken")
+                                .setBalance(123L)
+                                .setKycStatus(TokenKycStatus.Granted)
+                                .setFreezeStatus(TokenFreezeStatus.Unfrozen)
+                                .setAutomaticAssociation(true)
+                                .setDecimals(1)
+                                .build(),
+                        TokenRelationship.newBuilder()
+                                .setTokenId(nftTokenId)
+                                .setSymbol("UnfrozenToken")
+                                .setBalance(2L)
+                                .setKycStatus(TokenKycStatus.Granted)
+                                .setFreezeStatus(TokenFreezeStatus.Unfrozen)
+                                .setAutomaticAssociation(false)
+                                .setDecimals(1)
+                                .build());
+
+        final var actualRels = StateView.tokenRels(subject, tokenAccount, maxTokensFprAccountInfo);
+
+        assertEquals(expectedRels, actualRels);
+    }
+
+    @Test
+    void getInfoForNftMissing() {
+        final var nftID = NftID.newBuilder().setTokenID(tokenId).setSerialNumber(123L).build();
+
+        final var actualTokenNftInfo = subject.infoForNft(nftID);
+
+        assertEquals(Optional.empty(), actualTokenNftInfo);
+    }
+
+    @Test
+    void getTokenType() {
+        given(tokens.get(tokenNum)).willReturn(token);
+        final var actualTokenType = subject.tokenType(tokenId).get();
+
+        assertEquals(FUNGIBLE_COMMON, actualTokenType);
+    }
+
+    @Test
+    void getTokenTypeMissing() {
+        final var actualTokenType = subject.tokenType(tokenId);
+
+        assertEquals(Optional.empty(), actualTokenType);
+    }
+
+    @Test
+    void getTokenTypeException() {
+        given(tokens.get(tokenId)).willThrow(new RuntimeException());
+
+        final var actualTokenType = subject.tokenType(tokenId);
+
+        assertEquals(Optional.empty(), actualTokenType);
+    }
+
+    @Test
+    void infoForRegularAccount() {
+        given(contracts.get(EntityNum.fromAccountId(tokenAccountId))).willReturn(tokenAccount);
+
+        mockedStatic = mockStatic(StateView.class);
+        mockedStatic
+                .when(() -> StateView.tokenRels(subject, tokenAccount, maxTokensFprAccountInfo))
+                .thenReturn(Collections.emptyList());
+        given(networkInfo.ledgerId()).willReturn(ledgerId);
+
+        final var expectedResponse =
+                CryptoGetInfoResponse.AccountInfo.newBuilder()
+                        .setLedgerId(ledgerId)
+                        .setKey(asKeyUnchecked(tokenAccount.getAccountKey()))
+                        .setAccountID(tokenAccountId)
+                        .setAlias(tokenAccount.getAlias())
+                        .setReceiverSigRequired(tokenAccount.isReceiverSigRequired())
+                        .setDeleted(tokenAccount.isDeleted())
+                        .setMemo(tokenAccount.getMemo())
+                        .setAutoRenewPeriod(
+                                Duration.newBuilder().setSeconds(tokenAccount.getAutoRenewSecs()))
+                        .setBalance(tokenAccount.getBalance())
+                        .setExpirationTime(
+                                Timestamp.newBuilder().setSeconds(tokenAccount.getExpiry()))
+                        .setContractAccountID(EntityIdUtils.asHexedEvmAddress(tokenAccountId))
+                        .setOwnedNfts(tokenAccount.getNftsOwned())
+                        .setMaxAutomaticTokenAssociations(
+                                tokenAccount.getMaxAutomaticAssociations())
+                        .setStakingInfo(
+                                StakingInfo.newBuilder()
+                                        .setDeclineReward(true)
+                                        .setStakedAccountId(
+                                                AccountID.newBuilder().setAccountNum(10L).build())
+                                        .build())
+                        .build();
+
+        final var actualResponse =
+                subject.infoForAccount(
+                        tokenAccountId, aliasManager, maxTokensFprAccountInfo, rewardCalculator);
+
+        assertEquals(expectedResponse, actualResponse.get());
+        mockedStatic.close();
+    }
+
+    @Test
+    void stakingInfoReturnedCorrectly() {
+        final var startPeriod = 10000L;
+        tokenAccount =
+                MerkleAccountFactory.newAccount().isSmartContract(false).tokens(tokenId).get();
+        tokenAccount.setStakedId(-10L);
+        tokenAccount.setDeclineReward(false);
+        tokenAccount.setStakePeriodStart(startPeriod);
+        given(rewardCalculator.epochSecondAtStartOfPeriod(startPeriod)).willReturn(1_234_567L);
+
+        given(contracts.get(EntityNum.fromAccountId(tokenAccountId))).willReturn(tokenAccount);
+
+        mockedStatic = mockStatic(StateView.class);
+        mockedStatic
+                .when(() -> StateView.tokenRels(subject, tokenAccount, maxTokensFprAccountInfo))
+                .thenReturn(Collections.emptyList());
+        given(networkInfo.ledgerId()).willReturn(ledgerId);
+
+        final var expectedResponse =
+                StakingInfo.newBuilder()
+                        .setDeclineReward(false)
+                        .setStakedNodeId(9L)
+                        .setStakePeriodStart(Timestamp.newBuilder().setSeconds(1_234_567L))
+                        .build();
+
+        final var actualResponse =
+                subject.infoForAccount(
+                        tokenAccountId, aliasManager, maxTokensFprAccountInfo, rewardCalculator);
+
+        assertEquals(expectedResponse, actualResponse.get().getStakingInfo());
+        mockedStatic.close();
+    }
+
+    @Test
+    void infoForExternallyOperatedAccount() {
+        final byte[] ecdsaKey =
+                Hex.decode("033a514176466fa815ed481ffad09110a2d344f6c9b78c1d14afc351c3a51be33d");
+        given(contracts.get(EntityNum.fromAccountId(tokenAccountId))).willReturn(tokenAccount);
+        tokenAccount.setAccountKey(new JECDSASecp256k1Key(ecdsaKey));
+        final var expectedAddress = CommonUtils.hex(EthTxSigs.recoverAddressFromPubKey(ecdsaKey));
+
+        mockedStatic = mockStatic(StateView.class);
+        mockedStatic
+                .when(() -> StateView.tokenRels(subject, tokenAccount, maxTokensFprAccountInfo))
+                .thenReturn(Collections.emptyList());
+        given(networkInfo.ledgerId()).willReturn(ledgerId);
+
+        final var expectedResponse =
+                CryptoGetInfoResponse.AccountInfo.newBuilder()
+                        .setLedgerId(ledgerId)
+                        .setKey(asKeyUnchecked(tokenAccount.getAccountKey()))
+                        .setAccountID(tokenAccountId)
+                        .setAlias(tokenAccount.getAlias())
+                        .setReceiverSigRequired(tokenAccount.isReceiverSigRequired())
+                        .setDeleted(tokenAccount.isDeleted())
+                        .setMemo(tokenAccount.getMemo())
+                        .setAutoRenewPeriod(
+                                Duration.newBuilder().setSeconds(tokenAccount.getAutoRenewSecs()))
+                        .setBalance(tokenAccount.getBalance())
+                        .setExpirationTime(
+                                Timestamp.newBuilder().setSeconds(tokenAccount.getExpiry()))
+                        .setContractAccountID(expectedAddress)
+                        .setOwnedNfts(tokenAccount.getNftsOwned())
+                        .setMaxAutomaticTokenAssociations(
+                                tokenAccount.getMaxAutomaticAssociations())
+                        .setStakingInfo(
+                                StakingInfo.newBuilder()
+                                        .setStakedAccountId(
+                                                AccountID.newBuilder().setAccountNum(10).build())
+                                        .setDeclineReward(true)
+                                        .build())
+                        .build();
+
+        final var actualResponse =
+                subject.infoForAccount(
+                        tokenAccountId, aliasManager, maxTokensFprAccountInfo, rewardCalculator);
+        mockedStatic.close();
+
+        assertEquals(expectedResponse, actualResponse.get());
+    }
+
+    @Test
+    void accountDetails() {
+        given(contracts.get(EntityNum.fromAccountId(tokenAccountId))).willReturn(tokenAccount);
+
+        mockedStatic = mockStatic(StateView.class);
+        mockedStatic
+                .when(() -> StateView.tokenRels(subject, tokenAccount, maxTokensFprAccountInfo))
+                .thenReturn(Collections.emptyList());
+        given(networkInfo.ledgerId()).willReturn(ledgerId);
+        final var expectedResponse =
+                GetAccountDetailsResponse.AccountDetails.newBuilder()
+                        .setLedgerId(ledgerId)
+                        .setKey(asKeyUnchecked(tokenAccount.getAccountKey()))
+                        .setAccountId(tokenAccountId)
+                        .setAlias(tokenAccount.getAlias())
+                        .setReceiverSigRequired(tokenAccount.isReceiverSigRequired())
+                        .setDeleted(tokenAccount.isDeleted())
+                        .setMemo(tokenAccount.getMemo())
+                        .setAutoRenewPeriod(
+                                Duration.newBuilder().setSeconds(tokenAccount.getAutoRenewSecs()))
+                        .setBalance(tokenAccount.getBalance())
+                        .setExpirationTime(
+                                Timestamp.newBuilder().setSeconds(tokenAccount.getExpiry()))
+                        .setContractAccountId(EntityIdUtils.asHexedEvmAddress(tokenAccountId))
+                        .setOwnedNfts(tokenAccount.getNftsOwned())
+                        .setMaxAutomaticTokenAssociations(
+                                tokenAccount.getMaxAutomaticAssociations())
+                        .addAllGrantedCryptoAllowances(getCryptoGrantedAllowancesList(tokenAccount))
+                        .addAllGrantedTokenAllowances(
+                                getFungibleGrantedTokenAllowancesList(tokenAccount))
+                        .addAllGrantedNftAllowances(getNftGrantedAllowancesList(tokenAccount))
+                        .build();
+
+        final var actualResponse =
+                subject.accountDetails(tokenAccountId, aliasManager, maxTokensFprAccountInfo);
+        mockedStatic.close();
+
+        assertEquals(expectedResponse, actualResponse.get());
+    }
+
+    @Test
+    void infoForAccountWithAlias() {
+        given(aliasManager.lookupIdBy(any())).willReturn(EntityNum.fromAccountId(tokenAccountId));
+        given(contracts.get(EntityNum.fromAccountId(tokenAccountId))).willReturn(tokenAccount);
+        mockedStatic = mockStatic(StateView.class);
+        mockedStatic
+                .when(() -> StateView.tokenRels(subject, tokenAccount, maxTokensFprAccountInfo))
+                .thenReturn(Collections.emptyList());
+        given(networkInfo.ledgerId()).willReturn(ledgerId);
+
+        final var expectedResponse =
+                CryptoGetInfoResponse.AccountInfo.newBuilder()
+                        .setLedgerId(ledgerId)
+                        .setKey(asKeyUnchecked(tokenAccount.getAccountKey()))
+                        .setAccountID(tokenAccountId)
+                        .setAlias(tokenAccount.getAlias())
+                        .setReceiverSigRequired(tokenAccount.isReceiverSigRequired())
+                        .setDeleted(tokenAccount.isDeleted())
+                        .setMemo(tokenAccount.getMemo())
+                        .setAutoRenewPeriod(
+                                Duration.newBuilder().setSeconds(tokenAccount.getAutoRenewSecs()))
+                        .setBalance(tokenAccount.getBalance())
+                        .setExpirationTime(
+                                Timestamp.newBuilder().setSeconds(tokenAccount.getExpiry()))
+                        .setContractAccountID(EntityIdUtils.asHexedEvmAddress(tokenAccountId))
+                        .setOwnedNfts(tokenAccount.getNftsOwned())
+                        .setMaxAutomaticTokenAssociations(
+                                tokenAccount.getMaxAutomaticAssociations())
+                        .setStakingInfo(
+                                StakingInfo.newBuilder()
+                                        .setDeclineReward(true)
+                                        .setStakedAccountId(
+                                                AccountID.newBuilder().setAccountNum(10L).build())
+                                        .build())
+                        .build();
+
+        final var actualResponse =
+                subject.infoForAccount(
+                        accountWithAlias, aliasManager, maxTokensFprAccountInfo, rewardCalculator);
+        mockedStatic.close();
+        assertEquals(expectedResponse, actualResponse.get());
+    }
+
+    @Test
+    void numNftsOwnedWorksForExisting() {
+        given(contracts.get(EntityNum.fromAccountId(tokenAccountId))).willReturn(tokenAccount);
+
+        assertEquals(tokenAccount.getNftsOwned(), subject.numNftsOwnedBy(tokenAccountId));
+    }
+
+    @Test
+    void infoForMissingAccount() {
+        given(contracts.get(EntityNum.fromAccountId(tokenAccountId))).willReturn(null);
+
+        final var actualResponse =
+                subject.infoForAccount(
+                        tokenAccountId, aliasManager, maxTokensFprAccountInfo, rewardCalculator);
+
+        assertEquals(Optional.empty(), actualResponse);
+    }
+
+    @Test
+    void infoForMissingAccountWithAlias() {
+        EntityNum mockedEntityNum = mock(EntityNum.class);
+
+        given(aliasManager.lookupIdBy(any())).willReturn(mockedEntityNum);
+        given(contracts.get(mockedEntityNum)).willReturn(null);
+
+        final var actualResponse =
+                subject.infoForAccount(
+                        accountWithAlias, aliasManager, maxTokensFprAccountInfo, rewardCalculator);
+        assertEquals(Optional.empty(), actualResponse);
+    }
+
+    @Test
+    void getTopics() {
+        final var children = new MutableStateChildren();
+        children.setTopics(topics);
+
+        subject = new StateView(null, children, null);
+
+        final var actualTopics = subject.topics();
+
+        assertEquals(topics, actualTopics);
+    }
+
+    @Test
+    void getStorageAndContractStorage() {
+        final var children = new MutableStateChildren();
+        children.setContractStorage(contractStorage);
+        children.setStorage(storage);
+
+        subject = new StateView(null, children, null);
+
+        final var actualStorage = subject.storage();
+        final var actualContractStorage = subject.contractStorage();
+
+        assertEquals(storage, actualStorage);
+        assertEquals(contractStorage, actualContractStorage);
+    }
+
+    @Test
+    void getStakingInfoAndContext() {
+        final var children = new MutableStateChildren();
+        children.setStakingInfo(stakingInfo);
+        children.setNetworkCtx(networkContext);
+
+        subject = new StateView(null, children, null);
+
+        final var actualStakingInfo = subject.stakingInfo();
+        final var actualNetworkContext = subject.networkCtx();
+
+        assertEquals(stakingInfo, actualStakingInfo);
+        assertEquals(networkContext, actualNetworkContext);
+    }
+
+    @Test
+    void returnsEmptyOptionalIfContractMissing() {
+        given(contracts.get(any())).willReturn(null);
+
+        assertTrue(
+                subject.infoForContract(
+                                cid, aliasManager, maxTokensFprAccountInfo, rewardCalculator)
+                        .isEmpty());
+    }
+
+    @Test
+    void handlesNullKey() {
+        given(contracts.get(EntityNum.fromContractId(cid))).willReturn(contract);
+        given(networkInfo.ledgerId()).willReturn(ledgerId);
+        mockedStatic = mockStatic(StateView.class);
+        mockedStatic
+                .when(() -> StateView.tokenRels(any(), any(), anyInt()))
+                .thenReturn(Collections.emptyList());
+        contract.setAccountKey(null);
+
+        final var info =
+                subject.infoForContract(
+                                cid, aliasManager, maxTokensFprAccountInfo, rewardCalculator)
+                        .get();
+
+        assertFalse(info.hasAdminKey());
+        mockedStatic.close();
+    }
+
+    @Test
+    void handlesNullAutoRenewAccount() {
+        given(contracts.get(EntityNum.fromContractId(cid))).willReturn(contract);
+        given(networkInfo.ledgerId()).willReturn(ledgerId);
+        mockedStatic = mockStatic(StateView.class);
+        mockedStatic
+                .when(() -> StateView.tokenRels(any(), any(), anyInt()))
+                .thenReturn(Collections.emptyList());
+        contract.setAutoRenewAccount(null);
+
+        final var info =
+                subject.infoForContract(
+                                cid, aliasManager, maxTokensFprAccountInfo, rewardCalculator)
+                        .get();
+
+        assertFalse(info.hasAutoRenewAccountId());
+        mockedStatic.close();
+    }
+
+    @Test
+    void getsAttrs() {
+        given(attrs.get(target)).willReturn(metadata);
+
+        final var stuff = subject.attrOf(target);
+
+        assertEquals(metadata.toString(), stuff.get().toString());
+    }
+
+    @Test
+    void getsBytecode() {
+        given(bytecode.get(argThat((byte[] bytes) -> Arrays.equals(cidAddress, bytes))))
+                .willReturn(expectedBytecode);
+
+        final var actual = subject.bytecodeOf(EntityNum.fromContractId(cid));
+
+        assertArrayEquals(expectedBytecode, actual.get());
+    }
+
+    @Test
+    void getsContents() {
+        given(contents.get(target)).willReturn(data);
+
+        final var stuff = subject.contentsOf(target);
+
+        assertTrue(stuff.isPresent());
+        assertArrayEquals(data, stuff.get());
+    }
+
+    @Test
+    void assemblesFileInfo() {
+        given(attrs.get(target)).willReturn(metadata);
+        given(contents.get(target)).willReturn(data);
+        given(networkInfo.ledgerId()).willReturn(ledgerId);
+
+        final var info = subject.infoForFile(target);
+
+        assertTrue(info.isPresent());
+        assertEquals(expected, info.get());
+    }
+
+    @Test
+    void assemblesFileInfoForImmutable() {
+        given(attrs.get(target)).willReturn(immutableMetadata);
+        given(contents.get(target)).willReturn(data);
+        given(networkInfo.ledgerId()).willReturn(ledgerId);
+
+        final var info = subject.infoForFile(target);
+
+        assertTrue(info.isPresent());
+        assertEquals(expectedImmutable, info.get());
+    }
+
+    @Test
+    void assemblesFileInfoForDeleted() {
+        expected = expected.toBuilder().setDeleted(true).setSize(0).build();
+        metadata.setDeleted(true);
+
+        given(attrs.get(target)).willReturn(metadata);
+        given(networkInfo.ledgerId()).willReturn(ledgerId);
+
+        final var info = subject.infoForFile(target);
+
+        assertTrue(info.isPresent());
+        assertEquals(expected, info.get());
+    }
+
+    @Test
+    void returnsEmptyForMissing() {
+        final var info = subject.infoForFile(target);
+
+        assertTrue(info.isEmpty());
+    }
+
+    @Test
+    void returnsEmptyForMissingContent() {
+        final var info = subject.contentsOf(target);
+
+        assertTrue(info.isEmpty());
+    }
+
+    @Test
+    void returnsEmptyForMissingAttr() {
+        final var info = subject.attrOf(target);
+
+        assertTrue(info.isEmpty());
+    }
+
+    @Test
+    void getsSpecialFileContents() {
+        FileID file150 = asFile("0.0.150");
+
+        given(specialFiles.get(file150)).willReturn(data);
+        given(specialFiles.contains(file150)).willReturn(true);
+
+        final var stuff = subject.contentsOf(file150);
+
+        assertTrue(Arrays.equals(data, stuff.get()));
+    }
+
+    @Test
+    void rejectsMissingNft() {
+        final var optionalNftInfo = subject.infoForNft(missingNftId);
+
+        assertTrue(optionalNftInfo.isEmpty());
+    }
+
+    @Test
+    void abortsNftGetWhenMissingTreasuryAsExpected() {
+        tokens = mock(MerkleMap.class);
+        targetNft.setOwner(MISSING_ENTITY_ID);
+
+        final var optionalNftInfo = subject.infoForNft(targetNftId);
+
+        assertTrue(optionalNftInfo.isEmpty());
+    }
+
+    @Test
+    void getsSpenderAsExpected() {
+        given(networkInfo.ledgerId()).willReturn(ledgerId);
+
+        final var optionalNftInfo = subject.infoForNft(targetNftId);
+
+        assertTrue(optionalNftInfo.isPresent());
+        final var info = optionalNftInfo.get();
+        assertEquals(ledgerId, info.getLedgerId());
+        assertEquals(targetNftId, info.getNftID());
+        assertEquals(nftOwnerId, info.getAccountID());
+        assertEquals(MISSING_ENTITY_ID, EntityId.fromGrpcAccountId(info.getSpenderId()));
+        assertEquals(fromJava(nftCreation).toGrpc(), info.getCreationTime());
+        assertArrayEquals(nftMeta, info.getMetadata().toByteArray());
+    }
+
+    @Test
+    void interpolatesTreasuryIdOnNftGet() {
+        targetNft.setOwner(MISSING_ENTITY_ID);
+
+        final var token = new MerkleToken();
+        token.setTreasury(EntityId.fromGrpcAccountId(tokenAccountId));
+        given(tokens.get(targetNftKey.getHiOrderAsNum())).willReturn(token);
+        given(networkInfo.ledgerId()).willReturn(ledgerId);
+
+        final var optionalNftInfo = subject.infoForNft(targetNftId);
+
+        final var info = optionalNftInfo.get();
+        assertEquals(ledgerId, info.getLedgerId());
+        assertEquals(targetNftId, info.getNftID());
+        assertEquals(tokenAccountId, info.getAccountID());
+        assertEquals(fromJava(nftCreation).toGrpc(), info.getCreationTime());
+        assertArrayEquals(nftMeta, info.getMetadata().toByteArray());
+    }
+
+    @Test
+    void getNftsAsExpected() {
+        given(networkInfo.ledgerId()).willReturn(ledgerId);
+        targetNft.setSpender(EntityId.fromGrpcAccountId(nftSpenderId));
+
+        final var optionalNftInfo = subject.infoForNft(targetNftId);
+
+        assertTrue(optionalNftInfo.isPresent());
+        final var info = optionalNftInfo.get();
+        assertEquals(ledgerId, info.getLedgerId());
+        assertEquals(targetNftId, info.getNftID());
+        assertEquals(nftOwnerId, info.getAccountID());
+        assertEquals(nftSpenderId, info.getSpenderId());
+        assertEquals(fromJava(nftCreation).toGrpc(), info.getCreationTime());
+        assertArrayEquals(nftMeta, info.getMetadata().toByteArray());
+    }
+
+    @Test
+    void viewAdaptToNullChildren() {
+        subject = new StateView(null, null, null);
+
+        assertSame(StateView.EMPTY_MM, subject.tokens());
+        assertSame(StateView.EMPTY_VM, subject.storage());
+        assertSame(StateView.EMPTY_VM, subject.contractStorage());
+        assertSame(StateView.EMPTY_MM, subject.uniqueTokens());
+        assertSame(StateView.EMPTY_MM, subject.tokenAssociations());
+        assertSame(StateView.EMPTY_MM, subject.contracts());
+        assertSame(StateView.EMPTY_MM, subject.accounts());
+        assertSame(StateView.EMPTY_MM, subject.topics());
+        assertSame(StateView.EMPTY_MM, subject.stakingInfo());
+        assertSame(EMPTY_CTX, subject.networkCtx());
+        assertTrue(subject.contentsOf(target).isEmpty());
+        assertTrue(subject.infoForFile(target).isEmpty());
+        assertTrue(
+                subject.infoForContract(
+                                cid, aliasManager, maxTokensFprAccountInfo, rewardCalculator)
+                        .isEmpty());
+        assertTrue(
+                subject.infoForAccount(
+                                tokenAccountId,
+                                aliasManager,
+                                maxTokensFprAccountInfo,
+                                rewardCalculator)
+                        .isEmpty());
+        assertTrue(subject.tokenType(tokenId).isEmpty());
+        assertTrue(subject.infoForNft(targetNftId).isEmpty());
+        assertTrue(subject.infoForSchedule(scheduleId).isEmpty());
+        assertTrue(subject.infoForToken(tokenId).isEmpty());
+        assertTrue(subject.tokenWith(tokenId).isEmpty());
+        assertFalse(subject.nftExists(targetNftId));
+        assertFalse(subject.scheduleExists(scheduleId));
+        assertFalse(subject.tokenExists(tokenId));
+        assertEquals(0, subject.numNftsOwnedBy(nftOwnerId));
+    }
+
+    @Test
+    void constructsBackingStores() {
+        assertTrue(subject.asReadOnlyAccountStore() instanceof BackingAccounts);
+        assertTrue(subject.asReadOnlyTokenStore() instanceof BackingTokens);
+        assertTrue(subject.asReadOnlyNftStore() instanceof BackingNfts);
+        assertTrue(subject.asReadOnlyAssociationStore() instanceof BackingTokenRels);
+        assertEquals(tokens, ((BackingTokens) subject.asReadOnlyTokenStore()).getDelegate().get());
+        assertEquals(
+                contracts,
+                ((BackingAccounts) subject.asReadOnlyAccountStore()).getDelegate().get());
+        assertEquals(
+                uniqueTokens, ((BackingNfts) subject.asReadOnlyNftStore()).getDelegate().get());
+        assertEquals(
+                tokenRels,
+                ((BackingTokenRels) subject.asReadOnlyAssociationStore()).getDelegate().get());
+    }
+
+    private final Instant nftCreation = Instant.ofEpochSecond(1_234_567L, 8);
+    private final byte[] nftMeta = "abcdefgh".getBytes();
+    private final NftID targetNftId =
+            NftID.newBuilder().setTokenID(IdUtils.asToken("0.0.3")).setSerialNumber(4L).build();
+    private final NftID missingNftId =
+            NftID.newBuilder().setTokenID(IdUtils.asToken("0.0.9")).setSerialNumber(5L).build();
+    private final EntityNumPair targetNftKey = EntityNumPair.fromLongs(3, 4);
+    private final EntityNumPair treasuryNftKey = EntityNumPair.fromLongs(3, 5);
+    private final MerkleUniqueToken targetNft =
+            new MerkleUniqueToken(
+                    EntityId.fromGrpcAccountId(nftOwnerId), nftMeta, fromJava(nftCreation));
+    private final MerkleUniqueToken treasuryNft =
+            new MerkleUniqueToken(
+                    EntityId.fromGrpcAccountId(treasuryOwnerId), nftMeta, fromJava(nftCreation));
+
+    private final CustomFeeBuilder builder = new CustomFeeBuilder(payerAccountId);
+    private final CustomFee customFixedFeeInHbar = builder.withFixedFee(fixedHbar(100L));
+    private final CustomFee customFixedFeeInHts = builder.withFixedFee(fixedHts(tokenId, 100L));
+    private final CustomFee customFixedFeeSameToken = builder.withFixedFee(fixedHts(50L));
+    private final CustomFee customFractionalFee =
+            builder.withFractionalFee(
+                    fractional(15L, 100L).setMinimumAmount(10L).setMaximumAmount(50L));
+    private final List<CustomFee> grpcCustomFees =
+            List.of(
+                    customFixedFeeInHbar,
+                    customFixedFeeInHts,
+                    customFixedFeeSameToken,
+                    customFractionalFee);
 }

--- a/hedera-node/src/test/java/com/hedera/services/context/primitives/StateViewTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/context/primitives/StateViewTest.java
@@ -253,6 +253,7 @@ class StateViewTest {
 		tokenAccount.setAlias(TxnHandlingScenario.TOKEN_ADMIN_KT.asKey().getEd25519());
 		tokenAccount.setHeadTokenId(tokenId.getTokenNum());
 		tokenAccount.setNumAssociations(1);
+		tokenAccount.setStakePeriodStart(1);
 		tokenAccount.setNumPositiveBalances(0);
 		tokenAccount.setStakedId(10L);
 		tokenAccount.setDeclineReward(true);
@@ -860,8 +861,8 @@ class StateViewTest {
 						.build())
 				.build();
 
-		final var actualResponse = subject.infoForAccount(accountWithAlias, aliasManager, maxTokensFprAccountInfo,
-				rewardCalculator);
+		final var actualResponse = subject.infoForAccount(
+				accountWithAlias, aliasManager, maxTokensFprAccountInfo, rewardCalculator);
 		mockedStatic.close();
 		assertEquals(expectedResponse, actualResponse.get());
 	}

--- a/hedera-node/src/test/java/com/hedera/services/txns/validation/PureValidationTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/txns/validation/PureValidationTest.java
@@ -23,6 +23,7 @@ package com.hedera.services.txns.validation;
 import com.hedera.services.context.NodeInfo;
 import com.hedera.services.state.merkle.MerkleAccount;
 import com.hedera.services.utils.EntityNum;
+import com.hedera.test.factories.accounts.MerkleAccountFactory;
 import com.hedera.test.utils.TxnUtils;
 import com.hederahashgraph.api.proto.java.AccountID;
 import com.swirlds.merkle.map.MerkleMap;
@@ -33,6 +34,8 @@ import java.time.Instant;
 import static com.hedera.services.ledger.accounts.HederaAccountCustomizer.STAKED_ACCOUNT_ID_CASE;
 import static com.hedera.services.ledger.accounts.HederaAccountCustomizer.STAKED_NODE_ID_CASE;
 import static com.hedera.test.utils.IdUtils.asAccount;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_ACCOUNT_ID;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OK;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -46,6 +49,19 @@ class PureValidationTest {
 	private static final long impossiblyBigSecs = Instant.MAX.getEpochSecond() + 1;
 	private static final int impossiblyBigNanos = 1_000_000_000;
 	private static final NodeInfo nodeInfo = mock(NodeInfo.class);
+
+	@Test
+	@SuppressWarnings("unchecked")
+	void contractOkIfExplicitlyAllowed() {
+		final MerkleMap<EntityNum, MerkleAccount> accounts = mock(MerkleMap.class);
+		final var account = MerkleAccountFactory.newAccount().get();
+		final var contract = MerkleAccountFactory.newContract().get();
+		final var num = EntityNum.fromLong(1234L);
+
+		given(accounts.get(num)).willReturn(contract);
+		assertEquals(INVALID_ACCOUNT_ID, PureValidation.queryableAccountStatus(num, accounts));
+		assertEquals(OK, PureValidation.queryableAccountOrContractStatus(num, accounts));
+	}
 
 	@Test
 	void mapsSensibleTimestamp() {
@@ -80,11 +96,6 @@ class PureValidationTest {
 		final var deletedAccount = new MerkleAccount();
 		deletedAccount.setDeleted(true);
 		given(accounts.get(EntityNum.fromAccountId(stakedAccountID))).willReturn(deletedAccount);
-		assertFalse(PureValidation.isValidStakedId(STAKED_ACCOUNT_ID_CASE, stakedAccountID, stakedNodeId, accounts, nodeInfo));
-
-		final var smartContract = new MerkleAccount();
-		smartContract.setSmartContract(true);
-		given(accounts.get(EntityNum.fromAccountId(stakedAccountID))).willReturn(smartContract);
 		assertFalse(PureValidation.isValidStakedId(STAKED_ACCOUNT_ID_CASE, stakedAccountID, stakedNodeId, accounts, nodeInfo));
 	}
 

--- a/hedera-node/src/test/java/com/hedera/services/txns/validation/PureValidationTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/txns/validation/PureValidationTest.java
@@ -1,11 +1,6 @@
-package com.hedera.services.txns.validation;
-
-/*-
- * ‌
- * Hedera Services Node
- * ​
- * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
- * ​
+/*
+ * Copyright (C) 2020-2022 Hedera Hashgraph, LLC
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -17,19 +12,8 @@ package com.hedera.services.txns.validation;
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- * ‍
  */
-
-import com.hedera.services.context.NodeInfo;
-import com.hedera.services.state.merkle.MerkleAccount;
-import com.hedera.services.utils.EntityNum;
-import com.hedera.test.factories.accounts.MerkleAccountFactory;
-import com.hedera.test.utils.TxnUtils;
-import com.hederahashgraph.api.proto.java.AccountID;
-import com.swirlds.merkle.map.MerkleMap;
-import org.junit.jupiter.api.Test;
-
-import java.time.Instant;
+package com.hedera.services.txns.validation;
 
 import static com.hedera.services.ledger.accounts.HederaAccountCustomizer.STAKED_ACCOUNT_ID_CASE;
 import static com.hedera.services.ledger.accounts.HederaAccountCustomizer.STAKED_NODE_ID_CASE;
@@ -42,75 +26,94 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 
+import com.hedera.services.context.NodeInfo;
+import com.hedera.services.state.merkle.MerkleAccount;
+import com.hedera.services.utils.EntityNum;
+import com.hedera.test.factories.accounts.MerkleAccountFactory;
+import com.hedera.test.utils.TxnUtils;
+import com.hederahashgraph.api.proto.java.AccountID;
+import com.swirlds.merkle.map.MerkleMap;
+import java.time.Instant;
+import org.junit.jupiter.api.Test;
+
 class PureValidationTest {
-	private static final Instant now = Instant.now();
-	private static final long impossiblySmallSecs = Instant.MIN.getEpochSecond() - 1;
-	private static final int impossiblySmallNanos = -1;
-	private static final long impossiblyBigSecs = Instant.MAX.getEpochSecond() + 1;
-	private static final int impossiblyBigNanos = 1_000_000_000;
-	private static final NodeInfo nodeInfo = mock(NodeInfo.class);
+    private static final Instant now = Instant.now();
+    private static final long impossiblySmallSecs = Instant.MIN.getEpochSecond() - 1;
+    private static final int impossiblySmallNanos = -1;
+    private static final long impossiblyBigSecs = Instant.MAX.getEpochSecond() + 1;
+    private static final int impossiblyBigNanos = 1_000_000_000;
+    private static final NodeInfo nodeInfo = mock(NodeInfo.class);
 
-	@Test
-	@SuppressWarnings("unchecked")
-	void contractOkIfExplicitlyAllowed() {
-		final MerkleMap<EntityNum, MerkleAccount> accounts = mock(MerkleMap.class);
-		final var account = MerkleAccountFactory.newAccount().get();
-		final var contract = MerkleAccountFactory.newContract().get();
-		final var num = EntityNum.fromLong(1234L);
+    @Test
+    @SuppressWarnings("unchecked")
+    void contractOkIfExplicitlyAllowed() {
+        final MerkleMap<EntityNum, MerkleAccount> accounts = mock(MerkleMap.class);
+        final var account = MerkleAccountFactory.newAccount().get();
+        final var contract = MerkleAccountFactory.newContract().get();
+        final var num = EntityNum.fromLong(1234L);
 
-		given(accounts.get(num)).willReturn(contract);
-		assertEquals(INVALID_ACCOUNT_ID, PureValidation.queryableAccountStatus(num, accounts));
-		assertEquals(OK, PureValidation.queryableAccountOrContractStatus(num, accounts));
-	}
+        given(accounts.get(num)).willReturn(contract);
+        assertEquals(INVALID_ACCOUNT_ID, PureValidation.queryableAccountStatus(num, accounts));
+        assertEquals(OK, PureValidation.queryableAccountOrContractStatus(num, accounts));
+    }
 
-	@Test
-	void mapsSensibleTimestamp() {
-		final var proto = TxnUtils.timestampFrom(now.getEpochSecond(), now.getNano());
+    @Test
+    void mapsSensibleTimestamp() {
+        final var proto = TxnUtils.timestampFrom(now.getEpochSecond(), now.getNano());
 
-		assertEquals(now, PureValidation.asCoercedInstant(proto));
-	}
+        assertEquals(now, PureValidation.asCoercedInstant(proto));
+    }
 
-	@Test
-	void coercesTooSmallTimestamp() {
-		final var proto = TxnUtils.timestampFrom(impossiblySmallSecs, impossiblySmallNanos);
+    @Test
+    void coercesTooSmallTimestamp() {
+        final var proto = TxnUtils.timestampFrom(impossiblySmallSecs, impossiblySmallNanos);
 
-		assertEquals(Instant.MIN, PureValidation.asCoercedInstant(proto));
-	}
+        assertEquals(Instant.MIN, PureValidation.asCoercedInstant(proto));
+    }
 
-	@Test
-	void coercesTooBigTimestamp() {
-		final var proto = TxnUtils.timestampFrom(impossiblyBigSecs, impossiblyBigNanos);
+    @Test
+    void coercesTooBigTimestamp() {
+        final var proto = TxnUtils.timestampFrom(impossiblyBigSecs, impossiblyBigNanos);
 
-		assertEquals(Instant.MAX, PureValidation.asCoercedInstant(proto));
-	}
+        assertEquals(Instant.MAX, PureValidation.asCoercedInstant(proto));
+    }
 
-	@Test
-	void validatesStakedId() {
-		final var stakedAccountID = asAccount("0.0.2");
-		final var stakedNodeId = 0;
-		final MerkleMap<EntityNum, MerkleAccount> accounts = mock(MerkleMap.class);
-		given(accounts.get(EntityNum.fromAccountId(stakedAccountID))).willReturn(new MerkleAccount());
+    @Test
+    void validatesStakedId() {
+        final var stakedAccountID = asAccount("0.0.2");
+        final var stakedNodeId = 0;
+        final MerkleMap<EntityNum, MerkleAccount> accounts = mock(MerkleMap.class);
+        given(accounts.get(EntityNum.fromAccountId(stakedAccountID)))
+                .willReturn(new MerkleAccount());
 
-		assertTrue(PureValidation.isValidStakedId(STAKED_ACCOUNT_ID_CASE, stakedAccountID, stakedNodeId, accounts, nodeInfo));
+        assertTrue(
+                PureValidation.isValidStakedId(
+                        STAKED_ACCOUNT_ID_CASE, stakedAccountID, stakedNodeId, accounts, nodeInfo));
 
-		final var deletedAccount = new MerkleAccount();
-		deletedAccount.setDeleted(true);
-		given(accounts.get(EntityNum.fromAccountId(stakedAccountID))).willReturn(deletedAccount);
-		assertFalse(PureValidation.isValidStakedId(STAKED_ACCOUNT_ID_CASE, stakedAccountID, stakedNodeId, accounts, nodeInfo));
-	}
+        final var deletedAccount = new MerkleAccount();
+        deletedAccount.setDeleted(true);
+        given(accounts.get(EntityNum.fromAccountId(stakedAccountID))).willReturn(deletedAccount);
+        assertFalse(
+                PureValidation.isValidStakedId(
+                        STAKED_ACCOUNT_ID_CASE, stakedAccountID, stakedNodeId, accounts, nodeInfo));
+    }
 
-	@Test
-	void validatesStakedNodeId() {
-		final var stakedAccountID = AccountID.getDefaultInstance();
-		final var stakedNodeId = 2;
+    @Test
+    void validatesStakedNodeId() {
+        final var stakedAccountID = AccountID.getDefaultInstance();
+        final var stakedNodeId = 2;
 
-		final MerkleMap<EntityNum, MerkleAccount> accounts = mock(MerkleMap.class);
-		final NodeInfo nodeInfo = mock(NodeInfo.class);
+        final MerkleMap<EntityNum, MerkleAccount> accounts = mock(MerkleMap.class);
+        final NodeInfo nodeInfo = mock(NodeInfo.class);
 
-		given(nodeInfo.isValidId(stakedNodeId)).willReturn(true);
-		assertTrue(PureValidation.isValidStakedId(STAKED_NODE_ID_CASE, stakedAccountID, stakedNodeId, accounts, nodeInfo));
+        given(nodeInfo.isValidId(stakedNodeId)).willReturn(true);
+        assertTrue(
+                PureValidation.isValidStakedId(
+                        STAKED_NODE_ID_CASE, stakedAccountID, stakedNodeId, accounts, nodeInfo));
 
-		given(nodeInfo.isValidId(stakedNodeId)).willReturn(false);
-		assertFalse(PureValidation.isValidStakedId(STAKED_NODE_ID_CASE, stakedAccountID, stakedNodeId, accounts, nodeInfo));
-	}
+        given(nodeInfo.isValidId(stakedNodeId)).willReturn(false);
+        assertFalse(
+                PureValidation.isValidStakedId(
+                        STAKED_NODE_ID_CASE, stakedAccountID, stakedNodeId, accounts, nodeInfo));
+    }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -228,7 +228,7 @@
 		<ethereum-core.version>1.12.0-v0.5.0</ethereum-core.version>
 		<grpc.version>1.39.0</grpc.version>
 		<guava.version>31.1-jre</guava.version>
-		<hapi-proto.version>0.28.1-SNAPSHOT</hapi-proto.version>
+		<hapi-proto.version>0.28.1</hapi-proto.version>
 		<headlong.version>6.1.1</headlong.version>
 		<javax.annotation-api.version>1.3.2</javax.annotation-api.version>
 		<javax-inject.version>1</javax-inject.version>

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -45,7 +45,7 @@ dependencyResolutionManagement {
             version("eddsa-version", "0.3.0")
             version("grpc-version", "1.39.0")
             version("guava-version", "31.1-jre")
-            version("hapi-version", "0.28.1-SNAPSHOT")
+            version("hapi-version", "0.28.1")
             version("headlong-version", "6.1.1")
             version("jackson-version", "2.12.6.1")
             version("javax-annotation-version", "1.3.2")

--- a/test-clients/src/main/java/com/hedera/services/bdd/spec/assertions/AccountInfoAsserts.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/spec/assertions/AccountInfoAsserts.java
@@ -35,6 +35,7 @@ import static com.hedera.services.bdd.suites.HapiApiSuite.ONE_HBAR;
 import static com.hederahashgraph.api.proto.java.CryptoGetInfoResponse.AccountInfo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class AccountInfoAsserts extends BaseErroringAssertsProvider<AccountInfo> {
@@ -93,7 +94,7 @@ public class AccountInfoAsserts extends BaseErroringAssertsProvider<AccountInfo>
 		return this;
 	}
 
-	public AccountInfoAsserts noStakedAccountId(){
+	public AccountInfoAsserts noStakedAccountId() {
 		registerProvider((spec, o) -> {
 			assertEquals(AccountID.getDefaultInstance(),
 					((AccountInfo) o).getStakingInfo().getStakedAccountId(),
@@ -102,7 +103,25 @@ public class AccountInfoAsserts extends BaseErroringAssertsProvider<AccountInfo>
 		return this;
 	}
 
-	public AccountInfoAsserts noStakingNodeId(){
+	public AccountInfoAsserts someStakePeriodStart() {
+		registerProvider((spec, o) -> {
+			assertNotEquals(0,
+					((AccountInfo) o).getStakingInfo().getStakePeriodStart().getSeconds(),
+					"Wrong stakePeriodStart");
+		});
+		return this;
+	}
+
+	public AccountInfoAsserts noStakePeriodStart() {
+		registerProvider((spec, o) -> {
+			assertEquals(0,
+					((AccountInfo) o).getStakingInfo().getStakePeriodStart().getSeconds(),
+					"Wrong stakePeriodStart");
+		});
+		return this;
+	}
+
+	public AccountInfoAsserts noStakingNodeId() {
 		registerProvider((spec, o) -> {
 			assertEquals(0, ((AccountInfo) o).getStakingInfo().getStakedNodeId(),
 					"Bad stakedNodeId id!");
@@ -119,7 +138,7 @@ public class AccountInfoAsserts extends BaseErroringAssertsProvider<AccountInfo>
 		return this;
 	}
 
-	public AccountInfoAsserts isDeclinedReward(boolean isDeclined){
+	public AccountInfoAsserts isDeclinedReward(boolean isDeclined) {
 		registerProvider((spec, o) -> {
 			assertEquals(isDeclined,
 					((AccountInfo) o).getStakingInfo().getDeclineReward(),

--- a/test-clients/src/main/java/com/hedera/services/bdd/spec/assertions/AccountInfoAsserts.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/spec/assertions/AccountInfoAsserts.java
@@ -15,23 +15,22 @@
  */
 package com.hedera.services.bdd.spec.assertions;
 
-import com.hedera.services.bdd.spec.HapiApiSpec;
-import com.hedera.services.bdd.spec.HapiPropertySource;
-import com.hedera.services.bdd.spec.queries.crypto.ExpectedTokenRel;
-import com.hederahashgraph.api.proto.java.AccountID;
-import com.hederahashgraph.api.proto.java.Key;
-import org.junit.jupiter.api.Assertions;
-
-import java.util.List;
-import java.util.Optional;
-import java.util.function.Function;
-
 import static com.hedera.services.bdd.suites.HapiApiSuite.ONE_HBAR;
 import static com.hederahashgraph.api.proto.java.CryptoGetInfoResponse.AccountInfo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.hedera.services.bdd.spec.HapiApiSpec;
+import com.hedera.services.bdd.spec.HapiPropertySource;
+import com.hedera.services.bdd.spec.queries.crypto.ExpectedTokenRel;
+import com.hederahashgraph.api.proto.java.AccountID;
+import com.hederahashgraph.api.proto.java.Key;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
+import org.junit.jupiter.api.Assertions;
 
 public class AccountInfoAsserts extends BaseErroringAssertsProvider<AccountInfo> {
     public static AccountInfoAsserts accountWith() {
@@ -102,37 +101,47 @@ public class AccountInfoAsserts extends BaseErroringAssertsProvider<AccountInfo>
 
     public AccountInfoAsserts noStakedAccountId() {
         registerProvider(
-                (spec, o) -> assertEquals(
-                        AccountID.getDefaultInstance(),
-                        ((AccountInfo) o).getStakingInfo().getStakedAccountId(),
-                        "Bad stakedAccountId id!"));
+                (spec, o) ->
+                        assertEquals(
+                                AccountID.getDefaultInstance(),
+                                ((AccountInfo) o).getStakingInfo().getStakedAccountId(),
+                                "Bad stakedAccountId id!"));
         return this;
     }
 
     public AccountInfoAsserts someStakePeriodStart() {
         registerProvider(
-                (spec, o) -> assertNotEquals(
-                        0,
-                        ((AccountInfo) o).getStakingInfo().getStakePeriodStart().getSeconds(),
-                        "Wrong stakePeriodStart"));
+                (spec, o) ->
+                        assertNotEquals(
+                                0,
+                                ((AccountInfo) o)
+                                        .getStakingInfo()
+                                        .getStakePeriodStart()
+                                        .getSeconds(),
+                                "Wrong stakePeriodStart"));
         return this;
     }
 
     public AccountInfoAsserts noStakePeriodStart() {
         registerProvider(
-                (spec, o) -> assertEquals(
-                        0,
-                        ((AccountInfo) o).getStakingInfo().getStakePeriodStart().getSeconds(),
-                        "Wrong stakePeriodStart"));
+                (spec, o) ->
+                        assertEquals(
+                                0,
+                                ((AccountInfo) o)
+                                        .getStakingInfo()
+                                        .getStakePeriodStart()
+                                        .getSeconds(),
+                                "Wrong stakePeriodStart"));
         return this;
     }
 
     public AccountInfoAsserts noStakingNodeId() {
         registerProvider(
-                (spec, o) -> assertEquals(
-                        0,
-                        ((AccountInfo) o).getStakingInfo().getStakedNodeId(),
-                        "Bad stakedNodeId id!"));
+                (spec, o) ->
+                        assertEquals(
+                                0,
+                                ((AccountInfo) o).getStakingInfo().getStakedNodeId(),
+                                "Bad stakedNodeId id!"));
         return this;
     }
 

--- a/test-clients/src/main/java/com/hedera/services/bdd/spec/assertions/AccountInfoAsserts.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/spec/assertions/AccountInfoAsserts.java
@@ -1,11 +1,6 @@
-package com.hedera.services.bdd.spec.assertions;
-
-/*-
- * ‌
- * Hedera Services Test Clients
- * ​
- * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
- * ​
+/*
+ * Copyright (C) 2020-2022 Hedera Hashgraph, LLC
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -17,8 +12,8 @@ package com.hedera.services.bdd.spec.assertions;
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- * ‍
  */
+package com.hedera.services.bdd.spec.assertions;
 
 import com.hedera.services.bdd.spec.HapiApiSpec;
 import com.hedera.services.bdd.spec.HapiPropertySource;
@@ -39,335 +34,401 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class AccountInfoAsserts extends BaseErroringAssertsProvider<AccountInfo> {
-	public static AccountInfoAsserts accountWith() {
-		return new AccountInfoAsserts();
-	}
+    public static AccountInfoAsserts accountWith() {
+        return new AccountInfoAsserts();
+    }
 
-	public AccountInfoAsserts noChangesFromSnapshot(final String snapshot) {
-		registerProvider((spec, o) -> {
-			final var expected = spec.registry().getAccountInfo(snapshot);
-			final var actual = (AccountInfo) o;
-			assertEquals(expected, actual, "Changes occurred since snapshot '" + snapshot + "'");
-		});
-		return this;
-	}
+    public AccountInfoAsserts noChangesFromSnapshot(final String snapshot) {
+        registerProvider(
+                (spec, o) -> {
+                    final var expected = spec.registry().getAccountInfo(snapshot);
+                    final var actual = (AccountInfo) o;
+                    assertEquals(
+                            expected, actual, "Changes occurred since snapshot '" + snapshot + "'");
+                });
+        return this;
+    }
 
-	public AccountInfoAsserts newAssociationsFromSnapshot(
-			final String snapshot,
-			final List<ExpectedTokenRel> newRels
-	) {
-		for (final var newRel : newRels) {
-			registerProvider((spec, o) -> {
-				final var baseline = spec.registry().getAccountInfo(snapshot);
-				for (final var existingRel : baseline.getTokenRelationshipsList()) {
-					assertFalse(newRel.matches(spec, existingRel),
-							"Expected no existing rel to match " + newRel
-									+ ", but " + existingRel + " did");
-				}
+    public AccountInfoAsserts newAssociationsFromSnapshot(
+            final String snapshot, final List<ExpectedTokenRel> newRels) {
+        for (final var newRel : newRels) {
+            registerProvider(
+                    (spec, o) -> {
+                        final var baseline = spec.registry().getAccountInfo(snapshot);
+                        for (final var existingRel : baseline.getTokenRelationshipsList()) {
+                            assertFalse(
+                                    newRel.matches(spec, existingRel),
+                                    "Expected no existing rel to match "
+                                            + newRel
+                                            + ", but "
+                                            + existingRel
+                                            + " did");
+                        }
 
-				final var current = (AccountInfo) o;
-				var someMatches = false;
-				for (final var currentRel : current.getTokenRelationshipsList()) {
-					someMatches |= newRel.matches(spec, currentRel);
-				}
-				assertTrue(someMatches, "Expected some new rel to match " + newRel + ", but none did");
-			});
-		}
-		return this;
-	}
+                        final var current = (AccountInfo) o;
+                        var someMatches = false;
+                        for (final var currentRel : current.getTokenRelationshipsList()) {
+                            someMatches |= newRel.matches(spec, currentRel);
+                        }
+                        assertTrue(
+                                someMatches,
+                                "Expected some new rel to match " + newRel + ", but none did");
+                    });
+        }
+        return this;
+    }
 
-	public AccountInfoAsserts accountId(String account) {
-		registerProvider((spec, o) -> {
-			assertEquals(spec.registry().getAccountID(account),
-					((AccountInfo) o).getAccountID(),
-					"Bad account Id!");
-		});
-		return this;
-	}
+    public AccountInfoAsserts accountId(String account) {
+        registerProvider(
+                (spec, o) -> {
+                    assertEquals(
+                            spec.registry().getAccountID(account),
+                            ((AccountInfo) o).getAccountID(),
+                            "Bad account Id!");
+                });
+        return this;
+    }
 
-	public AccountInfoAsserts stakedAccountId(String idLiteral) {
-		registerProvider((spec, o) -> {
-			assertEquals(HapiPropertySource.asAccount(idLiteral),
-					((AccountInfo) o).getStakingInfo().getStakedAccountId(),
-					"Bad stakedAccountId id!");
-		});
-		return this;
-	}
+    public AccountInfoAsserts stakedAccountId(String idLiteral) {
+        registerProvider(
+                (spec, o) -> {
+                    assertEquals(
+                            HapiPropertySource.asAccount(idLiteral),
+                            ((AccountInfo) o).getStakingInfo().getStakedAccountId(),
+                            "Bad stakedAccountId id!");
+                });
+        return this;
+    }
 
-	public AccountInfoAsserts noStakedAccountId() {
-		registerProvider((spec, o) -> {
-			assertEquals(AccountID.getDefaultInstance(),
-					((AccountInfo) o).getStakingInfo().getStakedAccountId(),
-					"Bad stakedAccountId id!");
-		});
-		return this;
-	}
+    public AccountInfoAsserts noStakedAccountId() {
+        registerProvider(
+                (spec, o) -> assertEquals(
+                        AccountID.getDefaultInstance(),
+                        ((AccountInfo) o).getStakingInfo().getStakedAccountId(),
+                        "Bad stakedAccountId id!"));
+        return this;
+    }
 
-	public AccountInfoAsserts someStakePeriodStart() {
-		registerProvider((spec, o) -> {
-			assertNotEquals(0,
-					((AccountInfo) o).getStakingInfo().getStakePeriodStart().getSeconds(),
-					"Wrong stakePeriodStart");
-		});
-		return this;
-	}
+    public AccountInfoAsserts someStakePeriodStart() {
+        registerProvider(
+                (spec, o) -> assertNotEquals(
+                        0,
+                        ((AccountInfo) o).getStakingInfo().getStakePeriodStart().getSeconds(),
+                        "Wrong stakePeriodStart"));
+        return this;
+    }
 
-	public AccountInfoAsserts noStakePeriodStart() {
-		registerProvider((spec, o) -> {
-			assertEquals(0,
-					((AccountInfo) o).getStakingInfo().getStakePeriodStart().getSeconds(),
-					"Wrong stakePeriodStart");
-		});
-		return this;
-	}
+    public AccountInfoAsserts noStakePeriodStart() {
+        registerProvider(
+                (spec, o) -> assertEquals(
+                        0,
+                        ((AccountInfo) o).getStakingInfo().getStakePeriodStart().getSeconds(),
+                        "Wrong stakePeriodStart"));
+        return this;
+    }
 
-	public AccountInfoAsserts noStakingNodeId() {
-		registerProvider((spec, o) -> {
-			assertEquals(0, ((AccountInfo) o).getStakingInfo().getStakedNodeId(),
-					"Bad stakedNodeId id!");
-		});
-		return this;
-	}
+    public AccountInfoAsserts noStakingNodeId() {
+        registerProvider(
+                (spec, o) -> assertEquals(
+                        0,
+                        ((AccountInfo) o).getStakingInfo().getStakedNodeId(),
+                        "Bad stakedNodeId id!"));
+        return this;
+    }
 
-	public AccountInfoAsserts stakedNodeId(long idLiteral) {
-		registerProvider((spec, o) -> {
-			assertEquals(idLiteral,
-					((AccountInfo) o).getStakingInfo().getStakedNodeId(),
-					"Bad stakedNodeId id!");
-		});
-		return this;
-	}
+    public AccountInfoAsserts stakedNodeId(long idLiteral) {
+        registerProvider(
+                (spec, o) -> {
+                    assertEquals(
+                            idLiteral,
+                            ((AccountInfo) o).getStakingInfo().getStakedNodeId(),
+                            "Bad stakedNodeId id!");
+                });
+        return this;
+    }
 
-	public AccountInfoAsserts isDeclinedReward(boolean isDeclined) {
-		registerProvider((spec, o) -> {
-			assertEquals(isDeclined,
-					((AccountInfo) o).getStakingInfo().getDeclineReward(),
-					"Bad isDeclinedReward!");
-		});
-		return this;
-	}
+    public AccountInfoAsserts isDeclinedReward(boolean isDeclined) {
+        registerProvider(
+                (spec, o) -> {
+                    assertEquals(
+                            isDeclined,
+                            ((AccountInfo) o).getStakingInfo().getDeclineReward(),
+                            "Bad isDeclinedReward!");
+                });
+        return this;
+    }
 
-	public AccountInfoAsserts solidityId(String cid) {
-		registerProvider((spec, o) -> {
-			AccountID id = spec.registry().getAccountID(cid);
-			final var solidityId = HapiPropertySource.asHexedSolidityAddress(id);
-			assertEquals(solidityId,
-					((AccountInfo) o).getContractAccountID(),
-					"Bad Solidity contract Id!");
-		});
-		return this;
-	}
+    public AccountInfoAsserts solidityId(String cid) {
+        registerProvider(
+                (spec, o) -> {
+                    AccountID id = spec.registry().getAccountID(cid);
+                    final var solidityId = HapiPropertySource.asHexedSolidityAddress(id);
+                    assertEquals(
+                            solidityId,
+                            ((AccountInfo) o).getContractAccountID(),
+                            "Bad Solidity contract Id!");
+                });
+        return this;
+    }
 
-	public AccountInfoAsserts key(String key) {
-		registerProvider((spec, o) -> {
-			assertEquals(spec.registry().getKey(key), ((AccountInfo) o).getKey(), "Bad key!");
-		});
-		return this;
-	}
+    public AccountInfoAsserts key(String key) {
+        registerProvider(
+                (spec, o) -> {
+                    assertEquals(
+                            spec.registry().getKey(key), ((AccountInfo) o).getKey(), "Bad key!");
+                });
+        return this;
+    }
 
-	public AccountInfoAsserts key(Key key) {
-		registerProvider((spec, o) -> {
-			assertEquals(key, ((AccountInfo) o).getKey(), "Bad key!");
-		});
-		return this;
-	}
+    public AccountInfoAsserts key(Key key) {
+        registerProvider(
+                (spec, o) -> {
+                    assertEquals(key, ((AccountInfo) o).getKey(), "Bad key!");
+                });
+        return this;
+    }
 
-	public AccountInfoAsserts receiverSigReq(Boolean isReq) {
-		registerProvider((spec, o) -> {
-			assertEquals(isReq, ((AccountInfo) o).getReceiverSigRequired(), "Bad receiver sig requirement!");
-		});
-		return this;
-	}
+    public AccountInfoAsserts receiverSigReq(Boolean isReq) {
+        registerProvider(
+                (spec, o) -> {
+                    assertEquals(
+                            isReq,
+                            ((AccountInfo) o).getReceiverSigRequired(),
+                            "Bad receiver sig requirement!");
+                });
+        return this;
+    }
 
-	public AccountInfoAsserts balance(long amount) {
-		registerProvider((spec, o) -> {
-			assertEquals(amount, ((AccountInfo) o).getBalance(), "Bad balance!");
-		});
-		return this;
-	}
+    public AccountInfoAsserts balance(long amount) {
+        registerProvider(
+                (spec, o) -> {
+                    assertEquals(amount, ((AccountInfo) o).getBalance(), "Bad balance!");
+                });
+        return this;
+    }
 
-	public AccountInfoAsserts expectedBalanceWithChargedUsd(
-			final long amount,
-			final double expectedUsdToSubtract,
-			final double allowedPercentDiff
-	) {
-		registerProvider((spec, o) -> {
-			final var rates = spec.ratesProvider().rates();
-			var expectedTinyBarsToSubtract = expectedUsdToSubtract * 100
-					* rates.getHbarEquiv() / rates.getCentEquiv()
-					* ONE_HBAR;
-			final var newAmount = ((AccountInfo) o).getBalance();
-			final var actualSubtractedTinybars = amount - newAmount;
-			System.out.println("Expected to deduct " + (long) expectedTinyBarsToSubtract
-					+ " tinybar to equal ≈ $" + expectedUsdToSubtract + " at a "
-					+ rates.getHbarEquiv() + "ℏ <-> " + rates.getCentEquiv()
-					+ "¢ exchange rate (actually deducted " + (amount - newAmount) + " tinybars)");
+    public AccountInfoAsserts expectedBalanceWithChargedUsd(
+            final long amount,
+            final double expectedUsdToSubtract,
+            final double allowedPercentDiff) {
+        registerProvider(
+                (spec, o) -> {
+                    final var rates = spec.ratesProvider().rates();
+                    var expectedTinyBarsToSubtract =
+                            expectedUsdToSubtract
+                                    * 100
+                                    * rates.getHbarEquiv()
+                                    / rates.getCentEquiv()
+                                    * ONE_HBAR;
+                    final var newAmount = ((AccountInfo) o).getBalance();
+                    final var actualSubtractedTinybars = amount - newAmount;
+                    System.out.println(
+                            "Expected to deduct "
+                                    + (long) expectedTinyBarsToSubtract
+                                    + " tinybar to equal ≈ $"
+                                    + expectedUsdToSubtract
+                                    + " at a "
+                                    + rates.getHbarEquiv()
+                                    + "ℏ <-> "
+                                    + rates.getCentEquiv()
+                                    + "¢ exchange rate (actually deducted "
+                                    + (amount - newAmount)
+                                    + " tinybars)");
 
-			assertEquals(
-					expectedTinyBarsToSubtract,
-					actualSubtractedTinybars,
-					(allowedPercentDiff / 100.0) * expectedTinyBarsToSubtract,
-					"Unexpected balance deduction");
-		});
-		return this;
-	}
+                    assertEquals(
+                            expectedTinyBarsToSubtract,
+                            actualSubtractedTinybars,
+                            (allowedPercentDiff / 100.0) * expectedTinyBarsToSubtract,
+                            "Unexpected balance deduction");
+                });
+        return this;
+    }
 
-	public static void assertTinybarAmountIsApproxUsd(
-			final HapiApiSpec spec,
-			final double expectedFractionalUsd,
-			final long actualTinybars,
-			final double allowedPercentDiff
-	) {
-		final var expectedTinybars = expectedFractionalUsd * 100
-				* spec.ratesProvider().rates().getHbarEquiv() / spec.ratesProvider().rates().getCentEquiv()
-				* ONE_HBAR;
-		final var allowedDiff = (allowedPercentDiff / 100.0) * expectedTinybars;
-		assertEquals(expectedTinybars, actualTinybars, allowedDiff, "Wrong balance");
-	}
+    public static void assertTinybarAmountIsApproxUsd(
+            final HapiApiSpec spec,
+            final double expectedFractionalUsd,
+            final long actualTinybars,
+            final double allowedPercentDiff) {
+        final var expectedTinybars =
+                expectedFractionalUsd
+                        * 100
+                        * spec.ratesProvider().rates().getHbarEquiv()
+                        / spec.ratesProvider().rates().getCentEquiv()
+                        * ONE_HBAR;
+        final var allowedDiff = (allowedPercentDiff / 100.0) * expectedTinybars;
+        assertEquals(expectedTinybars, actualTinybars, allowedDiff, "Wrong balance");
+    }
 
-	public AccountInfoAsserts hasAlias() {
-		registerProvider((spec, o) -> {
-			assertFalse(((AccountInfo) o).getAlias().isEmpty(), "Has no Alias!");
-		});
-		return this;
-	}
+    public AccountInfoAsserts hasAlias() {
+        registerProvider(
+                (spec, o) -> {
+                    assertFalse(((AccountInfo) o).getAlias().isEmpty(), "Has no Alias!");
+                });
+        return this;
+    }
 
-	public AccountInfoAsserts alias(String alias) {
-		registerProvider((spec, o) -> {
-			assertEquals(spec.registry().getKey(alias).toByteString(), ((AccountInfo) o).getAlias(), "Bad Alias!");
-		});
-		return this;
-	}
+    public AccountInfoAsserts alias(String alias) {
+        registerProvider(
+                (spec, o) -> {
+                    assertEquals(
+                            spec.registry().getKey(alias).toByteString(),
+                            ((AccountInfo) o).getAlias(),
+                            "Bad Alias!");
+                });
+        return this;
+    }
 
-	public AccountInfoAsserts noAlias() {
-		registerProvider((spec, o) -> {
-			assertTrue(((AccountInfo) o).getAlias().isEmpty(), "Bad Alias!");
-		});
-		return this;
-	}
+    public AccountInfoAsserts noAlias() {
+        registerProvider(
+                (spec, o) -> {
+                    assertTrue(((AccountInfo) o).getAlias().isEmpty(), "Bad Alias!");
+                });
+        return this;
+    }
 
-	public AccountInfoAsserts balanceLessThan(long amount) {
-		registerProvider((spec, o) -> {
-			long actual = ((AccountInfo) o).getBalance();
-			String errorMessage = String.format("Bad balance! %s is not less than %s", actual, amount);
-			assertTrue(actual < amount, errorMessage);
-		});
-		return this;
-	}
+    public AccountInfoAsserts balanceLessThan(long amount) {
+        registerProvider(
+                (spec, o) -> {
+                    long actual = ((AccountInfo) o).getBalance();
+                    String errorMessage =
+                            String.format("Bad balance! %s is not less than %s", actual, amount);
+                    assertTrue(actual < amount, errorMessage);
+                });
+        return this;
+    }
 
-	public AccountInfoAsserts memo(String memo) {
-		registerProvider((spec, o) -> {
-			assertEquals(memo, ((AccountInfo) o).getMemo(), "Bad memo!");
-		});
-		return this;
-	}
+    public AccountInfoAsserts memo(String memo) {
+        registerProvider(
+                (spec, o) -> {
+                    assertEquals(memo, ((AccountInfo) o).getMemo(), "Bad memo!");
+                });
+        return this;
+    }
 
-	public AccountInfoAsserts balance(Function<HapiApiSpec, Function<Long, Optional<String>>> dynamicCondition) {
-		registerProvider((spec, o) -> {
-			Function<Long, Optional<String>> expectation = dynamicCondition.apply(spec);
-			long actual = ((AccountInfo) o).getBalance();
-			Optional<String> failure = expectation.apply(actual);
-			if (failure.isPresent()) {
-				Assertions.fail("Bad balance! :: " + failure.get());
-			}
-		});
-		return this;
-	}
+    public AccountInfoAsserts balance(
+            Function<HapiApiSpec, Function<Long, Optional<String>>> dynamicCondition) {
+        registerProvider(
+                (spec, o) -> {
+                    Function<Long, Optional<String>> expectation = dynamicCondition.apply(spec);
+                    long actual = ((AccountInfo) o).getBalance();
+                    Optional<String> failure = expectation.apply(actual);
+                    if (failure.isPresent()) {
+                        Assertions.fail("Bad balance! :: " + failure.get());
+                    }
+                });
+        return this;
+    }
 
-	public static Function<HapiApiSpec, Function<Long, Optional<String>>> changeFromSnapshot(
-			String snapshot,
-			Function<HapiApiSpec, Long> expDeltaFn
-	) {
-		return approxChangeFromSnapshot(snapshot, expDeltaFn, 0L);
-	}
+    public static Function<HapiApiSpec, Function<Long, Optional<String>>> changeFromSnapshot(
+            String snapshot, Function<HapiApiSpec, Long> expDeltaFn) {
+        return approxChangeFromSnapshot(snapshot, expDeltaFn, 0L);
+    }
 
-	public static Function<HapiApiSpec, Function<Long, Optional<String>>> changeFromSnapshot(
-			String snapshot,
-			long expDelta
-	) {
-		return approxChangeFromSnapshot(snapshot, expDelta, 0L);
-	}
+    public static Function<HapiApiSpec, Function<Long, Optional<String>>> changeFromSnapshot(
+            String snapshot, long expDelta) {
+        return approxChangeFromSnapshot(snapshot, expDelta, 0L);
+    }
 
-	public static Function<HapiApiSpec, Function<Long, Optional<String>>> approxChangeFromSnapshot(
-			String snapshot,
-			long expDelta,
-			long epsilon
-	) {
-		return approxChangeFromSnapshot(snapshot, ignore -> expDelta, epsilon);
-	}
+    public static Function<HapiApiSpec, Function<Long, Optional<String>>> approxChangeFromSnapshot(
+            String snapshot, long expDelta, long epsilon) {
+        return approxChangeFromSnapshot(snapshot, ignore -> expDelta, epsilon);
+    }
 
-	public static Function<HapiApiSpec, Function<Long, Optional<String>>> approxChangeFromSnapshot(
-			String snapshot,
-			Function<HapiApiSpec, Long> expDeltaFn,
-			long epsilon
-	) {
-		return spec -> actual -> {
-			long expDelta = expDeltaFn.apply(spec);
-			long actualDelta = actual - spec.registry().getBalanceSnapshot(snapshot);
-			if (Math.abs(actualDelta - expDelta) <= epsilon) {
-				return Optional.empty();
-			} else {
-				return Optional.of(
-						String.format("Expected balance change from '%s' to be <%d +/- %d>, was <%d>!",
-								snapshot, expDelta, epsilon, actualDelta));
-			}
-		};
-	}
+    public static Function<HapiApiSpec, Function<Long, Optional<String>>> approxChangeFromSnapshot(
+            String snapshot, Function<HapiApiSpec, Long> expDeltaFn, long epsilon) {
+        return spec ->
+                actual -> {
+                    long expDelta = expDeltaFn.apply(spec);
+                    long actualDelta = actual - spec.registry().getBalanceSnapshot(snapshot);
+                    if (Math.abs(actualDelta - expDelta) <= epsilon) {
+                        return Optional.empty();
+                    } else {
+                        return Optional.of(
+                                String.format(
+                                        "Expected balance change from '%s' to be <%d +/- %d>, was"
+                                                + " <%d>!",
+                                        snapshot, expDelta, epsilon, actualDelta));
+                    }
+                };
+    }
 
-	public AccountInfoAsserts sendThreshold(long amount) {
-		registerProvider((spec, o) -> {
-			assertEquals(amount, ((AccountInfo) o).getGenerateSendRecordThreshold(), "Bad send threshold!");
-		});
-		return this;
-	}
+    public AccountInfoAsserts sendThreshold(long amount) {
+        registerProvider(
+                (spec, o) -> {
+                    assertEquals(
+                            amount,
+                            ((AccountInfo) o).getGenerateSendRecordThreshold(),
+                            "Bad send threshold!");
+                });
+        return this;
+    }
 
-	public AccountInfoAsserts receiveThreshold(long amount) {
-		registerProvider((spec, o) -> {
-			assertEquals(amount, ((AccountInfo) o).getGenerateReceiveRecordThreshold(),
-					"Bad receive threshold!");
-		});
-		return this;
-	}
+    public AccountInfoAsserts receiveThreshold(long amount) {
+        registerProvider(
+                (spec, o) -> {
+                    assertEquals(
+                            amount,
+                            ((AccountInfo) o).getGenerateReceiveRecordThreshold(),
+                            "Bad receive threshold!");
+                });
+        return this;
+    }
 
-	public AccountInfoAsserts expiry(long approxTime, long epsilon) {
-		registerProvider((spec, o) -> {
-			long expiry = ((AccountInfo) o).getExpirationTime().getSeconds();
-			assertTrue(Math.abs(approxTime - expiry) <= epsilon,
-					String.format("Expiry %d not in [%d, %d]!", expiry, approxTime - epsilon, approxTime + epsilon));
-		});
-		return this;
-	}
+    public AccountInfoAsserts expiry(long approxTime, long epsilon) {
+        registerProvider(
+                (spec, o) -> {
+                    long expiry = ((AccountInfo) o).getExpirationTime().getSeconds();
+                    assertTrue(
+                            Math.abs(approxTime - expiry) <= epsilon,
+                            String.format(
+                                    "Expiry %d not in [%d, %d]!",
+                                    expiry, approxTime - epsilon, approxTime + epsilon));
+                });
+        return this;
+    }
 
-	public AccountInfoAsserts expiry(String registryEntry, long delta) {
-		registerProvider((spec, o) -> {
-			long expiry = ((AccountInfo) o).getExpirationTime().getSeconds();
-			long expected = spec.registry().getAccountInfo(registryEntry).getExpirationTime().getSeconds() + delta;
-			assertEquals(expected, expiry, "Bad expiry!");
-		});
-		return this;
-	}
+    public AccountInfoAsserts expiry(String registryEntry, long delta) {
+        registerProvider(
+                (spec, o) -> {
+                    long expiry = ((AccountInfo) o).getExpirationTime().getSeconds();
+                    long expected =
+                            spec.registry()
+                                            .getAccountInfo(registryEntry)
+                                            .getExpirationTime()
+                                            .getSeconds()
+                                    + delta;
+                    assertEquals(expected, expiry, "Bad expiry!");
+                });
+        return this;
+    }
 
-	public AccountInfoAsserts autoRenew(long period) {
-		registerProvider((spec, o) -> {
-			assertEquals(period, ((AccountInfo) o).getAutoRenewPeriod().getSeconds(),
-					"Bad auto-renew period!");
-		});
-		return this;
-	}
+    public AccountInfoAsserts autoRenew(long period) {
+        registerProvider(
+                (spec, o) -> {
+                    assertEquals(
+                            period,
+                            ((AccountInfo) o).getAutoRenewPeriod().getSeconds(),
+                            "Bad auto-renew period!");
+                });
+        return this;
+    }
 
-	public AccountInfoAsserts nonce(long nonce) {
-		registerProvider((spec, o) -> {
-			assertEquals(nonce, ((AccountInfo) o).getEthereumNonce(),
-					"Bad nonce!");
-		});
-		return this;
-	}
+    public AccountInfoAsserts nonce(long nonce) {
+        registerProvider(
+                (spec, o) -> {
+                    assertEquals(nonce, ((AccountInfo) o).getEthereumNonce(), "Bad nonce!");
+                });
+        return this;
+    }
 
-	public AccountInfoAsserts pendingRewards(long reward) {
-		registerProvider((spec, o) -> {
-			assertEquals(reward, ((AccountInfo) o).getStakingInfo().getPendingReward(),
-					"Bad pending rewards!");
-		});
-		return this;
-	}
+    public AccountInfoAsserts pendingRewards(long reward) {
+        registerProvider(
+                (spec, o) -> {
+                    assertEquals(
+                            reward,
+                            ((AccountInfo) o).getStakingInfo().getPendingReward(),
+                            "Bad pending rewards!");
+                });
+        return this;
+    }
 }

--- a/test-clients/src/main/java/com/hedera/services/bdd/spec/assertions/AccountInfoAsserts.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/spec/assertions/AccountInfoAsserts.java
@@ -15,24 +15,23 @@
  */
 package com.hedera.services.bdd.spec.assertions;
 
-import com.hedera.services.bdd.spec.HapiApiSpec;
-import com.hedera.services.bdd.spec.HapiPropertySource;
-import com.hedera.services.bdd.spec.queries.crypto.ExpectedTokenRel;
-import com.hederahashgraph.api.proto.java.AccountID;
-import com.hederahashgraph.api.proto.java.Key;
-import org.junit.jupiter.api.Assertions;
-
-import java.util.List;
-import java.util.Optional;
-import java.util.function.Function;
-import java.util.function.ToLongFunction;
-
 import static com.hedera.services.bdd.suites.HapiApiSuite.ONE_HBAR;
 import static com.hederahashgraph.api.proto.java.CryptoGetInfoResponse.AccountInfo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.hedera.services.bdd.spec.HapiApiSpec;
+import com.hedera.services.bdd.spec.HapiPropertySource;
+import com.hedera.services.bdd.spec.queries.crypto.ExpectedTokenRel;
+import com.hederahashgraph.api.proto.java.AccountID;
+import com.hederahashgraph.api.proto.java.Key;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.function.ToLongFunction;
+import org.junit.jupiter.api.Assertions;
 
 public class AccountInfoAsserts extends BaseErroringAssertsProvider<AccountInfo> {
     public static AccountInfoAsserts accountWith() {
@@ -81,21 +80,20 @@ public class AccountInfoAsserts extends BaseErroringAssertsProvider<AccountInfo>
 
     public AccountInfoAsserts accountId(String account) {
         registerProvider(
-                (spec, o) -> assertEquals(
-                        spec.registry().getAccountID(account),
-                        ((AccountInfo) o).getAccountID(),
-                        "Bad account Id!"));
+                (spec, o) ->
+                        assertEquals(
+                                spec.registry().getAccountID(account),
+                                ((AccountInfo) o).getAccountID(),
+                                "Bad account Id!"));
         return this;
     }
 
     public AccountInfoAsserts stakedAccountId(String idLiteral) {
         registerProvider(
-                (spec, o) -> {
-                    assertEquals(
-                            HapiPropertySource.asAccount(idLiteral),
-                            ((AccountInfo) o).getStakingInfo().getStakedAccountId(),
-                            "Bad stakedAccountId id!");
-                });
+                (spec, o) -> assertEquals(
+                        HapiPropertySource.asAccount(idLiteral),
+                        ((AccountInfo) o).getStakingInfo().getStakedAccountId(),
+                        "Bad stakedAccountId id!"));
         return this;
     }
 
@@ -147,23 +145,19 @@ public class AccountInfoAsserts extends BaseErroringAssertsProvider<AccountInfo>
 
     public AccountInfoAsserts stakedNodeId(long idLiteral) {
         registerProvider(
-                (spec, o) -> {
-                    assertEquals(
-                            idLiteral,
-                            ((AccountInfo) o).getStakingInfo().getStakedNodeId(),
-                            "Bad stakedNodeId id!");
-                });
+                (spec, o) -> assertEquals(
+                        idLiteral,
+                        ((AccountInfo) o).getStakingInfo().getStakedNodeId(),
+                        "Bad stakedNodeId id!"));
         return this;
     }
 
     public AccountInfoAsserts isDeclinedReward(boolean isDeclined) {
         registerProvider(
-                (spec, o) -> {
-                    assertEquals(
-                            isDeclined,
-                            ((AccountInfo) o).getStakingInfo().getDeclineReward(),
-                            "Bad isDeclinedReward!");
-                });
+                (spec, o) -> assertEquals(
+                        isDeclined,
+                        ((AccountInfo) o).getStakingInfo().getDeclineReward(),
+                        "Bad isDeclinedReward!"));
         return this;
     }
 
@@ -182,37 +176,29 @@ public class AccountInfoAsserts extends BaseErroringAssertsProvider<AccountInfo>
 
     public AccountInfoAsserts key(String key) {
         registerProvider(
-                (spec, o) -> {
-                    assertEquals(
-                            spec.registry().getKey(key), ((AccountInfo) o).getKey(), "Bad key!");
-                });
+                (spec, o) -> assertEquals(
+                        spec.registry().getKey(key), ((AccountInfo) o).getKey(), "Bad key!"));
         return this;
     }
 
     public AccountInfoAsserts key(Key key) {
         registerProvider(
-                (spec, o) -> {
-                    assertEquals(key, ((AccountInfo) o).getKey(), "Bad key!");
-                });
+                (spec, o) -> assertEquals(key, ((AccountInfo) o).getKey(), "Bad key!"));
         return this;
     }
 
     public AccountInfoAsserts receiverSigReq(Boolean isReq) {
         registerProvider(
-                (spec, o) -> {
-                    assertEquals(
-                            isReq,
-                            ((AccountInfo) o).getReceiverSigRequired(),
-                            "Bad receiver sig requirement!");
-                });
+                (spec, o) -> assertEquals(
+                        isReq,
+                        ((AccountInfo) o).getReceiverSigRequired(),
+                        "Bad receiver sig requirement!"));
         return this;
     }
 
     public AccountInfoAsserts balance(long amount) {
         registerProvider(
-                (spec, o) -> {
-                    assertEquals(amount, ((AccountInfo) o).getBalance(), "Bad balance!");
-                });
+                (spec, o) -> assertEquals(amount, ((AccountInfo) o).getBalance(), "Bad balance!"));
         return this;
     }
 
@@ -231,7 +217,7 @@ public class AccountInfoAsserts extends BaseErroringAssertsProvider<AccountInfo>
                                     * ONE_HBAR;
                     final var newAmount = ((AccountInfo) o).getBalance();
                     final var actualSubtractedTinybars = amount - newAmount;
-                    System.out.println(
+                    final var errorMsgIfOutsideTolerance =
                             "Expected to deduct "
                                     + (long) expectedTinyBarsToSubtract
                                     + " tinybar to equal ≈ $"
@@ -242,13 +228,12 @@ public class AccountInfoAsserts extends BaseErroringAssertsProvider<AccountInfo>
                                     + rates.getCentEquiv()
                                     + "¢ exchange rate (actually deducted "
                                     + (amount - newAmount)
-                                    + " tinybars)");
-
+                                    + " tinybars)";
                     assertEquals(
                             expectedTinyBarsToSubtract,
                             actualSubtractedTinybars,
                             (allowedPercentDiff / 100.0) * expectedTinyBarsToSubtract,
-                            "Unexpected balance deduction");
+                        errorMsgIfOutsideTolerance);
                 });
         return this;
     }
@@ -270,28 +255,22 @@ public class AccountInfoAsserts extends BaseErroringAssertsProvider<AccountInfo>
 
     public AccountInfoAsserts hasAlias() {
         registerProvider(
-                (spec, o) -> {
-                    assertFalse(((AccountInfo) o).getAlias().isEmpty(), "Has no Alias!");
-                });
+                (spec, o) -> assertFalse(((AccountInfo) o).getAlias().isEmpty(), "Has no Alias!"));
         return this;
     }
 
     public AccountInfoAsserts alias(String alias) {
         registerProvider(
-                (spec, o) -> {
-                    assertEquals(
-                            spec.registry().getKey(alias).toByteString(),
-                            ((AccountInfo) o).getAlias(),
-                            "Bad Alias!");
-                });
+                (spec, o) -> assertEquals(
+                        spec.registry().getKey(alias).toByteString(),
+                        ((AccountInfo) o).getAlias(),
+                        "Bad Alias!"));
         return this;
     }
 
     public AccountInfoAsserts noAlias() {
         registerProvider(
-                (spec, o) -> {
-                    assertTrue(((AccountInfo) o).getAlias().isEmpty(), "Bad Alias!");
-                });
+                (spec, o) -> assertTrue(((AccountInfo) o).getAlias().isEmpty(), "Bad Alias!"));
         return this;
     }
 
@@ -308,9 +287,7 @@ public class AccountInfoAsserts extends BaseErroringAssertsProvider<AccountInfo>
 
     public AccountInfoAsserts memo(String memo) {
         registerProvider(
-                (spec, o) -> {
-                    assertEquals(memo, ((AccountInfo) o).getMemo(), "Bad memo!");
-                });
+                (spec, o) -> assertEquals(memo, ((AccountInfo) o).getMemo(), "Bad memo!"));
         return this;
     }
 
@@ -363,19 +340,21 @@ public class AccountInfoAsserts extends BaseErroringAssertsProvider<AccountInfo>
 
     public AccountInfoAsserts sendThreshold(long amount) {
         registerProvider(
-                (spec, o) -> assertEquals(
-                        amount,
-                        ((AccountInfo) o).getGenerateSendRecordThreshold(),
-                        "Bad send threshold!"));
+                (spec, o) ->
+                        assertEquals(
+                                amount,
+                                ((AccountInfo) o).getGenerateSendRecordThreshold(),
+                                "Bad send threshold!"));
         return this;
     }
 
     public AccountInfoAsserts receiveThreshold(long amount) {
         registerProvider(
-                (spec, o) -> assertEquals(
-                        amount,
-                        ((AccountInfo) o).getGenerateReceiveRecordThreshold(),
-                        "Bad receive threshold!"));
+                (spec, o) ->
+                        assertEquals(
+                                amount,
+                                ((AccountInfo) o).getGenerateReceiveRecordThreshold(),
+                                "Bad receive threshold!"));
         return this;
     }
 
@@ -409,25 +388,28 @@ public class AccountInfoAsserts extends BaseErroringAssertsProvider<AccountInfo>
 
     public AccountInfoAsserts autoRenew(long period) {
         registerProvider(
-                (spec, o) -> assertEquals(
-                        period,
-                        ((AccountInfo) o).getAutoRenewPeriod().getSeconds(),
-                        "Bad auto-renew period!"));
+                (spec, o) ->
+                        assertEquals(
+                                period,
+                                ((AccountInfo) o).getAutoRenewPeriod().getSeconds(),
+                                "Bad auto-renew period!"));
         return this;
     }
 
     public AccountInfoAsserts nonce(long nonce) {
         registerProvider(
-                (spec, o) -> assertEquals(nonce, ((AccountInfo) o).getEthereumNonce(), "Bad nonce!"));
+                (spec, o) ->
+                        assertEquals(nonce, ((AccountInfo) o).getEthereumNonce(), "Bad nonce!"));
         return this;
     }
 
     public AccountInfoAsserts pendingRewards(long reward) {
         registerProvider(
-                (spec, o) -> assertEquals(
-                        reward,
-                        ((AccountInfo) o).getStakingInfo().getPendingReward(),
-                        "Bad pending rewards!"));
+                (spec, o) ->
+                        assertEquals(
+                                reward,
+                                ((AccountInfo) o).getStakingInfo().getPendingReward(),
+                                "Bad pending rewards!"));
         return this;
     }
 }

--- a/test-clients/src/main/java/com/hedera/services/bdd/spec/assertions/AccountInfoAsserts.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/spec/assertions/AccountInfoAsserts.java
@@ -90,10 +90,11 @@ public class AccountInfoAsserts extends BaseErroringAssertsProvider<AccountInfo>
 
     public AccountInfoAsserts stakedAccountId(String idLiteral) {
         registerProvider(
-                (spec, o) -> assertEquals(
-                        HapiPropertySource.asAccount(idLiteral),
-                        ((AccountInfo) o).getStakingInfo().getStakedAccountId(),
-                        "Bad stakedAccountId id!"));
+                (spec, o) ->
+                        assertEquals(
+                                HapiPropertySource.asAccount(idLiteral),
+                                ((AccountInfo) o).getStakingInfo().getStakedAccountId(),
+                                "Bad stakedAccountId id!"));
         return this;
     }
 
@@ -145,19 +146,21 @@ public class AccountInfoAsserts extends BaseErroringAssertsProvider<AccountInfo>
 
     public AccountInfoAsserts stakedNodeId(long idLiteral) {
         registerProvider(
-                (spec, o) -> assertEquals(
-                        idLiteral,
-                        ((AccountInfo) o).getStakingInfo().getStakedNodeId(),
-                        "Bad stakedNodeId id!"));
+                (spec, o) ->
+                        assertEquals(
+                                idLiteral,
+                                ((AccountInfo) o).getStakingInfo().getStakedNodeId(),
+                                "Bad stakedNodeId id!"));
         return this;
     }
 
     public AccountInfoAsserts isDeclinedReward(boolean isDeclined) {
         registerProvider(
-                (spec, o) -> assertEquals(
-                        isDeclined,
-                        ((AccountInfo) o).getStakingInfo().getDeclineReward(),
-                        "Bad isDeclinedReward!"));
+                (spec, o) ->
+                        assertEquals(
+                                isDeclined,
+                                ((AccountInfo) o).getStakingInfo().getDeclineReward(),
+                                "Bad isDeclinedReward!"));
         return this;
     }
 
@@ -176,23 +179,26 @@ public class AccountInfoAsserts extends BaseErroringAssertsProvider<AccountInfo>
 
     public AccountInfoAsserts key(String key) {
         registerProvider(
-                (spec, o) -> assertEquals(
-                        spec.registry().getKey(key), ((AccountInfo) o).getKey(), "Bad key!"));
+                (spec, o) ->
+                        assertEquals(
+                                spec.registry().getKey(key),
+                                ((AccountInfo) o).getKey(),
+                                "Bad key!"));
         return this;
     }
 
     public AccountInfoAsserts key(Key key) {
-        registerProvider(
-                (spec, o) -> assertEquals(key, ((AccountInfo) o).getKey(), "Bad key!"));
+        registerProvider((spec, o) -> assertEquals(key, ((AccountInfo) o).getKey(), "Bad key!"));
         return this;
     }
 
     public AccountInfoAsserts receiverSigReq(Boolean isReq) {
         registerProvider(
-                (spec, o) -> assertEquals(
-                        isReq,
-                        ((AccountInfo) o).getReceiverSigRequired(),
-                        "Bad receiver sig requirement!"));
+                (spec, o) ->
+                        assertEquals(
+                                isReq,
+                                ((AccountInfo) o).getReceiverSigRequired(),
+                                "Bad receiver sig requirement!"));
         return this;
     }
 
@@ -233,7 +239,7 @@ public class AccountInfoAsserts extends BaseErroringAssertsProvider<AccountInfo>
                             expectedTinyBarsToSubtract,
                             actualSubtractedTinybars,
                             (allowedPercentDiff / 100.0) * expectedTinyBarsToSubtract,
-                        errorMsgIfOutsideTolerance);
+                            errorMsgIfOutsideTolerance);
                 });
         return this;
     }
@@ -261,10 +267,11 @@ public class AccountInfoAsserts extends BaseErroringAssertsProvider<AccountInfo>
 
     public AccountInfoAsserts alias(String alias) {
         registerProvider(
-                (spec, o) -> assertEquals(
-                        spec.registry().getKey(alias).toByteString(),
-                        ((AccountInfo) o).getAlias(),
-                        "Bad Alias!"));
+                (spec, o) ->
+                        assertEquals(
+                                spec.registry().getKey(alias).toByteString(),
+                                ((AccountInfo) o).getAlias(),
+                                "Bad Alias!"));
         return this;
     }
 
@@ -286,8 +293,7 @@ public class AccountInfoAsserts extends BaseErroringAssertsProvider<AccountInfo>
     }
 
     public AccountInfoAsserts memo(String memo) {
-        registerProvider(
-                (spec, o) -> assertEquals(memo, ((AccountInfo) o).getMemo(), "Bad memo!"));
+        registerProvider((spec, o) -> assertEquals(memo, ((AccountInfo) o).getMemo(), "Bad memo!"));
         return this;
     }
 

--- a/test-clients/src/main/java/com/hedera/services/bdd/spec/assertions/AccountInfoAsserts.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/spec/assertions/AccountInfoAsserts.java
@@ -15,22 +15,24 @@
  */
 package com.hedera.services.bdd.spec.assertions;
 
+import com.hedera.services.bdd.spec.HapiApiSpec;
+import com.hedera.services.bdd.spec.HapiPropertySource;
+import com.hedera.services.bdd.spec.queries.crypto.ExpectedTokenRel;
+import com.hederahashgraph.api.proto.java.AccountID;
+import com.hederahashgraph.api.proto.java.Key;
+import org.junit.jupiter.api.Assertions;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.function.ToLongFunction;
+
 import static com.hedera.services.bdd.suites.HapiApiSuite.ONE_HBAR;
 import static com.hederahashgraph.api.proto.java.CryptoGetInfoResponse.AccountInfo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-
-import com.hedera.services.bdd.spec.HapiApiSpec;
-import com.hedera.services.bdd.spec.HapiPropertySource;
-import com.hedera.services.bdd.spec.queries.crypto.ExpectedTokenRel;
-import com.hederahashgraph.api.proto.java.AccountID;
-import com.hederahashgraph.api.proto.java.Key;
-import java.util.List;
-import java.util.Optional;
-import java.util.function.Function;
-import org.junit.jupiter.api.Assertions;
 
 public class AccountInfoAsserts extends BaseErroringAssertsProvider<AccountInfo> {
     public static AccountInfoAsserts accountWith() {
@@ -79,12 +81,10 @@ public class AccountInfoAsserts extends BaseErroringAssertsProvider<AccountInfo>
 
     public AccountInfoAsserts accountId(String account) {
         registerProvider(
-                (spec, o) -> {
-                    assertEquals(
-                            spec.registry().getAccountID(account),
-                            ((AccountInfo) o).getAccountID(),
-                            "Bad account Id!");
-                });
+                (spec, o) -> assertEquals(
+                        spec.registry().getAccountID(account),
+                        ((AccountInfo) o).getAccountID(),
+                        "Bad account Id!"));
         return this;
     }
 
@@ -329,7 +329,7 @@ public class AccountInfoAsserts extends BaseErroringAssertsProvider<AccountInfo>
     }
 
     public static Function<HapiApiSpec, Function<Long, Optional<String>>> changeFromSnapshot(
-            String snapshot, Function<HapiApiSpec, Long> expDeltaFn) {
+            String snapshot, ToLongFunction<HapiApiSpec> expDeltaFn) {
         return approxChangeFromSnapshot(snapshot, expDeltaFn, 0L);
     }
 
@@ -344,10 +344,10 @@ public class AccountInfoAsserts extends BaseErroringAssertsProvider<AccountInfo>
     }
 
     public static Function<HapiApiSpec, Function<Long, Optional<String>>> approxChangeFromSnapshot(
-            String snapshot, Function<HapiApiSpec, Long> expDeltaFn, long epsilon) {
+            String snapshot, ToLongFunction<HapiApiSpec> expDeltaFn, long epsilon) {
         return spec ->
                 actual -> {
-                    long expDelta = expDeltaFn.apply(spec);
+                    long expDelta = expDeltaFn.applyAsLong(spec);
                     long actualDelta = actual - spec.registry().getBalanceSnapshot(snapshot);
                     if (Math.abs(actualDelta - expDelta) <= epsilon) {
                         return Optional.empty();
@@ -363,23 +363,19 @@ public class AccountInfoAsserts extends BaseErroringAssertsProvider<AccountInfo>
 
     public AccountInfoAsserts sendThreshold(long amount) {
         registerProvider(
-                (spec, o) -> {
-                    assertEquals(
-                            amount,
-                            ((AccountInfo) o).getGenerateSendRecordThreshold(),
-                            "Bad send threshold!");
-                });
+                (spec, o) -> assertEquals(
+                        amount,
+                        ((AccountInfo) o).getGenerateSendRecordThreshold(),
+                        "Bad send threshold!"));
         return this;
     }
 
     public AccountInfoAsserts receiveThreshold(long amount) {
         registerProvider(
-                (spec, o) -> {
-                    assertEquals(
-                            amount,
-                            ((AccountInfo) o).getGenerateReceiveRecordThreshold(),
-                            "Bad receive threshold!");
-                });
+                (spec, o) -> assertEquals(
+                        amount,
+                        ((AccountInfo) o).getGenerateReceiveRecordThreshold(),
+                        "Bad receive threshold!"));
         return this;
     }
 
@@ -413,31 +409,25 @@ public class AccountInfoAsserts extends BaseErroringAssertsProvider<AccountInfo>
 
     public AccountInfoAsserts autoRenew(long period) {
         registerProvider(
-                (spec, o) -> {
-                    assertEquals(
-                            period,
-                            ((AccountInfo) o).getAutoRenewPeriod().getSeconds(),
-                            "Bad auto-renew period!");
-                });
+                (spec, o) -> assertEquals(
+                        period,
+                        ((AccountInfo) o).getAutoRenewPeriod().getSeconds(),
+                        "Bad auto-renew period!"));
         return this;
     }
 
     public AccountInfoAsserts nonce(long nonce) {
         registerProvider(
-                (spec, o) -> {
-                    assertEquals(nonce, ((AccountInfo) o).getEthereumNonce(), "Bad nonce!");
-                });
+                (spec, o) -> assertEquals(nonce, ((AccountInfo) o).getEthereumNonce(), "Bad nonce!"));
         return this;
     }
 
     public AccountInfoAsserts pendingRewards(long reward) {
         registerProvider(
-                (spec, o) -> {
-                    assertEquals(
-                            reward,
-                            ((AccountInfo) o).getStakingInfo().getPendingReward(),
-                            "Bad pending rewards!");
-                });
+                (spec, o) -> assertEquals(
+                        reward,
+                        ((AccountInfo) o).getStakingInfo().getPendingReward(),
+                        "Bad pending rewards!"));
         return this;
     }
 }

--- a/test-clients/src/main/java/com/hedera/services/bdd/spec/assertions/ContractInfoAsserts.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/spec/assertions/ContractInfoAsserts.java
@@ -15,24 +15,25 @@
  */
 package com.hedera.services.bdd.spec.assertions;
 
-import com.hedera.services.bdd.spec.HapiPropertySource;
-import com.hedera.services.bdd.spec.queries.crypto.ExpectedTokenRel;
-import com.hedera.services.bdd.spec.transactions.TxnUtils;
-import com.hederahashgraph.api.proto.java.AccountID;
-import com.hederahashgraph.api.proto.java.CryptoGetInfoResponse;
-import com.hederahashgraph.api.proto.java.Key;
-
-import java.util.List;
-
 import static com.hederahashgraph.api.proto.java.ContractGetInfoResponse.ContractInfo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.hedera.services.bdd.spec.HapiPropertySource;
+import com.hedera.services.bdd.spec.queries.crypto.ExpectedTokenRel;
+import com.hedera.services.bdd.spec.transactions.TxnUtils;
+import com.hederahashgraph.api.proto.java.AccountID;
+import com.hederahashgraph.api.proto.java.CryptoGetInfoResponse;
+import com.hederahashgraph.api.proto.java.Key;
+import java.util.List;
+
 public class ContractInfoAsserts extends BaseErroringAssertsProvider<ContractInfo> {
     private static final String BAD_MEMO = "Bad memo";
-    public static ContractInfoAsserts infoKnownFor(String contract) {
+  private static final String BAD_ADMIN_KEY = "Bad admin key";
+
+  public static ContractInfoAsserts infoKnownFor(String contract) {
         return contractWith().knownInfoFor(contract);
     }
 
@@ -60,7 +61,7 @@ public class ContractInfoAsserts extends BaseErroringAssertsProvider<ContractInf
                     assertEquals(
                             spec.registry().getKey(contract),
                             actual.getAdminKey(),
-                            "Bad admin key!");
+                            BAD_ADMIN_KEY);
                     assertTrue(
                             object2ContractInfo(o).getExpirationTime().getSeconds() != 0,
                             "Expiry must not be null!");
@@ -75,59 +76,49 @@ public class ContractInfoAsserts extends BaseErroringAssertsProvider<ContractInf
 
     public ContractInfoAsserts nonNullContractId() {
         registerProvider(
-                (spec, o) -> {
-                    assertTrue(object2ContractInfo(o).hasContractID(), "Null contractId!");
-                });
+                (spec, o) -> assertTrue(object2ContractInfo(o).hasContractID(), "Null contractId!"));
         return this;
     }
 
     public ContractInfoAsserts noStakePeriodStart() {
         registerProvider(
-                (spec, o) -> {
-                    assertEquals(
-                            0,
-                            object2ContractInfo(o)
-                                    .getStakingInfo()
-                                    .getStakePeriodStart()
-                                    .getSeconds(),
-                            "Wrong stakePeriodStart");
-                });
+                (spec, o) -> assertEquals(
+                        0,
+                        object2ContractInfo(o)
+                                .getStakingInfo()
+                                .getStakePeriodStart()
+                                .getSeconds(),
+                        "Wrong stakePeriodStart"));
         return this;
     }
 
     public ContractInfoAsserts someStakePeriodStart() {
         registerProvider(
-                (spec, o) -> {
-                    assertNotEquals(
-                            0,
-                            object2ContractInfo(o)
-                                    .getStakingInfo()
-                                    .getStakePeriodStart()
-                                    .getSeconds(),
-                            "Wrong stakePeriodStart");
-                });
+                (spec, o) -> assertNotEquals(
+                        0,
+                        object2ContractInfo(o)
+                                .getStakingInfo()
+                                .getStakePeriodStart()
+                                .getSeconds(),
+                        "Wrong stakePeriodStart"));
         return this;
     }
 
     public ContractInfoAsserts addressOrAlias(final String hexedEvm) {
         registerProvider(
-                (spec, o) -> {
-                    assertEquals(
-                            hexedEvm,
-                            object2ContractInfo(o).getContractAccountID(),
-                            "Bad EVM address");
-                });
+                (spec, o) -> assertEquals(
+                        hexedEvm,
+                        object2ContractInfo(o).getContractAccountID(),
+                        "Bad EVM address"));
         return this;
     }
 
     public ContractInfoAsserts maxAutoAssociations(final int num) {
         registerProvider(
-                (spec, o) -> {
-                    assertEquals(
-                            num,
-                            object2ContractInfo(o).getMaxAutomaticTokenAssociations(),
-                            "Bad Contract maxAutoAssociations");
-                });
+                (spec, o) -> assertEquals(
+                        num,
+                        object2ContractInfo(o).getMaxAutomaticTokenAssociations(),
+                        "Bad Contract maxAutoAssociations"));
         return this;
     }
 
@@ -177,28 +168,32 @@ public class ContractInfoAsserts extends BaseErroringAssertsProvider<ContractInf
 
     public ContractInfoAsserts solidityAddress(String contract) {
         registerProvider(
-                (spec, o) -> assertEquals(
-                        TxnUtils.solidityIdFrom(spec.registry().getContractId(contract)),
-                        TxnUtils.solidityIdFrom(object2ContractInfo(o).getContractID()),
-                        "Bad Solidity address"));
+                (spec, o) ->
+                        assertEquals(
+                                TxnUtils.solidityIdFrom(spec.registry().getContractId(contract)),
+                                TxnUtils.solidityIdFrom(object2ContractInfo(o).getContractID()),
+                                "Bad Solidity address"));
         return this;
     }
 
     public ContractInfoAsserts isDeleted() {
         registerProvider(
-                (spec, o) -> assertTrue(object2ContractInfo(o).getDeleted(), "Bad deletion status!"));
+                (spec, o) ->
+                        assertTrue(object2ContractInfo(o).getDeleted(), "Bad deletion status!"));
         return this;
     }
 
     public ContractInfoAsserts memo(String expectedMemo) {
         registerProvider(
-                (spec, o) -> assertEquals(expectedMemo, object2ContractInfo(o).getMemo(), BAD_MEMO));
+                (spec, o) ->
+                        assertEquals(expectedMemo, object2ContractInfo(o).getMemo(), BAD_MEMO));
         return this;
     }
 
     public ContractInfoAsserts balance(long balance) {
         registerProvider(
-                (spec, o) -> assertEquals(balance, object2ContractInfo(o).getBalance(), "Bad balance!"));
+                (spec, o) ->
+                        assertEquals(balance, object2ContractInfo(o).getBalance(), "Bad balance!"));
         return this;
     }
 
@@ -226,10 +221,11 @@ public class ContractInfoAsserts extends BaseErroringAssertsProvider<ContractInf
 
     public ContractInfoAsserts expiry(long expectedExpiry) {
         registerProvider(
-                (spec, o) -> assertEquals(
-                        expectedExpiry,
-                        object2ContractInfo(o).getExpirationTime().getSeconds(),
-                        "Bad expiry time!"));
+                (spec, o) ->
+                        assertEquals(
+                                expectedExpiry,
+                                object2ContractInfo(o).getExpirationTime().getSeconds(),
+                                "Bad expiry time!"));
         return this;
     }
 
@@ -242,7 +238,7 @@ public class ContractInfoAsserts extends BaseErroringAssertsProvider<ContractInf
                             expected.getAutoRenewPeriod(),
                             actual.getAutoRenewPeriod(),
                             "Bad auto renew period!");
-                    assertEquals(expected.getAdminKey(), actual.getAdminKey(), "Bad admin key!");
+                    assertEquals(expected.getAdminKey(), actual.getAdminKey(), BAD_ADMIN_KEY);
                     assertEquals(expected.getMemo(), actual.getMemo(), BAD_MEMO);
                 });
         return this;
@@ -253,7 +249,7 @@ public class ContractInfoAsserts extends BaseErroringAssertsProvider<ContractInf
                 (spec, o) -> {
                     Key expectedKey = spec.registry().getKey(expectedKeyName);
                     assertEquals(
-                            expectedKey, object2ContractInfo(o).getAdminKey(), "Bad admin key!");
+                            expectedKey, object2ContractInfo(o).getAdminKey(), BAD_ADMIN_KEY);
                 });
         return this;
     }
@@ -282,12 +278,10 @@ public class ContractInfoAsserts extends BaseErroringAssertsProvider<ContractInf
 
     public ContractInfoAsserts autoRenew(long expectedAutoRenew) {
         registerProvider(
-                (spec, o) -> {
-                    assertEquals(
-                            expectedAutoRenew,
-                            object2ContractInfo(o).getAutoRenewPeriod().getSeconds(),
-                            "Bad" + " autoRenew!");
-                });
+                (spec, o) -> assertEquals(
+                        expectedAutoRenew,
+                        object2ContractInfo(o).getAutoRenewPeriod().getSeconds(),
+                        "Bad" + " autoRenew!"));
         return this;
     }
 
@@ -295,89 +289,73 @@ public class ContractInfoAsserts extends BaseErroringAssertsProvider<ContractInf
         /* EVM storage maps 32-byte keys to 32-byte values */
         final long numStorageBytes = expectedKvPairs * 64L;
         registerProvider(
-                (spec, o) -> {
-                    assertEquals(
-                            numStorageBytes,
-                            object2ContractInfo(o).getStorage(),
-                            "Bad storage size!");
-                });
+                (spec, o) -> assertEquals(
+                        numStorageBytes,
+                        object2ContractInfo(o).getStorage(),
+                        "Bad storage size!"));
         return this;
     }
 
     public ContractInfoAsserts stakedAccountId(String idLiteral) {
         registerProvider(
-                (spec, o) -> {
-                    assertEquals(
-                            TxnUtils.asId(idLiteral, spec),
-                            (object2ContractInfo(o)).getStakingInfo().getStakedAccountId(),
-                            "Bad stakedAccountId id!");
-                });
+                (spec, o) -> assertEquals(
+                        TxnUtils.asId(idLiteral, spec),
+                        (object2ContractInfo(o)).getStakingInfo().getStakedAccountId(),
+                        "Bad stakedAccountId id!"));
         return this;
     }
 
     public ContractInfoAsserts stakedNodeId(long idLiteral) {
         registerProvider(
-                (spec, o) -> {
-                    assertEquals(
-                            idLiteral,
-                            (object2ContractInfo(o)).getStakingInfo().getStakedNodeId(),
-                            "Bad stakedNodeId id!");
-                });
+                (spec, o) -> assertEquals(
+                        idLiteral,
+                        (object2ContractInfo(o)).getStakingInfo().getStakedNodeId(),
+                        "Bad stakedNodeId id!"));
         return this;
     }
 
     public ContractInfoAsserts isDeclinedReward(boolean isDeclined) {
         registerProvider(
-                (spec, o) -> {
-                    assertEquals(
-                            isDeclined,
-                            (object2ContractInfo(o)).getStakingInfo().getDeclineReward(),
-                            "Bad isDeclinedReward!");
-                });
+                (spec, o) -> assertEquals(
+                        isDeclined,
+                        (object2ContractInfo(o)).getStakingInfo().getDeclineReward(),
+                        "Bad isDeclinedReward!"));
         return this;
     }
 
     public ContractInfoAsserts noStakedAccountId() {
         registerProvider(
-                (spec, o) -> {
-                    assertEquals(
-                            AccountID.getDefaultInstance(),
-                            (object2ContractInfo(o)).getStakingInfo().getStakedAccountId(),
-                            "Bad stakedAccountId id!");
-                });
+                (spec, o) -> assertEquals(
+                        AccountID.getDefaultInstance(),
+                        (object2ContractInfo(o)).getStakingInfo().getStakedAccountId(),
+                        "Bad stakedAccountId id!"));
         return this;
     }
 
     public ContractInfoAsserts noStakingNodeId() {
         registerProvider(
-                (spec, o) -> {
-                    assertEquals(
-                            0,
-                            (object2ContractInfo(o)).getStakingInfo().getStakedNodeId(),
-                            "Bad stakedNodeId id!");
-                });
+                (spec, o) -> assertEquals(
+                        0,
+                        (object2ContractInfo(o)).getStakingInfo().getStakedNodeId(),
+                        "Bad stakedNodeId id!"));
         return this;
     }
 
     public ContractInfoAsserts autoRenewAccountId(String id) {
         registerProvider(
-                (spec, o) -> {
-                    assertEquals(
-                            spec.registry().getAccountID(id),
-                            object2ContractInfo(o).getAutoRenewAccountId(),
-                            "Bad autoRenewAccountId !");
-                });
+                (spec, o) -> assertEquals(
+                        spec.registry().getAccountID(id),
+                        object2ContractInfo(o).getAutoRenewAccountId(),
+                        "Bad autoRenewAccountId !"));
         return this;
     }
 
     public ContractInfoAsserts pendingRewards(long reward) {
         registerProvider(
-                (spec, o) -> {
-                    assertEquals(
-                            reward,
-                            (object2ContractInfo(o)).getStakingInfo().getPendingReward(),
-                            "Bad pending rewards!");
-                });
+                (spec, o) -> assertEquals(
+                        reward,
+                        (object2ContractInfo(o)).getStakingInfo().getPendingReward(),
+                        "Bad pending rewards!"));
         return this;
     }
 

--- a/test-clients/src/main/java/com/hedera/services/bdd/spec/assertions/ContractInfoAsserts.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/spec/assertions/ContractInfoAsserts.java
@@ -31,9 +31,9 @@ import java.util.List;
 
 public class ContractInfoAsserts extends BaseErroringAssertsProvider<ContractInfo> {
     private static final String BAD_MEMO = "Bad memo";
-  private static final String BAD_ADMIN_KEY = "Bad admin key";
+    private static final String BAD_ADMIN_KEY = "Bad admin key";
 
-  public static ContractInfoAsserts infoKnownFor(String contract) {
+    public static ContractInfoAsserts infoKnownFor(String contract) {
         return contractWith().knownInfoFor(contract);
     }
 
@@ -59,9 +59,7 @@ public class ContractInfoAsserts extends BaseErroringAssertsProvider<ContractInf
                             actual.getContractAccountID(),
                             "Bad Solidity id!");
                     assertEquals(
-                            spec.registry().getKey(contract),
-                            actual.getAdminKey(),
-                            BAD_ADMIN_KEY);
+                            spec.registry().getKey(contract), actual.getAdminKey(), BAD_ADMIN_KEY);
                     assertTrue(
                             object2ContractInfo(o).getExpirationTime().getSeconds() != 0,
                             "Expiry must not be null!");
@@ -76,49 +74,54 @@ public class ContractInfoAsserts extends BaseErroringAssertsProvider<ContractInf
 
     public ContractInfoAsserts nonNullContractId() {
         registerProvider(
-                (spec, o) -> assertTrue(object2ContractInfo(o).hasContractID(), "Null contractId!"));
+                (spec, o) ->
+                        assertTrue(object2ContractInfo(o).hasContractID(), "Null contractId!"));
         return this;
     }
 
     public ContractInfoAsserts noStakePeriodStart() {
         registerProvider(
-                (spec, o) -> assertEquals(
-                        0,
-                        object2ContractInfo(o)
-                                .getStakingInfo()
-                                .getStakePeriodStart()
-                                .getSeconds(),
-                        "Wrong stakePeriodStart"));
+                (spec, o) ->
+                        assertEquals(
+                                0,
+                                object2ContractInfo(o)
+                                        .getStakingInfo()
+                                        .getStakePeriodStart()
+                                        .getSeconds(),
+                                "Wrong stakePeriodStart"));
         return this;
     }
 
     public ContractInfoAsserts someStakePeriodStart() {
         registerProvider(
-                (spec, o) -> assertNotEquals(
-                        0,
-                        object2ContractInfo(o)
-                                .getStakingInfo()
-                                .getStakePeriodStart()
-                                .getSeconds(),
-                        "Wrong stakePeriodStart"));
+                (spec, o) ->
+                        assertNotEquals(
+                                0,
+                                object2ContractInfo(o)
+                                        .getStakingInfo()
+                                        .getStakePeriodStart()
+                                        .getSeconds(),
+                                "Wrong stakePeriodStart"));
         return this;
     }
 
     public ContractInfoAsserts addressOrAlias(final String hexedEvm) {
         registerProvider(
-                (spec, o) -> assertEquals(
-                        hexedEvm,
-                        object2ContractInfo(o).getContractAccountID(),
-                        "Bad EVM address"));
+                (spec, o) ->
+                        assertEquals(
+                                hexedEvm,
+                                object2ContractInfo(o).getContractAccountID(),
+                                "Bad EVM address"));
         return this;
     }
 
     public ContractInfoAsserts maxAutoAssociations(final int num) {
         registerProvider(
-                (spec, o) -> assertEquals(
-                        num,
-                        object2ContractInfo(o).getMaxAutomaticTokenAssociations(),
-                        "Bad Contract maxAutoAssociations"));
+                (spec, o) ->
+                        assertEquals(
+                                num,
+                                object2ContractInfo(o).getMaxAutomaticTokenAssociations(),
+                                "Bad Contract maxAutoAssociations"));
         return this;
     }
 
@@ -248,8 +251,7 @@ public class ContractInfoAsserts extends BaseErroringAssertsProvider<ContractInf
         registerProvider(
                 (spec, o) -> {
                     Key expectedKey = spec.registry().getKey(expectedKeyName);
-                    assertEquals(
-                            expectedKey, object2ContractInfo(o).getAdminKey(), BAD_ADMIN_KEY);
+                    assertEquals(expectedKey, object2ContractInfo(o).getAdminKey(), BAD_ADMIN_KEY);
                 });
         return this;
     }
@@ -278,10 +280,11 @@ public class ContractInfoAsserts extends BaseErroringAssertsProvider<ContractInf
 
     public ContractInfoAsserts autoRenew(long expectedAutoRenew) {
         registerProvider(
-                (spec, o) -> assertEquals(
-                        expectedAutoRenew,
-                        object2ContractInfo(o).getAutoRenewPeriod().getSeconds(),
-                        "Bad" + " autoRenew!"));
+                (spec, o) ->
+                        assertEquals(
+                                expectedAutoRenew,
+                                object2ContractInfo(o).getAutoRenewPeriod().getSeconds(),
+                                "Bad" + " autoRenew!"));
         return this;
     }
 
@@ -289,73 +292,81 @@ public class ContractInfoAsserts extends BaseErroringAssertsProvider<ContractInf
         /* EVM storage maps 32-byte keys to 32-byte values */
         final long numStorageBytes = expectedKvPairs * 64L;
         registerProvider(
-                (spec, o) -> assertEquals(
-                        numStorageBytes,
-                        object2ContractInfo(o).getStorage(),
-                        "Bad storage size!"));
+                (spec, o) ->
+                        assertEquals(
+                                numStorageBytes,
+                                object2ContractInfo(o).getStorage(),
+                                "Bad storage size!"));
         return this;
     }
 
     public ContractInfoAsserts stakedAccountId(String idLiteral) {
         registerProvider(
-                (spec, o) -> assertEquals(
-                        TxnUtils.asId(idLiteral, spec),
-                        (object2ContractInfo(o)).getStakingInfo().getStakedAccountId(),
-                        "Bad stakedAccountId id!"));
+                (spec, o) ->
+                        assertEquals(
+                                TxnUtils.asId(idLiteral, spec),
+                                (object2ContractInfo(o)).getStakingInfo().getStakedAccountId(),
+                                "Bad stakedAccountId id!"));
         return this;
     }
 
     public ContractInfoAsserts stakedNodeId(long idLiteral) {
         registerProvider(
-                (spec, o) -> assertEquals(
-                        idLiteral,
-                        (object2ContractInfo(o)).getStakingInfo().getStakedNodeId(),
-                        "Bad stakedNodeId id!"));
+                (spec, o) ->
+                        assertEquals(
+                                idLiteral,
+                                (object2ContractInfo(o)).getStakingInfo().getStakedNodeId(),
+                                "Bad stakedNodeId id!"));
         return this;
     }
 
     public ContractInfoAsserts isDeclinedReward(boolean isDeclined) {
         registerProvider(
-                (spec, o) -> assertEquals(
-                        isDeclined,
-                        (object2ContractInfo(o)).getStakingInfo().getDeclineReward(),
-                        "Bad isDeclinedReward!"));
+                (spec, o) ->
+                        assertEquals(
+                                isDeclined,
+                                (object2ContractInfo(o)).getStakingInfo().getDeclineReward(),
+                                "Bad isDeclinedReward!"));
         return this;
     }
 
     public ContractInfoAsserts noStakedAccountId() {
         registerProvider(
-                (spec, o) -> assertEquals(
-                        AccountID.getDefaultInstance(),
-                        (object2ContractInfo(o)).getStakingInfo().getStakedAccountId(),
-                        "Bad stakedAccountId id!"));
+                (spec, o) ->
+                        assertEquals(
+                                AccountID.getDefaultInstance(),
+                                (object2ContractInfo(o)).getStakingInfo().getStakedAccountId(),
+                                "Bad stakedAccountId id!"));
         return this;
     }
 
     public ContractInfoAsserts noStakingNodeId() {
         registerProvider(
-                (spec, o) -> assertEquals(
-                        0,
-                        (object2ContractInfo(o)).getStakingInfo().getStakedNodeId(),
-                        "Bad stakedNodeId id!"));
+                (spec, o) ->
+                        assertEquals(
+                                0,
+                                (object2ContractInfo(o)).getStakingInfo().getStakedNodeId(),
+                                "Bad stakedNodeId id!"));
         return this;
     }
 
     public ContractInfoAsserts autoRenewAccountId(String id) {
         registerProvider(
-                (spec, o) -> assertEquals(
-                        spec.registry().getAccountID(id),
-                        object2ContractInfo(o).getAutoRenewAccountId(),
-                        "Bad autoRenewAccountId !"));
+                (spec, o) ->
+                        assertEquals(
+                                spec.registry().getAccountID(id),
+                                object2ContractInfo(o).getAutoRenewAccountId(),
+                                "Bad autoRenewAccountId !"));
         return this;
     }
 
     public ContractInfoAsserts pendingRewards(long reward) {
         registerProvider(
-                (spec, o) -> assertEquals(
-                        reward,
-                        (object2ContractInfo(o)).getStakingInfo().getPendingReward(),
-                        "Bad pending rewards!"));
+                (spec, o) ->
+                        assertEquals(
+                                reward,
+                                (object2ContractInfo(o)).getStakingInfo().getPendingReward(),
+                                "Bad pending rewards!"));
         return this;
     }
 

--- a/test-clients/src/main/java/com/hedera/services/bdd/spec/assertions/ContractInfoAsserts.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/spec/assertions/ContractInfoAsserts.java
@@ -15,21 +15,23 @@
  */
 package com.hedera.services.bdd.spec.assertions;
 
-import static com.hederahashgraph.api.proto.java.ContractGetInfoResponse.ContractInfo;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
 import com.hedera.services.bdd.spec.HapiPropertySource;
 import com.hedera.services.bdd.spec.queries.crypto.ExpectedTokenRel;
 import com.hedera.services.bdd.spec.transactions.TxnUtils;
 import com.hederahashgraph.api.proto.java.AccountID;
 import com.hederahashgraph.api.proto.java.CryptoGetInfoResponse;
 import com.hederahashgraph.api.proto.java.Key;
+
 import java.util.List;
 
+import static com.hederahashgraph.api.proto.java.ContractGetInfoResponse.ContractInfo;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 public class ContractInfoAsserts extends BaseErroringAssertsProvider<ContractInfo> {
+    private static final String BAD_MEMO = "Bad memo";
     public static ContractInfoAsserts infoKnownFor(String contract) {
         return contractWith().knownInfoFor(contract);
     }
@@ -66,7 +68,7 @@ public class ContractInfoAsserts extends BaseErroringAssertsProvider<ContractInf
                             otherExpectedInfo.getAutoRenewPeriod(),
                             actual.getAutoRenewPeriod(),
                             "Bad auto renew period!");
-                    assertEquals(otherExpectedInfo.getMemo(), actual.getMemo(), "Bad memo!");
+                    assertEquals(otherExpectedInfo.getMemo(), actual.getMemo(), BAD_MEMO);
                 });
         return this;
     }
@@ -175,36 +177,28 @@ public class ContractInfoAsserts extends BaseErroringAssertsProvider<ContractInf
 
     public ContractInfoAsserts solidityAddress(String contract) {
         registerProvider(
-                (spec, o) -> {
-                    assertEquals(
-                            TxnUtils.solidityIdFrom(spec.registry().getContractId(contract)),
-                            TxnUtils.solidityIdFrom(object2ContractInfo(o).getContractID()),
-                            "Bad Solidity address");
-                });
+                (spec, o) -> assertEquals(
+                        TxnUtils.solidityIdFrom(spec.registry().getContractId(contract)),
+                        TxnUtils.solidityIdFrom(object2ContractInfo(o).getContractID()),
+                        "Bad Solidity address"));
         return this;
     }
 
     public ContractInfoAsserts isDeleted() {
         registerProvider(
-                (spec, o) -> {
-                    assertEquals(true, object2ContractInfo(o).getDeleted(), "Bad deletion status!");
-                });
+                (spec, o) -> assertTrue(object2ContractInfo(o).getDeleted(), "Bad deletion status!"));
         return this;
     }
 
     public ContractInfoAsserts memo(String expectedMemo) {
         registerProvider(
-                (spec, o) -> {
-                    assertEquals(expectedMemo, object2ContractInfo(o).getMemo(), "Bad memo!");
-                });
+                (spec, o) -> assertEquals(expectedMemo, object2ContractInfo(o).getMemo(), BAD_MEMO));
         return this;
     }
 
     public ContractInfoAsserts balance(long balance) {
         registerProvider(
-                (spec, o) -> {
-                    assertEquals(balance, object2ContractInfo(o).getBalance(), "Bad balance!");
-                });
+                (spec, o) -> assertEquals(balance, object2ContractInfo(o).getBalance(), "Bad balance!"));
         return this;
     }
 
@@ -232,12 +226,10 @@ public class ContractInfoAsserts extends BaseErroringAssertsProvider<ContractInf
 
     public ContractInfoAsserts expiry(long expectedExpiry) {
         registerProvider(
-                (spec, o) -> {
-                    assertEquals(
-                            expectedExpiry,
-                            object2ContractInfo(o).getExpirationTime().getSeconds(),
-                            "Bad expiry time!");
-                });
+                (spec, o) -> assertEquals(
+                        expectedExpiry,
+                        object2ContractInfo(o).getExpirationTime().getSeconds(),
+                        "Bad expiry time!"));
         return this;
     }
 
@@ -251,7 +243,7 @@ public class ContractInfoAsserts extends BaseErroringAssertsProvider<ContractInf
                             actual.getAutoRenewPeriod(),
                             "Bad auto renew period!");
                     assertEquals(expected.getAdminKey(), actual.getAdminKey(), "Bad admin key!");
-                    assertEquals(expected.getMemo(), actual.getMemo(), "Bad memo!");
+                    assertEquals(expected.getMemo(), actual.getMemo(), BAD_MEMO);
                 });
         return this;
     }

--- a/test-clients/src/main/java/com/hedera/services/bdd/spec/assertions/ContractInfoAsserts.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/spec/assertions/ContractInfoAsserts.java
@@ -1,11 +1,6 @@
-package com.hedera.services.bdd.spec.assertions;
-
-/*-
- * ‌
- * Hedera Services Test Clients
- * ​
- * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
- * ​
+/*
+ * Copyright (C) 2020-2022 Hedera Hashgraph, LLC
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -17,17 +12,8 @@ package com.hedera.services.bdd.spec.assertions;
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- * ‍
  */
-
-import com.hedera.services.bdd.spec.HapiPropertySource;
-import com.hedera.services.bdd.spec.queries.crypto.ExpectedTokenRel;
-import com.hedera.services.bdd.spec.transactions.TxnUtils;
-import com.hederahashgraph.api.proto.java.AccountID;
-import com.hederahashgraph.api.proto.java.CryptoGetInfoResponse;
-import com.hederahashgraph.api.proto.java.Key;
-
-import java.util.List;
+package com.hedera.services.bdd.spec.assertions;
 
 import static com.hederahashgraph.api.proto.java.ContractGetInfoResponse.ContractInfo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -35,294 +21,375 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.hedera.services.bdd.spec.HapiPropertySource;
+import com.hedera.services.bdd.spec.queries.crypto.ExpectedTokenRel;
+import com.hedera.services.bdd.spec.transactions.TxnUtils;
+import com.hederahashgraph.api.proto.java.AccountID;
+import com.hederahashgraph.api.proto.java.CryptoGetInfoResponse;
+import com.hederahashgraph.api.proto.java.Key;
+import java.util.List;
+
 public class ContractInfoAsserts extends BaseErroringAssertsProvider<ContractInfo> {
-	public static ContractInfoAsserts infoKnownFor(String contract) {
-		return contractWith().knownInfoFor(contract);
-	}
+    public static ContractInfoAsserts infoKnownFor(String contract) {
+        return contractWith().knownInfoFor(contract);
+    }
 
-	public static ContractInfoAsserts contractWith() {
-		return new ContractInfoAsserts();
-	}
+    public static ContractInfoAsserts contractWith() {
+        return new ContractInfoAsserts();
+    }
 
-	public ContractInfoAsserts knownInfoFor(String contract) {
-		registerProvider((spec, o) -> {
-			ContractInfo actual = (ContractInfo) o;
-			assertEquals(spec.registry().getContractId(contract), actual.getContractID(),
-					"Bad contract id!");
-			assertEquals(TxnUtils.equivAccount(spec.registry().getContractId(contract)),
-					actual.getAccountID(),
-					"Bad account id!");
-			ContractInfo otherExpectedInfo = spec.registry().getContractInfo(contract);
-			assertEquals(
-					otherExpectedInfo.getContractAccountID(), actual.getContractAccountID(),
-					"Bad Solidity id!");
-			assertEquals(spec.registry().getKey(contract), actual.getAdminKey(),
-					"Bad admin key!");
-			assertTrue(object2ContractInfo(o).getExpirationTime().getSeconds() != 0,
-					"Expiry must not be null!");
-			assertEquals(otherExpectedInfo.getAutoRenewPeriod(), actual.getAutoRenewPeriod(),
-					"Bad auto renew period!");
-			assertEquals(otherExpectedInfo.getMemo(), actual.getMemo(),
-					"Bad memo!");
-		});
-		return this;
-	}
+    public ContractInfoAsserts knownInfoFor(String contract) {
+        registerProvider(
+                (spec, o) -> {
+                    ContractInfo actual = (ContractInfo) o;
+                    assertEquals(
+                            spec.registry().getContractId(contract),
+                            actual.getContractID(),
+                            "Bad contract id!");
+                    assertEquals(
+                            TxnUtils.equivAccount(spec.registry().getContractId(contract)),
+                            actual.getAccountID(),
+                            "Bad account id!");
+                    ContractInfo otherExpectedInfo = spec.registry().getContractInfo(contract);
+                    assertEquals(
+                            otherExpectedInfo.getContractAccountID(),
+                            actual.getContractAccountID(),
+                            "Bad Solidity id!");
+                    assertEquals(
+                            spec.registry().getKey(contract),
+                            actual.getAdminKey(),
+                            "Bad admin key!");
+                    assertTrue(
+                            object2ContractInfo(o).getExpirationTime().getSeconds() != 0,
+                            "Expiry must not be null!");
+                    assertEquals(
+                            otherExpectedInfo.getAutoRenewPeriod(),
+                            actual.getAutoRenewPeriod(),
+                            "Bad auto renew period!");
+                    assertEquals(otherExpectedInfo.getMemo(), actual.getMemo(), "Bad memo!");
+                });
+        return this;
+    }
 
-	public ContractInfoAsserts nonNullContractId() {
-		registerProvider((spec, o) -> {
-			assertTrue(object2ContractInfo(o).hasContractID(), "Null contractId!");
-		});
-		return this;
-	}
+    public ContractInfoAsserts nonNullContractId() {
+        registerProvider(
+                (spec, o) -> {
+                    assertTrue(object2ContractInfo(o).hasContractID(), "Null contractId!");
+                });
+        return this;
+    }
 
-	public ContractInfoAsserts noStakePeriodStart() {
-		registerProvider((spec, o) -> {
-			assertEquals(0,
-					object2ContractInfo(o).getStakingInfo().getStakePeriodStart().getSeconds(),
-					"Wrong stakePeriodStart");
-		});
-		return this;
-	}
+    public ContractInfoAsserts noStakePeriodStart() {
+        registerProvider(
+                (spec, o) -> {
+                    assertEquals(
+                            0,
+                            object2ContractInfo(o)
+                                    .getStakingInfo()
+                                    .getStakePeriodStart()
+                                    .getSeconds(),
+                            "Wrong stakePeriodStart");
+                });
+        return this;
+    }
 
-	public ContractInfoAsserts someStakePeriodStart() {
-		registerProvider((spec, o) -> {
-			assertNotEquals(0,
-					object2ContractInfo(o).getStakingInfo().getStakePeriodStart().getSeconds(),
-					"Wrong stakePeriodStart");
-		});
-		return this;
-	}
+    public ContractInfoAsserts someStakePeriodStart() {
+        registerProvider(
+                (spec, o) -> {
+                    assertNotEquals(
+                            0,
+                            object2ContractInfo(o)
+                                    .getStakingInfo()
+                                    .getStakePeriodStart()
+                                    .getSeconds(),
+                            "Wrong stakePeriodStart");
+                });
+        return this;
+    }
 
-	public ContractInfoAsserts addressOrAlias(final String hexedEvm) {
-		registerProvider((spec, o) -> {
-			assertEquals(
-					hexedEvm,
-					object2ContractInfo(o).getContractAccountID(),
-					"Bad EVM address");
-		});
-		return this;
-	}
+    public ContractInfoAsserts addressOrAlias(final String hexedEvm) {
+        registerProvider(
+                (spec, o) -> {
+                    assertEquals(
+                            hexedEvm,
+                            object2ContractInfo(o).getContractAccountID(),
+                            "Bad EVM address");
+                });
+        return this;
+    }
 
-	public ContractInfoAsserts maxAutoAssociations(final int num) {
-		registerProvider((spec, o) -> {
-			assertEquals(
-					num,
-					object2ContractInfo(o).getMaxAutomaticTokenAssociations(),
-					"Bad Contract maxAutoAssociations");
-		});
-		return this;
-	}
+    public ContractInfoAsserts maxAutoAssociations(final int num) {
+        registerProvider(
+                (spec, o) -> {
+                    assertEquals(
+                            num,
+                            object2ContractInfo(o).getMaxAutomaticTokenAssociations(),
+                            "Bad Contract maxAutoAssociations");
+                });
+        return this;
+    }
 
-	public ContractInfoAsserts newAssociationsFromSnapshot(
-			final String snapshot,
-			final List<ExpectedTokenRel> newRels
-	) {
-		for (final var newRel : newRels) {
-			registerProvider((spec, o) -> {
-				final var baseline = spec.registry().getAccountInfo(snapshot);
-				for (final var existingRel : baseline.getTokenRelationshipsList()) {
-					assertFalse(newRel.matches(spec, existingRel),
-							"Expected no existing rel to match " + newRel
-									+ ", but " + existingRel + " did");
-				}
+    public ContractInfoAsserts newAssociationsFromSnapshot(
+            final String snapshot, final List<ExpectedTokenRel> newRels) {
+        for (final var newRel : newRels) {
+            registerProvider(
+                    (spec, o) -> {
+                        final var baseline = spec.registry().getAccountInfo(snapshot);
+                        for (final var existingRel : baseline.getTokenRelationshipsList()) {
+                            assertFalse(
+                                    newRel.matches(spec, existingRel),
+                                    "Expected no existing rel to match "
+                                            + newRel
+                                            + ", but "
+                                            + existingRel
+                                            + " did");
+                        }
 
-				final var current = (CryptoGetInfoResponse.AccountInfo) o;
-				var someMatches = false;
-				for (final var currentRel : current.getTokenRelationshipsList()) {
-					someMatches |= newRel.matches(spec, currentRel);
-				}
-				assertTrue(someMatches, "Expected some new rel to match " + newRel + ", but none did");
-			});
-		}
-		return this;
-	}
+                        final var current = (CryptoGetInfoResponse.AccountInfo) o;
+                        var someMatches = false;
+                        for (final var currentRel : current.getTokenRelationshipsList()) {
+                            someMatches |= newRel.matches(spec, currentRel);
+                        }
+                        assertTrue(
+                                someMatches,
+                                "Expected some new rel to match " + newRel + ", but none did");
+                    });
+        }
+        return this;
+    }
 
-	public ContractInfoAsserts hasAlreadyUsedAutomaticAssociations(final int num) {
-		registerProvider((spec, o) -> {
-			var actualTokenRels = object2ContractInfo(o).getTokenRelationshipsList();
-			int actualCount = 0;
-			for (var rel : actualTokenRels) {
-				if (rel.getAutomaticAssociation()) {
-					actualCount++;
-				}
-			}
-			assertEquals(actualCount, num);
-		});
-		return this;
-	}
+    public ContractInfoAsserts hasAlreadyUsedAutomaticAssociations(final int num) {
+        registerProvider(
+                (spec, o) -> {
+                    var actualTokenRels = object2ContractInfo(o).getTokenRelationshipsList();
+                    int actualCount = 0;
+                    for (var rel : actualTokenRels) {
+                        if (rel.getAutomaticAssociation()) {
+                            actualCount++;
+                        }
+                    }
+                    assertEquals(actualCount, num);
+                });
+        return this;
+    }
 
-	public ContractInfoAsserts solidityAddress(String contract) {
-		registerProvider((spec, o) -> {
-			assertEquals(
-					TxnUtils.solidityIdFrom(spec.registry().getContractId(contract)),
-					TxnUtils.solidityIdFrom(object2ContractInfo(o).getContractID()),
-					"Bad Solidity address");
-		});
-		return this;
-	}
+    public ContractInfoAsserts solidityAddress(String contract) {
+        registerProvider(
+                (spec, o) -> {
+                    assertEquals(
+                            TxnUtils.solidityIdFrom(spec.registry().getContractId(contract)),
+                            TxnUtils.solidityIdFrom(object2ContractInfo(o).getContractID()),
+                            "Bad Solidity address");
+                });
+        return this;
+    }
 
-	public ContractInfoAsserts isDeleted() {
-		registerProvider((spec, o) -> {
-			assertEquals(true, object2ContractInfo(o).getDeleted(), "Bad deletion status!");
-		});
-		return this;
-	}
+    public ContractInfoAsserts isDeleted() {
+        registerProvider(
+                (spec, o) -> {
+                    assertEquals(true, object2ContractInfo(o).getDeleted(), "Bad deletion status!");
+                });
+        return this;
+    }
 
-	public ContractInfoAsserts memo(String expectedMemo) {
-		registerProvider((spec, o) -> {
-			assertEquals(expectedMemo, object2ContractInfo(o).getMemo(), "Bad memo!");
-		});
-		return this;
-	}
+    public ContractInfoAsserts memo(String expectedMemo) {
+        registerProvider(
+                (spec, o) -> {
+                    assertEquals(expectedMemo, object2ContractInfo(o).getMemo(), "Bad memo!");
+                });
+        return this;
+    }
 
-	public ContractInfoAsserts balance(long balance) {
-		registerProvider((spec, o) -> {
-			assertEquals(balance, object2ContractInfo(o).getBalance(), "Bad balance!");
-		});
-		return this;
-	}
+    public ContractInfoAsserts balance(long balance) {
+        registerProvider(
+                (spec, o) -> {
+                    assertEquals(balance, object2ContractInfo(o).getBalance(), "Bad balance!");
+                });
+        return this;
+    }
 
-	public ContractInfoAsserts balanceLessThan(long amount) {
-		registerProvider((spec, o) -> {
-			long actual = object2ContractInfo(o).getBalance();
-			String errorMessage = String.format("Bad balance! %s is not less than %s", actual, amount);
-			assertTrue(actual < amount, errorMessage);
-		});
-		return this;
-	}
+    public ContractInfoAsserts balanceLessThan(long amount) {
+        registerProvider(
+                (spec, o) -> {
+                    long actual = object2ContractInfo(o).getBalance();
+                    String errorMessage =
+                            String.format("Bad balance! %s is not less than %s", actual, amount);
+                    assertTrue(actual < amount, errorMessage);
+                });
+        return this;
+    }
 
-	public ContractInfoAsserts balanceGreaterThan(long amount) {
-		registerProvider((spec, o) -> {
-			long actual = object2ContractInfo(o).getBalance();
-			String errorMessage = String.format("Bad balance! %s is not greater than %s", actual, amount);
-			assertTrue(actual > amount, errorMessage);
-		});
-		return this;
-	}
+    public ContractInfoAsserts balanceGreaterThan(long amount) {
+        registerProvider(
+                (spec, o) -> {
+                    long actual = object2ContractInfo(o).getBalance();
+                    String errorMessage =
+                            String.format("Bad balance! %s is not greater than %s", actual, amount);
+                    assertTrue(actual > amount, errorMessage);
+                });
+        return this;
+    }
 
-	public ContractInfoAsserts expiry(long expectedExpiry) {
-		registerProvider((spec, o) -> {
-			assertEquals(expectedExpiry, object2ContractInfo(o).getExpirationTime().getSeconds(),
-					"Bad expiry time!");
-		});
-		return this;
-	}
+    public ContractInfoAsserts expiry(long expectedExpiry) {
+        registerProvider(
+                (spec, o) -> {
+                    assertEquals(
+                            expectedExpiry,
+                            object2ContractInfo(o).getExpirationTime().getSeconds(),
+                            "Bad expiry time!");
+                });
+        return this;
+    }
 
-	public ContractInfoAsserts propertiesInheritedFrom(String contract) {
-		registerProvider((spec, o) -> {
-			ContractInfo expected = spec.registry().getContractInfo(contract);
-			ContractInfo actual = object2ContractInfo(o);
-			assertEquals(expected.getAutoRenewPeriod(), actual.getAutoRenewPeriod(), "Bad auto renew period!");
-			assertEquals(expected.getAdminKey(), actual.getAdminKey(), "Bad admin key!");
-			assertEquals(expected.getMemo(), actual.getMemo(), "Bad memo!");
-		});
-		return this;
-	}
+    public ContractInfoAsserts propertiesInheritedFrom(String contract) {
+        registerProvider(
+                (spec, o) -> {
+                    ContractInfo expected = spec.registry().getContractInfo(contract);
+                    ContractInfo actual = object2ContractInfo(o);
+                    assertEquals(
+                            expected.getAutoRenewPeriod(),
+                            actual.getAutoRenewPeriod(),
+                            "Bad auto renew period!");
+                    assertEquals(expected.getAdminKey(), actual.getAdminKey(), "Bad admin key!");
+                    assertEquals(expected.getMemo(), actual.getMemo(), "Bad memo!");
+                });
+        return this;
+    }
 
-	public ContractInfoAsserts adminKey(String expectedKeyName) {
-		registerProvider((spec, o) -> {
-			Key expectedKey = spec.registry().getKey(expectedKeyName);
-			assertEquals(expectedKey, object2ContractInfo(o).getAdminKey(), "Bad admin key!");
-		});
-		return this;
-	}
+    public ContractInfoAsserts adminKey(String expectedKeyName) {
+        registerProvider(
+                (spec, o) -> {
+                    Key expectedKey = spec.registry().getKey(expectedKeyName);
+                    assertEquals(
+                            expectedKey, object2ContractInfo(o).getAdminKey(), "Bad admin key!");
+                });
+        return this;
+    }
 
-	public ContractInfoAsserts immutableContractKey(String name) {
-		registerProvider((spec, o) -> {
-			final var actualKey = object2ContractInfo(o).getAdminKey();
-			assertTrue(actualKey.hasContractID(),
-					"Expected a contract admin key, got " + actualKey);
-			if (TxnUtils.isIdLiteral(name)) {
-				assertEquals(HapiPropertySource.asContract(name), actualKey.getContractID(),
-						"Wrong immutable contract key");
-			} else {
-				assertEquals(spec.registry().getContractId(name), actualKey.getContractID(),
-						"Wrong immutable contract key");
-			}
-		});
-		return this;
-	}
+    public ContractInfoAsserts immutableContractKey(String name) {
+        registerProvider(
+                (spec, o) -> {
+                    final var actualKey = object2ContractInfo(o).getAdminKey();
+                    assertTrue(
+                            actualKey.hasContractID(),
+                            "Expected a contract admin key, got " + actualKey);
+                    if (TxnUtils.isIdLiteral(name)) {
+                        assertEquals(
+                                HapiPropertySource.asContract(name),
+                                actualKey.getContractID(),
+                                "Wrong immutable contract key");
+                    } else {
+                        assertEquals(
+                                spec.registry().getContractId(name),
+                                actualKey.getContractID(),
+                                "Wrong immutable contract key");
+                    }
+                });
+        return this;
+    }
 
-	public ContractInfoAsserts autoRenew(long expectedAutoRenew) {
-		registerProvider((spec, o) -> {
-			assertEquals(expectedAutoRenew, object2ContractInfo(o).getAutoRenewPeriod().getSeconds(), "Bad" +
-					" autoRenew!");
-		});
-		return this;
-	}
+    public ContractInfoAsserts autoRenew(long expectedAutoRenew) {
+        registerProvider(
+                (spec, o) -> {
+                    assertEquals(
+                            expectedAutoRenew,
+                            object2ContractInfo(o).getAutoRenewPeriod().getSeconds(),
+                            "Bad" + " autoRenew!");
+                });
+        return this;
+    }
 
-	public ContractInfoAsserts numKvPairs(int expectedKvPairs) {
-		/* EVM storage maps 32-byte keys to 32-byte values */
-		final long numStorageBytes = expectedKvPairs * 64L;
-		registerProvider((spec, o) -> {
-			assertEquals(numStorageBytes, object2ContractInfo(o).getStorage(), "Bad storage size!");
-		});
-		return this;
-	}
+    public ContractInfoAsserts numKvPairs(int expectedKvPairs) {
+        /* EVM storage maps 32-byte keys to 32-byte values */
+        final long numStorageBytes = expectedKvPairs * 64L;
+        registerProvider(
+                (spec, o) -> {
+                    assertEquals(
+                            numStorageBytes,
+                            object2ContractInfo(o).getStorage(),
+                            "Bad storage size!");
+                });
+        return this;
+    }
 
+    public ContractInfoAsserts stakedAccountId(String idLiteral) {
+        registerProvider(
+                (spec, o) -> {
+                    assertEquals(
+                            TxnUtils.asId(idLiteral, spec),
+                            (object2ContractInfo(o)).getStakingInfo().getStakedAccountId(),
+                            "Bad stakedAccountId id!");
+                });
+        return this;
+    }
 
-	public ContractInfoAsserts stakedAccountId(String idLiteral) {
-		registerProvider((spec, o) -> {
-			assertEquals(TxnUtils.asId(idLiteral, spec),
-					(object2ContractInfo(o)).getStakingInfo().getStakedAccountId(),
-					"Bad stakedAccountId id!");
-		});
-		return this;
-	}
+    public ContractInfoAsserts stakedNodeId(long idLiteral) {
+        registerProvider(
+                (spec, o) -> {
+                    assertEquals(
+                            idLiteral,
+                            (object2ContractInfo(o)).getStakingInfo().getStakedNodeId(),
+                            "Bad stakedNodeId id!");
+                });
+        return this;
+    }
 
-	public ContractInfoAsserts stakedNodeId(long idLiteral) {
-		registerProvider((spec, o) -> {
-			assertEquals(idLiteral,
-					(object2ContractInfo(o)).getStakingInfo().getStakedNodeId(),
-					"Bad stakedNodeId id!");
-		});
-		return this;
-	}
+    public ContractInfoAsserts isDeclinedReward(boolean isDeclined) {
+        registerProvider(
+                (spec, o) -> {
+                    assertEquals(
+                            isDeclined,
+                            (object2ContractInfo(o)).getStakingInfo().getDeclineReward(),
+                            "Bad isDeclinedReward!");
+                });
+        return this;
+    }
 
-	public ContractInfoAsserts isDeclinedReward(boolean isDeclined) {
-		registerProvider((spec, o) -> {
-			assertEquals(isDeclined,
-					(object2ContractInfo(o)).getStakingInfo().getDeclineReward(),
-					"Bad isDeclinedReward!");
-		});
-		return this;
-	}
+    public ContractInfoAsserts noStakedAccountId() {
+        registerProvider(
+                (spec, o) -> {
+                    assertEquals(
+                            AccountID.getDefaultInstance(),
+                            (object2ContractInfo(o)).getStakingInfo().getStakedAccountId(),
+                            "Bad stakedAccountId id!");
+                });
+        return this;
+    }
 
-	public ContractInfoAsserts noStakedAccountId() {
-		registerProvider((spec, o) -> {
-			assertEquals(AccountID.getDefaultInstance(),
-					(object2ContractInfo(o)).getStakingInfo().getStakedAccountId(),
-					"Bad stakedAccountId id!");
-		});
-		return this;
-	}
+    public ContractInfoAsserts noStakingNodeId() {
+        registerProvider(
+                (spec, o) -> {
+                    assertEquals(
+                            0,
+                            (object2ContractInfo(o)).getStakingInfo().getStakedNodeId(),
+                            "Bad stakedNodeId id!");
+                });
+        return this;
+    }
 
-	public ContractInfoAsserts noStakingNodeId() {
-		registerProvider((spec, o) -> {
-			assertEquals(0, (object2ContractInfo(o)).getStakingInfo().getStakedNodeId(),
-					"Bad stakedNodeId id!");
-		});
-		return this;
-	}
+    public ContractInfoAsserts autoRenewAccountId(String id) {
+        registerProvider(
+                (spec, o) -> {
+                    assertEquals(
+                            spec.registry().getAccountID(id),
+                            object2ContractInfo(o).getAutoRenewAccountId(),
+                            "Bad autoRenewAccountId !");
+                });
+        return this;
+    }
 
+    public ContractInfoAsserts pendingRewards(long reward) {
+        registerProvider(
+                (spec, o) -> {
+                    assertEquals(
+                            reward,
+                            (object2ContractInfo(o)).getStakingInfo().getPendingReward(),
+                            "Bad pending rewards!");
+                });
+        return this;
+    }
 
-	public ContractInfoAsserts autoRenewAccountId(String id) {
-		registerProvider((spec, o) -> {
-			assertEquals(spec.registry().getAccountID(id)
-					, object2ContractInfo(o).getAutoRenewAccountId(), "Bad autoRenewAccountId !");
-		});
-		return this;
-	}
-
-	public ContractInfoAsserts pendingRewards(long reward) {
-		registerProvider((spec, o) -> {
-			assertEquals(reward, (object2ContractInfo(o)).getStakingInfo().getPendingReward(),
-					"Bad pending rewards!");
-		});
-		return this;
-	}
-
-	private ContractInfo object2ContractInfo(Object o) {
-		return (ContractInfo) o;
-	}
+    private ContractInfo object2ContractInfo(Object o) {
+        return (ContractInfo) o;
+    }
 }

--- a/test-clients/src/main/java/com/hedera/services/bdd/spec/assertions/ContractInfoAsserts.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/spec/assertions/ContractInfoAsserts.java
@@ -32,6 +32,7 @@ import java.util.List;
 import static com.hederahashgraph.api.proto.java.ContractGetInfoResponse.ContractInfo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ContractInfoAsserts extends BaseErroringAssertsProvider<ContractInfo> {
@@ -70,6 +71,24 @@ public class ContractInfoAsserts extends BaseErroringAssertsProvider<ContractInf
 	public ContractInfoAsserts nonNullContractId() {
 		registerProvider((spec, o) -> {
 			assertTrue(object2ContractInfo(o).hasContractID(), "Null contractId!");
+		});
+		return this;
+	}
+
+	public ContractInfoAsserts noStakePeriodStart() {
+		registerProvider((spec, o) -> {
+			assertEquals(0,
+					object2ContractInfo(o).getStakingInfo().getStakePeriodStart().getSeconds(),
+					"Wrong stakePeriodStart");
+		});
+		return this;
+	}
+
+	public ContractInfoAsserts someStakePeriodStart() {
+		registerProvider((spec, o) -> {
+			assertNotEquals(0,
+					object2ContractInfo(o).getStakingInfo().getStakePeriodStart().getSeconds(),
+					"Wrong stakePeriodStart");
 		});
 		return this;
 	}
@@ -269,7 +288,7 @@ public class ContractInfoAsserts extends BaseErroringAssertsProvider<ContractInf
 		return this;
 	}
 
-	public ContractInfoAsserts noStakedAccountId(){
+	public ContractInfoAsserts noStakedAccountId() {
 		registerProvider((spec, o) -> {
 			assertEquals(AccountID.getDefaultInstance(),
 					(object2ContractInfo(o)).getStakingInfo().getStakedAccountId(),
@@ -278,7 +297,7 @@ public class ContractInfoAsserts extends BaseErroringAssertsProvider<ContractInf
 		return this;
 	}
 
-	public ContractInfoAsserts noStakingNodeId(){
+	public ContractInfoAsserts noStakingNodeId() {
 		registerProvider((spec, o) -> {
 			assertEquals(0, (object2ContractInfo(o)).getStakingInfo().getStakedNodeId(),
 					"Bad stakedNodeId id!");

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/AutoAccountCreationSuite.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/AutoAccountCreationSuite.java
@@ -15,23 +15,6 @@
  */
 package com.hedera.services.bdd.suites.crypto;
 
-import com.google.protobuf.ByteString;
-import com.hedera.services.bdd.spec.HapiApiSpec;
-import com.hedera.services.bdd.spec.keys.KeyShape;
-import com.hedera.services.bdd.suites.HapiApiSuite;
-import com.hederahashgraph.api.proto.java.AccountID;
-import com.hederahashgraph.api.proto.java.ContractID;
-import com.hederahashgraph.api.proto.java.Key;
-import com.hederahashgraph.api.proto.java.KeyList;
-import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
-import com.hederahashgraph.api.proto.java.ThresholdKey;
-import com.hederahashgraph.api.proto.java.TransactionRecord;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-
-import java.util.List;
-import java.util.concurrent.atomic.AtomicLong;
-
 import static com.hedera.services.bdd.spec.HapiApiSpec.defaultHapiSpec;
 import static com.hedera.services.bdd.spec.PropertySource.asAccountString;
 import static com.hedera.services.bdd.spec.assertions.AccountInfoAsserts.accountWith;
@@ -63,6 +46,22 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.ACCOUNT_DELETE
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INSUFFICIENT_ACCOUNT_BALANCE;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SUCCESS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.google.protobuf.ByteString;
+import com.hedera.services.bdd.spec.HapiApiSpec;
+import com.hedera.services.bdd.spec.keys.KeyShape;
+import com.hedera.services.bdd.suites.HapiApiSuite;
+import com.hederahashgraph.api.proto.java.AccountID;
+import com.hederahashgraph.api.proto.java.ContractID;
+import com.hederahashgraph.api.proto.java.Key;
+import com.hederahashgraph.api.proto.java.KeyList;
+import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
+import com.hederahashgraph.api.proto.java.ThresholdKey;
+import com.hederahashgraph.api.proto.java.TransactionRecord;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 public class AutoAccountCreationSuite extends HapiApiSuite {
     private static final Logger LOG = LogManager.getLogger(AutoAccountCreationSuite.class);

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoTransferSuite.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoTransferSuite.java
@@ -15,6 +15,30 @@
  */
 package com.hedera.services.bdd.suites.crypto;
 
+import com.google.protobuf.ByteString;
+import com.hedera.services.bdd.spec.HapiApiSpec;
+import com.hedera.services.bdd.spec.HapiSpecOperation;
+import com.hedera.services.bdd.spec.HapiSpecSetup;
+import com.hedera.services.bdd.spec.assertions.AccountDetailsAsserts;
+import com.hedera.services.bdd.spec.keys.SigControl;
+import com.hedera.services.bdd.spec.utilops.UtilVerbs;
+import com.hedera.services.bdd.suites.HapiApiSuite;
+import com.hederahashgraph.api.proto.java.AccountID;
+import com.hederahashgraph.api.proto.java.TokenID;
+import com.hederahashgraph.api.proto.java.TokenSupplyType;
+import com.hederahashgraph.api.proto.java.TokenTransferList;
+import com.hederahashgraph.api.proto.java.TokenType;
+import com.hederahashgraph.api.proto.java.TransferList;
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.List;
+import java.util.Map;
+import java.util.OptionalLong;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.IntStream;
+
 import static com.google.protobuf.ByteString.copyFromUtf8;
 import static com.hedera.services.bdd.spec.HapiApiSpec.defaultHapiSpec;
 import static com.hedera.services.bdd.spec.HapiPropertySource.accountIdFromHexedMirrorAddress;
@@ -23,6 +47,7 @@ import static com.hedera.services.bdd.spec.HapiPropertySource.asSolidityAddress;
 import static com.hedera.services.bdd.spec.HapiPropertySource.asTopicString;
 import static com.hedera.services.bdd.spec.assertions.AccountInfoAsserts.accountWith;
 import static com.hedera.services.bdd.spec.assertions.AutoAssocAsserts.accountTokenPairsInAnyOrder;
+import static com.hedera.services.bdd.spec.assertions.ContractInfoAsserts.contractWith;
 import static com.hedera.services.bdd.spec.assertions.TransactionRecordAsserts.includingFungibleMovement;
 import static com.hedera.services.bdd.spec.assertions.TransactionRecordAsserts.includingNonfungibleMovement;
 import static com.hedera.services.bdd.spec.assertions.TransactionRecordAsserts.recordWith;
@@ -40,6 +65,8 @@ import static com.hedera.services.bdd.spec.queries.QueryVerbs.getTxnRecord;
 import static com.hedera.services.bdd.spec.queries.crypto.ExpectedTokenRel.relationshipWith;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.contractCall;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.contractCreate;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.contractUpdate;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.createDefaultContract;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.createTopic;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoApproveAllowance;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoCreate;
@@ -108,2006 +135,2012 @@ import static com.hederahashgraph.api.proto.java.TokenType.NON_FUNGIBLE_UNIQUE;
 import static com.swirlds.common.utility.CommonUtils.unhex;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import com.google.protobuf.ByteString;
-import com.hedera.services.bdd.spec.HapiApiSpec;
-import com.hedera.services.bdd.spec.HapiSpecOperation;
-import com.hedera.services.bdd.spec.HapiSpecSetup;
-import com.hedera.services.bdd.spec.assertions.AccountDetailsAsserts;
-import com.hedera.services.bdd.spec.keys.SigControl;
-import com.hedera.services.bdd.spec.utilops.UtilVerbs;
-import com.hedera.services.bdd.suites.HapiApiSuite;
-import com.hederahashgraph.api.proto.java.AccountID;
-import com.hederahashgraph.api.proto.java.TokenID;
-import com.hederahashgraph.api.proto.java.TokenSupplyType;
-import com.hederahashgraph.api.proto.java.TokenTransferList;
-import com.hederahashgraph.api.proto.java.TokenType;
-import com.hederahashgraph.api.proto.java.TransferList;
-import java.util.List;
-import java.util.Map;
-import java.util.OptionalLong;
-import java.util.concurrent.atomic.AtomicReference;
-import java.util.stream.IntStream;
-import org.apache.commons.lang3.tuple.Pair;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-
 public class CryptoTransferSuite extends HapiApiSuite {
 
-    private static final Logger LOG = LogManager.getLogger(CryptoTransferSuite.class);
-    private static final String OWNER = "owner";
-    private static final String OTHER_OWNER = "otherOwner";
-    private static final String SPENDER = "spender";
-    private static final String PAYER = "payer";
-    private static final String SENDER = "sender";
-    private static final String RECEIVER = "receiver";
-    private static final String OTHER_RECEIVER = "otherReceiver";
-    private static final String ANOTHER_RECEIVER = "anotherReceiver";
-    private static final String FUNGIBLE_TOKEN = "fungible";
-    private static final String NON_FUNGIBLE_TOKEN = "nonFungible";
-    private static final String TOKEN_WITH_CUSTOM_FEE = "tokenWithCustomFee";
-    private static final String ADMIN_KEY = "adminKey";
-    private static final String KYC_KEY = "kycKey";
-    private static final String FREEZE_KEY = "freezeKey";
-    private static final String SUPPLY_KEY = "supplyKey";
-    private static final String WIPE_KEY = "wipeKey";
-    private static final String PAUSE_KEY = "pauseKey";
-    private static final String PARTY = "party";
-    private static final String COUNTERPARTY = "counterparty";
-    private static final String MULTI_KEY = "multi";
-    private static final String NOT_TO_BE = "notToBe";
-    private static final String TOKEN = "token";
-    private static final String OWNING_PARTY = "owningParty";
-    private static final String VALID_TXN = "validTxn";
-    private static final String UNCHECKED_TXN = "uncheckedTxn";
-    private static final String PAYEE_SIG_REQ = "payeeSigReq";
-    private static final String TOKENS_INVOLVED_LOG_MESSAGE =
-            """
-0 tokens involved,
-  2 account adjustments: {} tb, ${}"
-1 tokens involved,
-  2 account adjustments: {} tb, ${} (~{}x pure crypto)
-  3 account adjustments: {} tb, ${} (~{}x pure crypto)
-  4 account adjustments: {} tb, ${} (~{}x pure crypto)
-  5 account adjustments: {} tb, ${} (~{}x pure crypto)
-  6 account adjustments: {} tb, ${} (~{}x pure crypto)
-2 tokens involved,
-  4 account adjustments: {} tb, ${} (~{}x pure crypto)
-  5 account adjustments: {} tb, ${} (~{}x pure crypto)
-  6 account adjustments: {} tb, ${} (~{}x pure crypto)
-3 tokens involved,
-  6 account adjustments: {} tb, ${} (~{}x pure crypto)
-                                                          """;
-    public static final String HODL_XFER = "hodlXfer";
-    public static final String PAYEE_NO_SIG_REQ = "payeeNoSigReq";
+	private static final Logger LOG = LogManager.getLogger(CryptoTransferSuite.class);
+	private static final String OWNER = "owner";
+	private static final String OTHER_OWNER = "otherOwner";
+	private static final String SPENDER = "spender";
+	private static final String PAYER = "payer";
+	private static final String SENDER = "sender";
+	private static final String RECEIVER = "receiver";
+	private static final String OTHER_RECEIVER = "otherReceiver";
+	private static final String ANOTHER_RECEIVER = "anotherReceiver";
+	private static final String FUNGIBLE_TOKEN = "fungible";
+	private static final String NON_FUNGIBLE_TOKEN = "nonFungible";
+	private static final String TOKEN_WITH_CUSTOM_FEE = "tokenWithCustomFee";
+	private static final String ADMIN_KEY = "adminKey";
+	private static final String KYC_KEY = "kycKey";
+	private static final String FREEZE_KEY = "freezeKey";
+	private static final String SUPPLY_KEY = "supplyKey";
+	private static final String WIPE_KEY = "wipeKey";
+	private static final String PAUSE_KEY = "pauseKey";
+	private static final String PARTY = "party";
+	private static final String COUNTERPARTY = "counterparty";
+	private static final String MULTI_KEY = "multi";
+	private static final String NOT_TO_BE = "notToBe";
+	private static final String TOKEN = "token";
+	private static final String OWNING_PARTY = "owningParty";
+	private static final String VALID_TXN = "validTxn";
+	private static final String UNCHECKED_TXN = "uncheckedTxn";
+	private static final String PAYEE_SIG_REQ = "payeeSigReq";
+	private static final String TOKENS_INVOLVED_LOG_MESSAGE =
+			"""
+					0 tokens involved,
+					  2 account adjustments: {} tb, ${}"
+					1 tokens involved,
+					  2 account adjustments: {} tb, ${} (~{}x pure crypto)
+					  3 account adjustments: {} tb, ${} (~{}x pure crypto)
+					  4 account adjustments: {} tb, ${} (~{}x pure crypto)
+					  5 account adjustments: {} tb, ${} (~{}x pure crypto)
+					  6 account adjustments: {} tb, ${} (~{}x pure crypto)
+					2 tokens involved,
+					  4 account adjustments: {} tb, ${} (~{}x pure crypto)
+					  5 account adjustments: {} tb, ${} (~{}x pure crypto)
+					  6 account adjustments: {} tb, ${} (~{}x pure crypto)
+					3 tokens involved,
+					  6 account adjustments: {} tb, ${} (~{}x pure crypto)
+					                                                          """;
+	public static final String HODL_XFER = "hodlXfer";
+	public static final String PAYEE_NO_SIG_REQ = "payeeNoSigReq";
 
-    public static void main(String... args) {
-        new CryptoTransferSuite().runSuiteAsync();
-    }
+	public static void main(String... args) {
+		new CryptoTransferSuite().runSuiteAsync();
+	}
 
-    @Override
-    public List<HapiApiSpec> getSpecsInSuite() {
-        return List.of(
-                transferWithMissingAccountGetsInvalidAccountId(),
-                vanillaTransferSucceeds(),
-                complexKeyAcctPaysForOwnTransfer(),
-                twoComplexKeysRequired(),
-                specialAccountsBalanceCheck(),
-                tokenTransferFeesScaleAsExpected(),
-                okToSetInvalidPaymentHeaderForCostAnswer(),
-                baseCryptoTransferFeeChargedAsExpected(),
-                autoAssociationRequiresOpenSlots(),
-                royaltyCollectorsCanUseAutoAssociation(),
-                royaltyCollectorsCannotUseAutoAssociationWithoutOpenSlots(),
-                dissociatedRoyaltyCollectorsCanUseAutoAssociation(),
-                hbarAndFungibleSelfTransfersRejectedBothInPrecheckAndHandle(),
-                transferToNonAccountEntitiesReturnsInvalidAccountId(),
-                nftSelfTransfersRejectedBothInPrecheckAndHandle(),
-                checksExpectedDecimalsForFungibleTokenTransferList(),
-                allowanceTransfersWorkAsExpected(),
-                allowanceTransfersWithComplexTransfersWork(),
-                canUseMirrorAliasesForNonContractXfers(),
-                canUseEip1014AliasesForXfers(),
-                cannotTransferFromImmutableAccounts(),
-                nftTransfersCannotRepeatSerialNos());
-    }
+	@Override
+	public List<HapiApiSpec> getSpecsInSuite() {
+		return List.of(
+				transferWithMissingAccountGetsInvalidAccountId(),
+				vanillaTransferSucceeds(),
+				complexKeyAcctPaysForOwnTransfer(),
+				twoComplexKeysRequired(),
+				specialAccountsBalanceCheck(),
+				tokenTransferFeesScaleAsExpected(),
+				okToSetInvalidPaymentHeaderForCostAnswer(),
+				baseCryptoTransferFeeChargedAsExpected(),
+				autoAssociationRequiresOpenSlots(),
+				royaltyCollectorsCanUseAutoAssociation(),
+				royaltyCollectorsCannotUseAutoAssociationWithoutOpenSlots(),
+				dissociatedRoyaltyCollectorsCanUseAutoAssociation(),
+				hbarAndFungibleSelfTransfersRejectedBothInPrecheckAndHandle(),
+				transferToNonAccountEntitiesReturnsInvalidAccountId(),
+				nftSelfTransfersRejectedBothInPrecheckAndHandle(),
+				checksExpectedDecimalsForFungibleTokenTransferList(),
+				allowanceTransfersWorkAsExpected(),
+				allowanceTransfersWithComplexTransfersWork(),
+				canUseMirrorAliasesForNonContractXfers(),
+				canUseEip1014AliasesForXfers(),
+				cannotTransferFromImmutableAccounts(),
+				nftTransfersCannotRepeatSerialNos(),
+				noStakePeriodStartIfNotStakingToNode()
+		);
+	}
 
-    @Override
-    public boolean canRunConcurrent() {
-        return true;
-    }
+	@Override
+	public boolean canRunConcurrent() {
+		return true;
+	}
 
-    // https://github.com/hashgraph/hedera-services/issues/2875
-    private HapiApiSpec canUseMirrorAliasesForNonContractXfers() {
-        final var fungibleToken = "fungibleToken";
-        final var nonFungibleToken = "nonFungibleToken";
-        final AtomicReference<TokenID> ftId = new AtomicReference<>();
-        final AtomicReference<TokenID> nftId = new AtomicReference<>();
-        final AtomicReference<AccountID> partyId = new AtomicReference<>();
-        final AtomicReference<AccountID> counterId = new AtomicReference<>();
-        final AtomicReference<ByteString> partyAlias = new AtomicReference<>();
-        final AtomicReference<ByteString> counterAlias = new AtomicReference<>();
-        final var hbarXfer = "hbarXfer";
-        final var nftXfer = "nftXfer";
-        final var ftXfer = "ftXfer";
+	// https://github.com/hashgraph/hedera-services/issues/2875
+	private HapiApiSpec canUseMirrorAliasesForNonContractXfers() {
+		final var fungibleToken = "fungibleToken";
+		final var nonFungibleToken = "nonFungibleToken";
+		final AtomicReference<TokenID> ftId = new AtomicReference<>();
+		final AtomicReference<TokenID> nftId = new AtomicReference<>();
+		final AtomicReference<AccountID> partyId = new AtomicReference<>();
+		final AtomicReference<AccountID> counterId = new AtomicReference<>();
+		final AtomicReference<ByteString> partyAlias = new AtomicReference<>();
+		final AtomicReference<ByteString> counterAlias = new AtomicReference<>();
+		final var hbarXfer = "hbarXfer";
+		final var nftXfer = "nftXfer";
+		final var ftXfer = "ftXfer";
 
-        return defaultHapiSpec("CanUseMirrorAliasesForNonContractXfers")
-                .given(
-                        newKeyNamed(MULTI_KEY),
-                        cryptoCreate(PARTY).maxAutomaticTokenAssociations(2),
-                        cryptoCreate(COUNTERPARTY).maxAutomaticTokenAssociations(2),
-                        tokenCreate(fungibleToken).treasury(PARTY).initialSupply(1_000_000),
-                        tokenCreate(nonFungibleToken)
-                                .initialSupply(0)
-                                .treasury(PARTY)
-                                .tokenType(NON_FUNGIBLE_UNIQUE)
-                                .supplyKey(MULTI_KEY),
-                        mintToken(nonFungibleToken, List.of(copyFromUtf8("Please mind the vase."))),
-                        withOpContext(
-                                (spec, opLog) -> {
-                                    final var registry = spec.registry();
-                                    ftId.set(registry.getTokenID(fungibleToken));
-                                    nftId.set(registry.getTokenID(nonFungibleToken));
-                                    partyId.set(registry.getAccountID(PARTY));
-                                    counterId.set(registry.getAccountID(COUNTERPARTY));
-                                    partyAlias.set(
-                                            ByteString.copyFrom(asSolidityAddress(partyId.get())));
-                                    counterAlias.set(
-                                            ByteString.copyFrom(
-                                                    asSolidityAddress(counterId.get())));
-                                }))
-                .when(
-                        cryptoTransfer(
-                                        (spec, b) ->
-                                                b.setTransfers(
-                                                        TransferList.newBuilder()
-                                                                .addAccountAmounts(
-                                                                        aaWith(
-                                                                                partyAlias.get(),
-                                                                                -1))
-                                                                .addAccountAmounts(
-                                                                        aaWith(partyId.get(), -1))
-                                                                .addAccountAmounts(
-                                                                        aaWith(
-                                                                                counterId.get(),
-                                                                                +2))))
-                                .signedBy(DEFAULT_PAYER, PARTY)
-                                .hasKnownStatus(ACCOUNT_REPEATED_IN_ACCOUNT_AMOUNTS),
-                        // Check signing requirements aren't distorted by aliases
-                        cryptoTransfer(
-                                        (spec, b) ->
-                                                b.setTransfers(
-                                                        TransferList.newBuilder()
-                                                                .addAccountAmounts(
-                                                                        aaWith(
-                                                                                partyAlias.get(),
-                                                                                -2))
-                                                                .addAccountAmounts(
-                                                                        aaWith(
-                                                                                counterId.get(),
-                                                                                +2))))
-                                .signedBy(DEFAULT_PAYER)
-                                .hasKnownStatus(INVALID_SIGNATURE),
-                        cryptoTransfer(
-                                        (spec, b) ->
-                                                b.addTokenTransfers(
-                                                        TokenTransferList.newBuilder()
-                                                                .setToken(nftId.get())
-                                                                .addNftTransfers(
-                                                                        ocWith(
-                                                                                accountId(
-                                                                                        partyAlias
-                                                                                                .get()),
-                                                                                counterId.get(),
-                                                                                1L))))
-                                .signedBy(DEFAULT_PAYER)
-                                .hasKnownStatus(INVALID_SIGNATURE),
-                        cryptoTransfer(
-                                        (spec, b) ->
-                                                b.addTokenTransfers(
-                                                        TokenTransferList.newBuilder()
-                                                                .setToken(ftId.get())
-                                                                .addTransfers(
-                                                                        aaWith(
-                                                                                partyAlias.get(),
-                                                                                -500))
-                                                                .addTransfers(
-                                                                        aaWith(
-                                                                                counterAlias.get(),
-                                                                                +500))))
-                                .signedBy(DEFAULT_PAYER)
-                                .hasKnownStatus(INVALID_SIGNATURE),
-                        // Now do the actual transfers
-                        cryptoTransfer(
-                                        (spec, b) ->
-                                                b.setTransfers(
-                                                        TransferList.newBuilder()
-                                                                .addAccountAmounts(
-                                                                        aaWith(
-                                                                                partyAlias.get(),
-                                                                                -2))
-                                                                .addAccountAmounts(
-                                                                        aaWith(
-                                                                                counterAlias.get(),
-                                                                                +2))))
-                                .signedBy(DEFAULT_PAYER, PARTY)
-                                .via(hbarXfer),
-                        cryptoTransfer(
-                                        (spec, b) ->
-                                                b.addTokenTransfers(
-                                                        TokenTransferList.newBuilder()
-                                                                .setToken(nftId.get())
-                                                                .addNftTransfers(
-                                                                        ocWith(
-                                                                                accountId(
-                                                                                        partyAlias
-                                                                                                .get()),
-                                                                                accountId(
-                                                                                        counterAlias
-                                                                                                .get()),
-                                                                                1L))))
-                                .signedBy(DEFAULT_PAYER, PARTY)
-                                .via(nftXfer),
-                        cryptoTransfer(
-                                        (spec, b) ->
-                                                b.addTokenTransfers(
-                                                        TokenTransferList.newBuilder()
-                                                                .setToken(ftId.get())
-                                                                .addTransfers(
-                                                                        aaWith(
-                                                                                partyAlias.get(),
-                                                                                -500))
-                                                                .addTransfers(
-                                                                        aaWith(
-                                                                                counterAlias.get(),
-                                                                                +500))))
-                                .signedBy(DEFAULT_PAYER, PARTY)
-                                .via(ftXfer))
-                .then(
-                        getTxnRecord(hbarXfer).logged(),
-                        getTxnRecord(nftXfer).logged(),
-                        getTxnRecord(ftXfer).logged());
-    }
+		return defaultHapiSpec("CanUseMirrorAliasesForNonContractXfers")
+				.given(
+						newKeyNamed(MULTI_KEY),
+						cryptoCreate(PARTY).maxAutomaticTokenAssociations(2),
+						cryptoCreate(COUNTERPARTY).maxAutomaticTokenAssociations(2),
+						tokenCreate(fungibleToken).treasury(PARTY).initialSupply(1_000_000),
+						tokenCreate(nonFungibleToken)
+								.initialSupply(0)
+								.treasury(PARTY)
+								.tokenType(NON_FUNGIBLE_UNIQUE)
+								.supplyKey(MULTI_KEY),
+						mintToken(nonFungibleToken, List.of(copyFromUtf8("Please mind the vase."))),
+						withOpContext(
+								(spec, opLog) -> {
+									final var registry = spec.registry();
+									ftId.set(registry.getTokenID(fungibleToken));
+									nftId.set(registry.getTokenID(nonFungibleToken));
+									partyId.set(registry.getAccountID(PARTY));
+									counterId.set(registry.getAccountID(COUNTERPARTY));
+									partyAlias.set(
+											ByteString.copyFrom(asSolidityAddress(partyId.get())));
+									counterAlias.set(
+											ByteString.copyFrom(
+													asSolidityAddress(counterId.get())));
+								}))
+				.when(
+						cryptoTransfer(
+								(spec, b) ->
+										b.setTransfers(
+												TransferList.newBuilder()
+														.addAccountAmounts(
+																aaWith(
+																		partyAlias.get(),
+																		-1))
+														.addAccountAmounts(
+																aaWith(partyId.get(), -1))
+														.addAccountAmounts(
+																aaWith(
+																		counterId.get(),
+																		+2))))
+								.signedBy(DEFAULT_PAYER, PARTY)
+								.hasKnownStatus(ACCOUNT_REPEATED_IN_ACCOUNT_AMOUNTS),
+						// Check signing requirements aren't distorted by aliases
+						cryptoTransfer(
+								(spec, b) ->
+										b.setTransfers(
+												TransferList.newBuilder()
+														.addAccountAmounts(
+																aaWith(
+																		partyAlias.get(),
+																		-2))
+														.addAccountAmounts(
+																aaWith(
+																		counterId.get(),
+																		+2))))
+								.signedBy(DEFAULT_PAYER)
+								.hasKnownStatus(INVALID_SIGNATURE),
+						cryptoTransfer(
+								(spec, b) ->
+										b.addTokenTransfers(
+												TokenTransferList.newBuilder()
+														.setToken(nftId.get())
+														.addNftTransfers(
+																ocWith(
+																		accountId(
+																				partyAlias
+																						.get()),
+																		counterId.get(),
+																		1L))))
+								.signedBy(DEFAULT_PAYER)
+								.hasKnownStatus(INVALID_SIGNATURE),
+						cryptoTransfer(
+								(spec, b) ->
+										b.addTokenTransfers(
+												TokenTransferList.newBuilder()
+														.setToken(ftId.get())
+														.addTransfers(
+																aaWith(
+																		partyAlias.get(),
+																		-500))
+														.addTransfers(
+																aaWith(
+																		counterAlias.get(),
+																		+500))))
+								.signedBy(DEFAULT_PAYER)
+								.hasKnownStatus(INVALID_SIGNATURE),
+						// Now do the actual transfers
+						cryptoTransfer(
+								(spec, b) ->
+										b.setTransfers(
+												TransferList.newBuilder()
+														.addAccountAmounts(
+																aaWith(
+																		partyAlias.get(),
+																		-2))
+														.addAccountAmounts(
+																aaWith(
+																		counterAlias.get(),
+																		+2))))
+								.signedBy(DEFAULT_PAYER, PARTY)
+								.via(hbarXfer),
+						cryptoTransfer(
+								(spec, b) ->
+										b.addTokenTransfers(
+												TokenTransferList.newBuilder()
+														.setToken(nftId.get())
+														.addNftTransfers(
+																ocWith(
+																		accountId(
+																				partyAlias
+																						.get()),
+																		accountId(
+																				counterAlias
+																						.get()),
+																		1L))))
+								.signedBy(DEFAULT_PAYER, PARTY)
+								.via(nftXfer),
+						cryptoTransfer(
+								(spec, b) ->
+										b.addTokenTransfers(
+												TokenTransferList.newBuilder()
+														.setToken(ftId.get())
+														.addTransfers(
+																aaWith(
+																		partyAlias.get(),
+																		-500))
+														.addTransfers(
+																aaWith(
+																		counterAlias.get(),
+																		+500))))
+								.signedBy(DEFAULT_PAYER, PARTY)
+								.via(ftXfer))
+				.then(
+						getTxnRecord(hbarXfer).logged(),
+						getTxnRecord(nftXfer).logged(),
+						getTxnRecord(ftXfer).logged());
+	}
 
-    @SuppressWarnings("java:S5669")
-    private HapiApiSpec canUseEip1014AliasesForXfers() {
-        final var partyCreation2 = "partyCreation2";
-        final var counterCreation2 = "counterCreation2";
-        final var contract = "CreateDonor";
+	@SuppressWarnings("java:S5669")
+	private HapiApiSpec canUseEip1014AliasesForXfers() {
+		final var partyCreation2 = "partyCreation2";
+		final var counterCreation2 = "counterCreation2";
+		final var contract = "CreateDonor";
 
-        final AtomicReference<String> partyAliasAddr = new AtomicReference<>();
-        final AtomicReference<String> partyMirrorAddr = new AtomicReference<>();
-        final AtomicReference<String> counterAliasAddr = new AtomicReference<>();
-        final AtomicReference<String> counterMirrorAddr = new AtomicReference<>();
-        final AtomicReference<TokenID> ftId = new AtomicReference<>();
-        final AtomicReference<TokenID> nftId = new AtomicReference<>();
-        final AtomicReference<String> partyLiteral = new AtomicReference<>();
-        final AtomicReference<AccountID> partyId = new AtomicReference<>();
-        final AtomicReference<String> counterLiteral = new AtomicReference<>();
-        final AtomicReference<AccountID> counterId = new AtomicReference<>();
-        final var hbarXfer = "hbarXfer";
-        final var nftXfer = "nftXfer";
-        final var ftXfer = "ftXfer";
+		final AtomicReference<String> partyAliasAddr = new AtomicReference<>();
+		final AtomicReference<String> partyMirrorAddr = new AtomicReference<>();
+		final AtomicReference<String> counterAliasAddr = new AtomicReference<>();
+		final AtomicReference<String> counterMirrorAddr = new AtomicReference<>();
+		final AtomicReference<TokenID> ftId = new AtomicReference<>();
+		final AtomicReference<TokenID> nftId = new AtomicReference<>();
+		final AtomicReference<String> partyLiteral = new AtomicReference<>();
+		final AtomicReference<AccountID> partyId = new AtomicReference<>();
+		final AtomicReference<String> counterLiteral = new AtomicReference<>();
+		final AtomicReference<AccountID> counterId = new AtomicReference<>();
+		final var hbarXfer = "hbarXfer";
+		final var nftXfer = "nftXfer";
+		final var ftXfer = "ftXfer";
 
-        final byte[] salt =
-                unhex("aabbccddeeff0011aabbccddeeff0011aabbccddeeff0011aabbccddeeff0011");
-        final byte[] otherSalt =
-                unhex("aabbccddee880011aabbccddee880011aabbccddee880011aabbccddee880011");
+		final byte[] salt =
+				unhex("aabbccddeeff0011aabbccddeeff0011aabbccddeeff0011aabbccddeeff0011");
+		final byte[] otherSalt =
+				unhex("aabbccddee880011aabbccddee880011aabbccddee880011aabbccddee880011");
 
-        return defaultHapiSpec("CanUseEip1014AliasesForXfers")
-                .given(
-                        newKeyNamed(MULTI_KEY),
-                        cryptoCreate(TOKEN_TREASURY),
-                        uploadInitCode(contract),
-                        contractCreate(contract).adminKey(MULTI_KEY).payingWith(GENESIS),
-                        contractCall(contract, "buildDonor", salt)
-                                .sending(1000)
-                                .payingWith(GENESIS)
-                                .gas(2_000_000L)
-                                .via(partyCreation2),
-                        captureOneChildCreate2MetaFor(
-                                PARTY, partyCreation2, partyMirrorAddr, partyAliasAddr),
-                        contractCall(contract, "buildDonor", otherSalt)
-                                .sending(1000)
-                                .payingWith(GENESIS)
-                                .gas(2_000_000L)
-                                .via(counterCreation2),
-                        captureOneChildCreate2MetaFor(
-                                COUNTERPARTY,
-                                counterCreation2,
-                                counterMirrorAddr,
-                                counterAliasAddr),
-                        tokenCreate(FUNGIBLE_TOKEN)
-                                .treasury(TOKEN_TREASURY)
-                                .initialSupply(1_000_000),
-                        tokenCreate(NON_FUNGIBLE_TOKEN)
-                                .treasury(TOKEN_TREASURY)
-                                .initialSupply(0)
-                                .tokenType(NON_FUNGIBLE_UNIQUE)
-                                .supplyKey(MULTI_KEY),
-                        mintToken(
-                                NON_FUNGIBLE_TOKEN, List.of(copyFromUtf8("Please mind the vase."))),
-                        withOpContext(
-                                (spec, opLog) -> {
-                                    final var registry = spec.registry();
-                                    ftId.set(registry.getTokenID(FUNGIBLE_TOKEN));
-                                    nftId.set(registry.getTokenID(NON_FUNGIBLE_TOKEN));
-                                    partyId.set(
-                                            accountIdFromHexedMirrorAddress(partyMirrorAddr.get()));
-                                    partyLiteral.set(asAccountString(partyId.get()));
-                                    counterId.set(
-                                            accountIdFromHexedMirrorAddress(
-                                                    counterMirrorAddr.get()));
-                                    counterLiteral.set(asAccountString(counterId.get()));
-                                }))
-                .when(
-                        sourcing(
-                                () ->
-                                        tokenAssociate(
-                                                        partyLiteral.get(),
-                                                        List.of(FUNGIBLE_TOKEN, NON_FUNGIBLE_TOKEN))
-                                                .signedBy(DEFAULT_PAYER, MULTI_KEY)),
-                        sourcing(
-                                () ->
-                                        tokenAssociate(
-                                                        counterLiteral.get(),
-                                                        List.of(FUNGIBLE_TOKEN, NON_FUNGIBLE_TOKEN))
-                                                .signedBy(DEFAULT_PAYER, MULTI_KEY)),
-                        sourcing(() -> getContractInfo(partyLiteral.get()).logged()),
-                        sourcing(
-                                () ->
-                                        cryptoTransfer(
-                                                        moving(500_000, FUNGIBLE_TOKEN)
-                                                                .between(
-                                                                        TOKEN_TREASURY,
-                                                                        partyLiteral.get()),
-                                                        movingUnique(NON_FUNGIBLE_TOKEN, 1L)
-                                                                .between(
-                                                                        TOKEN_TREASURY,
-                                                                        partyLiteral.get()))
-                                                .signedBy(DEFAULT_PAYER, TOKEN_TREASURY)),
-                        cryptoTransfer(
-                                        (spec, b) ->
-                                                b.setTransfers(
-                                                        TransferList.newBuilder()
-                                                                .addAccountAmounts(
-                                                                        aaWith(
-                                                                                partyAliasAddr
-                                                                                        .get(),
-                                                                                -1))
-                                                                .addAccountAmounts(
-                                                                        aaWith(partyId.get(), -1))
-                                                                .addAccountAmounts(
-                                                                        aaWith(
-                                                                                counterId.get(),
-                                                                                +2))))
-                                .signedBy(DEFAULT_PAYER, MULTI_KEY)
-                                .hasKnownStatus(ACCOUNT_REPEATED_IN_ACCOUNT_AMOUNTS),
-                        // Check signing requirements aren't distorted by aliases
-                        cryptoTransfer(
-                                        (spec, b) ->
-                                                b.setTransfers(
-                                                        TransferList.newBuilder()
-                                                                .addAccountAmounts(
-                                                                        aaWith(
-                                                                                partyAliasAddr
-                                                                                        .get(),
-                                                                                -2))
-                                                                .addAccountAmounts(
-                                                                        aaWith(
-                                                                                counterAliasAddr
-                                                                                        .get(),
-                                                                                +2))))
-                                .signedBy(DEFAULT_PAYER)
-                                .hasKnownStatus(INVALID_SIGNATURE),
-                        cryptoTransfer(
-                                        (spec, b) ->
-                                                b.addTokenTransfers(
-                                                        TokenTransferList.newBuilder()
-                                                                .setToken(nftId.get())
-                                                                .addNftTransfers(
-                                                                        ocWith(
-                                                                                accountId(
-                                                                                        partyAliasAddr
-                                                                                                .get()),
-                                                                                counterId.get(),
-                                                                                1L))))
-                                .signedBy(DEFAULT_PAYER)
-                                .hasKnownStatus(INVALID_SIGNATURE),
-                        cryptoTransfer(
-                                        (spec, b) ->
-                                                b.addTokenTransfers(
-                                                        TokenTransferList.newBuilder()
-                                                                .setToken(ftId.get())
-                                                                .addTransfers(
-                                                                        aaWith(
-                                                                                partyAliasAddr
-                                                                                        .get(),
-                                                                                -500))
-                                                                .addTransfers(
-                                                                        aaWith(
-                                                                                counterAliasAddr
-                                                                                        .get(),
-                                                                                +500))))
-                                .signedBy(DEFAULT_PAYER)
-                                .hasKnownStatus(INVALID_SIGNATURE),
-                        // Now do the actual transfers
-                        cryptoTransfer(
-                                        (spec, b) ->
-                                                b.setTransfers(
-                                                        TransferList.newBuilder()
-                                                                .addAccountAmounts(
-                                                                        aaWith(
-                                                                                partyAliasAddr
-                                                                                        .get(),
-                                                                                -2))
-                                                                .addAccountAmounts(
-                                                                        aaWith(
-                                                                                counterAliasAddr
-                                                                                        .get(),
-                                                                                +2))))
-                                .signedBy(DEFAULT_PAYER, MULTI_KEY)
-                                .via(hbarXfer),
-                        cryptoTransfer(
-                                        (spec, b) ->
-                                                b.addTokenTransfers(
-                                                        TokenTransferList.newBuilder()
-                                                                .setToken(nftId.get())
-                                                                .addNftTransfers(
-                                                                        ocWith(
-                                                                                accountId(
-                                                                                        partyAliasAddr
-                                                                                                .get()),
-                                                                                accountId(
-                                                                                        counterAliasAddr
-                                                                                                .get()),
-                                                                                1L))))
-                                .signedBy(DEFAULT_PAYER, MULTI_KEY)
-                                .via(nftXfer),
-                        cryptoTransfer(
-                                        (spec, b) ->
-                                                b.addTokenTransfers(
-                                                        TokenTransferList.newBuilder()
-                                                                .setToken(ftId.get())
-                                                                .addTransfers(
-                                                                        aaWith(
-                                                                                partyAliasAddr
-                                                                                        .get(),
-                                                                                -500))
-                                                                .addTransfers(
-                                                                        aaWith(
-                                                                                counterAliasAddr
-                                                                                        .get(),
-                                                                                +500))))
-                                .signedBy(DEFAULT_PAYER, MULTI_KEY)
-                                .via(ftXfer))
-                .then(
-                        sourcing(
-                                () ->
-                                        getTxnRecord(hbarXfer)
-                                                .hasPriority(
-                                                        recordWith()
-                                                                .transfers(
-                                                                        including(
-                                                                                tinyBarsFromTo(
-                                                                                        partyLiteral
-                                                                                                .get(),
-                                                                                        counterLiteral
-                                                                                                .get(),
-                                                                                        2))))),
-                        sourcing(
-                                () ->
-                                        getTxnRecord(nftXfer)
-                                                .hasPriority(
-                                                        recordWith()
-                                                                .tokenTransfers(
-                                                                        includingNonfungibleMovement(
-                                                                                movingUnique(
-                                                                                                NON_FUNGIBLE_TOKEN,
-                                                                                                1L)
-                                                                                        .between(
-                                                                                                partyLiteral
-                                                                                                        .get(),
-                                                                                                counterLiteral
-                                                                                                        .get()))))),
-                        sourcing(
-                                () ->
-                                        getTxnRecord(ftXfer)
-                                                .hasPriority(
-                                                        recordWith()
-                                                                .tokenTransfers(
-                                                                        includingFungibleMovement(
-                                                                                moving(
-                                                                                                500,
-                                                                                                FUNGIBLE_TOKEN)
-                                                                                        .between(
-                                                                                                partyLiteral
-                                                                                                        .get(),
-                                                                                                counterLiteral
-                                                                                                        .get()))))));
-    }
+		return defaultHapiSpec("CanUseEip1014AliasesForXfers")
+				.given(
+						newKeyNamed(MULTI_KEY),
+						cryptoCreate(TOKEN_TREASURY),
+						uploadInitCode(contract),
+						contractCreate(contract).adminKey(MULTI_KEY).payingWith(GENESIS),
+						contractCall(contract, "buildDonor", salt)
+								.sending(1000)
+								.payingWith(GENESIS)
+								.gas(2_000_000L)
+								.via(partyCreation2),
+						captureOneChildCreate2MetaFor(
+								PARTY, partyCreation2, partyMirrorAddr, partyAliasAddr),
+						contractCall(contract, "buildDonor", otherSalt)
+								.sending(1000)
+								.payingWith(GENESIS)
+								.gas(2_000_000L)
+								.via(counterCreation2),
+						captureOneChildCreate2MetaFor(
+								COUNTERPARTY,
+								counterCreation2,
+								counterMirrorAddr,
+								counterAliasAddr),
+						tokenCreate(FUNGIBLE_TOKEN)
+								.treasury(TOKEN_TREASURY)
+								.initialSupply(1_000_000),
+						tokenCreate(NON_FUNGIBLE_TOKEN)
+								.treasury(TOKEN_TREASURY)
+								.initialSupply(0)
+								.tokenType(NON_FUNGIBLE_UNIQUE)
+								.supplyKey(MULTI_KEY),
+						mintToken(
+								NON_FUNGIBLE_TOKEN, List.of(copyFromUtf8("Please mind the vase."))),
+						withOpContext(
+								(spec, opLog) -> {
+									final var registry = spec.registry();
+									ftId.set(registry.getTokenID(FUNGIBLE_TOKEN));
+									nftId.set(registry.getTokenID(NON_FUNGIBLE_TOKEN));
+									partyId.set(
+											accountIdFromHexedMirrorAddress(partyMirrorAddr.get()));
+									partyLiteral.set(asAccountString(partyId.get()));
+									counterId.set(
+											accountIdFromHexedMirrorAddress(
+													counterMirrorAddr.get()));
+									counterLiteral.set(asAccountString(counterId.get()));
+								}))
+				.when(
+						sourcing(
+								() ->
+										tokenAssociate(
+												partyLiteral.get(),
+												List.of(FUNGIBLE_TOKEN, NON_FUNGIBLE_TOKEN))
+												.signedBy(DEFAULT_PAYER, MULTI_KEY)),
+						sourcing(
+								() ->
+										tokenAssociate(
+												counterLiteral.get(),
+												List.of(FUNGIBLE_TOKEN, NON_FUNGIBLE_TOKEN))
+												.signedBy(DEFAULT_PAYER, MULTI_KEY)),
+						sourcing(() -> getContractInfo(partyLiteral.get()).logged()),
+						sourcing(
+								() ->
+										cryptoTransfer(
+												moving(500_000, FUNGIBLE_TOKEN)
+														.between(
+																TOKEN_TREASURY,
+																partyLiteral.get()),
+												movingUnique(NON_FUNGIBLE_TOKEN, 1L)
+														.between(
+																TOKEN_TREASURY,
+																partyLiteral.get()))
+												.signedBy(DEFAULT_PAYER, TOKEN_TREASURY)),
+						cryptoTransfer(
+								(spec, b) ->
+										b.setTransfers(
+												TransferList.newBuilder()
+														.addAccountAmounts(
+																aaWith(
+																		partyAliasAddr
+																				.get(),
+																		-1))
+														.addAccountAmounts(
+																aaWith(partyId.get(), -1))
+														.addAccountAmounts(
+																aaWith(
+																		counterId.get(),
+																		+2))))
+								.signedBy(DEFAULT_PAYER, MULTI_KEY)
+								.hasKnownStatus(ACCOUNT_REPEATED_IN_ACCOUNT_AMOUNTS),
+						// Check signing requirements aren't distorted by aliases
+						cryptoTransfer(
+								(spec, b) ->
+										b.setTransfers(
+												TransferList.newBuilder()
+														.addAccountAmounts(
+																aaWith(
+																		partyAliasAddr
+																				.get(),
+																		-2))
+														.addAccountAmounts(
+																aaWith(
+																		counterAliasAddr
+																				.get(),
+																		+2))))
+								.signedBy(DEFAULT_PAYER)
+								.hasKnownStatus(INVALID_SIGNATURE),
+						cryptoTransfer(
+								(spec, b) ->
+										b.addTokenTransfers(
+												TokenTransferList.newBuilder()
+														.setToken(nftId.get())
+														.addNftTransfers(
+																ocWith(
+																		accountId(
+																				partyAliasAddr
+																						.get()),
+																		counterId.get(),
+																		1L))))
+								.signedBy(DEFAULT_PAYER)
+								.hasKnownStatus(INVALID_SIGNATURE),
+						cryptoTransfer(
+								(spec, b) ->
+										b.addTokenTransfers(
+												TokenTransferList.newBuilder()
+														.setToken(ftId.get())
+														.addTransfers(
+																aaWith(
+																		partyAliasAddr
+																				.get(),
+																		-500))
+														.addTransfers(
+																aaWith(
+																		counterAliasAddr
+																				.get(),
+																		+500))))
+								.signedBy(DEFAULT_PAYER)
+								.hasKnownStatus(INVALID_SIGNATURE),
+						// Now do the actual transfers
+						cryptoTransfer(
+								(spec, b) ->
+										b.setTransfers(
+												TransferList.newBuilder()
+														.addAccountAmounts(
+																aaWith(
+																		partyAliasAddr
+																				.get(),
+																		-2))
+														.addAccountAmounts(
+																aaWith(
+																		counterAliasAddr
+																				.get(),
+																		+2))))
+								.signedBy(DEFAULT_PAYER, MULTI_KEY)
+								.via(hbarXfer),
+						cryptoTransfer(
+								(spec, b) ->
+										b.addTokenTransfers(
+												TokenTransferList.newBuilder()
+														.setToken(nftId.get())
+														.addNftTransfers(
+																ocWith(
+																		accountId(
+																				partyAliasAddr
+																						.get()),
+																		accountId(
+																				counterAliasAddr
+																						.get()),
+																		1L))))
+								.signedBy(DEFAULT_PAYER, MULTI_KEY)
+								.via(nftXfer),
+						cryptoTransfer(
+								(spec, b) ->
+										b.addTokenTransfers(
+												TokenTransferList.newBuilder()
+														.setToken(ftId.get())
+														.addTransfers(
+																aaWith(
+																		partyAliasAddr
+																				.get(),
+																		-500))
+														.addTransfers(
+																aaWith(
+																		counterAliasAddr
+																				.get(),
+																		+500))))
+								.signedBy(DEFAULT_PAYER, MULTI_KEY)
+								.via(ftXfer))
+				.then(
+						sourcing(
+								() ->
+										getTxnRecord(hbarXfer)
+												.hasPriority(
+														recordWith()
+																.transfers(
+																		including(
+																				tinyBarsFromTo(
+																						partyLiteral
+																								.get(),
+																						counterLiteral
+																								.get(),
+																						2))))),
+						sourcing(
+								() ->
+										getTxnRecord(nftXfer)
+												.hasPriority(
+														recordWith()
+																.tokenTransfers(
+																		includingNonfungibleMovement(
+																				movingUnique(
+																						NON_FUNGIBLE_TOKEN,
+																						1L)
+																						.between(
+																								partyLiteral
+																										.get(),
+																								counterLiteral
+																										.get()))))),
+						sourcing(
+								() ->
+										getTxnRecord(ftXfer)
+												.hasPriority(
+														recordWith()
+																.tokenTransfers(
+																		includingFungibleMovement(
+																				moving(
+																						500,
+																						FUNGIBLE_TOKEN)
+																						.between(
+																								partyLiteral
+																										.get(),
+																								counterLiteral
+																										.get()))))));
+	}
 
-    private HapiApiSpec cannotTransferFromImmutableAccounts() {
-        final var contract = "PayableConstructor";
-        final var multiKey = "swiss";
+	private HapiApiSpec cannotTransferFromImmutableAccounts() {
+		final var contract = "PayableConstructor";
+		final var multiKey = "swiss";
 
-        return defaultHapiSpec("CannotTransferFromImmutableAccounts")
-                .given(
-                        newKeyNamed(multiKey),
-                        uploadInitCode(contract),
-                        contractCreate(contract).balance(ONE_HBAR).immutable().payingWith(GENESIS))
-                .when()
-                .then(
-                        // Even the treasury cannot withdraw from an immutable contract
-                        cryptoTransfer(tinyBarsFromTo(contract, FUNDING, ONE_HBAR))
-                                .payingWith(GENESIS)
-                                .signedBy(GENESIS)
-                                .fee(ONE_HBAR)
-                                .hasKnownStatus(INVALID_SIGNATURE),
-                        // Even the treasury cannot withdraw staking funds
-                        cryptoTransfer(tinyBarsFromTo(STAKING_REWARD, FUNDING, ONE_HBAR))
-                                .payingWith(GENESIS)
-                                .signedBy(GENESIS)
-                                .fee(ONE_HBAR)
-                                .hasKnownStatus(INVALID_ACCOUNT_ID),
-                        cryptoTransfer(tinyBarsFromTo(NODE_REWARD, FUNDING, ONE_HBAR))
-                                .payingWith(GENESIS)
-                                .signedBy(GENESIS)
-                                .fee(ONE_HBAR)
-                                .hasKnownStatus(INVALID_ACCOUNT_ID),
-                        // Immutable accounts cannot be updated or deleted
-                        cryptoUpdate(STAKING_REWARD)
-                                .payingWith(GENESIS)
-                                .signedBy(GENESIS)
-                                .fee(ONE_HBAR)
-                                .hasKnownStatus(INVALID_ACCOUNT_ID),
-                        cryptoDelete(STAKING_REWARD)
-                                .payingWith(GENESIS)
-                                .signedBy(GENESIS)
-                                .fee(ONE_HBAR)
-                                .hasKnownStatus(INVALID_ACCOUNT_ID),
-                        // Immutable accounts cannot serve any role for tokens
-                        tokenCreate(TOKEN).adminKey(multiKey),
-                        tokenAssociate(NODE_REWARD, TOKEN)
-                                .payingWith(GENESIS)
-                                .signedBy(GENESIS)
-                                .fee(ONE_HBAR)
-                                .hasKnownStatus(INVALID_ACCOUNT_ID),
-                        tokenUpdate(TOKEN)
-                                .payingWith(GENESIS)
-                                .signedBy(GENESIS, multiKey)
-                                .fee(ONE_HBAR)
-                                .treasury(STAKING_REWARD)
-                                .hasKnownStatus(INVALID_ACCOUNT_ID),
-                        tokenCreate(NOT_TO_BE)
-                                .treasury(STAKING_REWARD)
-                                .payingWith(GENESIS)
-                                .signedBy(GENESIS)
-                                .fee(ONE_HBAR)
-                                .hasKnownStatus(INVALID_ACCOUNT_ID),
-                        tokenCreate(NOT_TO_BE)
-                                .autoRenewAccount(NODE_REWARD)
-                                .payingWith(GENESIS)
-                                .signedBy(GENESIS)
-                                .fee(ONE_HBAR)
-                                .hasKnownStatus(INVALID_AUTORENEW_ACCOUNT),
-                        tokenCreate(NOT_TO_BE)
-                                .payingWith(GENESIS)
-                                .signedBy(GENESIS)
-                                .fee(ONE_HBAR)
-                                .withCustom(fixedHbarFee(5 * ONE_HBAR, STAKING_REWARD))
-                                .hasKnownStatus(INVALID_CUSTOM_FEE_COLLECTOR),
-                        // Immutable accounts cannot be topic auto-renew accounts
-                        createTopic(NOT_TO_BE)
-                                .autoRenewAccountId(NODE_REWARD)
-                                .payingWith(GENESIS)
-                                .signedBy(GENESIS)
-                                .fee(ONE_HBAR)
-                                .hasKnownStatus(INVALID_AUTORENEW_ACCOUNT),
-                        // Immutable accounts cannot be schedule transaction payers
-                        scheduleCreate(
-                                        NOT_TO_BE,
-                                        cryptoTransfer(tinyBarsFromTo(GENESIS, FUNDING, 1)))
-                                .payingWith(GENESIS)
-                                .signedBy(GENESIS)
-                                .fee(ONE_HBAR)
-                                .designatingPayer(STAKING_REWARD)
-                                .fee(ONE_HUNDRED_HBARS)
-                                .hasKnownStatus(INVALID_ACCOUNT_ID),
-                        // Immutable accounts cannot approve or adjust allowances
-                        cryptoApproveAllowance()
-                                .payingWith(GENESIS)
-                                .signedBy(GENESIS)
-                                .fee(ONE_HBAR)
-                                .addCryptoAllowance(NODE_REWARD, FUNDING, 100L)
-                                .hasKnownStatus(INVALID_ALLOWANCE_OWNER_ID));
-    }
+		return defaultHapiSpec("CannotTransferFromImmutableAccounts")
+				.given(
+						newKeyNamed(multiKey),
+						uploadInitCode(contract),
+						contractCreate(contract).balance(ONE_HBAR).immutable().payingWith(GENESIS))
+				.when()
+				.then(
+						// Even the treasury cannot withdraw from an immutable contract
+						cryptoTransfer(tinyBarsFromTo(contract, FUNDING, ONE_HBAR))
+								.payingWith(GENESIS)
+								.signedBy(GENESIS)
+								.fee(ONE_HBAR)
+								.hasKnownStatus(INVALID_SIGNATURE),
+						// Even the treasury cannot withdraw staking funds
+						cryptoTransfer(tinyBarsFromTo(STAKING_REWARD, FUNDING, ONE_HBAR))
+								.payingWith(GENESIS)
+								.signedBy(GENESIS)
+								.fee(ONE_HBAR)
+								.hasKnownStatus(INVALID_ACCOUNT_ID),
+						cryptoTransfer(tinyBarsFromTo(NODE_REWARD, FUNDING, ONE_HBAR))
+								.payingWith(GENESIS)
+								.signedBy(GENESIS)
+								.fee(ONE_HBAR)
+								.hasKnownStatus(INVALID_ACCOUNT_ID),
+						// Immutable accounts cannot be updated or deleted
+						cryptoUpdate(STAKING_REWARD)
+								.payingWith(GENESIS)
+								.signedBy(GENESIS)
+								.fee(ONE_HBAR)
+								.hasKnownStatus(INVALID_ACCOUNT_ID),
+						cryptoDelete(STAKING_REWARD)
+								.payingWith(GENESIS)
+								.signedBy(GENESIS)
+								.fee(ONE_HBAR)
+								.hasKnownStatus(INVALID_ACCOUNT_ID),
+						// Immutable accounts cannot serve any role for tokens
+						tokenCreate(TOKEN).adminKey(multiKey),
+						tokenAssociate(NODE_REWARD, TOKEN)
+								.payingWith(GENESIS)
+								.signedBy(GENESIS)
+								.fee(ONE_HBAR)
+								.hasKnownStatus(INVALID_ACCOUNT_ID),
+						tokenUpdate(TOKEN)
+								.payingWith(GENESIS)
+								.signedBy(GENESIS, multiKey)
+								.fee(ONE_HBAR)
+								.treasury(STAKING_REWARD)
+								.hasKnownStatus(INVALID_ACCOUNT_ID),
+						tokenCreate(NOT_TO_BE)
+								.treasury(STAKING_REWARD)
+								.payingWith(GENESIS)
+								.signedBy(GENESIS)
+								.fee(ONE_HBAR)
+								.hasKnownStatus(INVALID_ACCOUNT_ID),
+						tokenCreate(NOT_TO_BE)
+								.autoRenewAccount(NODE_REWARD)
+								.payingWith(GENESIS)
+								.signedBy(GENESIS)
+								.fee(ONE_HBAR)
+								.hasKnownStatus(INVALID_AUTORENEW_ACCOUNT),
+						tokenCreate(NOT_TO_BE)
+								.payingWith(GENESIS)
+								.signedBy(GENESIS)
+								.fee(ONE_HBAR)
+								.withCustom(fixedHbarFee(5 * ONE_HBAR, STAKING_REWARD))
+								.hasKnownStatus(INVALID_CUSTOM_FEE_COLLECTOR),
+						// Immutable accounts cannot be topic auto-renew accounts
+						createTopic(NOT_TO_BE)
+								.autoRenewAccountId(NODE_REWARD)
+								.payingWith(GENESIS)
+								.signedBy(GENESIS)
+								.fee(ONE_HBAR)
+								.hasKnownStatus(INVALID_AUTORENEW_ACCOUNT),
+						// Immutable accounts cannot be schedule transaction payers
+						scheduleCreate(
+								NOT_TO_BE,
+								cryptoTransfer(tinyBarsFromTo(GENESIS, FUNDING, 1)))
+								.payingWith(GENESIS)
+								.signedBy(GENESIS)
+								.fee(ONE_HBAR)
+								.designatingPayer(STAKING_REWARD)
+								.fee(ONE_HUNDRED_HBARS)
+								.hasKnownStatus(INVALID_ACCOUNT_ID),
+						// Immutable accounts cannot approve or adjust allowances
+						cryptoApproveAllowance()
+								.payingWith(GENESIS)
+								.signedBy(GENESIS)
+								.fee(ONE_HBAR)
+								.addCryptoAllowance(NODE_REWARD, FUNDING, 100L)
+								.hasKnownStatus(INVALID_ALLOWANCE_OWNER_ID));
+	}
 
-    private HapiApiSpec allowanceTransfersWithComplexTransfersWork() {
-        return defaultHapiSpec("AllowanceTransfersWithComplexTransfersWork")
-                .given(
-                        newKeyNamed(ADMIN_KEY),
-                        newKeyNamed(FREEZE_KEY),
-                        newKeyNamed(KYC_KEY),
-                        newKeyNamed(SUPPLY_KEY),
-                        cryptoCreate(OWNER).balance(ONE_HUNDRED_HBARS),
-                        cryptoCreate(OTHER_OWNER).balance(ONE_HUNDRED_HBARS),
-                        cryptoCreate(SPENDER).balance(ONE_HUNDRED_HBARS),
-                        cryptoCreate(RECEIVER).balance(0L),
-                        cryptoCreate(OTHER_RECEIVER).balance(ONE_HBAR),
-                        cryptoCreate(ANOTHER_RECEIVER).balance(0L),
-                        cryptoCreate(TOKEN_TREASURY),
-                        tokenCreate(FUNGIBLE_TOKEN)
-                                .supplyType(TokenSupplyType.FINITE)
-                                .tokenType(FUNGIBLE_COMMON)
-                                .treasury(TOKEN_TREASURY)
-                                .maxSupply(10000)
-                                .initialSupply(5000)
-                                .adminKey(ADMIN_KEY)
-                                .kycKey(KYC_KEY),
-                        tokenCreate(NON_FUNGIBLE_TOKEN)
-                                .supplyType(TokenSupplyType.FINITE)
-                                .tokenType(NON_FUNGIBLE_UNIQUE)
-                                .treasury(TOKEN_TREASURY)
-                                .maxSupply(12L)
-                                .supplyKey(SUPPLY_KEY)
-                                .adminKey(ADMIN_KEY)
-                                .kycKey(KYC_KEY)
-                                .initialSupply(0L),
-                        mintToken(
-                                NON_FUNGIBLE_TOKEN,
-                                List.of(
-                                        ByteString.copyFromUtf8("a"),
-                                        ByteString.copyFromUtf8("b"),
-                                        ByteString.copyFromUtf8("c"),
-                                        ByteString.copyFromUtf8("d"),
-                                        ByteString.copyFromUtf8("e"))))
-                .when(
-                        tokenAssociate(OWNER, FUNGIBLE_TOKEN, NON_FUNGIBLE_TOKEN),
-                        tokenAssociate(OTHER_OWNER, FUNGIBLE_TOKEN, NON_FUNGIBLE_TOKEN),
-                        tokenAssociate(RECEIVER, FUNGIBLE_TOKEN, NON_FUNGIBLE_TOKEN),
-                        tokenAssociate(SPENDER, FUNGIBLE_TOKEN),
-                        tokenAssociate(ANOTHER_RECEIVER, FUNGIBLE_TOKEN),
-                        grantTokenKyc(FUNGIBLE_TOKEN, OWNER),
-                        grantTokenKyc(FUNGIBLE_TOKEN, OTHER_OWNER),
-                        grantTokenKyc(FUNGIBLE_TOKEN, RECEIVER),
-                        grantTokenKyc(FUNGIBLE_TOKEN, ANOTHER_RECEIVER),
-                        grantTokenKyc(FUNGIBLE_TOKEN, SPENDER),
-                        grantTokenKyc(NON_FUNGIBLE_TOKEN, OWNER),
-                        grantTokenKyc(NON_FUNGIBLE_TOKEN, OTHER_OWNER),
-                        grantTokenKyc(NON_FUNGIBLE_TOKEN, RECEIVER),
-                        cryptoTransfer(
-                                moving(100, FUNGIBLE_TOKEN).between(TOKEN_TREASURY, SPENDER),
-                                moving(1000, FUNGIBLE_TOKEN).between(TOKEN_TREASURY, OWNER),
-                                movingUnique(NON_FUNGIBLE_TOKEN, 1, 2)
-                                        .between(TOKEN_TREASURY, OWNER),
-                                moving(1000, FUNGIBLE_TOKEN).between(TOKEN_TREASURY, OTHER_OWNER),
-                                movingUnique(NON_FUNGIBLE_TOKEN, 3, 4)
-                                        .between(TOKEN_TREASURY, OTHER_OWNER)),
-                        cryptoApproveAllowance()
-                                .payingWith(OWNER)
-                                .addCryptoAllowance(OWNER, SPENDER, 10 * ONE_HBAR)
-                                .addTokenAllowance(OWNER, FUNGIBLE_TOKEN, SPENDER, 500)
-                                .addNftAllowance(
-                                        OWNER, NON_FUNGIBLE_TOKEN, SPENDER, false, List.of(1L, 2L))
-                                .fee(ONE_HUNDRED_HBARS),
-                        cryptoApproveAllowance()
-                                .payingWith(OTHER_OWNER)
-                                .addCryptoAllowance(OTHER_OWNER, SPENDER, 5 * ONE_HBAR)
-                                .addTokenAllowance(OTHER_OWNER, FUNGIBLE_TOKEN, SPENDER, 100)
-                                .addNftAllowance(
-                                        OTHER_OWNER, NON_FUNGIBLE_TOKEN, SPENDER, true, List.of(3L))
-                                .fee(ONE_HUNDRED_HBARS))
-                .then(
-                        cryptoTransfer(
-                                        movingHbar(ONE_HBAR).between(SPENDER, RECEIVER),
-                                        movingHbar(ONE_HBAR)
-                                                .between(OTHER_RECEIVER, ANOTHER_RECEIVER),
-                                        movingHbar(ONE_HBAR).between(OWNER, RECEIVER),
-                                        movingHbar(ONE_HBAR).between(OTHER_OWNER, RECEIVER),
-                                        movingHbarWithAllowance(ONE_HBAR).between(OWNER, RECEIVER),
-                                        movingHbarWithAllowance(ONE_HBAR)
-                                                .between(OTHER_OWNER, RECEIVER),
-                                        moving(50, FUNGIBLE_TOKEN)
-                                                .between(RECEIVER, ANOTHER_RECEIVER),
-                                        moving(50, FUNGIBLE_TOKEN).between(SPENDER, RECEIVER),
-                                        moving(50, FUNGIBLE_TOKEN).between(OWNER, RECEIVER),
-                                        moving(15, FUNGIBLE_TOKEN).between(OTHER_OWNER, RECEIVER),
-                                        movingWithAllowance(30, FUNGIBLE_TOKEN)
-                                                .between(OWNER, RECEIVER),
-                                        movingWithAllowance(10, FUNGIBLE_TOKEN)
-                                                .between(OTHER_OWNER, RECEIVER),
-                                        movingWithAllowance(5, FUNGIBLE_TOKEN)
-                                                .between(OTHER_OWNER, OWNER),
-                                        movingUnique(NON_FUNGIBLE_TOKEN, 1L)
-                                                .between(OWNER, RECEIVER),
-                                        movingUniqueWithAllowance(NON_FUNGIBLE_TOKEN, 2L)
-                                                .between(OWNER, RECEIVER),
-                                        movingUniqueWithAllowance(NON_FUNGIBLE_TOKEN, 4L)
-                                                .between(OTHER_OWNER, RECEIVER),
-                                        movingUniqueWithAllowance(NON_FUNGIBLE_TOKEN, 3L)
-                                                .between(OTHER_OWNER, RECEIVER))
-                                .payingWith(SPENDER)
-                                .signedBy(SPENDER, OWNER, OTHER_RECEIVER, OTHER_OWNER)
-                                .via("complexAllowanceTransfer"),
-                        getTxnRecord("complexAllowanceTransfer").logged(),
-                        getAccountDetails(OWNER)
-                                .payingWith(GENESIS)
-                                .hasToken(relationshipWith(FUNGIBLE_TOKEN).balance(925))
-                                .hasToken(relationshipWith(NON_FUNGIBLE_TOKEN).balance(0))
-                                .has(
-                                        AccountDetailsAsserts.accountWith()
-                                                .balanceLessThan(98 * ONE_HBAR)
-                                                .cryptoAllowancesContaining(SPENDER, 9 * ONE_HBAR)
-                                                .tokenAllowancesContaining(
-                                                        FUNGIBLE_TOKEN, SPENDER, 475)),
-                        getAccountDetails(OTHER_OWNER)
-                                .payingWith(GENESIS)
-                                .hasToken(relationshipWith(FUNGIBLE_TOKEN).balance(970))
-                                .hasToken(relationshipWith(NON_FUNGIBLE_TOKEN).balance(0))
-                                .has(
-                                        AccountDetailsAsserts.accountWith()
-                                                .balanceLessThan(98 * ONE_HBAR)
-                                                .cryptoAllowancesContaining(SPENDER, 4 * ONE_HBAR)
-                                                .tokenAllowancesContaining(
-                                                        FUNGIBLE_TOKEN, SPENDER, 85)
-                                                .nftApprovedAllowancesContaining(
-                                                        NON_FUNGIBLE_TOKEN, SPENDER)),
-                        getAccountInfo(RECEIVER)
-                                .hasToken(relationshipWith(FUNGIBLE_TOKEN).balance(105))
-                                .hasToken(relationshipWith(NON_FUNGIBLE_TOKEN).balance(4))
-                                .has(accountWith().balance(5 * ONE_HBAR)),
-                        getAccountInfo(ANOTHER_RECEIVER)
-                                .hasToken(relationshipWith(FUNGIBLE_TOKEN).balance(50))
-                                .has(accountWith().balance(ONE_HBAR)));
-    }
+	private HapiApiSpec allowanceTransfersWithComplexTransfersWork() {
+		return defaultHapiSpec("AllowanceTransfersWithComplexTransfersWork")
+				.given(
+						newKeyNamed(ADMIN_KEY),
+						newKeyNamed(FREEZE_KEY),
+						newKeyNamed(KYC_KEY),
+						newKeyNamed(SUPPLY_KEY),
+						cryptoCreate(OWNER).balance(ONE_HUNDRED_HBARS),
+						cryptoCreate(OTHER_OWNER).balance(ONE_HUNDRED_HBARS),
+						cryptoCreate(SPENDER).balance(ONE_HUNDRED_HBARS),
+						cryptoCreate(RECEIVER).balance(0L),
+						cryptoCreate(OTHER_RECEIVER).balance(ONE_HBAR),
+						cryptoCreate(ANOTHER_RECEIVER).balance(0L),
+						cryptoCreate(TOKEN_TREASURY),
+						tokenCreate(FUNGIBLE_TOKEN)
+								.supplyType(TokenSupplyType.FINITE)
+								.tokenType(FUNGIBLE_COMMON)
+								.treasury(TOKEN_TREASURY)
+								.maxSupply(10000)
+								.initialSupply(5000)
+								.adminKey(ADMIN_KEY)
+								.kycKey(KYC_KEY),
+						tokenCreate(NON_FUNGIBLE_TOKEN)
+								.supplyType(TokenSupplyType.FINITE)
+								.tokenType(NON_FUNGIBLE_UNIQUE)
+								.treasury(TOKEN_TREASURY)
+								.maxSupply(12L)
+								.supplyKey(SUPPLY_KEY)
+								.adminKey(ADMIN_KEY)
+								.kycKey(KYC_KEY)
+								.initialSupply(0L),
+						mintToken(
+								NON_FUNGIBLE_TOKEN,
+								List.of(
+										ByteString.copyFromUtf8("a"),
+										ByteString.copyFromUtf8("b"),
+										ByteString.copyFromUtf8("c"),
+										ByteString.copyFromUtf8("d"),
+										ByteString.copyFromUtf8("e"))))
+				.when(
+						tokenAssociate(OWNER, FUNGIBLE_TOKEN, NON_FUNGIBLE_TOKEN),
+						tokenAssociate(OTHER_OWNER, FUNGIBLE_TOKEN, NON_FUNGIBLE_TOKEN),
+						tokenAssociate(RECEIVER, FUNGIBLE_TOKEN, NON_FUNGIBLE_TOKEN),
+						tokenAssociate(SPENDER, FUNGIBLE_TOKEN),
+						tokenAssociate(ANOTHER_RECEIVER, FUNGIBLE_TOKEN),
+						grantTokenKyc(FUNGIBLE_TOKEN, OWNER),
+						grantTokenKyc(FUNGIBLE_TOKEN, OTHER_OWNER),
+						grantTokenKyc(FUNGIBLE_TOKEN, RECEIVER),
+						grantTokenKyc(FUNGIBLE_TOKEN, ANOTHER_RECEIVER),
+						grantTokenKyc(FUNGIBLE_TOKEN, SPENDER),
+						grantTokenKyc(NON_FUNGIBLE_TOKEN, OWNER),
+						grantTokenKyc(NON_FUNGIBLE_TOKEN, OTHER_OWNER),
+						grantTokenKyc(NON_FUNGIBLE_TOKEN, RECEIVER),
+						cryptoTransfer(
+								moving(100, FUNGIBLE_TOKEN).between(TOKEN_TREASURY, SPENDER),
+								moving(1000, FUNGIBLE_TOKEN).between(TOKEN_TREASURY, OWNER),
+								movingUnique(NON_FUNGIBLE_TOKEN, 1, 2)
+										.between(TOKEN_TREASURY, OWNER),
+								moving(1000, FUNGIBLE_TOKEN).between(TOKEN_TREASURY, OTHER_OWNER),
+								movingUnique(NON_FUNGIBLE_TOKEN, 3, 4)
+										.between(TOKEN_TREASURY, OTHER_OWNER)),
+						cryptoApproveAllowance()
+								.payingWith(OWNER)
+								.addCryptoAllowance(OWNER, SPENDER, 10 * ONE_HBAR)
+								.addTokenAllowance(OWNER, FUNGIBLE_TOKEN, SPENDER, 500)
+								.addNftAllowance(
+										OWNER, NON_FUNGIBLE_TOKEN, SPENDER, false, List.of(1L, 2L))
+								.fee(ONE_HUNDRED_HBARS),
+						cryptoApproveAllowance()
+								.payingWith(OTHER_OWNER)
+								.addCryptoAllowance(OTHER_OWNER, SPENDER, 5 * ONE_HBAR)
+								.addTokenAllowance(OTHER_OWNER, FUNGIBLE_TOKEN, SPENDER, 100)
+								.addNftAllowance(
+										OTHER_OWNER, NON_FUNGIBLE_TOKEN, SPENDER, true, List.of(3L))
+								.fee(ONE_HUNDRED_HBARS))
+				.then(
+						cryptoTransfer(
+								movingHbar(ONE_HBAR).between(SPENDER, RECEIVER),
+								movingHbar(ONE_HBAR)
+										.between(OTHER_RECEIVER, ANOTHER_RECEIVER),
+								movingHbar(ONE_HBAR).between(OWNER, RECEIVER),
+								movingHbar(ONE_HBAR).between(OTHER_OWNER, RECEIVER),
+								movingHbarWithAllowance(ONE_HBAR).between(OWNER, RECEIVER),
+								movingHbarWithAllowance(ONE_HBAR)
+										.between(OTHER_OWNER, RECEIVER),
+								moving(50, FUNGIBLE_TOKEN)
+										.between(RECEIVER, ANOTHER_RECEIVER),
+								moving(50, FUNGIBLE_TOKEN).between(SPENDER, RECEIVER),
+								moving(50, FUNGIBLE_TOKEN).between(OWNER, RECEIVER),
+								moving(15, FUNGIBLE_TOKEN).between(OTHER_OWNER, RECEIVER),
+								movingWithAllowance(30, FUNGIBLE_TOKEN)
+										.between(OWNER, RECEIVER),
+								movingWithAllowance(10, FUNGIBLE_TOKEN)
+										.between(OTHER_OWNER, RECEIVER),
+								movingWithAllowance(5, FUNGIBLE_TOKEN)
+										.between(OTHER_OWNER, OWNER),
+								movingUnique(NON_FUNGIBLE_TOKEN, 1L)
+										.between(OWNER, RECEIVER),
+								movingUniqueWithAllowance(NON_FUNGIBLE_TOKEN, 2L)
+										.between(OWNER, RECEIVER),
+								movingUniqueWithAllowance(NON_FUNGIBLE_TOKEN, 4L)
+										.between(OTHER_OWNER, RECEIVER),
+								movingUniqueWithAllowance(NON_FUNGIBLE_TOKEN, 3L)
+										.between(OTHER_OWNER, RECEIVER))
+								.payingWith(SPENDER)
+								.signedBy(SPENDER, OWNER, OTHER_RECEIVER, OTHER_OWNER)
+								.via("complexAllowanceTransfer"),
+						getTxnRecord("complexAllowanceTransfer").logged(),
+						getAccountDetails(OWNER)
+								.payingWith(GENESIS)
+								.hasToken(relationshipWith(FUNGIBLE_TOKEN).balance(925))
+								.hasToken(relationshipWith(NON_FUNGIBLE_TOKEN).balance(0))
+								.has(
+										AccountDetailsAsserts.accountWith()
+												.balanceLessThan(98 * ONE_HBAR)
+												.cryptoAllowancesContaining(SPENDER, 9 * ONE_HBAR)
+												.tokenAllowancesContaining(
+														FUNGIBLE_TOKEN, SPENDER, 475)),
+						getAccountDetails(OTHER_OWNER)
+								.payingWith(GENESIS)
+								.hasToken(relationshipWith(FUNGIBLE_TOKEN).balance(970))
+								.hasToken(relationshipWith(NON_FUNGIBLE_TOKEN).balance(0))
+								.has(
+										AccountDetailsAsserts.accountWith()
+												.balanceLessThan(98 * ONE_HBAR)
+												.cryptoAllowancesContaining(SPENDER, 4 * ONE_HBAR)
+												.tokenAllowancesContaining(
+														FUNGIBLE_TOKEN, SPENDER, 85)
+												.nftApprovedAllowancesContaining(
+														NON_FUNGIBLE_TOKEN, SPENDER)),
+						getAccountInfo(RECEIVER)
+								.hasToken(relationshipWith(FUNGIBLE_TOKEN).balance(105))
+								.hasToken(relationshipWith(NON_FUNGIBLE_TOKEN).balance(4))
+								.has(accountWith().balance(5 * ONE_HBAR)),
+						getAccountInfo(ANOTHER_RECEIVER)
+								.hasToken(relationshipWith(FUNGIBLE_TOKEN).balance(50))
+								.has(accountWith().balance(ONE_HBAR)));
+	}
 
-    private HapiApiSpec allowanceTransfersWorkAsExpected() {
-        return defaultHapiSpec("AllowanceTransfersWorkAsExpected")
-                .given(
-                        fileUpdate(APP_PROPERTIES)
-                                .fee(ONE_HUNDRED_HBARS)
-                                .payingWith(EXCHANGE_RATE_CONTROL)
-                                .overridingProps(
-                                        Map.of(
-                                                "hedera.allowances.maxTransactionLimit", "20",
-                                                "hedera.allowances.maxAccountLimit", "100")),
-                        newKeyNamed(ADMIN_KEY),
-                        newKeyNamed(FREEZE_KEY),
-                        newKeyNamed(KYC_KEY),
-                        newKeyNamed(PAUSE_KEY),
-                        newKeyNamed(SUPPLY_KEY),
-                        newKeyNamed(WIPE_KEY),
-                        cryptoCreate(TOKEN_TREASURY),
-                        cryptoCreate(OWNER).balance(ONE_HUNDRED_HBARS),
-                        cryptoCreate(SPENDER).balance(ONE_HUNDRED_HBARS),
-                        cryptoCreate(RECEIVER),
-                        cryptoCreate(OTHER_RECEIVER)
-                                .balance(ONE_HBAR)
-                                .maxAutomaticTokenAssociations(1),
-                        tokenCreate(FUNGIBLE_TOKEN)
-                                .supplyType(TokenSupplyType.FINITE)
-                                .tokenType(FUNGIBLE_COMMON)
-                                .treasury(TOKEN_TREASURY)
-                                .maxSupply(10000)
-                                .initialSupply(5000)
-                                .adminKey(ADMIN_KEY)
-                                .pauseKey(PAUSE_KEY)
-                                .kycKey(KYC_KEY)
-                                .freezeKey(FREEZE_KEY),
-                        tokenCreate(NON_FUNGIBLE_TOKEN)
-                                .supplyType(TokenSupplyType.FINITE)
-                                .tokenType(NON_FUNGIBLE_UNIQUE)
-                                .treasury(TOKEN_TREASURY)
-                                .maxSupply(12L)
-                                .supplyKey(SUPPLY_KEY)
-                                .adminKey(ADMIN_KEY)
-                                .freezeKey(FREEZE_KEY)
-                                .wipeKey(WIPE_KEY)
-                                .pauseKey(PAUSE_KEY)
-                                .initialSupply(0L),
-                        tokenCreate(TOKEN_WITH_CUSTOM_FEE)
-                                .treasury(TOKEN_TREASURY)
-                                .supplyType(TokenSupplyType.FINITE)
-                                .initialSupply(1000)
-                                .maxSupply(5000)
-                                .adminKey(ADMIN_KEY)
-                                .withCustom(fixedHtsFee(10, "0.0.0", TOKEN_TREASURY)),
-                        mintToken(
-                                NON_FUNGIBLE_TOKEN,
-                                List.of(
-                                        ByteString.copyFromUtf8("a"),
-                                        ByteString.copyFromUtf8("b"),
-                                        ByteString.copyFromUtf8("c"),
-                                        ByteString.copyFromUtf8("d"),
-                                        ByteString.copyFromUtf8("e"),
-                                        ByteString.copyFromUtf8("f"))))
-                .when(
-                        tokenAssociate(
-                                OWNER, FUNGIBLE_TOKEN, NON_FUNGIBLE_TOKEN, TOKEN_WITH_CUSTOM_FEE),
-                        tokenAssociate(
-                                RECEIVER,
-                                FUNGIBLE_TOKEN,
-                                NON_FUNGIBLE_TOKEN,
-                                TOKEN_WITH_CUSTOM_FEE),
-                        grantTokenKyc(FUNGIBLE_TOKEN, OWNER),
-                        grantTokenKyc(FUNGIBLE_TOKEN, RECEIVER),
-                        cryptoTransfer(
-                                moving(1000, FUNGIBLE_TOKEN).between(TOKEN_TREASURY, OWNER),
-                                moving(15, TOKEN_WITH_CUSTOM_FEE).between(TOKEN_TREASURY, OWNER),
-                                movingUnique(NON_FUNGIBLE_TOKEN, 1L, 2L, 3L, 4L, 5L, 6L)
-                                        .between(TOKEN_TREASURY, OWNER)),
-                        cryptoApproveAllowance()
-                                .payingWith(OWNER)
-                                .addCryptoAllowance(OWNER, SPENDER, 10 * ONE_HBAR)
-                                .addTokenAllowance(OWNER, FUNGIBLE_TOKEN, SPENDER, 1500)
-                                .addTokenAllowance(OWNER, TOKEN_WITH_CUSTOM_FEE, SPENDER, 100)
-                                .addNftAllowance(
-                                        OWNER,
-                                        NON_FUNGIBLE_TOKEN,
-                                        SPENDER,
-                                        false,
-                                        List.of(1L, 2L, 3L, 4L, 6L))
-                                .fee(ONE_HUNDRED_HBARS))
-                .then(
-                        cryptoTransfer(
-                                        movingWithAllowance(10, TOKEN_WITH_CUSTOM_FEE)
-                                                .between(OWNER, RECEIVER))
-                                .payingWith(SPENDER)
-                                .signedBy(SPENDER)
-                                .fee(ONE_HBAR)
-                                .hasKnownStatus(INSUFFICIENT_SENDER_ACCOUNT_BALANCE_FOR_CUSTOM_FEE),
-                        cryptoTransfer(
-                                        movingWithAllowance(100, FUNGIBLE_TOKEN)
-                                                .between(OWNER, OWNER))
-                                .payingWith(SPENDER)
-                                .signedBy(SPENDER)
-                                .dontFullyAggregateTokenTransfers()
-                                .hasPrecheck(ACCOUNT_REPEATED_IN_ACCOUNT_AMOUNTS),
-                        cryptoTransfer(
-                                        movingUniqueWithAllowance(NON_FUNGIBLE_TOKEN, 3)
-                                                .between(OWNER, OTHER_RECEIVER))
-                                .payingWith(SPENDER)
-                                .signedBy(SPENDER),
-                        cryptoTransfer(
-                                        movingWithAllowance(100, FUNGIBLE_TOKEN)
-                                                .between(OWNER, OTHER_RECEIVER))
-                                .payingWith(SPENDER)
-                                .signedBy(SPENDER)
-                                .hasKnownStatus(NO_REMAINING_AUTOMATIC_ASSOCIATIONS),
-                        cryptoUpdate(OTHER_RECEIVER)
-                                .receiverSigRequired(true)
-                                .maxAutomaticAssociations(2),
-                        cryptoTransfer(
-                                        movingUniqueWithAllowance(NON_FUNGIBLE_TOKEN, 4)
-                                                .between(OWNER, OTHER_RECEIVER))
-                                .payingWith(SPENDER)
-                                .signedBy(SPENDER)
-                                .hasKnownStatus(INVALID_SIGNATURE),
-                        cryptoTransfer(
-                                        movingUniqueWithAllowance(NON_FUNGIBLE_TOKEN, 4)
-                                                .between(OWNER, OTHER_RECEIVER))
-                                .payingWith(SPENDER)
-                                .signedBy(SPENDER, OTHER_RECEIVER),
-                        cryptoTransfer(
-                                movingUnique(NON_FUNGIBLE_TOKEN, 6).between(OWNER, RECEIVER)),
-                        cryptoTransfer(
-                                        movingUniqueWithAllowance(NON_FUNGIBLE_TOKEN, 6)
-                                                .between(OWNER, RECEIVER))
-                                .payingWith(SPENDER)
-                                .signedBy(SPENDER)
-                                .hasKnownStatus(SPENDER_DOES_NOT_HAVE_ALLOWANCE),
-                        cryptoTransfer(
-                                        movingUniqueWithAllowance(NON_FUNGIBLE_TOKEN, 6)
-                                                .between(RECEIVER, OWNER))
-                                .payingWith(SPENDER)
-                                .signedBy(SPENDER)
-                                .hasKnownStatus(SPENDER_DOES_NOT_HAVE_ALLOWANCE),
-                        cryptoTransfer(
-                                movingUnique(NON_FUNGIBLE_TOKEN, 6).between(RECEIVER, OWNER)),
-                        cryptoTransfer(
-                                        movingUniqueWithAllowance(NON_FUNGIBLE_TOKEN, 6)
-                                                .between(OWNER, RECEIVER))
-                                .payingWith(SPENDER)
-                                .signedBy(SPENDER)
-                                .hasKnownStatus(SPENDER_DOES_NOT_HAVE_ALLOWANCE),
-                        cryptoTransfer(
-                                movingUnique(NON_FUNGIBLE_TOKEN, 6).between(OWNER, RECEIVER)),
-                        tokenAssociate(OTHER_RECEIVER, FUNGIBLE_TOKEN),
-                        grantTokenKyc(FUNGIBLE_TOKEN, OTHER_RECEIVER),
-                        cryptoTransfer(
-                                        movingWithAllowance(1100, FUNGIBLE_TOKEN)
-                                                .between(OWNER, OTHER_RECEIVER))
-                                .payingWith(SPENDER)
-                                .signedBy(SPENDER, OTHER_RECEIVER)
-                                .hasKnownStatus(INSUFFICIENT_TOKEN_BALANCE),
-                        cryptoTransfer(allowanceTinyBarsFromTo(OWNER, RECEIVER, 5 * ONE_HBAR))
-                                .payingWith(DEFAULT_PAYER)
-                                .signedBy(DEFAULT_PAYER)
-                                .hasKnownStatus(SPENDER_DOES_NOT_HAVE_ALLOWANCE),
-                        tokenPause(FUNGIBLE_TOKEN),
-                        cryptoTransfer(
-                                        movingWithAllowance(50, FUNGIBLE_TOKEN)
-                                                .between(OWNER, RECEIVER),
-                                        movingUniqueWithAllowance(NON_FUNGIBLE_TOKEN, 1)
-                                                .between(OWNER, RECEIVER))
-                                .payingWith(SPENDER)
-                                .signedBy(SPENDER)
-                                .hasKnownStatus(TOKEN_IS_PAUSED),
-                        tokenUnpause(FUNGIBLE_TOKEN),
-                        tokenFreeze(FUNGIBLE_TOKEN, OWNER),
-                        cryptoTransfer(
-                                        movingWithAllowance(50, FUNGIBLE_TOKEN)
-                                                .between(OWNER, RECEIVER),
-                                        movingUniqueWithAllowance(NON_FUNGIBLE_TOKEN, 1)
-                                                .between(OWNER, RECEIVER))
-                                .payingWith(SPENDER)
-                                .signedBy(SPENDER)
-                                .hasKnownStatus(ACCOUNT_FROZEN_FOR_TOKEN),
-                        tokenUnfreeze(FUNGIBLE_TOKEN, OWNER),
-                        revokeTokenKyc(FUNGIBLE_TOKEN, RECEIVER),
-                        cryptoTransfer(
-                                        movingWithAllowance(50, FUNGIBLE_TOKEN)
-                                                .between(OWNER, RECEIVER),
-                                        movingUniqueWithAllowance(NON_FUNGIBLE_TOKEN, 1)
-                                                .between(OWNER, RECEIVER))
-                                .payingWith(SPENDER)
-                                .signedBy(SPENDER)
-                                .hasKnownStatus(ACCOUNT_KYC_NOT_GRANTED_FOR_TOKEN),
-                        grantTokenKyc(FUNGIBLE_TOKEN, RECEIVER),
-                        cryptoTransfer(
-                                        allowanceTinyBarsFromTo(OWNER, RECEIVER, 5 * ONE_HBAR),
-                                        tinyBarsFromTo(SPENDER, RECEIVER, ONE_HBAR))
-                                .payingWith(SPENDER)
-                                .signedBy(SPENDER),
-                        cryptoTransfer(
-                                        movingWithAllowance(50, FUNGIBLE_TOKEN)
-                                                .between(OWNER, RECEIVER),
-                                        movingUniqueWithAllowance(NON_FUNGIBLE_TOKEN, 1)
-                                                .between(OWNER, RECEIVER))
-                                .payingWith(SPENDER)
-                                .signedBy(SPENDER),
-                        cryptoTransfer(allowanceTinyBarsFromTo(OWNER, RECEIVER, 5 * ONE_HBAR + 1))
-                                .payingWith(SPENDER)
-                                .signedBy(SPENDER)
-                                .hasKnownStatus(AMOUNT_EXCEEDS_ALLOWANCE),
-                        cryptoTransfer(
-                                        movingWithAllowance(50, FUNGIBLE_TOKEN)
-                                                .between(OWNER, RECEIVER),
-                                        movingUniqueWithAllowance(NON_FUNGIBLE_TOKEN, 5)
-                                                .between(OWNER, RECEIVER))
-                                .payingWith(SPENDER)
-                                .signedBy(SPENDER)
-                                .hasKnownStatus(SPENDER_DOES_NOT_HAVE_ALLOWANCE),
-                        getAccountDetails(OWNER)
-                                .payingWith(GENESIS)
-                                .has(
-                                        AccountDetailsAsserts.accountWith()
-                                                .tokenAllowancesContaining(
-                                                        FUNGIBLE_TOKEN, SPENDER, 1450))
-                                .hasToken(relationshipWith(FUNGIBLE_TOKEN).balance(950L)),
-                        cryptoTransfer(moving(1000, FUNGIBLE_TOKEN).between(TOKEN_TREASURY, OWNER)),
-                        cryptoTransfer(
-                                        movingUniqueWithAllowance(NON_FUNGIBLE_TOKEN, 2L)
-                                                .between(OWNER, RECEIVER),
-                                        movingWithAllowance(1451, FUNGIBLE_TOKEN)
-                                                .between(OWNER, RECEIVER))
-                                .payingWith(SPENDER)
-                                .signedBy(SPENDER)
-                                .hasKnownStatus(AMOUNT_EXCEEDS_ALLOWANCE),
-                        getAccountInfo(OWNER)
-                                .hasToken(relationshipWith(NON_FUNGIBLE_TOKEN).balance(2)),
-                        cryptoTransfer(allowanceTinyBarsFromTo(OWNER, RECEIVER, 5 * ONE_HBAR))
-                                .payingWith(SPENDER)
-                                .signedBy(SPENDER),
-                        cryptoTransfer(
-                                        movingWithAllowance(50, FUNGIBLE_TOKEN)
-                                                .between(OWNER, RECEIVER),
-                                        movingUniqueWithAllowance(NON_FUNGIBLE_TOKEN, 2L)
-                                                .between(OWNER, RECEIVER))
-                                .payingWith(SPENDER)
-                                .signedBy(SPENDER),
-                        cryptoTransfer(allowanceTinyBarsFromTo(OWNER, RECEIVER, 5 * ONE_HBAR))
-                                .payingWith(SPENDER)
-                                .signedBy(SPENDER)
-                                .hasKnownStatus(SPENDER_DOES_NOT_HAVE_ALLOWANCE),
-                        cryptoTransfer(
-                                movingUnique(NON_FUNGIBLE_TOKEN, 2L).between(RECEIVER, OWNER)),
-                        cryptoTransfer(
-                                        movingUniqueWithAllowance(NON_FUNGIBLE_TOKEN, 2L)
-                                                .between(OWNER, RECEIVER))
-                                .payingWith(SPENDER)
-                                .signedBy(SPENDER)
-                                .hasKnownStatus(SPENDER_DOES_NOT_HAVE_ALLOWANCE),
-                        cryptoApproveAllowance()
-                                .payingWith(OWNER)
-                                .addNftAllowance(
-                                        OWNER, NON_FUNGIBLE_TOKEN, SPENDER, true, List.of())
-                                .fee(ONE_HUNDRED_HBARS),
-                        cryptoTransfer(
-                                        movingUniqueWithAllowance(NON_FUNGIBLE_TOKEN, 2L)
-                                                .between(OWNER, RECEIVER))
-                                .payingWith(SPENDER)
-                                .signedBy(SPENDER),
-                        cryptoTransfer(
-                                movingUnique(NON_FUNGIBLE_TOKEN, 2L).between(RECEIVER, OWNER)),
-                        cryptoTransfer(
-                                        movingUniqueWithAllowance(NON_FUNGIBLE_TOKEN, 2L)
-                                                .between(OWNER, RECEIVER))
-                                .payingWith(SPENDER)
-                                .signedBy(SPENDER),
-                        getAccountDetails(OWNER)
-                                .payingWith(GENESIS)
-                                .has(
-                                        AccountDetailsAsserts.accountWith()
-                                                .cryptoAllowancesCount(0)
-                                                .tokenAllowancesContaining(
-                                                        FUNGIBLE_TOKEN, SPENDER, 1400)
-                                                .nftApprovedAllowancesContaining(
-                                                        NON_FUNGIBLE_TOKEN, SPENDER)));
-    }
+	private HapiApiSpec allowanceTransfersWorkAsExpected() {
+		return defaultHapiSpec("AllowanceTransfersWorkAsExpected")
+				.given(
+						fileUpdate(APP_PROPERTIES)
+								.fee(ONE_HUNDRED_HBARS)
+								.payingWith(EXCHANGE_RATE_CONTROL)
+								.overridingProps(
+										Map.of(
+												"hedera.allowances.maxTransactionLimit", "20",
+												"hedera.allowances.maxAccountLimit", "100")),
+						newKeyNamed(ADMIN_KEY),
+						newKeyNamed(FREEZE_KEY),
+						newKeyNamed(KYC_KEY),
+						newKeyNamed(PAUSE_KEY),
+						newKeyNamed(SUPPLY_KEY),
+						newKeyNamed(WIPE_KEY),
+						cryptoCreate(TOKEN_TREASURY),
+						cryptoCreate(OWNER).balance(ONE_HUNDRED_HBARS),
+						cryptoCreate(SPENDER).balance(ONE_HUNDRED_HBARS),
+						cryptoCreate(RECEIVER),
+						cryptoCreate(OTHER_RECEIVER)
+								.balance(ONE_HBAR)
+								.maxAutomaticTokenAssociations(1),
+						tokenCreate(FUNGIBLE_TOKEN)
+								.supplyType(TokenSupplyType.FINITE)
+								.tokenType(FUNGIBLE_COMMON)
+								.treasury(TOKEN_TREASURY)
+								.maxSupply(10000)
+								.initialSupply(5000)
+								.adminKey(ADMIN_KEY)
+								.pauseKey(PAUSE_KEY)
+								.kycKey(KYC_KEY)
+								.freezeKey(FREEZE_KEY),
+						tokenCreate(NON_FUNGIBLE_TOKEN)
+								.supplyType(TokenSupplyType.FINITE)
+								.tokenType(NON_FUNGIBLE_UNIQUE)
+								.treasury(TOKEN_TREASURY)
+								.maxSupply(12L)
+								.supplyKey(SUPPLY_KEY)
+								.adminKey(ADMIN_KEY)
+								.freezeKey(FREEZE_KEY)
+								.wipeKey(WIPE_KEY)
+								.pauseKey(PAUSE_KEY)
+								.initialSupply(0L),
+						tokenCreate(TOKEN_WITH_CUSTOM_FEE)
+								.treasury(TOKEN_TREASURY)
+								.supplyType(TokenSupplyType.FINITE)
+								.initialSupply(1000)
+								.maxSupply(5000)
+								.adminKey(ADMIN_KEY)
+								.withCustom(fixedHtsFee(10, "0.0.0", TOKEN_TREASURY)),
+						mintToken(
+								NON_FUNGIBLE_TOKEN,
+								List.of(
+										ByteString.copyFromUtf8("a"),
+										ByteString.copyFromUtf8("b"),
+										ByteString.copyFromUtf8("c"),
+										ByteString.copyFromUtf8("d"),
+										ByteString.copyFromUtf8("e"),
+										ByteString.copyFromUtf8("f"))))
+				.when(
+						tokenAssociate(
+								OWNER, FUNGIBLE_TOKEN, NON_FUNGIBLE_TOKEN, TOKEN_WITH_CUSTOM_FEE),
+						tokenAssociate(
+								RECEIVER,
+								FUNGIBLE_TOKEN,
+								NON_FUNGIBLE_TOKEN,
+								TOKEN_WITH_CUSTOM_FEE),
+						grantTokenKyc(FUNGIBLE_TOKEN, OWNER),
+						grantTokenKyc(FUNGIBLE_TOKEN, RECEIVER),
+						cryptoTransfer(
+								moving(1000, FUNGIBLE_TOKEN).between(TOKEN_TREASURY, OWNER),
+								moving(15, TOKEN_WITH_CUSTOM_FEE).between(TOKEN_TREASURY, OWNER),
+								movingUnique(NON_FUNGIBLE_TOKEN, 1L, 2L, 3L, 4L, 5L, 6L)
+										.between(TOKEN_TREASURY, OWNER)),
+						cryptoApproveAllowance()
+								.payingWith(OWNER)
+								.addCryptoAllowance(OWNER, SPENDER, 10 * ONE_HBAR)
+								.addTokenAllowance(OWNER, FUNGIBLE_TOKEN, SPENDER, 1500)
+								.addTokenAllowance(OWNER, TOKEN_WITH_CUSTOM_FEE, SPENDER, 100)
+								.addNftAllowance(
+										OWNER,
+										NON_FUNGIBLE_TOKEN,
+										SPENDER,
+										false,
+										List.of(1L, 2L, 3L, 4L, 6L))
+								.fee(ONE_HUNDRED_HBARS))
+				.then(
+						cryptoTransfer(
+								movingWithAllowance(10, TOKEN_WITH_CUSTOM_FEE)
+										.between(OWNER, RECEIVER))
+								.payingWith(SPENDER)
+								.signedBy(SPENDER)
+								.fee(ONE_HBAR)
+								.hasKnownStatus(INSUFFICIENT_SENDER_ACCOUNT_BALANCE_FOR_CUSTOM_FEE),
+						cryptoTransfer(
+								movingWithAllowance(100, FUNGIBLE_TOKEN)
+										.between(OWNER, OWNER))
+								.payingWith(SPENDER)
+								.signedBy(SPENDER)
+								.dontFullyAggregateTokenTransfers()
+								.hasPrecheck(ACCOUNT_REPEATED_IN_ACCOUNT_AMOUNTS),
+						cryptoTransfer(
+								movingUniqueWithAllowance(NON_FUNGIBLE_TOKEN, 3)
+										.between(OWNER, OTHER_RECEIVER))
+								.payingWith(SPENDER)
+								.signedBy(SPENDER),
+						cryptoTransfer(
+								movingWithAllowance(100, FUNGIBLE_TOKEN)
+										.between(OWNER, OTHER_RECEIVER))
+								.payingWith(SPENDER)
+								.signedBy(SPENDER)
+								.hasKnownStatus(NO_REMAINING_AUTOMATIC_ASSOCIATIONS),
+						cryptoUpdate(OTHER_RECEIVER)
+								.receiverSigRequired(true)
+								.maxAutomaticAssociations(2),
+						cryptoTransfer(
+								movingUniqueWithAllowance(NON_FUNGIBLE_TOKEN, 4)
+										.between(OWNER, OTHER_RECEIVER))
+								.payingWith(SPENDER)
+								.signedBy(SPENDER)
+								.hasKnownStatus(INVALID_SIGNATURE),
+						cryptoTransfer(
+								movingUniqueWithAllowance(NON_FUNGIBLE_TOKEN, 4)
+										.between(OWNER, OTHER_RECEIVER))
+								.payingWith(SPENDER)
+								.signedBy(SPENDER, OTHER_RECEIVER),
+						cryptoTransfer(
+								movingUnique(NON_FUNGIBLE_TOKEN, 6).between(OWNER, RECEIVER)),
+						cryptoTransfer(
+								movingUniqueWithAllowance(NON_FUNGIBLE_TOKEN, 6)
+										.between(OWNER, RECEIVER))
+								.payingWith(SPENDER)
+								.signedBy(SPENDER)
+								.hasKnownStatus(SPENDER_DOES_NOT_HAVE_ALLOWANCE),
+						cryptoTransfer(
+								movingUniqueWithAllowance(NON_FUNGIBLE_TOKEN, 6)
+										.between(RECEIVER, OWNER))
+								.payingWith(SPENDER)
+								.signedBy(SPENDER)
+								.hasKnownStatus(SPENDER_DOES_NOT_HAVE_ALLOWANCE),
+						cryptoTransfer(
+								movingUnique(NON_FUNGIBLE_TOKEN, 6).between(RECEIVER, OWNER)),
+						cryptoTransfer(
+								movingUniqueWithAllowance(NON_FUNGIBLE_TOKEN, 6)
+										.between(OWNER, RECEIVER))
+								.payingWith(SPENDER)
+								.signedBy(SPENDER)
+								.hasKnownStatus(SPENDER_DOES_NOT_HAVE_ALLOWANCE),
+						cryptoTransfer(
+								movingUnique(NON_FUNGIBLE_TOKEN, 6).between(OWNER, RECEIVER)),
+						tokenAssociate(OTHER_RECEIVER, FUNGIBLE_TOKEN),
+						grantTokenKyc(FUNGIBLE_TOKEN, OTHER_RECEIVER),
+						cryptoTransfer(
+								movingWithAllowance(1100, FUNGIBLE_TOKEN)
+										.between(OWNER, OTHER_RECEIVER))
+								.payingWith(SPENDER)
+								.signedBy(SPENDER, OTHER_RECEIVER)
+								.hasKnownStatus(INSUFFICIENT_TOKEN_BALANCE),
+						cryptoTransfer(allowanceTinyBarsFromTo(OWNER, RECEIVER, 5 * ONE_HBAR))
+								.payingWith(DEFAULT_PAYER)
+								.signedBy(DEFAULT_PAYER)
+								.hasKnownStatus(SPENDER_DOES_NOT_HAVE_ALLOWANCE),
+						tokenPause(FUNGIBLE_TOKEN),
+						cryptoTransfer(
+								movingWithAllowance(50, FUNGIBLE_TOKEN)
+										.between(OWNER, RECEIVER),
+								movingUniqueWithAllowance(NON_FUNGIBLE_TOKEN, 1)
+										.between(OWNER, RECEIVER))
+								.payingWith(SPENDER)
+								.signedBy(SPENDER)
+								.hasKnownStatus(TOKEN_IS_PAUSED),
+						tokenUnpause(FUNGIBLE_TOKEN),
+						tokenFreeze(FUNGIBLE_TOKEN, OWNER),
+						cryptoTransfer(
+								movingWithAllowance(50, FUNGIBLE_TOKEN)
+										.between(OWNER, RECEIVER),
+								movingUniqueWithAllowance(NON_FUNGIBLE_TOKEN, 1)
+										.between(OWNER, RECEIVER))
+								.payingWith(SPENDER)
+								.signedBy(SPENDER)
+								.hasKnownStatus(ACCOUNT_FROZEN_FOR_TOKEN),
+						tokenUnfreeze(FUNGIBLE_TOKEN, OWNER),
+						revokeTokenKyc(FUNGIBLE_TOKEN, RECEIVER),
+						cryptoTransfer(
+								movingWithAllowance(50, FUNGIBLE_TOKEN)
+										.between(OWNER, RECEIVER),
+								movingUniqueWithAllowance(NON_FUNGIBLE_TOKEN, 1)
+										.between(OWNER, RECEIVER))
+								.payingWith(SPENDER)
+								.signedBy(SPENDER)
+								.hasKnownStatus(ACCOUNT_KYC_NOT_GRANTED_FOR_TOKEN),
+						grantTokenKyc(FUNGIBLE_TOKEN, RECEIVER),
+						cryptoTransfer(
+								allowanceTinyBarsFromTo(OWNER, RECEIVER, 5 * ONE_HBAR),
+								tinyBarsFromTo(SPENDER, RECEIVER, ONE_HBAR))
+								.payingWith(SPENDER)
+								.signedBy(SPENDER),
+						cryptoTransfer(
+								movingWithAllowance(50, FUNGIBLE_TOKEN)
+										.between(OWNER, RECEIVER),
+								movingUniqueWithAllowance(NON_FUNGIBLE_TOKEN, 1)
+										.between(OWNER, RECEIVER))
+								.payingWith(SPENDER)
+								.signedBy(SPENDER),
+						cryptoTransfer(allowanceTinyBarsFromTo(OWNER, RECEIVER, 5 * ONE_HBAR + 1))
+								.payingWith(SPENDER)
+								.signedBy(SPENDER)
+								.hasKnownStatus(AMOUNT_EXCEEDS_ALLOWANCE),
+						cryptoTransfer(
+								movingWithAllowance(50, FUNGIBLE_TOKEN)
+										.between(OWNER, RECEIVER),
+								movingUniqueWithAllowance(NON_FUNGIBLE_TOKEN, 5)
+										.between(OWNER, RECEIVER))
+								.payingWith(SPENDER)
+								.signedBy(SPENDER)
+								.hasKnownStatus(SPENDER_DOES_NOT_HAVE_ALLOWANCE),
+						getAccountDetails(OWNER)
+								.payingWith(GENESIS)
+								.has(
+										AccountDetailsAsserts.accountWith()
+												.tokenAllowancesContaining(
+														FUNGIBLE_TOKEN, SPENDER, 1450))
+								.hasToken(relationshipWith(FUNGIBLE_TOKEN).balance(950L)),
+						cryptoTransfer(moving(1000, FUNGIBLE_TOKEN).between(TOKEN_TREASURY, OWNER)),
+						cryptoTransfer(
+								movingUniqueWithAllowance(NON_FUNGIBLE_TOKEN, 2L)
+										.between(OWNER, RECEIVER),
+								movingWithAllowance(1451, FUNGIBLE_TOKEN)
+										.between(OWNER, RECEIVER))
+								.payingWith(SPENDER)
+								.signedBy(SPENDER)
+								.hasKnownStatus(AMOUNT_EXCEEDS_ALLOWANCE),
+						getAccountInfo(OWNER)
+								.hasToken(relationshipWith(NON_FUNGIBLE_TOKEN).balance(2)),
+						cryptoTransfer(allowanceTinyBarsFromTo(OWNER, RECEIVER, 5 * ONE_HBAR))
+								.payingWith(SPENDER)
+								.signedBy(SPENDER),
+						cryptoTransfer(
+								movingWithAllowance(50, FUNGIBLE_TOKEN)
+										.between(OWNER, RECEIVER),
+								movingUniqueWithAllowance(NON_FUNGIBLE_TOKEN, 2L)
+										.between(OWNER, RECEIVER))
+								.payingWith(SPENDER)
+								.signedBy(SPENDER),
+						cryptoTransfer(allowanceTinyBarsFromTo(OWNER, RECEIVER, 5 * ONE_HBAR))
+								.payingWith(SPENDER)
+								.signedBy(SPENDER)
+								.hasKnownStatus(SPENDER_DOES_NOT_HAVE_ALLOWANCE),
+						cryptoTransfer(
+								movingUnique(NON_FUNGIBLE_TOKEN, 2L).between(RECEIVER, OWNER)),
+						cryptoTransfer(
+								movingUniqueWithAllowance(NON_FUNGIBLE_TOKEN, 2L)
+										.between(OWNER, RECEIVER))
+								.payingWith(SPENDER)
+								.signedBy(SPENDER)
+								.hasKnownStatus(SPENDER_DOES_NOT_HAVE_ALLOWANCE),
+						cryptoApproveAllowance()
+								.payingWith(OWNER)
+								.addNftAllowance(
+										OWNER, NON_FUNGIBLE_TOKEN, SPENDER, true, List.of())
+								.fee(ONE_HUNDRED_HBARS),
+						cryptoTransfer(
+								movingUniqueWithAllowance(NON_FUNGIBLE_TOKEN, 2L)
+										.between(OWNER, RECEIVER))
+								.payingWith(SPENDER)
+								.signedBy(SPENDER),
+						cryptoTransfer(
+								movingUnique(NON_FUNGIBLE_TOKEN, 2L).between(RECEIVER, OWNER)),
+						cryptoTransfer(
+								movingUniqueWithAllowance(NON_FUNGIBLE_TOKEN, 2L)
+										.between(OWNER, RECEIVER))
+								.payingWith(SPENDER)
+								.signedBy(SPENDER),
+						getAccountDetails(OWNER)
+								.payingWith(GENESIS)
+								.has(
+										AccountDetailsAsserts.accountWith()
+												.cryptoAllowancesCount(0)
+												.tokenAllowancesContaining(
+														FUNGIBLE_TOKEN, SPENDER, 1400)
+												.nftApprovedAllowancesContaining(
+														NON_FUNGIBLE_TOKEN, SPENDER)));
+	}
 
-    private HapiApiSpec checksExpectedDecimalsForFungibleTokenTransferList() {
-        return defaultHapiSpec("checksExpectedDecimalsForFungibleTokenTransferList")
-                .given(
-                        newKeyNamed(MULTI_KEY),
-                        cryptoCreate(TOKEN_TREASURY),
-                        cryptoCreate(OWNING_PARTY).maxAutomaticTokenAssociations(123),
-                        tokenCreate(FUNGIBLE_TOKEN)
-                                .tokenType(FUNGIBLE_COMMON)
-                                .treasury(TOKEN_TREASURY)
-                                .decimals(2)
-                                .initialSupply(1234)
-                                .via("tokenCreate"),
-                        getTxnRecord("tokenCreate")
-                                .hasNewTokenAssociation(FUNGIBLE_TOKEN, TOKEN_TREASURY),
-                        cryptoTransfer(
-                                        moving(100, FUNGIBLE_TOKEN)
-                                                .between(TOKEN_TREASURY, OWNING_PARTY))
-                                .via("initialXfer"),
-                        getTxnRecord("initialXfer")
-                                .hasNewTokenAssociation(FUNGIBLE_TOKEN, OWNING_PARTY))
-                .when(
-                        getAccountInfo(OWNING_PARTY).savingSnapshot(OWNING_PARTY),
-                        cryptoTransfer(
-                                        movingWithDecimals(10, FUNGIBLE_TOKEN, 4)
-                                                .betweenWithDecimals(TOKEN_TREASURY, OWNING_PARTY))
-                                .signedBy(DEFAULT_PAYER, OWNING_PARTY, TOKEN_TREASURY)
-                                .hasKnownStatus(UNEXPECTED_TOKEN_DECIMALS)
-                                .via("failedTxn"),
-                        cryptoTransfer(
-                                        movingWithDecimals(20, FUNGIBLE_TOKEN, 2)
-                                                .betweenWithDecimals(TOKEN_TREASURY, OWNING_PARTY))
-                                .signedBy(DEFAULT_PAYER, OWNING_PARTY, TOKEN_TREASURY)
-                                .hasKnownStatus(SUCCESS)
-                                .via(VALID_TXN),
-                        usableTxnIdNamed(UNCHECKED_TXN).payerId(DEFAULT_PAYER),
-                        uncheckedSubmit(
-                                        cryptoTransfer(
-                                                        movingWithDecimals(10, FUNGIBLE_TOKEN, 4)
-                                                                .betweenWithDecimals(
-                                                                        TOKEN_TREASURY,
-                                                                        OWNING_PARTY))
-                                                .signedBy(
-                                                        DEFAULT_PAYER, OWNING_PARTY, TOKEN_TREASURY)
-                                                .txnId(UNCHECKED_TXN))
-                                .payingWith(GENESIS))
-                .then(
-                        sleepFor(5_000),
-                        getReceipt(UNCHECKED_TXN)
-                                .hasPriorityStatus(UNEXPECTED_TOKEN_DECIMALS)
-                                .logged(),
-                        getReceipt(VALID_TXN).hasPriorityStatus(SUCCESS),
-                        getTxnRecord(VALID_TXN).logged(),
-                        getAccountInfo(OWNING_PARTY)
-                                .hasAlreadyUsedAutomaticAssociations(1)
-                                .hasToken(relationshipWith(FUNGIBLE_TOKEN).balance(120))
-                                .logged());
-    }
+	private HapiApiSpec checksExpectedDecimalsForFungibleTokenTransferList() {
+		return defaultHapiSpec("checksExpectedDecimalsForFungibleTokenTransferList")
+				.given(
+						newKeyNamed(MULTI_KEY),
+						cryptoCreate(TOKEN_TREASURY),
+						cryptoCreate(OWNING_PARTY).maxAutomaticTokenAssociations(123),
+						tokenCreate(FUNGIBLE_TOKEN)
+								.tokenType(FUNGIBLE_COMMON)
+								.treasury(TOKEN_TREASURY)
+								.decimals(2)
+								.initialSupply(1234)
+								.via("tokenCreate"),
+						getTxnRecord("tokenCreate")
+								.hasNewTokenAssociation(FUNGIBLE_TOKEN, TOKEN_TREASURY),
+						cryptoTransfer(
+								moving(100, FUNGIBLE_TOKEN)
+										.between(TOKEN_TREASURY, OWNING_PARTY))
+								.via("initialXfer"),
+						getTxnRecord("initialXfer")
+								.hasNewTokenAssociation(FUNGIBLE_TOKEN, OWNING_PARTY))
+				.when(
+						getAccountInfo(OWNING_PARTY).savingSnapshot(OWNING_PARTY),
+						cryptoTransfer(
+								movingWithDecimals(10, FUNGIBLE_TOKEN, 4)
+										.betweenWithDecimals(TOKEN_TREASURY, OWNING_PARTY))
+								.signedBy(DEFAULT_PAYER, OWNING_PARTY, TOKEN_TREASURY)
+								.hasKnownStatus(UNEXPECTED_TOKEN_DECIMALS)
+								.via("failedTxn"),
+						cryptoTransfer(
+								movingWithDecimals(20, FUNGIBLE_TOKEN, 2)
+										.betweenWithDecimals(TOKEN_TREASURY, OWNING_PARTY))
+								.signedBy(DEFAULT_PAYER, OWNING_PARTY, TOKEN_TREASURY)
+								.hasKnownStatus(SUCCESS)
+								.via(VALID_TXN),
+						usableTxnIdNamed(UNCHECKED_TXN).payerId(DEFAULT_PAYER),
+						uncheckedSubmit(
+								cryptoTransfer(
+										movingWithDecimals(10, FUNGIBLE_TOKEN, 4)
+												.betweenWithDecimals(
+														TOKEN_TREASURY,
+														OWNING_PARTY))
+										.signedBy(
+												DEFAULT_PAYER, OWNING_PARTY, TOKEN_TREASURY)
+										.txnId(UNCHECKED_TXN))
+								.payingWith(GENESIS))
+				.then(
+						sleepFor(5_000),
+						getReceipt(UNCHECKED_TXN)
+								.hasPriorityStatus(UNEXPECTED_TOKEN_DECIMALS)
+								.logged(),
+						getReceipt(VALID_TXN).hasPriorityStatus(SUCCESS),
+						getTxnRecord(VALID_TXN).logged(),
+						getAccountInfo(OWNING_PARTY)
+								.hasAlreadyUsedAutomaticAssociations(1)
+								.hasToken(relationshipWith(FUNGIBLE_TOKEN).balance(120))
+								.logged());
+	}
 
-    private HapiApiSpec nftTransfersCannotRepeatSerialNos() {
-        final var aParty = "aParty";
-        final var bParty = "bParty";
-        final var cParty = "cParty";
-        final var dParty = "dParty";
-        final var multipurpose = MULTI_KEY;
-        final var nftType = "nftType";
-        final var hotTxn = "hotTxn";
-        final var mintTxn = "mintTxn";
+	private HapiApiSpec nftTransfersCannotRepeatSerialNos() {
+		final var aParty = "aParty";
+		final var bParty = "bParty";
+		final var cParty = "cParty";
+		final var dParty = "dParty";
+		final var multipurpose = MULTI_KEY;
+		final var nftType = "nftType";
+		final var hotTxn = "hotTxn";
+		final var mintTxn = "mintTxn";
 
-        return defaultHapiSpec("NftTransfersCannotRepeatSerialNos")
-                .given(
-                        newKeyNamed(multipurpose),
-                        cryptoCreate(TOKEN_TREASURY),
-                        cryptoCreate(aParty).maxAutomaticTokenAssociations(1),
-                        cryptoCreate(bParty).maxAutomaticTokenAssociations(1),
-                        cryptoCreate(cParty).maxAutomaticTokenAssociations(1),
-                        cryptoCreate(dParty).maxAutomaticTokenAssociations(1),
-                        tokenCreate(nftType)
-                                .tokenType(NON_FUNGIBLE_UNIQUE)
-                                .treasury(TOKEN_TREASURY)
-                                .supplyKey(multipurpose)
-                                .initialSupply(0),
-                        mintToken(nftType, List.of(copyFromUtf8("Hot potato!"))).via(mintTxn),
-                        getTxnRecord(mintTxn).logged())
-                .when(cryptoTransfer(movingUnique(nftType, 1L).between(TOKEN_TREASURY, aParty)))
-                .then(
-                        cryptoTransfer(
-                                        (spec, b) -> {
-                                            final var registry = spec.registry();
-                                            final var aId = registry.getAccountID(aParty);
-                                            final var bId = registry.getAccountID(bParty);
-                                            final var cId = registry.getAccountID(cParty);
-                                            final var dId = registry.getAccountID(dParty);
-                                            b.addTokenTransfers(
-                                                    TokenTransferList.newBuilder()
-                                                            .setToken(registry.getTokenID(nftType))
-                                                            .addNftTransfers(ocWith(aId, bId, 1))
-                                                            .addNftTransfers(ocWith(bId, cId, 1))
-                                                            .addNftTransfers(ocWith(cId, dId, 1)));
-                                        })
-                                .via(hotTxn)
-                                .signedBy(DEFAULT_PAYER, aParty, bParty, cParty)
-                                .hasPrecheck(INVALID_ACCOUNT_AMOUNTS));
-    }
+		return defaultHapiSpec("NftTransfersCannotRepeatSerialNos")
+				.given(
+						newKeyNamed(multipurpose),
+						cryptoCreate(TOKEN_TREASURY),
+						cryptoCreate(aParty).maxAutomaticTokenAssociations(1),
+						cryptoCreate(bParty).maxAutomaticTokenAssociations(1),
+						cryptoCreate(cParty).maxAutomaticTokenAssociations(1),
+						cryptoCreate(dParty).maxAutomaticTokenAssociations(1),
+						tokenCreate(nftType)
+								.tokenType(NON_FUNGIBLE_UNIQUE)
+								.treasury(TOKEN_TREASURY)
+								.supplyKey(multipurpose)
+								.initialSupply(0),
+						mintToken(nftType, List.of(copyFromUtf8("Hot potato!"))).via(mintTxn),
+						getTxnRecord(mintTxn).logged())
+				.when(cryptoTransfer(movingUnique(nftType, 1L).between(TOKEN_TREASURY, aParty)))
+				.then(
+						cryptoTransfer(
+								(spec, b) -> {
+									final var registry = spec.registry();
+									final var aId = registry.getAccountID(aParty);
+									final var bId = registry.getAccountID(bParty);
+									final var cId = registry.getAccountID(cParty);
+									final var dId = registry.getAccountID(dParty);
+									b.addTokenTransfers(
+											TokenTransferList.newBuilder()
+													.setToken(registry.getTokenID(nftType))
+													.addNftTransfers(ocWith(aId, bId, 1))
+													.addNftTransfers(ocWith(bId, cId, 1))
+													.addNftTransfers(ocWith(cId, dId, 1)));
+								})
+								.via(hotTxn)
+								.signedBy(DEFAULT_PAYER, aParty, bParty, cParty)
+								.hasPrecheck(INVALID_ACCOUNT_AMOUNTS));
+	}
 
-    private HapiApiSpec nftSelfTransfersRejectedBothInPrecheckAndHandle() {
-        final var owningParty = OWNING_PARTY;
-        final var multipurpose = MULTI_KEY;
-        final var nftType = "nftType";
-        final var uncheckedTxn = UNCHECKED_TXN;
+	private HapiApiSpec noStakePeriodStartIfNotStakingToNode() {
+		final var user = "user";
+		final var contract = "contract";
+		return defaultHapiSpec("NoStakePeriodStartIfNotStakingToNode")
+				.given(
+						newKeyNamed(ADMIN_KEY),
+						cryptoCreate(user)
+								.key(ADMIN_KEY)
+								.stakedNodeId(0L),
+						createDefaultContract(contract)
+								.adminKey(ADMIN_KEY)
+								.stakedNodeId(0L),
+						getAccountInfo(user).has(accountWith().someStakePeriodStart()),
+						getContractInfo(contract).has(contractWith().someStakePeriodStart())
+				).when(
+						cryptoUpdate(user).newStakedAccountId(contract),
+						contractUpdate(contract).newStakedAccountId(user)
+				).then(
+						getAccountInfo(user).has(accountWith().noStakePeriodStart()),
+						getContractInfo(contract).has(contractWith().noStakePeriodStart())
+				);
+	}
 
-        return defaultHapiSpec("NftSelfTransfersRejectedBothInPrecheckAndHandle")
-                .given(
-                        newKeyNamed(multipurpose),
-                        cryptoCreate(TOKEN_TREASURY),
-                        cryptoCreate(owningParty).maxAutomaticTokenAssociations(123),
-                        tokenCreate(nftType)
-                                .tokenType(NON_FUNGIBLE_UNIQUE)
-                                .treasury(TOKEN_TREASURY)
-                                .supplyKey(multipurpose)
-                                .initialSupply(0),
-                        mintToken(
-                                nftType,
-                                List.of(
-                                        copyFromUtf8("We"),
-                                        copyFromUtf8("are"),
-                                        copyFromUtf8("the"))),
-                        cryptoTransfer(
-                                movingUnique(nftType, 1L, 2L).between(TOKEN_TREASURY, owningParty)))
-                .when(
-                        getAccountInfo(owningParty).savingSnapshot(owningParty),
-                        cryptoTransfer(movingUnique(nftType, 1L).between(owningParty, owningParty))
-                                .signedBy(DEFAULT_PAYER, owningParty)
-                                .hasPrecheck(ACCOUNT_REPEATED_IN_ACCOUNT_AMOUNTS),
-                        usableTxnIdNamed(uncheckedTxn).payerId(DEFAULT_PAYER),
-                        uncheckedSubmit(
-                                        cryptoTransfer(
-                                                        movingUnique(nftType, 1L)
-                                                                .between(owningParty, owningParty))
-                                                .signedBy(DEFAULT_PAYER, owningParty)
-                                                .txnId(uncheckedTxn))
-                                .payingWith(GENESIS))
-                .then(
-                        sleepFor(2_000),
-                        getReceipt(uncheckedTxn)
-                                .hasPriorityStatus(ACCOUNT_REPEATED_IN_ACCOUNT_AMOUNTS),
-                        getAccountInfo(owningParty)
-                                .has(accountWith().noChangesFromSnapshot(owningParty)));
-    }
+	private HapiApiSpec nftSelfTransfersRejectedBothInPrecheckAndHandle() {
+		final var owningParty = OWNING_PARTY;
+		final var multipurpose = MULTI_KEY;
+		final var nftType = "nftType";
+		final var uncheckedTxn = UNCHECKED_TXN;
 
-    private HapiApiSpec hbarAndFungibleSelfTransfersRejectedBothInPrecheckAndHandle() {
-        final var uncheckedHbarTxn = "uncheckedHbarTxn";
-        final var uncheckedFtTxn = "uncheckedFtTxn";
+		return defaultHapiSpec("NftSelfTransfersRejectedBothInPrecheckAndHandle")
+				.given(
+						newKeyNamed(multipurpose),
+						cryptoCreate(TOKEN_TREASURY),
+						cryptoCreate(owningParty).maxAutomaticTokenAssociations(123),
+						tokenCreate(nftType)
+								.tokenType(NON_FUNGIBLE_UNIQUE)
+								.treasury(TOKEN_TREASURY)
+								.supplyKey(multipurpose)
+								.initialSupply(0),
+						mintToken(
+								nftType,
+								List.of(
+										copyFromUtf8("We"),
+										copyFromUtf8("are"),
+										copyFromUtf8("the"))),
+						cryptoTransfer(
+								movingUnique(nftType, 1L, 2L).between(TOKEN_TREASURY, owningParty)))
+				.when(
+						getAccountInfo(owningParty).savingSnapshot(owningParty),
+						cryptoTransfer(movingUnique(nftType, 1L).between(owningParty, owningParty))
+								.signedBy(DEFAULT_PAYER, owningParty)
+								.hasPrecheck(ACCOUNT_REPEATED_IN_ACCOUNT_AMOUNTS),
+						usableTxnIdNamed(uncheckedTxn).payerId(DEFAULT_PAYER),
+						uncheckedSubmit(
+								cryptoTransfer(
+										movingUnique(nftType, 1L)
+												.between(owningParty, owningParty))
+										.signedBy(DEFAULT_PAYER, owningParty)
+										.txnId(uncheckedTxn))
+								.payingWith(GENESIS))
+				.then(
+						sleepFor(2_000),
+						getReceipt(uncheckedTxn)
+								.hasPriorityStatus(ACCOUNT_REPEATED_IN_ACCOUNT_AMOUNTS),
+						getAccountInfo(owningParty)
+								.has(accountWith().noChangesFromSnapshot(owningParty)));
+	}
 
-        return defaultHapiSpec("HbarAndFungibleSelfTransfersRejectedBothInPrecheckAndHandle")
-                .given(
-                        newKeyNamed(MULTI_KEY),
-                        cryptoCreate(TOKEN_TREASURY),
-                        cryptoCreate(OWNING_PARTY).maxAutomaticTokenAssociations(123),
-                        tokenCreate(FUNGIBLE_TOKEN)
-                                .tokenType(FUNGIBLE_COMMON)
-                                .treasury(TOKEN_TREASURY)
-                                .initialSupply(1234),
-                        cryptoTransfer(
-                                moving(100, FUNGIBLE_TOKEN).between(TOKEN_TREASURY, OWNING_PARTY)))
-                .when(
-                        getAccountInfo(OWNING_PARTY).savingSnapshot(OWNING_PARTY),
-                        cryptoTransfer(tinyBarsFromTo(OWNING_PARTY, OWNING_PARTY, 1))
-                                .signedBy(DEFAULT_PAYER, OWNING_PARTY)
-                                .hasPrecheck(ACCOUNT_REPEATED_IN_ACCOUNT_AMOUNTS),
-                        cryptoTransfer(
-                                        moving(1, FUNGIBLE_TOKEN)
-                                                .between(OWNING_PARTY, OWNING_PARTY))
-                                .signedBy(DEFAULT_PAYER, OWNING_PARTY)
-                                .dontFullyAggregateTokenTransfers()
-                                .hasPrecheck(ACCOUNT_REPEATED_IN_ACCOUNT_AMOUNTS),
-                        /* And bypassing precheck */
-                        usableTxnIdNamed(uncheckedHbarTxn).payerId(DEFAULT_PAYER),
-                        usableTxnIdNamed(uncheckedFtTxn).payerId(DEFAULT_PAYER),
-                        uncheckedSubmit(
-                                        cryptoTransfer(
-                                                        tinyBarsFromTo(
-                                                                OWNING_PARTY, OWNING_PARTY, 1))
-                                                .signedBy(DEFAULT_PAYER, OWNING_PARTY)
-                                                .txnId(uncheckedHbarTxn))
-                                .payingWith(GENESIS),
-                        uncheckedSubmit(
-                                        cryptoTransfer(
-                                                        moving(1, FUNGIBLE_TOKEN)
-                                                                .between(
-                                                                        OWNING_PARTY, OWNING_PARTY))
-                                                .signedBy(DEFAULT_PAYER, OWNING_PARTY)
-                                                .dontFullyAggregateTokenTransfers()
-                                                .txnId(uncheckedFtTxn))
-                                .payingWith(GENESIS))
-                .then(
-                        sleepFor(5_000),
-                        getReceipt(uncheckedHbarTxn)
-                                .hasPriorityStatus(ACCOUNT_REPEATED_IN_ACCOUNT_AMOUNTS),
-                        getReceipt(uncheckedFtTxn)
-                                .hasPriorityStatus(ACCOUNT_REPEATED_IN_ACCOUNT_AMOUNTS),
-                        getAccountInfo(OWNING_PARTY)
-                                .has(accountWith().noChangesFromSnapshot(OWNING_PARTY)));
-    }
+	private HapiApiSpec hbarAndFungibleSelfTransfersRejectedBothInPrecheckAndHandle() {
+		final var uncheckedHbarTxn = "uncheckedHbarTxn";
+		final var uncheckedFtTxn = "uncheckedFtTxn";
 
-    private HapiApiSpec dissociatedRoyaltyCollectorsCanUseAutoAssociation() {
-        final var commonWithCustomFees = "commonWithCustomFees";
-        final var fractionalCollector = "fractionalCollector";
-        final var selfDenominatedCollector = "selfDenominatedCollector";
-        final var plentyOfSlots = 10;
+		return defaultHapiSpec("HbarAndFungibleSelfTransfersRejectedBothInPrecheckAndHandle")
+				.given(
+						newKeyNamed(MULTI_KEY),
+						cryptoCreate(TOKEN_TREASURY),
+						cryptoCreate(OWNING_PARTY).maxAutomaticTokenAssociations(123),
+						tokenCreate(FUNGIBLE_TOKEN)
+								.tokenType(FUNGIBLE_COMMON)
+								.treasury(TOKEN_TREASURY)
+								.initialSupply(1234),
+						cryptoTransfer(
+								moving(100, FUNGIBLE_TOKEN).between(TOKEN_TREASURY, OWNING_PARTY)))
+				.when(
+						getAccountInfo(OWNING_PARTY).savingSnapshot(OWNING_PARTY),
+						cryptoTransfer(tinyBarsFromTo(OWNING_PARTY, OWNING_PARTY, 1))
+								.signedBy(DEFAULT_PAYER, OWNING_PARTY)
+								.hasPrecheck(ACCOUNT_REPEATED_IN_ACCOUNT_AMOUNTS),
+						cryptoTransfer(
+								moving(1, FUNGIBLE_TOKEN)
+										.between(OWNING_PARTY, OWNING_PARTY))
+								.signedBy(DEFAULT_PAYER, OWNING_PARTY)
+								.dontFullyAggregateTokenTransfers()
+								.hasPrecheck(ACCOUNT_REPEATED_IN_ACCOUNT_AMOUNTS),
+						/* And bypassing precheck */
+						usableTxnIdNamed(uncheckedHbarTxn).payerId(DEFAULT_PAYER),
+						usableTxnIdNamed(uncheckedFtTxn).payerId(DEFAULT_PAYER),
+						uncheckedSubmit(
+								cryptoTransfer(
+										tinyBarsFromTo(
+												OWNING_PARTY, OWNING_PARTY, 1))
+										.signedBy(DEFAULT_PAYER, OWNING_PARTY)
+										.txnId(uncheckedHbarTxn))
+								.payingWith(GENESIS),
+						uncheckedSubmit(
+								cryptoTransfer(
+										moving(1, FUNGIBLE_TOKEN)
+												.between(
+														OWNING_PARTY, OWNING_PARTY))
+										.signedBy(DEFAULT_PAYER, OWNING_PARTY)
+										.dontFullyAggregateTokenTransfers()
+										.txnId(uncheckedFtTxn))
+								.payingWith(GENESIS))
+				.then(
+						sleepFor(5_000),
+						getReceipt(uncheckedHbarTxn)
+								.hasPriorityStatus(ACCOUNT_REPEATED_IN_ACCOUNT_AMOUNTS),
+						getReceipt(uncheckedFtTxn)
+								.hasPriorityStatus(ACCOUNT_REPEATED_IN_ACCOUNT_AMOUNTS),
+						getAccountInfo(OWNING_PARTY)
+								.has(accountWith().noChangesFromSnapshot(OWNING_PARTY)));
+	}
 
-        return defaultHapiSpec("RoyaltyCollectorsCanUseAutoAssociation")
-                .given(
-                        cryptoCreate(TOKEN_TREASURY),
-                        cryptoCreate(fractionalCollector)
-                                .maxAutomaticTokenAssociations(plentyOfSlots),
-                        cryptoCreate(selfDenominatedCollector)
-                                .maxAutomaticTokenAssociations(plentyOfSlots),
-                        cryptoCreate(PARTY).maxAutomaticTokenAssociations(plentyOfSlots),
-                        cryptoCreate(COUNTERPARTY).maxAutomaticTokenAssociations(plentyOfSlots),
-                        newKeyNamed(MULTI_KEY),
-                        getAccountInfo(PARTY).savingSnapshot(PARTY),
-                        getAccountInfo(COUNTERPARTY).savingSnapshot(COUNTERPARTY),
-                        getAccountInfo(fractionalCollector).savingSnapshot(fractionalCollector),
-                        getAccountInfo(selfDenominatedCollector)
-                                .savingSnapshot(selfDenominatedCollector))
-                .when(
-                        tokenCreate(commonWithCustomFees)
-                                .tokenType(FUNGIBLE_COMMON)
-                                .treasury(TOKEN_TREASURY)
-                                .withCustom(
-                                        fractionalFee(
-                                                1,
-                                                10,
-                                                0,
-                                                OptionalLong.empty(),
-                                                fractionalCollector))
-                                .withCustom(fixedHtsFee(5, "0.0.0", selfDenominatedCollector))
-                                .initialSupply(Long.MAX_VALUE)
-                                .signedBy(
-                                        DEFAULT_PAYER,
-                                        TOKEN_TREASURY,
-                                        fractionalCollector,
-                                        selfDenominatedCollector),
-                        cryptoTransfer(
-                                moving(1_000_000, commonWithCustomFees)
-                                        .between(TOKEN_TREASURY, PARTY)),
-                        tokenDissociate(fractionalCollector, commonWithCustomFees),
-                        tokenDissociate(selfDenominatedCollector, commonWithCustomFees))
-                .then(
-                        cryptoTransfer(
-                                        moving(1000, commonWithCustomFees)
-                                                .between(PARTY, COUNTERPARTY))
-                                .fee(ONE_HBAR)
-                                .via(HODL_XFER),
-                        getTxnRecord(HODL_XFER)
-                                .hasPriority(
-                                        recordWith()
-                                                .autoAssociated(
-                                                        accountTokenPairsInAnyOrder(
-                                                                List.of(
-                                                                        /* The counterparty auto-associates to the fungible type */
-                                                                        Pair.of(
-                                                                                COUNTERPARTY,
-                                                                                commonWithCustomFees),
-                                                                        /* Both royalty collectors re-auto-associate */
-                                                                        Pair.of(
-                                                                                fractionalCollector,
-                                                                                commonWithCustomFees),
-                                                                        Pair.of(
-                                                                                selfDenominatedCollector,
-                                                                                commonWithCustomFees))))),
-                        getAccountInfo(fractionalCollector)
-                                .has(
-                                        accountWith()
-                                                .newAssociationsFromSnapshot(
-                                                        PARTY,
-                                                        List.of(
-                                                                relationshipWith(
-                                                                                commonWithCustomFees)
-                                                                        .balance(100)))),
-                        getAccountInfo(selfDenominatedCollector)
-                                .has(
-                                        accountWith()
-                                                .newAssociationsFromSnapshot(
-                                                        PARTY,
-                                                        List.of(
-                                                                relationshipWith(
-                                                                                commonWithCustomFees)
-                                                                        .balance(5)))));
-    }
+	private HapiApiSpec dissociatedRoyaltyCollectorsCanUseAutoAssociation() {
+		final var commonWithCustomFees = "commonWithCustomFees";
+		final var fractionalCollector = "fractionalCollector";
+		final var selfDenominatedCollector = "selfDenominatedCollector";
+		final var plentyOfSlots = 10;
 
-    private HapiApiSpec royaltyCollectorsCanUseAutoAssociation() {
-        final var uniqueWithRoyalty = "uniqueWithRoyalty";
-        final var firstFungible = "firstFungible";
-        final var secondFungible = "secondFungible";
-        final var firstRoyaltyCollector = "firstRoyaltyCollector";
-        final var secondRoyaltyCollector = "secondRoyaltyCollector";
-        final var plentyOfSlots = 10;
-        final var exchangeAmount = 12 * 15;
-        final var firstRoyaltyAmount = exchangeAmount / 12;
-        final var secondRoyaltyAmount = exchangeAmount / 15;
-        final var netExchangeAmount = exchangeAmount - firstRoyaltyAmount - secondRoyaltyAmount;
+		return defaultHapiSpec("RoyaltyCollectorsCanUseAutoAssociation")
+				.given(
+						cryptoCreate(TOKEN_TREASURY),
+						cryptoCreate(fractionalCollector)
+								.maxAutomaticTokenAssociations(plentyOfSlots),
+						cryptoCreate(selfDenominatedCollector)
+								.maxAutomaticTokenAssociations(plentyOfSlots),
+						cryptoCreate(PARTY).maxAutomaticTokenAssociations(plentyOfSlots),
+						cryptoCreate(COUNTERPARTY).maxAutomaticTokenAssociations(plentyOfSlots),
+						newKeyNamed(MULTI_KEY),
+						getAccountInfo(PARTY).savingSnapshot(PARTY),
+						getAccountInfo(COUNTERPARTY).savingSnapshot(COUNTERPARTY),
+						getAccountInfo(fractionalCollector).savingSnapshot(fractionalCollector),
+						getAccountInfo(selfDenominatedCollector)
+								.savingSnapshot(selfDenominatedCollector))
+				.when(
+						tokenCreate(commonWithCustomFees)
+								.tokenType(FUNGIBLE_COMMON)
+								.treasury(TOKEN_TREASURY)
+								.withCustom(
+										fractionalFee(
+												1,
+												10,
+												0,
+												OptionalLong.empty(),
+												fractionalCollector))
+								.withCustom(fixedHtsFee(5, "0.0.0", selfDenominatedCollector))
+								.initialSupply(Long.MAX_VALUE)
+								.signedBy(
+										DEFAULT_PAYER,
+										TOKEN_TREASURY,
+										fractionalCollector,
+										selfDenominatedCollector),
+						cryptoTransfer(
+								moving(1_000_000, commonWithCustomFees)
+										.between(TOKEN_TREASURY, PARTY)),
+						tokenDissociate(fractionalCollector, commonWithCustomFees),
+						tokenDissociate(selfDenominatedCollector, commonWithCustomFees))
+				.then(
+						cryptoTransfer(
+								moving(1000, commonWithCustomFees)
+										.between(PARTY, COUNTERPARTY))
+								.fee(ONE_HBAR)
+								.via(HODL_XFER),
+						getTxnRecord(HODL_XFER)
+								.hasPriority(
+										recordWith()
+												.autoAssociated(
+														accountTokenPairsInAnyOrder(
+																List.of(
+																		/* The counterparty auto-associates to the
+																		fungible type */
+																		Pair.of(
+																				COUNTERPARTY,
+																				commonWithCustomFees),
+																		/* Both royalty collectors re-auto-associate */
+																		Pair.of(
+																				fractionalCollector,
+																				commonWithCustomFees),
+																		Pair.of(
+																				selfDenominatedCollector,
+																				commonWithCustomFees))))),
+						getAccountInfo(fractionalCollector)
+								.has(
+										accountWith()
+												.newAssociationsFromSnapshot(
+														PARTY,
+														List.of(
+																relationshipWith(
+																		commonWithCustomFees)
+																		.balance(100)))),
+						getAccountInfo(selfDenominatedCollector)
+								.has(
+										accountWith()
+												.newAssociationsFromSnapshot(
+														PARTY,
+														List.of(
+																relationshipWith(
+																		commonWithCustomFees)
+																		.balance(5)))));
+	}
 
-        return defaultHapiSpec("RoyaltyCollectorsCanUseAutoAssociation")
-                .given(
-                        cryptoCreate(TOKEN_TREASURY),
-                        cryptoCreate(firstRoyaltyCollector)
-                                .maxAutomaticTokenAssociations(plentyOfSlots),
-                        cryptoCreate(secondRoyaltyCollector)
-                                .maxAutomaticTokenAssociations(plentyOfSlots),
-                        cryptoCreate(PARTY).maxAutomaticTokenAssociations(plentyOfSlots),
-                        cryptoCreate(COUNTERPARTY).maxAutomaticTokenAssociations(plentyOfSlots),
-                        newKeyNamed(MULTI_KEY),
-                        getAccountInfo(PARTY).savingSnapshot(PARTY),
-                        getAccountInfo(COUNTERPARTY).savingSnapshot(COUNTERPARTY),
-                        getAccountInfo(firstRoyaltyCollector).savingSnapshot(firstRoyaltyCollector),
-                        getAccountInfo(secondRoyaltyCollector)
-                                .savingSnapshot(secondRoyaltyCollector))
-                .when(
-                        tokenCreate(firstFungible)
-                                .treasury(TOKEN_TREASURY)
-                                .tokenType(FUNGIBLE_COMMON)
-                                .initialSupply(123456789),
-                        tokenCreate(secondFungible)
-                                .treasury(TOKEN_TREASURY)
-                                .tokenType(FUNGIBLE_COMMON)
-                                .initialSupply(123456789),
-                        cryptoTransfer(
-                                moving(1000, firstFungible).between(TOKEN_TREASURY, COUNTERPARTY),
-                                moving(1000, secondFungible).between(TOKEN_TREASURY, COUNTERPARTY)),
-                        tokenCreate(uniqueWithRoyalty)
-                                .tokenType(NON_FUNGIBLE_UNIQUE)
-                                .treasury(TOKEN_TREASURY)
-                                .supplyKey(MULTI_KEY)
-                                .withCustom(royaltyFeeNoFallback(1, 12, firstRoyaltyCollector))
-                                .withCustom(royaltyFeeNoFallback(1, 15, secondRoyaltyCollector))
-                                .initialSupply(0L),
-                        mintToken(uniqueWithRoyalty, List.of(copyFromUtf8("HODL"))),
-                        cryptoTransfer(
-                                movingUnique(uniqueWithRoyalty, 1L).between(TOKEN_TREASURY, PARTY)))
-                .then(
-                        cryptoTransfer(
-                                        movingUnique(uniqueWithRoyalty, 1L)
-                                                .between(PARTY, COUNTERPARTY),
-                                        moving(12 * 15L, firstFungible)
-                                                .between(COUNTERPARTY, PARTY),
-                                        moving(12 * 15L, secondFungible)
-                                                .between(COUNTERPARTY, PARTY))
-                                .fee(ONE_HBAR)
-                                .via(HODL_XFER),
-                        getTxnRecord(HODL_XFER)
-                                .hasPriority(
-                                        recordWith()
-                                                .autoAssociated(
-                                                        accountTokenPairsInAnyOrder(
-                                                                List.of(
-                                                                        /* The counterparty auto-associates to the non-fungible type */
-                                                                        Pair.of(
-                                                                                COUNTERPARTY,
-                                                                                uniqueWithRoyalty),
-                                                                        /* The sending party auto-associates to both fungibles */
-                                                                        Pair.of(
-                                                                                PARTY,
-                                                                                firstFungible),
-                                                                        Pair.of(
-                                                                                PARTY,
-                                                                                secondFungible),
-                                                                        /* Both royalty collectors auto-associate to both fungibles */
-                                                                        Pair.of(
-                                                                                firstRoyaltyCollector,
-                                                                                firstFungible),
-                                                                        Pair.of(
-                                                                                secondRoyaltyCollector,
-                                                                                firstFungible),
-                                                                        Pair.of(
-                                                                                firstRoyaltyCollector,
-                                                                                secondFungible),
-                                                                        Pair.of(
-                                                                                secondRoyaltyCollector,
-                                                                                secondFungible))))),
-                        getAccountInfo(PARTY)
-                                .has(
-                                        accountWith()
-                                                .newAssociationsFromSnapshot(
-                                                        PARTY,
-                                                        List.of(
-                                                                relationshipWith(uniqueWithRoyalty)
-                                                                        .balance(0),
-                                                                relationshipWith(firstFungible)
-                                                                        .balance(netExchangeAmount),
-                                                                relationshipWith(secondFungible)
-                                                                        .balance(
-                                                                                netExchangeAmount)))),
-                        getAccountInfo(COUNTERPARTY)
-                                .has(
-                                        accountWith()
-                                                .newAssociationsFromSnapshot(
-                                                        PARTY,
-                                                        List.of(
-                                                                relationshipWith(uniqueWithRoyalty)
-                                                                        .balance(1),
-                                                                relationshipWith(firstFungible)
-                                                                        .balance(
-                                                                                1000L
-                                                                                        - exchangeAmount),
-                                                                relationshipWith(secondFungible)
-                                                                        .balance(
-                                                                                1000L
-                                                                                        - exchangeAmount)))),
-                        getAccountInfo(firstRoyaltyCollector)
-                                .has(
-                                        accountWith()
-                                                .newAssociationsFromSnapshot(
-                                                        PARTY,
-                                                        List.of(
-                                                                relationshipWith(firstFungible)
-                                                                        .balance(
-                                                                                exchangeAmount
-                                                                                        / 12),
-                                                                relationshipWith(secondFungible)
-                                                                        .balance(
-                                                                                exchangeAmount
-                                                                                        / 12)))),
-                        getAccountInfo(secondRoyaltyCollector)
-                                .has(
-                                        accountWith()
-                                                .newAssociationsFromSnapshot(
-                                                        PARTY,
-                                                        List.of(
-                                                                relationshipWith(firstFungible)
-                                                                        .balance(
-                                                                                exchangeAmount
-                                                                                        / 15),
-                                                                relationshipWith(secondFungible)
-                                                                        .balance(
-                                                                                exchangeAmount
-                                                                                        / 15)))));
-    }
+	private HapiApiSpec royaltyCollectorsCanUseAutoAssociation() {
+		final var uniqueWithRoyalty = "uniqueWithRoyalty";
+		final var firstFungible = "firstFungible";
+		final var secondFungible = "secondFungible";
+		final var firstRoyaltyCollector = "firstRoyaltyCollector";
+		final var secondRoyaltyCollector = "secondRoyaltyCollector";
+		final var plentyOfSlots = 10;
+		final var exchangeAmount = 12 * 15;
+		final var firstRoyaltyAmount = exchangeAmount / 12;
+		final var secondRoyaltyAmount = exchangeAmount / 15;
+		final var netExchangeAmount = exchangeAmount - firstRoyaltyAmount - secondRoyaltyAmount;
 
-    private HapiApiSpec royaltyCollectorsCannotUseAutoAssociationWithoutOpenSlots() {
-        final var uniqueWithRoyalty = "uniqueWithRoyalty";
-        final var someFungible = "firstFungible";
-        final var royaltyCollectorNoSlots = "royaltyCollectorNoSlots";
-        final var party = PARTY;
-        final var counterparty = COUNTERPARTY;
-        final var multipurpose = MULTI_KEY;
-        final var hodlXfer = HODL_XFER;
+		return defaultHapiSpec("RoyaltyCollectorsCanUseAutoAssociation")
+				.given(
+						cryptoCreate(TOKEN_TREASURY),
+						cryptoCreate(firstRoyaltyCollector)
+								.maxAutomaticTokenAssociations(plentyOfSlots),
+						cryptoCreate(secondRoyaltyCollector)
+								.maxAutomaticTokenAssociations(plentyOfSlots),
+						cryptoCreate(PARTY).maxAutomaticTokenAssociations(plentyOfSlots),
+						cryptoCreate(COUNTERPARTY).maxAutomaticTokenAssociations(plentyOfSlots),
+						newKeyNamed(MULTI_KEY),
+						getAccountInfo(PARTY).savingSnapshot(PARTY),
+						getAccountInfo(COUNTERPARTY).savingSnapshot(COUNTERPARTY),
+						getAccountInfo(firstRoyaltyCollector).savingSnapshot(firstRoyaltyCollector),
+						getAccountInfo(secondRoyaltyCollector)
+								.savingSnapshot(secondRoyaltyCollector))
+				.when(
+						tokenCreate(firstFungible)
+								.treasury(TOKEN_TREASURY)
+								.tokenType(FUNGIBLE_COMMON)
+								.initialSupply(123456789),
+						tokenCreate(secondFungible)
+								.treasury(TOKEN_TREASURY)
+								.tokenType(FUNGIBLE_COMMON)
+								.initialSupply(123456789),
+						cryptoTransfer(
+								moving(1000, firstFungible).between(TOKEN_TREASURY, COUNTERPARTY),
+								moving(1000, secondFungible).between(TOKEN_TREASURY, COUNTERPARTY)),
+						tokenCreate(uniqueWithRoyalty)
+								.tokenType(NON_FUNGIBLE_UNIQUE)
+								.treasury(TOKEN_TREASURY)
+								.supplyKey(MULTI_KEY)
+								.withCustom(royaltyFeeNoFallback(1, 12, firstRoyaltyCollector))
+								.withCustom(royaltyFeeNoFallback(1, 15, secondRoyaltyCollector))
+								.initialSupply(0L),
+						mintToken(uniqueWithRoyalty, List.of(copyFromUtf8("HODL"))),
+						cryptoTransfer(
+								movingUnique(uniqueWithRoyalty, 1L).between(TOKEN_TREASURY, PARTY)))
+				.then(
+						cryptoTransfer(
+								movingUnique(uniqueWithRoyalty, 1L)
+										.between(PARTY, COUNTERPARTY),
+								moving(12 * 15L, firstFungible)
+										.between(COUNTERPARTY, PARTY),
+								moving(12 * 15L, secondFungible)
+										.between(COUNTERPARTY, PARTY))
+								.fee(ONE_HBAR)
+								.via(HODL_XFER),
+						getTxnRecord(HODL_XFER)
+								.hasPriority(
+										recordWith()
+												.autoAssociated(
+														accountTokenPairsInAnyOrder(
+																List.of(
+																		/* The counterparty auto-associates to the
+																		non-fungible type */
+																		Pair.of(
+																				COUNTERPARTY,
+																				uniqueWithRoyalty),
+																		/* The sending party auto-associates to both
+																		fungibles */
+																		Pair.of(
+																				PARTY,
+																				firstFungible),
+																		Pair.of(
+																				PARTY,
+																				secondFungible),
+																		/* Both royalty collectors auto-associate to
+																		both fungibles */
+																		Pair.of(
+																				firstRoyaltyCollector,
+																				firstFungible),
+																		Pair.of(
+																				secondRoyaltyCollector,
+																				firstFungible),
+																		Pair.of(
+																				firstRoyaltyCollector,
+																				secondFungible),
+																		Pair.of(
+																				secondRoyaltyCollector,
+																				secondFungible))))),
+						getAccountInfo(PARTY)
+								.has(
+										accountWith()
+												.newAssociationsFromSnapshot(
+														PARTY,
+														List.of(
+																relationshipWith(uniqueWithRoyalty)
+																		.balance(0),
+																relationshipWith(firstFungible)
+																		.balance(netExchangeAmount),
+																relationshipWith(secondFungible)
+																		.balance(
+																				netExchangeAmount)))),
+						getAccountInfo(COUNTERPARTY)
+								.has(
+										accountWith()
+												.newAssociationsFromSnapshot(
+														PARTY,
+														List.of(
+																relationshipWith(uniqueWithRoyalty)
+																		.balance(1),
+																relationshipWith(firstFungible)
+																		.balance(
+																				1000L
+																						- exchangeAmount),
+																relationshipWith(secondFungible)
+																		.balance(
+																				1000L
+																						- exchangeAmount)))),
+						getAccountInfo(firstRoyaltyCollector)
+								.has(
+										accountWith()
+												.newAssociationsFromSnapshot(
+														PARTY,
+														List.of(
+																relationshipWith(firstFungible)
+																		.balance(
+																				exchangeAmount
+																						/ 12),
+																relationshipWith(secondFungible)
+																		.balance(
+																				exchangeAmount
+																						/ 12)))),
+						getAccountInfo(secondRoyaltyCollector)
+								.has(
+										accountWith()
+												.newAssociationsFromSnapshot(
+														PARTY,
+														List.of(
+																relationshipWith(firstFungible)
+																		.balance(
+																				exchangeAmount
+																						/ 15),
+																relationshipWith(secondFungible)
+																		.balance(
+																				exchangeAmount
+																						/ 15)))));
+	}
 
-        return defaultHapiSpec("RoyaltyCollectorsCanUseAutoAssociationWithoutOpenSlots")
-                .given(
-                        cryptoCreate(TOKEN_TREASURY),
-                        cryptoCreate(royaltyCollectorNoSlots),
-                        cryptoCreate(party).maxAutomaticTokenAssociations(123),
-                        cryptoCreate(counterparty).maxAutomaticTokenAssociations(123),
-                        newKeyNamed(multipurpose),
-                        getAccountInfo(party).savingSnapshot(party),
-                        getAccountInfo(counterparty).savingSnapshot(counterparty),
-                        getAccountInfo(royaltyCollectorNoSlots)
-                                .savingSnapshot(royaltyCollectorNoSlots))
-                .when(
-                        tokenCreate(someFungible)
-                                .treasury(TOKEN_TREASURY)
-                                .tokenType(FUNGIBLE_COMMON)
-                                .initialSupply(123456789),
-                        cryptoTransfer(
-                                moving(1000, someFungible).between(TOKEN_TREASURY, counterparty)),
-                        tokenCreate(uniqueWithRoyalty)
-                                .tokenType(NON_FUNGIBLE_UNIQUE)
-                                .treasury(TOKEN_TREASURY)
-                                .supplyKey(multipurpose)
-                                .withCustom(royaltyFeeNoFallback(1, 12, royaltyCollectorNoSlots))
-                                .initialSupply(0L),
-                        mintToken(uniqueWithRoyalty, List.of(copyFromUtf8("HODL"))),
-                        cryptoTransfer(
-                                movingUnique(uniqueWithRoyalty, 1L).between(TOKEN_TREASURY, party)))
-                .then(
-                        cryptoTransfer(
-                                        movingUnique(uniqueWithRoyalty, 1L)
-                                                .between(party, counterparty),
-                                        moving(123, someFungible).between(counterparty, party))
-                                .fee(ONE_HBAR)
-                                .via(hodlXfer)
-                                .hasKnownStatus(TOKEN_NOT_ASSOCIATED_TO_ACCOUNT),
-                        getTxnRecord(hodlXfer)
-                                .hasPriority(
-                                        recordWith()
-                                                .autoAssociated(
-                                                        accountTokenPairsInAnyOrder(List.of()))),
-                        getAccountInfo(party)
-                                .has(
-                                        accountWith()
-                                                .newAssociationsFromSnapshot(
-                                                        party,
-                                                        List.of(
-                                                                relationshipWith(uniqueWithRoyalty)
-                                                                        .balance(1)))));
-    }
+	private HapiApiSpec royaltyCollectorsCannotUseAutoAssociationWithoutOpenSlots() {
+		final var uniqueWithRoyalty = "uniqueWithRoyalty";
+		final var someFungible = "firstFungible";
+		final var royaltyCollectorNoSlots = "royaltyCollectorNoSlots";
+		final var party = PARTY;
+		final var counterparty = COUNTERPARTY;
+		final var multipurpose = MULTI_KEY;
+		final var hodlXfer = HODL_XFER;
 
-    private HapiApiSpec autoAssociationRequiresOpenSlots() {
-        final String tokenA = "tokenA";
-        final String tokenB = "tokenB";
-        final String firstUser = "firstUser";
-        final String secondUser = "secondUser";
-        final String treasury = "treasury";
-        final String tokenAcreateTxn = "tokenACreate";
-        final String tokenBcreateTxn = "tokenBCreate";
-        final String transferToFU = "transferToFU";
-        final String transferToSU = "transferToSU";
+		return defaultHapiSpec("RoyaltyCollectorsCanUseAutoAssociationWithoutOpenSlots")
+				.given(
+						cryptoCreate(TOKEN_TREASURY),
+						cryptoCreate(royaltyCollectorNoSlots),
+						cryptoCreate(party).maxAutomaticTokenAssociations(123),
+						cryptoCreate(counterparty).maxAutomaticTokenAssociations(123),
+						newKeyNamed(multipurpose),
+						getAccountInfo(party).savingSnapshot(party),
+						getAccountInfo(counterparty).savingSnapshot(counterparty),
+						getAccountInfo(royaltyCollectorNoSlots)
+								.savingSnapshot(royaltyCollectorNoSlots))
+				.when(
+						tokenCreate(someFungible)
+								.treasury(TOKEN_TREASURY)
+								.tokenType(FUNGIBLE_COMMON)
+								.initialSupply(123456789),
+						cryptoTransfer(
+								moving(1000, someFungible).between(TOKEN_TREASURY, counterparty)),
+						tokenCreate(uniqueWithRoyalty)
+								.tokenType(NON_FUNGIBLE_UNIQUE)
+								.treasury(TOKEN_TREASURY)
+								.supplyKey(multipurpose)
+								.withCustom(royaltyFeeNoFallback(1, 12, royaltyCollectorNoSlots))
+								.initialSupply(0L),
+						mintToken(uniqueWithRoyalty, List.of(copyFromUtf8("HODL"))),
+						cryptoTransfer(
+								movingUnique(uniqueWithRoyalty, 1L).between(TOKEN_TREASURY, party)))
+				.then(
+						cryptoTransfer(
+								movingUnique(uniqueWithRoyalty, 1L)
+										.between(party, counterparty),
+								moving(123, someFungible).between(counterparty, party))
+								.fee(ONE_HBAR)
+								.via(hodlXfer)
+								.hasKnownStatus(TOKEN_NOT_ASSOCIATED_TO_ACCOUNT),
+						getTxnRecord(hodlXfer)
+								.hasPriority(
+										recordWith()
+												.autoAssociated(
+														accountTokenPairsInAnyOrder(List.of()))),
+						getAccountInfo(party)
+								.has(
+										accountWith()
+												.newAssociationsFromSnapshot(
+														party,
+														List.of(
+																relationshipWith(uniqueWithRoyalty)
+																		.balance(1)))));
+	}
 
-        return defaultHapiSpec("AutoAssociationRequiresOpenSlots")
-                .given(
-                        cryptoCreate(treasury).balance(ONE_HUNDRED_HBARS),
-                        cryptoCreate(firstUser).balance(ONE_HBAR).maxAutomaticTokenAssociations(1),
-                        cryptoCreate(secondUser).balance(ONE_HBAR).maxAutomaticTokenAssociations(2))
-                .when(
-                        tokenCreate(tokenA)
-                                .tokenType(TokenType.FUNGIBLE_COMMON)
-                                .initialSupply(Long.MAX_VALUE)
-                                .treasury(treasury)
-                                .via(tokenAcreateTxn),
-                        getTxnRecord(tokenAcreateTxn)
-                                .hasNewTokenAssociation(tokenA, treasury)
-                                .logged(),
-                        tokenCreate(tokenB)
-                                .tokenType(TokenType.FUNGIBLE_COMMON)
-                                .initialSupply(Long.MAX_VALUE)
-                                .treasury(treasury)
-                                .via(tokenBcreateTxn),
-                        getTxnRecord(tokenBcreateTxn)
-                                .hasNewTokenAssociation(tokenB, treasury)
-                                .logged(),
-                        cryptoTransfer(moving(1, tokenA).between(treasury, firstUser))
-                                .via(transferToFU),
-                        getTxnRecord(transferToFU)
-                                .hasNewTokenAssociation(tokenA, firstUser)
-                                .logged(),
-                        cryptoTransfer(moving(1, tokenB).between(treasury, secondUser))
-                                .via(transferToSU),
-                        getTxnRecord(transferToSU)
-                                .hasNewTokenAssociation(tokenB, secondUser)
-                                .logged())
-                .then(
-                        cryptoTransfer(moving(1, tokenB).between(treasury, firstUser))
-                                .hasKnownStatus(NO_REMAINING_AUTOMATIC_ASSOCIATIONS)
-                                .via("failedTransfer"),
-                        getAccountInfo(firstUser)
-                                .hasAlreadyUsedAutomaticAssociations(1)
-                                .hasMaxAutomaticAssociations(1)
-                                .logged(),
-                        getAccountInfo(secondUser)
-                                .hasAlreadyUsedAutomaticAssociations(1)
-                                .hasMaxAutomaticAssociations(2)
-                                .logged(),
-                        cryptoTransfer(moving(1, tokenA).between(treasury, secondUser)),
-                        getAccountInfo(secondUser)
-                                .hasAlreadyUsedAutomaticAssociations(2)
-                                .hasMaxAutomaticAssociations(2)
-                                .logged(),
-                        cryptoTransfer(moving(1, tokenA).between(firstUser, treasury)),
-                        tokenDissociate(firstUser, tokenA),
-                        cryptoTransfer(moving(1, tokenB).between(treasury, firstUser)));
-    }
+	private HapiApiSpec autoAssociationRequiresOpenSlots() {
+		final String tokenA = "tokenA";
+		final String tokenB = "tokenB";
+		final String firstUser = "firstUser";
+		final String secondUser = "secondUser";
+		final String treasury = "treasury";
+		final String tokenAcreateTxn = "tokenACreate";
+		final String tokenBcreateTxn = "tokenBCreate";
+		final String transferToFU = "transferToFU";
+		final String transferToSU = "transferToSU";
 
-    private HapiApiSpec baseCryptoTransferFeeChargedAsExpected() {
-        final var expectedHbarXferPriceUsd = 0.0001;
-        final var expectedHtsXferPriceUsd = 0.001;
-        final var expectedNftXferPriceUsd = 0.001;
-        final var expectedHtsXferWithCustomFeePriceUsd = 0.002;
-        final var expectedNftXferWithCustomFeePriceUsd = 0.002;
-        final var transferAmount = 1L;
-        final var customFeeCollector = "customFeeCollector";
-        final var nonTreasurySender = "nonTreasurySender";
-        final var hbarXferTxn = "hbarXferTxn";
-        final var fungibleToken = "fungibleToken";
-        final var fungibleTokenWithCustomFee = "fungibleTokenWithCustomFee";
-        final var htsXferTxn = "htsXferTxn";
-        final var htsXferTxnWithCustomFee = "htsXferTxnWithCustomFee";
-        final var nonFungibleToken = "nonFungibleToken";
-        final var nonFungibleTokenWithCustomFee = "nonFungibleTokenWithCustomFee";
-        final var nftXferTxn = "nftXferTxn";
-        final var nftXferTxnWithCustomFee = "nftXferTxnWithCustomFee";
+		return defaultHapiSpec("AutoAssociationRequiresOpenSlots")
+				.given(
+						cryptoCreate(treasury).balance(ONE_HUNDRED_HBARS),
+						cryptoCreate(firstUser).balance(ONE_HBAR).maxAutomaticTokenAssociations(1),
+						cryptoCreate(secondUser).balance(ONE_HBAR).maxAutomaticTokenAssociations(2))
+				.when(
+						tokenCreate(tokenA)
+								.tokenType(TokenType.FUNGIBLE_COMMON)
+								.initialSupply(Long.MAX_VALUE)
+								.treasury(treasury)
+								.via(tokenAcreateTxn),
+						getTxnRecord(tokenAcreateTxn)
+								.hasNewTokenAssociation(tokenA, treasury)
+								.logged(),
+						tokenCreate(tokenB)
+								.tokenType(TokenType.FUNGIBLE_COMMON)
+								.initialSupply(Long.MAX_VALUE)
+								.treasury(treasury)
+								.via(tokenBcreateTxn),
+						getTxnRecord(tokenBcreateTxn)
+								.hasNewTokenAssociation(tokenB, treasury)
+								.logged(),
+						cryptoTransfer(moving(1, tokenA).between(treasury, firstUser))
+								.via(transferToFU),
+						getTxnRecord(transferToFU)
+								.hasNewTokenAssociation(tokenA, firstUser)
+								.logged(),
+						cryptoTransfer(moving(1, tokenB).between(treasury, secondUser))
+								.via(transferToSU),
+						getTxnRecord(transferToSU)
+								.hasNewTokenAssociation(tokenB, secondUser)
+								.logged())
+				.then(
+						cryptoTransfer(moving(1, tokenB).between(treasury, firstUser))
+								.hasKnownStatus(NO_REMAINING_AUTOMATIC_ASSOCIATIONS)
+								.via("failedTransfer"),
+						getAccountInfo(firstUser)
+								.hasAlreadyUsedAutomaticAssociations(1)
+								.hasMaxAutomaticAssociations(1)
+								.logged(),
+						getAccountInfo(secondUser)
+								.hasAlreadyUsedAutomaticAssociations(1)
+								.hasMaxAutomaticAssociations(2)
+								.logged(),
+						cryptoTransfer(moving(1, tokenA).between(treasury, secondUser)),
+						getAccountInfo(secondUser)
+								.hasAlreadyUsedAutomaticAssociations(2)
+								.hasMaxAutomaticAssociations(2)
+								.logged(),
+						cryptoTransfer(moving(1, tokenA).between(firstUser, treasury)),
+						tokenDissociate(firstUser, tokenA),
+						cryptoTransfer(moving(1, tokenB).between(treasury, firstUser)));
+	}
 
-        return defaultHapiSpec("BaseCryptoTransferIsChargedAsExpected")
-                .given(
-                        cryptoCreate(nonTreasurySender).balance(ONE_HUNDRED_HBARS),
-                        cryptoCreate(SENDER).balance(ONE_HUNDRED_HBARS),
-                        cryptoCreate(RECEIVER),
-                        cryptoCreate(customFeeCollector),
-                        tokenCreate(fungibleToken)
-                                .treasury(SENDER)
-                                .tokenType(FUNGIBLE_COMMON)
-                                .initialSupply(100L),
-                        tokenCreate(fungibleTokenWithCustomFee)
-                                .treasury(SENDER)
-                                .tokenType(FUNGIBLE_COMMON)
-                                .withCustom(fixedHbarFee(transferAmount, customFeeCollector))
-                                .initialSupply(100L),
-                        tokenAssociate(RECEIVER, fungibleToken, fungibleTokenWithCustomFee),
-                        newKeyNamed(SUPPLY_KEY),
-                        tokenCreate(nonFungibleToken)
-                                .initialSupply(0)
-                                .supplyKey(SUPPLY_KEY)
-                                .tokenType(NON_FUNGIBLE_UNIQUE)
-                                .treasury(SENDER),
-                        tokenCreate(nonFungibleTokenWithCustomFee)
-                                .initialSupply(0)
-                                .supplyKey(SUPPLY_KEY)
-                                .tokenType(NON_FUNGIBLE_UNIQUE)
-                                .withCustom(fixedHbarFee(transferAmount, customFeeCollector))
-                                .treasury(SENDER),
-                        tokenAssociate(
-                                nonTreasurySender,
-                                List.of(fungibleTokenWithCustomFee, nonFungibleTokenWithCustomFee)),
-                        mintToken(nonFungibleToken, List.of(copyFromUtf8("memo1"))),
-                        mintToken(nonFungibleTokenWithCustomFee, List.of(copyFromUtf8("memo2"))),
-                        tokenAssociate(RECEIVER, nonFungibleToken, nonFungibleTokenWithCustomFee),
-                        cryptoTransfer(
-                                        movingUnique(nonFungibleTokenWithCustomFee, 1)
-                                                .between(SENDER, nonTreasurySender))
-                                .payingWith(SENDER),
-                        cryptoTransfer(
-                                        moving(1, fungibleTokenWithCustomFee)
-                                                .between(SENDER, nonTreasurySender))
-                                .payingWith(SENDER))
-                .when(
-                        cryptoTransfer(tinyBarsFromTo(SENDER, RECEIVER, 100L))
-                                .payingWith(SENDER)
-                                .blankMemo()
-                                .via(hbarXferTxn),
-                        cryptoTransfer(moving(1, fungibleToken).between(SENDER, RECEIVER))
-                                .blankMemo()
-                                .payingWith(SENDER)
-                                .via(htsXferTxn),
-                        cryptoTransfer(movingUnique(nonFungibleToken, 1).between(SENDER, RECEIVER))
-                                .blankMemo()
-                                .payingWith(SENDER)
-                                .via(nftXferTxn),
-                        cryptoTransfer(
-                                        moving(1, fungibleTokenWithCustomFee)
-                                                .between(nonTreasurySender, RECEIVER))
-                                .blankMemo()
-                                .fee(ONE_HBAR)
-                                .payingWith(nonTreasurySender)
-                                .via(htsXferTxnWithCustomFee),
-                        cryptoTransfer(
-                                        movingUnique(nonFungibleTokenWithCustomFee, 1)
-                                                .between(nonTreasurySender, RECEIVER))
-                                .blankMemo()
-                                .fee(ONE_HBAR)
-                                .payingWith(nonTreasurySender)
-                                .via(nftXferTxnWithCustomFee))
-                .then(
-                        validateChargedUsdWithin(hbarXferTxn, expectedHbarXferPriceUsd, 0.01),
-                        validateChargedUsdWithin(htsXferTxn, expectedHtsXferPriceUsd, 0.01),
-                        validateChargedUsdWithin(nftXferTxn, expectedNftXferPriceUsd, 0.01),
-                        validateChargedUsdWithin(
-                                htsXferTxnWithCustomFee, expectedHtsXferWithCustomFeePriceUsd, 0.1),
-                        validateChargedUsdWithin(
-                                nftXferTxnWithCustomFee,
-                                expectedNftXferWithCustomFeePriceUsd,
-                                0.3));
-    }
+	private HapiApiSpec baseCryptoTransferFeeChargedAsExpected() {
+		final var expectedHbarXferPriceUsd = 0.0001;
+		final var expectedHtsXferPriceUsd = 0.001;
+		final var expectedNftXferPriceUsd = 0.001;
+		final var expectedHtsXferWithCustomFeePriceUsd = 0.002;
+		final var expectedNftXferWithCustomFeePriceUsd = 0.002;
+		final var transferAmount = 1L;
+		final var customFeeCollector = "customFeeCollector";
+		final var nonTreasurySender = "nonTreasurySender";
+		final var hbarXferTxn = "hbarXferTxn";
+		final var fungibleToken = "fungibleToken";
+		final var fungibleTokenWithCustomFee = "fungibleTokenWithCustomFee";
+		final var htsXferTxn = "htsXferTxn";
+		final var htsXferTxnWithCustomFee = "htsXferTxnWithCustomFee";
+		final var nonFungibleToken = "nonFungibleToken";
+		final var nonFungibleTokenWithCustomFee = "nonFungibleTokenWithCustomFee";
+		final var nftXferTxn = "nftXferTxn";
+		final var nftXferTxnWithCustomFee = "nftXferTxnWithCustomFee";
 
-    private HapiApiSpec okToSetInvalidPaymentHeaderForCostAnswer() {
-        return defaultHapiSpec("OkToSetInvalidPaymentHeaderForCostAnswer")
-                .given(cryptoTransfer(tinyBarsFromTo(DEFAULT_PAYER, FUNDING, 1L)).via("misc"))
-                .when()
-                .then(
-                        getTxnRecord("misc").useEmptyTxnAsCostPayment(),
-                        getTxnRecord("misc").omittingAnyPaymentForCostAnswer());
-    }
+		return defaultHapiSpec("BaseCryptoTransferIsChargedAsExpected")
+				.given(
+						cryptoCreate(nonTreasurySender).balance(ONE_HUNDRED_HBARS),
+						cryptoCreate(SENDER).balance(ONE_HUNDRED_HBARS),
+						cryptoCreate(RECEIVER),
+						cryptoCreate(customFeeCollector),
+						tokenCreate(fungibleToken)
+								.treasury(SENDER)
+								.tokenType(FUNGIBLE_COMMON)
+								.initialSupply(100L),
+						tokenCreate(fungibleTokenWithCustomFee)
+								.treasury(SENDER)
+								.tokenType(FUNGIBLE_COMMON)
+								.withCustom(fixedHbarFee(transferAmount, customFeeCollector))
+								.initialSupply(100L),
+						tokenAssociate(RECEIVER, fungibleToken, fungibleTokenWithCustomFee),
+						newKeyNamed(SUPPLY_KEY),
+						tokenCreate(nonFungibleToken)
+								.initialSupply(0)
+								.supplyKey(SUPPLY_KEY)
+								.tokenType(NON_FUNGIBLE_UNIQUE)
+								.treasury(SENDER),
+						tokenCreate(nonFungibleTokenWithCustomFee)
+								.initialSupply(0)
+								.supplyKey(SUPPLY_KEY)
+								.tokenType(NON_FUNGIBLE_UNIQUE)
+								.withCustom(fixedHbarFee(transferAmount, customFeeCollector))
+								.treasury(SENDER),
+						tokenAssociate(
+								nonTreasurySender,
+								List.of(fungibleTokenWithCustomFee, nonFungibleTokenWithCustomFee)),
+						mintToken(nonFungibleToken, List.of(copyFromUtf8("memo1"))),
+						mintToken(nonFungibleTokenWithCustomFee, List.of(copyFromUtf8("memo2"))),
+						tokenAssociate(RECEIVER, nonFungibleToken, nonFungibleTokenWithCustomFee),
+						cryptoTransfer(
+								movingUnique(nonFungibleTokenWithCustomFee, 1)
+										.between(SENDER, nonTreasurySender))
+								.payingWith(SENDER),
+						cryptoTransfer(
+								moving(1, fungibleTokenWithCustomFee)
+										.between(SENDER, nonTreasurySender))
+								.payingWith(SENDER))
+				.when(
+						cryptoTransfer(tinyBarsFromTo(SENDER, RECEIVER, 100L))
+								.payingWith(SENDER)
+								.blankMemo()
+								.via(hbarXferTxn),
+						cryptoTransfer(moving(1, fungibleToken).between(SENDER, RECEIVER))
+								.blankMemo()
+								.payingWith(SENDER)
+								.via(htsXferTxn),
+						cryptoTransfer(movingUnique(nonFungibleToken, 1).between(SENDER, RECEIVER))
+								.blankMemo()
+								.payingWith(SENDER)
+								.via(nftXferTxn),
+						cryptoTransfer(
+								moving(1, fungibleTokenWithCustomFee)
+										.between(nonTreasurySender, RECEIVER))
+								.blankMemo()
+								.fee(ONE_HBAR)
+								.payingWith(nonTreasurySender)
+								.via(htsXferTxnWithCustomFee),
+						cryptoTransfer(
+								movingUnique(nonFungibleTokenWithCustomFee, 1)
+										.between(nonTreasurySender, RECEIVER))
+								.blankMemo()
+								.fee(ONE_HBAR)
+								.payingWith(nonTreasurySender)
+								.via(nftXferTxnWithCustomFee))
+				.then(
+						validateChargedUsdWithin(hbarXferTxn, expectedHbarXferPriceUsd, 0.01),
+						validateChargedUsdWithin(htsXferTxn, expectedHtsXferPriceUsd, 0.01),
+						validateChargedUsdWithin(nftXferTxn, expectedNftXferPriceUsd, 0.01),
+						validateChargedUsdWithin(
+								htsXferTxnWithCustomFee, expectedHtsXferWithCustomFeePriceUsd, 0.1),
+						validateChargedUsdWithin(
+								nftXferTxnWithCustomFee,
+								expectedNftXferWithCustomFeePriceUsd,
+								0.3));
+	}
 
-    @SuppressWarnings("java:S5960")
-    private HapiApiSpec tokenTransferFeesScaleAsExpected() {
-        return defaultHapiSpec("TokenTransferFeesScaleAsExpected")
-                .given(
-                        cryptoCreate("a"),
-                        cryptoCreate("b"),
-                        cryptoCreate("c").balance(0L),
-                        cryptoCreate("d").balance(0L),
-                        cryptoCreate("e").balance(0L),
-                        cryptoCreate("f").balance(0L),
-                        tokenCreate("A").treasury("a"),
-                        tokenCreate("B").treasury("b"),
-                        tokenCreate("C").treasury("c"))
-                .when(
-                        tokenAssociate("b", "A", "C"),
-                        tokenAssociate("c", "A", "B"),
-                        tokenAssociate("d", "A", "B", "C"),
-                        tokenAssociate("e", "A", "B", "C"),
-                        tokenAssociate("f", "A", "B", "C"),
-                        cryptoTransfer(tinyBarsFromTo("a", "b", 1))
-                                .via("pureCrypto")
-                                .fee(ONE_HUNDRED_HBARS)
-                                .payingWith("a"),
-                        cryptoTransfer(moving(1, "A").between("a", "b"))
-                                .via("oneTokenTwoAccounts")
-                                .fee(ONE_HUNDRED_HBARS)
-                                .payingWith("a"),
-                        cryptoTransfer(moving(2, "A").distributing("a", "b", "c"))
-                                .via("oneTokenThreeAccounts")
-                                .fee(ONE_HUNDRED_HBARS)
-                                .payingWith("a"),
-                        cryptoTransfer(moving(3, "A").distributing("a", "b", "c", "d"))
-                                .via("oneTokenFourAccounts")
-                                .fee(ONE_HUNDRED_HBARS)
-                                .payingWith("a"),
-                        cryptoTransfer(moving(4, "A").distributing("a", "b", "c", "d", "e"))
-                                .via("oneTokenFiveAccounts")
-                                .fee(ONE_HUNDRED_HBARS)
-                                .payingWith("a"),
-                        cryptoTransfer(moving(5, "A").distributing("a", "b", "c", "d", "e", "f"))
-                                .via("oneTokenSixAccounts")
-                                .fee(ONE_HUNDRED_HBARS)
-                                .payingWith("a"),
-                        cryptoTransfer(
-                                        moving(1, "A").between("a", "c"),
-                                        moving(1, "B").between("b", "d"))
-                                .via("twoTokensFourAccounts")
-                                .fee(ONE_HUNDRED_HBARS)
-                                .payingWith("a"),
-                        cryptoTransfer(
-                                        moving(1, "A").between("a", "c"),
-                                        moving(2, "B").distributing("b", "d", "e"))
-                                .via("twoTokensFiveAccounts")
-                                .fee(ONE_HUNDRED_HBARS)
-                                .payingWith("a"),
-                        cryptoTransfer(
-                                        moving(1, "A").between("a", "c"),
-                                        moving(3, "B").distributing("b", "d", "e", "f"))
-                                .via("twoTokensSixAccounts")
-                                .fee(ONE_HUNDRED_HBARS)
-                                .payingWith("a"),
-                        cryptoTransfer(
-                                        moving(1, "A").between("a", "d"),
-                                        moving(1, "B").between("b", "e"),
-                                        moving(1, "C").between("c", "f"))
-                                .via("threeTokensSixAccounts")
-                                .fee(ONE_HUNDRED_HBARS)
-                                .payingWith("a"))
-                .then(
-                        withOpContext(
-                                (spec, opLog) -> {
-                                    var ref = getTxnRecord("pureCrypto");
-                                    var t1a2 = getTxnRecord("oneTokenTwoAccounts");
-                                    var t1a3 = getTxnRecord("oneTokenThreeAccounts");
-                                    var t1a4 = getTxnRecord("oneTokenFourAccounts");
-                                    var t1a5 = getTxnRecord("oneTokenFiveAccounts");
-                                    var t1a6 = getTxnRecord("oneTokenSixAccounts");
-                                    var t2a4 = getTxnRecord("twoTokensFourAccounts");
-                                    var t2a5 = getTxnRecord("twoTokensFiveAccounts");
-                                    var t2a6 = getTxnRecord("twoTokensSixAccounts");
-                                    var t3a6 = getTxnRecord("threeTokensSixAccounts");
-                                    allRunFor(
-                                            spec, ref, t1a2, t1a3, t1a4, t1a5, t1a6, t2a4, t2a5,
-                                            t2a6, t3a6);
+	private HapiApiSpec okToSetInvalidPaymentHeaderForCostAnswer() {
+		return defaultHapiSpec("OkToSetInvalidPaymentHeaderForCostAnswer")
+				.given(cryptoTransfer(tinyBarsFromTo(DEFAULT_PAYER, FUNDING, 1L)).via("misc"))
+				.when()
+				.then(
+						getTxnRecord("misc").useEmptyTxnAsCostPayment(),
+						getTxnRecord("misc").omittingAnyPaymentForCostAnswer());
+	}
 
-                                    var refFee = ref.getResponseRecord().getTransactionFee();
-                                    var t1a2Fee = t1a2.getResponseRecord().getTransactionFee();
-                                    var t1a3Fee = t1a3.getResponseRecord().getTransactionFee();
-                                    var t1a4Fee = t1a4.getResponseRecord().getTransactionFee();
-                                    var t1a5Fee = t1a5.getResponseRecord().getTransactionFee();
-                                    var t1a6Fee = t1a6.getResponseRecord().getTransactionFee();
-                                    var t2a4Fee = t2a4.getResponseRecord().getTransactionFee();
-                                    var t2a5Fee = t2a5.getResponseRecord().getTransactionFee();
-                                    var t2a6Fee = t2a6.getResponseRecord().getTransactionFee();
-                                    var t3a6Fee = t3a6.getResponseRecord().getTransactionFee();
+	@SuppressWarnings("java:S5960")
+	private HapiApiSpec tokenTransferFeesScaleAsExpected() {
+		return defaultHapiSpec("TokenTransferFeesScaleAsExpected")
+				.given(
+						cryptoCreate("a"),
+						cryptoCreate("b"),
+						cryptoCreate("c").balance(0L),
+						cryptoCreate("d").balance(0L),
+						cryptoCreate("e").balance(0L),
+						cryptoCreate("f").balance(0L),
+						tokenCreate("A").treasury("a"),
+						tokenCreate("B").treasury("b"),
+						tokenCreate("C").treasury("c"))
+				.when(
+						tokenAssociate("b", "A", "C"),
+						tokenAssociate("c", "A", "B"),
+						tokenAssociate("d", "A", "B", "C"),
+						tokenAssociate("e", "A", "B", "C"),
+						tokenAssociate("f", "A", "B", "C"),
+						cryptoTransfer(tinyBarsFromTo("a", "b", 1))
+								.via("pureCrypto")
+								.fee(ONE_HUNDRED_HBARS)
+								.payingWith("a"),
+						cryptoTransfer(moving(1, "A").between("a", "b"))
+								.via("oneTokenTwoAccounts")
+								.fee(ONE_HUNDRED_HBARS)
+								.payingWith("a"),
+						cryptoTransfer(moving(2, "A").distributing("a", "b", "c"))
+								.via("oneTokenThreeAccounts")
+								.fee(ONE_HUNDRED_HBARS)
+								.payingWith("a"),
+						cryptoTransfer(moving(3, "A").distributing("a", "b", "c", "d"))
+								.via("oneTokenFourAccounts")
+								.fee(ONE_HUNDRED_HBARS)
+								.payingWith("a"),
+						cryptoTransfer(moving(4, "A").distributing("a", "b", "c", "d", "e"))
+								.via("oneTokenFiveAccounts")
+								.fee(ONE_HUNDRED_HBARS)
+								.payingWith("a"),
+						cryptoTransfer(moving(5, "A").distributing("a", "b", "c", "d", "e", "f"))
+								.via("oneTokenSixAccounts")
+								.fee(ONE_HUNDRED_HBARS)
+								.payingWith("a"),
+						cryptoTransfer(
+								moving(1, "A").between("a", "c"),
+								moving(1, "B").between("b", "d"))
+								.via("twoTokensFourAccounts")
+								.fee(ONE_HUNDRED_HBARS)
+								.payingWith("a"),
+						cryptoTransfer(
+								moving(1, "A").between("a", "c"),
+								moving(2, "B").distributing("b", "d", "e"))
+								.via("twoTokensFiveAccounts")
+								.fee(ONE_HUNDRED_HBARS)
+								.payingWith("a"),
+						cryptoTransfer(
+								moving(1, "A").between("a", "c"),
+								moving(3, "B").distributing("b", "d", "e", "f"))
+								.via("twoTokensSixAccounts")
+								.fee(ONE_HUNDRED_HBARS)
+								.payingWith("a"),
+						cryptoTransfer(
+								moving(1, "A").between("a", "d"),
+								moving(1, "B").between("b", "e"),
+								moving(1, "C").between("c", "f"))
+								.via("threeTokensSixAccounts")
+								.fee(ONE_HUNDRED_HBARS)
+								.payingWith("a"))
+				.then(
+						withOpContext(
+								(spec, opLog) -> {
+									var ref = getTxnRecord("pureCrypto");
+									var t1a2 = getTxnRecord("oneTokenTwoAccounts");
+									var t1a3 = getTxnRecord("oneTokenThreeAccounts");
+									var t1a4 = getTxnRecord("oneTokenFourAccounts");
+									var t1a5 = getTxnRecord("oneTokenFiveAccounts");
+									var t1a6 = getTxnRecord("oneTokenSixAccounts");
+									var t2a4 = getTxnRecord("twoTokensFourAccounts");
+									var t2a5 = getTxnRecord("twoTokensFiveAccounts");
+									var t2a6 = getTxnRecord("twoTokensSixAccounts");
+									var t3a6 = getTxnRecord("threeTokensSixAccounts");
+									allRunFor(
+											spec, ref, t1a2, t1a3, t1a4, t1a5, t1a6, t2a4, t2a5,
+											t2a6, t3a6);
 
-                                    var rates = spec.ratesProvider();
-                                    opLog.info(
-                                            TOKENS_INVOLVED_LOG_MESSAGE,
-                                            refFee,
-                                            sdec(rates.toUsdWithActiveRates(refFee), 4),
-                                            t1a2Fee,
-                                            sdec(rates.toUsdWithActiveRates(t1a2Fee), 4),
-                                            sdec((1.0 * t1a2Fee / refFee), 1),
-                                            t1a3Fee,
-                                            sdec(rates.toUsdWithActiveRates(t1a3Fee), 4),
-                                            sdec((1.0 * t1a3Fee / refFee), 1),
-                                            t1a4Fee,
-                                            sdec(rates.toUsdWithActiveRates(t1a4Fee), 4),
-                                            sdec((1.0 * t1a4Fee / refFee), 1),
-                                            t1a5Fee,
-                                            sdec(rates.toUsdWithActiveRates(t1a5Fee), 4),
-                                            sdec((1.0 * t1a5Fee / refFee), 1),
-                                            t1a6Fee,
-                                            sdec(rates.toUsdWithActiveRates(t1a6Fee), 4),
-                                            sdec((1.0 * t1a6Fee / refFee), 1),
-                                            t2a4Fee,
-                                            sdec(rates.toUsdWithActiveRates(t2a4Fee), 4),
-                                            sdec((1.0 * t2a4Fee / refFee), 1),
-                                            t2a5Fee,
-                                            sdec(rates.toUsdWithActiveRates(t2a5Fee), 4),
-                                            sdec((1.0 * t2a5Fee / refFee), 1),
-                                            t2a6Fee,
-                                            sdec(rates.toUsdWithActiveRates(t2a6Fee), 4),
-                                            sdec((1.0 * t2a6Fee / refFee), 1),
-                                            t3a6Fee,
-                                            sdec(rates.toUsdWithActiveRates(t3a6Fee), 4),
-                                            sdec((1.0 * t3a6Fee / refFee), 1));
+									var refFee = ref.getResponseRecord().getTransactionFee();
+									var t1a2Fee = t1a2.getResponseRecord().getTransactionFee();
+									var t1a3Fee = t1a3.getResponseRecord().getTransactionFee();
+									var t1a4Fee = t1a4.getResponseRecord().getTransactionFee();
+									var t1a5Fee = t1a5.getResponseRecord().getTransactionFee();
+									var t1a6Fee = t1a6.getResponseRecord().getTransactionFee();
+									var t2a4Fee = t2a4.getResponseRecord().getTransactionFee();
+									var t2a5Fee = t2a5.getResponseRecord().getTransactionFee();
+									var t2a6Fee = t2a6.getResponseRecord().getTransactionFee();
+									var t3a6Fee = t3a6.getResponseRecord().getTransactionFee();
 
-                                    double pureHbarUsd = rates.toUsdWithActiveRates(refFee);
-                                    double pureOneTokenTwoAccountsUsd =
-                                            rates.toUsdWithActiveRates(t1a2Fee);
-                                    double pureTwoTokensFourAccountsUsd =
-                                            rates.toUsdWithActiveRates(t2a4Fee);
-                                    double pureThreeTokensSixAccountsUsd =
-                                            rates.toUsdWithActiveRates(t3a6Fee);
-                                    assertEquals(
-                                            10.0, pureOneTokenTwoAccountsUsd / pureHbarUsd, 1.0);
-                                    assertEquals(
-                                            20.0, pureTwoTokensFourAccountsUsd / pureHbarUsd, 2.0);
-                                    assertEquals(
-                                            30.0, pureThreeTokensSixAccountsUsd / pureHbarUsd, 3.0);
-                                }));
-    }
+									var rates = spec.ratesProvider();
+									opLog.info(
+											TOKENS_INVOLVED_LOG_MESSAGE,
+											refFee,
+											sdec(rates.toUsdWithActiveRates(refFee), 4),
+											t1a2Fee,
+											sdec(rates.toUsdWithActiveRates(t1a2Fee), 4),
+											sdec((1.0 * t1a2Fee / refFee), 1),
+											t1a3Fee,
+											sdec(rates.toUsdWithActiveRates(t1a3Fee), 4),
+											sdec((1.0 * t1a3Fee / refFee), 1),
+											t1a4Fee,
+											sdec(rates.toUsdWithActiveRates(t1a4Fee), 4),
+											sdec((1.0 * t1a4Fee / refFee), 1),
+											t1a5Fee,
+											sdec(rates.toUsdWithActiveRates(t1a5Fee), 4),
+											sdec((1.0 * t1a5Fee / refFee), 1),
+											t1a6Fee,
+											sdec(rates.toUsdWithActiveRates(t1a6Fee), 4),
+											sdec((1.0 * t1a6Fee / refFee), 1),
+											t2a4Fee,
+											sdec(rates.toUsdWithActiveRates(t2a4Fee), 4),
+											sdec((1.0 * t2a4Fee / refFee), 1),
+											t2a5Fee,
+											sdec(rates.toUsdWithActiveRates(t2a5Fee), 4),
+											sdec((1.0 * t2a5Fee / refFee), 1),
+											t2a6Fee,
+											sdec(rates.toUsdWithActiveRates(t2a6Fee), 4),
+											sdec((1.0 * t2a6Fee / refFee), 1),
+											t3a6Fee,
+											sdec(rates.toUsdWithActiveRates(t3a6Fee), 4),
+											sdec((1.0 * t3a6Fee / refFee), 1));
 
-    public static String sdec(double d, int numDecimals) {
-        var fmt = "%" + String.format(".0%df", numDecimals);
-        return String.format(fmt, d);
-    }
+									double pureHbarUsd = rates.toUsdWithActiveRates(refFee);
+									double pureOneTokenTwoAccountsUsd =
+											rates.toUsdWithActiveRates(t1a2Fee);
+									double pureTwoTokensFourAccountsUsd =
+											rates.toUsdWithActiveRates(t2a4Fee);
+									double pureThreeTokensSixAccountsUsd =
+											rates.toUsdWithActiveRates(t3a6Fee);
+									assertEquals(
+											10.0, pureOneTokenTwoAccountsUsd / pureHbarUsd, 1.0);
+									assertEquals(
+											20.0, pureTwoTokensFourAccountsUsd / pureHbarUsd, 2.0);
+									assertEquals(
+											30.0, pureThreeTokensSixAccountsUsd / pureHbarUsd, 3.0);
+								}));
+	}
 
-    private HapiApiSpec transferToNonAccountEntitiesReturnsInvalidAccountId() {
-        AtomicReference<String> invalidAccountId = new AtomicReference<>();
+	public static String sdec(double d, int numDecimals) {
+		var fmt = "%" + String.format(".0%df", numDecimals);
+		return String.format(fmt, d);
+	}
 
-        return defaultHapiSpec("TransferToNonAccountEntitiesReturnsInvalidAccountId")
-                .given(
-                        tokenCreate(TOKEN),
-                        createTopic("something"),
-                        withOpContext(
-                                (spec, opLog) -> {
-                                    var topicId = spec.registry().getTopicID("something");
-                                    invalidAccountId.set(asTopicString(topicId));
-                                }))
-                .when()
-                .then(
-                        sourcing(
-                                () ->
-                                        cryptoTransfer(
-                                                        tinyBarsFromTo(
-                                                                DEFAULT_PAYER,
-                                                                invalidAccountId.get(),
-                                                                1L))
-                                                .signedBy(DEFAULT_PAYER)
-                                                .hasKnownStatus(INVALID_ACCOUNT_ID)),
-                        sourcing(
-                                () ->
-                                        cryptoTransfer(
-                                                        moving(1, TOKEN)
-                                                                .between(
-                                                                        DEFAULT_PAYER,
-                                                                        invalidAccountId.get()))
-                                                .signedBy(DEFAULT_PAYER)
-                                                .hasKnownStatus(INVALID_ACCOUNT_ID)));
-    }
+	private HapiApiSpec transferToNonAccountEntitiesReturnsInvalidAccountId() {
+		AtomicReference<String> invalidAccountId = new AtomicReference<>();
 
-    private HapiApiSpec complexKeyAcctPaysForOwnTransfer() {
-        SigControl enoughUniqueSigs =
-                SigControl.threshSigs(
-                        2,
-                        SigControl.threshSigs(1, OFF, OFF, OFF, OFF, OFF, OFF, ON),
-                        SigControl.threshSigs(3, ON, ON, ON, OFF, OFF, OFF, OFF));
-        String node = HapiSpecSetup.getDefaultInstance().defaultNodeName();
+		return defaultHapiSpec("TransferToNonAccountEntitiesReturnsInvalidAccountId")
+				.given(
+						tokenCreate(TOKEN),
+						createTopic("something"),
+						withOpContext(
+								(spec, opLog) -> {
+									var topicId = spec.registry().getTopicID("something");
+									invalidAccountId.set(asTopicString(topicId));
+								}))
+				.when()
+				.then(
+						sourcing(
+								() ->
+										cryptoTransfer(
+												tinyBarsFromTo(
+														DEFAULT_PAYER,
+														invalidAccountId.get(),
+														1L))
+												.signedBy(DEFAULT_PAYER)
+												.hasKnownStatus(INVALID_ACCOUNT_ID)),
+						sourcing(
+								() ->
+										cryptoTransfer(
+												moving(1, TOKEN)
+														.between(
+																DEFAULT_PAYER,
+																invalidAccountId.get()))
+												.signedBy(DEFAULT_PAYER)
+												.hasKnownStatus(INVALID_ACCOUNT_ID)));
+	}
 
-        return defaultHapiSpec("ComplexKeyAcctPaysForOwnTransfer")
-                .given(
-                        newKeyNamed("complexKey").shape(enoughUniqueSigs),
-                        cryptoCreate(PAYER).key("complexKey").balance(1_000_000_000L))
-                .when()
-                .then(
-                        cryptoTransfer(tinyBarsFromTo(PAYER, node, 1_000_000L))
-                                .payingWith(PAYER)
-                                .numPayerSigs(14)
-                                .fee(ONE_HUNDRED_HBARS));
-    }
+	private HapiApiSpec complexKeyAcctPaysForOwnTransfer() {
+		SigControl enoughUniqueSigs =
+				SigControl.threshSigs(
+						2,
+						SigControl.threshSigs(1, OFF, OFF, OFF, OFF, OFF, OFF, ON),
+						SigControl.threshSigs(3, ON, ON, ON, OFF, OFF, OFF, OFF));
+		String node = HapiSpecSetup.getDefaultInstance().defaultNodeName();
 
-    private HapiApiSpec twoComplexKeysRequired() {
-        SigControl payerShape = threshOf(2, threshOf(1, 7), threshOf(3, 7));
-        SigControl receiverShape = SigControl.threshSigs(3, threshOf(2, 2), threshOf(3, 5), ON);
+		return defaultHapiSpec("ComplexKeyAcctPaysForOwnTransfer")
+				.given(
+						newKeyNamed("complexKey").shape(enoughUniqueSigs),
+						cryptoCreate(PAYER).key("complexKey").balance(1_000_000_000L))
+				.when()
+				.then(
+						cryptoTransfer(tinyBarsFromTo(PAYER, node, 1_000_000L))
+								.payingWith(PAYER)
+								.numPayerSigs(14)
+								.fee(ONE_HUNDRED_HBARS));
+	}
 
-        SigControl payerSigs =
-                SigControl.threshSigs(
-                        2,
-                        SigControl.threshSigs(1, ON, OFF, OFF, OFF, OFF, OFF, OFF),
-                        SigControl.threshSigs(3, ON, ON, ON, OFF, OFF, OFF, OFF));
-        SigControl receiverSigs =
-                SigControl.threshSigs(
-                        3,
-                        SigControl.threshSigs(2, ON, ON),
-                        SigControl.threshSigs(3, OFF, OFF, ON, ON, ON),
-                        ON);
+	private HapiApiSpec twoComplexKeysRequired() {
+		SigControl payerShape = threshOf(2, threshOf(1, 7), threshOf(3, 7));
+		SigControl receiverShape = SigControl.threshSigs(3, threshOf(2, 2), threshOf(3, 5), ON);
 
-        return defaultHapiSpec("TwoComplexKeysRequired")
-                .given(
-                        newKeyNamed("payerKey").shape(payerShape),
-                        newKeyNamed("receiverKey").shape(receiverShape),
-                        cryptoCreate(PAYER).key("payerKey").balance(100_000_000_000L),
-                        cryptoCreate(RECEIVER)
-                                .receiverSigRequired(true)
-                                .key("receiverKey")
-                                .payingWith(PAYER))
-                .when()
-                .then(
-                        cryptoTransfer(tinyBarsFromTo(GENESIS, RECEIVER, 1_000L))
-                                .payingWith(PAYER)
-                                .sigControl(
-                                        forKey(PAYER, payerSigs), forKey(RECEIVER, receiverSigs))
-                                .hasKnownStatus(SUCCESS)
-                                .fee(ONE_HUNDRED_HBARS));
-    }
+		SigControl payerSigs =
+				SigControl.threshSigs(
+						2,
+						SigControl.threshSigs(1, ON, OFF, OFF, OFF, OFF, OFF, OFF),
+						SigControl.threshSigs(3, ON, ON, ON, OFF, OFF, OFF, OFF));
+		SigControl receiverSigs =
+				SigControl.threshSigs(
+						3,
+						SigControl.threshSigs(2, ON, ON),
+						SigControl.threshSigs(3, OFF, OFF, ON, ON, ON),
+						ON);
 
-    private HapiApiSpec specialAccountsBalanceCheck() {
-        return defaultHapiSpec("SpecialAccountsBalanceCheck")
-                .given()
-                .when()
-                .then(
-                        IntStream.concat(IntStream.range(1, 101), IntStream.range(900, 1001))
-                                .mapToObj(i -> getAccountBalance("0.0." + i).logged())
-                                .toArray(HapiSpecOperation[]::new));
-    }
+		return defaultHapiSpec("TwoComplexKeysRequired")
+				.given(
+						newKeyNamed("payerKey").shape(payerShape),
+						newKeyNamed("receiverKey").shape(receiverShape),
+						cryptoCreate(PAYER).key("payerKey").balance(100_000_000_000L),
+						cryptoCreate(RECEIVER)
+								.receiverSigRequired(true)
+								.key("receiverKey")
+								.payingWith(PAYER))
+				.when()
+				.then(
+						cryptoTransfer(tinyBarsFromTo(GENESIS, RECEIVER, 1_000L))
+								.payingWith(PAYER)
+								.sigControl(
+										forKey(PAYER, payerSigs), forKey(RECEIVER, receiverSigs))
+								.hasKnownStatus(SUCCESS)
+								.fee(ONE_HUNDRED_HBARS));
+	}
 
-    private HapiApiSpec transferWithMissingAccountGetsInvalidAccountId() {
-        return defaultHapiSpec("TransferWithMissingAccount")
-                .given(cryptoCreate(PAYEE_SIG_REQ).receiverSigRequired(true))
-                .when(
-                        cryptoTransfer(tinyBarsFromTo("1.2.3", PAYEE_SIG_REQ, 1_000L))
-                                .signedBy(DEFAULT_PAYER, PAYEE_SIG_REQ)
-                                .hasKnownStatus(INVALID_ACCOUNT_ID))
-                .then();
-    }
+	private HapiApiSpec specialAccountsBalanceCheck() {
+		return defaultHapiSpec("SpecialAccountsBalanceCheck")
+				.given()
+				.when()
+				.then(
+						IntStream.concat(IntStream.range(1, 101), IntStream.range(900, 1001))
+								.mapToObj(i -> getAccountBalance("0.0." + i).logged())
+								.toArray(HapiSpecOperation[]::new));
+	}
 
-    private HapiApiSpec vanillaTransferSucceeds() {
-        long initialBalance = HapiSpecSetup.getDefaultInstance().defaultBalance();
+	private HapiApiSpec transferWithMissingAccountGetsInvalidAccountId() {
+		return defaultHapiSpec("TransferWithMissingAccount")
+				.given(cryptoCreate(PAYEE_SIG_REQ).receiverSigRequired(true))
+				.when(
+						cryptoTransfer(tinyBarsFromTo("1.2.3", PAYEE_SIG_REQ, 1_000L))
+								.signedBy(DEFAULT_PAYER, PAYEE_SIG_REQ)
+								.hasKnownStatus(INVALID_ACCOUNT_ID))
+				.then();
+	}
 
-        return defaultHapiSpec("VanillaTransferSucceeds")
-                .given(
-                        UtilVerbs.inParallel(
-                                cryptoCreate(PAYER),
-                                cryptoCreate(PAYEE_SIG_REQ).receiverSigRequired(true),
-                                cryptoCreate(PAYEE_NO_SIG_REQ)))
-                .when(
-                        cryptoTransfer(
-                                        tinyBarsFromTo(PAYER, PAYEE_SIG_REQ, 1_000L),
-                                        tinyBarsFromTo(PAYER, PAYEE_NO_SIG_REQ, 2_000L))
-                                .via("transferTxn"))
-                .then(
-                        getAccountInfo(PAYER)
-                                .logged()
-                                .hasExpectedLedgerId("0x03")
-                                .has(accountWith().balance(initialBalance - 3_000L)),
-                        getAccountInfo(PAYEE_SIG_REQ)
-                                .has(accountWith().balance(initialBalance + 1_000L)),
-                        getAccountDetails(PAYEE_NO_SIG_REQ)
-                                .payingWith(GENESIS)
-                                .has(
-                                        AccountDetailsAsserts.accountWith()
-                                                .balance(initialBalance + 2_000L)
-                                                .noAllowances()));
-    }
+	private HapiApiSpec vanillaTransferSucceeds() {
+		long initialBalance = HapiSpecSetup.getDefaultInstance().defaultBalance();
 
-    @Override
-    protected Logger getResultsLogger() {
-        return LOG;
-    }
+		return defaultHapiSpec("VanillaTransferSucceeds")
+				.given(
+						UtilVerbs.inParallel(
+								cryptoCreate(PAYER),
+								cryptoCreate(PAYEE_SIG_REQ).receiverSigRequired(true),
+								cryptoCreate(PAYEE_NO_SIG_REQ)))
+				.when(
+						cryptoTransfer(
+								tinyBarsFromTo(PAYER, PAYEE_SIG_REQ, 1_000L),
+								tinyBarsFromTo(PAYER, PAYEE_NO_SIG_REQ, 2_000L))
+								.via("transferTxn"))
+				.then(
+						getAccountInfo(PAYER)
+								.logged()
+								.hasExpectedLedgerId("0x03")
+								.has(accountWith().balance(initialBalance - 3_000L)),
+						getAccountInfo(PAYEE_SIG_REQ)
+								.has(accountWith().balance(initialBalance + 1_000L)),
+						getAccountDetails(PAYEE_NO_SIG_REQ)
+								.payingWith(GENESIS)
+								.has(
+										AccountDetailsAsserts.accountWith()
+												.balance(initialBalance + 2_000L)
+												.noAllowances()));
+	}
+
+	@Override
+	protected Logger getResultsLogger() {
+		return LOG;
+	}
 }

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoTransferSuite.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoTransferSuite.java
@@ -15,30 +15,6 @@
  */
 package com.hedera.services.bdd.suites.crypto;
 
-import com.google.protobuf.ByteString;
-import com.hedera.services.bdd.spec.HapiApiSpec;
-import com.hedera.services.bdd.spec.HapiSpecOperation;
-import com.hedera.services.bdd.spec.HapiSpecSetup;
-import com.hedera.services.bdd.spec.assertions.AccountDetailsAsserts;
-import com.hedera.services.bdd.spec.keys.SigControl;
-import com.hedera.services.bdd.spec.utilops.UtilVerbs;
-import com.hedera.services.bdd.suites.HapiApiSuite;
-import com.hederahashgraph.api.proto.java.AccountID;
-import com.hederahashgraph.api.proto.java.TokenID;
-import com.hederahashgraph.api.proto.java.TokenSupplyType;
-import com.hederahashgraph.api.proto.java.TokenTransferList;
-import com.hederahashgraph.api.proto.java.TokenType;
-import com.hederahashgraph.api.proto.java.TransferList;
-import org.apache.commons.lang3.tuple.Pair;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-
-import java.util.List;
-import java.util.Map;
-import java.util.OptionalLong;
-import java.util.concurrent.atomic.AtomicReference;
-import java.util.stream.IntStream;
-
 import static com.google.protobuf.ByteString.copyFromUtf8;
 import static com.hedera.services.bdd.spec.HapiApiSpec.defaultHapiSpec;
 import static com.hedera.services.bdd.spec.HapiPropertySource.accountIdFromHexedMirrorAddress;
@@ -47,7 +23,6 @@ import static com.hedera.services.bdd.spec.HapiPropertySource.asSolidityAddress;
 import static com.hedera.services.bdd.spec.HapiPropertySource.asTopicString;
 import static com.hedera.services.bdd.spec.assertions.AccountInfoAsserts.accountWith;
 import static com.hedera.services.bdd.spec.assertions.AutoAssocAsserts.accountTokenPairsInAnyOrder;
-import static com.hedera.services.bdd.spec.assertions.ContractInfoAsserts.contractWith;
 import static com.hedera.services.bdd.spec.assertions.TransactionRecordAsserts.includingFungibleMovement;
 import static com.hedera.services.bdd.spec.assertions.TransactionRecordAsserts.includingNonfungibleMovement;
 import static com.hedera.services.bdd.spec.assertions.TransactionRecordAsserts.recordWith;
@@ -65,8 +40,6 @@ import static com.hedera.services.bdd.spec.queries.QueryVerbs.getTxnRecord;
 import static com.hedera.services.bdd.spec.queries.crypto.ExpectedTokenRel.relationshipWith;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.contractCall;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.contractCreate;
-import static com.hedera.services.bdd.spec.transactions.TxnVerbs.contractUpdate;
-import static com.hedera.services.bdd.spec.transactions.TxnVerbs.createDefaultContract;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.createTopic;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoApproveAllowance;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoCreate;
@@ -135,2012 +108,2006 @@ import static com.hederahashgraph.api.proto.java.TokenType.NON_FUNGIBLE_UNIQUE;
 import static com.swirlds.common.utility.CommonUtils.unhex;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import com.google.protobuf.ByteString;
+import com.hedera.services.bdd.spec.HapiApiSpec;
+import com.hedera.services.bdd.spec.HapiSpecOperation;
+import com.hedera.services.bdd.spec.HapiSpecSetup;
+import com.hedera.services.bdd.spec.assertions.AccountDetailsAsserts;
+import com.hedera.services.bdd.spec.keys.SigControl;
+import com.hedera.services.bdd.spec.utilops.UtilVerbs;
+import com.hedera.services.bdd.suites.HapiApiSuite;
+import com.hederahashgraph.api.proto.java.AccountID;
+import com.hederahashgraph.api.proto.java.TokenID;
+import com.hederahashgraph.api.proto.java.TokenSupplyType;
+import com.hederahashgraph.api.proto.java.TokenTransferList;
+import com.hederahashgraph.api.proto.java.TokenType;
+import com.hederahashgraph.api.proto.java.TransferList;
+import java.util.List;
+import java.util.Map;
+import java.util.OptionalLong;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.IntStream;
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 public class CryptoTransferSuite extends HapiApiSuite {
 
-	private static final Logger LOG = LogManager.getLogger(CryptoTransferSuite.class);
-	private static final String OWNER = "owner";
-	private static final String OTHER_OWNER = "otherOwner";
-	private static final String SPENDER = "spender";
-	private static final String PAYER = "payer";
-	private static final String SENDER = "sender";
-	private static final String RECEIVER = "receiver";
-	private static final String OTHER_RECEIVER = "otherReceiver";
-	private static final String ANOTHER_RECEIVER = "anotherReceiver";
-	private static final String FUNGIBLE_TOKEN = "fungible";
-	private static final String NON_FUNGIBLE_TOKEN = "nonFungible";
-	private static final String TOKEN_WITH_CUSTOM_FEE = "tokenWithCustomFee";
-	private static final String ADMIN_KEY = "adminKey";
-	private static final String KYC_KEY = "kycKey";
-	private static final String FREEZE_KEY = "freezeKey";
-	private static final String SUPPLY_KEY = "supplyKey";
-	private static final String WIPE_KEY = "wipeKey";
-	private static final String PAUSE_KEY = "pauseKey";
-	private static final String PARTY = "party";
-	private static final String COUNTERPARTY = "counterparty";
-	private static final String MULTI_KEY = "multi";
-	private static final String NOT_TO_BE = "notToBe";
-	private static final String TOKEN = "token";
-	private static final String OWNING_PARTY = "owningParty";
-	private static final String VALID_TXN = "validTxn";
-	private static final String UNCHECKED_TXN = "uncheckedTxn";
-	private static final String PAYEE_SIG_REQ = "payeeSigReq";
-	private static final String TOKENS_INVOLVED_LOG_MESSAGE =
-			"""
-					0 tokens involved,
-					  2 account adjustments: {} tb, ${}"
-					1 tokens involved,
-					  2 account adjustments: {} tb, ${} (~{}x pure crypto)
-					  3 account adjustments: {} tb, ${} (~{}x pure crypto)
-					  4 account adjustments: {} tb, ${} (~{}x pure crypto)
-					  5 account adjustments: {} tb, ${} (~{}x pure crypto)
-					  6 account adjustments: {} tb, ${} (~{}x pure crypto)
-					2 tokens involved,
-					  4 account adjustments: {} tb, ${} (~{}x pure crypto)
-					  5 account adjustments: {} tb, ${} (~{}x pure crypto)
-					  6 account adjustments: {} tb, ${} (~{}x pure crypto)
-					3 tokens involved,
-					  6 account adjustments: {} tb, ${} (~{}x pure crypto)
-					                                                          """;
-	public static final String HODL_XFER = "hodlXfer";
-	public static final String PAYEE_NO_SIG_REQ = "payeeNoSigReq";
+    private static final Logger LOG = LogManager.getLogger(CryptoTransferSuite.class);
+    private static final String OWNER = "owner";
+    private static final String OTHER_OWNER = "otherOwner";
+    private static final String SPENDER = "spender";
+    private static final String PAYER = "payer";
+    private static final String SENDER = "sender";
+    private static final String RECEIVER = "receiver";
+    private static final String OTHER_RECEIVER = "otherReceiver";
+    private static final String ANOTHER_RECEIVER = "anotherReceiver";
+    private static final String FUNGIBLE_TOKEN = "fungible";
+    private static final String NON_FUNGIBLE_TOKEN = "nonFungible";
+    private static final String TOKEN_WITH_CUSTOM_FEE = "tokenWithCustomFee";
+    private static final String ADMIN_KEY = "adminKey";
+    private static final String KYC_KEY = "kycKey";
+    private static final String FREEZE_KEY = "freezeKey";
+    private static final String SUPPLY_KEY = "supplyKey";
+    private static final String WIPE_KEY = "wipeKey";
+    private static final String PAUSE_KEY = "pauseKey";
+    private static final String PARTY = "party";
+    private static final String COUNTERPARTY = "counterparty";
+    private static final String MULTI_KEY = "multi";
+    private static final String NOT_TO_BE = "notToBe";
+    private static final String TOKEN = "token";
+    private static final String OWNING_PARTY = "owningParty";
+    private static final String VALID_TXN = "validTxn";
+    private static final String UNCHECKED_TXN = "uncheckedTxn";
+    private static final String PAYEE_SIG_REQ = "payeeSigReq";
+    private static final String TOKENS_INVOLVED_LOG_MESSAGE =
+            """
+0 tokens involved,
+  2 account adjustments: {} tb, ${}"
+1 tokens involved,
+  2 account adjustments: {} tb, ${} (~{}x pure crypto)
+  3 account adjustments: {} tb, ${} (~{}x pure crypto)
+  4 account adjustments: {} tb, ${} (~{}x pure crypto)
+  5 account adjustments: {} tb, ${} (~{}x pure crypto)
+  6 account adjustments: {} tb, ${} (~{}x pure crypto)
+2 tokens involved,
+  4 account adjustments: {} tb, ${} (~{}x pure crypto)
+  5 account adjustments: {} tb, ${} (~{}x pure crypto)
+  6 account adjustments: {} tb, ${} (~{}x pure crypto)
+3 tokens involved,
+  6 account adjustments: {} tb, ${} (~{}x pure crypto)
+                                                          """;
+    public static final String HODL_XFER = "hodlXfer";
+    public static final String PAYEE_NO_SIG_REQ = "payeeNoSigReq";
 
-	public static void main(String... args) {
-		new CryptoTransferSuite().runSuiteAsync();
-	}
+    public static void main(String... args) {
+        new CryptoTransferSuite().runSuiteAsync();
+    }
 
-	@Override
-	public List<HapiApiSpec> getSpecsInSuite() {
-		return List.of(
-				transferWithMissingAccountGetsInvalidAccountId(),
-				vanillaTransferSucceeds(),
-				complexKeyAcctPaysForOwnTransfer(),
-				twoComplexKeysRequired(),
-				specialAccountsBalanceCheck(),
-				tokenTransferFeesScaleAsExpected(),
-				okToSetInvalidPaymentHeaderForCostAnswer(),
-				baseCryptoTransferFeeChargedAsExpected(),
-				autoAssociationRequiresOpenSlots(),
-				royaltyCollectorsCanUseAutoAssociation(),
-				royaltyCollectorsCannotUseAutoAssociationWithoutOpenSlots(),
-				dissociatedRoyaltyCollectorsCanUseAutoAssociation(),
-				hbarAndFungibleSelfTransfersRejectedBothInPrecheckAndHandle(),
-				transferToNonAccountEntitiesReturnsInvalidAccountId(),
-				nftSelfTransfersRejectedBothInPrecheckAndHandle(),
-				checksExpectedDecimalsForFungibleTokenTransferList(),
-				allowanceTransfersWorkAsExpected(),
-				allowanceTransfersWithComplexTransfersWork(),
-				canUseMirrorAliasesForNonContractXfers(),
-				canUseEip1014AliasesForXfers(),
-				cannotTransferFromImmutableAccounts(),
-				nftTransfersCannotRepeatSerialNos(),
-				noStakePeriodStartIfNotStakingToNode()
-		);
-	}
+    @Override
+    public List<HapiApiSpec> getSpecsInSuite() {
+        return List.of(
+                transferWithMissingAccountGetsInvalidAccountId(),
+                vanillaTransferSucceeds(),
+                complexKeyAcctPaysForOwnTransfer(),
+                twoComplexKeysRequired(),
+                specialAccountsBalanceCheck(),
+                tokenTransferFeesScaleAsExpected(),
+                okToSetInvalidPaymentHeaderForCostAnswer(),
+                baseCryptoTransferFeeChargedAsExpected(),
+                autoAssociationRequiresOpenSlots(),
+                royaltyCollectorsCanUseAutoAssociation(),
+                royaltyCollectorsCannotUseAutoAssociationWithoutOpenSlots(),
+                dissociatedRoyaltyCollectorsCanUseAutoAssociation(),
+                hbarAndFungibleSelfTransfersRejectedBothInPrecheckAndHandle(),
+                transferToNonAccountEntitiesReturnsInvalidAccountId(),
+                nftSelfTransfersRejectedBothInPrecheckAndHandle(),
+                checksExpectedDecimalsForFungibleTokenTransferList(),
+                allowanceTransfersWorkAsExpected(),
+                allowanceTransfersWithComplexTransfersWork(),
+                canUseMirrorAliasesForNonContractXfers(),
+                canUseEip1014AliasesForXfers(),
+                cannotTransferFromImmutableAccounts(),
+                nftTransfersCannotRepeatSerialNos());
+    }
 
-	@Override
-	public boolean canRunConcurrent() {
-		return true;
-	}
+    @Override
+    public boolean canRunConcurrent() {
+        return true;
+    }
 
-	// https://github.com/hashgraph/hedera-services/issues/2875
-	private HapiApiSpec canUseMirrorAliasesForNonContractXfers() {
-		final var fungibleToken = "fungibleToken";
-		final var nonFungibleToken = "nonFungibleToken";
-		final AtomicReference<TokenID> ftId = new AtomicReference<>();
-		final AtomicReference<TokenID> nftId = new AtomicReference<>();
-		final AtomicReference<AccountID> partyId = new AtomicReference<>();
-		final AtomicReference<AccountID> counterId = new AtomicReference<>();
-		final AtomicReference<ByteString> partyAlias = new AtomicReference<>();
-		final AtomicReference<ByteString> counterAlias = new AtomicReference<>();
-		final var hbarXfer = "hbarXfer";
-		final var nftXfer = "nftXfer";
-		final var ftXfer = "ftXfer";
+    // https://github.com/hashgraph/hedera-services/issues/2875
+    private HapiApiSpec canUseMirrorAliasesForNonContractXfers() {
+        final var fungibleToken = "fungibleToken";
+        final var nonFungibleToken = "nonFungibleToken";
+        final AtomicReference<TokenID> ftId = new AtomicReference<>();
+        final AtomicReference<TokenID> nftId = new AtomicReference<>();
+        final AtomicReference<AccountID> partyId = new AtomicReference<>();
+        final AtomicReference<AccountID> counterId = new AtomicReference<>();
+        final AtomicReference<ByteString> partyAlias = new AtomicReference<>();
+        final AtomicReference<ByteString> counterAlias = new AtomicReference<>();
+        final var hbarXfer = "hbarXfer";
+        final var nftXfer = "nftXfer";
+        final var ftXfer = "ftXfer";
 
-		return defaultHapiSpec("CanUseMirrorAliasesForNonContractXfers")
-				.given(
-						newKeyNamed(MULTI_KEY),
-						cryptoCreate(PARTY).maxAutomaticTokenAssociations(2),
-						cryptoCreate(COUNTERPARTY).maxAutomaticTokenAssociations(2),
-						tokenCreate(fungibleToken).treasury(PARTY).initialSupply(1_000_000),
-						tokenCreate(nonFungibleToken)
-								.initialSupply(0)
-								.treasury(PARTY)
-								.tokenType(NON_FUNGIBLE_UNIQUE)
-								.supplyKey(MULTI_KEY),
-						mintToken(nonFungibleToken, List.of(copyFromUtf8("Please mind the vase."))),
-						withOpContext(
-								(spec, opLog) -> {
-									final var registry = spec.registry();
-									ftId.set(registry.getTokenID(fungibleToken));
-									nftId.set(registry.getTokenID(nonFungibleToken));
-									partyId.set(registry.getAccountID(PARTY));
-									counterId.set(registry.getAccountID(COUNTERPARTY));
-									partyAlias.set(
-											ByteString.copyFrom(asSolidityAddress(partyId.get())));
-									counterAlias.set(
-											ByteString.copyFrom(
-													asSolidityAddress(counterId.get())));
-								}))
-				.when(
-						cryptoTransfer(
-								(spec, b) ->
-										b.setTransfers(
-												TransferList.newBuilder()
-														.addAccountAmounts(
-																aaWith(
-																		partyAlias.get(),
-																		-1))
-														.addAccountAmounts(
-																aaWith(partyId.get(), -1))
-														.addAccountAmounts(
-																aaWith(
-																		counterId.get(),
-																		+2))))
-								.signedBy(DEFAULT_PAYER, PARTY)
-								.hasKnownStatus(ACCOUNT_REPEATED_IN_ACCOUNT_AMOUNTS),
-						// Check signing requirements aren't distorted by aliases
-						cryptoTransfer(
-								(spec, b) ->
-										b.setTransfers(
-												TransferList.newBuilder()
-														.addAccountAmounts(
-																aaWith(
-																		partyAlias.get(),
-																		-2))
-														.addAccountAmounts(
-																aaWith(
-																		counterId.get(),
-																		+2))))
-								.signedBy(DEFAULT_PAYER)
-								.hasKnownStatus(INVALID_SIGNATURE),
-						cryptoTransfer(
-								(spec, b) ->
-										b.addTokenTransfers(
-												TokenTransferList.newBuilder()
-														.setToken(nftId.get())
-														.addNftTransfers(
-																ocWith(
-																		accountId(
-																				partyAlias
-																						.get()),
-																		counterId.get(),
-																		1L))))
-								.signedBy(DEFAULT_PAYER)
-								.hasKnownStatus(INVALID_SIGNATURE),
-						cryptoTransfer(
-								(spec, b) ->
-										b.addTokenTransfers(
-												TokenTransferList.newBuilder()
-														.setToken(ftId.get())
-														.addTransfers(
-																aaWith(
-																		partyAlias.get(),
-																		-500))
-														.addTransfers(
-																aaWith(
-																		counterAlias.get(),
-																		+500))))
-								.signedBy(DEFAULT_PAYER)
-								.hasKnownStatus(INVALID_SIGNATURE),
-						// Now do the actual transfers
-						cryptoTransfer(
-								(spec, b) ->
-										b.setTransfers(
-												TransferList.newBuilder()
-														.addAccountAmounts(
-																aaWith(
-																		partyAlias.get(),
-																		-2))
-														.addAccountAmounts(
-																aaWith(
-																		counterAlias.get(),
-																		+2))))
-								.signedBy(DEFAULT_PAYER, PARTY)
-								.via(hbarXfer),
-						cryptoTransfer(
-								(spec, b) ->
-										b.addTokenTransfers(
-												TokenTransferList.newBuilder()
-														.setToken(nftId.get())
-														.addNftTransfers(
-																ocWith(
-																		accountId(
-																				partyAlias
-																						.get()),
-																		accountId(
-																				counterAlias
-																						.get()),
-																		1L))))
-								.signedBy(DEFAULT_PAYER, PARTY)
-								.via(nftXfer),
-						cryptoTransfer(
-								(spec, b) ->
-										b.addTokenTransfers(
-												TokenTransferList.newBuilder()
-														.setToken(ftId.get())
-														.addTransfers(
-																aaWith(
-																		partyAlias.get(),
-																		-500))
-														.addTransfers(
-																aaWith(
-																		counterAlias.get(),
-																		+500))))
-								.signedBy(DEFAULT_PAYER, PARTY)
-								.via(ftXfer))
-				.then(
-						getTxnRecord(hbarXfer).logged(),
-						getTxnRecord(nftXfer).logged(),
-						getTxnRecord(ftXfer).logged());
-	}
+        return defaultHapiSpec("CanUseMirrorAliasesForNonContractXfers")
+                .given(
+                        newKeyNamed(MULTI_KEY),
+                        cryptoCreate(PARTY).maxAutomaticTokenAssociations(2),
+                        cryptoCreate(COUNTERPARTY).maxAutomaticTokenAssociations(2),
+                        tokenCreate(fungibleToken).treasury(PARTY).initialSupply(1_000_000),
+                        tokenCreate(nonFungibleToken)
+                                .initialSupply(0)
+                                .treasury(PARTY)
+                                .tokenType(NON_FUNGIBLE_UNIQUE)
+                                .supplyKey(MULTI_KEY),
+                        mintToken(nonFungibleToken, List.of(copyFromUtf8("Please mind the vase."))),
+                        withOpContext(
+                                (spec, opLog) -> {
+                                    final var registry = spec.registry();
+                                    ftId.set(registry.getTokenID(fungibleToken));
+                                    nftId.set(registry.getTokenID(nonFungibleToken));
+                                    partyId.set(registry.getAccountID(PARTY));
+                                    counterId.set(registry.getAccountID(COUNTERPARTY));
+                                    partyAlias.set(
+                                            ByteString.copyFrom(asSolidityAddress(partyId.get())));
+                                    counterAlias.set(
+                                            ByteString.copyFrom(
+                                                    asSolidityAddress(counterId.get())));
+                                }))
+                .when(
+                        cryptoTransfer(
+                                        (spec, b) ->
+                                                b.setTransfers(
+                                                        TransferList.newBuilder()
+                                                                .addAccountAmounts(
+                                                                        aaWith(
+                                                                                partyAlias.get(),
+                                                                                -1))
+                                                                .addAccountAmounts(
+                                                                        aaWith(partyId.get(), -1))
+                                                                .addAccountAmounts(
+                                                                        aaWith(
+                                                                                counterId.get(),
+                                                                                +2))))
+                                .signedBy(DEFAULT_PAYER, PARTY)
+                                .hasKnownStatus(ACCOUNT_REPEATED_IN_ACCOUNT_AMOUNTS),
+                        // Check signing requirements aren't distorted by aliases
+                        cryptoTransfer(
+                                        (spec, b) ->
+                                                b.setTransfers(
+                                                        TransferList.newBuilder()
+                                                                .addAccountAmounts(
+                                                                        aaWith(
+                                                                                partyAlias.get(),
+                                                                                -2))
+                                                                .addAccountAmounts(
+                                                                        aaWith(
+                                                                                counterId.get(),
+                                                                                +2))))
+                                .signedBy(DEFAULT_PAYER)
+                                .hasKnownStatus(INVALID_SIGNATURE),
+                        cryptoTransfer(
+                                        (spec, b) ->
+                                                b.addTokenTransfers(
+                                                        TokenTransferList.newBuilder()
+                                                                .setToken(nftId.get())
+                                                                .addNftTransfers(
+                                                                        ocWith(
+                                                                                accountId(
+                                                                                        partyAlias
+                                                                                                .get()),
+                                                                                counterId.get(),
+                                                                                1L))))
+                                .signedBy(DEFAULT_PAYER)
+                                .hasKnownStatus(INVALID_SIGNATURE),
+                        cryptoTransfer(
+                                        (spec, b) ->
+                                                b.addTokenTransfers(
+                                                        TokenTransferList.newBuilder()
+                                                                .setToken(ftId.get())
+                                                                .addTransfers(
+                                                                        aaWith(
+                                                                                partyAlias.get(),
+                                                                                -500))
+                                                                .addTransfers(
+                                                                        aaWith(
+                                                                                counterAlias.get(),
+                                                                                +500))))
+                                .signedBy(DEFAULT_PAYER)
+                                .hasKnownStatus(INVALID_SIGNATURE),
+                        // Now do the actual transfers
+                        cryptoTransfer(
+                                        (spec, b) ->
+                                                b.setTransfers(
+                                                        TransferList.newBuilder()
+                                                                .addAccountAmounts(
+                                                                        aaWith(
+                                                                                partyAlias.get(),
+                                                                                -2))
+                                                                .addAccountAmounts(
+                                                                        aaWith(
+                                                                                counterAlias.get(),
+                                                                                +2))))
+                                .signedBy(DEFAULT_PAYER, PARTY)
+                                .via(hbarXfer),
+                        cryptoTransfer(
+                                        (spec, b) ->
+                                                b.addTokenTransfers(
+                                                        TokenTransferList.newBuilder()
+                                                                .setToken(nftId.get())
+                                                                .addNftTransfers(
+                                                                        ocWith(
+                                                                                accountId(
+                                                                                        partyAlias
+                                                                                                .get()),
+                                                                                accountId(
+                                                                                        counterAlias
+                                                                                                .get()),
+                                                                                1L))))
+                                .signedBy(DEFAULT_PAYER, PARTY)
+                                .via(nftXfer),
+                        cryptoTransfer(
+                                        (spec, b) ->
+                                                b.addTokenTransfers(
+                                                        TokenTransferList.newBuilder()
+                                                                .setToken(ftId.get())
+                                                                .addTransfers(
+                                                                        aaWith(
+                                                                                partyAlias.get(),
+                                                                                -500))
+                                                                .addTransfers(
+                                                                        aaWith(
+                                                                                counterAlias.get(),
+                                                                                +500))))
+                                .signedBy(DEFAULT_PAYER, PARTY)
+                                .via(ftXfer))
+                .then(
+                        getTxnRecord(hbarXfer).logged(),
+                        getTxnRecord(nftXfer).logged(),
+                        getTxnRecord(ftXfer).logged());
+    }
 
-	@SuppressWarnings("java:S5669")
-	private HapiApiSpec canUseEip1014AliasesForXfers() {
-		final var partyCreation2 = "partyCreation2";
-		final var counterCreation2 = "counterCreation2";
-		final var contract = "CreateDonor";
+    @SuppressWarnings("java:S5669")
+    private HapiApiSpec canUseEip1014AliasesForXfers() {
+        final var partyCreation2 = "partyCreation2";
+        final var counterCreation2 = "counterCreation2";
+        final var contract = "CreateDonor";
 
-		final AtomicReference<String> partyAliasAddr = new AtomicReference<>();
-		final AtomicReference<String> partyMirrorAddr = new AtomicReference<>();
-		final AtomicReference<String> counterAliasAddr = new AtomicReference<>();
-		final AtomicReference<String> counterMirrorAddr = new AtomicReference<>();
-		final AtomicReference<TokenID> ftId = new AtomicReference<>();
-		final AtomicReference<TokenID> nftId = new AtomicReference<>();
-		final AtomicReference<String> partyLiteral = new AtomicReference<>();
-		final AtomicReference<AccountID> partyId = new AtomicReference<>();
-		final AtomicReference<String> counterLiteral = new AtomicReference<>();
-		final AtomicReference<AccountID> counterId = new AtomicReference<>();
-		final var hbarXfer = "hbarXfer";
-		final var nftXfer = "nftXfer";
-		final var ftXfer = "ftXfer";
+        final AtomicReference<String> partyAliasAddr = new AtomicReference<>();
+        final AtomicReference<String> partyMirrorAddr = new AtomicReference<>();
+        final AtomicReference<String> counterAliasAddr = new AtomicReference<>();
+        final AtomicReference<String> counterMirrorAddr = new AtomicReference<>();
+        final AtomicReference<TokenID> ftId = new AtomicReference<>();
+        final AtomicReference<TokenID> nftId = new AtomicReference<>();
+        final AtomicReference<String> partyLiteral = new AtomicReference<>();
+        final AtomicReference<AccountID> partyId = new AtomicReference<>();
+        final AtomicReference<String> counterLiteral = new AtomicReference<>();
+        final AtomicReference<AccountID> counterId = new AtomicReference<>();
+        final var hbarXfer = "hbarXfer";
+        final var nftXfer = "nftXfer";
+        final var ftXfer = "ftXfer";
 
-		final byte[] salt =
-				unhex("aabbccddeeff0011aabbccddeeff0011aabbccddeeff0011aabbccddeeff0011");
-		final byte[] otherSalt =
-				unhex("aabbccddee880011aabbccddee880011aabbccddee880011aabbccddee880011");
+        final byte[] salt =
+                unhex("aabbccddeeff0011aabbccddeeff0011aabbccddeeff0011aabbccddeeff0011");
+        final byte[] otherSalt =
+                unhex("aabbccddee880011aabbccddee880011aabbccddee880011aabbccddee880011");
 
-		return defaultHapiSpec("CanUseEip1014AliasesForXfers")
-				.given(
-						newKeyNamed(MULTI_KEY),
-						cryptoCreate(TOKEN_TREASURY),
-						uploadInitCode(contract),
-						contractCreate(contract).adminKey(MULTI_KEY).payingWith(GENESIS),
-						contractCall(contract, "buildDonor", salt)
-								.sending(1000)
-								.payingWith(GENESIS)
-								.gas(2_000_000L)
-								.via(partyCreation2),
-						captureOneChildCreate2MetaFor(
-								PARTY, partyCreation2, partyMirrorAddr, partyAliasAddr),
-						contractCall(contract, "buildDonor", otherSalt)
-								.sending(1000)
-								.payingWith(GENESIS)
-								.gas(2_000_000L)
-								.via(counterCreation2),
-						captureOneChildCreate2MetaFor(
-								COUNTERPARTY,
-								counterCreation2,
-								counterMirrorAddr,
-								counterAliasAddr),
-						tokenCreate(FUNGIBLE_TOKEN)
-								.treasury(TOKEN_TREASURY)
-								.initialSupply(1_000_000),
-						tokenCreate(NON_FUNGIBLE_TOKEN)
-								.treasury(TOKEN_TREASURY)
-								.initialSupply(0)
-								.tokenType(NON_FUNGIBLE_UNIQUE)
-								.supplyKey(MULTI_KEY),
-						mintToken(
-								NON_FUNGIBLE_TOKEN, List.of(copyFromUtf8("Please mind the vase."))),
-						withOpContext(
-								(spec, opLog) -> {
-									final var registry = spec.registry();
-									ftId.set(registry.getTokenID(FUNGIBLE_TOKEN));
-									nftId.set(registry.getTokenID(NON_FUNGIBLE_TOKEN));
-									partyId.set(
-											accountIdFromHexedMirrorAddress(partyMirrorAddr.get()));
-									partyLiteral.set(asAccountString(partyId.get()));
-									counterId.set(
-											accountIdFromHexedMirrorAddress(
-													counterMirrorAddr.get()));
-									counterLiteral.set(asAccountString(counterId.get()));
-								}))
-				.when(
-						sourcing(
-								() ->
-										tokenAssociate(
-												partyLiteral.get(),
-												List.of(FUNGIBLE_TOKEN, NON_FUNGIBLE_TOKEN))
-												.signedBy(DEFAULT_PAYER, MULTI_KEY)),
-						sourcing(
-								() ->
-										tokenAssociate(
-												counterLiteral.get(),
-												List.of(FUNGIBLE_TOKEN, NON_FUNGIBLE_TOKEN))
-												.signedBy(DEFAULT_PAYER, MULTI_KEY)),
-						sourcing(() -> getContractInfo(partyLiteral.get()).logged()),
-						sourcing(
-								() ->
-										cryptoTransfer(
-												moving(500_000, FUNGIBLE_TOKEN)
-														.between(
-																TOKEN_TREASURY,
-																partyLiteral.get()),
-												movingUnique(NON_FUNGIBLE_TOKEN, 1L)
-														.between(
-																TOKEN_TREASURY,
-																partyLiteral.get()))
-												.signedBy(DEFAULT_PAYER, TOKEN_TREASURY)),
-						cryptoTransfer(
-								(spec, b) ->
-										b.setTransfers(
-												TransferList.newBuilder()
-														.addAccountAmounts(
-																aaWith(
-																		partyAliasAddr
-																				.get(),
-																		-1))
-														.addAccountAmounts(
-																aaWith(partyId.get(), -1))
-														.addAccountAmounts(
-																aaWith(
-																		counterId.get(),
-																		+2))))
-								.signedBy(DEFAULT_PAYER, MULTI_KEY)
-								.hasKnownStatus(ACCOUNT_REPEATED_IN_ACCOUNT_AMOUNTS),
-						// Check signing requirements aren't distorted by aliases
-						cryptoTransfer(
-								(spec, b) ->
-										b.setTransfers(
-												TransferList.newBuilder()
-														.addAccountAmounts(
-																aaWith(
-																		partyAliasAddr
-																				.get(),
-																		-2))
-														.addAccountAmounts(
-																aaWith(
-																		counterAliasAddr
-																				.get(),
-																		+2))))
-								.signedBy(DEFAULT_PAYER)
-								.hasKnownStatus(INVALID_SIGNATURE),
-						cryptoTransfer(
-								(spec, b) ->
-										b.addTokenTransfers(
-												TokenTransferList.newBuilder()
-														.setToken(nftId.get())
-														.addNftTransfers(
-																ocWith(
-																		accountId(
-																				partyAliasAddr
-																						.get()),
-																		counterId.get(),
-																		1L))))
-								.signedBy(DEFAULT_PAYER)
-								.hasKnownStatus(INVALID_SIGNATURE),
-						cryptoTransfer(
-								(spec, b) ->
-										b.addTokenTransfers(
-												TokenTransferList.newBuilder()
-														.setToken(ftId.get())
-														.addTransfers(
-																aaWith(
-																		partyAliasAddr
-																				.get(),
-																		-500))
-														.addTransfers(
-																aaWith(
-																		counterAliasAddr
-																				.get(),
-																		+500))))
-								.signedBy(DEFAULT_PAYER)
-								.hasKnownStatus(INVALID_SIGNATURE),
-						// Now do the actual transfers
-						cryptoTransfer(
-								(spec, b) ->
-										b.setTransfers(
-												TransferList.newBuilder()
-														.addAccountAmounts(
-																aaWith(
-																		partyAliasAddr
-																				.get(),
-																		-2))
-														.addAccountAmounts(
-																aaWith(
-																		counterAliasAddr
-																				.get(),
-																		+2))))
-								.signedBy(DEFAULT_PAYER, MULTI_KEY)
-								.via(hbarXfer),
-						cryptoTransfer(
-								(spec, b) ->
-										b.addTokenTransfers(
-												TokenTransferList.newBuilder()
-														.setToken(nftId.get())
-														.addNftTransfers(
-																ocWith(
-																		accountId(
-																				partyAliasAddr
-																						.get()),
-																		accountId(
-																				counterAliasAddr
-																						.get()),
-																		1L))))
-								.signedBy(DEFAULT_PAYER, MULTI_KEY)
-								.via(nftXfer),
-						cryptoTransfer(
-								(spec, b) ->
-										b.addTokenTransfers(
-												TokenTransferList.newBuilder()
-														.setToken(ftId.get())
-														.addTransfers(
-																aaWith(
-																		partyAliasAddr
-																				.get(),
-																		-500))
-														.addTransfers(
-																aaWith(
-																		counterAliasAddr
-																				.get(),
-																		+500))))
-								.signedBy(DEFAULT_PAYER, MULTI_KEY)
-								.via(ftXfer))
-				.then(
-						sourcing(
-								() ->
-										getTxnRecord(hbarXfer)
-												.hasPriority(
-														recordWith()
-																.transfers(
-																		including(
-																				tinyBarsFromTo(
-																						partyLiteral
-																								.get(),
-																						counterLiteral
-																								.get(),
-																						2))))),
-						sourcing(
-								() ->
-										getTxnRecord(nftXfer)
-												.hasPriority(
-														recordWith()
-																.tokenTransfers(
-																		includingNonfungibleMovement(
-																				movingUnique(
-																						NON_FUNGIBLE_TOKEN,
-																						1L)
-																						.between(
-																								partyLiteral
-																										.get(),
-																								counterLiteral
-																										.get()))))),
-						sourcing(
-								() ->
-										getTxnRecord(ftXfer)
-												.hasPriority(
-														recordWith()
-																.tokenTransfers(
-																		includingFungibleMovement(
-																				moving(
-																						500,
-																						FUNGIBLE_TOKEN)
-																						.between(
-																								partyLiteral
-																										.get(),
-																								counterLiteral
-																										.get()))))));
-	}
+        return defaultHapiSpec("CanUseEip1014AliasesForXfers")
+                .given(
+                        newKeyNamed(MULTI_KEY),
+                        cryptoCreate(TOKEN_TREASURY),
+                        uploadInitCode(contract),
+                        contractCreate(contract).adminKey(MULTI_KEY).payingWith(GENESIS),
+                        contractCall(contract, "buildDonor", salt)
+                                .sending(1000)
+                                .payingWith(GENESIS)
+                                .gas(2_000_000L)
+                                .via(partyCreation2),
+                        captureOneChildCreate2MetaFor(
+                                PARTY, partyCreation2, partyMirrorAddr, partyAliasAddr),
+                        contractCall(contract, "buildDonor", otherSalt)
+                                .sending(1000)
+                                .payingWith(GENESIS)
+                                .gas(2_000_000L)
+                                .via(counterCreation2),
+                        captureOneChildCreate2MetaFor(
+                                COUNTERPARTY,
+                                counterCreation2,
+                                counterMirrorAddr,
+                                counterAliasAddr),
+                        tokenCreate(FUNGIBLE_TOKEN)
+                                .treasury(TOKEN_TREASURY)
+                                .initialSupply(1_000_000),
+                        tokenCreate(NON_FUNGIBLE_TOKEN)
+                                .treasury(TOKEN_TREASURY)
+                                .initialSupply(0)
+                                .tokenType(NON_FUNGIBLE_UNIQUE)
+                                .supplyKey(MULTI_KEY),
+                        mintToken(
+                                NON_FUNGIBLE_TOKEN, List.of(copyFromUtf8("Please mind the vase."))),
+                        withOpContext(
+                                (spec, opLog) -> {
+                                    final var registry = spec.registry();
+                                    ftId.set(registry.getTokenID(FUNGIBLE_TOKEN));
+                                    nftId.set(registry.getTokenID(NON_FUNGIBLE_TOKEN));
+                                    partyId.set(
+                                            accountIdFromHexedMirrorAddress(partyMirrorAddr.get()));
+                                    partyLiteral.set(asAccountString(partyId.get()));
+                                    counterId.set(
+                                            accountIdFromHexedMirrorAddress(
+                                                    counterMirrorAddr.get()));
+                                    counterLiteral.set(asAccountString(counterId.get()));
+                                }))
+                .when(
+                        sourcing(
+                                () ->
+                                        tokenAssociate(
+                                                        partyLiteral.get(),
+                                                        List.of(FUNGIBLE_TOKEN, NON_FUNGIBLE_TOKEN))
+                                                .signedBy(DEFAULT_PAYER, MULTI_KEY)),
+                        sourcing(
+                                () ->
+                                        tokenAssociate(
+                                                        counterLiteral.get(),
+                                                        List.of(FUNGIBLE_TOKEN, NON_FUNGIBLE_TOKEN))
+                                                .signedBy(DEFAULT_PAYER, MULTI_KEY)),
+                        sourcing(() -> getContractInfo(partyLiteral.get()).logged()),
+                        sourcing(
+                                () ->
+                                        cryptoTransfer(
+                                                        moving(500_000, FUNGIBLE_TOKEN)
+                                                                .between(
+                                                                        TOKEN_TREASURY,
+                                                                        partyLiteral.get()),
+                                                        movingUnique(NON_FUNGIBLE_TOKEN, 1L)
+                                                                .between(
+                                                                        TOKEN_TREASURY,
+                                                                        partyLiteral.get()))
+                                                .signedBy(DEFAULT_PAYER, TOKEN_TREASURY)),
+                        cryptoTransfer(
+                                        (spec, b) ->
+                                                b.setTransfers(
+                                                        TransferList.newBuilder()
+                                                                .addAccountAmounts(
+                                                                        aaWith(
+                                                                                partyAliasAddr
+                                                                                        .get(),
+                                                                                -1))
+                                                                .addAccountAmounts(
+                                                                        aaWith(partyId.get(), -1))
+                                                                .addAccountAmounts(
+                                                                        aaWith(
+                                                                                counterId.get(),
+                                                                                +2))))
+                                .signedBy(DEFAULT_PAYER, MULTI_KEY)
+                                .hasKnownStatus(ACCOUNT_REPEATED_IN_ACCOUNT_AMOUNTS),
+                        // Check signing requirements aren't distorted by aliases
+                        cryptoTransfer(
+                                        (spec, b) ->
+                                                b.setTransfers(
+                                                        TransferList.newBuilder()
+                                                                .addAccountAmounts(
+                                                                        aaWith(
+                                                                                partyAliasAddr
+                                                                                        .get(),
+                                                                                -2))
+                                                                .addAccountAmounts(
+                                                                        aaWith(
+                                                                                counterAliasAddr
+                                                                                        .get(),
+                                                                                +2))))
+                                .signedBy(DEFAULT_PAYER)
+                                .hasKnownStatus(INVALID_SIGNATURE),
+                        cryptoTransfer(
+                                        (spec, b) ->
+                                                b.addTokenTransfers(
+                                                        TokenTransferList.newBuilder()
+                                                                .setToken(nftId.get())
+                                                                .addNftTransfers(
+                                                                        ocWith(
+                                                                                accountId(
+                                                                                        partyAliasAddr
+                                                                                                .get()),
+                                                                                counterId.get(),
+                                                                                1L))))
+                                .signedBy(DEFAULT_PAYER)
+                                .hasKnownStatus(INVALID_SIGNATURE),
+                        cryptoTransfer(
+                                        (spec, b) ->
+                                                b.addTokenTransfers(
+                                                        TokenTransferList.newBuilder()
+                                                                .setToken(ftId.get())
+                                                                .addTransfers(
+                                                                        aaWith(
+                                                                                partyAliasAddr
+                                                                                        .get(),
+                                                                                -500))
+                                                                .addTransfers(
+                                                                        aaWith(
+                                                                                counterAliasAddr
+                                                                                        .get(),
+                                                                                +500))))
+                                .signedBy(DEFAULT_PAYER)
+                                .hasKnownStatus(INVALID_SIGNATURE),
+                        // Now do the actual transfers
+                        cryptoTransfer(
+                                        (spec, b) ->
+                                                b.setTransfers(
+                                                        TransferList.newBuilder()
+                                                                .addAccountAmounts(
+                                                                        aaWith(
+                                                                                partyAliasAddr
+                                                                                        .get(),
+                                                                                -2))
+                                                                .addAccountAmounts(
+                                                                        aaWith(
+                                                                                counterAliasAddr
+                                                                                        .get(),
+                                                                                +2))))
+                                .signedBy(DEFAULT_PAYER, MULTI_KEY)
+                                .via(hbarXfer),
+                        cryptoTransfer(
+                                        (spec, b) ->
+                                                b.addTokenTransfers(
+                                                        TokenTransferList.newBuilder()
+                                                                .setToken(nftId.get())
+                                                                .addNftTransfers(
+                                                                        ocWith(
+                                                                                accountId(
+                                                                                        partyAliasAddr
+                                                                                                .get()),
+                                                                                accountId(
+                                                                                        counterAliasAddr
+                                                                                                .get()),
+                                                                                1L))))
+                                .signedBy(DEFAULT_PAYER, MULTI_KEY)
+                                .via(nftXfer),
+                        cryptoTransfer(
+                                        (spec, b) ->
+                                                b.addTokenTransfers(
+                                                        TokenTransferList.newBuilder()
+                                                                .setToken(ftId.get())
+                                                                .addTransfers(
+                                                                        aaWith(
+                                                                                partyAliasAddr
+                                                                                        .get(),
+                                                                                -500))
+                                                                .addTransfers(
+                                                                        aaWith(
+                                                                                counterAliasAddr
+                                                                                        .get(),
+                                                                                +500))))
+                                .signedBy(DEFAULT_PAYER, MULTI_KEY)
+                                .via(ftXfer))
+                .then(
+                        sourcing(
+                                () ->
+                                        getTxnRecord(hbarXfer)
+                                                .hasPriority(
+                                                        recordWith()
+                                                                .transfers(
+                                                                        including(
+                                                                                tinyBarsFromTo(
+                                                                                        partyLiteral
+                                                                                                .get(),
+                                                                                        counterLiteral
+                                                                                                .get(),
+                                                                                        2))))),
+                        sourcing(
+                                () ->
+                                        getTxnRecord(nftXfer)
+                                                .hasPriority(
+                                                        recordWith()
+                                                                .tokenTransfers(
+                                                                        includingNonfungibleMovement(
+                                                                                movingUnique(
+                                                                                                NON_FUNGIBLE_TOKEN,
+                                                                                                1L)
+                                                                                        .between(
+                                                                                                partyLiteral
+                                                                                                        .get(),
+                                                                                                counterLiteral
+                                                                                                        .get()))))),
+                        sourcing(
+                                () ->
+                                        getTxnRecord(ftXfer)
+                                                .hasPriority(
+                                                        recordWith()
+                                                                .tokenTransfers(
+                                                                        includingFungibleMovement(
+                                                                                moving(
+                                                                                                500,
+                                                                                                FUNGIBLE_TOKEN)
+                                                                                        .between(
+                                                                                                partyLiteral
+                                                                                                        .get(),
+                                                                                                counterLiteral
+                                                                                                        .get()))))));
+    }
 
-	private HapiApiSpec cannotTransferFromImmutableAccounts() {
-		final var contract = "PayableConstructor";
-		final var multiKey = "swiss";
+    private HapiApiSpec cannotTransferFromImmutableAccounts() {
+        final var contract = "PayableConstructor";
+        final var multiKey = "swiss";
 
-		return defaultHapiSpec("CannotTransferFromImmutableAccounts")
-				.given(
-						newKeyNamed(multiKey),
-						uploadInitCode(contract),
-						contractCreate(contract).balance(ONE_HBAR).immutable().payingWith(GENESIS))
-				.when()
-				.then(
-						// Even the treasury cannot withdraw from an immutable contract
-						cryptoTransfer(tinyBarsFromTo(contract, FUNDING, ONE_HBAR))
-								.payingWith(GENESIS)
-								.signedBy(GENESIS)
-								.fee(ONE_HBAR)
-								.hasKnownStatus(INVALID_SIGNATURE),
-						// Even the treasury cannot withdraw staking funds
-						cryptoTransfer(tinyBarsFromTo(STAKING_REWARD, FUNDING, ONE_HBAR))
-								.payingWith(GENESIS)
-								.signedBy(GENESIS)
-								.fee(ONE_HBAR)
-								.hasKnownStatus(INVALID_ACCOUNT_ID),
-						cryptoTransfer(tinyBarsFromTo(NODE_REWARD, FUNDING, ONE_HBAR))
-								.payingWith(GENESIS)
-								.signedBy(GENESIS)
-								.fee(ONE_HBAR)
-								.hasKnownStatus(INVALID_ACCOUNT_ID),
-						// Immutable accounts cannot be updated or deleted
-						cryptoUpdate(STAKING_REWARD)
-								.payingWith(GENESIS)
-								.signedBy(GENESIS)
-								.fee(ONE_HBAR)
-								.hasKnownStatus(INVALID_ACCOUNT_ID),
-						cryptoDelete(STAKING_REWARD)
-								.payingWith(GENESIS)
-								.signedBy(GENESIS)
-								.fee(ONE_HBAR)
-								.hasKnownStatus(INVALID_ACCOUNT_ID),
-						// Immutable accounts cannot serve any role for tokens
-						tokenCreate(TOKEN).adminKey(multiKey),
-						tokenAssociate(NODE_REWARD, TOKEN)
-								.payingWith(GENESIS)
-								.signedBy(GENESIS)
-								.fee(ONE_HBAR)
-								.hasKnownStatus(INVALID_ACCOUNT_ID),
-						tokenUpdate(TOKEN)
-								.payingWith(GENESIS)
-								.signedBy(GENESIS, multiKey)
-								.fee(ONE_HBAR)
-								.treasury(STAKING_REWARD)
-								.hasKnownStatus(INVALID_ACCOUNT_ID),
-						tokenCreate(NOT_TO_BE)
-								.treasury(STAKING_REWARD)
-								.payingWith(GENESIS)
-								.signedBy(GENESIS)
-								.fee(ONE_HBAR)
-								.hasKnownStatus(INVALID_ACCOUNT_ID),
-						tokenCreate(NOT_TO_BE)
-								.autoRenewAccount(NODE_REWARD)
-								.payingWith(GENESIS)
-								.signedBy(GENESIS)
-								.fee(ONE_HBAR)
-								.hasKnownStatus(INVALID_AUTORENEW_ACCOUNT),
-						tokenCreate(NOT_TO_BE)
-								.payingWith(GENESIS)
-								.signedBy(GENESIS)
-								.fee(ONE_HBAR)
-								.withCustom(fixedHbarFee(5 * ONE_HBAR, STAKING_REWARD))
-								.hasKnownStatus(INVALID_CUSTOM_FEE_COLLECTOR),
-						// Immutable accounts cannot be topic auto-renew accounts
-						createTopic(NOT_TO_BE)
-								.autoRenewAccountId(NODE_REWARD)
-								.payingWith(GENESIS)
-								.signedBy(GENESIS)
-								.fee(ONE_HBAR)
-								.hasKnownStatus(INVALID_AUTORENEW_ACCOUNT),
-						// Immutable accounts cannot be schedule transaction payers
-						scheduleCreate(
-								NOT_TO_BE,
-								cryptoTransfer(tinyBarsFromTo(GENESIS, FUNDING, 1)))
-								.payingWith(GENESIS)
-								.signedBy(GENESIS)
-								.fee(ONE_HBAR)
-								.designatingPayer(STAKING_REWARD)
-								.fee(ONE_HUNDRED_HBARS)
-								.hasKnownStatus(INVALID_ACCOUNT_ID),
-						// Immutable accounts cannot approve or adjust allowances
-						cryptoApproveAllowance()
-								.payingWith(GENESIS)
-								.signedBy(GENESIS)
-								.fee(ONE_HBAR)
-								.addCryptoAllowance(NODE_REWARD, FUNDING, 100L)
-								.hasKnownStatus(INVALID_ALLOWANCE_OWNER_ID));
-	}
+        return defaultHapiSpec("CannotTransferFromImmutableAccounts")
+                .given(
+                        newKeyNamed(multiKey),
+                        uploadInitCode(contract),
+                        contractCreate(contract).balance(ONE_HBAR).immutable().payingWith(GENESIS))
+                .when()
+                .then(
+                        // Even the treasury cannot withdraw from an immutable contract
+                        cryptoTransfer(tinyBarsFromTo(contract, FUNDING, ONE_HBAR))
+                                .payingWith(GENESIS)
+                                .signedBy(GENESIS)
+                                .fee(ONE_HBAR)
+                                .hasKnownStatus(INVALID_SIGNATURE),
+                        // Even the treasury cannot withdraw staking funds
+                        cryptoTransfer(tinyBarsFromTo(STAKING_REWARD, FUNDING, ONE_HBAR))
+                                .payingWith(GENESIS)
+                                .signedBy(GENESIS)
+                                .fee(ONE_HBAR)
+                                .hasKnownStatus(INVALID_ACCOUNT_ID),
+                        cryptoTransfer(tinyBarsFromTo(NODE_REWARD, FUNDING, ONE_HBAR))
+                                .payingWith(GENESIS)
+                                .signedBy(GENESIS)
+                                .fee(ONE_HBAR)
+                                .hasKnownStatus(INVALID_ACCOUNT_ID),
+                        // Immutable accounts cannot be updated or deleted
+                        cryptoUpdate(STAKING_REWARD)
+                                .payingWith(GENESIS)
+                                .signedBy(GENESIS)
+                                .fee(ONE_HBAR)
+                                .hasKnownStatus(INVALID_ACCOUNT_ID),
+                        cryptoDelete(STAKING_REWARD)
+                                .payingWith(GENESIS)
+                                .signedBy(GENESIS)
+                                .fee(ONE_HBAR)
+                                .hasKnownStatus(INVALID_ACCOUNT_ID),
+                        // Immutable accounts cannot serve any role for tokens
+                        tokenCreate(TOKEN).adminKey(multiKey),
+                        tokenAssociate(NODE_REWARD, TOKEN)
+                                .payingWith(GENESIS)
+                                .signedBy(GENESIS)
+                                .fee(ONE_HBAR)
+                                .hasKnownStatus(INVALID_ACCOUNT_ID),
+                        tokenUpdate(TOKEN)
+                                .payingWith(GENESIS)
+                                .signedBy(GENESIS, multiKey)
+                                .fee(ONE_HBAR)
+                                .treasury(STAKING_REWARD)
+                                .hasKnownStatus(INVALID_ACCOUNT_ID),
+                        tokenCreate(NOT_TO_BE)
+                                .treasury(STAKING_REWARD)
+                                .payingWith(GENESIS)
+                                .signedBy(GENESIS)
+                                .fee(ONE_HBAR)
+                                .hasKnownStatus(INVALID_ACCOUNT_ID),
+                        tokenCreate(NOT_TO_BE)
+                                .autoRenewAccount(NODE_REWARD)
+                                .payingWith(GENESIS)
+                                .signedBy(GENESIS)
+                                .fee(ONE_HBAR)
+                                .hasKnownStatus(INVALID_AUTORENEW_ACCOUNT),
+                        tokenCreate(NOT_TO_BE)
+                                .payingWith(GENESIS)
+                                .signedBy(GENESIS)
+                                .fee(ONE_HBAR)
+                                .withCustom(fixedHbarFee(5 * ONE_HBAR, STAKING_REWARD))
+                                .hasKnownStatus(INVALID_CUSTOM_FEE_COLLECTOR),
+                        // Immutable accounts cannot be topic auto-renew accounts
+                        createTopic(NOT_TO_BE)
+                                .autoRenewAccountId(NODE_REWARD)
+                                .payingWith(GENESIS)
+                                .signedBy(GENESIS)
+                                .fee(ONE_HBAR)
+                                .hasKnownStatus(INVALID_AUTORENEW_ACCOUNT),
+                        // Immutable accounts cannot be schedule transaction payers
+                        scheduleCreate(
+                                        NOT_TO_BE,
+                                        cryptoTransfer(tinyBarsFromTo(GENESIS, FUNDING, 1)))
+                                .payingWith(GENESIS)
+                                .signedBy(GENESIS)
+                                .fee(ONE_HBAR)
+                                .designatingPayer(STAKING_REWARD)
+                                .fee(ONE_HUNDRED_HBARS)
+                                .hasKnownStatus(INVALID_ACCOUNT_ID),
+                        // Immutable accounts cannot approve or adjust allowances
+                        cryptoApproveAllowance()
+                                .payingWith(GENESIS)
+                                .signedBy(GENESIS)
+                                .fee(ONE_HBAR)
+                                .addCryptoAllowance(NODE_REWARD, FUNDING, 100L)
+                                .hasKnownStatus(INVALID_ALLOWANCE_OWNER_ID));
+    }
 
-	private HapiApiSpec allowanceTransfersWithComplexTransfersWork() {
-		return defaultHapiSpec("AllowanceTransfersWithComplexTransfersWork")
-				.given(
-						newKeyNamed(ADMIN_KEY),
-						newKeyNamed(FREEZE_KEY),
-						newKeyNamed(KYC_KEY),
-						newKeyNamed(SUPPLY_KEY),
-						cryptoCreate(OWNER).balance(ONE_HUNDRED_HBARS),
-						cryptoCreate(OTHER_OWNER).balance(ONE_HUNDRED_HBARS),
-						cryptoCreate(SPENDER).balance(ONE_HUNDRED_HBARS),
-						cryptoCreate(RECEIVER).balance(0L),
-						cryptoCreate(OTHER_RECEIVER).balance(ONE_HBAR),
-						cryptoCreate(ANOTHER_RECEIVER).balance(0L),
-						cryptoCreate(TOKEN_TREASURY),
-						tokenCreate(FUNGIBLE_TOKEN)
-								.supplyType(TokenSupplyType.FINITE)
-								.tokenType(FUNGIBLE_COMMON)
-								.treasury(TOKEN_TREASURY)
-								.maxSupply(10000)
-								.initialSupply(5000)
-								.adminKey(ADMIN_KEY)
-								.kycKey(KYC_KEY),
-						tokenCreate(NON_FUNGIBLE_TOKEN)
-								.supplyType(TokenSupplyType.FINITE)
-								.tokenType(NON_FUNGIBLE_UNIQUE)
-								.treasury(TOKEN_TREASURY)
-								.maxSupply(12L)
-								.supplyKey(SUPPLY_KEY)
-								.adminKey(ADMIN_KEY)
-								.kycKey(KYC_KEY)
-								.initialSupply(0L),
-						mintToken(
-								NON_FUNGIBLE_TOKEN,
-								List.of(
-										ByteString.copyFromUtf8("a"),
-										ByteString.copyFromUtf8("b"),
-										ByteString.copyFromUtf8("c"),
-										ByteString.copyFromUtf8("d"),
-										ByteString.copyFromUtf8("e"))))
-				.when(
-						tokenAssociate(OWNER, FUNGIBLE_TOKEN, NON_FUNGIBLE_TOKEN),
-						tokenAssociate(OTHER_OWNER, FUNGIBLE_TOKEN, NON_FUNGIBLE_TOKEN),
-						tokenAssociate(RECEIVER, FUNGIBLE_TOKEN, NON_FUNGIBLE_TOKEN),
-						tokenAssociate(SPENDER, FUNGIBLE_TOKEN),
-						tokenAssociate(ANOTHER_RECEIVER, FUNGIBLE_TOKEN),
-						grantTokenKyc(FUNGIBLE_TOKEN, OWNER),
-						grantTokenKyc(FUNGIBLE_TOKEN, OTHER_OWNER),
-						grantTokenKyc(FUNGIBLE_TOKEN, RECEIVER),
-						grantTokenKyc(FUNGIBLE_TOKEN, ANOTHER_RECEIVER),
-						grantTokenKyc(FUNGIBLE_TOKEN, SPENDER),
-						grantTokenKyc(NON_FUNGIBLE_TOKEN, OWNER),
-						grantTokenKyc(NON_FUNGIBLE_TOKEN, OTHER_OWNER),
-						grantTokenKyc(NON_FUNGIBLE_TOKEN, RECEIVER),
-						cryptoTransfer(
-								moving(100, FUNGIBLE_TOKEN).between(TOKEN_TREASURY, SPENDER),
-								moving(1000, FUNGIBLE_TOKEN).between(TOKEN_TREASURY, OWNER),
-								movingUnique(NON_FUNGIBLE_TOKEN, 1, 2)
-										.between(TOKEN_TREASURY, OWNER),
-								moving(1000, FUNGIBLE_TOKEN).between(TOKEN_TREASURY, OTHER_OWNER),
-								movingUnique(NON_FUNGIBLE_TOKEN, 3, 4)
-										.between(TOKEN_TREASURY, OTHER_OWNER)),
-						cryptoApproveAllowance()
-								.payingWith(OWNER)
-								.addCryptoAllowance(OWNER, SPENDER, 10 * ONE_HBAR)
-								.addTokenAllowance(OWNER, FUNGIBLE_TOKEN, SPENDER, 500)
-								.addNftAllowance(
-										OWNER, NON_FUNGIBLE_TOKEN, SPENDER, false, List.of(1L, 2L))
-								.fee(ONE_HUNDRED_HBARS),
-						cryptoApproveAllowance()
-								.payingWith(OTHER_OWNER)
-								.addCryptoAllowance(OTHER_OWNER, SPENDER, 5 * ONE_HBAR)
-								.addTokenAllowance(OTHER_OWNER, FUNGIBLE_TOKEN, SPENDER, 100)
-								.addNftAllowance(
-										OTHER_OWNER, NON_FUNGIBLE_TOKEN, SPENDER, true, List.of(3L))
-								.fee(ONE_HUNDRED_HBARS))
-				.then(
-						cryptoTransfer(
-								movingHbar(ONE_HBAR).between(SPENDER, RECEIVER),
-								movingHbar(ONE_HBAR)
-										.between(OTHER_RECEIVER, ANOTHER_RECEIVER),
-								movingHbar(ONE_HBAR).between(OWNER, RECEIVER),
-								movingHbar(ONE_HBAR).between(OTHER_OWNER, RECEIVER),
-								movingHbarWithAllowance(ONE_HBAR).between(OWNER, RECEIVER),
-								movingHbarWithAllowance(ONE_HBAR)
-										.between(OTHER_OWNER, RECEIVER),
-								moving(50, FUNGIBLE_TOKEN)
-										.between(RECEIVER, ANOTHER_RECEIVER),
-								moving(50, FUNGIBLE_TOKEN).between(SPENDER, RECEIVER),
-								moving(50, FUNGIBLE_TOKEN).between(OWNER, RECEIVER),
-								moving(15, FUNGIBLE_TOKEN).between(OTHER_OWNER, RECEIVER),
-								movingWithAllowance(30, FUNGIBLE_TOKEN)
-										.between(OWNER, RECEIVER),
-								movingWithAllowance(10, FUNGIBLE_TOKEN)
-										.between(OTHER_OWNER, RECEIVER),
-								movingWithAllowance(5, FUNGIBLE_TOKEN)
-										.between(OTHER_OWNER, OWNER),
-								movingUnique(NON_FUNGIBLE_TOKEN, 1L)
-										.between(OWNER, RECEIVER),
-								movingUniqueWithAllowance(NON_FUNGIBLE_TOKEN, 2L)
-										.between(OWNER, RECEIVER),
-								movingUniqueWithAllowance(NON_FUNGIBLE_TOKEN, 4L)
-										.between(OTHER_OWNER, RECEIVER),
-								movingUniqueWithAllowance(NON_FUNGIBLE_TOKEN, 3L)
-										.between(OTHER_OWNER, RECEIVER))
-								.payingWith(SPENDER)
-								.signedBy(SPENDER, OWNER, OTHER_RECEIVER, OTHER_OWNER)
-								.via("complexAllowanceTransfer"),
-						getTxnRecord("complexAllowanceTransfer").logged(),
-						getAccountDetails(OWNER)
-								.payingWith(GENESIS)
-								.hasToken(relationshipWith(FUNGIBLE_TOKEN).balance(925))
-								.hasToken(relationshipWith(NON_FUNGIBLE_TOKEN).balance(0))
-								.has(
-										AccountDetailsAsserts.accountWith()
-												.balanceLessThan(98 * ONE_HBAR)
-												.cryptoAllowancesContaining(SPENDER, 9 * ONE_HBAR)
-												.tokenAllowancesContaining(
-														FUNGIBLE_TOKEN, SPENDER, 475)),
-						getAccountDetails(OTHER_OWNER)
-								.payingWith(GENESIS)
-								.hasToken(relationshipWith(FUNGIBLE_TOKEN).balance(970))
-								.hasToken(relationshipWith(NON_FUNGIBLE_TOKEN).balance(0))
-								.has(
-										AccountDetailsAsserts.accountWith()
-												.balanceLessThan(98 * ONE_HBAR)
-												.cryptoAllowancesContaining(SPENDER, 4 * ONE_HBAR)
-												.tokenAllowancesContaining(
-														FUNGIBLE_TOKEN, SPENDER, 85)
-												.nftApprovedAllowancesContaining(
-														NON_FUNGIBLE_TOKEN, SPENDER)),
-						getAccountInfo(RECEIVER)
-								.hasToken(relationshipWith(FUNGIBLE_TOKEN).balance(105))
-								.hasToken(relationshipWith(NON_FUNGIBLE_TOKEN).balance(4))
-								.has(accountWith().balance(5 * ONE_HBAR)),
-						getAccountInfo(ANOTHER_RECEIVER)
-								.hasToken(relationshipWith(FUNGIBLE_TOKEN).balance(50))
-								.has(accountWith().balance(ONE_HBAR)));
-	}
+    private HapiApiSpec allowanceTransfersWithComplexTransfersWork() {
+        return defaultHapiSpec("AllowanceTransfersWithComplexTransfersWork")
+                .given(
+                        newKeyNamed(ADMIN_KEY),
+                        newKeyNamed(FREEZE_KEY),
+                        newKeyNamed(KYC_KEY),
+                        newKeyNamed(SUPPLY_KEY),
+                        cryptoCreate(OWNER).balance(ONE_HUNDRED_HBARS),
+                        cryptoCreate(OTHER_OWNER).balance(ONE_HUNDRED_HBARS),
+                        cryptoCreate(SPENDER).balance(ONE_HUNDRED_HBARS),
+                        cryptoCreate(RECEIVER).balance(0L),
+                        cryptoCreate(OTHER_RECEIVER).balance(ONE_HBAR),
+                        cryptoCreate(ANOTHER_RECEIVER).balance(0L),
+                        cryptoCreate(TOKEN_TREASURY),
+                        tokenCreate(FUNGIBLE_TOKEN)
+                                .supplyType(TokenSupplyType.FINITE)
+                                .tokenType(FUNGIBLE_COMMON)
+                                .treasury(TOKEN_TREASURY)
+                                .maxSupply(10000)
+                                .initialSupply(5000)
+                                .adminKey(ADMIN_KEY)
+                                .kycKey(KYC_KEY),
+                        tokenCreate(NON_FUNGIBLE_TOKEN)
+                                .supplyType(TokenSupplyType.FINITE)
+                                .tokenType(NON_FUNGIBLE_UNIQUE)
+                                .treasury(TOKEN_TREASURY)
+                                .maxSupply(12L)
+                                .supplyKey(SUPPLY_KEY)
+                                .adminKey(ADMIN_KEY)
+                                .kycKey(KYC_KEY)
+                                .initialSupply(0L),
+                        mintToken(
+                                NON_FUNGIBLE_TOKEN,
+                                List.of(
+                                        ByteString.copyFromUtf8("a"),
+                                        ByteString.copyFromUtf8("b"),
+                                        ByteString.copyFromUtf8("c"),
+                                        ByteString.copyFromUtf8("d"),
+                                        ByteString.copyFromUtf8("e"))))
+                .when(
+                        tokenAssociate(OWNER, FUNGIBLE_TOKEN, NON_FUNGIBLE_TOKEN),
+                        tokenAssociate(OTHER_OWNER, FUNGIBLE_TOKEN, NON_FUNGIBLE_TOKEN),
+                        tokenAssociate(RECEIVER, FUNGIBLE_TOKEN, NON_FUNGIBLE_TOKEN),
+                        tokenAssociate(SPENDER, FUNGIBLE_TOKEN),
+                        tokenAssociate(ANOTHER_RECEIVER, FUNGIBLE_TOKEN),
+                        grantTokenKyc(FUNGIBLE_TOKEN, OWNER),
+                        grantTokenKyc(FUNGIBLE_TOKEN, OTHER_OWNER),
+                        grantTokenKyc(FUNGIBLE_TOKEN, RECEIVER),
+                        grantTokenKyc(FUNGIBLE_TOKEN, ANOTHER_RECEIVER),
+                        grantTokenKyc(FUNGIBLE_TOKEN, SPENDER),
+                        grantTokenKyc(NON_FUNGIBLE_TOKEN, OWNER),
+                        grantTokenKyc(NON_FUNGIBLE_TOKEN, OTHER_OWNER),
+                        grantTokenKyc(NON_FUNGIBLE_TOKEN, RECEIVER),
+                        cryptoTransfer(
+                                moving(100, FUNGIBLE_TOKEN).between(TOKEN_TREASURY, SPENDER),
+                                moving(1000, FUNGIBLE_TOKEN).between(TOKEN_TREASURY, OWNER),
+                                movingUnique(NON_FUNGIBLE_TOKEN, 1, 2)
+                                        .between(TOKEN_TREASURY, OWNER),
+                                moving(1000, FUNGIBLE_TOKEN).between(TOKEN_TREASURY, OTHER_OWNER),
+                                movingUnique(NON_FUNGIBLE_TOKEN, 3, 4)
+                                        .between(TOKEN_TREASURY, OTHER_OWNER)),
+                        cryptoApproveAllowance()
+                                .payingWith(OWNER)
+                                .addCryptoAllowance(OWNER, SPENDER, 10 * ONE_HBAR)
+                                .addTokenAllowance(OWNER, FUNGIBLE_TOKEN, SPENDER, 500)
+                                .addNftAllowance(
+                                        OWNER, NON_FUNGIBLE_TOKEN, SPENDER, false, List.of(1L, 2L))
+                                .fee(ONE_HUNDRED_HBARS),
+                        cryptoApproveAllowance()
+                                .payingWith(OTHER_OWNER)
+                                .addCryptoAllowance(OTHER_OWNER, SPENDER, 5 * ONE_HBAR)
+                                .addTokenAllowance(OTHER_OWNER, FUNGIBLE_TOKEN, SPENDER, 100)
+                                .addNftAllowance(
+                                        OTHER_OWNER, NON_FUNGIBLE_TOKEN, SPENDER, true, List.of(3L))
+                                .fee(ONE_HUNDRED_HBARS))
+                .then(
+                        cryptoTransfer(
+                                        movingHbar(ONE_HBAR).between(SPENDER, RECEIVER),
+                                        movingHbar(ONE_HBAR)
+                                                .between(OTHER_RECEIVER, ANOTHER_RECEIVER),
+                                        movingHbar(ONE_HBAR).between(OWNER, RECEIVER),
+                                        movingHbar(ONE_HBAR).between(OTHER_OWNER, RECEIVER),
+                                        movingHbarWithAllowance(ONE_HBAR).between(OWNER, RECEIVER),
+                                        movingHbarWithAllowance(ONE_HBAR)
+                                                .between(OTHER_OWNER, RECEIVER),
+                                        moving(50, FUNGIBLE_TOKEN)
+                                                .between(RECEIVER, ANOTHER_RECEIVER),
+                                        moving(50, FUNGIBLE_TOKEN).between(SPENDER, RECEIVER),
+                                        moving(50, FUNGIBLE_TOKEN).between(OWNER, RECEIVER),
+                                        moving(15, FUNGIBLE_TOKEN).between(OTHER_OWNER, RECEIVER),
+                                        movingWithAllowance(30, FUNGIBLE_TOKEN)
+                                                .between(OWNER, RECEIVER),
+                                        movingWithAllowance(10, FUNGIBLE_TOKEN)
+                                                .between(OTHER_OWNER, RECEIVER),
+                                        movingWithAllowance(5, FUNGIBLE_TOKEN)
+                                                .between(OTHER_OWNER, OWNER),
+                                        movingUnique(NON_FUNGIBLE_TOKEN, 1L)
+                                                .between(OWNER, RECEIVER),
+                                        movingUniqueWithAllowance(NON_FUNGIBLE_TOKEN, 2L)
+                                                .between(OWNER, RECEIVER),
+                                        movingUniqueWithAllowance(NON_FUNGIBLE_TOKEN, 4L)
+                                                .between(OTHER_OWNER, RECEIVER),
+                                        movingUniqueWithAllowance(NON_FUNGIBLE_TOKEN, 3L)
+                                                .between(OTHER_OWNER, RECEIVER))
+                                .payingWith(SPENDER)
+                                .signedBy(SPENDER, OWNER, OTHER_RECEIVER, OTHER_OWNER)
+                                .via("complexAllowanceTransfer"),
+                        getTxnRecord("complexAllowanceTransfer").logged(),
+                        getAccountDetails(OWNER)
+                                .payingWith(GENESIS)
+                                .hasToken(relationshipWith(FUNGIBLE_TOKEN).balance(925))
+                                .hasToken(relationshipWith(NON_FUNGIBLE_TOKEN).balance(0))
+                                .has(
+                                        AccountDetailsAsserts.accountWith()
+                                                .balanceLessThan(98 * ONE_HBAR)
+                                                .cryptoAllowancesContaining(SPENDER, 9 * ONE_HBAR)
+                                                .tokenAllowancesContaining(
+                                                        FUNGIBLE_TOKEN, SPENDER, 475)),
+                        getAccountDetails(OTHER_OWNER)
+                                .payingWith(GENESIS)
+                                .hasToken(relationshipWith(FUNGIBLE_TOKEN).balance(970))
+                                .hasToken(relationshipWith(NON_FUNGIBLE_TOKEN).balance(0))
+                                .has(
+                                        AccountDetailsAsserts.accountWith()
+                                                .balanceLessThan(98 * ONE_HBAR)
+                                                .cryptoAllowancesContaining(SPENDER, 4 * ONE_HBAR)
+                                                .tokenAllowancesContaining(
+                                                        FUNGIBLE_TOKEN, SPENDER, 85)
+                                                .nftApprovedAllowancesContaining(
+                                                        NON_FUNGIBLE_TOKEN, SPENDER)),
+                        getAccountInfo(RECEIVER)
+                                .hasToken(relationshipWith(FUNGIBLE_TOKEN).balance(105))
+                                .hasToken(relationshipWith(NON_FUNGIBLE_TOKEN).balance(4))
+                                .has(accountWith().balance(5 * ONE_HBAR)),
+                        getAccountInfo(ANOTHER_RECEIVER)
+                                .hasToken(relationshipWith(FUNGIBLE_TOKEN).balance(50))
+                                .has(accountWith().balance(ONE_HBAR)));
+    }
 
-	private HapiApiSpec allowanceTransfersWorkAsExpected() {
-		return defaultHapiSpec("AllowanceTransfersWorkAsExpected")
-				.given(
-						fileUpdate(APP_PROPERTIES)
-								.fee(ONE_HUNDRED_HBARS)
-								.payingWith(EXCHANGE_RATE_CONTROL)
-								.overridingProps(
-										Map.of(
-												"hedera.allowances.maxTransactionLimit", "20",
-												"hedera.allowances.maxAccountLimit", "100")),
-						newKeyNamed(ADMIN_KEY),
-						newKeyNamed(FREEZE_KEY),
-						newKeyNamed(KYC_KEY),
-						newKeyNamed(PAUSE_KEY),
-						newKeyNamed(SUPPLY_KEY),
-						newKeyNamed(WIPE_KEY),
-						cryptoCreate(TOKEN_TREASURY),
-						cryptoCreate(OWNER).balance(ONE_HUNDRED_HBARS),
-						cryptoCreate(SPENDER).balance(ONE_HUNDRED_HBARS),
-						cryptoCreate(RECEIVER),
-						cryptoCreate(OTHER_RECEIVER)
-								.balance(ONE_HBAR)
-								.maxAutomaticTokenAssociations(1),
-						tokenCreate(FUNGIBLE_TOKEN)
-								.supplyType(TokenSupplyType.FINITE)
-								.tokenType(FUNGIBLE_COMMON)
-								.treasury(TOKEN_TREASURY)
-								.maxSupply(10000)
-								.initialSupply(5000)
-								.adminKey(ADMIN_KEY)
-								.pauseKey(PAUSE_KEY)
-								.kycKey(KYC_KEY)
-								.freezeKey(FREEZE_KEY),
-						tokenCreate(NON_FUNGIBLE_TOKEN)
-								.supplyType(TokenSupplyType.FINITE)
-								.tokenType(NON_FUNGIBLE_UNIQUE)
-								.treasury(TOKEN_TREASURY)
-								.maxSupply(12L)
-								.supplyKey(SUPPLY_KEY)
-								.adminKey(ADMIN_KEY)
-								.freezeKey(FREEZE_KEY)
-								.wipeKey(WIPE_KEY)
-								.pauseKey(PAUSE_KEY)
-								.initialSupply(0L),
-						tokenCreate(TOKEN_WITH_CUSTOM_FEE)
-								.treasury(TOKEN_TREASURY)
-								.supplyType(TokenSupplyType.FINITE)
-								.initialSupply(1000)
-								.maxSupply(5000)
-								.adminKey(ADMIN_KEY)
-								.withCustom(fixedHtsFee(10, "0.0.0", TOKEN_TREASURY)),
-						mintToken(
-								NON_FUNGIBLE_TOKEN,
-								List.of(
-										ByteString.copyFromUtf8("a"),
-										ByteString.copyFromUtf8("b"),
-										ByteString.copyFromUtf8("c"),
-										ByteString.copyFromUtf8("d"),
-										ByteString.copyFromUtf8("e"),
-										ByteString.copyFromUtf8("f"))))
-				.when(
-						tokenAssociate(
-								OWNER, FUNGIBLE_TOKEN, NON_FUNGIBLE_TOKEN, TOKEN_WITH_CUSTOM_FEE),
-						tokenAssociate(
-								RECEIVER,
-								FUNGIBLE_TOKEN,
-								NON_FUNGIBLE_TOKEN,
-								TOKEN_WITH_CUSTOM_FEE),
-						grantTokenKyc(FUNGIBLE_TOKEN, OWNER),
-						grantTokenKyc(FUNGIBLE_TOKEN, RECEIVER),
-						cryptoTransfer(
-								moving(1000, FUNGIBLE_TOKEN).between(TOKEN_TREASURY, OWNER),
-								moving(15, TOKEN_WITH_CUSTOM_FEE).between(TOKEN_TREASURY, OWNER),
-								movingUnique(NON_FUNGIBLE_TOKEN, 1L, 2L, 3L, 4L, 5L, 6L)
-										.between(TOKEN_TREASURY, OWNER)),
-						cryptoApproveAllowance()
-								.payingWith(OWNER)
-								.addCryptoAllowance(OWNER, SPENDER, 10 * ONE_HBAR)
-								.addTokenAllowance(OWNER, FUNGIBLE_TOKEN, SPENDER, 1500)
-								.addTokenAllowance(OWNER, TOKEN_WITH_CUSTOM_FEE, SPENDER, 100)
-								.addNftAllowance(
-										OWNER,
-										NON_FUNGIBLE_TOKEN,
-										SPENDER,
-										false,
-										List.of(1L, 2L, 3L, 4L, 6L))
-								.fee(ONE_HUNDRED_HBARS))
-				.then(
-						cryptoTransfer(
-								movingWithAllowance(10, TOKEN_WITH_CUSTOM_FEE)
-										.between(OWNER, RECEIVER))
-								.payingWith(SPENDER)
-								.signedBy(SPENDER)
-								.fee(ONE_HBAR)
-								.hasKnownStatus(INSUFFICIENT_SENDER_ACCOUNT_BALANCE_FOR_CUSTOM_FEE),
-						cryptoTransfer(
-								movingWithAllowance(100, FUNGIBLE_TOKEN)
-										.between(OWNER, OWNER))
-								.payingWith(SPENDER)
-								.signedBy(SPENDER)
-								.dontFullyAggregateTokenTransfers()
-								.hasPrecheck(ACCOUNT_REPEATED_IN_ACCOUNT_AMOUNTS),
-						cryptoTransfer(
-								movingUniqueWithAllowance(NON_FUNGIBLE_TOKEN, 3)
-										.between(OWNER, OTHER_RECEIVER))
-								.payingWith(SPENDER)
-								.signedBy(SPENDER),
-						cryptoTransfer(
-								movingWithAllowance(100, FUNGIBLE_TOKEN)
-										.between(OWNER, OTHER_RECEIVER))
-								.payingWith(SPENDER)
-								.signedBy(SPENDER)
-								.hasKnownStatus(NO_REMAINING_AUTOMATIC_ASSOCIATIONS),
-						cryptoUpdate(OTHER_RECEIVER)
-								.receiverSigRequired(true)
-								.maxAutomaticAssociations(2),
-						cryptoTransfer(
-								movingUniqueWithAllowance(NON_FUNGIBLE_TOKEN, 4)
-										.between(OWNER, OTHER_RECEIVER))
-								.payingWith(SPENDER)
-								.signedBy(SPENDER)
-								.hasKnownStatus(INVALID_SIGNATURE),
-						cryptoTransfer(
-								movingUniqueWithAllowance(NON_FUNGIBLE_TOKEN, 4)
-										.between(OWNER, OTHER_RECEIVER))
-								.payingWith(SPENDER)
-								.signedBy(SPENDER, OTHER_RECEIVER),
-						cryptoTransfer(
-								movingUnique(NON_FUNGIBLE_TOKEN, 6).between(OWNER, RECEIVER)),
-						cryptoTransfer(
-								movingUniqueWithAllowance(NON_FUNGIBLE_TOKEN, 6)
-										.between(OWNER, RECEIVER))
-								.payingWith(SPENDER)
-								.signedBy(SPENDER)
-								.hasKnownStatus(SPENDER_DOES_NOT_HAVE_ALLOWANCE),
-						cryptoTransfer(
-								movingUniqueWithAllowance(NON_FUNGIBLE_TOKEN, 6)
-										.between(RECEIVER, OWNER))
-								.payingWith(SPENDER)
-								.signedBy(SPENDER)
-								.hasKnownStatus(SPENDER_DOES_NOT_HAVE_ALLOWANCE),
-						cryptoTransfer(
-								movingUnique(NON_FUNGIBLE_TOKEN, 6).between(RECEIVER, OWNER)),
-						cryptoTransfer(
-								movingUniqueWithAllowance(NON_FUNGIBLE_TOKEN, 6)
-										.between(OWNER, RECEIVER))
-								.payingWith(SPENDER)
-								.signedBy(SPENDER)
-								.hasKnownStatus(SPENDER_DOES_NOT_HAVE_ALLOWANCE),
-						cryptoTransfer(
-								movingUnique(NON_FUNGIBLE_TOKEN, 6).between(OWNER, RECEIVER)),
-						tokenAssociate(OTHER_RECEIVER, FUNGIBLE_TOKEN),
-						grantTokenKyc(FUNGIBLE_TOKEN, OTHER_RECEIVER),
-						cryptoTransfer(
-								movingWithAllowance(1100, FUNGIBLE_TOKEN)
-										.between(OWNER, OTHER_RECEIVER))
-								.payingWith(SPENDER)
-								.signedBy(SPENDER, OTHER_RECEIVER)
-								.hasKnownStatus(INSUFFICIENT_TOKEN_BALANCE),
-						cryptoTransfer(allowanceTinyBarsFromTo(OWNER, RECEIVER, 5 * ONE_HBAR))
-								.payingWith(DEFAULT_PAYER)
-								.signedBy(DEFAULT_PAYER)
-								.hasKnownStatus(SPENDER_DOES_NOT_HAVE_ALLOWANCE),
-						tokenPause(FUNGIBLE_TOKEN),
-						cryptoTransfer(
-								movingWithAllowance(50, FUNGIBLE_TOKEN)
-										.between(OWNER, RECEIVER),
-								movingUniqueWithAllowance(NON_FUNGIBLE_TOKEN, 1)
-										.between(OWNER, RECEIVER))
-								.payingWith(SPENDER)
-								.signedBy(SPENDER)
-								.hasKnownStatus(TOKEN_IS_PAUSED),
-						tokenUnpause(FUNGIBLE_TOKEN),
-						tokenFreeze(FUNGIBLE_TOKEN, OWNER),
-						cryptoTransfer(
-								movingWithAllowance(50, FUNGIBLE_TOKEN)
-										.between(OWNER, RECEIVER),
-								movingUniqueWithAllowance(NON_FUNGIBLE_TOKEN, 1)
-										.between(OWNER, RECEIVER))
-								.payingWith(SPENDER)
-								.signedBy(SPENDER)
-								.hasKnownStatus(ACCOUNT_FROZEN_FOR_TOKEN),
-						tokenUnfreeze(FUNGIBLE_TOKEN, OWNER),
-						revokeTokenKyc(FUNGIBLE_TOKEN, RECEIVER),
-						cryptoTransfer(
-								movingWithAllowance(50, FUNGIBLE_TOKEN)
-										.between(OWNER, RECEIVER),
-								movingUniqueWithAllowance(NON_FUNGIBLE_TOKEN, 1)
-										.between(OWNER, RECEIVER))
-								.payingWith(SPENDER)
-								.signedBy(SPENDER)
-								.hasKnownStatus(ACCOUNT_KYC_NOT_GRANTED_FOR_TOKEN),
-						grantTokenKyc(FUNGIBLE_TOKEN, RECEIVER),
-						cryptoTransfer(
-								allowanceTinyBarsFromTo(OWNER, RECEIVER, 5 * ONE_HBAR),
-								tinyBarsFromTo(SPENDER, RECEIVER, ONE_HBAR))
-								.payingWith(SPENDER)
-								.signedBy(SPENDER),
-						cryptoTransfer(
-								movingWithAllowance(50, FUNGIBLE_TOKEN)
-										.between(OWNER, RECEIVER),
-								movingUniqueWithAllowance(NON_FUNGIBLE_TOKEN, 1)
-										.between(OWNER, RECEIVER))
-								.payingWith(SPENDER)
-								.signedBy(SPENDER),
-						cryptoTransfer(allowanceTinyBarsFromTo(OWNER, RECEIVER, 5 * ONE_HBAR + 1))
-								.payingWith(SPENDER)
-								.signedBy(SPENDER)
-								.hasKnownStatus(AMOUNT_EXCEEDS_ALLOWANCE),
-						cryptoTransfer(
-								movingWithAllowance(50, FUNGIBLE_TOKEN)
-										.between(OWNER, RECEIVER),
-								movingUniqueWithAllowance(NON_FUNGIBLE_TOKEN, 5)
-										.between(OWNER, RECEIVER))
-								.payingWith(SPENDER)
-								.signedBy(SPENDER)
-								.hasKnownStatus(SPENDER_DOES_NOT_HAVE_ALLOWANCE),
-						getAccountDetails(OWNER)
-								.payingWith(GENESIS)
-								.has(
-										AccountDetailsAsserts.accountWith()
-												.tokenAllowancesContaining(
-														FUNGIBLE_TOKEN, SPENDER, 1450))
-								.hasToken(relationshipWith(FUNGIBLE_TOKEN).balance(950L)),
-						cryptoTransfer(moving(1000, FUNGIBLE_TOKEN).between(TOKEN_TREASURY, OWNER)),
-						cryptoTransfer(
-								movingUniqueWithAllowance(NON_FUNGIBLE_TOKEN, 2L)
-										.between(OWNER, RECEIVER),
-								movingWithAllowance(1451, FUNGIBLE_TOKEN)
-										.between(OWNER, RECEIVER))
-								.payingWith(SPENDER)
-								.signedBy(SPENDER)
-								.hasKnownStatus(AMOUNT_EXCEEDS_ALLOWANCE),
-						getAccountInfo(OWNER)
-								.hasToken(relationshipWith(NON_FUNGIBLE_TOKEN).balance(2)),
-						cryptoTransfer(allowanceTinyBarsFromTo(OWNER, RECEIVER, 5 * ONE_HBAR))
-								.payingWith(SPENDER)
-								.signedBy(SPENDER),
-						cryptoTransfer(
-								movingWithAllowance(50, FUNGIBLE_TOKEN)
-										.between(OWNER, RECEIVER),
-								movingUniqueWithAllowance(NON_FUNGIBLE_TOKEN, 2L)
-										.between(OWNER, RECEIVER))
-								.payingWith(SPENDER)
-								.signedBy(SPENDER),
-						cryptoTransfer(allowanceTinyBarsFromTo(OWNER, RECEIVER, 5 * ONE_HBAR))
-								.payingWith(SPENDER)
-								.signedBy(SPENDER)
-								.hasKnownStatus(SPENDER_DOES_NOT_HAVE_ALLOWANCE),
-						cryptoTransfer(
-								movingUnique(NON_FUNGIBLE_TOKEN, 2L).between(RECEIVER, OWNER)),
-						cryptoTransfer(
-								movingUniqueWithAllowance(NON_FUNGIBLE_TOKEN, 2L)
-										.between(OWNER, RECEIVER))
-								.payingWith(SPENDER)
-								.signedBy(SPENDER)
-								.hasKnownStatus(SPENDER_DOES_NOT_HAVE_ALLOWANCE),
-						cryptoApproveAllowance()
-								.payingWith(OWNER)
-								.addNftAllowance(
-										OWNER, NON_FUNGIBLE_TOKEN, SPENDER, true, List.of())
-								.fee(ONE_HUNDRED_HBARS),
-						cryptoTransfer(
-								movingUniqueWithAllowance(NON_FUNGIBLE_TOKEN, 2L)
-										.between(OWNER, RECEIVER))
-								.payingWith(SPENDER)
-								.signedBy(SPENDER),
-						cryptoTransfer(
-								movingUnique(NON_FUNGIBLE_TOKEN, 2L).between(RECEIVER, OWNER)),
-						cryptoTransfer(
-								movingUniqueWithAllowance(NON_FUNGIBLE_TOKEN, 2L)
-										.between(OWNER, RECEIVER))
-								.payingWith(SPENDER)
-								.signedBy(SPENDER),
-						getAccountDetails(OWNER)
-								.payingWith(GENESIS)
-								.has(
-										AccountDetailsAsserts.accountWith()
-												.cryptoAllowancesCount(0)
-												.tokenAllowancesContaining(
-														FUNGIBLE_TOKEN, SPENDER, 1400)
-												.nftApprovedAllowancesContaining(
-														NON_FUNGIBLE_TOKEN, SPENDER)));
-	}
+    private HapiApiSpec allowanceTransfersWorkAsExpected() {
+        return defaultHapiSpec("AllowanceTransfersWorkAsExpected")
+                .given(
+                        fileUpdate(APP_PROPERTIES)
+                                .fee(ONE_HUNDRED_HBARS)
+                                .payingWith(EXCHANGE_RATE_CONTROL)
+                                .overridingProps(
+                                        Map.of(
+                                                "hedera.allowances.maxTransactionLimit", "20",
+                                                "hedera.allowances.maxAccountLimit", "100")),
+                        newKeyNamed(ADMIN_KEY),
+                        newKeyNamed(FREEZE_KEY),
+                        newKeyNamed(KYC_KEY),
+                        newKeyNamed(PAUSE_KEY),
+                        newKeyNamed(SUPPLY_KEY),
+                        newKeyNamed(WIPE_KEY),
+                        cryptoCreate(TOKEN_TREASURY),
+                        cryptoCreate(OWNER).balance(ONE_HUNDRED_HBARS),
+                        cryptoCreate(SPENDER).balance(ONE_HUNDRED_HBARS),
+                        cryptoCreate(RECEIVER),
+                        cryptoCreate(OTHER_RECEIVER)
+                                .balance(ONE_HBAR)
+                                .maxAutomaticTokenAssociations(1),
+                        tokenCreate(FUNGIBLE_TOKEN)
+                                .supplyType(TokenSupplyType.FINITE)
+                                .tokenType(FUNGIBLE_COMMON)
+                                .treasury(TOKEN_TREASURY)
+                                .maxSupply(10000)
+                                .initialSupply(5000)
+                                .adminKey(ADMIN_KEY)
+                                .pauseKey(PAUSE_KEY)
+                                .kycKey(KYC_KEY)
+                                .freezeKey(FREEZE_KEY),
+                        tokenCreate(NON_FUNGIBLE_TOKEN)
+                                .supplyType(TokenSupplyType.FINITE)
+                                .tokenType(NON_FUNGIBLE_UNIQUE)
+                                .treasury(TOKEN_TREASURY)
+                                .maxSupply(12L)
+                                .supplyKey(SUPPLY_KEY)
+                                .adminKey(ADMIN_KEY)
+                                .freezeKey(FREEZE_KEY)
+                                .wipeKey(WIPE_KEY)
+                                .pauseKey(PAUSE_KEY)
+                                .initialSupply(0L),
+                        tokenCreate(TOKEN_WITH_CUSTOM_FEE)
+                                .treasury(TOKEN_TREASURY)
+                                .supplyType(TokenSupplyType.FINITE)
+                                .initialSupply(1000)
+                                .maxSupply(5000)
+                                .adminKey(ADMIN_KEY)
+                                .withCustom(fixedHtsFee(10, "0.0.0", TOKEN_TREASURY)),
+                        mintToken(
+                                NON_FUNGIBLE_TOKEN,
+                                List.of(
+                                        ByteString.copyFromUtf8("a"),
+                                        ByteString.copyFromUtf8("b"),
+                                        ByteString.copyFromUtf8("c"),
+                                        ByteString.copyFromUtf8("d"),
+                                        ByteString.copyFromUtf8("e"),
+                                        ByteString.copyFromUtf8("f"))))
+                .when(
+                        tokenAssociate(
+                                OWNER, FUNGIBLE_TOKEN, NON_FUNGIBLE_TOKEN, TOKEN_WITH_CUSTOM_FEE),
+                        tokenAssociate(
+                                RECEIVER,
+                                FUNGIBLE_TOKEN,
+                                NON_FUNGIBLE_TOKEN,
+                                TOKEN_WITH_CUSTOM_FEE),
+                        grantTokenKyc(FUNGIBLE_TOKEN, OWNER),
+                        grantTokenKyc(FUNGIBLE_TOKEN, RECEIVER),
+                        cryptoTransfer(
+                                moving(1000, FUNGIBLE_TOKEN).between(TOKEN_TREASURY, OWNER),
+                                moving(15, TOKEN_WITH_CUSTOM_FEE).between(TOKEN_TREASURY, OWNER),
+                                movingUnique(NON_FUNGIBLE_TOKEN, 1L, 2L, 3L, 4L, 5L, 6L)
+                                        .between(TOKEN_TREASURY, OWNER)),
+                        cryptoApproveAllowance()
+                                .payingWith(OWNER)
+                                .addCryptoAllowance(OWNER, SPENDER, 10 * ONE_HBAR)
+                                .addTokenAllowance(OWNER, FUNGIBLE_TOKEN, SPENDER, 1500)
+                                .addTokenAllowance(OWNER, TOKEN_WITH_CUSTOM_FEE, SPENDER, 100)
+                                .addNftAllowance(
+                                        OWNER,
+                                        NON_FUNGIBLE_TOKEN,
+                                        SPENDER,
+                                        false,
+                                        List.of(1L, 2L, 3L, 4L, 6L))
+                                .fee(ONE_HUNDRED_HBARS))
+                .then(
+                        cryptoTransfer(
+                                        movingWithAllowance(10, TOKEN_WITH_CUSTOM_FEE)
+                                                .between(OWNER, RECEIVER))
+                                .payingWith(SPENDER)
+                                .signedBy(SPENDER)
+                                .fee(ONE_HBAR)
+                                .hasKnownStatus(INSUFFICIENT_SENDER_ACCOUNT_BALANCE_FOR_CUSTOM_FEE),
+                        cryptoTransfer(
+                                        movingWithAllowance(100, FUNGIBLE_TOKEN)
+                                                .between(OWNER, OWNER))
+                                .payingWith(SPENDER)
+                                .signedBy(SPENDER)
+                                .dontFullyAggregateTokenTransfers()
+                                .hasPrecheck(ACCOUNT_REPEATED_IN_ACCOUNT_AMOUNTS),
+                        cryptoTransfer(
+                                        movingUniqueWithAllowance(NON_FUNGIBLE_TOKEN, 3)
+                                                .between(OWNER, OTHER_RECEIVER))
+                                .payingWith(SPENDER)
+                                .signedBy(SPENDER),
+                        cryptoTransfer(
+                                        movingWithAllowance(100, FUNGIBLE_TOKEN)
+                                                .between(OWNER, OTHER_RECEIVER))
+                                .payingWith(SPENDER)
+                                .signedBy(SPENDER)
+                                .hasKnownStatus(NO_REMAINING_AUTOMATIC_ASSOCIATIONS),
+                        cryptoUpdate(OTHER_RECEIVER)
+                                .receiverSigRequired(true)
+                                .maxAutomaticAssociations(2),
+                        cryptoTransfer(
+                                        movingUniqueWithAllowance(NON_FUNGIBLE_TOKEN, 4)
+                                                .between(OWNER, OTHER_RECEIVER))
+                                .payingWith(SPENDER)
+                                .signedBy(SPENDER)
+                                .hasKnownStatus(INVALID_SIGNATURE),
+                        cryptoTransfer(
+                                        movingUniqueWithAllowance(NON_FUNGIBLE_TOKEN, 4)
+                                                .between(OWNER, OTHER_RECEIVER))
+                                .payingWith(SPENDER)
+                                .signedBy(SPENDER, OTHER_RECEIVER),
+                        cryptoTransfer(
+                                movingUnique(NON_FUNGIBLE_TOKEN, 6).between(OWNER, RECEIVER)),
+                        cryptoTransfer(
+                                        movingUniqueWithAllowance(NON_FUNGIBLE_TOKEN, 6)
+                                                .between(OWNER, RECEIVER))
+                                .payingWith(SPENDER)
+                                .signedBy(SPENDER)
+                                .hasKnownStatus(SPENDER_DOES_NOT_HAVE_ALLOWANCE),
+                        cryptoTransfer(
+                                        movingUniqueWithAllowance(NON_FUNGIBLE_TOKEN, 6)
+                                                .between(RECEIVER, OWNER))
+                                .payingWith(SPENDER)
+                                .signedBy(SPENDER)
+                                .hasKnownStatus(SPENDER_DOES_NOT_HAVE_ALLOWANCE),
+                        cryptoTransfer(
+                                movingUnique(NON_FUNGIBLE_TOKEN, 6).between(RECEIVER, OWNER)),
+                        cryptoTransfer(
+                                        movingUniqueWithAllowance(NON_FUNGIBLE_TOKEN, 6)
+                                                .between(OWNER, RECEIVER))
+                                .payingWith(SPENDER)
+                                .signedBy(SPENDER)
+                                .hasKnownStatus(SPENDER_DOES_NOT_HAVE_ALLOWANCE),
+                        cryptoTransfer(
+                                movingUnique(NON_FUNGIBLE_TOKEN, 6).between(OWNER, RECEIVER)),
+                        tokenAssociate(OTHER_RECEIVER, FUNGIBLE_TOKEN),
+                        grantTokenKyc(FUNGIBLE_TOKEN, OTHER_RECEIVER),
+                        cryptoTransfer(
+                                        movingWithAllowance(1100, FUNGIBLE_TOKEN)
+                                                .between(OWNER, OTHER_RECEIVER))
+                                .payingWith(SPENDER)
+                                .signedBy(SPENDER, OTHER_RECEIVER)
+                                .hasKnownStatus(INSUFFICIENT_TOKEN_BALANCE),
+                        cryptoTransfer(allowanceTinyBarsFromTo(OWNER, RECEIVER, 5 * ONE_HBAR))
+                                .payingWith(DEFAULT_PAYER)
+                                .signedBy(DEFAULT_PAYER)
+                                .hasKnownStatus(SPENDER_DOES_NOT_HAVE_ALLOWANCE),
+                        tokenPause(FUNGIBLE_TOKEN),
+                        cryptoTransfer(
+                                        movingWithAllowance(50, FUNGIBLE_TOKEN)
+                                                .between(OWNER, RECEIVER),
+                                        movingUniqueWithAllowance(NON_FUNGIBLE_TOKEN, 1)
+                                                .between(OWNER, RECEIVER))
+                                .payingWith(SPENDER)
+                                .signedBy(SPENDER)
+                                .hasKnownStatus(TOKEN_IS_PAUSED),
+                        tokenUnpause(FUNGIBLE_TOKEN),
+                        tokenFreeze(FUNGIBLE_TOKEN, OWNER),
+                        cryptoTransfer(
+                                        movingWithAllowance(50, FUNGIBLE_TOKEN)
+                                                .between(OWNER, RECEIVER),
+                                        movingUniqueWithAllowance(NON_FUNGIBLE_TOKEN, 1)
+                                                .between(OWNER, RECEIVER))
+                                .payingWith(SPENDER)
+                                .signedBy(SPENDER)
+                                .hasKnownStatus(ACCOUNT_FROZEN_FOR_TOKEN),
+                        tokenUnfreeze(FUNGIBLE_TOKEN, OWNER),
+                        revokeTokenKyc(FUNGIBLE_TOKEN, RECEIVER),
+                        cryptoTransfer(
+                                        movingWithAllowance(50, FUNGIBLE_TOKEN)
+                                                .between(OWNER, RECEIVER),
+                                        movingUniqueWithAllowance(NON_FUNGIBLE_TOKEN, 1)
+                                                .between(OWNER, RECEIVER))
+                                .payingWith(SPENDER)
+                                .signedBy(SPENDER)
+                                .hasKnownStatus(ACCOUNT_KYC_NOT_GRANTED_FOR_TOKEN),
+                        grantTokenKyc(FUNGIBLE_TOKEN, RECEIVER),
+                        cryptoTransfer(
+                                        allowanceTinyBarsFromTo(OWNER, RECEIVER, 5 * ONE_HBAR),
+                                        tinyBarsFromTo(SPENDER, RECEIVER, ONE_HBAR))
+                                .payingWith(SPENDER)
+                                .signedBy(SPENDER),
+                        cryptoTransfer(
+                                        movingWithAllowance(50, FUNGIBLE_TOKEN)
+                                                .between(OWNER, RECEIVER),
+                                        movingUniqueWithAllowance(NON_FUNGIBLE_TOKEN, 1)
+                                                .between(OWNER, RECEIVER))
+                                .payingWith(SPENDER)
+                                .signedBy(SPENDER),
+                        cryptoTransfer(allowanceTinyBarsFromTo(OWNER, RECEIVER, 5 * ONE_HBAR + 1))
+                                .payingWith(SPENDER)
+                                .signedBy(SPENDER)
+                                .hasKnownStatus(AMOUNT_EXCEEDS_ALLOWANCE),
+                        cryptoTransfer(
+                                        movingWithAllowance(50, FUNGIBLE_TOKEN)
+                                                .between(OWNER, RECEIVER),
+                                        movingUniqueWithAllowance(NON_FUNGIBLE_TOKEN, 5)
+                                                .between(OWNER, RECEIVER))
+                                .payingWith(SPENDER)
+                                .signedBy(SPENDER)
+                                .hasKnownStatus(SPENDER_DOES_NOT_HAVE_ALLOWANCE),
+                        getAccountDetails(OWNER)
+                                .payingWith(GENESIS)
+                                .has(
+                                        AccountDetailsAsserts.accountWith()
+                                                .tokenAllowancesContaining(
+                                                        FUNGIBLE_TOKEN, SPENDER, 1450))
+                                .hasToken(relationshipWith(FUNGIBLE_TOKEN).balance(950L)),
+                        cryptoTransfer(moving(1000, FUNGIBLE_TOKEN).between(TOKEN_TREASURY, OWNER)),
+                        cryptoTransfer(
+                                        movingUniqueWithAllowance(NON_FUNGIBLE_TOKEN, 2L)
+                                                .between(OWNER, RECEIVER),
+                                        movingWithAllowance(1451, FUNGIBLE_TOKEN)
+                                                .between(OWNER, RECEIVER))
+                                .payingWith(SPENDER)
+                                .signedBy(SPENDER)
+                                .hasKnownStatus(AMOUNT_EXCEEDS_ALLOWANCE),
+                        getAccountInfo(OWNER)
+                                .hasToken(relationshipWith(NON_FUNGIBLE_TOKEN).balance(2)),
+                        cryptoTransfer(allowanceTinyBarsFromTo(OWNER, RECEIVER, 5 * ONE_HBAR))
+                                .payingWith(SPENDER)
+                                .signedBy(SPENDER),
+                        cryptoTransfer(
+                                        movingWithAllowance(50, FUNGIBLE_TOKEN)
+                                                .between(OWNER, RECEIVER),
+                                        movingUniqueWithAllowance(NON_FUNGIBLE_TOKEN, 2L)
+                                                .between(OWNER, RECEIVER))
+                                .payingWith(SPENDER)
+                                .signedBy(SPENDER),
+                        cryptoTransfer(allowanceTinyBarsFromTo(OWNER, RECEIVER, 5 * ONE_HBAR))
+                                .payingWith(SPENDER)
+                                .signedBy(SPENDER)
+                                .hasKnownStatus(SPENDER_DOES_NOT_HAVE_ALLOWANCE),
+                        cryptoTransfer(
+                                movingUnique(NON_FUNGIBLE_TOKEN, 2L).between(RECEIVER, OWNER)),
+                        cryptoTransfer(
+                                        movingUniqueWithAllowance(NON_FUNGIBLE_TOKEN, 2L)
+                                                .between(OWNER, RECEIVER))
+                                .payingWith(SPENDER)
+                                .signedBy(SPENDER)
+                                .hasKnownStatus(SPENDER_DOES_NOT_HAVE_ALLOWANCE),
+                        cryptoApproveAllowance()
+                                .payingWith(OWNER)
+                                .addNftAllowance(
+                                        OWNER, NON_FUNGIBLE_TOKEN, SPENDER, true, List.of())
+                                .fee(ONE_HUNDRED_HBARS),
+                        cryptoTransfer(
+                                        movingUniqueWithAllowance(NON_FUNGIBLE_TOKEN, 2L)
+                                                .between(OWNER, RECEIVER))
+                                .payingWith(SPENDER)
+                                .signedBy(SPENDER),
+                        cryptoTransfer(
+                                movingUnique(NON_FUNGIBLE_TOKEN, 2L).between(RECEIVER, OWNER)),
+                        cryptoTransfer(
+                                        movingUniqueWithAllowance(NON_FUNGIBLE_TOKEN, 2L)
+                                                .between(OWNER, RECEIVER))
+                                .payingWith(SPENDER)
+                                .signedBy(SPENDER),
+                        getAccountDetails(OWNER)
+                                .payingWith(GENESIS)
+                                .has(
+                                        AccountDetailsAsserts.accountWith()
+                                                .cryptoAllowancesCount(0)
+                                                .tokenAllowancesContaining(
+                                                        FUNGIBLE_TOKEN, SPENDER, 1400)
+                                                .nftApprovedAllowancesContaining(
+                                                        NON_FUNGIBLE_TOKEN, SPENDER)));
+    }
 
-	private HapiApiSpec checksExpectedDecimalsForFungibleTokenTransferList() {
-		return defaultHapiSpec("checksExpectedDecimalsForFungibleTokenTransferList")
-				.given(
-						newKeyNamed(MULTI_KEY),
-						cryptoCreate(TOKEN_TREASURY),
-						cryptoCreate(OWNING_PARTY).maxAutomaticTokenAssociations(123),
-						tokenCreate(FUNGIBLE_TOKEN)
-								.tokenType(FUNGIBLE_COMMON)
-								.treasury(TOKEN_TREASURY)
-								.decimals(2)
-								.initialSupply(1234)
-								.via("tokenCreate"),
-						getTxnRecord("tokenCreate")
-								.hasNewTokenAssociation(FUNGIBLE_TOKEN, TOKEN_TREASURY),
-						cryptoTransfer(
-								moving(100, FUNGIBLE_TOKEN)
-										.between(TOKEN_TREASURY, OWNING_PARTY))
-								.via("initialXfer"),
-						getTxnRecord("initialXfer")
-								.hasNewTokenAssociation(FUNGIBLE_TOKEN, OWNING_PARTY))
-				.when(
-						getAccountInfo(OWNING_PARTY).savingSnapshot(OWNING_PARTY),
-						cryptoTransfer(
-								movingWithDecimals(10, FUNGIBLE_TOKEN, 4)
-										.betweenWithDecimals(TOKEN_TREASURY, OWNING_PARTY))
-								.signedBy(DEFAULT_PAYER, OWNING_PARTY, TOKEN_TREASURY)
-								.hasKnownStatus(UNEXPECTED_TOKEN_DECIMALS)
-								.via("failedTxn"),
-						cryptoTransfer(
-								movingWithDecimals(20, FUNGIBLE_TOKEN, 2)
-										.betweenWithDecimals(TOKEN_TREASURY, OWNING_PARTY))
-								.signedBy(DEFAULT_PAYER, OWNING_PARTY, TOKEN_TREASURY)
-								.hasKnownStatus(SUCCESS)
-								.via(VALID_TXN),
-						usableTxnIdNamed(UNCHECKED_TXN).payerId(DEFAULT_PAYER),
-						uncheckedSubmit(
-								cryptoTransfer(
-										movingWithDecimals(10, FUNGIBLE_TOKEN, 4)
-												.betweenWithDecimals(
-														TOKEN_TREASURY,
-														OWNING_PARTY))
-										.signedBy(
-												DEFAULT_PAYER, OWNING_PARTY, TOKEN_TREASURY)
-										.txnId(UNCHECKED_TXN))
-								.payingWith(GENESIS))
-				.then(
-						sleepFor(5_000),
-						getReceipt(UNCHECKED_TXN)
-								.hasPriorityStatus(UNEXPECTED_TOKEN_DECIMALS)
-								.logged(),
-						getReceipt(VALID_TXN).hasPriorityStatus(SUCCESS),
-						getTxnRecord(VALID_TXN).logged(),
-						getAccountInfo(OWNING_PARTY)
-								.hasAlreadyUsedAutomaticAssociations(1)
-								.hasToken(relationshipWith(FUNGIBLE_TOKEN).balance(120))
-								.logged());
-	}
+    private HapiApiSpec checksExpectedDecimalsForFungibleTokenTransferList() {
+        return defaultHapiSpec("checksExpectedDecimalsForFungibleTokenTransferList")
+                .given(
+                        newKeyNamed(MULTI_KEY),
+                        cryptoCreate(TOKEN_TREASURY),
+                        cryptoCreate(OWNING_PARTY).maxAutomaticTokenAssociations(123),
+                        tokenCreate(FUNGIBLE_TOKEN)
+                                .tokenType(FUNGIBLE_COMMON)
+                                .treasury(TOKEN_TREASURY)
+                                .decimals(2)
+                                .initialSupply(1234)
+                                .via("tokenCreate"),
+                        getTxnRecord("tokenCreate")
+                                .hasNewTokenAssociation(FUNGIBLE_TOKEN, TOKEN_TREASURY),
+                        cryptoTransfer(
+                                        moving(100, FUNGIBLE_TOKEN)
+                                                .between(TOKEN_TREASURY, OWNING_PARTY))
+                                .via("initialXfer"),
+                        getTxnRecord("initialXfer")
+                                .hasNewTokenAssociation(FUNGIBLE_TOKEN, OWNING_PARTY))
+                .when(
+                        getAccountInfo(OWNING_PARTY).savingSnapshot(OWNING_PARTY),
+                        cryptoTransfer(
+                                        movingWithDecimals(10, FUNGIBLE_TOKEN, 4)
+                                                .betweenWithDecimals(TOKEN_TREASURY, OWNING_PARTY))
+                                .signedBy(DEFAULT_PAYER, OWNING_PARTY, TOKEN_TREASURY)
+                                .hasKnownStatus(UNEXPECTED_TOKEN_DECIMALS)
+                                .via("failedTxn"),
+                        cryptoTransfer(
+                                        movingWithDecimals(20, FUNGIBLE_TOKEN, 2)
+                                                .betweenWithDecimals(TOKEN_TREASURY, OWNING_PARTY))
+                                .signedBy(DEFAULT_PAYER, OWNING_PARTY, TOKEN_TREASURY)
+                                .hasKnownStatus(SUCCESS)
+                                .via(VALID_TXN),
+                        usableTxnIdNamed(UNCHECKED_TXN).payerId(DEFAULT_PAYER),
+                        uncheckedSubmit(
+                                        cryptoTransfer(
+                                                        movingWithDecimals(10, FUNGIBLE_TOKEN, 4)
+                                                                .betweenWithDecimals(
+                                                                        TOKEN_TREASURY,
+                                                                        OWNING_PARTY))
+                                                .signedBy(
+                                                        DEFAULT_PAYER, OWNING_PARTY, TOKEN_TREASURY)
+                                                .txnId(UNCHECKED_TXN))
+                                .payingWith(GENESIS))
+                .then(
+                        sleepFor(5_000),
+                        getReceipt(UNCHECKED_TXN)
+                                .hasPriorityStatus(UNEXPECTED_TOKEN_DECIMALS)
+                                .logged(),
+                        getReceipt(VALID_TXN).hasPriorityStatus(SUCCESS),
+                        getTxnRecord(VALID_TXN).logged(),
+                        getAccountInfo(OWNING_PARTY)
+                                .hasAlreadyUsedAutomaticAssociations(1)
+                                .hasToken(relationshipWith(FUNGIBLE_TOKEN).balance(120))
+                                .logged());
+    }
 
-	private HapiApiSpec nftTransfersCannotRepeatSerialNos() {
-		final var aParty = "aParty";
-		final var bParty = "bParty";
-		final var cParty = "cParty";
-		final var dParty = "dParty";
-		final var multipurpose = MULTI_KEY;
-		final var nftType = "nftType";
-		final var hotTxn = "hotTxn";
-		final var mintTxn = "mintTxn";
+    private HapiApiSpec nftTransfersCannotRepeatSerialNos() {
+        final var aParty = "aParty";
+        final var bParty = "bParty";
+        final var cParty = "cParty";
+        final var dParty = "dParty";
+        final var multipurpose = MULTI_KEY;
+        final var nftType = "nftType";
+        final var hotTxn = "hotTxn";
+        final var mintTxn = "mintTxn";
 
-		return defaultHapiSpec("NftTransfersCannotRepeatSerialNos")
-				.given(
-						newKeyNamed(multipurpose),
-						cryptoCreate(TOKEN_TREASURY),
-						cryptoCreate(aParty).maxAutomaticTokenAssociations(1),
-						cryptoCreate(bParty).maxAutomaticTokenAssociations(1),
-						cryptoCreate(cParty).maxAutomaticTokenAssociations(1),
-						cryptoCreate(dParty).maxAutomaticTokenAssociations(1),
-						tokenCreate(nftType)
-								.tokenType(NON_FUNGIBLE_UNIQUE)
-								.treasury(TOKEN_TREASURY)
-								.supplyKey(multipurpose)
-								.initialSupply(0),
-						mintToken(nftType, List.of(copyFromUtf8("Hot potato!"))).via(mintTxn),
-						getTxnRecord(mintTxn).logged())
-				.when(cryptoTransfer(movingUnique(nftType, 1L).between(TOKEN_TREASURY, aParty)))
-				.then(
-						cryptoTransfer(
-								(spec, b) -> {
-									final var registry = spec.registry();
-									final var aId = registry.getAccountID(aParty);
-									final var bId = registry.getAccountID(bParty);
-									final var cId = registry.getAccountID(cParty);
-									final var dId = registry.getAccountID(dParty);
-									b.addTokenTransfers(
-											TokenTransferList.newBuilder()
-													.setToken(registry.getTokenID(nftType))
-													.addNftTransfers(ocWith(aId, bId, 1))
-													.addNftTransfers(ocWith(bId, cId, 1))
-													.addNftTransfers(ocWith(cId, dId, 1)));
-								})
-								.via(hotTxn)
-								.signedBy(DEFAULT_PAYER, aParty, bParty, cParty)
-								.hasPrecheck(INVALID_ACCOUNT_AMOUNTS));
-	}
+        return defaultHapiSpec("NftTransfersCannotRepeatSerialNos")
+                .given(
+                        newKeyNamed(multipurpose),
+                        cryptoCreate(TOKEN_TREASURY),
+                        cryptoCreate(aParty).maxAutomaticTokenAssociations(1),
+                        cryptoCreate(bParty).maxAutomaticTokenAssociations(1),
+                        cryptoCreate(cParty).maxAutomaticTokenAssociations(1),
+                        cryptoCreate(dParty).maxAutomaticTokenAssociations(1),
+                        tokenCreate(nftType)
+                                .tokenType(NON_FUNGIBLE_UNIQUE)
+                                .treasury(TOKEN_TREASURY)
+                                .supplyKey(multipurpose)
+                                .initialSupply(0),
+                        mintToken(nftType, List.of(copyFromUtf8("Hot potato!"))).via(mintTxn),
+                        getTxnRecord(mintTxn).logged())
+                .when(cryptoTransfer(movingUnique(nftType, 1L).between(TOKEN_TREASURY, aParty)))
+                .then(
+                        cryptoTransfer(
+                                        (spec, b) -> {
+                                            final var registry = spec.registry();
+                                            final var aId = registry.getAccountID(aParty);
+                                            final var bId = registry.getAccountID(bParty);
+                                            final var cId = registry.getAccountID(cParty);
+                                            final var dId = registry.getAccountID(dParty);
+                                            b.addTokenTransfers(
+                                                    TokenTransferList.newBuilder()
+                                                            .setToken(registry.getTokenID(nftType))
+                                                            .addNftTransfers(ocWith(aId, bId, 1))
+                                                            .addNftTransfers(ocWith(bId, cId, 1))
+                                                            .addNftTransfers(ocWith(cId, dId, 1)));
+                                        })
+                                .via(hotTxn)
+                                .signedBy(DEFAULT_PAYER, aParty, bParty, cParty)
+                                .hasPrecheck(INVALID_ACCOUNT_AMOUNTS));
+    }
 
-	private HapiApiSpec noStakePeriodStartIfNotStakingToNode() {
-		final var user = "user";
-		final var contract = "contract";
-		return defaultHapiSpec("NoStakePeriodStartIfNotStakingToNode")
-				.given(
-						newKeyNamed(ADMIN_KEY),
-						cryptoCreate(user)
-								.key(ADMIN_KEY)
-								.stakedNodeId(0L),
-						createDefaultContract(contract)
-								.adminKey(ADMIN_KEY)
-								.stakedNodeId(0L),
-						getAccountInfo(user).has(accountWith().someStakePeriodStart()),
-						getContractInfo(contract).has(contractWith().someStakePeriodStart())
-				).when(
-						cryptoUpdate(user).newStakedAccountId(contract),
-						contractUpdate(contract).newStakedAccountId(user)
-				).then(
-						getAccountInfo(user).has(accountWith().noStakePeriodStart()),
-						getContractInfo(contract).has(contractWith().noStakePeriodStart())
-				);
-	}
+    private HapiApiSpec nftSelfTransfersRejectedBothInPrecheckAndHandle() {
+        final var owningParty = OWNING_PARTY;
+        final var multipurpose = MULTI_KEY;
+        final var nftType = "nftType";
+        final var uncheckedTxn = UNCHECKED_TXN;
 
-	private HapiApiSpec nftSelfTransfersRejectedBothInPrecheckAndHandle() {
-		final var owningParty = OWNING_PARTY;
-		final var multipurpose = MULTI_KEY;
-		final var nftType = "nftType";
-		final var uncheckedTxn = UNCHECKED_TXN;
+        return defaultHapiSpec("NftSelfTransfersRejectedBothInPrecheckAndHandle")
+                .given(
+                        newKeyNamed(multipurpose),
+                        cryptoCreate(TOKEN_TREASURY),
+                        cryptoCreate(owningParty).maxAutomaticTokenAssociations(123),
+                        tokenCreate(nftType)
+                                .tokenType(NON_FUNGIBLE_UNIQUE)
+                                .treasury(TOKEN_TREASURY)
+                                .supplyKey(multipurpose)
+                                .initialSupply(0),
+                        mintToken(
+                                nftType,
+                                List.of(
+                                        copyFromUtf8("We"),
+                                        copyFromUtf8("are"),
+                                        copyFromUtf8("the"))),
+                        cryptoTransfer(
+                                movingUnique(nftType, 1L, 2L).between(TOKEN_TREASURY, owningParty)))
+                .when(
+                        getAccountInfo(owningParty).savingSnapshot(owningParty),
+                        cryptoTransfer(movingUnique(nftType, 1L).between(owningParty, owningParty))
+                                .signedBy(DEFAULT_PAYER, owningParty)
+                                .hasPrecheck(ACCOUNT_REPEATED_IN_ACCOUNT_AMOUNTS),
+                        usableTxnIdNamed(uncheckedTxn).payerId(DEFAULT_PAYER),
+                        uncheckedSubmit(
+                                        cryptoTransfer(
+                                                        movingUnique(nftType, 1L)
+                                                                .between(owningParty, owningParty))
+                                                .signedBy(DEFAULT_PAYER, owningParty)
+                                                .txnId(uncheckedTxn))
+                                .payingWith(GENESIS))
+                .then(
+                        sleepFor(2_000),
+                        getReceipt(uncheckedTxn)
+                                .hasPriorityStatus(ACCOUNT_REPEATED_IN_ACCOUNT_AMOUNTS),
+                        getAccountInfo(owningParty)
+                                .has(accountWith().noChangesFromSnapshot(owningParty)));
+    }
 
-		return defaultHapiSpec("NftSelfTransfersRejectedBothInPrecheckAndHandle")
-				.given(
-						newKeyNamed(multipurpose),
-						cryptoCreate(TOKEN_TREASURY),
-						cryptoCreate(owningParty).maxAutomaticTokenAssociations(123),
-						tokenCreate(nftType)
-								.tokenType(NON_FUNGIBLE_UNIQUE)
-								.treasury(TOKEN_TREASURY)
-								.supplyKey(multipurpose)
-								.initialSupply(0),
-						mintToken(
-								nftType,
-								List.of(
-										copyFromUtf8("We"),
-										copyFromUtf8("are"),
-										copyFromUtf8("the"))),
-						cryptoTransfer(
-								movingUnique(nftType, 1L, 2L).between(TOKEN_TREASURY, owningParty)))
-				.when(
-						getAccountInfo(owningParty).savingSnapshot(owningParty),
-						cryptoTransfer(movingUnique(nftType, 1L).between(owningParty, owningParty))
-								.signedBy(DEFAULT_PAYER, owningParty)
-								.hasPrecheck(ACCOUNT_REPEATED_IN_ACCOUNT_AMOUNTS),
-						usableTxnIdNamed(uncheckedTxn).payerId(DEFAULT_PAYER),
-						uncheckedSubmit(
-								cryptoTransfer(
-										movingUnique(nftType, 1L)
-												.between(owningParty, owningParty))
-										.signedBy(DEFAULT_PAYER, owningParty)
-										.txnId(uncheckedTxn))
-								.payingWith(GENESIS))
-				.then(
-						sleepFor(2_000),
-						getReceipt(uncheckedTxn)
-								.hasPriorityStatus(ACCOUNT_REPEATED_IN_ACCOUNT_AMOUNTS),
-						getAccountInfo(owningParty)
-								.has(accountWith().noChangesFromSnapshot(owningParty)));
-	}
+    private HapiApiSpec hbarAndFungibleSelfTransfersRejectedBothInPrecheckAndHandle() {
+        final var uncheckedHbarTxn = "uncheckedHbarTxn";
+        final var uncheckedFtTxn = "uncheckedFtTxn";
 
-	private HapiApiSpec hbarAndFungibleSelfTransfersRejectedBothInPrecheckAndHandle() {
-		final var uncheckedHbarTxn = "uncheckedHbarTxn";
-		final var uncheckedFtTxn = "uncheckedFtTxn";
+        return defaultHapiSpec("HbarAndFungibleSelfTransfersRejectedBothInPrecheckAndHandle")
+                .given(
+                        newKeyNamed(MULTI_KEY),
+                        cryptoCreate(TOKEN_TREASURY),
+                        cryptoCreate(OWNING_PARTY).maxAutomaticTokenAssociations(123),
+                        tokenCreate(FUNGIBLE_TOKEN)
+                                .tokenType(FUNGIBLE_COMMON)
+                                .treasury(TOKEN_TREASURY)
+                                .initialSupply(1234),
+                        cryptoTransfer(
+                                moving(100, FUNGIBLE_TOKEN).between(TOKEN_TREASURY, OWNING_PARTY)))
+                .when(
+                        getAccountInfo(OWNING_PARTY).savingSnapshot(OWNING_PARTY),
+                        cryptoTransfer(tinyBarsFromTo(OWNING_PARTY, OWNING_PARTY, 1))
+                                .signedBy(DEFAULT_PAYER, OWNING_PARTY)
+                                .hasPrecheck(ACCOUNT_REPEATED_IN_ACCOUNT_AMOUNTS),
+                        cryptoTransfer(
+                                        moving(1, FUNGIBLE_TOKEN)
+                                                .between(OWNING_PARTY, OWNING_PARTY))
+                                .signedBy(DEFAULT_PAYER, OWNING_PARTY)
+                                .dontFullyAggregateTokenTransfers()
+                                .hasPrecheck(ACCOUNT_REPEATED_IN_ACCOUNT_AMOUNTS),
+                        /* And bypassing precheck */
+                        usableTxnIdNamed(uncheckedHbarTxn).payerId(DEFAULT_PAYER),
+                        usableTxnIdNamed(uncheckedFtTxn).payerId(DEFAULT_PAYER),
+                        uncheckedSubmit(
+                                        cryptoTransfer(
+                                                        tinyBarsFromTo(
+                                                                OWNING_PARTY, OWNING_PARTY, 1))
+                                                .signedBy(DEFAULT_PAYER, OWNING_PARTY)
+                                                .txnId(uncheckedHbarTxn))
+                                .payingWith(GENESIS),
+                        uncheckedSubmit(
+                                        cryptoTransfer(
+                                                        moving(1, FUNGIBLE_TOKEN)
+                                                                .between(
+                                                                        OWNING_PARTY, OWNING_PARTY))
+                                                .signedBy(DEFAULT_PAYER, OWNING_PARTY)
+                                                .dontFullyAggregateTokenTransfers()
+                                                .txnId(uncheckedFtTxn))
+                                .payingWith(GENESIS))
+                .then(
+                        sleepFor(5_000),
+                        getReceipt(uncheckedHbarTxn)
+                                .hasPriorityStatus(ACCOUNT_REPEATED_IN_ACCOUNT_AMOUNTS),
+                        getReceipt(uncheckedFtTxn)
+                                .hasPriorityStatus(ACCOUNT_REPEATED_IN_ACCOUNT_AMOUNTS),
+                        getAccountInfo(OWNING_PARTY)
+                                .has(accountWith().noChangesFromSnapshot(OWNING_PARTY)));
+    }
 
-		return defaultHapiSpec("HbarAndFungibleSelfTransfersRejectedBothInPrecheckAndHandle")
-				.given(
-						newKeyNamed(MULTI_KEY),
-						cryptoCreate(TOKEN_TREASURY),
-						cryptoCreate(OWNING_PARTY).maxAutomaticTokenAssociations(123),
-						tokenCreate(FUNGIBLE_TOKEN)
-								.tokenType(FUNGIBLE_COMMON)
-								.treasury(TOKEN_TREASURY)
-								.initialSupply(1234),
-						cryptoTransfer(
-								moving(100, FUNGIBLE_TOKEN).between(TOKEN_TREASURY, OWNING_PARTY)))
-				.when(
-						getAccountInfo(OWNING_PARTY).savingSnapshot(OWNING_PARTY),
-						cryptoTransfer(tinyBarsFromTo(OWNING_PARTY, OWNING_PARTY, 1))
-								.signedBy(DEFAULT_PAYER, OWNING_PARTY)
-								.hasPrecheck(ACCOUNT_REPEATED_IN_ACCOUNT_AMOUNTS),
-						cryptoTransfer(
-								moving(1, FUNGIBLE_TOKEN)
-										.between(OWNING_PARTY, OWNING_PARTY))
-								.signedBy(DEFAULT_PAYER, OWNING_PARTY)
-								.dontFullyAggregateTokenTransfers()
-								.hasPrecheck(ACCOUNT_REPEATED_IN_ACCOUNT_AMOUNTS),
-						/* And bypassing precheck */
-						usableTxnIdNamed(uncheckedHbarTxn).payerId(DEFAULT_PAYER),
-						usableTxnIdNamed(uncheckedFtTxn).payerId(DEFAULT_PAYER),
-						uncheckedSubmit(
-								cryptoTransfer(
-										tinyBarsFromTo(
-												OWNING_PARTY, OWNING_PARTY, 1))
-										.signedBy(DEFAULT_PAYER, OWNING_PARTY)
-										.txnId(uncheckedHbarTxn))
-								.payingWith(GENESIS),
-						uncheckedSubmit(
-								cryptoTransfer(
-										moving(1, FUNGIBLE_TOKEN)
-												.between(
-														OWNING_PARTY, OWNING_PARTY))
-										.signedBy(DEFAULT_PAYER, OWNING_PARTY)
-										.dontFullyAggregateTokenTransfers()
-										.txnId(uncheckedFtTxn))
-								.payingWith(GENESIS))
-				.then(
-						sleepFor(5_000),
-						getReceipt(uncheckedHbarTxn)
-								.hasPriorityStatus(ACCOUNT_REPEATED_IN_ACCOUNT_AMOUNTS),
-						getReceipt(uncheckedFtTxn)
-								.hasPriorityStatus(ACCOUNT_REPEATED_IN_ACCOUNT_AMOUNTS),
-						getAccountInfo(OWNING_PARTY)
-								.has(accountWith().noChangesFromSnapshot(OWNING_PARTY)));
-	}
+    private HapiApiSpec dissociatedRoyaltyCollectorsCanUseAutoAssociation() {
+        final var commonWithCustomFees = "commonWithCustomFees";
+        final var fractionalCollector = "fractionalCollector";
+        final var selfDenominatedCollector = "selfDenominatedCollector";
+        final var plentyOfSlots = 10;
 
-	private HapiApiSpec dissociatedRoyaltyCollectorsCanUseAutoAssociation() {
-		final var commonWithCustomFees = "commonWithCustomFees";
-		final var fractionalCollector = "fractionalCollector";
-		final var selfDenominatedCollector = "selfDenominatedCollector";
-		final var plentyOfSlots = 10;
+        return defaultHapiSpec("RoyaltyCollectorsCanUseAutoAssociation")
+                .given(
+                        cryptoCreate(TOKEN_TREASURY),
+                        cryptoCreate(fractionalCollector)
+                                .maxAutomaticTokenAssociations(plentyOfSlots),
+                        cryptoCreate(selfDenominatedCollector)
+                                .maxAutomaticTokenAssociations(plentyOfSlots),
+                        cryptoCreate(PARTY).maxAutomaticTokenAssociations(plentyOfSlots),
+                        cryptoCreate(COUNTERPARTY).maxAutomaticTokenAssociations(plentyOfSlots),
+                        newKeyNamed(MULTI_KEY),
+                        getAccountInfo(PARTY).savingSnapshot(PARTY),
+                        getAccountInfo(COUNTERPARTY).savingSnapshot(COUNTERPARTY),
+                        getAccountInfo(fractionalCollector).savingSnapshot(fractionalCollector),
+                        getAccountInfo(selfDenominatedCollector)
+                                .savingSnapshot(selfDenominatedCollector))
+                .when(
+                        tokenCreate(commonWithCustomFees)
+                                .tokenType(FUNGIBLE_COMMON)
+                                .treasury(TOKEN_TREASURY)
+                                .withCustom(
+                                        fractionalFee(
+                                                1,
+                                                10,
+                                                0,
+                                                OptionalLong.empty(),
+                                                fractionalCollector))
+                                .withCustom(fixedHtsFee(5, "0.0.0", selfDenominatedCollector))
+                                .initialSupply(Long.MAX_VALUE)
+                                .signedBy(
+                                        DEFAULT_PAYER,
+                                        TOKEN_TREASURY,
+                                        fractionalCollector,
+                                        selfDenominatedCollector),
+                        cryptoTransfer(
+                                moving(1_000_000, commonWithCustomFees)
+                                        .between(TOKEN_TREASURY, PARTY)),
+                        tokenDissociate(fractionalCollector, commonWithCustomFees),
+                        tokenDissociate(selfDenominatedCollector, commonWithCustomFees))
+                .then(
+                        cryptoTransfer(
+                                        moving(1000, commonWithCustomFees)
+                                                .between(PARTY, COUNTERPARTY))
+                                .fee(ONE_HBAR)
+                                .via(HODL_XFER),
+                        getTxnRecord(HODL_XFER)
+                                .hasPriority(
+                                        recordWith()
+                                                .autoAssociated(
+                                                        accountTokenPairsInAnyOrder(
+                                                                List.of(
+                                                                        /* The counterparty auto-associates to the fungible type */
+                                                                        Pair.of(
+                                                                                COUNTERPARTY,
+                                                                                commonWithCustomFees),
+                                                                        /* Both royalty collectors re-auto-associate */
+                                                                        Pair.of(
+                                                                                fractionalCollector,
+                                                                                commonWithCustomFees),
+                                                                        Pair.of(
+                                                                                selfDenominatedCollector,
+                                                                                commonWithCustomFees))))),
+                        getAccountInfo(fractionalCollector)
+                                .has(
+                                        accountWith()
+                                                .newAssociationsFromSnapshot(
+                                                        PARTY,
+                                                        List.of(
+                                                                relationshipWith(
+                                                                                commonWithCustomFees)
+                                                                        .balance(100)))),
+                        getAccountInfo(selfDenominatedCollector)
+                                .has(
+                                        accountWith()
+                                                .newAssociationsFromSnapshot(
+                                                        PARTY,
+                                                        List.of(
+                                                                relationshipWith(
+                                                                                commonWithCustomFees)
+                                                                        .balance(5)))));
+    }
 
-		return defaultHapiSpec("RoyaltyCollectorsCanUseAutoAssociation")
-				.given(
-						cryptoCreate(TOKEN_TREASURY),
-						cryptoCreate(fractionalCollector)
-								.maxAutomaticTokenAssociations(plentyOfSlots),
-						cryptoCreate(selfDenominatedCollector)
-								.maxAutomaticTokenAssociations(plentyOfSlots),
-						cryptoCreate(PARTY).maxAutomaticTokenAssociations(plentyOfSlots),
-						cryptoCreate(COUNTERPARTY).maxAutomaticTokenAssociations(plentyOfSlots),
-						newKeyNamed(MULTI_KEY),
-						getAccountInfo(PARTY).savingSnapshot(PARTY),
-						getAccountInfo(COUNTERPARTY).savingSnapshot(COUNTERPARTY),
-						getAccountInfo(fractionalCollector).savingSnapshot(fractionalCollector),
-						getAccountInfo(selfDenominatedCollector)
-								.savingSnapshot(selfDenominatedCollector))
-				.when(
-						tokenCreate(commonWithCustomFees)
-								.tokenType(FUNGIBLE_COMMON)
-								.treasury(TOKEN_TREASURY)
-								.withCustom(
-										fractionalFee(
-												1,
-												10,
-												0,
-												OptionalLong.empty(),
-												fractionalCollector))
-								.withCustom(fixedHtsFee(5, "0.0.0", selfDenominatedCollector))
-								.initialSupply(Long.MAX_VALUE)
-								.signedBy(
-										DEFAULT_PAYER,
-										TOKEN_TREASURY,
-										fractionalCollector,
-										selfDenominatedCollector),
-						cryptoTransfer(
-								moving(1_000_000, commonWithCustomFees)
-										.between(TOKEN_TREASURY, PARTY)),
-						tokenDissociate(fractionalCollector, commonWithCustomFees),
-						tokenDissociate(selfDenominatedCollector, commonWithCustomFees))
-				.then(
-						cryptoTransfer(
-								moving(1000, commonWithCustomFees)
-										.between(PARTY, COUNTERPARTY))
-								.fee(ONE_HBAR)
-								.via(HODL_XFER),
-						getTxnRecord(HODL_XFER)
-								.hasPriority(
-										recordWith()
-												.autoAssociated(
-														accountTokenPairsInAnyOrder(
-																List.of(
-																		/* The counterparty auto-associates to the
-																		fungible type */
-																		Pair.of(
-																				COUNTERPARTY,
-																				commonWithCustomFees),
-																		/* Both royalty collectors re-auto-associate */
-																		Pair.of(
-																				fractionalCollector,
-																				commonWithCustomFees),
-																		Pair.of(
-																				selfDenominatedCollector,
-																				commonWithCustomFees))))),
-						getAccountInfo(fractionalCollector)
-								.has(
-										accountWith()
-												.newAssociationsFromSnapshot(
-														PARTY,
-														List.of(
-																relationshipWith(
-																		commonWithCustomFees)
-																		.balance(100)))),
-						getAccountInfo(selfDenominatedCollector)
-								.has(
-										accountWith()
-												.newAssociationsFromSnapshot(
-														PARTY,
-														List.of(
-																relationshipWith(
-																		commonWithCustomFees)
-																		.balance(5)))));
-	}
+    private HapiApiSpec royaltyCollectorsCanUseAutoAssociation() {
+        final var uniqueWithRoyalty = "uniqueWithRoyalty";
+        final var firstFungible = "firstFungible";
+        final var secondFungible = "secondFungible";
+        final var firstRoyaltyCollector = "firstRoyaltyCollector";
+        final var secondRoyaltyCollector = "secondRoyaltyCollector";
+        final var plentyOfSlots = 10;
+        final var exchangeAmount = 12 * 15;
+        final var firstRoyaltyAmount = exchangeAmount / 12;
+        final var secondRoyaltyAmount = exchangeAmount / 15;
+        final var netExchangeAmount = exchangeAmount - firstRoyaltyAmount - secondRoyaltyAmount;
 
-	private HapiApiSpec royaltyCollectorsCanUseAutoAssociation() {
-		final var uniqueWithRoyalty = "uniqueWithRoyalty";
-		final var firstFungible = "firstFungible";
-		final var secondFungible = "secondFungible";
-		final var firstRoyaltyCollector = "firstRoyaltyCollector";
-		final var secondRoyaltyCollector = "secondRoyaltyCollector";
-		final var plentyOfSlots = 10;
-		final var exchangeAmount = 12 * 15;
-		final var firstRoyaltyAmount = exchangeAmount / 12;
-		final var secondRoyaltyAmount = exchangeAmount / 15;
-		final var netExchangeAmount = exchangeAmount - firstRoyaltyAmount - secondRoyaltyAmount;
+        return defaultHapiSpec("RoyaltyCollectorsCanUseAutoAssociation")
+                .given(
+                        cryptoCreate(TOKEN_TREASURY),
+                        cryptoCreate(firstRoyaltyCollector)
+                                .maxAutomaticTokenAssociations(plentyOfSlots),
+                        cryptoCreate(secondRoyaltyCollector)
+                                .maxAutomaticTokenAssociations(plentyOfSlots),
+                        cryptoCreate(PARTY).maxAutomaticTokenAssociations(plentyOfSlots),
+                        cryptoCreate(COUNTERPARTY).maxAutomaticTokenAssociations(plentyOfSlots),
+                        newKeyNamed(MULTI_KEY),
+                        getAccountInfo(PARTY).savingSnapshot(PARTY),
+                        getAccountInfo(COUNTERPARTY).savingSnapshot(COUNTERPARTY),
+                        getAccountInfo(firstRoyaltyCollector).savingSnapshot(firstRoyaltyCollector),
+                        getAccountInfo(secondRoyaltyCollector)
+                                .savingSnapshot(secondRoyaltyCollector))
+                .when(
+                        tokenCreate(firstFungible)
+                                .treasury(TOKEN_TREASURY)
+                                .tokenType(FUNGIBLE_COMMON)
+                                .initialSupply(123456789),
+                        tokenCreate(secondFungible)
+                                .treasury(TOKEN_TREASURY)
+                                .tokenType(FUNGIBLE_COMMON)
+                                .initialSupply(123456789),
+                        cryptoTransfer(
+                                moving(1000, firstFungible).between(TOKEN_TREASURY, COUNTERPARTY),
+                                moving(1000, secondFungible).between(TOKEN_TREASURY, COUNTERPARTY)),
+                        tokenCreate(uniqueWithRoyalty)
+                                .tokenType(NON_FUNGIBLE_UNIQUE)
+                                .treasury(TOKEN_TREASURY)
+                                .supplyKey(MULTI_KEY)
+                                .withCustom(royaltyFeeNoFallback(1, 12, firstRoyaltyCollector))
+                                .withCustom(royaltyFeeNoFallback(1, 15, secondRoyaltyCollector))
+                                .initialSupply(0L),
+                        mintToken(uniqueWithRoyalty, List.of(copyFromUtf8("HODL"))),
+                        cryptoTransfer(
+                                movingUnique(uniqueWithRoyalty, 1L).between(TOKEN_TREASURY, PARTY)))
+                .then(
+                        cryptoTransfer(
+                                        movingUnique(uniqueWithRoyalty, 1L)
+                                                .between(PARTY, COUNTERPARTY),
+                                        moving(12 * 15L, firstFungible)
+                                                .between(COUNTERPARTY, PARTY),
+                                        moving(12 * 15L, secondFungible)
+                                                .between(COUNTERPARTY, PARTY))
+                                .fee(ONE_HBAR)
+                                .via(HODL_XFER),
+                        getTxnRecord(HODL_XFER)
+                                .hasPriority(
+                                        recordWith()
+                                                .autoAssociated(
+                                                        accountTokenPairsInAnyOrder(
+                                                                List.of(
+                                                                        /* The counterparty auto-associates to the non-fungible type */
+                                                                        Pair.of(
+                                                                                COUNTERPARTY,
+                                                                                uniqueWithRoyalty),
+                                                                        /* The sending party auto-associates to both fungibles */
+                                                                        Pair.of(
+                                                                                PARTY,
+                                                                                firstFungible),
+                                                                        Pair.of(
+                                                                                PARTY,
+                                                                                secondFungible),
+                                                                        /* Both royalty collectors auto-associate to both fungibles */
+                                                                        Pair.of(
+                                                                                firstRoyaltyCollector,
+                                                                                firstFungible),
+                                                                        Pair.of(
+                                                                                secondRoyaltyCollector,
+                                                                                firstFungible),
+                                                                        Pair.of(
+                                                                                firstRoyaltyCollector,
+                                                                                secondFungible),
+                                                                        Pair.of(
+                                                                                secondRoyaltyCollector,
+                                                                                secondFungible))))),
+                        getAccountInfo(PARTY)
+                                .has(
+                                        accountWith()
+                                                .newAssociationsFromSnapshot(
+                                                        PARTY,
+                                                        List.of(
+                                                                relationshipWith(uniqueWithRoyalty)
+                                                                        .balance(0),
+                                                                relationshipWith(firstFungible)
+                                                                        .balance(netExchangeAmount),
+                                                                relationshipWith(secondFungible)
+                                                                        .balance(
+                                                                                netExchangeAmount)))),
+                        getAccountInfo(COUNTERPARTY)
+                                .has(
+                                        accountWith()
+                                                .newAssociationsFromSnapshot(
+                                                        PARTY,
+                                                        List.of(
+                                                                relationshipWith(uniqueWithRoyalty)
+                                                                        .balance(1),
+                                                                relationshipWith(firstFungible)
+                                                                        .balance(
+                                                                                1000L
+                                                                                        - exchangeAmount),
+                                                                relationshipWith(secondFungible)
+                                                                        .balance(
+                                                                                1000L
+                                                                                        - exchangeAmount)))),
+                        getAccountInfo(firstRoyaltyCollector)
+                                .has(
+                                        accountWith()
+                                                .newAssociationsFromSnapshot(
+                                                        PARTY,
+                                                        List.of(
+                                                                relationshipWith(firstFungible)
+                                                                        .balance(
+                                                                                exchangeAmount
+                                                                                        / 12),
+                                                                relationshipWith(secondFungible)
+                                                                        .balance(
+                                                                                exchangeAmount
+                                                                                        / 12)))),
+                        getAccountInfo(secondRoyaltyCollector)
+                                .has(
+                                        accountWith()
+                                                .newAssociationsFromSnapshot(
+                                                        PARTY,
+                                                        List.of(
+                                                                relationshipWith(firstFungible)
+                                                                        .balance(
+                                                                                exchangeAmount
+                                                                                        / 15),
+                                                                relationshipWith(secondFungible)
+                                                                        .balance(
+                                                                                exchangeAmount
+                                                                                        / 15)))));
+    }
 
-		return defaultHapiSpec("RoyaltyCollectorsCanUseAutoAssociation")
-				.given(
-						cryptoCreate(TOKEN_TREASURY),
-						cryptoCreate(firstRoyaltyCollector)
-								.maxAutomaticTokenAssociations(plentyOfSlots),
-						cryptoCreate(secondRoyaltyCollector)
-								.maxAutomaticTokenAssociations(plentyOfSlots),
-						cryptoCreate(PARTY).maxAutomaticTokenAssociations(plentyOfSlots),
-						cryptoCreate(COUNTERPARTY).maxAutomaticTokenAssociations(plentyOfSlots),
-						newKeyNamed(MULTI_KEY),
-						getAccountInfo(PARTY).savingSnapshot(PARTY),
-						getAccountInfo(COUNTERPARTY).savingSnapshot(COUNTERPARTY),
-						getAccountInfo(firstRoyaltyCollector).savingSnapshot(firstRoyaltyCollector),
-						getAccountInfo(secondRoyaltyCollector)
-								.savingSnapshot(secondRoyaltyCollector))
-				.when(
-						tokenCreate(firstFungible)
-								.treasury(TOKEN_TREASURY)
-								.tokenType(FUNGIBLE_COMMON)
-								.initialSupply(123456789),
-						tokenCreate(secondFungible)
-								.treasury(TOKEN_TREASURY)
-								.tokenType(FUNGIBLE_COMMON)
-								.initialSupply(123456789),
-						cryptoTransfer(
-								moving(1000, firstFungible).between(TOKEN_TREASURY, COUNTERPARTY),
-								moving(1000, secondFungible).between(TOKEN_TREASURY, COUNTERPARTY)),
-						tokenCreate(uniqueWithRoyalty)
-								.tokenType(NON_FUNGIBLE_UNIQUE)
-								.treasury(TOKEN_TREASURY)
-								.supplyKey(MULTI_KEY)
-								.withCustom(royaltyFeeNoFallback(1, 12, firstRoyaltyCollector))
-								.withCustom(royaltyFeeNoFallback(1, 15, secondRoyaltyCollector))
-								.initialSupply(0L),
-						mintToken(uniqueWithRoyalty, List.of(copyFromUtf8("HODL"))),
-						cryptoTransfer(
-								movingUnique(uniqueWithRoyalty, 1L).between(TOKEN_TREASURY, PARTY)))
-				.then(
-						cryptoTransfer(
-								movingUnique(uniqueWithRoyalty, 1L)
-										.between(PARTY, COUNTERPARTY),
-								moving(12 * 15L, firstFungible)
-										.between(COUNTERPARTY, PARTY),
-								moving(12 * 15L, secondFungible)
-										.between(COUNTERPARTY, PARTY))
-								.fee(ONE_HBAR)
-								.via(HODL_XFER),
-						getTxnRecord(HODL_XFER)
-								.hasPriority(
-										recordWith()
-												.autoAssociated(
-														accountTokenPairsInAnyOrder(
-																List.of(
-																		/* The counterparty auto-associates to the
-																		non-fungible type */
-																		Pair.of(
-																				COUNTERPARTY,
-																				uniqueWithRoyalty),
-																		/* The sending party auto-associates to both
-																		fungibles */
-																		Pair.of(
-																				PARTY,
-																				firstFungible),
-																		Pair.of(
-																				PARTY,
-																				secondFungible),
-																		/* Both royalty collectors auto-associate to
-																		both fungibles */
-																		Pair.of(
-																				firstRoyaltyCollector,
-																				firstFungible),
-																		Pair.of(
-																				secondRoyaltyCollector,
-																				firstFungible),
-																		Pair.of(
-																				firstRoyaltyCollector,
-																				secondFungible),
-																		Pair.of(
-																				secondRoyaltyCollector,
-																				secondFungible))))),
-						getAccountInfo(PARTY)
-								.has(
-										accountWith()
-												.newAssociationsFromSnapshot(
-														PARTY,
-														List.of(
-																relationshipWith(uniqueWithRoyalty)
-																		.balance(0),
-																relationshipWith(firstFungible)
-																		.balance(netExchangeAmount),
-																relationshipWith(secondFungible)
-																		.balance(
-																				netExchangeAmount)))),
-						getAccountInfo(COUNTERPARTY)
-								.has(
-										accountWith()
-												.newAssociationsFromSnapshot(
-														PARTY,
-														List.of(
-																relationshipWith(uniqueWithRoyalty)
-																		.balance(1),
-																relationshipWith(firstFungible)
-																		.balance(
-																				1000L
-																						- exchangeAmount),
-																relationshipWith(secondFungible)
-																		.balance(
-																				1000L
-																						- exchangeAmount)))),
-						getAccountInfo(firstRoyaltyCollector)
-								.has(
-										accountWith()
-												.newAssociationsFromSnapshot(
-														PARTY,
-														List.of(
-																relationshipWith(firstFungible)
-																		.balance(
-																				exchangeAmount
-																						/ 12),
-																relationshipWith(secondFungible)
-																		.balance(
-																				exchangeAmount
-																						/ 12)))),
-						getAccountInfo(secondRoyaltyCollector)
-								.has(
-										accountWith()
-												.newAssociationsFromSnapshot(
-														PARTY,
-														List.of(
-																relationshipWith(firstFungible)
-																		.balance(
-																				exchangeAmount
-																						/ 15),
-																relationshipWith(secondFungible)
-																		.balance(
-																				exchangeAmount
-																						/ 15)))));
-	}
+    private HapiApiSpec royaltyCollectorsCannotUseAutoAssociationWithoutOpenSlots() {
+        final var uniqueWithRoyalty = "uniqueWithRoyalty";
+        final var someFungible = "firstFungible";
+        final var royaltyCollectorNoSlots = "royaltyCollectorNoSlots";
+        final var party = PARTY;
+        final var counterparty = COUNTERPARTY;
+        final var multipurpose = MULTI_KEY;
+        final var hodlXfer = HODL_XFER;
 
-	private HapiApiSpec royaltyCollectorsCannotUseAutoAssociationWithoutOpenSlots() {
-		final var uniqueWithRoyalty = "uniqueWithRoyalty";
-		final var someFungible = "firstFungible";
-		final var royaltyCollectorNoSlots = "royaltyCollectorNoSlots";
-		final var party = PARTY;
-		final var counterparty = COUNTERPARTY;
-		final var multipurpose = MULTI_KEY;
-		final var hodlXfer = HODL_XFER;
+        return defaultHapiSpec("RoyaltyCollectorsCanUseAutoAssociationWithoutOpenSlots")
+                .given(
+                        cryptoCreate(TOKEN_TREASURY),
+                        cryptoCreate(royaltyCollectorNoSlots),
+                        cryptoCreate(party).maxAutomaticTokenAssociations(123),
+                        cryptoCreate(counterparty).maxAutomaticTokenAssociations(123),
+                        newKeyNamed(multipurpose),
+                        getAccountInfo(party).savingSnapshot(party),
+                        getAccountInfo(counterparty).savingSnapshot(counterparty),
+                        getAccountInfo(royaltyCollectorNoSlots)
+                                .savingSnapshot(royaltyCollectorNoSlots))
+                .when(
+                        tokenCreate(someFungible)
+                                .treasury(TOKEN_TREASURY)
+                                .tokenType(FUNGIBLE_COMMON)
+                                .initialSupply(123456789),
+                        cryptoTransfer(
+                                moving(1000, someFungible).between(TOKEN_TREASURY, counterparty)),
+                        tokenCreate(uniqueWithRoyalty)
+                                .tokenType(NON_FUNGIBLE_UNIQUE)
+                                .treasury(TOKEN_TREASURY)
+                                .supplyKey(multipurpose)
+                                .withCustom(royaltyFeeNoFallback(1, 12, royaltyCollectorNoSlots))
+                                .initialSupply(0L),
+                        mintToken(uniqueWithRoyalty, List.of(copyFromUtf8("HODL"))),
+                        cryptoTransfer(
+                                movingUnique(uniqueWithRoyalty, 1L).between(TOKEN_TREASURY, party)))
+                .then(
+                        cryptoTransfer(
+                                        movingUnique(uniqueWithRoyalty, 1L)
+                                                .between(party, counterparty),
+                                        moving(123, someFungible).between(counterparty, party))
+                                .fee(ONE_HBAR)
+                                .via(hodlXfer)
+                                .hasKnownStatus(TOKEN_NOT_ASSOCIATED_TO_ACCOUNT),
+                        getTxnRecord(hodlXfer)
+                                .hasPriority(
+                                        recordWith()
+                                                .autoAssociated(
+                                                        accountTokenPairsInAnyOrder(List.of()))),
+                        getAccountInfo(party)
+                                .has(
+                                        accountWith()
+                                                .newAssociationsFromSnapshot(
+                                                        party,
+                                                        List.of(
+                                                                relationshipWith(uniqueWithRoyalty)
+                                                                        .balance(1)))));
+    }
 
-		return defaultHapiSpec("RoyaltyCollectorsCanUseAutoAssociationWithoutOpenSlots")
-				.given(
-						cryptoCreate(TOKEN_TREASURY),
-						cryptoCreate(royaltyCollectorNoSlots),
-						cryptoCreate(party).maxAutomaticTokenAssociations(123),
-						cryptoCreate(counterparty).maxAutomaticTokenAssociations(123),
-						newKeyNamed(multipurpose),
-						getAccountInfo(party).savingSnapshot(party),
-						getAccountInfo(counterparty).savingSnapshot(counterparty),
-						getAccountInfo(royaltyCollectorNoSlots)
-								.savingSnapshot(royaltyCollectorNoSlots))
-				.when(
-						tokenCreate(someFungible)
-								.treasury(TOKEN_TREASURY)
-								.tokenType(FUNGIBLE_COMMON)
-								.initialSupply(123456789),
-						cryptoTransfer(
-								moving(1000, someFungible).between(TOKEN_TREASURY, counterparty)),
-						tokenCreate(uniqueWithRoyalty)
-								.tokenType(NON_FUNGIBLE_UNIQUE)
-								.treasury(TOKEN_TREASURY)
-								.supplyKey(multipurpose)
-								.withCustom(royaltyFeeNoFallback(1, 12, royaltyCollectorNoSlots))
-								.initialSupply(0L),
-						mintToken(uniqueWithRoyalty, List.of(copyFromUtf8("HODL"))),
-						cryptoTransfer(
-								movingUnique(uniqueWithRoyalty, 1L).between(TOKEN_TREASURY, party)))
-				.then(
-						cryptoTransfer(
-								movingUnique(uniqueWithRoyalty, 1L)
-										.between(party, counterparty),
-								moving(123, someFungible).between(counterparty, party))
-								.fee(ONE_HBAR)
-								.via(hodlXfer)
-								.hasKnownStatus(TOKEN_NOT_ASSOCIATED_TO_ACCOUNT),
-						getTxnRecord(hodlXfer)
-								.hasPriority(
-										recordWith()
-												.autoAssociated(
-														accountTokenPairsInAnyOrder(List.of()))),
-						getAccountInfo(party)
-								.has(
-										accountWith()
-												.newAssociationsFromSnapshot(
-														party,
-														List.of(
-																relationshipWith(uniqueWithRoyalty)
-																		.balance(1)))));
-	}
+    private HapiApiSpec autoAssociationRequiresOpenSlots() {
+        final String tokenA = "tokenA";
+        final String tokenB = "tokenB";
+        final String firstUser = "firstUser";
+        final String secondUser = "secondUser";
+        final String treasury = "treasury";
+        final String tokenAcreateTxn = "tokenACreate";
+        final String tokenBcreateTxn = "tokenBCreate";
+        final String transferToFU = "transferToFU";
+        final String transferToSU = "transferToSU";
 
-	private HapiApiSpec autoAssociationRequiresOpenSlots() {
-		final String tokenA = "tokenA";
-		final String tokenB = "tokenB";
-		final String firstUser = "firstUser";
-		final String secondUser = "secondUser";
-		final String treasury = "treasury";
-		final String tokenAcreateTxn = "tokenACreate";
-		final String tokenBcreateTxn = "tokenBCreate";
-		final String transferToFU = "transferToFU";
-		final String transferToSU = "transferToSU";
+        return defaultHapiSpec("AutoAssociationRequiresOpenSlots")
+                .given(
+                        cryptoCreate(treasury).balance(ONE_HUNDRED_HBARS),
+                        cryptoCreate(firstUser).balance(ONE_HBAR).maxAutomaticTokenAssociations(1),
+                        cryptoCreate(secondUser).balance(ONE_HBAR).maxAutomaticTokenAssociations(2))
+                .when(
+                        tokenCreate(tokenA)
+                                .tokenType(TokenType.FUNGIBLE_COMMON)
+                                .initialSupply(Long.MAX_VALUE)
+                                .treasury(treasury)
+                                .via(tokenAcreateTxn),
+                        getTxnRecord(tokenAcreateTxn)
+                                .hasNewTokenAssociation(tokenA, treasury)
+                                .logged(),
+                        tokenCreate(tokenB)
+                                .tokenType(TokenType.FUNGIBLE_COMMON)
+                                .initialSupply(Long.MAX_VALUE)
+                                .treasury(treasury)
+                                .via(tokenBcreateTxn),
+                        getTxnRecord(tokenBcreateTxn)
+                                .hasNewTokenAssociation(tokenB, treasury)
+                                .logged(),
+                        cryptoTransfer(moving(1, tokenA).between(treasury, firstUser))
+                                .via(transferToFU),
+                        getTxnRecord(transferToFU)
+                                .hasNewTokenAssociation(tokenA, firstUser)
+                                .logged(),
+                        cryptoTransfer(moving(1, tokenB).between(treasury, secondUser))
+                                .via(transferToSU),
+                        getTxnRecord(transferToSU)
+                                .hasNewTokenAssociation(tokenB, secondUser)
+                                .logged())
+                .then(
+                        cryptoTransfer(moving(1, tokenB).between(treasury, firstUser))
+                                .hasKnownStatus(NO_REMAINING_AUTOMATIC_ASSOCIATIONS)
+                                .via("failedTransfer"),
+                        getAccountInfo(firstUser)
+                                .hasAlreadyUsedAutomaticAssociations(1)
+                                .hasMaxAutomaticAssociations(1)
+                                .logged(),
+                        getAccountInfo(secondUser)
+                                .hasAlreadyUsedAutomaticAssociations(1)
+                                .hasMaxAutomaticAssociations(2)
+                                .logged(),
+                        cryptoTransfer(moving(1, tokenA).between(treasury, secondUser)),
+                        getAccountInfo(secondUser)
+                                .hasAlreadyUsedAutomaticAssociations(2)
+                                .hasMaxAutomaticAssociations(2)
+                                .logged(),
+                        cryptoTransfer(moving(1, tokenA).between(firstUser, treasury)),
+                        tokenDissociate(firstUser, tokenA),
+                        cryptoTransfer(moving(1, tokenB).between(treasury, firstUser)));
+    }
 
-		return defaultHapiSpec("AutoAssociationRequiresOpenSlots")
-				.given(
-						cryptoCreate(treasury).balance(ONE_HUNDRED_HBARS),
-						cryptoCreate(firstUser).balance(ONE_HBAR).maxAutomaticTokenAssociations(1),
-						cryptoCreate(secondUser).balance(ONE_HBAR).maxAutomaticTokenAssociations(2))
-				.when(
-						tokenCreate(tokenA)
-								.tokenType(TokenType.FUNGIBLE_COMMON)
-								.initialSupply(Long.MAX_VALUE)
-								.treasury(treasury)
-								.via(tokenAcreateTxn),
-						getTxnRecord(tokenAcreateTxn)
-								.hasNewTokenAssociation(tokenA, treasury)
-								.logged(),
-						tokenCreate(tokenB)
-								.tokenType(TokenType.FUNGIBLE_COMMON)
-								.initialSupply(Long.MAX_VALUE)
-								.treasury(treasury)
-								.via(tokenBcreateTxn),
-						getTxnRecord(tokenBcreateTxn)
-								.hasNewTokenAssociation(tokenB, treasury)
-								.logged(),
-						cryptoTransfer(moving(1, tokenA).between(treasury, firstUser))
-								.via(transferToFU),
-						getTxnRecord(transferToFU)
-								.hasNewTokenAssociation(tokenA, firstUser)
-								.logged(),
-						cryptoTransfer(moving(1, tokenB).between(treasury, secondUser))
-								.via(transferToSU),
-						getTxnRecord(transferToSU)
-								.hasNewTokenAssociation(tokenB, secondUser)
-								.logged())
-				.then(
-						cryptoTransfer(moving(1, tokenB).between(treasury, firstUser))
-								.hasKnownStatus(NO_REMAINING_AUTOMATIC_ASSOCIATIONS)
-								.via("failedTransfer"),
-						getAccountInfo(firstUser)
-								.hasAlreadyUsedAutomaticAssociations(1)
-								.hasMaxAutomaticAssociations(1)
-								.logged(),
-						getAccountInfo(secondUser)
-								.hasAlreadyUsedAutomaticAssociations(1)
-								.hasMaxAutomaticAssociations(2)
-								.logged(),
-						cryptoTransfer(moving(1, tokenA).between(treasury, secondUser)),
-						getAccountInfo(secondUser)
-								.hasAlreadyUsedAutomaticAssociations(2)
-								.hasMaxAutomaticAssociations(2)
-								.logged(),
-						cryptoTransfer(moving(1, tokenA).between(firstUser, treasury)),
-						tokenDissociate(firstUser, tokenA),
-						cryptoTransfer(moving(1, tokenB).between(treasury, firstUser)));
-	}
+    private HapiApiSpec baseCryptoTransferFeeChargedAsExpected() {
+        final var expectedHbarXferPriceUsd = 0.0001;
+        final var expectedHtsXferPriceUsd = 0.001;
+        final var expectedNftXferPriceUsd = 0.001;
+        final var expectedHtsXferWithCustomFeePriceUsd = 0.002;
+        final var expectedNftXferWithCustomFeePriceUsd = 0.002;
+        final var transferAmount = 1L;
+        final var customFeeCollector = "customFeeCollector";
+        final var nonTreasurySender = "nonTreasurySender";
+        final var hbarXferTxn = "hbarXferTxn";
+        final var fungibleToken = "fungibleToken";
+        final var fungibleTokenWithCustomFee = "fungibleTokenWithCustomFee";
+        final var htsXferTxn = "htsXferTxn";
+        final var htsXferTxnWithCustomFee = "htsXferTxnWithCustomFee";
+        final var nonFungibleToken = "nonFungibleToken";
+        final var nonFungibleTokenWithCustomFee = "nonFungibleTokenWithCustomFee";
+        final var nftXferTxn = "nftXferTxn";
+        final var nftXferTxnWithCustomFee = "nftXferTxnWithCustomFee";
 
-	private HapiApiSpec baseCryptoTransferFeeChargedAsExpected() {
-		final var expectedHbarXferPriceUsd = 0.0001;
-		final var expectedHtsXferPriceUsd = 0.001;
-		final var expectedNftXferPriceUsd = 0.001;
-		final var expectedHtsXferWithCustomFeePriceUsd = 0.002;
-		final var expectedNftXferWithCustomFeePriceUsd = 0.002;
-		final var transferAmount = 1L;
-		final var customFeeCollector = "customFeeCollector";
-		final var nonTreasurySender = "nonTreasurySender";
-		final var hbarXferTxn = "hbarXferTxn";
-		final var fungibleToken = "fungibleToken";
-		final var fungibleTokenWithCustomFee = "fungibleTokenWithCustomFee";
-		final var htsXferTxn = "htsXferTxn";
-		final var htsXferTxnWithCustomFee = "htsXferTxnWithCustomFee";
-		final var nonFungibleToken = "nonFungibleToken";
-		final var nonFungibleTokenWithCustomFee = "nonFungibleTokenWithCustomFee";
-		final var nftXferTxn = "nftXferTxn";
-		final var nftXferTxnWithCustomFee = "nftXferTxnWithCustomFee";
+        return defaultHapiSpec("BaseCryptoTransferIsChargedAsExpected")
+                .given(
+                        cryptoCreate(nonTreasurySender).balance(ONE_HUNDRED_HBARS),
+                        cryptoCreate(SENDER).balance(ONE_HUNDRED_HBARS),
+                        cryptoCreate(RECEIVER),
+                        cryptoCreate(customFeeCollector),
+                        tokenCreate(fungibleToken)
+                                .treasury(SENDER)
+                                .tokenType(FUNGIBLE_COMMON)
+                                .initialSupply(100L),
+                        tokenCreate(fungibleTokenWithCustomFee)
+                                .treasury(SENDER)
+                                .tokenType(FUNGIBLE_COMMON)
+                                .withCustom(fixedHbarFee(transferAmount, customFeeCollector))
+                                .initialSupply(100L),
+                        tokenAssociate(RECEIVER, fungibleToken, fungibleTokenWithCustomFee),
+                        newKeyNamed(SUPPLY_KEY),
+                        tokenCreate(nonFungibleToken)
+                                .initialSupply(0)
+                                .supplyKey(SUPPLY_KEY)
+                                .tokenType(NON_FUNGIBLE_UNIQUE)
+                                .treasury(SENDER),
+                        tokenCreate(nonFungibleTokenWithCustomFee)
+                                .initialSupply(0)
+                                .supplyKey(SUPPLY_KEY)
+                                .tokenType(NON_FUNGIBLE_UNIQUE)
+                                .withCustom(fixedHbarFee(transferAmount, customFeeCollector))
+                                .treasury(SENDER),
+                        tokenAssociate(
+                                nonTreasurySender,
+                                List.of(fungibleTokenWithCustomFee, nonFungibleTokenWithCustomFee)),
+                        mintToken(nonFungibleToken, List.of(copyFromUtf8("memo1"))),
+                        mintToken(nonFungibleTokenWithCustomFee, List.of(copyFromUtf8("memo2"))),
+                        tokenAssociate(RECEIVER, nonFungibleToken, nonFungibleTokenWithCustomFee),
+                        cryptoTransfer(
+                                        movingUnique(nonFungibleTokenWithCustomFee, 1)
+                                                .between(SENDER, nonTreasurySender))
+                                .payingWith(SENDER),
+                        cryptoTransfer(
+                                        moving(1, fungibleTokenWithCustomFee)
+                                                .between(SENDER, nonTreasurySender))
+                                .payingWith(SENDER))
+                .when(
+                        cryptoTransfer(tinyBarsFromTo(SENDER, RECEIVER, 100L))
+                                .payingWith(SENDER)
+                                .blankMemo()
+                                .via(hbarXferTxn),
+                        cryptoTransfer(moving(1, fungibleToken).between(SENDER, RECEIVER))
+                                .blankMemo()
+                                .payingWith(SENDER)
+                                .via(htsXferTxn),
+                        cryptoTransfer(movingUnique(nonFungibleToken, 1).between(SENDER, RECEIVER))
+                                .blankMemo()
+                                .payingWith(SENDER)
+                                .via(nftXferTxn),
+                        cryptoTransfer(
+                                        moving(1, fungibleTokenWithCustomFee)
+                                                .between(nonTreasurySender, RECEIVER))
+                                .blankMemo()
+                                .fee(ONE_HBAR)
+                                .payingWith(nonTreasurySender)
+                                .via(htsXferTxnWithCustomFee),
+                        cryptoTransfer(
+                                        movingUnique(nonFungibleTokenWithCustomFee, 1)
+                                                .between(nonTreasurySender, RECEIVER))
+                                .blankMemo()
+                                .fee(ONE_HBAR)
+                                .payingWith(nonTreasurySender)
+                                .via(nftXferTxnWithCustomFee))
+                .then(
+                        validateChargedUsdWithin(hbarXferTxn, expectedHbarXferPriceUsd, 0.01),
+                        validateChargedUsdWithin(htsXferTxn, expectedHtsXferPriceUsd, 0.01),
+                        validateChargedUsdWithin(nftXferTxn, expectedNftXferPriceUsd, 0.01),
+                        validateChargedUsdWithin(
+                                htsXferTxnWithCustomFee, expectedHtsXferWithCustomFeePriceUsd, 0.1),
+                        validateChargedUsdWithin(
+                                nftXferTxnWithCustomFee,
+                                expectedNftXferWithCustomFeePriceUsd,
+                                0.3));
+    }
 
-		return defaultHapiSpec("BaseCryptoTransferIsChargedAsExpected")
-				.given(
-						cryptoCreate(nonTreasurySender).balance(ONE_HUNDRED_HBARS),
-						cryptoCreate(SENDER).balance(ONE_HUNDRED_HBARS),
-						cryptoCreate(RECEIVER),
-						cryptoCreate(customFeeCollector),
-						tokenCreate(fungibleToken)
-								.treasury(SENDER)
-								.tokenType(FUNGIBLE_COMMON)
-								.initialSupply(100L),
-						tokenCreate(fungibleTokenWithCustomFee)
-								.treasury(SENDER)
-								.tokenType(FUNGIBLE_COMMON)
-								.withCustom(fixedHbarFee(transferAmount, customFeeCollector))
-								.initialSupply(100L),
-						tokenAssociate(RECEIVER, fungibleToken, fungibleTokenWithCustomFee),
-						newKeyNamed(SUPPLY_KEY),
-						tokenCreate(nonFungibleToken)
-								.initialSupply(0)
-								.supplyKey(SUPPLY_KEY)
-								.tokenType(NON_FUNGIBLE_UNIQUE)
-								.treasury(SENDER),
-						tokenCreate(nonFungibleTokenWithCustomFee)
-								.initialSupply(0)
-								.supplyKey(SUPPLY_KEY)
-								.tokenType(NON_FUNGIBLE_UNIQUE)
-								.withCustom(fixedHbarFee(transferAmount, customFeeCollector))
-								.treasury(SENDER),
-						tokenAssociate(
-								nonTreasurySender,
-								List.of(fungibleTokenWithCustomFee, nonFungibleTokenWithCustomFee)),
-						mintToken(nonFungibleToken, List.of(copyFromUtf8("memo1"))),
-						mintToken(nonFungibleTokenWithCustomFee, List.of(copyFromUtf8("memo2"))),
-						tokenAssociate(RECEIVER, nonFungibleToken, nonFungibleTokenWithCustomFee),
-						cryptoTransfer(
-								movingUnique(nonFungibleTokenWithCustomFee, 1)
-										.between(SENDER, nonTreasurySender))
-								.payingWith(SENDER),
-						cryptoTransfer(
-								moving(1, fungibleTokenWithCustomFee)
-										.between(SENDER, nonTreasurySender))
-								.payingWith(SENDER))
-				.when(
-						cryptoTransfer(tinyBarsFromTo(SENDER, RECEIVER, 100L))
-								.payingWith(SENDER)
-								.blankMemo()
-								.via(hbarXferTxn),
-						cryptoTransfer(moving(1, fungibleToken).between(SENDER, RECEIVER))
-								.blankMemo()
-								.payingWith(SENDER)
-								.via(htsXferTxn),
-						cryptoTransfer(movingUnique(nonFungibleToken, 1).between(SENDER, RECEIVER))
-								.blankMemo()
-								.payingWith(SENDER)
-								.via(nftXferTxn),
-						cryptoTransfer(
-								moving(1, fungibleTokenWithCustomFee)
-										.between(nonTreasurySender, RECEIVER))
-								.blankMemo()
-								.fee(ONE_HBAR)
-								.payingWith(nonTreasurySender)
-								.via(htsXferTxnWithCustomFee),
-						cryptoTransfer(
-								movingUnique(nonFungibleTokenWithCustomFee, 1)
-										.between(nonTreasurySender, RECEIVER))
-								.blankMemo()
-								.fee(ONE_HBAR)
-								.payingWith(nonTreasurySender)
-								.via(nftXferTxnWithCustomFee))
-				.then(
-						validateChargedUsdWithin(hbarXferTxn, expectedHbarXferPriceUsd, 0.01),
-						validateChargedUsdWithin(htsXferTxn, expectedHtsXferPriceUsd, 0.01),
-						validateChargedUsdWithin(nftXferTxn, expectedNftXferPriceUsd, 0.01),
-						validateChargedUsdWithin(
-								htsXferTxnWithCustomFee, expectedHtsXferWithCustomFeePriceUsd, 0.1),
-						validateChargedUsdWithin(
-								nftXferTxnWithCustomFee,
-								expectedNftXferWithCustomFeePriceUsd,
-								0.3));
-	}
+    private HapiApiSpec okToSetInvalidPaymentHeaderForCostAnswer() {
+        return defaultHapiSpec("OkToSetInvalidPaymentHeaderForCostAnswer")
+                .given(cryptoTransfer(tinyBarsFromTo(DEFAULT_PAYER, FUNDING, 1L)).via("misc"))
+                .when()
+                .then(
+                        getTxnRecord("misc").useEmptyTxnAsCostPayment(),
+                        getTxnRecord("misc").omittingAnyPaymentForCostAnswer());
+    }
 
-	private HapiApiSpec okToSetInvalidPaymentHeaderForCostAnswer() {
-		return defaultHapiSpec("OkToSetInvalidPaymentHeaderForCostAnswer")
-				.given(cryptoTransfer(tinyBarsFromTo(DEFAULT_PAYER, FUNDING, 1L)).via("misc"))
-				.when()
-				.then(
-						getTxnRecord("misc").useEmptyTxnAsCostPayment(),
-						getTxnRecord("misc").omittingAnyPaymentForCostAnswer());
-	}
+    @SuppressWarnings("java:S5960")
+    private HapiApiSpec tokenTransferFeesScaleAsExpected() {
+        return defaultHapiSpec("TokenTransferFeesScaleAsExpected")
+                .given(
+                        cryptoCreate("a"),
+                        cryptoCreate("b"),
+                        cryptoCreate("c").balance(0L),
+                        cryptoCreate("d").balance(0L),
+                        cryptoCreate("e").balance(0L),
+                        cryptoCreate("f").balance(0L),
+                        tokenCreate("A").treasury("a"),
+                        tokenCreate("B").treasury("b"),
+                        tokenCreate("C").treasury("c"))
+                .when(
+                        tokenAssociate("b", "A", "C"),
+                        tokenAssociate("c", "A", "B"),
+                        tokenAssociate("d", "A", "B", "C"),
+                        tokenAssociate("e", "A", "B", "C"),
+                        tokenAssociate("f", "A", "B", "C"),
+                        cryptoTransfer(tinyBarsFromTo("a", "b", 1))
+                                .via("pureCrypto")
+                                .fee(ONE_HUNDRED_HBARS)
+                                .payingWith("a"),
+                        cryptoTransfer(moving(1, "A").between("a", "b"))
+                                .via("oneTokenTwoAccounts")
+                                .fee(ONE_HUNDRED_HBARS)
+                                .payingWith("a"),
+                        cryptoTransfer(moving(2, "A").distributing("a", "b", "c"))
+                                .via("oneTokenThreeAccounts")
+                                .fee(ONE_HUNDRED_HBARS)
+                                .payingWith("a"),
+                        cryptoTransfer(moving(3, "A").distributing("a", "b", "c", "d"))
+                                .via("oneTokenFourAccounts")
+                                .fee(ONE_HUNDRED_HBARS)
+                                .payingWith("a"),
+                        cryptoTransfer(moving(4, "A").distributing("a", "b", "c", "d", "e"))
+                                .via("oneTokenFiveAccounts")
+                                .fee(ONE_HUNDRED_HBARS)
+                                .payingWith("a"),
+                        cryptoTransfer(moving(5, "A").distributing("a", "b", "c", "d", "e", "f"))
+                                .via("oneTokenSixAccounts")
+                                .fee(ONE_HUNDRED_HBARS)
+                                .payingWith("a"),
+                        cryptoTransfer(
+                                        moving(1, "A").between("a", "c"),
+                                        moving(1, "B").between("b", "d"))
+                                .via("twoTokensFourAccounts")
+                                .fee(ONE_HUNDRED_HBARS)
+                                .payingWith("a"),
+                        cryptoTransfer(
+                                        moving(1, "A").between("a", "c"),
+                                        moving(2, "B").distributing("b", "d", "e"))
+                                .via("twoTokensFiveAccounts")
+                                .fee(ONE_HUNDRED_HBARS)
+                                .payingWith("a"),
+                        cryptoTransfer(
+                                        moving(1, "A").between("a", "c"),
+                                        moving(3, "B").distributing("b", "d", "e", "f"))
+                                .via("twoTokensSixAccounts")
+                                .fee(ONE_HUNDRED_HBARS)
+                                .payingWith("a"),
+                        cryptoTransfer(
+                                        moving(1, "A").between("a", "d"),
+                                        moving(1, "B").between("b", "e"),
+                                        moving(1, "C").between("c", "f"))
+                                .via("threeTokensSixAccounts")
+                                .fee(ONE_HUNDRED_HBARS)
+                                .payingWith("a"))
+                .then(
+                        withOpContext(
+                                (spec, opLog) -> {
+                                    var ref = getTxnRecord("pureCrypto");
+                                    var t1a2 = getTxnRecord("oneTokenTwoAccounts");
+                                    var t1a3 = getTxnRecord("oneTokenThreeAccounts");
+                                    var t1a4 = getTxnRecord("oneTokenFourAccounts");
+                                    var t1a5 = getTxnRecord("oneTokenFiveAccounts");
+                                    var t1a6 = getTxnRecord("oneTokenSixAccounts");
+                                    var t2a4 = getTxnRecord("twoTokensFourAccounts");
+                                    var t2a5 = getTxnRecord("twoTokensFiveAccounts");
+                                    var t2a6 = getTxnRecord("twoTokensSixAccounts");
+                                    var t3a6 = getTxnRecord("threeTokensSixAccounts");
+                                    allRunFor(
+                                            spec, ref, t1a2, t1a3, t1a4, t1a5, t1a6, t2a4, t2a5,
+                                            t2a6, t3a6);
 
-	@SuppressWarnings("java:S5960")
-	private HapiApiSpec tokenTransferFeesScaleAsExpected() {
-		return defaultHapiSpec("TokenTransferFeesScaleAsExpected")
-				.given(
-						cryptoCreate("a"),
-						cryptoCreate("b"),
-						cryptoCreate("c").balance(0L),
-						cryptoCreate("d").balance(0L),
-						cryptoCreate("e").balance(0L),
-						cryptoCreate("f").balance(0L),
-						tokenCreate("A").treasury("a"),
-						tokenCreate("B").treasury("b"),
-						tokenCreate("C").treasury("c"))
-				.when(
-						tokenAssociate("b", "A", "C"),
-						tokenAssociate("c", "A", "B"),
-						tokenAssociate("d", "A", "B", "C"),
-						tokenAssociate("e", "A", "B", "C"),
-						tokenAssociate("f", "A", "B", "C"),
-						cryptoTransfer(tinyBarsFromTo("a", "b", 1))
-								.via("pureCrypto")
-								.fee(ONE_HUNDRED_HBARS)
-								.payingWith("a"),
-						cryptoTransfer(moving(1, "A").between("a", "b"))
-								.via("oneTokenTwoAccounts")
-								.fee(ONE_HUNDRED_HBARS)
-								.payingWith("a"),
-						cryptoTransfer(moving(2, "A").distributing("a", "b", "c"))
-								.via("oneTokenThreeAccounts")
-								.fee(ONE_HUNDRED_HBARS)
-								.payingWith("a"),
-						cryptoTransfer(moving(3, "A").distributing("a", "b", "c", "d"))
-								.via("oneTokenFourAccounts")
-								.fee(ONE_HUNDRED_HBARS)
-								.payingWith("a"),
-						cryptoTransfer(moving(4, "A").distributing("a", "b", "c", "d", "e"))
-								.via("oneTokenFiveAccounts")
-								.fee(ONE_HUNDRED_HBARS)
-								.payingWith("a"),
-						cryptoTransfer(moving(5, "A").distributing("a", "b", "c", "d", "e", "f"))
-								.via("oneTokenSixAccounts")
-								.fee(ONE_HUNDRED_HBARS)
-								.payingWith("a"),
-						cryptoTransfer(
-								moving(1, "A").between("a", "c"),
-								moving(1, "B").between("b", "d"))
-								.via("twoTokensFourAccounts")
-								.fee(ONE_HUNDRED_HBARS)
-								.payingWith("a"),
-						cryptoTransfer(
-								moving(1, "A").between("a", "c"),
-								moving(2, "B").distributing("b", "d", "e"))
-								.via("twoTokensFiveAccounts")
-								.fee(ONE_HUNDRED_HBARS)
-								.payingWith("a"),
-						cryptoTransfer(
-								moving(1, "A").between("a", "c"),
-								moving(3, "B").distributing("b", "d", "e", "f"))
-								.via("twoTokensSixAccounts")
-								.fee(ONE_HUNDRED_HBARS)
-								.payingWith("a"),
-						cryptoTransfer(
-								moving(1, "A").between("a", "d"),
-								moving(1, "B").between("b", "e"),
-								moving(1, "C").between("c", "f"))
-								.via("threeTokensSixAccounts")
-								.fee(ONE_HUNDRED_HBARS)
-								.payingWith("a"))
-				.then(
-						withOpContext(
-								(spec, opLog) -> {
-									var ref = getTxnRecord("pureCrypto");
-									var t1a2 = getTxnRecord("oneTokenTwoAccounts");
-									var t1a3 = getTxnRecord("oneTokenThreeAccounts");
-									var t1a4 = getTxnRecord("oneTokenFourAccounts");
-									var t1a5 = getTxnRecord("oneTokenFiveAccounts");
-									var t1a6 = getTxnRecord("oneTokenSixAccounts");
-									var t2a4 = getTxnRecord("twoTokensFourAccounts");
-									var t2a5 = getTxnRecord("twoTokensFiveAccounts");
-									var t2a6 = getTxnRecord("twoTokensSixAccounts");
-									var t3a6 = getTxnRecord("threeTokensSixAccounts");
-									allRunFor(
-											spec, ref, t1a2, t1a3, t1a4, t1a5, t1a6, t2a4, t2a5,
-											t2a6, t3a6);
+                                    var refFee = ref.getResponseRecord().getTransactionFee();
+                                    var t1a2Fee = t1a2.getResponseRecord().getTransactionFee();
+                                    var t1a3Fee = t1a3.getResponseRecord().getTransactionFee();
+                                    var t1a4Fee = t1a4.getResponseRecord().getTransactionFee();
+                                    var t1a5Fee = t1a5.getResponseRecord().getTransactionFee();
+                                    var t1a6Fee = t1a6.getResponseRecord().getTransactionFee();
+                                    var t2a4Fee = t2a4.getResponseRecord().getTransactionFee();
+                                    var t2a5Fee = t2a5.getResponseRecord().getTransactionFee();
+                                    var t2a6Fee = t2a6.getResponseRecord().getTransactionFee();
+                                    var t3a6Fee = t3a6.getResponseRecord().getTransactionFee();
 
-									var refFee = ref.getResponseRecord().getTransactionFee();
-									var t1a2Fee = t1a2.getResponseRecord().getTransactionFee();
-									var t1a3Fee = t1a3.getResponseRecord().getTransactionFee();
-									var t1a4Fee = t1a4.getResponseRecord().getTransactionFee();
-									var t1a5Fee = t1a5.getResponseRecord().getTransactionFee();
-									var t1a6Fee = t1a6.getResponseRecord().getTransactionFee();
-									var t2a4Fee = t2a4.getResponseRecord().getTransactionFee();
-									var t2a5Fee = t2a5.getResponseRecord().getTransactionFee();
-									var t2a6Fee = t2a6.getResponseRecord().getTransactionFee();
-									var t3a6Fee = t3a6.getResponseRecord().getTransactionFee();
+                                    var rates = spec.ratesProvider();
+                                    opLog.info(
+                                            TOKENS_INVOLVED_LOG_MESSAGE,
+                                            refFee,
+                                            sdec(rates.toUsdWithActiveRates(refFee), 4),
+                                            t1a2Fee,
+                                            sdec(rates.toUsdWithActiveRates(t1a2Fee), 4),
+                                            sdec((1.0 * t1a2Fee / refFee), 1),
+                                            t1a3Fee,
+                                            sdec(rates.toUsdWithActiveRates(t1a3Fee), 4),
+                                            sdec((1.0 * t1a3Fee / refFee), 1),
+                                            t1a4Fee,
+                                            sdec(rates.toUsdWithActiveRates(t1a4Fee), 4),
+                                            sdec((1.0 * t1a4Fee / refFee), 1),
+                                            t1a5Fee,
+                                            sdec(rates.toUsdWithActiveRates(t1a5Fee), 4),
+                                            sdec((1.0 * t1a5Fee / refFee), 1),
+                                            t1a6Fee,
+                                            sdec(rates.toUsdWithActiveRates(t1a6Fee), 4),
+                                            sdec((1.0 * t1a6Fee / refFee), 1),
+                                            t2a4Fee,
+                                            sdec(rates.toUsdWithActiveRates(t2a4Fee), 4),
+                                            sdec((1.0 * t2a4Fee / refFee), 1),
+                                            t2a5Fee,
+                                            sdec(rates.toUsdWithActiveRates(t2a5Fee), 4),
+                                            sdec((1.0 * t2a5Fee / refFee), 1),
+                                            t2a6Fee,
+                                            sdec(rates.toUsdWithActiveRates(t2a6Fee), 4),
+                                            sdec((1.0 * t2a6Fee / refFee), 1),
+                                            t3a6Fee,
+                                            sdec(rates.toUsdWithActiveRates(t3a6Fee), 4),
+                                            sdec((1.0 * t3a6Fee / refFee), 1));
 
-									var rates = spec.ratesProvider();
-									opLog.info(
-											TOKENS_INVOLVED_LOG_MESSAGE,
-											refFee,
-											sdec(rates.toUsdWithActiveRates(refFee), 4),
-											t1a2Fee,
-											sdec(rates.toUsdWithActiveRates(t1a2Fee), 4),
-											sdec((1.0 * t1a2Fee / refFee), 1),
-											t1a3Fee,
-											sdec(rates.toUsdWithActiveRates(t1a3Fee), 4),
-											sdec((1.0 * t1a3Fee / refFee), 1),
-											t1a4Fee,
-											sdec(rates.toUsdWithActiveRates(t1a4Fee), 4),
-											sdec((1.0 * t1a4Fee / refFee), 1),
-											t1a5Fee,
-											sdec(rates.toUsdWithActiveRates(t1a5Fee), 4),
-											sdec((1.0 * t1a5Fee / refFee), 1),
-											t1a6Fee,
-											sdec(rates.toUsdWithActiveRates(t1a6Fee), 4),
-											sdec((1.0 * t1a6Fee / refFee), 1),
-											t2a4Fee,
-											sdec(rates.toUsdWithActiveRates(t2a4Fee), 4),
-											sdec((1.0 * t2a4Fee / refFee), 1),
-											t2a5Fee,
-											sdec(rates.toUsdWithActiveRates(t2a5Fee), 4),
-											sdec((1.0 * t2a5Fee / refFee), 1),
-											t2a6Fee,
-											sdec(rates.toUsdWithActiveRates(t2a6Fee), 4),
-											sdec((1.0 * t2a6Fee / refFee), 1),
-											t3a6Fee,
-											sdec(rates.toUsdWithActiveRates(t3a6Fee), 4),
-											sdec((1.0 * t3a6Fee / refFee), 1));
+                                    double pureHbarUsd = rates.toUsdWithActiveRates(refFee);
+                                    double pureOneTokenTwoAccountsUsd =
+                                            rates.toUsdWithActiveRates(t1a2Fee);
+                                    double pureTwoTokensFourAccountsUsd =
+                                            rates.toUsdWithActiveRates(t2a4Fee);
+                                    double pureThreeTokensSixAccountsUsd =
+                                            rates.toUsdWithActiveRates(t3a6Fee);
+                                    assertEquals(
+                                            10.0, pureOneTokenTwoAccountsUsd / pureHbarUsd, 1.0);
+                                    assertEquals(
+                                            20.0, pureTwoTokensFourAccountsUsd / pureHbarUsd, 2.0);
+                                    assertEquals(
+                                            30.0, pureThreeTokensSixAccountsUsd / pureHbarUsd, 3.0);
+                                }));
+    }
 
-									double pureHbarUsd = rates.toUsdWithActiveRates(refFee);
-									double pureOneTokenTwoAccountsUsd =
-											rates.toUsdWithActiveRates(t1a2Fee);
-									double pureTwoTokensFourAccountsUsd =
-											rates.toUsdWithActiveRates(t2a4Fee);
-									double pureThreeTokensSixAccountsUsd =
-											rates.toUsdWithActiveRates(t3a6Fee);
-									assertEquals(
-											10.0, pureOneTokenTwoAccountsUsd / pureHbarUsd, 1.0);
-									assertEquals(
-											20.0, pureTwoTokensFourAccountsUsd / pureHbarUsd, 2.0);
-									assertEquals(
-											30.0, pureThreeTokensSixAccountsUsd / pureHbarUsd, 3.0);
-								}));
-	}
+    public static String sdec(double d, int numDecimals) {
+        var fmt = "%" + String.format(".0%df", numDecimals);
+        return String.format(fmt, d);
+    }
 
-	public static String sdec(double d, int numDecimals) {
-		var fmt = "%" + String.format(".0%df", numDecimals);
-		return String.format(fmt, d);
-	}
+    private HapiApiSpec transferToNonAccountEntitiesReturnsInvalidAccountId() {
+        AtomicReference<String> invalidAccountId = new AtomicReference<>();
 
-	private HapiApiSpec transferToNonAccountEntitiesReturnsInvalidAccountId() {
-		AtomicReference<String> invalidAccountId = new AtomicReference<>();
+        return defaultHapiSpec("TransferToNonAccountEntitiesReturnsInvalidAccountId")
+                .given(
+                        tokenCreate(TOKEN),
+                        createTopic("something"),
+                        withOpContext(
+                                (spec, opLog) -> {
+                                    var topicId = spec.registry().getTopicID("something");
+                                    invalidAccountId.set(asTopicString(topicId));
+                                }))
+                .when()
+                .then(
+                        sourcing(
+                                () ->
+                                        cryptoTransfer(
+                                                        tinyBarsFromTo(
+                                                                DEFAULT_PAYER,
+                                                                invalidAccountId.get(),
+                                                                1L))
+                                                .signedBy(DEFAULT_PAYER)
+                                                .hasKnownStatus(INVALID_ACCOUNT_ID)),
+                        sourcing(
+                                () ->
+                                        cryptoTransfer(
+                                                        moving(1, TOKEN)
+                                                                .between(
+                                                                        DEFAULT_PAYER,
+                                                                        invalidAccountId.get()))
+                                                .signedBy(DEFAULT_PAYER)
+                                                .hasKnownStatus(INVALID_ACCOUNT_ID)));
+    }
 
-		return defaultHapiSpec("TransferToNonAccountEntitiesReturnsInvalidAccountId")
-				.given(
-						tokenCreate(TOKEN),
-						createTopic("something"),
-						withOpContext(
-								(spec, opLog) -> {
-									var topicId = spec.registry().getTopicID("something");
-									invalidAccountId.set(asTopicString(topicId));
-								}))
-				.when()
-				.then(
-						sourcing(
-								() ->
-										cryptoTransfer(
-												tinyBarsFromTo(
-														DEFAULT_PAYER,
-														invalidAccountId.get(),
-														1L))
-												.signedBy(DEFAULT_PAYER)
-												.hasKnownStatus(INVALID_ACCOUNT_ID)),
-						sourcing(
-								() ->
-										cryptoTransfer(
-												moving(1, TOKEN)
-														.between(
-																DEFAULT_PAYER,
-																invalidAccountId.get()))
-												.signedBy(DEFAULT_PAYER)
-												.hasKnownStatus(INVALID_ACCOUNT_ID)));
-	}
+    private HapiApiSpec complexKeyAcctPaysForOwnTransfer() {
+        SigControl enoughUniqueSigs =
+                SigControl.threshSigs(
+                        2,
+                        SigControl.threshSigs(1, OFF, OFF, OFF, OFF, OFF, OFF, ON),
+                        SigControl.threshSigs(3, ON, ON, ON, OFF, OFF, OFF, OFF));
+        String node = HapiSpecSetup.getDefaultInstance().defaultNodeName();
 
-	private HapiApiSpec complexKeyAcctPaysForOwnTransfer() {
-		SigControl enoughUniqueSigs =
-				SigControl.threshSigs(
-						2,
-						SigControl.threshSigs(1, OFF, OFF, OFF, OFF, OFF, OFF, ON),
-						SigControl.threshSigs(3, ON, ON, ON, OFF, OFF, OFF, OFF));
-		String node = HapiSpecSetup.getDefaultInstance().defaultNodeName();
+        return defaultHapiSpec("ComplexKeyAcctPaysForOwnTransfer")
+                .given(
+                        newKeyNamed("complexKey").shape(enoughUniqueSigs),
+                        cryptoCreate(PAYER).key("complexKey").balance(1_000_000_000L))
+                .when()
+                .then(
+                        cryptoTransfer(tinyBarsFromTo(PAYER, node, 1_000_000L))
+                                .payingWith(PAYER)
+                                .numPayerSigs(14)
+                                .fee(ONE_HUNDRED_HBARS));
+    }
 
-		return defaultHapiSpec("ComplexKeyAcctPaysForOwnTransfer")
-				.given(
-						newKeyNamed("complexKey").shape(enoughUniqueSigs),
-						cryptoCreate(PAYER).key("complexKey").balance(1_000_000_000L))
-				.when()
-				.then(
-						cryptoTransfer(tinyBarsFromTo(PAYER, node, 1_000_000L))
-								.payingWith(PAYER)
-								.numPayerSigs(14)
-								.fee(ONE_HUNDRED_HBARS));
-	}
+    private HapiApiSpec twoComplexKeysRequired() {
+        SigControl payerShape = threshOf(2, threshOf(1, 7), threshOf(3, 7));
+        SigControl receiverShape = SigControl.threshSigs(3, threshOf(2, 2), threshOf(3, 5), ON);
 
-	private HapiApiSpec twoComplexKeysRequired() {
-		SigControl payerShape = threshOf(2, threshOf(1, 7), threshOf(3, 7));
-		SigControl receiverShape = SigControl.threshSigs(3, threshOf(2, 2), threshOf(3, 5), ON);
+        SigControl payerSigs =
+                SigControl.threshSigs(
+                        2,
+                        SigControl.threshSigs(1, ON, OFF, OFF, OFF, OFF, OFF, OFF),
+                        SigControl.threshSigs(3, ON, ON, ON, OFF, OFF, OFF, OFF));
+        SigControl receiverSigs =
+                SigControl.threshSigs(
+                        3,
+                        SigControl.threshSigs(2, ON, ON),
+                        SigControl.threshSigs(3, OFF, OFF, ON, ON, ON),
+                        ON);
 
-		SigControl payerSigs =
-				SigControl.threshSigs(
-						2,
-						SigControl.threshSigs(1, ON, OFF, OFF, OFF, OFF, OFF, OFF),
-						SigControl.threshSigs(3, ON, ON, ON, OFF, OFF, OFF, OFF));
-		SigControl receiverSigs =
-				SigControl.threshSigs(
-						3,
-						SigControl.threshSigs(2, ON, ON),
-						SigControl.threshSigs(3, OFF, OFF, ON, ON, ON),
-						ON);
+        return defaultHapiSpec("TwoComplexKeysRequired")
+                .given(
+                        newKeyNamed("payerKey").shape(payerShape),
+                        newKeyNamed("receiverKey").shape(receiverShape),
+                        cryptoCreate(PAYER).key("payerKey").balance(100_000_000_000L),
+                        cryptoCreate(RECEIVER)
+                                .receiverSigRequired(true)
+                                .key("receiverKey")
+                                .payingWith(PAYER))
+                .when()
+                .then(
+                        cryptoTransfer(tinyBarsFromTo(GENESIS, RECEIVER, 1_000L))
+                                .payingWith(PAYER)
+                                .sigControl(
+                                        forKey(PAYER, payerSigs), forKey(RECEIVER, receiverSigs))
+                                .hasKnownStatus(SUCCESS)
+                                .fee(ONE_HUNDRED_HBARS));
+    }
 
-		return defaultHapiSpec("TwoComplexKeysRequired")
-				.given(
-						newKeyNamed("payerKey").shape(payerShape),
-						newKeyNamed("receiverKey").shape(receiverShape),
-						cryptoCreate(PAYER).key("payerKey").balance(100_000_000_000L),
-						cryptoCreate(RECEIVER)
-								.receiverSigRequired(true)
-								.key("receiverKey")
-								.payingWith(PAYER))
-				.when()
-				.then(
-						cryptoTransfer(tinyBarsFromTo(GENESIS, RECEIVER, 1_000L))
-								.payingWith(PAYER)
-								.sigControl(
-										forKey(PAYER, payerSigs), forKey(RECEIVER, receiverSigs))
-								.hasKnownStatus(SUCCESS)
-								.fee(ONE_HUNDRED_HBARS));
-	}
+    private HapiApiSpec specialAccountsBalanceCheck() {
+        return defaultHapiSpec("SpecialAccountsBalanceCheck")
+                .given()
+                .when()
+                .then(
+                        IntStream.concat(IntStream.range(1, 101), IntStream.range(900, 1001))
+                                .mapToObj(i -> getAccountBalance("0.0." + i).logged())
+                                .toArray(HapiSpecOperation[]::new));
+    }
 
-	private HapiApiSpec specialAccountsBalanceCheck() {
-		return defaultHapiSpec("SpecialAccountsBalanceCheck")
-				.given()
-				.when()
-				.then(
-						IntStream.concat(IntStream.range(1, 101), IntStream.range(900, 1001))
-								.mapToObj(i -> getAccountBalance("0.0." + i).logged())
-								.toArray(HapiSpecOperation[]::new));
-	}
+    private HapiApiSpec transferWithMissingAccountGetsInvalidAccountId() {
+        return defaultHapiSpec("TransferWithMissingAccount")
+                .given(cryptoCreate(PAYEE_SIG_REQ).receiverSigRequired(true))
+                .when(
+                        cryptoTransfer(tinyBarsFromTo("1.2.3", PAYEE_SIG_REQ, 1_000L))
+                                .signedBy(DEFAULT_PAYER, PAYEE_SIG_REQ)
+                                .hasKnownStatus(INVALID_ACCOUNT_ID))
+                .then();
+    }
 
-	private HapiApiSpec transferWithMissingAccountGetsInvalidAccountId() {
-		return defaultHapiSpec("TransferWithMissingAccount")
-				.given(cryptoCreate(PAYEE_SIG_REQ).receiverSigRequired(true))
-				.when(
-						cryptoTransfer(tinyBarsFromTo("1.2.3", PAYEE_SIG_REQ, 1_000L))
-								.signedBy(DEFAULT_PAYER, PAYEE_SIG_REQ)
-								.hasKnownStatus(INVALID_ACCOUNT_ID))
-				.then();
-	}
+    private HapiApiSpec vanillaTransferSucceeds() {
+        long initialBalance = HapiSpecSetup.getDefaultInstance().defaultBalance();
 
-	private HapiApiSpec vanillaTransferSucceeds() {
-		long initialBalance = HapiSpecSetup.getDefaultInstance().defaultBalance();
+        return defaultHapiSpec("VanillaTransferSucceeds")
+                .given(
+                        UtilVerbs.inParallel(
+                                cryptoCreate(PAYER),
+                                cryptoCreate(PAYEE_SIG_REQ).receiverSigRequired(true),
+                                cryptoCreate(PAYEE_NO_SIG_REQ)))
+                .when(
+                        cryptoTransfer(
+                                        tinyBarsFromTo(PAYER, PAYEE_SIG_REQ, 1_000L),
+                                        tinyBarsFromTo(PAYER, PAYEE_NO_SIG_REQ, 2_000L))
+                                .via("transferTxn"))
+                .then(
+                        getAccountInfo(PAYER)
+                                .logged()
+                                .hasExpectedLedgerId("0x03")
+                                .has(accountWith().balance(initialBalance - 3_000L)),
+                        getAccountInfo(PAYEE_SIG_REQ)
+                                .has(accountWith().balance(initialBalance + 1_000L)),
+                        getAccountDetails(PAYEE_NO_SIG_REQ)
+                                .payingWith(GENESIS)
+                                .has(
+                                        AccountDetailsAsserts.accountWith()
+                                                .balance(initialBalance + 2_000L)
+                                                .noAllowances()));
+    }
 
-		return defaultHapiSpec("VanillaTransferSucceeds")
-				.given(
-						UtilVerbs.inParallel(
-								cryptoCreate(PAYER),
-								cryptoCreate(PAYEE_SIG_REQ).receiverSigRequired(true),
-								cryptoCreate(PAYEE_NO_SIG_REQ)))
-				.when(
-						cryptoTransfer(
-								tinyBarsFromTo(PAYER, PAYEE_SIG_REQ, 1_000L),
-								tinyBarsFromTo(PAYER, PAYEE_NO_SIG_REQ, 2_000L))
-								.via("transferTxn"))
-				.then(
-						getAccountInfo(PAYER)
-								.logged()
-								.hasExpectedLedgerId("0x03")
-								.has(accountWith().balance(initialBalance - 3_000L)),
-						getAccountInfo(PAYEE_SIG_REQ)
-								.has(accountWith().balance(initialBalance + 1_000L)),
-						getAccountDetails(PAYEE_NO_SIG_REQ)
-								.payingWith(GENESIS)
-								.has(
-										AccountDetailsAsserts.accountWith()
-												.balance(initialBalance + 2_000L)
-												.noAllowances()));
-	}
-
-	@Override
-	protected Logger getResultsLogger() {
-		return LOG;
-	}
+    @Override
+    protected Logger getResultsLogger() {
+        return LOG;
+    }
 }


### PR DESCRIPTION
**Description**:
- Two tweaks to make staking behavior more intuitive and consistent.
- The EET verifying these behaviors is [here](https://github.com/hashgraph/hedera-services/blob/minor-staking-fixes/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoTransferSuite.java#L1259); a direct comparison is impossible b/c spotless.