### PR TITLE
Fix supply key requirement for NFT creations

### DIFF
--- a/hedera-node/src/main/java/com/hedera/services/txns/token/validators/CreateChecks.java
+++ b/hedera-node/src/main/java/com/hedera/services/txns/token/validators/CreateChecks.java
@@ -1,11 +1,6 @@
-package com.hedera.services.txns.token.validators;
-
-/*-
- * ‌
- * Hedera Services Node
- * ​
- * Copyright (C) 2018 - 2022 Hedera Hashgraph, LLC
- * ​
+/*
+ * Copyright (C) 2022 Hedera Hashgraph, LLC
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -17,23 +12,11 @@ package com.hedera.services.txns.token.validators;
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- * ‍
  */
-
-import com.hedera.services.context.properties.GlobalDynamicProperties;
-import com.hedera.services.state.enums.TokenType;
-import com.hedera.services.txns.validation.OptionValidator;
-import com.hedera.services.utils.TokenTypesMapper;
-import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
-import com.hederahashgraph.api.proto.java.TokenCreateTransactionBody;
-import com.hederahashgraph.api.proto.java.TransactionBody;
-
-import javax.inject.Inject;
-import javax.inject.Singleton;
-import java.time.Instant;
-import java.util.function.Function;
+package com.hedera.services.txns.token.validators;
 
 import static com.hedera.services.txns.validation.TokenListChecks.checkKeys;
+import static com.hedera.services.txns.validation.TokenListChecks.nftSupplyKeyCheck;
 import static com.hedera.services.txns.validation.TokenListChecks.suppliesCheck;
 import static com.hedera.services.txns.validation.TokenListChecks.supplyTypeCheck;
 import static com.hedera.services.txns.validation.TokenListChecks.typeCheck;
@@ -44,93 +27,117 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.NOT_SUPPORTED;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OK;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TOKEN_HAS_NO_FREEZE_KEY;
 
+import com.hedera.services.context.properties.GlobalDynamicProperties;
+import com.hedera.services.state.enums.TokenType;
+import com.hedera.services.txns.validation.OptionValidator;
+import com.hedera.services.utils.TokenTypesMapper;
+import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
+import com.hederahashgraph.api.proto.java.TokenCreateTransactionBody;
+import com.hederahashgraph.api.proto.java.TransactionBody;
+import java.time.Instant;
+import java.util.function.Function;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
 @Singleton
 public final class CreateChecks {
-	private final GlobalDynamicProperties dynamicProperties;
-	private final OptionValidator validator;
+    private final GlobalDynamicProperties dynamicProperties;
+    private final OptionValidator validator;
 
-	@Inject
-	public CreateChecks(final GlobalDynamicProperties dynamicProperties, final OptionValidator validator) {
-		this.dynamicProperties = dynamicProperties;
-		this.validator = validator;
-	}
+    @Inject
+    public CreateChecks(
+            final GlobalDynamicProperties dynamicProperties, final OptionValidator validator) {
+        this.dynamicProperties = dynamicProperties;
+        this.validator = validator;
+    }
 
-	public Function<TransactionBody, ResponseCodeEnum> validatorForConsTime(final Instant curConsTime) {
-		return txnBody -> {
-			TokenCreateTransactionBody op = txnBody.getTokenCreation();
+    public Function<TransactionBody, ResponseCodeEnum> validatorForConsTime(
+            final Instant curConsTime) {
+        return txnBody -> {
+            TokenCreateTransactionBody op = txnBody.getTokenCreation();
 
-			final var domainType = TokenTypesMapper.mapToDomain(op.getTokenType());
-			if (domainType == TokenType.NON_FUNGIBLE_UNIQUE && !dynamicProperties.areNftsEnabled()) {
-				return NOT_SUPPORTED;
-			}
+            final var domainType = TokenTypesMapper.mapToDomain(op.getTokenType());
+            if (domainType == TokenType.NON_FUNGIBLE_UNIQUE
+                    && !dynamicProperties.areNftsEnabled()) {
+                return NOT_SUPPORTED;
+            }
 
-			var validity = validator.memoCheck(op.getMemo());
-			if (validity != OK) {
-				return validity;
-			}
+            var validity = validator.memoCheck(op.getMemo());
+            if (validity != OK) {
+                return validity;
+            }
 
-			validity = validator.tokenSymbolCheck(op.getSymbol());
-			if (validity != OK) {
-				return validity;
-			}
+            validity = validator.tokenSymbolCheck(op.getSymbol());
+            if (validity != OK) {
+                return validity;
+            }
 
-			validity = validator.tokenNameCheck(op.getName());
-			if (validity != OK) {
-				return validity;
-			}
+            validity = validator.tokenNameCheck(op.getName());
+            if (validity != OK) {
+                return validity;
+            }
 
-			validity = typeCheck(op.getTokenType(), op.getInitialSupply(), op.getDecimals());
-			if (validity != OK) {
-				return validity;
-			}
+            validity = typeCheck(op.getTokenType(), op.getInitialSupply(), op.getDecimals());
+            if (validity != OK) {
+                return validity;
+            }
 
-			validity = supplyTypeCheck(op.getSupplyType(), op.getMaxSupply());
-			if (validity != OK) {
-				return validity;
-			}
+            validity = supplyTypeCheck(op.getSupplyType(), op.getMaxSupply());
+            if (validity != OK) {
+                return validity;
+            }
 
-			validity = suppliesCheck(op.getInitialSupply(), op.getMaxSupply());
-			if (validity != OK) {
-				return validity;
-			}
+            validity = suppliesCheck(op.getInitialSupply(), op.getMaxSupply());
+            if (validity != OK) {
+                return validity;
+            }
 
-			if (!op.hasTreasury()) {
-				return INVALID_TREASURY_ACCOUNT_FOR_TOKEN;
-			}
+            validity = nftSupplyKeyCheck(op.getTokenType(), op.hasSupplyKey());
+            if (validity != OK) {
+                return validity;
+            }
 
-			validity = checkKeys(
-					op.hasAdminKey(), op.getAdminKey(),
-					op.hasKycKey(), op.getKycKey(),
-					op.hasWipeKey(), op.getWipeKey(),
-					op.hasSupplyKey(), op.getSupplyKey(),
-					op.hasFreezeKey(), op.getFreezeKey(),
-					op.hasFeeScheduleKey(), op.getFeeScheduleKey(),
-					op.hasPauseKey(), op.getPauseKey());
-			if (validity != OK) {
-				return validity;
-			}
+            if (!op.hasTreasury()) {
+                return INVALID_TREASURY_ACCOUNT_FOR_TOKEN;
+            }
 
-			if (op.getFreezeDefault() && !op.hasFreezeKey()) {
-				return TOKEN_HAS_NO_FREEZE_KEY;
-			}
-			return validateAutoRenewAccount(op, validator, curConsTime);
-		};
-	}
+            validity =
+                    checkKeys(
+                            op.hasAdminKey(), op.getAdminKey(),
+                            op.hasKycKey(), op.getKycKey(),
+                            op.hasWipeKey(), op.getWipeKey(),
+                            op.hasSupplyKey(), op.getSupplyKey(),
+                            op.hasFreezeKey(), op.getFreezeKey(),
+                            op.hasFeeScheduleKey(), op.getFeeScheduleKey(),
+                            op.hasPauseKey(), op.getPauseKey());
+            if (validity != OK) {
+                return validity;
+            }
 
-	private ResponseCodeEnum validateAutoRenewAccount(
-			final TokenCreateTransactionBody op,
-			final OptionValidator validator,
-			final Instant curConsTime
-	) {
-		ResponseCodeEnum validity = OK;
-		if (op.hasAutoRenewAccount()) {
-			validity = validator.isValidAutoRenewPeriod(op.getAutoRenewPeriod()) ? OK : INVALID_RENEWAL_PERIOD;
-			return validity;
-		} else {
-			if (curConsTime != null && op.getExpiry().getSeconds() <= curConsTime.getEpochSecond()) {
-				return INVALID_EXPIRATION_TIME;
-			}
-		}
-		return validity;
-	}
+            if (op.getFreezeDefault() && !op.hasFreezeKey()) {
+                return TOKEN_HAS_NO_FREEZE_KEY;
+            }
+            return validateAutoRenewAccount(op, validator, curConsTime);
+        };
+    }
+
+    private ResponseCodeEnum validateAutoRenewAccount(
+            final TokenCreateTransactionBody op,
+            final OptionValidator validator,
+            final Instant curConsTime) {
+        ResponseCodeEnum validity = OK;
+        if (op.hasAutoRenewAccount()) {
+            validity =
+                    validator.isValidAutoRenewPeriod(op.getAutoRenewPeriod())
+                            ? OK
+                            : INVALID_RENEWAL_PERIOD;
+            return validity;
+        } else {
+            if (curConsTime != null
+                    && op.getExpiry().getSeconds() <= curConsTime.getEpochSecond()) {
+                return INVALID_EXPIRATION_TIME;
+            }
+        }
+        return validity;
+    }
 }

--- a/hedera-node/src/main/java/com/hedera/services/txns/validation/TokenListChecks.java
+++ b/hedera-node/src/main/java/com/hedera/services/txns/validation/TokenListChecks.java
@@ -1,11 +1,6 @@
-package com.hedera.services.txns.validation;
-
-/*-
- * ‌
- * Hedera Services Node
- * ​
- * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
- * ​
+/*
+ * Copyright (C) 2020-2021 Hedera Hashgraph, LLC
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -17,19 +12,8 @@ package com.hedera.services.txns.validation;
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- * ‍
  */
-
-import com.hedera.services.sigs.utils.ImmutableKeyUtils;
-import com.hederahashgraph.api.proto.java.Key;
-import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
-import com.hederahashgraph.api.proto.java.TokenID;
-import com.hederahashgraph.api.proto.java.TokenSupplyType;
-import com.hederahashgraph.api.proto.java.TokenType;
-
-import java.util.HashSet;
-import java.util.List;
-import java.util.function.Predicate;
+package com.hedera.services.txns.validation;
 
 import static com.hedera.services.txns.validation.PureValidation.checkKey;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_ADMIN_KEY;
@@ -44,118 +28,149 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_TOKEN_
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_WIPE_KEY;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.NOT_SUPPORTED;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OK;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TOKEN_HAS_NO_SUPPLY_KEY;
+
+import com.hedera.services.sigs.utils.ImmutableKeyUtils;
+import com.hederahashgraph.api.proto.java.Key;
+import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
+import com.hederahashgraph.api.proto.java.TokenID;
+import com.hederahashgraph.api.proto.java.TokenSupplyType;
+import com.hederahashgraph.api.proto.java.TokenType;
+import java.util.HashSet;
+import java.util.List;
+import java.util.function.Predicate;
 
 public final class TokenListChecks {
-	static Predicate<Key> adminKeyRemoval = ImmutableKeyUtils::signalsKeyRemoval;
+    static Predicate<Key> adminKeyRemoval = ImmutableKeyUtils::signalsKeyRemoval;
 
-	private TokenListChecks() {
-		throw new UnsupportedOperationException("Utility Class");
-	}
+    private TokenListChecks() {
+        throw new UnsupportedOperationException("Utility Class");
+    }
 
-	public static boolean repeatsItself(final List<TokenID> tokens) {
-		return new HashSet<>(tokens).size() < tokens.size();
-	}
+    public static boolean repeatsItself(final List<TokenID> tokens) {
+        return new HashSet<>(tokens).size() < tokens.size();
+    }
 
-	public static ResponseCodeEnum typeCheck(final TokenType type, final long initialSupply, final int decimals) {
-		switch (type) {
-			case FUNGIBLE_COMMON:
-				return fungibleCommonTypeCheck(initialSupply, decimals);
-			case NON_FUNGIBLE_UNIQUE:
-				return nonFungibleUniqueCheck(initialSupply, decimals);
-			default:
-				return NOT_SUPPORTED;
-		}
-	}
+    public static ResponseCodeEnum typeCheck(
+            final TokenType type, final long initialSupply, final int decimals) {
+        switch (type) {
+            case FUNGIBLE_COMMON:
+                return fungibleCommonTypeCheck(initialSupply, decimals);
+            case NON_FUNGIBLE_UNIQUE:
+                return nonFungibleUniqueCheck(initialSupply, decimals);
+            default:
+                return NOT_SUPPORTED;
+        }
+    }
 
-	public static ResponseCodeEnum nonFungibleUniqueCheck(final long initialSupply, final int decimals) {
-		if (initialSupply != 0) {
-			return INVALID_TOKEN_INITIAL_SUPPLY;
-		}
+    public static ResponseCodeEnum nonFungibleUniqueCheck(
+            final long initialSupply, final int decimals) {
+        if (initialSupply != 0) {
+            return INVALID_TOKEN_INITIAL_SUPPLY;
+        }
 
-		return decimals != 0 ? INVALID_TOKEN_DECIMALS : OK;
-	}
+        return decimals != 0 ? INVALID_TOKEN_DECIMALS : OK;
+    }
 
-	public static ResponseCodeEnum fungibleCommonTypeCheck(final long initialSupply, final int decimals) {
-		if (initialSupply < 0) {
-			return INVALID_TOKEN_INITIAL_SUPPLY;
-		}
+    public static ResponseCodeEnum fungibleCommonTypeCheck(
+            final long initialSupply, final int decimals) {
+        if (initialSupply < 0) {
+            return INVALID_TOKEN_INITIAL_SUPPLY;
+        }
 
-		return decimals < 0 ? INVALID_TOKEN_DECIMALS : OK;
-	}
+        return decimals < 0 ? INVALID_TOKEN_DECIMALS : OK;
+    }
 
-	public static ResponseCodeEnum suppliesCheck(final long initialSupply, final long maxSupply) {
-		if (maxSupply > 0 && initialSupply > maxSupply) {
-			return INVALID_TOKEN_INITIAL_SUPPLY;
-		}
+    public static ResponseCodeEnum suppliesCheck(final long initialSupply, final long maxSupply) {
+        if (maxSupply > 0 && initialSupply > maxSupply) {
+            return INVALID_TOKEN_INITIAL_SUPPLY;
+        }
 
-		return OK;
-	}
+        return OK;
+    }
 
-	public static ResponseCodeEnum supplyTypeCheck(final TokenSupplyType supplyType, final long maxSupply) {
-		switch (supplyType) {
-			case INFINITE:
-				return maxSupply != 0 ? INVALID_TOKEN_MAX_SUPPLY : OK;
-			case FINITE:
-				return maxSupply <= 0 ? INVALID_TOKEN_MAX_SUPPLY : OK;
-			default:
-				return NOT_SUPPORTED;
-		}
-	}
+    public static ResponseCodeEnum supplyTypeCheck(
+            final TokenSupplyType supplyType, final long maxSupply) {
+        switch (supplyType) {
+            case INFINITE:
+                return maxSupply != 0 ? INVALID_TOKEN_MAX_SUPPLY : OK;
+            case FINITE:
+                return maxSupply <= 0 ? INVALID_TOKEN_MAX_SUPPLY : OK;
+            default:
+                return NOT_SUPPORTED;
+        }
+    }
 
-	public static ResponseCodeEnum checkKeys(
-			final boolean hasAdminKey, final Key adminKey,
-			final boolean hasKycKey, final Key kycKey,
-			final boolean hasWipeKey, final Key wipeKey,
-			final boolean hasSupplyKey, final Key supplyKey,
-			final boolean hasFreezeKey, final Key freezeKey,
-			final boolean hasFeeScheduleKey, final Key feeScheduleKey,
-			final boolean hasPauseKey, final Key pauseKey
-	) {
-		ResponseCodeEnum validity = checkAdminKey(hasAdminKey, adminKey);
-		if (validity != OK) {
-			return validity;
-		}
+    public static ResponseCodeEnum checkKeys(
+            final boolean hasAdminKey,
+            final Key adminKey,
+            final boolean hasKycKey,
+            final Key kycKey,
+            final boolean hasWipeKey,
+            final Key wipeKey,
+            final boolean hasSupplyKey,
+            final Key supplyKey,
+            final boolean hasFreezeKey,
+            final Key freezeKey,
+            final boolean hasFeeScheduleKey,
+            final Key feeScheduleKey,
+            final boolean hasPauseKey,
+            final Key pauseKey) {
+        ResponseCodeEnum validity = checkAdminKey(hasAdminKey, adminKey);
+        if (validity != OK) {
+            return validity;
+        }
 
-		validity = checkKeyOfType(hasKycKey, kycKey, INVALID_KYC_KEY);
-		if (validity != OK) {
-			return validity;
-		}
+        validity = checkKeyOfType(hasKycKey, kycKey, INVALID_KYC_KEY);
+        if (validity != OK) {
+            return validity;
+        }
 
-		validity = checkKeyOfType(hasWipeKey, wipeKey, INVALID_WIPE_KEY);
-		if (validity != OK) {
-			return validity;
-		}
+        validity = checkKeyOfType(hasWipeKey, wipeKey, INVALID_WIPE_KEY);
+        if (validity != OK) {
+            return validity;
+        }
 
-		validity = checkKeyOfType(hasSupplyKey, supplyKey, INVALID_SUPPLY_KEY);
-		if (validity != OK) {
-			return validity;
-		}
+        validity = checkKeyOfType(hasSupplyKey, supplyKey, INVALID_SUPPLY_KEY);
+        if (validity != OK) {
+            return validity;
+        }
 
-		validity = checkKeyOfType(hasFreezeKey, freezeKey, INVALID_FREEZE_KEY);
-		if (validity != OK) {
-			return validity;
-		}
+        validity = checkKeyOfType(hasFreezeKey, freezeKey, INVALID_FREEZE_KEY);
+        if (validity != OK) {
+            return validity;
+        }
 
-		validity = checkKeyOfType(hasFeeScheduleKey, feeScheduleKey, INVALID_CUSTOM_FEE_SCHEDULE_KEY);
-		if (validity != OK) {
-			return validity;
-		}
+        validity =
+                checkKeyOfType(hasFeeScheduleKey, feeScheduleKey, INVALID_CUSTOM_FEE_SCHEDULE_KEY);
+        if (validity != OK) {
+            return validity;
+        }
 
-		validity = checkKeyOfType(hasPauseKey, pauseKey, INVALID_PAUSE_KEY);
-		return validity;
-	}
+        validity = checkKeyOfType(hasPauseKey, pauseKey, INVALID_PAUSE_KEY);
+        return validity;
+    }
 
-	private static ResponseCodeEnum checkAdminKey(final boolean hasAdminKey, final Key adminKey) {
-		if (hasAdminKey && !adminKeyRemoval.test(adminKey)) {
-			return checkKey(adminKey, INVALID_ADMIN_KEY);
-		}
-		return OK;
-	}
+    private static ResponseCodeEnum checkAdminKey(final boolean hasAdminKey, final Key adminKey) {
+        if (hasAdminKey && !adminKeyRemoval.test(adminKey)) {
+            return checkKey(adminKey, INVALID_ADMIN_KEY);
+        }
+        return OK;
+    }
 
-	private static ResponseCodeEnum checkKeyOfType(final boolean hasKey, final Key key, final ResponseCodeEnum code) {
-		if (hasKey) {
-			return checkKey(key, code);
-		}
-		return OK;
-	}
+    private static ResponseCodeEnum checkKeyOfType(
+            final boolean hasKey, final Key key, final ResponseCodeEnum code) {
+        if (hasKey) {
+            return checkKey(key, code);
+        }
+        return OK;
+    }
+
+    public static ResponseCodeEnum nftSupplyKeyCheck(
+            final TokenType tokenType, final boolean supplyKey) {
+        if (tokenType == TokenType.NON_FUNGIBLE_UNIQUE && !supplyKey) {
+            return TOKEN_HAS_NO_SUPPLY_KEY;
+        }
+        return OK;
+    }
 }

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/fees/AllBaseOpFeesSuite.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/fees/AllBaseOpFeesSuite.java
@@ -1,11 +1,6 @@
-package com.hedera.services.bdd.suites.fees;
-
-/*-
- * ‌
- * Hedera Services Test Clients
- * ​
- * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
- * ​
+/*
+ * Copyright (C) 2021-2022 Hedera Hashgraph, LLC
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -17,18 +12,8 @@ package com.hedera.services.bdd.suites.fees;
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- * ‍
  */
-
-import com.google.protobuf.ByteString;
-import com.hedera.services.bdd.spec.HapiApiSpec;
-import com.hedera.services.bdd.suites.HapiApiSuite;
-import com.hederahashgraph.api.proto.java.TokenSupplyType;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-
-import java.time.Instant;
-import java.util.List;
+package com.hedera.services.bdd.suites.fees;
 
 import static com.hedera.services.bdd.spec.HapiApiSpec.defaultHapiSpec;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.burnToken;
@@ -46,204 +31,216 @@ import static com.hedera.services.bdd.spec.utilops.UtilVerbs.validateChargedUsdW
 import static com.hedera.services.bdd.suites.utils.MiscEETUtils.metadata;
 import static com.hederahashgraph.api.proto.java.TokenType.NON_FUNGIBLE_UNIQUE;
 
+import com.google.protobuf.ByteString;
+import com.hedera.services.bdd.spec.HapiApiSpec;
+import com.hedera.services.bdd.suites.HapiApiSuite;
+import com.hederahashgraph.api.proto.java.TokenSupplyType;
+import java.time.Instant;
+import java.util.List;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 public class AllBaseOpFeesSuite extends HapiApiSuite {
-	private static final Logger log = LogManager.getLogger(AllBaseOpFeesSuite.class);
+    private static final Logger log = LogManager.getLogger(AllBaseOpFeesSuite.class);
 
-	private static final double ALLOWED_DIFFERENCE_PERCENTAGE = 0.01;
+    private static final double ALLOWED_DIFFERENCE_PERCENTAGE = 0.01;
 
-	private static final String TREASURE_KEY = "treasureKey";
-	private static final String FUNGIBLE_COMMON_TOKEN = "fungibleCommonToken";
+    private static final String TREASURE_KEY = "treasureKey";
+    private static final String FUNGIBLE_COMMON_TOKEN = "fungibleCommonToken";
 
-	private static final String ADMIN_KEY = "adminKey";
-	private static final String SUPPLY_KEY = "supplyKey";
-	private static final String FREEZE_KEY = "freezeKey";
-	private static final String WIPE_KEY = "wipeKey";
-	private static final String KYC_KEY = "kycKey";
+    private static final String ADMIN_KEY = "adminKey";
+    private static final String SUPPLY_KEY = "supplyKey";
+    private static final String FREEZE_KEY = "freezeKey";
+    private static final String WIPE_KEY = "wipeKey";
+    private static final String KYC_KEY = "kycKey";
 
-	private static final String CIVILIAN_ACCT = "civilian";
+    private static final String CIVILIAN_ACCT = "civilian";
 
-	private static final String UNIQUE_TOKEN = "nftType";
+    private static final String UNIQUE_TOKEN = "nftType";
 
-	private static final String BASE_TXN = "baseTxn";
+    private static final String BASE_TXN = "baseTxn";
 
-	private static final double EXPECTED_UNFREEZE_PRICE_USD = 0.001;
-	private static final double EXPECTED_FREEZE_PRICE_USD = 0.001;
-	private static final double EXPECTED_NFT_MINT_PRICE_USD = 0.05;
-	private static final double EXPECTED_NFT_BURN_PRICE_USD = 0.001;
-	private static final double EXPECTED_NFT_WIPE_PRICE_USD = 0.001;
+    private static final double EXPECTED_UNFREEZE_PRICE_USD = 0.001;
+    private static final double EXPECTED_FREEZE_PRICE_USD = 0.001;
+    private static final double EXPECTED_NFT_MINT_PRICE_USD = 0.05;
+    private static final double EXPECTED_NFT_BURN_PRICE_USD = 0.001;
+    private static final double EXPECTED_NFT_WIPE_PRICE_USD = 0.001;
 
-	public static void main(String... args) {
-		new AllBaseOpFeesSuite().runSuiteSync();
-	}
+    public static void main(String... args) {
+        new AllBaseOpFeesSuite().runSuiteSync();
+    }
 
-	@Override
-	public List<HapiApiSpec> getSpecsInSuite() {
-		return allOf(List.of(new HapiApiSpec[] {
-						baseNftFreezeUnfreezeChargedAsExpected(),
-						baseCommonFreezeUnfreezeChargedAsExpected(),
-						baseNftMintOperationIsChargedExpectedFee(),
-						baseNftWipeOperationIsChargedExpectedFee(),
-						baseNftBurnOperationIsChargedExpectedFee(),
-				})
-		);
-	}
+    @Override
+    public List<HapiApiSpec> getSpecsInSuite() {
+        return allOf(
+                List.of(
+                        new HapiApiSpec[] {
+                            baseNftFreezeUnfreezeChargedAsExpected(),
+                            baseCommonFreezeUnfreezeChargedAsExpected(),
+                            baseNftMintOperationIsChargedExpectedFee(),
+                            baseNftWipeOperationIsChargedExpectedFee(),
+                            baseNftBurnOperationIsChargedExpectedFee(),
+                        }));
+    }
 
-	private HapiApiSpec baseNftMintOperationIsChargedExpectedFee() {
-		final var standard100ByteMetadata = ByteString.copyFromUtf8(
-				"0123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789");
+    private HapiApiSpec baseNftMintOperationIsChargedExpectedFee() {
+        final var standard100ByteMetadata =
+                ByteString.copyFromUtf8(
+                        "0123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789");
 
-		return defaultHapiSpec("BaseUniqueMintOperationIsChargedExpectedFee")
-				.given(
-						newKeyNamed(SUPPLY_KEY),
-						cryptoCreate(CIVILIAN_ACCT).key(SUPPLY_KEY),
-						tokenCreate(UNIQUE_TOKEN)
-								.initialSupply(0L)
-								.expiry(Instant.now().getEpochSecond() + THREE_MONTHS_IN_SECONDS)
-								.supplyKey(SUPPLY_KEY)
-								.tokenType(NON_FUNGIBLE_UNIQUE)
-				)
-				.when(
-						mintToken(UNIQUE_TOKEN, List.of(standard100ByteMetadata))
-								.payingWith(CIVILIAN_ACCT)
-								.signedBy(SUPPLY_KEY)
-								.blankMemo()
-								.via(BASE_TXN)
-				).then(
-						validateChargedUsdWithin(BASE_TXN, EXPECTED_NFT_MINT_PRICE_USD, ALLOWED_DIFFERENCE_PERCENTAGE)
-				);
-	}
+        return defaultHapiSpec("BaseUniqueMintOperationIsChargedExpectedFee")
+                .given(
+                        newKeyNamed(SUPPLY_KEY),
+                        cryptoCreate(CIVILIAN_ACCT).key(SUPPLY_KEY),
+                        tokenCreate(UNIQUE_TOKEN)
+                                .initialSupply(0L)
+                                .expiry(Instant.now().getEpochSecond() + THREE_MONTHS_IN_SECONDS)
+                                .supplyKey(SUPPLY_KEY)
+                                .tokenType(NON_FUNGIBLE_UNIQUE))
+                .when(
+                        mintToken(UNIQUE_TOKEN, List.of(standard100ByteMetadata))
+                                .payingWith(CIVILIAN_ACCT)
+                                .signedBy(SUPPLY_KEY)
+                                .blankMemo()
+                                .via(BASE_TXN))
+                .then(
+                        validateChargedUsdWithin(
+                                BASE_TXN,
+                                EXPECTED_NFT_MINT_PRICE_USD,
+                                ALLOWED_DIFFERENCE_PERCENTAGE));
+    }
 
-	private HapiApiSpec baseNftWipeOperationIsChargedExpectedFee() {
-		return defaultHapiSpec("BaseUniqueWipeOperationIsChargedExpectedFee")
-				.given(
-						newKeyNamed(SUPPLY_KEY),
-						newKeyNamed(WIPE_KEY),
-						cryptoCreate(CIVILIAN_ACCT).key(WIPE_KEY),
-						cryptoCreate(TOKEN_TREASURY).balance(ONE_HUNDRED_HBARS).key(WIPE_KEY),
-						tokenCreate(UNIQUE_TOKEN)
-								.tokenType(NON_FUNGIBLE_UNIQUE)
-								.supplyType(TokenSupplyType.INFINITE)
-								.initialSupply(0L)
-								.supplyKey(SUPPLY_KEY)
-								.wipeKey(WIPE_KEY)
-								.treasury(TOKEN_TREASURY),
-						tokenAssociate(CIVILIAN_ACCT, UNIQUE_TOKEN),
-						mintToken(UNIQUE_TOKEN,
-								List.of(ByteString.copyFromUtf8("token_to_wipe"))),
-						cryptoTransfer(movingUnique(UNIQUE_TOKEN, 1L)
-								.between(TOKEN_TREASURY, CIVILIAN_ACCT))
-				)
-				.when(
-						wipeTokenAccount(UNIQUE_TOKEN, CIVILIAN_ACCT, List.of(1L))
-								.payingWith(TOKEN_TREASURY)
-								.fee(ONE_HBAR)
-								.blankMemo()
-								.via(BASE_TXN)
-				).then(
-						validateChargedUsdWithin(BASE_TXN, EXPECTED_NFT_WIPE_PRICE_USD, 0.01)
-				);
-	}
+    private HapiApiSpec baseNftWipeOperationIsChargedExpectedFee() {
+        return defaultHapiSpec("BaseUniqueWipeOperationIsChargedExpectedFee")
+                .given(
+                        newKeyNamed(SUPPLY_KEY),
+                        newKeyNamed(WIPE_KEY),
+                        cryptoCreate(CIVILIAN_ACCT).key(WIPE_KEY),
+                        cryptoCreate(TOKEN_TREASURY).balance(ONE_HUNDRED_HBARS).key(WIPE_KEY),
+                        tokenCreate(UNIQUE_TOKEN)
+                                .tokenType(NON_FUNGIBLE_UNIQUE)
+                                .supplyType(TokenSupplyType.INFINITE)
+                                .initialSupply(0L)
+                                .supplyKey(SUPPLY_KEY)
+                                .wipeKey(WIPE_KEY)
+                                .treasury(TOKEN_TREASURY),
+                        tokenAssociate(CIVILIAN_ACCT, UNIQUE_TOKEN),
+                        mintToken(UNIQUE_TOKEN, List.of(ByteString.copyFromUtf8("token_to_wipe"))),
+                        cryptoTransfer(
+                                movingUnique(UNIQUE_TOKEN, 1L)
+                                        .between(TOKEN_TREASURY, CIVILIAN_ACCT)))
+                .when(
+                        wipeTokenAccount(UNIQUE_TOKEN, CIVILIAN_ACCT, List.of(1L))
+                                .payingWith(TOKEN_TREASURY)
+                                .fee(ONE_HBAR)
+                                .blankMemo()
+                                .via(BASE_TXN))
+                .then(validateChargedUsdWithin(BASE_TXN, EXPECTED_NFT_WIPE_PRICE_USD, 0.01));
+    }
 
+    private HapiApiSpec baseNftBurnOperationIsChargedExpectedFee() {
+        return defaultHapiSpec("BaseUniqueBurnOperationIsChargedExpectedFee")
+                .given(
+                        newKeyNamed(SUPPLY_KEY),
+                        cryptoCreate(CIVILIAN_ACCT).key(SUPPLY_KEY),
+                        cryptoCreate(TOKEN_TREASURY),
+                        tokenCreate(UNIQUE_TOKEN)
+                                .initialSupply(0)
+                                .supplyKey(SUPPLY_KEY)
+                                .tokenType(NON_FUNGIBLE_UNIQUE)
+                                .treasury(TOKEN_TREASURY),
+                        mintToken(UNIQUE_TOKEN, List.of(metadata("memo"))))
+                .when(
+                        burnToken(UNIQUE_TOKEN, List.of(1L))
+                                .fee(ONE_HBAR)
+                                .payingWith(CIVILIAN_ACCT)
+                                .blankMemo()
+                                .via(BASE_TXN))
+                .then(validateChargedUsdWithin(BASE_TXN, EXPECTED_NFT_BURN_PRICE_USD, 0.01));
+    }
 
-	private HapiApiSpec baseNftBurnOperationIsChargedExpectedFee() {
-		return defaultHapiSpec("BaseUniqueBurnOperationIsChargedExpectedFee")
-				.given(
-						newKeyNamed(SUPPLY_KEY),
-						cryptoCreate(CIVILIAN_ACCT).key(SUPPLY_KEY),
-						cryptoCreate(TOKEN_TREASURY),
-						tokenCreate(UNIQUE_TOKEN)
-								.initialSupply(0)
-								.supplyKey(SUPPLY_KEY)
-								.tokenType(NON_FUNGIBLE_UNIQUE)
-								.treasury(TOKEN_TREASURY),
-						mintToken(UNIQUE_TOKEN, List.of(metadata("memo")))
-				)
-				.when(
-						burnToken(UNIQUE_TOKEN, List.of(1L))
-								.fee(ONE_HBAR)
-								.payingWith(CIVILIAN_ACCT)
-								.blankMemo()
-								.via(BASE_TXN)
-				).then(
-						validateChargedUsdWithin(BASE_TXN, EXPECTED_NFT_BURN_PRICE_USD, 0.01)
-				);
-	}
+    private HapiApiSpec baseNftFreezeUnfreezeChargedAsExpected() {
+        return defaultHapiSpec("baseNftFreezeUnfreezeChargedAsExpected")
+                .given(
+                        newKeyNamed(TREASURE_KEY),
+                        newKeyNamed(ADMIN_KEY),
+                        newKeyNamed(KYC_KEY),
+                        cryptoCreate(TOKEN_TREASURY).balance(ONE_HUNDRED_HBARS).key(TREASURE_KEY),
+                        cryptoCreate(CIVILIAN_ACCT),
+                        tokenCreate(UNIQUE_TOKEN)
+                                .tokenType(NON_FUNGIBLE_UNIQUE)
+                                .supplyType(TokenSupplyType.INFINITE)
+                                .initialSupply(0L)
+                                .adminKey(ADMIN_KEY)
+                                .freezeKey(TOKEN_TREASURY)
+                                .kycKey(KYC_KEY)
+                                .freezeDefault(false)
+                                .treasury(TOKEN_TREASURY)
+                                .payingWith(TOKEN_TREASURY)
+                                .supplyKey(ADMIN_KEY)
+                                .via(BASE_TXN),
+                        tokenAssociate(CIVILIAN_ACCT, UNIQUE_TOKEN))
+                .when(
+                        tokenFreeze(UNIQUE_TOKEN, CIVILIAN_ACCT)
+                                .blankMemo()
+                                .signedBy(TOKEN_TREASURY)
+                                .payingWith(TOKEN_TREASURY)
+                                .via("freeze"),
+                        tokenUnfreeze(UNIQUE_TOKEN, CIVILIAN_ACCT)
+                                .blankMemo()
+                                .payingWith(TOKEN_TREASURY)
+                                .signedBy(TOKEN_TREASURY)
+                                .via("unfreeze"))
+                .then(
+                        validateChargedUsdWithin(
+                                "freeze", EXPECTED_FREEZE_PRICE_USD, ALLOWED_DIFFERENCE_PERCENTAGE),
+                        validateChargedUsdWithin(
+                                "unfreeze",
+                                EXPECTED_UNFREEZE_PRICE_USD,
+                                ALLOWED_DIFFERENCE_PERCENTAGE));
+    }
 
-	private HapiApiSpec baseNftFreezeUnfreezeChargedAsExpected() {
-		return defaultHapiSpec("baseNftFreezeUnfreezeChargedAsExpected")
-				.given(
-						newKeyNamed(TREASURE_KEY),
-						newKeyNamed(ADMIN_KEY),
-						newKeyNamed(KYC_KEY),
-						cryptoCreate(TOKEN_TREASURY).balance(ONE_HUNDRED_HBARS).key(TREASURE_KEY),
-						cryptoCreate(CIVILIAN_ACCT),
-						tokenCreate(UNIQUE_TOKEN)
-								.tokenType(NON_FUNGIBLE_UNIQUE)
-								.supplyType(TokenSupplyType.INFINITE)
-								.initialSupply(0L)
-								.adminKey(ADMIN_KEY)
-								.freezeKey(TOKEN_TREASURY)
-								.kycKey(KYC_KEY)
-								.freezeDefault(false)
-								.treasury(TOKEN_TREASURY)
-								.payingWith(TOKEN_TREASURY)
-								.via(BASE_TXN),
-						tokenAssociate(CIVILIAN_ACCT, UNIQUE_TOKEN)
-				).when(
-						tokenFreeze(UNIQUE_TOKEN, CIVILIAN_ACCT)
-								.blankMemo()
-								.signedBy(TOKEN_TREASURY)
-								.payingWith(TOKEN_TREASURY)
-								.via("freeze"),
-						tokenUnfreeze(UNIQUE_TOKEN, CIVILIAN_ACCT)
-								.blankMemo()
-								.payingWith(TOKEN_TREASURY)
-								.signedBy(TOKEN_TREASURY)
-								.via("unfreeze")
-				).then(
-						validateChargedUsdWithin("freeze", EXPECTED_FREEZE_PRICE_USD, ALLOWED_DIFFERENCE_PERCENTAGE),
-						validateChargedUsdWithin("unfreeze", EXPECTED_UNFREEZE_PRICE_USD, ALLOWED_DIFFERENCE_PERCENTAGE)
-				);
-	}
+    private HapiApiSpec baseCommonFreezeUnfreezeChargedAsExpected() {
+        return defaultHapiSpec("baseCommonFreezeUnfreezeChargedAsExpected")
+                .given(
+                        newKeyNamed(TREASURE_KEY),
+                        newKeyNamed(ADMIN_KEY),
+                        newKeyNamed(FREEZE_KEY),
+                        newKeyNamed(SUPPLY_KEY),
+                        newKeyNamed(WIPE_KEY),
+                        cryptoCreate(TOKEN_TREASURY).balance(ONE_HUNDRED_HBARS).key(TREASURE_KEY),
+                        cryptoCreate(CIVILIAN_ACCT),
+                        tokenCreate(FUNGIBLE_COMMON_TOKEN)
+                                .adminKey(ADMIN_KEY)
+                                .freezeKey(TOKEN_TREASURY)
+                                .wipeKey(WIPE_KEY)
+                                .supplyKey(SUPPLY_KEY)
+                                .freezeDefault(false)
+                                .treasury(TOKEN_TREASURY)
+                                .payingWith(TOKEN_TREASURY),
+                        tokenAssociate(CIVILIAN_ACCT, FUNGIBLE_COMMON_TOKEN))
+                .when(
+                        tokenFreeze(FUNGIBLE_COMMON_TOKEN, CIVILIAN_ACCT)
+                                .blankMemo()
+                                .signedBy(TOKEN_TREASURY)
+                                .payingWith(TOKEN_TREASURY)
+                                .via("freeze"),
+                        tokenUnfreeze(FUNGIBLE_COMMON_TOKEN, CIVILIAN_ACCT)
+                                .blankMemo()
+                                .payingWith(TOKEN_TREASURY)
+                                .signedBy(TOKEN_TREASURY)
+                                .via("unfreeze"))
+                .then(
+                        validateChargedUsdWithin(
+                                "freeze", EXPECTED_FREEZE_PRICE_USD, ALLOWED_DIFFERENCE_PERCENTAGE),
+                        validateChargedUsdWithin(
+                                "unfreeze",
+                                EXPECTED_UNFREEZE_PRICE_USD,
+                                ALLOWED_DIFFERENCE_PERCENTAGE));
+    }
 
-	private HapiApiSpec baseCommonFreezeUnfreezeChargedAsExpected() {
-		return defaultHapiSpec("baseCommonFreezeUnfreezeChargedAsExpected")
-				.given(
-						newKeyNamed(TREASURE_KEY),
-						newKeyNamed(ADMIN_KEY),
-						newKeyNamed(FREEZE_KEY),
-						newKeyNamed(SUPPLY_KEY),
-						newKeyNamed(WIPE_KEY),
-						cryptoCreate(TOKEN_TREASURY).balance(ONE_HUNDRED_HBARS).key(TREASURE_KEY),
-						cryptoCreate(CIVILIAN_ACCT),
-						tokenCreate(FUNGIBLE_COMMON_TOKEN)
-								.adminKey(ADMIN_KEY)
-								.freezeKey(TOKEN_TREASURY)
-								.wipeKey(WIPE_KEY)
-								.supplyKey(SUPPLY_KEY)
-								.freezeDefault(false)
-								.treasury(TOKEN_TREASURY)
-								.payingWith(TOKEN_TREASURY),
-						tokenAssociate(CIVILIAN_ACCT, FUNGIBLE_COMMON_TOKEN)
-				).when(
-						tokenFreeze(FUNGIBLE_COMMON_TOKEN, CIVILIAN_ACCT)
-								.blankMemo()
-								.signedBy(TOKEN_TREASURY)
-								.payingWith(TOKEN_TREASURY)
-								.via("freeze"),
-						tokenUnfreeze(FUNGIBLE_COMMON_TOKEN, CIVILIAN_ACCT)
-								.blankMemo()
-								.payingWith(TOKEN_TREASURY)
-								.signedBy(TOKEN_TREASURY)
-								.via("unfreeze")
-				).then(
-						validateChargedUsdWithin("freeze", EXPECTED_FREEZE_PRICE_USD, ALLOWED_DIFFERENCE_PERCENTAGE),
-						validateChargedUsdWithin("unfreeze", EXPECTED_UNFREEZE_PRICE_USD, ALLOWED_DIFFERENCE_PERCENTAGE)
-				);
-	}
-
-	@Override
-	protected Logger getResultsLogger() {
-		return log;
-	}
+    @Override
+    protected Logger getResultsLogger() {
+        return log;
+    }
 }

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/token/Hip17UnhappyTokensSuite.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/token/Hip17UnhappyTokensSuite.java
@@ -1,11 +1,6 @@
-package com.hedera.services.bdd.suites.token;
-
-/*-
- * ‌
- * Hedera Services Test Clients
- * ​
- * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
- * ​
+/*
+ * Copyright (C) 2021-2022 Hedera Hashgraph, LLC
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -17,22 +12,8 @@ package com.hedera.services.bdd.suites.token;
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- * ‍
  */
-
-import com.google.protobuf.ByteString;
-import com.hedera.services.bdd.spec.HapiApiSpec;
-import com.hedera.services.bdd.spec.transactions.token.TokenMovement;
-import com.hedera.services.bdd.suites.HapiApiSuite;
-import com.hedera.services.bdd.suites.autorenew.AutoRenewConfigChoices;
-import com.hederahashgraph.api.proto.java.TokenSupplyType;
-import com.hederahashgraph.api.proto.java.TokenType;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-
-import java.time.Instant;
-import java.util.List;
-import java.util.Set;
+package com.hedera.services.bdd.suites.token;
 
 import static com.hedera.services.bdd.spec.HapiApiSpec.defaultHapiSpec;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getAccountBalance;
@@ -66,491 +47,468 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SUCCESS;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TOKEN_WAS_DELETED;
 import static com.hederahashgraph.api.proto.java.TokenType.NON_FUNGIBLE_UNIQUE;
 
+import com.google.protobuf.ByteString;
+import com.hedera.services.bdd.spec.HapiApiSpec;
+import com.hedera.services.bdd.spec.transactions.token.TokenMovement;
+import com.hedera.services.bdd.suites.HapiApiSuite;
+import com.hedera.services.bdd.suites.autorenew.AutoRenewConfigChoices;
+import com.hederahashgraph.api.proto.java.TokenSupplyType;
+import com.hederahashgraph.api.proto.java.TokenType;
+import java.time.Instant;
+import java.util.List;
+import java.util.Set;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 public class Hip17UnhappyTokensSuite extends HapiApiSuite {
-	private static final Logger log = LogManager.getLogger(Hip17UnhappyTokensSuite.class);
+    private static final Logger log = LogManager.getLogger(Hip17UnhappyTokensSuite.class);
 
-	private static final String ANOTHER_USER = "AnotherUser";
-	private static final String ANOTHER_KEY = "AnotherKey";
+    private static final String ANOTHER_USER = "AnotherUser";
+    private static final String ANOTHER_KEY = "AnotherKey";
 
-	private static final String TOKEN_TREASURY = "treasury";
-	private static final String NEW_TOKEN_TREASURY = "newTreasury";
-	private static final String AUTO_RENEW_ACCT = "autoRenewAcct";
-	private static final String NEW_AUTO_RENEW_ACCT = "newAutoRenewAcct";
+    private static final String TOKEN_TREASURY = "treasury";
+    private static final String NEW_TOKEN_TREASURY = "newTreasury";
+    private static final String AUTO_RENEW_ACCT = "autoRenewAcct";
+    private static final String NEW_AUTO_RENEW_ACCT = "newAutoRenewAcct";
 
-	private static final String NFTexpired = "NFTexpired";
-	private static final String NFTdeleted = "NFTdeleted";
-	private static final String NFTautoRemoved = "NFTautoRemoved";
-	private static final String ADMIN_KEY = "adminKey";
-	private static final String SUPPLY_KEY = "supplyKey";
-	private static final String FREEZE_KEY = "freezeKey";
-	private static final String WIPE_KEY = "wipeKey";
-	private static final String KYC_KEY = "kycKey";
-	private static final String FEE_SCHEDULE_KEY = "feeScheduleKey";
+    private static final String NFTexpired = "NFTexpired";
+    private static final String NFTdeleted = "NFTdeleted";
+    private static final String NFTautoRemoved = "NFTautoRemoved";
+    private static final String ADMIN_KEY = "adminKey";
+    private static final String SUPPLY_KEY = "supplyKey";
+    private static final String FREEZE_KEY = "freezeKey";
+    private static final String WIPE_KEY = "wipeKey";
+    private static final String KYC_KEY = "kycKey";
+    private static final String FEE_SCHEDULE_KEY = "feeScheduleKey";
 
-	private static final String NEW_FREEZE_KEY = "newFreezeKey";
-	private static final String NEW_WIPE_KEY = "newWipeKey";
-	private static final String NEW_KYC_KEY = "newKycKey";
-	private static final String NEW_SUPPLY_KEY = "newSupplyKey";
+    private static final String NEW_FREEZE_KEY = "newFreezeKey";
+    private static final String NEW_WIPE_KEY = "newWipeKey";
+    private static final String NEW_KYC_KEY = "newKycKey";
+    private static final String NEW_SUPPLY_KEY = "newSupplyKey";
 
-	private static String FIRST_MEMO = "First things first";
-	private static String SECOND_MEMO = "Nothing left to do";
-	private static String SALTED_NAME = salted("primary");
-	private static String NEW_SALTED_NAME = salted("primary");
+    private static String FIRST_MEMO = "First things first";
+    private static String SECOND_MEMO = "Nothing left to do";
+    private static String SALTED_NAME = salted("primary");
+    private static String NEW_SALTED_NAME = salted("primary");
 
-	public static void main(String... args) {
-		new Hip17UnhappyTokensSuite().runSuiteSync();
-	}
+    public static void main(String... args) {
+        new Hip17UnhappyTokensSuite().runSuiteSync();
+    }
 
-	@Override
-	public List<HapiApiSpec> getSpecsInSuite() {
-		return List.of(new HapiApiSpec[] {
-				canStillGetNftInfoWhenDeleted(),
-				cannotWipeNftWhenDeleted(),
-				cannotBurnNftWhenDeleted(),
-				cannotMintNftWhenDeleted(),
-				cannotDissociateNftWhenDeleted(),
-				cannotAssociateNftWhenDeleted(),
-				cannotUpdateNftWhenDeleted(),
-				cannotUpdateNftFeeScheduleWhenDeleted(),
-				cannotTransferNftWhenDeleted(),
-				cannotFreezeNftWhenDeleted(),
-				cannotUnfreezeNftWhenDeleted(),
+    @Override
+    public List<HapiApiSpec> getSpecsInSuite() {
+        return List.of(
+                new HapiApiSpec[] {
+                    canStillGetNftInfoWhenDeleted(),
+                    cannotWipeNftWhenDeleted(),
+                    cannotBurnNftWhenDeleted(),
+                    cannotMintNftWhenDeleted(),
+                    cannotDissociateNftWhenDeleted(),
+                    cannotAssociateNftWhenDeleted(),
+                    cannotUpdateNftWhenDeleted(),
+                    cannotUpdateNftFeeScheduleWhenDeleted(),
+                    cannotTransferNftWhenDeleted(),
+                    cannotFreezeNftWhenDeleted(),
+                    cannotUnfreezeNftWhenDeleted(),
 
-				// TODO: when auto removal and expiry implemented, enable the following and
-				// also add all those scenarios like above to complete the matrix.
-				// cannotGetNftInfoWhenExpired()
-				// cannotGetNftInfoWhenAutoRemoved(),
-				// autoRemovalCasesSuiteCleanup()
-				}
-		);
-	}
-	private HapiApiSpec canStillGetNftInfoWhenDeleted() {
-		return defaultHapiSpec("canStillGetNftInfoWhenDeleted")
-				.given(
-						newKeyNamed(SUPPLY_KEY),
-						newKeyNamed(ADMIN_KEY),
-						cryptoCreate(TOKEN_TREASURY).balance(ONE_HUNDRED_HBARS),
-						tokenCreate(NFTdeleted)
-								.tokenType(NON_FUNGIBLE_UNIQUE)
-								.supplyType(TokenSupplyType.INFINITE)
-								.supplyKey(SUPPLY_KEY)
-								.adminKey(ADMIN_KEY)
-								.initialSupply(0)
-								.treasury(TOKEN_TREASURY),
-						mintToken(NFTdeleted, List.of(metadata(FIRST_MEMO)))
-				).when(
-						tokenDelete(NFTdeleted)
-				).then(
-						getTokenNftInfo(NFTdeleted, 1L)
-								.hasTokenID(NFTdeleted)
-								.hasSerialNum(1L)
-				);
-	}
+                    // TODO: when auto removal and expiry implemented, enable the following and
+                    // also add all those scenarios like above to complete the matrix.
+                    // cannotGetNftInfoWhenExpired()
+                    // cannotGetNftInfoWhenAutoRemoved(),
+                    // autoRemovalCasesSuiteCleanup()
+                });
+    }
 
+    private HapiApiSpec canStillGetNftInfoWhenDeleted() {
+        return defaultHapiSpec("canStillGetNftInfoWhenDeleted")
+                .given(
+                        newKeyNamed(SUPPLY_KEY),
+                        newKeyNamed(ADMIN_KEY),
+                        cryptoCreate(TOKEN_TREASURY).balance(ONE_HUNDRED_HBARS),
+                        tokenCreate(NFTdeleted)
+                                .tokenType(NON_FUNGIBLE_UNIQUE)
+                                .supplyType(TokenSupplyType.INFINITE)
+                                .supplyKey(SUPPLY_KEY)
+                                .adminKey(ADMIN_KEY)
+                                .initialSupply(0)
+                                .treasury(TOKEN_TREASURY),
+                        mintToken(NFTdeleted, List.of(metadata(FIRST_MEMO))))
+                .when(tokenDelete(NFTdeleted))
+                .then(getTokenNftInfo(NFTdeleted, 1L).hasTokenID(NFTdeleted).hasSerialNum(1L));
+    }
 
-	private HapiApiSpec cannotTransferNftWhenDeleted() {
-		return defaultHapiSpec("cannotTransferNftWhenDeleted")
-				.given(
-						newKeyNamed(SUPPLY_KEY),
-						newKeyNamed(ADMIN_KEY),
-						cryptoCreate(TOKEN_TREASURY),
-						cryptoCreate(ANOTHER_USER),
-						tokenCreate(NFTdeleted)
-								.tokenType(TokenType.NON_FUNGIBLE_UNIQUE)
-								.initialSupply(0)
-								.supplyType(TokenSupplyType.INFINITE)
-								.supplyKey(SUPPLY_KEY)
-								.adminKey(ADMIN_KEY)
-								.treasury(TOKEN_TREASURY)
-				).when(
-						tokenAssociate(ANOTHER_USER, NFTdeleted),
-						mintToken(NFTdeleted, List.of(metadata(FIRST_MEMO), metadata(SECOND_MEMO))),
-						cryptoTransfer(
-								TokenMovement.movingUnique(NFTdeleted, 1L)
-										.between(TOKEN_TREASURY, ANOTHER_USER)),
-						tokenDelete(NFTdeleted)
-				).then(
-						cryptoTransfer(
-								TokenMovement.movingUnique(NFTdeleted, 2L)
-										.between(TOKEN_TREASURY, ANOTHER_USER))
-								.hasKnownStatus(TOKEN_WAS_DELETED)
-				);
-	}
+    private HapiApiSpec cannotTransferNftWhenDeleted() {
+        return defaultHapiSpec("cannotTransferNftWhenDeleted")
+                .given(
+                        newKeyNamed(SUPPLY_KEY),
+                        newKeyNamed(ADMIN_KEY),
+                        cryptoCreate(TOKEN_TREASURY),
+                        cryptoCreate(ANOTHER_USER),
+                        tokenCreate(NFTdeleted)
+                                .tokenType(TokenType.NON_FUNGIBLE_UNIQUE)
+                                .initialSupply(0)
+                                .supplyType(TokenSupplyType.INFINITE)
+                                .supplyKey(SUPPLY_KEY)
+                                .adminKey(ADMIN_KEY)
+                                .treasury(TOKEN_TREASURY))
+                .when(
+                        tokenAssociate(ANOTHER_USER, NFTdeleted),
+                        mintToken(NFTdeleted, List.of(metadata(FIRST_MEMO), metadata(SECOND_MEMO))),
+                        cryptoTransfer(
+                                TokenMovement.movingUnique(NFTdeleted, 1L)
+                                        .between(TOKEN_TREASURY, ANOTHER_USER)),
+                        tokenDelete(NFTdeleted))
+                .then(
+                        cryptoTransfer(
+                                        TokenMovement.movingUnique(NFTdeleted, 2L)
+                                                .between(TOKEN_TREASURY, ANOTHER_USER))
+                                .hasKnownStatus(TOKEN_WAS_DELETED));
+    }
 
+    private HapiApiSpec cannotUnfreezeNftWhenDeleted() {
+        return defaultHapiSpec("cannotUnfreezeNftWhenDeleted")
+                .given(
+                        newKeyNamed(SUPPLY_KEY),
+                        newKeyNamed(FREEZE_KEY),
+                        newKeyNamed(ADMIN_KEY),
+                        cryptoCreate(TOKEN_TREASURY).balance(0L).key(ADMIN_KEY),
+                        tokenCreate(NFTdeleted)
+                                .tokenType(TokenType.NON_FUNGIBLE_UNIQUE)
+                                .initialSupply(0L)
+                                .freezeKey(FREEZE_KEY)
+                                .freezeDefault(true)
+                                .adminKey(ADMIN_KEY)
+                                .supplyKey(SUPPLY_KEY)
+                                .treasury(TOKEN_TREASURY))
+                .when(tokenDelete(NFTdeleted))
+                .then(tokenUnfreeze(NFTdeleted, TOKEN_TREASURY).hasKnownStatus(TOKEN_WAS_DELETED));
+    }
 
-	private HapiApiSpec cannotUnfreezeNftWhenDeleted() {
-		return defaultHapiSpec("cannotUnfreezeNftWhenDeleted")
-				.given(
-						newKeyNamed(SUPPLY_KEY),
-						newKeyNamed(FREEZE_KEY),
-						newKeyNamed(ADMIN_KEY),
-						cryptoCreate(TOKEN_TREASURY).balance(0L).key(ADMIN_KEY),
-						tokenCreate(NFTdeleted)
-								.tokenType(TokenType.NON_FUNGIBLE_UNIQUE)
-								.initialSupply(0L)
-								.freezeKey(FREEZE_KEY)
-								.freezeDefault(true)
-								.adminKey(ADMIN_KEY)
-								.supplyKey(SUPPLY_KEY)
-								.treasury(TOKEN_TREASURY)
+    private HapiApiSpec cannotFreezeNftWhenDeleted() {
+        return defaultHapiSpec("cannotFreezeNftWhenDeleted")
+                .given(
+                        newKeyNamed(SUPPLY_KEY),
+                        newKeyNamed(FREEZE_KEY),
+                        newKeyNamed(ADMIN_KEY),
+                        cryptoCreate(TOKEN_TREASURY).balance(0L).key(ADMIN_KEY),
+                        tokenCreate(NFTdeleted)
+                                .tokenType(TokenType.NON_FUNGIBLE_UNIQUE)
+                                .freezeKey(FREEZE_KEY)
+                                .adminKey(ADMIN_KEY)
+                                .supplyKey(SUPPLY_KEY)
+                                .initialSupply(0L)
+                                .treasury(TOKEN_TREASURY))
+                .when(tokenDelete(NFTdeleted))
+                .then(
+                        tokenFreeze(NFTdeleted, TOKEN_TREASURY)
+                                .hasPrecheck(OK)
+                                .hasKnownStatus(TOKEN_WAS_DELETED));
+    }
 
-				).when(
-						tokenDelete(NFTdeleted)
-				).then(
-						tokenUnfreeze(NFTdeleted, TOKEN_TREASURY)
-								.hasKnownStatus(TOKEN_WAS_DELETED)
-				);
-	}
+    private HapiApiSpec cannotDissociateNftWhenDeleted() {
+        return defaultHapiSpec("cannotDissociateNftWhenDeleted")
+                .given(
+                        newKeyNamed(ADMIN_KEY),
+                        newKeyNamed(SUPPLY_KEY),
+                        cryptoCreate(TOKEN_TREASURY).key(ADMIN_KEY),
+                        cryptoCreate(ANOTHER_USER),
+                        tokenCreate(NFTdeleted)
+                                .initialSupply(0)
+                                .tokenType(TokenType.NON_FUNGIBLE_UNIQUE)
+                                .supplyType(TokenSupplyType.INFINITE)
+                                .supplyKey(SUPPLY_KEY)
+                                .adminKey(ADMIN_KEY)
+                                .treasury(TOKEN_TREASURY),
+                        tokenAssociate(ANOTHER_USER, NFTdeleted))
+                .when(tokenDelete(NFTdeleted))
+                .then(tokenDissociate(ANOTHER_USER, NFTdeleted).hasKnownStatus(SUCCESS));
+    }
 
-	private HapiApiSpec cannotFreezeNftWhenDeleted() {
-		return defaultHapiSpec("cannotFreezeNftWhenDeleted")
-				.given(
-						newKeyNamed(SUPPLY_KEY),
-						newKeyNamed(FREEZE_KEY),
-						newKeyNamed(ADMIN_KEY),
-						cryptoCreate(TOKEN_TREASURY).balance(0L).key(ADMIN_KEY),
-						tokenCreate(NFTdeleted)
-								.tokenType(TokenType.NON_FUNGIBLE_UNIQUE)
-								.freezeKey(FREEZE_KEY)
-								.adminKey(ADMIN_KEY)
-								.supplyKey(SUPPLY_KEY)
-								.initialSupply(0L)
-								.treasury(TOKEN_TREASURY)
-				).when(
-						tokenDelete(NFTdeleted)
-				).then(
-						tokenFreeze(NFTdeleted, TOKEN_TREASURY)
-								.hasPrecheck(OK)
-								.hasKnownStatus(TOKEN_WAS_DELETED)
-				);
-	}
+    private HapiApiSpec cannotAssociateNftWhenDeleted() {
+        return defaultHapiSpec("cannotAssociateNftWhenDeleted")
+                .given(
+                        newKeyNamed(ADMIN_KEY),
+                        newKeyNamed(SUPPLY_KEY),
+                        cryptoCreate(TOKEN_TREASURY).key(ADMIN_KEY),
+                        cryptoCreate(ANOTHER_USER),
+                        tokenCreate(NFTdeleted)
+                                .initialSupply(0)
+                                .tokenType(TokenType.NON_FUNGIBLE_UNIQUE)
+                                .supplyType(TokenSupplyType.INFINITE)
+                                .supplyKey(SUPPLY_KEY)
+                                .adminKey(ADMIN_KEY)
+                                .treasury(TOKEN_TREASURY))
+                .when(tokenDelete(NFTdeleted))
+                .then(tokenAssociate(ANOTHER_USER, NFTdeleted).hasKnownStatus(TOKEN_WAS_DELETED));
+    }
 
-	private HapiApiSpec cannotDissociateNftWhenDeleted() {
-		return defaultHapiSpec("cannotDissociateNftWhenDeleted")
-				.given(
-						newKeyNamed(ADMIN_KEY),
-						newKeyNamed(SUPPLY_KEY),
-						cryptoCreate(TOKEN_TREASURY).key(ADMIN_KEY),
-						cryptoCreate(ANOTHER_USER),
-						tokenCreate(NFTdeleted)
-								.initialSupply(0)
-								.tokenType(TokenType.NON_FUNGIBLE_UNIQUE)
-								.supplyType(TokenSupplyType.INFINITE)
-								.supplyKey(SUPPLY_KEY)
-								.adminKey(ADMIN_KEY)
-								.treasury(TOKEN_TREASURY),
-						tokenAssociate(ANOTHER_USER, NFTdeleted)
-				)
-				.when(
-						tokenDelete(NFTdeleted)
-				)
-				.then(
-						tokenDissociate(ANOTHER_USER, NFTdeleted)
-								.hasKnownStatus(SUCCESS)
-				);
-	}
+    public HapiApiSpec cannotUpdateNftWhenDeleted() {
+        return defaultHapiSpec("cannotUpdateNftWhenDeleted")
+                .given(
+                        cryptoCreate(TOKEN_TREASURY).balance(ONE_HUNDRED_HBARS),
+                        cryptoCreate(NEW_TOKEN_TREASURY).balance(ONE_HUNDRED_HBARS),
+                        cryptoCreate(AUTO_RENEW_ACCT).balance(ONE_HUNDRED_HBARS),
+                        cryptoCreate(NEW_AUTO_RENEW_ACCT).balance(ONE_HUNDRED_HBARS),
+                        newKeyNamed(ADMIN_KEY),
+                        newKeyNamed(FREEZE_KEY),
+                        newKeyNamed(NEW_FREEZE_KEY),
+                        newKeyNamed(KYC_KEY),
+                        newKeyNamed(NEW_KYC_KEY),
+                        newKeyNamed(SUPPLY_KEY),
+                        newKeyNamed(NEW_SUPPLY_KEY),
+                        newKeyNamed(WIPE_KEY),
+                        newKeyNamed(NEW_WIPE_KEY),
+                        tokenCreate(NFTdeleted)
+                                .tokenType(NON_FUNGIBLE_UNIQUE)
+                                .supplyType(TokenSupplyType.INFINITE)
+                                .name(SALTED_NAME)
+                                .entityMemo(FIRST_MEMO)
+                                .treasury(TOKEN_TREASURY)
+                                .autoRenewAccount(AUTO_RENEW_ACCT)
+                                .autoRenewPeriod(100)
+                                .initialSupply(0)
+                                .adminKey(ADMIN_KEY)
+                                .freezeKey(FREEZE_KEY)
+                                .kycKey(KYC_KEY)
+                                .supplyKey(SUPPLY_KEY)
+                                .wipeKey(WIPE_KEY),
+                        tokenAssociate(NEW_TOKEN_TREASURY, NFTdeleted),
+                        // can update before NFT is deleted
+                        tokenUpdate(NFTdeleted)
+                                .entityMemo(ZERO_BYTE_MEMO)
+                                .hasPrecheck(INVALID_ZERO_BYTE_IN_STRING),
+                        tokenUpdate(NFTdeleted)
+                                .name(NEW_SALTED_NAME)
+                                .entityMemo(SECOND_MEMO)
+                                .treasury(NEW_TOKEN_TREASURY)
+                                .autoRenewAccount(NEW_AUTO_RENEW_ACCT)
+                                .autoRenewPeriod(101)
+                                .freezeKey(NEW_FREEZE_KEY)
+                                .kycKey(NEW_KYC_KEY)
+                                .supplyKey(NEW_SUPPLY_KEY)
+                                .wipeKey(NEW_WIPE_KEY)
+                                .hasKnownStatus(SUCCESS))
+                .when(tokenDelete(NFTdeleted))
+                .then(
+                        // can't update after NFT is deleted.
+                        tokenUpdate(NFTdeleted)
+                                .name(NEW_SALTED_NAME)
+                                .entityMemo(SECOND_MEMO)
+                                .hasKnownStatus(TOKEN_WAS_DELETED),
+                        tokenUpdate(NFTdeleted)
+                                .treasury(NEW_TOKEN_TREASURY)
+                                .hasKnownStatus(TOKEN_WAS_DELETED),
+                        tokenUpdate(NFTdeleted)
+                                .autoRenewAccount(NEW_AUTO_RENEW_ACCT)
+                                .autoRenewPeriod(102)
+                                .hasKnownStatus(TOKEN_WAS_DELETED),
+                        tokenUpdate(NFTdeleted)
+                                .freezeKey(NEW_FREEZE_KEY)
+                                .kycKey(NEW_KYC_KEY)
+                                .supplyKey(NEW_SUPPLY_KEY)
+                                .wipeKey(NEW_WIPE_KEY)
+                                .hasKnownStatus(TOKEN_WAS_DELETED));
+    }
 
-	private HapiApiSpec cannotAssociateNftWhenDeleted() {
-		return defaultHapiSpec("cannotAssociateNftWhenDeleted")
-				.given(
-						newKeyNamed(ADMIN_KEY),
-						newKeyNamed(SUPPLY_KEY),
-						cryptoCreate(TOKEN_TREASURY).key(ADMIN_KEY),
-						cryptoCreate(ANOTHER_USER),
-						tokenCreate(NFTdeleted)
-								.initialSupply(0)
-								.tokenType(TokenType.NON_FUNGIBLE_UNIQUE)
-								.supplyType(TokenSupplyType.INFINITE)
-								.supplyKey(SUPPLY_KEY)
-								.adminKey(ADMIN_KEY)
-								.treasury(TOKEN_TREASURY)
-				)
-				.when(
-						tokenDelete(NFTdeleted)
-				)
-				.then(
-						tokenAssociate(ANOTHER_USER, NFTdeleted)
-								.hasKnownStatus(TOKEN_WAS_DELETED)
-				);
-	}
+    private HapiApiSpec cannotUpdateNftFeeScheduleWhenDeleted() {
+        final var origHbarFee = 1_234L;
+        final var newHbarFee = 4_321L;
+        final var hbarCollector = "hbarFee";
 
-	public HapiApiSpec cannotUpdateNftWhenDeleted() {
-		return defaultHapiSpec("cannotUpdateNftWhenDeleted")
-				.given(
-						cryptoCreate(TOKEN_TREASURY).balance(ONE_HUNDRED_HBARS),
-						cryptoCreate(NEW_TOKEN_TREASURY).balance(ONE_HUNDRED_HBARS),
-						cryptoCreate(AUTO_RENEW_ACCT).balance(ONE_HUNDRED_HBARS),
-						cryptoCreate(NEW_AUTO_RENEW_ACCT).balance(ONE_HUNDRED_HBARS),
-						newKeyNamed(ADMIN_KEY),
-						newKeyNamed(FREEZE_KEY),
-						newKeyNamed(NEW_FREEZE_KEY),
-						newKeyNamed(KYC_KEY),
-						newKeyNamed(NEW_KYC_KEY),
-						newKeyNamed(SUPPLY_KEY),
-						newKeyNamed(NEW_SUPPLY_KEY),
-						newKeyNamed(WIPE_KEY),
-						newKeyNamed(NEW_WIPE_KEY),
-						tokenCreate(NFTdeleted)
-								.tokenType(NON_FUNGIBLE_UNIQUE)
-								.supplyType(TokenSupplyType.INFINITE)
-								.name(SALTED_NAME)
-								.entityMemo(FIRST_MEMO)
-								.treasury(TOKEN_TREASURY)
-								.autoRenewAccount(AUTO_RENEW_ACCT)
-								.autoRenewPeriod(100)
-								.initialSupply(0)
-								.adminKey(ADMIN_KEY)
-								.freezeKey(FREEZE_KEY)
-								.kycKey(KYC_KEY)
-								.supplyKey(SUPPLY_KEY)
-								.wipeKey(WIPE_KEY),
-						tokenAssociate(NEW_TOKEN_TREASURY, NFTdeleted),
-						// can update before NFT is deleted
-						tokenUpdate(NFTdeleted)
-								.entityMemo(ZERO_BYTE_MEMO)
-								.hasPrecheck(INVALID_ZERO_BYTE_IN_STRING),
-						tokenUpdate(NFTdeleted)
-								.name(NEW_SALTED_NAME)
-								.entityMemo(SECOND_MEMO)
-								.treasury(NEW_TOKEN_TREASURY)
-								.autoRenewAccount(NEW_AUTO_RENEW_ACCT)
-								.autoRenewPeriod(101)
-								.freezeKey(NEW_FREEZE_KEY)
-								.kycKey(NEW_KYC_KEY)
-								.supplyKey(NEW_SUPPLY_KEY)
-								.wipeKey(NEW_WIPE_KEY)
-								.hasKnownStatus(SUCCESS)
-						).when(
-						tokenDelete(NFTdeleted)
-				).then(
-						// can't update after NFT is deleted.
-						tokenUpdate(NFTdeleted)
-								.name(NEW_SALTED_NAME)
-								.entityMemo(SECOND_MEMO)
-								.hasKnownStatus(TOKEN_WAS_DELETED),
-						tokenUpdate(NFTdeleted)
-								.treasury(NEW_TOKEN_TREASURY)
-								.hasKnownStatus(TOKEN_WAS_DELETED),
-						tokenUpdate(NFTdeleted)
-								.autoRenewAccount(NEW_AUTO_RENEW_ACCT)
-								.autoRenewPeriod(102)
-								.hasKnownStatus(TOKEN_WAS_DELETED),
-						tokenUpdate(NFTdeleted)
-								.freezeKey(NEW_FREEZE_KEY)
-								.kycKey(NEW_KYC_KEY)
-								.supplyKey(NEW_SUPPLY_KEY)
-								.wipeKey(NEW_WIPE_KEY)
-								.hasKnownStatus(TOKEN_WAS_DELETED)
-				);
-	}
+        return defaultHapiSpec("cannotUpdateNftFeeScheduleWhenDeleted")
+                .given(
+                        newKeyNamed(ADMIN_KEY),
+                        newKeyNamed(FEE_SCHEDULE_KEY),
+                        cryptoCreate(TOKEN_TREASURY).key(ADMIN_KEY),
+                        cryptoCreate(hbarCollector),
+                        tokenCreate(NFTdeleted)
+                                .tokenType(NON_FUNGIBLE_UNIQUE)
+                                .initialSupply(0L)
+                                .adminKey(ADMIN_KEY)
+                                .treasury(TOKEN_TREASURY)
+                                .supplyKey(SUPPLY_KEY)
+                                .feeScheduleKey(FEE_SCHEDULE_KEY)
+                                .withCustom(fixedHbarFee(origHbarFee, hbarCollector)))
+                .when(tokenDelete(NFTdeleted))
+                .then(
+                        tokenFeeScheduleUpdate(NFTdeleted)
+                                .withCustom(fixedHbarFee(newHbarFee, hbarCollector))
+                                .hasKnownStatus(TOKEN_WAS_DELETED));
+    }
 
-	private HapiApiSpec cannotUpdateNftFeeScheduleWhenDeleted() {
-		final var origHbarFee = 1_234L;
-		final var newHbarFee = 4_321L;
-		final var hbarCollector = "hbarFee";
+    private HapiApiSpec cannotMintNftWhenDeleted() {
+        return defaultHapiSpec("cannotMintNftWhenDeleted")
+                .given(
+                        newKeyNamed(SUPPLY_KEY),
+                        newKeyNamed(WIPE_KEY),
+                        newKeyNamed(ADMIN_KEY),
+                        cryptoCreate(TOKEN_TREASURY).key(ADMIN_KEY),
+                        cryptoCreate(ANOTHER_USER),
+                        tokenCreate(NFTdeleted)
+                                .tokenType(NON_FUNGIBLE_UNIQUE)
+                                .supplyType(TokenSupplyType.INFINITE)
+                                .supplyKey(SUPPLY_KEY)
+                                .initialSupply(0)
+                                .treasury(TOKEN_TREASURY)
+                                .adminKey(ADMIN_KEY))
+                .when(tokenDelete(NFTdeleted))
+                .then(
+                        mintToken(NFTdeleted, List.of(ByteString.copyFromUtf8(FIRST_MEMO)))
+                                .hasKnownStatus(TOKEN_WAS_DELETED));
+    }
 
-		return defaultHapiSpec("cannotUpdateNftFeeScheduleWhenDeleted")
-				.given(
-						newKeyNamed(ADMIN_KEY),
-						newKeyNamed(FEE_SCHEDULE_KEY),
-						cryptoCreate(TOKEN_TREASURY).key(ADMIN_KEY),
-						cryptoCreate(hbarCollector),
-						tokenCreate(NFTdeleted)
-								.tokenType(NON_FUNGIBLE_UNIQUE)
-								.initialSupply(0L)
-								.adminKey(ADMIN_KEY)
-								.treasury(TOKEN_TREASURY)
-								.feeScheduleKey(FEE_SCHEDULE_KEY)
-								.withCustom(fixedHbarFee(origHbarFee, hbarCollector))
-				).when(
-						tokenDelete(NFTdeleted)
-				).then(
-						tokenFeeScheduleUpdate(NFTdeleted)
-								.withCustom(fixedHbarFee(newHbarFee, hbarCollector))
-								.hasKnownStatus(TOKEN_WAS_DELETED)
-				);
-	}
+    private HapiApiSpec cannotBurnNftWhenDeleted() {
+        return defaultHapiSpec("cannotBurnNftWhenDeleted")
+                .given(
+                        newKeyNamed(SUPPLY_KEY),
+                        newKeyNamed(WIPE_KEY),
+                        newKeyNamed(ADMIN_KEY),
+                        newKeyNamed(ANOTHER_KEY),
+                        cryptoCreate(TOKEN_TREASURY).key(ADMIN_KEY),
+                        cryptoCreate(ANOTHER_USER).key(ANOTHER_KEY),
+                        tokenCreate(NFTdeleted)
+                                .tokenType(NON_FUNGIBLE_UNIQUE)
+                                .supplyType(TokenSupplyType.INFINITE)
+                                .supplyKey(SUPPLY_KEY)
+                                .initialSupply(0)
+                                .treasury(TOKEN_TREASURY)
+                                .adminKey(ADMIN_KEY),
+                        tokenAssociate(ANOTHER_USER, NFTdeleted),
+                        mintToken(
+                                NFTdeleted,
+                                List.of(
+                                        ByteString.copyFromUtf8(FIRST_MEMO),
+                                        ByteString.copyFromUtf8(SECOND_MEMO))),
+                        cryptoTransfer(
+                                movingUnique(NFTdeleted, 2L).between(TOKEN_TREASURY, ANOTHER_USER)),
+                        getAccountInfo(ANOTHER_USER).hasOwnedNfts(1),
+                        getAccountInfo(TOKEN_TREASURY).hasOwnedNfts(1),
+                        getTokenInfo(NFTdeleted).hasTotalSupply(2),
+                        getTokenNftInfo(NFTdeleted, 2).hasCostAnswerPrecheck(OK),
+                        getTokenNftInfo(NFTdeleted, 1).hasSerialNum(1))
+                .when(tokenDelete(NFTdeleted))
+                .then(burnToken(NFTdeleted, List.of(2L)).hasKnownStatus(TOKEN_WAS_DELETED));
+    }
 
-	private HapiApiSpec cannotMintNftWhenDeleted() {
-		return defaultHapiSpec("cannotMintNftWhenDeleted")
-				.given(
-						newKeyNamed(SUPPLY_KEY),
-						newKeyNamed(WIPE_KEY),
-						newKeyNamed(ADMIN_KEY),
-						cryptoCreate(TOKEN_TREASURY).key(ADMIN_KEY),
-						cryptoCreate(ANOTHER_USER),
-						tokenCreate(NFTdeleted)
-								.tokenType(NON_FUNGIBLE_UNIQUE)
-								.supplyType(TokenSupplyType.INFINITE)
-								.supplyKey(SUPPLY_KEY)
-								.initialSupply(0)
-								.treasury(TOKEN_TREASURY)
-								.adminKey(ADMIN_KEY)
-				)
-				.when(
-						tokenDelete(NFTdeleted)
-				)
-				.then(
-						mintToken(NFTdeleted, List.of(ByteString.copyFromUtf8(FIRST_MEMO)))
-								.hasKnownStatus(TOKEN_WAS_DELETED)
-				);
-	}
+    private HapiApiSpec cannotWipeNftWhenDeleted() {
+        return defaultHapiSpec("cannotWipeNftWhenDeleted")
+                .given(
+                        newKeyNamed(SUPPLY_KEY),
+                        newKeyNamed(WIPE_KEY),
+                        newKeyNamed(ADMIN_KEY),
+                        newKeyNamed(ANOTHER_KEY),
+                        cryptoCreate(TOKEN_TREASURY).key(ADMIN_KEY),
+                        cryptoCreate(ANOTHER_USER).key(ANOTHER_KEY),
+                        tokenCreate(NFTdeleted)
+                                .tokenType(NON_FUNGIBLE_UNIQUE)
+                                .supplyType(TokenSupplyType.INFINITE)
+                                .supplyKey(SUPPLY_KEY)
+                                .initialSupply(0)
+                                .treasury(TOKEN_TREASURY)
+                                .adminKey(ADMIN_KEY)
+                                .wipeKey(WIPE_KEY),
+                        tokenAssociate(ANOTHER_USER, NFTdeleted),
+                        mintToken(
+                                NFTdeleted,
+                                List.of(
+                                        ByteString.copyFromUtf8(FIRST_MEMO),
+                                        ByteString.copyFromUtf8(SECOND_MEMO))),
+                        cryptoTransfer(
+                                movingUnique(NFTdeleted, 2L).between(TOKEN_TREASURY, ANOTHER_USER)),
+                        getAccountInfo(ANOTHER_USER).hasOwnedNfts(1),
+                        getAccountInfo(TOKEN_TREASURY).hasOwnedNfts(1),
+                        getTokenInfo(NFTdeleted).hasTotalSupply(2),
+                        getTokenNftInfo(NFTdeleted, 2).hasCostAnswerPrecheck(OK),
+                        getTokenNftInfo(NFTdeleted, 1).hasSerialNum(1))
+                .when(tokenDelete(NFTdeleted))
+                .then(
+                        wipeTokenAccount(NFTdeleted, ANOTHER_USER, List.of(1L))
+                                .hasKnownStatus(TOKEN_WAS_DELETED));
+    }
 
-	private HapiApiSpec cannotBurnNftWhenDeleted() {
-		return defaultHapiSpec("cannotBurnNftWhenDeleted")
-				.given(
-						newKeyNamed(SUPPLY_KEY),
-						newKeyNamed(WIPE_KEY),
-						newKeyNamed(ADMIN_KEY),
-						newKeyNamed(ANOTHER_KEY),
-						cryptoCreate(TOKEN_TREASURY).key(ADMIN_KEY),
-						cryptoCreate(ANOTHER_USER).key(ANOTHER_KEY),
-						tokenCreate(NFTdeleted)
-								.tokenType(NON_FUNGIBLE_UNIQUE)
-								.supplyType(TokenSupplyType.INFINITE)
-								.supplyKey(SUPPLY_KEY)
-								.initialSupply(0)
-								.treasury(TOKEN_TREASURY)
-								.adminKey(ADMIN_KEY),
-						tokenAssociate(ANOTHER_USER, NFTdeleted),
-						mintToken(NFTdeleted,
-								List.of(ByteString.copyFromUtf8(FIRST_MEMO), ByteString.copyFromUtf8(SECOND_MEMO))),
-						cryptoTransfer(
-								movingUnique(NFTdeleted, 2L).between(TOKEN_TREASURY, ANOTHER_USER)
-						),
-						getAccountInfo(ANOTHER_USER).hasOwnedNfts(1),
-						getAccountInfo(TOKEN_TREASURY).hasOwnedNfts(1),
-						getTokenInfo(NFTdeleted).hasTotalSupply(2),
-						getTokenNftInfo(NFTdeleted, 2).hasCostAnswerPrecheck(OK),
-						getTokenNftInfo(NFTdeleted, 1).hasSerialNum(1)
-				)
-				.when(
-						tokenDelete(NFTdeleted)
-				)
-				.then(
-						burnToken(NFTdeleted,  List.of(2L))
-								.hasKnownStatus(TOKEN_WAS_DELETED)
-				);
-	}
+    private HapiApiSpec cannotGetNftInfoWhenExpired() {
+        return defaultHapiSpec("cannotGetNftInfoWhenExpired")
+                .given(
+                        tokenOpsEnablement(),
+                        fileUpdate(APP_PROPERTIES)
+                                .payingWith(GENESIS)
+                                .overridingProps(
+                                        AutoRenewConfigChoices.propsForAccountAutoRenewOnWith(
+                                                1, 0L, 2, 2)),
+                        newKeyNamed(SUPPLY_KEY),
+                        cryptoCreate(TOKEN_TREASURY),
+                        tokenCreate(NFTexpired)
+                                .tokenType(NON_FUNGIBLE_UNIQUE)
+                                .supplyType(TokenSupplyType.INFINITE)
+                                .supplyKey(SUPPLY_KEY)
+                                .initialSupply(0)
+                                .expiry(Instant.now().getEpochSecond() + 5L)
+                                .treasury(TOKEN_TREASURY),
+                        mintToken(NFTexpired, List.of(metadata(FIRST_MEMO))))
+                .when(sleepFor(6000))
+                .then(getTokenNftInfo(NFTexpired, 1).hasCostAnswerPrecheckFrom(OK));
+    }
 
-	private HapiApiSpec cannotWipeNftWhenDeleted() {
-		return defaultHapiSpec("cannotWipeNftWhenDeleted")
-				.given(
-						newKeyNamed(SUPPLY_KEY),
-						newKeyNamed(WIPE_KEY),
-						newKeyNamed(ADMIN_KEY),
-						newKeyNamed(ANOTHER_KEY),
-						cryptoCreate(TOKEN_TREASURY).key(ADMIN_KEY),
-						cryptoCreate(ANOTHER_USER).key(ANOTHER_KEY),
-						tokenCreate(NFTdeleted)
-								.tokenType(NON_FUNGIBLE_UNIQUE)
-								.supplyType(TokenSupplyType.INFINITE)
-								.supplyKey(SUPPLY_KEY)
-								.initialSupply(0)
-								.treasury(TOKEN_TREASURY)
-								.adminKey(ADMIN_KEY)
-								.wipeKey(WIPE_KEY),
-						tokenAssociate(ANOTHER_USER, NFTdeleted),
-						mintToken(NFTdeleted,
-								List.of(ByteString.copyFromUtf8(FIRST_MEMO), ByteString.copyFromUtf8(SECOND_MEMO))),
-						cryptoTransfer(
-								movingUnique(NFTdeleted, 2L).between(TOKEN_TREASURY, ANOTHER_USER)
-						),
-						getAccountInfo(ANOTHER_USER).hasOwnedNfts(1),
-						getAccountInfo(TOKEN_TREASURY).hasOwnedNfts(1),
-						getTokenInfo(NFTdeleted).hasTotalSupply(2),
-						getTokenNftInfo(NFTdeleted, 2).hasCostAnswerPrecheck(OK),
-						getTokenNftInfo(NFTdeleted, 1).hasSerialNum(1)
-				)
-				.when(
-						tokenDelete(NFTdeleted)
-				)
-				.then(
-						wipeTokenAccount(NFTdeleted, ANOTHER_USER, List.of(1L)).hasKnownStatus(TOKEN_WAS_DELETED)
-				);
-	}
+    private HapiApiSpec cannotGetNftInfoWhenAutoRemoved() {
+        return defaultHapiSpec("cannotGetNftInfoWhenAutoRemoved")
+                .given(
+                        tokenOpsEnablement(),
+                        fileUpdate(APP_PROPERTIES)
+                                .payingWith(GENESIS)
+                                .overridingProps(
+                                        AutoRenewConfigChoices.propsForAccountAutoRenewOnWith(
+                                                1, 0L, 100, 100))
+                                .erasingProps(Set.of("minimumAutoRenewDuration")),
+                        newKeyNamed(SUPPLY_KEY),
+                        newKeyNamed(ADMIN_KEY),
+                        cryptoCreate(TOKEN_TREASURY)
+                                .balance(ONE_HUNDRED_HBARS)
+                                .autoRenewSecs(THREE_MONTHS_IN_SECONDS),
+                        tokenCreate(NFTautoRemoved)
+                                .tokenType(NON_FUNGIBLE_UNIQUE)
+                                .supplyType(TokenSupplyType.INFINITE)
+                                .supplyKey(SUPPLY_KEY)
+                                .adminKey(ADMIN_KEY)
+                                .initialSupply(0)
+                                .autoRenewAccount(TOKEN_TREASURY)
+                                .autoRenewPeriod(2L)
+                                .expiry(Instant.now().getEpochSecond() + 5L)
+                                .treasury(TOKEN_TREASURY),
+                        mintToken(
+                                        NFTautoRemoved,
+                                        List.of(metadata(FIRST_MEMO), metadata(SECOND_MEMO)),
+                                        "nftMint")
+                                .payingWith(GENESIS))
+                .when(
+                        cryptoTransfer(
+                                        tinyBarsFromTo(
+                                                TOKEN_TREASURY, GENESIS, ONE_HUNDRED_HBARS - 10))
+                                .payingWith(GENESIS),
+                        sleepFor(8000),
+                        cryptoTransfer(tinyBarsFromTo(TOKEN_TREASURY, GENESIS, 10))
+                                .payingWith(GENESIS))
+                .then(
+                        getAccountBalance(TOKEN_TREASURY).logged(),
+                        getTokenNftInfo(NFTautoRemoved, 1).hasAnswerOnlyPrecheck(OK).logged(),
+                        getTokenNftInfo(NFTautoRemoved, 1).hasCostAnswerPrecheckFrom(OK).logged());
+    }
 
+    private HapiApiSpec autoRemovalCasesSuiteCleanup() {
+        return defaultHapiSpec("AutoRemovalCasesSuiteCleanup")
+                .given()
+                .when()
+                .then(
+                        fileUpdate(APP_PROPERTIES)
+                                .payingWith(GENESIS)
+                                .overridingProps(disablingAutoRenewWithDefaults()));
+    }
 
-	private HapiApiSpec cannotGetNftInfoWhenExpired() {
-		return defaultHapiSpec("cannotGetNftInfoWhenExpired")
-				.given(
-						tokenOpsEnablement(),
-						fileUpdate(APP_PROPERTIES)
-								.payingWith(GENESIS)
-								.overridingProps(
-										AutoRenewConfigChoices.propsForAccountAutoRenewOnWith(1, 0L, 2, 2)),
-						newKeyNamed(SUPPLY_KEY),
-						cryptoCreate(TOKEN_TREASURY),
-						tokenCreate(NFTexpired)
-								.tokenType(NON_FUNGIBLE_UNIQUE)
-								.supplyType(TokenSupplyType.INFINITE)
-								.supplyKey(SUPPLY_KEY)
-								.initialSupply(0)
-								.expiry(Instant.now().getEpochSecond() + 5L)
-								.treasury(TOKEN_TREASURY),
-						mintToken(NFTexpired, List.of(metadata(FIRST_MEMO)))
-				).when(
-						sleepFor(6000)
-				).then(
-						getTokenNftInfo(NFTexpired, 1)
-								.hasCostAnswerPrecheckFrom(OK)
-				);
-	}
+    private ByteString metadata(String contents) {
+        return ByteString.copyFromUtf8(contents);
+    }
 
-	private HapiApiSpec cannotGetNftInfoWhenAutoRemoved() {
-		return defaultHapiSpec("cannotGetNftInfoWhenAutoRemoved")
-				.given(
-						tokenOpsEnablement(),
-						fileUpdate(APP_PROPERTIES)
-								.payingWith(GENESIS)
-								.overridingProps(
-										AutoRenewConfigChoices.propsForAccountAutoRenewOnWith(1, 0L, 100, 100))
-								.erasingProps(Set.of("minimumAutoRenewDuration")),
-						newKeyNamed(SUPPLY_KEY),
-						newKeyNamed(ADMIN_KEY),
-						cryptoCreate(TOKEN_TREASURY)
-								.balance(ONE_HUNDRED_HBARS).autoRenewSecs(THREE_MONTHS_IN_SECONDS),
-						tokenCreate(NFTautoRemoved)
-								.tokenType(NON_FUNGIBLE_UNIQUE)
-								.supplyType(TokenSupplyType.INFINITE)
-								.supplyKey(SUPPLY_KEY)
-								.adminKey(ADMIN_KEY)
-								.initialSupply(0)
-								.autoRenewAccount(TOKEN_TREASURY)
-								.autoRenewPeriod(2L)
-								.expiry(Instant.now().getEpochSecond() + 5L)
-								.treasury(TOKEN_TREASURY),
-
-						mintToken(NFTautoRemoved,List.of(metadata(FIRST_MEMO), metadata(SECOND_MEMO)), "nftMint")
-								.payingWith(GENESIS)
-				).when(
-						cryptoTransfer(tinyBarsFromTo(TOKEN_TREASURY, GENESIS, ONE_HUNDRED_HBARS - 10))
-								.payingWith(GENESIS),
-						sleepFor(8000),
-						cryptoTransfer(tinyBarsFromTo(TOKEN_TREASURY, GENESIS,  10)).payingWith(GENESIS)
-				).then(
-						getAccountBalance(TOKEN_TREASURY).logged(),
-						getTokenNftInfo(NFTautoRemoved,1).hasAnswerOnlyPrecheck(OK).logged(),
-						getTokenNftInfo(NFTautoRemoved,1)
-								.hasCostAnswerPrecheckFrom(OK).logged()
-				);
-	}
-
-	private HapiApiSpec autoRemovalCasesSuiteCleanup() {
-		return defaultHapiSpec("AutoRemovalCasesSuiteCleanup")
-				.given().when().then(
-						fileUpdate(APP_PROPERTIES)
-								.payingWith(GENESIS)
-								.overridingProps(disablingAutoRenewWithDefaults())
-				);
-	}
-
-	private ByteString metadata(String contents) {
-		return ByteString.copyFromUtf8(contents);
-	}
-
-	@Override
-	protected Logger getResultsLogger() {
-		return log;
-	}
+    @Override
+    protected Logger getResultsLogger() {
+        return log;
+    }
 }

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenAssociationSpecs.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenAssociationSpecs.java
@@ -1,11 +1,6 @@
-package com.hedera.services.bdd.suites.token;
-
-/*-
- * ‌
- * Hedera Services Test Clients
- * ​
- * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
- * ​
+/*
+ * Copyright (C) 2020-2022 Hedera Hashgraph, LLC
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -17,27 +12,8 @@ package com.hedera.services.bdd.suites.token;
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- * ‍
  */
-
-import com.google.protobuf.ByteString;
-import com.hedera.services.bdd.spec.HapiApiSpec;
-import com.hedera.services.bdd.spec.HapiPropertySource;
-import com.hedera.services.bdd.spec.HapiSpecOperation;
-import com.hedera.services.bdd.spec.assertions.BaseErroringAssertsProvider;
-import com.hedera.services.bdd.spec.assertions.ErroringAsserts;
-import com.hedera.services.bdd.spec.transactions.token.TokenMovement;
-import com.hedera.services.bdd.suites.HapiApiSuite;
-import com.hederahashgraph.api.proto.java.AccountAmount;
-import com.hederahashgraph.api.proto.java.TokenTransferList;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-
-import java.nio.charset.StandardCharsets;
-import java.util.Collections;
-import java.util.List;
-import java.util.concurrent.atomic.AtomicLong;
-import java.util.concurrent.atomic.AtomicReference;
+package com.hedera.services.bdd.suites.token;
 
 import static com.hedera.services.bdd.spec.HapiApiSpec.defaultHapiSpec;
 import static com.hedera.services.bdd.spec.HapiPropertySource.asHexedSolidityAddress;
@@ -85,549 +61,624 @@ import static com.hederahashgraph.api.proto.java.TokenKycStatus.KycNotApplicable
 import static com.hederahashgraph.api.proto.java.TokenType.NON_FUNGIBLE_UNIQUE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import com.google.protobuf.ByteString;
+import com.hedera.services.bdd.spec.HapiApiSpec;
+import com.hedera.services.bdd.spec.HapiPropertySource;
+import com.hedera.services.bdd.spec.HapiSpecOperation;
+import com.hedera.services.bdd.spec.assertions.BaseErroringAssertsProvider;
+import com.hedera.services.bdd.spec.assertions.ErroringAsserts;
+import com.hedera.services.bdd.spec.transactions.token.TokenMovement;
+import com.hedera.services.bdd.suites.HapiApiSuite;
+import com.hederahashgraph.api.proto.java.AccountAmount;
+import com.hederahashgraph.api.proto.java.TokenTransferList;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 public class TokenAssociationSpecs extends HapiApiSuite {
-	private static final Logger log = LogManager.getLogger(TokenAssociationSpecs.class);
+    private static final Logger log = LogManager.getLogger(TokenAssociationSpecs.class);
 
-	public static final String FREEZABLE_TOKEN_ON_BY_DEFAULT = "TokenA";
-	public static final String FREEZABLE_TOKEN_OFF_BY_DEFAULT = "TokenB";
-	public static final String KNOWABLE_TOKEN = "TokenC";
-	public static final String VANILLA_TOKEN = "TokenD";
-	public static final String MULTI_KEY = "multiKey";
-	public static final String TBD_TOKEN = "ToBeDeleted";
+    public static final String FREEZABLE_TOKEN_ON_BY_DEFAULT = "TokenA";
+    public static final String FREEZABLE_TOKEN_OFF_BY_DEFAULT = "TokenB";
+    public static final String KNOWABLE_TOKEN = "TokenC";
+    public static final String VANILLA_TOKEN = "TokenD";
+    public static final String MULTI_KEY = "multiKey";
+    public static final String TBD_TOKEN = "ToBeDeleted";
 
-	public static void main(String... args) {
-		final var spec = new TokenAssociationSpecs();
+    public static void main(String... args) {
+        final var spec = new TokenAssociationSpecs();
 
-		spec.deferResultsSummary();
-		spec.runSuiteAsync();
-		spec.summarizeDeferredResults();
-	}
+        spec.deferResultsSummary();
+        spec.runSuiteAsync();
+        spec.summarizeDeferredResults();
+    }
 
-	@Override
-	public List<HapiApiSpec> getSpecsInSuite() {
-		return List.of(new HapiApiSpec[] {
-						treasuryAssociationIsAutomatic(),
-						dissociateHasExpectedSemantics(),
-						associatedContractsMustHaveAdminKeys(),
-						expiredAndDeletedTokensStillAppearInContractInfo(),
-						dissociationFromExpiredTokensAsExpected(),
-						accountInfoQueriesAsExpected(),
-						handlesUseOfDefaultTokenId(),
-						contractInfoQueriesAsExpected(),
-						dissociateHasExpectedSemanticsForDeletedTokens(),
-						dissociateHasExpectedSemanticsForDissociatedContracts(),
-						canDissociateFromDeletedTokenWithAlreadyDissociatedTreasury(),
-						multiAssociationWithSameRepeatedTokenAsExpected(),
-				}
-		);
-	}
+    @Override
+    public List<HapiApiSpec> getSpecsInSuite() {
+        return List.of(
+                new HapiApiSpec[] {
+                    treasuryAssociationIsAutomatic(),
+                    dissociateHasExpectedSemantics(),
+                    associatedContractsMustHaveAdminKeys(),
+                    expiredAndDeletedTokensStillAppearInContractInfo(),
+                    dissociationFromExpiredTokensAsExpected(),
+                    accountInfoQueriesAsExpected(),
+                    handlesUseOfDefaultTokenId(),
+                    contractInfoQueriesAsExpected(),
+                    dissociateHasExpectedSemanticsForDeletedTokens(),
+                    dissociateHasExpectedSemanticsForDissociatedContracts(),
+                    canDissociateFromDeletedTokenWithAlreadyDissociatedTreasury(),
+                    multiAssociationWithSameRepeatedTokenAsExpected(),
+                });
+    }
 
-	@Override
-	public boolean canRunConcurrent() {
-		return true;
-	}
+    @Override
+    public boolean canRunConcurrent() {
+        return true;
+    }
 
-	private HapiApiSpec multiAssociationWithSameRepeatedTokenAsExpected() {
-		final var nfToken = "nfToken";
-		final var civilian = "civilian";
-		final var multiAssociate = "multiAssociate";
-		final var theContract = "AssociateDissociate";
-		final AtomicReference<String> tokenMirrorAddr = new AtomicReference<>();
-		final AtomicReference<String> civilianMirrorAddr = new AtomicReference<>();
+    private HapiApiSpec multiAssociationWithSameRepeatedTokenAsExpected() {
+        final var nfToken = "nfToken";
+        final var civilian = "civilian";
+        final var multiAssociate = "multiAssociate";
+        final var theContract = "AssociateDissociate";
+        final AtomicReference<String> tokenMirrorAddr = new AtomicReference<>();
+        final AtomicReference<String> civilianMirrorAddr = new AtomicReference<>();
 
-		return defaultHapiSpec("MultiAssociationWithSameRepeatedTokenAsExpected")
-				.given(
-						cryptoCreate(civilian).exposingCreatedIdTo(id ->
-								civilianMirrorAddr.set(asHexedSolidityAddress(id))),
-						tokenCreate(nfToken)
-								.tokenType(NON_FUNGIBLE_UNIQUE)
-								.initialSupply(0)
-								.exposingCreatedIdTo(idLit -> tokenMirrorAddr.set(
-										asHexedSolidityAddress(
-												HapiPropertySource.asToken(idLit)))),
-						uploadInitCode(theContract),
-						contractCreate(theContract)
-				).when(
-						sourcing(() -> contractCall(theContract,
-								"tokensAssociate",
-								civilianMirrorAddr.get(), List.of(tokenMirrorAddr.get(), tokenMirrorAddr.get())
-						)
-								.hasKnownStatus(CONTRACT_REVERT_EXECUTED)
-								.via(multiAssociate)
-								.payingWith(civilian)
-								.gas(4_000_000))
-				).then(
-						childRecordsCheck(multiAssociate, CONTRACT_REVERT_EXECUTED,
-								recordWith().status(TOKEN_ID_REPEATED_IN_TOKEN_LIST)),
-						getAccountInfo(civilian).hasNoTokenRelationship(nfToken)
-				);
-	}
+        return defaultHapiSpec("MultiAssociationWithSameRepeatedTokenAsExpected")
+                .given(
+                        cryptoCreate(civilian)
+                                .exposingCreatedIdTo(
+                                        id -> civilianMirrorAddr.set(asHexedSolidityAddress(id))),
+                        tokenCreate(nfToken)
+                                .tokenType(NON_FUNGIBLE_UNIQUE)
+                                .supplyKey(MULTI_KEY)
+                                .initialSupply(0)
+                                .exposingCreatedIdTo(
+                                        idLit ->
+                                                tokenMirrorAddr.set(
+                                                        asHexedSolidityAddress(
+                                                                HapiPropertySource.asToken(
+                                                                        idLit)))),
+                        uploadInitCode(theContract),
+                        contractCreate(theContract))
+                .when(
+                        sourcing(
+                                () ->
+                                        contractCall(
+                                                        theContract,
+                                                        "tokensAssociate",
+                                                        civilianMirrorAddr.get(),
+                                                        List.of(
+                                                                tokenMirrorAddr.get(),
+                                                                tokenMirrorAddr.get()))
+                                                .hasKnownStatus(CONTRACT_REVERT_EXECUTED)
+                                                .via(multiAssociate)
+                                                .payingWith(civilian)
+                                                .gas(4_000_000)))
+                .then(
+                        childRecordsCheck(
+                                multiAssociate,
+                                CONTRACT_REVERT_EXECUTED,
+                                recordWith().status(TOKEN_ID_REPEATED_IN_TOKEN_LIST)),
+                        getAccountInfo(civilian).hasNoTokenRelationship(nfToken));
+    }
 
-	public HapiApiSpec handlesUseOfDefaultTokenId() {
-		return defaultHapiSpec("HandlesUseOfDefaultTokenId")
-				.given().when().then(
-						tokenAssociate(DEFAULT_PAYER, "0.0.0")
-								.hasKnownStatus(INVALID_TOKEN_ID)
-				);
-	}
+    public HapiApiSpec handlesUseOfDefaultTokenId() {
+        return defaultHapiSpec("HandlesUseOfDefaultTokenId")
+                .given()
+                .when()
+                .then(tokenAssociate(DEFAULT_PAYER, "0.0.0").hasKnownStatus(INVALID_TOKEN_ID));
+    }
 
-	public HapiApiSpec associatedContractsMustHaveAdminKeys() {
-		String misc = "someToken";
-		String contract = "defaultContract";
+    public HapiApiSpec associatedContractsMustHaveAdminKeys() {
+        String misc = "someToken";
+        String contract = "defaultContract";
 
-		return defaultHapiSpec("AssociatedContractsMustHaveAdminKeys")
-				.given(
-						tokenCreate(misc)
-				).when(
-						createDefaultContract(contract).omitAdminKey()
-				).then(
-						tokenAssociate(contract, misc).hasKnownStatus(INVALID_SIGNATURE)
-				);
-	}
+        return defaultHapiSpec("AssociatedContractsMustHaveAdminKeys")
+                .given(tokenCreate(misc))
+                .when(createDefaultContract(contract).omitAdminKey())
+                .then(tokenAssociate(contract, misc).hasKnownStatus(INVALID_SIGNATURE));
+    }
 
-	public HapiApiSpec contractInfoQueriesAsExpected() {
-		return defaultHapiSpec("ContractInfoQueriesAsExpected")
-				.given(
-						newKeyNamed("simple"),
-						tokenCreate("a"),
-						tokenCreate("b"),
-						tokenCreate("c"),
-						tokenCreate("tbd").adminKey("simple"),
-						createDefaultContract("contract")
-				).when(
-						tokenAssociate("contract", "a", "b", "c", "tbd"),
-						getContractInfo("contract")
-								.hasToken(relationshipWith("a"))
-								.hasToken(relationshipWith("b"))
-								.hasToken(relationshipWith("c"))
-								.hasToken(relationshipWith("tbd")),
-						tokenDissociate("contract", "b"),
-						tokenDelete("tbd")
-				).then(
-						getContractInfo("contract")
-								.hasToken(relationshipWith("a"))
-								.hasNoTokenRelationship("b")
-								.hasToken(relationshipWith("c"))
-								.hasToken(relationshipWith("tbd"))
-								.logged()
-				);
-	}
+    public HapiApiSpec contractInfoQueriesAsExpected() {
+        return defaultHapiSpec("ContractInfoQueriesAsExpected")
+                .given(
+                        newKeyNamed("simple"),
+                        tokenCreate("a"),
+                        tokenCreate("b"),
+                        tokenCreate("c"),
+                        tokenCreate("tbd").adminKey("simple"),
+                        createDefaultContract("contract"))
+                .when(
+                        tokenAssociate("contract", "a", "b", "c", "tbd"),
+                        getContractInfo("contract")
+                                .hasToken(relationshipWith("a"))
+                                .hasToken(relationshipWith("b"))
+                                .hasToken(relationshipWith("c"))
+                                .hasToken(relationshipWith("tbd")),
+                        tokenDissociate("contract", "b"),
+                        tokenDelete("tbd"))
+                .then(
+                        getContractInfo("contract")
+                                .hasToken(relationshipWith("a"))
+                                .hasNoTokenRelationship("b")
+                                .hasToken(relationshipWith("c"))
+                                .hasToken(relationshipWith("tbd"))
+                                .logged());
+    }
 
-	public HapiApiSpec accountInfoQueriesAsExpected() {
-		return defaultHapiSpec("InfoQueriesAsExpected")
-				.given(
-						newKeyNamed("simple"),
-						tokenCreate("a").decimals(1),
-						tokenCreate("b").decimals(2),
-						tokenCreate("c").decimals(3),
-						tokenCreate("tbd").adminKey("simple").decimals(4),
-						cryptoCreate("account").balance(0L)
-				).when(
-						tokenAssociate("account", "a", "b", "c", "tbd"),
-						getAccountInfo("account")
-								.hasToken(relationshipWith("a").decimals(1))
-								.hasToken(relationshipWith("b").decimals(2))
-								.hasToken(relationshipWith("c").decimals(3))
-								.hasToken(relationshipWith("tbd").decimals(4)),
-						tokenDissociate("account", "b"),
-						tokenDelete("tbd")
-				).then(
-						getAccountInfo("account")
-								.hasToken(relationshipWith("a").decimals(1))
-								.hasNoTokenRelationship("b")
-								.hasToken(relationshipWith("c").decimals(3))
-								.hasToken(relationshipWith("tbd").decimals(4))
-								.logged()
-				);
-	}
+    public HapiApiSpec accountInfoQueriesAsExpected() {
+        return defaultHapiSpec("InfoQueriesAsExpected")
+                .given(
+                        newKeyNamed("simple"),
+                        tokenCreate("a").decimals(1),
+                        tokenCreate("b").decimals(2),
+                        tokenCreate("c").decimals(3),
+                        tokenCreate("tbd").adminKey("simple").decimals(4),
+                        cryptoCreate("account").balance(0L))
+                .when(
+                        tokenAssociate("account", "a", "b", "c", "tbd"),
+                        getAccountInfo("account")
+                                .hasToken(relationshipWith("a").decimals(1))
+                                .hasToken(relationshipWith("b").decimals(2))
+                                .hasToken(relationshipWith("c").decimals(3))
+                                .hasToken(relationshipWith("tbd").decimals(4)),
+                        tokenDissociate("account", "b"),
+                        tokenDelete("tbd"))
+                .then(
+                        getAccountInfo("account")
+                                .hasToken(relationshipWith("a").decimals(1))
+                                .hasNoTokenRelationship("b")
+                                .hasToken(relationshipWith("c").decimals(3))
+                                .hasToken(relationshipWith("tbd").decimals(4))
+                                .logged());
+    }
 
-	public HapiApiSpec expiredAndDeletedTokensStillAppearInContractInfo() {
-		final String contract = "Fuse";
-		final String treasury = "something";
-		final String expiringToken = "expiringToken";
-		final long lifetimeSecs = 10;
-		final long xfer = 123L;
-		AtomicLong now = new AtomicLong();
-		return defaultHapiSpec("ExpiredAndDeletedTokensStillAppearInContractInfo")
-				.given(
-						newKeyNamed("admin"),
-						cryptoCreate(treasury),
-						uploadInitCode(contract),
-						contractCreate(contract).gas(300_000).via("creation"),
-						withOpContext((spec, opLog) -> {
-							var subOp = getTxnRecord("creation");
-							allRunFor(spec, subOp);
-							var record = subOp.getResponseRecord();
-							now.set(record.getConsensusTimestamp().getSeconds());
-						}),
-						sourcing(() ->
-								tokenCreate(expiringToken)
-										.decimals(666)
-										.adminKey("admin")
-										.treasury(treasury)
-										.expiry(now.get() + lifetimeSecs))
-				).when(
-						tokenAssociate(contract, expiringToken),
-						cryptoTransfer(
-								moving(xfer, expiringToken)
-										.between(treasury, contract))
-				).then(
-						getAccountBalance(contract)
-								.hasTokenBalance(expiringToken, xfer),
-						getContractInfo(contract)
-								.hasToken(relationshipWith(expiringToken)
-										.freeze(FreezeNotApplicable)),
-						sleepFor(lifetimeSecs * 1_000L),
-						getAccountBalance(contract)
-								.hasTokenBalance(expiringToken, xfer, 666),
-						getContractInfo(contract)
-								.hasToken(relationshipWith(expiringToken)
-										.freeze(FreezeNotApplicable)),
-						tokenDelete(expiringToken),
-						getAccountBalance(contract)
-								.hasTokenBalance(expiringToken, xfer),
-						getContractInfo(contract)
-								.hasToken(relationshipWith(expiringToken)
-										.decimals(666)
-										.freeze(FreezeNotApplicable))
-				);
-	}
+    public HapiApiSpec expiredAndDeletedTokensStillAppearInContractInfo() {
+        final String contract = "Fuse";
+        final String treasury = "something";
+        final String expiringToken = "expiringToken";
+        final long lifetimeSecs = 10;
+        final long xfer = 123L;
+        AtomicLong now = new AtomicLong();
+        return defaultHapiSpec("ExpiredAndDeletedTokensStillAppearInContractInfo")
+                .given(
+                        newKeyNamed("admin"),
+                        cryptoCreate(treasury),
+                        uploadInitCode(contract),
+                        contractCreate(contract).gas(300_000).via("creation"),
+                        withOpContext(
+                                (spec, opLog) -> {
+                                    var subOp = getTxnRecord("creation");
+                                    allRunFor(spec, subOp);
+                                    var record = subOp.getResponseRecord();
+                                    now.set(record.getConsensusTimestamp().getSeconds());
+                                }),
+                        sourcing(
+                                () ->
+                                        tokenCreate(expiringToken)
+                                                .decimals(666)
+                                                .adminKey("admin")
+                                                .treasury(treasury)
+                                                .expiry(now.get() + lifetimeSecs)))
+                .when(
+                        tokenAssociate(contract, expiringToken),
+                        cryptoTransfer(moving(xfer, expiringToken).between(treasury, contract)))
+                .then(
+                        getAccountBalance(contract).hasTokenBalance(expiringToken, xfer),
+                        getContractInfo(contract)
+                                .hasToken(
+                                        relationshipWith(expiringToken)
+                                                .freeze(FreezeNotApplicable)),
+                        sleepFor(lifetimeSecs * 1_000L),
+                        getAccountBalance(contract).hasTokenBalance(expiringToken, xfer, 666),
+                        getContractInfo(contract)
+                                .hasToken(
+                                        relationshipWith(expiringToken)
+                                                .freeze(FreezeNotApplicable)),
+                        tokenDelete(expiringToken),
+                        getAccountBalance(contract).hasTokenBalance(expiringToken, xfer),
+                        getContractInfo(contract)
+                                .hasToken(
+                                        relationshipWith(expiringToken)
+                                                .decimals(666)
+                                                .freeze(FreezeNotApplicable)));
+    }
 
-	public HapiApiSpec dissociationFromExpiredTokensAsExpected() {
-		final String treasury = "accountA";
-		final String frozenAccount = "frozen";
-		final String unfrozenAccount = "unfrozen";
-		final String expiringToken = "expiringToken";
-		long lifetimeSecs = 10;
+    public HapiApiSpec dissociationFromExpiredTokensAsExpected() {
+        final String treasury = "accountA";
+        final String frozenAccount = "frozen";
+        final String unfrozenAccount = "unfrozen";
+        final String expiringToken = "expiringToken";
+        long lifetimeSecs = 10;
 
-		AtomicLong now = new AtomicLong();
-		return defaultHapiSpec("DissociationFromExpiredTokensAsExpected")
-				.given(
-						newKeyNamed("freezeKey"),
-						cryptoCreate(treasury),
-						cryptoCreate(frozenAccount).via("creation"),
-						cryptoCreate(unfrozenAccount).via("creation"),
-						withOpContext((spec, opLog) -> {
-							var subOp = getTxnRecord("creation");
-							allRunFor(spec, subOp);
-							var record = subOp.getResponseRecord();
-							now.set(record.getConsensusTimestamp().getSeconds());
-						}),
-						sourcing(() ->
-								tokenCreate(expiringToken)
-										.freezeKey("freezeKey")
-										.freezeDefault(true)
-										.treasury(treasury)
-										.initialSupply(1000L)
-										.expiry(now.get() + lifetimeSecs))
-				).when(
-						tokenAssociate(unfrozenAccount, expiringToken),
-						tokenAssociate(frozenAccount, expiringToken),
-						tokenUnfreeze(expiringToken, unfrozenAccount),
-						cryptoTransfer(
-								moving(100L, expiringToken)
-										.between(treasury, unfrozenAccount))
-				).then(
-						getAccountBalance(treasury)
-								.hasTokenBalance(expiringToken, 900L),
-						sleepFor(lifetimeSecs * 1_000L),
-						tokenDissociate(treasury, expiringToken)
-								.hasKnownStatus(ACCOUNT_IS_TREASURY),
-						tokenDissociate(unfrozenAccount, expiringToken)
-								.via("dissociateTxn"),
-						getTxnRecord("dissociateTxn")
-								.hasPriority(recordWith().tokenTransfers(new BaseErroringAssertsProvider<>() {
-									@Override
-									public ErroringAsserts<List<TokenTransferList>> assertsFor(
-											HapiApiSpec spec) {
-										return tokenXfers -> {
-											try {
-												assertEquals(
-														1,
-														tokenXfers.size(),
-														"Wrong number of tokens transferred!");
-												TokenTransferList xfers = tokenXfers.get(0);
-												assertEquals(
-														spec.registry().getTokenID(expiringToken),
-														xfers.getToken(),
-														"Wrong token transferred!");
-												AccountAmount toTreasury = xfers.getTransfers(0);
-												assertEquals(
-														spec.registry().getAccountID(treasury),
-														toTreasury.getAccountID(),
-														"Treasury should come first!");
-												assertEquals(
-														100L,
-														toTreasury.getAmount(),
-														"Treasury should get 100 tokens back!");
-												AccountAmount fromAccount = xfers.getTransfers(1);
-												assertEquals(
-														spec.registry().getAccountID(unfrozenAccount),
-														fromAccount.getAccountID(),
-														"Account should come second!");
-												assertEquals(
-														-100L,
-														fromAccount.getAmount(),
-														"Account should send 100 tokens back!");
-											} catch (Throwable error) {
-												return List.of(error);
-											}
-											return Collections.emptyList();
-										};
-									}
-								})),
-						getAccountBalance(treasury)
-								.hasTokenBalance(expiringToken, 1000L),
-						getAccountInfo(frozenAccount)
-								.hasToken(relationshipWith(expiringToken)
-										.freeze(Frozen)),
-						tokenDissociate(frozenAccount, expiringToken)
-								.hasKnownStatus(ACCOUNT_FROZEN_FOR_TOKEN)
-				);
-	}
+        AtomicLong now = new AtomicLong();
+        return defaultHapiSpec("DissociationFromExpiredTokensAsExpected")
+                .given(
+                        newKeyNamed("freezeKey"),
+                        cryptoCreate(treasury),
+                        cryptoCreate(frozenAccount).via("creation"),
+                        cryptoCreate(unfrozenAccount).via("creation"),
+                        withOpContext(
+                                (spec, opLog) -> {
+                                    var subOp = getTxnRecord("creation");
+                                    allRunFor(spec, subOp);
+                                    var record = subOp.getResponseRecord();
+                                    now.set(record.getConsensusTimestamp().getSeconds());
+                                }),
+                        sourcing(
+                                () ->
+                                        tokenCreate(expiringToken)
+                                                .freezeKey("freezeKey")
+                                                .freezeDefault(true)
+                                                .treasury(treasury)
+                                                .initialSupply(1000L)
+                                                .expiry(now.get() + lifetimeSecs)))
+                .when(
+                        tokenAssociate(unfrozenAccount, expiringToken),
+                        tokenAssociate(frozenAccount, expiringToken),
+                        tokenUnfreeze(expiringToken, unfrozenAccount),
+                        cryptoTransfer(
+                                moving(100L, expiringToken).between(treasury, unfrozenAccount)))
+                .then(
+                        getAccountBalance(treasury).hasTokenBalance(expiringToken, 900L),
+                        sleepFor(lifetimeSecs * 1_000L),
+                        tokenDissociate(treasury, expiringToken)
+                                .hasKnownStatus(ACCOUNT_IS_TREASURY),
+                        tokenDissociate(unfrozenAccount, expiringToken).via("dissociateTxn"),
+                        getTxnRecord("dissociateTxn")
+                                .hasPriority(
+                                        recordWith()
+                                                .tokenTransfers(
+                                                        new BaseErroringAssertsProvider<>() {
+                                                            @Override
+                                                            public ErroringAsserts<
+                                                                            List<TokenTransferList>>
+                                                                    assertsFor(HapiApiSpec spec) {
+                                                                return tokenXfers -> {
+                                                                    try {
+                                                                        assertEquals(
+                                                                                1,
+                                                                                tokenXfers.size(),
+                                                                                "Wrong number of"
+                                                                                    + " tokens"
+                                                                                    + " transferred!");
+                                                                        TokenTransferList xfers =
+                                                                                tokenXfers.get(0);
+                                                                        assertEquals(
+                                                                                spec.registry()
+                                                                                        .getTokenID(
+                                                                                                expiringToken),
+                                                                                xfers.getToken(),
+                                                                                "Wrong token"
+                                                                                    + " transferred!");
+                                                                        AccountAmount toTreasury =
+                                                                                xfers.getTransfers(
+                                                                                        0);
+                                                                        assertEquals(
+                                                                                spec.registry()
+                                                                                        .getAccountID(
+                                                                                                treasury),
+                                                                                toTreasury
+                                                                                        .getAccountID(),
+                                                                                "Treasury should"
+                                                                                    + " come"
+                                                                                    + " first!");
+                                                                        assertEquals(
+                                                                                100L,
+                                                                                toTreasury
+                                                                                        .getAmount(),
+                                                                                "Treasury should"
+                                                                                        + " get 100"
+                                                                                        + " tokens"
+                                                                                        + " back!");
+                                                                        AccountAmount fromAccount =
+                                                                                xfers.getTransfers(
+                                                                                        1);
+                                                                        assertEquals(
+                                                                                spec.registry()
+                                                                                        .getAccountID(
+                                                                                                unfrozenAccount),
+                                                                                fromAccount
+                                                                                        .getAccountID(),
+                                                                                "Account should"
+                                                                                    + " come"
+                                                                                    + " second!");
+                                                                        assertEquals(
+                                                                                -100L,
+                                                                                fromAccount
+                                                                                        .getAmount(),
+                                                                                "Account should"
+                                                                                    + " send 100"
+                                                                                    + " tokens"
+                                                                                    + " back!");
+                                                                    } catch (Throwable error) {
+                                                                        return List.of(error);
+                                                                    }
+                                                                    return Collections.emptyList();
+                                                                };
+                                                            }
+                                                        })),
+                        getAccountBalance(treasury).hasTokenBalance(expiringToken, 1000L),
+                        getAccountInfo(frozenAccount)
+                                .hasToken(relationshipWith(expiringToken).freeze(Frozen)),
+                        tokenDissociate(frozenAccount, expiringToken)
+                                .hasKnownStatus(ACCOUNT_FROZEN_FOR_TOKEN));
+    }
 
-	public HapiApiSpec canDissociateFromDeletedTokenWithAlreadyDissociatedTreasury() {
-		final String aNonTreasuryAcquaintance = "aNonTreasuryAcquaintance";
-		final String bNonTreasuryAcquaintance = "bNonTreasuryAcquaintance";
-		final long initialSupply = 100L;
-		final long nonZeroXfer = 10L;
-		final var treasuryDissoc = "treasuryDissoc";
-		final var aNonTreasuryDissoc = "aNonTreasuryDissoc";
-		final var bNonTreasuryDissoc = "bNonTreasuryDissoc";
+    public HapiApiSpec canDissociateFromDeletedTokenWithAlreadyDissociatedTreasury() {
+        final String aNonTreasuryAcquaintance = "aNonTreasuryAcquaintance";
+        final String bNonTreasuryAcquaintance = "bNonTreasuryAcquaintance";
+        final long initialSupply = 100L;
+        final long nonZeroXfer = 10L;
+        final var treasuryDissoc = "treasuryDissoc";
+        final var aNonTreasuryDissoc = "aNonTreasuryDissoc";
+        final var bNonTreasuryDissoc = "bNonTreasuryDissoc";
 
-		return defaultHapiSpec("CanDissociateFromDeletedTokenWithAlreadyDissociatedTreasury")
-				.given(
-						newKeyNamed(MULTI_KEY),
-						cryptoCreate(TOKEN_TREASURY).balance(0L),
-						tokenCreate(TBD_TOKEN)
-								.freezeKey(MULTI_KEY)
-								.freezeDefault(false)
-								.adminKey(MULTI_KEY)
-								.initialSupply(initialSupply)
-								.treasury(TOKEN_TREASURY),
-						cryptoCreate(aNonTreasuryAcquaintance).balance(0L),
-						cryptoCreate(bNonTreasuryAcquaintance).maxAutomaticTokenAssociations(1)
-				).when(
-						tokenAssociate(aNonTreasuryAcquaintance, TBD_TOKEN),
-						cryptoTransfer(moving(nonZeroXfer, TBD_TOKEN)
-								.distributing(TOKEN_TREASURY, aNonTreasuryAcquaintance, bNonTreasuryAcquaintance)),
-						tokenFreeze(TBD_TOKEN, aNonTreasuryAcquaintance),
-						tokenDelete(TBD_TOKEN),
-						tokenDissociate(bNonTreasuryAcquaintance, TBD_TOKEN).via(bNonTreasuryDissoc),
-						tokenDissociate(TOKEN_TREASURY, TBD_TOKEN).via(treasuryDissoc),
-						tokenDissociate(aNonTreasuryAcquaintance, TBD_TOKEN).via(aNonTreasuryDissoc)
-				).then(
-						getTxnRecord(bNonTreasuryDissoc).hasPriority(recordWith()
-								.tokenTransfers(changingFungibleBalances()
-										.including(TBD_TOKEN, bNonTreasuryAcquaintance, -nonZeroXfer / 2))),
-						getTxnRecord(treasuryDissoc).hasPriority(recordWith()
-								.tokenTransfers(changingFungibleBalances()
-										.including(TBD_TOKEN, TOKEN_TREASURY, nonZeroXfer - initialSupply))),
-						getTxnRecord(aNonTreasuryDissoc).hasPriority(recordWith()
-								.tokenTransfers(changingFungibleBalances()
-										.including(TBD_TOKEN, aNonTreasuryAcquaintance, -nonZeroXfer / 2)))
+        return defaultHapiSpec("CanDissociateFromDeletedTokenWithAlreadyDissociatedTreasury")
+                .given(
+                        newKeyNamed(MULTI_KEY),
+                        cryptoCreate(TOKEN_TREASURY).balance(0L),
+                        tokenCreate(TBD_TOKEN)
+                                .freezeKey(MULTI_KEY)
+                                .freezeDefault(false)
+                                .adminKey(MULTI_KEY)
+                                .initialSupply(initialSupply)
+                                .treasury(TOKEN_TREASURY),
+                        cryptoCreate(aNonTreasuryAcquaintance).balance(0L),
+                        cryptoCreate(bNonTreasuryAcquaintance).maxAutomaticTokenAssociations(1))
+                .when(
+                        tokenAssociate(aNonTreasuryAcquaintance, TBD_TOKEN),
+                        cryptoTransfer(
+                                moving(nonZeroXfer, TBD_TOKEN)
+                                        .distributing(
+                                                TOKEN_TREASURY,
+                                                aNonTreasuryAcquaintance,
+                                                bNonTreasuryAcquaintance)),
+                        tokenFreeze(TBD_TOKEN, aNonTreasuryAcquaintance),
+                        tokenDelete(TBD_TOKEN),
+                        tokenDissociate(bNonTreasuryAcquaintance, TBD_TOKEN)
+                                .via(bNonTreasuryDissoc),
+                        tokenDissociate(TOKEN_TREASURY, TBD_TOKEN).via(treasuryDissoc),
+                        tokenDissociate(aNonTreasuryAcquaintance, TBD_TOKEN)
+                                .via(aNonTreasuryDissoc))
+                .then(
+                        getTxnRecord(bNonTreasuryDissoc)
+                                .hasPriority(
+                                        recordWith()
+                                                .tokenTransfers(
+                                                        changingFungibleBalances()
+                                                                .including(
+                                                                        TBD_TOKEN,
+                                                                        bNonTreasuryAcquaintance,
+                                                                        -nonZeroXfer / 2))),
+                        getTxnRecord(treasuryDissoc)
+                                .hasPriority(
+                                        recordWith()
+                                                .tokenTransfers(
+                                                        changingFungibleBalances()
+                                                                .including(
+                                                                        TBD_TOKEN,
+                                                                        TOKEN_TREASURY,
+                                                                        nonZeroXfer
+                                                                                - initialSupply))),
+                        getTxnRecord(aNonTreasuryDissoc)
+                                .hasPriority(
+                                        recordWith()
+                                                .tokenTransfers(
+                                                        changingFungibleBalances()
+                                                                .including(
+                                                                        TBD_TOKEN,
+                                                                        aNonTreasuryAcquaintance,
+                                                                        -nonZeroXfer / 2))));
+    }
 
-				);
-	}
+    public HapiApiSpec dissociateHasExpectedSemanticsForDeletedTokens() {
+        final String tbdUniqToken = "UniqToBeDeleted";
+        final String zeroBalanceFrozen = "0bFrozen";
+        final String zeroBalanceUnfrozen = "0bUnfrozen";
+        final String nonZeroBalanceFrozen = "1bFrozen";
+        final String nonZeroBalanceUnfrozen = "1bUnfrozen";
+        final long initialSupply = 100L;
+        final long nonZeroXfer = 10L;
+        final var zeroBalanceDissoc = "zeroBalanceDissoc";
+        final var nonZeroBalanceDissoc = "nonZeroBalanceDissoc";
+        final var uniqDissoc = "uniqDissoc";
+        final var firstMeta = ByteString.copyFrom("FIRST".getBytes(StandardCharsets.UTF_8));
+        final var secondMeta = ByteString.copyFrom("SECOND".getBytes(StandardCharsets.UTF_8));
+        final var thirdMeta = ByteString.copyFrom("THIRD".getBytes(StandardCharsets.UTF_8));
 
-	public HapiApiSpec dissociateHasExpectedSemanticsForDeletedTokens() {
-		final String tbdUniqToken = "UniqToBeDeleted";
-		final String zeroBalanceFrozen = "0bFrozen";
-		final String zeroBalanceUnfrozen = "0bUnfrozen";
-		final String nonZeroBalanceFrozen = "1bFrozen";
-		final String nonZeroBalanceUnfrozen = "1bUnfrozen";
-		final long initialSupply = 100L;
-		final long nonZeroXfer = 10L;
-		final var zeroBalanceDissoc = "zeroBalanceDissoc";
-		final var nonZeroBalanceDissoc = "nonZeroBalanceDissoc";
-		final var uniqDissoc = "uniqDissoc";
-		final var firstMeta = ByteString.copyFrom("FIRST".getBytes(StandardCharsets.UTF_8));
-		final var secondMeta = ByteString.copyFrom("SECOND".getBytes(StandardCharsets.UTF_8));
-		final var thirdMeta = ByteString.copyFrom("THIRD".getBytes(StandardCharsets.UTF_8));
+        return defaultHapiSpec("DissociateHasExpectedSemanticsForDeletedTokens")
+                .given(
+                        newKeyNamed(MULTI_KEY),
+                        cryptoCreate(TOKEN_TREASURY).balance(0L),
+                        tokenCreate(TBD_TOKEN)
+                                .adminKey(MULTI_KEY)
+                                .initialSupply(initialSupply)
+                                .treasury(TOKEN_TREASURY)
+                                .freezeKey(MULTI_KEY)
+                                .freezeDefault(true),
+                        tokenCreate(tbdUniqToken)
+                                .tokenType(NON_FUNGIBLE_UNIQUE)
+                                .treasury(TOKEN_TREASURY)
+                                .adminKey(MULTI_KEY)
+                                .supplyKey(MULTI_KEY)
+                                .initialSupply(0),
+                        cryptoCreate(zeroBalanceFrozen).balance(0L),
+                        cryptoCreate(zeroBalanceUnfrozen).balance(0L),
+                        cryptoCreate(nonZeroBalanceFrozen).balance(0L),
+                        cryptoCreate(nonZeroBalanceUnfrozen).balance(0L))
+                .when(
+                        tokenAssociate(zeroBalanceFrozen, TBD_TOKEN),
+                        tokenAssociate(zeroBalanceUnfrozen, TBD_TOKEN),
+                        tokenAssociate(nonZeroBalanceFrozen, TBD_TOKEN),
+                        tokenAssociate(nonZeroBalanceUnfrozen, TBD_TOKEN),
+                        mintToken(tbdUniqToken, List.of(firstMeta, secondMeta, thirdMeta)),
+                        getAccountInfo(TOKEN_TREASURY).hasOwnedNfts(3),
+                        tokenUnfreeze(TBD_TOKEN, zeroBalanceUnfrozen),
+                        tokenUnfreeze(TBD_TOKEN, nonZeroBalanceUnfrozen),
+                        tokenUnfreeze(TBD_TOKEN, nonZeroBalanceFrozen),
+                        cryptoTransfer(
+                                moving(nonZeroXfer, TBD_TOKEN)
+                                        .between(TOKEN_TREASURY, nonZeroBalanceFrozen)),
+                        cryptoTransfer(
+                                moving(nonZeroXfer, TBD_TOKEN)
+                                        .between(TOKEN_TREASURY, nonZeroBalanceUnfrozen)),
+                        tokenFreeze(TBD_TOKEN, nonZeroBalanceFrozen),
+                        getAccountBalance(TOKEN_TREASURY)
+                                .hasTokenBalance(TBD_TOKEN, initialSupply - 2 * nonZeroXfer),
+                        tokenDelete(TBD_TOKEN),
+                        tokenDelete(tbdUniqToken))
+                .then(
+                        tokenDissociate(zeroBalanceFrozen, TBD_TOKEN).via(zeroBalanceDissoc),
+                        tokenDissociate(zeroBalanceUnfrozen, TBD_TOKEN),
+                        tokenDissociate(nonZeroBalanceFrozen, TBD_TOKEN).via(nonZeroBalanceDissoc),
+                        tokenDissociate(nonZeroBalanceUnfrozen, TBD_TOKEN),
+                        tokenDissociate(TOKEN_TREASURY, tbdUniqToken).via(uniqDissoc),
+                        getAccountBalance(TOKEN_TREASURY)
+                                .hasTokenBalance(TBD_TOKEN, initialSupply - 2 * nonZeroXfer),
+                        getTxnRecord(zeroBalanceDissoc)
+                                .hasPriority(recordWith().tokenTransfers(emptyTokenTransfers())),
+                        getTxnRecord(nonZeroBalanceDissoc)
+                                .hasPriority(
+                                        recordWith()
+                                                .tokenTransfers(
+                                                        changingFungibleBalances()
+                                                                .including(
+                                                                        TBD_TOKEN,
+                                                                        nonZeroBalanceFrozen,
+                                                                        -nonZeroXfer))),
+                        getTxnRecord(uniqDissoc)
+                                .hasPriority(
+                                        recordWith()
+                                                .tokenTransfers(
+                                                        changingFungibleBalances()
+                                                                .including(
+                                                                        tbdUniqToken,
+                                                                        TOKEN_TREASURY,
+                                                                        -3))),
+                        getAccountInfo(TOKEN_TREASURY).hasOwnedNfts(0));
+    }
 
-		return defaultHapiSpec("DissociateHasExpectedSemanticsForDeletedTokens")
-				.given(
-						newKeyNamed(MULTI_KEY),
-						cryptoCreate(TOKEN_TREASURY).balance(0L),
-						tokenCreate(TBD_TOKEN)
-								.adminKey(MULTI_KEY)
-								.initialSupply(initialSupply)
-								.treasury(TOKEN_TREASURY)
-								.freezeKey(MULTI_KEY)
-								.freezeDefault(true),
-						tokenCreate(tbdUniqToken)
-								.tokenType(NON_FUNGIBLE_UNIQUE)
-								.treasury(TOKEN_TREASURY)
-								.adminKey(MULTI_KEY)
-								.supplyKey(MULTI_KEY)
-								.initialSupply(0),
-						cryptoCreate(zeroBalanceFrozen).balance(0L),
-						cryptoCreate(zeroBalanceUnfrozen).balance(0L),
-						cryptoCreate(nonZeroBalanceFrozen).balance(0L),
-						cryptoCreate(nonZeroBalanceUnfrozen).balance(0L)
-				).when(
-						tokenAssociate(zeroBalanceFrozen, TBD_TOKEN),
-						tokenAssociate(zeroBalanceUnfrozen, TBD_TOKEN),
-						tokenAssociate(nonZeroBalanceFrozen, TBD_TOKEN),
-						tokenAssociate(nonZeroBalanceUnfrozen, TBD_TOKEN),
-						mintToken(tbdUniqToken, List.of(firstMeta, secondMeta, thirdMeta)),
-						getAccountInfo(TOKEN_TREASURY).hasOwnedNfts(3),
-						tokenUnfreeze(TBD_TOKEN, zeroBalanceUnfrozen),
-						tokenUnfreeze(TBD_TOKEN, nonZeroBalanceUnfrozen),
-						tokenUnfreeze(TBD_TOKEN, nonZeroBalanceFrozen),
+    public HapiApiSpec dissociateHasExpectedSemantics() {
+        return defaultHapiSpec("DissociateHasExpectedSemantics")
+                .given(flattened(basicKeysAndTokens()))
+                .when(
+                        tokenCreate("tkn1").treasury(TOKEN_TREASURY),
+                        tokenDissociate(TOKEN_TREASURY, "tkn1").hasKnownStatus(ACCOUNT_IS_TREASURY),
+                        cryptoCreate("misc"),
+                        tokenDissociate("misc", FREEZABLE_TOKEN_ON_BY_DEFAULT)
+                                .hasKnownStatus(TOKEN_NOT_ASSOCIATED_TO_ACCOUNT),
+                        tokenAssociate("misc", FREEZABLE_TOKEN_ON_BY_DEFAULT, KNOWABLE_TOKEN),
+                        tokenDissociate("misc", FREEZABLE_TOKEN_ON_BY_DEFAULT)
+                                .hasKnownStatus(ACCOUNT_FROZEN_FOR_TOKEN),
+                        tokenUnfreeze(FREEZABLE_TOKEN_ON_BY_DEFAULT, "misc"),
+                        cryptoTransfer(
+                                moving(1, FREEZABLE_TOKEN_ON_BY_DEFAULT)
+                                        .between(TOKEN_TREASURY, "misc")),
+                        tokenDissociate("misc", FREEZABLE_TOKEN_ON_BY_DEFAULT)
+                                .hasKnownStatus(TRANSACTION_REQUIRES_ZERO_TOKEN_BALANCES),
+                        cryptoTransfer(
+                                moving(1, FREEZABLE_TOKEN_ON_BY_DEFAULT)
+                                        .between("misc", TOKEN_TREASURY)),
+                        tokenDissociate("misc", FREEZABLE_TOKEN_ON_BY_DEFAULT))
+                .then(
+                        getAccountInfo("misc")
+                                .hasToken(relationshipWith(KNOWABLE_TOKEN))
+                                .hasNoTokenRelationship(FREEZABLE_TOKEN_ON_BY_DEFAULT)
+                                .logged());
+    }
 
-						cryptoTransfer(moving(nonZeroXfer, TBD_TOKEN).between(TOKEN_TREASURY, nonZeroBalanceFrozen)),
-						cryptoTransfer(moving(nonZeroXfer, TBD_TOKEN).between(TOKEN_TREASURY, nonZeroBalanceUnfrozen)),
+    public HapiApiSpec dissociateHasExpectedSemanticsForDissociatedContracts() {
+        final var multiKey = "multiKey";
+        final var uniqToken = "UniqToken";
+        final var contract = "Fuse";
+        final var bytecode = "bytecode";
+        final var firstMeta = ByteString.copyFrom("FIRST".getBytes(StandardCharsets.UTF_8));
+        final var secondMeta = ByteString.copyFrom("SECOND".getBytes(StandardCharsets.UTF_8));
+        final var thirdMeta = ByteString.copyFrom("THIRD".getBytes(StandardCharsets.UTF_8));
 
-						tokenFreeze(TBD_TOKEN, nonZeroBalanceFrozen),
-						getAccountBalance(TOKEN_TREASURY)
-								.hasTokenBalance(TBD_TOKEN, initialSupply - 2 * nonZeroXfer),
-						tokenDelete(TBD_TOKEN),
-						tokenDelete(tbdUniqToken)
-				).then(
-						tokenDissociate(zeroBalanceFrozen, TBD_TOKEN).via(zeroBalanceDissoc),
-						tokenDissociate(zeroBalanceUnfrozen, TBD_TOKEN),
-						tokenDissociate(nonZeroBalanceFrozen, TBD_TOKEN).via(nonZeroBalanceDissoc),
-						tokenDissociate(nonZeroBalanceUnfrozen, TBD_TOKEN),
-						tokenDissociate(TOKEN_TREASURY, tbdUniqToken).via(uniqDissoc),
-						getAccountBalance(TOKEN_TREASURY)
-								.hasTokenBalance(TBD_TOKEN, initialSupply - 2 * nonZeroXfer),
-						getTxnRecord(zeroBalanceDissoc)
-								.hasPriority(recordWith().tokenTransfers(emptyTokenTransfers())),
-						getTxnRecord(nonZeroBalanceDissoc)
-								.hasPriority(recordWith().tokenTransfers(changingFungibleBalances()
-										.including(TBD_TOKEN, nonZeroBalanceFrozen, -nonZeroXfer))),
-						getTxnRecord(uniqDissoc)
-								.hasPriority(recordWith().tokenTransfers(changingFungibleBalances()
-										.including(tbdUniqToken, TOKEN_TREASURY, -3))),
-						getAccountInfo(TOKEN_TREASURY).hasOwnedNfts(0)
-				);
-	}
+        return defaultHapiSpec("DissociateHasExpectedSemanticsForDissociatedContracts")
+                .given(
+                        newKeyNamed(multiKey),
+                        cryptoCreate(TOKEN_TREASURY).balance(0L).maxAutomaticTokenAssociations(542),
+                        uploadInitCode(contract),
+                        contractCreate(contract).gas(300_000),
+                        tokenCreate(uniqToken)
+                                .tokenType(NON_FUNGIBLE_UNIQUE)
+                                .initialSupply(0)
+                                .supplyKey(multiKey)
+                                .treasury(TOKEN_TREASURY),
+                        mintToken(uniqToken, List.of(firstMeta, secondMeta, thirdMeta)),
+                        getAccountInfo(TOKEN_TREASURY).logged())
+                .when(tokenAssociate(contract, uniqToken), tokenDissociate(contract, uniqToken))
+                .then(
+                        cryptoTransfer(
+                                        TokenMovement.movingUnique(uniqToken, 1L)
+                                                .between(TOKEN_TREASURY, contract))
+                                .hasKnownStatus(TOKEN_NOT_ASSOCIATED_TO_ACCOUNT));
+    }
 
-	public HapiApiSpec dissociateHasExpectedSemantics() {
-		return defaultHapiSpec("DissociateHasExpectedSemantics")
-				.given(flattened(
-						basicKeysAndTokens()
-				)).when(
-						tokenCreate("tkn1")
-								.treasury(TOKEN_TREASURY),
-						tokenDissociate(TOKEN_TREASURY, "tkn1")
-								.hasKnownStatus(ACCOUNT_IS_TREASURY),
-						cryptoCreate("misc"),
-						tokenDissociate("misc", FREEZABLE_TOKEN_ON_BY_DEFAULT)
-								.hasKnownStatus(TOKEN_NOT_ASSOCIATED_TO_ACCOUNT),
-						tokenAssociate("misc", FREEZABLE_TOKEN_ON_BY_DEFAULT, KNOWABLE_TOKEN),
-						tokenDissociate("misc", FREEZABLE_TOKEN_ON_BY_DEFAULT)
-								.hasKnownStatus(ACCOUNT_FROZEN_FOR_TOKEN),
-						tokenUnfreeze(FREEZABLE_TOKEN_ON_BY_DEFAULT, "misc"),
-						cryptoTransfer(
-								moving(1, FREEZABLE_TOKEN_ON_BY_DEFAULT)
-										.between(TOKEN_TREASURY, "misc")),
-						tokenDissociate("misc", FREEZABLE_TOKEN_ON_BY_DEFAULT)
-								.hasKnownStatus(TRANSACTION_REQUIRES_ZERO_TOKEN_BALANCES),
-						cryptoTransfer(
-								moving(1, FREEZABLE_TOKEN_ON_BY_DEFAULT)
-										.between("misc", TOKEN_TREASURY)),
-						tokenDissociate("misc", FREEZABLE_TOKEN_ON_BY_DEFAULT)
-				).then(
-						getAccountInfo("misc")
-								.hasToken(relationshipWith(KNOWABLE_TOKEN))
-								.hasNoTokenRelationship(FREEZABLE_TOKEN_ON_BY_DEFAULT)
-								.logged()
-				);
-	}
+    public HapiApiSpec treasuryAssociationIsAutomatic() {
+        return defaultHapiSpec("TreasuryAssociationIsAutomatic")
+                .given(basicKeysAndTokens())
+                .when()
+                .then(
+                        getAccountInfo(TOKEN_TREASURY)
+                                .hasToken(
+                                        relationshipWith(FREEZABLE_TOKEN_ON_BY_DEFAULT)
+                                                .kyc(KycNotApplicable)
+                                                .freeze(Unfrozen))
+                                .hasToken(
+                                        relationshipWith(FREEZABLE_TOKEN_OFF_BY_DEFAULT)
+                                                .kyc(KycNotApplicable)
+                                                .freeze(Unfrozen))
+                                .hasToken(
+                                        relationshipWith(KNOWABLE_TOKEN)
+                                                .kyc(Granted)
+                                                .freeze(FreezeNotApplicable))
+                                .hasToken(
+                                        relationshipWith(VANILLA_TOKEN)
+                                                .kyc(KycNotApplicable)
+                                                .freeze(FreezeNotApplicable))
+                                .logged(),
+                        cryptoCreate("test"),
+                        tokenAssociate("test", KNOWABLE_TOKEN),
+                        tokenAssociate("test", FREEZABLE_TOKEN_OFF_BY_DEFAULT),
+                        tokenAssociate("test", FREEZABLE_TOKEN_ON_BY_DEFAULT),
+                        tokenAssociate("test", VANILLA_TOKEN),
+                        getAccountInfo("test").logged(),
+                        tokenDissociate("test", VANILLA_TOKEN),
+                        getAccountInfo("test").logged(),
+                        tokenDissociate("test", FREEZABLE_TOKEN_OFF_BY_DEFAULT).logged(),
+                        getAccountInfo("test").logged());
+    }
 
-	public HapiApiSpec dissociateHasExpectedSemanticsForDissociatedContracts() {
-		final var multiKey = "multiKey";
-		final var uniqToken = "UniqToken";
-		final var contract = "Fuse";
-		final var bytecode = "bytecode";
-		final var firstMeta = ByteString.copyFrom("FIRST".getBytes(StandardCharsets.UTF_8));
-		final var secondMeta = ByteString.copyFrom("SECOND".getBytes(StandardCharsets.UTF_8));
-		final var thirdMeta = ByteString.copyFrom("THIRD".getBytes(StandardCharsets.UTF_8));
+    public static HapiSpecOperation[] basicKeysAndTokens() {
+        return new HapiSpecOperation[] {
+            newKeyNamed("kycKey"),
+            newKeyNamed("freezeKey"),
+            cryptoCreate(TOKEN_TREASURY).balance(0L),
+            tokenCreate(FREEZABLE_TOKEN_ON_BY_DEFAULT)
+                    .treasury(TOKEN_TREASURY)
+                    .freezeKey("freezeKey")
+                    .freezeDefault(true),
+            tokenCreate(FREEZABLE_TOKEN_OFF_BY_DEFAULT)
+                    .treasury(TOKEN_TREASURY)
+                    .freezeKey("freezeKey")
+                    .freezeDefault(false),
+            tokenCreate(KNOWABLE_TOKEN).treasury(TOKEN_TREASURY).kycKey("kycKey"),
+            tokenCreate(VANILLA_TOKEN).treasury(TOKEN_TREASURY)
+        };
+    }
 
-		return defaultHapiSpec("DissociateHasExpectedSemanticsForDissociatedContracts")
-				.given(
-						newKeyNamed(multiKey),
-						cryptoCreate(TOKEN_TREASURY).balance(0L).maxAutomaticTokenAssociations(542),
-						uploadInitCode(contract),
-						contractCreate(contract).gas(300_000),
-						tokenCreate(uniqToken)
-								.tokenType(NON_FUNGIBLE_UNIQUE)
-								.initialSupply(0)
-								.supplyKey(multiKey)
-								.treasury(TOKEN_TREASURY),
-						mintToken(uniqToken, List.of(firstMeta, secondMeta, thirdMeta)),
-						getAccountInfo(TOKEN_TREASURY).logged()
-				).when(
-						tokenAssociate(contract, uniqToken),
-						tokenDissociate(contract, uniqToken)
-				).then(
-						cryptoTransfer(TokenMovement.movingUnique(uniqToken, 1L)
-								.between(TOKEN_TREASURY, contract)
-						).hasKnownStatus(TOKEN_NOT_ASSOCIATED_TO_ACCOUNT)
-				);
-	}
-
-	public HapiApiSpec treasuryAssociationIsAutomatic() {
-		return defaultHapiSpec("TreasuryAssociationIsAutomatic")
-				.given(
-						basicKeysAndTokens()
-				).when().then(
-						getAccountInfo(TOKEN_TREASURY)
-								.hasToken(
-										relationshipWith(FREEZABLE_TOKEN_ON_BY_DEFAULT)
-												.kyc(KycNotApplicable)
-												.freeze(Unfrozen))
-								.hasToken(
-										relationshipWith(FREEZABLE_TOKEN_OFF_BY_DEFAULT)
-												.kyc(KycNotApplicable)
-												.freeze(Unfrozen))
-								.hasToken(
-										relationshipWith(KNOWABLE_TOKEN)
-												.kyc(Granted)
-												.freeze(FreezeNotApplicable))
-								.hasToken(
-										relationshipWith(VANILLA_TOKEN)
-												.kyc(KycNotApplicable)
-												.freeze(FreezeNotApplicable))
-								.logged(),
-						cryptoCreate("test"),
-						tokenAssociate("test", KNOWABLE_TOKEN),
-						tokenAssociate("test", FREEZABLE_TOKEN_OFF_BY_DEFAULT),
-						tokenAssociate("test", FREEZABLE_TOKEN_ON_BY_DEFAULT),
-						tokenAssociate("test", VANILLA_TOKEN),
-						getAccountInfo("test").logged(),
-						tokenDissociate("test", VANILLA_TOKEN),
-						getAccountInfo("test").logged(),
-						tokenDissociate("test", FREEZABLE_TOKEN_OFF_BY_DEFAULT).logged(),
-						getAccountInfo("test").logged()
-				);
-	}
-
-	public static HapiSpecOperation[] basicKeysAndTokens() {
-		return new HapiSpecOperation[] {
-				newKeyNamed("kycKey"),
-				newKeyNamed("freezeKey"),
-				cryptoCreate(TOKEN_TREASURY).balance(0L),
-				tokenCreate(FREEZABLE_TOKEN_ON_BY_DEFAULT)
-						.treasury(TOKEN_TREASURY)
-						.freezeKey("freezeKey")
-						.freezeDefault(true),
-				tokenCreate(FREEZABLE_TOKEN_OFF_BY_DEFAULT)
-						.treasury(TOKEN_TREASURY)
-						.freezeKey("freezeKey")
-						.freezeDefault(false),
-				tokenCreate(KNOWABLE_TOKEN)
-						.treasury(TOKEN_TREASURY)
-						.kycKey("kycKey"),
-				tokenCreate(VANILLA_TOKEN)
-						.treasury(TOKEN_TREASURY)
-		};
-	}
-
-	@Override
-	protected Logger getResultsLogger() {
-		return log;
-	}
+    @Override
+    protected Logger getResultsLogger() {
+        return log;
+    }
 }

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenCreateSpecs.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenCreateSpecs.java
@@ -1,11 +1,6 @@
-package com.hedera.services.bdd.suites.token;
-
-/*-
- * ‌
- * Hedera Services Test Clients
- * ​
- * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
- * ​
+/*
+ * Copyright (C) 2020-2022 Hedera Hashgraph, LLC
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -17,28 +12,8 @@ package com.hedera.services.bdd.suites.token;
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- * ‍
  */
-
-import com.hedera.services.bdd.spec.HapiApiSpec;
-import com.hedera.services.bdd.spec.HapiSpecSetup;
-import com.hedera.services.bdd.spec.transactions.TxnUtils;
-import com.hedera.services.bdd.suites.HapiApiSuite;
-import com.hederahashgraph.api.proto.java.TokenFreezeStatus;
-import com.hederahashgraph.api.proto.java.TokenKycStatus;
-import com.hederahashgraph.api.proto.java.TokenPauseStatus;
-import com.hederahashgraph.api.proto.java.TokenSupplyType;
-import com.hederahashgraph.api.proto.java.TokenType;
-import org.apache.commons.lang3.tuple.Pair;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-
-import java.time.Instant;
-import java.util.List;
-import java.util.OptionalLong;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
+package com.hedera.services.bdd.suites.token;
 
 import static com.hedera.services.bdd.spec.HapiApiSpec.defaultHapiSpec;
 import static com.hedera.services.bdd.spec.assertions.AccountInfoAsserts.accountWith;
@@ -98,988 +73,1063 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.MISSING_TOKEN_
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.ROYALTY_FRACTION_CANNOT_EXCEED_ONE;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SUCCESS;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TOKEN_HAS_NO_FREEZE_KEY;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TOKEN_HAS_NO_SUPPLY_KEY;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TOKEN_NAME_TOO_LONG;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TOKEN_NOT_ASSOCIATED_TO_FEE_COLLECTOR;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TOKEN_SYMBOL_TOO_LONG;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TRANSFERS_NOT_ZERO_SUM_FOR_TOKEN;
 import static com.hederahashgraph.api.proto.java.TokenType.NON_FUNGIBLE_UNIQUE;
 
+import com.hedera.services.bdd.spec.HapiApiSpec;
+import com.hedera.services.bdd.spec.HapiSpecSetup;
+import com.hedera.services.bdd.spec.transactions.TxnUtils;
+import com.hedera.services.bdd.suites.HapiApiSuite;
+import com.hederahashgraph.api.proto.java.TokenFreezeStatus;
+import com.hederahashgraph.api.proto.java.TokenKycStatus;
+import com.hederahashgraph.api.proto.java.TokenPauseStatus;
+import com.hederahashgraph.api.proto.java.TokenSupplyType;
+import com.hederahashgraph.api.proto.java.TokenType;
+import java.time.Instant;
+import java.util.List;
+import java.util.OptionalLong;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 public class TokenCreateSpecs extends HapiApiSuite {
-	private static final Logger log = LogManager.getLogger(TokenCreateSpecs.class);
+    private static final Logger log = LogManager.getLogger(TokenCreateSpecs.class);
 
-	private static String TOKEN_TREASURY = "treasury";
+    private static String TOKEN_TREASURY = "treasury";
 
-	private static final String A_TOKEN = "TokenA";
-	private static final String B_TOKEN = "TokenB";
-	private static final String FIRST_USER = "Client1";
+    private static final String A_TOKEN = "TokenA";
+    private static final String B_TOKEN = "TokenB";
+    private static final String FIRST_USER = "Client1";
 
-	private static final long defaultMaxLifetime =
-			Long.parseLong(HapiSpecSetup.getDefaultNodeProps().get("entities.maxLifetime"));
+    private static final long defaultMaxLifetime =
+            Long.parseLong(HapiSpecSetup.getDefaultNodeProps().get("entities.maxLifetime"));
 
-	public static void main(String... args) {
-		new TokenCreateSpecs().runSuiteSync();
-	}
+    public static void main(String... args) {
+        new TokenCreateSpecs().runSuiteSync();
+    }
 
-	@Override
-	public boolean canRunConcurrent() {
-		return true;
-	}
+    @Override
+    public boolean canRunConcurrent() {
+        return true;
+    }
 
-	@Override
-	public List<HapiApiSpec> getSpecsInSuite() {
-		return List.of(new HapiApiSpec[] {
-						creationValidatesNonFungiblePrechecks(),
-						creationValidatesMaxSupply(),
-						creationValidatesMemo(),
-						creationValidatesName(),
-						creationValidatesSymbol(),
-						treasuryHasCorrectBalance(),
-						creationRequiresAppropriateSigs(),
-						creationRequiresAppropriateSigsHappyPath(),
-						initialSupplyMustBeSane(),
-						creationYieldsExpectedToken(),
-						creationSetsExpectedName(),
-						creationValidatesTreasuryAccount(),
-						autoRenewValidationWorks(),
-						creationWithoutKYCSetsCorrectStatus(),
-						creationValidatesExpiry(),
-						creationValidatesFreezeDefaultWithNoFreezeKey(),
-						creationSetsCorrectExpiry(),
-						creationHappyPath(),
-						worksAsExpectedWithDefaultTokenId(),
-						cannotCreateWithExcessiveLifetime(),
-						prechecksWork(),
-						/* HIP-18 */
-						onlyValidCustomFeeScheduleCanBeCreated(),
-						feeCollectorSigningReqsWorkForTokenCreate(),
-						createsFungibleInfiniteByDefault(),
-						baseCreationsHaveExpectedPrices(),
-						/* HIP-23 */
-						validateNewTokenAssociations()
-				}
-		);
-	}
+    @Override
+    public List<HapiApiSpec> getSpecsInSuite() {
+        return List.of(
+                new HapiApiSpec[] {
+                    creationValidatesNonFungiblePrechecks(),
+                    creationValidatesMaxSupply(),
+                    creationValidatesMemo(),
+                    creationValidatesName(),
+                    creationValidatesSymbol(),
+                    treasuryHasCorrectBalance(),
+                    creationRequiresAppropriateSigs(),
+                    creationRequiresAppropriateSigsHappyPath(),
+                    initialSupplyMustBeSane(),
+                    creationYieldsExpectedToken(),
+                    creationSetsExpectedName(),
+                    creationValidatesTreasuryAccount(),
+                    autoRenewValidationWorks(),
+                    creationWithoutKYCSetsCorrectStatus(),
+                    creationValidatesExpiry(),
+                    creationValidatesFreezeDefaultWithNoFreezeKey(),
+                    creationSetsCorrectExpiry(),
+                    creationHappyPath(),
+                    worksAsExpectedWithDefaultTokenId(),
+                    cannotCreateWithExcessiveLifetime(),
+                    prechecksWork(),
+                    /* HIP-18 */
+                    onlyValidCustomFeeScheduleCanBeCreated(),
+                    feeCollectorSigningReqsWorkForTokenCreate(),
+                    createsFungibleInfiniteByDefault(),
+                    baseCreationsHaveExpectedPrices(),
+                    /* HIP-23 */
+                    validateNewTokenAssociations()
+                });
+    }
 
-	private HapiApiSpec validateNewTokenAssociations() {
-		final String aToken = "TokenA";
-		final String notToBeToken = "notToBeToken";
-		final String hbarCollector = "hbarCollector";
-		final String fractionalCollector = "fractionalCollector";
-		final String selfDenominatedFixedCollector = "selfDenominatedFixedCollector";
-		final String otherSelfDenominatedFixedCollector = "otherSelfDenominatedFixedCollector";
-		final String treasury = "treasury";
-		final String tbd = "toBeDeletd";
-		final String creationTxn = "creationTxn";
-		final String failedCreationTxn = "failedCreationTxn";
+    private HapiApiSpec validateNewTokenAssociations() {
+        final String aToken = "TokenA";
+        final String notToBeToken = "notToBeToken";
+        final String hbarCollector = "hbarCollector";
+        final String fractionalCollector = "fractionalCollector";
+        final String selfDenominatedFixedCollector = "selfDenominatedFixedCollector";
+        final String otherSelfDenominatedFixedCollector = "otherSelfDenominatedFixedCollector";
+        final String treasury = "treasury";
+        final String tbd = "toBeDeletd";
+        final String creationTxn = "creationTxn";
+        final String failedCreationTxn = "failedCreationTxn";
 
-		return defaultHapiSpec("ValidateNewTokenAssociations")
-				.given(
-						cryptoCreate(tbd),
-						cryptoDelete(tbd),
-						cryptoCreate(hbarCollector),
-						cryptoCreate(fractionalCollector),
-						cryptoCreate(selfDenominatedFixedCollector),
-						cryptoCreate(otherSelfDenominatedFixedCollector),
-						cryptoCreate(treasury)
-								.maxAutomaticTokenAssociations(10)
-								.balance(ONE_HUNDRED_HBARS)
-				).when(
-						getAccountInfo(treasury)
-								.savingSnapshot(treasury),
-						getAccountInfo(hbarCollector)
-								.savingSnapshot(hbarCollector),
-						getAccountInfo(fractionalCollector)
-								.savingSnapshot(fractionalCollector),
-						getAccountInfo(selfDenominatedFixedCollector)
-								.savingSnapshot(selfDenominatedFixedCollector),
-						getAccountInfo(otherSelfDenominatedFixedCollector)
-								.savingSnapshot(otherSelfDenominatedFixedCollector),
-						tokenCreate(aToken)
-								.tokenType(TokenType.FUNGIBLE_COMMON)
-								.initialSupply(Long.MAX_VALUE)
-								.treasury(treasury)
-								.withCustom(fixedHbarFee(
-										20L,
-										hbarCollector))
-								.withCustom(fractionalFee(
-										1L, 100L, 1L, OptionalLong.of(5L),
-										fractionalCollector))
-								.withCustom(fixedHtsFee(
-										2L, "0.0.0",
-										selfDenominatedFixedCollector))
-								.withCustom(fixedHtsFee(
-										3L, "0.0.0",
-										otherSelfDenominatedFixedCollector))
-								.signedBy(
-										DEFAULT_PAYER,
-										treasury,
-										fractionalCollector,
-										selfDenominatedFixedCollector, otherSelfDenominatedFixedCollector)
-								.via(creationTxn),
-						tokenCreate(notToBeToken)
-								.treasury(tbd)
-								.hasKnownStatus(INVALID_TREASURY_ACCOUNT_FOR_TOKEN)
-								.via(failedCreationTxn)
-				).then(
-						/* Validate records */
-						getTxnRecord(creationTxn)
-								.hasPriority(recordWith()
-										.autoAssociated(accountTokenPairs(List.of(
-												Pair.of(treasury, aToken),
-												Pair.of(fractionalCollector, aToken),
-												Pair.of(selfDenominatedFixedCollector, aToken),
-												Pair.of(otherSelfDenominatedFixedCollector, aToken)
-										)))),
-						getTxnRecord(failedCreationTxn)
-								.hasPriority(recordWith()
-										.autoAssociated(accountTokenPairs(List.of()))),
-						/* Validate state */
-						getAccountInfo(hbarCollector).has(accountWith()
-								.noChangesFromSnapshot(hbarCollector)),
-						getAccountInfo(treasury)
-								.hasMaxAutomaticAssociations(10)
-								/* TokenCreate auto-associations aren't part of the HIP-23 paradigm */
-								.hasAlreadyUsedAutomaticAssociations(0)
-								.has(accountWith()
-										.newAssociationsFromSnapshot(treasury,
-												List.of(relationshipWith(aToken)))),
-						getAccountInfo(fractionalCollector).has(accountWith()
-								.newAssociationsFromSnapshot(fractionalCollector,
-										List.of(relationshipWith(aToken)))),
-						getAccountInfo(selfDenominatedFixedCollector).has(accountWith()
-								.newAssociationsFromSnapshot(selfDenominatedFixedCollector,
-										List.of(relationshipWith(aToken)))),
-						getAccountInfo(otherSelfDenominatedFixedCollector).has(accountWith()
-								.newAssociationsFromSnapshot(otherSelfDenominatedFixedCollector,
-										List.of(relationshipWith(aToken))))
-				);
-	}
+        return defaultHapiSpec("ValidateNewTokenAssociations")
+                .given(
+                        cryptoCreate(tbd),
+                        cryptoDelete(tbd),
+                        cryptoCreate(hbarCollector),
+                        cryptoCreate(fractionalCollector),
+                        cryptoCreate(selfDenominatedFixedCollector),
+                        cryptoCreate(otherSelfDenominatedFixedCollector),
+                        cryptoCreate(treasury)
+                                .maxAutomaticTokenAssociations(10)
+                                .balance(ONE_HUNDRED_HBARS))
+                .when(
+                        getAccountInfo(treasury).savingSnapshot(treasury),
+                        getAccountInfo(hbarCollector).savingSnapshot(hbarCollector),
+                        getAccountInfo(fractionalCollector).savingSnapshot(fractionalCollector),
+                        getAccountInfo(selfDenominatedFixedCollector)
+                                .savingSnapshot(selfDenominatedFixedCollector),
+                        getAccountInfo(otherSelfDenominatedFixedCollector)
+                                .savingSnapshot(otherSelfDenominatedFixedCollector),
+                        tokenCreate(aToken)
+                                .tokenType(TokenType.FUNGIBLE_COMMON)
+                                .initialSupply(Long.MAX_VALUE)
+                                .treasury(treasury)
+                                .withCustom(fixedHbarFee(20L, hbarCollector))
+                                .withCustom(
+                                        fractionalFee(
+                                                1L,
+                                                100L,
+                                                1L,
+                                                OptionalLong.of(5L),
+                                                fractionalCollector))
+                                .withCustom(fixedHtsFee(2L, "0.0.0", selfDenominatedFixedCollector))
+                                .withCustom(
+                                        fixedHtsFee(
+                                                3L, "0.0.0", otherSelfDenominatedFixedCollector))
+                                .signedBy(
+                                        DEFAULT_PAYER,
+                                        treasury,
+                                        fractionalCollector,
+                                        selfDenominatedFixedCollector,
+                                        otherSelfDenominatedFixedCollector)
+                                .via(creationTxn),
+                        tokenCreate(notToBeToken)
+                                .treasury(tbd)
+                                .hasKnownStatus(INVALID_TREASURY_ACCOUNT_FOR_TOKEN)
+                                .via(failedCreationTxn))
+                .then(
+                        /* Validate records */
+                        getTxnRecord(creationTxn)
+                                .hasPriority(
+                                        recordWith()
+                                                .autoAssociated(
+                                                        accountTokenPairs(
+                                                                List.of(
+                                                                        Pair.of(treasury, aToken),
+                                                                        Pair.of(
+                                                                                fractionalCollector,
+                                                                                aToken),
+                                                                        Pair.of(
+                                                                                selfDenominatedFixedCollector,
+                                                                                aToken),
+                                                                        Pair.of(
+                                                                                otherSelfDenominatedFixedCollector,
+                                                                                aToken))))),
+                        getTxnRecord(failedCreationTxn)
+                                .hasPriority(
+                                        recordWith().autoAssociated(accountTokenPairs(List.of()))),
+                        /* Validate state */
+                        getAccountInfo(hbarCollector)
+                                .has(accountWith().noChangesFromSnapshot(hbarCollector)),
+                        getAccountInfo(treasury)
+                                .hasMaxAutomaticAssociations(10)
+                                /* TokenCreate auto-associations aren't part of the HIP-23 paradigm */
+                                .hasAlreadyUsedAutomaticAssociations(0)
+                                .has(
+                                        accountWith()
+                                                .newAssociationsFromSnapshot(
+                                                        treasury,
+                                                        List.of(relationshipWith(aToken)))),
+                        getAccountInfo(fractionalCollector)
+                                .has(
+                                        accountWith()
+                                                .newAssociationsFromSnapshot(
+                                                        fractionalCollector,
+                                                        List.of(relationshipWith(aToken)))),
+                        getAccountInfo(selfDenominatedFixedCollector)
+                                .has(
+                                        accountWith()
+                                                .newAssociationsFromSnapshot(
+                                                        selfDenominatedFixedCollector,
+                                                        List.of(relationshipWith(aToken)))),
+                        getAccountInfo(otherSelfDenominatedFixedCollector)
+                                .has(
+                                        accountWith()
+                                                .newAssociationsFromSnapshot(
+                                                        otherSelfDenominatedFixedCollector,
+                                                        List.of(relationshipWith(aToken)))));
+    }
 
-	private HapiApiSpec createsFungibleInfiniteByDefault() {
-		return defaultHapiSpec("CreatesFungibleInfiniteByDefault")
-				.given().when(
-						tokenCreate("DefaultFungible")
-				).then(
-						getTokenInfo("DefaultFungible")
-								.hasTokenType(TokenType.FUNGIBLE_COMMON)
-								.hasSupplyType(TokenSupplyType.INFINITE)
-				);
-	}
+    private HapiApiSpec createsFungibleInfiniteByDefault() {
+        return defaultHapiSpec("CreatesFungibleInfiniteByDefault")
+                .given()
+                .when(tokenCreate("DefaultFungible"))
+                .then(
+                        getTokenInfo("DefaultFungible")
+                                .hasTokenType(TokenType.FUNGIBLE_COMMON)
+                                .hasSupplyType(TokenSupplyType.INFINITE));
+    }
 
-	private HapiApiSpec worksAsExpectedWithDefaultTokenId() {
-		return defaultHapiSpec("WorksAsExpectedWithDefaultTokenId")
-				.given().when().then(
-						getTokenInfo("0.0.0").hasCostAnswerPrecheck(INVALID_TOKEN_ID)
-				);
-	}
+    private HapiApiSpec worksAsExpectedWithDefaultTokenId() {
+        return defaultHapiSpec("WorksAsExpectedWithDefaultTokenId")
+                .given()
+                .when()
+                .then(getTokenInfo("0.0.0").hasCostAnswerPrecheck(INVALID_TOKEN_ID));
+    }
 
-	public HapiApiSpec cannotCreateWithExcessiveLifetime() {
-		final var smallBuffer = 12_345L;
-		final var okExpiry = defaultMaxLifetime + Instant.now().getEpochSecond() - smallBuffer;
-		final var excessiveExpiry = defaultMaxLifetime + Instant.now().getEpochSecond() + smallBuffer;
-		return defaultHapiSpec("CannotCreateWithExcessiveLifetime")
-				.given().when().then(
-						tokenCreate("neverToBe")
-								.expiry(excessiveExpiry)
-								.hasKnownStatus(INVALID_EXPIRATION_TIME),
-						tokenCreate("neverToBe")
-								.expiry(okExpiry)
-				);
-	}
+    public HapiApiSpec cannotCreateWithExcessiveLifetime() {
+        final var smallBuffer = 12_345L;
+        final var okExpiry = defaultMaxLifetime + Instant.now().getEpochSecond() - smallBuffer;
+        final var excessiveExpiry =
+                defaultMaxLifetime + Instant.now().getEpochSecond() + smallBuffer;
+        return defaultHapiSpec("CannotCreateWithExcessiveLifetime")
+                .given()
+                .when()
+                .then(
+                        tokenCreate("neverToBe")
+                                .expiry(excessiveExpiry)
+                                .hasKnownStatus(INVALID_EXPIRATION_TIME),
+                        tokenCreate("neverToBe").expiry(okExpiry));
+    }
 
-	public HapiApiSpec autoRenewValidationWorks() {
-		return defaultHapiSpec("AutoRenewValidationWorks")
-				.given(
-						cryptoCreate("autoRenew").balance(0L),
-						cryptoCreate("deletingAccount").balance(0L)
-				).when(
-						cryptoDelete("deletingAccount"),
-						tokenCreate("primary")
-								.autoRenewAccount("deletingAccount")
-								.hasKnownStatus(INVALID_AUTORENEW_ACCOUNT),
-						tokenCreate("primary")
-								.signedBy(GENESIS)
-								.autoRenewAccount("1.2.3")
-								.hasKnownStatus(INVALID_AUTORENEW_ACCOUNT),
-						tokenCreate("primary")
-								.autoRenewAccount("autoRenew")
-								.autoRenewPeriod(Long.MAX_VALUE)
-								.hasPrecheck(INVALID_RENEWAL_PERIOD),
-						tokenCreate("primary")
-								.signedBy(GENESIS)
-								.autoRenewAccount("autoRenew")
-								.hasKnownStatus(INVALID_SIGNATURE),
-						tokenCreate("primary")
-								.autoRenewAccount("autoRenew")
-				).then(
-						getTokenInfo("primary")
-								.logged()
-				);
-	}
+    public HapiApiSpec autoRenewValidationWorks() {
+        return defaultHapiSpec("AutoRenewValidationWorks")
+                .given(
+                        cryptoCreate("autoRenew").balance(0L),
+                        cryptoCreate("deletingAccount").balance(0L))
+                .when(
+                        cryptoDelete("deletingAccount"),
+                        tokenCreate("primary")
+                                .autoRenewAccount("deletingAccount")
+                                .hasKnownStatus(INVALID_AUTORENEW_ACCOUNT),
+                        tokenCreate("primary")
+                                .signedBy(GENESIS)
+                                .autoRenewAccount("1.2.3")
+                                .hasKnownStatus(INVALID_AUTORENEW_ACCOUNT),
+                        tokenCreate("primary")
+                                .autoRenewAccount("autoRenew")
+                                .autoRenewPeriod(Long.MAX_VALUE)
+                                .hasPrecheck(INVALID_RENEWAL_PERIOD),
+                        tokenCreate("primary")
+                                .signedBy(GENESIS)
+                                .autoRenewAccount("autoRenew")
+                                .hasKnownStatus(INVALID_SIGNATURE),
+                        tokenCreate("primary").autoRenewAccount("autoRenew"))
+                .then(getTokenInfo("primary").logged());
+    }
 
-	public HapiApiSpec creationYieldsExpectedToken() {
-		return defaultHapiSpec("CreationYieldsExpectedToken")
-				.given(
-						cryptoCreate(TOKEN_TREASURY).balance(0L),
-						newKeyNamed("freeze")
-				).when(
-						tokenCreate("primary")
-								.initialSupply(123)
-								.decimals(4)
-								.freezeDefault(true)
-								.freezeKey("freeze")
-								.treasury(TOKEN_TREASURY)
-				).then(
-						getTokenInfo("primary")
-								.logged()
-								.hasRegisteredId("primary")
-				);
-	}
+    public HapiApiSpec creationYieldsExpectedToken() {
+        return defaultHapiSpec("CreationYieldsExpectedToken")
+                .given(cryptoCreate(TOKEN_TREASURY).balance(0L), newKeyNamed("freeze"))
+                .when(
+                        tokenCreate("primary")
+                                .initialSupply(123)
+                                .decimals(4)
+                                .freezeDefault(true)
+                                .freezeKey("freeze")
+                                .treasury(TOKEN_TREASURY))
+                .then(getTokenInfo("primary").logged().hasRegisteredId("primary"));
+    }
 
-	public HapiApiSpec creationSetsExpectedName() {
-		String saltedName = salted("primary");
-		return defaultHapiSpec("CreationSetsExpectedName")
-				.given(
-						cryptoCreate(TOKEN_TREASURY).balance(0L)
-				).when(
-						tokenCreate("primary")
-								.name(saltedName)
-								.treasury(TOKEN_TREASURY)
-				).then(
-						getTokenInfo("primary")
-								.logged()
-								.hasRegisteredId("primary")
-								.hasName(saltedName)
-				);
-	}
+    public HapiApiSpec creationSetsExpectedName() {
+        String saltedName = salted("primary");
+        return defaultHapiSpec("CreationSetsExpectedName")
+                .given(cryptoCreate(TOKEN_TREASURY).balance(0L))
+                .when(tokenCreate("primary").name(saltedName).treasury(TOKEN_TREASURY))
+                .then(
+                        getTokenInfo("primary")
+                                .logged()
+                                .hasRegisteredId("primary")
+                                .hasName(saltedName));
+    }
 
-	public HapiApiSpec creationWithoutKYCSetsCorrectStatus() {
-		String saltedName = salted("primary");
-		return defaultHapiSpec("CreationWithoutKYCSetsCorrectStatus")
-				.given(
-						cryptoCreate(TOKEN_TREASURY).balance(0L)
-				).when(
-						tokenCreate("primary")
-								.name(saltedName)
-								.treasury(TOKEN_TREASURY)
-				).then(
-						getAccountInfo(TOKEN_TREASURY)
-								.hasToken(
-										relationshipWith("primary")
-												.kyc(TokenKycStatus.KycNotApplicable)
-								)
-				);
-	}
+    public HapiApiSpec creationWithoutKYCSetsCorrectStatus() {
+        String saltedName = salted("primary");
+        return defaultHapiSpec("CreationWithoutKYCSetsCorrectStatus")
+                .given(cryptoCreate(TOKEN_TREASURY).balance(0L))
+                .when(tokenCreate("primary").name(saltedName).treasury(TOKEN_TREASURY))
+                .then(
+                        getAccountInfo(TOKEN_TREASURY)
+                                .hasToken(
+                                        relationshipWith("primary")
+                                                .kyc(TokenKycStatus.KycNotApplicable)));
+    }
 
-	public HapiApiSpec baseCreationsHaveExpectedPrices() {
-		final var civilian = "NonExemptPayer";
+    public HapiApiSpec baseCreationsHaveExpectedPrices() {
+        final var civilian = "NonExemptPayer";
 
-		final var expectedCommonNoCustomFeesPriceUsd = 1.00;
-		final var expectedUniqueNoCustomFeesPriceUsd = 1.00;
-		final var expectedCommonWithCustomFeesPriceUsd = 2.00;
-		final var expectedUniqueWithCustomFeesPriceUsd = 2.00;
+        final var expectedCommonNoCustomFeesPriceUsd = 1.00;
+        final var expectedUniqueNoCustomFeesPriceUsd = 1.00;
+        final var expectedCommonWithCustomFeesPriceUsd = 2.00;
+        final var expectedUniqueWithCustomFeesPriceUsd = 2.00;
 
-		final var commonNoFees = "commonNoFees";
-		final var commonWithFees = "commonWithFees";
-		final var uniqueNoFees = "uniqueNoFees";
-		final var uniqueWithFees = "uniqueWithFees";
+        final var commonNoFees = "commonNoFees";
+        final var commonWithFees = "commonWithFees";
+        final var uniqueNoFees = "uniqueNoFees";
+        final var uniqueWithFees = "uniqueWithFees";
 
-		final var autoRenew = "autoRenewAccount";
-		final var adminKey = "adminKey";
-		final var supplyKey = "supplyKey";
-		final var customFeeKey = "customFeeKey";
+        final var autoRenew = "autoRenewAccount";
+        final var adminKey = "adminKey";
+        final var supplyKey = "supplyKey";
+        final var customFeeKey = "customFeeKey";
 
-		return defaultHapiSpec("BaseCreationsHaveExpectedPrices")
-				.given(
-						cryptoCreate(civilian).balance(ONE_HUNDRED_HBARS),
-						cryptoCreate(TOKEN_TREASURY).balance(0L),
-						cryptoCreate(autoRenew).balance(0L),
-						newKeyNamed(adminKey),
-						newKeyNamed(supplyKey),
-						newKeyNamed(customFeeKey)
-				).when(
-						tokenCreate(commonNoFees)
-								.blankMemo()
-								.name("012345678912")
-								.symbol("ABCD")
-								.payingWith(civilian)
-								.treasury(TOKEN_TREASURY)
-								.autoRenewAccount(autoRenew)
-								.autoRenewPeriod(THREE_MONTHS_IN_SECONDS)
-								.adminKey(adminKey)
-								.via(txnFor(commonNoFees)),
-						tokenCreate(commonWithFees)
-								.blankMemo()
-								.name("012345678912")
-								.symbol("ABCD")
-								.payingWith(civilian)
-								.treasury(TOKEN_TREASURY)
-								.autoRenewAccount(autoRenew)
-								.autoRenewPeriod(THREE_MONTHS_IN_SECONDS)
-								.adminKey(adminKey)
-								.withCustom(fixedHbarFee(ONE_HBAR, TOKEN_TREASURY))
-								.feeScheduleKey(customFeeKey)
-								.via(txnFor(commonWithFees)),
-						tokenCreate(uniqueNoFees)
-								.payingWith(civilian)
-								.blankMemo()
-								.name("012345678912")
-								.symbol("ABCD")
-								.initialSupply(0L)
-								.tokenType(NON_FUNGIBLE_UNIQUE)
-								.treasury(TOKEN_TREASURY)
-								.autoRenewAccount(autoRenew)
-								.autoRenewPeriod(THREE_MONTHS_IN_SECONDS)
-								.adminKey(adminKey)
-								.supplyKey(supplyKey)
-								.via(txnFor(uniqueNoFees)),
-						tokenCreate(uniqueWithFees)
-								.payingWith(civilian)
-								.blankMemo()
-								.name("012345678912")
-								.symbol("ABCD")
-								.initialSupply(0L)
-								.tokenType(NON_FUNGIBLE_UNIQUE)
-								.treasury(TOKEN_TREASURY)
-								.autoRenewAccount(autoRenew)
-								.autoRenewPeriod(THREE_MONTHS_IN_SECONDS)
-								.adminKey(adminKey)
-								.withCustom(fixedHbarFee(ONE_HBAR, TOKEN_TREASURY))
-								.supplyKey(supplyKey)
-								.feeScheduleKey(customFeeKey)
-								.via(txnFor(uniqueWithFees))
-				).then(
-						validateChargedUsdWithin(
-								txnFor(commonNoFees), expectedCommonNoCustomFeesPriceUsd, 0.01),
-						validateChargedUsdWithin(
-								txnFor(commonWithFees), expectedCommonWithCustomFeesPriceUsd, 0.01),
-						validateChargedUsdWithin(
-								txnFor(uniqueNoFees), expectedUniqueNoCustomFeesPriceUsd, 0.01),
-						validateChargedUsdWithin(
-								txnFor(uniqueWithFees), expectedUniqueWithCustomFeesPriceUsd, 0.01)
-				);
-	}
+        return defaultHapiSpec("BaseCreationsHaveExpectedPrices")
+                .given(
+                        cryptoCreate(civilian).balance(ONE_HUNDRED_HBARS),
+                        cryptoCreate(TOKEN_TREASURY).balance(0L),
+                        cryptoCreate(autoRenew).balance(0L),
+                        newKeyNamed(adminKey),
+                        newKeyNamed(supplyKey),
+                        newKeyNamed(customFeeKey))
+                .when(
+                        tokenCreate(commonNoFees)
+                                .blankMemo()
+                                .name("012345678912")
+                                .symbol("ABCD")
+                                .payingWith(civilian)
+                                .treasury(TOKEN_TREASURY)
+                                .autoRenewAccount(autoRenew)
+                                .autoRenewPeriod(THREE_MONTHS_IN_SECONDS)
+                                .adminKey(adminKey)
+                                .via(txnFor(commonNoFees)),
+                        tokenCreate(commonWithFees)
+                                .blankMemo()
+                                .name("012345678912")
+                                .symbol("ABCD")
+                                .payingWith(civilian)
+                                .treasury(TOKEN_TREASURY)
+                                .autoRenewAccount(autoRenew)
+                                .autoRenewPeriod(THREE_MONTHS_IN_SECONDS)
+                                .adminKey(adminKey)
+                                .withCustom(fixedHbarFee(ONE_HBAR, TOKEN_TREASURY))
+                                .feeScheduleKey(customFeeKey)
+                                .via(txnFor(commonWithFees)),
+                        tokenCreate(uniqueNoFees)
+                                .payingWith(civilian)
+                                .blankMemo()
+                                .name("012345678912")
+                                .symbol("ABCD")
+                                .initialSupply(0L)
+                                .tokenType(NON_FUNGIBLE_UNIQUE)
+                                .treasury(TOKEN_TREASURY)
+                                .autoRenewAccount(autoRenew)
+                                .autoRenewPeriod(THREE_MONTHS_IN_SECONDS)
+                                .adminKey(adminKey)
+                                .supplyKey(supplyKey)
+                                .via(txnFor(uniqueNoFees)),
+                        tokenCreate(uniqueWithFees)
+                                .payingWith(civilian)
+                                .blankMemo()
+                                .name("012345678912")
+                                .symbol("ABCD")
+                                .initialSupply(0L)
+                                .tokenType(NON_FUNGIBLE_UNIQUE)
+                                .treasury(TOKEN_TREASURY)
+                                .autoRenewAccount(autoRenew)
+                                .autoRenewPeriod(THREE_MONTHS_IN_SECONDS)
+                                .adminKey(adminKey)
+                                .withCustom(fixedHbarFee(ONE_HBAR, TOKEN_TREASURY))
+                                .supplyKey(supplyKey)
+                                .feeScheduleKey(customFeeKey)
+                                .via(txnFor(uniqueWithFees)))
+                .then(
+                        validateChargedUsdWithin(
+                                txnFor(commonNoFees), expectedCommonNoCustomFeesPriceUsd, 0.01),
+                        validateChargedUsdWithin(
+                                txnFor(commonWithFees), expectedCommonWithCustomFeesPriceUsd, 0.01),
+                        validateChargedUsdWithin(
+                                txnFor(uniqueNoFees), expectedUniqueNoCustomFeesPriceUsd, 0.01),
+                        validateChargedUsdWithin(
+                                txnFor(uniqueWithFees),
+                                expectedUniqueWithCustomFeesPriceUsd,
+                                0.01));
+    }
 
-	private String txnFor(String tokenSubType) {
-		return tokenSubType + "Txn";
-	}
+    private String txnFor(String tokenSubType) {
+        return tokenSubType + "Txn";
+    }
 
-	public HapiApiSpec creationHappyPath() {
-		String memo = "JUMP";
-		String saltedName = salted("primary");
-		final var secondCreation = "secondCreation";
-		return defaultHapiSpec("CreationHappyPath")
-				.given(
-						cryptoCreate(TOKEN_TREASURY).balance(0L),
-						cryptoCreate("autoRenewAccount").balance(0L),
-						newKeyNamed("adminKey"),
-						newKeyNamed("freezeKey"),
-						newKeyNamed("kycKey"),
-						newKeyNamed("supplyKey"),
-						newKeyNamed("wipeKey"),
-						newKeyNamed("feeScheduleKey"),
-						newKeyNamed("pauseKey")
-				).when(
-						tokenCreate("primary")
-								.supplyType(TokenSupplyType.FINITE)
-								.entityMemo(memo)
-								.name(saltedName)
-								.treasury(TOKEN_TREASURY)
-								.autoRenewAccount("autoRenewAccount")
-								.autoRenewPeriod(THREE_MONTHS_IN_SECONDS)
-								.maxSupply(1000)
-								.initialSupply(500)
-								.decimals(1)
-								.adminKey("adminKey")
-								.freezeKey("freezeKey")
-								.kycKey("kycKey")
-								.supplyKey("supplyKey")
-								.wipeKey("wipeKey")
-								.feeScheduleKey("feeScheduleKey")
-								.pauseKey("pauseKey")
-								.via("createTxn"),
-						tokenCreate("non-fungible-unique-finite")
-								.tokenType(NON_FUNGIBLE_UNIQUE)
-								.supplyType(TokenSupplyType.FINITE)
-								.pauseKey("pauseKey")
-								.initialSupply(0)
-								.maxSupply(100)
-								.treasury(TOKEN_TREASURY)
-								.via(secondCreation),
-						getTxnRecord(secondCreation).logged().hasPriority(recordWith().autoAssociated(
-								accountTokenPairsInAnyOrder(List.of(
-										Pair.of(TOKEN_TREASURY, "non-fungible-unique-finite")
-								))))
-				).then(
-						withOpContext((spec, opLog) -> {
-							var createTxn = getTxnRecord("createTxn");
-							allRunFor(spec, createTxn);
-							var timestamp = createTxn.getResponseRecord().getConsensusTimestamp().getSeconds();
-							spec.registry().saveExpiry("primary", timestamp + THREE_MONTHS_IN_SECONDS);
-						}),
-						getTokenInfo("primary")
-								.logged()
-								.hasRegisteredId("primary")
-								.hasTokenType(TokenType.FUNGIBLE_COMMON)
-								.hasSupplyType(TokenSupplyType.FINITE)
-								.hasEntityMemo(memo)
-								.hasName(saltedName)
-								.hasTreasury(TOKEN_TREASURY)
-								.hasAutoRenewPeriod(THREE_MONTHS_IN_SECONDS)
-								.hasValidExpiry()
-								.hasDecimals(1)
-								.hasAdminKey("primary")
-								.hasFreezeKey("primary")
-								.hasKycKey("primary")
-								.hasSupplyKey("primary")
-								.hasWipeKey("primary")
-								.hasFeeScheduleKey("primary")
-								.hasPauseKey("primary")
-								.hasPauseStatus(TokenPauseStatus.Unpaused)
-								.hasMaxSupply(1000)
-								.hasTotalSupply(500)
-								.hasAutoRenewAccount("autoRenewAccount"),
-						getTokenInfo("non-fungible-unique-finite")
-								.logged()
-								.hasRegisteredId("non-fungible-unique-finite")
-								.hasTokenType(NON_FUNGIBLE_UNIQUE)
-								.hasSupplyType(TokenSupplyType.FINITE)
-								.hasPauseKey("primary")
-								.hasPauseStatus(TokenPauseStatus.Unpaused)
-								.hasTotalSupply(0)
-								.hasMaxSupply(100),
-						getAccountInfo(TOKEN_TREASURY)
-								.hasToken(
-										relationshipWith("primary")
-												.balance(500)
-												.kyc(TokenKycStatus.Granted)
-												.freeze(TokenFreezeStatus.Unfrozen)
-								)
-								.hasToken(
-										relationshipWith("non-fungible-unique-finite")
-												.balance(0)
-												.kyc(TokenKycStatus.KycNotApplicable)
-												.freeze(TokenFreezeStatus.FreezeNotApplicable)
-								)
-				);
-	}
+    public HapiApiSpec creationHappyPath() {
+        String memo = "JUMP";
+        String saltedName = salted("primary");
+        final var secondCreation = "secondCreation";
+        return defaultHapiSpec("CreationHappyPath")
+                .given(
+                        cryptoCreate(TOKEN_TREASURY).balance(0L),
+                        cryptoCreate("autoRenewAccount").balance(0L),
+                        newKeyNamed("adminKey"),
+                        newKeyNamed("freezeKey"),
+                        newKeyNamed("kycKey"),
+                        newKeyNamed("supplyKey"),
+                        newKeyNamed("wipeKey"),
+                        newKeyNamed("feeScheduleKey"),
+                        newKeyNamed("pauseKey"))
+                .when(
+                        tokenCreate("primary")
+                                .supplyType(TokenSupplyType.FINITE)
+                                .entityMemo(memo)
+                                .name(saltedName)
+                                .treasury(TOKEN_TREASURY)
+                                .autoRenewAccount("autoRenewAccount")
+                                .autoRenewPeriod(THREE_MONTHS_IN_SECONDS)
+                                .maxSupply(1000)
+                                .initialSupply(500)
+                                .decimals(1)
+                                .adminKey("adminKey")
+                                .freezeKey("freezeKey")
+                                .kycKey("kycKey")
+                                .supplyKey("supplyKey")
+                                .wipeKey("wipeKey")
+                                .feeScheduleKey("feeScheduleKey")
+                                .pauseKey("pauseKey")
+                                .via("createTxn"),
+                        tokenCreate("non-fungible-unique-finite")
+                                .tokenType(NON_FUNGIBLE_UNIQUE)
+                                .supplyType(TokenSupplyType.FINITE)
+                                .pauseKey("pauseKey")
+                                .initialSupply(0)
+                                .maxSupply(100)
+                                .treasury(TOKEN_TREASURY)
+                                .supplyKey(GENESIS)
+                                .via(secondCreation),
+                        getTxnRecord(secondCreation)
+                                .logged()
+                                .hasPriority(
+                                        recordWith()
+                                                .autoAssociated(
+                                                        accountTokenPairsInAnyOrder(
+                                                                List.of(
+                                                                        Pair.of(
+                                                                                TOKEN_TREASURY,
+                                                                                "non-fungible-unique-finite"))))))
+                .then(
+                        withOpContext(
+                                (spec, opLog) -> {
+                                    var createTxn = getTxnRecord("createTxn");
+                                    allRunFor(spec, createTxn);
+                                    var timestamp =
+                                            createTxn
+                                                    .getResponseRecord()
+                                                    .getConsensusTimestamp()
+                                                    .getSeconds();
+                                    spec.registry()
+                                            .saveExpiry(
+                                                    "primary", timestamp + THREE_MONTHS_IN_SECONDS);
+                                }),
+                        getTokenInfo("primary")
+                                .logged()
+                                .hasRegisteredId("primary")
+                                .hasTokenType(TokenType.FUNGIBLE_COMMON)
+                                .hasSupplyType(TokenSupplyType.FINITE)
+                                .hasEntityMemo(memo)
+                                .hasName(saltedName)
+                                .hasTreasury(TOKEN_TREASURY)
+                                .hasAutoRenewPeriod(THREE_MONTHS_IN_SECONDS)
+                                .hasValidExpiry()
+                                .hasDecimals(1)
+                                .hasAdminKey("primary")
+                                .hasFreezeKey("primary")
+                                .hasKycKey("primary")
+                                .hasSupplyKey("primary")
+                                .hasWipeKey("primary")
+                                .hasFeeScheduleKey("primary")
+                                .hasPauseKey("primary")
+                                .hasPauseStatus(TokenPauseStatus.Unpaused)
+                                .hasMaxSupply(1000)
+                                .hasTotalSupply(500)
+                                .hasAutoRenewAccount("autoRenewAccount"),
+                        getTokenInfo("non-fungible-unique-finite")
+                                .logged()
+                                .hasRegisteredId("non-fungible-unique-finite")
+                                .hasTokenType(NON_FUNGIBLE_UNIQUE)
+                                .hasSupplyType(TokenSupplyType.FINITE)
+                                .hasPauseKey("primary")
+                                .hasPauseStatus(TokenPauseStatus.Unpaused)
+                                .hasTotalSupply(0)
+                                .hasMaxSupply(100),
+                        getAccountInfo(TOKEN_TREASURY)
+                                .hasToken(
+                                        relationshipWith("primary")
+                                                .balance(500)
+                                                .kyc(TokenKycStatus.Granted)
+                                                .freeze(TokenFreezeStatus.Unfrozen))
+                                .hasToken(
+                                        relationshipWith("non-fungible-unique-finite")
+                                                .balance(0)
+                                                .kyc(TokenKycStatus.KycNotApplicable)
+                                                .freeze(TokenFreezeStatus.FreezeNotApplicable)));
+    }
 
-	public HapiApiSpec creationSetsCorrectExpiry() {
-		return defaultHapiSpec("CreationSetsCorrectExpiry")
-				.given(
-						cryptoCreate(TOKEN_TREASURY).balance(0L),
-						cryptoCreate("autoRenew").balance(0L)
-				).when(
-						tokenCreate("primary")
-								.autoRenewAccount("autoRenew")
-								.autoRenewPeriod(THREE_MONTHS_IN_SECONDS)
-								.treasury(TOKEN_TREASURY)
-								.via("createTxn")
-				).then(
-						withOpContext((spec, opLog) -> {
-							var createTxn = getTxnRecord("createTxn");
-							allRunFor(spec, createTxn);
-							var timestamp = createTxn.getResponseRecord().getConsensusTimestamp().getSeconds();
-							spec.registry().saveExpiry("primary", timestamp + THREE_MONTHS_IN_SECONDS);
-						}),
-						getTokenInfo("primary")
-								.logged()
-								.hasRegisteredId("primary")
-								.hasValidExpiry()
-				);
-	}
+    public HapiApiSpec creationSetsCorrectExpiry() {
+        return defaultHapiSpec("CreationSetsCorrectExpiry")
+                .given(
+                        cryptoCreate(TOKEN_TREASURY).balance(0L),
+                        cryptoCreate("autoRenew").balance(0L))
+                .when(
+                        tokenCreate("primary")
+                                .autoRenewAccount("autoRenew")
+                                .autoRenewPeriod(THREE_MONTHS_IN_SECONDS)
+                                .treasury(TOKEN_TREASURY)
+                                .via("createTxn"))
+                .then(
+                        withOpContext(
+                                (spec, opLog) -> {
+                                    var createTxn = getTxnRecord("createTxn");
+                                    allRunFor(spec, createTxn);
+                                    var timestamp =
+                                            createTxn
+                                                    .getResponseRecord()
+                                                    .getConsensusTimestamp()
+                                                    .getSeconds();
+                                    spec.registry()
+                                            .saveExpiry(
+                                                    "primary", timestamp + THREE_MONTHS_IN_SECONDS);
+                                }),
+                        getTokenInfo("primary")
+                                .logged()
+                                .hasRegisteredId("primary")
+                                .hasValidExpiry());
+    }
 
-	public HapiApiSpec creationValidatesExpiry() {
-		return defaultHapiSpec("CreationValidatesExpiry")
-				.given().when().then(
-						tokenCreate("primary")
-								.expiry(1000)
-								.hasPrecheck(INVALID_EXPIRATION_TIME)
-				);
-	}
+    public HapiApiSpec creationValidatesExpiry() {
+        return defaultHapiSpec("CreationValidatesExpiry")
+                .given()
+                .when()
+                .then(tokenCreate("primary").expiry(1000).hasPrecheck(INVALID_EXPIRATION_TIME));
+    }
 
-	public HapiApiSpec creationValidatesFreezeDefaultWithNoFreezeKey() {
-		return defaultHapiSpec("CreationValidatesFreezeDefaultWithNoFreezeKey")
-				.given()
-				.when()
-				.then(
-						tokenCreate("primary")
-								.freezeDefault(true)
-								.hasPrecheck(TOKEN_HAS_NO_FREEZE_KEY)
-				);
-	}
+    public HapiApiSpec creationValidatesFreezeDefaultWithNoFreezeKey() {
+        return defaultHapiSpec("CreationValidatesFreezeDefaultWithNoFreezeKey")
+                .given()
+                .when()
+                .then(
+                        tokenCreate("primary")
+                                .freezeDefault(true)
+                                .hasPrecheck(TOKEN_HAS_NO_FREEZE_KEY));
+    }
 
-	public HapiApiSpec creationValidatesMemo() {
-		return defaultHapiSpec("CreationValidatesMemo")
-				.given().when().then(
-						tokenCreate("primary")
-								.entityMemo("N\u0000!!!")
-								.hasPrecheck(INVALID_ZERO_BYTE_IN_STRING)
-				);
-	}
+    public HapiApiSpec creationValidatesMemo() {
+        return defaultHapiSpec("CreationValidatesMemo")
+                .given()
+                .when()
+                .then(
+                        tokenCreate("primary")
+                                .entityMemo("N\u0000!!!")
+                                .hasPrecheck(INVALID_ZERO_BYTE_IN_STRING));
+    }
 
-	public HapiApiSpec creationValidatesNonFungiblePrechecks() {
-		return defaultHapiSpec("CreationValidatesNonFungiblePrechecks")
-				.given()
-				.when()
-				.then(
-						tokenCreate("primary")
-								.tokenType(NON_FUNGIBLE_UNIQUE)
-								.initialSupply(1)
-								.decimals(0)
-								.hasPrecheck(INVALID_TOKEN_INITIAL_SUPPLY),
-						tokenCreate("primary")
-								.tokenType(NON_FUNGIBLE_UNIQUE)
-								.initialSupply(0)
-								.decimals(1)
-								.hasPrecheck(INVALID_TOKEN_DECIMALS)
-				);
-	}
+    public HapiApiSpec creationValidatesNonFungiblePrechecks() {
+        return defaultHapiSpec("CreationValidatesNonFungiblePrechecks")
+                .given()
+                .when()
+                .then(
+                        tokenCreate("primary")
+                                .tokenType(NON_FUNGIBLE_UNIQUE)
+                                .initialSupply(0)
+                                .decimals(0)
+                                .hasPrecheck(TOKEN_HAS_NO_SUPPLY_KEY),
+                        tokenCreate("primary")
+                                .tokenType(NON_FUNGIBLE_UNIQUE)
+                                .initialSupply(1)
+                                .decimals(0)
+                                .hasPrecheck(INVALID_TOKEN_INITIAL_SUPPLY),
+                        tokenCreate("primary")
+                                .tokenType(NON_FUNGIBLE_UNIQUE)
+                                .initialSupply(0)
+                                .decimals(1)
+                                .hasPrecheck(INVALID_TOKEN_DECIMALS));
+    }
 
-	public HapiApiSpec creationValidatesMaxSupply() {
-		return defaultHapiSpec("CreationValidatesMaxSupply")
-				.given().when().then(
-						tokenCreate("primary")
-								.maxSupply(-1)
-								.hasPrecheck(INVALID_TOKEN_MAX_SUPPLY),
-						tokenCreate("primary")
-								.maxSupply(1)
-								.hasPrecheck(INVALID_TOKEN_MAX_SUPPLY),
-						tokenCreate("primary")
-								.supplyType(TokenSupplyType.FINITE)
-								.maxSupply(0)
-								.hasPrecheck(INVALID_TOKEN_MAX_SUPPLY),
-						tokenCreate("primary")
-								.supplyType(TokenSupplyType.FINITE)
-								.maxSupply(-1)
-								.hasPrecheck(INVALID_TOKEN_MAX_SUPPLY),
-						tokenCreate("primary")
-								.supplyType(TokenSupplyType.FINITE)
-								.initialSupply(2)
-								.maxSupply(1)
-								.hasPrecheck(INVALID_TOKEN_INITIAL_SUPPLY)
-				);
-	}
+    public HapiApiSpec creationValidatesMaxSupply() {
+        return defaultHapiSpec("CreationValidatesMaxSupply")
+                .given()
+                .when()
+                .then(
+                        tokenCreate("primary").maxSupply(-1).hasPrecheck(INVALID_TOKEN_MAX_SUPPLY),
+                        tokenCreate("primary").maxSupply(1).hasPrecheck(INVALID_TOKEN_MAX_SUPPLY),
+                        tokenCreate("primary")
+                                .supplyType(TokenSupplyType.FINITE)
+                                .maxSupply(0)
+                                .hasPrecheck(INVALID_TOKEN_MAX_SUPPLY),
+                        tokenCreate("primary")
+                                .supplyType(TokenSupplyType.FINITE)
+                                .maxSupply(-1)
+                                .hasPrecheck(INVALID_TOKEN_MAX_SUPPLY),
+                        tokenCreate("primary")
+                                .supplyType(TokenSupplyType.FINITE)
+                                .initialSupply(2)
+                                .maxSupply(1)
+                                .hasPrecheck(INVALID_TOKEN_INITIAL_SUPPLY));
+    }
 
-	public HapiApiSpec onlyValidCustomFeeScheduleCanBeCreated() {
-		return defaultHapiSpec("OnlyValidCustomFeeScheduleCanBeCreated")
-				.given(
-						newKeyNamed(customFeesKey),
-						cryptoCreate(htsCollector),
-						cryptoCreate(hbarCollector),
-						cryptoCreate(tokenCollector),
-						tokenCreate(feeDenom).treasury(htsCollector)
-				).when(
-						tokenCreate(token)
-								.treasury(tokenCollector)
-								.withCustom(fractionalFee(
-										numerator, 0,
-										minimumToCollect, OptionalLong.of(maximumToCollect),
-										tokenCollector))
-								.hasKnownStatus(FRACTION_DIVIDES_BY_ZERO),
-						tokenCreate(token)
-								.treasury(tokenCollector)
-								.withCustom(fixedHbarFee(hbarAmount, invalidEntityId))
-								.hasKnownStatus(INVALID_CUSTOM_FEE_COLLECTOR),
-						tokenCreate(token)
-								.treasury(tokenCollector)
-								.withCustom(fixedHtsFee(htsAmount, invalidEntityId, htsCollector))
-								.hasKnownStatus(INVALID_TOKEN_ID_IN_CUSTOM_FEES),
-						tokenCreate(token)
-								.treasury(tokenCollector)
-								.withCustom(fixedHtsFee(htsAmount, feeDenom, hbarCollector))
-								.hasKnownStatus(TOKEN_NOT_ASSOCIATED_TO_FEE_COLLECTOR),
-						tokenCreate(token)
-								.treasury(tokenCollector)
-								.withCustom(incompleteCustomFee(hbarCollector))
-								.signedBy(DEFAULT_PAYER, tokenCollector, hbarCollector)
-								.hasKnownStatus(CUSTOM_FEE_NOT_FULLY_SPECIFIED),
-						tokenCreate(token)
-								.treasury(tokenCollector)
-								.withCustom(fixedHtsFee(negativeHtsFee, feeDenom, hbarCollector))
-								.hasKnownStatus(CUSTOM_FEE_MUST_BE_POSITIVE),
-						tokenCreate(token)
-								.treasury(tokenCollector)
-								.withCustom(fractionalFee(
-										numerator, -denominator,
-										minimumToCollect, OptionalLong.of(maximumToCollect),
-										tokenCollector))
-								.hasKnownStatus(CUSTOM_FEE_MUST_BE_POSITIVE),
-						tokenCreate(token)
-								.treasury(tokenCollector)
-								.withCustom(fractionalFee(
-										numerator, denominator,
-										-minimumToCollect, OptionalLong.of(maximumToCollect),
-										tokenCollector))
-								.hasKnownStatus(CUSTOM_FEE_MUST_BE_POSITIVE),
-						tokenCreate(token)
-								.treasury(tokenCollector)
-								.withCustom(fractionalFee(
-										numerator, denominator,
-										minimumToCollect, OptionalLong.of(-maximumToCollect),
-										tokenCollector))
-								.hasKnownStatus(CUSTOM_FEE_MUST_BE_POSITIVE),
-						tokenCreate(token)
-								.treasury(tokenCollector)
-								.withCustom(fractionalFee(
-										-numerator, -denominator,
-										minimumToCollect, OptionalLong.of(maximumToCollect),
-										tokenCollector))
-								.hasKnownStatus(CUSTOM_FEE_MUST_BE_POSITIVE),
-						tokenCreate(token)
-								.treasury(tokenCollector)
-								.withCustom(fractionalFee(
-										numerator, denominator,
-										minimumToCollect, OptionalLong.of(minimumToCollect - 1),
-										tokenCollector))
-								.hasKnownStatus(FRACTIONAL_FEE_MAX_AMOUNT_LESS_THAN_MIN_AMOUNT),
-						tokenCreate(token)
-								.treasury(tokenCollector)
-								.withCustom(fractionalFee(
-										numerator, denominator,
-										minimumToCollect, OptionalLong.of(minimumToCollect),
-										tokenCollector))
-								.hasKnownStatus(SUCCESS),
-						tokenCreate(token)
-								.treasury(tokenCollector)
-								.withCustom(royaltyFeeNoFallback(1, 2, tokenCollector))
-								.hasKnownStatus(CUSTOM_ROYALTY_FEE_ONLY_ALLOWED_FOR_NON_FUNGIBLE_UNIQUE),
-						tokenCreate(token)
-								.tokenType(NON_FUNGIBLE_UNIQUE)
-								.initialSupply(0L)
-								.treasury(tokenCollector)
-								.withCustom(royaltyFeeNoFallback(-1, 2, tokenCollector))
-								.hasKnownStatus(CUSTOM_FEE_MUST_BE_POSITIVE),
-						tokenCreate(token)
-								.tokenType(NON_FUNGIBLE_UNIQUE)
-								.initialSupply(0L)
-								.treasury(tokenCollector)
-								.withCustom(royaltyFeeNoFallback(1, -2, tokenCollector))
-								.hasKnownStatus(CUSTOM_FEE_MUST_BE_POSITIVE),
-						tokenCreate(token)
-								.tokenType(NON_FUNGIBLE_UNIQUE)
-								.initialSupply(0L)
-								.treasury(tokenCollector)
-								.withCustom(royaltyFeeNoFallback(1, 0, tokenCollector))
-								.hasKnownStatus(FRACTION_DIVIDES_BY_ZERO),
-						tokenCreate(token)
-								.tokenType(NON_FUNGIBLE_UNIQUE)
-								.initialSupply(0L)
-								.treasury(tokenCollector)
-								.withCustom(royaltyFeeNoFallback(2, 1, tokenCollector))
-								.hasKnownStatus(ROYALTY_FRACTION_CANNOT_EXCEED_ONE),
-						tokenCreate(token)
-								.tokenType(NON_FUNGIBLE_UNIQUE)
-								.initialSupply(0L)
-								.treasury(tokenCollector)
-								.withCustom(royaltyFeeWithFallback(
-										1, 2,
-										fixedHbarFeeInheritingRoyaltyCollector(-100),
-										tokenCollector))
-								.hasKnownStatus(CUSTOM_FEE_MUST_BE_POSITIVE),
-						tokenCreate(token)
-								.tokenType(NON_FUNGIBLE_UNIQUE)
-								.initialSupply(0L)
-								.treasury(tokenCollector)
-								.withCustom(royaltyFeeWithFallback(
-										1, 2,
-										fixedHtsFeeInheritingRoyaltyCollector(100, "1.2.3"),
-										tokenCollector))
-								.hasKnownStatus(INVALID_TOKEN_ID_IN_CUSTOM_FEES),
-						tokenCreate(token)
-								.tokenType(NON_FUNGIBLE_UNIQUE)
-								.initialSupply(0L)
-								.treasury(htsCollector)
-								.withCustom(royaltyFeeWithFallback(
-										1, 2,
-										fixedHtsFeeInheritingRoyaltyCollector(100, feeDenom),
-										htsCollector)),
-						tokenCreate(token)
-								.treasury(tokenCollector)
-								.withCustom(fixedHbarFee(hbarAmount, hbarCollector))
-								.withCustom(fixedHtsFee(htsAmount, feeDenom, htsCollector))
-								.withCustom(fixedHtsFee(htsAmount, "0.0.0", htsCollector))
-								.withCustom(fractionalFee(
-										numerator, denominator,
-										minimumToCollect, OptionalLong.of(maximumToCollect),
-										tokenCollector))
-								.signedBy(DEFAULT_PAYER, tokenCollector, htsCollector)
-				).then(
-						getTokenInfo(token)
-								.hasCustom(fixedHbarFeeInSchedule(hbarAmount, hbarCollector))
-								.hasCustom(fixedHtsFeeInSchedule(htsAmount, feeDenom, htsCollector))
-								.hasCustom(fixedHtsFeeInSchedule(htsAmount, token, htsCollector))
-								.hasCustom(fractionalFeeInSchedule(
-										numerator, denominator,
-										minimumToCollect,
-										OptionalLong.of(maximumToCollect),
-										false,
-										tokenCollector))
-				);
-	}
+    public HapiApiSpec onlyValidCustomFeeScheduleCanBeCreated() {
+        return defaultHapiSpec("OnlyValidCustomFeeScheduleCanBeCreated")
+                .given(
+                        newKeyNamed(customFeesKey),
+                        cryptoCreate(htsCollector),
+                        cryptoCreate(hbarCollector),
+                        cryptoCreate(tokenCollector),
+                        tokenCreate(feeDenom).treasury(htsCollector))
+                .when(
+                        tokenCreate(token)
+                                .treasury(tokenCollector)
+                                .withCustom(
+                                        fractionalFee(
+                                                numerator,
+                                                0,
+                                                minimumToCollect,
+                                                OptionalLong.of(maximumToCollect),
+                                                tokenCollector))
+                                .hasKnownStatus(FRACTION_DIVIDES_BY_ZERO),
+                        tokenCreate(token)
+                                .treasury(tokenCollector)
+                                .withCustom(fixedHbarFee(hbarAmount, invalidEntityId))
+                                .hasKnownStatus(INVALID_CUSTOM_FEE_COLLECTOR),
+                        tokenCreate(token)
+                                .treasury(tokenCollector)
+                                .withCustom(fixedHtsFee(htsAmount, invalidEntityId, htsCollector))
+                                .hasKnownStatus(INVALID_TOKEN_ID_IN_CUSTOM_FEES),
+                        tokenCreate(token)
+                                .treasury(tokenCollector)
+                                .withCustom(fixedHtsFee(htsAmount, feeDenom, hbarCollector))
+                                .hasKnownStatus(TOKEN_NOT_ASSOCIATED_TO_FEE_COLLECTOR),
+                        tokenCreate(token)
+                                .treasury(tokenCollector)
+                                .withCustom(incompleteCustomFee(hbarCollector))
+                                .signedBy(DEFAULT_PAYER, tokenCollector, hbarCollector)
+                                .hasKnownStatus(CUSTOM_FEE_NOT_FULLY_SPECIFIED),
+                        tokenCreate(token)
+                                .treasury(tokenCollector)
+                                .withCustom(fixedHtsFee(negativeHtsFee, feeDenom, hbarCollector))
+                                .hasKnownStatus(CUSTOM_FEE_MUST_BE_POSITIVE),
+                        tokenCreate(token)
+                                .treasury(tokenCollector)
+                                .withCustom(
+                                        fractionalFee(
+                                                numerator,
+                                                -denominator,
+                                                minimumToCollect,
+                                                OptionalLong.of(maximumToCollect),
+                                                tokenCollector))
+                                .hasKnownStatus(CUSTOM_FEE_MUST_BE_POSITIVE),
+                        tokenCreate(token)
+                                .treasury(tokenCollector)
+                                .withCustom(
+                                        fractionalFee(
+                                                numerator,
+                                                denominator,
+                                                -minimumToCollect,
+                                                OptionalLong.of(maximumToCollect),
+                                                tokenCollector))
+                                .hasKnownStatus(CUSTOM_FEE_MUST_BE_POSITIVE),
+                        tokenCreate(token)
+                                .treasury(tokenCollector)
+                                .withCustom(
+                                        fractionalFee(
+                                                numerator,
+                                                denominator,
+                                                minimumToCollect,
+                                                OptionalLong.of(-maximumToCollect),
+                                                tokenCollector))
+                                .hasKnownStatus(CUSTOM_FEE_MUST_BE_POSITIVE),
+                        tokenCreate(token)
+                                .treasury(tokenCollector)
+                                .withCustom(
+                                        fractionalFee(
+                                                -numerator,
+                                                -denominator,
+                                                minimumToCollect,
+                                                OptionalLong.of(maximumToCollect),
+                                                tokenCollector))
+                                .hasKnownStatus(CUSTOM_FEE_MUST_BE_POSITIVE),
+                        tokenCreate(token)
+                                .treasury(tokenCollector)
+                                .withCustom(
+                                        fractionalFee(
+                                                numerator,
+                                                denominator,
+                                                minimumToCollect,
+                                                OptionalLong.of(minimumToCollect - 1),
+                                                tokenCollector))
+                                .hasKnownStatus(FRACTIONAL_FEE_MAX_AMOUNT_LESS_THAN_MIN_AMOUNT),
+                        tokenCreate(token)
+                                .treasury(tokenCollector)
+                                .withCustom(
+                                        fractionalFee(
+                                                numerator,
+                                                denominator,
+                                                minimumToCollect,
+                                                OptionalLong.of(minimumToCollect),
+                                                tokenCollector))
+                                .hasKnownStatus(SUCCESS),
+                        tokenCreate(token)
+                                .treasury(tokenCollector)
+                                .withCustom(royaltyFeeNoFallback(1, 2, tokenCollector))
+                                .hasKnownStatus(
+                                        CUSTOM_ROYALTY_FEE_ONLY_ALLOWED_FOR_NON_FUNGIBLE_UNIQUE),
+                        tokenCreate(token)
+                                .tokenType(NON_FUNGIBLE_UNIQUE)
+                                .supplyKey(GENESIS)
+                                .initialSupply(0L)
+                                .treasury(tokenCollector)
+                                .withCustom(royaltyFeeNoFallback(-1, 2, tokenCollector))
+                                .hasKnownStatus(CUSTOM_FEE_MUST_BE_POSITIVE),
+                        tokenCreate(token)
+                                .tokenType(NON_FUNGIBLE_UNIQUE)
+                                .supplyKey(GENESIS)
+                                .initialSupply(0L)
+                                .treasury(tokenCollector)
+                                .withCustom(royaltyFeeNoFallback(1, -2, tokenCollector))
+                                .hasKnownStatus(CUSTOM_FEE_MUST_BE_POSITIVE),
+                        tokenCreate(token)
+                                .tokenType(NON_FUNGIBLE_UNIQUE)
+                                .supplyKey(GENESIS)
+                                .initialSupply(0L)
+                                .treasury(tokenCollector)
+                                .withCustom(royaltyFeeNoFallback(1, 0, tokenCollector))
+                                .hasKnownStatus(FRACTION_DIVIDES_BY_ZERO),
+                        tokenCreate(token)
+                                .tokenType(NON_FUNGIBLE_UNIQUE)
+                                .supplyKey(GENESIS)
+                                .initialSupply(0L)
+                                .treasury(tokenCollector)
+                                .withCustom(royaltyFeeNoFallback(2, 1, tokenCollector))
+                                .hasKnownStatus(ROYALTY_FRACTION_CANNOT_EXCEED_ONE),
+                        tokenCreate(token)
+                                .tokenType(NON_FUNGIBLE_UNIQUE)
+                                .supplyKey(GENESIS)
+                                .initialSupply(0L)
+                                .treasury(tokenCollector)
+                                .withCustom(
+                                        royaltyFeeWithFallback(
+                                                1,
+                                                2,
+                                                fixedHbarFeeInheritingRoyaltyCollector(-100),
+                                                tokenCollector))
+                                .hasKnownStatus(CUSTOM_FEE_MUST_BE_POSITIVE),
+                        tokenCreate(token)
+                                .tokenType(NON_FUNGIBLE_UNIQUE)
+                                .supplyKey(GENESIS)
+                                .initialSupply(0L)
+                                .treasury(tokenCollector)
+                                .withCustom(
+                                        royaltyFeeWithFallback(
+                                                1,
+                                                2,
+                                                fixedHtsFeeInheritingRoyaltyCollector(100, "1.2.3"),
+                                                tokenCollector))
+                                .hasKnownStatus(INVALID_TOKEN_ID_IN_CUSTOM_FEES),
+                        tokenCreate(token)
+                                .tokenType(NON_FUNGIBLE_UNIQUE)
+                                .supplyKey(GENESIS)
+                                .initialSupply(0L)
+                                .treasury(htsCollector)
+                                .withCustom(
+                                        royaltyFeeWithFallback(
+                                                1,
+                                                2,
+                                                fixedHtsFeeInheritingRoyaltyCollector(
+                                                        100, feeDenom),
+                                                htsCollector)),
+                        tokenCreate(token)
+                                .treasury(tokenCollector)
+                                .withCustom(fixedHbarFee(hbarAmount, hbarCollector))
+                                .withCustom(fixedHtsFee(htsAmount, feeDenom, htsCollector))
+                                .withCustom(fixedHtsFee(htsAmount, "0.0.0", htsCollector))
+                                .withCustom(
+                                        fractionalFee(
+                                                numerator,
+                                                denominator,
+                                                minimumToCollect,
+                                                OptionalLong.of(maximumToCollect),
+                                                tokenCollector))
+                                .signedBy(DEFAULT_PAYER, tokenCollector, htsCollector))
+                .then(
+                        getTokenInfo(token)
+                                .hasCustom(fixedHbarFeeInSchedule(hbarAmount, hbarCollector))
+                                .hasCustom(fixedHtsFeeInSchedule(htsAmount, feeDenom, htsCollector))
+                                .hasCustom(fixedHtsFeeInSchedule(htsAmount, token, htsCollector))
+                                .hasCustom(
+                                        fractionalFeeInSchedule(
+                                                numerator,
+                                                denominator,
+                                                minimumToCollect,
+                                                OptionalLong.of(maximumToCollect),
+                                                false,
+                                                tokenCollector)));
+    }
 
-	private HapiApiSpec feeCollectorSigningReqsWorkForTokenCreate() {
-		return defaultHapiSpec("FeeCollectorSigningReqsEnforced")
-				.given(
-						newKeyNamed(customFeesKey),
-						cryptoCreate(htsCollector).receiverSigRequired(true),
-						cryptoCreate(hbarCollector),
-						cryptoCreate(tokenCollector),
-						cryptoCreate(TOKEN_TREASURY),
-						tokenCreate(feeDenom).treasury(htsCollector)
-				).when(
-						tokenCreate(token)
-								.treasury(TOKEN_TREASURY)
-								.withCustom(fractionalFee(
-										numerator, 0,
-										minimumToCollect, OptionalLong.of(maximumToCollect),
-										tokenCollector))
-								.hasKnownStatus(INVALID_SIGNATURE),
-						tokenCreate(token)
-								.treasury(TOKEN_TREASURY)
-								.withCustom(fixedHtsFee(htsAmount, feeDenom, htsCollector))
-								.hasKnownStatus(INVALID_SIGNATURE),
-						tokenCreate(token)
-								.treasury(TOKEN_TREASURY)
-								.withCustom(fractionalFee(
-										numerator, -denominator,
-										minimumToCollect, OptionalLong.of(maximumToCollect),
-										tokenCollector))
-								.hasKnownStatus(INVALID_SIGNATURE),
-						tokenCreate(token)
-								.treasury(TOKEN_TREASURY)
-								.withCustom(fixedHbarFee(hbarAmount, hbarCollector))
-								.withCustom(fixedHtsFee(htsAmount, feeDenom, htsCollector))
-								.withCustom(fractionalFee(
-										numerator, denominator,
-										minimumToCollect, OptionalLong.of(maximumToCollect),
-										tokenCollector))
-								.signedBy(DEFAULT_PAYER, TOKEN_TREASURY, htsCollector, tokenCollector)
-				).then(
-						getTokenInfo(token)
-								.hasCustom(fixedHbarFeeInSchedule(hbarAmount, hbarCollector))
-								.hasCustom(fixedHtsFeeInSchedule(htsAmount, feeDenom, htsCollector))
-								.hasCustom(fractionalFeeInSchedule(
-										numerator, denominator,
-										minimumToCollect, OptionalLong.of(maximumToCollect), false,
-										tokenCollector)),
-						getAccountInfo(tokenCollector).hasToken(relationshipWith(token)),
-						getAccountInfo(hbarCollector).hasNoTokenRelationship(token),
-						getAccountInfo(htsCollector).hasNoTokenRelationship(token)
-				);
-	}
+    private HapiApiSpec feeCollectorSigningReqsWorkForTokenCreate() {
+        return defaultHapiSpec("FeeCollectorSigningReqsEnforced")
+                .given(
+                        newKeyNamed(customFeesKey),
+                        cryptoCreate(htsCollector).receiverSigRequired(true),
+                        cryptoCreate(hbarCollector),
+                        cryptoCreate(tokenCollector),
+                        cryptoCreate(TOKEN_TREASURY),
+                        tokenCreate(feeDenom).treasury(htsCollector))
+                .when(
+                        tokenCreate(token)
+                                .treasury(TOKEN_TREASURY)
+                                .withCustom(
+                                        fractionalFee(
+                                                numerator,
+                                                0,
+                                                minimumToCollect,
+                                                OptionalLong.of(maximumToCollect),
+                                                tokenCollector))
+                                .hasKnownStatus(INVALID_SIGNATURE),
+                        tokenCreate(token)
+                                .treasury(TOKEN_TREASURY)
+                                .withCustom(fixedHtsFee(htsAmount, feeDenom, htsCollector))
+                                .hasKnownStatus(INVALID_SIGNATURE),
+                        tokenCreate(token)
+                                .treasury(TOKEN_TREASURY)
+                                .withCustom(
+                                        fractionalFee(
+                                                numerator,
+                                                -denominator,
+                                                minimumToCollect,
+                                                OptionalLong.of(maximumToCollect),
+                                                tokenCollector))
+                                .hasKnownStatus(INVALID_SIGNATURE),
+                        tokenCreate(token)
+                                .treasury(TOKEN_TREASURY)
+                                .withCustom(fixedHbarFee(hbarAmount, hbarCollector))
+                                .withCustom(fixedHtsFee(htsAmount, feeDenom, htsCollector))
+                                .withCustom(
+                                        fractionalFee(
+                                                numerator,
+                                                denominator,
+                                                minimumToCollect,
+                                                OptionalLong.of(maximumToCollect),
+                                                tokenCollector))
+                                .signedBy(
+                                        DEFAULT_PAYER,
+                                        TOKEN_TREASURY,
+                                        htsCollector,
+                                        tokenCollector))
+                .then(
+                        getTokenInfo(token)
+                                .hasCustom(fixedHbarFeeInSchedule(hbarAmount, hbarCollector))
+                                .hasCustom(fixedHtsFeeInSchedule(htsAmount, feeDenom, htsCollector))
+                                .hasCustom(
+                                        fractionalFeeInSchedule(
+                                                numerator,
+                                                denominator,
+                                                minimumToCollect,
+                                                OptionalLong.of(maximumToCollect),
+                                                false,
+                                                tokenCollector)),
+                        getAccountInfo(tokenCollector).hasToken(relationshipWith(token)),
+                        getAccountInfo(hbarCollector).hasNoTokenRelationship(token),
+                        getAccountInfo(htsCollector).hasNoTokenRelationship(token));
+    }
 
-	public HapiApiSpec creationValidatesName() {
-		AtomicInteger maxUtf8Bytes = new AtomicInteger();
+    public HapiApiSpec creationValidatesName() {
+        AtomicInteger maxUtf8Bytes = new AtomicInteger();
 
-		return defaultHapiSpec("CreationValidatesName")
-				.given(
-						cryptoCreate(TOKEN_TREASURY).balance(0L),
-						recordSystemProperty("tokens.maxTokenNameUtf8Bytes", Integer::parseInt, maxUtf8Bytes::set)
-				).when().then(
-						tokenCreate("primary")
-								.name("")
-								.logged()
-								.hasPrecheck(MISSING_TOKEN_NAME),
-						tokenCreate("primary")
-								.name("T\u0000ken")
-								.logged()
-								.hasPrecheck(INVALID_ZERO_BYTE_IN_STRING),
-						sourcing(() -> tokenCreate("tooLong")
-								.name(TxnUtils.nAscii(maxUtf8Bytes.get() + 1))
-								.hasPrecheck(TOKEN_NAME_TOO_LONG)),
-						sourcing(() -> tokenCreate("tooLongAgain")
-								.name(nCurrencySymbols(maxUtf8Bytes.get() / 3 + 1))
-								.hasPrecheck(TOKEN_NAME_TOO_LONG))
-				);
-	}
+        return defaultHapiSpec("CreationValidatesName")
+                .given(
+                        cryptoCreate(TOKEN_TREASURY).balance(0L),
+                        recordSystemProperty(
+                                "tokens.maxTokenNameUtf8Bytes",
+                                Integer::parseInt,
+                                maxUtf8Bytes::set))
+                .when()
+                .then(
+                        tokenCreate("primary").name("").logged().hasPrecheck(MISSING_TOKEN_NAME),
+                        tokenCreate("primary")
+                                .name("T\u0000ken")
+                                .logged()
+                                .hasPrecheck(INVALID_ZERO_BYTE_IN_STRING),
+                        sourcing(
+                                () ->
+                                        tokenCreate("tooLong")
+                                                .name(TxnUtils.nAscii(maxUtf8Bytes.get() + 1))
+                                                .hasPrecheck(TOKEN_NAME_TOO_LONG)),
+                        sourcing(
+                                () ->
+                                        tokenCreate("tooLongAgain")
+                                                .name(nCurrencySymbols(maxUtf8Bytes.get() / 3 + 1))
+                                                .hasPrecheck(TOKEN_NAME_TOO_LONG)));
+    }
 
+    public HapiApiSpec creationValidatesSymbol() {
+        AtomicInteger maxUtf8Bytes = new AtomicInteger();
 
-	public HapiApiSpec creationValidatesSymbol() {
-		AtomicInteger maxUtf8Bytes = new AtomicInteger();
+        return defaultHapiSpec("CreationValidatesSymbol")
+                .given(
+                        cryptoCreate(TOKEN_TREASURY).balance(0L),
+                        recordSystemProperty(
+                                "tokens.maxSymbolUtf8Bytes", Integer::parseInt, maxUtf8Bytes::set))
+                .when()
+                .then(
+                        tokenCreate("missingSymbol").symbol("").hasPrecheck(MISSING_TOKEN_SYMBOL),
+                        tokenCreate("primary")
+                                .name("T\u0000ken")
+                                .logged()
+                                .hasPrecheck(INVALID_ZERO_BYTE_IN_STRING),
+                        sourcing(
+                                () ->
+                                        tokenCreate("tooLong")
+                                                .symbol(TxnUtils.nAscii(maxUtf8Bytes.get() + 1))
+                                                .hasPrecheck(TOKEN_SYMBOL_TOO_LONG)),
+                        sourcing(
+                                () ->
+                                        tokenCreate("tooLongAgain")
+                                                .symbol(
+                                                        nCurrencySymbols(
+                                                                maxUtf8Bytes.get() / 3 + 1))
+                                                .hasPrecheck(TOKEN_SYMBOL_TOO_LONG)));
+    }
 
-		return defaultHapiSpec("CreationValidatesSymbol")
-				.given(
-						cryptoCreate(TOKEN_TREASURY).balance(0L),
-						recordSystemProperty("tokens.maxSymbolUtf8Bytes", Integer::parseInt, maxUtf8Bytes::set)
-				).when().then(
-						tokenCreate("missingSymbol")
-								.symbol("")
-								.hasPrecheck(MISSING_TOKEN_SYMBOL),
-						tokenCreate("primary")
-								.name("T\u0000ken")
-								.logged()
-								.hasPrecheck(INVALID_ZERO_BYTE_IN_STRING),
-						sourcing(() -> tokenCreate("tooLong")
-								.symbol(TxnUtils.nAscii(maxUtf8Bytes.get() + 1))
-								.hasPrecheck(TOKEN_SYMBOL_TOO_LONG)),
-						sourcing(() -> tokenCreate("tooLongAgain")
-								.symbol(nCurrencySymbols(maxUtf8Bytes.get() / 3 + 1))
-								.hasPrecheck(TOKEN_SYMBOL_TOO_LONG))
-				);
-	}
+    private String nCurrencySymbols(int n) {
+        return IntStream.range(0, n).mapToObj(ignore -> "€").collect(Collectors.joining());
+    }
 
-	private String nCurrencySymbols(int n) {
-		return IntStream.range(0, n).mapToObj(ignore -> "€").collect(Collectors.joining());
-	}
+    public HapiApiSpec creationRequiresAppropriateSigs() {
+        return defaultHapiSpec("CreationRequiresAppropriateSigs")
+                .given(
+                        cryptoCreate("payer").balance(ONE_HUNDRED_HBARS),
+                        cryptoCreate(TOKEN_TREASURY).balance(0L),
+                        newKeyNamed("adminKey"))
+                .when()
+                .then(
+                        tokenCreate("shouldntWork")
+                                .treasury(TOKEN_TREASURY)
+                                .payingWith("payer")
+                                .adminKey("adminKey")
+                                .signedBy("payer")
+                                .hasKnownStatus(INVALID_SIGNATURE),
+                        /* treasury must sign */
+                        tokenCreate("shouldntWorkEither")
+                                .treasury(TOKEN_TREASURY)
+                                .payingWith("payer")
+                                .adminKey("adminKey")
+                                .signedBy("payer", "adminKey")
+                                .hasKnownStatus(INVALID_SIGNATURE));
+    }
 
-	public HapiApiSpec creationRequiresAppropriateSigs() {
-		return defaultHapiSpec("CreationRequiresAppropriateSigs")
-				.given(
-						cryptoCreate("payer").balance(ONE_HUNDRED_HBARS),
-						cryptoCreate(TOKEN_TREASURY).balance(0L),
-						newKeyNamed("adminKey")
-				).when().then(
-						tokenCreate("shouldntWork")
-								.treasury(TOKEN_TREASURY)
-								.payingWith("payer")
-								.adminKey("adminKey")
-								.signedBy("payer")
-								.hasKnownStatus(INVALID_SIGNATURE),
-						/* treasury must sign */
-						tokenCreate("shouldntWorkEither")
-								.treasury(TOKEN_TREASURY)
-								.payingWith("payer")
-								.adminKey("adminKey")
-								.signedBy("payer", "adminKey")
-								.hasKnownStatus(INVALID_SIGNATURE)
-				);
-	}
+    public HapiApiSpec creationRequiresAppropriateSigsHappyPath() {
+        return defaultHapiSpec("CreationRequiresAppropriateSigsHappyPath")
+                .given(
+                        cryptoCreate("payer"),
+                        cryptoCreate(TOKEN_TREASURY).balance(0L),
+                        newKeyNamed("adminKey"))
+                .when()
+                .then(
+                        tokenCreate("shouldWork")
+                                .treasury(TOKEN_TREASURY)
+                                .payingWith("payer")
+                                .adminKey("adminKey")
+                                .signedBy(TOKEN_TREASURY, "payer", "adminKey")
+                                .hasKnownStatus(SUCCESS));
+    }
 
-	public HapiApiSpec creationRequiresAppropriateSigsHappyPath() {
-		return defaultHapiSpec("CreationRequiresAppropriateSigsHappyPath")
-				.given(
-						cryptoCreate("payer"),
-						cryptoCreate(TOKEN_TREASURY).balance(0L),
-						newKeyNamed("adminKey")
-				).when().then(
-						tokenCreate("shouldWork")
-								.treasury(TOKEN_TREASURY)
-								.payingWith("payer")
-								.adminKey("adminKey")
-								.signedBy(TOKEN_TREASURY, "payer", "adminKey")
-								.hasKnownStatus(SUCCESS)
-				);
-	}
+    public HapiApiSpec creationValidatesTreasuryAccount() {
+        return defaultHapiSpec("CreationValidatesTreasuryAccount")
+                .given(cryptoCreate(TOKEN_TREASURY).balance(0L))
+                .when(cryptoDelete(TOKEN_TREASURY))
+                .then(
+                        tokenCreate("shouldntWork")
+                                .treasury(TOKEN_TREASURY)
+                                .hasKnownStatus(INVALID_TREASURY_ACCOUNT_FOR_TOKEN));
+    }
 
-	public HapiApiSpec creationValidatesTreasuryAccount() {
-		return defaultHapiSpec("CreationValidatesTreasuryAccount")
-				.given(
-						cryptoCreate(TOKEN_TREASURY).balance(0L)
-				).when(
-						cryptoDelete(TOKEN_TREASURY)
-				).then(
-						tokenCreate("shouldntWork")
-								.treasury(TOKEN_TREASURY)
-								.hasKnownStatus(INVALID_TREASURY_ACCOUNT_FOR_TOKEN)
-				);
-	}
+    public HapiApiSpec initialSupplyMustBeSane() {
+        return defaultHapiSpec("InitialSupplyMustBeSane")
+                .given()
+                .when()
+                .then(
+                        tokenCreate("sinking")
+                                .initialSupply(-1L)
+                                .hasPrecheck(INVALID_TOKEN_INITIAL_SUPPLY),
+                        tokenCreate("bad decimals")
+                                .decimals(-1)
+                                .hasPrecheck(INVALID_TOKEN_DECIMALS),
+                        tokenCreate("bad decimals")
+                                .decimals(1 << 31)
+                                .hasPrecheck(INVALID_TOKEN_DECIMALS),
+                        tokenCreate("bad initial supply")
+                                .initialSupply(1L << 63)
+                                .hasPrecheck(INVALID_TOKEN_INITIAL_SUPPLY));
+    }
 
-	public HapiApiSpec initialSupplyMustBeSane() {
-		return defaultHapiSpec("InitialSupplyMustBeSane")
-				.given().when().then(
-						tokenCreate("sinking")
-								.initialSupply(-1L)
-								.hasPrecheck(INVALID_TOKEN_INITIAL_SUPPLY),
-						tokenCreate("bad decimals")
-								.decimals(-1)
-								.hasPrecheck(INVALID_TOKEN_DECIMALS),
-						tokenCreate("bad decimals")
-								.decimals(1 << 31)
-								.hasPrecheck(INVALID_TOKEN_DECIMALS),
-						tokenCreate("bad initial supply")
-								.initialSupply(1L << 63)
-								.hasPrecheck(INVALID_TOKEN_INITIAL_SUPPLY)
-				);
-	}
+    public HapiApiSpec treasuryHasCorrectBalance() {
+        String token = salted("myToken");
 
-	public HapiApiSpec treasuryHasCorrectBalance() {
-		String token = salted("myToken");
+        int decimals = 1;
+        long initialSupply = 100_000;
 
-		int decimals = 1;
-		long initialSupply = 100_000;
+        return defaultHapiSpec("TreasuryHasCorrectBalance")
+                .given(cryptoCreate(TOKEN_TREASURY).balance(1L))
+                .when(
+                        tokenCreate(token)
+                                .treasury(TOKEN_TREASURY)
+                                .decimals(decimals)
+                                .initialSupply(initialSupply))
+                .then(
+                        getAccountBalance(TOKEN_TREASURY)
+                                .hasTinyBars(1L)
+                                .hasTokenBalance(token, initialSupply));
+    }
 
-		return defaultHapiSpec("TreasuryHasCorrectBalance")
-				.given(
-						cryptoCreate(TOKEN_TREASURY).balance(1L)
-				).when(
-						tokenCreate(token)
-								.treasury(TOKEN_TREASURY)
-								.decimals(decimals)
-								.initialSupply(initialSupply)
-				).then(
-						getAccountBalance(TOKEN_TREASURY)
-								.hasTinyBars(1L)
-								.hasTokenBalance(token, initialSupply)
-				);
-	}
+    private HapiApiSpec prechecksWork() {
+        return defaultHapiSpec("PrechecksWork")
+                .given(
+                        cryptoCreate(TOKEN_TREASURY).balance(0L),
+                        cryptoCreate(FIRST_USER).balance(0L))
+                .when(
+                        tokenCreate(A_TOKEN).initialSupply(100).treasury(TOKEN_TREASURY),
+                        tokenCreate(B_TOKEN).initialSupply(100).treasury(TOKEN_TREASURY))
+                .then(
+                        cryptoTransfer(
+                                        moving(1, A_TOKEN).between(TOKEN_TREASURY, FIRST_USER),
+                                        moving(1, A_TOKEN).between(TOKEN_TREASURY, FIRST_USER))
+                                .dontFullyAggregateTokenTransfers()
+                                .hasPrecheck(ACCOUNT_REPEATED_IN_ACCOUNT_AMOUNTS),
+                        cryptoTransfer(
+                                        movingHbar(1).between(TOKEN_TREASURY, FIRST_USER),
+                                        movingHbar(1).between(TOKEN_TREASURY, FIRST_USER))
+                                .dontFullyAggregateTokenTransfers()
+                                .hasPrecheck(ACCOUNT_REPEATED_IN_ACCOUNT_AMOUNTS),
+                        cryptoTransfer(
+                                        moving(1, A_TOKEN).between(TOKEN_TREASURY, FIRST_USER),
+                                        moving(1, A_TOKEN).between(TOKEN_TREASURY, FIRST_USER))
+                                .dontFullyAggregateTokenTransfers()
+                                .hasPrecheck(ACCOUNT_REPEATED_IN_ACCOUNT_AMOUNTS),
+                        cryptoTransfer(moving(0, A_TOKEN).between(TOKEN_TREASURY, FIRST_USER))
+                                .hasPrecheck(INVALID_ACCOUNT_AMOUNTS),
+                        cryptoTransfer(moving(10, A_TOKEN).from(TOKEN_TREASURY))
+                                .hasPrecheck(TRANSFERS_NOT_ZERO_SUM_FOR_TOKEN),
+                        cryptoTransfer(moving(10, A_TOKEN).empty())
+                                .hasPrecheck(EMPTY_TOKEN_TRANSFER_ACCOUNT_AMOUNTS));
+    }
 
-	private HapiApiSpec prechecksWork() {
-		return defaultHapiSpec("PrechecksWork")
-				.given(
-						cryptoCreate(TOKEN_TREASURY).balance(0L),
-						cryptoCreate(FIRST_USER).balance(0L)
-				).when(
-						tokenCreate(A_TOKEN)
-								.initialSupply(100)
-								.treasury(TOKEN_TREASURY),
-						tokenCreate(B_TOKEN)
-								.initialSupply(100)
-								.treasury(TOKEN_TREASURY)
-				).then(
-						cryptoTransfer(
-								moving(1, A_TOKEN)
-										.between(TOKEN_TREASURY, FIRST_USER),
-								moving(1, A_TOKEN)
-										.between(TOKEN_TREASURY, FIRST_USER))
-								.dontFullyAggregateTokenTransfers()
-								.hasPrecheck(ACCOUNT_REPEATED_IN_ACCOUNT_AMOUNTS),
-						cryptoTransfer(
-								movingHbar(1)
-										.between(TOKEN_TREASURY, FIRST_USER),
-								movingHbar(1)
-										.between(TOKEN_TREASURY, FIRST_USER))
-								.dontFullyAggregateTokenTransfers()
-								.hasPrecheck(ACCOUNT_REPEATED_IN_ACCOUNT_AMOUNTS),
-						cryptoTransfer(
-								moving(1, A_TOKEN)
-										.between(TOKEN_TREASURY, FIRST_USER),
-								moving(1, A_TOKEN)
-										.between(TOKEN_TREASURY, FIRST_USER))
-								.dontFullyAggregateTokenTransfers()
-								.hasPrecheck(ACCOUNT_REPEATED_IN_ACCOUNT_AMOUNTS),
-						cryptoTransfer(
-								moving(0, A_TOKEN)
-										.between(TOKEN_TREASURY, FIRST_USER)
-						).hasPrecheck(INVALID_ACCOUNT_AMOUNTS),
-						cryptoTransfer(
-								moving(10, A_TOKEN)
-										.from(TOKEN_TREASURY)
-						).hasPrecheck(TRANSFERS_NOT_ZERO_SUM_FOR_TOKEN),
-						cryptoTransfer(
-								moving(10, A_TOKEN)
-										.empty()
-						).hasPrecheck(EMPTY_TOKEN_TRANSFER_ACCOUNT_AMOUNTS)
-				);
-	}
+    @Override
+    protected Logger getResultsLogger() {
+        return log;
+    }
 
-	@Override
-	protected Logger getResultsLogger() {
-		return log;
-	}
-
-	private final long hbarAmount = 1_234L;
-	private final long htsAmount = 2_345L;
-	private final long numerator = 1;
-	private final long denominator = 10;
-	private final long minimumToCollect = 5;
-	private final long maximumToCollect = 50;
-	private final String token = "withCustomSchedules";
-	private final String feeDenom = "denom";
-	private final String hbarCollector = "hbarFee";
-	private final String htsCollector = "denomFee";
-	private final String tokenCollector = "fractionalFee";
-	private final String invalidEntityId = "1.2.786";
-	private final long negativeHtsFee = -100L;
-	private final String customFeesKey = "antique";
+    private final long hbarAmount = 1_234L;
+    private final long htsAmount = 2_345L;
+    private final long numerator = 1;
+    private final long denominator = 10;
+    private final long minimumToCollect = 5;
+    private final long maximumToCollect = 50;
+    private final String token = "withCustomSchedules";
+    private final String feeDenom = "denom";
+    private final String hbarCollector = "hbarFee";
+    private final String htsCollector = "denomFee";
+    private final String tokenCollector = "fractionalFee";
+    private final String invalidEntityId = "1.2.786";
+    private final long negativeHtsFee = -100L;
+    private final String customFeesKey = "antique";
 }

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenPauseSpecs.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenPauseSpecs.java
@@ -478,6 +478,7 @@ public final class TokenPauseSpecs extends HapiApiSuite {
                                 .treasury(TOKEN_TREASURY),
                         tokenCreate(NON_FUNGIBLE_UNIQUE_PRIMARY)
                                 .tokenType(NON_FUNGIBLE_UNIQUE)
+                                .supplyKey(SUPPLY_KEY)
                                 .supplyType(TokenSupplyType.FINITE)
                                 .initialSupply(0)
                                 .maxSupply(100)


### PR DESCRIPTION
Signed-off-by: Neeharika-Sompalli <neeharika.sompalli@hedera.com>

Fixes #3698 

- Added a precheck for `TokenCreateTransitionLogic`  to validate supply key exusts if the `tokenType` is `NON_FUNGIBLE_UNIQUE`