### PR TITLE
Skip treasury clones in the `0.0.350-399` range

### DIFF
--- a/hedera-node/src/main/java/com/hedera/services/ServicesState.java
+++ b/hedera-node/src/main/java/com/hedera/services/ServicesState.java
@@ -296,9 +296,7 @@ public class ServicesState extends PartialNaryMerkleInternal
             if (trigger == RESTART) {
                 networkCtx().discardPreparedUpgradeMeta();
                 dualState.setFreezeTime(null);
-                // By default, don't (re-)stream migration records on a patch release; this will
-                // almost always be the desired behavior, though exceptions are conceivable
-                if (deployedVersion.isNonPatchUpgradeFrom(deserializedVersion)) {
+                if (deployedVersion.hasMigrationRecordsFrom(deserializedVersion)) {
                     networkCtx().markMigrationRecordsNotYetStreamed();
                 }
             }

--- a/hedera-node/src/main/java/com/hedera/services/config/HederaNumbers.java
+++ b/hedera-node/src/main/java/com/hedera/services/config/HederaNumbers.java
@@ -26,6 +26,8 @@ import javax.inject.Singleton;
 public class HederaNumbers {
     public static final long NUM_RESERVED_SYSTEM_ENTITIES = 750L;
     public static final long FIRST_POST_SYSTEM_FILE_ENTITY = 200L;
+    public static final long FIRST_RESERVED_SYSTEM_CONTRACT = 350L;
+    public static final long LAST_RESERVED_SYSTEM_CONTRACT = 399L;
 
     private final PropertySource properties;
 

--- a/hedera-node/src/main/java/com/hedera/services/context/properties/SerializableSemVers.java
+++ b/hedera-node/src/main/java/com/hedera/services/context/properties/SerializableSemVers.java
@@ -29,7 +29,7 @@ import org.jetbrains.annotations.NotNull;
 
 public class SerializableSemVers implements SoftwareVersion {
     private static final String IS_INCOMPARABLE_MSG = " cannot be compared to ";
-    private static boolean CURRENT_VERSION_HAS_PATCH_MIGRATION_RECORDS = false;
+    private static boolean currentVersionHasPatchMigrationRecords = false;
     public static final int RELEASE_027_VERSION = 1;
     public static final long CLASS_ID = 0x6f2b1bc2df8cbd0bL;
 
@@ -96,7 +96,7 @@ public class SerializableSemVers implements SoftwareVersion {
 
     public boolean hasMigrationRecordsFrom(@Nullable final SoftwareVersion other) {
         return isNonPatchUpgradeFrom(other)
-                || (this.isAfter(other) && CURRENT_VERSION_HAS_PATCH_MIGRATION_RECORDS);
+                || (this.isAfter(other) && currentVersionHasPatchMigrationRecords);
     }
 
     @VisibleForTesting
@@ -218,6 +218,6 @@ public class SerializableSemVers implements SoftwareVersion {
     @VisibleForTesting
     static void setCurrentVersionHasPatchMigrationRecords(
             boolean currentVersionHasPatchMigrationRecords) {
-        CURRENT_VERSION_HAS_PATCH_MIGRATION_RECORDS = currentVersionHasPatchMigrationRecords;
+        SerializableSemVers.currentVersionHasPatchMigrationRecords = currentVersionHasPatchMigrationRecords;
     }
 }

--- a/hedera-node/src/main/java/com/hedera/services/context/properties/SerializableSemVers.java
+++ b/hedera-node/src/main/java/com/hedera/services/context/properties/SerializableSemVers.java
@@ -218,6 +218,7 @@ public class SerializableSemVers implements SoftwareVersion {
     @VisibleForTesting
     static void setCurrentVersionHasPatchMigrationRecords(
             boolean currentVersionHasPatchMigrationRecords) {
-        SerializableSemVers.currentVersionHasPatchMigrationRecords = currentVersionHasPatchMigrationRecords;
+        SerializableSemVers.currentVersionHasPatchMigrationRecords =
+                currentVersionHasPatchMigrationRecords;
     }
 }

--- a/hedera-node/src/main/java/com/hedera/services/context/properties/SerializableSemVers.java
+++ b/hedera-node/src/main/java/com/hedera/services/context/properties/SerializableSemVers.java
@@ -1,24 +1,19 @@
-package com.hedera.services.context.properties;
-
-/*-
- * ‌
- * Hedera Services Node
- * ​
- * Copyright (C) 2018 - 2022 Hedera Hashgraph, LLC
- * ​
+/*
+ * Copyright (C) 2022 Hedera Hashgraph, LLC
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- * ‍
  */
+package com.hedera.services.context.properties;
 
 import static com.hedera.services.context.properties.SemanticVersions.asSemVer;
 
@@ -33,193 +28,196 @@ import javax.annotation.Nullable;
 import org.jetbrains.annotations.NotNull;
 
 public class SerializableSemVers implements SoftwareVersion {
-	private static final String IS_INCOMPARABLE_MSG = " cannot be compared to ";
-	private static boolean CURRENT_VERSION_HAS_PATCH_MIGRATION_RECORDS = false;
-	public static final int RELEASE_027_VERSION = 1;
-	public static final long CLASS_ID = 0x6f2b1bc2df8cbd0bL;
+    private static final String IS_INCOMPARABLE_MSG = " cannot be compared to ";
+    private static boolean CURRENT_VERSION_HAS_PATCH_MIGRATION_RECORDS = false;
+    public static final int RELEASE_027_VERSION = 1;
+    public static final long CLASS_ID = 0x6f2b1bc2df8cbd0bL;
 
-	public static final Comparator<SemanticVersion> SEM_VER_COMPARATOR =
-			Comparator.comparingInt(SemanticVersion::getMajor)
-					.thenComparingInt(SemanticVersion::getMinor)
-					.thenComparingInt(SemanticVersion::getPatch)
-					// We never deploy versions with `pre` or `build` parts to prod envs,
-					// so just give precedence to the version that doesn't have one
-					.thenComparingInt(semver -> semver.getPre().isBlank() ? 1 : 0)
-					.thenComparingInt(semver -> semver.getBuild().isBlank() ? 1 : 0);
-	public static final Comparator<SerializableSemVers> FULL_COMPARATOR =
-			Comparator.comparing(SerializableSemVers::getServices, SEM_VER_COMPARATOR)
-					.thenComparing(SerializableSemVers::getProto, SEM_VER_COMPARATOR);
+    public static final Comparator<SemanticVersion> SEM_VER_COMPARATOR =
+            Comparator.comparingInt(SemanticVersion::getMajor)
+                    .thenComparingInt(SemanticVersion::getMinor)
+                    .thenComparingInt(SemanticVersion::getPatch)
+                    // We never deploy versions with `pre` or `build` parts to prod envs,
+                    // so just give precedence to the version that doesn't have one
+                    .thenComparingInt(semver -> semver.getPre().isBlank() ? 1 : 0)
+                    .thenComparingInt(semver -> semver.getBuild().isBlank() ? 1 : 0);
+    public static final Comparator<SerializableSemVers> FULL_COMPARATOR =
+            Comparator.comparing(SerializableSemVers::getServices, SEM_VER_COMPARATOR)
+                    .thenComparing(SerializableSemVers::getProto, SEM_VER_COMPARATOR);
 
-	private SemanticVersion proto;
-	private SemanticVersion services;
+    private SemanticVersion proto;
+    private SemanticVersion services;
 
-	public SerializableSemVers() {
-		// RuntimeConstructable
-	}
+    public SerializableSemVers() {
+        // RuntimeConstructable
+    }
 
-	public SemanticVersion getProto() {
-		return proto;
-	}
+    public SemanticVersion getProto() {
+        return proto;
+    }
 
-	public SemanticVersion getServices() {
-		return services;
-	}
+    public SemanticVersion getServices() {
+        return services;
+    }
 
-	public SerializableSemVers(@NotNull final SemanticVersion proto, @NotNull final SemanticVersion services) {
-		this.proto = proto;
-		this.services = services;
-	}
+    public SerializableSemVers(
+            @NotNull final SemanticVersion proto, @NotNull final SemanticVersion services) {
+        this.proto = proto;
+        this.services = services;
+    }
 
-	public static SerializableSemVers forHapiAndHedera(@NotNull final String proto, @NotNull final String services) {
-		return new SerializableSemVers(asSemVer(proto), asSemVer(services));
-	}
+    public static SerializableSemVers forHapiAndHedera(
+            @NotNull final String proto, @NotNull final String services) {
+        return new SerializableSemVers(asSemVer(proto), asSemVer(services));
+    }
 
-	@Override
-	public long getClassId() {
-		return CLASS_ID;
-	}
+    @Override
+    public long getClassId() {
+        return CLASS_ID;
+    }
 
+    @Override
+    public int getVersion() {
+        return RELEASE_027_VERSION;
+    }
 
-	@Override
-	public int getVersion() {
-		return RELEASE_027_VERSION;
-	}
+    @Override
+    public int getMinimumSupportedVersion() {
+        return RELEASE_027_VERSION;
+    }
 
-	@Override
-	public int getMinimumSupportedVersion() {
-		return RELEASE_027_VERSION;
-	}
+    public boolean isAfter(@Nullable final SoftwareVersion other) {
+        return compareTo(other) > 0;
+    }
 
-	public boolean isAfter(@Nullable final SoftwareVersion other) {
-		return compareTo(other) > 0;
-	}
+    public boolean isBefore(@Nullable final SoftwareVersion other) {
+        return compareTo(other) < 0;
+    }
 
-	public boolean isBefore(@Nullable final SoftwareVersion other) {
-		return compareTo(other) < 0;
-	}
+    public boolean hasMigrationRecordsFrom(@Nullable final SoftwareVersion other) {
+        return isNonPatchUpgradeFrom(other)
+                || (this.isAfter(other) && CURRENT_VERSION_HAS_PATCH_MIGRATION_RECORDS);
+    }
 
-	public boolean hasMigrationRecordsFrom(@Nullable final SoftwareVersion other) {
-		return isNonPatchUpgradeFrom(other) || (this.isAfter(other) && CURRENT_VERSION_HAS_PATCH_MIGRATION_RECORDS);
-	}
+    @VisibleForTesting
+    boolean isNonPatchUpgradeFrom(@Nullable final SoftwareVersion other) {
+        if (other == null) {
+            return true;
+        }
+        if (other instanceof SerializableSemVers that) {
+            return this.isAfter(that) && haveDifferentMajorAndMinorVersions(this, that);
+        } else {
+            throw new IllegalArgumentException("Version " + this + IS_INCOMPARABLE_MSG + other);
+        }
+    }
 
-	@VisibleForTesting
-	boolean isNonPatchUpgradeFrom(@Nullable final SoftwareVersion other) {
-		if (other == null) {
-			return true;
-		}
-		if (other instanceof SerializableSemVers that) {
-			return this.isAfter(that) && haveDifferentMajorAndMinorVersions(this, that);
-		} else {
-			throw new IllegalArgumentException("Version " + this + IS_INCOMPARABLE_MSG + other);
-		}
-	}
+    private boolean haveDifferentMajorAndMinorVersions(
+            @NotNull final SerializableSemVers a, @NotNull final SerializableSemVers b) {
+        return a.services.getMajor() != b.services.getMajor()
+                || a.services.getMinor() != b.services.getMinor();
+    }
 
-	private boolean haveDifferentMajorAndMinorVersions(
-			@NotNull final SerializableSemVers a,
-			@NotNull final SerializableSemVers b
-	) {
-		return a.services.getMajor() != b.services.getMajor() ||
-				a.services.getMinor() != b.services.getMinor();
-	}
+    @Override
+    public int compareTo(@Nullable final SoftwareVersion other) {
+        if (proto == null || services == null) {
+            throw new IllegalStateException(
+                    "Uninitialized version " + this + IS_INCOMPARABLE_MSG + other);
+        }
+        if (other == SoftwareVersion.NO_VERSION) {
+            // We are later than any unknown version
+            return 1;
+        }
+        if (other instanceof SerializableSemVers that) {
+            return FULL_COMPARATOR.compare(this, that);
+        } else {
+            throw new IllegalArgumentException("Version " + this + IS_INCOMPARABLE_MSG + other);
+        }
+    }
 
-	@Override
-	public int compareTo(@Nullable final SoftwareVersion other) {
-		if (proto == null || services == null) {
-			throw new IllegalStateException("Uninitialized version " + this + IS_INCOMPARABLE_MSG + other);
-		}
-		if (other == SoftwareVersion.NO_VERSION) {
-			// We are later than any unknown version
-			return 1;
-		}
-		if (other instanceof SerializableSemVers that) {
-			return FULL_COMPARATOR.compare(this, that);
-		} else {
-			throw new IllegalArgumentException("Version " + this + IS_INCOMPARABLE_MSG + other);
-		}
-	}
+    @Override
+    public void deserialize(final SerializableDataInputStream in, final int version)
+            throws IOException {
+        proto = deserializeSemVer(in);
+        services = deserializeSemVer(in);
+    }
 
-	@Override
-	public void deserialize(final SerializableDataInputStream in, final int version) throws IOException {
-		proto = deserializeSemVer(in);
-		services = deserializeSemVer(in);
-	}
+    @Override
+    public void serialize(final SerializableDataOutputStream out) throws IOException {
+        serializeSemVer(proto, out);
+        serializeSemVer(services, out);
+    }
 
-	@Override
-	public void serialize(final SerializableDataOutputStream out) throws IOException {
-		serializeSemVer(proto, out);
-		serializeSemVer(services, out);
-	}
+    @Override
+    public String toString() {
+        return "Services @ " + readable(services) + " | HAPI @ " + readable(proto);
+    }
 
-	@Override
-	public String toString() {
-		return "Services @ " + readable(services) + " | HAPI @ " + readable(proto);
-	}
+    private static void serializeSemVer(
+            final SemanticVersion semVer, final SerializableDataOutputStream out)
+            throws IOException {
+        out.writeInt(semVer.getMajor());
+        out.writeInt(semVer.getMinor());
+        out.writeInt(semVer.getPatch());
+        serializeIfUsed(semVer.getPre(), out);
+        serializeIfUsed(semVer.getBuild(), out);
+    }
 
-	private static void serializeSemVer(
-			final SemanticVersion semVer,
-			final SerializableDataOutputStream out
-	) throws IOException {
-		out.writeInt(semVer.getMajor());
-		out.writeInt(semVer.getMinor());
-		out.writeInt(semVer.getPatch());
-		serializeIfUsed(semVer.getPre(), out);
-		serializeIfUsed(semVer.getBuild(), out);
-	}
+    private static void serializeIfUsed(
+            final String semVerPart, final SerializableDataOutputStream out) throws IOException {
+        if (semVerPart.isBlank()) {
+            out.writeBoolean(false);
+        } else {
+            out.writeBoolean(true);
+            out.writeNormalisedString(semVerPart);
+        }
+    }
 
-	private static void serializeIfUsed(
-			final String semVerPart,
-			final SerializableDataOutputStream out
-	) throws IOException {
-		if (semVerPart.isBlank()) {
-			out.writeBoolean(false);
-		} else {
-			out.writeBoolean(true);
-			out.writeNormalisedString(semVerPart);
-		}
-	}
+    private static SemanticVersion deserializeSemVer(final SerializableDataInputStream in)
+            throws IOException {
+        final var ans = SemanticVersion.newBuilder();
+        ans.setMajor(in.readInt()).setMinor(in.readInt()).setPatch(in.readInt());
+        if (in.readBoolean()) {
+            ans.setPre(in.readNormalisedString(Integer.MAX_VALUE));
+        }
+        if (in.readBoolean()) {
+            ans.setBuild(in.readNormalisedString(Integer.MAX_VALUE));
+        }
+        return ans.build();
+    }
 
-	private static SemanticVersion deserializeSemVer(final SerializableDataInputStream in) throws IOException {
-		final var ans = SemanticVersion.newBuilder();
-		ans.setMajor(in.readInt()).setMinor(in.readInt()).setPatch(in.readInt());
-		if (in.readBoolean()) {
-			ans.setPre(in.readNormalisedString(Integer.MAX_VALUE));
-		}
-		if (in.readBoolean()) {
-			ans.setBuild(in.readNormalisedString(Integer.MAX_VALUE));
-		}
-		return ans.build();
-	}
+    private static String readable(@Nullable final SemanticVersion semVer) {
+        if (semVer == null) {
+            return "<N/A>";
+        }
+        final var sb =
+                new StringBuilder()
+                        .append(semVer.getMajor())
+                        .append(".")
+                        .append(semVer.getMinor())
+                        .append(".")
+                        .append(semVer.getPatch());
+        if (!semVer.getPre().isBlank()) {
+            sb.append("-").append(semVer.getPre());
+        }
+        if (!semVer.getBuild().isBlank()) {
+            sb.append("+").append(semVer.getBuild());
+        }
+        return sb.toString();
+    }
 
-	private static String readable(@Nullable final SemanticVersion semVer) {
-		if (semVer == null) {
-			return "<N/A>";
-		}
-		final var sb = new StringBuilder()
-				.append(semVer.getMajor()).append(".")
-				.append(semVer.getMinor()).append(".")
-				.append(semVer.getPatch());
-		if (!semVer.getPre().isBlank()) {
-			sb.append("-").append(semVer.getPre());
-		}
-		if (!semVer.getBuild().isBlank()) {
-			sb.append("+").append(semVer.getBuild());
-		}
-		return sb.toString();
-	}
+    @VisibleForTesting
+    public void setProto(final SemanticVersion proto) {
+        this.proto = proto;
+    }
 
-	@VisibleForTesting
-	public void setProto(final SemanticVersion proto) {
-		this.proto = proto;
-	}
+    @VisibleForTesting
+    public void setServices(final SemanticVersion services) {
+        this.services = services;
+    }
 
-	@VisibleForTesting
-	public void setServices(final SemanticVersion services) {
-		this.services = services;
-	}
-
-	@VisibleForTesting
-	static void setCurrentVersionHasPatchMigrationRecords(
-			boolean currentVersionHasPatchMigrationRecords) {
-		CURRENT_VERSION_HAS_PATCH_MIGRATION_RECORDS = currentVersionHasPatchMigrationRecords;
-	}
+    @VisibleForTesting
+    static void setCurrentVersionHasPatchMigrationRecords(
+            boolean currentVersionHasPatchMigrationRecords) {
+        CURRENT_VERSION_HAS_PATCH_MIGRATION_RECORDS = currentVersionHasPatchMigrationRecords;
+    }
 }

--- a/hedera-node/src/main/java/com/hedera/services/context/properties/SerializableSemVers.java
+++ b/hedera-node/src/main/java/com/hedera/services/context/properties/SerializableSemVers.java
@@ -1,19 +1,24 @@
-/*
- * Copyright (C) 2022 Hedera Hashgraph, LLC
- *
+package com.hedera.services.context.properties;
+
+/*-
+ * ‌
+ * Hedera Services Node
+ * ​
+ * Copyright (C) 2018 - 2022 Hedera Hashgraph, LLC
+ * ​
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * ‍
  */
-package com.hedera.services.context.properties;
 
 import static com.hedera.services.context.properties.SemanticVersions.asSemVer;
 
@@ -28,183 +33,193 @@ import javax.annotation.Nullable;
 import org.jetbrains.annotations.NotNull;
 
 public class SerializableSemVers implements SoftwareVersion {
-    private static final String IS_INCOMPARABLE_MSG = " cannot be compared to ";
-    public static final int RELEASE_027_VERSION = 1;
-    public static final long CLASS_ID = 0x6f2b1bc2df8cbd0bL;
+	private static final String IS_INCOMPARABLE_MSG = " cannot be compared to ";
+	private static boolean CURRENT_VERSION_HAS_PATCH_MIGRATION_RECORDS = false;
+	public static final int RELEASE_027_VERSION = 1;
+	public static final long CLASS_ID = 0x6f2b1bc2df8cbd0bL;
 
-    public static final Comparator<SemanticVersion> SEM_VER_COMPARATOR =
-            Comparator.comparingInt(SemanticVersion::getMajor)
-                    .thenComparingInt(SemanticVersion::getMinor)
-                    .thenComparingInt(SemanticVersion::getPatch)
-                    // We never deploy versions with `pre` or `build` parts to prod envs,
-                    // so just give precedence to the version that doesn't have one
-                    .thenComparingInt(semver -> semver.getPre().isBlank() ? 1 : 0)
-                    .thenComparingInt(semver -> semver.getBuild().isBlank() ? 1 : 0);
-    public static final Comparator<SerializableSemVers> FULL_COMPARATOR =
-            Comparator.comparing(SerializableSemVers::getServices, SEM_VER_COMPARATOR)
-                    .thenComparing(SerializableSemVers::getProto, SEM_VER_COMPARATOR);
+	public static final Comparator<SemanticVersion> SEM_VER_COMPARATOR =
+			Comparator.comparingInt(SemanticVersion::getMajor)
+					.thenComparingInt(SemanticVersion::getMinor)
+					.thenComparingInt(SemanticVersion::getPatch)
+					// We never deploy versions with `pre` or `build` parts to prod envs,
+					// so just give precedence to the version that doesn't have one
+					.thenComparingInt(semver -> semver.getPre().isBlank() ? 1 : 0)
+					.thenComparingInt(semver -> semver.getBuild().isBlank() ? 1 : 0);
+	public static final Comparator<SerializableSemVers> FULL_COMPARATOR =
+			Comparator.comparing(SerializableSemVers::getServices, SEM_VER_COMPARATOR)
+					.thenComparing(SerializableSemVers::getProto, SEM_VER_COMPARATOR);
 
-    private SemanticVersion proto;
-    private SemanticVersion services;
+	private SemanticVersion proto;
+	private SemanticVersion services;
 
-    public SerializableSemVers() {
-        // RuntimeConstructable
-    }
+	public SerializableSemVers() {
+		// RuntimeConstructable
+	}
 
-    public SemanticVersion getProto() {
-        return proto;
-    }
+	public SemanticVersion getProto() {
+		return proto;
+	}
 
-    public SemanticVersion getServices() {
-        return services;
-    }
+	public SemanticVersion getServices() {
+		return services;
+	}
 
-    public SerializableSemVers(
-            @NotNull final SemanticVersion proto, @NotNull final SemanticVersion services) {
-        this.proto = proto;
-        this.services = services;
-    }
+	public SerializableSemVers(@NotNull final SemanticVersion proto, @NotNull final SemanticVersion services) {
+		this.proto = proto;
+		this.services = services;
+	}
 
-    public static SerializableSemVers forHapiAndHedera(
-            @NotNull final String proto, @NotNull final String services) {
-        return new SerializableSemVers(asSemVer(proto), asSemVer(services));
-    }
+	public static SerializableSemVers forHapiAndHedera(@NotNull final String proto, @NotNull final String services) {
+		return new SerializableSemVers(asSemVer(proto), asSemVer(services));
+	}
 
-    @Override
-    public long getClassId() {
-        return CLASS_ID;
-    }
+	@Override
+	public long getClassId() {
+		return CLASS_ID;
+	}
 
-    @Override
-    public int getVersion() {
-        return RELEASE_027_VERSION;
-    }
 
-    @Override
-    public int getMinimumSupportedVersion() {
-        return RELEASE_027_VERSION;
-    }
+	@Override
+	public int getVersion() {
+		return RELEASE_027_VERSION;
+	}
 
-    public boolean isAfter(@Nullable final SoftwareVersion other) {
-        return compareTo(other) > 0;
-    }
+	@Override
+	public int getMinimumSupportedVersion() {
+		return RELEASE_027_VERSION;
+	}
 
-    public boolean isBefore(@Nullable final SoftwareVersion other) {
-        return compareTo(other) < 0;
-    }
+	public boolean isAfter(@Nullable final SoftwareVersion other) {
+		return compareTo(other) > 0;
+	}
 
-    public boolean isNonPatchUpgradeFrom(@Nullable final SoftwareVersion other) {
-        if (other == null) {
-            return true;
-        }
-        if (other instanceof SerializableSemVers that) {
-            return this.isAfter(that) && haveDifferentMajorAndMinorVersions(this, that);
-        } else {
-            throw new IllegalArgumentException("Version " + this + IS_INCOMPARABLE_MSG + other);
-        }
-    }
+	public boolean isBefore(@Nullable final SoftwareVersion other) {
+		return compareTo(other) < 0;
+	}
 
-    private boolean haveDifferentMajorAndMinorVersions(
-            @NotNull final SerializableSemVers a, @NotNull final SerializableSemVers b) {
-        return a.services.getMajor() != b.services.getMajor()
-                || a.services.getMinor() != b.services.getMinor();
-    }
+	public boolean hasMigrationRecordsFrom(@Nullable final SoftwareVersion other) {
+		return isNonPatchUpgradeFrom(other) || (this.isAfter(other) && CURRENT_VERSION_HAS_PATCH_MIGRATION_RECORDS);
+	}
 
-    @Override
-    public int compareTo(@Nullable final SoftwareVersion other) {
-        if (proto == null || services == null) {
-            throw new IllegalStateException(
-                    "Uninitialized version " + this + IS_INCOMPARABLE_MSG + other);
-        }
-        if (other == SoftwareVersion.NO_VERSION) {
-            // We are later than any unknown version
-            return 1;
-        }
-        if (other instanceof SerializableSemVers that) {
-            return FULL_COMPARATOR.compare(this, that);
-        } else {
-            throw new IllegalArgumentException("Version " + this + IS_INCOMPARABLE_MSG + other);
-        }
-    }
+	@VisibleForTesting
+	boolean isNonPatchUpgradeFrom(@Nullable final SoftwareVersion other) {
+		if (other == null) {
+			return true;
+		}
+		if (other instanceof SerializableSemVers that) {
+			return this.isAfter(that) && haveDifferentMajorAndMinorVersions(this, that);
+		} else {
+			throw new IllegalArgumentException("Version " + this + IS_INCOMPARABLE_MSG + other);
+		}
+	}
 
-    @Override
-    public void deserialize(final SerializableDataInputStream in, final int version)
-            throws IOException {
-        proto = deserializeSemVer(in);
-        services = deserializeSemVer(in);
-    }
+	private boolean haveDifferentMajorAndMinorVersions(
+			@NotNull final SerializableSemVers a,
+			@NotNull final SerializableSemVers b
+	) {
+		return a.services.getMajor() != b.services.getMajor() ||
+				a.services.getMinor() != b.services.getMinor();
+	}
 
-    @Override
-    public void serialize(final SerializableDataOutputStream out) throws IOException {
-        serializeSemVer(proto, out);
-        serializeSemVer(services, out);
-    }
+	@Override
+	public int compareTo(@Nullable final SoftwareVersion other) {
+		if (proto == null || services == null) {
+			throw new IllegalStateException("Uninitialized version " + this + IS_INCOMPARABLE_MSG + other);
+		}
+		if (other == SoftwareVersion.NO_VERSION) {
+			// We are later than any unknown version
+			return 1;
+		}
+		if (other instanceof SerializableSemVers that) {
+			return FULL_COMPARATOR.compare(this, that);
+		} else {
+			throw new IllegalArgumentException("Version " + this + IS_INCOMPARABLE_MSG + other);
+		}
+	}
 
-    @Override
-    public String toString() {
-        return "Services @ " + readable(services) + " | HAPI @ " + readable(proto);
-    }
+	@Override
+	public void deserialize(final SerializableDataInputStream in, final int version) throws IOException {
+		proto = deserializeSemVer(in);
+		services = deserializeSemVer(in);
+	}
 
-    private static void serializeSemVer(
-            final SemanticVersion semVer, final SerializableDataOutputStream out)
-            throws IOException {
-        out.writeInt(semVer.getMajor());
-        out.writeInt(semVer.getMinor());
-        out.writeInt(semVer.getPatch());
-        serializeIfUsed(semVer.getPre(), out);
-        serializeIfUsed(semVer.getBuild(), out);
-    }
+	@Override
+	public void serialize(final SerializableDataOutputStream out) throws IOException {
+		serializeSemVer(proto, out);
+		serializeSemVer(services, out);
+	}
 
-    private static void serializeIfUsed(
-            final String semVerPart, final SerializableDataOutputStream out) throws IOException {
-        if (semVerPart.isBlank()) {
-            out.writeBoolean(false);
-        } else {
-            out.writeBoolean(true);
-            out.writeNormalisedString(semVerPart);
-        }
-    }
+	@Override
+	public String toString() {
+		return "Services @ " + readable(services) + " | HAPI @ " + readable(proto);
+	}
 
-    private static SemanticVersion deserializeSemVer(final SerializableDataInputStream in)
-            throws IOException {
-        final var ans = SemanticVersion.newBuilder();
-        ans.setMajor(in.readInt()).setMinor(in.readInt()).setPatch(in.readInt());
-        if (in.readBoolean()) {
-            ans.setPre(in.readNormalisedString(Integer.MAX_VALUE));
-        }
-        if (in.readBoolean()) {
-            ans.setBuild(in.readNormalisedString(Integer.MAX_VALUE));
-        }
-        return ans.build();
-    }
+	private static void serializeSemVer(
+			final SemanticVersion semVer,
+			final SerializableDataOutputStream out
+	) throws IOException {
+		out.writeInt(semVer.getMajor());
+		out.writeInt(semVer.getMinor());
+		out.writeInt(semVer.getPatch());
+		serializeIfUsed(semVer.getPre(), out);
+		serializeIfUsed(semVer.getBuild(), out);
+	}
 
-    private static String readable(@Nullable final SemanticVersion semVer) {
-        if (semVer == null) {
-            return "<N/A>";
-        }
-        final var sb =
-                new StringBuilder()
-                        .append(semVer.getMajor())
-                        .append(".")
-                        .append(semVer.getMinor())
-                        .append(".")
-                        .append(semVer.getPatch());
-        if (!semVer.getPre().isBlank()) {
-            sb.append("-").append(semVer.getPre());
-        }
-        if (!semVer.getBuild().isBlank()) {
-            sb.append("+").append(semVer.getBuild());
-        }
-        return sb.toString();
-    }
+	private static void serializeIfUsed(
+			final String semVerPart,
+			final SerializableDataOutputStream out
+	) throws IOException {
+		if (semVerPart.isBlank()) {
+			out.writeBoolean(false);
+		} else {
+			out.writeBoolean(true);
+			out.writeNormalisedString(semVerPart);
+		}
+	}
 
-    @VisibleForTesting
-    public void setProto(final SemanticVersion proto) {
-        this.proto = proto;
-    }
+	private static SemanticVersion deserializeSemVer(final SerializableDataInputStream in) throws IOException {
+		final var ans = SemanticVersion.newBuilder();
+		ans.setMajor(in.readInt()).setMinor(in.readInt()).setPatch(in.readInt());
+		if (in.readBoolean()) {
+			ans.setPre(in.readNormalisedString(Integer.MAX_VALUE));
+		}
+		if (in.readBoolean()) {
+			ans.setBuild(in.readNormalisedString(Integer.MAX_VALUE));
+		}
+		return ans.build();
+	}
 
-    @VisibleForTesting
-    public void setServices(final SemanticVersion services) {
-        this.services = services;
-    }
+	private static String readable(@Nullable final SemanticVersion semVer) {
+		if (semVer == null) {
+			return "<N/A>";
+		}
+		final var sb = new StringBuilder()
+				.append(semVer.getMajor()).append(".")
+				.append(semVer.getMinor()).append(".")
+				.append(semVer.getPatch());
+		if (!semVer.getPre().isBlank()) {
+			sb.append("-").append(semVer.getPre());
+		}
+		if (!semVer.getBuild().isBlank()) {
+			sb.append("+").append(semVer.getBuild());
+		}
+		return sb.toString();
+	}
+
+	@VisibleForTesting
+	public void setProto(final SemanticVersion proto) {
+		this.proto = proto;
+	}
+
+	@VisibleForTesting
+	public void setServices(final SemanticVersion services) {
+		this.services = services;
+	}
+
+	@VisibleForTesting
+	static void setCurrentVersionHasPatchMigrationRecords(
+			boolean currentVersionHasPatchMigrationRecords) {
+		CURRENT_VERSION_HAS_PATCH_MIGRATION_RECORDS = currentVersionHasPatchMigrationRecords;
+	}
 }

--- a/hedera-node/src/main/java/com/hedera/services/state/initialization/TreasuryCloner.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/initialization/TreasuryCloner.java
@@ -16,6 +16,8 @@
 package com.hedera.services.state.initialization;
 
 import static com.hedera.services.config.HederaNumbers.FIRST_POST_SYSTEM_FILE_ENTITY;
+import static com.hedera.services.config.HederaNumbers.FIRST_RESERVED_SYSTEM_CONTRACT;
+import static com.hedera.services.config.HederaNumbers.LAST_RESERVED_SYSTEM_CONTRACT;
 import static com.hedera.services.config.HederaNumbers.NUM_RESERVED_SYSTEM_ENTITIES;
 import static com.hedera.services.context.properties.StaticPropertiesHolder.STATIC_PROPERTIES;
 
@@ -33,6 +35,7 @@ import org.apache.logging.log4j.Logger;
 
 @Singleton
 public class TreasuryCloner {
+
     private static final Logger log = LogManager.getLogger(TreasuryCloner.class);
 
     private final AccountNumbers accountNums;
@@ -51,6 +54,9 @@ public class TreasuryCloner {
         final var treasuryId = STATIC_PROPERTIES.scopedAccountWith(accountNums.treasury());
         final var treasury = accounts.getImmutableRef(treasuryId);
         for (long i = FIRST_POST_SYSTEM_FILE_ENTITY; i <= NUM_RESERVED_SYSTEM_ENTITIES; i++) {
+            if (i >= FIRST_RESERVED_SYSTEM_CONTRACT && i <= LAST_RESERVED_SYSTEM_CONTRACT) {
+                continue;
+            }
             final var nextCloneId = STATIC_PROPERTIES.scopedAccountWith(i);
             if (accounts.contains(nextCloneId)) {
                 continue;
@@ -58,6 +64,7 @@ public class TreasuryCloner {
             final var nextClone =
                     new HederaAccountCustomizer()
                             .isReceiverSigRequired(treasury.isReceiverSigRequired())
+                            .isDeclinedReward(treasury.isDeclinedReward())
                             .isDeleted(false)
                             .expiry(treasury.getExpiry())
                             .memo(treasury.getMemo())

--- a/hedera-node/src/main/java/com/hedera/services/state/initialization/TreasuryCloner.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/initialization/TreasuryCloner.java
@@ -28,6 +28,7 @@ import com.hedera.services.state.merkle.MerkleAccount;
 import com.hederahashgraph.api.proto.java.AccountID;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.LongStream;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import org.apache.logging.log4j.LogManager;
@@ -53,12 +54,10 @@ public class TreasuryCloner {
     public void ensureTreasuryClonesExist() {
         final var treasuryId = STATIC_PROPERTIES.scopedAccountWith(accountNums.treasury());
         final var treasury = accounts.getImmutableRef(treasuryId);
-        for (long i = FIRST_POST_SYSTEM_FILE_ENTITY; i <= NUM_RESERVED_SYSTEM_ENTITIES; i++) {
-            if (i >= FIRST_RESERVED_SYSTEM_CONTRACT && i <= LAST_RESERVED_SYSTEM_CONTRACT) {
-                continue;
-            }
-            final var nextCloneId = STATIC_PROPERTIES.scopedAccountWith(i);
+        for (final var num : nonContractSystemNums()) {
+            final var nextCloneId = STATIC_PROPERTIES.scopedAccountWith(num);
             if (accounts.contains(nextCloneId)) {
+                // In ^0.28.6, all accounts will either exist (restart) or not exist (genesis)
                 continue;
             }
             final var nextClone =
@@ -84,5 +83,18 @@ public class TreasuryCloner {
 
     public List<MerkleAccount> getClonesCreated() {
         return clonesCreated;
+    }
+
+    public void forgetScannedSystemAccounts() {
+        clonesCreated.clear();
+    }
+
+    private long[] nonContractSystemNums() {
+        return LongStream.rangeClosed(FIRST_POST_SYSTEM_FILE_ENTITY, NUM_RESERVED_SYSTEM_ENTITIES)
+                .filter(
+                        i ->
+                                i < FIRST_RESERVED_SYSTEM_CONTRACT
+                                        || i > LAST_RESERVED_SYSTEM_CONTRACT)
+                .toArray();
     }
 }

--- a/hedera-node/src/main/java/com/hedera/services/state/migration/MigrationRecordsManager.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/migration/MigrationRecordsManager.java
@@ -209,6 +209,7 @@ public class MigrationRecordsManager {
                 "staking fund");
     }
 
+    @SuppressWarnings("java:S107")
     private void publishSyntheticCreation(
             final EntityNum num,
             final long autoRenewPeriod,

--- a/hedera-node/src/main/java/com/hedera/services/state/migration/MigrationRecordsManager.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/migration/MigrationRecordsManager.java
@@ -194,6 +194,7 @@ public class MigrationRecordsManager {
                                         "treasury clone"));
 
         curNetworkCtx.markMigrationRecordsStreamed();
+        treasuryCloner.forgetScannedSystemAccounts();
     }
 
     private void publishSyntheticCreationForStakingFund(

--- a/hedera-node/src/main/java/com/hedera/services/state/migration/MigrationRecordsManager.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/migration/MigrationRecordsManager.java
@@ -383,8 +383,8 @@ public class MigrationRecordsManager {
         if (maxNumberOfKvPairsToIterate != 0) {
             log.warn(
                     "After walking through all iterable storage of contract 0.0.{},"
-                            + " numContractKvPairs field indicates that there should have been {} more"
-                            + " k/v pair(s) left",
+                        + " numContractKvPairs field indicates that there should have been {} more"
+                        + " k/v pair(s) left",
                     contractId.getContractNum(),
                     maxNumberOfKvPairsToIterate);
         }

--- a/hedera-node/src/test/java/com/hedera/services/context/properties/SerializableSemVersTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/context/properties/SerializableSemVersTest.java
@@ -1,11 +1,6 @@
-package com.hedera.services.context.properties;
-
-/*-
- * ‌
- * Hedera Services Node
- * ​
- * Copyright (C) 2018 - 2022 Hedera Hashgraph, LLC
- * ​
+/*
+ * Copyright (C) 2022 Hedera Hashgraph, LLC
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -17,8 +12,8 @@ package com.hedera.services.context.properties;
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- * ‍
  */
+package com.hedera.services.context.properties;
 
 import static com.hedera.services.context.properties.SerializableSemVers.SEM_VER_COMPARATOR;
 import static com.hedera.services.context.properties.SerializableSemVersSerdeTest.assertEqualVersions;

--- a/hedera-node/src/test/java/com/hedera/services/context/properties/SerializableSemVersTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/context/properties/SerializableSemVersTest.java
@@ -1,6 +1,11 @@
-/*
- * Copyright (C) 2022 Hedera Hashgraph, LLC
- *
+package com.hedera.services.context.properties;
+
+/*-
+ * ‌
+ * Hedera Services Node
+ * ​
+ * Copyright (C) 2018 - 2022 Hedera Hashgraph, LLC
+ * ​
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -12,12 +17,15 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * ‍
  */
-package com.hedera.services.context.properties;
 
 import static com.hedera.services.context.properties.SerializableSemVers.SEM_VER_COMPARATOR;
 import static com.hedera.services.context.properties.SerializableSemVersSerdeTest.assertEqualVersions;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 
 import com.hederahashgraph.api.proto.java.SemanticVersion;
@@ -115,7 +123,24 @@ class SerializableSemVersTest {
     }
 
     @Test
-    void detectsNonPatchServicesUpgardes() {
+    void answersTruthfullyOnPendingMigrationRecords() {
+        final var someProto = semVerWith(1, 1, 1, null, null);
+        final var saved027Version = semVerWith(0, 27, 7, null, null);
+        final var saved028Version = semVerWith(0, 28, 5, null, null);
+        final var patch0286 = semVerWith(0, 28, 6, null, null);
+
+        final var subject = new SerializableSemVers(someProto, patch0286);
+        final var v0277 = new SerializableSemVers(someProto, saved027Version);
+        final var v0285 = new SerializableSemVers(someProto, saved028Version);
+
+        assertTrue(subject.hasMigrationRecordsFrom(v0277));
+        SerializableSemVers.setCurrentVersionHasPatchMigrationRecords(true);
+        assertTrue(subject.hasMigrationRecordsFrom(v0285));
+        assertFalse(subject.hasMigrationRecordsFrom(subject));
+    }
+
+    @Test
+    void detectsNonPatchServicesUpgrades() {
         final var services = semVerWith(1, 2, 3, null, null);
         final var servicesPatch = semVerWith(1, 2, 4, null, null);
         final var servicesMinorUpgrade = semVerWith(1, 3, 3, null, null);

--- a/hedera-node/src/test/java/com/hedera/services/state/initialization/TreasuryClonerTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/state/initialization/TreasuryClonerTest.java
@@ -69,11 +69,11 @@ public class TreasuryClonerTest {
         final var created = subject.getClonesCreated();
 
         for (long i = 200; i <= 750L; i++) {
-            if (i != 666) {
+            if (i != 666 && !(i >= 350 && i < 400)) {
                 verify(accounts).put(idFor(i), accountWith(pretendExpiry, pretendTreasuryKey));
             }
         }
-        Assertions.assertEquals(550, created.size());
+        Assertions.assertEquals(500, created.size());
         verifyNoMoreInteractions(accounts);
     }
 

--- a/hedera-node/src/test/java/com/hedera/services/state/initialization/TreasuryClonerTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/state/initialization/TreasuryClonerTest.java
@@ -16,8 +16,9 @@
 package com.hedera.services.state.initialization;
 
 import static com.hedera.services.context.properties.StaticPropertiesHolder.STATIC_PROPERTIES;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willAnswer;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -30,7 +31,6 @@ import com.hedera.services.legacy.core.jproto.JEd25519Key;
 import com.hedera.services.legacy.core.jproto.JKey;
 import com.hedera.services.state.merkle.MerkleAccount;
 import com.hederahashgraph.api.proto.java.AccountID;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -56,14 +56,22 @@ public class TreasuryClonerTest {
 
     @Test
     void clonesAsExpected() {
-        given(accounts.getImmutableRef(idFor(2L)))
-                .willReturn(accountWith(pretendExpiry, pretendTreasuryKey));
         willAnswer(
                         invocationOnMock ->
                                 ((AccountID) invocationOnMock.getArgument(0)).getAccountNum()
                                         == 666L)
                 .given(accounts)
                 .contains(any());
+        willAnswer(
+                        invocationOnMock -> {
+                            final var id = (AccountID) invocationOnMock.getArgument(0);
+                            if (id.getAccountNum() == 2L || id.getAccountNum() == 666L) {
+                                return accountWith(pretendExpiry, pretendTreasuryKey);
+                            }
+                            return null;
+                        })
+                .given(accounts)
+                .getImmutableRef(any());
 
         subject.ensureTreasuryClonesExist();
         final var created = subject.getClonesCreated();
@@ -73,8 +81,11 @@ public class TreasuryClonerTest {
                 verify(accounts).put(idFor(i), accountWith(pretendExpiry, pretendTreasuryKey));
             }
         }
-        Assertions.assertEquals(500, created.size());
+        assertEquals(500, created.size());
         verifyNoMoreInteractions(accounts);
+
+        subject.forgetScannedSystemAccounts();
+        assertTrue(subject.getClonesCreated().isEmpty());
     }
 
     private AccountID idFor(final long num) {

--- a/hedera-node/src/test/java/com/hedera/services/state/migration/MigrationRecordsManagerTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/state/migration/MigrationRecordsManagerTest.java
@@ -708,6 +708,7 @@ class MigrationRecordsManagerTest {
                         .setKey(MiscUtils.asKeyUnchecked(pretendTreasuryKey))
                         .setMemo("123")
                         .setInitialBalance(0)
+                    .setReceiverSigRequired(true)
                         .setAutoRenewPeriod(
                                 Duration.newBuilder()
                                         .setSeconds(pretendExpiry - now.getEpochSecond()))

--- a/hedera-node/src/test/java/com/hedera/services/state/migration/MigrationRecordsManagerTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/state/migration/MigrationRecordsManagerTest.java
@@ -709,7 +709,7 @@ class MigrationRecordsManagerTest {
                         .setKey(MiscUtils.asKeyUnchecked(pretendTreasuryKey))
                         .setMemo("123")
                         .setInitialBalance(0)
-                    .setReceiverSigRequired(true)
+                        .setReceiverSigRequired(true)
                         .setAutoRenewPeriod(
                                 Duration.newBuilder()
                                         .setSeconds(pretendExpiry - now.getEpochSecond()))

--- a/hedera-node/src/test/java/com/hedera/services/state/migration/MigrationRecordsManagerTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/state/migration/MigrationRecordsManagerTest.java
@@ -216,6 +216,7 @@ class MigrationRecordsManagerTest {
                 .trackPrecedingChildRecord(
                         eq(DEFAULT_SOURCE_ID), bodyCaptor.capture(), eq(pretend801));
         verify(networkCtx).markMigrationRecordsStreamed();
+        verify(treasuryCloner).forgetScannedSystemAccounts();
         verify(recordsHistorian)
                 .trackPrecedingChildRecord(
                         eq(DEFAULT_SOURCE_ID), bodyCaptor.capture(), eq(pretend200));


### PR DESCRIPTION
**Description**:
- Omits treasury clones in the range reserved for system contracts. 
- Ensures clones have the same `declineRewards` as the treasury.