### PR TITLE
Add dedicated account in wipe e2e tests

### DIFF
--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/GrantRevokeKycSuite.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/GrantRevokeKycSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2022 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/GrantRevokeKycSuite.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/GrantRevokeKycSuite.java
@@ -94,6 +94,7 @@ public class GrantRevokeKycSuite extends HapiApiSuite {
         final AtomicReference<AccountID> accountID = new AtomicReference<>();
         final AtomicReference<AccountID> secondAccountID = new AtomicReference<>();
         final AtomicReference<TokenID> tokenWithoutKeyID = new AtomicReference<>();
+        final var invalidTokenID = TokenID.newBuilder().build();
 
         return defaultHapiSpec("GrantRevokeKycFail")
                 .given(
@@ -160,7 +161,7 @@ public class GrantRevokeKycSuite extends HapiApiSuite {
                                                 contractCall(
                                                                 GRANT_REVOKE_KYC_CONTRACT,
                                                                 TOKEN_REVOKE_KYC,
-                                                                asAddress(accountID.get()),
+                                                                asAddress(invalidTokenID),
                                                                 asAddress(secondAccountID.get()))
                                                         .payingWith(ACCOUNT)
                                                         .via("RevokeKycWrongTokenTx")
@@ -169,7 +170,7 @@ public class GrantRevokeKycSuite extends HapiApiSuite {
                                                 contractCall(
                                                                 GRANT_REVOKE_KYC_CONTRACT,
                                                                 TOKEN_GRANT_KYC,
-                                                                asAddress(accountID.get()),
+                                                                asAddress(invalidTokenID),
                                                                 asAddress(secondAccountID.get()))
                                                         .payingWith(ACCOUNT)
                                                         .via("GrantKycWrongTokenTx")

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/WipeTokenAccountPrecompileSuite.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/WipeTokenAccountPrecompileSuite.java
@@ -48,6 +48,7 @@ import org.apache.logging.log4j.Logger;
 public class WipeTokenAccountPrecompileSuite extends HapiApiSuite {
     private static final Logger log = LogManager.getLogger(WipeTokenAccountPrecompileSuite.class);
     private static final String WIPE_CONTRACT = "WipeTokenAccount";
+    private static final String ADMIN_ACCOUNT = "admin";
     private static final String ACCOUNT = "anybody";
     private static final String SECOND_ACCOUNT = "anybodySecond";
     private static final String WIPE_KEY = "wipeKey";
@@ -71,6 +72,7 @@ public class WipeTokenAccountPrecompileSuite extends HapiApiSuite {
     }
 
     private HapiApiSpec wipeFungibleTokenScenarios() {
+        final AtomicReference<AccountID> adminAccountID = new AtomicReference<>();
         final AtomicReference<AccountID> accountID = new AtomicReference<>();
         final AtomicReference<AccountID> secondAccountID = new AtomicReference<>();
         final AtomicReference<TokenID> vanillaTokenID = new AtomicReference<>();
@@ -78,9 +80,9 @@ public class WipeTokenAccountPrecompileSuite extends HapiApiSuite {
         return defaultHapiSpec("WipeFungibleTokenScenarios")
                 .given(
                         newKeyNamed(WIPE_KEY),
+                        cryptoCreate(ADMIN_ACCOUNT).exposingCreatedIdTo(adminAccountID::set),
                         cryptoCreate(ACCOUNT).exposingCreatedIdTo(accountID::set),
                         cryptoCreate(SECOND_ACCOUNT).exposingCreatedIdTo(secondAccountID::set),
-                        cryptoUpdate(SECOND_ACCOUNT).key(WIPE_KEY),
                         cryptoCreate(TOKEN_TREASURY),
                         tokenCreate(VANILLA_TOKEN)
                                 .tokenType(FUNGIBLE_COMMON)
@@ -104,18 +106,18 @@ public class WipeTokenAccountPrecompileSuite extends HapiApiSuite {
                                                                 asAddress(vanillaTokenID.get()),
                                                                 asAddress(accountID.get()),
                                                                 10L)
-                                                        .payingWith(ACCOUNT)
+                                                        .payingWith(ADMIN_ACCOUNT)
                                                         .via("accountDoesNotOwnWipeKeyTxn")
                                                         .gas(GAS_TO_OFFER)
                                                         .hasKnownStatus(CONTRACT_REVERT_EXECUTED),
-                                                cryptoUpdate(ACCOUNT).key(WIPE_KEY),
+                                                cryptoUpdate(ADMIN_ACCOUNT).key(WIPE_KEY),
                                                 contractCall(
                                                                 WIPE_CONTRACT,
                                                                 WIPE_FUNGIBLE_TOKEN,
                                                                 asAddress(vanillaTokenID.get()),
                                                                 asAddress(accountID.get()),
                                                                 1_000L)
-                                                        .payingWith(ACCOUNT)
+                                                        .payingWith(ADMIN_ACCOUNT)
                                                         .via("amountLargerThanBalanceTxn")
                                                         .gas(GAS_TO_OFFER)
                                                         .hasKnownStatus(CONTRACT_REVERT_EXECUTED),
@@ -125,7 +127,7 @@ public class WipeTokenAccountPrecompileSuite extends HapiApiSuite {
                                                                 asAddress(vanillaTokenID.get()),
                                                                 asAddress(secondAccountID.get()),
                                                                 10L)
-                                                        .payingWith(SECOND_ACCOUNT)
+                                                        .payingWith(ADMIN_ACCOUNT)
                                                         .via("accountDoesNotOwnTokensTxn")
                                                         .gas(GAS_TO_OFFER)
                                                         .hasKnownStatus(CONTRACT_REVERT_EXECUTED),
@@ -135,7 +137,7 @@ public class WipeTokenAccountPrecompileSuite extends HapiApiSuite {
                                                                 asAddress(vanillaTokenID.get()),
                                                                 asAddress(accountID.get()),
                                                                 10L)
-                                                        .payingWith(ACCOUNT)
+                                                        .payingWith(ADMIN_ACCOUNT)
                                                         .via("wipeFungibleTxn")
                                                         .gas(GAS_TO_OFFER))))
                 .then(
@@ -177,6 +179,7 @@ public class WipeTokenAccountPrecompileSuite extends HapiApiSuite {
     }
 
     private HapiApiSpec wipeNonFungibleTokenScenarios() {
+        final AtomicReference<AccountID> adminAccountID = new AtomicReference<>();
         final AtomicReference<AccountID> accountID = new AtomicReference<>();
         final AtomicReference<TokenID> vanillaTokenID = new AtomicReference<>();
 
@@ -184,10 +187,12 @@ public class WipeTokenAccountPrecompileSuite extends HapiApiSuite {
                 .given(
                         newKeyNamed(WIPE_KEY),
                         newKeyNamed(MULTI_KEY),
+                        cryptoCreate(ADMIN_ACCOUNT)
+                                .key(WIPE_KEY)
+                                .exposingCreatedIdTo(adminAccountID::set),
                         cryptoCreate(ACCOUNT)
                                 .balance(INITIAL_BALANCE)
                                 .exposingCreatedIdTo(accountID::set),
-                        cryptoUpdate(ACCOUNT).key(WIPE_KEY),
                         cryptoCreate(TOKEN_TREASURY),
                         tokenCreate(VANILLA_TOKEN)
                                 .tokenType(NON_FUNGIBLE_UNIQUE)
@@ -216,7 +221,7 @@ public class WipeTokenAccountPrecompileSuite extends HapiApiSuite {
                                                             asAddress(vanillaTokenID.get()),
                                                             asAddress(accountID.get()),
                                                             List.of(2L))
-                                                    .payingWith(ACCOUNT)
+                                                    .payingWith(ADMIN_ACCOUNT)
                                                     .via(
                                                             "wipeNonFungibleAccountDoesNotOwnTheSerialTxn")
                                                     .gas(GAS_TO_OFFER)
@@ -227,7 +232,7 @@ public class WipeTokenAccountPrecompileSuite extends HapiApiSuite {
                                                             asAddress(vanillaTokenID.get()),
                                                             asAddress(accountID.get()),
                                                             List.of(-2L))
-                                                    .payingWith(ACCOUNT)
+                                                    .payingWith(ADMIN_ACCOUNT)
                                                     .via("wipeNonFungibleNegativeSerialTxn")
                                                     .gas(GAS_TO_OFFER)
                                                     .hasKnownStatus(CONTRACT_REVERT_EXECUTED),
@@ -237,7 +242,7 @@ public class WipeTokenAccountPrecompileSuite extends HapiApiSuite {
                                                             asAddress(vanillaTokenID.get()),
                                                             asAddress(accountID.get()),
                                                             List.of(3L))
-                                                    .payingWith(ACCOUNT)
+                                                    .payingWith(ADMIN_ACCOUNT)
                                                     .via("wipeNonFungibleSerialDoesNotExistsTxn")
                                                     .gas(GAS_TO_OFFER)
                                                     .hasKnownStatus(CONTRACT_REVERT_EXECUTED),
@@ -247,7 +252,7 @@ public class WipeTokenAccountPrecompileSuite extends HapiApiSuite {
                                                             asAddress(vanillaTokenID.get()),
                                                             asAddress(accountID.get()),
                                                             serialNumbers)
-                                                    .payingWith(ACCOUNT)
+                                                    .payingWith(ADMIN_ACCOUNT)
                                                     .via("wipeNonFungibleTxn")
                                                     .gas(GAS_TO_OFFER));
                                 }))

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/WipeTokenAccountPrecompileSuite.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/WipeTokenAccountPrecompileSuite.java
@@ -220,7 +220,8 @@ public class WipeTokenAccountPrecompileSuite extends HapiApiSuite {
                                                             asAddress(accountID.get()),
                                                             serialNumbers)
                                                     .payingWith(ADMIN_ACCOUNT)
-                                                    .via("wipeNonFungibleAccountDoesNotOwnWipeKeyTxn")
+                                                    .via(
+                                                            "wipeNonFungibleAccountDoesNotOwnWipeKeyTxn")
                                                     .gas(GAS_TO_OFFER)
                                                     .hasKnownStatus(CONTRACT_REVERT_EXECUTED),
                                             cryptoUpdate(ADMIN_ACCOUNT).key(WIPE_KEY),


### PR DESCRIPTION
**Description**:

Add dedicated account in wipe e2e tests.
Additionally use an invalid token instead of address of an account address in GrantRevokeKycSuite for revoking and granting in cases.

**Related issue(s)**: https://github.com/hashgraph/hedera-services/issues/3766

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [X] Tested (unit, integration, etc.)
