### PR TITLE
Reset contracts before re-counting them inside `InitializationFlow`

### DIFF
--- a/hedera-node/src/main/java/com/hedera/services/context/init/StoreInitializationFlow.java
+++ b/hedera-node/src/main/java/com/hedera/services/context/init/StoreInitializationFlow.java
@@ -69,6 +69,7 @@ public class StoreInitializationFlow {
         backingNfts.rebuildFromSources();
         log.info("Backing stores rebuilt");
 
+        usageLimits.resetNumContracts();
         aliasManager.rebuildAliasesMap(
                 workingState.accounts(),
                 (num, account) -> {

--- a/hedera-node/src/main/java/com/hedera/services/state/validation/UsageLimits.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/validation/UsageLimits.java
@@ -55,6 +55,10 @@ public class UsageLimits implements ContractStorageLimits, AccountUsageTracking 
         updatedNumAccounts();
     }
 
+    public void resetNumContracts() {
+        numContracts = 0;
+    }
+
     public void recordContracts(final int n) {
         numContracts += n;
     }

--- a/hedera-node/src/test/java/com/hedera/services/context/init/StoreInitializationFlowTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/context/init/StoreInitializationFlowTest.java
@@ -84,6 +84,7 @@ class StoreInitializationFlowTest {
         verify(backingTokenRels).rebuildFromSources();
         verify(backingAccounts).rebuildFromSources();
         verify(backingNfts).rebuildFromSources();
+        verify(usageLimits).resetNumContracts();
         verify(aliasManager).rebuildAliasesMap(eq(accounts), captor.capture());
         final var observer = captor.getValue();
         observer.accept(EntityNum.fromInt(1), MerkleAccountFactory.newAccount().get());

--- a/hedera-node/src/test/java/com/hedera/services/state/validation/UsageLimitsTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/state/validation/UsageLimitsTest.java
@@ -104,6 +104,13 @@ class UsageLimitsTest {
     }
 
     @Test
+    void canResetContracts() {
+        subject.recordContracts(2);
+        subject.resetNumContracts();
+        assertEquals(0, subject.getNumContracts());
+    }
+
+    @Test
     void getsPercentsUsed() {
         given(dynamicProperties.maxNumAccounts()).willReturn(5L);
         given(dynamicProperties.maxNumContracts()).willReturn(5L);


### PR DESCRIPTION
**Description**:
 - Ensure contracts are not re-counted on reconnect. 🤕 