### PR TITLE
Fix NPE when creating approve for all synth transaction

### DIFF
--- a/hedera-node/src/main/java/com/hedera/services/store/contracts/precompile/SyntheticTxnFactory.java
+++ b/hedera-node/src/main/java/com/hedera/services/store/contracts/precompile/SyntheticTxnFactory.java
@@ -289,13 +289,14 @@ public class SyntheticTxnFactory {
     }
 
     public TransactionBody.Builder createApproveAllowanceForAllNFT(
-            final SetApprovalForAllWrapper setApprovalForAllWrapper, final TokenID tokenID) {
+            final SetApprovalForAllWrapper setApprovalForAllWrapper) {
+
         final var builder = CryptoApproveAllowanceTransactionBody.newBuilder();
 
         builder.addNftAllowances(
                 NftAllowance.newBuilder()
                         .setApprovedForAll(BoolValue.of(setApprovalForAllWrapper.approved()))
-                        .setTokenId(tokenID)
+                        .setTokenId(setApprovalForAllWrapper.tokenId())
                         .setSpender(setApprovalForAllWrapper.to())
                         .build());
 

--- a/hedera-node/src/main/java/com/hedera/services/store/contracts/precompile/impl/SetApprovalForAllPrecompile.java
+++ b/hedera-node/src/main/java/com/hedera/services/store/contracts/precompile/impl/SetApprovalForAllPrecompile.java
@@ -99,8 +99,7 @@ public class SetApprovalForAllPrecompile extends AbstractWritePrecompile {
         setApprovalForAllWrapper =
                 decoder.decodeSetApprovalForAll(nestedInput, tokenId, aliasResolver);
         transactionBody =
-                syntheticTxnFactory.createApproveAllowanceForAllNFT(
-                        setApprovalForAllWrapper, tokenId);
+                syntheticTxnFactory.createApproveAllowanceForAllNFT(setApprovalForAllWrapper);
         return transactionBody;
     }
 

--- a/hedera-node/src/test/java/com/hedera/services/store/contracts/precompile/ERC721PrecompilesTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/store/contracts/precompile/ERC721PrecompilesTest.java
@@ -949,9 +949,7 @@ class ERC721PrecompilesTest {
         given(feeCalculator.computeFee(any(), any(), any(), any())).willReturn(mockFeeObject);
         given(mockFeeObject.getServiceFee()).willReturn(1L);
 
-        given(
-                        syntheticTxnFactory.createApproveAllowanceForAllNFT(
-                                SET_APPROVAL_FOR_ALL_WRAPPER, token))
+        given(syntheticTxnFactory.createApproveAllowanceForAllNFT(SET_APPROVAL_FOR_ALL_WRAPPER))
                 .willReturn(mockSynthBodyBuilder);
         given(mockSynthBodyBuilder.build()).willReturn(TransactionBody.newBuilder().build());
         given(mockSynthBodyBuilder.setTransactionID(any(TransactionID.class)))
@@ -1021,9 +1019,7 @@ class ERC721PrecompilesTest {
         given(feeCalculator.computeFee(any(), any(), any(), any())).willReturn(mockFeeObject);
         given(mockFeeObject.getServiceFee()).willReturn(1L);
 
-        given(
-                        syntheticTxnFactory.createApproveAllowanceForAllNFT(
-                                SET_APPROVAL_FOR_ALL_WRAPPER, null))
+        given(syntheticTxnFactory.createApproveAllowanceForAllNFT(SET_APPROVAL_FOR_ALL_WRAPPER))
                 .willReturn(mockSynthBodyBuilder);
         given(mockSynthBodyBuilder.build()).willReturn(TransactionBody.newBuilder().build());
         given(mockSynthBodyBuilder.setTransactionID(any(TransactionID.class)))

--- a/hedera-node/src/test/java/com/hedera/services/store/contracts/precompile/SyntheticTxnFactoryTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/store/contracts/precompile/SyntheticTxnFactoryTest.java
@@ -496,12 +496,13 @@ class SyntheticTxnFactoryTest {
     void createsAdjustAllowanceForAllNFT() {
         var allowances = new SetApprovalForAllWrapper(nonFungible, receiver, true);
 
-        final var result = subject.createApproveAllowanceForAllNFT(allowances, token);
+        final var result = subject.createApproveAllowanceForAllNFT(allowances);
         final var txnBody = result.build();
 
         assertEquals(
                 receiver, txnBody.getCryptoApproveAllowance().getNftAllowances(0).getSpender());
-        assertEquals(token, txnBody.getCryptoApproveAllowance().getNftAllowances(0).getTokenId());
+        assertEquals(
+                nonFungible, txnBody.getCryptoApproveAllowance().getNftAllowances(0).getTokenId());
         assertEquals(
                 BoolValue.of(true),
                 txnBody.getCryptoApproveAllowance().getNftAllowances(0).getApprovedForAll());

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/ApproveAllowanceSuite.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/ApproveAllowanceSuite.java
@@ -456,7 +456,6 @@ public class ApproveAllowanceSuite extends HapiApiSuite {
                                                                                                                 spec.registry()
                                                                                                                         .getAccountID(
                                                                                                                                 theSpender)))))))),
-                        getTxnRecord(allowanceTxn).andAllChildRecords().logged(),
                         UtilVerbs.resetToDefault(EXPORT_RECORD_RESULTS_FEATURE_FLAG));
     }
 
@@ -510,10 +509,11 @@ public class ApproveAllowanceSuite extends HapiApiSuite {
                                                                                         theSpender)),
                                                                 true)
                                                         .payingWith(OWNER)
+                                                        .gas(5_000_000L)
                                                         .via(allowanceTxn)
                                                         .hasKnownStatus(SUCCESS))))
                 .then(
-                        getTxnRecord(allowanceTxn).andAllChildRecords().logged(),
+                        childRecordsCheck(allowanceTxn, SUCCESS, recordWith().status(SUCCESS)),
                         UtilVerbs.resetToDefault(EXPORT_RECORD_RESULTS_FEATURE_FLAG));
     }
 }


### PR DESCRIPTION
**Description**:

When a user calls the `setApprovalForAll(address token, address operator, bool approved)` function of the HTS precompiled contract, the tokenId field of the [SetApprovalForAllPrecompile](https://github.com/hashgraph/hedera-services/blob/67166f8e252e9d99608b601c9a026c283765b066/hedera-node/src/main/java/com/hedera/services/store/contracts/precompile/impl/SetApprovalForAllPrecompile.java#L84) is initialized with a `null` value, which causes an NPE in [SyntheticTxnFactory](https://github.com/hashgraph/hedera-services/blob/67166f8e252e9d99608b601c9a026c283765b066/hedera-node/src/main/java/com/hedera/services/store/contracts/precompile/SyntheticTxnFactory.java#L298) when constructing the `CryptoApproveAllowanceTransactionBody`. 

Fix: use the tokenId value from the setApprovalForAllWrapper which is correctly initialized [here](https://github.com/hashgraph/hedera-services/blob/67166f8e252e9d99608b601c9a026c283765b066/hedera-node/src/main/java/com/hedera/services/store/contracts/precompile/codec/DecodingFacade.java#L736).

Also updates the EET that tests the `setApprovalForAll` function, since it wasn't asserting any successful execution (the contract doesn't revert if failed and a successful child record was not expected).

**Related issue(s)**:

Fixes #3797 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
