### PR TITLE
Add delay for reconnect correctness test

### DIFF
--- a/hedera-node/src/test/java/com/hedera/services/store/contracts/precompile/TokenPrecompileReadOperationsTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/store/contracts/precompile/TokenPrecompileReadOperationsTest.java
@@ -51,6 +51,7 @@ import com.hedera.services.store.contracts.precompile.codec.TokenInfoWrapper;
 import com.hedera.services.store.contracts.precompile.utils.PrecompilePricingUtils;
 import com.hedera.services.store.models.Id;
 import com.hedera.services.utils.EntityNum;
+import com.hedera.services.utils.accessors.AccessorFactory;
 import com.hederahashgraph.api.proto.java.TokenID;
 import com.hederahashgraph.api.proto.java.TransactionBody;
 import com.swirlds.merkle.map.MerkleMap;
@@ -90,6 +91,7 @@ class TokenPrecompileReadOperationsTest {
     @Mock private InfrastructureFactory infrastructureFactory;
     @Mock private MerkleMap<EntityNum, MerkleToken> tokenMerkleMap;
     @Mock private AssetsLoader assetLoader;
+    @Mock private AccessorFactory accessorFactory;
     private MerkleToken merkleToken;
     private final TokenID tokenID = asToken("0.0.5");
 
@@ -100,7 +102,7 @@ class TokenPrecompileReadOperationsTest {
 
         PrecompilePricingUtils precompilePricingUtils =
                 new PrecompilePricingUtils(
-                        assetLoader, exchange, () -> feeCalculator, resourceCosts, stateView);
+                        assetLoader, exchange, () -> feeCalculator, resourceCosts, stateView, accessorFactory);
         subject =
                 new HTSPrecompiledContract(
                         dynamicProperties,

--- a/hedera-node/src/test/java/com/hedera/services/store/contracts/precompile/TokenPrecompileReadOperationsTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/store/contracts/precompile/TokenPrecompileReadOperationsTest.java
@@ -91,7 +91,6 @@ class TokenPrecompileReadOperationsTest {
     @Mock private InfrastructureFactory infrastructureFactory;
     @Mock private MerkleMap<EntityNum, MerkleToken> tokenMerkleMap;
     @Mock private AssetsLoader assetLoader;
-    @Mock private AccessorFactory accessorFactory;
     private MerkleToken merkleToken;
     private final TokenID tokenID = asToken("0.0.5");
 

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/reconnect/ValidateDuplicateTransactionAfterReconnect.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/reconnect/ValidateDuplicateTransactionAfterReconnect.java
@@ -61,7 +61,7 @@ public class ValidateDuplicateTransactionAfterReconnect extends HapiApiSuite {
                                 .loggingAvailabilityEvery(10)
                                 .sleepingBetweenRetriesFor(5),
                         // the target node is back online, but may enter reconnect session soon,
-                        // add some delay to wait it to finish
+                        // add some delay to wait for it to finish
                         sleepFor(Duration.ofSeconds(30).toMillis()),
                         cryptoCreate("repeatedTransaction")
                                 .txnId(transactionId)

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/reconnect/ValidateDuplicateTransactionAfterReconnect.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/reconnect/ValidateDuplicateTransactionAfterReconnect.java
@@ -60,6 +60,9 @@ public class ValidateDuplicateTransactionAfterReconnect extends HapiApiSuite {
                                 .within(180, TimeUnit.SECONDS)
                                 .loggingAvailabilityEvery(10)
                                 .sleepingBetweenRetriesFor(5),
+                        // the target node is back online, but may enter reconnect session soon,
+                        // add some delay to wait it to finish
+                        sleepFor(Duration.ofSeconds(30).toMillis()),
                         cryptoCreate("repeatedTransaction")
                                 .txnId(transactionId)
                                 .hasPrecheck(DUPLICATE_TRANSACTION)


### PR DESCRIPTION
Closes regression issue 2739
https://github.com/swirlds/swirlds-platform-regression/issues/2739

Add a little delay after the client found the offline node is back online