### PR TITLE
Ensure release pipeline replaces underscores in the branch name with periods

### DIFF
--- a/.github/workflows/comp-build-release-artifact.yaml
+++ b/.github/workflows/comp-build-release-artifact.yaml
@@ -139,7 +139,7 @@ jobs:
           BRANCH_NAME="${{ github.head_ref || github.ref_name }}"
           BRANCH_NAME="${BRANCH_NAME##origin/}"
           BRANCH_NAME_LOWER="$(echo "${BRANCH_NAME}" | tr '[:upper:]' '[:lower:]')"
-          BRANCH_NAME_SAFE="$(echo "${BRANCH_NAME_LOWER}" | tr '/' '-')"
+          BRANCH_NAME_SAFE="$(echo "${BRANCH_NAME_LOWER}" | tr '/' '-' | tr '_' '.')"
 
           COMMIT_PREFIX="adhoc"
           [[ "${{ inputs.version-policy }}" == "branch-commit" ]] && COMMIT_PREFIX="${BRANCH_NAME_SAFE}"


### PR DESCRIPTION
**Description**:

Resolves an issue caused by a branch name with an underscore character `_` forming an invalid semantic version number.

**Related issue(s)**:

Fixes #3854 

**Notes for reviewer**:

Passing test run: https://github.com/hashgraph/hedera-services/actions/runs/2936862246
