### PR TITLE
Update the release artifact pipeline to use the newest version of deterministic-zip

### DIFF
--- a/.github/workflows/comp-build-release-artifact.yaml
+++ b/.github/workflows/comp-build-release-artifact.yaml
@@ -96,7 +96,7 @@ jobs:
       - name: Install Deterministic Zip Tooling
         run: |
           echo "::group::Download Binary"
-          sudo curl -L -o /usr/local/bin/deterministic-zip https://github.com/timo-reymann/deterministic-zip/releases/download/1.1.0/deterministic-zip_linux-amd64
+          sudo curl -L -o /usr/local/bin/deterministic-zip https://github.com/timo-reymann/deterministic-zip/releases/download/1.2.0/deterministic-zip_linux-amd64
           echo "::endgroup::"
           echo "::group::Change Binary Permissions"
           sudo chmod -v +x /usr/local/bin/deterministic-zip
@@ -257,7 +257,7 @@ jobs:
           fi
 
           ARTIFACT_FILE="${ARTIFACT_BASE_DIR}/${ARTIFACT_NAME}.zip"
-          deterministic-zip -vr "${ARTIFACT_FILE}" *
+          deterministic-zip -D -vr "${ARTIFACT_FILE}" *
 
           echo "::set-output name=folder::${ARTIFACT_BASE_DIR}"
           echo "::set-output name=name::${ARTIFACT_NAME}"


### PR DESCRIPTION
## Description

This change updates the `deterministic-zip` software to version `1.2.0` which enables directory entry support.

### Related Issues

Fixes #3873 

## Example DZip Output

```
Enable verbose mode
Executing feature Recursive ...
read directory data
Executing feature Directories ...
Using go zip compression method 8
Adding VERSION
Adding data/
Adding data/apps/
Adding data/apps/HederaNode.jar
Adding data/lib/
Adding data/lib/animal-sniffer-annotations-1.19.jar
Adding data/lib/annotations-16.0.2.jar
Adding data/lib/annotations-4.1.1.4.jar
Adding data/lib/apiguardian-api-1.0.0.jar
Adding data/lib/bcpkix-jdk15on-1.70.jar
Adding data/lib/bcprov-jdk15on-1.70.jar
Adding data/lib/bcutil-jdk15on-1.70.jar
Adding data/lib/besu-datatypes-22.7.1.jar
Adding data/lib/bls12-381-0.5.0.jar
Adding data/lib/caffeine-3.1.1.jar
Adding data/lib/checker-qual-3.22.0.jar
Adding data/lib/classgraph-4.8.65.jar
Adding data/lib/commons-codec-1.15.jar
Adding data/lib/commons-collections4-4.4.jar
Adding data/lib/commons-io-2.11.0.jar
Adding data/lib/commons-lang3-3.12.0.jar
Adding data/lib/crypto-22.7.1.jar
Adding data/lib/dagger-2.42.jar
Adding data/lib/eclipse-collections-10.4.0.jar
Adding data/lib/eclipse-collections-api-10.4.0.jar
Adding data/lib/eddsa-0.3.0.jar
Adding data/lib/error_prone_annotations-2.14.0.jar
Adding data/lib/evm-22.7.1.jar
Adding data/lib/failureaccess-1.0.1.jar
Adding data/lib/framework-1.3.2.jar
Adding data/lib/framework-internal-1.3.2.jar
Adding data/lib/grpc-api-1.39.0.jar
Adding data/lib/grpc-context-1.39.0.jar
Adding data/lib/grpc-core-1.39.0.jar
Adding data/lib/grpc-netty-1.39.0.jar
Adding data/lib/grpc-protobuf-1.39.0.jar
Adding data/lib/grpc-protobuf-lite-1.39.0.jar
Adding data/lib/grpc-stub-1.39.0.jar
Adding data/lib/grpc-testing-1.39.0.jar
Adding data/lib/gson-2.9.0.jar
Adding data/lib/guava-31.0.1-jre.jar
Adding data/lib/hamcrest-core-1.3.jar
Adding data/lib/hapi-fees-0.29.0-03873-det-zip-update.xb282[35](https://github.com/hashgraph/hedera-services/runs/8098291179?check_suite_focus=true#step:21:36)2.jar
Adding data/lib/hapi-utils-0.29.0-0[38](https://github.com/hashgraph/hedera-services/runs/8098291179?check_suite_focus=true#step:21:39)73-det-zip-update.xb2823[52](https://github.com/hashgraph/hedera-services/runs/8098291179?check_suite_focus=true#step:21:53).jar
Adding data/lib/headlong-6.1.1.jar
Adding data/lib/hedera-protobuf-java-api-0.30.0-SNAPSHOT.jar
Adding data/lib/j2objc-annotations-1.3.jar
Adding data/lib/jackson-annotations-2.13.2.jar
Adding data/lib/jackson-core-2.13.2.jar
Adding data/lib/jackson-databind-2.13.2.1.jar
Adding data/lib/jackson-datatype-jsr310-2.13.2.jar
Adding data/lib/javafx-base-17.jar
Adding data/lib/javax.annotation-api-1.3.2.jar
Adding data/lib/javax.inject-1.jar
Adding data/lib/jna-5.11.0.jar
Adding data/lib/jsr305-3.0.2.jar
Adding data/lib/junit-4.12.jar
Adding data/lib/junit-jupiter-api-5.5.0-M1.jar
Adding data/lib/junit-jupiter-params-5.5.0-M1.jar
Adding data/lib/junit-platform-commons-1.5.0-M1.jar
Adding data/lib/kotlin-stdlib-1.6.10.jar
Adding data/lib/kotlin-stdlib-common-1.6.10.jar
Adding data/lib/kotlin-stdlib-jdk7-1.6.10.jar
Adding data/lib/kotlin-stdlib-jdk8-1.6.10.jar
Adding data/lib/lazysodium-java-5.1.1.jar
Adding data/lib/listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar
Adding data/lib/log4j-api-2.17.2.jar
Adding data/lib/log4j-core-2.17.2.jar
Adding data/lib/netty-buffer-4.1.66.Final.jar
Adding data/lib/netty-codec-4.1.66.Final.jar
Adding data/lib/netty-codec-http-4.1.66.Final.jar
Adding data/lib/netty-codec-http2-4.1.66.Final.jar
Adding data/lib/netty-codec-socks-4.1.66.Final.jar
Adding data/lib/netty-common-4.1.66.Final.jar
Adding data/lib/netty-handler-4.1.66.Final.jar
Adding data/lib/netty-handler-proxy-4.1.66.Final.jar
Adding data/lib/netty-resolver-4.1.66.Final.jar
Adding data/lib/netty-transport-4.1.66.Final.jar
Adding data/lib/netty-transport-native-epoll-4.1.66.Final-linux-x86_64.jar
Adding data/lib/netty-transport-native-epoll-4.1.66.Final.jar
Adding data/lib/netty-transport-native-unix-common-4.1.66.Final.jar
Adding data/lib/opencensus-api-0.28.0.jar
Adding data/lib/opentest4j-1.1.1.jar
Adding data/lib/perfmark-api-0.23.0.jar
Adding data/lib/plugin-api-22.7.1.jar
Adding data/lib/portmapper-2.0.4.jar
Adding data/lib/proto-google-common-protos-2.0.1.jar
Adding data/lib/protobuf-java-3.19.4.jar
Adding data/lib/resource-loader-2.0.1.jar
Adding data/lib/rlp-22.7.1.jar
Adding data/lib/secp2[56](https://github.com/hashgraph/hedera-services/runs/8098291179?check_suite_focus=true#step:21:57)k1-0.5.0.jar
Adding data/lib/slf4j-api-1.8.0-beta2.jar
Adding data/lib/slf4j-nop-1.8.0-beta2.jar
Adding data/lib/swirlds-common-0.29.1.jar
Adding data/lib/swirlds-common-test-0.29.1.jar
Adding data/lib/swirlds-fchashmap-0.29.1.jar
Adding data/lib/swirlds-fcqueue-0.29.1.jar
Adding data/lib/swirlds-jasperdb-0.29.1.jar
Adding data/lib/swirlds-logging-0.29.1.jar
Adding data/lib/swirlds-merkle-0.29.1.jar
Adding data/lib/swirlds-platform-core-0.29.1.jar
Adding data/lib/swirlds-test-framework-0.29.1.jar
Adding data/lib/swirlds-virtualmap-0.29.1.jar
Adding data/lib/tuweni-bytes-2.2.0.jar
Adding data/lib/tuweni-units-2.2.0.jar
Adding during-freeze.sh
Adding immediate.sh
```

## Example Zip Inspection

```
Archive:  build-03873-det-zip-update-b282352c.zip
  Length      Date    Time    Name
---------  ---------- -----   ----
       94  10-31-2018 19:00   VERSION
        0  10-31-2018 19:00   data/
        0  10-31-2018 19:00   data/apps/
  2976836  10-31-2018 19:00   data/apps/HederaNode.jar
        0  10-31-2018 19:00   data/lib/
     3473  10-31-2018 19:00   data/lib/animal-sniffer-annotations-1.19.jar
    18538  10-31-2018 19:00   data/lib/annotations-16.0.2.jar
     3120  10-31-2018 19:00   data/lib/annotations-4.1.1.4.jar
     2164  10-31-2018 19:00   data/lib/apiguardian-api-1.0.0.jar
   963713  10-31-2018 19:00   data/lib/bcpkix-jdk15on-1.70.jar
  5867298  10-31-2018 19:00   data/lib/bcprov-jdk15on-1.70.jar
   482530  10-31-2018 19:00   data/lib/bcutil-jdk15on-1.70.jar
     6464  10-31-2018 19:00   data/lib/besu-datatypes-22.7.1.jar
  1715703  10-31-2018 19:00   data/lib/bls12-381-0.5.0.jar
   745492  10-31-2018 19:00   data/lib/caffeine-3.1.1.jar
   222169  10-31-2018 19:00   data/lib/checker-qual-3.22.0.jar
   481151  10-31-2018 19:00   data/lib/classgraph-4.8.65.jar
   353793  10-31-2018 19:00   data/lib/commons-codec-1.15.jar
   751914  10-31-2018 19:00   data/lib/commons-collections4-4.4.jar
   327135  10-31-2018 19:00   data/lib/commons-io-2.11.0.jar
   587402  10-31-2018 19:00   data/lib/commons-lang3-3.12.0.jar
    60178  10-31-2018 19:00   data/lib/crypto-22.7.1.jar
    36930  10-31-2018 19:00   data/lib/dagger-2.42.jar
 10330135  10-31-2018 19:00   data/lib/eclipse-collections-10.4.0.jar
  1413775  10-31-2018 19:00   data/lib/eclipse-collections-api-10.4.0.jar
    63292  10-31-2018 19:00   data/lib/eddsa-0.3.0.jar
    16023  10-31-2018 19:00   data/lib/error_prone_annotations-2.14.0.jar
   256054  10-31-2018 19:00   data/lib/evm-22.7.1.jar
     4617  10-31-2018 19:00   data/lib/failureaccess-1.0.1.jar
   178222  10-31-2018 19:00   data/lib/framework-1.3.2.jar
   301266  10-31-2018 19:00   data/lib/framework-internal-1.3.2.jar
   254516  10-31-2018 19:00   data/lib/grpc-api-1.39.0.jar
    30665  10-31-2018 19:00   data/lib/grpc-context-1.39.0.jar
   655878  10-31-2018 19:00   data/lib/grpc-core-1.39.0.jar
   279975  10-31-2018 19:00   data/lib/grpc-netty-1.39.0.jar
     5178  10-31-2018 19:00   data/lib/grpc-protobuf-1.39.0.jar
     7628  10-31-2018 19:00   data/lib/grpc-protobuf-lite-1.39.0.jar
    49595  10-31-2018 19:00   data/lib/grpc-stub-1.39.0.jar
    67794  10-31-2018 19:00   data/lib/grpc-testing-1.39.0.jar
   249277  10-31-2018 19:00   data/lib/gson-2.9.0.jar
  2974216  10-31-2018 19:00   data/lib/guava-31.0.1-jre.jar
    45024  10-31-2018 19:00   data/lib/hamcrest-core-1.3.jar
   134758  10-31-2018 19:00   data/lib/hapi-fees-0.29.0-03873-det-zip-update.xb282352.jar
    97216  10-31-2018 19:00   data/lib/hapi-utils-0.29.0-03873-det-zip-update.xb282352.jar
   122989  10-31-2018 19:00   data/lib/headlong-6.1.1.jar
  3327454  10-31-2018 19:00   data/lib/hedera-protobuf-java-api-0.30.0-SNAPSHOT.jar
     8781  10-31-2018 19:00   data/lib/j2objc-annotations-1.3.jar
    75717  10-31-2018 19:00   data/lib/jackson-annotations-2.13.2.jar
   374739  10-31-2018 19:00   data/lib/jackson-core-2.13.2.jar
  1534977  10-31-2018 19:00   data/lib/jackson-databind-2.13.2.1.jar
   121204  10-31-2018 19:00   data/lib/jackson-datatype-jsr310-2.13.2.jar
      261  10-31-2018 19:00   data/lib/javafx-base-17.jar
    26586  10-31-2018 19:00   data/lib/javax.annotation-api-1.3.2.jar
     2497  10-31-2018 19:00   data/lib/javax.inject-1.jar
  1825174  10-31-2018 19:00   data/lib/jna-5.11.0.jar
    19936  10-31-2018 19:00   data/lib/jsr305-3.0.2.jar
   314932  10-31-2018 19:00   data/lib/junit-4.12.jar
   134130  10-31-2018 19:00   data/lib/junit-jupiter-api-5.5.0-M1.jar
   548082  10-31-2018 19:00   data/lib/junit-jupiter-params-5.5.0-M1.jar
    89517  10-31-2018 19:00   data/lib/junit-platform-commons-1.5.0-M1.jar
  1508076  10-31-2018 19:00   data/lib/kotlin-stdlib-1.6.10.jar
   200617  10-31-2018 19:00   data/lib/kotlin-stdlib-common-1.6.10.jar
    22358  10-31-2018 19:00   data/lib/kotlin-stdlib-jdk7-1.6.10.jar
    16202  10-31-2018 19:00   data/lib/kotlin-stdlib-jdk8-1.6.10.jar
  2223734  10-31-2018 19:00   data/lib/lazysodium-java-5.1.1.jar
     2199  10-31-2018 19:00   data/lib/listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar
   302511  10-31-2018 19:00   data/lib/log4j-api-2.17.2.jar
  1811089  10-31-2018 19:00   data/lib/log4j-core-2.17.2.jar
   301747  10-31-2018 19:00   data/lib/netty-buffer-4.1.66.Final.jar
   335445  10-31-2018 19:00   data/lib/netty-codec-4.1.66.Final.jar
   634133  10-31-2018 19:00   data/lib/netty-codec-http-4.1.66.Final.jar
   471239  10-31-2018 19:00   data/lib/netty-codec-http2-4.1.66.Final.jar
   119035  10-31-2018 19:00   data/lib/netty-codec-socks-4.1.66.Final.jar
   651268  10-31-2018 19:00   data/lib/netty-common-4.1.66.Final.jar
   524455  10-31-2018 19:00   data/lib/netty-handler-4.1.66.Final.jar
    23961  10-31-2018 19:00   data/lib/netty-handler-proxy-4.1.66.Final.jar
    37008  10-31-2018 19:00   data/lib/netty-resolver-4.1.66.Final.jar
   478383  10-31-2018 19:00   data/lib/netty-transport-4.1.66.Final.jar
   171186  10-31-2018 19:00   data/lib/netty-transport-native-epoll-4.1.66.Final-linux-x86_64.jar
   140373  10-31-2018 19:00   data/lib/netty-transport-native-epoll-4.1.66.Final.jar
    40171  10-31-2018 19:00   data/lib/netty-transport-native-unix-common-4.1.66.Final.jar
   351661  10-31-2018 19:00   data/lib/opencensus-api-0.28.0.jar
     7121  10-31-2018 19:00   data/lib/opentest4j-1.1.1.jar
     6385  10-31-2018 19:00   data/lib/perfmark-api-0.23.0.jar
    39565  10-31-2018 19:00   data/lib/plugin-api-22.7.1.jar
   239983  10-31-2018 19:00   data/lib/portmapper-2.0.4.jar
  1557780  10-31-2018 19:00   data/lib/proto-google-common-protos-2.0.1.jar
  1681869  10-31-2018 19:00   data/lib/protobuf-java-3.19.4.jar
    15573  10-31-2018 19:00   data/lib/resource-loader-2.0.1.jar
    27396  10-31-2018 19:00   data/lib/rlp-22.7.1.jar
   701601  10-31-2018 19:00   data/lib/secp256k1-0.5.0.jar
    43907  10-31-2018 19:00   data/lib/slf4j-api-1.8.0-beta2.jar
     5560  10-31-2018 19:00   data/lib/slf4j-nop-1.8.0-beta2.jar
   614566  10-31-2018 19:00   data/lib/swirlds-common-0.29.1.jar
   148753  10-31-2018 19:00   data/lib/swirlds-common-test-0.29.1.jar
    25450  10-31-2018 19:00   data/lib/swirlds-fchashmap-0.29.1.jar
    20289  10-31-2018 19:00   data/lib/swirlds-fcqueue-0.29.1.jar
   157721  10-31-2018 19:00   data/lib/swirlds-jasperdb-0.29.1.jar
    44146  10-31-2018 19:00   data/lib/swirlds-logging-0.29.1.jar
    29237  10-31-2018 19:00   data/lib/swirlds-merkle-0.29.1.jar
   784716  10-31-2018 19:00   data/lib/swirlds-platform-core-0.29.1.jar
     7861  10-31-2018 19:00   data/lib/swirlds-test-framework-0.29.1.jar
   139095  10-31-2018 19:00   data/lib/swirlds-virtualmap-0.29.1.jar
    62349  10-31-2018 19:00   data/lib/tuweni-bytes-2.2.0.jar
    62495  10-31-2018 19:00   data/lib/tuweni-units-2.2.0.jar
     6560  10-31-2018 19:00   during-freeze.sh
     5174  10-31-2018 19:00   immediate.sh
---------                     -------
 58350180                     107 files

```
