### PR TITLE
Add expiry stats + misc cleanup and fixes

### DIFF
--- a/hedera-node/src/main/java/com/hedera/services/state/expiry/EntityAutoExpiry.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/expiry/EntityAutoExpiry.java
@@ -15,6 +15,8 @@
  */
 package com.hedera.services.state.expiry;
 
+import static com.hedera.services.state.expiry.ExpiryProcessResult.*;
+
 import com.hedera.services.config.HederaNumbers;
 import com.hedera.services.context.properties.GlobalDynamicProperties;
 import com.hedera.services.records.ConsensusTimeTracker;
@@ -22,14 +24,11 @@ import com.hedera.services.state.logic.NetworkCtxManager;
 import com.hedera.services.state.merkle.MerkleNetworkContext;
 import com.hedera.services.state.submerkle.SequenceNumber;
 import com.hedera.services.throttling.ExpiryThrottle;
-
 import java.time.Instant;
 import java.util.function.Supplier;
 import javax.annotation.Nullable;
 import javax.inject.Inject;
 import javax.inject.Singleton;
-
-import static com.hedera.services.state.expiry.ExpiryProcessResult.*;
 
 @Singleton
 public class EntityAutoExpiry {

--- a/hedera-node/src/main/java/com/hedera/services/state/expiry/EntityAutoExpiry.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/expiry/EntityAutoExpiry.java
@@ -121,7 +121,7 @@ public class EntityAutoExpiry {
             final int entitiesProcessed) {
         return idsScanned < maxIdsToScan
                 && entitiesProcessed < maxEntitiesToProcess
-                && result != NO_CAPACITY_NOW
+                && result != NO_CAPACITY_LEFT
                 && consensusTimeTracker.hasMoreStandaloneRecordTime();
     }
 

--- a/hedera-node/src/main/java/com/hedera/services/state/expiry/EntityAutoExpiry.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/expiry/EntityAutoExpiry.java
@@ -83,7 +83,6 @@ public class EntityAutoExpiry {
         if (networkCtxManager.currentTxnIsFirstInConsensusSecond()) {
             curNetworkCtx.clearAutoRenewSummaryCounts();
         }
-        expiryProcess.beginCycle(currentConsTime);
 
         int idsScanned = 0;
         int entitiesProcessed = 0;
@@ -96,7 +95,7 @@ public class EntityAutoExpiry {
                 idsScanned++;
             }
             // Each processing attempt will generate at most one child record
-            result = expiryProcess.process(scanNum);
+            result = expiryProcess.process(scanNum, currentConsTime);
             if (result == NOTHING_TO_DO) {
                 advanceScan = true;
             } else {
@@ -107,7 +106,6 @@ public class EntityAutoExpiry {
             }
         }
 
-        expiryProcess.endCycle();
         curNetworkCtx.updateAutoRenewSummaryCounts(idsScanned, entitiesProcessed);
         curNetworkCtx.updateLastScannedEntity(advanceScan ? scanNum : scanNum - 1);
     }

--- a/hedera-node/src/main/java/com/hedera/services/state/expiry/ExpiryProcess.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/expiry/ExpiryProcess.java
@@ -15,8 +15,7 @@
  */
 package com.hedera.services.state.expiry;
 
-import static com.hedera.services.state.expiry.ExpiryProcessResult.NOTHING_TO_DO;
-import static com.hedera.services.state.expiry.ExpiryProcessResult.STILL_MORE_TO_DO;
+import static com.hedera.services.state.expiry.ExpiryProcessResult.*;
 
 import com.hedera.services.state.expiry.classification.ClassificationWork;
 import com.hedera.services.state.expiry.removal.RemovalWork;
@@ -46,7 +45,7 @@ public class ExpiryProcess {
         final var entityNum = EntityNum.fromLong(literalNum);
         final var result = classifier.classify(entityNum, now);
         return switch (result) {
-            case COME_BACK_LATER -> STILL_MORE_TO_DO;
+            case COME_BACK_LATER -> NO_CAPACITY_LEFT;
 
             case EXPIRED_ACCOUNT_READY_TO_RENEW -> renewalWork.tryToRenewAccount(entityNum, now);
             case DETACHED_ACCOUNT_GRACE_PERIOD_OVER -> removalWork.tryToRemoveAccount(entityNum);

--- a/hedera-node/src/main/java/com/hedera/services/state/expiry/ExpiryProcess.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/expiry/ExpiryProcess.java
@@ -15,8 +15,8 @@
  */
 package com.hedera.services.state.expiry;
 
-import static com.hedera.services.state.expiry.EntityProcessResult.NOTHING_TO_DO;
-import static com.hedera.services.state.expiry.EntityProcessResult.STILL_MORE_TO_DO;
+import static com.hedera.services.state.expiry.ExpiryProcessResult.NOTHING_TO_DO;
+import static com.hedera.services.state.expiry.ExpiryProcessResult.STILL_MORE_TO_DO;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.hedera.services.state.expiry.classification.ClassificationWork;
@@ -30,15 +30,15 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 @Singleton
-public class AutoExpiryCycle {
-    private static final Logger log = LogManager.getLogger(AutoExpiryCycle.class);
+public class ExpiryProcess {
+    private static final Logger log = LogManager.getLogger(ExpiryProcess.class);
     private final RenewalWork renewalWork;
     private final RemovalWork removalWork;
     private final ClassificationWork classifier;
     private Instant cycleTime = null;
 
     @Inject
-    public AutoExpiryCycle(
+    public ExpiryProcess(
             final ClassificationWork classifier,
             final RenewalWork renewalWork,
             final RemovalWork removalWork) {
@@ -52,7 +52,7 @@ public class AutoExpiryCycle {
         cycleTime = currentConsTime;
     }
 
-    public EntityProcessResult process(final long literalNum) {
+    public ExpiryProcessResult process(final long literalNum) {
         warnIfNotInCycle();
 
         final var entityNum = EntityNum.fromLong(literalNum);

--- a/hedera-node/src/main/java/com/hedera/services/state/expiry/ExpiryProcessResult.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/expiry/ExpiryProcessResult.java
@@ -15,8 +15,25 @@
  */
 package com.hedera.services.state.expiry;
 
-public enum EntityProcessResult {
+/**
+ * Summarizes the result of processing an {@code 0.0.X} id that might refer to an expiring entity.
+ */
+public enum ExpiryProcessResult {
+    /**
+     * Either the id did not refer to an entity; or that entity is not expired.
+     */
     NOTHING_TO_DO,
+    /**
+     * The id referred to an expiring entity, but its auto-renewal or auto-removal work could
+     * not be completed in the current process step.
+     */
     STILL_MORE_TO_DO,
-    DONE
+    /**
+     * The id referred to an expiring entity, and its auto-renewal or auto-removal work is complete.
+     */
+    DONE,
+    /**
+     * The expiry throttle bucket was full, and nothing can be inferred about the given id.
+     */
+    NO_CAPACITY_NOW
 }

--- a/hedera-node/src/main/java/com/hedera/services/state/expiry/ExpiryProcessResult.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/expiry/ExpiryProcessResult.java
@@ -24,12 +24,16 @@ public enum ExpiryProcessResult {
     /**
      * The id referred to an expiring entity, but its auto-renewal or auto-removal work could not be
      * completed in the current process step.
+     *
+     * <p><b>IMPORTANT:</b> Right now, the only reason that auto-renewal or auto-removal work will not
+     * complete for an entity is {@link ExpiryProcessResult#NO_CAPACITY_LEFT}. But it is quite
+     * conceivable we will use this result value in the future.
      */
     STILL_MORE_TO_DO,
     /**
      * The id referred to an expiring entity, and its auto-renewal or auto-removal work is complete.
      */
     DONE,
-    /** The expiry throttle bucket was full, and nothing can be inferred about the given id. */
-    NO_CAPACITY_NOW
+    /** The expiry throttle bucket is full, and no more work can be done at this time. */
+    NO_CAPACITY_LEFT
 }

--- a/hedera-node/src/main/java/com/hedera/services/state/expiry/ExpiryProcessResult.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/expiry/ExpiryProcessResult.java
@@ -19,21 +19,17 @@ package com.hedera.services.state.expiry;
  * Summarizes the result of processing an {@code 0.0.X} id that might refer to an expiring entity.
  */
 public enum ExpiryProcessResult {
-    /**
-     * Either the id did not refer to an entity; or that entity is not expired.
-     */
+    /** Either the id did not refer to an entity; or that entity is not expired. */
     NOTHING_TO_DO,
     /**
-     * The id referred to an expiring entity, but its auto-renewal or auto-removal work could
-     * not be completed in the current process step.
+     * The id referred to an expiring entity, but its auto-renewal or auto-removal work could not be
+     * completed in the current process step.
      */
     STILL_MORE_TO_DO,
     /**
      * The id referred to an expiring entity, and its auto-renewal or auto-removal work is complete.
      */
     DONE,
-    /**
-     * The expiry throttle bucket was full, and nothing can be inferred about the given id.
-     */
+    /** The expiry throttle bucket was full, and nothing can be inferred about the given id. */
     NO_CAPACITY_NOW
 }

--- a/hedera-node/src/main/java/com/hedera/services/state/expiry/ExpiryProcessResult.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/expiry/ExpiryProcessResult.java
@@ -25,8 +25,8 @@ public enum ExpiryProcessResult {
      * The id referred to an expiring entity, but its auto-renewal or auto-removal work could not be
      * completed in the current process step.
      *
-     * <p><b>IMPORTANT:</b> Right now, the only reason that auto-renewal or auto-removal work will not
-     * complete for an entity is {@link ExpiryProcessResult#NO_CAPACITY_LEFT}. But it is quite
+     * <p><b>IMPORTANT:</b> Right now, the only reason that auto-renewal or auto-removal work will
+     * not complete for an entity is {@link ExpiryProcessResult#NO_CAPACITY_LEFT}. But it is quite
      * conceivable we will use this result value in the future.
      */
     STILL_MORE_TO_DO,

--- a/hedera-node/src/main/java/com/hedera/services/state/expiry/removal/ContractGC.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/expiry/removal/ContractGC.java
@@ -35,9 +35,12 @@ import java.util.List;
 import java.util.function.Supplier;
 import javax.inject.Inject;
 import javax.inject.Singleton;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 @Singleton
 public class ContractGC {
+    private static final Logger log = LogManager.getLogger(ContractGC.class);
     static final List<MapAccessType> BYTECODE_REMOVAL_WORK = List.of(BLOBS_REMOVE);
     static final List<MapAccessType> ROOT_KEY_UPDATE_WORK = List.of(ACCOUNTS_GET_FOR_MODIFY);
     static final List<MapAccessType> ONLY_SLOT_REMOVAL_WORK = List.of(STORAGE_REMOVE);
@@ -107,9 +110,16 @@ public class ContractGC {
         var n = 0;
         var contractKey = rootKey;
         while (contractKey != null && expiryThrottle.allow(workToRemoveFrom(i)) && i-- > 0) {
-            // We are always removing the root, hence receiving the new root
-            contractKey = removalFacilitation.removeNext(contractKey, contractKey, listRemoval);
-            n++;
+            try {
+                contractKey = removalFacilitation.removeNext(contractKey, contractKey, listRemoval);
+                n++;
+            } catch (Exception unrecoverable) {
+                log.error(
+                        "Unable to reclaim all storage from contract 0.0.{}",
+                        contractNum,
+                        unrecoverable);
+                contractKey = null;
+            }
         }
         if (contractKey == null) {
             // Treat all pairs as removed if we have no more non-null keys

--- a/hedera-node/src/main/java/com/hedera/services/state/expiry/removal/RemovalHelper.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/expiry/removal/RemovalHelper.java
@@ -15,6 +15,8 @@
  */
 package com.hedera.services.state.expiry.removal;
 
+import static com.hedera.services.state.expiry.ExpiryProcessResult.*;
+
 import com.hedera.services.context.properties.GlobalDynamicProperties;
 import com.hedera.services.state.expiry.ExpiryProcessResult;
 import com.hedera.services.state.expiry.ExpiryRecordsHelper;
@@ -23,8 +25,6 @@ import com.hedera.services.stats.ExpiryStats;
 import com.hedera.services.utils.EntityNum;
 import javax.inject.Inject;
 import javax.inject.Singleton;
-
-import static com.hedera.services.state.expiry.ExpiryProcessResult.*;
 
 @Singleton
 public class RemovalHelper implements RemovalWork {

--- a/hedera-node/src/main/java/com/hedera/services/state/expiry/removal/RemovalHelper.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/expiry/removal/RemovalHelper.java
@@ -15,12 +15,12 @@
  */
 package com.hedera.services.state.expiry.removal;
 
-import static com.hedera.services.state.expiry.EntityProcessResult.DONE;
-import static com.hedera.services.state.expiry.EntityProcessResult.NOTHING_TO_DO;
-import static com.hedera.services.state.expiry.EntityProcessResult.STILL_MORE_TO_DO;
+import static com.hedera.services.state.expiry.ExpiryProcessResult.DONE;
+import static com.hedera.services.state.expiry.ExpiryProcessResult.NOTHING_TO_DO;
+import static com.hedera.services.state.expiry.ExpiryProcessResult.STILL_MORE_TO_DO;
 
 import com.hedera.services.context.properties.GlobalDynamicProperties;
-import com.hedera.services.state.expiry.EntityProcessResult;
+import com.hedera.services.state.expiry.ExpiryProcessResult;
 import com.hedera.services.state.expiry.ExpiryRecordsHelper;
 import com.hedera.services.state.expiry.classification.ClassificationWork;
 import com.hedera.services.utils.EntityNum;
@@ -50,7 +50,7 @@ public class RemovalHelper implements RemovalWork {
     }
 
     @Override
-    public EntityProcessResult tryToRemoveAccount(final EntityNum account) {
+    public ExpiryProcessResult tryToRemoveAccount(final EntityNum account) {
         if (!properties.shouldAutoRenewAccounts()) {
             return NOTHING_TO_DO;
         }
@@ -58,14 +58,14 @@ public class RemovalHelper implements RemovalWork {
     }
 
     @Override
-    public EntityProcessResult tryToRemoveContract(final EntityNum contract) {
+    public ExpiryProcessResult tryToRemoveContract(final EntityNum contract) {
         if (!properties.shouldAutoRenewContracts()) {
             return NOTHING_TO_DO;
         }
         return remove(contract, true);
     }
 
-    private EntityProcessResult remove(final EntityNum num, final boolean isContract) {
+    private ExpiryProcessResult remove(final EntityNum num, final boolean isContract) {
         final var lastClassified = classifier.getLastClassified();
         if (isContract && !contractGC.expireBestEffort(num, lastClassified)) {
             return STILL_MORE_TO_DO;

--- a/hedera-node/src/main/java/com/hedera/services/state/expiry/removal/RemovalHelper.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/expiry/removal/RemovalHelper.java
@@ -15,10 +15,6 @@
  */
 package com.hedera.services.state.expiry.removal;
 
-import static com.hedera.services.state.expiry.ExpiryProcessResult.DONE;
-import static com.hedera.services.state.expiry.ExpiryProcessResult.NOTHING_TO_DO;
-import static com.hedera.services.state.expiry.ExpiryProcessResult.STILL_MORE_TO_DO;
-
 import com.hedera.services.context.properties.GlobalDynamicProperties;
 import com.hedera.services.state.expiry.ExpiryProcessResult;
 import com.hedera.services.state.expiry.ExpiryRecordsHelper;
@@ -27,6 +23,8 @@ import com.hedera.services.stats.ExpiryStats;
 import com.hedera.services.utils.EntityNum;
 import javax.inject.Inject;
 import javax.inject.Singleton;
+
+import static com.hedera.services.state.expiry.ExpiryProcessResult.*;
 
 @Singleton
 public class RemovalHelper implements RemovalWork {
@@ -72,7 +70,7 @@ public class RemovalHelper implements RemovalWork {
     private ExpiryProcessResult remove(final EntityNum num, final boolean isContract) {
         final var lastClassified = classifier.getLastClassified();
         if (isContract && !contractGC.expireBestEffort(num, lastClassified)) {
-            return STILL_MORE_TO_DO;
+            return NO_CAPACITY_LEFT;
         }
         final var gcOutcome = accountGC.expireBestEffort(num, lastClassified);
         if (gcOutcome.needsExternalizing()) {
@@ -85,7 +83,7 @@ public class RemovalHelper implements RemovalWork {
             }
             return DONE;
         } else {
-            return STILL_MORE_TO_DO;
+            return NO_CAPACITY_LEFT;
         }
     }
 }

--- a/hedera-node/src/main/java/com/hedera/services/state/expiry/removal/RemovalWork.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/expiry/removal/RemovalWork.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2022 Hedera Hashgraph, LLC
+ * Copyright (C) 2022 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/src/main/java/com/hedera/services/state/expiry/removal/RemovalWork.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/expiry/removal/RemovalWork.java
@@ -15,7 +15,7 @@
  */
 package com.hedera.services.state.expiry.removal;
 
-import com.hedera.services.state.expiry.EntityProcessResult;
+import com.hedera.services.state.expiry.ExpiryProcessResult;
 import com.hedera.services.utils.EntityNum;
 
 /** Provides the logic needed for the account and contract expiry and removal cycle */
@@ -28,7 +28,7 @@ public interface RemovalWork {
      * @param account expired account
      * @return result for the successful removal
      */
-    EntityProcessResult tryToRemoveAccount(EntityNum account);
+    ExpiryProcessResult tryToRemoveAccount(EntityNum account);
     /**
      * Tries to remove an expired contract and returns {@code EntityProcessResult.DONE} if it is
      * successful. If the auto-removal of expiring contracts is not enabled, returns {@code
@@ -37,5 +37,5 @@ public interface RemovalWork {
      * @param contract expired contract
      * @return result for the successful removal
      */
-    EntityProcessResult tryToRemoveContract(EntityNum contract);
+    ExpiryProcessResult tryToRemoveContract(EntityNum contract);
 }

--- a/hedera-node/src/main/java/com/hedera/services/state/expiry/removal/TreasuryReturnHelper.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/expiry/removal/TreasuryReturnHelper.java
@@ -71,7 +71,7 @@ public class TreasuryReturnHelper {
         }
     }
 
-    EntityNumPair finishNft(
+    EntityNumPair burnOrReturnNft(
             final boolean burn,
             final EntityNumPair rootKey,
             final MerkleMap<EntityNumPair, MerkleUniqueToken> nfts) {

--- a/hedera-node/src/main/java/com/hedera/services/state/expiry/renewal/RenewalHelper.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/expiry/renewal/RenewalHelper.java
@@ -96,7 +96,7 @@ public class RenewalHelper implements RenewalWork {
         final var payer = classifier.getPayerForLastClassified();
         final var expired = classifier.getLastClassified();
         if (!expiryThrottle.allow(workFor(payer, expired))) {
-            return STILL_MORE_TO_DO;
+            return NO_CAPACITY_LEFT;
         }
 
         final long reqPeriod = expired.getAutoRenewSecs();

--- a/hedera-node/src/main/java/com/hedera/services/state/expiry/renewal/RenewalHelper.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/expiry/renewal/RenewalHelper.java
@@ -15,14 +15,14 @@
  */
 package com.hedera.services.state.expiry.renewal;
 
-import static com.hedera.services.state.expiry.EntityProcessResult.*;
+import static com.hedera.services.state.expiry.ExpiryProcessResult.*;
 import static com.hedera.services.throttling.MapAccessType.ACCOUNTS_GET_FOR_MODIFY;
 import static com.hedera.services.utils.EntityNum.fromAccountId;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.hedera.services.context.properties.GlobalDynamicProperties;
 import com.hedera.services.fees.FeeCalculator;
-import com.hedera.services.state.expiry.EntityProcessResult;
+import com.hedera.services.state.expiry.ExpiryProcessResult;
 import com.hedera.services.state.expiry.ExpiryRecordsHelper;
 import com.hedera.services.state.expiry.classification.ClassificationWork;
 import com.hedera.services.state.expiry.classification.EntityLookup;
@@ -69,7 +69,7 @@ public class RenewalHelper implements RenewalWork {
     }
 
     @Override
-    public EntityProcessResult tryToRenewContract(
+    public ExpiryProcessResult tryToRenewContract(
             final EntityNum contract, final Instant cycleTime) {
         if (!dynamicProperties.shouldAutoRenewContracts()) {
             return NOTHING_TO_DO;
@@ -78,14 +78,14 @@ public class RenewalHelper implements RenewalWork {
     }
 
     @Override
-    public EntityProcessResult tryToRenewAccount(final EntityNum account, final Instant cycleTime) {
+    public ExpiryProcessResult tryToRenewAccount(final EntityNum account, final Instant cycleTime) {
         if (!dynamicProperties.shouldAutoRenewAccounts()) {
             return NOTHING_TO_DO;
         }
         return renew(account, cycleTime, false);
     }
 
-    private EntityProcessResult renew(
+    private ExpiryProcessResult renew(
             final EntityNum account, final Instant cycleTime, final boolean isContract) {
         assertHasLastClassifiedAccount();
 

--- a/hedera-node/src/main/java/com/hedera/services/state/expiry/renewal/RenewalWork.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/expiry/renewal/RenewalWork.java
@@ -15,7 +15,7 @@
  */
 package com.hedera.services.state.expiry.renewal;
 
-import com.hedera.services.state.expiry.EntityProcessResult;
+import com.hedera.services.state.expiry.ExpiryProcessResult;
 import com.hedera.services.utils.EntityNum;
 import java.time.Instant;
 
@@ -30,7 +30,7 @@ public interface RenewalWork {
      * @param cycleTime consensus time for the current renewal cycle
      * @return result for the successful renewal
      */
-    EntityProcessResult tryToRenewAccount(EntityNum account, final Instant cycleTime);
+    ExpiryProcessResult tryToRenewAccount(EntityNum account, final Instant cycleTime);
 
     /**
      * Tries to renew a contract and returns {@code EntityProcessResult.DONE} if it is successful.
@@ -41,5 +41,5 @@ public interface RenewalWork {
      * @param cycleTime consensus time for the current renewal cycle
      * @return result for the successful renewal
      */
-    EntityProcessResult tryToRenewContract(EntityNum contract, final Instant cycleTime);
+    ExpiryProcessResult tryToRenewContract(EntityNum contract, final Instant cycleTime);
 }

--- a/hedera-node/src/main/java/com/hedera/services/state/merkle/MerkleNetworkContext.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/merkle/MerkleNetworkContext.java
@@ -613,7 +613,7 @@ public class MerkleNetworkContext extends PartialMerkleLeaf implements MerkleLea
     }
 
     /* --- Getters --- */
-    public long getEntitiesScannedThisSecond() {
+    public long idsScannedThisSecond() {
         return entitiesScannedThisSecond;
     }
 

--- a/hedera-node/src/main/java/com/hedera/services/state/migration/ReleaseThirtyMigration.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/migration/ReleaseThirtyMigration.java
@@ -83,7 +83,7 @@ public class ReleaseThirtyMigration {
                 () ->
                         contracts.forEach(
                                 (id, account) -> {
-                                    if (account.isSmartContract()) {
+                                    if (account.isSmartContract() && !account.isDeleted()) {
                                         setNewExpiry(lastKnownConsensusSecond, contracts, id);
                                     }
                                 }),

--- a/hedera-node/src/main/java/com/hedera/services/stats/ExpiryStats.java
+++ b/hedera-node/src/main/java/com/hedera/services/stats/ExpiryStats.java
@@ -1,0 +1,23 @@
+package com.hedera.services.stats;
+
+import com.hedera.services.state.merkle.MerkleNetworkContext;
+import com.swirlds.common.system.Platform;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+@Singleton
+public class ExpiryStats {
+
+    @Inject
+    public ExpiryStats() {
+    }
+
+    public void registerWith(final Platform platform) {
+        throw new AssertionError("Not implemented");
+    }
+
+    public void updateAll() {
+        throw new AssertionError("Not implemented");
+    }
+}

--- a/hedera-node/src/main/java/com/hedera/services/stats/ExpiryStats.java
+++ b/hedera-node/src/main/java/com/hedera/services/stats/ExpiryStats.java
@@ -61,8 +61,8 @@ public class ExpiryStats {
         contractsRenewed.increment();
     }
 
-    public void incorporateLastConsSec(final int idsScanned) {
-        idsScannedPerConsSec.update(idsScanned);
+    public void includeIdsScannedInLastConsSec(final long n) {
+        idsScannedPerConsSec.update(n);
     }
 
     public static final class Descriptions {

--- a/hedera-node/src/main/java/com/hedera/services/stats/ExpiryStats.java
+++ b/hedera-node/src/main/java/com/hedera/services/stats/ExpiryStats.java
@@ -1,23 +1,95 @@
 package com.hedera.services.stats;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.hedera.services.state.merkle.MerkleNetworkContext;
+import com.swirlds.common.metrics.Counter;
+import com.swirlds.common.metrics.RunningAverageMetric;
+import com.swirlds.common.metrics.SpeedometerMetric;
 import com.swirlds.common.system.Platform;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
+import static com.hedera.services.stats.ServicesStatsManager.RUNNING_AVG_FORMAT;
+import static com.hedera.services.stats.ServicesStatsManager.STAT_CATEGORY;
+
 @Singleton
 public class ExpiryStats {
+    private final double halfLife;
+    private Counter contractsRemoved;
+    private Counter contractsRenewed;
+    private RunningAverageMetric idsScannedPerConsSec;
 
-    @Inject
-    public ExpiryStats() {
+    public ExpiryStats(final double halfLife) {
+        this.halfLife = halfLife;
     }
 
     public void registerWith(final Platform platform) {
-        throw new AssertionError("Not implemented");
+        contractsRemoved = platform.getOrCreateMetric(
+                new Counter.Config(STAT_CATEGORY, Names.CONTRACTS_REMOVED_SINCE_RESTART)
+                        .withDescription(Descriptions.CONTRACTS_REMOVED_SINCE_RESTART));
+        contractsRenewed = platform.getOrCreateMetric(
+                new Counter.Config(STAT_CATEGORY, Names.CONTRACTS_RENEWED_SINCE_RESTART)
+                        .withDescription(Descriptions.CONTRACTS_RENEWED_SINCE_RESTART));
+        idsScannedPerConsSec =
+                platform.getOrCreateMetric(
+                        new RunningAverageMetric.Config(
+                                STAT_CATEGORY, Names.IDS_SCANNED_PER_CONSENSUS_SEC)
+                                .withDescription(Descriptions.IDS_SCANNED_PER_CONSENSUS_SEC)
+                                .withFormat(RUNNING_AVG_FORMAT)
+                                .withHalfLife(halfLife));
     }
 
-    public void updateAll() {
-        throw new AssertionError("Not implemented");
+    public void countRemovedContract() {
+        contractsRemoved.increment();
+    }
+
+    public void countRenewedContract() {
+        contractsRenewed.increment();
+    }
+
+    public void incorporateLastConsSec(final int idsScanned) {
+        idsScannedPerConsSec.update(idsScanned);
+    }
+
+    public static final class Descriptions {
+        static final String IDS_SCANNED_PER_CONSENSUS_SEC =
+                "average entity ids scanned per second of consensus time";
+        static final String CONTRACTS_REMOVED_SINCE_RESTART =
+                "number of expired contracts removed since last restart";
+        static final String CONTRACTS_RENEWED_SINCE_RESTART =
+                "number of expired contracts renewed since last restart";
+
+        private Descriptions() {
+            throw new UnsupportedOperationException("Utility Class");
+        }
+    }
+
+    public static final class Names {
+        static final String IDS_SCANNED_PER_CONSENSUS_SEC =
+                "idsScannedPerConsSec";
+        static final String CONTRACTS_REMOVED_SINCE_RESTART =
+                "contractsRemoved";
+        static final String CONTRACTS_RENEWED_SINCE_RESTART =
+                "contractsRenewed";
+
+        private Names() {
+            throw new UnsupportedOperationException("Utility Class");
+        }
+    }
+
+    @VisibleForTesting
+    void setContractsRemoved(final Counter contractsRemoved) {
+        this.contractsRemoved = contractsRemoved;
+    }
+
+    @VisibleForTesting
+    void setContractsRenewed(final Counter contractsRenewed) {
+        this.contractsRenewed = contractsRenewed;
+    }
+
+    @VisibleForTesting
+    void setIdsScannedPerConsSec(final RunningAverageMetric idsScannedPerConsSec) {
+        this.idsScannedPerConsSec = idsScannedPerConsSec;
     }
 }

--- a/hedera-node/src/main/java/com/hedera/services/stats/ExpiryStats.java
+++ b/hedera-node/src/main/java/com/hedera/services/stats/ExpiryStats.java
@@ -1,17 +1,28 @@
+/*
+ * Copyright (C) 2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hedera.services.stats;
-
-import com.google.common.annotations.VisibleForTesting;
-import com.hedera.services.state.merkle.MerkleNetworkContext;
-import com.swirlds.common.metrics.Counter;
-import com.swirlds.common.metrics.RunningAverageMetric;
-import com.swirlds.common.metrics.SpeedometerMetric;
-import com.swirlds.common.system.Platform;
-
-import javax.inject.Inject;
-import javax.inject.Singleton;
 
 import static com.hedera.services.stats.ServicesStatsManager.RUNNING_AVG_FORMAT;
 import static com.hedera.services.stats.ServicesStatsManager.STAT_CATEGORY;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.swirlds.common.metrics.Counter;
+import com.swirlds.common.metrics.RunningAverageMetric;
+import com.swirlds.common.system.Platform;
+import javax.inject.Singleton;
 
 @Singleton
 public class ExpiryStats {
@@ -25,16 +36,18 @@ public class ExpiryStats {
     }
 
     public void registerWith(final Platform platform) {
-        contractsRemoved = platform.getOrCreateMetric(
-                new Counter.Config(STAT_CATEGORY, Names.CONTRACTS_REMOVED_SINCE_RESTART)
-                        .withDescription(Descriptions.CONTRACTS_REMOVED_SINCE_RESTART));
-        contractsRenewed = platform.getOrCreateMetric(
-                new Counter.Config(STAT_CATEGORY, Names.CONTRACTS_RENEWED_SINCE_RESTART)
-                        .withDescription(Descriptions.CONTRACTS_RENEWED_SINCE_RESTART));
+        contractsRemoved =
+                platform.getOrCreateMetric(
+                        new Counter.Config(STAT_CATEGORY, Names.CONTRACTS_REMOVED_SINCE_RESTART)
+                                .withDescription(Descriptions.CONTRACTS_REMOVED_SINCE_RESTART));
+        contractsRenewed =
+                platform.getOrCreateMetric(
+                        new Counter.Config(STAT_CATEGORY, Names.CONTRACTS_RENEWED_SINCE_RESTART)
+                                .withDescription(Descriptions.CONTRACTS_RENEWED_SINCE_RESTART));
         idsScannedPerConsSec =
                 platform.getOrCreateMetric(
                         new RunningAverageMetric.Config(
-                                STAT_CATEGORY, Names.IDS_SCANNED_PER_CONSENSUS_SEC)
+                                        STAT_CATEGORY, Names.IDS_SCANNED_PER_CONSENSUS_SEC)
                                 .withDescription(Descriptions.IDS_SCANNED_PER_CONSENSUS_SEC)
                                 .withFormat(RUNNING_AVG_FORMAT)
                                 .withHalfLife(halfLife));
@@ -66,12 +79,9 @@ public class ExpiryStats {
     }
 
     public static final class Names {
-        static final String IDS_SCANNED_PER_CONSENSUS_SEC =
-                "idsScannedPerConsSec";
-        static final String CONTRACTS_REMOVED_SINCE_RESTART =
-                "contractsRemoved";
-        static final String CONTRACTS_RENEWED_SINCE_RESTART =
-                "contractsRenewed";
+        static final String IDS_SCANNED_PER_CONSENSUS_SEC = "idsScannedPerConsSec";
+        static final String CONTRACTS_REMOVED_SINCE_RESTART = "contractsRemoved";
+        static final String CONTRACTS_RENEWED_SINCE_RESTART = "contractsRenewed";
 
         private Names() {
             throw new UnsupportedOperationException("Utility Class");

--- a/hedera-node/src/main/java/com/hedera/services/stats/MiscRunningAvgs.java
+++ b/hedera-node/src/main/java/com/hedera/services/stats/MiscRunningAvgs.java
@@ -25,8 +25,6 @@ import com.swirlds.common.system.Platform;
 public class MiscRunningAvgs {
     final double halfLife;
     private RunningAverageMetric gasPerConsSec;
-    private RunningAverageMetric accountRetryWaitMs;
-    private RunningAverageMetric accountLookupRetries;
     private RunningAverageMetric handledSubmitMessageSize;
     private RunningAverageMetric writeQueueSizeRecordStream;
     private RunningAverageMetric hashQueueSizeRecordStream;
@@ -40,18 +38,6 @@ public class MiscRunningAvgs {
                 platform.getOrCreateMetric(
                         new RunningAverageMetric.Config(STAT_CATEGORY, Names.GAS_PER_CONSENSUS_SEC)
                                 .withDescription(Descriptions.GAS_PER_CONSENSUS_SEC)
-                                .withFormat(RUNNING_AVG_FORMAT)
-                                .withHalfLife(halfLife));
-        accountRetryWaitMs =
-                platform.getOrCreateMetric(
-                        new RunningAverageMetric.Config(STAT_CATEGORY, Names.ACCOUNT_RETRY_WAIT_MS)
-                                .withDescription(Descriptions.ACCOUNT_RETRY_WAIT_MS)
-                                .withFormat(RUNNING_AVG_FORMAT)
-                                .withHalfLife(halfLife));
-        accountLookupRetries =
-                platform.getOrCreateMetric(
-                        new RunningAverageMetric.Config(STAT_CATEGORY, Names.ACCOUNT_LOOKUP_RETRIES)
-                                .withDescription(Descriptions.ACCOUNT_LOOKUP_RETRIES)
                                 .withFormat(RUNNING_AVG_FORMAT)
                                 .withHalfLife(halfLife));
         handledSubmitMessageSize =
@@ -77,14 +63,6 @@ public class MiscRunningAvgs {
                                 .withHalfLife(halfLife));
     }
 
-    public void recordAccountLookupRetries(final int num) {
-        accountLookupRetries.update(num);
-    }
-
-    public void recordAccountRetryWaitMs(final double time) {
-        accountRetryWaitMs.update(time);
-    }
-
     public void recordHandledSubmitMessageSize(final int bytes) {
         handledSubmitMessageSize.update(bytes);
     }
@@ -103,8 +81,6 @@ public class MiscRunningAvgs {
 
     public static final class Names {
         static final String GAS_PER_CONSENSUS_SEC = "gasPerConsSec";
-        static final String ACCOUNT_RETRY_WAIT_MS = "avgAcctRetryWaitMs";
-        static final String ACCOUNT_LOOKUP_RETRIES = "avgAcctLookupRetryAttempts";
         static final String HANDLED_SUBMIT_MESSAGE_SIZE = "avgHdlSubMsgSize";
 
         static final String WRITE_QUEUE_SIZE_RECORD_STREAM = "writeQueueSizeRecordStream";
@@ -118,13 +94,8 @@ public class MiscRunningAvgs {
     public static final class Descriptions {
         static final String GAS_PER_CONSENSUS_SEC =
                 "average EVM gas used per second of consensus time";
-        static final String ACCOUNT_RETRY_WAIT_MS =
-                "average time is millis spent waiting to lookup the account number";
-        static final String ACCOUNT_LOOKUP_RETRIES =
-                "average number of retry attempts made to lookup the account number";
         static final String HANDLED_SUBMIT_MESSAGE_SIZE =
                 "average size of the handled HCS submit message transaction";
-
         static final String WRITE_QUEUE_SIZE_RECORD_STREAM =
                 "size of the queue from which we take records and write to RecordStream file";
         static final String HASH_QUEUE_SIZE_RECORD_STREAM =
@@ -138,16 +109,6 @@ public class MiscRunningAvgs {
     @VisibleForTesting
     void setGasPerConsSec(RunningAverageMetric gasPerConsSec) {
         this.gasPerConsSec = gasPerConsSec;
-    }
-
-    @VisibleForTesting
-    void setAccountRetryWaitMs(RunningAverageMetric accountRetryWaitMs) {
-        this.accountRetryWaitMs = accountRetryWaitMs;
-    }
-
-    @VisibleForTesting
-    void setAccountLookupRetries(RunningAverageMetric accountLookupRetries) {
-        this.accountLookupRetries = accountLookupRetries;
     }
 
     @VisibleForTesting

--- a/hedera-node/src/main/java/com/hedera/services/stats/ServicesStatsManager.java
+++ b/hedera-node/src/main/java/com/hedera/services/stats/ServicesStatsManager.java
@@ -50,6 +50,7 @@ public class ServicesStatsManager {
 
     static final String STATS_UPDATE_THREAD_NAME_TPL = "StatsUpdateThread%d";
 
+    private final ExpiryStats expiryStats;
     private final HapiOpCounters opCounters;
     private final MiscRunningAvgs runningAvgs;
     private final MiscSpeedometers speedometers;
@@ -62,6 +63,7 @@ public class ServicesStatsManager {
 
     @Inject
     public ServicesStatsManager(
+            final ExpiryStats expiryStats,
             final HapiOpCounters opCounters,
             final ThrottleGauges throttleGauges,
             final MiscRunningAvgs runningAvgs,
@@ -74,6 +76,7 @@ public class ServicesStatsManager {
         this.storage = storage;
         this.bytecode = bytecode;
         this.localProperties = localProperties;
+        this.expiryStats = expiryStats;
         this.opCounters = opCounters;
         this.runningAvgs = runningAvgs;
         this.speedometers = speedometers;
@@ -84,6 +87,7 @@ public class ServicesStatsManager {
 
     public void initializeFor(final Platform platform) {
         opCounters.registerWith(platform);
+        expiryStats.registerWith(platform);
         runningAvgs.registerWith(platform);
         speedometers.registerWith(platform);
         throttleGauges.registerWith(platform);

--- a/hedera-node/src/main/java/com/hedera/services/stats/StatsModule.java
+++ b/hedera-node/src/main/java/com/hedera/services/stats/StatsModule.java
@@ -29,8 +29,7 @@ import javax.inject.Singleton;
 public final class StatsModule {
     @Provides
     @Singleton
-    public static ExpiryStats provideExpiryStats(
-            final NodeLocalProperties nodeLocalProperties) {
+    public static ExpiryStats provideExpiryStats(final NodeLocalProperties nodeLocalProperties) {
         return new ExpiryStats(nodeLocalProperties.statsRunningAvgHalfLifeSecs());
     }
 

--- a/hedera-node/src/main/java/com/hedera/services/stats/StatsModule.java
+++ b/hedera-node/src/main/java/com/hedera/services/stats/StatsModule.java
@@ -29,6 +29,13 @@ import javax.inject.Singleton;
 public final class StatsModule {
     @Provides
     @Singleton
+    public static ExpiryStats provideExpiryStats(
+            final NodeLocalProperties nodeLocalProperties) {
+        return new ExpiryStats(nodeLocalProperties.statsRunningAvgHalfLifeSecs());
+    }
+
+    @Provides
+    @Singleton
     public static MiscRunningAvgs provideMiscRunningAvgs(
             final NodeLocalProperties nodeLocalProperties) {
         return new MiscRunningAvgs(nodeLocalProperties.statsRunningAvgHalfLifeSecs());

--- a/hedera-node/src/main/java/com/hedera/services/store/StoresModule.java
+++ b/hedera-node/src/main/java/com/hedera/services/store/StoresModule.java
@@ -32,11 +32,7 @@ import com.hedera.services.ledger.backing.BackingNfts;
 import com.hedera.services.ledger.backing.BackingStore;
 import com.hedera.services.ledger.backing.BackingTokenRels;
 import com.hedera.services.ledger.backing.BackingTokens;
-import com.hedera.services.ledger.interceptors.LinkAwareTokenRelsCommitInterceptor;
-import com.hedera.services.ledger.interceptors.StakingAccountsCommitInterceptor;
-import com.hedera.services.ledger.interceptors.TokenRelsLinkManager;
-import com.hedera.services.ledger.interceptors.TokensCommitInterceptor;
-import com.hedera.services.ledger.interceptors.UniqueTokensLinkManager;
+import com.hedera.services.ledger.interceptors.*;
 import com.hedera.services.ledger.properties.AccountProperty;
 import com.hedera.services.ledger.properties.ChangeSummaryManager;
 import com.hedera.services.ledger.properties.NftProperty;
@@ -87,11 +83,16 @@ public interface StoresModule {
             final UsageLimits usageLimits,
             final UniqueTokensLinkManager uniqueTokensLinkManager,
             final Supplier<MerkleMap<EntityNumPair, MerkleUniqueToken>> uniqueTokens) {
-        return new TransactionalLedger<>(
-                NftProperty.class,
-                MerkleUniqueToken::new,
-                new BackingNfts(uniqueTokens),
-                new ChangeSummaryManager<>());
+        final var uniqueTokensLedger =
+                new TransactionalLedger<>(
+                        NftProperty.class,
+                        MerkleUniqueToken::new,
+                        new BackingNfts(uniqueTokens),
+                        new ChangeSummaryManager<>());
+        final var uniqueTokensCommitInterceptor =
+                new LinkAwareUniqueTokensCommitInterceptor(usageLimits, uniqueTokensLinkManager);
+        uniqueTokensLedger.setCommitInterceptor(uniqueTokensCommitInterceptor);
+        return uniqueTokensLedger;
     }
 
     @Provides

--- a/hedera-node/src/test/java/com/hedera/services/config/MockGlobalDynamicProps.java
+++ b/hedera-node/src/test/java/com/hedera/services/config/MockGlobalDynamicProps.java
@@ -27,6 +27,7 @@ public class MockGlobalDynamicProps extends GlobalDynamicProperties {
     private final CongestionMultipliers differentMultipliers =
             CongestionMultipliers.from("90,11x,95,26x,99,101x");
 
+    private int maxToTouch = 2;
     private int minCongestionPeriod = 2;
     private long gracePeriod = 604800;
     private boolean useAutoRenew = true;
@@ -35,7 +36,6 @@ public class MockGlobalDynamicProps extends GlobalDynamicProperties {
     private boolean exportBalances = true;
     private CongestionMultipliers currentMultipliers = defaultMultipliers;
     private boolean throttleByGas;
-    private boolean overwriteFundingAccount = false;
 
     public MockGlobalDynamicProps() {
         super(null, null);
@@ -202,7 +202,11 @@ public class MockGlobalDynamicProps extends GlobalDynamicProperties {
 
     @Override
     public int autoRenewMaxNumberOfEntitiesToRenewOrDelete() {
-        return 2;
+        return maxToTouch;
+    }
+
+    public void setMaxToTouch(int maxToTouch) {
+        this.maxToTouch = maxToTouch;
     }
 
     @Override

--- a/hedera-node/src/test/java/com/hedera/services/context/properties/SerializableSemVersTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/context/properties/SerializableSemVersTest.java
@@ -47,6 +47,13 @@ class SerializableSemVersTest {
     }
 
     @Test
+    void ordersWithRespectToAlphaNumber() {
+        final var alpha1 = semVerWith(1, 9, 9, "alpha.1", null);
+        final var alpha0 = semVerWith(1, 9, 9, "alpha.0", null);
+        assertTrue(SEM_VER_COMPARATOR.compare(alpha0, alpha1) < 0);
+    }
+
+    @Test
     void comparatorPrioritizesOrderAsExpected() {
         assertTrue(
                 SEM_VER_COMPARATOR.compare(
@@ -65,7 +72,7 @@ class SerializableSemVersTest {
                         < 0);
         assertTrue(
                 SEM_VER_COMPARATOR.compare(
-                                semVerWith(1, 0, 1, "pre", null),
+                                semVerWith(1, 0, 1, "alpha.12345", null),
                                 semVerWith(1, 0, 1, null, "build"))
                         < 0);
         assertTrue(

--- a/hedera-node/src/test/java/com/hedera/services/state/expiry/EntityAutoExpiryTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/state/expiry/EntityAutoExpiryTest.java
@@ -15,9 +15,7 @@
  */
 package com.hedera.services.state.expiry;
 
-import static com.hedera.services.state.expiry.EntityProcessResult.DONE;
-import static com.hedera.services.state.expiry.EntityProcessResult.NOTHING_TO_DO;
-import static com.hedera.services.state.expiry.EntityProcessResult.STILL_MORE_TO_DO;
+import static com.hedera.services.state.expiry.ExpiryProcessResult.*;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.never;
@@ -45,12 +43,12 @@ import org.mockito.junit.jupiter.MockitoExtension;
 class EntityAutoExpiryTest {
     private final Instant instantNow = Instant.ofEpochSecond(1_234_567L);
     private final HederaNumbers mockHederaNums = new MockHederaNumbers();
-    private final MockGlobalDynamicProps properties = new MockGlobalDynamicProps();
+    private final MockGlobalDynamicProps mockDynamicProps = new MockGlobalDynamicProps();
 
     private final long aNum = 1002L, bNum = 1003L, cNum = 1004L;
 
     @Mock private SequenceNumber seqNo;
-    @Mock private AutoExpiryCycle autoExpiryCycle;
+    @Mock private ExpiryProcess expiryProcess;
     @Mock private NetworkCtxManager networkCtxManager;
     @Mock private MerkleNetworkContext networkCtx;
     @Mock private ConsensusTimeTracker consensusTimeTracker;
@@ -64,8 +62,8 @@ class EntityAutoExpiryTest {
                 new EntityAutoExpiry(
                         mockHederaNums,
                         expiryThrottle,
-                        autoExpiryCycle,
-                        properties,
+                        expiryProcess,
+                        mockDynamicProps,
                         networkCtxManager,
                         () -> networkCtx,
                         consensusTimeTracker,
@@ -75,17 +73,17 @@ class EntityAutoExpiryTest {
     @Test
     void abortsIfNotAutoRenewing() {
         // setup:
-        properties.disableAutoRenew();
+        mockDynamicProps.disableAutoRenew();
 
         // when:
         subject.execute(instantNow);
 
         // then:
-        verifyNoInteractions(autoExpiryCycle);
+        verifyNoInteractions(expiryProcess);
         verify(networkCtx).syncExpiryThrottle(expiryThrottle);
 
         // cleanup:
-        properties.enableAutoRenew();
+        mockDynamicProps.enableAutoRenew();
     }
 
     @Test
@@ -97,7 +95,7 @@ class EntityAutoExpiryTest {
         subject.execute(instantNow);
 
         // then:
-        verifyNoInteractions(autoExpiryCycle);
+        verifyNoInteractions(expiryProcess);
     }
 
     @Test
@@ -109,7 +107,7 @@ class EntityAutoExpiryTest {
         subject.execute(instantNow);
 
         // then:
-        verifyNoInteractions(autoExpiryCycle);
+        verifyNoInteractions(expiryProcess);
     }
 
     @Test
@@ -118,6 +116,7 @@ class EntityAutoExpiryTest {
         given(networkCtxManager.currentTxnIsFirstInConsensusSecond()).willReturn(true);
         givenWrapNum(aNum + 123);
         givenLastScanned(aNum - 1);
+        given(expiryProcess.process(anyLong())).willReturn(NOTHING_TO_DO);
 
         // when:
         subject.execute(instantNow);
@@ -130,22 +129,22 @@ class EntityAutoExpiryTest {
     void scansToExpectedNumWithNothingToTouch() {
         // setup:
         given(consensusTimeTracker.hasMoreStandaloneRecordTime()).willReturn(true);
-        long numToScan = properties.autoRenewNumberOfEntitiesToScan();
+        long numToScan = mockDynamicProps.autoRenewNumberOfEntitiesToScan();
 
         givenWrapNum(aNum + numToScan);
         givenLastScanned(aNum - 1);
-        given(autoExpiryCycle.process(anyLong())).willReturn(NOTHING_TO_DO);
+        given(expiryProcess.process(anyLong())).willReturn(NOTHING_TO_DO);
 
         // when:
         subject.execute(instantNow);
 
         // then:
-        verify(autoExpiryCycle).beginCycle(instantNow);
+        verify(expiryProcess).beginCycle(instantNow);
         for (long i = aNum; i < aNum + numToScan; i++) {
-            verify(autoExpiryCycle).process(i);
+            verify(expiryProcess).process(i);
         }
         // and:
-        verify(autoExpiryCycle).endCycle();
+        verify(expiryProcess).endCycle();
         verify(networkCtx).updateLastScannedEntity(aNum + numToScan - 1);
     }
 
@@ -156,16 +155,18 @@ class EntityAutoExpiryTest {
         given(consensusTimeTracker.hasMoreStandaloneRecordTime()).willReturn(true);
         givenWrapNum(aNum + numToScan + 1);
         givenLastScanned(aNum - 1);
-        given(autoExpiryCycle.process(aNum)).willReturn(STILL_MORE_TO_DO).willReturn(DONE);
+        given(expiryProcess.process(aNum)).willReturn(STILL_MORE_TO_DO).willReturn(DONE);
+        mockDynamicProps.setMaxToTouch(1);
 
         // when:
         subject.execute(instantNow);
 
         // then:
-        verify(autoExpiryCycle).beginCycle(instantNow);
-        verify(autoExpiryCycle, times(2)).process(aNum);
-        verify(autoExpiryCycle).endCycle();
-        verifyNoMoreInteractions(autoExpiryCycle);
+        verify(expiryProcess).beginCycle(instantNow);
+        verify(expiryProcess, times(2)).process(aNum);
+        verify(expiryProcess).endCycle();
+        verifyNoMoreInteractions(expiryProcess);
+        verify(networkCtx).updateAutoRenewSummaryCounts(1, 1);
         verify(networkCtx).updateLastScannedEntity(aNum);
     }
 
@@ -176,16 +177,20 @@ class EntityAutoExpiryTest {
         given(consensusTimeTracker.hasMoreStandaloneRecordTime()).willReturn(true);
         givenWrapNum(aNum + numToScan + 1);
         givenLastScanned(aNum - 1);
-        given(autoExpiryCycle.process(aNum)).willReturn(STILL_MORE_TO_DO);
+        given(expiryProcess.process(aNum))
+                .willReturn(STILL_MORE_TO_DO)
+                .willReturn(STILL_MORE_TO_DO)
+                .willReturn(STILL_MORE_TO_DO)
+                .willReturn(NO_CAPACITY_NOW);
 
         // when:
         subject.execute(instantNow);
 
         // then:
-        verify(autoExpiryCycle).beginCycle(instantNow);
-        verify(autoExpiryCycle, times(2)).process(aNum);
-        verify(autoExpiryCycle).endCycle();
-        verifyNoMoreInteractions(autoExpiryCycle);
+        verify(expiryProcess).beginCycle(instantNow);
+        verify(expiryProcess, times(4)).process(aNum);
+        verify(expiryProcess).endCycle();
+        verifyNoMoreInteractions(expiryProcess);
         verify(networkCtx).updateLastScannedEntity(aNum - 1);
     }
 
@@ -193,24 +198,24 @@ class EntityAutoExpiryTest {
     void stopsEarlyWhenLotsToTouch() {
         // setup:
         given(consensusTimeTracker.hasMoreStandaloneRecordTime()).willReturn(true);
-        long numToScan = properties.autoRenewNumberOfEntitiesToScan();
+        long numToScan = mockDynamicProps.autoRenewNumberOfEntitiesToScan();
 
         givenWrapNum(aNum + numToScan);
         givenLastScanned(aNum - 1);
-        given(autoExpiryCycle.process(aNum)).willReturn(DONE);
-        given(autoExpiryCycle.process(bNum)).willReturn(DONE);
+        given(expiryProcess.process(aNum)).willReturn(DONE);
+        given(expiryProcess.process(bNum)).willReturn(DONE);
 
         // when:
         subject.execute(instantNow);
 
         // then:
-        verify(autoExpiryCycle).beginCycle(instantNow);
+        verify(expiryProcess).beginCycle(instantNow);
         for (long i = aNum; i < cNum; i++) {
-            verify(autoExpiryCycle).process(i);
+            verify(expiryProcess).process(i);
         }
         // and:
-        verify(autoExpiryCycle, never()).process(cNum);
-        verify(autoExpiryCycle).endCycle();
+        verify(expiryProcess, never()).process(cNum);
+        verify(expiryProcess).endCycle();
         verify(networkCtx).updateLastScannedEntity(bNum);
     }
 
@@ -218,11 +223,11 @@ class EntityAutoExpiryTest {
     void stopsEarlyWhenNoMoreStandaloneRecordTime() {
         // setup:
         given(consensusTimeTracker.hasMoreStandaloneRecordTime()).willReturn(true);
-        long numToScan = properties.autoRenewNumberOfEntitiesToScan();
+        long numToScan = mockDynamicProps.autoRenewNumberOfEntitiesToScan();
 
         givenWrapNum(aNum + numToScan);
         givenLastScanned(aNum - 1);
-        given(autoExpiryCycle.process(aNum))
+        given(expiryProcess.process(aNum))
                 .willAnswer(
                         i -> {
                             given(consensusTimeTracker.hasMoreStandaloneRecordTime())
@@ -234,11 +239,11 @@ class EntityAutoExpiryTest {
         subject.execute(instantNow);
 
         // then:
-        verify(autoExpiryCycle).beginCycle(instantNow);
-        verify(autoExpiryCycle).process(aNum);
+        verify(expiryProcess).beginCycle(instantNow);
+        verify(expiryProcess).process(aNum);
         // and:
-        verify(autoExpiryCycle, never()).process(bNum);
-        verify(autoExpiryCycle).endCycle();
+        verify(expiryProcess, never()).process(bNum);
+        verify(expiryProcess).endCycle();
         verify(networkCtx).updateLastScannedEntity(aNum);
     }
 
@@ -246,27 +251,27 @@ class EntityAutoExpiryTest {
     void understandsHowToWrap() {
         // setup:
         given(consensusTimeTracker.hasMoreStandaloneRecordTime()).willReturn(true);
-        long numToScan = properties.autoRenewNumberOfEntitiesToScan();
+        long numToScan = mockDynamicProps.autoRenewNumberOfEntitiesToScan();
 
         givenWrapNum(aNum + numToScan);
         givenLastScanned(aNum + numToScan - 2);
-        given(autoExpiryCycle.process(aNum + numToScan - 1)).willReturn(NOTHING_TO_DO);
-        given(autoExpiryCycle.process(aNum - 1)).willReturn(NOTHING_TO_DO);
-        given(autoExpiryCycle.process(aNum)).willReturn(DONE);
-        given(autoExpiryCycle.process(bNum)).willReturn(DONE);
+        given(expiryProcess.process(aNum + numToScan - 1)).willReturn(NOTHING_TO_DO);
+        given(expiryProcess.process(aNum - 1)).willReturn(NOTHING_TO_DO);
+        given(expiryProcess.process(aNum)).willReturn(DONE);
+        given(expiryProcess.process(bNum)).willReturn(DONE);
 
         // when:
         subject.execute(instantNow);
 
         // then:
-        verify(autoExpiryCycle).beginCycle(instantNow);
-        verify(autoExpiryCycle).process(aNum + numToScan - 1);
+        verify(expiryProcess).beginCycle(instantNow);
+        verify(expiryProcess).process(aNum + numToScan - 1);
         for (long i = aNum; i < cNum; i++) {
-            verify(autoExpiryCycle).process(i);
+            verify(expiryProcess).process(i);
         }
         // and:
-        verify(autoExpiryCycle, never()).process(cNum);
-        verify(autoExpiryCycle).endCycle();
+        verify(expiryProcess, never()).process(cNum);
+        verify(expiryProcess).endCycle();
         verify(networkCtx).updateLastScannedEntity(bNum);
         // and:
         verify(networkCtx).updateAutoRenewSummaryCounts(4, 2);

--- a/hedera-node/src/test/java/com/hedera/services/state/expiry/EntityAutoExpiryTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/state/expiry/EntityAutoExpiryTest.java
@@ -184,7 +184,7 @@ class EntityAutoExpiryTest {
                 .willReturn(STILL_MORE_TO_DO)
                 .willReturn(STILL_MORE_TO_DO)
                 .willReturn(STILL_MORE_TO_DO)
-                .willReturn(NO_CAPACITY_NOW);
+                .willReturn(NO_CAPACITY_LEFT);
 
         // when:
         subject.execute(instantNow);

--- a/hedera-node/src/test/java/com/hedera/services/state/expiry/ExpiryProcessTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/state/expiry/ExpiryProcessTest.java
@@ -15,9 +15,9 @@
  */
 package com.hedera.services.state.expiry;
 
-import static com.hedera.services.state.expiry.EntityProcessResult.DONE;
-import static com.hedera.services.state.expiry.EntityProcessResult.NOTHING_TO_DO;
-import static com.hedera.services.state.expiry.EntityProcessResult.STILL_MORE_TO_DO;
+import static com.hedera.services.state.expiry.ExpiryProcessResult.DONE;
+import static com.hedera.services.state.expiry.ExpiryProcessResult.NOTHING_TO_DO;
+import static com.hedera.services.state.expiry.ExpiryProcessResult.STILL_MORE_TO_DO;
 import static com.hedera.services.state.expiry.classification.ClassificationResult.*;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
@@ -49,7 +49,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
-class AutoExpiryCycleTest {
+class ExpiryProcessTest {
     private final Instant now = Instant.ofEpochSecond(1_234_567L);
     private final long requestedRenewalPeriod = 3601L;
     private final long nonZeroBalance = 2L;
@@ -101,12 +101,12 @@ class AutoExpiryCycleTest {
     private MockGlobalDynamicProps dynamicProperties = new MockGlobalDynamicProps();
     private RenewalWork renewalWork;
     private RemovalWork removalWork;
-    private AutoExpiryCycle subject;
+    private ExpiryProcess subject;
 
     @BeforeEach
     void setUp() {
         setUpPreRequisites();
-        subject = new AutoExpiryCycle(classifier, renewalWork, removalWork);
+        subject = new ExpiryProcess(classifier, renewalWork, removalWork);
     }
 
     private void setUpPreRequisites() {

--- a/hedera-node/src/test/java/com/hedera/services/state/expiry/ExpiryProcessTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/state/expiry/ExpiryProcessTest.java
@@ -35,6 +35,7 @@ import com.hedera.services.state.expiry.renewal.RenewalHelper;
 import com.hedera.services.state.expiry.renewal.RenewalWork;
 import com.hedera.services.state.merkle.MerkleAccount;
 import com.hedera.services.state.submerkle.EntityId;
+import com.hedera.services.stats.ExpiryStats;
 import com.hedera.services.throttling.ExpiryThrottle;
 import com.hedera.services.utils.EntityNum;
 import com.hedera.test.factories.accounts.MerkleAccountFactory;
@@ -96,6 +97,7 @@ class ExpiryProcessTest {
     @Mock private ExpiryRecordsHelper recordsHelper;
     @Mock private MerkleMap<EntityNum, MerkleAccount> accounts;
     @Mock private ExpiryThrottle expiryThrottle;
+    @Mock private ExpiryStats expiryStats;
     private EntityLookup lookup;
     private MockGlobalDynamicProps dynamicProperties = new MockGlobalDynamicProps();
     private RenewalWork renewalWork;
@@ -112,10 +114,21 @@ class ExpiryProcessTest {
         lookup = new EntityLookup(() -> accounts);
         renewalWork =
                 new RenewalHelper(
-                        lookup, expiryThrottle, classifier, dynamicProperties, fees, recordsHelper);
+                        expiryStats,
+                        lookup,
+                        expiryThrottle,
+                        classifier,
+                        dynamicProperties,
+                        fees,
+                        recordsHelper);
         removalWork =
                 new RemovalHelper(
-                        classifier, dynamicProperties, contractGC, accountGC, recordsHelper);
+                        expiryStats,
+                        classifier,
+                        dynamicProperties,
+                        contractGC,
+                        accountGC,
+                        recordsHelper);
     }
 
     @Test

--- a/hedera-node/src/test/java/com/hedera/services/state/expiry/ExpiryProcessTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/state/expiry/ExpiryProcessTest.java
@@ -15,9 +15,7 @@
  */
 package com.hedera.services.state.expiry;
 
-import static com.hedera.services.state.expiry.ExpiryProcessResult.DONE;
-import static com.hedera.services.state.expiry.ExpiryProcessResult.NOTHING_TO_DO;
-import static com.hedera.services.state.expiry.ExpiryProcessResult.STILL_MORE_TO_DO;
+import static com.hedera.services.state.expiry.ExpiryProcessResult.*;
 import static com.hedera.services.state.expiry.classification.ClassificationResult.*;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
@@ -142,13 +140,13 @@ class ExpiryProcessTest {
     }
 
     @Test
-    void stillMoreToDoIfCannotClassify() {
+    void noCapacityNow() {
         given(classifier.classify(EntityNum.fromLong(nonExpiredAccountNum), now))
                 .willReturn(COME_BACK_LATER);
 
         var result = subject.process(nonExpiredAccountNum, now);
 
-        assertEquals(STILL_MORE_TO_DO, result);
+        assertEquals(NO_CAPACITY_LEFT, result);
         verifyNoMoreInteractions(classifier);
     }
 

--- a/hedera-node/src/test/java/com/hedera/services/state/expiry/ExpiryProcessTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/state/expiry/ExpiryProcessTest.java
@@ -259,7 +259,7 @@ class ExpiryProcessTest {
 
         final var result = subject.process(brokeExpiredContractNum, now);
 
-        assertEquals(STILL_MORE_TO_DO, result);
+        assertEquals(NO_CAPACITY_LEFT, result);
         verifyNoMoreInteractions(accountGC, recordsHelper);
     }
 
@@ -275,7 +275,7 @@ class ExpiryProcessTest {
 
         final var result = subject.process(brokeExpiredAccountNum, now);
 
-        assertEquals(STILL_MORE_TO_DO, result);
+        assertEquals(NO_CAPACITY_LEFT, result);
         verify(accountGC).expireBestEffort(expiredNum, mockAccount);
         verify(recordsHelper)
                 .streamCryptoRemovalStep(false, expiredNum, null, partiallyFinishedReturns);

--- a/hedera-node/src/test/java/com/hedera/services/state/expiry/removal/RemovalHelperTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/state/expiry/removal/RemovalHelperTest.java
@@ -25,7 +25,7 @@ import static org.mockito.Mockito.verifyNoInteractions;
 
 import com.google.protobuf.ByteString;
 import com.hedera.services.config.MockGlobalDynamicProps;
-import com.hedera.services.state.expiry.EntityProcessResult;
+import com.hedera.services.state.expiry.ExpiryProcessResult;
 import com.hedera.services.state.expiry.ExpiryRecordsHelper;
 import com.hedera.services.state.expiry.classification.ClassificationWork;
 import com.hedera.services.state.expiry.classification.EntityLookup;
@@ -80,11 +80,11 @@ class RemovalHelperTest {
     void doesNothingWhenDisabled() {
         properties.disableAutoRenew();
         var result = subject.tryToRemoveAccount(EntityNum.fromLong(nonExpiredAccountNum));
-        assertEquals(EntityProcessResult.NOTHING_TO_DO, result);
+        assertEquals(ExpiryProcessResult.NOTHING_TO_DO, result);
 
         properties.disableContractAutoRenew();
         result = subject.tryToRemoveContract(EntityNum.fromLong(nonExpiredAccountNum));
-        assertEquals(EntityProcessResult.NOTHING_TO_DO, result);
+        assertEquals(ExpiryProcessResult.NOTHING_TO_DO, result);
     }
 
     @Test
@@ -101,7 +101,7 @@ class RemovalHelperTest {
         var result = subject.tryToRemoveAccount(expiredNum);
 
         verify(recordsHelper).streamCryptoRemovalStep(false, expiredNum, null, finishedReturns);
-        assertEquals(EntityProcessResult.DONE, result);
+        assertEquals(ExpiryProcessResult.DONE, result);
     }
 
     @Test
@@ -118,7 +118,7 @@ class RemovalHelperTest {
         var result = subject.tryToRemoveAccount(expiredNum);
 
         verifyNoInteractions(recordsHelper);
-        assertEquals(EntityProcessResult.STILL_MORE_TO_DO, result);
+        assertEquals(ExpiryProcessResult.STILL_MORE_TO_DO, result);
     }
 
     @Test
@@ -139,7 +139,7 @@ class RemovalHelperTest {
 
         verify(recordsHelper)
                 .streamCryptoRemovalStep(true, expiredNum, autoRenewId, finishedReturns);
-        assertEquals(EntityProcessResult.DONE, result);
+        assertEquals(ExpiryProcessResult.DONE, result);
     }
 
     private final Instant now = Instant.ofEpochSecond(1_234_567L);

--- a/hedera-node/src/test/java/com/hedera/services/state/expiry/removal/TreasuryReturnHelperTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/state/expiry/removal/TreasuryReturnHelperTest.java
@@ -85,7 +85,7 @@ class TreasuryReturnHelperTest {
         given(nfts.get(aNftKey)).willReturn(someNft);
         someNft.setNext(bNftKey.asNftNumPair());
 
-        final var newRoot = subject.finishNft(true, aNftKey, nfts);
+        final var newRoot = subject.burnOrReturnNft(true, aNftKey, nfts);
 
         verify(nfts).remove(aNftKey);
         assertEquals(bNftKey, newRoot);
@@ -96,7 +96,7 @@ class TreasuryReturnHelperTest {
         given(nfts.getForModify(aNftKey)).willReturn(someNft);
         someNft.setNext(NftNumPair.MISSING_NFT_NUM_PAIR);
 
-        final var newRoot = subject.finishNft(false, aNftKey, nfts);
+        final var newRoot = subject.burnOrReturnNft(false, aNftKey, nfts);
 
         verify(nfts, never()).remove(aNftKey);
         assertEquals(EntityId.MISSING_ENTITY_ID, someNft.getOwner());
@@ -108,7 +108,7 @@ class TreasuryReturnHelperTest {
         given(nfts.getForModify(aNftKey)).willReturn(someNft);
         someNft.setNext(null);
 
-        final var newRoot = subject.finishNft(false, aNftKey, nfts);
+        final var newRoot = subject.burnOrReturnNft(false, aNftKey, nfts);
 
         verify(nfts, never()).remove(aNftKey);
         assertEquals(EntityId.MISSING_ENTITY_ID, someNft.getOwner());

--- a/hedera-node/src/test/java/com/hedera/services/state/expiry/removal/TreasuryReturnsTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/state/expiry/removal/TreasuryReturnsTest.java
@@ -164,7 +164,8 @@ class TreasuryReturnsTest {
         givenCorruptNfsSetup();
         given(expiryThrottle.allow(any())).willReturn(true);
         given(entityLookup.getMutableAccount(num)).willReturn(accountWithNfts);
-        given(returnHelper.burnOrReturnNft(true, bNftKey, nfts)).willThrow(NullPointerException.class);
+        given(returnHelper.burnOrReturnNft(true, bNftKey, nfts))
+                .willThrow(NullPointerException.class);
 
         final var expected = NonFungibleTreasuryReturns.FINISHED_NOOP_NON_FUNGIBLE_RETURNS;
 

--- a/hedera-node/src/test/java/com/hedera/services/state/expiry/removal/TreasuryReturnsTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/state/expiry/removal/TreasuryReturnsTest.java
@@ -130,10 +130,41 @@ class TreasuryReturnsTest {
     }
 
     @Test
+    void recoversFromCorruptRelsLinks() {
+        givenCorruptUnitsSetup();
+        given(expiryThrottle.allow(any())).willReturn(true);
+        given(entityLookup.getMutableAccount(num)).willReturn(accountWithRels);
+
+        final var expected = new FungibleTreasuryReturns(List.of(), List.of(), true);
+
+        final var actual = subject.returnFungibleUnitsFrom(accountWithRels);
+
+        assertEquals(expected, actual);
+        assertEquals(0, accountWithRels.getNumAssociations());
+        assertTrue(accountWithRels.isDeleted());
+    }
+
+    @Test
     void returnsAllNftsGivenCapacity() {
         givenStandardNftsSetup(true, true);
         given(expiryThrottle.allow(any())).willReturn(true);
         given(entityLookup.getMutableAccount(num)).willReturn(accountWithNfts);
+
+        final var expected = NonFungibleTreasuryReturns.FINISHED_NOOP_NON_FUNGIBLE_RETURNS;
+
+        final var actual = subject.returnNftsFrom(accountWithNfts);
+
+        assertEquals(expected, actual);
+        assertEquals(0, accountWithNfts.getNftsOwned());
+        assertTrue(accountWithNfts.isDeleted());
+    }
+
+    @Test
+    void recoversFromBadFinish() {
+        givenCorruptNfsSetup();
+        given(expiryThrottle.allow(any())).willReturn(true);
+        given(entityLookup.getMutableAccount(num)).willReturn(accountWithNfts);
+        given(returnHelper.burnOrReturnNft(true, bNftKey, nfts)).willThrow(NullPointerException.class);
 
         final var expected = NonFungibleTreasuryReturns.FINISHED_NOOP_NON_FUNGIBLE_RETURNS;
 
@@ -303,6 +334,15 @@ class TreasuryReturnsTest {
         }
     }
 
+    private void givenCorruptUnitsSetup() {
+        subject.setRelRemovalFacilitation(relRemover);
+        given(tokens.get(aRelKey.getLowOrderAsNum())).willReturn(fungibleToken);
+        given(tokenRels.get(aRelKey)).willReturn(aRelStatus);
+
+        given(relRemover.removeNext(eq(aRelKey), eq(aRelKey), any(TokenRelsListMutation.class)))
+                .willThrow(NullPointerException.class);
+    }
+
     private void givenStandardNftsSetup(final boolean includeB, final boolean includeBRemoval) {
         given(tokens.get(aNftKey.getHiOrderAsNum())).willReturn(nfToken);
         if (includeB) {
@@ -318,7 +358,7 @@ class TreasuryReturnsTest {
                                 any(List.class),
                                 any(List.class)))
                 .willReturn(true);
-        given(returnHelper.finishNft(false, aNftKey, nfts)).willReturn(bNftKey);
+        given(returnHelper.burnOrReturnNft(false, aNftKey, nfts)).willReturn(bNftKey);
         if (includeBRemoval) {
             given(
                             returnHelper.updateNftReturns(
@@ -329,8 +369,23 @@ class TreasuryReturnsTest {
                                     any(List.class),
                                     any(List.class)))
                     .willReturn(false);
-            given(returnHelper.finishNft(true, bNftKey, nfts)).willReturn(null);
+            given(returnHelper.burnOrReturnNft(true, bNftKey, nfts)).willReturn(null);
         }
+    }
+
+    private void givenCorruptNfsSetup() {
+        given(tokens.get(aNftKey.getHiOrderAsNum())).willReturn(nfToken);
+        given(tokens.get(bNftKey.getHiOrderAsNum())).willReturn(deletedNfToken);
+
+        given(
+                        returnHelper.updateNftReturns(
+                                eq(num),
+                                eq(aNftKey.getHiOrderAsNum()),
+                                eq(nfToken),
+                                eq(aNftKey.getLowOrderAsLong()),
+                                any(List.class),
+                                any(List.class)))
+                .willReturn(true);
     }
 
     private final long aSerialNo = 777L;

--- a/hedera-node/src/test/java/com/hedera/services/state/expiry/renewal/RenewalHelperTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/state/expiry/renewal/RenewalHelperTest.java
@@ -29,7 +29,7 @@ import com.google.protobuf.ByteString;
 import com.hedera.services.config.MockGlobalDynamicProps;
 import com.hedera.services.fees.FeeCalculator;
 import com.hedera.services.fees.calculation.RenewAssessment;
-import com.hedera.services.state.expiry.EntityProcessResult;
+import com.hedera.services.state.expiry.ExpiryProcessResult;
 import com.hedera.services.state.expiry.ExpiryRecordsHelper;
 import com.hedera.services.state.expiry.classification.ClassificationWork;
 import com.hedera.services.state.expiry.classification.EntityLookup;
@@ -111,7 +111,7 @@ class RenewalHelperTest {
 
         final var result =
                 subject.tryToRenewAccount(EntityNum.fromLong(fundedExpiredAccountNum), now);
-        assertEquals(EntityProcessResult.STILL_MORE_TO_DO, result);
+        assertEquals(ExpiryProcessResult.STILL_MORE_TO_DO, result);
     }
 
     @Test
@@ -132,18 +132,18 @@ class RenewalHelperTest {
 
         final var result =
                 subject.tryToRenewAccount(EntityNum.fromLong(fundedExpiredAccountNum), now);
-        assertEquals(EntityProcessResult.STILL_MORE_TO_DO, result);
+        assertEquals(ExpiryProcessResult.STILL_MORE_TO_DO, result);
     }
 
     @Test
     void doesNothingWhenDisabled() {
         properties.disableAutoRenew();
         var result = subject.tryToRenewAccount(EntityNum.fromLong(fundedExpiredAccountNum), now);
-        assertEquals(EntityProcessResult.NOTHING_TO_DO, result);
+        assertEquals(ExpiryProcessResult.NOTHING_TO_DO, result);
 
         properties.disableContractAutoRenew();
         result = subject.tryToRenewContract(EntityNum.fromLong(fundedExpiredAccountNum), now);
-        assertEquals(EntityProcessResult.NOTHING_TO_DO, result);
+        assertEquals(ExpiryProcessResult.NOTHING_TO_DO, result);
     }
 
     @Test

--- a/hedera-node/src/test/java/com/hedera/services/state/expiry/renewal/RenewalHelperTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/state/expiry/renewal/RenewalHelperTest.java
@@ -115,7 +115,7 @@ class RenewalHelperTest {
 
         final var result =
                 subject.tryToRenewAccount(EntityNum.fromLong(fundedExpiredAccountNum), now);
-        assertEquals(ExpiryProcessResult.STILL_MORE_TO_DO, result);
+        assertEquals(ExpiryProcessResult.NO_CAPACITY_LEFT, result);
     }
 
     @Test
@@ -137,7 +137,7 @@ class RenewalHelperTest {
 
         final var result =
                 subject.tryToRenewAccount(EntityNum.fromLong(fundedExpiredAccountNum), now);
-        assertEquals(ExpiryProcessResult.STILL_MORE_TO_DO, result);
+        assertEquals(ExpiryProcessResult.NO_CAPACITY_LEFT, result);
     }
 
     @Test

--- a/hedera-node/src/test/java/com/hedera/services/state/expiry/renewal/RenewalHelperTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/state/expiry/renewal/RenewalHelperTest.java
@@ -34,6 +34,7 @@ import com.hedera.services.state.expiry.ExpiryRecordsHelper;
 import com.hedera.services.state.expiry.classification.ClassificationWork;
 import com.hedera.services.state.expiry.classification.EntityLookup;
 import com.hedera.services.state.merkle.MerkleAccount;
+import com.hedera.services.stats.ExpiryStats;
 import com.hedera.services.throttling.ExpiryThrottle;
 import com.hedera.services.utils.EntityNum;
 import com.hedera.test.factories.accounts.MerkleAccountFactory;
@@ -52,6 +53,7 @@ class RenewalHelperTest {
     @Mock private FeeCalculator fees;
     @Mock private ExpiryRecordsHelper recordsHelper;
     @Mock private ExpiryThrottle expiryThrottle;
+    @Mock private ExpiryStats expiryStats;
 
     private EntityLookup lookup;
     private ClassificationWork classificationWork;
@@ -63,6 +65,7 @@ class RenewalHelperTest {
         classificationWork = new ClassificationWork(properties, lookup, expiryThrottle);
         subject =
                 new RenewalHelper(
+                        expiryStats,
                         lookup,
                         expiryThrottle,
                         classificationWork,
@@ -98,6 +101,7 @@ class RenewalHelperTest {
         // then:
         verify(accounts, times(2)).getForModify(key);
         verify(accounts).getForModify(fundingKey);
+        verify(expiryStats).countRenewedContract();
         assertEquals(key, classificationWork.getPayerNumForLastClassified());
     }
 
@@ -123,6 +127,7 @@ class RenewalHelperTest {
 
         subject =
                 new RenewalHelper(
+                        expiryStats,
                         lookup,
                         expiryThrottle,
                         classificationWork,

--- a/hedera-node/src/test/java/com/hedera/services/state/merkle/MerkleNetworkContextTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/state/merkle/MerkleNetworkContextTest.java
@@ -221,7 +221,7 @@ class MerkleNetworkContextTest {
         assertSame(subjectCopy.expiryUsageSnapshot(), subject.expiryUsageSnapshot());
         assertSame(subjectCopy.getCongestionLevelStarts(), subject.getCongestionLevelStarts());
         assertEquals(subjectCopy.getStateVersion(), stateVersion);
-        assertEquals(subjectCopy.getEntitiesScannedThisSecond(), entitiesScannedThisSecond);
+        assertEquals(subjectCopy.idsScannedThisSecond(), entitiesScannedThisSecond);
         assertEquals(subjectCopy.getEntitiesTouchedThisSecond(), entitiesTouchedThisSecond);
         assertEquals(subjectCopy.getPreparedUpdateFileNum(), preparedUpdateFileNum);
         assertSame(subjectCopy.getPreparedUpdateFileHash(), subject.getPreparedUpdateFileHash());
@@ -293,7 +293,7 @@ class MerkleNetworkContextTest {
         assertSame(subject.getCongestionLevelStarts(), subjectCopy.getCongestionLevelStarts());
         // and:
         assertEquals(subjectCopy.getStateVersion(), stateVersion);
-        assertEquals(subjectCopy.getEntitiesScannedThisSecond(), entitiesScannedThisSecond);
+        assertEquals(subjectCopy.idsScannedThisSecond(), entitiesScannedThisSecond);
         assertEquals(subjectCopy.getEntitiesTouchedThisSecond(), entitiesTouchedThisSecond);
         assertEquals(subjectCopy.getPreparedUpdateFileNum(), preparedUpdateFileNum);
         assertSame(subjectCopy.getPreparedUpdateFileHash(), subject.getPreparedUpdateFileHash());
@@ -338,7 +338,7 @@ class MerkleNetworkContextTest {
         assertEquals(a.expiryUsageSnapshot(), b.expiryUsageSnapshot());
         assertArrayEquals(a.getCongestionLevelStarts(), b.getCongestionLevelStarts());
         assertEquals(a.getStateVersion(), b.getStateVersion());
-        assertEquals(a.getEntitiesScannedThisSecond(), b.getEntitiesScannedThisSecond());
+        assertEquals(a.idsScannedThisSecond(), b.idsScannedThisSecond());
         assertEquals(a.getEntitiesTouchedThisSecond(), b.getEntitiesTouchedThisSecond());
         assertEquals(a.getPreparedUpdateFileNum(), b.getPreparedUpdateFileNum());
         assertArrayEquals(a.getPreparedUpdateFileHash(), b.getPreparedUpdateFileHash());
@@ -694,7 +694,7 @@ class MerkleNetworkContextTest {
                 (int) entitiesScannedThisSecond, (int) entitiesTouchedThisSecond);
 
         // then:
-        assertEquals(2 * entitiesScannedThisSecond, subject.getEntitiesScannedThisSecond());
+        assertEquals(2 * entitiesScannedThisSecond, subject.idsScannedThisSecond());
         assertEquals(2 * entitiesTouchedThisSecond, subject.getEntitiesTouchedThisSecond());
     }
 
@@ -705,7 +705,7 @@ class MerkleNetworkContextTest {
 
         // then:
         assertEquals(0, subject.getEntitiesTouchedThisSecond());
-        assertEquals(0, subject.getEntitiesScannedThisSecond());
+        assertEquals(0, subject.idsScannedThisSecond());
     }
 
     @Test

--- a/hedera-node/src/test/java/com/hedera/services/stats/ExpiryStatsTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/stats/ExpiryStatsTest.java
@@ -1,4 +1,24 @@
+/*
+ * Copyright (C) 2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hedera.services.stats;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 import com.swirlds.common.metrics.Counter;
 import com.swirlds.common.metrics.RunningAverageMetric;
@@ -9,19 +29,12 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-
-
 @ExtendWith(MockitoExtension.class)
 class ExpiryStatsTest {
     private static final double halfLife = 10.0;
 
     @Mock private Platform platform;
-    @Mock
-    private RunningAverageMetric idsScannedPerConsSec;
+    @Mock private RunningAverageMetric idsScannedPerConsSec;
     @Mock private Counter contractsRemoved;
     @Mock private Counter contractsRenewed;
 

--- a/hedera-node/src/test/java/com/hedera/services/stats/ExpiryStatsTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/stats/ExpiryStatsTest.java
@@ -15,7 +15,6 @@
  */
 package com.hedera.services.stats;
 
-import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -60,7 +59,7 @@ class ExpiryStatsTest {
 
         subject.countRemovedContract();
         subject.countRenewedContract();
-        subject.incorporateLastConsSec(5);
+        subject.includeIdsScannedInLastConsSec(5L);
 
         verify(contractsRemoved).increment();
         verify(contractsRenewed).increment();

--- a/hedera-node/src/test/java/com/hedera/services/stats/ExpiryStatsTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/stats/ExpiryStatsTest.java
@@ -1,0 +1,62 @@
+package com.hedera.services.stats;
+
+import com.swirlds.common.metrics.Counter;
+import com.swirlds.common.metrics.RunningAverageMetric;
+import com.swirlds.common.system.Platform;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+
+@ExtendWith(MockitoExtension.class)
+class ExpiryStatsTest {
+    private static final double halfLife = 10.0;
+
+    @Mock private Platform platform;
+    @Mock
+    private RunningAverageMetric idsScannedPerConsSec;
+    @Mock private Counter contractsRemoved;
+    @Mock private Counter contractsRenewed;
+
+    private ExpiryStats subject;
+
+    @BeforeEach
+    void setup() {
+        subject = new ExpiryStats(halfLife);
+    }
+
+    @Test
+    void registersExpectedStatEntries() {
+        setMocks();
+
+        subject.registerWith(platform);
+
+        verify(platform, times(3)).getOrCreateMetric(any());
+    }
+
+    @Test
+    void recordsToExpectedMetrics() {
+        setMocks();
+
+        subject.countRemovedContract();
+        subject.countRenewedContract();
+        subject.incorporateLastConsSec(5);
+
+        verify(contractsRemoved).increment();
+        verify(contractsRenewed).increment();
+        verify(idsScannedPerConsSec).update(5.0);
+    }
+
+    private void setMocks() {
+        subject.setIdsScannedPerConsSec(idsScannedPerConsSec);
+        subject.setContractsRemoved(contractsRemoved);
+        subject.setContractsRenewed(contractsRenewed);
+    }
+}

--- a/hedera-node/src/test/java/com/hedera/services/stats/MiscRunningAvgsTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/stats/MiscRunningAvgsTest.java
@@ -16,7 +16,6 @@
 package com.hedera.services.stats;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.mock;
 import static org.mockito.BDDMockito.verify;
 import static org.mockito.internal.verification.VerificationModeFactory.times;
 

--- a/hedera-node/src/test/java/com/hedera/services/stats/MiscRunningAvgsTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/stats/MiscRunningAvgsTest.java
@@ -35,8 +35,6 @@ class MiscRunningAvgsTest {
     @Mock private Platform platform;
 
     @Mock private RunningAverageMetric gasPerSec;
-    @Mock private RunningAverageMetric waitMs;
-    @Mock private RunningAverageMetric retries;
     @Mock private RunningAverageMetric submitSizes;
     @Mock private RunningAverageMetric queueSize;
     @Mock private RunningAverageMetric hashS;
@@ -44,8 +42,6 @@ class MiscRunningAvgsTest {
 
     @BeforeEach
     void setup() {
-        platform = mock(Platform.class);
-
         subject = new MiscRunningAvgs(halfLife);
     }
 
@@ -55,22 +51,18 @@ class MiscRunningAvgsTest {
 
         subject.registerWith(platform);
 
-        verify(platform, times(6)).getOrCreateMetric(any());
+        verify(platform, times(4)).getOrCreateMetric(any());
     }
 
     @Test
     void recordsToExpectedAvgs() {
         setMocks();
 
-        subject.recordAccountLookupRetries(1);
-        subject.recordAccountRetryWaitMs(2.0);
         subject.recordHandledSubmitMessageSize(3);
         subject.writeQueueSizeRecordStream(4);
         subject.hashQueueSizeRecordStream(5);
         subject.recordGasPerConsSec(6L);
 
-        verify(retries).update(1.0);
-        verify(waitMs).update(2.0);
         verify(submitSizes).update(3.0);
         verify(queueSize).update(4.0);
         verify(hashS).update(5);
@@ -78,8 +70,6 @@ class MiscRunningAvgsTest {
     }
 
     private void setMocks() {
-        subject.setAccountLookupRetries(retries);
-        subject.setAccountRetryWaitMs(waitMs);
         subject.setHandledSubmitMessageSize(submitSizes);
         subject.setWriteQueueSizeRecordStream(queueSize);
         subject.setHashQueueSizeRecordStream(hashS);

--- a/hedera-node/src/test/java/com/hedera/services/stats/ServicesStatsManagerTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/stats/ServicesStatsManagerTest.java
@@ -59,6 +59,8 @@ class ServicesStatsManagerTest {
     @Mock private VirtualMap<VirtualBlobKey, VirtualBlobValue> bytecode;
     @Mock private ThrottleGauges throttleGauges;
     @Mock private EntityUtilGauges entityUtilGauges;
+    @Mock
+    private ExpiryStats expiryStats;
 
     ServicesStatsManager subject;
 
@@ -76,6 +78,7 @@ class ServicesStatsManagerTest {
 
         subject =
                 new ServicesStatsManager(
+                        expiryStats,
                         counters,
                         throttleGauges,
                         runningAvgs,
@@ -115,6 +118,7 @@ class ServicesStatsManagerTest {
         // then:
         verify(counters).registerWith(platform);
         verify(speedometers).registerWith(platform);
+        verify(expiryStats).registerWith(platform);
         verify(miscSpeedometers).registerWith(platform);
         verify(runningAvgs).registerWith(platform);
         verify(throttleGauges).registerWith(platform);

--- a/hedera-node/src/test/java/com/hedera/services/stats/ServicesStatsManagerTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/stats/ServicesStatsManagerTest.java
@@ -59,8 +59,7 @@ class ServicesStatsManagerTest {
     @Mock private VirtualMap<VirtualBlobKey, VirtualBlobValue> bytecode;
     @Mock private ThrottleGauges throttleGauges;
     @Mock private EntityUtilGauges entityUtilGauges;
-    @Mock
-    private ExpiryStats expiryStats;
+    @Mock private ExpiryStats expiryStats;
 
     ServicesStatsManager subject;
 

--- a/hedera-node/src/test/java/com/hedera/services/utils/UtilsConstructorTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/utils/UtilsConstructorTest.java
@@ -54,10 +54,7 @@ import com.hedera.services.state.migration.*;
 import com.hedera.services.state.serdes.IoUtils;
 import com.hedera.services.state.virtual.IterableStorageUtils;
 import com.hedera.services.state.virtual.KeyPackingUtils;
-import com.hedera.services.stats.MiscRunningAvgs;
-import com.hedera.services.stats.MiscSpeedometers;
-import com.hedera.services.stats.ServicesStatsConfig;
-import com.hedera.services.stats.StatsModule;
+import com.hedera.services.stats.*;
 import com.hedera.services.store.contracts.precompile.AbiConstants;
 import com.hedera.services.store.contracts.precompile.utils.DescriptorUtils;
 import com.hedera.services.store.contracts.precompile.utils.PrecompileUtils;
@@ -123,6 +120,8 @@ class UtilsConstructorTest {
                             ReleaseTwentySixMigration.class,
                             StateChildIndices.class,
                             StateVersions.class,
+                            ExpiryStats.Names.class,
+                            ExpiryStats.Descriptions.class,
                             MiscRunningAvgs.Names.class,
                             MiscRunningAvgs.Descriptions.class,
                             MiscSpeedometers.Names.class,

--- a/test-clients/yahcli/run/build.sh
+++ b/test-clients/yahcli/run/build.sh
@@ -1,5 +1,5 @@
 #! /bin/sh
-TAG=${1:-'0.2.6'}
+TAG=${1:-'0.2.7'}
 
 cd ../..
 ./gradlew shadowJar \


### PR DESCRIPTION
**Description**:
 - Makes `SerializableSemVer` ordering `alpha.x`-aware.
 - Further refactors and simplifies `EntityAutoExpiry`.
 - Removes confusing "cycle" semantics from `AutoExpiryCycle` (now `ExpiryProcess`).
   * Fixes return codes to clarify that expiry work only aborts early if `NO_CAPACITY_LEFT`.
 - Wraps all link-dependent auto-removal work in `try`/`catch` blocks.
 - Adds `ExpiryStats`:
     1. A running average of id's scanned per consensus second.
     2. A counter of contracts auto-removed since the last restart.
     3. A counter of contracts auto-renewed since the last restart.
 - Removes two unused stats from `MiscRunningAvgs`.
 - Reinstates the `LinkAwareUniqueTokensCommitInterceptor` in the `nftsLedger`.
 - Only auto-renews non-deleted contracts during migration.
