### PR TITLE
Rationalize treatment of expired entity lifetimes

### DIFF
--- a/hedera-node/src/test/java/com/hedera/services/fees/charging/RecordedStorageFeeChargingTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/fees/charging/RecordedStorageFeeChargingTest.java
@@ -15,10 +15,7 @@
  */
 package com.hedera.services.fees.charging;
 
-import static com.hedera.services.ledger.properties.AccountProperty.AUTO_RENEW_ACCOUNT_ID;
-import static com.hedera.services.ledger.properties.AccountProperty.BALANCE;
-import static com.hedera.services.ledger.properties.AccountProperty.EXPIRY;
-import static com.hedera.services.ledger.properties.AccountProperty.IS_DELETED;
+import static com.hedera.services.ledger.properties.AccountProperty.*;
 import static com.hedera.services.records.TxnAwareRecordsHistorian.DEFAULT_SOURCE_ID;
 import static com.hedera.test.utils.TxnUtils.assertExhaustsResourceLimit;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INSUFFICIENT_BALANCES_FOR_STORAGE_RENT;
@@ -162,6 +159,31 @@ class RecordedStorageFeeChargingTest {
         verify(accountsLedger).set(cContract, BALANCE, 2L);
         verify(accountsLedger).set(funding, BALANCE, expectedACharge);
         verify(accountsLedger).set(funding, BALANCE, expectedACharge + expectedCCharge);
+    }
+
+    @Test
+    void usesAutoRenewPeriodForAncientContract() {
+        givenStandardSetup();
+        final Map<Long, KvUsageInfo> usageInfos = new LinkedHashMap<>();
+        usageInfos.put(aContract.getAccountNum(), nonFreeUsageFor(+2));
+        usageInfos.put(bContract.getAccountNum(), nonFreeUsageFor(-1));
+        final var expectedACharge =
+                STORAGE_PRICE_TIERS.priceOfPendingUsage(
+                        someRate,
+                        NUM_SLOTS_USED,
+                        REFERENCE_LIFETIME,
+                        usageInfos.get(aContract.getAccountNum()));
+        given(accountsLedger.get(funding, BALANCE)).willReturn(0L).willReturn(expectedACharge);
+
+        givenAncientChargeableContract(aContract, -1, REFERENCE_LIFETIME, anAutoRenew);
+        givenAutoRenew(anAutoRenew, expectedACharge + 1);
+
+        subject.chargeStorageRent(NUM_SLOTS_USED, usageInfos, accountsLedger);
+
+        verify(accountsLedger).set(anAutoRenew, BALANCE, 1L);
+        verify(accountsLedger, never()).set(eq(aContract), eq(BALANCE), anyLong());
+        verify(accountsLedger).set(funding, BALANCE, expectedACharge);
+        verify(accountsLedger).set(funding, BALANCE, expectedACharge);
     }
 
     @Test
@@ -625,6 +647,25 @@ class RecordedStorageFeeChargingTest {
             given(accountsLedger.get(id, BALANCE)).willReturn(amount);
         }
         given(accountsLedger.get(id, EXPIRY)).willReturn(now.getEpochSecond() + expiry);
+        if (autoRenewId != null) {
+            given(accountsLedger.get(id, AUTO_RENEW_ACCOUNT_ID))
+                    .willReturn(EntityId.fromGrpcAccountId(autoRenewId));
+        } else {
+            given(accountsLedger.get(id, AUTO_RENEW_ACCOUNT_ID))
+                    .willReturn(EntityId.MISSING_ENTITY_ID);
+        }
+    }
+
+    private void givenAncientChargeableContract(
+            final AccountID id,
+            final long amount,
+            final long expiry,
+            @Nullable AccountID autoRenewId) {
+        if (amount > -1) {
+            given(accountsLedger.get(id, BALANCE)).willReturn(amount);
+        }
+        given(accountsLedger.get(id, EXPIRY)).willReturn(now.getEpochSecond() - expiry);
+        given(accountsLedger.get(id, AUTO_RENEW_PERIOD)).willReturn(expiry);
         if (autoRenewId != null) {
             given(accountsLedger.get(id, AUTO_RENEW_ACCOUNT_ID))
                     .willReturn(EntityId.fromGrpcAccountId(autoRenewId));

--- a/hedera-node/src/test/java/com/hedera/services/state/expiry/AutoExpiryCycleTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/state/expiry/AutoExpiryCycleTest.java
@@ -345,11 +345,6 @@ class AutoExpiryCycleTest {
         given(
                         accountsLedger.get(
                                 EntityNum.fromLong(fundedExpiredAccountNum).toGrpcAccountId(),
-                                AccountProperty.EXPIRY))
-                .willReturn(now.getEpochSecond() - 1);
-        given(
-                        accountsLedger.get(
-                                EntityNum.fromLong(fundedExpiredAccountNum).toGrpcAccountId(),
                                 AccountProperty.BALANCE))
                 .willReturn(nonZeroBalance);
 
@@ -364,7 +359,7 @@ class AutoExpiryCycleTest {
         verify(feeDistribution).distributeChargedFee(anyLong(), eq(accountsLedger));
         verify(recordsHelper)
                 .streamCryptoRenewal(
-                        key, fee, now.getEpochSecond() - 1 + actualRenewalPeriod, false, key);
+                        key, fee, now.getEpochSecond() + actualRenewalPeriod, false, key);
     }
 
     @Test
@@ -385,11 +380,6 @@ class AutoExpiryCycleTest {
         given(
                         accountsLedger.get(
                                 EntityNum.fromLong(fundedExpiredContractNum).toGrpcAccountId(),
-                                AccountProperty.EXPIRY))
-                .willReturn(now.getEpochSecond() - 1);
-        given(
-                        accountsLedger.get(
-                                EntityNum.fromLong(fundedExpiredContractNum).toGrpcAccountId(),
                                 AccountProperty.BALANCE))
                 .willReturn(nonZeroBalance);
 
@@ -405,7 +395,7 @@ class AutoExpiryCycleTest {
         verify(feeDistribution).distributeChargedFee(anyLong(), eq(accountsLedger));
         verify(recordsHelper)
                 .streamCryptoRenewal(
-                        key, fee, now.getEpochSecond() - 1 + actualRenewalPeriod, true, key);
+                        key, fee, now.getEpochSecond() + actualRenewalPeriod, true, key);
     }
 
     @Test


### PR DESCRIPTION
**Description**:
Fixes two edge cases for expired contracts:
 - When renewing a contract, make sure its new expiry is in the future by using `now + renewalPeriod` instead of `oldExpiry + renewalPeriod` (it's possible the auto-renew cycle will take a long time to visit an expired contract, and for a small value of `renewalPeriod`, we could leave the contract still expired).
 - When charging storage fees for an expired contract, treat the expected lifetime of the new storage slots as the contract's auto-renew period.