### PR TITLE
Allocate a reduced `consensusTimeStamp` to accommodate triggered transactions in balance file

### DIFF
--- a/hedera-node/src/main/java/com/hedera/services/state/logic/StandardProcessLogic.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/logic/StandardProcessLogic.java
@@ -15,6 +15,8 @@
  */
 package com.hedera.services.state.logic;
 
+import static com.hedera.services.utils.Units.MIN_TRANS_TIMESTAMP_INCR_NANOS;
+
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.hedera.services.context.TransactionContext;
 import com.hedera.services.context.primitives.StateView;
@@ -28,7 +30,6 @@ import com.hedera.services.txns.schedule.ScheduleProcessing;
 import com.hedera.services.txns.span.ExpandHandleSpan;
 import com.hedera.services.utils.accessors.TxnAccessor;
 import com.swirlds.common.system.transaction.Transaction;
-import com.swirlds.platform.internal.EventImpl;
 import java.time.Instant;
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -90,7 +91,7 @@ public class StandardProcessLogic implements ProcessLogic {
             // current transaction
             // in the balance file with consensus timestamp X to include all transactions whose
             // consensus time T <= X.
-            consensusTime = consensusTime.minusNanos(EventImpl.MIN_TRANS_TIMESTAMP_INCR_NANOS);
+            consensusTime = consensusTime.minusNanos(MIN_TRANS_TIMESTAMP_INCR_NANOS);
 
             final var accessor = expandHandleSpan.accessorFor(platformTxn);
             accessor.setStateView(workingView);

--- a/hedera-node/src/main/java/com/hedera/services/state/logic/StandardProcessLogic.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/logic/StandardProcessLogic.java
@@ -28,6 +28,7 @@ import com.hedera.services.txns.schedule.ScheduleProcessing;
 import com.hedera.services.txns.span.ExpandHandleSpan;
 import com.hedera.services.utils.accessors.TxnAccessor;
 import com.swirlds.common.system.transaction.Transaction;
+import com.swirlds.platform.internal.EventImpl;
 import java.time.Instant;
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -83,6 +84,14 @@ public class StandardProcessLogic implements ProcessLogic {
     public void incorporateConsensusTxn(
             Transaction platformTxn, Instant consensusTime, long submittingMember) {
         try {
+            // Deduct 1000 nanos from the consensusTime allotted by platform, to accommodate the
+            // preceding,
+            // following child records and any long term scheduled transactions triggered by the
+            // current transaction
+            // in the balance file with consensus timestamp X to include all transactions whose
+            // consensus time T <= X.
+            consensusTime = consensusTime.minusNanos(EventImpl.MIN_TRANS_TIMESTAMP_INCR_NANOS);
+
             final var accessor = expandHandleSpan.accessorFor(platformTxn);
             accessor.setStateView(workingView);
             if (!invariantChecks.holdFor(accessor, consensusTime, submittingMember)) {


### PR DESCRIPTION
Signed-off-by: Neeharika-Sompalli <neeharika.sompalli@swirldslabs.com>

Fixes #3869

In order to solve the issue of a balance file with consensusTimestamp X, has all the child transactions and triggered long term scheduled transactions with T <= X be included in it,  
Deducted 1000 nanos from the consensusTime allotted by platform, when allocating to the transaction in services.