### PR TITLE
Check for `null` bytecode in traceability migration

### DIFF
--- a/hedera-node/src/main/java/com/hedera/services/state/migration/MigrationRecordsManager.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/migration/MigrationRecordsManager.java
@@ -322,6 +322,13 @@ public class MigrationRecordsManager {
 
                             final var bytecodeSidecar =
                                     generateMigrationBytecodeSidecarFor(contractId);
+                            if (bytecodeSidecar == null) {
+                                log.debug(
+                                        "Contract 0.0.{} has no bytecode in state - no migration"
+                                                + " sidecar records will be published.",
+                                        contractId.getContractNum());
+                                return;
+                            }
                             transactionContext.addSidecarRecord(bytecodeSidecar);
                             log.debug(
                                     "Published migration bytecode sidecar for contract 0.0.{}",
@@ -352,6 +359,9 @@ public class MigrationRecordsManager {
             final ContractID contractId) {
         final var runtimeCode =
                 entityAccess.fetchCodeIfPresent(EntityIdUtils.asAccount(contractId));
+        if (runtimeCode == null) {
+            return null;
+        }
         final var bytecodeSidecar =
                 SidecarUtils.createContractBytecodeSidecarFrom(
                         contractId, runtimeCode.toArrayUnsafe());

--- a/hedera-node/src/main/java/com/hedera/services/state/migration/MigrationRecordsManager.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/migration/MigrationRecordsManager.java
@@ -323,7 +323,7 @@ public class MigrationRecordsManager {
                             final var bytecodeSidecar =
                                     generateMigrationBytecodeSidecarFor(contractId);
                             if (bytecodeSidecar == null) {
-                                log.debug(
+                                log.warn(
                                         "Contract 0.0.{} has no bytecode in state - no migration"
                                                 + " sidecar records will be published.",
                                         contractId.getContractNum());

--- a/hedera-node/src/test/java/com/hedera/services/state/migration/MigrationRecordsManagerTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/state/migration/MigrationRecordsManagerTest.java
@@ -602,11 +602,13 @@ class MigrationRecordsManagerTest {
         verify(transactionContext, never())
                 .addSidecarRecord(any(TransactionSidecarRecord.Builder.class));
         assertThat(
-            logCaptor.warnLogs(),
-            contains(
-                Matchers.equalTo(
-                    "Contract 0.0." + contractNum + " has no bytecode in state - no migration"
-                        + " sidecar records will be published.")));
+                logCaptor.warnLogs(),
+                contains(
+                        Matchers.equalTo(
+                                "Contract 0.0."
+                                        + contractNum
+                                        + " has no bytecode in state - no migration"
+                                        + " sidecar records will be published.")));
     }
 
     @Test

--- a/hedera-node/src/test/java/com/hedera/services/state/migration/MigrationRecordsManagerTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/state/migration/MigrationRecordsManagerTest.java
@@ -592,7 +592,8 @@ class MigrationRecordsManagerTest {
         accounts.clear();
         final var contract = mock(MerkleAccount.class);
         given(contract.isSmartContract()).willReturn(true);
-        final var entityNum = EntityNum.fromLong(1L);
+        final var contractNum = 1L;
+        final var entityNum = EntityNum.fromLong(contractNum);
         accounts.put(entityNum, contract);
 
         subject.publishMigrationRecords(now);
@@ -600,6 +601,12 @@ class MigrationRecordsManagerTest {
         assertTrue(subject.areTraceabilityRecordsStreamed());
         verify(transactionContext, never())
                 .addSidecarRecord(any(TransactionSidecarRecord.Builder.class));
+        assertThat(
+            logCaptor.warnLogs(),
+            contains(
+                Matchers.equalTo(
+                    "Contract 0.0." + contractNum + " has no bytecode in state - no migration"
+                        + " sidecar records will be published.")));
     }
 
     @Test

--- a/hedera-node/src/test/java/com/hedera/services/state/migration/MigrationRecordsManagerTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/state/migration/MigrationRecordsManagerTest.java
@@ -593,8 +593,10 @@ class MigrationRecordsManagerTest {
         final var contract = mock(MerkleAccount.class);
         given(contract.isSmartContract()).willReturn(true);
         final var contractNum = 1L;
-        final var entityNum = EntityNum.fromLong(contractNum);
-        accounts.put(entityNum, contract);
+        final var contractEntityNum = EntityNum.fromLong(contractNum);
+        accounts.put(contractEntityNum, contract);
+        given(entityAccess.fetchCodeIfPresent(contractEntityNum.toGrpcAccountId()))
+                .willReturn(null);
 
         subject.publishMigrationRecords(now);
 


### PR DESCRIPTION
Signed-off-by: Dimitar Dinev <mitkojc@gmail.com>

**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->

* Changes traceability migration logic in `MigrationRecordsManager` to check for `null` bytecode for a contract and not export any sidecars in such cases.

**Related issue(s)**:

Fixes #3922 
