### PR TITLE
Extract `hedera-evm` submodule

### DIFF
--- a/hedera-evm/build.gradle
+++ b/hedera-evm/build.gradle
@@ -1,0 +1,28 @@
+plugins {
+    id("com.hedera.hashgraph.hedera-conventions")
+    id("com.hedera.hashgraph.benchmark-conventions")
+    id("maven-publish")
+}
+
+description = "Hedera Evm"
+
+version '0.29.0-SNAPSHOT'
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation(project(":hapi-utils"))
+    implementation(libs.bundles.logging)
+    implementation(libs.commons.lang3)
+    implementation(libs.hapi)
+    implementation(libs.javax.inject)
+    implementation(libs.jackson)
+    implementation(libs.jetbrains.annotation)
+    testImplementation(testLibs.bundles.testing)
+}
+
+test {
+    useJUnitPlatform()
+}


### PR DESCRIPTION
**Description**:
Define a new submodule `hedera-evm` inside `hedera-services` that will serve as a building block for the EVM library that extracts common Hedera smart contract EVM logic and would be reused.

**Related issue(s)**:

Fixes #

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
