### PR TITLE
Removed all instances of longValue being unsafely called on BigInteger types

### DIFF
--- a/hedera-node/src/main/java/com/hedera/services/state/virtual/schedule/ScheduleEqualityVirtualValue.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/virtual/schedule/ScheduleEqualityVirtualValue.java
@@ -170,7 +170,7 @@ public class ScheduleEqualityVirtualValue extends PartialMerkleLeaf
 
         var cur = ids.get(hash);
 
-        if (cur != null && cur.longValue() != id) {
+        if (cur != null && cur != id) {
             throw new IllegalStateException(
                     "multiple ids with same hash during add! " + cur + " and " + id);
         }
@@ -183,7 +183,7 @@ public class ScheduleEqualityVirtualValue extends PartialMerkleLeaf
 
         var cur = ids.get(hash);
 
-        if (cur != null && cur.longValue() != id) {
+        if (cur != null && cur != id) {
             throw new IllegalStateException(
                     "multiple ids with same hash during remove! " + cur + " and " + id);
         }

--- a/hedera-node/src/main/java/com/hedera/services/store/contracts/precompile/SyntheticTxnFactory.java
+++ b/hedera-node/src/main/java/com/hedera/services/store/contracts/precompile/SyntheticTxnFactory.java
@@ -314,14 +314,14 @@ public class SyntheticTxnFactory {
                     TokenAllowance.newBuilder()
                             .setTokenId(approveWrapper.tokenId())
                             .setSpender(approveWrapper.spender())
-                            .setAmount(approveWrapper.amount().longValue())
+                            .setAmount(approveWrapper.amount().longValueExact())
                             .build());
         } else {
             final var op =
                     NftAllowance.newBuilder()
                             .setTokenId(approveWrapper.tokenId())
                             .setSpender(approveWrapper.spender())
-                            .addSerialNumbers(approveWrapper.serialNumber().longValue());
+                            .addSerialNumbers(approveWrapper.serialNumber().longValueExact());
             if (ownerId != null) {
                 op.setOwner(ownerId.toGrpcAccountId());
                 if (!ownerId.equals(operatorId)) {
@@ -342,7 +342,10 @@ public class SyntheticTxnFactory {
                                         .setOwner(owner.toGrpcAccountId())
                                         .setTokenId(approveWrapper.tokenId())
                                         .addAllSerialNumbers(
-                                                List.of(approveWrapper.serialNumber().longValue()))
+                                                List.of(
+                                                        approveWrapper
+                                                                .serialNumber()
+                                                                .longValueExact()))
                                         .build()))
                 .build();
         return TransactionBody.newBuilder().setCryptoDeleteAllowance(builder);
@@ -429,7 +432,7 @@ public class SyntheticTxnFactory {
                         ? TokenSupplyType.FINITE
                         : TokenSupplyType.INFINITE);
         txnBodyBuilder.setMaxSupply(tokenCreateWrapper.getMaxSupply());
-        txnBodyBuilder.setInitialSupply(tokenCreateWrapper.getInitSupply().longValue());
+        txnBodyBuilder.setInitialSupply(tokenCreateWrapper.getInitSupply().longValueExact());
         if (tokenCreateWrapper.getTreasury() != null)
             txnBodyBuilder.setTreasury(tokenCreateWrapper.getTreasury());
         txnBodyBuilder.setFreezeDefault(tokenCreateWrapper.isFreezeDefault());

--- a/hedera-node/src/main/java/com/hedera/services/store/contracts/precompile/impl/ERCTransferPrecompile.java
+++ b/hedera-node/src/main/java/com/hedera/services/store/contracts/precompile/impl/ERCTransferPrecompile.java
@@ -173,8 +173,8 @@ public class ERCTransferPrecompile extends TransferPrecompile {
         final var amount = (BigInteger) decodedArguments.get(1);
 
         final List<SyntheticTxnFactory.FungibleTokenTransfer> fungibleTransfers = new ArrayList<>();
-        addSignedAdjustment(fungibleTransfers, token, recipient, amount.longValue());
-        addSignedAdjustment(fungibleTransfers, token, caller, -amount.longValue());
+        addSignedAdjustment(fungibleTransfers, token, recipient, amount.longValueExact());
+        addSignedAdjustment(fungibleTransfers, token, caller, -amount.longValueExact());
 
         return Collections.singletonList(
                 new TokenTransferWrapper(NO_NFT_EXCHANGES, fungibleTransfers));
@@ -199,19 +199,19 @@ public class ERCTransferPrecompile extends TransferPrecompile {
                     new ArrayList<>();
             final var amount = (BigInteger) decodedArguments.get(2);
 
-            addSignedAdjustment(fungibleTransfers, token, to, amount.longValue());
+            addSignedAdjustment(fungibleTransfers, token, to, amount.longValueExact());
 
             if (from.equals(operatorId.toGrpcAccountId())) {
-                addSignedAdjustment(fungibleTransfers, token, from, -amount.longValue());
+                addSignedAdjustment(fungibleTransfers, token, from, -amount.longValueExact());
             } else {
-                addApprovedAdjustment(fungibleTransfers, token, from, -amount.longValue());
+                addApprovedAdjustment(fungibleTransfers, token, from, -amount.longValueExact());
             }
 
             return Collections.singletonList(
                     new TokenTransferWrapper(NO_NFT_EXCHANGES, fungibleTransfers));
         } else {
             final List<SyntheticTxnFactory.NftExchange> nonFungibleTransfers = new ArrayList<>();
-            final var serialNo = ((BigInteger) decodedArguments.get(2)).longValue();
+            final var serialNo = ((BigInteger) decodedArguments.get(2)).longValueExact();
             final var ownerId = ledgers.ownerIfPresent(NftId.fromGrpc(token, serialNo));
 
             if (operatorId.equals(ownerId)) {

--- a/hedera-node/src/main/java/com/hedera/services/store/contracts/precompile/impl/GetApprovedPrecompile.java
+++ b/hedera-node/src/main/java/com/hedera/services/store/contracts/precompile/impl/GetApprovedPrecompile.java
@@ -120,6 +120,6 @@ public class GetApprovedPrecompile extends AbstractReadOnlyPrecompile {
                         : convertAddressBytesToTokenID(decodedArguments.get(0));
 
         final var serialNo = (BigInteger) decodedArguments.get(offset);
-        return new GetApprovedWrapper(tId, serialNo.longValue());
+        return new GetApprovedWrapper(tId, serialNo.longValueExact());
     }
 }

--- a/hedera-node/src/main/java/com/hedera/services/store/contracts/precompile/impl/OwnerOfPrecompile.java
+++ b/hedera-node/src/main/java/com/hedera/services/store/contracts/precompile/impl/OwnerOfPrecompile.java
@@ -85,6 +85,6 @@ public class OwnerOfPrecompile extends AbstractReadOnlyPrecompile {
 
         final var tokenId = (BigInteger) decodedArguments.get(0);
 
-        return new OwnerOfAndTokenURIWrapper(tokenId.longValue());
+        return new OwnerOfAndTokenURIWrapper(tokenId.longValueExact());
     }
 }

--- a/hedera-node/src/main/java/com/hedera/services/store/contracts/precompile/impl/TokenURIPrecompile.java
+++ b/hedera-node/src/main/java/com/hedera/services/store/contracts/precompile/impl/TokenURIPrecompile.java
@@ -82,6 +82,6 @@ public class TokenURIPrecompile extends AbstractReadOnlyPrecompile {
 
         final var tokenId = (BigInteger) decodedArguments.get(0);
 
-        return new OwnerOfAndTokenURIWrapper(tokenId.longValue());
+        return new OwnerOfAndTokenURIWrapper(tokenId.longValueExact());
     }
 }

--- a/hedera-node/src/test/java/com/hedera/services/store/contracts/precompile/ERCTransferPrecompileTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/store/contracts/precompile/ERCTransferPrecompileTest.java
@@ -29,13 +29,12 @@ import com.hedera.services.state.submerkle.EntityId;
 import com.hedera.services.store.contracts.WorldLedgers;
 import com.hederahashgraph.api.proto.java.AccountID;
 import com.hederahashgraph.api.proto.java.TokenID;
+import java.util.function.UnaryOperator;
 import org.apache.tuweni.bytes.Bytes;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-
-import java.util.function.UnaryOperator;
 
 @ExtendWith(MockitoExtension.class)
 class ERCTransferPrecompileTest {
@@ -77,12 +76,7 @@ class ERCTransferPrecompileTest {
 
         assertThrows(
                 ArithmeticException.class,
-                () ->
-                        decodeERCTransfer(
-                                TRANSFER_LONG_OVERFLOWN,
-                                TOKEN_ID,
-                                accId,
-                                aliasResolver));
+                () -> decodeERCTransfer(TRANSFER_LONG_OVERFLOWN, TOKEN_ID, accId, aliasResolver));
     }
 
     @Test

--- a/hedera-node/src/test/java/com/hedera/services/store/contracts/precompile/ERCTransferPrecompileTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/store/contracts/precompile/ERCTransferPrecompileTest.java
@@ -20,6 +20,7 @@ import static com.hedera.services.store.contracts.precompile.impl.ERCTransferPre
 import static java.util.function.UnaryOperator.identity;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
@@ -39,15 +40,18 @@ class ERCTransferPrecompileTest {
     private static final Bytes TRANSFER_INPUT =
             Bytes.fromHexString(
                     "0xa9059cbb00000000000000000000000000000000000000000000000000000000000005a50000000000000000000000000000000000000000000000000000000000000002");
-
+    private static final Bytes TRANSFER_LONG_OVERFLOWN =
+            Bytes.fromHexString(
+                    "0xa9059cbb00000000000000000000000000000000000000000000000000000000000003ea0000000000000000000000000000000000000000000000010000000000000002");
     private static final Bytes TRANSFER_FROM_FUNGIBLE_INPUT =
             Bytes.fromHexString(
                     "0x23b872dd00000000000000000000000000000000000000000000000000000000000005aa00000000000000000000000000000000000000000000000000000000000005ab0000000000000000000000000000000000000000000000000000000000000005");
-
     private static final Bytes TRANSFER_FROM_NON_FUNGIBLE_INPUT =
             Bytes.fromHexString(
                     "0x23b872dd00000000000000000000000000000000000000000000000000000000000003e900000000000000000000000000000000000000000000000000000000000003ea0000000000000000000000000000000000000000000000000000000000000001");
-
+    private static final Bytes TRANSFER_FROM_LONG_OVERFLOWN =
+            Bytes.fromHexString(
+                    "0x23b872dd00000000000000000000000000000000000000000000000000000000000003ef00000000000000000000000000000000000000000000000000000000000003f00000000000000000000000000000000000000000000000010000000000000002");
     private static final long TOKEN_NUM_HAPI_TOKEN = 0x1234;
     private static final TokenID TOKEN_ID =
             TokenID.newBuilder().setTokenNum(TOKEN_NUM_HAPI_TOKEN).build();
@@ -62,6 +66,18 @@ class ERCTransferPrecompileTest {
 
         assertTrue(fungibleTransfer.receiver().getAccountNum() > 0);
         assertEquals(2, fungibleTransfer.amount());
+    }
+
+    @Test
+    void decodeTransferShouldThrowOnAmountOverflown() {
+        assertThrows(
+                ArithmeticException.class,
+                () ->
+                        decodeERCTransfer(
+                                TRANSFER_LONG_OVERFLOWN,
+                                TOKEN_ID,
+                                AccountID.getDefaultInstance(),
+                                identity()));
     }
 
     @Test
@@ -138,5 +154,20 @@ class ERCTransferPrecompileTest {
         assertTrue(nftTransfer.getReceiverAccountID().getAccountNum() > 0);
         assertEquals(1, nftTransfer.getSerialNumber());
         assertFalse(nftTransfer.getIsApproval());
+    }
+
+    @Test
+    void decodeTransferFromShouldThrowOnAmountOverflown() {
+        final var fromOp = new EntityId(0, 0, 1450);
+        assertThrows(
+                ArithmeticException.class,
+                () ->
+                        decodeERCTransferFrom(
+                                TRANSFER_FROM_LONG_OVERFLOWN,
+                                TOKEN_ID,
+                                true,
+                                identity(),
+                                ledgers,
+                                fromOp));
     }
 }

--- a/hedera-node/src/test/java/com/hedera/services/store/contracts/precompile/ERCTransferPrecompileTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/store/contracts/precompile/ERCTransferPrecompileTest.java
@@ -35,6 +35,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.function.UnaryOperator;
+
 @ExtendWith(MockitoExtension.class)
 class ERCTransferPrecompileTest {
     private static final Bytes TRANSFER_INPUT =
@@ -70,14 +72,17 @@ class ERCTransferPrecompileTest {
 
     @Test
     void decodeTransferShouldThrowOnAmountOverflown() {
+        final var accId = AccountID.getDefaultInstance();
+        final UnaryOperator<byte[]> aliasResolver = identity();
+
         assertThrows(
                 ArithmeticException.class,
                 () ->
                         decodeERCTransfer(
                                 TRANSFER_LONG_OVERFLOWN,
                                 TOKEN_ID,
-                                AccountID.getDefaultInstance(),
-                                identity()));
+                                accId,
+                                aliasResolver));
     }
 
     @Test
@@ -159,6 +164,8 @@ class ERCTransferPrecompileTest {
     @Test
     void decodeTransferFromShouldThrowOnAmountOverflown() {
         final var fromOp = new EntityId(0, 0, 1450);
+        final UnaryOperator<byte[]> aliasResolver = identity();
+
         assertThrows(
                 ArithmeticException.class,
                 () ->
@@ -166,7 +173,7 @@ class ERCTransferPrecompileTest {
                                 TRANSFER_FROM_LONG_OVERFLOWN,
                                 TOKEN_ID,
                                 true,
-                                identity(),
+                                aliasResolver,
                                 ledgers,
                                 fromOp));
     }

--- a/hedera-node/src/test/java/com/hedera/services/store/contracts/precompile/GetApprovedPrecompileTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/store/contracts/precompile/GetApprovedPrecompileTest.java
@@ -17,6 +17,7 @@ package com.hedera.services.store.contracts.precompile;
 
 import static com.hedera.services.store.contracts.precompile.impl.GetApprovedPrecompile.decodeGetApproved;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.hederahashgraph.api.proto.java.TokenID;
 import org.apache.tuweni.bytes.Bytes;
@@ -29,6 +30,9 @@ class GetApprovedPrecompileTest {
     private static final Bytes GET_APPROVED_INPUT_ERC =
             Bytes.fromHexString(
                     "0x081812fc0000000000000000000000000000000000000000000000000000000000000001");
+    private static final Bytes GET_APPROVED_LONG_OVERFLOWN =
+            Bytes.fromHexString(
+                    "0x081812fc0000000000000000000000000000000000000000000000010000000000000001");
     private static final Bytes GET_APPROVED_INPUT_HAPI =
             Bytes.fromHexString(
                     "0x098f236600000000000000000000000000000000000000000000000000000000000012340000000000000000000000000000000000000000000000000000000000000001");
@@ -44,6 +48,13 @@ class GetApprovedPrecompileTest {
 
         assertEquals(TOKEN_ID.getTokenNum(), decodedInput.tokenId().getTokenNum());
         assertEquals(1, decodedInput.serialNo());
+    }
+
+    @Test
+    void decodeGetApprovedShouldThrowOnSerialNoOverflown() {
+        assertThrows(
+                ArithmeticException.class,
+                () -> decodeGetApproved(GET_APPROVED_LONG_OVERFLOWN, TOKEN_ID));
     }
 
     @Test

--- a/hedera-node/src/test/java/com/hedera/services/store/contracts/precompile/OwnerOfPrecompileTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/store/contracts/precompile/OwnerOfPrecompileTest.java
@@ -17,6 +17,7 @@ package com.hedera.services.store.contracts.precompile;
 
 import static com.hedera.services.store.contracts.precompile.impl.OwnerOfPrecompile.decodeOwnerOf;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.apache.tuweni.bytes.Bytes;
 import org.junit.jupiter.api.Test;
@@ -29,11 +30,19 @@ class OwnerOfPrecompileTest {
     private static final Bytes OWNER_OF_INPUT =
             Bytes.fromHexString(
                     "0x6352211e0000000000000000000000000000000000000000000000000000000000000001");
+    private static final Bytes OWNER_OF_LONG_OVERFLOWN =
+            Bytes.fromHexString(
+                    "0x6352211e0000000000000000000000000000000000000000000000010000000000000001");
 
     @Test
     void decodeOwnerOfInput() {
         final var decodedInput = decodeOwnerOf(OWNER_OF_INPUT);
 
         assertEquals(1, decodedInput.serialNo());
+    }
+
+    @Test
+    void decodeOwnerOfShouldThrowOnTokenIdOverflown() {
+        assertThrows(ArithmeticException.class, () -> decodeOwnerOf(OWNER_OF_LONG_OVERFLOWN));
     }
 }

--- a/hedera-node/src/test/java/com/hedera/services/store/contracts/precompile/TokenURIPrecompileTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/store/contracts/precompile/TokenURIPrecompileTest.java
@@ -17,6 +17,7 @@ package com.hedera.services.store.contracts.precompile;
 
 import static com.hedera.services.store.contracts.precompile.impl.TokenURIPrecompile.decodeTokenUriNFT;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.apache.tuweni.bytes.Bytes;
 import org.junit.jupiter.api.Test;
@@ -29,11 +30,19 @@ class TokenURIPrecompileTest {
     private static final Bytes TOKEN_URI_INPUT =
             Bytes.fromHexString(
                     "0xc87b56dd0000000000000000000000000000000000000000000000000000000000000001");
+    private static final Bytes TOKEN_URI_LONG_OVERFLOWN =
+            Bytes.fromHexString(
+                    "0xc87b56dd0000000000000000000000000000000000000000000000010000000000000001");
 
     @Test
     void decodeTokenUriInput() {
         final var decodedInput = decodeTokenUriNFT(TOKEN_URI_INPUT);
 
         assertEquals(1, decodedInput.serialNo());
+    }
+
+    @Test
+    void decodeTokenUriShouldThrowOnTokenIdOverflown() {
+        assertThrows(ArithmeticException.class, () -> decodeTokenUriNFT(TOKEN_URI_LONG_OVERFLOWN));
     }
 }


### PR DESCRIPTION
Signed-off-by: Georgi Georgiev <georgi.getz@outlook.com>

**Description**:
This PR focuses on the problem that the `longValue()` method of `BigInteger` allows overflows of the long value which can lead to some unexpected results.
It's not opened directly to the master branch because a significant part of the cases were in the decoding facade which would have caused a lot of needless conflicts.

**Related issue(s)**:

Fixes #3920 

**Checklist**

- [x] Tested (unit, integration, etc.)
