### PR TITLE
Move re-usable test helpers under `TestUtils`, clean up rehydrated calldata mgmt

### DIFF
--- a/hedera-node/src/main/java/com/hedera/services/utils/accessors/PlatformTxnAccessor.java
+++ b/hedera-node/src/main/java/com/hedera/services/utils/accessors/PlatformTxnAccessor.java
@@ -18,6 +18,7 @@ package com.hedera.services.utils.accessors;
 import com.google.common.base.MoreObjects;
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.hedera.services.context.primitives.StateView;
+import com.hedera.services.ethereum.EthTxData;
 import com.hedera.services.ledger.accounts.AliasManager;
 import com.hedera.services.sigs.order.LinkedRefs;
 import com.hedera.services.sigs.sourcing.PojoSigMapPubKeyToSigBytes;
@@ -300,6 +301,11 @@ public class PlatformTxnAccessor implements SwirldsTxnAccessor {
     @Override
     public void countAutoCreationsWith(final AliasManager aliasManager) {
         delegate.countAutoCreationsWith(aliasManager);
+    }
+
+    @Override
+    public EthTxData opEthTxData() {
+        return delegate.opEthTxData();
     }
 
     @Override

--- a/hedera-node/src/main/java/com/hedera/services/utils/accessors/SignedTxnAccessor.java
+++ b/hedera-node/src/main/java/com/hedera/services/utils/accessors/SignedTxnAccessor.java
@@ -21,23 +21,7 @@ import static com.hedera.services.legacy.proto.utils.CommonUtils.noThrowSha384Ha
 import static com.hedera.services.usage.token.TokenOpsUsageUtils.TOKEN_OPS_USAGE_UTILS;
 import static com.hedera.services.utils.EntityIdUtils.isAlias;
 import static com.hedera.services.utils.MiscUtils.FUNCTION_EXTRACTOR;
-import static com.hederahashgraph.api.proto.java.HederaFunctionality.ConsensusSubmitMessage;
-import static com.hederahashgraph.api.proto.java.HederaFunctionality.CryptoApproveAllowance;
-import static com.hederahashgraph.api.proto.java.HederaFunctionality.CryptoCreate;
-import static com.hederahashgraph.api.proto.java.HederaFunctionality.CryptoDeleteAllowance;
-import static com.hederahashgraph.api.proto.java.HederaFunctionality.CryptoTransfer;
-import static com.hederahashgraph.api.proto.java.HederaFunctionality.CryptoUpdate;
-import static com.hederahashgraph.api.proto.java.HederaFunctionality.EthereumTransaction;
-import static com.hederahashgraph.api.proto.java.HederaFunctionality.TokenAccountWipe;
-import static com.hederahashgraph.api.proto.java.HederaFunctionality.TokenBurn;
-import static com.hederahashgraph.api.proto.java.HederaFunctionality.TokenCreate;
-import static com.hederahashgraph.api.proto.java.HederaFunctionality.TokenFeeScheduleUpdate;
-import static com.hederahashgraph.api.proto.java.HederaFunctionality.TokenFreezeAccount;
-import static com.hederahashgraph.api.proto.java.HederaFunctionality.TokenMint;
-import static com.hederahashgraph.api.proto.java.HederaFunctionality.TokenPause;
-import static com.hederahashgraph.api.proto.java.HederaFunctionality.TokenUnfreezeAccount;
-import static com.hederahashgraph.api.proto.java.HederaFunctionality.TokenUnpause;
-import static com.hederahashgraph.api.proto.java.HederaFunctionality.UtilPrng;
+import static com.hederahashgraph.api.proto.java.HederaFunctionality.*;
 import static com.hederahashgraph.api.proto.java.SubType.TOKEN_FUNGIBLE_COMMON;
 import static com.hederahashgraph.api.proto.java.SubType.TOKEN_NON_FUNGIBLE_UNIQUE;
 
@@ -54,26 +38,13 @@ import com.hedera.services.txns.span.ExpandHandleSpanMapAccessor;
 import com.hedera.services.usage.BaseTransactionMeta;
 import com.hedera.services.usage.SigUsage;
 import com.hedera.services.usage.consensus.SubmitMessageMeta;
-import com.hedera.services.usage.crypto.CryptoApproveAllowanceMeta;
-import com.hedera.services.usage.crypto.CryptoCreateMeta;
-import com.hedera.services.usage.crypto.CryptoDeleteAllowanceMeta;
-import com.hedera.services.usage.crypto.CryptoTransferMeta;
-import com.hedera.services.usage.crypto.CryptoUpdateMeta;
+import com.hedera.services.usage.crypto.*;
 import com.hedera.services.usage.token.TokenOpsUsage;
 import com.hedera.services.usage.token.meta.FeeScheduleUpdateMeta;
 import com.hedera.services.usage.util.UtilPrngMeta;
 import com.hedera.services.utils.EntityNum;
 import com.hedera.services.utils.MiscUtils;
-import com.hederahashgraph.api.proto.java.AccountID;
-import com.hederahashgraph.api.proto.java.HederaFunctionality;
-import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
-import com.hederahashgraph.api.proto.java.ScheduleID;
-import com.hederahashgraph.api.proto.java.SignatureMap;
-import com.hederahashgraph.api.proto.java.SignedTransaction;
-import com.hederahashgraph.api.proto.java.SubType;
-import com.hederahashgraph.api.proto.java.Transaction;
-import com.hederahashgraph.api.proto.java.TransactionBody;
-import com.hederahashgraph.api.proto.java.TransactionID;
+import com.hederahashgraph.api.proto.java.*;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -181,6 +152,12 @@ public class SignedTxnAccessor implements TxnAccessor {
         getFunction();
         setBaseUsageMeta();
         setOpUsageMeta();
+    }
+
+    @Override
+    public EthTxData opEthTxData() {
+        final var hapiTx = txn.getEthereumTransaction();
+        return EthTxData.populateEthTxData(unwrapUnsafelyIfPossible(hapiTx.getEthereumData()));
     }
 
     @Override
@@ -573,9 +550,7 @@ public class SignedTxnAccessor implements TxnAccessor {
     }
 
     private void setEthTxDataMeta() {
-        var hapiTx = txn.getEthereumTransaction();
-        final var ethTxData = EthTxData.populateEthTxData(hapiTx.getEthereumData().toByteArray());
-        SPAN_MAP_ACCESSOR.setEthTxDataMeta(this, ethTxData);
+        SPAN_MAP_ACCESSOR.setEthTxDataMeta(this, opEthTxData());
     }
 
     @Override

--- a/hedera-node/src/main/java/com/hedera/services/utils/accessors/TxnAccessor.java
+++ b/hedera-node/src/main/java/com/hedera/services/utils/accessors/TxnAccessor.java
@@ -16,21 +16,14 @@
 package com.hedera.services.utils.accessors;
 
 import com.hedera.services.context.primitives.StateView;
+import com.hedera.services.ethereum.EthTxData;
 import com.hedera.services.ledger.accounts.AliasManager;
 import com.hedera.services.txns.span.ExpandHandleSpanMapAccessor;
 import com.hedera.services.usage.BaseTransactionMeta;
 import com.hedera.services.usage.SigUsage;
 import com.hedera.services.usage.consensus.SubmitMessageMeta;
 import com.hedera.services.usage.crypto.CryptoTransferMeta;
-import com.hederahashgraph.api.proto.java.AccountID;
-import com.hederahashgraph.api.proto.java.HederaFunctionality;
-import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
-import com.hederahashgraph.api.proto.java.ScheduleID;
-import com.hederahashgraph.api.proto.java.SignatureMap;
-import com.hederahashgraph.api.proto.java.SubType;
-import com.hederahashgraph.api.proto.java.Transaction;
-import com.hederahashgraph.api.proto.java.TransactionBody;
-import com.hederahashgraph.api.proto.java.TransactionID;
+import com.hederahashgraph.api.proto.java.*;
 import java.util.Map;
 
 /**
@@ -119,6 +112,9 @@ public interface TxnAccessor {
     boolean areAutoCreationsCounted();
 
     void countAutoCreationsWith(AliasManager aliasManager);
+
+    // Used only for EthereumTransaction
+    EthTxData opEthTxData();
 
     // Used only for SubmitMessage
     SubmitMessageMeta availSubmitUsageMeta();

--- a/hedera-node/src/test/java/com/hedera/services/utils/accessors/PlatformTxnAccessorTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/utils/accessors/PlatformTxnAccessorTest.java
@@ -24,12 +24,7 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OK;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.collection.IsIterableContainingInOrder.contains;
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.verify;
 import static org.mockito.Mockito.mock;
@@ -42,17 +37,8 @@ import com.hedera.services.legacy.proto.utils.CommonUtils;
 import com.hedera.services.sigs.order.LinkedRefs;
 import com.hedera.services.utils.RationalizedSigMeta;
 import com.hedera.test.utils.IdUtils;
-import com.hederahashgraph.api.proto.java.AccountID;
-import com.hederahashgraph.api.proto.java.ConsensusCreateTopicTransactionBody;
-import com.hederahashgraph.api.proto.java.ConsensusSubmitMessageTransactionBody;
-import com.hederahashgraph.api.proto.java.HederaFunctionality;
-import com.hederahashgraph.api.proto.java.SignatureMap;
-import com.hederahashgraph.api.proto.java.SignaturePair;
-import com.hederahashgraph.api.proto.java.SignedTransaction;
-import com.hederahashgraph.api.proto.java.SubType;
-import com.hederahashgraph.api.proto.java.Transaction;
-import com.hederahashgraph.api.proto.java.TransactionBody;
-import com.hederahashgraph.api.proto.java.TransactionID;
+import com.hedera.test.utils.TxnUtils;
+import com.hederahashgraph.api.proto.java.*;
 import com.swirlds.common.system.transaction.internal.SwirldTransaction;
 import java.util.HashMap;
 import java.util.List;
@@ -76,6 +62,14 @@ class PlatformTxnAccessorTest {
         final var newMap = Map.of("1", new Object());
         subject.setRationalizedSpanMap(newMap);
         verify(delegate).setRationalizedSpanMap(newMap);
+    }
+
+    @Test
+    void delegatesGettingEthTxData() {
+        final var txn = TxnUtils.buildTransactionFrom(TxnUtils.ethereumTransactionOp());
+        final var delegate = SignedTxnAccessor.uncheckedFrom(txn);
+        final var subject = new PlatformTxnAccessor(delegate, new SwirldTransaction());
+        assertEquals(delegate.opEthTxData(), subject.opEthTxData());
     }
 
     @Test
@@ -301,6 +295,7 @@ class PlatformTxnAccessorTest {
     }
 
     @Test
+    @SuppressWarnings("java:S5961")
     void delegatesToSignedTxnAccessor() throws InvalidProtocolBufferException {
         AccountID payer = asAccount("0.0.2");
         TransactionBody someTxn =

--- a/hedera-node/src/test/java/com/hedera/services/utils/accessors/SignedTxnAccessorTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/utils/accessors/SignedTxnAccessorTest.java
@@ -19,6 +19,7 @@ import static com.hedera.services.state.submerkle.FcCustomFee.fixedFee;
 import static com.hedera.services.state.submerkle.FcCustomFee.fractionalFee;
 import static com.hedera.services.txns.ethereum.TestingConstants.TRUFFLE0_PRIVATE_ECDSA_KEY;
 import static com.hedera.test.utils.IdUtils.*;
+import static com.hedera.test.utils.TxnUtils.buildTransactionFrom;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_TOKEN_ID;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OK;
 import static com.hederahashgraph.api.proto.java.SubType.TOKEN_FUNGIBLE_COMMON;
@@ -123,7 +124,7 @@ class SignedTxnAccessorTest {
 
     @Test
     void uncheckedPropagatesIaeOnNonsense() {
-        final var nonsenseTxn = TxnUtils.buildTransactionFrom(ByteString.copyFromUtf8("NONSENSE"));
+        final var nonsenseTxn = buildTransactionFrom(ByteString.copyFromUtf8("NONSENSE"));
 
         assertThrows(
                 IllegalArgumentException.class, () -> SignedTxnAccessor.uncheckedFrom(nonsenseTxn));
@@ -240,9 +241,7 @@ class SignedTxnAccessorTest {
     @Test
     void detectsCommonTokenBurnSubtypeFromGrpcSyntax() {
         final var op = TokenBurnTransactionBody.newBuilder().setAmount(1_234).build();
-        final var txn =
-                TxnUtils.buildTransactionFrom(
-                        TransactionBody.newBuilder().setTokenBurn(op).build());
+        final var txn = buildTransactionFrom(TransactionBody.newBuilder().setTokenBurn(op).build());
 
         final var subject = SignedTxnAccessor.uncheckedFrom(txn);
 
@@ -287,9 +286,7 @@ class SignedTxnAccessorTest {
                 TokenBurnTransactionBody.newBuilder()
                         .addAllSerialNumbers(List.of(1L, 2L, 3L))
                         .build();
-        final var txn =
-                TxnUtils.buildTransactionFrom(
-                        TransactionBody.newBuilder().setTokenBurn(op).build());
+        final var txn = buildTransactionFrom(TransactionBody.newBuilder().setTokenBurn(op).build());
 
         final var subject = SignedTxnAccessor.uncheckedFrom(txn);
 
@@ -299,9 +296,7 @@ class SignedTxnAccessorTest {
     @Test
     void detectsCommonTokenMintSubtypeFromGrpcSyntax() {
         final var op = TokenMintTransactionBody.newBuilder().setAmount(1_234).build();
-        final var txn =
-                TxnUtils.buildTransactionFrom(
-                        TransactionBody.newBuilder().setTokenMint(op).build());
+        final var txn = buildTransactionFrom(TransactionBody.newBuilder().setTokenMint(op).build());
 
         final var subject = SignedTxnAccessor.uncheckedFrom(txn);
 
@@ -314,9 +309,7 @@ class SignedTxnAccessorTest {
                 TokenMintTransactionBody.newBuilder()
                         .addAllMetadata(List.of(ByteString.copyFromUtf8("STANDARD")))
                         .build();
-        final var txn =
-                TxnUtils.buildTransactionFrom(
-                        TransactionBody.newBuilder().setTokenMint(op).build());
+        final var txn = buildTransactionFrom(TransactionBody.newBuilder().setTokenMint(op).build());
 
         final var subject = SignedTxnAccessor.uncheckedFrom(txn);
 
@@ -370,7 +363,7 @@ class SignedTxnAccessorTest {
 
     @Test
     void understandsFullXferUsageIncTokens() {
-        final var txn = TxnUtils.buildTransactionFrom(tokenXfers());
+        final var txn = buildTransactionFrom(tokenXfers());
         final var subject = SignedTxnAccessor.uncheckedFrom(txn);
 
         final var xferMeta = subject.availXferUsageMeta();
@@ -400,7 +393,7 @@ class SignedTxnAccessorTest {
                                 ConsensusSubmitMessageTransactionBody.newBuilder()
                                         .setMessage(ByteString.copyFromUtf8(message)))
                         .build();
-        final var txn = TxnUtils.buildTransactionFrom(txnBody);
+        final var txn = buildTransactionFrom(txnBody);
         final var subject = SignedTxnAccessor.uncheckedFrom(txn);
 
         final var submitMeta = subject.availSubmitUsageMeta();
@@ -429,7 +422,7 @@ class SignedTxnAccessorTest {
                         70000l);
         final var body = CommonUtils.extractTransactionBody(transaction);
         final var signedTransaction = TxnUtils.signedTransactionFrom(body, expectedMap);
-        final var newTransaction = TxnUtils.buildTransactionFrom(signedTransaction.toByteString());
+        final var newTransaction = buildTransactionFrom(signedTransaction.toByteString());
         final var accessor = SignedTxnAccessor.uncheckedFrom(newTransaction);
 
         assertEquals(newTransaction, accessor.getSignedTxnWrapper());
@@ -530,7 +523,7 @@ class SignedTxnAccessorTest {
                                                 Timestamp.newBuilder().setSeconds(now)))
                         .setTokenPause(op)
                         .build();
-        final var txn = TxnUtils.buildTransactionFrom(txnBody);
+        final var txn = buildTransactionFrom(txnBody);
         final var accessor = SignedTxnAccessor.uncheckedFrom(txn);
         final var spanMapAccessor = accessor.getSpanMapAccessor();
 
@@ -552,7 +545,7 @@ class SignedTxnAccessorTest {
                                                 Timestamp.newBuilder().setSeconds(now)))
                         .setTokenUnpause(op)
                         .build();
-        final var txn = TxnUtils.buildTransactionFrom(txnBody);
+        final var txn = buildTransactionFrom(txnBody);
         final var accessor = SignedTxnAccessor.uncheckedFrom(txn);
         final var spanMapAccessor = accessor.getSpanMapAccessor();
 
@@ -639,7 +632,7 @@ class SignedTxnAccessorTest {
     void setPrngMetaWorks() {
         final var op = UtilPrngTransactionBody.newBuilder().setRange(10).build();
         final var txn =
-                TxnUtils.buildTransactionFrom(
+                buildTransactionFrom(
                         TransactionBody.newBuilder()
                                 .setTransactionID(
                                         TransactionID.newBuilder()
@@ -659,7 +652,7 @@ class SignedTxnAccessorTest {
     void getGasLimitWorksForCreate() {
         final var op = ContractCreateTransactionBody.newBuilder().setGas(123456789L).build();
         final var txn =
-                TxnUtils.buildTransactionFrom(
+                buildTransactionFrom(
                         TransactionBody.newBuilder().setContractCreateInstance(op).build());
 
         final var subject = SignedTxnAccessor.uncheckedFrom(txn);
@@ -671,8 +664,7 @@ class SignedTxnAccessorTest {
     void getGasLimitWorksForCall() {
         final var op = ContractCallTransactionBody.newBuilder().setGas(123456789L).build();
         final var txn =
-                TxnUtils.buildTransactionFrom(
-                        TransactionBody.newBuilder().setContractCall(op).build());
+                buildTransactionFrom(TransactionBody.newBuilder().setContractCall(op).build());
 
         final var subject = SignedTxnAccessor.uncheckedFrom(txn);
 
@@ -683,8 +675,7 @@ class SignedTxnAccessorTest {
     void precheckSupportingFunctionsWork() throws InvalidProtocolBufferException {
         var falseOp = ContractCallTransactionBody.newBuilder().setGas(123456789L).build();
         var txn =
-                TxnUtils.buildTransactionFrom(
-                        TransactionBody.newBuilder().setContractCall(falseOp).build());
+                buildTransactionFrom(TransactionBody.newBuilder().setContractCall(falseOp).build());
 
         final var accessor = SignedTxnAccessor.uncheckedFrom(txn);
 
@@ -695,9 +686,7 @@ class SignedTxnAccessorTest {
                 TokenWipeAccountTransactionBody.newBuilder()
                         .setAccount(asAccount("0.0.1000"))
                         .build();
-        txn =
-                TxnUtils.buildTransactionFrom(
-                        TransactionBody.newBuilder().setTokenWipe(trueOp).build());
+        txn = buildTransactionFrom(TransactionBody.newBuilder().setTokenWipe(trueOp).build());
 
         final var dynamicProperties = mock(GlobalDynamicProperties.class);
         given(dynamicProperties.areNftsEnabled()).willReturn(true);
@@ -736,7 +725,7 @@ class SignedTxnAccessorTest {
                         .setEthereumData(ByteString.copyFrom(ethTxData.encodeTx()))
                         .build();
         final var txn =
-                TxnUtils.buildTransactionFrom(
+                buildTransactionFrom(
                         TransactionBody.newBuilder().setEthereumTransaction(op).build());
 
         final var subject = SignedTxnAccessor.uncheckedFrom(txn);
@@ -748,8 +737,7 @@ class SignedTxnAccessorTest {
     void getGasLimitReturnsZeroByDefault() {
         final var op = TokenCreateTransactionBody.getDefaultInstance();
         final var txn =
-                TxnUtils.buildTransactionFrom(
-                        TransactionBody.newBuilder().setTokenCreation(op).build());
+                buildTransactionFrom(TransactionBody.newBuilder().setTokenCreation(op).build());
 
         final var subject = SignedTxnAccessor.uncheckedFrom(txn);
 
@@ -760,8 +748,7 @@ class SignedTxnAccessorTest {
     void markThrottleExemptWorks() {
         final var op = ContractCallTransactionBody.newBuilder().build();
         final var txn =
-                TxnUtils.buildTransactionFrom(
-                        TransactionBody.newBuilder().setContractCall(op).build());
+                buildTransactionFrom(TransactionBody.newBuilder().setContractCall(op).build());
 
         final var subject = SignedTxnAccessor.uncheckedFrom(txn);
 
@@ -776,8 +763,7 @@ class SignedTxnAccessorTest {
     void throttleExemptWorksWithExemptPayer() {
         final var op = ContractCallTransactionBody.newBuilder().build();
         final var txn =
-                TxnUtils.buildTransactionFrom(
-                        TransactionBody.newBuilder().setContractCall(op).build());
+                buildTransactionFrom(TransactionBody.newBuilder().setContractCall(op).build());
 
         final var subject = SignedTxnAccessor.uncheckedFrom(txn);
 
@@ -790,8 +776,7 @@ class SignedTxnAccessorTest {
     void throttleExemptWorksWithNonExemptPayer() {
         final var op = ContractCallTransactionBody.newBuilder().build();
         final var txn =
-                TxnUtils.buildTransactionFrom(
-                        TransactionBody.newBuilder().setContractCall(op).build());
+                buildTransactionFrom(TransactionBody.newBuilder().setContractCall(op).build());
 
         final var subject = SignedTxnAccessor.uncheckedFrom(txn);
 
@@ -804,8 +789,7 @@ class SignedTxnAccessorTest {
     void throttleExemptWorksWithNullPayer() {
         final var op = ContractCallTransactionBody.newBuilder().build();
         final var txn =
-                TxnUtils.buildTransactionFrom(
-                        TransactionBody.newBuilder().setContractCall(op).build());
+                buildTransactionFrom(TransactionBody.newBuilder().setContractCall(op).build());
 
         final var subject = SignedTxnAccessor.uncheckedFrom(txn);
 
@@ -818,8 +802,7 @@ class SignedTxnAccessorTest {
     void markCongestionExemptWorks() {
         final var op = ContractCallTransactionBody.newBuilder().build();
         final var txn =
-                TxnUtils.buildTransactionFrom(
-                        TransactionBody.newBuilder().setContractCall(op).build());
+                buildTransactionFrom(TransactionBody.newBuilder().setContractCall(op).build());
 
         final var subject = SignedTxnAccessor.uncheckedFrom(txn);
 
@@ -922,8 +905,7 @@ class SignedTxnAccessorTest {
     void setterAndGetterForStateViewWorks() {
         final var op = ContractCallTransactionBody.newBuilder().build();
         final var txn =
-                TxnUtils.buildTransactionFrom(
-                        TransactionBody.newBuilder().setContractCall(op).build());
+                buildTransactionFrom(TransactionBody.newBuilder().setContractCall(op).build());
 
         final var subject = SignedTxnAccessor.uncheckedFrom(txn);
         final var stateView = mock(StateView.class);
@@ -943,8 +925,7 @@ class SignedTxnAccessorTest {
 
         final var op = ContractCallTransactionBody.newBuilder().build();
         final var txn =
-                TxnUtils.buildTransactionFrom(
-                        TransactionBody.newBuilder().setContractCall(op).build());
+                buildTransactionFrom(TransactionBody.newBuilder().setContractCall(op).build());
         final var subject = SignedTxnAccessor.uncheckedFrom(txn);
         subject.setStateView(stateView);
 
@@ -953,23 +934,23 @@ class SignedTxnAccessorTest {
     }
 
     private Transaction signedCryptoCreateTxn() {
-        return TxnUtils.buildTransactionFrom(cryptoCreateOp());
+        return buildTransactionFrom(cryptoCreateOp());
     }
 
     private Transaction signedCryptoUpdateTxn() {
-        return TxnUtils.buildTransactionFrom(cryptoUpdateOp());
+        return buildTransactionFrom(cryptoUpdateOp());
     }
 
     private Transaction signedCryptoApproveTxn() {
-        return TxnUtils.buildTransactionFrom(cryptoApproveOp());
+        return buildTransactionFrom(cryptoApproveOp());
     }
 
     private Transaction signedCryptoDeleteAllowanceTxn() {
-        return TxnUtils.buildTransactionFrom(cryptoDeleteAllowanceOp());
+        return buildTransactionFrom(cryptoDeleteAllowanceOp());
     }
 
     private Transaction signedEthereumTxn() {
-        return TxnUtils.buildTransactionFrom(TxnUtils.ethereumTransactionOp());
+        return buildTransactionFrom(TxnUtils.ethereumTransactionOp());
     }
 
     private TransactionBody cryptoCreateOp() {
@@ -1032,7 +1013,7 @@ class SignedTxnAccessorTest {
     }
 
     private Transaction signedFeeScheduleUpdateTxn() {
-        return TxnUtils.buildTransactionFrom(feeScheduleUpdateTxn());
+        return buildTransactionFrom(feeScheduleUpdateTxn());
     }
 
     private TransactionBody feeScheduleUpdateTxn() {
@@ -1077,7 +1058,7 @@ class SignedTxnAccessorTest {
                         .setCryptoTransfer(op)
                         .build();
 
-        return TxnUtils.buildTransactionFrom(txnBody);
+        return buildTransactionFrom(txnBody);
     }
 
     private Transaction buildDefaultCryptoCreateTxn() {
@@ -1086,7 +1067,7 @@ class SignedTxnAccessorTest {
                         .setCryptoCreateAccount(CryptoCreateTransactionBody.getDefaultInstance())
                         .build();
 
-        return TxnUtils.buildTransactionFrom(txnBody);
+        return buildTransactionFrom(txnBody);
     }
 
     private TransactionBody tokenXfers() {
@@ -1133,7 +1114,7 @@ class SignedTxnAccessorTest {
     }
 
     private Transaction signedTokenCreateTxn() {
-        return TxnUtils.buildTransactionFrom(givenAutoRenewBasedOp());
+        return buildTransactionFrom(givenAutoRenewBasedOp());
     }
 
     private TransactionBody givenAutoRenewBasedOp() {

--- a/hedera-node/src/test/java/com/hedera/services/utils/accessors/TokenWipeAccessorTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/utils/accessors/TokenWipeAccessorTest.java
@@ -15,10 +15,10 @@
  */
 package com.hedera.services.utils.accessors;
 
-import static com.hedera.services.utils.accessors.SignedTxnAccessorTest.buildTransactionFrom;
 import static com.hedera.test.utils.IdUtils.asAccount;
 import static com.hedera.test.utils.IdUtils.asModelId;
 import static com.hedera.test.utils.IdUtils.asToken;
+import static com.hedera.test.utils.TxnUtils.buildTransactionFrom;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_TRANSACTION_BODY;
 import static com.hederahashgraph.api.proto.java.SubType.TOKEN_FUNGIBLE_COMMON;
 import static com.hederahashgraph.api.proto.java.SubType.TOKEN_NON_FUNGIBLE_UNIQUE;

--- a/hedera-node/src/test/java/com/hedera/test/utils/TxnUtils.java
+++ b/hedera-node/src/test/java/com/hedera/test/utils/TxnUtils.java
@@ -35,20 +35,7 @@ import com.hedera.services.state.submerkle.*;
 import com.hedera.services.utils.EntityNum;
 import com.hedera.test.factories.keys.KeyTree;
 import com.hedera.test.factories.scenarios.TxnHandlingScenario;
-import com.hederahashgraph.api.proto.java.AccountAmount;
-import com.hederahashgraph.api.proto.java.AccountID;
-import com.hederahashgraph.api.proto.java.ContractFunctionResult;
-import com.hederahashgraph.api.proto.java.ContractLoginfo;
-import com.hederahashgraph.api.proto.java.Key;
-import com.hederahashgraph.api.proto.java.KeyList;
-import com.hederahashgraph.api.proto.java.NftTransfer;
-import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
-import com.hederahashgraph.api.proto.java.Timestamp;
-import com.hederahashgraph.api.proto.java.TokenID;
-import com.hederahashgraph.api.proto.java.TokenTransferList;
-import com.hederahashgraph.api.proto.java.Transaction;
-import com.hederahashgraph.api.proto.java.TransactionID;
-import com.hederahashgraph.api.proto.java.TransferList;
+import com.hederahashgraph.api.proto.java.*;
 import java.time.Instant;
 import java.util.List;
 import java.util.Random;
@@ -492,5 +479,42 @@ public class TxnUtils {
                                                                                 .getReceiverAccountID()))
                                                 .toList()))
                 .toList();
+    }
+
+    public static TransactionBody ethereumTransactionOp() {
+        final var op =
+                EthereumTransactionBody.newBuilder()
+                        .setEthereumData(
+                                ByteString.copyFrom(
+                                        com.swirlds.common.utility.CommonUtils.unhex(
+                                                "f864012f83018000947e3a9eaf9bcc39e2ffa38eb30bf7a93feacbc18180827653820277a0f9fbff985d374be4a55f296915002eec11ac96f1ce2df183adf992baa9390b2fa00c1e867cc960d9c74ec2e6a662b7908ec4c8cc9f3091e886bcefbeb2290fb792")))
+                        .build();
+        return TransactionBody.newBuilder()
+                .setTransactionID(
+                        TransactionID.newBuilder()
+                                .setTransactionValidStart(
+                                        Timestamp.newBuilder().setSeconds(1_234_567L)))
+                .setEthereumTransaction(op)
+                .build();
+    }
+
+    public static Transaction buildTransactionFrom(final TransactionBody transactionBody) {
+        return buildTransactionFrom(signedTransactionFrom(transactionBody).toByteString());
+    }
+
+    public static Transaction buildTransactionFrom(final ByteString signedTransactionBytes) {
+        return Transaction.newBuilder().setSignedTransactionBytes(signedTransactionBytes).build();
+    }
+
+    private static SignedTransaction signedTransactionFrom(final TransactionBody txnBody) {
+        return signedTransactionFrom(txnBody, SignatureMap.getDefaultInstance());
+    }
+
+    public static SignedTransaction signedTransactionFrom(
+            final TransactionBody txnBody, final SignatureMap sigMap) {
+        return SignedTransaction.newBuilder()
+                .setBodyBytes(txnBody.toByteString())
+                .setSigMap(sigMap)
+                .build();
     }
 }


### PR DESCRIPTION
**Description**:
- Simplifies management of rehydrated calldata.
- Adds and refactors some unit tests.