### PR TITLE
Updating logging configs for different environment to exclude logging STATE_HASH events to swirlds.log and include STATE_HASH events for swirlds-hashstream.log

### DIFF
--- a/hedera-node/configuration/compose/log4j2.xml
+++ b/hedera-node/configuration/compose/log4j2.xml
@@ -40,6 +40,18 @@
       <DefaultRolloverStrategy max="10"/>
     </RollingFile>
 
+    <!-- Platform hash stream logs -->
+    <RollingFile name="swirldsHashStream" fileName="output/swirlds-hashstream.log"
+                 filePattern="output/swirlds-hashstream.log-%d{yyyy-MM-dd}-%i.log">
+      <PatternLayout>
+        <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %-8sn %-5p %-16marker &lt;%t&gt; %c{1}: %msg{nolookups}%n</pattern>
+      </PatternLayout>
+      <Policies>
+        <SizeBasedTriggeringPolicy size="100 MB"/>
+      </Policies>
+      <DefaultRolloverStrategy max="10"/>
+    </RollingFile>
+
   </Appenders>
   <Loggers>
     <Root level="FATAL">
@@ -115,6 +127,7 @@
         <!-- Saved States -->
         <MarkerFilter marker="SNAPSHOT_MANAGER"       onMatch="ACCEPT" onMismatch="NEUTRAL"/>
         <MarkerFilter marker="STATE_TO_DISK"          onMatch="ACCEPT" onMismatch="NEUTRAL"/>
+        <MarkerFilter marker="STATE_HASH"             onMatch="DENY"   onMismatch="NEUTRAL"/>
 
         <!-- Beta Mirror -->
         <MarkerFilter marker="BETA_MIRROR_NODE"       onMatch="ACCEPT" onMismatch="NEUTRAL"/>

--- a/hedera-node/configuration/dev/log4j2.xml
+++ b/hedera-node/configuration/dev/log4j2.xml
@@ -76,6 +76,7 @@
           <!-- JasperDB & Virtual Merkle -->
           <MarkerFilter marker="JASPER_DB"              onMatch="DENY" onMismatch="NEUTRAL"/>
           <MarkerFilter marker="VIRTUAL_MERKLE_STATS"   onMatch="DENY" onMismatch="NEUTRAL"/>
+          <MarkerFilter marker="STATE_HASH"             onMatch="DENY" onMismatch="NEUTRAL"/>
         </Filters>
       </AppenderRef>
 
@@ -162,7 +163,7 @@
         <!-- Saved States -->
         <MarkerFilter marker="SNAPSHOT_MANAGER"       onMatch="ACCEPT" onMismatch="NEUTRAL"/>
         <MarkerFilter marker="STATE_TO_DISK"          onMatch="ACCEPT" onMismatch="NEUTRAL"/>
-        <MarkerFilter marker="STATE_HASH"             onMatch="DENY"   onMismatch="NEUTRAL"/>
+        <MarkerFilter marker="STATE_HASH"             onMatch="ACCEPT" onMismatch="NEUTRAL"/>
 
         <!-- Beta Mirror -->
         <MarkerFilter marker="BETA_MIRROR_NODE"       onMatch="ACCEPT" onMismatch="NEUTRAL"/>

--- a/hedera-node/configuration/dev/log4j2.xml
+++ b/hedera-node/configuration/dev/log4j2.xml
@@ -51,6 +51,18 @@
       <DefaultRolloverStrategy max="10"/>
     </RollingFile>
 
+    <!-- Platform hash stream logs -->
+    <RollingFile name="swirldsHashStream" fileName="output/swirlds-hashstream.log"
+                             filePattern="output/swirlds-hashstream.log-%d{yyyy-MM-dd}-%i.log">
+      <PatternLayout>
+        <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %-8sn %-5p %-16marker &lt;%t&gt; %c{1}: %msg{nolookups}%n</pattern>
+      </PatternLayout>
+      <Policies>
+        <SizeBasedTriggeringPolicy size="100 MB"/>
+      </Policies>
+      <DefaultRolloverStrategy max="10"/>
+    </RollingFile>
+
   </Appenders>
   <Loggers>
     <Root level="FATAL">
@@ -73,6 +85,14 @@
           <MarkerFilter marker="JASPER_DB"              onMatch="ACCEPT" onMismatch="NEUTRAL"/>
           <MarkerFilter marker="VIRTUAL_MERKLE_STATS"   onMatch="ACCEPT" onMismatch="NEUTRAL"/>
           <MarkerFilter marker="DISABLED"               onMatch="DENY"   onMismatch="DENY" />
+        </Filters>
+      </AppenderRef>
+
+      <AppenderRef ref="swirldsHashStream">
+        <Filters>
+          <!-- Hash stream log -->
+          <MarkerFilter marker="STATE_HASH"             onMatch="ACCEPT"  onMismatch="NEUTRAL"/>
+          <MarkerFilter marker="DISABLED"               onMatch="DENY"    onMismatch="DENY" />
         </Filters>
       </AppenderRef>
 
@@ -142,6 +162,7 @@
         <!-- Saved States -->
         <MarkerFilter marker="SNAPSHOT_MANAGER"       onMatch="ACCEPT" onMismatch="NEUTRAL"/>
         <MarkerFilter marker="STATE_TO_DISK"          onMatch="ACCEPT" onMismatch="NEUTRAL"/>
+        <MarkerFilter marker="STATE_HASH"             onMatch="DENY"   onMismatch="NEUTRAL"/>
 
         <!-- Beta Mirror -->
         <MarkerFilter marker="BETA_MIRROR_NODE"       onMatch="ACCEPT" onMismatch="NEUTRAL"/>

--- a/hedera-node/configuration/mainnet/log4j2.xml
+++ b/hedera-node/configuration/mainnet/log4j2.xml
@@ -75,6 +75,7 @@
           <!-- JasperDB & Virtual Merkle -->
           <MarkerFilter marker="JASPER_DB"              onMatch="DENY" onMismatch="NEUTRAL"/>
           <MarkerFilter marker="VIRTUAL_MERKLE_STATS"   onMatch="DENY" onMismatch="NEUTRAL"/>
+          <MarkerFilter marker="STATE_HASH"             onMatch="DENY" onMismatch="NEUTRAL"/>
         </Filters>
       </AppenderRef>
 
@@ -160,7 +161,7 @@
         <!-- Saved States -->
         <MarkerFilter marker="SNAPSHOT_MANAGER"       onMatch="ACCEPT" onMismatch="NEUTRAL"/>
         <MarkerFilter marker="STATE_TO_DISK"          onMatch="ACCEPT" onMismatch="NEUTRAL"/>
-        <MarkerFilter marker="STATE_HASH"             onMatch="DENY"   onMismatch="NEUTRAL"/>
+        <MarkerFilter marker="STATE_HASH"             onMatch="ACCEPT"   onMismatch="NEUTRAL"/>
 
         <!-- Beta Mirror -->
         <MarkerFilter marker="BETA_MIRROR_NODE"       onMatch="ACCEPT" onMismatch="NEUTRAL"/>

--- a/hedera-node/configuration/mainnet/log4j2.xml
+++ b/hedera-node/configuration/mainnet/log4j2.xml
@@ -51,6 +51,17 @@
       <DefaultRolloverStrategy max="10"/>
     </RollingFile>
 
+    <!-- Platform hash stream logs -->
+    <RollingFile name="swirldsHashStream" fileName="output/swirlds-hashstream.log"
+                 filePattern="output/swirlds-hashstream.log-%d{yyyy-MM-dd}-%i.log">
+      <PatternLayout>
+        <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %-8sn %-5p %-16marker &lt;%t&gt; %c{1}: %msg{nolookups}%n</pattern>
+      </PatternLayout>
+      <Policies>
+        <SizeBasedTriggeringPolicy size="100 MB"/>
+      </Policies>
+      <DefaultRolloverStrategy max="10"/>
+    </RollingFile>
   </Appenders>
   <Loggers>
     <Root level="FATAL">
@@ -76,6 +87,13 @@
         </Filters>
       </AppenderRef>
 
+      <AppenderRef ref="swirldsHashStream">
+        <Filters>
+          <!-- Hash stream log -->
+          <MarkerFilter marker="STATE_HASH"             onMatch="ACCEPT"  onMismatch="NEUTRAL"/>
+          <MarkerFilter marker="DISABLED"               onMatch="DENY"    onMismatch="DENY" />
+        </Filters>
+      </AppenderRef>
       <!--
 	  Due to known log4j2 issues with how Markers and LogLevels are evaluated there must be a top level <Filter> element
 	  to ensure that the root logger does not execute all the lambda arguments erroneously. Potential work around in the
@@ -142,6 +160,7 @@
         <!-- Saved States -->
         <MarkerFilter marker="SNAPSHOT_MANAGER"       onMatch="ACCEPT" onMismatch="NEUTRAL"/>
         <MarkerFilter marker="STATE_TO_DISK"          onMatch="ACCEPT" onMismatch="NEUTRAL"/>
+        <MarkerFilter marker="STATE_HASH"             onMatch="DENY"   onMismatch="NEUTRAL"/>
 
         <!-- Beta Mirror -->
         <MarkerFilter marker="BETA_MIRROR_NODE"       onMatch="ACCEPT" onMismatch="NEUTRAL"/>

--- a/hedera-node/configuration/preprod/log4j2.xml
+++ b/hedera-node/configuration/preprod/log4j2.xml
@@ -76,6 +76,7 @@
           <!-- JasperDB & Virtual Merkle -->
           <MarkerFilter marker="JASPER_DB"              onMatch="DENY" onMismatch="NEUTRAL"/>
           <MarkerFilter marker="VIRTUAL_MERKLE_STATS"   onMatch="DENY" onMismatch="NEUTRAL"/>
+          <MarkerFilter marker="STATE_HASH"             onMatch="DENY" onMismatch="NEUTRAL"/>
         </Filters>
       </AppenderRef>
 
@@ -162,7 +163,7 @@
         <!-- Saved States -->
         <MarkerFilter marker="SNAPSHOT_MANAGER"       onMatch="ACCEPT" onMismatch="NEUTRAL"/>
         <MarkerFilter marker="STATE_TO_DISK"          onMatch="ACCEPT" onMismatch="NEUTRAL"/>
-        <MarkerFilter marker="STATE_HASH"             onMatch="DENY"   onMismatch="NEUTRAL"/>
+        <MarkerFilter marker="STATE_HASH"             onMatch="ACCEPT" onMismatch="NEUTRAL"/>
 
         <!-- Beta Mirror -->
         <MarkerFilter marker="BETA_MIRROR_NODE"       onMatch="ACCEPT" onMismatch="NEUTRAL"/>

--- a/hedera-node/configuration/preprod/log4j2.xml
+++ b/hedera-node/configuration/preprod/log4j2.xml
@@ -51,6 +51,18 @@
       <DefaultRolloverStrategy max="10"/>
     </RollingFile>
 
+    <!-- Platform hash stream logs -->
+    <RollingFile name="swirldsHashStream" fileName="output/swirlds-hashstream.log"
+                 filePattern="output/swirlds-hashstream.log-%d{yyyy-MM-dd}-%i.log">
+      <PatternLayout>
+        <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %-8sn %-5p %-16marker &lt;%t&gt; %c{1}: %msg{nolookups}%n</pattern>
+      </PatternLayout>
+      <Policies>
+        <SizeBasedTriggeringPolicy size="100 MB"/>
+      </Policies>
+      <DefaultRolloverStrategy max="10"/>
+    </RollingFile>
+
   </Appenders>
   <Loggers>
     <Root level="FATAL">
@@ -73,6 +85,14 @@
           <MarkerFilter marker="JASPER_DB"              onMatch="ACCEPT" onMismatch="NEUTRAL"/>
           <MarkerFilter marker="VIRTUAL_MERKLE_STATS"   onMatch="ACCEPT" onMismatch="NEUTRAL"/>
           <MarkerFilter marker="DISABLED"               onMatch="DENY"   onMismatch="DENY" />
+        </Filters>
+      </AppenderRef>
+
+      <AppenderRef ref="swirldsHashStream">
+        <Filters>
+          <!-- Hash stream log -->
+          <MarkerFilter marker="STATE_HASH"             onMatch="ACCEPT"  onMismatch="NEUTRAL"/>
+          <MarkerFilter marker="DISABLED"               onMatch="DENY"    onMismatch="DENY" />
         </Filters>
       </AppenderRef>
 
@@ -142,6 +162,7 @@
         <!-- Saved States -->
         <MarkerFilter marker="SNAPSHOT_MANAGER"       onMatch="ACCEPT" onMismatch="NEUTRAL"/>
         <MarkerFilter marker="STATE_TO_DISK"          onMatch="ACCEPT" onMismatch="NEUTRAL"/>
+        <MarkerFilter marker="STATE_HASH"             onMatch="DENY"   onMismatch="NEUTRAL"/>
 
         <!-- Beta Mirror -->
         <MarkerFilter marker="BETA_MIRROR_NODE"       onMatch="ACCEPT" onMismatch="NEUTRAL"/>

--- a/hedera-node/configuration/previewnet/log4j2.xml
+++ b/hedera-node/configuration/previewnet/log4j2.xml
@@ -76,6 +76,7 @@
           <!-- JasperDB & Virtual Merkle -->
           <MarkerFilter marker="JASPER_DB"              onMatch="DENY" onMismatch="NEUTRAL"/>
           <MarkerFilter marker="VIRTUAL_MERKLE_STATS"   onMatch="DENY" onMismatch="NEUTRAL"/>
+          <MarkerFilter marker="STATE_HASH"             onMatch="DENY" onMismatch="NEUTRAL"/>
         </Filters>
       </AppenderRef>
 
@@ -162,7 +163,7 @@
         <!-- Saved States -->
         <MarkerFilter marker="SNAPSHOT_MANAGER"       onMatch="ACCEPT" onMismatch="NEUTRAL"/>
         <MarkerFilter marker="STATE_TO_DISK"          onMatch="ACCEPT" onMismatch="NEUTRAL"/>
-        <MarkerFilter marker="STATE_HASH"             onMatch="DENY"   onMismatch="NEUTRAL"/>
+        <MarkerFilter marker="STATE_HASH"             onMatch="ACCEPT" onMismatch="NEUTRAL"/>
 
         <!-- Beta Mirror -->
         <MarkerFilter marker="BETA_MIRROR_NODE"       onMatch="ACCEPT" onMismatch="NEUTRAL"/>

--- a/hedera-node/configuration/previewnet/log4j2.xml
+++ b/hedera-node/configuration/previewnet/log4j2.xml
@@ -51,6 +51,18 @@
       <DefaultRolloverStrategy max="10"/>
     </RollingFile>
 
+    <!-- Platform hash stream logs -->
+    <RollingFile name="swirldsHashStream" fileName="output/swirlds-hashstream.log"
+                 filePattern="output/swirlds-hashstream.log-%d{yyyy-MM-dd}-%i.log">
+      <PatternLayout>
+        <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %-8sn %-5p %-16marker &lt;%t&gt; %c{1}: %msg{nolookups}%n</pattern>
+      </PatternLayout>
+      <Policies>
+        <SizeBasedTriggeringPolicy size="100 MB"/>
+      </Policies>
+      <DefaultRolloverStrategy max="10"/>
+    </RollingFile>
+
   </Appenders>
   <Loggers>
     <Root level="FATAL">
@@ -73,6 +85,14 @@
           <MarkerFilter marker="JASPER_DB"              onMatch="ACCEPT" onMismatch="NEUTRAL"/>
           <MarkerFilter marker="VIRTUAL_MERKLE_STATS"   onMatch="ACCEPT" onMismatch="NEUTRAL"/>
           <MarkerFilter marker="DISABLED"               onMatch="DENY"   onMismatch="DENY" />
+        </Filters>
+      </AppenderRef>
+
+      <AppenderRef ref="swirldsHashStream">
+        <Filters>
+          <!-- Hash stream log -->
+          <MarkerFilter marker="STATE_HASH"             onMatch="ACCEPT"  onMismatch="NEUTRAL"/>
+          <MarkerFilter marker="DISABLED"               onMatch="DENY"    onMismatch="DENY" />
         </Filters>
       </AppenderRef>
 
@@ -142,6 +162,7 @@
         <!-- Saved States -->
         <MarkerFilter marker="SNAPSHOT_MANAGER"       onMatch="ACCEPT" onMismatch="NEUTRAL"/>
         <MarkerFilter marker="STATE_TO_DISK"          onMatch="ACCEPT" onMismatch="NEUTRAL"/>
+        <MarkerFilter marker="STATE_HASH"             onMatch="DENY"   onMismatch="NEUTRAL"/>
 
         <!-- Beta Mirror -->
         <MarkerFilter marker="BETA_MIRROR_NODE"       onMatch="ACCEPT" onMismatch="NEUTRAL"/>

--- a/hedera-node/configuration/testnet/log4j2.xml
+++ b/hedera-node/configuration/testnet/log4j2.xml
@@ -76,6 +76,7 @@
           <!-- JasperDB & Virtual Merkle -->
           <MarkerFilter marker="JASPER_DB"              onMatch="DENY" onMismatch="NEUTRAL"/>
           <MarkerFilter marker="VIRTUAL_MERKLE_STATS"   onMatch="DENY" onMismatch="NEUTRAL"/>
+          <MarkerFilter marker="STATE_HASH"             onMatch="DENY" onMismatch="NEUTRAL"/>
         </Filters>
       </AppenderRef>
 
@@ -162,7 +163,7 @@
         <!-- Saved States -->
         <MarkerFilter marker="SNAPSHOT_MANAGER"       onMatch="ACCEPT" onMismatch="NEUTRAL"/>
         <MarkerFilter marker="STATE_TO_DISK"          onMatch="ACCEPT" onMismatch="NEUTRAL"/>
-        <MarkerFilter marker="STATE_HASH"             onMatch="DENY"   onMismatch="NEUTRAL"/>
+        <MarkerFilter marker="STATE_HASH"             onMatch="ACCEPT" onMismatch="NEUTRAL"/>
 
         <!-- Beta Mirror -->
         <MarkerFilter marker="BETA_MIRROR_NODE"       onMatch="ACCEPT" onMismatch="NEUTRAL"/>

--- a/hedera-node/configuration/testnet/log4j2.xml
+++ b/hedera-node/configuration/testnet/log4j2.xml
@@ -51,6 +51,18 @@
       <DefaultRolloverStrategy max="10"/>
     </RollingFile>
 
+    <!-- Platform hash stream logs -->
+    <RollingFile name="swirldsHashStream" fileName="output/swirlds-hashstream.log"
+                 filePattern="output/swirlds-hashstream.log-%d{yyyy-MM-dd}-%i.log">
+      <PatternLayout>
+        <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %-8sn %-5p %-16marker &lt;%t&gt; %c{1}: %msg{nolookups}%n</pattern>
+      </PatternLayout>
+      <Policies>
+        <SizeBasedTriggeringPolicy size="100 MB"/>
+      </Policies>
+      <DefaultRolloverStrategy max="10"/>
+    </RollingFile>
+
   </Appenders>
   <Loggers>
     <Root level="FATAL">
@@ -73,6 +85,14 @@
           <MarkerFilter marker="JASPER_DB"              onMatch="ACCEPT" onMismatch="NEUTRAL"/>
           <MarkerFilter marker="VIRTUAL_MERKLE_STATS"   onMatch="ACCEPT" onMismatch="NEUTRAL"/>
           <MarkerFilter marker="DISABLED"               onMatch="DENY"   onMismatch="DENY" />
+        </Filters>
+      </AppenderRef>
+
+      <AppenderRef ref="swirldsHashStream">
+        <Filters>
+          <!-- Hash stream log -->
+          <MarkerFilter marker="STATE_HASH"             onMatch="ACCEPT"  onMismatch="NEUTRAL"/>
+          <MarkerFilter marker="DISABLED"               onMatch="DENY"    onMismatch="DENY" />
         </Filters>
       </AppenderRef>
 
@@ -142,6 +162,7 @@
         <!-- Saved States -->
         <MarkerFilter marker="SNAPSHOT_MANAGER"       onMatch="ACCEPT" onMismatch="NEUTRAL"/>
         <MarkerFilter marker="STATE_TO_DISK"          onMatch="ACCEPT" onMismatch="NEUTRAL"/>
+        <MarkerFilter marker="STATE_HASH"             onMatch="DENY"   onMismatch="NEUTRAL"/>
 
         <!-- Beta Mirror -->
         <MarkerFilter marker="BETA_MIRROR_NODE"       onMatch="ACCEPT" onMismatch="NEUTRAL"/>


### PR DESCRIPTION
Updates logging configs for the different environments to exclude STATE_HASH events from logging to swirlds.log and include them in swirlds-hashstream.log

Related bug:
https://github.com/swirlds/swirlds-platform/issues/5649