### PR TITLE
Fix wrong emitter address in `approve` and `approveForAll` precompiles

### DIFF
--- a/hedera-node/src/main/java/com/hedera/services/store/contracts/precompile/impl/ApprovePrecompile.java
+++ b/hedera-node/src/main/java/com/hedera/services/store/contracts/precompile/impl/ApprovePrecompile.java
@@ -22,7 +22,6 @@ import static com.hedera.services.contracts.ParsingConstants.INT;
 import static com.hedera.services.contracts.ParsingConstants.INT_BOOL_PAIR;
 import static com.hedera.services.exceptions.ValidationUtils.validateTrueOrRevert;
 import static com.hedera.services.state.submerkle.EntityId.MISSING_ENTITY_ID;
-import static com.hedera.services.store.contracts.precompile.HTSPrecompiledContract.HTS_PRECOMPILED_CONTRACT_ADDRESS;
 import static com.hedera.services.store.contracts.precompile.codec.DecodingFacade.convertAddressBytesToTokenID;
 import static com.hedera.services.store.contracts.precompile.codec.DecodingFacade.convertLeftPaddedAddressToAccountId;
 import static com.hedera.services.store.contracts.precompile.codec.DecodingFacade.decodeFunctionCall;
@@ -226,12 +225,12 @@ public class ApprovePrecompile extends AbstractWritePrecompile {
                 throw new InvalidTransactionException(e.getResponseCode(), true);
             }
         }
-        final var precompileAddress = Address.fromHexString(HTS_PRECOMPILED_CONTRACT_ADDRESS);
 
+        final var tokenAddress = asTypedEvmAddress(approveOp.tokenId());
         if (approveOp.isFungible()) {
-            frame.addLog(getLogForFungibleAdjustAllowance(precompileAddress));
+            frame.addLog(getLogForFungibleAdjustAllowance(tokenAddress));
         } else {
-            frame.addLog(getLogForNftAdjustAllowance(precompileAddress));
+            frame.addLog(getLogForNftAdjustAllowance(tokenAddress));
         }
     }
 
@@ -316,8 +315,9 @@ public class ApprovePrecompile extends AbstractWritePrecompile {
         return EncodingFacade.LogBuilder.logBuilder()
                 .forLogger(logger)
                 .forEventSignature(AbiConstants.APPROVAL_EVENT)
-                .forIndexedArgument(senderAddress)
-                .forIndexedArgument(asTypedEvmAddress(approveOp.spender()))
+                .forIndexedArgument(ledgers.canonicalAddress(senderAddress))
+                .forIndexedArgument(
+                        ledgers.canonicalAddress(asTypedEvmAddress(approveOp.spender())))
                 .forDataItem(approveOp.amount())
                 .build();
     }
@@ -326,8 +326,9 @@ public class ApprovePrecompile extends AbstractWritePrecompile {
         return EncodingFacade.LogBuilder.logBuilder()
                 .forLogger(logger)
                 .forEventSignature(AbiConstants.APPROVAL_EVENT)
-                .forIndexedArgument(senderAddress)
-                .forIndexedArgument(asTypedEvmAddress(approveOp.spender()))
+                .forIndexedArgument(ledgers.canonicalAddress(senderAddress))
+                .forIndexedArgument(
+                        ledgers.canonicalAddress(asTypedEvmAddress(approveOp.spender())))
                 .forIndexedArgument(approveOp.serialNumber())
                 .build();
     }

--- a/hedera-node/src/main/java/com/hedera/services/store/contracts/precompile/impl/SetApprovalForAllPrecompile.java
+++ b/hedera-node/src/main/java/com/hedera/services/store/contracts/precompile/impl/SetApprovalForAllPrecompile.java
@@ -17,7 +17,6 @@ package com.hedera.services.store.contracts.precompile.impl;
 
 import static com.hedera.services.contracts.ParsingConstants.INT;
 import static com.hedera.services.exceptions.ValidationUtils.validateTrueOrRevert;
-import static com.hedera.services.store.contracts.precompile.HTSPrecompiledContract.HTS_PRECOMPILED_CONTRACT_ADDRESS;
 import static com.hedera.services.store.contracts.precompile.codec.DecodingFacade.convertAddressBytesToTokenID;
 import static com.hedera.services.store.contracts.precompile.codec.DecodingFacade.convertLeftPaddedAddressToAccountId;
 import static com.hedera.services.store.contracts.precompile.codec.DecodingFacade.decodeFunctionCall;
@@ -149,9 +148,8 @@ public class SetApprovalForAllPrecompile extends AbstractWritePrecompile {
                 transactionBody.getCryptoApproveAllowance().getNftAllowancesList(),
                 EntityIdUtils.accountIdFromEvmAddress(frame.getSenderAddress()));
 
-        final var precompileAddress = Address.fromHexString(HTS_PRECOMPILED_CONTRACT_ADDRESS);
-
-        frame.addLog(getLogForSetApprovalForAll(precompileAddress));
+        final var tokenAddress = asTypedEvmAddress(setApprovalForAllWrapper.tokenId());
+        frame.addLog(getLogForSetApprovalForAll(tokenAddress));
     }
 
     @Override
@@ -163,8 +161,9 @@ public class SetApprovalForAllPrecompile extends AbstractWritePrecompile {
         return EncodingFacade.LogBuilder.logBuilder()
                 .forLogger(logger)
                 .forEventSignature(AbiConstants.APPROVAL_FOR_ALL_EVENT)
-                .forIndexedArgument(senderAddress)
-                .forIndexedArgument(asTypedEvmAddress(setApprovalForAllWrapper.to()))
+                .forIndexedArgument(ledgers.canonicalAddress(senderAddress))
+                .forIndexedArgument(
+                        ledgers.canonicalAddress(asTypedEvmAddress(setApprovalForAllWrapper.to())))
                 .forDataItem(setApprovalForAllWrapper.approved())
                 .build();
     }

--- a/hedera-node/src/test/java/com/hedera/services/store/contracts/precompile/ERC20PrecompilesTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/store/contracts/precompile/ERC20PrecompilesTest.java
@@ -1074,6 +1074,8 @@ class ERC20PrecompilesTest {
                 .thenReturn(APPROVE_WRAPPER);
         given(dynamicProperties.areAllowancesEnabled()).willReturn(true);
         given(encoder.encodeApprove(SUCCESS.getNumber(), true)).willReturn(successResult);
+        given(wrappedLedgers.canonicalAddress(recipientAddress)).willReturn(recipientAddress);
+        given(wrappedLedgers.canonicalAddress(contractAddress)).willReturn(senderAddress);
 
         // when:
         subject.prepareFields(frame);
@@ -1151,6 +1153,8 @@ class ERC20PrecompilesTest {
                 .thenReturn(APPROVE_NFT_WRAPPER);
         given(dynamicProperties.areAllowancesEnabled()).willReturn(true);
         given(encoder.encodeApproveNFT(SUCCESS.getNumber())).willReturn(successResult);
+        given(wrappedLedgers.canonicalAddress(recipientAddress)).willReturn(recipientAddress);
+        given(wrappedLedgers.canonicalAddress(contractAddress)).willReturn(senderAddress);
 
         // when:
         subject.prepareFields(frame);
@@ -1163,6 +1167,15 @@ class ERC20PrecompilesTest {
         verify(wrappedLedgers).commit();
         verify(worldUpdater)
                 .manageInProgressRecord(recordsHistorian, mockRecordBuilder, mockSynthBodyBuilder);
+        verify(frame)
+                .addLog(
+                        EncodingFacade.LogBuilder.logBuilder()
+                                .forLogger(tokenAddress)
+                                .forEventSignature(AbiConstants.APPROVAL_EVENT)
+                                .forIndexedArgument(senderAddress)
+                                .forIndexedArgument(recipientAddress)
+                                .forDataItem(APPROVE_WRAPPER.amount())
+                                .build());
     }
 
     @Test
@@ -1339,6 +1352,15 @@ class ERC20PrecompilesTest {
         verify(wrappedLedgers).commit();
         verify(worldUpdater)
                 .manageInProgressRecord(recordsHistorian, mockRecordBuilder, mockSynthBodyBuilder);
+        verify(frame)
+                .addLog(
+                        EncodingFacade.LogBuilder.logBuilder()
+                                .forLogger(tokenAddress)
+                                .forEventSignature(AbiConstants.APPROVAL_EVENT)
+                                .forIndexedArgument(senderAddress)
+                                .forIndexedArgument(recipientAddress)
+                                .forIndexedArgument(APPROVE_WRAPPER.serialNumber())
+                                .build());
     }
 
     @Test

--- a/hedera-node/src/test/java/com/hedera/services/store/contracts/precompile/ERC20PrecompilesTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/store/contracts/precompile/ERC20PrecompilesTest.java
@@ -1088,6 +1088,15 @@ class ERC20PrecompilesTest {
         verify(wrappedLedgers).commit();
         verify(worldUpdater)
                 .manageInProgressRecord(recordsHistorian, mockRecordBuilder, mockSynthBodyBuilder);
+        verify(frame)
+                .addLog(
+                        EncodingFacade.LogBuilder.logBuilder()
+                                .forLogger(tokenAddress)
+                                .forEventSignature(AbiConstants.APPROVAL_EVENT)
+                                .forIndexedArgument(senderAddress)
+                                .forIndexedArgument(recipientAddress)
+                                .forDataItem(APPROVE_WRAPPER.amount())
+                                .build());
     }
 
     @Test
@@ -1174,7 +1183,7 @@ class ERC20PrecompilesTest {
                                 .forEventSignature(AbiConstants.APPROVAL_EVENT)
                                 .forIndexedArgument(senderAddress)
                                 .forIndexedArgument(recipientAddress)
-                                .forDataItem(APPROVE_WRAPPER.amount())
+                                .forIndexedArgument(APPROVE_NFT_WRAPPER.serialNumber())
                                 .build());
     }
 
@@ -1352,15 +1361,6 @@ class ERC20PrecompilesTest {
         verify(wrappedLedgers).commit();
         verify(worldUpdater)
                 .manageInProgressRecord(recordsHistorian, mockRecordBuilder, mockSynthBodyBuilder);
-        verify(frame)
-                .addLog(
-                        EncodingFacade.LogBuilder.logBuilder()
-                                .forLogger(tokenAddress)
-                                .forEventSignature(AbiConstants.APPROVAL_EVENT)
-                                .forIndexedArgument(senderAddress)
-                                .forIndexedArgument(recipientAddress)
-                                .forIndexedArgument(APPROVE_WRAPPER.serialNumber())
-                                .build());
     }
 
     @Test

--- a/hedera-node/src/test/java/com/hedera/services/store/contracts/precompile/ERC721PrecompilesTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/store/contracts/precompile/ERC721PrecompilesTest.java
@@ -1051,6 +1051,8 @@ class ERC721PrecompilesTest {
         given(accountStore.loadAccount(any())).willReturn(new Account(accountId));
         given(dynamicProperties.areAllowancesEnabled()).willReturn(true);
         given(infrastructureFactory.newApproveAllowanceChecks()).willReturn(allowanceChecks);
+        given(wrappedLedgers.canonicalAddress(recipientAddress)).willReturn(recipientAddress);
+        given(wrappedLedgers.canonicalAddress(contractAddress)).willReturn(senderAddress);
 
         given(
                         allowanceChecks.allowancesValidation(
@@ -1079,6 +1081,15 @@ class ERC721PrecompilesTest {
         verify(wrappedLedgers).commit();
         verify(worldUpdater)
                 .manageInProgressRecord(recordsHistorian, mockRecordBuilder, mockSynthBodyBuilder);
+        verify(frame)
+                .addLog(
+                        EncodingFacade.LogBuilder.logBuilder()
+                                .forLogger(tokenAddress)
+                                .forEventSignature(AbiConstants.APPROVAL_FOR_ALL_EVENT)
+                                .forIndexedArgument(senderAddress)
+                                .forIndexedArgument(recipientAddress)
+                                .forDataItem(SET_APPROVAL_FOR_ALL_WRAPPER.approved())
+                                .build());
     }
 
     @Test

--- a/test-clients/src/main/java/com/hedera/services/bdd/spec/assertions/ContractLogAsserts.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/spec/assertions/ContractLogAsserts.java
@@ -95,6 +95,17 @@ public class ContractLogAsserts extends BaseErroringAssertsProvider<ContractLogi
         return this;
     }
 
+    public ContractLogAsserts booleanValue(boolean expected) {
+        registerProvider(
+                (spec, o) -> {
+                    byte[] data = dataFrom(o);
+                    boolean actual = data[data.length - 1] != 0;
+                    Assertions.assertEquals(
+                            expected, actual, "Bad boolean value in log data: " + actual);
+                });
+        return this;
+    }
+
     public ContractLogAsserts noTopics() {
         registerProvider(
                 (spec, o) -> {


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->

A continuation of #3608, fixing emitter address in the rest of the functions, for which we emit events - `approve` and `setApprovalForAll`.

**Related issue(s)**:

Fixes #3530 
