### PR TITLE
Add hedera-evm / hedera-evm-api submodules

### DIFF
--- a/hedera-node/hedera-evm-api/build.gradle.kts
+++ b/hedera-node/hedera-evm-api/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2022 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm-api/build.gradle.kts
+++ b/hedera-node/hedera-evm-api/build.gradle.kts
@@ -1,0 +1,20 @@
+/*
+ * Copyright (C) 2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+plugins {
+    id("com.hedera.hashgraph.hedera-conventions")
+}
+
+description = "Hedera EVM - API"

--- a/hedera-node/hedera-evm-api/src/main/java/com/hedera/services/evm/PlaceholderApi.java
+++ b/hedera-node/hedera-evm-api/src/main/java/com/hedera/services/evm/PlaceholderApi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2022 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm-api/src/main/java/com/hedera/services/evm/PlaceholderApi.java
+++ b/hedera-node/hedera-evm-api/src/main/java/com/hedera/services/evm/PlaceholderApi.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) 2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hedera.services.evm;
+
+/**
+ * Placeholder interface for to-be-determined public APIs. We'll remove this interface when we're
+ * ready to start splitting out the interfaces for {@code hedera-node} services.
+ */
+public interface PlaceholderApi {}

--- a/hedera-node/hedera-evm-api/src/main/java/com/hedera/services/evm/package-info.java
+++ b/hedera-node/hedera-evm-api/src/main/java/com/hedera/services/evm/package-info.java
@@ -1,0 +1,8 @@
+/**
+ * Includes interface-only specifications of the public APIs provided by the services in {@code
+ * hedera-node}. Any changes to said public APIs must be reflected and documented in this package
+ * <i>before</i> writing their implementations.
+ *
+ * <p><b>There should be no implementation code inside this package.</b>
+ */
+package com.hedera.services.evm;

--- a/hedera-node/hedera-evm-api/src/main/java/module-info.java
+++ b/hedera-node/hedera-evm-api/src/main/java/module-info.java
@@ -1,0 +1,3 @@
+module com.hedera.services.evm {
+    exports com.hedera.services.evm;
+}

--- a/hedera-node/hedera-evm/build.gradle.kts
+++ b/hedera-node/hedera-evm/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2022 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/build.gradle.kts
+++ b/hedera-node/hedera-evm/build.gradle.kts
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+plugins {
+    id("com.hedera.hashgraph.hedera-conventions")
+}
+
+description = "Hedera EVM - Implementation"
+
+dependencies {
+    api(project(":hedera-node:hedera-evm-api"))
+}

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/services/evm/implementation/PlaceholderImplementation.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/services/evm/implementation/PlaceholderImplementation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2022 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/services/evm/implementation/PlaceholderImplementation.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/services/evm/implementation/PlaceholderImplementation.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hedera.services.evm.implementation;
+
+import com.hedera.services.evm.PlaceholderApi;
+
+/**
+ * Placeholder <b>implementation</b> for to-be-determined public APIs. We'll remove this class when
+ * we remove the {@link PlaceholderApi} interface.
+ */
+@SuppressWarnings("unused")
+public class PlaceholderImplementation implements PlaceholderApi {}

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/services/evm/implementation/package-info.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/services/evm/implementation/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Provides implementation classes for the public APIs inside of the {@code com.hedera.services.api}
+ * package.
+ */
+package com.hedera.services.evm.implementation;

--- a/hedera-node/hedera-evm/src/main/java/module-info.java
+++ b/hedera-node/hedera-evm/src/main/java/module-info.java
@@ -1,0 +1,3 @@
+module com.hedera.services.evm.implementation {
+    requires com.hedera.services.evm;
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -25,6 +25,8 @@ include(":hapi-fees")
 include(":hedera-node")
 include(":hedera-node:hedera-app")
 include(":hedera-node:hedera-app-api")
+include(":hedera-node:hedera-evm")
+include(":hedera-node:hedera-evm-api")
 include(":test-clients")
 
 // Enable Gradle Build Scan


### PR DESCRIPTION
Signed-off-by: ivanparnarev <ivan.parnarev@limechain.tech>

**Description**:
This PR creates two new subprojects – hedera-evm and hedera-evm-api – under the hedera-node project in preparation for implementing EVM modularisation. 