### PR TITLE
Remove FOSSA support from the CI pipelines

### DIFF
--- a/.github/workflows/comp-compile-application-code.yaml
+++ b/.github/workflows/comp-compile-application-code.yaml
@@ -249,18 +249,3 @@ jobs:
         with:
           gradle-version: ${{ inputs.gradle-version }}
           arguments: sonarqube --info --scan
-
-      - name: FOSSA Scan
-        uses: fossas/fossa-action@v1.3.1
-        if: ${{ inputs.enable-fossa-scan && !cancelled() }}
-        continue-on-error: true
-        with:
-          api-key: ${{ secrets.fossa-api-token }}
-
-      - name: FOSSA Test
-        uses: fossas/fossa-action@v1.3.1
-        if: ${{ inputs.enable-fossa-test && !cancelled() }}
-        continue-on-error: true
-        with:
-          api-key: ${{ secrets.fossa-api-token }}
-          run-tests: true

--- a/compose-build.sh
+++ b/compose-build.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-DEFAULT_TAG=$(./gradlew :hedera-node:showVersion --quiet | tr -d '[:space:]')
+DEFAULT_TAG=$(./gradlew showVersion --quiet | tr -d '[:space:]')
 GIT_TAG=${1:-"$DEFAULT_TAG"}
 echo $GIT_TAG
 echo "TAG=$GIT_TAG" > .env


### PR DESCRIPTION
## Description

Removes the FOSSA actions from our CI pipelines due to the current outage at the third-party service level. 

### Related issues

- Closes #3982 
