### PR TITLE
Allow zero unit token transfers

### DIFF
--- a/hedera-node/src/main/java/com/hedera/services/ledger/PureTransferSemanticChecks.java
+++ b/hedera-node/src/main/java/com/hedera/services/ledger/PureTransferSemanticChecks.java
@@ -206,9 +206,6 @@ public class PureTransferSemanticChecks {
             if (!adjust.hasAccountID()) {
                 return INVALID_ACCOUNT_ID;
             }
-            if (adjust.getAmount() == 0) {
-                return INVALID_ACCOUNT_AMOUNTS;
-            }
         }
         if (hasRepeatedAccount(adjusts)) {
             return ACCOUNT_REPEATED_IN_ACCOUNT_AMOUNTS;

--- a/hedera-node/src/main/java/com/hedera/services/store/models/Token.java
+++ b/hedera-node/src/main/java/com/hedera/services/store/models/Token.java
@@ -25,7 +25,9 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.CANNOT_WIPE_TO
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.FAIL_INVALID;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INSUFFICIENT_TOKEN_BALANCE;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_TOKEN_BURN_AMOUNT;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_TOKEN_BURN_METADATA;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_TOKEN_MINT_AMOUNT;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_TOKEN_MINT_METADATA;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_WIPING_AMOUNT;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SERIAL_NUMBER_LIMIT_REACHED;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TOKEN_HAS_NO_PAUSE_KEY;
@@ -191,6 +193,8 @@ public class Token {
             final List<ByteString> metadata,
             final RichInstant creationTime) {
         final var metadataCount = metadata.size();
+        validateFalse(
+                metadata.isEmpty(), INVALID_TOKEN_MINT_METADATA, "Cannot mint zero unique tokens");
         validateTrue(
                 type == TokenType.NON_FUNGIBLE_UNIQUE,
                 FAIL_INVALID,
@@ -235,6 +239,7 @@ public class Token {
             final TokenRelationship treasuryRelationship,
             final List<Long> serialNumbers) {
         validateTrue(type == TokenType.NON_FUNGIBLE_UNIQUE, FAIL_INVALID);
+        validateFalse(serialNumbers.isEmpty(), INVALID_TOKEN_BURN_METADATA);
         final var treasuryId = treasury.getId();
         for (final long serialNum : serialNumbers) {
             final var uniqueToken = loadedUniqueTokens.get(serialNum);
@@ -291,6 +296,10 @@ public class Token {
             TokenRelationship accountRel,
             List<Long> serialNumbers) {
         validateTrue(type == TokenType.NON_FUNGIBLE_UNIQUE, FAIL_INVALID);
+        validateFalse(
+                serialNumbers.isEmpty(),
+                FAIL_INVALID); // why is this FAIL_INVALID , should be INVALID_TOKEN_WIPE_METADATA ?
+
         baseWipeValidations(accountRel);
         for (var serialNum : serialNumbers) {
             final var uniqueToken = loadedUniqueTokens.get(serialNum);

--- a/hedera-node/src/main/java/com/hedera/services/store/models/Token.java
+++ b/hedera-node/src/main/java/com/hedera/services/store/models/Token.java
@@ -296,9 +296,7 @@ public class Token {
             TokenRelationship accountRel,
             List<Long> serialNumbers) {
         validateTrue(type == TokenType.NON_FUNGIBLE_UNIQUE, FAIL_INVALID);
-        validateFalse(
-                serialNumbers.isEmpty(),
-                FAIL_INVALID); // why is this FAIL_INVALID , should be INVALID_TOKEN_WIPE_METADATA ?
+        validateFalse(serialNumbers.isEmpty(), INVALID_WIPING_AMOUNT);
 
         baseWipeValidations(accountRel);
         for (var serialNum : serialNumbers) {

--- a/hedera-node/src/main/java/com/hedera/services/store/models/Token.java
+++ b/hedera-node/src/main/java/com/hedera/services/store/models/Token.java
@@ -291,8 +291,6 @@ public class Token {
             TokenRelationship accountRel,
             List<Long> serialNumbers) {
         validateTrue(type == TokenType.NON_FUNGIBLE_UNIQUE, FAIL_INVALID);
-        validateFalse(serialNumbers.isEmpty(), FAIL_INVALID);
-
         baseWipeValidations(accountRel);
         for (var serialNum : serialNumbers) {
             final var uniqueToken = loadedUniqueTokens.get(serialNum);

--- a/hedera-node/src/main/java/com/hedera/services/store/models/Token.java
+++ b/hedera-node/src/main/java/com/hedera/services/store/models/Token.java
@@ -25,9 +25,7 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.CANNOT_WIPE_TO
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.FAIL_INVALID;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INSUFFICIENT_TOKEN_BALANCE;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_TOKEN_BURN_AMOUNT;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_TOKEN_BURN_METADATA;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_TOKEN_MINT_AMOUNT;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_TOKEN_MINT_METADATA;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_WIPING_AMOUNT;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SERIAL_NUMBER_LIMIT_REACHED;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TOKEN_HAS_NO_PAUSE_KEY;
@@ -168,7 +166,7 @@ public class Token {
     public void mint(
             final TokenRelationship treasuryRel, final long amount, boolean ignoreSupplyKey) {
         validateTrue(
-                amount > 0, INVALID_TOKEN_MINT_AMOUNT, errorMessage("mint", amount, treasuryRel));
+                amount >= 0, INVALID_TOKEN_MINT_AMOUNT, errorMessage("mint", amount, treasuryRel));
         validateTrue(
                 type == TokenType.FUNGIBLE_COMMON,
                 FAIL_INVALID,
@@ -193,8 +191,6 @@ public class Token {
             final List<ByteString> metadata,
             final RichInstant creationTime) {
         final var metadataCount = metadata.size();
-        validateFalse(
-                metadata.isEmpty(), INVALID_TOKEN_MINT_METADATA, "Cannot mint zero unique tokens");
         validateTrue(
                 type == TokenType.NON_FUNGIBLE_UNIQUE,
                 FAIL_INVALID,
@@ -221,7 +217,7 @@ public class Token {
 
     public void burn(final TokenRelationship treasuryRel, final long amount) {
         validateTrue(
-                amount > 0, INVALID_TOKEN_BURN_AMOUNT, errorMessage("burn", amount, treasuryRel));
+                amount >= 0, INVALID_TOKEN_BURN_AMOUNT, errorMessage("burn", amount, treasuryRel));
         changeSupply(treasuryRel, -amount, INVALID_TOKEN_BURN_AMOUNT, false);
     }
 
@@ -239,7 +235,6 @@ public class Token {
             final TokenRelationship treasuryRelationship,
             final List<Long> serialNumbers) {
         validateTrue(type == TokenType.NON_FUNGIBLE_UNIQUE, FAIL_INVALID);
-        validateFalse(serialNumbers.isEmpty(), INVALID_TOKEN_BURN_METADATA);
         final var treasuryId = treasury.getId();
         for (final long serialNum : serialNumbers) {
             final var uniqueToken = loadedUniqueTokens.get(serialNum);
@@ -418,7 +413,7 @@ public class Token {
     }
 
     private void amountWipeValidations(final TokenRelationship accountRel, final long amount) {
-        validateTrue(amount > 0, INVALID_WIPING_AMOUNT, errorMessage("wipe", amount, accountRel));
+        validateTrue(amount >= 0, INVALID_WIPING_AMOUNT, errorMessage("wipe", amount, accountRel));
 
         final var newTotalSupply = totalSupply - amount;
         validateTrue(

--- a/hedera-node/src/main/java/com/hedera/services/txns/token/TokenOpsValidator.java
+++ b/hedera-node/src/main/java/com/hedera/services/txns/token/TokenOpsValidator.java
@@ -118,12 +118,12 @@ public final class TokenOpsValidator {
         }
 
         boolean bothPresent = (fungibleCount > 0 && nftCount > 0);
-        boolean nonePresent = (fungibleCount < 0 && nftCount == 0);
-        if (nonePresent) {
-            return invalidTokenAmount;
-        }
         if (bothPresent) {
             return INVALID_TRANSACTION_BODY;
+        }
+
+        if (fungibleCount < 0) {
+            return invalidTokenAmount;
         }
 
         if (fungibleCount <= 0 && nftCount > 0) {

--- a/hedera-node/src/main/java/com/hedera/services/txns/token/TokenOpsValidator.java
+++ b/hedera-node/src/main/java/com/hedera/services/txns/token/TokenOpsValidator.java
@@ -118,7 +118,7 @@ public final class TokenOpsValidator {
         }
 
         boolean bothPresent = (fungibleCount > 0 && nftCount > 0);
-        boolean nonePresent = (fungibleCount <= 0 && nftCount == 0);
+        boolean nonePresent = (fungibleCount < 0 && nftCount == 0);
         if (nonePresent) {
             return invalidTokenAmount;
         }

--- a/hedera-node/src/test/java/com/hedera/services/ledger/PureTransferSemanticChecksTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/ledger/PureTransferSemanticChecksTest.java
@@ -509,22 +509,10 @@ class PureTransferSemanticChecksTest {
     }
 
     @Test
-    void rejectsZeroAccountAmount() {
+    void acceptsZeroAccountAmount() {
         // expect:
         assertEquals(
-                INVALID_ACCOUNT_AMOUNTS,
-                subject.validateTokenTransferSemantics(
-                        List.of(
-                                TokenTransferList.newBuilder()
-                                        .setToken(aTid)
-                                        .addTransfers(
-                                                AccountAmount.newBuilder()
-                                                        .setAccountID(a)
-                                                        .setAmount(0)
-                                                        .build())
-                                        .build())));
-        assertEquals(
-                INVALID_ACCOUNT_AMOUNTS,
+                OK,
                 subject.validateTokenTransferSemantics(
                         List.of(
                                 TokenTransferList.newBuilder()

--- a/hedera-node/src/test/java/com/hedera/services/store/models/TokenTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/store/models/TokenTest.java
@@ -20,6 +20,7 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.CANNOT_WIPE_TO
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.FAIL_INVALID;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INSUFFICIENT_TOKEN_BALANCE;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_TOKEN_BURN_AMOUNT;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_TOKEN_BURN_METADATA;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_TOKEN_MINT_AMOUNT;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SERIAL_NUMBER_LIMIT_REACHED;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TOKEN_HAS_NO_PAUSE_KEY;
@@ -561,7 +562,9 @@ class TokenTest {
                 });
 
         subject.setType(TokenType.NON_FUNGIBLE_UNIQUE);
-        assertDoesNotThrow(() -> subject.burn(ownershipTracker, treasuryRel, emptySerialNumber));
+        assertFailsWith(
+                () -> subject.burn(ownershipTracker, treasuryRel, emptySerialNumber),
+                INVALID_TOKEN_BURN_METADATA);
     }
 
     @Test
@@ -617,7 +620,8 @@ class TokenTest {
                 });
 
         subject.setType(TokenType.NON_FUNGIBLE_UNIQUE);
-        assertDoesNotThrow(
+        assertThrows(
+                InvalidTransactionException.class,
                 () -> {
                     subject.mint(
                             ownershipTracker,

--- a/hedera-node/src/test/java/com/hedera/services/store/models/TokenTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/store/models/TokenTest.java
@@ -20,7 +20,6 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.CANNOT_WIPE_TO
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.FAIL_INVALID;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INSUFFICIENT_TOKEN_BALANCE;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_TOKEN_BURN_AMOUNT;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_TOKEN_BURN_METADATA;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_TOKEN_MINT_AMOUNT;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SERIAL_NUMBER_LIMIT_REACHED;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TOKEN_HAS_NO_PAUSE_KEY;
@@ -562,9 +561,7 @@ class TokenTest {
                 });
 
         subject.setType(TokenType.NON_FUNGIBLE_UNIQUE);
-        assertFailsWith(
-                () -> subject.burn(ownershipTracker, treasuryRel, emptySerialNumber),
-                INVALID_TOKEN_BURN_METADATA);
+        assertDoesNotThrow(() -> subject.burn(ownershipTracker, treasuryRel, emptySerialNumber));
     }
 
     @Test
@@ -620,8 +617,7 @@ class TokenTest {
                 });
 
         subject.setType(TokenType.NON_FUNGIBLE_UNIQUE);
-        assertThrows(
-                InvalidTransactionException.class,
+        assertDoesNotThrow(
                 () -> {
                     subject.mint(
                             ownershipTracker,

--- a/hedera-node/src/test/java/com/hedera/services/txns/token/BurnLogicTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/txns/token/BurnLogicTest.java
@@ -15,6 +15,8 @@
  */
 package com.hedera.services.txns.token;
 
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OK;
+import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
@@ -102,6 +104,18 @@ class BurnLogicTest {
         verify(accountStore).commitAccount(any(Account.class));
     }
 
+    @Test
+    void precheckWorksForZeroFungibleAmount() {
+        givenValidTxnCtxWithZeroAmount();
+        assertEquals(OK, subject.validateSyntax(tokenBurnTxn));
+    }
+
+    @Test
+    void precheckWorksForNonZeroFungibleAmount() {
+        givenUniqueTxnCtxWithNoSerials();
+        assertEquals(OK, subject.validateSyntax(tokenBurnTxn));
+    }
+
     private void givenValidTxnCtx() {
         tokenBurnTxn =
                 TransactionBody.newBuilder()
@@ -109,6 +123,24 @@ class BurnLogicTest {
                                 TokenBurnTransactionBody.newBuilder()
                                         .setToken(grpcId)
                                         .setAmount(amount))
+                        .build();
+    }
+
+    private void givenValidTxnCtxWithZeroAmount() {
+        tokenBurnTxn =
+                TransactionBody.newBuilder()
+                        .setTokenBurn(
+                                TokenBurnTransactionBody.newBuilder().setToken(grpcId).setAmount(0))
+                        .build();
+    }
+
+    private void givenUniqueTxnCtxWithNoSerials() {
+        tokenBurnTxn =
+                TransactionBody.newBuilder()
+                        .setTokenBurn(
+                                TokenBurnTransactionBody.newBuilder()
+                                        .setToken(grpcId)
+                                        .addAllSerialNumbers(List.of()))
                         .build();
     }
 

--- a/hedera-node/src/test/java/com/hedera/services/txns/token/MintLogicTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/txns/token/MintLogicTest.java
@@ -17,6 +17,8 @@ package com.hedera.services.txns.token;
 
 import static com.hedera.test.utils.TxnUtils.assertFailsWith;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.MAX_NFTS_IN_PRICE_REGIME_HAVE_BEEN_MINTED;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OK;
+import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
@@ -164,6 +166,18 @@ class MintLogicTest {
         verify(accountStore).commitAccount(any(Account.class));
     }
 
+    @Test
+    void precheckWorksForZeroFungibleAmount() {
+        givenValidTxnCtxWithZeroAmount();
+        assertEquals(OK, subject.validateSyntax(tokenMintTxn));
+    }
+
+    @Test
+    void precheckWorksForNonZeroFungibleAmount() {
+        givenUniqueTxnCtxWithNoSerials();
+        assertEquals(OK, subject.validateSyntax(tokenMintTxn));
+    }
+
     private void givenValidUniqueTxnCtx() {
         tokenMintTxn =
                 TransactionBody.newBuilder()
@@ -181,6 +195,24 @@ class MintLogicTest {
                                 TokenMintTransactionBody.newBuilder()
                                         .setToken(grpcId)
                                         .setAmount(amount))
+                        .build();
+    }
+
+    private void givenValidTxnCtxWithZeroAmount() {
+        tokenMintTxn =
+                TransactionBody.newBuilder()
+                        .setTokenMint(
+                                TokenMintTransactionBody.newBuilder().setToken(grpcId).setAmount(0))
+                        .build();
+    }
+
+    private void givenUniqueTxnCtxWithNoSerials() {
+        tokenMintTxn =
+                TransactionBody.newBuilder()
+                        .setTokenMint(
+                                TokenMintTransactionBody.newBuilder()
+                                        .setToken(grpcId)
+                                        .addAllMetadata(List.of()))
                         .build();
     }
 }

--- a/hedera-node/src/test/java/com/hedera/services/txns/token/TokenBurnTransitionLogicTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/txns/token/TokenBurnTransitionLogicTest.java
@@ -118,11 +118,11 @@ class TokenBurnTransitionLogicTest {
     }
 
     @Test
-    void rejectsInvalidZeroAmount() {
+    void allowsZeroAmount() {
         givenInvalidZeroAmount();
 
         // expect:
-        assertEquals(INVALID_TOKEN_BURN_AMOUNT, subject.semanticCheck().apply(tokenBurnTxn));
+        assertEquals(OK, subject.semanticCheck().apply(tokenBurnTxn));
     }
 
     @Test
@@ -142,13 +142,13 @@ class TokenBurnTransitionLogicTest {
     }
 
     @Test
-    void rejectsInvalidTxnBodyWithNoProps() {
+    void allowsTxnBodyWithNoProps() {
         tokenBurnTxn =
                 TransactionBody.newBuilder()
                         .setTokenBurn(TokenBurnTransactionBody.newBuilder().setToken(grpcId))
                         .build();
 
-        assertEquals(INVALID_TOKEN_BURN_AMOUNT, subject.semanticCheck().apply(tokenBurnTxn));
+        assertEquals(OK, subject.semanticCheck().apply(tokenBurnTxn));
     }
 
     @Test

--- a/hedera-node/src/test/java/com/hedera/services/txns/token/TokenMintTransitionLogicTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/txns/token/TokenMintTransitionLogicTest.java
@@ -121,11 +121,11 @@ class TokenMintTransitionLogicTest {
     }
 
     @Test
-    void rejectsInvalidZeroAmount() {
-        givenInvalidZeroAmount();
+    void allowsZeroAmount() {
+        givenZeroAmount();
 
         // expect:
-        assertEquals(INVALID_TOKEN_MINT_AMOUNT, subject.semanticCheck().apply(tokenMintTxn));
+        assertEquals(OK, subject.semanticCheck().apply(tokenMintTxn));
     }
 
     @Test
@@ -144,13 +144,13 @@ class TokenMintTransitionLogicTest {
     }
 
     @Test
-    void rejectsInvalidTxnBodyWithNoProps() {
+    void allowsTxnBodyWithNoProps() {
         tokenMintTxn =
                 TransactionBody.newBuilder()
                         .setTokenMint(TokenMintTransactionBody.newBuilder().setToken(grpcId))
                         .build();
 
-        assertEquals(INVALID_TOKEN_MINT_AMOUNT, subject.semanticCheck().apply(tokenMintTxn));
+        assertEquals(OK, subject.semanticCheck().apply(tokenMintTxn));
     }
 
     @Test
@@ -250,7 +250,7 @@ class TokenMintTransitionLogicTest {
                         .build();
     }
 
-    private void givenInvalidZeroAmount() {
+    private void givenZeroAmount() {
         tokenMintTxn =
                 TransactionBody.newBuilder()
                         .setTokenMint(

--- a/hedera-node/src/test/java/com/hedera/services/txns/token/TokenOpsValidatorTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/txns/token/TokenOpsValidatorTest.java
@@ -57,9 +57,11 @@ class TokenOpsValidatorTest {
 
     @Test
     void tokenMintFailsWithInvalidTokenCounts() {
-        assertEquals(INVALID_TOKEN_MINT_AMOUNT, forMintWith(0, 0, true));
+        assertEquals(OK, forMintWith(0, 0, true));
 
         assertEquals(INVALID_TRANSACTION_BODY, forMintWith(1, 1, true));
+        assertEquals(INVALID_TOKEN_MINT_AMOUNT, forMintWith(1, -1, true));
+        assertEquals(INVALID_TOKEN_MINT_AMOUNT, forMintWith(0, -1, true));
     }
 
     @Test

--- a/hedera-node/src/test/java/com/hedera/services/txns/token/TokenWipeTransitionLogicTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/txns/token/TokenWipeTransitionLogicTest.java
@@ -208,11 +208,11 @@ class TokenWipeTransitionLogicTest {
     }
 
     @Test
-    void rejectsInvalidZeroAmount() throws InvalidProtocolBufferException {
-        givenInvalidZeroWipeAmount();
+    void allowsZeroAmount() throws InvalidProtocolBufferException {
+        givenZeroWipeAmount();
 
         // expect:
-        assertEquals(INVALID_WIPING_AMOUNT, subject.validateSemantics(accessor));
+        assertEquals(OK, subject.validateSemantics(accessor));
     }
 
     @Test
@@ -327,7 +327,7 @@ class TokenWipeTransitionLogicTest {
         given(swirldsTxnAccessor.getDelegate()).willReturn(accessor);
     }
 
-    private void givenInvalidZeroWipeAmount() throws InvalidProtocolBufferException {
+    private void givenZeroWipeAmount() throws InvalidProtocolBufferException {
         tokenWipeTxnBody =
                 TransactionBody.newBuilder()
                         .setTokenWipe(

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/ContractHTSSuite.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/ContractHTSSuite.java
@@ -261,6 +261,9 @@ public class ContractHTSSuite extends HapiApiSuite {
                         contractCall(theContract, "depositTokens", 50)
                                 .gas(GAS_TO_OFFER)
                                 .via("zeno"),
+                        contractCall(theContract, "depositTokens", 0)
+                                .gas(GAS_TO_OFFER)
+                                .via("zeroTransfers"),
                         contractCall(theContract, "withdrawTokens")
                                 .payingWith(RECEIVER)
                                 .alsoSigningWithFullPrefix(theContract)
@@ -921,7 +924,8 @@ public class ContractHTSSuite extends HapiApiSuite {
                                                             1L)
                                                     .alsoSigningWithFullPrefix(ACCOUNT)
                                                     .gas(GAS_TO_OFFER)
-                                                    .via("distributeTx"));
+                                                    .via("distributeTx")
+                                            );
                                 }))
                 .then(
                         getTokenInfo(NFT).hasTotalSupply(2),

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/ContractHTSSuite.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/ContractHTSSuite.java
@@ -924,8 +924,7 @@ public class ContractHTSSuite extends HapiApiSuite {
                                                             1L)
                                                     .alsoSigningWithFullPrefix(ACCOUNT)
                                                     .gas(GAS_TO_OFFER)
-                                                    .via("distributeTx")
-                                            );
+                                                    .via("distributeTx"));
                                 }))
                 .then(
                         getTokenInfo(NFT).hasTotalSupply(2),

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/WipeTokenAccountPrecompileSuite.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/WipeTokenAccountPrecompileSuite.java
@@ -69,9 +69,7 @@ public class WipeTokenAccountPrecompileSuite extends HapiApiSuite {
 
     @Override
     public List<HapiApiSpec> getSpecsInSuite() {
-        return allOf(List.of(
-//                wipeFungibleTokenScenarios(),
-                wipeNonFungibleTokenScenarios()));
+        return allOf(List.of(wipeFungibleTokenScenarios(), wipeNonFungibleTokenScenarios()));
     }
 
     private HapiApiSpec wipeFungibleTokenScenarios() {
@@ -103,101 +101,105 @@ public class WipeTokenAccountPrecompileSuite extends HapiApiSuite {
                                 (spec, opLog) ->
                                         allRunFor(
                                                 spec,
-//                                                contractCall(
-//                                                                WIPE_CONTRACT,
-//                                                                WIPE_FUNGIBLE_TOKEN,
-//                                                                asAddress(vanillaTokenID.get()),
-//                                                                asAddress(accountID.get()),
-//                                                                10L)
-//                                                        .payingWith(ADMIN_ACCOUNT)
-//                                                        .via("accountDoesNotOwnWipeKeyTxn")
-//                                                        .gas(GAS_TO_OFFER)
-//                                                        .hasKnownStatus(CONTRACT_REVERT_EXECUTED),
-//                                                cryptoUpdate(ADMIN_ACCOUNT).key(WIPE_KEY),
-//                                                contractCall(
-//                                                                WIPE_CONTRACT,
-//                                                                WIPE_FUNGIBLE_TOKEN,
-//                                                                asAddress(vanillaTokenID.get()),
-//                                                                asAddress(accountID.get()),
-//                                                                1_000L)
-//                                                        .payingWith(ADMIN_ACCOUNT)
-//                                                        .via("amountLargerThanBalanceTxn")
-//                                                        .gas(GAS_TO_OFFER)
-//                                                        .hasKnownStatus(CONTRACT_REVERT_EXECUTED),
-//                                                contractCall(
-//                                                                WIPE_CONTRACT,
-//                                                                WIPE_FUNGIBLE_TOKEN,
-//                                                                asAddress(vanillaTokenID.get()),
-//                                                                asAddress(secondAccountID.get()),
-//                                                                10L)
-//                                                        .payingWith(ADMIN_ACCOUNT)
-//                                                        .via("accountDoesNotOwnTokensTxn")
-//                                                        .gas(GAS_TO_OFFER)
-//                                                        .hasKnownStatus(CONTRACT_REVERT_EXECUTED),
-//                                                contractCall(
-//                                                                WIPE_CONTRACT,
-//                                                                WIPE_FUNGIBLE_TOKEN,
-//                                                                asAddress(vanillaTokenID.get()),
-//                                                                asAddress(accountID.get()),
-//                                                                10L)
-//                                                        .payingWith(ADMIN_ACCOUNT)
-//                                                        .via("wipeFungibleTxn")
-//                                                        .gas(GAS_TO_OFFER),
                                                 contractCall(
-                                                        WIPE_CONTRACT,
-                                                        WIPE_FUNGIBLE_TOKEN,
-                                                        asAddress(vanillaTokenID.get()),
-                                                        asAddress(accountID.get()),
-                                                        0L)
+                                                                WIPE_CONTRACT,
+                                                                WIPE_FUNGIBLE_TOKEN,
+                                                                asAddress(vanillaTokenID.get()),
+                                                                asAddress(accountID.get()),
+                                                                10L)
+                                                        .payingWith(ADMIN_ACCOUNT)
+                                                        .via("accountDoesNotOwnWipeKeyTxn")
+                                                        .gas(GAS_TO_OFFER)
+                                                        .hasKnownStatus(CONTRACT_REVERT_EXECUTED),
+                                                cryptoUpdate(ADMIN_ACCOUNT).key(WIPE_KEY),
+                                                contractCall(
+                                                                WIPE_CONTRACT,
+                                                                WIPE_FUNGIBLE_TOKEN,
+                                                                asAddress(vanillaTokenID.get()),
+                                                                asAddress(accountID.get()),
+                                                                1_000L)
+                                                        .payingWith(ADMIN_ACCOUNT)
+                                                        .via("amountLargerThanBalanceTxn")
+                                                        .gas(GAS_TO_OFFER)
+                                                        .hasKnownStatus(CONTRACT_REVERT_EXECUTED),
+                                                contractCall(
+                                                                WIPE_CONTRACT,
+                                                                WIPE_FUNGIBLE_TOKEN,
+                                                                asAddress(vanillaTokenID.get()),
+                                                                asAddress(secondAccountID.get()),
+                                                                10L)
+                                                        .payingWith(ADMIN_ACCOUNT)
+                                                        .via("accountDoesNotOwnTokensTxn")
+                                                        .gas(GAS_TO_OFFER)
+                                                        .hasKnownStatus(CONTRACT_REVERT_EXECUTED),
+                                                contractCall(
+                                                                WIPE_CONTRACT,
+                                                                WIPE_FUNGIBLE_TOKEN,
+                                                                asAddress(vanillaTokenID.get()),
+                                                                asAddress(accountID.get()),
+                                                                10L)
+                                                        .payingWith(ADMIN_ACCOUNT)
+                                                        .via("wipeFungibleTxn")
+                                                        .gas(GAS_TO_OFFER),
+                                                contractCall(
+                                                                WIPE_CONTRACT,
+                                                                WIPE_FUNGIBLE_TOKEN,
+                                                                asAddress(vanillaTokenID.get()),
+                                                                asAddress(accountID.get()),
+                                                                0L)
                                                         .payingWith(ADMIN_ACCOUNT)
                                                         .via("wipeFungibleTxnWithZeroAmount")
+                                                        .gas(GAS_TO_OFFER),
+                                                //
+                                                // negative amount throws run time exception as
+                                                //
+                                                // amount is uint64 in solidity file
+
+                                                contractCall(
+                                                                WIPE_CONTRACT,
+                                                                WIPE_FUNGIBLE_TOKEN,
+                                                                asAddress(vanillaTokenID.get()),
+                                                                asAddress(accountID.get()),
+                                                                -1L)
+                                                        .payingWith(ADMIN_ACCOUNT)
+                                                        .via("failedWipeFungibleTxn")
                                                         .gas(GAS_TO_OFFER)
-                                                // negative amount throws run time exception as amount is uint64 in solidity file
-//                                                contractCall(
-//                                                        WIPE_CONTRACT,
-//                                                        WIPE_FUNGIBLE_TOKEN,
-//                                                        asAddress(vanillaTokenID.get()),
-//                                                        asAddress(accountID.get()),
-//                                                        -1L)
-//                                                        .payingWith(ADMIN_ACCOUNT)
-//                                                        .via("failedWipeFungibleTxn")
-//                                                        .gas(GAS_TO_OFFER)
-//                                                        .hasKnownStatus(CONTRACT_REVERT_EXECUTED)
-//                                                        .logged()
-                                        ))).then(
-//                        childRecordsCheck(
-//                                "accountDoesNotOwnWipeKeyTxn",
-//                                CONTRACT_REVERT_EXECUTED,
-//                                recordWith()
-//                                        .status(INVALID_SIGNATURE)
-//                                        .contractCallResult(
-//                                                resultWith()
-//                                                        .contractCallResult(
-//                                                                htsPrecompileResult()
-//                                                                        .withStatus(
-//                                                                                INVALID_SIGNATURE)))),
-//                        childRecordsCheck(
-//                                "amountLargerThanBalanceTxn",
-//                                CONTRACT_REVERT_EXECUTED,
-//                                recordWith()
-//                                        .status(INVALID_WIPING_AMOUNT)
-//                                        .contractCallResult(
-//                                                resultWith()
-//                                                        .contractCallResult(
-//                                                                htsPrecompileResult()
-//                                                                        .withStatus(
-//                                                                                INVALID_WIPING_AMOUNT)))),
-//                        childRecordsCheck(
-//                                "accountDoesNotOwnTokensTxn",
-//                                CONTRACT_REVERT_EXECUTED,
-//                                recordWith()
-//                                        .status(INVALID_WIPING_AMOUNT)
-//                                        .contractCallResult(
-//                                                resultWith()
-//                                                        .contractCallResult(
-//                                                                htsPrecompileResult()
-//                                                                        .withStatus(
-//                                                                                INVALID_WIPING_AMOUNT)))),
+                                                        .hasKnownStatus(CONTRACT_REVERT_EXECUTED)
+                                                        .logged())))
+                .then(
+                        childRecordsCheck(
+                                "accountDoesNotOwnWipeKeyTxn",
+                                CONTRACT_REVERT_EXECUTED,
+                                recordWith()
+                                        .status(INVALID_SIGNATURE)
+                                        .contractCallResult(
+                                                resultWith()
+                                                        .contractCallResult(
+                                                                htsPrecompileResult()
+                                                                        .withStatus(
+                                                                                INVALID_SIGNATURE)))),
+                        childRecordsCheck(
+                                "amountLargerThanBalanceTxn",
+                                CONTRACT_REVERT_EXECUTED,
+                                recordWith()
+                                        .status(INVALID_WIPING_AMOUNT)
+                                        .contractCallResult(
+                                                resultWith()
+                                                        .contractCallResult(
+                                                                htsPrecompileResult()
+                                                                        .withStatus(
+                                                                                INVALID_WIPING_AMOUNT)))),
+                        childRecordsCheck(
+                                "accountDoesNotOwnTokensTxn",
+                                CONTRACT_REVERT_EXECUTED,
+                                recordWith()
+                                        .status(INVALID_WIPING_AMOUNT)
+                                        .contractCallResult(
+                                                resultWith()
+                                                        .contractCallResult(
+                                                                htsPrecompileResult()
+                                                                        .withStatus(
+                                                                                INVALID_WIPING_AMOUNT)))),
                         childRecordsCheck(
                                 "wipeFungibleTxnWithZeroAmount",
                                 SUCCESS,
@@ -207,8 +209,7 @@ public class WipeTokenAccountPrecompileSuite extends HapiApiSuite {
                                                 resultWith()
                                                         .contractCallResult(
                                                                 htsPrecompileResult()
-                                                                        .withStatus(
-                                                                                SUCCESS)))),
+                                                                        .withStatus(SUCCESS)))),
                         getTokenInfo(VANILLA_TOKEN).hasTotalSupply(990),
                         getAccountBalance(ACCOUNT).hasTokenBalance(VANILLA_TOKEN, 490));
     }
@@ -248,114 +249,113 @@ public class WipeTokenAccountPrecompileSuite extends HapiApiSuite {
                                     serialNumbers.add(1L);
                                     allRunFor(
                                             spec,
-//                                            contractCall(
-//                                                            WIPE_CONTRACT,
-//                                                            WIPE_NON_FUNGIBLE_TOKEN,
-//                                                            asAddress(vanillaTokenID.get()),
-//                                                            asAddress(accountID.get()),
-//                                                            serialNumbers)
-//                                                    .payingWith(ADMIN_ACCOUNT)
-//                                                    .via(
-//                                                            "wipeNonFungibleAccountDoesNotOwnWipeKeyTxn")
-//                                                    .gas(GAS_TO_OFFER)
-//                                                    .hasKnownStatus(CONTRACT_REVERT_EXECUTED),
-//                                            cryptoUpdate(ADMIN_ACCOUNT).key(WIPE_KEY),
-//                                            contractCall(
-//                                                            WIPE_CONTRACT,
-//                                                            WIPE_NON_FUNGIBLE_TOKEN,
-//                                                            asAddress(vanillaTokenID.get()),
-//                                                            asAddress(accountID.get()),
-//                                                            List.of(2L))
-//                                                    .payingWith(ADMIN_ACCOUNT)
-//                                                    .via(
-//                                                            "wipeNonFungibleAccountDoesNotOwnTheSerialTxn")
-//                                                    .gas(GAS_TO_OFFER)
-//                                                    .hasKnownStatus(CONTRACT_REVERT_EXECUTED),
-//                                            contractCall(
-//                                                            WIPE_CONTRACT,
-//                                                            WIPE_NON_FUNGIBLE_TOKEN,
-//                                                            asAddress(vanillaTokenID.get()),
-//                                                            asAddress(accountID.get()),
-//                                                            List.of(-2L))
-//                                                    .payingWith(ADMIN_ACCOUNT)
-//                                                    .via("wipeNonFungibleNegativeSerialTxn")
-//                                                    .gas(GAS_TO_OFFER)
-//                                                    .hasKnownStatus(CONTRACT_REVERT_EXECUTED),
-//                                            contractCall(
-//                                                            WIPE_CONTRACT,
-//                                                            WIPE_NON_FUNGIBLE_TOKEN,
-//                                                            asAddress(vanillaTokenID.get()),
-//                                                            asAddress(accountID.get()),
-//                                                            List.of(3L))
-//                                                    .payingWith(ADMIN_ACCOUNT)
-//                                                    .via("wipeNonFungibleSerialDoesNotExistsTxn")
-//                                                    .gas(GAS_TO_OFFER)
-//                                                    .hasKnownStatus(CONTRACT_REVERT_EXECUTED),
                                             contractCall(
-                                                    WIPE_CONTRACT,
-                                                    WIPE_NON_FUNGIBLE_TOKEN,
-                                                    asAddress(vanillaTokenID.get()),
-                                                    asAddress(accountID.get()),
-                                                    List.of())
+                                                            WIPE_CONTRACT,
+                                                            WIPE_NON_FUNGIBLE_TOKEN,
+                                                            asAddress(vanillaTokenID.get()),
+                                                            asAddress(accountID.get()),
+                                                            serialNumbers)
+                                                    .payingWith(ADMIN_ACCOUNT)
+                                                    .via(
+                                                            "wipeNonFungibleAccountDoesNotOwnWipeKeyTxn")
+                                                    .gas(GAS_TO_OFFER)
+                                                    .hasKnownStatus(CONTRACT_REVERT_EXECUTED),
+                                            cryptoUpdate(ADMIN_ACCOUNT).key(WIPE_KEY),
+                                            contractCall(
+                                                            WIPE_CONTRACT,
+                                                            WIPE_NON_FUNGIBLE_TOKEN,
+                                                            asAddress(vanillaTokenID.get()),
+                                                            asAddress(accountID.get()),
+                                                            List.of(2L))
+                                                    .payingWith(ADMIN_ACCOUNT)
+                                                    .via(
+                                                            "wipeNonFungibleAccountDoesNotOwnTheSerialTxn")
+                                                    .gas(GAS_TO_OFFER)
+                                                    .hasKnownStatus(CONTRACT_REVERT_EXECUTED),
+                                            contractCall(
+                                                            WIPE_CONTRACT,
+                                                            WIPE_NON_FUNGIBLE_TOKEN,
+                                                            asAddress(vanillaTokenID.get()),
+                                                            asAddress(accountID.get()),
+                                                            List.of(-2L))
+                                                    .payingWith(ADMIN_ACCOUNT)
+                                                    .via("wipeNonFungibleNegativeSerialTxn")
+                                                    .gas(GAS_TO_OFFER)
+                                                    .hasKnownStatus(CONTRACT_REVERT_EXECUTED),
+                                            contractCall(
+                                                            WIPE_CONTRACT,
+                                                            WIPE_NON_FUNGIBLE_TOKEN,
+                                                            asAddress(vanillaTokenID.get()),
+                                                            asAddress(accountID.get()),
+                                                            List.of(3L))
+                                                    .payingWith(ADMIN_ACCOUNT)
+                                                    .via("wipeNonFungibleSerialDoesNotExistsTxn")
+                                                    .gas(GAS_TO_OFFER)
+                                                    .hasKnownStatus(CONTRACT_REVERT_EXECUTED),
+                                            contractCall(
+                                                            WIPE_CONTRACT,
+                                                            WIPE_NON_FUNGIBLE_TOKEN,
+                                                            asAddress(vanillaTokenID.get()),
+                                                            asAddress(accountID.get()),
+                                                            List.of())
                                                     .payingWith(ADMIN_ACCOUNT)
                                                     .gas(GAS_TO_OFFER)
-                                                    .logged()
-//                                            contractCall(
-//                                                            WIPE_CONTRACT,
-//                                                            WIPE_NON_FUNGIBLE_TOKEN,
-//                                                            asAddress(vanillaTokenID.get()),
-//                                                            asAddress(accountID.get()),
-//                                                            serialNumbers)
-//                                                    .payingWith(ADMIN_ACCOUNT)
-//                                                    .via("wipeNonFungibleTxn")
-//                                                    .gas(GAS_TO_OFFER)
-                                    );
+                                                    .logged(),
+                                            contractCall(
+                                                            WIPE_CONTRACT,
+                                                            WIPE_NON_FUNGIBLE_TOKEN,
+                                                            asAddress(vanillaTokenID.get()),
+                                                            asAddress(accountID.get()),
+                                                            serialNumbers)
+                                                    .payingWith(ADMIN_ACCOUNT)
+                                                    .via("wipeNonFungibleTxn")
+                                                    .gas(GAS_TO_OFFER));
                                 }))
                 .then(
-//                        childRecordsCheck(
-//                                "wipeNonFungibleAccountDoesNotOwnWipeKeyTxn",
-//                                CONTRACT_REVERT_EXECUTED,
-//                                recordWith()
-//                                        .status(INVALID_SIGNATURE)
-//                                        .contractCallResult(
-//                                                resultWith()
-//                                                        .contractCallResult(
-//                                                                htsPrecompileResult()
-//                                                                        .withStatus(
-//                                                                                INVALID_SIGNATURE)))),
-//                        childRecordsCheck(
-//                                "wipeNonFungibleAccountDoesNotOwnTheSerialTxn",
-//                                CONTRACT_REVERT_EXECUTED,
-//                                recordWith()
-//                                        .status(ACCOUNT_DOES_NOT_OWN_WIPED_NFT)
-//                                        .contractCallResult(
-//                                                resultWith()
-//                                                        .contractCallResult(
-//                                                                htsPrecompileResult()
-//                                                                        .withStatus(
-//                                                                                ACCOUNT_DOES_NOT_OWN_WIPED_NFT)))),
-//                        childRecordsCheck(
-//                                "wipeNonFungibleNegativeSerialTxn",
-//                                CONTRACT_REVERT_EXECUTED,
-//                                recordWith()
-//                                        .status(INVALID_NFT_ID)
-//                                        .contractCallResult(
-//                                                resultWith()
-//                                                        .contractCallResult(
-//                                                                htsPrecompileResult()
-//                                                                        .withStatus(
-//                                                                                INVALID_NFT_ID)))),
-//                        childRecordsCheck(
-//                                "wipeNonFungibleSerialDoesNotExistsTxn",
-//                                CONTRACT_REVERT_EXECUTED,
-//                                recordWith()
-//                                        .status(INVALID_NFT_ID)
-//                                        .contractCallResult(
-//                                                resultWith()
-//                                                        .contractCallResult(
-//                                                                htsPrecompileResult()
-//                                                                        .withStatus(
-//                                                                                INVALID_NFT_ID)))),
+                        childRecordsCheck(
+                                "wipeNonFungibleAccountDoesNotOwnWipeKeyTxn",
+                                CONTRACT_REVERT_EXECUTED,
+                                recordWith()
+                                        .status(INVALID_SIGNATURE)
+                                        .contractCallResult(
+                                                resultWith()
+                                                        .contractCallResult(
+                                                                htsPrecompileResult()
+                                                                        .withStatus(
+                                                                                INVALID_SIGNATURE)))),
+                        childRecordsCheck(
+                                "wipeNonFungibleAccountDoesNotOwnTheSerialTxn",
+                                CONTRACT_REVERT_EXECUTED,
+                                recordWith()
+                                        .status(ACCOUNT_DOES_NOT_OWN_WIPED_NFT)
+                                        .contractCallResult(
+                                                resultWith()
+                                                        .contractCallResult(
+                                                                htsPrecompileResult()
+                                                                        .withStatus(
+                                                                                ACCOUNT_DOES_NOT_OWN_WIPED_NFT)))),
+                        childRecordsCheck(
+                                "wipeNonFungibleNegativeSerialTxn",
+                                CONTRACT_REVERT_EXECUTED,
+                                recordWith()
+                                        .status(INVALID_NFT_ID)
+                                        .contractCallResult(
+                                                resultWith()
+                                                        .contractCallResult(
+                                                                htsPrecompileResult()
+                                                                        .withStatus(
+                                                                                INVALID_NFT_ID)))),
+                        childRecordsCheck(
+                                "wipeNonFungibleSerialDoesNotExistsTxn",
+                                CONTRACT_REVERT_EXECUTED,
+                                recordWith()
+                                        .status(INVALID_NFT_ID)
+                                        .contractCallResult(
+                                                resultWith()
+                                                        .contractCallResult(
+                                                                htsPrecompileResult()
+                                                                        .withStatus(
+                                                                                INVALID_NFT_ID)))),
                         getTxnRecord("wipeNonFungibleEmptySerialTxn").andAllChildRecords().logged(),
                         childRecordsCheck(
                                 "wipeNonFungibleEmptySerialTxn",
@@ -366,8 +366,7 @@ public class WipeTokenAccountPrecompileSuite extends HapiApiSuite {
                                                 resultWith()
                                                         .contractCallResult(
                                                                 htsPrecompileResult()
-                                                                        .withStatus(
-                                                                                SUCCESS)))),
+                                                                        .withStatus(SUCCESS)))),
                         getTokenInfo(VANILLA_TOKEN).hasTotalSupply(1),
                         getAccountBalance(ACCOUNT).hasTokenBalance(VANILLA_TOKEN, 0));
     }

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/WipeTokenAccountPrecompileSuite.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/WipeTokenAccountPrecompileSuite.java
@@ -22,6 +22,7 @@ import static com.hedera.services.bdd.spec.assertions.TransactionRecordAsserts.r
 import static com.hedera.services.bdd.spec.infrastructure.providers.ops.crypto.RandomAccount.INITIAL_BALANCE;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getAccountBalance;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getTokenInfo;
+import static com.hedera.services.bdd.spec.queries.QueryVerbs.getTxnRecord;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.*;
 import static com.hedera.services.bdd.spec.transactions.token.TokenMovement.moving;
 import static com.hedera.services.bdd.spec.transactions.token.TokenMovement.movingUnique;
@@ -68,7 +69,9 @@ public class WipeTokenAccountPrecompileSuite extends HapiApiSuite {
 
     @Override
     public List<HapiApiSpec> getSpecsInSuite() {
-        return allOf(List.of(wipeFungibleTokenScenarios(), wipeNonFungibleTokenScenarios()));
+        return allOf(List.of(
+//                wipeFungibleTokenScenarios(),
+                wipeNonFungibleTokenScenarios()));
     }
 
     private HapiApiSpec wipeFungibleTokenScenarios() {
@@ -100,80 +103,112 @@ public class WipeTokenAccountPrecompileSuite extends HapiApiSuite {
                                 (spec, opLog) ->
                                         allRunFor(
                                                 spec,
+//                                                contractCall(
+//                                                                WIPE_CONTRACT,
+//                                                                WIPE_FUNGIBLE_TOKEN,
+//                                                                asAddress(vanillaTokenID.get()),
+//                                                                asAddress(accountID.get()),
+//                                                                10L)
+//                                                        .payingWith(ADMIN_ACCOUNT)
+//                                                        .via("accountDoesNotOwnWipeKeyTxn")
+//                                                        .gas(GAS_TO_OFFER)
+//                                                        .hasKnownStatus(CONTRACT_REVERT_EXECUTED),
+//                                                cryptoUpdate(ADMIN_ACCOUNT).key(WIPE_KEY),
+//                                                contractCall(
+//                                                                WIPE_CONTRACT,
+//                                                                WIPE_FUNGIBLE_TOKEN,
+//                                                                asAddress(vanillaTokenID.get()),
+//                                                                asAddress(accountID.get()),
+//                                                                1_000L)
+//                                                        .payingWith(ADMIN_ACCOUNT)
+//                                                        .via("amountLargerThanBalanceTxn")
+//                                                        .gas(GAS_TO_OFFER)
+//                                                        .hasKnownStatus(CONTRACT_REVERT_EXECUTED),
+//                                                contractCall(
+//                                                                WIPE_CONTRACT,
+//                                                                WIPE_FUNGIBLE_TOKEN,
+//                                                                asAddress(vanillaTokenID.get()),
+//                                                                asAddress(secondAccountID.get()),
+//                                                                10L)
+//                                                        .payingWith(ADMIN_ACCOUNT)
+//                                                        .via("accountDoesNotOwnTokensTxn")
+//                                                        .gas(GAS_TO_OFFER)
+//                                                        .hasKnownStatus(CONTRACT_REVERT_EXECUTED),
+//                                                contractCall(
+//                                                                WIPE_CONTRACT,
+//                                                                WIPE_FUNGIBLE_TOKEN,
+//                                                                asAddress(vanillaTokenID.get()),
+//                                                                asAddress(accountID.get()),
+//                                                                10L)
+//                                                        .payingWith(ADMIN_ACCOUNT)
+//                                                        .via("wipeFungibleTxn")
+//                                                        .gas(GAS_TO_OFFER),
                                                 contractCall(
-                                                                WIPE_CONTRACT,
-                                                                WIPE_FUNGIBLE_TOKEN,
-                                                                asAddress(vanillaTokenID.get()),
-                                                                asAddress(accountID.get()),
-                                                                10L)
+                                                        WIPE_CONTRACT,
+                                                        WIPE_FUNGIBLE_TOKEN,
+                                                        asAddress(vanillaTokenID.get()),
+                                                        asAddress(accountID.get()),
+                                                        0L)
                                                         .payingWith(ADMIN_ACCOUNT)
-                                                        .via("accountDoesNotOwnWipeKeyTxn")
+                                                        .via("wipeFungibleTxnWithZeroAmount")
                                                         .gas(GAS_TO_OFFER)
-                                                        .hasKnownStatus(CONTRACT_REVERT_EXECUTED),
-                                                cryptoUpdate(ADMIN_ACCOUNT).key(WIPE_KEY),
-                                                contractCall(
-                                                                WIPE_CONTRACT,
-                                                                WIPE_FUNGIBLE_TOKEN,
-                                                                asAddress(vanillaTokenID.get()),
-                                                                asAddress(accountID.get()),
-                                                                1_000L)
-                                                        .payingWith(ADMIN_ACCOUNT)
-                                                        .via("amountLargerThanBalanceTxn")
-                                                        .gas(GAS_TO_OFFER)
-                                                        .hasKnownStatus(CONTRACT_REVERT_EXECUTED),
-                                                contractCall(
-                                                                WIPE_CONTRACT,
-                                                                WIPE_FUNGIBLE_TOKEN,
-                                                                asAddress(vanillaTokenID.get()),
-                                                                asAddress(secondAccountID.get()),
-                                                                10L)
-                                                        .payingWith(ADMIN_ACCOUNT)
-                                                        .via("accountDoesNotOwnTokensTxn")
-                                                        .gas(GAS_TO_OFFER)
-                                                        .hasKnownStatus(CONTRACT_REVERT_EXECUTED),
-                                                contractCall(
-                                                                WIPE_CONTRACT,
-                                                                WIPE_FUNGIBLE_TOKEN,
-                                                                asAddress(vanillaTokenID.get()),
-                                                                asAddress(accountID.get()),
-                                                                10L)
-                                                        .payingWith(ADMIN_ACCOUNT)
-                                                        .via("wipeFungibleTxn")
-                                                        .gas(GAS_TO_OFFER))))
-                .then(
+                                                // negative amount throws run time exception as amount is uint64 in solidity file
+//                                                contractCall(
+//                                                        WIPE_CONTRACT,
+//                                                        WIPE_FUNGIBLE_TOKEN,
+//                                                        asAddress(vanillaTokenID.get()),
+//                                                        asAddress(accountID.get()),
+//                                                        -1L)
+//                                                        .payingWith(ADMIN_ACCOUNT)
+//                                                        .via("failedWipeFungibleTxn")
+//                                                        .gas(GAS_TO_OFFER)
+//                                                        .hasKnownStatus(CONTRACT_REVERT_EXECUTED)
+//                                                        .logged()
+                                        ))).then(
+//                        childRecordsCheck(
+//                                "accountDoesNotOwnWipeKeyTxn",
+//                                CONTRACT_REVERT_EXECUTED,
+//                                recordWith()
+//                                        .status(INVALID_SIGNATURE)
+//                                        .contractCallResult(
+//                                                resultWith()
+//                                                        .contractCallResult(
+//                                                                htsPrecompileResult()
+//                                                                        .withStatus(
+//                                                                                INVALID_SIGNATURE)))),
+//                        childRecordsCheck(
+//                                "amountLargerThanBalanceTxn",
+//                                CONTRACT_REVERT_EXECUTED,
+//                                recordWith()
+//                                        .status(INVALID_WIPING_AMOUNT)
+//                                        .contractCallResult(
+//                                                resultWith()
+//                                                        .contractCallResult(
+//                                                                htsPrecompileResult()
+//                                                                        .withStatus(
+//                                                                                INVALID_WIPING_AMOUNT)))),
+//                        childRecordsCheck(
+//                                "accountDoesNotOwnTokensTxn",
+//                                CONTRACT_REVERT_EXECUTED,
+//                                recordWith()
+//                                        .status(INVALID_WIPING_AMOUNT)
+//                                        .contractCallResult(
+//                                                resultWith()
+//                                                        .contractCallResult(
+//                                                                htsPrecompileResult()
+//                                                                        .withStatus(
+//                                                                                INVALID_WIPING_AMOUNT)))),
                         childRecordsCheck(
-                                "accountDoesNotOwnWipeKeyTxn",
-                                CONTRACT_REVERT_EXECUTED,
+                                "wipeFungibleTxnWithZeroAmount",
+                                SUCCESS,
                                 recordWith()
-                                        .status(INVALID_SIGNATURE)
+                                        .status(SUCCESS)
                                         .contractCallResult(
                                                 resultWith()
                                                         .contractCallResult(
                                                                 htsPrecompileResult()
                                                                         .withStatus(
-                                                                                INVALID_SIGNATURE)))),
-                        childRecordsCheck(
-                                "amountLargerThanBalanceTxn",
-                                CONTRACT_REVERT_EXECUTED,
-                                recordWith()
-                                        .status(INVALID_WIPING_AMOUNT)
-                                        .contractCallResult(
-                                                resultWith()
-                                                        .contractCallResult(
-                                                                htsPrecompileResult()
-                                                                        .withStatus(
-                                                                                INVALID_WIPING_AMOUNT)))),
-                        childRecordsCheck(
-                                "accountDoesNotOwnTokensTxn",
-                                CONTRACT_REVERT_EXECUTED,
-                                recordWith()
-                                        .status(INVALID_WIPING_AMOUNT)
-                                        .contractCallResult(
-                                                resultWith()
-                                                        .contractCallResult(
-                                                                htsPrecompileResult()
-                                                                        .withStatus(
-                                                                                INVALID_WIPING_AMOUNT)))),
+                                                                                SUCCESS)))),
                         getTokenInfo(VANILLA_TOKEN).hasTotalSupply(990),
                         getAccountBalance(ACCOUNT).hasTokenBalance(VANILLA_TOKEN, 490));
     }
@@ -213,104 +248,126 @@ public class WipeTokenAccountPrecompileSuite extends HapiApiSuite {
                                     serialNumbers.add(1L);
                                     allRunFor(
                                             spec,
+//                                            contractCall(
+//                                                            WIPE_CONTRACT,
+//                                                            WIPE_NON_FUNGIBLE_TOKEN,
+//                                                            asAddress(vanillaTokenID.get()),
+//                                                            asAddress(accountID.get()),
+//                                                            serialNumbers)
+//                                                    .payingWith(ADMIN_ACCOUNT)
+//                                                    .via(
+//                                                            "wipeNonFungibleAccountDoesNotOwnWipeKeyTxn")
+//                                                    .gas(GAS_TO_OFFER)
+//                                                    .hasKnownStatus(CONTRACT_REVERT_EXECUTED),
+//                                            cryptoUpdate(ADMIN_ACCOUNT).key(WIPE_KEY),
+//                                            contractCall(
+//                                                            WIPE_CONTRACT,
+//                                                            WIPE_NON_FUNGIBLE_TOKEN,
+//                                                            asAddress(vanillaTokenID.get()),
+//                                                            asAddress(accountID.get()),
+//                                                            List.of(2L))
+//                                                    .payingWith(ADMIN_ACCOUNT)
+//                                                    .via(
+//                                                            "wipeNonFungibleAccountDoesNotOwnTheSerialTxn")
+//                                                    .gas(GAS_TO_OFFER)
+//                                                    .hasKnownStatus(CONTRACT_REVERT_EXECUTED),
+//                                            contractCall(
+//                                                            WIPE_CONTRACT,
+//                                                            WIPE_NON_FUNGIBLE_TOKEN,
+//                                                            asAddress(vanillaTokenID.get()),
+//                                                            asAddress(accountID.get()),
+//                                                            List.of(-2L))
+//                                                    .payingWith(ADMIN_ACCOUNT)
+//                                                    .via("wipeNonFungibleNegativeSerialTxn")
+//                                                    .gas(GAS_TO_OFFER)
+//                                                    .hasKnownStatus(CONTRACT_REVERT_EXECUTED),
+//                                            contractCall(
+//                                                            WIPE_CONTRACT,
+//                                                            WIPE_NON_FUNGIBLE_TOKEN,
+//                                                            asAddress(vanillaTokenID.get()),
+//                                                            asAddress(accountID.get()),
+//                                                            List.of(3L))
+//                                                    .payingWith(ADMIN_ACCOUNT)
+//                                                    .via("wipeNonFungibleSerialDoesNotExistsTxn")
+//                                                    .gas(GAS_TO_OFFER)
+//                                                    .hasKnownStatus(CONTRACT_REVERT_EXECUTED),
                                             contractCall(
-                                                            WIPE_CONTRACT,
-                                                            WIPE_NON_FUNGIBLE_TOKEN,
-                                                            asAddress(vanillaTokenID.get()),
-                                                            asAddress(accountID.get()),
-                                                            serialNumbers)
+                                                    WIPE_CONTRACT,
+                                                    WIPE_NON_FUNGIBLE_TOKEN,
+                                                    asAddress(vanillaTokenID.get()),
+                                                    asAddress(accountID.get()),
+                                                    List.of())
                                                     .payingWith(ADMIN_ACCOUNT)
-                                                    .via(
-                                                            "wipeNonFungibleAccountDoesNotOwnWipeKeyTxn")
                                                     .gas(GAS_TO_OFFER)
-                                                    .hasKnownStatus(CONTRACT_REVERT_EXECUTED),
-                                            cryptoUpdate(ADMIN_ACCOUNT).key(WIPE_KEY),
-                                            contractCall(
-                                                            WIPE_CONTRACT,
-                                                            WIPE_NON_FUNGIBLE_TOKEN,
-                                                            asAddress(vanillaTokenID.get()),
-                                                            asAddress(accountID.get()),
-                                                            List.of(2L))
-                                                    .payingWith(ADMIN_ACCOUNT)
-                                                    .via(
-                                                            "wipeNonFungibleAccountDoesNotOwnTheSerialTxn")
-                                                    .gas(GAS_TO_OFFER)
-                                                    .hasKnownStatus(CONTRACT_REVERT_EXECUTED),
-                                            contractCall(
-                                                            WIPE_CONTRACT,
-                                                            WIPE_NON_FUNGIBLE_TOKEN,
-                                                            asAddress(vanillaTokenID.get()),
-                                                            asAddress(accountID.get()),
-                                                            List.of(-2L))
-                                                    .payingWith(ADMIN_ACCOUNT)
-                                                    .via("wipeNonFungibleNegativeSerialTxn")
-                                                    .gas(GAS_TO_OFFER)
-                                                    .hasKnownStatus(CONTRACT_REVERT_EXECUTED),
-                                            contractCall(
-                                                            WIPE_CONTRACT,
-                                                            WIPE_NON_FUNGIBLE_TOKEN,
-                                                            asAddress(vanillaTokenID.get()),
-                                                            asAddress(accountID.get()),
-                                                            List.of(3L))
-                                                    .payingWith(ADMIN_ACCOUNT)
-                                                    .via("wipeNonFungibleSerialDoesNotExistsTxn")
-                                                    .gas(GAS_TO_OFFER)
-                                                    .hasKnownStatus(CONTRACT_REVERT_EXECUTED),
-                                            contractCall(
-                                                            WIPE_CONTRACT,
-                                                            WIPE_NON_FUNGIBLE_TOKEN,
-                                                            asAddress(vanillaTokenID.get()),
-                                                            asAddress(accountID.get()),
-                                                            serialNumbers)
-                                                    .payingWith(ADMIN_ACCOUNT)
-                                                    .via("wipeNonFungibleTxn")
-                                                    .gas(GAS_TO_OFFER));
+                                                    .logged()
+//                                            contractCall(
+//                                                            WIPE_CONTRACT,
+//                                                            WIPE_NON_FUNGIBLE_TOKEN,
+//                                                            asAddress(vanillaTokenID.get()),
+//                                                            asAddress(accountID.get()),
+//                                                            serialNumbers)
+//                                                    .payingWith(ADMIN_ACCOUNT)
+//                                                    .via("wipeNonFungibleTxn")
+//                                                    .gas(GAS_TO_OFFER)
+                                    );
                                 }))
                 .then(
+//                        childRecordsCheck(
+//                                "wipeNonFungibleAccountDoesNotOwnWipeKeyTxn",
+//                                CONTRACT_REVERT_EXECUTED,
+//                                recordWith()
+//                                        .status(INVALID_SIGNATURE)
+//                                        .contractCallResult(
+//                                                resultWith()
+//                                                        .contractCallResult(
+//                                                                htsPrecompileResult()
+//                                                                        .withStatus(
+//                                                                                INVALID_SIGNATURE)))),
+//                        childRecordsCheck(
+//                                "wipeNonFungibleAccountDoesNotOwnTheSerialTxn",
+//                                CONTRACT_REVERT_EXECUTED,
+//                                recordWith()
+//                                        .status(ACCOUNT_DOES_NOT_OWN_WIPED_NFT)
+//                                        .contractCallResult(
+//                                                resultWith()
+//                                                        .contractCallResult(
+//                                                                htsPrecompileResult()
+//                                                                        .withStatus(
+//                                                                                ACCOUNT_DOES_NOT_OWN_WIPED_NFT)))),
+//                        childRecordsCheck(
+//                                "wipeNonFungibleNegativeSerialTxn",
+//                                CONTRACT_REVERT_EXECUTED,
+//                                recordWith()
+//                                        .status(INVALID_NFT_ID)
+//                                        .contractCallResult(
+//                                                resultWith()
+//                                                        .contractCallResult(
+//                                                                htsPrecompileResult()
+//                                                                        .withStatus(
+//                                                                                INVALID_NFT_ID)))),
+//                        childRecordsCheck(
+//                                "wipeNonFungibleSerialDoesNotExistsTxn",
+//                                CONTRACT_REVERT_EXECUTED,
+//                                recordWith()
+//                                        .status(INVALID_NFT_ID)
+//                                        .contractCallResult(
+//                                                resultWith()
+//                                                        .contractCallResult(
+//                                                                htsPrecompileResult()
+//                                                                        .withStatus(
+//                                                                                INVALID_NFT_ID)))),
+                        getTxnRecord("wipeNonFungibleEmptySerialTxn").andAllChildRecords().logged(),
                         childRecordsCheck(
-                                "wipeNonFungibleAccountDoesNotOwnWipeKeyTxn",
-                                CONTRACT_REVERT_EXECUTED,
+                                "wipeNonFungibleEmptySerialTxn",
+                                SUCCESS,
                                 recordWith()
-                                        .status(INVALID_SIGNATURE)
+                                        .status(SUCCESS)
                                         .contractCallResult(
                                                 resultWith()
                                                         .contractCallResult(
                                                                 htsPrecompileResult()
                                                                         .withStatus(
-                                                                                INVALID_SIGNATURE)))),
-                        childRecordsCheck(
-                                "wipeNonFungibleAccountDoesNotOwnTheSerialTxn",
-                                CONTRACT_REVERT_EXECUTED,
-                                recordWith()
-                                        .status(ACCOUNT_DOES_NOT_OWN_WIPED_NFT)
-                                        .contractCallResult(
-                                                resultWith()
-                                                        .contractCallResult(
-                                                                htsPrecompileResult()
-                                                                        .withStatus(
-                                                                                ACCOUNT_DOES_NOT_OWN_WIPED_NFT)))),
-                        childRecordsCheck(
-                                "wipeNonFungibleNegativeSerialTxn",
-                                CONTRACT_REVERT_EXECUTED,
-                                recordWith()
-                                        .status(INVALID_NFT_ID)
-                                        .contractCallResult(
-                                                resultWith()
-                                                        .contractCallResult(
-                                                                htsPrecompileResult()
-                                                                        .withStatus(
-                                                                                INVALID_NFT_ID)))),
-                        childRecordsCheck(
-                                "wipeNonFungibleSerialDoesNotExistsTxn",
-                                CONTRACT_REVERT_EXECUTED,
-                                recordWith()
-                                        .status(INVALID_NFT_ID)
-                                        .contractCallResult(
-                                                resultWith()
-                                                        .contractCallResult(
-                                                                htsPrecompileResult()
-                                                                        .withStatus(
-                                                                                INVALID_NFT_ID)))),
+                                                                                SUCCESS)))),
                         getTokenInfo(VANILLA_TOKEN).hasTotalSupply(1),
                         getAccountBalance(ACCOUNT).hasTokenBalance(VANILLA_TOKEN, 0));
     }

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/WipeTokenAccountPrecompileSuite.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/WipeTokenAccountPrecompileSuite.java
@@ -275,24 +275,6 @@ public class WipeTokenAccountPrecompileSuite extends HapiApiSuite {
                                                     .via("wipeNonFungibleSerialDoesNotExistsTxn")
                                                     .gas(GAS_TO_OFFER)
                                                     .hasKnownStatus(CONTRACT_REVERT_EXECUTED),
-                                            //
-                                            // contractCall(
-                                            //
-                                            //      WIPE_CONTRACT,
-                                            //
-                                            //      WIPE_NON_FUNGIBLE_TOKEN,
-                                            //
-                                            //      asAddress(vanillaTokenID.get()),
-                                            //
-                                            //      asAddress(accountID.get()),
-                                            //
-                                            //      List.of())
-                                            //
-                                            // .payingWith(ADMIN_ACCOUNT)
-                                            //
-                                            // .gas(GAS_TO_OFFER)
-                                            //
-                                            // .logged(),
                                             contractCall(
                                                             WIPE_CONTRACT,
                                                             WIPE_NON_FUNGIBLE_TOKEN,
@@ -348,21 +330,6 @@ public class WipeTokenAccountPrecompileSuite extends HapiApiSuite {
                                                                 htsPrecompileResult()
                                                                         .withStatus(
                                                                                 INVALID_NFT_ID)))),
-                        //
-                        // getTxnRecord("wipeNonFungibleEmptySerialTxn").andAllChildRecords().logged(),
-                        //                        childRecordsCheck(
-                        //                                "wipeNonFungibleEmptySerialTxn",
-                        //                                SUCCESS,
-                        //                                recordWith()
-                        //                                        .status(SUCCESS)
-                        //                                        .contractCallResult(
-                        //                                                resultWith()
-                        //
-                        // .contractCallResult(
-                        //
-                        // htsPrecompileResult()
-                        //
-                        // .withStatus(SUCCESS)))),
                         getTokenInfo(VANILLA_TOKEN).hasTotalSupply(1),
                         getAccountBalance(ACCOUNT).hasTokenBalance(VANILLA_TOKEN, 0));
     }

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/WipeTokenAccountPrecompileSuite.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/WipeTokenAccountPrecompileSuite.java
@@ -22,7 +22,6 @@ import static com.hedera.services.bdd.spec.assertions.TransactionRecordAsserts.r
 import static com.hedera.services.bdd.spec.infrastructure.providers.ops.crypto.RandomAccount.INITIAL_BALANCE;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getAccountBalance;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getTokenInfo;
-import static com.hedera.services.bdd.spec.queries.QueryVerbs.getTxnRecord;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.*;
 import static com.hedera.services.bdd.spec.transactions.token.TokenMovement.moving;
 import static com.hedera.services.bdd.spec.transactions.token.TokenMovement.movingUnique;
@@ -149,23 +148,7 @@ public class WipeTokenAccountPrecompileSuite extends HapiApiSuite {
                                                                 0L)
                                                         .payingWith(ADMIN_ACCOUNT)
                                                         .via("wipeFungibleTxnWithZeroAmount")
-                                                        .gas(GAS_TO_OFFER),
-                                                //
-                                                // negative amount throws run time exception as
-                                                //
-                                                // amount is uint64 in solidity file
-
-                                                contractCall(
-                                                                WIPE_CONTRACT,
-                                                                WIPE_FUNGIBLE_TOKEN,
-                                                                asAddress(vanillaTokenID.get()),
-                                                                asAddress(accountID.get()),
-                                                                -1L)
-                                                        .payingWith(ADMIN_ACCOUNT)
-                                                        .via("failedWipeFungibleTxn")
-                                                        .gas(GAS_TO_OFFER)
-                                                        .hasKnownStatus(CONTRACT_REVERT_EXECUTED)
-                                                        .logged())))
+                                                        .gas(GAS_TO_OFFER))))
                 .then(
                         childRecordsCheck(
                                 "accountDoesNotOwnWipeKeyTxn",
@@ -292,15 +275,24 @@ public class WipeTokenAccountPrecompileSuite extends HapiApiSuite {
                                                     .via("wipeNonFungibleSerialDoesNotExistsTxn")
                                                     .gas(GAS_TO_OFFER)
                                                     .hasKnownStatus(CONTRACT_REVERT_EXECUTED),
-                                            contractCall(
-                                                            WIPE_CONTRACT,
-                                                            WIPE_NON_FUNGIBLE_TOKEN,
-                                                            asAddress(vanillaTokenID.get()),
-                                                            asAddress(accountID.get()),
-                                                            List.of())
-                                                    .payingWith(ADMIN_ACCOUNT)
-                                                    .gas(GAS_TO_OFFER)
-                                                    .logged(),
+                                            //
+                                            // contractCall(
+                                            //
+                                            //      WIPE_CONTRACT,
+                                            //
+                                            //      WIPE_NON_FUNGIBLE_TOKEN,
+                                            //
+                                            //      asAddress(vanillaTokenID.get()),
+                                            //
+                                            //      asAddress(accountID.get()),
+                                            //
+                                            //      List.of())
+                                            //
+                                            // .payingWith(ADMIN_ACCOUNT)
+                                            //
+                                            // .gas(GAS_TO_OFFER)
+                                            //
+                                            // .logged(),
                                             contractCall(
                                                             WIPE_CONTRACT,
                                                             WIPE_NON_FUNGIBLE_TOKEN,
@@ -356,17 +348,21 @@ public class WipeTokenAccountPrecompileSuite extends HapiApiSuite {
                                                                 htsPrecompileResult()
                                                                         .withStatus(
                                                                                 INVALID_NFT_ID)))),
-                        getTxnRecord("wipeNonFungibleEmptySerialTxn").andAllChildRecords().logged(),
-                        childRecordsCheck(
-                                "wipeNonFungibleEmptySerialTxn",
-                                SUCCESS,
-                                recordWith()
-                                        .status(SUCCESS)
-                                        .contractCallResult(
-                                                resultWith()
-                                                        .contractCallResult(
-                                                                htsPrecompileResult()
-                                                                        .withStatus(SUCCESS)))),
+                        //
+                        // getTxnRecord("wipeNonFungibleEmptySerialTxn").andAllChildRecords().logged(),
+                        //                        childRecordsCheck(
+                        //                                "wipeNonFungibleEmptySerialTxn",
+                        //                                SUCCESS,
+                        //                                recordWith()
+                        //                                        .status(SUCCESS)
+                        //                                        .contractCallResult(
+                        //                                                resultWith()
+                        //
+                        // .contractCallResult(
+                        //
+                        // htsPrecompileResult()
+                        //
+                        // .withStatus(SUCCESS)))),
                         getTokenInfo(VANILLA_TOKEN).hasTotalSupply(1),
                         getAccountBalance(ACCOUNT).hasTokenBalance(VANILLA_TOKEN, 0));
     }

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/schedule/ScheduleExecutionSpecs.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/schedule/ScheduleExecutionSpecs.java
@@ -221,8 +221,7 @@ public class ScheduleExecutionSpecs extends HapiApiSuite {
                                 scheduledPermissionedFileUpdateUnauthorizedPayerFails(),
                                 scheduledSystemDeleteWorksAsExpected(),
                                 scheduledSystemDeleteUnauthorizedPayerFails(isLongTermEnabled),
-                                congestionPricingAffectsImmediateScheduleExecution()
-                                ));
+                                congestionPricingAffectsImmediateScheduleExecution()));
     }
 
     private HapiApiSpec scheduledBurnFailsWithInvalidTxBody() {

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/schedule/ScheduleExecutionSpecs.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/schedule/ScheduleExecutionSpecs.java
@@ -561,7 +561,6 @@ public class ScheduleExecutionSpecs extends HapiApiSuite {
     }
 
     private HapiApiSpec scheduledMintFailsWithInvalidAmount() {
-        final var failingTxn = "failingTxn";
         final var zeroAmountTxn = "zeroAmountTxn";
         return defaultHapiSpec("ScheduledMintFailsWithInvalidAmount")
                 .given(

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/schedule/ScheduleExecutionSpecs.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/schedule/ScheduleExecutionSpecs.java
@@ -89,6 +89,7 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_CHUNK_
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_FILE_ID;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_NFT_ID;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_TOKEN_BURN_AMOUNT;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_TOKEN_BURN_METADATA;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_TOKEN_MINT_AMOUNT;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_TRANSACTION_BODY;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.MESSAGE_SIZE_TOO_LARGE;
@@ -220,7 +221,8 @@ public class ScheduleExecutionSpecs extends HapiApiSuite {
                                 scheduledPermissionedFileUpdateUnauthorizedPayerFails(),
                                 scheduledSystemDeleteWorksAsExpected(),
                                 scheduledSystemDeleteUnauthorizedPayerFails(isLongTermEnabled),
-                                congestionPricingAffectsImmediateScheduleExecution()));
+                                congestionPricingAffectsImmediateScheduleExecution()
+                                ));
     }
 
     private HapiApiSpec scheduledBurnFailsWithInvalidTxBody() {
@@ -479,7 +481,7 @@ public class ScheduleExecutionSpecs extends HapiApiSuite {
                 .then(
                         getTxnRecord(successTxn)
                                 .scheduled()
-                                .hasPriority(recordWith().status(SUCCESS)),
+                                .hasPriority(recordWith().status(INVALID_TOKEN_BURN_METADATA)),
                         getTokenInfo(A_TOKEN).hasTotalSupply(0));
     }
 

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/schedule/ScheduleExecutionSpecs.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/schedule/ScheduleExecutionSpecs.java
@@ -459,7 +459,6 @@ public class ScheduleExecutionSpecs extends HapiApiSuite {
     }
 
     private HapiApiSpec scheduledBurnForUniqueSucceedsWithExistingAmount() {
-        String failingTxn = "failingTxn";
         return defaultHapiSpec("scheduledBurnForUniqueSucceedsWithExistingAmount")
                 .given(
                         cryptoCreate("treasury"),

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenCreateSpecs.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenCreateSpecs.java
@@ -28,6 +28,7 @@ import static com.hedera.services.bdd.spec.queries.crypto.ExpectedTokenRel.relat
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoCreate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoDelete;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoTransfer;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.tokenAssociate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.tokenCreate;
 import static com.hedera.services.bdd.spec.transactions.token.CustomFeeSpecs.fixedHbarFee;
 import static com.hedera.services.bdd.spec.transactions.token.CustomFeeSpecs.fixedHbarFeeInheritingRoyaltyCollector;
@@ -55,7 +56,6 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.CUSTOM_ROYALTY
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.EMPTY_TOKEN_TRANSFER_ACCOUNT_AMOUNTS;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.FRACTIONAL_FEE_MAX_AMOUNT_LESS_THAN_MIN_AMOUNT;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.FRACTION_DIVIDES_BY_ZERO;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_ACCOUNT_AMOUNTS;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_AUTORENEW_ACCOUNT;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_CUSTOM_FEE_COLLECTOR;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_EXPIRATION_TIME;
@@ -70,6 +70,7 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_TREASU
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_ZERO_BYTE_IN_STRING;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.MISSING_TOKEN_NAME;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.MISSING_TOKEN_SYMBOL;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OK;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.ROYALTY_FRACTION_CANNOT_EXCEED_ONE;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SUCCESS;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TOKEN_HAS_NO_FREEZE_KEY;
@@ -1110,8 +1111,9 @@ public class TokenCreateSpecs extends HapiApiSuite {
                                         moving(1, A_TOKEN).between(TOKEN_TREASURY, FIRST_USER))
                                 .dontFullyAggregateTokenTransfers()
                                 .hasPrecheck(ACCOUNT_REPEATED_IN_ACCOUNT_AMOUNTS),
+                        tokenAssociate(FIRST_USER, A_TOKEN),
                         cryptoTransfer(moving(0, A_TOKEN).between(TOKEN_TREASURY, FIRST_USER))
-                                .hasPrecheck(INVALID_ACCOUNT_AMOUNTS),
+                                .hasPrecheck(OK),
                         cryptoTransfer(moving(10, A_TOKEN).from(TOKEN_TREASURY))
                                 .hasPrecheck(TRANSFERS_NOT_ZERO_SUM_FOR_TOKEN),
                         cryptoTransfer(moving(10, A_TOKEN).empty())

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenManagementSpecs.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenManagementSpecs.java
@@ -42,7 +42,6 @@ import static com.hedera.services.bdd.spec.utilops.UtilVerbs.newKeyNamed;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.ACCOUNT_FROZEN_FOR_TOKEN;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.ACCOUNT_KYC_NOT_GRANTED_FOR_TOKEN;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.CANNOT_WIPE_TOKEN_TREASURY_ACCOUNT;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.FAIL_INVALID;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INSUFFICIENT_TOKEN_BALANCE;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_ACCOUNT_ID;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_SIGNATURE;
@@ -152,7 +151,8 @@ public class TokenManagementSpecs extends HapiApiSuite {
                         burnToken(fungible, 0),
                         burnToken(nft, List.of()).hasKnownStatus(INVALID_TOKEN_BURN_METADATA),
                         wipeTokenAccount(fungible, civilian, 0),
-                        wipeTokenAccount(nft, civilian, List.of()).hasKnownStatus(FAIL_INVALID),
+                        wipeTokenAccount(nft, civilian, List.of())
+                                .hasKnownStatus(INVALID_WIPING_AMOUNT),
                         getAccountInfo(TOKEN_TREASURY)
                                 .hasToken(relationshipWith(fungible).balance(8))
                                 .hasOwnedNfts(0)

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenManagementSpecs.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenManagementSpecs.java
@@ -46,6 +46,7 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_SIGNAT
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_TOKEN_BURN_AMOUNT;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_TOKEN_MINT_AMOUNT;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_WIPING_AMOUNT;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OK;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TOKEN_HAS_NO_KYC_KEY;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TOKEN_HAS_NO_SUPPLY_KEY;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TOKEN_HAS_NO_WIPE_KEY;
@@ -452,9 +453,11 @@ public class TokenManagementSpecs extends HapiApiSuite {
                                 .hasKnownStatus(TOKEN_HAS_NO_SUPPLY_KEY),
                         mintToken("supple", Long.MAX_VALUE)
                                 .hasKnownStatus(INVALID_TOKEN_MINT_AMOUNT),
-                        mintToken("supple", 0).hasPrecheck(INVALID_TOKEN_MINT_AMOUNT),
+                        mintToken("supple", 0).hasPrecheck(OK),
+                        mintToken("supple", -1).hasPrecheck(INVALID_TOKEN_MINT_AMOUNT),
                         burnToken("supple", 2).hasKnownStatus(INVALID_TOKEN_BURN_AMOUNT),
-                        burnToken("supple", 0).hasPrecheck(INVALID_TOKEN_BURN_AMOUNT));
+                        burnToken("supple", 0).hasPrecheck(OK),
+                        burnToken("supple", -1).hasPrecheck(INVALID_TOKEN_BURN_AMOUNT));
     }
 
     @Override

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenManagementSpecs.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenManagementSpecs.java
@@ -84,19 +84,19 @@ public class TokenManagementSpecs extends HapiApiSuite {
     public List<HapiApiSpec> getSpecsInSuite() {
         return List.of(
                 new HapiApiSpec[] {
-                    //                    freezeMgmtSuccessCasesWork(),
-                    //                    kycMgmtFailureCasesWork(),
-                    //                    kycMgmtSuccessCasesWork(),
-                    //                    supplyMgmtSuccessCasesWork(),
-                    //                    wipeAccountFailureCasesWork(),
-                    //                    wipeAccountSuccessCasesWork(),
-                    //                    supplyMgmtFailureCasesWork(),
-                    //                    burnTokenFailsDueToInsufficientTreasuryBalance(),
-                    //                    frozenTreasuryCannotBeMintedOrBurned(),
-                    //                    revokedKYCTreasuryCannotBeMintedOrBurned(),
-                    //                    fungibleCommonMaxSupplyReachWork(),
-                    //                    mintingMaxLongValueWorks(),
-                    //                    nftMintProvidesMintedNftsAndNewTotalSupply(),
+                    freezeMgmtSuccessCasesWork(),
+                    kycMgmtFailureCasesWork(),
+                    kycMgmtSuccessCasesWork(),
+                    supplyMgmtSuccessCasesWork(),
+                    wipeAccountFailureCasesWork(),
+                    wipeAccountSuccessCasesWork(),
+                    supplyMgmtFailureCasesWork(),
+                    burnTokenFailsDueToInsufficientTreasuryBalance(),
+                    frozenTreasuryCannotBeMintedOrBurned(),
+                    revokedKYCTreasuryCannotBeMintedOrBurned(),
+                    fungibleCommonMaxSupplyReachWork(),
+                    mintingMaxLongValueWorks(),
+                    nftMintProvidesMintedNftsAndNewTotalSupply(),
                     zeroUnitTokenOperationsWorkAsExpected()
                 });
     }

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenManagementSpecs.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenManagementSpecs.java
@@ -197,6 +197,8 @@ public class TokenManagementSpecs extends HapiApiSuite {
                         getAccountBalance(TOKEN_TREASURY).hasTokenBalance(wipeableToken, 500),
                         getAccountInfo("misc").logged(),
                         wipeTokenAccount(wipeableToken, "misc", 500).via("wipeTxn"),
+                        getAccountInfo("misc").logged(),
+                        wipeTokenAccount(wipeableToken, "misc", 0).via("wipeWithZeroAmount"),
                         getAccountInfo("misc").logged())
                 .then(
                         getAccountBalance("misc").hasTokenBalance(wipeableToken, 0),
@@ -252,8 +254,6 @@ public class TokenManagementSpecs extends HapiApiSuite {
                         wipeTokenAccount(anotherWipeableToken, "misc", 501)
                                 .hasKnownStatus(INVALID_WIPING_AMOUNT),
                         wipeTokenAccount(anotherWipeableToken, "misc", -1)
-                                .hasPrecheck(INVALID_WIPING_AMOUNT),
-                        wipeTokenAccount(anotherWipeableToken, "misc", 0)
                                 .hasPrecheck(INVALID_WIPING_AMOUNT));
     }
 

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenManagementSpecs.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenManagementSpecs.java
@@ -42,11 +42,14 @@ import static com.hedera.services.bdd.spec.utilops.UtilVerbs.newKeyNamed;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.ACCOUNT_FROZEN_FOR_TOKEN;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.ACCOUNT_KYC_NOT_GRANTED_FOR_TOKEN;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.CANNOT_WIPE_TOKEN_TREASURY_ACCOUNT;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.FAIL_INVALID;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INSUFFICIENT_TOKEN_BALANCE;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_ACCOUNT_ID;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_SIGNATURE;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_TOKEN_BURN_AMOUNT;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_TOKEN_BURN_METADATA;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_TOKEN_MINT_AMOUNT;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_TOKEN_MINT_METADATA;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_WIPING_AMOUNT;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OK;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TOKEN_HAS_NO_KYC_KEY;
@@ -81,19 +84,19 @@ public class TokenManagementSpecs extends HapiApiSuite {
     public List<HapiApiSpec> getSpecsInSuite() {
         return List.of(
                 new HapiApiSpec[] {
-                    freezeMgmtSuccessCasesWork(),
-                    kycMgmtFailureCasesWork(),
-                    kycMgmtSuccessCasesWork(),
-                    supplyMgmtSuccessCasesWork(),
-                    wipeAccountFailureCasesWork(),
-                    wipeAccountSuccessCasesWork(),
-                    supplyMgmtFailureCasesWork(),
-                    burnTokenFailsDueToInsufficientTreasuryBalance(),
-                    frozenTreasuryCannotBeMintedOrBurned(),
-                    revokedKYCTreasuryCannotBeMintedOrBurned(),
-                    fungibleCommonMaxSupplyReachWork(),
-                    mintingMaxLongValueWorks(),
-                    nftMintProvidesMintedNftsAndNewTotalSupply(),
+                    //                    freezeMgmtSuccessCasesWork(),
+                    //                    kycMgmtFailureCasesWork(),
+                    //                    kycMgmtSuccessCasesWork(),
+                    //                    supplyMgmtSuccessCasesWork(),
+                    //                    wipeAccountFailureCasesWork(),
+                    //                    wipeAccountSuccessCasesWork(),
+                    //                    supplyMgmtFailureCasesWork(),
+                    //                    burnTokenFailsDueToInsufficientTreasuryBalance(),
+                    //                    frozenTreasuryCannotBeMintedOrBurned(),
+                    //                    revokedKYCTreasuryCannotBeMintedOrBurned(),
+                    //                    fungibleCommonMaxSupplyReachWork(),
+                    //                    mintingMaxLongValueWorks(),
+                    //                    nftMintProvidesMintedNftsAndNewTotalSupply(),
                     zeroUnitTokenOperationsWorkAsExpected()
                 });
     }
@@ -144,12 +147,12 @@ public class TokenManagementSpecs extends HapiApiSuite {
                 .then(
                         cryptoTransfer(moving(0, fungible).between(TOKEN_TREASURY, civilian))
                                 .logged(),
-                        mintToken(fungible, 0).logged(),
-                        mintToken(nft, List.of()).logged(),
-                        burnToken(fungible, 0).logged(),
-                        burnToken(nft, List.of()).logged(),
-                        wipeTokenAccount(fungible, civilian, 0).logged(),
-                        wipeTokenAccount(nft, civilian, List.of()).logged(),
+                        mintToken(fungible, 0),
+                        mintToken(nft, List.of()).hasKnownStatus(INVALID_TOKEN_MINT_METADATA),
+                        burnToken(fungible, 0),
+                        burnToken(nft, List.of()).hasKnownStatus(INVALID_TOKEN_BURN_METADATA),
+                        wipeTokenAccount(fungible, civilian, 0),
+                        wipeTokenAccount(nft, civilian, List.of()).hasKnownStatus(FAIL_INVALID),
                         getAccountInfo(TOKEN_TREASURY)
                                 .hasToken(relationshipWith(fungible).balance(8))
                                 .hasOwnedNfts(0)

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/token/UniqueTokenManagementSpecs.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/token/UniqueTokenManagementSpecs.java
@@ -787,7 +787,11 @@ public class UniqueTokenManagementSpecs extends HapiApiSuite {
                 .when(
                         wipeTokenAccount(A_TOKEN, "account", List.of(1L, 2L))
                                 .hasKnownStatus(INVALID_WIPING_AMOUNT)
-                                .via("wipeTx"))
+                                .via("wipeTx"),
+                        wipeTokenAccount(A_TOKEN, "account", List.of())
+                                .hasKnownStatus(OK)
+                                .via("wipeEmptySerialTx")
+                )
                 .then(
                         getTokenInfo(A_TOKEN).hasTotalSupply(10),
                         getTxnRecord("wipeTx").showsNoTransfers(),

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/token/UniqueTokenManagementSpecs.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/token/UniqueTokenManagementSpecs.java
@@ -790,8 +790,7 @@ public class UniqueTokenManagementSpecs extends HapiApiSuite {
                                 .via("wipeTx"),
                         wipeTokenAccount(A_TOKEN, "account", List.of())
                                 .hasKnownStatus(OK)
-                                .via("wipeEmptySerialTx")
-                )
+                                .via("wipeEmptySerialTx"))
                 .then(
                         getTokenInfo(A_TOKEN).hasTotalSupply(10),
                         getTxnRecord("wipeTx").showsNoTransfers(),


### PR DESCRIPTION
Fixes #3961 #3962 #3960 

Related to [HIP-564](https://hips.hedera.com/hip/hip-564)

- Allowed zero unit fungible token changes in `TokenTransfers`, `BurnLogic`, `MintLogic` and `WipeLogic`
- If no fungible/non-fungible units are present in a transfer it fails in the handle transaction.
- Added unit tests for the same
- Test plan is added [here](https://www.notion.so/swirldslabs/HIP-564-Zero-Unit-Token-Operations-in-Smart-Contracts-Test-Plan-32eee41855694fa086b9addb4f7ff303)