### PR TITLE
Update the new develop branch to ensure all workflows are triggering appropriately

### DIFF
--- a/.github/workflows/flow-build-application.yaml
+++ b/.github/workflows/flow-build-application.yaml
@@ -69,7 +69,7 @@ on:
         default: "wrapper"
   push:
     branches:
-      - master
+      - develop
       - main
 
 defaults:

--- a/.github/workflows/flow-deploy-release-artifact.yaml
+++ b/.github/workflows/flow-deploy-release-artifact.yaml
@@ -53,8 +53,7 @@ on:
         default: "wrapper"
   push:
     branches:
-      - master
-      - main
+      - develop
     tags:
       - "v[0-9]+.[0-9]+.[0-9]+-?*"
 


### PR DESCRIPTION
## Description

Updates the Github Action workflows to properly trigger on the new `develop` branch and to stop triggering on the `master` and `main` branches where appropriate.

### Related Issues

- Closes #4063 