### PR TITLE
Support yahcli staking

### DIFF
--- a/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/crypto/HapiCryptoUpdate.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/crypto/HapiCryptoUpdate.java
@@ -15,6 +15,11 @@
  */
 package com.hedera.services.bdd.spec.transactions.crypto;
 
+import static com.hedera.services.bdd.spec.PropertySource.asAccountString;
+import static com.hedera.services.bdd.spec.queries.QueryVerbs.getAccountInfo;
+import static com.hedera.services.bdd.spec.transactions.TxnUtils.*;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SUCCESS;
+
 import com.google.common.base.MoreObjects;
 import com.google.protobuf.BoolValue;
 import com.google.protobuf.Int32Value;
@@ -34,19 +39,13 @@ import com.hedera.services.usage.crypto.CryptoUpdateMeta;
 import com.hedera.services.usage.crypto.ExtantCryptoContext;
 import com.hedera.services.usage.state.UsageAccumulator;
 import com.hederahashgraph.api.proto.java.*;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-
 import java.util.List;
 import java.util.Optional;
 import java.util.OptionalLong;
 import java.util.function.Consumer;
 import java.util.function.Function;
-
-import static com.hedera.services.bdd.spec.PropertySource.asAccountString;
-import static com.hedera.services.bdd.spec.queries.QueryVerbs.getAccountInfo;
-import static com.hedera.services.bdd.spec.transactions.TxnUtils.*;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SUCCESS;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 public class HapiCryptoUpdate extends HapiTxnOp<HapiCryptoUpdate> {
     static final Logger log = LogManager.getLogger(HapiCryptoUpdate.class);
@@ -244,7 +243,7 @@ public class HapiCryptoUpdate extends HapiTxnOp<HapiCryptoUpdate> {
                                     isDeclinedReward.ifPresent(
                                             b -> builder.setDeclineReward(BoolValue.of(b)));
                                 });
-        if (logUpdateDetailsToSysout)  {
+        if (logUpdateDetailsToSysout) {
             System.out.println("\n---- Raw update ----\n");
             System.out.println(opBody);
             System.out.println("--------------------\n");
@@ -297,7 +296,6 @@ public class HapiCryptoUpdate extends HapiTxnOp<HapiCryptoUpdate> {
             return HapiApiSuite.ONE_HBAR;
         }
     }
-
 
     @SuppressWarnings("java:S112")
     private CryptoGetInfoResponse.AccountInfo lookupInfo(HapiApiSpec spec) throws Throwable {

--- a/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/crypto/HapiCryptoUpdate.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/crypto/HapiCryptoUpdate.java
@@ -15,13 +15,6 @@
  */
 package com.hedera.services.bdd.spec.transactions.crypto;
 
-import static com.hedera.services.bdd.spec.PropertySource.asAccountString;
-import static com.hedera.services.bdd.spec.queries.QueryVerbs.getAccountInfo;
-import static com.hedera.services.bdd.spec.transactions.TxnUtils.asIdForKeyLookUp;
-import static com.hedera.services.bdd.spec.transactions.TxnUtils.defaultUpdateSigners;
-import static com.hedera.services.bdd.spec.transactions.TxnUtils.suFrom;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SUCCESS;
-
 import com.google.common.base.MoreObjects;
 import com.google.protobuf.BoolValue;
 import com.google.protobuf.Int32Value;
@@ -40,36 +33,33 @@ import com.hedera.services.usage.BaseTransactionMeta;
 import com.hedera.services.usage.crypto.CryptoUpdateMeta;
 import com.hedera.services.usage.crypto.ExtantCryptoContext;
 import com.hedera.services.usage.state.UsageAccumulator;
-import com.hederahashgraph.api.proto.java.AccountID;
-import com.hederahashgraph.api.proto.java.CryptoGetInfoResponse;
-import com.hederahashgraph.api.proto.java.CryptoUpdateTransactionBody;
-import com.hederahashgraph.api.proto.java.Duration;
-import com.hederahashgraph.api.proto.java.HederaFunctionality;
-import com.hederahashgraph.api.proto.java.Key;
-import com.hederahashgraph.api.proto.java.Timestamp;
-import com.hederahashgraph.api.proto.java.Transaction;
-import com.hederahashgraph.api.proto.java.TransactionBody;
-import com.hederahashgraph.api.proto.java.TransactionResponse;
+import com.hederahashgraph.api.proto.java.*;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import java.util.List;
 import java.util.Optional;
 import java.util.OptionalLong;
 import java.util.function.Consumer;
 import java.util.function.Function;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
+
+import static com.hedera.services.bdd.spec.PropertySource.asAccountString;
+import static com.hedera.services.bdd.spec.queries.QueryVerbs.getAccountInfo;
+import static com.hedera.services.bdd.spec.transactions.TxnUtils.*;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SUCCESS;
 
 public class HapiCryptoUpdate extends HapiTxnOp<HapiCryptoUpdate> {
     static final Logger log = LogManager.getLogger(HapiCryptoUpdate.class);
 
     private boolean useContractKey = false;
     private boolean skipNewKeyRegistryUpdate = false;
+    private boolean logUpdateDetailsToSysout = false;
     private String account;
     private String aliasKeySource = null;
     private OptionalLong sendThreshold = OptionalLong.empty();
     private Optional<Key> updKey = Optional.empty();
     private OptionalLong newExpiry = OptionalLong.empty();
     private OptionalLong newAutoRenewPeriod = OptionalLong.empty();
-    private Optional<Long> lifetimeSecs = Optional.empty();
     private Optional<String> newProxy = Optional.empty();
     private Optional<String> entityMemo = Optional.empty();
     private Optional<String> updKeyName = Optional.empty();
@@ -94,6 +84,11 @@ public class HapiCryptoUpdate extends HapiTxnOp<HapiCryptoUpdate> {
         }
     }
 
+    public HapiCryptoUpdate withYahcliLogging() {
+        logUpdateDetailsToSysout = true;
+        return this;
+    }
+
     public HapiCryptoUpdate notUpdatingRegistryWithNewKey() {
         skipNewKeyRegistryUpdate = true;
         return this;
@@ -116,11 +111,6 @@ public class HapiCryptoUpdate extends HapiTxnOp<HapiCryptoUpdate> {
 
     public HapiCryptoUpdate autoRenewPeriod(long p) {
         newAutoRenewPeriod = OptionalLong.of(p);
-        return this;
-    }
-
-    public HapiCryptoUpdate lifetime(long secs) {
-        lifetimeSecs = Optional.of(secs);
         return this;
     }
 
@@ -178,10 +168,12 @@ public class HapiCryptoUpdate extends HapiTxnOp<HapiCryptoUpdate> {
     }
 
     @Override
+    @SuppressWarnings("java:S106")
     protected Consumer<TransactionBody.Builder> opBodyDef(HapiApiSpec spec) throws Throwable {
         try {
             updKey = updKeyName.map(spec.registry()::getKey);
-        } catch (Exception ignore) {
+        } catch (Exception missingKey) {
+            log.warn("No such key {}", updKey);
         }
         AccountID id;
 
@@ -252,6 +244,11 @@ public class HapiCryptoUpdate extends HapiTxnOp<HapiCryptoUpdate> {
                                     isDeclinedReward.ifPresent(
                                             b -> builder.setDeclineReward(BoolValue.of(b)));
                                 });
+        if (logUpdateDetailsToSysout)  {
+            System.out.println("\n---- Raw update ----\n");
+            System.out.println(opBody);
+            System.out.println("--------------------\n");
+        }
         return builder -> builder.setCryptoUpdateAccount(opBody);
     }
 
@@ -301,6 +298,8 @@ public class HapiCryptoUpdate extends HapiTxnOp<HapiCryptoUpdate> {
         }
     }
 
+
+    @SuppressWarnings("java:S112")
     private CryptoGetInfoResponse.AccountInfo lookupInfo(HapiApiSpec spec) throws Throwable {
         HapiGetAccountInfo subOp = getAccountInfo(account).noLogging();
         Optional<Throwable> error = subOp.execFor(spec);

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/file/FileUpdateSuite.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/file/FileUpdateSuite.java
@@ -15,23 +15,6 @@
  */
 package com.hedera.services.bdd.suites.file;
 
-import com.google.protobuf.ByteString;
-import com.hedera.services.bdd.spec.HapiApiSpec;
-import com.hedera.services.bdd.spec.HapiSpecSetup;
-import com.hedera.services.bdd.spec.transactions.TxnUtils;
-import com.hedera.services.bdd.spec.transactions.TxnVerbs;
-import com.hedera.services.bdd.spec.utilops.UtilVerbs;
-import com.hedera.services.bdd.suites.HapiApiSuite;
-import com.hedera.services.bdd.suites.token.TokenAssociationSpecs;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-
-import java.math.BigInteger;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.concurrent.atomic.AtomicLong;
-
 import static com.hedera.services.bdd.spec.HapiApiSpec.customHapiSpec;
 import static com.hedera.services.bdd.spec.HapiApiSpec.defaultHapiSpec;
 import static com.hedera.services.bdd.spec.assertions.ContractFnResultAsserts.resultWith;
@@ -56,6 +39,22 @@ import static com.hederahashgraph.api.proto.java.TokenKycStatus.KycNotApplicable
 import static com.hederahashgraph.api.proto.java.TokenKycStatus.Revoked;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.google.protobuf.ByteString;
+import com.hedera.services.bdd.spec.HapiApiSpec;
+import com.hedera.services.bdd.spec.HapiSpecSetup;
+import com.hedera.services.bdd.spec.transactions.TxnUtils;
+import com.hedera.services.bdd.spec.transactions.TxnVerbs;
+import com.hedera.services.bdd.spec.utilops.UtilVerbs;
+import com.hedera.services.bdd.suites.HapiApiSuite;
+import com.hedera.services.bdd.suites.token.TokenAssociationSpecs;
+import java.math.BigInteger;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicLong;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * NOTE: 1. This test suite covers the test08UpdateFile() test scenarios from the legacy
@@ -115,37 +114,39 @@ public class FileUpdateSuite extends HapiApiSuite {
     public List<HapiApiSpec> getSpecsInSuite() {
         return List.of(
                 new HapiApiSpec[] {
-//                    vanillaUpdateSucceeds(),
-//                    updateFeesCompatibleWithCreates(),
-//                    apiPermissionsChangeDynamically(),
-//                    cannotUpdateExpirationPastMaxLifetime(),
-//                    optimisticSpecialFileUpdate(),
-//                    associateHasExpectedSemantics(),
-//                    notTooManyFeeScheduleCanBeCreated(),
-//                    allUnusedGasIsRefundedIfSoConfigured(),
-//                    maxRefundIsEnforced(),
-//                    gasLimitOverMaxGasLimitFailsPrecheck(),
-//                    autoCreationIsDynamic(),
-//                    kvLimitsEnforced(),
-//                    serviceFeeRefundedIfConsGasExhausted(),
-//                    chainIdChangesDynamically(),
-//                    entitiesNotCreatableAfterUsageLimitsReached(),
-//                    rentItemizedAsExpectedWithOverridePriceTiers(),
-//                    messageSubmissionSizeChange(),
-                        getMainnetInfo(),
+                    //                    vanillaUpdateSucceeds(),
+                    //                    updateFeesCompatibleWithCreates(),
+                    //                    apiPermissionsChangeDynamically(),
+                    //                    cannotUpdateExpirationPastMaxLifetime(),
+                    //                    optimisticSpecialFileUpdate(),
+                    //                    associateHasExpectedSemantics(),
+                    //                    notTooManyFeeScheduleCanBeCreated(),
+                    //                    allUnusedGasIsRefundedIfSoConfigured(),
+                    //                    maxRefundIsEnforced(),
+                    //                    gasLimitOverMaxGasLimitFailsPrecheck(),
+                    //                    autoCreationIsDynamic(),
+                    //                    kvLimitsEnforced(),
+                    //                    serviceFeeRefundedIfConsGasExhausted(),
+                    //                    chainIdChangesDynamically(),
+                    //                    entitiesNotCreatableAfterUsageLimitsReached(),
+                    //                    rentItemizedAsExpectedWithOverridePriceTiers(),
+                    //                    messageSubmissionSizeChange(),
+                    getMainnetInfo(),
                 });
     }
 
     private HapiApiSpec getMainnetInfo() {
-        return customHapiSpec("GetMainnetInfo").withProperties(Map.of(
-                        "nodes", "35.237.200.180",
-                        "fees.useFixedOffer", "true",
-                        "fees.fixedOffer", "100000000",
-                        "default.payer", "0.0.748787",
-                        "default.payer.mnemonicFile", "account748787.words"
-                )).given().when().then(
-                        getVersionInfo().logged()
-                );
+        return customHapiSpec("GetMainnetInfo")
+                .withProperties(
+                        Map.of(
+                                "nodes", "35.237.200.180",
+                                "fees.useFixedOffer", "true",
+                                "fees.fixedOffer", "100000000",
+                                "default.payer", "0.0.748787",
+                                "default.payer.mnemonicFile", "account748787.words"))
+                .given()
+                .when()
+                .then(getVersionInfo().logged());
     }
 
     private HapiApiSpec associateHasExpectedSemantics() {

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenAssociationSpecs.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenAssociationSpecs.java
@@ -15,52 +15,6 @@
  */
 package com.hedera.services.bdd.suites.token;
 
-import static com.hedera.services.bdd.spec.HapiApiSpec.defaultHapiSpec;
-import static com.hedera.services.bdd.spec.HapiPropertySource.asHexedSolidityAddress;
-import static com.hedera.services.bdd.spec.assertions.NoTokenTransfers.emptyTokenTransfers;
-import static com.hedera.services.bdd.spec.assertions.SomeFungibleTransfers.changingFungibleBalances;
-import static com.hedera.services.bdd.spec.assertions.TransactionRecordAsserts.recordWith;
-import static com.hedera.services.bdd.spec.queries.QueryVerbs.getAccountBalance;
-import static com.hedera.services.bdd.spec.queries.QueryVerbs.getAccountInfo;
-import static com.hedera.services.bdd.spec.queries.QueryVerbs.getContractInfo;
-import static com.hedera.services.bdd.spec.queries.QueryVerbs.getTxnRecord;
-import static com.hedera.services.bdd.spec.queries.crypto.ExpectedTokenRel.relationshipWith;
-import static com.hedera.services.bdd.spec.transactions.TxnVerbs.contractCall;
-import static com.hedera.services.bdd.spec.transactions.TxnVerbs.contractCreate;
-import static com.hedera.services.bdd.spec.transactions.TxnVerbs.createDefaultContract;
-import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoCreate;
-import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoTransfer;
-import static com.hedera.services.bdd.spec.transactions.TxnVerbs.mintToken;
-import static com.hedera.services.bdd.spec.transactions.TxnVerbs.tokenAssociate;
-import static com.hedera.services.bdd.spec.transactions.TxnVerbs.tokenCreate;
-import static com.hedera.services.bdd.spec.transactions.TxnVerbs.tokenDelete;
-import static com.hedera.services.bdd.spec.transactions.TxnVerbs.tokenDissociate;
-import static com.hedera.services.bdd.spec.transactions.TxnVerbs.tokenFreeze;
-import static com.hedera.services.bdd.spec.transactions.TxnVerbs.tokenUnfreeze;
-import static com.hedera.services.bdd.spec.transactions.TxnVerbs.uploadInitCode;
-import static com.hedera.services.bdd.spec.transactions.token.TokenMovement.moving;
-import static com.hedera.services.bdd.spec.utilops.CustomSpecAssert.allRunFor;
-import static com.hedera.services.bdd.spec.utilops.UtilVerbs.childRecordsCheck;
-import static com.hedera.services.bdd.spec.utilops.UtilVerbs.newKeyNamed;
-import static com.hedera.services.bdd.spec.utilops.UtilVerbs.sleepFor;
-import static com.hedera.services.bdd.spec.utilops.UtilVerbs.sourcing;
-import static com.hedera.services.bdd.spec.utilops.UtilVerbs.withOpContext;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.ACCOUNT_FROZEN_FOR_TOKEN;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.ACCOUNT_IS_TREASURY;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.CONTRACT_REVERT_EXECUTED;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_SIGNATURE;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_TOKEN_ID;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TOKEN_ID_REPEATED_IN_TOKEN_LIST;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TOKEN_NOT_ASSOCIATED_TO_ACCOUNT;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TRANSACTION_REQUIRES_ZERO_TOKEN_BALANCES;
-import static com.hederahashgraph.api.proto.java.TokenFreezeStatus.FreezeNotApplicable;
-import static com.hederahashgraph.api.proto.java.TokenFreezeStatus.Frozen;
-import static com.hederahashgraph.api.proto.java.TokenFreezeStatus.Unfrozen;
-import static com.hederahashgraph.api.proto.java.TokenKycStatus.Granted;
-import static com.hederahashgraph.api.proto.java.TokenKycStatus.KycNotApplicable;
-import static com.hederahashgraph.api.proto.java.TokenType.NON_FUNGIBLE_UNIQUE;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
 import com.google.protobuf.ByteString;
 import com.hedera.services.bdd.spec.HapiApiSpec;
 import com.hedera.services.bdd.spec.HapiPropertySource;
@@ -71,13 +25,32 @@ import com.hedera.services.bdd.spec.transactions.token.TokenMovement;
 import com.hedera.services.bdd.suites.HapiApiSuite;
 import com.hederahashgraph.api.proto.java.AccountAmount;
 import com.hederahashgraph.api.proto.java.TokenTransferList;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
+
+import static com.hedera.services.bdd.spec.HapiApiSpec.defaultHapiSpec;
+import static com.hedera.services.bdd.spec.HapiPropertySource.asHexedSolidityAddress;
+import static com.hedera.services.bdd.spec.assertions.NoTokenTransfers.emptyTokenTransfers;
+import static com.hedera.services.bdd.spec.assertions.SomeFungibleTransfers.changingFungibleBalances;
+import static com.hedera.services.bdd.spec.assertions.TransactionRecordAsserts.recordWith;
+import static com.hedera.services.bdd.spec.queries.QueryVerbs.*;
+import static com.hedera.services.bdd.spec.queries.crypto.ExpectedTokenRel.relationshipWith;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.*;
+import static com.hedera.services.bdd.spec.transactions.token.TokenMovement.moving;
+import static com.hedera.services.bdd.spec.utilops.CustomSpecAssert.allRunFor;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.*;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.*;
+import static com.hederahashgraph.api.proto.java.TokenFreezeStatus.*;
+import static com.hederahashgraph.api.proto.java.TokenKycStatus.Granted;
+import static com.hederahashgraph.api.proto.java.TokenKycStatus.KycNotApplicable;
+import static com.hederahashgraph.api.proto.java.TokenType.NON_FUNGIBLE_UNIQUE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class TokenAssociationSpecs extends HapiApiSuite {
     private static final Logger log = LogManager.getLogger(TokenAssociationSpecs.class);
@@ -567,7 +540,7 @@ public class TokenAssociationSpecs extends HapiApiSuite {
 
     public HapiApiSpec dissociateHasExpectedSemantics() {
         return defaultHapiSpec("DissociateHasExpectedSemantics")
-                .given(flattened(basicKeysAndTokens()))
+                .given(basicKeysAndTokens())
                 .when(
                         tokenCreate("tkn1").treasury(TOKEN_TREASURY),
                         tokenDissociate(TOKEN_TREASURY, "tkn1").hasKnownStatus(ACCOUNT_IS_TREASURY),

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenAssociationSpecs.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenAssociationSpecs.java
@@ -15,25 +15,6 @@
  */
 package com.hedera.services.bdd.suites.token;
 
-import com.google.protobuf.ByteString;
-import com.hedera.services.bdd.spec.HapiApiSpec;
-import com.hedera.services.bdd.spec.HapiPropertySource;
-import com.hedera.services.bdd.spec.HapiSpecOperation;
-import com.hedera.services.bdd.spec.assertions.BaseErroringAssertsProvider;
-import com.hedera.services.bdd.spec.assertions.ErroringAsserts;
-import com.hedera.services.bdd.spec.transactions.token.TokenMovement;
-import com.hedera.services.bdd.suites.HapiApiSuite;
-import com.hederahashgraph.api.proto.java.AccountAmount;
-import com.hederahashgraph.api.proto.java.TokenTransferList;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-
-import java.nio.charset.StandardCharsets;
-import java.util.Collections;
-import java.util.List;
-import java.util.concurrent.atomic.AtomicLong;
-import java.util.concurrent.atomic.AtomicReference;
-
 import static com.hedera.services.bdd.spec.HapiApiSpec.defaultHapiSpec;
 import static com.hedera.services.bdd.spec.HapiPropertySource.asHexedSolidityAddress;
 import static com.hedera.services.bdd.spec.assertions.NoTokenTransfers.emptyTokenTransfers;
@@ -51,6 +32,24 @@ import static com.hederahashgraph.api.proto.java.TokenKycStatus.Granted;
 import static com.hederahashgraph.api.proto.java.TokenKycStatus.KycNotApplicable;
 import static com.hederahashgraph.api.proto.java.TokenType.NON_FUNGIBLE_UNIQUE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.google.protobuf.ByteString;
+import com.hedera.services.bdd.spec.HapiApiSpec;
+import com.hedera.services.bdd.spec.HapiPropertySource;
+import com.hedera.services.bdd.spec.HapiSpecOperation;
+import com.hedera.services.bdd.spec.assertions.BaseErroringAssertsProvider;
+import com.hedera.services.bdd.spec.assertions.ErroringAsserts;
+import com.hedera.services.bdd.spec.transactions.token.TokenMovement;
+import com.hedera.services.bdd.suites.HapiApiSuite;
+import com.hederahashgraph.api.proto.java.AccountAmount;
+import com.hederahashgraph.api.proto.java.TokenTransferList;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 public class TokenAssociationSpecs extends HapiApiSuite {
     private static final Logger log = LogManager.getLogger(TokenAssociationSpecs.class);

--- a/test-clients/src/main/java/com/hedera/services/yahcli/commands/accounts/AccountsCommand.java
+++ b/test-clients/src/main/java/com/hedera/services/yahcli/commands/accounts/AccountsCommand.java
@@ -16,23 +16,26 @@
 package com.hedera.services.yahcli.commands.accounts;
 
 import com.hedera.services.yahcli.Yahcli;
-import java.util.concurrent.Callable;
 import picocli.CommandLine;
 import picocli.CommandLine.HelpCommand;
 import picocli.CommandLine.ParentCommand;
 
+import java.util.concurrent.Callable;
+
 @CommandLine.Command(
         name = "accounts",
         subcommands = {
-            HelpCommand.class,
-            BalanceCommand.class,
-            RekeyCommand.class,
-            SendCommand.class,
-            CreateCommand.class
+                HelpCommand.class,
+                BalanceCommand.class,
+                RekeyCommand.class,
+                SendCommand.class,
+                CreateCommand.class,
+                StakeCommand.class
         },
         description = "Performs account operations")
 public class AccountsCommand implements Callable<Integer> {
-    @ParentCommand Yahcli yahcli;
+    @ParentCommand
+    Yahcli yahcli;
 
     @Override
     public Integer call() throws Exception {

--- a/test-clients/src/main/java/com/hedera/services/yahcli/commands/accounts/AccountsCommand.java
+++ b/test-clients/src/main/java/com/hedera/services/yahcli/commands/accounts/AccountsCommand.java
@@ -16,26 +16,24 @@
 package com.hedera.services.yahcli.commands.accounts;
 
 import com.hedera.services.yahcli.Yahcli;
+import java.util.concurrent.Callable;
 import picocli.CommandLine;
 import picocli.CommandLine.HelpCommand;
 import picocli.CommandLine.ParentCommand;
 
-import java.util.concurrent.Callable;
-
 @CommandLine.Command(
         name = "accounts",
         subcommands = {
-                HelpCommand.class,
-                BalanceCommand.class,
-                RekeyCommand.class,
-                SendCommand.class,
-                CreateCommand.class,
-                StakeCommand.class
+            HelpCommand.class,
+            BalanceCommand.class,
+            RekeyCommand.class,
+            SendCommand.class,
+            CreateCommand.class,
+            StakeCommand.class
         },
         description = "Performs account operations")
 public class AccountsCommand implements Callable<Integer> {
-    @ParentCommand
-    Yahcli yahcli;
+    @ParentCommand Yahcli yahcli;
 
     @Override
     public Integer call() throws Exception {

--- a/test-clients/src/main/java/com/hedera/services/yahcli/commands/accounts/StakeCommand.java
+++ b/test-clients/src/main/java/com/hedera/services/yahcli/commands/accounts/StakeCommand.java
@@ -1,15 +1,29 @@
+/*
+ * Copyright (C) 2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hedera.services.yahcli.commands.accounts;
-
-import com.hedera.services.yahcli.config.ConfigUtils;
-import com.hedera.services.yahcli.suites.StakeSuite;
-import com.hedera.services.yahcli.suites.Utils;
-import picocli.CommandLine;
-
-import java.util.concurrent.Callable;
 
 import static com.hedera.services.bdd.spec.HapiApiSpec.SpecStatus.PASSED;
 import static com.hedera.services.yahcli.config.ConfigUtils.configFrom;
 import static com.hedera.services.yahcli.output.CommonMessages.COMMON_MESSAGES;
+
+import com.hedera.services.yahcli.config.ConfigUtils;
+import com.hedera.services.yahcli.suites.StakeSuite;
+import com.hedera.services.yahcli.suites.Utils;
+import java.util.concurrent.Callable;
+import picocli.CommandLine;
 
 @CommandLine.Command(
         name = "stake",
@@ -68,31 +82,39 @@ public class StakeCommand implements Callable<Integer> {
         }
         final var delegate =
                 new StakeSuite(
-                        config, config.asSpecConfig(), target, type, stakedAccountNum, declineReward);
+                        config,
+                        config.asSpecConfig(),
+                        target,
+                        type,
+                        stakedAccountNum,
+                        declineReward);
         delegate.runSuiteSync();
 
         if (stakedAccountNum == null) {
             stakedAccountNum = ConfigUtils.asId(config.getDefaultPayer());
         }
         if (delegate.getFinalSpecs().get(0).getStatus() == PASSED) {
-            final var msgSb = new StringBuilder("SUCCESS - account ")
-                    .append(Utils.extractAccount(stakedAccountNum))
-                    .append(" updated");
+            final var msgSb =
+                    new StringBuilder("SUCCESS - account ")
+                            .append(Utils.extractAccount(stakedAccountNum))
+                            .append(" updated");
             if (type != StakeSuite.TargetType.NONE) {
                 msgSb.append(", now staked to ")
                         .append(type.name())
                         .append(" ")
-                        .append(type == StakeSuite.TargetType.NODE
-                                ? electedNodeId
-                                : Utils.extractAccount(electedAccountNum));
+                        .append(
+                                type == StakeSuite.TargetType.NODE
+                                        ? electedNodeId
+                                        : Utils.extractAccount(electedAccountNum));
             }
             if (declineReward != null) {
                 msgSb.append(" with declineReward=").append(declineReward);
             }
             COMMON_MESSAGES.info(msgSb.toString());
         } else {
-            COMMON_MESSAGES.warn("FAILED to change staking election for account "
-                    + Utils.extractAccount(stakedAccountNum));
+            COMMON_MESSAGES.warn(
+                    "FAILED to change staking election for account "
+                            + Utils.extractAccount(stakedAccountNum));
             return 1;
         }
 
@@ -105,35 +127,47 @@ public class StakeCommand implements Callable<Integer> {
                     accountsCommand.getYahcli().getSpec().commandLine(),
                     "Cannot both start and stop declining rewards");
         }
-        final var changedDeclineRewards = startDecliningRewards != null || stopDecliningRewards != null;
+        final var changedDeclineRewards =
+                startDecliningRewards != null || stopDecliningRewards != null;
         if (electedNodeId != null) {
             if (electedAccountNum != null) {
                 throw new CommandLine.ParameterException(
                         accountsCommand.getYahcli().getSpec().commandLine(),
-                        "Cannot stake to both node (" + electedNodeId
-                                + ") and account (" + electedAccountNum + ")");
+                        "Cannot stake to both node ("
+                                + electedNodeId
+                                + ") and account ("
+                                + electedAccountNum
+                                + ")");
             }
             try {
                 Long.parseLong(electedNodeId);
             } catch (final Exception any) {
                 throw new CommandLine.ParameterException(
                         accountsCommand.getYahcli().getSpec().commandLine(),
-                        "--node-id value '" + electedNodeId
-                                + "' is un-parseable (" + any.getMessage() + ")");
+                        "--node-id value '"
+                                + electedNodeId
+                                + "' is un-parseable ("
+                                + any.getMessage()
+                                + ")");
             }
         } else if (electedAccountNum == null && !changedDeclineRewards) {
             throw new CommandLine.ParameterException(
                     accountsCommand.getYahcli().getSpec().commandLine(),
-                    "Must stake to either a node or an account (" + electedAccountNum + "); or " +
-                            "start/stop declining rewards");
+                    "Must stake to either a node or an account ("
+                            + electedAccountNum
+                            + "); or "
+                            + "start/stop declining rewards");
         } else if (electedAccountNum != null) {
             try {
                 Utils.extractAccount(electedAccountNum);
             } catch (final Exception any) {
                 throw new CommandLine.ParameterException(
                         accountsCommand.getYahcli().getSpec().commandLine(),
-                        "--account-num value '" + electedAccountNum
-                                + "' is un-parseable (" + any.getMessage() + ")");
+                        "--account-num value '"
+                                + electedAccountNum
+                                + "' is un-parseable ("
+                                + any.getMessage()
+                                + ")");
             }
         }
 
@@ -143,10 +177,12 @@ public class StakeCommand implements Callable<Integer> {
             } catch (final Exception any) {
                 throw new CommandLine.ParameterException(
                         accountsCommand.getYahcli().getSpec().commandLine(),
-                        "staked account parameter '" + stakedAccountNum
-                                + "' is un-parseable (" + any.getMessage() + ")");
+                        "staked account parameter '"
+                                + stakedAccountNum
+                                + "' is un-parseable ("
+                                + any.getMessage()
+                                + ")");
             }
         }
     }
 }
-

--- a/test-clients/src/main/java/com/hedera/services/yahcli/commands/accounts/StakeCommand.java
+++ b/test-clients/src/main/java/com/hedera/services/yahcli/commands/accounts/StakeCommand.java
@@ -1,0 +1,152 @@
+package com.hedera.services.yahcli.commands.accounts;
+
+import com.hedera.services.yahcli.config.ConfigUtils;
+import com.hedera.services.yahcli.suites.StakeSuite;
+import com.hedera.services.yahcli.suites.Utils;
+import picocli.CommandLine;
+
+import java.util.concurrent.Callable;
+
+import static com.hedera.services.bdd.spec.HapiApiSpec.SpecStatus.PASSED;
+import static com.hedera.services.yahcli.config.ConfigUtils.configFrom;
+import static com.hedera.services.yahcli.output.CommonMessages.COMMON_MESSAGES;
+
+@CommandLine.Command(
+        name = "stake",
+        subcommands = {CommandLine.HelpCommand.class},
+        description = "Changes the staking election for an account")
+public class StakeCommand implements Callable<Integer> {
+    @CommandLine.ParentCommand AccountsCommand accountsCommand;
+
+    @CommandLine.Option(
+            names = {"-n", "--to-node-id"},
+            paramLabel = "id of node to stake to")
+    String electedNodeId;
+
+    @CommandLine.Option(
+            names = {"-a", "--to-account-num"},
+            paramLabel = "the account to stake to")
+    String electedAccountNum;
+
+    @CommandLine.Option(
+            names = {"--stop-declining-rewards"},
+            paramLabel = "trigger to add declineReward=false")
+    Boolean stopDecliningRewards;
+
+    @CommandLine.Option(
+            names = {"--start-declining-rewards"},
+            paramLabel = "trigger to add declineReward=true")
+    Boolean startDecliningRewards;
+
+    @CommandLine.Parameters(
+            arity = "0..1",
+            paramLabel = "<account>",
+            description = "the account to stake")
+    String stakedAccountNum;
+
+    @Override
+    public Integer call() throws Exception {
+        final var config = configFrom(accountsCommand.getYahcli());
+        assertValidParams();
+        final String target;
+        final StakeSuite.TargetType type;
+        if (electedNodeId != null) {
+            type = StakeSuite.TargetType.NODE;
+            target = electedNodeId;
+        } else if (electedAccountNum != null) {
+            type = StakeSuite.TargetType.ACCOUNT;
+            target = electedAccountNum;
+        } else {
+            target = null;
+            type = StakeSuite.TargetType.NONE;
+        }
+        Boolean declineReward = null;
+        if (startDecliningRewards != null) {
+            declineReward = Boolean.TRUE;
+        } else if (stopDecliningRewards != null) {
+            declineReward = Boolean.FALSE;
+        }
+        final var delegate =
+                new StakeSuite(
+                        config, config.asSpecConfig(), target, type, stakedAccountNum, declineReward);
+        delegate.runSuiteSync();
+
+        if (stakedAccountNum == null) {
+            stakedAccountNum = ConfigUtils.asId(config.getDefaultPayer());
+        }
+        if (delegate.getFinalSpecs().get(0).getStatus() == PASSED) {
+            final var msgSb = new StringBuilder("SUCCESS - account ")
+                    .append(Utils.extractAccount(stakedAccountNum))
+                    .append(" updated");
+            if (type != StakeSuite.TargetType.NONE) {
+                msgSb.append(", now staked to ")
+                        .append(type.name())
+                        .append(" ")
+                        .append(type == StakeSuite.TargetType.NODE
+                                ? electedNodeId
+                                : Utils.extractAccount(electedAccountNum));
+            }
+            if (declineReward != null) {
+                msgSb.append(" with declineReward=").append(declineReward);
+            }
+            COMMON_MESSAGES.info(msgSb.toString());
+        } else {
+            COMMON_MESSAGES.warn("FAILED to change staking election for account "
+                    + Utils.extractAccount(stakedAccountNum));
+            return 1;
+        }
+
+        return 0;
+    }
+
+    private void assertValidParams() {
+        if (stopDecliningRewards != null && startDecliningRewards != null) {
+            throw new CommandLine.ParameterException(
+                    accountsCommand.getYahcli().getSpec().commandLine(),
+                    "Cannot both start and stop declining rewards");
+        }
+        final var changedDeclineRewards = startDecliningRewards != null || stopDecliningRewards != null;
+        if (electedNodeId != null) {
+            if (electedAccountNum != null) {
+                throw new CommandLine.ParameterException(
+                        accountsCommand.getYahcli().getSpec().commandLine(),
+                        "Cannot stake to both node (" + electedNodeId
+                                + ") and account (" + electedAccountNum + ")");
+            }
+            try {
+                Long.parseLong(electedNodeId);
+            } catch (final Exception any) {
+                throw new CommandLine.ParameterException(
+                        accountsCommand.getYahcli().getSpec().commandLine(),
+                        "--node-id value '" + electedNodeId
+                                + "' is un-parseable (" + any.getMessage() + ")");
+            }
+        } else if (electedAccountNum == null && !changedDeclineRewards) {
+            throw new CommandLine.ParameterException(
+                    accountsCommand.getYahcli().getSpec().commandLine(),
+                    "Must stake to either a node or an account (" + electedAccountNum + "); or " +
+                            "start/stop declining rewards");
+        } else if (electedAccountNum != null) {
+            try {
+                Utils.extractAccount(electedAccountNum);
+            } catch (final Exception any) {
+                throw new CommandLine.ParameterException(
+                        accountsCommand.getYahcli().getSpec().commandLine(),
+                        "--account-num value '" + electedAccountNum
+                                + "' is un-parseable (" + any.getMessage() + ")");
+            }
+        }
+
+        if (stakedAccountNum != null) {
+            try {
+                Utils.extractAccount(stakedAccountNum);
+            } catch (final Exception any) {
+                throw new CommandLine.ParameterException(
+                        accountsCommand.getYahcli().getSpec().commandLine(),
+                        "staked account parameter '" + stakedAccountNum
+                                + "' is un-parseable (" + any.getMessage() + ")");
+            }
+        }
+    }
+}
+

--- a/test-clients/src/main/java/com/hedera/services/yahcli/config/ConfigManager.java
+++ b/test-clients/src/main/java/com/hedera/services/yahcli/config/ConfigManager.java
@@ -15,16 +15,16 @@
  */
 package com.hedera.services.yahcli.config;
 
+import static com.hedera.services.bdd.spec.HapiPropertySource.asDotDelimitedLongArray;
+import static com.hedera.services.yahcli.config.ConfigUtils.*;
+import static java.util.stream.Collectors.toList;
+
 import com.hedera.services.bdd.suites.utils.sysfiles.serdes.StandardSerdes;
 import com.hedera.services.bdd.suites.utils.sysfiles.serdes.ThrottlesJsonToGrpcBytes;
 import com.hedera.services.yahcli.Yahcli;
 import com.hedera.services.yahcli.config.domain.GlobalConfig;
 import com.hedera.services.yahcli.config.domain.NetConfig;
 import com.hedera.services.yahcli.config.domain.NodeConfig;
-import org.yaml.snakeyaml.Yaml;
-import org.yaml.snakeyaml.constructor.Constructor;
-import picocli.CommandLine;
-
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -33,10 +33,9 @@ import java.nio.file.Paths;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-
-import static com.hedera.services.bdd.spec.HapiPropertySource.asDotDelimitedLongArray;
-import static com.hedera.services.yahcli.config.ConfigUtils.*;
-import static java.util.stream.Collectors.toList;
+import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.constructor.Constructor;
+import picocli.CommandLine;
 
 public class ConfigManager {
     private static final long MISSING_NODE_ACCOUNT = -1;

--- a/test-clients/src/main/java/com/hedera/services/yahcli/config/ConfigManager.java
+++ b/test-clients/src/main/java/com/hedera/services/yahcli/config/ConfigManager.java
@@ -15,19 +15,16 @@
  */
 package com.hedera.services.yahcli.config;
 
-import static com.hedera.services.bdd.spec.HapiPropertySource.asDotDelimitedLongArray;
-import static com.hedera.services.yahcli.config.ConfigUtils.asId;
-import static com.hedera.services.yahcli.config.ConfigUtils.isLiteral;
-import static com.hedera.services.yahcli.config.ConfigUtils.promptForPassphrase;
-import static com.hedera.services.yahcli.config.ConfigUtils.unlocks;
-import static java.util.stream.Collectors.toList;
-
 import com.hedera.services.bdd.suites.utils.sysfiles.serdes.StandardSerdes;
 import com.hedera.services.bdd.suites.utils.sysfiles.serdes.ThrottlesJsonToGrpcBytes;
 import com.hedera.services.yahcli.Yahcli;
 import com.hedera.services.yahcli.config.domain.GlobalConfig;
 import com.hedera.services.yahcli.config.domain.NetConfig;
 import com.hedera.services.yahcli.config.domain.NodeConfig;
+import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.constructor.Constructor;
+import picocli.CommandLine;
+
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -36,9 +33,10 @@ import java.nio.file.Paths;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import org.yaml.snakeyaml.Yaml;
-import org.yaml.snakeyaml.constructor.Constructor;
-import picocli.CommandLine;
+
+import static com.hedera.services.bdd.spec.HapiPropertySource.asDotDelimitedLongArray;
+import static com.hedera.services.yahcli.config.ConfigUtils.*;
+import static java.util.stream.Collectors.toList;
 
 public class ConfigManager {
     private static final long MISSING_NODE_ACCOUNT = -1;
@@ -105,7 +103,7 @@ public class ConfigManager {
             specConfig.put("default.payer.pemKeyPassphrase", finalPassphrase.get());
         } else {
             try {
-                var mnemonic = Files.readString(keyFile.toPath());
+                var mnemonic = Files.readString(keyFile.toPath()).trim();
                 specConfig.put("default.payer.mnemonic", mnemonic);
             } catch (IOException e) {
                 fail(String.format("Mnemonic file %s is inaccessible!", keyFile.getPath()));

--- a/test-clients/src/main/java/com/hedera/services/yahcli/config/ConfigUtils.java
+++ b/test-clients/src/main/java/com/hedera/services/yahcli/config/ConfigUtils.java
@@ -15,6 +15,9 @@
  */
 package com.hedera.services.yahcli.config;
 
+import static com.hedera.services.bdd.spec.persistence.SpecKey.readFirstKpFromPem;
+import static com.hedera.services.yahcli.output.CommonMessages.COMMON_MESSAGES;
+
 import com.hedera.services.bdd.spec.HapiApiSpec;
 import com.hedera.services.bdd.spec.fees.FeesAndRatesProvider;
 import com.hedera.services.bdd.spec.infrastructure.HapiApiClients;
@@ -26,9 +29,6 @@ import com.hedera.services.bdd.spec.utilops.CustomSpecAssert;
 import com.hedera.services.bdd.suites.meta.VersionInfoSpec;
 import com.hedera.services.yahcli.Yahcli;
 import com.hedera.services.yahcli.suites.*;
-import org.apache.logging.log4j.Level;
-import org.apache.logging.log4j.LogManager;
-
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
@@ -36,9 +36,8 @@ import java.io.InputStreamReader;
 import java.nio.file.Paths;
 import java.util.List;
 import java.util.Optional;
-
-import static com.hedera.services.bdd.spec.persistence.SpecKey.readFirstKpFromPem;
-import static com.hedera.services.yahcli.output.CommonMessages.COMMON_MESSAGES;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
 
 public class ConfigUtils {
     public static String asId(String entity) {

--- a/test-clients/src/main/java/com/hedera/services/yahcli/config/ConfigUtils.java
+++ b/test-clients/src/main/java/com/hedera/services/yahcli/config/ConfigUtils.java
@@ -15,9 +15,6 @@
  */
 package com.hedera.services.yahcli.config;
 
-import static com.hedera.services.bdd.spec.persistence.SpecKey.readFirstKpFromPem;
-import static com.hedera.services.yahcli.output.CommonMessages.COMMON_MESSAGES;
-
 import com.hedera.services.bdd.spec.HapiApiSpec;
 import com.hedera.services.bdd.spec.fees.FeesAndRatesProvider;
 import com.hedera.services.bdd.spec.infrastructure.HapiApiClients;
@@ -29,6 +26,9 @@ import com.hedera.services.bdd.spec.utilops.CustomSpecAssert;
 import com.hedera.services.bdd.suites.meta.VersionInfoSpec;
 import com.hedera.services.yahcli.Yahcli;
 import com.hedera.services.yahcli.suites.*;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
@@ -36,8 +36,9 @@ import java.io.InputStreamReader;
 import java.nio.file.Paths;
 import java.util.List;
 import java.util.Optional;
-import org.apache.logging.log4j.Level;
-import org.apache.logging.log4j.LogManager;
+
+import static com.hedera.services.bdd.spec.persistence.SpecKey.readFirstKpFromPem;
+import static com.hedera.services.yahcli.output.CommonMessages.COMMON_MESSAGES;
 
 public class ConfigUtils {
     public static String asId(String entity) {
@@ -55,6 +56,16 @@ public class ConfigUtils {
 
     public static Optional<File> keyFileFor(String keysLoc, String typedNum) {
         return keyFileAt(keysLoc + File.separator + typedNum);
+    }
+
+    public static File uncheckedKeyFileFor(String keysLoc, String typedNum) {
+        final var fileLoc = keysLoc + File.separator + typedNum;
+        final var file = keyFileAt(fileLoc);
+        if (file.isEmpty()) {
+            throw new IllegalArgumentException("No such key file " + fileLoc);
+        } else {
+            return file.get();
+        }
     }
 
     public static Optional<File> keyFileAt(String sansExt) {
@@ -165,6 +176,7 @@ public class ConfigUtils {
                         SendSuite.class,
                         CreateSuite.class,
                         SpecialFileHashSuite.class,
+                        StakeSuite.class,
                         CustomSpecAssert.class)
                 .forEach(cls -> setLogLevel(cls, logLevel));
     }

--- a/test-clients/src/main/java/com/hedera/services/yahcli/suites/StakeSuite.java
+++ b/test-clients/src/main/java/com/hedera/services/yahcli/suites/StakeSuite.java
@@ -1,18 +1,19 @@
+/*
+ * Copyright (C) 2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hedera.services.yahcli.suites;
-
-
-import com.hedera.services.bdd.spec.HapiApiSpec;
-import com.hedera.services.bdd.spec.HapiSpecOperation;
-import com.hedera.services.bdd.spec.transactions.crypto.HapiCryptoUpdate;
-import com.hedera.services.bdd.suites.HapiApiSuite;
-import com.hedera.services.yahcli.config.ConfigManager;
-import com.hedera.services.yahcli.config.ConfigUtils;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-
-import javax.annotation.Nullable;
-import java.util.List;
-import java.util.Map;
 
 import static com.hedera.services.bdd.spec.HapiApiSpec.customHapiSpec;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoUpdate;
@@ -20,11 +21,27 @@ import static com.hedera.services.bdd.spec.utilops.UtilVerbs.keyFromFile;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.noOp;
 import static com.hedera.services.yahcli.config.ConfigUtils.uncheckedKeyFileFor;
 
+import com.hedera.services.bdd.spec.HapiApiSpec;
+import com.hedera.services.bdd.spec.HapiSpecOperation;
+import com.hedera.services.bdd.spec.transactions.crypto.HapiCryptoUpdate;
+import com.hedera.services.bdd.suites.HapiApiSuite;
+import com.hedera.services.yahcli.config.ConfigManager;
+import com.hedera.services.yahcli.config.ConfigUtils;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Nullable;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 public class StakeSuite extends HapiApiSuite {
     private static final Logger log = LogManager.getLogger(StakeSuite.class);
     private static final String STAKER_KEY_IF_NEEDED = "STAKER_KEY";
 
-    public enum TargetType {NODE, ACCOUNT, NONE}
+    public enum TargetType {
+        NODE,
+        ACCOUNT,
+        NONE
+    }
 
     private final ConfigManager configManager;
     private final Map<String, String> specConfig;
@@ -44,9 +61,7 @@ public class StakeSuite extends HapiApiSuite {
         this.target = target;
         this.targetType = targetType;
         this.declineRewards = declineRewards;
-        this.stakingAccount = stakingAccount != null
-                ? Utils.extractAccount(stakingAccount)
-                : null;
+        this.stakingAccount = stakingAccount != null ? Utils.extractAccount(stakingAccount) : null;
         this.configManager = configManager;
     }
 
@@ -60,12 +75,12 @@ public class StakeSuite extends HapiApiSuite {
             return noOp();
         } else {
             return keyFromFile(
-                    STAKER_KEY_IF_NEEDED,
-                    uncheckedKeyFileFor(
-                                    configManager.keysLoc(),
-                                    "account" + numberOf(stakingAccount))
-                            .getAbsolutePath()
-            ).yahcliLogged();
+                            STAKER_KEY_IF_NEEDED,
+                            uncheckedKeyFileFor(
+                                            configManager.keysLoc(),
+                                            "account" + numberOf(stakingAccount))
+                                    .getAbsolutePath())
+                    .yahcliLogged();
         }
     }
 
@@ -74,16 +89,12 @@ public class StakeSuite extends HapiApiSuite {
     }
 
     private HapiApiSpec doStake() {
-        final var toUpdate = stakingAccount == null
-                ? DEFAULT_PAYER : stakingAccount;
+        final var toUpdate = stakingAccount == null ? DEFAULT_PAYER : stakingAccount;
         return customHapiSpec("DoStake")
-                .withProperties(specConfig).given(
-                        importKeyIfNecessary()
-                ).when().then(
-                        customized(cryptoUpdate(toUpdate)
-                                .blankMemo()
-                                .withYahcliLogging())
-                );
+                .withProperties(specConfig)
+                .given(importKeyIfNecessary())
+                .when()
+                .then(customized(cryptoUpdate(toUpdate).blankMemo().withYahcliLogging()));
     }
 
     private HapiCryptoUpdate customized(final HapiCryptoUpdate baseUpdate) {

--- a/test-clients/src/main/java/com/hedera/services/yahcli/suites/StakeSuite.java
+++ b/test-clients/src/main/java/com/hedera/services/yahcli/suites/StakeSuite.java
@@ -1,0 +1,110 @@
+package com.hedera.services.yahcli.suites;
+
+
+import com.hedera.services.bdd.spec.HapiApiSpec;
+import com.hedera.services.bdd.spec.HapiSpecOperation;
+import com.hedera.services.bdd.spec.transactions.crypto.HapiCryptoUpdate;
+import com.hedera.services.bdd.suites.HapiApiSuite;
+import com.hedera.services.yahcli.config.ConfigManager;
+import com.hedera.services.yahcli.config.ConfigUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import javax.annotation.Nullable;
+import java.util.List;
+import java.util.Map;
+
+import static com.hedera.services.bdd.spec.HapiApiSpec.customHapiSpec;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoUpdate;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.keyFromFile;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.noOp;
+import static com.hedera.services.yahcli.config.ConfigUtils.uncheckedKeyFileFor;
+
+public class StakeSuite extends HapiApiSuite {
+    private static final Logger log = LogManager.getLogger(StakeSuite.class);
+    private static final String STAKER_KEY_IF_NEEDED = "STAKER_KEY";
+
+    public enum TargetType {NODE, ACCOUNT, NONE}
+
+    private final ConfigManager configManager;
+    private final Map<String, String> specConfig;
+    private final String stakingAccount;
+    private final String target;
+    private final TargetType targetType;
+    private final Boolean declineRewards;
+
+    public StakeSuite(
+            final ConfigManager configManager,
+            final Map<String, String> specConfig,
+            final String target,
+            final TargetType targetType,
+            @Nullable final String stakingAccount,
+            @Nullable final Boolean declineRewards) {
+        this.specConfig = specConfig;
+        this.target = target;
+        this.targetType = targetType;
+        this.declineRewards = declineRewards;
+        this.stakingAccount = stakingAccount != null
+                ? Utils.extractAccount(stakingAccount)
+                : null;
+        this.configManager = configManager;
+    }
+
+    @Override
+    public List<HapiApiSpec> getSpecsInSuite() {
+        return List.of(doStake());
+    }
+
+    private HapiSpecOperation importKeyIfNecessary() {
+        if (stakingAccount == null) {
+            return noOp();
+        } else {
+            return keyFromFile(
+                    STAKER_KEY_IF_NEEDED,
+                    uncheckedKeyFileFor(
+                                    configManager.keysLoc(),
+                                    "account" + numberOf(stakingAccount))
+                            .getAbsolutePath()
+            ).yahcliLogged();
+        }
+    }
+
+    private long numberOf(final String id) {
+        return Long.parseLong(id.substring(id.lastIndexOf(".") + 1));
+    }
+
+    private HapiApiSpec doStake() {
+        final var toUpdate = stakingAccount == null
+                ? DEFAULT_PAYER : stakingAccount;
+        return customHapiSpec("DoStake")
+                .withProperties(specConfig).given(
+                        importKeyIfNecessary()
+                ).when().then(
+                        customized(cryptoUpdate(toUpdate)
+                                .blankMemo()
+                                .withYahcliLogging())
+                );
+    }
+
+    private HapiCryptoUpdate customized(final HapiCryptoUpdate baseUpdate) {
+        if (targetType == TargetType.ACCOUNT) {
+            baseUpdate.newStakedAccountId(ConfigUtils.asId(target));
+        } else if (targetType == TargetType.NODE) {
+            baseUpdate.newStakedNodeId(Long.parseLong(target));
+        }
+        if (declineRewards != null) {
+            baseUpdate.newDeclinedReward(declineRewards);
+        }
+        if (stakingAccount == null) {
+            baseUpdate.signedBy(DEFAULT_PAYER);
+        } else {
+            baseUpdate.signedBy(DEFAULT_PAYER, STAKER_KEY_IF_NEEDED);
+        }
+        return baseUpdate.fee(ONE_HBAR);
+    }
+
+    @Override
+    protected Logger getResultsLogger() {
+        return log;
+    }
+}

--- a/test-clients/src/main/java/com/hedera/services/yahcli/suites/Utils.java
+++ b/test-clients/src/main/java/com/hedera/services/yahcli/suites/Utils.java
@@ -15,20 +15,16 @@
  */
 package com.hedera.services.yahcli.suites;
 
-import static com.hedera.services.bdd.spec.transactions.TxnUtils.isIdLiteral;
-
 import com.hederahashgraph.api.proto.java.FileID;
+
 import java.io.File;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
-import java.util.Arrays;
-import java.util.EnumSet;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
+
+import static com.hedera.services.bdd.spec.transactions.TxnUtils.isIdLiteral;
 
 public class Utils {
     private static final DateTimeFormatter DATE_TIME_FORMAT =
@@ -51,7 +47,7 @@ public class Utils {
         }
     }
 
-    static String extractAccount(final String account) {
+    public static String extractAccount(final String account) {
         if (isIdLiteral(account)) {
             return account;
         } else {

--- a/test-clients/src/main/java/com/hedera/services/yahcli/suites/Utils.java
+++ b/test-clients/src/main/java/com/hedera/services/yahcli/suites/Utils.java
@@ -15,16 +15,15 @@
  */
 package com.hedera.services.yahcli.suites;
 
-import com.hederahashgraph.api.proto.java.FileID;
+import static com.hedera.services.bdd.spec.transactions.TxnUtils.isIdLiteral;
 
+import com.hederahashgraph.api.proto.java.FileID;
 import java.io.File;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.*;
 import java.util.stream.Collectors;
-
-import static com.hedera.services.bdd.spec.transactions.TxnUtils.isIdLiteral;
 
 public class Utils {
     private static final DateTimeFormatter DATE_TIME_FORMAT =

--- a/test-clients/yahcli/README.md
+++ b/test-clients/yahcli/README.md
@@ -24,6 +24,7 @@ appear below.
 12. [Getting deployed version info of a network](#get-version-info)
 13. [Creating a new key](#generate-a-new-ed25519-key)
 14. [Printing key details](#printing-key-details)
+15. [Changing a staking election](#changing-a-staking-election)
 
 # Setting up the working directory
 
@@ -440,4 +441,28 @@ $ docker run -it -v $(pwd):/launch gcr.io/hedera-registry/yahcli:0.2.6 keys prin
 .i. The public key @ novel.pem is : 4351607d4a00821e6cbd8e8c186bfa3a2b8fdb5ca81cf1e5f84e95a86875fd84
 .i. The private key @ novel.pem is: ea52bce1ad54a88e156f50840e856b941f9b0db09266660c953cd14205546ca2
 .i.   -> With DER prefix; 302e020100300506032b657004220420ea52bce1ad54a88e156f50840e856b941f9b0db09266660c953cd14205546ca2
+```
+
+# Changing a staking election
+
+You can elect to stake to either a node or another account. With no other arguments, the `accounts stake` subcommand 
+updates the payer account's election. For example,
+```
+$ docker run -it -v $(pwd):/launch gcr.io/hedera-registry/yahcli:0.2.6 -n localhost -p 2 accounts stake --to-node-id 0
+...
+.i. SUCCESS - account 0.0.2 is now staked to NODE 0
+
+$ docker run -it -v $(pwd):/launch gcr.io/hedera-registry/yahcli:0.2.6 -n localhost -p 2 accounts stake --to-account-num 1001
+...
+.i. SUCCESS - account 0.0.2 is now staked to ACCOUNT 0.0.1001
+```
+
+You can also change the staking election of an account other than the payer **if** yahcli can access the account's key in 
+PEM or mnemonic form. For example,
+```
+$ ls localhost/keys/account1001.*
+localhost/keys/account1001.pass		localhost/keys/account1001.pem		localhost/keys/account1001.words
+$ docker run -it -v $(pwd):/launch gcr.io/hedera-registry/yahcli:0.2.6 -n localhost -p 2 accounts stake --to-node-id 0 1001
+...
+.i. SUCCESS - account 0.0.1001 is now staked to NODE 0
 ```

--- a/test-clients/yahcli/README.md
+++ b/test-clients/yahcli/README.md
@@ -1,4 +1,4 @@
-# Yahcli v0.2.6
+# Yahcli v0.2.9
 Yahcli (_Yet Another Hedera Command Line Interface_) supports DevOps
 actions against the Hedera networks listed in a _config.yml_ file.
 
@@ -62,14 +62,14 @@ node by its IP adress. However, if the IP address given to the `-i` option does
 not appear in the _config.yml_, then we **must** explicitly give its node
 account via the `-a` option. So with the above _config.yml_, it is enough to do,
 ```
-$ docker run -it -v $(pwd):/launch gcr.io/hedera-registry/yahcli:0.2.6 -p 2 -n previewnet \
+$ docker run -it -v $(pwd):/launch gcr.io/hedera-registry/yahcli:0.2.9 -p 2 -n previewnet \
 > -i 35.231.208.148
 ```
 
 ...since the ip `35.231.208.148` is in the _config.yml_. But to use an IP not
 in the _config.yml_, we must also specify the node account, 
 ```
-$ docker run -it -v $(pwd):/launch gcr.io/hedera-registry/yahcli:0.2.6 -p 2 -n previewnet \
+$ docker run -it -v $(pwd):/launch gcr.io/hedera-registry/yahcli:0.2.9 -p 2 -n previewnet \
 > -i 35.199.15.177 -a 4
 ```
 
@@ -94,7 +94,7 @@ use with that network. :guard: &nbsp; If there is no corresponding
 `account{num}.pass` for a PEM file, please be ready to enter 
 the passphrase interactively in the console. For example,
 ```
-$ docker run -it -v $(pwd):/launch yahcli:0.2.6 -p 2 sysfiles download all 
+$ docker run -it -v $(pwd):/launch yahcli:0.2.9 -p 2 sysfiles download all 
 Targeting localhost, paying with 0.0.2
 Please enter the passphrase for key file localhost/keys/account2.pem: 
 ```
@@ -112,7 +112,7 @@ Note that yahcli does not support multi-sig accounts.
 
 To list all available commands,
 ```
-$ docker run -it -v $(pwd):/launch gcr.io/hedera-registry/yahcli:0.2.6 help
+$ docker run -it -v $(pwd):/launch gcr.io/hedera-registry/yahcli:0.2.9 help
 ``` 
 
 :information_desk_person: &nbsp; Since the only key we have for previewnet
@@ -121,7 +121,7 @@ when running against this network.
 
 To download the fee schedules from previewnet given the config above, we run,
 ```
-$ docker run -it -v $(pwd):/launch gcr.io/hedera-registry/yahcli:0.2.6 -p 2 -n previewnet sysfiles download fees
+$ docker run -it -v $(pwd):/launch gcr.io/hedera-registry/yahcli:0.2.9 -p 2 -n previewnet sysfiles download fees
 Targeting previewnet, paying with 0.0.2
 Downloading the fees...OK
 $ ls previewnet/sysfiles/
@@ -132,14 +132,14 @@ The fee schedules were downloaded in JSON form to _previewnet/sysfiles/feeSchedu
 To see more options for the `download` subcommand (including a custom download directory), 
 we run,
 ```
-$ docker run -it -v $(pwd):/launch gcr.io/hedera-registry/yahcli:0.2.6 sysfiles download help
+$ docker run -it -v $(pwd):/launch gcr.io/hedera-registry/yahcli:0.2.9 sysfiles download help
 ```
 
 The remaining sections of this document focus on specific use cases.
 
 # Getting account balances
 ```
-$ docker run -it -v $(pwd):/launch gcr.io/hedera-registry/yahcli:0.2.6 -n previewnet -p 2 accounts balance 56 50
+$ docker run -it -v $(pwd):/launch gcr.io/hedera-registry/yahcli:0.2.9 -n previewnet -p 2 accounts balance 56 50
 ```
 
 # Sending account funds
@@ -148,7 +148,7 @@ You can send funds from the default payer's account to a beneficiary account, in
 The default denomination is `hbar`. To change the memo for the `CryptoTransfer`, use the `--memo` option.
 
 ```
-$ docker run -it -v $(pwd):/launch gcr.io/hedera-registry/yahcli:0.2.6 -n previewnet -p 2 accounts send --denomination hbar --to 58 --memo "Yes or no" 1_000_000
+$ docker run -it -v $(pwd):/launch gcr.io/hedera-registry/yahcli:0.2.9 -n previewnet -p 2 accounts send --denomination hbar --to 58 --memo "Yes or no" 1_000_000
 
 ```
 
@@ -156,7 +156,7 @@ $ docker run -it -v $(pwd):/launch gcr.io/hedera-registry/yahcli:0.2.6 -n previe
 You can also create an entirely new account with an optional initial balance (default `0`) and memo (default blank).
 
 ```
-$ docker run -it -v $(pwd):/launch gcr.io/hedera-registry/yahcli:0.2.6 -n previewnet -p 2 accounts create -d hbar -a 1 --memo "Who danced between"
+$ docker run -it -v $(pwd):/launch gcr.io/hedera-registry/yahcli:0.2.9 -n previewnet -p 2 accounts create -d hbar -a 1 --memo "Who danced between"
 
 ```
 
@@ -186,7 +186,7 @@ localhost
 
 We first download the existing address book,
 ```
-$ docker run -it -v $(pwd):/launch gcr.io/hedera-registry/yahcli:0.2.6 -n localhost -p 2 sysfiles download address-book
+$ docker run -it -v $(pwd):/launch gcr.io/hedera-registry/yahcli:0.2.9 -n localhost -p 2 sysfiles download address-book
 Targeting localhost, paying with 0.0.2
 Downloading the address-book...OK
 ```
@@ -216,12 +216,12 @@ files, respectively.
 
 And now we upload the new address book, this time using the address book admin `0.0.55` as the payer:
 ```
-$ docker run -it -v $(pwd):/launch gcr.io/hedera-registry/yahcli:0.2.6 -n localhost -p 55 sysfiles upload address-book
+$ docker run -it -v $(pwd):/launch gcr.io/hedera-registry/yahcli:0.2.9 -n localhost -p 55 sysfiles upload address-book
 ```
 
 Finally we re-download the book to see that the hex-encoded cert hash and RSA public key were uploaded as expected:
 ```
-$ docker run -it -v $(pwd):/launch gcr.io/hedera-registry/yahcli:0.2.6 -n localhost -p 2 sysfiles download address-book
+$ docker run -it -v $(pwd):/launch gcr.io/hedera-registry/yahcli:0.2.9 -n localhost -p 2 sysfiles download address-book
 Targeting localhost, paying with 0.0.2
 Downloading the address-book...OK
 $ tail -17 localhost/sysfiles/addressBook.json 
@@ -259,21 +259,21 @@ localhost/sysfiles/
 
 Then proceed as with any other `sysfiles upload` command, 
 ```
-$ docker run -it -v $(pwd):/launch gcr.io/hedera-registry/yahcli:0.2.6 -n localhost -p 58 sysfiles upload software-zip
+$ docker run -it -v $(pwd):/launch gcr.io/hedera-registry/yahcli:0.2.9 -n localhost -p 58 sysfiles upload software-zip
 ...
-$ docker run -it -v $(pwd):/launch gcr.io/hedera-registry/yahcli:0.2.6 -n localhost -p 58 sysfiles upload telemetry-zip
+$ docker run -it -v $(pwd):/launch gcr.io/hedera-registry/yahcli:0.2.9 -n localhost -p 58 sysfiles upload telemetry-zip
 ...
 ```
 
-:repeat:&nbsp;Since `yahcli:0.2.6` you can add the `--restart-from-failure` option like,
+:repeat:&nbsp;Since `yahcli:0.2.9` you can add the `--restart-from-failure` option like,
 ```
-$ docker run -it -v $(pwd):/launch gcr.io/hedera-registry/yahcli:0.2.6 -n localhost -p 58 sysfiles upload software-zip --restart-from-failure
+$ docker run -it -v $(pwd):/launch gcr.io/hedera-registry/yahcli:0.2.9 -n localhost -p 58 sysfiles upload software-zip --restart-from-failure
 ```
 
 If the hash of the file on the network matches the hash of a prefix of the bytes you're uploading, then yahcli will
 automatically restart the upload after that prefix. For example,
 ```
-$ docker run -it -v $(pwd):/launch gcr.io/hedera-registry/yahcli:0.2.6 -n localhost -p 58 sysfiles upload software-zip
+$ docker run -it -v $(pwd):/launch gcr.io/hedera-registry/yahcli:0.2.9 -n localhost -p 58 sysfiles upload software-zip
 Log level is WARN
 Targeting localhost, paying with 0.0.2
 .i. Continuing upload for 0.0.150 with 34 appends already finished (out of 97 appends required)
@@ -284,7 +284,7 @@ Targeting localhost, paying with 0.0.2
 
 You can also directly check the SHA-384 hash of a special file with the `sysfiles hash-check` subcommand,
 ```
-$ docker run -it -v $(pwd):/launch gcr.io/hedera-registry/yahcli:0.2.6 -n localhost -p 58 sysfiles hash-check software-zip
+$ docker run -it -v $(pwd):/launch gcr.io/hedera-registry/yahcli:0.2.9 -n localhost -p 58 sysfiles hash-check software-zip
 ```
 
 ### Recovering from a failed special file upload
@@ -297,7 +297,7 @@ $ docker run -it -v $(pwd):/launch gcr.io/hedera-registry/yahcli:0.2.6 -n localh
 Services will be validated by type; to see all supported options, run,
 
 ```
-$ docker run -it -v $(pwd):/launch gcr.io/hedera-registry/yahcli:0.2.6 -n localhost -p 2 validate help
+$ docker run -it -v $(pwd):/launch gcr.io/hedera-registry/yahcli:0.2.9 -n localhost -p 2 validate help
 ```
 
 # Preparing an NMT software upgrade
@@ -308,7 +308,7 @@ SHA-384 hash of this ZIP must be given so the nodes can validate the integrity o
 staging its artifacts for NMT to use. This looks like,
 
 ```
-$ docker run -it -v $(pwd):/launch gcr.io/hedera-registry/yahcli:0.2.6 -n localhost -p 58 prepare-upgrade \
+$ docker run -it -v $(pwd):/launch gcr.io/hedera-registry/yahcli:0.2.9 -n localhost -p 58 prepare-upgrade \
 > --upgrade-zip-hash 5d3b0e619d8513dfbf606ef00a2e83ba97d736f5f5ba61561d895ea83a6d4c34fce05d6cd74c83ec171f710e37e12aab
 ```
 
@@ -320,7 +320,7 @@ SHA-384 hash of this ZIP must be known so the nodes can validate the integrity o
 staging its artifacts for NMT to use.  This looks like,
 
 ```
-$ docker run -it -v $(pwd):/launch gcr.io/hedera-registry/yahcli:0.2.6 -n localhost -p 58 upgrade-telemetry \
+$ docker run -it -v $(pwd):/launch gcr.io/hedera-registry/yahcli:0.2.9 -n localhost -p 58 upgrade-telemetry \
 > --upgrade-zip-hash 8ec75ab44b6c8ccac4a6e7f7d77b5a66280cad8d8a86ed961975a3bea597613f83af9075f65786bf9101d50047ca768f \
 > --start-time 2022-01-01.00:00:00
 ```
@@ -333,21 +333,21 @@ software upgrade.
 
 A vanilla freeze with no NMT upgrade only includes the start time, 
 ```
-$ docker run -it -v $(pwd):/launch gcr.io/hedera-registry/yahcli:0.2.6 -n localhost -p 58 freeze \
+$ docker run -it -v $(pwd):/launch gcr.io/hedera-registry/yahcli:0.2.9 -n localhost -p 58 freeze \
 > --start-time 2022-01-01.00:00:00
 ```
 
 While a freeze that should trigger a staged NMT upgrade uses the `freeze-upgrade` variant,
 which **must** repeat the hash of the intended update, 
 ```
-$ docker run -it -v $(pwd):/launch gcr.io/hedera-registry/yahcli:0.2.6 -n localhost -p 58 freeze-upgrade \
+$ docker run -it -v $(pwd):/launch gcr.io/hedera-registry/yahcli:0.2.9 -n localhost -p 58 freeze-upgrade \
 > --upgrade-zip-hash 5d3b0e619d8513dfbf606ef00a2e83ba97d736f5f5ba61561d895ea83a6d4c34fce05d6cd74c83ec171f710e37e12aab
 > --start-time 2021-09-09.20:11:13 
 ```
 
 To abort a scheduled freeze, simply use the `freeze-abort` command,
 ```
-$ docker run -it -v $(pwd):/launch gcr.io/hedera-registry/yahcli:0.2.6 -n localhost -p 58 freeze-abort 
+$ docker run -it -v $(pwd):/launch gcr.io/hedera-registry/yahcli:0.2.9 -n localhost -p 58 freeze-abort 
 ```
 
 # Updating account keys
@@ -357,7 +357,7 @@ can be either PEM files or BIP-39 mnemonics.)
 
 Our first example uses a randomly generated new key,
 ```
-$ docker run -it -v $(pwd):/launch gcr.io/hedera-registry/yahcli:0.2.6 -p 2 -n localhost \
+$ docker run -it -v $(pwd):/launch gcr.io/hedera-registry/yahcli:0.2.9 -p 2 -n localhost \
 > accounts rekey --gen-new-key 57
 Targeting localhost, paying with 0.0.2
 .i. Exported a newly generated key in PEM format to localhost/keys/account57.pem
@@ -379,7 +379,7 @@ localhost/keys
 
 For the next example, we specify an existing PEM file, and enter its passphrase when prompted,
 ```
-$ docker run -it -v $(pwd):/launch gcr.io/hedera-registry/yahcli:0.2.6 -p 57 -n localhost \
+$ docker run -it -v $(pwd):/launch gcr.io/hedera-registry/yahcli:0.2.9 -p 57 -n localhost \
 > accounts rekey -k new-account57.pem 57
 Targeting localhost, paying with 0.0.2
 Please enter the passphrase for key file new-account55.pem: 
@@ -391,7 +391,7 @@ In our final example, we replace the `0.0.57` key from a mnemonic,
 ```
 $ cat new-account57.words
 goddess maze eternal small normal october ... author
-$ docker run -it -v $(pwd):/launch gcr.io/hedera-registry/yahcli:0.2.6 -p 57 -n localhost \
+$ docker run -it -v $(pwd):/launch gcr.io/hedera-registry/yahcli:0.2.9 -p 57 -n localhost \
 > accounts rekey -k new-account57.words 57
 Targeting localhost, paying with 0.0.2
 .i. Exported key from new-account55 to localhost/keys/account57.pem
@@ -400,7 +400,7 @@ Targeting localhost, paying with 0.0.2
 
 # Get version info
 ```
-$ docker run -it -v $(pwd):/launch gcr.io/hedera-registry/yahcli:0.2.6 -n previewnet -p 2 version
+$ docker run -it -v $(pwd):/launch gcr.io/hedera-registry/yahcli:0.2.9 -n previewnet -p 2 version
 ```
 
 # Generate a new Ed25519 key
@@ -408,7 +408,7 @@ $ docker run -it -v $(pwd):/launch gcr.io/hedera-registry/yahcli:0.2.6 -n previe
 You can use yahcli to generate a new Ed25519 key in PEM and mnemonic forms; note that 
 ECDSA(secp256k1) keys are not yet supported. The most common pattern will likely be,
 ```
-$ docker run -it -v $(pwd):/launch gcr.io/hedera-registry/yahcli:0.2.6 keys gen-new -p novel.pem
+$ docker run -it -v $(pwd):/launch gcr.io/hedera-registry/yahcli:0.2.9 keys gen-new -p novel.pem
 .i. Generating a new key @ novel.pem
 .i.  - The public key is: 4351607d4a00821e6cbd8e8c186bfa3a2b8fdb5ca81cf1e5f84e95a86875fd84
 .i.  - Passphrase @ novel.pass
@@ -429,15 +429,15 @@ generated passphrase in a _.pass_ file.
 
 If you have a PEM or mnemonic file for an Ed25519 key pair and need to extract the public key, you can run,
 ```
-$ docker run -it -v $(pwd):/launch gcr.io/hedera-registry/yahcli:0.2.6 keys print-public -p novel.pem -x PkpcBBYCjd7K
+$ docker run -it -v $(pwd):/launch gcr.io/hedera-registry/yahcli:0.2.9 keys print-public -p novel.pem -x PkpcBBYCjd7K
 .i. The public key @ novel.pem is: 4351607d4a00821e6cbd8e8c186bfa3a2b8fdb5ca81cf1e5f84e95a86875fd84
-$ docker run -it -v $(pwd):/launch gcr.io/hedera-registry/yahcli:0.2.6 keys print-public -p novel.words
+$ docker run -it -v $(pwd):/launch gcr.io/hedera-registry/yahcli:0.2.9 keys print-public -p novel.words
 .i. The public key @ novel.words is: 4351607d4a00821e6cbd8e8c186bfa3a2b8fdb5ca81cf1e5f84e95a86875fd84 
 ```
 
 If you need both the public and private keys, use instead the `print-keys` subcommand,
 ```
-$ docker run -it -v $(pwd):/launch gcr.io/hedera-registry/yahcli:0.2.6 keys print-keys -p novel.pem -x PkpcBBYCjd7K
+$ docker run -it -v $(pwd):/launch gcr.io/hedera-registry/yahcli:0.2.9 keys print-keys -p novel.pem -x PkpcBBYCjd7K
 .i. The public key @ novel.pem is : 4351607d4a00821e6cbd8e8c186bfa3a2b8fdb5ca81cf1e5f84e95a86875fd84
 .i. The private key @ novel.pem is: ea52bce1ad54a88e156f50840e856b941f9b0db09266660c953cd14205546ca2
 .i.   -> With DER prefix; 302e020100300506032b657004220420ea52bce1ad54a88e156f50840e856b941f9b0db09266660c953cd14205546ca2
@@ -448,21 +448,48 @@ $ docker run -it -v $(pwd):/launch gcr.io/hedera-registry/yahcli:0.2.6 keys prin
 You can elect to stake to either a node or another account. With no other arguments, the `accounts stake` subcommand 
 updates the payer account's election. For example,
 ```
-$ docker run -it -v $(pwd):/launch gcr.io/hedera-registry/yahcli:0.2.6 -n localhost -p 2 accounts stake --to-node-id 0
+$ docker run -it -v $(pwd):/launch gcr.io/hedera-registry/yahcli:0.2.9 -n localhost -p 2 accounts stake --to-node-id 0
 ...
 .i. SUCCESS - account 0.0.2 is now staked to NODE 0
 
-$ docker run -it -v $(pwd):/launch gcr.io/hedera-registry/yahcli:0.2.6 -n localhost -p 2 accounts stake --to-account-num 1001
+$ docker run -it -v $(pwd):/launch gcr.io/hedera-registry/yahcli:0.2.9 -n localhost -p 2 accounts stake --to-account-num 1001
 ...
 .i. SUCCESS - account 0.0.2 is now staked to ACCOUNT 0.0.1001
 ```
+
+## Electing for a non-payer account
 
 You can also change the staking election of an account other than the payer **if** yahcli can access the account's key in 
 PEM or mnemonic form. For example,
 ```
 $ ls localhost/keys/account1001.*
 localhost/keys/account1001.pass		localhost/keys/account1001.pem		localhost/keys/account1001.words
-$ docker run -it -v $(pwd):/launch gcr.io/hedera-registry/yahcli:0.2.6 -n localhost -p 2 accounts stake --to-node-id 0 1001
+$ docker run -it -v $(pwd):/launch gcr.io/hedera-registry/yahcli:0.2.9 -n localhost -p 2 accounts stake --to-node-id 0 1001
 ...
 .i. SUCCESS - account 0.0.1001 is now staked to NODE 0
 ```
+
+## Declining rewards 
+
+With any of the above commands, you can add the `--start-declining-rewards` or `--stop-declining-rewards` option to
+set the corresponding field in the underlying HAPI `CryptoUpdate`. For example,
+```
+$ docker run -it -v $(pwd):/launch gcr.io/hedera-registry/yahcli:0.2.9 -n stabletestnet -p 45949104 accounts stake --start-declining-rewards --to-node-id 2
+Log level is WARN
+Targeting stabletestnet, paying with 0.0.45949104
+
+---- Raw update ----
+
+accountIDToUpdate {
+  accountNum: 45949104
+}
+staked_node_id: 2
+decline_reward {
+  value: true
+}
+
+--------------------
+
+.i. SUCCESS - account 0.0.45949104 updated, now staked to NODE 2 with declineReward=true
+```
+

--- a/test-clients/yahcli/run/build.sh
+++ b/test-clients/yahcli/run/build.sh
@@ -1,5 +1,5 @@
 #! /bin/sh
-TAG=${1:-'0.2.7'}
+TAG=${1:-'0.2.8'}
 
 cd ../..
 ./gradlew shadowJar \

--- a/test-clients/yahcli/run/build.sh
+++ b/test-clients/yahcli/run/build.sh
@@ -1,5 +1,5 @@
 #! /bin/sh
-TAG=${1:-'0.2.8'}
+TAG=${1:-'0.2.9'}
 
 cd ../..
 ./gradlew shadowJar \

--- a/test-clients/yahcli/run/publish.sh
+++ b/test-clients/yahcli/run/publish.sh
@@ -1,5 +1,5 @@
 #! /bin/sh
-TAG=${1:-'0.2.6'}
+TAG=${1:-'0.2.8'}
 
 cd ../..
 ./gradlew shadowJar \

--- a/test-clients/yahcli/run/publish.sh
+++ b/test-clients/yahcli/run/publish.sh
@@ -1,5 +1,5 @@
 #! /bin/sh
-TAG=${1:-'0.2.8'}
+TAG=${1:-'0.2.9'}
 
 cd ../..
 ./gradlew shadowJar \


### PR DESCRIPTION
**Description**:
 - Adds the `accounts stake` subcommand to yahcli; please see the README section [here](https://github.com/hashgraph/hedera-services/blob/04058-yahcli-staking/test-clients/yahcli/README.md#changing-a-staking-election).
 - Functionality is deployed in tag `gcr.io/hedera-registry/yahcli:0.2.9`