### PR TITLE
Ensure CircleCI cron tasks run on the develop branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -645,7 +645,7 @@ workflows:
           filters:
             branches:
               only:
-                - master
+                - develop
     jobs:
       - jrs_gcp_machine_cleanup:
           name: GCP-Machine-Cleanup
@@ -663,7 +663,7 @@ workflows:
           filters:
             branches:
               only:
-                - master
+                - develop
     jobs:
       - build-platform-and-services
       - jrs-regression:
@@ -685,7 +685,7 @@ workflows:
           filters:
             branches:
               only:
-                - master
+                - develop
     jobs:
       - build-platform-and-services
       - jrs-regression:
@@ -708,7 +708,7 @@ workflows:
           filters:
             branches:
               only:
-                - master
+                - develop
     jobs:
       - build-platform-and-services
       - jrs-regression:
@@ -731,7 +731,7 @@ workflows:
           filters:
             branches:
               only:
-                - master
+                - develop
     jobs:
       - build-platform-and-services
       - jrs-regression:
@@ -754,7 +754,7 @@ workflows:
           filters:
             branches:
               only:
-                - master
+                - develop
     jobs:
       - build-platform-and-services
       - jrs-regression:
@@ -798,7 +798,7 @@ workflows:
                 at: /
 
 
-  # This workflow will be running normally in master branch on a daily basis
+  # This workflow will be running normally in develop branch on a daily basis
 
   GCP-Daily-Services-Crypto-Migration-7N-1C:
     triggers:
@@ -807,7 +807,7 @@ workflows:
           filters:
             branches:
               only:
-                - master
+                - develop
     jobs:
       - build-platform-and-services
       - jrs-regression:
@@ -859,7 +859,7 @@ workflows:
           filters:
             branches:
               only:
-                - master
+                - develop
     jobs:
       - build-platform-and-services
       - jrs-regression:
@@ -882,7 +882,7 @@ workflows:
           filters:
             branches:
               only:
-                - master
+                - develop
     jobs:
       - build-platform-and-services
       - jrs-regression:
@@ -905,7 +905,7 @@ workflows:
           filters:
             branches:
               only:
-                - master
+                - develop
     jobs:
       - build-platform-and-services
       - jrs-regression:
@@ -928,7 +928,7 @@ workflows:
           filters:
             branches:
               only:
-                - master
+                - develop
     jobs:
       - build-platform-and-services
       - jrs-regression:
@@ -951,7 +951,7 @@ workflows:
           filters:
             branches:
               only:
-                - master
+                - develop
     jobs:
       - build-platform-and-services
       - jrs-regression:
@@ -974,7 +974,7 @@ workflows:
           filters:
             branches:
               only:
-                - master
+                - develop
     jobs:
       - build-platform-and-services
       - jrs-regression:
@@ -997,7 +997,7 @@ workflows:
           filters:
             branches:
               only:
-                - master
+                - develop
     jobs:
       - build-platform-and-services
       - jrs-regression:
@@ -1020,7 +1020,7 @@ workflows:
           filters:
             branches:
               only:
-                - master
+                - develop
     jobs:
       - build-platform-and-services
       - jrs-regression:
@@ -1043,7 +1043,7 @@ workflows:
           filters:
             branches:
               only:
-                - master
+                - develop
     jobs:
       - build-platform-and-services
       - jrs-regression:
@@ -1066,7 +1066,7 @@ workflows:
           filters:
             branches:
               only:
-                - master
+                - develop
     jobs:
       - build-platform-and-services
       - jrs-regression:
@@ -1089,7 +1089,7 @@ workflows:
           filters:
             branches:
               only:
-                - master
+                - develop
     jobs:
       - build-platform-and-services
       - jrs-regression:
@@ -1112,7 +1112,7 @@ workflows:
           filters:
             branches:
               only:
-                - master
+                - develop
     jobs:
       - build-platform-and-services
       - jrs-regression:
@@ -1135,7 +1135,7 @@ workflows:
           filters:
             branches:
               only:
-                - master
+                - develop
     jobs:
       - build-platform-and-services
       - jrs-regression:
@@ -1159,7 +1159,7 @@ workflows:
           filters:
             branches:
               only:
-                - master
+                - develop
     jobs:
       - build-platform-and-services
       - jrs-regression:
@@ -1183,7 +1183,7 @@ workflows:
           filters:
             branches:
               only:
-                - master
+                - develop
     jobs:
       - build-platform-and-services
       - jrs-regression:
@@ -1206,7 +1206,7 @@ workflows:
           filters:
             branches:
               only:
-                - master
+                - develop
     jobs:
       - build-platform-and-services
       - jrs-regression:
@@ -1229,7 +1229,7 @@ workflows:
           filters:
             branches:
               only:
-                - master
+                - develop
     jobs:
       - build-platform-and-services
       - jrs-regression:
@@ -1252,7 +1252,7 @@ workflows:
           filters:
             branches:
               only:
-                - master
+                - develop
     jobs:
       - build-platform-and-services
       - jrs-regression:
@@ -1275,7 +1275,7 @@ workflows:
           filters:
             branches:
               only:
-                - master
+                - develop
     jobs:
       - build-platform-and-services
       - jrs-regression:
@@ -1298,7 +1298,7 @@ workflows:
           filters:
             branches:
               only:
-                - master
+                - develop
     jobs:
       - build-platform-and-services
       - jrs-regression:
@@ -1322,7 +1322,7 @@ workflows:
           filters:
             branches:
               only:
-                - master
+                - develop
     jobs:
       - build-platform-and-services
       - jrs-regression:
@@ -1345,7 +1345,7 @@ workflows:
           filters:
             branches:
               only:
-                - master
+                - develop
     jobs:
       - build-platform-and-services
       - jrs-regression:
@@ -1368,7 +1368,7 @@ workflows:
           filters:
             branches:
               only:
-                - master
+                - develop
     jobs:
       - build-platform-and-services
       - jrs-regression:
@@ -1391,7 +1391,7 @@ workflows:
           filters:
             branches:
               only:
-                - master
+                - develop
     jobs:
       - build-platform-and-services
       - jrs-regression:
@@ -1414,7 +1414,7 @@ workflows:
           filters:
             branches:
               only:
-                - master
+                - develop
     jobs:
       - build-platform-and-services
       - jrs-regression:


### PR DESCRIPTION
## Description

Updates the CircleCI cron jobs to only execute against the `develop` branch instead of the `master` branch.

### Related Issues

- Closes #4098 