### PR TITLE
Resolve classpath issues with the Gradle run task

### DIFF
--- a/hedera-node/hedera-mono-service/build.gradle.kts
+++ b/hedera-node/hedera-mono-service/build.gradle.kts
@@ -118,9 +118,11 @@ tasks.assemble {
 
 // Create the "run" task for running a Hedera consensus node
 tasks.register<JavaExec>("run") {
+    group = "application"
     dependsOn(tasks.assemble)
-    workingDir(project(":hedera-node").projectDir)
-    classpath(project(":hedera-node").file("data/apps/HederaNode.jar"))
+    workingDir = project(":hedera-node").projectDir
+    jvmArgs = listOf("-cp", "data/lib/*")
+    mainClass.set("com.swirlds.platform.Browser")
 }
 
 val cleanRun = tasks.register("cleanRun") {
@@ -131,7 +133,7 @@ val cleanRun = tasks.register("cleanRun") {
     prj.delete(File(prj.projectDir, "swirlds.jar"))
     prj.projectDir.list { _, fileName -> fileName.startsWith("MainNetStats") }
         ?.forEach { file ->
-            project.delete(file)
+            prj.delete(file)
         }
 
     val dataDir = File(prj.projectDir, "data")


### PR DESCRIPTION
## Description

Resolves the issues with the Gradle `run` task due to classpath issues related to several PRs which restructured the folder and module layouts.

### Related Issues

- Closes #4122 