### PR TITLE
Fix `ServicesApp` unit test

### DIFF
--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/services/ServicesApp.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/services/ServicesApp.java
@@ -200,6 +200,9 @@ public interface ServicesApp {
         Builder platform(Platform platform);
 
         @BindsInstance
+        Builder consoleCreator(StateModule.ConsoleCreator consoleCreator);
+
+        @BindsInstance
         Builder selfId(long selfId);
 
         @BindsInstance

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/services/ServicesState.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/services/ServicesState.java
@@ -53,6 +53,7 @@ import com.swirlds.common.system.events.Event;
 import com.swirlds.fchashmap.FCHashMap;
 import com.swirlds.jasperdb.JasperDbBuilder;
 import com.swirlds.merkle.map.MerkleMap;
+import com.swirlds.platform.gui.SwirldsGui;
 import com.swirlds.platform.state.DualStateImpl;
 import com.swirlds.virtualmap.VirtualMap;
 import com.swirlds.virtualmap.VirtualMapMigration;
@@ -279,6 +280,7 @@ public class ServicesState extends PartialNaryMerkleInternal
                             .bootstrapProps(bootstrapProps)
                             .initialHash(initialHash)
                             .platform(platform)
+                            .consoleCreator(SwirldsGui::createConsole)
                             .crypto(CryptoFactory.getInstance())
                             .selfId(selfId)
                             .build();

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/services/state/StateModule.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/services/state/StateModule.java
@@ -71,6 +71,7 @@ import com.hedera.services.utils.NamedDigestFactory;
 import com.hedera.services.utils.Pause;
 import com.hedera.services.utils.SleepingPause;
 import com.hedera.services.utils.SystemExits;
+import com.swirlds.common.Console;
 import com.swirlds.common.crypto.Signature;
 import com.swirlds.common.notification.NotificationEngine;
 import com.swirlds.common.notification.NotificationFactory;
@@ -84,7 +85,6 @@ import com.swirlds.common.system.state.notifications.NewSignedStateListener;
 import com.swirlds.common.utility.CommonUtils;
 import com.swirlds.jasperdb.JasperDbBuilder;
 import com.swirlds.merkle.map.MerkleMap;
-import com.swirlds.platform.gui.SwirldsGui;
 import com.swirlds.virtualmap.VirtualMap;
 import dagger.Binds;
 import dagger.Module;
@@ -97,10 +97,16 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.Supplier;
+import javax.annotation.Nullable;
 import javax.inject.Singleton;
 
 @Module(includes = HandleLogicModule.class)
 public interface StateModule {
+    interface ConsoleCreator {
+        @Nullable
+        Console createConsole(Platform platform, boolean visible);
+    }
+
     @Binds
     @Singleton
     IssListener bindIssListener(ServicesIssListener servicesIssListener);
@@ -197,9 +203,9 @@ public interface StateModule {
 
     @Provides
     @Singleton
-    static Optional<PrintStream> providePrintStream(Platform platform) {
-        final var console = SwirldsGui.createConsole(platform, true);
-        return Optional.ofNullable(console).map(c -> c.out);
+    static Optional<PrintStream> providePrintStream(
+            final ConsoleCreator consoleCreator, final Platform platform) {
+        return Optional.ofNullable(consoleCreator.createConsole(platform, true)).map(c -> c.out);
     }
 
     @Provides

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/services/ServicesAppTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/services/ServicesAppTest.java
@@ -102,12 +102,14 @@ class ServicesAppTest {
                         .bootstrapProps(props)
                         .initialHash(EMPTY_HASH)
                         .platform(platform)
+                        .consoleCreator((ignore, visible) -> null)
                         .crypto(cryptography)
                         .selfId(selfId)
                         .build();
     }
 
     @Test
+    @SuppressWarnings("java:S5961")
     void objectGraphRootsAreAvailable() {
         assertThat(subject.eventExpansion(), instanceOf(EventExpansion.class));
         assertThat(subject.treasuryCloner(), instanceOf(TreasuryCloner.class));
@@ -140,7 +142,7 @@ class ServicesAppTest {
         assertThat(subject.virtualMapFactory(), instanceOf(VirtualMapFactory.class));
         assertThat(subject.prefetchProcessor(), instanceOf(PrefetchProcessor.class));
         assertSame(subject.nodeId(), selfNodeId);
-        assertSame(subject.pause(), SLEEPING_PAUSE);
+        assertSame(SLEEPING_PAUSE, subject.pause());
         assertTrue(subject.consoleOut().isEmpty());
     }
 }

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/services/ServicesStateTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/services/ServicesStateTest.java
@@ -372,6 +372,7 @@ class ServicesStateTest {
         given(appBuilder.bootstrapProps(any())).willReturn(appBuilder);
         given(appBuilder.crypto(any())).willReturn(appBuilder);
         given(appBuilder.staticAccountMemo(bookMemo)).willReturn(appBuilder);
+        given(appBuilder.consoleCreator(any())).willReturn(appBuilder);
         given(appBuilder.initialHash(EMPTY_HASH)).willReturn(appBuilder);
         given(appBuilder.platform(platform)).willReturn(appBuilder);
         given(appBuilder.selfId(1L)).willReturn(appBuilder);
@@ -435,6 +436,7 @@ class ServicesStateTest {
         given(appBuilder.bootstrapProps(any())).willReturn(appBuilder);
         given(appBuilder.crypto(any())).willReturn(appBuilder);
         given(appBuilder.staticAccountMemo(bookMemo)).willReturn(appBuilder);
+        given(appBuilder.consoleCreator(any())).willReturn(appBuilder);
         given(appBuilder.initialHash(EMPTY_HASH)).willReturn(appBuilder);
         given(appBuilder.platform(platform)).willReturn(appBuilder);
         given(appBuilder.selfId(1L)).willReturn(appBuilder);
@@ -804,6 +806,7 @@ class ServicesStateTest {
                 .initialHash(new Hash())
                 .platform(platform)
                 .crypto(CryptoFactory.getInstance())
+                .consoleCreator((ignore, visible) -> null)
                 .selfId(platform.getSelfId().getId())
                 .staticAccountMemo("memo")
                 .bootstrapProps(new BootstrapProperties())

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/services/state/StateModuleTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/services/state/StateModuleTest.java
@@ -40,6 +40,7 @@ class StateModuleTest {
     @Mock private MutableStateChildren workingState;
     @Mock private PropertySource properties;
     @Mock private NetworkInfo networkInfo;
+    @Mock private StateModule.ConsoleCreator consoleCreator;
 
     @Test
     void providesDefaultCharset() {


### PR DESCRIPTION
**Description**:
 - Make the `Console` creator a bound instance of `ServicesApp.Builder` so we can avoid calling `SwirldGui.createConsole()` during unit tests.