### PR TITLE
Avoid change to prod code for `@TestDir` PR

### DIFF
--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/services/txns/network/UpgradeActions.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/services/txns/network/UpgradeActions.java
@@ -151,11 +151,7 @@ public class UpgradeActions {
         return runAsync(
                 () -> {
                     try {
-                        var artifactsLocFile = new File(artifactsLoc);
-                        if (!artifactsLocFile.exists()) {
-                            artifactsLocFile.mkdirs();
-                        }
-                        FileUtils.cleanDirectory(artifactsLocFile);
+                        FileUtils.cleanDirectory(new File(artifactsLoc));
                         unzipAction.unzip(archiveData, artifactsLoc);
                         log.info(
                                 "Finished unzipping {} bytes for {} update into {}",

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/services/txns/network/UpgradeActionsTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/services/txns/network/UpgradeActionsTest.java
@@ -136,6 +136,7 @@ class UpgradeActionsTest {
         given(dynamicProperties.upgradeArtifactsLoc()).willReturn(markerFilesLoc);
         given(dualState.getFreezeTime()).willReturn(then);
         given(dualState.getLastFrozenTime()).willReturn(then);
+        assertTrue(new File(markerFilesLoc).mkdirs());
 
         subject.catchUpOnMissedSideEffects();
 
@@ -222,6 +223,7 @@ class UpgradeActionsTest {
     @Test
     void complainsLoudlyWhenUnableToUnzipArchive() throws IOException {
         rmIfPresent(EXEC_IMMEDIATE_MARKER);
+        assertTrue(new File(markerFilesLoc).mkdirs());
 
         given(dynamicProperties.upgradeArtifactsLoc()).willReturn(markerFilesLoc);
         willThrow(IOException.class).given(unzipAction).unzip(PRETEND_ARCHIVE, markerFilesLoc);
@@ -256,23 +258,9 @@ class UpgradeActionsTest {
     }
 
     @Test
-    void upgradeCreatesMissingWriteDirectory() {
-        final var d = Paths.get(markerFilesLoc).toFile();
-        if (d.exists()) {
-            assertTrue(d.delete());
-        }
-
-        given(dynamicProperties.upgradeArtifactsLoc()).willReturn(markerFilesLoc);
-
-        subject.extractSoftwareUpgrade(PRETEND_ARCHIVE).join();
-
-        assertTrue(d.exists());
-        rmIfPresent(EXEC_IMMEDIATE_MARKER);
-    }
-
-    @Test
     void upgradesTelemetry() throws IOException {
         rmIfPresent(EXEC_TELEMETRY_MARKER);
+        assertTrue(new File(markerFilesLoc).mkdirs());
 
         given(dynamicProperties.upgradeArtifactsLoc()).willReturn(markerFilesLoc);
 


### PR DESCRIPTION
Optional, avoids changing production code in this PR. (Shouldn't matter either way tho.)
