### PR TITLE
Add `NA` stake period start reset at reward account index

### DIFF
--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/services/ledger/interceptors/StakingAccountsCommitInterceptor.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/services/ledger/interceptors/StakingAccountsCommitInterceptor.java
@@ -208,6 +208,7 @@ public class StakingAccountsCommitInterceptor extends AccountsCommitInterceptor 
                     stakeChangeManager.findOrAdd(
                             accountNumbers.stakingRewardAccount(), pendingChanges);
             updateBalance(-rewardsPaid, fundingI, pendingChanges);
+            stakePeriodStartUpdates[fundingI] = NA;
         }
     }
 


### PR DESCRIPTION
**Description**:
 - Ensures the reward account's (meaningless) `stakePeriodStart` is always `NA`.