### PR TITLE
Fill `stakePeriodStartUpdates` array with `NA`

### DIFF
--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/services/ledger/interceptors/StakingAccountsCommitInterceptor.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/services/ledger/interceptors/StakingAccountsCommitInterceptor.java
@@ -427,7 +427,8 @@ public class StakingAccountsCommitInterceptor extends AccountsCommitInterceptor 
         }
         // The stakeChangeScenarios and stakePeriodStartUpdates arrays are filled and used
         // left-to-right only. We need to reset all the arrays to avoid causing any errors
-        // during reconnect.
+        // during reconnect. 0.0.800 will be added to the change-list in a reward situation,
+        // after this, it should have NA set instead of any old values.
 
         Arrays.fill(rewardsEarned, NA);
         Arrays.fill(stakeAtStartOfLastRewardedPeriodUpdates, NA);

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/services/ledger/interceptors/StakingAccountsCommitInterceptor.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/services/ledger/interceptors/StakingAccountsCommitInterceptor.java
@@ -426,10 +426,13 @@ public class StakingAccountsCommitInterceptor extends AccountsCommitInterceptor 
             stakePeriodStartUpdates = new long[maxImpliedChanges];
         }
         // The stakeChangeScenarios and stakePeriodStartUpdates arrays are filled and used
-        // left-to-right only
+        // left-to-right only. We need to reset all the arrays to avoid causing any errors
+        // during reconnect.
+
         Arrays.fill(rewardsEarned, NA);
         Arrays.fill(stakeAtStartOfLastRewardedPeriodUpdates, NA);
         Arrays.fill(stakedToMeUpdates, NA);
+        Arrays.fill(stakePeriodStartUpdates, NA);
     }
 
     private void setCurrentAndNewIds(

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/services/ledger/interceptors/StakingAccountsCommitInterceptorTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/services/ledger/interceptors/StakingAccountsCommitInterceptorTest.java
@@ -29,6 +29,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
@@ -888,6 +889,33 @@ class StakingAccountsCommitInterceptorTest {
 
         assertEquals(2 * HBARS_TO_TINYBARS, stakedToMeUpdates[0]);
         assertEquals(counterpartyBalance + 2 * HBARS_TO_TINYBARS, stakedToMeUpdates[1]);
+    }
+
+    @Test
+    void rewardAccountStakePeriodStartAlwaysReset() {
+        given(dynamicProperties.isStakingEnabled()).willReturn(true);
+        final var changes = buildChanges();
+        final var rewardPayment = 1L;
+        final var expectedFundingI = 2;
+        counterparty.setStakePeriodStart(stakePeriodStart - 2);
+
+        given(networkCtx.areRewardsActivated()).willReturn(true);
+        given(rewardCalculator.computePendingReward(counterparty)).willReturn(rewardPayment);
+        given(rewardCalculator.applyReward(rewardPayment, counterparty, changes.changes(1)))
+                .willReturn(true);
+        given(rewardCalculator.rewardsPaidInThisTxn()).willReturn(rewardPayment);
+        given(stakePeriodManager.startUpdateFor(anyLong(), anyLong(), anyBoolean(), anyBoolean()))
+                .willReturn(NA);
+        given(stakeChangeManager.findOrAdd(anyLong(), any()))
+                .willAnswer(
+                        invocation -> {
+                            changes.include(stakingFundId, new MerkleAccount(), new HashMap<>());
+                            return expectedFundingI;
+                        });
+        subject.getStakePeriodStartUpdates()[expectedFundingI] = 666L;
+
+        subject.preview(changes);
+        assertEquals(NA, subject.getStakePeriodStartUpdates()[expectedFundingI]);
     }
 
     public EntityChangeSet<AccountID, HederaAccount, AccountProperty>

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/services/ledger/interceptors/StakingAccountsCommitInterceptorTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/services/ledger/interceptors/StakingAccountsCommitInterceptorTest.java
@@ -894,6 +894,7 @@ class StakingAccountsCommitInterceptorTest {
     @Test
     void rewardAccountStakePeriodStartAlwaysReset() {
         given(dynamicProperties.isStakingEnabled()).willReturn(true);
+
         final var changes = buildChanges();
         final var rewardPayment = 1L;
         final var expectedFundingI = 2;


### PR DESCRIPTION
Fixes #4145 

Although the staking interceptor explicitly sets any stake-able account's value in the `stakePeriodStartUpdates` array, when `0.0.800` is added to the change-list in a reward situation, it will not always have a NA set in the `stakePeriodStartUpdates` array.

To avoid this reset the array for each transaction.