### PR TITLE
Delegate to `Serializable*Stream` serde in `ReplHederaKey` default implementation

### DIFF
--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/keys/impl/HederaEd25519Key.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/keys/impl/HederaEd25519Key.java
@@ -86,18 +86,8 @@ public class HederaEd25519Key implements ReplHederaKey {
     }
 
     @Override
-    public void serialize(final ByteBuffer to) throws IOException {
-        to.put(key, 0, key.length);
-    }
-
-    @Override
     public void serialize(final SerializableDataOutputStream out) throws IOException {
         out.write(key, 0, key.length);
-    }
-
-    @Override
-    public void deserialize(final ByteBuffer from, final int version) throws IOException {
-        from.get(key);
     }
 
     @Override

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/keys/impl/HederaKeyList.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/keys/impl/HederaKeyList.java
@@ -99,33 +99,12 @@ public class HederaKeyList implements ReplHederaKey {
     }
 
     @Override
-    public void serialize(final ByteBuffer buf) throws IOException {
-        try (final var baos = new ByteArrayOutputStream()) {
-            try (final var out = new SerializableDataOutputStream(baos)) {
-                this.serialize(out);
-            }
-            baos.flush();
-            buf.put(baos.toByteArray());
-        }
-    }
-
-    @Override
     public void serialize(final SerializableDataOutputStream out) throws IOException {
         final var len = keys.size();
         out.writeInt(len);
         for (final var key : keys) {
             out.writeSerializable(key, true);
         }
-    }
-
-    @Override
-    public void deserialize(final ByteBuffer buf, final int version) throws IOException {
-        try (final var bais = new ByteArrayInputStream(buf.array())) {
-            try (final var in = new SerializableDataInputStream(bais)) {
-                this.deserialize(in, version);
-            }
-        }
-        buf.position(buf.array().length);
     }
 
     @Override

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/spi/keys/ByteBufferBackedInputStream.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/spi/keys/ByteBufferBackedInputStream.java
@@ -1,0 +1,31 @@
+package com.hedera.node.app.spi.keys;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+
+public class ByteBufferBackedInputStream extends InputStream {
+    ByteBuffer buf;
+
+    public ByteBufferBackedInputStream(ByteBuffer buf) {
+        this.buf = buf;
+    }
+
+    public int read() throws IOException {
+        if (!buf.hasRemaining()) {
+            return -1;
+        }
+        return buf.get() & 0xFF;
+    }
+
+    public int read(byte[] bytes, int off, int len)
+            throws IOException {
+        if (!buf.hasRemaining()) {
+            return -1;
+        }
+
+        len = Math.min(len, buf.remaining());
+        buf.get(bytes, off, len);
+        return len;
+    }
+}

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/spi/keys/ReplHederaKey.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/spi/keys/ReplHederaKey.java
@@ -15,11 +15,38 @@
  */
 package com.hedera.node.app.spi.keys;
 
+import com.google.common.io.ByteStreams;
+import com.swirlds.common.io.streams.SerializableDataInputStream;
+import com.swirlds.common.io.streams.SerializableDataOutputStream;
 import com.swirlds.virtualmap.VirtualValue;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
 
 /**
  * Temporary key needed to not break existing code. This will be removed after legacy {@link
  * com.hedera.services.legacy.core.jproto.JKey} is replaced with {@link HederaKey}. Once this is
  * removed {@link HederaKey} will extend {@link VirtualValue}
  */
-public interface ReplHederaKey extends VirtualValue, HederaKey {}
+public interface ReplHederaKey extends VirtualValue, HederaKey {
+    @Override
+    default void serialize(final ByteBuffer buf) throws IOException {
+        try (final var baos = new ByteArrayOutputStream()) {
+            try (final var out = new SerializableDataOutputStream(baos)) {
+                this.serialize(out);
+            }
+            baos.flush();
+            buf.put(baos.toByteArray());
+        }
+    }
+
+    @Override
+    default void deserialize(final ByteBuffer buf, final int version) throws IOException {
+        try (final var bbIn = new ByteBufferBackedInputStream(buf)) {
+            try (final var in = new SerializableDataInputStream(bbIn)) {
+                this.deserialize(in, version);
+            }
+        }
+    }
+}


### PR DESCRIPTION
- Provides default `ReplHederaKey` serde for `ByteBuffer` that delegates to `Serializable*Stream` implementation.
- Uses `ByteBufferBackedInputStream` to wrap a `ByteBuffer` in an `InputStream` without requiring the buffer to have an on-heap backing `byte[]` array.