### PR TITLE
Extract parent class for HederaMessageCallProcessor

### DIFF
--- a/hedera-node/hedera-evm-api/src/main/java/com/hedera/services/evm/accounts/AccountAccessor.java
+++ b/hedera-node/hedera-evm-api/src/main/java/com/hedera/services/evm/accounts/AccountAccessor.java
@@ -20,4 +20,6 @@ import org.hyperledger.besu.datatypes.Address;
 public interface AccountAccessor {
 
     Address canonicalAddress(final Address addressOrAlias);
+
+    boolean isTokenAddress(final Address address);
 }

--- a/hedera-node/hedera-evm-api/src/main/java/com/hedera/services/evm/contracts/execution/HederaEvmMessageCallProcessor.java
+++ b/hedera-node/hedera-evm-api/src/main/java/com/hedera/services/evm/contracts/execution/HederaEvmMessageCallProcessor.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hedera.services.evm.contracts.execution;
 
 import static org.hyperledger.besu.evm.frame.ExceptionalHaltReason.INSUFFICIENT_GAS;
@@ -23,68 +38,68 @@ import org.hyperledger.besu.evm.tracing.OperationTracer;
 
 /** Overrides Besu precompiler handling, so we can break model layers in Precompile execution */
 public class HederaEvmMessageCallProcessor extends MessageCallProcessor {
-  private static final String INVALID_TRANSFER_MSG = "Transfer of Value to Hedera Precompile";
-  private static final Optional<ExceptionalHaltReason> ILLEGAL_STATE_CHANGE =
-      Optional.of(ExceptionalHaltReason.ILLEGAL_STATE_CHANGE);
-  public static final Bytes INVALID_TRANSFER =
-      Bytes.of(INVALID_TRANSFER_MSG.getBytes(StandardCharsets.UTF_8));
+    private static final String INVALID_TRANSFER_MSG = "Transfer of Value to Hedera Precompile";
+    private static final Optional<ExceptionalHaltReason> ILLEGAL_STATE_CHANGE =
+            Optional.of(ExceptionalHaltReason.ILLEGAL_STATE_CHANGE);
+    public static final Bytes INVALID_TRANSFER =
+            Bytes.of(INVALID_TRANSFER_MSG.getBytes(StandardCharsets.UTF_8));
 
-  private final Map<Address, PrecompiledContract> hederaPrecompiles;
-  protected long gasRequirement;
-  protected Bytes output;
+    private final Map<Address, PrecompiledContract> hederaPrecompiles;
+    protected long gasRequirement;
+    protected Bytes output;
 
-  public HederaEvmMessageCallProcessor(
-      final EVM evm,
-      final PrecompileContractRegistry precompiles,
-      final Map<String, PrecompiledContract> hederaPrecompileList) {
-    super(evm, precompiles);
-    hederaPrecompiles = new HashMap<>();
-    hederaPrecompileList.forEach((k, v) -> hederaPrecompiles.put(Address.fromHexString(k), v));
-  }
+    public HederaEvmMessageCallProcessor(
+            final EVM evm,
+            final PrecompileContractRegistry precompiles,
+            final Map<String, PrecompiledContract> hederaPrecompileList) {
+        super(evm, precompiles);
+        hederaPrecompiles = new HashMap<>();
+        hederaPrecompileList.forEach((k, v) -> hederaPrecompiles.put(Address.fromHexString(k), v));
+    }
 
-  @Override
-  public void start(final MessageFrame frame, final OperationTracer operationTracer) {
-    final var hederaPrecompile = hederaPrecompiles.get(frame.getContractAddress());
-    if (hederaPrecompile != null) {
-      executeHederaPrecompile(hederaPrecompile, frame, operationTracer);
-    } else {
-      if (frame.getValue().greaterThan(Wei.ZERO)) {
-        final var updater = (AbstractLedgerEvmWorldUpdater) frame.getWorldUpdater();
-        if (updater.isTokenAddress(frame.getRecipientAddress())) {
-          frame.setExceptionalHaltReason(ILLEGAL_STATE_CHANGE);
-          frame.setState(MessageFrame.State.EXCEPTIONAL_HALT);
+    @Override
+    public void start(final MessageFrame frame, final OperationTracer operationTracer) {
+        final var hederaPrecompile = hederaPrecompiles.get(frame.getContractAddress());
+        if (hederaPrecompile != null) {
+            executeHederaPrecompile(hederaPrecompile, frame, operationTracer);
+        } else {
+            if (frame.getValue().greaterThan(Wei.ZERO)) {
+                final var updater = (AbstractLedgerEvmWorldUpdater) frame.getWorldUpdater();
+                if (updater.isTokenAddress(frame.getRecipientAddress())) {
+                    frame.setExceptionalHaltReason(ILLEGAL_STATE_CHANGE);
+                    frame.setState(MessageFrame.State.EXCEPTIONAL_HALT);
+                }
+            }
+            if (frame.getState() != EXCEPTIONAL_HALT) {
+                super.start(frame, operationTracer);
+            }
         }
-      }
-      if (frame.getState() != EXCEPTIONAL_HALT) {
-        super.start(frame, operationTracer);
-      }
     }
-  }
 
-  protected void executeHederaPrecompile(
-      final PrecompiledContract contract,
-      final MessageFrame frame,
-      final OperationTracer operationTracer) {
-    if(output!=null && !output.isEmpty()) {
-      output = contract.computePrecompile(frame.getInputData(), frame).getOutput();
-      }
-    if(gasRequirement == 0L) {
-      gasRequirement = contract.gasRequirement(frame.getInputData());
-      }
-    operationTracer.tracePrecompileCall(frame, gasRequirement, output);
-    if (frame.getState() == REVERT) {
-      return;
+    protected void executeHederaPrecompile(
+            final PrecompiledContract contract,
+            final MessageFrame frame,
+            final OperationTracer operationTracer) {
+        if (output == null || output.isEmpty()) {
+            output = contract.computePrecompile(frame.getInputData(), frame).getOutput();
+        }
+        if (gasRequirement == 0L) {
+            gasRequirement = contract.gasRequirement(frame.getInputData());
+        }
+        operationTracer.tracePrecompileCall(frame, gasRequirement, output);
+        if (frame.getState() == REVERT) {
+            return;
+        }
+        if (frame.getRemainingGas() < gasRequirement) {
+            frame.decrementRemainingGas(frame.getRemainingGas());
+            frame.setExceptionalHaltReason(Optional.of(INSUFFICIENT_GAS));
+            frame.setState(EXCEPTIONAL_HALT);
+        } else if (output != null) {
+            frame.decrementRemainingGas(gasRequirement);
+            frame.setOutputData(output);
+            frame.setState(COMPLETED_SUCCESS);
+        } else {
+            frame.setState(EXCEPTIONAL_HALT);
+        }
     }
-    if (frame.getRemainingGas() < gasRequirement) {
-      frame.decrementRemainingGas(frame.getRemainingGas());
-      frame.setExceptionalHaltReason(Optional.of(INSUFFICIENT_GAS));
-      frame.setState(EXCEPTIONAL_HALT);
-    } else if (output != null) {
-      frame.decrementRemainingGas(gasRequirement);
-      frame.setOutputData(output);
-      frame.setState(COMPLETED_SUCCESS);
-    } else {
-      frame.setState(EXCEPTIONAL_HALT);
-    }
-  }
 }

--- a/hedera-node/hedera-evm-api/src/main/java/com/hedera/services/evm/contracts/execution/HederaEvmMessageCallProcessor.java
+++ b/hedera-node/hedera-evm-api/src/main/java/com/hedera/services/evm/contracts/execution/HederaEvmMessageCallProcessor.java
@@ -1,0 +1,90 @@
+package com.hedera.services.evm.contracts.execution;
+
+import static org.hyperledger.besu.evm.frame.ExceptionalHaltReason.INSUFFICIENT_GAS;
+import static org.hyperledger.besu.evm.frame.MessageFrame.State.COMPLETED_SUCCESS;
+import static org.hyperledger.besu.evm.frame.MessageFrame.State.EXCEPTIONAL_HALT;
+import static org.hyperledger.besu.evm.frame.MessageFrame.State.REVERT;
+
+import com.hedera.services.evm.store.contracts.AbstractLedgerEvmWorldUpdater;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import org.apache.tuweni.bytes.Bytes;
+import org.hyperledger.besu.datatypes.Address;
+import org.hyperledger.besu.datatypes.Wei;
+import org.hyperledger.besu.evm.EVM;
+import org.hyperledger.besu.evm.frame.ExceptionalHaltReason;
+import org.hyperledger.besu.evm.frame.MessageFrame;
+import org.hyperledger.besu.evm.precompile.PrecompileContractRegistry;
+import org.hyperledger.besu.evm.precompile.PrecompiledContract;
+import org.hyperledger.besu.evm.processor.MessageCallProcessor;
+import org.hyperledger.besu.evm.tracing.OperationTracer;
+
+/** Overrides Besu precompiler handling, so we can break model layers in Precompile execution */
+public class HederaEvmMessageCallProcessor extends MessageCallProcessor {
+  private static final String INVALID_TRANSFER_MSG = "Transfer of Value to Hedera Precompile";
+  private static final Optional<ExceptionalHaltReason> ILLEGAL_STATE_CHANGE =
+      Optional.of(ExceptionalHaltReason.ILLEGAL_STATE_CHANGE);
+  public static final Bytes INVALID_TRANSFER =
+      Bytes.of(INVALID_TRANSFER_MSG.getBytes(StandardCharsets.UTF_8));
+
+  private final Map<Address, PrecompiledContract> hederaPrecompiles;
+  protected long gasRequirement;
+  protected Bytes output;
+
+  public HederaEvmMessageCallProcessor(
+      final EVM evm,
+      final PrecompileContractRegistry precompiles,
+      final Map<String, PrecompiledContract> hederaPrecompileList) {
+    super(evm, precompiles);
+    hederaPrecompiles = new HashMap<>();
+    hederaPrecompileList.forEach((k, v) -> hederaPrecompiles.put(Address.fromHexString(k), v));
+  }
+
+  @Override
+  public void start(final MessageFrame frame, final OperationTracer operationTracer) {
+    final var hederaPrecompile = hederaPrecompiles.get(frame.getContractAddress());
+    if (hederaPrecompile != null) {
+      executeHederaPrecompile(hederaPrecompile, frame, operationTracer);
+    } else {
+      if (frame.getValue().greaterThan(Wei.ZERO)) {
+        final var updater = (AbstractLedgerEvmWorldUpdater) frame.getWorldUpdater();
+        if (updater.isTokenAddress(frame.getRecipientAddress())) {
+          frame.setExceptionalHaltReason(ILLEGAL_STATE_CHANGE);
+          frame.setState(MessageFrame.State.EXCEPTIONAL_HALT);
+        }
+      }
+      if (frame.getState() != EXCEPTIONAL_HALT) {
+        super.start(frame, operationTracer);
+      }
+    }
+  }
+
+  protected void executeHederaPrecompile(
+      final PrecompiledContract contract,
+      final MessageFrame frame,
+      final OperationTracer operationTracer) {
+    if(output!=null && !output.isEmpty()) {
+      output = contract.computePrecompile(frame.getInputData(), frame).getOutput();
+      }
+    if(gasRequirement == 0L) {
+      gasRequirement = contract.gasRequirement(frame.getInputData());
+      }
+    operationTracer.tracePrecompileCall(frame, gasRequirement, output);
+    if (frame.getState() == REVERT) {
+      return;
+    }
+    if (frame.getRemainingGas() < gasRequirement) {
+      frame.decrementRemainingGas(frame.getRemainingGas());
+      frame.setExceptionalHaltReason(Optional.of(INSUFFICIENT_GAS));
+      frame.setState(EXCEPTIONAL_HALT);
+    } else if (output != null) {
+      frame.decrementRemainingGas(gasRequirement);
+      frame.setOutputData(output);
+      frame.setState(COMPLETED_SUCCESS);
+    } else {
+      frame.setState(EXCEPTIONAL_HALT);
+    }
+  }
+}

--- a/hedera-node/hedera-evm-api/src/main/java/com/hedera/services/evm/store/contracts/AbstractLedgerEvmWorldUpdater.java
+++ b/hedera-node/hedera-evm-api/src/main/java/com/hedera/services/evm/store/contracts/AbstractLedgerEvmWorldUpdater.java
@@ -83,4 +83,8 @@ public class AbstractLedgerEvmWorldUpdater implements WorldUpdater {
     public Account get(Address address) {
         return new UpdatedHederaEvmAccount(accountAccessor.canonicalAddress(address));
     }
+
+    public boolean isTokenAddress(Address address) {
+        return accountAccessor.isTokenAddress(address);
+    }
 }

--- a/hedera-node/hedera-evm-api/src/test/java/com/hedera/services/evm/store/models/MockAccountAccessor.java
+++ b/hedera-node/hedera-evm-api/src/test/java/com/hedera/services/evm/store/models/MockAccountAccessor.java
@@ -26,4 +26,9 @@ public class MockAccountAccessor implements AccountAccessor {
     public Address canonicalAddress(Address addressOrAlias) {
         return address;
     }
+
+    @Override
+    public boolean isTokenAddress(Address address) {
+        return false;
+    }
 }

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/services/contracts/execution/HederaMessageCallProcessor.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/services/contracts/execution/HederaMessageCallProcessor.java
@@ -15,12 +15,12 @@
  */
 package com.hedera.services.contracts.execution;
 
-import static org.hyperledger.besu.evm.frame.ExceptionalHaltReason.INSUFFICIENT_GAS;
-import static org.hyperledger.besu.evm.frame.MessageFrame.State.*;
+import static org.hyperledger.besu.evm.frame.MessageFrame.State.CODE_EXECUTING;
+import static org.hyperledger.besu.evm.frame.MessageFrame.State.EXCEPTIONAL_HALT;
 
 import com.hedera.services.contracts.execution.traceability.ContractActionType;
 import com.hedera.services.contracts.execution.traceability.HederaOperationTracer;
-import com.hedera.services.store.contracts.HederaStackedWorldStateUpdater;
+import com.hedera.services.evm.contracts.execution.HederaEvmMessageCallProcessor;
 import com.hedera.services.store.contracts.precompile.HTSPrecompiledContract;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
@@ -28,17 +28,14 @@ import java.util.Map;
 import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes;
 import org.hyperledger.besu.datatypes.Address;
-import org.hyperledger.besu.datatypes.Wei;
 import org.hyperledger.besu.evm.EVM;
 import org.hyperledger.besu.evm.frame.ExceptionalHaltReason;
 import org.hyperledger.besu.evm.frame.MessageFrame;
 import org.hyperledger.besu.evm.precompile.PrecompileContractRegistry;
 import org.hyperledger.besu.evm.precompile.PrecompiledContract;
-import org.hyperledger.besu.evm.processor.MessageCallProcessor;
 import org.hyperledger.besu.evm.tracing.OperationTracer;
 
-/** Overrides Besu precompiler handling, so we can break model layers in Precompile execution */
-public class HederaMessageCallProcessor extends MessageCallProcessor {
+public class HederaMessageCallProcessor extends HederaEvmMessageCallProcessor {
     private static final String INVALID_TRANSFER_MSG = "Transfer of Value to Hedera Precompile";
     private static final Optional<ExceptionalHaltReason> ILLEGAL_STATE_CHANGE =
             Optional.of(ExceptionalHaltReason.ILLEGAL_STATE_CHANGE);
@@ -51,30 +48,17 @@ public class HederaMessageCallProcessor extends MessageCallProcessor {
             final EVM evm,
             final PrecompileContractRegistry precompiles,
             final Map<String, PrecompiledContract> hederaPrecompileList) {
-        super(evm, precompiles);
+        super(evm, precompiles, hederaPrecompileList);
         hederaPrecompiles = new HashMap<>();
         hederaPrecompileList.forEach((k, v) -> hederaPrecompiles.put(Address.fromHexString(k), v));
     }
 
     @Override
     public void start(final MessageFrame frame, final OperationTracer operationTracer) {
-        MessageFrame.State nonPrecompileResultState = null;
+        super.start(frame, operationTracer);
+
         final var hederaPrecompile = hederaPrecompiles.get(frame.getContractAddress());
-        if (hederaPrecompile != null) {
-            executeHederaPrecompile(hederaPrecompile, frame, operationTracer);
-        } else {
-            if (frame.getValue().greaterThan(Wei.ZERO)) {
-                final var updater = (HederaStackedWorldStateUpdater) frame.getWorldUpdater();
-                if (updater.isTokenAddress(frame.getRecipientAddress())) {
-                    frame.setExceptionalHaltReason(ILLEGAL_STATE_CHANGE);
-                    frame.setState(MessageFrame.State.EXCEPTIONAL_HALT);
-                }
-            }
-            if (frame.getState() != EXCEPTIONAL_HALT) {
-                super.start(frame, operationTracer);
-            }
-            nonPrecompileResultState = frame.getState();
-        }
+        final var nonPrecompileResultState = frame.getState();
         if (nonPrecompileResultState != EXCEPTIONAL_HALT
                 && nonPrecompileResultState != CODE_EXECUTING) {
             // Pre-compile execution doesn't set the state to CODE_EXECUTING after start()
@@ -87,34 +71,15 @@ public class HederaMessageCallProcessor extends MessageCallProcessor {
         }
     }
 
-    void executeHederaPrecompile(
+    protected void executeHederaPrecompile(
             final PrecompiledContract contract,
             final MessageFrame frame,
             final OperationTracer operationTracer) {
-        final long gasRequirement;
-        final Bytes output;
         if (contract instanceof HTSPrecompiledContract htsPrecompile) {
             final var costedResult = htsPrecompile.computeCosted(frame.getInputData(), frame);
             output = costedResult.getValue();
             gasRequirement = costedResult.getKey();
-        } else {
-            output = contract.computePrecompile(frame.getInputData(), frame).getOutput();
-            gasRequirement = contract.gasRequirement(frame.getInputData());
         }
-        operationTracer.tracePrecompileCall(frame, gasRequirement, output);
-        if (frame.getState() == REVERT) {
-            return;
-        }
-        if (frame.getRemainingGas() < gasRequirement) {
-            frame.decrementRemainingGas(frame.getRemainingGas());
-            frame.setExceptionalHaltReason(Optional.of(INSUFFICIENT_GAS));
-            frame.setState(EXCEPTIONAL_HALT);
-        } else if (output != null) {
-            frame.decrementRemainingGas(gasRequirement);
-            frame.setOutputData(output);
-            frame.setState(COMPLETED_SUCCESS);
-        } else {
-            frame.setState(EXCEPTIONAL_HALT);
-        }
+        super.executeHederaPrecompile(contract, frame, operationTracer);
     }
 }

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/services/store/contracts/AccountAccessorImpl.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/services/store/contracts/AccountAccessorImpl.java
@@ -30,4 +30,9 @@ public class AccountAccessorImpl implements AccountAccessor {
     public Address canonicalAddress(final Address addressOrAlias) {
         return trackingLedgers.canonicalAddress(addressOrAlias);
     }
+
+    @Override
+    public boolean isTokenAddress(Address address) {
+        return trackingLedgers.isTokenAddress(address);
+    }
 }

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/services/contracts/execution/HederaMessageCallProcessorTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/services/contracts/execution/HederaMessageCallProcessorTest.java
@@ -27,6 +27,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doCallRealMethod;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
@@ -114,7 +115,7 @@ class HederaMessageCallProcessorTest {
         verify(frame).decrementRemainingGas(GAS_ONE);
         verify(frame).setOutputData(Bytes.of(1));
         verify(frame).setState(COMPLETED_SUCCESS);
-        verify(frame).getState();
+        verify(frame, times(2)).getState();
         verifyNoMoreInteractions(nonHtsPrecompile, frame, hederaTracer);
     }
 
@@ -129,7 +130,7 @@ class HederaMessageCallProcessorTest {
 
         subject.start(frame, hederaTracer);
 
-        verify(frame).getState();
+        verify(frame, times(2)).getState();
         verify(hederaTracer).tracePrecompileCall(frame, GAS_ONE, Bytes.of(1));
         verify(hederaTracer).tracePrecompileResult(frame, ContractActionType.SYSTEM);
         verify(frame).decrementRemainingGas(GAS_ONE);


### PR DESCRIPTION
**Description**:
In order to use the `hedera-evm-api` library on mirror-node side, we would have the need of default MessageCallProcessor that could be set up inside the `HederaEvmTxProcessor`. 

This PR defines a parent class for `HederaMessageCallProcessor` that could be instantiated in the mirror-node. It has traceability logic obfuscated and temporarily not supporting `HTSPrecompiledContract` cases. Once we implement precompile implementations for the `hedera-evm-api` library that logic would be added in additional PR.

**Related issue(s)**: #4159 

Fixes #4159 

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
