### PR TITLE
Disable recovery test until new implementation is merged

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1222,28 +1222,28 @@ workflows:
             - attach_workspace:
                 at: /
 
-  GCP-Daily-Services-Recovery-4N-1C:
-    triggers:
-      - schedule:
-          cron: "55 6 * * *"
-          filters:
-            branches:
-              only:
-                - develop
-    jobs:
-      - build-platform-and-services
-      - jrs-regression:
-          context: Slack
-          regression_path: /swirlds-platform/regression/assets
-          result_path: assets/results/4N_1C/Recovery
-          config_type: "daily"
-          workflow-name: "GCP-Daily-Services-Recovery-4N-1C"
-          requires:
-            - build-platform-and-services
-          pre-steps:
-            - install-tools
-            - attach_workspace:
-                at: /
+#  GCP-Daily-Services-Recovery-4N-1C:
+#    triggers:
+#      - schedule:
+#          cron: "55 6 * * *"
+#          filters:
+#            branches:
+#              only:
+#                - develop
+#    jobs:
+#      - build-platform-and-services
+#      - jrs-regression:
+#          context: Slack
+#          regression_path: /swirlds-platform/regression/assets
+#          result_path: assets/results/4N_1C/Recovery
+#          config_type: "daily"
+#          workflow-name: "GCP-Daily-Services-Recovery-4N-1C"
+#          requires:
+#            - build-platform-and-services
+#          pre-steps:
+#            - install-tools
+#            - attach_workspace:
+#                at: /
 
   GCP-Weekly-Services-Query-Restart-Performance-7N-7C:
     triggers:


### PR DESCRIPTION

Stop nightly regression to save cost.

