### PR TITLE
Cherry-pick fixes for `v0.31.2`

### DIFF
--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/services/ledger/BalanceChange.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/services/ledger/BalanceChange.java
@@ -221,6 +221,10 @@ public class BalanceChange {
         return isForFungibleToken() || isForNft();
     }
 
+    public boolean affectsAccount(final AccountID target) {
+        return target.equals(this.accountId);
+    }
+
     public NftId nftId() {
         return nftId;
     }

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/services/ledger/interceptors/AccountsCommitInterceptor.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/services/ledger/interceptors/AccountsCommitInterceptor.java
@@ -103,6 +103,15 @@ public class AccountsCommitInterceptor
             @NotNull final Map<AccountProperty, Object> accountChanges) {
         if (accountChanges.containsKey(AccountProperty.BALANCE)) {
             final long newBalance = (long) accountChanges.get(AccountProperty.BALANCE);
+            if (newBalance < 0) {
+                throw new IllegalStateException(
+                        "Cannot set "
+                                + ((merkleAccount == null)
+                                        ? "<N/A>"
+                                        : merkleAccount.getKey().toIdString())
+                                + " balance to "
+                                + newBalance);
+            }
             final long adjustment =
                     (merkleAccount != null) ? newBalance - merkleAccount.getBalance() : newBalance;
             sideEffectsTracker.trackHbarChange(accountNum, adjustment);

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/services/legacy/core/jproto/JECDSASecp256k1Key.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/services/legacy/core/jproto/JECDSASecp256k1Key.java
@@ -15,6 +15,8 @@
  */
 package com.hedera.services.legacy.core.jproto;
 
+import com.hedera.services.legacy.proto.utils.ByteStringUtils;
+import com.hederahashgraph.api.proto.java.Key;
 import com.swirlds.common.utility.CommonUtils;
 import java.util.Arrays;
 
@@ -22,6 +24,8 @@ import java.util.Arrays;
 public class JECDSASecp256k1Key extends JKey {
     private byte[] ecdsaSecp256k1Key;
 
+    private static final byte ODD_PARITY = (byte) 0x03;
+    private static final byte EVEN_PARITY = (byte) 0x02;
     public static final int ECDSA_SECP256K1_COMPRESSED_KEY_LENGTH = 33;
 
     public JECDSASecp256k1Key(final byte[] ecdsaSecp256k1Key) {
@@ -38,6 +42,15 @@ public class JECDSASecp256k1Key extends JKey {
         return !(isEmpty()
                 || (ecdsaSecp256k1Key.length != ECDSA_SECP256K1_COMPRESSED_KEY_LENGTH)
                 || (ecdsaSecp256k1Key[0] != 0x02 && ecdsaSecp256k1Key[0] != 0x03));
+    }
+
+    public static boolean isValidProto(final Key secp256k1Key) {
+        if (secp256k1Key.getECDSASecp256K1().size() != ECDSA_SECP256K1_COMPRESSED_KEY_LENGTH) {
+            return false;
+        }
+        final var parityByte =
+                ByteStringUtils.unwrapUnsafelyIfPossible(secp256k1Key.getECDSASecp256K1())[0];
+        return parityByte == ODD_PARITY || parityByte == EVEN_PARITY;
     }
 
     @Override

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/services/legacy/core/jproto/JEd25519Key.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/services/legacy/core/jproto/JEd25519Key.java
@@ -15,6 +15,7 @@
  */
 package com.hedera.services.legacy.core.jproto;
 
+import com.hederahashgraph.api.proto.java.Key;
 import com.swirlds.common.utility.CommonUtils;
 import java.util.Arrays;
 
@@ -55,6 +56,10 @@ public class JEd25519Key extends JKey {
         } else {
             return ed25519.length == ED25519_BYTE_LENGTH;
         }
+    }
+
+    public static boolean isValidProto(final Key ed25519Key) {
+        return ed25519Key.getEd25519().size() == ED25519_BYTE_LENGTH;
     }
 
     @Override

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/services/utils/MiscUtils.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/services/utils/MiscUtils.java
@@ -162,6 +162,8 @@ import com.google.protobuf.InvalidProtocolBufferException;
 import com.hedera.services.ethereum.EthTxData;
 import com.hedera.services.exceptions.UnknownHederaFunctionality;
 import com.hedera.services.ledger.HederaLedger;
+import com.hedera.services.legacy.core.jproto.JECDSASecp256k1Key;
+import com.hedera.services.legacy.core.jproto.JEd25519Key;
 import com.hedera.services.legacy.core.jproto.JKey;
 import com.hedera.services.state.submerkle.ExpirableTxnRecord;
 import com.hedera.services.state.submerkle.RichInstant;
@@ -920,15 +922,21 @@ public final class MiscUtils {
 
     /**
      * Attempts to parse a {@code Key} from given alias {@code ByteString}. If the Key is of type
-     * Ed25519 or ECDSA(secp256k1), returns true and false otherwise.
+     * Ed25519 or ECDSA(secp256k1), returns true if it is a valid key; and false otherwise.
      *
      * @param alias given alias byte string
-     * @return whether it parses to a primitive key
+     * @return whether it parses to a valid primitive key
      */
     public static boolean isSerializedProtoKey(final ByteString alias) {
         try {
             final var key = Key.parseFrom(alias);
-            return !key.getECDSASecp256K1().isEmpty() || !key.getEd25519().isEmpty();
+            if (!key.getECDSASecp256K1().isEmpty()) {
+                return JECDSASecp256k1Key.isValidProto(key);
+            } else if (!key.getEd25519().isEmpty()) {
+                return JEd25519Key.isValidProto(key);
+            } else {
+                return false;
+            }
         } catch (InvalidProtocolBufferException ignore) {
             return false;
         }

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/services/ledger/LedgerBalanceChangesTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/services/ledger/LedgerBalanceChangesTest.java
@@ -260,6 +260,7 @@ class LedgerBalanceChangesTest {
         // and:
         backingAccounts.getRef(bModel).setDeleted(true);
         givenUnexpiredEntities();
+        given(txnCtx.activePayer()).willReturn(uninvolvedPayer);
 
         // when:
         subject.begin();
@@ -318,6 +319,7 @@ class LedgerBalanceChangesTest {
         givenUnexpiredEntities();
 
         givenInitialBalancesAndOwnership();
+        given(txnCtx.activePayer()).willReturn(uninvolvedPayer);
 
         // when:
         subject.begin();
@@ -335,6 +337,7 @@ class LedgerBalanceChangesTest {
     void happyPathRecordsTransfersAndChangesBalancesAsExpected() {
         givenInitialBalancesAndOwnership();
         givenUnexpiredEntities();
+        given(txnCtx.activePayer()).willReturn(uninvolvedPayer);
 
         // when:
         subject.begin();
@@ -611,6 +614,7 @@ class LedgerBalanceChangesTest {
     private final AccountID aModel = asAccount("0.0.3");
     private final AccountID bModel = asAccount("0.0.4");
     private final AccountID cModel = asAccount("0.0.5");
+    private final AccountID uninvolvedPayer = asAccount("0.0.666666");
     private final Id token = new Id(0, 0, 75231);
     private final Id anotherToken = new Id(0, 0, 75232);
     private final Id yetAnotherToken = new Id(0, 0, 75233);

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/services/ledger/TransferLogicTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/services/ledger/TransferLogicTest.java
@@ -19,6 +19,7 @@ import static com.hedera.services.ledger.properties.AccountProperty.BALANCE;
 import static com.hedera.services.ledger.properties.NftProperty.SPENDER;
 import static com.hedera.services.state.submerkle.EntityId.MISSING_ENTITY_ID;
 import static com.hedera.test.mocks.TestContextValidator.TEST_VALIDATOR;
+import static com.hedera.test.utils.TxnUtils.aaOf;
 import static com.hedera.test.utils.TxnUtils.assertFailsWith;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INSUFFICIENT_ACCOUNT_BALANCE;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INSUFFICIENT_PAYER_BALANCE;
@@ -427,9 +428,52 @@ class TransferLogicTest {
     }
 
     @Test
+    void failsIfPayerDoesntHaveEnoughBalanceAfterTransfersFromHisAccount() {
+        final var autoFee = 500L;
+        final var payerInitBalance = 1_000L;
+        final var firstAlias = ByteString.copyFromUtf8("fake");
+        final var firstNewAccount = IdUtils.asAccount("0.0.1234");
+        final var firstNewAccountNum = EntityNum.fromAccountId(firstNewAccount);
+        final var firstTrigger = BalanceChange.changingHbar(aaOf(payer, -payerInitBalance), payer);
+        final var secondTrigger =
+                BalanceChange.changingHbar(aliasedAa(firstAlias, payerInitBalance), payer);
+        final var changes = List.of(firstTrigger, secondTrigger);
+        given(autoCreationLogic.create(secondTrigger, accountsLedger, changes))
+                .willAnswer(
+                        invocationOnMock -> {
+                            accountsLedger.create(firstNewAccount);
+                            final var change = (BalanceChange) invocationOnMock.getArgument(0);
+                            change.replaceNonEmptyAliasWith(firstNewAccountNum);
+                            change.setNewBalance(change.getAggregatedUnits());
+                            return Pair.of(OK, autoFee);
+                        });
+        final var funding = IdUtils.asAccount("0.0.98");
+        accountsLedger.begin();
+        accountsLedger.create(funding);
+        accountsLedger.create(payer);
+        accountsLedger.set(payer, BALANCE, payerInitBalance);
+        accountsLedger.commit();
+        accountsLedger.begin();
+
+        given(txnCtx.activePayer()).willReturn(payer);
+        given(aliasManager.lookupIdBy(firstAlias)).willReturn(EntityNum.MISSING_NUM);
+        given(autoCreationLogic.reclaimPendingAliases()).willReturn(true);
+
+        final var ex =
+                assertThrows(InvalidTransactionException.class, () -> subject.doZeroSum(changes));
+
+        assertEquals(INSUFFICIENT_PAYER_BALANCE, ex.getResponseCode());
+        assertEquals(0L, (long) accountsLedger.get(funding, AccountProperty.BALANCE));
+        assertEquals(payerInitBalance, (long) accountsLedger.get(payer, AccountProperty.BALANCE));
+        verify(autoCreationLogic, never()).submitRecordsTo(recordsHistorian);
+        verify(autoCreationLogic).reclaimPendingAliases();
+    }
+
+    @Test
     void happyPathHbarAllowance() {
         setUpAccountWithAllowances();
         final var change = BalanceChange.changingHbar(allowanceAA(owner, -50L), payer);
+        given(txnCtx.activePayer()).willReturn(payer);
 
         accountsLedger.begin();
         subject.doZeroSum(List.of(change));

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/services/ledger/interceptors/AccountsCommitInterceptorTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/services/ledger/interceptors/AccountsCommitInterceptorTest.java
@@ -15,6 +15,7 @@
  */
 package com.hedera.services.ledger.interceptors;
 
+import static com.hedera.services.ledger.properties.AccountProperty.BALANCE;
 import static com.hedera.services.ledger.properties.AccountProperty.IS_SMART_CONTRACT;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -26,6 +27,7 @@ import com.hedera.services.state.merkle.MerkleAccount;
 import com.hedera.services.state.validation.AccountUsageTracking;
 import com.hederahashgraph.api.proto.java.AccountID;
 import java.util.Map;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -62,6 +64,22 @@ class AccountsCommitInterceptorTest {
         subject.postCommit();
 
         verifyNoInteractions(usageTracking);
+    }
+
+    @Test
+    void failsFastOnImpossibleBalance() {
+        final EntityChangeSet<AccountID, MerkleAccount, AccountProperty>
+                impossibleNewAccountBalance = new EntityChangeSet<>();
+        impossibleNewAccountBalance.include(idWith(1234L), null, Map.of(BALANCE, -1L));
+        Assertions.assertThrows(
+                IllegalStateException.class, () -> subject.preview(impossibleNewAccountBalance));
+
+        final EntityChangeSet<AccountID, MerkleAccount, AccountProperty>
+                impossibleExtantAccountBalance = new EntityChangeSet<>();
+        impossibleExtantAccountBalance.include(
+                idWith(1234L), new MerkleAccount(), Map.of(BALANCE, -1L));
+        Assertions.assertThrows(
+                IllegalStateException.class, () -> subject.preview(impossibleExtantAccountBalance));
     }
 
     private EntityChangeSet<AccountID, MerkleAccount, AccountProperty> pendingChanges(

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/services/ledger/interceptors/StakingAccountsCommitInterceptorTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/services/ledger/interceptors/StakingAccountsCommitInterceptorTest.java
@@ -898,7 +898,10 @@ class StakingAccountsCommitInterceptorTest {
         given(stakeChangeManager.findOrAdd(anyLong(), any()))
                 .willAnswer(
                         invocation -> {
-                            changes.include(stakingFundId, new MerkleAccount(), new HashMap<>());
+                            changes.include(
+                                    stakingFundId,
+                                    MerkleAccountFactory.newAccount().balance(123).get(),
+                                    new HashMap<>());
                             return expectedFundingI;
                         });
         subject.getStakePeriodStartUpdates()[expectedFundingI] = 666L;

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -59,7 +59,7 @@ dependencyResolutionManagement {
             version("eddsa-version", "0.3.0")
             version("grpc-version", "1.39.0")
             version("guava-version", "31.1-jre")
-            version("hapi-version", "0.31.0-alpha.0-SNAPSHOT")
+            version("hapi-version", "0.31.0")
             version("headlong-version", "6.1.1")
             version("jackson-version", "2.12.6.1")
             version("javax-annotation-version", "1.3.2")

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/AutoAccountCreationSuite.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/AutoAccountCreationSuite.java
@@ -24,12 +24,7 @@ import static com.hedera.services.bdd.spec.assertions.AutoAssocAsserts.accountTo
 import static com.hedera.services.bdd.spec.assertions.ContractInfoAsserts.contractWith;
 import static com.hedera.services.bdd.spec.assertions.TransactionRecordAsserts.includingFungibleMovement;
 import static com.hedera.services.bdd.spec.assertions.TransactionRecordAsserts.recordWith;
-import static com.hedera.services.bdd.spec.queries.QueryVerbs.getAccountInfo;
-import static com.hedera.services.bdd.spec.queries.QueryVerbs.getAliasedAccountInfo;
-import static com.hedera.services.bdd.spec.queries.QueryVerbs.getAutoCreatedAccountBalance;
-import static com.hedera.services.bdd.spec.queries.QueryVerbs.getContractInfo;
-import static com.hedera.services.bdd.spec.queries.QueryVerbs.getReceipt;
-import static com.hedera.services.bdd.spec.queries.QueryVerbs.getTxnRecord;
+import static com.hedera.services.bdd.spec.queries.QueryVerbs.*;
 import static com.hedera.services.bdd.spec.queries.crypto.ExpectedTokenRel.relationshipWith;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.contractUpdate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.createDefaultContract;
@@ -51,22 +46,10 @@ import static com.hedera.services.bdd.spec.transactions.token.TokenMovement.movi
 import static com.hedera.services.bdd.spec.transactions.token.TokenMovement.movingHbar;
 import static com.hedera.services.bdd.spec.transactions.token.TokenMovement.movingUnique;
 import static com.hedera.services.bdd.spec.utilops.CustomSpecAssert.allRunFor;
-import static com.hedera.services.bdd.spec.utilops.UtilVerbs.assertionsHold;
-import static com.hedera.services.bdd.spec.utilops.UtilVerbs.childRecordsCheck;
-import static com.hedera.services.bdd.spec.utilops.UtilVerbs.newKeyNamed;
-import static com.hedera.services.bdd.spec.utilops.UtilVerbs.overriding;
-import static com.hedera.services.bdd.spec.utilops.UtilVerbs.overridingAllOf;
-import static com.hedera.services.bdd.spec.utilops.UtilVerbs.sourcing;
-import static com.hedera.services.bdd.spec.utilops.UtilVerbs.withOpContext;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.*;
 import static com.hedera.services.bdd.suites.contract.Utils.aaWith;
 import static com.hedera.services.bdd.suites.contract.hapi.ContractUpdateSuite.ADMIN_KEY;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.ACCOUNT_DELETED;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.ACCOUNT_REPEATED_IN_ACCOUNT_AMOUNTS;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INSUFFICIENT_ACCOUNT_BALANCE;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INSUFFICIENT_SENDER_ACCOUNT_BALANCE_FOR_CUSTOM_FEE;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.NOT_SUPPORTED;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.NO_REMAINING_AUTOMATIC_ASSOCIATIONS;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SUCCESS;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.*;
 import static com.hederahashgraph.api.proto.java.TokenSupplyType.FINITE;
 import static com.hederahashgraph.api.proto.java.TokenType.FUNGIBLE_COMMON;
 import static com.hederahashgraph.api.proto.java.TokenType.NON_FUNGIBLE_UNIQUE;
@@ -89,6 +72,7 @@ import com.hederahashgraph.api.proto.java.TokenType;
 import com.hederahashgraph.api.proto.java.TransactionRecord;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import org.apache.commons.lang3.tuple.Pair;
@@ -173,7 +157,8 @@ public class AutoAccountCreationSuite extends HapiApiSuite {
                 autoCreateWithNftFallBackFeeFails(),
                 repeatedAliasInSameTransferListFails(),
                 tokenTransfersFailWhenFeatureFlagDisabled(),
-                canAutoCreateWithHbarAndTokenTransfers());
+                canAutoCreateWithHbarAndTokenTransfers(),
+                payerBalanceIsReflectsAllChangesBeforeFeeCharging());
     }
 
     private HapiApiSpec canAutoCreateWithHbarAndTokenTransfers() {
@@ -632,6 +617,75 @@ public class AutoAccountCreationSuite extends HapiApiSuite {
                         getAliasedAccountInfo(VALID_ALIAS)
                                 .hasToken(relationshipWith(A_TOKEN).balance(10))
                                 .hasToken(relationshipWith(B_TOKEN).balance(20)));
+    }
+
+    private HapiApiSpec payerBalanceIsReflectsAllChangesBeforeFeeCharging() {
+        final var secondAliasKey = "secondAlias";
+        final var secondPayer = "secondPayer";
+        final AtomicLong totalAutoCreationFees = new AtomicLong();
+
+        return defaultHapiSpec("PayerBalanceIsReflectsAllChangesBeforeFeeCharging")
+                .given(
+                        overriding(FEATURE_FLAG, "true"),
+                        newKeyNamed(VALID_ALIAS),
+                        cryptoCreate(TOKEN_TREASURY),
+                        tokenCreate(A_TOKEN)
+                                .tokenType(FUNGIBLE_COMMON)
+                                .initialSupply(1000)
+                                .treasury(TOKEN_TREASURY),
+                        cryptoCreate(CIVILIAN)
+                                .balance(ONE_HUNDRED_HBARS)
+                                .maxAutomaticTokenAssociations(1),
+                        cryptoTransfer(moving(100, A_TOKEN).between(TOKEN_TREASURY, CIVILIAN)),
+                        cryptoTransfer(
+                                        moving(10, A_TOKEN).between(CIVILIAN, VALID_ALIAS),
+                                        movingHbar(1).between(CIVILIAN, FUNDING))
+                                .fee(50 * ONE_HBAR)
+                                .payingWith(CIVILIAN)
+                                .signedBy(CIVILIAN),
+                        getAccountBalance(CIVILIAN)
+                                .exposingBalanceTo(
+                                        balance ->
+                                                totalAutoCreationFees.set(
+                                                        ONE_HUNDRED_HBARS - balance - 1)))
+                .when(
+                        logIt(
+                                spec ->
+                                        String.format(
+                                                "Total auto-creation fees: %d",
+                                                totalAutoCreationFees.get())),
+                        sourcing(
+                                () ->
+                                        cryptoCreate(secondPayer)
+                                                .maxAutomaticTokenAssociations(1)
+                                                .balance(totalAutoCreationFees.get())),
+                        cryptoTransfer(moving(100, A_TOKEN).between(TOKEN_TREASURY, secondPayer)))
+                .then(
+                        newKeyNamed(secondAliasKey),
+                        sourcing(
+                                () ->
+                                        cryptoTransfer(
+                                                        moving(10, A_TOKEN)
+                                                                .between(
+                                                                        secondPayer,
+                                                                        secondAliasKey),
+                                                        movingHbar(1).between(secondPayer, FUNDING))
+                                                .fee(totalAutoCreationFees.get() - 2)
+                                                .payingWith(secondPayer)
+                                                .signedBy(secondPayer)
+                                                .hasKnownStatus(INSUFFICIENT_PAYER_BALANCE)),
+                        getAccountBalance(secondPayer)
+                                .hasTinyBars(
+                                        spec ->
+                                                // Should only be charged a few hundred thousand
+                                                // tinybar at most
+                                                balance ->
+                                                        ((totalAutoCreationFees.get() - balance)
+                                                                        > 500_000L)
+                                                                ? Optional.empty()
+                                                                : Optional.of(
+                                                                        "Payer was"
+                                                                            + " over-charged!")));
     }
 
     private HapiApiSpec canAutoCreateWithFungibleTokenTransfersToAlias() {


### PR DESCRIPTION
**Description**:
 - Prevents user error auto-creating accounts with invalid keys.
 - Fails faster on invalid balance change attempts.
 - Cherry-picks [this](https://github.com/hashgraph/hedera-services/pull/4161) PR