### PR TITLE
Left-pad `(r, s)` curve points given to native library

### DIFF
--- a/hapi-utils/src/main/java/com/hedera/services/ethereum/EthTxSigs.java
+++ b/hapi-utils/src/main/java/com/hedera/services/ethereum/EthTxSigs.java
@@ -24,6 +24,7 @@ import static org.hyperledger.besu.nativelib.secp256k1.LibSecp256k1.secp256k1_ec
 
 import com.esaulpaugh.headlong.rlp.RLPEncoder;
 import com.esaulpaugh.headlong.util.Integers;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.MoreObjects;
 import com.sun.jna.ptr.IntByReference;
 import com.sun.jna.ptr.LongByReference;
@@ -179,9 +180,9 @@ public record EthTxSigs(byte[] publicKey, byte[] address) {
             int recId, byte[] r, byte[] s, byte[] message) {
         byte[] dataHash = new Keccak.Digest256().digest(message);
 
-        byte[] signature = new byte[64];
-        System.arraycopy(r, 0, signature, 0, r.length);
-        System.arraycopy(s, 0, signature, 32, s.length);
+        // The RLP library output won't include leading zeros, which means
+        // a simple (r, s) concatenation breaks signature verification below
+        byte[] signature = concatLeftPadded(r, s);
 
         final LibSecp256k1.secp256k1_ecdsa_recoverable_signature parsedSignature =
                 new LibSecp256k1.secp256k1_ecdsa_recoverable_signature();
@@ -197,6 +198,16 @@ public record EthTxSigs(byte[] publicKey, byte[] address) {
         } else {
             return newPubKey;
         }
+    }
+
+    @VisibleForTesting
+    static byte[] concatLeftPadded(final byte[] r, final byte[] s) {
+        byte[] signature = new byte[64];
+        final var rLeadingZeros = 32 - r.length;
+        System.arraycopy(r, 0, signature, rLeadingZeros, r.length);
+        final var sLeadingZeros = 32 - s.length;
+        System.arraycopy(s, 0, signature, 32 + sLeadingZeros, s.length);
+        return signature;
     }
 
     @Override

--- a/hapi-utils/src/test/java/com/hedera/services/ethereum/EthTxSigsTest.java
+++ b/hapi-utils/src/test/java/com/hedera/services/ethereum/EthTxSigsTest.java
@@ -32,11 +32,67 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import com.swirlds.common.utility.*;
 import java.math.BigInteger;
-import java.util.Arrays;
+import java.util.*;
 import org.junit.jupiter.api.Test;
 
 class EthTxSigsTest {
+    private final SplittableRandom random = new SplittableRandom();
+
+    @Test
+    void leftPadsRIfNecessary() {
+        final var r = nextBytes(30);
+        final var s = nextBytes(32);
+        final var sig = EthTxSigs.concatLeftPadded(r, s);
+        assertArrayEquals(r, Arrays.copyOfRange(sig, 2, 32));
+        assertArrayEquals(s, Arrays.copyOfRange(sig, 32, 64));
+    }
+
+    @Test
+    void issue4180CaseStudyPasses() {
+        final var expectedFromAddress =
+                CommonUtils.unhex("5052672db37ad6f222b8de61665c6bb76acfefaa");
+        final var ethTxData =
+                EthTxData.populateEthTxData(
+                        CommonUtils.unhex(
+                                "f88b718601d1a94a20008316e360940000000000000000000000000000000002e8a7b980a4fdacd5760000000000000000000000000000000000000000000000000000000000000002820273a076398dfd239dcdf69aeef7328a5e8cc69ef1b4ba5cca56eab1af06d7959923599f8194cd217b301cbdbdcd05b3572c411ec9333af39c98af8c5c9de45ddb05c5"));
+        final var ethTxSigs = EthTxSigs.extractSignatures(ethTxData);
+        assertArrayEquals(expectedFromAddress, ethTxSigs.address());
+    }
+
+    @Test
+    void leftPadsSIfNecessary() {
+        final var r = nextBytes(32);
+        final var s = nextBytes(29);
+        final var sig = EthTxSigs.concatLeftPadded(r, s);
+        assertArrayEquals(r, Arrays.copyOfRange(sig, 0, 32));
+        assertArrayEquals(s, Arrays.copyOfRange(sig, 35, 64));
+    }
+
+    @Test
+    void leftPadsBothIfNecessary() {
+        final var r = nextBytes(31);
+        final var s = nextBytes(29);
+        final var sig = EthTxSigs.concatLeftPadded(r, s);
+        assertArrayEquals(r, Arrays.copyOfRange(sig, 1, 32));
+        assertArrayEquals(s, Arrays.copyOfRange(sig, 35, 64));
+    }
+
+    @Test
+    void leftPadsNeitherIfUnnecessary() {
+        final var r = nextBytes(32);
+        final var s = nextBytes(32);
+        final var sig = EthTxSigs.concatLeftPadded(r, s);
+        assertArrayEquals(r, Arrays.copyOfRange(sig, 0, 32));
+        assertArrayEquals(s, Arrays.copyOfRange(sig, 32, 64));
+    }
+
+    public byte[] nextBytes(final int n) {
+        final var ans = new byte[n];
+        random.nextBytes(ans);
+        return ans;
+    }
 
     @Test
     void signsLegacyUnprotectedNull() {


### PR DESCRIPTION
**Description**:
 - Ensures the 64-byte `signature` used in `EthTxSigs.extractSig()` verification is a concatenation of 32-byte curve points, _including_ any leading zeros.
 - Closes #4180 