### PR TITLE
Move swirlds-hashstream log file to subdirectory

### DIFF
--- a/hedera-node/configuration/compose/log4j2.xml
+++ b/hedera-node/configuration/compose/log4j2.xml
@@ -41,8 +41,8 @@
     </RollingFile>
 
     <!-- Platform hash stream logs -->
-    <RollingFile name="swirldsHashStream" fileName="output/swirlds-hashstream.log"
-                 filePattern="output/swirlds-hashstream.log-%d{yyyy-MM-dd}-%i.log">
+    <RollingFile name="swirldsHashStream" fileName="output/swirlds-hashstream/swirlds-hashstream.log"
+                 filePattern="output/swirlds-hashstream/swirlds-hashstream.log-%d{yyyy-MM-dd}-%i.log">
       <PatternLayout>
         <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %-8sn %-5p %-16marker &lt;%t&gt; %c{1}: %msg{nolookups}%n</pattern>
       </PatternLayout>

--- a/hedera-node/configuration/dev/log4j2.xml
+++ b/hedera-node/configuration/dev/log4j2.xml
@@ -52,8 +52,8 @@
     </RollingFile>
 
     <!-- Platform hash stream logs -->
-    <RollingFile name="swirldsHashStream" fileName="output/swirlds-hashstream.log"
-                             filePattern="output/swirlds-hashstream.log-%d{yyyy-MM-dd}-%i.log">
+    <RollingFile name="swirldsHashStream" fileName="output/swirlds-hashstream/swirlds-hashstream.log"
+                             filePattern="output/swirlds-hashstream/swirlds-hashstream.log-%d{yyyy-MM-dd}-%i.log">
       <PatternLayout>
         <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %-8sn %-5p %-16marker &lt;%t&gt; %c{1}: %msg{nolookups}%n</pattern>
       </PatternLayout>

--- a/hedera-node/configuration/mainnet/log4j2.xml
+++ b/hedera-node/configuration/mainnet/log4j2.xml
@@ -52,8 +52,8 @@
     </RollingFile>
 
     <!-- Platform hash stream logs -->
-    <RollingFile name="swirldsHashStream" fileName="output/swirlds-hashstream.log"
-                 filePattern="output/swirlds-hashstream.log-%d{yyyy-MM-dd}-%i.log">
+    <RollingFile name="swirldsHashStream" fileName="output/swirlds-hashstream/swirlds-hashstream.log"
+                 filePattern="output/swirlds-hashstream/swirlds-hashstream.log-%d{yyyy-MM-dd}-%i.log">
       <PatternLayout>
         <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %-8sn %-5p %-16marker &lt;%t&gt; %c{1}: %msg{nolookups}%n</pattern>
       </PatternLayout>

--- a/hedera-node/configuration/preprod/log4j2.xml
+++ b/hedera-node/configuration/preprod/log4j2.xml
@@ -52,8 +52,8 @@
     </RollingFile>
 
     <!-- Platform hash stream logs -->
-    <RollingFile name="swirldsHashStream" fileName="output/swirlds-hashstream.log"
-                 filePattern="output/swirlds-hashstream.log-%d{yyyy-MM-dd}-%i.log">
+    <RollingFile name="swirldsHashStream" fileName="output/swirlds-hashstream/swirlds-hashstream.log"
+                 filePattern="output/swirlds-hashstream/swirlds-hashstream.log-%d{yyyy-MM-dd}-%i.log">
       <PatternLayout>
         <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %-8sn %-5p %-16marker &lt;%t&gt; %c{1}: %msg{nolookups}%n</pattern>
       </PatternLayout>

--- a/hedera-node/configuration/previewnet/log4j2.xml
+++ b/hedera-node/configuration/previewnet/log4j2.xml
@@ -52,8 +52,8 @@
     </RollingFile>
 
     <!-- Platform hash stream logs -->
-    <RollingFile name="swirldsHashStream" fileName="output/swirlds-hashstream.log"
-                 filePattern="output/swirlds-hashstream.log-%d{yyyy-MM-dd}-%i.log">
+    <RollingFile name="swirldsHashStream" fileName="output/swirlds-hashstream/swirlds-hashstream.log"
+                 filePattern="output/swirlds-hashstream/swirlds-hashstream.log-%d{yyyy-MM-dd}-%i.log">
       <PatternLayout>
         <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %-8sn %-5p %-16marker &lt;%t&gt; %c{1}: %msg{nolookups}%n</pattern>
       </PatternLayout>

--- a/hedera-node/configuration/testnet/log4j2.xml
+++ b/hedera-node/configuration/testnet/log4j2.xml
@@ -52,8 +52,8 @@
     </RollingFile>
 
     <!-- Platform hash stream logs -->
-    <RollingFile name="swirldsHashStream" fileName="output/swirlds-hashstream.log"
-                 filePattern="output/swirlds-hashstream.log-%d{yyyy-MM-dd}-%i.log">
+    <RollingFile name="swirldsHashStream" fileName="output/swirlds-hashstream/swirlds-hashstream.log"
+                 filePattern="output/swirlds-hashstream/swirlds-hashstream.log-%d{yyyy-MM-dd}-%i.log">
       <PatternLayout>
         <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %-8sn %-5p %-16marker &lt;%t&gt; %c{1}: %msg{nolookups}%n</pattern>
       </PatternLayout>


### PR DESCRIPTION
This PR moves the swirlds-hashstream log file into a subdirectory within all log4j configs.