### PR TITLE
Add `TxnResourceUsageEstimator` support for secondary fees

### DIFF
--- a/hapi-utils/src/main/java/com/hederahashgraph/fee/FeeBuilder.java
+++ b/hapi-utils/src/main/java/com/hederahashgraph/fee/FeeBuilder.java
@@ -152,16 +152,48 @@ public class FeeBuilder {
 
     public static FeeObject getFeeObject(
             FeeData feeData, FeeData feeMatrices, ExchangeRate exchangeRate, long multiplier) {
-        // get the Network Fee
-        long networkFee =
-                getComponentFeeInTinyCents(feeData.getNetworkdata(), feeMatrices.getNetworkdata());
-        long nodeFee = getComponentFeeInTinyCents(feeData.getNodedata(), feeMatrices.getNodedata());
-        long serviceFee =
-                getComponentFeeInTinyCents(feeData.getServicedata(), feeMatrices.getServicedata());
-        // convert the Fee to tiny hbars
+        return internalGetFeeObject(
+                feeData, feeMatrices, exchangeRate, multiplier,
+                0L, 0L, 0L);
+    }
+
+    public static FeeObject getFeeObjectWithSecondary(
+            FeeData feeData,
+            FeeData feeMatrices,
+            FeeObject secondaryFees,
+            ExchangeRate exchangeRate,
+            long multiplier
+    ) {
+        return internalGetFeeObject(
+                feeData, feeMatrices, exchangeRate, multiplier,
+                secondaryFees.getNetworkFee(), secondaryFees.getNodeFee(), secondaryFees.getServiceFee());
+    }
+
+    private static FeeObject internalGetFeeObject(
+            final FeeData feeData,
+            final FeeData feeMatrices,
+            final ExchangeRate exchangeRate,
+            final long multiplier,
+            final long secondaryNetworkFee,
+            final long secondaryNodeFee,
+            final long secondaryServiceFee
+    ) {
+        // First compute fees in tinycents
+        var networkFee =
+                getComponentFeeInTinyCents(feeData.getNetworkdata(), feeMatrices.getNetworkdata())
+                        + secondaryNetworkFee;
+        var nodeFee =
+                getComponentFeeInTinyCents(feeData.getNodedata(), feeMatrices.getNodedata())
+                        + secondaryNodeFee;
+        var serviceFee =
+                getComponentFeeInTinyCents(feeData.getServicedata(), feeMatrices.getServicedata())
+                        + secondaryServiceFee;
+
+        // Then convert to tinybars
         networkFee = FeeBuilder.getTinybarsFromTinyCents(exchangeRate, networkFee) * multiplier;
         nodeFee = FeeBuilder.getTinybarsFromTinyCents(exchangeRate, nodeFee) * multiplier;
         serviceFee = FeeBuilder.getTinybarsFromTinyCents(exchangeRate, serviceFee) * multiplier;
+
         return new FeeObject(nodeFee, networkFee, serviceFee);
     }
 

--- a/hapi-utils/src/test/java/com/hederahashgraph/fee/FeeBuilderTest.java
+++ b/hapi-utils/src/test/java/com/hederahashgraph/fee/FeeBuilderTest.java
@@ -193,6 +193,16 @@ class FeeBuilderTest {
     }
 
     @Test
+    void canIncludeSecondaryFees() {
+        final var secondaryFees = new FeeObject(1L, 2L, 3L);
+        var result = FeeBuilder.getFeeObjectWithSecondary(
+                feeData, feeMatrices, secondaryFees, exchangeRate, 10);
+        assertEquals(200, result.getNodeFee());
+        assertEquals(300, result.getNetworkFee());
+        assertEquals(400, result.getServiceFee());
+    }
+
+    @Test
     void assertGetFeeObject() {
         var result = FeeBuilder.getFeeObject(feeData, feeMatrices, exchangeRate);
         assertEquals(10, result.getNodeFee());

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/services/fees/calculation/TxnResourceUsageEstimator.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/services/fees/calculation/TxnResourceUsageEstimator.java
@@ -19,6 +19,7 @@ import com.hedera.services.context.primitives.StateView;
 import com.hederahashgraph.api.proto.java.FeeData;
 import com.hederahashgraph.api.proto.java.TransactionBody;
 import com.hederahashgraph.exception.InvalidTxBodyException;
+import com.hederahashgraph.fee.FeeObject;
 import com.hederahashgraph.fee.SigValueObj;
 
 /**
@@ -47,4 +48,18 @@ public interface TxnResourceUsageEstimator {
      */
     FeeData usageGiven(TransactionBody txn, SigValueObj sigUsage, StateView view)
             throws InvalidTxBodyException;
+
+    /**
+     * Returns whether this estimator can directly compute USD-denominated fees to add
+     * to the resource-derived {@link com.hederahashgraph.fee.FeeObject}.
+     *
+     * @return if this usage estimator can compute secondary fees
+     */
+    default boolean hasSecondaryFees() {
+        return false;
+    }
+
+    default FeeObject secondaryFeesFor(final TransactionBody txn) {
+        throw new UnsupportedOperationException();
+    }
 }

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/services/fees/calculation/UsageBasedFeeCalculator.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/services/fees/calculation/UsageBasedFeeCalculator.java
@@ -23,6 +23,7 @@ import static com.hederahashgraph.api.proto.java.HederaFunctionality.ContractCre
 import static com.hederahashgraph.api.proto.java.HederaFunctionality.CryptoAccountAutoRenew;
 import static com.hederahashgraph.fee.FeeBuilder.FEE_DIVISOR_FACTOR;
 import static com.hederahashgraph.fee.FeeBuilder.getFeeObject;
+import static com.hederahashgraph.fee.FeeBuilder.getFeeObjectWithSecondary;
 import static com.hederahashgraph.fee.FeeBuilder.getTinybarsFromTinyCents;
 
 import com.hedera.services.context.primitives.StateView;
@@ -239,13 +240,24 @@ public class UsageBasedFeeCalculator implements FeeCalculator {
             var sigUsage = getSigUsage(accessor, payerKey);
             var usageEstimator = getTxnUsageEstimator(accessor);
             try {
-                final var usage = usageEstimator.usageGiven(accessor.getTxn(), sigUsage, view);
+                final var txn = accessor.getTxn();
+                final var usage = usageEstimator.usageGiven(txn, sigUsage, view);
                 final var applicablePrices = prices.get(usage.getSubType());
-                return getFeeObject(
-                        applicablePrices,
-                        usage,
-                        rate,
-                        feeMultiplierSource.currentMultiplier(accessor));
+                final var multiplier = feeMultiplierSource.currentMultiplier(accessor);
+                if (usageEstimator.hasSecondaryFees()) {
+                    return getFeeObjectWithSecondary(
+                            applicablePrices,
+                            usage,
+                            usageEstimator.secondaryFeesFor(txn),
+                            rate,
+                            multiplier);
+                } else {
+                    return getFeeObject(
+                            applicablePrices,
+                            usage,
+                            rate,
+                            multiplier);
+                }
             } catch (InvalidTxBodyException e) {
                 log.warn(
                         "Argument accessor={} malformed for implied estimator {}!",

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/services/fees/calculation/schedule/txns/ScheduleCreateResourceUsage.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/services/fees/calculation/schedule/txns/ScheduleCreateResourceUsage.java
@@ -23,6 +23,7 @@ import com.hedera.services.usage.schedule.ScheduleOpsUsage;
 import com.hederahashgraph.api.proto.java.FeeData;
 import com.hederahashgraph.api.proto.java.TransactionBody;
 import com.hederahashgraph.exception.InvalidTxBodyException;
+import com.hederahashgraph.fee.FeeObject;
 import com.hederahashgraph.fee.SigValueObj;
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -80,5 +81,19 @@ public class ScheduleCreateResourceUsage implements TxnResourceUsageEstimator {
                 priceIncrement,
                 increasedPriceBytesPerMonth,
                 defaultLifeTimeSecs);
+    }
+
+    @Override
+    public boolean hasSecondaryFees() {
+        // TODO - return true;
+        return false;
+    }
+
+    @Override
+    public FeeObject secondaryFeesFor(final TransactionBody txn) {
+        // TODO - check if the price increment applies; if so, compute
+        // the increased cost ABC **in tinycents** and return a
+        // FeeObject(0, 0, ABC) here
+        return null;
     }
 }

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/services/fees/calculation/TxnResourceUsageEstimatorTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/services/fees/calculation/TxnResourceUsageEstimatorTest.java
@@ -1,0 +1,26 @@
+package com.hedera.services.fees.calculation;
+
+import com.hederahashgraph.api.proto.java.TransactionBody;
+import org.junit.jupiter.api.Test;
+import org.mockito.BDDMockito;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.willCallRealMethod;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+class TxnResourceUsageEstimatorTest {
+    @Test
+    void defaultResourceUsageEstimatorHasNoSecondaryFees() {
+        final var mockSubject = mock(TxnResourceUsageEstimator.class);
+
+        willCallRealMethod().given(mockSubject).hasSecondaryFees();
+        willCallRealMethod().given(mockSubject).secondaryFeesFor(any());
+
+        assertFalse(mockSubject.hasSecondaryFees());
+        verify(mockSubject).hasSecondaryFees();
+        assertThrows(UnsupportedOperationException.class, () ->
+                mockSubject.secondaryFeesFor(TransactionBody.getDefaultInstance()));
+    }
+}

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/services/fees/calculation/UsageBasedFeeCalculatorTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/services/fees/calculation/UsageBasedFeeCalculatorTest.java
@@ -40,6 +40,7 @@ import static com.hederahashgraph.api.proto.java.ResponseType.ANSWER_ONLY;
 import static com.hederahashgraph.fee.FeeBuilder.FEE_DIVISOR_FACTOR;
 import static com.hederahashgraph.fee.FeeBuilder.HRS_DIVISOR;
 import static com.hederahashgraph.fee.FeeBuilder.getFeeObject;
+import static com.hederahashgraph.fee.FeeBuilder.getFeeObjectWithSecondary;
 import static com.hederahashgraph.fee.FeeBuilder.getTinybarsFromTinyCents;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -669,6 +670,43 @@ class UsageBasedFeeCalculatorTest {
         assertEquals(fees.getNodeFee(), expectedFees.getNodeFee());
         assertEquals(fees.getNetworkFee(), expectedFees.getNetworkFee());
         assertEquals(fees.getServiceFee(), expectedFees.getServiceFee());
+    }
+
+    @Test
+    void usesSecondaryFeesWhenAppropos() throws Exception {
+        // setup:
+        SigValueObj expectedSigUsage =
+                new SigValueObj(
+                        FeeBuilder.getSignatureCount(signedTxn),
+                        9,
+                        FeeBuilder.getSignatureSize(signedTxn));
+
+        final var secondaryFees = new FeeObject(1, 2, 3);
+        FeeObject expectedFees =
+                getFeeObjectWithSecondary(
+                        DEFAULT_RESOURCE_PRICES.get(SubType.DEFAULT), resourceUsage,
+                        secondaryFees, currentRate, 1L);
+
+        given(txnUsageEstimators.get(CryptoCreate)).willReturn(List.of(correctOpEstimator));
+        given(correctOpEstimator.applicableTo(accessor.getTxn())).willReturn(true);
+        given(correctOpEstimator.hasSecondaryFees()).willReturn(true);
+        given(correctOpEstimator.secondaryFeesFor(accessor.getTxn())).willReturn(secondaryFees);
+        given(
+                correctOpEstimator.usageGiven(
+                        argThat(accessor.getTxn()::equals),
+                        argThat(factory.apply(expectedSigUsage)),
+                        argThat(view::equals)))
+                .willReturn(resourceUsage);
+        given(exchange.rate(at)).willReturn(currentRate);
+        given(usagePrices.pricesGiven(CryptoCreate, at)).willReturn(DEFAULT_RESOURCE_PRICES);
+
+        // when:
+        FeeObject fees = subject.estimateFee(accessor, payerKey, view, at);
+
+        // then:
+        assertEquals(expectedFees.getNodeFee(), fees.getNodeFee());
+        assertEquals(expectedFees.getNetworkFee(), fees.getNetworkFee());
+        assertEquals(expectedFees.getServiceFee(), fees.getServiceFee());
     }
 
     private final Function<SigValueObj, ArgumentMatcher<SigValueObj>> factory =


### PR DESCRIPTION
**Description**:
- Provides a different way to support directly adding fees _in tinycents_ to the charged price.
- Does this by updating `TxnResourceUsageEstimator` to signal via `hasSecondaryFees()` that the fee calculator should combine both the resource-scaled prices and the explicit secondary fees in its returned `FeeObject`.
