### PR TITLE
Match user expectations on indirect staking reward situations

### DIFF
--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/services/ledger/interceptors/StakingAccountsCommitInterceptor.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/services/ledger/interceptors/StakingAccountsCommitInterceptor.java
@@ -291,7 +291,7 @@ public class StakingAccountsCommitInterceptor extends AccountsCommitInterceptor 
             final var roundedInitialBalance = roundedToHbar(initialBalance);
             final var delta = roundedFinalBalance - roundedInitialBalance;
             // Even if the stakee's total stake hasn't changed, we still want to
-            // trigger a reward situation to match user expectations; c.f.,
+            // trigger a reward situation whenever the staker balance changes; c.f.,
             // https://github.com/hashgraph/hedera-services/issues/4166
             final var alwaysUpdate = finalBalance != initialBalance;
             alterStakedToMe(curStakedId, delta, alwaysUpdate, pendingChanges);

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/services/ledger/interceptors/StakingAccountsCommitInterceptorTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/services/ledger/interceptors/StakingAccountsCommitInterceptorTest.java
@@ -839,6 +839,90 @@ class StakingAccountsCommitInterceptorTest {
     }
 
     @Test
+    void includesIndirectStakeeInChangesEvenIfTotalStakeUnchanged() {
+        counterparty.setStakedId(1L);
+        stakingFund.setStakePeriodStart(-1);
+        counterparty.setStakePeriodStart(stakePeriodStart - 2);
+
+        final Map<AccountProperty, Object> stakingFundChanges =
+                Map.of(AccountProperty.BALANCE, 100L);
+        final var pendingChanges = buildPendingAccountStakeChanges(counterpartyBalance + 1);
+        pendingChanges.include(stakingFundId, stakingFund, stakingFundChanges);
+        given(accounts.get(EntityNum.fromLong(1L))).willReturn(merkleAccount);
+        given(merkleAccount.getStakedToMe()).willReturn(counterpartyBalance);
+
+        subject =
+                new StakingAccountsCommitInterceptor(
+                        sideEffectsTracker,
+                        () -> networkCtx,
+                        dynamicProperties,
+                        rewardCalculator,
+                        new StakeChangeManager(
+                                stakeInfoManager,
+                                () -> AccountStorageAdapter.fromInMemory(accounts)),
+                        stakePeriodManager,
+                        stakeInfoManager,
+                        accountNumbers,
+                        txnCtx,
+                        usageTracking);
+
+        subject.getRewardsEarned()[1] = 0;
+        subject.getRewardsEarned()[2] = 1;
+        assertEquals(2, pendingChanges.size());
+
+        subject.setCurStakedId(1L);
+        subject.setNewStakedId(1L);
+        Arrays.fill(subject.getStakedToMeUpdates(), NA);
+        subject.updateStakedToMeSideEffects(
+                counterparty,
+                StakeChangeScenario.FROM_ACCOUNT_TO_ACCOUNT,
+                pendingChanges.changes(0),
+                pendingChanges);
+        assertEquals(counterpartyBalance, subject.getStakedToMeUpdates()[2]);
+    }
+
+    @Test
+    void doesntUpdateStakedToMeIfStakerBalanceIsExactlyTheSame() {
+        counterparty.setStakedId(1L);
+        stakingFund.setStakePeriodStart(-1);
+        counterparty.setStakePeriodStart(stakePeriodStart - 2);
+
+        final Map<AccountProperty, Object> stakingFundChanges =
+                Map.of(AccountProperty.BALANCE, 100L);
+        final var pendingChanges = buildPendingAccountStakeChanges(counterpartyBalance);
+        pendingChanges.include(stakingFundId, stakingFund, stakingFundChanges);
+
+        subject =
+                new StakingAccountsCommitInterceptor(
+                        sideEffectsTracker,
+                        () -> networkCtx,
+                        dynamicProperties,
+                        rewardCalculator,
+                        new StakeChangeManager(
+                                stakeInfoManager,
+                                () -> AccountStorageAdapter.fromInMemory(accounts)),
+                        stakePeriodManager,
+                        stakeInfoManager,
+                        accountNumbers,
+                        txnCtx,
+                        usageTracking);
+
+        subject.getRewardsEarned()[1] = 0;
+        subject.getRewardsEarned()[2] = 1;
+        assertEquals(2, pendingChanges.size());
+
+        subject.setCurStakedId(1L);
+        subject.setNewStakedId(1L);
+        Arrays.fill(subject.getStakedToMeUpdates(), NA);
+        subject.updateStakedToMeSideEffects(
+                counterparty,
+                StakeChangeScenario.FROM_ACCOUNT_TO_ACCOUNT,
+                pendingChanges.changes(0),
+                pendingChanges);
+        assertEquals(NA, subject.getStakedToMeUpdates()[2]);
+    }
+
+    @Test
     void updatesStakedToMeSideEffectsPaysRewardsIfRewardable() {
         counterparty.setStakedId(123L);
         stakingFund.setStakePeriodStart(-1);
@@ -941,7 +1025,12 @@ class StakingAccountsCommitInterceptorTest {
 
     public EntityChangeSet<AccountID, HederaAccount, AccountProperty>
             buildPendingAccountStakeChanges() {
-        var changes = randomStakeAccountChanges(100L * HBARS_TO_TINYBARS);
+        return buildPendingAccountStakeChanges(100L * HBARS_TO_TINYBARS);
+    }
+
+    public EntityChangeSet<AccountID, HederaAccount, AccountProperty>
+            buildPendingAccountStakeChanges(final long newBalance) {
+        var changes = randomStakeAccountChanges(newBalance);
         var pendingChanges = new EntityChangeSet<AccountID, HederaAccount, AccountProperty>();
         pendingChanges.include(counterpartyId, counterparty, changes);
         return pendingChanges;

--- a/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/meta/HapiGetTxnRecord.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/meta/HapiGetTxnRecord.java
@@ -132,6 +132,7 @@ public class HapiGetTxnRecord extends HapiQueryOp<HapiGetTxnRecord> {
 
     private boolean noPseudoRandomData = false;
     private List<Pair<String, Long>> paidStakingRewards = new ArrayList<>();
+    private int numStakingRewardsPaid = -1;
 
     private Consumer<List<?>> eventDataObserver;
     private String eventName;
@@ -234,6 +235,11 @@ public class HapiGetTxnRecord extends HapiQueryOp<HapiGetTxnRecord> {
 
     public HapiGetTxnRecord hasPaidStakingRewards(List<Pair<String, Long>> rewards) {
         paidStakingRewards = rewards;
+        return this;
+    }
+
+    public HapiGetTxnRecord hasPaidStakingRewardsCount(final int n) {
+        numStakingRewardsPaid = n;
         return this;
     }
 
@@ -600,6 +606,12 @@ public class HapiGetTxnRecord extends HapiQueryOp<HapiGetTxnRecord> {
                             childRecord.getAlias().toStringUtf8());
                 }
             }
+        }
+        if (numStakingRewardsPaid != -1) {
+            assertEquals(
+                    numStakingRewardsPaid,
+                    actualRecord.getPaidStakingRewardsCount(),
+                    "Wrong # of staking rewards paid");
         }
         if (!paidStakingRewards.isEmpty()) {
             if (actualRecord.getPaidStakingRewardsList().isEmpty()) {

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/staking/StakingSuite.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/staking/StakingSuite.java
@@ -16,7 +16,6 @@
 package com.hedera.services.bdd.suites.crypto.staking;
 
 import static com.hedera.services.bdd.spec.HapiApiSpec.defaultHapiSpec;
-import static com.hedera.services.bdd.spec.HapiApiSpec.onlyDefaultHapiSpec;
 import static com.hedera.services.bdd.spec.assertions.AccountInfoAsserts.accountWith;
 import static com.hedera.services.bdd.spec.assertions.ContractInfoAsserts.contractWith;
 import static com.hedera.services.bdd.spec.assertions.TransactionRecordAsserts.recordWith;
@@ -197,7 +196,7 @@ public class StakingSuite extends HapiApiSuite {
     }
 
     private HapiApiSpec losingEvenAZeroBalanceStakerTriggersStakeeRewardSituation() {
-        return onlyDefaultHapiSpec("LosingEvenAZeroBalanceStakerTriggersStakeeRewardSituation")
+        return defaultHapiSpec("LosingEvenAZeroBalanceStakerTriggersStakeeRewardSituation")
                 .given(
                         overriding(STAKING_START_THRESHOLD, "" + 10 * ONE_HBAR),
                         overriding(STAKING_REWARD_RATE, "" + SOME_REWARD_RATE),

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/staking/StakingSuite.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/staking/StakingSuite.java
@@ -16,6 +16,7 @@
 package com.hedera.services.bdd.suites.crypto.staking;
 
 import static com.hedera.services.bdd.spec.HapiApiSpec.defaultHapiSpec;
+import static com.hedera.services.bdd.spec.HapiApiSpec.onlyDefaultHapiSpec;
 import static com.hedera.services.bdd.spec.assertions.AccountInfoAsserts.accountWith;
 import static com.hedera.services.bdd.spec.assertions.ContractInfoAsserts.contractWith;
 import static com.hedera.services.bdd.spec.assertions.TransactionRecordAsserts.recordWith;
@@ -82,6 +83,8 @@ public class StakingSuite extends HapiApiSuite {
         // These specs cannot really be run in CI; they are mostly useful for local
         // validation on a network started with a staking.periodMins=1 override
         return List.of(
+                losingEvenAZeroBalanceStakerTriggersStakeeRewardSituation(),
+                evenOneTinybarChangeInIndirectStakingAccountTriggersStakeeRewardSituation(),
                 rewardsWorkAsExpected(),
                 rewardPaymentsNotRepeatedInSamePeriod(),
                 getInfoQueriesReturnsPendingRewards(),
@@ -134,7 +137,7 @@ public class StakingSuite extends HapiApiSuite {
         final long bobPendingRewardsCase1 =
                 rewardSumHistoryCase1 * (ONE_HUNDRED_HBARS / TINY_PARTS_PER_WHOLE);
 
-        return defaultHapiSpec("rewardsWorkAsExpected")
+        return defaultHapiSpec("SecondOrderRewardSituationsWork")
                 .given(
                         overriding(STAKING_START_THRESHOLD, "" + 10 * ONE_HBAR),
                         overriding(STAKING_REWARD_RATE, "" + SOME_REWARD_RATE),
@@ -171,6 +174,44 @@ public class StakingSuite extends HapiApiSuite {
                                                 Pair.of(ALICE, alicePendingRewardsCase1),
                                                 Pair.of(BOB, bobPendingRewardsCase1)))
                                 .logged());
+    }
+
+    private HapiApiSpec
+            evenOneTinybarChangeInIndirectStakingAccountTriggersStakeeRewardSituation() {
+        return defaultHapiSpec(
+                        "EvenOneTinybarChangeInIndirectStakingAccountTriggersStakeeRewardSituation")
+                .given(
+                        overriding(STAKING_START_THRESHOLD, "" + 10 * ONE_HBAR),
+                        overriding(STAKING_REWARD_RATE, "" + SOME_REWARD_RATE),
+                        cryptoTransfer(tinyBarsFromTo(GENESIS, STAKING_REWARD, ONE_MILLION_HBARS)))
+                .when(
+                        cryptoCreate(ALICE).stakedNodeId(0).balance(ONE_HUNDRED_HBARS),
+                        cryptoCreate(BOB).stakedAccountId(ALICE).balance(ONE_HUNDRED_HBARS),
+                        cryptoCreate(CAROL).stakedAccountId(ALICE).balance(ONE_HUNDRED_HBARS),
+                        sleepFor(INTER_PERIOD_SLEEP_MS),
+                        cryptoTransfer(tinyBarsFromTo(DEFAULT_PAYER, FUNDING, 1L)),
+                        sleepFor(INTER_PERIOD_SLEEP_MS))
+                .then(
+                        cryptoTransfer(tinyBarsFromTo(DEFAULT_PAYER, CAROL, 1)).via(FIRST_TRANSFER),
+                        getTxnRecord(FIRST_TRANSFER).hasPaidStakingRewardsCount(1));
+    }
+
+    private HapiApiSpec losingEvenAZeroBalanceStakerTriggersStakeeRewardSituation() {
+        return onlyDefaultHapiSpec("LosingEvenAZeroBalanceStakerTriggersStakeeRewardSituation")
+                .given(
+                        overriding(STAKING_START_THRESHOLD, "" + 10 * ONE_HBAR),
+                        overriding(STAKING_REWARD_RATE, "" + SOME_REWARD_RATE),
+                        cryptoTransfer(tinyBarsFromTo(GENESIS, STAKING_REWARD, ONE_MILLION_HBARS)))
+                .when(
+                        cryptoCreate(ALICE).stakedNodeId(0).balance(ONE_HUNDRED_HBARS),
+                        cryptoCreate(BOB).stakedAccountId(ALICE).balance(0L),
+                        cryptoCreate(CAROL).stakedAccountId(ALICE).balance(ONE_HUNDRED_HBARS),
+                        sleepFor(INTER_PERIOD_SLEEP_MS),
+                        cryptoTransfer(tinyBarsFromTo(DEFAULT_PAYER, FUNDING, 1L)),
+                        sleepFor(INTER_PERIOD_SLEEP_MS))
+                .then(
+                        cryptoUpdate(BOB).newStakedNodeId(0L).via(FIRST_TRANSFER),
+                        getTxnRecord(FIRST_TRANSFER).hasPaidStakingRewardsCount(1));
     }
 
     private HapiApiSpec getInfoQueriesReturnsPendingRewards() {


### PR DESCRIPTION
**Description**:
 - Closes #4166 
 - Suppose `A` stakes to `B`, and `B` stakes to a node. This PR adds reward situations for `B` in three cases:
    1. `A`'s balance changes, but **not** its number of whole hbars.
    2. `A`'s balance is less than 1 whole hbar, and stops staking to `B`.
    3. Some other account `C`  with balance less than 1 whole hbar **starts** staking to `B`.
 - `B`'s total stake does not change in any of these cases, so there's no harm in not treating them as reward sitautions; but users have reported being surprised by this policy.