### PR TITLE
Support account and file auto-renew accounts

### DIFF
--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/services/context/primitives/StateView.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/services/context/primitives/StateView.java
@@ -470,6 +470,9 @@ public class StateView {
                         .setOwnedNfts(account.getNftsOwned())
                         .setMaxAutomaticTokenAssociations(account.getMaxAutomaticAssociations())
                         .setEthereumNonce(account.getEthereumNonce());
+        Optional.ofNullable(account.getAutoRenewAccount())
+                .map(EntityId::toGrpcAccountId)
+                .ifPresent(info::setAutoRenewAccount);
         Optional.ofNullable(account.getProxy())
                 .map(EntityId::toGrpcAccountId)
                 .ifPresent(info::setProxyAccountID);

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/services/context/primitives/StateView.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/services/context/primitives/StateView.java
@@ -421,6 +421,9 @@ public class StateView {
         }
         if (!stateChildren.specialFiles().contains(id)) {
             info.setMemo(attr.getMemo());
+            if (attr.getAutoRenewId() != null) {
+                info.setAutoRenewAccount(attr.getAutoRenewId().toGrpcAccountId());
+            }
         } else {
             // The "memo" of a special upgrade file is its hexed SHA-384 hash for DevOps convenience
             final var upgradeHash =

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/services/context/primitives/StateView.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/services/context/primitives/StateView.java
@@ -424,6 +424,10 @@ public class StateView {
             if (attr.getAutoRenewId() != null) {
                 info.setAutoRenewAccount(attr.getAutoRenewId().toGrpcAccountId());
             }
+            if (attr.getAutoRenewPeriod() != 0) {
+                info.setAutoRenewPeriod(
+                        Duration.newBuilder().setSeconds(attr.getAutoRenewPeriod()).build());
+            }
         } else {
             // The "memo" of a special upgrade file is its hexed SHA-384 hash for DevOps convenience
             final var upgradeHash =

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/services/files/HFileMeta.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/services/files/HFileMeta.java
@@ -21,6 +21,7 @@ import com.google.common.base.MoreObjects;
 import com.hedera.services.legacy.core.jproto.JKey;
 import com.hedera.services.state.submerkle.EntityId;
 import com.hedera.services.utils.MiscUtils;
+import com.hederahashgraph.api.proto.java.Duration;
 import java.io.ByteArrayInputStream;
 import java.io.DataInputStream;
 import java.io.IOException;
@@ -32,6 +33,7 @@ public class HFileMeta {
     private String memo = DEFAULT_MEMO;
     private boolean deleted;
     private EntityId autoRenewId;
+    private long autoRenewPeriod;
 
     public HFileMeta(boolean deleted, JKey wacl, long expiry) {
         this.deleted = deleted;
@@ -46,12 +48,19 @@ public class HFileMeta {
         this.expiry = expiry;
     }
 
-    public HFileMeta(boolean deleted, JKey wacl, long expiry, String memo, EntityId autoRenewId) {
+    public HFileMeta(
+            boolean deleted,
+            JKey wacl,
+            long expiry,
+            String memo,
+            EntityId autoRenewId,
+            long autoRenewPeriod) {
         this.wacl = wacl;
         this.memo = memo;
         this.deleted = deleted;
         this.expiry = expiry;
         this.autoRenewId = autoRenewId;
+        this.autoRenewPeriod = autoRenewPeriod;
     }
 
     public byte[] serialize() throws IOException {
@@ -109,6 +118,18 @@ public class HFileMeta {
         this.autoRenewId = null;
     }
 
+    public long getAutoRenewPeriod() {
+        return autoRenewPeriod;
+    }
+
+    public Duration getTypedAutoRenewPeriod() {
+        return Duration.newBuilder().setSeconds(autoRenewPeriod).build();
+    }
+
+    public void setAutoRenewPeriod(long autoRenewPeriod) {
+        this.autoRenewPeriod = autoRenewPeriod;
+    }
+
     @Override
     public String toString() {
         return MoreObjects.toStringHelper(this)
@@ -117,6 +138,7 @@ public class HFileMeta {
                 .add("expiry", expiry)
                 .add("deleted", deleted)
                 .add("autoRenewId", autoRenewId)
+                .add("autoRenewPeriod", autoRenewPeriod)
                 .toString();
     }
 }

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/services/files/HFileMeta.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/services/files/HFileMeta.java
@@ -21,7 +21,6 @@ import com.google.common.base.MoreObjects;
 import com.hedera.services.legacy.core.jproto.JKey;
 import com.hedera.services.state.submerkle.EntityId;
 import com.hedera.services.utils.MiscUtils;
-import com.hederahashgraph.api.proto.java.Duration;
 import java.io.ByteArrayInputStream;
 import java.io.DataInputStream;
 import java.io.IOException;
@@ -114,16 +113,8 @@ public class HFileMeta {
         this.autoRenewId = autoRenewId;
     }
 
-    public void removeAutoRenewId() {
-        this.autoRenewId = null;
-    }
-
     public long getAutoRenewPeriod() {
         return autoRenewPeriod;
-    }
-
-    public Duration getTypedAutoRenewPeriod() {
-        return Duration.newBuilder().setSeconds(autoRenewPeriod).build();
     }
 
     public void setAutoRenewPeriod(long autoRenewPeriod) {

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/services/files/HFileMeta.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/services/files/HFileMeta.java
@@ -21,11 +21,10 @@ import com.google.common.base.MoreObjects;
 import com.hedera.services.legacy.core.jproto.JKey;
 import com.hedera.services.state.submerkle.EntityId;
 import com.hedera.services.utils.MiscUtils;
-
-import javax.annotation.Nullable;
 import java.io.ByteArrayInputStream;
 import java.io.DataInputStream;
 import java.io.IOException;
+import javax.annotation.Nullable;
 
 public class HFileMeta {
     private JKey wacl;

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/services/files/HFileMeta.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/services/files/HFileMeta.java
@@ -19,7 +19,10 @@ import static com.hedera.services.state.merkle.MerkleAccountState.DEFAULT_MEMO;
 
 import com.google.common.base.MoreObjects;
 import com.hedera.services.legacy.core.jproto.JKey;
+import com.hedera.services.state.submerkle.EntityId;
 import com.hedera.services.utils.MiscUtils;
+
+import javax.annotation.Nullable;
 import java.io.ByteArrayInputStream;
 import java.io.DataInputStream;
 import java.io.IOException;
@@ -29,6 +32,7 @@ public class HFileMeta {
     private long expiry;
     private String memo = DEFAULT_MEMO;
     private boolean deleted;
+    private EntityId autoRenewId;
 
     public HFileMeta(boolean deleted, JKey wacl, long expiry) {
         this.deleted = deleted;
@@ -41,6 +45,14 @@ public class HFileMeta {
         this.memo = memo;
         this.deleted = deleted;
         this.expiry = expiry;
+    }
+
+    public HFileMeta(boolean deleted, JKey wacl, long expiry, String memo, EntityId autoRenewId) {
+        this.wacl = wacl;
+        this.memo = memo;
+        this.deleted = deleted;
+        this.expiry = expiry;
+        this.autoRenewId = autoRenewId;
     }
 
     public byte[] serialize() throws IOException {
@@ -85,6 +97,19 @@ public class HFileMeta {
         this.memo = memo;
     }
 
+    @Nullable
+    public EntityId getAutoRenewId() {
+        return autoRenewId;
+    }
+
+    public void setAutoRenewId(EntityId autoRenewId) {
+        this.autoRenewId = autoRenewId;
+    }
+
+    public void removeAutoRenewId() {
+        this.autoRenewId = null;
+    }
+
     @Override
     public String toString() {
         return MoreObjects.toStringHelper(this)
@@ -92,6 +117,7 @@ public class HFileMeta {
                 .add("wacl", MiscUtils.describe(wacl))
                 .add("expiry", expiry)
                 .add("deleted", deleted)
+                .add("autoRenewId", autoRenewId)
                 .toString();
     }
 }

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/services/files/HFileMetaSerde.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/services/files/HFileMetaSerde.java
@@ -69,8 +69,8 @@ public class HFileMetaSerde {
         return unpack(in);
     }
 
-    private static HFileMeta readSerializableMeta(
-            final DataInputStream in, final long version) throws IOException {
+    private static HFileMeta readSerializableMeta(final DataInputStream in, final long version)
+            throws IOException {
         final var serIn = new SerializableDataInputStream(in);
         final var isDeleted = serIn.readBoolean();
         final var expiry = serIn.readLong();

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/services/files/HFileMetaSerde.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/services/files/HFileMetaSerde.java
@@ -46,6 +46,7 @@ public class HFileMetaSerde {
                     serOut.writeNormalisedString(meta.getMemo());
                     writeNullable(meta.getWacl(), serOut, IoUtils::serializeKey);
                     serOut.writeSerializable(meta.getAutoRenewId(), true);
+                    serOut.writeLong(meta.getAutoRenewPeriod());
                 });
     }
 
@@ -80,7 +81,8 @@ public class HFileMetaSerde {
             return new HFileMeta(isDeleted, wacl, expiry, memo);
         } else {
             final EntityId autoRenewId = serIn.readSerializable();
-            return new HFileMeta(isDeleted, wacl, expiry, memo, autoRenewId);
+            final long autoRenewPeriod = serIn.readLong();
+            return new HFileMeta(isDeleted, wacl, expiry, memo, autoRenewId, autoRenewPeriod);
         }
     }
 

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/services/ledger/HederaLedger.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/services/ledger/HederaLedger.java
@@ -18,6 +18,7 @@ package com.hedera.services.ledger;
 import static com.hedera.services.ledger.TransferLogic.dropTokenChanges;
 import static com.hedera.services.ledger.backing.BackingTokenRels.asTokenRel;
 import static com.hedera.services.ledger.properties.AccountProperty.ALIAS;
+import static com.hedera.services.ledger.properties.AccountProperty.AUTO_RENEW_ACCOUNT_ID;
 import static com.hedera.services.ledger.properties.AccountProperty.AUTO_RENEW_PERIOD;
 import static com.hedera.services.ledger.properties.AccountProperty.BALANCE;
 import static com.hedera.services.ledger.properties.AccountProperty.EXPIRY;
@@ -55,11 +56,13 @@ import com.hedera.services.state.migration.HederaAccount;
 import com.hedera.services.state.migration.HederaTokenRel;
 import com.hedera.services.state.migration.UniqueTokenAdapter;
 import com.hedera.services.state.submerkle.CurrencyAdjustments;
+import com.hedera.services.state.submerkle.EntityId;
 import com.hedera.services.store.contracts.MutableEntityAccess;
 import com.hedera.services.store.models.NftId;
 import com.hedera.services.store.tokens.TokenStore;
 import com.hedera.services.txns.crypto.AutoCreationLogic;
 import com.hedera.services.txns.validation.OptionValidator;
+import com.hedera.services.utils.EntityNum;
 import com.hederahashgraph.api.proto.java.AccountID;
 import com.hederahashgraph.api.proto.java.ContractID;
 import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
@@ -381,6 +384,11 @@ public class HederaLedger {
 
     public long autoRenewPeriod(AccountID id) {
         return (long) accountsLedger.get(id, AUTO_RENEW_PERIOD);
+    }
+
+    public EntityNum autoRenewNum(final AccountID id) {
+        final var autoRenewId = (EntityId) accountsLedger.get(id, AUTO_RENEW_ACCOUNT_ID);
+        return autoRenewId == null ? null : autoRenewId.asNum();
     }
 
     public boolean isSmartContract(AccountID id) {

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/services/ledger/accounts/AccountCustomizer.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/services/ledger/accounts/AccountCustomizer.java
@@ -40,6 +40,7 @@ import com.hedera.services.legacy.core.jproto.JKey;
 import com.hedera.services.state.submerkle.EntityId;
 import java.util.EnumMap;
 import java.util.Map;
+import javax.annotation.Nullable;
 
 /**
  * Implements a fluent builder for defining a set of standard customizations relevant to any account
@@ -164,10 +165,9 @@ public abstract class AccountCustomizer<
         return self();
     }
 
-    public T autoRenewAccount(final EntityId option) {
-        if (option != null) {
-            changeManager.update(changes, optionProperties.get(AUTO_RENEW_ACCOUNT_ID), option);
-        }
+    public T autoRenewAccount(@Nullable final EntityId option) {
+        // If null, denotes removal of the auto-renew account
+        changeManager.update(changes, optionProperties.get(AUTO_RENEW_ACCOUNT_ID), option);
         return self();
     }
 

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/services/ledger/accounts/HederaAccountCustomizer.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/services/ledger/accounts/HederaAccountCustomizer.java
@@ -87,9 +87,11 @@ public final class HederaAccountCustomizer
             op.setDeclineReward((boolean) changes.get(AccountProperty.DECLINE_REWARD));
         }
         if (changes.containsKey(AccountProperty.AUTO_RENEW_ACCOUNT_ID)) {
-            op.setAutoRenewAccountId(
-                    ((EntityId) changes.get(AccountProperty.AUTO_RENEW_ACCOUNT_ID))
-                            .toGrpcAccountId());
+            final var maybeAutoRenewAccount =
+                    (EntityId) changes.get(AccountProperty.AUTO_RENEW_ACCOUNT_ID);
+            if (maybeAutoRenewAccount != null) {
+                op.setAutoRenewAccountId(maybeAutoRenewAccount.toGrpcAccountId());
+            }
         }
         if (changes.containsKey(AccountProperty.MAX_AUTOMATIC_ASSOCIATIONS)) {
             op.setMaxAutomaticTokenAssociations(

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/services/sigs/order/SigRequirements.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/services/sigs/order/SigRequirements.java
@@ -1401,15 +1401,14 @@ public class SigRequirements {
                     return tokenResult.failureIfAny();
                 } else {
                     final var tokenMeta = tokenResult.metadata();
-                    if (tokenMeta.hasRoyaltyWithFallback()) {
-                        if (!receivesFungibleValue(counterparty, op)) {
-                            // Fallback situation; but we still need to check if the treasury is
-                            // the sender or receiver, since in neither case will the fallback fee
-                            // actually be charged
-                            final var treasury = tokenMeta.treasury().toGrpcAccountId();
-                            if (!treasury.equals(party) && !treasury.equals(counterparty)) {
-                                required.add(meta.key());
-                            }
+                    if (tokenMeta.hasRoyaltyWithFallback()
+                            && !receivesFungibleValue(counterparty, op)) {
+                        // Fallback situation; but we still need to check if the treasury is
+                        // the sender or receiver, since in neither case will the fallback fee
+                        // actually be charged
+                        final var treasury = tokenMeta.treasury().toGrpcAccountId();
+                        if (!treasury.equals(party) && !treasury.equals(counterparty)) {
+                            required.add(meta.key());
                         }
                     }
                 }

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/services/sigs/order/SigRequirements.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/services/sigs/order/SigRequirements.java
@@ -1402,12 +1402,14 @@ public class SigRequirements {
                 } else {
                     final var tokenMeta = tokenResult.metadata();
                     if (tokenMeta.hasRoyaltyWithFallback()) {
-                        final var fallbackApplies =
-                                !receivesFungibleValue(counterparty, op)
-                                        && counterparty.getAccountNum()
-                                                != tokenMeta.treasury().num();
-                        if (fallbackApplies) {
-                            required.add(meta.key());
+                        if (!receivesFungibleValue(counterparty, op)) {
+                            // Fallback situation; but we still need to check if the treasury is
+                            // the sender or receiver, since in neither case will the fallback fee
+                            // actually be charged
+                            final var treasury = tokenMeta.treasury().toGrpcAccountId();
+                            if (!treasury.equals(party) && !treasury.equals(counterparty)) {
+                                required.add(meta.key());
+                            }
                         }
                     }
                 }

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/services/sigs/order/SigRequirements.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/services/sigs/order/SigRequirements.java
@@ -522,6 +522,7 @@ public class SigRequirements {
             }
             if (needsAutoRenewSignature(
                     op,
+                    true,
                     FileUpdateTransactionBody::hasAutoRenewAccount,
                     FileUpdateTransactionBody::getAutoRenewAccount)) {
                 final var autoRenewResult =
@@ -566,6 +567,7 @@ public class SigRequirements {
         final var needsAutoRenew =
                 needsAutoRenewSignature(
                         op,
+                        false,
                         FileCreateTransactionBody::hasAutoRenewAccount,
                         FileCreateTransactionBody::getAutoRenewAccount);
         final var candidate = asUsableFcKey(Key.newBuilder().setKeyList(op.getKeys()).build());
@@ -691,6 +693,7 @@ public class SigRequirements {
             }
             if (needsAutoRenewSignature(
                     op,
+                    true,
                     CryptoUpdateTransactionBody::hasAutoRenewAccount,
                     CryptoUpdateTransactionBody::getAutoRenewAccount)) {
                 final var autoRenewResult =
@@ -816,6 +819,7 @@ public class SigRequirements {
         final var needsAutoRenew =
                 needsAutoRenewSignature(
                         op,
+                        false,
                         CryptoCreateTransactionBody::hasAutoRenewAccount,
                         CryptoCreateTransactionBody::getAutoRenewAccount);
         if (!op.getReceiverSigRequired() && !needsAutoRenew) {
@@ -1529,9 +1533,11 @@ public class SigRequirements {
 
     private <T> boolean needsAutoRenewSignature(
             final T op,
+            final boolean permitsRemoval,
             final Predicate<T> autoRenewTest,
             final Function<T, AccountID> autoRenewGetter) {
-        return autoRenewTest.test(op) && !designatesAccountRemoval(autoRenewGetter.apply(op));
+        return autoRenewTest.test(op)
+                && !(permitsRemoval && designatesAccountRemoval(autoRenewGetter.apply(op)));
     }
 
     private boolean tryToAddAutoRenew(

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/services/txns/crypto/CryptoCreateTransitionLogic.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/services/txns/crypto/CryptoCreateTransitionLogic.java
@@ -128,10 +128,9 @@ public class CryptoCreateTransitionLogic implements TransitionLogic {
             final var op = txn.getCryptoCreateAccount();
             final var now = txnCtx.consensusTime().getEpochSecond();
 
-            final var summarizedMeta = expiryValidator.summarizeCreationAttempt(
-                    now,
-                    true,
-                    ExpiryMeta.fromCryptoCreateOp(op));
+            final var summarizedMeta =
+                    expiryValidator.summarizeCreationAttempt(
+                            now, true, ExpiryMeta.fromCryptoCreateOp(op));
             if (!summarizedMeta.isValid()) {
                 txnCtx.setStatus(summarizedMeta.status());
                 return;
@@ -172,7 +171,8 @@ public class CryptoCreateTransitionLogic implements TransitionLogic {
         }
     }
 
-    private HederaAccountCustomizer asCustomizer(final CryptoCreateTransactionBody op, final ExpiryMeta validMeta) {
+    private HederaAccountCustomizer asCustomizer(
+            final CryptoCreateTransactionBody op, final ExpiryMeta validMeta) {
         var customizer = new HederaAccountCustomizer();
         customizer
                 .memo(op.getMemo())

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/services/txns/crypto/CryptoCreateTransitionLogic.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/services/txns/crypto/CryptoCreateTransitionLogic.java
@@ -182,7 +182,6 @@ public class CryptoCreateTransitionLogic implements TransitionLogic {
                 .maxAutomaticAssociations(op.getMaxAutomaticTokenAssociations())
                 .isDeclinedReward(op.getDeclineReward());
         if (validMeta.hasAutoRenewNum()) {
-            System.out.println("BOOP");
             customizer.autoRenewAccount(validMeta.autoRenewId());
         }
 

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/services/txns/crypto/CryptoCreateTransitionLogic.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/services/txns/crypto/CryptoCreateTransitionLogic.java
@@ -182,6 +182,7 @@ public class CryptoCreateTransitionLogic implements TransitionLogic {
                 .maxAutomaticAssociations(op.getMaxAutomaticTokenAssociations())
                 .isDeclinedReward(op.getDeclineReward());
         if (validMeta.hasAutoRenewNum()) {
+            System.out.println("BOOP");
             customizer.autoRenewAccount(validMeta.autoRenewId());
         }
 

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/services/txns/crypto/CryptoUpdateTransitionLogic.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/services/txns/crypto/CryptoUpdateTransitionLogic.java
@@ -20,14 +20,11 @@ import static com.hedera.services.ledger.accounts.staking.StakingUtils.validSent
 import static com.hedera.services.utils.MiscUtils.asFcKeyUnchecked;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.ACCOUNT_DELETED;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.ACCOUNT_EXPIRED_AND_PENDING_REMOVAL;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.AUTORENEW_DURATION_NOT_IN_RANGE;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.BAD_ENCODING;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.EXISTING_AUTOMATIC_ASSOCIATIONS_EXCEED_GIVEN_LIMIT;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.EXPIRATION_REDUCTION_NOT_ALLOWED;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.FAIL_INVALID;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_ACCOUNT_ID;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_ADMIN_KEY;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_EXPIRATION_TIME;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_STAKING_ID;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OK;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.PROXY_ACCOUNT_ID_FIELD_IS_DEPRECATED;
@@ -54,14 +51,12 @@ import com.hederahashgraph.api.proto.java.AccountID;
 import com.hederahashgraph.api.proto.java.CryptoUpdateTransactionBody;
 import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
 import com.hederahashgraph.api.proto.java.TransactionBody;
-
 import java.util.EnumSet;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 import javax.inject.Inject;
 import javax.inject.Singleton;
-
 import org.apache.commons.codec.DecoderException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -120,10 +115,11 @@ public class CryptoUpdateTransitionLogic implements TransitionLogic {
                 return;
             }
 
-            final var currentMeta = new ExpiryMeta(
-                    ledger.expiry(target),
-                    ledger.autoRenewPeriod(target),
-                    ledger.autoRenewNum(target));
+            final var currentMeta =
+                    new ExpiryMeta(
+                            ledger.expiry(target),
+                            ledger.autoRenewPeriod(target),
+                            ledger.autoRenewNum(target));
             final var requestedMeta = ExpiryMeta.fromCryptoUpdateOp(op);
             final var summarizedMeta =
                     expiryValidator.summarizeUpdateAttempt(currentMeta, requestedMeta);

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/services/txns/crypto/CryptoUpdateTransitionLogic.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/services/txns/crypto/CryptoUpdateTransitionLogic.java
@@ -132,6 +132,7 @@ public class CryptoUpdateTransitionLogic implements TransitionLogic {
                 customizer.isExpiredAndPendingRemoval(false);
             }
 
+            summarizedMeta.knownValidMeta().updateCustomizer(customizer);
             ledger.customize(target, customizer);
             sigImpactHistorian.markEntityChanged(target.getAccountNum());
             txnCtx.setStatus(SUCCESS);

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/services/txns/file/FileCreateTransitionLogic.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/services/txns/file/FileCreateTransitionLogic.java
@@ -128,7 +128,12 @@ public class FileCreateTransitionLogic implements TransitionLogic {
         if (op.hasAutoRenewAccount()) {
             final var autoRenewId = EntityId.fromGrpcAccountId(op.getAutoRenewAccount());
             return new HFileMeta(
-                    false, wacl, op.getExpirationTime().getSeconds(), op.getMemo(), autoRenewId);
+                    false,
+                    wacl,
+                    op.getExpirationTime().getSeconds(),
+                    op.getMemo(),
+                    autoRenewId,
+                    op.getAutoRenewPeriod().getSeconds());
         } else {
             return new HFileMeta(false, wacl, op.getExpirationTime().getSeconds(), op.getMemo());
         }

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/services/txns/file/FileCreateTransitionLogic.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/services/txns/file/FileCreateTransitionLogic.java
@@ -127,7 +127,8 @@ public class FileCreateTransitionLogic implements TransitionLogic {
 
         if (op.hasAutoRenewAccount()) {
             final var autoRenewId = EntityId.fromGrpcAccountId(op.getAutoRenewAccount());
-            return new HFileMeta(false, wacl, op.getExpirationTime().getSeconds(), op.getMemo(), autoRenewId);
+            return new HFileMeta(
+                    false, wacl, op.getExpirationTime().getSeconds(), op.getMemo(), autoRenewId);
         } else {
             return new HFileMeta(false, wacl, op.getExpirationTime().getSeconds(), op.getMemo());
         }

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/services/txns/file/FileCreateTransitionLogic.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/services/txns/file/FileCreateTransitionLogic.java
@@ -42,7 +42,6 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 import javax.inject.Inject;
 import javax.inject.Singleton;
-
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -89,9 +88,7 @@ public class FileCreateTransitionLogic implements TransitionLogic {
             final var expiryMeta = ExpiryMeta.fromFileCreateOp(op);
             final var summarizedMeta =
                     expiryValidator.summarizeCreationAttempt(
-                            txnId.getTransactionValidStart().getSeconds(),
-                            false,
-                            expiryMeta);
+                            txnId.getTransactionValidStart().getSeconds(), false, expiryMeta);
             if (!summarizedMeta.isValid()) {
                 txnCtx.setStatus(summarizedMeta.status());
                 return;
@@ -137,10 +134,9 @@ public class FileCreateTransitionLogic implements TransitionLogic {
         return OK;
     }
 
-    private HFileMeta asAttr(
-            final FileCreateTransactionBody op,
-            final ExpiryMeta validExpiryMeta) {
-        final var wacl = op.hasKeys() ? asFcKeyUnchecked(wrapped(op.getKeys())) : StateView.EMPTY_WACL;
+    private HFileMeta asAttr(final FileCreateTransactionBody op, final ExpiryMeta validExpiryMeta) {
+        final var wacl =
+                op.hasKeys() ? asFcKeyUnchecked(wrapped(op.getKeys())) : StateView.EMPTY_WACL;
         return new HFileMeta(
                 false,
                 wacl,

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/services/txns/file/FileCreateTransitionLogic.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/services/txns/file/FileCreateTransitionLogic.java
@@ -143,7 +143,7 @@ public class FileCreateTransitionLogic implements TransitionLogic {
                 validExpiryMeta.expiry(),
                 op.getMemo(),
                 validExpiryMeta.autoRenewId(),
-                validExpiryMeta.readableAutoRenewPeriod());
+                validExpiryMeta.usableAutoRenewPeriod());
     }
 
     private ResponseCodeEnum validate(final TransactionBody fileCreateTxn) {

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/services/txns/file/FileUpdateTransitionLogic.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/services/txns/file/FileUpdateTransitionLogic.java
@@ -26,7 +26,6 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.PREPARED_UPDAT
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SUCCESS;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.UNAUTHORIZED;
 import static java.lang.Boolean.TRUE;
-import static java.lang.Math.max;
 
 import com.hedera.services.config.EntityNumbers;
 import com.hedera.services.context.TransactionContext;
@@ -105,7 +104,8 @@ public class FileUpdateTransitionLogic implements TransitionLogic {
 
             final var currentMeta = ExpiryMeta.fromExtantFileMeta(attr);
             final var requestedMeta = ExpiryMeta.fromFileUpdateOp(op);
-            final var summarizedMeta = expiryValidator.summarizeUpdateAttempt(currentMeta, requestedMeta);
+            final var summarizedMeta =
+                    expiryValidator.summarizeUpdateAttempt(currentMeta, requestedMeta);
             if (!summarizedMeta.isValid()) {
                 txnCtx.setStatus(summarizedMeta.status());
                 return;
@@ -145,9 +145,7 @@ public class FileUpdateTransitionLogic implements TransitionLogic {
     }
 
     private void updateAttrBased(
-            final HFileMeta attr,
-            final ExpiryMeta validMeta,
-            final FileUpdateTransactionBody op) {
+            final HFileMeta attr, final ExpiryMeta validMeta, final FileUpdateTransactionBody op) {
         // All fields have already been validated at this point
         if (op.hasKeys()) {
             attr.setWacl(asFcKeyUnchecked(wrapped(op.getKeys())));

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/services/txns/file/FileUpdateTransitionLogic.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/services/txns/file/FileUpdateTransitionLogic.java
@@ -40,7 +40,6 @@ import com.hedera.services.state.merkle.MerkleNetworkContext;
 import com.hedera.services.state.submerkle.EntityId;
 import com.hedera.services.txns.TransitionLogic;
 import com.hedera.services.txns.validation.OptionValidator;
-import com.hedera.services.utils.MiscUtils;
 import com.hederahashgraph.api.proto.java.Duration;
 import com.hederahashgraph.api.proto.java.FileID;
 import com.hederahashgraph.api.proto.java.FileUpdateTransactionBody;

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/services/txns/file/FileUpdateTransitionLogic.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/services/txns/file/FileUpdateTransitionLogic.java
@@ -17,6 +17,7 @@ package com.hedera.services.txns.file;
 
 import static com.hedera.services.files.TieredHederaFs.firstUnsuccessful;
 import static com.hedera.services.utils.MiscUtils.asFcKeyUnchecked;
+import static com.hedera.services.utils.MiscUtils.designatesAccountRemoval;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.AUTORENEW_DURATION_NOT_IN_RANGE;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.BAD_ENCODING;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.FAIL_INVALID;
@@ -36,8 +37,10 @@ import com.hedera.services.files.HederaFs;
 import com.hedera.services.files.TieredHederaFs;
 import com.hedera.services.ledger.SigImpactHistorian;
 import com.hedera.services.state.merkle.MerkleNetworkContext;
+import com.hedera.services.state.submerkle.EntityId;
 import com.hedera.services.txns.TransitionLogic;
 import com.hedera.services.txns.validation.OptionValidator;
+import com.hedera.services.utils.MiscUtils;
 import com.hederahashgraph.api.proto.java.Duration;
 import com.hederahashgraph.api.proto.java.FileID;
 import com.hederahashgraph.api.proto.java.FileUpdateTransactionBody;
@@ -141,6 +144,13 @@ public class FileUpdateTransitionLogic implements TransitionLogic {
         }
         if (op.hasMemo()) {
             attr.setMemo(op.getMemo().getValue());
+        }
+        if (op.hasAutoRenewAccount()) {
+            if (designatesAccountRemoval(op.getAutoRenewAccount())) {
+                attr.removeAutoRenewId();
+            } else {
+                attr.setAutoRenewId(EntityId.fromGrpcAccountId(op.getAutoRenewAccount()));
+            }
         }
     }
 

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/services/txns/validation/ExpiryMeta.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/services/txns/validation/ExpiryMeta.java
@@ -1,34 +1,43 @@
+/*
+ * Copyright (C) 2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hedera.services.txns.validation;
 
 import com.hedera.services.files.HFileMeta;
-import com.hedera.services.state.migration.HederaAccount;
 import com.hedera.services.state.submerkle.EntityId;
 import com.hedera.services.utils.EntityNum;
 import com.hederahashgraph.api.proto.java.CryptoCreateTransactionBody;
 import com.hederahashgraph.api.proto.java.CryptoUpdateTransactionBody;
 import com.hederahashgraph.api.proto.java.FileCreateTransactionBody;
 import com.hederahashgraph.api.proto.java.FileUpdateTransactionBody;
-
-import javax.annotation.Nullable;
 import java.util.function.LongSupplier;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
+import javax.annotation.Nullable;
 
-public record ExpiryMeta(
-        long expiry,
-        long autoRenewPeriod,
-        @Nullable EntityNum autoRenewNum) {
+public record ExpiryMeta(long expiry, long autoRenewPeriod, @Nullable EntityNum autoRenewNum) {
     public static final long UNUSED_FIELD_SENTINEL = Long.MIN_VALUE;
-    public static final ExpiryMeta INVALID_EXPIRY_META = new ExpiryMeta(
-            UNUSED_FIELD_SENTINEL,
-            UNUSED_FIELD_SENTINEL,
-            null);
+    public static final ExpiryMeta INVALID_EXPIRY_META =
+            new ExpiryMeta(UNUSED_FIELD_SENTINEL, UNUSED_FIELD_SENTINEL, null);
 
     public static ExpiryMeta withExplicitExpiry(final long expiry) {
         return new ExpiryMeta(expiry, UNUSED_FIELD_SENTINEL, null);
     }
 
-    public static ExpiryMeta withAutoRenewSpecNotSelfFunding(final long autoRenewPeriod, final EntityNum autoRenewNum) {
+    public static ExpiryMeta withAutoRenewSpecNotSelfFunding(
+            final long autoRenewPeriod, final EntityNum autoRenewNum) {
         return new ExpiryMeta(UNUSED_FIELD_SENTINEL, autoRenewPeriod, autoRenewNum);
     }
 
@@ -84,14 +93,13 @@ public record ExpiryMeta(
             final LongSupplier autoRenewPeriodFn,
             final Predicate<T> autoRenewNumTest,
             final Supplier<EntityNum> autoRenewNumFn) {
-        final var expiry = expiryTest.test(op)
-                ? expiryFn.getAsLong() : UNUSED_FIELD_SENTINEL;
-        final var autoRenewPeriod = autoRenewPeriodTest.test(op)
-                ? autoRenewPeriodFn.getAsLong() : UNUSED_FIELD_SENTINEL;
+        final var expiry = expiryTest.test(op) ? expiryFn.getAsLong() : UNUSED_FIELD_SENTINEL;
+        final var autoRenewPeriod =
+                autoRenewPeriodTest.test(op)
+                        ? autoRenewPeriodFn.getAsLong()
+                        : UNUSED_FIELD_SENTINEL;
         // FUTURE WORK - support aliases here
-        final var autoRenewNum = autoRenewNumTest.test(op)
-                ? autoRenewNumFn.get()
-                : null;
+        final var autoRenewNum = autoRenewNumTest.test(op) ? autoRenewNumFn.get() : null;
         return new ExpiryMeta(expiry, autoRenewPeriod, autoRenewNum);
     }
 
@@ -113,7 +121,10 @@ public record ExpiryMeta(
         meta.setExpiry(expiry);
         meta.setAutoRenewPeriod(autoRenewPeriod);
         // 0.0.0 is a sentinel value used to remove an auto-renew account
-        meta.setAutoRenewId(autoRenewNum == null || autoRenewNum.longValue() == 0 ? null : autoRenewNum.toEntityId());
+        meta.setAutoRenewId(
+                autoRenewNum == null || autoRenewNum.longValue() == 0
+                        ? null
+                        : autoRenewNum.toEntityId());
     }
 
     @Nullable

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/services/txns/validation/ExpiryValidator.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/services/txns/validation/ExpiryValidator.java
@@ -1,16 +1,31 @@
+/*
+ * Copyright (C) 2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hedera.services.txns.validation;
-
-import javax.inject.Inject;
-import javax.inject.Singleton;
 
 import static com.hedera.services.txns.validation.SummarizedExpiryMeta.EXPIRY_REDUCTION_SUMMARY;
 import static com.hedera.services.txns.validation.SummarizedExpiryMeta.INVALID_EXPIRY_SUMMARY;
 import static com.hedera.services.txns.validation.SummarizedExpiryMeta.INVALID_PERIOD_SUMMARY;
 
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
 /**
- * Provides helpers to summarize the validity and net consequence of creating and updating
- * an entity's expiration related metadata (that is, its expiration, auto-renew period, and
- * auto-renew account number).
+ * Provides helpers to summarize the validity and net consequence of creating and updating an
+ * entity's expiration related metadata (that is, its expiration, auto-renew period, and auto-renew
+ * account number).
  */
 @Singleton
 public class ExpiryValidator {
@@ -22,47 +37,50 @@ public class ExpiryValidator {
     }
 
     /**
-     * Summarizes the validity and net consequences of an attempt to create an entity with the requested
-     * expiration metadata, at the given time.
+     * Summarizes the validity and net consequences of an attempt to create an entity with the
+     * requested expiration metadata, at the given time.
      *
-     * @param now           the effective consensus time
+     * @param now the effective consensus time
      * @param requestedMeta the new entity's desired metadata
      * @param canSelfFundRenewals whether the new entity can self-fund renewals
      * @return a summary of the metadata validity and net effect
      */
     public SummarizedExpiryMeta summarizeCreationAttempt(
-            final long now,
-            final boolean canSelfFundRenewals,
-            final ExpiryMeta requestedMeta) {
-        // If the expiry is not set explicitly, it may be possible to infer it from the auto-renew period
+            final long now, final boolean canSelfFundRenewals, final ExpiryMeta requestedMeta) {
+        // If the expiry is not set explicitly, it may be possible to infer it from the auto-renew
+        // period
         long resolvedExpiry = requestedMeta.expiry();
-        if (requestedMeta.hasFullAutoRenewSpec() || (!requestedMeta.hasExplicitExpiry() && canSelfFundRenewals)) {
+        if (requestedMeta.hasFullAutoRenewSpec()
+                || (!requestedMeta.hasExplicitExpiry() && canSelfFundRenewals)) {
             resolvedExpiry = now + requestedMeta.autoRenewPeriod();
         }
         if (!validator.isValidExpiry(resolvedExpiry)) {
             return INVALID_EXPIRY_SUMMARY;
         }
         // We always require a valid auto-renew period if set
-        if (requestedMeta.hasAutoRenewPeriod() && !validator.isValidAutoRenewPeriod(requestedMeta.autoRenewPeriod())) {
+        if (requestedMeta.hasAutoRenewPeriod()
+                && !validator.isValidAutoRenewPeriod(requestedMeta.autoRenewPeriod())) {
             return INVALID_PERIOD_SUMMARY;
         }
         // The auto-renew account is already validated while enforcing signing requirements,
         // so nothing more to do with it here
-        return SummarizedExpiryMeta.forValid(new ExpiryMeta(
-                resolvedExpiry,
-                requestedMeta.autoRenewPeriod(),
-                requestedMeta.autoRenewNum()));
+        return SummarizedExpiryMeta.forValid(
+                new ExpiryMeta(
+                        resolvedExpiry,
+                        requestedMeta.autoRenewPeriod(),
+                        requestedMeta.autoRenewNum()));
     }
 
     /**
-     * Summarizes the validity and net consequences of an attempt to update an entity with the requested
-     * expiration metadata, relative to the given current metadata.
+     * Summarizes the validity and net consequences of an attempt to update an entity with the
+     * requested expiration metadata, relative to the given current metadata.
      *
-     * @param currentMeta   the current expiry metadata
+     * @param currentMeta the current expiry metadata
      * @param requestedMeta the entity's desired metadata update
      * @return a summary of the metadata update validity and net effect
      */
-    public SummarizedExpiryMeta summarizeUpdateAttempt(final ExpiryMeta currentMeta, final ExpiryMeta requestedMeta) {
+    public SummarizedExpiryMeta summarizeUpdateAttempt(
+            final ExpiryMeta currentMeta, final ExpiryMeta requestedMeta) {
         var resolvedExpiry = currentMeta.expiry();
         if (requestedMeta.hasExplicitExpiry()) {
             if (requestedMeta.expiry() < currentMeta.expiry()) {
@@ -84,13 +102,15 @@ public class ExpiryValidator {
 
         var resolvedAutoRenewNum = currentMeta.autoRenewNum();
         if (requestedMeta.hasAutoRenewNum()) {
-            if (!currentMeta.hasAutoRenewNum() && !validator.isValidAutoRenewPeriod(resolvedAutoRenewPeriod)) {
+            if (!currentMeta.hasAutoRenewNum()
+                    && !validator.isValidAutoRenewPeriod(resolvedAutoRenewPeriod)) {
                 return INVALID_PERIOD_SUMMARY;
             } else {
                 resolvedAutoRenewNum = requestedMeta.autoRenewNum();
             }
         }
-        final var resolvedMeta = new ExpiryMeta(resolvedExpiry, resolvedAutoRenewPeriod, resolvedAutoRenewNum);
+        final var resolvedMeta =
+                new ExpiryMeta(resolvedExpiry, resolvedAutoRenewPeriod, resolvedAutoRenewNum);
         return SummarizedExpiryMeta.forValid(resolvedMeta);
     }
 }

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/services/txns/validation/ExpiryValidator.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/services/txns/validation/ExpiryValidator.java
@@ -1,0 +1,96 @@
+package com.hedera.services.txns.validation;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+import static com.hedera.services.txns.validation.SummarizedExpiryMeta.EXPIRY_REDUCTION_SUMMARY;
+import static com.hedera.services.txns.validation.SummarizedExpiryMeta.INVALID_EXPIRY_SUMMARY;
+import static com.hedera.services.txns.validation.SummarizedExpiryMeta.INVALID_PERIOD_SUMMARY;
+
+/**
+ * Provides helpers to summarize the validity and net consequence of creating and updating
+ * an entity's expiration related metadata (that is, its expiration, auto-renew period, and
+ * auto-renew account number).
+ */
+@Singleton
+public class ExpiryValidator {
+    private final OptionValidator validator;
+
+    @Inject
+    public ExpiryValidator(OptionValidator validator) {
+        this.validator = validator;
+    }
+
+    /**
+     * Summarizes the validity and net consequences of an attempt to create an entity with the requested
+     * expiration metadata, at the given time.
+     *
+     * @param now           the effective consensus time
+     * @param requestedMeta the new entity's desired metadata
+     * @param canSelfFundRenewals whether the new entity can self-fund renewals
+     * @return a summary of the metadata validity and net effect
+     */
+    public SummarizedExpiryMeta summarizeCreationAttempt(
+            final long now,
+            final boolean canSelfFundRenewals,
+            final ExpiryMeta requestedMeta) {
+        // If the expiry is not set explicitly, it may be possible to infer it from the auto-renew period
+        long resolvedExpiry = requestedMeta.expiry();
+        if (requestedMeta.hasFullAutoRenewSpec() || (!requestedMeta.hasExplicitExpiry() && canSelfFundRenewals)) {
+            resolvedExpiry = now + requestedMeta.autoRenewPeriod();
+        }
+        if (!validator.isValidExpiry(resolvedExpiry)) {
+            return INVALID_EXPIRY_SUMMARY;
+        }
+        // We always require a valid auto-renew period if set
+        if (requestedMeta.hasAutoRenewPeriod() && !validator.isValidAutoRenewPeriod(requestedMeta.autoRenewPeriod())) {
+            return INVALID_PERIOD_SUMMARY;
+        }
+        // The auto-renew account is already validated while enforcing signing requirements,
+        // so nothing more to do with it here
+        return SummarizedExpiryMeta.forValid(new ExpiryMeta(
+                resolvedExpiry,
+                requestedMeta.autoRenewPeriod(),
+                requestedMeta.autoRenewNum()));
+    }
+
+    /**
+     * Summarizes the validity and net consequences of an attempt to update an entity with the requested
+     * expiration metadata, relative to the given current metadata.
+     *
+     * @param currentMeta   the current expiry metadata
+     * @param requestedMeta the entity's desired metadata update
+     * @return a summary of the metadata update validity and net effect
+     */
+    public SummarizedExpiryMeta summarizeUpdateAttempt(final ExpiryMeta currentMeta, final ExpiryMeta requestedMeta) {
+        var resolvedExpiry = currentMeta.expiry();
+        if (requestedMeta.hasExplicitExpiry()) {
+            if (requestedMeta.expiry() < currentMeta.expiry()) {
+                return EXPIRY_REDUCTION_SUMMARY;
+            } else if (!validator.isValidExpiry(requestedMeta.expiry())) {
+                return INVALID_EXPIRY_SUMMARY;
+            } else {
+                resolvedExpiry = requestedMeta.expiry();
+            }
+        }
+
+        var resolvedAutoRenewPeriod = currentMeta.autoRenewPeriod();
+        if (requestedMeta.hasAutoRenewPeriod()) {
+            if (!validator.isValidAutoRenewPeriod(requestedMeta.autoRenewPeriod())) {
+                return INVALID_PERIOD_SUMMARY;
+            }
+            resolvedAutoRenewPeriod = requestedMeta.autoRenewPeriod();
+        }
+
+        var resolvedAutoRenewNum = currentMeta.autoRenewNum();
+        if (requestedMeta.hasAutoRenewNum()) {
+            if (!currentMeta.hasAutoRenewNum() && !validator.isValidAutoRenewPeriod(resolvedAutoRenewPeriod)) {
+                return INVALID_PERIOD_SUMMARY;
+            } else {
+                resolvedAutoRenewNum = requestedMeta.autoRenewNum();
+            }
+        }
+        final var resolvedMeta = new ExpiryMeta(resolvedExpiry, resolvedAutoRenewPeriod, resolvedAutoRenewNum);
+        return SummarizedExpiryMeta.forValid(resolvedMeta);
+    }
+}

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/services/txns/validation/OptionValidator.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/services/txns/validation/OptionValidator.java
@@ -24,6 +24,7 @@ import com.hedera.services.state.merkle.MerkleTopic;
 import com.hedera.services.state.migration.AccountStorageAdapter;
 import com.hedera.services.state.migration.HederaAccount;
 import com.hedera.services.utils.EntityNum;
+import com.hedera.services.utils.MiscUtils;
 import com.hedera.services.utils.accessors.TxnAccessor;
 import com.hederahashgraph.api.proto.java.AccountID;
 import com.hederahashgraph.api.proto.java.ContractID;
@@ -44,6 +45,9 @@ import java.time.Instant;
 public interface OptionValidator {
     boolean hasGoodEncoding(Key key);
 
+    default boolean isValidExpiry(final long then) {
+        return isValidExpiry(MiscUtils.asSecondsTimestamp(then));
+    }
     boolean isValidExpiry(Timestamp expiry);
 
     boolean isThisNodeAccount(AccountID id);
@@ -52,6 +56,9 @@ public interface OptionValidator {
 
     boolean isAfterConsensusSecond(long now);
 
+    default boolean isValidAutoRenewPeriod(final long len) {
+        return isValidAutoRenewPeriod(Duration.newBuilder().setSeconds(len).build());
+    }
     boolean isValidAutoRenewPeriod(Duration autoRenewPeriod);
 
     boolean isAcceptableTransfersLength(TransferList accountAmounts);

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/services/txns/validation/OptionValidator.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/services/txns/validation/OptionValidator.java
@@ -48,6 +48,7 @@ public interface OptionValidator {
     default boolean isValidExpiry(final long then) {
         return isValidExpiry(MiscUtils.asSecondsTimestamp(then));
     }
+
     boolean isValidExpiry(Timestamp expiry);
 
     boolean isThisNodeAccount(AccountID id);
@@ -59,6 +60,7 @@ public interface OptionValidator {
     default boolean isValidAutoRenewPeriod(final long len) {
         return isValidAutoRenewPeriod(Duration.newBuilder().setSeconds(len).build());
     }
+
     boolean isValidAutoRenewPeriod(Duration autoRenewPeriod);
 
     boolean isAcceptableTransfersLength(TransferList accountAmounts);

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/services/txns/validation/SummarizedExpiryMeta.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/services/txns/validation/SummarizedExpiryMeta.java
@@ -1,0 +1,33 @@
+package com.hedera.services.txns.validation;
+
+import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
+
+import static com.hedera.services.txns.validation.ExpiryMeta.INVALID_EXPIRY_META;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.AUTORENEW_DURATION_NOT_IN_RANGE;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.EXPIRATION_REDUCTION_NOT_ALLOWED;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_EXPIRATION_TIME;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OK;
+
+public record SummarizedExpiryMeta(ResponseCodeEnum status, ExpiryMeta meta) {
+    public static final SummarizedExpiryMeta INVALID_PERIOD_SUMMARY =
+            new SummarizedExpiryMeta(AUTORENEW_DURATION_NOT_IN_RANGE, INVALID_EXPIRY_META);
+    public static final SummarizedExpiryMeta INVALID_EXPIRY_SUMMARY =
+            new SummarizedExpiryMeta(INVALID_EXPIRATION_TIME, INVALID_EXPIRY_META);
+    public static final SummarizedExpiryMeta EXPIRY_REDUCTION_SUMMARY =
+            new SummarizedExpiryMeta(EXPIRATION_REDUCTION_NOT_ALLOWED, INVALID_EXPIRY_META);
+
+    public static SummarizedExpiryMeta forValid(ExpiryMeta expiryMeta) {
+        return new SummarizedExpiryMeta(OK, expiryMeta);
+    }
+
+    public boolean isValid() {
+        return status == OK;
+    }
+
+    public ExpiryMeta knownValidMeta() {
+        if (!isValid()) {
+            throw new IllegalStateException("Meta not known valid");
+        }
+        return meta;
+    }
+}

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/services/txns/validation/SummarizedExpiryMeta.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/services/txns/validation/SummarizedExpiryMeta.java
@@ -1,12 +1,27 @@
+/*
+ * Copyright (C) 2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hedera.services.txns.validation;
-
-import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
 
 import static com.hedera.services.txns.validation.ExpiryMeta.INVALID_EXPIRY_META;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.AUTORENEW_DURATION_NOT_IN_RANGE;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.EXPIRATION_REDUCTION_NOT_ALLOWED;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_EXPIRATION_TIME;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OK;
+
+import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
 
 public record SummarizedExpiryMeta(ResponseCodeEnum status, ExpiryMeta meta) {
     public static final SummarizedExpiryMeta INVALID_PERIOD_SUMMARY =

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/services/utils/MiscUtils.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/services/utils/MiscUtils.java
@@ -1042,4 +1042,11 @@ public final class MiscUtils {
     public static boolean hasUnknownFieldsHere(final GeneratedMessageV3 msg) {
         return !msg.getUnknownFields().asMap().isEmpty();
     }
+
+    public static boolean designatesAccountRemoval(final AccountID id) {
+        return id.getShardNum() == 0
+                && id.getRealmNum() == 0
+                && id.getAccountNum() == 0
+                && id.getAlias().isEmpty();
+    }
 }

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/services/context/primitives/StateViewTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/services/context/primitives/StateViewTest.java
@@ -223,7 +223,11 @@ class StateViewTest {
     public void setup() throws Throwable {
         metadata =
                 new HFileMeta(
-                        false, TxnHandlingScenario.MISC_FILE_WACL_KT.asJKey(), expiry, fileMemo, autoRenewId);
+                        false,
+                        TxnHandlingScenario.MISC_FILE_WACL_KT.asJKey(),
+                        expiry,
+                        fileMemo,
+                        autoRenewId);
         immutableMetadata = new HFileMeta(false, StateView.EMPTY_WACL, expiry);
 
         expectedImmutable =

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/services/context/primitives/StateViewTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/services/context/primitives/StateViewTest.java
@@ -227,7 +227,8 @@ class StateViewTest {
                         TxnHandlingScenario.MISC_FILE_WACL_KT.asJKey(),
                         expiry,
                         fileMemo,
-                        autoRenewId);
+                        autoRenewId,
+                        autoRenewPeriod);
         immutableMetadata = new HFileMeta(false, StateView.EMPTY_WACL, expiry);
 
         expectedImmutable =
@@ -243,6 +244,8 @@ class StateViewTest {
                         .setKeys(TxnHandlingScenario.MISC_FILE_WACL_KT.asKey().getKeyList())
                         .setMemo(fileMemo)
                         .setAutoRenewAccount(autoRenewId.toGrpcAccountId())
+                        .setAutoRenewPeriod(
+                                Duration.newBuilder().setSeconds(autoRenewPeriod).build())
                         .build();
 
         tokenAccount =

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/services/context/primitives/StateViewTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/services/context/primitives/StateViewTest.java
@@ -144,6 +144,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 class StateViewTest {
     private static final int wellKnownNumKvPairs = 144;
     private final Instant resolutionTime = Instant.ofEpochSecond(123L);
+    private final EntityId autoRenewId = new EntityId(0, 0, 666_666L);
     private final RichInstant now =
             RichInstant.fromGrpc(Timestamp.newBuilder().setNanos(123123213).build());
     private final int maxTokensFprAccountInfo = 10;
@@ -222,7 +223,7 @@ class StateViewTest {
     public void setup() throws Throwable {
         metadata =
                 new HFileMeta(
-                        false, TxnHandlingScenario.MISC_FILE_WACL_KT.asJKey(), expiry, fileMemo);
+                        false, TxnHandlingScenario.MISC_FILE_WACL_KT.asJKey(), expiry, fileMemo, autoRenewId);
         immutableMetadata = new HFileMeta(false, StateView.EMPTY_WACL, expiry);
 
         expectedImmutable =
@@ -237,6 +238,7 @@ class StateViewTest {
                 expectedImmutable.toBuilder()
                         .setKeys(TxnHandlingScenario.MISC_FILE_WACL_KT.asKey().getKeyList())
                         .setMemo(fileMemo)
+                        .setAutoRenewAccount(autoRenewId.toGrpcAccountId())
                         .build();
 
         tokenAccount =

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/services/context/primitives/StateViewTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/services/context/primitives/StateViewTest.java
@@ -260,6 +260,7 @@ class StateViewTest {
         tokenAccount.setNumPositiveBalances(0);
         tokenAccount.setStakedId(10L);
         tokenAccount.setDeclineReward(true);
+        tokenAccount.setAutoRenewAccount(autoRenewId);
         contract =
                 MerkleAccountFactory.newAccount()
                         .alias(create2Address)
@@ -752,6 +753,7 @@ class StateViewTest {
                         .setMemo(tokenAccount.getMemo())
                         .setAutoRenewPeriod(
                                 Duration.newBuilder().setSeconds(tokenAccount.getAutoRenewSecs()))
+                        .setAutoRenewAccount(autoRenewId.toGrpcAccountId())
                         .setBalance(tokenAccount.getBalance())
                         .setExpirationTime(
                                 Timestamp.newBuilder().setSeconds(tokenAccount.getExpiry()))
@@ -833,6 +835,7 @@ class StateViewTest {
                         .setMemo(tokenAccount.getMemo())
                         .setAutoRenewPeriod(
                                 Duration.newBuilder().setSeconds(tokenAccount.getAutoRenewSecs()))
+                        .setAutoRenewAccount(autoRenewId.toGrpcAccountId())
                         .setBalance(tokenAccount.getBalance())
                         .setExpirationTime(
                                 Timestamp.newBuilder().setSeconds(tokenAccount.getExpiry()))
@@ -917,6 +920,7 @@ class StateViewTest {
                         .setMemo(tokenAccount.getMemo())
                         .setAutoRenewPeriod(
                                 Duration.newBuilder().setSeconds(tokenAccount.getAutoRenewSecs()))
+                        .setAutoRenewAccount(autoRenewId.toGrpcAccountId())
                         .setBalance(tokenAccount.getBalance())
                         .setExpirationTime(
                                 Timestamp.newBuilder().setSeconds(tokenAccount.getExpiry()))

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/services/files/HFileMetaSerdeTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/services/files/HFileMetaSerdeTest.java
@@ -27,20 +27,18 @@ import static org.mockito.BDDMockito.mock;
 import com.hedera.services.legacy.core.jproto.JKey;
 import com.hedera.services.legacy.core.jproto.JObjectType;
 import com.hedera.services.state.submerkle.EntityId;
-import com.hedera.services.stream.RecordStreamObject;
 import com.hedera.test.factories.scenarios.TxnHandlingScenario;
 import com.hedera.test.utils.IdUtils;
 import com.hedera.test.utils.SeededPropertySource;
 import com.hederahashgraph.api.proto.java.FileGetInfoResponse.FileInfo;
 import com.hederahashgraph.api.proto.java.FileID;
 import com.hederahashgraph.api.proto.java.Timestamp;
-import java.io.ByteArrayInputStream;
-import java.io.DataInputStream;
-import java.io.IOException;
-
 import com.swirlds.common.constructable.ClassConstructorPair;
 import com.swirlds.common.constructable.ConstructableRegistry;
 import com.swirlds.common.constructable.ConstructableRegistryException;
+import java.io.ByteArrayInputStream;
+import java.io.DataInputStream;
+import java.io.IOException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -96,11 +94,10 @@ class HFileMetaSerdeTest {
     }
 
     @Test
-    void deserializesWithMemoAndKeyAndAutoRenewAccount() throws IOException, ConstructableRegistryException {
+    void deserializesWithMemoAndKeyAndAutoRenewAccount()
+            throws IOException, ConstructableRegistryException {
         ConstructableRegistry.getInstance()
-                .registerConstructable(
-                        new ClassConstructorPair(
-                                EntityId.class, EntityId::new));
+                .registerConstructable(new ClassConstructorPair(EntityId.class, EntityId::new));
         final var propertySource = SeededPropertySource.forSerdeTest((int) AUTO_RENEW_VERSION, 1);
         final var expected =
                 new HFileMeta(

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/services/files/HFileMetaSerdeTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/services/files/HFileMetaSerdeTest.java
@@ -105,7 +105,8 @@ class HFileMetaSerdeTest {
                         propertySource.nextKeyList(2),
                         propertySource.nextUnsignedLong(),
                         propertySource.nextString(69),
-                        propertySource.nextEntityId());
+                        propertySource.nextEntityId(),
+                        666_666L);
 
         final var serializedForm = HFileMetaSerde.serialize(expected);
         final var actual =

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/services/ledger/HederaLedgerTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/services/ledger/HederaLedgerTest.java
@@ -306,7 +306,8 @@ class HederaLedgerTest extends BaseHederaLedgerTestHelper {
 
     @Test
     void delegatesToCorrectAutoRenewId() {
-        given(accountsLedger.get(genesis, AUTO_RENEW_ACCOUNT_ID)).willReturn(new EntityId(0, 0, 666));
+        given(accountsLedger.get(genesis, AUTO_RENEW_ACCOUNT_ID))
+                .willReturn(new EntityId(0, 0, 666));
 
         final var ans = subject.autoRenewNum(genesis);
 

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/services/ledger/HederaLedgerTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/services/ledger/HederaLedgerTest.java
@@ -17,6 +17,7 @@ package com.hedera.services.ledger;
 
 import static com.hedera.services.exceptions.InsufficientFundsException.messageFor;
 import static com.hedera.services.ledger.properties.AccountProperty.ALIAS;
+import static com.hedera.services.ledger.properties.AccountProperty.AUTO_RENEW_ACCOUNT_ID;
 import static com.hedera.services.ledger.properties.AccountProperty.AUTO_RENEW_PERIOD;
 import static com.hedera.services.ledger.properties.AccountProperty.BALANCE;
 import static com.hedera.services.ledger.properties.AccountProperty.EXPIRY;
@@ -34,6 +35,7 @@ import static com.hedera.test.utils.IdUtils.asAccount;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -53,6 +55,7 @@ import com.hedera.services.exceptions.InsufficientFundsException;
 import com.hedera.services.exceptions.MissingEntityException;
 import com.hedera.services.ledger.accounts.HederaAccountCustomizer;
 import com.hedera.services.state.submerkle.CurrencyAdjustments;
+import com.hedera.services.state.submerkle.EntityId;
 import com.hedera.services.txns.crypto.AutoCreationLogic;
 import com.hedera.services.txns.validation.OptionValidator;
 import com.hedera.test.utils.IdUtils;
@@ -299,6 +302,20 @@ class HederaLedgerTest extends BaseHederaLedgerTestHelper {
         subject.autoRenewPeriod(genesis);
 
         verify(accountsLedger).get(genesis, AUTO_RENEW_PERIOD);
+    }
+
+    @Test
+    void delegatesToCorrectAutoRenewId() {
+        given(accountsLedger.get(genesis, AUTO_RENEW_ACCOUNT_ID)).willReturn(new EntityId(0, 0, 666));
+
+        final var ans = subject.autoRenewNum(genesis);
+
+        assertEquals(666L, ans.longValue());
+    }
+
+    @Test
+    void relaysNullAutoRenewId() {
+        assertNull(subject.autoRenewNum(genesis));
     }
 
     @Test

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/services/ledger/accounts/AccountCustomizerTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/services/ledger/accounts/AccountCustomizerTest.java
@@ -47,6 +47,7 @@ import com.hedera.services.ledger.properties.TestAccountProperty;
 import com.hedera.services.legacy.core.jproto.JKeyList;
 import com.hedera.services.state.submerkle.EntityId;
 import java.util.EnumMap;
+import java.util.Objects;
 import org.junit.jupiter.api.Test;
 
 class AccountCustomizerTest {
@@ -166,7 +167,6 @@ class AccountCustomizerTest {
         setupWithMockChangeManager();
 
         subject.proxy(null);
-        subject.autoRenewAccount(null);
 
         verifyNoInteractions(changeManager);
     }
@@ -185,6 +185,21 @@ class AccountCustomizerTest {
                                 TestAccountCustomizer.OPTION_PROPERTIES.get(AUTO_RENEW_ACCOUNT_ID)
                                         ::equals),
                         argThat(autoRenewId::equals));
+    }
+
+    @Test
+    void changesExpectedAutoRenewAccountPropertyIfNull() {
+        setupWithMockChangeManager();
+
+        subject.autoRenewAccount(null);
+
+        verify(changeManager)
+                .update(
+                        any(EnumMap.class),
+                        argThat(
+                                TestAccountCustomizer.OPTION_PROPERTIES.get(AUTO_RENEW_ACCOUNT_ID)
+                                        ::equals),
+                        argThat(Objects::isNull));
     }
 
     @Test

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/services/ledger/accounts/HederaAccountCustomizerTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/services/ledger/accounts/HederaAccountCustomizerTest.java
@@ -19,6 +19,7 @@ import static com.hedera.services.context.properties.StaticPropertiesHolder.STAT
 import static com.hedera.services.ledger.accounts.AccountCustomizer.Option;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import com.google.protobuf.ByteString;
 import com.hedera.services.ledger.properties.AccountProperty;
@@ -78,7 +79,30 @@ class HederaAccountCustomizerTest {
         assertEquals(memo, op.getMemo());
         assertEquals(STATIC_PROPERTIES.scopedAccountWith(stakedId), op.getStakedAccountId());
         assertEquals(autoRenew, op.getAutoRenewPeriod().getSeconds());
-        assertEquals(false, op.getDeclineReward());
+        assertFalse(op.getDeclineReward());
+    }
+
+    @Test
+    void customizesSyntheticContractWithoutAutoRenewAccountIfNull() {
+        final var memo = "Inherited";
+        final var stakedId = 4L;
+        final var autoRenew = 7776001L;
+        final var expiry = 1_234_567L;
+
+        final var customizer =
+                new HederaAccountCustomizer()
+                        .memo(memo)
+                        .stakedId(stakedId)
+                        .autoRenewPeriod(autoRenew)
+                        .expiry(expiry)
+                        .isSmartContract(true)
+                        .autoRenewAccount(null)
+                        .maxAutomaticAssociations(10);
+
+        final var op = ContractCreateTransactionBody.newBuilder();
+        customizer.customizeSynthetic(op);
+
+        assertFalse(op.hasAutoRenewAccountId());
     }
 
     @Test

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/services/legacy/core/jproto/HFileMetaTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/services/legacy/core/jproto/HFileMetaTest.java
@@ -18,6 +18,7 @@ package com.hedera.services.legacy.core.jproto;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.hedera.services.files.HFileMeta;
+import com.hedera.services.state.submerkle.EntityId;
 import com.hedera.services.utils.MiscUtils;
 import com.hedera.test.factories.scenarios.TxnHandlingScenario;
 import org.junit.jupiter.api.BeforeEach;
@@ -28,12 +29,13 @@ class HFileMetaTest {
     private JKey wacl = TxnHandlingScenario.COMPLEX_KEY_ACCOUNT_KT.asJKeyUnchecked().getKeyList();
     private String memo = "Remember me?";
     private boolean deleted = true;
+    private final EntityId autoRenewId = new EntityId(0, 0, 666_666L);
 
     HFileMeta subject;
 
     @BeforeEach
     void setUp() {
-        subject = new HFileMeta(deleted, wacl, expiry, memo);
+        subject = new HFileMeta(deleted, wacl, expiry, memo, autoRenewId);
     }
 
     @Test
@@ -52,6 +54,9 @@ class HFileMetaTest {
                         + ", "
                         + "deleted="
                         + deleted
+                        + ", "
+                        + "autoRenewId="
+                        + autoRenewId
                         + "}";
 
         // when:

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/services/legacy/core/jproto/HFileMetaTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/services/legacy/core/jproto/HFileMetaTest.java
@@ -30,12 +30,13 @@ class HFileMetaTest {
     private String memo = "Remember me?";
     private boolean deleted = true;
     private final EntityId autoRenewId = new EntityId(0, 0, 666_666L);
+    private final long autoRenewPeriod = 424242L;
 
     HFileMeta subject;
 
     @BeforeEach
     void setUp() {
-        subject = new HFileMeta(deleted, wacl, expiry, memo, autoRenewId);
+        subject = new HFileMeta(deleted, wacl, expiry, memo, autoRenewId, autoRenewPeriod);
     }
 
     @Test
@@ -57,6 +58,9 @@ class HFileMetaTest {
                         + ", "
                         + "autoRenewId="
                         + autoRenewId
+                        + ", "
+                        + "autoRenewPeriod="
+                        + autoRenewPeriod
                         + "}";
 
         // when:

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/services/sigs/order/SigRequirementsTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/services/sigs/order/SigRequirementsTest.java
@@ -92,6 +92,8 @@ import static com.hedera.test.factories.scenarios.CryptoAllowanceScenarios.CRYPT
 import static com.hedera.test.factories.scenarios.CryptoAllowanceScenarios.CRYPTO_DELETE_NFT_ALLOWANCE_MISSING_OWNER_SCENARIO;
 import static com.hedera.test.factories.scenarios.CryptoCreateScenarios.CRYPTO_CREATE_NO_RECEIVER_SIG_SCENARIO;
 import static com.hedera.test.factories.scenarios.CryptoCreateScenarios.CRYPTO_CREATE_RECEIVER_SIG_SCENARIO;
+import static com.hedera.test.factories.scenarios.CryptoCreateScenarios.CRYPTO_CREATE_WITH_AUTO_RENEW_AND_SIG_REQUIRED_SCENARIO;
+import static com.hedera.test.factories.scenarios.CryptoCreateScenarios.CRYPTO_CREATE_WITH_MISSING_AUTO_RENEW;
 import static com.hedera.test.factories.scenarios.CryptoDeleteScenarios.CRYPTO_DELETE_MISSING_RECEIVER_SIG_SCENARIO;
 import static com.hedera.test.factories.scenarios.CryptoDeleteScenarios.CRYPTO_DELETE_MISSING_TARGET;
 import static com.hedera.test.factories.scenarios.CryptoDeleteScenarios.CRYPTO_DELETE_NO_TARGET_RECEIVER_SIG_CUSTOM_PAYER_PAID_SCENARIO;
@@ -135,6 +137,8 @@ import static com.hedera.test.factories.scenarios.CryptoTransferScenarios.TOKEN_
 import static com.hedera.test.factories.scenarios.CryptoTransferScenarios.TOKEN_TRANSACT_WITH_OWNERSHIP_CHANGE_USING_ALIAS;
 import static com.hedera.test.factories.scenarios.CryptoTransferScenarios.TOKEN_TRANSACT_WITH_RECEIVER_SIG_REQ_AND_EXTANT_SENDERS;
 import static com.hedera.test.factories.scenarios.CryptoTransferScenarios.TOKEN_TRNASFER_ALLOWANCE_SPENDER_SCENARIO;
+import static com.hedera.test.factories.scenarios.CryptoUpdateScenarios.CRYPTO_UPDATE_DESIGNATING_AUTO_RENEW_REMOVAL_SCENARIO;
+import static com.hedera.test.factories.scenarios.CryptoUpdateScenarios.CRYPTO_UPDATE_DESIGNATING_MISSING_AUTO_RENEW_SCENARIO;
 import static com.hedera.test.factories.scenarios.CryptoUpdateScenarios.CRYPTO_UPDATE_IMMUTABLE_ACCOUNT_SCENARIO;
 import static com.hedera.test.factories.scenarios.CryptoUpdateScenarios.CRYPTO_UPDATE_MISSING_ACCOUNT_SCENARIO;
 import static com.hedera.test.factories.scenarios.CryptoUpdateScenarios.CRYPTO_UPDATE_NO_NEW_KEY_CUSTOM_PAYER_PAID_SCENARIO;
@@ -145,6 +149,7 @@ import static com.hedera.test.factories.scenarios.CryptoUpdateScenarios.CRYPTO_U
 import static com.hedera.test.factories.scenarios.CryptoUpdateScenarios.CRYPTO_UPDATE_SYS_ACCOUNT_WITH_PRIVILEGED_PAYER;
 import static com.hedera.test.factories.scenarios.CryptoUpdateScenarios.CRYPTO_UPDATE_TREASURY_ACCOUNT_WITH_TREASURY_AND_NEW_KEY;
 import static com.hedera.test.factories.scenarios.CryptoUpdateScenarios.CRYPTO_UPDATE_TREASURY_ACCOUNT_WITH_TREASURY_AND_NO_NEW_KEY;
+import static com.hedera.test.factories.scenarios.CryptoUpdateScenarios.CRYPTO_UPDATE_WITH_NEW_AUTO_RENEW_SCENARIO;
 import static com.hedera.test.factories.scenarios.CryptoUpdateScenarios.CRYPTO_UPDATE_WITH_NEW_KEY_CUSTOM_PAYER_PAID_SCENARIO;
 import static com.hedera.test.factories.scenarios.CryptoUpdateScenarios.CRYPTO_UPDATE_WITH_NEW_KEY_SCENARIO;
 import static com.hedera.test.factories.scenarios.CryptoUpdateScenarios.CRYPTO_UPDATE_WITH_NEW_KEY_SELF_PAID_SCENARIO;
@@ -154,12 +159,16 @@ import static com.hedera.test.factories.scenarios.FileAppendScenarios.MASTER_SYS
 import static com.hedera.test.factories.scenarios.FileAppendScenarios.SYSTEM_FILE_APPEND_WITH_PRIVILEGD_PAYER;
 import static com.hedera.test.factories.scenarios.FileAppendScenarios.TREASURY_SYS_FILE_APPEND_SCENARIO;
 import static com.hedera.test.factories.scenarios.FileAppendScenarios.VANILLA_FILE_APPEND_SCENARIO;
+import static com.hedera.test.factories.scenarios.FileCreateScenarios.FILE_CREATE_WITH_AUTO_RENEW_SCENARIO;
+import static com.hedera.test.factories.scenarios.FileCreateScenarios.FILE_CREATE_WITH_MISSING_AUTO_RENEW_SCENARIO;
 import static com.hedera.test.factories.scenarios.FileCreateScenarios.VANILLA_FILE_CREATE_SCENARIO;
 import static com.hedera.test.factories.scenarios.FileDeleteScenarios.IMMUTABLE_FILE_DELETE_SCENARIO;
 import static com.hedera.test.factories.scenarios.FileDeleteScenarios.MISSING_FILE_DELETE_SCENARIO;
 import static com.hedera.test.factories.scenarios.FileDeleteScenarios.VANILLA_FILE_DELETE_SCENARIO;
 import static com.hedera.test.factories.scenarios.FileUpdateScenarios.FILE_UPDATE_MISSING_SCENARIO;
 import static com.hedera.test.factories.scenarios.FileUpdateScenarios.FILE_UPDATE_NEW_WACL_SCENARIO;
+import static com.hedera.test.factories.scenarios.FileUpdateScenarios.FILE_UPDATE_WITH_AUTO_RENEW_SCENARIO;
+import static com.hedera.test.factories.scenarios.FileUpdateScenarios.FILE_UPDATE_WITH_MISSING_AUTO_RENEW_SCENARIO;
 import static com.hedera.test.factories.scenarios.FileUpdateScenarios.IMMUTABLE_FILE_UPDATE_SCENARIO;
 import static com.hedera.test.factories.scenarios.FileUpdateScenarios.MASTER_SYS_FILE_UPDATE_SCENARIO;
 import static com.hedera.test.factories.scenarios.FileUpdateScenarios.TREASURY_SYS_FILE_UPDATE_SCENARIO;
@@ -549,6 +558,21 @@ class SigRequirementsTest {
         // then:
         assertThat(summary.getOrderedKeys(), iterableWithSize(1));
         assertThat(sanityRestored(summary.getOrderedKeys()), contains(DEFAULT_ACCOUNT_KT.asKey()));
+    }
+
+    @Test
+    void getsCryptoCreateWithAutoRenewAccount() throws Throwable {
+        // given:
+        setupFor(CRYPTO_CREATE_WITH_AUTO_RENEW_AND_SIG_REQUIRED_SCENARIO);
+
+        // when:
+        final var summary = subject.keysForOtherParties(txn, summaryFactory);
+
+        // then:
+        assertThat(summary.getOrderedKeys(), iterableWithSize(2));
+        assertThat(
+                sanityRestored(summary.getOrderedKeys()),
+                contains(DEFAULT_ACCOUNT_KT.asKey(), FIRST_TOKEN_SENDER_KT.asKey()));
     }
 
     @Test
@@ -1630,6 +1654,34 @@ class SigRequirementsTest {
     }
 
     @Test
+    void getsCryptoUpdateNewAutoRenew() throws Throwable {
+        // given:
+        setupFor(CRYPTO_UPDATE_WITH_NEW_AUTO_RENEW_SCENARIO);
+
+        // when:
+        final var summary = subject.keysForOtherParties(txn, summaryFactory);
+
+        // then:
+        assertThat(summary.getOrderedKeys(), iterableWithSize(2));
+        assertThat(
+                sanityRestored(summary.getOrderedKeys()),
+                contains(MISC_ACCOUNT_KT.asKey(), FIRST_TOKEN_SENDER_KT.asKey()));
+    }
+
+    @Test
+    void getsCryptoUpdateSentinelAutoRenew() throws Throwable {
+        // given:
+        setupFor(CRYPTO_UPDATE_DESIGNATING_AUTO_RENEW_REMOVAL_SCENARIO);
+
+        // when:
+        final var summary = subject.keysForOtherParties(txn, summaryFactory);
+
+        // then:
+        assertThat(summary.getOrderedKeys(), iterableWithSize(1));
+        assertThat(sanityRestored(summary.getOrderedKeys()), contains(MISC_ACCOUNT_KT.asKey()));
+    }
+
+    @Test
     void getsCryptoUpdateVanillaNewKeyWithCustomPayer() throws Throwable {
         // given:
         setupFor(CRYPTO_UPDATE_WITH_NEW_KEY_SCENARIO);
@@ -1966,6 +2018,40 @@ class SigRequirementsTest {
     }
 
     @Test
+    void reportsCryptoUpdateMissingAutoRenewAccount() throws Throwable {
+        setupFor(CRYPTO_UPDATE_DESIGNATING_MISSING_AUTO_RENEW_SCENARIO);
+        // and:
+        mockSummaryFactory();
+        // and:
+        SigningOrderResult<ResponseCodeEnum> result = mock(SigningOrderResult.class);
+
+        given(mockSummaryFactory.forInvalidAutoRenewAccount()).willReturn(result);
+
+        // when:
+        subject.keysForOtherParties(txn, mockSummaryFactory);
+
+        // then:
+        verify(mockSummaryFactory).forInvalidAutoRenewAccount();
+    }
+
+    @Test
+    void reportsCryptoCreateMissingAutoRenewAccount() throws Throwable {
+        setupFor(CRYPTO_CREATE_WITH_MISSING_AUTO_RENEW);
+        // and:
+        mockSummaryFactory();
+        // and:
+        SigningOrderResult<ResponseCodeEnum> result = mock(SigningOrderResult.class);
+
+        given(mockSummaryFactory.forInvalidAutoRenewAccount()).willReturn(result);
+
+        // when:
+        subject.keysForOtherParties(txn, mockSummaryFactory);
+
+        // then:
+        verify(mockSummaryFactory).forInvalidAutoRenewAccount();
+    }
+
+    @Test
     void reportsCryptoUpdateMissingAccountWithCustomPayer() throws Throwable {
         setupFor(CRYPTO_UPDATE_MISSING_ACCOUNT_SCENARIO);
         // and:
@@ -2266,6 +2352,38 @@ class SigRequirementsTest {
     }
 
     @Test
+    void getsFileCreateWithAutoRenew() throws Throwable {
+        // given:
+        setupFor(FILE_CREATE_WITH_AUTO_RENEW_SCENARIO);
+
+        // when:
+        final var summary = subject.keysForOtherParties(txn, summaryFactory);
+
+        // then:
+        assertThat(summary.getOrderedKeys(), iterableWithSize(2));
+        assertThat(
+                sanityRestored(summary.getOrderedKeys()),
+                contains(DEFAULT_WACL_KT.asKey(), FIRST_TOKEN_SENDER_KT.asKey()));
+    }
+
+    @Test
+    void getsFileCreateWithMissingAutoRenew() throws Throwable {
+        // given:
+        setupFor(FILE_CREATE_WITH_MISSING_AUTO_RENEW_SCENARIO);
+        // and:
+        mockSummaryFactory();
+        // and:
+        SigningOrderResult<ResponseCodeEnum> result = mock(SigningOrderResult.class);
+
+        given(mockSummaryFactory.forInvalidAutoRenewAccount()).willReturn(result);
+
+        // when:
+        subject.keysForOtherParties(txn, mockSummaryFactory);
+
+        verify(mockSummaryFactory).forInvalidAutoRenewAccount();
+    }
+
+    @Test
     void getsFileAppend() throws Throwable {
         // given:
         setupFor(VANILLA_FILE_APPEND_SCENARIO);
@@ -2563,6 +2681,21 @@ class SigRequirementsTest {
         // then:
         assertThat(summary.getOrderedKeys(), iterableWithSize(1));
         assertThat(sanityRestored(summary.getOrderedKeys()), contains(MISC_FILE_WACL_KT.asKey()));
+    }
+
+    @Test
+    void getsFileUpdateWithAutoRenew() throws Throwable {
+        // given:
+        setupFor(FILE_UPDATE_WITH_AUTO_RENEW_SCENARIO);
+
+        // when:
+        final var summary = subject.keysForOtherParties(txn, summaryFactory);
+
+        // then:
+        assertThat(summary.getOrderedKeys(), iterableWithSize(2));
+        assertThat(
+                sanityRestored(summary.getOrderedKeys()),
+                contains(MISC_FILE_WACL_KT.asKey(), FIRST_TOKEN_SENDER_KT.asKey()));
     }
 
     @Test
@@ -3296,6 +3429,24 @@ class SigRequirementsTest {
     void invalidAutoRenewAccountOnConsensusCreateTopicThrows() throws Throwable {
         // given:
         setupFor(CONSENSUS_CREATE_TOPIC_MISSING_AUTORENEW_ACCOUNT_SCENARIO);
+        // and:
+        mockSummaryFactory();
+        // and:
+        SigningOrderResult<ResponseCodeEnum> result = mock(SigningOrderResult.class);
+
+        given(mockSummaryFactory.forInvalidAutoRenewAccount()).willReturn(result);
+
+        // when:
+        subject.keysForOtherParties(txn, mockSummaryFactory);
+
+        // then:
+        verify(mockSummaryFactory).forInvalidAutoRenewAccount();
+    }
+
+    @Test
+    void invalidAutoRenewAccountOnFileUpdate() throws Throwable {
+        // given:
+        setupFor(FILE_UPDATE_WITH_MISSING_AUTO_RENEW_SCENARIO);
         // and:
         mockSummaryFactory();
         // and:

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/services/sigs/order/SigRequirementsTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/services/sigs/order/SigRequirementsTest.java
@@ -133,6 +133,7 @@ import static com.hedera.test.factories.scenarios.CryptoTransferScenarios.TOKEN_
 import static com.hedera.test.factories.scenarios.CryptoTransferScenarios.TOKEN_TRANSACT_WITH_OWNERSHIP_CHANGE_NO_RECEIVER_SIG_REQ_AND_MISSING_TOKEN;
 import static com.hedera.test.factories.scenarios.CryptoTransferScenarios.TOKEN_TRANSACT_WITH_OWNERSHIP_CHANGE_NO_RECEIVER_SIG_REQ_BUT_ROYALTY_FEE_WITH_FALLBACK_TRIGGERED;
 import static com.hedera.test.factories.scenarios.CryptoTransferScenarios.TOKEN_TRANSACT_WITH_OWNERSHIP_CHANGE_NO_SIG_REQ_WITH_FALLBACK_TRIGGERED_BUT_SENDER_IS_TREASURY;
+import static com.hedera.test.factories.scenarios.CryptoTransferScenarios.TOKEN_TRANSACT_WITH_OWNERSHIP_CHANGE_NO_SIG_REQ_WITH_FALLBACK_WHEN_RECEIVER_IS_TREASURY;
 import static com.hedera.test.factories.scenarios.CryptoTransferScenarios.TOKEN_TRANSACT_WITH_OWNERSHIP_CHANGE_RECEIVER_SIG_REQ;
 import static com.hedera.test.factories.scenarios.CryptoTransferScenarios.TOKEN_TRANSACT_WITH_OWNERSHIP_CHANGE_USING_ALIAS;
 import static com.hedera.test.factories.scenarios.CryptoTransferScenarios.TOKEN_TRANSACT_WITH_RECEIVER_SIG_REQ_AND_EXTANT_SENDERS;
@@ -1036,6 +1037,21 @@ class SigRequirementsTest {
         // then:
         assertThat(summary.getOrderedKeys(), iterableWithSize(1));
         assertThat(sanityRestored(summary.getOrderedKeys()), contains(MISC_ACCOUNT_KT.asKey()));
+    }
+
+    @Test
+    void getsNftOwnerChangeWithNoSigReqAndFallbackFeeTriggeredButReceiverIsTreasury()
+            throws Throwable {
+        // given:
+        setupFor(
+                TOKEN_TRANSACT_WITH_OWNERSHIP_CHANGE_NO_SIG_REQ_WITH_FALLBACK_WHEN_RECEIVER_IS_TREASURY);
+
+        // when:
+        final var summary = subject.keysForOtherParties(txn, summaryFactory);
+
+        // then:
+        assertThat(summary.getOrderedKeys(), iterableWithSize(1));
+        assertThat(sanityRestored(summary.getOrderedKeys()), contains(NO_RECEIVER_SIG_KT.asKey()));
     }
 
     @Test

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/services/sigs/order/SigRequirementsTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/services/sigs/order/SigRequirementsTest.java
@@ -161,6 +161,7 @@ import static com.hedera.test.factories.scenarios.FileAppendScenarios.TREASURY_S
 import static com.hedera.test.factories.scenarios.FileAppendScenarios.VANILLA_FILE_APPEND_SCENARIO;
 import static com.hedera.test.factories.scenarios.FileCreateScenarios.FILE_CREATE_WITH_AUTO_RENEW_SCENARIO;
 import static com.hedera.test.factories.scenarios.FileCreateScenarios.FILE_CREATE_WITH_MISSING_AUTO_RENEW_SCENARIO;
+import static com.hedera.test.factories.scenarios.FileCreateScenarios.IMMUTABLE_FILE_CREATE_SCENARIO;
 import static com.hedera.test.factories.scenarios.FileCreateScenarios.VANILLA_FILE_CREATE_SCENARIO;
 import static com.hedera.test.factories.scenarios.FileDeleteScenarios.IMMUTABLE_FILE_DELETE_SCENARIO;
 import static com.hedera.test.factories.scenarios.FileDeleteScenarios.MISSING_FILE_DELETE_SCENARIO;
@@ -545,6 +546,17 @@ class SigRequirementsTest {
         assertThat(
                 sanityRestored(summary.getOrderedKeys()),
                 contains(CUSTOM_PAYER_ACCOUNT_KT.asKey()));
+    }
+
+    @Test
+    void getsCryptoCreateNoReceiverSigReqOrAutoRenew() throws Throwable {
+        setupFor(CRYPTO_CREATE_NO_RECEIVER_SIG_SCENARIO);
+        final var linkedRefs = new LinkedRefs();
+
+        final var summary =
+                subject.keysForOtherParties(txn, summaryFactory, linkedRefs, CUSTOM_PAYER_ACCOUNT);
+
+        assertThat(summary.getOrderedKeys(), iterableWithSize(0));
     }
 
     @Test
@@ -2349,6 +2361,18 @@ class SigRequirementsTest {
         // then:
         assertThat(summary.getOrderedKeys(), iterableWithSize(1));
         assertThat(sanityRestored(summary.getOrderedKeys()), contains(DEFAULT_WACL_KT.asKey()));
+    }
+
+    @Test
+    void getsImmutableFileCreate() throws Throwable {
+        // given:
+        setupFor(IMMUTABLE_FILE_CREATE_SCENARIO);
+
+        // when:
+        final var summary = subject.keysForOtherParties(txn, summaryFactory);
+
+        // then:
+        assertThat(summary.getOrderedKeys(), iterableWithSize(0));
     }
 
     @Test

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/services/txns/crypto/CryptoCreateTransitionLogicTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/services/txns/crypto/CryptoCreateTransitionLogicTest.java
@@ -25,7 +25,6 @@ import static com.hedera.services.legacy.core.jproto.JEd25519Key.ED25519_BYTE_LE
 import static com.hedera.services.txns.crypto.CryptoCreateTransitionLogic.MAX_CHARGEABLE_AUTO_ASSOCIATIONS;
 import static com.hedera.services.utils.EntityNum.MISSING_NUM;
 import static com.hedera.services.utils.MiscUtils.asKeyUnchecked;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.AUTORENEW_DURATION_NOT_IN_RANGE;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.BAD_ENCODING;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.FAIL_INVALID;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INSUFFICIENT_PAYER_BALANCE;
@@ -436,11 +435,11 @@ class CryptoCreateTransitionLogicTest {
                 unhex("03af80b11d25145da28c583359beb47b21796b2fe1a23c1511e443e7a64dfdb27d");
         final var invalidEcdsaKey =
                 Key.newBuilder().setECDSASecp256K1(ByteString.copyFrom(invalidEcdsaBytes)).build();
-        final var opBuilder = CryptoCreateTransactionBody.newBuilder()
-                .setAutoRenewPeriod(Duration.newBuilder())
-                .setKey(invalidEcdsaKey);
-        cryptoCreateTxn = TransactionBody.newBuilder()
-                .setCryptoCreateAccount(opBuilder).build();
+        final var opBuilder =
+                CryptoCreateTransactionBody.newBuilder()
+                        .setAutoRenewPeriod(Duration.newBuilder())
+                        .setKey(invalidEcdsaKey);
+        cryptoCreateTxn = TransactionBody.newBuilder().setCryptoCreateAccount(opBuilder).build();
         given(usageLimits.areCreatableAccounts(1)).willReturn(true);
         given(accessor.getTxn()).willReturn(cryptoCreateTxn);
         given(txnCtx.activePayer()).willReturn(ourAccount());
@@ -788,9 +787,10 @@ class CryptoCreateTransitionLogicTest {
     void followsHappyPathECKey() throws DecoderException {
         final var captor = ArgumentCaptor.forClass(HederaAccountCustomizer.class);
 
-        final var opBuilder = CryptoCreateTransactionBody.newBuilder()
-                .setAutoRenewPeriod(Duration.newBuilder())
-                .setKey(ECDSA_KEY);
+        final var opBuilder =
+                CryptoCreateTransactionBody.newBuilder()
+                        .setAutoRenewPeriod(Duration.newBuilder())
+                        .setKey(ECDSA_KEY);
         cryptoCreateTxn = TransactionBody.newBuilder().setCryptoCreateAccount(opBuilder).build();
         given(accessor.getTxn()).willReturn(cryptoCreateTxn);
         given(txnCtx.activePayer()).willReturn(ourAccount());
@@ -832,9 +832,10 @@ class CryptoCreateTransitionLogicTest {
     void followsHappyPathECKeyAndCreateWithAliasAndLazyCreateDisabled() throws DecoderException {
         final var captor = ArgumentCaptor.forClass(HederaAccountCustomizer.class);
 
-        final var opBuilder = CryptoCreateTransactionBody.newBuilder()
-                .setAutoRenewPeriod(Duration.newBuilder())
-                .setKey(ECDSA_KEY);
+        final var opBuilder =
+                CryptoCreateTransactionBody.newBuilder()
+                        .setAutoRenewPeriod(Duration.newBuilder())
+                        .setKey(ECDSA_KEY);
         cryptoCreateTxn = TransactionBody.newBuilder().setCryptoCreateAccount(opBuilder).build();
         given(accessor.getTxn()).willReturn(cryptoCreateTxn);
         given(txnCtx.activePayer()).willReturn(ourAccount());
@@ -875,11 +876,11 @@ class CryptoCreateTransitionLogicTest {
     void followsHappyPathEDKey() throws DecoderException {
         final var captor = ArgumentCaptor.forClass(HederaAccountCustomizer.class);
 
-        final var opBuilder = CryptoCreateTransactionBody.newBuilder()
-                .setAutoRenewPeriod(Duration.newBuilder())
-                .setKey(aPrimitiveEDKey);
-        cryptoCreateTxn = TransactionBody.newBuilder()
-                .setCryptoCreateAccount(opBuilder).build();
+        final var opBuilder =
+                CryptoCreateTransactionBody.newBuilder()
+                        .setAutoRenewPeriod(Duration.newBuilder())
+                        .setKey(aPrimitiveEDKey);
+        cryptoCreateTxn = TransactionBody.newBuilder().setCryptoCreateAccount(opBuilder).build();
         given(accessor.getTxn()).willReturn(cryptoCreateTxn);
         given(txnCtx.activePayer()).willReturn(ourAccount());
         given(txnCtx.accessor()).willReturn(accessor);

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/services/txns/crypto/CryptoUpdateTransitionLogicTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/services/txns/crypto/CryptoUpdateTransitionLogicTest.java
@@ -152,7 +152,7 @@ class CryptoUpdateTransitionLogicTest {
         verify(txnCtx).setStatus(SUCCESS);
         verify(sigImpactHistorian).markEntityChanged(TARGET.getAccountNum());
         final var changes = captor.getValue().getChanges();
-        assertEquals(0, changes.size());
+        assertEquals(3, changes.size());
     }
 
     @Test
@@ -167,7 +167,7 @@ class CryptoUpdateTransitionLogicTest {
         verify(txnCtx).setStatus(SUCCESS);
         verify(sigImpactHistorian).markEntityChanged(TARGET.getAccountNum());
         final var changes = captor.getValue().getChanges();
-        assertEquals(1, changes.size());
+        assertEquals(4, changes.size());
         assertEquals(-11L, changes.get(AccountProperty.STAKED_ID));
         assertNull(changes.get(AccountProperty.DECLINE_REWARD));
     }
@@ -298,7 +298,7 @@ class CryptoUpdateTransitionLogicTest {
         verify(txnCtx).setStatus(SUCCESS);
         verify(sigImpactHistorian).markEntityChanged(TARGET.getAccountNum());
         final var changes = captor.getValue().getChanges();
-        assertEquals(1, changes.size());
+        assertEquals(4, changes.size());
         assertEquals(true, changes.get(AccountProperty.DECLINE_REWARD));
     }
 
@@ -312,7 +312,7 @@ class CryptoUpdateTransitionLogicTest {
         verify(ledger).customize(argThat(TARGET::equals), captor.capture());
         verify(txnCtx).setStatus(SUCCESS);
         final var changes = captor.getValue().getChanges();
-        assertEquals(1, changes.size());
+        assertEquals(4, changes.size());
         assertEquals(true, changes.get(AccountProperty.IS_RECEIVER_SIG_REQUIRED));
     }
 
@@ -327,7 +327,7 @@ class CryptoUpdateTransitionLogicTest {
         verify(ledger).customize(argThat(TARGET::equals), captor.capture());
         verify(txnCtx).setStatus(SUCCESS);
         final var changes = captor.getValue().getChanges();
-        assertEquals(1, changes.size());
+        assertEquals(4, changes.size());
         assertEquals(true, changes.get(AccountProperty.IS_RECEIVER_SIG_REQUIRED));
     }
 
@@ -342,7 +342,7 @@ class CryptoUpdateTransitionLogicTest {
         verify(ledger).customize(argThat(TARGET::equals), captor.capture());
         verify(txnCtx).setStatus(SUCCESS);
         final var changes = captor.getValue().getChanges();
-        assertEquals(1, changes.size());
+        assertEquals(3, changes.size());
         assertEquals(NEW_EXPIRY, (long) changes.get(AccountProperty.EXPIRY));
     }
 
@@ -361,7 +361,7 @@ class CryptoUpdateTransitionLogicTest {
         verify(ledger).customize(argThat(TARGET::equals), captor.capture());
         verify(txnCtx).setStatus(SUCCESS);
         final var changes = captor.getValue().getChanges();
-        assertEquals(1, changes.size());
+        assertEquals(4, changes.size());
         assertEquals(
                 NEW_MAX_AUTOMATIC_ASSOCIATIONS,
                 (int) changes.get(AccountProperty.MAX_AUTOMATIC_ASSOCIATIONS));
@@ -438,7 +438,7 @@ class CryptoUpdateTransitionLogicTest {
 
         verify(ledger).customize(argThat(TARGET::equals), captor.capture());
         final var changes = captor.getValue().getChanges();
-        assertEquals(1, changes.size());
+        assertEquals(4, changes.size());
         assertEquals(MEMO, changes.get(AccountProperty.MEMO));
     }
 
@@ -452,7 +452,7 @@ class CryptoUpdateTransitionLogicTest {
 
         verify(ledger).customize(argThat(TARGET::equals), captor.capture());
         final var changes = captor.getValue().getChanges();
-        assertEquals(1, changes.size());
+        assertEquals(3, changes.size());
         assertEquals(AUTO_RENEW_PERIOD, changes.get(AccountProperty.AUTO_RENEW_PERIOD));
     }
 
@@ -465,7 +465,7 @@ class CryptoUpdateTransitionLogicTest {
 
         verify(ledger).customize(argThat(TARGET::equals), captor.capture());
         final var changes = captor.getValue().getChanges();
-        assertEquals(1, changes.size());
+        assertEquals(4, changes.size());
         assertEquals(KEY, JKey.mapJKey((JKey) changes.get(AccountProperty.KEY)));
     }
 

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/services/txns/crypto/CryptoUpdateTransitionLogicTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/services/txns/crypto/CryptoUpdateTransitionLogicTest.java
@@ -22,7 +22,6 @@ import static com.hedera.services.ledger.accounts.AccountCustomizer.Option.MAX_A
 import static com.hedera.services.ledger.accounts.AccountCustomizer.Option.STAKED_ID;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.ACCOUNT_DELETED;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.ACCOUNT_EXPIRED_AND_PENDING_REMOVAL;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.AUTORENEW_DURATION_NOT_IN_RANGE;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.BAD_ENCODING;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.EXISTING_AUTOMATIC_ASSOCIATIONS_EXCEED_GIVEN_LIMIT;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.EXPIRATION_REDUCTION_NOT_ALLOWED;

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/services/txns/file/FileCreateTransitionLogicTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/services/txns/file/FileCreateTransitionLogicTest.java
@@ -19,7 +19,6 @@ import static com.hedera.services.txns.file.FileCreateTransitionLogicTest.ValidP
 import static com.hedera.services.txns.file.FileCreateTransitionLogicTest.ValidProperty.CONTENTS;
 import static com.hedera.services.txns.file.FileCreateTransitionLogicTest.ValidProperty.EXPIRY;
 import static com.hedera.services.txns.file.FileCreateTransitionLogicTest.ValidProperty.KEY;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.AUTORENEW_DURATION_NOT_IN_RANGE;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.FAIL_INVALID;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_EXPIRATION_TIME;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_FILE_WACL;
@@ -37,7 +36,6 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.inOrder;
 import static org.mockito.BDDMockito.mock;
 import static org.mockito.BDDMockito.verify;
-import static org.mockito.BDDMockito.willAnswer;
 import static org.mockito.BDDMockito.willThrow;
 
 import com.google.protobuf.ByteString;
@@ -70,7 +68,6 @@ import java.util.EnumSet;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.InOrder;
-
 
 class FileCreateTransitionLogicTest {
     private UsageLimits usageLimits;

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/services/txns/file/FileUpdateTransitionLogicTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/services/txns/file/FileUpdateTransitionLogicTest.java
@@ -160,7 +160,13 @@ class FileUpdateTransitionLogicTest {
 
         subject =
                 new FileUpdateTransitionLogic(
-                        hfs, number, validator, expiryValidator, sigImpactHistorian, txnCtx, () -> networkCtx);
+                        hfs,
+                        number,
+                        validator,
+                        expiryValidator,
+                        sigImpactHistorian,
+                        txnCtx,
+                        () -> networkCtx);
     }
 
     @Test

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/services/txns/validation/ContextOptionValidatorTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/services/txns/validation/ContextOptionValidatorTest.java
@@ -49,6 +49,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.mock;
 import static org.mockito.BDDMockito.verify;
+import static org.mockito.Mockito.doCallRealMethod;
 
 import com.google.protobuf.ByteString;
 import com.hedera.services.context.NodeInfo;
@@ -65,6 +66,7 @@ import com.hedera.services.state.merkle.MerkleTopic;
 import com.hedera.services.state.migration.AccountStorageAdapter;
 import com.hedera.services.state.migration.HederaAccount;
 import com.hedera.services.utils.EntityNum;
+import com.hedera.services.utils.MiscUtils;
 import com.hedera.services.utils.accessors.SignedTxnAccessor;
 import com.hedera.test.factories.accounts.MerkleAccountFactory;
 import com.hedera.test.factories.scenarios.TxnHandlingScenario;
@@ -172,6 +174,19 @@ class ContextOptionValidatorTest {
         view = mock(StateView.class);
 
         subject = new ContextOptionValidator(nodeInfo, properties, txnCtx, dynamicProperties);
+    }
+
+    @Test
+    void defaultMethodsDelegate() {
+        final var mockSubject = mock(OptionValidator.class);
+        doCallRealMethod().when(mockSubject).isValidExpiry(1L);
+        doCallRealMethod().when(mockSubject).isValidAutoRenewPeriod(2L);
+
+        mockSubject.isValidExpiry(1L);
+        mockSubject.isValidAutoRenewPeriod(2L);
+
+        verify(mockSubject).isValidExpiry(MiscUtils.asSecondsTimestamp(1L));
+        verify(mockSubject).isValidAutoRenewPeriod(Duration.newBuilder().setSeconds(2L).build());
     }
 
     private FileGetInfoResponse.FileInfo asMinimalInfo(HFileMeta meta) throws Exception {

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/services/txns/validation/ExpiryMetaTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/services/txns/validation/ExpiryMetaTest.java
@@ -1,4 +1,22 @@
+/*
+ * Copyright (C) 2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hedera.services.txns.validation;
+
+import static com.hedera.services.txns.validation.ExpiryMeta.UNUSED_FIELD_SENTINEL;
+import static org.junit.jupiter.api.Assertions.*;
 
 import com.hedera.services.files.HFileMeta;
 import com.hedera.services.legacy.core.jproto.JEd25519Key;
@@ -8,9 +26,6 @@ import com.hedera.services.utils.MiscUtils;
 import com.hederahashgraph.api.proto.java.Duration;
 import com.hederahashgraph.api.proto.java.FileCreateTransactionBody;
 import org.junit.jupiter.api.Test;
-
-import static com.hedera.services.txns.validation.ExpiryMeta.UNUSED_FIELD_SENTINEL;
-import static org.junit.jupiter.api.Assertions.*;
 
 class ExpiryMetaTest {
     @Test
@@ -61,9 +76,10 @@ class ExpiryMetaTest {
 
     @Test
     void setsExpiryIfPresentOnFileCreate() {
-        final var op = FileCreateTransactionBody.newBuilder()
-                .setExpirationTime(MiscUtils.asSecondsTimestamp(aTime))
-                .build();
+        final var op =
+                FileCreateTransactionBody.newBuilder()
+                        .setExpirationTime(MiscUtils.asSecondsTimestamp(aTime))
+                        .build();
 
         final var expected = ExpiryMeta.withExplicitExpiry(aTime);
         final var actual = ExpiryMeta.fromFileCreateOp(op);
@@ -73,9 +89,10 @@ class ExpiryMetaTest {
 
     @Test
     void setsAutoRenewPeriodIfPresent() {
-        final var op = FileCreateTransactionBody.newBuilder()
-                .setAutoRenewPeriod(Duration.newBuilder().setSeconds(aPeriod).build())
-                .build();
+        final var op =
+                FileCreateTransactionBody.newBuilder()
+                        .setAutoRenewPeriod(Duration.newBuilder().setSeconds(aPeriod).build())
+                        .build();
 
         final var expected = new ExpiryMeta(UNUSED_FIELD_SENTINEL, aPeriod, null);
         final var actual = ExpiryMeta.fromFileCreateOp(op);
@@ -85,11 +102,13 @@ class ExpiryMetaTest {
 
     @Test
     void setsAutoRenewNumIfPresent() {
-        final var op = FileCreateTransactionBody.newBuilder()
-                .setAutoRenewAccount(anAutoRenewNum.toGrpcAccountId())
-                .build();
+        final var op =
+                FileCreateTransactionBody.newBuilder()
+                        .setAutoRenewAccount(anAutoRenewNum.toGrpcAccountId())
+                        .build();
 
-        final var expected = new ExpiryMeta(UNUSED_FIELD_SENTINEL, UNUSED_FIELD_SENTINEL, anAutoRenewNum);
+        final var expected =
+                new ExpiryMeta(UNUSED_FIELD_SENTINEL, UNUSED_FIELD_SENTINEL, anAutoRenewNum);
         final var actual = ExpiryMeta.fromFileCreateOp(op);
 
         assertEquals(expected, actual);
@@ -100,5 +119,6 @@ class ExpiryMetaTest {
     private static final long aPeriod = 666_666L;
     private static final EntityNum anAutoRenewNum = EntityNum.fromLong(888);
 
-    private static final JEd25519Key someKey = new JEd25519Key(";;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;".getBytes());
+    private static final JEd25519Key someKey =
+            new JEd25519Key(";;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;".getBytes());
 }

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/services/txns/validation/ExpiryMetaTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/services/txns/validation/ExpiryMetaTest.java
@@ -23,6 +23,8 @@ import com.hedera.services.legacy.core.jproto.JEd25519Key;
 import com.hedera.services.state.submerkle.EntityId;
 import com.hedera.services.utils.EntityNum;
 import com.hedera.services.utils.MiscUtils;
+import com.hederahashgraph.api.proto.java.CryptoCreateTransactionBody;
+import com.hederahashgraph.api.proto.java.CryptoUpdateTransactionBody;
 import com.hederahashgraph.api.proto.java.Duration;
 import com.hederahashgraph.api.proto.java.FileCreateTransactionBody;
 import org.junit.jupiter.api.Test;
@@ -101,6 +103,34 @@ class ExpiryMetaTest {
     }
 
     @Test
+    void getsAutoRenewAccountFromCryptoCreate() {
+        final var op =
+                CryptoCreateTransactionBody.newBuilder()
+                        .setAutoRenewAccount(anAutoRenewNum.toGrpcAccountId())
+                        .build();
+
+        final var expected =
+                new ExpiryMeta(UNUSED_FIELD_SENTINEL, UNUSED_FIELD_SENTINEL, anAutoRenewNum);
+        final var actual = ExpiryMeta.fromCryptoCreateOp(op);
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    void getsAutoRenewAccountFromCryptoUpdate() {
+        final var op =
+                CryptoUpdateTransactionBody.newBuilder()
+                        .setAutoRenewAccount(anAutoRenewNum.toGrpcAccountId())
+                        .build();
+
+        final var expected =
+                new ExpiryMeta(UNUSED_FIELD_SENTINEL, UNUSED_FIELD_SENTINEL, anAutoRenewNum);
+        final var actual = ExpiryMeta.fromCryptoUpdateOp(op);
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
     void setsAutoRenewNumIfPresent() {
         final var op =
                 FileCreateTransactionBody.newBuilder()
@@ -112,6 +142,12 @@ class ExpiryMetaTest {
         final var actual = ExpiryMeta.fromFileCreateOp(op);
 
         assertEquals(expected, actual);
+    }
+
+    @Test
+    void readableAutoRenewPeriodIsZeroIfUnset() {
+        final var noAutoRenew = ExpiryMeta.withExplicitExpiry(aTime);
+        assertEquals(0, noAutoRenew.usableAutoRenewPeriod());
     }
 
     private static final long aTime = 666_666_666L;

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/services/txns/validation/ExpiryMetaTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/services/txns/validation/ExpiryMetaTest.java
@@ -1,0 +1,104 @@
+package com.hedera.services.txns.validation;
+
+import com.hedera.services.files.HFileMeta;
+import com.hedera.services.legacy.core.jproto.JEd25519Key;
+import com.hedera.services.state.submerkle.EntityId;
+import com.hedera.services.utils.EntityNum;
+import com.hedera.services.utils.MiscUtils;
+import com.hederahashgraph.api.proto.java.Duration;
+import com.hederahashgraph.api.proto.java.FileCreateTransactionBody;
+import org.junit.jupiter.api.Test;
+
+import static com.hedera.services.txns.validation.ExpiryMeta.UNUSED_FIELD_SENTINEL;
+import static org.junit.jupiter.api.Assertions.*;
+
+class ExpiryMetaTest {
+    @Test
+    void refusesToUpdateFileMetaIfUnsetPeriod() {
+        final var subject = ExpiryMeta.withExplicitExpiry(bTime);
+        final var target = new HFileMeta(false, someKey, aTime);
+        assertThrows(IllegalStateException.class, () -> subject.updateFileMeta(target));
+    }
+
+    @Test
+    void refusesToUpdateFileMetaIfUnsetExpiry() {
+        final var subject = new ExpiryMeta(UNUSED_FIELD_SENTINEL, aPeriod, null);
+        final var target = new HFileMeta(false, someKey, aTime);
+        assertThrows(IllegalStateException.class, () -> subject.updateFileMeta(target));
+    }
+
+    @Test
+    void nullsOutAutoRenewIfNull() {
+        final var subject = new ExpiryMeta(bTime, 0, null);
+        final var target = new HFileMeta(false, someKey, aTime);
+        subject.updateFileMeta(target);
+        assertEquals(bTime, target.getExpiry());
+        assertEquals(0, target.getAutoRenewPeriod());
+        assertNull(target.getAutoRenewId());
+    }
+
+    @Test
+    void nullsOutAutoRenewIfMissingNum() {
+        final var subject = new ExpiryMeta(bTime, 0, EntityNum.MISSING_NUM);
+        final var target = new HFileMeta(false, someKey, aTime);
+        target.setAutoRenewId(new EntityId(0, 0, 666));
+        subject.updateFileMeta(target);
+        assertEquals(bTime, target.getExpiry());
+        assertEquals(0, target.getAutoRenewPeriod());
+        assertNull(target.getAutoRenewId());
+    }
+
+    @Test
+    void setsAutoRenewIfNotMissingNum() {
+        final var newAutoRenewId = new EntityId(0, 0, 666);
+        final var subject = new ExpiryMeta(bTime, 0, newAutoRenewId.asNum());
+        final var target = new HFileMeta(false, someKey, aTime);
+        subject.updateFileMeta(target);
+        assertEquals(bTime, target.getExpiry());
+        assertEquals(0, target.getAutoRenewPeriod());
+        assertEquals(newAutoRenewId, target.getAutoRenewId());
+    }
+
+    @Test
+    void setsExpiryIfPresentOnFileCreate() {
+        final var op = FileCreateTransactionBody.newBuilder()
+                .setExpirationTime(MiscUtils.asSecondsTimestamp(aTime))
+                .build();
+
+        final var expected = ExpiryMeta.withExplicitExpiry(aTime);
+        final var actual = ExpiryMeta.fromFileCreateOp(op);
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    void setsAutoRenewPeriodIfPresent() {
+        final var op = FileCreateTransactionBody.newBuilder()
+                .setAutoRenewPeriod(Duration.newBuilder().setSeconds(aPeriod).build())
+                .build();
+
+        final var expected = new ExpiryMeta(UNUSED_FIELD_SENTINEL, aPeriod, null);
+        final var actual = ExpiryMeta.fromFileCreateOp(op);
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    void setsAutoRenewNumIfPresent() {
+        final var op = FileCreateTransactionBody.newBuilder()
+                .setAutoRenewAccount(anAutoRenewNum.toGrpcAccountId())
+                .build();
+
+        final var expected = new ExpiryMeta(UNUSED_FIELD_SENTINEL, UNUSED_FIELD_SENTINEL, anAutoRenewNum);
+        final var actual = ExpiryMeta.fromFileCreateOp(op);
+
+        assertEquals(expected, actual);
+    }
+
+    private static final long aTime = 666_666_666L;
+    private static final long bTime = 777_777_777L;
+    private static final long aPeriod = 666_666L;
+    private static final EntityNum anAutoRenewNum = EntityNum.fromLong(888);
+
+    private static final JEd25519Key someKey = new JEd25519Key(";;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;".getBytes());
+}

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/services/txns/validation/ExpiryValidatorTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/services/txns/validation/ExpiryValidatorTest.java
@@ -1,0 +1,177 @@
+package com.hedera.services.txns.validation;
+
+import com.hedera.services.utils.EntityNum;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static com.hedera.services.txns.validation.ExpiryMeta.UNUSED_FIELD_SENTINEL;
+import static com.hedera.services.txns.validation.SummarizedExpiryMeta.EXPIRY_REDUCTION_SUMMARY;
+import static com.hedera.services.txns.validation.SummarizedExpiryMeta.INVALID_EXPIRY_SUMMARY;
+import static com.hedera.services.txns.validation.SummarizedExpiryMeta.INVALID_PERIOD_SUMMARY;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class ExpiryValidatorTest {
+    @Mock
+    private OptionValidator validator;
+
+    private ExpiryValidator subject;
+
+    @BeforeEach
+    void setUp() {
+        subject = new ExpiryValidator(validator);
+    }
+
+    @Test
+    void onCreationRequiresEitherExplicitValueOrFullAutoRenewMetaIfNotSelfFunding() {
+        assertSame(INVALID_EXPIRY_SUMMARY, subject.summarizeCreationAttempt(
+                now,
+                false,
+                new ExpiryMeta(UNUSED_FIELD_SENTINEL, UNUSED_FIELD_SENTINEL, anAutoRenewNum)));
+        assertSame(INVALID_EXPIRY_SUMMARY, subject.summarizeCreationAttempt(
+                now,
+                false,
+                new ExpiryMeta(UNUSED_FIELD_SENTINEL, aPeriod, null)));
+    }
+
+    @Test
+    void onCreationRequiresValidExpiryIfExplicit() {
+        given(validator.isValidExpiry(aTime)).willReturn(false);
+        assertSame(INVALID_EXPIRY_SUMMARY, subject.summarizeCreationAttempt(
+                now,
+                false,
+                new ExpiryMeta(aTime, UNUSED_FIELD_SENTINEL, anAutoRenewNum)));
+    }
+
+    @Test
+    void onCreationUsesAutoRenewPeriodEvenWithoutFullSpecIfSelfFunding() {
+        given(validator.isValidExpiry(now + aPeriod)).willReturn(true);
+        given(validator.isValidAutoRenewPeriod(aPeriod)).willReturn(true);
+        final var actual = subject.summarizeCreationAttempt(
+                        now,
+                        true,
+                        new ExpiryMeta(UNUSED_FIELD_SENTINEL, aPeriod, null));
+        assertTrue(actual.isValid());
+    }
+
+    @Test
+    void onCreationRequiresValidExpiryIfImplicit() {
+        given(validator.isValidExpiry(now + aPeriod)).willReturn(false);
+        assertSame(INVALID_EXPIRY_SUMMARY, subject.summarizeCreationAttempt(
+                now,
+                false,
+                new ExpiryMeta(UNUSED_FIELD_SENTINEL, aPeriod, anAutoRenewNum)));
+    }
+
+    @Test
+    void validatesAutoRenewPeriodIfSet() {
+        given(validator.isValidExpiry(aTime)).willReturn(true);
+        assertSame(INVALID_PERIOD_SUMMARY, subject.summarizeCreationAttempt(
+                now, false, new ExpiryMeta(aTime, aPeriod, null)));
+    }
+
+    @Test
+    void validatesImpliedExpiry() {
+        given(validator.isValidExpiry(aTime)).willReturn(true);
+        assertSame(INVALID_PERIOD_SUMMARY, subject.summarizeCreationAttempt(
+                now,
+                false,
+                new ExpiryMeta(aTime, aPeriod, null)));
+    }
+
+    @Test
+    void summarizesExpiryOnlyCase() {
+        given(validator.isValidExpiry(aTime)).willReturn(true);
+        final var request = ExpiryMeta.withExplicitExpiry(aTime);
+        final var expected = SummarizedExpiryMeta.forValid(request);
+
+        assertEquals(expected, subject.summarizeCreationAttempt(now, false, request));
+    }
+
+    @Test
+    void summarizesExpiryAndAutoRenewNumCase() {
+        given(validator.isValidExpiry(aTime)).willReturn(true);
+        final var request = new ExpiryMeta(aTime, UNUSED_FIELD_SENTINEL, anAutoRenewNum);
+        final var expected = SummarizedExpiryMeta.forValid(request);
+
+        assertEquals(expected, subject.summarizeCreationAttempt(now, false, request));
+    }
+
+    @Test
+    void summarizesExpiryAndValidAutoRenewPeriodCase() {
+        given(validator.isValidExpiry(aTime)).willReturn(true);
+        given(validator.isValidAutoRenewPeriod(aPeriod)).willReturn(true);
+        final var request = new ExpiryMeta(aTime, aPeriod, null);
+        final var expected = SummarizedExpiryMeta.forValid(request);
+
+        assertEquals(expected, subject.summarizeCreationAttempt(now, false, request));
+    }
+
+    @Test
+    void summarizesFullAutoRenewSpecPeriodCase() {
+        given(validator.isValidAutoRenewPeriod(aPeriod)).willReturn(true);
+        given(validator.isValidExpiry(now + aPeriod)).willReturn(true);
+        final var implicitRequest = new ExpiryMeta(now + aPeriod, aPeriod, anAutoRenewNum);
+        final var expected = SummarizedExpiryMeta.forValid(implicitRequest);
+
+        assertEquals(expected, subject.summarizeCreationAttempt(now,
+                false,
+                ExpiryMeta.withAutoRenewSpecNotSelfFunding(aPeriod, anAutoRenewNum)));
+    }
+
+    @Test
+    void updateCannotExplicitlyReduceExpiry() {
+        final var current = ExpiryMeta.withExplicitExpiry(aTime);
+        final var update = ExpiryMeta.withExplicitExpiry(aTime - 1);
+
+        assertSame(EXPIRY_REDUCTION_SUMMARY, subject.summarizeUpdateAttempt(current, update));
+    }
+
+    @Test
+    void explicitExpiryExtensionMustBeValid() {
+        final var current = ExpiryMeta.withExplicitExpiry(aTime);
+        final var update = ExpiryMeta.withExplicitExpiry(bTime);
+
+        assertSame(INVALID_EXPIRY_SUMMARY, subject.summarizeUpdateAttempt(current, update));
+    }
+
+    @Test
+    void ifJustSettingAutoRenewAccountThenNetPeriodMustBeValid() {
+        final var current = new ExpiryMeta(aTime, 0, null);
+        final var update = new ExpiryMeta(UNUSED_FIELD_SENTINEL, UNUSED_FIELD_SENTINEL, anAutoRenewNum);
+
+        assertSame(INVALID_PERIOD_SUMMARY, subject.summarizeUpdateAttempt(current, update));
+    }
+
+    @Test
+    void ifSettingAutoRenewPeriodThenMustBeValid() {
+        final var current = new ExpiryMeta(aTime, 0, null);
+        final var update = new ExpiryMeta(UNUSED_FIELD_SENTINEL, bPeriod, anAutoRenewNum);
+
+        assertSame(INVALID_PERIOD_SUMMARY, subject.summarizeUpdateAttempt(current, update));
+    }
+
+    @Test
+    void canSetEverythingValidly() {
+        final var current = new ExpiryMeta(aTime, 0, null);
+        final var update = new ExpiryMeta(bTime, bPeriod, anAutoRenewNum);
+
+        given(validator.isValidExpiry(bTime)).willReturn(true);
+        given(validator.isValidAutoRenewPeriod(bPeriod)).willReturn(true);
+
+        final var expected = SummarizedExpiryMeta.forValid(update);
+
+        assertEquals(expected, subject.summarizeUpdateAttempt(current, update));
+    }
+
+    private static final long now = 1_234_567;
+    private static final long aTime = 666_666_666L;
+    private static final long bTime = 777_777_777L;
+    private static final long aPeriod = 666_666L;
+    private static final long bPeriod = 777_777L;
+    private static final EntityNum anAutoRenewNum = EntityNum.fromLong(888);
+}

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/services/txns/validation/ExpiryValidatorTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/services/txns/validation/ExpiryValidatorTest.java
@@ -1,11 +1,19 @@
+/*
+ * Copyright (C) 2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hedera.services.txns.validation;
-
-import com.hedera.services.utils.EntityNum;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
 
 import static com.hedera.services.txns.validation.ExpiryMeta.UNUSED_FIELD_SENTINEL;
 import static com.hedera.services.txns.validation.SummarizedExpiryMeta.EXPIRY_REDUCTION_SUMMARY;
@@ -14,10 +22,16 @@ import static com.hedera.services.txns.validation.SummarizedExpiryMeta.INVALID_P
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.BDDMockito.given;
 
+import com.hedera.services.utils.EntityNum;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
 @ExtendWith(MockitoExtension.class)
 class ExpiryValidatorTest {
-    @Mock
-    private OptionValidator validator;
+    @Mock private OptionValidator validator;
 
     private ExpiryValidator subject;
 
@@ -28,59 +42,63 @@ class ExpiryValidatorTest {
 
     @Test
     void onCreationRequiresEitherExplicitValueOrFullAutoRenewMetaIfNotSelfFunding() {
-        assertSame(INVALID_EXPIRY_SUMMARY, subject.summarizeCreationAttempt(
-                now,
-                false,
-                new ExpiryMeta(UNUSED_FIELD_SENTINEL, UNUSED_FIELD_SENTINEL, anAutoRenewNum)));
-        assertSame(INVALID_EXPIRY_SUMMARY, subject.summarizeCreationAttempt(
-                now,
-                false,
-                new ExpiryMeta(UNUSED_FIELD_SENTINEL, aPeriod, null)));
+        assertSame(
+                INVALID_EXPIRY_SUMMARY,
+                subject.summarizeCreationAttempt(
+                        now,
+                        false,
+                        new ExpiryMeta(
+                                UNUSED_FIELD_SENTINEL, UNUSED_FIELD_SENTINEL, anAutoRenewNum)));
+        assertSame(
+                INVALID_EXPIRY_SUMMARY,
+                subject.summarizeCreationAttempt(
+                        now, false, new ExpiryMeta(UNUSED_FIELD_SENTINEL, aPeriod, null)));
     }
 
     @Test
     void onCreationRequiresValidExpiryIfExplicit() {
         given(validator.isValidExpiry(aTime)).willReturn(false);
-        assertSame(INVALID_EXPIRY_SUMMARY, subject.summarizeCreationAttempt(
-                now,
-                false,
-                new ExpiryMeta(aTime, UNUSED_FIELD_SENTINEL, anAutoRenewNum)));
+        assertSame(
+                INVALID_EXPIRY_SUMMARY,
+                subject.summarizeCreationAttempt(
+                        now, false, new ExpiryMeta(aTime, UNUSED_FIELD_SENTINEL, anAutoRenewNum)));
     }
 
     @Test
     void onCreationUsesAutoRenewPeriodEvenWithoutFullSpecIfSelfFunding() {
         given(validator.isValidExpiry(now + aPeriod)).willReturn(true);
         given(validator.isValidAutoRenewPeriod(aPeriod)).willReturn(true);
-        final var actual = subject.summarizeCreationAttempt(
-                        now,
-                        true,
-                        new ExpiryMeta(UNUSED_FIELD_SENTINEL, aPeriod, null));
+        final var actual =
+                subject.summarizeCreationAttempt(
+                        now, true, new ExpiryMeta(UNUSED_FIELD_SENTINEL, aPeriod, null));
         assertTrue(actual.isValid());
     }
 
     @Test
     void onCreationRequiresValidExpiryIfImplicit() {
         given(validator.isValidExpiry(now + aPeriod)).willReturn(false);
-        assertSame(INVALID_EXPIRY_SUMMARY, subject.summarizeCreationAttempt(
-                now,
-                false,
-                new ExpiryMeta(UNUSED_FIELD_SENTINEL, aPeriod, anAutoRenewNum)));
+        assertSame(
+                INVALID_EXPIRY_SUMMARY,
+                subject.summarizeCreationAttempt(
+                        now,
+                        false,
+                        new ExpiryMeta(UNUSED_FIELD_SENTINEL, aPeriod, anAutoRenewNum)));
     }
 
     @Test
     void validatesAutoRenewPeriodIfSet() {
         given(validator.isValidExpiry(aTime)).willReturn(true);
-        assertSame(INVALID_PERIOD_SUMMARY, subject.summarizeCreationAttempt(
-                now, false, new ExpiryMeta(aTime, aPeriod, null)));
+        assertSame(
+                INVALID_PERIOD_SUMMARY,
+                subject.summarizeCreationAttempt(now, false, new ExpiryMeta(aTime, aPeriod, null)));
     }
 
     @Test
     void validatesImpliedExpiry() {
         given(validator.isValidExpiry(aTime)).willReturn(true);
-        assertSame(INVALID_PERIOD_SUMMARY, subject.summarizeCreationAttempt(
-                now,
-                false,
-                new ExpiryMeta(aTime, aPeriod, null)));
+        assertSame(
+                INVALID_PERIOD_SUMMARY,
+                subject.summarizeCreationAttempt(now, false, new ExpiryMeta(aTime, aPeriod, null)));
     }
 
     @Test
@@ -118,9 +136,12 @@ class ExpiryValidatorTest {
         final var implicitRequest = new ExpiryMeta(now + aPeriod, aPeriod, anAutoRenewNum);
         final var expected = SummarizedExpiryMeta.forValid(implicitRequest);
 
-        assertEquals(expected, subject.summarizeCreationAttempt(now,
-                false,
-                ExpiryMeta.withAutoRenewSpecNotSelfFunding(aPeriod, anAutoRenewNum)));
+        assertEquals(
+                expected,
+                subject.summarizeCreationAttempt(
+                        now,
+                        false,
+                        ExpiryMeta.withAutoRenewSpecNotSelfFunding(aPeriod, anAutoRenewNum)));
     }
 
     @Test
@@ -142,7 +163,8 @@ class ExpiryValidatorTest {
     @Test
     void ifJustSettingAutoRenewAccountThenNetPeriodMustBeValid() {
         final var current = new ExpiryMeta(aTime, 0, null);
-        final var update = new ExpiryMeta(UNUSED_FIELD_SENTINEL, UNUSED_FIELD_SENTINEL, anAutoRenewNum);
+        final var update =
+                new ExpiryMeta(UNUSED_FIELD_SENTINEL, UNUSED_FIELD_SENTINEL, anAutoRenewNum);
 
         assertSame(INVALID_PERIOD_SUMMARY, subject.summarizeUpdateAttempt(current, update));
     }

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/services/txns/validation/SummarizedExpiryMetaTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/services/txns/validation/SummarizedExpiryMetaTest.java
@@ -1,13 +1,30 @@
+/*
+ * Copyright (C) 2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hedera.services.txns.validation;
 
-import org.junit.jupiter.api.Test;
-
 import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
 
 class SummarizedExpiryMetaTest {
     @Test
     void ensuresMetaIsValidWhenExpected() {
-        assertThrows(IllegalStateException.class, SummarizedExpiryMeta.INVALID_EXPIRY_SUMMARY::knownValidMeta);
+        assertThrows(
+                IllegalStateException.class,
+                SummarizedExpiryMeta.INVALID_EXPIRY_SUMMARY::knownValidMeta);
     }
 
     @Test

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/services/txns/validation/SummarizedExpiryMetaTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/services/txns/validation/SummarizedExpiryMetaTest.java
@@ -1,0 +1,20 @@
+package com.hedera.services.txns.validation;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class SummarizedExpiryMetaTest {
+    @Test
+    void ensuresMetaIsValidWhenExpected() {
+        assertThrows(IllegalStateException.class, SummarizedExpiryMeta.INVALID_EXPIRY_SUMMARY::knownValidMeta);
+    }
+
+    @Test
+    void returnsMetaIfValid() {
+        final var expected = ExpiryMeta.withExplicitExpiry(1_234_567L);
+        final var subject = SummarizedExpiryMeta.forValid(expected);
+        final var actual = subject.knownValidMeta();
+        assertSame(expected, actual);
+    }
+}

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/services/utils/MiscUtilsTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/services/utils/MiscUtilsTest.java
@@ -124,7 +124,6 @@ import com.swirlds.common.system.address.Address;
 import com.swirlds.common.system.address.AddressBook;
 import com.swirlds.fcqueue.FCQueue;
 import com.swirlds.merkle.map.MerkleMap;
-
 import java.lang.reflect.Method;
 import java.math.BigInteger;
 import java.nio.ByteBuffer;
@@ -136,7 +135,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.BiConsumer;
 import java.util.stream.Stream;
-
 import org.apache.commons.codec.DecoderException;
 import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes;
@@ -161,8 +159,7 @@ class MiscUtilsTest {
     void canRunWithLoggedDuration() {
         final var mockLogger = mock(Logger.class);
         final var desc = "nothing";
-        MiscUtils.withLoggedDuration(() -> {
-        }, mockLogger, desc);
+        MiscUtils.withLoggedDuration(() -> {}, mockLogger, desc);
         verify(mockLogger).info("Starting {}", desc);
         verify(mockLogger).info("Done with {} in {}ms", desc, 0L);
     }
@@ -180,7 +177,8 @@ class MiscUtilsTest {
     void forEachDropInWorksAsExpected() {
         // setup:
         final MerkleMap<FcLong, KeyedMerkleLong<FcLong>> testMm = new MerkleMap<>();
-        @SuppressWarnings("unchecked") final BiConsumer<FcLong, KeyedMerkleLong<FcLong>> mockConsumer =
+        @SuppressWarnings("unchecked")
+        final BiConsumer<FcLong, KeyedMerkleLong<FcLong>> mockConsumer =
                 BDDMockito.mock(BiConsumer.class);
         // and:
         final var key1 = new FcLong(1L);
@@ -246,9 +244,9 @@ class MiscUtilsTest {
     void asFcKeyReturnsEmptyOnInvalidKey() {
         assertTrue(
                 asUsableFcKey(
-                        Key.newBuilder()
-                                .setEd25519(ByteString.copyFrom("1".getBytes()))
-                                .build())
+                                Key.newBuilder()
+                                        .setEd25519(ByteString.copyFrom("1".getBytes()))
+                                        .build())
                         .isEmpty());
     }
 
@@ -402,120 +400,120 @@ class MiscUtilsTest {
     @Test
     void getExpectedOrdinaryTxn() {
         final Map<
-                String,
-                BodySetter<
-                        ? extends GeneratedMessageV3, SchedulableTransactionBody.Builder>>
+                        String,
+                        BodySetter<
+                                ? extends GeneratedMessageV3, SchedulableTransactionBody.Builder>>
                 setters =
-                new HashMap<>() {
-                    {
-                        put(
-                                "ContractCall",
-                                new BodySetter<>(ContractCallTransactionBody.class));
-                        put(
-                                "ContractCreateInstance",
-                                new BodySetter<>(ContractCreateTransactionBody.class));
-                        put(
-                                "ContractUpdateInstance",
-                                new BodySetter<>(ContractUpdateTransactionBody.class));
-                        put(
-                                "ContractDeleteInstance",
-                                new BodySetter<>(ContractDeleteTransactionBody.class));
-                        put(
-                                "CryptoCreateAccount",
-                                new BodySetter<>(CryptoCreateTransactionBody.class));
-                        put(
-                                "CryptoDelete",
-                                new BodySetter<>(CryptoDeleteTransactionBody.class));
-                        put(
-                                "CryptoTransfer",
-                                new BodySetter<>(CryptoTransferTransactionBody.class));
-                        put(
-                                "CryptoUpdateAccount",
-                                new BodySetter<>(CryptoUpdateTransactionBody.class));
-                        put(
-                                "FileAppend",
-                                new BodySetter<>(FileAppendTransactionBody.class));
-                        put(
-                                "FileCreate",
-                                new BodySetter<>(FileCreateTransactionBody.class));
-                        put(
-                                "FileDelete",
-                                new BodySetter<>(FileDeleteTransactionBody.class));
-                        put(
-                                "FileUpdate",
-                                new BodySetter<>(FileUpdateTransactionBody.class));
-                        put(
-                                "SystemDelete",
-                                new BodySetter<>(SystemDeleteTransactionBody.class));
-                        put(
-                                "SystemUndelete",
-                                new BodySetter<>(SystemUndeleteTransactionBody.class));
-                        put("Freeze", new BodySetter<>(FreezeTransactionBody.class));
-                        put(
-                                "ConsensusCreateTopic",
-                                new BodySetter<>(
-                                        ConsensusCreateTopicTransactionBody.class));
-                        put(
-                                "ConsensusUpdateTopic",
-                                new BodySetter<>(
-                                        ConsensusUpdateTopicTransactionBody.class));
-                        put(
-                                "ConsensusDeleteTopic",
-                                new BodySetter<>(
-                                        ConsensusDeleteTopicTransactionBody.class));
-                        put(
-                                "ConsensusSubmitMessage",
-                                new BodySetter<>(
-                                        ConsensusSubmitMessageTransactionBody.class));
-                        put(
-                                "TokenCreation",
-                                new BodySetter<>(TokenCreateTransactionBody.class));
-                        put(
-                                "TokenFreeze",
-                                new BodySetter<>(TokenFreezeAccountTransactionBody.class));
-                        put(
-                                "TokenUnfreeze",
-                                new BodySetter<>(
-                                        TokenUnfreezeAccountTransactionBody.class));
-                        put(
-                                "TokenGrantKyc",
-                                new BodySetter<>(TokenGrantKycTransactionBody.class));
-                        put(
-                                "TokenRevokeKyc",
-                                new BodySetter<>(TokenRevokeKycTransactionBody.class));
-                        put(
-                                "TokenDeletion",
-                                new BodySetter<>(TokenDeleteTransactionBody.class));
-                        put(
-                                "TokenUpdate",
-                                new BodySetter<>(TokenUpdateTransactionBody.class));
-                        put("TokenMint", new BodySetter<>(TokenMintTransactionBody.class));
-                        put("TokenBurn", new BodySetter<>(TokenBurnTransactionBody.class));
-                        put(
-                                "TokenWipe",
-                                new BodySetter<>(TokenWipeAccountTransactionBody.class));
-                        put(
-                                "TokenAssociate",
-                                new BodySetter<>(TokenAssociateTransactionBody.class));
-                        put(
-                                "TokenDissociate",
-                                new BodySetter<>(TokenDissociateTransactionBody.class));
-                        put(
-                                "TokenUnpause",
-                                new BodySetter<>(TokenUnpauseTransactionBody.class));
-                        put(
-                                "TokenPause",
-                                new BodySetter<>(TokenPauseTransactionBody.class));
-                        put(
-                                "ScheduleDelete",
-                                new BodySetter<>(ScheduleDeleteTransactionBody.class));
-                        put("UtilPrng", new BodySetter<>(UtilPrngTransactionBody.class));
-                        put(
-                                "CryptoApproveAllowance",
-                                new BodySetter<>(
-                                        CryptoApproveAllowanceTransactionBody.class));
-                    }
-                };
+                        new HashMap<>() {
+                            {
+                                put(
+                                        "ContractCall",
+                                        new BodySetter<>(ContractCallTransactionBody.class));
+                                put(
+                                        "ContractCreateInstance",
+                                        new BodySetter<>(ContractCreateTransactionBody.class));
+                                put(
+                                        "ContractUpdateInstance",
+                                        new BodySetter<>(ContractUpdateTransactionBody.class));
+                                put(
+                                        "ContractDeleteInstance",
+                                        new BodySetter<>(ContractDeleteTransactionBody.class));
+                                put(
+                                        "CryptoCreateAccount",
+                                        new BodySetter<>(CryptoCreateTransactionBody.class));
+                                put(
+                                        "CryptoDelete",
+                                        new BodySetter<>(CryptoDeleteTransactionBody.class));
+                                put(
+                                        "CryptoTransfer",
+                                        new BodySetter<>(CryptoTransferTransactionBody.class));
+                                put(
+                                        "CryptoUpdateAccount",
+                                        new BodySetter<>(CryptoUpdateTransactionBody.class));
+                                put(
+                                        "FileAppend",
+                                        new BodySetter<>(FileAppendTransactionBody.class));
+                                put(
+                                        "FileCreate",
+                                        new BodySetter<>(FileCreateTransactionBody.class));
+                                put(
+                                        "FileDelete",
+                                        new BodySetter<>(FileDeleteTransactionBody.class));
+                                put(
+                                        "FileUpdate",
+                                        new BodySetter<>(FileUpdateTransactionBody.class));
+                                put(
+                                        "SystemDelete",
+                                        new BodySetter<>(SystemDeleteTransactionBody.class));
+                                put(
+                                        "SystemUndelete",
+                                        new BodySetter<>(SystemUndeleteTransactionBody.class));
+                                put("Freeze", new BodySetter<>(FreezeTransactionBody.class));
+                                put(
+                                        "ConsensusCreateTopic",
+                                        new BodySetter<>(
+                                                ConsensusCreateTopicTransactionBody.class));
+                                put(
+                                        "ConsensusUpdateTopic",
+                                        new BodySetter<>(
+                                                ConsensusUpdateTopicTransactionBody.class));
+                                put(
+                                        "ConsensusDeleteTopic",
+                                        new BodySetter<>(
+                                                ConsensusDeleteTopicTransactionBody.class));
+                                put(
+                                        "ConsensusSubmitMessage",
+                                        new BodySetter<>(
+                                                ConsensusSubmitMessageTransactionBody.class));
+                                put(
+                                        "TokenCreation",
+                                        new BodySetter<>(TokenCreateTransactionBody.class));
+                                put(
+                                        "TokenFreeze",
+                                        new BodySetter<>(TokenFreezeAccountTransactionBody.class));
+                                put(
+                                        "TokenUnfreeze",
+                                        new BodySetter<>(
+                                                TokenUnfreezeAccountTransactionBody.class));
+                                put(
+                                        "TokenGrantKyc",
+                                        new BodySetter<>(TokenGrantKycTransactionBody.class));
+                                put(
+                                        "TokenRevokeKyc",
+                                        new BodySetter<>(TokenRevokeKycTransactionBody.class));
+                                put(
+                                        "TokenDeletion",
+                                        new BodySetter<>(TokenDeleteTransactionBody.class));
+                                put(
+                                        "TokenUpdate",
+                                        new BodySetter<>(TokenUpdateTransactionBody.class));
+                                put("TokenMint", new BodySetter<>(TokenMintTransactionBody.class));
+                                put("TokenBurn", new BodySetter<>(TokenBurnTransactionBody.class));
+                                put(
+                                        "TokenWipe",
+                                        new BodySetter<>(TokenWipeAccountTransactionBody.class));
+                                put(
+                                        "TokenAssociate",
+                                        new BodySetter<>(TokenAssociateTransactionBody.class));
+                                put(
+                                        "TokenDissociate",
+                                        new BodySetter<>(TokenDissociateTransactionBody.class));
+                                put(
+                                        "TokenUnpause",
+                                        new BodySetter<>(TokenUnpauseTransactionBody.class));
+                                put(
+                                        "TokenPause",
+                                        new BodySetter<>(TokenPauseTransactionBody.class));
+                                put(
+                                        "ScheduleDelete",
+                                        new BodySetter<>(ScheduleDeleteTransactionBody.class));
+                                put("UtilPrng", new BodySetter<>(UtilPrngTransactionBody.class));
+                                put(
+                                        "CryptoApproveAllowance",
+                                        new BodySetter<>(
+                                                CryptoApproveAllowanceTransactionBody.class));
+                            }
+                        };
 
         setters.forEach(
                 (bodyType, setter) -> {
@@ -558,137 +556,137 @@ class MiscUtilsTest {
     void getExpectedTxnStat() {
         final Map<String, BodySetter<? extends GeneratedMessageV3, TransactionBody.Builder>>
                 setters =
-                new HashMap<>() {
-                    {
-                        put(
-                                CryptoController.CRYPTO_CREATE_METRIC,
-                                new BodySetter<>(CryptoCreateTransactionBody.class));
-                        put(
-                                CryptoController.CRYPTO_UPDATE_METRIC,
-                                new BodySetter<>(CryptoUpdateTransactionBody.class));
-                        put(
-                                CryptoController.CRYPTO_TRANSFER_METRIC,
-                                new BodySetter<>(CryptoTransferTransactionBody.class));
-                        put(
-                                CryptoController.CRYPTO_DELETE_METRIC,
-                                new BodySetter<>(CryptoDeleteTransactionBody.class));
-                        put(
-                                ContractController.CREATE_CONTRACT_METRIC,
-                                new BodySetter<>(ContractCreateTransactionBody.class));
-                        put(
-                                ContractController.CALL_CONTRACT_METRIC,
-                                new BodySetter<>(ContractCallTransactionBody.class));
-                        put(
-                                ContractController.UPDATE_CONTRACT_METRIC,
-                                new BodySetter<>(ContractUpdateTransactionBody.class));
-                        put(
-                                ContractController.DELETE_CONTRACT_METRIC,
-                                new BodySetter<>(ContractDeleteTransactionBody.class));
-                        put(
-                                CryptoController.ADD_LIVE_HASH_METRIC,
-                                new BodySetter<>(CryptoAddLiveHashTransactionBody.class));
-                        put(
-                                CryptoController.DELETE_LIVE_HASH_METRIC,
-                                new BodySetter<>(
-                                        CryptoDeleteLiveHashTransactionBody.class));
-                        put(
-                                FileController.CREATE_FILE_METRIC,
-                                new BodySetter<>(FileCreateTransactionBody.class));
-                        put(
-                                FileController.FILE_APPEND_METRIC,
-                                new BodySetter<>(FileAppendTransactionBody.class));
-                        put(
-                                FileController.UPDATE_FILE_METRIC,
-                                new BodySetter<>(FileUpdateTransactionBody.class));
-                        put(
-                                FileController.DELETE_FILE_METRIC,
-                                new BodySetter<>(FileDeleteTransactionBody.class));
-                        put(
-                                FreezeController.FREEZE_METRIC,
-                                new BodySetter<>(FreezeTransactionBody.class));
-                        put(
-                                ServicesStatsConfig.SYSTEM_DELETE_METRIC,
-                                new BodySetter<>(SystemDeleteTransactionBody.class));
-                        put(
-                                ServicesStatsConfig.SYSTEM_UNDELETE_METRIC,
-                                new BodySetter<>(SystemUndeleteTransactionBody.class));
-                        put(
-                                ConsensusController.CREATE_TOPIC_METRIC,
-                                new BodySetter<>(
-                                        ConsensusCreateTopicTransactionBody.class));
-                        put(
-                                ConsensusController.UPDATE_TOPIC_METRIC,
-                                new BodySetter<>(
-                                        ConsensusUpdateTopicTransactionBody.class));
-                        put(
-                                ConsensusController.DELETE_TOPIC_METRIC,
-                                new BodySetter<>(
-                                        ConsensusDeleteTopicTransactionBody.class));
-                        put(
-                                ConsensusController.SUBMIT_MESSAGE_METRIC,
-                                new BodySetter<>(
-                                        ConsensusSubmitMessageTransactionBody.class));
-                        put(
-                                TOKEN_CREATE_METRIC,
-                                new BodySetter<>(TokenCreateTransactionBody.class));
-                        put(
-                                TOKEN_FREEZE_METRIC,
-                                new BodySetter<>(TokenFreezeAccountTransactionBody.class));
-                        put(
-                                TOKEN_UNFREEZE_METRIC,
-                                new BodySetter<>(
-                                        TokenUnfreezeAccountTransactionBody.class));
-                        put(
-                                TOKEN_GRANT_KYC_METRIC,
-                                new BodySetter<>(TokenGrantKycTransactionBody.class));
-                        put(
-                                TOKEN_REVOKE_KYC_METRIC,
-                                new BodySetter<>(TokenRevokeKycTransactionBody.class));
-                        put(
-                                TOKEN_DELETE_METRIC,
-                                new BodySetter<>(TokenDeleteTransactionBody.class));
-                        put(
-                                TOKEN_UPDATE_METRIC,
-                                new BodySetter<>(TokenUpdateTransactionBody.class));
-                        put(
-                                TOKEN_MINT_METRIC,
-                                new BodySetter<>(TokenMintTransactionBody.class));
-                        put(
-                                TOKEN_BURN_METRIC,
-                                new BodySetter<>(TokenBurnTransactionBody.class));
-                        put(
-                                TOKEN_WIPE_ACCOUNT_METRIC,
-                                new BodySetter<>(TokenWipeAccountTransactionBody.class));
-                        put(
-                                TOKEN_ASSOCIATE_METRIC,
-                                new BodySetter<>(TokenAssociateTransactionBody.class));
-                        put(
-                                TOKEN_DISSOCIATE_METRIC,
-                                new BodySetter<>(TokenDissociateTransactionBody.class));
-                        put(
-                                TOKEN_FEE_SCHEDULE_UPDATE_METRIC,
-                                new BodySetter<>(
-                                        TokenFeeScheduleUpdateTransactionBody.class));
-                        put(
-                                TOKEN_UNPAUSE_METRIC,
-                                new BodySetter<>(TokenUnpauseTransactionBody.class));
-                        put(
-                                TOKEN_PAUSE_METRIC,
-                                new BodySetter<>(TokenPauseTransactionBody.class));
-                        put(
-                                SCHEDULE_CREATE_METRIC,
-                                new BodySetter<>(ScheduleCreateTransactionBody.class));
-                        put(
-                                SCHEDULE_SIGN_METRIC,
-                                new BodySetter<>(ScheduleSignTransactionBody.class));
-                        put(
-                                SCHEDULE_DELETE_METRIC,
-                                new BodySetter<>(ScheduleDeleteTransactionBody.class));
-                        put(
-                                UTIL_PRNG_METRIC,
-                                new BodySetter<>(UtilPrngTransactionBody.class));
-                    }
-                };
+                        new HashMap<>() {
+                            {
+                                put(
+                                        CryptoController.CRYPTO_CREATE_METRIC,
+                                        new BodySetter<>(CryptoCreateTransactionBody.class));
+                                put(
+                                        CryptoController.CRYPTO_UPDATE_METRIC,
+                                        new BodySetter<>(CryptoUpdateTransactionBody.class));
+                                put(
+                                        CryptoController.CRYPTO_TRANSFER_METRIC,
+                                        new BodySetter<>(CryptoTransferTransactionBody.class));
+                                put(
+                                        CryptoController.CRYPTO_DELETE_METRIC,
+                                        new BodySetter<>(CryptoDeleteTransactionBody.class));
+                                put(
+                                        ContractController.CREATE_CONTRACT_METRIC,
+                                        new BodySetter<>(ContractCreateTransactionBody.class));
+                                put(
+                                        ContractController.CALL_CONTRACT_METRIC,
+                                        new BodySetter<>(ContractCallTransactionBody.class));
+                                put(
+                                        ContractController.UPDATE_CONTRACT_METRIC,
+                                        new BodySetter<>(ContractUpdateTransactionBody.class));
+                                put(
+                                        ContractController.DELETE_CONTRACT_METRIC,
+                                        new BodySetter<>(ContractDeleteTransactionBody.class));
+                                put(
+                                        CryptoController.ADD_LIVE_HASH_METRIC,
+                                        new BodySetter<>(CryptoAddLiveHashTransactionBody.class));
+                                put(
+                                        CryptoController.DELETE_LIVE_HASH_METRIC,
+                                        new BodySetter<>(
+                                                CryptoDeleteLiveHashTransactionBody.class));
+                                put(
+                                        FileController.CREATE_FILE_METRIC,
+                                        new BodySetter<>(FileCreateTransactionBody.class));
+                                put(
+                                        FileController.FILE_APPEND_METRIC,
+                                        new BodySetter<>(FileAppendTransactionBody.class));
+                                put(
+                                        FileController.UPDATE_FILE_METRIC,
+                                        new BodySetter<>(FileUpdateTransactionBody.class));
+                                put(
+                                        FileController.DELETE_FILE_METRIC,
+                                        new BodySetter<>(FileDeleteTransactionBody.class));
+                                put(
+                                        FreezeController.FREEZE_METRIC,
+                                        new BodySetter<>(FreezeTransactionBody.class));
+                                put(
+                                        ServicesStatsConfig.SYSTEM_DELETE_METRIC,
+                                        new BodySetter<>(SystemDeleteTransactionBody.class));
+                                put(
+                                        ServicesStatsConfig.SYSTEM_UNDELETE_METRIC,
+                                        new BodySetter<>(SystemUndeleteTransactionBody.class));
+                                put(
+                                        ConsensusController.CREATE_TOPIC_METRIC,
+                                        new BodySetter<>(
+                                                ConsensusCreateTopicTransactionBody.class));
+                                put(
+                                        ConsensusController.UPDATE_TOPIC_METRIC,
+                                        new BodySetter<>(
+                                                ConsensusUpdateTopicTransactionBody.class));
+                                put(
+                                        ConsensusController.DELETE_TOPIC_METRIC,
+                                        new BodySetter<>(
+                                                ConsensusDeleteTopicTransactionBody.class));
+                                put(
+                                        ConsensusController.SUBMIT_MESSAGE_METRIC,
+                                        new BodySetter<>(
+                                                ConsensusSubmitMessageTransactionBody.class));
+                                put(
+                                        TOKEN_CREATE_METRIC,
+                                        new BodySetter<>(TokenCreateTransactionBody.class));
+                                put(
+                                        TOKEN_FREEZE_METRIC,
+                                        new BodySetter<>(TokenFreezeAccountTransactionBody.class));
+                                put(
+                                        TOKEN_UNFREEZE_METRIC,
+                                        new BodySetter<>(
+                                                TokenUnfreezeAccountTransactionBody.class));
+                                put(
+                                        TOKEN_GRANT_KYC_METRIC,
+                                        new BodySetter<>(TokenGrantKycTransactionBody.class));
+                                put(
+                                        TOKEN_REVOKE_KYC_METRIC,
+                                        new BodySetter<>(TokenRevokeKycTransactionBody.class));
+                                put(
+                                        TOKEN_DELETE_METRIC,
+                                        new BodySetter<>(TokenDeleteTransactionBody.class));
+                                put(
+                                        TOKEN_UPDATE_METRIC,
+                                        new BodySetter<>(TokenUpdateTransactionBody.class));
+                                put(
+                                        TOKEN_MINT_METRIC,
+                                        new BodySetter<>(TokenMintTransactionBody.class));
+                                put(
+                                        TOKEN_BURN_METRIC,
+                                        new BodySetter<>(TokenBurnTransactionBody.class));
+                                put(
+                                        TOKEN_WIPE_ACCOUNT_METRIC,
+                                        new BodySetter<>(TokenWipeAccountTransactionBody.class));
+                                put(
+                                        TOKEN_ASSOCIATE_METRIC,
+                                        new BodySetter<>(TokenAssociateTransactionBody.class));
+                                put(
+                                        TOKEN_DISSOCIATE_METRIC,
+                                        new BodySetter<>(TokenDissociateTransactionBody.class));
+                                put(
+                                        TOKEN_FEE_SCHEDULE_UPDATE_METRIC,
+                                        new BodySetter<>(
+                                                TokenFeeScheduleUpdateTransactionBody.class));
+                                put(
+                                        TOKEN_UNPAUSE_METRIC,
+                                        new BodySetter<>(TokenUnpauseTransactionBody.class));
+                                put(
+                                        TOKEN_PAUSE_METRIC,
+                                        new BodySetter<>(TokenPauseTransactionBody.class));
+                                put(
+                                        SCHEDULE_CREATE_METRIC,
+                                        new BodySetter<>(ScheduleCreateTransactionBody.class));
+                                put(
+                                        SCHEDULE_SIGN_METRIC,
+                                        new BodySetter<>(ScheduleSignTransactionBody.class));
+                                put(
+                                        SCHEDULE_DELETE_METRIC,
+                                        new BodySetter<>(ScheduleDeleteTransactionBody.class));
+                                put(
+                                        UTIL_PRNG_METRIC,
+                                        new BodySetter<>(UtilPrngTransactionBody.class));
+                            }
+                        };
 
         setters.forEach(
                 (stat, setter) -> {
@@ -709,54 +707,54 @@ class MiscUtilsTest {
     void getsExpectedQueryFunctionality() {
         final Map<HederaFunctionality, BodySetter<? extends GeneratedMessageV3, Query.Builder>>
                 setters =
-                new HashMap<>() {
-                    {
-                        put(
-                                GetVersionInfo,
-                                new BodySetter<>(NetworkGetVersionInfoQuery.class));
-                        put(GetByKey, new BodySetter<>(GetByKeyQuery.class));
-                        put(
-                                ConsensusGetTopicInfo,
-                                new BodySetter<>(ConsensusGetTopicInfoQuery.class));
-                        put(GetBySolidityID, new BodySetter<>(GetBySolidityIDQuery.class));
-                        put(
-                                ContractCallLocal,
-                                new BodySetter<>(ContractCallLocalQuery.class));
-                        put(ContractGetInfo, new BodySetter<>(ContractGetInfoQuery.class));
-                        put(
-                                ContractGetBytecode,
-                                new BodySetter<>(ContractGetBytecodeQuery.class));
-                        put(
-                                ContractGetRecords,
-                                new BodySetter<>(ContractGetRecordsQuery.class));
-                        put(
-                                CryptoGetAccountBalance,
-                                new BodySetter<>(CryptoGetAccountBalanceQuery.class));
-                        put(
-                                CryptoGetAccountRecords,
-                                new BodySetter<>(CryptoGetAccountRecordsQuery.class));
-                        put(CryptoGetInfo, new BodySetter<>(CryptoGetInfoQuery.class));
-                        put(
-                                CryptoGetLiveHash,
-                                new BodySetter<>(CryptoGetLiveHashQuery.class));
-                        put(FileGetContents, new BodySetter<>(FileGetContentsQuery.class));
-                        put(FileGetInfo, new BodySetter<>(FileGetInfoQuery.class));
-                        put(
-                                TransactionGetReceipt,
-                                new BodySetter<>(TransactionGetReceiptQuery.class));
-                        put(
-                                TransactionGetRecord,
-                                new BodySetter<>(TransactionGetRecordQuery.class));
-                        put(TokenGetInfo, new BodySetter<>(TokenGetInfoQuery.class));
-                        put(ScheduleGetInfo, new BodySetter<>(ScheduleGetInfoQuery.class));
-                        put(
-                                NetworkGetExecutionTime,
-                                new BodySetter<>(NetworkGetExecutionTimeQuery.class));
-                        put(
-                                GetAccountDetails,
-                                new BodySetter<>(GetAccountDetailsQuery.class));
-                    }
-                };
+                        new HashMap<>() {
+                            {
+                                put(
+                                        GetVersionInfo,
+                                        new BodySetter<>(NetworkGetVersionInfoQuery.class));
+                                put(GetByKey, new BodySetter<>(GetByKeyQuery.class));
+                                put(
+                                        ConsensusGetTopicInfo,
+                                        new BodySetter<>(ConsensusGetTopicInfoQuery.class));
+                                put(GetBySolidityID, new BodySetter<>(GetBySolidityIDQuery.class));
+                                put(
+                                        ContractCallLocal,
+                                        new BodySetter<>(ContractCallLocalQuery.class));
+                                put(ContractGetInfo, new BodySetter<>(ContractGetInfoQuery.class));
+                                put(
+                                        ContractGetBytecode,
+                                        new BodySetter<>(ContractGetBytecodeQuery.class));
+                                put(
+                                        ContractGetRecords,
+                                        new BodySetter<>(ContractGetRecordsQuery.class));
+                                put(
+                                        CryptoGetAccountBalance,
+                                        new BodySetter<>(CryptoGetAccountBalanceQuery.class));
+                                put(
+                                        CryptoGetAccountRecords,
+                                        new BodySetter<>(CryptoGetAccountRecordsQuery.class));
+                                put(CryptoGetInfo, new BodySetter<>(CryptoGetInfoQuery.class));
+                                put(
+                                        CryptoGetLiveHash,
+                                        new BodySetter<>(CryptoGetLiveHashQuery.class));
+                                put(FileGetContents, new BodySetter<>(FileGetContentsQuery.class));
+                                put(FileGetInfo, new BodySetter<>(FileGetInfoQuery.class));
+                                put(
+                                        TransactionGetReceipt,
+                                        new BodySetter<>(TransactionGetReceiptQuery.class));
+                                put(
+                                        TransactionGetRecord,
+                                        new BodySetter<>(TransactionGetRecordQuery.class));
+                                put(TokenGetInfo, new BodySetter<>(TokenGetInfoQuery.class));
+                                put(ScheduleGetInfo, new BodySetter<>(ScheduleGetInfoQuery.class));
+                                put(
+                                        NetworkGetExecutionTime,
+                                        new BodySetter<>(NetworkGetExecutionTimeQuery.class));
+                                put(
+                                        GetAccountDetails,
+                                        new BodySetter<>(GetAccountDetailsQuery.class));
+                            }
+                        };
 
         setters.forEach(
                 (function, setter) -> {
@@ -813,130 +811,130 @@ class MiscUtilsTest {
     @Test
     void getsExpectedTxnFunctionality() {
         final Map<
-                HederaFunctionality,
-                BodySetter<? extends GeneratedMessageV3, TransactionBody.Builder>>
+                        HederaFunctionality,
+                        BodySetter<? extends GeneratedMessageV3, TransactionBody.Builder>>
                 setters =
-                new HashMap<>() {
-                    {
-                        put(
-                                SystemDelete,
-                                new BodySetter<>(SystemDeleteTransactionBody.class));
-                        put(
-                                SystemUndelete,
-                                new BodySetter<>(SystemUndeleteTransactionBody.class));
-                        put(
-                                ContractCall,
-                                new BodySetter<>(ContractCallTransactionBody.class));
-                        put(
-                                ContractCreate,
-                                new BodySetter<>(ContractCreateTransactionBody.class));
-                        put(
-                                EthereumTransaction,
-                                new BodySetter<>(EthereumTransactionBody.class));
-                        put(
-                                ContractUpdate,
-                                new BodySetter<>(ContractUpdateTransactionBody.class));
-                        put(
-                                CryptoAddLiveHash,
-                                new BodySetter<>(CryptoAddLiveHashTransactionBody.class));
-                        put(
-                                CryptoCreate,
-                                new BodySetter<>(CryptoCreateTransactionBody.class));
-                        put(
-                                CryptoDelete,
-                                new BodySetter<>(CryptoDeleteTransactionBody.class));
-                        put(
-                                CryptoDeleteLiveHash,
-                                new BodySetter<>(
-                                        CryptoDeleteLiveHashTransactionBody.class));
-                        put(
-                                CryptoTransfer,
-                                new BodySetter<>(CryptoTransferTransactionBody.class));
-                        put(
-                                CryptoUpdate,
-                                new BodySetter<>(CryptoUpdateTransactionBody.class));
-                        put(FileAppend, new BodySetter<>(FileAppendTransactionBody.class));
-                        put(FileCreate, new BodySetter<>(FileCreateTransactionBody.class));
-                        put(FileDelete, new BodySetter<>(FileDeleteTransactionBody.class));
-                        put(FileUpdate, new BodySetter<>(FileUpdateTransactionBody.class));
-                        put(
-                                ContractDelete,
-                                new BodySetter<>(ContractDeleteTransactionBody.class));
-                        put(
-                                TokenCreate,
-                                new BodySetter<>(TokenCreateTransactionBody.class));
-                        put(
-                                TokenFreezeAccount,
-                                new BodySetter<>(TokenFreezeAccountTransactionBody.class));
-                        put(
-                                TokenUnfreezeAccount,
-                                new BodySetter<>(
-                                        TokenUnfreezeAccountTransactionBody.class));
-                        put(
-                                TokenGrantKycToAccount,
-                                new BodySetter<>(TokenGrantKycTransactionBody.class));
-                        put(
-                                TokenRevokeKycFromAccount,
-                                new BodySetter<>(TokenRevokeKycTransactionBody.class));
-                        put(
-                                TokenDelete,
-                                new BodySetter<>(TokenDeleteTransactionBody.class));
-                        put(
-                                TokenUpdate,
-                                new BodySetter<>(TokenUpdateTransactionBody.class));
-                        put(TokenMint, new BodySetter<>(TokenMintTransactionBody.class));
-                        put(TokenBurn, new BodySetter<>(TokenBurnTransactionBody.class));
-                        put(
-                                TokenAccountWipe,
-                                new BodySetter<>(TokenWipeAccountTransactionBody.class));
-                        put(
-                                TokenAssociateToAccount,
-                                new BodySetter<>(TokenAssociateTransactionBody.class));
-                        put(
-                                TokenDissociateFromAccount,
-                                new BodySetter<>(TokenDissociateTransactionBody.class));
-                        put(
-                                TokenUnpause,
-                                new BodySetter<>(TokenUnpauseTransactionBody.class));
-                        put(TokenPause, new BodySetter<>(TokenPauseTransactionBody.class));
-                        put(
-                                ScheduleCreate,
-                                new BodySetter<>(ScheduleCreateTransactionBody.class));
-                        put(
-                                ScheduleSign,
-                                new BodySetter<>(ScheduleSignTransactionBody.class));
-                        put(
-                                ScheduleDelete,
-                                new BodySetter<>(ScheduleDeleteTransactionBody.class));
-                        put(Freeze, new BodySetter<>(FreezeTransactionBody.class));
-                        put(
-                                ConsensusCreateTopic,
-                                new BodySetter<>(
-                                        ConsensusCreateTopicTransactionBody.class));
-                        put(
-                                ConsensusUpdateTopic,
-                                new BodySetter<>(
-                                        ConsensusUpdateTopicTransactionBody.class));
-                        put(
-                                ConsensusDeleteTopic,
-                                new BodySetter<>(
-                                        ConsensusDeleteTopicTransactionBody.class));
-                        put(
-                                ConsensusSubmitMessage,
-                                new BodySetter<>(
-                                        ConsensusSubmitMessageTransactionBody.class));
-                        put(UncheckedSubmit, new BodySetter<>(UncheckedSubmitBody.class));
-                        put(
-                                TokenFeeScheduleUpdate,
-                                new BodySetter<>(
-                                        TokenFeeScheduleUpdateTransactionBody.class));
-                        put(UtilPrng, new BodySetter<>(UtilPrngTransactionBody.class));
-                        put(
-                                CryptoApproveAllowance,
-                                new BodySetter<>(
-                                        CryptoApproveAllowanceTransactionBody.class));
-                    }
-                };
+                        new HashMap<>() {
+                            {
+                                put(
+                                        SystemDelete,
+                                        new BodySetter<>(SystemDeleteTransactionBody.class));
+                                put(
+                                        SystemUndelete,
+                                        new BodySetter<>(SystemUndeleteTransactionBody.class));
+                                put(
+                                        ContractCall,
+                                        new BodySetter<>(ContractCallTransactionBody.class));
+                                put(
+                                        ContractCreate,
+                                        new BodySetter<>(ContractCreateTransactionBody.class));
+                                put(
+                                        EthereumTransaction,
+                                        new BodySetter<>(EthereumTransactionBody.class));
+                                put(
+                                        ContractUpdate,
+                                        new BodySetter<>(ContractUpdateTransactionBody.class));
+                                put(
+                                        CryptoAddLiveHash,
+                                        new BodySetter<>(CryptoAddLiveHashTransactionBody.class));
+                                put(
+                                        CryptoCreate,
+                                        new BodySetter<>(CryptoCreateTransactionBody.class));
+                                put(
+                                        CryptoDelete,
+                                        new BodySetter<>(CryptoDeleteTransactionBody.class));
+                                put(
+                                        CryptoDeleteLiveHash,
+                                        new BodySetter<>(
+                                                CryptoDeleteLiveHashTransactionBody.class));
+                                put(
+                                        CryptoTransfer,
+                                        new BodySetter<>(CryptoTransferTransactionBody.class));
+                                put(
+                                        CryptoUpdate,
+                                        new BodySetter<>(CryptoUpdateTransactionBody.class));
+                                put(FileAppend, new BodySetter<>(FileAppendTransactionBody.class));
+                                put(FileCreate, new BodySetter<>(FileCreateTransactionBody.class));
+                                put(FileDelete, new BodySetter<>(FileDeleteTransactionBody.class));
+                                put(FileUpdate, new BodySetter<>(FileUpdateTransactionBody.class));
+                                put(
+                                        ContractDelete,
+                                        new BodySetter<>(ContractDeleteTransactionBody.class));
+                                put(
+                                        TokenCreate,
+                                        new BodySetter<>(TokenCreateTransactionBody.class));
+                                put(
+                                        TokenFreezeAccount,
+                                        new BodySetter<>(TokenFreezeAccountTransactionBody.class));
+                                put(
+                                        TokenUnfreezeAccount,
+                                        new BodySetter<>(
+                                                TokenUnfreezeAccountTransactionBody.class));
+                                put(
+                                        TokenGrantKycToAccount,
+                                        new BodySetter<>(TokenGrantKycTransactionBody.class));
+                                put(
+                                        TokenRevokeKycFromAccount,
+                                        new BodySetter<>(TokenRevokeKycTransactionBody.class));
+                                put(
+                                        TokenDelete,
+                                        new BodySetter<>(TokenDeleteTransactionBody.class));
+                                put(
+                                        TokenUpdate,
+                                        new BodySetter<>(TokenUpdateTransactionBody.class));
+                                put(TokenMint, new BodySetter<>(TokenMintTransactionBody.class));
+                                put(TokenBurn, new BodySetter<>(TokenBurnTransactionBody.class));
+                                put(
+                                        TokenAccountWipe,
+                                        new BodySetter<>(TokenWipeAccountTransactionBody.class));
+                                put(
+                                        TokenAssociateToAccount,
+                                        new BodySetter<>(TokenAssociateTransactionBody.class));
+                                put(
+                                        TokenDissociateFromAccount,
+                                        new BodySetter<>(TokenDissociateTransactionBody.class));
+                                put(
+                                        TokenUnpause,
+                                        new BodySetter<>(TokenUnpauseTransactionBody.class));
+                                put(TokenPause, new BodySetter<>(TokenPauseTransactionBody.class));
+                                put(
+                                        ScheduleCreate,
+                                        new BodySetter<>(ScheduleCreateTransactionBody.class));
+                                put(
+                                        ScheduleSign,
+                                        new BodySetter<>(ScheduleSignTransactionBody.class));
+                                put(
+                                        ScheduleDelete,
+                                        new BodySetter<>(ScheduleDeleteTransactionBody.class));
+                                put(Freeze, new BodySetter<>(FreezeTransactionBody.class));
+                                put(
+                                        ConsensusCreateTopic,
+                                        new BodySetter<>(
+                                                ConsensusCreateTopicTransactionBody.class));
+                                put(
+                                        ConsensusUpdateTopic,
+                                        new BodySetter<>(
+                                                ConsensusUpdateTopicTransactionBody.class));
+                                put(
+                                        ConsensusDeleteTopic,
+                                        new BodySetter<>(
+                                                ConsensusDeleteTopicTransactionBody.class));
+                                put(
+                                        ConsensusSubmitMessage,
+                                        new BodySetter<>(
+                                                ConsensusSubmitMessageTransactionBody.class));
+                                put(UncheckedSubmit, new BodySetter<>(UncheckedSubmitBody.class));
+                                put(
+                                        TokenFeeScheduleUpdate,
+                                        new BodySetter<>(
+                                                TokenFeeScheduleUpdateTransactionBody.class));
+                                put(UtilPrng, new BodySetter<>(UtilPrngTransactionBody.class));
+                                put(
+                                        CryptoApproveAllowance,
+                                        new BodySetter<>(
+                                                CryptoApproveAllowanceTransactionBody.class));
+                            }
+                        };
 
         setters.forEach(
                 (function, setter) -> {
@@ -1237,18 +1235,16 @@ class MiscUtilsTest {
 
     @Test
     void sentinelDetectedCorrectly() {
-        assertFalse(MiscUtils.designatesAccountRemoval(AccountID.newBuilder()
-                .setShardNum(1L)
-                .build()));
-        assertFalse(MiscUtils.designatesAccountRemoval(AccountID.newBuilder()
-                .setRealmNum(1L)
-                .build()));
-        assertFalse(MiscUtils.designatesAccountRemoval(AccountID.newBuilder()
-                .setAccountNum(1L)
-                .build()));
-        assertFalse(MiscUtils.designatesAccountRemoval(AccountID.newBuilder()
-                .setAlias(ByteString.copyFromUtf8("abcd"))
-                .build()));
+        assertFalse(
+                MiscUtils.designatesAccountRemoval(AccountID.newBuilder().setShardNum(1L).build()));
+        assertFalse(
+                MiscUtils.designatesAccountRemoval(AccountID.newBuilder().setRealmNum(1L).build()));
+        assertFalse(
+                MiscUtils.designatesAccountRemoval(
+                        AccountID.newBuilder().setAccountNum(1L).build()));
+        assertFalse(
+                MiscUtils.designatesAccountRemoval(
+                        AccountID.newBuilder().setAlias(ByteString.copyFromUtf8("abcd")).build()));
     }
 
     public static String byteArrayToBinaryString(byte[] bytes) {

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/services/utils/MiscUtilsTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/services/utils/MiscUtilsTest.java
@@ -124,6 +124,7 @@ import com.swirlds.common.system.address.Address;
 import com.swirlds.common.system.address.AddressBook;
 import com.swirlds.fcqueue.FCQueue;
 import com.swirlds.merkle.map.MerkleMap;
+
 import java.lang.reflect.Method;
 import java.math.BigInteger;
 import java.nio.ByteBuffer;
@@ -135,6 +136,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.BiConsumer;
 import java.util.stream.Stream;
+
 import org.apache.commons.codec.DecoderException;
 import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes;
@@ -159,7 +161,8 @@ class MiscUtilsTest {
     void canRunWithLoggedDuration() {
         final var mockLogger = mock(Logger.class);
         final var desc = "nothing";
-        MiscUtils.withLoggedDuration(() -> {}, mockLogger, desc);
+        MiscUtils.withLoggedDuration(() -> {
+        }, mockLogger, desc);
         verify(mockLogger).info("Starting {}", desc);
         verify(mockLogger).info("Done with {} in {}ms", desc, 0L);
     }
@@ -177,8 +180,7 @@ class MiscUtilsTest {
     void forEachDropInWorksAsExpected() {
         // setup:
         final MerkleMap<FcLong, KeyedMerkleLong<FcLong>> testMm = new MerkleMap<>();
-        @SuppressWarnings("unchecked")
-        final BiConsumer<FcLong, KeyedMerkleLong<FcLong>> mockConsumer =
+        @SuppressWarnings("unchecked") final BiConsumer<FcLong, KeyedMerkleLong<FcLong>> mockConsumer =
                 BDDMockito.mock(BiConsumer.class);
         // and:
         final var key1 = new FcLong(1L);
@@ -244,9 +246,9 @@ class MiscUtilsTest {
     void asFcKeyReturnsEmptyOnInvalidKey() {
         assertTrue(
                 asUsableFcKey(
-                                Key.newBuilder()
-                                        .setEd25519(ByteString.copyFrom("1".getBytes()))
-                                        .build())
+                        Key.newBuilder()
+                                .setEd25519(ByteString.copyFrom("1".getBytes()))
+                                .build())
                         .isEmpty());
     }
 
@@ -400,120 +402,120 @@ class MiscUtilsTest {
     @Test
     void getExpectedOrdinaryTxn() {
         final Map<
-                        String,
-                        BodySetter<
-                                ? extends GeneratedMessageV3, SchedulableTransactionBody.Builder>>
+                String,
+                BodySetter<
+                        ? extends GeneratedMessageV3, SchedulableTransactionBody.Builder>>
                 setters =
-                        new HashMap<>() {
-                            {
-                                put(
-                                        "ContractCall",
-                                        new BodySetter<>(ContractCallTransactionBody.class));
-                                put(
-                                        "ContractCreateInstance",
-                                        new BodySetter<>(ContractCreateTransactionBody.class));
-                                put(
-                                        "ContractUpdateInstance",
-                                        new BodySetter<>(ContractUpdateTransactionBody.class));
-                                put(
-                                        "ContractDeleteInstance",
-                                        new BodySetter<>(ContractDeleteTransactionBody.class));
-                                put(
-                                        "CryptoCreateAccount",
-                                        new BodySetter<>(CryptoCreateTransactionBody.class));
-                                put(
-                                        "CryptoDelete",
-                                        new BodySetter<>(CryptoDeleteTransactionBody.class));
-                                put(
-                                        "CryptoTransfer",
-                                        new BodySetter<>(CryptoTransferTransactionBody.class));
-                                put(
-                                        "CryptoUpdateAccount",
-                                        new BodySetter<>(CryptoUpdateTransactionBody.class));
-                                put(
-                                        "FileAppend",
-                                        new BodySetter<>(FileAppendTransactionBody.class));
-                                put(
-                                        "FileCreate",
-                                        new BodySetter<>(FileCreateTransactionBody.class));
-                                put(
-                                        "FileDelete",
-                                        new BodySetter<>(FileDeleteTransactionBody.class));
-                                put(
-                                        "FileUpdate",
-                                        new BodySetter<>(FileUpdateTransactionBody.class));
-                                put(
-                                        "SystemDelete",
-                                        new BodySetter<>(SystemDeleteTransactionBody.class));
-                                put(
-                                        "SystemUndelete",
-                                        new BodySetter<>(SystemUndeleteTransactionBody.class));
-                                put("Freeze", new BodySetter<>(FreezeTransactionBody.class));
-                                put(
-                                        "ConsensusCreateTopic",
-                                        new BodySetter<>(
-                                                ConsensusCreateTopicTransactionBody.class));
-                                put(
-                                        "ConsensusUpdateTopic",
-                                        new BodySetter<>(
-                                                ConsensusUpdateTopicTransactionBody.class));
-                                put(
-                                        "ConsensusDeleteTopic",
-                                        new BodySetter<>(
-                                                ConsensusDeleteTopicTransactionBody.class));
-                                put(
-                                        "ConsensusSubmitMessage",
-                                        new BodySetter<>(
-                                                ConsensusSubmitMessageTransactionBody.class));
-                                put(
-                                        "TokenCreation",
-                                        new BodySetter<>(TokenCreateTransactionBody.class));
-                                put(
-                                        "TokenFreeze",
-                                        new BodySetter<>(TokenFreezeAccountTransactionBody.class));
-                                put(
-                                        "TokenUnfreeze",
-                                        new BodySetter<>(
-                                                TokenUnfreezeAccountTransactionBody.class));
-                                put(
-                                        "TokenGrantKyc",
-                                        new BodySetter<>(TokenGrantKycTransactionBody.class));
-                                put(
-                                        "TokenRevokeKyc",
-                                        new BodySetter<>(TokenRevokeKycTransactionBody.class));
-                                put(
-                                        "TokenDeletion",
-                                        new BodySetter<>(TokenDeleteTransactionBody.class));
-                                put(
-                                        "TokenUpdate",
-                                        new BodySetter<>(TokenUpdateTransactionBody.class));
-                                put("TokenMint", new BodySetter<>(TokenMintTransactionBody.class));
-                                put("TokenBurn", new BodySetter<>(TokenBurnTransactionBody.class));
-                                put(
-                                        "TokenWipe",
-                                        new BodySetter<>(TokenWipeAccountTransactionBody.class));
-                                put(
-                                        "TokenAssociate",
-                                        new BodySetter<>(TokenAssociateTransactionBody.class));
-                                put(
-                                        "TokenDissociate",
-                                        new BodySetter<>(TokenDissociateTransactionBody.class));
-                                put(
-                                        "TokenUnpause",
-                                        new BodySetter<>(TokenUnpauseTransactionBody.class));
-                                put(
-                                        "TokenPause",
-                                        new BodySetter<>(TokenPauseTransactionBody.class));
-                                put(
-                                        "ScheduleDelete",
-                                        new BodySetter<>(ScheduleDeleteTransactionBody.class));
-                                put("UtilPrng", new BodySetter<>(UtilPrngTransactionBody.class));
-                                put(
-                                        "CryptoApproveAllowance",
-                                        new BodySetter<>(
-                                                CryptoApproveAllowanceTransactionBody.class));
-                            }
-                        };
+                new HashMap<>() {
+                    {
+                        put(
+                                "ContractCall",
+                                new BodySetter<>(ContractCallTransactionBody.class));
+                        put(
+                                "ContractCreateInstance",
+                                new BodySetter<>(ContractCreateTransactionBody.class));
+                        put(
+                                "ContractUpdateInstance",
+                                new BodySetter<>(ContractUpdateTransactionBody.class));
+                        put(
+                                "ContractDeleteInstance",
+                                new BodySetter<>(ContractDeleteTransactionBody.class));
+                        put(
+                                "CryptoCreateAccount",
+                                new BodySetter<>(CryptoCreateTransactionBody.class));
+                        put(
+                                "CryptoDelete",
+                                new BodySetter<>(CryptoDeleteTransactionBody.class));
+                        put(
+                                "CryptoTransfer",
+                                new BodySetter<>(CryptoTransferTransactionBody.class));
+                        put(
+                                "CryptoUpdateAccount",
+                                new BodySetter<>(CryptoUpdateTransactionBody.class));
+                        put(
+                                "FileAppend",
+                                new BodySetter<>(FileAppendTransactionBody.class));
+                        put(
+                                "FileCreate",
+                                new BodySetter<>(FileCreateTransactionBody.class));
+                        put(
+                                "FileDelete",
+                                new BodySetter<>(FileDeleteTransactionBody.class));
+                        put(
+                                "FileUpdate",
+                                new BodySetter<>(FileUpdateTransactionBody.class));
+                        put(
+                                "SystemDelete",
+                                new BodySetter<>(SystemDeleteTransactionBody.class));
+                        put(
+                                "SystemUndelete",
+                                new BodySetter<>(SystemUndeleteTransactionBody.class));
+                        put("Freeze", new BodySetter<>(FreezeTransactionBody.class));
+                        put(
+                                "ConsensusCreateTopic",
+                                new BodySetter<>(
+                                        ConsensusCreateTopicTransactionBody.class));
+                        put(
+                                "ConsensusUpdateTopic",
+                                new BodySetter<>(
+                                        ConsensusUpdateTopicTransactionBody.class));
+                        put(
+                                "ConsensusDeleteTopic",
+                                new BodySetter<>(
+                                        ConsensusDeleteTopicTransactionBody.class));
+                        put(
+                                "ConsensusSubmitMessage",
+                                new BodySetter<>(
+                                        ConsensusSubmitMessageTransactionBody.class));
+                        put(
+                                "TokenCreation",
+                                new BodySetter<>(TokenCreateTransactionBody.class));
+                        put(
+                                "TokenFreeze",
+                                new BodySetter<>(TokenFreezeAccountTransactionBody.class));
+                        put(
+                                "TokenUnfreeze",
+                                new BodySetter<>(
+                                        TokenUnfreezeAccountTransactionBody.class));
+                        put(
+                                "TokenGrantKyc",
+                                new BodySetter<>(TokenGrantKycTransactionBody.class));
+                        put(
+                                "TokenRevokeKyc",
+                                new BodySetter<>(TokenRevokeKycTransactionBody.class));
+                        put(
+                                "TokenDeletion",
+                                new BodySetter<>(TokenDeleteTransactionBody.class));
+                        put(
+                                "TokenUpdate",
+                                new BodySetter<>(TokenUpdateTransactionBody.class));
+                        put("TokenMint", new BodySetter<>(TokenMintTransactionBody.class));
+                        put("TokenBurn", new BodySetter<>(TokenBurnTransactionBody.class));
+                        put(
+                                "TokenWipe",
+                                new BodySetter<>(TokenWipeAccountTransactionBody.class));
+                        put(
+                                "TokenAssociate",
+                                new BodySetter<>(TokenAssociateTransactionBody.class));
+                        put(
+                                "TokenDissociate",
+                                new BodySetter<>(TokenDissociateTransactionBody.class));
+                        put(
+                                "TokenUnpause",
+                                new BodySetter<>(TokenUnpauseTransactionBody.class));
+                        put(
+                                "TokenPause",
+                                new BodySetter<>(TokenPauseTransactionBody.class));
+                        put(
+                                "ScheduleDelete",
+                                new BodySetter<>(ScheduleDeleteTransactionBody.class));
+                        put("UtilPrng", new BodySetter<>(UtilPrngTransactionBody.class));
+                        put(
+                                "CryptoApproveAllowance",
+                                new BodySetter<>(
+                                        CryptoApproveAllowanceTransactionBody.class));
+                    }
+                };
 
         setters.forEach(
                 (bodyType, setter) -> {
@@ -556,137 +558,137 @@ class MiscUtilsTest {
     void getExpectedTxnStat() {
         final Map<String, BodySetter<? extends GeneratedMessageV3, TransactionBody.Builder>>
                 setters =
-                        new HashMap<>() {
-                            {
-                                put(
-                                        CryptoController.CRYPTO_CREATE_METRIC,
-                                        new BodySetter<>(CryptoCreateTransactionBody.class));
-                                put(
-                                        CryptoController.CRYPTO_UPDATE_METRIC,
-                                        new BodySetter<>(CryptoUpdateTransactionBody.class));
-                                put(
-                                        CryptoController.CRYPTO_TRANSFER_METRIC,
-                                        new BodySetter<>(CryptoTransferTransactionBody.class));
-                                put(
-                                        CryptoController.CRYPTO_DELETE_METRIC,
-                                        new BodySetter<>(CryptoDeleteTransactionBody.class));
-                                put(
-                                        ContractController.CREATE_CONTRACT_METRIC,
-                                        new BodySetter<>(ContractCreateTransactionBody.class));
-                                put(
-                                        ContractController.CALL_CONTRACT_METRIC,
-                                        new BodySetter<>(ContractCallTransactionBody.class));
-                                put(
-                                        ContractController.UPDATE_CONTRACT_METRIC,
-                                        new BodySetter<>(ContractUpdateTransactionBody.class));
-                                put(
-                                        ContractController.DELETE_CONTRACT_METRIC,
-                                        new BodySetter<>(ContractDeleteTransactionBody.class));
-                                put(
-                                        CryptoController.ADD_LIVE_HASH_METRIC,
-                                        new BodySetter<>(CryptoAddLiveHashTransactionBody.class));
-                                put(
-                                        CryptoController.DELETE_LIVE_HASH_METRIC,
-                                        new BodySetter<>(
-                                                CryptoDeleteLiveHashTransactionBody.class));
-                                put(
-                                        FileController.CREATE_FILE_METRIC,
-                                        new BodySetter<>(FileCreateTransactionBody.class));
-                                put(
-                                        FileController.FILE_APPEND_METRIC,
-                                        new BodySetter<>(FileAppendTransactionBody.class));
-                                put(
-                                        FileController.UPDATE_FILE_METRIC,
-                                        new BodySetter<>(FileUpdateTransactionBody.class));
-                                put(
-                                        FileController.DELETE_FILE_METRIC,
-                                        new BodySetter<>(FileDeleteTransactionBody.class));
-                                put(
-                                        FreezeController.FREEZE_METRIC,
-                                        new BodySetter<>(FreezeTransactionBody.class));
-                                put(
-                                        ServicesStatsConfig.SYSTEM_DELETE_METRIC,
-                                        new BodySetter<>(SystemDeleteTransactionBody.class));
-                                put(
-                                        ServicesStatsConfig.SYSTEM_UNDELETE_METRIC,
-                                        new BodySetter<>(SystemUndeleteTransactionBody.class));
-                                put(
-                                        ConsensusController.CREATE_TOPIC_METRIC,
-                                        new BodySetter<>(
-                                                ConsensusCreateTopicTransactionBody.class));
-                                put(
-                                        ConsensusController.UPDATE_TOPIC_METRIC,
-                                        new BodySetter<>(
-                                                ConsensusUpdateTopicTransactionBody.class));
-                                put(
-                                        ConsensusController.DELETE_TOPIC_METRIC,
-                                        new BodySetter<>(
-                                                ConsensusDeleteTopicTransactionBody.class));
-                                put(
-                                        ConsensusController.SUBMIT_MESSAGE_METRIC,
-                                        new BodySetter<>(
-                                                ConsensusSubmitMessageTransactionBody.class));
-                                put(
-                                        TOKEN_CREATE_METRIC,
-                                        new BodySetter<>(TokenCreateTransactionBody.class));
-                                put(
-                                        TOKEN_FREEZE_METRIC,
-                                        new BodySetter<>(TokenFreezeAccountTransactionBody.class));
-                                put(
-                                        TOKEN_UNFREEZE_METRIC,
-                                        new BodySetter<>(
-                                                TokenUnfreezeAccountTransactionBody.class));
-                                put(
-                                        TOKEN_GRANT_KYC_METRIC,
-                                        new BodySetter<>(TokenGrantKycTransactionBody.class));
-                                put(
-                                        TOKEN_REVOKE_KYC_METRIC,
-                                        new BodySetter<>(TokenRevokeKycTransactionBody.class));
-                                put(
-                                        TOKEN_DELETE_METRIC,
-                                        new BodySetter<>(TokenDeleteTransactionBody.class));
-                                put(
-                                        TOKEN_UPDATE_METRIC,
-                                        new BodySetter<>(TokenUpdateTransactionBody.class));
-                                put(
-                                        TOKEN_MINT_METRIC,
-                                        new BodySetter<>(TokenMintTransactionBody.class));
-                                put(
-                                        TOKEN_BURN_METRIC,
-                                        new BodySetter<>(TokenBurnTransactionBody.class));
-                                put(
-                                        TOKEN_WIPE_ACCOUNT_METRIC,
-                                        new BodySetter<>(TokenWipeAccountTransactionBody.class));
-                                put(
-                                        TOKEN_ASSOCIATE_METRIC,
-                                        new BodySetter<>(TokenAssociateTransactionBody.class));
-                                put(
-                                        TOKEN_DISSOCIATE_METRIC,
-                                        new BodySetter<>(TokenDissociateTransactionBody.class));
-                                put(
-                                        TOKEN_FEE_SCHEDULE_UPDATE_METRIC,
-                                        new BodySetter<>(
-                                                TokenFeeScheduleUpdateTransactionBody.class));
-                                put(
-                                        TOKEN_UNPAUSE_METRIC,
-                                        new BodySetter<>(TokenUnpauseTransactionBody.class));
-                                put(
-                                        TOKEN_PAUSE_METRIC,
-                                        new BodySetter<>(TokenPauseTransactionBody.class));
-                                put(
-                                        SCHEDULE_CREATE_METRIC,
-                                        new BodySetter<>(ScheduleCreateTransactionBody.class));
-                                put(
-                                        SCHEDULE_SIGN_METRIC,
-                                        new BodySetter<>(ScheduleSignTransactionBody.class));
-                                put(
-                                        SCHEDULE_DELETE_METRIC,
-                                        new BodySetter<>(ScheduleDeleteTransactionBody.class));
-                                put(
-                                        UTIL_PRNG_METRIC,
-                                        new BodySetter<>(UtilPrngTransactionBody.class));
-                            }
-                        };
+                new HashMap<>() {
+                    {
+                        put(
+                                CryptoController.CRYPTO_CREATE_METRIC,
+                                new BodySetter<>(CryptoCreateTransactionBody.class));
+                        put(
+                                CryptoController.CRYPTO_UPDATE_METRIC,
+                                new BodySetter<>(CryptoUpdateTransactionBody.class));
+                        put(
+                                CryptoController.CRYPTO_TRANSFER_METRIC,
+                                new BodySetter<>(CryptoTransferTransactionBody.class));
+                        put(
+                                CryptoController.CRYPTO_DELETE_METRIC,
+                                new BodySetter<>(CryptoDeleteTransactionBody.class));
+                        put(
+                                ContractController.CREATE_CONTRACT_METRIC,
+                                new BodySetter<>(ContractCreateTransactionBody.class));
+                        put(
+                                ContractController.CALL_CONTRACT_METRIC,
+                                new BodySetter<>(ContractCallTransactionBody.class));
+                        put(
+                                ContractController.UPDATE_CONTRACT_METRIC,
+                                new BodySetter<>(ContractUpdateTransactionBody.class));
+                        put(
+                                ContractController.DELETE_CONTRACT_METRIC,
+                                new BodySetter<>(ContractDeleteTransactionBody.class));
+                        put(
+                                CryptoController.ADD_LIVE_HASH_METRIC,
+                                new BodySetter<>(CryptoAddLiveHashTransactionBody.class));
+                        put(
+                                CryptoController.DELETE_LIVE_HASH_METRIC,
+                                new BodySetter<>(
+                                        CryptoDeleteLiveHashTransactionBody.class));
+                        put(
+                                FileController.CREATE_FILE_METRIC,
+                                new BodySetter<>(FileCreateTransactionBody.class));
+                        put(
+                                FileController.FILE_APPEND_METRIC,
+                                new BodySetter<>(FileAppendTransactionBody.class));
+                        put(
+                                FileController.UPDATE_FILE_METRIC,
+                                new BodySetter<>(FileUpdateTransactionBody.class));
+                        put(
+                                FileController.DELETE_FILE_METRIC,
+                                new BodySetter<>(FileDeleteTransactionBody.class));
+                        put(
+                                FreezeController.FREEZE_METRIC,
+                                new BodySetter<>(FreezeTransactionBody.class));
+                        put(
+                                ServicesStatsConfig.SYSTEM_DELETE_METRIC,
+                                new BodySetter<>(SystemDeleteTransactionBody.class));
+                        put(
+                                ServicesStatsConfig.SYSTEM_UNDELETE_METRIC,
+                                new BodySetter<>(SystemUndeleteTransactionBody.class));
+                        put(
+                                ConsensusController.CREATE_TOPIC_METRIC,
+                                new BodySetter<>(
+                                        ConsensusCreateTopicTransactionBody.class));
+                        put(
+                                ConsensusController.UPDATE_TOPIC_METRIC,
+                                new BodySetter<>(
+                                        ConsensusUpdateTopicTransactionBody.class));
+                        put(
+                                ConsensusController.DELETE_TOPIC_METRIC,
+                                new BodySetter<>(
+                                        ConsensusDeleteTopicTransactionBody.class));
+                        put(
+                                ConsensusController.SUBMIT_MESSAGE_METRIC,
+                                new BodySetter<>(
+                                        ConsensusSubmitMessageTransactionBody.class));
+                        put(
+                                TOKEN_CREATE_METRIC,
+                                new BodySetter<>(TokenCreateTransactionBody.class));
+                        put(
+                                TOKEN_FREEZE_METRIC,
+                                new BodySetter<>(TokenFreezeAccountTransactionBody.class));
+                        put(
+                                TOKEN_UNFREEZE_METRIC,
+                                new BodySetter<>(
+                                        TokenUnfreezeAccountTransactionBody.class));
+                        put(
+                                TOKEN_GRANT_KYC_METRIC,
+                                new BodySetter<>(TokenGrantKycTransactionBody.class));
+                        put(
+                                TOKEN_REVOKE_KYC_METRIC,
+                                new BodySetter<>(TokenRevokeKycTransactionBody.class));
+                        put(
+                                TOKEN_DELETE_METRIC,
+                                new BodySetter<>(TokenDeleteTransactionBody.class));
+                        put(
+                                TOKEN_UPDATE_METRIC,
+                                new BodySetter<>(TokenUpdateTransactionBody.class));
+                        put(
+                                TOKEN_MINT_METRIC,
+                                new BodySetter<>(TokenMintTransactionBody.class));
+                        put(
+                                TOKEN_BURN_METRIC,
+                                new BodySetter<>(TokenBurnTransactionBody.class));
+                        put(
+                                TOKEN_WIPE_ACCOUNT_METRIC,
+                                new BodySetter<>(TokenWipeAccountTransactionBody.class));
+                        put(
+                                TOKEN_ASSOCIATE_METRIC,
+                                new BodySetter<>(TokenAssociateTransactionBody.class));
+                        put(
+                                TOKEN_DISSOCIATE_METRIC,
+                                new BodySetter<>(TokenDissociateTransactionBody.class));
+                        put(
+                                TOKEN_FEE_SCHEDULE_UPDATE_METRIC,
+                                new BodySetter<>(
+                                        TokenFeeScheduleUpdateTransactionBody.class));
+                        put(
+                                TOKEN_UNPAUSE_METRIC,
+                                new BodySetter<>(TokenUnpauseTransactionBody.class));
+                        put(
+                                TOKEN_PAUSE_METRIC,
+                                new BodySetter<>(TokenPauseTransactionBody.class));
+                        put(
+                                SCHEDULE_CREATE_METRIC,
+                                new BodySetter<>(ScheduleCreateTransactionBody.class));
+                        put(
+                                SCHEDULE_SIGN_METRIC,
+                                new BodySetter<>(ScheduleSignTransactionBody.class));
+                        put(
+                                SCHEDULE_DELETE_METRIC,
+                                new BodySetter<>(ScheduleDeleteTransactionBody.class));
+                        put(
+                                UTIL_PRNG_METRIC,
+                                new BodySetter<>(UtilPrngTransactionBody.class));
+                    }
+                };
 
         setters.forEach(
                 (stat, setter) -> {
@@ -707,54 +709,54 @@ class MiscUtilsTest {
     void getsExpectedQueryFunctionality() {
         final Map<HederaFunctionality, BodySetter<? extends GeneratedMessageV3, Query.Builder>>
                 setters =
-                        new HashMap<>() {
-                            {
-                                put(
-                                        GetVersionInfo,
-                                        new BodySetter<>(NetworkGetVersionInfoQuery.class));
-                                put(GetByKey, new BodySetter<>(GetByKeyQuery.class));
-                                put(
-                                        ConsensusGetTopicInfo,
-                                        new BodySetter<>(ConsensusGetTopicInfoQuery.class));
-                                put(GetBySolidityID, new BodySetter<>(GetBySolidityIDQuery.class));
-                                put(
-                                        ContractCallLocal,
-                                        new BodySetter<>(ContractCallLocalQuery.class));
-                                put(ContractGetInfo, new BodySetter<>(ContractGetInfoQuery.class));
-                                put(
-                                        ContractGetBytecode,
-                                        new BodySetter<>(ContractGetBytecodeQuery.class));
-                                put(
-                                        ContractGetRecords,
-                                        new BodySetter<>(ContractGetRecordsQuery.class));
-                                put(
-                                        CryptoGetAccountBalance,
-                                        new BodySetter<>(CryptoGetAccountBalanceQuery.class));
-                                put(
-                                        CryptoGetAccountRecords,
-                                        new BodySetter<>(CryptoGetAccountRecordsQuery.class));
-                                put(CryptoGetInfo, new BodySetter<>(CryptoGetInfoQuery.class));
-                                put(
-                                        CryptoGetLiveHash,
-                                        new BodySetter<>(CryptoGetLiveHashQuery.class));
-                                put(FileGetContents, new BodySetter<>(FileGetContentsQuery.class));
-                                put(FileGetInfo, new BodySetter<>(FileGetInfoQuery.class));
-                                put(
-                                        TransactionGetReceipt,
-                                        new BodySetter<>(TransactionGetReceiptQuery.class));
-                                put(
-                                        TransactionGetRecord,
-                                        new BodySetter<>(TransactionGetRecordQuery.class));
-                                put(TokenGetInfo, new BodySetter<>(TokenGetInfoQuery.class));
-                                put(ScheduleGetInfo, new BodySetter<>(ScheduleGetInfoQuery.class));
-                                put(
-                                        NetworkGetExecutionTime,
-                                        new BodySetter<>(NetworkGetExecutionTimeQuery.class));
-                                put(
-                                        GetAccountDetails,
-                                        new BodySetter<>(GetAccountDetailsQuery.class));
-                            }
-                        };
+                new HashMap<>() {
+                    {
+                        put(
+                                GetVersionInfo,
+                                new BodySetter<>(NetworkGetVersionInfoQuery.class));
+                        put(GetByKey, new BodySetter<>(GetByKeyQuery.class));
+                        put(
+                                ConsensusGetTopicInfo,
+                                new BodySetter<>(ConsensusGetTopicInfoQuery.class));
+                        put(GetBySolidityID, new BodySetter<>(GetBySolidityIDQuery.class));
+                        put(
+                                ContractCallLocal,
+                                new BodySetter<>(ContractCallLocalQuery.class));
+                        put(ContractGetInfo, new BodySetter<>(ContractGetInfoQuery.class));
+                        put(
+                                ContractGetBytecode,
+                                new BodySetter<>(ContractGetBytecodeQuery.class));
+                        put(
+                                ContractGetRecords,
+                                new BodySetter<>(ContractGetRecordsQuery.class));
+                        put(
+                                CryptoGetAccountBalance,
+                                new BodySetter<>(CryptoGetAccountBalanceQuery.class));
+                        put(
+                                CryptoGetAccountRecords,
+                                new BodySetter<>(CryptoGetAccountRecordsQuery.class));
+                        put(CryptoGetInfo, new BodySetter<>(CryptoGetInfoQuery.class));
+                        put(
+                                CryptoGetLiveHash,
+                                new BodySetter<>(CryptoGetLiveHashQuery.class));
+                        put(FileGetContents, new BodySetter<>(FileGetContentsQuery.class));
+                        put(FileGetInfo, new BodySetter<>(FileGetInfoQuery.class));
+                        put(
+                                TransactionGetReceipt,
+                                new BodySetter<>(TransactionGetReceiptQuery.class));
+                        put(
+                                TransactionGetRecord,
+                                new BodySetter<>(TransactionGetRecordQuery.class));
+                        put(TokenGetInfo, new BodySetter<>(TokenGetInfoQuery.class));
+                        put(ScheduleGetInfo, new BodySetter<>(ScheduleGetInfoQuery.class));
+                        put(
+                                NetworkGetExecutionTime,
+                                new BodySetter<>(NetworkGetExecutionTimeQuery.class));
+                        put(
+                                GetAccountDetails,
+                                new BodySetter<>(GetAccountDetailsQuery.class));
+                    }
+                };
 
         setters.forEach(
                 (function, setter) -> {
@@ -811,130 +813,130 @@ class MiscUtilsTest {
     @Test
     void getsExpectedTxnFunctionality() {
         final Map<
-                        HederaFunctionality,
-                        BodySetter<? extends GeneratedMessageV3, TransactionBody.Builder>>
+                HederaFunctionality,
+                BodySetter<? extends GeneratedMessageV3, TransactionBody.Builder>>
                 setters =
-                        new HashMap<>() {
-                            {
-                                put(
-                                        SystemDelete,
-                                        new BodySetter<>(SystemDeleteTransactionBody.class));
-                                put(
-                                        SystemUndelete,
-                                        new BodySetter<>(SystemUndeleteTransactionBody.class));
-                                put(
-                                        ContractCall,
-                                        new BodySetter<>(ContractCallTransactionBody.class));
-                                put(
-                                        ContractCreate,
-                                        new BodySetter<>(ContractCreateTransactionBody.class));
-                                put(
-                                        EthereumTransaction,
-                                        new BodySetter<>(EthereumTransactionBody.class));
-                                put(
-                                        ContractUpdate,
-                                        new BodySetter<>(ContractUpdateTransactionBody.class));
-                                put(
-                                        CryptoAddLiveHash,
-                                        new BodySetter<>(CryptoAddLiveHashTransactionBody.class));
-                                put(
-                                        CryptoCreate,
-                                        new BodySetter<>(CryptoCreateTransactionBody.class));
-                                put(
-                                        CryptoDelete,
-                                        new BodySetter<>(CryptoDeleteTransactionBody.class));
-                                put(
-                                        CryptoDeleteLiveHash,
-                                        new BodySetter<>(
-                                                CryptoDeleteLiveHashTransactionBody.class));
-                                put(
-                                        CryptoTransfer,
-                                        new BodySetter<>(CryptoTransferTransactionBody.class));
-                                put(
-                                        CryptoUpdate,
-                                        new BodySetter<>(CryptoUpdateTransactionBody.class));
-                                put(FileAppend, new BodySetter<>(FileAppendTransactionBody.class));
-                                put(FileCreate, new BodySetter<>(FileCreateTransactionBody.class));
-                                put(FileDelete, new BodySetter<>(FileDeleteTransactionBody.class));
-                                put(FileUpdate, new BodySetter<>(FileUpdateTransactionBody.class));
-                                put(
-                                        ContractDelete,
-                                        new BodySetter<>(ContractDeleteTransactionBody.class));
-                                put(
-                                        TokenCreate,
-                                        new BodySetter<>(TokenCreateTransactionBody.class));
-                                put(
-                                        TokenFreezeAccount,
-                                        new BodySetter<>(TokenFreezeAccountTransactionBody.class));
-                                put(
-                                        TokenUnfreezeAccount,
-                                        new BodySetter<>(
-                                                TokenUnfreezeAccountTransactionBody.class));
-                                put(
-                                        TokenGrantKycToAccount,
-                                        new BodySetter<>(TokenGrantKycTransactionBody.class));
-                                put(
-                                        TokenRevokeKycFromAccount,
-                                        new BodySetter<>(TokenRevokeKycTransactionBody.class));
-                                put(
-                                        TokenDelete,
-                                        new BodySetter<>(TokenDeleteTransactionBody.class));
-                                put(
-                                        TokenUpdate,
-                                        new BodySetter<>(TokenUpdateTransactionBody.class));
-                                put(TokenMint, new BodySetter<>(TokenMintTransactionBody.class));
-                                put(TokenBurn, new BodySetter<>(TokenBurnTransactionBody.class));
-                                put(
-                                        TokenAccountWipe,
-                                        new BodySetter<>(TokenWipeAccountTransactionBody.class));
-                                put(
-                                        TokenAssociateToAccount,
-                                        new BodySetter<>(TokenAssociateTransactionBody.class));
-                                put(
-                                        TokenDissociateFromAccount,
-                                        new BodySetter<>(TokenDissociateTransactionBody.class));
-                                put(
-                                        TokenUnpause,
-                                        new BodySetter<>(TokenUnpauseTransactionBody.class));
-                                put(TokenPause, new BodySetter<>(TokenPauseTransactionBody.class));
-                                put(
-                                        ScheduleCreate,
-                                        new BodySetter<>(ScheduleCreateTransactionBody.class));
-                                put(
-                                        ScheduleSign,
-                                        new BodySetter<>(ScheduleSignTransactionBody.class));
-                                put(
-                                        ScheduleDelete,
-                                        new BodySetter<>(ScheduleDeleteTransactionBody.class));
-                                put(Freeze, new BodySetter<>(FreezeTransactionBody.class));
-                                put(
-                                        ConsensusCreateTopic,
-                                        new BodySetter<>(
-                                                ConsensusCreateTopicTransactionBody.class));
-                                put(
-                                        ConsensusUpdateTopic,
-                                        new BodySetter<>(
-                                                ConsensusUpdateTopicTransactionBody.class));
-                                put(
-                                        ConsensusDeleteTopic,
-                                        new BodySetter<>(
-                                                ConsensusDeleteTopicTransactionBody.class));
-                                put(
-                                        ConsensusSubmitMessage,
-                                        new BodySetter<>(
-                                                ConsensusSubmitMessageTransactionBody.class));
-                                put(UncheckedSubmit, new BodySetter<>(UncheckedSubmitBody.class));
-                                put(
-                                        TokenFeeScheduleUpdate,
-                                        new BodySetter<>(
-                                                TokenFeeScheduleUpdateTransactionBody.class));
-                                put(UtilPrng, new BodySetter<>(UtilPrngTransactionBody.class));
-                                put(
-                                        CryptoApproveAllowance,
-                                        new BodySetter<>(
-                                                CryptoApproveAllowanceTransactionBody.class));
-                            }
-                        };
+                new HashMap<>() {
+                    {
+                        put(
+                                SystemDelete,
+                                new BodySetter<>(SystemDeleteTransactionBody.class));
+                        put(
+                                SystemUndelete,
+                                new BodySetter<>(SystemUndeleteTransactionBody.class));
+                        put(
+                                ContractCall,
+                                new BodySetter<>(ContractCallTransactionBody.class));
+                        put(
+                                ContractCreate,
+                                new BodySetter<>(ContractCreateTransactionBody.class));
+                        put(
+                                EthereumTransaction,
+                                new BodySetter<>(EthereumTransactionBody.class));
+                        put(
+                                ContractUpdate,
+                                new BodySetter<>(ContractUpdateTransactionBody.class));
+                        put(
+                                CryptoAddLiveHash,
+                                new BodySetter<>(CryptoAddLiveHashTransactionBody.class));
+                        put(
+                                CryptoCreate,
+                                new BodySetter<>(CryptoCreateTransactionBody.class));
+                        put(
+                                CryptoDelete,
+                                new BodySetter<>(CryptoDeleteTransactionBody.class));
+                        put(
+                                CryptoDeleteLiveHash,
+                                new BodySetter<>(
+                                        CryptoDeleteLiveHashTransactionBody.class));
+                        put(
+                                CryptoTransfer,
+                                new BodySetter<>(CryptoTransferTransactionBody.class));
+                        put(
+                                CryptoUpdate,
+                                new BodySetter<>(CryptoUpdateTransactionBody.class));
+                        put(FileAppend, new BodySetter<>(FileAppendTransactionBody.class));
+                        put(FileCreate, new BodySetter<>(FileCreateTransactionBody.class));
+                        put(FileDelete, new BodySetter<>(FileDeleteTransactionBody.class));
+                        put(FileUpdate, new BodySetter<>(FileUpdateTransactionBody.class));
+                        put(
+                                ContractDelete,
+                                new BodySetter<>(ContractDeleteTransactionBody.class));
+                        put(
+                                TokenCreate,
+                                new BodySetter<>(TokenCreateTransactionBody.class));
+                        put(
+                                TokenFreezeAccount,
+                                new BodySetter<>(TokenFreezeAccountTransactionBody.class));
+                        put(
+                                TokenUnfreezeAccount,
+                                new BodySetter<>(
+                                        TokenUnfreezeAccountTransactionBody.class));
+                        put(
+                                TokenGrantKycToAccount,
+                                new BodySetter<>(TokenGrantKycTransactionBody.class));
+                        put(
+                                TokenRevokeKycFromAccount,
+                                new BodySetter<>(TokenRevokeKycTransactionBody.class));
+                        put(
+                                TokenDelete,
+                                new BodySetter<>(TokenDeleteTransactionBody.class));
+                        put(
+                                TokenUpdate,
+                                new BodySetter<>(TokenUpdateTransactionBody.class));
+                        put(TokenMint, new BodySetter<>(TokenMintTransactionBody.class));
+                        put(TokenBurn, new BodySetter<>(TokenBurnTransactionBody.class));
+                        put(
+                                TokenAccountWipe,
+                                new BodySetter<>(TokenWipeAccountTransactionBody.class));
+                        put(
+                                TokenAssociateToAccount,
+                                new BodySetter<>(TokenAssociateTransactionBody.class));
+                        put(
+                                TokenDissociateFromAccount,
+                                new BodySetter<>(TokenDissociateTransactionBody.class));
+                        put(
+                                TokenUnpause,
+                                new BodySetter<>(TokenUnpauseTransactionBody.class));
+                        put(TokenPause, new BodySetter<>(TokenPauseTransactionBody.class));
+                        put(
+                                ScheduleCreate,
+                                new BodySetter<>(ScheduleCreateTransactionBody.class));
+                        put(
+                                ScheduleSign,
+                                new BodySetter<>(ScheduleSignTransactionBody.class));
+                        put(
+                                ScheduleDelete,
+                                new BodySetter<>(ScheduleDeleteTransactionBody.class));
+                        put(Freeze, new BodySetter<>(FreezeTransactionBody.class));
+                        put(
+                                ConsensusCreateTopic,
+                                new BodySetter<>(
+                                        ConsensusCreateTopicTransactionBody.class));
+                        put(
+                                ConsensusUpdateTopic,
+                                new BodySetter<>(
+                                        ConsensusUpdateTopicTransactionBody.class));
+                        put(
+                                ConsensusDeleteTopic,
+                                new BodySetter<>(
+                                        ConsensusDeleteTopicTransactionBody.class));
+                        put(
+                                ConsensusSubmitMessage,
+                                new BodySetter<>(
+                                        ConsensusSubmitMessageTransactionBody.class));
+                        put(UncheckedSubmit, new BodySetter<>(UncheckedSubmitBody.class));
+                        put(
+                                TokenFeeScheduleUpdate,
+                                new BodySetter<>(
+                                        TokenFeeScheduleUpdateTransactionBody.class));
+                        put(UtilPrng, new BodySetter<>(UtilPrngTransactionBody.class));
+                        put(
+                                CryptoApproveAllowance,
+                                new BodySetter<>(
+                                        CryptoApproveAllowanceTransactionBody.class));
+                    }
+                };
 
         setters.forEach(
                 (function, setter) -> {
@@ -1231,6 +1233,22 @@ class MiscUtilsTest {
         final var alias = ByteString.copyFrom(ecdsaKeyBytes);
 
         assertThrows(IllegalStateException.class, () -> MiscUtils.asPrimitiveKeyUnchecked(alias));
+    }
+
+    @Test
+    void sentinelDetectedCorrectly() {
+        assertFalse(MiscUtils.designatesAccountRemoval(AccountID.newBuilder()
+                .setShardNum(1L)
+                .build()));
+        assertFalse(MiscUtils.designatesAccountRemoval(AccountID.newBuilder()
+                .setRealmNum(1L)
+                .build()));
+        assertFalse(MiscUtils.designatesAccountRemoval(AccountID.newBuilder()
+                .setAccountNum(1L)
+                .build()));
+        assertFalse(MiscUtils.designatesAccountRemoval(AccountID.newBuilder()
+                .setAlias(ByteString.copyFromUtf8("abcd"))
+                .build()));
     }
 
     public static String byteArrayToBinaryString(byte[] bytes) {

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/test/factories/scenarios/CryptoCreateScenarios.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/test/factories/scenarios/CryptoCreateScenarios.java
@@ -28,6 +28,36 @@ public enum CryptoCreateScenarios implements TxnHandlingScenario {
                     from(newSignedCryptoCreate().receiverSigRequired(false).get()));
         }
     },
+    CRYPTO_CREATE_WITH_AUTO_RENEW_SCENARIO {
+        public PlatformTxnAccessor platformTxn() throws Throwable {
+            return PlatformTxnAccessor.from(
+                    from(
+                            newSignedCryptoCreate()
+                                    .receiverSigRequired(false)
+                                    .newAutoRenewAccount(FIRST_TOKEN_SENDER_ID)
+                                    .get()));
+        }
+    },
+    CRYPTO_CREATE_WITH_MISSING_AUTO_RENEW {
+        public PlatformTxnAccessor platformTxn() throws Throwable {
+            return PlatformTxnAccessor.from(
+                    from(
+                            newSignedCryptoCreate()
+                                    .receiverSigRequired(false)
+                                    .newAutoRenewAccount(MISSING_ACCOUNT_ID)
+                                    .get()));
+        }
+    },
+    CRYPTO_CREATE_WITH_AUTO_RENEW_AND_SIG_REQUIRED_SCENARIO {
+        public PlatformTxnAccessor platformTxn() throws Throwable {
+            return PlatformTxnAccessor.from(
+                    from(
+                            newSignedCryptoCreate()
+                                    .receiverSigRequired(true)
+                                    .newAutoRenewAccount(FIRST_TOKEN_SENDER_ID)
+                                    .get()));
+        }
+    },
     CRYPTO_CREATE_RECEIVER_SIG_SCENARIO {
         public PlatformTxnAccessor platformTxn() throws Throwable {
             return PlatformTxnAccessor.from(

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/test/factories/scenarios/CryptoTransferScenarios.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/test/factories/scenarios/CryptoTransferScenarios.java
@@ -418,6 +418,16 @@ public enum CryptoTransferScenarios implements TxnHandlingScenario {
                                     .get()));
         }
     },
+    TOKEN_TRANSACT_WITH_OWNERSHIP_CHANGE_NO_SIG_REQ_WITH_FALLBACK_WHEN_RECEIVER_IS_TREASURY {
+        @Override
+        public PlatformTxnAccessor platformTxn() throws Throwable {
+            return PlatformTxnAccessor.from(
+                    from(
+                            newSignedCryptoTransfer()
+                                    .changingOwner(ROYALTY_TOKEN_NFT, NO_RECEIVER_SIG, MISC_ACCOUNT)
+                                    .get()));
+        }
+    },
     TOKEN_TRANSACT_WITH_OWNERSHIP_CHANGE_NO_RECEIVER_SIG_REQ_AND_FALLBACK_NOT_TRIGGERED_DUE_TO_HBAR {
         @Override
         public PlatformTxnAccessor platformTxn() throws Throwable {

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/test/factories/scenarios/CryptoUpdateScenarios.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/test/factories/scenarios/CryptoUpdateScenarios.java
@@ -97,6 +97,33 @@ public enum CryptoUpdateScenarios implements TxnHandlingScenario {
                                     .get()));
         }
     },
+    CRYPTO_UPDATE_WITH_NEW_AUTO_RENEW_SCENARIO {
+        public PlatformTxnAccessor platformTxn() throws Throwable {
+            return PlatformTxnAccessor.from(
+                    from(
+                            newSignedCryptoUpdate(MISC_ACCOUNT_ID)
+                                    .newAutoRenewAccount(FIRST_TOKEN_SENDER_ID)
+                                    .get()));
+        }
+    },
+    CRYPTO_UPDATE_DESIGNATING_AUTO_RENEW_REMOVAL_SCENARIO {
+        public PlatformTxnAccessor platformTxn() throws Throwable {
+            return PlatformTxnAccessor.from(
+                    from(
+                            newSignedCryptoUpdate(MISC_ACCOUNT_ID)
+                                    .newAutoRenewAccount(SENTINEL_ID)
+                                    .get()));
+        }
+    },
+    CRYPTO_UPDATE_DESIGNATING_MISSING_AUTO_RENEW_SCENARIO {
+        public PlatformTxnAccessor platformTxn() throws Throwable {
+            return PlatformTxnAccessor.from(
+                    from(
+                            newSignedCryptoUpdate(MISC_ACCOUNT_ID)
+                                    .newAutoRenewAccount(MISSING_ACCOUNT_ID)
+                                    .get()));
+        }
+    },
     CRYPTO_UPDATE_SYS_ACCOUNT_WITH_NEW_KEY_SCENARIO {
         public PlatformTxnAccessor platformTxn() throws Throwable {
             return PlatformTxnAccessor.from(

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/test/factories/scenarios/FileCreateScenarios.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/test/factories/scenarios/FileCreateScenarios.java
@@ -25,5 +25,17 @@ public enum FileCreateScenarios implements TxnHandlingScenario {
         public PlatformTxnAccessor platformTxn() throws Throwable {
             return PlatformTxnAccessor.from(from(newSignedFileCreate().get()));
         }
+    },
+    FILE_CREATE_WITH_AUTO_RENEW_SCENARIO {
+        public PlatformTxnAccessor platformTxn() throws Throwable {
+            return PlatformTxnAccessor.from(
+                    from(newSignedFileCreate().newAutoRenewAccount(FIRST_TOKEN_SENDER_ID).get()));
+        }
+    },
+    FILE_CREATE_WITH_MISSING_AUTO_RENEW_SCENARIO {
+        public PlatformTxnAccessor platformTxn() throws Throwable {
+            return PlatformTxnAccessor.from(
+                    from(newSignedFileCreate().newAutoRenewAccount(MISSING_ACCOUNT_ID).get()));
+        }
     }
 }

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/test/factories/scenarios/FileCreateScenarios.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/test/factories/scenarios/FileCreateScenarios.java
@@ -26,6 +26,13 @@ public enum FileCreateScenarios implements TxnHandlingScenario {
             return PlatformTxnAccessor.from(from(newSignedFileCreate().get()));
         }
     },
+    IMMUTABLE_FILE_CREATE_SCENARIO {
+        public PlatformTxnAccessor platformTxn() throws Throwable {
+            return PlatformTxnAccessor.from(from(newSignedFileCreate()
+                    .immutable()
+                    .get()));
+        }
+    },
     FILE_CREATE_WITH_AUTO_RENEW_SCENARIO {
         public PlatformTxnAccessor platformTxn() throws Throwable {
             return PlatformTxnAccessor.from(

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/test/factories/scenarios/FileCreateScenarios.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/test/factories/scenarios/FileCreateScenarios.java
@@ -28,9 +28,7 @@ public enum FileCreateScenarios implements TxnHandlingScenario {
     },
     IMMUTABLE_FILE_CREATE_SCENARIO {
         public PlatformTxnAccessor platformTxn() throws Throwable {
-            return PlatformTxnAccessor.from(from(newSignedFileCreate()
-                    .immutable()
-                    .get()));
+            return PlatformTxnAccessor.from(from(newSignedFileCreate().immutable().get()));
         }
     },
     FILE_CREATE_WITH_AUTO_RENEW_SCENARIO {

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/test/factories/scenarios/FileUpdateScenarios.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/test/factories/scenarios/FileUpdateScenarios.java
@@ -28,6 +28,24 @@ public enum FileUpdateScenarios implements TxnHandlingScenario {
             return PlatformTxnAccessor.from(from(newSignedFileUpdate(MISC_FILE_ID).get()));
         }
     },
+    FILE_UPDATE_WITH_AUTO_RENEW_SCENARIO {
+        public PlatformTxnAccessor platformTxn() throws Throwable {
+            return PlatformTxnAccessor.from(
+                    from(
+                            newSignedFileUpdate(MISC_FILE_ID)
+                                    .newAutoRenewAccount(FIRST_TOKEN_SENDER_ID)
+                                    .get()));
+        }
+    },
+    FILE_UPDATE_WITH_MISSING_AUTO_RENEW_SCENARIO {
+        public PlatformTxnAccessor platformTxn() throws Throwable {
+            return PlatformTxnAccessor.from(
+                    from(
+                            newSignedFileUpdate(MISC_FILE_ID)
+                                    .newAutoRenewAccount(MISSING_ACCOUNT_ID)
+                                    .get()));
+        }
+    },
     TREASURY_SYS_FILE_UPDATE_SCENARIO {
         public PlatformTxnAccessor platformTxn() throws Throwable {
             return PlatformTxnAccessor.from(

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/test/factories/scenarios/TxnHandlingScenario.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/test/factories/scenarios/TxnHandlingScenario.java
@@ -590,6 +590,7 @@ public interface TxnHandlingScenario {
     String KNOWN_TOKEN_WITH_PAUSE_ID = "0.0.780";
     TokenID KNOWN_TOKEN_WITH_PAUSE = asToken(KNOWN_TOKEN_WITH_PAUSE_ID);
 
+    String SENTINEL_ID = "0.0.0";
     String FIRST_TOKEN_SENDER_ID = "0.0.888";
     AccountID FIRST_TOKEN_SENDER = asAccount(FIRST_TOKEN_SENDER_ID);
     ByteString FIRST_TOKEN_SENDER_LITERAL_ALIAS = ByteString.copyFromUtf8("firstTokenSender");

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/test/factories/txns/CryptoCreateFactory.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/test/factories/txns/CryptoCreateFactory.java
@@ -18,6 +18,7 @@ package com.hedera.test.factories.txns;
 import static com.hedera.test.factories.keys.NodeFactory.ed25519;
 import static com.hedera.test.factories.keys.NodeFactory.list;
 import static com.hedera.test.factories.keys.NodeFactory.threshold;
+import static com.hedera.test.utils.IdUtils.asAccount;
 
 import com.hedera.test.factories.keys.KeyTree;
 import com.hederahashgraph.api.proto.java.CryptoCreateTransactionBody;
@@ -25,6 +26,7 @@ import com.hederahashgraph.api.proto.java.Duration;
 import com.hederahashgraph.api.proto.java.Transaction;
 import com.hederahashgraph.api.proto.java.TransactionBody;
 import java.util.OptionalLong;
+import javax.annotation.Nullable;
 
 public class CryptoCreateFactory extends SignedTxnFactory<CryptoCreateFactory> {
     public static final KeyTree DEFAULT_ACCOUNT_KT =
@@ -38,6 +40,7 @@ public class CryptoCreateFactory extends SignedTxnFactory<CryptoCreateFactory> {
     private KeyTree accountKt = DEFAULT_ACCOUNT_KT;
     private Duration autoRenewPeriod = DEFAULT_AUTO_RENEW_PERIOD;
     private OptionalLong balance = OptionalLong.empty();
+    @Nullable private String autoRenewAccount;
 
     private CryptoCreateFactory() {}
 
@@ -65,6 +68,9 @@ public class CryptoCreateFactory extends SignedTxnFactory<CryptoCreateFactory> {
                         .setSendRecordThreshold(sendThresholdTinybars)
                         .setReceiveRecordThreshold(receiveThresholdTinybars);
         balance.ifPresent(op::setInitialBalance);
+        if (autoRenewAccount != null) {
+            op.setAutoRenewAccount(asAccount(autoRenewAccount));
+        }
         txn.setCryptoCreateAccount(op);
     }
 
@@ -80,6 +86,11 @@ public class CryptoCreateFactory extends SignedTxnFactory<CryptoCreateFactory> {
 
     public CryptoCreateFactory receiverSigRequired(boolean isRequired) {
         this.receiverSigRequired = isRequired;
+        return this;
+    }
+
+    public CryptoCreateFactory newAutoRenewAccount(final String autoRenewAccount) {
+        this.autoRenewAccount = autoRenewAccount;
         return this;
     }
 }

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/test/factories/txns/CryptoUpdateFactory.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/test/factories/txns/CryptoUpdateFactory.java
@@ -22,9 +22,11 @@ import com.hederahashgraph.api.proto.java.CryptoUpdateTransactionBody;
 import com.hederahashgraph.api.proto.java.Transaction;
 import com.hederahashgraph.api.proto.java.TransactionBody;
 import java.util.Optional;
+import javax.annotation.Nullable;
 
 public class CryptoUpdateFactory extends SignedTxnFactory<CryptoUpdateFactory> {
     private final String account;
+    @Nullable private String autoRenewAccount;
     private Optional<KeyTree> newAccountKt = Optional.empty();
 
     public CryptoUpdateFactory(String account) {
@@ -49,12 +51,20 @@ public class CryptoUpdateFactory extends SignedTxnFactory<CryptoUpdateFactory> {
     protected void customizeTxn(TransactionBody.Builder txn) {
         CryptoUpdateTransactionBody.Builder op =
                 CryptoUpdateTransactionBody.newBuilder().setAccountIDToUpdate(asAccount(account));
+        if (autoRenewAccount != null) {
+            op.setAutoRenewAccount(asAccount(autoRenewAccount));
+        }
         newAccountKt.ifPresent(kt -> op.setKey(kt.asKey(keyFactory)));
         txn.setCryptoUpdateAccount(op);
     }
 
     public CryptoUpdateFactory newAccountKt(KeyTree newAccountKt) {
         this.newAccountKt = Optional.of(newAccountKt);
+        return this;
+    }
+
+    public CryptoUpdateFactory newAutoRenewAccount(final String autoRenewAccount) {
+        this.autoRenewAccount = autoRenewAccount;
         return this;
     }
 }

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/test/factories/txns/FileCreateFactory.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/test/factories/txns/FileCreateFactory.java
@@ -30,6 +30,7 @@ public class FileCreateFactory extends SignedTxnFactory<FileCreateFactory> {
 
     private KeyTree waclKt = DEFAULT_WACL_KT;
     @Nullable private String autoRenewAccount;
+    private boolean immutable;
 
     private FileCreateFactory() {}
 
@@ -50,12 +51,19 @@ public class FileCreateFactory extends SignedTxnFactory<FileCreateFactory> {
     @Override
     protected void customizeTxn(TransactionBody.Builder txn) {
         FileCreateTransactionBody.Builder op =
-                FileCreateTransactionBody.newBuilder()
-                        .setKeys(waclKt.asKey(keyFactory).getKeyList());
+                FileCreateTransactionBody.newBuilder();
+        if (!immutable) {
+            op.setKeys(waclKt.asKey(keyFactory).getKeyList());
+        }
         if (autoRenewAccount != null) {
             op.setAutoRenewAccount(asAccount(autoRenewAccount));
         }
         txn.setFileCreate(op);
+    }
+
+    public FileCreateFactory immutable() {
+        this.immutable = true;
+        return this;
     }
 
     public FileCreateFactory waclKt(KeyTree waclKt) {

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/test/factories/txns/FileCreateFactory.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/test/factories/txns/FileCreateFactory.java
@@ -50,8 +50,7 @@ public class FileCreateFactory extends SignedTxnFactory<FileCreateFactory> {
 
     @Override
     protected void customizeTxn(TransactionBody.Builder txn) {
-        FileCreateTransactionBody.Builder op =
-                FileCreateTransactionBody.newBuilder();
+        FileCreateTransactionBody.Builder op = FileCreateTransactionBody.newBuilder();
         if (!immutable) {
             op.setKeys(waclKt.asKey(keyFactory).getKeyList());
         }

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/test/factories/txns/FileCreateFactory.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/test/factories/txns/FileCreateFactory.java
@@ -17,16 +17,19 @@ package com.hedera.test.factories.txns;
 
 import static com.hedera.test.factories.keys.NodeFactory.ed25519;
 import static com.hedera.test.factories.keys.NodeFactory.list;
+import static com.hedera.test.utils.IdUtils.asAccount;
 
 import com.hedera.test.factories.keys.KeyTree;
 import com.hederahashgraph.api.proto.java.FileCreateTransactionBody;
 import com.hederahashgraph.api.proto.java.Transaction;
 import com.hederahashgraph.api.proto.java.TransactionBody;
+import javax.annotation.Nullable;
 
 public class FileCreateFactory extends SignedTxnFactory<FileCreateFactory> {
     public static final KeyTree DEFAULT_WACL_KT = KeyTree.withRoot(list(ed25519()));
 
     private KeyTree waclKt = DEFAULT_WACL_KT;
+    @Nullable private String autoRenewAccount;
 
     private FileCreateFactory() {}
 
@@ -49,11 +52,19 @@ public class FileCreateFactory extends SignedTxnFactory<FileCreateFactory> {
         FileCreateTransactionBody.Builder op =
                 FileCreateTransactionBody.newBuilder()
                         .setKeys(waclKt.asKey(keyFactory).getKeyList());
+        if (autoRenewAccount != null) {
+            op.setAutoRenewAccount(asAccount(autoRenewAccount));
+        }
         txn.setFileCreate(op);
     }
 
     public FileCreateFactory waclKt(KeyTree waclKt) {
         this.waclKt = waclKt;
+        return this;
+    }
+
+    public FileCreateFactory newAutoRenewAccount(final String autoRenewAccount) {
+        this.autoRenewAccount = autoRenewAccount;
         return this;
     }
 }

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/test/factories/txns/FileUpdateFactory.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/test/factories/txns/FileUpdateFactory.java
@@ -15,6 +15,7 @@
  */
 package com.hedera.test.factories.txns;
 
+import static com.hedera.test.utils.IdUtils.asAccount;
 import static com.hedera.test.utils.IdUtils.asFile;
 
 import com.hedera.test.factories.keys.KeyTree;
@@ -22,10 +23,12 @@ import com.hederahashgraph.api.proto.java.FileUpdateTransactionBody;
 import com.hederahashgraph.api.proto.java.Transaction;
 import com.hederahashgraph.api.proto.java.TransactionBody;
 import java.util.Optional;
+import javax.annotation.Nullable;
 
 public class FileUpdateFactory extends SignedTxnFactory<FileUpdateFactory> {
     private final String file;
     private Optional<KeyTree> newWaclKt = Optional.empty();
+    @Nullable private String autoRenewAccount;
 
     public FileUpdateFactory(String file) {
         this.file = file;
@@ -50,11 +53,19 @@ public class FileUpdateFactory extends SignedTxnFactory<FileUpdateFactory> {
         FileUpdateTransactionBody.Builder op =
                 FileUpdateTransactionBody.newBuilder().setFileID(asFile(file));
         newWaclKt.ifPresent(kt -> op.setKeys(kt.asKey().getKeyList()));
+        if (autoRenewAccount != null) {
+            op.setAutoRenewAccount(asAccount(autoRenewAccount));
+        }
         txn.setFileUpdate(op);
     }
 
     public FileUpdateFactory newWaclKt(KeyTree newWaclKt) {
         this.newWaclKt = Optional.of(newWaclKt);
+        return this;
+    }
+
+    public FileUpdateFactory newAutoRenewAccount(final String autoRenewAccount) {
+        this.autoRenewAccount = autoRenewAccount;
         return this;
     }
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -59,7 +59,7 @@ dependencyResolutionManagement {
             version("eddsa-version", "0.3.0")
             version("grpc-version", "1.39.0")
             version("guava-version", "31.1-jre")
-            version("hapi-version", "0.32.0-SNAPSHOT")
+            version("hapi-version", "0.32.0-period-SNAPSHOT")
             version("headlong-version", "6.1.1")
             version("jackson-version", "2.12.6.1")
             version("javax-annotation-version", "1.3.2")

--- a/test-clients/src/main/java/com/hedera/services/bdd/spec/HapiSpecOperation.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/spec/HapiSpecOperation.java
@@ -204,7 +204,6 @@ public abstract class HapiSpecOperation {
                 updateStateOf(spec);
             }
         } catch (Throwable t) {
-            t.printStackTrace();
             if (unavailableNode && t.getMessage().startsWith("UNAVAILABLE")) {
                 log.info(
                         "Node {} is unavailable as expected!",

--- a/test-clients/src/main/java/com/hedera/services/bdd/spec/HapiSpecOperation.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/spec/HapiSpecOperation.java
@@ -204,6 +204,7 @@ public abstract class HapiSpecOperation {
                 updateStateOf(spec);
             }
         } catch (Throwable t) {
+            t.printStackTrace();
             if (unavailableNode && t.getMessage().startsWith("UNAVAILABLE")) {
                 log.info(
                         "Node {} is unavailable as expected!",

--- a/test-clients/src/main/java/com/hedera/services/bdd/spec/assertions/AccountInfoAsserts.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/spec/assertions/AccountInfoAsserts.java
@@ -92,6 +92,25 @@ public class AccountInfoAsserts extends BaseErroringAssertsProvider<AccountInfo>
         return this;
     }
 
+    public AccountInfoAsserts autoRenewAccountId(String account) {
+        registerProvider(
+                (spec, o) ->
+                        assertEquals(
+                                spec.registry().getAccountID(account),
+                                ((AccountInfo) o).getAutoRenewAccount(),
+                                "Bad auto-renew account"));
+        return this;
+    }
+
+    public AccountInfoAsserts noAutoRenewAccountId() {
+        registerProvider(
+                (spec, o) ->
+                        assertFalse(
+                                ((AccountInfo) o).hasAutoRenewAccount(),
+                                "Expected no auto-renew account"));
+        return this;
+    }
+
     public AccountInfoAsserts stakedAccountId(String idLiteral) {
         registerProvider(
                 (spec, o) ->

--- a/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/HapiQueryOp.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/HapiQueryOp.java
@@ -62,6 +62,8 @@ import java.util.stream.Stream;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import javax.annotation.Nullable;
+
 public abstract class HapiQueryOp<T extends HapiQueryOp<T>> extends HapiSpecOperation {
     private static final Logger log = LogManager.getLogger(HapiQueryOp.class);
 

--- a/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/HapiQueryOp.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/HapiQueryOp.java
@@ -62,8 +62,6 @@ import java.util.stream.Stream;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import javax.annotation.Nullable;
-
 public abstract class HapiQueryOp<T extends HapiQueryOp<T>> extends HapiSpecOperation {
     private static final Logger log = LogManager.getLogger(HapiQueryOp.class);
 

--- a/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/file/HapiGetFileInfo.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/file/HapiGetFileInfo.java
@@ -52,6 +52,7 @@ public class HapiGetFileInfo extends HapiQueryOp<HapiGetFileInfo> {
     private Optional<String> expectedMemo = Optional.empty();
     @Nullable private String expectedAutoRenewAccount;
     private boolean hasNoAutoRenewAccount;
+    private long expectedAutoRenewPeriod = -1;
 
     @SuppressWarnings("java:S1068")
     private Optional<String> expectedKeyRepr = Optional.empty();
@@ -94,6 +95,11 @@ public class HapiGetFileInfo extends HapiQueryOp<HapiGetFileInfo> {
 
     public HapiGetFileInfo hasAutoRenewAccount(final String v) {
         expectedAutoRenewAccount = v;
+        return this;
+    }
+
+    public HapiGetFileInfo hasAutoRenewPeriod(final long l) {
+        expectedAutoRenewPeriod = l;
         return this;
     }
 
@@ -168,6 +174,12 @@ public class HapiGetFileInfo extends HapiQueryOp<HapiGetFileInfo> {
         }
         if (hasNoAutoRenewAccount) {
             Assertions.assertFalse(info.hasAutoRenewAccount(), "Should have no auto-renew account");
+        }
+        if (expectedAutoRenewPeriod != -1) {
+            Assertions.assertEquals(
+                    expectedAutoRenewPeriod,
+                    info.getAutoRenewPeriod().getSeconds(),
+                    "Wrong auto-renew account period");
         }
 
         Assertions.assertEquals(TxnUtils.asFileId(file, spec), info.getFileID(), "Wrong file id!");

--- a/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/file/HapiGetFileInfo.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/file/HapiGetFileInfo.java
@@ -33,11 +33,10 @@ import java.util.function.Consumer;
 import java.util.function.LongPredicate;
 import java.util.function.LongSupplier;
 import java.util.function.Supplier;
+import javax.annotation.Nullable;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.Assertions;
-
-import javax.annotation.Nullable;
 
 public class HapiGetFileInfo extends HapiQueryOp<HapiGetFileInfo> {
     private static final Logger LOG = LogManager.getLogger(HapiGetFileInfo.class);
@@ -51,8 +50,7 @@ public class HapiGetFileInfo extends HapiQueryOp<HapiGetFileInfo> {
     private Optional<Boolean> expectedDeleted = Optional.empty();
     private Optional<String> expectedWacl = Optional.empty();
     private Optional<String> expectedMemo = Optional.empty();
-    @Nullable
-    private String expectedAutoRenewAccount;
+    @Nullable private String expectedAutoRenewAccount;
     private boolean hasNoAutoRenewAccount;
 
     @SuppressWarnings("java:S1068")
@@ -165,7 +163,8 @@ public class HapiGetFileInfo extends HapiQueryOp<HapiGetFileInfo> {
 
         if (expectedAutoRenewAccount != null) {
             final var expectedId = TxnUtils.asId(expectedAutoRenewAccount, spec);
-            Assertions.assertEquals(expectedId, info.getAutoRenewAccount(), "Wrong auto-renew account");
+            Assertions.assertEquals(
+                    expectedId, info.getAutoRenewAccount(), "Wrong auto-renew account");
         }
         if (hasNoAutoRenewAccount) {
             Assertions.assertFalse(info.hasAutoRenewAccount(), "Should have no auto-renew account");

--- a/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/file/HapiGetFileInfo.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/file/HapiGetFileInfo.java
@@ -37,6 +37,8 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.Assertions;
 
+import javax.annotation.Nullable;
+
 public class HapiGetFileInfo extends HapiQueryOp<HapiGetFileInfo> {
     private static final Logger LOG = LogManager.getLogger(HapiGetFileInfo.class);
 
@@ -49,6 +51,9 @@ public class HapiGetFileInfo extends HapiQueryOp<HapiGetFileInfo> {
     private Optional<Boolean> expectedDeleted = Optional.empty();
     private Optional<String> expectedWacl = Optional.empty();
     private Optional<String> expectedMemo = Optional.empty();
+    @Nullable
+    private String expectedAutoRenewAccount;
+    private boolean hasNoAutoRenewAccount;
 
     @SuppressWarnings("java:S1068")
     private Optional<String> expectedKeyRepr = Optional.empty();
@@ -86,6 +91,16 @@ public class HapiGetFileInfo extends HapiQueryOp<HapiGetFileInfo> {
 
     public HapiGetFileInfo hasMemo(String v) {
         expectedMemo = Optional.of(v);
+        return this;
+    }
+
+    public HapiGetFileInfo hasAutoRenewAccount(final String v) {
+        expectedAutoRenewAccount = v;
+        return this;
+    }
+
+    public HapiGetFileInfo hasNoAutoRenewAccount() {
+        hasNoAutoRenewAccount = false;
         return this;
     }
 
@@ -147,6 +162,14 @@ public class HapiGetFileInfo extends HapiQueryOp<HapiGetFileInfo> {
     @SuppressWarnings("java:S5960")
     protected void assertExpectationsGiven(HapiApiSpec spec) throws Throwable {
         var info = response.getFileGetInfo().getFileInfo();
+
+        if (expectedAutoRenewAccount != null) {
+            final var expectedId = TxnUtils.asId(expectedAutoRenewAccount, spec);
+            Assertions.assertEquals(expectedId, info.getAutoRenewAccount(), "Wrong auto-renew account");
+        }
+        if (hasNoAutoRenewAccount) {
+            Assertions.assertFalse(info.hasAutoRenewAccount(), "Should have no auto-renew account");
+        }
 
         Assertions.assertEquals(TxnUtils.asFileId(file, spec), info.getFileID(), "Wrong file id!");
         keyReprObserver.ifPresent(

--- a/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/HapiTxnOp.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/HapiTxnOp.java
@@ -50,6 +50,7 @@ import com.hedera.services.bdd.spec.keys.OverlappingKeyGenerator;
 import com.hedera.services.bdd.spec.keys.SigMapGenerator;
 import com.hedera.services.bdd.spec.stats.QueryObs;
 import com.hedera.services.bdd.spec.stats.TxnObs;
+import com.hederahashgraph.api.proto.java.AccountID;
 import com.hederahashgraph.api.proto.java.Key;
 import com.hederahashgraph.api.proto.java.Query;
 import com.hederahashgraph.api.proto.java.Response;
@@ -78,6 +79,8 @@ import org.apache.tuweni.bytes.Bytes;
 public abstract class HapiTxnOp<T extends HapiTxnOp<T>> extends HapiSpecOperation {
     private static final Logger log = LogManager.getLogger(HapiTxnOp.class);
 
+    public static final AccountID AUTO_RENEW_REMOVE_SENTINEL_ID =
+            AccountID.newBuilder().setShardNum(0L).setRealmNum(0L).setAccountNum(0L).build();
     private static final Response UNKNOWN_RESPONSE =
             Response.newBuilder()
                     .setTransactionGetReceipt(

--- a/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/TxnUtils.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/TxnUtils.java
@@ -97,6 +97,7 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.regex.Pattern;
 import java.util.stream.IntStream;
+import javax.annotation.Nullable;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -137,6 +138,19 @@ public class TxnUtils {
         signers.add(spec -> spec.registry().getKey(owningEntity));
         if (newKeyName.isPresent()) {
             signers.add(spec -> spec.registry().getKey(newKeyName.get()));
+        }
+        return signers;
+    }
+
+    public static List<Function<HapiApiSpec, Key>> payerOptionalAndMaybeAutoRenewSigners(
+            final Function<HapiApiSpec, String> effectivePayer,
+            final Key key,
+            @Nullable String autoRenewAccount) {
+        final List<Function<HapiApiSpec, Key>> signers = new ArrayList<>();
+        signers.add(spec -> spec.registry().getKey(effectivePayer.apply(spec)));
+        signers.add(ignore -> key);
+        if (autoRenewAccount != null) {
+            signers.add(spec -> spec.registry().getKey(autoRenewAccount));
         }
         return signers;
     }

--- a/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/TxnUtils.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/TxnUtils.java
@@ -144,11 +144,11 @@ public class TxnUtils {
 
     public static List<Function<HapiApiSpec, Key>> payerOptionalAndMaybeAutoRenewSigners(
             final Function<HapiApiSpec, String> effectivePayer,
-            final Key key,
+            @Nullable final Key key,
             @Nullable String autoRenewAccount) {
         final List<Function<HapiApiSpec, Key>> signers = new ArrayList<>();
         signers.add(spec -> spec.registry().getKey(effectivePayer.apply(spec)));
-        signers.add(ignore -> key);
+        signers.add(ignore -> Optional.ofNullable(key).orElse(Key.getDefaultInstance()));
         if (autoRenewAccount != null) {
             signers.add(spec -> spec.registry().getKey(autoRenewAccount));
         }

--- a/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/crypto/HapiCryptoUpdate.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/crypto/HapiCryptoUpdate.java
@@ -130,6 +130,11 @@ public class HapiCryptoUpdate extends HapiTxnOp<HapiCryptoUpdate> {
         return this;
     }
 
+    public HapiCryptoUpdate explicitKey(Key key) {
+        updKey = Optional.of(key);
+        return this;
+    }
+
     public HapiCryptoUpdate receiverSigRequired(boolean isRequired) {
         updSigRequired = Optional.of(isRequired);
         return this;
@@ -176,10 +181,12 @@ public class HapiCryptoUpdate extends HapiTxnOp<HapiCryptoUpdate> {
     @Override
     @SuppressWarnings("java:S106")
     protected Consumer<TransactionBody.Builder> opBodyDef(HapiApiSpec spec) throws Throwable {
-        try {
-            updKey = updKeyName.map(spec.registry()::getKey);
-        } catch (Exception missingKey) {
-            log.warn("No such key {}", updKey);
+        if (updKey.isEmpty()) {
+            try {
+                updKey = updKeyName.map(spec.registry()::getKey);
+            } catch (Exception missingKey) {
+                log.warn("No such key {}", updKey);
+            }
         }
         AccountID id;
 

--- a/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/crypto/HapiCryptoUpdate.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/crypto/HapiCryptoUpdate.java
@@ -69,6 +69,7 @@ public class HapiCryptoUpdate extends HapiTxnOp<HapiCryptoUpdate> {
     private Optional<Long> newStakedNodeId = Optional.empty();
     private Optional<Boolean> isDeclinedReward = Optional.empty();
     @Nullable private String autoRenewAccount;
+    private boolean removeAutoRenewAccount = false;
 
     private ReferenceType referenceType = ReferenceType.REGISTRY_NAME;
 
@@ -87,6 +88,11 @@ public class HapiCryptoUpdate extends HapiTxnOp<HapiCryptoUpdate> {
 
     public HapiCryptoUpdate autoRenewAccount(final String autoRenewAccount) {
         this.autoRenewAccount = autoRenewAccount;
+        return this;
+    }
+
+    public HapiCryptoUpdate removingAutoRenewAccount() {
+        this.removeAutoRenewAccount = true;
         return this;
     }
 
@@ -221,7 +227,9 @@ public class HapiCryptoUpdate extends HapiTxnOp<HapiCryptoUpdate> {
                                     } else {
                                         updKey.ifPresent(builder::setKey);
                                     }
-                                    if (autoRenewAccount != null) {
+                                    if (removeAutoRenewAccount) {
+                                        builder.setAutoRenewAccount(AUTO_RENEW_REMOVE_SENTINEL_ID);
+                                    } else if (autoRenewAccount != null) {
                                         builder.setAutoRenewAccount(asId(autoRenewAccount, spec));
                                     }
                                     newAutoRenewPeriod.ifPresent(

--- a/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/file/HapiFileCreate.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/file/HapiFileCreate.java
@@ -30,6 +30,7 @@ import com.hedera.services.bdd.spec.keys.KeyGenerator;
 import com.hedera.services.bdd.spec.keys.SigControl;
 import com.hedera.services.bdd.spec.transactions.HapiTxnOp;
 import com.hedera.services.bdd.spec.transactions.TxnFactory;
+import com.hederahashgraph.api.proto.java.Duration;
 import com.hederahashgraph.api.proto.java.FeeData;
 import com.hederahashgraph.api.proto.java.FileCreateTransactionBody;
 import com.hederahashgraph.api.proto.java.HederaFunctionality;
@@ -61,6 +62,7 @@ public class HapiFileCreate extends HapiTxnOp<HapiFileCreate> {
     private final String fileName;
     private boolean immutable = false;
     private boolean advertiseCreation = false;
+    private long autoRenewPeriod = -1;
     OptionalLong expiry = OptionalLong.empty();
     OptionalLong lifetime = OptionalLong.empty();
     Optional<String> contentsPath = Optional.empty();
@@ -89,6 +91,11 @@ public class HapiFileCreate extends HapiTxnOp<HapiFileCreate> {
 
     public HapiFileCreate autoRenewAccount(final String autoRenewAccount) {
         this.autoRenewAccount = autoRenewAccount;
+        return this;
+    }
+
+    public HapiFileCreate autoRenewPeriod(final long p) {
+        this.autoRenewPeriod = p;
         return this;
     }
 
@@ -200,6 +207,12 @@ public class HapiFileCreate extends HapiTxnOp<HapiFileCreate> {
 
                                     if (autoRenewAccount != null) {
                                         builder.setAutoRenewAccount(asId(autoRenewAccount, spec));
+                                    }
+                                    if (autoRenewPeriod != -1) {
+                                        builder.setAutoRenewPeriod(
+                                                Duration.newBuilder()
+                                                        .setSeconds(autoRenewPeriod)
+                                                        .build());
                                     }
                                     memo.ifPresent(builder::setMemo);
                                     contents.ifPresent(

--- a/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/file/HapiFileUpdate.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/file/HapiFileUpdate.java
@@ -21,7 +21,6 @@ import static com.hedera.services.bdd.spec.transactions.TxnUtils.asId;
 import static com.hedera.services.bdd.spec.transactions.TxnUtils.suFrom;
 import static com.hedera.services.bdd.spec.utilops.CustomSpecAssert.allRunFor;
 import static com.hedera.services.bdd.suites.HapiApiSuite.ONE_HBAR;
-import static com.hedera.services.bdd.suites.utils.sysfiles.serdes.StandardSerdes.SYS_FILE_SERDES;
 import static java.util.Collections.EMPTY_MAP;
 import static java.util.Collections.EMPTY_SET;
 
@@ -73,8 +72,6 @@ import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.Assertions;
 
 public class HapiFileUpdate extends HapiTxnOp<HapiFileUpdate> {
-    // Temporary work-around for CI states with expired system files
-    private static final long MIN_SYS_FILE_LIFETIME = 7776000L;
     static final Logger LOG = LogManager.getLogger(HapiFileUpdate.class);
 
     /* WARNING - set to true only if you really want to replace 0.0.121/2! */
@@ -320,8 +317,6 @@ public class HapiFileUpdate extends HapiTxnOp<HapiFileUpdate> {
             }
         } else if (lifetimeSecs.isPresent()) {
             nl = lifetimeSecs.get();
-        } else if (SYS_FILE_SERDES.containsKey(fid.getFileNum())) {
-            nl = MIN_SYS_FILE_LIFETIME;
         }
         final OptionalLong newLifetime = (nl == -1) ? OptionalLong.empty() : OptionalLong.of(nl);
         FileUpdateTransactionBody opBody =

--- a/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/file/HapiFileUpdate.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/file/HapiFileUpdate.java
@@ -38,6 +38,7 @@ import com.hedera.services.bdd.spec.transactions.TxnFactory;
 import com.hedera.services.bdd.spec.transactions.TxnUtils;
 import com.hedera.services.bdd.suites.HapiApiSuite;
 import com.hedera.services.usage.file.ExtantFileContext;
+import com.hederahashgraph.api.proto.java.Duration;
 import com.hederahashgraph.api.proto.java.ExchangeRateSet;
 import com.hederahashgraph.api.proto.java.FileGetInfoResponse;
 import com.hederahashgraph.api.proto.java.FileID;
@@ -98,6 +99,7 @@ public class HapiFileUpdate extends HapiTxnOp<HapiFileUpdate> {
     Optional<Consumer<ResponseCodeEnum>> postUpdateCb = Optional.empty();
 
     @Nullable private String autoRenewAccount;
+    private long autoRenewPeriod = -1;
 
     public HapiFileUpdate(String file) {
         this.file = file;
@@ -140,6 +142,11 @@ public class HapiFileUpdate extends HapiTxnOp<HapiFileUpdate> {
 
     public HapiFileUpdate autoRenewAccount(final String autoRenewAccount) {
         this.autoRenewAccount = autoRenewAccount;
+        return this;
+    }
+
+    public HapiFileUpdate autoRenewPeriod(final long p) {
+        this.autoRenewPeriod = p;
         return this;
     }
 
@@ -325,6 +332,12 @@ public class HapiFileUpdate extends HapiTxnOp<HapiFileUpdate> {
                                     builder.setFileID(fid);
                                     if (autoRenewAccount != null) {
                                         builder.setAutoRenewAccount(asId(autoRenewAccount, spec));
+                                    }
+                                    if (autoRenewPeriod != -1) {
+                                        builder.setAutoRenewPeriod(
+                                                Duration.newBuilder()
+                                                        .setSeconds(autoRenewPeriod)
+                                                        .build());
                                     }
                                     newMemo.ifPresent(
                                             s ->

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/HapiApiSuite.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/HapiApiSuite.java
@@ -68,6 +68,7 @@ public abstract class HapiApiSuite {
     public static final long THOUSAND_HBAR = 1_000 * ONE_HBAR;
     public static final long ONE_MILLION_HBARS = 1_000_000L * ONE_HBAR;
     public static final long THREE_MONTHS_IN_SECONDS = 7776000L;
+    public static final long ONE_MONTHS_IN_SECONDS = THREE_MONTHS_IN_SECONDS / 3;
 
     public static final String CHAIN_ID_PROP = "contracts.chainId";
     public static final String CRYPTO_CREATE_WITH_ALIAS_ENABLED = "cryptoCreateWithAlias.enabled";

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/autorenew/GracePeriodRestrictionsSuite.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/autorenew/GracePeriodRestrictionsSuite.java
@@ -56,7 +56,6 @@ import static com.hedera.services.bdd.suites.contract.Utils.asAddress;
 import static com.hedera.services.bdd.suites.contract.Utils.getABIFor;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.ACCOUNT_EXPIRED_AND_PENDING_REMOVAL;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.EXPIRATION_REDUCTION_NOT_ALLOWED;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_EXPIRATION_TIME;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_SOLIDITY_ADDRESS;
 
 import com.hedera.services.bdd.spec.HapiApiSpec;
@@ -183,7 +182,7 @@ public class GracePeriodRestrictionsSuite extends HapiApiSuite {
                         cryptoUpdate(detachedAccount)
                                 .memo("Can't update with past expiry")
                                 .expiring(certainlyPast)
-                                .hasKnownStatus(INVALID_EXPIRATION_TIME),
+                                .hasKnownStatus(EXPIRATION_REDUCTION_NOT_ALLOWED),
                         cryptoUpdate(detachedAccount)
                                 .memo("CAN extend expiry")
                                 .expiring(certainlyDistant))

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoCreateSuite.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoCreateSuite.java
@@ -65,7 +65,6 @@ public class CryptoCreateSuite extends HapiApiSuite {
     private static final String defaultAssociationsLimit =
             HapiSpecSetup.getDefaultNodeProps().get(associationsLimitProperty);
     public static final String ACCOUNT = "account";
-    public static final String AUTO_CREATED_ACCOUNT = "auto-created account";
     public static final String ED_25519_KEY = "ed25519Alias";
     public static final String LAZY_CREATION_ENABLED = "lazyCreation.enabled";
     public static final String TRUE = "true";
@@ -266,7 +265,7 @@ public class CryptoCreateSuite extends HapiApiSuite {
                 .then(
                         cryptoCreate("broken")
                                 .autoRenewSecs(1L)
-                                .hasPrecheck(AUTORENEW_DURATION_NOT_IN_RANGE),
+                                .hasKnownStatus(AUTORENEW_DURATION_NOT_IN_RANGE),
                         cryptoCreate("alsoBroken")
                                 .entityMemo(ZERO_BYTE_MEMO)
                                 .hasPrecheck(INVALID_ZERO_BYTE_IN_STRING));

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/file/FileCreateSuite.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/file/FileCreateSuite.java
@@ -16,7 +16,6 @@
 package com.hedera.services.bdd.suites.file;
 
 import static com.hedera.services.bdd.spec.HapiApiSpec.defaultHapiSpec;
-import static com.hedera.services.bdd.spec.HapiApiSpec.onlyDefaultHapiSpec;
 import static com.hedera.services.bdd.spec.keys.ControlForKey.forKey;
 import static com.hedera.services.bdd.spec.keys.KeyShape.SIMPLE;
 import static com.hedera.services.bdd.spec.keys.KeyShape.listOf;
@@ -29,7 +28,6 @@ import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoCreate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.fileCreate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.fileUpdate;
 import static com.hedera.services.bdd.suites.file.FileUpdateSuite.CIVILIAN;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.AUTORENEW_DURATION_NOT_IN_RANGE;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_EXPIRATION_TIME;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_NODE_ACCOUNT;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_SIGNATURE;
@@ -83,7 +81,7 @@ public class FileCreateSuite extends HapiApiSuite {
                 .then(
                         fileCreate("test")
                                 .lifetime(defaultMaxLifetime + 12_345L)
-                                .hasPrecheck(AUTORENEW_DURATION_NOT_IN_RANGE));
+                                .hasKnownStatus(INVALID_EXPIRATION_TIME));
     }
 
     private HapiApiSpec createWithMemoWorks() {
@@ -108,7 +106,7 @@ public class FileCreateSuite extends HapiApiSuite {
         final var withUnspecifiedExpiry = "withUnspecifiedExpiry";
         final var withIgnoredAutoRenewPeriod = "withIgnoredAutoRenewPeriod";
 
-        return onlyDefaultHapiSpec("CreateWithAutoRenewWorks")
+        return defaultHapiSpec("CreateWithAutoRenewWorks")
                 .given(
                         cryptoCreate(CIVILIAN),
                         // Auto-renew account must sign
@@ -121,7 +119,7 @@ public class FileCreateSuite extends HapiApiSuite {
                                 .unmodifiable()
                                 .autoRenewAccount(CIVILIAN)
                                 .noExplicitExpiry()
-                                .hasKnownStatus(INVALID_EXPIRATION_TIME))
+                                .hasPrecheck(INVALID_EXPIRATION_TIME))
                 .when(
                         fileCreate(withIgnoredExpiry)
                                 .unmodifiable()

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/file/FileCreateSuite.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/file/FileCreateSuite.java
@@ -16,6 +16,7 @@
 package com.hedera.services.bdd.suites.file;
 
 import static com.hedera.services.bdd.spec.HapiApiSpec.defaultHapiSpec;
+import static com.hedera.services.bdd.spec.HapiApiSpec.onlyDefaultHapiSpec;
 import static com.hedera.services.bdd.spec.keys.ControlForKey.forKey;
 import static com.hedera.services.bdd.spec.keys.KeyShape.SIMPLE;
 import static com.hedera.services.bdd.spec.keys.KeyShape.listOf;
@@ -24,7 +25,12 @@ import static com.hedera.services.bdd.spec.keys.KeyShape.threshOf;
 import static com.hedera.services.bdd.spec.keys.SigControl.OFF;
 import static com.hedera.services.bdd.spec.keys.SigControl.ON;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getFileInfo;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoCreate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.fileCreate;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.fileUpdate;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.newKeyListNamed;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.newKeyNamed;
+import static com.hedera.services.bdd.suites.file.FileUpdateSuite.CIVILIAN;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.AUTORENEW_DURATION_NOT_IN_RANGE;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_NODE_ACCOUNT;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_SIGNATURE;
@@ -35,6 +41,7 @@ import com.hedera.services.bdd.spec.HapiSpecSetup;
 import com.hedera.services.bdd.spec.keys.KeyShape;
 import com.hedera.services.bdd.spec.keys.SigControl;
 import com.hedera.services.bdd.spec.transactions.TxnUtils;
+import com.hedera.services.bdd.spec.utilops.UtilVerbs;
 import com.hedera.services.bdd.suites.HapiApiSuite;
 import com.hederahashgraph.api.proto.java.AccountID;
 import com.hederahashgraph.api.proto.java.Transaction;
@@ -65,6 +72,8 @@ public class FileCreateSuite extends HapiApiSuite {
                     createFailsWithMissingSigs(),
                     createFailsWithPayerAccountNotFound(),
                     createFailsWithExcessiveLifetime(),
+                        createWithAutoRenewWorks(),
+                        updateWithAutoRenewWorks(),
                 });
     }
 
@@ -89,6 +98,49 @@ public class FileCreateSuite extends HapiApiSuite {
                         fileCreate("memorable").entityMemo(memo))
                 .when()
                 .then(getFileInfo("memorable").hasExpectedLedgerId("0x03").hasMemo(memo));
+    }
+
+    private HapiApiSpec createWithAutoRenewWorks() {
+        return defaultHapiSpec("CreateWithAutoRenewWorks")
+                .given(
+                        cryptoCreate(CIVILIAN),
+                        fileCreate("ntb")
+                                .unmodifiable()
+                                .autoRenewAccount(CIVILIAN)
+                                .signedBy(DEFAULT_PAYER)
+                                .hasKnownStatus(INVALID_SIGNATURE)
+                )
+                .when(
+                        fileCreate("ok")
+                                .unmodifiable()
+                                .autoRenewAccount(CIVILIAN))
+                .then(getFileInfo("ok").hasAutoRenewAccount(CIVILIAN));
+    }
+
+    private HapiApiSpec updateWithAutoRenewWorks() {
+        final var target = "someFile";
+        final var replAutoRenew = "replAutoRenew";
+        return defaultHapiSpec("UpdateWithAutoRenewWorks")
+                .given(
+                        cryptoCreate(CIVILIAN),
+                        cryptoCreate(replAutoRenew),
+                        fileCreate(target)
+                                .autoRenewAccount(CIVILIAN))
+                .when(
+                        fileUpdate(target)
+                                .autoRenewAccount(replAutoRenew)
+                                .signedBy(DEFAULT_PAYER, target)
+                                .hasKnownStatus(INVALID_SIGNATURE),
+                        fileUpdate(target)
+                                .autoRenewAccount(replAutoRenew),
+                        getFileInfo(target).hasAutoRenewAccount(replAutoRenew)
+                )
+                .then(
+                        fileUpdate(target)
+                                .autoRenewAccount("0.0.0")
+                                .signedBy(DEFAULT_PAYER, target),
+                        getFileInfo(target).hasNoAutoRenewAccount()
+                );
     }
 
     private HapiApiSpec createFailsWithMissingSigs() {

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/file/FileCreateSuite.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/file/FileCreateSuite.java
@@ -16,7 +16,6 @@
 package com.hedera.services.bdd.suites.file;
 
 import static com.hedera.services.bdd.spec.HapiApiSpec.defaultHapiSpec;
-import static com.hedera.services.bdd.spec.HapiApiSpec.onlyDefaultHapiSpec;
 import static com.hedera.services.bdd.spec.keys.ControlForKey.forKey;
 import static com.hedera.services.bdd.spec.keys.KeyShape.SIMPLE;
 import static com.hedera.services.bdd.spec.keys.KeyShape.listOf;
@@ -28,8 +27,6 @@ import static com.hedera.services.bdd.spec.queries.QueryVerbs.getFileInfo;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoCreate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.fileCreate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.fileUpdate;
-import static com.hedera.services.bdd.spec.utilops.UtilVerbs.newKeyListNamed;
-import static com.hedera.services.bdd.spec.utilops.UtilVerbs.newKeyNamed;
 import static com.hedera.services.bdd.suites.file.FileUpdateSuite.CIVILIAN;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.AUTORENEW_DURATION_NOT_IN_RANGE;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_NODE_ACCOUNT;
@@ -41,7 +38,6 @@ import com.hedera.services.bdd.spec.HapiSpecSetup;
 import com.hedera.services.bdd.spec.keys.KeyShape;
 import com.hedera.services.bdd.spec.keys.SigControl;
 import com.hedera.services.bdd.spec.transactions.TxnUtils;
-import com.hedera.services.bdd.spec.utilops.UtilVerbs;
 import com.hedera.services.bdd.suites.HapiApiSuite;
 import com.hederahashgraph.api.proto.java.AccountID;
 import com.hederahashgraph.api.proto.java.Transaction;
@@ -72,8 +68,8 @@ public class FileCreateSuite extends HapiApiSuite {
                     createFailsWithMissingSigs(),
                     createFailsWithPayerAccountNotFound(),
                     createFailsWithExcessiveLifetime(),
-                        createWithAutoRenewWorks(),
-                        updateWithAutoRenewWorks(),
+                    createWithAutoRenewWorks(),
+                    updateWithAutoRenewWorks(),
                 });
     }
 
@@ -108,12 +104,8 @@ public class FileCreateSuite extends HapiApiSuite {
                                 .unmodifiable()
                                 .autoRenewAccount(CIVILIAN)
                                 .signedBy(DEFAULT_PAYER)
-                                .hasKnownStatus(INVALID_SIGNATURE)
-                )
-                .when(
-                        fileCreate("ok")
-                                .unmodifiable()
-                                .autoRenewAccount(CIVILIAN))
+                                .hasKnownStatus(INVALID_SIGNATURE))
+                .when(fileCreate("ok").unmodifiable().autoRenewAccount(CIVILIAN))
                 .then(getFileInfo("ok").hasAutoRenewAccount(CIVILIAN));
     }
 
@@ -124,23 +116,19 @@ public class FileCreateSuite extends HapiApiSuite {
                 .given(
                         cryptoCreate(CIVILIAN),
                         cryptoCreate(replAutoRenew),
-                        fileCreate(target)
-                                .autoRenewAccount(CIVILIAN))
+                        fileCreate(target).autoRenewAccount(CIVILIAN))
                 .when(
                         fileUpdate(target)
                                 .autoRenewAccount(replAutoRenew)
                                 .signedBy(DEFAULT_PAYER, target)
                                 .hasKnownStatus(INVALID_SIGNATURE),
-                        fileUpdate(target)
-                                .autoRenewAccount(replAutoRenew),
-                        getFileInfo(target).hasAutoRenewAccount(replAutoRenew)
-                )
+                        fileUpdate(target).autoRenewAccount(replAutoRenew),
+                        getFileInfo(target).hasAutoRenewAccount(replAutoRenew))
                 .then(
                         fileUpdate(target)
                                 .autoRenewAccount("0.0.0")
                                 .signedBy(DEFAULT_PAYER, target),
-                        getFileInfo(target).hasNoAutoRenewAccount()
-                );
+                        getFileInfo(target).hasNoAutoRenewAccount());
     }
 
     private HapiApiSpec createFailsWithMissingSigs() {

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/file/FileCreateSuite.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/file/FileCreateSuite.java
@@ -43,7 +43,6 @@ import com.hedera.services.bdd.spec.transactions.TxnUtils;
 import com.hedera.services.bdd.suites.HapiApiSuite;
 import com.hederahashgraph.api.proto.java.AccountID;
 import com.hederahashgraph.api.proto.java.Transaction;
-
 import java.time.Instant;
 import java.util.List;
 import org.apache.logging.log4j.LogManager;
@@ -101,9 +100,8 @@ public class FileCreateSuite extends HapiApiSuite {
     }
 
     private HapiApiSpec createWithAutoRenewWorks() {
-        final var explicitExpiry = Instant.now()
-                .plusSeconds(2 * ONE_MONTHS_IN_SECONDS)
-                .getEpochSecond();
+        final var explicitExpiry =
+                Instant.now().plusSeconds(2 * ONE_MONTHS_IN_SECONDS).getEpochSecond();
         final var someAutoRenewPeriod = THREE_MONTHS_IN_SECONDS + 1;
 
         final var withIgnoredExpiry = "withIgnoredExpiry";

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/file/FileCreateSuite.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/file/FileCreateSuite.java
@@ -105,25 +105,41 @@ public class FileCreateSuite extends HapiApiSuite {
                                 .autoRenewAccount(CIVILIAN)
                                 .signedBy(DEFAULT_PAYER)
                                 .hasKnownStatus(INVALID_SIGNATURE))
-                .when(fileCreate("ok").unmodifiable().autoRenewAccount(CIVILIAN))
-                .then(getFileInfo("ok").hasAutoRenewAccount(CIVILIAN));
+                .when(
+                        fileCreate("ok")
+                                .unmodifiable()
+                                .autoRenewPeriod(THREE_MONTHS_IN_SECONDS + 1)
+                                .autoRenewAccount(CIVILIAN))
+                .then(
+                        getFileInfo("ok")
+                                .hasAutoRenewPeriod(THREE_MONTHS_IN_SECONDS + 1)
+                                .hasAutoRenewAccount(CIVILIAN));
     }
 
     private HapiApiSpec updateWithAutoRenewWorks() {
         final var target = "someFile";
         final var replAutoRenew = "replAutoRenew";
+        final var firstAutoRenewPeriod = 7776666L;
+        final var secondAutoRenewPeriod = 7777777L;
         return defaultHapiSpec("UpdateWithAutoRenewWorks")
                 .given(
                         cryptoCreate(CIVILIAN),
                         cryptoCreate(replAutoRenew),
-                        fileCreate(target).autoRenewAccount(CIVILIAN))
+                        fileCreate(target)
+                                .autoRenewPeriod(firstAutoRenewPeriod)
+                                .autoRenewAccount(CIVILIAN))
                 .when(
                         fileUpdate(target)
                                 .autoRenewAccount(replAutoRenew)
+                                .autoRenewPeriod(secondAutoRenewPeriod)
                                 .signedBy(DEFAULT_PAYER, target)
                                 .hasKnownStatus(INVALID_SIGNATURE),
-                        fileUpdate(target).autoRenewAccount(replAutoRenew),
-                        getFileInfo(target).hasAutoRenewAccount(replAutoRenew))
+                        fileUpdate(target)
+                                .autoRenewPeriod(secondAutoRenewPeriod)
+                                .autoRenewAccount(replAutoRenew),
+                        getFileInfo(target)
+                                .hasAutoRenewPeriod(secondAutoRenewPeriod)
+                                .hasAutoRenewAccount(replAutoRenew))
                 .then(
                         fileUpdate(target)
                                 .autoRenewAccount("0.0.0")

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/file/FileUpdateSuite.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/file/FileUpdateSuite.java
@@ -16,6 +16,7 @@
 package com.hedera.services.bdd.suites.file;
 
 import static com.hedera.services.bdd.spec.HapiApiSpec.defaultHapiSpec;
+import static com.hedera.services.bdd.spec.HapiApiSpec.onlyDefaultHapiSpec;
 import static com.hedera.services.bdd.spec.assertions.ContractFnResultAsserts.resultWith;
 import static com.hedera.services.bdd.spec.assertions.ContractInfoAsserts.contractWith;
 import static com.hedera.services.bdd.spec.assertions.TransactionRecordAsserts.recordWith;
@@ -62,11 +63,11 @@ import static com.hedera.services.bdd.spec.utilops.UtilVerbs.updateSpecialFile;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.usableTxnIdNamed;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.withOpContext;
 import static com.hedera.services.bdd.suites.utils.contracts.SimpleBytesResult.bigIntResult;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.AUTORENEW_DURATION_NOT_IN_RANGE;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.BUSY;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.CONSENSUS_GAS_EXHAUSTED;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.CUSTOM_FEES_LIST_TOO_LONG;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INSUFFICIENT_BALANCES_FOR_STORAGE_RENT;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_EXPIRATION_TIME;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_TOKEN_ID;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_ZERO_BYTE_IN_STRING;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.MAX_CONTRACT_STORAGE_EXCEEDED;
@@ -379,13 +380,13 @@ public class FileUpdateSuite extends HapiApiSuite {
     }
 
     private HapiApiSpec cannotUpdateExpirationPastMaxLifetime() {
-        return defaultHapiSpec("CannotUpdateExpirationPastMaxLifetime")
+        return onlyDefaultHapiSpec("CannotUpdateExpirationPastMaxLifetime")
                 .given(fileCreate("test"))
                 .when()
                 .then(
                         fileUpdate("test")
                                 .lifetime(DEFAULT_MAX_LIFETIME + 12_345L)
-                                .hasPrecheck(AUTORENEW_DURATION_NOT_IN_RANGE));
+                                .hasKnownStatus(INVALID_EXPIRATION_TIME));
     }
 
     private HapiApiSpec maxRefundIsEnforced() {

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenTransactSpecs.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenTransactSpecs.java
@@ -2152,7 +2152,7 @@ public class TokenTransactSpecs extends HapiApiSuite {
         final var returnTransfer = "returnTransfer";
         final var multiKey = "multiKey";
 
-        return onlyDefaultHapiSpec("TreasuriesAreExemptFromFallbackFeesWhenReceivingNfts")
+        return defaultHapiSpec("TreasuriesAreExemptFromFallbackFeesWhenReceivingNfts")
                 .given(
                         newKeyNamed(multiKey),
                         cryptoCreate(edgar),

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenTransactSpecs.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenTransactSpecs.java
@@ -17,7 +17,6 @@ package com.hedera.services.bdd.suites.token;
 
 import static com.google.protobuf.ByteString.copyFromUtf8;
 import static com.hedera.services.bdd.spec.HapiApiSpec.defaultHapiSpec;
-import static com.hedera.services.bdd.spec.HapiApiSpec.onlyDefaultHapiSpec;
 import static com.hedera.services.bdd.spec.assertions.AccountInfoAsserts.accountWith;
 import static com.hedera.services.bdd.spec.assertions.AccountInfoAsserts.changeFromSnapshot;
 import static com.hedera.services.bdd.spec.assertions.AutoAssocAsserts.accountTokenPairs;


### PR DESCRIPTION
**Description**:
 - Allows users to create and update files and accounts with auto-renew metadata; and see this metadata via queries.
    * ➡️  Note that neither entity type expires today.
 - Reduces duplication of expiry metadata logic by creating [an `ExpiryValidator`](https://github.com/hashgraph/hedera-services/blob/0103-account-and-file-auto-renew-accounts/hedera-node/hedera-mono-service/src/main/java/com/hedera/services/txns/validation/ExpiryValidator.java#L25) that is used for `Crypto{Create,Update}` and `File{Create,Update}`.
    * 🧾 We should eventually refactor all entity types' expiry metadata management to use the `ExpiryValidator` instead of repeating its logic (or slight variations on its logic!)

**Related issues**:
 - Closes #103 
 - Closes #4245 