### PR TITLE
Fix Maven publishes of the EVM modules to properly respect prerelease versions

### DIFF
--- a/.github/workflows/comp-build-release-artifact.yaml
+++ b/.github/workflows/comp-build-release-artifact.yaml
@@ -270,7 +270,7 @@ jobs:
           sha384sum "${ARTIFACT_NAME}.zip" | tee "${ARTIFACT_NAME}.sha384"
 
       - name: Upload Artifacts (DevOps GCP Bucket)
-        uses: google-github-actions/upload-cloud-storage@v0.10.2
+        uses: google-github-actions/upload-cloud-storage@v0.10.4
         if: ${{ inputs.dry-run-enabled != true && !cancelled() && !failure() }}
         with:
           path: ${{ steps.artifact-release.outputs.folder }}

--- a/.github/workflows/comp-build-release-artifact.yaml
+++ b/.github/workflows/comp-build-release-artifact.yaml
@@ -144,12 +144,12 @@ jobs:
           COMMIT_PREFIX="adhoc"
           [[ "${{ inputs.version-policy }}" == "branch-commit" ]] && COMMIT_PREFIX="${BRANCH_NAME_SAFE}"
 
-          echo "::set-output name=branch-name::${BRANCH_NAME}"
-          echo "::set-output name=branch-name-lower::${BRANCH_NAME_LOWER}"
-          echo "::set-output name=branch-name-safe::${BRANCH_NAME_SAFE}"
-          echo "::set-output name=commit-prefix::${COMMIT_PREFIX}"
-          echo "::set-output name=commit-id::${{ github.sha }}"
-          echo "::set-output name=commit-id-short::$(echo "${{ github.sha }}" | cut -c1-8)"
+          echo "branch-name=${BRANCH_NAME}" >>"${GITHUB_OUTPUT}"
+          echo "branch-name-lower=${BRANCH_NAME_LOWER}" >>"${GITHUB_OUTPUT}"
+          echo "branch-name-safe=${BRANCH_NAME_SAFE}" >>"${GITHUB_OUTPUT}"
+          echo "commit-prefix=${COMMIT_PREFIX}" >>"${GITHUB_OUTPUT}"
+          echo "commit-id=${{ github.sha }}" >>"${GITHUB_OUTPUT}"
+          echo "commit-id-short=$(echo "${{ github.sha }}" | cut -c1-8)" >>"${GITHUB_OUTPUT}"
 
       - name: Verify Version Update (As Specified)
         if: ${{ inputs.version-policy == 'specified' && !cancelled() && !failure() }}
@@ -220,7 +220,7 @@ jobs:
         id: effective-version
         run: |
           EFF_VERSION="$(./gradlew showVersion --quiet | tr -d '[:space:]')"
-          echo "::set-output name=number::${EFF_VERSION}"
+          echo "number=${EFF_VERSION}" >>"${GITHUB_OUTPUT}"
 
       - name: Stage Artifact Build Folder
         id: artifact-staging
@@ -234,7 +234,7 @@ jobs:
           cp -f hedera-node/configuration/update/immediate.sh "${BUILD_BASE_DIR}"
           cp -f hedera-node/configuration/update/during-freeze.sh "${BUILD_BASE_DIR}"
 
-          echo "::set-output name=folder::${BUILD_BASE_DIR}"
+          echo "folder=${BUILD_BASE_DIR}" >>"${GITHUB_OUTPUT}"
 
       - name: Write Artifact Version Descriptor
         working-directory: ${{ steps.artifact-staging.outputs.folder }}
@@ -259,9 +259,9 @@ jobs:
           ARTIFACT_FILE="${ARTIFACT_BASE_DIR}/${ARTIFACT_NAME}.zip"
           deterministic-zip -D -vr "${ARTIFACT_FILE}" *
 
-          echo "::set-output name=folder::${ARTIFACT_BASE_DIR}"
-          echo "::set-output name=name::${ARTIFACT_NAME}"
-          echo "::set-output name=file::${ARTIFACT_FILE}"
+          echo "folder=${ARTIFACT_BASE_DIR}" >>"${GITHUB_OUTPUT}"
+          echo "name=${ARTIFACT_NAME}" >>"${GITHUB_OUTPUT}"
+          echo "file=${ARTIFACT_FILE}" >>"${GITHUB_OUTPUT}"
 
       - name: Compute SHA Hash
         working-directory: ${{ steps.artifact-release.outputs.folder }}

--- a/.github/workflows/flow-deploy-release-artifact.yaml
+++ b/.github/workflows/flow-deploy-release-artifact.yaml
@@ -150,6 +150,9 @@ jobs:
     runs-on: [self-hosted, Linux, services, standard, ephemeral]
     needs:
       - prepare-tag-release
+      - release-adhoc
+      - release-tag
+      - release-branch
     outputs:
       payload: ${{ steps.dispatch.outputs.payload }}
     if: ${{ always() }}

--- a/.github/workflows/flow-deploy-release-artifact.yaml
+++ b/.github/workflows/flow-deploy-release-artifact.yaml
@@ -89,6 +89,7 @@ jobs:
     if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') }}
     outputs:
       version: ${{ steps.tag.outputs.version }}
+      prerelease: ${{ steps.tag.outputs.prerelease }}
     steps:
       - name: Install Semantic Version Tools
         run: |
@@ -109,9 +110,12 @@ jobs:
           PRERELEASE_VERSION="$(semver get prerel "${{ github.ref_name }}")"
 
           FINAL_VERSION="${RELEASE_VERSION}"
+          PRERELEASE_FLAG="false"
           [[ -n "${PRERELEASE_VERSION}" ]] && FINAL_VERSION="${RELEASE_VERSION}-${PRERELEASE_VERSION}"
-
-          echo "::set-output name=version::${FINAL_VERSION}"
+          [[ -n "${PRERELEASE_VERSION}" ]] && PRERELEASE_FLAG="true"
+          
+          echo "version=${FINAL_VERSION}" >>"${GITHUB_OUTPUT}"
+          echo "prerelease=${PRERELEASE_FLAG}" >>"${GITHUB_OUTPUT}"
 
   release-tag:
     name: Release / Tag
@@ -190,7 +194,6 @@ jobs:
             VERSION_NUM="${{ needs.prepare-tag-release.outputs.version }}"
           fi
 
-
           REQ_JSON="$(jq --compact-output --null-input \
                       --arg ref "${{ github.ref }}" \
                       --arg jdist "${{ github.event.inputs.java-distribution || 'temurin' }}" \
@@ -200,7 +203,8 @@ jobs:
                       --arg vnum "${VERSION_NUM}" \
                       '{"ref": $ref, "java": {"distribution": $jdist, "version": $jver}, "gradle": {"version": $gver}, "release": {"version": {"policy": $vpol, "number": $vnum}}}')"
 
-          echo "::set-output name=payload::${REQ_JSON}"
+          echo "payload=${REQ_JSON}" >>"${GITHUB_OUTPUT}"
+          printf "## Dispatch Payload\n```json\n%s\n```\n" "$(jq '.' <<<"${REQ_JSON}")" >>"${GITHUB_STEP_SUMMARY}"
 
   dispatch-mc-release:
     name: Release / MC / Dispatch
@@ -210,7 +214,7 @@ jobs:
       - release-adhoc
       - release-tag
       - release-branch
-    if: ${{ always() }}
+    if: (needs.release-tag.result == 'success' || needs.release-branch.result == 'success' || needs.release-adhoc.result == 'success') && needs.prepare-mc-release.result == 'success' && always() }}
     steps:
       - name: Repository Dispatch
         uses: peter-evans/repository-dispatch@v2

--- a/.github/workflows/flow-deploy-release-artifact.yaml
+++ b/.github/workflows/flow-deploy-release-artifact.yaml
@@ -204,7 +204,7 @@ jobs:
                       '{"ref": $ref, "java": {"distribution": $jdist, "version": $jver}, "gradle": {"version": $gver}, "release": {"version": {"policy": $vpol, "number": $vnum}}}')"
 
           echo "payload=${REQ_JSON}" >>"${GITHUB_OUTPUT}"
-          printf "## Dispatch Payload\n```json\n%s\n```\n" "$(jq '.' <<<"${REQ_JSON}")" >>"${GITHUB_STEP_SUMMARY}"
+          printf "## Dispatch Payload\n\`\`\`json\n%s\n\`\`\`\n" "$(jq '.' <<<"${REQ_JSON}")" >>"${GITHUB_STEP_SUMMARY}"
 
   dispatch-mc-release:
     name: Release / MC / Dispatch

--- a/.github/workflows/flow-deploy-release-artifact.yaml
+++ b/.github/workflows/flow-deploy-release-artifact.yaml
@@ -113,7 +113,7 @@ jobs:
           PRERELEASE_FLAG="false"
           [[ -n "${PRERELEASE_VERSION}" ]] && FINAL_VERSION="${RELEASE_VERSION}-${PRERELEASE_VERSION}"
           [[ -n "${PRERELEASE_VERSION}" ]] && PRERELEASE_FLAG="true"
-          
+
           echo "version=${FINAL_VERSION}" >>"${GITHUB_OUTPUT}"
           echo "prerelease=${PRERELEASE_FLAG}" >>"${GITHUB_OUTPUT}"
 

--- a/.github/workflows/flow-deploy-release-artifact.yaml
+++ b/.github/workflows/flow-deploy-release-artifact.yaml
@@ -214,7 +214,7 @@ jobs:
       - release-adhoc
       - release-tag
       - release-branch
-    if: (needs.release-tag.result == 'success' || needs.release-branch.result == 'success' || needs.release-adhoc.result == 'success') && needs.prepare-mc-release.result == 'success' && always() }}
+    if: ${{ (needs.release-tag.result == 'success' || needs.release-branch.result == 'success' || needs.release-adhoc.result == 'success') && needs.prepare-mc-release.result == 'success' && always() }}
     steps:
       - name: Repository Dispatch
         uses: peter-evans/repository-dispatch@v2


### PR DESCRIPTION
## Description

Enhances the release workflows to remove Github features which are deprecated. Additionally, adds a new output to allow for the filtering of prerelease builds. Improves the workflow to not attempt a MC release if the prerequisite jobs have failed. 

The actual fix for publishing prerelease tag versions was made in [this commit](https://github.com/hashgraph/hedera-internal-workflows/commit/52c9d728e6f2e49052dd2aecae971210ef62a2a6) on the internal repository.

### Related Issues 

- Closes #4189 