### PR TITLE
Enhance the release pipeline to ensure a failure if Jenkins fails to dispatch the job

### DIFF
--- a/.github/workflows/comp-build-release-artifact.yaml
+++ b/.github/workflows/comp-build-release-artifact.yaml
@@ -306,8 +306,8 @@ jobs:
         env:
           JSON_RESPONSE: ${{ steps.jenkins-integration.outputs.response }}
         run: |
-          INTEGRATION_TRIGGERED="$(jq '.jobs."build-upgrade-integration".triggered' <<"${JSON_RESPONSE}")"
-          DOCKER_TRIGGERED="$(jq '.jobs."build-upgrade-integration-docker".triggered' <<"${JSON_RESPONSE}")"
+          INTEGRATION_TRIGGERED="$(jq '.jobs."build-upgrade-integration".triggered' <<<"${JSON_RESPONSE}")"
+          DOCKER_TRIGGERED="$(jq '.jobs."build-upgrade-integration-docker".triggered' <<<"${JSON_RESPONSE}")"
 
           if [[ "${INTEGRATION_TRIGGERED}" != true ]]; then
             echo "::error title=Jenkins Trigger Failure::Failed to trigger the 'build-upgrade-integration' job via the Jenkins 'integration' pipeline!"
@@ -324,7 +324,7 @@ jobs:
         env:
           JSON_RESPONSE: ${{ steps.jenkins-preview.outputs.response }}
         run: |
-          PREVIEW_TRIGGERED="$(jq '.jobs."build-preview-testnet".triggered' <<"${JSON_RESPONSE}")"
+          PREVIEW_TRIGGERED="$(jq '.jobs."build-preview-testnet".triggered' <<<"${JSON_RESPONSE}")"
          
           if [[ "${PREVIEW_TRIGGERED}" != true ]]; then
             echo "::error title=Jenkins Trigger Failure::Failed to trigger the 'build-preview-testnet' job via the Jenkins 'preview' pipeline!"

--- a/.github/workflows/comp-build-release-artifact.yaml
+++ b/.github/workflows/comp-build-release-artifact.yaml
@@ -295,9 +295,39 @@ jobs:
 
       - name: Display Jenkins Payload
         env:
-          JSON_RESPONSE: ${{ steps.jenkins-integration.outputs.response }}
+          JSON_RESPONSE: ${{ steps.jenkins-integration.outputs.response || steps.jenkins-preview.outputs.response }}
         if: ${{ inputs.trigger-env-deploy == 'integration' || inputs.trigger-env-deploy == 'preview' }}
-        run: jq '.' <<<"${JSON_RESPONSE}"
+        run: |
+          jq '.' <<<"${JSON_RESPONSE}"
+          printf "## Jenkins Response Payload\n\`\`\`json\n%s\n\`\`\`\n" "$(jq '.' <<<"${JSON_RESPONSE}")" >>"${GITHUB_STEP_SUMMARY}"
 
-#      - name: Check for Jenkins Failures
-#        run: |
+      - name: Check for Jenkins Failures (Integration)
+        if: ${{ inputs.trigger-env-deploy == 'integration' }}
+        env:
+          JSON_RESPONSE: ${{ steps.jenkins-integration.outputs.response }}
+        run: |
+          INTEGRATION_TRIGGERED="$(jq '.jobs."build-upgrade-integration".triggered' <<"${JSON_RESPONSE}")"
+          DOCKER_TRIGGERED="$(jq '.jobs."build-upgrade-integration-docker".triggered' <<"${JSON_RESPONSE}")"
+
+          if [[ "${INTEGRATION_TRIGGERED}" != true ]]; then
+            echo "::error title=Jenkins Trigger Failure::Failed to trigger the 'build-upgrade-integration' job via the Jenkins 'integration' pipeline!"
+            exit 1
+          fi
+          
+          if [[ "${DOCKER_TRIGGERED}" != true ]]; then
+            echo "::error title=Jenkins Trigger Failure::Failed to trigger the 'build-upgrade-integration-docker' job via the Jenkins 'integration' pipeline!"
+            exit 1
+          fi
+
+      - name: Check for Jenkins Failures (Preview)
+        if: ${{ inputs.trigger-env-deploy == 'preview' }}
+        env:
+          JSON_RESPONSE: ${{ steps.jenkins-preview.outputs.response }}
+        run: |
+          PREVIEW_TRIGGERED="$(jq '.jobs."build-preview-testnet".triggered' <<"${JSON_RESPONSE}")"
+         
+          if [[ "${PREVIEW_TRIGGERED}" != true ]]; then
+            echo "::error title=Jenkins Trigger Failure::Failed to trigger the 'build-preview-testnet' job via the Jenkins 'preview' pipeline!"
+            exit 1
+          fi
+          

--- a/.github/workflows/comp-build-release-artifact.yaml
+++ b/.github/workflows/comp-build-release-artifact.yaml
@@ -299,7 +299,7 @@ jobs:
         if: ${{ inputs.trigger-env-deploy == 'integration' || inputs.trigger-env-deploy == 'preview' }}
         run: |
           jq '.' <<<"${JSON_RESPONSE}"
-          printf "## Jenkins Response Payload\n\`\`\`json\n%s\n\`\`\`\n" "$(jq '.' <<<"${JSON_RESPONSE}")" >>"${GITHUB_STEP_SUMMARY}"
+          printf "### Jenkins Response Payload\n\`\`\`json\n%s\n\`\`\`\n" "$(jq '.' <<<"${JSON_RESPONSE}")" >>"${GITHUB_STEP_SUMMARY}"
 
       - name: Check for Jenkins Failures (Integration)
         if: ${{ inputs.trigger-env-deploy == 'integration' }}

--- a/.github/workflows/comp-build-release-artifact.yaml
+++ b/.github/workflows/comp-build-release-artifact.yaml
@@ -313,7 +313,7 @@ jobs:
             echo "::error title=Jenkins Trigger Failure::Failed to trigger the 'build-upgrade-integration' job via the Jenkins 'integration' pipeline!"
             exit 1
           fi
-          
+
           if [[ "${DOCKER_TRIGGERED}" != true ]]; then
             echo "::error title=Jenkins Trigger Failure::Failed to trigger the 'build-upgrade-integration-docker' job via the Jenkins 'integration' pipeline!"
             exit 1
@@ -325,9 +325,8 @@ jobs:
           JSON_RESPONSE: ${{ steps.jenkins-preview.outputs.response }}
         run: |
           PREVIEW_TRIGGERED="$(jq '.jobs."build-preview-testnet".triggered' <<<"${JSON_RESPONSE}")"
-         
+
           if [[ "${PREVIEW_TRIGGERED}" != true ]]; then
             echo "::error title=Jenkins Trigger Failure::Failed to trigger the 'build-preview-testnet' job via the Jenkins 'preview' pipeline!"
             exit 1
           fi
-          

--- a/.github/workflows/comp-build-release-artifact.yaml
+++ b/.github/workflows/comp-build-release-artifact.yaml
@@ -278,6 +278,7 @@ jobs:
           parent: false
 
       - name: Notify Jenkins of Release (Integration)
+        id: jenkins-integration
         uses: fjogeleit/http-request-action@v1.10.0
         if: ${{ inputs.dry-run-enabled != true && inputs.trigger-env-deploy == 'integration' && !cancelled() && !failure() }}
         with:
@@ -285,8 +286,18 @@ jobs:
           data: ${{ toJSON(github.event) }}
 
       - name: Notify Jenkins of Release (Preview)
+        id: jenkins-preview
         uses: fjogeleit/http-request-action@v1.10.0
         if: ${{ inputs.dry-run-enabled != true && inputs.trigger-env-deploy == 'preview' && !cancelled() && !failure() }}
         with:
           url: ${{ secrets.jenkins-preview-url }}
           data: ${{ toJSON(github.event) }}
+
+      - name: Display Jenkins Payload
+        env:
+          JSON_RESPONSE: ${{ steps.jenkins-integration.outputs.response }}
+        if: ${{ inputs.trigger-env-deploy == 'integration' || inputs.trigger-env-deploy == 'preview' }}
+        run: jq '.' <<<"${JSON_RESPONSE}"
+
+#      - name: Check for Jenkins Failures
+#        run: |

--- a/.github/workflows/flow-deploy-release-artifact.yaml
+++ b/.github/workflows/flow-deploy-release-artifact.yaml
@@ -71,7 +71,9 @@ jobs:
       version-policy: branch-commit
       #      new-version: ${{ github.event.inputs.new-version }}
       #      trigger-env-deploy: ${{ github.event.inputs.trigger-env-deploy }}
-      trigger-env-deploy: none
+      #trigger-env-deploy: none
+      # For testing only via integration
+      trigger-env-deploy: integration
       dry-run-enabled: ${{ github.event.inputs.dry-run-enabled == 'true' }}
       java-version: ${{ github.event.inputs.java-version || '17.0.3' }}
       java-distribution: ${{ github.event.inputs.java-distribution || 'temurin' }}

--- a/.github/workflows/flow-deploy-release-artifact.yaml
+++ b/.github/workflows/flow-deploy-release-artifact.yaml
@@ -71,9 +71,7 @@ jobs:
       version-policy: branch-commit
       #      new-version: ${{ github.event.inputs.new-version }}
       #      trigger-env-deploy: ${{ github.event.inputs.trigger-env-deploy }}
-      #trigger-env-deploy: none
-      # For testing only via integration
-      trigger-env-deploy: integration
+      trigger-env-deploy: none
       dry-run-enabled: ${{ github.event.inputs.dry-run-enabled == 'true' }}
       java-version: ${{ github.event.inputs.java-version || '17.0.3' }}
       java-distribution: ${{ github.event.inputs.java-distribution || 'temurin' }}


### PR DESCRIPTION
## Description

Updates the CI release pipeline to ensure that any Jenkins handoff failures will properly cause the GH Actions workflow to report the failure by failing in turn.

### Related Issues

- Closes #4190 