### PR TITLE
Add concurrency group support to the PR Checks CI workflow

### DIFF
--- a/.github/workflows/flow-pull-request-checks.yaml
+++ b/.github/workflows/flow-pull-request-checks.yaml
@@ -27,6 +27,10 @@ defaults:
   run:
     shell: bash
 
+concurrency:
+  group: pr-checks-${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: Code


### PR DESCRIPTION
## Description

Adds a concurrency group constraint to the PR Checks CI pipeline to prevent multiple PR updates from simultaneously running many jobs which could monopolize the available CI runners. 

### Related Issues

- Closes #4260 