### PR TITLE
Set balance on synthetic creations export records

### DIFF
--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/services/state/merkle/MerkleNetworkContext.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/services/state/merkle/MerkleNetworkContext.java
@@ -62,7 +62,7 @@ import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes32;
 
 public class MerkleNetworkContext extends PartialMerkleLeaf implements MerkleLeaf {
-    private static final long MAX_PENDING_REWARDS = 50_000_000_000L * HBARS_TO_TINYBARS;
+    public static final long MAX_PENDING_REWARDS = 50_000_000_000L * HBARS_TO_TINYBARS;
     private static final Logger log = LogManager.getLogger(MerkleNetworkContext.class);
 
     private static final int NUM_BLOCK_HASHES_TO_KEEP = 256;

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/services/state/migration/MigrationRecordsManager.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/services/state/migration/MigrationRecordsManager.java
@@ -213,8 +213,9 @@ public class MigrationRecordsManager {
                         balance);
         final var synthRecord =
                 creator.createSuccessfulSyntheticRecord(NO_CUSTOM_FEES, tracker, recordMemo);
-        // show the balance of treasury account for mirror node reconciliation.
-        if (num.longValue() == 2L) {
+        // show the balance of any accounts whose balance is not zero for mirror node
+        // reconciliation.
+        if (balance != 0) {
             synthRecord.setHbarAdjustments(
                     CurrencyAdjustments.fromChanges(
                             new long[] {balance}, new long[] {num.longValue()}));

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/services/state/migration/MigrationRecordsManager.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/services/state/migration/MigrationRecordsManager.java
@@ -35,6 +35,7 @@ import com.hedera.services.records.RecordsHistorian;
 import com.hedera.services.state.EntityCreator;
 import com.hedera.services.state.initialization.BackedSystemAccountsCreator;
 import com.hedera.services.state.merkle.MerkleNetworkContext;
+import com.hedera.services.state.submerkle.CurrencyAdjustments;
 import com.hedera.services.state.submerkle.ExpirableTxnRecord;
 import com.hedera.services.store.contracts.precompile.SyntheticTxnFactory;
 import com.hedera.services.utils.EntityNum;
@@ -167,7 +168,8 @@ public class MigrationRecordsManager {
                                 asKeyUnchecked(account.getAccountKey()),
                                 account.getMemo(),
                                 memo,
-                                description));
+                                description,
+                                account.getBalance()));
     }
 
     private boolean grantingFreeAutoRenewals() {
@@ -184,7 +186,9 @@ public class MigrationRecordsManager {
                 immutableKey,
                 EMPTY_MEMO,
                 STAKING_MEMO,
-                "staking fund");
+                "staking fund",
+                0L); // since 0.0.800 and 0.0.801 are created with zero balance,
+                            // it is okay to hard code zero balance here.
     }
 
     @SuppressWarnings("java:S107")
@@ -196,14 +200,18 @@ public class MigrationRecordsManager {
             final Key key,
             final String accountMemo,
             final String recordMemo,
-            final String description) {
+            final String description,
+            final long balance) {
         final var tracker = sideEffectsFactory.get();
         tracker.trackAutoCreation(num.toGrpcAccountId(), ByteString.EMPTY);
         final var synthBody =
                 synthCreation(
-                        autoRenewPeriod, key, accountMemo, receiverSigRequired, declineReward);
+                        autoRenewPeriod, key, accountMemo, receiverSigRequired, declineReward, balance);
         final var synthRecord =
                 creator.createSuccessfulSyntheticRecord(NO_CUSTOM_FEES, tracker, recordMemo);
+//        synthRecord.setHbarAdjustments(CurrencyAdjustments
+//                .fromChanges(new long[]{balance}, new long[]{num.longValue()}));
+
         recordsHistorian.trackPrecedingChildRecord(DEFAULT_SOURCE_ID, synthBody, synthRecord);
         sigImpactHistorian.markEntityChanged(num.longValue());
         log.info(
@@ -217,14 +225,15 @@ public class MigrationRecordsManager {
             final Key key,
             final String memo,
             final boolean receiverSigRequired,
-            final boolean declineReward) {
+            final boolean declineReward,
+            final long balance) {
         final var txnBody =
                 CryptoCreateTransactionBody.newBuilder()
                         .setKey(key)
                         .setMemo(memo)
                         .setDeclineReward(declineReward)
                         .setReceiverSigRequired(receiverSigRequired)
-                        .setInitialBalance(0)
+                        .setInitialBalance(balance)
                         .setAutoRenewPeriod(Duration.newBuilder().setSeconds(autoRenewPeriod))
                         .build();
         return TransactionBody.newBuilder().setCryptoCreateAccount(txnBody);

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/services/state/migration/MigrationRecordsManager.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/services/state/migration/MigrationRecordsManager.java
@@ -187,8 +187,7 @@ public class MigrationRecordsManager {
                 EMPTY_MEMO,
                 STAKING_MEMO,
                 "staking fund",
-                0L); // since 0.0.800 and 0.0.801 are created with zero balance,
-                            // it is okay to hard code zero balance here.
+                0L); // since 0.0.800 and 0.0.801 are created with zero balance
     }
 
     @SuppressWarnings("java:S107")
@@ -206,11 +205,20 @@ public class MigrationRecordsManager {
         tracker.trackAutoCreation(num.toGrpcAccountId(), ByteString.EMPTY);
         final var synthBody =
                 synthCreation(
-                        autoRenewPeriod, key, accountMemo, receiverSigRequired, declineReward, balance);
+                        autoRenewPeriod,
+                        key,
+                        accountMemo,
+                        receiverSigRequired,
+                        declineReward,
+                        balance);
         final var synthRecord =
                 creator.createSuccessfulSyntheticRecord(NO_CUSTOM_FEES, tracker, recordMemo);
-//        synthRecord.setHbarAdjustments(CurrencyAdjustments
-//                .fromChanges(new long[]{balance}, new long[]{num.longValue()}));
+        // show the balance of treasury account for mirror node reconciliation.
+        if (num.longValue() == 2L) {
+            synthRecord.setHbarAdjustments(
+                    CurrencyAdjustments.fromChanges(
+                            new long[] {balance}, new long[] {num.longValue()}));
+        }
 
         recordsHistorian.trackPrecedingChildRecord(DEFAULT_SOURCE_ID, synthBody, synthRecord);
         sigImpactHistorian.markEntityChanged(num.longValue());

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/services/state/migration/MigrationRecordsManagerTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/services/state/migration/MigrationRecordsManagerTest.java
@@ -20,7 +20,9 @@ import static com.hedera.services.records.TxnAwareRecordsHistorian.DEFAULT_SOURC
 import static com.hedera.services.state.EntityCreator.EMPTY_MEMO;
 import static com.hedera.services.state.EntityCreator.NO_CUSTOM_FEES;
 import static com.hedera.services.state.initialization.TreasuryClonerTest.accountWith;
+import static com.hedera.services.state.merkle.MerkleNetworkContext.MAX_PENDING_REWARDS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.ArgumentCaptor.forClass;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
@@ -126,6 +128,7 @@ class MigrationRecordsManagerTest {
     @Mock private SideEffectsTracker tracker201;
     @Mock private SideEffectsTracker tracker100;
     @Mock private SideEffectsTracker tracker101;
+    @Mock private SideEffectsTracker tracker2;
     @Mock private EntityCreator creator;
     @Mock private AccountNumbers accountNumbers;
     @Mock private BackedSystemAccountsCreator systemAccountsCreator;
@@ -161,6 +164,52 @@ class MigrationRecordsManagerTest {
                             case 4 -> tracker100;
                             default -> tracker101;
                         });
+    }
+
+    @Test
+    void streamsTreasuryAccountCreationRecordsWithTransferList() {
+        final ArgumentCaptor<TransactionBody.Builder> bodyCaptor =
+                forClass(TransactionBody.Builder.class);
+        subject.setSideEffectsFactory(
+                () ->
+                        switch (nextTracker.getAndIncrement()) {
+                            case 0 -> tracker2;
+                            default -> tracker2;
+                        });
+
+        final var systemAccountSynthBody = expectedTreasuryAccountCreationSynthBody();
+        final var record = ExpirableTxnRecord.newBuilder();
+
+        given(consensusTimeTracker.unlimitedPreceding()).willReturn(true);
+        given(
+                        creator.createSuccessfulSyntheticRecord(
+                                NO_CUSTOM_FEES, tracker2, SYSTEM_ACCOUNT_CREATION_MEMO))
+                .willReturn(record);
+        given(systemAccountsCreator.getTreasuryClonesCreated()).willReturn(List.of());
+        given(systemAccountsCreator.getSystemAccountsCreated()).willReturn(List.of(merkleAccount));
+        given(merkleAccount.number()).willReturn(2);
+        given(merkleAccount.getBalance()).willReturn(MAX_PENDING_REWARDS);
+        given(merkleAccount.getExpiry()).willReturn(pretendExpiry);
+        given(merkleAccount.isReceiverSigRequired()).willReturn(true);
+        given(merkleAccount.getAccountKey()).willReturn(pretendTreasuryKey);
+        given(merkleAccount.getMemo()).willReturn("123");
+        given(networkCtx.consensusTimeOfLastHandledTxn()).willReturn(now);
+
+        subject.publishMigrationRecords(now);
+
+        verify(sigImpactHistorian).markEntityChanged(2L);
+        verify(recordsHistorian)
+                .trackPrecedingChildRecord(eq(DEFAULT_SOURCE_ID), bodyCaptor.capture(), eq(record));
+        verify(networkCtx).markMigrationRecordsStreamed();
+        verify(systemAccountsCreator).forgetCreations();
+
+        final var bodies = bodyCaptor.getAllValues();
+        assertEquals(systemAccountSynthBody, bodies.get(0).build());
+        assertFalse(record.getHbarAdjustments().isEmpty());
+        assertEquals(1, record.getHbarAdjustments().getAccountNums().length);
+        assertEquals(1, record.getHbarAdjustments().getHbars().length);
+        assertEquals(2L, record.getHbarAdjustments().getAccountNums()[0]);
+        assertEquals(MAX_PENDING_REWARDS, record.getHbarAdjustments().getHbars()[0]);
     }
 
     @Test
@@ -412,11 +461,25 @@ class MigrationRecordsManagerTest {
                 CryptoCreateTransactionBody.newBuilder()
                         .setKey(MiscUtils.asKeyUnchecked(systemAccountKey))
                         .setMemo("123")
-                        .setInitialBalance(0)
+                        .setInitialBalance(0L)
                         .setReceiverSigRequired(true)
                         .setAutoRenewPeriod(
                                 Duration.newBuilder()
                                         .setSeconds(systemAccount - now.getEpochSecond()))
+                        .build();
+        return TransactionBody.newBuilder().setCryptoCreateAccount(txnBody).build();
+    }
+
+    private TransactionBody expectedTreasuryAccountCreationSynthBody() {
+        final var txnBody =
+                CryptoCreateTransactionBody.newBuilder()
+                        .setKey(MiscUtils.asKeyUnchecked(pretendTreasuryKey))
+                        .setMemo("123")
+                        .setInitialBalance(MAX_PENDING_REWARDS)
+                        .setReceiverSigRequired(true)
+                        .setAutoRenewPeriod(
+                                Duration.newBuilder()
+                                        .setSeconds(pretendExpiry - now.getEpochSecond()))
                         .build();
         return TransactionBody.newBuilder().setCryptoCreateAccount(txnBody).build();
     }

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/services/state/submerkle/ExpirableTxnRecordBuilderTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/services/state/submerkle/ExpirableTxnRecordBuilderTest.java
@@ -21,6 +21,7 @@ import static com.hedera.services.state.submerkle.EntityId.MISSING_ENTITY_ID;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
@@ -203,6 +204,29 @@ class ExpirableTxnRecordBuilderTest {
         final var expectedAccounts = new long[] {firstInBoth.num(), secondInBoth.num()};
         assertArrayEquals(expectedChanges, subject.getHbarAdjustments().hbars);
         assertArrayEquals(expectedAccounts, subject.getHbarAdjustments().accountNums);
+    }
+
+    @Test
+    void doesAdjustForTreasuryCreationWithMoreThanOneAdjusts() {
+        final var firstInBoth = new EntityId(0, 0, 3);
+        final var secondInBoth = new EntityId(0, 0, 4);
+
+        final var thisAdjusts =
+                new CurrencyAdjustments(
+                        new long[] {+6, +3}, new long[] {firstInBoth.num(), secondInBoth.num()});
+        final var thatAdjusts =
+                new CurrencyAdjustments(new long[] {MAX_PENDING_REWARDS, 1L}, new long[] {2L, 3L});
+
+        final var that = ExpirableTxnRecord.newBuilder();
+        that.setHbarAdjustments(thatAdjusts);
+
+        subject.setHbarAdjustments(thisAdjusts);
+        subject.excludeHbarChangesFrom(that);
+
+        final var expectedChanges = new long[] {+6, +3};
+        final var expectedAccounts = new long[] {firstInBoth.num(), secondInBoth.num()};
+        assertNotEquals(expectedChanges.length, subject.getHbarAdjustments().hbars.length);
+        assertNotEquals(expectedAccounts.length, subject.getHbarAdjustments().accountNums.length);
     }
 
     @Test

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoTransferSuite.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoTransferSuite.java
@@ -167,29 +167,30 @@ public class CryptoTransferSuite extends HapiApiSuite {
     @Override
     public List<HapiApiSpec> getSpecsInSuite() {
         return List.of(
-                transferWithMissingAccountGetsInvalidAccountId(),
-                complexKeyAcctPaysForOwnTransfer(),
-                twoComplexKeysRequired(),
-                specialAccountsBalanceCheck(),
-                tokenTransferFeesScaleAsExpected(),
-                okToSetInvalidPaymentHeaderForCostAnswer(),
-                baseCryptoTransferFeeChargedAsExpected(),
-                autoAssociationRequiresOpenSlots(),
-                royaltyCollectorsCanUseAutoAssociation(),
-                royaltyCollectorsCannotUseAutoAssociationWithoutOpenSlots(),
-                dissociatedRoyaltyCollectorsCanUseAutoAssociation(),
-                hbarAndFungibleSelfTransfersRejectedBothInPrecheckAndHandle(),
-                transferToNonAccountEntitiesReturnsInvalidAccountId(),
-                nftSelfTransfersRejectedBothInPrecheckAndHandle(),
-                checksExpectedDecimalsForFungibleTokenTransferList(),
-                allowanceTransfersWorkAsExpected(),
-                allowanceTransfersWithComplexTransfersWork(),
-                canUseMirrorAliasesForNonContractXfers(),
-                canUseEip1014AliasesForXfers(),
-                cannotTransferFromImmutableAccounts(),
-                nftTransfersCannotRepeatSerialNos(),
-                vanillaTransferSucceeds(),
-                aliasKeysAreValidated());
+//                transferWithMissingAccountGetsInvalidAccountId(),
+//                complexKeyAcctPaysForOwnTransfer(),
+//                twoComplexKeysRequired(),
+//                specialAccountsBalanceCheck(),
+//                tokenTransferFeesScaleAsExpected(),
+//                okToSetInvalidPaymentHeaderForCostAnswer(),
+//                baseCryptoTransferFeeChargedAsExpected(),
+//                autoAssociationRequiresOpenSlots(),
+//                royaltyCollectorsCanUseAutoAssociation(),
+//                royaltyCollectorsCannotUseAutoAssociationWithoutOpenSlots(),
+//                dissociatedRoyaltyCollectorsCanUseAutoAssociation(),
+//                hbarAndFungibleSelfTransfersRejectedBothInPrecheckAndHandle(),
+//                transferToNonAccountEntitiesReturnsInvalidAccountId(),
+//                nftSelfTransfersRejectedBothInPrecheckAndHandle(),
+//                checksExpectedDecimalsForFungibleTokenTransferList(),
+//                allowanceTransfersWorkAsExpected(),
+//                allowanceTransfersWithComplexTransfersWork(),
+//                canUseMirrorAliasesForNonContractXfers(),
+//                canUseEip1014AliasesForXfers(),
+//                cannotTransferFromImmutableAccounts(),
+//                nftTransfersCannotRepeatSerialNos(),
+                vanillaTransferSucceeds()
+//                aliasKeysAreValidated()
+        );
     }
 
     @Override
@@ -2100,32 +2101,38 @@ public class CryptoTransferSuite extends HapiApiSuite {
 
         return defaultHapiSpec("VanillaTransferSucceeds")
                 .given(
-                        cryptoCreate("somebody")
-                                .maxAutomaticTokenAssociations(5001)
-                                .hasPrecheck(
-                                        REQUESTED_NUM_AUTOMATIC_ASSOCIATIONS_EXCEEDS_ASSOCIATION_LIMIT),
-                        UtilVerbs.inParallel(
-                                cryptoCreate(PAYER),
-                                cryptoCreate(PAYEE_SIG_REQ).receiverSigRequired(true),
-                                cryptoCreate(PAYEE_NO_SIG_REQ)))
+                        cryptoCreate(PAYER).via("test"),
+                        getTxnRecord("test").andAllChildRecords().logged()
+//                        cryptoCreate("somebody")
+//                                .maxAutomaticTokenAssociations(5001)
+//                                .hasPrecheck(
+//                                        REQUESTED_NUM_AUTOMATIC_ASSOCIATIONS_EXCEEDS_ASSOCIATION_LIMIT),
+//                        UtilVerbs.inParallel(
+//                                cryptoCreate(PAYER),
+//                                cryptoCreate(PAYEE_SIG_REQ).receiverSigRequired(true),
+//                                cryptoCreate(PAYEE_NO_SIG_REQ))
+                )
+
                 .when(
-                        cryptoTransfer(
-                                        tinyBarsFromTo(PAYER, PAYEE_SIG_REQ, 1_000L),
-                                        tinyBarsFromTo(PAYER, PAYEE_NO_SIG_REQ, 2_000L))
-                                .via("transferTxn"))
+//                        cryptoTransfer(
+//                                        tinyBarsFromTo(PAYER, PAYEE_SIG_REQ, 1_000L),
+//                                        tinyBarsFromTo(PAYER, PAYEE_NO_SIG_REQ, 2_000L))
+//                                .via("transferTxn")
+                )
                 .then(
-                        getAccountInfo(PAYER)
-                                .logged()
-                                .hasExpectedLedgerId("0x03")
-                                .has(accountWith().balance(initialBalance - 3_000L)),
-                        getAccountInfo(PAYEE_SIG_REQ)
-                                .has(accountWith().balance(initialBalance + 1_000L)),
-                        getAccountDetails(PAYEE_NO_SIG_REQ)
-                                .payingWith(GENESIS)
-                                .has(
-                                        AccountDetailsAsserts.accountWith()
-                                                .balance(initialBalance + 2_000L)
-                                                .noAllowances()));
+//                        getAccountInfo(PAYER)
+//                                .logged()
+//                                .hasExpectedLedgerId("0x03")
+//                                .has(accountWith().balance(initialBalance - 3_000L)),
+//                        getAccountInfo(PAYEE_SIG_REQ)
+//                                .has(accountWith().balance(initialBalance + 1_000L)),
+//                        getAccountDetails(PAYEE_NO_SIG_REQ)
+//                                .payingWith(GENESIS)
+//                                .has(
+//                                        AccountDetailsAsserts.accountWith()
+//                                                .balance(initialBalance + 2_000L)
+//                                                .noAllowances())
+                );
     }
 
     @Override

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoTransferSuite.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoTransferSuite.java
@@ -167,30 +167,29 @@ public class CryptoTransferSuite extends HapiApiSuite {
     @Override
     public List<HapiApiSpec> getSpecsInSuite() {
         return List.of(
-//                transferWithMissingAccountGetsInvalidAccountId(),
-//                complexKeyAcctPaysForOwnTransfer(),
-//                twoComplexKeysRequired(),
-//                specialAccountsBalanceCheck(),
-//                tokenTransferFeesScaleAsExpected(),
-//                okToSetInvalidPaymentHeaderForCostAnswer(),
-//                baseCryptoTransferFeeChargedAsExpected(),
-//                autoAssociationRequiresOpenSlots(),
-//                royaltyCollectorsCanUseAutoAssociation(),
-//                royaltyCollectorsCannotUseAutoAssociationWithoutOpenSlots(),
-//                dissociatedRoyaltyCollectorsCanUseAutoAssociation(),
-//                hbarAndFungibleSelfTransfersRejectedBothInPrecheckAndHandle(),
-//                transferToNonAccountEntitiesReturnsInvalidAccountId(),
-//                nftSelfTransfersRejectedBothInPrecheckAndHandle(),
-//                checksExpectedDecimalsForFungibleTokenTransferList(),
-//                allowanceTransfersWorkAsExpected(),
-//                allowanceTransfersWithComplexTransfersWork(),
-//                canUseMirrorAliasesForNonContractXfers(),
-//                canUseEip1014AliasesForXfers(),
-//                cannotTransferFromImmutableAccounts(),
-//                nftTransfersCannotRepeatSerialNos(),
-                vanillaTransferSucceeds()
-//                aliasKeysAreValidated()
-        );
+                transferWithMissingAccountGetsInvalidAccountId(),
+                complexKeyAcctPaysForOwnTransfer(),
+                twoComplexKeysRequired(),
+                specialAccountsBalanceCheck(),
+                tokenTransferFeesScaleAsExpected(),
+                okToSetInvalidPaymentHeaderForCostAnswer(),
+                baseCryptoTransferFeeChargedAsExpected(),
+                autoAssociationRequiresOpenSlots(),
+                royaltyCollectorsCanUseAutoAssociation(),
+                royaltyCollectorsCannotUseAutoAssociationWithoutOpenSlots(),
+                dissociatedRoyaltyCollectorsCanUseAutoAssociation(),
+                hbarAndFungibleSelfTransfersRejectedBothInPrecheckAndHandle(),
+                transferToNonAccountEntitiesReturnsInvalidAccountId(),
+                nftSelfTransfersRejectedBothInPrecheckAndHandle(),
+                checksExpectedDecimalsForFungibleTokenTransferList(),
+                allowanceTransfersWorkAsExpected(),
+                allowanceTransfersWithComplexTransfersWork(),
+                canUseMirrorAliasesForNonContractXfers(),
+                canUseEip1014AliasesForXfers(),
+                cannotTransferFromImmutableAccounts(),
+                nftTransfersCannotRepeatSerialNos(),
+                vanillaTransferSucceeds(),
+                aliasKeysAreValidated());
     }
 
     @Override
@@ -2101,38 +2100,32 @@ public class CryptoTransferSuite extends HapiApiSuite {
 
         return defaultHapiSpec("VanillaTransferSucceeds")
                 .given(
-                        cryptoCreate(PAYER).via("test"),
-                        getTxnRecord("test").andAllChildRecords().logged()
-//                        cryptoCreate("somebody")
-//                                .maxAutomaticTokenAssociations(5001)
-//                                .hasPrecheck(
-//                                        REQUESTED_NUM_AUTOMATIC_ASSOCIATIONS_EXCEEDS_ASSOCIATION_LIMIT),
-//                        UtilVerbs.inParallel(
-//                                cryptoCreate(PAYER),
-//                                cryptoCreate(PAYEE_SIG_REQ).receiverSigRequired(true),
-//                                cryptoCreate(PAYEE_NO_SIG_REQ))
-                )
-
+                        cryptoCreate("somebody")
+                                .maxAutomaticTokenAssociations(5001)
+                                .hasPrecheck(
+                                        REQUESTED_NUM_AUTOMATIC_ASSOCIATIONS_EXCEEDS_ASSOCIATION_LIMIT),
+                        UtilVerbs.inParallel(
+                                cryptoCreate(PAYER),
+                                cryptoCreate(PAYEE_SIG_REQ).receiverSigRequired(true),
+                                cryptoCreate(PAYEE_NO_SIG_REQ)))
                 .when(
-//                        cryptoTransfer(
-//                                        tinyBarsFromTo(PAYER, PAYEE_SIG_REQ, 1_000L),
-//                                        tinyBarsFromTo(PAYER, PAYEE_NO_SIG_REQ, 2_000L))
-//                                .via("transferTxn")
-                )
+                        cryptoTransfer(
+                                        tinyBarsFromTo(PAYER, PAYEE_SIG_REQ, 1_000L),
+                                        tinyBarsFromTo(PAYER, PAYEE_NO_SIG_REQ, 2_000L))
+                                .via("transferTxn"))
                 .then(
-//                        getAccountInfo(PAYER)
-//                                .logged()
-//                                .hasExpectedLedgerId("0x03")
-//                                .has(accountWith().balance(initialBalance - 3_000L)),
-//                        getAccountInfo(PAYEE_SIG_REQ)
-//                                .has(accountWith().balance(initialBalance + 1_000L)),
-//                        getAccountDetails(PAYEE_NO_SIG_REQ)
-//                                .payingWith(GENESIS)
-//                                .has(
-//                                        AccountDetailsAsserts.accountWith()
-//                                                .balance(initialBalance + 2_000L)
-//                                                .noAllowances())
-                );
+                        getAccountInfo(PAYER)
+                                .logged()
+                                .hasExpectedLedgerId("0x03")
+                                .has(accountWith().balance(initialBalance - 3_000L)),
+                        getAccountInfo(PAYEE_SIG_REQ)
+                                .has(accountWith().balance(initialBalance + 1_000L)),
+                        getAccountDetails(PAYEE_NO_SIG_REQ)
+                                .payingWith(GENESIS)
+                                .has(
+                                        AccountDetailsAsserts.accountWith()
+                                                .balance(initialBalance + 2_000L)
+                                                .noAllowances()));
     }
 
     @Override


### PR DESCRIPTION
Fixes https://github.com/hashgraph/hedera-services/issues/4273
Sets the balances of accounts created in on synthetic creations export records

Tested by:
1. starting node at genesis
2. Do a CryptoCreate transaction paying with account 2.
3. Look at the child records of the transaction to have synthetic creation records. Only for Genesis account shows the balance on Created account record.

Top level record transfer list
```
, receipt {
  status: SUCCESS
  accountID {
    accountNum: 2
  }
}
transactionHash: "\r\222\243\0276 \340\027\226=\205\234\241\t\366[\237ik\006\230\211\004\221\262\213\360\325\255gDu\230\244f\252\203\020|\260\222N\371\000\317\345\252\364"
consensusTimestamp {
  seconds: 1668116519
  nanos: 219633498
}
transactionID {
  transactionValidStart {
    seconds: 1668116459
    nanos: 792
  }
  accountID {
    accountNum: 2
  }
  nonce: 505
}
memo: "Synthetic system creation"
transferList {
  accountAmounts {
    accountID {
      accountNum: 2
    }
    amount: 5000000000000000000
  }
}