### PR TITLE
Fixes broken YahCli builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,9 @@ hs_err_pid*
 # Local runtime assets
 hedera-node/swirlds-tmp
 
+test-clients/yahcli/*.jar
+test-clients/yahcli/assets/*.jar
+
 *.sh
 !run/generate-changelog.sh
 !run/new-release-branch.sh
@@ -55,6 +58,7 @@ hedera-node/swirlds-tmp
 !test-clients/yahcli/run/*.sh
 !test-clients/yahcli/assets/*.sh
 !test-clients/yahcli/run/test/local/*.sh
+
 *.json
 !hapi-fees/src/main/resources/*.json
 !hapi-fees/src/test/resources/*.json

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,9 +10,5 @@ org.gradle.caching=true
 # Default JMH benchmark includes regex
 includesRegex=.*
 
-# Default test-clients jar is SuiteRunner
-sjJar=SuiteRunner.jar
-sjMainClass=com.hedera.services.bdd.suites.SuiteRunner
-
 # Require spotless to fetch license header dates from Git history
 spotlessSetLicenseHeaderYearsFromGitHistory=true

--- a/test-clients/build.gradle.kts
+++ b/test-clients/build.gradle.kts
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 
 /*
@@ -95,7 +110,7 @@ val yahCliJar = tasks.register<ShadowJar>("yahCliJar") {
     from(sourceSets.main.get().output)
     configurations = listOf(project.configurations["runtimeClasspath"])
 
-    exclude(listOf("META-INF/*.DSA","META-INF/*.SF"))
+    exclude(listOf("META-INF/*.DSA", "META-INF/*.SF"))
 
     archiveClassifier.set("yahcli")
     isReproducibleFileOrder = true

--- a/test-clients/build.gradle.kts
+++ b/test-clients/build.gradle.kts
@@ -110,7 +110,7 @@ val yahCliJar = tasks.register<ShadowJar>("yahCliJar") {
     from(sourceSets.main.get().output)
     configurations = listOf(project.configurations["runtimeClasspath"])
 
-    exclude(listOf("META-INF/*.DSA", "META-INF/*.SF"))
+    exclude(listOf("META-INF/*.DSA", "META-INF/*.RSA", "META-INF/*.SF", "META-INF/INDEX.LIST"))
 
     archiveClassifier.set("yahcli")
     isReproducibleFileOrder = true

--- a/test-clients/yahcli/Dockerfile
+++ b/test-clients/yahcli/Dockerfile
@@ -1,10 +1,63 @@
-FROM ubuntu:22.04 AS base-runtime
+FROM ubuntu:22.04
 # JDK
-RUN apt-get -y update && \
-    apt-get upgrade -y && \
-    apt-get install -y software-properties-common && \
-    add-apt-repository -y ppa:openjdk-r/ppa && \
-    apt-get install -y openjdk-17-jdk
+ENV JAVA_HOME /opt/java/openjdk
+ENV PATH $JAVA_HOME/bin:$PATH
+
+# Default to UTF-8 file.encoding
+ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
+
+RUN apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends tzdata curl wget ca-certificates fontconfig locales binutils \
+    && echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen \
+    && locale-gen en_US.UTF-8 \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV JAVA_VERSION jdk-17.0.5+8
+
+RUN set -eux; \
+    ARCH="$(dpkg --print-architecture)"; \
+    case "${ARCH}" in \
+       aarch64|arm64) \
+         ESUM='34d6414710db27cd7760fe369135f3b9927ccc81410280606613166d4106d60a'; \
+         BINARY_URL='https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.5%2B8/OpenJDK17U-jre_aarch64_linux_hotspot_17.0.5_8.tar.gz'; \
+         ;; \
+       armhf|arm) \
+         ESUM='9e0d1745139fe502f22df1e261d2ed1ad807085dd75a8b333d481289b579870d'; \
+         BINARY_URL='https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.5%2B8/OpenJDK17U-jre_arm_linux_hotspot_17.0.5_8.tar.gz'; \
+         ;; \
+       ppc64el|powerpc:common64) \
+         ESUM='51dd491505bd2e096676b9dc8ecaf196d78993215af16c0f9dfddfe3dbc0205b'; \
+         BINARY_URL='https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.5%2B8/OpenJDK17U-jre_ppc64le_linux_hotspot_17.0.5_8.tar.gz'; \
+         ;; \
+       s390x|s390:64-bit) \
+         ESUM='eeb1e92b8267e7e015908f3e3b80e48f418b37a2b4491f65290bc5d25e5daf93'; \
+         BINARY_URL='https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.5%2B8/OpenJDK17U-jre_s390x_linux_hotspot_17.0.5_8.tar.gz'; \
+         ;; \
+       amd64|i386:x86-64) \
+         ESUM='11326464a14b63e6328d1d2088a23fb559c0e36b3f380e4c1f8dcbe160a8b95e'; \
+         BINARY_URL='https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.5%2B8/OpenJDK17U-jre_x64_linux_hotspot_17.0.5_8.tar.gz'; \
+         ;; \
+       *) \
+         echo "Unsupported arch: ${ARCH}"; \
+         exit 1; \
+         ;; \
+    esac; \
+	  wget -O /tmp/openjdk.tar.gz ${BINARY_URL}; \
+	  echo "${ESUM} */tmp/openjdk.tar.gz" | sha256sum -c -; \
+	  mkdir -p "$JAVA_HOME"; \
+	  tar --extract \
+	      --file /tmp/openjdk.tar.gz \
+	      --directory "$JAVA_HOME" \
+	      --strip-components 1 \
+	      --no-same-owner \
+	  ; \
+    rm /tmp/openjdk.tar.gz; \
+# https://github.com/docker-library/openjdk/issues/331#issuecomment-498834472
+    find "$JAVA_HOME/lib" -name '*.so' -exec dirname '{}' ';' | sort -u > /etc/ld.so.conf.d/docker-openjdk.conf; \
+    ldconfig; \
+# https://github.com/docker-library/openjdk/issues/212#issuecomment-420979840
+# https://openjdk.java.net/jeps/341
+    java -Xshare:dump;
 
 RUN mkdir -p /launch /opt/bin
 

--- a/test-clients/yahcli/run/build.sh
+++ b/test-clients/yahcli/run/build.sh
@@ -1,10 +1,29 @@
-#! /bin/sh
-TAG=${1:-'0.2.9'}
+#!/usr/bin/env bash
+set -eo pipefail
 
-cd ../..
-./gradlew shadowJar \
-  -PsjJar=yahcli.jar -PsjMainClass=com.hedera.services.yahcli.Yahcli
-cd -
-run/refresh-jar.sh
+TAG=${1:-'0.2.9'}
+SCRIPT_SOURCE="${BASH_SOURCE[0]}"
+
+READLINK_OPTS=""
+
+if readlink -f . >/dev/null 2>&1; then
+  READLINK_OPTS="-f"
+fi
+
+if [[ -n "$(readlink ${READLINK_OPTS} "${SCRIPT_SOURCE}")" ]]; then
+  SCRIPT_SOURCE="$(readlink ${READLINK_OPTS} "${SCRIPT_SOURCE}")"
+fi
+
+SCRIPT_PATH="$(cd "$(dirname "${SCRIPT_SOURCE}")" && pwd)"
+
+OLD_CWD="$(pwd)"
+
+cd "${SCRIPT_PATH}/../../.."
+./gradlew assemble
+cd "${SCRIPT_PATH}/.."
+
+rm -f assets/yahcli.jar >/dev/null 2>&1 || true
+cp -f yahcli.jar assets/
 
 docker build -t yahcli:$TAG .
+cd "${OLD_CWD}"

--- a/test-clients/yahcli/run/refresh-jar.sh
+++ b/test-clients/yahcli/run/refresh-jar.sh
@@ -1,2 +1,0 @@
-#! /bin/sh
-mv ../build/libs/yahcli.jar assets/

--- a/test-clients/yahcli/yahcli
+++ b/test-clients/yahcli/yahcli
@@ -1,2 +1,2 @@
 #! /bin/sh
-java -jar yahcli.jar $*
+java -jar yahcli.jar "${@}"


### PR DESCRIPTION
## Description

Address the issues reported by @tinker-michaelj in #4187 regarding the YahCli build not working.  This PR also ensure the YahCli docker image uses our standard `Adoptium Temurin OpenJDK 17` java version. It also ensure the docker image always uses UTF-8 encoding/character sets and the docker build scripts will function properly regardless of the current working directory. 

### Related Issues

- Closes #4187 