### PR TITLE
Fix `totalStakeAtStartOfLastRewardedPeriod` management

### DIFF
--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/services/ledger/interceptors/StakingAccountsCommitInterceptorTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/services/ledger/interceptors/StakingAccountsCommitInterceptorTest.java
@@ -329,6 +329,15 @@ class StakingAccountsCommitInterceptorTest {
     }
 
     @Test
+    void earningZeroRewardsWithStartBeforeLastNonRewardableStillUpdatesSASOLARP() {
+        final var account = mock(HederaAccount.class);
+        given(stakePeriodManager.firstNonRewardableStakePeriod()).willReturn(3L);
+        given(account.getStakePeriodStart()).willReturn(2L);
+
+        assertTrue(subject.shouldRememberStakeStartFor(account, -1, 0));
+    }
+
+    @Test
     void anAccountWithAlreadyCollectedRewardShouldNotHaveStakeStartUpdated() {
         given(dynamicProperties.isStakingEnabled()).willReturn(true);
         final var changes = new EntityChangeSet<AccountID, HederaAccount, AccountProperty>();

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/staking/StakingSuite.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/staking/StakingSuite.java
@@ -90,7 +90,8 @@ public class StakingSuite extends HapiApiSuite {
                 secondOrderRewardSituationsWork(),
                 endOfStakingPeriodRecTest(),
                 rewardsOfDeletedAreRedirectedToBeneficiary(),
-                canBeRewardedWithoutMinStakeIfSoConfigured());
+                canBeRewardedWithoutMinStakeIfSoConfigured(),
+                zeroRewardEarnedWithZeroWholeHbarsStillSetsSASOLARP());
     }
 
     private HapiApiSpec canBeRewardedWithoutMinStakeIfSoConfigured() {
@@ -192,6 +193,27 @@ public class StakingSuite extends HapiApiSuite {
                         sleepFor(INTER_PERIOD_SLEEP_MS))
                 .then(
                         cryptoTransfer(tinyBarsFromTo(DEFAULT_PAYER, CAROL, 1)).via(FIRST_TRANSFER),
+                        getTxnRecord(FIRST_TRANSFER).hasPaidStakingRewardsCount(1));
+    }
+
+    private HapiApiSpec zeroRewardEarnedWithZeroWholeHbarsStillSetsSASOLARP() {
+        return defaultHapiSpec("ZeroRewardEarnedWithZeroWholeHbarsStillSetsSASOLARP")
+                .given(
+                        overriding(STAKING_START_THRESHOLD, "" + 10 * ONE_HBAR),
+                        overriding(STAKING_REWARD_RATE, "" + SOME_REWARD_RATE),
+                        cryptoTransfer(tinyBarsFromTo(GENESIS, STAKING_REWARD, ONE_MILLION_HBARS)),
+                        // Ensure all periods have a non-zero reward rate
+                        cryptoCreate("helpfulStaker").stakedNodeId(0).balance(ONE_MILLION_HBARS),
+                        sleepFor(INTER_PERIOD_SLEEP_MS))
+                .when(
+                        cryptoCreate(ALICE).stakedNodeId(0).balance(0L),
+                        sleepFor(INTER_PERIOD_SLEEP_MS),
+                        cryptoTransfer(tinyBarsFromTo(GENESIS, ALICE, ONE_HUNDRED_HBARS)),
+                        sleepFor(INTER_PERIOD_SLEEP_MS),
+                        cryptoTransfer(tinyBarsFromTo(ALICE, FUNDING, ONE_HUNDRED_HBARS)),
+                        sleepFor(INTER_PERIOD_SLEEP_MS))
+                .then(
+                        cryptoTransfer(tinyBarsFromTo(DEFAULT_PAYER, ALICE, 1)).via(FIRST_TRANSFER),
                         getTxnRecord(FIRST_TRANSFER).hasPaidStakingRewardsCount(1));
     }
 


### PR DESCRIPTION
**Description**:
 - Updates an account's `totalStakeAtStartOfLastRewardedPeriod` when it earns zero rewards due to staking zero whole hbars.

**Related issues**:
 - Closes #4269 