### PR TITLE
Add `libs.log4j.core` as dependency in `test-clients`

### DIFF
--- a/test-clients/build.gradle.kts
+++ b/test-clients/build.gradle.kts
@@ -68,6 +68,7 @@ dependencies {
         exclude("javax.annotation", "javax.annotation-api")
     }
     implementation(libs.headlong)
+    implementation(libs.log4j.core)
     implementation(testLibs.json)
     implementation(testLibs.junit.jupiter.api)
     implementation(testLibs.picocli)
@@ -100,7 +101,8 @@ tasks.shadowJar {
 
     manifest {
         attributes(
-            "Main-Class" to "com.hedera.services.bdd.suites.SuiteRunner"
+            "Main-Class" to "com.hedera.services.bdd.suites.SuiteRunner",
+            "Multi-Release" to "true"
         )
     }
 }
@@ -120,7 +122,8 @@ val yahCliJar = tasks.register<ShadowJar>("yahCliJar") {
 
     manifest {
         attributes(
-            "Main-Class" to "com.hedera.services.yahcli.Yahcli"
+            "Main-Class" to "com.hedera.services.yahcli.Yahcli",
+            "Multi-Release" to "true"
         )
     }
 }


### PR DESCRIPTION
... for both BDD and yahcli command line tool.

**Description**:

Fixes problem where if a yahcli command initalized log4j it would fail due to not being able to find log4j's jar.

- Added `libs.log4j.core` as a dependency
- Added `"Multi-Release" to "true"` to both manifests (BDD and yahcli)
  - per https://stackoverflow.com/a/54713830/751579 (found by Nathan)

Signed-off-by: David Bakin <117694041+david-bakin-sl@users.noreply.github.com>

**Related issue(s)**:

Fixes #4283 

**Notes for reviewer**:

I tested running `yahcli` only, not the bdd suite.

**Checklist**

- [*] Tested - ran the `yahcli` command line tool `validate` command which performs logging: works
