### PR TITLE
Ensure `EthereumTransitionLogic` works during e.g. state recovery

### DIFF
--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/services/txns/span/SpanMapManager.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/services/txns/span/SpanMapManager.java
@@ -171,7 +171,7 @@ public class SpanMapManager {
         }
     }
 
-    private void rationalizeEthereumSpan(final TxnAccessor accessor) {
+    public void rationalizeEthereumSpan(final TxnAccessor accessor) {
         final var expansion = spanMapAccessor.getEthTxExpansion(accessor);
         if (expansion == null || areChanged(Objects.requireNonNull(expansion.linkedRefs()))) {
             final Map<String, Object> spanMap = new HashMap<>();

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/services/txns/ethereum/EthereumTransitionLogicTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/services/txns/ethereum/EthereumTransitionLogicTest.java
@@ -281,6 +281,17 @@ class EthereumTransitionLogicTest {
         assertDoesNotThrow(() -> subject.preFetch(accessor));
     }
 
+    @Test
+    void dealsWithRecoveryEdgeCase() {
+        given(spanMapAccessor.getEthTxExpansion(accessor))
+                .willReturn(null)
+                .willReturn(notOkExpansion);
+
+        assertFailsWith(() -> subject.validatedCallerOf(accessor), INVALID_ETHEREUM_TRANSACTION);
+
+        verify(spanMapManager).rationalizeEthereumSpan(accessor);
+    }
+
     private void givenReasonableSemantics() {
         given(spanMapAccessor.getEthTxDataMeta(accessor)).willReturn(ethTxData);
         given(dynamicProperties.chainIdBytes()).willReturn(chainIdBytes);


### PR DESCRIPTION
**Description**:
 - "Makes up" for a missed `preHandle()` call in `EthereumTransitionLogic` by explicitly calling `rationalizeEthereumSpan()` as needed.

**Related issue(s)**:

Fixes #4285
