### PR TITLE
Waive treasury sig if receiving NFT w/ fallback fee

### DIFF
--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/services/sigs/order/SigRequirements.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/services/sigs/order/SigRequirements.java
@@ -1344,12 +1344,13 @@ public class SigRequirements {
                     return tokenResult.failureIfAny();
                 } else {
                     final var tokenMeta = tokenResult.metadata();
-                    if (tokenMeta.hasRoyaltyWithFallback()) {
-                        final var fallbackApplies =
-                                !receivesFungibleValue(counterparty, op)
-                                        && counterparty.getAccountNum()
-                                                != tokenMeta.treasury().num();
-                        if (fallbackApplies) {
+                    if (tokenMeta.hasRoyaltyWithFallback()
+                            && !receivesFungibleValue(counterparty, op)) {
+                        // Fallback situation; but we still need to check if the treasury is
+                        // the sender or receiver, since in neither case will the fallback fee
+                        // actually be charged
+                        final var treasury = tokenMeta.treasury().toGrpcAccountId();
+                        if (!treasury.equals(party) && !treasury.equals(counterparty)) {
                             required.add(meta.key());
                         }
                     }

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/services/sigs/order/SigRequirementsTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/services/sigs/order/SigRequirementsTest.java
@@ -131,6 +131,7 @@ import static com.hedera.test.factories.scenarios.CryptoTransferScenarios.TOKEN_
 import static com.hedera.test.factories.scenarios.CryptoTransferScenarios.TOKEN_TRANSACT_WITH_OWNERSHIP_CHANGE_NO_RECEIVER_SIG_REQ_AND_MISSING_TOKEN;
 import static com.hedera.test.factories.scenarios.CryptoTransferScenarios.TOKEN_TRANSACT_WITH_OWNERSHIP_CHANGE_NO_RECEIVER_SIG_REQ_BUT_ROYALTY_FEE_WITH_FALLBACK_TRIGGERED;
 import static com.hedera.test.factories.scenarios.CryptoTransferScenarios.TOKEN_TRANSACT_WITH_OWNERSHIP_CHANGE_NO_SIG_REQ_WITH_FALLBACK_TRIGGERED_BUT_SENDER_IS_TREASURY;
+import static com.hedera.test.factories.scenarios.CryptoTransferScenarios.TOKEN_TRANSACT_WITH_OWNERSHIP_CHANGE_NO_SIG_REQ_WITH_FALLBACK_WHEN_RECEIVER_IS_TREASURY;
 import static com.hedera.test.factories.scenarios.CryptoTransferScenarios.TOKEN_TRANSACT_WITH_OWNERSHIP_CHANGE_RECEIVER_SIG_REQ;
 import static com.hedera.test.factories.scenarios.CryptoTransferScenarios.TOKEN_TRANSACT_WITH_OWNERSHIP_CHANGE_USING_ALIAS;
 import static com.hedera.test.factories.scenarios.CryptoTransferScenarios.TOKEN_TRANSACT_WITH_RECEIVER_SIG_REQ_AND_EXTANT_SENDERS;
@@ -1032,6 +1033,21 @@ class SigRequirementsTest {
         assertThat(summary.getOrderedKeys(), iterableWithSize(1));
         assertThat(
                 sanityRestored(summary.getOrderedKeys()), contains(FIRST_TOKEN_SENDER_KT.asKey()));
+    }
+
+    @Test
+    void getsNftOwnerChangeWithNoSigReqAndFallbackFeeTriggeredButReceiverIsTreasury()
+            throws Throwable {
+        // given:
+        setupFor(
+                TOKEN_TRANSACT_WITH_OWNERSHIP_CHANGE_NO_SIG_REQ_WITH_FALLBACK_WHEN_RECEIVER_IS_TREASURY);
+
+        // when:
+        final var summary = subject.keysForOtherParties(txn, summaryFactory);
+
+        // then:
+        assertThat(summary.getOrderedKeys(), iterableWithSize(1));
+        assertThat(sanityRestored(summary.getOrderedKeys()), contains(NO_RECEIVER_SIG_KT.asKey()));
     }
 
     @Test

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/test/factories/scenarios/CryptoTransferScenarios.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/test/factories/scenarios/CryptoTransferScenarios.java
@@ -47,6 +47,16 @@ public enum CryptoTransferScenarios implements TxnHandlingScenario {
                                     .get()));
         }
     },
+    TOKEN_TRANSACT_WITH_OWNERSHIP_CHANGE_NO_SIG_REQ_WITH_FALLBACK_WHEN_RECEIVER_IS_TREASURY {
+        @Override
+        public PlatformTxnAccessor platformTxn() throws Throwable {
+            return PlatformTxnAccessor.from(
+                    from(
+                            newSignedCryptoTransfer()
+                                    .changingOwner(ROYALTY_TOKEN_NFT, NO_RECEIVER_SIG, MISC_ACCOUNT)
+                                    .get()));
+        }
+    },
     CRYPTO_TRANSFER_SENDER_IS_MISSING_ALIAS_SCENARIO {
         public PlatformTxnAccessor platformTxn() throws Throwable {
             return PlatformTxnAccessor.from(


### PR DESCRIPTION
**Description**:
 - Waives signature of a treasury for token w/ custom royalty + fallback fee when it's receiving an NFT of its type, since no fee will actually be assessed.

**Related issue(s)**:
- Fixes #4245