### PR TITLE
[HIP-583] Allow `CryptoCreate` txns with `ECDSA` key and `public address` alias when lazy creation flag is off

### DIFF
--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/services/txns/crypto/CryptoCreateTransitionLogic.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/services/txns/crypto/CryptoCreateTransitionLogic.java
@@ -349,8 +349,7 @@ public class CryptoCreateTransitionLogic implements TransitionLogic {
     private ResponseCodeEnum validateAliasIsEVMAddressCase(final CryptoCreateTransactionBody op) {
         var alias = op.getAlias();
         if (!alias.isEmpty() && alias.size() == EVM_ADDRESS_SIZE) {
-            if (!dynamicProperties.isCryptoCreateWithAliasEnabled()
-                    || !dynamicProperties.isLazyCreationEnabled()) {
+            if (!dynamicProperties.isCryptoCreateWithAliasEnabled()) {
                 return NOT_SUPPORTED;
             }
 
@@ -370,6 +369,8 @@ public class CryptoCreateTransitionLogic implements TransitionLogic {
                 if (!Arrays.equals(recoveredEvmAddress, alias.toByteArray())) {
                     return INVALID_ALIAS_KEY;
                 }
+            } else if (!dynamicProperties.isLazyCreationEnabled()) {
+                return NOT_SUPPORTED;
             }
         }
         return OK;

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/services/txns/crypto/CryptoCreateTransitionLogicTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/services/txns/crypto/CryptoCreateTransitionLogicTest.java
@@ -324,6 +324,21 @@ class CryptoCreateTransitionLogicTest {
     }
 
     @Test
+    void acceptsTxnWithEvmAddressAliasWhenBothFlagsAreEnabled() {
+        final var opBuilder =
+                CryptoCreateTransactionBody.newBuilder()
+                        .setAutoRenewPeriod(
+                                Duration.newBuilder().setSeconds(CUSTOM_AUTO_RENEW_PERIOD))
+                        .setAlias(ByteStringUtils.wrapUnsafely(EVM_ADDRESS_BYTES));
+        cryptoCreateTxn = TransactionBody.newBuilder().setCryptoCreateAccount(opBuilder).build();
+        given(aliasManager.lookupIdBy(any())).willReturn(MISSING_NUM);
+        given(dynamicProperties.isCryptoCreateWithAliasEnabled()).willReturn(true);
+        given(dynamicProperties.isLazyCreationEnabled()).willReturn(true);
+
+        assertEquals(OK, subject.semanticCheck().apply(cryptoCreateTxn));
+    }
+
+    @Test
     void rejectsWhenEmptyKeyAndEVMAddressAlias() {
         final var opBuilder =
                 CryptoCreateTransactionBody.newBuilder()

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/services/txns/crypto/CryptoCreateTransitionLogicTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/services/txns/crypto/CryptoCreateTransitionLogicTest.java
@@ -72,6 +72,7 @@ import com.hedera.services.ledger.accounts.HederaAccountCustomizer;
 import com.hedera.services.ledger.properties.AccountProperty;
 import com.hedera.services.legacy.core.jproto.JEd25519Key;
 import com.hedera.services.legacy.core.jproto.JKey;
+import com.hedera.services.legacy.proto.utils.ByteStringUtils;
 import com.hedera.services.state.merkle.MerkleAccount;
 import com.hedera.services.state.migration.AccountStorageAdapter;
 import com.hedera.services.state.migration.HederaAccount;
@@ -290,6 +291,39 @@ class CryptoCreateTransitionLogicTest {
     }
 
     @Test
+    void acceptsTxnWithECDSAKeyAndEvmAddressWhenOnlyCryptoCreateWithAliasFlagIsEnabled() {
+        final var opBuilder =
+                CryptoCreateTransactionBody.newBuilder()
+                        .setKey(ECDSA_KEY)
+                        .setAutoRenewPeriod(
+                                Duration.newBuilder().setSeconds(CUSTOM_AUTO_RENEW_PERIOD))
+                        .setAlias(ByteStringUtils.wrapUnsafely(EVM_ADDRESS_BYTES));
+        cryptoCreateTxn = TransactionBody.newBuilder().setCryptoCreateAccount(opBuilder).build();
+        given(aliasManager.lookupIdBy(any())).willReturn(MISSING_NUM);
+        given(dynamicProperties.isCryptoCreateWithAliasEnabled()).willReturn(true);
+        given(dynamicProperties.isLazyCreationEnabled()).willReturn(false);
+
+        assertEquals(OK, subject.semanticCheck().apply(cryptoCreateTxn));
+    }
+
+    @Test
+    void
+            acceptsTxnWithECDSAKeyAndEvmAddressWhenBothCryptoCreateWithAliasAndLazyCreateFlagsAreEnabled() {
+        final var opBuilder =
+                CryptoCreateTransactionBody.newBuilder()
+                        .setKey(ECDSA_KEY)
+                        .setAutoRenewPeriod(
+                                Duration.newBuilder().setSeconds(CUSTOM_AUTO_RENEW_PERIOD))
+                        .setAlias(ByteStringUtils.wrapUnsafely(EVM_ADDRESS_BYTES));
+        cryptoCreateTxn = TransactionBody.newBuilder().setCryptoCreateAccount(opBuilder).build();
+        given(aliasManager.lookupIdBy(any())).willReturn(MISSING_NUM);
+        given(dynamicProperties.isCryptoCreateWithAliasEnabled()).willReturn(true);
+        given(dynamicProperties.isLazyCreationEnabled()).willReturn(true);
+
+        assertEquals(OK, subject.semanticCheck().apply(cryptoCreateTxn));
+    }
+
+    @Test
     void rejectsWhenEmptyKeyAndEVMAddressAlias() {
         final var opBuilder =
                 CryptoCreateTransactionBody.newBuilder()
@@ -348,6 +382,7 @@ class CryptoCreateTransitionLogicTest {
         cryptoCreateTxn = TransactionBody.newBuilder().setCryptoCreateAccount(opBuilder).build();
         given(dynamicProperties.isCryptoCreateWithAliasEnabled()).willReturn(true);
         given(dynamicProperties.isLazyCreationEnabled()).willReturn(false);
+        given(aliasManager.lookupIdBy(any())).willReturn(MISSING_NUM);
 
         assertEquals(NOT_SUPPORTED, subject.semanticCheck().apply(cryptoCreateTxn));
     }

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoCreateSuite.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoCreateSuite.java
@@ -69,6 +69,7 @@ public class CryptoCreateSuite extends HapiApiSuite {
     public static final String ED_25519_KEY = "ed25519Alias";
     public static final String LAZY_CREATION_ENABLED = "lazyCreation.enabled";
     public static final String TRUE = "true";
+    public static final String FALSE = "false";
 
     public static void main(String... args) {
         new CryptoCreateSuite().runSuiteSync();
@@ -526,8 +527,8 @@ public class CryptoCreateSuite extends HapiApiSuite {
     private HapiApiSpec txnsUsingHip583FunctionalitiesAreNotAcceptedWhenFlagsAreDisabled() {
         return defaultHapiSpec("txnsUsingHip583FunctionalitiesAreNotAcceptedWhenFlagsAreDisabled")
                 .given(
-                        UtilVerbs.overriding(LAZY_CREATION_ENABLED, "false"),
-                        UtilVerbs.overriding(CRYPTO_CREATE_WITH_ALIAS_ENABLED, "false"),
+                        UtilVerbs.overriding(LAZY_CREATION_ENABLED, FALSE),
+                        UtilVerbs.overriding(CRYPTO_CREATE_WITH_ALIAS_ENABLED, FALSE),
                         newKeyNamed(SECP_256K1_SOURCE_KEY).shape(SECP_256K1_SHAPE),
                         newKeyNamed(ED_25519_KEY).shape(KeyShape.ED25519))
                 .when(
@@ -744,7 +745,7 @@ public class CryptoCreateSuite extends HapiApiSuite {
     private HapiApiSpec createAnAccountWithEVMAddressAliasAndECKey() {
         return defaultHapiSpec("CreateAnAccountWithEVMAddressAliasAndECKey")
                 .given(
-                        UtilVerbs.overriding(LAZY_CREATION_ENABLED, "false"),
+                        UtilVerbs.overriding(LAZY_CREATION_ENABLED, FALSE),
                         UtilVerbs.overriding(CRYPTO_CREATE_WITH_ALIAS_ENABLED, TRUE),
                         newKeyNamed(SECP_256K1_SOURCE_KEY).shape(SECP_256K1_SHAPE))
                 .when(

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoCreateSuite.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoCreateSuite.java
@@ -744,7 +744,7 @@ public class CryptoCreateSuite extends HapiApiSuite {
     private HapiApiSpec createAnAccountWithEVMAddressAliasAndECKey() {
         return defaultHapiSpec("CreateAnAccountWithEVMAddressAliasAndECKey")
                 .given(
-                        UtilVerbs.overriding(LAZY_CREATION_ENABLED, TRUE),
+                        UtilVerbs.overriding(LAZY_CREATION_ENABLED, "false"),
                         UtilVerbs.overriding(CRYPTO_CREATE_WITH_ALIAS_ENABLED, TRUE),
                         newKeyNamed(SECP_256K1_SOURCE_KEY).shape(SECP_256K1_SHAPE))
                 .when(


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->

* Alters `CryptoCreate` semantic checks to accept a txn with `ECDSA` key and `public address` alias (**which does not classify as a hollow account (lazy) creation**), independently of the current value of the `lazyCreation.enbaled` flag.

**Related issue(s)**:

Fixes #4265