### PR TITLE
Fix precompile operations order execution inside `HederaEvmMessageCallProcessor`

### DIFF
--- a/hedera-node/hedera-evm-api/src/main/java/com/hedera/services/evm/contracts/execution/HederaEvmMessageCallProcessor.java
+++ b/hedera-node/hedera-evm-api/src/main/java/com/hedera/services/evm/contracts/execution/HederaEvmMessageCallProcessor.java
@@ -20,7 +20,6 @@ import static org.hyperledger.besu.evm.frame.MessageFrame.State.COMPLETED_SUCCES
 import static org.hyperledger.besu.evm.frame.MessageFrame.State.EXCEPTIONAL_HALT;
 import static org.hyperledger.besu.evm.frame.MessageFrame.State.REVERT;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.hedera.services.evm.store.contracts.AbstractLedgerEvmWorldUpdater;
 import java.util.HashMap;
 import java.util.Map;
@@ -98,15 +97,5 @@ public class HederaEvmMessageCallProcessor extends MessageCallProcessor {
         } else {
             frame.setState(EXCEPTIONAL_HALT);
         }
-    }
-
-    @VisibleForTesting
-    public void setGasRequirement(long gasRequirement) {
-        this.gasRequirement = gasRequirement;
-    }
-
-    @VisibleForTesting
-    public void setOutput(Bytes output) {
-        this.output = output;
     }
 }

--- a/hedera-node/hedera-evm-api/src/main/java/com/hedera/services/evm/contracts/execution/HederaEvmMessageCallProcessor.java
+++ b/hedera-node/hedera-evm-api/src/main/java/com/hedera/services/evm/contracts/execution/HederaEvmMessageCallProcessor.java
@@ -78,12 +78,11 @@ public class HederaEvmMessageCallProcessor extends MessageCallProcessor {
             final PrecompiledContract contract,
             final MessageFrame frame,
             final OperationTracer operationTracer) {
-        if (output == null || output.isEmpty()) {
+        if (!"HTS".equals(contract.getName())) {
             output = contract.computePrecompile(frame.getInputData(), frame).getOutput();
-        }
-        if (gasRequirement == 0L) {
             gasRequirement = contract.gasRequirement(frame.getInputData());
         }
+
         operationTracer.tracePrecompileCall(frame, gasRequirement, output);
         if (frame.getState() == REVERT) {
             return;

--- a/hedera-node/hedera-evm-api/src/test/java/com/hedera/services/evm/contracts/execution/HederaEvmMessageCallProcessorTest.java
+++ b/hedera-node/hedera-evm-api/src/test/java/com/hedera/services/evm/contracts/execution/HederaEvmMessageCallProcessorTest.java
@@ -196,7 +196,9 @@ class HederaEvmMessageCallProcessorTest {
         verify(frame).setState(EXCEPTIONAL_HALT);
         verify(frame).decrementRemainingGas(GAS_ONE_K);
         verify(nonHtsPrecompile).computePrecompile(Bytes.EMPTY, frame);
+        verify(nonHtsPrecompile).getName();
         verify(hederaEvmOperationTracer).tracePrecompileCall(frame, GAS_ONE_M, null);
+        verifyNoMoreInteractions(nonHtsPrecompile, frame, hederaEvmOperationTracer);
     }
 
     @Test
@@ -210,7 +212,9 @@ class HederaEvmMessageCallProcessorTest {
         subject.executeHederaPrecompile(nonHtsPrecompile, frame, hederaEvmOperationTracer);
 
         verify(frame).setState(EXCEPTIONAL_HALT);
+        verify(nonHtsPrecompile).getName();
         verify(hederaEvmOperationTracer).tracePrecompileCall(frame, GAS_ONE, null);
+        verifyNoMoreInteractions(nonHtsPrecompile, frame, hederaEvmOperationTracer);
     }
 
     @Test
@@ -223,5 +227,7 @@ class HederaEvmMessageCallProcessorTest {
         subject.executeHederaPrecompile(nonHtsPrecompile, frame, hederaEvmOperationTracer);
 
         verify(hederaEvmOperationTracer).tracePrecompileCall(frame, GAS_ONE, null);
+        verify(nonHtsPrecompile).getName();
+        verifyNoMoreInteractions(nonHtsPrecompile, frame, hederaEvmOperationTracer);
     }
 }

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/services/contracts/execution/HederaMessageCallProcessorTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/services/contracts/execution/HederaMessageCallProcessorTest.java
@@ -110,6 +110,7 @@ class HederaMessageCallProcessorTest {
         subject.start(frame, hederaTracer);
 
         verify(nonHtsPrecompile).computePrecompile(Bytes.of(1), frame);
+        verify(nonHtsPrecompile).getName();
         verify(hederaTracer).tracePrecompileCall(frame, GAS_ONE, Bytes.of(1));
         verify(hederaTracer).tracePrecompileResult(frame, ContractActionType.SYSTEM);
         verify(frame).decrementRemainingGas(GAS_ONE);
@@ -125,6 +126,7 @@ class HederaMessageCallProcessorTest {
         given(frame.getInputData()).willReturn(Bytes.of(1));
         given(frame.getContractAddress()).willReturn(HTS_PRECOMPILE_ADDRESS);
         given(frame.getState()).willReturn(CODE_SUCCESS);
+        given(htsPrecompile.getName()).willReturn("HTS");
         given(htsPrecompile.computeCosted(any(), eq(frame)))
                 .willReturn(Pair.of(GAS_ONE, Bytes.of(1)));
 
@@ -228,6 +230,8 @@ class HederaMessageCallProcessorTest {
         verify(frame).setState(EXCEPTIONAL_HALT);
         verify(frame).decrementRemainingGas(GAS_ONE_K);
         verify(nonHtsPrecompile).computePrecompile(Bytes.EMPTY, frame);
+        verify(nonHtsPrecompile).getName();
+        verify(nonHtsPrecompile).gasRequirement(Bytes.EMPTY);
         verify(operationTrace).tracePrecompileCall(frame, GAS_ONE_M, null);
         verifyNoMoreInteractions(nonHtsPrecompile, frame, operationTrace);
     }
@@ -244,6 +248,8 @@ class HederaMessageCallProcessorTest {
 
         verify(frame).setState(EXCEPTIONAL_HALT);
         verify(operationTrace).tracePrecompileCall(frame, GAS_ONE, null);
+        verify(nonHtsPrecompile).getName();
+        verify(nonHtsPrecompile).gasRequirement(Bytes.EMPTY);
         verifyNoMoreInteractions(nonHtsPrecompile, frame, operationTrace);
     }
 
@@ -251,6 +257,7 @@ class HederaMessageCallProcessorTest {
     void revertedPrecompileReturns() {
         given(frame.getInputData()).willReturn(Bytes.EMPTY);
         given(htsPrecompile.computeCosted(any(), any())).willReturn(Pair.of(GAS_ONE, output));
+        given(htsPrecompile.getName()).willReturn("HTS");
         given(frame.getState()).willReturn(REVERT);
 
         subject.executeHederaPrecompile(htsPrecompile, frame, operationTrace);


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->
Fix an issue regarding executing unnecessary precompile methods resulting in additional child records creation.

**Related issue(s)**: #4160 

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
