### PR TITLE
Contract bytecode disassembler, as CLI - part 1

### DIFF
--- a/test-clients/build.gradle.kts
+++ b/test-clients/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -49,8 +49,10 @@ sourceSets {
 }
 
 dependencies {
+    compileOnly(libs.spotbugs.annotations)
     implementation(project(":hedera-node:hapi-utils"))
     implementation(project(":hedera-node:hapi-fees"))
+    implementation(project(":hedera-node:hedera-mono-service")) // for `yahcli signedstate`
     implementation(libs.bundles.besu) {
         exclude("javax.annotation", "javax.annotation-api")
     }
@@ -75,6 +77,8 @@ dependencies {
     implementation(libs.protobuf.java)
     implementation(testLibs.snakeyaml)
     implementation(libs.swirlds.common)
+    implementation(libs.swirlds.merkle)
+    implementation(libs.swirlds.platform.core)
     implementation(testLibs.testcontainers.core)
     itestImplementation(libs.bundles.swirlds)
     itestImplementation(testLibs.bundles.testcontainers)

--- a/test-clients/src/main/java/com/hedera/services/yahcli/Yahcli.java
+++ b/test-clients/src/main/java/com/hedera/services/yahcli/Yahcli.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2022 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ import com.hedera.services.yahcli.commands.accounts.AccountsCommand;
 import com.hedera.services.yahcli.commands.fees.FeesCommand;
 import com.hedera.services.yahcli.commands.files.SysFilesCommand;
 import com.hedera.services.yahcli.commands.keys.KeysCommand;
+import com.hedera.services.yahcli.commands.signedstate.SignedStateCommand;
 import com.hedera.services.yahcli.commands.system.FreezeAbortCommand;
 import com.hedera.services.yahcli.commands.system.FreezeOnlyCommand;
 import com.hedera.services.yahcli.commands.system.FreezeUpgradeCommand;
@@ -50,6 +51,7 @@ import picocli.CommandLine.Spec;
             PrepareUpgradeCommand.class,
             FreezeUpgradeCommand.class,
             TelemetryUpgradeCommand.class,
+            SignedStateCommand.class,
             VersionInfoCommand.class
         },
         description = "Performs DevOps-type actions against a Hedera Services network")

--- a/test-clients/src/main/java/com/hedera/services/yahcli/commands/signedstate/SignedStateCommand.java
+++ b/test-clients/src/main/java/com/hedera/services/yahcli/commands/signedstate/SignedStateCommand.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hedera.services.yahcli.commands.signedstate;
+
+import com.hedera.services.yahcli.Yahcli;
+import java.util.concurrent.Callable;
+import picocli.CommandLine;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.ParentCommand;
+
+@Command(
+        name = "signedstate",
+        subcommands = {CommandLine.HelpCommand.class, SummarizeSignedStateFileCommand.class},
+        description = "Dealing with signed state files")
+public class SignedStateCommand implements Callable<Integer> {
+    @ParentCommand Yahcli yahcli;
+
+    @Override
+    public Integer call() throws Exception {
+        throw new CommandLine.ParameterException(
+                yahcli.getSpec().commandLine(), "Please specify a signedstate subcommand!");
+    }
+
+    public Yahcli getYahcli() {
+        return yahcli;
+    }
+}

--- a/test-clients/src/main/java/com/hedera/services/yahcli/commands/signedstate/SignedStateHolder.java
+++ b/test-clients/src/main/java/com/hedera/services/yahcli/commands/signedstate/SignedStateHolder.java
@@ -1,0 +1,201 @@
+/*
+ * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hedera.services.yahcli.commands.signedstate;
+
+import com.hedera.node.app.service.mono.ServicesState;
+import com.hedera.node.app.service.mono.state.migration.AccountStorageAdapter;
+import com.hedera.node.app.service.mono.state.virtual.VirtualBlobKey;
+import com.hedera.node.app.service.mono.state.virtual.VirtualBlobKey.Type;
+import com.hedera.node.app.service.mono.state.virtual.VirtualBlobValue;
+import com.swirlds.common.constructable.ConstructableRegistry;
+import com.swirlds.platform.state.signed.SignedStateFileReader;
+import com.swirlds.virtualmap.VirtualMap;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Navigates a signed state "file" and returns information from it
+ *
+ * <p>A "signed state" is actually a directory tree, at the top level of which is the serialized
+ * merkle tree of the hashgraph state. That is in a file named `SignedState.swh` and file is called
+ * the "signed state file". But the whole directory tree must be present.
+ *
+ * <p>This uses a `SignedStateFileReader` to suck that entire merkle tree into memory, plus the
+ * indexes of the virtual maps ("vmap"s) - ~1Gb serialized (2022-11). Then you can traverse the
+ * rematerialized hashgraph state.
+ *
+ * <p>Currently implements only operations needed for looking at contracts: - {@link
+ * #getAllKnownContracts()} looks in all the accounts to get all the contract ids present, - {@link
+ * #getAllContractContents(Collection)} returns a map, indexed by contract id, of the contract
+ * bytecodes.
+ */
+public class SignedStateHolder {
+
+    @NonNull private final Path swh;
+    @NonNull private ServicesState platformState;
+
+    public SignedStateHolder(@NonNull final Path swhFile) throws Exception {
+        swh = swhFile;
+        platformState = dehydrate();
+    }
+
+    /** Deserialize the signed state file into an in-memory data structure. */
+    private ServicesState dehydrate() throws Exception {
+        // register all applicable classes on classpath before deserializing signed state
+        ConstructableRegistry.getInstance().registerConstructables("*");
+        platformState =
+                (ServicesState)
+                        (SignedStateFileReader.readStateFile(swh).signedState().getSwirldState());
+        assertSignedStateComponentExists(platformState, "platform state (Swirlds)");
+        return platformState;
+    }
+
+    /**
+     * A contract - some bytecode associated with its contract id(s)
+     *
+     * @param ids - direct from the signed state file there's one contract id for each bytecode, but
+     *     there are duplicates which can be coalesced and then there's a set of ids for the single
+     *     contract
+     * @param bytecode - bytecode of the contractd
+     */
+    public record Contract(
+            @NonNull Set</*NonNull*/ Integer> ids, @NonNull byte /*@NonNull*/[] bytecode) {
+
+        @Override
+        public boolean equals(Object o) {
+            return o instanceof Contract other
+                    && ids.equals(other.ids)
+                    && Arrays.equals(bytecode, other.bytecode);
+        }
+
+        @Override
+        public int hashCode() {
+            return ids.hashCode() * 31 + Arrays.hashCode(bytecode);
+        }
+
+        @Override
+        public String toString() {
+
+            var csvIds = new StringBuilder();
+            for (var id : ids()) {
+                csvIds.append(id); // hides a `toString` which is why `String::join` isn't enough
+                csvIds.append(',');
+            }
+            csvIds.setLength(csvIds.length() - 1);
+
+            return String.format(
+                    "Contract{ids=(%s), bytecode=%s}",
+                    csvIds.toString(), Arrays.toString(bytecode));
+        }
+    }
+
+    /**
+     * All contracts extracted from a signed state file
+     *
+     * @param contracts - dictionary of contract bytecodes indexed by their contract id (as a Long)
+     * @param registeredContractsCount - total #contracts known to the _accounts_ in the signed
+     *     state file (not all actually have bytecodes in the file store, and of those, some have
+     *     0-length bytecode files)
+     */
+    public record Contracts(
+            @NonNull Collection</*@NonNull*/ Contract> contracts, int registeredContractsCount) {}
+
+    /**
+     * Convenience method: Given the signed state file's name (the `.swh` file) return all the
+     * bytecodes for all the contracts in that state.
+     */
+    public static @NonNull Contracts getContracts(@NonNull final Path inputFile) throws Exception {
+        final var signedState = new SignedStateHolder(inputFile);
+        final var contractIds = signedState.getAllKnownContracts();
+        final var contractContents = signedState.getAllContractContents(contractIds);
+        return new Contracts(contractContents, contractIds.size());
+    }
+
+    public @NonNull ServicesState getPlatformState() {
+        return platformState;
+    }
+
+    /** Gets all existing accounts */
+    public @NonNull AccountStorageAdapter getAccounts() {
+        final var accounts = platformState.accounts();
+        assertSignedStateComponentExists(accounts, "accounts");
+        return accounts;
+    }
+
+    /**
+     * Returns the file store from the state
+     *
+     * <p>The file state contains, among other things, all the contracts' bytecodes.
+     */
+    public @NonNull VirtualMap<VirtualBlobKey, VirtualBlobValue> getFileStore() {
+        final var fileStore = platformState.storage();
+        assertSignedStateComponentExists(fileStore, "fileStore");
+        return fileStore;
+    }
+
+    /**
+     * Returns all contracts known via Hedera accounts, by their contract id (lowered to an Integer)
+     */
+    public @NonNull Set</*@NonNull*/ Integer> getAllKnownContracts() {
+        var ids = new HashSet<Integer>();
+        getAccounts()
+                .forEach(
+                        (k, v) -> {
+                            if (null != k && null != v && v.isSmartContract())
+                                ids.add(k.intValue());
+                        });
+        return ids;
+    }
+
+    /** Returns the bytecodes for all the requested contracts */
+    public @NonNull Collection</*@NonNull*/ Contract> getAllContractContents(
+            @NonNull final Collection</*@NonNull*/ Integer> contractIds) {
+
+        final var fileStore = getFileStore();
+        var codes = new ArrayList<Contract>();
+        for (var cid : contractIds) {
+            final var vbk = new VirtualBlobKey(Type.CONTRACT_BYTECODE, cid);
+            if (fileStore.containsKey(vbk)) {
+                final var blob = fileStore.get(vbk);
+                if (null != blob) {
+                    final var c = new Contract(Set.of(cid), blob.getData());
+                    codes.add(c);
+                }
+            }
+        }
+        return codes;
+    }
+
+    public static class MissingSignedStateComponent extends NullPointerException {
+        public MissingSignedStateComponent(
+                @NonNull final String component, @NonNull final Path swh) {
+            super(
+                    String.format(
+                            "Expected non-null %s from signed state file %s",
+                            component, swh.toString()));
+        }
+    }
+
+    private void assertSignedStateComponentExists(
+            final Object component, @NonNull final String componentName) {
+        if (null == component) throw new MissingSignedStateComponent(componentName, swh);
+    }
+}

--- a/test-clients/src/main/java/com/hedera/services/yahcli/commands/signedstate/SummarizeSignedStateFileCommand.java
+++ b/test-clients/src/main/java/com/hedera/services/yahcli/commands/signedstate/SummarizeSignedStateFileCommand.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hedera.services.yahcli.commands.signedstate;
+
+import static com.hedera.services.yahcli.commands.signedstate.SignedStateHolder.getContracts;
+
+import com.hedera.services.yahcli.commands.signedstate.SignedStateHolder.Contract;
+import java.lang.reflect.Array;
+import java.nio.file.Path;
+import java.util.concurrent.Callable;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.ParentCommand;
+
+@Command(
+        name = "summarize",
+        subcommands = {picocli.CommandLine.HelpCommand.class},
+        description = "Summarizes contents of signed state file (to stdout)")
+public class SummarizeSignedStateFileCommand implements Callable<Integer> {
+    @ParentCommand private SignedStateCommand signedStateCommand;
+
+    @Option(
+            names = {"-f", "--file"},
+            arity = "1",
+            description = "Input signed state file")
+    Path inputFile;
+
+    @Override
+    public Integer call() throws Exception {
+        final var knownContracts = getContracts(inputFile);
+
+        final int contractsWithBytecodeFound = knownContracts.contracts().size();
+        final var bytesFound =
+                knownContracts.contracts().stream()
+                        .map(Contract::bytecode)
+                        .mapToInt(Array::getLength)
+                        .sum();
+
+        System.out.printf(
+                "SummarizeSignedStateFile: %d contractIDs found %d contracts found in file store"
+                        + " (%d bytes total)",
+                knownContracts.registeredContractsCount(), contractsWithBytecodeFound, bytesFound);
+
+        return 0;
+    }
+}


### PR DESCRIPTION
First of a (short) sequence of PRs that will provide a utility that can disassemble contracts from a signed state file, and, ultimately, analyze contracts by looking at their bytecodes for interesting patterns (possibly supplementing the contract's
bytecodes with information from other sources, e.g., mirror nodes).

**Description**:

Built using the (original) Unix philosophy: Provide single-purpose tools that each do just one thing and then use it in pipelines to get things done. 
- E.g., use tool to _get all contracts_, then use `grep` to do a rough filter to get contracts you want, then use tool to `disassemble` contracts, then use `grep`|`awk`|`python`|`Mathematica`| _whatever_ to do further analysis.

- This is **tranche 1:** Not a useful command (it just prints the number of contracts found in the signed state file) but demonstrates the ability to actually open and read the signed state file.

- **N.B.:** Code is living right now as a subcommand of the `yahcli` tool, simply because that was a convenient place to do this work (given the paucity of examples of how to build CLI tools in this repo.  Final destination of this tool will probably be (likely be? possibly be?) a standalone tool of its own somewhere else in this repo.
  - _Suggestions on where to put it as a standalone CLI tool welcome!_  But _must_ be accompanied by assistance with the build system 'cause I don't know how to create a separate executable.

- Requires a signed state _archive_ - the `.swh` file _and_ the accompanying directory with the virtual maps, most especially the `filestore` vmap which contains the actual contract bytecodes.  But needs everything so that the reader can reconstitute the _entire_ signed state in memory.  (But the structure/presence of these files/directories is not validated.)

**Usage**:

- `yahcli signedstate summarize --file <name-of-.swh-file>`
  - tells you how many contract ids found, how many of those had bytecodes saved in the file store, and total number of bytecode bytes
    - _Suggestions for other interesting data/metadata to display as summary welcomed!_

**Related issue(s)**:

Progress for #4267

**Related PRs**:

- #4319 - part 1
- #4320 - part 2
- #4346 - part 3

**Notes for reviewer**:

- Changes were made to the gradle build instructions for _all_ of `test-clients` (meaning, the tests as well as `yahcli`). Specifically, dependencies were added. It may be possible to do better than this and scope the new dependencies strictly to `yahcli`.  Please advise. (@srkswirlds - perhaps this is you who needs to advise me?)

**Interesting facts**:

- A reasonably current signed state archive has:
  - 1932 contract ids registered in accounts
  - 1879 have bytecode in the file store, 3 have 0-length entries for their bytecode in the file store (?)
  - ~13Mb of bytecode altogether

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (only by running it)

Signed-off-by: David Bakin <117694041+david-bakin-sl@users.noreply.github.com>
