### PR TITLE
Contract bytecode disassembler, as CLI - part 2

### DIFF
--- a/test-clients/build.gradle.kts
+++ b/test-clients/build.gradle.kts
@@ -59,6 +59,7 @@ dependencies {
     implementation(libs.bundles.logging)
     implementation(testLibs.besu.internal)
     implementation(testLibs.commons.collections4)
+    implementation(libs.commons.codec)
     implementation(libs.commons.io)
     implementation(libs.guava)
     implementation(libs.hapi) {

--- a/test-clients/src/main/java/com/hedera/services/yahcli/commands/signedstate/00-running-yahcli-to-get-contract-info.md
+++ b/test-clients/src/main/java/com/hedera/services/yahcli/commands/signedstate/00-running-yahcli-to-get-contract-info.md
@@ -1,0 +1,94 @@
+- (all examples using a signed state file from ~2022-11-10)
+
+# `signedstate` command
+
+The `signedstate` command lets the user access certain kinds 
+of information that is in the "signed state file" - a snapshot
+state dump of the Hedera hashgraph's accounts and file store and
+smart contract key/value stores (current at the point in time the
+snapshot was taken).
+
+The current line of development is directed towards pulling out
+contracts from the signed state and doing certain kinds of
+analysis on them.<sup>†</sup>
+
+## The signed state "file"
+
+The "signed state file" is not actually a file, it's a directory structure
+containing a merkle tree (in `SignedState.swh`) and peer files/directories
+which are maps of the file store ("storage") and per-smart-contract key-value
+store (these latter two things are "virtual maps").
+
+On disk the signed state file is ~1.3GB (as of 2022-10).  When deserialized
+the entire merkle tree (~725MB serialized) is materialized in memory, as 
+well as the indexes to the two virtual maps.  The values of the virtual maps
+are read from disk when accessed.
+
+## Contracts
+
+In the signed state, a contract's bytecode can be found from an account
+id by looking in the file store using a (virtual blob) key which is a
+pair of the account id and `Type.CONTRACT_BYTECODE`.  The account id
+must be of a smart contract account.
+
+## Contract-related subcommands of `signedstate`
+
+The contract-related subcommands of the `signedstate` command are:
+
+* `yahcli signedstate dumprawcontracts` - dumps the bytecodes for all contracts in the signed state
+  - optionally eliminate duplicates
+* (that's it for now)
+    
+
+## `dumprawcontracts` subcommand
+
+### get contract bytecodes out of signed state file
+- (signed state file is actually in a directory tree of all signed state information)
+
+```bash
+./yahcli signedstate dumprawcontracts --with-ids --prefix=">" \
+   -f ~/Downloads/contract_state_hip_583_analysis/SignedState.swh | \
+   grep -E '^>' | cut -f 2,3 > raw-contract-bytecodes.txt
+```
+#### output is one contract/line plus a bunch of cruft to ignore
+ - contract lines are preceded by prefix (here `>`)
+   - use `grep -E '^>'` to get _only_ contract lines
+ - each contract line has tab-separated fields
+   - first field is prefix (here '>') (if `--prefix` argument given)
+     - above command uses `cut` to remove prefix from line
+   - second field is hex-encoded contract
+   - third field is contract id (decimal) (if `--with-ids`) argument given
+
+- found 1932 contracts registered with accounts, 1876 with bytecode (3 with 0-length bytecode!)
+
+Add `--unique` to get only _unique_ contracts (by bytecode), and now, if `--with-ids` argument
+present, each contract line has an additional tab-separated field:
+  - fourth field is comma-separated list of all contract ids with this same bytecode
+
+```bash
+./yahcli signedstate dumprawcontracts --unique --with-ids --prefix=">" \
+   -f ~/Downloads/contract_state_hip_583_analysis/SignedState.swh | \
+   grep -E '^>' | cut -f 2,3 > raw-unique-contract-bytecodes.txt
+```
+
+### find only solidity contracts
+
+- consider that the solidity prelude is
+  ```
+  (0x60) PUSH1 0x??
+  (0x60) PUSH1 0x??
+  (0x52) MSTORE
+  ```
+
+So:
+
+```bash
+grep -E '^60..60..52' < raw-unique-contract-bytecodes.txt > raw-unique-solidity-only-contract-bytecodes.txt
+```
+
+- 481 "solidity only" contracts left (with maybe some false positives)
+
+----
+
+<sup>†</sup> But other kinds of information extraction from a signed state file
+can be added as needed.

--- a/test-clients/src/main/java/com/hedera/services/yahcli/commands/signedstate/ByteArrayAsKey.java
+++ b/test-clients/src/main/java/com/hedera/services/yahcli/commands/signedstate/ByteArrayAsKey.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hedera.services.yahcli.commands.signedstate;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.Arrays;
+
+/** Implements equality-of-content on a byte array so it can be used as a map key */
+public record ByteArrayAsKey(@NonNull byte[] array) {
+
+    @Override
+    public boolean equals(Object o) {
+        return o instanceof ByteArrayAsKey other && Arrays.equals(array, other.array);
+    }
+
+    @Override
+    public int hashCode() {
+        return Arrays.hashCode(array);
+    }
+
+    @Override
+    public String toString() {
+        return "ByteArrayAsKey{" + "array=" + Arrays.toString(array) + '}';
+    }
+}

--- a/test-clients/src/main/java/com/hedera/services/yahcli/commands/signedstate/DumpRawContractsCommand.java
+++ b/test-clients/src/main/java/com/hedera/services/yahcli/commands/signedstate/DumpRawContractsCommand.java
@@ -1,0 +1,205 @@
+/*
+ * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hedera.services.yahcli.commands.signedstate;
+
+import static com.hedera.services.yahcli.commands.signedstate.SignedStateHolder.getContracts;
+
+import com.hedera.services.yahcli.commands.signedstate.SignedStateHolder.Contract;
+import com.hedera.services.yahcli.commands.signedstate.SignedStateHolder.Contracts;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.HexFormat;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.ParentCommand;
+
+@Command(
+        name = "dumprawcontracts",
+        subcommands = {picocli.CommandLine.HelpCommand.class},
+        description = "Dumps contract bytecodes in hex (to stdout)")
+public class DumpRawContractsCommand implements Callable<Integer> {
+    @ParentCommand private SignedStateCommand signedStateCommand;
+
+    @Option(
+            names = {"-f", "--file"},
+            arity = "1",
+            description = "Input signed state file")
+    Path inputFile;
+
+    @Option(
+            names = {"-u", "--unique"},
+            description = "Emit each contract only once (not matter how many times it occurs)")
+    boolean emitUnique;
+
+    @Option(
+            names = {"-p", "--prefix"},
+            description =
+                    "Prefix for each contract bytecode line (suitable for finding lines via grep")
+    String prefix = "";
+
+    @Option(
+            names = {"-#", "--with-ids"},
+            description = "Output contract ids too")
+    boolean withIds;
+
+    @Override
+    public Integer call() throws Exception {
+
+        var zeroLengthCount = new int[1];
+
+        var r = getNonTrivialContracts(inputFile, zeroLengthCount);
+
+        final var totalContractsRegisteredWithAccounts = r.registeredContractsCount();
+        final var totalContractsPresentInFileStore = r.contracts().size();
+        var totalUniqueContractsPresentInFileStore = totalContractsPresentInFileStore;
+
+        if (emitUnique) {
+            r = uniquifyContracts(r);
+            totalUniqueContractsPresentInFileStore = r.contracts().size();
+        }
+
+        var formattedContracts = formatContractLines(r);
+
+        System.out.printf(
+                "%d registered contracts, %d with bytecode (%d are 0-length)%s%n",
+                totalContractsRegisteredWithAccounts,
+                totalContractsPresentInFileStore + zeroLengthCount[0],
+                zeroLengthCount[0],
+                emitUnique
+                        ? String.format(
+                                ", %d unique (by bytecode)", totalUniqueContractsPresentInFileStore)
+                        : "");
+        for (var s : formattedContracts) System.out.println(s);
+
+        return 0;
+    }
+
+    /** Format a collection of pairs of a set of contract ids with their associated bytecode */
+    private @NonNull Collection</*@NonNull*/ String> formatContractLines(
+            @NonNull final Contracts contracts) {
+        Collection</*@NonNull*/ String> formattedContracts = new ArrayList<>();
+        for (var contract : contracts.contracts()) {
+            final var s = formatContractLine(contract);
+            formattedContracts.add(s);
+        }
+        return formattedContracts;
+    }
+
+    private final HexFormat hexer = HexFormat.of().withUpperCase();
+
+    /** Format a single contract line - may have a prefix, may want any id, may want _all_ ids */
+    private @NonNull String formatContractLine(@NonNull final Contract contract) {
+        StringBuilder sb =
+                new StringBuilder(
+                        contract.bytecode().length * 2
+                                + prefix.length()
+                                + 50 /*more than enuf for the rest*/);
+        if (!prefix.isEmpty()) {
+            sb.append(prefix);
+            sb.append('\t');
+        }
+
+        sb.append(hexer.formatHex(contract.bytecode()));
+
+        var ids = contract.ids();
+        if (withIds && !ids.isEmpty()) {
+            // Output canonical id - we choose the minimum id (so it is deterministic)
+            sb.append('\t');
+            sb.append(ids.stream().mapToInt(i -> i).min().getAsInt());
+
+            // Now output _all_ ids
+            sb.append('\t');
+
+            sb.append(String.join(",", ids.stream().map(Object::toString).toList()));
+        }
+
+        return sb.toString();
+    }
+
+    /**
+     * Returns, out of the signed state store, all unique contracts (by their bytecode)
+     *
+     * <p>Returns the set of all unique contract (by their bytecode), each contract with _all_ of
+     * the contract ids associated with it. Also returns the total number of contracts registered in
+     * the signed state file. The latter number may be larger than the number of
+     * contracts-with-bytecodes returned because some contracts known to accounts are not present in
+     * the file store.
+     */
+    private @NonNull Contracts uniquifyContracts(@NonNull final Contracts contracts) {
+
+        // First, create a map where the bytecode is the key (have to wrap the array for that) and
+        // the value is a set of all contract ids associated with that bytecode.
+        var contractsByBytecode = new HashMap<ByteArrayAsKey, Set<Integer>>();
+        for (var contract : contracts.contracts()) {
+            final var bytecode = contract.bytecode();
+            final var cids = contract.ids();
+            contractsByBytecode.compute(
+                    new ByteArrayAsKey(bytecode),
+                    (k, v) -> {
+                        if (null == v) {
+                            v = new HashSet<>();
+                        }
+                        v.addAll(cids);
+                        return v;
+                    });
+        }
+
+        // Second, flatten that map into a collection.
+        var uniqueContracts = new ArrayList<Contract>(contractsByBytecode.size());
+        for (var kv : contractsByBytecode.entrySet()) {
+            uniqueContracts.add(new Contract(kv.getValue(), kv.getKey().array()));
+        }
+
+        return new Contracts(uniqueContracts, contracts.registeredContractsCount());
+    }
+
+    /**
+     * Returns, out of the signed state store, all contracts
+     *
+     * <p>Returns both the set of all contract ids with their bytecode, and the total number of
+     * contracts registered in the signed state file. The latter number may be larger than the
+     * number of contracts-with-bytecodes returned because some contracts known to accounts are not
+     * present in the file store.
+     */
+    private @NonNull Contracts getNonTrivialContracts(
+            @NonNull final Path inputFile, @NonNull int[] outZeroLengthCount) throws Exception {
+
+        var knownContracts = getContracts(inputFile);
+
+        // Remove (and report) 0-length contracts (what's that about? probably some user's error?)
+        knownContracts
+                .contracts()
+                .removeIf(
+                        contract -> {
+                            if (0 == contract.bytecode().length) {
+                                outZeroLengthCount[0]++;
+                                System.out.printf(
+                                        "!!! 0-byte bytecode for %d%n",
+                                        contract.ids().iterator().next());
+                                return true;
+                            }
+                            return false;
+                        });
+
+        return knownContracts;
+    }
+}

--- a/test-clients/src/main/java/com/hedera/services/yahcli/commands/signedstate/SignedStateCommand.java
+++ b/test-clients/src/main/java/com/hedera/services/yahcli/commands/signedstate/SignedStateCommand.java
@@ -23,7 +23,11 @@ import picocli.CommandLine.ParentCommand;
 
 @Command(
         name = "signedstate",
-        subcommands = {CommandLine.HelpCommand.class, SummarizeSignedStateFileCommand.class},
+        subcommands = {
+            CommandLine.HelpCommand.class,
+            SummarizeSignedStateFileCommand.class,
+            DumpRawContractsCommand.class
+        },
         description = "Dealing with signed state files")
 public class SignedStateCommand implements Callable<Integer> {
     @ParentCommand Yahcli yahcli;

--- a/test-clients/src/main/java/com/hedera/services/yahcli/commands/signedstate/SignedStateHolder.java
+++ b/test-clients/src/main/java/com/hedera/services/yahcli/commands/signedstate/SignedStateHolder.java
@@ -76,8 +76,7 @@ public class SignedStateHolder {
      *     contract
      * @param bytecode - bytecode of the contractd
      */
-    public record Contract(
-            @NonNull Set</*NonNull*/ Integer> ids, @NonNull byte /*@NonNull*/[] bytecode) {
+    public record Contract(@NonNull Set</*@NonNull*/ Integer> ids, @NonNull byte[] bytecode) {
 
         @Override
         public boolean equals(Object o) {


### PR DESCRIPTION
Second of a (short) sequence of PRs that will provide a utility that can disassemble contracts from a signed state file, and, ultimately, analyze contracts by looking at their bytecodes for interesting patterns (possibly supplementing the contract's
bytecodes with information from other sources, e.g., mirror nodes).

**Description**:

Built using the (original) Unix philosophy: Provide single-purpose tools that each do just one thing and then use it in pipelines to get things done. 
- E.g., use tool to _get all contracts_, then use `grep` to do a rough filter to get contracts you want, then use tool to `disassemble` contracts, then use `grep`|`awk`|`python`|`Mathematica`| _whatever_ to do further analysis.

- Tranche 1 was #4319 - see that PR for further notes on this tool in progress.

- This is **tranche 2:** Dump all contracts found in the signed state file to stdout, hex encoded, with their associated contract ids.

**Usage**:
   ```
   yahcli signedstate dumprawcontracts -- file <name-of-.swh-file> --with-ids --unique --prefix ">" | \
       grep -E '^>' | cut -f 2,3
   ```

**Related issue(s)**:

Progress for #4267

**Related PRs**:

- #4319 - part 1
- #4320 - part 2
- #4346 - part 3

**Notes for reviewer**:

- Changes were made (again) to the gradle build instructions for _all_ of `test-clients` (meaning, the tests as well as `yahcli`). Specifically, dependencies were added. It may be possible to do better than this and scope the new dependencies strictly to `yahcli`.  Please advise. (@srkswirlds - perhaps this is you who needs to advise me?)

**Interesting facts**:

- A reasonably current signed state archive has:
  - 1932 contract ids registered in accounts
  - 1876 have bytecode in the file store, 3 more have 0-length entries for their bytecode in the file store
  - 504 unique contracts (by bytecode)
  - 481 have the Solidity compiler "prelude"
  - ~13Mb of bytecode altogether

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (only by running it)

Signed-off-by: David Bakin <117694041+david-bakin-sl@users.noreply.github.com>