### PR TITLE
Mark `eet` and `itest` dependencies explicit

### DIFF
--- a/test-clients/build.gradle.kts
+++ b/test-clients/build.gradle.kts
@@ -15,21 +15,6 @@
  */
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 
-/*
- * Copyright (C) 2022 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 plugins {
     id("com.hedera.hashgraph.conventions")
     id("com.hedera.hashgraph.shadow-jar")
@@ -85,11 +70,13 @@ tasks.itest {
     systemProperty("junit.jupiter.execution.parallel.enabled", false)
     systemProperty("TAG", "services-node:" + project.version)
     systemProperty("networkWorkspaceDir", File(project.buildDir, "network/itest"))
+    outputs.upToDateWhen { false }
 }
 
 tasks.eet {
     systemProperty("TAG", "services-node:" + project.version)
     systemProperty("networkWorkspaceDir", File(project.buildDir, "network/eet"))
+    outputs.upToDateWhen { false }
 }
 
 tasks.shadowJar {

--- a/test-clients/build.gradle.kts
+++ b/test-clients/build.gradle.kts
@@ -63,20 +63,60 @@ dependencies {
     implementation(testLibs.testcontainers.core)
     itestImplementation(libs.bundles.swirlds)
     itestImplementation(testLibs.bundles.testcontainers)
+    itestImplementation(project(":hedera-node:hedera-app"))
+    itestImplementation(project(":hedera-node:hedera-app-spi"))
+    itestImplementation(project(":hedera-node:hedera-evm"))
+    itestImplementation(project(":hedera-node:hedera-evm-api"))
+    itestImplementation(project(":hedera-node:hedera-mono-service"))
+    itestImplementation(project(":modules:hedera-admin-service"))
+    itestImplementation(project(":modules:hedera-admin-service-impl"))
+    itestImplementation(project(":modules:hedera-consensus-service"))
+    itestImplementation(project(":modules:hedera-consensus-service-impl"))
+    itestImplementation(project(":modules:hedera-file-service"))
+    itestImplementation(project(":modules:hedera-file-service-impl"))
+    itestImplementation(project(":modules:hedera-network-service"))
+    itestImplementation(project(":modules:hedera-network-service-impl"))
+    itestImplementation(project(":modules:hedera-schedule-service"))
+    itestImplementation(project(":modules:hedera-schedule-service-impl"))
+    itestImplementation(project(":modules:hedera-smart-contract-service"))
+    itestImplementation(project(":modules:hedera-smart-contract-service-impl"))
+    itestImplementation(project(":modules:hedera-token-service"))
+    itestImplementation(project(":modules:hedera-token-service-impl"))
+    itestImplementation(project(":modules:hedera-util-service"))
+    itestImplementation(project(":modules:hedera-util-service-impl"))
     eetImplementation(testLibs.bundles.testcontainers)
+    eetImplementation(project(":hedera-node:hedera-app"))
+    eetImplementation(project(":hedera-node:hedera-app-spi"))
+    eetImplementation(project(":hedera-node:hedera-evm"))
+    eetImplementation(project(":hedera-node:hedera-evm-api"))
+    eetImplementation(project(":hedera-node:hedera-mono-service"))
+    eetImplementation(project(":modules:hedera-admin-service"))
+    eetImplementation(project(":modules:hedera-admin-service-impl"))
+    eetImplementation(project(":modules:hedera-consensus-service"))
+    eetImplementation(project(":modules:hedera-consensus-service-impl"))
+    eetImplementation(project(":modules:hedera-file-service"))
+    eetImplementation(project(":modules:hedera-file-service-impl"))
+    eetImplementation(project(":modules:hedera-network-service"))
+    eetImplementation(project(":modules:hedera-network-service-impl"))
+    eetImplementation(project(":modules:hedera-schedule-service"))
+    eetImplementation(project(":modules:hedera-schedule-service-impl"))
+    eetImplementation(project(":modules:hedera-smart-contract-service"))
+    eetImplementation(project(":modules:hedera-smart-contract-service-impl"))
+    eetImplementation(project(":modules:hedera-token-service"))
+    eetImplementation(project(":modules:hedera-token-service-impl"))
+    eetImplementation(project(":modules:hedera-util-service"))
+    eetImplementation(project(":modules:hedera-util-service-impl"))
 }
 
 tasks.itest {
     systemProperty("junit.jupiter.execution.parallel.enabled", false)
     systemProperty("TAG", "services-node:" + project.version)
     systemProperty("networkWorkspaceDir", File(project.buildDir, "network/itest"))
-    outputs.upToDateWhen { false }
 }
 
 tasks.eet {
     systemProperty("TAG", "services-node:" + project.version)
     systemProperty("networkWorkspaceDir", File(project.buildDir, "network/eet"))
-    outputs.upToDateWhen { false }
 }
 
 tasks.shadowJar {


### PR DESCRIPTION
**Description**:
We have observed some CI runs with,
```
...
> Task :test-clients:itest FROM-CACHE 👈 🤔
> Task :hedera-node:hedera-app-spi:jar UP-TO-DATE
> Task :hedera-node:hedera-app:compileItestJava
> Task :hedera-node:hedera-app:processItestResources NO-SOURCE
```
The result is that no `HapiSuite`'s are actually executed---see for example [here](https://github.com/hashgraph/hedera-services/actions/runs/3517095134/jobs/5894475927).

This PR tries to enlighten Gradle on what module changes could actually cause `eet` or `itest` to fail.