### PR TITLE
Contract bytecode disassembler,  as CLI - part 3

### DIFF
--- a/test-clients/src/main/java/com/hedera/services/yahcli/commands/signedstate/DecompileContractCommand.java
+++ b/test-clients/src/main/java/com/hedera/services/yahcli/commands/signedstate/DecompileContractCommand.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hedera.services.yahcli.commands.signedstate;
+
+import static com.hedera.services.yahcli.commands.signedstate.evminfo.Assembly.UPPERCASE_HEX_FORMATTER;
+
+import com.hedera.services.yahcli.commands.signedstate.HexStringConverter.Bytes;
+import com.hedera.services.yahcli.commands.signedstate.evminfo.Assembly;
+import com.hedera.services.yahcli.commands.signedstate.evminfo.Assembly.Line;
+import com.hedera.services.yahcli.commands.signedstate.evminfo.Assembly.Variant;
+import com.hedera.services.yahcli.commands.signedstate.evminfo.CommentLine;
+import com.hedera.services.yahcli.commands.signedstate.evminfo.DirectiveLine;
+import com.hedera.services.yahcli.commands.signedstate.evminfo.DirectiveLine.Kind;
+import com.hedera.services.yahcli.commands.signedstate.evminfo.LabelLine;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.Callable;
+import java.util.stream.Collectors;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.ParentCommand;
+
+@Command(
+        name = "decompilecontract",
+        subcommands = {picocli.CommandLine.HelpCommand.class},
+        description = "Decompiles contract bytecodes")
+public class DecompileContractCommand implements Callable<Integer> {
+    @ParentCommand private SignedStateCommand signedStateCommand;
+
+    @Option(
+            names = {"-b", "--bytecode"},
+            required = true,
+            arity = "1",
+            converter = HexStringConverter.class,
+            paramLabel = "HEX",
+            description = "Contract bytecode as a hex string")
+    Bytes theContract;
+
+    @Option(
+            names = {"-p", "--prefix"},
+            description = "Prefix for each assembly line")
+    String prefix = "";
+
+    @Option(
+            names = {"-i", "--id"},
+            paramLabel = "CONTRACT_ID",
+            description = "Contract Id (decimal, optional)")
+    Optional<Integer> theContractId;
+
+    @Option(names = "--with-code-offset", description = "Display code offsets")
+    boolean withCodeOffset;
+
+    @Option(names = "--with-opcode", description = "Display opcode (in hex")
+    boolean withOpcode;
+
+    @Option(names = "--with-metrics", description = "Record metrics in generated assembly")
+    boolean withMetrics;
+
+    @Option(
+            names = "--with-contract-bytecode",
+            description = "Put the contract bytecode in a comment")
+    boolean withContractBytecode;
+
+    @Option(names = "--do-not-decode-before-metadata")
+    boolean withoutDecodeBeforeMetadata;
+
+    @Override
+    public Integer call() throws Exception {
+        disassembleContract();
+        return 0;
+    }
+
+    void disassembleContract() throws Exception {
+
+        try {
+            var options = new ArrayList<Variant>();
+            if (withCodeOffset) options.add(Variant.DISPLAY_CODE_OFFSET);
+            if (withOpcode) options.add(Variant.DISPLAY_OPCODE_HEX);
+            if (withoutDecodeBeforeMetadata) options.add(Variant.WITHOUT_DECODE_BEFORE_METADATA);
+
+            var metrics = new HashMap</*@NonNull*/ String, /*@NonNull*/ Object>();
+            metrics.put(START_TIMESTAMP, System.nanoTime());
+
+            // Do the disassembly here ...
+            final var asm = new Assembly(metrics, options.toArray(new Variant[0]));
+            final var prefixLines = getPrefixLines();
+            final var lines = asm.getInstructions(prefixLines, theContract.contents);
+
+            metrics.put(END_TIMESTAMP, System.nanoTime());
+
+            if (withMetrics) {
+                // replace existing `END` directive with one that has the metrics as a comment
+                final var endDirective = new DirectiveLine(Kind.END, formatMetrics(metrics));
+                if (lines.get(lines.size() - 1) instanceof DirectiveLine directive
+                        && Kind.END.name().equals(directive.directive()))
+                    lines.remove(lines.size() - 1);
+                lines.add(endDirective);
+            }
+
+            for (var line : lines) System.out.printf("%s%s%n", prefix, line.formatLine());
+        } catch (Exception ex) {
+            throw printFormattedException(theContractId, ex);
+        }
+    }
+
+    /**
+     * Create "prefix" lines to be put ahead of disassembly
+     *
+     * <p>Put some interesting data in the form of comments and directives to be placed as a prefix
+     * in front of the disassembly.
+     */
+    List<Line> getPrefixLines() {
+        var lines = new ArrayList<Line>();
+        if (withContractBytecode) {
+            final var comment =
+                    String.format(
+                            "contract (%d bytes): %s",
+                            theContract.contents.length,
+                            UPPERCASE_HEX_FORMATTER.formatHex(theContract.contents));
+            lines.add(new CommentLine(comment));
+        }
+        {
+            final var comment = theContractId.map(i -> "contract id: " + i.toString()).orElse("");
+            lines.add(new DirectiveLine(Kind.BEGIN, comment));
+        }
+        lines.add(new LabelLine("ENTRY"));
+        return lines;
+    }
+
+    // metrics keys:
+    static final String START_TIMESTAMP = "START_TIMESTAMP"; // long
+    static final String END_TIMESTAMP = "END_TIMESTAMP"; // long
+
+    /** Format metrics into a string suitable for a comment on the `END` directive */
+    String formatMetrics(@NonNull final Map</*@NonNull*/ String, /*@NonNull*/ Object> metrics) {
+        var sb = new StringBuilder();
+
+        // elapsed time computation
+        final var nanosElapsed =
+                (long) metrics.get(END_TIMESTAMP) - (long) metrics.get(START_TIMESTAMP);
+        final float msElapsed = nanosElapsed / 1.e6f;
+        sb.append(String.format("%.3f ms elapsed", msElapsed));
+
+        return sb.toString();
+    }
+
+    /**
+     * Dump the contract id + exception + stacktrace to stdout
+     *
+     * <p>Do it here so each line can be formatted with a known prefix so that you can easily grep
+     * for problems in a directory full of disassembled contracts.
+     */
+    Exception printFormattedException(final Optional<Integer> theContractId, final Exception ex) {
+        final var EXCEPTION_PREFIX = "***";
+
+        var sw = new StringWriter(2000);
+        var pw = new PrintWriter(sw, true /*auto-flush*/);
+        ex.printStackTrace(pw);
+        final var starredExceptionDump =
+                sw.toString()
+                        .lines()
+                        .map(s -> EXCEPTION_PREFIX + s)
+                        .collect(Collectors.joining("\n"));
+        System.out.printf(
+                "*** EXCEPTION CAUGHT (id %s): %s%n%s%n",
+                theContractId.map(Object::toString).orElse("NOT-GIVEN"),
+                ex.toString(),
+                starredExceptionDump);
+        return ex;
+    }
+}

--- a/test-clients/src/main/java/com/hedera/services/yahcli/commands/signedstate/HexStringConverter.java
+++ b/test-clients/src/main/java/com/hedera/services/yahcli/commands/signedstate/HexStringConverter.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hedera.services.yahcli.commands.signedstate;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.HexFormat;
+import java.util.regex.Pattern;
+import picocli.CommandLine.ITypeConverter;
+import picocli.CommandLine.TypeConversionException;
+
+/**
+ * Converts a hex string command line argument to a byte array
+ *
+ * <p>For Picocli library - implements a type-specific converter from hex string to bytes.
+ */
+public class HexStringConverter implements ITypeConverter<HexStringConverter.Bytes> {
+
+    // Unfortunately can't return `byte[]` directly from the custom type converter because Piccoli
+    // gets confused: When the argument is declared (at the command class) it thinks it wants a
+    // multi-value type (even if `arity=1` is specified). Thus: need to wrap it in a stupid class.
+    // Would have used a record but Sonarlint complains (properly) that records with array members
+    // need overrides for `equals`/`hashcode`/`toString`, and at that point, why bother?
+    // See https://stackoverflow.com/a/74207195/751579.
+    public static class Bytes {
+        public final @NonNull byte[] contents;
+
+        public Bytes(final byte[] b) {
+            if (null == b)
+                throw new TypeConversionException("-b bytecode missing an array value (somehow)");
+            contents = b;
+        }
+    }
+
+    /** "Converts the specified command line argument value to some domain object" */
+    @Override
+    public @NonNull Bytes convert(@NonNull final String value) {
+        if (0 != value.length() % 2)
+            throw new TypeConversionException("-b bytecode must have even number of hexits");
+        if (!Pattern.compile("[0-9a-fA-F]+").matcher(value).matches())
+            throw new TypeConversionException("-b bytecode has invalid characters (not hexits)");
+        return new Bytes(HexFormat.of().parseHex(value));
+    }
+}

--- a/test-clients/src/main/java/com/hedera/services/yahcli/commands/signedstate/SignedStateCommand.java
+++ b/test-clients/src/main/java/com/hedera/services/yahcli/commands/signedstate/SignedStateCommand.java
@@ -26,7 +26,8 @@ import picocli.CommandLine.ParentCommand;
         subcommands = {
             CommandLine.HelpCommand.class,
             SummarizeSignedStateFileCommand.class,
-            DumpRawContractsCommand.class
+            DumpRawContractsCommand.class,
+            DecompileContractCommand.class
         },
         description = "Dealing with signed state files")
 public class SignedStateCommand implements Callable<Integer> {

--- a/test-clients/src/main/java/com/hedera/services/yahcli/commands/signedstate/evminfo/Assembly.java
+++ b/test-clients/src/main/java/com/hedera/services/yahcli/commands/signedstate/evminfo/Assembly.java
@@ -1,0 +1,543 @@
+/*
+ * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hedera.services.yahcli.commands.signedstate.evminfo;
+
+import com.hedera.services.yahcli.commands.signedstate.evminfo.DataPseudoOpLine.Kind;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HexFormat;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.function.IntFunction;
+import java.util.regex.Pattern;
+
+/**
+ * Generates disassembly of an EVM contract
+ *
+ * <p>Generates the disassembly of an EVM contract. Defines the _lines_ of a disassembly as falling
+ * into two classes: `Line`s - every line in the disassembly is one of these records, and `Code` -
+ * all bytes of the bytecode go into one of these records.
+ */
+public class Assembly {
+
+    /**
+     * A line of the disassembly
+     *
+     * <p>(dev note: here is an _interface_ with _default_ methods so that "subclasses" can be
+     * immutable records - which is what I really want)
+     */
+    public static interface Line {
+
+        /** Formats the line into a string suitable for directly putting in the disassembly */
+        void formatLine(StringBuilder sb);
+
+        /**
+         * Formats the line into a string suitable for directly putting in the disassembly
+         *
+         * <p>Convenience method so that holders of Lines don't have to create their own
+         * StringBuilder
+         */
+        default String formatLine() {
+            var sb = new StringBuilder(MAX_EXPECTED_LINE);
+            formatLine(sb);
+            return sb.toString();
+        }
+
+        /**
+         * Extend a string until it reaches the goal column
+         *
+         * <p>Utility function useful for lining up fields (opcode, mnemonic, comment, etc.) into
+         * columns.
+         */
+        default void extendWithBlanksTo(StringBuilder sb, int goalColumn) {
+            if (goalColumn <= sb.length()) {
+                // Already past the goal column ... just pad with a couple of blanks
+                sb.append("  ");
+                return;
+            }
+
+            // Need to pad to goal column - keep sticking blanks on to the end until past
+            // the goal, then truncate to correct size
+            while (sb.length() < goalColumn) {
+                sb.append("                ");
+            }
+            sb.setLength(goalColumn);
+        }
+
+        /**
+         * Check if this Line is a specific instruction opcodes
+         *
+         * <p>Convenience method for check to see if this line is an instruction with the given
+         * opcode.
+         */
+        default boolean thisLineIsA(int opcode) {
+            return this instanceof CodeLine codeLine && codeLine.opcode() == opcode;
+        }
+
+        /** Make a HexFormatter available to all Lines */
+        default HexFormat hexer() {
+            return Assembly.UPPERCASE_HEX_FORMATTER;
+        }
+    }
+
+    /**
+     * A line of _code_ (something with bytes from the contract)
+     *
+     * <p>A line of _code_ in the disassembly (could be an opcode, maybe a pseudo-op like `DATA`, or
+     * maybe a (discovered) macro.
+     */
+    public static interface Code {
+
+        /** Returns the code offset of this line of code */
+        public abstract int getCodeOffset();
+
+        /** Returns the number of bytes of this line of code */
+        public abstract int getCodeSize();
+    }
+
+    /**
+     * Enum to describe disassembly variants, and pass them to records which implement Line
+     *
+     * <p>Each variant way to disassemble has its own enum value. Each enum value has a boolean
+     * which is true iff that variant is desired. (Some people might think this is a rather sleezy
+     * way to communiate global program state to the various records that are the Lines of the
+     * disassembly. But there's actually nothing wrong with using a named singleton to represent
+     * that state, and that's what Java gives you with enums: they're compiler-generated named
+     * singletons with whatever state you want to give them.)
+     */
+    public enum Variant {
+        DISPLAY_CODE_OFFSET,
+        DISPLAY_OPCODE_HEX,
+        WITHOUT_DECODE_BEFORE_METADATA;
+
+        private boolean value = false;
+
+        public boolean getValue() {
+            return value;
+        }
+
+        void setOptionOn() {
+            this.value = true;
+        }
+    }
+
+    public Assembly(
+            @NonNull final Map</*@NonNull*/ String, /*@NonNull*/ Object> metrics,
+            @NonNull final Variant... options) {
+
+        // First: take the desired disassembly variants (passed in as a map) and use them to set
+        // the Options enum instances "ON" appropriately.
+        for (var o : options) {
+            switch (o) {
+                case DISPLAY_CODE_OFFSET -> {
+                    Variant.DISPLAY_CODE_OFFSET.setOptionOn();
+                    Columns.adjustFieldColumns(Columns.CODE_OFFSET, CODE_OFFSET_COLUMN_WIDTH);
+                }
+                case DISPLAY_OPCODE_HEX -> {
+                    Variant.DISPLAY_OPCODE_HEX.setOptionOn();
+                    Columns.adjustFieldColumns(Columns.OPCODE, OPCODE_COLUMN_WIDTH);
+                }
+                case WITHOUT_DECODE_BEFORE_METADATA -> {
+                    Variant.WITHOUT_DECODE_BEFORE_METADATA.setOptionOn();
+                }
+            }
+        }
+        this.metrics = metrics;
+    }
+
+    /**
+     * Map for accumulating interesting metrics of disassembled code.
+     *
+     * <p>RFU.
+     */
+    private final @NonNull Map</*@NonNull*/ String, /*@NonNull*/ Object> metrics;
+
+    /**
+     * Named enums for each "column" in the disassembly output, holding their column location
+     *
+     * <p>Each "column" in the resulting disassembly has its own enum value, which holds its column
+     * position. But the column locations depend on which variants are chosen. E.g., you may or may
+     * not be formatting with the code offset present. Thus there is a mechanism where the columns
+     * are given default values for the vanilla disassembly, and as options are selected which _add_
+     * a column to the disassembly the other columns to its right are moved over. For this purpose
+     * columns are "grouped".
+     */
+    enum Columns {
+        CODE_OFFSET(0, DEFAULT_CODE_OFFSET_COLUMN),
+        OPCODE(1, DEFAULT_OPCODE_COLUMN),
+        COMMENT(2, DEFAULT_COMMENT_COLUMN),
+        LABEL(2, DEFAULT_LABEL_COLUMN),
+        MNEMONIC(2, DEFAULT_MNEMONIC_COLUMN),
+        OPERAND(2, DEFAULT_OPERAND_COLUMN),
+        EOL_COMMENT(2, DEFAULT_EOL_COMMENT_COLUMN);
+
+        public final int columnModificationGroup;
+        private int column;
+
+        public int getColumn() {
+            return column;
+        }
+
+        Columns(int columnModificationGroup, int column) {
+            this.columnModificationGroup = columnModificationGroup;
+            this.column = column;
+        }
+
+        /** When an option adds a column to the disassembly adjust the location of other columns */
+        static void adjustFieldColumns(@NonNull final Columns after, int byWidth) {
+            for (var e : Columns.values())
+                if (after.columnModificationGroup < e.columnModificationGroup) e.column += byWidth;
+        }
+    }
+
+    /** The next instruction decoded from the bytestream */
+    public record NextInstruction(@NonNull Line line, int nextOffset) {}
+
+    /**
+     * Get next instruction from bytecode stream
+     *
+     * <p>Get the next instruction from the bytecode stream, returning both the next instruction
+     * decoded (as a Code) and the _next_ offset for the _next_ next instruction. At end of bytecode
+     * it returns the "END" directive and then the _next_ time it is called it finally returns
+     * `null`, signalling the caller to stop iterating.
+     */
+    public NextInstruction getNextInstruction(@NonNull final byte[] bytecode, int codeOffset) {
+
+        // Check end conditions
+        if (codeOffset < 0) return null;
+        if (codeOffset >= bytecode.length)
+            return new NextInstruction(new DirectiveLine(DirectiveLine.Kind.END), -1);
+
+        // Get the next opcode and its syntax.
+        final byte opcode = bytecode[codeOffset];
+        final Opcodes.Descr descr = Opcodes.getOpcode(opcode);
+        final boolean haveExtraBytes = descr.extraBytes() > 0;
+        final int instructionLength = 1 /*opcode itself*/ + descr.extraBytes();
+
+        // If we're decoding junk (e.g., we're decoding inside a block of code data) we might
+        // find ourselves looking at what seems to be a `PUSHn` that runs off the end of the
+        // bytecode.  That can't be right.
+        if (haveExtraBytes && codeOffset + instructionLength > bytecode.length)
+            throw new IndexOutOfBoundsException(
+                    String.format(
+                            "opcode %s at offset %d overruns bytecode (of length %d)",
+                            descr.mnemonic(), codeOffset, bytecode.length));
+
+        // Pull out the operand bytes, if any
+        final var operandBytes =
+                haveExtraBytes
+                        ? Arrays.copyOfRange(
+                                bytecode, codeOffset + 1, codeOffset + instructionLength)
+                        : new byte[0];
+
+        // The comment field will be used to flag uses of unassigned opcodes.  (We're most
+        // likely decoding "instructions" in a code data block.)
+        final var comment = descr.assigned() ? "" : "**UNASSIGNED OPCODE**";
+
+        // Assemble the instruction and give it to the caller
+        final var line = new CodeLine(codeOffset, opcode, operandBytes, comment);
+        return new NextInstruction(line, codeOffset + instructionLength);
+    }
+
+    // Disassemble the entire bytecode
+
+    /** Disassemble the entire contract bytecode into its Lines of Code. */
+    public List</*@NonNull*/ Line> getInstructions(
+            @NonNull final List</*@NonNull*/ Line> prefixLines, @NonNull final byte[] bytecode) {
+        List<Line> lines = new ArrayList<>(prefixLines);
+
+        // First thing: find the metadata at the end of the contract - see where it starts, and
+        // how long it is
+        final var metadataByteRange = locateMetadata(bytecode);
+
+        // This comparator returns 0 if _at_ the metadata start, or >0 if _past_ the metadata start
+        final IntFunction<Integer> atMetadataOffset =
+                metadataByteRange.isEmpty()
+                        ? ofs -> -1 /* never reach the end */
+                        : ofs -> Integer.compare(ofs, metadataByteRange.from());
+
+        // Main instruction decode loop, working from bytecode
+        NextInstruction nextInstruction;
+        int currentOffset = 0;
+        try {
+            while (null != (nextInstruction = getNextInstruction(bytecode, currentOffset))) {
+
+                // Check to see if we've overrun the start of the metadata
+                if (atMetadataOffset.apply(nextInstruction.nextOffset()) > 0) {
+                    // This instruction, evidently some kind of `PUSHn`, is taking us right past
+                    // where the metadata is supposed to start.  That means we're already decoding
+                    // the code data section and it is coming out as junk.  So we just replace
+                    // this current junk instruction with a DATA that sucks up everything from here
+                    // to where we know the metadata starts.  (If the junk started before this
+                    // point that's ok too, it'll get eaten up when we search backward for `INVALID`
+                    // or `STOP`.  (For an example of this see contract 1358908.)
+                    boolean sanityCheck =
+                            nextInstruction.line() instanceof Code code && code.getCodeSize() > 0;
+                    if (!sanityCheck)
+                        throw new IllegalStateException(
+                                "Have somehow run past metadata from with a single-byte"
+                                        + " instruction");
+                    final var data =
+                            getBytecodeRangeAsData(
+                                    bytecode,
+                                    new Range<Byte>(currentOffset, metadataByteRange.from() - 1),
+                                    "Backtracking data",
+                                    Kind.DATA);
+                    nextInstruction = new NextInstruction(data, metadataByteRange.from());
+                }
+
+                // Ok, have an instruction to add the growing disassembly ...
+                lines.add(nextInstruction.line());
+                currentOffset = nextInstruction.nextOffset();
+
+                // If now we've reached the metadata time to suck it all up and emit it as a
+                // `METADATA` pseudo-op.
+                if (0 == atMetadataOffset.apply(currentOffset)) {
+                    final var comment =
+                            String.format(
+                                    "(metadata %d (%04X) bytes)",
+                                    metadataByteRange.length(), metadataByteRange.length());
+                    final var data =
+                            getBytecodeRangeAsData(
+                                    bytecode,
+                                    metadataByteRange,
+                                    comment,
+                                    DataPseudoOpLine.Kind.METADATA);
+                    lines.add(data);
+                    break;
+                }
+            }
+
+            // At this point we've decoded everything to the end - now look for interesting cases
+            // where you can simplify/correct/improve-for-readability the assembly source.
+
+            // First interesting case: see if there's a code data block at the end that should
+            // have disassembled as DATA and not code - that would be the stuff between a final
+            // `INVALID` or `STOP` and the start of the metadata.
+
+            lines = elideCodeData(lines, bytecode);
+
+            // (At this time that turns out to be the _only_ interesting case we're looking for.)
+
+        } catch (IndexOutOfBoundsException ex) {
+            // If we've overrun the end then obviously something went wrong - is this an invalid
+            // contract?  Have we messed up by not finding the code block properly?  Whatever,
+            // we've got to emit the last bunch of bytes as a `DATA_OVERRUN` pseudo-op.
+            // (Currently happens for contract 44928, dunno why yet.)
+            if (ex.getMessage().contains("overruns bytecode")) {
+                final var data =
+                        getBytecodeRangeAsData(
+                                bytecode,
+                                new Range<Byte>(currentOffset, bytecode.length),
+                                "(*** PUSHn opcode here overruns end of bytecode)",
+                                DataPseudoOpLine.Kind.DATA_OVERRUN);
+                lines.add(data);
+            }
+        }
+
+        return lines;
+    }
+
+    /**
+     * Elide the code block with a replacement `DATA` pseudo-op.
+     *
+     * <p>Given the lines (last one of which is probably a `METADATA` pseudo-op) find the code data
+     * block between the "last" `INVALID` or `STOP` instruction and the start of the metadata, take
+     * that bunch of data and change it into an (uninterpreted) `DATA` pseudo-op, and use it to
+     * _replace_ all the (mis-)interpreted lines of Code.
+     */
+    List<Line> elideCodeData(@NonNull final List<Line> lines, @NonNull final byte[] bytecode) {
+        if (!Variant.WITHOUT_DECODE_BEFORE_METADATA.getValue()) {
+
+            // This function maps a `Range<Line>` of disassembled instructions to a `Range<Byte>`
+            // of those bytecodes in the contract.  It does this by looking in the Lines to see what
+            // offsets they are at in the bytecode.  Ranges here are _exclusive_ at the "to" end.
+            final Function<Range<Line>, Range<Byte>> bytecodeRangeFromLineRange =
+                    lr -> {
+                        if (lines.size() == lr.from()) return Range.empty();
+
+                        final var fromLine = lines.get(lr.from());
+                        final var toLine = lines.get(lr.to());
+                        if (fromLine instanceof Code fromCode && toLine instanceof Code toCode) {
+                            return new Range<Byte>(
+                                    fromCode.getCodeOffset(), toCode.getCodeOffset());
+                        } else
+                            throw new IllegalStateException(
+                                    String.format(
+                                            "Expected Code at line index %d or %d (%s, %s)",
+                                            lr.from(), lr.to(), fromLine, toLine));
+                    };
+
+            // Search backwards from the metadata to an `INVALID` or `STOP` (if present).
+            final var lineRange = lookBackwardsForDelimiterInstruction(lines, bytecode);
+
+            if (!lineRange.isEmpty()) {
+                final var codeRange = bytecodeRangeFromLineRange.apply(lineRange);
+
+                // Eliminate junk "instructions" we've already disassembled that were, in fact,
+                // part of this code data block
+                lines.subList(lineRange.from(), lineRange.to()).clear();
+                // FYI (very) arguable Java design decision: See "Why is Java's `AbstractList`'s
+                // `removeRange()` method protected?
+                // See
+                // https://stackoverflow.com/questions/2289183/why-is-javas-abstractlists-removerange-method-protected
+
+                // And now turn that bunch of bytecodes into a `DATA` pseudo-op.
+                final var dataLine =
+                        getBytecodeRangeAsData(bytecode, codeRange, "", DataPseudoOpLine.Kind.DATA);
+                lines.add(lineRange.from(), dataLine);
+            }
+        }
+
+        return lines;
+    }
+
+    /**
+     * Look for a code data block between an `INVALID` or `STOP` and the metadata.
+     *
+     * <p>Look for a code data block between an `INVALID` or `STOP` and the metadata. We want the
+     * _last_ `INVALID` or `STOP`. (There might be more than one.) How do we know which? We search
+     * _backwards_ from the metadata line.
+     */
+    @NonNull
+    public Range<Line> lookBackwardsForDelimiterInstruction(
+            @NonNull final List</*@NonNull*/ Line> lines, @NonNull final byte[] bytecode) {
+        // Only tricky thing here is keeping track of both Line locations and bytecode offsets.
+
+        // start with empty ranges
+        int lineRangeFrom = lines.size();
+        int lineRangeTo = lineRangeFrom;
+
+        if (lines.isEmpty() || 0 == bytecode.length) return Range.empty();
+
+        // We either have metadata at the end, or we don't
+        if (lines.get(lines.size() - 1) instanceof DataPseudoOpLine data
+                && data.kind() == DataPseudoOpLine.Kind.METADATA) {
+            lineRangeFrom--;
+            lineRangeTo--;
+        }
+
+        // Scan now for first prior `INVALID` or `STOP`
+        while (lineRangeFrom >= 0) {
+            if (lines.get(lineRangeFrom) instanceof CodeLine code) {
+                if (code.opcode() == INVALID_OPCODE || code.opcode() == STOP_OPCODE) {
+                    lineRangeFrom++;
+                    if (lineRangeFrom == lineRangeTo)
+                        return Range.empty(); // This would be if there was no data block between
+                    // INVALID/STOP and the metadate/end
+                    return new Range<>(lineRangeFrom, lineRangeTo);
+                }
+            }
+            lineRangeFrom--;
+        }
+        // Here, no INVALID or STOP found all the way to the beginning of the contract
+        return Range.empty();
+    }
+
+    record SolidityMetadata(int metadataLength, String approxVersion, Pattern metadataPattern) {
+        SolidityMetadata(int metadataLength, String approxVersion, String metadataPattern) {
+            this(metadataLength, approxVersion, Pattern.compile(metadataPattern));
+        }
+    }
+
+    /**
+     * Signatures of "known" Solidity-generated metadata.
+     *
+     * <p>Signatures of "known" Solidity-generated metadata. Probably missing some, and will need to
+     * update this in the future as the Solidity compiler evolves. Possibly this is too strict and
+     * we shouldn't care. Maybe _other_ contract language compilers put metadata at the end in the
+     * same CBOR format but containing different data. We'll see.
+     *
+     * <p>- ref: <a href="https://www.badykov.com/ethereum/solidity-bytecode-metadata/">...</a> -
+     * ref: <a
+     * href="https://docs.soliditylang.org/en/v0.8.17/metadata.html#encoding-of-the-metadata-hash-in-the-bytecode">...</a>
+     */
+    static final SolidityMetadata[] solidityMetadataEvolution = {
+        new SolidityMetadata(0x0029, "~0.4.17", "A165627A7A72305820(..){32}0029"),
+        new SolidityMetadata(0x0032, "0.5.10", "A265627A7A72305820(..){32}64736F6C6343(..){3}0032"),
+        new SolidityMetadata(0x0032, "0.5.10", "A265627A7A72315820(..){32}64736F6C6343(..){3}0032"),
+        new SolidityMetadata(0x0033, "~0.8.17", "A264697066735822(..){34}64736F6C6343(..){3}0033")
+    };
+
+    static final int MAX_METADATA_LENGTH = 0x60; // just a guess
+
+    /**
+     * Given contract bytecode find the Solidity metadata blob at the very end of it, if present.
+     *
+     * <p>Solitity puts metadata at the end of a compiled contract. It consists of a CBOR-encoded
+     * blob followed by its length, the latter in two bytes (and the length here is that of the CBOR
+     * blob only, not the entire metadata blob including the length bytes).
+     *
+     * <p>Look for the metadata at the end - performing some sanity checks on it. We only recognize
+     * certain "known" patterns (there maybe some we're missing!) And the most obvious rigorous
+     * sanity check isn't performed: we don't decode the metadata to see if it is a valid CBOR-
+     * encoding thing. (Maybe someday.)
+     */
+    public @NonNull Range<Byte> locateMetadata(@NonNull final byte[] bytecode) {
+        if (bytecode.length < 2) return Range.empty();
+        final int metadataLength =
+                bytecode[bytecode.length - 2] * 256 + bytecode[bytecode.length - 1];
+
+        if (MAX_METADATA_LENGTH < metadataLength) return Range.empty();
+        if (bytecode.length < metadataLength + 2) return Range.empty();
+
+        final var metadataFrom = bytecode.length - 2 - metadataLength;
+        final var tailAsHex =
+                UPPERCASE_HEX_FORMATTER.formatHex(bytecode, metadataFrom, bytecode.length);
+        for (var sm : solidityMetadataEvolution) {
+            if (sm.metadataLength != metadataLength) continue;
+            if (sm.metadataPattern.matcher(tailAsHex).matches())
+                return new Range<>(metadataFrom, bytecode.length);
+        }
+
+        // Don't get persnickety about metadata matching the known signatures.  So far we
+        // have 2 that look like metadata at the end but don't match the signature.  We also
+        // have ~50 that look like data of some kind at the end but don't have metadata.
+        return new Range<>(metadataFrom, bytecode.length);
+    }
+
+    /** Given a range, return, as a `DATA` pseudo-op, the contract bytecodes in that range */
+    public @NonNull Line getBytecodeRangeAsData(
+            @NonNull final byte[] bytecode,
+            @NonNull final Range<Byte> range,
+            @NonNull final String comment,
+            @NonNull final DataPseudoOpLine.Kind kind) {
+        final var dataBytes = Arrays.copyOfRange(bytecode, range.from(), range.to());
+        return new DataPseudoOpLine(range.from(), kind, dataBytes, comment);
+    }
+
+    public static final int INVALID_OPCODE = Opcodes.getDescrFor("INVALID").opcode();
+    public static final int STOP_OPCODE = Opcodes.getDescrFor("STOP").opcode();
+
+    public static final int DEFAULT_CODE_OFFSET_COLUMN = 0;
+    public static final int DEFAULT_OPCODE_COLUMN = 0;
+    public static final int DEFAULT_COMMENT_COLUMN = 6;
+    public static final int DEFAULT_LABEL_COLUMN = 6;
+    public static final int DEFAULT_MNEMONIC_COLUMN = 10;
+    public static final int DEFAULT_OPERAND_COLUMN = 18;
+    public static final int DEFAULT_EOL_COMMENT_COLUMN = 22;
+    public static final int MAX_EXPECTED_LINE = 80;
+
+    public static final int CODE_OFFSET_COLUMN_WIDTH = 8;
+    public static final int OPCODE_COLUMN_WIDTH = 2;
+
+    public static final String FULL_LINE_COMMENT_PREFIX = "# ";
+    public static final String EOL_COMMENT_PREFIX = "# ";
+
+    public static final HexFormat UPPERCASE_HEX_FORMATTER = HexFormat.of().withUpperCase();
+}

--- a/test-clients/src/main/java/com/hedera/services/yahcli/commands/signedstate/evminfo/CodeLine.java
+++ b/test-clients/src/main/java/com/hedera/services/yahcli/commands/signedstate/evminfo/CodeLine.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hedera.services.yahcli.commands.signedstate.evminfo;
+
+import com.hedera.services.yahcli.commands.signedstate.evminfo.Assembly.Columns;
+import com.hedera.services.yahcli.commands.signedstate.evminfo.Assembly.Variant;
+import java.util.Arrays;
+
+/**
+ * Represents an instruction line in the generated assembly
+ *
+ * <p>Instruction lines have an opcode, an optional operand (an array of bytes), an offset of where
+ * the instruction is in the bytecode, and an optional comment.
+ */
+public record CodeLine(int codeOffset, int opcode, byte[] operandBytes, String eolComment)
+        implements Assembly.Line, Assembly.Code {
+
+    public CodeLine {
+        opcode = opcode & 0xFF; // convert to unsigned (in case it's not)
+        // De-null optional arguments
+        operandBytes = null != operandBytes ? operandBytes : new byte[0];
+        eolComment = null != eolComment ? eolComment : "";
+    }
+
+    @Override
+    public void formatLine(StringBuilder sb) {
+        if (Variant.DISPLAY_CODE_OFFSET.getValue()) {
+            extendWithBlanksTo(sb, Columns.CODE_OFFSET.getColumn());
+            sb.append(String.format("%5X", codeOffset));
+        }
+
+        if (Variant.DISPLAY_OPCODE_HEX.getValue()) {
+            extendWithBlanksTo(sb, Columns.OPCODE.getColumn());
+            sb.append(String.format("  %02X", opcode()));
+        }
+
+        extendWithBlanksTo(sb, Columns.MNEMONIC.getColumn());
+        sb.append(Opcodes.getOpcode(opcode()).mnemonic());
+        if (0 != operandBytes.length) {
+            extendWithBlanksTo(sb, Columns.OPERAND.getColumn());
+            sb.append(hexer().formatHex(operandBytes));
+        }
+        if (!eolComment.isEmpty()) {
+            if (Columns.EOL_COMMENT.getColumn() - 1 > sb.length()) {
+                extendWithBlanksTo(sb, Columns.EOL_COMMENT.getColumn());
+            } else {
+                sb.append("  ");
+            }
+            sb.append(Assembly.EOL_COMMENT_PREFIX);
+            sb.append(eolComment);
+        }
+    }
+
+    @Override
+    public int getCodeOffset() {
+        return codeOffset;
+    }
+
+    @Override
+    public int getCodeSize() {
+        return 1 + operandBytes.length;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        return o instanceof CodeLine other
+                && codeOffset == other.codeOffset
+                && opcode == other.opcode
+                && Arrays.equals(operandBytes, other.operandBytes)
+                && eolComment.equals(other.eolComment);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = codeOffset;
+        result = 31 * result + opcode;
+        result = 31 * result + Arrays.hashCode(operandBytes);
+        result = 31 * result + eolComment.hashCode();
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return String.format(
+                "CodeLine[codeOffset=%04X, opcode=%d (%02X), operandBytes=%s, eolComment='%s']",
+                codeOffset, opcode, opcode(), hexer().formatHex(operandBytes), eolComment);
+    }
+}

--- a/test-clients/src/main/java/com/hedera/services/yahcli/commands/signedstate/evminfo/CommentLine.java
+++ b/test-clients/src/main/java/com/hedera/services/yahcli/commands/signedstate/evminfo/CommentLine.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hedera.services.yahcli.commands.signedstate.evminfo;
+
+import com.hedera.services.yahcli.commands.signedstate.evminfo.Assembly.Columns;
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+/** Represents a full-line comment in the generated assembly */
+public record CommentLine(@NonNull String comment) implements Assembly.Line {
+
+    @Override
+    public void formatLine(StringBuilder sb) {
+        extendWithBlanksTo(sb, Columns.COMMENT.getColumn());
+        sb.append(Assembly.FULL_LINE_COMMENT_PREFIX);
+        sb.append(comment);
+    }
+}

--- a/test-clients/src/main/java/com/hedera/services/yahcli/commands/signedstate/evminfo/DataPseudoOpLine.java
+++ b/test-clients/src/main/java/com/hedera/services/yahcli/commands/signedstate/evminfo/DataPseudoOpLine.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hedera.services.yahcli.commands.signedstate.evminfo;
+
+import com.hedera.services.yahcli.commands.signedstate.evminfo.Assembly.Columns;
+import com.hedera.services.yahcli.commands.signedstate.evminfo.Assembly.Variant;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.Arrays;
+
+/**
+ * Represents a `DATA` pseudo op in the generated assembly
+ *
+ * <p>A DATA line is just a blob of bytes. It disassembles to the hex representation of that blob.
+ * Because it is actual code bytes it has a code offset.
+ */
+public record DataPseudoOpLine(
+        int codeOffset, @NonNull Kind kind, byte[] operandBytes, String eolComment)
+        implements Assembly.Line, Assembly.Code {
+
+    public enum Kind {
+        DATA,
+        METADATA,
+        DATA_OVERRUN
+    }
+
+    public DataPseudoOpLine {
+        // De-null operands
+        operandBytes = null != operandBytes ? operandBytes : new byte[0];
+        eolComment = null != eolComment ? eolComment : "";
+    }
+
+    // NOTTODO: There's a LOT of commonality here with CodeLine! like maybe this should be a
+    // subclass (except: can't do that because it's a record, and this doesn't seem like the
+    // kind of thing that should be a default method of the interface ...)
+    @Override
+    public void formatLine(StringBuilder sb) {
+        if (Variant.DISPLAY_CODE_OFFSET.getValue()) {
+            extendWithBlanksTo(sb, Columns.CODE_OFFSET.getColumn());
+            sb.append(String.format("%5X", codeOffset));
+        }
+        extendWithBlanksTo(sb, Columns.MNEMONIC.getColumn());
+        sb.append(kind.name());
+
+        if (0 != operandBytes.length) {
+            extendWithBlanksTo(sb, Columns.OPERAND.getColumn());
+            sb.append(hexer().formatHex(operandBytes));
+        }
+        if (!eolComment.isEmpty()) {
+            if (Columns.EOL_COMMENT.getColumn() - 1 > sb.length()) {
+                extendWithBlanksTo(sb, Columns.EOL_COMMENT.getColumn());
+            } else {
+                sb.append("  ");
+            }
+            sb.append(Assembly.EOL_COMMENT_PREFIX);
+            sb.append(eolComment);
+        }
+    }
+
+    @Override
+    public int getCodeOffset() {
+        return codeOffset;
+    }
+
+    @Override
+    public int getCodeSize() {
+        return operandBytes.length;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        return o instanceof DataPseudoOpLine other
+                && codeOffset == other.codeOffset
+                && Arrays.equals(operandBytes, other.operandBytes)
+                && eolComment.equals(other.eolComment)
+                && kind.equals(other.kind);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = codeOffset;
+        result = 31 * result + Arrays.hashCode(operandBytes);
+        result = 31 * result + eolComment.hashCode();
+        result = 31 * result + kind.hashCode();
+        return result;
+    }
+
+    @Override
+    public @NonNull String toString() {
+        return String.format(
+                "CodeLine[codeOffset=%04X, operandBytes=%s, eolComment='%s', kind=%s]",
+                codeOffset, hexer().formatHex(operandBytes), eolComment, kind.toString());
+    }
+}

--- a/test-clients/src/main/java/com/hedera/services/yahcli/commands/signedstate/evminfo/DirectiveLine.java
+++ b/test-clients/src/main/java/com/hedera/services/yahcli/commands/signedstate/evminfo/DirectiveLine.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hedera.services.yahcli.commands.signedstate.evminfo;
+
+import com.hedera.services.yahcli.commands.signedstate.evminfo.Assembly.Columns;
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+/**
+ * Represents a directive in the generated assembly.
+ *
+ * <p>Directives are commands to the assembler (and notes to the reader) such as `BEGIN` and `END`.
+ */
+public record DirectiveLine(
+        @NonNull String directive, @NonNull String operand, @NonNull String comment)
+        implements Assembly.Line {
+
+    /**
+     * It isn't _necessary_ that the directives be listed here - _any_ string can be passed as the
+     * mnemonic of this Directive. But it's convenient for common/popular directives since you can
+     * control the spelling this way ...
+     */
+    public enum Kind {
+        BEGIN,
+        END
+    }
+
+    public DirectiveLine(@NonNull final String directive) {
+        this(directive, "", "");
+    }
+
+    public DirectiveLine(@NonNull final Kind directive) {
+        this(directive.name(), "", "");
+    }
+
+    public DirectiveLine(@NonNull final String directive, @NonNull final String comment) {
+        this(directive, "", comment);
+    }
+
+    public DirectiveLine(@NonNull final Kind directive, @NonNull final String comment) {
+        this(directive.name(), "", comment);
+    }
+
+    @Override
+    public void formatLine(StringBuilder sb) {
+        if (!directive.isEmpty()) {
+            extendWithBlanksTo(sb, Columns.MNEMONIC.getColumn());
+            sb.append(directive);
+        }
+        if (!operand.isEmpty()) {
+            extendWithBlanksTo(sb, Columns.OPERAND.getColumn());
+            sb.append(operand);
+        }
+        if (!comment.isEmpty()) {
+            extendWithBlanksTo(sb, Columns.EOL_COMMENT.getColumn());
+            sb.append(Assembly.EOL_COMMENT_PREFIX);
+            sb.append(comment);
+        }
+    }
+}

--- a/test-clients/src/main/java/com/hedera/services/yahcli/commands/signedstate/evminfo/LabelLine.java
+++ b/test-clients/src/main/java/com/hedera/services/yahcli/commands/signedstate/evminfo/LabelLine.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hedera.services.yahcli.commands.signedstate.evminfo;
+
+import com.hedera.services.yahcli.commands.signedstate.evminfo.Assembly.Columns;
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+/** Represents a label in the generated assembly (a named offset in the code) */
+public record LabelLine(@NonNull String label) implements Assembly.Line {
+
+    public static final String LABEL_PREFIX = "";
+    public static final String LABEL_SUFFIX = ":";
+
+    @Override
+    public void formatLine(StringBuilder sb) {
+        extendWithBlanksTo(sb, Columns.LABEL.getColumn());
+        sb.append(LABEL_PREFIX);
+        sb.append(label);
+        sb.append(LABEL_SUFFIX);
+    }
+}

--- a/test-clients/src/main/java/com/hedera/services/yahcli/commands/signedstate/evminfo/Opcodes.java
+++ b/test-clients/src/main/java/com/hedera/services/yahcli/commands/signedstate/evminfo/Opcodes.java
@@ -1,0 +1,240 @@
+/*
+ * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hedera.services.yahcli.commands.signedstate.evminfo;
+
+import static java.util.stream.Collectors.toMap;
+import static java.util.stream.Collectors.toSet;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSortedMap;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+/**
+ * Contains a type (Descr) describing an EVM opcode, and table lookup
+ *
+ * <p>Contained record type Descr describes an EVM opcode, and there is table lookup to get from a
+ * byte to the opcode (mnemonic) or the other way around.
+ */
+public class Opcodes {
+
+    // Describes an EVM opcode
+    // - extraBytes is the # of bytes in the codestream, following the opcode, which are
+    //   part of this instruction (the `PUSHnn` instructions only)
+    // - assigned is true for all _assigned_ opcodes (including 0xFE `INVALID`)
+
+    /**
+     * Describes an EVM opcode
+     *
+     * @param opcode - value of the opcode, e.g., 0x62 for a "push 2 bytes" instruction
+     * @param extraBytes - how many extra bytes go with this opcode, e.g., 2 for "push 2 bytes"
+     * @param mnemonic - mnemonic for this opcode, e.g., "PUSH2" for "push 2 bytes" instruction
+     * @param assigned - true if this is an _assigned_ EVM opcode (e.g., a _legal_ opcode)
+     */
+    public record Descr(int opcode, int extraBytes, String mnemonic, boolean assigned) {
+
+        public Descr(int opcode, final String mnemonic) {
+            this(opcode, 0, mnemonic, true);
+        }
+
+        public Descr(int opcode, final String mnemonic, boolean assigned) {
+            this(opcode, 0, mnemonic, assigned);
+        }
+
+        public Descr(int opcode, int extraBytes, final String mnemonic) {
+            this(opcode, extraBytes, mnemonic, true);
+        }
+    }
+
+    /** Table of opcodes, indexed by opcode */
+    private static final ImmutableList<Descr> byOpcode;
+
+    /** Get an opcode Descr, given opcode value */
+    public static @NonNull Descr getOpcode(int opcode) {
+        return byOpcode.get(opcode & 0xFF);
+    }
+
+    /** Table of opcodes, indexed by mnemonic */
+    private static final ImmutableSortedMap<String, Descr> byMnemonic;
+
+    /** Get an opcode Descr, given mnemonic */
+    public static @NonNull Descr getDescrFor(@NonNull final String mnemonic) {
+        final var descr = Opcodes.byMnemonic.get(mnemonic.toUpperCase());
+        if (null == descr)
+            throw new IllegalArgumentException(
+                    String.format("opcode '%s' not found in table", mnemonic));
+        return descr;
+    }
+
+    static {
+        // Create the opcode tables ... see https://ethereum.org/en/developers/docs/evm/opcodes/
+
+        var descrs = new ArrayList<Descr>(256);
+
+        // Start with all the unique/ordinary opcodes
+        """
+          00 STOP
+          01 ADD
+          02 MUL
+          03 SUB
+          04 DIV
+          05 SDIV
+          06 MOD
+          07 SMOD
+          08 ADDMOD
+          09 MULMOD
+          0A EXP
+          0B SIGNEXTEND
+          10 LT
+          11 GT
+          12 SLT
+          13 SGT
+          14 EQ
+          15 ISZERO
+          16 AND
+          17 OR
+          18 XOR
+          19 NOT
+          1A BYTE
+          1B SHL
+          1C SHR
+          1D SAR
+          20 KECCAK256
+          30 ADDRESS
+          31 BALANCE
+          32 ORIGIN
+          33 CALLER
+          34 CALLVALUE
+          35 CALLDATALOAD
+          36 CALLDATASIZE
+          37 CALLDATACOPY
+          38 CODESIZE
+          39 CODECOPY
+          3A GASPRICE
+          3B EXTCODESIZE
+          3C EXTCODECOPY
+          3D RETURNDATASIZE
+          3E RETURNDATACOPY
+          3F EXTCODEHASH
+          40 BLOCKHASH
+          41 COINBASE
+          42 TIMESTAMP
+          43 NUMBER
+          44 PREVRANDAO
+          45 GASLIMIT
+          46 CHAIND
+          47 SELFBALANCE
+          48 BASEFEE
+          50 POP
+          51 MLOAD
+          52 MSTORE
+          53 MSTORE8
+          54 SLOAD
+          55 SSTORE
+          56 JUMP
+          57 JUMPI
+          58 PC
+          59 MSIZE
+          5A GAS
+          5B JUMPDEST
+          F0 CREATE
+          F1 CALL
+          F2 CALLCODE
+          F3 RETURN
+          F4 DELEGATECALL
+          F5 CREATE2
+          FA STATICCALL
+          FD REVERT
+          FE INVALID
+          FF SELFDESTRUCT
+          """
+                .lines()
+                .forEach(
+                        line -> {
+                            final var no = line.split(" ");
+                            final var op = Integer.parseUnsignedInt(no[0], 16);
+                            descrs.add(new Descr(op, no[1]));
+                        });
+
+        // Add all the "multiple" opcodes
+        for (int i = 1; i <= 32; i++) {
+            descrs.add(new Descr(0x60 + i - 1, i, "PUSH" + Integer.toString(i)));
+        }
+        for (int i = 1; i <= 16; i++) {
+            descrs.add(new Descr(0x80 + i - 1, "DUP" + Integer.toString(i)));
+        }
+        for (int i = 1; i <= 16; i++) {
+            descrs.add(new Descr(0x90 + i - 1, "SWAP" + Integer.toString(i)));
+        }
+        for (int i = 0; i <= 4; i++) {
+            descrs.add(new Descr(0xA0 + i, "LOG" + Integer.toString(i)));
+        }
+        // Add all the unassigned (thus invalid) opcodes
+        concatStreams(
+                        intRange(0x0C, 0x0F),
+                        intRange(0x1E, 0x1F),
+                        intRange(0x21, 0x2F),
+                        intRange(0x49, 0x4F),
+                        intRange(0x5C, 0x5F),
+                        intRange(0xA5, 0xEF),
+                        intRange(0xF6, 0xF9),
+                        intRange(0xFB, 0xFC))
+                // (Say, you'd think Guava's `RangeSet` would be perfect for this ... except you
+                // can't iterate it.  A set which you can't iterate over its members ... it's a good
+                // idea, because ... I dunno ...)
+                .forEach(
+                        i -> {
+                            final var n = String.format("%02X", i);
+                            descrs.add(new Descr(i, "UNASSIGNED-" + n, false));
+                        });
+
+        // Validate we've got all 256 opcodes defined
+        final var allOpcodes = descrs.stream().map(Descr::opcode).collect(toSet());
+
+        // sanity check this data constructor ...
+        if (256 != allOpcodes.size()) {
+            throw new IllegalStateException(
+                    String.format(
+                            "EVM opcode table incomplete, only %s opcodes present",
+                            allOpcodes.size()));
+        }
+
+        descrs.sort(Comparator.comparingInt(Descr::opcode));
+        byOpcode = ImmutableList.copyOf(descrs);
+        byMnemonic =
+                ImmutableSortedMap.copyOf(descrs.stream().collect(toMap(Descr::mnemonic, d -> d)));
+    }
+
+    /** Returns a Stream<Integer> of a range of integers, inclusive of both ends */
+    private static Stream<Integer> intRange(int low, int high) {
+        return IntStream.rangeClosed(low, high).boxed();
+    }
+
+    /** Variadic Stream concatenation (why isn't this part of Java Streams class?) */
+    @SafeVarargs
+    private static @NonNull Stream<Integer> concatStreams(final Stream<Integer>... sis) {
+        Stream<Integer> s = Stream.empty();
+        for (var str : sis) s = Stream.concat(s, str);
+        return s;
+    }
+
+    private Opcodes() {
+        throw new UnsupportedOperationException("Utility class");
+    }
+}

--- a/test-clients/src/main/java/com/hedera/services/yahcli/commands/signedstate/evminfo/Range.java
+++ b/test-clients/src/main/java/com/hedera/services/yahcli/commands/signedstate/evminfo/Range.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hedera.services.yahcli.commands.signedstate.evminfo;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+/**
+ * Represents a range of integers
+ *
+ * <p>A range of integers specified by inclusive index at the low end, exclusive at the high end,
+ * thus an empty range is from == to. (There is no check that this range is "valid", i.e., 0 <=
+ * from, from <= to.)
+ *
+ * @param from - inclusive
+ * @param to - exclusive
+ * @param <T> - just used for typing purposes, because we're using ranges of bytecodes and lines
+ */
+record Range<T>(int from, int to) {
+
+    /** Get length of range */
+    public int length() {
+        return Math.max(0, to - from);
+    }
+
+    /** Returns an empty range */
+    public static <T> @NonNull Range<T> empty() {
+        return new Range<>(0, 0);
+    }
+
+    /** Predicate: is this range empty? */
+    public boolean isEmpty() {
+        return 0 == length();
+    }
+
+    @Override
+    public String toString() {
+        return String.format("Range[from: %04X; to: %04X]", from, to);
+    }
+}


### PR DESCRIPTION
Third (probably last) of a (short) sequence of PRs that will provide a utility that can disassemble contracts from a signed state file, and, ultimately, analyze contracts by looking at their bytecodes for interesting patterns (possibly supplementing the contract's
bytecodes with information from other sources, e.g., mirror nodes).

**Description**:

Built using the (original) Unix philosophy: Provide single-purpose tools that each do just one thing and then use it in pipelines to get things done. 
- E.g., use tool to _get all contracts_, then use `grep` to do a rough filter to get contracts you want, then use tool to `decompile` contracts to assembly language, then use `grep`|`awk`|`python`|`Mathematica`| _whatever_ to do further analysis.

- Tranche 1 was #4319 - see that PR for further notes on this tool in progress.

- Tranche 2 was #4320  Dump all contracts found in the signed state file to stdout, hex encoded, with their associated contract ids.

- This is **tranche 3:** Disassemble a contract, provided as a hex-string on the command line.

Disassembles contract.  Handles (Solidity?) metadata CBOR blob at end as well as the "code data" blob ahead of the metadata (bytes between the "last" `INVALID` or `STOP` opcode and the start of the metadata) - neither blob of bytes should be disassembled.

Works in two phases: "parses" contract bytecode converting it to a data structure of disassembled "lines", then emits the lines as assembly code (or as an assembly "listing").  The latter part - dumping the lines - is trivial (as each line has an appropriate `toString()`.  The interesting part is the data structure - which includes records for code (a single opcode with optional operand), pseudo-ops, directives (`BEGIN`, `END`), and labels.  IOW, a representation of an assembly source file that can then be groveled (for example, to identify patterns) and manipulated (for example, to replace patterns by "macros", e.g., for vtable entries, etc.).

**Usage**:
   ```
   yahcli signedstate decompilecontract  --with-code-offset --with-opcode --with-contract-bytecode \
            --id <contract-id> --bytecode 60806040⬅·····⮕0033
   ```

**Related issue(s)**:

Progress for #4267

**Related PRs**:

- #4319 - part 1
- #4320 - part 2
- #4346 - part 3

**Interesting facts**:

- A reasonably current signed state archive has:
  - 1932 contract ids registered in accounts
  - 1876 have bytecode in the file store, 3 more have 0-length entries for their bytecode in the file store
  - 504 unique contracts (by bytecode)
  - 481 have the Solidity compiler "prelude"
  - ~13Mb of bytecode altogether

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (only by running it)

Signed-off-by: David Bakin <117694041+david-bakin-sl@users.noreply.github.com>