### PR TITLE
New tag to bump platform version

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 # Current release version
-version=0.33.0-SNAPSHOT
+version=0.33.1-SNAPSHOT
 
 # Need increased heap for running Gradle itself, or SonarQube will run the JVM out of metaspace
 org.gradle.jvmargs=-Xmx2048m

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 # Current release version
-version=0.33.1-SNAPSHOT
+version=0.33.0-SNAPSHOT
 
 # Need increased heap for running Gradle itself, or SonarQube will run the JVM out of metaspace
 org.gradle.jvmargs=-Xmx2048m

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -73,7 +73,7 @@ dependencyResolutionManagement {
             version("eddsa-version", "0.3.0")
             version("grpc-version", "1.50.2")
             version("guava-version", "31.1-jre")
-            version("hapi-version", "0.32.0-SNAPSHOT")
+            version("hapi-version", "0.33.0-SNAPSHOT")
             version("headlong-version", "6.1.1")
             version("helidon-version", "3.0.2")
             version("jackson-version", "2.13.3")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -84,7 +84,7 @@ dependencyResolutionManagement {
             version("netty-version", "4.1.66.Final")
             version("protobuf-java-version", "3.19.4")
             version("slf4j-version", "2.0.3")
-            version("swirlds-version", "0.33.0-alpha.2")
+            version("swirlds-version", "0.33.0-alpha.3")
             version("tuweni-version", "2.2.0")
             version("jna-version", "5.12.1")
             version("jsr305-version", "3.0.2")


### PR DESCRIPTION
Bump services to 0.33.0-alpha.1
Bump platform to 0.33.0-alpha.3

Signed-off-by: Kim Rader <kim.rader@swirldslabs.com>

