### PR TITLE
Enable prometheus scrape endpoint for preprod

### DIFF
--- a/hedera-node/configuration/preprod/settings.txt
+++ b/hedera-node/configuration/preprod/settings.txt
@@ -27,3 +27,4 @@ waitAtStartup,                                 false
 jasperDb.storagePath,                          /opt/hgcapp/services-hedera/HapiApp2.0/data/saved
 jasperDb.iteratorInputBufferBytes,             16777216
 virtualMap.preferredFlushQueueSize,            10000
+prometheusEndpointEnabled,                     true


### PR DESCRIPTION
This PR enables the Prometheus scrape endpoint for all preproduction environments.