### PR TITLE
Change setting to `consensus.roundsExpired`

### DIFF
--- a/hedera-node/configuration/compose/settings.txt
+++ b/hedera-node/configuration/compose/settings.txt
@@ -8,7 +8,6 @@ reconnect.active,                              1
 reconnect.asyncStreamTimeoutMilliseconds,      60000
 reconnect.reconnectWindowSeconds,              -1
 showInternalStats,                             1
-state.roundsExpired,                           500
 state.saveStatePeriod,                         300
 useLoopbackIp,                                 false
 waitAtStartup,                                 false

--- a/hedera-node/configuration/dev/settings.txt
+++ b/hedera-node/configuration/dev/settings.txt
@@ -11,7 +11,6 @@ reconnect.asyncStreamTimeoutMilliseconds,      60000
 reconnect.reconnectWindowSeconds,              -1
 showDbStats,                                   0
 showInternalStats,                             1
-state.roundsExpired,                           500
 state.saveStatePeriod,                         300
 state.signedStateKeep,                         10
 useLoopbackIp,                                 false

--- a/hedera-node/configuration/mainnet/settings.txt
+++ b/hedera-node/configuration/mainnet/settings.txt
@@ -17,7 +17,6 @@ reconnect.asyncStreamTimeoutMilliseconds,      60000
 reconnect.reconnectWindowSeconds,              -1
 showDbStats,                                   0
 showInternalStats,                             1
-state.roundsExpired,                           500
 state.saveStatePeriod,                         900
 state.signedStateDisk,                         5
 state.signedStateKeep,                         10

--- a/hedera-node/configuration/preprod/settings.txt
+++ b/hedera-node/configuration/preprod/settings.txt
@@ -17,7 +17,6 @@ reconnect.asyncStreamTimeoutMilliseconds,      60000
 reconnect.reconnectWindowSeconds,              -1
 showDbStats,                                   0
 showInternalStats,                             1
-state.roundsExpired,                           500
 state.saveStatePeriod,                         900
 state.signedStateDisk,                         5
 state.signedStateKeep,                         10

--- a/hedera-node/configuration/previewnet/settings.txt
+++ b/hedera-node/configuration/previewnet/settings.txt
@@ -17,7 +17,6 @@ reconnect.asyncStreamTimeoutMilliseconds,      60000
 reconnect.reconnectWindowSeconds,              -1
 showDbStats,                                   0
 showInternalStats,                             1
-state.roundsExpired,                           500
 state.saveStatePeriod,                         900
 state.signedStateDisk,                         5
 state.signedStateKeep,                         10

--- a/hedera-node/configuration/testnet/settings.txt
+++ b/hedera-node/configuration/testnet/settings.txt
@@ -17,7 +17,7 @@ reconnect.asyncStreamTimeoutMilliseconds,      60000
 reconnect.reconnectWindowSeconds,              -1
 showDbStats,                                   0
 showInternalStats,                             1
-state.roundsExpired,                           1500
+consensus.roundsExpired,                           1500
 state.saveStatePeriod,                         900
 state.signedStateDisk,                         5
 state.signedStateKeep,                         10

--- a/hedera-node/configuration/testnet/settings.txt
+++ b/hedera-node/configuration/testnet/settings.txt
@@ -17,7 +17,7 @@ reconnect.asyncStreamTimeoutMilliseconds,      60000
 reconnect.reconnectWindowSeconds,              -1
 showDbStats,                                   0
 showInternalStats,                             1
-consensus.roundsExpired,                           1500
+consensus.roundsExpired,                       1500
 state.saveStatePeriod,                         900
 state.signedStateDisk,                         5
 state.signedStateKeep,                         10

--- a/hedera-node/settings.txt
+++ b/hedera-node/settings.txt
@@ -7,7 +7,6 @@ reconnect.active,                              1
 reconnect.asyncStreamTimeoutMilliseconds,      60000
 reconnect.reconnectWindowSeconds,              -1
 showInternalStats,                             1
-state.roundsExpired,                           500
 state.saveStatePeriod,                         300
 useLoopbackIp,                                 false
 waitAtStartup,                                 false

--- a/test-clients/src/eet/resources/network/config/settings.txt
+++ b/test-clients/src/eet/resources/network/config/settings.txt
@@ -8,7 +8,6 @@ reconnect.active,                              1
 reconnect.asyncStreamTimeoutMilliseconds,      60000
 reconnect.reconnectWindowSeconds,              -1
 showInternalStats,                             1
-state.roundsExpired,                           500
 state.saveStatePeriod,                         300
 useLoopbackIp,                                 false
 waitAtStartup,                                 false

--- a/test-clients/src/itest/resources/network/config/settings.txt
+++ b/test-clients/src/itest/resources/network/config/settings.txt
@@ -8,7 +8,6 @@ reconnect.active,                              1
 reconnect.asyncStreamTimeoutMilliseconds,      60000
 reconnect.reconnectWindowSeconds,              -1
 showInternalStats,                             1
-state.roundsExpired,                           500
 state.saveStatePeriod,                         300
 useLoopbackIp,                                 false
 waitAtStartup,                                 false

--- a/test-clients/src/main/resource/testfiles/updateFeature/updateSettings/sdk/settings.txt
+++ b/test-clients/src/main/resource/testfiles/updateFeature/updateSettings/sdk/settings.txt
@@ -16,7 +16,6 @@ reconnect.asyncStreamTimeoutMilliseconds, 60000
 reconnect.reconnectWindowSeconds,              300
 showDbStats,                                   0
 showInternalStats,                             1
-state.roundsExpired,                           500
 state.saveStatePeriod,                         900
 state.signedStateDisk,                         5
 state.signedStateKeep,                         100


### PR DESCRIPTION
Signed-off-by: Neeharika-Sompalli <neeharika.sompalli@swirldslabs.com>

`state.roundsExpired` setting name is changed in platform to `consensus.roundsExpired`. 
Changed the same in Services and removed when value is same as default 500 .
