### PR TITLE
Use `0.33.0-grpc-1.45.1-SNAPSHOT` protobuf artifact

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -72,7 +72,7 @@ dependencyResolutionManagement {
             version("eddsa-version", "0.3.0")
             version("grpc-version", "1.50.2")
             version("guava-version", "31.1-jre")
-            version("hapi-version", "0.33.0-SNAPSHOT")
+            version("hapi-version", "0.33.0-grpc-1.45.1-SNAPSHOT")
             version("headlong-version", "6.1.1")
             version("helidon-version", "3.0.2")
             version("jackson-version", "2.13.3")


### PR DESCRIPTION
**Description**:
-  Fixes the `io.grpc` version conflict that causes all `develop` test clients to fail
- Closes #4433 

```
java.lang.AbstractMethodError: Receiver class io.grpc.netty.NettyClientTransport does not define or inherit an implementation of the resolved method 'abstract io.grpc.internal.ClientStream newStream(io.grpc.MethodDescriptor, io.grpc.Metadata, io.grpc.CallOptions, io.grpc.ClientStreamTracer[])' of interface io.grpc.internal.ClientTransport.
```