### PR TITLE
Merge service descriptor files

### DIFF
--- a/test-clients/build.gradle.kts
+++ b/test-clients/build.gradle.kts
@@ -66,7 +66,7 @@ dependencies {
     implementation(libs.grpc.stub)
     implementation(libs.grpc.protobuf)
     implementation(libs.grpc.netty)
-    
+
     implementation(libs.headlong)
     implementation(libs.log4j.core)
     implementation(testLibs.json)


### PR DESCRIPTION
**Description**:
After fixing the `io.grpc` version conflict surfaced by [this PR](https://github.com/hashgraph/hedera-services/commit/16b5c21cce86ff09d4b455a967304602228d5b3a), `yahcli` and `SuiteRunner` shadow JARs starting failing _instead_ with,
```
Caused by: io.grpc.StatusRuntimeException: UNKNOWN
	at io.grpc.stub.ClientCalls.toStatusRuntimeException(ClientCalls.java:271)
...
Caused by: java.nio.channels.UnsupportedAddressTypeException
	at java.base/sun.nio.ch.Net.checkAddress(Net.java:146)
	at java.base/sun.nio.ch.Net.checkAddress(Net.java:157)
```

The root cause seems to be un-merged service descriptor files---see [this SO answer](https://stackoverflow.com/questions/73286776/grpc-unsupportedaddresstypeexception-but-only-when-packaged-with-shadowjar).

I could reproduce the failure locally and verify adding `mergeServiceFiles()` to `shadowJar` configuration fixes it.