### PR TITLE
Enriching evm-module's  account/updater  impl.

### DIFF
--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/AbstractLedgerEvmWorldUpdater.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/AbstractLedgerEvmWorldUpdater.java
@@ -16,7 +16,6 @@
 package com.hedera.node.app.service.evm.store.contracts;
 
 import com.hedera.node.app.service.evm.accounts.AccountAccessor;
-import com.hedera.node.app.service.evm.store.models.UpdatedHederaEvmAccount;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Optional;
@@ -36,11 +35,6 @@ public abstract class AbstractLedgerEvmWorldUpdater implements WorldUpdater {
 
     @Override
     public EvmAccount createAccount(Address address, long nonce, Wei balance) {
-        return null;
-    }
-
-    @Override
-    public EvmAccount getAccount(Address address) {
         return null;
     }
 
@@ -77,11 +71,6 @@ public abstract class AbstractLedgerEvmWorldUpdater implements WorldUpdater {
     @Override
     public WorldUpdater updater() {
         return this;
-    }
-
-    @Override
-    public Account get(Address address) {
-        return new UpdatedHederaEvmAccount(accountAccessor.canonicalAddress(address));
     }
 
     public boolean isTokenAddress(Address address) {

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/HederaEvmStackedWorldStateUpdater.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/HederaEvmStackedWorldStateUpdater.java
@@ -21,7 +21,6 @@ import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.datatypes.Wei;
 import org.hyperledger.besu.evm.account.Account;
 import org.hyperledger.besu.evm.account.EvmAccount;
-import org.hyperledger.besu.evm.worldstate.UpdateTrackingAccount;
 
 public class HederaEvmStackedWorldStateUpdater extends AbstractLedgerEvmWorldUpdater {
 
@@ -43,8 +42,9 @@ public class HederaEvmStackedWorldStateUpdater extends AbstractLedgerEvmWorldUpd
         final var accountBalance = Wei.of(hederaEvmEntityAccess.getBalance(address));
         final var account = new UpdatedHederaEvmAccount(address);
         account.setBalance(accountBalance);
+        account.setEvmEntityAccess(hederaEvmEntityAccess);
 
-        return new UpdateTrackingAccount<>(account);
+        return account;
     }
 
     @Override

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/HederaEvmStackedWorldStateUpdater.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/HederaEvmStackedWorldStateUpdater.java
@@ -16,10 +16,30 @@
 package com.hedera.node.app.service.evm.store.contracts;
 
 import com.hedera.node.app.service.evm.accounts.AccountAccessor;
+import com.hedera.node.app.service.evm.store.models.UpdatedHederaEvmAccount;
+import org.hyperledger.besu.datatypes.Address;
+import org.hyperledger.besu.datatypes.Wei;
+import org.hyperledger.besu.evm.account.EvmAccount;
+import org.hyperledger.besu.evm.worldstate.UpdateTrackingAccount;
+import org.hyperledger.besu.evm.worldstate.WrappedEvmAccount;
 
 public class HederaEvmStackedWorldStateUpdater extends AbstractLedgerEvmWorldUpdater {
 
-    public HederaEvmStackedWorldStateUpdater(AccountAccessor accountAccessor) {
+    protected final HederaEvmEntityAccess hederaEvmEntityAccess;
+
+    public HederaEvmStackedWorldStateUpdater(
+            AccountAccessor accountAccessor, HederaEvmEntityAccess hederaEvmEntityAccess) {
         super(accountAccessor);
+        this.hederaEvmEntityAccess = hederaEvmEntityAccess;
+    }
+
+    @Override
+    public EvmAccount getAccount(Address address) {
+        final var balance = Wei.of(hederaEvmEntityAccess.getBalance(address));
+        final var evmAccount =
+                new UpdatedHederaEvmAccount(accountAccessor.canonicalAddress(address));
+        evmAccount.setBalance(balance);
+
+        return new WrappedEvmAccount(new UpdateTrackingAccount<>(evmAccount));
     }
 }

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/HederaEvmStackedWorldStateUpdater.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/HederaEvmStackedWorldStateUpdater.java
@@ -28,7 +28,8 @@ public class HederaEvmStackedWorldStateUpdater extends AbstractLedgerEvmWorldUpd
     protected final HederaEvmEntityAccess hederaEvmEntityAccess;
 
     public HederaEvmStackedWorldStateUpdater(
-            AccountAccessor accountAccessor, HederaEvmEntityAccess hederaEvmEntityAccess) {
+            final AccountAccessor accountAccessor,
+            final HederaEvmEntityAccess hederaEvmEntityAccess) {
         super(accountAccessor);
         this.hederaEvmEntityAccess = hederaEvmEntityAccess;
     }

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/HederaEvmWorldState.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/HederaEvmWorldState.java
@@ -84,14 +84,15 @@ public class HederaEvmWorldState implements HederaEvmMutableWorldState {
 
     @Override
     public HederaEvmWorldUpdater updater() {
-        return new Updater(accountAccessor);
+        return new Updater(accountAccessor, hederaEvmEntityAccess);
     }
 
     public static class Updater extends HederaEvmStackedWorldStateUpdater
             implements HederaEvmWorldUpdater {
 
-        protected Updater(AccountAccessor accountAccessor) {
-            super(accountAccessor);
+        protected Updater(
+                AccountAccessor accountAccessor, HederaEvmEntityAccess hederaEvmEntityAccess) {
+            super(accountAccessor, hederaEvmEntityAccess);
         }
 
         @Override
@@ -101,7 +102,7 @@ public class HederaEvmWorldState implements HederaEvmMutableWorldState {
 
         @Override
         public WorldUpdater updater() {
-            return new HederaEvmStackedWorldStateUpdater(accountAccessor);
+            return new HederaEvmStackedWorldStateUpdater(accountAccessor, hederaEvmEntityAccess);
         }
     }
 }

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/HederaEvmWorldState.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/HederaEvmWorldState.java
@@ -91,7 +91,8 @@ public class HederaEvmWorldState implements HederaEvmMutableWorldState {
             implements HederaEvmWorldUpdater {
 
         protected Updater(
-                AccountAccessor accountAccessor, HederaEvmEntityAccess hederaEvmEntityAccess) {
+                final AccountAccessor accountAccessor,
+                final HederaEvmEntityAccess hederaEvmEntityAccess) {
             super(accountAccessor, hederaEvmEntityAccess);
         }
 

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/models/UpdatedHederaEvmAccount.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/models/UpdatedHederaEvmAccount.java
@@ -128,7 +128,6 @@ public class UpdatedHederaEvmAccount implements MutableAccount, EvmAccount {
         } else if (hederaEvmEntityAccess != null) {
             value = UInt256.fromBytes(hederaEvmEntityAccess.getStorage(address, key.toBytes()));
         }
-        // Temporary with future PR we could read the whole mirror-node db ContractState table
         if (value != null) {
             setStorageValue(key, value);
             return value;

--- a/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/store/contracts/HederaEvmWorldStateTest.java
+++ b/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/store/contracts/HederaEvmWorldStateTest.java
@@ -17,6 +17,7 @@ package com.hedera.node.app.service.evm.store.contracts;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -87,7 +88,7 @@ class HederaEvmWorldStateTest {
     }
 
     @Test
-    void returnsWorldStateAccountt() {
+    void returnsWorldStateAccount() {
         final var address = Address.RIPEMD160;
         given(hederaEvmEntityAccess.getBalance(address)).willReturn(balance);
         given(hederaEvmEntityAccess.isUsable(any())).willReturn(true);
@@ -123,5 +124,6 @@ class HederaEvmWorldStateTest {
     void updater() {
         var actualSubject = subject2.updater();
         assertEquals(0, actualSubject.getSbhRefund());
+        assertNotNull(actualSubject.updater().get(Address.RIPEMD160));
     }
 }

--- a/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/store/contracts/HederaEvmWorldStateTest.java
+++ b/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/store/contracts/HederaEvmWorldStateTest.java
@@ -17,7 +17,6 @@ package com.hedera.node.app.service.evm.store.contracts;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -124,6 +123,6 @@ class HederaEvmWorldStateTest {
     void updater() {
         var actualSubject = subject2.updater();
         assertEquals(0, actualSubject.getSbhRefund());
-        assertNotNull(actualSubject.updater().get(Address.RIPEMD160));
+        assertNull(actualSubject.updater().get(Address.RIPEMD160));
     }
 }

--- a/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/store/models/HederaEvmStackedWorldStateUpdaterTest.java
+++ b/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/store/models/HederaEvmStackedWorldStateUpdaterTest.java
@@ -33,13 +33,14 @@ class HederaEvmStackedWorldStateUpdaterTest {
     private final Address address =
             Address.fromHexString("0x000000000000000000000000000000000000077e");
     MockAccountAccessor accountAccessor = new MockAccountAccessor();
+    MockEntityAccess entityAccess = new MockEntityAccess();
     HederaEvmStackedWorldStateUpdater hederaEvmStackedWorldStateUpdater =
-            new HederaEvmStackedWorldStateUpdater(accountAccessor);
+            new HederaEvmStackedWorldStateUpdater(accountAccessor, entityAccess);
 
     @Test
     void accountTests() {
         assertNull(hederaEvmStackedWorldStateUpdater.createAccount(address, 1, Wei.ONE));
-        assertNull(hederaEvmStackedWorldStateUpdater.getAccount(address));
+        assertEquals(Wei.of(100L), hederaEvmStackedWorldStateUpdater.getAccount(address).getBalance());
         assertEquals(
                 Collections.emptyList(), hederaEvmStackedWorldStateUpdater.getTouchedAccounts());
         hederaEvmStackedWorldStateUpdater.commit();

--- a/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/store/models/HederaEvmStackedWorldStateUpdaterTest.java
+++ b/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/store/models/HederaEvmStackedWorldStateUpdaterTest.java
@@ -40,7 +40,8 @@ class HederaEvmStackedWorldStateUpdaterTest {
     @Test
     void accountTests() {
         assertNull(hederaEvmStackedWorldStateUpdater.createAccount(address, 1, Wei.ONE));
-        assertEquals(Wei.of(100L), hederaEvmStackedWorldStateUpdater.getAccount(address).getBalance());
+        assertEquals(
+                Wei.of(100L), hederaEvmStackedWorldStateUpdater.getAccount(address).getBalance());
         assertEquals(
                 Collections.emptyList(), hederaEvmStackedWorldStateUpdater.getTouchedAccounts());
         hederaEvmStackedWorldStateUpdater.commit();

--- a/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/store/models/MockEntityAccess.java
+++ b/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/store/models/MockEntityAccess.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hedera.node.app.service.evm.store.models;
 
 import com.google.protobuf.ByteString;
@@ -6,38 +21,38 @@ import org.apache.tuweni.bytes.Bytes;
 import org.hyperledger.besu.datatypes.Address;
 
 public class MockEntityAccess implements HederaEvmEntityAccess {
-	@Override
-	public boolean isUsable(Address address) {
-		return false;
-	}
+    @Override
+    public boolean isUsable(Address address) {
+        return false;
+    }
 
-	@Override
-	public long getBalance(Address address) {
-		return 100;
-	}
+    @Override
+    public long getBalance(Address address) {
+        return 100;
+    }
 
-	@Override
-	public boolean isTokenAccount(Address address) {
-		return false;
-	}
+    @Override
+    public boolean isTokenAccount(Address address) {
+        return false;
+    }
 
-	@Override
-	public ByteString alias(Address address) {
-		return null;
-	}
+    @Override
+    public ByteString alias(Address address) {
+        return null;
+    }
 
-	@Override
-	public boolean isExtant(Address address) {
-		return false;
-	}
+    @Override
+    public boolean isExtant(Address address) {
+        return false;
+    }
 
-	@Override
-	public Bytes getStorage(Address address, Bytes key) {
-		return null;
-	}
+    @Override
+    public Bytes getStorage(Address address, Bytes key) {
+        return null;
+    }
 
-	@Override
-	public Bytes fetchCodeIfPresent(Address address) {
-		return null;
-	}
+    @Override
+    public Bytes fetchCodeIfPresent(Address address) {
+        return null;
+    }
 }

--- a/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/store/models/MockEntityAccess.java
+++ b/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/store/models/MockEntityAccess.java
@@ -1,0 +1,43 @@
+package com.hedera.node.app.service.evm.store.models;
+
+import com.google.protobuf.ByteString;
+import com.hedera.node.app.service.evm.store.contracts.HederaEvmEntityAccess;
+import org.apache.tuweni.bytes.Bytes;
+import org.hyperledger.besu.datatypes.Address;
+
+public class MockEntityAccess implements HederaEvmEntityAccess {
+	@Override
+	public boolean isUsable(Address address) {
+		return false;
+	}
+
+	@Override
+	public long getBalance(Address address) {
+		return 100;
+	}
+
+	@Override
+	public boolean isTokenAccount(Address address) {
+		return false;
+	}
+
+	@Override
+	public ByteString alias(Address address) {
+		return null;
+	}
+
+	@Override
+	public boolean isExtant(Address address) {
+		return false;
+	}
+
+	@Override
+	public Bytes getStorage(Address address, Bytes key) {
+		return null;
+	}
+
+	@Override
+	public Bytes fetchCodeIfPresent(Address address) {
+		return null;
+	}
+}

--- a/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/store/models/UpdatedHederaEvmAccountTest.java
+++ b/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/store/models/UpdatedHederaEvmAccountTest.java
@@ -15,17 +15,22 @@
  */
 package com.hedera.node.app.service.evm.store.models;
 
+import static org.apache.tuweni.units.bigints.UInt256.MIN_VALUE;
+import static org.apache.tuweni.units.bigints.UInt256.ZERO;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.BDDMockito.given;
 
+import com.hedera.node.app.service.evm.store.contracts.HederaEvmEntityAccess;
 import java.util.Collections;
+import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
-import org.apache.tuweni.units.bigints.UInt256;
 import org.hyperledger.besu.datatypes.Address;
+import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.datatypes.Wei;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
@@ -39,9 +44,14 @@ class UpdatedHederaEvmAccountTest {
             Address.fromHexString("0x000000000000000000000000000000000000077e");
     private UpdatedHederaEvmAccount subject;
 
+    @Mock private HederaEvmEntityAccess hederaEvmEntityAccess;
+
     @BeforeEach
     void setUp() {
-        subject = new UpdatedHederaEvmAccount(address, 1, Wei.ONE);
+        subject = new UpdatedHederaEvmAccount(address);
+        subject.setBalance(Wei.ONE);
+        subject.setNonce(1L);
+        subject.setEvmEntityAccess(hederaEvmEntityAccess);
     }
 
     @Test
@@ -58,7 +68,7 @@ class UpdatedHederaEvmAccountTest {
 
     @Test
     void addressHash() {
-        assertNull(subject.getAddressHash());
+        assertEquals(Hash.hash(address), subject.getAddressHash());
     }
 
     @Test
@@ -75,26 +85,58 @@ class UpdatedHederaEvmAccountTest {
 
     @Test
     void getCode() {
-        assertNull(subject.getCode());
+        assertEquals(Bytes.EMPTY, subject.getCode());
     }
 
     @Test
     void getCodeHash() {
-        assertNull(subject.getCodeHash());
+        assertEquals(Hash.hash(Bytes.EMPTY), subject.getCodeHash());
     }
 
     @Test
     void getStorageValue() {
-        assertNull(subject.getStorageValue(UInt256.MIN_VALUE));
+        subject.setStorageValue(MIN_VALUE, MIN_VALUE);
+        assertEquals(ZERO, subject.getStorageValue(MIN_VALUE));
+    }
+
+    @Test
+    void getStorageValueFromDb() {
+        given(hederaEvmEntityAccess.getStorage(address, MIN_VALUE)).willReturn(MIN_VALUE);
+        assertEquals(ZERO, subject.getStorageValue(MIN_VALUE));
     }
 
     @Test
     void getOriginalStorageValue() {
-        assertNull(subject.getOriginalStorageValue(UInt256.MIN_VALUE));
+        subject = new UpdatedHederaEvmAccount(address, 0, Wei.ZERO);
+        assertEquals(ZERO, subject.getOriginalStorageValue(MIN_VALUE));
     }
 
     @Test
     void storageEntriesFrom() {
         assertEquals(Collections.emptyNavigableMap(), subject.storageEntriesFrom(Bytes32.ZERO, 0));
+    }
+
+    @Test
+    void getUpdatedStorage() {
+        subject.setStorageValue(MIN_VALUE, MIN_VALUE);
+        assertEquals(MIN_VALUE, subject.getUpdatedStorage().get(MIN_VALUE));
+    }
+
+    @Test
+    void clearStorage() {
+        subject.setStorageValue(MIN_VALUE, MIN_VALUE);
+        subject.clearStorage();
+        assertEquals(0, subject.getUpdatedStorage().size());
+    }
+
+    @Test
+    void getMutable() {
+        assertEquals(subject, subject.getMutable());
+    }
+
+    @Test
+    void setCode() {
+        subject.setCode(Bytes.EMPTY);
+        assertEquals(Bytes.EMPTY, subject.getCode());
     }
 }


### PR DESCRIPTION
This PR  enriches the exported in the evm-module  [UpdatedHederaEvmAccount](https://github.com/hashgraph/hedera-services/blob/111b0a75fd5dd6370ace30a257f199f03761d34e/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/models/UpdatedHederaEvmAccount.java).
 The changes makes it a suitable mutable account that can be called for transfers, check of account balance and get stored storage values.

Implementation for [HederaEvmStackedWorldStateUpdater](https://github.com/hashgraph/hedera-services/blob/111b0a75fd5dd6370ace30a257f199f03761d34e/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/HederaEvmStackedWorldStateUpdater.java) `get` and `getAccount` methods also added. 

`The introduced  implementations are not final and will be enriched with future PR's for the current state of the  mirror-node eth_call. `
