### PR TITLE
Avoid `txnCtx.consensusTime()` when recomputing rewards

### DIFF
--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ledger/accounts/staking/RewardCalculator.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ledger/accounts/staking/RewardCalculator.java
@@ -48,7 +48,8 @@ public class RewardCalculator {
     }
 
     public long computePendingReward(final HederaAccount account) {
-        final var effectiveStart = stakePeriodManager.effectivePeriod(account.getStakePeriodStart());
+        final var effectiveStart =
+                stakePeriodManager.effectivePeriod(account.getStakePeriodStart());
         if (!stakePeriodManager.isRewardable(effectiveStart)) {
             return 0;
         }
@@ -86,7 +87,8 @@ public class RewardCalculator {
 
     public long estimatePendingRewards(
             final HederaAccount account, @Nullable final MerkleStakingInfo nodeStakingInfo) {
-        final var effectiveStart = stakePeriodManager.effectivePeriod(account.getStakePeriodStart());
+        final var effectiveStart =
+                stakePeriodManager.effectivePeriod(account.getStakePeriodStart());
         if (!stakePeriodManager.isEstimatedRewardable(effectiveStart)) {
             return 0;
         }

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ledger/accounts/staking/RewardCalculator.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ledger/accounts/staking/RewardCalculator.java
@@ -48,12 +48,16 @@ public class RewardCalculator {
     }
 
     public long computePendingReward(final HederaAccount account) {
+        final var effectiveStart = stakePeriodManager.effectivePeriod(account.getStakePeriodStart());
+        if (!stakePeriodManager.isRewardable(effectiveStart)) {
+            return 0;
+        }
         final var rewardOffered =
                 computeRewardFromDetails(
                         account,
                         stakeInfoManager.mutableStakeInfoFor(account.getStakedNodeAddressBookId()),
                         stakePeriodManager.currentStakePeriod(),
-                        stakePeriodManager.effectivePeriod(account.getStakePeriodStart()));
+                        effectiveStart);
         return account.isDeclinedReward() ? 0 : rewardOffered;
     }
 
@@ -82,12 +86,16 @@ public class RewardCalculator {
 
     public long estimatePendingRewards(
             final HederaAccount account, @Nullable final MerkleStakingInfo nodeStakingInfo) {
+        final var effectiveStart = stakePeriodManager.effectivePeriod(account.getStakePeriodStart());
+        if (!stakePeriodManager.isEstimatedRewardable(effectiveStart)) {
+            return 0;
+        }
         final var rewardOffered =
                 computeRewardFromDetails(
                         account,
                         nodeStakingInfo,
                         stakePeriodManager.estimatedCurrentStakePeriod(),
-                        stakePeriodManager.effectivePeriod(account.getStakePeriodStart()));
+                        effectiveStart);
         return account.isDeclinedReward() ? 0 : rewardOffered;
     }
 
@@ -101,7 +109,7 @@ public class RewardCalculator {
             @Nullable final MerkleStakingInfo nodeStakingInfo,
             final long currentStakePeriod,
             final long effectiveStart) {
-        if (nodeStakingInfo == null || !stakePeriodManager.isRewardable(effectiveStart)) {
+        if (nodeStakingInfo == null) {
             return 0L;
         }
         final var rewardSumHistory = nodeStakingInfo.getRewardSumHistory();

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ledger/accounts/staking/StakePeriodManager.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ledger/accounts/staking/StakePeriodManager.java
@@ -101,6 +101,13 @@ public class StakePeriodManager {
     public boolean isRewardable(final long stakePeriodStart) {
         return stakePeriodStart > -1 && stakePeriodStart < firstNonRewardableStakePeriod();
     }
+    public long estimatedFirstNonRewardableStakePeriod() {
+        return networkCtx.get().areRewardsActivated() ? estimatedCurrentStakePeriod() - 1 : Long.MIN_VALUE;
+    }
+
+    public boolean isEstimatedRewardable(final long stakePeriodStart) {
+        return stakePeriodStart > -1 && stakePeriodStart < estimatedFirstNonRewardableStakePeriod();
+    }
 
     public long effectivePeriod(final long stakePeriodStart) {
         if (stakePeriodStart > -1 && stakePeriodStart < currentStakePeriod - numStoredPeriods) {

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ledger/accounts/staking/StakePeriodManager.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ledger/accounts/staking/StakePeriodManager.java
@@ -101,8 +101,11 @@ public class StakePeriodManager {
     public boolean isRewardable(final long stakePeriodStart) {
         return stakePeriodStart > -1 && stakePeriodStart < firstNonRewardableStakePeriod();
     }
+
     public long estimatedFirstNonRewardableStakePeriod() {
-        return networkCtx.get().areRewardsActivated() ? estimatedCurrentStakePeriod() - 1 : Long.MIN_VALUE;
+        return networkCtx.get().areRewardsActivated()
+                ? estimatedCurrentStakePeriod() - 1
+                : Long.MIN_VALUE;
     }
 
     public boolean isEstimatedRewardable(final long stakePeriodStart) {

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/accounts/staking/RewardCalculatorTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/accounts/staking/RewardCalculatorTest.java
@@ -123,10 +123,8 @@ class RewardCalculatorTest {
     void doesntComputeRewardReturnsZeroIfNotInRange() {
         final var changes = new HashMap<AccountProperty, Object>();
 
-        given(stakePeriodManager.currentStakePeriod()).willReturn(todayNumber);
         given(stakePeriodManager.effectivePeriod(anyLong())).willReturn(todayNumber - 1);
         given(account.getStakePeriodStart()).willReturn(todayNumber - 1);
-        given(stakeInfoManager.mutableStakeInfoFor(anyLong())).willReturn(new MerkleStakingInfo());
         willCallRealMethod().given(stakePeriodManager).isRewardable(anyLong());
 
         final var reward = subject.computePendingReward(account);
@@ -229,7 +227,7 @@ class RewardCalculatorTest {
         given(account.isDeclinedReward()).willReturn(false);
         given(account.totalStake()).willReturn(100 * Units.HBARS_TO_TINYBARS);
         given(stakePeriodManager.effectivePeriod(todayNum - 2)).willReturn(todayNum - 2);
-        given(stakePeriodManager.isRewardable(todayNum - 2)).willReturn(true);
+        given(stakePeriodManager.isEstimatedRewardable(todayNum - 2)).willReturn(true);
 
         subject.setRewardsPaidInThisTxn(100L);
         final long reward = subject.estimatePendingRewards(account, merkleStakingInfo);

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/accounts/staking/StakePeriodManagerTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/accounts/staking/StakePeriodManagerTest.java
@@ -130,6 +130,14 @@ class StakePeriodManagerTest {
         givenDevManager();
         final var approx = Instant.now().getEpochSecond() / 60;
         assertTrue(Math.abs(approx - subject.estimatedCurrentStakePeriod()) <= 1);
+
+        assertEquals(Long.MIN_VALUE, subject.estimatedFirstNonRewardableStakePeriod());
+        given(networkCtx.areRewardsActivated()).willReturn(true);
+        assertEquals(approx - 1, subject.estimatedFirstNonRewardableStakePeriod());
+
+        assertFalse(subject.isEstimatedRewardable(-1));
+        assertFalse(subject.isEstimatedRewardable(approx - 1));
+        assertTrue(subject.isEstimatedRewardable(approx - 2));
     }
 
     @Test


### PR DESCRIPTION
**Description**:
Even when using `estimatePendingRewards()` in `StakeStartupHelper.doUpgradeHousekeeping()`, there is a second path to hit `txnCtx.consensusTime()` through `StakePeriodManager.currentStakePeriod()`:

```
Caused by: java.lang.NullPointerException: Cannot invoke "java.time.Instant.getEpochSecond()" because "now" is null
	at com.hedera.services.ledger.accounts.staking.StakePeriodManager.currentStakePeriod(StakePeriodManager.java:73) ~[main/:?]
	at com.hedera.services.ledger.accounts.staking.StakePeriodManager.firstNonRewardableStakePeriod(StakePeriodManager.java:99) ~[main/:?]
	at com.hedera.services.ledger.accounts.staking.StakePeriodManager.isRewardable(StakePeriodManager.java:103) ~[main/:?]
	at com.hedera.services.ledger.accounts.staking.RewardCalculator.computeRewardFromDetails(RewardCalculator.java:104) ~[main/:?]
	at com.hedera.services.ledger.accounts.staking.RewardCalculator.estimatePendingRewards(RewardCalculator.java:86) ~[main/:?]
	at com.hedera.services.ledger.accounts.staking.StakeStartupHelper.lambda$recomputeQuantities$3(StakeStartupHelper.java:195) ~[main/:?]
```

This PR provides an `Instant.now()`-based version of `StakePeriodManager.firstNonRewardableStakingPeriod()` to avoid this problem.