### PR TITLE
Add prehandle implementation for topic create

### DIFF
--- a/hedera-node/hedera-consensus-service-impl/build.gradle.kts
+++ b/hedera-node/hedera-consensus-service-impl/build.gradle.kts
@@ -27,4 +27,8 @@ dependencies {
     api(project(":hedera-node:hedera-consensus-service"))
     implementation(project(":hedera-node:hedera-mono-service"))
     compileOnly(libs.spotbugs.annotations)
+
+    testImplementation(testLibs.bundles.testing)
+    testImplementation(testFixtures(project(":hedera-node:hedera-mono-service")))
+    testImplementation(testLibs.mockito.inline)
 }

--- a/hedera-node/hedera-consensus-service-impl/src/main/java/com/hedera/node/app/service/consensus/impl/ConsensusPreTransactionHandlerImpl.java
+++ b/hedera-node/hedera-consensus-service-impl/src/main/java/com/hedera/node/app/service/consensus/impl/ConsensusPreTransactionHandlerImpl.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (C) 2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hedera.node.app.service.consensus.impl;
+
+import static com.hedera.node.app.service.mono.Utils.asHederaKey;
+
+import com.hedera.node.app.service.consensus.ConsensusPreTransactionHandler;
+import com.hedera.node.app.spi.AccountKeyLookup;
+import com.hedera.node.app.spi.key.HederaKey;
+import com.hedera.node.app.spi.meta.SigTransactionMetadata;
+import com.hedera.node.app.spi.meta.TransactionMetadata;
+import com.hederahashgraph.api.proto.java.AccountID;
+import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
+import com.hederahashgraph.api.proto.java.TransactionBody;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.commons.lang3.NotImplementedException;
+
+@SuppressWarnings("DanglingJavadoc")
+public class ConsensusPreTransactionHandlerImpl implements ConsensusPreTransactionHandler {
+
+    private final AccountKeyLookup keyFinder;
+
+    public ConsensusPreTransactionHandlerImpl(@NonNull final AccountKeyLookup keyFinder) {
+        this.keyFinder = keyFinder;
+    }
+
+    @Override
+    /** {@inheritDoc} */
+    public TransactionMetadata preHandleCreateTopic(TransactionBody txn, AccountID payer) {
+        final var op = txn.getConsensusCreateTopic();
+
+        final var payerKeyLookup = keyFinder.getKey(payer);
+        final var payerKey = payerKeyLookup.key();
+        if (payerKeyLookup.failed()) {
+            return new SigTransactionMetadata(
+                    txn, payer, payerKeyLookup.failureReason(), payerKey, List.of());
+        }
+
+        final var adminKey = asHederaKey(op.getAdminKey());
+        final var submitKey = asHederaKey(op.getSubmitKey());
+        if (adminKey.isPresent() || submitKey.isPresent()) {
+            final var otherReqs = new ArrayList<HederaKey>();
+            adminKey.ifPresent(otherReqs::add);
+            submitKey.ifPresent(otherReqs::add);
+            return new SigTransactionMetadata(txn, payer, ResponseCodeEnum.OK, payerKey, otherReqs);
+        }
+
+        return new SigTransactionMetadata(txn, payer, ResponseCodeEnum.OK, payerKey, List.of());
+    }
+
+    @Override
+    /** {@inheritDoc} */
+    public TransactionMetadata preHandleUpdateTopic(TransactionBody txn, AccountID payer) {
+        throw new NotImplementedException();
+    }
+
+    @Override
+    /** {@inheritDoc} */
+    public TransactionMetadata preHandleDeleteTopic(TransactionBody txn, AccountID payer) {
+        throw new NotImplementedException();
+    }
+
+    @Override
+    /** {@inheritDoc} */
+    public TransactionMetadata preHandleSubmitMessage(TransactionBody txn, AccountID payer) {
+        throw new NotImplementedException();
+    }
+}

--- a/hedera-node/hedera-consensus-service-impl/src/main/java/com/hedera/node/app/service/consensus/impl/ConsensusServiceImpl.java
+++ b/hedera-node/hedera-consensus-service-impl/src/main/java/com/hedera/node/app/service/consensus/impl/ConsensusServiceImpl.java
@@ -20,15 +20,18 @@ import com.hedera.node.app.service.consensus.ConsensusService;
 import com.hedera.node.app.spi.PreHandleContext;
 import com.hedera.node.app.spi.state.States;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.Objects;
 
 /**
  * Standard implementation of the {@link ConsensusService} {@link com.hedera.node.app.spi.Service}.
  */
-public final class StandardConsensusService implements ConsensusService {
+public final class ConsensusServiceImpl implements ConsensusService {
     @NonNull
     @Override
     public ConsensusPreTransactionHandler createPreTransactionHandler(
             @NonNull States states, @NonNull PreHandleContext ctx) {
-        throw new UnsupportedOperationException("Not yet implemented");
+        Objects.requireNonNull(states);
+        Objects.requireNonNull(ctx);
+        return new ConsensusPreTransactionHandlerImpl(ctx.keyLookup());
     }
 }

--- a/hedera-node/hedera-consensus-service-impl/src/main/java/module-info.java
+++ b/hedera-node/hedera-consensus-service-impl/src/main/java/module-info.java
@@ -1,10 +1,16 @@
+import com.hedera.node.app.service.consensus.ConsensusService;
+import com.hedera.node.app.service.consensus.impl.ConsensusServiceImpl;
+
 module com.hedera.node.app.service.consensus.impl {
     requires transitive com.hedera.node.app.service.consensus;
 
-    provides com.hedera.node.app.service.consensus.ConsensusService with
-            com.hedera.node.app.service.consensus.impl.StandardConsensusService;
+    provides ConsensusService with
+            ConsensusServiceImpl;
 
     requires static com.github.spotbugs.annotations;
+    requires com.hedera.hashgraph.protobuf.java.api;
+    requires org.apache.commons.lang3;
+    requires com.hedera.node.app.service.mono;
 
     exports com.hedera.node.app.service.consensus.impl to
             com.hedera.node.app.service.consensus.impl.test;

--- a/hedera-node/hedera-consensus-service-impl/src/test/java/com/hedera/node/app/service/consensus/impl/test/ConsensusPreTransactionHandlerImplTest.java
+++ b/hedera-node/hedera-consensus-service-impl/src/test/java/com/hedera/node/app/service/consensus/impl/test/ConsensusPreTransactionHandlerImplTest.java
@@ -1,0 +1,212 @@
+/*
+ * Copyright (C) 2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hedera.node.app.service.consensus.impl.test;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+import com.google.protobuf.ByteString;
+import com.hedera.node.app.service.consensus.impl.ConsensusPreTransactionHandlerImpl;
+import com.hedera.node.app.service.mono.Utils;
+import com.hedera.node.app.spi.AccountKeyLookup;
+import com.hedera.node.app.spi.KeyOrLookupFailureReason;
+import com.hedera.node.app.spi.key.HederaKey;
+import com.hedera.node.app.spi.meta.TransactionMetadata;
+import com.hedera.test.utils.IdUtils;
+import com.hedera.test.utils.KeyUtils;
+import com.hederahashgraph.api.proto.java.AccountID;
+import com.hederahashgraph.api.proto.java.ConsensusCreateTopicTransactionBody;
+import com.hederahashgraph.api.proto.java.Key;
+import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
+import com.hederahashgraph.api.proto.java.TransactionBody;
+import com.hederahashgraph.api.proto.java.TransactionID;
+import java.util.List;
+import org.apache.commons.lang3.NotImplementedException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ConsensusPreTransactionHandlerImplTest {
+    private static final AccountID ACCOUNT_ID_3 = IdUtils.asAccount("0.0.3");
+    private static final Key SIMPLE_KEY_A =
+            Key.newBuilder()
+                    .setEd25519(ByteString.copyFrom("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".getBytes()))
+                    .build();
+    private static final Key SIMPLE_KEY_B =
+            Key.newBuilder()
+                    .setEd25519(ByteString.copyFrom("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb".getBytes()))
+                    .build();
+
+    @Mock private AccountKeyLookup keyFinder;
+
+    private ConsensusPreTransactionHandlerImpl subject;
+
+    @BeforeEach
+    void setUp() {
+        subject = new ConsensusPreTransactionHandlerImpl(keyFinder);
+    }
+
+    @Test
+    void createAddsAllNonNullKeyInputs() {
+        final var payerKey = mockPayerLookup();
+        final var adminKey = SIMPLE_KEY_A;
+        final var submitKey = SIMPLE_KEY_B;
+
+        final var result =
+                subject.preHandleCreateTopic(newCreateTxn(adminKey, submitKey), ACCOUNT_ID_3);
+
+        assertOkResponse(result);
+        Assertions.assertEquals(payerKey, result.payerKey());
+        final var expectedHederaAdminKey = Utils.asHederaKey(adminKey).orElseThrow();
+        Assertions.assertTrue(result.requiredNonPayerKeys().contains(expectedHederaAdminKey));
+        final var expectedHederaSubmitKey = Utils.asHederaKey(submitKey).orElseThrow();
+        Assertions.assertTrue(result.requiredNonPayerKeys().contains(expectedHederaSubmitKey));
+        Assertions.assertEquals(2, result.requiredNonPayerKeys().size());
+    }
+
+    @Test
+    void createOnlyRequiresPayerKey() {
+        final var payerKey = mockPayerLookup();
+
+        final var result = subject.preHandleCreateTopic(newCreateTxn(null, null), ACCOUNT_ID_3);
+
+        assertOkResponse(result);
+        Assertions.assertEquals(payerKey, result.payerKey());
+        Assertions.assertEquals(List.of(), result.requiredNonPayerKeys());
+    }
+
+    @Test
+    void createAddsDifferentAdminKey() {
+        final var payerKey = mockPayerLookup();
+        final var adminKey = SIMPLE_KEY_A;
+
+        final var result = subject.preHandleCreateTopic(newCreateTxn(adminKey, null), ACCOUNT_ID_3);
+
+        assertOkResponse(result);
+        Assertions.assertEquals(payerKey, result.payerKey());
+        final var expectedHederaAdminKey = Utils.asHederaKey(adminKey).orElseThrow();
+        Assertions.assertTrue(result.requiredNonPayerKeys().contains(expectedHederaAdminKey));
+        Assertions.assertEquals(1, result.requiredNonPayerKeys().size());
+    }
+
+    @Test
+    void createAddsDifferentSubmitKey() {
+        final var payerKey = mockPayerLookup();
+        final var submitKey = SIMPLE_KEY_B;
+
+        final var result =
+                subject.preHandleCreateTopic(newCreateTxn(null, submitKey), ACCOUNT_ID_3);
+
+        assertOkResponse(result);
+        Assertions.assertEquals(payerKey, result.payerKey());
+        final var expectedHederaSubmitKey = Utils.asHederaKey(submitKey).orElseThrow();
+        Assertions.assertTrue(result.requiredNonPayerKeys().contains(expectedHederaSubmitKey));
+        Assertions.assertEquals(1, result.requiredNonPayerKeys().size());
+    }
+
+    @Test
+    void createAddsPayerAsAdmin() {
+        final var protoPayerKey = SIMPLE_KEY_A;
+        final var payerKey = mockPayerLookup(protoPayerKey);
+
+        final var result =
+                subject.preHandleCreateTopic(newCreateTxn(protoPayerKey, null), ACCOUNT_ID_3);
+
+        assertOkResponse(result);
+        Assertions.assertEquals(payerKey, result.payerKey());
+        Assertions.assertEquals(List.of(payerKey), result.requiredNonPayerKeys());
+    }
+
+    @Test
+    void createAddsPayerAsSubmitter() {
+        final var protoPayerKey = SIMPLE_KEY_B;
+        final var payerKey = mockPayerLookup(protoPayerKey);
+
+        final var result =
+                subject.preHandleCreateTopic(newCreateTxn(null, protoPayerKey), ACCOUNT_ID_3);
+
+        assertOkResponse(result);
+        Assertions.assertEquals(payerKey, result.payerKey());
+        Assertions.assertEquals(List.of(payerKey), result.requiredNonPayerKeys());
+    }
+
+    @Test
+    void createFailsWhenPayerNotFound() {
+        given(keyFinder.getKey(any()))
+                .willReturn(
+                        KeyOrLookupFailureReason.withFailureReason(
+                                ResponseCodeEnum
+                                        .ACCOUNT_ID_DOES_NOT_EXIST)); // Any error response code
+        final var inputTxn = newCreateTxn(null, null);
+
+        final var result = subject.preHandleCreateTopic(inputTxn, ACCOUNT_ID_3);
+
+        Assertions.assertEquals(ResponseCodeEnum.ACCOUNT_ID_DOES_NOT_EXIST, result.status());
+        Assertions.assertNull(result.payerKey());
+        Assertions.assertTrue(result.failed());
+        Assertions.assertTrue(result.requiredNonPayerKeys().isEmpty());
+    }
+
+    @Test
+    void notImplementedMethodsThrowException() {
+        assertThrows(
+                NotImplementedException.class,
+                () -> subject.preHandleUpdateTopic(mock(TransactionBody.class), ACCOUNT_ID_3));
+        assertThrows(
+                NotImplementedException.class,
+                () -> subject.preHandleDeleteTopic(mock(TransactionBody.class), ACCOUNT_ID_3));
+        assertThrows(
+                NotImplementedException.class,
+                () -> subject.preHandleSubmitMessage(mock(TransactionBody.class), ACCOUNT_ID_3));
+    }
+
+    private HederaKey mockPayerLookup() {
+        return mockPayerLookup(KeyUtils.A_COMPLEX_KEY);
+    }
+
+    private HederaKey mockPayerLookup(Key key) {
+        final var returnKey = Utils.asHederaKey(key).orElseThrow();
+        given(keyFinder.getKey(ACCOUNT_ID_3))
+                .willReturn(KeyOrLookupFailureReason.withKey(returnKey));
+        return returnKey;
+    }
+
+    private static TransactionBody newCreateTxn(Key adminKey, Key submitKey) {
+        final var txnId = TransactionID.newBuilder().setAccountID(ACCOUNT_ID_3).build();
+        final var createTopicBuilder = ConsensusCreateTopicTransactionBody.newBuilder();
+        if (adminKey != null) {
+            createTopicBuilder.setAdminKey(adminKey);
+        }
+        if (submitKey != null) {
+            createTopicBuilder.setSubmitKey(submitKey);
+        }
+        return TransactionBody.newBuilder()
+                .setTransactionID(txnId)
+                .setConsensusCreateTopic(createTopicBuilder.build())
+                .build();
+    }
+
+    private static void assertOkResponse(TransactionMetadata result) {
+        Assertions.assertEquals(ResponseCodeEnum.OK, result.status());
+        Assertions.assertFalse(result.failed());
+    }
+}

--- a/hedera-node/hedera-consensus-service-impl/src/test/java/com/hedera/node/app/service/consensus/impl/test/ConsensusPreTransactionHandlerImplTest.java
+++ b/hedera-node/hedera-consensus-service-impl/src/test/java/com/hedera/node/app/service/consensus/impl/test/ConsensusPreTransactionHandlerImplTest.java
@@ -160,7 +160,7 @@ class ConsensusPreTransactionHandlerImplTest {
 
         final var result = subject.preHandleCreateTopic(inputTxn, ACCOUNT_ID_3);
 
-        Assertions.assertEquals(ResponseCodeEnum.ACCOUNT_ID_DOES_NOT_EXIST, result.status());
+        Assertions.assertEquals(ResponseCodeEnum.INVALID_PAYER_ACCOUNT_ID, result.status());
         Assertions.assertNull(result.payerKey());
         Assertions.assertTrue(result.failed());
         Assertions.assertTrue(result.requiredNonPayerKeys().isEmpty());

--- a/hedera-node/hedera-consensus-service-impl/src/test/java/com/hedera/node/app/service/consensus/impl/test/ConsensusServiceImplTest.java
+++ b/hedera-node/hedera-consensus-service-impl/src/test/java/com/hedera/node/app/service/consensus/impl/test/ConsensusServiceImplTest.java
@@ -17,8 +17,11 @@ package com.hedera.node.app.service.consensus.impl.test;
 
 import com.hedera.node.app.service.consensus.ConsensusService;
 import com.hedera.node.app.service.consensus.impl.ConsensusServiceImpl;
+import com.hedera.node.app.spi.PreHandleContext;
+import com.hedera.node.app.spi.state.States;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 class ConsensusServiceImplTest {
 
@@ -33,5 +36,30 @@ class ConsensusServiceImplTest {
                 ConsensusServiceImpl.class,
                 service.getClass(),
                 "We must always receive an instance of type ConsensusServiceImpl");
+    }
+
+    @Test
+    void serviceCreatesPreTransactionHandler() {
+        final var service = ConsensusService.getInstance();
+
+        final var result =
+                service.createPreTransactionHandler(
+                        Mockito.mock(States.class), Mockito.mock(PreHandleContext.class));
+
+        Assertions.assertNotNull(result);
+    }
+
+    @Test
+    void checkNullArgs() {
+        final var service = ConsensusService.getInstance();
+
+        Assertions.assertThrows(
+                NullPointerException.class,
+                () ->
+                        service.createPreTransactionHandler(
+                                null, Mockito.mock(PreHandleContext.class)));
+        Assertions.assertThrows(
+                NullPointerException.class,
+                () -> service.createPreTransactionHandler(Mockito.mock(States.class), null));
     }
 }

--- a/hedera-node/hedera-consensus-service-impl/src/test/java/com/hedera/node/app/service/consensus/impl/test/ConsensusServiceImplTest.java
+++ b/hedera-node/hedera-consensus-service-impl/src/test/java/com/hedera/node/app/service/consensus/impl/test/ConsensusServiceImplTest.java
@@ -16,11 +16,11 @@
 package com.hedera.node.app.service.consensus.impl.test;
 
 import com.hedera.node.app.service.consensus.ConsensusService;
-import com.hedera.node.app.service.consensus.impl.StandardConsensusService;
+import com.hedera.node.app.service.consensus.impl.ConsensusServiceImpl;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-class StandardConsensusServiceTest {
+class ConsensusServiceImplTest {
 
     @Test
     void testSpi() {
@@ -30,8 +30,8 @@ class StandardConsensusServiceTest {
         // then
         Assertions.assertNotNull(service, "We must always receive an instance");
         Assertions.assertEquals(
-                StandardConsensusService.class,
+                ConsensusServiceImpl.class,
                 service.getClass(),
-                "We must always receive an instance of type StandardConsensusService");
+                "We must always receive an instance of type ConsensusServiceImpl");
     }
 }

--- a/hedera-node/hedera-consensus-service-impl/src/test/java/module-info.java
+++ b/hedera-node/hedera-consensus-service-impl/src/test/java/module-info.java
@@ -2,6 +2,13 @@ module com.hedera.node.app.service.consensus.impl.test {
     requires com.hedera.node.app.service.consensus;
     requires com.hedera.node.app.service.consensus.impl;
     requires org.junit.jupiter.api;
+    requires com.hedera.node.app.service.mono.testFixtures;
+    requires com.hedera.hashgraph.protobuf.java.api;
+    requires com.google.protobuf;
+    requires org.mockito.junit.jupiter;
+    requires org.mockito;
+    requires org.apache.commons.lang3;
+    requires com.hedera.node.app.service.mono;
 
     opens com.hedera.node.app.service.consensus.impl.test to
             org.junit.platform.commons;

--- a/hedera-node/hedera-schedule-service-impl/src/main/java/module-info.java
+++ b/hedera-node/hedera-schedule-service-impl/src/main/java/module-info.java
@@ -8,8 +8,7 @@ module com.hedera.node.app.service.schedule.impl {
     requires com.hedera.node.app.service.mono;
 
     exports com.hedera.node.app.service.schedule.impl to
-            com.hedera.node.app.service.schedule.impl.test,
-            com.hedera.node.app.service.scheduled.impl.test;
+            com.hedera.node.app.service.schedule.impl.test;
 
     provides com.hedera.node.app.service.schedule.ScheduleService with
             ScheduleServiceImpl;


### PR DESCRIPTION
* Add (consensus) topic creation prehandle method
* Modifies SigTransactionMetadata to not add the payer key multiple times

Related issue(s):
Part of #4030