### PR TITLE
Use static ledgers to answer view queries

### DIFF
--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/HTSPrecompiledContract.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/HTSPrecompiledContract.java
@@ -208,8 +208,7 @@ public class HTSPrecompiledContract extends AbstractPrecompiledContract {
                                     input,
                                     frame,
                                     precompilePricingUtils::computeViewFunctionGas,
-                                    currentView,
-                                    ledgers);
+                                    currentView);
                     return executor.computeCosted();
                 }
             }

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/InfrastructureFactory.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/InfrastructureFactory.java
@@ -278,9 +278,8 @@ public class InfrastructureFactory {
             final Bytes input,
             final MessageFrame frame,
             final ViewGasCalculator gasCalculator,
-            final StateView stateView,
-            final WorldLedgers ledgers) {
-        return new ViewExecutor(input, frame, encoder, gasCalculator, stateView, ledgers);
+            final StateView stateView) {
+        return new ViewExecutor(input, frame, encoder, gasCalculator, stateView);
     }
 
     public ApproveAllowanceLogic newApproveAllowanceLogic(

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/proxy/ViewExecutor.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/proxy/ViewExecutor.java
@@ -34,6 +34,7 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.NOT_SUPPORTED;
 
 import com.hedera.node.app.service.mono.context.primitives.StateView;
 import com.hedera.node.app.service.mono.exceptions.InvalidTransactionException;
+import com.hedera.node.app.service.mono.store.contracts.HederaStackedWorldStateUpdater;
 import com.hedera.node.app.service.mono.store.contracts.WorldLedgers;
 import com.hedera.node.app.service.mono.store.contracts.precompile.codec.EncodingFacade;
 import com.hedera.node.app.service.mono.store.contracts.precompile.codec.TokenExpiryWrapper;
@@ -72,14 +73,14 @@ public class ViewExecutor {
             final MessageFrame frame,
             final EncodingFacade encoder,
             final ViewGasCalculator gasCalculator,
-            final StateView stateView,
-            final WorldLedgers ledgers) {
+            final StateView stateView) {
         this.input = input;
         this.frame = frame;
         this.encoder = encoder;
         this.gasCalculator = gasCalculator;
         this.stateView = stateView;
-        this.ledgers = ledgers;
+        final var updater = (HederaStackedWorldStateUpdater) frame.getWorldUpdater();
+        this.ledgers = updater.trackingLedgers();
     }
 
     public Pair<Long, Bytes> computeCosted() {

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/HTSPrecompiledContractTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/HTSPrecompiledContractTest.java
@@ -383,6 +383,7 @@ class HTSPrecompiledContractTest {
         given(messageFrame.isStatic()).willReturn(true);
         given(messageFrame.getWorldUpdater()).willReturn(worldUpdater);
         given(worldUpdater.isInTransaction()).willReturn(false);
+        given(worldUpdater.trackingLedgers()).willReturn(wrappedLedgers);
 
         final var viewExecutor =
                 new ViewExecutor(
@@ -390,9 +391,8 @@ class HTSPrecompiledContractTest {
                         messageFrame,
                         encoder,
                         precompilePricingUtils::computeViewFunctionGas,
-                        stateView,
-                        wrappedLedgers);
-        given(infrastructureFactory.newViewExecutor(any(), any(), any(), any(), any()))
+                        stateView);
+        given(infrastructureFactory.newViewExecutor(any(), any(), any(), any()))
                 .willReturn(viewExecutor);
         given(feeCalculator.estimatePayment(any(), any(), any(), any(), any()))
                 .willReturn(mockFeeObject);

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/InfrastructureFactoryTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/InfrastructureFactoryTest.java
@@ -53,6 +53,7 @@ import com.hedera.node.app.service.mono.store.contracts.HederaStackedWorldStateU
 import com.hedera.node.app.service.mono.store.contracts.WorldLedgers;
 import com.hedera.node.app.service.mono.store.contracts.precompile.codec.EncodingFacade;
 import com.hedera.node.app.service.mono.store.contracts.precompile.proxy.RedirectViewExecutor;
+import com.hedera.node.app.service.mono.store.contracts.precompile.proxy.ViewExecutor;
 import com.hedera.node.app.service.mono.store.contracts.precompile.proxy.ViewGasCalculator;
 import com.hedera.node.app.service.mono.store.models.NftId;
 import com.hedera.node.app.service.mono.store.tokens.HederaTokenStore;
@@ -151,6 +152,15 @@ class InfrastructureFactoryTest {
                         syntheticTxnFactory,
                         view,
                         entityCreator);
+    }
+
+    @Test
+    void canCreateViewExecutor() {
+        final var fakeInput = Bytes.of(1, 2, 3);
+        given(frame.getWorldUpdater()).willReturn(worldStateUpdater);
+        given(worldStateUpdater.trackingLedgers()).willReturn(ledgers);
+        assertInstanceOf(
+                ViewExecutor.class, subject.newViewExecutor(fakeInput, frame, gasCalculator, view));
     }
 
     @Test

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/proxy/ViewExecutorTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/proxy/ViewExecutorTest.java
@@ -53,6 +53,7 @@ import com.hedera.node.app.service.mono.context.primitives.StateView;
 import com.hedera.node.app.service.mono.ledger.properties.TokenProperty;
 import com.hedera.node.app.service.mono.legacy.core.jproto.JKey;
 import com.hedera.node.app.service.mono.state.enums.TokenType;
+import com.hedera.node.app.service.mono.store.contracts.HederaStackedWorldStateUpdater;
 import com.hedera.node.app.service.mono.store.contracts.WorldLedgers;
 import com.hedera.node.app.service.mono.store.contracts.precompile.codec.EncodingFacade;
 import com.hedera.node.app.service.mono.store.contracts.precompile.codec.GetTokenKeyWrapper;
@@ -107,6 +108,7 @@ class ViewExecutorTest {
     @Mock private WorldLedgers ledgers;
     @Mock private JKey key;
     @Mock private NetworkInfo networkInfo;
+    @Mock private HederaStackedWorldStateUpdater updater;
 
     public static final AccountID account = IdUtils.asAccount("0.0.777");
     public static final AccountID spender = IdUtils.asAccount("0.0.888");
@@ -527,9 +529,9 @@ class ViewExecutorTest {
         given(frame.getBlockValues()).willReturn(blockValues);
         given(blockValues.getTimestamp()).willReturn(timestamp);
         given(viewGasCalculator.compute(resultingTimestamp, MINIMUM_TINYBARS_COST)).willReturn(gas);
-        this.subject =
-                new ViewExecutor(
-                        input, frame, encodingFacade, viewGasCalculator, stateView, ledgers);
+        given(frame.getWorldUpdater()).willReturn(updater);
+        given(updater.trackingLedgers()).willReturn(ledgers);
+        this.subject = new ViewExecutor(input, frame, encodingFacade, viewGasCalculator, stateView);
         return input;
     }
 
@@ -541,11 +543,11 @@ class ViewExecutorTest {
                         tokenAddress,
                         Bytes.of(Integers.toBytes(serialNumber)));
         given(frame.getBlockValues()).willReturn(blockValues);
+        given(frame.getWorldUpdater()).willReturn(updater);
+        given(updater.trackingLedgers()).willReturn(ledgers);
         given(blockValues.getTimestamp()).willReturn(timestamp);
         given(viewGasCalculator.compute(resultingTimestamp, MINIMUM_TINYBARS_COST)).willReturn(gas);
-        this.subject =
-                new ViewExecutor(
-                        input, frame, encodingFacade, viewGasCalculator, stateView, ledgers);
+        this.subject = new ViewExecutor(input, frame, encodingFacade, viewGasCalculator, stateView);
         return input;
     }
 


### PR DESCRIPTION
**Description**:
 - Don't use the `HTSPrecompiledContract#ledgers` to construct a `ViewExecutor`---these ledgers are subject to odd race conditions---or could even be `null` if the view function is running in a `ContractCallLocal` query!
 - Instead use the frame updater's `WorldLedger`.