### PR TITLE
Skip PBJ unit tests in CI

### DIFF
--- a/.github/workflows/comp-compile-application-code.yaml
+++ b/.github/workflows/comp-compile-application-code.yaml
@@ -153,7 +153,7 @@ jobs:
         if: ${{ inputs.enable-unit-tests && steps.gradle-build.conclusion == 'success' && !cancelled() }}
         with:
           gradle-version: ${{ inputs.gradle-version }}
-          arguments: check --scan
+          arguments: check --scan -x :hedera-node:hapi:test
 
       - name: Publish Unit Test Report
         uses: mikepenz/action-junit-report@v3


### PR DESCRIPTION
**Description**:
 - The `:hedera-node:hapi:test` task runs for multiple hours in CI and always fails. Skip it for now.