### PR TITLE
Migrate Actions workflows to new cluster 

### DIFF
--- a/.github/workflows/comp-build-release-artifact.yaml
+++ b/.github/workflows/comp-build-release-artifact.yaml
@@ -79,7 +79,7 @@ permissions:
 jobs:
   Artifact:
     name: ${{ inputs.custom-job-label || 'Artifact' }}
-    runs-on: [self-hosted, Linux, services, standard, ephemeral]
+    runs-on: [self-hosted, Linux, medium, ephemeral]
     steps:
       - name: Install Semantic Version Tools
         run: |
@@ -164,18 +164,15 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v3
 
-      - name: Validate Gradle Wrapper
-        uses: gradle/wrapper-validation-action@v1
-
       - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v0
+        uses: google-github-actions/auth@v1
         if: ${{ inputs.dry-run-enabled != true && !cancelled() && !failure() }}
         with:
           workload_identity_provider: "projects/235822363393/locations/global/workloadIdentityPools/hedera-builds-pool/providers/hedera-builds-gh-actions"
           service_account: "hedera-artifact-builds@devops-1-254919.iam.gserviceaccount.com"
 
       - name: Setup Google Cloud SDK
-        uses: google-github-actions/setup-gcloud@v0
+        uses: google-github-actions/setup-gcloud@v1
         if: ${{ inputs.dry-run-enabled != true && !cancelled() && !failure() }}
 
       - name: Setup Java
@@ -270,7 +267,7 @@ jobs:
           sha384sum "${ARTIFACT_NAME}.zip" | tee "${ARTIFACT_NAME}.sha384"
 
       - name: Upload Artifacts (DevOps GCP Bucket)
-        uses: google-github-actions/upload-cloud-storage@v0.10.4
+        uses: google-github-actions/upload-cloud-storage@v1
         if: ${{ inputs.dry-run-enabled != true && !cancelled() && !failure() }}
         with:
           path: ${{ steps.artifact-release.outputs.folder }}
@@ -279,7 +276,7 @@ jobs:
 
       - name: Notify Jenkins of Release (Integration)
         id: jenkins-integration
-        uses: fjogeleit/http-request-action@v1.10.0
+        uses: fjogeleit/http-request-action@v1
         if: ${{ inputs.dry-run-enabled != true && inputs.trigger-env-deploy == 'integration' && !cancelled() && !failure() }}
         with:
           url: ${{ secrets.jenkins-integration-url }}
@@ -287,7 +284,7 @@ jobs:
 
       - name: Notify Jenkins of Release (Preview)
         id: jenkins-preview
-        uses: fjogeleit/http-request-action@v1.10.0
+        uses: fjogeleit/http-request-action@v1
         if: ${{ inputs.dry-run-enabled != true && inputs.trigger-env-deploy == 'preview' && !cancelled() && !failure() }}
         with:
           url: ${{ secrets.jenkins-preview-url }}

--- a/.github/workflows/comp-compile-application-code.yaml
+++ b/.github/workflows/comp-compile-application-code.yaml
@@ -104,7 +104,7 @@ permissions:
 jobs:
   compile:
     name: ${{ inputs.custom-job-label || 'Compiles' }}
-    runs-on: [self-hosted, Linux, services, standard, ephemeral]
+    runs-on: [self-hosted, Linux, medium, ephemeral]
     steps:
       - name: Checkout Code
         uses: actions/checkout@v3
@@ -113,9 +113,6 @@ jobs:
         if: ${{ (inputs.enable-sonar-analysis || inputs.enable-unit-tests) && !cancelled() }}
         run: |
           git fetch --unshallow --no-recurse-submodules
-
-      - name: Validate Gradle Wrapper
-        uses: gradle/wrapper-validation-action@v1
 
       - name: Setup Java
         uses: actions/setup-java@v3
@@ -237,7 +234,7 @@ jobs:
             SONAR_OPTS=""
           fi
 
-          echo "::set-output name=options::${SONAR_OPTS}"
+          echo "options=${SONAR_OPTS}" >> "${GITHUB_OUTPUT}"
 
       - name: SonarCloud Scan
         uses: gradle/gradle-build-action@v2

--- a/.github/workflows/flow-deploy-release-artifact.yaml
+++ b/.github/workflows/flow-deploy-release-artifact.yaml
@@ -85,7 +85,7 @@ jobs:
 
   prepare-tag-release:
     name: Release / Tag / Prepare
-    runs-on: [self-hosted, Linux, services, standard, ephemeral]
+    runs-on: [self-hosted, Linux, medium, ephemeral]
     if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') }}
     outputs:
       version: ${{ steps.tag.outputs.version }}
@@ -147,7 +147,7 @@ jobs:
 
   prepare-mc-release:
     name: Release / MC / Prepare
-    runs-on: [self-hosted, Linux, services, standard, ephemeral]
+    runs-on: [self-hosted, Linux, medium, ephemeral]
     needs:
       - prepare-tag-release
       - release-adhoc
@@ -211,7 +211,7 @@ jobs:
 
   dispatch-mc-release:
     name: Release / MC / Dispatch
-    runs-on: [ self-hosted, Linux, services, standard, ephemeral ]
+    runs-on: [self-hosted, Linux, medium, ephemeral]
     needs:
       - prepare-mc-release
       - release-adhoc

--- a/.github/workflows/flow-pull-request-checks.yaml
+++ b/.github/workflows/flow-pull-request-checks.yaml
@@ -44,7 +44,7 @@ jobs:
 
   unit-label-check:
     name: "Label Check [CI:UnitTests]"
-    runs-on: [self-hosted, Linux, services, standard, ephemeral]
+    runs-on: [self-hosted, Linux, medium, ephemeral]
     if: ${{ contains(github.event.pull_request.labels.*.name, 'CI:UnitTests') || contains(github.event.pull_request.labels.*.name, 'CI:FinalChecks') }}
     steps:
       - name: Check Labels


### PR DESCRIPTION
## Description

Updates the workflows to use the new ARC cluster and fixes remaining deprecation warnings due to `set-output` usage in the steps.

### Related Issues 

- Closes #4544 