### PR TITLE
Add override for class path `state.mainClassNameOverride`

### DIFF
--- a/hedera-node/configuration/compose/settings.txt
+++ b/hedera-node/configuration/compose/settings.txt
@@ -12,3 +12,4 @@ state.saveStatePeriod,                         300
 useLoopbackIp,                                 false
 waitAtStartup,                                 false
 virtualMap.preferredFlushQueueSize,            10000
+state.mainClassNameOverride,                   com.hedera.services.ServicesMain

--- a/hedera-node/configuration/mainnet/settings.txt
+++ b/hedera-node/configuration/mainnet/settings.txt
@@ -26,3 +26,4 @@ waitAtStartup,                                 false
 jasperDb.storagePath,                          /opt/hgcapp/services-hedera/HapiApp2.0/data/saved
 jasperDb.iteratorInputBufferBytes,             16777216
 virtualMap.preferredFlushQueueSize,            10000
+state.mainClassNameOverride,                   com.hedera.services.ServicesMain

--- a/hedera-node/configuration/preprod/settings.txt
+++ b/hedera-node/configuration/preprod/settings.txt
@@ -27,3 +27,4 @@ jasperDb.storagePath,                          /opt/hgcapp/services-hedera/HapiA
 jasperDb.iteratorInputBufferBytes,             16777216
 virtualMap.preferredFlushQueueSize,            10000
 prometheusEndpointEnabled,                     true
+state.mainClassNameOverride,                   com.hedera.services.ServicesMain

--- a/hedera-node/configuration/previewnet/settings.txt
+++ b/hedera-node/configuration/previewnet/settings.txt
@@ -26,3 +26,4 @@ waitAtStartup,                                 false
 jasperDb.storagePath,                          /opt/hgcapp/services-hedera/HapiApp2.0/data/saved
 jasperDb.iteratorInputBufferBytes,             16777216
 virtualMap.preferredFlushQueueSize,            10000
+state.mainClassNameOverride,                   com.hedera.services.ServicesMain

--- a/hedera-node/configuration/testnet/settings.txt
+++ b/hedera-node/configuration/testnet/settings.txt
@@ -27,3 +27,4 @@ waitAtStartup,                                 false
 jasperDb.storagePath,                          /opt/hgcapp/services-hedera/HapiApp2.0/data/saved
 jasperDb.iteratorInputBufferBytes,             16777216
 virtualMap.preferredFlushQueueSize,            10000
+state.mainClassNameOverride,                   com.hedera.services.ServicesMain

--- a/hedera-node/settings.txt
+++ b/hedera-node/settings.txt
@@ -10,3 +10,4 @@ showInternalStats,                             1
 state.saveStatePeriod,                         300
 useLoopbackIp,                                 false
 waitAtStartup,                                 false
+state.mainClassNameOverride,                   com.hedera.services.ServicesMain


### PR DESCRIPTION
Signed-off-by: Neeharika-Sompalli <neeharika.sompalli@swirldslabs.com>

Added an override for the class path using setting
```
state.mainClassNameOverride,                   com.hedera.services.ServicesMain
```

This class path is used by Devops in their scripts