### PR TITLE
Bump platform version

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -112,7 +112,7 @@ dependencyResolutionManagement {
             version("netty-version", "4.1.66.Final")
             version("protobuf-java-version", "3.19.4")
             version("slf4j-version", "2.0.3")
-            version("swirlds-version", "0.34.0")
+            version("swirlds-version", "0.35.0-alpha.0")
             version("tuweni-version", "2.2.0")
             version("jna-version", "5.12.1")
             version("jsr305-version", "3.0.2")


### PR DESCRIPTION
Signed-off-by: Kim Rader <kim.rader@swirldslabs.com>

Incorporate platform version 0.35.0-alpha.0 into services code
