### PR TITLE
Port `0.34.0-alpha.1` patches

### DIFF
--- a/.github/workflows/comp-compile-application-code.yaml
+++ b/.github/workflows/comp-compile-application-code.yaml
@@ -1,5 +1,5 @@
 ##
-# Copyright (C) 2022 Hedera Hashgraph, LLC
+# Copyright (C) 2022-2023 Hedera Hashgraph, LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/AbstractLedgerEvmWorldUpdater.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/AbstractLedgerEvmWorldUpdater.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/HederaEvmStackedWorldStateUpdater.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/HederaEvmStackedWorldStateUpdater.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/HederaEvmWorldState.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/HederaEvmWorldState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/models/UpdatedHederaEvmAccount.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/models/UpdatedHederaEvmAccount.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/store/contracts/HederaEvmWorldStateTest.java
+++ b/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/store/contracts/HederaEvmWorldStateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/store/models/HederaEvmStackedWorldStateUpdaterTest.java
+++ b/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/store/models/HederaEvmStackedWorldStateUpdaterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/store/models/MockEntityAccess.java
+++ b/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/store/models/MockEntityAccess.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/store/models/UpdatedHederaEvmAccountTest.java
+++ b/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/store/models/UpdatedHederaEvmAccountTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/contracts/ContractsV_0_32Module.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/contracts/ContractsV_0_32Module.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/contracts/operation/AbstractRecordingCreateOperation.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/contracts/operation/AbstractRecordingCreateOperation.java
@@ -268,8 +268,13 @@ public abstract class AbstractRecordingCreateOperation extends AbstractOperation
     private AccountID matchingHollowAccountId(
             HederaStackedWorldStateUpdater updater, Address contract) {
         final var accountID = accountIdFromEvmAddress(updater.aliases().resolveForEvm(contract));
-        final var accountKey = updater.trackingAccounts().get(accountID, KEY);
-        return EMPTY_KEY.equals(accountKey) ? accountID : null;
+        final var trackingAccounts = updater.trackingAccounts();
+        if (trackingAccounts.contains(accountID)) {
+            final var accountKey = updater.trackingAccounts().get(accountID, KEY);
+            return EMPTY_KEY.equals(accountKey) ? accountID : null;
+        } else {
+            return null;
+        }
     }
 
     private void finalizeHollowAccountIntoContract(

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/contracts/operation/HederaCallOperation.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/contracts/operation/HederaCallOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2022 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/contracts/operation/HederaCallOperationV032.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/contracts/operation/HederaCallOperationV032.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/HederaStackedWorldStateUpdater.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/HederaStackedWorldStateUpdater.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2022 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -237,6 +237,11 @@ public class HederaStackedWorldStateUpdater
             numAllocatedIds--;
         }
         sbhRefund = 0L;
+    }
+
+    public void reclaimLatestContractId() {
+        worldState.reclaimContractId();
+        numAllocatedIds--;
     }
 
     @Override

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/UpdateTrackingLedgerAccount.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/UpdateTrackingLedgerAccount.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2022 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/contract/helpers/UpdateCustomizerFactory.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/contract/helpers/UpdateCustomizerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2022 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/contract/helpers/UpdateCustomizerFactory.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/contract/helpers/UpdateCustomizerFactory.java
@@ -18,12 +18,14 @@ package com.hedera.node.app.service.mono.txns.contract.helpers;
 import static com.hedera.node.app.service.mono.ledger.accounts.HederaAccountCustomizer.hasStakedId;
 import static com.hedera.node.app.service.mono.sigs.utils.ImmutableKeyUtils.IMMUTABILITY_SENTINEL_KEY;
 import static com.hedera.node.app.service.mono.state.submerkle.EntityId.fromGrpcAccountId;
+import static com.hedera.node.app.service.mono.txns.crypto.validators.CryptoCreateChecks.MAX_CHARGEABLE_AUTO_ASSOCIATIONS;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.CONTRACT_EXPIRED_AND_PENDING_REMOVAL;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.EXPIRATION_REDUCTION_NOT_ALLOWED;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_ADMIN_KEY;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_EXPIRATION_TIME;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.MODIFYING_IMMUTABLE_CONTRACT;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OK;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.REQUESTED_NUM_AUTOMATIC_ASSOCIATIONS_EXCEEDS_ASSOCIATION_LIMIT;
 
 import com.hedera.node.app.service.mono.ledger.accounts.HederaAccountCustomizer;
 import com.hedera.node.app.service.mono.legacy.core.jproto.JContractIDKey;
@@ -100,6 +102,12 @@ public class UpdateCustomizerFactory {
             customizer.autoRenewAccount(fromGrpcAccountId(op.getAutoRenewAccountId()));
         }
         if (op.hasMaxAutomaticTokenAssociations()) {
+            if (op.getMaxAutomaticTokenAssociations().getValue()
+                    > MAX_CHARGEABLE_AUTO_ASSOCIATIONS) {
+                return Pair.of(
+                        Optional.empty(),
+                        REQUESTED_NUM_AUTOMATIC_ASSOCIATIONS_EXCEEDS_ASSOCIATION_LIMIT);
+            }
             customizer.maxAutomaticAssociations(op.getMaxAutomaticTokenAssociations().getValue());
         }
 

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/crypto/CryptoCreateTransitionLogic.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/crypto/CryptoCreateTransitionLogic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2022 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/crypto/CryptoCreateTransitionLogic.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/crypto/CryptoCreateTransitionLogic.java
@@ -16,6 +16,7 @@
 package com.hedera.node.app.service.mono.txns.crypto;
 
 import static com.hedera.node.app.service.evm.utils.EthSigsUtils.recoverAddressFromPubKey;
+import static com.hedera.node.app.service.mono.context.BasicTransactionContext.EMPTY_KEY;
 import static com.hedera.node.app.service.mono.ledger.accounts.HederaAccountCustomizer.hasStakedId;
 import static com.hedera.node.app.service.mono.ledger.properties.AccountProperty.BALANCE;
 import static com.hedera.node.app.service.mono.txns.crypto.validators.CryptoCreateChecks.aliasAndEvmAddressProvided;
@@ -210,6 +211,7 @@ public class CryptoCreateTransitionLogic implements TransitionLogic {
             customizer.key(key);
         } else if (onlyEvmAddressProvided(op)) {
             customizer.alias(op.getEvmAddress());
+            customizer.key(EMPTY_KEY);
         } else if (onlyAliasProvided(op)) {
             populateKeyAndAliasInCaseOfAliasOrAliasAndEvmAddressProvided(op, customizer);
         } else if (keyAndAliasProvided(op)) {

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/crypto/validators/CryptoCreateChecks.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/crypto/validators/CryptoCreateChecks.java
@@ -55,7 +55,7 @@ import javax.inject.Singleton;
 
 @Singleton
 public class CryptoCreateChecks {
-    static final int MAX_CHARGEABLE_AUTO_ASSOCIATIONS = 5000;
+    public static final int MAX_CHARGEABLE_AUTO_ASSOCIATIONS = 5000;
     private final GlobalDynamicProperties dynamicProperties;
     private final OptionValidator validator;
     private final Supplier<AccountStorageAdapter> accounts;

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/crypto/validators/CryptoCreateChecks.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/crypto/validators/CryptoCreateChecks.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/submission/SolvencyPrecheck.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/submission/SolvencyPrecheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2022 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/contracts/ContractsV032ModuleTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/contracts/ContractsV032ModuleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/contracts/operation/AbstractRecordingCreateOperationTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/contracts/operation/AbstractRecordingCreateOperationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,8 +15,13 @@
  */
 package com.hedera.node.app.service.mono.contracts.operation;
 
+import static com.hedera.node.app.service.mono.context.BasicTransactionContext.EMPTY_KEY;
 import static com.hedera.node.app.service.mono.contracts.operation.AbstractRecordingCreateOperation.haltWith;
+import static com.hedera.node.app.service.mono.ledger.properties.AccountProperty.ETHEREUM_NONCE;
+import static com.hedera.node.app.service.mono.ledger.properties.AccountProperty.IS_SMART_CONTRACT;
+import static com.hedera.node.app.service.mono.ledger.properties.AccountProperty.KEY;
 import static com.hedera.node.app.service.mono.state.EntityCreator.EMPTY_MEMO;
+import static com.hedera.node.app.service.mono.txns.contract.ContractCreateTransitionLogic.STANDIN_CONTRACT_ID_KEY;
 import static org.hyperledger.besu.evm.frame.ExceptionalHaltReason.ILLEGAL_STATE_CHANGE;
 import static org.hyperledger.besu.evm.frame.ExceptionalHaltReason.INSUFFICIENT_GAS;
 import static org.junit.jupiter.api.Assertions.*;
@@ -24,22 +29,32 @@ import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
 
+import com.google.protobuf.ByteString;
 import com.hedera.node.app.service.mono.context.SideEffectsTracker;
 import com.hedera.node.app.service.mono.context.properties.GlobalDynamicProperties;
+import com.hedera.node.app.service.mono.ledger.TransactionalLedger;
+import com.hedera.node.app.service.mono.ledger.accounts.ContractAliases;
 import com.hedera.node.app.service.mono.ledger.accounts.ContractCustomizer;
+import com.hedera.node.app.service.mono.ledger.properties.AccountProperty;
+import com.hedera.node.app.service.mono.legacy.core.jproto.JKey;
 import com.hedera.node.app.service.mono.legacy.core.jproto.TxnReceipt;
 import com.hedera.node.app.service.mono.records.RecordsHistorian;
 import com.hedera.node.app.service.mono.state.EntityCreator;
+import com.hedera.node.app.service.mono.state.migration.HederaAccount;
 import com.hedera.node.app.service.mono.state.submerkle.EntityId;
 import com.hedera.node.app.service.mono.state.submerkle.ExpirableTxnRecord;
 import com.hedera.node.app.service.mono.store.contracts.HederaStackedWorldStateUpdater;
 import com.hedera.node.app.service.mono.store.contracts.precompile.SyntheticTxnFactory;
+import com.hedera.node.app.service.mono.utils.EntityIdUtils;
+import com.hedera.node.app.service.mono.utils.MiscUtils;
 import com.hedera.node.app.service.mono.utils.SidecarUtils;
 import com.hedera.services.stream.proto.SidecarType;
 import com.hedera.services.stream.proto.TransactionSidecarRecord;
 import com.hedera.test.utils.IdUtils;
+import com.hederahashgraph.api.proto.java.AccountID;
 import com.hederahashgraph.api.proto.java.ContractCreateTransactionBody;
 import com.hederahashgraph.api.proto.java.ContractID;
+import com.hederahashgraph.api.proto.java.Key;
 import com.hederahashgraph.api.proto.java.Timestamp;
 import com.hederahashgraph.api.proto.java.TransactionBody;
 import java.util.Collections;
@@ -82,6 +97,8 @@ class AbstractRecordingCreateOperationTest {
     @Mock private RecordsHistorian recordsHistorian;
     @Mock private ContractCustomizer contractCustomizer;
     @Mock private GlobalDynamicProperties dynamicProperties;
+    @Mock private ContractAliases aliases;
+    @Mock private TransactionalLedger<AccountID, AccountProperty, HederaAccount> accounts;
 
     private static final long childStipend = 1_000_000L;
     private static final Wei gasPrice = Wei.of(1000L);
@@ -92,6 +109,13 @@ class AbstractRecordingCreateOperationTest {
             new Operation.OperationResult(Subject.PRETEND_COST, null);
     private static final EntityId autoRenewId = new EntityId(0, 0, 8);
 
+    private static final JKey nonEmptyKey =
+            MiscUtils.asFcKeyUnchecked(
+                    Key.newBuilder()
+                            .setEd25519(
+                                    ByteString.copyFrom(
+                                            "01234567890123456789012345678901".getBytes()))
+                            .build());
     private Subject subject;
 
     @BeforeEach
@@ -185,10 +209,11 @@ class AbstractRecordingCreateOperationTest {
         final var frameCaptor = ArgumentCaptor.forClass(MessageFrame.class);
         givenSpawnPrereqs();
         givenBuilderPrereqs();
+        givenUpdaterWithAliases(EntityIdUtils.parseAccount("0.0.1234"), nonEmptyKey);
         given(updater.customizerForPendingCreation()).willReturn(contractCustomizer);
+        given(updater.idOfLastNewAddress()).willReturn(lastAllocated);
         given(syntheticTxnFactory.contractCreation(contractCustomizer)).willReturn(mockCreation);
         given(creator.createSuccessfulSyntheticRecord(any(), any(), any())).willReturn(liveRecord);
-        given(updater.idOfLastNewAddress()).willReturn(lastAllocated);
         final var initCode = "initCode".getBytes();
         given(frame.readMemory(anyLong(), anyLong())).willReturn(Bytes.wrap(initCode));
         final var newContractMock = mock(Account.class);
@@ -251,10 +276,11 @@ class AbstractRecordingCreateOperationTest {
         final var frameCaptor = ArgumentCaptor.forClass(MessageFrame.class);
         givenSpawnPrereqs();
         givenBuilderPrereqs();
+        givenUpdaterWithAliases(EntityIdUtils.parseAccount("0.0.1234"), nonEmptyKey);
         given(updater.customizerForPendingCreation()).willReturn(contractCustomizer);
+        given(updater.idOfLastNewAddress()).willReturn(lastAllocated);
         given(syntheticTxnFactory.contractCreation(contractCustomizer)).willReturn(mockCreation);
         given(creator.createSuccessfulSyntheticRecord(any(), any(), any())).willReturn(liveRecord);
-        given(updater.idOfLastNewAddress()).willReturn(lastAllocated);
         given(dynamicProperties.enabledSidecars()).willReturn(Set.of());
 
         assertSameResult(EMPTY_HALT_RESULT, subject.execute(frame, evm));
@@ -284,10 +310,139 @@ class AbstractRecordingCreateOperationTest {
     }
 
     @Test
+    void hasExpectedHollowAccountCompletionOnSuccessWithSidecarEnabled() {
+        final var trackerCaptor = ArgumentCaptor.forClass(SideEffectsTracker.class);
+        final var liveRecord =
+                ExpirableTxnRecord.newBuilder()
+                        .setReceiptBuilder(
+                                TxnReceipt.newBuilder()
+                                        .setStatus(TxnReceipt.REVERTED_SUCCESS_LITERAL));
+        final var mockCreation =
+                TransactionBody.newBuilder()
+                        .setContractCreateInstance(
+                                ContractCreateTransactionBody.newBuilder()
+                                        .setAutoRenewAccountId(autoRenewId.toGrpcAccountId()));
+        final var frameCaptor = ArgumentCaptor.forClass(MessageFrame.class);
+        givenSpawnPrereqs();
+        givenBuilderPrereqs();
+        given(dynamicProperties.isLazyCreationEnabled()).willReturn(true);
+        final var hollowAccountId = EntityIdUtils.parseAccount("0.0.5678");
+        givenUpdaterWithAliases(hollowAccountId, EMPTY_KEY);
+        given(updater.customizerForPendingCreation()).willReturn(contractCustomizer);
+        given(syntheticTxnFactory.contractCreation(contractCustomizer)).willReturn(mockCreation);
+        given(creator.createSuccessfulSyntheticRecord(any(), any(), any())).willReturn(liveRecord);
+        final var initCode = "initCode".getBytes();
+        given(frame.readMemory(anyLong(), anyLong())).willReturn(Bytes.wrap(initCode));
+        final var newContractMock = mock(Account.class);
+        final var runtimeCode = "runtimeCode".getBytes();
+        given(newContractMock.getCode()).willReturn(Bytes.of(runtimeCode));
+        given(updater.get(Subject.PRETEND_CONTRACT_ADDRESS)).willReturn(newContractMock);
+        final var sidecarRecord =
+                TransactionSidecarRecord.newBuilder()
+                        .setConsensusTimestamp(Timestamp.newBuilder().setSeconds(666L).build());
+        final var sidecarUtilsMockedStatic = mockStatic(SidecarUtils.class);
+        sidecarUtilsMockedStatic
+                .when(
+                        () ->
+                                SidecarUtils.createContractBytecodeSidecarFrom(
+                                        EntityIdUtils.asContract(hollowAccountId),
+                                        initCode,
+                                        runtimeCode))
+                .thenReturn(sidecarRecord);
+        given(dynamicProperties.enabledSidecars())
+                .willReturn(Set.of(SidecarType.CONTRACT_BYTECODE));
+
+        assertSameResult(EMPTY_HALT_RESULT, subject.execute(frame, evm));
+
+        verify(stack).addFirst(frameCaptor.capture());
+        final var childFrame = frameCaptor.getValue();
+        // when:
+        childFrame.setState(MessageFrame.State.COMPLETED_SUCCESS);
+        childFrame.notifyCompletion();
+        // then:
+        verify(frame).pushStackItem(Words.fromAddress(Subject.PRETEND_CONTRACT_ADDRESS));
+        verify(creator)
+                .createSuccessfulSyntheticRecord(
+                        eq(Collections.emptyList()), trackerCaptor.capture(), eq(EMPTY_MEMO));
+        verify(updater).reclaimLatestContractId();
+        verify(updater.trackingAccounts()).set(hollowAccountId, IS_SMART_CONTRACT, true);
+        verify(updater.trackingAccounts()).set(hollowAccountId, KEY, STANDIN_CONTRACT_ID_KEY);
+        verify(updater.trackingAccounts()).set(hollowAccountId, ETHEREUM_NONCE, 1L);
+        verify(updater)
+                .manageInProgressRecord(
+                        recordsHistorian, liveRecord, mockCreation, List.of(sidecarRecord));
+        // and:
+        final var tracker = trackerCaptor.getValue();
+        assertTrue(tracker.hasTrackedContractCreation());
+        assertEquals(EntityIdUtils.asContract(hollowAccountId), tracker.getTrackedNewContractId());
+        assertArrayEquals(
+                Subject.PRETEND_CONTRACT_ADDRESS.toArrayUnsafe(),
+                tracker.getNewEntityAlias().toByteArray());
+        // and:
+        assertTrue(liveRecord.shouldNotBeExternalized());
+        sidecarUtilsMockedStatic.close();
+    }
+
+    @Test
+    void hasExpectedHollowAccountCompletionOnSuccessWithoutSidecarEnabled() {
+        final var trackerCaptor = ArgumentCaptor.forClass(SideEffectsTracker.class);
+        final var liveRecord =
+                ExpirableTxnRecord.newBuilder()
+                        .setReceiptBuilder(
+                                TxnReceipt.newBuilder()
+                                        .setStatus(TxnReceipt.REVERTED_SUCCESS_LITERAL));
+        final var mockCreation =
+                TransactionBody.newBuilder()
+                        .setContractCreateInstance(
+                                ContractCreateTransactionBody.newBuilder()
+                                        .setAutoRenewAccountId(autoRenewId.toGrpcAccountId()));
+        final var frameCaptor = ArgumentCaptor.forClass(MessageFrame.class);
+        givenSpawnPrereqs();
+        givenBuilderPrereqs();
+        given(dynamicProperties.isLazyCreationEnabled()).willReturn(true);
+        final var hollowAccountId = EntityIdUtils.parseAccount("0.0.5678");
+        givenUpdaterWithAliases(hollowAccountId, EMPTY_KEY);
+        given(updater.customizerForPendingCreation()).willReturn(contractCustomizer);
+        given(syntheticTxnFactory.contractCreation(contractCustomizer)).willReturn(mockCreation);
+        given(creator.createSuccessfulSyntheticRecord(any(), any(), any())).willReturn(liveRecord);
+        given(dynamicProperties.enabledSidecars()).willReturn(Set.of());
+
+        assertSameResult(EMPTY_HALT_RESULT, subject.execute(frame, evm));
+
+        verify(stack).addFirst(frameCaptor.capture());
+        final var childFrame = frameCaptor.getValue();
+        // when:
+        childFrame.setState(MessageFrame.State.COMPLETED_SUCCESS);
+        childFrame.notifyCompletion();
+        // then:
+        verify(frame).pushStackItem(Words.fromAddress(Subject.PRETEND_CONTRACT_ADDRESS));
+        verify(creator)
+                .createSuccessfulSyntheticRecord(
+                        eq(Collections.emptyList()), trackerCaptor.capture(), eq(EMPTY_MEMO));
+        verify(updater).reclaimLatestContractId();
+        verify(updater.trackingAccounts()).set(hollowAccountId, IS_SMART_CONTRACT, true);
+        verify(updater.trackingAccounts()).set(hollowAccountId, KEY, STANDIN_CONTRACT_ID_KEY);
+        verify(updater.trackingAccounts()).set(hollowAccountId, ETHEREUM_NONCE, 1L);
+        verify(updater)
+                .manageInProgressRecord(
+                        recordsHistorian, liveRecord, mockCreation, Collections.emptyList());
+        // and:
+        final var tracker = trackerCaptor.getValue();
+        assertTrue(tracker.hasTrackedContractCreation());
+        assertEquals(EntityIdUtils.asContract(hollowAccountId), tracker.getTrackedNewContractId());
+        assertArrayEquals(
+                Subject.PRETEND_CONTRACT_ADDRESS.toArrayUnsafe(),
+                tracker.getNewEntityAlias().toByteArray());
+        // and:
+        assertTrue(liveRecord.shouldNotBeExternalized());
+    }
+
+    @Test
     void hasExpectedChildCompletionOnFailure() {
         final var captor = ArgumentCaptor.forClass(MessageFrame.class);
         givenSpawnPrereqs();
         givenBuilderPrereqs();
+        givenUpdaterWithAliases(EntityIdUtils.parseAccount("0.0.1234"), nonEmptyKey);
 
         assertSameResult(EMPTY_HALT_RESULT, subject.execute(frame, evm));
 
@@ -296,6 +451,28 @@ class AbstractRecordingCreateOperationTest {
         // when:
         childFrame.setState(MessageFrame.State.COMPLETED_FAILED);
         childFrame.notifyCompletion();
+        verify(frame).pushStackItem(UInt256.ZERO);
+    }
+
+    @Test
+    void failsWhenMatchingHollowAccountExistsAndLazyCreationDisabled() {
+        given(frame.stackSize()).willReturn(3);
+        given(frame.getRemainingGas()).willReturn(Subject.PRETEND_GAS_COST);
+        given(frame.getStackItem(0)).willReturn(Bytes.ofUnsignedLong(value));
+        given(frame.getRecipientAddress()).willReturn(recipient);
+        given(frame.getWorldUpdater()).willReturn(updater);
+        given(updater.getAccount(recipient)).willReturn(recipientAccount);
+        given(recipientAccount.getMutable()).willReturn(mutableAccount);
+        given(mutableAccount.getBalance()).willReturn(Wei.of(value));
+        given(frame.getMessageStackDepth()).willReturn(1023);
+        given(frame.getStackItem(anyInt())).willReturn(Bytes.ofUnsignedLong(1));
+        final var hollowAccountId = EntityIdUtils.parseAccount("0.0.5678");
+        givenUpdaterWithAliases(hollowAccountId, EMPTY_KEY);
+
+        subject.execute(frame, evm);
+
+        verify(frame).readMutableMemory(1L, 1L);
+        verify(frame).popStackItems(3);
         verify(frame).pushStackItem(UInt256.ZERO);
     }
 
@@ -321,6 +498,15 @@ class AbstractRecordingCreateOperationTest {
         given(recipientAccount.getMutable()).willReturn(mutableAccount);
         given(mutableAccount.getBalance()).willReturn(Wei.of(value));
         given(frame.getMessageStackDepth()).willReturn(1023);
+    }
+
+    private void givenUpdaterWithAliases(
+            final AccountID expectedAccountId, final JKey expectedKey) {
+        given(updater.aliases()).willReturn(aliases);
+        given(aliases.resolveForEvm(any()))
+                .willReturn(EntityIdUtils.asTypedEvmAddress(expectedAccountId));
+        given(updater.trackingAccounts()).willReturn(accounts);
+        given(accounts.get(expectedAccountId, AccountProperty.KEY)).willReturn(expectedKey);
     }
 
     private void assertSameResult(

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/contracts/operation/AbstractRecordingCreateOperationTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/contracts/operation/AbstractRecordingCreateOperationTest.java
@@ -438,6 +438,34 @@ class AbstractRecordingCreateOperationTest {
     }
 
     @Test
+    void hasExpectedHollowAccountCompletionWithoutLazyCreationEnabled() {
+        given(frame.stackSize()).willReturn(3);
+        given(frame.getStackItem(anyInt())).willReturn(Bytes.ofUnsignedLong(1));
+        given(frame.getRemainingGas()).willReturn(Subject.PRETEND_GAS_COST);
+        given(frame.getRecipientAddress()).willReturn(recipient);
+        given(frame.getWorldUpdater()).willReturn(updater);
+        given(updater.getAccount(recipient)).willReturn(recipientAccount);
+        given(recipientAccount.getMutable()).willReturn(mutableAccount);
+        given(mutableAccount.getBalance()).willReturn(Wei.of(value));
+        given(frame.getMessageFrameStack()).willReturn(stack);
+        given(updater.updater()).willReturn(updater);
+        given(frame.getOriginatorAddress()).willReturn(recipient);
+        given(frame.getGasPrice()).willReturn(gasPrice);
+        given(frame.getBlockValues()).willReturn(blockValues);
+        given(frame.getMiningBeneficiary()).willReturn(recipient);
+        given(frame.getBlockHashLookup()).willReturn(l -> Hash.ZERO);
+        given(dynamicProperties.isLazyCreationEnabled()).willReturn(false);
+        final var hollowAccountId = EntityIdUtils.parseAccount("0.0.5678");
+        given(updater.aliases()).willReturn(aliases);
+        given(aliases.resolveForEvm(any()))
+                .willReturn(EntityIdUtils.asTypedEvmAddress(hollowAccountId));
+        given(updater.trackingAccounts()).willReturn(accounts);
+        given(accounts.contains(hollowAccountId)).willReturn(false);
+
+        assertSameResult(EMPTY_HALT_RESULT, subject.execute(frame, evm));
+    }
+
+    @Test
     void hasExpectedChildCompletionOnFailure() {
         final var captor = ArgumentCaptor.forClass(MessageFrame.class);
         givenSpawnPrereqs();
@@ -506,6 +534,7 @@ class AbstractRecordingCreateOperationTest {
         given(aliases.resolveForEvm(any()))
                 .willReturn(EntityIdUtils.asTypedEvmAddress(expectedAccountId));
         given(updater.trackingAccounts()).willReturn(accounts);
+        given(accounts.contains(expectedAccountId)).willReturn((expectedKey != null));
         given(accounts.get(expectedAccountId, AccountProperty.KEY)).willReturn(expectedKey);
     }
 

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/contracts/operation/HederaCallOperationTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/contracts/operation/HederaCallOperationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2022 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/contracts/operation/HederaCallOperationV032Test.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/contracts/operation/HederaCallOperationV032Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/HederaStackedWorldStateUpdaterTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/HederaStackedWorldStateUpdaterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2022 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -359,6 +359,13 @@ class HederaStackedWorldStateUpdaterTest {
         subject.revert();
         assertEquals(0L, subject.getSbhRefund());
         verify(worldState, times(3)).reclaimContractId();
+    }
+
+    @Test
+    void reclaimLatestContractIdBehavesAsExpected() {
+        subject.countIdsAllocatedByStacked(1);
+        subject.reclaimLatestContractId();
+        verify(worldState, times(1)).reclaimContractId();
     }
 
     @Test

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/contract/helpers/UpdateCustomizerFactoryTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/contract/helpers/UpdateCustomizerFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2022 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/contract/helpers/UpdateCustomizerFactoryTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/contract/helpers/UpdateCustomizerFactoryTest.java
@@ -21,6 +21,7 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.EXPIRATION_RED
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_ADMIN_KEY;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_EXPIRATION_TIME;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.MODIFYING_IMMUTABLE_CONTRACT;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.REQUESTED_NUM_AUTOMATIC_ASSOCIATIONS_EXCEEDS_ASSOCIATION_LIMIT;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -33,6 +34,7 @@ import com.google.protobuf.StringValue;
 import com.hedera.node.app.service.mono.legacy.core.jproto.JContractIDKey;
 import com.hedera.node.app.service.mono.sigs.utils.ImmutableKeyUtils;
 import com.hedera.node.app.service.mono.state.merkle.MerkleAccount;
+import com.hedera.node.app.service.mono.txns.crypto.validators.CryptoCreateChecks;
 import com.hedera.node.app.service.mono.txns.validation.OptionValidator;
 import com.hedera.node.app.service.mono.utils.MiscUtils;
 import com.hedera.test.factories.accounts.MerkleAccountFactory;
@@ -339,5 +341,31 @@ class UpdateCustomizerFactoryTest {
                                         StringValue.newBuilder()
                                                 .setValue("Interesting to see you here!"))
                                 .build()));
+    }
+
+    @Test
+    void rejectsExcessAutoAssociations() {
+        // given:
+        var mutableContract =
+                MerkleAccountFactory.newContract()
+                        .accountKeys(MISC_ADMIN_KT.asJKeyUnchecked())
+                        .get();
+        // and:
+        var op =
+                ContractUpdateTransactionBody.newBuilder()
+                        .setMaxAutomaticTokenAssociations(
+                                Int32Value.newBuilder()
+                                        .setValue(
+                                                CryptoCreateChecks.MAX_CHARGEABLE_AUTO_ASSOCIATIONS
+                                                        + 1))
+                        .build();
+
+        // when:
+        var result = subject.customizerFor(mutableContract, optionValidator, op);
+
+        // then:
+        assertTrue(result.getLeft().isEmpty());
+        assertEquals(
+                REQUESTED_NUM_AUTOMATIC_ASSOCIATIONS_EXCEEDS_ASSOCIATION_LIMIT, result.getRight());
     }
 }

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/crypto/CryptoCreateTransitionLogicTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/crypto/CryptoCreateTransitionLogicTest.java
@@ -15,6 +15,7 @@
  */
 package com.hedera.node.app.service.mono.txns.crypto;
 
+import static com.hedera.node.app.service.mono.context.BasicTransactionContext.EMPTY_KEY;
 import static com.hedera.node.app.service.mono.ledger.properties.AccountProperty.AUTO_RENEW_PERIOD;
 import static com.hedera.node.app.service.mono.ledger.properties.AccountProperty.DECLINE_REWARD;
 import static com.hedera.node.app.service.mono.ledger.properties.AccountProperty.EXPIRY;
@@ -988,7 +989,7 @@ class CryptoCreateTransitionLogicTest {
     }
 
     @Test
-    void followsHappyPathEVMAddress() {
+    void followsHappyPathEVMAddress() throws DecoderException {
         final var captor = ArgumentCaptor.forClass(HederaAccountCustomizer.class);
         final var opBuilder =
                 CryptoCreateTransactionBody.newBuilder()
@@ -1024,10 +1025,11 @@ class CryptoCreateTransitionLogicTest {
         verify(sigImpactHistorian).markEntityChanged(CREATED.getAccountNum());
 
         final var changes = captor.getValue().getChanges();
-        assertEquals(7, changes.size());
+        assertEquals(8, changes.size());
         assertEquals(0, (long) changes.get(AUTO_RENEW_PERIOD));
         assertEquals(txnCtx.consensusTime().getEpochSecond(), (long) changes.get(EXPIRY));
         assertEquals(ByteString.copyFrom(EVM_ADDRESS_BYTES), changes.get(AccountProperty.ALIAS));
+        assertEquals(EMPTY_KEY, changes.get(AccountProperty.KEY));
         assertEquals(false, changes.get(IS_RECEIVER_SIG_REQUIRED));
         assertEquals(MEMO, changes.get(AccountProperty.MEMO));
         assertEquals(MAX_AUTO_ASSOCIATIONS, changes.get(MAX_AUTOMATIC_ASSOCIATIONS));

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/crypto/CryptoCreateTransitionLogicTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/crypto/CryptoCreateTransitionLogicTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2022 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-clients/src/main/java/com/hedera/services/bdd/spec/assertions/ContractInfoAsserts.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/spec/assertions/ContractInfoAsserts.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2022 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
  */
 package com.hedera.services.bdd.spec.assertions;
 
+import static com.hedera.services.bdd.suites.HapiSuite.STANDIN_CONTRACT_ID_KEY;
 import static com.hederahashgraph.api.proto.java.ContractGetInfoResponse.ContractInfo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -271,6 +272,16 @@ public class ContractInfoAsserts extends BaseErroringAssertsProvider<ContractInf
                     Key expectedKey = spec.registry().getKey(expectedKeyName);
                     assertEquals(expectedKey, object2ContractInfo(o).getAdminKey(), BAD_ADMIN_KEY);
                 });
+        return this;
+    }
+
+    public ContractInfoAsserts hasStandinContractKey() {
+        registerProvider(
+                (spec, o) ->
+                        assertEquals(
+                                STANDIN_CONTRACT_ID_KEY,
+                                object2ContractInfo(o).getAdminKey(),
+                                BAD_ADMIN_KEY));
         return this;
     }
 

--- a/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/QueryVerbs.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/QueryVerbs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2022 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/crypto/HapiGetAccountBalance.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/crypto/HapiGetAccountBalance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2022 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/crypto/HapiGetAccountInfo.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/crypto/HapiGetAccountInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2022 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/crypto/ReferenceType.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/crypto/ReferenceType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2022 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-clients/src/main/java/com/hedera/services/bdd/spec/verification/traceability/SidecarWatcher.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/spec/verification/traceability/SidecarWatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -65,7 +65,8 @@ public class SidecarWatcher {
                                 retryCount++;
                                 try {
                                     final var sidecarFile =
-                                            RecordStreamingUtils.readSidecarFile(newFilePath);
+                                            RecordStreamingUtils.readMaybeCompressedSidecarFile(
+                                                    newFilePath);
                                     onNewSidecarFile(sidecarFile);
                                     return;
                                 } catch (IOException e) {

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/HapiSuite.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/HapiSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2022 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ import com.hedera.services.bdd.spec.HapiSpecOperation;
 import com.hedera.services.bdd.spec.HapiSpecSetup;
 import com.hedera.services.bdd.spec.infrastructure.HapiApiClients;
 import com.hedera.services.bdd.spec.keys.KeyShape;
+import com.hederahashgraph.api.proto.java.ContractID;
 import com.hederahashgraph.api.proto.java.Key;
 import com.hederahashgraph.api.proto.java.KeyList;
 import java.math.BigInteger;
@@ -58,6 +59,10 @@ public abstract class HapiSuite {
     public static final Key EMPTY_KEY =
             Key.newBuilder().setKeyList(KeyList.newBuilder().build()).build();
 
+    public static final Key STANDIN_CONTRACT_ID_KEY =
+            Key.newBuilder()
+                    .setContractID(ContractID.newBuilder().setContractNum(0).build())
+                    .build();
     private static final int BYTES_PER_KB = 1024;
     public static final int MAX_CALL_DATA_SIZE = 6 * BYTES_PER_KB;
     public static final BigInteger WEIBARS_TO_TINYBARS = BigInteger.valueOf(10_000_000_000L);

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/opcodes/Create2OperationSuite.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/opcodes/Create2OperationSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,8 +35,8 @@ import static com.hedera.services.bdd.spec.queries.QueryVerbs.getAccountInfo;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getAliasedContractBalance;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getContractBytecode;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getContractInfo;
-import static com.hedera.services.bdd.spec.queries.QueryVerbs.getLiteralAliasAccountInfo;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getTxnRecord;
+import static com.hedera.services.bdd.spec.queries.crypto.ExpectedTokenRel.relationshipWith;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.contractCall;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.contractCallWithFunctionAbi;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.contractCreate;
@@ -66,6 +66,14 @@ import static com.hedera.services.bdd.suites.contract.Utils.aliasDelegateContrac
 import static com.hedera.services.bdd.suites.contract.Utils.asAddress;
 import static com.hedera.services.bdd.suites.contract.Utils.captureOneChildCreate2MetaFor;
 import static com.hedera.services.bdd.suites.contract.Utils.getABIFor;
+import static com.hedera.services.bdd.suites.contract.Utils.ocWith;
+import static com.hedera.services.bdd.suites.crypto.AutoAccountCreationSuite.A_TOKEN;
+import static com.hedera.services.bdd.suites.crypto.AutoAccountCreationSuite.LAZY_MEMO;
+import static com.hedera.services.bdd.suites.crypto.AutoAccountCreationSuite.NFT_CREATE;
+import static com.hedera.services.bdd.suites.crypto.AutoAccountCreationSuite.NFT_INFINITE_SUPPLY_TOKEN;
+import static com.hedera.services.bdd.suites.crypto.AutoAccountCreationSuite.PARTY;
+import static com.hedera.services.bdd.suites.crypto.AutoAccountCreationSuite.TOKEN_A_CREATE;
+import static com.hedera.services.bdd.suites.token.TokenAssociationSpecs.MULTI_KEY;
 import static com.hedera.services.bdd.suites.utils.contracts.precompile.HTSPrecompileResult.htsPrecompileResult;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.ACCOUNT_STILL_OWNS_NFTS;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.CONTRACT_DELETED;
@@ -77,6 +85,7 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OBTAINER_SAME_
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.REVERTED_SUCCESS;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SUCCESS;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TRANSACTION_REQUIRES_ZERO_TOKEN_BALANCES;
+import static com.hederahashgraph.api.proto.java.TokenSupplyType.FINITE;
 import static com.hederahashgraph.api.proto.java.TokenType.FUNGIBLE_COMMON;
 import static com.hederahashgraph.api.proto.java.TokenType.NON_FUNGIBLE_UNIQUE;
 import static com.swirlds.common.utility.CommonUtils.hex;
@@ -94,9 +103,13 @@ import com.hedera.services.bdd.spec.HapiSpec;
 import com.hedera.services.bdd.spec.HapiSpecOperation;
 import com.hedera.services.bdd.spec.transactions.contract.HapiParserUtil;
 import com.hedera.services.bdd.suites.HapiSuite;
+import com.hederahashgraph.api.proto.java.AccountID;
 import com.hederahashgraph.api.proto.java.ContractID;
 import com.hederahashgraph.api.proto.java.NftTransfer;
+import com.hederahashgraph.api.proto.java.TokenID;
+import com.hederahashgraph.api.proto.java.TokenSupplyType;
 import com.hederahashgraph.api.proto.java.TokenTransferList;
+import com.hederahashgraph.api.proto.java.TokenType;
 import com.hederahashgraph.api.proto.java.TransferList;
 import com.swirlds.common.utility.CommonUtils;
 import java.math.BigInteger;
@@ -112,19 +125,24 @@ public class Create2OperationSuite extends HapiSuite {
 
     private static final Logger LOG = LogManager.getLogger(Create2OperationSuite.class);
     private static final String CREATION = "creation";
-    private static final String GET_BYTECODE = "getBytecode";
-    private static final String DEPLOY = "deploy";
+    public static final String GET_BYTECODE = "getBytecode";
+    public static final String DEPLOY = "deploy";
     private static final String CREATE_2_TXN = "create2Txn";
     private static final String SWISS = "swiss";
-    private static final String SALT =
+    public static final String SALT =
             "aabbccddeeff0011aabbccddeeff0011aabbccddeeff0011aabbccddeeff0011";
     private static final String RETURNER = "Returner";
     private static final String CALL_RETURNER = "callReturner";
-    private static final String RETURNER_REPORTED_LOG_MESSAGE =
+    public static final String RETURNER_REPORTED_LOG_MESSAGE =
             "Returner reported {} when called with mirror address";
-    private static final String CONTRACT_REPORTED_LOG_MESSAGE =
+    public static final String CONTRACT_REPORTED_LOG_MESSAGE =
             "Contract reported TestContract initcode is {} bytes";
-    public static final String ADMIN_KEY = "adminKey";
+    public static final String CONTRACT_REPORTED_ADDRESS_MESSAGE =
+            "Contract reported address results {}";
+    public static final String EXPECTED_CREATE2_ADDRESS_MESSAGE =
+            "  --> Expected CREATE2 address is {}";
+    private static final String ADMIN_KEY = "adminKey";
+    public static final String GET_ADDRESS = "getAddress";
 
     public static void main(String... args) {
         new Create2OperationSuite().runSuiteSync();
@@ -144,7 +162,7 @@ public class Create2OperationSuite extends HapiSuite {
     public List<HapiSpec> getSpecsInSuite() {
         return List.of(
                 create2FactoryWorksAsExpected(),
-                canBlockCreate2ChildWithHollowAccount(),
+                canMergeCreate2ChildWithHollowAccount(),
                 canDeleteViaAlias(),
                 cannotSelfDestructToMirrorAddress(),
                 priorityAddressIsCreate2ForStaticHapiCalls(),
@@ -452,14 +470,13 @@ public class Create2OperationSuite extends HapiSuite {
                                 () ->
                                         contractCallLocal(
                                                         contract,
-                                                        "getAddress",
+                                                        GET_ADDRESS,
                                                         testContractInitcode.get(),
                                                         salt)
                                                 .exposingTypedResultsTo(
                                                         results -> {
                                                             LOG.info(
-                                                                    "Contract reported address"
-                                                                            + " results {}",
+                                                                    CONTRACT_REPORTED_ADDRESS_MESSAGE,
                                                                     results);
                                                             final var expectedAddrBytes =
                                                                     (Address) results[0];
@@ -470,8 +487,7 @@ public class Create2OperationSuite extends HapiSuite {
                                                                                                     .toString())
                                                                                     .toArray());
                                                             LOG.info(
-                                                                    "  --> Expected CREATE2 address"
-                                                                            + " is {}",
+                                                                    EXPECTED_CREATE2_ADDRESS_MESSAGE,
                                                                     hexedAddress);
                                                             expectedCreate2Address.set(
                                                                     hexedAddress);
@@ -639,25 +655,30 @@ public class Create2OperationSuite extends HapiSuite {
     }
 
     @SuppressWarnings("java:S5960")
-    private HapiSpec canBlockCreate2ChildWithHollowAccount() {
+    private HapiSpec canMergeCreate2ChildWithHollowAccount() {
         final var tcValue = 1_234L;
         final var contract = "Create2Factory";
         final var creation = CREATION;
         final var salt = BigInteger.valueOf(42);
         final var adminKey = ADMIN_KEY;
-        final var replAdminKey = "replAdminKey";
         final var entityMemo = "JUST DO IT";
         final AtomicReference<String> factoryEvmAddress = new AtomicReference<>();
         final AtomicReference<String> expectedCreate2Address = new AtomicReference<>();
         final AtomicReference<String> hollowCreationAddress = new AtomicReference<>();
-        final AtomicReference<String> blockedAliasAddr = new AtomicReference<>();
-        final AtomicReference<String> blockedMirrorAddr = new AtomicReference<>();
+        final AtomicReference<String> mergedAliasAddr = new AtomicReference<>();
+        final AtomicReference<String> mergedMirrorAddr = new AtomicReference<>();
         final AtomicReference<byte[]> testContractInitcode = new AtomicReference<>();
 
-        return defaultHapiSpec("CanBlockCreate2ChildWithHollowAccount")
+        final var initialTokenSupply = 1000;
+        final AtomicReference<TokenID> ftId = new AtomicReference<>();
+        final AtomicReference<TokenID> nftId = new AtomicReference<>();
+        final AtomicReference<AccountID> partyId = new AtomicReference<>();
+        final AtomicReference<ByteString> partyAlias = new AtomicReference<>();
+
+        return defaultHapiSpec("CanMergeCreate2ChildWithHollowAccount")
                 .given(
                         newKeyNamed(adminKey),
-                        newKeyNamed(replAdminKey),
+                        newKeyNamed(MULTI_KEY),
                         uploadInitCode(contract),
                         contractCreate(contract)
                                 .payingWith(GENESIS)
@@ -667,7 +688,37 @@ public class Create2OperationSuite extends HapiSuite {
                                 .exposingNumTo(
                                         num ->
                                                 factoryEvmAddress.set(
-                                                        asHexedSolidityAddress(0, 0, num))))
+                                                        asHexedSolidityAddress(0, 0, num))),
+                        cryptoCreate(PARTY).maxAutomaticTokenAssociations(2),
+                        tokenCreate(A_TOKEN)
+                                .tokenType(FUNGIBLE_COMMON)
+                                .supplyType(FINITE)
+                                .initialSupply(initialTokenSupply)
+                                .maxSupply(10L * initialTokenSupply)
+                                .treasury(PARTY)
+                                .via(TOKEN_A_CREATE),
+                        tokenCreate(NFT_INFINITE_SUPPLY_TOKEN)
+                                .tokenType(TokenType.NON_FUNGIBLE_UNIQUE)
+                                .adminKey(MULTI_KEY)
+                                .supplyKey(MULTI_KEY)
+                                .supplyType(TokenSupplyType.INFINITE)
+                                .initialSupply(0)
+                                .treasury(PARTY)
+                                .via(NFT_CREATE),
+                        mintToken(
+                                NFT_INFINITE_SUPPLY_TOKEN,
+                                List.of(
+                                        ByteString.copyFromUtf8("a"),
+                                        ByteString.copyFromUtf8("b"))),
+                        withOpContext(
+                                (spec, opLog) -> {
+                                    final var registry = spec.registry();
+                                    ftId.set(registry.getTokenID(A_TOKEN));
+                                    nftId.set(registry.getTokenID(NFT_INFINITE_SUPPLY_TOKEN));
+                                    partyId.set(registry.getAccountID(PARTY));
+                                    partyAlias.set(
+                                            ByteString.copyFrom(asSolidityAddress(partyId.get())));
+                                }))
                 .when(
                         sourcing(
                                 () ->
@@ -691,14 +742,13 @@ public class Create2OperationSuite extends HapiSuite {
                                 () ->
                                         contractCallLocal(
                                                         contract,
-                                                        "getAddress",
+                                                        GET_ADDRESS,
                                                         testContractInitcode.get(),
                                                         salt)
                                                 .exposingTypedResultsTo(
                                                         results -> {
                                                             LOG.info(
-                                                                    "Contract reported address"
-                                                                            + " results {}",
+                                                                    CONTRACT_REPORTED_ADDRESS_MESSAGE,
                                                                     results);
                                                             final var expectedAddrBytes =
                                                                     (Address) results[0];
@@ -709,8 +759,7 @@ public class Create2OperationSuite extends HapiSuite {
                                                                                                     .toString())
                                                                                     .toArray());
                                                             LOG.info(
-                                                                    "  --> Expected CREATE2 address"
-                                                                            + " is {}",
+                                                                    EXPECTED_CREATE2_ADDRESS_MESSAGE,
                                                                     hexedAddress);
                                                             expectedCreate2Address.set(
                                                                     hexedAddress);
@@ -737,27 +786,73 @@ public class Create2OperationSuite extends HapiSuite {
                                             final var defaultPayerId =
                                                     spec.registry().getAccountID(DEFAULT_PAYER);
                                             b.setTransfers(
-                                                    TransferList.newBuilder()
-                                                            .addAccountAmounts(
-                                                                    aaWith(
-                                                                            ByteString.copyFrom(
-                                                                                    CommonUtils
-                                                                                            .unhex(
-                                                                                                    expectedCreate2Address
-                                                                                                            .get())),
-                                                                            +ONE_HBAR))
-                                                            .addAccountAmounts(
-                                                                    aaWith(
-                                                                            defaultPayerId,
-                                                                            -ONE_HBAR)));
+                                                            TransferList.newBuilder()
+                                                                    .addAccountAmounts(
+                                                                            aaWith(
+                                                                                    ByteString
+                                                                                            .copyFrom(
+                                                                                                    CommonUtils
+                                                                                                            .unhex(
+                                                                                                                    expectedCreate2Address
+                                                                                                                            .get())),
+                                                                                    +ONE_HBAR))
+                                                                    .addAccountAmounts(
+                                                                            aaWith(
+                                                                                    defaultPayerId,
+                                                                                    -ONE_HBAR)))
+                                                    .addTokenTransfers(
+                                                            TokenTransferList.newBuilder()
+                                                                    .setToken(ftId.get())
+                                                                    .addTransfers(
+                                                                            aaWith(
+                                                                                    partyAlias
+                                                                                            .get(),
+                                                                                    -500))
+                                                                    .addTransfers(
+                                                                            aaWith(
+                                                                                    ByteString
+                                                                                            .copyFrom(
+                                                                                                    CommonUtils
+                                                                                                            .unhex(
+                                                                                                                    expectedCreate2Address
+                                                                                                                            .get())),
+                                                                                    +500)))
+                                                    .addTokenTransfers(
+                                                            TokenTransferList.newBuilder()
+                                                                    .setToken(nftId.get())
+                                                                    .addNftTransfers(
+                                                                            ocWith(
+                                                                                    accountId(
+                                                                                            partyAlias
+                                                                                                    .get()),
+                                                                                    accountId(
+                                                                                            ByteString
+                                                                                                    .copyFrom(
+                                                                                                            CommonUtils
+                                                                                                                    .unhex(
+                                                                                                                            expectedCreate2Address
+                                                                                                                                    .get()))),
+                                                                                    1L)));
                                         })
-                                .signedBy(DEFAULT_PAYER)
+                                .signedBy(DEFAULT_PAYER, PARTY)
                                 .fee(ONE_HBAR)
                                 .via(creation),
                         getTxnRecord(creation)
                                 .andAllChildRecords()
                                 .exposingCreationsTo(l -> hollowCreationAddress.set(l.get(0))),
-                        sourcing(() -> getAccountInfo(hollowCreationAddress.get()).logged()),
+                        sourcing(() -> getAccountInfo(hollowCreationAddress.get()).logged()))
+                .then(
+                        sourcing(
+                                () ->
+                                        contractCall(
+                                                        contract,
+                                                        "wronglyDeployTwice",
+                                                        testContractInitcode.get(),
+                                                        salt)
+                                                .payingWith(GENESIS)
+                                                .gas(4_000_000L)
+                                                .sending(tcValue)
+                                                .hasKnownStatus(INVALID_SOLIDITY_ADDRESS)),
                         sourcing(
                                 () ->
                                         contractCall(
@@ -770,25 +865,10 @@ public class Create2OperationSuite extends HapiSuite {
                                                 .sending(tcValue)
                                                 .via(CREATE_2_TXN)),
                         captureOneChildCreate2MetaFor(
-                                "Blocked contract",
+                                "Merged deployed contract with hollow account",
                                 CREATE_2_TXN,
-                                blockedMirrorAddr,
-                                blockedAliasAddr),
-                        logIt(
-                                "FIXME - Re-deployed the CREATE2 contract, should have been"
-                                        + " blocked!"),
-                        // Notice the hollow account is still linked to the address, not the
-                        // re-redeployed
-                        // CREATE2 contract
-                        sourcing(
-                                () ->
-                                        getLiteralAliasAccountInfo(blockedAliasAddr.get())
-                                                .nodePayment(ONE_HBAR)
-                                                .logged()))
-                .then(
-                        // IMPORTANT CLUE - but now CREATE2 *does* fail to redeploy the contract.
-                        // Seems
-                        // like existence of code is the deciding factor?
+                                mergedMirrorAddr,
+                                mergedAliasAddr),
                         sourcing(
                                 () ->
                                         contractCall(
@@ -798,8 +878,57 @@ public class Create2OperationSuite extends HapiSuite {
                                                         salt)
                                                 .payingWith(GENESIS)
                                                 .gas(4_000_000L)
-                                                /* Cannot repeat CREATE2 with same args without destroying the existing contract */
-                                                .hasKnownStatus(INVALID_SOLIDITY_ADDRESS)));
+                                                /* Cannot repeat CREATE2
+                                                with same args without destroying the existing contract */
+
+                                                .hasKnownStatus(INVALID_SOLIDITY_ADDRESS)),
+                        sourcing(
+                                () ->
+                                        getContractInfo(mergedAliasAddr.get())
+                                                .has(
+                                                        contractWith()
+                                                                .numKvPairs(2)
+                                                                .hasStandinContractKey()
+                                                                .maxAutoAssociations(2)
+                                                                .hasAlreadyUsedAutomaticAssociations(
+                                                                        2)
+                                                                .memo(LAZY_MEMO)
+                                                                .balance(ONE_HBAR + tcValue))
+                                                .hasToken(relationshipWith(A_TOKEN).balance(500))
+                                                .hasToken(
+                                                        relationshipWith(NFT_INFINITE_SUPPLY_TOKEN)
+                                                                .balance(1))
+                                                .logged()),
+                        sourcing(() -> getContractBytecode(mergedAliasAddr.get()).isNonEmpty()),
+                        sourcing(
+                                () ->
+                                        contractCallLocal(
+                                                        contract,
+                                                        GET_ADDRESS,
+                                                        testContractInitcode.get(),
+                                                        salt)
+                                                .exposingTypedResultsTo(
+                                                        results -> {
+                                                            LOG.info(
+                                                                    CONTRACT_REPORTED_ADDRESS_MESSAGE,
+                                                                    results);
+                                                            final var addrBytes =
+                                                                    (Address) results[0];
+                                                            final var hexedAddress =
+                                                                    hex(
+                                                                            Bytes.fromHexString(
+                                                                                            addrBytes
+                                                                                                    .toString())
+                                                                                    .toArray());
+                                                            LOG.info(
+                                                                    EXPECTED_CREATE2_ADDRESS_MESSAGE,
+                                                                    hexedAddress);
+
+                                                            assertEquals(
+                                                                    expectedCreate2Address.get(),
+                                                                    hexedAddress);
+                                                        })
+                                                .payingWith(GENESIS)));
     }
 
     @SuppressWarnings("java:S5669")

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/traceability/TraceabilitySuite.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/traceability/TraceabilitySuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,53 +17,27 @@ package com.hedera.services.bdd.suites.contract.traceability;
 
 import static com.hedera.node.app.service.evm.utils.EthSigsUtils.recoverAddressFromPubKey;
 import static com.hedera.services.bdd.spec.HapiPropertySource.asContract;
-import static com.hedera.services.bdd.spec.HapiPropertySource.asContractString;
-import static com.hedera.services.bdd.spec.HapiPropertySource.asHexedSolidityAddress;
 import static com.hedera.services.bdd.spec.HapiSpec.defaultHapiSpec;
 import static com.hedera.services.bdd.spec.HapiSpec.propertyPreservingHapiSpec;
 import static com.hedera.services.bdd.spec.assertions.AccountInfoAsserts.accountWith;
-import static com.hedera.services.bdd.spec.queries.QueryVerbs.contractCallLocal;
-import static com.hedera.services.bdd.spec.queries.QueryVerbs.getAliasedAccountInfo;
-import static com.hedera.services.bdd.spec.queries.QueryVerbs.getContractBytecode;
-import static com.hedera.services.bdd.spec.queries.QueryVerbs.getTxnRecord;
-import static com.hedera.services.bdd.spec.transactions.TxnVerbs.contractCall;
-import static com.hedera.services.bdd.spec.transactions.TxnVerbs.contractCreate;
-import static com.hedera.services.bdd.spec.transactions.TxnVerbs.contractCustomCreate;
-import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoCreate;
-import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoTransfer;
-import static com.hedera.services.bdd.spec.transactions.TxnVerbs.ethereumContractCreate;
-import static com.hedera.services.bdd.spec.transactions.TxnVerbs.ethereumCryptoTransfer;
-import static com.hedera.services.bdd.spec.transactions.TxnVerbs.mintToken;
-import static com.hedera.services.bdd.spec.transactions.TxnVerbs.tokenCreate;
-import static com.hedera.services.bdd.spec.transactions.TxnVerbs.uploadInitCode;
+import static com.hedera.services.bdd.spec.queries.QueryVerbs.*;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.*;
 import static com.hedera.services.bdd.spec.transactions.contract.HapiParserUtil.asHeadlongAddress;
 import static com.hedera.services.bdd.spec.transactions.contract.HapiParserUtil.stripSelector;
 import static com.hedera.services.bdd.spec.transactions.crypto.HapiCryptoTransfer.tinyBarsFromAccountToAlias;
 import static com.hedera.services.bdd.spec.transactions.token.TokenMovement.movingUnique;
 import static com.hedera.services.bdd.spec.utilops.CustomSpecAssert.allRunFor;
 import static com.hedera.services.bdd.spec.utilops.UtilStateChange.stateChangesToGrpc;
-import static com.hedera.services.bdd.spec.utilops.UtilVerbs.assertionsHold;
-import static com.hedera.services.bdd.spec.utilops.UtilVerbs.newKeyNamed;
-import static com.hedera.services.bdd.spec.utilops.UtilVerbs.overriding;
-import static com.hedera.services.bdd.spec.utilops.UtilVerbs.overridingThree;
-import static com.hedera.services.bdd.spec.utilops.UtilVerbs.sourcing;
-import static com.hedera.services.bdd.spec.utilops.UtilVerbs.withOpContext;
-import static com.hedera.services.bdd.suites.contract.Utils.asAddress;
-import static com.hedera.services.bdd.suites.contract.Utils.asSolidityAddress;
-import static com.hedera.services.bdd.suites.contract.Utils.asToken;
-import static com.hedera.services.bdd.suites.contract.Utils.extractBytecodeUnhexed;
-import static com.hedera.services.bdd.suites.contract.Utils.getABIFor;
-import static com.hedera.services.bdd.suites.contract.Utils.getResourcePath;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.*;
+import static com.hedera.services.bdd.suites.contract.Utils.*;
+import static com.hedera.services.bdd.suites.contract.opcodes.Create2OperationSuite.*;
 import static com.hedera.services.bdd.suites.contract.precompile.AssociatePrecompileSuite.getNestedContractAddress;
-import static com.hedera.services.stream.proto.ContractActionType.CALL;
-import static com.hedera.services.stream.proto.ContractActionType.CREATE;
-import static com.hedera.services.stream.proto.ContractActionType.PRECOMPILE;
-import static com.hedera.services.stream.proto.ContractActionType.SYSTEM;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.CONTRACT_REVERT_EXECUTED;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INSUFFICIENT_GAS;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_SOLIDITY_ADDRESS;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SUCCESS;
+import static com.hedera.services.bdd.suites.crypto.AutoAccountCreationSuite.*;
+import static com.hedera.services.bdd.suites.token.TokenAssociationSpecs.MULTI_KEY;
+import static com.hedera.services.stream.proto.ContractActionType.*;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.*;
 import static com.hederahashgraph.api.proto.java.TokenType.NON_FUNGIBLE_UNIQUE;
+import static com.swirlds.common.utility.CommonUtils.hex;
 import static org.hyperledger.besu.crypto.Hash.keccak256;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -89,17 +63,9 @@ import com.hedera.services.bdd.spec.utilops.CustomSpecAssert;
 import com.hedera.services.bdd.spec.verification.traceability.ExpectedSidecar;
 import com.hedera.services.bdd.spec.verification.traceability.SidecarWatcher;
 import com.hedera.services.bdd.suites.HapiSuite;
-import com.hedera.services.bdd.suites.contract.Utils.FunctionType;
-import com.hedera.services.stream.proto.CallOperationType;
-import com.hedera.services.stream.proto.ContractAction;
-import com.hedera.services.stream.proto.ContractActions;
-import com.hedera.services.stream.proto.ContractBytecode;
-import com.hedera.services.stream.proto.ContractStateChanges;
-import com.hedera.services.stream.proto.TransactionSidecarRecord;
-import com.hederahashgraph.api.proto.java.AccountID;
-import com.hederahashgraph.api.proto.java.ContractID;
-import com.hederahashgraph.api.proto.java.TokenID;
-import com.hederahashgraph.api.proto.java.TokenType;
+import com.hedera.services.stream.proto.*;
+import com.hederahashgraph.api.proto.java.*;
+import com.swirlds.common.utility.CommonUtils;
 import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Paths;
@@ -193,6 +159,7 @@ public class TraceabilitySuite extends HapiSuite {
                         vanillaBytecodeSidecar2(),
                         actionsShowPropagatedRevert(),
                         ethereumLazyCreateExportsExpectedSidecars(),
+                        hollowAccountCreate2MergeExportsExpectedSidecars(),
                         assertSidecars())
                 .toList();
     }
@@ -6165,7 +6132,7 @@ public class TraceabilitySuite extends HapiSuite {
                                                                     .setOutput(EMPTY)
                                                                     .build())));
                                 }),
-                        expectContractBytecodeSidecarSansInitcodeFor(TRACEABILITY_TXN, contract));
+                        expectContractBytecode(TRACEABILITY_TXN, contract));
     }
 
     HapiSpec traceabilityE2EScenario13() {
@@ -6302,7 +6269,8 @@ public class TraceabilitySuite extends HapiSuite {
                                 .exposingNumTo(
                                         num ->
                                                 factoryEvmAddress.set(
-                                                        asHexedSolidityAddress(0, 0, num))),
+                                                        HapiPropertySource.asHexedSolidityAddress(
+                                                                0, 0, num))),
                         withOpContext(
                                 (spec, opLog) ->
                                         allRunFor(
@@ -6401,8 +6369,9 @@ public class TraceabilitySuite extends HapiSuite {
                                                     CREATE_2_TXN,
                                                     List.of(
                                                             StateChange.stateChangeFor(
-                                                                            asContractString(
-                                                                                    childId))
+                                                                            HapiPropertySource
+                                                                                    .asContractString(
+                                                                                            childId))
                                                                     .withStorageChanges(
                                                                             StorageChange
                                                                                     .readAndWritten(
@@ -6472,32 +6441,15 @@ public class TraceabilitySuite extends HapiSuite {
                                                                     .setCallDepth(1)
                                                                     .build())),
                                             hapiGetContractBytecode);
-                                    sidecarWatcher.addExpectedSidecar(
-                                            new ExpectedSidecar(
-                                                    specName,
-                                                    TransactionSidecarRecord.newBuilder()
-                                                            .setConsensusTimestamp(
-                                                                    topLevelCallTxnRecord
-                                                                            .getChildRecord(0)
-                                                                            .getConsensusTimestamp())
-                                                            .setBytecode(
-                                                                    ContractBytecode.newBuilder()
-                                                                            .setContractId(
-                                                                                    asContract(
-                                                                                            mirrorLiteralId
-                                                                                                    .get()))
-                                                                            .setInitcode(
-                                                                                    ByteStringUtils
-                                                                                            .wrapUnsafely(
-                                                                                                    testContractInitcode
-                                                                                                            .get()))
-                                                                            .setRuntimeBytecode(
-                                                                                    ByteStringUtils
-                                                                                            .wrapUnsafely(
-                                                                                                    bytecodeFromMirror
-                                                                                                            .get()))
-                                                                            .build())
-                                                            .build()));
+                                    expectContractBytecode(
+                                            specName,
+                                            topLevelCallTxnRecord
+                                                    .getChildRecord(0)
+                                                    .getConsensusTimestamp(),
+                                            asContract(mirrorLiteralId.get()),
+                                            ByteStringUtils.wrapUnsafely(
+                                                    testContractInitcode.get()),
+                                            ByteStringUtils.wrapUnsafely(bytecodeFromMirror.get()));
                                 }))
                 .then();
     }
@@ -6585,9 +6537,10 @@ public class TraceabilitySuite extends HapiSuite {
                                                                                     toHash
                                                                                             .getBytes(),
                                                                                     hexedSolidityAddressToHeadlongAddress(
-                                                                                            asHexedSolidityAddress(
-                                                                                                    vanillaTokenID
-                                                                                                            .get()))))
+                                                                                            HapiPropertySource
+                                                                                                    .asHexedSolidityAddress(
+                                                                                                            vanillaTokenID
+                                                                                                                    .get()))))
                                                                     .setOutput(
                                                                             ByteStringUtils
                                                                                     .wrapUnsafely(
@@ -6652,9 +6605,10 @@ public class TraceabilitySuite extends HapiSuite {
                                                                                                                 + "(address)")
                                                                                                     .encodeCallWithArgs(
                                                                                                             hexedSolidityAddressToHeadlongAddress(
-                                                                                                                    asHexedSolidityAddress(
-                                                                                                                            vanillaTokenID
-                                                                                                                                    .get())))
+                                                                                                                    HapiPropertySource
+                                                                                                                            .asHexedSolidityAddress(
+                                                                                                                                    vanillaTokenID
+                                                                                                                                            .get())))
                                                                                                     .array()))
                                                                     .setOutput(
                                                                             ByteStringUtils
@@ -7126,13 +7080,17 @@ public class TraceabilitySuite extends HapiSuite {
                         cryptoCreate(somebody)
                                 .maxAutomaticTokenAssociations(2)
                                 .exposingCreatedIdTo(
-                                        id -> somebodyMirrorAddr.set(asHexedSolidityAddress(id))),
+                                        id ->
+                                                somebodyMirrorAddr.set(
+                                                        HapiPropertySource.asHexedSolidityAddress(
+                                                                id))),
                         cryptoCreate(somebodyElse)
                                 .maxAutomaticTokenAssociations(2)
                                 .exposingCreatedIdTo(
                                         id ->
                                                 somebodyElseMirrorAddr.set(
-                                                        asHexedSolidityAddress(id))),
+                                                        HapiPropertySource.asHexedSolidityAddress(
+                                                                id))),
                         newKeyNamed(someSupplyKey),
                         tokenCreate(tokenInQuestion)
                                 .supplyKey(someSupplyKey)
@@ -7142,7 +7100,7 @@ public class TraceabilitySuite extends HapiSuite {
                                 .exposingCreatedIdTo(
                                         idLit ->
                                                 tiqMirrorAddr.set(
-                                                        asHexedSolidityAddress(
+                                                        HapiPropertySource.asHexedSolidityAddress(
                                                                 HapiPropertySource.asToken(
                                                                         idLit)))),
                         mintToken(
@@ -7195,15 +7153,17 @@ public class TraceabilitySuite extends HapiSuite {
                                                                                     APPROVE_BY_DELEGATE,
                                                                                     "doIt",
                                                                                     hexedSolidityAddressToHeadlongAddress(
-                                                                                            asHexedSolidityAddress(
-                                                                                                    spec.registry()
-                                                                                                            .getTokenID(
-                                                                                                                    tokenInQuestion))),
+                                                                                            HapiPropertySource
+                                                                                                    .asHexedSolidityAddress(
+                                                                                                            spec.registry()
+                                                                                                                    .getTokenID(
+                                                                                                                            tokenInQuestion))),
                                                                                     hexedSolidityAddressToHeadlongAddress(
-                                                                                            asHexedSolidityAddress(
-                                                                                                    spec.registry()
-                                                                                                            .getAccountID(
-                                                                                                                    somebodyElse))),
+                                                                                            HapiPropertySource
+                                                                                                    .asHexedSolidityAddress(
+                                                                                                            spec.registry()
+                                                                                                                    .getAccountID(
+                                                                                                                            somebodyElse))),
                                                                                     serialNumberId))
                                                                     .setGas(979000)
                                                                     .setGasUsed(948950)
@@ -7237,10 +7197,11 @@ public class TraceabilitySuite extends HapiSuite {
                                                                                                             "approve(address,uint256)")
                                                                                                     .encodeCallWithArgs(
                                                                                                             hexedSolidityAddressToHeadlongAddress(
-                                                                                                                    asHexedSolidityAddress(
-                                                                                                                            spec.registry()
-                                                                                                                                    .getAccountID(
-                                                                                                                                            somebodyElse))),
+                                                                                                                    HapiPropertySource
+                                                                                                                            .asHexedSolidityAddress(
+                                                                                                                                    spec.registry()
+                                                                                                                                            .getAccountID(
+                                                                                                                                                    somebodyElse))),
                                                                                                             serialNumberId)
                                                                                                     .array()))
                                                                     .setRevertReason(
@@ -7289,10 +7250,11 @@ public class TraceabilitySuite extends HapiSuite {
                                                                                                                                             encodeTuple(
                                                                                                                                                     "(address)",
                                                                                                                                                     hexedSolidityAddressToHeadlongAddress(
-                                                                                                                                                            asHexedSolidityAddress(
-                                                                                                                                                                    spec.registry()
-                                                                                                                                                                            .getTokenID(
-                                                                                                                                                                                    tokenInQuestion)))),
+                                                                                                                                                            HapiPropertySource
+                                                                                                                                                                    .asHexedSolidityAddress(
+                                                                                                                                                                            spec.registry()
+                                                                                                                                                                                    .getTokenID(
+                                                                                                                                                                                            tokenInQuestion)))),
                                                                                                                                             12,
                                                                                                                                             32)),
                                                                                                             Function
@@ -7300,10 +7262,11 @@ public class TraceabilitySuite extends HapiSuite {
                                                                                                                             "approve(address,uint256)")
                                                                                                                     .encodeCallWithArgs(
                                                                                                                             hexedSolidityAddressToHeadlongAddress(
-                                                                                                                                    asHexedSolidityAddress(
-                                                                                                                                            spec.registry()
-                                                                                                                                                    .getAccountID(
-                                                                                                                                                            somebodyElse))),
+                                                                                                                                    HapiPropertySource
+                                                                                                                                            .asHexedSolidityAddress(
+                                                                                                                                                    spec.registry()
+                                                                                                                                                            .getAccountID(
+                                                                                                                                                                    somebodyElse))),
                                                                                                                             serialNumberId)
                                                                                                                     .array())))
                                                                     .setError(
@@ -7442,6 +7405,252 @@ public class TraceabilitySuite extends HapiSuite {
                                                                                     .get())
                                                                     .setOutput(EMPTY)
                                                                     .build())));
+                                }));
+    }
+
+    @SuppressWarnings("java:S5960")
+    private HapiSpec hollowAccountCreate2MergeExportsExpectedSidecars() {
+        final var tcValue = 1_234L;
+        final var create2Factory = "Create2Factory";
+        final var creation = "creation";
+        final var salt = BigInteger.valueOf(42);
+        final var adminKey = "ADMIN_KEY";
+        final var entityMemo = "JUST DO IT";
+        final AtomicReference<String> factoryEvmAddress = new AtomicReference<>();
+        final AtomicReference<String> expectedCreate2Address = new AtomicReference<>();
+        final AtomicReference<String> hollowCreationAddress = new AtomicReference<>();
+        final AtomicReference<String> mergedAliasAddr = new AtomicReference<>();
+        final AtomicReference<String> mergedMirrorAddr = new AtomicReference<>();
+        final AtomicReference<byte[]> testContractInitcode = new AtomicReference<>();
+        final AtomicReference<AccountID> mergedAccountId = new AtomicReference<>();
+        final var CREATE_2_TXN = "create2Txn";
+        final var specName = "hollowAccountCreate2MergeExportsExpectedSidecars";
+        return propertyPreservingHapiSpec(specName)
+                .preserving(LAZY_CREATE_PROPERTY, SIDECARS_PROP)
+                .given(
+                        overriding(LAZY_CREATE_PROPERTY, "true"),
+                        overriding(SIDECARS_PROP, ""),
+                        newKeyNamed(adminKey),
+                        newKeyNamed(MULTI_KEY),
+                        uploadInitCode(create2Factory),
+                        contractCreate(create2Factory)
+                                .payingWith(GENESIS)
+                                .adminKey(adminKey)
+                                .entityMemo(entityMemo)
+                                .via(CREATE_2_TXN)
+                                .exposingNumTo(
+                                        num ->
+                                                factoryEvmAddress.set(
+                                                        HapiPropertySource.asHexedSolidityAddress(
+                                                                0, 0, num))),
+                        cryptoCreate(PARTY).maxAutomaticTokenAssociations(2))
+                .when(
+                        sourcing(
+                                () ->
+                                        contractCallLocal(
+                                                        create2Factory,
+                                                        GET_BYTECODE,
+                                                        asHeadlongAddress(factoryEvmAddress.get()),
+                                                        salt)
+                                                .exposingTypedResultsTo(
+                                                        results -> {
+                                                            final var tcInitcode =
+                                                                    (byte[]) results[0];
+                                                            testContractInitcode.set(tcInitcode);
+                                                            log.info(
+                                                                    CONTRACT_REPORTED_LOG_MESSAGE,
+                                                                    tcInitcode.length);
+                                                        })
+                                                .payingWith(GENESIS)
+                                                .nodePayment(ONE_HBAR)),
+                        sourcing(
+                                () ->
+                                        contractCallLocal(
+                                                        create2Factory,
+                                                        GET_ADDRESS,
+                                                        testContractInitcode.get(),
+                                                        salt)
+                                                .exposingTypedResultsTo(
+                                                        results -> {
+                                                            log.info(
+                                                                    CONTRACT_REPORTED_ADDRESS_MESSAGE,
+                                                                    results);
+                                                            final var expectedAddrBytes =
+                                                                    (Address) results[0];
+                                                            final var hexedAddress =
+                                                                    hex(
+                                                                            Bytes.fromHexString(
+                                                                                            expectedAddrBytes
+                                                                                                    .toString())
+                                                                                    .toArray());
+                                                            log.info(
+                                                                    EXPECTED_CREATE2_ADDRESS_MESSAGE,
+                                                                    hexedAddress);
+                                                            expectedCreate2Address.set(
+                                                                    hexedAddress);
+                                                        })
+                                                .payingWith(GENESIS)),
+                        // Create a hollow account at the desired address
+                        cryptoTransfer(
+                                        (spec, b) -> {
+                                            final var defaultPayerId =
+                                                    spec.registry().getAccountID(DEFAULT_PAYER);
+                                            b.setTransfers(
+                                                    TransferList.newBuilder()
+                                                            .addAccountAmounts(
+                                                                    aaWith(
+                                                                            ByteString.copyFrom(
+                                                                                    CommonUtils
+                                                                                            .unhex(
+                                                                                                    expectedCreate2Address
+                                                                                                            .get())),
+                                                                            +ONE_HBAR))
+                                                            .addAccountAmounts(
+                                                                    aaWith(
+                                                                            defaultPayerId,
+                                                                            -ONE_HBAR)));
+                                        })
+                                .signedBy(DEFAULT_PAYER, PARTY)
+                                .fee(ONE_HBAR)
+                                .via(creation),
+                        getTxnRecord(creation)
+                                .andAllChildRecords()
+                                .exposingCreationsTo(l -> hollowCreationAddress.set(l.get(0))),
+                        // save the id of the hollow account
+                        sourcing(
+                                () ->
+                                        getAccountInfo(hollowCreationAddress.get())
+                                                .logged()
+                                                .exposingIdTo(mergedAccountId::set)),
+                        sourcing(
+                                () ->
+                                        overriding(
+                                                SIDECARS_PROP,
+                                                "CONTRACT_ACTION,CONTRACT_STATE_CHANGE,CONTRACT_BYTECODE")),
+                        sourcing(
+                                () ->
+                                        contractCall(
+                                                        create2Factory,
+                                                        DEPLOY,
+                                                        testContractInitcode.get(),
+                                                        salt)
+                                                .payingWith(GENESIS)
+                                                .gas(4_000_000L)
+                                                .sending(tcValue)
+                                                .via(CREATE_2_TXN)),
+                        captureOneChildCreate2MetaFor(
+                                "Merged deployed create2Factory with hollow account",
+                                CREATE_2_TXN,
+                                mergedMirrorAddr,
+                                mergedAliasAddr))
+                .then(
+                        // assert sidecars
+                        withOpContext(
+                                (spec, opLog) -> {
+                                    final var mergedContractIdAsString =
+                                            HapiPropertySource.asAccountString(
+                                                    mergedAccountId.get());
+                                    final AtomicReference<byte[]> mergedContractBytecode =
+                                            new AtomicReference<>();
+                                    final var hapiGetContractBytecode =
+                                            getContractBytecode(mergedContractIdAsString)
+                                                    .exposingBytecodeTo(
+                                                            mergedContractBytecode::set);
+                                    final var topLevelCallTxnRecord =
+                                            getTxnRecord(CREATE_2_TXN).andAllChildRecords();
+                                    allRunFor(
+                                            spec,
+                                            topLevelCallTxnRecord,
+                                            expectContractStateChangesSidecarFor(
+                                                    CREATE_2_TXN,
+                                                    List.of(
+                                                            // recipient should be the original
+                                                            // hollow account id as a contract
+                                                            StateChange.stateChangeFor(
+                                                                            mergedContractIdAsString)
+                                                                    .withStorageChanges(
+                                                                            StorageChange
+                                                                                    .readAndWritten(
+                                                                                            formattedAssertionValue(
+                                                                                                    0L),
+                                                                                            formattedAssertionValue(
+                                                                                                    0L),
+                                                                                            ByteStringUtils
+                                                                                                    .wrapUnsafely(
+                                                                                                            Bytes
+                                                                                                                    .fromHexString(
+                                                                                                                            factoryEvmAddress
+                                                                                                                                    .get())
+                                                                                                                    .trimLeadingZeros()
+                                                                                                                    .toArrayUnsafe())),
+                                                                            StorageChange
+                                                                                    .readAndWritten(
+                                                                                            formattedAssertionValue(
+                                                                                                    1L),
+                                                                                            formattedAssertionValue(
+                                                                                                    0L),
+                                                                                            formattedAssertionValue(
+                                                                                                    salt
+                                                                                                            .longValue()))))),
+                                            expectContractActionSidecarFor(
+                                                    CREATE_2_TXN,
+                                                    List.of(
+                                                            ContractAction.newBuilder()
+                                                                    .setCallType(CALL)
+                                                                    .setCallOperationType(
+                                                                            CallOperationType
+                                                                                    .OP_CALL)
+                                                                    .setCallingAccount(
+                                                                            TxnUtils.asId(
+                                                                                    GENESIS, spec))
+                                                                    .setGas(3979000)
+                                                                    .setValue(tcValue)
+                                                                    .setRecipientContract(
+                                                                            spec.registry()
+                                                                                    .getContractId(
+                                                                                            create2Factory))
+                                                                    .setGasUsed(80135)
+                                                                    .setOutput(EMPTY)
+                                                                    .setInput(
+                                                                            encodeFunctionCall(
+                                                                                    create2Factory,
+                                                                                    DEPLOY,
+                                                                                    testContractInitcode
+                                                                                            .get(),
+                                                                                    salt))
+                                                                    .build(),
+                                                            ContractAction.newBuilder()
+                                                                    .setCallType(CREATE)
+                                                                    .setCallOperationType(
+                                                                            CallOperationType
+                                                                                    .OP_CREATE2)
+                                                                    .setCallingContract(
+                                                                            spec.registry()
+                                                                                    .getContractId(
+                                                                                            create2Factory))
+                                                                    .setGas(3883883)
+                                                                    // recipient should be the
+                                                                    // original hollow account id as
+                                                                    // a contract
+                                                                    .setRecipientContract(
+                                                                            asContract(
+                                                                                    mergedContractIdAsString))
+                                                                    .setGasUsed(44936)
+                                                                    .setValue(tcValue)
+                                                                    .setOutput(EMPTY)
+                                                                    .setCallDepth(1)
+                                                                    .build())),
+                                            hapiGetContractBytecode);
+                                    expectContractBytecode(
+                                            specName,
+                                            topLevelCallTxnRecord
+                                                    .getChildRecord(0)
+                                                    .getConsensusTimestamp(),
+                                            asContract(mergedContractIdAsString),
+                                            ByteStringUtils.wrapUnsafely(
+                                                    testContractInitcode.get()),
+                                            ByteStringUtils.wrapUnsafely(
+                                                    mergedContractBytecode.get()));
                                 }));
     }
 
@@ -7613,7 +7822,7 @@ public class TraceabilitySuite extends HapiSuite {
                 });
     }
 
-    private CustomSpecAssert expectContractBytecodeSidecarSansInitcodeFor(
+    private CustomSpecAssert expectContractBytecode(
             final String contractCreateTxn, final String contractName) {
         return withOpContext(
                 (spec, opLog) -> {
@@ -7643,6 +7852,28 @@ public class TraceabilitySuite extends HapiSuite {
                                                             .build())
                                             .build()));
                 });
+    }
+
+    private void expectContractBytecode(
+            final String specName,
+            final Timestamp timestamp,
+            final ContractID contractID,
+            final ByteString initCode,
+            final ByteString runtimeCode) {
+        sidecarWatcher.addExpectedSidecar(
+                new ExpectedSidecar(
+                        specName,
+                        TransactionSidecarRecord.newBuilder()
+                                .setConsensusTimestamp(timestamp)
+                                .setBytecode(
+                                        ContractBytecode.newBuilder()
+                                                // recipient should be the original hollow account
+                                                // id as a contract
+                                                .setContractId(contractID)
+                                                .setInitcode(initCode)
+                                                .setRuntimeBytecode(runtimeCode)
+                                                .build())
+                                .build()));
     }
 
     private ByteString getInitcode(final String binFileName, final Object... constructorArgs) {

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/AutoAccountCreationSuite.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/AutoAccountCreationSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2022 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -132,7 +132,7 @@ public class AutoAccountCreationSuite extends HapiSuite {
     public static final String NFT_INFINITE_SUPPLY_TOKEN = "nftA";
     private static final String NFT_FINITE_SUPPLY_TOKEN = "nftB";
     private static final String MULTI_KEY = "multi";
-    private static final String PARTY = "party";
+    public static final String PARTY = "party";
     private static final String COUNTERPARTY = "counterparty";
 
     private static final String CIVILIAN = "somebody";

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoCreateSuite.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoCreateSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2022 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoCreateSuite.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoCreateSuite.java
@@ -21,16 +21,23 @@ import static com.hedera.services.bdd.spec.assertions.AccountInfoAsserts.account
 import static com.hedera.services.bdd.spec.keys.KeyShape.SIMPLE;
 import static com.hedera.services.bdd.spec.keys.KeyShape.listOf;
 import static com.hedera.services.bdd.spec.keys.KeyShape.threshOf;
+import static com.hedera.services.bdd.spec.keys.TrieSigMapGenerator.uniqueWithFullPrefixesFor;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getAccountBalance;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getAccountInfo;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getTxnRecord;
 import static com.hedera.services.bdd.spec.transactions.TxnUtils.randomUtf8Bytes;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoCreate;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoTransfer;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.tokenCreate;
+import static com.hedera.services.bdd.spec.transactions.crypto.HapiCryptoTransfer.tinyBarsFromTo;
 import static com.hedera.services.bdd.spec.utilops.CustomSpecAssert.allRunFor;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.newKeyNamed;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.validateChargedUsd;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.withOpContext;
+import static com.hedera.services.bdd.suites.crypto.AutoAccountCreationSuite.CRYPTO_TRANSFER_RECEIVER;
+import static com.hedera.services.bdd.suites.crypto.AutoAccountCreationSuite.LAZY_CREATE_SPONSOR;
+import static com.hedera.services.bdd.suites.crypto.AutoAccountUpdateSuite.INITIAL_BALANCE;
+import static com.hedera.services.bdd.suites.crypto.AutoAccountUpdateSuite.TRANSFER_TXN_2;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.AUTORENEW_DURATION_NOT_IN_RANGE;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.BAD_ENCODING;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INSUFFICIENT_TX_FEE;
@@ -39,11 +46,14 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_ALIAS_
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_STAKING_ID;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_ZERO_BYTE_IN_STRING;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.KEY_REQUIRED;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SUCCESS;
 
 import com.google.protobuf.ByteString;
 import com.hedera.services.bdd.spec.HapiSpec;
 import com.hedera.services.bdd.spec.keys.KeyShape;
+import com.hedera.services.bdd.spec.queries.meta.HapiGetTxnRecord;
 import com.hedera.services.bdd.suites.HapiSuite;
+import com.hederahashgraph.api.proto.java.AccountID;
 import com.hederahashgraph.api.proto.java.Key;
 import com.hederahashgraph.api.proto.java.KeyList;
 import com.hederahashgraph.api.proto.java.ThresholdKey;
@@ -90,7 +100,8 @@ public class CryptoCreateSuite extends HapiSuite {
                 createAnAccountWithECKeyAndNoAlias(),
                 createAnAccountWithEDKeyAndNoAlias(),
                 createAnAccountWithED25519KeyAndED25519Alias(),
-                createAnAccountWithECKeyAndECKeyAlias());
+                createAnAccountWithECKeyAndECKeyAlias(),
+                hollowAccountCompletionAfterCryptoCreate());
     }
 
     private HapiSpec createAnAccountWithStakingFields() {
@@ -509,6 +520,7 @@ public class CryptoCreateSuite extends HapiSuite {
                                                     .logged()
                                                     .has(
                                                             accountWith()
+                                                                    .hasEmptyKey()
                                                                     .evmAddress(evmAddressBytes)
                                                                     .autoRenew(
                                                                             THREE_MONTHS_IN_SECONDS)
@@ -690,6 +702,67 @@ public class CryptoCreateSuite extends HapiSuite {
                                                                             THREE_MONTHS_IN_SECONDS)
                                                                     .receiverSigReq(false));
                                     allRunFor(spec, hapiGetAccountInfo, hapiGetAnotherAccountInfo);
+                                }))
+                .then();
+    }
+
+    private HapiSpec hollowAccountCompletionAfterCryptoCreate() {
+        return defaultHapiSpec("HollowAccountCompletionAfterCryptoCreate")
+                .given(
+                        newKeyNamed(SECP_256K1_SOURCE_KEY).shape(SECP_256K1_SHAPE),
+                        cryptoCreate(LAZY_CREATE_SPONSOR).balance(INITIAL_BALANCE * ONE_HBAR),
+                        cryptoCreate(CRYPTO_TRANSFER_RECEIVER).balance(INITIAL_BALANCE * ONE_HBAR))
+                .when(
+                        withOpContext(
+                                (spec, opLog) -> {
+                                    final var ecdsaKey =
+                                            spec.registry().getKey(SECP_256K1_SOURCE_KEY);
+                                    final var tmp = ecdsaKey.getECDSASecp256K1().toByteArray();
+                                    final var addressBytes = recoverAddressFromPubKey(tmp);
+                                    assert addressBytes.length > 0;
+                                    final var evmAddressBytes = ByteString.copyFrom(addressBytes);
+                                    final var op =
+                                            cryptoCreate(ACCOUNT)
+                                                    .evmAddress(evmAddressBytes)
+                                                    .balance(100 * ONE_HBAR)
+                                                    .via("createTxn");
+
+                                    final HapiGetTxnRecord hapiGetTxnRecord =
+                                            getTxnRecord("createTxn").andAllChildRecords().logged();
+
+                                    allRunFor(spec, op, hapiGetTxnRecord);
+
+                                    final AccountID newAccountID =
+                                            hapiGetTxnRecord
+                                                    .getResponseRecord()
+                                                    .getReceipt()
+                                                    .getAccountID();
+                                    spec.registry()
+                                            .saveAccountId(SECP_256K1_SOURCE_KEY, newAccountID);
+
+                                    final var op2 =
+                                            cryptoTransfer(
+                                                            tinyBarsFromTo(
+                                                                    LAZY_CREATE_SPONSOR,
+                                                                    CRYPTO_TRANSFER_RECEIVER,
+                                                                    ONE_HUNDRED_HBARS))
+                                                    .payingWith(SECP_256K1_SOURCE_KEY)
+                                                    .sigMapPrefixes(
+                                                            uniqueWithFullPrefixesFor(
+                                                                    SECP_256K1_SOURCE_KEY))
+                                                    .hasKnownStatus(SUCCESS)
+                                                    .via(TRANSFER_TXN_2);
+
+                                    var hapiGetAccountInfo =
+                                            getAccountInfo(ACCOUNT)
+                                                    .logged()
+                                                    .has(
+                                                            accountWith()
+                                                                    .evmAddress(evmAddressBytes)
+                                                                    .key(SECP_256K1_SOURCE_KEY)
+                                                                    .noAlias());
+
+                                    allRunFor(spec, op2, hapiGetAccountInfo);
                                 }))
                 .then();
     }

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/leaky/LeakyContractTestsSuite.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/leaky/LeakyContractTestsSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
**Description**:
 - Includes https://github.com/hashgraph/hedera-services/pull/4572, https://github.com/hashgraph/hedera-services/pull/4508, and a recently-noted missing one-line check on max auto-associations in `ContractUpdate` (c.f., `UpdateCustomizerFactory`).
 - And license header updates. 😞 