### PR TITLE
Remove `0.34` properties from develop prod config files

### DIFF
--- a/hedera-node/configuration/mainnet/bootstrap.properties
+++ b/hedera-node/configuration/mainnet/bootstrap.properties
@@ -6,4 +6,3 @@ contracts.sidecars=
 hedera.recordStream.enableTraceabilityMigration=false
 autoCreation.enabled=true
 lazyCreation.enabled=false
-cryptoCreateWithAliasAndEvmAddress.enabled=false

--- a/hedera-node/configuration/testnet/bootstrap.properties
+++ b/hedera-node/configuration/testnet/bootstrap.properties
@@ -4,4 +4,3 @@ hedera.recordStream.recordFileVersion=6
 hedera.recordStream.signatureFileVersion=6
 autoCreation.enabled=true
 lazyCreation.enabled=false
-cryptoCreateWithAliasAndEvmAddress.enabled=false

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ServicesStateTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ServicesStateTest.java
@@ -110,12 +110,14 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import org.apache.commons.io.FileUtils;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith({MockitoExtension.class, LogCaptureExtension.class})
@@ -175,6 +177,11 @@ class ServicesStateTest extends ResponsibleVMapUser {
         if (APPS.includes(selfId.getId())) {
             APPS.clear(selfId.getId());
         }
+    }
+
+    @AfterAll
+    static void clearMocks() {
+        Mockito.framework().clearInlineMocks();
     }
 
     @Test


### PR DESCRIPTION
**Description**:
- Remove `cryptoCreateWithAliasAndEvmAddress.enabled` from _mainnet/bootstrap.properties_ and _testnet/bootstrap.properties_.
- Adds `Mockito.framework().clearInlineMocks()` to `ServicesStateTest` per @OlegMazurov.