### PR TITLE
Add tracking of property changes for hollow account completion

### DIFF
--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/sigs/metadata/StateChildrenSigMetadataLookup.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/sigs/metadata/StateChildrenSigMetadataLookup.java
@@ -227,6 +227,10 @@ public final class StateChildrenSigMetadataLookup implements SigMetadataLookup {
         } else {
             final var key = account.getAccountKey();
             if (key.isEmpty()) {
+                if (linkedRefs != null) {
+                    linkedRefs.link(fileNumbers.applicationProperties());
+                }
+
                 if (!properties.isLazyCreationEnabled()) {
                     return SafeLookupResult.failure(IMMUTABLE_ACCOUNT);
                 }


### PR DESCRIPTION
Signed-off-by: Miroslav Gatsanoga <miroslav.gatsanoga@limechain.tech>

**Description**: Add tracking of property changes for hollow account completion as mentioned in [this PR comment](https://github.com/hashgraph/hedera-services/pull/4128#discussion_r1053690324).
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->

**Related issue(s)**:

Fixes: https://github.com/hashgraph/hedera-services/issues/4546
