### PR TITLE
Make PR checks run on PRs from forks

### DIFF
--- a/.github/workflows/comp-compile-application-code.yaml
+++ b/.github/workflows/comp-compile-application-code.yaml
@@ -110,7 +110,7 @@ jobs:
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # pin@v3
 
       - name: Expand Shallow Clone for SonarQube
-        if: ${{ (inputs.enable-sonar-analysis || inputs.enable-unit-tests) && !cancelled() }}
+        if: ${{ (inputs.enable-sonar-analysis || inputs.enable-unit-tests) && !cancelled() && github.repository_owner == 'hashgraph' }}
         run: |
           git fetch --unshallow --no-recurse-submodules
 
@@ -233,7 +233,7 @@ jobs:
         id: sonar-cloud
         env:
           IS_PULL_REQUEST: ${{ github.event_name == 'pull_request' || github.event_name == 'pull_request_target' }}
-        if: ${{ inputs.enable-sonar-analysis && steps.gradle-build.conclusion == 'success' && !cancelled() }}
+        if: ${{ inputs.enable-sonar-analysis && steps.gradle-build.conclusion == 'success' && !cancelled() && github.repository_owner == 'hashgraph' }}
         run: |
           SONAR_OPTS="-Dsonar.branch.name=${{ github.ref_name }}"
           if [[ "${IS_PULL_REQUEST}" == true ]]; then
@@ -248,7 +248,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.access-token }}
           SONAR_TOKEN: ${{ secrets.sonar-token }}
           SONAR_OPTS: ${{ steps.sonar-cloud.outputs.options }}
-        if: ${{ inputs.enable-sonar-analysis && steps.gradle-build.conclusion == 'success' && !cancelled() }}
+        if: ${{ inputs.enable-sonar-analysis && steps.gradle-build.conclusion == 'success' && !cancelled() && github.repository_owner == 'hashgraph' }}
         with:
           gradle-version: ${{ inputs.gradle-version }}
           arguments: sonarqube --info --scan

--- a/.github/workflows/comp-compile-application-code.yaml
+++ b/.github/workflows/comp-compile-application-code.yaml
@@ -109,8 +109,8 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # pin@v3
 
-      - name: Expand Shallow Clone for SonarQube
-        if: ${{ (inputs.enable-sonar-analysis || inputs.enable-unit-tests) && github.event.pull_request.head.repo.full_name == github.repository && !cancelled() }}
+      - name: Expand Shallow Clone for SonarQube and Spotless
+        if: ${{ (inputs.enable-sonar-analysis || inputs.enable-unit-tests) && !cancelled() }}
         run: |
           git fetch --unshallow --no-recurse-submodules
 

--- a/.github/workflows/comp-compile-application-code.yaml
+++ b/.github/workflows/comp-compile-application-code.yaml
@@ -110,7 +110,7 @@ jobs:
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # pin@v3
 
       - name: Expand Shallow Clone for SonarQube
-        if: ${{ (inputs.enable-sonar-analysis || inputs.enable-unit-tests) && !cancelled() && github.repository_owner == 'hashgraph' }}
+        if: ${{ (inputs.enable-sonar-analysis || inputs.enable-unit-tests) && github.event.pull_request.head.repo.full_name == github.repository && !cancelled() }}
         run: |
           git fetch --unshallow --no-recurse-submodules
 
@@ -233,7 +233,7 @@ jobs:
         id: sonar-cloud
         env:
           IS_PULL_REQUEST: ${{ github.event_name == 'pull_request' || github.event_name == 'pull_request_target' }}
-        if: ${{ inputs.enable-sonar-analysis && steps.gradle-build.conclusion == 'success' && !cancelled() && github.repository_owner == 'hashgraph' }}
+        if: ${{ inputs.enable-sonar-analysis && steps.gradle-build.conclusion == 'success' && github.event.pull_request.head.repo.full_name == github.repository && !cancelled() }}
         run: |
           SONAR_OPTS="-Dsonar.branch.name=${{ github.ref_name }}"
           if [[ "${IS_PULL_REQUEST}" == true ]]; then
@@ -248,7 +248,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.access-token }}
           SONAR_TOKEN: ${{ secrets.sonar-token }}
           SONAR_OPTS: ${{ steps.sonar-cloud.outputs.options }}
-        if: ${{ inputs.enable-sonar-analysis && steps.gradle-build.conclusion == 'success' && !cancelled() && github.repository_owner == 'hashgraph' }}
+        if: ${{ inputs.enable-sonar-analysis && steps.gradle-build.conclusion == 'success' && github.event.pull_request.head.repo.full_name == github.repository && !cancelled() }}
         with:
           gradle-version: ${{ inputs.gradle-version }}
           arguments: sonarqube --info --scan

--- a/.github/workflows/flow-pull-request-checks.yaml
+++ b/.github/workflows/flow-pull-request-checks.yaml
@@ -48,12 +48,8 @@ jobs:
     if: ${{ contains(github.event.pull_request.labels.*.name, 'CI:UnitTests') || contains(github.event.pull_request.labels.*.name, 'CI:FinalChecks') }}
     steps:
       - name: Check Labels
-        uses: jesusvasquez333/verify-pr-label-action@657d111bbbe13e22bbd55870f1813c699bde1401 # pin@v1.4.0
         if: github.event_name == 'pull_request'
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          valid-labels: "CI:UnitTests, CI:FinalChecks"
-          disable-reviews: true
+        run: echo PR labels that trigger the tests are [CI:UnitTests] and [CI:FinalChecks]
 
   unit-tests:
     name: Unit Tests


### PR DESCRIPTION

**Description**:
Allows the PR checks workflow to run on PRs from forks

* Removes a dependency on a third party action


**Related issue(s)**:

Fixes #

**Notes for reviewer**:
This PR removes the use of the third party `verify-pr-label-action` and relies on the built in if checks which allows the workflow to work on PRs from forks, without requiring the use of the less secure `pull_request_target` event type.
The separate Label Check step is left for better readability of the workflow and to make it clear and easy to understand for everyone how to trigger the tests.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
