### PR TITLE
Define `SignatureVerifier` API

### DIFF
--- a/hedera-node/hedera-app-spi/build.gradle.kts
+++ b/hedera-node/hedera-app-spi/build.gradle.kts
@@ -34,6 +34,7 @@ configurations.all {
 
 dependencies {
     implementation(libs.grpc.stub)
+    implementation(libs.swirlds.common)
     api(libs.hapi)
     api(libs.helidon.io.grpc)
     api(libs.jsr305.annotation)

--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/signatures/OverrideSignatureVerifier.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/signatures/OverrideSignatureVerifier.java
@@ -20,8 +20,8 @@ import com.swirlds.common.crypto.VerificationStatus;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 /**
- * Given a non-cryptographic key, returns whether it should be considered to have signed at the
- * current checkpoint.
+ * Given a Hedera key, returns whether it should be considered to have signed at the current
+ * checkpoint.
  *
  * <p>The EVM system contracts need this interface to allow the {@link SignatureVerifier} to
  * correctly test keys of type {@code contractID} and {@code delegatable_contract_id}.
@@ -30,7 +30,9 @@ import edu.umd.cs.findbugs.annotations.NonNull;
  * to detect valid signatures already added to the scheduled transaction, perhaps long ago, and not
  * present in the current transaction's {@code SignatureMap}.
  *
- * <p>
+ * <p>The {@code FileDelete} transaction handler needs this interface to provide "revocation
+ * service" semantics; i.e. such that if the target file's admin key is a {@code KeyList}, then a
+ * single signature in that list suffices to remove it.
  */
 @FunctionalInterface
 public interface OverrideSignatureVerifier {

--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/signatures/OverrideSignatureVerifier.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/signatures/OverrideSignatureVerifier.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hedera.node.app.spi.signatures;
+
+import com.hedera.node.app.spi.key.HederaKey;
+import com.swirlds.common.crypto.VerificationStatus;
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+/**
+ * Given a non-cryptographic key, returns whether it should be considered to have signed at the
+ * current checkpoint.
+ *
+ * <p>The EVM system contracts need this interface to allow the {@link SignatureVerifier} to
+ * correctly test keys of type {@code contractID} and {@code delegatable_contract_id}.
+ *
+ * <p>The scheduled transaction service needs this interface to allow the {@link SignatureVerifier}
+ * to detect valid signatures already added to the scheduled transaction, perhaps long ago, and not
+ * present in the current transaction's {@code SignatureMap}.
+ *
+ * <p>
+ */
+@FunctionalInterface
+public interface OverrideSignatureVerifier {
+    /**
+     * Given a key, returns whether it should be considered to have signed at the current
+     * checkpoint. Implementations are free to return {@link VerificationStatus#UNKNOWN} if they
+     * cannot determine the answer.
+     *
+     * @param key the key to test
+     * @return whether the key has signed, if known
+     */
+    @NonNull
+    VerificationStatus hasSigned(@NonNull HederaKey key);
+}

--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/signatures/SignatureVerifier.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/signatures/SignatureVerifier.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hedera.node.app.spi.signatures;
+
+import com.hedera.node.app.spi.Service;
+import com.hedera.node.app.spi.key.HederaKey;
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+/**
+ * Allows either a workflow or a {@link Service} to test if a {@link HederaKey} has signed at the
+ * current point in the workflow.
+ *
+ * <p>There are three kinds of "checkpoints" where we test signatures:
+ *
+ * <ol>
+ *   <li>Before submitting or executing a top-level HAPI transaction.
+ *   <li>Before triggering the execution of a scheduled transaction.
+ *   <li>Before executing a EVM system contract.
+ * </ol>
+ *
+ * Note that workflows are solely responsible for enforcing the first checkpoint, while {@link
+ * Service} business logic must detect and enforce the second and third checkpoints.
+ */
+public interface SignatureVerifier {
+    /**
+     * Returns whether the given key has signed at the current checkpoint.
+     *
+     * @param key the key to test
+     * @return whether the key has signed
+     */
+    boolean hasSigned(@NonNull HederaKey key);
+
+    /**
+     * Returns whether the given key has signed at the current checkpoint, giving priority to
+     * verdicts from the given {@link OverrideSignatureVerifier}. That is, if the given {@link
+     * OverrideSignatureVerifier} returns either {@link
+     * com.swirlds.common.crypto.VerificationStatus#VALID} or {@link
+     * com.swirlds.common.crypto.VerificationStatus#INVALID}, then that verdict is returned.
+     * Otherwise, this {@link SignatureVerifier} gives the final verdict.
+     *
+     * @param key the key to test
+     * @param override the {@link OverrideSignatureVerifier} to consult first
+     * @return whether the key has signed
+     */
+    boolean hasSigned(@NonNull HederaKey key, @NonNull OverrideSignatureVerifier override);
+}

--- a/hedera-node/hedera-app-spi/src/main/java/module-info.java
+++ b/hedera-node/hedera-app-spi/src/main/java/module-info.java
@@ -1,6 +1,7 @@
 module com.hedera.node.app.spi {
     requires transitive com.hedera.hashgraph.protobuf.java.api;
     requires static transitive com.github.spotbugs.annotations;
+    requires com.swirlds.common;
 
     exports com.hedera.node.app.spi;
     exports com.hedera.node.app.spi.state;

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/legacy/core/jproto/JContractIDKey.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/legacy/core/jproto/JContractIDKey.java
@@ -17,7 +17,20 @@ package com.hedera.node.app.service.mono.legacy.core.jproto;
 
 import com.hederahashgraph.api.proto.java.ContractID;
 
-/** Maps to proto Key of type contractID. */
+/**
+ * Maps to proto Key of type contractID.
+ *
+ * <p>Just as a public-private key pair is used to control permissions for a Hedera entity (e.g., an
+ * account), a {@code contractID} key is <i>also</i> used to control permissions for an entity. The
+ * difference is that a {@code contractID} key requires a particular contract to be executing in
+ * order to count as having "signed".
+ *
+ * <p>For example, suppose {@code 0.0.X} is an account. Its key is {@code Key{contractID=0.0.C}}.
+ *
+ * <p>Then <b>if</b> we are executing a contract operation, and the EVM receiver address in the
+ * current frame is {@code 0.0.C}, then this EVM transaction can use system contracts to, for
+ * example, transfer all the hbar from account {@code 0.0.X}.
+ */
 public class JContractIDKey extends JKey {
     private final long shardNum;
     private final long realmNum;


### PR DESCRIPTION
**Description**:
 - Adds SPI types for the Hedera signature verification facility.
 - ⚠️  Possibly controversial: Adds SPI dependency on `com.swirlds.common` to re-use platform's `VerificationStatus` enum.
 - ⚠️ Also provocative: Claims in javadoc that there are three instances where business logic will at least participate in enforcing signing requirements (within an EVM system contract, before triggering a scheduled transaction, and evaluating the top-level signature on a `FileDelete`).