### PR TITLE
Add Singleton States

### DIFF
--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/state/EmptyReadableStates.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/state/EmptyReadableStates.java
@@ -26,7 +26,14 @@ public final class EmptyReadableStates implements ReadableStates {
     @Override
     public <K extends Comparable<K>, V> ReadableKVState<K, V> get(@NonNull String stateKey) {
         Objects.requireNonNull(stateKey);
-        throw new IllegalArgumentException("There are no states");
+        throw new IllegalArgumentException("There are no k/v states");
+    }
+
+    @NonNull
+    @Override
+    public <T> ReadableSingletonState<T> getSingleton(@NonNull String stateKey) {
+        Objects.requireNonNull(stateKey);
+        throw new IllegalArgumentException("There are no singleton states");
     }
 
     @Override

--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/state/EmptyWritableStates.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/state/EmptyWritableStates.java
@@ -26,7 +26,14 @@ public final class EmptyWritableStates implements WritableStates {
     @Override
     public <K extends Comparable<K>, V> WritableKVState<K, V> get(@NonNull String stateKey) {
         Objects.requireNonNull(stateKey);
-        throw new IllegalArgumentException("There are no states");
+        throw new IllegalArgumentException("There are no k/v states");
+    }
+
+    @NonNull
+    @Override
+    public <T> WritableSingletonState<T> getSingleton(@NonNull String stateKey) {
+        Objects.requireNonNull(stateKey);
+        throw new IllegalArgumentException("There are no singleton states");
     }
 
     @Override

--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/state/FilteredReadableStates.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/state/FilteredReadableStates.java
@@ -52,10 +52,21 @@ public class FilteredReadableStates implements ReadableStates {
     public <K extends Comparable<K>, V> ReadableKVState<K, V> get(@NonNull String stateKey) {
         Objects.requireNonNull(stateKey);
         if (!contains(stateKey)) {
-            throw new IllegalArgumentException("Could not find state " + stateKey);
+            throw new IllegalArgumentException("Could not find k/v state " + stateKey);
         }
 
         return delegate.get(stateKey);
+    }
+
+    @NonNull
+    @Override
+    public <T> ReadableSingletonState<T> getSingleton(@NonNull String stateKey) {
+        Objects.requireNonNull(stateKey);
+        if (!contains(stateKey)) {
+            throw new IllegalArgumentException("Could not find singleton state " + stateKey);
+        }
+
+        return delegate.getSingleton(stateKey);
     }
 
     @Override

--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/state/FilteredWritableStates.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/state/FilteredWritableStates.java
@@ -44,9 +44,20 @@ public class FilteredWritableStates extends FilteredReadableStates implements Wr
     public <K extends Comparable<K>, V> WritableKVState<K, V> get(@NonNull String stateKey) {
         Objects.requireNonNull(stateKey);
         if (!contains(stateKey)) {
-            throw new IllegalArgumentException("Could not find state " + stateKey);
+            throw new IllegalArgumentException("Could not find k/v state " + stateKey);
         }
 
         return delegate.get(stateKey);
+    }
+
+    @NonNull
+    @Override
+    public <T> WritableSingletonState<T> getSingleton(@NonNull String stateKey) {
+        Objects.requireNonNull(stateKey);
+        if (!contains(stateKey)) {
+            throw new IllegalArgumentException("Could not find singleton state " + stateKey);
+        }
+
+        return delegate.getSingleton(stateKey);
     }
 }

--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/state/ReadableSingletonState.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/state/ReadableSingletonState.java
@@ -52,5 +52,5 @@ public interface ReadableSingletonState<T> {
      *
      * @return true if {@link #get()} has been called on this instance
      */
-    boolean read();
+    boolean isRead();
 }

--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/state/ReadableSingletonState.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/state/ReadableSingletonState.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hedera.node.app.spi.state;
+
+public interface ReadableSingletonState<T> {
+    String getStateKey();
+
+    T get();
+
+    boolean read();
+}

--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/state/ReadableSingletonState.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/state/ReadableSingletonState.java
@@ -19,10 +19,9 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 
 /**
- * Provides stateful access to a singleton type. Most state in Hedera is k/v state,
- * represented by {@link ReadableKVState}. But some state is not based on a map,
- * but is rather a single instance, such as the AddressBook information. This
- * type can be used to access that state.
+ * Provides stateful access to a singleton type. Most state in Hedera is k/v state, represented by
+ * {@link ReadableKVState}. But some state is not based on a map, but is rather a single instance,
+ * such as the AddressBook information. This type can be used to access that state.
  *
  * @param <T> The type of the state, such as an AddressBook or NetworkData.
  */
@@ -50,6 +49,7 @@ public interface ReadableSingletonState<T> {
 
     /**
      * Gets whether the value of this {@link ReadableSingletonState} has been read.
+     *
      * @return true if {@link #get()} has been called on this instance
      */
     boolean read();

--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/state/ReadableSingletonState.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/state/ReadableSingletonState.java
@@ -15,10 +15,42 @@
  */
 package com.hedera.node.app.spi.state;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+
+/**
+ * Provides stateful access to a singleton type. Most state in Hedera is k/v state,
+ * represented by {@link ReadableKVState}. But some state is not based on a map,
+ * but is rather a single instance, such as the AddressBook information. This
+ * type can be used to access that state.
+ *
+ * @param <T> The type of the state, such as an AddressBook or NetworkData.
+ */
 public interface ReadableSingletonState<T> {
+    /**
+     * Gets the "state key" that uniquely identifies this {@link ReadableKVState} within the {@link
+     * Schema} which are scoped to the service implementation. The key is therefore not globally
+     * unique, only unique within the service implementation itself.
+     *
+     * <p>The call is idempotent, always returning the same value. It must never return null.
+     *
+     * @return The state key. This will never be null, and will always be the same value for an
+     *     instance of {@link ReadableKVState}.
+     */
+    @NonNull
     String getStateKey();
 
+    /**
+     * Gets the singleton value.
+     *
+     * @return The value, or null if there is no value.
+     */
+    @Nullable
     T get();
 
+    /**
+     * Gets whether the value of this {@link ReadableSingletonState} has been read.
+     * @return true if {@link #get()} has been called on this instance
+     */
     boolean read();
 }

--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/state/ReadableSingletonStateBase.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/state/ReadableSingletonStateBase.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hedera.node.app.spi.state;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.Objects;
+import java.util.function.Supplier;
+
+public class ReadableSingletonStateBase<T> implements ReadableSingletonState<T> {
+    private final String stateKey;
+    private final Supplier<T> backingStoreAccessor;
+    private boolean read = false;
+
+    public ReadableSingletonStateBase(
+            @NonNull final String stateKey, @NonNull final Supplier<T> backingStoreAccessor) {
+        this.stateKey = Objects.requireNonNull(stateKey);
+        this.backingStoreAccessor = Objects.requireNonNull(backingStoreAccessor);
+    }
+
+    @Override
+    public final String getStateKey() {
+        return stateKey;
+    }
+
+    @Override
+    public T get() {
+        // TODO Should this be cached after first read? Repeatable read vs. dirty read
+        this.read = true;
+        return backingStoreAccessor.get();
+    }
+
+    @Override
+    public boolean read() {
+        return read;
+    }
+
+    public void reset() {
+        this.read = false;
+    }
+}

--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/state/ReadableSingletonStateBase.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/state/ReadableSingletonStateBase.java
@@ -50,13 +50,12 @@ public class ReadableSingletonStateBase<T> implements ReadableSingletonState<T> 
 
     @Override
     public T get() {
-        // TODO Should this be cached after first read? Repeatable read vs. dirty read
         this.read = true;
         return backingStoreAccessor.get();
     }
 
     @Override
-    public boolean read() {
+    public boolean isRead() {
         return read;
     }
 

--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/state/ReadableSingletonStateBase.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/state/ReadableSingletonStateBase.java
@@ -33,7 +33,8 @@ public class ReadableSingletonStateBase<T> implements ReadableSingletonState<T> 
      * Creates a new instance.
      *
      * @param stateKey The state key for this instance
-     * @param backingStoreAccessor A {@link Supplier} that provides access to the value in the backing store.
+     * @param backingStoreAccessor A {@link Supplier} that provides access to the value in the
+     *     backing store.
      */
     public ReadableSingletonStateBase(
             @NonNull final String stateKey, @NonNull final Supplier<T> backingStoreAccessor) {

--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/state/ReadableSingletonStateBase.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/state/ReadableSingletonStateBase.java
@@ -19,11 +19,22 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.Objects;
 import java.util.function.Supplier;
 
+/**
+ * A convenient implementation of {@link ReadableSingletonStateBase}.
+ *
+ * @param <T> The type of the value
+ */
 public class ReadableSingletonStateBase<T> implements ReadableSingletonState<T> {
     private final String stateKey;
     private final Supplier<T> backingStoreAccessor;
     private boolean read = false;
 
+    /**
+     * Creates a new instance.
+     *
+     * @param stateKey The state key for this instance
+     * @param backingStoreAccessor A {@link Supplier} that provides access to the value in the backing store.
+     */
     public ReadableSingletonStateBase(
             @NonNull final String stateKey, @NonNull final Supplier<T> backingStoreAccessor) {
         this.stateKey = Objects.requireNonNull(stateKey);
@@ -31,6 +42,7 @@ public class ReadableSingletonStateBase<T> implements ReadableSingletonState<T> 
     }
 
     @Override
+    @NonNull
     public final String getStateKey() {
         return stateKey;
     }
@@ -47,6 +59,7 @@ public class ReadableSingletonStateBase<T> implements ReadableSingletonState<T> 
         return read;
     }
 
+    /** Clears any cached data, including whether the instance has been read. */
     public void reset() {
         this.read = false;
     }

--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/state/ReadableStates.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/state/ReadableStates.java
@@ -39,6 +39,9 @@ public interface ReadableStates {
     @NonNull
     <K extends Comparable<K>, V> ReadableKVState<K, V> get(@NonNull String stateKey);
 
+    @NonNull
+    <T> ReadableSingletonState<T> getSingleton(@NonNull String stateKey);
+
     /**
      * Gets whether the given state key is a member of this set.
      *

--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/state/StateDefinition.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/state/StateDefinition.java
@@ -100,10 +100,11 @@ public record StateDefinition<K extends Comparable<K>, V>(
      * @param stateKey The state key
      * @param valueSerdes The serdes for the singleton value
      * @return An instance of {@link StateDefinition}
-     * @param <T> The type of the singleton
+     * @param <K> The key type
+     * @param <V> The value type
      */
-    public static <T> StateDefinition<?, T> singleton(
-            @NonNull final String stateKey, @NonNull final Serdes<T> valueSerdes) {
+    public static <K extends Comparable<K>, V> StateDefinition<K, V> singleton(
+            @NonNull final String stateKey, @NonNull final Serdes<V> valueSerdes) {
         return new StateDefinition<>(stateKey, null, valueSerdes, 1, false, true);
     }
 }

--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/state/StateDefinition.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/state/StateDefinition.java
@@ -40,6 +40,8 @@ public record StateDefinition<K extends Comparable<K>, V>(
         boolean onDisk,
         boolean singleton) {
 
+    private static final int NO_MAX = -1;
+
     public StateDefinition {
         if (singleton && onDisk) {
             throw new IllegalArgumentException("A state cannot both be 'singleton' and 'onDisk'");
@@ -70,7 +72,7 @@ public record StateDefinition<K extends Comparable<K>, V>(
             @NonNull final String stateKey,
             @NonNull final Serdes<K> keySerdes,
             @NonNull final Serdes<V> valueSerdes) {
-        return new StateDefinition<>(stateKey, keySerdes, valueSerdes, -1, false, false);
+        return new StateDefinition<>(stateKey, keySerdes, valueSerdes, NO_MAX, false, false);
     }
 
     /**
@@ -105,6 +107,6 @@ public record StateDefinition<K extends Comparable<K>, V>(
      */
     public static <K extends Comparable<K>, V> StateDefinition<K, V> singleton(
             @NonNull final String stateKey, @NonNull final Serdes<V> valueSerdes) {
-        return new StateDefinition<>(stateKey, null, valueSerdes, 1, false, true);
+        return new StateDefinition<>(stateKey, null, valueSerdes, NO_MAX, false, true);
     }
 }

--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/state/WritableSingletonState.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/state/WritableSingletonState.java
@@ -15,8 +15,24 @@
  */
 package com.hedera.node.app.spi.state;
 
-public interface WritableSingletonState<T> extends ReadableSingletonState<T> {
-    void put(T value);
+import edu.umd.cs.findbugs.annotations.Nullable;
 
+/**
+ * Provides mutable access to singleton state.
+ *
+ * @param <T> The type of the state
+ */
+public interface WritableSingletonState<T> extends ReadableSingletonState<T> {
+    /**
+     * Sets the given value on this state.
+     *
+     * @param value The value. May be null.
+     */
+    void put(@Nullable T value);
+
+    /**
+     * Gets whether the {@link #put(Object)} method has been called on this instance.
+     * @return True if the {@link #put(Object)} method has been called
+     */
     boolean modified();
 }

--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/state/WritableSingletonState.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/state/WritableSingletonState.java
@@ -35,5 +35,5 @@ public interface WritableSingletonState<T> extends ReadableSingletonState<T> {
      *
      * @return True if the {@link #put(Object)} method has been called
      */
-    boolean modified();
+    boolean isModified();
 }

--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/state/WritableSingletonState.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/state/WritableSingletonState.java
@@ -32,6 +32,7 @@ public interface WritableSingletonState<T> extends ReadableSingletonState<T> {
 
     /**
      * Gets whether the {@link #put(Object)} method has been called on this instance.
+     *
      * @return True if the {@link #put(Object)} method has been called
      */
     boolean modified();

--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/state/WritableSingletonState.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/state/WritableSingletonState.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hedera.node.app.spi.state;
+
+public interface WritableSingletonState<T> extends ReadableSingletonState<T> {
+    void put(T value);
+
+    boolean modified();
+}

--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/state/WritableSingletonStateBase.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/state/WritableSingletonStateBase.java
@@ -22,6 +22,7 @@ import java.util.function.Supplier;
 
 /**
  * A convenient base class for mutable singletons.
+ *
  * @param <T> The type
  */
 public class WritableSingletonStateBase<T> extends ReadableSingletonStateBase<T>
@@ -32,8 +33,10 @@ public class WritableSingletonStateBase<T> extends ReadableSingletonStateBase<T>
 
     /**
      * Creates a new instance.
+     *
      * @param stateKey The state key for this instance
-     * @param backingStoreAccessor A {@link Supplier} that provides access to the value in the backing store.
+     * @param backingStoreAccessor A {@link Supplier} that provides access to the value in the
+     *     backing store.
      * @param backingStoreMutator A {@link Consumer} for mutating the value in the backing store.
      */
     public WritableSingletonStateBase(
@@ -69,8 +72,8 @@ public class WritableSingletonStateBase<T> extends ReadableSingletonStateBase<T>
 
     /**
      * Flushes all changes into the underlying data store. This method should <strong>ONLY</strong>
-     * be called by the code that created the {@link WritableSingletonStateBase} instance or owns it.
-     * Don't cast and commit unless you own the instance!
+     * be called by the code that created the {@link WritableSingletonStateBase} instance or owns
+     * it. Don't cast and commit unless you own the instance!
      */
     public void commit() {
         if (modified) {
@@ -82,7 +85,7 @@ public class WritableSingletonStateBase<T> extends ReadableSingletonStateBase<T>
      * {@inheritDoc}
      *
      * <p>Clears the "modified" and cached value, in addition to the super implementation
-     * */
+     */
     @Override
     public void reset() {
         this.modified = false;

--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/state/WritableSingletonStateBase.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/state/WritableSingletonStateBase.java
@@ -66,7 +66,7 @@ public class WritableSingletonStateBase<T> extends ReadableSingletonStateBase<T>
     }
 
     @Override
-    public boolean modified() {
+    public boolean isModified() {
         return modified;
     }
 

--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/state/WritableSingletonStateBase.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/state/WritableSingletonStateBase.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hedera.node.app.spi.state;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.Objects;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+public class WritableSingletonStateBase<T> extends ReadableSingletonStateBase<T>
+        implements WritableSingletonState<T> {
+    private final Consumer<T> backingStoreMutator;
+    private boolean modified;
+    private T value;
+
+    public WritableSingletonStateBase(
+            @NonNull final String stateKey,
+            @NonNull final Supplier<T> backingStoreAccessor,
+            @NonNull final Consumer<T> backingStoreMutator) {
+        super(stateKey, backingStoreAccessor);
+        this.backingStoreMutator = Objects.requireNonNull(backingStoreMutator);
+    }
+
+    @Override
+    public T get() {
+        // Possible pattern: "put" and then "get". In this case, "read" should be false!! Otherwise
+        // we invalidate tx when we don't need to
+        if (modified) {
+            return value;
+        }
+
+        value = super.get();
+        return value;
+    }
+
+    @Override
+    public void put(T value) {
+        this.modified = true;
+        this.value = value;
+    }
+
+    @Override
+    public boolean modified() {
+        return modified;
+    }
+
+    public void commit() {
+        if (modified) {
+            backingStoreMutator.accept(value);
+        }
+    }
+
+    @Override
+    public void reset() {
+        this.modified = false;
+        this.value = null;
+        super.reset();
+    }
+}

--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/state/WritableSingletonStateBase.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/state/WritableSingletonStateBase.java
@@ -20,12 +20,22 @@ import java.util.Objects;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
+/**
+ * A convenient base class for mutable singletons.
+ * @param <T> The type
+ */
 public class WritableSingletonStateBase<T> extends ReadableSingletonStateBase<T>
         implements WritableSingletonState<T> {
     private final Consumer<T> backingStoreMutator;
     private boolean modified;
     private T value;
 
+    /**
+     * Creates a new instance.
+     * @param stateKey The state key for this instance
+     * @param backingStoreAccessor A {@link Supplier} that provides access to the value in the backing store.
+     * @param backingStoreMutator A {@link Consumer} for mutating the value in the backing store.
+     */
     public WritableSingletonStateBase(
             @NonNull final String stateKey,
             @NonNull final Supplier<T> backingStoreAccessor,
@@ -57,12 +67,22 @@ public class WritableSingletonStateBase<T> extends ReadableSingletonStateBase<T>
         return modified;
     }
 
+    /**
+     * Flushes all changes into the underlying data store. This method should <strong>ONLY</strong>
+     * be called by the code that created the {@link WritableSingletonStateBase} instance or owns it.
+     * Don't cast and commit unless you own the instance!
+     */
     public void commit() {
         if (modified) {
             backingStoreMutator.accept(value);
         }
     }
 
+    /**
+     * {@inheritDoc}
+     *
+     * <p>Clears the "modified" and cached value, in addition to the super implementation
+     * */
     @Override
     public void reset() {
         this.modified = false;

--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/state/WritableStates.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/state/WritableStates.java
@@ -26,10 +26,10 @@ public interface WritableStates extends ReadableStates {
      * the {@link Schema}.
      *
      * @param stateKey The key used for looking up state
-     * @param <K>      The key type in the state.
-     * @param <V>      The value type in the state.
+     * @param <K> The key type in the state.
+     * @param <V> The value type in the state.
      * @return The state for that key. This will never be null.
-     * @throws NullPointerException     if stateKey is null.
+     * @throws NullPointerException if stateKey is null.
      * @throws IllegalArgumentException if the state cannot be found.
      */
     @Override

--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/state/WritableStates.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/state/WritableStates.java
@@ -35,4 +35,8 @@ public interface WritableStates extends ReadableStates {
     @Override
     @NonNull
     <K extends Comparable<K>, V> WritableKVState<K, V> get(@NonNull String stateKey);
+
+    @Override
+    @NonNull
+    <T> WritableSingletonState<T> getSingleton(@NonNull String stateKey);
 }

--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/state/WritableStates.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/state/WritableStates.java
@@ -26,10 +26,10 @@ public interface WritableStates extends ReadableStates {
      * the {@link Schema}.
      *
      * @param stateKey The key used for looking up state
+     * @param <K>      The key type in the state.
+     * @param <V>      The value type in the state.
      * @return The state for that key. This will never be null.
-     * @param <K> The key type in the state.
-     * @param <V> The value type in the state.
-     * @throws NullPointerException if stateKey is null.
+     * @throws NullPointerException     if stateKey is null.
      * @throws IllegalArgumentException if the state cannot be found.
      */
     @Override

--- a/hedera-node/hedera-app-spi/src/test/java/com/hedera/node/app/spi/state/EmptyReadableStatesTest.java
+++ b/hedera-node/hedera-app-spi/src/test/java/com/hedera/node/app/spi/state/EmptyReadableStatesTest.java
@@ -55,4 +55,11 @@ class EmptyReadableStatesTest extends StateTestBase {
         assertThatThrownBy(() -> states.get(UNKNOWN_KEY))
                 .isInstanceOf(IllegalArgumentException.class);
     }
+
+    @Test
+    @DisplayName("Throws IAE for any non-null singleton key")
+    void nonNullSingletonKey() {
+        assertThatThrownBy(() -> states.getSingleton(UNKNOWN_KEY))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
 }

--- a/hedera-node/hedera-app-spi/src/test/java/com/hedera/node/app/spi/state/EmptyWritableStatesTest.java
+++ b/hedera-node/hedera-app-spi/src/test/java/com/hedera/node/app/spi/state/EmptyWritableStatesTest.java
@@ -55,4 +55,11 @@ class EmptyWritableStatesTest extends StateTestBase {
         assertThatThrownBy(() -> states.get(UNKNOWN_KEY))
                 .isInstanceOf(IllegalArgumentException.class);
     }
+
+    @Test
+    @DisplayName("Throws IAE for any non-null singleton key")
+    void nonNullSingletonKey() {
+        assertThatThrownBy(() -> states.getSingleton(UNKNOWN_KEY))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
 }

--- a/hedera-node/hedera-app-spi/src/test/java/com/hedera/node/app/spi/state/FilteredReadableStatesTest.java
+++ b/hedera-node/hedera-app-spi/src/test/java/com/hedera/node/app/spi/state/FilteredReadableStatesTest.java
@@ -70,6 +70,13 @@ class FilteredReadableStatesTest {
             assertThatThrownBy(() -> states.get(UNKNOWN_KEY))
                     .isInstanceOf(IllegalArgumentException.class);
         }
+
+        @Test
+        @DisplayName("Throws IAE for any non-null Singleton key")
+        void nonNullSingletonKey() {
+            assertThatThrownBy(() -> states.getSingleton(UNKNOWN_KEY))
+                    .isInstanceOf(IllegalArgumentException.class);
+        }
     }
 
     @Nested
@@ -113,6 +120,13 @@ class FilteredReadableStatesTest {
             assertThatThrownBy(() -> states.get(UNKNOWN_KEY))
                     .isInstanceOf(IllegalArgumentException.class);
         }
+
+        @Test
+        @DisplayName("Throws IAE for any non-null Singleton key")
+        void nonNullSingletonKey() {
+            assertThatThrownBy(() -> states.getSingleton(UNKNOWN_KEY))
+                    .isInstanceOf(IllegalArgumentException.class);
+        }
     }
 
     @Nested
@@ -125,12 +139,14 @@ class FilteredReadableStatesTest {
             final var delegate =
                     MapReadableStates.builder()
                             .state(readableFruitState())
-                            .state(readableCountryState())
+                            .state(readableCountryState()) // <-- singleton state
                             .state(readableAnimalState())
+                            .state(readableSpaceState()) // <-- singleton state
                             .state(readableSTEAMState())
                             .build();
             states =
-                    new FilteredReadableStates(delegate, Set.of(ANIMAL_STATE_KEY, STEAM_STATE_KEY));
+                    new FilteredReadableStates(
+                            delegate, Set.of(ANIMAL_STATE_KEY, COUNTRY_STATE_KEY));
         }
 
         @Test
@@ -149,16 +165,17 @@ class FilteredReadableStatesTest {
         @DisplayName("Contains")
         void contains() {
             assertThat(states.contains(FRUIT_STATE_KEY)).isFalse();
-            assertThat(states.contains(COUNTRY_STATE_KEY)).isFalse();
+            assertThat(states.contains(COUNTRY_STATE_KEY)).isTrue();
             assertThat(states.contains(ANIMAL_STATE_KEY)).isTrue();
-            assertThat(states.contains(STEAM_STATE_KEY)).isTrue();
+            assertThat(states.contains(STEAM_STATE_KEY)).isFalse();
+            assertThat(states.contains(SPACE_STATE_KEY)).isFalse();
         }
 
         @Test
         @DisplayName("Can read the 2 states")
         void acceptedStates() {
             assertThat(states.get(ANIMAL_STATE_KEY)).isNotNull();
-            assertThat(states.get(STEAM_STATE_KEY)).isNotNull();
+            assertThat(states.getSingleton(COUNTRY_STATE_KEY)).isNotNull();
         }
 
         @Test
@@ -166,7 +183,9 @@ class FilteredReadableStatesTest {
         void filteredStates() {
             assertThatThrownBy(() -> states.get(FRUIT_STATE_KEY))
                     .isInstanceOf(IllegalArgumentException.class);
-            assertThatThrownBy(() -> states.get(COUNTRY_STATE_KEY))
+            assertThatThrownBy(() -> states.get(STEAM_STATE_KEY))
+                    .isInstanceOf(IllegalArgumentException.class);
+            assertThatThrownBy(() -> states.getSingleton(SPACE_STATE_KEY))
                     .isInstanceOf(IllegalArgumentException.class);
         }
     }
@@ -178,16 +197,27 @@ class FilteredReadableStatesTest {
 
         @BeforeEach
         void setUp() {
-            final var delegate = MapReadableStates.builder().state(readableFruitState()).build();
-            states = new FilteredReadableStates(delegate, Set.of(FRUIT_STATE_KEY, SPACE_STATE_KEY));
+            final var delegate =
+                    MapReadableStates.builder()
+                            .state(readableFruitState())
+                            .state(readableCountryState())
+                            .build();
+            states =
+                    new FilteredReadableStates(
+                            delegate,
+                            Set.of(
+                                    FRUIT_STATE_KEY,
+                                    ANIMAL_STATE_KEY,
+                                    COUNTRY_STATE_KEY,
+                                    SPACE_STATE_KEY));
         }
 
         @Test
         @DisplayName(
-                "Exactly 1 states was included because only one of two filtered states were in the"
-                        + " delegate")
+                "Exactly 2 states were included because only two of four filtered states were in"
+                        + " the delegate")
         void size() {
-            assertThat(states.size()).isEqualTo(1);
+            assertThat(states.size()).isEqualTo(2);
         }
 
         @Test
@@ -200,19 +230,26 @@ class FilteredReadableStatesTest {
         @DisplayName("Contains")
         void contains() {
             assertThat(states.contains(FRUIT_STATE_KEY)).isTrue();
+            assertThat(states.contains(COUNTRY_STATE_KEY)).isTrue();
+            assertThat(states.contains(ANIMAL_STATE_KEY)).isFalse();
             assertThat(states.contains(SPACE_STATE_KEY)).isFalse();
         }
 
         @Test
-        @DisplayName("Can read FRUIT because it is in the acceptable set and in the delegate")
+        @DisplayName(
+                "Can read FRUIT and COUNTRY because they are in the acceptable set and in the"
+                        + " delegate")
         void acceptedStates() {
             assertThat(states.get(FRUIT_STATE_KEY)).isNotNull();
+            assertThat(states.getSingleton(COUNTRY_STATE_KEY)).isNotNull();
         }
 
         @Test
         @DisplayName("Cannot read STEM because it is not in the delegate")
         void missingState() {
-            assertThatThrownBy(() -> states.get(STEAM_STATE_KEY))
+            assertThatThrownBy(() -> states.get(ANIMAL_STATE_KEY))
+                    .isInstanceOf(IllegalArgumentException.class);
+            assertThatThrownBy(() -> states.getSingleton(SPACE_STATE_KEY))
                     .isInstanceOf(IllegalArgumentException.class);
         }
     }

--- a/hedera-node/hedera-app-spi/src/test/java/com/hedera/node/app/spi/state/ReadableSingletonStateBaseTest.java
+++ b/hedera-node/hedera-app-spi/src/test/java/com/hedera/node/app/spi/state/ReadableSingletonStateBaseTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hedera.node.app.spi.state;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class ReadableSingletonStateBaseTest extends SingletonStateTestBase {
+    @Override
+    protected ReadableSingletonStateBase<String> createState() {
+        return new ReadableSingletonStateBase<>(COUNTRY_STATE_KEY, backingStore::get);
+    }
+
+    @Test
+    @DisplayName("Constructor throws NPE if stateKey is null")
+    void nullStateKey() {
+        //noinspection DataFlowIssue
+        assertThatThrownBy(() -> new ReadableSingletonStateBase<>(null, () -> AUSTRALIA))
+                .isInstanceOf(NullPointerException.class);
+    }
+
+    /** Make sure the constructor is holding onto the state key properly */
+    @Test
+    @DisplayName("The state key must match what was provided in the constructor")
+    void testStateKey() {
+        final var state = new ReadableSingletonStateBase<>(COUNTRY_STATE_KEY, () -> AUSTRALIA);
+        assertThat(state.getStateKey()).isEqualTo(COUNTRY_STATE_KEY);
+    }
+
+    @Test
+    @DisplayName("Constructor throws NPE if backingStoreAccessor is null")
+    void nullAccessor() {
+        //noinspection DataFlowIssue
+        assertThatThrownBy(() -> new ReadableSingletonStateBase<>(COUNTRY_STATE_KEY, null))
+                .isInstanceOf(NullPointerException.class);
+    }
+}

--- a/hedera-node/hedera-app-spi/src/test/java/com/hedera/node/app/spi/state/SingletonStateTestBase.java
+++ b/hedera-node/hedera-app-spi/src/test/java/com/hedera/node/app/spi/state/SingletonStateTestBase.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hedera.node.app.spi.state;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+abstract class SingletonStateTestBase extends StateTestBase {
+    protected AtomicReference<String> backingStore = new AtomicReference<>(AUSTRALIA);
+
+    protected abstract ReadableSingletonStateBase<String> createState();
+
+    /**
+     * When we are asked to get an unknown item (something not in the backing store), the {@link
+     * ReadableSingletonStateBase} still needs to remember we read this value, because the fact that
+     * the value was missing might be an important piece of information when working in pre-handle.
+     */
+    @Test
+    @DisplayName("`get` with no value")
+    void testNonExistingGet() {
+        backingStore.set(null);
+        final var state = createState();
+        assertThat(state.read()).isFalse();
+        assertThat(state.get()).isNull();
+        assertThat(state.read()).isTrue();
+    }
+
+    /**
+     * When asked to get a known item, not only is it returned, but we also record this in the
+     * "readKeys".
+     */
+    @Test
+    @DisplayName("`get` of a known item returns that item")
+    void testExistingGet() {
+        backingStore.set(BRAZIL);
+        final var state = createState();
+        assertThat(state.read()).isFalse();
+        assertThat(state.get()).isEqualTo(BRAZIL);
+        assertThat(state.read()).isTrue();
+    }
+
+    @Test
+    @DisplayName("`reset` clears the readKeys cache")
+    void testReset() {
+        // Given a state which has been read and has the "read" flag set
+        backingStore.set(CHAD);
+        final var state = createState();
+        assertThat(state.get()).isEqualTo(CHAD);
+        assertThat(state.read()).isTrue();
+
+        // When we reset
+        state.reset();
+
+        // Then the "read" flag is false
+        assertThat(state.read()).isFalse();
+
+        // And when the value in the backing store is changed
+        backingStore.set(DENMARK);
+        // Then it doesn't affect the state
+        assertThat(state.read()).isFalse();
+
+        // Until we ask for the value, and then it shows the new value
+        assertThat(state.get()).isEqualTo(DENMARK);
+        assertThat(state.read()).isTrue();
+    }
+
+    /**
+     * This specific behavior should never show up in actual code, because all states associated
+     * with a transaction are destroyed after having been committed (or in a nested/wrapped
+     * scenario, we shouldn't be updating the backing data while a wrapped data is being used).
+     * However, in such a situation, the right behavior is to show the updated values in the backing
+     * store, unless the value has been overridden in this state (which cannot happen on readable
+     * states).
+     */
+    @Test
+    @DisplayName("State sees changes committed to backend")
+    void dirtyRead() {
+        backingStore.set(CHAD);
+        final var state = createState();
+        assertThat(state.get()).isEqualTo(CHAD);
+        backingStore.set(DENMARK);
+        assertThat(state.get()).isEqualTo(DENMARK);
+    }
+}

--- a/hedera-node/hedera-app-spi/src/test/java/com/hedera/node/app/spi/state/SingletonStateTestBase.java
+++ b/hedera-node/hedera-app-spi/src/test/java/com/hedera/node/app/spi/state/SingletonStateTestBase.java
@@ -36,9 +36,9 @@ abstract class SingletonStateTestBase extends StateTestBase {
     void testNonExistingGet() {
         backingStore.set(null);
         final var state = createState();
-        assertThat(state.read()).isFalse();
+        assertThat(state.isRead()).isFalse();
         assertThat(state.get()).isNull();
-        assertThat(state.read()).isTrue();
+        assertThat(state.isRead()).isTrue();
     }
 
     /**
@@ -50,9 +50,9 @@ abstract class SingletonStateTestBase extends StateTestBase {
     void testExistingGet() {
         backingStore.set(BRAZIL);
         final var state = createState();
-        assertThat(state.read()).isFalse();
+        assertThat(state.isRead()).isFalse();
         assertThat(state.get()).isEqualTo(BRAZIL);
-        assertThat(state.read()).isTrue();
+        assertThat(state.isRead()).isTrue();
     }
 
     @Test
@@ -62,22 +62,22 @@ abstract class SingletonStateTestBase extends StateTestBase {
         backingStore.set(CHAD);
         final var state = createState();
         assertThat(state.get()).isEqualTo(CHAD);
-        assertThat(state.read()).isTrue();
+        assertThat(state.isRead()).isTrue();
 
         // When we reset
         state.reset();
 
         // Then the "read" flag is false
-        assertThat(state.read()).isFalse();
+        assertThat(state.isRead()).isFalse();
 
         // And when the value in the backing store is changed
         backingStore.set(DENMARK);
         // Then it doesn't affect the state
-        assertThat(state.read()).isFalse();
+        assertThat(state.isRead()).isFalse();
 
         // Until we ask for the value, and then it shows the new value
         assertThat(state.get()).isEqualTo(DENMARK);
-        assertThat(state.read()).isTrue();
+        assertThat(state.isRead()).isTrue();
     }
 
     /**

--- a/hedera-node/hedera-app-spi/src/test/java/com/hedera/node/app/spi/state/StateTestBase.java
+++ b/hedera-node/hedera-app-spi/src/test/java/com/hedera/node/app/spi/state/StateTestBase.java
@@ -17,6 +17,7 @@ package com.hedera.node.app.spi.state;
 
 import com.hedera.node.app.spi.fixtures.state.*;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.concurrent.atomic.AtomicReference;
 
 public class StateTestBase extends TestBase {
     @NonNull
@@ -72,29 +73,15 @@ public class StateTestBase extends TestBase {
     }
 
     @NonNull
-    protected MapReadableKVState<String, String> readableSpaceState() {
-        return MapReadableKVState.<String, String>builder(SPACE_STATE_KEY)
-                .value(A_KEY, ASTRONAUT)
-                .value(B_KEY, BLASTOFF)
-                .value(C_KEY, COMET)
-                .value(D_KEY, DRACO)
-                .value(E_KEY, EXOPLANET)
-                .value(F_KEY, FORCE)
-                .value(G_KEY, GRAVITY)
-                .build();
+    protected ReadableSingletonState<String> readableSpaceState() {
+        return new ReadableSingletonStateBase<>(SPACE_STATE_KEY, () -> ASTRONAUT);
     }
 
     @NonNull
-    protected MapWritableKVState<String, String> writableSpaceState() {
-        return MapWritableKVState.<String, String>builder(SPACE_STATE_KEY)
-                .value(A_KEY, ASTRONAUT)
-                .value(B_KEY, BLASTOFF)
-                .value(C_KEY, COMET)
-                .value(D_KEY, DRACO)
-                .value(E_KEY, EXOPLANET)
-                .value(F_KEY, FORCE)
-                .value(G_KEY, GRAVITY)
-                .build();
+    protected WritableSingletonState<String> writableSpaceState() {
+        final AtomicReference<String> backingValue = new AtomicReference<>(ASTRONAUT);
+        return new WritableSingletonStateBase<>(
+                SPACE_STATE_KEY, backingValue::get, backingValue::set);
     }
 
     @NonNull
@@ -124,29 +111,15 @@ public class StateTestBase extends TestBase {
     }
 
     @NonNull
-    protected MapReadableKVState<String, String> readableCountryState() {
-        return MapReadableKVState.<String, String>builder(COUNTRY_STATE_KEY)
-                .value(A_KEY, AUSTRALIA)
-                .value(B_KEY, BRAZIL)
-                .value(C_KEY, CHAD)
-                .value(D_KEY, DENMARK)
-                .value(E_KEY, ESTONIA)
-                .value(F_KEY, FRANCE)
-                .value(G_KEY, GHANA)
-                .build();
+    protected ReadableSingletonState<String> readableCountryState() {
+        return new ReadableSingletonStateBase<>(COUNTRY_STATE_KEY, () -> AUSTRALIA);
     }
 
     @NonNull
-    protected MapWritableKVState<String, String> writableCountryState() {
-        return MapWritableKVState.<String, String>builder(COUNTRY_STATE_KEY)
-                .value(A_KEY, AUSTRALIA)
-                .value(B_KEY, BRAZIL)
-                .value(C_KEY, CHAD)
-                .value(D_KEY, DENMARK)
-                .value(E_KEY, ESTONIA)
-                .value(F_KEY, FRANCE)
-                .value(G_KEY, GHANA)
-                .build();
+    protected WritableSingletonState<String> writableCountryState() {
+        final AtomicReference<String> backingValue = new AtomicReference<>(AUSTRALIA);
+        return new WritableSingletonStateBase<>(
+                COUNTRY_STATE_KEY, backingValue::get, backingValue::set);
     }
 
     @NonNull

--- a/hedera-node/hedera-app-spi/src/test/java/com/hedera/node/app/spi/state/WritableSingletonStateBaseTest.java
+++ b/hedera-node/hedera-app-spi/src/test/java/com/hedera/node/app/spi/state/WritableSingletonStateBaseTest.java
@@ -83,7 +83,7 @@ class WritableSingletonStateBaseTest extends SingletonStateTestBase {
         @DisplayName("`modified` is false on a new state")
         void initialValueForModified() {
             final var state = createState();
-            assertThat(state.modified()).isFalse();
+            assertThat(state.isModified()).isFalse();
         }
 
         @Test
@@ -91,7 +91,7 @@ class WritableSingletonStateBaseTest extends SingletonStateTestBase {
         void modifiedAfterPut() {
             final var state = createState();
             state.put(BRAZIL);
-            assertThat(state.modified()).isTrue();
+            assertThat(state.isModified()).isTrue();
         }
 
         @Test
@@ -99,7 +99,7 @@ class WritableSingletonStateBaseTest extends SingletonStateTestBase {
         void readDoesNotModify() {
             final var state = createState();
             assertThat(state.get()).isEqualTo(AUSTRALIA);
-            assertThat(state.modified()).isFalse();
+            assertThat(state.isModified()).isFalse();
         }
     }
 
@@ -154,9 +154,9 @@ class WritableSingletonStateBaseTest extends SingletonStateTestBase {
         void modifiedCleared() {
             final var state = createState();
             state.put(BRAZIL);
-            assertThat(state.modified()).isTrue();
+            assertThat(state.isModified()).isTrue();
             state.reset();
-            assertThat(state.modified()).isFalse();
+            assertThat(state.isModified()).isFalse();
         }
 
         @Test

--- a/hedera-node/hedera-app-spi/src/test/java/com/hedera/node/app/spi/state/WritableSingletonStateBaseTest.java
+++ b/hedera-node/hedera-app-spi/src/test/java/com/hedera/node/app/spi/state/WritableSingletonStateBaseTest.java
@@ -1,0 +1,192 @@
+/*
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hedera.node.app.spi.state;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class WritableSingletonStateBaseTest extends SingletonStateTestBase {
+
+    @Override
+    protected WritableSingletonStateBase<String> createState() {
+        return new WritableSingletonStateBase<>(
+                COUNTRY_STATE_KEY, backingStore::get, backingStore::set);
+    }
+
+    @Nested
+    @DisplayName("Constructor Tests")
+    class ConstructorTest {
+        @Test
+        @DisplayName("Constructor throws NPE if stateKey is null")
+        void nullStateKey() {
+            //noinspection DataFlowIssue
+            assertThatThrownBy(
+                            () ->
+                                    new WritableSingletonStateBase<>(
+                                            null, () -> AUSTRALIA, val -> {}))
+                    .isInstanceOf(NullPointerException.class);
+        }
+
+        /** Make sure the constructor is holding onto the state key properly */
+        @Test
+        @DisplayName("The state key must match what was provided in the constructor")
+        void testStateKey() {
+            final var state =
+                    new WritableSingletonStateBase<>(COUNTRY_STATE_KEY, () -> AUSTRALIA, val -> {});
+            assertThat(state.getStateKey()).isEqualTo(COUNTRY_STATE_KEY);
+        }
+
+        @Test
+        @DisplayName("Constructor throws NPE if backingStoreAccessor is null")
+        void nullAccessor() {
+            //noinspection DataFlowIssue
+            assertThatThrownBy(
+                            () ->
+                                    new WritableSingletonStateBase<>(
+                                            COUNTRY_STATE_KEY, null, val -> {}))
+                    .isInstanceOf(NullPointerException.class);
+        }
+
+        @Test
+        @DisplayName("Constructor throws NPE if backingStoreMutator is null")
+        void nullMutator() {
+            //noinspection DataFlowIssue
+            assertThatThrownBy(
+                            () ->
+                                    new WritableSingletonStateBase<>(
+                                            COUNTRY_STATE_KEY, () -> AUSTRALIA, null))
+                    .isInstanceOf(NullPointerException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("Modified Flag Tests")
+    class ModifiedTest {
+        @Test
+        @DisplayName("`modified` is false on a new state")
+        void initialValueForModified() {
+            final var state = createState();
+            assertThat(state.modified()).isFalse();
+        }
+
+        @Test
+        @DisplayName("`modified` is true after `put`")
+        void modifiedAfterPut() {
+            final var state = createState();
+            state.put(BRAZIL);
+            assertThat(state.modified()).isTrue();
+        }
+
+        @Test
+        @DisplayName("`modified` is not impacted by `get`")
+        void readDoesNotModify() {
+            final var state = createState();
+            assertThat(state.get()).isEqualTo(AUSTRALIA);
+            assertThat(state.modified()).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("Put Tests")
+    class PutTest {
+        @Test
+        @DisplayName("`get` reads `put` value")
+        void getAfterPut() {
+            final var state = createState();
+            assertThat(state.get()).isEqualTo(AUSTRALIA);
+            state.put(BRAZIL);
+            assertThat(state.get()).isEqualTo(BRAZIL);
+        }
+    }
+
+    @Nested
+    @DisplayName("Commit Tests")
+    class CommitTest {
+        @Test
+        @DisplayName("`commit` of clean state is no-op")
+        void commitClean() {
+            final var state = createState();
+            state.commit();
+            assertThat(backingStore.get()).isEqualTo(AUSTRALIA);
+        }
+
+        @Test
+        @DisplayName("`commit` of newly put value stores in backing store")
+        void commitDirty() {
+            final var state = createState();
+            state.put(FRANCE);
+            state.commit();
+            assertThat(backingStore.get()).isEqualTo(FRANCE);
+        }
+
+        @Test
+        @DisplayName("`commit` of newly put null stores in backing store")
+        void commitNull() {
+            final var state = createState();
+            state.put(null);
+            state.commit();
+            assertThat(backingStore.get()).isNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("Reset Tests")
+    class ResetTest {
+        @Test
+        @DisplayName("`modified` is cleared on reset")
+        void modifiedCleared() {
+            final var state = createState();
+            state.put(BRAZIL);
+            assertThat(state.modified()).isTrue();
+            state.reset();
+            assertThat(state.modified()).isFalse();
+        }
+
+        @Test
+        @DisplayName("modified value is cleared on reset")
+        void valueCleared() {
+            final var state = createState();
+            state.put(BRAZIL);
+            state.reset();
+            assertThat(state.get()).isEqualTo(AUSTRALIA);
+        }
+    }
+
+    /**
+     * This specific behavior should never show up in actual code, because all states associated
+     * with a transaction are destroyed after having been committed (or in a nested/wrapped
+     * scenario, we shouldn't be updating the backing data while a wrapped data is being used).
+     * However, in such a situation, the right behavior is to show the updated values in the backing
+     * store, unless the value has been overridden in this state.
+     */
+    @Test
+    @DisplayName("State sees changes committed to backend if not modified on the state")
+    void dirtyRead() {
+        backingStore.set(CHAD);
+        final var state = createState();
+        assertThat(state.get()).isEqualTo(CHAD);
+        backingStore.set(DENMARK);
+        assertThat(state.get()).isEqualTo(DENMARK); // Sees change
+        state.put(ESTONIA);
+        assertThat(state.get()).isEqualTo(ESTONIA);
+        backingStore.set(FRANCE);
+        assertThat(state.get()).isEqualTo(ESTONIA); // Does not see change
+    }
+}

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/merkle/MerkleHederaState.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/merkle/MerkleHederaState.java
@@ -15,12 +15,22 @@
  */
 package com.hedera.node.app.state.merkle;
 
-import com.hedera.node.app.spi.state.*;
+import com.hedera.node.app.spi.state.EmptyReadableStates;
+import com.hedera.node.app.spi.state.EmptyWritableStates;
+import com.hedera.node.app.spi.state.ReadableKVState;
+import com.hedera.node.app.spi.state.ReadableSingletonState;
+import com.hedera.node.app.spi.state.ReadableStates;
+import com.hedera.node.app.spi.state.WritableKVState;
+import com.hedera.node.app.spi.state.WritableSingletonState;
+import com.hedera.node.app.spi.state.WritableStates;
 import com.hedera.node.app.state.HederaState;
 import com.hedera.node.app.state.merkle.disk.OnDiskReadableKVState;
 import com.hedera.node.app.state.merkle.disk.OnDiskWritableKVState;
 import com.hedera.node.app.state.merkle.memory.InMemoryReadableKVState;
 import com.hedera.node.app.state.merkle.memory.InMemoryWritableKVState;
+import com.hedera.node.app.state.merkle.singleton.ReadableSingletonStateImpl;
+import com.hedera.node.app.state.merkle.singleton.SingletonNode;
+import com.hedera.node.app.state.merkle.singleton.WritableSingletonStateImpl;
 import com.swirlds.common.merkle.MerkleInternal;
 import com.swirlds.common.merkle.MerkleNode;
 import com.swirlds.common.merkle.impl.PartialNaryMerkleInternal;
@@ -29,10 +39,15 @@ import com.swirlds.common.system.SwirldDualState;
 import com.swirlds.common.system.SwirldState2;
 import com.swirlds.common.system.address.AddressBook;
 import com.swirlds.common.system.events.Event;
+import com.swirlds.common.utility.Labeled;
 import com.swirlds.merkle.map.MerkleMap;
 import com.swirlds.virtualmap.VirtualMap;
 import edu.umd.cs.findbugs.annotations.NonNull;
-import java.util.*;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
@@ -262,13 +277,9 @@ public class MerkleHederaState extends PartialNaryMerkleInternal
         Objects.requireNonNull(md);
         Objects.requireNonNull(node);
 
-        String label;
-        if (node instanceof MerkleMap<?, ?> m) {
-            label = m.getLabel();
-        } else if (node instanceof VirtualMap<?, ?> v) {
-            label = v.getLabel();
-        } else {
-            throw new IllegalArgumentException("`node` must be a VirtualMap or MerkleMap");
+        final var label = node instanceof Labeled labeled ? labeled.getLabel() : null;
+        if (label == null) {
+            throw new IllegalArgumentException("`node` must be a Labeled and have a label");
         }
 
         final var def = md.stateDefinition();
@@ -278,7 +289,7 @@ public class MerkleHederaState extends PartialNaryMerkleInternal
                             + "the merkle node is not a VirtualMap");
         }
 
-        if (label == null || label.isEmpty()) {
+        if (label.isEmpty()) {
             // It looks like both MerkleMap and VirtualMap do not allow for a null label.
             // But I want to leave this check in here anyway, in case that is ever changed.
             throw new IllegalArgumentException("A label must be specified on the node");
@@ -339,8 +350,7 @@ public class MerkleHederaState extends PartialNaryMerkleInternal
         final var label = StateUtils.computeLabel(serviceName, stateKey);
         for (int i = 0, n = getNumberOfChildren(); i < n; i++) {
             final var node = getChild(i);
-            if (node instanceof MerkleMap<?, ?> m && label.equals(m.getLabel())
-                    || node instanceof VirtualMap<?, ?> v && label.equals(v.getLabel())) {
+            if (node instanceof Labeled labeled && label.equals(labeled.getLabel())) {
                 return i;
             }
         }
@@ -348,33 +358,12 @@ public class MerkleHederaState extends PartialNaryMerkleInternal
         return -1;
     }
 
-    /**
-     * Utility method for finding and returning the given node. Will throw an ISE if such a node
-     * cannot be found!
-     *
-     * @param md The metadata
-     * @return The found node
-     */
-    @NonNull
-    private MerkleNode findNode(@NonNull final StateMetadata<?, ?> md) {
-        final var index = findNodeIndex(md.serviceName(), md.stateDefinition().stateKey());
-        if (index == -1) {
-            // This can only happen if there WAS a node here, and it was removed!
-            throw new IllegalStateException(
-                    "State '"
-                            + md.stateDefinition().stateKey()
-                            + "' for service '"
-                            + md.serviceName()
-                            + "' is missing from the merkle tree!");
-        }
-
-        return getChild(index);
-    }
-
-    /** An implementation of {@link ReadableStates} based on the merkle tree. */
-    private final class MerkleReadableStates implements ReadableStates {
+    /** Base class implementation for states based on MerkleTree */
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    private abstract class MerkleStates implements ReadableStates {
         private final Map<String, StateMetadata<?, ?>> stateMetadata;
-        private final Map<String, ReadableKVState<?, ?>> instances;
+        private final Map<String, ReadableKVState<?, ?>> kvInstances;
+        private final Map<String, ReadableSingletonState<?>> singletonInstances;
         private final Set<String> stateKeys;
 
         /**
@@ -382,41 +371,65 @@ public class MerkleHederaState extends PartialNaryMerkleInternal
          *
          * @param stateMetadata cannot be null
          */
-        MerkleReadableStates(@NonNull final Map<String, StateMetadata<?, ?>> stateMetadata) {
+        MerkleStates(@NonNull final Map<String, StateMetadata<?, ?>> stateMetadata) {
             this.stateMetadata = Objects.requireNonNull(stateMetadata);
             this.stateKeys = Collections.unmodifiableSet(stateMetadata.keySet());
-            this.instances = new HashMap<>();
+            this.kvInstances = new HashMap<>();
+            this.singletonInstances = new HashMap<>();
         }
 
         @NonNull
         @Override
-        @SuppressWarnings({"rawtypes", "unchecked"})
         public <K extends Comparable<K>, V> ReadableKVState<K, V> get(@NonNull String stateKey) {
-            final ReadableKVState<K, V> instance = (ReadableKVState<K, V>) instances.get(stateKey);
+            final ReadableKVState<K, V> instance =
+                    (ReadableKVState<K, V>) kvInstances.get(stateKey);
             if (instance != null) {
                 return instance;
             }
 
             final var md = stateMetadata.get(stateKey);
-            if (md == null) {
-                throw new IllegalArgumentException("Unknown state key '" + stateKey + ";");
+            if (md == null || md.stateDefinition().singleton()) {
+                throw new IllegalArgumentException("Unknown k/v state key '" + stateKey + ";");
             }
 
             final var node = findNode(md);
             if (node instanceof VirtualMap v) {
-                final var ret = new OnDiskReadableKVState<>(md, v);
-                instances.put(stateKey, ret);
+                final var ret = createReadableKVState(md, v);
+                kvInstances.put(stateKey, ret);
                 return ret;
             } else if (node instanceof MerkleMap m) {
-                final var ret = new InMemoryReadableKVState<>(md, m);
-                instances.put(stateKey, ret);
+                final var ret = createReadableKVState(md, m);
+                kvInstances.put(stateKey, ret);
                 return ret;
             } else {
-                // This method cannot possibly be reached. The findNodeIndex method ONLY
-                // returns an index if the type is VirtualMap or MerkleMap. There is no
-                // way to modify the merkle tree between the line that calls findNodeIndex
-                // and here. So this can never be reached, even in testing!
-                throw new IllegalStateException("Unexpected type for state " + stateKey);
+                // This exception should never be thrown. Only if "findNode" found the wrong node!
+                throw new IllegalStateException("Unexpected type for k/v state " + stateKey);
+            }
+        }
+
+        @NonNull
+        @Override
+        public <T> ReadableSingletonState<T> getSingleton(@NonNull String stateKey) {
+            final ReadableSingletonState<T> instance =
+                    (ReadableSingletonState<T>) singletonInstances.get(stateKey);
+            if (instance != null) {
+                return instance;
+            }
+
+            final var md = stateMetadata.get(stateKey);
+            if (md == null || !md.stateDefinition().singleton()) {
+                throw new IllegalArgumentException(
+                        "Unknown singleton state key '" + stateKey + "'");
+            }
+
+            final var node = findNode(md);
+            if (node instanceof SingletonNode s) {
+                final var ret = createReadableSingletonState(md, s);
+                singletonInstances.put(stateKey, ret);
+                return (ReadableSingletonState<T>) ret;
+            } else {
+                // This exception should never be thrown. Only if "findNode" found the wrong node!
+                throw new IllegalStateException("Unexpected type for singleton state " + stateKey);
             }
         }
 
@@ -430,66 +443,120 @@ public class MerkleHederaState extends PartialNaryMerkleInternal
         public Set<String> stateKeys() {
             return stateKeys;
         }
+
+        @NonNull
+        protected abstract ReadableKVState createReadableKVState(
+                @NonNull StateMetadata md, @NonNull VirtualMap v);
+
+        @NonNull
+        protected abstract ReadableKVState createReadableKVState(
+                @NonNull StateMetadata md, @NonNull MerkleMap m);
+
+        @NonNull
+        protected abstract ReadableSingletonState createReadableSingletonState(
+                @NonNull StateMetadata md, @NonNull SingletonNode<?> s);
+
+        /**
+         * Utility method for finding and returning the given node. Will throw an ISE if such a node
+         * cannot be found!
+         *
+         * @param md The metadata
+         * @return The found node
+         */
+        @NonNull
+        private MerkleNode findNode(@NonNull final StateMetadata<?, ?> md) {
+            final var index = findNodeIndex(md.serviceName(), md.stateDefinition().stateKey());
+            if (index == -1) {
+                // This can only happen if there WAS a node here, and it was removed!
+                throw new IllegalStateException(
+                        "State '"
+                                + md.stateDefinition().stateKey()
+                                + "' for service '"
+                                + md.serviceName()
+                                + "' is missing from the merkle tree!");
+            }
+
+            return getChild(index);
+        }
+    }
+
+    /** An implementation of {@link ReadableStates} based on the merkle tree. */
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    private final class MerkleReadableStates extends MerkleStates {
+        /**
+         * Create a new instance
+         *
+         * @param stateMetadata cannot be null
+         */
+        MerkleReadableStates(@NonNull final Map<String, StateMetadata<?, ?>> stateMetadata) {
+            super(stateMetadata);
+        }
+
+        @Override
+        @NonNull
+        protected ReadableKVState<?, ?> createReadableKVState(
+                @NonNull final StateMetadata md, @NonNull final VirtualMap v) {
+            return new OnDiskReadableKVState<>(md, v);
+        }
+
+        @Override
+        @NonNull
+        protected ReadableKVState<?, ?> createReadableKVState(
+                @NonNull final StateMetadata md, @NonNull final MerkleMap m) {
+            return new InMemoryReadableKVState<>(md, m);
+        }
+
+        @Override
+        @NonNull
+        protected ReadableSingletonState<?> createReadableSingletonState(
+                @NonNull final StateMetadata md, @NonNull final SingletonNode<?> s) {
+            return new ReadableSingletonStateImpl<>(md, s);
+        }
     }
 
     /** An implementation of {@link WritableStates} based on the merkle tree. */
-    private final class MerkleWritableStates implements WritableStates {
-        private final Map<String, StateMetadata<?, ?>> stateMetadata;
-        private final Map<String, WritableKVState<?, ?>> instances;
-        private final Set<String> stateKeys;
-
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    private final class MerkleWritableStates extends MerkleStates implements WritableStates {
         /**
          * Create a new instance
          *
          * @param stateMetadata cannot be null
          */
         MerkleWritableStates(@NonNull final Map<String, StateMetadata<?, ?>> stateMetadata) {
-            this.stateMetadata = Objects.requireNonNull(stateMetadata);
-            this.stateKeys = Collections.unmodifiableSet(stateMetadata.keySet());
-            this.instances = new HashMap<>();
+            super(stateMetadata);
         }
 
         @NonNull
         @Override
-        @SuppressWarnings({"rawtypes", "unchecked"})
         public <K extends Comparable<K>, V> WritableKVState<K, V> get(@NonNull String stateKey) {
-            final WritableKVState<K, V> instance = (WritableKVState<K, V>) instances.get(stateKey);
-            if (instance != null) {
-                return instance;
-            }
-
-            final var md = stateMetadata.get(stateKey);
-            if (md == null) {
-                throw new IllegalArgumentException("Unknown state key '" + stateKey + "'");
-            }
-
-            final var node = findNode(md);
-            if (node instanceof VirtualMap v) {
-                final var ret = new OnDiskWritableKVState<>(md, v);
-                instances.put(stateKey, ret);
-                return ret;
-            } else if (node instanceof MerkleMap m) {
-                final var ret = new InMemoryWritableKVState<>(md, m);
-                instances.put(stateKey, ret);
-                return ret;
-            } else {
-                // This method cannot possibly be reached. The findNodeIndex method ONLY
-                // returns an index if the type is VirtualMap or MerkleMap. There is no
-                // way to modify the merkle tree between the line that calls findNodeIndex
-                // and here. So this can never be reached, even in testing!
-                throw new IllegalStateException("Unexpected type for state " + stateKey);
-            }
-        }
-
-        @Override
-        public boolean contains(@NonNull String stateKey) {
-            return stateMetadata.containsKey(stateKey);
+            return (WritableKVState<K, V>) super.get(stateKey);
         }
 
         @NonNull
         @Override
-        public Set<String> stateKeys() {
-            return stateKeys;
+        public <T> WritableSingletonState<T> getSingleton(@NonNull String stateKey) {
+            return (WritableSingletonState<T>) super.getSingleton(stateKey);
+        }
+
+        @Override
+        @NonNull
+        protected WritableKVState<?, ?> createReadableKVState(
+                @NonNull final StateMetadata md, @NonNull final VirtualMap v) {
+            return new OnDiskWritableKVState<>(md, v);
+        }
+
+        @Override
+        @NonNull
+        protected WritableKVState<?, ?> createReadableKVState(
+                @NonNull final StateMetadata md, @NonNull final MerkleMap m) {
+            return new InMemoryWritableKVState<>(md, m);
+        }
+
+        @Override
+        @NonNull
+        protected WritableSingletonState<?> createReadableSingletonState(
+                @NonNull final StateMetadata md, @NonNull final SingletonNode<?> s) {
+            return new WritableSingletonStateImpl<>(md, s);
         }
     }
 }

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/merkle/MerkleHederaState.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/merkle/MerkleHederaState.java
@@ -321,7 +321,6 @@ public class MerkleHederaState extends PartialNaryMerkleInternal
      * @param stateKey The state key
      */
     void removeServiceState(@NonNull final String serviceName, @NonNull final String stateKey) {
-
         throwIfImmutable();
         Objects.requireNonNull(serviceName);
         Objects.requireNonNull(stateKey);
@@ -426,7 +425,7 @@ public class MerkleHederaState extends PartialNaryMerkleInternal
             if (node instanceof SingletonNode s) {
                 final var ret = createReadableSingletonState(md, s);
                 singletonInstances.put(stateKey, ret);
-                return (ReadableSingletonState<T>) ret;
+                return ret;
             } else {
                 // This exception should never be thrown. Only if "findNode" found the wrong node!
                 throw new IllegalStateException("Unexpected type for singleton state " + stateKey);

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/merkle/MerkleSchemaRegistry.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/merkle/MerkleSchemaRegistry.java
@@ -26,11 +26,12 @@ import com.hedera.node.app.state.merkle.disk.OnDiskValueSerializer;
 import com.hedera.node.app.state.merkle.memory.InMemoryValue;
 import com.hedera.node.app.state.merkle.memory.InMemoryWritableKVState;
 import com.hedera.node.app.state.merkle.singleton.SingletonNode;
+import com.hedera.node.app.state.merkle.singleton.StringLeaf;
+import com.hedera.node.app.state.merkle.singleton.ValueLeaf;
 import com.hederahashgraph.api.proto.java.SemanticVersion;
 import com.swirlds.common.constructable.ClassConstructorPair;
 import com.swirlds.common.constructable.ConstructableRegistry;
 import com.swirlds.common.constructable.ConstructableRegistryException;
-import com.swirlds.common.constructable.RuntimeConstructable;
 import com.swirlds.common.crypto.DigestType;
 import com.swirlds.jasperdb.JasperDbBuilder;
 import com.swirlds.jasperdb.VirtualLeafRecordSerializer;
@@ -41,7 +42,6 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import java.nio.file.Path;
 import java.util.*;
-import java.util.function.Supplier;
 
 /**
  * An implementation of {@link SchemaRegistry}.
@@ -338,32 +338,25 @@ public class MerkleSchemaRegistry implements SchemaRegistry {
         // various delegate writers and parsers, and so can parse/write different types of data
         // based on the id.
         try {
-            final Supplier<RuntimeConstructable> inMemoryValueCreator = () -> new InMemoryValue(md);
-            final var inMemoryValuePair =
-                    new ClassConstructorPair(InMemoryValue.class, inMemoryValueCreator);
-            constructableRegistry.registerConstructable(inMemoryValuePair);
-
-            final Supplier<RuntimeConstructable> onDiskKeyCreator = () -> new OnDiskKey<>(md);
-            final var onDiskKeyPair = new ClassConstructorPair(OnDiskKey.class, onDiskKeyCreator);
-            constructableRegistry.registerConstructable(onDiskKeyPair);
-
-            final Supplier<RuntimeConstructable> onDiskKeySerializerCreator =
-                    () -> new OnDiskKeySerializer<>(md);
-            final var onDiskKeySerializerPair =
-                    new ClassConstructorPair(OnDiskKeySerializer.class, onDiskKeySerializerCreator);
-            constructableRegistry.registerConstructable(onDiskKeySerializerPair);
-
-            final Supplier<RuntimeConstructable> onDiskValueCreator = () -> new OnDiskValue<>(md);
-            final var onDiskValuePair =
-                    new ClassConstructorPair(OnDiskValue.class, onDiskValueCreator);
-            constructableRegistry.registerConstructable(onDiskValuePair);
-
-            final Supplier<RuntimeConstructable> onDiskValueSerializerCreator =
-                    () -> new OnDiskValueSerializer<>(md);
-            final var onDiskValueSerializerPair =
+            constructableRegistry.registerConstructable(
+                    new ClassConstructorPair(InMemoryValue.class, () -> new InMemoryValue(md)));
+            constructableRegistry.registerConstructable(
+                    new ClassConstructorPair(OnDiskKey.class, () -> new OnDiskKey<>(md)));
+            constructableRegistry.registerConstructable(
                     new ClassConstructorPair(
-                            OnDiskValueSerializer.class, onDiskValueSerializerCreator);
-            constructableRegistry.registerConstructable(onDiskValueSerializerPair);
+                            OnDiskKeySerializer.class, () -> new OnDiskKeySerializer<>(md)));
+            constructableRegistry.registerConstructable(
+                    new ClassConstructorPair(OnDiskValue.class, () -> new OnDiskValue<>(md)));
+            constructableRegistry.registerConstructable(
+                    new ClassConstructorPair(
+                            OnDiskValueSerializer.class, () -> new OnDiskValueSerializer<>(md)));
+            constructableRegistry.registerConstructable(
+                    new ClassConstructorPair(
+                            SingletonNode.class, () -> new SingletonNode<>(md, null)));
+            constructableRegistry.registerConstructable(
+                    new ClassConstructorPair(StringLeaf.class, StringLeaf::new));
+            constructableRegistry.registerConstructable(
+                    new ClassConstructorPair(ValueLeaf.class, () -> new ValueLeaf<>(md)));
         } catch (ConstructableRegistryException e) {
             // This is a fatal error.
             throw new RuntimeException(

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/merkle/StateMetadata.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/merkle/StateMetadata.java
@@ -31,6 +31,7 @@ public final class StateMetadata<K extends Comparable<K>, V> {
     private static final String ON_DISK_VALUE_CLASS_ID_SUFFIX = "OnDiskValue";
     private static final String ON_DISK_VALUE_SERIALIZER_CLASS_ID_SUFFIX = "OnDiskValueSerializer";
     private static final String IN_MEMORY_VALUE_CLASS_ID_SUFFIX = "InMemoryValue";
+    private static final String SINGLETON_CLASS_ID_SUFFIX = "SingletonLeaf";
 
     private final String serviceName;
     private final Schema schema;
@@ -40,6 +41,7 @@ public final class StateMetadata<K extends Comparable<K>, V> {
     private final long onDiskValueClassId;
     private final long onDiskValueSerializerClassId;
     private final long inMemoryValueClassId;
+    private final long singletonClassId;
 
     /**
      * Create an instance.
@@ -73,6 +75,9 @@ public final class StateMetadata<K extends Comparable<K>, V> {
         this.inMemoryValueClassId =
                 StateUtils.computeClassId(
                         serviceName, stateKey, version, IN_MEMORY_VALUE_CLASS_ID_SUFFIX);
+        this.singletonClassId =
+                StateUtils.computeClassId(
+                        serviceName, stateKey, version, SINGLETON_CLASS_ID_SUFFIX);
     }
 
     public String serviceName() {
@@ -105,5 +110,9 @@ public final class StateMetadata<K extends Comparable<K>, V> {
 
     public long inMemoryValueClassId() {
         return inMemoryValueClassId;
+    }
+
+    public long singletonClassId() {
+        return singletonClassId;
     }
 }

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/merkle/singleton/ReadableSingletonStateImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/merkle/singleton/ReadableSingletonStateImpl.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hedera.node.app.state.merkle.singleton;
+
+import com.hedera.node.app.spi.state.ReadableSingletonStateBase;
+import com.hedera.node.app.state.merkle.StateMetadata;
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+public class ReadableSingletonStateImpl<T> extends ReadableSingletonStateBase<T> {
+    public ReadableSingletonStateImpl(
+            @NonNull final StateMetadata<?, ?> md, @NonNull final SingletonNode<T> node) {
+        super(md.stateDefinition().stateKey(), node::getValue);
+    }
+}

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/merkle/singleton/SingletonNode.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/merkle/singleton/SingletonNode.java
@@ -16,6 +16,7 @@
 package com.hedera.node.app.state.merkle.singleton;
 
 import com.hedera.node.app.state.merkle.StateMetadata;
+import com.hedera.node.app.state.merkle.StateUtils;
 import com.swirlds.common.merkle.MerkleInternal;
 import com.swirlds.common.merkle.impl.PartialBinaryMerkleInternal;
 import com.swirlds.common.utility.Labeled;
@@ -41,7 +42,7 @@ public class SingletonNode<T> extends PartialBinaryMerkleInternal
     }
 
     public SingletonNode(@NonNull final StateMetadata<?, T> md, @NonNull final T value) {
-        setLeft(new StringLeaf(md.stateDefinition().stateKey()));
+        setLeft(new StringLeaf(StateUtils.computeLabel(md.serviceName(), md.stateDefinition().stateKey())));
         setRight(new ValueLeaf<T>(md, value));
     }
 

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/merkle/singleton/SingletonNode.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/merkle/singleton/SingletonNode.java
@@ -15,37 +15,69 @@
  */
 package com.hedera.node.app.state.merkle.singleton;
 
+import com.hedera.node.app.state.merkle.StateMetadata;
 import com.swirlds.common.merkle.MerkleInternal;
 import com.swirlds.common.merkle.impl.PartialBinaryMerkleInternal;
 import com.swirlds.common.utility.Labeled;
+import edu.umd.cs.findbugs.annotations.NonNull;
 
-// two child nodes, one with the label, one with the value
+/**
+ * A merkle node with a string (the label) as the left child, and the merkle node value as the right
+ * child. We actually support a raw type (any type!) as the value, and we serialize it and put it
+ * into a simple merkle node.
+ *
+ * @param <T> The value type
+ */
 public class SingletonNode<T> extends PartialBinaryMerkleInternal
         implements Labeled, MerkleInternal {
+    private static final long CLASS_ID = 0x3832CC837AB77BFL;
+    public static final int CLASS_VERSION = 1;
+
+    // Only exists for constructable registry as it works today. Remove ASAP!
+    @Deprecated(forRemoval = true)
+    public SingletonNode() {
+        setLeft(new StringLeaf());
+        setRight(null);
+    }
+
+    public SingletonNode(@NonNull final StateMetadata<?, T> md, @NonNull final T value) {
+        setLeft(new StringLeaf(md.stateDefinition().stateKey()));
+        setRight(new ValueLeaf<T>(md, value));
+    }
+
+    private SingletonNode(@NonNull final SingletonNode<T> other) {
+        this.setLeft(other.getLeft().copy());
+        this.setRight(other.getRight().copy());
+    }
 
     @Override
-    public MerkleInternal copy() {
-        return null;
+    public SingletonNode<T> copy() {
+        return new SingletonNode<>(this);
     }
 
     @Override
     public long getClassId() {
-        return 0;
+        return CLASS_ID;
     }
 
     @Override
     public int getVersion() {
-        return 0;
+        return CLASS_VERSION;
     }
 
     @Override
     public String getLabel() {
-        return null;
+        final StringLeaf left = getLeft();
+        return left.getLabel();
     }
 
     public T getValue() {
-        return null;
+        final ValueLeaf<T> right = getRight();
+        return right.getValue();
     }
 
-    public void setValue(T value) {}
+    public void setValue(T value) {
+        ValueLeaf<T> right = getRight();
+        right.setValue(value);
+    }
 }

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/merkle/singleton/SingletonNode.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/merkle/singleton/SingletonNode.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hedera.node.app.state.merkle.singleton;
+
+import com.swirlds.common.merkle.MerkleInternal;
+import com.swirlds.common.merkle.impl.PartialBinaryMerkleInternal;
+import com.swirlds.common.utility.Labeled;
+
+// two child nodes, one with the label, one with the value
+public class SingletonNode<T> extends PartialBinaryMerkleInternal
+        implements Labeled, MerkleInternal {
+
+    @Override
+    public MerkleInternal copy() {
+        return null;
+    }
+
+    @Override
+    public long getClassId() {
+        return 0;
+    }
+
+    @Override
+    public int getVersion() {
+        return 0;
+    }
+
+    @Override
+    public String getLabel() {
+        return null;
+    }
+
+    public T getValue() {
+        return null;
+    }
+
+    public void setValue(T value) {}
+}

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/merkle/singleton/SingletonNode.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/merkle/singleton/SingletonNode.java
@@ -42,7 +42,10 @@ public class SingletonNode<T> extends PartialBinaryMerkleInternal
     }
 
     public SingletonNode(@NonNull final StateMetadata<?, T> md, @NonNull final T value) {
-        setLeft(new StringLeaf(StateUtils.computeLabel(md.serviceName(), md.stateDefinition().stateKey())));
+        setLeft(
+                new StringLeaf(
+                        StateUtils.computeLabel(
+                                md.serviceName(), md.stateDefinition().stateKey())));
         setRight(new ValueLeaf<T>(md, value));
     }
 

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/merkle/singleton/StringLeaf.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/merkle/singleton/StringLeaf.java
@@ -23,6 +23,7 @@ import com.swirlds.common.utility.Labeled;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.IOException;
 
+/** A leaf in the merkle tree that stores a string as its value. */
 public class StringLeaf extends PartialMerkleLeaf implements Labeled, MerkleLeaf {
     private static final long CLASS_ID = 0x9C829FF3B2283L;
     public static final int CLASS_VERSION = 1;

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/merkle/singleton/StringLeaf.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/merkle/singleton/StringLeaf.java
@@ -22,7 +22,6 @@ import com.swirlds.common.merkle.impl.PartialMerkleLeaf;
 import com.swirlds.common.utility.Labeled;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.IOException;
-import java.util.Objects;
 
 public class StringLeaf extends PartialMerkleLeaf implements Labeled, MerkleLeaf {
     private static final long CLASS_ID = 0x9C829FF3B2283L;
@@ -34,7 +33,7 @@ public class StringLeaf extends PartialMerkleLeaf implements Labeled, MerkleLeaf
     public StringLeaf() {}
 
     public StringLeaf(@NonNull final String label) {
-        this.label = Objects.requireNonNull(label);
+        setLabel(label);
     }
 
     /** Copy constructor. */

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/merkle/singleton/StringLeaf.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/merkle/singleton/StringLeaf.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hedera.node.app.state.merkle.singleton;
+
+import com.swirlds.common.io.streams.SerializableDataInputStream;
+import com.swirlds.common.io.streams.SerializableDataOutputStream;
+import com.swirlds.common.merkle.MerkleLeaf;
+import com.swirlds.common.merkle.impl.PartialMerkleLeaf;
+import com.swirlds.common.utility.Labeled;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.io.IOException;
+import java.util.Objects;
+
+public class StringLeaf extends PartialMerkleLeaf implements Labeled, MerkleLeaf {
+    private static final long CLASS_ID = 0x9C829FF3B2283L;
+    public static final int CLASS_VERSION = 1;
+
+    private String label = "";
+
+    /** Zero-arg constructor. */
+    public StringLeaf() {}
+
+    public StringLeaf(@NonNull final String label) {
+        this.label = Objects.requireNonNull(label);
+    }
+
+    /** Copy constructor. */
+    private StringLeaf(@NonNull final StringLeaf that) {
+        this.label = that.label;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public long getClassId() {
+        return CLASS_ID;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public int getVersion() {
+        return CLASS_VERSION;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void serialize(final SerializableDataOutputStream out) throws IOException {
+        out.writeNormalisedString(label);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void deserialize(final SerializableDataInputStream in, final int version)
+            throws IOException {
+        label = in.readNormalisedString(MAX_LABEL_LENGTH);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public StringLeaf copy() {
+        return new StringLeaf(this);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public String getLabel() {
+        return label;
+    }
+
+    /** Set the label. */
+    public void setLabel(@NonNull final String label) {
+        if (label.length() > MAX_LABEL_LENGTH) {
+            throw new IllegalArgumentException(
+                    "Label " + label + " exceeds maximum length of " + MAX_LABEL_LENGTH);
+        }
+        this.label = label;
+    }
+}

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/merkle/singleton/ValueLeaf.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/merkle/singleton/ValueLeaf.java
@@ -56,9 +56,9 @@ public class ValueLeaf<T> extends PartialMerkleLeaf implements MerkleLeaf {
      * @param md The state metadata
      * @param value The value.
      */
-    public ValueLeaf(@NonNull final StateMetadata<?, T> md, @NonNull final T value) {
+    public ValueLeaf(@NonNull final StateMetadata<?, T> md, @Nullable final T value) {
         this(md);
-        this.val = Objects.requireNonNull(value);
+        this.val = value;
     }
 
     /** {@inheritDoc} */

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/merkle/singleton/ValueLeaf.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/merkle/singleton/ValueLeaf.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hedera.node.app.state.merkle.singleton;
+
+import com.hedera.node.app.state.merkle.StateMetadata;
+import com.swirlds.common.io.streams.SerializableDataInputStream;
+import com.swirlds.common.io.streams.SerializableDataOutputStream;
+import com.swirlds.common.merkle.MerkleLeaf;
+import com.swirlds.common.merkle.impl.PartialMerkleLeaf;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+import java.io.DataInputStream;
+import java.io.IOException;
+import java.util.Objects;
+
+public class ValueLeaf<T> extends PartialMerkleLeaf implements MerkleLeaf {
+    @Deprecated(forRemoval = true)
+    private static final long CLASS_ID = 0x65A48B28C563D72EL;
+
+    private final StateMetadata<?, T> md;
+    /** The actual value. For example, it could be an Account or SmartContract. */
+    private T val;
+
+    // Default constructor provided for ConstructableRegistry, TO BE REMOVED ASAP
+    @Deprecated(forRemoval = true)
+    public ValueLeaf() {
+        md = null;
+    }
+
+    /**
+     * Used by the deserialization system to create an {@link ValueLeaf} that does not yet have a
+     * value. Normally this should not be used.
+     *
+     * @param md The state metadata
+     */
+    public ValueLeaf(@NonNull final StateMetadata<?, T> md) {
+        this.md = Objects.requireNonNull(md);
+    }
+
+    /**
+     * Create a new instance with the given value.
+     *
+     * @param md The state metadata
+     * @param value The value.
+     */
+    public ValueLeaf(@NonNull final StateMetadata<?, T> md, @NonNull final T value) {
+        this(md);
+        this.val = Objects.requireNonNull(value);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public ValueLeaf<T> copy() {
+        throwIfImmutable();
+        throwIfDestroyed();
+
+        final var cp = new ValueLeaf<>(md, val);
+        setImmutable(true);
+        return cp;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public long getClassId() {
+        // Null `md` for ConstructableRegistry, TO BE REMOVED ASAP
+        return md == null ? CLASS_ID : md.singletonClassId();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public int getVersion() {
+        return 1;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void serialize(final SerializableDataOutputStream out) throws IOException {
+        final var valueSerdes = md.stateDefinition().valueSerdes();
+        valueSerdes.write(val, out);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void deserialize(final SerializableDataInputStream in, final int version)
+            throws IOException {
+        final var valueSerdes = md.stateDefinition().valueSerdes();
+        this.val = valueSerdes.parse(new DataInputStream(in));
+    }
+
+    /**
+     * Gets the value.
+     *
+     * @return The value.
+     */
+    @Nullable
+    public T getValue() {
+        return val;
+    }
+
+    /**
+     * Sets the value. Cannot be called if the leaf is immutable.
+     *
+     * @param value the new value
+     */
+    public void setValue(@Nullable final T value) {
+        throwIfImmutable();
+        this.val = value;
+    }
+}

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/merkle/singleton/ValueLeaf.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/merkle/singleton/ValueLeaf.java
@@ -26,6 +26,10 @@ import java.io.DataInputStream;
 import java.io.IOException;
 import java.util.Objects;
 
+/**
+ * A Merkle leaf that stores an arbitrary value with delegated serialization based on the {@link
+ * StateMetadata}.
+ */
 public class ValueLeaf<T> extends PartialMerkleLeaf implements MerkleLeaf {
     @Deprecated(forRemoval = true)
     private static final long CLASS_ID = 0x65A48B28C563D72EL;

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/merkle/singleton/WritableSingletonStateImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/merkle/singleton/WritableSingletonStateImpl.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hedera.node.app.state.merkle.singleton;
+
+import com.hedera.node.app.spi.state.WritableSingletonStateBase;
+import com.hedera.node.app.state.merkle.StateMetadata;
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+public class WritableSingletonStateImpl<T> extends WritableSingletonStateBase<T> {
+    public WritableSingletonStateImpl(
+            @NonNull final StateMetadata<?, ?> md, @NonNull final SingletonNode<T> node) {
+        super(md.stateDefinition().stateKey(), node::getValue, node::setValue);
+    }
+}

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/state/merkle/MerkleHederaStateTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/state/merkle/MerkleHederaStateTest.java
@@ -180,8 +180,7 @@ class MerkleHederaStateTest extends MerkleTestBase {
                     new StateMetadata<>(
                             FIRST_SERVICE,
                             new TestSchema(1),
-                            new StateDefinition<>(
-                                    FRUIT_STATE_KEY, STRING_SERDES, LONG_SERDES, 10, false));
+                            StateDefinition.inMemory(FRUIT_STATE_KEY, STRING_SERDES, LONG_SERDES));
 
             hederaMerkle.putServiceStateIfAbsent(fruitMetadata, fruitMerkleMap);
             hederaMerkle.putServiceStateIfAbsent(fruitMetadata2, fruitMerkleMap);
@@ -200,8 +199,8 @@ class MerkleHederaStateTest extends MerkleTestBase {
                     new StateMetadata<>(
                             FIRST_SERVICE,
                             new TestSchema(1),
-                            new StateDefinition<>(
-                                    FRUIT_STATE_KEY, STRING_SERDES, STRING_SERDES, 10, true));
+                            StateDefinition.onDisk(
+                                    FRUIT_STATE_KEY, STRING_SERDES, STRING_SERDES, 10));
 
             assertThatThrownBy(
                             () ->
@@ -275,8 +274,8 @@ class MerkleHederaStateTest extends MerkleTestBase {
                         new StateMetadata<>(
                                 serviceName,
                                 new TestSchema(1),
-                                new StateDefinition<>(
-                                        FRUIT_STATE_KEY, STRING_SERDES, STRING_SERDES, 100, false));
+                                StateDefinition.inMemory(
+                                        FRUIT_STATE_KEY, STRING_SERDES, STRING_SERDES));
 
                 final var node = createMerkleMap(label);
                 map.put(serviceName, node);

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/state/merkle/MerkleHederaStateTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/state/merkle/MerkleHederaStateTest.java
@@ -21,7 +21,6 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import com.hedera.node.app.spi.fixtures.state.TestSchema;
 import com.hedera.node.app.spi.state.ReadableKVState;
 import com.hedera.node.app.spi.state.ReadableSingletonState;
-import com.hedera.node.app.spi.state.ReadableSingletonStateBase;
 import com.hedera.node.app.spi.state.StateDefinition;
 import com.hedera.node.app.spi.state.WritableKVState;
 import com.hedera.node.app.spi.state.WritableSingletonState;
@@ -48,8 +47,8 @@ class MerkleHederaStateTest extends MerkleTestBase {
     private final AtomicBoolean onHandleCalled = new AtomicBoolean(false);
 
     /**
-     * Start with an empty Merkle Tree, but with the "fruit" map and metadata created and ready
-     * to be added.
+     * Start with an empty Merkle Tree, but with the "fruit" map and metadata created and ready to
+     * be added.
      */
     @BeforeEach
     void setUp() {
@@ -468,7 +467,8 @@ class MerkleHederaStateTest extends MerkleTestBase {
             assertThat(animalStates.get(F_KEY)).isSameAs(FOX);
             assertThat(animalStates.get(G_KEY)).isNull();
 
-            final ReadableSingletonState<String> countryState = states.getSingleton(COUNTRY_STATE_KEY);
+            final ReadableSingletonState<String> countryState =
+                    states.getSingleton(COUNTRY_STATE_KEY);
             assertThat(countryState.getStateKey()).isEqualTo(COUNTRY_STATE_KEY);
             assertThat(countryState.get()).isEqualTo(GHANA);
 

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/state/merkle/MerkleSchemaRegistryTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/state/merkle/MerkleSchemaRegistryTest.java
@@ -302,8 +302,8 @@ class MerkleSchemaRegistryTest extends MerkleTestBase {
                     @SuppressWarnings("rawtypes")
                     public Set<StateDefinition> statesToCreate() {
                         final var fruitDef =
-                                new StateDefinition<>(
-                                        FRUIT_STATE_KEY, STRING_SERDES, STRING_SERDES, 100, false);
+                                StateDefinition.inMemory(
+                                        FRUIT_STATE_KEY, STRING_SERDES, STRING_SERDES);
                         return Set.of(fruitDef);
                     }
 
@@ -329,8 +329,8 @@ class MerkleSchemaRegistryTest extends MerkleTestBase {
                     @SuppressWarnings("rawtypes")
                     public Set<StateDefinition> statesToCreate() {
                         final var animalDef =
-                                new StateDefinition<>(
-                                        ANIMAL_STATE_KEY, STRING_SERDES, STRING_SERDES, 100, true);
+                                StateDefinition.onDisk(
+                                        ANIMAL_STATE_KEY, STRING_SERDES, STRING_SERDES, 100);
                         return Set.of(animalDef);
                     }
 

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/state/merkle/MerkleTestBase.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/state/merkle/MerkleTestBase.java
@@ -132,8 +132,7 @@ public class MerkleTestBase extends TestBase {
                 new StateMetadata<>(
                         FIRST_SERVICE,
                         new TestSchema(1),
-                        new StateDefinition<>(
-                                FRUIT_STATE_KEY, STRING_SERDES, STRING_SERDES, 100, false));
+                        StateDefinition.inMemory(FRUIT_STATE_KEY, STRING_SERDES, STRING_SERDES));
     }
 
     /** Sets up the "Fruit" virtual map, label, and metadata. */
@@ -143,8 +142,7 @@ public class MerkleTestBase extends TestBase {
                 new StateMetadata<>(
                         FIRST_SERVICE,
                         new TestSchema(1),
-                        new StateDefinition<>(
-                                FRUIT_STATE_KEY, STRING_SERDES, STRING_SERDES, 100, true));
+                        StateDefinition.onDisk(FRUIT_STATE_KEY, STRING_SERDES, STRING_SERDES, 100));
         fruitVirtualMap = createVirtualMap(fruitVirtualLabel, fruitVirtualMetadata);
     }
 
@@ -156,8 +154,7 @@ public class MerkleTestBase extends TestBase {
                 new StateMetadata<>(
                         FIRST_SERVICE,
                         new TestSchema(1),
-                        new StateDefinition<>(
-                                ANIMAL_STATE_KEY, STRING_SERDES, STRING_SERDES, 100, false));
+                        StateDefinition.inMemory(ANIMAL_STATE_KEY, STRING_SERDES, STRING_SERDES));
     }
 
     /** Sets up the "Space" merkle map, label, and metadata. */
@@ -168,32 +165,7 @@ public class MerkleTestBase extends TestBase {
                 new StateMetadata<>(
                         SECOND_SERVICE,
                         new TestSchema(1),
-                        new StateDefinition<>(
-                                SPACE_STATE_KEY, LONG_SERDES, STRING_SERDES, 100, false));
-    }
-
-    /** Sets up the "Steam" merkle map, label, and metadata. */
-    protected void setupSteamMerkleMap() {
-        steamLabel = StateUtils.computeLabel(SECOND_SERVICE, STEAM_STATE_KEY);
-        steamMerkleMap = createMerkleMap(steamLabel);
-        steamMetadata =
-                new StateMetadata<>(
-                        SECOND_SERVICE,
-                        new TestSchema(1),
-                        new StateDefinition<>(
-                                STEAM_STATE_KEY, STRING_SERDES, STRING_SERDES, 100, false));
-    }
-
-    /** Sets up the "Country" merkle map, label, and metadata. */
-    protected void setupCountryMerkleMap() {
-        countryLabel = StateUtils.computeLabel(SECOND_SERVICE, COUNTRY_STATE_KEY);
-        countryMerkleMap = createMerkleMap(countryLabel);
-        countryMetadata =
-                new StateMetadata<>(
-                        SECOND_SERVICE,
-                        new TestSchema(1),
-                        new StateDefinition<>(
-                                COUNTRY_STATE_KEY, STRING_SERDES, STRING_SERDES, 100, false));
+                        StateDefinition.inMemory(SPACE_STATE_KEY, LONG_SERDES, STRING_SERDES));
     }
 
     /** Sets up the {@link #registry}, ready to be used for serialization tests */

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/state/merkle/SerializationTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/state/merkle/SerializationTest.java
@@ -44,11 +44,9 @@ class SerializationTest extends MerkleTestBase {
             @SuppressWarnings("rawtypes")
             public Set<StateDefinition> statesToCreate() {
                 final var fruitDef =
-                        new StateDefinition<>(
-                                FRUIT_STATE_KEY, STRING_SERDES, STRING_SERDES, 100, false);
+                        StateDefinition.inMemory(FRUIT_STATE_KEY, STRING_SERDES, STRING_SERDES);
                 final var animalDef =
-                        new StateDefinition<>(
-                                ANIMAL_STATE_KEY, STRING_SERDES, STRING_SERDES, 100, true);
+                        StateDefinition.onDisk(ANIMAL_STATE_KEY, STRING_SERDES, STRING_SERDES, 100);
                 return Set.of(fruitDef, animalDef);
             }
 

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/state/merkle/StateUtilsTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/state/merkle/StateUtilsTest.java
@@ -209,8 +209,7 @@ class StateUtilsTest extends MerkleTestBase {
                         new StateMetadata<>(
                                 serviceName,
                                 new TestSchema(1),
-                                new StateDefinition<>(
-                                        stateKey, STRING_SERDES, STRING_SERDES, 100, false));
+                                StateDefinition.inMemory(stateKey, STRING_SERDES, STRING_SERDES));
                 final var hash = StateUtils.computeClassId(md, "extra string");
                 hashes.add(hash);
             }

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/state/merkle/disk/OnDiskReadableStateTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/state/merkle/disk/OnDiskReadableStateTest.java
@@ -38,8 +38,7 @@ class OnDiskReadableStateTest extends MerkleTestBase {
                 new StateMetadata<>(
                         FIRST_SERVICE,
                         new TestSchema(1),
-                        new StateDefinition<>(
-                                FRUIT_STATE_KEY, STRING_SERDES, STRING_SERDES, 100, true));
+                        StateDefinition.onDisk(FRUIT_STATE_KEY, STRING_SERDES, STRING_SERDES, 100));
         virtualMap = createVirtualMap("TEST LABEL", md);
     }
 

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/state/merkle/disk/OnDiskTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/state/merkle/disk/OnDiskTest.java
@@ -63,8 +63,8 @@ class OnDiskTest extends MerkleTestBase {
         storageDir = TemporaryFileBuilder.buildTemporaryDirectory();
 
         def =
-                new StateDefinition<>(
-                        ACCOUNT_STATE_KEY, new AccountIDSerdes(), new AccountSerdes(), 100, true);
+                StateDefinition.onDisk(
+                        ACCOUNT_STATE_KEY, new AccountIDSerdes(), new AccountSerdes(), 100);
 
         //noinspection rawtypes
         schema =

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/state/merkle/singleton/StringLeafTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/state/merkle/singleton/StringLeafTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hedera.node.app.state.merkle.singleton;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.hedera.node.app.state.merkle.MerkleTestBase;
+import org.junit.jupiter.api.Test;
+
+class StringLeafTest extends MerkleTestBase {
+    @Test
+    void setValue() {
+        final var leaf = new StringLeaf("Label 1");
+        assertThat(leaf.getLabel()).isEqualTo("Label 1");
+        leaf.setLabel("Label 2");
+        assertThat(leaf.getLabel()).isEqualTo("Label 2");
+    }
+
+    @Test
+    void labelTooLong() {
+        final var label = randomString(2000);
+        assertThatThrownBy(() -> new StringLeaf(label))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("exceeds maximum length");
+    }
+}

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/state/merkle/singleton/ValueLeafTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/state/merkle/singleton/ValueLeafTest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hedera.node.app.state.merkle.singleton;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.hedera.node.app.state.merkle.MerkleTestBase;
+import org.junit.jupiter.api.Test;
+
+class ValueLeafTest extends MerkleTestBase {
+    @Test
+    void setValue() {
+        setupSingletonCountry();
+        final var leaf = new ValueLeaf<>(countryMetadata, DENMARK);
+        assertThat(leaf.getValue()).isEqualTo(DENMARK);
+        leaf.setValue(FRANCE);
+        assertThat(leaf.getValue()).isEqualTo(FRANCE);
+    }
+}


### PR DESCRIPTION
Adds singleton states. The PR is a little on the large size, but represents only this one change, of adding singleton states. The following items were covered:

- [x] Create new SPI for `ReadableSingletonState` and `WritableSingletonState`
- [x] Add `getSingleton` to `ReadableStates` and `WritableStates`
- [x] Write tests and update test fixtures to support these
- [x] Update `MerkleHederaState` to support these changes to `ReadableStates` and `WritableStates`
- [x] Add `SingletonNode` which is a `Labeled` merkle node
- [x] Update `MerkleHederaState` to support `SingletonNode`s
- [x] Update schema migration code to support `singleton` nodes
- [x] Add serialization tests for the `SingletonNode`
- [x] Add unit tests for `SingletonNode` and associated classes
- [x] Add Javadoc

Closes #4793