### PR TITLE
Fix ServicesMain run

### DIFF
--- a/hedera-node/hedera-app/src/main/java/module-info.java
+++ b/hedera-node/hedera-app/src/main/java/module-info.java
@@ -1,6 +1,4 @@
-module com.hedera.node.app {
-    opens com.hedera.node.app;
-
+open module com.hedera.node.app {
     requires io.helidon.grpc.core;
     requires io.helidon.grpc.server;
     requires com.swirlds.common;

--- a/hedera-node/hedera-app/src/main/java/module-info.java
+++ b/hedera-node/hedera-app/src/main/java/module-info.java
@@ -1,4 +1,4 @@
-open module com.hedera.node.app {
+module com.hedera.node.app {
     requires io.helidon.grpc.core;
     requires io.helidon.grpc.server;
     requires com.swirlds.common;
@@ -30,4 +30,17 @@ open module com.hedera.node.app {
     requires com.hedera.node.app.service.util.impl;
     requires com.swirlds.platform;
     requires org.apache.logging.log4j;
+
+    exports com.hedera.node.app to
+            com.swirlds.platform;
+    exports com.hedera.node.app.state to
+            com.swirlds.common;
+    exports com.hedera.node.app.state.merkle to
+            com.swirlds.common;
+    exports com.hedera.node.app.state.merkle.disk to
+            com.swirlds.common;
+    exports com.hedera.node.app.state.merkle.memory to
+            com.swirlds.common;
+    exports com.hedera.node.app.state.merkle.singleton to
+            com.swirlds.common;
 }


### PR DESCRIPTION
Signed-off-by: Neeharika-Sompalli <neeharika.sompalli@swirldslabs.com>

Fix the error faced while running `ServicesMain` on current develop.
```
2023-01-24 07:49:02.680 12       ERROR EXCEPTION        <main> Browser: 
com.swirlds.common.constructable.ConstructableRegistryException: Could not create a lambda for constructor: symbolic reference class is not accessible: class com.hedera.node.app.state.merkle.MerkleHederaState, from class com.swirlds.common.constructable.internal.GenericConstructorRegistry (module com.swirlds.common)
	...........
Caused by: java.lang.IllegalAccessException: symbolic reference class is not accessible: class com.hedera.node.app.state.merkle.MerkleHederaState, from class com.swirlds.common.constructable.internal.GenericConstructorRegistry (module com.swirlds.common)
```