### PR TITLE
Enable prometheus scrape endpoint in previewnet and testnet

### DIFF
--- a/hedera-node/configuration/previewnet/settings.txt
+++ b/hedera-node/configuration/previewnet/settings.txt
@@ -27,3 +27,4 @@ jasperDb.storagePath,                          /opt/hgcapp/services-hedera/HapiA
 jasperDb.iteratorInputBufferBytes,             16777216
 virtualMap.preferredFlushQueueSize,            10000
 state.mainClassNameOverride,                   com.hedera.services.ServicesMain
+prometheusEndpointEnabled,                     true

--- a/hedera-node/configuration/testnet/settings.txt
+++ b/hedera-node/configuration/testnet/settings.txt
@@ -29,3 +29,4 @@ jasperDb.iteratorInputBufferBytes,             16777216
 virtualMap.preferredFlushQueueSize,            10000
 state.mainClassNameOverride,                   com.hedera.services.ServicesMain
 chatter.useChatter,                            false
+prometheusEndpointEnabled,                     true


### PR DESCRIPTION
This PR enabled the prometheus scrape endpoint for both previewnet and the stable testnet.