### PR TITLE
Implement TokenAssociateHandler prehandle

### DIFF
--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenAssociateToAccountHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenAssociateToAccountHandler.java
@@ -21,7 +21,6 @@ import static java.util.Objects.requireNonNull;
 import com.hedera.node.app.spi.meta.PreHandleContext;
 import com.hedera.node.app.spi.meta.TransactionMetadata;
 import com.hedera.node.app.spi.workflows.TransactionHandler;
-import com.hederahashgraph.api.proto.java.TransactionBody;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -36,14 +35,10 @@ public class TokenAssociateToAccountHandler implements TransactionHandler {
     public TokenAssociateToAccountHandler() {}
 
     /**
-     * This method is called during the pre-handle workflow.
-     *
-     * <p>Typically, this method validates the {@link TransactionBody} semantically, gathers all
-     * required keys, warms the cache, and creates the {@link TransactionMetadata} that is used in
-     * the handle stage.
-     *
-     * <p>Please note: the method signature is just a placeholder which is most likely going to
-     * change.
+     * Pre-handles a {@link
+     * com.hederahashgraph.api.proto.java.HederaFunctionality#TokenAssociateToAccount} transaction,
+     * returning the metadata required to, at minimum, validate the signatures of all required
+     * signing keys.
      *
      * @param context the {@link PreHandleContext} which collects all information that will be
      *     passed to {@link #handle(TransactionMetadata)}

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenAssociateToAccountHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenAssociateToAccountHandler.java
@@ -15,6 +15,7 @@
  */
 package com.hedera.node.app.service.token.impl.handlers;
 
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_ACCOUNT_ID;
 import static java.util.Objects.requireNonNull;
 
 import com.hedera.node.app.spi.meta.PreHandleContext;
@@ -50,7 +51,11 @@ public class TokenAssociateToAccountHandler implements TransactionHandler {
      */
     public void preHandle(@NonNull final PreHandleContext context) {
         requireNonNull(context);
-        throw new UnsupportedOperationException("Not implemented");
+
+        final var op = context.getTxn().getTokenAssociate();
+        final var target = op.getAccount();
+
+        context.addNonPayerKey(target, INVALID_ACCOUNT_ID);
     }
 
     /**

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenAssociateToAccountHandlerTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenAssociateToAccountHandlerTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hedera.node.app.service.token.impl.test.handlers;
+
+import static com.hedera.test.factories.scenarios.TokenAssociateScenarios.TOKEN_ASSOCIATE_WITH_CUSTOM_PAYER_PAID_KNOWN_TARGET;
+import static com.hedera.test.factories.scenarios.TokenAssociateScenarios.TOKEN_ASSOCIATE_WITH_IMMUTABLE_TARGET;
+import static com.hedera.test.factories.scenarios.TokenAssociateScenarios.TOKEN_ASSOCIATE_WITH_KNOWN_TARGET;
+import static com.hedera.test.factories.scenarios.TokenAssociateScenarios.TOKEN_ASSOCIATE_WITH_MISSING_TARGET;
+import static com.hedera.test.factories.scenarios.TokenAssociateScenarios.TOKEN_ASSOCIATE_WITH_SELF_PAID_KNOWN_TARGET;
+import static com.hedera.test.factories.scenarios.TxnHandlingScenario.CUSTOM_PAYER_ACCOUNT_KT;
+import static com.hedera.test.factories.scenarios.TxnHandlingScenario.MISC_ACCOUNT_KT;
+import static com.hedera.test.utils.KeyUtils.sanityRestored;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_ACCOUNT_ID;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OK;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.hedera.node.app.service.token.impl.handlers.TokenAssociateToAccountHandler;
+import com.hedera.node.app.spi.meta.PreHandleContext;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+class TokenAssociateToAccountHandlerTest extends ParityTestBase {
+
+    private final TokenAssociateToAccountHandler subject = new TokenAssociateToAccountHandler();
+
+    @Test
+    void tokenAssociateWithKnownTargetScenario() {
+        final var theTxn = txnFrom(TOKEN_ASSOCIATE_WITH_KNOWN_TARGET);
+
+        final var context = new PreHandleContext(keyLookup, theTxn);
+        subject.preHandle(context);
+
+        assertFalse(context.failed());
+        assertEquals(OK, context.getStatus());
+        assertEquals(1, context.getRequiredNonPayerKeys().size());
+        assertThat(
+                sanityRestored(context.getRequiredNonPayerKeys()),
+                Matchers.contains(MISC_ACCOUNT_KT.asKey()));
+    }
+
+    @Test
+    void tokenAssociateWithSelfPaidKnownTargetScenario() {
+        final var theTxn = txnFrom(TOKEN_ASSOCIATE_WITH_SELF_PAID_KNOWN_TARGET);
+
+        final var context = new PreHandleContext(keyLookup, theTxn);
+        subject.preHandle(context);
+
+        assertFalse(context.failed());
+        assertEquals(OK, context.getStatus());
+        assertEquals(0, context.getRequiredNonPayerKeys().size());
+    }
+
+    @Test
+    void tokenAssociateWithCustomPaidKnownTargetScenario() {
+        final var theTxn = txnFrom(TOKEN_ASSOCIATE_WITH_CUSTOM_PAYER_PAID_KNOWN_TARGET);
+
+        final var context = new PreHandleContext(keyLookup, theTxn);
+        subject.preHandle(context);
+
+        assertFalse(context.failed());
+        assertEquals(OK, context.getStatus());
+        assertEquals(1, context.getRequiredNonPayerKeys().size());
+        assertThat(
+                sanityRestored(context.getRequiredNonPayerKeys()),
+                Matchers.contains(CUSTOM_PAYER_ACCOUNT_KT.asKey()));
+    }
+
+    @Test
+    void tokenAssociateWithImmutableTargetScenario() {
+        final var theTxn = txnFrom(TOKEN_ASSOCIATE_WITH_IMMUTABLE_TARGET);
+
+        final var context = new PreHandleContext(keyLookup, theTxn);
+        subject.preHandle(context);
+
+        assertTrue(context.failed());
+        assertEquals(INVALID_ACCOUNT_ID, context.getStatus());
+        assertEquals(0, context.getRequiredNonPayerKeys().size());
+    }
+
+    @Test
+    void tokenAssociateWithMissingTargetScenario() {
+        final var theTxn = txnFrom(TOKEN_ASSOCIATE_WITH_MISSING_TARGET);
+
+        final var context = new PreHandleContext(keyLookup, theTxn);
+        subject.preHandle(context);
+
+        assertTrue(context.failed());
+        assertEquals(INVALID_ACCOUNT_ID, context.getStatus());
+        assertEquals(0, context.getRequiredNonPayerKeys().size());
+    }
+}


### PR DESCRIPTION
Description:

    Adds the pre handle logic for token associate

Related issue(s):

Fixes https://github.com/hashgraph/hedera-services/issues/4604