### PR TITLE
Implement TokenDissociateFromAccountHandler preHandle

### DIFF
--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenDissociateFromAccountHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenDissociateFromAccountHandler.java
@@ -15,12 +15,12 @@
  */
 package com.hedera.node.app.service.token.impl.handlers;
 
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_ACCOUNT_ID;
 import static java.util.Objects.requireNonNull;
 
 import com.hedera.node.app.spi.meta.PreHandleContext;
 import com.hedera.node.app.spi.meta.TransactionMetadata;
 import com.hedera.node.app.spi.workflows.TransactionHandler;
-import com.hederahashgraph.api.proto.java.TransactionBody;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -35,11 +35,10 @@ public class TokenDissociateFromAccountHandler implements TransactionHandler {
     public TokenDissociateFromAccountHandler() {}
 
     /**
-     * This method is called during the pre-handle workflow.
-     *
-     * <p>Typically, this method validates the {@link TransactionBody} semantically, gathers all
-     * required keys, warms the cache, and creates the {@link TransactionMetadata} that is used in
-     * the handle stage.
+     * Pre-handles a {@link
+     * com.hederahashgraph.api.proto.java.HederaFunctionality#TokenDissociateFromAccount}
+     * transaction, returning the metadata required to, at minimum, validate the signatures of all
+     * required signing keys.
      *
      * <p>Please note: the method signature is just a placeholder which is most likely going to
      * change.
@@ -50,7 +49,10 @@ public class TokenDissociateFromAccountHandler implements TransactionHandler {
      */
     public void preHandle(@NonNull final PreHandleContext context) {
         requireNonNull(context);
-        throw new UnsupportedOperationException("Not implemented");
+        final var op = context.getTxn().getTokenDissociate();
+        final var target = op.getAccount();
+
+        context.addNonPayerKey(target, INVALID_ACCOUNT_ID);
     }
 
     /**

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenDissociateFromAccountHandlerTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenDissociateFromAccountHandlerTest.java
@@ -58,7 +58,7 @@ class TokenDissociateFromAccountHandlerTest extends ParityTestBase {
     void tokenDissociateWithSelfPaidKnownTargetScenario() {
         final var theTxn = txnFrom(TOKEN_DISSOCIATE_WITH_SELF_PAID_KNOWN_TARGET);
 
-final var context = new PreHandleContext(keyLookup, theTxn);
+        final var context = new PreHandleContext(keyLookup, theTxn);
         subject.preHandle(context);
 
         assertFalse(context.failed());
@@ -70,7 +70,7 @@ final var context = new PreHandleContext(keyLookup, theTxn);
     void tokenDissociateWithCustomPaidKnownTargetScenario() {
         final var theTxn = txnFrom(TOKEN_DISSOCIATE_WITH_CUSTOM_PAYER_PAID_KNOWN_TARGET);
 
-final var context = new PreHandleContext(keyLookup, theTxn);
+        final var context = new PreHandleContext(keyLookup, theTxn);
         subject.preHandle(context);
 
         assertFalse(context.failed());
@@ -85,7 +85,7 @@ final var context = new PreHandleContext(keyLookup, theTxn);
     void tokenDissociateWithMissingTargetScenario() {
         final var theTxn = txnFrom(TOKEN_DISSOCIATE_WITH_MISSING_TARGET);
 
-final var context = new PreHandleContext(keyLookup, theTxn);
+        final var context = new PreHandleContext(keyLookup, theTxn);
         subject.preHandle(context);
 
         assertTrue(context.failed());

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenDissociateFromAccountHandlerTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenDissociateFromAccountHandlerTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hedera.node.app.service.token.impl.test.handlers;
+
+import static com.hedera.test.factories.scenarios.TokenDissociateScenarios.TOKEN_DISSOCIATE_WITH_CUSTOM_PAYER_PAID_KNOWN_TARGET;
+import static com.hedera.test.factories.scenarios.TokenDissociateScenarios.TOKEN_DISSOCIATE_WITH_KNOWN_TARGET;
+import static com.hedera.test.factories.scenarios.TokenDissociateScenarios.TOKEN_DISSOCIATE_WITH_MISSING_TARGET;
+import static com.hedera.test.factories.scenarios.TokenDissociateScenarios.TOKEN_DISSOCIATE_WITH_SELF_PAID_KNOWN_TARGET;
+import static com.hedera.test.factories.scenarios.TxnHandlingScenario.CUSTOM_PAYER_ACCOUNT_KT;
+import static com.hedera.test.factories.scenarios.TxnHandlingScenario.MISC_ACCOUNT_KT;
+import static com.hedera.test.utils.KeyUtils.sanityRestored;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_ACCOUNT_ID;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OK;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.hedera.node.app.service.token.impl.handlers.TokenDissociateFromAccountHandler;
+import com.hedera.node.app.spi.meta.PreHandleContext;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+class TokenDissociateFromAccountHandlerTest extends ParityTestBase {
+
+    private final TokenDissociateFromAccountHandler subject =
+            new TokenDissociateFromAccountHandler();
+
+    @Test
+    void tokenDissociateWithKnownTargetScenario() {
+        final var theTxn = txnFrom(TOKEN_DISSOCIATE_WITH_KNOWN_TARGET);
+
+        final var context = new PreHandleContext(keyLookup, theTxn);
+        subject.preHandle(context);
+
+        assertFalse(context.failed());
+        assertEquals(OK, context.getStatus());
+        assertEquals(1, context.getRequiredNonPayerKeys().size());
+        assertThat(
+                sanityRestored(context.getRequiredNonPayerKeys()),
+                Matchers.contains(MISC_ACCOUNT_KT.asKey()));
+    }
+
+    @Test
+    void tokenDissociateWithSelfPaidKnownTargetScenario() {
+        final var theTxn = txnFrom(TOKEN_DISSOCIATE_WITH_SELF_PAID_KNOWN_TARGET);
+
+final var context = new PreHandleContext(keyLookup, theTxn);
+        subject.preHandle(context);
+
+        assertFalse(context.failed());
+        assertEquals(OK, context.getStatus());
+        assertEquals(0, context.getRequiredNonPayerKeys().size());
+    }
+
+    @Test
+    void tokenDissociateWithCustomPaidKnownTargetScenario() {
+        final var theTxn = txnFrom(TOKEN_DISSOCIATE_WITH_CUSTOM_PAYER_PAID_KNOWN_TARGET);
+
+final var context = new PreHandleContext(keyLookup, theTxn);
+        subject.preHandle(context);
+
+        assertFalse(context.failed());
+        assertEquals(OK, context.getStatus());
+        assertEquals(1, context.getRequiredNonPayerKeys().size());
+        assertThat(
+                sanityRestored(context.getRequiredNonPayerKeys()),
+                Matchers.contains(CUSTOM_PAYER_ACCOUNT_KT.asKey()));
+    }
+
+    @Test
+    void tokenDissociateWithMissingTargetScenario() {
+        final var theTxn = txnFrom(TOKEN_DISSOCIATE_WITH_MISSING_TARGET);
+
+final var context = new PreHandleContext(keyLookup, theTxn);
+        subject.preHandle(context);
+
+        assertTrue(context.failed());
+        assertEquals(INVALID_ACCOUNT_ID, context.getStatus());
+        assertEquals(0, context.getRequiredNonPayerKeys().size());
+    }
+}


### PR DESCRIPTION
Description:

Adds the pre handle logic for token dissociate

Related issue(s):

Fixes https://github.com/hashgraph/hedera-services/issues/4631