### PR TITLE
Adding support for Redirect Token Calls fro evm-module 

### DIFF
--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/AbstractEvmStackedLedgerUpdater.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/AbstractEvmStackedLedgerUpdater.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hedera.node.app.service.evm.store.contracts;
+
+import com.hedera.node.app.service.evm.accounts.AccountAccessor;
+import com.hedera.node.app.service.evm.store.models.UpdatedHederaEvmAccount;
+import org.hyperledger.besu.datatypes.Address;
+import org.hyperledger.besu.evm.account.Account;
+import org.hyperledger.besu.evm.worldstate.WorldView;
+
+public class AbstractEvmStackedLedgerUpdater<W extends WorldView, A extends Account>
+        extends AbstractLedgerEvmWorldUpdater<
+                AbstractLedgerEvmWorldUpdater<W, A>, UpdatedHederaEvmAccount<A>> {
+
+    protected AbstractEvmStackedLedgerUpdater(
+            final AbstractLedgerEvmWorldUpdater<W, A> world,
+            final AccountAccessor accountAccessor,
+            final HederaEvmEntityAccess entityAccess) {
+        super(world, accountAccessor, entityAccess);
+    }
+
+    @Override
+    public UpdatedHederaEvmAccount<A> getForMutation(Address address) {
+        final var wrapped = wrappedWorldView();
+        final A account = wrapped.getForMutation(address);
+
+        return account == null ? null : new UpdatedHederaEvmAccount<>(account);
+    }
+}

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/AbstractLedgerEvmWorldUpdater.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/AbstractLedgerEvmWorldUpdater.java
@@ -16,21 +16,53 @@
 package com.hedera.node.app.service.evm.store.contracts;
 
 import com.hedera.node.app.service.evm.accounts.AccountAccessor;
+import com.hedera.node.app.service.evm.store.models.UpdatedHederaEvmAccount;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.datatypes.Wei;
 import org.hyperledger.besu.evm.account.Account;
 import org.hyperledger.besu.evm.account.EvmAccount;
 import org.hyperledger.besu.evm.worldstate.WorldUpdater;
+import org.hyperledger.besu.evm.worldstate.WorldView;
+import org.hyperledger.besu.evm.worldstate.WrappedEvmAccount;
 
-public abstract class AbstractLedgerEvmWorldUpdater implements WorldUpdater {
+public abstract class AbstractLedgerEvmWorldUpdater<W extends WorldView, A extends Account>
+        implements WorldUpdater {
 
+    protected final W world;
     protected final AccountAccessor accountAccessor;
+    private Map<Address, UpdatedHederaEvmAccount<A>> updatedEvmAccounts = new HashMap<>();
+    private HederaEvmEntityAccess hederaEvmEntityAccess;
 
-    protected AbstractLedgerEvmWorldUpdater(AccountAccessor accountAccessor) {
+    protected AbstractLedgerEvmWorldUpdater(final W world, final AccountAccessor accountAccessor) {
+        this.world = world;
         this.accountAccessor = accountAccessor;
+    }
+
+    protected AbstractLedgerEvmWorldUpdater(
+            final W world,
+            final AccountAccessor accountAccessor,
+            final HederaEvmEntityAccess hederaEvmEntityAccess) {
+        this(world, accountAccessor);
+        this.hederaEvmEntityAccess = hederaEvmEntityAccess;
+    }
+
+    /**
+     * Given an address, returns an account that can be mutated <b>with the assurance</b> that these
+     * mutations will be tracked in the change-set represented by this {@link WorldUpdater}; and
+     * either committed or reverted atomically with all other mutations in the change-set.
+     *
+     * @param address the address of interest
+     * @return a tracked mutable account for the given address
+     */
+    public abstract A getForMutation(Address address);
+
+    protected W wrappedWorldView() {
+        return world;
     }
 
     @Override
@@ -75,5 +107,39 @@ public abstract class AbstractLedgerEvmWorldUpdater implements WorldUpdater {
 
     public boolean isTokenAddress(Address address) {
         return accountAccessor.isTokenAddress(address);
+    }
+
+    @Override
+    public Account get(Address address) {
+        if (!address.equals(accountAccessor.canonicalAddress(address))) {
+            return null;
+        }
+        final var extantMutable = this.updatedEvmAccounts.get(address);
+        if (extantMutable != null) {
+            return extantMutable;
+        }
+
+        return world.get(address);
+    }
+
+    @Override
+    public EvmAccount getAccount(Address address) {
+        final var extantMutable = this.updatedEvmAccounts.get(address);
+        if (extantMutable != null) {
+            return new WrappedEvmAccount(extantMutable);
+        }
+
+        final var origin = getForMutation(address);
+        if (origin == null) {
+            return null;
+        }
+        final var newMutable = new UpdatedHederaEvmAccount<>(origin);
+        return new WrappedEvmAccount(track(newMutable));
+    }
+
+    private UpdatedHederaEvmAccount<A> track(final UpdatedHederaEvmAccount<A> account) {
+        account.setEvmEntityAccess(hederaEvmEntityAccess);
+        updatedEvmAccounts.put(account.getAddress(), account);
+        return account;
     }
 }

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/HederaEvmStackedWorldStateUpdater.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/HederaEvmStackedWorldStateUpdater.java
@@ -16,25 +16,31 @@
 package com.hedera.node.app.service.evm.store.contracts;
 
 import com.hedera.node.app.service.evm.accounts.AccountAccessor;
+import com.hedera.node.app.service.evm.contracts.execution.EvmProperties;
 import com.hedera.node.app.service.evm.store.models.UpdatedHederaEvmAccount;
 import com.hedera.node.app.service.evm.store.tokens.TokenAccessor;
 import org.hyperledger.besu.datatypes.Address;
-import org.hyperledger.besu.datatypes.Wei;
 import org.hyperledger.besu.evm.account.Account;
 import org.hyperledger.besu.evm.account.EvmAccount;
+import org.hyperledger.besu.evm.worldstate.WrappedEvmAccount;
 
-public class HederaEvmStackedWorldStateUpdater extends AbstractLedgerEvmWorldUpdater {
+public class HederaEvmStackedWorldStateUpdater
+        extends AbstractEvmStackedLedgerUpdater<HederaEvmMutableWorldState, Account> {
 
     protected final HederaEvmEntityAccess hederaEvmEntityAccess;
     protected final TokenAccessor tokenAccessor;
+    private final EvmProperties evmProperties;
 
     public HederaEvmStackedWorldStateUpdater(
+            final AbstractLedgerEvmWorldUpdater<HederaEvmMutableWorldState, Account> updater,
             final AccountAccessor accountAccessor,
             final HederaEvmEntityAccess hederaEvmEntityAccess,
-            final TokenAccessor tokenAccessor) {
-        super(accountAccessor);
+            final TokenAccessor tokenAccessor,
+            final EvmProperties evmProperties) {
+        super(updater, accountAccessor, hederaEvmEntityAccess);
         this.hederaEvmEntityAccess = hederaEvmEntityAccess;
         this.tokenAccessor = tokenAccessor;
+        this.evmProperties = evmProperties;
     }
 
     public TokenAccessor tokenAccessor() {
@@ -42,21 +48,27 @@ public class HederaEvmStackedWorldStateUpdater extends AbstractLedgerEvmWorldUpd
     }
 
     @Override
-    public Account get(Address address) {
-        if (!address.equals(accountAccessor.canonicalAddress(address))) {
-            return null;
+    public Account get(final Address address) {
+        if (isTokenRedirect(address)) {
+            return new HederaEvmWorldStateTokenAccount(address);
         }
-
-        final var accountBalance = Wei.of(hederaEvmEntityAccess.getBalance(address));
-        final var account = new UpdatedHederaEvmAccount(address);
-        account.setBalance(accountBalance);
-        account.setEvmEntityAccess(hederaEvmEntityAccess);
-
-        return account;
+        return super.get(address);
     }
 
     @Override
-    public EvmAccount getAccount(Address address) {
-        return (EvmAccount) get(address);
+    public EvmAccount getAccount(final Address address) {
+        if (isTokenRedirect(address)) {
+            final var proxyAccount = new HederaEvmWorldStateTokenAccount(address);
+            final var newMutable = new UpdatedHederaEvmAccount<>(proxyAccount);
+            newMutable.setEvmEntityAccess(hederaEvmEntityAccess);
+            return new WrappedEvmAccount(newMutable);
+        }
+
+        return super.getAccount(address);
+    }
+
+    private boolean isTokenRedirect(final Address address) {
+        return hederaEvmEntityAccess.isTokenAccount(address)
+                && evmProperties.isRedirectTokenCallsEnabled();
     }
 }

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/HederaEvmWorldState.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/HederaEvmWorldState.java
@@ -88,17 +88,28 @@ public class HederaEvmWorldState implements HederaEvmMutableWorldState {
 
     @Override
     public HederaEvmWorldUpdater updater() {
-        return new Updater(accountAccessor, hederaEvmEntityAccess, tokenAccessor);
+        return new Updater(
+                this, accountAccessor, hederaEvmEntityAccess, tokenAccessor, evmProperties);
     }
 
-    public static class Updater extends HederaEvmStackedWorldStateUpdater
+    public static class Updater
+            extends AbstractLedgerEvmWorldUpdater<HederaEvmMutableWorldState, Account>
             implements HederaEvmWorldUpdater {
 
+        private final HederaEvmEntityAccess hederaEvmEntityAccess;
+        private final TokenAccessor tokenAccessor;
+        private final EvmProperties evmProperties;
+
         protected Updater(
+                final HederaEvmWorldState world,
                 final AccountAccessor accountAccessor,
                 final HederaEvmEntityAccess hederaEvmEntityAccess,
-                final TokenAccessor tokenAccessor) {
-            super(accountAccessor, hederaEvmEntityAccess, tokenAccessor);
+                final TokenAccessor tokenAccessor,
+                final EvmProperties evmProperties) {
+            super(world, accountAccessor);
+            this.tokenAccessor = tokenAccessor;
+            this.hederaEvmEntityAccess = hederaEvmEntityAccess;
+            this.evmProperties = evmProperties;
         }
 
         @Override
@@ -107,9 +118,15 @@ public class HederaEvmWorldState implements HederaEvmMutableWorldState {
         }
 
         @Override
+        public Account getForMutation(final Address address) {
+            final HederaEvmWorldState wrapped = (HederaEvmWorldState) wrappedWorldView();
+            return wrapped.get(address);
+        }
+
+        @Override
         public WorldUpdater updater() {
             return new HederaEvmStackedWorldStateUpdater(
-                    accountAccessor, hederaEvmEntityAccess, tokenAccessor);
+                    this, accountAccessor, hederaEvmEntityAccess, tokenAccessor, evmProperties);
         }
     }
 }

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/models/UpdatedHederaEvmAccount.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/models/UpdatedHederaEvmAccount.java
@@ -30,11 +30,12 @@ import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.datatypes.Wei;
 import org.hyperledger.besu.evm.ModificationNotAllowedException;
+import org.hyperledger.besu.evm.account.Account;
 import org.hyperledger.besu.evm.account.AccountStorageEntry;
 import org.hyperledger.besu.evm.account.EvmAccount;
 import org.hyperledger.besu.evm.account.MutableAccount;
 
-public class UpdatedHederaEvmAccount implements MutableAccount, EvmAccount {
+public class UpdatedHederaEvmAccount<A extends Account> implements MutableAccount, EvmAccount {
     protected Hash addressHash;
     private Address address;
     private long nonce;
@@ -42,21 +43,28 @@ public class UpdatedHederaEvmAccount implements MutableAccount, EvmAccount {
     private HederaEvmEntityAccess hederaEvmEntityAccess;
     protected final NavigableMap<UInt256, UInt256> updatedStorage;
 
+    @Nullable protected final A account;
     @Nullable protected Bytes updatedCode;
     @Nullable private Hash updatedCodeHash;
 
     public UpdatedHederaEvmAccount(Address address) {
-        this(address, 0L, Wei.ZERO);
-        this.updatedCode = Bytes.EMPTY;
+        this.address = address;
+        addressHash = Hash.hash(address);
+        account = null;
+        balance = Wei.ZERO;
+        nonce = 0L;
+        updatedCode = Bytes.EMPTY;
+        updatedStorage = new TreeMap<>();
     }
 
-    public UpdatedHederaEvmAccount(Address address, long nonce, Wei balance) {
-        this.address = address;
-        this.addressHash = Hash.hash(address);
-        this.nonce = nonce;
-        this.balance = balance;
-        this.updatedStorage = new TreeMap<>();
-        this.updatedCode = null;
+    public UpdatedHederaEvmAccount(final A account) {
+        this.account = account;
+        address = account.getAddress();
+        addressHash = Hash.hash(address);
+        balance = account.getBalance();
+        nonce = account.getNonce();
+        updatedCode = null;
+        updatedStorage = new TreeMap<>();
     }
 
     @Override

--- a/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/store/models/MockAccountAccessor.java
+++ b/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/store/models/MockAccountAccessor.java
@@ -19,8 +19,7 @@ import com.hedera.node.app.service.evm.accounts.AccountAccessor;
 import org.hyperledger.besu.datatypes.Address;
 
 public class MockAccountAccessor implements AccountAccessor {
-    private final Address address =
-            Address.fromHexString("0x000000000000000000000000000000000000077e");
+    private Address address = Address.fromHexString("0x000000000000000000000000000000000000077e");
 
     @Override
     public Address canonicalAddress(Address addressOrAlias) {
@@ -30,5 +29,9 @@ public class MockAccountAccessor implements AccountAccessor {
     @Override
     public boolean isTokenAddress(Address address) {
         return false;
+    }
+
+    public void changeAddress(Address address) {
+        this.address = address;
     }
 }

--- a/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/store/models/MockEntityAccess.java
+++ b/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/store/models/MockEntityAccess.java
@@ -17,10 +17,14 @@ package com.hedera.node.app.service.evm.store.models;
 
 import com.google.protobuf.ByteString;
 import com.hedera.node.app.service.evm.store.contracts.HederaEvmEntityAccess;
+import java.util.HashMap;
+import java.util.Map;
 import org.apache.tuweni.bytes.Bytes;
 import org.hyperledger.besu.datatypes.Address;
 
 public class MockEntityAccess implements HederaEvmEntityAccess {
+    private final Map<Address, Boolean> accounts = new HashMap<>();
+
     @Override
     public boolean isUsable(Address address) {
         return false;
@@ -33,7 +37,8 @@ public class MockEntityAccess implements HederaEvmEntityAccess {
 
     @Override
     public boolean isTokenAccount(Address address) {
-        return false;
+        final var isToken = accounts.get(address);
+        return isToken != null ? isToken : false;
     }
 
     @Override
@@ -54,5 +59,9 @@ public class MockEntityAccess implements HederaEvmEntityAccess {
     @Override
     public Bytes fetchCodeIfPresent(Address address) {
         return null;
+    }
+
+    public void setIsTokenFor(final Address address) {
+        accounts.put(address, true);
     }
 }

--- a/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/store/models/UpdatedHederaEvmAccountTest.java
+++ b/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/store/models/UpdatedHederaEvmAccountTest.java
@@ -107,7 +107,7 @@ class UpdatedHederaEvmAccountTest {
 
     @Test
     void getOriginalStorageValue() {
-        subject = new UpdatedHederaEvmAccount(address, 0, Wei.ZERO);
+        subject = new UpdatedHederaEvmAccount(address);
         assertEquals(ZERO, subject.getOriginalStorageValue(MIN_VALUE));
     }
 

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/AbstractLedgerWorldUpdater.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/AbstractLedgerWorldUpdater.java
@@ -89,10 +89,9 @@ import org.hyperledger.besu.evm.worldstate.WrappedEvmAccount;
  * @param <W> the most specialized world updater to be used
  */
 public abstract class AbstractLedgerWorldUpdater<W extends WorldView, A extends Account>
-        extends AbstractLedgerEvmWorldUpdater {
+        extends AbstractLedgerEvmWorldUpdater<W, A> {
     protected static final int UNKNOWN_RECORD_SOURCE_ID = -1;
 
-    private final W world;
     private final WorldLedgers trackingLedgers;
 
     // All the record source ids of our committed child updaters
@@ -104,20 +103,9 @@ public abstract class AbstractLedgerWorldUpdater<W extends WorldView, A extends 
     protected Map<Address, UpdateTrackingLedgerAccount<A>> updatedAccounts = new HashMap<>();
 
     protected AbstractLedgerWorldUpdater(final W world, final WorldLedgers trackingLedgers) {
-        super(new AccountAccessorImpl(trackingLedgers));
-        this.world = world;
+        super(world, new AccountAccessorImpl(trackingLedgers));
         this.trackingLedgers = trackingLedgers;
     }
-
-    /**
-     * Given an address, returns an account that can be mutated <b>with the assurance</b> that these
-     * mutations will be tracked in the change-set represented by this {@link WorldUpdater}; and
-     * either committed or reverted atomically with all other mutations in the change-set.
-     *
-     * @param address the address of interest
-     * @return a tracked mutable account for the given address
-     */
-    protected abstract A getForMutation(Address address);
 
     /**
      * Returns the {@link ContractCustomizer} to use for the pending creation.
@@ -350,10 +338,6 @@ public abstract class AbstractLedgerWorldUpdater<W extends WorldView, A extends 
     public void trackLazilyCreatedAccount(final Address address) {
         final var newMutable = new UpdateTrackingLedgerAccount<A>(address, trackingAccounts());
         track(newMutable);
-    }
-
-    protected W wrappedWorldView() {
-        return world;
     }
 
     protected Collection<Address> getDeletedAccounts() {

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/AbstractStackedLedgerUpdater.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/AbstractStackedLedgerUpdater.java
@@ -43,7 +43,7 @@ public abstract class AbstractStackedLedgerUpdater<W extends WorldView, A extend
 
     /** {@inheritDoc} */
     @Override
-    protected UpdateTrackingLedgerAccount<A> getForMutation(final Address address) {
+    public UpdateTrackingLedgerAccount<A> getForMutation(final Address address) {
         final var wrapped = wrappedWorldView();
         final var wrappedMutable = wrapped.updatedAccounts.get(address);
         if (wrappedMutable != null) {

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/HederaWorldState.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/HederaWorldState.java
@@ -203,7 +203,7 @@ public class HederaWorldState extends HederaEvmWorldState implements HederaMutab
         }
 
         @Override
-        protected Account getForMutation(final Address address) {
+        public Account getForMutation(final Address address) {
             final HederaWorldState wrapped = (HederaWorldState) wrappedWorldView();
             return wrapped.get(address);
         }

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/UpdateTrackingLedgerAccount.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/UpdateTrackingLedgerAccount.java
@@ -38,12 +38,11 @@ import org.hyperledger.besu.evm.account.Account;
 import org.hyperledger.besu.evm.account.AccountStorageEntry;
 import org.hyperledger.besu.evm.account.MutableAccount;
 
-public class UpdateTrackingLedgerAccount<A extends Account> extends UpdatedHederaEvmAccount {
+public class UpdateTrackingLedgerAccount<A extends Account> extends UpdatedHederaEvmAccount<A> {
     private final AccountID accountId;
 
     private TransactionalLedger<AccountID, AccountProperty, HederaAccount> trackingAccounts;
 
-    @Nullable private final A account;
     private boolean storageWasCleared = false;
 
     public UpdateTrackingLedgerAccount(
@@ -54,8 +53,6 @@ public class UpdateTrackingLedgerAccount<A extends Account> extends UpdatedHeder
         super(address);
         Preconditions.checkNotNull(address);
         this.accountId = EntityIdUtils.accountIdFromEvmAddress(address);
-        this.addressHash = Hash.hash(super.getAddress());
-        this.account = null;
         this.trackingAccounts = trackingAccounts;
     }
 
@@ -65,14 +62,13 @@ public class UpdateTrackingLedgerAccount<A extends Account> extends UpdatedHeder
             @Nullable
                     final TransactionalLedger<AccountID, AccountProperty, HederaAccount>
                             trackingAccounts) {
-        super(account.getAddress(), account.getNonce(), account.getBalance());
+        super(account);
         Preconditions.checkNotNull(account);
         this.accountId = EntityIdUtils.accountIdFromEvmAddress(account.getAddress());
         this.addressHash =
                 account instanceof UpdateTrackingLedgerAccount
                         ? ((UpdateTrackingLedgerAccount<A>) account).addressHash
                         : Hash.hash(account.getAddress());
-        this.account = account;
         this.trackingAccounts = trackingAccounts;
     }
 

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/MockLedgerWorldUpdater.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/MockLedgerWorldUpdater.java
@@ -38,7 +38,7 @@ public class MockLedgerWorldUpdater extends AbstractLedgerWorldUpdater<HederaWor
     }
 
     @Override
-    protected Account getForMutation(Address address) {
+    public Account getForMutation(Address address) {
         return wrappedWorldView().get(address);
     }
 


### PR DESCRIPTION
This PR enrich the current hedera-evm module Updaters and HederaEvmWorldState to work with `HederaEvmWorldStateTokenAccount` adding a support for redirect token calls.
The flow tends to be a light mimic of the mono-services one with as litle duplication possible.


The workflow in this PR is being test from mirror-node side in [PR](https://github.com/hashgraph/hedera-mirror-node/pull/5206).

Follow-up [PR](https://github.com/hashgraph/hedera-services/pull/4894/files#diff-dbed0555410c6fe08e05b985f47fd2518053a381919a0b134ff683c5d76c44ac) with refactoring and removal of duplicated fields.

Fixes #4798 