### PR TITLE
Fix : Fix `nftsOwned` for Treasury when NFTs are returned back to treasury

### DIFF
--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/expiry/removal/TreasuryReturnHelper.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/expiry/removal/TreasuryReturnHelper.java
@@ -58,11 +58,6 @@ public class TreasuryReturnHelper {
             final long serialNo,
             final List<EntityId> tokenTypes,
             final List<NftAdjustments> returnExchanges) {
-        final var mutableTreasury = entityLookup.getMutableAccount(token.treasuryNum());
-        final var numPair =
-                EntityNumPair.fromLongs(token.treasuryNum().longValue(), tokenNum.longValue());
-        final var tokenRel = tokenRels.get().getForModify(numPair);
-
         final var tokenId = tokenNum.toEntityId();
         var typeI = tokenTypes.indexOf(tokenId);
         if (typeI == -1) {
@@ -79,8 +74,10 @@ public class TreasuryReturnHelper {
             returnExchanges
                     .get(typeI)
                     .appendAdjust(expiredNum.toEntityId(), token.treasury(), serialNo);
+
+            final var mutableTreasury = entityLookup.getMutableAccount(token.treasuryNum());
             mutableTreasury.setNftsOwned(mutableTreasury.getNftsOwned() + 1);
-            tokenRel.setBalance(tokenRel.getBalance() + 1);
+            incrementTreasuryBalance(token, tokenNum, 1, tokenRels.get());
             return true;
         }
     }

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/expiry/removal/TreasuryReturnHelperTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/expiry/removal/TreasuryReturnHelperTest.java
@@ -22,6 +22,8 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 import com.hedera.node.app.service.evm.store.tokens.TokenType;
+import com.hedera.node.app.service.mono.state.expiry.classification.EntityLookup;
+import com.hedera.node.app.service.mono.state.merkle.MerkleAccount;
 import com.hedera.node.app.service.mono.state.merkle.MerkleToken;
 import com.hedera.node.app.service.mono.state.merkle.MerkleTokenRelStatus;
 import com.hedera.node.app.service.mono.state.merkle.MerkleUniqueToken;
@@ -49,7 +51,9 @@ import org.mockito.junit.jupiter.MockitoExtension;
 class TreasuryReturnHelperTest {
     @Mock private TokenRelStorageAdapter tokenRels;
     @Mock private UniqueTokenMapAdapter nfts;
-
+    @Mock private EntityLookup lookup;
+    @Mock private MerkleAccount treasury;
+    @Mock private MerkleTokenRelStatus rel;
     private final List<CurrencyAdjustments> returnTransfers = new ArrayList<>();
     private final List<EntityId> tokenTypes = new ArrayList<>();
     private final List<NftAdjustments> returnExchanges = new ArrayList<>();
@@ -58,7 +62,7 @@ class TreasuryReturnHelperTest {
 
     @BeforeEach
     void setUp() {
-        subject = new TreasuryReturnHelper();
+        subject = new TreasuryReturnHelper(lookup, () -> tokenRels);
     }
 
     @Test
@@ -145,10 +149,18 @@ class TreasuryReturnHelperTest {
     }
 
     @Test
-    void justAppendsReturnIfTokenNotDeleted() {
+    void appendsAndChangedNumOwnedNftsIfTokenNotDeleted() {
         final List<EntityId> tokenTypes = new ArrayList<>();
         tokenTypes.add(nonFungibleTokenNum.toEntityId());
         returnExchanges.add(new NftAdjustments());
+        given(lookup.getMutableAccount(treasuryNum)).willReturn(treasury);
+        given(
+                        tokenRels.getForModify(
+                                EntityNumPair.fromLongs(
+                                        treasuryNum.longValue(), nonFungibleTokenNum.longValue())))
+                .willReturn(rel);
+        given(treasury.getNftsOwned()).willReturn(0L);
+        given(rel.getBalance()).willReturn(0L);
 
         final var didReturn =
                 subject.updateNftReturns(
@@ -169,6 +181,8 @@ class TreasuryReturnHelperTest {
         assertTrue(didReturn);
         assertEquals(exchangesFrom(ttls), returnExchanges);
         assertEquals(1, tokenTypes.size());
+        verify(treasury).setNftsOwned(1L);
+        verify(rel).setBalance(1L);
     }
 
     @Test

--- a/test-clients/src/main/java/com/hedera/services/bdd/junit/ExpiryRecordsValidator.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/junit/ExpiryRecordsValidator.java
@@ -25,9 +25,8 @@ import java.util.List;
 
 /** This validator validates expiry contract records at the end of test run */
 public class ExpiryRecordsValidator implements RecordStreamValidator {
-    public ExpiryRecordsValidator(){
+    public ExpiryRecordsValidator() {}
 
-    }
     private static final String AUTO_RENEWAL_MEMO = " was automatically renewed";
     private static final String AUTO_EXPIRY_MEMO = " was automatically deleted";
 

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/file/FileUpdateSuite.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/file/FileUpdateSuite.java
@@ -125,7 +125,7 @@ public class FileUpdateSuite extends HapiSuite {
     private static final String INVALID_ENTITY_ID = "1.2.3";
 
     public static final String INDIVIDUAL_KV_LIMIT_PROP = "contracts.maxKvPairs.individual";
-    private static final String AGGREGATE_KV_LIMIT_PROP = "contracts.maxKvPairs.aggregate";
+    public static final String AGGREGATE_KV_LIMIT_PROP = "contracts.maxKvPairs.aggregate";
     private static final String USE_GAS_THROTTLE_PROP = "contracts.throttle.throttleByGas";
     private static final String MAX_CUSTOM_FEES_PROP = "tokens.maxCustomFeesAllowed";
     private static final String MAX_REFUND_GAS_PROP = "contracts.maxRefundPercentOfGasLimit";
@@ -138,11 +138,11 @@ public class FileUpdateSuite extends HapiSuite {
             Long.parseLong(HapiSpecSetup.getDefaultNodeProps().get("entities.maxLifetime"));
     private static final String DEFAULT_MAX_CUSTOM_FEES =
             HapiSpecSetup.getDefaultNodeProps().get(MAX_CUSTOM_FEES_PROP);
-    private static final String DEFAULT_MAX_KV_PAIRS_PER_CONTRACT =
+    public static final String DEFAULT_MAX_KV_PAIRS_PER_CONTRACT =
             HapiSpecSetup.getDefaultNodeProps().get(INDIVIDUAL_KV_LIMIT_PROP);
-    private static final String DEFAULT_MAX_KV_PAIRS =
+    public static final String DEFAULT_MAX_KV_PAIRS =
             HapiSpecSetup.getDefaultNodeProps().get(AGGREGATE_KV_LIMIT_PROP);
-    private static final String DEFAULT_MAX_CONS_GAS =
+    public static final String DEFAULT_MAX_CONS_GAS =
             HapiSpecSetup.getDefaultNodeProps().get(CONS_MAX_GAS_PROP);
 
     public static final String STORAGE_PRICE_TIERS_PROP = "contract.storageSlotPriceTiers";


### PR DESCRIPTION
Fixes #4895 

- Sets balance and NftsOwned on treasury when NFTs are returned back to treasury