### PR TITLE
WIP: Metrics/logging collection for traceability

### DIFF
--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/contracts/execution/HederaEvmTxProcessor.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/contracts/execution/HederaEvmTxProcessor.java
@@ -78,6 +78,10 @@ public abstract class HederaEvmTxProcessor {
         this.tracer = tracer;
     }
 
+    public HederaEvmOperationTracer getOperationTracer() {
+        return tracer;
+    }
+
     protected HederaEvmTxProcessor(
             final HederaEvmMutableWorldState worldState,
             final PricesAndFeesProvider livePricesSource,

--- a/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/contracts/execution/HederaEvmTxProcessorTest.java
+++ b/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/contracts/execution/HederaEvmTxProcessorTest.java
@@ -27,6 +27,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.hedera.node.app.service.evm.contracts.execution.traceability.DefaultHederaTracer;
+import com.hedera.node.app.service.evm.contracts.execution.traceability.HederaEvmOperationTracer;
 import com.hedera.node.app.service.evm.store.contracts.HederaEvmMutableWorldState;
 import com.hedera.node.app.service.evm.store.contracts.HederaEvmWorldUpdater;
 import com.hedera.node.app.service.evm.store.models.HederaEvmAccount;
@@ -115,6 +116,7 @@ class HederaEvmTxProcessorTest {
     private final String INSUFFICIENT_GAS = "INSUFFICIENT_GAS";
 
     private MockHederaEvmTxProcessor evmTxProcessor;
+    private HederaEvmOperationTracer tracer;
     private String mcpVersion;
     private String ccpVersion;
 
@@ -152,8 +154,14 @@ class HederaEvmTxProcessorTest {
         evmTxProcessor = new MockHederaEvmTxProcessor(
                 worldState, livePricesSource, globalDynamicProperties, gasCalculator, mcps, ccps, blockMetaSource);
 
-        final var hederaEvmOperationTracer = new DefaultHederaTracer();
-        evmTxProcessor.setOperationTracer(hederaEvmOperationTracer);
+        tracer = new DefaultHederaTracer();
+        evmTxProcessor.setOperationTracer(tracer);
+    }
+
+    @Test
+    void getterForTracerWorks() {
+        final var actual = evmTxProcessor.getOperationTracer();
+        assertEquals(tracer, actual);
     }
 
     @Test

--- a/hedera-node/hedera-mono-service/src/jmh/java/com/hedera/node/app/service/mono/submerkle/RandomFactory.java
+++ b/hedera-node/hedera-mono-service/src/jmh/java/com/hedera/node/app/service/mono/submerkle/RandomFactory.java
@@ -22,6 +22,7 @@ import com.hedera.node.app.service.mono.context.FullEvmResult;
 import com.hedera.node.app.service.mono.contracts.execution.HederaMessageCallProcessor;
 import com.hedera.node.app.service.mono.contracts.execution.TransactionProcessingResult;
 import com.hedera.node.app.service.mono.state.merkle.internals.BitPackUtils;
+import com.hedera.node.app.service.mono.stats.SidecarInstrumentation;
 import com.hederahashgraph.api.proto.java.ContractID;
 import com.swirlds.common.utility.CommonUtils;
 import java.util.ArrayList;
@@ -64,6 +65,7 @@ public class RandomFactory {
         // TODO(Nathan): An 8th argument was added to the method but this code was no updated. I
         // added Collections.emptyList() to achieve successful compilation, but this logic may not
         // be correct.
+
         final var ans = TransactionProcessingResult.successful(
                 logs,
                 randomNonNegativeLong(),
@@ -72,7 +74,8 @@ public class RandomFactory {
                 output,
                 randomAddress(),
                 randomStateChanges(params),
-                Collections.emptyList());
+                Collections.emptyList(),
+                SidecarInstrumentation.createNoop());
         if (r.nextDouble() < params.creationProbability()) {
             ans.setCreatedContracts(randomCreations(params.maxCreations()));
         }
@@ -106,7 +109,8 @@ public class RandomFactory {
                 revertReason,
                 haltReason,
                 randomStateChanges(params),
-                Collections.emptyList());
+                Collections.emptyList(),
+                SidecarInstrumentation.createNoop());
     }
 
     private Map<Address, Map<Bytes, Pair<Bytes, Bytes>>> randomStateChanges(final EvmResultRandomParams params) {

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/contracts/execution/traceability/HederaOperationTracer.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/contracts/execution/traceability/HederaOperationTracer.java
@@ -17,6 +17,8 @@
 package com.hedera.node.app.service.mono.contracts.execution.traceability;
 
 import com.hedera.node.app.service.evm.contracts.execution.traceability.HederaEvmOperationTracer;
+import com.hedera.node.app.service.mono.stats.SidecarInstrumentation;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import org.hyperledger.besu.evm.frame.MessageFrame;
 
 /**
@@ -34,4 +36,12 @@ public interface HederaOperationTracer extends HederaEvmOperationTracer {
      *     SYSTEM}
      */
     void tracePrecompileResult(final MessageFrame frame, final ContractActionType type);
+
+    /**
+     * Get the instrumentation collector for operations involving the sidecar records.
+     *
+     * @return An instrumentation collector for EVM operations on sidecar records.
+     */
+    @NonNull
+    SidecarInstrumentation getInstrumentation();
 }

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/exceptions/Requires.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/exceptions/Requires.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.node.app.service.mono.exceptions;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.ArrayList;
+import java.util.Objects;
+
+/** Utility class holding certain logic-error assertions/validations. */
+public class Requires {
+
+    /** Takes pairs of (some object instance, name of that object) and throws if _any_ of the
+     * given object instances are null.  Exception thrown includes the name of _all_ such
+     * null object instances.  Intended to be used to check _multiple_ arguments of a method
+     * that cannot any of them be null, and report _all_ null arguments at the same time.
+     *
+     * @param args List of object-1, name-1, object-2, name-2, ...
+     */
+    public static void nonNull(Object... args) {
+        if (args.length % 2 != 0) throw new IllegalArgumentException("Must have even number of arguments");
+
+        final var nullNames = new ArrayList<String>();
+
+        for (int i = 0; i < args.length; i += 2) {
+            if (Objects.isNull(args[i])) {
+                final var name = args[i + 1];
+                if (Objects.isNull(name))
+                    throw new IllegalArgumentException("argument %d has null name".formatted(i / 2));
+                nullNames.add(name.toString());
+            }
+        }
+
+        if (!nullNames.isEmpty()) {
+            final var names = String.join(", ", nullNames);
+            final var msg = "null argument%s found: %s".formatted(nullNames.size() == 1 ? "" : "s", names);
+            throw new NullArgumentsException(msg);
+        }
+    }
+
+    public static class NullArgumentsException extends NullPointerException {
+        public NullArgumentsException(@NonNull String msg) {
+            super(msg);
+            Objects.requireNonNull(msg, "msg:String");
+        }
+    }
+
+    /** This is a utility class */
+    private Requires() {}
+}

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/records/TransactionRecordService.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/records/TransactionRecordService.java
@@ -27,6 +27,7 @@ import com.hedera.node.app.service.mono.state.submerkle.EvmFnResult;
 import com.hedera.node.app.service.mono.store.models.Topic;
 import com.hedera.node.app.service.mono.utils.SidecarUtils;
 import com.hedera.services.stream.proto.TransactionSidecarRecord;
+import java.util.Objects;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
@@ -109,12 +110,15 @@ public class TransactionRecordService {
     }
 
     private void addAllSidecarsToTxnContextFrom(final TransactionProcessingResult result) {
+        final var sidecarInstrumentation = result.getSidecarInstrumentation();
+        Objects.requireNonNull(sidecarInstrumentation, "sidecarInstrumentation:SidecarInstrumentation required");
         if (!result.getStateChanges().isEmpty()) {
-            txnCtx.addSidecarRecord(SidecarUtils.createStateChangesSidecarFrom(result.getStateChanges()));
+            txnCtx.addSidecarRecord(
+                    SidecarUtils.createStateChangesSidecarFrom(result.getStateChanges(), sidecarInstrumentation));
         }
         final var actions = result.getActions();
         if (!actions.isEmpty()) {
-            txnCtx.addSidecarRecord(SidecarUtils.createContractActionsSidecar(actions));
+            txnCtx.addSidecarRecord(SidecarUtils.createContractActionsSidecar(actions, sidecarInstrumentation));
         }
     }
 

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/records/TxnAwareRecordsHistorian.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/records/TxnAwareRecordsHistorian.java
@@ -308,6 +308,8 @@ public class TxnAwareRecordsHistorian implements RecordsHistorian {
 
     public static void timestampSidecars(
             final List<TransactionSidecarRecord.Builder> sidecars, final Instant txnTimestamp) {
+        // (This operation is not expensive so we don't bother to add it to the sidecar
+        // instrumentation)
         final var commonTimestamp = MiscUtils.asTimestamp(txnTimestamp);
         for (final var sidecar : sidecars) {
             sidecar.setConsensusTimestamp(commonTimestamp);

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/tasks/TraceabilityExportTask.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/tasks/TraceabilityExportTask.java
@@ -198,6 +198,7 @@ public class TraceabilityExportTask implements SystemTask {
         }
         final var bytecodeSidecar =
                 SidecarUtils.createContractBytecodeSidecarFrom(contractId, runtimeCode.toArrayUnsafe());
+        // (Don't need sidecar instrumentation here because: migration only)
         bytecodeSidecar.setMigration(true);
         return bytecodeSidecar;
     }

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/stats/NoopSidecarInstrumentation.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/stats/NoopSidecarInstrumentation.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.node.app.service.mono.stats;
+
+import com.hedera.services.stream.proto.SidecarType;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.io.Closeable;
+import java.time.Duration;
+
+/**
+ * A noop (aka "do nothing") implementation of sidecar instrumentation suitable for tests or other
+ * contexts where a sidecar instrumentation is required but actual metrics collecting is not needed.
+ */
+class NoopSidecarInstrumentation implements SidecarInstrumentation {
+    @Override
+    public void addSample(@NonNull final SidecarType type, final long size) {}
+
+    @Override
+    public void addSample(@NonNull final SidecarType type, @NonNull final Duration duration) {}
+
+    @Override
+    public void addSample(@NonNull final SidecarType type, final long size, @NonNull final Duration duration) {}
+
+    @Override
+    public void addSamples(@NonNull final SidecarInstrumentation samples) {}
+
+    @Override
+    public Closeable startTimer(@NonNull final SidecarType type) {
+        return () -> {};
+    }
+
+    @Override
+    public void captureDurationSplit(@NonNull final SidecarType type, @NonNull final Runnable fn) {
+        fn.run();
+    }
+
+    @Override
+    public <V> V captureDurationSplit(@NonNull final SidecarType type, @NonNull final ExceptionFreeCallable<V> fn) {
+        return fn.call();
+    }
+
+    @Override
+    public void addDurationSplitsAsDurationSample(@NonNull final SidecarType type) {}
+
+    @Override
+    public void reset() {}
+
+    @Override
+    public void addCopy() {}
+
+    @Override
+    public boolean removeCopy() {
+        return false;
+    }
+
+    @Override
+    public String toString(@NonNull final SidecarType type) {
+        return "%s[INVALID]".formatted(type.name());
+    }
+}

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/stats/SidecarAccumulators.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/stats/SidecarAccumulators.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.node.app.service.mono.stats;
+
+import com.hedera.node.app.service.mono.utils.LongSampleAccumulator;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.Objects;
+
+/**
+ * Holds the accumulators for a single sidecar type's logging/metrics.
+ *
+ * <p>Keeps an accumulator for the serialized size (in bytes) of a sidecar type (over a consensus
+ * transaction), and an accumulator for the duration (in milliseconds) it took to
+ * compute/format/serialize the sidecar.
+ *
+ * <p>Has a separate accumulator for compute duration "splits" so multiple separate compute periods
+ * can be added together and become _one_ sample.
+ */
+public class SidecarAccumulators {
+
+    private final @NonNull LongSampleAccumulator serializedSize;
+    private final @NonNull LongSampleAccumulator computeDuration;
+    private final @NonNull LongSampleAccumulator durationSplit;
+
+    // duration is computed in ns, but displayed in ms
+    private static final long NANOS_TO_MILLIS = 1_000_000L;
+
+    /** Construct a metrics collector for a sidecar, given a name for it. */
+    public SidecarAccumulators(@NonNull final String name) {
+        Objects.requireNonNull(name, "name:String");
+        serializedSize = new LongSampleAccumulator(name + "SizeBytes");
+        computeDuration = new LongSampleAccumulator(name + "DurationMs", NANOS_TO_MILLIS);
+        durationSplit = new LongSampleAccumulator(name + "DurationSplitMs", NANOS_TO_MILLIS);
+    }
+
+    /**
+     * Finalize a duration measurement by adding all the splits together as one sample to the
+     * compute duration.
+     */
+    public void finalizeDurationSplits() {
+        durationSplit.coalesceSamples();
+        computeDuration.addSamples(durationSplit);
+        durationSplit.reset();
+    }
+
+    /** Reset the sidecar's metrics to zero samples. */
+    public void reset() {
+        serializedSize.reset();
+        computeDuration.reset();
+        durationSplit.reset();
+    }
+
+    @Override
+    public @NonNull String toString() {
+        return "SidecarAccumulators[serializedSize=%s, computeDuration=%s, durationSplit=%s]"
+                .formatted(serializedSize, computeDuration, durationSplit);
+    }
+
+    public @NonNull LongSampleAccumulator getSerializedSize() {
+        return serializedSize;
+    }
+
+    public @NonNull LongSampleAccumulator getComputeDuration() {
+        return computeDuration;
+    }
+
+    public @NonNull LongSampleAccumulator getDurationSplit() {
+        return durationSplit;
+    }
+}

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/stats/SidecarInstrumentation.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/stats/SidecarInstrumentation.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.node.app.service.mono.stats;
+
+import com.hedera.services.stream.proto.SidecarType;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.io.Closeable;
+import java.time.Duration;
+
+/**
+ * Holds the accumulators needed for the metrics/logging of a sidecar record (corresponding, most
+ * likely, to a record block. There's a separate accumulator for each kind of sidecar record
+ * (bytecode, state change, actions).
+ */
+public interface SidecarInstrumentation {
+
+    /**
+     * Add a sample of the serialized size of a sidecar transaction, for a particular kind of
+     * sidecar
+     */
+    void addSample(@NonNull final SidecarType type, long size);
+
+    /**
+     * Add a sample of the compute duration of a sidecar transaction, for a particular kind of
+     * sidecar
+     */
+    void addSample(@NonNull final SidecarType type, @NonNull final Duration duration);
+
+    /**
+     * Add a sample of both serialized size and compute time for a sidecar transaction, for a
+     * particular kind of sidecar
+     */
+    void addSample(@NonNull final SidecarType type, long size, @NonNull final Duration duration);
+
+    /**
+     * Add the entire accumulated values of a SidecarInstrumentation to this one (which is a summary
+     * of multiple records).  In use ensure that these roll-ups go only in one direction - from more
+     * specific accumulator to more general accumulator - and that will in turn ensure that there are
+     * no deadlock/livelock problems (when this method takes a lock so it can add all samples
+     * atomically.)
+     */
+    void addSamples(@NonNull final SidecarInstrumentation samples);
+
+    /**
+     * Start timing a split. Use the returned record in a try-with-resources that encloses the
+     * computation to be timed.
+     */
+    Closeable startTimer(@NonNull final SidecarType type);
+
+    /**
+     * Measure a duration split for a computation given by a `Runnable`, add that duration split as
+     * a sample.
+     */
+    void captureDurationSplit(@NonNull final SidecarType type, @NonNull final Runnable fn);
+
+    /** Just like a callable except _doesn't_ declare it throws a checked exception */
+    interface ExceptionFreeCallable<V> {
+        V call();
+    }
+
+    /**
+     * Measure a duration split for a computation given by a `Runnable`, add that duration split as
+     * a sample.
+     */
+    <V> V captureDurationSplit(@NonNull final SidecarType type, @NonNull final ExceptionFreeCallable<V> fn);
+
+    /**
+     * Finalize a duration measurement by adding all the splits, for one sidecar type, together as
+     * one sample to the compute duration.
+     */
+    void addDurationSplitsAsDurationSample(@NonNull final SidecarType type);
+
+    /* Reset all accumulators (all sidecar types) to zero samples */
+    void reset();
+
+    // Copy management: the same measurements are used for multiple sidecar transactions.  And
+    // they need to be passed across thread boundaries via a queue.  There's no way to know which
+    // is the last one for a given sidecar record, and no way to signal that across the queue.
+    // So a counter is incremented every time this measurement set is passed through the queue,
+    // and decremented when it is removed.  When the counter reaches zero it's time to log and
+    // report
+    // metrics.
+
+    /** Increment the copy counter when passing this across the record stream queue. */
+    void addCopy();
+
+    /**
+     * Decrement the copy counter when processing this after fetching it from the records stream
+     * queue. Returns `true` when this is the _last_ copy coming across the queue (it's time to log
+     * and issue metrics).
+     */
+    boolean removeCopy();
+
+    String toString(@NonNull final SidecarType type);
+
+    /**
+     * Create a _cheap_ (no heap!) do-nothing implementation for: 1. some uses where a
+     * instrumentation is required by a function signature but we don't need the metrics 2. some
+     * uses where you need to create a placeholder before a "real" one is created 3. all the tests
+     * where we aren't tracking metrics at all
+     */
+    @SuppressWarnings("java:S1186") // suppress warning about lots of empty method bodies: it's intentional
+    static SidecarInstrumentation createNoop() {
+        return new NoopSidecarInstrumentation();
+    }
+}

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/stats/SidecarInstrumentationImpl.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/stats/SidecarInstrumentationImpl.java
@@ -1,0 +1,252 @@
+/*
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.node.app.service.mono.stats;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.hedera.node.app.service.mono.exceptions.Requires;
+import com.hedera.services.stream.proto.SidecarType;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.time.Clock;
+import java.time.Duration;
+import java.util.EnumMap;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Holds the accumulators needed for the metrics/logging of a sidecar record (corresponding, most
+ * likely, to a record block. There's a separate accumulator for each kind of sidecar record
+ * (bytecode, state change, actions).
+ */
+public class SidecarInstrumentationImpl implements SidecarInstrumentation {
+
+    private final @NonNull EnumMap<SidecarType, SidecarAccumulators> accumulators;
+    private final @NonNull Clock clock;
+    private final @NonNull AtomicInteger copies;
+
+    private SidecarInstrumentationImpl(
+            final @NonNull EnumMap<SidecarType, SidecarAccumulators> accumulators,
+            final @NonNull Clock clock,
+            final @NonNull AtomicInteger copies) {
+        Requires.nonNull(accumulators, "accumulators:EnumMap<>", clock, "clock:Clock", copies, "copies:AtomicInteger");
+
+        this.accumulators = accumulators;
+        this.clock = clock;
+        this.copies = copies;
+    }
+
+    /** Constructs the sidecar instrumentation */
+    public SidecarInstrumentationImpl() {
+        this(new EnumMap<>(SidecarType.class), Clock.systemUTC(), new AtomicInteger());
+        createAccumulators();
+    }
+
+    /** Constructs the sidecar instrumentation, allowing the injection of a `Clock` (for testing) */
+    public SidecarInstrumentationImpl(@NonNull Clock clock) {
+        this(new EnumMap<>(SidecarType.class), clock, new AtomicInteger());
+        createAccumulators();
+    }
+
+    /** Create an accumulator for each kind of sidecar record */
+    private void createAccumulators() {
+        for (final var e : SidecarType.values()) accumulators.put(e, new SidecarAccumulators(e.name()));
+    }
+
+    /**
+     * Add a sample of the serialized size of a sidecar transaction, for a particular kind of
+     * sidecar
+     */
+    @Override
+    public void addSample(@NonNull final SidecarType type, long size) {
+        Objects.requireNonNull(type, "type:SidecarType");
+        final var acc = accumulators.get(type);
+        acc.getSerializedSize().addSample(size);
+    }
+
+    /**
+     * Add a sample of the compute duration of a sidecar transaction, for a particular kind of
+     * sidecar
+     */
+    @Override
+    public void addSample(@NonNull final SidecarType type, @NonNull final Duration duration) {
+        Requires.nonNull(type, "type:SidecarType", duration, "duration:Duration");
+
+        final var acc = accumulators.get(type);
+        acc.getComputeDuration().addSample(duration.toNanos());
+    }
+
+    /**
+     * Add a sample of both serialized size and compute time for a sidecar transaction, for a
+     * particular kind of sidecar
+     */
+    @Override
+    public void addSample(@NonNull final SidecarType type, long size, @NonNull final Duration duration) {
+        Requires.nonNull(type, "type:SidecarType", duration, "duration:Duration");
+
+        final var acc = accumulators.get(type);
+        acc.getSerializedSize().addSample(size);
+        acc.getComputeDuration().addSample(duration.toNanos());
+    }
+
+    /**
+     * Add the entire accumulated values of a SidecarInstrumentation to this one (which is a summary
+     * of multiple records
+     */
+    @SuppressWarnings("java:S2445")
+    // sync on method parameter _OK_ because adding samples goes only in _one_ direction ever (from
+    // more specific accumulator to more general accumulator)
+    @Override
+    public void addSamples(@NonNull final SidecarInstrumentation samples) {
+        Objects.requireNonNull(samples, "samples:SidecarInstrumentation");
+
+        if (samples instanceof SidecarInstrumentationImpl impl) {
+            final var syncObjs = orderByHashcode(this, samples);
+            synchronized (syncObjs[0]) {
+                synchronized (syncObjs[1]) {
+                    for (final var e : SidecarType.values()) {
+                        final var thisAcc = accumulators.get(e);
+                        final var thatAcc = impl.accumulators.get(e);
+                        thisAcc.getComputeDuration().addSamples(thatAcc.getComputeDuration());
+                        thisAcc.getSerializedSize().addSamples(thatAcc.getSerializedSize());
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Start timing a split. Use the returned value in a try-with-resources that encloses the
+     * computation to be timed.
+     */
+    @Override
+    public Closeable startTimer(@NonNull final SidecarType type) {
+        Objects.requireNonNull(type, "type:SidecarType");
+        final var start = clock.instant();
+        return () -> {
+            final var now = clock.instant();
+            final var interval = Duration.between(start, now);
+            accumulators.get(type).getDurationSplit().addSample(interval.toNanos());
+        };
+    }
+
+    /**
+     * Measure a duration split for a computation given by a `Runnable`, add that duration split as
+     * a sample.
+     */
+    @Override
+    public void captureDurationSplit(@NonNull final SidecarType type, @NonNull final Runnable fn) {
+        Requires.nonNull(type, "type:SidecarType", fn, "fn:Runnable");
+
+        try (final var timer = startTimer(type)) {
+            fn.run();
+        } catch (IOException ex) { // because Closeable
+            throw new UncheckedIOException(ex);
+        }
+    }
+
+    /**
+     * Measure a duration split for a computation given by a `Runnable`, add that duration split as
+     * a sample.
+     */
+    @Override
+    public <V> V captureDurationSplit(@NonNull final SidecarType type, @NonNull final ExceptionFreeCallable<V> fn) {
+        Requires.nonNull(type, "type:SidecarType", fn, "fn:ExceptionFreeCallable");
+
+        try (final var timer = startTimer(type)) {
+            return fn.call();
+        } catch (IOException ex) { // because Closeable
+            throw new UncheckedIOException(ex);
+        }
+    }
+
+    /**
+     * Finalize a duration measurement by adding all the splits, for one sidecar type, together as
+     * one sample to the compute duration.
+     */
+    @Override
+    public void addDurationSplitsAsDurationSample(@NonNull final SidecarType type) {
+        Objects.requireNonNull(type, "type:SidecarType");
+        accumulators.get(type).finalizeDurationSplits();
+    }
+
+    /* Reset all accumulators (all sidecar types) to zero samples */
+    @Override
+    public void reset() {
+        for (final var a : accumulators.values()) a.reset();
+    }
+
+    // Copy management: the same measurements are used for multiple sidecar transactions.  And
+    // they need to be passed across thread boundaries via a queue.  There's no way to know which
+    // is the last one for a given sidecar record, and no way to signal that across the queue.
+    // So a counter is incremented every time this measurement set is passed through the queue,
+    // and decremented when it is removed.  When the counter reaches zero it's time to log and
+    // report
+    // metrics.
+
+    /** Increment the copy counter when passing this across the record stream queue. */
+    @Override
+    public void addCopy() {
+        copies.incrementAndGet();
+    }
+
+    /**
+     * Decrement the copy counter when processing this after fetching it from the records stream
+     * queue. Returns `true` when this is the _last_ copy coming across the queue (it's time to log
+     * and issue metrics).
+     */
+    @Override
+    public boolean removeCopy() {
+        return 0 == copies.decrementAndGet();
+    }
+
+    @VisibleForTesting
+    int getCopies() {
+        return copies.get();
+    }
+
+    @Override
+    public String toString(@NonNull final SidecarType type) {
+        Objects.requireNonNull(type, "type:SidecarType");
+        return accumulators.get(type).toString();
+    }
+
+    /** Order two objects based on their hashCode (why? so you can synchronize _in order_ to avoid deadlock) */
+    private static Object[] orderByHashcode(final @NonNull Object a, final @NonNull Object b) {
+        Requires.nonNull(a, "a:Object", b, "b:Object");
+
+        if (a == b) throw new IllegalArgumentException("arguments are not distinct objects");
+
+        final int hca = System.identityHashCode(a);
+        final int hcb = System.identityHashCode(b);
+        if (hca < hcb) return new Object[] {a, b};
+        else return new Object[] {b, a};
+
+        // Depends on JVM trying really very hard to not return colliding hashcodes for distinct objects
+    }
+
+    @VisibleForTesting
+    static Object[] testOrderByHashcode(final @NonNull Object a, final @NonNull Object b) {
+        return orderByHashcode(a, b);
+    }
+
+    @VisibleForTesting
+    Clock getClock() {
+        return clock;
+    }
+}

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/utils/LongSampleAccumulator.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/utils/LongSampleAccumulator.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.node.app.service.mono.utils;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.Objects;
+
+/**
+ * A statistics "counter" that collects (reduces) `Long` samples, keeping track of the number of
+ * samples, the total accumulated, and the maximum seen.
+ */
+public final class LongSampleAccumulator {
+
+    /** (Base) name for this accumulator */
+    private final String name;
+
+    /**
+     * Scaling factor for this accumulator (used for changing units, e.g., accumulate nanosec but
+     * return millisec
+     */
+    private final long denominator;
+
+    // For the current use case concurrent updates to counters are not needed.  But provided anyway
+    // via synchronized blocks - which should be very cheap in the case of no contention, which is
+    // what is expected.  (Not using atomics because there are multiple values to be updated
+    // together.)
+
+    private int nSamples;
+    private long total;
+    private long maximum;
+
+    /** Construct an accumulator, providing its name and its scaling factor. */
+    public LongSampleAccumulator(@NonNull final String name, long denominator) {
+        Objects.requireNonNull(name, "name:String");
+        if (0 == denominator) throw new IllegalArgumentException("denominator (scale factor) must be > 0");
+
+        this.name = name;
+        this.denominator = denominator;
+        reset();
+    }
+
+    /**
+     * Construct an accumulator, providing its name (direct accumulator: scaling factor is unity)
+     */
+    public LongSampleAccumulator(@NonNull final String name) {
+        this(name, 1L);
+    }
+
+    /** Reset accumulator to zero (no samples). */
+    public void reset() {
+        synchronized (this) {
+            nSamples = 0;
+            total = 0L;
+            maximum = Long.MIN_VALUE;
+        }
+    }
+
+    /** Add a single sample to the accumulator */
+    public void addSample(long sample) {
+        synchronized (this) {
+            nSamples++;
+            total += sample;
+            maximum = Long.max(maximum, sample);
+        }
+    }
+
+    /** Add _all_ the samples of another accumulator into this one */
+    public void addSamples(@NonNull final LongSampleAccumulator samples) {
+        Objects.requireNonNull(samples, "samples:LongSampleAccumulator");
+        final var values = samples.getAccumulatedValues();
+        if (denominator != values.denominator)
+            throw new IllegalArgumentException("must have same denominator when adding accumulators");
+        synchronized (this) {
+            nSamples += values.nSamples();
+            total += values.total();
+            maximum = Long.max(maximum, values.maximum());
+        }
+    }
+
+    /**
+     * Coalesce all samples taken in this accumulator as if they were all just one measurement.
+     *
+     * <p>Useful when measuring a duration over several periods. Sum of _all_ durations should be
+     * treated as one measurement.
+     */
+    public void coalesceSamples() {
+        synchronized (this) {
+            nSamples = 1;
+            maximum = total;
+        }
+    }
+
+    /** Unscaled values of an accumulator */
+    public record LongSampleAccumulatedValues(
+            @NonNull String name, int nSamples, long total, long maximum, long denominator) {}
+
+    /** Return _unscaled_ values of this accumulator (count, total, and maximum) */
+    public @NonNull LongSampleAccumulatedValues getAccumulatedValues() {
+        synchronized (this) {
+            return new LongSampleAccumulatedValues(name, nSamples, total, maximum, denominator);
+        }
+    }
+
+    /* Scaled values of an accumulator */
+    public record DoubleSampleAccumulatedValues(@NonNull String name, int nSamples, double total, double maximum) {}
+
+    /**
+     * Return _scaled_ values of this accumulator (count, total, and maximum, the latter two divided
+     * by the denominator (scale factor))
+     */
+    public @NonNull DoubleSampleAccumulatedValues getScaledAccumulatedValues() {
+        final var values = getAccumulatedValues();
+        return new DoubleSampleAccumulatedValues(
+                values.name(),
+                values.nSamples(),
+                (double) values.total() / (double) values.denominator(),
+                values.maximum() != Long.MIN_VALUE
+                        ? (double) values.maximum / (double) values.denominator()
+                        : -Double.MAX_VALUE);
+    }
+
+    public @NonNull String toString() {
+        final var values = getAccumulatedValues();
+        final String maxIt = "\uD835\uDC5A\uD835\uDC4E\uD835\uDC65"; // "𝑚𝑎𝑥"
+        return "%s[#%d, ∑%d, %s %s, ÷%d]"
+                .formatted(
+                        values.name(),
+                        values.nSamples(),
+                        values.total(),
+                        maxIt,
+                        values.maximum() != Long.MIN_VALUE ? Long.toString(values.maximum()) : "MINIMUM",
+                        values.denominator());
+    }
+}

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/contracts/execution/CallEvmTxProcessorTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/contracts/execution/CallEvmTxProcessorTest.java
@@ -40,6 +40,7 @@ import static org.mockito.Mockito.when;
 import static org.mockito.internal.verification.VerificationModeFactory.times;
 
 import com.hedera.node.app.service.evm.contracts.execution.HederaBlockValues;
+import com.hedera.node.app.service.evm.contracts.execution.traceability.DefaultHederaTracer;
 import com.hedera.node.app.service.evm.exceptions.InvalidTransactionException;
 import com.hedera.node.app.service.mono.context.properties.GlobalDynamicProperties;
 import com.hedera.node.app.service.mono.contracts.execution.traceability.ContractActionType;
@@ -50,6 +51,7 @@ import com.hedera.node.app.service.mono.ledger.TransactionalLedger;
 import com.hedera.node.app.service.mono.ledger.accounts.AliasManager;
 import com.hedera.node.app.service.mono.ledger.properties.AccountProperty;
 import com.hedera.node.app.service.mono.state.migration.HederaAccount;
+import com.hedera.node.app.service.mono.stats.SidecarInstrumentation;
 import com.hedera.node.app.service.mono.store.contracts.CodeCache;
 import com.hedera.node.app.service.mono.store.contracts.HederaStackedWorldStateUpdater;
 import com.hedera.node.app.service.mono.store.contracts.HederaWorldState;
@@ -201,6 +203,7 @@ class CallEvmTxProcessorTest {
                 ccps,
                 aliasManager,
                 blockMetaSource);
+        callEvmTxProcessor.setOperationTracer(new DefaultHederaTracer());
     }
 
     @Test
@@ -433,6 +436,7 @@ class CallEvmTxProcessorTest {
                     doCallRealMethod()
                             .when(mock)
                             .tracePostExecution(any(MessageFrame.class), any(OperationResult.class));
+                    doReturn(SidecarInstrumentation.createNoop()).when(mock).getInstrumentation();
                     doReturn(List.of(action, action2)).when(mock).getActions();
                 })) {
 
@@ -669,6 +673,7 @@ class CallEvmTxProcessorTest {
                 ccps,
                 aliasManager,
                 blockMetaSource);
+        callEvmTxProcessor.setOperationTracer(new DefaultHederaTracer());
         given(worldState.updater()).willReturn(updater);
         given(updater.updater()).willReturn(stackedUpdater);
         given(globalDynamicProperties.fundingAccountAddress()).willReturn(new Id(0, 0, 1010).asEvmAddress());

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/contracts/execution/CallLocalEvmTxProcessorTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/contracts/execution/CallLocalEvmTxProcessorTest.java
@@ -32,6 +32,7 @@ import static org.mockito.Mockito.when;
 
 import com.hedera.node.app.service.evm.contracts.execution.BlockMetaSource;
 import com.hedera.node.app.service.evm.contracts.execution.HederaBlockValues;
+import com.hedera.node.app.service.evm.contracts.execution.traceability.DefaultHederaTracer;
 import com.hedera.node.app.service.mono.context.properties.GlobalDynamicProperties;
 import com.hedera.node.app.service.mono.ledger.accounts.AliasManager;
 import com.hedera.node.app.service.mono.store.contracts.CodeCache;
@@ -138,6 +139,7 @@ class CallLocalEvmTxProcessorTest {
 
         callLocalEvmTxProcessor.setWorldState(worldState);
         callLocalEvmTxProcessor.setBlockMetaSource(blockMetaSource);
+        callLocalEvmTxProcessor.setOperationTracer(new DefaultHederaTracer());
     }
 
     @Test

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/contracts/execution/CallLocalExecutorTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/contracts/execution/CallLocalExecutorTest.java
@@ -33,6 +33,7 @@ import com.hedera.node.app.hapi.utils.builder.RequestBuilder;
 import com.hedera.node.app.service.evm.contracts.operations.HederaExceptionalHaltReason;
 import com.hedera.node.app.service.evm.exceptions.InvalidTransactionException;
 import com.hedera.node.app.service.mono.ledger.accounts.AliasManager;
+import com.hedera.node.app.service.mono.stats.SidecarInstrumentation;
 import com.hedera.node.app.service.mono.store.AccountStore;
 import com.hedera.node.app.service.mono.store.contracts.EntityAccess;
 import com.hedera.node.app.service.mono.store.models.Account;
@@ -97,7 +98,15 @@ class CallLocalExecutorTest {
         given(aliasManager.lookupIdBy(target.getEvmAddress())).willReturn(EntityNum.fromLong(contractID.num()));
 
         final var transactionProcessingResult = TransactionProcessingResult.successful(
-                new ArrayList<>(), 0, 0, 1, Bytes.EMPTY, callerID.asEvmAddress(), new TreeMap<>(), new ArrayList<>());
+                new ArrayList<>(),
+                0,
+                0,
+                1,
+                Bytes.EMPTY,
+                callerID.asEvmAddress(),
+                new TreeMap<>(),
+                new ArrayList<>(),
+                SidecarInstrumentation.createNoop());
         final var expected = response(OK, transactionProcessingResult);
 
         given(accountStore.loadAccount(any())).willReturn(new Account(callerID));
@@ -123,7 +132,15 @@ class CallLocalExecutorTest {
         given(aliasManager.lookupIdBy(sender.getAlias())).willReturn(EntityNum.fromLong(senderID.num()));
 
         final var transactionProcessingResult = TransactionProcessingResult.successful(
-                new ArrayList<>(), 0, 0, 1, Bytes.EMPTY, callerID.asEvmAddress(), new TreeMap<>(), new ArrayList<>());
+                new ArrayList<>(),
+                0,
+                0,
+                1,
+                Bytes.EMPTY,
+                callerID.asEvmAddress(),
+                new TreeMap<>(),
+                new ArrayList<>(),
+                SidecarInstrumentation.createNoop());
         final var expected = response(OK, transactionProcessingResult);
 
         given(accountStore.loadAccount(any())).willReturn(new Account(callerID));
@@ -149,7 +166,8 @@ class CallLocalExecutorTest {
                 Bytes.EMPTY,
                 callerID.asEvmAddress(),
                 Collections.emptyMap(),
-                new ArrayList<>());
+                new ArrayList<>(),
+                SidecarInstrumentation.createNoop());
         final var expected = response(OK, transactionProcessingResult);
 
         given(accountStore.loadAccount(any())).willReturn(new Account(callerID));
@@ -175,7 +193,8 @@ class CallLocalExecutorTest {
                 Bytes.EMPTY,
                 callerID.asEvmAddress(),
                 Collections.emptyMap(),
-                new ArrayList<>());
+                new ArrayList<>(),
+                SidecarInstrumentation.createNoop());
         final var expected = response(OK, transactionProcessingResult);
 
         given(entityAccess.isTokenAccount(any())).willReturn(true);
@@ -199,7 +218,8 @@ class CallLocalExecutorTest {
                 Optional.empty(),
                 Optional.of(ExceptionalHaltReason.ILLEGAL_STATE_CHANGE),
                 Collections.emptyMap(),
-                Collections.emptyList());
+                Collections.emptyList(),
+                SidecarInstrumentation.createNoop());
         final var expected = response(LOCAL_CALL_MODIFICATION_EXCEPTION, transactionProcessingResult);
 
         given(accountStore.loadAccount(any())).willReturn(new Account(callerID));
@@ -224,7 +244,8 @@ class CallLocalExecutorTest {
                 Optional.empty(),
                 Optional.of(HederaExceptionalHaltReason.INVALID_SOLIDITY_ADDRESS),
                 Collections.emptyMap(),
-                Collections.emptyList());
+                Collections.emptyList(),
+                SidecarInstrumentation.createNoop());
         final var expected = response(INVALID_SOLIDITY_ADDRESS, transactionProcessingResult);
 
         given(accountStore.loadAccount(any())).willReturn(new Account(callerID));
@@ -249,7 +270,8 @@ class CallLocalExecutorTest {
                 Optional.of(Bytes.of("out of gas".getBytes())),
                 Optional.empty(),
                 Collections.emptyMap(),
-                Collections.emptyList());
+                Collections.emptyList(),
+                SidecarInstrumentation.createNoop());
         final var expected = response(CONTRACT_REVERT_EXECUTED, transactionProcessingResult);
 
         given(accountStore.loadAccount(any())).willReturn(new Account(callerID));

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/contracts/execution/CreateEvmTxProcessorTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/contracts/execution/CreateEvmTxProcessorTest.java
@@ -31,6 +31,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.hedera.node.app.service.evm.contracts.execution.HederaBlockValues;
+import com.hedera.node.app.service.evm.contracts.execution.traceability.DefaultHederaTracer;
 import com.hedera.node.app.service.mono.context.properties.GlobalDynamicProperties;
 import com.hedera.node.app.service.mono.ledger.accounts.AliasManager;
 import com.hedera.node.app.service.mono.store.contracts.CodeCache;
@@ -147,6 +148,7 @@ class CreateEvmTxProcessorTest {
                 ccps,
                 aliasManager,
                 blockMetaSource);
+        createEvmTxProcessor.setOperationTracer(new DefaultHederaTracer());
     }
 
     @Test

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/exceptions/RequiresTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/exceptions/RequiresTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.node.app.service.mono.exceptions;
+
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+
+import org.junit.jupiter.api.Test;
+
+class RequiresTest {
+    @Test
+    void NonNullTest() {
+        {
+            // trivial case
+            Requires.nonNull();
+        }
+
+        {
+            // Success cases
+            Requires.nonNull("foo", "foo");
+            Requires.nonNull("bar", "bar", "bar", "bar");
+            Requires.nonNull("bear", "bear", "bear", "bear", "bear", "bear");
+        }
+
+        {
+            // Null args detected cases
+            assertThatExceptionOfType(Requires.NullArgumentsException.class)
+                    .isThrownBy(() -> {
+                        Requires.nonNull(null, "argument-1");
+                    })
+                    .withMessage("null argument found: argument-1");
+            assertThatExceptionOfType(Requires.NullArgumentsException.class)
+                    .isThrownBy(() -> {
+                        Requires.nonNull(this, "argument-1", null, "argument-2");
+                    })
+                    .withMessage("null argument found: argument-2");
+            assertThatExceptionOfType(Requires.NullArgumentsException.class)
+                    .isThrownBy(() -> {
+                        Requires.nonNull(null, "argument-1", null, "argument-2");
+                    })
+                    .withMessage("null arguments found: argument-1, argument-2");
+            assertThatExceptionOfType(Requires.NullArgumentsException.class)
+                    .isThrownBy(() -> {
+                        Requires.nonNull(null, "argument-1", this, "argument-2", null, "argument-3");
+                    })
+                    .withMessage("null arguments found: argument-1, argument-3");
+        }
+
+        {
+            // Bad #args
+            assertThatIllegalArgumentException().isThrownBy(() -> {
+                Requires.nonNull("foo");
+            });
+            assertThatIllegalArgumentException().isThrownBy(() -> {
+                Requires.nonNull("foo", "foo", "foo", "foo", "foo");
+            });
+        }
+
+        {
+            // Null arg but also null name
+            assertThatIllegalArgumentException().isThrownBy(() -> {
+                Requires.nonNull(null, null);
+            });
+        }
+    }
+}

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/contract/queries/ContractCallLocalResourceUsageTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/contract/queries/ContractCallLocalResourceUsageTest.java
@@ -44,6 +44,7 @@ import com.hedera.node.app.service.mono.contracts.execution.TransactionProcessin
 import com.hedera.node.app.service.mono.ledger.accounts.AliasManager;
 import com.hedera.node.app.service.mono.ledger.ids.EntityIdSource;
 import com.hedera.node.app.service.mono.queries.contract.ContractCallLocalAnswer;
+import com.hedera.node.app.service.mono.stats.SidecarInstrumentation;
 import com.hedera.node.app.service.mono.store.AccountStore;
 import com.hedera.node.app.service.mono.store.models.Account;
 import com.hedera.node.app.service.mono.store.models.Id;
@@ -156,7 +157,8 @@ class ContractCallLocalResourceUsageTest {
                 Bytes.EMPTY,
                 callerID.asEvmAddress(),
                 Collections.emptyMap(),
-                Collections.emptyList());
+                Collections.emptyList(),
+                SidecarInstrumentation.createNoop());
         final var response = okResponse(transactionProcessingResult);
         final var estimateResponse = subject.dummyResponse(target);
         final var expected = expectedUsage();

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/queries/contract/ContractCallLocalAnswerTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/queries/contract/ContractCallLocalAnswerTest.java
@@ -52,6 +52,7 @@ import com.hedera.node.app.service.mono.ledger.ids.EntityIdSource;
 import com.hedera.node.app.service.mono.state.adapters.MerkleMapLike;
 import com.hedera.node.app.service.mono.state.merkle.MerkleAccount;
 import com.hedera.node.app.service.mono.state.migration.AccountStorageAdapter;
+import com.hedera.node.app.service.mono.stats.SidecarInstrumentation;
 import com.hedera.node.app.service.mono.store.AccountStore;
 import com.hedera.node.app.service.mono.store.contracts.EntityAccess;
 import com.hedera.node.app.service.mono.store.models.Account;
@@ -278,10 +279,15 @@ class ContractCallLocalAnswerTest {
     void getsCallResponseWhenNoBlockMetaAvailable() throws Throwable {
         // setup:
         final Query sensibleQuery = validQuery(ANSWER_ONLY, 5L);
-
         final var transactionProcessingResult = TransactionProcessingResult.failed(
-                0, 0, 1, Optional.empty(), Optional.empty(), new TreeMap<>(), new ArrayList<>());
-
+                0,
+                0,
+                1,
+                Optional.empty(),
+                Optional.empty(),
+                new TreeMap<>(),
+                new ArrayList<>(),
+                SidecarInstrumentation.createNoop());
         final Response response = subject.responseGiven(sensibleQuery, view, OK, 0L);
 
         // then:
@@ -294,9 +300,15 @@ class ContractCallLocalAnswerTest {
     void getsCallResponseWhenNoCtx() throws Throwable {
         // setup:
         final Query sensibleQuery = validQuery(ANSWER_ONLY, 5L);
-
         final var transactionProcessingResult = TransactionProcessingResult.failed(
-                0, 0, 1, Optional.empty(), Optional.empty(), new TreeMap<>(), new ArrayList<>());
+                0,
+                0,
+                1,
+                Optional.empty(),
+                Optional.empty(),
+                new TreeMap<>(),
+                new ArrayList<>(),
+                SidecarInstrumentation.createNoop());
 
         given(accountStore.loadAccount(any())).willReturn(new Account(Id.fromGrpcContract(target)));
         given(accountStore.loadContract(any())).willReturn(new Account(Id.fromGrpcContract(target)));

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/records/TransactionRecordServiceTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/records/TransactionRecordServiceTest.java
@@ -41,6 +41,7 @@ import com.hedera.node.app.service.mono.contracts.execution.traceability.Contrac
 import com.hedera.node.app.service.mono.contracts.execution.traceability.SolidityAction;
 import com.hedera.node.app.service.mono.state.submerkle.EntityId;
 import com.hedera.node.app.service.mono.state.submerkle.EvmFnResult;
+import com.hedera.node.app.service.mono.stats.SidecarInstrumentation;
 import com.hedera.node.app.service.mono.store.models.Id;
 import com.hedera.node.app.service.mono.store.models.Topic;
 import com.hedera.node.app.service.mono.utils.EntityNum;
@@ -75,6 +76,7 @@ class TransactionRecordServiceTest {
     private static final Map<Address, Map<Bytes, Pair<Bytes, Bytes>>> stateChanges = new TreeMap<>(
             Map.of(Address.fromHexString("0x9"), Map.of(Bytes.of(10), Pair.of(Bytes.of(11), Bytes.of(12)))));
     private static final List<SolidityAction> actions = List.of(createAction(OP_CALL), createAction(OP_CREATE2));
+    private static final SidecarInstrumentation sidecarInstrumentationNoop = SidecarInstrumentation.createNoop();
 
     @Mock
     private TransactionContext txnCtx;
@@ -106,6 +108,7 @@ class TransactionRecordServiceTest {
         given(processingResult.getGasUsed()).willReturn(GAS_USED);
         given(processingResult.getRecipient()).willReturn(recipient);
         given(processingResult.getOutput()).willReturn(Bytes.fromHexStringLenient("0xabcd"));
+        given(processingResult.getSidecarInstrumentation()).willReturn(sidecarInstrumentationNoop);
         // when:
         subject.externalizeSuccessfulEvmCreate(processingResult, mockAddr);
         // then:
@@ -130,6 +133,7 @@ class TransactionRecordServiceTest {
         given(processingResult.getOutput()).willReturn(Bytes.fromHexStringLenient("0xabcd"));
         given(processingResult.getStateChanges()).willReturn(stateChanges);
         given(processingResult.getActions()).willReturn(actions);
+        given(processingResult.getSidecarInstrumentation()).willReturn(sidecarInstrumentationNoop);
         final var contractBytecodeSidecar = SidecarUtils.createContractBytecodeSidecarFrom(
                 IdUtils.asContract("0.0.5"), "initCode".getBytes(), "runtimeCode".getBytes());
 
@@ -162,6 +166,7 @@ class TransactionRecordServiceTest {
         given(processingResult.getOutput()).willReturn(Bytes.fromHexStringLenient("0xabcd"));
         given(processingResult.getStateChanges()).willReturn(stateChanges);
         given(processingResult.getActions()).willReturn(actions);
+        given(processingResult.getSidecarInstrumentation()).willReturn(sidecarInstrumentationNoop);
         final var contextCaptor = ArgumentCaptor.forClass(TransactionSidecarRecord.Builder.class);
 
         // when:
@@ -190,6 +195,7 @@ class TransactionRecordServiceTest {
         given(processingResult.getOutput()).willReturn(Bytes.fromHexStringLenient("0xabcd"));
         given(processingResult.getStateChanges()).willReturn(Collections.emptyMap());
         given(processingResult.getActions()).willReturn(Collections.emptyList());
+        given(processingResult.getSidecarInstrumentation()).willReturn(sidecarInstrumentationNoop);
 
         // when:
         subject.externaliseEvmCallTransaction(processingResult);
@@ -206,6 +212,7 @@ class TransactionRecordServiceTest {
         final var contextCaptor = ArgumentCaptor.forClass(TransactionSidecarRecord.Builder.class);
         givenProcessingResult(false, null);
         given(processingResult.getStateChanges()).willReturn(stateChanges);
+        given(processingResult.getSidecarInstrumentation()).willReturn(sidecarInstrumentationNoop);
         final var contractBytecodeSidecar = SidecarUtils.createContractBytecodeSidecarFrom(
                 IdUtils.asContract("0.0.5"), "initCode".getBytes(), "runtimeCode".getBytes());
         // when:
@@ -229,6 +236,7 @@ class TransactionRecordServiceTest {
         final var contextCaptor = ArgumentCaptor.forClass(TransactionSidecarRecord.Builder.class);
         givenProcessingResult(false, null);
         given(processingResult.getStateChanges()).willReturn(stateChanges);
+        given(processingResult.getSidecarInstrumentation()).willReturn(sidecarInstrumentationNoop);
         // when
         subject.externalizeUnsuccessfulEvmCreate(processingResult, null);
         // then:
@@ -247,6 +255,7 @@ class TransactionRecordServiceTest {
     void externalisesEvmCreateTransactionWithContractRevert() {
         // given:
         givenProcessingResult(false, null);
+        given(processingResult.getSidecarInstrumentation()).willReturn(sidecarInstrumentationNoop);
         // when:
         subject.externalizeUnsuccessfulEvmCreate(processingResult);
         // then:
@@ -260,6 +269,7 @@ class TransactionRecordServiceTest {
     void externalisesEvmCreateTransactionWithSelfDestruct() {
         // given:
         givenProcessingResult(false, SELF_DESTRUCT_TO_SELF);
+        given(processingResult.getSidecarInstrumentation()).willReturn(sidecarInstrumentationNoop);
         // when:
         subject.externalizeUnsuccessfulEvmCreate(processingResult);
         // then:
@@ -272,6 +282,7 @@ class TransactionRecordServiceTest {
     void externalisesEvmCreateTransactionWithInvalidSolidityAddress() {
         // given:
         givenProcessingResult(false, INVALID_SOLIDITY_ADDRESS);
+        given(processingResult.getSidecarInstrumentation()).willReturn(sidecarInstrumentationNoop);
         // when:
         subject.externalizeUnsuccessfulEvmCreate(processingResult);
         // then:
@@ -284,6 +295,7 @@ class TransactionRecordServiceTest {
     void externalisesEvmCreateTransactionWithInvalidSignature() {
         // given:
         givenProcessingResult(false, INVALID_SIGNATURE);
+        given(processingResult.getSidecarInstrumentation()).willReturn(sidecarInstrumentationNoop);
         // when:
         subject.externalizeUnsuccessfulEvmCreate(processingResult);
         // then:

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/submerkle/EvmFnResultTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/submerkle/EvmFnResultTest.java
@@ -29,6 +29,7 @@ import com.google.protobuf.BytesValue;
 import com.hedera.node.app.hapi.utils.ethereum.EthTxData;
 import com.hedera.node.app.service.mono.contracts.execution.HederaMessageCallProcessor;
 import com.hedera.node.app.service.mono.contracts.execution.TransactionProcessingResult;
+import com.hedera.node.app.service.mono.stats.SidecarInstrumentation;
 import com.hedera.node.app.service.mono.utils.EntityNum;
 import com.hederahashgraph.api.proto.java.ContractFunctionResult;
 import com.hederahashgraph.api.proto.java.ContractID;
@@ -132,7 +133,8 @@ class EvmFnResultTest {
                 Optional.of(HederaMessageCallProcessor.INVALID_TRANSFER),
                 Optional.empty(),
                 Collections.emptyMap(),
-                Collections.emptyList());
+                Collections.emptyList(),
+                SidecarInstrumentation.createNoop());
 
         final var actual = EvmFnResult.fromCall(input);
 
@@ -163,7 +165,8 @@ class EvmFnResultTest {
                 Bytes.wrap(result),
                 recipient,
                 Collections.emptyMap(),
-                Collections.emptyList());
+                Collections.emptyList(),
+                SidecarInstrumentation.createNoop());
         input.setCreatedContracts(grpcCreatedContractIds);
 
         final var actual = EvmFnResult.fromCall(input);
@@ -204,7 +207,8 @@ class EvmFnResultTest {
                 Bytes.wrap(result),
                 recipient,
                 Collections.emptyMap(),
-                Collections.emptyList());
+                Collections.emptyList(),
+                SidecarInstrumentation.createNoop());
         input.setCreatedContracts(grpcCreatedContractIds);
 
         final var actual = EvmFnResult.fromCreate(input, evmAddress);

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/stats/LongSampleAccumulatorTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/stats/LongSampleAccumulatorTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.node.app.service.mono.stats;
+
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.hedera.node.app.service.mono.utils.LongSampleAccumulator;
+import org.junit.jupiter.api.Test;
+
+class LongSampleAccumulatorTest {
+
+    @Test
+    void addSamplesComplainsOfDifferentDenominatorsTest() {
+
+        final var src = new LongSampleAccumulator("Foo", 100);
+        final var sut = new LongSampleAccumulator("Bar", 250);
+
+        assertThatIllegalArgumentException().isThrownBy(() -> {
+            sut.addSamples(src);
+        });
+    }
+
+    @Test
+    void coalesceSamplesTest() {
+
+        final var sut = new LongSampleAccumulator("Zed", 1);
+        sut.addSample(1);
+        sut.addSample(10);
+        sut.addSample(100);
+
+        final String expectedBefore = """
+                Zed[#3, ∑111, 𝑚𝑎𝑥 100, ÷1]\
+                """;
+        assertEquals(expectedBefore, sut.toString());
+
+        sut.coalesceSamples();
+
+        final String expectedAfter = """
+                Zed[#1, ∑111, 𝑚𝑎𝑥 111, ÷1]\
+                """;
+        assertEquals(expectedAfter, sut.toString());
+    }
+}

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/stats/SidecarInstrumentationImplTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/stats/SidecarInstrumentationImplTest.java
@@ -1,0 +1,375 @@
+/*
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.node.app.service.mono.stats;
+
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertLinesMatch;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.hedera.services.stream.proto.SidecarType;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.time.Clock;
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Test;
+
+class SidecarInstrumentationImplTest {
+
+    static final Long M = Long.MIN_VALUE;
+
+    // Match `LongSampleAccumulator.toString()`
+    @NonNull
+    static String expectedAccumulator(
+            @NonNull String name,
+            @NonNull String type,
+            @NonNull String units,
+            int n,
+            long total,
+            long max,
+            long denom) {
+        final String expectedFormat = """
+                %s=%s%s[#%d, ∑%d, 𝑚𝑎𝑥 %s, ÷%d]\
+                """;
+        final var maxs = max == Long.MIN_VALUE ? "MINIMUM" : Long.toString(max, 10);
+        return expectedFormat.formatted(name, type, units, n, total, maxs, denom);
+    }
+
+    // Match `SidecarAccumulators.toString()`
+    @NonNull
+    static String expectedAccumulators(
+            @NonNull String type,
+            int nss, // quad for "serializedSize" == "ss"
+            long tss,
+            long mss,
+            long dss,
+            int ncd, // quad for "computeDuration" == "cd"
+            long tcd,
+            long mcd,
+            long dcd,
+            int nds, // quad for "durationSplit" == "ds"
+            long tds,
+            long mds,
+            long dds) {
+        final var ss = expectedAccumulator("serializedSize", type, "SizeBytes", nss, tss, mss, dss);
+        final var cd = expectedAccumulator("computeDuration", type, "DurationMs", ncd, tcd, mcd, dcd);
+        final var ds = expectedAccumulator("durationSplit", type, "DurationSplitMs", nds, tds, mds, dds);
+        return "SidecarAccumulators[%s, %s, %s]".formatted(ss, cd, ds);
+    }
+
+    // limited escaping for regexp just suited for our needs here - left only brackets need to be quoted
+    @NonNull
+    static String escapeForRegexp(@NonNull String re) {
+        return re.replace("[", "\\[");
+    }
+
+    @Test
+    void constructorPassingInClockTest() {
+        final Clock clock = Clock.offset(Clock.systemDefaultZone(), Duration.ofHours(1));
+        final SidecarInstrumentationImpl sut = new SidecarInstrumentationImpl(clock);
+        assertEquals(clock, sut.getClock());
+    }
+
+    @Test
+    void addSampleSizeTest() {
+
+        final SidecarInstrumentation sut = new SidecarInstrumentationImpl();
+
+        long sample1 = 100L;
+        sut.addSample(SidecarType.CONTRACT_BYTECODE, sample1);
+
+        //        """
+        //        SidecarAccumulators\\[\
+        //        serializedSize=CONTRACT_BYTECODESizeBytes\\[#1, ∑100, 𝑚𝑎𝑥 100, ÷1], \
+        //        computeDuration=CONTRACT_BYTECODEDurationMs\\[#0, ∑0, 𝑚𝑎𝑥 MINIMUM, ÷1000000], \
+        //        durationSplit=CONTRACT_BYTECODEDurationSplitMs\\[#0, ∑0, 𝑚𝑎𝑥 MINIMUM, ÷1000000]]\
+        //        """;
+
+        final var expected1 =
+                expectedAccumulators("CONTRACT_BYTECODE", 1, 100, 100, 1, 0, 0, M, 1000000, 0, 0, M, 1000000);
+        assertEquals(expected1, sut.toString(SidecarType.CONTRACT_BYTECODE));
+
+        long sample2 = 233L;
+        sut.addSample(SidecarType.CONTRACT_BYTECODE, sample2);
+
+        final var expected2 =
+                expectedAccumulators("CONTRACT_BYTECODE", 2, 333, 233, 1, 0, 0, M, 1000000, 0, 0, M, 1000000);
+        assertEquals(expected2, sut.toString(SidecarType.CONTRACT_BYTECODE));
+    }
+
+    @Test
+    void addSampleDurationTest() {
+
+        final SidecarInstrumentation sut = new SidecarInstrumentationImpl();
+
+        Duration sample1 = Duration.ofNanos(100L);
+        sut.addSample(SidecarType.CONTRACT_BYTECODE, sample1);
+
+        final var expected1 =
+                expectedAccumulators("CONTRACT_BYTECODE", 0, 0, M, 1, 1, 100, 100, 1000000, 0, 0, M, 1000000);
+        assertEquals(expected1, sut.toString(SidecarType.CONTRACT_BYTECODE));
+
+        Duration sample2 = Duration.ofNanos(233L);
+        sut.addSample(SidecarType.CONTRACT_BYTECODE, sample2);
+
+        final var expected2 =
+                expectedAccumulators("CONTRACT_BYTECODE", 0, 0, M, 1, 2, 333, 233, 1000000, 0, 0, M, 1000000);
+        assertEquals(expected2, sut.toString(SidecarType.CONTRACT_BYTECODE));
+    }
+
+    // A short sleep that will pass a test for having an actual delay
+    private void doNothingButExpectTrouble() throws InterruptedException {
+        TimeUnit.MILLISECONDS.sleep(1);
+    }
+
+    @Test
+    void captureDurationSplitRunnableTest() {
+
+        final SidecarInstrumentation sut = new SidecarInstrumentationImpl();
+        final Runnable lambda = () -> {
+            try {
+                doNothingButExpectTrouble();
+            } catch (InterruptedException ex) {
+                return;
+            }
+        };
+
+        // Build a regexp to match a variable number of nanoseconds delay: At least 1ms, and total == max
+        final var expectedPreRegexp =
+                expectedAccumulators("CONTRACT_BYTECODE", 0, 0, M, 1, 0, 0, M, 1000000, 1, 12345, 54321, 1000000);
+        final var expectedRegexp = escapeForRegexp(expectedPreRegexp)
+                .replace("12345", "([1-7][0-9]{6})")
+                .replace("54321", "\\1");
+
+        sut.captureDurationSplit(SidecarType.CONTRACT_BYTECODE, lambda);
+
+        assertLinesMatch(List.of(expectedRegexp), List.of(sut.toString(SidecarType.CONTRACT_BYTECODE)));
+    }
+
+    @Test
+    void captureDurationSplitCallableTest() {
+
+        final SidecarInstrumentation sut = new SidecarInstrumentationImpl();
+        final SidecarInstrumentation.ExceptionFreeCallable<Integer> lambda = () -> {
+            try {
+                doNothingButExpectTrouble();
+            } catch (InterruptedException ex) {
+                return -1;
+            }
+            return 25_000;
+        };
+
+        final Integer expectedReturn = 25_000;
+
+        // Build a regexp to match a variable number of nanoseconds delay: At least 1ms, and total == max
+        final var expectedPreRegexp =
+                expectedAccumulators("CONTRACT_BYTECODE", 0, 0, M, 1, 0, 0, M, 1000000, 1, 12345, 54321, 1000000);
+        final var expectedRegexp = escapeForRegexp(expectedPreRegexp)
+                .replace("12345", "([1-7][0-9]{6})")
+                .replace("54321", "\\1");
+
+        final Integer actualReturn = sut.captureDurationSplit(SidecarType.CONTRACT_BYTECODE, lambda);
+
+        assertEquals(expectedReturn, actualReturn);
+        assertLinesMatch(List.of(expectedRegexp), List.of(sut.toString(SidecarType.CONTRACT_BYTECODE)));
+    }
+
+    @Test
+    void addSampleSizeAndDurationTest() {
+
+        final SidecarInstrumentation sut = new SidecarInstrumentationImpl();
+
+        long sample1L = 100;
+        Duration sample1D = Duration.ofNanos(100L);
+        sut.addSample(SidecarType.CONTRACT_BYTECODE, sample1L, sample1D);
+
+        final var expected1 =
+                expectedAccumulators("CONTRACT_BYTECODE", 1, 100, 100, 1, 1, 100, 100, 1000000, 0, 0, M, 1000000);
+        assertEquals(expected1, sut.toString(SidecarType.CONTRACT_BYTECODE));
+
+        long sample2L = 233;
+        Duration sample2D = Duration.ofNanos(233L);
+        sut.addSample(SidecarType.CONTRACT_BYTECODE, sample2L, sample2D);
+
+        final var expected2 =
+                expectedAccumulators("CONTRACT_BYTECODE", 2, 333, 233, 1, 2, 333, 233, 1000000, 0, 0, M, 1000000);
+        assertEquals(expected2, sut.toString(SidecarType.CONTRACT_BYTECODE));
+    }
+
+    @Test
+    void addSamplesTest() {
+
+        final SidecarInstrumentation src = new SidecarInstrumentationImpl();
+        src.addSample(SidecarType.CONTRACT_BYTECODE, 100L);
+        src.addSample(SidecarType.CONTRACT_ACTION, Duration.ofNanos(321L));
+
+        final SidecarInstrumentation sut = new SidecarInstrumentationImpl();
+        sut.addSample(SidecarType.CONTRACT_BYTECODE, 55L);
+        sut.addSample(SidecarType.CONTRACT_BYTECODE, Duration.ofNanos(123L));
+        sut.addSample(SidecarType.CONTRACT_STATE_CHANGE, Duration.ofNanos(555L));
+
+        sut.addSamples(src);
+
+        final var actual = String.join(
+                "; ",
+                sut.toString(SidecarType.CONTRACT_BYTECODE),
+                sut.toString(SidecarType.CONTRACT_ACTION),
+                sut.toString(SidecarType.CONTRACT_STATE_CHANGE));
+
+        final var expectedBC =
+                expectedAccumulators("CONTRACT_BYTECODE", 2, 155, 100, 1, 1, 123, 123, 1000000, 0, 0, M, 1000000);
+        final var expectedAC =
+                expectedAccumulators("CONTRACT_ACTION", 0, 0, M, 1, 1, 321, 321, 1000000, 0, 0, M, 1000000);
+        final var expectedSC =
+                expectedAccumulators("CONTRACT_STATE_CHANGE", 0, 0, M, 1, 1, 555, 555, 1000000, 0, 0, M, 1000000);
+        final var expected = String.join("; ", expectedBC, expectedAC, expectedSC);
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    void addSamplesDoesNothingIfNotAProperImpl() {
+
+        final SidecarInstrumentation src = SidecarInstrumentation.createNoop();
+        final SidecarInstrumentation sut = new SidecarInstrumentationImpl();
+        sut.addSample(SidecarType.CONTRACT_BYTECODE, 55L);
+        sut.addSample(SidecarType.CONTRACT_BYTECODE, Duration.ofNanos(123L));
+        sut.addSample(SidecarType.CONTRACT_STATE_CHANGE, Duration.ofNanos(555L));
+
+        sut.addSamples(src);
+
+        final var actual = String.join(
+                "; ",
+                sut.toString(SidecarType.CONTRACT_BYTECODE),
+                sut.toString(SidecarType.CONTRACT_ACTION),
+                sut.toString(SidecarType.CONTRACT_STATE_CHANGE));
+
+        final var expectedBC =
+                expectedAccumulators("CONTRACT_BYTECODE", 1, 55, 55, 1, 1, 123, 123, 1000000, 0, 0, M, 1000000);
+        final var expectedAC = expectedAccumulators("CONTRACT_ACTION", 0, 0, M, 1, 0, 0, M, 1000000, 0, 0, M, 1000000);
+        final var expectedSC =
+                expectedAccumulators("CONTRACT_STATE_CHANGE", 0, 0, M, 1, 1, 555, 555, 1000000, 0, 0, M, 1000000);
+        final var expected = String.join("; ", expectedBC, expectedAC, expectedSC);
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    void captureDurationSplitRunnableOfNoopInstrumentationTest() {
+        final SidecarInstrumentation sut = SidecarInstrumentation.createNoop();
+        final Runnable lambda = () -> {
+            try {
+                doNothingButExpectTrouble();
+            } catch (InterruptedException ex) {
+                return;
+            }
+        };
+
+        final String expectedStringRegexp = "CONTRACT_BYTECODE\\[INVALID]";
+
+        sut.captureDurationSplit(SidecarType.CONTRACT_BYTECODE, lambda);
+
+        assertLinesMatch(List.of(expectedStringRegexp), List.of(sut.toString(SidecarType.CONTRACT_BYTECODE)));
+    }
+
+    @Test
+    void captureDurationSplitCallableOfNoopInstrumentationTest() {
+        final SidecarInstrumentation sut = SidecarInstrumentation.createNoop();
+        final SidecarInstrumentation.ExceptionFreeCallable<Integer> lambda = () -> {
+            try {
+                doNothingButExpectTrouble();
+            } catch (InterruptedException ex) {
+                return -1;
+            }
+            return 25_000;
+        };
+
+        final Integer expectedReturn = 25_000;
+        final String expectedStringRegexp = "CONTRACT_BYTECODE\\[INVALID]";
+
+        final Integer actualReturn = sut.captureDurationSplit(SidecarType.CONTRACT_BYTECODE, lambda);
+
+        assertEquals(expectedReturn, actualReturn);
+        assertLinesMatch(List.of(expectedStringRegexp), List.of(sut.toString(SidecarType.CONTRACT_BYTECODE)));
+    }
+
+    @Test
+    void toStringOnNoopInstrumentation() {
+        final SidecarInstrumentation sut = SidecarInstrumentation.createNoop();
+        final String expected = "CONTRACT_BYTECODE[INVALID]";
+        final String actual = sut.toString(SidecarType.CONTRACT_BYTECODE);
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    void resetTest() {
+        final SidecarInstrumentation sut = new SidecarInstrumentationImpl();
+
+        sut.addSample(SidecarType.CONTRACT_BYTECODE, 100L);
+        sut.addSample(SidecarType.CONTRACT_ACTION, Duration.ofNanos(321L));
+        sut.addSample(SidecarType.CONTRACT_BYTECODE, 55L);
+        sut.addSample(SidecarType.CONTRACT_BYTECODE, Duration.ofNanos(123L));
+        sut.addSample(SidecarType.CONTRACT_STATE_CHANGE, Duration.ofNanos(555L));
+
+        sut.reset();
+
+        final var actual = String.join(
+                "; ",
+                sut.toString(SidecarType.CONTRACT_BYTECODE),
+                sut.toString(SidecarType.CONTRACT_ACTION),
+                sut.toString(SidecarType.CONTRACT_STATE_CHANGE));
+
+        final var expectedBC =
+                expectedAccumulators("CONTRACT_BYTECODE", 0, 0, M, 1, 0, 0, M, 1000000, 0, 0, M, 1000000);
+        final var expectedAC = expectedAccumulators("CONTRACT_ACTION", 0, 0, M, 1, 0, 0, M, 1000000, 0, 0, M, 1000000);
+        final var expectedSC =
+                expectedAccumulators("CONTRACT_STATE_CHANGE", 0, 0, M, 1, 0, 0, M, 1000000, 0, 0, M, 1000000);
+        final var expected = String.join("; ", expectedBC, expectedAC, expectedSC);
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    void copyCounterTest() {
+        final SidecarInstrumentationImpl sutHidden = new SidecarInstrumentationImpl();
+        final SidecarInstrumentation sut = sutHidden;
+
+        assertEquals(0, sutHidden.getCopies());
+        sut.addCopy();
+        assertEquals(1, sutHidden.getCopies());
+        sut.addCopy();
+        assertEquals(2, sutHidden.getCopies());
+        assertFalse(sut.removeCopy());
+        assertTrue(sut.removeCopy());
+    }
+
+    @Test
+    void orderByHashcodeTest() {
+        final Object a = new SidecarInstrumentationImpl();
+        final Object b = new SidecarInstrumentationImpl();
+
+        assertNotEquals(
+                SidecarInstrumentationImpl.testOrderByHashcode(a, b),
+                SidecarInstrumentationImpl.testOrderByHashcode(b, a));
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(() -> {
+                    SidecarInstrumentationImpl.testOrderByHashcode(a, a);
+                })
+                .withMessage("arguments are not distinct objects");
+    }
+}

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/contract/ContractCallTransitionLogicTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/contract/ContractCallTransitionLogicTest.java
@@ -46,6 +46,7 @@ import com.hedera.node.app.service.mono.contracts.execution.TransactionProcessin
 import com.hedera.node.app.service.mono.ledger.SigImpactHistorian;
 import com.hedera.node.app.service.mono.ledger.accounts.AliasManager;
 import com.hedera.node.app.service.mono.records.TransactionRecordService;
+import com.hedera.node.app.service.mono.stats.SidecarInstrumentation;
 import com.hedera.node.app.service.mono.store.AccountStore;
 import com.hedera.node.app.service.mono.store.contracts.CodeCache;
 import com.hedera.node.app.service.mono.store.contracts.EntityAccess;
@@ -164,7 +165,15 @@ class ContractCallTransitionLogicTest {
         // flag
         // and:
         var results = TransactionProcessingResult.successful(
-                null, 1234L, 0L, 124L, Bytes.EMPTY, contractAccount.getId().asEvmAddress(), Map.of(), List.of());
+                null,
+                1234L,
+                0L,
+                124L,
+                Bytes.EMPTY,
+                contractAccount.getId().asEvmAddress(),
+                Map.of(),
+                List.of(),
+                SidecarInstrumentation.createNoop());
         given(evmTxProcessor.execute(
                         senderAccount,
                         contractAccount.getId().asEvmAddress(),
@@ -198,7 +207,15 @@ class ContractCallTransitionLogicTest {
         given(accountStore.loadAccount(relayerAccount.getId())).willReturn(relayerAccount);
         // and:
         var results = TransactionProcessingResult.successful(
-                null, 1234L, 0L, 124L, Bytes.EMPTY, contractAccount.getId().asEvmAddress(), Map.of(), List.of());
+                null,
+                1234L,
+                0L,
+                124L,
+                Bytes.EMPTY,
+                contractAccount.getId().asEvmAddress(),
+                Map.of(),
+                List.of(),
+                SidecarInstrumentation.createNoop());
         given(evmTxProcessor.executeEth(
                         senderAccount,
                         contractAccount.getId().asEvmAddress(),
@@ -239,7 +256,15 @@ class ContractCallTransitionLogicTest {
         given(accountStore.loadAccount(relayerAccount.getId())).willReturn(relayerAccount);
         // and:
         var results = TransactionProcessingResult.successful(
-                null, 1234L, 0L, 124L, Bytes.EMPTY, Address.wrap(Bytes.wrap(alias.toByteArray())), Map.of(), List.of());
+                null,
+                1234L,
+                0L,
+                124L,
+                Bytes.EMPTY,
+                Address.wrap(Bytes.wrap(alias.toByteArray())),
+                Map.of(),
+                List.of(),
+                SidecarInstrumentation.createNoop());
         given(evmTxProcessor.executeEth(
                         senderAccount,
                         Address.wrap(Bytes.wrap(alias.toByteArray())),
@@ -280,8 +305,16 @@ class ContractCallTransitionLogicTest {
         given(accountStore.loadAccount(senderAccount.getId())).willReturn(senderAccount);
         given(accountStore.loadAccount(relayerAccount.getId())).willReturn(relayerAccount);
         // and:
+
         var results = TransactionProcessingResult.failed(
-                1234L, 0L, 124L, Optional.of(Bytes.EMPTY), Optional.empty(), Map.of(), List.of());
+                1234L,
+                0L,
+                124L,
+                Optional.of(Bytes.EMPTY),
+                Optional.empty(),
+                Map.of(),
+                List.of(),
+                SidecarInstrumentation.createNoop());
         given(evmTxProcessor.executeEth(
                         senderAccount,
                         Address.wrap(Bytes.wrap(alias.toByteArray())),
@@ -493,7 +526,15 @@ class ContractCallTransitionLogicTest {
 
         // and:
         var results = TransactionProcessingResult.successful(
-                null, 1234L, 0L, 124L, Bytes.EMPTY, contractAccount.getId().asEvmAddress(), Map.of(), List.of());
+                null,
+                1234L,
+                0L,
+                124L,
+                Bytes.EMPTY,
+                contractAccount.getId().asEvmAddress(),
+                Map.of(),
+                List.of(),
+                SidecarInstrumentation.createNoop());
         given(evmTxProcessor.execute(
                         senderAccount,
                         new Account(new Id(target.getShardNum(), target.getRealmNum(), target.getContractNum()))
@@ -536,7 +577,15 @@ class ContractCallTransitionLogicTest {
                 .willReturn(contractAccount);
         // and:
         var results = TransactionProcessingResult.successful(
-                null, 1234L, 0L, 124L, Bytes.EMPTY, contractAccount.getId().asEvmAddress(), Map.of(), List.of());
+                null,
+                1234L,
+                0L,
+                124L,
+                Bytes.EMPTY,
+                contractAccount.getId().asEvmAddress(),
+                Map.of(),
+                List.of(),
+                SidecarInstrumentation.createNoop());
         given(evmTxProcessor.execute(
                         senderAccount,
                         contractAccount.getId().asEvmAddress(),

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/utils/LongSampleAccumulatorTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/utils/LongSampleAccumulatorTest.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.node.app.service.mono.utils;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.Arrays;
+import java.util.stream.LongStream;
+import org.junit.jupiter.api.Test;
+
+class LongSampleAccumulatorTest {
+
+    @Test
+    void invalidDenominatorIsDetected() {
+        assertThrows(IllegalArgumentException.class, () -> new LongSampleAccumulator("baz", 0L));
+    }
+
+    @Test
+    void noSamplesProducesZeroValues() {
+        final String name = "foo";
+        final long denominator = 100L;
+        final var sut = new LongSampleAccumulator(name, denominator);
+
+        verifyNullResult(name, denominator, sut);
+    }
+
+    @Test
+    void oneSampleIsIdentity() {
+        final String name = "foo";
+        final long sample = 25_100L;
+        final long denominator = 100L;
+        final var sut = new LongSampleAccumulator(name, denominator);
+        sut.addSample(sample);
+
+        final var values = sut.getAccumulatedValues();
+        assertEquals(name, values.name());
+        assertEquals(1, values.nSamples());
+        assertEquals(sample, values.total());
+        assertEquals(sample, values.maximum());
+        assertEquals(denominator, values.denominator());
+
+        final var scaledValues = sut.getScaledAccumulatedValues();
+        assertEquals(name, scaledValues.name());
+        assertEquals(1, scaledValues.nSamples());
+        assertEquals((double) sample / (double) denominator, scaledValues.total());
+        assertEquals((double) sample / (double) denominator, scaledValues.maximum());
+
+        assertEquals("foo[#1, ∑25100, \uD835\uDC5A\uD835\uDC4E\uD835\uDC65 25100, ÷100]", sut.toString());
+    }
+
+    @Test
+    void multipleSamplesAreEffective() {
+
+        final String name = "foo";
+        final long[] samples = LongStream.range(0, 250).map(v -> v * v).toArray();
+        final long nSamples = samples.length;
+        assertEquals(250, nSamples);
+        final long total = Arrays.stream(samples).sum();
+        final long maximum = (long) Math.pow(nSamples - 1, 2);
+        final long denominator = 100L;
+        final var sut = new LongSampleAccumulator(name, denominator);
+        for (final var v : samples) sut.addSample(v);
+
+        final var values = sut.getAccumulatedValues();
+        assertEquals(name, values.name());
+        assertEquals(nSamples, values.nSamples());
+        assertEquals(total, values.total());
+        assertEquals(maximum, values.maximum());
+        assertEquals(denominator, values.denominator());
+
+        final var scaledValues = sut.getScaledAccumulatedValues();
+        assertEquals(name, scaledValues.name());
+        assertEquals(nSamples, scaledValues.nSamples());
+        assertEquals((double) total / (double) denominator, scaledValues.total());
+        assertEquals((double) maximum / (double) denominator, scaledValues.maximum());
+
+        assertEquals("foo[#250, ∑5177125, \uD835\uDC5A\uD835\uDC4E\uD835\uDC65 62001, ÷100]", sut.toString());
+    }
+
+    @Test
+    void resetWorksAsExpected() {
+        final String name = "foo";
+        final long sample = 25_100L;
+        final long denominator = 100L;
+        final var sut = new LongSampleAccumulator(name, denominator);
+        sut.addSample(sample);
+        sut.reset();
+
+        verifyNullResult(name, denominator, sut);
+    }
+
+    private void verifyNullResult(@NonNull String name, long denominator, final LongSampleAccumulator sut) {
+        final var values = sut.getAccumulatedValues();
+        assertEquals(name, values.name());
+        assertEquals(0, values.nSamples());
+        assertEquals(0L, values.total());
+        assertEquals(Long.MIN_VALUE, values.maximum());
+        assertEquals(denominator, values.denominator());
+
+        final var scaledValues = sut.getScaledAccumulatedValues();
+        assertEquals(name, scaledValues.name());
+        assertEquals(0, scaledValues.nSamples());
+        assertEquals(0.0, scaledValues.total());
+        assertEquals(-Double.MAX_VALUE, scaledValues.maximum());
+
+        assertEquals("foo[#0, ∑0, \uD835\uDC5A\uD835\uDC4E\uD835\uDC65 MINIMUM, ÷100]", sut.toString());
+    }
+}

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/utils/ResponseCodeUtilTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/utils/ResponseCodeUtilTest.java
@@ -21,6 +21,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import com.hedera.node.app.service.mono.contracts.execution.TransactionProcessingResult;
 import com.hedera.node.app.service.mono.exceptions.ResourceLimitException;
+import com.hedera.node.app.service.mono.stats.SidecarInstrumentation;
 import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
 import java.util.List;
 import java.util.Map;
@@ -40,6 +41,13 @@ class ResponseCodeUtilTest {
     private TransactionProcessingResult failureWithRevertReasonFrom(final ResponseCodeEnum status) {
         final var ex = new ResourceLimitException(status);
         return TransactionProcessingResult.failed(
-                1L, 2L, 3L, Optional.of(ex.messageBytes()), Optional.empty(), Map.of(), List.of());
+                1L,
+                2L,
+                3L,
+                Optional.of(ex.messageBytes()),
+                Optional.empty(),
+                Map.of(),
+                List.of(),
+                SidecarInstrumentation.createNoop());
     }
 }


### PR DESCRIPTION
Add metrics/logging to support performance investigations around sidecars.

**Reviewers:  Might want to take a brief look at the new metrics classes and how they're used to collect durations so I can get your comments on that.  

Signed-off-by: David Bakin <117694041+david-bakin-sl@users.noreply.github.com>

**Related issue(s)**:

Fixes #4682 

**Notes for reviewer**:

## What this PR does

New metrics/logging was added so that performance impact of creating
sidecars could be investigated, if the need arises.

For _each_ of the 3 sidecar types we collect
1. For each transaction involving a sidecar
  1. Time needed to _compute_ the sidecar data including:
     - building supporting data structures (if necessary)
     - building a protobuf builder
     - serializing the actual protobuf from the builder
  1. Size of the serialized data
1. For each sidecar record
  1. Count of transactions
  1. Total duration for all transactions in sidecar, and max duration
     of a tx in the sidecar
  1. Total size for all transactions in sidecar, and max size of a tx
     in the sidecar
 
These are issued as metrics. But metrics are sampled (every three seconds)
so samples can be lost.  We're looking for outliers.  So in addition
_each_ of these is logged.  That way you can use a log aggregator to get
each and every tx and sidecar record, to summarize, or find the outliers
(e.g., TP90 or whatever).

## How this PR does it (guide to the PR)

This work is divided into the following major pieces:

1. Collecting the data
   - where the _duration_ we want actually comes from a number of 
     separate computations spread through the code
1. Plumbing it throughout the system
1. Exporting it (metrics and logs) 
1. Fixing up unit tests to account for changes in plumbing

### Collecting the data

- Current metrics classes are not quite ready for this
  - we want count/total/max not just count/total or count/max or total/max
  - we want hierarchical collection
    - txs summarized into sidecars
    - separate compute durations for a tx summarized for that tx
  - no current metric helps you  _measure_ duration data
  
- For this I've introduced classes (from lowest-level up):
  - `LongSampleAccumulator` - accumulator for long values, tracking number of samples,
     total value, maximum value.  Also has a scale factor for units.
     - scale factor is used because duration is accumulated in nanoseconds but
       reported in milliseconds
  - `SidecarAccumulators` - this holds accumulators for three measurements:
    - serialized size
    - duration
    - the duration "split"
      - "split" in the sense of timing separate sprints and adding them together later to get a total measurement
    - and also let's you add the current split to the accumulated duration and clear the split
  - `SidecarInstrumentation` (interface)
    - this is the main instrumentation class that collects data for either
      a single tx, or summarizes it for a sidecar
    - includes the mechanism to measure duration splits
    - there's a true implementation (`SidecarInstrumentationImpl`)
      and also a "noop" implementation (an anonymous class inline with the interface
  
- Duration is measured by methods `captureDurationSplit` that take either a `Runnable`
  or a `Callable` - and run the lambda given while timing it, and accumulating the 
  duration.
  - (This is actually what is going to be most annoying to review:  All _I_ did was
    wrap this call around existing code, putting the existing code in a lambda.  But the
    _reviewer_ will see the code differently with different indentation and wrapping and
    will have to look at it to see it's the same.)
    
- Most of the sidecar work happens in `HederaTracer` and `SidecarUtils` with some more
  scattered here and there.  So that's where the calls to `captureDurationSplit` are.

### Plumbing the data

- We start by adding a `SidecarInstrumentation` into a `HederaOperationTracer` interface
  (implemented in `HederaTracer`).)
- The instrumentation instance for a tx is created in `EvmTxProcessor.execute()` where
  it is added to the tracer that itself is added to the processor.
- It then gets plumbed into a `TransactionResult` when those are created.
- Then **TBD**

### Exporting it

- **TBD**

### Fixing up unit tests

- Multiple unit tests needed to be fixed up to account for the plumbing.  Those changes
  are largely trivial.
- Some unit tests needed to be fixed up because the addition of a `SidecarInstrumentation`
  parameter messed up mock setups or verification.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
