### PR TITLE
4896 - add grpc response code when the ingest workflow is happening a…

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/ingest/IngestWorkflowImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/ingest/IngestWorkflowImpl.java
@@ -155,6 +155,10 @@ public final class IngestWorkflowImpl implements IngestWorkflow {
             }
         }
 
+        if (result != OK) {
+            opCounters.countResponseCodes(result);
+        }
+
         // 8. Return PreCheck code and evtl. estimated fee
         final var transactionResponse =
                 TransactionResponse.newBuilder()

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/stats/ServicesStatsConfig.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/stats/ServicesStatsConfig.java
@@ -26,9 +26,9 @@ import java.util.Set;
 public final class ServicesStatsConfig {
     static final Set<HederaFunctionality> IGNORED_FUNCTIONS =
             EnumSet.of(NONE, UNRECOGNIZED, GetByKey);
-
     static final String COUNTER_HANDLED_NAME_TPL = "%sHdl";
     static final String COUNTER_RECEIVED_NAME_TPL = "%sRcv";
+    static final String COUNTER_HANDLED_RESPONSE_CODE_NAME = "%sResponseCode";
     static final String COUNTER_DEPRECATED_TXNS_NAME = "DeprTxnsRcv";
     static final String COUNTER_ANSWERED_NAME_TPL = "%sSub";
     static final String COUNTER_SUBMITTED_NAME_TPL = "%sSub";
@@ -39,6 +39,7 @@ public final class ServicesStatsConfig {
     static final String SPEEDOMETER_DEPRECATED_TXNS_NAME = "DeprTxnsRcv/sec";
 
     static final String COUNTER_HANDLED_DESC_TPL = "number of %s handled";
+    static final String COUNTER_HANDLED_RESPONSE_CODE_DESC = "number of response %s handled";
     static final String COUNTER_RECEIVED_DESC_TPL = "number of %s received";
     static final String COUNTER_RECEIVED_DEPRECATED_DESC = "number of deprecated txns received";
     static final String COUNTER_ANSWERED_DESC_TPL = "number of %s answered";

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/stats/HapiOpCountersTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/stats/HapiOpCountersTest.java
@@ -19,6 +19,8 @@ import static com.hederahashgraph.api.proto.java.HederaFunctionality.ConsensusSu
 import static com.hederahashgraph.api.proto.java.HederaFunctionality.CryptoTransfer;
 import static com.hederahashgraph.api.proto.java.HederaFunctionality.NONE;
 import static com.hederahashgraph.api.proto.java.HederaFunctionality.TokenGetInfo;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OK;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.PAYER_ACCOUNT_NOT_FOUND;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -102,7 +104,7 @@ class HapiOpCountersTest {
 
     @Test
     void registersExpectedStatEntries() {
-        verify(metrics, times(9)).getOrCreate(any());
+        verify(metrics, times(300)).getOrCreate(any());
     }
 
     @Test
@@ -148,8 +150,10 @@ class HapiOpCountersTest {
         subject.countReceived(TokenGetInfo);
         subject.countAnswered(TokenGetInfo);
         subject.countAnswered(TokenGetInfo);
+        subject.countResponseCodes(PAYER_ACCOUNT_NOT_FOUND);
+        subject.countResponseCodes(PAYER_ACCOUNT_NOT_FOUND);
 
-        verify(counter, times(12)).increment();
+        verify(counter, times(14)).increment();
     }
 
     @Test
@@ -158,11 +162,13 @@ class HapiOpCountersTest {
         assertDoesNotThrow(() -> subject.countSubmitted(NONE));
         assertDoesNotThrow(() -> subject.countHandled(NONE));
         assertDoesNotThrow(() -> subject.countAnswered(NONE));
+        assertDoesNotThrow(() -> subject.countResponseCodes(OK));
 
         assertEquals(0L, subject.receivedSoFar(NONE));
         assertEquals(0L, subject.submittedSoFar(NONE));
         assertEquals(0L, subject.handledSoFar(NONE));
         assertEquals(0L, subject.answeredSoFar(NONE));
+        assertEquals(0L, subject.responseCodeSoFar(OK));
     }
 
     @Test


### PR DESCRIPTION
add grpc response code when the ingest workflow is happening and the response code is not to track it in the metrics.

Signed-off-by: Lev Povolotsky <lev@swirldslabs.com>

**Description**:
<!--
This PR is needed that we will be able to present response code metrics and use them in grafana and  Prometheus 

This PR modifies ... in order to support ...
* response code from grpc while the ingest workflow is triggered 
-->

**Related issue(s)**:

Fixes #4896 

**Checklist**

- [ ] Tested (unit, integration, etc.)
