### PR TITLE
Use `0.35` protobufs

### DIFF
--- a/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/keys/Ed25519Utils.java
+++ b/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/keys/Ed25519Utils.java
@@ -39,7 +39,8 @@ public final class Ed25519Utils {
     private static final Provider BC_PROVIDER = new BouncyCastleProvider();
     private static final Provider ED_PROVIDER = new EdDSASecurityProvider();
 
-    private static final String TEST_CLIENTS_PREFIX = "test-clients" + File.separator;
+    private static final String TEST_CLIENTS_PREFIX =
+            "hedera-node" + File.separator + "test-clients" + File.separator;
     private static final String RESOURCE_PATH_SEGMENT = "src/main/resource";
     public static final EdDSANamedCurveSpec ED25519_PARAMS =
             EdDSANamedCurveTable.getByName(EdDSANamedCurveTable.ED_25519);

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoCreateSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoCreateSuite.java
@@ -18,9 +18,11 @@ package com.hedera.services.bdd.suites.crypto;
 import static com.hedera.node.app.service.evm.utils.EthSigsUtils.recoverAddressFromPubKey;
 import static com.hedera.services.bdd.spec.HapiSpec.defaultHapiSpec;
 import static com.hedera.services.bdd.spec.assertions.AccountInfoAsserts.accountWith;
+import static com.hedera.services.bdd.spec.assertions.TransactionRecordAsserts.recordWith;
 import static com.hedera.services.bdd.spec.keys.KeyShape.SIMPLE;
 import static com.hedera.services.bdd.spec.keys.KeyShape.listOf;
 import static com.hedera.services.bdd.spec.keys.KeyShape.threshOf;
+import static com.hedera.services.bdd.spec.keys.SigControl.SECP256K1_ON;
 import static com.hedera.services.bdd.spec.keys.TrieSigMapGenerator.uniqueWithFullPrefixesFor;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getAccountBalance;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getAccountInfo;
@@ -32,6 +34,7 @@ import static com.hedera.services.bdd.spec.transactions.TxnVerbs.tokenCreate;
 import static com.hedera.services.bdd.spec.transactions.crypto.HapiCryptoTransfer.tinyBarsFromTo;
 import static com.hedera.services.bdd.spec.utilops.CustomSpecAssert.allRunFor;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.newKeyNamed;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.sourcing;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.validateChargedUsd;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.withOpContext;
 import static com.hedera.services.bdd.suites.crypto.AutoAccountCreationSuite.CRYPTO_TRANSFER_RECEIVER;
@@ -59,6 +62,7 @@ import com.hederahashgraph.api.proto.java.KeyList;
 import com.hederahashgraph.api.proto.java.ThresholdKey;
 import com.swirlds.common.utility.CommonUtils;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -109,7 +113,7 @@ public class CryptoCreateSuite extends HapiSuite {
                 createAnAccountWithED25519KeyAndED25519Alias(),
                 createAnAccountWithECKeyAndECKeyAlias(),
                 hollowAccountCompletionAfterCryptoCreate(),
-                cannotCreateAnAccountWithLongZeroKey());
+                cannotCreateAnAccountWithLongZeroKeyButCanUseEvmAddress());
     }
 
     private HapiSpec createAnAccountWithStakingFields() {
@@ -170,16 +174,44 @@ public class CryptoCreateSuite extends HapiSuite {
                                 .hasPrecheck(INVALID_STAKING_ID));
     }
 
-    private HapiSpec cannotCreateAnAccountWithLongZeroKey() {
+    private HapiSpec cannotCreateAnAccountWithLongZeroKeyButCanUseEvmAddress() {
+        final AtomicReference<ByteString> secp256k1Key = new AtomicReference<>();
+        final AtomicReference<ByteString> evmAddress = new AtomicReference<>();
+        final var ecdsaKey = "ecdsaKey";
         final var longZeroAddress =
                 ByteString.copyFrom(CommonUtils.unhex("0000000000000000000000000000000fffffffff"));
+        final var creation = "creation";
         return defaultHapiSpec("CannotCreateAnAccountWithLongZeroKey")
-                .given()
-                .when()
-                .then(
+                .given(
                         cryptoCreate(ACCOUNT)
                                 .evmAddress(longZeroAddress)
-                                .hasPrecheck(INVALID_ALIAS_KEY));
+                                .hasPrecheck(INVALID_ALIAS_KEY),
+                        newKeyNamed(ecdsaKey).shape(SECP256K1_ON))
+                .when(
+                        withOpContext(
+                                (spec, opLog) -> {
+                                    secp256k1Key.set(
+                                            spec.registry().getKey(ecdsaKey).toByteString());
+                                    final var rawAddress =
+                                            recoverAddressFromPubKey(
+                                                    spec.registry()
+                                                            .getKey(ecdsaKey)
+                                                            .getECDSASecp256K1()
+                                                            .toByteArray());
+                                    evmAddress.set(ByteString.copyFrom(rawAddress));
+                                }))
+                .then(
+                        sourcing(
+                                () ->
+                                        cryptoCreate(ACCOUNT)
+                                                .alias(secp256k1Key.get())
+                                                .via(creation)),
+                        sourcing(
+                                () ->
+                                        getTxnRecord(creation)
+                                                .hasPriority(
+                                                        recordWith()
+                                                                .evmAddress(evmAddress.get()))));
     }
 
     /* Prior to 0.13.0, a "canonical" CryptoCreate (one sig, 3 month auto-renew) cost 1¢. */

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoCreateSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoCreateSuite.java
@@ -57,6 +57,7 @@ import com.hederahashgraph.api.proto.java.AccountID;
 import com.hederahashgraph.api.proto.java.Key;
 import com.hederahashgraph.api.proto.java.KeyList;
 import com.hederahashgraph.api.proto.java.ThresholdKey;
+import com.swirlds.common.utility.CommonUtils;
 import java.util.List;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -107,7 +108,8 @@ public class CryptoCreateSuite extends HapiSuite {
                 createAnAccountWithEDKeyAndNoAlias(),
                 createAnAccountWithED25519KeyAndED25519Alias(),
                 createAnAccountWithECKeyAndECKeyAlias(),
-                hollowAccountCompletionAfterCryptoCreate());
+                hollowAccountCompletionAfterCryptoCreate(),
+                cannotCreateAnAccountWithLongZeroKey());
     }
 
     private HapiSpec createAnAccountWithStakingFields() {
@@ -166,6 +168,18 @@ public class CryptoCreateSuite extends HapiSuite {
                                 .declinedReward(false)
                                 .stakedNodeId(-1L)
                                 .hasPrecheck(INVALID_STAKING_ID));
+    }
+
+    private HapiSpec cannotCreateAnAccountWithLongZeroKey() {
+        final var longZeroAddress =
+                ByteString.copyFrom(CommonUtils.unhex("0000000000000000000000000000000fffffffff"));
+        return defaultHapiSpec("CannotCreateAnAccountWithLongZeroKey")
+                .given()
+                .when()
+                .then(
+                        cryptoCreate(ACCOUNT)
+                                .evmAddress(longZeroAddress)
+                                .hasPrecheck(INVALID_ALIAS_KEY));
     }
 
     /* Prior to 0.13.0, a "canonical" CryptoCreate (one sig, 3 month auto-renew) cost 1¢. */

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -75,7 +75,7 @@ gitRepositories {
         uri.set("https://github.com/hashgraph/hedera-protobufs.git")
         // choose tag or branch of HAPI you would like to test with
         // This version needs to match tha HAPI version below in versionCatalogs
-        tag.set("v0.34.0")
+        tag.set("v0.35.0")
         // do not load project from repo
         autoInclude.set(false)
     }
@@ -89,7 +89,7 @@ dependencyResolutionManagement {
         // distribution. These libs can be depended on during compilation, or bundled as part of runtime.
         create("libs") {
             // The HAPI API version to use, this need to match the tag set on gitRepositories above
-            version("hapi-version", "0.34.0")
+            version("hapi-version", "0.35.0")
 
             // Definition of version numbers for all libraries
             version("pbj-version", "0.3.0")


### PR DESCRIPTION
**Description**:
- Update to `v0.35.0` protobufs, validate that long-zero address cannot be used as an alias.