### PR TITLE
Minor spec update to reflect current behavior

### DIFF
--- a/hedera-node/docs/scheduled-transactions/revised-spec.md
+++ b/hedera-node/docs/scheduled-transactions/revised-spec.md
@@ -180,10 +180,10 @@ message ScheduleDeleteTransactionBody {
 ```  
 
 When a `ScheduleDelete` resolves to `SUCCESS`, its target schedule is marked as 
-as deleted. Any future attempts to trigger this schedule will result in `SCHEDULE_WAS_DELETED`.
+as deleted. Any future attempts to trigger this schedule will result in `INVALID_SCHEDULE_ID`.
 However, the schedule will remain in network state until it expires. (Note that if we try 
 to delete a schedule that already executed, our `ScheduleDelete` will resolve
-to `SCHEDULE_WAS_EXECUTED` and have no effect.)
+to `INVALID_SCHEDULE_ID` and have no effect.)
   
 ## The `ScheduleGetInfo` query
   


### PR DESCRIPTION

Very minor change to the Schedule spec to modify the error code that is returned when someone tries to delete a schedule which has already executed or been deleted. Spec was out of alignment with how the code actually behaves. After discussion, decision was made to update the spec to reflect current behavior.

**Related issue(s)**:

Fixes issue #4814 
