### PR TITLE
Java annotation for interfaces of hedera-evm that are the "interim SPI"

### DIFF
--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/accounts/AccountAccessor.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/accounts/AccountAccessor.java
@@ -16,8 +16,10 @@
 
 package com.hedera.node.app.service.evm.accounts;
 
+import com.hedera.node.app.service.evm.annotations.InterimSPI;
 import org.hyperledger.besu.datatypes.Address;
 
+@InterimSPI
 public interface AccountAccessor {
 
     Address canonicalAddress(final Address addressOrAlias);

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/accounts/HederaEvmContractAliases.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/accounts/HederaEvmContractAliases.java
@@ -18,11 +18,13 @@ package com.hedera.node.app.service.evm.accounts;
 
 import com.google.common.base.Suppliers;
 import com.google.common.primitives.Longs;
+import com.hedera.node.app.service.evm.annotations.InterimSPI;
 import com.hedera.node.app.service.evm.contracts.execution.StaticProperties;
 import java.util.Arrays;
 import java.util.function.Supplier;
 import org.hyperledger.besu.datatypes.Address;
 
+@InterimSPI
 public abstract class HederaEvmContractAliases {
 
     public static final int EVM_ADDRESS_LEN = 20;

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/annotations/InterimSPI.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/annotations/InterimSPI.java
@@ -19,6 +19,7 @@ package com.hedera.node.app.service.evm.annotations;
 import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.SOURCE;
 
+import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
@@ -29,5 +30,6 @@ import java.lang.annotation.Target;
  * of this module.  This will mark classes suitable for being extended in the meantime.
  */
 @Target(TYPE)
+@Inherited
 @Retention(SOURCE)
 public @interface InterimSPI {}

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/annotations/InterimSPI.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/annotations/InterimSPI.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.node.app.service.evm.annotations;
+
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.SOURCE;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+/**
+ * Marks an _interim_ SPI interface or class, extensible _outside_ of the `hedera-evm` module
+ *
+ * "Interim" because there's a bit of redesign needed here to find proper extension points
+ * of this module.  This will mark classes suitable for being extended in the meantime.
+ */
+@Target(TYPE)
+@Retention(SOURCE)
+public @interface InterimSPI {}

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/contracts/execution/BlockMetaSource.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/contracts/execution/BlockMetaSource.java
@@ -16,6 +16,7 @@
 
 package com.hedera.node.app.service.evm.contracts.execution;
 
+import com.hedera.node.app.service.evm.annotations.InterimSPI;
 import com.swirlds.common.crypto.DigestType;
 import com.swirlds.common.crypto.ImmutableHash;
 import org.apache.tuweni.bytes.Bytes32;
@@ -23,6 +24,7 @@ import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.evm.frame.BlockValues;
 
 /** Provides block information to a {@link HederaEvmTxProcessor}. */
+@InterimSPI
 public interface BlockMetaSource {
     Hash UNAVAILABLE_BLOCK_HASH = ethHashFrom(new ImmutableHash(new byte[DigestType.SHA_384.digestLength()]));
 

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/contracts/execution/EvmProperties.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/contracts/execution/EvmProperties.java
@@ -16,8 +16,10 @@
 
 package com.hedera.node.app.service.evm.contracts.execution;
 
+import com.hedera.node.app.service.evm.annotations.InterimSPI;
 import org.hyperledger.besu.datatypes.Address;
 
+@InterimSPI
 public interface EvmProperties {
 
     String evmVersion();

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/contracts/execution/HederaEvmMessageCallProcessor.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/contracts/execution/HederaEvmMessageCallProcessor.java
@@ -21,6 +21,7 @@ import static org.hyperledger.besu.evm.frame.MessageFrame.State.COMPLETED_SUCCES
 import static org.hyperledger.besu.evm.frame.MessageFrame.State.EXCEPTIONAL_HALT;
 import static org.hyperledger.besu.evm.frame.MessageFrame.State.REVERT;
 
+import com.hedera.node.app.service.evm.annotations.InterimSPI;
 import com.hedera.node.app.service.evm.store.contracts.AbstractLedgerEvmWorldUpdater;
 import com.hedera.node.app.service.evm.store.contracts.HederaEvmStackedWorldStateUpdater;
 import com.hedera.node.app.service.evm.store.contracts.precompile.EvmHTSPrecompiledContract;
@@ -39,6 +40,7 @@ import org.hyperledger.besu.evm.processor.MessageCallProcessor;
 import org.hyperledger.besu.evm.tracing.OperationTracer;
 
 /** Overrides Besu precompiler handling, so we can break model layers in Precompile execution */
+@InterimSPI
 public class HederaEvmMessageCallProcessor extends MessageCallProcessor {
     private static final Optional<ExceptionalHaltReason> ILLEGAL_STATE_CHANGE =
             Optional.of(ExceptionalHaltReason.ILLEGAL_STATE_CHANGE);

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/contracts/execution/HederaEvmTransactionProcessingResult.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/contracts/execution/HederaEvmTransactionProcessingResult.java
@@ -16,6 +16,7 @@
 
 package com.hedera.node.app.service.evm.contracts.execution;
 
+import com.hedera.node.app.service.evm.annotations.InterimSPI;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -28,6 +29,7 @@ import org.hyperledger.besu.evm.log.Log;
  * Model object holding all the necessary data to build and externalise the result of a single EVM
  * transaction
  */
+@InterimSPI
 public class HederaEvmTransactionProcessingResult {
     /** The status of the transaction after being processed. */
     public enum Status {

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/contracts/execution/HederaEvmTxProcessor.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/contracts/execution/HederaEvmTxProcessor.java
@@ -16,6 +16,7 @@
 
 package com.hedera.node.app.service.evm.contracts.execution;
 
+import com.hedera.node.app.service.evm.annotations.InterimSPI;
 import com.hedera.node.app.service.evm.contracts.execution.traceability.HederaEvmOperationTracer;
 import com.hedera.node.app.service.evm.store.contracts.HederaEvmMutableWorldState;
 import com.hedera.node.app.service.evm.store.contracts.HederaEvmWorldUpdater;
@@ -44,6 +45,7 @@ import org.hyperledger.besu.evm.tracing.OperationTracer;
  * long, long, long, Bytes, boolean, Address)} method that handles the end-to-end execution of an
  * EVM transaction.
  */
+@InterimSPI
 public abstract class HederaEvmTxProcessor {
     private static final int MAX_STACK_SIZE = 1024;
 

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/contracts/execution/PricesAndFeesProvider.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/contracts/execution/PricesAndFeesProvider.java
@@ -16,9 +16,11 @@
 
 package com.hedera.node.app.service.evm.contracts.execution;
 
+import com.hedera.node.app.service.evm.annotations.InterimSPI;
 import com.hederahashgraph.api.proto.java.HederaFunctionality;
 import java.time.Instant;
 
+@InterimSPI
 public interface PricesAndFeesProvider {
     long currentGasPrice(final Instant now, final HederaFunctionality function);
 }

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/contracts/execution/StaticProperties.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/contracts/execution/StaticProperties.java
@@ -16,7 +16,10 @@
 
 package com.hedera.node.app.service.evm.contracts.execution;
 
+import com.hedera.node.app.service.evm.annotations.InterimSPI;
+
 @SuppressWarnings("java:S1118") // Add a private constructor to hide the implicit public one.
+@InterimSPI
 public abstract class StaticProperties {
 
     protected static long shard = 0;

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/contracts/execution/traceability/HederaEvmOperationTracer.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/contracts/execution/traceability/HederaEvmOperationTracer.java
@@ -16,9 +16,11 @@
 
 package com.hedera.node.app.service.evm.contracts.execution.traceability;
 
+import com.hedera.node.app.service.evm.annotations.InterimSPI;
 import org.hyperledger.besu.evm.frame.MessageFrame;
 import org.hyperledger.besu.evm.tracing.OperationTracer;
 
+@InterimSPI
 public interface HederaEvmOperationTracer extends OperationTracer {
 
     /**

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/contracts/operations/HederaEvmSLoadOperation.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/contracts/operations/HederaEvmSLoadOperation.java
@@ -16,6 +16,7 @@
 
 package com.hedera.node.app.service.evm.contracts.operations;
 
+import com.hedera.node.app.service.evm.annotations.InterimSPI;
 import com.hedera.node.app.service.evm.store.contracts.AbstractLedgerEvmWorldUpdater;
 import org.apache.tuweni.bytes.Bytes32;
 import org.apache.tuweni.units.bigints.UInt256;
@@ -28,6 +29,7 @@ import org.hyperledger.besu.evm.gascalculator.GasCalculator;
 import org.hyperledger.besu.evm.internal.FixedStack;
 import org.hyperledger.besu.evm.operation.AbstractOperation;
 
+@InterimSPI
 public class HederaEvmSLoadOperation extends AbstractOperation {
     protected final long warmCost;
     protected final long coldCost;

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/exceptions/InvalidTransactionException.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/exceptions/InvalidTransactionException.java
@@ -16,6 +16,7 @@
 
 package com.hedera.node.app.service.evm.exceptions;
 
+import com.hedera.node.app.service.evm.annotations.InterimSPI;
 import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
 import org.apache.tuweni.bytes.Bytes;
 
@@ -27,6 +28,7 @@ import org.apache.tuweni.bytes.Bytes;
  * some form of user error. The {@code FAIL_INVALID} code indicates an internal system error; and it
  * is usually desirable in that case to include a detail message in the constructor.
  */
+@InterimSPI
 public class InvalidTransactionException extends RuntimeException {
 
     private final ResponseCodeEnum responseCode;

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/AbstractCodeCache.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/AbstractCodeCache.java
@@ -20,6 +20,7 @@ import static com.hedera.node.app.service.evm.store.contracts.HederaEvmWorldStat
 
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
+import com.hedera.node.app.service.evm.annotations.InterimSPI;
 import com.hedera.node.app.service.evm.store.contracts.utils.BytesKey;
 import java.util.concurrent.TimeUnit;
 import org.hyperledger.besu.datatypes.Address;
@@ -27,6 +28,7 @@ import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.evm.Code;
 import org.hyperledger.besu.evm.code.CodeFactory;
 
+@InterimSPI
 public class AbstractCodeCache {
     protected final HederaEvmEntityAccess entityAccess;
     protected final Cache<BytesKey, Code> cache;

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/AbstractLedgerEvmWorldUpdater.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/AbstractLedgerEvmWorldUpdater.java
@@ -17,6 +17,7 @@
 package com.hedera.node.app.service.evm.store.contracts;
 
 import com.hedera.node.app.service.evm.accounts.AccountAccessor;
+import com.hedera.node.app.service.evm.annotations.InterimSPI;
 import com.hedera.node.app.service.evm.store.models.UpdatedHederaEvmAccount;
 import java.util.Collection;
 import java.util.Collections;
@@ -31,6 +32,7 @@ import org.hyperledger.besu.evm.worldstate.WorldUpdater;
 import org.hyperledger.besu.evm.worldstate.WorldView;
 import org.hyperledger.besu.evm.worldstate.WrappedEvmAccount;
 
+@InterimSPI
 public abstract class AbstractLedgerEvmWorldUpdater<W extends WorldView, A extends Account> implements WorldUpdater {
 
     protected final W world;

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/HederaEvmEntityAccess.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/HederaEvmEntityAccess.java
@@ -17,9 +17,11 @@
 package com.hedera.node.app.service.evm.store.contracts;
 
 import com.google.protobuf.ByteString;
+import com.hedera.node.app.service.evm.annotations.InterimSPI;
 import org.apache.tuweni.bytes.Bytes;
 import org.hyperledger.besu.datatypes.Address;
 
+@InterimSPI
 public interface HederaEvmEntityAccess {
 
     boolean isUsable(Address address);

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/HederaEvmMutableWorldState.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/HederaEvmMutableWorldState.java
@@ -16,6 +16,7 @@
 
 package com.hedera.node.app.service.evm.store.contracts;
 
+import com.hedera.node.app.service.evm.annotations.InterimSPI;
 import org.hyperledger.besu.evm.worldstate.WorldState;
 import org.hyperledger.besu.evm.worldstate.WorldView;
 
@@ -23,6 +24,7 @@ import org.hyperledger.besu.evm.worldstate.WorldView;
  * Hedera adapted interface for a view over the accounts of the world state and methods for
  * persisting state changes
  */
+@InterimSPI
 public interface HederaEvmMutableWorldState extends WorldState, WorldView {
     /**
      * Creates an updater for this mutable world view.

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/HederaEvmWorldState.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/HederaEvmWorldState.java
@@ -17,6 +17,7 @@
 package com.hedera.node.app.service.evm.store.contracts;
 
 import com.hedera.node.app.service.evm.accounts.AccountAccessor;
+import com.hedera.node.app.service.evm.annotations.InterimSPI;
 import com.hedera.node.app.service.evm.contracts.execution.EvmProperties;
 import com.hedera.node.app.service.evm.store.tokens.TokenAccessor;
 import java.util.stream.Stream;
@@ -27,6 +28,7 @@ import org.hyperledger.besu.datatypes.Wei;
 import org.hyperledger.besu.evm.account.Account;
 import org.hyperledger.besu.evm.worldstate.WorldUpdater;
 
+@InterimSPI
 public class HederaEvmWorldState implements HederaEvmMutableWorldState {
 
     private final HederaEvmEntityAccess hederaEvmEntityAccess;

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/HederaEvmWorldUpdater.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/HederaEvmWorldUpdater.java
@@ -16,6 +16,7 @@
 
 package com.hedera.node.app.service.evm.store.contracts;
 
+import com.hedera.node.app.service.evm.annotations.InterimSPI;
 import org.hyperledger.besu.evm.worldstate.WorldUpdater;
 
 /**
@@ -23,6 +24,7 @@ import org.hyperledger.besu.evm.worldstate.WorldUpdater;
  * org.hyperledger.besu.evm.frame.MessageFrame} in order to provide a layered view for read/writes
  * of the state during EVM transaction execution
  */
+@InterimSPI
 public interface HederaEvmWorldUpdater extends WorldUpdater {
     /**
      * Tracks how much Gas should be refunded to the sender account for the TX. SBH price is

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/precompile/impl/EvmAllowancePrecompile.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/precompile/impl/EvmAllowancePrecompile.java
@@ -24,9 +24,11 @@ import com.esaulpaugh.headlong.abi.ABIType;
 import com.esaulpaugh.headlong.abi.Function;
 import com.esaulpaugh.headlong.abi.Tuple;
 import com.esaulpaugh.headlong.abi.TypeFactory;
+import com.hedera.node.app.service.evm.annotations.InterimSPI;
 import com.hedera.node.app.service.evm.store.contracts.precompile.codec.TokenAllowanceWrapper;
 import org.apache.tuweni.bytes.Bytes;
 
+@InterimSPI
 public interface EvmAllowancePrecompile {
 
     Function ERC_ALLOWANCE_FUNCTION = new Function("allowance(address,address)", INT);

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/precompile/impl/EvmBalanceOfPrecompile.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/precompile/impl/EvmBalanceOfPrecompile.java
@@ -24,9 +24,11 @@ import com.esaulpaugh.headlong.abi.ABIType;
 import com.esaulpaugh.headlong.abi.Function;
 import com.esaulpaugh.headlong.abi.Tuple;
 import com.esaulpaugh.headlong.abi.TypeFactory;
+import com.hedera.node.app.service.evm.annotations.InterimSPI;
 import com.hedera.node.app.service.evm.store.contracts.precompile.codec.BalanceOfWrapper;
 import org.apache.tuweni.bytes.Bytes;
 
+@InterimSPI
 public interface EvmBalanceOfPrecompile {
 
     Function BALANCE_OF_TOKEN_FUNCTION = new Function("balanceOf(address)", INT);

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/precompile/impl/EvmFungibleTokenInfoPrecompile.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/precompile/impl/EvmFungibleTokenInfoPrecompile.java
@@ -23,9 +23,11 @@ import com.esaulpaugh.headlong.abi.ABIType;
 import com.esaulpaugh.headlong.abi.Function;
 import com.esaulpaugh.headlong.abi.Tuple;
 import com.esaulpaugh.headlong.abi.TypeFactory;
+import com.hedera.node.app.service.evm.annotations.InterimSPI;
 import com.hedera.node.app.service.evm.store.contracts.precompile.codec.TokenInfoWrapper;
 import org.apache.tuweni.bytes.Bytes;
 
+@InterimSPI
 public interface EvmFungibleTokenInfoPrecompile {
 
     Function GET_FUNGIBLE_TOKEN_INFO_FUNCTION = new Function("getFungibleTokenInfo(address)");

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/precompile/impl/EvmGetApprovedPrecompile.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/precompile/impl/EvmGetApprovedPrecompile.java
@@ -24,10 +24,12 @@ import com.esaulpaugh.headlong.abi.ABIType;
 import com.esaulpaugh.headlong.abi.Function;
 import com.esaulpaugh.headlong.abi.Tuple;
 import com.esaulpaugh.headlong.abi.TypeFactory;
+import com.hedera.node.app.service.evm.annotations.InterimSPI;
 import com.hedera.node.app.service.evm.store.contracts.precompile.codec.GetApprovedWrapper;
 import java.math.BigInteger;
 import org.apache.tuweni.bytes.Bytes;
 
+@InterimSPI
 public interface EvmGetApprovedPrecompile {
 
     Function ERC_GET_APPROVED_FUNCTION = new Function("getApproved(uint256)", INT);

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/precompile/impl/EvmGetTokenDefaultFreezeStatus.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/precompile/impl/EvmGetTokenDefaultFreezeStatus.java
@@ -24,9 +24,11 @@ import com.esaulpaugh.headlong.abi.ABIType;
 import com.esaulpaugh.headlong.abi.Function;
 import com.esaulpaugh.headlong.abi.Tuple;
 import com.esaulpaugh.headlong.abi.TypeFactory;
+import com.hedera.node.app.service.evm.annotations.InterimSPI;
 import com.hedera.node.app.service.evm.store.contracts.precompile.codec.GetTokenDefaultFreezeStatusWrapper;
 import org.apache.tuweni.bytes.Bytes;
 
+@InterimSPI
 public interface EvmGetTokenDefaultFreezeStatus {
     Function GET_TOKEN_DEFAULT_FREEZE_STATUS_FUNCTION = new Function("getTokenDefaultFreezeStatus(address)", INT);
     Bytes GET_TOKEN_DEFAULT_FREEZE_STATUS_SELECTOR = Bytes.wrap(GET_TOKEN_DEFAULT_FREEZE_STATUS_FUNCTION.selector());

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/precompile/impl/EvmGetTokenDefaultKycStatus.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/precompile/impl/EvmGetTokenDefaultKycStatus.java
@@ -24,9 +24,11 @@ import com.esaulpaugh.headlong.abi.ABIType;
 import com.esaulpaugh.headlong.abi.Function;
 import com.esaulpaugh.headlong.abi.Tuple;
 import com.esaulpaugh.headlong.abi.TypeFactory;
+import com.hedera.node.app.service.evm.annotations.InterimSPI;
 import com.hedera.node.app.service.evm.store.contracts.precompile.codec.GetTokenDefaultKycStatusWrapper;
 import org.apache.tuweni.bytes.Bytes;
 
+@InterimSPI
 public interface EvmGetTokenDefaultKycStatus {
     Function GET_TOKEN_DEFAULT_KYC_STATUS_FUNCTION = new Function("getTokenDefaultKycStatus(address)", INT);
     Bytes GET_TOKEN_DEFAULT_KYC_STATUS_SELECTOR = Bytes.wrap(GET_TOKEN_DEFAULT_KYC_STATUS_FUNCTION.selector());

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/precompile/impl/EvmGetTokenExpiryInfoPrecompile.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/precompile/impl/EvmGetTokenExpiryInfoPrecompile.java
@@ -23,9 +23,11 @@ import com.esaulpaugh.headlong.abi.ABIType;
 import com.esaulpaugh.headlong.abi.Function;
 import com.esaulpaugh.headlong.abi.Tuple;
 import com.esaulpaugh.headlong.abi.TypeFactory;
+import com.hedera.node.app.service.evm.annotations.InterimSPI;
 import com.hedera.node.app.service.evm.store.contracts.precompile.codec.GetTokenExpiryInfoWrapper;
 import org.apache.tuweni.bytes.Bytes;
 
+@InterimSPI
 public interface EvmGetTokenExpiryInfoPrecompile {
     Function GET_TOKEN_EXPIRY_INFO_FUNCTION = new Function("getTokenExpiryInfo(address)");
     Bytes GET_TOKEN_EXPIRY_INFO_SELECTOR = Bytes.wrap(GET_TOKEN_EXPIRY_INFO_FUNCTION.selector());

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/precompile/impl/EvmGetTokenKeyPrecompile.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/precompile/impl/EvmGetTokenKeyPrecompile.java
@@ -23,10 +23,12 @@ import com.esaulpaugh.headlong.abi.ABIType;
 import com.esaulpaugh.headlong.abi.Function;
 import com.esaulpaugh.headlong.abi.Tuple;
 import com.esaulpaugh.headlong.abi.TypeFactory;
+import com.hedera.node.app.service.evm.annotations.InterimSPI;
 import com.hedera.node.app.service.evm.store.contracts.precompile.codec.GetTokenKeyWrapper;
 import java.math.BigInteger;
 import org.apache.tuweni.bytes.Bytes;
 
+@InterimSPI
 public interface EvmGetTokenKeyPrecompile {
     Function GET_TOKEN_KEYS_FUNCTION = new Function("getTokenKey(address,uint256)");
     Bytes GET_TOKEN_KEYS_SELECTOR = Bytes.wrap(GET_TOKEN_KEYS_FUNCTION.selector());

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/precompile/impl/EvmGetTokenTypePrecompile.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/precompile/impl/EvmGetTokenTypePrecompile.java
@@ -23,9 +23,11 @@ import com.esaulpaugh.headlong.abi.ABIType;
 import com.esaulpaugh.headlong.abi.Function;
 import com.esaulpaugh.headlong.abi.Tuple;
 import com.esaulpaugh.headlong.abi.TypeFactory;
+import com.hedera.node.app.service.evm.annotations.InterimSPI;
 import com.hedera.node.app.service.evm.store.contracts.precompile.codec.TokenInfoWrapper;
 import org.apache.tuweni.bytes.Bytes;
 
+@InterimSPI
 public interface EvmGetTokenTypePrecompile {
     Function GET_TOKEN_TYPE_FUNCTION = new Function("getTokenType(address)", "(int,int32)");
     Bytes GET_TOKEN_TYPE_SELECTOR = Bytes.wrap(GET_TOKEN_TYPE_FUNCTION.selector());

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/precompile/impl/EvmIsApprovedForAllPrecompile.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/precompile/impl/EvmIsApprovedForAllPrecompile.java
@@ -24,9 +24,11 @@ import com.esaulpaugh.headlong.abi.ABIType;
 import com.esaulpaugh.headlong.abi.Function;
 import com.esaulpaugh.headlong.abi.Tuple;
 import com.esaulpaugh.headlong.abi.TypeFactory;
+import com.hedera.node.app.service.evm.annotations.InterimSPI;
 import com.hedera.node.app.service.evm.store.contracts.precompile.codec.IsApproveForAllWrapper;
 import org.apache.tuweni.bytes.Bytes;
 
+@InterimSPI
 public interface EvmIsApprovedForAllPrecompile {
 
     Function ERC_IS_APPROVED_FOR_ALL = new Function("isApprovedForAll(address,address)", BOOL);

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/precompile/impl/EvmIsFrozenPrecompile.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/precompile/impl/EvmIsFrozenPrecompile.java
@@ -24,9 +24,11 @@ import com.esaulpaugh.headlong.abi.ABIType;
 import com.esaulpaugh.headlong.abi.Function;
 import com.esaulpaugh.headlong.abi.Tuple;
 import com.esaulpaugh.headlong.abi.TypeFactory;
+import com.hedera.node.app.service.evm.annotations.InterimSPI;
 import com.hedera.node.app.service.evm.store.contracts.precompile.codec.TokenFreezeUnfreezeWrapper;
 import org.apache.tuweni.bytes.Bytes;
 
+@InterimSPI
 public interface EvmIsFrozenPrecompile {
 
     Function IS_FROZEN_TOKEN_FUNCTION = new Function("isFrozen(address,address)", INT_BOOL_PAIR);

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/precompile/impl/EvmIsKycPrecompile.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/precompile/impl/EvmIsKycPrecompile.java
@@ -24,9 +24,11 @@ import com.esaulpaugh.headlong.abi.ABIType;
 import com.esaulpaugh.headlong.abi.Function;
 import com.esaulpaugh.headlong.abi.Tuple;
 import com.esaulpaugh.headlong.abi.TypeFactory;
+import com.hedera.node.app.service.evm.annotations.InterimSPI;
 import com.hedera.node.app.service.evm.store.contracts.precompile.codec.GrantRevokeKycWrapper;
 import org.apache.tuweni.bytes.Bytes;
 
+@InterimSPI
 public interface EvmIsKycPrecompile {
 
     Function IS_KYC_TOKEN_FUNCTION = new Function("isKyc(address,address)", INT_BOOL_PAIR);

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/precompile/impl/EvmIsTokenPrecompile.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/precompile/impl/EvmIsTokenPrecompile.java
@@ -24,9 +24,11 @@ import com.esaulpaugh.headlong.abi.ABIType;
 import com.esaulpaugh.headlong.abi.Function;
 import com.esaulpaugh.headlong.abi.Tuple;
 import com.esaulpaugh.headlong.abi.TypeFactory;
+import com.hedera.node.app.service.evm.annotations.InterimSPI;
 import com.hedera.node.app.service.evm.store.contracts.precompile.codec.TokenInfoWrapper;
 import org.apache.tuweni.bytes.Bytes;
 
+@InterimSPI
 public interface EvmIsTokenPrecompile {
     Function IS_TOKEN_FUNCTION = new Function("isToken(address)", INT_BOOL_PAIR);
     Bytes IS_TOKEN_FUNCTION_SELECTOR = Bytes.wrap(IS_TOKEN_FUNCTION.selector());

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/precompile/impl/EvmNonFungibleTokenInfoPrecompile.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/precompile/impl/EvmNonFungibleTokenInfoPrecompile.java
@@ -22,9 +22,11 @@ import com.esaulpaugh.headlong.abi.ABIType;
 import com.esaulpaugh.headlong.abi.Function;
 import com.esaulpaugh.headlong.abi.Tuple;
 import com.esaulpaugh.headlong.abi.TypeFactory;
+import com.hedera.node.app.service.evm.annotations.InterimSPI;
 import com.hedera.node.app.service.evm.store.contracts.precompile.codec.TokenInfoWrapper;
 import org.apache.tuweni.bytes.Bytes;
 
+@InterimSPI
 public interface EvmNonFungibleTokenInfoPrecompile {
 
     Function GET_NON_FUNGIBLE_TOKEN_INFO_FUNCTION = new Function("getNonFungibleTokenInfo(address,int64)");

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/precompile/impl/EvmOwnerOfPrecompile.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/precompile/impl/EvmOwnerOfPrecompile.java
@@ -24,10 +24,12 @@ import com.esaulpaugh.headlong.abi.ABIType;
 import com.esaulpaugh.headlong.abi.Function;
 import com.esaulpaugh.headlong.abi.Tuple;
 import com.esaulpaugh.headlong.abi.TypeFactory;
+import com.hedera.node.app.service.evm.annotations.InterimSPI;
 import com.hedera.node.app.service.evm.store.contracts.precompile.codec.OwnerOfAndTokenURIWrapper;
 import java.math.BigInteger;
 import org.apache.tuweni.bytes.Bytes;
 
+@InterimSPI
 public interface EvmOwnerOfPrecompile {
 
     Function OWNER_OF_NFT_FUNCTION = new Function("ownerOf(uint256)", INT);

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/precompile/impl/EvmRedirectForTokenPrecompile.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/precompile/impl/EvmRedirectForTokenPrecompile.java
@@ -22,9 +22,11 @@ import com.esaulpaugh.headlong.abi.ABIType;
 import com.esaulpaugh.headlong.abi.Function;
 import com.esaulpaugh.headlong.abi.Tuple;
 import com.esaulpaugh.headlong.abi.TypeFactory;
+import com.hedera.node.app.service.evm.annotations.InterimSPI;
 import com.hedera.node.app.service.evm.store.contracts.precompile.codec.ExplicitRedirectForTokenWrapper;
 import org.apache.tuweni.bytes.Bytes;
 
+@InterimSPI
 public interface EvmRedirectForTokenPrecompile {
     Function REDIRECT_FOR_TOKEN_FUNCTION = new Function("redirectForToken(address,bytes)");
     Bytes REDIRECT_FOR_TOKEN_SELECTOR = Bytes.wrap(REDIRECT_FOR_TOKEN_FUNCTION.selector());

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/precompile/impl/EvmTokenGetCustomFeesPrecompile.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/precompile/impl/EvmTokenGetCustomFeesPrecompile.java
@@ -23,9 +23,11 @@ import com.esaulpaugh.headlong.abi.ABIType;
 import com.esaulpaugh.headlong.abi.Function;
 import com.esaulpaugh.headlong.abi.Tuple;
 import com.esaulpaugh.headlong.abi.TypeFactory;
+import com.hedera.node.app.service.evm.annotations.InterimSPI;
 import com.hedera.node.app.service.evm.store.contracts.precompile.codec.TokenGetCustomFeesWrapper;
 import org.apache.tuweni.bytes.Bytes;
 
+@InterimSPI
 public interface EvmTokenGetCustomFeesPrecompile {
 
     Function TOKEN_GET_CUSTOM_FEES_FUNCTION = new Function("getTokenCustomFees(address)");

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/precompile/impl/EvmTokenInfoPrecompile.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/precompile/impl/EvmTokenInfoPrecompile.java
@@ -23,9 +23,11 @@ import com.esaulpaugh.headlong.abi.ABIType;
 import com.esaulpaugh.headlong.abi.Function;
 import com.esaulpaugh.headlong.abi.Tuple;
 import com.esaulpaugh.headlong.abi.TypeFactory;
+import com.hedera.node.app.service.evm.annotations.InterimSPI;
 import com.hedera.node.app.service.evm.store.contracts.precompile.codec.TokenInfoWrapper;
 import org.apache.tuweni.bytes.Bytes;
 
+@InterimSPI
 public interface EvmTokenInfoPrecompile {
 
     Function GET_TOKEN_INFO_FUNCTION = new Function("getTokenInfo(address)");

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/precompile/impl/EvmTokenURIPrecompile.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/contracts/precompile/impl/EvmTokenURIPrecompile.java
@@ -24,10 +24,12 @@ import com.esaulpaugh.headlong.abi.ABIType;
 import com.esaulpaugh.headlong.abi.Function;
 import com.esaulpaugh.headlong.abi.Tuple;
 import com.esaulpaugh.headlong.abi.TypeFactory;
+import com.hedera.node.app.service.evm.annotations.InterimSPI;
 import com.hedera.node.app.service.evm.store.contracts.precompile.codec.OwnerOfAndTokenURIWrapper;
 import java.math.BigInteger;
 import org.apache.tuweni.bytes.Bytes;
 
+@InterimSPI
 public interface EvmTokenURIPrecompile {
 
     Function TOKEN_URI_NFT_FUNCTION = new Function("tokenURI(uint256)", STRING);

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/models/HederaEvmAccount.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/models/HederaEvmAccount.java
@@ -18,12 +18,14 @@ package com.hedera.node.app.service.evm.store.models;
 
 import com.google.common.base.MoreObjects;
 import com.google.protobuf.ByteString;
+import com.hedera.node.app.service.evm.annotations.InterimSPI;
 import com.hedera.node.app.service.evm.utils.EthSigsUtils;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.tuweni.bytes.Bytes;
 import org.hyperledger.besu.datatypes.Address;
 
+@InterimSPI
 public class HederaEvmAccount {
 
     public static final ByteString ECDSA_KEY_ALIAS_PREFIX = ByteString.copyFrom(new byte[] {0x3a, 0x21});

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/models/UpdatedHederaEvmAccount.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/models/UpdatedHederaEvmAccount.java
@@ -18,6 +18,7 @@ package com.hedera.node.app.service.evm.store.models;
 
 import static org.apache.tuweni.units.bigints.UInt256.ZERO;
 
+import com.hedera.node.app.service.evm.annotations.InterimSPI;
 import com.hedera.node.app.service.evm.store.contracts.HederaEvmEntityAccess;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import java.util.Collections;
@@ -36,6 +37,7 @@ import org.hyperledger.besu.evm.account.AccountStorageEntry;
 import org.hyperledger.besu.evm.account.EvmAccount;
 import org.hyperledger.besu.evm.account.MutableAccount;
 
+@InterimSPI
 public class UpdatedHederaEvmAccount<A extends Account> implements MutableAccount, EvmAccount {
     protected Hash addressHash;
     private Address address;

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/tokens/TokenAccessor.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/store/tokens/TokenAccessor.java
@@ -16,6 +16,7 @@
 
 package com.hedera.node.app.service.evm.store.tokens;
 
+import com.hedera.node.app.service.evm.annotations.InterimSPI;
 import com.hedera.node.app.service.evm.store.contracts.precompile.codec.CustomFee;
 import com.hedera.node.app.service.evm.store.contracts.precompile.codec.EvmKey;
 import com.hedera.node.app.service.evm.store.contracts.precompile.codec.EvmNftInfo;
@@ -25,6 +26,7 @@ import java.util.List;
 import java.util.Optional;
 import org.hyperledger.besu.datatypes.Address;
 
+@InterimSPI
 public interface TokenAccessor {
     Optional<EvmTokenInfo> evmInfoForToken(final Address token);
 


### PR DESCRIPTION
**Description**:

Adds an annotation to identify interfaces/classes that are acceptable for extending _outside_ of the `hedera-evm` module. Only interfaces/classes so identified are extension points.  Thus, use of this annotation declares the `hedera-evm` module SPI (service provider interface).

However: This is only an _interim_ SPI.  A clean SPI is needed (will be designed/provided) in the future.  (And at that time it should be that no annotation is necessary to mark it, other language features - e.g. packages, in particular - will suffice.)

There is no enforcement of this annotation (via an annotation processor) planned.

**Related issue(s)**:

Makes progress towards #5115.  Doesn't fi* it the _right_ way, as mentioned above, but takes a useful step.  (Not marked "fi*ed" so Github doesn't _close_ the issue.)

**Notes for reviewer**:

I verified this manually by inspection of the `hedera-services` and `hedera-mirror-node` repos using IntelliJ `Find Usages` functionality, looking only at those uses which were "Usage in extends/implement clause" and _not_ in `com.hedera.node.app.service.evm`.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [not necessary] Tested (unit, integration, etc.)
