### PR TITLE
Update mainnet settings to enable prometheus

### DIFF
--- a/hedera-node/configuration/mainnet/settings.txt
+++ b/hedera-node/configuration/mainnet/settings.txt
@@ -27,4 +27,5 @@ jasperDb.storagePath,                          /opt/hgcapp/services-hedera/HapiA
 jasperDb.iteratorInputBufferBytes,             16777216
 virtualMap.preferredFlushQueueSize,            10000
 state.mainClassNameOverride,                   com.hedera.services.ServicesMain
+prometheusEndpointEnabled,                     true
 chatter.useChatter,                            false


### PR DESCRIPTION
This PR updates settings.txt to enable the prometheus scrape endpoint. 

As this is now enabled in all configurations, we may also want to consider a follow-up before too long that enables the prometheus scrape endpoint by default.