### PR TITLE
Fix action sidecars missing expected fields

### DIFF
--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/config/PropertyNames.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/config/PropertyNames.java
@@ -100,6 +100,7 @@ public class PropertyNames {
     public static final String CONTRACTS_MAX_NUM = "contracts.maxNumber";
     public static final String CONTRACTS_CHAIN_ID = "contracts.chainId";
     public static final String CONTRACTS_SIDECARS = "contracts.sidecars";
+    public static final String CONTRACTS_SIDECAR_VALIDATION_ENABLED = "contracts.sidecarValidationEnabled";
     public static final String CONTRACTS_THROTTLE_THROTTLE_BY_GAS = "contracts.throttle.throttleByGas";
     public static final String CONTRACTS_MAX_REFUND_PERCENT_OF_GAS_LIMIT = "contracts.maxRefundPercentOfGasLimit";
     public static final String CONTRACTS_SCHEDULE_THROTTLE_MAX_GAS_LIMIT = "contracts.scheduleThrottleMaxGasLimit";

--- a/hedera-node/hedera-app/src/test/resources/bootstrap.properties
+++ b/hedera-node/hedera-app/src/test/resources/bootstrap.properties
@@ -87,6 +87,7 @@ contracts.redirectTokenCalls=true
 contracts.referenceSlotLifetime=31536000
 contracts.scheduleThrottleMaxGasLimit=5000000
 contracts.sidecars=CONTRACT_STATE_CHANGE,CONTRACT_BYTECODE
+contracts.sidecarValidationEnabled=false
 contract.storageSlotPriceTiers=0til100M,2000til450M
 contracts.throttle.throttleByGas=true
 contracts.precompile.atomicCryptoTransfer.enabled=true

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/contracts/execution/HederaEvmTxProcessor.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/contracts/execution/HederaEvmTxProcessor.java
@@ -168,6 +168,8 @@ public abstract class HederaEvmTxProcessor {
         this.gasUsed = calculateGasUsedByTX(gasLimit, initialFrame);
         this.sbhRefund = updater.getSbhRefund();
 
+        tracer.finalizeOperation(initialFrame);
+
         // Externalise result
         if (initialFrame.getState() == MessageFrame.State.COMPLETED_SUCCESS) {
             return HederaEvmTransactionProcessingResult.successful(

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/contracts/execution/traceability/HederaEvmOperationTracer.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/contracts/execution/traceability/HederaEvmOperationTracer.java
@@ -27,4 +27,10 @@ public interface HederaEvmOperationTracer extends OperationTracer {
      * @param initialFrame the initial frame associated with this EVM execution
      */
     default void init(final MessageFrame initialFrame) {}
+
+    /**
+     * Performs finalization/validation/cleanup logic when EVM execution ends.
+     * @param initialFrame - the initial frame associated with this EVM execution (thus the final result is here)
+     */
+    default void finalizeOperation(final MessageFrame initialFrame) {}
 }

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/properties/BootstrapProperties.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/properties/BootstrapProperties.java
@@ -84,6 +84,7 @@ import static com.hedera.node.app.spi.config.PropertyNames.CONTRACTS_REDIRECT_TO
 import static com.hedera.node.app.spi.config.PropertyNames.CONTRACTS_REFERENCE_SLOT_LIFETIME;
 import static com.hedera.node.app.spi.config.PropertyNames.CONTRACTS_SCHEDULE_THROTTLE_MAX_GAS_LIMIT;
 import static com.hedera.node.app.spi.config.PropertyNames.CONTRACTS_SIDECARS;
+import static com.hedera.node.app.spi.config.PropertyNames.CONTRACTS_SIDECAR_VALIDATION_ENABLED;
 import static com.hedera.node.app.spi.config.PropertyNames.CONTRACTS_STORAGE_SLOT_PRICE_TIERS;
 import static com.hedera.node.app.spi.config.PropertyNames.CONTRACTS_THROTTLE_THROTTLE_BY_GAS;
 import static com.hedera.node.app.spi.config.PropertyNames.CRYPTO_CREATE_WITH_ALIAS_AND_EVM_ADDRESS_ENABLED;
@@ -261,6 +262,7 @@ public final class BootstrapProperties implements PropertySource {
         }
         return in;
     };
+
     private static ThrowingStreamProvider fileStreamProvider = loc -> Files.newInputStream(Paths.get(loc));
 
     private final boolean logEnabled;
@@ -443,6 +445,7 @@ public final class BootstrapProperties implements PropertySource {
             CONTRACTS_MAX_NUM,
             CONTRACTS_CHAIN_ID,
             CONTRACTS_SIDECARS,
+            CONTRACTS_SIDECAR_VALIDATION_ENABLED,
             CONTRACTS_STORAGE_SLOT_PRICE_TIERS,
             CONTRACTS_REFERENCE_SLOT_LIFETIME,
             CONTRACTS_ITEMIZE_STORAGE_FEES,
@@ -740,6 +743,7 @@ public final class BootstrapProperties implements PropertySource {
             entry(CONTRACTS_MAX_KV_PAIRS_INDIVIDUAL, AS_INT),
             entry(CONTRACTS_CHAIN_ID, AS_INT),
             entry(CONTRACTS_SIDECARS, AS_SIDECARS),
+            entry(CONTRACTS_SIDECAR_VALIDATION_ENABLED, AS_BOOLEAN),
             entry(CONTRACTS_MAX_REFUND_PERCENT_OF_GAS_LIMIT, AS_INT),
             entry(CONTRACTS_SCHEDULE_THROTTLE_MAX_GAS_LIMIT, AS_LONG),
             entry(CONTRACTS_REDIRECT_TOKEN_CALLS, AS_BOOLEAN),

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/properties/GlobalDynamicProperties.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/properties/GlobalDynamicProperties.java
@@ -60,6 +60,7 @@ import static com.hedera.node.app.spi.config.PropertyNames.CONTRACTS_REDIRECT_TO
 import static com.hedera.node.app.spi.config.PropertyNames.CONTRACTS_REFERENCE_SLOT_LIFETIME;
 import static com.hedera.node.app.spi.config.PropertyNames.CONTRACTS_SCHEDULE_THROTTLE_MAX_GAS_LIMIT;
 import static com.hedera.node.app.spi.config.PropertyNames.CONTRACTS_SIDECARS;
+import static com.hedera.node.app.spi.config.PropertyNames.CONTRACTS_SIDECAR_VALIDATION_ENABLED;
 import static com.hedera.node.app.spi.config.PropertyNames.CONTRACTS_STORAGE_SLOT_PRICE_TIERS;
 import static com.hedera.node.app.spi.config.PropertyNames.CONTRACTS_THROTTLE_THROTTLE_BY_GAS;
 import static com.hedera.node.app.spi.config.PropertyNames.CRYPTO_CREATE_WITH_ALIAS_AND_EVM_ADDRESS_ENABLED;
@@ -261,6 +262,7 @@ public class GlobalDynamicProperties implements EvmProperties {
     private long maxNumSchedules;
     private boolean utilPrngEnabled;
     private Set<SidecarType> enabledSidecars;
+    private boolean sidecarValidationEnabled;
     private boolean requireMinStakeToReward;
     private Map<Long, Long> nodeMaxMinStakeRatios;
     private int sidecarMaxSizeMb;
@@ -368,6 +370,7 @@ public class GlobalDynamicProperties implements EvmProperties {
         create2Enabled = properties.getBooleanProperty(CONTRACTS_ALLOW_CREATE2);
         redirectTokenCalls = properties.getBooleanProperty(CONTRACTS_REDIRECT_TOKEN_CALLS);
         enabledSidecars = properties.getSidecarsProperty(CONTRACTS_SIDECARS);
+        sidecarValidationEnabled = properties.getBooleanProperty(CONTRACTS_SIDECAR_VALIDATION_ENABLED);
         enableAllowances = properties.getBooleanProperty(HEDERA_ALLOWANCES_IS_ENABLED);
         final var autoRenewTargetTypes = properties.getTypesProperty(AUTO_RENEW_TARGET_TYPES);
         expireAccounts = autoRenewTargetTypes.contains(ACCOUNT);
@@ -818,6 +821,10 @@ public class GlobalDynamicProperties implements EvmProperties {
 
     public Set<SidecarType> enabledSidecars() {
         return enabledSidecars;
+    }
+
+    public boolean validateSidecarsEnabled() {
+        return sidecarValidationEnabled;
     }
 
     public boolean requireMinStakeToReward() {

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/contracts/execution/traceability/HederaTracer.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/contracts/execution/traceability/HederaTracer.java
@@ -186,9 +186,6 @@ public class HederaTracer implements HederaOperationTracer {
         actionConfig.accept(action);
 
         allActions.add(action);
-        if (isActionSidecarValidationEnabled() && !action.isValid()) {
-            invalidActions.add(action);
-        }
         currentActionsStack.push(action);
     }
 
@@ -271,6 +268,10 @@ public class HederaTracer implements HederaOperationTracer {
                     }
                 }
                 break;
+        }
+
+        if (isActionSidecarValidationEnabled() && !action.isValid()) {
+            invalidActions.add(action);
         }
     }
 

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/contracts/execution/traceability/HederaTracer.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/contracts/execution/traceability/HederaTracer.java
@@ -28,6 +28,7 @@ import static com.hedera.node.app.service.mono.contracts.execution.traceability.
 import static com.hedera.node.app.service.mono.contracts.execution.traceability.ContractActionType.CREATE;
 import static org.hyperledger.besu.evm.frame.MessageFrame.Type.CONTRACT_CREATION;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.hedera.node.app.service.mono.state.submerkle.EntityId;
 import com.hedera.node.app.service.mono.store.contracts.HederaStackedWorldStateUpdater;
 import java.nio.charset.StandardCharsets;
@@ -37,6 +38,10 @@ import java.util.Deque;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Consumer;
+import java.util.function.Function;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes;
 import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.evm.code.CodeV0;
@@ -49,8 +54,15 @@ import org.hyperledger.besu.evm.operation.Operation.OperationResult;
 
 public class HederaTracer implements HederaOperationTracer {
 
-    private final List<SolidityAction> allActions;
-    private final Deque<SolidityAction> currentActionsStack;
+    private static final Logger log = LogManager.getLogger(HederaTracer.class);
+    private static final Level logLevel = Level.DEBUG;
+
+    @VisibleForTesting
+    protected List<SolidityAction> allActions;
+
+    @VisibleForTesting
+    protected final Deque<SolidityAction> currentActionsStack;
+
     private final boolean areActionSidecarsEnabled;
 
     private static final int OP_CODE_CREATE = 0xF0;
@@ -74,6 +86,34 @@ public class HederaTracer implements HederaOperationTracer {
     }
 
     @Override
+    public void finalizeOperation(final MessageFrame initialFrame) {
+        if (areActionSidecarsEnabled) {
+            // make sure only valid actions are left in allActions
+            final var validActions =
+                    allActions.stream().filter(SolidityAction::isValid).toList();
+
+            // Two possible error conditions are that invalid actions (mainly `oneof` fields that
+            // don't have _exactly_ one alternative set) are added to the set of actions (which can
+            // cause problems when ingesting sidecar records elsewhere) and that the current actions
+            // stack is out-of-sync (due to some error elsewhere).  (The latter condition has not yet
+            // been observed outside deliberate fault injection and probably doesn't happen in a
+            // running system.)
+            if (!currentActionsStack.isEmpty() || validActions.size() != allActions.size()) {
+                log.atLevel(logLevel)
+                        .log(
+                                "Invalid at end of EVM run: {} ({})",
+                                () -> formatAnomaliesAtFinalizationForLog(validActions),
+                                () -> formatFrameContextForLog(initialFrame));
+            }
+
+            // Keep only _valid_ actions (this avoids problems when _ingesting_ action sidecars)
+            if (validActions.size() != allActions.size()) {
+                allActions = validActions;
+            }
+        }
+    }
+
+    @Override
     public void tracePostExecution(final MessageFrame currentFrame, final OperationResult operationResult) {
         if (areActionSidecarsEnabled) {
             final var frameState = currentFrame.getState();
@@ -82,7 +122,8 @@ public class HederaTracer implements HederaOperationTracer {
                     final var nextFrame = currentFrame.getMessageFrameStack().peek();
                     trackInnerActionFor(nextFrame, currentFrame);
                 } else {
-                    finalizeActionFor(currentActionsStack.pop(), currentFrame, frameState);
+                    popActionStack(currentFrame)
+                            .ifPresent(action -> finalizeActionFor(action, currentFrame, frameState));
                 }
             }
         }
@@ -133,76 +174,103 @@ public class HederaTracer implements HederaOperationTracer {
     }
 
     private void finalizeActionFor(final SolidityAction action, final MessageFrame frame, final State frameState) {
-        if (frameState == State.CODE_SUCCESS || frameState == State.COMPLETED_SUCCESS) {
-            action.setGasUsed(action.getGas() - frame.getRemainingGas());
-            // externalize output for calls only - create output is externalized in bytecode sidecar
-            if (action.getCallType() != CREATE) {
-                action.setOutput(frame.getOutputData().toArrayUnsafe());
-                if (action.getInvalidSolidityAddress() != null) {
-                    // we had a successful lazy create, replace targeted address
-                    // with its new Hedera id
-                    final var recipientAsHederaId = EntityId.fromAddress(
-                            asMirrorAddress(Address.wrap(Bytes.of(action.getInvalidSolidityAddress())), frame));
-                    action.setTargetedAddress(null);
-                    action.setRecipientAccount(recipientAsHederaId);
+
+        switch (frameState) {
+            case NOT_STARTED, CODE_EXECUTING, CODE_SUSPENDED:
+                {
+                    // these states are not "final" states needing to finalize the actions
                 }
-            } else {
-                action.setOutput(new byte[0]);
-            }
-        } else if (frameState == State.REVERT) {
-            // deliberate failures do not burn extra gas
-            action.setGasUsed(action.getGas() - frame.getRemainingGas());
-            frame.getRevertReason()
-                    .ifPresentOrElse(
-                            bytes -> action.setRevertReason(bytes.toArrayUnsafe()),
-                            () -> action.setRevertReason(new byte[0]));
-            if (frame.getType().equals(CONTRACT_CREATION)) {
-                action.setRecipientContract(null);
-            }
-        } else if (frameState == State.EXCEPTIONAL_HALT) {
-            // exceptional exits always burn all gas
-            action.setGasUsed(action.getGas());
-            final var exceptionalHaltReasonOptional = frame.getExceptionalHaltReason();
-            if (exceptionalHaltReasonOptional.isPresent()) {
-                final var exceptionalHaltReason = exceptionalHaltReasonOptional.get();
-                action.setError(exceptionalHaltReason.name().getBytes(StandardCharsets.UTF_8));
-                // when a contract tries to call a non-existing address (resulting in a
-                // INVALID_SOLIDITY_ADDRESS failure),
-                // we have to create a synthetic action recording this, otherwise the details of the
-                // intended call
-                // (e.g. the targeted invalid address) and sequence of events leading to the failure
-                // are lost
-                if (action.getCallType().equals(CALL) && exceptionalHaltReason.equals(INVALID_SOLIDITY_ADDRESS)) {
-                    final var syntheticInvalidAction = new SolidityAction(
-                            CALL, frame.getRemainingGas(), null, 0, frame.getMessageStackDepth() + 1);
-                    syntheticInvalidAction.setCallingContract(
-                            EntityId.fromAddress(asMirrorAddress(frame.getContractAddress(), frame)));
-                    syntheticInvalidAction.setTargetedAddress(
-                            Words.toAddress(frame.getStackItem(1)).toArray());
-                    syntheticInvalidAction.setError(
-                            INVALID_SOLIDITY_ADDRESS.name().getBytes(StandardCharsets.UTF_8));
-                    syntheticInvalidAction.setCallOperationType(
-                            toCallOperationType(frame.getCurrentOperation().getOpcode()));
-                    allActions.add(syntheticInvalidAction);
+                break;
+
+            case CODE_SUCCESS, COMPLETED_SUCCESS:
+                {
+                    action.setGasUsed(action.getGas() - frame.getRemainingGas());
+                    // externalize output for calls only - create output is externalized in bytecode sidecar
+                    if (action.getCallType() != CREATE) {
+                        action.setOutput(frame.getOutputData().toArrayUnsafe());
+                        if (action.getInvalidSolidityAddress() != null) {
+                            // we had a successful lazy create, replace targeted address
+                            // with its new Hedera id
+                            final var recipientAsHederaId = EntityId.fromAddress(
+                                    asMirrorAddress(Address.wrap(Bytes.of(action.getInvalidSolidityAddress())), frame));
+                            action.setTargetedAddress(null);
+                            action.setRecipientAccount(recipientAsHederaId);
+                        }
+                    } else {
+                        action.setOutput(new byte[0]);
+                    }
                 }
-            } else {
-                action.setError(new byte[0]);
-            }
-            if (frame.getType().equals(CONTRACT_CREATION)) {
-                action.setRecipientContract(null);
-            }
+                break;
+
+            case REVERT:
+                {
+                    // deliberate failures do not burn extra gas
+                    action.setGasUsed(action.getGas() - frame.getRemainingGas());
+                    frame.getRevertReason()
+                            .ifPresentOrElse(
+                                    bytes -> action.setRevertReason(bytes.toArrayUnsafe()),
+                                    () -> action.setRevertReason(new byte[0]));
+                    if (frame.getType().equals(CONTRACT_CREATION)) {
+                        action.setTargetedAddress(
+                                action.getRecipientContract().toEvmAddress().toArray());
+                        action.setRecipientContract(null);
+                    }
+                }
+                break;
+
+            case EXCEPTIONAL_HALT, COMPLETED_FAILED:
+                {
+                    // exceptional exits always burn all gas
+                    action.setGasUsed(action.getGas());
+                    final var exceptionalHaltReasonOptional = frame.getExceptionalHaltReason();
+                    if (exceptionalHaltReasonOptional.isPresent()) {
+                        final var exceptionalHaltReason = exceptionalHaltReasonOptional.get();
+                        action.setError(exceptionalHaltReason.name().getBytes(StandardCharsets.UTF_8));
+                        // when a contract tries to call a non-existing address (resulting in a
+                        // INVALID_SOLIDITY_ADDRESS failure),
+                        // we have to create a synthetic action recording this, otherwise the details of the
+                        // intended call
+                        // (e.g. the targeted invalid address) and sequence of events leading to the failure
+                        // are lost
+                        if (action.getCallType().equals(CALL)
+                                && exceptionalHaltReason.equals(INVALID_SOLIDITY_ADDRESS)) {
+                            final var syntheticInvalidAction = new SolidityAction(
+                                    CALL, frame.getRemainingGas(), null, 0, frame.getMessageStackDepth() + 1);
+                            syntheticInvalidAction.setGasUsed(0L);
+                            syntheticInvalidAction.setCallingContract(
+                                    EntityId.fromAddress(asMirrorAddress(frame.getContractAddress(), frame)));
+                            syntheticInvalidAction.setTargetedAddress(
+                                    Words.toAddress(frame.getStackItem(1)).toArray());
+                            syntheticInvalidAction.setError(
+                                    INVALID_SOLIDITY_ADDRESS.name().getBytes(StandardCharsets.UTF_8));
+                            syntheticInvalidAction.setCallOperationType(toCallOperationType(
+                                    frame.getCurrentOperation().getOpcode()));
+                            allActions.add(syntheticInvalidAction);
+                        }
+                    } else {
+                        action.setError(new byte[0]);
+                    }
+                    if (frame.getType().equals(CONTRACT_CREATION)) {
+                        // TODO: Is this the correct semantics?
+                        action.setTargetedAddress(
+                                action.getRecipientContract().toEvmAddress().toArray());
+                        action.setRecipientContract(null);
+                    }
+                }
+                break;
         }
     }
 
     @Override
     public void tracePrecompileResult(final MessageFrame frame, final ContractActionType type) {
         if (areActionSidecarsEnabled) {
-            final var lastAction = currentActionsStack.pop();
-            lastAction.setCallType(type);
-            lastAction.setRecipientAccount(null);
-            lastAction.setTargetedAddress(null);
-            lastAction.setRecipientContract(EntityId.fromAddress(frame.getContractAddress()));
-            finalizeActionFor(lastAction, frame, frame.getState());
+            popActionStack(frame).ifPresent(lastAction -> {
+                lastAction.setCallType(type);
+                lastAction.setRecipientAccount(null);
+                lastAction.setTargetedAddress(null);
+                lastAction.setRecipientContract(EntityId.fromAddress(frame.getContractAddress()));
+                finalizeActionFor(lastAction, frame, frame.getState());
+            });
         }
     }
 
@@ -247,5 +315,51 @@ public class HederaTracer implements HederaOperationTracer {
     private Address asMirrorAddress(final Address addressOrAlias, final MessageFrame messageFrame) {
         final var aliases = ((HederaStackedWorldStateUpdater) messageFrame.getWorldUpdater()).aliases();
         return aliases.resolveForEvm(addressOrAlias);
+    }
+
+    private Optional<SolidityAction> popActionStack(final MessageFrame frame) {
+        if (!currentActionsStack.isEmpty()) {
+            return Optional.of(currentActionsStack.pop());
+        } else {
+            log.atLevel(logLevel).log("Action stack prematurely empty ({})", () -> formatFrameContextForLog(frame));
+            return Optional.empty();
+        }
+    }
+
+    private String formatAnomaliesAtFinalizationForLog(final List<SolidityAction> validActions) {
+        final var msgs = new ArrayList<String>();
+        if (!this.currentActionsStack.isEmpty())
+            msgs.add("currentActionsStack not empty, has %d elements left".formatted(this.currentActionsStack.size()));
+        if (validActions.size() != this.allActions.size()) {
+            msgs.add("of %d actions given, %d were invalid"
+                    .formatted(this.allActions.size(), this.allActions.size() - validActions.size()));
+            final var invalidActions = new ArrayList<>(allActions);
+            invalidActions.removeIf(SolidityAction::isValid);
+            for (final var ia : invalidActions) {
+                msgs.add("invalid: %s".formatted(ia.toFullString()));
+            }
+        }
+        return String.join("; ", msgs);
+    }
+
+    private static String formatFrameContextForLog(final MessageFrame frame) {
+        if (null == frame) return "<no frame for context>";
+
+        final Function<Address, String> addressToString = Address::toUnprefixedHexString;
+
+        final var originator = get(frame, MessageFrame::getOriginatorAddress, addressToString);
+        final var sender = get(frame, MessageFrame::getSenderAddress, addressToString);
+        final var recipient = get(frame, MessageFrame::getRecipientAddress, addressToString);
+        final var contract = get(frame, MessageFrame::getContractAddress, addressToString);
+        final var type = get(frame, MessageFrame::getType, Object::toString);
+        final var state = get(frame, MessageFrame::getState, Object::toString);
+
+        return "originator %s sender %s recipient %s contract %s type %s state %s"
+                .formatted(originator, sender, recipient, contract, type, state);
+    }
+
+    private static <E, I> String get(
+            final E subject, final Function<E, I> getter, final Function<I, String> processor) {
+        return null != subject ? processor.compose(getter).apply(subject) : "null";
     }
 }

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/contracts/execution/traceability/SolidityAction.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/contracts/execution/traceability/SolidityAction.java
@@ -37,7 +37,7 @@ public class SolidityAction {
     private EntityId recipientContract;
     private byte[] invalidSolidityAddress;
     private final long value;
-    private Long gasUsed;
+    private long gasUsed = 0L;
     private byte[] output;
     private byte[] revertReason;
     private byte[] error;
@@ -60,14 +60,15 @@ public class SolidityAction {
     /**
      * Check that the fields are set correctly for the semantics of the underlying protobuf
      *
-     * (Respecting, for example, protobuf `oneof` unions...)
+     * Respecting, for example, protobuf `oneof` unions... (but allowing for `oneof recipient` to be missing
+     * entirely, because that's ok)
      */
     public boolean isValid() {
         boolean ok = true;
         ok &= null != getCallType() && ContractActionType.NO_ACTION != getCallType();
         ok &= 1 == countNonNulls(getCallingAccount(), getCallingContract());
         ok &= null != getInput();
-        ok &= 1 == countNonNulls(getRecipientAccount(), getRecipientContract(), getInvalidSolidityAddress());
+        ok &= 1 >= countNonNulls(getRecipientAccount(), getRecipientContract(), getInvalidSolidityAddress());
         ok &= 1 == countNonNulls(getOutput(), getRevertReason(), getError());
         ok &= null != getCallOperationType() && CallOperationType.OP_UNKNOWN != getCallOperationType();
         return ok;
@@ -192,7 +193,7 @@ public class SolidityAction {
     }
 
     public long getGasUsed() {
-        return null != gasUsed ? gasUsed : 0L;
+        return gasUsed;
     }
 
     public byte[] getRevertReason() {

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/contracts/execution/traceability/SolidityAction.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/contracts/execution/traceability/SolidityAction.java
@@ -19,6 +19,11 @@ package com.hedera.node.app.service.mono.contracts.execution.traceability;
 import com.hedera.node.app.hapi.utils.ByteStringUtils;
 import com.hedera.node.app.service.mono.state.submerkle.EntityId;
 import com.hedera.services.stream.proto.ContractAction;
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+import org.apache.tuweni.bytes.Bytes;
 
 public class SolidityAction {
     private static final byte[] MISSING_BYTES = new byte[0];
@@ -32,7 +37,7 @@ public class SolidityAction {
     private EntityId recipientContract;
     private byte[] invalidSolidityAddress;
     private final long value;
-    private long gasUsed;
+    private Long gasUsed;
     private byte[] output;
     private byte[] revertReason;
     private byte[] error;
@@ -50,6 +55,52 @@ public class SolidityAction {
         this.input = input == null ? MISSING_BYTES : input;
         this.value = value;
         this.callDepth = callDepth;
+    }
+
+    /**
+     * Check that the fields are set correctly for the semantics of the underlying protobuf
+     *
+     * (Respecting, for example, protobuf `oneof` unions...)
+     */
+    public boolean isValid() {
+        boolean ok = true;
+        ok &= null != getCallType() && ContractActionType.NO_ACTION != getCallType();
+        ok &= 1 == countNonNulls(getCallingAccount(), getCallingContract());
+        ok &= null != getInput();
+        ok &= 1 == countNonNulls(getRecipientAccount(), getRecipientContract(), getInvalidSolidityAddress());
+        ok &= 1 == countNonNulls(getOutput(), getRevertReason(), getError());
+        ok &= null != getCallOperationType() && CallOperationType.OP_UNKNOWN != getCallOperationType();
+        return ok;
+    }
+
+    public String toFullString() {
+        final var sb = new StringBuilder();
+
+        Function<Object, String> fobj = o -> null != o ? o.toString() : "<null>";
+        Function<byte[], String> fbytes =
+                b -> null != b ? (0 != b.length ? Bytes.wrap(b).toHexString() : "<empty>") : "<null>";
+        BiConsumer<String, Object> ff =
+                (n, o) -> sb.append("%s: %s, ".formatted(n, o instanceof byte[] b ? fbytes.apply(b) : fobj.apply(o)));
+
+        sb.append("SolidityAction(");
+        ff.accept("callType", callType);
+        ff.accept("callOperationType", callOperationType);
+        ff.accept("value", value);
+        ff.accept("gas", gas);
+        ff.accept("gasUsed", gasUsed);
+        ff.accept("callDepth", callDepth);
+        ff.accept("callingAccount", callingAccount);
+        ff.accept("callingContract", callingContract);
+        ff.accept("recipientAccount", recipientAccount);
+        ff.accept("recipientContract", recipientContract);
+        ff.accept("invalidSolidityAddress (aka targetedAddress)", invalidSolidityAddress);
+        ff.accept("input", input);
+        ff.accept("output", output);
+        ff.accept("revertReason", revertReason);
+        ff.accept("error", error);
+        sb.setLength(sb.length() - 2);
+        sb.append(")");
+        return sb.toString();
     }
 
     public ContractActionType getCallType() {
@@ -141,7 +192,7 @@ public class SolidityAction {
     }
 
     public long getGasUsed() {
-        return gasUsed;
+        return null != gasUsed ? gasUsed : 0L;
     }
 
     public byte[] getRevertReason() {
@@ -174,7 +225,7 @@ public class SolidityAction {
             grpc.setTargetedAddress(ByteStringUtils.wrapUnsafely(invalidSolidityAddress));
         }
         grpc.setValue(value);
-        grpc.setGasUsed(gasUsed);
+        grpc.setGasUsed(getGasUsed());
         if (output != null) {
             grpc.setOutput(ByteStringUtils.wrapUnsafely(output));
         } else if (revertReason != null) {
@@ -186,5 +237,9 @@ public class SolidityAction {
         grpc.setCallOperationType(
                 com.hedera.services.stream.proto.CallOperationType.forNumber(callOperationType.ordinal()));
         return grpc.build();
+    }
+
+    private static long countNonNulls(Object... objs) {
+        return Arrays.stream(objs).filter(Objects::nonNull).count();
     }
 }

--- a/hedera-node/hedera-mono-service/src/main/resources/bootstrap.properties
+++ b/hedera-node/hedera-mono-service/src/main/resources/bootstrap.properties
@@ -87,6 +87,7 @@ contracts.redirectTokenCalls=true
 contracts.referenceSlotLifetime=31536000
 contracts.scheduleThrottleMaxGasLimit=5000000
 contracts.sidecars=CONTRACT_STATE_CHANGE,CONTRACT_BYTECODE,CONTRACT_ACTION
+contracts.sidecarValidationEnabled=false
 contract.storageSlotPriceTiers=0til100M,2000til450M
 contracts.throttle.throttleByGas=true
 contracts.precompile.atomicCryptoTransfer.enabled=false

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/context/properties/BootstrapPropertiesTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/context/properties/BootstrapPropertiesTest.java
@@ -90,6 +90,7 @@ import static com.hedera.node.app.spi.config.PropertyNames.CONTRACTS_REDIRECT_TO
 import static com.hedera.node.app.spi.config.PropertyNames.CONTRACTS_REFERENCE_SLOT_LIFETIME;
 import static com.hedera.node.app.spi.config.PropertyNames.CONTRACTS_SCHEDULE_THROTTLE_MAX_GAS_LIMIT;
 import static com.hedera.node.app.spi.config.PropertyNames.CONTRACTS_SIDECARS;
+import static com.hedera.node.app.spi.config.PropertyNames.CONTRACTS_SIDECAR_VALIDATION_ENABLED;
 import static com.hedera.node.app.spi.config.PropertyNames.CONTRACTS_STORAGE_SLOT_PRICE_TIERS;
 import static com.hedera.node.app.spi.config.PropertyNames.CONTRACTS_THROTTLE_THROTTLE_BY_GAS;
 import static com.hedera.node.app.spi.config.PropertyNames.CRYPTO_CREATE_WITH_ALIAS_AND_EVM_ADDRESS_ENABLED;
@@ -489,6 +490,7 @@ class BootstrapPropertiesTest {
             entry(TOKENS_MAX_AGGREGATE_RELS, 10_000_000L),
             entry(UTIL_PRNG_IS_ENABLED, true),
             entry(CONTRACTS_SIDECARS, EnumSet.of(SidecarType.CONTRACT_STATE_CHANGE, SidecarType.CONTRACT_BYTECODE)),
+            entry(CONTRACTS_SIDECAR_VALIDATION_ENABLED, false),
             entry(HEDERA_RECORD_STREAM_SIDECAR_MAX_SIZE_MB, 256),
             entry(HEDERA_RECORD_STREAM_ENABLE_TRACEABILITY_MIGRATION, true),
             entry(TRACEABILITY_MIN_FREE_TO_USED_GAS_THROTTLE_RATIO, 9L),

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/contracts/execution/SolidityActionTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/contracts/execution/SolidityActionTest.java
@@ -50,6 +50,8 @@ class SolidityActionTest {
 
     @Test
     void isValidTest() {
+        // "gasUsed" and missing "oneof recipient" omitted in these tests because those are okay never having been set
+
         final byte[] BYTES = new byte[5];
         record SACtor(boolean good, Supplier<SolidityAction> ctor) {}
         final var ctors = Map.of(
@@ -69,36 +71,27 @@ class SolidityActionTest {
                 "recipientAccount", sa -> sa.setRecipientAccount(sender),
                 "recipientContract", sa -> sa.setRecipientContract(sender),
                 "invalidSolidityAddress", sa -> sa.setTargetedAddress(BYTES),
-                "gasUsed", sa -> sa.setGasUsed(10),
                 "output", sa -> sa.setOutput(BYTES),
                 "revertReason", sa -> sa.setRevertReason(BYTES),
                 "error", sa -> sa.setError(BYTES),
                 "callOperationType", sa -> sa.setCallOperationType(CallOperationType.OP_DELEGATECALL));
         record SAFields(boolean good, String... fields) {}
         final var fields = List.<SAFields>of(
-                new SAFields(true, "callingAccount", "recipientAccount", "gasUsed", "output", "callOperationType"),
+                new SAFields(true, "callingAccount", "recipientAccount", "output", "callOperationType"),
+                new SAFields(true, "callingContract", "recipientContract", "revertReason", "callOperationType"),
+                new SAFields(true, "callingAccount", "invalidSolidityAddress", "error", "callOperationType"),
+                new SAFields(true, "callingContract", "recipientAccount", "revertReason", "callOperationType"),
+                new SAFields(true, "callingAccount", "recipientContract", "output", "callOperationType"),
+                new SAFields(false, "recipientAccount", "output", "callOperationType"),
+                new SAFields(true, "callingAccount", "error", "callOperationType"),
                 new SAFields(
-                        true, "callingContract", "recipientContract", "gasUsed", "revertReason", "callOperationType"),
-                new SAFields(true, "callingAccount", "invalidSolidityAddress", "gasUsed", "error", "callOperationType"),
-                new SAFields(
-                        true, "callingContract", "recipientAccount", "gasUsed", "revertReason", "callOperationType"),
-                new SAFields(true, "callingAccount", "recipientContract", "gasUsed", "output", "callOperationType"),
-                new SAFields(false, "recipientAccount", "gasUsed", "output", "callOperationType"),
-                new SAFields(
-                        false,
-                        "callingAccount",
-                        "callingContract",
-                        "recipientAccount",
-                        "gasUsed",
-                        "output",
-                        "callOperationType"),
-                new SAFields(false, "callingAccount", "gasUsed", "output", "callOperationType"),
+                        false, "callingAccount", "callingContract", "recipientAccount", "output", "callOperationType"),
+                new SAFields(true, "callingAccount", "output", "callOperationType"),
                 new SAFields(
                         false,
                         "callingAccount",
                         "recipientAccount",
                         "invalidSolidityAddress",
-                        "gasUsed",
                         "output",
                         "callOperationType"),
                 new SAFields(
@@ -107,37 +100,22 @@ class SolidityActionTest {
                         "recipientAccount",
                         "recipientContract",
                         "invalidSolidityAddress",
-                        "gasUsed",
                         "output",
                         "callOperationType"),
-                new SAFields(false, "callingAccount", "recipientContract", "output", "callOperationType"),
-                new SAFields(false, "callingContract", "invalidSolidityAddress", "gasUsed", "callOperationType"),
+                new SAFields(false, "callingContract", "invalidSolidityAddress", "callOperationType"),
                 new SAFields(
-                        false,
-                        "callingAccount",
-                        "recipientAccount",
-                        "gasUsed",
-                        "output",
-                        "revertReason",
-                        "callOperationType"),
+                        false, "callingAccount", "recipientAccount", "output", "revertReason", "callOperationType"),
                 new SAFields(
-                        false,
-                        "callingContract",
-                        "recipientContract",
-                        "gasUsed",
-                        "revertReason",
-                        "error",
-                        "callOperationType"),
+                        false, "callingContract", "recipientContract", "revertReason", "error", "callOperationType"),
                 new SAFields(
                         false,
                         "callingAccount",
                         "invalidSolidityAddress",
-                        "gasUsed",
                         "output",
                         "revertReason",
                         "error",
                         "callOperationType"),
-                new SAFields(false, "callingContract", "recipientAccount", "gasUsed", "output"));
+                new SAFields(false, "callingContract", "recipientAccount", "output"));
 
         // sanity check validity of 'fields' test cases
         assertThat(fields.stream()
@@ -173,7 +151,7 @@ class SolidityActionTest {
         }
         softly.assertAll();
         assertThat(ncases).isEqualTo(80);
-        assertThat(ngood).isEqualTo(15);
+        assertThat(ngood).isEqualTo(21);
     }
 
     @Test
@@ -259,7 +237,7 @@ class SolidityActionTest {
                 .isEqualTo(
                         """
                 SolidityAction(callType: CREATE, callOperationType: <null>, value: 11, gas: 7, \
-                gasUsed: <null>, callDepth: 13, callingAccount: <null>, callingContract: <null>, \
+                gasUsed: 0, callDepth: 13, callingAccount: <null>, callingContract: <null>, \
                 recipientAccount: <null>, recipientContract: <null>, invalidSolidityAddress \
                 (aka targetedAddress): <null>, input: <empty>, output: <null>, \
                 revertReason: <null>, error: <null>)\

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/contracts/execution/SolidityActionTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/contracts/execution/SolidityActionTest.java
@@ -16,6 +16,9 @@
 
 package com.hedera.node.app.service.mono.contracts.execution;
 
+import static com.hedera.node.app.service.mono.contracts.execution.traceability.CallOperationType.OP_CREATE;
+import static com.hedera.node.app.service.mono.contracts.execution.traceability.ContractActionType.CREATE;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.hedera.node.app.hapi.utils.ByteStringUtils;
@@ -26,6 +29,12 @@ import com.hedera.node.app.service.mono.state.submerkle.EntityId;
 import com.hedera.node.app.service.mono.utils.EntityIdUtils;
 import com.hedera.services.stream.proto.ContractAction;
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+import org.assertj.core.api.SoftAssertions;
 import org.hyperledger.besu.datatypes.Address;
 import org.junit.jupiter.api.Test;
 
@@ -38,7 +47,134 @@ class SolidityActionTest {
     private final long value = 55L;
     private final long gasUsed = 555L;
     private final long gas = 100L;
-    ;
+
+    @Test
+    void isValidTest() {
+        final byte[] BYTES = new byte[5];
+        record SACtor(boolean good, Supplier<SolidityAction> ctor) {}
+        final var ctors = Map.of(
+                "good",
+                new SACtor(true, () -> new SolidityAction(CREATE, 5, BYTES, 7, 10)),
+                "null call type",
+                new SACtor(false, () -> new SolidityAction(null, 5, BYTES, 7, 10)),
+                "bad call type",
+                new SACtor(false, () -> new SolidityAction(ContractActionType.NO_ACTION, 5, BYTES, 7, 10)),
+                "bad input", /* true because this one case is _fixed_ by SolidityAction's constructor */
+                new SACtor(true, () -> new SolidityAction(CREATE, 5, null, 7, 10)),
+                "good but empty input",
+                new SACtor(true, () -> new SolidityAction(CREATE, 5, new byte[0], 7, 10)));
+        final var fieldSetters = Map.<String, Consumer<SolidityAction>>of(
+                "callingAccount", sa -> sa.setCallingAccount(sender),
+                "callingContract", sa -> sa.setCallingContract(sender),
+                "recipientAccount", sa -> sa.setRecipientAccount(sender),
+                "recipientContract", sa -> sa.setRecipientContract(sender),
+                "invalidSolidityAddress", sa -> sa.setTargetedAddress(BYTES),
+                "gasUsed", sa -> sa.setGasUsed(10),
+                "output", sa -> sa.setOutput(BYTES),
+                "revertReason", sa -> sa.setRevertReason(BYTES),
+                "error", sa -> sa.setError(BYTES),
+                "callOperationType", sa -> sa.setCallOperationType(CallOperationType.OP_DELEGATECALL));
+        record SAFields(boolean good, String... fields) {}
+        final var fields = List.<SAFields>of(
+                new SAFields(true, "callingAccount", "recipientAccount", "gasUsed", "output", "callOperationType"),
+                new SAFields(
+                        true, "callingContract", "recipientContract", "gasUsed", "revertReason", "callOperationType"),
+                new SAFields(true, "callingAccount", "invalidSolidityAddress", "gasUsed", "error", "callOperationType"),
+                new SAFields(
+                        true, "callingContract", "recipientAccount", "gasUsed", "revertReason", "callOperationType"),
+                new SAFields(true, "callingAccount", "recipientContract", "gasUsed", "output", "callOperationType"),
+                new SAFields(false, "recipientAccount", "gasUsed", "output", "callOperationType"),
+                new SAFields(
+                        false,
+                        "callingAccount",
+                        "callingContract",
+                        "recipientAccount",
+                        "gasUsed",
+                        "output",
+                        "callOperationType"),
+                new SAFields(false, "callingAccount", "gasUsed", "output", "callOperationType"),
+                new SAFields(
+                        false,
+                        "callingAccount",
+                        "recipientAccount",
+                        "invalidSolidityAddress",
+                        "gasUsed",
+                        "output",
+                        "callOperationType"),
+                new SAFields(
+                        false,
+                        "callingContract",
+                        "recipientAccount",
+                        "recipientContract",
+                        "invalidSolidityAddress",
+                        "gasUsed",
+                        "output",
+                        "callOperationType"),
+                new SAFields(false, "callingAccount", "recipientContract", "output", "callOperationType"),
+                new SAFields(false, "callingContract", "invalidSolidityAddress", "gasUsed", "callOperationType"),
+                new SAFields(
+                        false,
+                        "callingAccount",
+                        "recipientAccount",
+                        "gasUsed",
+                        "output",
+                        "revertReason",
+                        "callOperationType"),
+                new SAFields(
+                        false,
+                        "callingContract",
+                        "recipientContract",
+                        "gasUsed",
+                        "revertReason",
+                        "error",
+                        "callOperationType"),
+                new SAFields(
+                        false,
+                        "callingAccount",
+                        "invalidSolidityAddress",
+                        "gasUsed",
+                        "output",
+                        "revertReason",
+                        "error",
+                        "callOperationType"),
+                new SAFields(false, "callingContract", "recipientAccount", "gasUsed", "output"));
+
+        // sanity check validity of 'fields' test cases
+        assertThat(fields.stream()
+                        .map(SAFields::fields)
+                        .flatMap(Arrays::stream)
+                        .distinct()
+                        .filter(k -> !fieldSetters.containsKey(k))
+                        .sorted()
+                        .toList())
+                .as("sanity check that all field names specified in tests are correct has _failed_")
+                .isEmpty();
+
+        // now: test cases are cartesian product of constructor setup plus field setups
+        int ncases = 0;
+        int ngood = 0;
+        final var softly = new SoftAssertions();
+        for (final var ctorNV : ctors.entrySet()) {
+            for (final var field : fields) {
+                boolean expected = ctorNV.getValue().good() && field.good();
+
+                // Construct the SolidityAction with the given constructor values
+                final var sut = ctorNV.getValue().ctor().get();
+                // Set fields to valid values with the given field names
+                for (final var setter : field.fields()) {
+                    fieldSetters.get(setter).accept(sut);
+                }
+                softly.assertThat(sut.isValid())
+                        .as("ctor(%s)[%s]".formatted(ctorNV.getKey(), String.join(",", field.fields())))
+                        .isEqualTo(expected);
+                ncases++;
+                if (expected) ngood++;
+            }
+        }
+        softly.assertAll();
+        assertThat(ncases).isEqualTo(80);
+        assertThat(ngood).isEqualTo(15);
+    }
 
     @Test
     void toGrpcWhenCallingAccountAndRecipientAccountAndOutputAreSet() {
@@ -114,5 +250,43 @@ class SolidityActionTest {
                 .build();
 
         assertEquals(expected, actual.toGrpc());
+    }
+
+    @Test
+    void toFullStringTest() {
+        var sut = new SolidityAction(CREATE, 7, null, 11, 13);
+        assertThat(sut.toFullString())
+                .isEqualTo(
+                        """
+                SolidityAction(callType: CREATE, callOperationType: <null>, value: 11, gas: 7, \
+                gasUsed: <null>, callDepth: 13, callingAccount: <null>, callingContract: <null>, \
+                recipientAccount: <null>, recipientContract: <null>, invalidSolidityAddress \
+                (aka targetedAddress): <null>, input: <empty>, output: <null>, \
+                revertReason: <null>, error: <null>)\
+                """);
+
+        sut = new SolidityAction(CREATE, 7, new byte[] {0x20, 0x21, 0x22}, 11, 13);
+        sut.setCallOperationType(OP_CREATE);
+        sut.setGasUsed(17);
+        sut.setCallingAccount(EntityId.fromNum(1234));
+        sut.setCallingContract(EntityId.fromNum(2345));
+        sut.setRecipientAccount(EntityId.fromNum(3456));
+        sut.setRecipientContract(EntityId.fromNum(4567));
+        sut.setTargetedAddress(new byte[] {0x10, 0x11, 0x12});
+        sut.setOutput(new byte[] {0x30, 0x31, 0x32});
+        sut.setRevertReason(new byte[] {0x40, 0x41, 0x42});
+        sut.setError(new byte[] {0x50, 0x51, 0x52});
+        assertThat(sut.toFullString())
+                .isEqualTo(
+                        """
+                SolidityAction(callType: CREATE, callOperationType: OP_CREATE, value: 11, gas: 7, \
+                gasUsed: 17, callDepth: 13, callingAccount: EntityId{shard=0, realm=0, num=1234}, \
+                callingContract: EntityId{shard=0, realm=0, num=2345}, \
+                recipientAccount: EntityId{shard=0, realm=0, num=3456}, \
+                recipientContract: EntityId{shard=0, realm=0, num=4567}, \
+                invalidSolidityAddress (aka targetedAddress): 0x101112, \
+                input: 0x202122, output: 0x303132, revertReason: 0x404142, \
+                error: 0x505152)\
+                """);
     }
 }

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/test/extensions/LogCaptor.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/test/extensions/LogCaptor.java
@@ -54,6 +54,10 @@ public class LogCaptor {
         this.logger.setLevel(Level.DEBUG);
     }
 
+    public void clear() {
+        capture.reset();
+    }
+
     public void stopCapture() {
         this.logger.removeAppender(appender);
     }

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/test/extensions/LoggingSubject.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/test/extensions/LoggingSubject.java
@@ -22,8 +22,12 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * In a JUnit5 test extended with the {@link LogCaptureExtension}, denotes the field whose logs
- * should be captured per test method execution.
+ * In a JUnit5 test extended with the {@link LogCaptureExtension}, denotes the
+ * field of a class type whose logs should be captured per test method execution.
+ *
+ * (The field itself isn't used - only its type is needed, to get a
+ * {@link org.apache.logging.log4j.Logger} for that type - thus it need not ever
+ * hold an instance.)
  */
 @Target(ElementType.FIELD)
 @Retention(RetentionPolicy.RUNTIME)

--- a/hedera-node/hedera-mono-service/src/test/resources/bootstrap.properties
+++ b/hedera-node/hedera-mono-service/src/test/resources/bootstrap.properties
@@ -87,6 +87,7 @@ contracts.redirectTokenCalls=true
 contracts.referenceSlotLifetime=31536000
 contracts.scheduleThrottleMaxGasLimit=5000000
 contracts.sidecars=CONTRACT_STATE_CHANGE,CONTRACT_BYTECODE,CONTRACT_ACTION
+contracts.sidecarValidationEnabled=false
 contract.storageSlotPriceTiers=0til100M,2000til450M
 contracts.throttle.throttleByGas=true
 contracts.precompile.atomicCryptoTransfer.enabled=true

--- a/hedera-node/hedera-mono-service/src/test/resources/bootstrap/standard.properties
+++ b/hedera-node/hedera-mono-service/src/test/resources/bootstrap/standard.properties
@@ -84,6 +84,7 @@ contracts.redirectTokenCalls=true
 contracts.referenceSlotLifetime=31536000
 contracts.scheduleThrottleMaxGasLimit=5000000
 contracts.sidecars=CONTRACT_STATE_CHANGE,CONTRACT_BYTECODE
+contracts.sidecarValidationEnabled=false
 expiry.minCycleEntryCapacity=ACCOUNTS_GET,ACCOUNTS_GET_FOR_MODIFY,STORAGE_GET,STORAGE_GET,STORAGE_REMOVE,STORAGE_PUT
 expiry.throttleResource=expiry-throttle.json
 contract.storageSlotPriceTiers=0til100M,2000til450M

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/traceability/TraceabilitySuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/traceability/TraceabilitySuite.java
@@ -4330,6 +4330,8 @@ public class TraceabilitySuite extends HapiSuite {
                                                 .setGas(931868)
                                                 .setCallDepth(1)
                                                 .setGasUsed(201)
+                                                // TODO: need to setTargetedAddress here, but with what???
+                                                // (also scenarios 18 and 20)
                                                 .setRevertReason(EMPTY)
                                                 .build())))));
     }
@@ -4988,12 +4990,12 @@ public class TraceabilitySuite extends HapiSuite {
                     sidecarWatcher.tearDown();
                 }))
                 .then(assertionsHold((spec, assertLog) -> {
-                    assertTrue(sidecarWatcher.thereAreNoMismatchedSidecars(), sidecarWatcher.getErrors());
+                    assertTrue(sidecarWatcher.thereAreNoMismatchedSidecars(), sidecarWatcher.getMismatchErrors());
                     assertTrue(
                             sidecarWatcher.thereAreNoPendingSidecars(),
                             "There are some sidecars that have not been yet"
                                     + " externalized in the sidecar files after all"
-                                    + " specs.");
+                                    + " specs: " + sidecarWatcher.getPendingErrors());
                 }));
     }
 
@@ -5160,6 +5162,14 @@ public class TraceabilitySuite extends HapiSuite {
         final var recordStreamFolderPath = HapiSpec.isRunningInCi()
                 ? HapiSpec.ciPropOverrides().get(RECORD_STREAM_FOLDER_PATH_PROPERTY_KEY)
                 : HapiSpecSetup.getDefaultPropertySource().get(RECORD_STREAM_FOLDER_PATH_PROPERTY_KEY);
+
+        {
+            final var absolutePath =
+                    Paths.get(recordStreamFolderPath).toAbsolutePath().toString();
+            log.info("recordStreamFolderPath from config %s: %s (absolute %s)"
+                    .formatted(HapiSpec.isRunningInCi() ? "CI" : "not CI", recordStreamFolderPath, absolutePath));
+        }
+
         sidecarWatcher = new SidecarWatcher(Paths.get(recordStreamFolderPath));
         sidecarWatcher.watch();
     }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/traceability/TraceabilitySuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/traceability/TraceabilitySuite.java
@@ -4330,8 +4330,6 @@ public class TraceabilitySuite extends HapiSuite {
                                                 .setGas(931868)
                                                 .setCallDepth(1)
                                                 .setGasUsed(201)
-                                                // TODO: need to setTargetedAddress here, but with what???
-                                                // (also scenarios 18 and 20)
                                                 .setRevertReason(EMPTY)
                                                 .build())))));
     }


### PR DESCRIPTION
**Description**:

**_Why_**

Finalization of the contracts actions (as part of the flow of producing `CONTRACT_ACTION` sidecars) was not performed when the frame state == `COMPLETED_FAILURE`. The state diagram in `org.hyperledger.besu.evm.frame.MessageFrame` shows you can't get to `COMPLETED_FAILURE` without going through `EXCEPTIONAL_HALT` - which _was_ being handled. But there we are.

(You can see the BESU state diagram [here](https://github.com/hyperledger/besu/blob/d48403d1852e270b2c58cc867885f448b04e1518/evm/src/main/java/org/hyperledger/besu/evm/frame/MessageFrame.java#L86). It clearly shows you only get to `COMPLETED_FAILURE` by going first to `EXCEPTIONAL_HALT`.  But it shows the same for getting to `COMPLETED_SUCCESS` only after `CODE_SUCCESS` while our _existing_ code [here](https://github.com/hashgraph/hedera-services/blob/1c9e74a9fd1e9892771e53c39c14ce1e05ddaef8/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/contracts/execution/traceability/HederaTracer.java#L136) clearly _does_ test both those alternatives ...)

**_What_**

* Add `COMPLETED_FAILED` state to be the same as s`EXCEPTIONAL_HALT` in `finalizeActionFor()`
   * to handle the case where you can get there _without_ going through `EXCEPTIONAL_HALT` first (contrary to documentation)
   * and changed an if-ladder to a switch so `javac` will tell us if there are any states not handled at all
* Ensure that all action sidecars have correct semantics (i.e., the correct fields supplied, and _all_ of the necessary fields supplied) by construction, and
* Validate that all action sidecars have correct semantics:
  * Add `invalidActions` list in `HederaTracer` to capture actions that failed validation
     * Each action is validated when created or updated 
  * Add `HederaEvmOperationTracer.finalizeOperation(messageFrame initialFrame)` to log all validation failures after all actions for this transaction have been saved in the tracer
  * All this validation work is gated by new dynamic property `contracts.sidecarValidationEnabled` (default is **not enabled**)
    * Pass that property through the `HederaTracer` constructor
    * And since that constructor would otherwise now take two separate boolean flags (and be confusing), updated the signature to take (self-describing) enum values `HederaTracer.EmitActionSidecars` and `HederaTracer.ValidateActionSidecars`


**_Results_**

1. We handle `EXCEPTIONAL_HALT` which is we believe is the state that broke things
1. We now have improved logging to give us an idea of the state in case that occurs or any other state
1. We don't create any actions for states not called out in the switch - and ensure that the switch is complete
1. We have a validation flow to give us coverage of checking action details, notable the oneofs
1. We've got new units tests to confirm that invalid action sidecars are detected and logged


**Related issue(s)**:

Fixes #5169 

**Notes for reviewer**:

Validation is enabled by a new feature flag.  Adding a new feature flag touches a surprising number of files even before you actually _use_ it.

The question of what level to log validation at (if enabled) (and whether it should have a throttle if logged at INFO or higher) is TBD and tracked in #5514 

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
