### PR TITLE
05433 hedera-schedule-service to use PBJ entities

### DIFF
--- a/hedera-node/hedera-schedule-service-impl/src/main/java/com/hedera/node/app/service/schedule/impl/ScheduleServiceImpl.java
+++ b/hedera-node/hedera-schedule-service-impl/src/main/java/com/hedera/node/app/service/schedule/impl/ScheduleServiceImpl.java
@@ -16,6 +16,8 @@
 
 package com.hedera.node.app.service.schedule.impl;
 
+import com.hedera.hapi.node.base.SemanticVersion;
+import com.hedera.node.app.service.mono.state.codec.MonoMapCodecAdapter;
 import com.hedera.node.app.service.mono.state.virtual.EntityNumVirtualKey;
 import com.hedera.node.app.service.mono.state.virtual.EntityNumVirtualKeySerializer;
 import com.hedera.node.app.service.mono.state.virtual.schedule.ScheduleEqualityVirtualKey;
@@ -30,8 +32,6 @@ import com.hedera.node.app.service.schedule.impl.serdes.MonoSchedulingStateAdapt
 import com.hedera.node.app.spi.state.Schema;
 import com.hedera.node.app.spi.state.SchemaRegistry;
 import com.hedera.node.app.spi.state.StateDefinition;
-import com.hedera.node.app.spi.state.serdes.MonoMapCodecAdapter;
-import com.hederahashgraph.api.proto.java.SemanticVersion;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.Set;
 
@@ -40,7 +40,7 @@ import java.util.Set;
  */
 public final class ScheduleServiceImpl implements ScheduleService {
     private static final SemanticVersion CURRENT_VERSION =
-            SemanticVersion.newBuilder().setMinor(34).build();
+            SemanticVersion.newBuilder().minor(34).build();
 
     public static final String SCHEDULING_STATE_KEY = "SCHEDULING_STATE";
     public static final String SCHEDULES_BY_ID_KEY = "SCHEDULES_BY_ID";

--- a/hedera-node/hedera-schedule-service-impl/src/main/java/com/hedera/node/app/service/schedule/impl/serdes/MonoSchedulingStateAdapterCodec.java
+++ b/hedera-node/hedera-schedule-service-impl/src/main/java/com/hedera/node/app/service/schedule/impl/serdes/MonoSchedulingStateAdapterCodec.java
@@ -17,31 +17,40 @@
 package com.hedera.node.app.service.schedule.impl.serdes;
 
 import com.hedera.node.app.service.mono.state.merkle.MerkleScheduledTransactionsState;
+import com.hedera.pbj.runtime.Codec;
+import com.hedera.pbj.runtime.io.DataInput;
+import com.hedera.pbj.runtime.io.DataInputStream;
+import com.hedera.pbj.runtime.io.DataOutput;
+import com.hedera.pbj.runtime.io.DataOutputStream;
 import com.swirlds.common.io.streams.SerializableDataInputStream;
 import com.swirlds.common.io.streams.SerializableDataOutputStream;
 import edu.umd.cs.findbugs.annotations.NonNull;
-import java.io.DataInput;
-import java.io.DataOutput;
 import java.io.IOException;
 
 public class MonoSchedulingStateAdapterCodec implements Codec<MerkleScheduledTransactionsState> {
     @NonNull
     @Override
     public MerkleScheduledTransactionsState parse(final @NonNull DataInput input) throws IOException {
-        if (input instanceof SerializableDataInputStream in) {
+        if (input instanceof DataInputStream in) {
             final var context = new MerkleScheduledTransactionsState();
-            context.deserialize(in, MerkleScheduledTransactionsState.CURRENT_VERSION);
+            context.deserialize(new SerializableDataInputStream(in), MerkleScheduledTransactionsState.CURRENT_VERSION);
             return context;
         } else {
             throw new IllegalArgumentException("Expected a SerializableDataInputStream");
         }
     }
 
+    @NonNull
+    @Override
+    public MerkleScheduledTransactionsState parseStrict(@NonNull final DataInput dataInput) throws IOException {
+        return parse(dataInput);
+    }
+
     @Override
     public void write(final @NonNull MerkleScheduledTransactionsState item, final @NonNull DataOutput output)
             throws IOException {
-        if (output instanceof SerializableDataOutputStream out) {
-            item.serialize(out);
+        if (output instanceof DataOutputStream out) {
+            item.serialize(new SerializableDataOutputStream(out));
         } else {
             throw new IllegalArgumentException("Expected a SerializableDataOutputStream");
         }
@@ -53,7 +62,7 @@ public class MonoSchedulingStateAdapterCodec implements Codec<MerkleScheduledTra
     }
 
     @Override
-    public int typicalSize() {
+    public int measureRecord(final MerkleScheduledTransactionsState merkleScheduledTransactionsState) {
         throw new UnsupportedOperationException();
     }
 

--- a/hedera-node/hedera-schedule-service-impl/src/test/java/com/hedera/node/app/service/schedule/impl/test/ScheduleComponentTest.java
+++ b/hedera-node/hedera-schedule-service-impl/src/test/java/com/hedera/node/app/service/schedule/impl/test/ScheduleComponentTest.java
@@ -16,7 +16,7 @@
 
 package com.hedera.node.app.service.schedule.impl.test;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import com.hedera.node.app.service.schedule.impl.components.DaggerScheduleComponent;
 import com.hedera.node.app.service.schedule.impl.components.ScheduleComponent;

--- a/hedera-node/hedera-schedule-service-impl/src/test/java/com/hedera/node/app/service/schedule/impl/test/handlers/ScheduleDeleteHandlerTest.java
+++ b/hedera-node/hedera-schedule-service-impl/src/test/java/com/hedera/node/app/service/schedule/impl/test/handlers/ScheduleDeleteHandlerTest.java
@@ -19,7 +19,6 @@ package com.hedera.node.app.service.schedule.impl.test.handlers;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_SCHEDULE_ID;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.OK;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.SCHEDULE_IS_IMMUTABLE;
-import static com.hedera.node.app.service.schedule.impl.Utils.asOrdinary;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.BDDMockito.given;
 
@@ -35,7 +34,6 @@ import com.hedera.node.app.service.schedule.impl.ReadableScheduleStore;
 import com.hedera.node.app.service.schedule.impl.handlers.ScheduleDeleteHandler;
 import com.hedera.node.app.spi.KeyOrLookupFailureReason;
 import com.hedera.node.app.spi.workflows.PreHandleContext;
-import com.hedera.node.app.spi.meta.TransactionMetadata;
 import com.hedera.node.app.spi.state.ReadableKVStateBase;
 import java.util.List;
 import java.util.Optional;
@@ -117,14 +115,6 @@ class ScheduleDeleteHandlerTest extends ScheduleHandlerTestBase {
                         TransactionID.newBuilder().accountID(scheduler).build())
                 .cryptoCreateAccount(CryptoCreateTransactionBody.newBuilder().build())
                 .build();
-        scheduledMeta = new TransactionMetadata(
-                asOrdinary(txn.scheduleCreate().orElseThrow().scheduledTransactionBody(), txn.transactionID()),
-                scheduler,
-                OK,
-                schedulerKey,
-                List.of(),
-                null,
-                List.of());
     }
 
     private TransactionBody scheduleDeleteTransaction() {

--- a/hedera-node/hedera-schedule-service-impl/src/test/java/com/hedera/node/app/service/schedule/impl/test/serdes/MonoSchedulingStateAdapterSerdesTest.java
+++ b/hedera-node/hedera-schedule-service-impl/src/test/java/com/hedera/node/app/service/schedule/impl/test/serdes/MonoSchedulingStateAdapterSerdesTest.java
@@ -21,12 +21,12 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.hedera.node.app.service.mono.state.merkle.MerkleScheduledTransactionsState;
 import com.hedera.node.app.service.schedule.impl.serdes.MonoSchedulingStateAdapterCodec;
-import com.swirlds.common.io.streams.SerializableDataInputStream;
-import com.swirlds.common.io.streams.SerializableDataOutputStream;
+import com.hedera.pbj.runtime.io.DataInput;
+import com.hedera.pbj.runtime.io.DataInputStream;
+import com.hedera.pbj.runtime.io.DataOutput;
+import com.hedera.pbj.runtime.io.DataOutputStream;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-import java.io.DataInput;
-import java.io.DataOutput;
 import java.io.IOException;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
@@ -46,7 +46,7 @@ class MonoSchedulingStateAdapterSerdesTest {
 
     @Test
     void doesntSupportUnnecessary() {
-        assertThrows(UnsupportedOperationException.class, subject::typicalSize);
+        assertThrows(UnsupportedOperationException.class, () -> subject.measureRecord(SOME_SCHEDULING_STATE));
         assertThrows(UnsupportedOperationException.class, () -> subject.measure(input));
         assertThrows(UnsupportedOperationException.class, () -> subject.fastEquals(SOME_SCHEDULING_STATE, input));
     }
@@ -54,11 +54,10 @@ class MonoSchedulingStateAdapterSerdesTest {
     @Test
     void canSerializeAndDeserializeFromAppropriateStream() throws IOException {
         final var baos = new ByteArrayOutputStream();
-        final var actualOut = new SerializableDataOutputStream(baos);
+        final DataOutput actualOut = new DataOutputStream(baos);
         subject.write(SOME_SCHEDULING_STATE, actualOut);
-        actualOut.flush();
 
-        final var actualIn = new SerializableDataInputStream(new ByteArrayInputStream(baos.toByteArray()));
+        final var actualIn = new DataInputStream(new ByteArrayInputStream(baos.toByteArray()));
         final var parsed = subject.parse(actualIn);
         assertEquals(SOME_SCHEDULING_STATE.getHash(), parsed.getHash());
     }

--- a/hedera-node/hedera-schedule-service-impl/src/test/java/module-info.java
+++ b/hedera-node/hedera-schedule-service-impl/src/test/java/module-info.java
@@ -5,6 +5,7 @@ module com.hedera.node.app.service.schedule.impl.test {
     requires transitive com.hedera.node.app.service.schedule.impl;
     requires org.mockito;
     requires org.mockito.junit.jupiter;
+    requires dagger;
     requires com.hedera.node.app.service.mono.testFixtures;
     requires org.apache.commons.lang3;
     requires org.apache.commons.codec;


### PR DESCRIPTION
**Description**:

 * Fix compilation for ScheduleServiceImpl and MonoSchedulingStateAdapterCodec
 * Fix compilation for ScheduleComponentTest, ScheduleDeleteHandlerTest, and MonoSchedulingStateAdapterSerdesTest
 * Fix module-info
 * Copied a fix to test fixtures in mono service from @netopyr

**Related issue(s)**:

Fixes #5433 
