### PR TITLE
Action sidecars missing field fix cherry-pick to 0.36

### DIFF
--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/config/PropertyNames.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/config/PropertyNames.java
@@ -100,6 +100,7 @@ public class PropertyNames {
     public static final String CONTRACTS_MAX_NUM = "contracts.maxNumber";
     public static final String CONTRACTS_CHAIN_ID = "contracts.chainId";
     public static final String CONTRACTS_SIDECARS = "contracts.sidecars";
+    public static final String CONTRACTS_SIDECAR_VALIDATION_ENABLED = "contracts.sidecarValidationEnabled";
     public static final String CONTRACTS_THROTTLE_THROTTLE_BY_GAS = "contracts.throttle.throttleByGas";
     public static final String CONTRACTS_MAX_REFUND_PERCENT_OF_GAS_LIMIT = "contracts.maxRefundPercentOfGasLimit";
     public static final String CONTRACTS_SCHEDULE_THROTTLE_MAX_GAS_LIMIT = "contracts.scheduleThrottleMaxGasLimit";

--- a/hedera-node/hedera-app/src/test/resources/bootstrap.properties
+++ b/hedera-node/hedera-app/src/test/resources/bootstrap.properties
@@ -87,6 +87,7 @@ contracts.redirectTokenCalls=true
 contracts.referenceSlotLifetime=31536000
 contracts.scheduleThrottleMaxGasLimit=5000000
 contracts.sidecars=CONTRACT_STATE_CHANGE,CONTRACT_BYTECODE
+contracts.sidecarValidationEnabled=false
 contract.storageSlotPriceTiers=0til100M,2000til450M
 contracts.throttle.throttleByGas=true
 contracts.precompile.atomicCryptoTransfer.enabled=true

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/contracts/execution/HederaEvmTxProcessor.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/contracts/execution/HederaEvmTxProcessor.java
@@ -168,6 +168,8 @@ public abstract class HederaEvmTxProcessor {
         this.gasUsed = calculateGasUsedByTX(gasLimit, initialFrame);
         this.sbhRefund = updater.getSbhRefund();
 
+        tracer.finalizeOperation(initialFrame);
+
         // Externalise result
         if (initialFrame.getState() == MessageFrame.State.COMPLETED_SUCCESS) {
             return HederaEvmTransactionProcessingResult.successful(

--- a/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/contracts/execution/traceability/HederaEvmOperationTracer.java
+++ b/hedera-node/hedera-evm/src/main/java/com/hedera/node/app/service/evm/contracts/execution/traceability/HederaEvmOperationTracer.java
@@ -27,4 +27,10 @@ public interface HederaEvmOperationTracer extends OperationTracer {
      * @param initialFrame the initial frame associated with this EVM execution
      */
     default void init(final MessageFrame initialFrame) {}
+
+    /**
+     * Performs finalization/validation/cleanup logic when EVM execution ends.
+     * @param initialFrame - the initial frame associated with this EVM execution (thus the final result is here)
+     */
+    default void finalizeOperation(final MessageFrame initialFrame) {}
 }

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/properties/BootstrapProperties.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/properties/BootstrapProperties.java
@@ -84,6 +84,7 @@ import static com.hedera.node.app.spi.config.PropertyNames.CONTRACTS_REDIRECT_TO
 import static com.hedera.node.app.spi.config.PropertyNames.CONTRACTS_REFERENCE_SLOT_LIFETIME;
 import static com.hedera.node.app.spi.config.PropertyNames.CONTRACTS_SCHEDULE_THROTTLE_MAX_GAS_LIMIT;
 import static com.hedera.node.app.spi.config.PropertyNames.CONTRACTS_SIDECARS;
+import static com.hedera.node.app.spi.config.PropertyNames.CONTRACTS_SIDECAR_VALIDATION_ENABLED;
 import static com.hedera.node.app.spi.config.PropertyNames.CONTRACTS_STORAGE_SLOT_PRICE_TIERS;
 import static com.hedera.node.app.spi.config.PropertyNames.CONTRACTS_THROTTLE_THROTTLE_BY_GAS;
 import static com.hedera.node.app.spi.config.PropertyNames.CRYPTO_CREATE_WITH_ALIAS_AND_EVM_ADDRESS_ENABLED;
@@ -261,6 +262,7 @@ public final class BootstrapProperties implements PropertySource {
         }
         return in;
     };
+
     private static ThrowingStreamProvider fileStreamProvider = loc -> Files.newInputStream(Paths.get(loc));
 
     private final boolean logEnabled;
@@ -443,6 +445,7 @@ public final class BootstrapProperties implements PropertySource {
             CONTRACTS_MAX_NUM,
             CONTRACTS_CHAIN_ID,
             CONTRACTS_SIDECARS,
+            CONTRACTS_SIDECAR_VALIDATION_ENABLED,
             CONTRACTS_STORAGE_SLOT_PRICE_TIERS,
             CONTRACTS_REFERENCE_SLOT_LIFETIME,
             CONTRACTS_ITEMIZE_STORAGE_FEES,
@@ -740,6 +743,7 @@ public final class BootstrapProperties implements PropertySource {
             entry(CONTRACTS_MAX_KV_PAIRS_INDIVIDUAL, AS_INT),
             entry(CONTRACTS_CHAIN_ID, AS_INT),
             entry(CONTRACTS_SIDECARS, AS_SIDECARS),
+            entry(CONTRACTS_SIDECAR_VALIDATION_ENABLED, AS_BOOLEAN),
             entry(CONTRACTS_MAX_REFUND_PERCENT_OF_GAS_LIMIT, AS_INT),
             entry(CONTRACTS_SCHEDULE_THROTTLE_MAX_GAS_LIMIT, AS_LONG),
             entry(CONTRACTS_REDIRECT_TOKEN_CALLS, AS_BOOLEAN),

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/properties/GlobalDynamicProperties.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/properties/GlobalDynamicProperties.java
@@ -60,6 +60,7 @@ import static com.hedera.node.app.spi.config.PropertyNames.CONTRACTS_REDIRECT_TO
 import static com.hedera.node.app.spi.config.PropertyNames.CONTRACTS_REFERENCE_SLOT_LIFETIME;
 import static com.hedera.node.app.spi.config.PropertyNames.CONTRACTS_SCHEDULE_THROTTLE_MAX_GAS_LIMIT;
 import static com.hedera.node.app.spi.config.PropertyNames.CONTRACTS_SIDECARS;
+import static com.hedera.node.app.spi.config.PropertyNames.CONTRACTS_SIDECAR_VALIDATION_ENABLED;
 import static com.hedera.node.app.spi.config.PropertyNames.CONTRACTS_STORAGE_SLOT_PRICE_TIERS;
 import static com.hedera.node.app.spi.config.PropertyNames.CONTRACTS_THROTTLE_THROTTLE_BY_GAS;
 import static com.hedera.node.app.spi.config.PropertyNames.CRYPTO_CREATE_WITH_ALIAS_AND_EVM_ADDRESS_ENABLED;
@@ -261,6 +262,7 @@ public class GlobalDynamicProperties implements EvmProperties {
     private long maxNumSchedules;
     private boolean utilPrngEnabled;
     private Set<SidecarType> enabledSidecars;
+    private boolean sidecarValidationEnabled;
     private boolean requireMinStakeToReward;
     private Map<Long, Long> nodeMaxMinStakeRatios;
     private int sidecarMaxSizeMb;
@@ -368,6 +370,7 @@ public class GlobalDynamicProperties implements EvmProperties {
         create2Enabled = properties.getBooleanProperty(CONTRACTS_ALLOW_CREATE2);
         redirectTokenCalls = properties.getBooleanProperty(CONTRACTS_REDIRECT_TOKEN_CALLS);
         enabledSidecars = properties.getSidecarsProperty(CONTRACTS_SIDECARS);
+        sidecarValidationEnabled = properties.getBooleanProperty(CONTRACTS_SIDECAR_VALIDATION_ENABLED);
         enableAllowances = properties.getBooleanProperty(HEDERA_ALLOWANCES_IS_ENABLED);
         final var autoRenewTargetTypes = properties.getTypesProperty(AUTO_RENEW_TARGET_TYPES);
         expireAccounts = autoRenewTargetTypes.contains(ACCOUNT);
@@ -818,6 +821,10 @@ public class GlobalDynamicProperties implements EvmProperties {
 
     public Set<SidecarType> enabledSidecars() {
         return enabledSidecars;
+    }
+
+    public boolean validateSidecarsEnabled() {
+        return sidecarValidationEnabled;
     }
 
     public boolean requireMinStakeToReward() {

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/contracts/execution/traceability/SolidityAction.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/contracts/execution/traceability/SolidityAction.java
@@ -19,6 +19,11 @@ package com.hedera.node.app.service.mono.contracts.execution.traceability;
 import com.hedera.node.app.hapi.utils.ByteStringUtils;
 import com.hedera.node.app.service.mono.state.submerkle.EntityId;
 import com.hedera.services.stream.proto.ContractAction;
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+import org.apache.tuweni.bytes.Bytes;
 
 public class SolidityAction {
     private static final byte[] MISSING_BYTES = new byte[0];
@@ -32,7 +37,7 @@ public class SolidityAction {
     private EntityId recipientContract;
     private byte[] invalidSolidityAddress;
     private final long value;
-    private long gasUsed;
+    private long gasUsed = 0L;
     private byte[] output;
     private byte[] revertReason;
     private byte[] error;
@@ -50,6 +55,53 @@ public class SolidityAction {
         this.input = input == null ? MISSING_BYTES : input;
         this.value = value;
         this.callDepth = callDepth;
+    }
+
+    /**
+     * Check that the fields are set correctly for the semantics of the underlying protobuf
+     *
+     * Respecting, for example, protobuf `oneof` unions... (but allowing for `oneof recipient` to be missing
+     * entirely, because that's ok)
+     */
+    public boolean isValid() {
+        boolean ok = true;
+        ok &= null != getCallType() && ContractActionType.NO_ACTION != getCallType();
+        ok &= 1 == countNonNulls(getCallingAccount(), getCallingContract());
+        ok &= null != getInput();
+        ok &= 1 >= countNonNulls(getRecipientAccount(), getRecipientContract(), getInvalidSolidityAddress());
+        ok &= 1 == countNonNulls(getOutput(), getRevertReason(), getError());
+        ok &= null != getCallOperationType() && CallOperationType.OP_UNKNOWN != getCallOperationType();
+        return ok;
+    }
+
+    public String toFullString() {
+        final var sb = new StringBuilder();
+
+        Function<Object, String> fobj = o -> null != o ? o.toString() : "<null>";
+        Function<byte[], String> fbytes =
+                b -> null != b ? (0 != b.length ? Bytes.wrap(b).toHexString() : "<empty>") : "<null>";
+        BiConsumer<String, Object> ff =
+                (n, o) -> sb.append("%s: %s, ".formatted(n, o instanceof byte[] b ? fbytes.apply(b) : fobj.apply(o)));
+
+        sb.append("SolidityAction(");
+        ff.accept("callType", callType);
+        ff.accept("callOperationType", callOperationType);
+        ff.accept("value", value);
+        ff.accept("gas", gas);
+        ff.accept("gasUsed", gasUsed);
+        ff.accept("callDepth", callDepth);
+        ff.accept("callingAccount", callingAccount);
+        ff.accept("callingContract", callingContract);
+        ff.accept("recipientAccount", recipientAccount);
+        ff.accept("recipientContract", recipientContract);
+        ff.accept("invalidSolidityAddress (aka targetedAddress)", invalidSolidityAddress);
+        ff.accept("input", input);
+        ff.accept("output", output);
+        ff.accept("revertReason", revertReason);
+        ff.accept("error", error);
+        sb.setLength(sb.length() - 2);
+        sb.append(")");
+        return sb.toString();
     }
 
     public ContractActionType getCallType() {
@@ -174,7 +226,7 @@ public class SolidityAction {
             grpc.setTargetedAddress(ByteStringUtils.wrapUnsafely(invalidSolidityAddress));
         }
         grpc.setValue(value);
-        grpc.setGasUsed(gasUsed);
+        grpc.setGasUsed(getGasUsed());
         if (output != null) {
             grpc.setOutput(ByteStringUtils.wrapUnsafely(output));
         } else if (revertReason != null) {
@@ -186,5 +238,9 @@ public class SolidityAction {
         grpc.setCallOperationType(
                 com.hedera.services.stream.proto.CallOperationType.forNumber(callOperationType.ordinal()));
         return grpc.build();
+    }
+
+    private static long countNonNulls(Object... objs) {
+        return Arrays.stream(objs).filter(Objects::nonNull).count();
     }
 }

--- a/hedera-node/hedera-mono-service/src/main/resources/bootstrap.properties
+++ b/hedera-node/hedera-mono-service/src/main/resources/bootstrap.properties
@@ -87,6 +87,7 @@ contracts.redirectTokenCalls=true
 contracts.referenceSlotLifetime=31536000
 contracts.scheduleThrottleMaxGasLimit=5000000
 contracts.sidecars=CONTRACT_STATE_CHANGE,CONTRACT_BYTECODE,CONTRACT_ACTION
+contracts.sidecarValidationEnabled=false
 contract.storageSlotPriceTiers=0til100M,2000til450M
 contracts.throttle.throttleByGas=true
 contracts.precompile.atomicCryptoTransfer.enabled=false

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/context/properties/BootstrapPropertiesTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/context/properties/BootstrapPropertiesTest.java
@@ -90,6 +90,7 @@ import static com.hedera.node.app.spi.config.PropertyNames.CONTRACTS_REDIRECT_TO
 import static com.hedera.node.app.spi.config.PropertyNames.CONTRACTS_REFERENCE_SLOT_LIFETIME;
 import static com.hedera.node.app.spi.config.PropertyNames.CONTRACTS_SCHEDULE_THROTTLE_MAX_GAS_LIMIT;
 import static com.hedera.node.app.spi.config.PropertyNames.CONTRACTS_SIDECARS;
+import static com.hedera.node.app.spi.config.PropertyNames.CONTRACTS_SIDECAR_VALIDATION_ENABLED;
 import static com.hedera.node.app.spi.config.PropertyNames.CONTRACTS_STORAGE_SLOT_PRICE_TIERS;
 import static com.hedera.node.app.spi.config.PropertyNames.CONTRACTS_THROTTLE_THROTTLE_BY_GAS;
 import static com.hedera.node.app.spi.config.PropertyNames.CRYPTO_CREATE_WITH_ALIAS_AND_EVM_ADDRESS_ENABLED;
@@ -489,6 +490,7 @@ class BootstrapPropertiesTest {
             entry(TOKENS_MAX_AGGREGATE_RELS, 10_000_000L),
             entry(UTIL_PRNG_IS_ENABLED, true),
             entry(CONTRACTS_SIDECARS, EnumSet.of(SidecarType.CONTRACT_STATE_CHANGE, SidecarType.CONTRACT_BYTECODE)),
+            entry(CONTRACTS_SIDECAR_VALIDATION_ENABLED, false),
             entry(HEDERA_RECORD_STREAM_SIDECAR_MAX_SIZE_MB, 256),
             entry(HEDERA_RECORD_STREAM_ENABLE_TRACEABILITY_MIGRATION, true),
             entry(TRACEABILITY_MIN_FREE_TO_USED_GAS_THROTTLE_RATIO, 9L),

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/contracts/execution/HederaTracerTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/contracts/execution/HederaTracerTest.java
@@ -26,6 +26,9 @@ import static com.hedera.node.app.service.mono.contracts.execution.traceability.
 import static com.hedera.node.app.service.mono.contracts.execution.traceability.CallOperationType.OP_UNKNOWN;
 import static com.hedera.node.app.service.mono.contracts.execution.traceability.ContractActionType.CALL;
 import static com.hedera.node.app.service.mono.contracts.execution.traceability.ContractActionType.CREATE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -34,16 +37,37 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
+import com.google.common.collect.Sets;
+import com.hedera.node.app.service.mono.contracts.execution.traceability.CallOperationType;
 import com.hedera.node.app.service.mono.contracts.execution.traceability.ContractActionType;
 import com.hedera.node.app.service.mono.contracts.execution.traceability.HederaTracer;
+import com.hedera.node.app.service.mono.contracts.execution.traceability.HederaTracer.EmitActionSidecars;
+import com.hedera.node.app.service.mono.contracts.execution.traceability.HederaTracer.ValidateActionSidecars;
+import com.hedera.node.app.service.mono.contracts.execution.traceability.SolidityAction;
 import com.hedera.node.app.service.mono.ledger.accounts.ContractAliases;
 import com.hedera.node.app.service.mono.state.submerkle.EntityId;
 import com.hedera.node.app.service.mono.store.contracts.HederaStackedWorldStateUpdater;
+import com.hedera.test.extensions.LogCaptor;
+import com.hedera.test.extensions.LogCaptureExtension;
+import com.hedera.test.extensions.LoggingSubject;
+import com.hedera.test.extensions.LoggingTarget;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Deque;
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+import org.apache.logging.log4j.Level;
 import org.apache.tuweni.bytes.Bytes;
+import org.assertj.core.api.SoftAssertions;
 import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.datatypes.Wei;
@@ -60,10 +84,12 @@ import org.hyperledger.besu.evm.operation.Operation.OperationResult;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-@ExtendWith(MockitoExtension.class)
+@ExtendWith({MockitoExtension.class, LogCaptureExtension.class})
 class HederaTracerTest {
 
     private static final Code code = CodeFactory.createCode(Bytes.of(4), Hash.EMPTY, 0, false);
@@ -74,6 +100,13 @@ class HederaTracerTest {
     private static final Address originator = Address.fromHexString("0x1");
     private static final Address contract = Address.fromHexString("0x2");
     private static final Address accountReceiver = Address.fromHexString("0x3");
+    private static final Address sender = Address.fromHexString("0x4");
+
+    @LoggingTarget
+    private LogCaptor logCaptor;
+
+    @LoggingSubject
+    private HederaTracer loggedHederaTracer;
 
     @Mock
     private MessageFrame messageFrame;
@@ -91,7 +124,99 @@ class HederaTracerTest {
 
     @BeforeEach
     void setUp() {
-        subject = new HederaTracer(true);
+        subject = new HederaTracer(EmitActionSidecars.ENABLED, ValidateActionSidecars.ENABLED);
+    }
+
+    /**
+     * Helper for testing correctness of (what will eventually be) protobuf `oneof` fields
+     *
+     * Add to param `ss` the names of all fields you're setting that belong to the
+     * `oneof` being checked.  Will ensure that only _one_ field is set, and if not,
+     * produce an appropriate diagnostic.
+     *
+     * @param name name of the `oneof`
+     * @param ss names of the _present_ fields that _belong_ to the `oneof`
+     */
+    void oneofChecker(final String name, final Map<String, Boolean> ss) {
+        final var presentFields = ss.entrySet().stream()
+                .filter(Map.Entry::getValue)
+                .map(Map.Entry::getKey)
+                .sorted()
+                .toList();
+        final var presentFieldNames = String.join(", ", presentFields);
+        final var allFieldNames = ss.keySet().stream().sorted().collect(Collectors.joining(", "));
+
+        if (presentFields.size() == 0) {
+            assertThat(presentFields)
+                    .as("%s not supplied, needs one of %s".formatted(name, allFieldNames))
+                    .hasSize(1);
+        } else if (presentFields.size() != 1) {
+            assertThat(presentFields)
+                    .as("%s has more than one field supplied, must have only one of %s"
+                            .formatted(name, presentFieldNames))
+                    .hasSize(1);
+        }
+    }
+    ;
+
+    @Test
+    void oneofCheckerInternalTest() {
+        assertThatNoException().isThrownBy(() -> {
+            oneofChecker("check-ok", Map.of("foo", false, "bar", true, "bear", false));
+        });
+        assertThatExceptionOfType(AssertionError.class)
+                .isThrownBy(() -> {
+                    oneofChecker("check-0-fails", Map.of("foo", false, "bar", false, "bear", false));
+                })
+                .withMessageContaining("check-0-fails not supplied, needs one of bar, bear, foo");
+        assertThatExceptionOfType(AssertionError.class)
+                .isThrownBy(() -> {
+                    oneofChecker("check-2-fails", Map.of("foo", false, "bar", true, "bear", true));
+                })
+                .withMessageContaining(
+                        "check-2-fails has more than one field supplied, must have only one of bar, bear");
+    }
+
+    void validateAllActionFieldsAreSet(final SolidityAction solidityAction) {
+        final var oneof = new TreeMap<String, Boolean>();
+
+        assertThat(solidityAction.getCallType())
+                .as("call_type must have valid enum value")
+                .isNotNull()
+                .isNotEqualTo(ContractActionType.NO_ACTION);
+
+        oneof.clear();
+        oneof.put("calling_account", null != solidityAction.getCallingAccount());
+        oneof.put("calling_contract", null != solidityAction.getCallingContract());
+        oneofChecker("caller", oneof);
+
+        // can't check `gas` - it's a final integer
+
+        assertThat(solidityAction.getInput())
+                .as("input must be non-null (though it can be empty)")
+                .isNotNull();
+
+        oneof.clear();
+        oneof.put("recipient_account", null != solidityAction.getRecipientAccount());
+        oneof.put("recipient_contract", null != solidityAction.getRecipientContract());
+        oneof.put("targeted_address", null != solidityAction.getInvalidSolidityAddress());
+        oneofChecker("recipient", oneof);
+
+        // can't check `value` - it's a final integer
+        // can't check `gas_used` - it's a naked integer that might legitimately be 0
+
+        oneof.clear();
+        oneof.put("output", null != solidityAction.getOutput());
+        oneof.put("revert_reason", null != solidityAction.getRevertReason());
+        oneof.put("error", null != solidityAction.getError());
+        oneofChecker("result_data", oneof);
+
+        // can't check `call_depth` - it's a final integer
+
+        assertThat(solidityAction.getCallOperationType())
+                .as("call_operation_type must have valid enum value")
+                .isNotNull()
+                .isNotEqualTo(CallOperationType.OP_UNKNOWN);
     }
 
     @Test
@@ -214,6 +339,7 @@ class HederaTracerTest {
         // then
         final var actions = subject.getActions();
         final var solidityAction = actions.get(0);
+        validateAllActionFieldsAreSet(solidityAction);
         assertEquals(initialGas - remainingGasAfterExecution, solidityAction.getGasUsed());
         assertEquals(output.toArrayUnsafe(), solidityAction.getOutput());
         assertEquals(OP_CALL, solidityAction.getCallOperationType());
@@ -233,6 +359,7 @@ class HederaTracerTest {
         // then
         final var actions = subject.getActions();
         final var solidityAction = actions.get(0);
+        validateAllActionFieldsAreSet(solidityAction);
         assertEquals(initialGas - remainingGasAfterExecution, solidityAction.getGasUsed());
         assertArrayEquals(new byte[0], solidityAction.getOutput());
         assertEquals(OP_CREATE, solidityAction.getCallOperationType());
@@ -252,6 +379,7 @@ class HederaTracerTest {
         subject.tracePostExecution(messageFrame, operationResult);
         // then
         final var solidityAction = subject.getActions().get(0);
+        validateAllActionFieldsAreSet(solidityAction);
         assertEquals(initialGas - remainingGasAfterExecution, solidityAction.getGasUsed());
         assertEquals(revertReason.toArrayUnsafe(), solidityAction.getRevertReason());
     }
@@ -269,44 +397,56 @@ class HederaTracerTest {
         subject.tracePostExecution(messageFrame, operationResult);
         // then
         final var solidityAction = subject.getActions().get(0);
+        validateAllActionFieldsAreSet(solidityAction);
         assertEquals(initialGas - remainingGasAfterExecution, solidityAction.getGasUsed());
         assertArrayEquals(new byte[0], solidityAction.getRevertReason());
     }
 
-    @Test
-    void finalizesExceptionallyHaltedFrameWithoutHaltReasonAsExpected() {
+    @ParameterizedTest
+    @EnumSource(
+            value = State.class,
+            names = {"EXCEPTIONAL_HALT", "COMPLETED_FAILED"})
+    void finalizesFailedFrameWithoutHaltReasonAsExpected(State state) {
         // given
         givenTracedExecutingFrame(Type.MESSAGE_CALL);
         // when
         subject.init(messageFrame);
-        given(messageFrame.getState()).willReturn(State.EXCEPTIONAL_HALT);
+        given(messageFrame.getState()).willReturn(state);
         subject.tracePostExecution(messageFrame, operationResult);
         // then
         final var solidityAction = subject.getActions().get(0);
+        validateAllActionFieldsAreSet(solidityAction);
         assertEquals(initialGas, solidityAction.getGasUsed());
         assertArrayEquals(new byte[0], solidityAction.getError());
         assertNull(solidityAction.getInvalidSolidityAddress());
     }
 
-    @Test
-    void finalizesExceptionallyHaltedFrameWithHaltReasonAsExpected() {
+    @ParameterizedTest
+    @EnumSource(
+            value = State.class,
+            names = {"EXCEPTIONAL_HALT", "COMPLETED_FAILED"})
+    void finalizesFailedFrameWithHaltReasonAsExpected(State state) {
         // given
         givenTracedExecutingFrame(Type.MESSAGE_CALL);
         subject.init(messageFrame);
         // when
-        given(messageFrame.getState()).willReturn(State.EXCEPTIONAL_HALT);
+        given(messageFrame.getState()).willReturn(state);
         final var codeTooLarge = Optional.of(ExceptionalHaltReason.CODE_TOO_LARGE);
         given(messageFrame.getExceptionalHaltReason()).willReturn(codeTooLarge);
         subject.tracePostExecution(messageFrame, operationResult);
         // then
         final var solidityAction = subject.getActions().get(0);
+        validateAllActionFieldsAreSet(solidityAction);
         assertEquals(initialGas, solidityAction.getGasUsed());
         assertArrayEquals(codeTooLarge.get().name().getBytes(StandardCharsets.UTF_8), solidityAction.getError());
         assertNull(solidityAction.getInvalidSolidityAddress());
     }
 
-    @Test
-    void finalizesExceptionallyHaltedFrameWithInvalidAddressRecipientAsExpected() {
+    @ParameterizedTest
+    @EnumSource(
+            value = State.class,
+            names = {"EXCEPTIONAL_HALT", "COMPLETED_FAILED"})
+    void finalizesFailedFrameWithInvalidAddressRecipientAsExpected(State state) {
         // given
         given(messageFrame.getType()).willReturn(Type.MESSAGE_CALL);
         given(messageFrame.getCode()).willReturn(CodeV0.EMPTY_CODE);
@@ -324,7 +464,7 @@ class HederaTracerTest {
 
         subject.init(messageFrame);
         // when
-        given(messageFrame.getState()).willReturn(State.EXCEPTIONAL_HALT);
+        given(messageFrame.getState()).willReturn(state);
         final var invalidSolidityAddress = Optional.of(INVALID_SOLIDITY_ADDRESS);
         given(messageFrame.getExceptionalHaltReason()).willReturn(invalidSolidityAddress);
         given(messageFrame.getStackItem(1)).willReturn(Bytes.of(contract.toArrayUnsafe()));
@@ -334,6 +474,7 @@ class HederaTracerTest {
         subject.tracePostExecution(messageFrame, operationResult);
         // then
         final var topLevelAction = subject.getActions().get(0);
+        validateAllActionFieldsAreSet(topLevelAction);
         assertEquals(initialGas, topLevelAction.getGasUsed());
         assertArrayEquals(
                 invalidSolidityAddress.get().name().getBytes(StandardCharsets.UTF_8), topLevelAction.getError());
@@ -341,6 +482,7 @@ class HederaTracerTest {
         assertNull(topLevelAction.getRecipientContract());
         assertNull(topLevelAction.getInvalidSolidityAddress());
         final var syntheticInvalidAddressAction = subject.getActions().get(1);
+        validateAllActionFieldsAreSet(syntheticInvalidAddressAction);
         assertEquals(CALL, syntheticInvalidAddressAction.getCallType());
         assertEquals(OP_CALL, syntheticInvalidAddressAction.getCallOperationType());
         assertEquals(0, syntheticInvalidAddressAction.getValue());
@@ -353,8 +495,11 @@ class HederaTracerTest {
         assertEquals(messageFrame.getRemainingGas(), syntheticInvalidAddressAction.getGas());
     }
 
-    @Test
-    void finalizesExceptionallyHaltedCreateFrameWithInvalidAddressReasonAsExpected() {
+    @ParameterizedTest
+    @EnumSource(
+            value = State.class,
+            names = {"EXCEPTIONAL_HALT", "COMPLETED_FAILED"})
+    void finalizesFailedCreateFrameWithInvalidAddressReasonAsExpected(State state) {
         // given
         given(messageFrame.getType()).willReturn(Type.CONTRACT_CREATION);
         given(messageFrame.getCode()).willReturn(CodeV0.EMPTY_CODE);
@@ -371,13 +516,14 @@ class HederaTracerTest {
 
         subject.init(messageFrame);
         // when
-        given(messageFrame.getState()).willReturn(State.EXCEPTIONAL_HALT);
+        given(messageFrame.getState()).willReturn(state);
         final var invalidSolidityAddress = Optional.of(INVALID_SOLIDITY_ADDRESS);
         given(messageFrame.getExceptionalHaltReason()).willReturn(invalidSolidityAddress);
         subject.tracePostExecution(messageFrame, operationResult);
         // then
         assertEquals(1, subject.getActions().size());
         final var topLevelAction = subject.getActions().get(0);
+        validateAllActionFieldsAreSet(topLevelAction);
         assertEquals(initialGas, topLevelAction.getGasUsed());
         assertArrayEquals(
                 invalidSolidityAddress.get().name().getBytes(StandardCharsets.UTF_8), topLevelAction.getError());
@@ -386,16 +532,20 @@ class HederaTracerTest {
         assertNull(topLevelAction.getInvalidSolidityAddress());
     }
 
-    @Test
-    void clearsRecipientOfExceptionallyHaltedCreateFrame() {
+    @ParameterizedTest
+    @EnumSource(
+            value = State.class,
+            names = {"EXCEPTIONAL_HALT", "COMPLETED_FAILED"})
+    void clearsRecipientOfFailedCreateFrame(State state) {
         // given
         givenTracedExecutingFrame(Type.CONTRACT_CREATION);
         subject.init(messageFrame);
         // when
-        given(messageFrame.getState()).willReturn(State.EXCEPTIONAL_HALT);
+        given(messageFrame.getState()).willReturn(state);
         subject.tracePostExecution(messageFrame, operationResult);
         // then
         final var solidityAction = subject.getActions().get(0);
+        // this is a child frame where current frame is CODE_EXECUTING, so we aren't finalized at this time
         assertNull(solidityAction.getRecipientAccount());
         assertNull(solidityAction.getRecipientContract());
     }
@@ -410,6 +560,7 @@ class HederaTracerTest {
         subject.tracePostExecution(messageFrame, operationResult);
         // then
         final var solidityAction = subject.getActions().get(0);
+        // this is a frame where current frame is CODE_EXECUTING, so we aren't finalized at this time
         assertNull(solidityAction.getRecipientAccount());
         assertNull(solidityAction.getRecipientContract());
     }
@@ -437,6 +588,7 @@ class HederaTracerTest {
         subject.tracePrecompileResult(messageFrame, ContractActionType.PRECOMPILE);
         // then
         final var solidityAction = subject.getActions().get(0);
+        validateAllActionFieldsAreSet(solidityAction);
         assertEquals(ContractActionType.PRECOMPILE, solidityAction.getCallType());
         assertNull(solidityAction.getRecipientAccount());
         assertEquals(EntityId.fromAddress(contract), solidityAction.getRecipientContract());
@@ -467,6 +619,7 @@ class HederaTracerTest {
         subject.tracePrecompileResult(messageFrame, ContractActionType.SYSTEM);
         // then
         final var solidityAction = subject.getActions().get(0);
+        validateAllActionFieldsAreSet(solidityAction);
         assertEquals(ContractActionType.SYSTEM, solidityAction.getCallType());
         assertNull(solidityAction.getRecipientAccount());
         assertEquals(EntityId.fromAddress(contract), solidityAction.getRecipientContract());
@@ -477,7 +630,7 @@ class HederaTracerTest {
     @Test
     void finalizesSystemPrecompileCallAsExpectedWhenActionsNotEnabled() {
         // given
-        subject = new HederaTracer(false);
+        subject = new HederaTracer(EmitActionSidecars.DISABLED, ValidateActionSidecars.DISABLED);
         // when
         subject.tracePostExecution(messageFrame, operationResult);
         subject.tracePrecompileResult(messageFrame, ContractActionType.SYSTEM);
@@ -487,7 +640,7 @@ class HederaTracerTest {
 
     @Test
     void traceAccountCreationResultWhenTraceabilityNotEnabled() {
-        subject = new HederaTracer(false);
+        subject = new HederaTracer(EmitActionSidecars.DISABLED, ValidateActionSidecars.DISABLED);
         final var haltReason = Optional.of(INVALID_SOLIDITY_ADDRESS);
 
         subject.traceAccountCreationResult(messageFrame, haltReason);
@@ -522,6 +675,7 @@ class HederaTracerTest {
         // then
         assertEquals(1, subject.getActions().size());
         final var action = subject.getActions().get(0);
+        validateAllActionFieldsAreSet(action);
         assertEquals(contract, action.getRecipientAccount().toEvmAddress());
         assertNull(action.getInvalidSolidityAddress());
         assertNull(action.getRecipientContract());
@@ -554,13 +708,17 @@ class HederaTracerTest {
 
         assertEquals(1, subject.getActions().size());
         final var action = subject.getActions().get(0);
+        validateAllActionFieldsAreSet(action);
         assertEquals(contract, action.getRecipientAccount().toEvmAddress());
         assertNull(action.getInvalidSolidityAddress());
         assertNull(action.getRecipientContract());
     }
 
-    @Test
-    void failedLazyCreationActionsIsFinalizedAsExpected() {
+    @ParameterizedTest
+    @EnumSource(
+            value = State.class,
+            names = {"EXCEPTIONAL_HALT", "COMPLETED_FAILED"})
+    void failedLazyCreationActionsIsFinalizedAsExpected(State state) {
         // given
         given(messageFrame.getType()).willReturn(Type.MESSAGE_CALL);
         given(messageFrame.getOriginatorAddress()).willReturn(originator);
@@ -576,13 +734,14 @@ class HederaTracerTest {
         subject.init(messageFrame);
 
         // when
-        given(messageFrame.getState()).willReturn(State.EXCEPTIONAL_HALT);
+        given(messageFrame.getState()).willReturn(state);
         given(messageFrame.getExceptionalHaltReason()).willReturn(Optional.of(ExceptionalHaltReason.INSUFFICIENT_GAS));
 
         subject.tracePostExecution(messageFrame, operationResult);
 
         assertEquals(1, subject.getActions().size());
         final var action = subject.getActions().get(0);
+        validateAllActionFieldsAreSet(action);
         assertArrayEquals(contract.toArrayUnsafe(), action.getInvalidSolidityAddress());
         assertNull(action.getRecipientAccount());
         assertNull(action.getRecipientContract());
@@ -590,7 +749,7 @@ class HederaTracerTest {
 
     @Test
     void actionsAreNotTrackedWhenNotEnabled() {
-        subject = new HederaTracer(false);
+        subject = new HederaTracer(EmitActionSidecars.DISABLED, ValidateActionSidecars.DISABLED);
 
         subject.init(messageFrame);
         subject.tracePostExecution(messageFrame, operationResult);
@@ -652,6 +811,7 @@ class HederaTracerTest {
         // assert child frame action is initialized as expected
         assertEquals(2, subject.getActions().size());
         final var childFrame1 = subject.getActions().get(1);
+        // this is a child frame where current frame is CODE_SUSPENDED, so we aren't finalized at this time
         assertEquals(OP_CALL, childFrame1.getCallOperationType());
     }
 
@@ -666,6 +826,7 @@ class HederaTracerTest {
         // assert child frame action is initialized as expected
         assertEquals(2, subject.getActions().size());
         final var childFrame1 = subject.getActions().get(1);
+        // this is a child frame where current frame is CODE_SUSPENDED, so we aren't finalized at this time
         assertEquals(OP_CREATE, childFrame1.getCallOperationType());
     }
 
@@ -680,6 +841,7 @@ class HederaTracerTest {
         // assert child frame action is initialized as expected
         assertEquals(2, subject.getActions().size());
         final var childFrame1 = subject.getActions().get(1);
+        // this is a child frame where current frame is CODE_SUSPENDED, so we aren't finalized at this time
         assertEquals(OP_CALLCODE, childFrame1.getCallOperationType());
     }
 
@@ -694,6 +856,7 @@ class HederaTracerTest {
         // assert child frame action is initialized as expected
         assertEquals(2, subject.getActions().size());
         final var childFrame1 = subject.getActions().get(1);
+        // this is a child frame where current frame is CODE_SUSPENDED, so we aren't finalized at this time
         assertEquals(OP_DELEGATECALL, childFrame1.getCallOperationType());
     }
 
@@ -708,6 +871,7 @@ class HederaTracerTest {
         // assert child frame action is initialized as expected
         assertEquals(2, subject.getActions().size());
         final var childFrame1 = subject.getActions().get(1);
+        // this is a child frame where current frame is CODE_SUSPENDED, so we aren't finalized at this time
         assertEquals(OP_CREATE2, childFrame1.getCallOperationType());
     }
 
@@ -722,6 +886,7 @@ class HederaTracerTest {
         // assert child frame action is initialized as expected
         assertEquals(2, subject.getActions().size());
         final var childFrame1 = subject.getActions().get(1);
+        // this is a child frame where current frame is CODE_SUSPENDED, so we aren't finalized at this time
         assertEquals(OP_STATICCALL, childFrame1.getCallOperationType());
     }
 
@@ -736,6 +901,7 @@ class HederaTracerTest {
         // assert child frame action is initialized as expected
         assertEquals(2, subject.getActions().size());
         final var childFrame1 = subject.getActions().get(1);
+        // this is a child frame where current frame is CODE_SUSPENDED, so we aren't finalized at this time
         assertEquals(OP_UNKNOWN, childFrame1.getCallOperationType());
     }
 
@@ -788,5 +954,227 @@ class HederaTracerTest {
         }
 
         subject.tracePostExecution(messageFrame, operationResult);
+    }
+
+    @Test
+    void finalizeOperationTestWithValidationDisabled() {
+
+        final var badSolidityAction1 = new SolidityAction(CALL, 7, new byte[7], 7, 7);
+        final var goodSolidityAction1 = new SolidityAction(CALL, 7, new byte[7], 7, 7);
+        {
+            goodSolidityAction1.setCallingAccount(new EntityId());
+            goodSolidityAction1.setRecipientAccount(new EntityId());
+            goodSolidityAction1.setGasUsed(7);
+            goodSolidityAction1.setOutput(new byte[7]);
+            goodSolidityAction1.setCallOperationType(OP_CALL);
+        }
+        final var allActions = new ArrayList<>(List.of(badSolidityAction1, goodSolidityAction1));
+        final var invalidActions = new ArrayList<>(List.of(badSolidityAction1));
+
+        final var sut = new HederaTracer(EmitActionSidecars.ENABLED, ValidateActionSidecars.DISABLED) {
+            {
+                logLevel = Level.ERROR;
+            }
+
+            public void setAllActions(final Collection<SolidityAction> sas) {
+                this.allActions = new ArrayList<>(sas);
+            }
+
+            public void setInvalidActions(final Collection<SolidityAction> sas) {
+                this.invalidActions = new ArrayList<>(sas);
+            }
+
+            public Collection<SolidityAction> getAllActions() {
+                return List.copyOf(allActions);
+            }
+        };
+
+        sut.setAllActions(allActions);
+        sut.setInvalidActions(invalidActions);
+        sut.finalizeOperation(messageFrame);
+
+        final var actualActions = sut.getAllActions();
+        assertThat(actualActions).hasSize(2);
+        assertThat(actualActions.stream().filter(SolidityAction::isValid).count())
+                .isEqualTo(1);
+        assertThat(actualActions).hasSameElementsAs(allActions);
+
+        final var actualLogs = Stream.of(
+                        logCaptor.debugLogs().stream(),
+                        logCaptor.infoLogs().stream(),
+                        logCaptor.warnLogs().stream(),
+                        logCaptor.errorLogs().stream())
+                .flatMap(s -> s)
+                .toList();
+        assertThat(actualLogs).isEmpty();
+        logCaptor.clear();
+    }
+
+    @Test
+    void finalizeOperationTestWithValidationEnabled() {
+
+        given(messageFrame.getContractAddress()).willReturn(contract);
+        given(messageFrame.getOriginatorAddress()).willReturn(originator);
+        given(messageFrame.getRecipientAddress()).willReturn(accountReceiver);
+        given(messageFrame.getSenderAddress()).willReturn(sender);
+        given(messageFrame.getState()).willReturn(State.CODE_EXECUTING);
+        given(messageFrame.getType()).willReturn(Type.MESSAGE_CALL);
+
+        Function<Collection<SolidityAction>, Collection<SolidityAction>> getOnlyValid =
+                cas -> cas.stream().filter(SolidityAction::isValid).toList();
+        Function<Collection<SolidityAction>, Collection<SolidityAction>> getOnlyInvalid =
+                cas -> cas.stream().filter(sa -> !sa.isValid()).toList();
+        Function<Collection<SolidityAction>, Integer> countValid =
+                cas -> getOnlyValid.apply(cas).size();
+
+        final var badSolidityAction1 = new SolidityAction(CALL, 7, new byte[7], 7, 7);
+        assertThat(badSolidityAction1.isValid()).isFalse();
+        final var badSolidityAction2 = copy(badSolidityAction1);
+        final var badSolidityAction3 = copy(badSolidityAction1);
+        final var goodSolidityAction1 = new SolidityAction(CALL, 7, new byte[7], 7, 7);
+        {
+            goodSolidityAction1.setCallingAccount(new EntityId());
+            goodSolidityAction1.setRecipientAccount(new EntityId());
+            goodSolidityAction1.setGasUsed(7);
+            goodSolidityAction1.setOutput(new byte[7]);
+            goodSolidityAction1.setCallOperationType(OP_CALL);
+        }
+        assertThat(goodSolidityAction1.isValid()).isTrue();
+        final var goodSolidityAction2 = copy(goodSolidityAction1);
+        final var goodSolidityAction3 = copy(goodSolidityAction1);
+
+        final var actions = Set.of(
+                badSolidityAction1,
+                badSolidityAction2,
+                badSolidityAction3,
+                goodSolidityAction1,
+                goodSolidityAction2,
+                goodSolidityAction3);
+        assertThat(countValid.apply(actions)).isEqualTo(3);
+        final var powerActions = Sets.powerSet(actions);
+        assertThat(powerActions).hasSize(64);
+
+        final var namedSAs = Map.of(
+                badSolidityAction1,
+                "bad1",
+                badSolidityAction2,
+                "bad2",
+                badSolidityAction3,
+                "bad3",
+                goodSolidityAction1,
+                "good1",
+                goodSolidityAction2,
+                "good2",
+                goodSolidityAction3,
+                "good3");
+        assertThat(namedSAs).hasSize(6);
+
+        final var softly = new SoftAssertions();
+        for (final var testStackDepth : IntStream.of(0, 1, 3).toArray())
+            for (final var test : powerActions) {
+
+                final var sut = new HederaTracer(EmitActionSidecars.ENABLED, ValidateActionSidecars.ENABLED) {
+                    {
+                        logLevel = Level.ERROR;
+                    }
+
+                    public void setAllActions(final Collection<SolidityAction> sas) {
+                        this.allActions = new ArrayList<>(sas);
+                    }
+
+                    public void setInvalidActions(final Collection<SolidityAction> sas) {
+                        this.invalidActions = new ArrayList<>(sas);
+                    }
+
+                    public Collection<SolidityAction> getAllActions() {
+                        return List.copyOf(allActions);
+                    }
+
+                    public void pushSA() {
+                        currentActionsStack.add(new SolidityAction(CALL, 7, new byte[7], 7, 7));
+                    }
+                };
+
+                Function<Collection<SolidityAction>, String> toString =
+                        sas -> sas.stream().map(namedSAs::get).sorted().collect(Collectors.joining(","));
+
+                final var expectedNActions = test.size();
+
+                final var expectedValidActions = getOnlyValid.apply(test);
+                final var expectedNValidActions = expectedValidActions.size();
+
+                final var expectedInvalidActions = getOnlyInvalid.apply(test);
+                final var expectedNInvalidActions = expectedInvalidActions.size();
+
+                final var expectedTestCaseIsValid = expectedNActions == expectedNValidActions;
+
+                sut.setAllActions(test);
+                sut.setInvalidActions(expectedInvalidActions);
+                for (int k = 0; k < testStackDepth; k++) sut.pushSA();
+                sut.finalizeOperation(messageFrame);
+
+                final var actualActions = sut.getAllActions();
+                softly.assertThat(actualActions).hasSize(expectedNValidActions);
+                softly.assertThat(countValid.apply(actualActions)).isEqualTo(expectedNValidActions);
+                softly.assertThat(actualActions).hasSameElementsAs(expectedValidActions);
+
+                final var testName =
+                        "test case [%s] with %d invalid".formatted(toString.apply(test), expectedNInvalidActions);
+
+                final var actualLogs = Stream.of(
+                                logCaptor.debugLogs().stream(),
+                                logCaptor.infoLogs().stream(),
+                                logCaptor.warnLogs().stream(),
+                                logCaptor.errorLogs().stream())
+                        .flatMap(s -> s)
+                        .toList();
+
+                if (expectedTestCaseIsValid && testStackDepth == 0) {
+                    softly.assertThat(actualLogs).as(testName + " #logs").hasSize(0);
+                } else {
+                    softly.assertThat(actualLogs).as(testName + " #logs").hasSize(1);
+                    final var actualLog = actualLogs.get(0);
+
+                    if (testStackDepth > 0) {
+                        softly.assertThat(actualLog)
+                                .as(testName)
+                                .contains("currentActionsStack not empty")
+                                .contains("has %d elements".formatted(testStackDepth));
+                    } else {
+                        softly.assertThat(actualLog).as(testName).doesNotContain("currentActionsStack not empty");
+                    }
+
+                    if (expectedTestCaseIsValid) {
+                        softly.assertThat(actualLog).as(testName).doesNotContain("were invalid");
+                    } else {
+                        softly.assertThat(actualLog)
+                                .as(testName)
+                                .contains("of %d actions given, %d were invalid"
+                                        .formatted(expectedNActions, expectedNInvalidActions));
+                    }
+                }
+
+                logCaptor.clear();
+            }
+        softly.assertAll();
+    }
+
+    private SolidityAction copy(final SolidityAction sa) {
+        final var r =
+                new SolidityAction(sa.getCallType(), sa.getGas(), sa.getInput(), sa.getValue(), sa.getCallDepth());
+
+        r.setCallOperationType(sa.getCallOperationType());
+        r.setCallingAccount(sa.getCallingAccount());
+        r.setCallingContract(sa.getCallingContract());
+        r.setError(sa.getError());
+        r.setGasUsed(sa.getGasUsed());
+        r.setOutput(sa.getOutput());
+        r.setRecipientAccount(sa.getRecipientAccount());
+        r.setRecipientContract(sa.getRecipientContract());
+        r.setRevertReason(sa.getRevertReason());
+        r.setTargetedAddress(sa.getInvalidSolidityAddress());
+
+        assertThat(r.isValid()).isEqualTo(sa.isValid());
+        return r;
     }
 }

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/contracts/execution/SolidityActionTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/contracts/execution/SolidityActionTest.java
@@ -16,6 +16,9 @@
 
 package com.hedera.node.app.service.mono.contracts.execution;
 
+import static com.hedera.node.app.service.mono.contracts.execution.traceability.CallOperationType.OP_CREATE;
+import static com.hedera.node.app.service.mono.contracts.execution.traceability.ContractActionType.CREATE;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.hedera.node.app.hapi.utils.ByteStringUtils;
@@ -26,6 +29,12 @@ import com.hedera.node.app.service.mono.state.submerkle.EntityId;
 import com.hedera.node.app.service.mono.utils.EntityIdUtils;
 import com.hedera.services.stream.proto.ContractAction;
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+import org.assertj.core.api.SoftAssertions;
 import org.hyperledger.besu.datatypes.Address;
 import org.junit.jupiter.api.Test;
 
@@ -38,7 +47,112 @@ class SolidityActionTest {
     private final long value = 55L;
     private final long gasUsed = 555L;
     private final long gas = 100L;
-    ;
+
+    @Test
+    void isValidTest() {
+        // "gasUsed" and missing "oneof recipient" omitted in these tests because those are okay never having been set
+
+        final byte[] BYTES = new byte[5];
+        record SACtor(boolean good, Supplier<SolidityAction> ctor) {}
+        final var ctors = Map.of(
+                "good",
+                new SACtor(true, () -> new SolidityAction(CREATE, 5, BYTES, 7, 10)),
+                "null call type",
+                new SACtor(false, () -> new SolidityAction(null, 5, BYTES, 7, 10)),
+                "bad call type",
+                new SACtor(false, () -> new SolidityAction(ContractActionType.NO_ACTION, 5, BYTES, 7, 10)),
+                "bad input", /* true because this one case is _fixed_ by SolidityAction's constructor */
+                new SACtor(true, () -> new SolidityAction(CREATE, 5, null, 7, 10)),
+                "good but empty input",
+                new SACtor(true, () -> new SolidityAction(CREATE, 5, new byte[0], 7, 10)));
+        final var fieldSetters = Map.<String, Consumer<SolidityAction>>of(
+                "callingAccount", sa -> sa.setCallingAccount(sender),
+                "callingContract", sa -> sa.setCallingContract(sender),
+                "recipientAccount", sa -> sa.setRecipientAccount(sender),
+                "recipientContract", sa -> sa.setRecipientContract(sender),
+                "invalidSolidityAddress", sa -> sa.setTargetedAddress(BYTES),
+                "output", sa -> sa.setOutput(BYTES),
+                "revertReason", sa -> sa.setRevertReason(BYTES),
+                "error", sa -> sa.setError(BYTES),
+                "callOperationType", sa -> sa.setCallOperationType(CallOperationType.OP_DELEGATECALL));
+        record SAFields(boolean good, String... fields) {}
+        final var fields = List.<SAFields>of(
+                new SAFields(true, "callingAccount", "recipientAccount", "output", "callOperationType"),
+                new SAFields(true, "callingContract", "recipientContract", "revertReason", "callOperationType"),
+                new SAFields(true, "callingAccount", "invalidSolidityAddress", "error", "callOperationType"),
+                new SAFields(true, "callingContract", "recipientAccount", "revertReason", "callOperationType"),
+                new SAFields(true, "callingAccount", "recipientContract", "output", "callOperationType"),
+                new SAFields(false, "recipientAccount", "output", "callOperationType"),
+                new SAFields(true, "callingAccount", "error", "callOperationType"),
+                new SAFields(
+                        false, "callingAccount", "callingContract", "recipientAccount", "output", "callOperationType"),
+                new SAFields(true, "callingAccount", "output", "callOperationType"),
+                new SAFields(
+                        false,
+                        "callingAccount",
+                        "recipientAccount",
+                        "invalidSolidityAddress",
+                        "output",
+                        "callOperationType"),
+                new SAFields(
+                        false,
+                        "callingContract",
+                        "recipientAccount",
+                        "recipientContract",
+                        "invalidSolidityAddress",
+                        "output",
+                        "callOperationType"),
+                new SAFields(false, "callingContract", "invalidSolidityAddress", "callOperationType"),
+                new SAFields(
+                        false, "callingAccount", "recipientAccount", "output", "revertReason", "callOperationType"),
+                new SAFields(
+                        false, "callingContract", "recipientContract", "revertReason", "error", "callOperationType"),
+                new SAFields(
+                        false,
+                        "callingAccount",
+                        "invalidSolidityAddress",
+                        "output",
+                        "revertReason",
+                        "error",
+                        "callOperationType"),
+                new SAFields(false, "callingContract", "recipientAccount", "output"));
+
+        // sanity check validity of 'fields' test cases
+        assertThat(fields.stream()
+                        .map(SAFields::fields)
+                        .flatMap(Arrays::stream)
+                        .distinct()
+                        .filter(k -> !fieldSetters.containsKey(k))
+                        .sorted()
+                        .toList())
+                .as("sanity check that all field names specified in tests are correct has _failed_")
+                .isEmpty();
+
+        // now: test cases are cartesian product of constructor setup plus field setups
+        int ncases = 0;
+        int ngood = 0;
+        final var softly = new SoftAssertions();
+        for (final var ctorNV : ctors.entrySet()) {
+            for (final var field : fields) {
+                boolean expected = ctorNV.getValue().good() && field.good();
+
+                // Construct the SolidityAction with the given constructor values
+                final var sut = ctorNV.getValue().ctor().get();
+                // Set fields to valid values with the given field names
+                for (final var setter : field.fields()) {
+                    fieldSetters.get(setter).accept(sut);
+                }
+                softly.assertThat(sut.isValid())
+                        .as("ctor(%s)[%s]".formatted(ctorNV.getKey(), String.join(",", field.fields())))
+                        .isEqualTo(expected);
+                ncases++;
+                if (expected) ngood++;
+            }
+        }
+        softly.assertAll();
+        assertThat(ncases).isEqualTo(80);
+        assertThat(ngood).isEqualTo(21);
+    }
 
     @Test
     void toGrpcWhenCallingAccountAndRecipientAccountAndOutputAreSet() {
@@ -114,5 +228,43 @@ class SolidityActionTest {
                 .build();
 
         assertEquals(expected, actual.toGrpc());
+    }
+
+    @Test
+    void toFullStringTest() {
+        var sut = new SolidityAction(CREATE, 7, null, 11, 13);
+        assertThat(sut.toFullString())
+                .isEqualTo(
+                        """
+                SolidityAction(callType: CREATE, callOperationType: <null>, value: 11, gas: 7, \
+                gasUsed: 0, callDepth: 13, callingAccount: <null>, callingContract: <null>, \
+                recipientAccount: <null>, recipientContract: <null>, invalidSolidityAddress \
+                (aka targetedAddress): <null>, input: <empty>, output: <null>, \
+                revertReason: <null>, error: <null>)\
+                """);
+
+        sut = new SolidityAction(CREATE, 7, new byte[] {0x20, 0x21, 0x22}, 11, 13);
+        sut.setCallOperationType(OP_CREATE);
+        sut.setGasUsed(17);
+        sut.setCallingAccount(EntityId.fromNum(1234));
+        sut.setCallingContract(EntityId.fromNum(2345));
+        sut.setRecipientAccount(EntityId.fromNum(3456));
+        sut.setRecipientContract(EntityId.fromNum(4567));
+        sut.setTargetedAddress(new byte[] {0x10, 0x11, 0x12});
+        sut.setOutput(new byte[] {0x30, 0x31, 0x32});
+        sut.setRevertReason(new byte[] {0x40, 0x41, 0x42});
+        sut.setError(new byte[] {0x50, 0x51, 0x52});
+        assertThat(sut.toFullString())
+                .isEqualTo(
+                        """
+                SolidityAction(callType: CREATE, callOperationType: OP_CREATE, value: 11, gas: 7, \
+                gasUsed: 17, callDepth: 13, callingAccount: EntityId{shard=0, realm=0, num=1234}, \
+                callingContract: EntityId{shard=0, realm=0, num=2345}, \
+                recipientAccount: EntityId{shard=0, realm=0, num=3456}, \
+                recipientContract: EntityId{shard=0, realm=0, num=4567}, \
+                invalidSolidityAddress (aka targetedAddress): 0x101112, \
+                input: 0x202122, output: 0x303132, revertReason: 0x404142, \
+                error: 0x505152)\
+                """);
     }
 }

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/test/extensions/LogCaptor.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/test/extensions/LogCaptor.java
@@ -54,6 +54,10 @@ public class LogCaptor {
         this.logger.setLevel(Level.DEBUG);
     }
 
+    public void clear() {
+        capture.reset();
+    }
+
     public void stopCapture() {
         this.logger.removeAppender(appender);
     }

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/test/extensions/LoggingSubject.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/test/extensions/LoggingSubject.java
@@ -22,8 +22,12 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * In a JUnit5 test extended with the {@link LogCaptureExtension}, denotes the field whose logs
- * should be captured per test method execution.
+ * In a JUnit5 test extended with the {@link LogCaptureExtension}, denotes the
+ * field of a class type whose logs should be captured per test method execution.
+ *
+ * (The field itself isn't used - only its type is needed, to get a
+ * {@link org.apache.logging.log4j.Logger} for that type - thus it need not ever
+ * hold an instance.)
  */
 @Target(ElementType.FIELD)
 @Retention(RetentionPolicy.RUNTIME)

--- a/hedera-node/hedera-mono-service/src/test/resources/bootstrap.properties
+++ b/hedera-node/hedera-mono-service/src/test/resources/bootstrap.properties
@@ -87,6 +87,7 @@ contracts.redirectTokenCalls=true
 contracts.referenceSlotLifetime=31536000
 contracts.scheduleThrottleMaxGasLimit=5000000
 contracts.sidecars=CONTRACT_STATE_CHANGE,CONTRACT_BYTECODE,CONTRACT_ACTION
+contracts.sidecarValidationEnabled=false
 contract.storageSlotPriceTiers=0til100M,2000til450M
 contracts.throttle.throttleByGas=true
 contracts.precompile.atomicCryptoTransfer.enabled=true

--- a/hedera-node/hedera-mono-service/src/test/resources/bootstrap/standard.properties
+++ b/hedera-node/hedera-mono-service/src/test/resources/bootstrap/standard.properties
@@ -84,6 +84,7 @@ contracts.redirectTokenCalls=true
 contracts.referenceSlotLifetime=31536000
 contracts.scheduleThrottleMaxGasLimit=5000000
 contracts.sidecars=CONTRACT_STATE_CHANGE,CONTRACT_BYTECODE
+contracts.sidecarValidationEnabled=false
 expiry.minCycleEntryCapacity=ACCOUNTS_GET,ACCOUNTS_GET_FOR_MODIFY,STORAGE_GET,STORAGE_GET,STORAGE_REMOVE,STORAGE_PUT
 expiry.throttleResource=expiry-throttle.json
 contract.storageSlotPriceTiers=0til100M,2000til450M

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/traceability/TraceabilitySuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/traceability/TraceabilitySuite.java
@@ -4988,12 +4988,12 @@ public class TraceabilitySuite extends HapiSuite {
                     sidecarWatcher.tearDown();
                 }))
                 .then(assertionsHold((spec, assertLog) -> {
-                    assertTrue(sidecarWatcher.thereAreNoMismatchedSidecars(), sidecarWatcher.getErrors());
+                    assertTrue(sidecarWatcher.thereAreNoMismatchedSidecars(), sidecarWatcher.getMismatchErrors());
                     assertTrue(
                             sidecarWatcher.thereAreNoPendingSidecars(),
                             "There are some sidecars that have not been yet"
                                     + " externalized in the sidecar files after all"
-                                    + " specs.");
+                                    + " specs: " + sidecarWatcher.getPendingErrors());
                 }));
     }
 
@@ -5160,6 +5160,14 @@ public class TraceabilitySuite extends HapiSuite {
         final var recordStreamFolderPath = HapiSpec.isRunningInCi()
                 ? HapiSpec.ciPropOverrides().get(RECORD_STREAM_FOLDER_PATH_PROPERTY_KEY)
                 : HapiSpecSetup.getDefaultPropertySource().get(RECORD_STREAM_FOLDER_PATH_PROPERTY_KEY);
+
+        {
+            final var absolutePath =
+                    Paths.get(recordStreamFolderPath).toAbsolutePath().toString();
+            log.info("recordStreamFolderPath from config %s: %s (absolute %s)"
+                    .formatted(HapiSpec.isRunningInCi() ? "CI" : "not CI", recordStreamFolderPath, absolutePath));
+        }
+
         sidecarWatcher = new SidecarWatcher(Paths.get(recordStreamFolderPath));
         sidecarWatcher.watch();
     }


### PR DESCRIPTION
Signed-off-by: Hedera Eng Automation <swirlds-eng-automation@swirlds.com>
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->

Cherry pick a fix to contract actions sidecar logic that 1) handles a state machine state that was missed before and 2) makes sure all fields of a contract actions sidecar are valid. 

**Related issue(s)**:

Cherry picks #5192
Fixes #5169
