### PR TITLE
5475 - Initialize Address Book On Startup

### DIFF
--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/config/StateConfig.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/config/StateConfig.java
@@ -91,6 +91,9 @@ import com.swirlds.config.api.ConfigProperty;
  * 		If true, then enable extra debug code that tracks signed states. Very useful for debugging state leaks.
  * 		This debug code is relatively expensive (it takes and stores stack traces when operations are
  * 		performed on signed state objects).
+ * @param forceUseOfConfigAddressBook
+ *         If true, then the address book from the config file will be used instead of the address book from the
+ *         signed state. This is useful for testing. It is not recommended to use this in production.
  */
 @ConfigData("state")
 public record StateConfig(
@@ -113,7 +116,8 @@ public record StateConfig(
         @ConfigProperty(defaultValue = "5") int debugHashDepth,
         @ConfigProperty(defaultValue = "1000") int maxAgeOfFutureStateSignatures,
         @ConfigProperty(defaultValue = "26") int roundsToKeepForSigning,
-        @ConfigProperty(defaultValue = "false") boolean signedStateSentinelEnabled) {
+        @ConfigProperty(defaultValue = "false") boolean signedStateSentinelEnabled,
+        @ConfigProperty(defaultValue = "true") boolean forceUseOfConfigAddressBook) {
 
     /**
      * Get the main class name that should be used for signed states.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/config/StateConfig.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/config/StateConfig.java
@@ -93,7 +93,7 @@ import com.swirlds.config.api.ConfigProperty;
  * 		performed on signed state objects).
  * @param forceUseOfConfigAddressBook
  *         If true, then the address book from the config file will be used instead of the address book from the
- *         signed state. This is useful for testing. It is not recommended to use this in production.
+ *         signed state and the swirld state will not be queried for any address book updates.
  */
 @ConfigData("state")
 public record StateConfig(

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/system/SwirldState.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/system/SwirldState.java
@@ -18,6 +18,7 @@ package com.swirlds.common.system;
 
 import com.swirlds.common.crypto.TransactionSignature;
 import com.swirlds.common.merkle.MerkleNode;
+import com.swirlds.common.system.address.AddressBook;
 import com.swirlds.common.system.events.Event;
 import com.swirlds.common.system.transaction.Transaction;
 import java.util.List;
@@ -57,11 +58,11 @@ public interface SwirldState extends MerkleNode {
 
     /**
      * Provides the application an opportunity to perform operations on transactions in an event prior to handling.
-     * Called against a given {@link Event} only once, globally (not once per state instance) This method may modify
-     * the {@link Transaction}s in the event by doing nothing, adding additional signatures, removing existing
-     * signatures, replacing signatures with versions that expand the public key from an application specific
-     * identifier to an actual public key, or attaching metadata. Additional signatures extracted from the transaction
-     * payload can also be added to the list of signatures to be verified.
+     * Called against a given {@link Event} only once, globally (not once per state instance) This method may modify the
+     * {@link Transaction}s in the event by doing nothing, adding additional signatures, removing existing signatures,
+     * replacing signatures with versions that expand the public key from an application specific identifier to an
+     * actual public key, or attaching metadata. Additional signatures extracted from the transaction payload can also
+     * be added to the list of signatures to be verified.
      * <p>
      * If signature verification is desired, it is recommended that process be started in this method on a background
      * thread using one of the methods below to give it time to complete before the transaction is handled
@@ -73,8 +74,7 @@ public interface SwirldState extends MerkleNode {
      * <p>
      * <strong>This method is always invoked on an immutable state.</strong>
      *
-     * @param event
-     * 		the event to perform pre-handling on
+     * @param event the event to perform pre-handling on
      * @see #handleConsensusRound(Round, SwirldDualState)
      */
     default void preHandle(final Event event) {}
@@ -101,6 +101,24 @@ public interface SwirldState extends MerkleNode {
      * </pre>
      */
     void handleConsensusRound(final Round round, final SwirldDualState swirldDualState);
+
+    /**
+     * Implementations of the SwirldState should always override this method in production.  The AddressBook returned
+     * should have the same Adddress entries as the configuration AddressBook, but with the stake values updated. The
+     * AddressBook previously saved in the state, if it exists, is provided for reference.
+     * <p>
+     * The default implementation of this method is provided for use in testing and to prevent compilation failure of
+     * implementing classes that have not yet implemented this method.
+     *
+     * @param configAddressBook the address book as loaded from config.txt. This address book may contain new nodes not
+     *                          present in the stateAddressBook. Must not be null.
+     * @param stateAddressBook  the address book loaded from the latest state on disk, or null if starting from genesis.
+     *                          May be null.
+     * @return a copy of the configuration address book with updated stake.
+     */
+    default AddressBook updateStake(final AddressBook configAddressBook, final AddressBook stateAddressBook) {
+        return configAddressBook;
+    }
 
     /**
      * {@inheritDoc}

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/system/SwirldState.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/system/SwirldState.java
@@ -112,11 +112,9 @@ public interface SwirldState extends MerkleNode {
      *
      * @param configAddressBook the address book as loaded from config.txt. This address book may contain new nodes not
      *                          present in the stateAddressBook. Must not be null.
-     * @param stateAddressBook  the address book loaded from the latest state on disk, or null if starting from genesis.
-     *                          May be null.
      * @return a copy of the configuration address book with updated stake.
      */
-    default AddressBook updateStake(final AddressBook configAddressBook, final AddressBook stateAddressBook) {
+    default AddressBook updateStake(final AddressBook configAddressBook) {
         return configAddressBook;
     }
 

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/system/SwirldState.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/system/SwirldState.java
@@ -21,7 +21,9 @@ import com.swirlds.common.merkle.MerkleNode;
 import com.swirlds.common.system.address.AddressBook;
 import com.swirlds.common.system.events.Event;
 import com.swirlds.common.system.transaction.Transaction;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * A Swirld app is defined by creating two classes, one implementing {@link SwirldMain}, and the other
@@ -114,7 +116,9 @@ public interface SwirldState extends MerkleNode {
      *                          present in the stateAddressBook. Must not be null.
      * @return a copy of the configuration address book with updated stake.
      */
-    default AddressBook updateStake(final AddressBook configAddressBook) {
+    @NonNull
+    default AddressBook updateStake(@NonNull final AddressBook configAddressBook) {
+        Objects.requireNonNull(configAddressBook, "configAddressBook must not be null");
         return configAddressBook;
     }
 

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/system/address/Address.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/system/address/Address.java
@@ -22,16 +22,17 @@ import com.swirlds.common.crypto.SerializablePublicKey;
 import com.swirlds.common.io.SelfSerializable;
 import com.swirlds.common.io.streams.SerializableDataInputStream;
 import com.swirlds.common.io.streams.SerializableDataOutputStream;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.IOException;
 import java.security.PublicKey;
 import java.util.Arrays;
 import java.util.Objects;
 
 /**
- * One address in an address book, including all the info about a member. It is immutable. Each getter for a
- * byte array returns a clone of that array. The constructor clones all the arrays passed to it. Each
- * "copySet" simply returns a new deep copy with one variable different. So it isn't a setter, but is a
- * variant of the builder design pattern without a separate build() method.
+ * One address in an address book, including all the info about a member. It is immutable. Each getter for a byte array
+ * returns a clone of that array. The constructor clones all the arrays passed to it. Each "copySet" simply returns a
+ * new deep copy with one variable different. So it isn't a setter, but is a variant of the builder design pattern
+ * without a separate build() method.
  */
 public class Address implements SelfSerializable {
     private static final long CLASS_ID = 0x5acfd3a4a32376eL;
@@ -139,44 +140,27 @@ public class Address implements SelfSerializable {
     /**
      * Same as
      * {@link #Address(long, String, String, long, boolean, byte[], int, byte[], int, byte[], int, byte[], int,
-     * SerializablePublicKey, SerializablePublicKey, SerializablePublicKey, String)}
-     * but with different key types.
+     * SerializablePublicKey, SerializablePublicKey, SerializablePublicKey, String)} but with different key types.
      * Deprecated, should use the method mentioned above.
      *
-     * @param id
-     * 		the ID for that member
-     * @param nickname
-     * 		the name given to that member by the member creating this address
-     * @param selfName
-     * 		the name given to that member by themself
-     * @param stake
-     * 		the amount of stake (0 if they should have no influence on the consensus)
-     * @param ownHost
-     * 		is that member running on the same machine as the member creating this address?
-     * @param addressInternalIpv4
-     * 		IPv4 address on the inside of the NATing router
-     * @param portInternalIpv4
-     * 		port for the internal IPv4 address
-     * @param addressExternalIpv4
-     * 		IPv4 address on the outside of the NATing router (same as internal if there is no NAT)
-     * @param portExternalIpv4
-     * 		port port for the external IPv4 address
-     * @param addressInternalIpv6
-     * 		IPv6 address on the inside of the NATing router
-     * @param portInternalIpv6
-     * 		port for the internal IPv6 address
-     * @param addressExternalIpv6
-     * 		address on the outside of the NATing router
-     * @param portExternalIpv6
-     * 		port for the external IPv6 address
-     * @param sigPublicKey
-     * 		public key used for signing
-     * @param encPublicKey
-     * 		public key used for encryption
-     * @param agreePublicKey
-     * 		public key used for key agreement in TLS
-     * @param memo
-     * 		additional information about the node, can be null
+     * @param id                  the ID for that member
+     * @param nickname            the name given to that member by the member creating this address
+     * @param selfName            the name given to that member by themself
+     * @param stake               the amount of stake (0 if they should have no influence on the consensus)
+     * @param ownHost             is that member running on the same machine as the member creating this address?
+     * @param addressInternalIpv4 IPv4 address on the inside of the NATing router
+     * @param portInternalIpv4    port for the internal IPv4 address
+     * @param addressExternalIpv4 IPv4 address on the outside of the NATing router (same as internal if there is no
+     *                            NAT)
+     * @param portExternalIpv4    port port for the external IPv4 address
+     * @param addressInternalIpv6 IPv6 address on the inside of the NATing router
+     * @param portInternalIpv6    port for the internal IPv6 address
+     * @param addressExternalIpv6 address on the outside of the NATing router
+     * @param portExternalIpv6    port for the external IPv6 address
+     * @param sigPublicKey        public key used for signing
+     * @param encPublicKey        public key used for encryption
+     * @param agreePublicKey      public key used for key agreement in TLS
+     * @param memo                additional information about the node, can be null
      */
     @Deprecated
     public Address(
@@ -220,40 +204,24 @@ public class Address implements SelfSerializable {
     /**
      * constructor for a mutable address for one member.
      *
-     * @param id
-     * 		the ID for that member
-     * @param nickname
-     * 		the name given to that member by the member creating this address
-     * @param selfName
-     * 		the name given to that member by themself
-     * @param stake
-     * 		the amount of stake (0 if they should have no influence on the consensus)
-     * @param ownHost
-     * 		is that member running on the same machine as the member creating this address?
-     * @param addressInternalIpv4
-     * 		IPv4 address on the inside of the NATing router
-     * @param portInternalIpv4
-     * 		port for the internal IPv4 address
-     * @param addressExternalIpv4
-     * 		IPv4 address on the outside of the NATing router (same as internal if there is no NAT)
-     * @param portExternalIpv4
-     * 		port for the external IPv4 address
-     * @param addressInternalIpv6
-     * 		IPv6 address on the inside of the NATing router
-     * @param portInternalIpv6
-     * 		port for the internal IPv6 address
-     * @param addressExternalIpv6
-     * 		address on the outside of the NATing router
-     * @param portExternalIpv6
-     * 		port for the external IPv6 address
-     * @param sigPublicKey
-     * 		public key used for signing
-     * @param encPublicKey
-     * 		public key used for encryption
-     * @param agreePublicKey
-     * 		public key used for key agreement in TLS
-     * @param memo
-     * 		additional information about the node, can be null
+     * @param id                  the ID for that member
+     * @param nickname            the name given to that member by the member creating this address
+     * @param selfName            the name given to that member by themself
+     * @param stake               the amount of stake (0 if they should have no influence on the consensus)
+     * @param ownHost             is that member running on the same machine as the member creating this address?
+     * @param addressInternalIpv4 IPv4 address on the inside of the NATing router
+     * @param portInternalIpv4    port for the internal IPv4 address
+     * @param addressExternalIpv4 IPv4 address on the outside of the NATing router (same as internal if there is no
+     *                            NAT)
+     * @param portExternalIpv4    port for the external IPv4 address
+     * @param addressInternalIpv6 IPv6 address on the inside of the NATing router
+     * @param portInternalIpv6    port for the internal IPv6 address
+     * @param addressExternalIpv6 address on the outside of the NATing router
+     * @param portExternalIpv6    port for the external IPv6 address
+     * @param sigPublicKey        public key used for signing
+     * @param encPublicKey        public key used for encryption
+     * @param agreePublicKey      public key used for key agreement in TLS
+     * @param memo                additional information about the node, can be null
      */
     public Address(
             final long id,
@@ -365,8 +333,7 @@ public class Address implements SelfSerializable {
     /**
      * Get local IP port
      *
-     * @param a
-     * 		the Address object to be operated on
+     * @param a the Address object to be operated on
      * @return port number
      */
     public int getConnectPortIpv4(Address a) {
@@ -376,8 +343,7 @@ public class Address implements SelfSerializable {
     /**
      * Check whether a given Address has the same external IPv4 address as mine.
      *
-     * @param a
-     * 		Given Address to check.
+     * @param a Given Address to check.
      * @return True if they are exactly the same.
      */
     public boolean isLocalTo(Address a) {
@@ -513,8 +479,7 @@ public class Address implements SelfSerializable {
     /**
      * Create a new Address object based this one with different Id.
      *
-     * @param id
-     * 		New Id for the created Address.
+     * @param id New Id for the created Address.
      * @return The new Address.
      */
     public Address copySetId(long id) {
@@ -526,8 +491,7 @@ public class Address implements SelfSerializable {
     /**
      * Create a new Address object based this one with different stake.
      *
-     * @param stake
-     * 		New stake for the created Address.
+     * @param stake New stake for the created Address.
      * @return The new Address.
      */
     public Address copySetStake(long stake) {
@@ -539,8 +503,7 @@ public class Address implements SelfSerializable {
     /**
      * Create a new Address object based this one with different nickname.
      *
-     * @param nickname
-     * 		New nickname for the created Address.
+     * @param nickname New nickname for the created Address.
      * @return The new Address.
      */
     public Address copySetNickname(String nickname) {
@@ -552,8 +515,7 @@ public class Address implements SelfSerializable {
     /**
      * Create a new Address object based this one with different selfName.
      *
-     * @param selfName
-     * 		New selfName for the created Address.
+     * @param selfName New selfName for the created Address.
      * @return The new Address.
      */
     public Address copySetSelfName(String selfName) {
@@ -565,8 +527,7 @@ public class Address implements SelfSerializable {
     /**
      * Create a new Address object based this one with different ownHost value.
      *
-     * @param ownHost
-     * 		New ownHost for the created Address.
+     * @param ownHost New ownHost for the created Address.
      * @return The new Address.
      */
     public Address copySetOwnHost(boolean ownHost) {
@@ -578,8 +539,7 @@ public class Address implements SelfSerializable {
     /**
      * Create a new Address object based this one with different internal IPv4 port.
      *
-     * @param portInternalIpv4
-     * 		New portInternalIpv4 for the created Address.
+     * @param portInternalIpv4 New portInternalIpv4 for the created Address.
      * @return The new Address.
      */
     public Address copySetPortInternalIpv4(int portInternalIpv4) {
@@ -591,8 +551,7 @@ public class Address implements SelfSerializable {
     /**
      * Create a new Address object based this one with different internal IPv6 port.
      *
-     * @param portInternalIpv6
-     * 		New portInternalIpv6 for the created Address.
+     * @param portInternalIpv6 New portInternalIpv6 for the created Address.
      * @return The new Address.
      */
     public Address copySetPortInternalIpv6(int portInternalIpv6) {
@@ -604,8 +563,7 @@ public class Address implements SelfSerializable {
     /**
      * Create a new Address object based this one with different external Ipv4 port.
      *
-     * @param portExternalIpv4
-     * 		New portExternalIpv4 for the created Address.
+     * @param portExternalIpv4 New portExternalIpv4 for the created Address.
      * @return The new Address.
      */
     public Address copySetPortExternalIpv4(int portExternalIpv4) {
@@ -617,8 +575,7 @@ public class Address implements SelfSerializable {
     /**
      * Create a new Address object based this one with different external Ipv6 port.
      *
-     * @param portExternalIpv6
-     * 		New portExternalIpv6 for the created Address.
+     * @param portExternalIpv6 New portExternalIpv6 for the created Address.
      * @return The new Address.
      */
     public Address copySetPortExternalIpv6(int portExternalIpv6) {
@@ -630,8 +587,7 @@ public class Address implements SelfSerializable {
     /**
      * Create a new Address object based this one with different internal IPv4 address.
      *
-     * @param AddressInternalIpv4
-     * 		New AddressInternalIpv4 for the created Address.
+     * @param AddressInternalIpv4 New AddressInternalIpv4 for the created Address.
      * @return The new Address.
      */
     public Address copySetAddressInternalIpv4(byte[] AddressInternalIpv4) {
@@ -643,8 +599,7 @@ public class Address implements SelfSerializable {
     /**
      * Create a new Address object based this one with different internal IPv6 address.
      *
-     * @param AddressInternalIpv6
-     * 		New AddressInternalIpv6 for the created Address.
+     * @param AddressInternalIpv6 New AddressInternalIpv6 for the created Address.
      * @return The new Address.
      */
     public Address copySetAddressInternalIpv6(byte[] AddressInternalIpv6) {
@@ -656,8 +611,7 @@ public class Address implements SelfSerializable {
     /**
      * Create a new Address object based this one with different external IPv4 address.
      *
-     * @param AddressExternalIpv4
-     * 		New AddressExternalIpv4 for the created Address.
+     * @param AddressExternalIpv4 New AddressExternalIpv4 for the created Address.
      * @return The new Address.
      */
     public Address copySetAddressExternalIpv4(byte[] AddressExternalIpv4) {
@@ -669,8 +623,7 @@ public class Address implements SelfSerializable {
     /**
      * Create a new Address object based this one with different external IPv6 address.
      *
-     * @param AddressExternalIpv6
-     * 		New AddressExternalIpv6 for the created Address.
+     * @param AddressExternalIpv6 New AddressExternalIpv6 for the created Address.
      * @return The new Address.
      */
     public Address copySetAddressExternalIpv6(byte[] AddressExternalIpv6) {
@@ -682,8 +635,7 @@ public class Address implements SelfSerializable {
     /**
      * Create a new Address object based this one with different PublicKey for signature.
      *
-     * @param sigPublicKey
-     * 		New sigPublicKey for the created Address.
+     * @param sigPublicKey New sigPublicKey for the created Address.
      * @return The new Address.
      */
     public Address copySetSigPublicKey(PublicKey sigPublicKey) {
@@ -695,8 +647,7 @@ public class Address implements SelfSerializable {
     /**
      * Create a new Address object based this one with different PublicKey for encrypting.
      *
-     * @param encPublicKey
-     * 		New encPublicKey for the created Address.
+     * @param encPublicKey New encPublicKey for the created Address.
      * @return The new Address.
      */
     public Address copySetEncPublicKey(PublicKey encPublicKey) {
@@ -708,8 +659,7 @@ public class Address implements SelfSerializable {
     /**
      * Create a new Address object based this one with different PublicKey for TLS key agreement.
      *
-     * @param agreePublicKey
-     * 		New agreePublicKey for the created Address.
+     * @param agreePublicKey New agreePublicKey for the created Address.
      * @return The new Address.
      */
     public Address copySetAgreePublicKey(PublicKey agreePublicKey) {
@@ -747,10 +697,8 @@ public class Address implements SelfSerializable {
     /**
      * Write the Address to the given stream. It should later be read from the stream with readAddress().
      *
-     * @param outStream
-     * 		the stream to write to.
-     * @throws IOException
-     * 		thrown if there any problems during operation
+     * @param outStream the stream to write to.
+     * @throws IOException thrown if there any problems during operation
      */
     @Deprecated
     public void writeAddress(SerializableDataOutputStream outStream) throws IOException {
@@ -758,16 +706,13 @@ public class Address implements SelfSerializable {
     }
 
     /**
-     * Return a new Address object read from the given stream. It should have been written to the stream
-     * with writeAddress().
+     * Return a new Address object read from the given stream. It should have been written to the stream with
+     * writeAddress().
      *
-     * @param inStream
-     * 		the stream to read from
-     * @param version
-     * 		the version of the serialized address
+     * @param inStream the stream to read from
+     * @param version  the version of the serialized address
      * @return the new Address object that was read.
-     * @throws IOException
-     * 		thrown if there are any problems in operation
+     * @throws IOException thrown if there are any problems in operation
      * @deprecated 0.6.6
      */
     @Deprecated(forRemoval = true)
@@ -851,8 +796,7 @@ public class Address implements SelfSerializable {
     /**
      * Return the String of dot format of the IPv4 address.
      *
-     * @param ip
-     * 		IP address.
+     * @param ip IP address.
      * @return IP address String of dot format.
      */
     public static String ipString(byte[] ip) {
@@ -873,9 +817,19 @@ public class Address implements SelfSerializable {
         }
 
         Address address = (Address) o;
+        return equalsWithoutStake(address) && stake == address.stake;
+    }
+
+    /**
+     * Checks for equality with another addresses without checking the equality of stake values.
+     *
+     * @param address The other address to check for equality with this address.
+     * @return true if all values in the other address match this address without consideration of stake, false
+     * otherwise.
+     */
+    public boolean equalsWithoutStake(@NonNull final Address address) {
         return id == address.id
                 && ownHost == address.ownHost
-                && stake == address.stake
                 && portInternalIpv4 == address.portInternalIpv4
                 && portExternalIpv4 == address.portExternalIpv4
                 && portInternalIpv6 == address.portInternalIpv6

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/system/address/AddressBookValidator.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/system/address/AddressBookValidator.java
@@ -18,12 +18,14 @@ package com.swirlds.common.system.address;
 
 import static com.swirlds.logging.LogMarker.EXCEPTION;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.stream.IntStream;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 /**
- * This class provides methods for validating new address books. These methods do not throw exceptions if
- * validation fails, but they are intentionally very noisy in the logs when they fail.
+ * This class provides methods for validating new address books. These methods do not throw exceptions if validation
+ * fails, but they are intentionally very noisy in the logs when they fail.
  */
 public final class AddressBookValidator {
 
@@ -37,8 +39,7 @@ public final class AddressBookValidator {
     /**
      * Make sure the address book has at least some stake.
      *
-     * @param addressBook
-     * 		the address book to validate
+     * @param addressBook the address book to validate
      * @return if the address book passes this validation
      */
     public static boolean hasNonZeroStake(final AddressBook addressBook) {
@@ -56,8 +57,7 @@ public final class AddressBookValidator {
     /**
      * Make sure the address book is not empty.
      *
-     * @param addressBook
-     * 		the address book to validate
+     * @param addressBook the address book to validate
      * @return if the address book passes this validation
      */
     public static boolean isNonEmpty(final AddressBook addressBook) {
@@ -71,10 +71,8 @@ public final class AddressBookValidator {
     /**
      * Sanity check, make sure that the next address book has a next ID greater or equal to the previous one.
      *
-     * @param previousAddressBook
-     * 		the previous address book
-     * @param addressBook
-     * 		the address book to validate
+     * @param previousAddressBook the previous address book
+     * @param addressBook         the address book to validate
      * @return if the address book passes this validation
      */
     public static boolean validNextId(final AddressBook previousAddressBook, final AddressBook addressBook) {
@@ -94,13 +92,11 @@ public final class AddressBookValidator {
 
     /**
      * No address that is removed may be re-added to the address book. If address N is skipped and address N+1 is later
-     * added, then address N can never be added (as this is difficult to distinguish from
-     * N being added and then removed).
+     * added, then address N can never be added (as this is difficult to distinguish from N being added and then
+     * removed).
      *
-     * @param previousAddressBook
-     * 		the previous address book
-     * @param addressBook
-     * 		the address book to validate
+     * @param previousAddressBook the previous address book
+     * @param addressBook         the address book to validate
      * @return if the address book passes this validation
      */
     public static boolean noAddressReinsertion(final AddressBook previousAddressBook, final AddressBook addressBook) {
@@ -121,11 +117,10 @@ public final class AddressBookValidator {
     }
 
     /**
-     * Check if a genesis address book is valid. In the case of an invalid address book, this method will
-     * write an error message to the log.
+     * Check if a genesis address book is valid. In the case of an invalid address book, this method will write an error
+     * message to the log.
      *
-     * @param candidateAddressBook
-     * 		a candidate address book that is being tested for validity
+     * @param candidateAddressBook a candidate address book that is being tested for validity
      * @return true if the address book is valid
      */
     public static boolean isGenesisAddressBookValid(final AddressBook candidateAddressBook) {
@@ -134,13 +129,11 @@ public final class AddressBookValidator {
     }
 
     /**
-     * Check if a new address book transition is valid. In the case of an invalid address book, this method will
-     * write an error message to the log.
+     * Check if a new address book transition is valid. In the case of an invalid address book, this method will write
+     * an error message to the log.
      *
-     * @param previousAddressBook
-     * 		the previous address book, is assumed to be valid
-     * @param candidateAddressBook
-     * 		the new address book that follows the current address book
+     * @param previousAddressBook  the previous address book, is assumed to be valid
+     * @param candidateAddressBook the new address book that follows the current address book
      * @return true if the transition is valid
      */
     public static boolean isNextAddressBookValid(
@@ -150,5 +143,44 @@ public final class AddressBookValidator {
                 && isNonEmpty(candidateAddressBook)
                 && validNextId(previousAddressBook, candidateAddressBook)
                 && noAddressReinsertion(previousAddressBook, candidateAddressBook);
+    }
+
+    /**
+     * Checks that the addresses between the two address books are identical except for stake value.
+     *
+     * @param addressBook1 An address book to compare for equality.
+     * @param addressBook2 An address book to compare for equality.
+     * @return true of the two address books contain the same addresses except for stake values, false otherwise.
+     */
+    public static boolean sameExceptForStake(
+            @NonNull final AddressBook addressBook1, @NonNull final AddressBook addressBook2) {
+        final int addressBookSize = addressBook1.getSize();
+        return addressBookSize == addressBook2.getSize()
+                && IntStream.range(0, addressBookSize)
+                        .mapToObj(i -> {
+                            final Address address1 = addressBook1.getAddress(i);
+                            final Address address2 = addressBook2.getAddress(i);
+                            if (address1 == null) {
+                                if (address2 == null) {
+                                    return true;
+                                } else {
+                                    logger.error(
+                                            EXCEPTION.getMarker(),
+                                            "Address at position {} is not the same between the two address books.",
+                                            i);
+                                    return false;
+                                }
+                            }
+                            final boolean equal = address1.equalsWithoutStake(address2);
+                            if (!equal) {
+                                logger.error(
+                                        EXCEPTION.getMarker(),
+                                        "Address at position {} is not the same between the two address books.",
+                                        i);
+                            }
+                            return equal;
+                        })
+                        .reduce((left, right) -> left && right)
+                        .orElse(false);
     }
 }

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/system/address/AddressBookValidator.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/system/address/AddressBookValidator.java
@@ -158,18 +158,16 @@ public final class AddressBookValidator {
         return addressBookSize == addressBook2.getSize()
                 && IntStream.range(0, addressBookSize)
                         .mapToObj(i -> {
-                            final Address address1 = addressBook1.getAddress(i);
-                            final Address address2 = addressBook2.getAddress(i);
-                            if (address1 == null) {
-                                if (address2 == null) {
-                                    return true;
-                                } else {
-                                    logger.error(
-                                            EXCEPTION.getMarker(),
-                                            "Address at position {} is not the same between the two address books.",
-                                            i);
-                                    return false;
-                                }
+                            final long nodeId1 = addressBook1.getId(i);
+                            final long nodeId2 = addressBook2.getId(i);
+                            final Address address1 = addressBook1.getAddress(nodeId1);
+                            final Address address2 = addressBook2.getAddress(nodeId2);
+                            if (address1 == null || address2 == null) {
+                                logger.error(
+                                        EXCEPTION.getMarker(),
+                                        "Address at index {} is null when accessed in order.",
+                                        i);
+                                throw new IllegalStateException("Address at index " + i + " is null.");
                             }
                             final boolean equal = address1.equalsWithoutStake(address2);
                             if (!equal) {

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/AddressBookInitializer.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/AddressBookInitializer.java
@@ -84,7 +84,7 @@ public class AddressBookInitializer {
     @NonNull
     private final AddressBook initialAddressBook;
     /** The path to the directory for writing address books. */
-    @NonNull
+    @Nullable
     private final Path pathToAddressBookDirectory;
     /** Indicate that the unmodified config address book must be used. */
     private final boolean useConfigAddressBook;

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/AddressBookInitializer.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/AddressBookInitializer.java
@@ -160,7 +160,7 @@ public class AddressBookInitializer {
                             + "genesisSwirldState.updateStake(configAddressBook, null).");
             final SwirldState genesisState = genesisSupplier.get();
             candidateAddressBook =
-                    genesisState.updateStake(configAddressBook.copy(), null).copy();
+                    genesisState.updateStake(configAddressBook.copy()).copy();
             genesisState.release();
         } else {
             final SoftwareVersion loadedSoftwareVersion = loadedSignedState
@@ -188,7 +188,7 @@ public class AddressBookInitializer {
                         currentVersion);
                 candidateAddressBook = loadedSignedState
                         .getSwirldState()
-                        .updateStake(configAddressBook.copy(), loadedAddressBook.copy())
+                        .updateStake(configAddressBook.copy())
                         .copy();
             }
         }
@@ -232,12 +232,13 @@ public class AddressBookInitializer {
      * @param usedAddressBook the address book to be returned from the AddressBookInitializer.
      */
     private void recordAddressBooks(@NonNull final AddressBook usedAddressBook) {
-        final String addressBookFileName =
-                ADDRESS_BOOK_FILE_PREFIX + "_" + currentVersion + "_" + DATE_TIME_FORMAT.format(Instant.now()) + ".txt";
+        final String date = DATE_TIME_FORMAT.format(Instant.now());
+        final String addressBookFileName = ADDRESS_BOOK_FILE_PREFIX + "_v" + currentVersion + "_" + date + ".txt";
+        final String addressBookDebugFileName = addressBookFileName + ".debug";
         try {
-            final File file = Path.of(this.pathToAddressBookDirectory.toString(), addressBookFileName)
+            final File debugFile = Path.of(this.pathToAddressBookDirectory.toString(), addressBookDebugFileName)
                     .toFile();
-            try (final FileWriter out = new FileWriter(file)) {
+            try (final FileWriter out = new FileWriter(debugFile)) {
                 out.write(CONFIG_ADDRESS_BOOK_HEADER + "\n");
                 out.write(configAddressBook.toConfigText() + "\n\n");
                 out.write(STATE_ADDRESS_BOOK_HEADER + "\n");
@@ -253,6 +254,11 @@ public class AddressBookInitializer {
                     out.write(usedAddressBook.toConfigText());
                 }
                 out.write("\n\n");
+            }
+            final File usedFile = Path.of(this.pathToAddressBookDirectory.toString(), addressBookFileName)
+                    .toFile();
+            try (final FileWriter out = new FileWriter(usedFile)) {
+                out.write(usedAddressBook.toConfigText());
             }
         } catch (final IOException e) {
             logger.error(EXCEPTION.getMarker(), "Not able to write address book to file. ", e);

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/AddressBookInitializer.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/AddressBookInitializer.java
@@ -1,0 +1,288 @@
+/*
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.swirlds.platform;
+
+import static com.swirlds.logging.LogMarker.EXCEPTION;
+import static com.swirlds.logging.LogMarker.STARTUP;
+
+import com.swirlds.common.system.SoftwareVersion;
+import com.swirlds.common.system.SwirldState;
+import com.swirlds.common.system.address.AddressBook;
+import com.swirlds.common.system.address.AddressBookValidator;
+import com.swirlds.platform.state.signed.SignedState;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.Objects;
+import java.util.function.Supplier;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+/**
+ * Determines the initial address book to use at platform start and validates it.
+ */
+public class AddressBookInitializer {
+
+    /** The header before the config address book in the usedAddressBook file. */
+    public static final String CONFIG_ADDRESS_BOOK_HEADER = "--- Configuration Address Book ---";
+    /** The header before the state address book in the usedAddressBook file. */
+    public static final String STATE_ADDRESS_BOOK_HEADER = "--- State Saved Address Book ---";
+    /** The header before the used address book in the usedAddressBook file. */
+    public static final String USED_ADDRESS_BOOK_HEADER = "--- Used Address Book ---";
+    /** The text indicating the config address book was used in the usedAddressBook file. */
+    public static final String CONFIG_ADDRESS_BOOK_USED = "The Configuration Address Book Was Used.";
+    /** The text indicating the state address book was used in the usedAddressBook file. */
+    public static final String STATE_ADDRESS_BOOK_USED = "The State Saved Address Book Was Used.";
+    /** The text indicating the state address book was null in the usedAddressBook file. */
+    public static final String STATE_ADDRESS_BOOK_NULL = "The State Saved Address Book Was NULL.";
+    /** The name of the address book directory to write address books to. */
+    private static final String ADDRESS_BOOK_DIRECTORY_NAME = "address_book";
+    /** The file name prefix to use when creating address book files. */
+    private static final String ADDRESS_BOOK_FILE_PREFIX = "usedAddressBook";
+    /** The format of date and time to use when creating address book files. */
+    private static final DateTimeFormatter DATE_TIME_FORMAT =
+            DateTimeFormatter.ofPattern("yyyy-MM-dd-HH-m-ss").withZone(ZoneId.systemDefault());
+    /** For logging info, warn, and error. */
+    private static final Logger logger = LogManager.getLogger(AddressBookInitializer.class);
+    /** The current version of the application from config.txt. */
+    @NonNull
+    private final SoftwareVersion currentVersion;
+    /** The SwirldState to use at genesis. */
+    @NonNull
+    private final Supplier<SwirldState> genesisSupplier;
+    /** The software version recorded in the saved signed state on disk. May be null. */
+    @Nullable
+    private final SoftwareVersion loadedSoftwareVersion;
+    /** the SwirldState provided by the saved signed state. */
+    @Nullable
+    private final SwirldState loadedSwirldState;
+    /** The address book loaded from the saved signed state on disk. May be null. */
+    @Nullable
+    private final AddressBook loadedAddressBook;
+    /** The address book derived from config.txt */
+    @NonNull
+    private final AddressBook configAddressBook;
+    /** The address book determined for use after {@link AddressBookInitializer#initialize()} is called. */
+    @NonNull
+    private final AddressBook initialAddressBook;
+    /** The path to the directory for writing address books. */
+    @NonNull
+    private final Path pathToAddressBookDirectory;
+    /** Indicate that the unmodified config address book must be used. */
+    private final boolean useConfigAddressBook;
+
+    /**
+     * Constructs an AddressBookInitializer to initialize an address book from the swirld application state, config.txt,
+     * and the saved state from disk.
+     *
+     * @param currentVersion       The current version of the application. Must not be null.
+     * @param signedState          The signed state loaded from disk.  May be null.
+     * @param genesisSupplier      The swirld application state in genesis start. Must not be null.
+     * @param configAddressBook    The address book derived from config.txt. Must not be null.
+     * @param parentDirectory      The parent directory of the address book directory. Must not be null.
+     * @param useConfigAddressBook Indicates if the unmodified config address book should be used.
+     */
+    public AddressBookInitializer(
+            @NonNull final SoftwareVersion currentVersion,
+            @Nullable final SignedState signedState,
+            @NonNull final Supplier<SwirldState> genesisSupplier,
+            @NonNull final AddressBook configAddressBook,
+            @NonNull final String parentDirectory,
+            @NonNull final boolean useConfigAddressBook) {
+        this.currentVersion = Objects.requireNonNull(currentVersion, "The currentVersion must not be null.");
+        this.genesisSupplier =
+                Objects.requireNonNull(genesisSupplier, "The genesis swirldState supplier must not be null.");
+        this.configAddressBook = Objects.requireNonNull(configAddressBook, "The configAddressBook must not be null.");
+        Objects.requireNonNull(parentDirectory, "The parentDirectory must not be null.");
+        this.useConfigAddressBook = useConfigAddressBook;
+        Path addressBookDirectoryPath = Path.of(parentDirectory, ADDRESS_BOOK_DIRECTORY_NAME);
+        try {
+            Files.createDirectories(addressBookDirectoryPath);
+        } catch (final IOException e) {
+            logger.error(EXCEPTION.getMarker(), "Not able to create directory: {}", addressBookDirectoryPath, e);
+            addressBookDirectoryPath = null;
+        }
+        this.pathToAddressBookDirectory = addressBookDirectoryPath;
+
+        if (signedState != null) {
+            this.loadedAddressBook = signedState.getAddressBook();
+            this.loadedSwirldState = signedState.getSwirldState();
+            SoftwareVersion stateVersion;
+            try {
+                stateVersion = signedState
+                        .getState()
+                        .getPlatformState()
+                        .getPlatformData()
+                        .getCreationSoftwareVersion();
+            } catch (final Exception e) {
+                logger.error(EXCEPTION.getMarker(), "Unable to retrieve software version from signed state.");
+                stateVersion = null;
+            }
+            this.loadedSoftwareVersion = stateVersion;
+        } else {
+            this.loadedAddressBook = null;
+            this.loadedSwirldState = null;
+            this.loadedSoftwareVersion = null;
+        }
+        initialAddressBook = initialize();
+    }
+
+    /**
+     * Returns the address book to use in the platform.
+     *
+     * @return the address book to use in the platform.
+     */
+    @NonNull
+    public AddressBook getInitialAddressBook() {
+        return initialAddressBook;
+    }
+
+    /**
+     * Determines the address book to use.  If there is no saved platform state, the config address book stake is
+     * updated by the swirld application state.  If the configured current version of the application is higher than the
+     * save state version, the swirld state is given both the config and previously saved address book to determine
+     * stake weights.  If the address book returned by the swirld application is valid, it is the initial address book
+     * to use, otherwise the configuration address book is the one to use.  All three address books, the configuration
+     * address book, the save state address book, and the new address book to use are recorded in the used address book
+     * file.
+     *
+     * @return the address book to use in the platform.
+     */
+    @NonNull
+    private AddressBook initialize() {
+        AddressBook candidateAddressBook = null;
+        if (useConfigAddressBook) {
+            // configuration is overriding to force use of configuration address book.
+            candidateAddressBook = configAddressBook;
+        } else if (loadedSoftwareVersion == null || loadedAddressBook == null || loadedSwirldState == null) {
+            logger.info(
+                    STARTUP.getMarker(),
+                    "The candidateAddressBook is set to genesisSwirldState.updateStake(configAddressBook, null)."
+                            + " Either the stateVersion or the stateAddressBook or the stateSwirldState are null.");
+            final SwirldState genesisState = genesisSupplier.get();
+            candidateAddressBook =
+                    genesisState.updateStake(configAddressBook.copy(), null).copy();
+            genesisState.release();
+        } else {
+            final int versionComparison = currentVersion.compareTo(loadedSoftwareVersion);
+            if (versionComparison < 0) {
+                throw new IllegalStateException("The currentVersion " + currentVersion
+                        + " is prior to the stateVersion " + loadedSoftwareVersion);
+            } else if (versionComparison == 0) {
+                logger.info(
+                        STARTUP.getMarker(),
+                        "No Software Upgrade. Continuing with software version {} and "
+                                + "using the loaded state's address book and stake values.",
+                        loadedSoftwareVersion);
+                candidateAddressBook = loadedAddressBook;
+            } else {
+                logger.info(
+                        STARTUP.getMarker(),
+                        "Software Upgrade from version {} to {}. "
+                                + "The address book stake will be updated by the saved state's SwirldState.",
+                        loadedSoftwareVersion,
+                        currentVersion);
+                candidateAddressBook = loadedSwirldState
+                        .updateStake(configAddressBook.copy(), loadedAddressBook.copy())
+                        .copy();
+            }
+        }
+        candidateAddressBook = checkCandidateAddressBookValidity(candidateAddressBook);
+        recordAddressBooks(candidateAddressBook);
+        return candidateAddressBook;
+    }
+
+    /**
+     * Checks if the candidateAddressBook is valid and returns it, otherwise returns the configAddressBook if it has
+     * non-zero stake.   If the candidateAddressBook's addresses are out of sync with the configAddressBook or both
+     * address books have 0 stake, an IllegalStateException is thrown.
+     *
+     * @return the valid address book to use.
+     */
+    @NonNull
+    private AddressBook checkCandidateAddressBookValidity(@Nullable final AddressBook candidateAddressBook) {
+        if (candidateAddressBook == null) {
+            logger.warn(STARTUP.getMarker(), "The candidateAddressBook is null, using configAddressBook instead.");
+            return configAddressBook;
+        } else if (!AddressBookValidator.hasNonZeroStake(candidateAddressBook)
+                || !AddressBookValidator.sameExceptForStake(configAddressBook, candidateAddressBook)) {
+            // an error was recorded by the address book validator.  Check the configuration address book for usability.
+            if (!AddressBookValidator.hasNonZeroStake(configAddressBook)) {
+                throw new IllegalStateException(
+                        "The candidateAddressBook is not valid and the configAddressBook has 0 total stake.");
+            } else {
+                logger.warn(
+                        STARTUP.getMarker(), "The candidateAddressBook is not valid, using configAddressBook instead.");
+                return configAddressBook;
+            }
+        }
+        return candidateAddressBook;
+    }
+
+    /**
+     * Records the configuration address book, the state loaded address book, and the usedAddressBook in a timestamped
+     * file for diagnostic purposes.  If the path to the address book directory does not resolve or a new file for
+     * address books cannot be created, no file is generated.
+     *
+     * @param usedAddressBook the address book to be returned from the AddressBookInitializer.
+     */
+    private void recordAddressBooks(@NonNull final AddressBook usedAddressBook) {
+        final String addressBookFileName =
+                ADDRESS_BOOK_FILE_PREFIX + "_" + currentVersion + "_" + DATE_TIME_FORMAT.format(Instant.now()) + ".txt";
+        try {
+            if (pathToAddressBookDirectory != null) {
+                final File file = Path.of(this.pathToAddressBookDirectory.toString(), addressBookFileName)
+                        .toFile();
+                try (final FileWriter out = new FileWriter(file)) {
+                    out.write(CONFIG_ADDRESS_BOOK_HEADER + "\n");
+                    out.write(configAddressBook.toConfigText() + "\n\n");
+                    out.write(STATE_ADDRESS_BOOK_HEADER + "\n");
+                    final String text =
+                            loadedAddressBook == null ? STATE_ADDRESS_BOOK_NULL : loadedAddressBook.toConfigText();
+                    out.write(text + "\n\n");
+                    out.write(USED_ADDRESS_BOOK_HEADER + "\n");
+                    if (usedAddressBook == configAddressBook) {
+                        out.write(CONFIG_ADDRESS_BOOK_USED);
+                    } else if (usedAddressBook == loadedAddressBook) {
+                        out.write(STATE_ADDRESS_BOOK_USED);
+                    } else {
+                        out.write(usedAddressBook.toConfigText());
+                    }
+                }
+            }
+        } catch (final IOException e) {
+            logger.error(EXCEPTION.getMarker(), "Not able to write address book to file. ", e);
+        }
+    }
+
+    /**
+     * Get the path to the directory where the address books are being recorded.
+     *
+     * @return the directory where the address books are being recorded.
+     */
+    @NonNull
+    public Path getPathToAddressBookDirectory() {
+        return pathToAddressBookDirectory;
+    }
+}

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/Browser.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/Browser.java
@@ -30,6 +30,7 @@ import static com.swirlds.platform.gui.internal.BrowserWindowManager.setInsets;
 import static com.swirlds.platform.gui.internal.BrowserWindowManager.setStateHierarchy;
 import static com.swirlds.platform.gui.internal.BrowserWindowManager.showBrowserWindow;
 import static com.swirlds.platform.state.address.AddressBookUtils.getOwnHostCount;
+import static com.swirlds.platform.state.signed.SignedStateFileReader.getSavedStateFiles;
 import static com.swirlds.platform.system.SystemExitReason.NODE_ADDRESS_MISMATCH;
 
 import com.swirlds.common.StartupTime;
@@ -59,6 +60,7 @@ import com.swirlds.common.metrics.platform.DefaultMetricsProvider;
 import com.swirlds.common.metrics.platform.prometheus.PrometheusConfig;
 import com.swirlds.common.system.NodeId;
 import com.swirlds.common.system.Platform;
+import com.swirlds.common.system.SoftwareVersion;
 import com.swirlds.common.system.SwirldMain;
 import com.swirlds.common.system.address.Address;
 import com.swirlds.common.system.address.AddressBook;
@@ -87,12 +89,18 @@ import com.swirlds.platform.gui.internal.InfoApp;
 import com.swirlds.platform.gui.internal.InfoMember;
 import com.swirlds.platform.gui.internal.InfoSwirld;
 import com.swirlds.platform.gui.internal.StateHierarchy;
+import com.swirlds.platform.reconnect.emergency.EmergencySignedStateValidator;
+import com.swirlds.platform.state.EmergencyRecoveryManager;
+import com.swirlds.platform.state.signed.SavedStateInfo;
+import com.swirlds.platform.state.signed.SignedState;
 import com.swirlds.platform.state.signed.SignedStateFileUtils;
 import com.swirlds.platform.swirldapp.AppLoaderException;
 import com.swirlds.platform.swirldapp.SwirldAppLoader;
+import com.swirlds.platform.system.Shutdown;
 import com.swirlds.platform.system.SystemUtils;
 import com.swirlds.platform.util.MetricsDocUtils;
 import com.swirlds.virtualmap.config.VirtualMapConfig;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import java.awt.Dimension;
 import java.awt.Frame;
 import java.awt.GraphicsEnvironment;
@@ -496,6 +504,33 @@ public class Browser {
                 final SwirldMain appMain = buildAppMain(appDefinition, appLoader);
                 appMain.setConfiguration(configuration);
 
+                // name of the app's SwirldMain class
+                final String mainClassName = appDefinition.getMainClassName();
+                // the name of this swirld
+                final String swirldName = appDefinition.getSwirldName();
+                final SoftwareVersion appVersion = appMain.getSoftwareVersion();
+                // We can't send a "real" dispatch, since the dispatcher will not have been started by the
+                // time this class is used.
+                final EmergencyRecoveryManager emergencyRecoveryManager = new EmergencyRecoveryManager(
+                        Shutdown::immediateShutDown, Settings.getInstance().getEmergencyRecoveryFileLoadDir());
+
+                final SignedState loadedSignedState = getUnmodifiedSignedStateFromDisk(
+                        mainClassName, swirldName, nodeId, appVersion, addressBook.copy(), emergencyRecoveryManager);
+
+                final StateConfig stateConfig =
+                        platformContext.getConfiguration().getConfigData(StateConfig.class);
+
+                // Initialize the address book from the configuration and platform saved state.
+                final AddressBookInitializer addressBookInitializer = new AddressBookInitializer(
+                        appVersion,
+                        loadedSignedState,
+                        appMain::newState,
+                        addressBook.copy(),
+                        stateConfig.savedStateDirectory(),
+                        stateConfig.forceUseOfConfigAddressBook());
+                // set here, then given to the state in run(). A copy of it is given to hashgraph.
+                final AddressBook initialAddressBook = addressBookInitializer.getInitialAddressBook();
+
                 final SwirldsPlatform platform = new SwirldsPlatform(
                         // window index
                         ownHostIndex,
@@ -508,15 +543,15 @@ public class Browser {
                         // address book index, which is the member ID
                         nodeId,
                         // copy of the address book,
-                        addressBook.copy(),
+                        initialAddressBook,
                         platformContext,
                         platformName,
-                        // name of the app's SwirldMain class
-                        appDefinition.getMainClassName(),
-                        // the name of this swirld
-                        appDefinition.getSwirldName(),
-                        appMain.getSoftwareVersion(),
-                        appMain::newState);
+                        mainClassName,
+                        swirldName,
+                        appVersion,
+                        appMain::newState,
+                        loadedSignedState,
+                        emergencyRecoveryManager);
 
                 new InfoMember(infoSwirld, i, platform);
 
@@ -550,6 +585,42 @@ public class Browser {
                 }
             }
         }
+    }
+
+    /**
+     * Load the signed state from the disk if it is present.
+     *
+     * @param mainClassName the name of the app's SwirldMain class.
+     * @param swirldName the name of the swirld to load the state for.
+     * @param selfId the ID of the node to load the state for.
+     * @param appVersion the version of the app to use for emergency recovery.
+     * @param configAddressBook the address book to use for emergency recovery.
+     * @param emergencyRecoveryManager the emergency recovery manager to use for emergency recovery.
+     * @return  the signed state loaded from disk.
+     */
+    private SignedState getUnmodifiedSignedStateFromDisk(
+            @NonNull final String mainClassName,
+            @NonNull final String swirldName,
+            @NonNull final NodeId selfId,
+            @NonNull final SoftwareVersion appVersion,
+            @NonNull final AddressBook configAddressBook,
+            @NonNull final EmergencyRecoveryManager emergencyRecoveryManager) {
+        final SavedStateInfo[] savedStateFiles = getSavedStateFiles(mainClassName, selfId, swirldName);
+        // We can't send a "real" dispatcher for shutdown, since the dispatcher will not have been started by the
+        // time this class is used.
+        final SavedStateLoader savedStateLoader = new SavedStateLoader(
+                Shutdown::immediateShutDown,
+                configAddressBook,
+                savedStateFiles,
+                appVersion,
+                () -> new EmergencySignedStateValidator(emergencyRecoveryManager.getEmergencyRecoveryFile()),
+                emergencyRecoveryManager);
+        try {
+            return savedStateLoader.getSavedStateToLoad();
+        } catch (final Exception e) {
+            logger.error(EXCEPTION.getMarker(), "Signed state not loaded from disk:", e);
+        }
+        return null;
     }
 
     /**

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/Browser.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/Browser.java
@@ -97,6 +97,7 @@ import com.swirlds.platform.state.signed.SignedStateFileUtils;
 import com.swirlds.platform.swirldapp.AppLoaderException;
 import com.swirlds.platform.swirldapp.SwirldAppLoader;
 import com.swirlds.platform.system.Shutdown;
+import com.swirlds.platform.system.SystemExitReason;
 import com.swirlds.platform.system.SystemUtils;
 import com.swirlds.platform.util.MetricsDocUtils;
 import com.swirlds.virtualmap.config.VirtualMapConfig;
@@ -619,6 +620,9 @@ public class Browser {
             return savedStateLoader.getSavedStateToLoad();
         } catch (final Exception e) {
             logger.error(EXCEPTION.getMarker(), "Signed state not loaded from disk:", e);
+            if (Settings.getInstance().isRequireStateLoad()) {
+                SystemUtils.exitSystem(SystemExitReason.SAVED_STATE_NOT_LOADED);
+            }
         }
         return null;
     }

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/SwirldsPlatform.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/SwirldsPlatform.java
@@ -444,7 +444,7 @@ public class SwirldsPlatform implements Platform, PlatformWithDeprecatedMethods,
             @NonNull final String swirldName,
             @NonNull final SoftwareVersion appVersion,
             @NonNull final Supplier<SwirldState> genesisStateBuilder,
-            @NonNull final SignedState loadedSignedState,
+            @Nullable final SignedState loadedSignedState,
             @NonNull final EmergencyRecoveryManager emergencyRecoveryManager) {
 
         this.platformContext = CommonUtils.throwArgNull(platformContext, "platformContext");

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/AddressBookInitializerTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/AddressBookInitializerTest.java
@@ -1,0 +1,483 @@
+/*
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.swirlds.platform;
+
+import static com.swirlds.platform.AddressBookInitializer.CONFIG_ADDRESS_BOOK_HEADER;
+import static com.swirlds.platform.AddressBookInitializer.CONFIG_ADDRESS_BOOK_USED;
+import static com.swirlds.platform.AddressBookInitializer.STATE_ADDRESS_BOOK_HEADER;
+import static com.swirlds.platform.AddressBookInitializer.STATE_ADDRESS_BOOK_NULL;
+import static com.swirlds.platform.AddressBookInitializer.STATE_ADDRESS_BOOK_USED;
+import static com.swirlds.platform.AddressBookInitializer.USED_ADDRESS_BOOK_HEADER;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.swirlds.common.io.utility.FileUtils;
+import com.swirlds.common.system.SoftwareVersion;
+import com.swirlds.common.system.SwirldState;
+import com.swirlds.common.system.address.Address;
+import com.swirlds.common.system.address.AddressBook;
+import com.swirlds.common.test.RandomAddressBookGenerator;
+import com.swirlds.platform.state.PlatformData;
+import com.swirlds.platform.state.PlatformState;
+import com.swirlds.platform.state.State;
+import com.swirlds.platform.state.signed.SignedState;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.stubbing.OngoingStubbing;
+
+class AddressBookInitializerTest {
+
+    @TempDir
+    Path testDirectory;
+
+    @Test
+    @DisplayName("Force the use of the config address book")
+    void forceUseOfConfigAddressBook() throws IOException {
+        clearTestDirectory();
+        final AddressBook configAddressBook = getRandomAddressBook();
+        final AddressBookInitializer initializer = new AddressBookInitializer(
+                getMockSoftwareVersion(1),
+                getMockSignedState(0),
+                getMockSwirldStateSupplier(1),
+                configAddressBook,
+                testDirectory.toString(),
+                true);
+        final AddressBook inititializedAddressBook = initializer.getInitialAddressBook();
+        assertEquals(
+                configAddressBook,
+                inititializedAddressBook,
+                "The initial address book must equal the config address book.");
+        assertAddressBookFileContent(initializer, configAddressBook, null, inititializedAddressBook);
+    }
+
+    @Test
+    @DisplayName("No state loaded from disk. Genesis State Initializes Address Book.")
+    void noStateLoadedFromDisk() throws IOException {
+        clearTestDirectory();
+        final AddressBook configAddressBook = getRandomAddressBook();
+        final AddressBook expectedAddressBook = copyWithStakeChanges(configAddressBook, 10);
+        final AddressBookInitializer initializer = new AddressBookInitializer(
+                getMockSoftwareVersion(1),
+                getMockSignedState(0),
+                getMockSwirldStateSupplier(10),
+                configAddressBook,
+                testDirectory.toString(),
+                false);
+        final AddressBook inititializedAddressBook = initializer.getInitialAddressBook();
+        assertEquals(
+                expectedAddressBook,
+                inititializedAddressBook,
+                "The initial address book must equal the expected address book.");
+        assertAddressBookFileContent(initializer, configAddressBook, null, inititializedAddressBook);
+    }
+
+    @Test
+    @DisplayName("No state loaded from disk. Genesis State set 0 stake.")
+    void noStateLoadedFromDiskGenesisStateSetZeroStake() throws IOException {
+        clearTestDirectory();
+        final AddressBook configAddressBook = getRandomAddressBook();
+        final AddressBookInitializer initializer = new AddressBookInitializer(
+                getMockSoftwareVersion(1),
+                getMockSignedState(0),
+                getMockSwirldStateSupplier(0),
+                configAddressBook,
+                testDirectory.toString(),
+                false);
+        final AddressBook inititializedAddressBook = initializer.getInitialAddressBook();
+        assertEquals(
+                configAddressBook,
+                inititializedAddressBook,
+                "The initial address book must equal the config address book.");
+        assertAddressBookFileContent(initializer, configAddressBook, null, inititializedAddressBook);
+    }
+
+    @Test
+    @DisplayName("No state loaded from disk. Genesis State modifies address book entries.")
+    void noStateLoadedFromDiskGenesisStateChangedAddressBook() throws IOException {
+        clearTestDirectory();
+        final AddressBook configAddressBook = getRandomAddressBook();
+        final AddressBookInitializer initializer = new AddressBookInitializer(
+                getMockSoftwareVersion(1),
+                getMockSignedState(0),
+                getMockSwirldStateSupplier(2),
+                configAddressBook,
+                testDirectory.toString(),
+                false);
+        final AddressBook inititializedAddressBook = initializer.getInitialAddressBook();
+        assertEquals(
+                configAddressBook,
+                inititializedAddressBook,
+                "The initial address book must equal the config address book.");
+        assertAddressBookFileContent(initializer, configAddressBook, null, inititializedAddressBook);
+    }
+
+    @Test
+    @DisplayName("SignedState has no address book or no SwirldState or no CreationSoftwareVersion.")
+    void noAddressBookNoPlatformData() throws IOException {
+        clearTestDirectory();
+        final AddressBook configAddressBook = getRandomAddressBook();
+        final AddressBookInitializer initializer = new AddressBookInitializer(
+                getMockSoftwareVersion(1),
+                getMockSignedState(1),
+                getMockSwirldStateSupplier(1),
+                configAddressBook,
+                testDirectory.toString(),
+                false);
+        final AddressBook inititializedAddressBook = initializer.getInitialAddressBook();
+        assertEquals(
+                configAddressBook,
+                inititializedAddressBook,
+                "The initial address book must equal the config address book.");
+        assertAddressBookFileContent(initializer, configAddressBook, null, inititializedAddressBook);
+    }
+
+    @Test
+    @DisplayName("Current software version is less than state software version.")
+    void currentVersionLessThanStateVersion() throws IOException {
+        clearTestDirectory();
+        final SignedState signedState = getMockSignedState(2);
+        final AddressBook configAddressBook = getRandomAddressBook();
+        final SoftwareVersion configSoftwareVersion = getMockSoftwareVersion(1);
+        final Supplier<SwirldState> genesisSwirldState = getMockSwirldStateSupplier(1);
+        final String directory = testDirectory.toString();
+
+        assertThrows(
+                IllegalStateException.class,
+                () -> new AddressBookInitializer(
+                        configSoftwareVersion, signedState, genesisSwirldState, configAddressBook, directory, false),
+                "IllegalStateException was not thrown.");
+    }
+
+    @Test
+    @DisplayName("Current software version is equal to state software version.")
+    void currentVersionEqualsStateVersion() throws IOException {
+        clearTestDirectory();
+        final SignedState signedState = getMockSignedState(2);
+        final AddressBook configAddressBook = copyWithStakeChanges(signedState.getAddressBook(), 10);
+        final AddressBookInitializer initializer = new AddressBookInitializer(
+                getMockSoftwareVersion(2),
+                signedState,
+                getMockSwirldStateSupplier(1),
+                configAddressBook,
+                testDirectory.toString(),
+                false);
+        final AddressBook inititializedAddressBook = initializer.getInitialAddressBook();
+        assertEquals(
+                signedState.getAddressBook(),
+                inititializedAddressBook,
+                "The initial address book must equal the state address book.");
+        assertAddressBookFileContent(
+                initializer, configAddressBook, signedState.getAddressBook(), inititializedAddressBook);
+    }
+
+    @Test
+    @DisplayName("Version upgrade, SwirldState set 0 Stake.")
+    void versionUpgradeSwirldStateZeroStake() throws IOException {
+        clearTestDirectory();
+        final SignedState signedState = getMockSignedState(2, 0);
+        final AddressBook configAddressBook = copyWithStakeChanges(signedState.getAddressBook(), 10);
+        final AddressBookInitializer initializer = new AddressBookInitializer(
+                getMockSoftwareVersion(3),
+                signedState,
+                getMockSwirldStateSupplier(0),
+                configAddressBook,
+                testDirectory.toString(),
+                false);
+        final AddressBook inititializedAddressBook = initializer.getInitialAddressBook();
+        assertEquals(
+                configAddressBook,
+                inititializedAddressBook,
+                "The initial address book must equal the config address book.");
+        assertAddressBookFileContent(
+                initializer, configAddressBook, signedState.getAddressBook(), inititializedAddressBook);
+    }
+
+    @Test
+    @DisplayName("Version upgrade, Swirld State modified the address book.")
+    void versionUpgradeSwirldStateModifiedAddressBook() throws IOException {
+        clearTestDirectory();
+        final SignedState signedState = getMockSignedState(2);
+        final AddressBook configAddressBook = copyWithStakeChanges(signedState.getAddressBook(), 7);
+        final AddressBookInitializer initializer = new AddressBookInitializer(
+                getMockSoftwareVersion(3),
+                signedState,
+                getMockSwirldStateSupplier(2),
+                configAddressBook,
+                testDirectory.toString(),
+                false);
+        final AddressBook inititializedAddressBook = initializer.getInitialAddressBook();
+        assertEquals(
+                configAddressBook,
+                inititializedAddressBook,
+                "The initial address book must equal the config address book.");
+        assertAddressBookFileContent(
+                initializer, configAddressBook, signedState.getAddressBook(), inititializedAddressBook);
+    }
+
+    @Test
+    @DisplayName("Version upgrade, Swirld State updates stake successfully.")
+    void versionUpgradeSwirldStateStakeUpdateWorks() throws IOException {
+        clearTestDirectory();
+        final SignedState signedState = getMockSignedState(2);
+        final AddressBook configAddressBook = copyWithStakeChanges(signedState.getAddressBook(), 5);
+        final AddressBookInitializer initializer = new AddressBookInitializer(
+                getMockSoftwareVersion(3),
+                signedState,
+                getMockSwirldStateSupplier(10),
+                configAddressBook,
+                testDirectory.toString(),
+                false);
+        final AddressBook inititializedAddressBook = initializer.getInitialAddressBook();
+        assertNotEquals(
+                configAddressBook,
+                inititializedAddressBook,
+                "The initial address book must not equal the config address book.");
+        assertNotEquals(
+                signedState.getAddressBook(),
+                inititializedAddressBook,
+                "The initial address book must not equal the state address book.");
+        assertAddressBookFileContent(
+                initializer, configAddressBook, signedState.getAddressBook(), inititializedAddressBook);
+    }
+
+    /**
+     * Copies the address book while setting stake per address to the given stake value.
+     *
+     * @param addressBook The address book to copy
+     * @param stakeValue  The new stake value per address.
+     * @return the copy of the input address book with the given stake value per address.
+     */
+    private AddressBook copyWithStakeChanges(AddressBook addressBook, int stakeValue) {
+        final AddressBook newAddressBook = new AddressBook();
+        for (Address address : addressBook) {
+            newAddressBook.add(address.copySetStake(stakeValue));
+        }
+        return newAddressBook;
+    }
+
+    /**
+     * Creates a mock SoftwareVersion matching the input version number.
+     *
+     * @param version the integer software version.
+     * @return the SoftwareVersion matching the input version.
+     */
+    private SoftwareVersion getMockSoftwareVersion(int version) {
+        final SoftwareVersion softwareVersion = mock(SoftwareVersion.class);
+        when(softwareVersion.getVersion()).thenReturn(version);
+        final AtomicReference<SoftwareVersion> softVersion = new AtomicReference<>();
+        when(softwareVersion.compareTo(argThat(sv -> {
+                    softVersion.set(sv);
+                    return true;
+                })))
+                .thenAnswer(i -> {
+                    SoftwareVersion other = softVersion.get();
+                    if (other == null) {
+                        return 1;
+                    } else {
+                        return Integer.compare(softwareVersion.getVersion(), other.getVersion());
+                    }
+                });
+        return softwareVersion;
+    }
+
+    /**
+     * Creates a mock signed state with the given scenario and a SwirldState that sets all addresses to have stake = 7.
+     *
+     * @param scenario The scenario of mock signed state to create.
+     * @return The mock SignedState with the input scenario loaded.
+     */
+    private SignedState getMockSignedState(final int scenario) {
+        return getMockSignedState(scenario, 7);
+    }
+
+    /**
+     * Creates a mock signed state with the given scenario and a SwirldState that sets all addresses to the given
+     * stakeValue.
+     *
+     * @param scenario   The scenario of mock signed state to create.
+     * @param stakeValue The stake value that the SwirldState should set all addresses to in its updateStake method.
+     * @return The mock SignedState with the input scenario loaded and SwirldState configured to set all addresses with
+     * given stakeValue.
+     */
+    private SignedState getMockSignedState(final int scenario, final int stakeValue) {
+        final SignedState signedState = mock(SignedState.class);
+        switch (scenario) {
+                // case 1: null content inside the SignedState
+            case 1:
+                return signedState;
+                // case 2: addressbook, SwirldState, and SoftwareVersion exist.
+            case 2: {
+                final SoftwareVersion softwareVersion = getMockSoftwareVersion(2);
+                final SwirldState swirldState =
+                        getMockSwirldStateSupplier(stakeValue).get();
+                final AddressBook stateAddressBook = getRandomAddressBook();
+                when(signedState.getAddressBook()).thenReturn(stateAddressBook);
+                when(signedState.getSwirldState()).thenReturn(swirldState);
+                final PlatformData platformData = mock(PlatformData.class);
+                when(platformData.getCreationSoftwareVersion()).thenReturn(softwareVersion);
+                final PlatformState platformState = mock(PlatformState.class);
+                when(platformState.getPlatformData()).thenReturn(platformData);
+                final State state = mock(State.class);
+                when(state.getPlatformState()).thenReturn(platformState);
+                when(signedState.getState()).thenReturn(state);
+                return signedState;
+            }
+            default:
+                return null;
+        }
+    }
+
+    /**
+     * Creates a mock swirld state with the given scenario.
+     *
+     * @param scenario The scenario to load.
+     * @return A SwirldState which behaves according to the input scenario.
+     */
+    private Supplier<SwirldState> getMockSwirldStateSupplier(int scenario) {
+
+        final AtomicReference<AddressBook> configAddressBook = new AtomicReference<>();
+        final AtomicReference<AddressBook> stateAddressBook = new AtomicReference<>();
+        final SwirldState swirldState = mock(SwirldState.class);
+
+        final OngoingStubbing<AddressBook> stub = when(swirldState.updateStake(
+                argThat(confAB -> {
+                    configAddressBook.set(confAB);
+                    return true;
+                }),
+                argThat(stateAB -> {
+                    stateAddressBook.set(stateAB);
+                    return true;
+                })));
+
+        switch (scenario) {
+            case 0:
+                stub.thenAnswer(foo -> copyWithStakeChanges(configAddressBook.get(), 0));
+                break;
+            case 1:
+                stub.thenAnswer(foo -> configAddressBook.get());
+                break;
+            case 2:
+                stub.thenAnswer(foo -> configAddressBook
+                        .get()
+                        .add(configAddressBook
+                                .get()
+                                .getAddress(0)
+                                .copySetId(configAddressBook.get().getNextNodeId())));
+                break;
+            case 7:
+                stub.thenAnswer(foo -> copyWithStakeChanges(configAddressBook.get(), 7));
+                break;
+            default:
+                stub.thenAnswer(foo -> copyWithStakeChanges(configAddressBook.get(), 10));
+        }
+
+        return () -> swirldState;
+    }
+
+    /**
+     * Creates an address book where each address has stake equal to its node ID.
+     *
+     * @return the address book created.
+     */
+    @NonNull
+    private AddressBook getRandomAddressBook() {
+        return new RandomAddressBookGenerator()
+                .setSequentialIds(true)
+                .setSize(5)
+                .setCustomStakeGenerator(i -> i)
+                .build();
+    }
+
+    /**
+     * removes all files and subdirectories from the test directory.
+     *
+     * @throws IOException if any IOException is created by deleting files or directories.
+     */
+    private void clearTestDirectory() throws IOException {
+        for (File file : testDirectory.toFile().listFiles()) {
+            if (file.isDirectory()) {
+                FileUtils.deleteDirectory(file.toPath());
+            } else {
+                file.delete();
+            }
+        }
+    }
+
+    /**
+     * Validates the state of the recorded address book file according to the excepted input states.
+     *
+     * @param initializer       The AddressBookInitializer constructed.
+     * @param configAddressBook The configuration address book.
+     * @param stateAddressBook  The state recorded address book.  May be null if there is no state, or it was unusable.
+     * @param usedAddressBook   The address book returned by the initializer.
+     * @throws IOException if any IOExceptions occur while reading the recorded file on disk.
+     */
+    private void assertAddressBookFileContent(
+            @NonNull final AddressBookInitializer initializer,
+            @NonNull final AddressBook configAddressBook,
+            @Nullable final AddressBook stateAddressBook,
+            @NonNull final AddressBook usedAddressBook)
+            throws IOException {
+        Objects.requireNonNull(initializer, "The initializer must not be null.");
+        Objects.requireNonNull(configAddressBook, "The configAddressBook must not be null.");
+        Objects.requireNonNull(configAddressBook, "The initializedAddressBook must not be null.");
+        final Path addressBookDirectory = initializer.getPathToAddressBookDirectory();
+        assertEquals(
+                1,
+                Arrays.stream(addressBookDirectory.toFile().listFiles()).count(),
+                "There should be exactly one file in the test directory.");
+        final File file = addressBookDirectory.toFile().listFiles()[0];
+        final String fileContent = Files.readString(file.toPath());
+
+        // check configAddressBook content
+        final String configText = CONFIG_ADDRESS_BOOK_HEADER + "\n" + configAddressBook.toConfigText();
+        assertTrue(fileContent.contains(configText), "The configAddressBook content is not:\n" + configText);
+
+        // check stateAddressBook content
+        final String stateText = stateAddressBook == null
+                ? STATE_ADDRESS_BOOK_HEADER + "\n" + STATE_ADDRESS_BOOK_NULL
+                : STATE_ADDRESS_BOOK_HEADER + "\n" + stateAddressBook.toConfigText();
+        assertTrue(fileContent.contains(stateText), "The stateAddressBook content is not:\n" + stateText);
+
+        // check usedAddressBook content
+        String usedText = USED_ADDRESS_BOOK_HEADER + "\n";
+        if (usedAddressBook == configAddressBook) {
+            usedText += CONFIG_ADDRESS_BOOK_USED;
+        } else if (usedAddressBook == stateAddressBook) {
+            usedText += STATE_ADDRESS_BOOK_USED;
+        } else {
+            usedText += usedAddressBook.toConfigText();
+        }
+        assertTrue(fileContent.contains(usedText), "The usedAddressBook content is not:\n" + usedText);
+    }
+}


### PR DESCRIPTION
**Description**:
Updates the address book through the `SwirldState` on version upgrade.  If there is no version upgrade, the address book loaded from the saved state on disk is used.   If there is no `SignedState` loadable from disk, the address book is initialized by the genesis `SwirldState`.  This solution moves the construction of the `EmergencyRecoveryManager` and loading of the `SignedState` from disk to `Browser.java` so that the `AddressBookInitializer` can determine the address book to pass to the `SwirldsPlatform`. 

- adds `AddressBookInitializer.java`
- adds `updateStake(AddressBook, AddressBook)` method to SwirldState.java
- adds `sameExceptForStake(AddressBook, AddressBook)` method to AddressBookValidator.java
- adds `toConfigText()` method to AddressBook.java
- adds `equalsWithoutStake(Address)` to Address.java
- adds `toConfigText()` to Address.java
- adds `forceUseOfConfigAddressBook` with default false to StateConfig.java
- updates `createLocalPlatforms()` to load the saved state and create the initial address book in Browser.java
- updates the `SwirldsPlatform` constructor to receive the `EmergencyRecoveryManager` and loaded `SignedState` from Browser.java

**Related issue(s)**:

Fixes #5475
Fixes #5581
Fixes #5582 
Fixes #5642 

**Notes for reviewer**:


**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
