### PR TITLE
5664 - serialize / deserialize AddressBook to text compatible with config.txt

### DIFF
--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/system/address/AddressBook.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/system/address/AddressBook.java
@@ -16,8 +16,10 @@
 
 package com.swirlds.common.system.address;
 
+import static com.swirlds.common.system.address.Address.ipString;
 import static com.swirlds.common.utility.CommonUtils.throwArgNull;
 
+import com.swirlds.common.formatting.TextTable;
 import com.swirlds.common.io.streams.SerializableDataInputStream;
 import com.swirlds.common.io.streams.SerializableDataOutputStream;
 import com.swirlds.common.merkle.MerkleLeaf;
@@ -33,9 +35,8 @@ import java.util.NoSuchElementException;
 import java.util.Objects;
 
 /**
- * The Address of every known member of the swirld. The getters are public and the setters aren't, so it is
- * read-only for apps.
- * When enableEventStreaming is set to be true, the memo field is required and should be unique.
+ * The Address of every known member of the swirld. The getters are public and the setters aren't, so it is read-only
+ * for apps. When enableEventStreaming is set to be true, the memo field is required and should be unique.
  */
 public class AddressBook extends PartialMerkleLeaf implements Iterable<Address>, MerkleLeaf {
 
@@ -99,8 +100,8 @@ public class AddressBook extends PartialMerkleLeaf implements Iterable<Address>,
     private final Map<String /* public key */, Long /* node ID */> publicKeyToId = new HashMap<>();
 
     /**
-     * A map of node IDs to indices within the address book. A node's index is equal to its position in a
-     * list of all nodes sorted by node ID (from least to greatest).
+     * A map of node IDs to indices within the address book. A node's index is equal to its position in a list of all
+     * nodes sorted by node ID (from least to greatest).
      */
     private final Map<Long /* node ID */, Integer /* index */> nodeIndices = new HashMap<>();
 
@@ -143,8 +144,7 @@ public class AddressBook extends PartialMerkleLeaf implements Iterable<Address>,
     /**
      * Create an address book initialized with the given list of addresses.
      *
-     * @param addresses
-     * 		the addresses to start with
+     * @param addresses the addresses to start with
      */
     public AddressBook(final List<Address> addresses) {
         addresses.forEach(this::add);
@@ -169,8 +169,8 @@ public class AddressBook extends PartialMerkleLeaf implements Iterable<Address>,
     /**
      * Get the round number when this address book was constructed.
      *
-     * @return the round when this address book was constructed, or {@link #UNKNOWN_ROUND} if the round is unknown
-     * 		or this address book was not constructed during a regular round
+     * @return the round when this address book was constructed, or {@link #UNKNOWN_ROUND} if the round is unknown or
+     * this address book was not constructed during a regular round
      */
     public long getRound() {
         return round;
@@ -179,9 +179,8 @@ public class AddressBook extends PartialMerkleLeaf implements Iterable<Address>,
     /**
      * Set the round number when this address book was constructed.
      *
-     * @param round
-     * 		the round when this address book was constructed, or {@link #UNKNOWN_ROUND} if the round is unknown
-     * 		or this address book was not constructed during a regular round
+     * @param round the round when this address book was constructed, or {@link #UNKNOWN_ROUND} if the round is unknown
+     *              or this address book was not constructed during a regular round
      * @return this object
      */
     public AddressBook setRound(final long round) {
@@ -218,8 +217,8 @@ public class AddressBook extends PartialMerkleLeaf implements Iterable<Address>,
     }
 
     /**
-     * Get the total stake of all members added together, where each member has nonnegative stake. This is zero if
-     * there are no members.
+     * Get the total stake of all members added together, where each member has nonnegative stake. This is zero if there
+     * are no members.
      *
      * @return the total stake
      */
@@ -228,11 +227,10 @@ public class AddressBook extends PartialMerkleLeaf implements Iterable<Address>,
     }
 
     /**
-     * Find the ID for the member whose address has the given public key. for now, this uses the nickname
-     * instead of the public key. Returns -1 if it does not exist.
+     * Find the ID for the member whose address has the given public key. for now, this uses the nickname instead of the
+     * public key. Returns -1 if it does not exist.
      *
-     * @param publicKey
-     * 		the public key to look up
+     * @param publicKey the public key to look up
      * @return the ID of the member with that key, or -1 if it was not found
      */
     public long getId(final String publicKey) {
@@ -242,8 +240,7 @@ public class AddressBook extends PartialMerkleLeaf implements Iterable<Address>,
     /**
      * Find the ID for the member at a given index within the address book.
      *
-     * @param index
-     * 		the index within the address book
+     * @param index the index within the address book
      * @return a node ID
      */
     public long getId(final int index) {
@@ -257,8 +254,7 @@ public class AddressBook extends PartialMerkleLeaf implements Iterable<Address>,
     /**
      * Get the index within the address book of a given node ID.
      *
-     * @param id
-     * 		the node's ID
+     * @param id the node's ID
      * @return the index of the node ID within the address book
      */
     public int getIndex(final long id) {
@@ -280,15 +276,13 @@ public class AddressBook extends PartialMerkleLeaf implements Iterable<Address>,
      * </p>
      *
      * <p>
-     * WARNING: the next node ID is typically maintained internally by the address book, and
-     * incorrect configuration may lead to undefined behavior. This value should only be manually set
-     * if an address book is being constructed from scratch for a round later than genesis
-     * (as opposed to constructing the address book iteratively by replaying all address book
-     * transactions since genesis).
+     * WARNING: the next node ID is typically maintained internally by the address book, and incorrect configuration may
+     * lead to undefined behavior. This value should only be manually set if an address book is being constructed from
+     * scratch for a round later than genesis (as opposed to constructing the address book iteratively by replaying all
+     * address book transactions since genesis).
      * </p>
      *
-     * @param nextNodeId
-     * 		the next node ID for the address book
+     * @param nextNodeId the next node ID for the address book
      * @return this object
      */
     public AddressBook setNextNodeId(final long nextNodeId) {
@@ -306,11 +300,9 @@ public class AddressBook extends PartialMerkleLeaf implements Iterable<Address>,
     /**
      * Get the address for the member with the given ID
      *
-     * @param id
-     * 		the member ID of the address to get
+     * @param id the member ID of the address to get
      * @return the address
-     * @throws NoSuchElementException
-     * 		if the given ID is not in the address book
+     * @throws NoSuchElementException if the given ID is not in the address book
      */
     public Address getAddress(final long id) {
         return addresses.get(id);
@@ -319,8 +311,7 @@ public class AddressBook extends PartialMerkleLeaf implements Iterable<Address>,
     /**
      * Check if an address for a given node ID is contained within this address book.
      *
-     * @param id
-     * 		a node ID
+     * @param id a node ID
      * @return true if this address book contains an address for the given node ID
      */
     public boolean contains(final long id) {
@@ -331,8 +322,7 @@ public class AddressBook extends PartialMerkleLeaf implements Iterable<Address>,
      * The address book maintains a list of deterministically ordered node IDs. Add a new node ID to the end of that
      * list and record its index.
      *
-     * @param nodeId
-     * 		the ID of the node being added
+     * @param nodeId the ID of the node being added
      */
     private void addToOrderedList(final long nodeId) {
         final int index = orderedNodeIds.size();
@@ -341,11 +331,10 @@ public class AddressBook extends PartialMerkleLeaf implements Iterable<Address>,
     }
 
     /**
-     * The address book maintains a list of deterministically ordered node IDs. Remove a node ID from that list,
-     * remove it from the index map, and update the indices of any node that had to be shifted as a result.
+     * The address book maintains a list of deterministically ordered node IDs. Remove a node ID from that list, remove
+     * it from the index map, and update the indices of any node that had to be shifted as a result.
      *
-     * @param nodeId
-     * 		the ID of the node being removed
+     * @param nodeId the ID of the node being removed
      */
     private void removeNodeFromOrderedList(final long nodeId) {
         final int indexToRemove = nodeIndices.remove(nodeId);
@@ -359,8 +348,7 @@ public class AddressBook extends PartialMerkleLeaf implements Iterable<Address>,
     /**
      * Update an existing entry in the address book.
      *
-     * @param address
-     * 		the new address
+     * @param address the new address
      */
     private void updateAddress(final Address address) {
         final Address oldAddress = Objects.requireNonNull(addresses.put(address.getId(), address));
@@ -386,8 +374,7 @@ public class AddressBook extends PartialMerkleLeaf implements Iterable<Address>,
     /**
      * Add a new address.
      *
-     * @param address
-     * 		the address to add
+     * @param address the address to add
      */
     private void addNewAddress(final Address address) {
         if (address.getId() < nextNodeId) {
@@ -414,12 +401,10 @@ public class AddressBook extends PartialMerkleLeaf implements Iterable<Address>,
     /**
      * Add an address to the address book, replacing the existing address with the same ID if one is present.
      *
-     * @param address
-     * 		the address for that member, may not be null, must have a node ID greater or equal to {@link #nextNodeId}
-     * 		if the address is not currently in the address book
+     * @param address the address for that member, may not be null, must have a node ID greater or equal to
+     *                {@link #nextNodeId} if the address is not currently in the address book
      * @return this object
-     * @throws IllegalStateException
-     * 		if a new address is added that has a node ID that is less than {@link #nextNodeId}
+     * @throws IllegalStateException if a new address is added that has a node ID that is less than {@link #nextNodeId}
      */
     public AddressBook add(final Address address) {
         throwIfImmutable();
@@ -438,8 +423,7 @@ public class AddressBook extends PartialMerkleLeaf implements Iterable<Address>,
     /**
      * Remove an address associated with a given node ID.
      *
-     * @param id
-     * 		the node ID that should have its address removed
+     * @param id the node ID that should have its address removed
      * @return this object
      */
     public AddressBook remove(final long id) {
@@ -541,6 +525,27 @@ public class AddressBook extends PartialMerkleLeaf implements Iterable<Address>,
     @Override
     public Iterator<Address> iterator() {
         return new AddressBookIterator(orderedNodeIds.iterator(), addresses);
+    }
+
+    /**
+     * The text form of an address book that appears in config.txt
+     *
+     * @return the string form of the AddressBook that would appear in config.txt
+     */
+    public String toConfigText() {
+        final TextTable table = new TextTable().setBordersEnabled(false);
+        for (final Address address : this) {
+            table.addRow(
+                    "address,",
+                    address.getNickname() + ",",
+                    address.getSelfName() + ",",
+                    address.getStake() + ",",
+                    ipString(address.getAddressInternalIpv4()) + ",",
+                    address.getPortInternalIpv4() + ",",
+                    ipString(address.getAddressExternalIpv4()) + ",",
+                    address.getPortExternalIpv4());
+        }
+        return table.render();
     }
 
     /**

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/system/address/AddressBookUtils.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/system/address/AddressBookUtils.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.swirlds.common.system.address;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.text.ParseException;
+import java.util.Objects;
+import java.util.function.Function;
+
+/**
+ * A utility class for AddressBook functionality.
+ */
+public class AddressBookUtils {
+    private AddressBookUtils() {}
+
+    /**
+     * Parses an address from a single line of text.  The address must be in the form used in config.txt
+     *
+     * @param addressLine         the string to parse an Address form.
+     * @param id                  the id to give to the parsed Address.
+     * @param isOwnHostDeterminer a function to determine if isOwn should be true given an InetAddress.
+     * @param memo                the memo text for the address.
+     * @return the Address parsed from the addressLine.
+     * @throws ParseException if there is any problem with creating an Address from the addressLine.
+     */
+    public static Address parseAddressConfigText(
+            @NonNull final String addressLine,
+            final long id,
+            @NonNull final Function<InetAddress, Boolean> isOwnHostDeterminer,
+            @NonNull final String memo)
+            throws ParseException {
+        Objects.requireNonNull(addressLine, "The addressLine must not be null.");
+        Objects.requireNonNull(isOwnHostDeterminer, "The isOwnHostDeterminer must not be null.");
+        Objects.requireNonNull(memo, "The memo must not be null.");
+        final String[] parts = addressLine.trim().split(",");
+        if (parts.length != 8) {
+            throw new ParseException("Not enough parts in the address line to parse correctly.", parts.length);
+        }
+        for (int i = 0; i < parts.length; i++) {
+            parts[i] = parts[i].trim();
+        }
+        if (!parts[0].equals("address")) {
+            throw new ParseException("The address line must start with 'address' and not '" + parts[0] + "'", 0);
+        }
+        final String nickname = parts[1];
+        final String selfname = parts[2];
+        final Long stake;
+        try {
+            stake = Long.parseLong(parts[3]);
+        } catch (NumberFormatException e) {
+            throw new ParseException("Cannot parse value of stake from '" + parts[3] + "'", 3);
+        }
+        final InetAddress internalIp;
+        try {
+            internalIp = InetAddress.getByName(parts[4]);
+        } catch (UnknownHostException e) {
+            throw new ParseException("Cannot parse ip address from '" + parts[4] + ",", 4);
+        }
+        final int internalPort;
+        try {
+            internalPort = Integer.parseInt(parts[5]);
+        } catch (NumberFormatException e) {
+            throw new ParseException("Cannot parse ip port from '" + parts[5] + "'", 5);
+        }
+        final InetAddress externalIp;
+        try {
+            externalIp = InetAddress.getByName(parts[6]);
+        } catch (UnknownHostException e) {
+            throw new ParseException("Cannot parse ip address from '" + parts[6] + ",", 6);
+        }
+        final int externalPort;
+        try {
+            externalPort = Integer.parseInt(parts[7]);
+        } catch (NumberFormatException e) {
+            throw new ParseException("Cannot parse ip port from '" + parts[7] + "'", 7);
+        }
+        final boolean isOwnHost = isOwnHostDeterminer.apply(internalIp);
+
+        return new Address(
+                id,
+                nickname,
+                selfname,
+                stake,
+                isOwnHost,
+                internalIp.getAddress(),
+                internalPort,
+                externalIp.getAddress(),
+                externalPort,
+                memo);
+    }
+
+    /**
+     * Parses an address book from text in the form described by config.txt
+     *
+     * @param addressBookText the config.txt compatible serialized address book to parse.
+     * @param posToId         a function to determine the address id given the position of the address in the text.
+     * @param isOwnDeterminer a function to determine if the address isOwn property should be true given an
+     *                        InetAddress.
+     * @param memoSource      a function to render memo text given the address id.
+     * @return a parsed AddressBook.
+     * @throws ParseException if any Address throws a ParseException when being parsed.
+     */
+    public static AddressBook parseAddressBookConfigText(
+            @NonNull final String addressBookText,
+            @NonNull final Function<Long, Long> posToId,
+            @NonNull final Function<InetAddress, Boolean> isOwnDeterminer,
+            @NonNull final Function<Long, String> memoSource)
+            throws ParseException {
+        Objects.requireNonNull(addressBookText, "The addressBookText must not be null.");
+        Objects.requireNonNull(posToId, "The posToId must not be null.");
+        Objects.requireNonNull(isOwnDeterminer, "The isOwnDeterminer must not be null.");
+        Objects.requireNonNull(memoSource, "The memoSource must not be null.");
+        final AddressBook addressBook = new AddressBook();
+        long pos = 0;
+        for (final String addressLine : addressBookText.split("\\r?\\n")) {
+            final long id = posToId.apply(pos);
+            addressBook.add(parseAddressConfigText(addressLine, id, isOwnDeterminer, memoSource.apply(id)));
+            pos++;
+        }
+        return addressBook;
+    }
+}

--- a/platform-sdk/swirlds-unit-tests/common/swirlds-common-test/src/test/java/com/swirlds/common/test/AddressBookTests.java
+++ b/platform-sdk/swirlds-unit-tests/common/swirlds-common-test/src/test/java/com/swirlds/common/test/AddressBookTests.java
@@ -16,6 +16,7 @@
 
 package com.swirlds.common.test;
 
+import static com.swirlds.common.system.address.AddressBookUtils.parseAddressBookConfigText;
 import static com.swirlds.common.test.RandomUtils.getRandomPrintSeed;
 import static com.swirlds.test.framework.TestQualifierTags.TIME_CONSUMING;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -37,6 +38,7 @@ import com.swirlds.common.system.address.AddressBook;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.text.ParseException;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -284,7 +286,7 @@ class AddressBookTests {
 
     @Test
     @DisplayName("toString() Test")
-    void toStringSanityTest() {
+    void atoStringSanityTest() {
         final AddressBook addressBook = new RandomAddressBookGenerator(getRandomPrintSeed()).build();
 
         // Basic sanity check, make sure this doesn't throw an exception
@@ -418,5 +420,55 @@ class AddressBookTests {
                 IllegalArgumentException.class,
                 () -> addressBook.setNextNodeId(0),
                 "node ID shouldn't be able to be set to a value less than an existing address book");
+    }
+
+    @Test
+    @DisplayName("Roundtrip address book serialization and deserialization compatible with config.txt")
+    void roundTripSerializeAndDeserializeCompatibleWithConfigTxt() throws ParseException {
+        final RandomAddressBookGenerator generator = new RandomAddressBookGenerator(getRandomPrintSeed());
+        final AddressBook addressBook = generator.build();
+        final String addressBookText = addressBook.toConfigText();
+        final Map<Long, Long> posToId = new HashMap<>();
+        long pos = 0;
+        for (Address address : addressBook) {
+            posToId.put(pos, address.getId());
+            pos++;
+        }
+        final AddressBook parsedAddressBook =
+                parseAddressBookConfigText(addressBookText, posToId::get, ip -> false, id -> "");
+        // Equality done on toConfigText() strings since the randomly generated address book has public key data.
+        assertEquals(addressBookText, parsedAddressBook.toConfigText(), "The AddressBooks are not equal.");
+    }
+
+    @Test
+    @DisplayName("Testing exceptions in parsing address books used in config.txt")
+    void parseExceptionTestsInParsingAddressBookConfigText() {
+        // not enough parts to make an address line
+        validateParseException("address", 1);
+        validateParseException("address, nickname", 2);
+        validateParseException("address, nickname, selfname", 3);
+        validateParseException("address, nickname, selfname, 10", 4);
+        validateParseException("address, nickname, selfname, 10, 192.168.0.1", 5);
+        validateParseException("address, nickname, selfname, 10, 192.168.0.1, 5000", 6);
+        validateParseException("address, nickname, selfname, 10, 192.168.0.1, 5000, 8.8.8.8", 7);
+
+        // Too many parts
+        validateParseException("address, nickname, selfname, 10, 192.168.0.1, 5000, 8.8.8.8, 5000, extra", 9);
+
+        // bad parsing of parts.
+        validateParseException("not an address, nickname, selfname, 10, 192.168.0.1, 5000, 8.8.8.8, 5000", 0);
+        validateParseException("address, nickname, selfname, not a stake, 192.168.0.1, 5000, 8.8.8.8, 5000", 3);
+        validateParseException("address, nickname, selfname, 10, 192.168.0.1, not a port, 8.8.8.8, 5000", 5);
+        validateParseException("address, nickname, selfname, 10, 192.168.0.1, 5000, 8.8.8.8, not a port", 7);
+    }
+
+    private void validateParseException(String addressBook, int part) {
+        assertThrows(
+                ParseException.class, () -> parseAddressBookConfigText(addressBook, pos -> pos, ip -> false, id -> ""));
+        try {
+            parseAddressBookConfigText(addressBook, pos -> pos, ip -> false, id -> "");
+        } catch (ParseException e) {
+            assertEquals(part, e.getErrorOffset(), "The part number is wrong in the exception: " + e.getMessage());
+        }
     }
 }


### PR DESCRIPTION
**Description**:
Be able to create strings of AddressBooks in the format used in Config.txt.  
Be able to create AddressBooks from the format used in Config.txt for unit testing purposes. 
- adds AddressBookUtils.java with the ability to parse an AddressBook from text used in config.txt
- adds unit tests for round trip serialization/deserialization and testing parse exceptions to AddressBookTests.java"
- adds `toConfigText()` method for rendering a config.txt compatible AddressBook to AddressBook.java

Fixes #5664 

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
