### PR TITLE
Fix Schedule Service to compile and pass unit tests with PBJ

### DIFF
--- a/hedera-node/hedera-schedule-service-impl/src/main/java/com/hedera/node/app/service/schedule/impl/ScheduleServiceImpl.java
+++ b/hedera-node/hedera-schedule-service-impl/src/main/java/com/hedera/node/app/service/schedule/impl/ScheduleServiceImpl.java
@@ -16,6 +16,8 @@
 
 package com.hedera.node.app.service.schedule.impl;
 
+import com.hedera.hapi.node.base.SemanticVersion;
+import com.hedera.node.app.service.mono.state.codec.MonoMapCodecAdapter;
 import com.hedera.node.app.service.mono.state.virtual.EntityNumVirtualKey;
 import com.hedera.node.app.service.mono.state.virtual.EntityNumVirtualKeySerializer;
 import com.hedera.node.app.service.mono.state.virtual.schedule.ScheduleEqualityVirtualKey;
@@ -30,8 +32,6 @@ import com.hedera.node.app.service.schedule.impl.serdes.MonoSchedulingStateAdapt
 import com.hedera.node.app.spi.state.Schema;
 import com.hedera.node.app.spi.state.SchemaRegistry;
 import com.hedera.node.app.spi.state.StateDefinition;
-import com.hedera.node.app.spi.state.serdes.MonoMapCodecAdapter;
-import com.hederahashgraph.api.proto.java.SemanticVersion;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.Set;
 
@@ -40,7 +40,7 @@ import java.util.Set;
  */
 public final class ScheduleServiceImpl implements ScheduleService {
     private static final SemanticVersion CURRENT_VERSION =
-            SemanticVersion.newBuilder().setMinor(34).build();
+            SemanticVersion.newBuilder().minor(34).build();
 
     public static final String SCHEDULING_STATE_KEY = "SCHEDULING_STATE";
     public static final String SCHEDULES_BY_ID_KEY = "SCHEDULES_BY_ID";

--- a/hedera-node/hedera-schedule-service-impl/src/test/java/com/hedera/node/app/service/schedule/impl/test/ReadableScheduleStoreTest.java
+++ b/hedera-node/hedera-schedule-service-impl/src/test/java/com/hedera/node/app/service/schedule/impl/test/ReadableScheduleStoreTest.java
@@ -36,6 +36,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+@SuppressWarnings({"unchecked", "rawtypes"})
 @ExtendWith(MockitoExtension.class)
 class ReadableScheduleStoreTest {
     @Mock
@@ -86,7 +87,7 @@ class ReadableScheduleStoreTest {
         assertEquals(Optional.of(adminKey), meta.get().adminKey());
         assertEquals(TransactionBody.newBuilder().build(), meta.get().scheduledTxn());
         assertEquals(
-                Optional.of(EntityId.fromNum(2L).toGrpcAccountId()), meta.get().designatedPayer());
+                Optional.of(EntityId.fromNum(2L).toPbjAccountId()), meta.get().designatedPayer());
     }
 
     @Test

--- a/hedera-node/hedera-schedule-service-impl/src/test/java/com/hedera/node/app/service/schedule/impl/test/handlers/ScheduleHandlerTestBase.java
+++ b/hedera-node/hedera-schedule-service-impl/src/test/java/com/hedera/node/app/service/schedule/impl/test/handlers/ScheduleHandlerTestBase.java
@@ -26,6 +26,7 @@ import com.hedera.hapi.node.base.TransactionID;
 import com.hedera.hapi.node.scheduled.SchedulableTransactionBody;
 import com.hedera.hapi.node.scheduled.ScheduleCreateTransactionBody;
 import com.hedera.hapi.node.transaction.TransactionBody;
+import com.hedera.hapi.node.util.UtilPrngTransactionBody;
 import com.hedera.node.app.spi.accounts.AccountAccess;
 import com.hedera.node.app.spi.key.HederaKey;
 import com.hedera.node.app.spi.state.ReadableStates;
@@ -38,10 +39,10 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 class ScheduleHandlerTestBase {
-    protected Key key = Key.newBuilder()
+    protected final static Key TEST_KEY = Key.newBuilder()
             .ed25519(Bytes.wrap("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"))
             .build();
-    protected HederaKey adminKey = asHederaKey(key).get();
+    protected HederaKey adminKey = asHederaKey(TEST_KEY).get();
     protected AccountID scheduler = AccountID.newBuilder().accountNum(1001L).build();
     protected AccountID payer = AccountID.newBuilder().accountNum(2001L).build();
 
@@ -74,8 +75,9 @@ class ScheduleHandlerTestBase {
         return TransactionBody.newBuilder()
                 .transactionID(TransactionID.newBuilder().accountID(scheduler))
                 .scheduleCreate(ScheduleCreateTransactionBody.newBuilder()
-                        .scheduledTransactionBody(
-                                SchedulableTransactionBody.newBuilder().build()))
+                        .scheduledTransactionBody(SchedulableTransactionBody.newBuilder()
+                                .utilPrng(UtilPrngTransactionBody.DEFAULT)
+                                .build()))
                 .build();
     }
 }

--- a/hedera-node/hedera-schedule-service-impl/src/test/java/com/hedera/node/app/service/schedule/impl/test/serdes/MonoSchedulingStateAdapterSerdesTest.java
+++ b/hedera-node/hedera-schedule-service-impl/src/test/java/com/hedera/node/app/service/schedule/impl/test/serdes/MonoSchedulingStateAdapterSerdesTest.java
@@ -21,51 +21,41 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.hedera.node.app.service.mono.state.merkle.MerkleScheduledTransactionsState;
 import com.hedera.node.app.service.schedule.impl.serdes.MonoSchedulingStateAdapterCodec;
-import com.swirlds.common.io.streams.SerializableDataInputStream;
-import com.swirlds.common.io.streams.SerializableDataOutputStream;
+import com.hedera.pbj.runtime.io.ReadableSequentialData;
+import com.hedera.pbj.runtime.io.stream.ReadableStreamingData;
+import com.hedera.pbj.runtime.io.stream.WritableStreamingData;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-import java.io.DataInput;
-import java.io.DataOutput;
 import java.io.IOException;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 
 class MonoSchedulingStateAdapterSerdesTest {
-    private static final long SOME_NUMBER = 666L;
+    private static final long SOME_NUMBER = 646L;
     private static final MerkleScheduledTransactionsState SOME_SCHEDULING_STATE =
             new MerkleScheduledTransactionsState(SOME_NUMBER);
-
-    @Mock
-    private DataInput input;
-
-    @Mock
-    private DataOutput output;
-
     final MonoSchedulingStateAdapterCodec subject = new MonoSchedulingStateAdapterCodec();
 
+    @Mock
+    private ReadableSequentialData input;
+
     @Test
-    void doesntSupportUnnecessary() {
-        assertThrows(UnsupportedOperationException.class, subject::typicalSize);
+    void doesNotSupportUnnecessary() {
+        assertThrows(UnsupportedOperationException.class, () -> subject.measureRecord(SOME_SCHEDULING_STATE));
         assertThrows(UnsupportedOperationException.class, () -> subject.measure(input));
         assertThrows(UnsupportedOperationException.class, () -> subject.fastEquals(SOME_SCHEDULING_STATE, input));
     }
 
     @Test
     void canSerializeAndDeserializeFromAppropriateStream() throws IOException {
-        final var baos = new ByteArrayOutputStream();
-        final var actualOut = new SerializableDataOutputStream(baos);
+        final ByteArrayOutputStream byteStream = new ByteArrayOutputStream();
+        final WritableStreamingData actualOut = new WritableStreamingData(byteStream);
         subject.write(SOME_SCHEDULING_STATE, actualOut);
         actualOut.flush();
 
-        final var actualIn = new SerializableDataInputStream(new ByteArrayInputStream(baos.toByteArray()));
-        final var parsed = subject.parse(actualIn);
+        final ReadableStreamingData actualIn =
+                new ReadableStreamingData(new ByteArrayInputStream(byteStream.toByteArray()));
+        final MerkleScheduledTransactionsState parsed = subject.parse(actualIn);
         assertEquals(SOME_SCHEDULING_STATE.getHash(), parsed.getHash());
-    }
-
-    @Test
-    void doesntSupportOtherStreams() {
-        assertThrows(IllegalArgumentException.class, () -> subject.parse(input));
-        assertThrows(IllegalArgumentException.class, () -> subject.write(SOME_SCHEDULING_STATE, output));
     }
 }


### PR DESCRIPTION
**Description**:

 * Small changes for correct serialization in the MonoSchedulingStateAdapterCodec.
 * Added missing imports and fixed method name change in ScheduleServiceImpl.
 * Updated test base class to make compatible with intensified non-null requirements.
 * Updated several tests to set mocking up better; the intensified non-null requirements require more mocks to return values.
 * Adjusted serialization/deserialization testing to work with PBJ DataIO classes.
 * Suppressed some unnecessary warnings in test classes
 * Removed, for now, two tests for not-in-whitelist transactions.
    * Those didn't actually test what was claimed, and what was tested, missing keys, throws NPE now, rather than failing.
    * Added `@todo` comments to create proper tests for non-whitelisted transactions

**Related issue(s)**:

Fixes #5623
