### PR TITLE
Smoke code: fixed formatting issue over strings in logs and concatenation  Printf-style format strings should be used correctly java:S3457

### DIFF
--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/grpc/NettyGrpcServerManager.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/grpc/NettyGrpcServerManager.java
@@ -20,18 +20,22 @@ import static com.hedera.node.app.service.mono.utils.SleepingPause.SLEEPING_PAUS
 
 import com.hedera.node.app.service.mono.context.properties.NodeLocalProperties;
 import com.hedera.node.app.service.mono.utils.Pause;
+
 import io.grpc.BindableService;
 import io.grpc.Server;
 import io.grpc.netty.NettyServerBuilder;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
+
 import javax.inject.Inject;
 import javax.inject.Singleton;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 @Singleton
 public class NettyGrpcServerManager implements GrpcServerManager {
@@ -93,7 +97,7 @@ public class NettyGrpcServerManager implements GrpcServerManager {
                 break;
             } catch (IOException e) {
                 final var summaryMsg = nettyAction("Still trying to start", sslEnabled, port, true);
-                log.warn("(Attempts=" + retryNo + ") " + summaryMsg + e.getMessage());
+                log.warn(String.format("(Attempts=%s) %s%s", retryNo, summaryMsg, e.getMessage()));
                 pause.forMs(startRetryIntervalMs);
             }
         }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/HapiSpecOperation.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/HapiSpecOperation.java
@@ -18,6 +18,7 @@ package com.hedera.services.bdd.spec;
 
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getTxnRecord;
 import static com.hedera.services.bdd.spec.transactions.TxnUtils.extractTxnId;
+
 import static java.util.Collections.EMPTY_LIST;
 import static java.util.stream.Collectors.toList;
 
@@ -52,6 +53,10 @@ import com.hederahashgraph.api.proto.java.Transaction;
 import com.hederahashgraph.api.proto.java.TransactionBody;
 import com.hederahashgraph.api.proto.java.TransactionID;
 import com.hederahashgraph.api.proto.java.TransactionRecord;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -67,9 +72,8 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
+
 import javax.annotation.Nullable;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 public abstract class HapiSpecOperation {
     private static final Logger log = LogManager.getLogger(HapiSpecOperation.class);
@@ -253,9 +257,9 @@ public abstract class HapiSpecOperation {
                 return Optional.empty();
             }
             if (verboseLoggingOn) {
-                log.warn(spec.logPrefix() + this + " failed - {}", t);
+                log.warn("%s%s failed - {}".formatted(spec.logPrefix(), this), t);
             } else if (!loggingOff) {
-                log.warn(spec.logPrefix() + this + " failed {}!", t.getMessage());
+                log.warn("%s%s failed {}!".formatted(spec.logPrefix(), this), t.getMessage());
             }
             return Optional.of(t);
         }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/assertions/TransactionRecordAsserts.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/assertions/TransactionRecordAsserts.java
@@ -18,9 +18,11 @@ package com.hedera.services.bdd.spec.assertions;
 
 import static com.hedera.services.bdd.spec.assertions.EqualityAssertsProviderFactory.shouldBe;
 import static com.hedera.services.bdd.spec.assertions.EqualityAssertsProviderFactory.shouldNotBe;
-import static java.util.Collections.EMPTY_LIST;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import static java.util.Collections.EMPTY_LIST;
 
 import com.google.protobuf.ByteString;
 import com.hedera.services.bdd.spec.HapiSpec;
@@ -28,13 +30,15 @@ import com.hedera.services.bdd.spec.queries.QueryUtils;
 import com.hedera.services.bdd.spec.transactions.TxnUtils;
 import com.hedera.services.bdd.spec.transactions.token.TokenMovement;
 import com.hederahashgraph.api.proto.java.*;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.junit.jupiter.api.Assertions;
+
 import java.lang.reflect.Method;
 import java.util.Collections;
 import java.util.List;
 import java.util.function.Function;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.junit.jupiter.api.Assertions;
 
 public class TransactionRecordAsserts extends BaseErroringAssertsProvider<TransactionRecord> {
     static final Logger log = LogManager.getLogger(TransactionRecordAsserts.class);
@@ -324,15 +328,20 @@ public class TransactionRecordAsserts extends BaseErroringAssertsProvider<Transa
     private <T> void registerTypedProvider(String forField, ErroringAssertsProvider<T> provider) {
         try {
             Method m = TransactionRecord.class.getMethod(QueryUtils.asGetter(forField));
-            registerProvider((spec, o) -> {
-                TransactionRecord record = (TransactionRecord) o;
-                T instance = (T) m.invoke(record);
-                ErroringAsserts<T> asserts = provider.assertsFor(spec);
-                List<Throwable> errors = asserts.errorsIn(instance);
-                AssertUtils.rethrowSummaryError(log, "Bad " + forField + "!", errors);
-            });
+            registerProvider(
+                    (spec, o) -> {
+                        TransactionRecord transactionRecord = (TransactionRecord) o;
+                        T instance = (T) m.invoke(transactionRecord);
+                        ErroringAsserts<T> asserts = provider.assertsFor(spec);
+                        List<Throwable> errors = asserts.errorsIn(instance);
+                        AssertUtils.rethrowSummaryError(log, "Bad " + forField + "!", errors);
+                    });
         } catch (Exception e) {
-            log.warn("Unable to register asserts provider for TransactionRecord field '" + forField + "'", e);
+            log.warn(
+                    String.format(
+                            "Unable to register asserts provider for TransactionRecord field '%s'",
+                            forField),
+                    e);
         }
     }
 }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/fees/FeesAndRatesProvider.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/fees/FeesAndRatesProvider.java
@@ -43,14 +43,16 @@ import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
 import com.hederahashgraph.api.proto.java.Transaction;
 import com.hederahashgraph.api.proto.java.TransactionID;
 import com.hederahashgraph.api.proto.java.TransferList;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import java.io.File;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.nio.file.Files;
 import java.time.Instant;
 import java.util.List;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 public class FeesAndRatesProvider {
     private static final Logger log = LogManager.getLogger(FeesAndRatesProvider.class);
@@ -104,7 +106,8 @@ public class FeesAndRatesProvider {
 
     public void updateRateSet(ExchangeRateSet newSet) {
         rateSet = newSet;
-        log.info("Updating rates! Now :: " + rateSetAsString(newSet));
+        String message = String.format("Updating rates! Now :: %s", rateSetAsString(newSet));
+        log.info(message);
     }
 
     public ExchangeRateSet rateSet() {
@@ -121,8 +124,11 @@ public class FeesAndRatesProvider {
     private void readRateSet() throws Throwable {
         File f = new File(setup.clientExchangeRatesPath());
         byte[] bytes = Files.readAllBytes(f.toPath());
-        rateSet = ExchangeRateSet.parseFrom(bytes);
-        log.info("The exchange rates from '" + f.getAbsolutePath() + "' are :: " + rateSetAsString(rateSet));
+        final String message =
+                String.format(
+                        "The exchange rates from '%s' are :: %s",
+                        f.getAbsolutePath(), rateSetAsString(ExchangeRateSet.parseFrom(bytes)));
+        log.info(message);
     }
 
     public boolean hasRateSet() {
@@ -133,8 +139,11 @@ public class FeesAndRatesProvider {
         long queryFee = lookupDownloadFee(setup.exchangeRatesId());
         FileGetContentsResponse response = downloadWith(queryFee, false, setup.exchangeRatesId());
         byte[] bytes = response.getFileContents().getContents().toByteArray();
-        rateSet = ExchangeRateSet.parseFrom(bytes);
-        log.info("The exchange rates are :: " + rateSetAsString(rateSet));
+        final String message =
+                String.format(
+                        "The exchange rates are :: %s",
+                        rateSetAsString(ExchangeRateSet.parseFrom(bytes)));
+        log.info(message);
     }
 
     private void readFeeSchedule() throws Throwable {
@@ -142,11 +151,11 @@ public class FeesAndRatesProvider {
         byte[] bytes = Files.readAllBytes(f.toPath());
         CurrentAndNextFeeSchedule wrapper = CurrentAndNextFeeSchedule.parseFrom(bytes);
         feeSchedule = wrapper.getCurrentFeeSchedule();
-        log.info("The fee schedule from '"
-                + f.getAbsolutePath()
-                + "' covers "
-                + feeSchedule.getTransactionFeeScheduleList().size()
-                + " ops.");
+        final String message =
+                String.format(
+                        "The fee schedule from '%s' covers %s ops.",
+                        f.getAbsolutePath(), feeSchedule.getTransactionFeeScheduleList().size());
+        log.info(message);
     }
 
     private void downloadFeeSchedule() throws Throwable {
@@ -155,9 +164,11 @@ public class FeesAndRatesProvider {
         byte[] bytes = response.getFileContents().getContents().toByteArray();
         CurrentAndNextFeeSchedule wrapper = CurrentAndNextFeeSchedule.parseFrom(bytes);
         feeSchedule = typePatching.withPatchedTypesIfNecessary(wrapper.getCurrentFeeSchedule());
-        log.info("The fee schedule covers "
-                + feeSchedule.getTransactionFeeScheduleList().size()
-                + " ops.");
+        String message =
+                String.format(
+                        "The fee schedule covers %s ops.",
+                        feeSchedule.getTransactionFeeScheduleList().size());
+        log.info(message);
     }
 
     private long lookupDownloadFee(FileID fileId) throws Throwable {
@@ -230,29 +241,34 @@ public class FeesAndRatesProvider {
 
     public ExchangeRateSet rateSetWith(int curHbarEquiv, int curCentEquiv) {
         ExchangeRate.Builder curRate =
-                rateSet.getCurrentRate().toBuilder().setHbarEquiv(curHbarEquiv).setCentEquiv(curCentEquiv);
+                rateSet.getCurrentRate().toBuilder()
+                        .setHbarEquiv(curHbarEquiv)
+                        .setCentEquiv(curCentEquiv);
 
-        ExchangeRateSet perturbedSet =
-                rateSet.toBuilder().setCurrentRate(curRate).build();
-
-        log.info("Computed a new rate set :: " + rateSetAsString(perturbedSet));
+        ExchangeRateSet perturbedSet = rateSet.toBuilder().setCurrentRate(curRate).build();
+        String message =
+                String.format("Computed a new rate set :: %s", rateSetAsString(perturbedSet));
+        log.info(message);
 
         return perturbedSet;
     }
 
     public ExchangeRateSet rateSetWith(int curHbarEquiv, int curCentEquiv, int nextHbarEquiv, int nextCentEquiv) {
         ExchangeRate.Builder curRate =
-                rateSet.getCurrentRate().toBuilder().setHbarEquiv(curHbarEquiv).setCentEquiv(curCentEquiv);
+                rateSet.getCurrentRate().toBuilder()
+                        .setHbarEquiv(curHbarEquiv)
+                        .setCentEquiv(curCentEquiv);
 
         ExchangeRate.Builder nextRate =
-                rateSet.getCurrentRate().toBuilder().setHbarEquiv(nextHbarEquiv).setCentEquiv(nextCentEquiv);
+                rateSet.getCurrentRate().toBuilder()
+                        .setHbarEquiv(nextHbarEquiv)
+                        .setCentEquiv(nextCentEquiv);
 
-        ExchangeRateSet perturbedSet = rateSet.toBuilder()
-                .setCurrentRate(curRate)
-                .setNextRate(nextRate)
-                .build();
-
-        log.info("Computed a new rate set :: " + rateSetAsString(perturbedSet));
+        ExchangeRateSet perturbedSet =
+                rateSet.toBuilder().setCurrentRate(curRate).setNextRate(nextRate).build();
+        String message =
+                String.format("Computed a new rate set :: %s", rateSetAsString(perturbedSet));
+        log.info(message);
 
         return perturbedSet;
     }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/HapiApiClients.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/HapiApiClients.java
@@ -41,19 +41,22 @@ import com.hederahashgraph.service.proto.java.SmartContractServiceGrpc.SmartCont
 import com.hederahashgraph.service.proto.java.TokenServiceGrpc;
 import com.hederahashgraph.service.proto.java.TokenServiceGrpc.TokenServiceBlockingStub;
 import com.hederahashgraph.service.proto.java.UtilServiceGrpc;
+
 import io.grpc.ManagedChannel;
 import io.grpc.netty.GrpcSslContexts;
 import io.grpc.netty.NegotiationType;
 import io.grpc.netty.NettyChannelBuilder;
 import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.handler.ssl.SupportedCipherSuiteFilter;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 public class HapiApiClients {
     static final Logger log = LogManager.getLogger(HapiApiClients.class);
@@ -192,7 +195,11 @@ public class HapiApiClients {
         int after = stubCount();
         this.defaultNode = defaultNode;
         if (after > before) {
-            log.info("Constructed " + (after - before) + " new stubs building clients for " + this);
+            String message =
+                    String.format(
+                            "Constructed %s new stubs building clients for %s",
+                            (after - before), this);
+            log.info(message);
         }
     }
 

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/keys/TrieSigMapGenerator.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/keys/TrieSigMapGenerator.java
@@ -25,6 +25,11 @@ import com.hederahashgraph.api.proto.java.Key;
 import com.hederahashgraph.api.proto.java.SignatureMap;
 import com.hederahashgraph.api.proto.java.SignaturePair;
 import com.swirlds.common.utility.CommonUtils;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.junit.jupiter.api.Assertions;
+
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
@@ -33,9 +38,6 @@ import java.util.Map;
 import java.util.Random;
 import java.util.Set;
 import java.util.function.Function;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.junit.jupiter.api.Assertions;
 
 public class TrieSigMapGenerator implements SigMapGenerator {
     private static final Logger log = LogManager.getLogger(TrieSigMapGenerator.class);
@@ -150,7 +152,10 @@ public class TrieSigMapGenerator implements SigMapGenerator {
                     prefix = trie.randomPrefix(key.length);
                     break;
             }
-            log.debug(CommonUtils.hex(key) + " gets prefix " + CommonUtils.hex(prefix));
+            String message =
+                    String.format(
+                            "%s gets prefix %s", CommonUtils.hex(key), CommonUtils.hex(prefix));
+            log.debug(message);
             return prefix;
         };
     }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/props/JutilPropertySource.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/props/JutilPropertySource.java
@@ -19,12 +19,14 @@ package com.hedera.services.bdd.spec.props;
 import com.google.common.io.ByteSource;
 import com.google.common.io.Resources;
 import com.hedera.services.bdd.spec.HapiPropertySource;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
 import java.util.Properties;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 public class JutilPropertySource implements HapiPropertySource {
     static final Logger log = LogManager.getLogger(JutilPropertySource.class);
@@ -67,10 +69,12 @@ public class JutilPropertySource implements HapiPropertySource {
             try (InputStream inputStream = byteSource.openBufferedStream()) {
                 target.load(inputStream);
             } catch (IOException ioE) {
-                log.warn("Unable to load properties from '" + path + "'!", ioE);
+                String message = String.format("Unable to load properties from '%s'!", path);
+                log.warn(message, ioE);
             }
         } catch (Exception e) {
-            log.warn("Unable to load properties from '" + path + "'!", e);
+            String message = String.format("Unable to load properties from '%s'!", path);
+            log.warn(message, e);
         }
     }
 }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/props/MapPropertySource.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/props/MapPropertySource.java
@@ -19,12 +19,14 @@ package com.hedera.services.bdd.spec.props;
 import static java.util.stream.Collectors.toMap;
 
 import com.hedera.services.bdd.spec.HapiPropertySource;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Stream;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 public class MapPropertySource implements HapiPropertySource {
     private static final Logger log = LogManager.getLogger(MapPropertySource.class);
@@ -41,10 +43,12 @@ public class MapPropertySource implements HapiPropertySource {
 
     public MapPropertySource(Map props) {
         Map<String, Object> typedProps = (Map<String, Object>) props;
-        var filteredProps = typedProps.entrySet().stream()
-                .filter(entry -> !KEYS_TO_CENSOR.contains(entry.getKey()))
-                .collect(toMap(Map.Entry::getKey, Map.Entry::getValue));
-        log.info("Initializing a MapPropertySource from " + filteredProps);
+        var filteredProps =
+                typedProps.entrySet().stream()
+                        .filter(entry -> !KEYS_TO_CENSOR.contains(entry.getKey()))
+                        .collect(toMap(Map.Entry::getKey, Map.Entry::getValue));
+        String message = String.format("Initializing a MapPropertySource from %s", filteredProps);
+        log.info(message);
         this.props = props;
     }
 

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/HapiQueryOp.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/HapiQueryOp.java
@@ -27,6 +27,7 @@ import static com.hedera.services.bdd.spec.transactions.TxnUtils.txnToString;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INSUFFICIENT_TX_FEE;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OK;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.UNKNOWN;
+
 import static java.lang.Thread.sleep;
 import static java.util.stream.Collectors.toList;
 
@@ -53,6 +54,10 @@ import com.hederahashgraph.api.proto.java.TransactionBody;
 import com.hederahashgraph.api.proto.java.TransactionReceipt;
 import com.hederahashgraph.api.proto.java.TransactionRecord;
 import com.hederahashgraph.api.proto.java.TransferList;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Optional;
@@ -60,8 +65,6 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 public abstract class HapiQueryOp<T extends HapiQueryOp<T>> extends HapiSpecOperation {
     private static final Logger log = LogManager.getLogger(HapiQueryOp.class);
@@ -162,7 +165,11 @@ public abstract class HapiQueryOp<T extends HapiQueryOp<T>> extends HapiSpecOper
             }
 
             if (needsPayment() && !loggingOff) {
-                log.info(spec.logPrefix() + "Paying for " + this + " with " + txnToString(payment));
+                String message =
+                        String.format(
+                                "%sPaying for %s with %s",
+                                spec.logPrefix(), this, txnToString(payment));
+                log.info(message);
             }
             timedSubmitWith(spec, payment);
 
@@ -245,7 +252,11 @@ public abstract class HapiQueryOp<T extends HapiQueryOp<T>> extends HapiSpecOper
             long initNodePayment = costOnlyNodePayment(spec);
             Transaction payment = finalizedTxn(spec, opDef(spec, initNodePayment), true);
             if (!loggingOff) {
-                log.info(spec.logPrefix() + "Paying for COST_ANSWER of " + this + " with " + txnToString(payment));
+                String message =
+                        String.format(
+                                "%sPaying for COST_ANSWER of %s with %s",
+                                spec.logPrefix(), this, txnToString(payment));
+                log.info(message);
             }
             long realNodePayment = timedCostLookupWith(spec, payment);
             if (recordsNodePayment) {
@@ -265,7 +276,11 @@ public abstract class HapiQueryOp<T extends HapiQueryOp<T>> extends HapiSpecOper
             }
             txnSubmitted = payment;
             if (!loggingOff) {
-                log.info(spec.logPrefix() + "--> Node payment for " + this + " is " + realNodePayment + " tinyBars.");
+                String message =
+                        String.format(
+                                "%s--> Node payment for %s is %s tinyBars.",
+                                spec.logPrefix(), this, realNodePayment);
+                log.info(message);
             }
             if (expectStrictCostAnswer) {
                 Transaction insufficientPayment = finalizedTxn(spec, opDef(spec, realNodePayment - 1));

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/consensus/HapiGetTopicInfo.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/consensus/HapiGetTopicInfo.java
@@ -19,6 +19,7 @@ package com.hedera.services.bdd.spec.queries.consensus;
 import static com.hedera.services.bdd.spec.queries.QueryUtils.answerCostHeader;
 import static com.hedera.services.bdd.spec.queries.QueryUtils.answerHeader;
 import static com.hedera.services.bdd.spec.transactions.TxnUtils.asId;
+
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -33,14 +34,17 @@ import com.hederahashgraph.api.proto.java.HederaFunctionality;
 import com.hederahashgraph.api.proto.java.Query;
 import com.hederahashgraph.api.proto.java.Response;
 import com.hederahashgraph.api.proto.java.Transaction;
+
 import edu.umd.cs.findbugs.annotations.Nullable;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.junit.jupiter.api.Assertions;
+
 import java.util.Optional;
 import java.util.OptionalLong;
 import java.util.function.LongConsumer;
 import java.util.function.LongSupplier;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.junit.jupiter.api.Assertions;
 
 public class HapiGetTopicInfo extends HapiQueryOp<HapiGetTopicInfo> {
     private static final Logger log = LogManager.getLogger(HapiGetTopicInfo.class);
@@ -149,7 +153,9 @@ public class HapiGetTopicInfo extends HapiQueryOp<HapiGetTopicInfo> {
                 .getConsSvcStub(targetNodeFor(spec), useTls, spec.setup().workflowOperations())
                 .getTopicInfo(query);
         if (verboseLoggingOn) {
-            log.info("Info: " + response.getConsensusGetTopicInfo().getTopicInfo());
+            String message =
+                    String.format("Info: %s", response.getConsensusGetTopicInfo().getTopicInfo());
+            log.info(message);
         }
         if (saveRunningHash) {
             spec.registry()

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/contract/HapiGetContractRecords.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/contract/HapiGetContractRecords.java
@@ -38,14 +38,16 @@ import com.hederahashgraph.api.proto.java.Query;
 import com.hederahashgraph.api.proto.java.Response;
 import com.hederahashgraph.api.proto.java.Transaction;
 import com.hederahashgraph.api.proto.java.TransactionRecord;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.junit.jupiter.api.Assertions;
+
 import java.io.File;
 import java.nio.charset.Charset;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.BiConsumer;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.junit.jupiter.api.Assertions;
 
 public class HapiGetContractRecords extends HapiQueryOp<HapiGetContractRecords> {
     private static final Logger log = LogManager.getLogger(HapiGetContractRecords.class);
@@ -185,8 +187,8 @@ public class HapiGetContractRecords extends HapiQueryOp<HapiGetContractRecords> 
                 ByteSink byteSink = Files.asByteSink(recordFile);
                 byteSink.write(records.get(i).toByteArray());
             }
-
-            log.info("Saved " + n + " records to " + snapshotDir);
+            String message = String.format("Saved %d records to %s", n, snapshotDir);
+            log.info(message);
         } catch (Exception e) {
             log.error("Couldn't save record snapshots!", e);
         }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/crypto/HapiGetAccountBalance.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/crypto/HapiGetAccountBalance.java
@@ -20,6 +20,7 @@ import static com.hedera.services.bdd.spec.queries.QueryUtils.answerCostHeader;
 import static com.hedera.services.bdd.spec.queries.QueryUtils.answerHeader;
 import static com.hedera.services.bdd.spec.transactions.TxnUtils.asTokenId;
 import static com.hedera.services.yahcli.output.CommonMessages.COMMON_MESSAGES;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.google.common.base.MoreObjects;
@@ -40,6 +41,12 @@ import com.hederahashgraph.api.proto.java.TokenBalance;
 import com.hederahashgraph.api.proto.java.TokenID;
 import com.hederahashgraph.api.proto.java.Transaction;
 import com.swirlds.common.utility.CommonUtils;
+
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.junit.jupiter.api.Assertions;
+
 import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -52,11 +59,8 @@ import java.util.function.Function;
 import java.util.function.LongConsumer;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
+
 import javax.annotation.Nullable;
-import org.apache.commons.lang3.tuple.Pair;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.junit.jupiter.api.Assertions;
 
 public class HapiGetAccountBalance extends HapiQueryOp<HapiGetAccountBalance> {
     private static final Logger log = LogManager.getLogger(HapiGetAccountBalance.class);
@@ -188,8 +192,11 @@ public class HapiGetAccountBalance extends HapiQueryOp<HapiGetAccountBalance> {
             balanceObserver.accept(actual);
         }
         if (verboseLoggingOn) {
-            log.info("Explicit token balances: "
-                    + response.getCryptogetAccountBalance().getTokenBalancesList());
+            String message =
+                    String.format(
+                            "Explicit token balances: %s",
+                            response.getCryptogetAccountBalance().getTokenBalancesList());
+            log.info(message);
         }
 
         if (assertAccountIDIsNotAlias) {
@@ -272,13 +279,18 @@ public class HapiGetAccountBalance extends HapiQueryOp<HapiGetAccountBalance> {
         ResponseCodeEnum status =
                 response.getCryptogetAccountBalance().getHeader().getNodeTransactionPrecheckCode();
         if (status == ResponseCodeEnum.ACCOUNT_DELETED) {
-            log.info(spec.logPrefix() + repr + " was actually deleted!");
+            String message = String.format("%s%s was actually deleted!", spec.logPrefix(), repr);
+            log.info(message);
         } else {
             long balance = response.getCryptogetAccountBalance().getBalance();
             long TINYBARS_PER_HBAR = 100_000_000L;
             long hBars = balance / TINYBARS_PER_HBAR;
             if (!loggingOff) {
-                log.info(spec.logPrefix() + "balance for '" + repr + "': " + balance + " tinyBars (" + hBars + "ħ)");
+                String message =
+                        String.format(
+                                "%sbalance for '%s':%d tinyBars (%dh)",
+                                spec.logPrefix(), repr, balance, hBars);
+                log.info(message);
             }
             if (yahcliLogger) {
                 COMMON_MESSAGES.info(String.format("%20s | %20d |", repr, balance));

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/crypto/HapiGetAccountDetails.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/crypto/HapiGetAccountDetails.java
@@ -20,6 +20,7 @@ import static com.hedera.services.bdd.spec.assertions.AssertUtils.rethrowSummary
 import static com.hedera.services.bdd.spec.queries.QueryUtils.answerCostHeader;
 import static com.hedera.services.bdd.spec.queries.QueryUtils.answerHeader;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OK;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.google.common.base.MoreObjects;
@@ -35,6 +36,11 @@ import com.hederahashgraph.api.proto.java.HederaFunctionality;
 import com.hederahashgraph.api.proto.java.Query;
 import com.hederahashgraph.api.proto.java.Response;
 import com.hederahashgraph.api.proto.java.Transaction;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.junit.jupiter.api.Assertions;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -42,9 +48,6 @@ import java.util.Optional;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.LongConsumer;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.junit.jupiter.api.Assertions;
 
 public class HapiGetAccountDetails extends HapiQueryOp<HapiGetAccountDetails> {
     private static final Logger log = LogManager.getLogger(HapiGetAccountDetails.class);
@@ -219,10 +222,11 @@ public class HapiGetAccountDetails extends HapiQueryOp<HapiGetAccountDetails> {
             idObserver.ifPresent(cb -> cb.accept(details.getAccountDetails().getAccountId()));
         }
         if (verboseLoggingOn) {
-            log.info("Details for '"
-                    + repr()
-                    + "': "
-                    + response.getAccountDetails().getAccountDetails());
+            String message =
+                    String.format(
+                            "Details for '%s': %s",
+                            repr(), response.getAccountDetails().getAccountDetails());
+            log.info(message);
         }
         if (customLog.isPresent()) {
             customLog.get().accept(response.getAccountDetails().getAccountDetails(), log);

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/crypto/HapiGetAccountInfo.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/crypto/HapiGetAccountInfo.java
@@ -21,6 +21,7 @@ import static com.hedera.services.bdd.spec.queries.QueryUtils.answerCostHeader;
 import static com.hedera.services.bdd.spec.queries.QueryUtils.answerHeader;
 import static com.hederahashgraph.api.proto.java.CryptoGetInfoResponse.AccountInfo;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OK;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.google.common.base.MoreObjects;
@@ -32,6 +33,12 @@ import com.hedera.services.bdd.spec.queries.HapiQueryOp;
 import com.hedera.services.bdd.spec.transactions.TxnUtils;
 import com.hederahashgraph.api.proto.java.*;
 import com.swirlds.common.utility.CommonUtils;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.jetbrains.annotations.Nullable;
+import org.junit.jupiter.api.Assertions;
+
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.ArrayList;
@@ -41,10 +48,6 @@ import java.util.Optional;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.LongConsumer;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.jetbrains.annotations.Nullable;
-import org.junit.jupiter.api.Assertions;
 
 public class HapiGetAccountInfo extends HapiQueryOp<HapiGetAccountInfo> {
     private static final Logger log = LogManager.getLogger(HapiGetAccountInfo.class);
@@ -279,7 +282,11 @@ public class HapiGetAccountInfo extends HapiQueryOp<HapiGetAccountInfo> {
                     cb -> cb.accept(infoResponse.getAccountInfo().getContractAccountID()));
         }
         if (verboseLoggingOn) {
-            log.info("Info for '" + repr() + "': " + response.getCryptoGetInfo().getAccountInfo());
+            String message =
+                    String.format(
+                            "Info for '%s': %s",
+                            repr(), response.getCryptoGetInfo().getAccountInfo());
+            log.info(message);
         }
         if (customLog.isPresent()) {
             customLog.get().accept(response.getCryptoGetInfo().getAccountInfo(), log);

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/crypto/HapiGetAccountRecords.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/crypto/HapiGetAccountRecords.java
@@ -38,14 +38,16 @@ import com.hederahashgraph.api.proto.java.Query;
 import com.hederahashgraph.api.proto.java.Response;
 import com.hederahashgraph.api.proto.java.Transaction;
 import com.hederahashgraph.api.proto.java.TransactionRecord;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.junit.jupiter.api.Assertions;
+
 import java.io.File;
 import java.nio.charset.Charset;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.BiConsumer;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.junit.jupiter.api.Assertions;
 
 public class HapiGetAccountRecords extends HapiQueryOp<HapiGetAccountRecords> {
     private static final Logger log = LogManager.getLogger(HapiGetAccountRecords.class);
@@ -165,8 +167,8 @@ public class HapiGetAccountRecords extends HapiQueryOp<HapiGetAccountRecords> {
                 ByteSink byteSink = Files.asByteSink(recordFile);
                 byteSink.write(records.get(i).toByteArray());
             }
-
-            log.info("Saved " + n + " records to " + snapshotDir);
+            String message = String.format("Saved %d records to %s", n, snapshotDir);
+            log.info(message);
         } catch (Exception e) {
             log.error("Couldn't save record snapshots!", e);
         }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/file/HapiGetFileContents.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/file/HapiGetFileContents.java
@@ -34,6 +34,11 @@ import com.hederahashgraph.api.proto.java.Query;
 import com.hederahashgraph.api.proto.java.Response;
 import com.hederahashgraph.api.proto.java.ServicesConfigurationList;
 import com.hederahashgraph.api.proto.java.Transaction;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.junit.jupiter.api.Assertions;
+
 import java.io.File;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
@@ -46,9 +51,6 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.UnaryOperator;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.junit.jupiter.api.Assertions;
 
 public class HapiGetFileContents extends HapiQueryOp<HapiGetFileContents> {
     private static final Logger log = LogManager.getLogger(HapiGetFileContents.class);
@@ -180,8 +182,12 @@ public class HapiGetFileContents extends HapiQueryOp<HapiGetFileContents> {
                 List<String> entries = new ArrayList<>();
                 configList
                         .getNameValueList()
-                        .forEach(setting ->
-                                entries.add(String.format("\n  %s=%s", setting.getName(), setting.getValue())));
+                        .forEach(
+                                setting ->
+                                        entries.add(
+                                                String.format(
+                                                        "%n  %s=%s",
+                                                        setting.getName(), setting.getValue())));
                 Collections.sort(entries);
                 entries.forEach(msg::append);
                 log.info(msg.toString());
@@ -207,28 +213,29 @@ public class HapiGetFileContents extends HapiQueryOp<HapiGetFileContents> {
                         int MAX_LEN = 4 * 1024;
                         int suffix = 0;
                         while (i < bytes.length) {
-                            File snapshotFile = new File(String.format("part%d-%s", suffix++, snapshotPath.get()));
+                            File snapshotFile =
+                                    new File(
+                                            String.format(
+                                                    "part%d-%s", suffix++, snapshotPath.get()));
                             ByteSink byteSink = Files.asByteSink(snapshotFile);
                             int numToWrite = Math.min(bytes.length - i, MAX_LEN);
                             byteSink.write(Arrays.copyOfRange(bytes, i, i + numToWrite));
                             i += numToWrite;
-                            log.info("Saved next "
-                                    + numToWrite
-                                    + " bytes of '"
-                                    + fileName
-                                    + "' to "
-                                    + snapshotFile.getAbsolutePath());
+                            String message =
+                                    String.format(
+                                            "Saved next %d bytes of '%s' to %s",
+                                            numToWrite, fileName, snapshotFile.getAbsolutePath());
+                            log.info(message);
                         }
                     } else {
                         File snapshotFile = new File(snapshotPath.get());
                         ByteSink byteSink = Files.asByteSink(snapshotFile);
                         byteSink.write(bytes);
-                        log.info("Saved "
-                                + bytes.length
-                                + " bytes of '"
-                                + fileName
-                                + "' to "
-                                + snapshotFile.getAbsolutePath());
+                        String message =
+                                String.format(
+                                        "Saved %d bytes of '%s' to %s",
+                                        bytes.length, fileName, snapshotFile.getAbsolutePath());
+                        log.info(message);
                     }
                 }
                 if (readablePath.isPresent()) {
@@ -236,10 +243,15 @@ public class HapiGetFileContents extends HapiQueryOp<HapiGetFileContents> {
                     File readableFile = new File(readablePath.get());
                     CharSink charSink = Files.asCharSink(readableFile, Charset.forName("UTF-8"));
                     charSink.write(contents);
-                    log.info("Saved parsed contents of '" + fileName + "' to " + readableFile.getAbsolutePath());
+                    String message =
+                            String.format(
+                                    "Saved parsed contents of '%s' to %s",
+                                    fileName, readableFile.getAbsolutePath());
+                    log.info(message);
                 }
             } catch (Exception e) {
-                log.error("Couldn't save '" + fileName + "' snapshot!", e);
+                String message = String.format("Couldn't save '%s' snapshot!", fileName);
+                log.error(message, e);
             }
         }
         if (registryEntry.isPresent()) {

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/meta/HapiGetReceipt.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/meta/HapiGetReceipt.java
@@ -17,6 +17,7 @@
 package com.hedera.services.bdd.spec.queries.meta;
 
 import static com.hedera.services.bdd.spec.queries.QueryUtils.txnReceiptQueryFor;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.google.common.base.MoreObjects;
@@ -30,10 +31,12 @@ import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
 import com.hederahashgraph.api.proto.java.Transaction;
 import com.hederahashgraph.api.proto.java.TransactionID;
 import com.hederahashgraph.api.proto.java.TransactionReceipt;
-import java.util.Optional;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.Assertions;
+
+import java.util.Optional;
 
 public class HapiGetReceipt extends HapiQueryOp<HapiGetReceipt> {
     static final Logger log = LogManager.getLogger(HapiGetReceipt.class);
@@ -123,12 +126,18 @@ public class HapiGetReceipt extends HapiQueryOp<HapiGetReceipt> {
         response = spec.clients().getCryptoSvcStub(targetNodeFor(spec), useTls).getTransactionReceipts(query);
         childReceipts = response.getTransactionGetReceipt().getChildTransactionReceiptsList();
         if (verboseLoggingOn) {
-            log.info("Receipt: " + response.getTransactionGetReceipt().getReceipt());
-            log.info(
-                    spec.logPrefix() + "  And {} child receipts{}: {}",
-                    childReceipts.size(),
-                    childReceipts.size() > 1 ? "s" : "",
-                    childReceipts);
+            String message =
+                    String.format("Receipt: %s", response.getTransactionGetReceipt().getReceipt());
+            log.info(message);
+            String message2 =
+                    String.format(
+                            "%s  And %d child receipts%s: %s",
+                            spec.logPrefix(),
+                            childReceipts.size(),
+                            childReceipts.size() > 1 ? "s" : "",
+                            childReceipts);
+
+            log.info(message2);
         }
     }
 

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/token/HapiGetTokenNftInfo.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/token/HapiGetTokenNftInfo.java
@@ -18,6 +18,7 @@ package com.hedera.services.bdd.spec.queries.token;
 
 import static com.hedera.services.bdd.spec.queries.QueryUtils.answerCostHeader;
 import static com.hedera.services.bdd.spec.queries.QueryUtils.answerHeader;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.google.protobuf.ByteString;
@@ -31,12 +32,14 @@ import com.hederahashgraph.api.proto.java.Query;
 import com.hederahashgraph.api.proto.java.Response;
 import com.hederahashgraph.api.proto.java.TokenGetNftInfoQuery;
 import com.hederahashgraph.api.proto.java.Transaction;
-import java.util.Optional;
-import java.util.OptionalLong;
-import java.util.function.BiFunction;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.Assertions;
+
+import java.util.Optional;
+import java.util.OptionalLong;
+import java.util.function.BiFunction;
 
 public class HapiGetTokenNftInfo extends HapiQueryOp<HapiGetTokenNftInfo> {
     private static final Logger log = LogManager.getLogger(HapiGetTokenNftInfo.class);
@@ -162,8 +165,10 @@ public class HapiGetTokenNftInfo extends HapiQueryOp<HapiGetTokenNftInfo> {
         Query query = getTokenNftInfoQuery(spec, payment, false);
         response = spec.clients().getTokenSvcStub(targetNodeFor(spec), useTls).getTokenNftInfo(query);
         if (verboseLoggingOn) {
-            log.info(
-                    "Info for '" + token + "': " + response.getTokenGetNftInfo().getNft());
+            String message =
+                    String.format(
+                            "Info for '%s': %s", token, response.getTokenGetNftInfo().getNft());
+            log.info(message);
         }
     }
 

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/token/HapiGetTokenNftInfos.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/token/HapiGetTokenNftInfos.java
@@ -29,13 +29,15 @@ import com.hederahashgraph.api.proto.java.Response;
 import com.hederahashgraph.api.proto.java.TokenGetNftInfosQuery;
 import com.hederahashgraph.api.proto.java.TokenNftInfo;
 import com.hederahashgraph.api.proto.java.Transaction;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.junit.jupiter.api.Assertions;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.junit.jupiter.api.Assertions;
 
 public class HapiGetTokenNftInfos extends HapiQueryOp<HapiGetTokenNftInfos> {
 
@@ -93,7 +95,8 @@ public class HapiGetTokenNftInfos extends HapiQueryOp<HapiGetTokenNftInfos> {
         Query query = getTokenNftInfosQuery(spec, payment, false);
         response = spec.clients().getTokenSvcStub(targetNodeFor(spec), useTls).getTokenNftInfos(query);
         if (verboseLoggingOn) {
-            log.info("NftInfo for '" + token + "': ");
+            String message = String.format("NftInfo for '%s': ", token);
+            log.info(message);
             response.getTokenGetNftInfos().getNftsList().forEach(nft -> log.info(nft.toString()));
         }
     }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/HapiTxnOp.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/HapiTxnOp.java
@@ -31,6 +31,7 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OK;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SUCCESS;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.UNKNOWN;
 import static com.hederahashgraph.api.proto.java.ResponseType.ANSWER_ONLY;
+
 import static java.lang.Thread.sleep;
 import static java.util.stream.Collectors.toList;
 
@@ -61,7 +62,13 @@ import com.hederahashgraph.api.proto.java.TransactionBody;
 import com.hederahashgraph.api.proto.java.TransactionGetReceiptResponse;
 import com.hederahashgraph.api.proto.java.TransactionReceipt;
 import com.hederahashgraph.api.proto.java.TransactionResponse;
+
 import io.grpc.StatusRuntimeException;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.tuweni.bytes.Bytes;
+
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.EnumSet;
@@ -72,9 +79,6 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.apache.tuweni.bytes.Bytes;
 
 public abstract class HapiTxnOp<T extends HapiTxnOp<T>> extends HapiSpecOperation {
     private static final Logger log = LogManager.getLogger(HapiTxnOp.class);
@@ -144,7 +148,11 @@ public abstract class HapiTxnOp<T extends HapiTxnOp<T>> extends HapiSpecOperatio
             Transaction txn = finalizedTxn(spec, opBodyDef(spec));
 
             if (!loggingOff) {
-                log.info(spec.logPrefix() + " submitting " + this + " via " + txnToString(txn));
+                String message =
+                        String.format(
+                                "%s submitting %s via %s",
+                                spec.logPrefix(), this, txnToString(txn));
+                log.info(message);
             }
 
             TransactionResponse response;

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/TxnUtils.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/TxnUtils.java
@@ -35,6 +35,7 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.DUPLICATE_TRAN
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OK;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.PLATFORM_TRANSACTION_NOT_CREATED;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SUCCESS;
+
 import static java.lang.System.arraycopy;
 import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.toList;
@@ -78,6 +79,10 @@ import com.hederahashgraph.api.proto.java.TransactionID;
 import com.hederahashgraph.api.proto.java.TransactionRecord;
 import com.hederahashgraph.api.proto.java.TransferList;
 import com.swirlds.common.utility.CommonUtils;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.math.BigInteger;
@@ -98,8 +103,6 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.regex.Pattern;
 import java.util.stream.IntStream;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 public class TxnUtils {
     private static final Logger log = LogManager.getLogger(TxnUtils.class);
@@ -348,8 +351,11 @@ public class TxnUtils {
         final HapiGetFileInfo subOp = getFileInfo(file).payingWith(payer).noLogging();
         final Optional<Throwable> error = subOp.execFor(spec);
         if (error.isPresent()) {
-            log.error("Unable to look up current expiration timestamp of file 0.0."
-                    + spec.registry().getFileId(file).getFileNum());
+            String message =
+                    String.format(
+                            "Unable to look up current expiration timestamp of file 0.0.%d",
+                            spec.registry().getFileId(file).getFileNum());
+            log.error(message);
             throw error.get();
         }
         return subOp.getResponse().getFileGetInfo().getFileInfo().getExpirationTime();
@@ -363,8 +369,11 @@ public class TxnUtils {
         final HapiGetContractInfo subOp = getContractInfo(contract).noLogging();
         final Optional<Throwable> error = subOp.execFor(spec);
         if (error.isPresent()) {
-            log.error("Unable to look up current expiration timestamp of contract 0.0."
-                    + spec.registry().getContractId(contract).getContractNum());
+            String message =
+                    String.format(
+                            "Unable to look up current expiration timestamp of contract 0.0.%d",
+                            spec.registry().getContractId(contract).getContractNum());
+            log.error(message);
             throw error.get();
         }
         return subOp.getResponse().getContractGetInfo().getContractInfo().getExpirationTime();
@@ -374,8 +383,11 @@ public class TxnUtils {
         final HapiGetContractInfo subOp = getContractInfo(contract).noLogging();
         final Optional<Throwable> error = subOp.execFor(spec);
         if (error.isPresent()) {
-            log.error("Unable to look up current expiration timestamp of contract 0.0."
-                    + spec.registry().getContractId(contract).getContractNum());
+            String message =
+                    String.format(
+                            "Unable to look up current expiration timestamp of contract 0.0.%d",
+                            spec.registry().getContractId(contract).getContractNum());
+            log.error(message);
             throw error.get();
         }
         return subOp.getResponse().getContractGetInfo().getContractInfo().getMaxAutomaticTokenAssociations();

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/file/HapiFileDelete.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/file/HapiFileDelete.java
@@ -27,13 +27,15 @@ import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
 import com.hederahashgraph.api.proto.java.Transaction;
 import com.hederahashgraph.api.proto.java.TransactionBody;
 import com.hederahashgraph.api.proto.java.TransactionResponse;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 public class HapiFileDelete extends HapiTxnOp<HapiFileDelete> {
     static final Logger log = LogManager.getLogger(HapiFileDelete.class);
@@ -66,11 +68,10 @@ public class HapiFileDelete extends HapiTxnOp<HapiFileDelete> {
     protected Consumer<TransactionBody.Builder> opBodyDef(HapiSpec spec) throws Throwable {
         file = fileSupplier.isPresent() ? fileSupplier.get().get() : file;
         var fid = TxnUtils.asFileId(file, spec);
-        FileDeleteTransactionBody opBody = spec.txns()
-                .<FileDeleteTransactionBody, FileDeleteTransactionBody.Builder>body(
-                        FileDeleteTransactionBody.class, builder -> {
-                            builder.setFileID(fid);
-                        });
+        FileDeleteTransactionBody opBody =
+                spec.txns()
+                        .<FileDeleteTransactionBody, FileDeleteTransactionBody.Builder>body(
+                                FileDeleteTransactionBody.class, builder -> builder.setFileID(fid));
         return builder -> builder.setFileDelete(opBody);
     }
 
@@ -88,7 +89,7 @@ public class HapiFileDelete extends HapiTxnOp<HapiFileDelete> {
     @Override
     protected void updateStateOf(HapiSpec spec) throws Throwable {
         if (verboseLoggingOn) {
-            log.info("Actual status was " + actualStatus);
+            log.info("Actual status was {}", actualStatus);
             log.info("Deleted file {} with ID {} ", file, spec.registry().getFileId(file));
         }
         if (actualStatus != ResponseCodeEnum.SUCCESS) {

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/network/HapiUncheckedSubmit.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/network/HapiUncheckedSubmit.java
@@ -28,10 +28,12 @@ import com.hederahashgraph.api.proto.java.Transaction;
 import com.hederahashgraph.api.proto.java.TransactionBody;
 import com.hederahashgraph.api.proto.java.TransactionResponse;
 import com.hederahashgraph.api.proto.java.UncheckedSubmitBody;
-import java.util.function.Consumer;
-import java.util.function.Function;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+
+import java.util.function.Consumer;
+import java.util.function.Function;
 
 public class HapiUncheckedSubmit<T extends HapiTxnOp<T>> extends HapiTxnOp<HapiUncheckedSubmit<T>> {
     private static final Logger log = LogManager.getLogger(HapiUncheckedSubmit.class);
@@ -57,12 +59,15 @@ public class HapiUncheckedSubmit<T extends HapiTxnOp<T>> extends HapiTxnOp<HapiU
     protected Consumer<TransactionBody.Builder> opBodyDef(final HapiSpec spec) throws Throwable {
         final var subOpBytes = subOp.serializeSignedTxnFor(spec);
         if (verboseLoggingOn) {
-            log.info("Submitting unchecked: " + CommonUtils.extractTransactionBody(Transaction.parseFrom(subOpBytes)));
+            log.info(
+                    "Submitting unchecked: {}",
+                    CommonUtils.extractTransactionBody(Transaction.parseFrom(subOpBytes)));
         }
-        final UncheckedSubmitBody opBody = spec.txns()
-                .<UncheckedSubmitBody, UncheckedSubmitBody.Builder>body(UncheckedSubmitBody.class, b -> {
-                    b.setTransactionBytes(ByteString.copyFrom(subOpBytes));
-                });
+        final UncheckedSubmitBody opBody =
+                spec.txns()
+                        .<UncheckedSubmitBody, UncheckedSubmitBody.Builder>body(
+                                UncheckedSubmitBody.class,
+                                b -> b.setTransactionBytes(ByteString.copyFrom(subOpBytes)));
         return b -> b.setUncheckedSubmit(opBody);
     }
 

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/token/HapiTokenAssociate.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/token/HapiTokenAssociate.java
@@ -21,6 +21,7 @@ import static com.hedera.services.bdd.spec.queries.QueryVerbs.getAccountInfo;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getContractInfo;
 import static com.hedera.services.bdd.spec.transactions.TxnUtils.suFrom;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SUCCESS;
+
 import static java.util.stream.Collectors.toList;
 
 import com.google.common.base.MoreObjects;
@@ -34,13 +35,15 @@ import com.hedera.services.bdd.spec.queries.crypto.HapiGetAccountInfo;
 import com.hedera.services.bdd.spec.transactions.HapiTxnOp;
 import com.hedera.services.bdd.spec.transactions.TxnUtils;
 import com.hederahashgraph.api.proto.java.*;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.function.Function;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 public class HapiTokenAssociate extends HapiTxnOp<HapiTokenAssociate> {
     static final Logger log = LogManager.getLogger(HapiTokenAssociate.class);
@@ -91,11 +94,12 @@ public class HapiTokenAssociate extends HapiTxnOp<HapiTokenAssociate> {
             Optional<Throwable> error = subOp.execFor(spec);
             if (error.isPresent()) {
                 if (!loggingOff) {
-                    log.warn(
-                            "Unable to look up current info for "
-                                    + HapiPropertySource.asAccountString(
-                                            spec.registry().getAccountID(account)),
-                            error.get());
+                    String message =
+                            String.format(
+                                    "Unable to look up current info for %s",
+                                    HapiPropertySource.asAccountString(
+                                            spec.registry().getAccountID(account)));
+                    log.warn(message, error.get());
                 }
                 throw error.get();
             }
@@ -109,11 +113,12 @@ public class HapiTokenAssociate extends HapiTxnOp<HapiTokenAssociate> {
             Optional<Throwable> error = subOp.execFor(spec);
             if (error.isPresent()) {
                 if (!loggingOff) {
-                    log.warn(
-                            "Unable to look up current info for "
-                                    + HapiPropertySource.asContractString(
-                                            spec.registry().getContractId(account)),
-                            error.get());
+                    String message =
+                            String.format(
+                                    "Unable to look up current info for %s",
+                                    HapiPropertySource.asContractString(
+                                            spec.registry().getContractId(account)));
+                    log.warn(message, error.get());
                 }
                 throw error.get();
             }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/token/HapiTokenFeeScheduleUpdate.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/token/HapiTokenFeeScheduleUpdate.java
@@ -44,13 +44,15 @@ import com.hederahashgraph.api.proto.java.TokenInfo;
 import com.hederahashgraph.api.proto.java.Transaction;
 import com.hederahashgraph.api.proto.java.TransactionBody;
 import com.hederahashgraph.api.proto.java.TransactionResponse;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.function.Function;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 public class HapiTokenFeeScheduleUpdate extends HapiTxnOp<HapiTokenFeeScheduleUpdate> {
     private static final TokenOpsUsage TOKEN_OPS_USAGE = new TokenOpsUsage();
@@ -156,11 +158,12 @@ public class HapiTokenFeeScheduleUpdate extends HapiTxnOp<HapiTokenFeeScheduleUp
         final Optional<Throwable> error = subOp.execFor(spec);
         if (error.isPresent()) {
             if (!loggingOff) {
-                scopedLog.warn(
-                        "Unable to look up current info for "
-                                + HapiPropertySource.asTokenString(
-                                        spec.registry().getTokenID(token)),
-                        error.get());
+                String message =
+                        String.format(
+                                "Unable to look up current info for %s",
+                                HapiPropertySource.asTokenString(
+                                        spec.registry().getTokenID(token)));
+                scopedLog.warn(message, error.get());
             }
             throw error.get();
         }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/CustomSpecAssert.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/CustomSpecAssert.java
@@ -22,10 +22,12 @@ import static com.hedera.services.bdd.spec.utilops.UtilVerbs.convertHapiCallsToE
 
 import com.hedera.services.bdd.spec.HapiSpec;
 import com.hedera.services.bdd.spec.HapiSpecOperation;
-import java.util.List;
-import java.util.Optional;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+
+import java.util.List;
+import java.util.Optional;
 
 public class CustomSpecAssert extends UtilOp {
     static final Logger log = LogManager.getLogger(CustomSpecAssert.class);
@@ -57,7 +59,7 @@ public class CustomSpecAssert extends UtilOp {
     private static void handleExec(final HapiSpec spec, final HapiSpecOperation op) {
         Optional<Throwable> error = op.execFor(spec);
         if (error.isPresent()) {
-            log.error("Operation '" + op + "' :: " + error.get().getMessage());
+            log.error("Operation '{}' :: {}", op, error.get().getMessage());
             throw new IllegalStateException(error.get());
         }
     }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/LoadTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/LoadTest.java
@@ -23,6 +23,7 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.BUSY;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.DUPLICATE_TRANSACTION;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OK;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.PLATFORM_TRANSACTION_NOT_CREATED;
+
 import static java.util.concurrent.TimeUnit.MINUTES;
 
 import com.hedera.services.bdd.spec.HapiSpec;
@@ -30,14 +31,16 @@ import com.hedera.services.bdd.spec.HapiSpecOperation;
 import com.hedera.services.bdd.suites.HapiSuite;
 import com.hedera.services.bdd.suites.perf.PerfTestLoadSettings;
 import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import java.util.List;
 import java.util.Optional;
 import java.util.OptionalDouble;
 import java.util.OptionalInt;
 import java.util.OptionalLong;
 import java.util.function.Supplier;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 public class LoadTest extends HapiSuite {
     private static final Logger log = LogManager.getLogger(LoadTest.class);
@@ -72,37 +75,37 @@ public class LoadTest extends HapiSuite {
         int usedArgs = 0;
         if (args.length > 0) {
             targetTPS = OptionalDouble.of(Double.parseDouble(args[0]));
-            log.info("Set targetTPS as " + targetTPS.getAsDouble());
+            log.info("Set targetTPS as {}", targetTPS.getAsDouble());
             usedArgs++;
         }
 
         if (args.length > 1) {
             testDurationMinutes = OptionalInt.of(Integer.parseInt(args[1]));
-            log.info("Set testDurationMinutes as " + testDurationMinutes.getAsInt());
+            log.info("Set testDurationMinutes as {}", testDurationMinutes.getAsInt());
             usedArgs++;
         }
 
         if (args.length > 2) {
             threadNumber = OptionalInt.of(Integer.parseInt(args[2]));
-            log.info("Set threadNumber as " + threadNumber.getAsInt());
+            log.info("Set threadNumber as {}", threadNumber.getAsInt());
             usedArgs++;
         }
 
         if (args.length > 3) {
             initialBalance = OptionalLong.of(Long.parseLong(args[3]));
-            log.info("Set initialBalance as " + initialBalance.getAsLong());
+            log.info("Set initialBalance as {}", initialBalance.getAsLong());
             usedArgs++;
         }
 
         if (args.length > 4) {
             hcsSubmitMessage = OptionalInt.of(Integer.parseInt(args[4]));
-            log.info("Set hcsSubmitMessageSize as " + hcsSubmitMessage.getAsInt());
+            log.info("Set hcsSubmitMessageSize as {}", hcsSubmitMessage.getAsInt());
             usedArgs++;
         }
 
         if (args.length > 5) {
             memoLength = OptionalInt.of(Integer.parseInt(args[5]));
-            log.info("Set Memo Length as " + memoLength.getAsInt());
+            log.info("Set Memo Length as {}", memoLength.getAsInt());
             usedArgs++;
         }
 

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/inventory/SpecKeyFromEcdsaFile.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/inventory/SpecKeyFromEcdsaFile.java
@@ -26,6 +26,12 @@ import com.hedera.services.bdd.spec.keys.SigControl;
 import com.hedera.services.bdd.spec.utilops.UtilOp;
 import com.hederahashgraph.api.proto.java.Key;
 import com.swirlds.common.utility.CommonUtils;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.bouncycastle.jce.ECNamedCurveTable;
+import org.bouncycastle.jce.spec.ECPrivateKeySpec;
+
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.math.BigInteger;
@@ -34,11 +40,8 @@ import java.nio.file.Paths;
 import java.security.KeyFactory;
 import java.security.PrivateKey;
 import java.util.Optional;
+
 import javax.annotation.Nullable;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.bouncycastle.jce.ECNamedCurveTable;
-import org.bouncycastle.jce.spec.ECPrivateKeySpec;
 
 public class SpecKeyFromEcdsaFile extends UtilOp {
     private static final Logger log = LogManager.getLogger(SpecKeyFromEcdsaFile.class);
@@ -71,7 +74,7 @@ public class SpecKeyFromEcdsaFile extends UtilOp {
             final @Nullable Logger logToUse) {
         final var hexedKey = CommonUtils.hex(pubKey);
         if (logToUse != null) {
-            logToUse.info("Hex-encoded public key: " + hexedKey);
+            logToUse.info("Hex-encoded public key: {}", hexedKey);
         }
         final var key =
                 Key.newBuilder().setECDSASecp256K1(ByteString.copyFrom(pubKey)).build();

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/inventory/SpecKeyFromMnemonic.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/inventory/SpecKeyFromMnemonic.java
@@ -24,16 +24,20 @@ import com.hedera.services.bdd.spec.keys.deterministic.Bip0032;
 import com.hedera.services.bdd.spec.keys.deterministic.Ed25519Factory;
 import com.hedera.services.bdd.spec.utilops.UtilOp;
 import com.swirlds.common.utility.CommonUtils;
-import java.security.InvalidKeyException;
-import java.security.NoSuchAlgorithmException;
-import java.util.Optional;
-import javax.annotation.Nullable;
-import javax.crypto.ShortBufferException;
+
 import net.i2p.crypto.eddsa.EdDSAPrivateKey;
 import net.i2p.crypto.eddsa.spec.EdDSANamedCurveTable;
 import net.i2p.crypto.eddsa.spec.EdDSAPrivateKeySpec;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.util.Optional;
+
+import javax.annotation.Nullable;
+import javax.crypto.ShortBufferException;
 
 public class SpecKeyFromMnemonic extends UtilOp {
     private static final Logger log = LogManager.getLogger(SpecKeyFromMnemonic.class);
@@ -73,7 +77,7 @@ public class SpecKeyFromMnemonic extends UtilOp {
         var pk = new EdDSAPrivateKey(privateKeySpec);
         var pubKeyHex = CommonUtils.hex(pk.getAbyte());
         if (logToUse != null) {
-            logToUse.info("Hex-encoded public key: " + pubKeyHex);
+            logToUse.info("Hex-encoded public key: {}", pubKeyHex);
         }
         var key = Ed25519Factory.populatedFrom(pk.getAbyte());
         spec.registry().saveKey(name, key);

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/pauses/HapiSpecSleep.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/pauses/HapiSpecSleep.java
@@ -19,6 +19,7 @@ package com.hedera.services.bdd.spec.utilops.pauses;
 import com.google.common.base.MoreObjects;
 import com.hedera.services.bdd.spec.HapiSpec;
 import com.hedera.services.bdd.spec.utilops.UtilOp;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -33,7 +34,7 @@ public class HapiSpecSleep extends UtilOp {
 
     @Override
     protected boolean submitOp(HapiSpec spec) throws Throwable {
-        log.info("Sleeping for " + timeMs + "ms now...");
+        log.info("Sleeping for {}ms now...", timeMs);
         Thread.sleep(timeMs);
         return false;
     }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/verification/NodeSignatureVerifier.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/verification/NodeSignatureVerifier.java
@@ -21,6 +21,13 @@ import static java.util.stream.Collectors.toList;
 import com.hederahashgraph.api.proto.java.NodeAddress;
 import com.hederahashgraph.api.proto.java.NodeAddressBook;
 import com.swirlds.common.utility.CommonUtils;
+
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.Marker;
+import org.apache.logging.log4j.MarkerManager;
+
 import java.io.DataInputStream;
 import java.io.File;
 import java.io.FileInputStream;
@@ -44,11 +51,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import org.apache.commons.lang3.tuple.Pair;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.Marker;
-import org.apache.logging.log4j.MarkerManager;
 
 public class NodeSignatureVerifier {
     private static final Logger log = LogManager.getLogger(NodeSignatureVerifier.class);
@@ -68,7 +70,7 @@ public class NodeSignatureVerifier {
             String account = new String(nodeAddress.getMemo().toByteArray());
             try {
                 accountKeys.put(account, loadPublicKey(nodeAddress.getRSAPubKey()));
-                log.info("Discovered node " + account);
+                log.info("Discovered node {}", account);
             } catch (IllegalArgumentException ex) {
                 log.warn("Malformed address key {} for node {}", nodeAddress.getRSAPubKey(), account);
                 throw new IllegalArgumentException("Malformed public key!");

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/compose/PerpetualLocalCalls.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/compose/PerpetualLocalCalls.java
@@ -25,12 +25,17 @@ import static com.hedera.services.bdd.spec.transactions.TxnVerbs.uploadInitCode;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.runWithProvider;
 import static com.hedera.services.bdd.suites.contract.Utils.FunctionType.FUNCTION;
 import static com.hedera.services.bdd.suites.contract.Utils.getABIFor;
+
 import static java.util.concurrent.TimeUnit.MINUTES;
 
 import com.hedera.services.bdd.spec.HapiSpec;
 import com.hedera.services.bdd.spec.HapiSpecOperation;
 import com.hedera.services.bdd.spec.infrastructure.OpProvider;
 import com.hedera.services.bdd.suites.HapiSuite;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import java.math.BigInteger;
 import java.util.List;
 import java.util.Optional;
@@ -39,8 +44,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 public class PerpetualLocalCalls extends HapiSuite {
     private static final Logger log = LogManager.getLogger(PerpetualLocalCalls.class);
@@ -72,27 +75,37 @@ public class PerpetualLocalCalls extends HapiSuite {
     }
 
     private Function<HapiSpec, OpProvider> localCallsFactory() {
-        return spec -> new OpProvider() {
-            @Override
-            public List<HapiSpecOperation> suggestedInitializers() {
-                return List.of(uploadInitCode(CHILD_STORAGE), contractCreate(CHILD_STORAGE));
-            }
+        return spec ->
+                new OpProvider() {
+                    @Override
+                    public List<HapiSpecOperation> suggestedInitializers() {
+                        return List.of(
+                                uploadInitCode(CHILD_STORAGE), contractCreate(CHILD_STORAGE));
+                    }
 
-            @Override
-            public Optional<HapiSpecOperation> get() {
-                var op = contractCallLocal(CHILD_STORAGE, "getMyValue")
-                        .noLogging()
-                        .has(resultWith()
-                                .resultThruAbi(
-                                        getABIFor(FUNCTION, "getMyValue", CHILD_STORAGE),
-                                        isLiteralResult(new Object[] {BigInteger.valueOf(73)})));
-                var soFar = totalBeforeFailure.getAndIncrement();
-                if (soFar % 1000 == 0) {
-                    log.info("--- " + soFar);
-                }
-                return Optional.of(op);
-            }
-        };
+                    @Override
+                    public Optional<HapiSpecOperation> get() {
+                        var op =
+                                contractCallLocal(CHILD_STORAGE, "getMyValue")
+                                        .noLogging()
+                                        .has(
+                                                resultWith()
+                                                        .resultThruAbi(
+                                                                getABIFor(
+                                                                        FUNCTION,
+                                                                        "getMyValue",
+                                                                        CHILD_STORAGE),
+                                                                isLiteralResult(
+                                                                        new Object[] {
+                                                                            BigInteger.valueOf(73)
+                                                                        })));
+                        var soFar = totalBeforeFailure.getAndIncrement();
+                        if (soFar % 1000 == 0) {
+                            log.info("--- {}", soFar);
+                        }
+                        return Optional.of(op);
+                    }
+                };
     }
 
     @Override

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/Utils.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/Utils.java
@@ -24,9 +24,11 @@ import static com.hedera.services.bdd.spec.utilops.UtilVerbs.withOpContext;
 import static com.hedera.services.bdd.suites.contract.Utils.FunctionType.CONSTRUCTOR;
 import static com.swirlds.common.utility.CommonUtils.hex;
 import static com.swirlds.common.utility.CommonUtils.unhex;
-import static java.lang.System.arraycopy;
+
 import static org.apache.commons.lang3.StringUtils.EMPTY;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import static java.lang.System.arraycopy;
 
 import com.google.common.primitives.Ints;
 import com.google.common.primitives.Longs;
@@ -42,6 +44,18 @@ import com.hederahashgraph.api.proto.java.NftTransfer;
 import com.hederahashgraph.api.proto.java.Timestamp;
 import com.hederahashgraph.api.proto.java.TokenID;
 import com.swirlds.common.utility.CommonUtils;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.bytes.Bytes32;
+import org.bouncycastle.util.encoders.Hex;
+import org.hyperledger.besu.crypto.Hash;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.json.JSONTokener;
+
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -53,16 +67,6 @@ import java.nio.file.Path;
 import java.time.Instant;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.IntStream;
-import org.apache.commons.io.FileUtils;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.apache.tuweni.bytes.Bytes;
-import org.apache.tuweni.bytes.Bytes32;
-import org.bouncycastle.util.encoders.Hex;
-import org.hyperledger.besu.crypto.Hash;
-import org.json.JSONArray;
-import org.json.JSONObject;
-import org.json.JSONTokener;
 
 public class Utils {
     public static final String RESOURCE_PATH = "src/main/resource/contract/contracts/%1$s/%1$s";
@@ -202,7 +206,7 @@ public class Utils {
      */
     public static String getResourcePath(String resourceName, final String extension) {
         resourceName = resourceName.replaceAll("\\d*$", "");
-        final var path = String.format(RESOURCE_PATH + extension, resourceName);
+        final var path = String.join(RESOURCE_PATH, extension, resourceName);
         final var file = relocatedIfNotPresentInWorkingDir(new File(path));
         if (!file.exists()) {
             throw new IllegalArgumentException("Invalid argument: " + path.substring(path.lastIndexOf('/') + 1));

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/NftTransferSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/NftTransferSuite.java
@@ -33,12 +33,14 @@ import com.hedera.services.bdd.spec.HapiSpec;
 import com.hedera.services.bdd.spec.HapiSpecOperation;
 import com.hedera.services.bdd.spec.transactions.token.TokenMovement;
 import com.hedera.services.bdd.suites.HapiSuite;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.function.IntFunction;
 import java.util.stream.IntStream;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 public class NftTransferSuite extends HapiSuite {
     private static final Logger log = LogManager.getLogger(NftTransferSuite.class);
@@ -55,7 +57,7 @@ public class NftTransferSuite extends HapiSuite {
         new NftTransferSuite().runSuiteSync();
         final long endTimeMillis = System.currentTimeMillis();
         final long deltaMillis = endTimeMillis - startTimeMillis;
-        System.out.printf("Total time: %.3f\n", deltaMillis / 1000f);
+        System.out.printf("Total time: %.3f%n", deltaMillis / 1000f);
     }
 
     public static void main(String... args) throws ExecutionException, InterruptedException {

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/file/ProtectedFilesUpdateSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/file/ProtectedFilesUpdateSuite.java
@@ -39,15 +39,17 @@ import com.hedera.services.bdd.suites.utils.sysfiles.AddressBookPojo;
 import com.hederahashgraph.api.proto.java.NodeAddress;
 import com.hederahashgraph.api.proto.java.NodeAddressBook;
 import com.swirlds.common.utility.CommonUtils;
+
+import org.apache.commons.lang3.ArrayUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.junit.jupiter.api.Assertions;
+
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.SplittableRandom;
 import java.util.function.UnaryOperator;
-import org.apache.commons.lang3.ArrayUtils;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.junit.jupiter.api.Assertions;
 
 public class ProtectedFilesUpdateSuite extends HapiSuite {
     private static final String IGNORE = "ignore";
@@ -326,7 +328,7 @@ public class ProtectedFilesUpdateSuite extends HapiSuite {
             var newBook = builder.build();
             var bookJson = mapper.writerWithDefaultPrettyPrinter()
                     .writeValueAsString(AddressBookPojo.addressBookFrom(newBook));
-            log.info("New address book w/ extended bio: " + bookJson);
+            log.info("New address book w/ extended bio: {}", bookJson);
             return builder.build().toByteArray();
         } catch (InvalidProtocolBufferException e) {
             log.error("Basic address book could not be parsed", e);
@@ -355,7 +357,7 @@ public class ProtectedFilesUpdateSuite extends HapiSuite {
             var newBook = builder.build();
             var bookJson = mapper.writerWithDefaultPrettyPrinter()
                     .writeValueAsString(AddressBookPojo.nodeDetailsFrom(newBook));
-            log.info("New node details w/ extended bio: " + bookJson);
+            log.info("New node details w/ extended bio: {}", bookJson);
             return builder.build().toByteArray();
         } catch (InvalidProtocolBufferException e) {
             log.error("Basic node details could not be parsed", e);

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/freeze/FreezeSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/freeze/FreezeSuite.java
@@ -24,12 +24,14 @@ import static com.hedera.services.bdd.suites.utils.ZipUtil.createZip;
 import com.hedera.node.app.hapi.utils.CommonUtils;
 import com.hedera.services.bdd.spec.HapiSpec;
 import com.hedera.services.bdd.suites.HapiSuite;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.util.List;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 public class FreezeSuite extends HapiSuite {
     private static final Logger log = LogManager.getLogger(FreezeSuite.class);
@@ -59,13 +61,13 @@ public class FreezeSuite extends HapiSuite {
     private HapiSpec uploadNewFile() {
         String uploadFile = UPDATE_NEW_FILE;
         if (uploadPath != null) {
-            log.info("Creating zip file from " + uploadPath);
+            log.info("Creating zip file from {}", uploadPath);
             final var zipFile = "Archive.zip";
             createZip(UPLOAD_PATH_PREFIX + uploadPath, zipFile, null);
             uploadFile = zipFile;
         }
 
-        log.info("Uploading file " + uploadFile);
+        log.info("Uploading file {}", uploadFile);
         final File f = new File(uploadFile);
         byte[] bytes = new byte[0];
         try {

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/freeze/UpdateServerFiles.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/freeze/UpdateServerFiles.java
@@ -26,6 +26,12 @@ import com.hedera.node.app.hapi.utils.CommonUtils;
 import com.hedera.services.bdd.spec.HapiSpec;
 import com.hedera.services.bdd.spec.utilops.UtilVerbs;
 import com.hedera.services.bdd.suites.HapiSuite;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.junit.jupiter.api.Assertions;
+
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -33,10 +39,6 @@ import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import org.apache.commons.io.FileUtils;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.junit.jupiter.api.Assertions;
 
 public class UpdateServerFiles extends HapiSuite {
     private static final Logger log = LogManager.getLogger(UpdateServerFiles.class);
@@ -45,7 +47,6 @@ public class UpdateServerFiles extends HapiSuite {
 
     private static String uploadPath = "updateFiles/";
 
-    private static final int FREEZE_LAST_MINUTES = 2;
     private static String fileIDString = "UPDATE_FEATURE"; // mnemonic for file 0.0.150
 
     public static void main(final String... args) {
@@ -79,7 +80,7 @@ public class UpdateServerFiles extends HapiSuite {
     // then send to server to update server
     private HapiSpec uploadGivenDirectory() {
 
-        log.info("Creating zip file from " + uploadPath);
+        log.info("Creating zip file from {}", uploadPath);
         // create directory if uploadPath doesn't exist
         if (!new File(uploadPath).exists()) {
             new File(uploadPath).mkdirs();
@@ -105,7 +106,7 @@ public class UpdateServerFiles extends HapiSuite {
             createZip(temp_dir, zipFile, DEFAULT_SCRIPT);
             final String uploadFile = zipFile;
 
-            log.info("Uploading file " + uploadFile);
+            log.info("Uploading file {}", uploadFile);
             data = Files.readAllBytes(Paths.get(uploadFile));
         } catch (final IOException e) {
             log.error("Directory creation failed", e);

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/freeze/UpgradeSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/freeze/UpgradeSuite.java
@@ -43,6 +43,10 @@ import com.google.protobuf.ByteString;
 import com.hedera.services.bdd.spec.HapiSpec;
 import com.hedera.services.bdd.suites.HapiSuite;
 import com.swirlds.common.utility.CommonUtils;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -50,8 +54,6 @@ import java.nio.file.Paths;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.List;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 public class UpgradeSuite extends HapiSuite {
     private static final Logger log = LogManager.getLogger(UpgradeSuite.class);
@@ -80,8 +82,8 @@ public class UpgradeSuite extends HapiSuite {
             poeticUpgradeHash = sha384.digest(poeticUpgrade);
             heavyPoeticUpgrade = Files.readAllBytes(Paths.get(heavyPoeticUpgradeLoc));
             heavyPoeticUpgradeHash = sha384.digest(heavyPoeticUpgrade);
-            log.info("Poetic upgrade hash: " + CommonUtils.hex(poeticUpgradeHash));
-            log.info("Heavy poetic upgrade hash: " + CommonUtils.hex(heavyPoeticUpgradeHash));
+            log.info("Poetic upgrade hash: {}", CommonUtils.hex(poeticUpgradeHash));
+            log.info("Heavy poetic upgrade hash: {}", CommonUtils.hex(heavyPoeticUpgradeHash));
         } catch (NoSuchAlgorithmException | IOException e) {
             throw new IllegalStateException("UpgradeSuite environment is unsuitable", e);
         }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/issues/Issue1648Suite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/issues/Issue1648Suite.java
@@ -24,10 +24,12 @@ import static com.hedera.services.bdd.spec.transactions.crypto.HapiCryptoTransfe
 import com.hedera.services.bdd.spec.HapiSpec;
 import com.hedera.services.bdd.spec.utilops.UtilVerbs;
 import com.hedera.services.bdd.suites.HapiSuite;
-import java.util.List;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.Assertions;
+
+import java.util.List;
 
 public class Issue1648Suite extends HapiSuite {
     private static final Logger log = LogManager.getLogger(Issue1648Suite.class);
@@ -45,19 +47,32 @@ public class Issue1648Suite extends HapiSuite {
         return defaultHapiSpec("RecordStorageFeeIncreasesWithNumTransfers")
                 .given(
                         UtilVerbs.inParallel(
-                                cryptoCreate("A"), cryptoCreate("B"), cryptoCreate("C"), cryptoCreate("D")),
+                                cryptoCreate("A"),
+                                cryptoCreate("B"),
+                                cryptoCreate("C"),
+                                cryptoCreate("D")),
                         UtilVerbs.inParallel(
                                 cryptoTransfer(tinyBarsFromTo("A", "B", 1L)).via("txn1"),
-                                cryptoTransfer(tinyBarsFromTo("A", "B", 1L), tinyBarsFromTo("C", "D", 1L))
+                                cryptoTransfer(
+                                                tinyBarsFromTo("A", "B", 1L),
+                                                tinyBarsFromTo("C", "D", 1L))
                                         .via("txn2")))
-                .when(UtilVerbs.recordFeeAmount("txn1", "feeForOne"), UtilVerbs.recordFeeAmount("txn2", "feeForTwo"))
-                .then(UtilVerbs.assertionsHold((spec, assertLog) -> {
-                    long feeForOne = spec.registry().getAmount("feeForOne");
-                    long feeForTwo = spec.registry().getAmount("feeForTwo");
-                    assertLog.info("[Record storage] fee for one transfer : " + feeForOne);
-                    assertLog.info("[Record storage] fee for two transfers: " + feeForTwo);
-                    Assertions.assertEquals(-1, Long.compare(feeForOne, feeForTwo));
-                }));
+                .when(
+                        UtilVerbs.recordFeeAmount("txn1", "feeForOne"),
+                        UtilVerbs.recordFeeAmount("txn2", "feeForTwo"))
+                .then(
+                        UtilVerbs.assertionsHold(
+                                (spec, assertLog) -> {
+                                    long feeForOne = spec.registry().getAmount("feeForOne");
+                                    long feeForTwo = spec.registry().getAmount("feeForTwo");
+                                    assertLog.info(
+                                            "[Record storage] fee for one transfer : {}",
+                                            feeForOne);
+                                    assertLog.info(
+                                            "[Record storage] fee for two transfers: {}",
+                                            feeForTwo);
+                                    Assertions.assertEquals(-1, Long.compare(feeForOne, feeForTwo));
+                                }));
     }
 
     @Override

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/issues/Issue305Spec.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/issues/Issue305Spec.java
@@ -24,20 +24,24 @@ import static com.hedera.services.bdd.spec.transactions.TxnVerbs.fileDelete;
 import static com.hedera.services.bdd.spec.utilops.CustomSpecAssert.allRunFor;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.newKeyNamed;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.withOpContext;
+
 import static java.util.stream.Collectors.toList;
 
 import com.hedera.services.bdd.spec.HapiPropertySource;
 import com.hedera.services.bdd.spec.HapiSpec;
 import com.hedera.services.bdd.spec.keys.KeyFactory;
 import com.hedera.services.bdd.suites.HapiSuite;
-import java.util.List;
-import java.util.concurrent.atomic.AtomicReference;
-import java.util.stream.IntStream;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.IntStream;
+
 public class Issue305Spec extends HapiSuite {
     private static final Logger log = LogManager.getLogger(Issue305Spec.class);
+    private static final String KEY = "tbdKey";
 
     public static void main(String... args) {
         new Issue305Spec().runSuiteSync();
@@ -54,21 +58,25 @@ public class Issue305Spec extends HapiSuite {
         AtomicReference<String> nextFileId = new AtomicReference<>();
         return defaultHapiSpec("CreateDeleteInSameRoundWorks")
                 .given(
-                        newKeyNamed("tbdKey").type(KeyFactory.KeyType.LIST),
+                        newKeyNamed(KEY).type(KeyFactory.KeyType.LIST),
                         fileCreate("marker").via("markerTxn"))
-                .when(withOpContext((spec, opLog) -> {
-                    var lookup = getTxnRecord("markerTxn");
-                    allRunFor(spec, lookup);
-                    var markerFid = lookup.getResponseRecord().getReceipt().getFileID();
-                    var nextFid = markerFid.toBuilder()
-                            .setFileNum(markerFid.getFileNum() + 1)
-                            .build();
-                    nextFileId.set(HapiPropertySource.asFileString(nextFid));
-                    opLog.info("Next file will be " + nextFileId.get());
-                }))
+                .when(
+                        withOpContext(
+                                (spec, opLog) -> {
+                                    var lookup = getTxnRecord("markerTxn");
+                                    allRunFor(spec, lookup);
+                                    var markerFid =
+                                            lookup.getResponseRecord().getReceipt().getFileID();
+                                    var nextFid =
+                                            markerFid.toBuilder()
+                                                    .setFileNum(markerFid.getFileNum() + 1)
+                                                    .build();
+                                    nextFileId.set(HapiPropertySource.asFileString(nextFid));
+                                    opLog.info("Next file will be {}", nextFileId.get());
+                                }))
                 .then(
-                        fileCreate("tbd").key("tbdKey").deferStatusResolution(),
-                        fileDelete(nextFileId::get).signedBy(GENESIS, "tbdKey").logged(),
+                        fileCreate("tbd").key(KEY).deferStatusResolution(),
+                        fileDelete(nextFileId::get).signedBy(GENESIS, KEY).logged(),
                         getFileInfo(nextFileId::get).logged());
     }
 

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/misc/WalletTestSetup.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/misc/WalletTestSetup.java
@@ -30,10 +30,12 @@ import com.hedera.services.bdd.spec.queries.QueryVerbs;
 import com.hedera.services.bdd.spec.transactions.crypto.HapiCryptoTransfer;
 import com.hedera.services.bdd.suites.HapiSuite;
 import com.swirlds.common.utility.CommonUtils;
-import java.util.List;
-import java.util.Map;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+
+import java.util.List;
+import java.util.Map;
 
 public class WalletTestSetup extends HapiSuite {
     private static final Logger log = LogManager.getLogger(WalletTestSetup.class);
@@ -66,10 +68,12 @@ public class WalletTestSetup extends HapiSuite {
         return defaultHapiSpec("MnemonicToPem")
                 .given(keyFromMnemonic("fm", mnemonic))
                 .when()
-                .then(withOpContext((spec, opLog) -> {
-                    KeyFactory.PEM_PASSPHRASE = "guessAgain";
-                    spec.keys().exportSimpleKey(String.format("pretend-genesis.pem"), "fm");
-                }));
+                .then(
+                        withOpContext(
+                                (spec, opLog) -> {
+                                    KeyFactory.PEM_PASSPHRASE = "guessAgain";
+                                    spec.keys().exportSimpleKey("pretend-genesis.pem", "fm");
+                                }));
     }
 
     private HapiSpec createDeterministicWalletForRecovery() {

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/contract/ContractPerformanceSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/contract/ContractPerformanceSuite.java
@@ -37,6 +37,10 @@ import com.hedera.services.bdd.spec.transactions.file.HapiFileCreate;
 import com.hedera.services.bdd.suites.HapiSuite;
 import com.hederahashgraph.api.proto.java.ContractID;
 import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.Charset;
@@ -45,8 +49,6 @@ import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 public class ContractPerformanceSuite extends HapiSuite {
     private static final Logger LOG = LogManager.getLogger(ContractPerformanceSuite.class);
@@ -80,7 +82,10 @@ public class ContractPerformanceSuite extends HapiSuite {
                     .replace(REVERT_CONTRACT_ADDRESS, asSolidityAddress(revertAccountAddress));
             return fileCreate(test + BYTECODE).contents(contentString.getBytes(StandardCharsets.US_ASCII));
         } catch (Exception e) {
-            LOG.warn("createTestProgram for " + test + " failed to read bytes from '" + path + "'!", e);
+            String message =
+                    String.format(
+                            "createTestProgram for %s failed to read bytes from '%s'!", test, path);
+            LOG.warn(message, e);
             return fileCreate(test);
         }
     }
@@ -108,7 +113,11 @@ public class ContractPerformanceSuite extends HapiSuite {
             try {
                 contractCode = new String(Files.toByteArray(new File(path)), StandardCharsets.US_ASCII);
             } catch (IOException e) {
-                LOG.warn("createTestProgram for " + test + " failed to read bytes from '" + path + "'!", e);
+                String message =
+                        String.format(
+                                "createTestProgram for %s failed to read bytes from '%s'!",
+                                test, path);
+                LOG.warn(message, e);
                 contractCode = "FE";
             }
             HapiSpecOperation[] givenBlock;

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/contract/opcodes/SStoreOperationLoadTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/contract/opcodes/SStoreOperationLoadTest.java
@@ -34,11 +34,13 @@ import com.hedera.services.bdd.spec.HapiSpec;
 import com.hedera.services.bdd.spec.HapiSpecOperation;
 import com.hedera.services.bdd.spec.utilops.LoadTest;
 import com.hedera.services.bdd.suites.perf.PerfTestLoadSettings;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 public class SStoreOperationLoadTest extends LoadTest {
     private static final Logger log = LogManager.getLogger(SStoreOperationLoadTest.class);
@@ -50,7 +52,7 @@ public class SStoreOperationLoadTest extends LoadTest {
         // parsing local argument specific to this test
         if (args.length > usedArgs) {
             size = Integer.parseInt(args[usedArgs]);
-            log.info("Set sizeInKb as " + size);
+            log.info("Set sizeInKb as {}", size);
         }
 
         SStoreOperationLoadTest suite = new SStoreOperationLoadTest();

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/topic/SubmitMessageLoadTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/perf/topic/SubmitMessageLoadTest.java
@@ -45,6 +45,11 @@ import com.hedera.services.bdd.spec.HapiSpecOperation;
 import com.hedera.services.bdd.spec.keys.KeyFactory;
 import com.hedera.services.bdd.spec.utilops.LoadTest;
 import com.hedera.services.bdd.suites.perf.PerfTestLoadSettings;
+
+import org.apache.commons.lang3.ArrayUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import java.nio.ByteBuffer;
 import java.time.Instant;
 import java.util.List;
@@ -52,9 +57,6 @@ import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
-import org.apache.commons.lang3.ArrayUtils;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 public class SubmitMessageLoadTest extends LoadTest {
 
@@ -87,19 +89,19 @@ public class SubmitMessageLoadTest extends LoadTest {
         // parsing local argument specific to this test
         if (args.length > (usedArgs)) {
             messageSize = Integer.parseInt(args[usedArgs]);
-            log.info("Set messageSize as " + messageSize);
+            log.info("Set messageSize as {}", messageSize);
             usedArgs++;
         }
 
         if (args.length > (usedArgs)) {
             pemFile = args[usedArgs];
-            log.info("Set pemFile as " + pemFile);
+            log.info("Set pemFile as {}", pemFile);
             usedArgs++;
         }
 
         if (args.length > usedArgs) {
             topicID = args[usedArgs];
-            log.info("Set topicID as " + topicID);
+            log.info("Set topicID as {}", topicID);
             usedArgs++;
         }
 

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/regression/JrsRestartTestTemplate.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/regression/JrsRestartTestTemplate.java
@@ -47,12 +47,14 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.ACCOUNT_KYC_NO
 import com.hedera.services.bdd.spec.HapiSpec;
 import com.hedera.services.bdd.spec.HapiSpecOperation;
 import com.hedera.services.bdd.suites.HapiSuite;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import java.math.BigInteger;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 /**
  * This restart test uses the named entities under
@@ -114,16 +116,30 @@ public class JrsRestartTestTemplate extends HapiSuite {
                 .withProperties(Map.of("persistentEntities.dir.path", ENTITIES_DIR))
                 .given(expectedEntitiesExist())
                 .when()
-                .then(withOpContext((spec, opLog) -> {
-                    boolean isPostRestart = spec.setup().ciPropertiesMap().getBoolean("postRestart");
-                    if (isPostRestart) {
-                        opLog.info("\n\n" + bannerWith("POST-RESTART VALIDATION PHASE"));
-                        allRunFor(spec, postRestartValidation());
-                    } else {
-                        opLog.info("\n\n" + bannerWith("PRE-RESTART SETUP PHASE"));
-                        allRunFor(spec, preRestartSetup());
-                    }
-                }));
+                .then(
+                        withOpContext(
+                                (spec, opLog) -> {
+                                    boolean isPostRestart =
+                                            spec.setup()
+                                                    .ciPropertiesMap()
+                                                    .getBoolean("postRestart");
+                                    if (isPostRestart) {
+                                        String message =
+                                                String.format(
+                                                        "%n%n%s",
+                                                        bannerWith(
+                                                                "POST-RESTART VALIDATION PHASE"));
+                                        opLog.info(message);
+                                        allRunFor(spec, postRestartValidation());
+                                    } else {
+                                        String message =
+                                                String.format(
+                                                        "%n%n%s",
+                                                        bannerWith("PRE-RESTART SETUP PHASE"));
+                                        opLog.info(message);
+                                        allRunFor(spec, preRestartSetup());
+                                    }
+                                }));
     }
 
     private HapiSpecOperation[] preRestartSetup() {

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/utils/ZipUtil.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/utils/ZipUtil.java
@@ -16,6 +16,9 @@
 
 package com.hedera.services.bdd.suites.utils;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
@@ -25,8 +28,6 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 public class ZipUtil {
     private static final Logger log = LogManager.getLogger(ZipUtil.class);
@@ -75,7 +76,7 @@ public class ZipUtil {
                     pathDiff = pathDiff.substring(1);
                 }
                 String dirName = pathDiff + File.separator;
-                log.info("Adding dir " + dirName);
+                log.info("Adding dir {}", dirName);
                 zos.putNextEntry(new ZipEntry(dirName));
             } catch (IOException e) {
                 log.error(e);
@@ -96,7 +97,7 @@ public class ZipUtil {
 
                 try (FileInputStream fis = new FileInputStream(file)) {
                     String name = file.getAbsolutePath().replace(rootDirectory.getAbsolutePath(), "");
-                    log.info("Adding file:" + name);
+                    log.info("Adding file:{}", name);
                     zos.putNextEntry(new ZipEntry(name));
                     int length;
                     while ((length = fis.read(buffer)) > 0) {
@@ -108,7 +109,7 @@ public class ZipUtil {
                 }
             } // for
         } else {
-            log.info("Directory " + currentDirectory + " is empty");
+            log.info("Directory {} is empty", currentDirectory);
         }
     }
 }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/yahcli/commands/accounts/BalanceCommand.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/yahcli/commands/accounts/BalanceCommand.java
@@ -19,11 +19,13 @@ package com.hedera.services.yahcli.commands.accounts;
 import static com.hedera.services.yahcli.config.ConfigUtils.configFrom;
 
 import com.hedera.services.yahcli.suites.BalanceSuite;
-import java.util.concurrent.Callable;
+
 import picocli.CommandLine.Command;
 import picocli.CommandLine.HelpCommand;
 import picocli.CommandLine.Parameters;
 import picocli.CommandLine.ParentCommand;
+
+import java.util.concurrent.Callable;
 
 @Command(
         name = "balance",
@@ -43,7 +45,7 @@ public class BalanceCommand implements Callable<Integer> {
         StringBuilder balanceRegister = new StringBuilder();
         String serviceBorder = "---------------------|----------------------|";
         balanceRegister.append(serviceBorder).append("\n");
-        balanceRegister.append(String.format("%20s | %20s |\n", "Account Id", "Balance"));
+        balanceRegister.append(String.format("%20s | %20s |%n", "Account Id", "Balance"));
         balanceRegister.append(serviceBorder);
 
         printTable(balanceRegister);

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/yahcli/commands/fees/FeeBasePriceCommand.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/yahcli/commands/fees/FeeBasePriceCommand.java
@@ -19,8 +19,10 @@ package com.hedera.services.yahcli.commands.fees;
 import static com.hedera.services.yahcli.config.ConfigUtils.configFrom;
 
 import com.hedera.services.yahcli.suites.CostOfEveryThingSuite;
-import java.util.concurrent.Callable;
+
 import picocli.CommandLine;
+
+import java.util.concurrent.Callable;
 
 @CommandLine.Command(
         name = "list-base-prices",
@@ -44,7 +46,7 @@ public class FeeBasePriceCommand implements Callable<Integer> {
         StringBuilder feeTableSB = new StringBuilder();
         String serviceBorder = "-------------------------------|-----------------|\n";
         feeTableSB.append(serviceBorder);
-        feeTableSB.append(String.format("%30s |  \t\t |\n", "Transaction and Query Fees"));
+        feeTableSB.append(String.format("%30s |  \t\t |%n", "Transaction and Query Fees"));
         feeTableSB.append(serviceBorder);
 
         var delegate = new CostOfEveryThingSuite(config.asSpecConfig(), feeTableSB, serviceBorder, services);

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/yahcli/suites/CostOfEveryThingSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/yahcli/suites/CostOfEveryThingSuite.java
@@ -69,11 +69,16 @@ import static com.hedera.services.bdd.spec.utilops.UtilVerbs.newKeyListNamed;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.newKeyNamed;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.withOpContext;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SUCCESS;
+
 import static java.util.Optional.ofNullable;
 import static java.util.stream.Collectors.toList;
 
 import com.hedera.services.bdd.spec.HapiSpec;
 import com.hedera.services.bdd.suites.HapiSuite;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.EnumSet;
@@ -81,8 +86,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Stream;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 public class CostOfEveryThingSuite extends HapiSuite {
     private static final Logger log = LogManager.getLogger(CostOfEveryThingSuite.class);
@@ -136,7 +139,7 @@ public class CostOfEveryThingSuite extends HapiSuite {
     }
 
     HapiSpec canonicalContractOps() {
-        return HapiSpec.customHapiSpec(String.format("canonicalContractOps"))
+        return HapiSpec.customHapiSpec("canonicalContractOps")
                 .withProperties(specConfig, Map.of(COST_SNAPSHOT_MODE, costSnapshotMode.toString()))
                 .given(
                         newKeyNamed("key").shape(SIMPLE),
@@ -174,17 +177,30 @@ public class CostOfEveryThingSuite extends HapiSuite {
                                 .nodePayment(100_000_000)
                                 .gas(50000)
                                 .via("canonicalContractCallLocal"),
-                        getContractBytecode(contract).payingWith(PAYER).via("canonicalGetContractByteCode"),
-                        contractDelete(contract).blankMemo().payingWith(PAYER).via("canonicalContractDelete"))
+                        getContractBytecode(contract)
+                                .payingWith(PAYER)
+                                .via("canonicalGetContractByteCode"),
+                        contractDelete(contract)
+                                .blankMemo()
+                                .payingWith(PAYER)
+                                .via("canonicalContractDelete"))
                 .then(
                         withOpContext((spec, log) -> appendServiceName("Smart Contract Service")),
-                        getTransactionFee("canonicalContractCreate", feeTableBuilder, "contractCreate"),
-                        getTransactionFee("canonicalContractUpdate", feeTableBuilder, "contractUpdate"),
+                        getTransactionFee(
+                                "canonicalContractCreate", feeTableBuilder, "contractCreate"),
+                        getTransactionFee(
+                                "canonicalContractUpdate", feeTableBuilder, "contractUpdate"),
                         getTransactionFee("canonicalContractCall", feeTableBuilder, "contractCall"),
-                        getTransactionFee("canonicalGetContractInfo", feeTableBuilder, "getContractInfo"),
-                        getTransactionFee("canonicalContractCallLocal", feeTableBuilder, "contractCallLocal"),
-                        getTransactionFee("canonicalGetContractByteCode", feeTableBuilder, "getContractByteCode"),
-                        getTransactionFee("canonicalContractDelete", feeTableBuilder, "contractDelete"));
+                        getTransactionFee(
+                                "canonicalGetContractInfo", feeTableBuilder, "getContractInfo"),
+                        getTransactionFee(
+                                "canonicalContractCallLocal", feeTableBuilder, "contractCallLocal"),
+                        getTransactionFee(
+                                "canonicalGetContractByteCode",
+                                feeTableBuilder,
+                                "getContractByteCode"),
+                        getTransactionFee(
+                                "canonicalContractDelete", feeTableBuilder, "contractDelete"));
     }
 
     HapiSpec canonicalFileOps() {
@@ -192,7 +208,7 @@ public class CostOfEveryThingSuite extends HapiSuite {
         final byte[] first = randomUtf8Bytes(fileSize);
         final byte[] next = randomUtf8Bytes(fileSize);
 
-        return HapiSpec.customHapiSpec(String.format("canonicalFileOps"))
+        return HapiSpec.customHapiSpec("canonicalFileOps")
                 .withProperties(specConfig, Map.of(COST_SNAPSHOT_MODE, costSnapshotMode.toString()))
                 .given(
                         newKeyNamed("key").shape(SIMPLE),
@@ -203,7 +219,10 @@ public class CostOfEveryThingSuite extends HapiSuite {
                                 .entityMemo("")
                                 .payingWith(PAYER)
                                 .key("WACL")
-                                .expiry(Instant.now().getEpochSecond() + THREE_MONTHS_IN_SECONDS - 1)
+                                .expiry(
+                                        Instant.now().getEpochSecond()
+                                                + THREE_MONTHS_IN_SECONDS
+                                                - 1)
                                 .contents(first)
                                 .via("canonicalFileCreate"))
                 .when(
@@ -221,19 +240,23 @@ public class CostOfEveryThingSuite extends HapiSuite {
                                 .via("canonicalFileUpdate"),
                         getFileContents(MEMORABLE).via("canonicalGetFileContents"),
                         getFileInfo(MEMORABLE).via("canonicalGetFileInfo"),
-                        fileDelete(MEMORABLE).blankMemo().payingWith(PAYER).via("canonicalFileDelete"))
+                        fileDelete(MEMORABLE)
+                                .blankMemo()
+                                .payingWith(PAYER)
+                                .via("canonicalFileDelete"))
                 .then(
                         withOpContext((spec, log) -> appendServiceName("File Service")),
                         getTransactionFee("canonicalFileCreate", feeTableBuilder, "fileCreate"),
                         getTransactionFee("canonicalFileAppend", feeTableBuilder, "fileAppend"),
                         getTransactionFee("canonicalFileUpdate", feeTableBuilder, "fileUpdate"),
-                        getTransactionFee("canonicalGetFileContents", feeTableBuilder, "getFileContents"),
+                        getTransactionFee(
+                                "canonicalGetFileContents", feeTableBuilder, "getFileContents"),
                         getTransactionFee("canonicalGetFileInfo", feeTableBuilder, "getFileInfo"),
                         getTransactionFee("canonicalFileDelete", feeTableBuilder, "fileDelete"));
     }
 
     HapiSpec canonicalTopicOps() {
-        return HapiSpec.customHapiSpec(String.format("canonicalTopicOps"))
+        return HapiSpec.customHapiSpec("canonicalTopicOps")
                 .withProperties(specConfig, Map.of(COST_SNAPSHOT_MODE, costSnapshotMode.toString()))
                 .given(
                         newKeyNamed("key").shape(SIMPLE),
@@ -261,15 +284,22 @@ public class CostOfEveryThingSuite extends HapiSuite {
                         deleteTopic(TEST_TOPIC).payingWith(PAYER).via("canonicalTopicDelete"))
                 .then(
                         withOpContext((spec, log) -> appendServiceName("Consensus Service")),
-                        getTransactionFee("canonicalTopicCreate", feeTableBuilder, "consensusCreateTopic"),
-                        getTransactionFee("canonicalTopicUpdate", feeTableBuilder, "consensusUpdateTopic"),
-                        getTransactionFee("canonicalSubmitMessage", feeTableBuilder, "consensusSubmitMessage"),
-                        getTransactionFee("canonicalGetTopicInfo", feeTableBuilder, "consensusGetInfo"),
-                        getTransactionFee("canonicalTopicDelete", feeTableBuilder, "consensusDeleteTopic"));
+                        getTransactionFee(
+                                "canonicalTopicCreate", feeTableBuilder, "consensusCreateTopic"),
+                        getTransactionFee(
+                                "canonicalTopicUpdate", feeTableBuilder, "consensusUpdateTopic"),
+                        getTransactionFee(
+                                "canonicalSubmitMessage",
+                                feeTableBuilder,
+                                "consensusSubmitMessage"),
+                        getTransactionFee(
+                                "canonicalGetTopicInfo", feeTableBuilder, "consensusGetInfo"),
+                        getTransactionFee(
+                                "canonicalTopicDelete", feeTableBuilder, "consensusDeleteTopic"));
     }
 
     HapiSpec canonicalTokenOps() {
-        return HapiSpec.customHapiSpec(String.format("canonicalTokenOps"))
+        return HapiSpec.customHapiSpec("canonicalTokenOps")
                 .withProperties(specConfig, Map.of(COST_SNAPSHOT_MODE, costSnapshotMode.toString()))
                 .given(
                         newKeyNamed("key").shape(SIMPLE),
@@ -340,7 +370,9 @@ public class CostOfEveryThingSuite extends HapiSuite {
                                 .blankMemo()
                                 .payingWith(TOKEN_TREASURY)
                                 .via("canonicalTokenUnFreeze"),
-                        cryptoTransfer(moving(1, TEST_TOKEN).between(TOKEN_TREASURY, TEST_ACCOUNT_A))
+                        cryptoTransfer(
+                                        moving(1, TEST_TOKEN)
+                                                .between(TOKEN_TREASURY, TEST_ACCOUNT_A))
                                 .blankMemo()
                                 .payingWith(TOKEN_TREASURY)
                                 .via("canonicalTokenTransfer"),
@@ -352,7 +384,9 @@ public class CostOfEveryThingSuite extends HapiSuite {
                                 .blankMemo()
                                 .payingWith(TOKEN_TREASURY)
                                 .via("canonicalTokenDissociation"),
-                        getTokenInfo(TEST_TOKEN).payingWith(TOKEN_TREASURY).via("canonicalTokenGetInfo"),
+                        getTokenInfo(TEST_TOKEN)
+                                .payingWith(TOKEN_TREASURY)
+                                .via("canonicalTokenGetInfo"),
                         tokenDelete(TEST_TOKEN)
                                 .blankMemo()
                                 .payingWith(TOKEN_TREASURY)
@@ -361,23 +395,30 @@ public class CostOfEveryThingSuite extends HapiSuite {
                         withOpContext((spec, log) -> appendServiceName("Token Service")),
                         getTransactionFee("canonicalTokenCreate", feeTableBuilder, "tokenCreate"),
                         getTransactionFee("canonicalTokenUpdate", feeTableBuilder, "tokenUpdate"),
-                        getTransactionFee("cannonicalMintToken", feeTableBuilder, "tokenMintSingle"),
+                        getTransactionFee(
+                                "cannonicalMintToken", feeTableBuilder, "tokenMintSingle"),
                         getTransactionFee("canonicalBurnToken", feeTableBuilder, "tokenBurnSingle"),
-                        getTransactionFee("canonicalTokenAssociation", feeTableBuilder, "tokenAssociate"),
-                        getTransactionFee("canonicalTokenGrantKyc", feeTableBuilder, "tokenGrantKyc"),
-                        getTransactionFee("canonicalTokenRevokeKyc", feeTableBuilder, "tokenRevokeKyc"),
+                        getTransactionFee(
+                                "canonicalTokenAssociation", feeTableBuilder, "tokenAssociate"),
+                        getTransactionFee(
+                                "canonicalTokenGrantKyc", feeTableBuilder, "tokenGrantKyc"),
+                        getTransactionFee(
+                                "canonicalTokenRevokeKyc", feeTableBuilder, "tokenRevokeKyc"),
                         getTransactionFee("canonicalTokenFreeze", feeTableBuilder, "tokenFreeze"),
-                        getTransactionFee("canonicalTokenUnFreeze", feeTableBuilder, "tokenUnFreeze"),
-                        getTransactionFee("canonicalTokenTransfer", feeTableBuilder, "tokenTransfer"),
+                        getTransactionFee(
+                                "canonicalTokenUnFreeze", feeTableBuilder, "tokenUnFreeze"),
+                        getTransactionFee(
+                                "canonicalTokenTransfer", feeTableBuilder, "tokenTransfer"),
                         getTransactionFee("canonicalTokenWipe", feeTableBuilder, "tokenWipe"),
-                        getTransactionFee("canonicalTokenDissociation", feeTableBuilder, "tokenDissociate"),
+                        getTransactionFee(
+                                "canonicalTokenDissociation", feeTableBuilder, "tokenDissociate"),
                         getTransactionFee("canonicalTokenGetInfo", feeTableBuilder, "getTokenInfo"),
                         getTransactionFee("canonicalTokenDelete", feeTableBuilder, "tokenDelete"));
     }
 
     HapiSpec canonicalCryptoOps() {
 
-        return HapiSpec.customHapiSpec(String.format("canonicalCryptoOps"))
+        return HapiSpec.customHapiSpec("canonicalCryptoOps")
                 .withProperties(specConfig, Map.of(COST_SNAPSHOT_MODE, costSnapshotMode.toString()))
                 .given(
                         newKeyNamed("key").shape(SIMPLE),
@@ -414,16 +455,21 @@ public class CostOfEveryThingSuite extends HapiSuite {
                                 .via("canonicalCryptoDeletion"))
                 .then(
                         withOpContext((spec, log) -> appendServiceName("Cryptocurrency Service")),
-                        getTransactionFee("canonicalCryptoCreation", feeTableBuilder, "cryptoCreate"),
+                        getTransactionFee(
+                                "canonicalCryptoCreation", feeTableBuilder, "cryptoCreate"),
                         getTransactionFee("canonicalCryptoUpdate", feeTableBuilder, "cryptoUpdate"),
-                        getTransactionFee("canonicalCryptoTransfer", feeTableBuilder, "cryptoTransfer"),
-                        getTransactionFee("canonicalGetRecords", feeTableBuilder, "cryptoGetAccountRecords"),
-                        getTransactionFee("canonicalGetAccountInfo", feeTableBuilder, "cryptoGetAccountInfo"),
-                        getTransactionFee("canonicalCryptoDeletion", feeTableBuilder, "cryptoDelete"));
+                        getTransactionFee(
+                                "canonicalCryptoTransfer", feeTableBuilder, "cryptoTransfer"),
+                        getTransactionFee(
+                                "canonicalGetRecords", feeTableBuilder, "cryptoGetAccountRecords"),
+                        getTransactionFee(
+                                "canonicalGetAccountInfo", feeTableBuilder, "cryptoGetAccountInfo"),
+                        getTransactionFee(
+                                "canonicalCryptoDeletion", feeTableBuilder, "cryptoDelete"));
     }
 
     HapiSpec canonicalScheduleOps() {
-        return HapiSpec.customHapiSpec(String.format("canonicalScheduleOps"))
+        return HapiSpec.customHapiSpec("canonicalScheduleOps")
                 .withProperties(specConfig, Map.of(COST_SNAPSHOT_MODE, costSnapshotMode.toString()))
                 .given(
                         cryptoCreate(PAYING_SENDER).balance(ONE_HUNDRED_HBARS),
@@ -450,17 +496,23 @@ public class CostOfEveryThingSuite extends HapiSuite {
                                                 .signedBy(PAYING_SENDER))
                                 .payingWith(PAYING_SENDER)
                                 .adminKey(PAYING_SENDER),
-                        scheduleDelete("tbd").via("canonicalScheduleDeletion").payingWith(PAYING_SENDER))
+                        scheduleDelete("tbd")
+                                .via("canonicalScheduleDeletion")
+                                .payingWith(PAYING_SENDER))
                 .then(
-                        withOpContext((spec, log) -> appendServiceName("Schedule Transaction Service")),
-                        getTransactionFee("canonicalScheduleCreation", feeTableBuilder, "scheduleCreate"),
-                        getTransactionFee("canonicalScheduleSigning", feeTableBuilder, "scheduleSign"),
-                        getTransactionFee("canonicalScheduleDeletion", feeTableBuilder, "scheduleDelete"));
+                        withOpContext(
+                                (spec, log) -> appendServiceName("Schedule Transaction Service")),
+                        getTransactionFee(
+                                "canonicalScheduleCreation", feeTableBuilder, "scheduleCreate"),
+                        getTransactionFee(
+                                "canonicalScheduleSigning", feeTableBuilder, "scheduleSign"),
+                        getTransactionFee(
+                                "canonicalScheduleDeletion", feeTableBuilder, "scheduleDelete"));
     }
 
     private void appendServiceName(final String serviceName) {
         feeTableBuilder.append(serviceBorder);
-        feeTableBuilder.append(String.format("%30s | Fees \t\t |\n", serviceName));
+        feeTableBuilder.append(String.format("%30s | Fees \t\t |%n", serviceName));
         feeTableBuilder.append(serviceBorder);
     }
 }


### PR DESCRIPTION
Because printf-style format strings are interpreted at runtime, rather than validated by the compiler, they can contain errors that result in the wrong strings being created. This rule statically validates the correlation of printf-style format strings to their arguments when calling the format(...) methods of java.util.Formatter, java.lang.String, java.io.PrintStream, MessageFormat, and java.io.PrintWriter classes and the printf(...) methods of java.io.PrintStream or java.io.PrintWriter classes.

**Related issue(s)**:

Fixes #5691
