### PR TITLE
5717: Improve VirtualNodeCache.merge

### DIFF
--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/cache/ConcurrentArray.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/cache/ConcurrentArray.java
@@ -21,10 +21,10 @@ import java.util.Arrays;
 import java.util.Comparator;
 import java.util.NoSuchElementException;
 import java.util.Objects;
-import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
 
@@ -45,9 +45,8 @@ import java.util.stream.Stream;
  * this class does not double the size of the storage, it simply increments by {@code capacity}.
  * <p>
  * Typically, an instance is created and then {@link #add(Object)} is called repeatedly. When the
- * {@link VirtualNodeCache} wishes to merge two arrays together, it will create a new {@link ConcurrentArray}
- * by supplying the two previous arrays to it via {@link #ConcurrentArray(ConcurrentArray, ConcurrentArray)}.
- * The source arrays for this operation <strong>must</strong> be immutable. An array is made immutable
+ * {@link VirtualNodeCache} wishes to merge two arrays together, it will call {@link #merge(ConcurrentArray)}.
+ * Both arrays for this operation <strong>must</strong> be immutable. An array is made immutable
  * by calling {@link #seal()}.
  * <p>
  * After all elements have been added, the {@link #sortedStream(Comparator)} method can be called to get
@@ -83,7 +82,8 @@ final class ConcurrentArray<T> {
      * To make this safe, it is imperative that <strong>only</strong> an immutable {@link ConcurrentArray} is the
      * source of a copy, so that the destination array can safely refer to the sub-arrays of the source.
      */
-    private final ConcurrentLinkedDeque<SubArray<T>> arrays = new ConcurrentLinkedDeque<>();
+    private volatile SubArray<T> head;
+    private final AtomicReference<SubArray<T>> current;
 
     /**
      * A thread-safe field holding the number of elements (that is, the number of actual elements in all sub-arrays).
@@ -136,47 +136,36 @@ final class ConcurrentArray<T> {
         // Add the first array, so we are primed and ready to go. This also saves on a check later for an empty
         // concurrent linked dequeue (we always know there is at least one sub-array).
         this.subarrayCapacity = capacity;
-        arrays.add(new SubArray<>(capacity));
+        current = new AtomicReference<>();
+        current.set(new SubArray<>(capacity));
     }
 
-    /**
-     * Create a new {@link ConcurrentArray} with the contents of two other {@link ConcurrentArray}s.
-     * <strong>IMPORTANT!</strong> this does <strong>NOT</strong> copy the array data out of the source
-     * {@link ConcurrentArray}s. It directly reuses the data. Both of the source arrays must be immutable.
-     * This array will be <strong>sealed</strong>. It cannot be mutated after merging.
-     *
-     * @param arrayOne
-     * 		The first array to take data from. Cannot be null. Must be immutable.
-     * @param arrayTwo
-     * 		The second array to take data from. Cannot be null. Must be immutable.
-     * @throws NullPointerException
-     * 		if either array is null
-     * @throws IllegalArgumentException
-     * 		if either array is mutable, or if they are the same instance.
-     */
-    ConcurrentArray(ConcurrentArray<T> arrayOne, ConcurrentArray<T> arrayTwo) {
-        Objects.requireNonNull(arrayOne);
-        Objects.requireNonNull(arrayTwo);
+    ConcurrentArray(final ConcurrentArray<T> other) {
+        this.subarrayCapacity = other.subarrayCapacity;
+        this.current = other.current;
+        this.head = null;
+    }
+
+    void merge(final ConcurrentArray<T> other) {
+        Objects.requireNonNull(other);
 
         // We don't allow either to be mutable
-        if (!arrayOne.isImmutable() || !arrayTwo.isImmutable()) {
+        if (!this.isImmutable() || !other.isImmutable()) {
             throw new IllegalArgumentException("The source arrays *must* be immutable");
         }
 
-        // OK, this is just being really picky. But don't let them be the same either. That's just weird.
-        // If both are the same, it is probably a bug. If we needed to support this, we could relax
-        // the restriction and just accept one of the two.
-        if (arrayOne == arrayTwo) {
+        if (other == this) {
             throw new IllegalArgumentException("Both arguments should be distinct instances");
         }
 
-        // Copy the pointers to the arrays of arrayOne and arrayTwo into the dequeue. We know
-        // that both sources are immutable, so we can do this safely.
-        this.subarrayCapacity = 1;
-        arrays.addAll(arrayOne.arrays);
-        arrays.addAll(arrayTwo.arrays);
-        elementCount.addAndGet(arrayOne.size() + arrayTwo.size());
-        immutable.set(true);
+        if (this.current != other.current) {
+            throw new IllegalArgumentException("Arrays are not from the same family");
+        }
+
+        if (other.head != null) {
+            head = other.head;
+            elementCount.addAndGet(other.size());
+        }
     }
 
     /**
@@ -224,12 +213,12 @@ final class ConcurrentArray<T> {
         }
 
         int count = 0;
-        for (final SubArray<T> arr : arrays) {
-            final int arrSize = arr.size.get();
+        for (SubArray<T> cur = head; cur != null; cur = cur.next) {
+            final int arrSize = cur.size.get();
             if (index >= count + arrSize) {
                 count += arrSize;
             } else {
-                return arr.get(index - count);
+                return cur.get(index - count);
             }
         }
 
@@ -250,19 +239,31 @@ final class ConcurrentArray<T> {
             throw new IllegalStateException("You can not call add on a immutable ConcurrentArray");
         }
 
+        if (head == null) {
+            synchronized (this) {
+                if (head == null) {
+                    SubArray<T> cur = current.get();
+                    if (cur.size.get() > 0) {
+                        cur.next = new SubArray<>(subarrayCapacity);
+                        cur = cur.next;
+                        current.set(cur);
+                    }
+                    head = cur;
+                }
+            }
+        }
+
         // The sub-arrays in the dequeue all considered full except for the very last one. If the very last one is
         // also full, then add a new sub-array. We want to avoid locking for normal operations, and only
         // do so if the sub-array is full. So we will get the last sub-array, try to add to it, and if we fail
         // to do so, then we will acquire the lock to create a new sub-array.
-        SubArray<T> lastArray = arrays.getLast();
-        boolean success = lastArray.add(element);
+        boolean success = current.get().add(element);
         if (!success) {
             synchronized (this) {
                 // Within this lock we need to create a new sub-array. Unless in a race another thread has already
                 // entered this critical section and created the sub array. So we will once again get the last
                 // sub-array from the dequeue, try to add to it, and determine if we need to add a new sub-array.
-                lastArray = arrays.getLast();
-                success = lastArray.add(element);
+                success = current.get().add(element);
                 if (!success) {
                     // Create the sub-array
                     final SubArray<T> newArray = new SubArray<>(subarrayCapacity);
@@ -275,7 +276,8 @@ final class ConcurrentArray<T> {
                     // other threads can come along and add items to the array. If we were to put this
                     // into the dequeue too soon, then the array could be filled up before our thread
                     // has a chance, causing the above assertion to fail.
-                    arrays.add(newArray);
+                    current.get().next = newArray;
+                    current.set(newArray);
                 }
             }
         }
@@ -296,6 +298,7 @@ final class ConcurrentArray<T> {
      * @throws IllegalStateException
      * 		If this instance is not immutable.
      */
+    @SuppressWarnings("unchecked")
     Stream<T> sortedStream(Comparator<T> comparator) {
         if (!immutable.get()) {
             throw new IllegalStateException("You can not call sortedStream on a mutable ConcurrentArray");
@@ -307,27 +310,22 @@ final class ConcurrentArray<T> {
             return Stream.empty();
         }
 
-        // Convert the sub-arrays into a single array and sort it. We considered numerous alternatives to try to
-        // avoid the array copies, but we could not find a more efficient solution. Lock so that we can safely combine
-        // the arrays and sort the result.
-        final SubArray<T> newArray = new SubArray<>(numberOfElements);
-        synchronized (this) {
-            // Copy all the arrays to one new array
-            int nextIndex = 0;
-            for (final SubArray<T> array : arrays) {
-                final int arraySize = array.size.get();
-                System.arraycopy(array.array, 0, newArray.array, nextIndex, arraySize);
-                nextIndex += arraySize;
-            }
-            newArray.size.set(numberOfElements);
-            arrays.clear();
-            arrays.add(newArray);
-
-            // Now sort
-            Arrays.parallelSort(newArray.array, 0, numberOfElements, comparator);
+        // Copy the sub-arrays into a single array and sort it.
+        T[] sortedArray = (T[]) new Object[numberOfElements];
+        int nextIndex = 0;
+        for (SubArray<T> array = head;
+                array != null && nextIndex < numberOfElements;
+                array = array.next) {
+            final int arraySize = array.size.get();
+            System.arraycopy(array.array, 0, sortedArray, nextIndex, arraySize);
+            nextIndex += arraySize;
         }
+
+        // Now sort
+        Arrays.parallelSort(sortedArray, 0, numberOfElements, comparator);
+
         // Create and return the stream
-        return Arrays.stream(newArray.array);
+        return Arrays.stream(sortedArray);
     }
 
     public StandardFuture<Void> parallelTraverse(Executor executor, Consumer<T> action) {
@@ -337,11 +335,13 @@ final class ConcurrentArray<T> {
 
         final StandardFuture<Void> result = new StandardFuture<>();
         final AtomicInteger count = new AtomicInteger(1);
-        for (SubArray<T> subArray : arrays) {
+        int nextIndex = 0;
+        int numberOfElements = elementCount.get();
+        for (SubArray<T> cur = head; cur != null && nextIndex < numberOfElements; cur = cur.next) {
             count.incrementAndGet();
+            final T[] array = cur.array;
+            final int size = cur.size.get();
             executor.execute(() -> {
-                T[] array = subArray.array;
-                int size = subArray.size.get();
                 for (int i = 0; i < size; ++i) {
                     action.accept(array[i]);
                 }
@@ -349,6 +349,7 @@ final class ConcurrentArray<T> {
                     result.complete(null);
                 }
             });
+            nextIndex += size;
         }
         if (count.decrementAndGet() == 0) {
             result.complete(null);
@@ -362,6 +363,7 @@ final class ConcurrentArray<T> {
     private static class SubArray<T> {
         private final T[] array;
         private final AtomicInteger size = new AtomicInteger(0);
+        private SubArray<T> next;
 
         @SuppressWarnings("unchecked")
         public SubArray(int capacity) {

--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/cache/ConcurrentArray.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/cache/ConcurrentArray.java
@@ -150,7 +150,7 @@ final class ConcurrentArray<T> {
         Objects.requireNonNull(other);
 
         // We don't allow either to be mutable
-        if (!this.isImmutable() || !other.isImmutable()) {
+        if (!(this.isImmutable() && other.isImmutable())) {
             throw new IllegalArgumentException("Both arrays *must* be immutable");
         }
 
@@ -161,8 +161,7 @@ final class ConcurrentArray<T> {
         if (elementCount.get() == 0) {
             head = other.head;
             tail = other.tail;
-        }
-        else if (other.elementCount.get() > 0) {
+        } else if (other.elementCount.get() > 0) {
             tail.next = other.head;
             elementCount.addAndGet(other.size());
         }

--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/cache/VirtualNodeCache.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/cache/VirtualNodeCache.java
@@ -263,7 +263,7 @@ public final class VirtualNodeCache<K extends VirtualKey<? super K>, V extends V
      * <p>
      * <strong>ONE PER CACHE INSTANCE</strong>.
      */
-    private ConcurrentArray<Mutation<VirtualLeafRecord<K, V>>> dirtyLeaves;
+    private ConcurrentArray<Mutation<VirtualLeafRecord<K, V>>> dirtyLeaves = new ConcurrentArray<>();
 
     /**
      * A set of leaf path changes that occurred in this version of the cache. This is separate
@@ -273,7 +273,7 @@ public final class VirtualNodeCache<K extends VirtualKey<? super K>, V extends V
      * <p>
      * <strong>ONE PER CACHE INSTANCE</strong>.
      */
-    private ConcurrentArray<Mutation<K>> dirtyLeafPaths;
+    private ConcurrentArray<Mutation<K>> dirtyLeafPaths = new ConcurrentArray<>();
 
     /**
      * A set of all modifications to internal nodes that occurred in this version of the cache.
@@ -283,7 +283,7 @@ public final class VirtualNodeCache<K extends VirtualKey<? super K>, V extends V
      * <p>
      * <strong>ONE PER CACHE INSTANCE</strong>.
      */
-    private ConcurrentArray<Mutation<VirtualInternalRecord>> dirtyInternals;
+    private ConcurrentArray<Mutation<VirtualInternalRecord>> dirtyInternals = new ConcurrentArray<>();
 
     /**
      * A shared lock that prevents two copies from being merged/released at the same time. For example,
@@ -318,9 +318,6 @@ public final class VirtualNodeCache<K extends VirtualKey<? super K>, V extends V
         this.keyToDirtyLeafIndex = new ConcurrentHashMap<>();
         this.pathToDirtyLeafIndex = new ConcurrentHashMap<>();
         this.pathToDirtyInternalIndex = new ConcurrentHashMap<>();
-        this.dirtyLeaves = new ConcurrentArray<>();
-        this.dirtyLeafPaths = new ConcurrentArray<>();
-        this.dirtyInternals = new ConcurrentArray<>();
         this.releaseLock = new ReentrantLock();
         this.lastReleased = new AtomicLong(-1L);
     }
@@ -343,9 +340,6 @@ public final class VirtualNodeCache<K extends VirtualKey<? super K>, V extends V
         this.keyToDirtyLeafIndex = source.keyToDirtyLeafIndex;
         this.pathToDirtyLeafIndex = source.pathToDirtyLeafIndex;
         this.pathToDirtyInternalIndex = source.pathToDirtyInternalIndex;
-        this.dirtyLeaves = new ConcurrentArray<>(source.dirtyLeaves);
-        this.dirtyLeafPaths = new ConcurrentArray<>(source.dirtyLeafPaths);
-        this.dirtyInternals = new ConcurrentArray<>(source.dirtyInternals);
         this.releaseLock = source.releaseLock;
         this.lastReleased = source.lastReleased;
 

--- a/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/VirtualMapTests.java
+++ b/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/VirtualMapTests.java
@@ -122,8 +122,8 @@ class VirtualMapTests extends VirtualTestBase {
             if (info != null) {
                 final String threadName = info.getThreadName();
                 if (!threadName.contains("hasher")
-                        && !threadName.contains("CacheCleaner-")
-                        && !threadName.contains("<virtual-pipeline: lifecycle")
+                        && !threadName.contains("virtual-map: cache-cleaner")
+                        && !threadName.contains("virtual-pipeline: lifecycle")
                         && !threadName.contains("ForkJoinPool.commonPool-worker-")
                         && !(threadName.contains("pool-") && threadName.contains("-thread-"))) {
                     threadNames.add(threadName);

--- a/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/internal/cache/ConcurrentArrayTest.java
+++ b/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/internal/cache/ConcurrentArrayTest.java
@@ -109,9 +109,9 @@ class ConcurrentArrayTest {
     @DisplayName("ConcurrentArrays must be immutable when merged")
     void mergeConstructorCannotTakeMutableSources() {
         final ConcurrentArray<String> mutableSource1 = new ConcurrentArray<>(10);
-        final ConcurrentArray<String> immutableSource = new ConcurrentArray<>(mutableSource1);
+        final ConcurrentArray<String> immutableSource = new ConcurrentArray<>(10);
         immutableSource.seal();
-        final ConcurrentArray<String> mutableSource2 = new ConcurrentArray<>(immutableSource);
+        final ConcurrentArray<String> mutableSource2 = new ConcurrentArray<>(10);
 
         assertThrows(
                 IllegalArgumentException.class,
@@ -156,7 +156,7 @@ class ConcurrentArrayTest {
         // Let 5 be left off
         a.seal();
 
-        final ConcurrentArray<String> b = new ConcurrentArray<>(a);
+        final ConcurrentArray<String> b = new ConcurrentArray<>(10);
         b.add("Element F");
         b.add("Element 2");
         b.add("Element 7");
@@ -204,7 +204,7 @@ class ConcurrentArrayTest {
         a.seal();
 
         // Make sure there is an empty space in this array for the test to be valid
-        final ConcurrentArray<String> b = new ConcurrentArray<>(a);
+        final ConcurrentArray<String> b = new ConcurrentArray<>(5);
         b.add("Element 5");
         b.add("Element 6");
         b.seal();
@@ -213,14 +213,9 @@ class ConcurrentArrayTest {
         assertTrue(b.isImmutable(), "Expected array to be immutable");
     }
 
-    /**
-     * Although this is NOT A REQUIREMENT for our implementation (at least, at the time
-     * this comment was written), it should be possible to use a ConcurrentArray as the source
-     * of more than one merged ConcurrentArray.
-     */
     @Test
     @Tags({@Tag("VirtualMerkle"), @Tag("VirtualNodeCache")})
-    @DisplayName("Reusing the same ConcurrentArray source should be permitted")
+    @DisplayName("Multiple merge")
     void reusingTheSameSourceArrayIsOK() {
         final ConcurrentArray<String> a = new ConcurrentArray<>(5);
         a.add("Element 1");
@@ -229,14 +224,14 @@ class ConcurrentArrayTest {
         a.add("Element 4");
         a.seal();
 
-        final ConcurrentArray<String> b = new ConcurrentArray<>(a);
+        final ConcurrentArray<String> b = new ConcurrentArray<>(5);
         b.add("Element 5");
         b.add("Element 6");
         b.add("Element 7");
         b.add("Element 8");
         b.seal();
 
-        final ConcurrentArray<String> c = new ConcurrentArray<>(b);
+        final ConcurrentArray<String> c = new ConcurrentArray<>(5);
         c.add("Element A");
         c.add("Element B");
         c.add("Element C");

--- a/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/internal/cache/ConcurrentArrayTest.java
+++ b/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/internal/cache/ConcurrentArrayTest.java
@@ -90,37 +90,37 @@ class ConcurrentArrayTest {
     }
 
     /**
-     * I should not be able to pass null as either source ConcurrentArray when creating a ConcurrentArray.
+     * I should not be able to pass null as an argument to merge.
      */
     @Test
     @Tags({@Tag("VirtualMerkle"), @Tag("VirtualNodeCache")})
-    @DisplayName("Null is not a valid input as either argument to the ConcurrentArray constructor")
+    @DisplayName("Null is not a valid input for merge")
     void mergeConstructorCannotTakeNull() {
         final ConcurrentArray<String> source = new ConcurrentArray<>(10);
         source.seal();
-        assertThrows(NullPointerException.class, () -> new ConcurrentArray<>(null, source), "Expected NPE");
-        assertThrows(NullPointerException.class, () -> new ConcurrentArray<>(source, null), "Expected NPE");
+        assertThrows(NullPointerException.class, () -> source.merge(null), "Expected NPE");
     }
 
     /**
-     * Neither source array can be mutable when using the "merge" constructor.
+     * Neither array can be mutable when merged.
      */
     @Test
     @Tags({@Tag("VirtualMerkle"), @Tag("VirtualNodeCache")})
-    @DisplayName("Source ConcurrentArrays must be immutable when passed to the constructor")
+    @DisplayName("ConcurrentArrays must be immutable when merged")
     void mergeConstructorCannotTakeMutableSources() {
-        final ConcurrentArray<String> immutableSource = new ConcurrentArray<>(10);
+        final ConcurrentArray<String> mutableSource1 = new ConcurrentArray<>(10);
+        final ConcurrentArray<String> immutableSource = new ConcurrentArray<>(mutableSource1);
         immutableSource.seal();
-        final ConcurrentArray<String> mutableSource = new ConcurrentArray<>(10);
+        final ConcurrentArray<String> mutableSource2 = new ConcurrentArray<>(immutableSource);
 
         assertThrows(
                 IllegalArgumentException.class,
-                () -> new ConcurrentArray<>(immutableSource, mutableSource),
-                "Expected IAE when passing a mutable source");
+                () -> immutableSource.merge(mutableSource1),
+                "Expected IAE when merging with a mutable source");
         assertThrows(
                 IllegalArgumentException.class,
-                () -> new ConcurrentArray<>(mutableSource, immutableSource),
-                "Expected IAE when passing a mutable source");
+                () -> mutableSource2.merge(immutableSource),
+                "Expected IAE when merging a mutable array");
     }
 
     /**
@@ -128,13 +128,13 @@ class ConcurrentArrayTest {
      */
     @Test
     @Tags({@Tag("VirtualMerkle"), @Tag("VirtualNodeCache")})
-    @DisplayName("Source ConcurrentArrays must be unique")
+    @DisplayName("Merged ConcurrentArrays must be unique")
     void mergeConstructorArgsMustBeUniqueInstances() {
         final ConcurrentArray<String> immutableSource = new ConcurrentArray<>(10);
         immutableSource.seal();
         assertThrows(
                 IllegalArgumentException.class,
-                () -> new ConcurrentArray<>(immutableSource, immutableSource),
+                () -> immutableSource.merge(immutableSource),
                 "Expected IAE when passing same source twice");
     }
 
@@ -156,7 +156,7 @@ class ConcurrentArrayTest {
         // Let 5 be left off
         a.seal();
 
-        final ConcurrentArray<String> b = new ConcurrentArray<>(10);
+        final ConcurrentArray<String> b = new ConcurrentArray<>(a);
         b.add("Element F");
         b.add("Element 2");
         b.add("Element 7");
@@ -170,10 +170,10 @@ class ConcurrentArrayTest {
         b.seal();
 
         // Merge. I should have 9 elements, and 5 should not be one of them.
-        final ConcurrentArray<String> arr = new ConcurrentArray<>(a, b);
-        assertEquals(14, arr.size(), "Wrong value");
+        b.merge(a);
+        assertEquals(14, b.size(), "Wrong value");
 
-        final List<String> elements = arr.seal().sortedStream(null).collect(Collectors.toList());
+        final List<String> elements = b.sortedStream(null).collect(Collectors.toList());
 
         assertEquals("Element 1", elements.get(0), "Wrong value");
         assertEquals("Element 2", elements.get(1), "Wrong value");
@@ -204,13 +204,13 @@ class ConcurrentArrayTest {
         a.seal();
 
         // Make sure there is an empty space in this array for the test to be valid
-        final ConcurrentArray<String> b = new ConcurrentArray<>(5);
+        final ConcurrentArray<String> b = new ConcurrentArray<>(a);
         b.add("Element 5");
         b.add("Element 6");
         b.seal();
 
-        final ConcurrentArray<String> arr = new ConcurrentArray<>(a, b);
-        assertTrue(arr.isImmutable(), "Expected array to be immutable");
+        b.merge(a);
+        assertTrue(b.isImmutable(), "Expected array to be immutable");
     }
 
     /**
@@ -229,7 +229,7 @@ class ConcurrentArrayTest {
         a.add("Element 4");
         a.seal();
 
-        final ConcurrentArray<String> b = new ConcurrentArray<>(5);
+        final ConcurrentArray<String> b = new ConcurrentArray<>(a);
         b.add("Element 5");
         b.add("Element 6");
         b.add("Element 7");
@@ -237,7 +237,7 @@ class ConcurrentArrayTest {
         b.add("Element 9");
         b.seal();
 
-        final ConcurrentArray<String> c = new ConcurrentArray<>(5);
+        final ConcurrentArray<String> c = new ConcurrentArray<>(b);
         c.add("Element A");
         c.add("Element B");
         c.add("Element C");
@@ -246,9 +246,9 @@ class ConcurrentArrayTest {
         c.seal();
 
         // Merge a and b together and validate the result
-        final ConcurrentArray<String> arr1 = new ConcurrentArray<>(a, b);
-        assertEquals(9, arr1.size(), "Wrong value");
-        List<String> elements = arr1.seal().sortedStream(null).collect(Collectors.toList());
+        b.merge(a);
+        assertEquals(9, b.size(), "Wrong value");
+        List<String> elements = b.sortedStream(null).collect(Collectors.toList());
 
         assertEquals(9, elements.size(), "Wrong value");
         assertEquals("Element 1", elements.get(0), "Wrong value");
@@ -262,20 +262,25 @@ class ConcurrentArrayTest {
         assertEquals("Element 9", elements.get(8), "Wrong value");
 
         // Merge a and c and validate the result.
-        final ConcurrentArray<String> arr2 = new ConcurrentArray<>(a, c);
-        assertEquals(9, arr2.size(), "Wrong value");
-        elements = arr2.seal().sortedStream(null).collect(Collectors.toList());
+        c.merge(b);
+        assertEquals(14, c.size(), "Wrong value");
+        elements = c.sortedStream(null).collect(Collectors.toList());
 
-        assertEquals(9, elements.size(), "Wrong value");
+        assertEquals(14, elements.size(), "Wrong value");
         assertEquals("Element 1", elements.get(0), "Wrong value");
         assertEquals("Element 2", elements.get(1), "Wrong value");
         assertEquals("Element 3", elements.get(2), "Wrong value");
         assertEquals("Element 4", elements.get(3), "Wrong value");
-        assertEquals("Element A", elements.get(4), "Wrong value");
-        assertEquals("Element B", elements.get(5), "Wrong value");
-        assertEquals("Element C", elements.get(6), "Wrong value");
-        assertEquals("Element D", elements.get(7), "Wrong value");
-        assertEquals("Element E", elements.get(8), "Wrong value");
+        assertEquals("Element 5", elements.get(4), "Wrong value");
+        assertEquals("Element 6", elements.get(5), "Wrong value");
+        assertEquals("Element 7", elements.get(6), "Wrong value");
+        assertEquals("Element 8", elements.get(7), "Wrong value");
+        assertEquals("Element 9", elements.get(8), "Wrong value");
+        assertEquals("Element A", elements.get(9), "Wrong value");
+        assertEquals("Element B", elements.get(10), "Wrong value");
+        assertEquals("Element C", elements.get(11), "Wrong value");
+        assertEquals("Element D", elements.get(12), "Wrong value");
+        assertEquals("Element E", elements.get(13), "Wrong value");
     }
 
     /**

--- a/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/internal/cache/ConcurrentArrayTest.java
+++ b/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/internal/cache/ConcurrentArrayTest.java
@@ -234,7 +234,6 @@ class ConcurrentArrayTest {
         b.add("Element 6");
         b.add("Element 7");
         b.add("Element 8");
-        b.add("Element 9");
         b.seal();
 
         final ConcurrentArray<String> c = new ConcurrentArray<>(b);
@@ -242,15 +241,14 @@ class ConcurrentArrayTest {
         c.add("Element B");
         c.add("Element C");
         c.add("Element D");
-        c.add("Element E");
         c.seal();
 
         // Merge a and b together and validate the result
         b.merge(a);
-        assertEquals(9, b.size(), "Wrong value");
+        assertEquals(8, b.size(), "Wrong value");
         List<String> elements = b.sortedStream(null).collect(Collectors.toList());
 
-        assertEquals(9, elements.size(), "Wrong value");
+        assertEquals(8, elements.size(), "Wrong value");
         assertEquals("Element 1", elements.get(0), "Wrong value");
         assertEquals("Element 2", elements.get(1), "Wrong value");
         assertEquals("Element 3", elements.get(2), "Wrong value");
@@ -259,14 +257,13 @@ class ConcurrentArrayTest {
         assertEquals("Element 6", elements.get(5), "Wrong value");
         assertEquals("Element 7", elements.get(6), "Wrong value");
         assertEquals("Element 8", elements.get(7), "Wrong value");
-        assertEquals("Element 9", elements.get(8), "Wrong value");
 
         // Merge a and c and validate the result.
         c.merge(b);
-        assertEquals(14, c.size(), "Wrong value");
+        assertEquals(12, c.size(), "Wrong value");
         elements = c.sortedStream(null).collect(Collectors.toList());
 
-        assertEquals(14, elements.size(), "Wrong value");
+        assertEquals(12, elements.size(), "Wrong value");
         assertEquals("Element 1", elements.get(0), "Wrong value");
         assertEquals("Element 2", elements.get(1), "Wrong value");
         assertEquals("Element 3", elements.get(2), "Wrong value");
@@ -275,12 +272,10 @@ class ConcurrentArrayTest {
         assertEquals("Element 6", elements.get(5), "Wrong value");
         assertEquals("Element 7", elements.get(6), "Wrong value");
         assertEquals("Element 8", elements.get(7), "Wrong value");
-        assertEquals("Element 9", elements.get(8), "Wrong value");
-        assertEquals("Element A", elements.get(9), "Wrong value");
-        assertEquals("Element B", elements.get(10), "Wrong value");
-        assertEquals("Element C", elements.get(11), "Wrong value");
-        assertEquals("Element D", elements.get(12), "Wrong value");
-        assertEquals("Element E", elements.get(13), "Wrong value");
+        assertEquals("Element A", elements.get(8), "Wrong value");
+        assertEquals("Element B", elements.get(9), "Wrong value");
+        assertEquals("Element C", elements.get(10), "Wrong value");
+        assertEquals("Element D", elements.get(11), "Wrong value");
     }
 
     /**

--- a/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/internal/cache/ConcurrentArrayTest.java
+++ b/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/internal/cache/ConcurrentArrayTest.java
@@ -215,7 +215,7 @@ class ConcurrentArrayTest {
 
     @Test
     @Tags({@Tag("VirtualMerkle"), @Tag("VirtualNodeCache")})
-    @DisplayName("Multiple merge")
+    @DisplayName("Reusing the same ConcurrentArray source should be permitted")
     void reusingTheSameSourceArrayIsOK() {
         final ConcurrentArray<String> a = new ConcurrentArray<>(5);
         a.add("Element 1");
@@ -236,6 +236,7 @@ class ConcurrentArrayTest {
         c.add("Element B");
         c.add("Element C");
         c.add("Element D");
+        c.add("Element E");
         c.seal();
 
         // Merge a and b together and validate the result
@@ -254,23 +255,20 @@ class ConcurrentArrayTest {
         assertEquals("Element 8", elements.get(7), "Wrong value");
 
         // Merge a and c and validate the result.
-        c.merge(b);
-        assertEquals(12, c.size(), "Wrong value");
+        c.merge(a);
+        assertEquals(9, c.size(), "Wrong value");
         elements = c.sortedStream(null).collect(Collectors.toList());
 
-        assertEquals(12, elements.size(), "Wrong value");
+        assertEquals(9, elements.size(), "Wrong value");
         assertEquals("Element 1", elements.get(0), "Wrong value");
         assertEquals("Element 2", elements.get(1), "Wrong value");
         assertEquals("Element 3", elements.get(2), "Wrong value");
         assertEquals("Element 4", elements.get(3), "Wrong value");
-        assertEquals("Element 5", elements.get(4), "Wrong value");
-        assertEquals("Element 6", elements.get(5), "Wrong value");
-        assertEquals("Element 7", elements.get(6), "Wrong value");
-        assertEquals("Element 8", elements.get(7), "Wrong value");
-        assertEquals("Element A", elements.get(8), "Wrong value");
-        assertEquals("Element B", elements.get(9), "Wrong value");
-        assertEquals("Element C", elements.get(10), "Wrong value");
-        assertEquals("Element D", elements.get(11), "Wrong value");
+        assertEquals("Element A", elements.get(4), "Wrong value");
+        assertEquals("Element B", elements.get(5), "Wrong value");
+        assertEquals("Element C", elements.get(6), "Wrong value");
+        assertEquals("Element D", elements.get(7), "Wrong value");
+        assertEquals("Element E", elements.get(8), "Wrong value");
     }
 
     /**


### PR DESCRIPTION
Closes #5717.

Merging `ConcurrentArray` copies is now constant time.
