### PR TITLE
5314: JasperDB to MerkleDb: logs and settings

### DIFF
--- a/hedera-node/configuration/dev/bootstrap.properties
+++ b/hedera-node/configuration/dev/bootstrap.properties
@@ -1,1 +1,2 @@
 bootstrap.throttleDefsJson.resource=throttles-dev.json
+virtualdatasource.jasperdbToMerkledb=true

--- a/hedera-node/configuration/dev/log4j2.xml
+++ b/hedera-node/configuration/dev/log4j2.xml
@@ -73,8 +73,9 @@
     <Logger name="com.swirlds" level="INFO" additivity="false">
       <AppenderRef ref="fileLog">
         <Filters>
-          <!-- JasperDB & Virtual Merkle -->
+          <!-- JasperDB / MerkleDb & Virtual Merkle -->
           <MarkerFilter marker="JASPER_DB"              onMatch="DENY" onMismatch="NEUTRAL"/>
+          <MarkerFilter marker="MERKLE_DB"              onMatch="DENY" onMismatch="NEUTRAL"/>
           <MarkerFilter marker="VIRTUAL_MERKLE_STATS"   onMatch="DENY" onMismatch="NEUTRAL"/>
           <MarkerFilter marker="STATE_HASH"             onMatch="DENY" onMismatch="NEUTRAL"/>
         </Filters>
@@ -82,8 +83,9 @@
 
       <AppenderRef ref="vMapLog">
         <Filters>
-          <!-- JasperDB & Virtual Merkle -->
+          <!-- JasperDB / MerkleDb & Virtual Merkle -->
           <MarkerFilter marker="JASPER_DB"              onMatch="ACCEPT" onMismatch="NEUTRAL"/>
+          <MarkerFilter marker="MERKLE_DB"              onMatch="ACCEPT" onMismatch="NEUTRAL"/>
           <MarkerFilter marker="VIRTUAL_MERKLE_STATS"   onMatch="ACCEPT" onMismatch="NEUTRAL"/>
           <MarkerFilter marker="DISABLED"               onMatch="DENY"   onMismatch="DENY" />
         </Filters>
@@ -183,8 +185,9 @@
         <MarkerFilter marker="MERKLE_GENERATION"      onMatch="DENY"   onMismatch="NEUTRAL"/>
         <MarkerFilter marker="MERKLE_LOCKS"           onMatch="DENY"   onMismatch="NEUTRAL"/>
 
-        <!-- JasperDB & Virtual Merkle -->
+        <!-- JasperDB / MerkleDd & Virtual Merkle -->
         <MarkerFilter marker="JASPER_DB"              onMatch="ACCEPT" onMismatch="NEUTRAL"/>
+        <MarkerFilter marker="MERKLE_DB"              onMatch="ACCEPT" onMismatch="NEUTRAL"/>
         <MarkerFilter marker="VIRTUAL_MERKLE_STATS"   onMatch="ACCEPT" onMismatch="NEUTRAL"/>
 
         <MarkerFilter marker="DISABLED"               onMatch="DENY"   onMismatch="DENY" />

--- a/hedera-node/configuration/dev/settings.txt
+++ b/hedera-node/configuration/dev/settings.txt
@@ -16,5 +16,6 @@ state.signedStateKeep,                         10
 useLoopbackIp,                                 false
 waitAtStartup,                                 false
 jasperDb.iteratorInputBufferBytes,             16777216
+merkleDb.iteratorInputBufferBytes,             16777216
 virtualMap.preferredFlushQueueSize,            10000
 transThrottle,                                 false

--- a/hedera-node/configuration/mainnet/log4j2.xml
+++ b/hedera-node/configuration/mainnet/log4j2.xml
@@ -72,8 +72,9 @@
     <Logger name="com.swirlds" level="INFO" additivity="false">
       <AppenderRef ref="fileLog">
         <Filters>
-          <!-- JasperDB & Virtual Merkle -->
+          <!-- JasperDB / MerkleDb & Virtual Merkle -->
           <MarkerFilter marker="JASPER_DB"              onMatch="DENY" onMismatch="NEUTRAL"/>
+          <MarkerFilter marker="MERKLE_DB"              onMatch="DENY" onMismatch="NEUTRAL"/>
           <MarkerFilter marker="VIRTUAL_MERKLE_STATS"   onMatch="DENY" onMismatch="NEUTRAL"/>
           <MarkerFilter marker="STATE_HASH"             onMatch="DENY" onMismatch="NEUTRAL"/>
         </Filters>
@@ -81,8 +82,9 @@
 
       <AppenderRef ref="vMapLog">
         <Filters>
-          <!-- JasperDB & Virtual Merkle -->
+          <!-- JasperDB / MerkleDb & Virtual Merkle -->
           <MarkerFilter marker="JASPER_DB"              onMatch="ACCEPT" onMismatch="NEUTRAL"/>
+          <MarkerFilter marker="MERKLE_DB"              onMatch="ACCEPT" onMismatch="NEUTRAL"/>
           <MarkerFilter marker="VIRTUAL_MERKLE_STATS"   onMatch="ACCEPT" onMismatch="NEUTRAL"/>
           <MarkerFilter marker="DISABLED"               onMatch="DENY"   onMismatch="DENY" />
         </Filters>
@@ -181,8 +183,9 @@
         <MarkerFilter marker="MERKLE_GENERATION"      onMatch="DENY"   onMismatch="NEUTRAL"/>
         <MarkerFilter marker="MERKLE_LOCKS"           onMatch="DENY"   onMismatch="NEUTRAL"/>
 
-        <!-- JasperDB & Virtual Merkle -->
+        <!-- JasperDB / MerkleDb & Virtual Merkle -->
         <MarkerFilter marker="JASPER_DB"              onMatch="ACCEPT" onMismatch="NEUTRAL"/>
+        <MarkerFilter marker="MERKLE_DB"              onMatch="ACCEPT" onMismatch="NEUTRAL"/>
         <MarkerFilter marker="VIRTUAL_MERKLE_STATS"   onMatch="ACCEPT" onMismatch="NEUTRAL"/>
 
         <MarkerFilter marker="DISABLED"               onMatch="DENY"   onMismatch="DENY" />

--- a/hedera-node/configuration/mainnet/settings.txt
+++ b/hedera-node/configuration/mainnet/settings.txt
@@ -23,8 +23,8 @@ state.signedStateKeep,                         10
 throttle7extra,                                0.5
 useLoopbackIp,                                 false
 waitAtStartup,                                 false
-jasperDb.storagePath,                          /opt/hgcapp/services-hedera/HapiApp2.0/data/saved
 jasperDb.iteratorInputBufferBytes,             16777216
+merkleDb.iteratorInputBufferBytes,             16777216
 virtualMap.preferredFlushQueueSize,            10000
 state.mainClassNameOverride,                   com.hedera.services.ServicesMain
 prometheusEndpointEnabled,                     true

--- a/hedera-node/configuration/preprod/log4j2.xml
+++ b/hedera-node/configuration/preprod/log4j2.xml
@@ -133,8 +133,9 @@
     <Logger name="com.swirlds" level="INFO" additivity="false">
       <AppenderRef ref="fileLog">
         <Filters>
-          <!-- JasperDB & Virtual Merkle -->
+          <!-- JasperDB / MerkleDb & Virtual Merkle -->
           <MarkerFilter marker="JASPER_DB"              onMatch="DENY" onMismatch="NEUTRAL"/>
+          <MarkerFilter marker="MERKLE_DB"              onMatch="DENY" onMismatch="NEUTRAL"/>
           <MarkerFilter marker="VIRTUAL_MERKLE_STATS"   onMatch="DENY" onMismatch="NEUTRAL"/>
           <MarkerFilter marker="STATE_HASH"             onMatch="DENY" onMismatch="NEUTRAL"/>
         </Filters>
@@ -142,8 +143,9 @@
 
       <AppenderRef ref="vMapLog">
         <Filters>
-          <!-- JasperDB & Virtual Merkle -->
+          <!-- JasperDB / MerkleDb & Virtual Merkle -->
           <MarkerFilter marker="JASPER_DB"              onMatch="ACCEPT" onMismatch="NEUTRAL"/>
+          <MarkerFilter marker="MERKLE_DB"              onMatch="ACCEPT" onMismatch="NEUTRAL"/>
           <MarkerFilter marker="VIRTUAL_MERKLE_STATS"   onMatch="ACCEPT" onMismatch="NEUTRAL"/>
           <MarkerFilter marker="DISABLED"               onMatch="DENY"   onMismatch="DENY" />
         </Filters>
@@ -243,8 +245,9 @@
         <MarkerFilter marker="MERKLE_GENERATION"      onMatch="DENY"   onMismatch="NEUTRAL"/>
         <MarkerFilter marker="MERKLE_LOCKS"           onMatch="DENY"   onMismatch="NEUTRAL"/>
 
-        <!-- JasperDB & Virtual Merkle -->
+        <!-- JasperDB / MerkleDb & Virtual Merkle -->
         <MarkerFilter marker="JASPER_DB"              onMatch="ACCEPT" onMismatch="NEUTRAL"/>
+        <MarkerFilter marker="MERKLE_DB"              onMatch="ACCEPT" onMismatch="NEUTRAL"/>
         <MarkerFilter marker="VIRTUAL_MERKLE_STATS"   onMatch="ACCEPT" onMismatch="NEUTRAL"/>
 
         <MarkerFilter marker="DISABLED"               onMatch="DENY"   onMismatch="DENY" />

--- a/hedera-node/configuration/preprod/settings.txt
+++ b/hedera-node/configuration/preprod/settings.txt
@@ -23,8 +23,8 @@ state.signedStateKeep,                         10
 throttle7extra,                                0.5
 useLoopbackIp,                                 false
 waitAtStartup,                                 false
-jasperDb.storagePath,                          /opt/hgcapp/services-hedera/HapiApp2.0/data/saved
 jasperDb.iteratorInputBufferBytes,             16777216
+merkleDb.iteratorInputBufferBytes,             16777216
 virtualMap.preferredFlushQueueSize,            10000
 prometheusEndpointEnabled,                     true
 state.mainClassNameOverride,                   com.hedera.services.ServicesMain

--- a/hedera-node/configuration/previewnet/log4j2.xml
+++ b/hedera-node/configuration/previewnet/log4j2.xml
@@ -73,8 +73,9 @@
     <Logger name="com.swirlds" level="INFO" additivity="false">
       <AppenderRef ref="fileLog">
         <Filters>
-          <!-- JasperDB & Virtual Merkle -->
+          <!-- JasperDB / MerkleDb & Virtual Merkle -->
           <MarkerFilter marker="JASPER_DB"              onMatch="DENY" onMismatch="NEUTRAL"/>
+          <MarkerFilter marker="MERKLE_DB"              onMatch="DENY" onMismatch="NEUTRAL"/>
           <MarkerFilter marker="VIRTUAL_MERKLE_STATS"   onMatch="DENY" onMismatch="NEUTRAL"/>
           <MarkerFilter marker="STATE_HASH"             onMatch="DENY" onMismatch="NEUTRAL"/>
         </Filters>
@@ -82,8 +83,9 @@
 
       <AppenderRef ref="vMapLog">
         <Filters>
-          <!-- JasperDB & Virtual Merkle -->
+          <!-- JasperDB / MerkleDb & Virtual Merkle -->
           <MarkerFilter marker="JASPER_DB"              onMatch="ACCEPT" onMismatch="NEUTRAL"/>
+          <MarkerFilter marker="MERKLE_DB"              onMatch="ACCEPT" onMismatch="NEUTRAL"/>
           <MarkerFilter marker="VIRTUAL_MERKLE_STATS"   onMatch="ACCEPT" onMismatch="NEUTRAL"/>
           <MarkerFilter marker="DISABLED"               onMatch="DENY"   onMismatch="DENY" />
         </Filters>
@@ -183,8 +185,9 @@
         <MarkerFilter marker="MERKLE_GENERATION"      onMatch="DENY"   onMismatch="NEUTRAL"/>
         <MarkerFilter marker="MERKLE_LOCKS"           onMatch="DENY"   onMismatch="NEUTRAL"/>
 
-        <!-- JasperDB & Virtual Merkle -->
+        <!-- JasperDB / MerkleDb & Virtual Merkle -->
         <MarkerFilter marker="JASPER_DB"              onMatch="ACCEPT" onMismatch="NEUTRAL"/>
+        <MarkerFilter marker="MERKLE_DB"              onMatch="ACCEPT" onMismatch="NEUTRAL"/>
         <MarkerFilter marker="VIRTUAL_MERKLE_STATS"   onMatch="ACCEPT" onMismatch="NEUTRAL"/>
 
         <MarkerFilter marker="DISABLED"               onMatch="DENY"   onMismatch="DENY" />

--- a/hedera-node/configuration/previewnet/settings.txt
+++ b/hedera-node/configuration/previewnet/settings.txt
@@ -23,8 +23,8 @@ state.signedStateKeep,                         10
 throttle7extra,                                0.5
 useLoopbackIp,                                 false
 waitAtStartup,                                 false
-jasperDb.storagePath,                          /opt/hgcapp/services-hedera/HapiApp2.0/data/saved
 jasperDb.iteratorInputBufferBytes,             16777216
+merkleDb.iteratorInputBufferBytes,             16777216
 virtualMap.preferredFlushQueueSize,            10000
 state.mainClassNameOverride,                   com.hedera.services.ServicesMain
 prometheusEndpointEnabled,                     true

--- a/hedera-node/configuration/testnet/log4j2.xml
+++ b/hedera-node/configuration/testnet/log4j2.xml
@@ -73,8 +73,9 @@
     <Logger name="com.swirlds" level="INFO" additivity="false">
       <AppenderRef ref="fileLog">
         <Filters>
-          <!-- JasperDB & Virtual Merkle -->
+          <!-- JasperDB / MerkleDb & Virtual Merkle -->
           <MarkerFilter marker="JASPER_DB"              onMatch="DENY" onMismatch="NEUTRAL"/>
+          <MarkerFilter marker="MERKLE_DB"              onMatch="DENY" onMismatch="NEUTRAL"/>
           <MarkerFilter marker="VIRTUAL_MERKLE_STATS"   onMatch="DENY" onMismatch="NEUTRAL"/>
           <MarkerFilter marker="STATE_HASH"             onMatch="DENY" onMismatch="NEUTRAL"/>
         </Filters>
@@ -82,8 +83,9 @@
 
       <AppenderRef ref="vMapLog">
         <Filters>
-          <!-- JasperDB & Virtual Merkle -->
+          <!-- JasperDB / MerkleDb & Virtual Merkle -->
           <MarkerFilter marker="JASPER_DB"              onMatch="ACCEPT" onMismatch="NEUTRAL"/>
+          <MarkerFilter marker="MERKLE_DB"              onMatch="ACCEPT" onMismatch="NEUTRAL"/>
           <MarkerFilter marker="VIRTUAL_MERKLE_STATS"   onMatch="ACCEPT" onMismatch="NEUTRAL"/>
           <MarkerFilter marker="DISABLED"               onMatch="DENY"   onMismatch="DENY" />
         </Filters>
@@ -183,8 +185,9 @@
         <MarkerFilter marker="MERKLE_GENERATION"      onMatch="DENY"   onMismatch="NEUTRAL"/>
         <MarkerFilter marker="MERKLE_LOCKS"           onMatch="DENY"   onMismatch="NEUTRAL"/>
 
-        <!-- JasperDB & Virtual Merkle -->
+        <!-- JasperDB / MerkleDb & Virtual Merkle -->
         <MarkerFilter marker="JASPER_DB"              onMatch="ACCEPT" onMismatch="NEUTRAL"/>
+        <MarkerFilter marker="MERKLE_DB"              onMatch="ACCEPT" onMismatch="NEUTRAL"/>
         <MarkerFilter marker="VIRTUAL_MERKLE_STATS"   onMatch="ACCEPT" onMismatch="NEUTRAL"/>
 
         <MarkerFilter marker="DISABLED"               onMatch="DENY"   onMismatch="DENY" />

--- a/hedera-node/configuration/testnet/settings.txt
+++ b/hedera-node/configuration/testnet/settings.txt
@@ -24,8 +24,8 @@ state.signedStateKeep,                         10
 throttle7extra,                                0.5
 useLoopbackIp,                                 false
 waitAtStartup,                                 false
-jasperDb.storagePath,                          /opt/hgcapp/services-hedera/HapiApp2.0/data/saved
 jasperDb.iteratorInputBufferBytes,             16777216
+merkleDb.iteratorInputBufferBytes,             16777216
 virtualMap.preferredFlushQueueSize,            10000
 state.mainClassNameOverride,                   com.hedera.services.ServicesMain
 chatter.useChatter,                            false

--- a/hedera-node/hedera-app/src/test/resources/bootstrap.properties
+++ b/hedera-node/hedera-app/src/test/resources/bootstrap.properties
@@ -211,4 +211,4 @@ hedera.prefetch.threadPoolSize=4
 hedera.prefetch.codeCacheTtlSecs=600
 utilPrng.isEnabled=true
 tokens.autoCreations.isEnabled=true
-virtualdatasource.jasperdbToMerkledb=false
+virtualdatasource.jasperdbToMerkledb=true

--- a/hedera-node/hedera-mono-service/src/jmh/java/com/hedera/node/app/service/mono/contracts/SizeLimitedStorageBench.java
+++ b/hedera-node/hedera-mono-service/src/jmh/java/com/hedera/node/app/service/mono/contracts/SizeLimitedStorageBench.java
@@ -130,9 +130,9 @@ public class SizeLimitedStorageBench {
     private void registerConstructables() {
         try {
             Constructables.registerForAccounts();
-            Constructables.registerForJasperDb();
             Constructables.registerForMerkleMap();
             Constructables.registerForVirtualMap();
+            Constructables.registerForVirtualDataSource();
             Constructables.registerForContractStorage();
         } catch (final ConstructableRegistryException e) {
             throw new IllegalStateException(e);

--- a/hedera-node/hedera-mono-service/src/jmh/java/com/hedera/node/app/service/mono/setup/Constructables.java
+++ b/hedera-node/hedera-mono-service/src/jmh/java/com/hedera/node/app/service/mono/setup/Constructables.java
@@ -37,6 +37,7 @@ import com.swirlds.jasperdb.JasperDbBuilder;
 import com.swirlds.merkle.map.MerkleMap;
 import com.swirlds.merkle.tree.MerkleBinaryTree;
 import com.swirlds.merkle.tree.MerkleTreeInternalNode;
+import com.swirlds.merkledb.MerkleDbDataSourceBuilder;
 import com.swirlds.virtualmap.VirtualMap;
 import com.swirlds.virtualmap.internal.cache.VirtualNodeCache;
 import com.swirlds.virtualmap.internal.merkle.VirtualMapState;
@@ -129,8 +130,11 @@ public class Constructables {
                 .registerConstructable(new ClassConstructorPair(VirtualNodeCache.class, VirtualNodeCache::new));
     }
 
-    public static void registerForJasperDb() throws ConstructableRegistryException {
+    public static void registerForVirtualDataSource() throws ConstructableRegistryException {
         ConstructableRegistry.getInstance()
                 .registerConstructable(new ClassConstructorPair(JasperDbBuilder.class, JasperDbBuilder::new));
+        ConstructableRegistry.getInstance()
+                .registerConstructable(
+                        new ClassConstructorPair(MerkleDbDataSourceBuilder.class, MerkleDbDataSourceBuilder::new));
     }
 }

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/context/properties/BootstrapPropertiesTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/context/properties/BootstrapPropertiesTest.java
@@ -504,7 +504,7 @@ class BootstrapPropertiesTest {
             entry(HEDERA_RECORD_STREAM_COMPRESS_FILES_ON_CREATION, true),
             entry(TOKENS_AUTO_CREATIONS_ENABLED, true),
             entry(WORKFLOWS_ENABLED, Set.of()),
-            entry(VIRTUALDATASOURCE_JASPERDB_TO_MERKLEDB, false));
+            entry(VIRTUALDATASOURCE_JASPERDB_TO_MERKLEDB, true));
 
     @Test
     void containsProperty() {

--- a/hedera-node/hedera-mono-service/src/test/resources/bootstrap.properties
+++ b/hedera-node/hedera-mono-service/src/test/resources/bootstrap.properties
@@ -211,4 +211,4 @@ hedera.prefetch.threadPoolSize=4
 hedera.prefetch.codeCacheTtlSecs=600
 utilPrng.isEnabled=true
 tokens.autoCreations.isEnabled=true
-virtualdatasource.jasperdbToMerkledb=false
+virtualdatasource.jasperdbToMerkledb=true

--- a/hedera-node/hedera-mono-service/src/test/resources/bootstrap/standard.properties
+++ b/hedera-node/hedera-mono-service/src/test/resources/bootstrap/standard.properties
@@ -209,4 +209,4 @@ stats.runningAvgHalfLifeSecs=10.0
 stats.speedometerHalfLifeSecs=10.0
 utilPrng.isEnabled=true
 tokens.autoCreations.isEnabled=true
-virtualdatasource.jasperdbToMerkledb=false
+virtualdatasource.jasperdbToMerkledb=true


### PR DESCRIPTION
Fix summary:

* Added MERKLE_DB marker to all log4j2 configs, next and similar to the existing JASPER_DB one
* Enabled MerkleDb by default in test resources (I don't think it has any effect on most tests, since tests usually use JasperDB explicitly; although some high-level tests may switch to MerkleDb)
* Enabled JasperDB to MerkleDb migration in "dev" configuration, while having it disabled in all other configs (testnet, mainnet, previewnet) - need somebody from the devops team to check this, who will be impacted and how

Fixes: https://github.com/hashgraph/hedera-services/issues/5314
Signed-off-by: Artem Ananev <artem.ananev@swirldslabs.com>
