### PR TITLE
05738 - deletes old saved address books

### DIFF
--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/config/StateConfig.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/config/StateConfig.java
@@ -91,9 +91,6 @@ import com.swirlds.config.api.ConfigProperty;
  * 		If true, then enable extra debug code that tracks signed states. Very useful for debugging state leaks.
  * 		This debug code is relatively expensive (it takes and stores stack traces when operations are
  * 		performed on signed state objects).
- * @param forceUseOfConfigAddressBook
- *         If true, then the address book from the config file will be used instead of the address book from the
- *         signed state and the swirld state will not be queried for any address book updates.
  */
 @ConfigData("state")
 public record StateConfig(
@@ -116,8 +113,7 @@ public record StateConfig(
         @ConfigProperty(defaultValue = "5") int debugHashDepth,
         @ConfigProperty(defaultValue = "1000") int maxAgeOfFutureStateSignatures,
         @ConfigProperty(defaultValue = "26") int roundsToKeepForSigning,
-        @ConfigProperty(defaultValue = "false") boolean signedStateSentinelEnabled,
-        @ConfigProperty(defaultValue = "true") boolean forceUseOfConfigAddressBook) {
+        @ConfigProperty(defaultValue = "false") boolean signedStateSentinelEnabled) {
 
     /**
      * Get the main class name that should be used for signed states.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/AddressBookInitializer.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/AddressBookInitializer.java
@@ -59,8 +59,6 @@ public class AddressBookInitializer {
     public static final String STATE_ADDRESS_BOOK_USED = "The State Saved Address Book Was Used.";
     /** The text indicating the state address book was null in the usedAddressBook file. */
     public static final String STATE_ADDRESS_BOOK_NULL = "The State Saved Address Book Was NULL.";
-    /** The name of the address book directory to write address books to. */
-    private static final String ADDRESS_BOOK_DIRECTORY_NAME = "address_book";
     /** The file name prefix to use when creating address book files. */
     private static final String ADDRESS_BOOK_FILE_PREFIX = "usedAddressBook";
     /** The format of date and time to use when creating address book files. */

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/AddressBookInitializer.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/AddressBookInitializer.java
@@ -234,7 +234,7 @@ public class AddressBookInitializer {
      *
      * @param usedAddressBook the address book to be returned from the AddressBookInitializer.
      */
-    synchronized private void recordAddressBooks(@NonNull final AddressBook usedAddressBook) {
+    private synchronized void recordAddressBooks(@NonNull final AddressBook usedAddressBook) {
         cleanAddressBookDirectory();
         final String date = DATE_TIME_FORMAT.format(Instant.now());
         final String addressBookFileName = ADDRESS_BOOK_FILE_PREFIX + "_v" + currentVersion + "_" + date + ".txt";
@@ -272,7 +272,7 @@ public class AddressBookInitializer {
     /**
      * Deletes the oldest address book files if there are more than the maximum number of address book files.
      */
-    synchronized private void cleanAddressBookDirectory() {
+    private synchronized void cleanAddressBookDirectory() {
         try {
             List<Path> files = Files.list(pathToAddressBookDirectory).sorted().toList();
             if (files.size() > MAX_ADDRESS_BOOK_FILES) {

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/Browser.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/Browser.java
@@ -545,17 +545,12 @@ public class Browser {
                 final SignedState loadedSignedState = getUnmodifiedSignedStateFromDisk(
                         mainClassName, swirldName, nodeId, appVersion, addressBook.copy(), emergencyRecoveryManager);
 
-                final StateConfig stateConfig =
-                        platformContext.getConfiguration().getConfigData(StateConfig.class);
+                final AddressBookConfig addressBookConfig =
+                        platformContext.getConfiguration().getConfigData(AddressBookConfig.class);
 
                 // Initialize the address book from the configuration and platform saved state.
                 final AddressBookInitializer addressBookInitializer = new AddressBookInitializer(
-                        appVersion,
-                        loadedSignedState,
-                        appMain::newState,
-                        addressBook.copy(),
-                        stateConfig.savedStateDirectory(),
-                        stateConfig.forceUseOfConfigAddressBook());
+                        appVersion, loadedSignedState, appMain::newState, addressBook.copy(), addressBookConfig);
                 // set here, then given to the state in run(). A copy of it is given to hashgraph.
                 final AddressBook initialAddressBook = addressBookInitializer.getInitialAddressBook();
 

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/config/AddressBookConfig.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/config/AddressBookConfig.java
@@ -27,6 +27,20 @@ import com.swirlds.config.api.ConfigProperty;
  * 		Intermediate workaround until the platform is capable of handling an address book that changes at runtime. This
  * 		feature will be removed in a future version. Check if the address book override is enabled. If enabled, then
  * 		the address book will only change when a node starts up. This feature will be removed in a future version.
+ * @param forceUseOfConfigAddressBook
+ *      If true, then the address book from the config file will be used instead of the address book from the
+ *      signed state and the swirld state will not be queried for any address book updates.
+ * @param addressBookDirectory
+ *      The directory where address book files are saved.
+ * @param maxRecordedAddressBookFiles
+ *      The maximum number of address book files to keep in the address book directory. On startup the
+ *      AddressBookInitializer will create two new files in the `/data/saved/address_book` directory. The
+ *      AddressBookInitializer will delete files by age, oldest first, if the number of files in the directory
+ *      exceeds the maximum indicated by this setting.
  */
 @ConfigData("addressBook")
-public record AddressBookConfig(@ConfigProperty(defaultValue = "true") boolean updateAddressBookOnlyAtUpgrade) {}
+public record AddressBookConfig(
+        @ConfigProperty(defaultValue = "true") boolean updateAddressBookOnlyAtUpgrade,
+        @ConfigProperty(defaultValue = "true") boolean forceUseOfConfigAddressBook,
+        @ConfigProperty(defaultValue = "data/saved/address_book") String addressBookDirectory,
+        @ConfigProperty(defaultValue = "50") int maxRecordedAddressBookFiles) {}

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/AddressBookInitializerTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/AddressBookInitializerTest.java
@@ -36,10 +36,13 @@ import com.swirlds.common.system.SwirldState;
 import com.swirlds.common.system.address.Address;
 import com.swirlds.common.system.address.AddressBook;
 import com.swirlds.common.test.RandomAddressBookGenerator;
+import com.swirlds.config.api.Configuration;
+import com.swirlds.platform.config.AddressBookConfig;
 import com.swirlds.platform.state.PlatformData;
 import com.swirlds.platform.state.PlatformState;
 import com.swirlds.platform.state.State;
 import com.swirlds.platform.state.signed.SignedState;
+import com.swirlds.test.framework.config.TestConfigBuilder;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -70,8 +73,7 @@ class AddressBookInitializerTest {
                 getMockSignedState(0),
                 getMockSwirldStateSupplier(1),
                 configAddressBook,
-                testDirectory.toString(),
-                true);
+                getAddressBookConfig(true));
         final AddressBook inititializedAddressBook = initializer.getInitialAddressBook();
         assertEquals(
                 configAddressBook,
@@ -91,8 +93,7 @@ class AddressBookInitializerTest {
                 signedState,
                 getMockSwirldStateSupplier(1),
                 configAddressBook,
-                testDirectory.toString(),
-                true);
+                getAddressBookConfig(true));
         final AddressBook inititializedAddressBook = initializer.getInitialAddressBook();
         assertEquals(
                 configAddressBook,
@@ -113,8 +114,7 @@ class AddressBookInitializerTest {
                 getMockSignedState(0),
                 getMockSwirldStateSupplier(10),
                 configAddressBook,
-                testDirectory.toString(),
-                false);
+                getAddressBookConfig(false));
         final AddressBook inititializedAddressBook = initializer.getInitialAddressBook();
         assertEquals(
                 expectedAddressBook,
@@ -133,8 +133,7 @@ class AddressBookInitializerTest {
                 getMockSignedState(0),
                 getMockSwirldStateSupplier(0),
                 configAddressBook,
-                testDirectory.toString(),
-                false);
+                getAddressBookConfig(false));
         final AddressBook inititializedAddressBook = initializer.getInitialAddressBook();
         assertEquals(
                 configAddressBook,
@@ -153,8 +152,7 @@ class AddressBookInitializerTest {
                 getMockSignedState(0),
                 getMockSwirldStateSupplier(2),
                 configAddressBook,
-                testDirectory.toString(),
-                false);
+                getAddressBookConfig(false));
         final AddressBook inititializedAddressBook = initializer.getInitialAddressBook();
         assertEquals(
                 configAddressBook,
@@ -171,12 +169,12 @@ class AddressBookInitializerTest {
         final AddressBook configAddressBook = getRandomAddressBook();
         final SoftwareVersion configSoftwareVersion = getMockSoftwareVersion(1);
         final Supplier<SwirldState> genesisSwirldState = getMockSwirldStateSupplier(1);
-        final String directory = testDirectory.toString();
+        final AddressBookConfig addressBookConfig = getAddressBookConfig(false);
 
         assertThrows(
                 IllegalStateException.class,
                 () -> new AddressBookInitializer(
-                        configSoftwareVersion, signedState, genesisSwirldState, configAddressBook, directory, false),
+                        configSoftwareVersion, signedState, genesisSwirldState, configAddressBook, addressBookConfig),
                 "IllegalStateException was not thrown.");
     }
 
@@ -191,8 +189,7 @@ class AddressBookInitializerTest {
                 signedState,
                 getMockSwirldStateSupplier(1),
                 configAddressBook,
-                testDirectory.toString(),
-                false);
+                getAddressBookConfig(false));
         final AddressBook inititializedAddressBook = initializer.getInitialAddressBook();
         assertEquals(
                 signedState.getAddressBook(),
@@ -213,8 +210,7 @@ class AddressBookInitializerTest {
                 signedState,
                 getMockSwirldStateSupplier(0),
                 configAddressBook,
-                testDirectory.toString(),
-                false);
+                getAddressBookConfig(false));
         final AddressBook inititializedAddressBook = initializer.getInitialAddressBook();
         assertEquals(
                 configAddressBook,
@@ -235,8 +231,7 @@ class AddressBookInitializerTest {
                 signedState,
                 getMockSwirldStateSupplier(2),
                 configAddressBook,
-                testDirectory.toString(),
-                false);
+                getAddressBookConfig(false));
         final AddressBook inititializedAddressBook = initializer.getInitialAddressBook();
         assertEquals(
                 configAddressBook,
@@ -257,8 +252,7 @@ class AddressBookInitializerTest {
                 signedState,
                 getMockSwirldStateSupplier(10),
                 configAddressBook,
-                testDirectory.toString(),
-                false);
+                getAddressBookConfig(false));
         final AddressBook inititializedAddressBook = initializer.getInitialAddressBook();
         assertNotEquals(
                 configAddressBook,
@@ -495,5 +489,21 @@ class AddressBookInitializerTest {
         assertTrue(
                 debugFileContent.contains(usedText),
                 "The usedAddressBook content is not:\n" + usedText + "\n\n debugFileContent:\n" + debugFileContent);
+    }
+
+    /**
+     * Creates an AddressBookConfig object with the given forceUseOfConfigAddressBook value.
+     *
+     * @param forceUseOfConfigAddressBook the value to use for the forceUseOfConfigAddressBook property.
+     * @return the AddressBookConfig object.
+     */
+    private AddressBookConfig getAddressBookConfig(boolean forceUseOfConfigAddressBook) {
+        final Configuration configuration = new TestConfigBuilder()
+                .withValue("addressBook.forceUseOfConfigAddressBook", forceUseOfConfigAddressBook)
+                .withValue("addressBook.addressBookDirectory", testDirectory.toString())
+                .withValue("addressBook.maxRecordedAddressBookFiles", 50)
+                .getOrCreateConfig();
+        final AddressBookConfig addressBookConfig = configuration.getConfigData(AddressBookConfig.class);
+        return addressBookConfig;
     }
 }


### PR DESCRIPTION
**Description**:
- adds `cleanAddressBookDirectory()` to AddressBookInitializer.java
- adds synchronized on methods which touch the file system.
- moves `forceUseOfConfigAddressBook` to AddressBookConfig.java
- adds `addressBookDirectory` to AddressBookConfig.java
- adds `maxRecordedAddressBookFiles` to AddressBookConfig.java
- replaces some arguments to the AddressBookInitializer constructor with an instance of AddressBookConfig.

Fixes #5738 

Tested Manually

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
