### PR TITLE
Include `ownerId` in synthetic child `ApproveAllowance` txn

### DIFF
--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/SyntheticTxnFactory.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/SyntheticTxnFactory.java
@@ -310,7 +310,7 @@ public class SyntheticTxnFactory {
         if (approveWrapper.isFungible()) {
             builder.addTokenAllowances(TokenAllowance.newBuilder()
                     .setTokenId(approveWrapper.tokenId())
-                    .setOwner(ownerId.toGrpcAccountId())
+                    .setOwner(Objects.requireNonNull(ownerId).toGrpcAccountId())
                     .setSpender(approveWrapper.spender())
                     .setAmount(approveWrapper.amount().longValueExact())
                     .build());

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/SyntheticTxnFactory.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/SyntheticTxnFactory.java
@@ -298,7 +298,7 @@ public class SyntheticTxnFactory {
     }
 
     public TransactionBody.Builder createFungibleApproval(
-            final ApproveWrapper approveWrapper, @NonNull EntityId ownerId) {
+            @NonNull final ApproveWrapper approveWrapper, @NonNull EntityId ownerId) {
         return createNonfungibleApproval(approveWrapper, ownerId, null);
     }
 

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/SyntheticTxnFactory.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/SyntheticTxnFactory.java
@@ -102,6 +102,7 @@ import com.hederahashgraph.api.proto.java.TokenUpdateTransactionBody;
 import com.hederahashgraph.api.proto.java.TokenWipeAccountTransactionBody;
 import com.hederahashgraph.api.proto.java.TransactionBody;
 import com.hederahashgraph.api.proto.java.TransactionID;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import java.math.BigInteger;
 import java.util.ArrayList;
@@ -296,8 +297,9 @@ public class SyntheticTxnFactory {
         return TransactionBody.newBuilder().setTokenMint(builder);
     }
 
-    public TransactionBody.Builder createFungibleApproval(final ApproveWrapper approveWrapper) {
-        return createNonfungibleApproval(approveWrapper, null, null);
+    public TransactionBody.Builder createFungibleApproval(
+            final ApproveWrapper approveWrapper, @NonNull EntityId ownerId) {
+        return createNonfungibleApproval(approveWrapper, ownerId, null);
     }
 
     public TransactionBody.Builder createNonfungibleApproval(
@@ -308,6 +310,7 @@ public class SyntheticTxnFactory {
         if (approveWrapper.isFungible()) {
             builder.addTokenAllowances(TokenAllowance.newBuilder()
                     .setTokenId(approveWrapper.tokenId())
+                    .setOwner(ownerId.toGrpcAccountId())
                     .setSpender(approveWrapper.spender())
                     .setAmount(approveWrapper.amount().longValueExact())
                     .build());

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/ApprovePrecompile.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/ApprovePrecompile.java
@@ -134,7 +134,7 @@ public class ApprovePrecompile extends AbstractWritePrecompile {
         approveOp = decodeTokenApprove(nestedInput, tokenId, isFungible, aliasResolver, ledgers);
 
         if (approveOp.isFungible()) {
-            transactionBody = syntheticTxnFactory.createFungibleApproval(approveOp);
+            transactionBody = syntheticTxnFactory.createFungibleApproval(approveOp, operatorId);
         } else {
             final var nftId =
                     NftId.fromGrpc(approveOp.tokenId(), approveOp.serialNumber().longValueExact());

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/ERC20PrecompilesTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/ERC20PrecompilesTest.java
@@ -110,6 +110,7 @@ import com.hedera.node.app.service.mono.state.merkle.MerkleToken;
 import com.hedera.node.app.service.mono.state.migration.HederaAccount;
 import com.hedera.node.app.service.mono.state.migration.HederaTokenRel;
 import com.hedera.node.app.service.mono.state.migration.UniqueTokenAdapter;
+import com.hedera.node.app.service.mono.state.submerkle.EntityId;
 import com.hedera.node.app.service.mono.state.submerkle.EvmFnResult;
 import com.hedera.node.app.service.mono.state.submerkle.ExpirableTxnRecord;
 import com.hedera.node.app.service.mono.state.submerkle.FcTokenAllowanceId;
@@ -901,7 +902,8 @@ class ERC20PrecompilesTest {
         given(feeCalculator.computeFee(any(), any(), any(), any())).willReturn(mockFeeObject);
         given(mockFeeObject.getServiceFee()).willReturn(1L);
 
-        given(syntheticTxnFactory.createFungibleApproval(APPROVE_WRAPPER)).willReturn(mockSynthBodyBuilder);
+        given(syntheticTxnFactory.createFungibleApproval(eq(APPROVE_WRAPPER), any()))
+                .willReturn(mockSynthBodyBuilder);
         given(mockSynthBodyBuilder.build())
                 .willReturn(TransactionBody.newBuilder().build());
         given(mockSynthBodyBuilder.setTransactionID(any(TransactionID.class))).willReturn(mockSynthBodyBuilder);
@@ -945,7 +947,8 @@ class ERC20PrecompilesTest {
         given(feeCalculator.computeFee(any(), any(), any(), any())).willReturn(mockFeeObject);
         given(mockFeeObject.getServiceFee()).willReturn(1L);
 
-        given(syntheticTxnFactory.createFungibleApproval(APPROVE_WRAPPER)).willReturn(mockSynthBodyBuilder);
+        given(syntheticTxnFactory.createFungibleApproval(APPROVE_WRAPPER, new EntityId(0, 0, 7L)))
+                .willReturn(mockSynthBodyBuilder);
         given(mockSynthBodyBuilder.build())
                 .willReturn(TransactionBody.newBuilder().build());
         given(mockSynthBodyBuilder.setTransactionID(any(TransactionID.class))).willReturn(mockSynthBodyBuilder);
@@ -1006,7 +1009,8 @@ class ERC20PrecompilesTest {
         given(feeCalculator.computeFee(any(), any(), any(), any())).willReturn(mockFeeObject);
         given(mockFeeObject.getServiceFee()).willReturn(1L);
 
-        given(syntheticTxnFactory.createFungibleApproval(APPROVE_WRAPPER)).willReturn(mockSynthBodyBuilder);
+        given(syntheticTxnFactory.createFungibleApproval(eq(APPROVE_WRAPPER), any()))
+                .willReturn(mockSynthBodyBuilder);
         given(mockSynthBodyBuilder.build())
                 .willReturn(TransactionBody.newBuilder().build());
         given(mockSynthBodyBuilder.setTransactionID(any(TransactionID.class))).willReturn(mockSynthBodyBuilder);

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/SyntheticTxnFactoryTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/SyntheticTxnFactoryTest.java
@@ -29,6 +29,7 @@ import static com.hedera.node.app.service.mono.store.contracts.precompile.HTSTes
 import static com.hedera.node.app.service.mono.store.contracts.precompile.HTSTestsUtil.payer;
 import static com.hedera.node.app.service.mono.store.contracts.precompile.HTSTestsUtil.receiver;
 import static com.hedera.node.app.service.mono.store.contracts.precompile.HTSTestsUtil.royaltyFee;
+import static com.hedera.node.app.service.mono.store.contracts.precompile.HTSTestsUtil.senderId;
 import static com.hedera.node.app.service.mono.store.contracts.precompile.HTSTestsUtil.token;
 import static com.hedera.node.app.service.mono.store.contracts.precompile.SyntheticTxnFactory.MOCK_INITCODE;
 import static com.hedera.node.app.service.mono.store.contracts.precompile.SyntheticTxnFactory.WEIBARS_TO_TINYBARS;
@@ -672,7 +673,7 @@ class SyntheticTxnFactoryTest {
         final var amount = BigInteger.ONE;
         final var allowances = new ApproveWrapper(token, receiver, amount, BigInteger.ZERO, true);
 
-        final var result = subject.createFungibleApproval(allowances);
+        final var result = subject.createFungibleApproval(allowances, senderId);
         final var txnBody = result.build();
 
         assertEquals(
@@ -680,9 +681,9 @@ class SyntheticTxnFactoryTest {
                 txnBody.getCryptoApproveAllowance().getTokenAllowances(0).getAmount());
         assertEquals(
                 token, txnBody.getCryptoApproveAllowance().getTokenAllowances(0).getTokenId());
-        assertEquals(
-                receiver,
-                txnBody.getCryptoApproveAllowance().getTokenAllowances(0).getSpender());
+        final var allowance = txnBody.getCryptoApproveAllowance().getTokenAllowances(0);
+        assertEquals(senderId.toGrpcAccountId(), allowance.getOwner());
+        assertEquals(receiver, allowance.getSpender());
     }
 
     @Test


### PR DESCRIPTION
**Description**:
 - Addresses #5608 but does not include migration records.
 - Sets `msg.sender` as `ownerId` in synthetic `ApproveAllowance` txn.