### PR TITLE
Use FCHashMap for aliases so they are versioned

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/Hedera.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/Hedera.java
@@ -78,7 +78,6 @@ import com.swirlds.common.system.address.AddressBook;
 import com.swirlds.common.system.events.Event;
 import com.swirlds.common.system.state.notifications.IssListener;
 import com.swirlds.common.system.state.notifications.NewSignedStateListener;
-import com.swirlds.fchashmap.FCHashMap;
 import com.swirlds.platform.gui.SwirldsGui;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
@@ -247,8 +246,7 @@ public final class Hedera implements SwirldMain {
     @Override
     @NonNull
     public SwirldState newState() {
-        return new MerkleHederaState(
-                this::onPreHandle, this::onHandleConsensusRound, this::onStateInitialized, new FCHashMap<>());
+        return new MerkleHederaState(this::onPreHandle, this::onHandleConsensusRound, this::onStateInitialized);
     }
 
     /*==================================================================================================================
@@ -683,9 +681,9 @@ public final class Hedera implements SwirldMain {
         logger.debug("Initializing dagger");
         final var selfId = platform.getSelfId().getId();
         if (daggerApp == null) {
+            stateChildren = state.getStateChildrenProvider(platform);
             // Today, the alias map has to be constructed by walking over all accounts.
-            // TODO Populate aliases properly
-            stateChildren = state.getStateChildrenProvider(platform, state.getAliases());
+            // TODO Populate aliases from stateChildren based on the accounts
             final var nodeAddress = stateChildren.addressBook().getAddress(selfId);
             final var initialHash =
                     stateChildren.runningHashLeaf().getRunningHash().getHash();

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/merkle/MerkleHederaState.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/merkle/MerkleHederaState.java
@@ -268,6 +268,11 @@ public class MerkleHederaState extends PartialNaryMerkleInternal implements Merk
         return CURRENT_VERSION;
     }
 
+    /** TEMPORARY: Gets access to the aliases rebuilt data structure. */
+    public final FCHashMap<ByteString, EntityNum> getAliases() {
+        return aliases;
+    }
+
     /**
      * {@inheritDoc}
      */

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/merkle/MerkleHederaState.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/merkle/MerkleHederaState.java
@@ -192,12 +192,11 @@ public class MerkleHederaState extends PartialNaryMerkleInternal implements Merk
     public MerkleHederaState(
             @NonNull final Consumer<Event> onPreHandle,
             @NonNull final BiConsumer<Round, SwirldDualState> onHandleConsensusRound,
-            @NonNull final OnStateInitialized onInit,
-            @NonNull final FCHashMap<ByteString, EntityNum> aliases) {
+            @NonNull final OnStateInitialized onInit) {
         this.onPreHandle = Objects.requireNonNull(onPreHandle);
         this.onHandleConsensusRound = Objects.requireNonNull(onHandleConsensusRound);
         this.onInit = Objects.requireNonNull(onInit);
-        this.aliases = Objects.requireNonNull(aliases);
+        this.aliases = new FCHashMap<>();
     }
 
     /**
@@ -266,11 +265,6 @@ public class MerkleHederaState extends PartialNaryMerkleInternal implements Merk
     @Override
     public int getVersion() {
         return CURRENT_VERSION;
-    }
-
-    /** TEMPORARY: Gets access to the aliases rebuilt data structure. */
-    public final FCHashMap<ByteString, EntityNum> getAliases() {
-        return aliases;
     }
 
     /**
@@ -662,8 +656,7 @@ public class MerkleHederaState extends PartialNaryMerkleInternal implements Merk
      * better than having this here.
      */
     @Deprecated(forRemoval = true)
-    public StateChildrenProvider getStateChildrenProvider(
-            @NonNull final Platform platform, @NonNull final Map<ByteString, EntityNum> aliases) {
+    public StateChildrenProvider getStateChildrenProvider(@NonNull final Platform platform) {
         return new StateChildrenProvider() {
             @Override
             @SuppressWarnings("unchecked")

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/signature/MonoSignaturePreparerTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/signature/MonoSignaturePreparerTest.java
@@ -176,7 +176,6 @@ class MonoSignaturePreparerTest {
         given(result.getPlatformSigs()).willReturn(List.of(mockSig, mockSig));
     }
 
-
     private void givenUnhappy(final PlatformSigsCreationResult result) {
         given(result.asCode()).willReturn(KEY_PREFIX_MISMATCH);
         given(result.hasFailed()).willReturn(true);

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/prehandle/PreHandleWorkflowImplTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/prehandle/PreHandleWorkflowImplTest.java
@@ -27,7 +27,6 @@ import static org.mockito.Mock.Strictness.LENIENT;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
-
 import static org.mockito.Mockito.when;
 
 import com.hedera.hapi.node.base.AccountID;

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/query/QueryWorkflowImplTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/query/QueryWorkflowImplTest.java
@@ -400,7 +400,6 @@ class QueryWorkflowImplTest extends AppTestBase {
         verifyAnsweredFileGetInfo(metrics, 1L);
     }
 
-
     @Test
     void testParsingFails() throws IOException {
         // given

--- a/hedera-node/hedera-consensus-service-impl/src/test/java/com/hedera/node/app/service/consensus/impl/test/handlers/ConsensusCreateTopicHandlerTest.java
+++ b/hedera-node/hedera-consensus-service-impl/src/test/java/com/hedera/node/app/service/consensus/impl/test/handlers/ConsensusCreateTopicHandlerTest.java
@@ -16,7 +16,6 @@
 
 package com.hedera.node.app.service.consensus.impl.test.handlers;
 
-
 import static com.hedera.node.app.service.consensus.impl.test.handlers.ConsensusTestUtils.SIMPLE_KEY_A;
 import static com.hedera.node.app.service.consensus.impl.test.handlers.ConsensusTestUtils.SIMPLE_KEY_B;
 import static com.hedera.node.app.service.consensus.impl.test.handlers.ConsensusTestUtils.assertOkResponse;

--- a/hedera-node/hedera-consensus-service-impl/src/test/java/com/hedera/node/app/service/consensus/impl/test/handlers/ConsensusHandlerTestBase.java
+++ b/hedera-node/hedera-consensus-service-impl/src/test/java/com/hedera/node/app/service/consensus/impl/test/handlers/ConsensusHandlerTestBase.java
@@ -17,7 +17,6 @@
 package com.hedera.node.app.service.consensus.impl.test.handlers;
 
 import static com.hedera.node.app.service.mono.Utils.asHederaKey;
-
 import static com.hedera.node.app.service.mono.pbj.PbjConverter.protoToPbj;
 import static com.hedera.test.utils.IdUtils.asAccount;
 import static com.hedera.test.utils.KeyUtils.A_COMPLEX_KEY;

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/FeeCalculatorModule.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/fees/FeeCalculatorModule.java
@@ -26,5 +26,4 @@ public interface FeeCalculatorModule {
     @Binds
     @Singleton
     FeeCalculator bindFeeCalculator(UsageBasedFeeCalculator usageBasedFeeCalculator);
-
 }


### PR DESCRIPTION
Use FCHashMap for aliases. Closes #5843.

The implementation makes `MerkleHederaState` the owner of the aliases map. It remembers to make fast-copies of it when needed, and makes the current version available through `StateChildrenProvider`.