### PR TITLE
Don't revert successful preceding child records for hollow account finalization

### DIFF
--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/legacy/core/jproto/TxnReceipt.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/legacy/core/jproto/TxnReceipt.java
@@ -380,8 +380,11 @@ public class TxnReceipt implements SelfSerializable {
         private long newTotalSupply;
         private TxnId scheduledTxnId;
         private long[] serialNumbers;
+        private boolean isRevertable = true;
 
         public void revert() {
+            if (!isRevertable) return;
+
             if (SUCCESS_LITERAL.equals(status)) {
                 status = REVERTED_SUCCESS_LITERAL;
             }
@@ -469,6 +472,11 @@ public class TxnReceipt implements SelfSerializable {
 
         public Builder setSerialNumbers(final long[] serialNumbers) {
             this.serialNumbers = serialNumbers;
+            return this;
+        }
+
+        public Builder nonRevertable() {
+            this.isRevertable = false;
             return this;
         }
 

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/crypto/HollowAccountFinalizationLogic.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/crypto/HollowAccountFinalizationLogic.java
@@ -186,6 +186,7 @@ public class HollowAccountFinalizationLogic {
         sideEffects.trackHollowAccountUpdate(accountID);
         final var childRecordBuilder =
                 creator.createSuccessfulSyntheticRecord(Collections.emptyList(), sideEffects, null);
+        childRecordBuilder.getReceiptBuilder().nonRevertable();
         final var inProgress = new InProgressChildRecord(
                 DEFAULT_SOURCE_ID, syntheticUpdate, childRecordBuilder, Collections.emptyList());
         final var childRecord = inProgress.recordBuilder();

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/legacy/core/jproto/TxnReceiptBuilderTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/legacy/core/jproto/TxnReceiptBuilderTest.java
@@ -20,7 +20,9 @@ import static com.hedera.node.app.service.mono.legacy.core.jproto.TxnReceipt.MIS
 import static com.hedera.node.app.service.mono.legacy.core.jproto.TxnReceipt.MISSING_RUNNING_HASH_VERSION;
 import static com.hedera.node.app.service.mono.legacy.core.jproto.TxnReceipt.MISSING_TOPIC_SEQ_NO;
 import static com.hedera.node.app.service.mono.legacy.core.jproto.TxnReceipt.REVERTED_SUCCESS_LITERAL;
+import static com.hedera.node.app.service.mono.legacy.core.jproto.TxnReceipt.SUCCESS_LITERAL;
 import static com.hedera.node.app.service.mono.state.submerkle.EntityId.MISSING_ENTITY_ID;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
@@ -80,4 +82,40 @@ class TxnReceiptBuilderTest {
         assertEquals(MISSING_NEW_TOTAL_SUPPLY, subject.getNewTotalSupply());
         assertEquals(MISSING_RUNNING_HASH_VERSION, subject.getRunningHashVersion());
     }
+
+    @Test
+    void doesNotRevertIfNonRevertable() {
+        subject.setStatus(SUCCESS_LITERAL);
+        subject.setAccountId(MISSING_ENTITY_ID);
+        subject.setContractId(MISSING_ENTITY_ID);
+        subject.setFileId(MISSING_ENTITY_ID);
+        subject.setTokenId(MISSING_ENTITY_ID);
+        subject.setTopicId(MISSING_ENTITY_ID);
+        subject.setScheduleId(MISSING_ENTITY_ID);
+        final TxnId scheduledTxnId = new TxnId();
+        subject.setScheduledTxnId(scheduledTxnId);
+        subject.setNewTotalSupply(123);
+        final long[] serialNumbers = {1, 2, 3};
+        subject.setSerialNumbers(serialNumbers);
+        subject.setRunningHashVersion(1);
+        subject.setTopicRunningHash("ABC".getBytes());
+        subject.setTopicSequenceNumber(321);
+        subject.nonRevertable();
+
+        subject.revert();
+
+        assertEquals(SUCCESS_LITERAL, subject.getStatus());
+        assertEquals(MISSING_ENTITY_ID, subject.getAccountId());
+        assertEquals(MISSING_ENTITY_ID, subject.getContractId());
+        assertEquals(MISSING_ENTITY_ID, subject.getFileId());
+        assertEquals(MISSING_ENTITY_ID, subject.getTokenId());
+        assertEquals(MISSING_ENTITY_ID, subject.getTopicId());
+        assertEquals(MISSING_ENTITY_ID, subject.getScheduleId());
+        assertEquals(MISSING_ENTITY_ID, subject.getScheduleId());
+        assertEquals(scheduledTxnId, subject.getScheduledTxnId());
+        assertEquals(123, subject.getNewTotalSupply());
+        assertArrayEquals(serialNumbers, subject.getSerialNumbers());
+        assertEquals(1, subject.getRunningHashVersion());
+    }
+
 }

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/crypto/HollowAccountFinalizationLogicTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/crypto/HollowAccountFinalizationLogicTest.java
@@ -159,6 +159,7 @@ class HollowAccountFinalizationLogicTest {
         given(syntheticTxnFactory.updateHollowAccount(hollowNum, asKeyUnchecked(key)))
                 .willReturn(txnBodyBuilder);
         given(creator.createSuccessfulSyntheticRecord(any(), any(), any())).willReturn(expirableTxnRecordBuilder);
+        given(expirableTxnRecordBuilder.getReceiptBuilder()).willReturn(txnReceiptBuilder);
 
         final var result = subject.perform();
 
@@ -170,6 +171,8 @@ class HollowAccountFinalizationLogicTest {
         verify(sigImpactHistorian).markAliasChanged(ByteString.copyFrom(evmAddress));
         verify(recordsHistorian)
                 .trackPrecedingChildRecord(DEFAULT_SOURCE_ID, txnBodyBuilder, expirableTxnRecordBuilder);
+        verify(expirableTxnRecordBuilder).getReceiptBuilder();
+        verify(txnReceiptBuilder).nonRevertable();
     }
 
     @Test
@@ -191,6 +194,7 @@ class HollowAccountFinalizationLogicTest {
         given(syntheticTxnFactory.updateHollowAccount(hollowNum, asKeyUnchecked(key)))
                 .willReturn(txnBodyBuilder);
         given(creator.createSuccessfulSyntheticRecord(any(), any(), any())).willReturn(expirableTxnRecordBuilder);
+        given(expirableTxnRecordBuilder.getReceiptBuilder()).willReturn(txnReceiptBuilder);
 
         final var result = subject.perform();
 
@@ -200,6 +204,8 @@ class HollowAccountFinalizationLogicTest {
         verify(sigImpactHistorian).markEntityChanged(hollowNum.longValue());
         verify(recordsHistorian)
                 .trackPrecedingChildRecord(DEFAULT_SOURCE_ID, txnBodyBuilder, expirableTxnRecordBuilder);
+        verify(expirableTxnRecordBuilder).getReceiptBuilder();
+        verify(txnReceiptBuilder).nonRevertable();
     }
 
     @Test
@@ -258,6 +264,8 @@ class HollowAccountFinalizationLogicTest {
         given(syntheticTxnFactory.updateHollowAccount(hollowNum, asKeyUnchecked(key)))
                 .willReturn(txnBodyBuilder);
         given(creator.createSuccessfulSyntheticRecord(any(), any(), any())).willReturn(expirableTxnRecordBuilder);
+        given(expirableTxnRecordBuilder.getReceiptBuilder()).willReturn(txnReceiptBuilder);
+
 
         given(txnCtx.accessor()).willReturn(txnAccessor);
         given(spanMapAccessor.getEthTxExpansion(txnAccessor)).willReturn(new EthTxExpansion(null, OK));
@@ -287,6 +295,8 @@ class HollowAccountFinalizationLogicTest {
         verify(sigImpactHistorian).markEntityChanged(hollowNum2.longValue());
         verify(recordsHistorian, times(2))
                 .trackPrecedingChildRecord(DEFAULT_SOURCE_ID, txnBodyBuilder, expirableTxnRecordBuilder);
+        verify(expirableTxnRecordBuilder, times(2)).getReceiptBuilder();
+        verify(txnReceiptBuilder, times(2)).nonRevertable();
     }
 
     @Test


### PR DESCRIPTION
**Description**:
If a preceding child record is for a hollow account finalization, it should not be reverted if the top-level transaction fails.

**Related issue(s)**:

Fixes https://github.com/hashgraph/hedera-services/issues/5873

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->
