### PR TITLE
cherry pick Fix AccountID's generated from missing EVM addresses

### DIFF
--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/codec/DecodingFacade.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/codec/DecodingFacade.java
@@ -20,6 +20,7 @@ import static com.hedera.node.app.hapi.utils.contracts.ParsingConstants.ARRAY_BR
 import static com.hedera.node.app.hapi.utils.contracts.ParsingConstants.EXPIRY;
 import static com.hedera.node.app.hapi.utils.contracts.ParsingConstants.EXPIRY_V2;
 import static com.hedera.node.app.hapi.utils.contracts.ParsingConstants.TOKEN_KEY;
+import static com.hedera.node.app.service.evm.accounts.HederaEvmContractAliases.isMirror;
 import static com.hedera.node.app.service.mono.utils.EntityIdUtils.accountIdFromEvmAddress;
 
 import com.esaulpaugh.headlong.abi.ABIType;
@@ -140,7 +141,13 @@ public class DecodingFacade {
     public static AccountID convertLeftPaddedAddressToAccountId(
             final byte[] leftPaddedAddress, @NonNull final UnaryOperator<byte[]> aliasResolver) {
         final var addressOrAlias = Arrays.copyOfRange(leftPaddedAddress, ADDRESS_SKIP_BYTES_LENGTH, WORD_LENGTH);
-        return accountIdFromEvmAddress(aliasResolver.apply(addressOrAlias));
+        final var resolvedAddress = aliasResolver.apply(addressOrAlias);
+        if (!isMirror(resolvedAddress)) {
+            return AccountID.newBuilder()
+                    .setAlias(ByteStringUtils.wrapUnsafely(addressOrAlias))
+                    .build();
+        }
+        return accountIdFromEvmAddress(resolvedAddress);
     }
 
     /**
@@ -156,7 +163,7 @@ public class DecodingFacade {
             @NonNull final UnaryOperator<byte[]> aliasResolver,
             @NonNull final Predicate<AccountID> exists) {
         var accountID = convertLeftPaddedAddressToAccountId(leftPaddedAddress, aliasResolver);
-        if (!exists.test(accountID)) {
+        if (!exists.test(accountID) && !accountID.hasAlias()) {
             accountID = generateAccountIDWithAliasCalculatedFrom(accountID);
         }
         return accountID;
@@ -199,7 +206,7 @@ public class DecodingFacade {
         for (final var transfer : abiTransfers) {
             var accountID = convertLeftPaddedAddressToAccountId(transfer.get(0), aliasResolver);
             final long amount = transfer.get(1);
-            if (amount > 0 && !exists.test(accountID)) {
+            if (amount > 0 && !exists.test(accountID) && !accountID.hasAlias()) {
                 accountID = generateAccountIDWithAliasCalculatedFrom(accountID);
             }
             // Only set the isApproval flag to true if it was sent in as a tuple parameter as "true"

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/codec/DecodingFacade.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/codec/DecodingFacade.java
@@ -142,6 +142,10 @@ public class DecodingFacade {
             final byte[] leftPaddedAddress, @NonNull final UnaryOperator<byte[]> aliasResolver) {
         final var addressOrAlias = Arrays.copyOfRange(leftPaddedAddress, ADDRESS_SKIP_BYTES_LENGTH, WORD_LENGTH);
         final var resolvedAddress = aliasResolver.apply(addressOrAlias);
+        // The input address was missing, so we return an AccountID with the
+        // missing address as alias; this means that any downstream code that
+        // relies on 0.0.X account numbers will get INVALID_ACCOUNT_ID, but
+        // the AccountID in any synthetic transaction body will have a valid
         if (!isMirror(resolvedAddress)) {
             return AccountID.newBuilder()
                     .setAlias(ByteStringUtils.wrapUnsafely(addressOrAlias))

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/TransferPrecompile.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/TransferPrecompile.java
@@ -71,6 +71,7 @@ import com.hederahashgraph.api.proto.java.AccountAmount;
 import com.hederahashgraph.api.proto.java.AccountID;
 import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
 import com.hederahashgraph.api.proto.java.Timestamp;
+import com.hederahashgraph.api.proto.java.TokenID;
 import com.hederahashgraph.api.proto.java.TransactionBody;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -452,21 +453,30 @@ public class TransferPrecompile extends AbstractWritePrecompile {
         final var amounts = (long[]) decodedArguments.get(2);
 
         final List<SyntheticTxnFactory.FungibleTokenTransfer> fungibleTransfers = new ArrayList<>();
-        for (int i = 0; i < accountIDs.size(); i++) {
-            final var amount = amounts[i];
-
-            var accountID = accountIDs.get(i);
-            if (amount > 0 && !exists.test(accountID)) {
-                accountID = generateAccountIDWithAliasCalculatedFrom(accountID);
-            }
-
-            DecodingFacade.addSignedAdjustment(fungibleTransfers, tokenType, accountID, amount, false);
-        }
+        addSignedAdjustments(fungibleTransfers, accountIDs, exists, tokenType, amounts);
 
         final var tokenTransferWrappers =
                 Collections.singletonList(new TokenTransferWrapper(NO_NFT_EXCHANGES, fungibleTransfers));
 
         return new CryptoTransferWrapper(new TransferWrapper(hbarTransfers), tokenTransferWrappers);
+    }
+
+    public static void addSignedAdjustments(
+            final List<SyntheticTxnFactory.FungibleTokenTransfer> fungibleTransfers,
+            final List<AccountID> accountIDs,
+            final Predicate<AccountID> exists,
+            final TokenID tokenType,
+            final long[] amounts) {
+        for (int i = 0; i < accountIDs.size(); i++) {
+            final var amount = amounts[i];
+
+            var accountID = accountIDs.get(i);
+            if (amount > 0 && !exists.test(accountID) && !accountID.hasAlias()) {
+                accountID = generateAccountIDWithAliasCalculatedFrom(accountID);
+            }
+
+            DecodingFacade.addSignedAdjustment(fungibleTransfers, tokenType, accountID, amount, false);
+        }
     }
 
     public static CryptoTransferWrapper decodeTransferToken(
@@ -496,19 +506,29 @@ public class TransferPrecompile extends AbstractWritePrecompile {
         final var serialNumbers = ((long[]) decodedArguments.get(3));
 
         final List<SyntheticTxnFactory.NftExchange> nftExchanges = new ArrayList<>();
+        addNftExchanges(nftExchanges, senders, receivers, serialNumbers, tokenID, exists);
+
+        final var tokenTransferWrappers =
+                Collections.singletonList(new TokenTransferWrapper(nftExchanges, NO_FUNGIBLE_TRANSFERS));
+        return new CryptoTransferWrapper(new TransferWrapper(hbarTransfers), tokenTransferWrappers);
+    }
+
+    public static void addNftExchanges(
+            final List<SyntheticTxnFactory.NftExchange> nftExchanges,
+            final List<AccountID> senders,
+            final List<AccountID> receivers,
+            final long[] serialNumbers,
+            final TokenID tokenID,
+            final Predicate<AccountID> exists) {
         for (var i = 0; i < senders.size(); i++) {
             var receiver = receivers.get(i);
-            if (!exists.test(receiver)) {
+            if (!exists.test(receiver) && !receiver.hasAlias()) {
                 receiver = generateAccountIDWithAliasCalculatedFrom(receiver);
             }
             final var nftExchange =
                     new SyntheticTxnFactory.NftExchange(serialNumbers[i], tokenID, senders.get(i), receiver);
             nftExchanges.add(nftExchange);
         }
-
-        final var tokenTransferWrappers =
-                Collections.singletonList(new TokenTransferWrapper(nftExchanges, NO_FUNGIBLE_TRANSFERS));
-        return new CryptoTransferWrapper(new TransferWrapper(hbarTransfers), tokenTransferWrappers);
     }
 
     public static CryptoTransferWrapper decodeTransferNFT(

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/TransferPrecompilesTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/TransferPrecompilesTest.java
@@ -69,6 +69,8 @@ import static com.hedera.node.app.service.mono.store.contracts.precompile.HTSTes
 import static com.hedera.node.app.service.mono.store.contracts.precompile.HTSTestsUtil.tokensTransferListAliasedX2;
 import static com.hedera.node.app.service.mono.store.contracts.precompile.HTSTestsUtil.tokensTransferListReceiverOnly;
 import static com.hedera.node.app.service.mono.store.contracts.precompile.HTSTestsUtil.tokensTransferListSenderOnly;
+import static com.hedera.node.app.service.mono.store.contracts.precompile.impl.TransferPrecompile.addNftExchanges;
+import static com.hedera.node.app.service.mono.store.contracts.precompile.impl.TransferPrecompile.addSignedAdjustments;
 import static com.hedera.node.app.service.mono.store.contracts.precompile.impl.TransferPrecompile.decodeCryptoTransfer;
 import static com.hedera.node.app.service.mono.store.contracts.precompile.impl.TransferPrecompile.decodeCryptoTransferV2;
 import static com.hedera.node.app.service.mono.store.contracts.precompile.impl.TransferPrecompile.decodeHbarTransfers;
@@ -2242,6 +2244,9 @@ class TransferPrecompilesTest {
         transferPrecompile
                 .when(() -> decodeTransferTokens(POSITIVE_AMOUNTS_TRANSFER_TOKENS_INPUT, identity(), accoundIdExists))
                 .thenCallRealMethod();
+        transferPrecompile
+                .when(() -> addSignedAdjustments(any(), any(), any(), any(), any()))
+                .thenCallRealMethod();
         final var decodedInput =
                 decodeTransferTokens(POSITIVE_AMOUNTS_TRANSFER_TOKENS_INPUT, identity(), accoundIdExists);
         final var hbarTransfers = decodedInput.transferWrapper().hbarTransfers();
@@ -2266,6 +2271,9 @@ class TransferPrecompilesTest {
         transferPrecompile
                 .when(() ->
                         decodeTransferTokens(POSITIVE_AMOUNTS_TRANSFER_TOKENS_INPUT, identity(), nonExistingPredicate))
+                .thenCallRealMethod();
+        transferPrecompile
+                .when(() -> addSignedAdjustments(any(), any(), any(), any(), any()))
                 .thenCallRealMethod();
         final var decodedInput =
                 decodeTransferTokens(POSITIVE_AMOUNTS_TRANSFER_TOKENS_INPUT, identity(), nonExistingPredicate);
@@ -2297,6 +2305,9 @@ class TransferPrecompilesTest {
         transferPrecompile
                 .when(() -> decodeTransferTokens(
                         POSITIVE_NEGATIVE_AMOUNT_TRANSFER_TOKENS_INPUT, identity(), accoundIdExists))
+                .thenCallRealMethod();
+        transferPrecompile
+                .when(() -> addSignedAdjustments(any(), any(), any(), any(), any()))
                 .thenCallRealMethod();
         final var decodedInput =
                 decodeTransferTokens(POSITIVE_NEGATIVE_AMOUNT_TRANSFER_TOKENS_INPUT, identity(), accoundIdExists);
@@ -2344,6 +2355,9 @@ class TransferPrecompilesTest {
         transferPrecompile
                 .when(() -> decodeHbarTransfers(any(), any(), any(), any()))
                 .thenCallRealMethod();
+        transferPrecompile
+                .when(() -> addNftExchanges(any(), any(), any(), any(), any(), any()))
+                .thenCallRealMethod();
         final var decodedInput = decodeTransferNFTs(TRANSFER_NFTS_INPUT, identity(), accoundIdExists);
         final var hbarTransfers = decodedInput.transferWrapper().hbarTransfers();
         final var nonFungibleTransfers =
@@ -2366,6 +2380,9 @@ class TransferPrecompilesTest {
         final Predicate<AccountID> nonExistingPredicate = acc -> false;
         transferPrecompile
                 .when(() -> decodeTransferNFTs(TRANSFER_NFTS_INPUT, identity(), nonExistingPredicate))
+                .thenCallRealMethod();
+        transferPrecompile
+                .when(() -> addNftExchanges(any(), any(), any(), any(), any(), any()))
                 .thenCallRealMethod();
         transferPrecompile
                 .when(() -> decodeTokenTransfer(any(), any(), any(), any()))

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/codec/DecodingFacadeTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/codec/DecodingFacadeTest.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.node.app.service.mono.store.contracts.precompile.codec;
+
+import static com.hedera.node.app.service.mono.store.contracts.precompile.codec.DecodingFacade.convertLeftPaddedAddressToAccountId;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+import com.esaulpaugh.headlong.abi.Address;
+import com.esaulpaugh.headlong.abi.Tuple;
+import com.google.common.primitives.Longs;
+import com.google.protobuf.ByteString;
+import com.hedera.node.app.service.mono.store.contracts.precompile.SyntheticTxnFactory;
+import com.hedera.node.app.service.mono.store.contracts.precompile.impl.TransferPrecompile;
+import com.hederahashgraph.api.proto.java.AccountID;
+import com.hederahashgraph.api.proto.java.TokenID;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Predicate;
+import java.util.function.UnaryOperator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class DecodingFacadeTest {
+    private static final int ADDRESS_SKIP_BYTES_LENGTH = 12;
+    private final Address address =
+            Address.wrap(Address.toChecksumAddress("0xabababababababababababababababababababab"));
+    private final byte[] addressBytes;
+    private final byte[] mirrorAddressBytes = new byte[20];
+    private final byte[] leftPaddedAddress = new byte[32];
+
+    {
+        addressBytes = Arrays.copyOfRange(address.value().toByteArray(), 1, 21);
+        System.arraycopy(addressBytes, 0, leftPaddedAddress, ADDRESS_SKIP_BYTES_LENGTH, 20);
+        System.arraycopy(Longs.toByteArray(Long.MAX_VALUE), 0, mirrorAddressBytes, 12, 8);
+    }
+
+    @Mock
+    private UnaryOperator<byte[]> aliasResolver;
+
+    @Mock
+    private Predicate<AccountID> exists;
+
+    @Test
+    void nonExistentMirrorAddressStillResultsInHollowCreationAttempt() {
+        given(aliasResolver.apply(any())).willReturn(mirrorAddressBytes);
+        final var convertedId = convertLeftPaddedAddressToAccountId(leftPaddedAddress, aliasResolver, exists);
+        assertTrue(convertedId.hasAlias());
+        assertArrayEquals(mirrorAddressBytes, convertedId.getAlias().toByteArray());
+    }
+
+    @Test
+    void fungibleTransfersDontRegenerateAliasIfAlreadyPresent() {
+        final var tuples = new Tuple[] {Tuple.of(leftPaddedAddress, 1L)};
+        final var tokenType = TokenID.newBuilder().setTokenNum(1234).build();
+        given(aliasResolver.apply(any())).willReturn(addressBytes);
+
+        final var transfers = DecodingFacade.bindFungibleTransfersFrom(tokenType, tuples, aliasResolver, exists);
+
+        final var transfer = transfers.get(0);
+        final var receiver = transfer.receiver();
+        assertTrue(receiver.hasAlias());
+        assertArrayEquals(addressBytes, receiver.getAlias().toByteArray());
+    }
+
+    @Test
+    void addingSignedAdjustmentsDoesntRegenerateAliasIfAlreadyPresent() {
+        final List<SyntheticTxnFactory.FungibleTokenTransfer> fungibleTransfers = new ArrayList<>();
+        final var tokenType = TokenID.newBuilder().setTokenNum(1234).build();
+        final List<AccountID> accountIds = new ArrayList<>();
+        accountIds.add(AccountID.newBuilder()
+                .setAlias(ByteString.copyFrom(addressBytes))
+                .build());
+        final long[] amounts = new long[] {1L};
+
+        TransferPrecompile.addSignedAdjustments(fungibleTransfers, accountIds, exists, tokenType, amounts);
+
+        final var transfer = fungibleTransfers.get(0);
+        final var receiver = transfer.receiver();
+        assertTrue(receiver.hasAlias());
+        assertArrayEquals(addressBytes, receiver.getAlias().toByteArray());
+    }
+
+    @Test
+    void addingNftExchangesDoesntRegenerateAliasIfAlreadyPresent() {
+        final List<SyntheticTxnFactory.NftExchange> nftExchanges = new ArrayList<>();
+        final var tokenType = TokenID.newBuilder().setTokenNum(1234).build();
+        final List<AccountID> senders = new ArrayList<>();
+        final List<AccountID> receivers = new ArrayList<>();
+        senders.add(AccountID.newBuilder().setAccountNum(12345).build());
+        receivers.add(AccountID.newBuilder()
+                .setAlias(ByteString.copyFrom(addressBytes))
+                .build());
+        final long[] serialNos = new long[] {1L};
+
+        TransferPrecompile.addNftExchanges(nftExchanges, senders, receivers, serialNos, tokenType, exists);
+
+        final var exchange = nftExchanges.get(0);
+        final var receiver = exchange.asGrpc().getReceiverAccountID();
+        assertTrue(receiver.hasAlias());
+        assertArrayEquals(addressBytes, receiver.getAlias().toByteArray());
+    }
+
+    @Test
+    void nonExtantAccountWithAliasAlreadyIsHollowCreationAttempt() {
+        given(aliasResolver.apply(any())).willReturn(addressBytes);
+        final var convertedId = convertLeftPaddedAddressToAccountId(leftPaddedAddress, aliasResolver, exists);
+        assertTrue(convertedId.hasAlias());
+        assertArrayEquals(addressBytes, convertedId.getAlias().toByteArray());
+    }
+
+    @Test
+    void nonMirrorAddressResultsInAliasedAccountId() {
+        given(aliasResolver.apply(any())).willReturn(addressBytes);
+        final var convertedId = convertLeftPaddedAddressToAccountId(leftPaddedAddress, aliasResolver);
+        assertTrue(convertedId.hasAlias());
+        assertArrayEquals(addressBytes, convertedId.getAlias().toByteArray());
+    }
+
+    @Test
+    void mirrorAddressResultsInExpectedId() {
+        given(aliasResolver.apply(any())).willReturn(mirrorAddressBytes);
+        final var expectedId =
+                AccountID.newBuilder().setAccountNum(Long.MAX_VALUE).build();
+        final var convertedId = convertLeftPaddedAddressToAccountId(leftPaddedAddress, aliasResolver);
+        assertEquals(expectedId, convertedId);
+    }
+}

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/AssociatePrecompileSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/AssociatePrecompileSuite.java
@@ -92,6 +92,7 @@ public class AssociatePrecompileSuite extends HapiSuite {
     private static final byte[] ACCOUNT_ADDRESS =
             asAddress(AccountID.newBuilder().build());
     private static final byte[] TOKEN_ADDRESS = asAddress(TokenID.newBuilder().build());
+    private static final String TOKEN_ASSOCIATE = "tokenAssociate";
 
     public static void main(String... args) {
         new AssociatePrecompileSuite().runSuiteAsync();
@@ -199,7 +200,7 @@ public class AssociatePrecompileSuite extends HapiSuite {
                                 .hasKnownStatus(CONTRACT_REVERT_EXECUTED),
                         contractCall(
                                         THE_CONTRACT,
-                                        "tokenAssociate",
+                                        TOKEN_ASSOCIATE,
                                         HapiParserUtil.asHeadlongAddress(asAddress(accountID.get())),
                                         HapiParserUtil.asHeadlongAddress(asAddress(vanillaTokenID.get())))
                                 .payingWith(GENESIS)
@@ -240,7 +241,7 @@ public class AssociatePrecompileSuite extends HapiSuite {
                         cryptoUpdate(ACCOUNT).key(DELEGATE_KEY),
                         contractCall(
                                         THE_CONTRACT,
-                                        "tokenAssociate",
+                                        TOKEN_ASSOCIATE,
                                         HapiParserUtil.asHeadlongAddress(asAddress(accountID.get())),
                                         HapiParserUtil.asHeadlongAddress(invalidAbiArgument))
                                 .payingWith(GENESIS)
@@ -249,7 +250,7 @@ public class AssociatePrecompileSuite extends HapiSuite {
                                 .hasKnownStatus(CONTRACT_REVERT_EXECUTED),
                         contractCall(
                                         THE_CONTRACT,
-                                        "tokenAssociate",
+                                        TOKEN_ASSOCIATE,
                                         HapiParserUtil.asHeadlongAddress(asAddress(accountID.get())),
                                         HapiParserUtil.asHeadlongAddress(asAddress(vanillaTokenID.get())))
                                 .payingWith(GENESIS)
@@ -414,7 +415,7 @@ public class AssociatePrecompileSuite extends HapiSuite {
                                 .treasury(TOKEN_TREASURY)
                                 .exposingCreatedIdTo(idLit ->
                                         tokenAddress.set(idAsHeadlongAddress(HapiPropertySource.asToken(idLit)))))
-                .when(sourcing(() -> contractCall(INNER_CONTRACT, "tokenAssociate", missingAddress, tokenAddress.get())
+                .when(sourcing(() -> contractCall(INNER_CONTRACT, TOKEN_ASSOCIATE, missingAddress, tokenAddress.get())
                         .via(txn)
                         .gas(GAS_TO_OFFER)
                         .hasKnownStatus(CONTRACT_REVERT_EXECUTED)))

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/AssociatePrecompileSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/AssociatePrecompileSuite.java
@@ -17,6 +17,7 @@
 package com.hedera.services.bdd.suites.contract.precompile;
 
 import static com.hedera.services.bdd.spec.HapiPropertySource.asDotDelimitedLongArray;
+import static com.hedera.services.bdd.spec.HapiPropertySource.idAsHeadlongAddress;
 import static com.hedera.services.bdd.spec.HapiSpec.defaultHapiSpec;
 import static com.hedera.services.bdd.spec.assertions.ContractFnResultAsserts.resultWith;
 import static com.hedera.services.bdd.spec.assertions.TransactionRecordAsserts.recordWith;
@@ -38,6 +39,7 @@ import static com.hedera.services.bdd.spec.utilops.CustomSpecAssert.allRunFor;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.childRecordsCheck;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.emptyChildRecordsCheck;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.newKeyNamed;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.sourcing;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.withOpContext;
 import static com.hedera.services.bdd.suites.contract.Utils.asAddress;
 import static com.hedera.services.bdd.suites.token.TokenAssociationSpecs.VANILLA_TOKEN;
@@ -116,7 +118,10 @@ public class AssociatePrecompileSuite extends HapiSuite {
     }
 
     List<HapiSpec> positiveSpecs() {
-        return List.of(nestedAssociateWorksAsExpected(), multipleAssociatePrecompileWithSignatureWorksForFungible());
+        return List.of(
+                nestedAssociateWorksAsExpected(),
+                multipleAssociatePrecompileWithSignatureWorksForFungible(),
+                associateWithMissingEvmAddressHasSaneTxnAndRecord());
     }
 
     /* -- HSCS-PREC-27 from HTS Precompile Test Plan -- */
@@ -391,6 +396,29 @@ public class AssociatePrecompileSuite extends HapiSuite {
                                                 .contractCallResult(
                                                         htsPrecompileResult().withStatus(SUCCESS)))),
                         getAccountInfo(ACCOUNT).hasNoTokenRelationship(VANILLA_TOKEN));
+    }
+
+    private HapiSpec associateWithMissingEvmAddressHasSaneTxnAndRecord() {
+        final AtomicReference<Address> tokenAddress = new AtomicReference<>();
+        final var missingAddress =
+                Address.wrap(Address.toChecksumAddress("0xabababababababababababababababababababab"));
+        final var txn = "txn";
+
+        return defaultHapiSpec("AssociateWithMissingEvmAddressHasSaneTxnAndRecord")
+                .given(
+                        cryptoCreate(TOKEN_TREASURY),
+                        uploadInitCode(INNER_CONTRACT),
+                        contractCreate(INNER_CONTRACT),
+                        tokenCreate(VANILLA_TOKEN)
+                                .tokenType(FUNGIBLE_COMMON)
+                                .treasury(TOKEN_TREASURY)
+                                .exposingCreatedIdTo(idLit ->
+                                        tokenAddress.set(idAsHeadlongAddress(HapiPropertySource.asToken(idLit)))))
+                .when(sourcing(() -> contractCall(INNER_CONTRACT, "tokenAssociate", missingAddress, tokenAddress.get())
+                        .via(txn)
+                        .gas(GAS_TO_OFFER)
+                        .hasKnownStatus(CONTRACT_REVERT_EXECUTED)))
+                .then(getTxnRecord(txn).andAllChildRecords().logged());
     }
 
     /* -- HSCS-PREC-27 from HTS Precompile Test Plan -- */


### PR DESCRIPTION
**Description**:

- Fix convertLeftPaddedAddressToAccountId() to, instead of generating a A.B.C id from an account referenced in a precompile via missing EVM address, generate a 0.0.<alias=0xA...BC> id in the synthetic transaction body.
- Update downstream code to respect this original alias when it is set.



