### PR TITLE
5090: ByteBuffer serialization for all HS virtual key/value serializers

### DIFF
--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/virtual/ContractMerkleDbKeySerializer.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/virtual/ContractMerkleDbKeySerializer.java
@@ -21,7 +21,6 @@ import static com.hedera.node.app.service.mono.state.virtual.ContractKey.getCont
 import static com.hedera.node.app.service.mono.state.virtual.ContractKey.getUint256KeyNonZeroBytesFromPacked;
 import static com.hedera.node.app.service.mono.state.virtual.KeyPackingUtils.deserializeUint256Key;
 
-import com.swirlds.common.io.streams.SerializableDataOutputStream;
 import com.swirlds.merkledb.serialize.KeySerializer;
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -73,13 +72,6 @@ public class ContractMerkleDbKeySerializer implements KeySerializer<ContractKey>
         Objects.requireNonNull(key);
         Objects.requireNonNull(buffer);
         return key.serializeReturningBytesWritten(buffer);
-    }
-
-    @Override
-    public int serialize(final ContractKey key, SerializableDataOutputStream out) throws IOException {
-        Objects.requireNonNull(key);
-        Objects.requireNonNull(out);
-        return key.serializeReturningBytesWritten(out);
     }
 
     // Key deserialization

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/virtual/EntityNumMerkleDbKeySerializer.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/virtual/EntityNumMerkleDbKeySerializer.java
@@ -16,7 +16,6 @@
 
 package com.hedera.node.app.service.mono.state.virtual;
 
-import com.swirlds.common.io.streams.SerializableDataOutputStream;
 import com.swirlds.merkledb.serialize.KeyIndexType;
 import com.swirlds.merkledb.serialize.KeySerializer;
 import java.io.IOException;
@@ -66,14 +65,6 @@ public class EntityNumMerkleDbKeySerializer implements KeySerializer<EntityNumVi
     @Override
     public int getSerializedSize() {
         return EntityNumVirtualKey.sizeInBytes();
-    }
-
-    @Override
-    public int serialize(EntityNumVirtualKey key, SerializableDataOutputStream out) throws IOException {
-        Objects.requireNonNull(key);
-        Objects.requireNonNull(out);
-        key.serialize(out);
-        return getSerializedSize();
     }
 
     @Override

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/virtual/IterableContractMerkleDbValueSerializer.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/virtual/IterableContractMerkleDbValueSerializer.java
@@ -16,7 +16,6 @@
 
 package com.hedera.node.app.service.mono.state.virtual;
 
-import com.swirlds.common.io.streams.SerializableDataOutputStream;
 import com.swirlds.merkledb.serialize.ValueSerializer;
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -57,10 +56,10 @@ public class IterableContractMerkleDbValueSerializer implements ValueSerializer<
     // Value serialization
 
     @Override
-    public int serialize(final IterableContractValue value, final SerializableDataOutputStream out) throws IOException {
+    public int serialize(final IterableContractValue value, final ByteBuffer buf) throws IOException {
         Objects.requireNonNull(value);
-        Objects.requireNonNull(out);
-        value.serialize(out);
+        Objects.requireNonNull(buf);
+        value.serialize(buf);
         return value.getSerializedSize();
     }
 

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/virtual/OnDiskAccountMerkleDbValueSerializer.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/virtual/OnDiskAccountMerkleDbValueSerializer.java
@@ -17,7 +17,6 @@
 package com.hedera.node.app.service.mono.state.virtual;
 
 import com.hedera.node.app.service.mono.state.virtual.entities.OnDiskAccount;
-import com.swirlds.common.io.streams.SerializableDataOutputStream;
 import com.swirlds.merkledb.serialize.ValueSerializer;
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -61,10 +60,10 @@ public class OnDiskAccountMerkleDbValueSerializer implements ValueSerializer<OnD
     }
 
     @Override
-    public int serialize(final OnDiskAccount value, final SerializableDataOutputStream out) throws IOException {
+    public int serialize(final OnDiskAccount value, final ByteBuffer buf) throws IOException {
         Objects.requireNonNull(value);
-        Objects.requireNonNull(out);
-        return value.serializeTo(out::writeByte, out::writeInt, out::writeLong, out::write);
+        Objects.requireNonNull(buf);
+        return value.serializeTo(buf::put, buf::putInt, buf::putLong, buf::put);
     }
 
     // Value deserializatioin

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/virtual/OnDiskTokenRelMerkleDbValueSerializer.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/virtual/OnDiskTokenRelMerkleDbValueSerializer.java
@@ -17,7 +17,6 @@
 package com.hedera.node.app.service.mono.state.virtual;
 
 import com.hedera.node.app.service.mono.state.virtual.entities.OnDiskTokenRel;
-import com.swirlds.common.io.streams.SerializableDataOutputStream;
 import com.swirlds.merkledb.serialize.ValueSerializer;
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -65,10 +64,10 @@ public class OnDiskTokenRelMerkleDbValueSerializer implements ValueSerializer<On
     // Value serialization
 
     @Override
-    public int serialize(final OnDiskTokenRel value, final SerializableDataOutputStream out) throws IOException {
+    public int serialize(final OnDiskTokenRel value, final ByteBuffer buf) throws IOException {
         Objects.requireNonNull(value);
-        Objects.requireNonNull(out);
-        value.serialize(out);
+        Objects.requireNonNull(buf);
+        value.serialize(buf);
         return getSerializedSize();
     }
 

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/virtual/UniqueTokenMerkleDbKeySerializer.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/virtual/UniqueTokenMerkleDbKeySerializer.java
@@ -16,7 +16,6 @@
 
 package com.hedera.node.app.service.mono.state.virtual;
 
-import com.swirlds.common.io.streams.SerializableDataOutputStream;
 import com.swirlds.merkledb.serialize.KeySerializer;
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -62,13 +61,6 @@ public class UniqueTokenMerkleDbKeySerializer implements KeySerializer<UniqueTok
     @Override
     public int getTypicalSerializedSize() {
         return UniqueTokenKey.ESTIMATED_SIZE_BYTES;
-    }
-
-    @Override
-    public int serialize(final UniqueTokenKey key, final SerializableDataOutputStream out) throws IOException {
-        Objects.requireNonNull(key);
-        Objects.requireNonNull(out);
-        return key.serializeTo(out::write);
     }
 
     @Override

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/virtual/UniqueTokenMerkleDbValueSerializer.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/virtual/UniqueTokenMerkleDbValueSerializer.java
@@ -16,7 +16,6 @@
 
 package com.hedera.node.app.service.mono.state.virtual;
 
-import com.swirlds.common.io.streams.SerializableDataOutputStream;
 import com.swirlds.merkledb.serialize.ValueSerializer;
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -60,10 +59,10 @@ public class UniqueTokenMerkleDbValueSerializer implements ValueSerializer<Uniqu
     // Value serialization
 
     @Override
-    public int serialize(final UniqueTokenValue value, final SerializableDataOutputStream out) throws IOException {
+    public int serialize(final UniqueTokenValue value, final ByteBuffer buf) throws IOException {
         Objects.requireNonNull(value);
-        Objects.requireNonNull(out);
-        value.serialize(out);
+        Objects.requireNonNull(buf);
+        value.serialize(buf);
         return value.getSerializedSize();
     }
 

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/virtual/VirtualBlobMerkleDbKeySerializer.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/virtual/VirtualBlobMerkleDbKeySerializer.java
@@ -16,7 +16,6 @@
 
 package com.hedera.node.app.service.mono.state.virtual;
 
-import com.swirlds.common.io.streams.SerializableDataOutputStream;
 import com.swirlds.merkledb.serialize.KeySerializer;
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -56,14 +55,6 @@ public class VirtualBlobMerkleDbKeySerializer implements KeySerializer<VirtualBl
 
     @Override
     public int getSerializedSize() {
-        return VirtualBlobKey.sizeInBytes();
-    }
-
-    @Override
-    public int serialize(final VirtualBlobKey key, final SerializableDataOutputStream out) throws IOException {
-        Objects.requireNonNull(key);
-        Objects.requireNonNull(out);
-        key.serialize(out);
         return VirtualBlobKey.sizeInBytes();
     }
 

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/virtual/VirtualBlobMerkleDbValueSerializer.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/virtual/VirtualBlobMerkleDbValueSerializer.java
@@ -16,7 +16,6 @@
 
 package com.hedera.node.app.service.mono.state.virtual;
 
-import com.swirlds.common.io.streams.SerializableDataOutputStream;
 import com.swirlds.merkledb.serialize.ValueSerializer;
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -59,8 +58,8 @@ public class VirtualBlobMerkleDbValueSerializer implements ValueSerializer<Virtu
     // Value serialization
 
     @Override
-    public int serialize(final VirtualBlobValue value, final SerializableDataOutputStream out) throws IOException {
-        value.serialize(out);
+    public int serialize(final VirtualBlobValue value, final ByteBuffer buf) throws IOException {
+        value.serialize(buf);
         return Integer.BYTES + value.getData().length; // data size (int) + data
     }
 


### PR DESCRIPTION
Fix summary:

* All HS key and value serializers for MerkleDb are changed according to the latest MerkleDb API changes. In particular, there is just one `serialize()` method (there were two previously), which writes data to a specified byte buffer (was: output stream)
* *NB*: this branch will not compile, until HS is switched to the latest version of the Swirlds platform

Fixes: https://github.com/hashgraph/hedera-services/issues/5090
