### PR TITLE
05895 - fixing startup crash due to new SwirldMain configuration

### DIFF
--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/Browser.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/Browser.java
@@ -213,7 +213,7 @@ public class Browser {
 
         // Assume all locally run instances provide the same configuration definitions to the configuration builder.
         if (appMains.size() > 0) {
-            appMains.get(0L).updateConfigurationBuilder(configurationBuilder);
+            appMains.values().iterator().next().updateConfigurationBuilder(configurationBuilder);
         }
 
         this.configuration = configurationBuilder.build();


### PR DESCRIPTION
**Description**:
Fixes a startup crash
* changed access of `appsMain.get(0L)` to an iteration over the values for the first next() value. 

**Related issue(s)**:

Fixes #5895 

