### PR TITLE
05584 - automating address book initialization tests

### DIFF
--- a/platform-sdk/platform-apps/tests/AddressBookTestingTool/README.md
+++ b/platform-sdk/platform-apps/tests/AddressBookTestingTool/README.md
@@ -16,31 +16,21 @@ uncomment the AddressBookTestingTool.jar
  app,    AddressBookTestingTool.jar,
 ```
 
-### AddressTestingToolMain.java
+### settings.txt
 
-If following these instructions sequentially, ensure the software version is 1.
+Add the following lines to the settings.txt file
 
-```java
-private static BasicSoftwareVersion softwareVersion = new BasicSoftwareVersion(1);
 ```
-
-### AddressTestingToolState.java
-
-If following these instructions sequentially, ensure the staking profile is 1.
-
-```java
-private int stakingProfile = 1;
+addressBookTestingTool.softwareVersion, 1
+addressBookTestingTool.stakingBehavior, 1
 ```
-
-
-
 ## Testing Genesis Behavior
 
 ### Force Use of Config Address Book on Genesis
 #### Instructions
 1. Delete `sdk/data/saved` directory if it exists
 2. Ensure settings.txt has `state.saveStatePeriod,     0`
-3. Add to settings.txt the value `state.forceUseOfConfigAddressBook, true`
+3. Add to settings.txt the value `addressBook.forceUseOfConfigAddressBook, true`
 4. Run the app for a short time.
 
 #### Validation
@@ -48,7 +38,7 @@ private int stakingProfile = 1;
 * check the swirlds.log for the text
 
 ```
-AddressBookInitializer: A setting has forced the use of the configuration address.
+AddressBookInitializer: Overriding the address book in the state with the address book from config.txt
 ```
 
 * check the directory `sdk/data/saved/address_book` for files
@@ -64,7 +54,7 @@ AddressBookInitializer: A setting has forced the use of the configuration addres
 #### Instructions
 1. Delete `sdk/data/saved` directory if it exists
 2. **Ensure settings.txt has `state.saveStatePeriod,     10` (differs from previous section)**
-3. **Ensure settings.txt has the value `state.forceUseOfConfigAddressBook, false` (differs from previous section)**
+3. **Ensure settings.txt has the value `addressBook.forceUseOfConfigAddressBook, false` (differs from previous section)**
 4. **Run the app for 20 seconds.  (differs from previous section)**
 
 #### Validation
@@ -88,7 +78,7 @@ AddressBookInitializer: The loaded signed state is null. The candidateAddressBoo
 ### No Software Upgrade, Use Saved State Address Book
 #### Instructions
 1. Ensure settings.txt has `state.saveStatePeriod,     10`
-2. Ensure settings.txt has the value `state.forceUseOfConfigAddressBook, false`
+2. Ensure settings.txt has the value `addressBook.forceUseOfConfigAddressBook, false`
 3. Run the app for 20 seconds.
 
 #### Validation
@@ -110,7 +100,7 @@ AddressBookInitializer: No Software Upgrade. Continuing with software version 1 
 ### No Software Upgrade, Force Use of Config Address Book
 #### Instructions
 1. Ensure settings.txt has `state.saveStatePeriod,     10`
-2. **Ensure settings.txt has the value `state.forceUseOfConfigAddressBook, true` (differs from previous section)**
+2. **Ensure settings.txt has the value `addressBook.forceUseOfConfigAddressBook, true` (differs from previous section)**
 3. Run the app for 20 seconds.
 
 #### Validation
@@ -118,7 +108,7 @@ AddressBookInitializer: No Software Upgrade. Continuing with software version 1 
 * check the swirlds.log for the text
 
 ```
-AddressBookInitializer: A setting has forced the use of the configuration address.
+AddressBookInitializer: Overriding the address book in the state with the address book from config.txt
 ```
 
 * check the directory `sdk/data/saved/address_book` for the latest files
@@ -132,7 +122,7 @@ AddressBookInitializer: A setting has forced the use of the configuration addres
 ### No Software Upgrade, Use Saved State Address Book, Matches Config
 #### Instructions
 1. Ensure settings.txt has `state.saveStatePeriod,     10`
-2. **Ensure settings.txt has the value `state.forceUseOfConfigAddressBook, false` (differs from previous section)**
+2. **Ensure settings.txt has the value `addressBook.forceUseOfConfigAddressBook, false` (differs from previous section)**
 3. Run the app for 20 seconds.
 
 #### Validation
@@ -153,13 +143,12 @@ AddressBookInitializer: No Software Upgrade. Continuing with software version 1 
 
 ## Testing Non-Genesis Behavior, Software Upgrade
 
-### Software Upgrade, Force Use of Config Address Book
+### Software Upgrade, Staking Behavior 2
 #### Instructions
 1. Ensure settings.txt has `state.saveStatePeriod,     10`
-2. Ensure settings.txt has the value `state.forceUseOfConfigAddressBook, false`
-3. **Increase the softwareVersion in AddressBookTestingToolMain.java to 2. (differs from previous section)**
-4. **Change the stakingProfile in AddressBookTestingToolState.java to 2. (differs from previous section)**
-5. **recompile the application: assemble ONLY!!!!.(differs from previous section)**
+2. Ensure settings.txt has the value `addressBook.forceUseOfConfigAddressBook, false`
+3. **Ensure settings.txt has the value `addressBookTestingTool.softwareVersion, 2` (differs from previous section)**
+4. **Ensure settings.txt has the value `addressBookTestingTool.stakingBehavior, 2` (differs from previous section)**
 6. Run the app for 20 seconds.
 
 #### Validation
@@ -176,4 +165,29 @@ AddressBookInitializer: Software Upgrade from version 1 to 2. The address book s
   * usedAddressBook_v1_<date>.txt.debug
     * The configuration address book is the same as what is in config.txt
     * The state saved address book is the same as what is in config.txt
+    * **the used address book matches the content of the non-debug .txt file. (differs from previous section)**
+
+
+### Software Upgrade, Force Use Of Config Address Book
+#### Instructions
+1. Ensure settings.txt has `state.saveStatePeriod,     10`
+2. **Ensure settings.txt has the value `addressBook.forceUseOfConfigAddressBook, true` (differs from previous section)**
+3. **Ensure settings.txt has the value `addressBookTestingTool.softwareVersion, 3` (differs from previous section)**
+4. **Ensure settings.txt has the value `addressBookTestingTool.stakingBehavior, 1` (differs from previous section)**
+6. Run the app for 20 seconds.
+
+#### Validation
+
+* check the swirlds.log for the text
+
+```
+AddressBookInitializer: Overriding the address book in the state with the address book from config.txt
+```
+
+* check the directory `sdk/data/saved/address_book` for the latest files
+  * usedAddressBook_v1_<date>.txt
+    * **matches the addresses in the config.txt, including stake value. (differs from previous section)**
+  * usedAddressBook_v1_<date>.txt.debug
+    * The configuration address book is the same as what is in config.txt
+    * **The state saved address book is the config.txt addresses with stake values incrementally increasing starting from 0 (differs from previous section)**
     * **the used address book matches the content of the non-debug .txt file. (differs from previous section)**

--- a/platform-sdk/platform-apps/tests/AddressBookTestingTool/README.md
+++ b/platform-sdk/platform-apps/tests/AddressBookTestingTool/README.md
@@ -197,14 +197,29 @@ Errors are logged if any of the following conditions are violated.
     * **the state saved address book contains the addresses in the config.txt, all with stake 10. (differs from previous section)**
     * **the used address book has the text `The Configuration Address Book Was Used.` (differs from previous section)**
 
-### Software Upgrade, Staking Behavior 2
-# START HERE WITH CONTINUING TO REVISE THE TEST DESCRIPTIONS FOR AUTOMATION
+### Test Scenario 5: Software Upgrade, Staking Behavior 2
 #### Instructions
-1. Ensure settings.txt has `state.saveStatePeriod,     10`
-2. Ensure settings.txt has the value `addressBook.forceUseOfConfigAddressBook, false`
-3. **Ensure settings.txt has the value `addressBookTestingTool.softwareVersion, 2` (differs from previous section)**
-4. **Ensure settings.txt has the value `addressBookTestingTool.stakingBehavior, 2` (differs from previous section)**
-6. Run the app for 20 seconds.
+
+1. Delete `sdk/data/saved` directory if it exists
+2. Ensure settings.txt has the following values
+```
+state.saveStatePeriod,                    10
+addressBook.forceUseOfConfigAddressBook,  false
+addressBookTestingTool.testScenario,      0
+addressBookTestingTool.softwareVersion,   1
+addressBookTestingTool.stakingBehavior,   1
+```
+3. Run the app for 60 seconds
+4. Stop the app
+5. Ensure settings.txt has the following values
+```
+state.saveStatePeriod,                    10
+addressBook.forceUseOfConfigAddressBook,  false
+addressBookTestingTool.testScenario,      5
+addressBookTestingTool.softwareVersion,   2
+addressBookTestingTool.stakingBehavior,   2
+```
+6. Run the app for 60 seconds.
 
 #### Validation
 
@@ -213,6 +228,14 @@ Errors are logged if any of the following conditions are violated.
 ```
 AddressBookInitializer: Software Upgrade from version 1 to 2. The address book stake will be updated by the saved state's SwirldState.
 ```
+and
+```
+AddressBookTestingToolState: Validating test scenario 5.
+```
+
+* check that there are no errors or exceptions in the swirlds.log
+
+Errors are logged if any of the following conditions are violated.
 
 * check the directory `sdk/data/saved/address_book` for the latest files
   * usedAddressBook_v1_<date>.txt
@@ -222,14 +245,29 @@ AddressBookInitializer: Software Upgrade from version 1 to 2. The address book s
     * The state saved address book is the same as what is in config.txt
     * **the used address book matches the content of the non-debug .txt file. (differs from previous section)**
 
-
-### Software Upgrade, Force Use Of Config Address Book
+### Test Scenario 6: Software Upgrade, Force Use Of Config Address Book
 #### Instructions
-1. Ensure settings.txt has `state.saveStatePeriod,     10`
-2. **Ensure settings.txt has the value `addressBook.forceUseOfConfigAddressBook, true` (differs from previous section)**
-3. **Ensure settings.txt has the value `addressBookTestingTool.softwareVersion, 3` (differs from previous section)**
-4. **Ensure settings.txt has the value `addressBookTestingTool.stakingBehavior, 1` (differs from previous section)**
-6. Run the app for 20 seconds.
+
+1. Delete `sdk/data/saved` directory if it exists
+2. Ensure settings.txt has the following values
+```
+state.saveStatePeriod,                    10
+addressBook.forceUseOfConfigAddressBook,  false
+addressBookTestingTool.testScenario,      0
+addressBookTestingTool.softwareVersion,   1
+addressBookTestingTool.stakingBehavior,   1
+```
+3. Run the app for 60 seconds
+4. Stop the app
+5. Ensure settings.txt has the following values
+```
+state.saveStatePeriod,                    10
+addressBook.forceUseOfConfigAddressBook,  true
+addressBookTestingTool.testScenario,      6
+addressBookTestingTool.softwareVersion,   2
+addressBookTestingTool.stakingBehavior,   2
+```
+6. Run the app for 60 seconds.
 
 #### Validation
 
@@ -238,6 +276,14 @@ AddressBookInitializer: Software Upgrade from version 1 to 2. The address book s
 ```
 AddressBookInitializer: Overriding the address book in the state with the address book from config.txt
 ```
+and
+```
+AddressBookTestingToolState: Validating test scenario 5.
+```
+
+* check that there are no errors or exceptions in the swirlds.log
+
+Errors are logged if any of the following conditions are violated.
 
 * check the directory `sdk/data/saved/address_book` for the latest files
   * usedAddressBook_v1_<date>.txt

--- a/platform-sdk/platform-apps/tests/AddressBookTestingTool/README.md
+++ b/platform-sdk/platform-apps/tests/AddressBookTestingTool/README.md
@@ -63,7 +63,7 @@ Errors are logged if any of the following conditions are violated.
     * the state saved address book was null
     * the used address book text says `The Configuration Address Book Was Used.`
 
-### Test Scenario 2: Call to SwirldState.updateStake() on Genesis
+### Test Scenario 2: Unforced use of Config Address Book on Genesis
 #### Instructions
 1. Delete `sdk/data/saved` directory if it exists
 2. Ensure settings.txt has the following values
@@ -94,11 +94,11 @@ Errors are logged if any of the following conditions are violated.
 
 * check the directory `sdk/data/saved/address_book` for files
   * usedAddressBook_v1_<date>.txt
-    * **contains the addresses in the config.txt, all with stake 10. (differs from previous section)**
+    * contains the addresses in the config.txt with identical stake
   * usedAddressBook_v1_<date>.txt.debug
     * The configuration address book is the same as what is in config.txt
     * the state saved address book was null
-    * **the used address book matches the content of the non-debug .txt file. (differs from previous section)**
+    * the used address book text says `The Configuration Address Book Was Used.`
 
 ## Testing Non-Genesis Behavior, No Software Upgrade
 

--- a/platform-sdk/platform-apps/tests/AddressBookTestingTool/README.md
+++ b/platform-sdk/platform-apps/tests/AddressBookTestingTool/README.md
@@ -26,12 +26,15 @@ addressBookTestingTool.stakingBehavior, 1
 ```
 ## Testing Genesis Behavior
 
-### Force Use of Config Address Book on Genesis
+### Test Scenario 1: Force Use of Config Address Book on Genesis
 #### Instructions
 1. Delete `sdk/data/saved` directory if it exists
-2. Ensure settings.txt has `state.saveStatePeriod,     0`
-3. Add to settings.txt the value `addressBook.forceUseOfConfigAddressBook, true`
-4. Run the app for a short time.
+2. Ensure settings.txt has the value `state.saveStatePeriod,     0`
+3. Ensure settings.txt has the value `addressBook.forceUseOfConfigAddressBook, true`
+4. Ensure settings.txt has the value `addressBookTestingTool.testScenario, 1`
+5. Ensure settings.txt has the value `addressBookTestingTool.softwareVersion, 1`
+6. Ensure settings.txt has the value `addressBookTestingTool.stakingBehavior, 1`
+7. Run the app for 60 seconds
 
 #### Validation
 
@@ -40,6 +43,14 @@ addressBookTestingTool.stakingBehavior, 1
 ```
 AddressBookInitializer: Overriding the address book in the state with the address book from config.txt
 ```
+and
+```
+AddressBookTestingToolState: Validating test scenario 1.
+```
+
+* check that there are no errors or exceptions in the swirlds.log
+
+Errors are logged if any of the following conditions are violated.
 
 * check the directory `sdk/data/saved/address_book` for files
   * usedAddressBook_v1_<date>.txt
@@ -49,13 +60,15 @@ AddressBookInitializer: Overriding the address book in the state with the addres
     * the state saved address book was null
     * the used address book text says `The Configuration Address Book Was Used.`
 
-
-### Call to SwirldState.updateStake() on Genesis
+### Test Scenario 2: Call to SwirldState.updateStake() on Genesis
 #### Instructions
 1. Delete `sdk/data/saved` directory if it exists
-2. **Ensure settings.txt has `state.saveStatePeriod,     10` (differs from previous section)**
-3. **Ensure settings.txt has the value `addressBook.forceUseOfConfigAddressBook, false` (differs from previous section)**
-4. **Run the app for 20 seconds.  (differs from previous section)**
+2. Ensure settings.txt has the value `state.saveStatePeriod,     0`
+3. Ensure settings.txt has the value `addressBook.forceUseOfConfigAddressBook, false`
+4. Ensure settings.txt has the value `addressBookTestingTool.testScenario, 2`
+5. Ensure settings.txt has the value `addressBookTestingTool.softwareVersion, 1`
+6. Ensure settings.txt has the value `addressBookTestingTool.stakingBehavior, 1`
+7. Run the app for 60 seconds
 
 #### Validation
 
@@ -64,6 +77,14 @@ AddressBookInitializer: Overriding the address book in the state with the addres
 ```
 AddressBookInitializer: The loaded signed state is null. The candidateAddressBook is set to genesisSwirldState.updateStake(configAddressBook, null).
 ```
+and
+```
+AddressBookTestingToolState: Validating test scenario 2.
+```
+
+* check that there are no errors or exceptions in the swirlds.log
+
+Errors are logged if any of the following conditions are violated.
 
 * check the directory `sdk/data/saved/address_book` for files
   * usedAddressBook_v1_<date>.txt
@@ -75,11 +96,22 @@ AddressBookInitializer: The loaded signed state is null. The candidateAddressBoo
 
 ## Testing Non-Genesis Behavior, No Software Upgrade
 
-### No Software Upgrade, Use Saved State Address Book
+### Test Scenario 3: No Software Upgrade, Use Saved State Address Book
 #### Instructions
-1. Ensure settings.txt has `state.saveStatePeriod,     10`
-2. Ensure settings.txt has the value `addressBook.forceUseOfConfigAddressBook, false`
-3. Run the app for 20 seconds.
+1. Delete `sdk/data/saved` directory if it exists
+2. Ensure settings.txt has the value `state.saveStatePeriod,     10`
+3. Ensure settings.txt has the value `addressBook.forceUseOfConfigAddressBook, false`
+4. Ensure settings.txt has the value `addressBookTestingTool.testScenario, 0`
+5. Ensure settings.txt has the value `addressBookTestingTool.softwareVersion, 1`
+6. Ensure settings.txt has the value `addressBookTestingTool.stakingBehavior, 1`
+7. Run the app for 60 seconds
+8. Stop the app
+9. Ensure settings.txt has the value `state.saveStatePeriod,     10`
+10. Ensure settings.txt has the value `addressBook.forceUseOfConfigAddressBook, false`
+11. Ensure settings.txt has the value `addressBookTestingTool.testScenario, 3`
+12. Ensure settings.txt has the value `addressBookTestingTool.softwareVersion, 1`
+13. Ensure settings.txt has the value `addressBookTestingTool.stakingBehavior, 2`
+14. Run the app for 60 seconds.
 
 #### Validation
 
@@ -88,6 +120,14 @@ AddressBookInitializer: The loaded signed state is null. The candidateAddressBoo
 ```
 AddressBookInitializer: No Software Upgrade. Continuing with software version 1 and using the loaded signed state's address book and stake values.
 ```
+and
+```
+AddressBookTestingToolState: Validating test scenario 3.
+```
+
+* check that there are no errors or exceptions in the swirlds.log
+
+Errors are logged if any of the following conditions are violated.
 
 * check the directory `sdk/data/saved/address_book` for the latest files
   * usedAddressBook_v1_<date>.txt
@@ -98,6 +138,7 @@ AddressBookInitializer: No Software Upgrade. Continuing with software version 1 
     * **the used address book has the text `The State Saved Address Book Was Used.` (differs from previous section)**
 
 ### No Software Upgrade, Force Use of Config Address Book
+# **START HERE TO CONTINUE UPDATING TEST DEFINITIONS**
 #### Instructions
 1. Ensure settings.txt has `state.saveStatePeriod,     10`
 2. **Ensure settings.txt has the value `addressBook.forceUseOfConfigAddressBook, true` (differs from previous section)**

--- a/platform-sdk/platform-apps/tests/AddressBookTestingTool/README.md
+++ b/platform-sdk/platform-apps/tests/AddressBookTestingTool/README.md
@@ -29,12 +29,15 @@ addressBookTestingTool.stakingBehavior, 1
 ### Test Scenario 1: Force Use of Config Address Book on Genesis
 #### Instructions
 1. Delete `sdk/data/saved` directory if it exists
-2. Ensure settings.txt has the value `state.saveStatePeriod,     0`
-3. Ensure settings.txt has the value `addressBook.forceUseOfConfigAddressBook, true`
-4. Ensure settings.txt has the value `addressBookTestingTool.testScenario, 1`
-5. Ensure settings.txt has the value `addressBookTestingTool.softwareVersion, 1`
-6. Ensure settings.txt has the value `addressBookTestingTool.stakingBehavior, 1`
-7. Run the app for 60 seconds
+2. Ensure settings.txt has the following values
+```
+state.saveStatePeriod,                    0
+addressBook.forceUseOfConfigAddressBook,  true
+addressBookTestingTool.testScenario,      1
+addressBookTestingTool.softwareVersion,   1
+addressBookTestingTool.stakingBehavior,   1
+```
+3. Run the app for 60 seconds
 
 #### Validation
 
@@ -63,12 +66,15 @@ Errors are logged if any of the following conditions are violated.
 ### Test Scenario 2: Call to SwirldState.updateStake() on Genesis
 #### Instructions
 1. Delete `sdk/data/saved` directory if it exists
-2. Ensure settings.txt has the value `state.saveStatePeriod,     0`
-3. Ensure settings.txt has the value `addressBook.forceUseOfConfigAddressBook, false`
-4. Ensure settings.txt has the value `addressBookTestingTool.testScenario, 2`
-5. Ensure settings.txt has the value `addressBookTestingTool.softwareVersion, 1`
-6. Ensure settings.txt has the value `addressBookTestingTool.stakingBehavior, 1`
-7. Run the app for 60 seconds
+2. Ensure settings.txt has the following values
+```
+state.saveStatePeriod,                    0
+addressBook.forceUseOfConfigAddressBook,  false
+addressBookTestingTool.testScenario,      2
+addressBookTestingTool.softwareVersion,   1
+addressBookTestingTool.stakingBehavior,   1
+```
+3. Run the app for 60 seconds
 
 #### Validation
 
@@ -99,19 +105,25 @@ Errors are logged if any of the following conditions are violated.
 ### Test Scenario 3: No Software Upgrade, Use Saved State Address Book
 #### Instructions
 1. Delete `sdk/data/saved` directory if it exists
-2. Ensure settings.txt has the value `state.saveStatePeriod,     10`
-3. Ensure settings.txt has the value `addressBook.forceUseOfConfigAddressBook, false`
-4. Ensure settings.txt has the value `addressBookTestingTool.testScenario, 0`
-5. Ensure settings.txt has the value `addressBookTestingTool.softwareVersion, 1`
-6. Ensure settings.txt has the value `addressBookTestingTool.stakingBehavior, 1`
-7. Run the app for 60 seconds
-8. Stop the app
-9. Ensure settings.txt has the value `state.saveStatePeriod,     10`
-10. Ensure settings.txt has the value `addressBook.forceUseOfConfigAddressBook, false`
-11. Ensure settings.txt has the value `addressBookTestingTool.testScenario, 3`
-12. Ensure settings.txt has the value `addressBookTestingTool.softwareVersion, 1`
-13. Ensure settings.txt has the value `addressBookTestingTool.stakingBehavior, 2`
-14. Run the app for 60 seconds.
+2. Ensure settings.txt has the following values
+```
+state.saveStatePeriod,                    10
+addressBook.forceUseOfConfigAddressBook,  false
+addressBookTestingTool.testScenario,      0
+addressBookTestingTool.softwareVersion,   1
+addressBookTestingTool.stakingBehavior,   1
+```
+3. Run the app for 60 seconds
+4. Stop the app
+5. Ensure settings.txt has the following values
+```
+state.saveStatePeriod,                    10
+addressBook.forceUseOfConfigAddressBook,  false
+addressBookTestingTool.testScenario,      3
+addressBookTestingTool.softwareVersion,   1
+addressBookTestingTool.stakingBehavior,   2
+```
+6. Run the app for 60 seconds.
 
 #### Validation
 
@@ -137,12 +149,29 @@ Errors are logged if any of the following conditions are violated.
     * **the state saved address book matches the content of the non-debug .txt file. (differs from previous section)**
     * **the used address book has the text `The State Saved Address Book Was Used.` (differs from previous section)**
 
-### No Software Upgrade, Force Use of Config Address Book
-# **START HERE TO CONTINUE UPDATING TEST DEFINITIONS**
+### Test Scenario 4: No Software Upgrade, Force Use of Config Address Book
 #### Instructions
-1. Ensure settings.txt has `state.saveStatePeriod,     10`
-2. **Ensure settings.txt has the value `addressBook.forceUseOfConfigAddressBook, true` (differs from previous section)**
-3. Run the app for 20 seconds.
+
+1. Delete `sdk/data/saved` directory if it exists
+2. Ensure settings.txt has the following values
+```
+state.saveStatePeriod,                    10
+addressBook.forceUseOfConfigAddressBook,  false
+addressBookTestingTool.testScenario,      0
+addressBookTestingTool.softwareVersion,   1
+addressBookTestingTool.stakingBehavior,   1
+```
+3. Run the app for 60 seconds
+4. Stop the app
+5. Ensure settings.txt has the following values
+```
+state.saveStatePeriod,                    10
+addressBook.forceUseOfConfigAddressBook,  true
+addressBookTestingTool.testScenario,      4
+addressBookTestingTool.softwareVersion,   1
+addressBookTestingTool.stakingBehavior,   2
+```
+6. Run the app for 60 seconds.
 
 #### Validation
 
@@ -151,6 +180,14 @@ Errors are logged if any of the following conditions are violated.
 ```
 AddressBookInitializer: Overriding the address book in the state with the address book from config.txt
 ```
+and
+```
+AddressBookTestingToolState: Validating test scenario 4.
+```
+
+* check that there are no errors or exceptions in the swirlds.log
+
+Errors are logged if any of the following conditions are violated.
 
 * check the directory `sdk/data/saved/address_book` for the latest files
   * usedAddressBook_v1_<date>.txt
@@ -160,31 +197,8 @@ AddressBookInitializer: Overriding the address book in the state with the addres
     * **the state saved address book contains the addresses in the config.txt, all with stake 10. (differs from previous section)**
     * **the used address book has the text `The Configuration Address Book Was Used.` (differs from previous section)**
 
-### No Software Upgrade, Use Saved State Address Book, Matches Config
-#### Instructions
-1. Ensure settings.txt has `state.saveStatePeriod,     10`
-2. **Ensure settings.txt has the value `addressBook.forceUseOfConfigAddressBook, false` (differs from previous section)**
-3. Run the app for 20 seconds.
-
-#### Validation
-
-* check the swirlds.log for the text
-
-```
-AddressBookInitializer: No Software Upgrade. Continuing with software version 1 and using the loaded signed state's address book and stake values.
-```
-
-* check the directory `sdk/data/saved/address_book` for the latest files
-  * usedAddressBook_v1_<date>.txt
-    * matches the addresses in the config.txt, including stake value.
-  * usedAddressBook_v1_<date>.txt.debug
-    * The configuration address book is the same as what is in config.txt
-    * **The state saved address book is the same as what is in the config.txt (differs from previous section)**
-    * **the used address book has the text `The State Saved Address Book Was Used.` (differs from previous section)**
-
-## Testing Non-Genesis Behavior, Software Upgrade
-
 ### Software Upgrade, Staking Behavior 2
+# START HERE WITH CONTINUING TO REVISE THE TEST DESCRIPTIONS FOR AUTOMATION
 #### Instructions
 1. Ensure settings.txt has `state.saveStatePeriod,     10`
 2. Ensure settings.txt has the value `addressBook.forceUseOfConfigAddressBook, false`

--- a/platform-sdk/platform-apps/tests/AddressBookTestingTool/src/main/java/com/swirlds/demo/addressbook/AddressBookTestingToolConfig.java
+++ b/platform-sdk/platform-apps/tests/AddressBookTestingTool/src/main/java/com/swirlds/demo/addressbook/AddressBookTestingToolConfig.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.swirlds.demo.addressbook;
+
+import com.swirlds.config.api.ConfigData;
+import com.swirlds.config.api.ConfigProperty;
+
+/**
+ * Config for address books and utilities that deal with address books.
+ *
+ * @param softwareVersion
+ * 		The integer value of the software version of the AddressBookTestingToolMain SwirldMain application.
+ * @param stakingBehavior
+ *      The integer value of the staking behavior of the AddressBookTestingToolState SwirldState.
+ */
+@ConfigData("addressBookTestingTool")
+public record AddressBookTestingToolConfig(
+        @ConfigProperty(defaultValue = "1") int softwareVersion,
+        @ConfigProperty(defaultValue = "1") int stakingBehavior) {}

--- a/platform-sdk/platform-apps/tests/AddressBookTestingTool/src/main/java/com/swirlds/demo/addressbook/AddressBookTestingToolConfig.java
+++ b/platform-sdk/platform-apps/tests/AddressBookTestingTool/src/main/java/com/swirlds/demo/addressbook/AddressBookTestingToolConfig.java
@@ -26,8 +26,11 @@ import com.swirlds.config.api.ConfigProperty;
  * 		The integer value of the software version of the AddressBookTestingToolMain SwirldMain application.
  * @param stakingBehavior
  *      The integer value of the staking behavior of the AddressBookTestingToolState SwirldState.
+ * @param testScenario
+ *     The integer value of the test scenario being run for validation.
  */
 @ConfigData("addressBookTestingTool")
 public record AddressBookTestingToolConfig(
         @ConfigProperty(defaultValue = "1") int softwareVersion,
-        @ConfigProperty(defaultValue = "1") int stakingBehavior) {}
+        @ConfigProperty(defaultValue = "0") int stakingBehavior,
+        @ConfigProperty(defaultValue = "0") int testScenario) {}

--- a/platform-sdk/platform-apps/tests/AddressBookTestingTool/src/main/java/com/swirlds/demo/addressbook/AddressBookTestingToolMain.java
+++ b/platform-sdk/platform-apps/tests/AddressBookTestingTool/src/main/java/com/swirlds/demo/addressbook/AddressBookTestingToolMain.java
@@ -70,9 +70,9 @@ public class AddressBookTestingToolMain implements SwirldMain {
 
     @Override
     public void setConfiguration(@NonNull final Configuration configuration) {
-        final int softwareVersion =
+        final int softVersion =
                 configuration.getConfigData(AddressBookTestingToolConfig.class).softwareVersion();
-        this.softwareVersion = new BasicSoftwareVersion(softwareVersion);
+        this.softwareVersion = new BasicSoftwareVersion(softVersion);
     }
 
     /**

--- a/platform-sdk/platform-apps/tests/AddressBookTestingTool/src/main/java/com/swirlds/demo/addressbook/AddressBookTestingToolMain.java
+++ b/platform-sdk/platform-apps/tests/AddressBookTestingTool/src/main/java/com/swirlds/demo/addressbook/AddressBookTestingToolMain.java
@@ -24,6 +24,8 @@ import com.swirlds.common.system.Platform;
 import com.swirlds.common.system.PlatformWithDeprecatedMethods;
 import com.swirlds.common.system.SwirldMain;
 import com.swirlds.common.system.SwirldState;
+import com.swirlds.config.api.Configuration;
+import com.swirlds.config.api.ConfigurationBuilder;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.security.SecureRandom;
 import java.util.Objects;
@@ -48,8 +50,8 @@ public class AddressBookTestingToolMain implements SwirldMain {
     /** The logger for this class. */
     private static final Logger logger = LogManager.getLogger(AddressBookTestingToolMain.class);
 
-    /** The default software version of this application. */
-    private static final BasicSoftwareVersion softwareVersion = new BasicSoftwareVersion(1);
+    /** The software version of this application.  If not configured, defaults to 0 */
+    private BasicSoftwareVersion softwareVersion = new BasicSoftwareVersion(0);
 
     /** The platform. */
     private Platform platform;
@@ -59,6 +61,18 @@ public class AddressBookTestingToolMain implements SwirldMain {
 
     public AddressBookTestingToolMain() {
         logger.info(STARTUP.getMarker(), "constructor called in Main.");
+    }
+
+    @Override
+    public void updateConfigurationBuilder(@NonNull final ConfigurationBuilder configurationBuilder) {
+        configurationBuilder.withConfigDataType(AddressBookTestingToolConfig.class);
+    }
+
+    @Override
+    public void setConfiguration(@NonNull final Configuration configuration) {
+        final int softwareVersion =
+                configuration.getConfigData(AddressBookTestingToolConfig.class).softwareVersion();
+        this.softwareVersion = new BasicSoftwareVersion(softwareVersion);
     }
 
     /**

--- a/platform-sdk/platform-apps/tests/AddressBookTestingTool/src/main/java/com/swirlds/demo/addressbook/AddressBookTestingToolState.java
+++ b/platform-sdk/platform-apps/tests/AddressBookTestingTool/src/main/java/com/swirlds/demo/addressbook/AddressBookTestingToolState.java
@@ -296,7 +296,7 @@ public class AddressBookTestingToolState extends PartialMerkleLeaf implements Sw
                 case 1:
                     return testScenario1GenesisForceUseOfConfigAddressBook();
                 case 2:
-                    return testScenario2GenesisSwirldStateUpdateStake();
+                    return testScenario2GenesisUnforcedUseOfConfigAddressBook();
                 case 3:
                     return testScenario3NoSoftwareUpdateUseSavedStateAddressBook();
                 case 4:
@@ -385,7 +385,7 @@ public class AddressBookTestingToolState extends PartialMerkleLeaf implements Sw
                 && equalsAsConfigText(platformAddressBook, updatedAddressBook, false);
     }
 
-    private boolean testScenario2GenesisSwirldStateUpdateStake() throws IOException, ParseException {
+    private boolean testScenario2GenesisUnforcedUseOfConfigAddressBook() throws IOException, ParseException {
         if (!checkTestScenarioConditions(false, 2, 1, 1)) {
             return false;
         }
@@ -395,9 +395,9 @@ public class AddressBookTestingToolState extends PartialMerkleLeaf implements Sw
         final AddressBook usedAddressBook = getUsedAddressBook();
         final AddressBook updatedAddressBook = updateStake(configAddressBook.copy());
 
-        return equalsAsConfigText(platformAddressBook, configAddressBook, false)
+        return equalsAsConfigText(platformAddressBook, configAddressBook, true)
                 && equalsAsConfigText(platformAddressBook, usedAddressBook, true)
-                && equalsAsConfigText(platformAddressBook, updatedAddressBook, true)
+                && equalsAsConfigText(platformAddressBook, updatedAddressBook, false)
                 && theStateAddressBookWasNull(true);
     }
 

--- a/platform-sdk/platform-apps/tests/AddressBookTestingTool/src/main/java/com/swirlds/demo/addressbook/AddressBookTestingToolState.java
+++ b/platform-sdk/platform-apps/tests/AddressBookTestingTool/src/main/java/com/swirlds/demo/addressbook/AddressBookTestingToolState.java
@@ -173,7 +173,15 @@ public class AddressBookTestingToolState extends PartialMerkleLeaf implements Sw
         }
 
         if (!validationPerformed.getAndSet(true)) {
-            validateTestScenario();
+            if (validateTestScenario()) {
+                logger.info(
+                        STARTUP.getMarker(),
+                        "Test scenario {} validated successfully.",
+                        testingToolConfig.testScenario());
+            } else {
+                logger.error(
+                        EXCEPTION.getMarker(), "Test scenario {} validation failed.", testingToolConfig.testScenario());
+            }
         }
     }
 

--- a/platform-sdk/platform-apps/tests/AddressBookTestingTool/src/main/java/com/swirlds/demo/addressbook/AddressBookTestingToolState.java
+++ b/platform-sdk/platform-apps/tests/AddressBookTestingTool/src/main/java/com/swirlds/demo/addressbook/AddressBookTestingToolState.java
@@ -303,10 +303,49 @@ public class AddressBookTestingToolState extends PartialMerkleLeaf implements Sw
                 return testScenario3NoSoftwareUpdateUseSavedStateAddressBook();
             case 4:
                 return testScenario4NoSoftwareUpdateForceUseOfConfigAddressBook();
+            case 5:
+                return testScenario5SoftwareUpgradeStakingBehavior2();
+            case 6:
+                return testScenario6SoftwareUpgradeForceUseOfConfigAddressBook();
             default:
                 logger.info(DEMO_INFO.getMarker(), "Test Scenario {}: no validation performed.", testScenario);
                 return true;
         }
+    }
+
+    private boolean testScenario6SoftwareUpgradeForceUseOfConfigAddressBook() {
+        if (!checkTestScenarioConditions(true, 6, 2, 2)) {
+            return false;
+        }
+
+        final AddressBook platformAddressBook = platform.getAddressBook();
+        final AddressBook configAddressBook = getConfigAddressBook();
+        final AddressBook stateAddressBook = getStateAddressBook();
+        final AddressBook usedAddressBook = getUsedAddressBook();
+        final AddressBook updatedAddressBook = updateStake(configAddressBook.copy());
+
+        return equalsAsConfigText(platformAddressBook, configAddressBook, true)
+                && equalsAsConfigText(platformAddressBook, stateAddressBook, false)
+                && equalsAsConfigText(platformAddressBook, usedAddressBook, true)
+                && equalsAsConfigText(platformAddressBook, updatedAddressBook, false)
+                && theConfigurationAddressBookWasUsed();
+    }
+
+    private boolean testScenario5SoftwareUpgradeStakingBehavior2() {
+        if (!checkTestScenarioConditions(false, 5, 2, 2)) {
+            return false;
+        }
+
+        final AddressBook platformAddressBook = platform.getAddressBook();
+        final AddressBook configAddressBook = getConfigAddressBook();
+        final AddressBook stateAddressBook = getStateAddressBook();
+        final AddressBook usedAddressBook = getUsedAddressBook();
+        final AddressBook updatedAddressBook = updateStake(configAddressBook.copy());
+
+        return equalsAsConfigText(platformAddressBook, configAddressBook, false)
+                && equalsAsConfigText(platformAddressBook, stateAddressBook, false)
+                && equalsAsConfigText(platformAddressBook, usedAddressBook, true)
+                && equalsAsConfigText(platformAddressBook, updatedAddressBook, true);
     }
 
     private boolean testScenario4NoSoftwareUpdateForceUseOfConfigAddressBook() {
@@ -323,7 +362,8 @@ public class AddressBookTestingToolState extends PartialMerkleLeaf implements Sw
         return equalsAsConfigText(platformAddressBook, configAddressBook, true)
                 && equalsAsConfigText(platformAddressBook, stateAddressBook, false)
                 && equalsAsConfigText(platformAddressBook, usedAddressBook, true)
-                && equalsAsConfigText(platformAddressBook, updatedAddressBook, false);
+                && equalsAsConfigText(platformAddressBook, updatedAddressBook, false)
+                && theConfigurationAddressBookWasUsed();
     }
 
     private boolean testScenario3NoSoftwareUpdateUseSavedStateAddressBook() {
@@ -344,11 +384,7 @@ public class AddressBookTestingToolState extends PartialMerkleLeaf implements Sw
     }
 
     private boolean testScenario2GenesisSwirldStateUpdateStake() {
-        // preconditions check
-        if (addressBookConfig.forceUseOfConfigAddressBook() == true) {
-            logger.error(
-                    EXCEPTION.getMarker(),
-                    "The test scenario requires the setting `addressBook.forceUseOfConfigAddressBook, false`");
+        if (!checkTestScenarioConditions(false, 2, 1, 1)) {
             return false;
         }
 
@@ -364,20 +400,18 @@ public class AddressBookTestingToolState extends PartialMerkleLeaf implements Sw
     }
 
     private boolean testScenario1GenesisForceUseOfConfigAddressBook() {
-        // preconditions check
-        if (addressBookConfig.forceUseOfConfigAddressBook() == false) {
-            logger.error(
-                    EXCEPTION.getMarker(),
-                    "The test scenario requires the setting `addressBook.forceUseOfConfigAddressBook, true`");
+        if (!checkTestScenarioConditions(true, 1, 1, 1)) {
             return false;
         }
 
         final AddressBook platformAddressBook = platform.getAddressBook();
         final AddressBook configAddressBook = getConfigAddressBook();
         final AddressBook usedAddressBook = getUsedAddressBook();
+        final AddressBook updatedAddressBook = updateStake(configAddressBook.copy());
 
         return equalsAsConfigText(platformAddressBook, configAddressBook, true)
                 && equalsAsConfigText(platformAddressBook, usedAddressBook, true)
+                && equalsAsConfigText(platformAddressBook, updatedAddressBook, false)
                 && theStateAddressBookWasNull(true)
                 && theConfigurationAddressBookWasUsed();
     }

--- a/platform-sdk/platform-apps/tests/AddressBookTestingTool/src/main/java/com/swirlds/demo/addressbook/AddressBookTestingToolState.java
+++ b/platform-sdk/platform-apps/tests/AddressBookTestingTool/src/main/java/com/swirlds/demo/addressbook/AddressBookTestingToolState.java
@@ -28,6 +28,7 @@ package com.swirlds.demo.addressbook;
 
 import static com.swirlds.logging.LogMarker.STARTUP;
 
+import com.swirlds.common.config.singleton.ConfigurationHolder;
 import com.swirlds.common.io.streams.SerializableDataInputStream;
 import com.swirlds.common.io.streams.SerializableDataOutputStream;
 import com.swirlds.common.merkle.MerkleLeaf;
@@ -59,7 +60,7 @@ public class AddressBookTestingToolState extends PartialMerkleLeaf implements Sw
     private static final Logger logger = LogManager.getLogger(AddressBookTestingToolState.class);
 
     /** modify this value to change how updateStake behaves. */
-    private static final int STAKING_PROFILE = 1;
+    private int stakingBehavior = 0;
 
     private static class ClassVersion {
         public static final int ORIGINAL = 1;
@@ -76,6 +77,8 @@ public class AddressBookTestingToolState extends PartialMerkleLeaf implements Sw
 
     public AddressBookTestingToolState() {
         logger.info(STARTUP.getMarker(), "New State Constructed.");
+        stakingBehavior = ConfigurationHolder.getConfigData(AddressBookTestingToolConfig.class)
+                .stakingBehavior();
     }
 
     /**
@@ -197,14 +200,14 @@ public class AddressBookTestingToolState extends PartialMerkleLeaf implements Sw
     @NonNull
     public AddressBook updateStake(@NonNull final AddressBook addressBook) {
         Objects.requireNonNull(addressBook, "the address book cannot be null");
-        logger.info("updateStake called in State. Staking Profile: {}", STAKING_PROFILE);
-        switch (STAKING_PROFILE) {
+        logger.info("updateStake called in State. Staking Behavior: {}", stakingBehavior);
+        switch (stakingBehavior) {
             case 1:
-                return stakingProfile1(addressBook);
+                return stakingBehavior1(addressBook);
             case 2:
-                return stakingProfile2(addressBook);
+                return stakingBehavior2(addressBook);
             default:
-                logger.info(STARTUP.getMarker(), "Staking Profile {}: no change to address book.", STAKING_PROFILE);
+                logger.info(STARTUP.getMarker(), "Staking Behavior {}: no change to address book.", stakingBehavior);
                 return addressBook;
         }
     }
@@ -216,8 +219,8 @@ public class AddressBookTestingToolState extends PartialMerkleLeaf implements Sw
      * @return the updated address book.
      */
     @NonNull
-    private AddressBook stakingProfile1(@NonNull final AddressBook addressBook) {
-        logger.info(STARTUP.getMarker(), "Staking Profile 1: updating all nodes to have 10 stake.");
+    private AddressBook stakingBehavior1(@NonNull final AddressBook addressBook) {
+        logger.info(STARTUP.getMarker(), "Staking Behavior 1: updating all nodes to have 10 stake.");
         for (int i = 0; i < addressBook.getSize(); i++) {
             addressBook.updateStake(i, 10);
         }
@@ -231,8 +234,8 @@ public class AddressBookTestingToolState extends PartialMerkleLeaf implements Sw
      * @return the updated address book.
      */
     @NonNull
-    private AddressBook stakingProfile2(@NonNull final AddressBook addressBook) {
-        logger.info(STARTUP.getMarker(), "Staking Profile 2: updating all nodes to have stake equal to their nodeId.");
+    private AddressBook stakingBehavior2(@NonNull final AddressBook addressBook) {
+        logger.info(STARTUP.getMarker(), "Staking Behavior 2: updating all nodes to have stake equal to their nodeId.");
         for (int i = 0; i < addressBook.getSize(); i++) {
             addressBook.updateStake(i, i);
         }

--- a/platform-sdk/platform-apps/tests/AddressBookTestingTool/src/main/java/module-info.java
+++ b/platform-sdk/platform-apps/tests/AddressBookTestingTool/src/main/java/module-info.java
@@ -7,4 +7,5 @@ module com.swirlds.demo.addressbook {
     requires org.bouncycastle.pkix;
     requires org.apache.logging.log4j;
     requires static com.github.spotbugs.annotations;
+    requires com.swirlds.config;
 }

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/system/SwirldState.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/system/SwirldState.java
@@ -106,8 +106,7 @@ public interface SwirldState extends MerkleNode {
 
     /**
      * Implementations of the SwirldState should always override this method in production.  The AddressBook returned
-     * should have the same Adddress entries as the configuration AddressBook, but with the stake values updated. The
-     * AddressBook previously saved in the state, if it exists, is provided for reference.
+     * should have the same Adddress entries as the configuration AddressBook, but with the stake values updated.
      * <p>
      * The default implementation of this method is provided for use in testing and to prevent compilation failure of
      * implementing classes that have not yet implemented this method.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/system/address/Address.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/system/address/Address.java
@@ -819,7 +819,7 @@ public class Address implements SelfSerializable {
         }
 
         Address address = (Address) o;
-        return equalsWithoutStake(address) && stake == address.stake;
+        return equalsWithoutStake(address) && ownHost == address.ownHost && stake == address.stake;
     }
 
     /**
@@ -831,7 +831,6 @@ public class Address implements SelfSerializable {
      */
     public boolean equalsWithoutStake(@NonNull final Address address) {
         return id == address.id
-                && ownHost == address.ownHost
                 && portInternalIpv4 == address.portInternalIpv4
                 && portExternalIpv4 == address.portExternalIpv4
                 && portInternalIpv6 == address.portInternalIpv6

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/system/address/Address.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/system/address/Address.java
@@ -819,17 +819,17 @@ public class Address implements SelfSerializable {
         }
 
         Address address = (Address) o;
-        return equalsWithoutStake(address) && ownHost == address.ownHost && stake == address.stake;
+        return equalsWithoutStakeAndOwnHost(address) && ownHost == address.ownHost && stake == address.stake;
     }
 
     /**
-     * Checks for equality with another addresses without checking the equality of stake values.
+     * Checks for equality with another addresses without checking the equality of stake or ownHost values.
      *
      * @param address The other address to check for equality with this address.
-     * @return true if all values in the other address match this address without consideration of stake, false
-     * otherwise.
+     * @return true if all values in the other address match this address without consideration of stake or ownHost
+     * values, false otherwise.
      */
-    public boolean equalsWithoutStake(@NonNull final Address address) {
+    public boolean equalsWithoutStakeAndOwnHost(@NonNull final Address address) {
         return id == address.id
                 && portInternalIpv4 == address.portInternalIpv4
                 && portExternalIpv4 == address.portExternalIpv4

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/system/address/AddressBookValidator.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/system/address/AddressBookValidator.java
@@ -176,7 +176,7 @@ public final class AddressBookValidator {
                         logger.error(EXCEPTION.getMarker(), "Address at index {} is null when accessed in order.", i);
                         throw new IllegalStateException("Address at index " + i + " is null.");
                     }
-                    final boolean equal = address1.equalsWithoutStake(address2);
+                    final boolean equal = address1.equalsWithoutStakeAndOwnHost(address2);
                     if (!equal) {
                         logger.error(
                                 EXCEPTION.getMarker(),

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/Network.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/Network.java
@@ -72,7 +72,7 @@ public class Network {
      * @throws SocketException
      * 		if there are any errors getting the addreses
      */
-    static boolean isOwn(InetAddress addr) throws SocketException {
+    public static boolean isOwn(InetAddress addr) throws SocketException {
         return getOwnAddresses().contains(addr);
     }
 

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/StateSigningTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/StateSigningTests.java
@@ -494,7 +494,7 @@ class StateSigningTests {
         int i = 0;
         for (final Address address : addressBook) {
             newAddressBook.add(address.copySetStake(0));
-            assertTrue(address.equalsWithoutStake(newAddressBook.getAddress(newAddressBook.getId(i))));
+            assertTrue(address.equalsWithoutStakeAndOwnHost(newAddressBook.getAddress(newAddressBook.getId(i))));
             i++;
         }
 


### PR DESCRIPTION
**Description**:
The following changes allow automated testing through JRS without recompiling.
* moves `isOwnHost` check from `equalsWithoutStake` to `equals` in Address.java
* adds AddressBookTestingToolConfig.java with `softwareVersion` and `stakingBehavior` settings.
* updates README.md instructions to use the new settings instead of recompiling.
* updates softwareVersion through settings in AddressBookTestingToolMain.java
* updates stakingBehavior through settings in AddressBookTestingToolState.java
* validates the different testing scenarios in AddressBookTestingToolState.java

**Related issue(s)**:

Fixes #5584 

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
