### PR TITLE
05908 Fixed DataFileWriter.finishWriting for Windows

### DIFF
--- a/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/files/DataFileWriter.java
+++ b/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/files/DataFileWriter.java
@@ -307,11 +307,11 @@ public final class DataFileWriter<D> {
         writeBytes(footerData);
         // truncate to the right size
         final long totalFileSize = mmapPositionInFile + writingMmap.position();
+        // release all the resources
+        closeMmapBuffer();
         writingChannel.truncate(totalFileSize);
         // after finishWriting(), mmapPositionInFile should be equal to the file size
         mmapPositionInFile = totalFileSize;
-        // release all the resources
-        closeMmapBuffer();
         writingChannel.force(true);
         writingChannel.close();
         writingChannel = null;


### PR DESCRIPTION
**Description**:
Whenever one invokes `DataFileWriter#finishWriting` on Windows OS, it fails with the following exception:

```
<merkledb: Store Internal Records #0> ERROR MerkleDbDataSource [mergeThenInterrupt] Failed to store internal records
java.io.IOException: The requested operation cannot be performed on a file with a user-mapped section open
	at sun.nio.ch.FileDispatcherImpl.truncate0(Native Method) ~[?:?]
	at sun.nio.ch.FileDispatcherImpl.truncate(FileDispatcherImpl.java:90) ~[?:?]
	at sun.nio.ch.FileChannelImpl.truncate(FileChannelImpl.java:437) ~[?:?]
	at com.swirlds.merkledb.files.DataFileWriter.finishWriting(DataFileWriter.java:310) ~[main/:?]
	at com.swirlds.merkledb.files.DataFileCollection.endWriting(DataFileCollection.java:649) ~[main/:?]
	at com.swirlds.merkledb.files.MemoryIndexDiskKeyValueStore.endWriting(MemoryIndexDiskKeyValueStore.java:277) ~[main/:?]
	at com.swirlds.merkledb.MerkleDbDataSource.writeInternalRecords(MerkleDbDataSource.java:1215) ~[main/:?]
	at com.swirlds.merkledb.MerkleDbDataSource.lambda$saveRecords$5(MerkleDbDataSource.java:588) ~[main/:?]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136) ~[?:?]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635) ~[?:?]
	at java.lang.Thread.run(Thread.java:833) ~[?:?]
```

It's caused by the fact that Windows doesn't let file truncation to happen, if has mapped buffer open.

The solution is simple: close the mapped byte buffer before the truncation.

**Related issue(s)**:

Fixes #5908 


**Checklist**

- No additional documentation is required
- No additional tests required
