### PR TITLE
Cherry pick - Use mirror address of selfdestruct-ed creation in record

### DIFF
--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/contract/ContractCreateTransitionLogic.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/contract/ContractCreateTransitionLogic.java
@@ -179,15 +179,16 @@ public class ContractCreateTransitionLogic implements TransitionLogic {
 
         final Address newContractAddress;
 
-        final var mirrorAddress = worldState.newContractAddress(sender.getId().asEvmAddress());
+        final var newContractMirrorAddress =
+                worldState.newContractAddress(sender.getId().asEvmAddress());
         if (relayerId == null) {
-            newContractAddress = mirrorAddress;
+            newContractAddress = newContractMirrorAddress;
         } else {
             // Since there is an Ethereum origin, set the contract address as the CREATE format
             // specified in the Yellow Paper
             final var create1ContractAddress =
                     Address.contractAddress(sender.canonicalAddress(), sender.getEthereumNonce());
-            aliasManager.link(create1ContractAddress, mirrorAddress);
+            aliasManager.link(create1ContractAddress, newContractMirrorAddress);
             newContractAddress = create1ContractAddress;
         }
 
@@ -241,14 +242,18 @@ public class ContractCreateTransitionLogic implements TransitionLogic {
         }
         if (result.isSuccessful()) {
             final var newEvmAddress = newContractAddress.toArrayUnsafe();
-            final var newContractId = contractIdFromEvmAddress(mirrorAddress);
-            final var contractBytecodeSidecar = op.getInitcodeSourceCase() != INITCODE
-                    ? SidecarUtils.createContractBytecodeSidecarFrom(
-                            newContractId,
-                            codeWithConstructorArgs.toArrayUnsafe(),
-                            result.getOutput().toArrayUnsafe())
-                    : SidecarUtils.createContractBytecodeSidecarFrom(
-                            newContractId, result.getOutput().toArrayUnsafe());
+            // Note we _cannot_ rely on a call to aliasResolver.resolveForEvm() here,
+            // because the new contract's EVM-address-to-id link might not exist
+            // any more---the new contract's constructor can SELFDESTRUCT
+            final var newContractId = contractIdFromEvmAddress(newContractMirrorAddress);
+            final var contractBytecodeSidecar =
+                    op.getInitcodeSourceCase() != INITCODE
+                            ? SidecarUtils.createContractBytecodeSidecarFrom(
+                                    newContractId,
+                                    codeWithConstructorArgs.toArrayUnsafe(),
+                                    result.getOutput().toArrayUnsafe())
+                            : SidecarUtils.createContractBytecodeSidecarFrom(
+                                    newContractId, result.getOutput().toArrayUnsafe());
             if (createSyntheticRecord) {
                 recordSyntheticOperation(newContractId, newEvmAddress, hapiSenderCustomizer, contractBytecodeSidecar);
                 // bytecode sidecar is already externalized if needed in {@link

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/contract/ContractCreateTransitionLogic.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/contract/ContractCreateTransitionLogic.java
@@ -179,16 +179,15 @@ public class ContractCreateTransitionLogic implements TransitionLogic {
 
         final Address newContractAddress;
 
+        final var mirrorAddress = worldState.newContractAddress(sender.getId().asEvmAddress());
         if (relayerId == null) {
-            newContractAddress = worldState.newContractAddress(sender.getId().asEvmAddress());
+            newContractAddress = mirrorAddress;
         } else {
             // Since there is an Ethereum origin, set the contract address as the CREATE format
             // specified in the Yellow Paper
             final var create1ContractAddress =
                     Address.contractAddress(sender.canonicalAddress(), sender.getEthereumNonce());
-            aliasManager.link(
-                    create1ContractAddress,
-                    worldState.newContractAddress(sender.getId().asEvmAddress()));
+            aliasManager.link(create1ContractAddress, mirrorAddress);
             newContractAddress = create1ContractAddress;
         }
 
@@ -242,8 +241,7 @@ public class ContractCreateTransitionLogic implements TransitionLogic {
         }
         if (result.isSuccessful()) {
             final var newEvmAddress = newContractAddress.toArrayUnsafe();
-            final var newEvmAddressResolved = aliasManager.resolveForEvm(newContractAddress);
-            final var newContractId = contractIdFromEvmAddress(newEvmAddressResolved);
+            final var newContractId = contractIdFromEvmAddress(mirrorAddress);
             final var contractBytecodeSidecar = op.getInitcodeSourceCase() != INITCODE
                     ? SidecarUtils.createContractBytecodeSidecarFrom(
                             newContractId,

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/contract/ContractCreateTransitionLogic.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/contract/ContractCreateTransitionLogic.java
@@ -246,14 +246,13 @@ public class ContractCreateTransitionLogic implements TransitionLogic {
             // because the new contract's EVM-address-to-id link might not exist
             // any more---the new contract's constructor can SELFDESTRUCT
             final var newContractId = contractIdFromEvmAddress(newContractMirrorAddress);
-            final var contractBytecodeSidecar =
-                    op.getInitcodeSourceCase() != INITCODE
-                            ? SidecarUtils.createContractBytecodeSidecarFrom(
-                                    newContractId,
-                                    codeWithConstructorArgs.toArrayUnsafe(),
-                                    result.getOutput().toArrayUnsafe())
-                            : SidecarUtils.createContractBytecodeSidecarFrom(
-                                    newContractId, result.getOutput().toArrayUnsafe());
+            final var contractBytecodeSidecar = op.getInitcodeSourceCase() != INITCODE
+                    ? SidecarUtils.createContractBytecodeSidecarFrom(
+                            newContractId,
+                            codeWithConstructorArgs.toArrayUnsafe(),
+                            result.getOutput().toArrayUnsafe())
+                    : SidecarUtils.createContractBytecodeSidecarFrom(
+                            newContractId, result.getOutput().toArrayUnsafe());
             if (createSyntheticRecord) {
                 recordSyntheticOperation(newContractId, newEvmAddress, hapiSenderCustomizer, contractBytecodeSidecar);
                 // bytecode sidecar is already externalized if needed in {@link

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/assertions/TransactionRecordAsserts.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/assertions/TransactionRecordAsserts.java
@@ -37,6 +37,7 @@ import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.Assertions;
 
 public class TransactionRecordAsserts extends BaseErroringAssertsProvider<TransactionRecord> {
+
     static final Logger log = LogManager.getLogger(TransactionRecordAsserts.class);
     static final String RECEIPT = "receipt";
     static final String TRANSACTION_FEE = "transactionFee";
@@ -170,7 +171,7 @@ public class TransactionRecordAsserts extends BaseErroringAssertsProvider<Transa
     }
 
     public TransactionRecordAsserts hasMirrorIdInReceipt() {
-        this.<TransactionReceipt>registerTypedProvider("receipt", spec -> receipt -> {
+        this.<TransactionReceipt>registerTypedProvider(RECEIPT, spec -> receipt -> {
             try {
                 assertEquals(0, receipt.getContractID().getShardNum(), "Bad receipt shard");
                 assertEquals(0, receipt.getContractID().getRealmNum(), "Bad receipt realm");

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/assertions/TransactionRecordAsserts.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/assertions/TransactionRecordAsserts.java
@@ -53,7 +53,7 @@ public class TransactionRecordAsserts extends BaseErroringAssertsProvider<Transa
     public TransactionRecordAsserts txnId(String expectedTxn) {
         this.<TransactionID>registerTypedProvider("transactionID", spec -> txnId -> {
             try {
-                Assertions.assertEquals(spec.registry().getTxnId(expectedTxn), txnId, "Wrong txnId!");
+                assertEquals(spec.registry().getTxnId(expectedTxn), txnId, "Wrong txnId!");
             } catch (Throwable t) {
                 return List.of(t);
             }
@@ -68,7 +68,7 @@ public class TransactionRecordAsserts extends BaseErroringAssertsProvider<Transa
                 final var expectedTime = parentTime.toBuilder()
                         .setNanos(parentTime.getNanos() + nonce)
                         .build();
-                Assertions.assertEquals(expectedTime, actualTime);
+                assertEquals(expectedTime, actualTime);
             } catch (Throwable t) {
                 return List.of(t);
             }
@@ -80,7 +80,7 @@ public class TransactionRecordAsserts extends BaseErroringAssertsProvider<Transa
     public TransactionRecordAsserts txnId(TransactionID expectedTxn) {
         this.<TransactionID>registerTypedProvider("transactionID", spec -> txnId -> {
             try {
-                Assertions.assertEquals(expectedTxn, txnId, "Wrong txnId!");
+                assertEquals(expectedTxn, txnId, "Wrong txnId!");
             } catch (Throwable t) {
                 return List.of(t);
             }
@@ -93,7 +93,7 @@ public class TransactionRecordAsserts extends BaseErroringAssertsProvider<Transa
         this.<ByteString>registerTypedProvider("prngBytes", spec -> prngBytes -> {
             try {
                 Assertions.assertNotNull(prngBytes, "Null prngBytes!");
-                Assertions.assertEquals(32, prngBytes.size(), "Wrong prngBytes!");
+                assertEquals(32, prngBytes.size(), "Wrong prngBytes!");
             } catch (Throwable t) {
                 return List.of(t);
             }
@@ -123,7 +123,7 @@ public class TransactionRecordAsserts extends BaseErroringAssertsProvider<Transa
     public TransactionRecordAsserts status(ResponseCodeEnum expectedStatus) {
         this.<TransactionReceipt>registerTypedProvider(RECEIPT, spec -> receipt -> {
             try {
-                Assertions.assertEquals(expectedStatus, receipt.getStatus(), "Bad status!");
+                assertEquals(expectedStatus, receipt.getStatus(), "Bad status!");
             } catch (Throwable t) {
                 return List.of(t);
             }
@@ -135,7 +135,7 @@ public class TransactionRecordAsserts extends BaseErroringAssertsProvider<Transa
     public TransactionRecordAsserts serialNos(List<Long> minted) {
         this.<TransactionReceipt>registerTypedProvider(RECEIPT, spec -> receipt -> {
             try {
-                Assertions.assertEquals(minted, receipt.getSerialNumbersList(), "Wrong serial nos");
+                assertEquals(minted, receipt.getSerialNumbersList(), "Wrong serial nos");
             } catch (Throwable t) {
                 return List.of(t);
             }
@@ -147,7 +147,7 @@ public class TransactionRecordAsserts extends BaseErroringAssertsProvider<Transa
     public TransactionRecordAsserts newTotalSupply(long expected) {
         this.<TransactionReceipt>registerTypedProvider(RECEIPT, spec -> receipt -> {
             try {
-                Assertions.assertEquals(expected, receipt.getNewTotalSupply(), "Wrong new total supply");
+                assertEquals(expected, receipt.getNewTotalSupply(), "Wrong new total supply");
             } catch (Throwable t) {
                 return List.of(t);
             }
@@ -160,8 +160,21 @@ public class TransactionRecordAsserts extends BaseErroringAssertsProvider<Transa
         this.<TransactionReceipt>registerTypedProvider(RECEIPT, spec -> receipt -> {
             try {
                 final var expected = TxnUtils.asContractId(id, spec);
-                Assertions.assertEquals(expected, receipt.getContractID(), "Bad targeted contract");
+                assertEquals(expected, receipt.getContractID(), "Bad targeted contract");
             } catch (Throwable t) {
+                return List.of(t);
+            }
+            return EMPTY_LIST;
+        });
+        return this;
+    }
+
+    public TransactionRecordAsserts hasMirrorIdInReceipt() {
+        this.<TransactionReceipt>registerTypedProvider("receipt", spec -> receipt -> {
+            try {
+                assertEquals(0, receipt.getContractID().getShardNum(), "Bad receipt shard");
+                assertEquals(0, receipt.getContractID().getRealmNum(), "Bad receipt realm");
+            } catch (Exception t) {
                 return List.of(t);
             }
             return EMPTY_LIST;
@@ -172,7 +185,7 @@ public class TransactionRecordAsserts extends BaseErroringAssertsProvider<Transa
     public TransactionRecordAsserts targetedContractId(final ContractID id) {
         this.<TransactionReceipt>registerTypedProvider(RECEIPT, spec -> receipt -> {
             try {
-                Assertions.assertEquals(id, receipt.getContractID(), "Bad targeted contract");
+                assertEquals(id, receipt.getContractID(), "Bad targeted contract");
             } catch (Exception t) {
                 return List.of(t);
             }
@@ -184,8 +197,7 @@ public class TransactionRecordAsserts extends BaseErroringAssertsProvider<Transa
     public TransactionRecordAsserts checkTopicRunningHashVersion(int versionNumber) {
         this.<TransactionReceipt>registerTypedProvider(RECEIPT, spec -> receipt -> {
             try {
-                Assertions.assertEquals(
-                        versionNumber, receipt.getTopicRunningHashVersion(), "Bad TopicRunningHashVerions!");
+                assertEquals(versionNumber, receipt.getTopicRunningHashVersion(), "Bad TopicRunningHashVerions!");
             } catch (Throwable t) {
                 return List.of(t);
             }


### PR DESCRIPTION
**Description**:
- Fixes: When an EthereumTransaction creates a contract whose constructor calls selfdestruct, the record contains a "nonsense" ContractID=A.B.C corresponding to the 0xA...BC EVM address instead of the 0.0.X id
- Eliminates assumption that a newly created contract's EVM address will still be linked at the end of its creating transaction. (Not the case if the constructor calls selfdestruct.)