### PR TITLE
05930 - fix address book init on software downgrade

### DIFF
--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/Browser.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/Browser.java
@@ -103,6 +103,7 @@ import com.swirlds.platform.swirldapp.SwirldAppLoader;
 import com.swirlds.platform.system.Shutdown;
 import com.swirlds.platform.system.SystemExitReason;
 import com.swirlds.platform.system.SystemUtils;
+import com.swirlds.platform.util.BootstrapUtils;
 import com.swirlds.platform.util.MetricsDocUtils;
 import com.swirlds.virtualmap.config.VirtualMapConfig;
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -636,12 +637,20 @@ public class Browser {
                 final SignedState loadedSignedState = getUnmodifiedSignedStateFromDisk(
                         mainClassName, swirldName, nodeId, appVersion, addressBook.copy(), emergencyRecoveryManager);
 
+                // check software version compatibility
+                final boolean softwareUpgrade = BootstrapUtils.detectSoftwareUpgrade(appVersion, loadedSignedState);
+
                 final AddressBookConfig addressBookConfig =
                         platformContext.getConfiguration().getConfigData(AddressBookConfig.class);
 
                 // Initialize the address book from the configuration and platform saved state.
                 final AddressBookInitializer addressBookInitializer = new AddressBookInitializer(
-                        appVersion, loadedSignedState, addressBook.copy(), addressBookConfig);
+                        appVersion,
+                        softwareUpgrade,
+                        loadedSignedState,
+
+                        addressBook.copy(),
+                        addressBookConfig);
                 // set here, then given to the state in run(). A copy of it is given to hashgraph.
                 final AddressBook initialAddressBook = addressBookInitializer.getInitialAddressBook();
 

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/Browser.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/Browser.java
@@ -645,12 +645,8 @@ public class Browser {
 
                 // Initialize the address book from the configuration and platform saved state.
                 final AddressBookInitializer addressBookInitializer = new AddressBookInitializer(
-                        appVersion,
-                        softwareUpgrade,
-                        loadedSignedState,
+                        appVersion, softwareUpgrade, loadedSignedState, addressBook.copy(), addressBookConfig);
 
-                        addressBook.copy(),
-                        addressBookConfig);
                 // set here, then given to the state in run(). A copy of it is given to hashgraph.
                 final AddressBook initialAddressBook = addressBookInitializer.getInitialAddressBook();
 

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/util/BootstrapUtils.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/util/BootstrapUtils.java
@@ -16,27 +16,39 @@
 
 package com.swirlds.platform.util;
 
+import static com.swirlds.logging.LogMarker.STARTUP;
+
 import com.swirlds.common.config.ConfigUtils;
 import com.swirlds.common.config.singleton.ConfigurationHolder;
 import com.swirlds.common.config.sources.LegacyFileConfigSource;
 import com.swirlds.common.constructable.ConstructableRegistry;
 import com.swirlds.common.constructable.ConstructableRegistryException;
+import com.swirlds.common.system.SoftwareVersion;
 import com.swirlds.common.system.SwirldMain;
 import com.swirlds.config.api.Configuration;
 import com.swirlds.config.api.ConfigurationBuilder;
 import com.swirlds.platform.Log4jSetup;
 import com.swirlds.platform.Settings;
+import com.swirlds.platform.state.signed.SignedState;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
 import java.io.IOException;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Objects;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Utility methods that are helpful when starting up a JVM.
  */
 public final class BootstrapUtils {
+
+    /** The logger for this class */
+    private static Logger logger = LogManager.getLogger(BootstrapUtils.class);
 
     private BootstrapUtils() {}
 
@@ -106,5 +118,44 @@ public final class BootstrapUtils {
         ConfigurationHolder.getInstance().setConfiguration(configuration);
 
         return configuration;
+    }
+
+    /**
+     * Detect if there is a software upgrade. This method will throw an IllegalStateException if the loaded signed state
+     * software version is greater than the current application software version.
+     *
+     * @param appVersion        the version of the app
+     * @param loadedSignedState the signed state that was loaded from disk
+     * @return true if there is a software upgrade, false otherwise
+     */
+    public static boolean detectSoftwareUpgrade(
+            @NonNull final SoftwareVersion appVersion, @Nullable final SignedState loadedSignedState) {
+        Objects.requireNonNull(appVersion, "The app version must not be null.");
+
+        final SoftwareVersion loadedSoftwareVersion = loadedSignedState == null
+                ? null
+                : loadedSignedState
+                        .getState()
+                        .getPlatformState()
+                        .getPlatformData()
+                        .getCreationSoftwareVersion();
+        final int versionComparison = loadedSoftwareVersion == null ? 1 : appVersion.compareTo(loadedSoftwareVersion);
+        final boolean softwareUpgrade;
+        if (versionComparison < 0) {
+            throw new IllegalStateException(
+                    "The current software version `" + appVersion + "` is prior to the software version `"
+                            + loadedSoftwareVersion + "` that created the state that was loaded from disk.");
+        } else if (versionComparison > 0) {
+            softwareUpgrade = true;
+            logger.info(
+                    STARTUP.getMarker(), "Software upgrade from version {} to {}. ", loadedSoftwareVersion, appVersion);
+        } else {
+            softwareUpgrade = false;
+            logger.info(
+                    STARTUP.getMarker(),
+                    "No Software Upgrade, continuing with software version {}.",
+                    loadedSoftwareVersion);
+        }
+        return softwareUpgrade;
     }
 }

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/AddressBookInitializerTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/AddressBookInitializerTest.java
@@ -24,7 +24,6 @@ import static com.swirlds.platform.AddressBookInitializer.STATE_ADDRESS_BOOK_USE
 import static com.swirlds.platform.AddressBookInitializer.USED_ADDRESS_BOOK_HEADER;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.mock;
@@ -69,7 +68,9 @@ class AddressBookInitializerTest {
         clearTestDirectory();
         final AddressBook configAddressBook = getRandomAddressBook();
         final AddressBookInitializer initializer = new AddressBookInitializer(
-                getMockSoftwareVersion(1), getMockSignedState(0), configAddressBook, getAddressBookConfig(true));
+                getMockSoftwareVersion(2),
+                // no software upgrade
+                false, getMockSignedState(0), configAddressBook, getAddressBookConfig(true));
         final AddressBook inititializedAddressBook = initializer.getInitialAddressBook();
         assertEquals(
                 configAddressBook,
@@ -85,7 +86,9 @@ class AddressBookInitializerTest {
         final AddressBook configAddressBook = getRandomAddressBook();
         SignedState signedState = getMockSignedState(1);
         final AddressBookInitializer initializer = new AddressBookInitializer(
-                getMockSoftwareVersion(1), signedState, configAddressBook, getAddressBookConfig(true));
+                getMockSoftwareVersion(2),
+                // no software upgrade
+                false, signedState, configAddressBook, getAddressBookConfig(true));
         final AddressBook inititializedAddressBook = initializer.getInitialAddressBook();
         assertEquals(
                 configAddressBook,
@@ -101,7 +104,9 @@ class AddressBookInitializerTest {
         clearTestDirectory();
         final AddressBook configAddressBook = getRandomAddressBook();
         final AddressBookInitializer initializer = new AddressBookInitializer(
-                getMockSoftwareVersion(1), getMockSignedState(0), configAddressBook, getAddressBookConfig(false));
+                getMockSoftwareVersion(2),
+                // no software upgrade
+                false, getMockSignedState(0), configAddressBook, getAddressBookConfig(false));
         final AddressBook inititializedAddressBook = initializer.getInitialAddressBook();
         assertEquals(
                 configAddressBook,
@@ -116,7 +121,9 @@ class AddressBookInitializerTest {
         clearTestDirectory();
         final AddressBook configAddressBook = getRandomAddressBook();
         final AddressBookInitializer initializer = new AddressBookInitializer(
-                getMockSoftwareVersion(1), getMockSignedState(0), configAddressBook, getAddressBookConfig(false));
+                getMockSoftwareVersion(2),
+                // no software upgrade
+                false, getMockSignedState(0), configAddressBook, getAddressBookConfig(false));
         final AddressBook inititializedAddressBook = initializer.getInitialAddressBook();
         assertEquals(
                 configAddressBook,
@@ -131,7 +138,9 @@ class AddressBookInitializerTest {
         clearTestDirectory();
         final AddressBook configAddressBook = getRandomAddressBook();
         final AddressBookInitializer initializer = new AddressBookInitializer(
-                getMockSoftwareVersion(1), getMockSignedState(0), configAddressBook, getAddressBookConfig(false));
+                getMockSoftwareVersion(2),
+                // no software upgrade
+                false, getMockSignedState(0), configAddressBook, getAddressBookConfig(false));
         final AddressBook inititializedAddressBook = initializer.getInitialAddressBook();
         assertEquals(
                 configAddressBook,
@@ -163,7 +172,11 @@ class AddressBookInitializerTest {
         final SignedState signedState = getMockSignedState(2);
         final AddressBook configAddressBook = copyWithStakeChanges(signedState.getAddressBook(), 10);
         final AddressBookInitializer initializer = new AddressBookInitializer(
-                getMockSoftwareVersion(2), signedState, configAddressBook, getAddressBookConfig(false));
+                getMockSoftwareVersion(2),
+                // no software upgrade
+                false,
+                signedState,
+                 configAddressBook, getAddressBookConfig(false));
         final AddressBook inititializedAddressBook = initializer.getInitialAddressBook();
         assertEquals(
                 signedState.getAddressBook(),
@@ -180,7 +193,11 @@ class AddressBookInitializerTest {
         final SignedState signedState = getMockSignedState(2, 0);
         final AddressBook configAddressBook = copyWithStakeChanges(signedState.getAddressBook(), 10);
         final AddressBookInitializer initializer = new AddressBookInitializer(
-                getMockSoftwareVersion(3), signedState, configAddressBook, getAddressBookConfig(false));
+                getMockSoftwareVersion(3),
+                // software upgrade
+                true,
+                signedState,
+                 configAddressBook, getAddressBookConfig(false));
         final AddressBook inititializedAddressBook = initializer.getInitialAddressBook();
         assertEquals(
                 configAddressBook,
@@ -197,7 +214,11 @@ class AddressBookInitializerTest {
         final SignedState signedState = getMockSignedState(2, 2);
         final AddressBook configAddressBook = copyWithStakeChanges(signedState.getAddressBook(), 3);
         final AddressBookInitializer initializer = new AddressBookInitializer(
-                getMockSoftwareVersion(3), signedState, configAddressBook, getAddressBookConfig(false));
+                getMockSoftwareVersion(3),
+                // software upgrade
+                true,
+                signedState,
+                 configAddressBook, getAddressBookConfig(false));
         final AddressBook inititializedAddressBook = initializer.getInitialAddressBook();
         assertEquals(
                 configAddressBook,
@@ -214,7 +235,11 @@ class AddressBookInitializerTest {
         final SignedState signedState = getMockSignedState(2);
         final AddressBook configAddressBook = copyWithStakeChanges(signedState.getAddressBook(), 5);
         final AddressBookInitializer initializer = new AddressBookInitializer(
-                getMockSoftwareVersion(3), signedState, configAddressBook, getAddressBookConfig(false));
+                getMockSoftwareVersion(3),
+                // software upgrade
+                true,
+                signedState,
+                 configAddressBook, getAddressBookConfig(false));
         final AddressBook inititializedAddressBook = initializer.getInitialAddressBook();
         assertNotEquals(
                 configAddressBook,

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/AddressBookInitializerTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/AddressBookInitializerTest.java
@@ -70,7 +70,10 @@ class AddressBookInitializerTest {
         final AddressBookInitializer initializer = new AddressBookInitializer(
                 getMockSoftwareVersion(2),
                 // no software upgrade
-                false, getMockSignedState(0), configAddressBook, getAddressBookConfig(true));
+                false,
+                getMockSignedState(0),
+                configAddressBook,
+                getAddressBookConfig(true));
         final AddressBook inititializedAddressBook = initializer.getInitialAddressBook();
         assertEquals(
                 configAddressBook,
@@ -88,7 +91,10 @@ class AddressBookInitializerTest {
         final AddressBookInitializer initializer = new AddressBookInitializer(
                 getMockSoftwareVersion(2),
                 // no software upgrade
-                false, signedState, configAddressBook, getAddressBookConfig(true));
+                false,
+                signedState,
+                configAddressBook,
+                getAddressBookConfig(true));
         final AddressBook inititializedAddressBook = initializer.getInitialAddressBook();
         assertEquals(
                 configAddressBook,
@@ -106,7 +112,10 @@ class AddressBookInitializerTest {
         final AddressBookInitializer initializer = new AddressBookInitializer(
                 getMockSoftwareVersion(2),
                 // no software upgrade
-                false, getMockSignedState(0), configAddressBook, getAddressBookConfig(false));
+                false,
+                getMockSignedState(0),
+                configAddressBook,
+                getAddressBookConfig(false));
         final AddressBook inititializedAddressBook = initializer.getInitialAddressBook();
         assertEquals(
                 configAddressBook,
@@ -123,7 +132,10 @@ class AddressBookInitializerTest {
         final AddressBookInitializer initializer = new AddressBookInitializer(
                 getMockSoftwareVersion(2),
                 // no software upgrade
-                false, getMockSignedState(0), configAddressBook, getAddressBookConfig(false));
+                false,
+                getMockSignedState(0),
+                configAddressBook,
+                getAddressBookConfig(false));
         final AddressBook inititializedAddressBook = initializer.getInitialAddressBook();
         assertEquals(
                 configAddressBook,
@@ -140,29 +152,16 @@ class AddressBookInitializerTest {
         final AddressBookInitializer initializer = new AddressBookInitializer(
                 getMockSoftwareVersion(2),
                 // no software upgrade
-                false, getMockSignedState(0), configAddressBook, getAddressBookConfig(false));
+                false,
+                getMockSignedState(0),
+                configAddressBook,
+                getAddressBookConfig(false));
         final AddressBook inititializedAddressBook = initializer.getInitialAddressBook();
         assertEquals(
                 configAddressBook,
                 inititializedAddressBook,
                 "The initial address book must equal the config address book.");
         assertAddressBookFileContent(initializer, configAddressBook, null, inititializedAddressBook);
-    }
-
-    @Test
-    @DisplayName("Current software version is less than state software version.")
-    void currentVersionLessThanStateVersion() throws IOException {
-        clearTestDirectory();
-        final SignedState signedState = getMockSignedState(2);
-        final AddressBook configAddressBook = getRandomAddressBook();
-        final SoftwareVersion configSoftwareVersion = getMockSoftwareVersion(1);
-        final AddressBookConfig addressBookConfig = getAddressBookConfig(false);
-
-        assertThrows(
-                IllegalStateException.class,
-                () -> new AddressBookInitializer(
-                        configSoftwareVersion, signedState, configAddressBook, addressBookConfig),
-                "IllegalStateException was not thrown.");
     }
 
     @Test
@@ -176,7 +175,8 @@ class AddressBookInitializerTest {
                 // no software upgrade
                 false,
                 signedState,
-                 configAddressBook, getAddressBookConfig(false));
+                configAddressBook,
+                getAddressBookConfig(false));
         final AddressBook inititializedAddressBook = initializer.getInitialAddressBook();
         assertEquals(
                 signedState.getAddressBook(),
@@ -197,7 +197,8 @@ class AddressBookInitializerTest {
                 // software upgrade
                 true,
                 signedState,
-                 configAddressBook, getAddressBookConfig(false));
+                configAddressBook,
+                getAddressBookConfig(false));
         final AddressBook inititializedAddressBook = initializer.getInitialAddressBook();
         assertEquals(
                 configAddressBook,
@@ -218,7 +219,8 @@ class AddressBookInitializerTest {
                 // software upgrade
                 true,
                 signedState,
-                 configAddressBook, getAddressBookConfig(false));
+                configAddressBook,
+                getAddressBookConfig(false));
         final AddressBook inititializedAddressBook = initializer.getInitialAddressBook();
         assertEquals(
                 configAddressBook,
@@ -239,7 +241,8 @@ class AddressBookInitializerTest {
                 // software upgrade
                 true,
                 signedState,
-                 configAddressBook, getAddressBookConfig(false));
+                configAddressBook,
+                getAddressBookConfig(false));
         final AddressBook inititializedAddressBook = initializer.getInitialAddressBook();
         assertNotEquals(
                 configAddressBook,


### PR DESCRIPTION
**Description**:
Fixes bug where forcing the use of the config.txt address book would bypass the check and exception throw on software version downgrade.   The version comparison is moved to the browser, immediately after loading any saved signed state. 

**Related issue(s)**:

Fixes #5930 

