### PR TITLE
Cherry Pick - Add signing requirements for transfer of NFT with fallback royalty fee

### DIFF
--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/properties/BootstrapProperties.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/properties/BootstrapProperties.java
@@ -253,6 +253,7 @@ public final class BootstrapProperties implements PropertySource {
                     CONTRACTS_PRECOMPILE_HTS_DEFAULT_GAS_COST,
                     CONTRACTS_PRECOMPILE_EXPORT_RECORD_RESULTS,
                     CONTRACTS_PRECOMPILE_HTS_ENABLE_TOKEN_CREATE,
+                    CONTRACTS_PRECOMPILE_HTS_UNSUPPORTED_CUSTOM_FEE_RECEIVER_DEBITS,
                     CONTRACTS_PRECOMPILE_ATOMIC_CRYPTO_TRANSFER_ENABLED,
                     CONTRACTS_EVM_VERSION,
                     CONTRACTS_DYNAMIC_EVM_VERSION,
@@ -551,6 +552,9 @@ public final class BootstrapProperties implements PropertySource {
                     entry(CONTRACTS_PRECOMPILE_HTS_DEFAULT_GAS_COST, AS_LONG),
                     entry(CONTRACTS_PRECOMPILE_EXPORT_RECORD_RESULTS, AS_BOOLEAN),
                     entry(CONTRACTS_PRECOMPILE_HTS_ENABLE_TOKEN_CREATE, AS_BOOLEAN),
+                    entry(
+                            CONTRACTS_PRECOMPILE_HTS_UNSUPPORTED_CUSTOM_FEE_RECEIVER_DEBITS,
+                            AS_CUSTOM_FEES_TYPE),
                     entry(CONTRACTS_PRECOMPILE_ATOMIC_CRYPTO_TRANSFER_ENABLED, AS_BOOLEAN),
                     entry(CONTRACTS_THROTTLE_THROTTLE_BY_GAS, AS_BOOLEAN),
                     entry(CONTRACTS_EVM_VERSION, AS_STRING),

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/properties/CustomFeeType.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/properties/CustomFeeType.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hedera.node.app.service.mono.context.properties;
+
+import static com.hedera.node.app.service.mono.utils.MiscUtils.csvSet;
+
+import java.util.Set;
+
+/**
+ * These are specifically for custom fees where the receiver pays the fee - this is **not** a
+ * enumeration of all possible custom fee types. See
+ * `contracts.precompile.unsupportedCustomFeeReceiverDebits`
+ */
+public enum CustomFeeType {
+    FIXED_FEE,
+    ROYALTY_FALLBACK_FEE;
+
+    public static Set<CustomFeeType> csvTypeSet(final String propertyValue) {
+        return csvSet(propertyValue, CustomFeeType::valueOf, CustomFeeType.class);
+    }
+}

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/properties/GlobalDynamicProperties.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/properties/GlobalDynamicProperties.java
@@ -127,6 +127,7 @@ public class GlobalDynamicProperties implements EvmProperties {
     private boolean enableAllowances;
     private boolean limitTokenAssociations;
     private boolean enableHTSPrecompileCreate;
+    private Set<CustomFeeType> htsUnsupportedCustomFeeReceiverDebits;
     private boolean atomicCryptoTransferEnabled;
     private KnownBlockValues knownBlockValues;
     private long exchangeRateGasReq;
@@ -283,6 +284,9 @@ public class GlobalDynamicProperties implements EvmProperties {
         limitTokenAssociations = properties.getBooleanProperty(ENTITIES_LIMIT_TOKEN_ASSOCIATIONS);
         enableHTSPrecompileCreate =
                 properties.getBooleanProperty(CONTRACTS_PRECOMPILE_HTS_ENABLE_TOKEN_CREATE);
+        htsUnsupportedCustomFeeReceiverDebits =
+                properties.getCustomFeesProperty(
+                        CONTRACTS_PRECOMPILE_HTS_UNSUPPORTED_CUSTOM_FEE_RECEIVER_DEBITS);
         atomicCryptoTransferEnabled =
                 properties.getBooleanProperty(CONTRACTS_PRECOMPILE_ATOMIC_CRYPTO_TRANSFER_ENABLED);
         knownBlockValues = properties.getBlockValuesProperty(CONTRACTS_KNOWN_BLOCK_HASH);
@@ -661,6 +665,10 @@ public class GlobalDynamicProperties implements EvmProperties {
 
     public boolean isHTSPrecompileCreateEnabled() {
         return enableHTSPrecompileCreate;
+    }
+
+    public Set<CustomFeeType> getHtsUnsupportedCustomFeeReceiverDebits() {
+        return htsUnsupportedCustomFeeReceiverDebits;
     }
 
     public boolean isAtomicCryptoTransferEnabled() {

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/properties/PropertyNames.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/properties/PropertyNames.java
@@ -137,6 +137,8 @@ public class PropertyNames {
             "contracts.precompile.exportRecordResults";
     public static final String CONTRACTS_PRECOMPILE_HTS_ENABLE_TOKEN_CREATE =
             "contracts.precompile.htsEnableTokenCreate";
+    public static final String CONTRACTS_PRECOMPILE_HTS_UNSUPPORTED_CUSTOM_FEE_RECEIVER_DEBITS =
+            "contracts.precompile.unsupportedCustomFeeReceiverDebits";
     public static final String CONTRACTS_PRECOMPILE_ATOMIC_CRYPTO_TRANSFER_ENABLED =
             "contracts.precompile.atomicCryptoTransfer.enabled";
     public static final String CONTRACTS_DYNAMIC_EVM_VERSION = "contracts.evm.version.dynamic";

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/properties/PropertySource.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/properties/PropertySource.java
@@ -89,6 +89,7 @@ public interface PropertySource {
     Function<String, Object> AS_ENTITY_NUM_RANGE = EntityIdUtils::parseEntityNumRange;
     Function<String, Object> AS_ENTITY_TYPES = EntityType::csvTypeSet;
     Function<String, Object> AS_ACCESS_LIST = MapAccessType::csvAccessList;
+    Function<String, Object> AS_CUSTOM_FEES_TYPE = CustomFeeType::csvTypeSet;
     Function<String, Object> AS_SIDECARS =
             s -> asEnumSet(SidecarType.class, SidecarType::valueOf, s);
     Function<String, Object> AS_RECOMPUTE_TYPES =
@@ -140,6 +141,11 @@ public interface PropertySource {
 
     @SuppressWarnings("unchecked")
     default Set<EntityType> getTypesProperty(String name) {
+        return getTypedProperty(Set.class, name);
+    }
+
+    @SuppressWarnings("unchecked")
+    default Set<CustomFeeType> getCustomFeesProperty(String name) {
         return getTypedProperty(Set.class, name);
     }
 

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/grpc/marshalling/AdjustmentUtils.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/grpc/marshalling/AdjustmentUtils.java
@@ -75,18 +75,42 @@ public final class AdjustmentUtils {
             final Id payer,
             final Id collector,
             final long amount,
-            final BalanceChangeManager manager) {
-        adjustForAssessed(payer, MISSING_ID, collector, MISSING_ID, amount, manager);
+            final BalanceChangeManager manager,
+            final boolean isFallbackFee) {
+        adjustForAssessed(payer, MISSING_ID, collector, MISSING_ID, amount, manager, isFallbackFee);
     }
 
+    /**
+     * Examines a custom fee (that is, an {@code amount} of a {@code denom} token being charged by a
+     * {@code chargingToken}); and updates the balance changes for its payer and collector in the
+     * given {@link BalanceChangeManager}.
+     *
+     * <p>If the fee is a fallback royalty fee, marks the payer's balance change with a special
+     * flag. When the contract service {@code TransferPrecompile} sees this flag, it <i>always</i>
+     * requires a payer authorization. (This is different from the normal case with custom fees,
+     * where the payer's authorization of the top-level token transfer <i>also</i> authorizes the
+     * network to charge the custom fee.)
+     *
+     * @param payer the payer of the fee
+     * @param chargingToken the token charging the fee
+     * @param collector the collector of the fee
+     * @param denom the denomination of the fee
+     * @param amount the amount of the fee
+     * @param manager the balance change manager
+     * @param isFallbackFee whether the fee is a fallback fee
+     */
     static void adjustForAssessed(
             final Id payer,
             final Id chargingToken,
             final Id collector,
             final Id denom,
             final long amount,
-            final BalanceChangeManager manager) {
+            final BalanceChangeManager manager,
+            final boolean isFallbackFee) {
         final var payerChange = adjustedChange(payer, chargingToken, denom, -amount, manager);
+        if (isFallbackFee) {
+            payerChange.setIncludesFallbackFee();
+        }
         payerChange.setCodeForInsufficientBalance(
                 INSUFFICIENT_SENDER_ACCOUNT_BALANCE_FOR_CUSTOM_FEE);
         adjustedChange(collector, chargingToken, denom, +amount, manager);

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/grpc/marshalling/FeeAssessor.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/grpc/marshalling/FeeAssessor.java
@@ -38,6 +38,9 @@ public class FeeAssessor {
     private final RoyaltyFeeAssessor royaltyFeeAssessor;
     private final FractionalFeeAssessor fractionalFeeAssessor;
 
+    public static final boolean IS_NOT_FALLBACK_FEE = false;
+    public static final boolean IS_FALLBACK_FEE = true;
+
     @Inject
     public FeeAssessor(
             FixedFeeAssessor fixedFeeAssessor,
@@ -111,7 +114,14 @@ public class FeeAssessor {
                 continue;
             }
             if (fee.getFeeType() == FIXED_FEE) {
-                fixedFeeAssessor.assess(payer, feeMeta, fee, balanceChangeManager, accumulator);
+                // This is a top-level fixed fee, not a fallback royalty fee
+                fixedFeeAssessor.assess(
+                        payer,
+                        feeMeta,
+                        fee,
+                        balanceChangeManager,
+                        accumulator,
+                        IS_NOT_FALLBACK_FEE);
                 if (balanceChangeManager.numChangesSoFar() > maxBalanceChanges) {
                     return ASSESSMENT_FAILED_WITH_TOO_MANY_ADJUSTMENTS_REQUIRED;
                 }

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/grpc/marshalling/FixedFeeAssessor.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/grpc/marshalling/FixedFeeAssessor.java
@@ -41,21 +41,35 @@ public class FixedFeeAssessor {
         this.customFeePayerExemptions = customFeePayerExemptions;
     }
 
+    /**
+     * Assess the given fixed fee, which may be either a top-level fixed fee or a fallback royalty
+     * fee.
+     *
+     * @param payer the payer of the fixed fee
+     * @param feeMeta the metadata for the token charging the fixed fee
+     * @param fee the fixed fee to assess
+     * @param changeManager the balance change manager to use for the assessment
+     * @param accumulator the accumulator for the assessed custom fees
+     * @param isFallbackFee whether the fee is a fallback royalty fee
+     * @return OK if the fee was assessed successfully, or a failure code if not
+     */
     public ResponseCodeEnum assess(
-            Id payer,
-            CustomFeeMeta feeMeta,
-            FcCustomFee fee,
-            BalanceChangeManager changeManager,
-            List<AssessedCustomFeeWrapper> accumulator) {
+            final Id payer,
+            final CustomFeeMeta feeMeta,
+            final FcCustomFee fee,
+            final BalanceChangeManager changeManager,
+            final List<AssessedCustomFeeWrapper> accumulator,
+            final boolean isFallbackFee) {
         if (customFeePayerExemptions.isPayerExempt(feeMeta, fee, payer)) {
             return OK;
         }
 
         final var fixedSpec = fee.getFixedFeeSpec();
         if (fixedSpec.getTokenDenomination() == null) {
-            return hbarFeeAssessor.assess(payer, fee, changeManager, accumulator);
+            return hbarFeeAssessor.assess(payer, fee, changeManager, accumulator, isFallbackFee);
         } else {
-            return htsFeeAssessor.assess(payer, feeMeta, fee, changeManager, accumulator);
+            return htsFeeAssessor.assess(
+                    payer, feeMeta, fee, changeManager, accumulator, isFallbackFee);
         }
     }
 }

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/grpc/marshalling/FractionalFeeAssessor.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/grpc/marshalling/FractionalFeeAssessor.java
@@ -15,6 +15,7 @@
  */
 package com.hedera.node.app.service.mono.grpc.marshalling;
 
+import static com.hedera.node.app.service.mono.grpc.marshalling.FeeAssessor.IS_NOT_FALLBACK_FEE;
 import static com.hedera.node.app.service.mono.state.submerkle.FcCustomFee.FeeType.FRACTIONAL_FEE;
 import static com.hedera.node.app.service.mono.state.submerkle.FcCustomFee.fixedFee;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.*;
@@ -91,7 +92,8 @@ public class FractionalFeeAssessor {
                                 denom.asEntityId(),
                                 fee.getFeeCollector(),
                                 fee.getAllCollectorsAreExempt());
-                fixedFeeAssessor.assess(payer, feeMeta, addedFee, changeManager, accumulator);
+                fixedFeeAssessor.assess(
+                        payer, feeMeta, addedFee, changeManager, accumulator, IS_NOT_FALLBACK_FEE);
             } else {
                 long exemptAmount;
                 try {

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/grpc/marshalling/HbarFeeAssessor.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/grpc/marshalling/HbarFeeAssessor.java
@@ -37,11 +37,12 @@ public class HbarFeeAssessor {
             final Id payer,
             final FcCustomFee hbarFee,
             final BalanceChangeManager changeManager,
-            final List<AssessedCustomFeeWrapper> accumulator) {
+            final List<AssessedCustomFeeWrapper> accumulator,
+            boolean isFallbackFee) {
         final var collector = hbarFee.getFeeCollectorAsId();
         final var fixedSpec = hbarFee.getFixedFeeSpec();
         final var amount = fixedSpec.getUnitsToCollect();
-        adjustForAssessedHbar(payer, collector, amount, changeManager);
+        adjustForAssessedHbar(payer, collector, amount, changeManager, isFallbackFee);
         final var effPayerAccountNums = new AccountID[] {payer.asGrpcAccount()};
         final var assessed =
                 new AssessedCustomFeeWrapper(collector.asEntityId(), amount, effPayerAccountNums);

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/grpc/marshalling/HtsFeeAssessor.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/grpc/marshalling/HtsFeeAssessor.java
@@ -37,7 +37,8 @@ public class HtsFeeAssessor {
             CustomFeeMeta chargingTokenMeta,
             FcCustomFee htsFee,
             BalanceChangeManager changeManager,
-            List<AssessedCustomFeeWrapper> accumulator) {
+            List<AssessedCustomFeeWrapper> accumulator,
+            boolean isFallbackFee) {
         final var collector = htsFee.getFeeCollectorAsId();
         final var fixedSpec = htsFee.getFixedFeeSpec();
         final var amount = fixedSpec.getUnitsToCollect();
@@ -48,7 +49,8 @@ public class HtsFeeAssessor {
                 collector,
                 denominatingToken,
                 amount,
-                changeManager);
+                changeManager,
+                isFallbackFee);
 
         final var effPayerAccountNums = new AccountID[] {payer.asGrpcAccount()};
         final var assessed =

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/grpc/marshalling/RoyaltyFeeAssessor.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/grpc/marshalling/RoyaltyFeeAssessor.java
@@ -15,6 +15,7 @@
  */
 package com.hedera.node.app.service.mono.grpc.marshalling;
 
+import static com.hedera.node.app.service.mono.grpc.marshalling.FeeAssessor.IS_FALLBACK_FEE;
 import static com.hedera.node.app.service.mono.state.submerkle.FcCustomFee.FeeType.ROYALTY_FEE;
 import static com.hedera.node.app.service.mono.store.models.Id.MISSING_ID;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.ACCOUNT_AMOUNT_TRANSFERS_ONLY_ALLOWED_FOR_FUNGIBLE_COMMON;
@@ -89,7 +90,12 @@ public class RoyaltyFeeAssessor {
                                     collector.asEntityId(),
                                     fee.getAllCollectorsAreExempt());
                     fixedFeeAssessor.assess(
-                            receiver, customFeeMeta, fallbackFee, changeManager, accumulator);
+                            receiver,
+                            customFeeMeta,
+                            fallbackFee,
+                            changeManager,
+                            accumulator,
+                            IS_FALLBACK_FEE);
                 }
             } else if (!customFeePayerExemptions.isPayerExempt(customFeeMeta, fee, payer)) {
                 final var fractionalValidity =

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ledger/BalanceChange.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ledger/BalanceChange.java
@@ -75,6 +75,10 @@ public class BalanceChange {
     private boolean isForCustomFee = false;
     private AccountID payerID = null;
 
+    // This is used to indicate if the balance change is for a custom fee that is a fallback fee
+    // This is used to enforce receiver signature requirements for fallback fees
+    private boolean includesFallbackFee = false;
+
     public static BalanceChange changingHbar(final AccountAmount aa, final AccountID payerID) {
         return new BalanceChange(null, aa, INSUFFICIENT_ACCOUNT_BALANCE, payerID);
     }
@@ -437,5 +441,22 @@ public class BalanceChange {
         if (isAlias(accountId)) return alias;
         else if (hasNonEmptyCounterPartyAlias()) return counterPartyAlias;
         else return null;
+    }
+
+    /**
+     * Boolean flag to indicate if the change is for a custom fee that includes a fallback fee.
+     *
+     * @return true if the change is for a custom fee that includes a fallback fee
+     */
+    public boolean includesFallbackFee() {
+        return includesFallbackFee;
+    }
+    /**
+     * Sets the flag to indicate if the change is for a custom fee that includes a fallback fee.
+     * This is used to enforce the receiver signature requirement in a crypto transfer of an NFT
+     * with a fallback royalty fee.
+     */
+    public void setIncludesFallbackFee() {
+        this.includesFallbackFee = true;
     }
 }

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/HTSPrecompiledContract.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/HTSPrecompiledContract.java
@@ -350,6 +350,7 @@ public class HTSPrecompiledContract extends AbstractPrecompiledContract {
                             precompilePricingUtils,
                             functionId,
                             senderAddress,
+                            dynamicProperties.getHtsUnsupportedCustomFeeReceiverDebits(),
                             dynamicProperties.isImplicitCreationEnabled(),
                             topLevelSigsEnabledForTransfer,
                             true);
@@ -366,6 +367,8 @@ public class HTSPrecompiledContract extends AbstractPrecompiledContract {
                                             precompilePricingUtils,
                                             functionId,
                                             senderAddress,
+                                            dynamicProperties
+                                                    .getHtsUnsupportedCustomFeeReceiverDebits(),
                                             dynamicProperties.isImplicitCreationEnabled(),
                                             topLevelSigsEnabledForTransfer,
                                             true));
@@ -714,6 +717,8 @@ public class HTSPrecompiledContract extends AbstractPrecompiledContract {
                                                             precompilePricingUtils,
                                                             functionId,
                                                             dynamicProperties
+                                                                    .getHtsUnsupportedCustomFeeReceiverDebits(),
+                                                            dynamicProperties
                                                                     .isImplicitCreationEnabled(),
                                                             topLevelSigsEnabledForTransfer));
 
@@ -733,6 +738,8 @@ public class HTSPrecompiledContract extends AbstractPrecompiledContract {
                                                             infrastructureFactory,
                                                             precompilePricingUtils,
                                                             functionId,
+                                                            dynamicProperties
+                                                                    .getHtsUnsupportedCustomFeeReceiverDebits(),
                                                             dynamicProperties
                                                                     .isImplicitCreationEnabled(),
                                                             topLevelSigsEnabledForTransfer));
@@ -913,6 +920,8 @@ public class HTSPrecompiledContract extends AbstractPrecompiledContract {
                                             infrastructureFactory,
                                             precompilePricingUtils,
                                             functionId,
+                                            dynamicProperties
+                                                    .getHtsUnsupportedCustomFeeReceiverDebits(),
                                             dynamicProperties.isImplicitCreationEnabled(),
                                             topLevelSigsEnabledForTransfer));
                     case AbiConstants.ABI_ID_TRANSFER_FROM_NFT -> checkFeatureFlag(
@@ -930,6 +939,8 @@ public class HTSPrecompiledContract extends AbstractPrecompiledContract {
                                             infrastructureFactory,
                                             precompilePricingUtils,
                                             functionId,
+                                            dynamicProperties
+                                                    .getHtsUnsupportedCustomFeeReceiverDebits(),
                                             dynamicProperties.isImplicitCreationEnabled(),
                                             topLevelSigsEnabledForTransfer));
                     default -> null;

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/ERCTransferPrecompile.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/ERCTransferPrecompile.java
@@ -34,6 +34,7 @@ import com.esaulpaugh.headlong.abi.Tuple;
 import com.esaulpaugh.headlong.abi.TypeFactory;
 import com.hedera.node.app.service.evm.exceptions.InvalidTransactionException;
 import com.hedera.node.app.service.mono.context.SideEffectsTracker;
+import com.hedera.node.app.service.mono.context.properties.CustomFeeType;
 import com.hedera.node.app.service.mono.contracts.sources.EvmSigsVerifier;
 import com.hedera.node.app.service.mono.state.submerkle.EntityId;
 import com.hedera.node.app.service.mono.state.submerkle.ExpirableTxnRecord;
@@ -57,6 +58,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 import java.util.function.Predicate;
 import java.util.function.UnaryOperator;
 import org.apache.tuweni.bytes.Bytes;
@@ -105,6 +107,7 @@ public class ERCTransferPrecompile extends TransferPrecompile {
             final InfrastructureFactory infrastructureFactory,
             final PrecompilePricingUtils pricingUtils,
             final int functionId,
+            final Set<CustomFeeType> htsUnsupportedCustomFeeReceiverDebits,
             final boolean isLazyCreationEnabled,
             final boolean topLevelSigsAreEnabled) {
         super(
@@ -117,6 +120,7 @@ public class ERCTransferPrecompile extends TransferPrecompile {
                 pricingUtils,
                 functionId,
                 callerAccount,
+                htsUnsupportedCustomFeeReceiverDebits,
                 isLazyCreationEnabled,
                 topLevelSigsAreEnabled,
                 false);
@@ -138,6 +142,7 @@ public class ERCTransferPrecompile extends TransferPrecompile {
             final InfrastructureFactory infrastructureFactory,
             final PrecompilePricingUtils pricingUtils,
             final int functionId,
+            final Set<CustomFeeType> htsUnsupportedCustomFeeReceiverDebits,
             final boolean isLazyCreationEnabled,
             final boolean topLevelSigsAreEnabled) {
         this(
@@ -153,6 +158,7 @@ public class ERCTransferPrecompile extends TransferPrecompile {
                 infrastructureFactory,
                 pricingUtils,
                 functionId,
+                htsUnsupportedCustomFeeReceiverDebits,
                 isLazyCreationEnabled,
                 topLevelSigsAreEnabled);
     }

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/TransferPrecompile.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/TransferPrecompile.java
@@ -254,8 +254,15 @@ public class TransferPrecompile extends AbstractWritePrecompile {
             if (change.hasAlias()) {
                 replaceAliasWithId(change, changes, completedLazyCreates);
             }
-            if (change.isForNft() || units < 0) {
-                if (change.isApprovedAllowance() || change.isForCustomFee()) {
+            final var isDebit = units < 0;
+            final var isCredit = units > 0;
+
+            if (change.isForNft() || isDebit) {
+                // The receiver signature is enforced for a transfer of NFT with a royalty fallback
+                // fee
+                final var isForNonFallbackRoyaltyFee =
+                        change.isForCustomFee() && !change.includesFallbackFee();
+                if (change.isApprovedAllowance() || isForNonFallbackRoyaltyFee) {
                     // Signing requirements are skipped for changes to be authorized via an
                     // allowance
                     continue;
@@ -299,7 +306,7 @@ public class TransferPrecompile extends AbstractWritePrecompile {
                                     ledgers,
                                     updater.aliases(),
                                     CryptoTransfer);
-                } else if (units > 0) {
+                } else if (isCredit) {
                     hasReceiverSigIfReq =
                             KeyActivationUtils.validateKey(
                                     frame,

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/TransferPrecompile.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/TransferPrecompile.java
@@ -44,6 +44,7 @@ import com.esaulpaugh.headlong.abi.TypeFactory;
 import com.google.protobuf.ByteString;
 import com.hedera.node.app.service.evm.exceptions.InvalidTransactionException;
 import com.hedera.node.app.service.mono.context.SideEffectsTracker;
+import com.hedera.node.app.service.mono.context.properties.CustomFeeType;
 import com.hedera.node.app.service.mono.contracts.sources.EvmSigsVerifier;
 import com.hedera.node.app.service.mono.grpc.marshalling.ImpliedTransfers;
 import com.hedera.node.app.service.mono.grpc.marshalling.ImpliedTransfersMarshal;
@@ -142,6 +143,7 @@ public class TransferPrecompile extends AbstractWritePrecompile {
     protected CryptoTransferWrapper transferOp;
     private AbstractAutoCreationLogic autoCreationLogic;
     private int numLazyCreates;
+    private Set<CustomFeeType> htsUnsupportedCustomReceiverDebits;
 
     // Non-final for testing purposes
     private boolean canFallbackToApprovals;
@@ -156,6 +158,7 @@ public class TransferPrecompile extends AbstractWritePrecompile {
             final PrecompilePricingUtils pricingUtils,
             final int functionId,
             final Address senderAddress,
+            final Set<CustomFeeType> htsUnsupportedCustomFeeReceiverDebits,
             final boolean isLazyCreationEnabled,
             final boolean topLevelSigsAreEnabled,
             final boolean canFallbackToApprovals) {
@@ -166,6 +169,7 @@ public class TransferPrecompile extends AbstractWritePrecompile {
         this.senderAddress = senderAddress;
         this.impliedTransfersMarshal =
                 infrastructureFactory.newImpliedTransfersMarshal(ledgers.customFeeSchedules());
+        this.htsUnsupportedCustomReceiverDebits = htsUnsupportedCustomFeeReceiverDebits;
         this.isLazyCreationEnabled = isLazyCreationEnabled;
         this.topLevelSigsAreEnabled = topLevelSigsAreEnabled;
         this.canFallbackToApprovals = canFallbackToApprovals;
@@ -239,6 +243,11 @@ public class TransferPrecompile extends AbstractWritePrecompile {
 
         hederaTokenStore.setAccountsLedger(ledgers.accounts());
 
+        final boolean allowFixedCustomFeeTransfers =
+                !htsUnsupportedCustomReceiverDebits.contains(CustomFeeType.FIXED_FEE);
+        final boolean allowRoyaltyFallbackCustomFeeTransfers =
+                !htsUnsupportedCustomReceiverDebits.contains(CustomFeeType.ROYALTY_FALLBACK_FEE);
+
         final var transferLogic =
                 infrastructureFactory.newTransferLogic(
                         hederaTokenStore,
@@ -254,8 +263,16 @@ public class TransferPrecompile extends AbstractWritePrecompile {
             if (change.hasAlias()) {
                 replaceAliasWithId(change, changes, completedLazyCreates);
             }
+
             final var isDebit = units < 0;
             final var isCredit = units > 0;
+
+            if (change.isForCustomFee() && isDebit) {
+                if (change.includesFallbackFee())
+                    validateTrue(
+                            allowRoyaltyFallbackCustomFeeTransfers, NOT_SUPPORTED, "royalty fee");
+                else validateTrue(allowFixedCustomFeeTransfers, NOT_SUPPORTED, "fixed fee");
+            }
 
             if (change.isForNft() || isDebit) {
                 // The receiver signature is enforced for a transfer of NFT with a royalty fallback

--- a/hedera-node/hedera-mono-service/src/main/resources/bootstrap.properties
+++ b/hedera-node/hedera-mono-service/src/main/resources/bootstrap.properties
@@ -84,6 +84,7 @@ contracts.precompile.exchangeRateGasCost=100
 contracts.precompile.exportRecordResults=true
 contracts.precompile.htsDefaultGasCost=10000
 contracts.precompile.htsEnableTokenCreate=true
+contracts.precompile.unsupportedCustomFeeReceiverDebits=
 # Current implementation requires two storage get()'s to remove a slot
 expiry.minCycleEntryCapacity=ACCOUNTS_GET,ACCOUNTS_GET_FOR_MODIFY,STORAGE_GET,STORAGE_GET,STORAGE_REMOVE,STORAGE_PUT
 expiry.throttleResource=expiry-throttle.json

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/context/properties/BootstrapPropertiesTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/context/properties/BootstrapPropertiesTest.java
@@ -153,6 +153,9 @@ class BootstrapPropertiesTest {
                     entry(CONTRACTS_PRECOMPILE_HTS_DEFAULT_GAS_COST, 10000L),
                     entry(CONTRACTS_PRECOMPILE_EXPORT_RECORD_RESULTS, true),
                     entry(CONTRACTS_PRECOMPILE_HTS_ENABLE_TOKEN_CREATE, true),
+                    entry(
+                            CONTRACTS_PRECOMPILE_HTS_UNSUPPORTED_CUSTOM_FEE_RECEIVER_DEBITS,
+                            EnumSet.of(CustomFeeType.FIXED_FEE)),
                     entry(DEV_ONLY_DEFAULT_NODE_LISTENS, true),
                     entry(CONTRACTS_PRECOMPILE_ATOMIC_CRYPTO_TRANSFER_ENABLED, true),
                     entry(DEV_DEFAULT_LISTENING_NODE_ACCOUNT, "0.0.3"),

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/grpc/marshalling/FeeAssessorTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/grpc/marshalling/FeeAssessorTest.java
@@ -15,6 +15,7 @@
  */
 package com.hedera.node.app.service.mono.grpc.marshalling;
 
+import static com.hedera.node.app.service.mono.grpc.marshalling.FeeAssessor.IS_NOT_FALLBACK_FEE;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.CUSTOM_FEE_CHARGING_EXCEEDED_MAX_ACCOUNT_AMOUNTS;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.CUSTOM_FEE_CHARGING_EXCEEDED_MAX_RECURSION_DEPTH;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.CUSTOM_FEE_OUTSIDE_NUMERIC_RANGE;
@@ -148,9 +149,22 @@ class FeeAssessorTest {
                         props);
 
         // then:
-        verify(fixedFeeAssessor).assess(payer, meta, hbarFee, balanceChangeManager, accumulator);
+        verify(fixedFeeAssessor)
+                .assess(
+                        payer,
+                        meta,
+                        hbarFee,
+                        balanceChangeManager,
+                        accumulator,
+                        IS_NOT_FALLBACK_FEE);
         verify(fixedFeeAssessor, times(2))
-                .assess(payer, meta, htsFee, balanceChangeManager, accumulator);
+                .assess(
+                        payer,
+                        meta,
+                        htsFee,
+                        balanceChangeManager,
+                        accumulator,
+                        IS_NOT_FALLBACK_FEE);
         assertEquals(OK, result);
     }
 
@@ -174,9 +188,22 @@ class FeeAssessorTest {
                         props);
 
         // then:
-        verify(fixedFeeAssessor).assess(payer, feeMeta, hbarFee, balanceChangeManager, accumulator);
+        verify(fixedFeeAssessor)
+                .assess(
+                        payer,
+                        feeMeta,
+                        hbarFee,
+                        balanceChangeManager,
+                        accumulator,
+                        IS_NOT_FALLBACK_FEE);
         verify(fixedFeeAssessor, times(2))
-                .assess(payer, feeMeta, htsFee, balanceChangeManager, accumulator);
+                .assess(
+                        payer,
+                        feeMeta,
+                        htsFee,
+                        balanceChangeManager,
+                        accumulator,
+                        IS_NOT_FALLBACK_FEE);
         verify(fractionalFeeAssessor)
                 .assessAllFractional(fungibleTrigger, feeMeta, balanceChangeManager, accumulator);
         assertEquals(OK, result);
@@ -196,7 +223,14 @@ class FeeAssessorTest {
                         props);
 
         // then:
-        verify(fixedFeeAssessor).assess(payer, meta, hbarFee, balanceChangeManager, accumulator);
+        verify(fixedFeeAssessor)
+                .assess(
+                        payer,
+                        meta,
+                        hbarFee,
+                        balanceChangeManager,
+                        accumulator,
+                        IS_NOT_FALLBACK_FEE);
         assertEquals(OK, result);
     }
 
@@ -310,7 +344,14 @@ class FeeAssessorTest {
                         props);
 
         // then:
-        verify(fixedFeeAssessor).assess(payer, meta, htsFee, balanceChangeManager, accumulator);
+        verify(fixedFeeAssessor)
+                .assess(
+                        payer,
+                        meta,
+                        htsFee,
+                        balanceChangeManager,
+                        accumulator,
+                        IS_NOT_FALLBACK_FEE);
         assertEquals(OK, result);
     }
 
@@ -331,8 +372,22 @@ class FeeAssessorTest {
                         props);
 
         // then:
-        verify(fixedFeeAssessor).assess(payer, meta, hbarFee, balanceChangeManager, accumulator);
-        verify(fixedFeeAssessor).assess(payer, meta, htsFee, balanceChangeManager, accumulator);
+        verify(fixedFeeAssessor)
+                .assess(
+                        payer,
+                        meta,
+                        hbarFee,
+                        balanceChangeManager,
+                        accumulator,
+                        IS_NOT_FALLBACK_FEE);
+        verify(fixedFeeAssessor)
+                .assess(
+                        payer,
+                        meta,
+                        htsFee,
+                        balanceChangeManager,
+                        accumulator,
+                        IS_NOT_FALLBACK_FEE);
         verify(fractionalFeeAssessor, never())
                 .assessAllFractional(fungibleTrigger, feeMeta, balanceChangeManager, accumulator);
         assertEquals(CUSTOM_FEE_CHARGING_EXCEEDED_MAX_ACCOUNT_AMOUNTS, result);
@@ -358,8 +413,22 @@ class FeeAssessorTest {
                         props);
 
         // then:
-        verify(fixedFeeAssessor).assess(payer, meta, hbarFee, balanceChangeManager, accumulator);
-        verify(fixedFeeAssessor).assess(payer, meta, htsFee, balanceChangeManager, accumulator);
+        verify(fixedFeeAssessor)
+                .assess(
+                        payer,
+                        meta,
+                        hbarFee,
+                        balanceChangeManager,
+                        accumulator,
+                        IS_NOT_FALLBACK_FEE);
+        verify(fixedFeeAssessor)
+                .assess(
+                        payer,
+                        meta,
+                        htsFee,
+                        balanceChangeManager,
+                        accumulator,
+                        IS_NOT_FALLBACK_FEE);
         verify(fractionalFeeAssessor)
                 .assessAllFractional(fungibleTrigger, feeMeta, balanceChangeManager, accumulator);
         assertEquals(CUSTOM_FEE_OUTSIDE_NUMERIC_RANGE, result);
@@ -386,8 +455,22 @@ class FeeAssessorTest {
                         props);
 
         // then:
-        verify(fixedFeeAssessor).assess(payer, meta, hbarFee, balanceChangeManager, accumulator);
-        verify(fixedFeeAssessor).assess(payer, meta, htsFee, balanceChangeManager, accumulator);
+        verify(fixedFeeAssessor)
+                .assess(
+                        payer,
+                        meta,
+                        hbarFee,
+                        balanceChangeManager,
+                        accumulator,
+                        IS_NOT_FALLBACK_FEE);
+        verify(fixedFeeAssessor)
+                .assess(
+                        payer,
+                        meta,
+                        htsFee,
+                        balanceChangeManager,
+                        accumulator,
+                        IS_NOT_FALLBACK_FEE);
         verify(fractionalFeeAssessor)
                 .assessAllFractional(fungibleTrigger, feeMeta, balanceChangeManager, accumulator);
         assertEquals(CUSTOM_FEE_CHARGING_EXCEEDED_MAX_ACCOUNT_AMOUNTS, result);

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/grpc/marshalling/FixedFeeAssessorTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/grpc/marshalling/FixedFeeAssessorTest.java
@@ -54,14 +54,16 @@ class FixedFeeAssessorTest {
         final var hbarFee = FcCustomFee.fixedFee(1, null, otherCollector, false);
 
         given(customFeePayerExemptions.isPayerExempt(any(), any(), any())).willReturn(false);
-        given(hbarFeeAssessor.assess(payer, hbarFee, changeManager, mockAccum)).willReturn(OK);
+        given(hbarFeeAssessor.assess(payer, hbarFee, changeManager, mockAccum, false))
+                .willReturn(OK);
 
         // when:
-        final var result = subject.assess(payer, chargingMeta, hbarFee, changeManager, mockAccum);
+        final var result =
+                subject.assess(payer, chargingMeta, hbarFee, changeManager, mockAccum, false);
 
         // then:
         assertEquals(OK, result);
-        BDDMockito.verify(hbarFeeAssessor).assess(payer, hbarFee, changeManager, mockAccum);
+        BDDMockito.verify(hbarFeeAssessor).assess(payer, hbarFee, changeManager, mockAccum, false);
     }
 
     @Test
@@ -69,16 +71,17 @@ class FixedFeeAssessorTest {
         FcCustomFee htsFee = FcCustomFee.fixedFee(1, feeDenom, otherCollector, false);
 
         given(customFeePayerExemptions.isPayerExempt(any(), any(), any())).willReturn(false);
-        given(htsFeeAssessor.assess(payer, chargingMeta, htsFee, changeManager, mockAccum))
+        given(htsFeeAssessor.assess(payer, chargingMeta, htsFee, changeManager, mockAccum, false))
                 .willReturn(OK);
 
         // when:
-        final var result = subject.assess(payer, chargingMeta, htsFee, changeManager, mockAccum);
+        final var result =
+                subject.assess(payer, chargingMeta, htsFee, changeManager, mockAccum, false);
 
         // then:
         assertEquals(OK, result);
         BDDMockito.verify(htsFeeAssessor)
-                .assess(payer, chargingMeta, htsFee, changeManager, mockAccum);
+                .assess(payer, chargingMeta, htsFee, changeManager, mockAccum, false);
     }
 
     @Test
@@ -90,7 +93,8 @@ class FixedFeeAssessorTest {
 
         // when:
         final var result =
-                subject.assess(chargingToken, chargingMeta, htsFee, changeManager, mockAccum);
+                subject.assess(
+                        chargingToken, chargingMeta, htsFee, changeManager, mockAccum, false);
 
         // then:
         assertEquals(OK, result);

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/grpc/marshalling/FractionalFeeAssessorTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/grpc/marshalling/FractionalFeeAssessorTest.java
@@ -135,7 +135,8 @@ class FractionalFeeAssessorTest {
                                 netOfTransfersFeeCollector,
                                 true),
                         changeManager,
-                        accumulator);
+                        accumulator,
+                        false);
     }
 
     @Test

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/grpc/marshalling/HbarFeeAssessorTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/grpc/marshalling/HbarFeeAssessorTest.java
@@ -53,7 +53,7 @@ class HbarFeeAssessorTest {
                 .willReturn(collectorChange);
 
         // when:
-        subject.assess(payer, hbarFee, balanceChangeManager, accumulator);
+        subject.assess(payer, hbarFee, balanceChangeManager, accumulator, false);
 
         // then:
         verify(payerChange).aggregateUnits(-amountOfHbarFee);
@@ -74,7 +74,7 @@ class HbarFeeAssessorTest {
                 INSUFFICIENT_SENDER_ACCOUNT_BALANCE_FOR_CUSTOM_FEE);
 
         // when:
-        subject.assess(payer, hbarFee, balanceChangeManager, accumulator);
+        subject.assess(payer, hbarFee, balanceChangeManager, accumulator, false);
 
         // then:
         verify(balanceChangeManager).includeChange(expectedPayerChange);

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/grpc/marshalling/HtsFeeAssessorTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/grpc/marshalling/HtsFeeAssessorTest.java
@@ -56,7 +56,7 @@ class HtsFeeAssessorTest {
         given(balanceChangeManager.changeFor(feeCollector, denom)).willReturn(collectorChange);
 
         // when:
-        subject.assess(payer, nonDenomFeeMeta, htsFee, balanceChangeManager, accumulator);
+        subject.assess(payer, nonDenomFeeMeta, htsFee, balanceChangeManager, accumulator, false);
 
         // then:
         verify(collectorChange).aggregateUnits(+amountOfHtsFee);
@@ -80,7 +80,34 @@ class HtsFeeAssessorTest {
                 INSUFFICIENT_SENDER_ACCOUNT_BALANCE_FOR_CUSTOM_FEE);
 
         // when:
-        subject.assess(payer, nonDenomFeeMeta, htsFee, balanceChangeManager, accumulator);
+        subject.assess(payer, nonDenomFeeMeta, htsFee, balanceChangeManager, accumulator, false);
+
+        // then:
+        verify(balanceChangeManager).includeChange(expectedPayerChange);
+        verify(balanceChangeManager)
+                .includeChange(
+                        BalanceChange.tokenCustomFeeAdjust(feeCollector, denom, +amountOfHtsFee));
+        // and:
+        assertEquals(1, accumulator.size());
+        assertEquals(expectedAssess, accumulator.get(0));
+    }
+
+    @Test
+    void addsNewChangesWithFallbackFeeIfNotPresent() {
+        // setup:
+        final var expectedAssess =
+                new AssessedCustomFeeWrapper(
+                        htsFeeCollector, feeDenom, amountOfHtsFee, effPayerNums);
+
+        // given:
+        final var expectedPayerChange =
+                BalanceChange.tokenCustomFeeAdjust(payer, denom, -amountOfHtsFee);
+        expectedPayerChange.setIncludesFallbackFee();
+        expectedPayerChange.setCodeForInsufficientBalance(
+                INSUFFICIENT_SENDER_ACCOUNT_BALANCE_FOR_CUSTOM_FEE);
+
+        // when:
+        subject.assess(payer, nonDenomFeeMeta, htsFee, balanceChangeManager, accumulator, true);
 
         // then:
         verify(balanceChangeManager).includeChange(expectedPayerChange);
@@ -107,7 +134,7 @@ class HtsFeeAssessorTest {
                 INSUFFICIENT_SENDER_ACCOUNT_BALANCE_FOR_CUSTOM_FEE);
 
         // when:
-        subject.assess(payer, denomFeeMeta, htsFee, balanceChangeManager, accumulator);
+        subject.assess(payer, denomFeeMeta, htsFee, balanceChangeManager, accumulator, false);
 
         // then:
         verify(balanceChangeManager).includeChange(expectedPayerChange);

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/grpc/marshalling/RoyaltyFeeAssessorTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/grpc/marshalling/RoyaltyFeeAssessorTest.java
@@ -103,7 +103,8 @@ class RoyaltyFeeAssessorTest {
                         feeMeta,
                         FcCustomFee.fixedFee(33, null, targetCollector, false),
                         changeManager,
-                        accumulator);
+                        accumulator,
+                        true);
     }
 
     @Test
@@ -142,7 +143,8 @@ class RoyaltyFeeAssessorTest {
                         feeMeta,
                         FcCustomFee.fixedFee(33, denom, targetCollector, false),
                         changeManager,
-                        accumulator);
+                        accumulator,
+                        true);
     }
 
     @Test

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/BalanceChangeTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/BalanceChangeTest.java
@@ -119,7 +119,10 @@ class BalanceChangeTest {
         adjust.setCodeForInsufficientBalance(INSUFFICIENT_PAYER_BALANCE);
         assertEquals(INSUFFICIENT_PAYER_BALANCE, adjust.codeForInsufficientBalance());
         adjust.setExemptFromCustomFees(false);
+        assertFalse(adjust.includesFallbackFee());
         assertFalse(adjust.isExemptFromCustomFees());
+        adjust.setIncludesFallbackFee();
+        assertTrue(adjust.includesFallbackFee());
     }
 
     @Test

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/HTSTestsUtil.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/HTSTestsUtil.java
@@ -556,6 +556,27 @@ public class HTSTestsUtil {
                                     .setSerialNumber(2L)
                                     .build(),
                             payer));
+    public static final List<BalanceChange> nftTransferChangesWithCustomFeesForRoyalty =
+            List.of(
+                    BalanceChange.changingNftOwnership(
+                            Id.fromGrpcToken(token),
+                            token,
+                            NftTransfer.newBuilder()
+                                    .setSenderAccountID(sender)
+                                    .setReceiverAccountID(receiver)
+                                    .setSerialNumber(1L)
+                                    .build(),
+                            payer),
+                    /* Simulate an assessed fallback fee */
+                    setFallBackFeeChange(
+                                    List.of(
+                                            BalanceChange.tokenCustomFeeAdjust(
+                                                    Id.fromGrpcAccount(receiver),
+                                                    Id.fromGrpcToken(token),
+                                                    -AMOUNT)))
+                            .get(0),
+                    BalanceChange.tokenCustomFeeAdjust(
+                            Id.fromGrpcAccount(feeCollector), Id.fromGrpcToken(token), +AMOUNT));
     public static final List<BalanceChange> balanceChangesForLazyCreateFailing =
             List.of(
                     BalanceChange.changingNftOwnership(
@@ -765,6 +786,12 @@ public class HTSTestsUtil {
             final List<TokenKeyWrapper> keys) {
         return new TokenUpdateWrapper(
                 nonFungible, null, null, null, null, keys, new TokenExpiryWrapper(0, null, 0));
+    }
+
+    private static List<BalanceChange> setFallBackFeeChange(
+            final List<BalanceChange> balanceChanges) {
+        balanceChanges.forEach(balanceChange -> balanceChange.setIncludesFallbackFee());
+        return balanceChanges;
     }
 
     public static final TokenCreateWrapper.FixedFeeWrapper fixedFee =

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/TransferPrecompilesTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/TransferPrecompilesTest.java
@@ -50,6 +50,7 @@ import static com.hedera.node.app.service.mono.store.contracts.precompile.HTSTes
 import static com.hedera.node.app.service.mono.store.contracts.precompile.HTSTestsUtil.hbarOnlyChanges;
 import static com.hedera.node.app.service.mono.store.contracts.precompile.HTSTestsUtil.hbarOnlyChangesAliased;
 import static com.hedera.node.app.service.mono.store.contracts.precompile.HTSTestsUtil.nftTransferChanges;
+import static com.hedera.node.app.service.mono.store.contracts.precompile.HTSTestsUtil.nftTransferChangesWithCustomFeesForRoyalty;
 import static com.hedera.node.app.service.mono.store.contracts.precompile.HTSTestsUtil.nftTransferChangesWithCustomFeesThatAreAlsoApproved;
 import static com.hedera.node.app.service.mono.store.contracts.precompile.HTSTestsUtil.nftTransferList;
 import static com.hedera.node.app.service.mono.store.contracts.precompile.HTSTestsUtil.nftsTransferChanges;
@@ -781,6 +782,111 @@ class TransferPrecompilesTest {
         verify(wrappedLedgers).commit();
         verify(worldUpdater)
                 .manageInProgressRecord(recordsHistorian, mockRecordBuilder, mockSynthBodyBuilder);
+    }
+
+    @Test
+    void transferNftsHappyPathWithRoyaltyFeeWorks() throws InvalidProtocolBufferException {
+        final Bytes pretendArguments = Bytes.of(Integers.toBytes(ABI_ID_TRANSFER_NFTS));
+
+        final var recipientAddr = Address.ALTBN128_ADD;
+        final var senderId = Id.fromGrpcAccount(sender);
+        final var receiverId = Id.fromGrpcAccount(receiver);
+
+        givenMinimalFrameContext();
+        givenLedgers();
+        givenPricingUtilsContext();
+        given(frame.getRecipientAddress()).willReturn(recipientAddr);
+        given(frame.getSenderAddress()).willReturn(contractAddress);
+        given(infrastructureFactory.newSideEffects()).willReturn(sideEffects);
+        given(infrastructureFactory.newImpliedTransfersMarshal(any()))
+                .willReturn(impliedTransfersMarshal);
+        given(worldUpdater.permissivelyUnaliased(any()))
+                .willAnswer(invocationOnMock -> invocationOnMock.getArgument(0));
+
+        given(syntheticTxnFactory.createCryptoTransfer(Collections.singletonList(nftsTransferList)))
+                .willReturn(mockSynthBodyBuilder);
+        given(mockSynthBodyBuilder.getCryptoTransfer()).willReturn(cryptoTransferTransactionBody);
+        given(
+                        sigsVerifier.hasActiveKey(
+                                Mockito.anyBoolean(), any(), any(), any(), eq(CryptoTransfer)))
+                .willReturn(true);
+        given(
+                        sigsVerifier.hasActiveKeyOrNoReceiverSigReq(
+                                Mockito.anyBoolean(), any(), any(), any(), eq(CryptoTransfer)))
+                .willReturn(true);
+        transferPrecompile
+                .when(() -> decodeTransferNFTs(eq(pretendArguments), any(), any()))
+                .thenReturn(CRYPTO_TRANSFER_NFTS_WRAPPER);
+        given(impliedTransfersMarshal.validityWithCurrentProps(cryptoTransferTransactionBody))
+                .willReturn(OK);
+
+        given(infrastructureFactory.newHederaTokenStore(sideEffects, tokens, nfts, tokenRels))
+                .willReturn(hederaTokenStore);
+
+        given(
+                        infrastructureFactory.newTransferLogic(
+                                hederaTokenStore, sideEffects, nfts, accounts, tokenRels))
+                .willReturn(transferLogic);
+        given(
+                        feeCalculator.estimatedGasPriceInTinybars(
+                                HederaFunctionality.ContractCall, timestamp))
+                .willReturn(1L);
+        given(mockSynthBodyBuilder.build())
+                .willReturn(
+                        TransactionBody.newBuilder()
+                                .setCryptoTransfer(cryptoTransferTransactionBody)
+                                .build());
+        given(mockSynthBodyBuilder.setTransactionID(any(TransactionID.class)))
+                .willReturn(mockSynthBodyBuilder);
+        given(feeCalculator.computeFee(any(), any(), any(), any())).willReturn(mockFeeObject);
+        given(mockFeeObject.getServiceFee()).willReturn(1L);
+        given(
+                        creator.createSuccessfulSyntheticRecord(
+                                Collections.emptyList(), sideEffects, EMPTY_MEMO))
+                .willReturn(mockRecordBuilder);
+        given(
+                        impliedTransfersMarshal.assessCustomFeesAndValidate(
+                                anyInt(), anyInt(), anyInt(), any(), any(), any()))
+                .willReturn(impliedTransfers);
+        given(impliedTransfers.getAllBalanceChanges())
+                .willReturn(nftTransferChangesWithCustomFeesForRoyalty);
+        given(impliedTransfers.getMeta()).willReturn(impliedTransfersMeta);
+        given(impliedTransfersMeta.code()).willReturn(OK);
+        given(aliases.resolveForEvm(any()))
+                .willAnswer(invocationOnMock -> invocationOnMock.getArgument(0));
+        given(worldUpdater.aliases()).willReturn(aliases);
+        given(frame.getSenderAddress()).willReturn(contractAddress);
+        when(accessorFactory.uncheckedSpecializedAccessor(any())).thenCallRealMethod();
+        when(accessorFactory.constructSpecializedAccessor(any())).thenCallRealMethod();
+
+        // when:
+        subject.prepareFields(frame);
+        subject.prepareComputation(pretendArguments, a -> a);
+        subject.getPrecompile().getGasRequirement(TEST_CONSENSUS_TIME);
+        final var result = subject.computeInternal(frame);
+
+        // then:
+        assertEquals(successResult, result);
+        // and:
+        verify(transferLogic).doZeroSum(nftTransferChangesWithCustomFeesForRoyalty);
+        verify(wrappedLedgers).commit();
+        verify(worldUpdater)
+                .manageInProgressRecord(recordsHistorian, mockRecordBuilder, mockSynthBodyBuilder);
+
+        verify(sigsVerifier)
+                .hasActiveKey(
+                        true,
+                        senderId.asEvmAddress(),
+                        recipientAddr,
+                        wrappedLedgers,
+                        CryptoTransfer);
+        verify(sigsVerifier)
+                .hasActiveKey(
+                        true,
+                        receiverId.asEvmAddress(),
+                        recipientAddr,
+                        wrappedLedgers,
+                        CryptoTransfer);
     }
 
     @Test

--- a/hedera-node/hedera-mono-service/src/test/resources/bootstrap.properties
+++ b/hedera-node/hedera-mono-service/src/test/resources/bootstrap.properties
@@ -84,6 +84,7 @@ contracts.precompile.exchangeRateGasCost=100
 contracts.precompile.exportRecordResults=true
 contracts.precompile.htsDefaultGasCost=10000
 contracts.precompile.htsEnableTokenCreate=true
+contracts.precompile.unsupportedCustomFeeReceiverDebits=
 # Current implementation requires two storage get()'s to remove a slot
 expiry.minCycleEntryCapacity=ACCOUNTS_GET,ACCOUNTS_GET_FOR_MODIFY,STORAGE_GET,STORAGE_GET,STORAGE_REMOVE,STORAGE_PUT
 expiry.throttleResource=expiry-throttle.json

--- a/hedera-node/hedera-mono-service/src/test/resources/bootstrap/standard.properties
+++ b/hedera-node/hedera-mono-service/src/test/resources/bootstrap/standard.properties
@@ -84,6 +84,7 @@ contracts.precompile.exchangeRateGasCost=100
 contracts.precompile.exportRecordResults=true
 contracts.precompile.htsDefaultGasCost=10000
 contracts.precompile.htsEnableTokenCreate=true
+contracts.precompile.unsupportedCustomFeeReceiverDebits=FIXED_FEE
 contracts.redirectTokenCalls=true
 contracts.referenceSlotLifetime=31536000
 contracts.scheduleThrottleMaxGasLimit=5000000
@@ -209,4 +210,3 @@ stats.runningAvgHalfLifeSecs=10.0
 stats.speedometerHalfLifeSecs=10.0
 utilPrng.isEnabled=true
 tokens.autoCreations.isEnabled=true
-

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hapi/ContractCallSuite.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hapi/ContractCallSuite.java
@@ -141,10 +141,10 @@ public class ContractCallSuite extends HapiSuite {
     private static final String OWNER = "owner";
     private static final String INSERT = "insert";
     private static final String TOKEN_ISSUER = "tokenIssuer";
-    private static final String DECIMALS = "decimals";
+    public static final String DECIMALS = "decimals";
     private static final String BALANCE_OF = "balanceOf";
     private static final String ISSUER_TOKEN_BALANCE = "issuerTokenBalance";
-    private static final String TRANSFER = "transfer";
+    public static final String TRANSFER = "transfer";
     private static final String ALICE_TOKEN_BALANCE = "aliceTokenBalance";
     private static final String CAROL_TOKEN_BALANCE = "carolTokenBalance";
     private static final String BOB_TOKEN_BALANCE = "bobTokenBalance";

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/AssociatePrecompileSuite.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/AssociatePrecompileSuite.java
@@ -19,7 +19,6 @@ import static com.hedera.services.bdd.spec.HapiPropertySource.asDotDelimitedLong
 import static com.hedera.services.bdd.spec.HapiPropertySource.asHexedSolidityAddress;
 import static com.hedera.services.bdd.spec.HapiPropertySource.idAsHeadlongAddress;
 import static com.hedera.services.bdd.spec.HapiSpec.defaultHapiSpec;
-import static com.hedera.services.bdd.spec.HapiSpec.onlyDefaultHapiSpec;
 import static com.hedera.services.bdd.spec.assertions.ContractFnResultAsserts.resultWith;
 import static com.hedera.services.bdd.spec.assertions.TransactionRecordAsserts.recordWith;
 import static com.hedera.services.bdd.spec.keys.KeyShape.DELEGATE_CONTRACT;
@@ -500,7 +499,7 @@ public class AssociatePrecompileSuite extends HapiSuite {
                         Address.toChecksumAddress("0xabababababababababababababababababababab"));
         final var txn = "txn";
 
-        return onlyDefaultHapiSpec("AssociateWithMissingEvmAddressHasSaneTxnAndRecord")
+        return defaultHapiSpec("AssociateWithMissingEvmAddressHasSaneTxnAndRecord")
                 .given(
                         cryptoCreate(TOKEN_TREASURY),
                         uploadInitCode(INNER_CONTRACT),

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/ContractKeysStillWorkAsExpectedSuite.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/ContractKeysStillWorkAsExpectedSuite.java
@@ -26,7 +26,9 @@ import static com.hedera.services.bdd.spec.keys.KeyShape.sigs;
 import static com.hedera.services.bdd.spec.keys.SigControl.ON;
 import static com.hedera.services.bdd.spec.keys.SigControl.SECP256K1_ON;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getAccountBalance;
+import static com.hedera.services.bdd.spec.queries.QueryVerbs.getAccountInfo;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getContractInfo;
+import static com.hedera.services.bdd.spec.queries.QueryVerbs.getTokenInfo;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getTokenNftInfo;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getTxnRecord;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.contractCall;
@@ -39,11 +41,17 @@ import static com.hedera.services.bdd.spec.transactions.TxnVerbs.mintToken;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.tokenAssociate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.tokenCreate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.uploadInitCode;
+import static com.hedera.services.bdd.spec.transactions.token.CustomFeeSpecs.fixedHbarFeeInheritingRoyaltyCollector;
+import static com.hedera.services.bdd.spec.transactions.token.CustomFeeSpecs.fixedHtsFeeInheritingRoyaltyCollector;
+import static com.hedera.services.bdd.spec.transactions.token.CustomFeeSpecs.royaltyFeeWithFallback;
+import static com.hedera.services.bdd.spec.transactions.token.TokenMovement.moving;
+import static com.hedera.services.bdd.spec.transactions.token.TokenMovement.movingUnique;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.blockingOrder;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.childRecordsCheck;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.newKeyNamed;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.noOp;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.overriding;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.overridingAllOf;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.overridingThree;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.sourcing;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.withOpContext;
@@ -64,6 +72,7 @@ import com.hedera.services.bdd.suites.HapiSuite;
 import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
 import com.hederahashgraph.api.proto.java.TokenType;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -71,6 +80,8 @@ import org.apache.logging.log4j.Logger;
 public class ContractKeysStillWorkAsExpectedSuite extends HapiSuite {
     private static final Logger log =
             LogManager.getLogger(ContractKeysStillWorkAsExpectedSuite.class);
+    private static final String EVM_ALIAS_ENABLED_PROP =
+            "cryptoCreateWithAliasAndEvmAddress.enabled";
     public static final String CONTRACTS_MAX_NUM_WITH_HAPI_SIGS_ACCESS =
             "contracts.maxNumWithHapiSigsAccess";
 
@@ -96,7 +107,185 @@ public class ContractKeysStillWorkAsExpectedSuite extends HapiSuite {
                 canStillTransferByVirtueOfContractIdInEOAThreshold(),
                 approvalFallbacksRequiredWithoutTopLevelSigAccess(),
                 topLevelSigsStillWorkWithDefaultGrandfatherNum(),
-                contractCanStillTransferItsOwnAssets());
+                contractCanStillTransferItsOwnAssets(),
+                fallbackFeeForHtsPayerMustSign(),
+                fallbackFeePayerMustSign());
+    }
+
+    private HapiSpec fallbackFeePayerMustSign() {
+        final AtomicReference<Address> senderAddr = new AtomicReference<>();
+        final AtomicReference<Address> receiverAddr = new AtomicReference<>();
+        final AtomicReference<Address> nonFungibleTokenMirrorAddr = new AtomicReference<>();
+
+        final var treasury = "treasury";
+        final var sender = "sender";
+        final var receiver = "receiver";
+        final var nft = "nft";
+        final var failedCallTxn = "failedCallTxn";
+
+        return propertyPreservingHapiSpec("FallbackFeePayerMustSign")
+                .preserving(EVM_ALIAS_ENABLED_PROP)
+                .given(
+                        overriding(EVM_ALIAS_ENABLED_PROP, "true"),
+                        uploadInitCode(WELL_KNOWN_TREASURY_CONTRACT),
+                        contractCreate(WELL_KNOWN_TREASURY_CONTRACT),
+                        newKeyNamed(MULTI_KEY),
+                        cryptoCreate(treasury),
+                        cryptoCreate(sender)
+                                .keyShape(SECP256K1_ON)
+                                .exposingEvmAddressTo(senderAddr::set),
+                        getAccountInfo(sender).logged(),
+                        cryptoCreate(receiver)
+                                .keyShape(SECP256K1_ON)
+                                .balance(ONE_HBAR)
+                                .exposingEvmAddressTo(receiverAddr::set))
+                .when(
+                        tokenCreate(nft)
+                                .exposingAddressTo(nonFungibleTokenMirrorAddr::set)
+                                .tokenType(TokenType.NON_FUNGIBLE_UNIQUE)
+                                .initialSupply(0)
+                                .supplyKey(MULTI_KEY)
+                                .withCustom(
+                                        royaltyFeeWithFallback(
+                                                1,
+                                                2,
+                                                fixedHbarFeeInheritingRoyaltyCollector(ONE_HBAR),
+                                                treasury))
+                                .treasury(treasury),
+                        getTokenInfo(nft).logged(),
+                        tokenAssociate(sender, nft),
+                        tokenAssociate(receiver, nft),
+                        mintToken(
+                                nft,
+                                List.of(
+                                        ByteString.copyFromUtf8("serialNo1"),
+                                        ByteString.copyFromUtf8("serialNo2"))),
+                        cryptoTransfer(movingUnique(nft, 1, 2).between(treasury, sender)))
+                .then(
+                        // Without the receiver signature, will fail with INVALID_SIGNATURE
+                        sourcing(
+                                () ->
+                                        contractCall(
+                                                        WELL_KNOWN_TREASURY_CONTRACT,
+                                                        "transferSerialNo1FromToOthers",
+                                                        nonFungibleTokenMirrorAddr.get(),
+                                                        senderAddr.get(),
+                                                        receiverAddr.get())
+                                                .gas(2_000_000)
+                                                .via(failedCallTxn)
+                                                .hasKnownStatus(CONTRACT_REVERT_EXECUTED)
+                                                .alsoSigningWithFullPrefix(sender)),
+                        childRecordsCheck(
+                                failedCallTxn,
+                                CONTRACT_REVERT_EXECUTED,
+                                recordWith().status(INVALID_FULL_PREFIX_SIGNATURE_FOR_PRECOMPILE)),
+                        // And no hbar were deducted from the receiver
+                        getAccountBalance(receiver).hasTinyBars(ONE_HBAR),
+                        // But now sign with receiver as well
+                        sourcing(
+                                () ->
+                                        contractCall(
+                                                        WELL_KNOWN_TREASURY_CONTRACT,
+                                                        "transferSerialNo1FromToOthers",
+                                                        nonFungibleTokenMirrorAddr.get(),
+                                                        senderAddr.get(),
+                                                        receiverAddr.get())
+                                                .gas(2_000_000)
+                                                .alsoSigningWithFullPrefix(sender, receiver)),
+                        // Receiver balance will be debited ONE_HBAR
+                        getAccountBalance(receiver).hasTinyBars(0L));
+    }
+
+    private HapiSpec fallbackFeeForHtsPayerMustSign() {
+        final AtomicReference<Address> senderAddr = new AtomicReference<>();
+        final AtomicReference<Address> receiverAddr = new AtomicReference<>();
+        final AtomicReference<Address> nonFungibleTokenMirrorAddr = new AtomicReference<>();
+
+        final var treasury = "treasury";
+        final var sender = "sender";
+        final var receiver = "receiver";
+        final var nft = "nft";
+        final var fungible = "fungible";
+        final var failedCallTxn = "failedCallTxn";
+
+        return propertyPreservingHapiSpec("FallbackFeeHtsPayerMustSign")
+                .preserving(EVM_ALIAS_ENABLED_PROP)
+                .given(
+                        overriding(EVM_ALIAS_ENABLED_PROP, "true"),
+                        uploadInitCode(WELL_KNOWN_TREASURY_CONTRACT),
+                        contractCreate(WELL_KNOWN_TREASURY_CONTRACT),
+                        newKeyNamed(MULTI_KEY),
+                        cryptoCreate(treasury),
+                        cryptoCreate(sender)
+                                .keyShape(SECP256K1_ON)
+                                .exposingEvmAddressTo(senderAddr::set),
+                        getAccountInfo(sender).logged(),
+                        cryptoCreate(receiver)
+                                .keyShape(SECP256K1_ON)
+                                .balance(ONE_HBAR)
+                                .exposingEvmAddressTo(receiverAddr::set))
+                .when(
+                        tokenCreate(fungible)
+                                .initialSupply(100)
+                                .tokenType(TokenType.FUNGIBLE_COMMON)
+                                .treasury(TOKEN_TREASURY),
+                        tokenAssociate(sender, fungible),
+                        tokenAssociate(receiver, fungible),
+                        cryptoTransfer(moving(10, fungible).between(TOKEN_TREASURY, receiver)),
+                        tokenCreate(nft)
+                                .exposingAddressTo(nonFungibleTokenMirrorAddr::set)
+                                .tokenType(TokenType.NON_FUNGIBLE_UNIQUE)
+                                .initialSupply(0)
+                                .supplyKey(MULTI_KEY)
+                                .withCustom(
+                                        royaltyFeeWithFallback(
+                                                1,
+                                                2,
+                                                fixedHtsFeeInheritingRoyaltyCollector(1, fungible),
+                                                treasury))
+                                .treasury(treasury),
+                        getTokenInfo(nft).logged(),
+                        tokenAssociate(sender, nft),
+                        tokenAssociate(receiver, nft),
+                        mintToken(
+                                nft,
+                                List.of(
+                                        ByteString.copyFromUtf8("serialNo1"),
+                                        ByteString.copyFromUtf8("serialNo2"))),
+                        cryptoTransfer(movingUnique(nft, 1, 2).between(treasury, sender)))
+                .then(
+                        // Without the receiver signature, will fail with INVALID_SIGNATURE
+                        sourcing(
+                                () ->
+                                        contractCall(
+                                                        WELL_KNOWN_TREASURY_CONTRACT,
+                                                        "transferSerialNo1FromToOthers",
+                                                        nonFungibleTokenMirrorAddr.get(),
+                                                        senderAddr.get(),
+                                                        receiverAddr.get())
+                                                .gas(2_000_000)
+                                                .via(failedCallTxn)
+                                                .hasKnownStatus(CONTRACT_REVERT_EXECUTED)
+                                                .alsoSigningWithFullPrefix(sender)),
+                        childRecordsCheck(
+                                failedCallTxn,
+                                CONTRACT_REVERT_EXECUTED,
+                                recordWith().status(INVALID_FULL_PREFIX_SIGNATURE_FOR_PRECOMPILE)),
+                        // And no tokens were deducted from the receiver
+                        getAccountBalance(receiver).hasTokenBalance(fungible, 10),
+                        // But now sign with receiver as well
+                        sourcing(
+                                () ->
+                                        contractCall(
+                                                        WELL_KNOWN_TREASURY_CONTRACT,
+                                                        "transferSerialNo1FromToOthers",
+                                                        nonFungibleTokenMirrorAddr.get(),
+                                                        senderAddr.get(),
+                                                        receiverAddr.get())
+                                                .gas(2_000_000)
+                                                .alsoSigningWithFullPrefix(sender, receiver)),
+                        // Receiver token balance of custom fee denomination should debit by 1
+                        getAccountBalance(receiver).hasTokenBalance(fungible, 9));
     }
 
     private HapiSpec contractCanStillTransferItsOwnAssets() {
@@ -214,7 +403,7 @@ public class ContractKeysStillWorkAsExpectedSuite extends HapiSuite {
         final AtomicReference<Address> bSenderAddr = new AtomicReference<>();
         final AtomicReference<Address> bReceiverAddr = new AtomicReference<>();
 
-        return propertyPreservingHapiSpec("ContractKeysWorkAsExpectedForFungibleTokenMgmt")
+        return propertyPreservingHapiSpec("ApprovalFallbacksRequiredWithoutTopLevelSigAccess")
                 .preserving(CONTRACTS_MAX_NUM_WITH_HAPI_SIGS_ACCESS)
                 .given(
                         // No top-level signatures are available to any contract
@@ -455,7 +644,7 @@ public class ContractKeysStillWorkAsExpectedSuite extends HapiSuite {
         final var receiver = "receiver";
         final var controlledSpenderKey = "controlledSpenderKey";
 
-        return propertyPreservingHapiSpec("ContractKeysWorkAsExpectedForFungibleTokenMgmt")
+        return propertyPreservingHapiSpec("CanStillTransferByVirtueOfContractIdInEOAThreshold")
                 .preserving(
                         CONTRACTS_MAX_NUM_WITH_HAPI_SIGS_ACCESS,
                         "contracts.withSpecialHapiSigsAccess",
@@ -523,15 +712,19 @@ public class ContractKeysStillWorkAsExpectedSuite extends HapiSuite {
                 .preserving(
                         CONTRACTS_MAX_NUM_WITH_HAPI_SIGS_ACCESS,
                         "contracts.withSpecialHapiSigsAccess",
-                        "contracts.allowSystemUseOfHapiSigs")
+                        "contracts.allowSystemUseOfHapiSigs",
+                        EVM_ALIAS_ENABLED_PROP)
                 .given(
-                        overridingThree(
-                                CONTRACTS_MAX_NUM_WITH_HAPI_SIGS_ACCESS,
-                                "0",
-                                "contracts.withSpecialHapiSigsAccess",
-                                "",
-                                "contracts.allowSystemUseOfHapiSigs",
-                                ""),
+                        overridingAllOf(
+                                Map.of(
+                                        CONTRACTS_MAX_NUM_WITH_HAPI_SIGS_ACCESS,
+                                        "0",
+                                        "contracts.withSpecialHapiSigsAccess",
+                                        "",
+                                        "contracts.allowSystemUseOfHapiSigs",
+                                        "",
+                                        EVM_ALIAS_ENABLED_PROP,
+                                        "true")),
                         uploadInitCode(managementContract),
                         newKeyNamed(tmpAdminKey),
                         contractCreate(managementContract).adminKey(tmpAdminKey),
@@ -583,7 +776,7 @@ public class ContractKeysStillWorkAsExpectedSuite extends HapiSuite {
         final AtomicReference<Address> tokenMirrorAddr = new AtomicReference<>();
         final AtomicReference<Address> accountAddr = new AtomicReference<>();
 
-        return defaultHapiSpec("ContractKeysWorkAsExpectedForFungibleTokenMgmt")
+        return defaultHapiSpec("ContractKeysStillHaveSpecificityNoMatterTopLevelSignatures")
                 .given(
                         uploadInitCode(managementContract, PAY_RECEIVABLE_CONTRACT),
                         newKeyNamed(tmpAdminKey),

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/ContractKeysStillWorkAsExpectedSuite.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/ContractKeysStillWorkAsExpectedSuite.java
@@ -86,6 +86,21 @@ public class ContractKeysStillWorkAsExpectedSuite extends HapiSuite {
             "cryptoCreateWithAliasAndEvmAddress.enabled";
     public static final String CONTRACTS_MAX_NUM_WITH_HAPI_SIGS_ACCESS =
             "contracts.maxNumWithHapiSigsAccess";
+    private static final String TREASURY = "treasury";
+    private static final String SENDER = "sender";
+    private static final String RECEIVER = "receiver";
+    private static final String FAILED_CALL_TXN = "failedCallTxn";
+    private static final String SERIAL_NO_1 = "serialNo1";
+    private static final String SERIAL_NO_2 = "serialNo2";
+    private static final String CONTRACTS_PRECOMPILE_UNSUPPORTED_CUSTOM_FEE_RECEIVER_DEBITS =
+            "contracts.precompile.unsupportedCustomFeeReceiverDebits";
+    private static final String TRANSFER_SERIAL_NO_1_FROM_TO_OTHERS =
+            "transferSerialNo1FromToOthers";
+    private static final String CONTRACTS_ALLOW_SYSTEM_USE_OF_HAPI_SIGS =
+            "contracts.allowSystemUseOfHapiSigs";
+    private static final String TOKEN = "token";
+    private static final String CONTRACTS_WITH_SPECIAL_HAPI_SIGS_ACCESS =
+            "contracts.withSpecialHapiSigsAccess";
 
     public static void main(String... args) {
         new ContractKeysStillWorkAsExpectedSuite().runSuiteSync();
@@ -120,11 +135,11 @@ public class ContractKeysStillWorkAsExpectedSuite extends HapiSuite {
         final AtomicReference<Address> receiverAddr = new AtomicReference<>();
         final AtomicReference<Address> nonFungibleTokenMirrorAddr = new AtomicReference<>();
 
-        final var treasury = "treasury";
-        final var sender = "sender";
-        final var receiver = "receiver";
+        final var treasury = TREASURY;
+        final var sender = SENDER;
+        final var receiver = RECEIVER;
         final var nft = "nft";
-        final var failedCallTxn = "failedCallTxn";
+        final var failedCallTxn = FAILED_CALL_TXN;
 
         return propertyPreservingHapiSpec("FixedFeeFailsWhenNotEnabled")
                 .preserving(EVM_ALIAS_ENABLED_PROP)
@@ -156,19 +171,19 @@ public class ContractKeysStillWorkAsExpectedSuite extends HapiSuite {
                         mintToken(
                                 nft,
                                 List.of(
-                                        ByteString.copyFromUtf8("serialNo1"),
-                                        ByteString.copyFromUtf8("serialNo2"))),
+                                        ByteString.copyFromUtf8(SERIAL_NO_1),
+                                        ByteString.copyFromUtf8(SERIAL_NO_2))),
                         cryptoTransfer(movingUnique(nft, 1, 2).between(treasury, sender)))
                 .then(
                         // override config to not allow fixed fees
                         overriding(
-                                "contracts.precompile.unsupportedCustomFeeReceiverDebits",
+                                CONTRACTS_PRECOMPILE_UNSUPPORTED_CUSTOM_FEE_RECEIVER_DEBITS,
                                 "FIXED_FEE"),
                         sourcing(
                                 () ->
                                         contractCall(
                                                         WELL_KNOWN_TREASURY_CONTRACT,
-                                                        "transferSerialNo1FromToOthers",
+                                                        TRANSFER_SERIAL_NO_1_FROM_TO_OTHERS,
                                                         nonFungibleTokenMirrorAddr.get(),
                                                         senderAddr.get(),
                                                         receiverAddr.get())
@@ -183,12 +198,12 @@ public class ContractKeysStillWorkAsExpectedSuite extends HapiSuite {
                         // And no hbar were deducted from the receiver
                         getAccountBalance(receiver).hasTinyBars(ONE_HBAR),
                         // override config to  allow fixed fees
-                        overriding("contracts.precompile.unsupportedCustomFeeReceiverDebits", ""),
+                        overriding(CONTRACTS_PRECOMPILE_UNSUPPORTED_CUSTOM_FEE_RECEIVER_DEBITS, ""),
                         sourcing(
                                 () ->
                                         contractCall(
                                                         WELL_KNOWN_TREASURY_CONTRACT,
-                                                        "transferSerialNo1FromToOthers",
+                                                        TRANSFER_SERIAL_NO_1_FROM_TO_OTHERS,
                                                         nonFungibleTokenMirrorAddr.get(),
                                                         senderAddr.get(),
                                                         receiverAddr.get())
@@ -203,11 +218,11 @@ public class ContractKeysStillWorkAsExpectedSuite extends HapiSuite {
         final AtomicReference<Address> receiverAddr = new AtomicReference<>();
         final AtomicReference<Address> nonFungibleTokenMirrorAddr = new AtomicReference<>();
 
-        final var treasury = "treasury";
-        final var sender = "sender";
-        final var receiver = "receiver";
+        final var treasury = TREASURY;
+        final var sender = SENDER;
+        final var receiver = RECEIVER;
         final var nft = "nft";
-        final var failedCallTxn = "failedCallTxn";
+        final var failedCallTxn = FAILED_CALL_TXN;
 
         return propertyPreservingHapiSpec("FallbackFeePayerMustSign")
                 .preserving(EVM_ALIAS_ENABLED_PROP)
@@ -244,17 +259,17 @@ public class ContractKeysStillWorkAsExpectedSuite extends HapiSuite {
                         mintToken(
                                 nft,
                                 List.of(
-                                        ByteString.copyFromUtf8("serialNo1"),
-                                        ByteString.copyFromUtf8("serialNo2"))),
+                                        ByteString.copyFromUtf8(SERIAL_NO_1),
+                                        ByteString.copyFromUtf8(SERIAL_NO_2))),
                         cryptoTransfer(movingUnique(nft, 1, 2).between(treasury, sender)))
                 .then(
                         // Without the receiver signature, will fail with INVALID_SIGNATURE
-                        overriding("contracts.precompile.unsupportedCustomFeeReceiverDebits", ""),
+                        overriding(CONTRACTS_PRECOMPILE_UNSUPPORTED_CUSTOM_FEE_RECEIVER_DEBITS, ""),
                         sourcing(
                                 () ->
                                         contractCall(
                                                         WELL_KNOWN_TREASURY_CONTRACT,
-                                                        "transferSerialNo1FromToOthers",
+                                                        TRANSFER_SERIAL_NO_1_FROM_TO_OTHERS,
                                                         nonFungibleTokenMirrorAddr.get(),
                                                         senderAddr.get(),
                                                         receiverAddr.get())
@@ -270,14 +285,14 @@ public class ContractKeysStillWorkAsExpectedSuite extends HapiSuite {
                         getAccountBalance(receiver).hasTinyBars(ONE_HBAR),
                         // override config to not allow royalty fee
                         overriding(
-                                "contracts.precompile.unsupportedCustomFeeReceiverDebits",
+                                CONTRACTS_PRECOMPILE_UNSUPPORTED_CUSTOM_FEE_RECEIVER_DEBITS,
                                 "ROYALTY_FALLBACK_FEE"),
                         // But now sign with receiver as well
                         sourcing(
                                 () ->
                                         contractCall(
                                                         WELL_KNOWN_TREASURY_CONTRACT,
-                                                        "transferSerialNo1FromToOthers",
+                                                        TRANSFER_SERIAL_NO_1_FROM_TO_OTHERS,
                                                         nonFungibleTokenMirrorAddr.get(),
                                                         senderAddr.get(),
                                                         receiverAddr.get())
@@ -292,12 +307,12 @@ public class ContractKeysStillWorkAsExpectedSuite extends HapiSuite {
                         // And no hbar were deducted from the receiver
                         getAccountBalance(receiver).hasTinyBars(ONE_HBAR),
                         // But now sign with receiver as well and allow royalty fee
-                        overriding("contracts.precompile.unsupportedCustomFeeReceiverDebits", ""),
+                        overriding(CONTRACTS_PRECOMPILE_UNSUPPORTED_CUSTOM_FEE_RECEIVER_DEBITS, ""),
                         sourcing(
                                 () ->
                                         contractCall(
                                                         WELL_KNOWN_TREASURY_CONTRACT,
-                                                        "transferSerialNo1FromToOthers",
+                                                        TRANSFER_SERIAL_NO_1_FROM_TO_OTHERS,
                                                         nonFungibleTokenMirrorAddr.get(),
                                                         senderAddr.get(),
                                                         receiverAddr.get())
@@ -312,12 +327,12 @@ public class ContractKeysStillWorkAsExpectedSuite extends HapiSuite {
         final AtomicReference<Address> receiverAddr = new AtomicReference<>();
         final AtomicReference<Address> nonFungibleTokenMirrorAddr = new AtomicReference<>();
 
-        final var treasury = "treasury";
-        final var sender = "sender";
-        final var receiver = "receiver";
+        final var treasury = TREASURY;
+        final var sender = SENDER;
+        final var receiver = RECEIVER;
         final var nft = "nft";
         final var fungible = "fungible";
-        final var failedCallTxn = "failedCallTxn";
+        final var failedCallTxn = FAILED_CALL_TXN;
 
         return propertyPreservingHapiSpec("FallbackFeeHtsPayerMustSign")
                 .preserving(EVM_ALIAS_ENABLED_PROP)
@@ -361,8 +376,8 @@ public class ContractKeysStillWorkAsExpectedSuite extends HapiSuite {
                         mintToken(
                                 nft,
                                 List.of(
-                                        ByteString.copyFromUtf8("serialNo1"),
-                                        ByteString.copyFromUtf8("serialNo2"))),
+                                        ByteString.copyFromUtf8(SERIAL_NO_1),
+                                        ByteString.copyFromUtf8(SERIAL_NO_2))),
                         cryptoTransfer(movingUnique(nft, 1, 2).between(treasury, sender)))
                 .then(
                         // Without the receiver signature, will fail with INVALID_SIGNATURE
@@ -370,7 +385,7 @@ public class ContractKeysStillWorkAsExpectedSuite extends HapiSuite {
                                 () ->
                                         contractCall(
                                                         WELL_KNOWN_TREASURY_CONTRACT,
-                                                        "transferSerialNo1FromToOthers",
+                                                        TRANSFER_SERIAL_NO_1_FROM_TO_OTHERS,
                                                         nonFungibleTokenMirrorAddr.get(),
                                                         senderAddr.get(),
                                                         receiverAddr.get())
@@ -389,7 +404,7 @@ public class ContractKeysStillWorkAsExpectedSuite extends HapiSuite {
                                 () ->
                                         contractCall(
                                                         WELL_KNOWN_TREASURY_CONTRACT,
-                                                        "transferSerialNo1FromToOthers",
+                                                        TRANSFER_SERIAL_NO_1_FROM_TO_OTHERS,
                                                         nonFungibleTokenMirrorAddr.get(),
                                                         senderAddr.get(),
                                                         receiverAddr.get())
@@ -440,7 +455,7 @@ public class ContractKeysStillWorkAsExpectedSuite extends HapiSuite {
                                 () ->
                                         contractCall(
                                                         WELL_KNOWN_TREASURY_CONTRACT,
-                                                        "transferSerialNo1FromToOthers",
+                                                        TRANSFER_SERIAL_NO_1_FROM_TO_OTHERS,
                                                         nonFungibleTokenMirrorAddr.get(),
                                                         treasuryContractAddr.get(),
                                                         aReceiverAddr.get())
@@ -706,7 +721,7 @@ public class ContractKeysStillWorkAsExpectedSuite extends HapiSuite {
                         () ->
                                 contractCall(
                                                 WELL_KNOWN_TREASURY_CONTRACT,
-                                                "transferSerialNo1FromToOthers",
+                                                TRANSFER_SERIAL_NO_1_FROM_TO_OTHERS,
                                                 nonFungibleTokenMirrorAddr.get(),
                                                 aSenderAddr.get(),
                                                 aReceiverAddr.get())
@@ -745,28 +760,28 @@ public class ContractKeysStillWorkAsExpectedSuite extends HapiSuite {
     }
 
     private HapiSpec canStillTransferByVirtueOfContractIdInEOAThreshold() {
-        final var fungibleToken = "token";
-        final var managementContract = "DoTokenManagement";
+        final var fungibleToken = TOKEN;
+        final var managementContract = WELL_KNOWN_TREASURY_CONTRACT;
         final AtomicReference<Address> tokenMirrorAddr = new AtomicReference<>();
         final AtomicReference<Address> controlledSpenderAddr = new AtomicReference<>();
         final AtomicReference<Address> receiverAddr = new AtomicReference<>();
         final var threshKeyShape = KeyShape.threshOf(1, CONTRACT, SECP256K1);
         final var controlledSpender = "controlledSpender";
-        final var receiver = "receiver";
+        final var receiver = RECEIVER;
         final var controlledSpenderKey = "controlledSpenderKey";
 
         return propertyPreservingHapiSpec("CanStillTransferByVirtueOfContractIdInEOAThreshold")
                 .preserving(
                         CONTRACTS_MAX_NUM_WITH_HAPI_SIGS_ACCESS,
-                        "contracts.withSpecialHapiSigsAccess",
-                        "contracts.allowSystemUseOfHapiSigs")
+                        CONTRACTS_WITH_SPECIAL_HAPI_SIGS_ACCESS,
+                        CONTRACTS_ALLOW_SYSTEM_USE_OF_HAPI_SIGS)
                 .given(
                         overridingThree(
                                 CONTRACTS_MAX_NUM_WITH_HAPI_SIGS_ACCESS,
                                 "0",
-                                "contracts.withSpecialHapiSigsAccess",
+                                CONTRACTS_WITH_SPECIAL_HAPI_SIGS_ACCESS,
                                 "",
-                                "contracts.allowSystemUseOfHapiSigs",
+                                CONTRACTS_ALLOW_SYSTEM_USE_OF_HAPI_SIGS,
                                 ""),
                         uploadInitCode(managementContract),
                         // Create an immutable contract with a method
@@ -811,8 +826,8 @@ public class ContractKeysStillWorkAsExpectedSuite extends HapiSuite {
     }
 
     private HapiSpec contractKeysWorkAsExpectedForFungibleTokenMgmt() {
-        final var fungibleToken = "token";
-        final var managementContract = "DoTokenManagement";
+        final var fungibleToken = TOKEN;
+        final var managementContract = WELL_KNOWN_TREASURY_CONTRACT;
         final var mgmtContractAsKey = "mgmtContractAsKey";
         final var tmpAdminKey = "tmpAdminKey";
         final var associatedAccount = "associatedAccount";
@@ -822,17 +837,17 @@ public class ContractKeysStillWorkAsExpectedSuite extends HapiSuite {
         return propertyPreservingHapiSpec("ContractKeysWorkAsExpectedForFungibleTokenMgmt")
                 .preserving(
                         CONTRACTS_MAX_NUM_WITH_HAPI_SIGS_ACCESS,
-                        "contracts.withSpecialHapiSigsAccess",
-                        "contracts.allowSystemUseOfHapiSigs",
+                        CONTRACTS_WITH_SPECIAL_HAPI_SIGS_ACCESS,
+                        CONTRACTS_ALLOW_SYSTEM_USE_OF_HAPI_SIGS,
                         EVM_ALIAS_ENABLED_PROP)
                 .given(
                         overridingAllOf(
                                 Map.of(
                                         CONTRACTS_MAX_NUM_WITH_HAPI_SIGS_ACCESS,
                                         "0",
-                                        "contracts.withSpecialHapiSigsAccess",
+                                        CONTRACTS_WITH_SPECIAL_HAPI_SIGS_ACCESS,
                                         "",
-                                        "contracts.allowSystemUseOfHapiSigs",
+                                        CONTRACTS_ALLOW_SYSTEM_USE_OF_HAPI_SIGS,
                                         "",
                                         EVM_ALIAS_ENABLED_PROP,
                                         "true")),
@@ -879,8 +894,8 @@ public class ContractKeysStillWorkAsExpectedSuite extends HapiSuite {
     }
 
     private HapiSpec contractKeysStillHaveSpecificityNoMatterTopLevelSignatures() {
-        final var fungibleToken = "token";
-        final var managementContract = "DoTokenManagement";
+        final var fungibleToken = TOKEN;
+        final var managementContract = WELL_KNOWN_TREASURY_CONTRACT;
         final var otherContractAsKey = "otherContractAsKey";
         final var tmpAdminKey = "tmpAdminKey";
         final var associatedAccount = "associatedAccount";

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/ContractKeysStillWorkAsExpectedSuite.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/ContractKeysStillWorkAsExpectedSuite.java
@@ -41,6 +41,7 @@ import static com.hedera.services.bdd.spec.transactions.TxnVerbs.mintToken;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.tokenAssociate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.tokenCreate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.uploadInitCode;
+import static com.hedera.services.bdd.spec.transactions.token.CustomFeeSpecs.fixedHbarFee;
 import static com.hedera.services.bdd.spec.transactions.token.CustomFeeSpecs.fixedHbarFeeInheritingRoyaltyCollector;
 import static com.hedera.services.bdd.spec.transactions.token.CustomFeeSpecs.fixedHtsFeeInheritingRoyaltyCollector;
 import static com.hedera.services.bdd.spec.transactions.token.CustomFeeSpecs.royaltyFeeWithFallback;
@@ -60,6 +61,7 @@ import static com.hedera.services.bdd.suites.token.TokenAssociationSpecs.MULTI_K
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.CONTRACT_REVERT_EXECUTED;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_FULL_PREFIX_SIGNATURE_FOR_PRECOMPILE;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_SIGNATURE;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.NOT_SUPPORTED;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SUCCESS;
 
 import com.esaulpaugh.headlong.abi.Address;
@@ -109,7 +111,91 @@ public class ContractKeysStillWorkAsExpectedSuite extends HapiSuite {
                 topLevelSigsStillWorkWithDefaultGrandfatherNum(),
                 contractCanStillTransferItsOwnAssets(),
                 fallbackFeeForHtsPayerMustSign(),
-                fallbackFeePayerMustSign());
+                fallbackFeePayerMustSign(),
+                fixedFeeFailsWhenDisabledButWorksWhenEnabled());
+    }
+
+    private HapiSpec fixedFeeFailsWhenDisabledButWorksWhenEnabled() {
+        final AtomicReference<Address> senderAddr = new AtomicReference<>();
+        final AtomicReference<Address> receiverAddr = new AtomicReference<>();
+        final AtomicReference<Address> nonFungibleTokenMirrorAddr = new AtomicReference<>();
+
+        final var treasury = "treasury";
+        final var sender = "sender";
+        final var receiver = "receiver";
+        final var nft = "nft";
+        final var failedCallTxn = "failedCallTxn";
+
+        return propertyPreservingHapiSpec("FixedFeeFailsWhenNotEnabled")
+                .preserving(EVM_ALIAS_ENABLED_PROP)
+                .given(
+                        overriding(EVM_ALIAS_ENABLED_PROP, "true"),
+                        uploadInitCode(WELL_KNOWN_TREASURY_CONTRACT),
+                        contractCreate(WELL_KNOWN_TREASURY_CONTRACT),
+                        newKeyNamed(MULTI_KEY),
+                        cryptoCreate(treasury),
+                        cryptoCreate(sender)
+                                .keyShape(SECP256K1_ON)
+                                .exposingEvmAddressTo(senderAddr::set),
+                        getAccountInfo(sender).logged(),
+                        cryptoCreate(receiver)
+                                .keyShape(SECP256K1_ON)
+                                .balance(ONE_HBAR)
+                                .exposingEvmAddressTo(receiverAddr::set))
+                .when(
+                        tokenCreate(nft)
+                                .exposingAddressTo(nonFungibleTokenMirrorAddr::set)
+                                .tokenType(TokenType.NON_FUNGIBLE_UNIQUE)
+                                .initialSupply(0)
+                                .supplyKey(MULTI_KEY)
+                                .withCustom(fixedHbarFee(1, treasury, false))
+                                .treasury(treasury),
+                        getTokenInfo(nft).logged(),
+                        tokenAssociate(sender, nft),
+                        tokenAssociate(receiver, nft),
+                        mintToken(
+                                nft,
+                                List.of(
+                                        ByteString.copyFromUtf8("serialNo1"),
+                                        ByteString.copyFromUtf8("serialNo2"))),
+                        cryptoTransfer(movingUnique(nft, 1, 2).between(treasury, sender)))
+                .then(
+                        // override config to not allow fixed fees
+                        overriding(
+                                "contracts.precompile.unsupportedCustomFeeReceiverDebits",
+                                "FIXED_FEE"),
+                        sourcing(
+                                () ->
+                                        contractCall(
+                                                        WELL_KNOWN_TREASURY_CONTRACT,
+                                                        "transferSerialNo1FromToOthers",
+                                                        nonFungibleTokenMirrorAddr.get(),
+                                                        senderAddr.get(),
+                                                        receiverAddr.get())
+                                                .gas(2_000_000)
+                                                .via(failedCallTxn)
+                                                .hasKnownStatus(CONTRACT_REVERT_EXECUTED)
+                                                .alsoSigningWithFullPrefix(sender)),
+                        childRecordsCheck(
+                                failedCallTxn,
+                                CONTRACT_REVERT_EXECUTED,
+                                recordWith().status(NOT_SUPPORTED)),
+                        // And no hbar were deducted from the receiver
+                        getAccountBalance(receiver).hasTinyBars(ONE_HBAR),
+                        // override config to  allow fixed fees
+                        overriding("contracts.precompile.unsupportedCustomFeeReceiverDebits", ""),
+                        sourcing(
+                                () ->
+                                        contractCall(
+                                                        WELL_KNOWN_TREASURY_CONTRACT,
+                                                        "transferSerialNo1FromToOthers",
+                                                        nonFungibleTokenMirrorAddr.get(),
+                                                        senderAddr.get(),
+                                                        receiverAddr.get())
+                                                .gas(2_000_000)
+                                                .via(failedCallTxn)
+                                                .hasKnownStatus(SUCCESS)
+                                                .alsoSigningWithFullPrefix(sender)));
     }
 
     private HapiSpec fallbackFeePayerMustSign() {
@@ -163,6 +249,7 @@ public class ContractKeysStillWorkAsExpectedSuite extends HapiSuite {
                         cryptoTransfer(movingUnique(nft, 1, 2).between(treasury, sender)))
                 .then(
                         // Without the receiver signature, will fail with INVALID_SIGNATURE
+                        overriding("contracts.precompile.unsupportedCustomFeeReceiverDebits", ""),
                         sourcing(
                                 () ->
                                         contractCall(
@@ -181,7 +268,31 @@ public class ContractKeysStillWorkAsExpectedSuite extends HapiSuite {
                                 recordWith().status(INVALID_FULL_PREFIX_SIGNATURE_FOR_PRECOMPILE)),
                         // And no hbar were deducted from the receiver
                         getAccountBalance(receiver).hasTinyBars(ONE_HBAR),
+                        // override config to not allow royalty fee
+                        overriding(
+                                "contracts.precompile.unsupportedCustomFeeReceiverDebits",
+                                "ROYALTY_FALLBACK_FEE"),
                         // But now sign with receiver as well
+                        sourcing(
+                                () ->
+                                        contractCall(
+                                                        WELL_KNOWN_TREASURY_CONTRACT,
+                                                        "transferSerialNo1FromToOthers",
+                                                        nonFungibleTokenMirrorAddr.get(),
+                                                        senderAddr.get(),
+                                                        receiverAddr.get())
+                                                .gas(2_000_000)
+                                                .via("removeRoyaltyFee")
+                                                .hasKnownStatus(CONTRACT_REVERT_EXECUTED)
+                                                .alsoSigningWithFullPrefix(sender, receiver)),
+                        childRecordsCheck(
+                                "removeRoyaltyFee",
+                                CONTRACT_REVERT_EXECUTED,
+                                recordWith().status(NOT_SUPPORTED)),
+                        // And no hbar were deducted from the receiver
+                        getAccountBalance(receiver).hasTinyBars(ONE_HBAR),
+                        // But now sign with receiver as well and allow royalty fee
+                        overriding("contracts.precompile.unsupportedCustomFeeReceiverDebits", ""),
                         sourcing(
                                 () ->
                                         contractCall(

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/ERCPrecompileSuite.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/ERCPrecompileSuite.java
@@ -89,15 +89,13 @@ import com.hederahashgraph.api.proto.java.HederaFunctionality;
 import com.hederahashgraph.api.proto.java.TokenID;
 import com.hederahashgraph.api.proto.java.TokenSupplyType;
 import com.hederahashgraph.api.proto.java.TokenType;
-
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.apache.tuweni.bytes.Bytes;
-
 import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.tuweni.bytes.Bytes;
 
 public class ERCPrecompileSuite extends HapiSuite {
     private static final Logger log = LogManager.getLogger(ERCPrecompileSuite.class);
@@ -950,7 +948,6 @@ public class ERCPrecompileSuite extends HapiSuite {
                                 CONTRACT_REVERT_EXECUTED,
                                 recordWith().status(SPENDER_DOES_NOT_HAVE_ALLOWANCE)));
     }
-
 
     private HapiSpec getErc721TokenName() {
         return defaultHapiSpec("ERC_721_NAME")

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/ERCPrecompileSuite.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/ERCPrecompileSuite.java
@@ -89,13 +89,15 @@ import com.hederahashgraph.api.proto.java.HederaFunctionality;
 import com.hederahashgraph.api.proto.java.TokenID;
 import com.hederahashgraph.api.proto.java.TokenSupplyType;
 import com.hederahashgraph.api.proto.java.TokenType;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.tuweni.bytes.Bytes;
+
 import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.apache.tuweni.bytes.Bytes;
 
 public class ERCPrecompileSuite extends HapiSuite {
     private static final Logger log = LogManager.getLogger(ERCPrecompileSuite.class);
@@ -948,6 +950,7 @@ public class ERCPrecompileSuite extends HapiSuite {
                                 CONTRACT_REVERT_EXECUTED,
                                 recordWith().status(SPENDER_DOES_NOT_HAVE_ALLOWANCE)));
     }
+
 
     private HapiSpec getErc721TokenName() {
         return defaultHapiSpec("ERC_721_NAME")

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/ERCPrecompileSuite.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/ERCPrecompileSuite.java
@@ -39,7 +39,6 @@ import static com.hedera.services.bdd.spec.transactions.TxnVerbs.contractCreate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoApproveAllowance;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoCreate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoTransfer;
-import static com.hedera.services.bdd.spec.transactions.TxnVerbs.fileCreate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.mintToken;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.tokenAssociate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.tokenCreate;
@@ -52,7 +51,6 @@ import static com.hedera.services.bdd.spec.utilops.CustomSpecAssert.allRunFor;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.balanceSnapshot;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.childRecordsCheck;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.newKeyNamed;
-import static com.hedera.services.bdd.spec.utilops.UtilVerbs.overriding;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.reduceFeeFor;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.sourcing;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.withOpContext;
@@ -66,11 +64,8 @@ import static com.hedera.services.bdd.suites.contract.Utils.parsedToByteString;
 import static com.hedera.services.bdd.suites.utils.contracts.AddressResult.hexedAddress;
 import static com.hedera.services.bdd.suites.utils.contracts.BoolResult.flag;
 import static com.hedera.services.bdd.suites.utils.contracts.precompile.HTSPrecompileResult.htsPrecompileResult;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.AMOUNT_EXCEEDS_ALLOWANCE;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.CONTRACT_REVERT_EXECUTED;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INSUFFICIENT_TOKEN_BALANCE;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_ACCOUNT_ID;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_ALLOWANCE_OWNER_ID;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_ALLOWANCE_SPENDER_ID;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_SOLIDITY_ADDRESS;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.MAX_CHILD_RECORDS_EXCEEDED;
@@ -78,8 +73,6 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SENDER_DOES_NO
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SPENDER_ACCOUNT_SAME_AS_OWNER;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SPENDER_DOES_NOT_HAVE_ALLOWANCE;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SUCCESS;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TOKEN_NOT_ASSOCIATED_TO_ACCOUNT;
-import static com.hederahashgraph.api.proto.java.TokenType.FUNGIBLE_COMMON;
 import static com.hederahashgraph.api.proto.java.TokenType.NON_FUNGIBLE_UNIQUE;
 
 import com.esaulpaugh.headlong.abi.Address;
@@ -110,7 +103,7 @@ public class ERCPrecompileSuite extends HapiSuite {
     private static final String FUNGIBLE_TOKEN = "fungibleToken";
     private static final String NON_FUNGIBLE_TOKEN = "nonFungibleToken";
     private static final String MULTI_KEY = "purpose";
-    private static final String ERC_20_CONTRACT_NAME = "erc20Contract";
+    public static final String ERC_20_CONTRACT_NAME = "erc20Contract";
     private static final String OWNER = "owner";
     private static final String ACCOUNT = "anybody";
     public static final String RECIPIENT = "recipient";
@@ -120,26 +113,26 @@ public class ERCPrecompileSuite extends HapiSuite {
             ByteString.copyFrom(FIRST.getBytes(StandardCharsets.UTF_8));
     private static final ByteString SECOND_META =
             ByteString.copyFrom(FIRST.getBytes(StandardCharsets.UTF_8));
-    private static final String TRANSFER_SIG_NAME = "transferSig";
+    public static final String TRANSFER_SIG_NAME = "transferSig";
     public static final String ERC_20_CONTRACT = "ERC20Contract";
     private static final String ERC_721_CONTRACT = "ERC721Contract";
-    private static final String NAME_TXN = "nameTxn";
+    public static final String NAME_TXN = "nameTxn";
     private static final String SYMBOL_TXN = "symbolTxn";
     private static final String TOTAL_SUPPLY_TXN = "totalSupplyTxn";
     private static final String BALANCE_OF_TXN = "balanceOfTxn";
-    private static final String ALLOWANCE_TXN = "allowanceTxn";
+    public static final String ALLOWANCE_TXN = "allowanceTxn";
     private static final String TRANSFER_TXN = "transferTxn";
     public static final String TRANSFER_FROM_ACCOUNT_TXN = "transferFromAccountTxn";
     private static final String BASE_APPROVE_TXN = "baseApproveTxn";
     private static final String IS_APPROVED_FOR_ALL = "outerIsApprovedForAll";
-    private static final String GET_ALLOWANCE = "getAllowance";
-    private static final String ALLOWANCE = "allowance";
+    public static final String GET_ALLOWANCE = "getAllowance";
+    public static final String ALLOWANCE = "allowance";
     private static final String SYMBOL = "symbol";
     private static final String DECIMALS = "decimals";
     private static final String TOTAL_SUPPLY = "totalSupply";
     private static final String BALANCE_OF = "balanceOf";
     private static final String TRANSFER = "transfer";
-    private static final String APPROVE = "approve";
+    public static final String APPROVE = "approve";
     private static final String OWNER_OF = "ownerOf";
     private static final String TOKEN_URI = "tokenURI";
     private static final String TOKEN = "token";
@@ -148,28 +141,28 @@ public class ERCPrecompileSuite extends HapiSuite {
     public static final String TRANSFER_FROM = "transferFrom";
     private static final String ERC_20_ABI = "ERC20ABI";
     private static final String ERC_721_ABI = "ERC721ABI";
-    private static final String MULTI_KEY_NAME = "multiKey";
-    private static final String A_CIVILIAN = "aCivilian";
-    private static final String B_CIVILIAN = "bCivilian";
-    private static final String DO_TRANSFER_FROM = "doTransferFrom";
+    public static final String MULTI_KEY_NAME = "multiKey";
+    public static final String A_CIVILIAN = "aCivilian";
+    public static final String B_CIVILIAN = "bCivilian";
+    public static final String DO_TRANSFER_FROM = "doTransferFrom";
     private static final String GET_APPROVED = "outerGetApproved";
     private static final String GET_BALANCE_OF = "getBalanceOf";
-    private static final String MISSING_FROM = "MISSING_FROM";
-    private static final String MISSING_TO = "MISSING_TO";
-    private static final String SOME_ERC_20_SCENARIOS = "SomeERC20Scenarios";
+    public static final String MISSING_FROM = "MISSING_FROM";
+    public static final String MISSING_TO = "MISSING_TO";
+    public static final String SOME_ERC_20_SCENARIOS = "SomeERC20Scenarios";
     private static final String SOME_ERC_721_SCENARIOS = "SomeERC721Scenarios";
     private static final String GET_OWNER_OF = "getOwnerOf";
     private static final String OPERATOR_DOES_NOT_EXISTS = "OPERATOR_DOES_NOT_EXISTS";
     private static final String SET_APPROVAL_FOR_ALL = "outerSetApprovalForAll";
     private static final String REVOKE_SPECIFIC_APPROVAL = "revokeSpecificApproval";
-    private static final String MSG_SENDER_IS_NOT_THE_SAME_AS_FROM =
+    public static final String MSG_SENDER_IS_NOT_THE_SAME_AS_FROM =
             "MSG_SENDER_IS_NOT_THE_SAME_AS_FROM";
-    private static final String MSG_SENDER_IS_THE_SAME_AS_FROM = "MSG_SENDER_IS_THE_SAME_AS_FROM";
+    public static final String MSG_SENDER_IS_THE_SAME_AS_FROM = "MSG_SENDER_IS_THE_SAME_AS_FROM";
     private static final String MISSING_TOKEN = "MISSING_TOKEN";
     private static final String WITH_SPENDER = "WITH_SPENDER";
-    private static final String DO_SPECIFIC_APPROVAL = "doSpecificApproval";
+    public static final String DO_SPECIFIC_APPROVAL = "doSpecificApproval";
     private static final String NFT_TOKEN_MINT = "nftTokenMint";
-    static final String TRANSFER_SIGNATURE = "Transfer(address,address,uint256)";
+    public static final String TRANSFER_SIGNATURE = "Transfer(address,address,uint256)";
 
     public static void main(String... args) {
         new ERCPrecompileSuite().runSuiteAsync();
@@ -187,28 +180,16 @@ public class ERCPrecompileSuite extends HapiSuite {
 
     List<HapiSpec> erc20() {
         return List.of(
-                getErc20TokenName(),
                 getErc20TokenSymbol(),
-                getErc20TokenDecimals(),
                 getErc20TotalSupply(),
                 getErc20BalanceOfAccount(),
                 transferErc20Token(),
                 transferErc20TokenFailWithAccount(),
-                erc20Allowance(),
-                erc20Approve(),
-                someERC20ApproveAllowanceScenariosPass(),
-                someERC20NegativeTransferFromScenariosPass(),
-                someERC20ApproveAllowanceScenarioInOneCall(),
-                getErc20TokenDecimalsFromErc721TokenFails(),
-                transferErc20TokenFromErc721TokenFails(),
                 transferErc20TokenReceiverContract(),
                 transferErc20TokenAliasedSender(),
                 directCallsWorkForERC20(),
-                erc20TransferFrom(),
-                erc20TransferFromSelf(),
                 getErc20TokenNameExceedingLimits(),
-                transferErc20TokenFromContractWithNoApproval(),
-                transferErc20TokenFromContractWithApproval());
+                transferErc20TokenFromContractWithNoApproval());
     }
 
     List<HapiSpec> erc721() {
@@ -234,56 +215,6 @@ public class ERCPrecompileSuite extends HapiSuite {
                 someERC721IsApprovedForAllScenariosPass(),
                 getErc721IsApprovedForAll(),
                 someERC721SetApprovedForAllScenariosPass());
-    }
-
-    private HapiSpec getErc20TokenName() {
-        return defaultHapiSpec("ERC_20_NAME")
-                .given(
-                        overriding("hedera.allowances.isEnabled", "true"),
-                        newKeyNamed(MULTI_KEY),
-                        cryptoCreate(ACCOUNT).balance(100 * ONE_HUNDRED_HBARS),
-                        cryptoCreate(TOKEN_TREASURY),
-                        tokenCreate(FUNGIBLE_TOKEN)
-                                .tokenType(TokenType.FUNGIBLE_COMMON)
-                                .supplyType(TokenSupplyType.INFINITE)
-                                .initialSupply(5)
-                                .name(TOKEN_NAME)
-                                .treasury(TOKEN_TREASURY)
-                                .adminKey(MULTI_KEY)
-                                .supplyKey(MULTI_KEY),
-                        uploadInitCode(ERC_20_CONTRACT),
-                        contractCreate(ERC_20_CONTRACT))
-                .when(
-                        withOpContext(
-                                (spec, opLog) ->
-                                        allRunFor(
-                                                spec,
-                                                contractCall(
-                                                                ERC_20_CONTRACT,
-                                                                "name",
-                                                                asHeadlongAddress(
-                                                                        asHexedAddress(
-                                                                                spec.registry()
-                                                                                        .getTokenID(
-                                                                                                FUNGIBLE_TOKEN))))
-                                                        .payingWith(ACCOUNT)
-                                                        .via(NAME_TXN)
-                                                        .gas(4_000_000)
-                                                        .hasKnownStatus(SUCCESS))))
-                .then(
-                        childRecordsCheck(
-                                NAME_TXN,
-                                SUCCESS,
-                                recordWith()
-                                        .status(SUCCESS)
-                                        .contractCallResult(
-                                                resultWith()
-                                                        .contractCallResult(
-                                                                htsPrecompileResult()
-                                                                        .forFunction(
-                                                                                FunctionType
-                                                                                        .ERC_NAME)
-                                                                        .withName(TOKEN_NAME)))));
     }
 
     private HapiSpec getErc20TokenSymbol() {
@@ -346,72 +277,6 @@ public class ERCPrecompileSuite extends HapiSuite {
                                         contractCallLocal(
                                                 ERC_20_CONTRACT,
                                                 SYMBOL,
-                                                asHeadlongAddress(tokenAddr.get()))));
-    }
-
-    private HapiSpec getErc20TokenDecimals() {
-        final var decimals = 10;
-        final var decimalsTxn = "decimalsTxn";
-        final AtomicReference<String> tokenAddr = new AtomicReference<>();
-
-        return defaultHapiSpec("ERC_20_DECIMALS")
-                .given(
-                        overriding("hedera.allowances.isEnabled", "true"),
-                        newKeyNamed(MULTI_KEY),
-                        cryptoCreate(ACCOUNT).balance(100 * ONE_HUNDRED_HBARS),
-                        cryptoCreate(TOKEN_TREASURY),
-                        tokenCreate(FUNGIBLE_TOKEN)
-                                .tokenType(TokenType.FUNGIBLE_COMMON)
-                                .supplyType(TokenSupplyType.INFINITE)
-                                .initialSupply(5)
-                                .decimals(decimals)
-                                .treasury(TOKEN_TREASURY)
-                                .adminKey(MULTI_KEY)
-                                .supplyKey(MULTI_KEY)
-                                .exposingCreatedIdTo(
-                                        id ->
-                                                tokenAddr.set(
-                                                        asHexedSolidityAddress(
-                                                                HapiPropertySource.asToken(id)))),
-                        fileCreate(ERC_20_CONTRACT_NAME),
-                        uploadInitCode(ERC_20_CONTRACT),
-                        contractCreate(ERC_20_CONTRACT))
-                .when(
-                        withOpContext(
-                                (spec, opLog) ->
-                                        allRunFor(
-                                                spec,
-                                                contractCall(
-                                                                ERC_20_CONTRACT,
-                                                                DECIMALS,
-                                                                asHeadlongAddress(
-                                                                        asHexedAddress(
-                                                                                spec.registry()
-                                                                                        .getTokenID(
-                                                                                                FUNGIBLE_TOKEN))))
-                                                        .payingWith(ACCOUNT)
-                                                        .via(decimalsTxn)
-                                                        .hasKnownStatus(SUCCESS)
-                                                        .gas(GAS_TO_OFFER))))
-                .then(
-                        childRecordsCheck(
-                                decimalsTxn,
-                                SUCCESS,
-                                recordWith()
-                                        .status(SUCCESS)
-                                        .contractCallResult(
-                                                resultWith()
-                                                        .contractCallResult(
-                                                                htsPrecompileResult()
-                                                                        .forFunction(
-                                                                                FunctionType
-                                                                                        .ERC_DECIMALS)
-                                                                        .withDecimals(decimals)))),
-                        sourcing(
-                                () ->
-                                        contractCallLocal(
-                                                ERC_20_CONTRACT,
-                                                DECIMALS,
                                                 asHeadlongAddress(tokenAddr.get()))));
     }
 
@@ -1082,419 +947,6 @@ public class ERCPrecompileSuite extends HapiSuite {
                                 transferFromOtherContractWithSignaturesTxn,
                                 CONTRACT_REVERT_EXECUTED,
                                 recordWith().status(SPENDER_DOES_NOT_HAVE_ALLOWANCE)));
-    }
-
-    private HapiSpec transferErc20TokenFromContractWithApproval() {
-        final var transferFromOtherContractWithSignaturesTxn =
-                "transferFromOtherContractWithSignaturesTxn";
-        final var nestedContract = "NestedERC20Contract";
-
-        return defaultHapiSpec("ERC_20_TRANSFER_FROM_CONTRACT_WITH_APPROVAL")
-                .given(
-                        newKeyNamed(MULTI_KEY),
-                        cryptoCreate(ACCOUNT).balance(10 * ONE_MILLION_HBARS),
-                        cryptoCreate(RECIPIENT),
-                        cryptoCreate(TOKEN_TREASURY),
-                        tokenCreate(FUNGIBLE_TOKEN)
-                                .tokenType(TokenType.FUNGIBLE_COMMON)
-                                .initialSupply(35)
-                                .treasury(TOKEN_TREASURY)
-                                .adminKey(MULTI_KEY)
-                                .supplyKey(MULTI_KEY),
-                        uploadInitCode(ERC_20_CONTRACT, nestedContract),
-                        newKeyNamed(TRANSFER_SIG_NAME).shape(SIMPLE.signedWith(ON)),
-                        contractCreate(ERC_20_CONTRACT).adminKey(TRANSFER_SIG_NAME),
-                        contractCreate(nestedContract).adminKey(TRANSFER_SIG_NAME),
-                        overriding("contracts.allowSystemUseOfHapiSigs", "CryptoTransfer"))
-                .when(
-                        withOpContext(
-                                (spec, opLog) ->
-                                        allRunFor(
-                                                spec,
-                                                tokenAssociate(ACCOUNT, List.of(FUNGIBLE_TOKEN)),
-                                                tokenAssociate(RECIPIENT, List.of(FUNGIBLE_TOKEN)),
-                                                tokenAssociate(
-                                                        ERC_20_CONTRACT, List.of(FUNGIBLE_TOKEN)),
-                                                tokenAssociate(
-                                                        nestedContract, List.of(FUNGIBLE_TOKEN)),
-                                                cryptoTransfer(
-                                                                TokenMovement.moving(
-                                                                                20, FUNGIBLE_TOKEN)
-                                                                        .between(
-                                                                                TOKEN_TREASURY,
-                                                                                ERC_20_CONTRACT))
-                                                        .payingWith(ACCOUNT),
-                                                contractCall(
-                                                                ERC_20_CONTRACT,
-                                                                APPROVE,
-                                                                HapiParserUtil.asHeadlongAddress(
-                                                                        asAddress(
-                                                                                spec.registry()
-                                                                                        .getTokenID(
-                                                                                                FUNGIBLE_TOKEN))),
-                                                                HapiParserUtil.asHeadlongAddress(
-                                                                        asAddress(
-                                                                                spec.registry()
-                                                                                        .getContractId(
-                                                                                                ERC_20_CONTRACT))),
-                                                                BigInteger.valueOf(20))
-                                                        .gas(1_000_000)
-                                                        .payingWith(ACCOUNT)
-                                                        .alsoSigningWithFullPrefix(
-                                                                TRANSFER_SIG_NAME),
-                                                contractCall(
-                                                                ERC_20_CONTRACT,
-                                                                TRANSFER_FROM,
-                                                                HapiParserUtil.asHeadlongAddress(
-                                                                        asAddress(
-                                                                                spec.registry()
-                                                                                        .getTokenID(
-                                                                                                FUNGIBLE_TOKEN))),
-                                                                HapiParserUtil.asHeadlongAddress(
-                                                                        asAddress(
-                                                                                spec.registry()
-                                                                                        .getContractId(
-                                                                                                ERC_20_CONTRACT))),
-                                                                HapiParserUtil.asHeadlongAddress(
-                                                                        asAddress(
-                                                                                spec.registry()
-                                                                                        .getContractId(
-                                                                                                nestedContract))),
-                                                                BigInteger.valueOf(5))
-                                                        .via(TRANSFER_TXN)
-                                                        .alsoSigningWithFullPrefix(
-                                                                TRANSFER_SIG_NAME)
-                                                        .hasKnownStatus(SUCCESS),
-                                                contractCall(
-                                                                ERC_20_CONTRACT,
-                                                                TRANSFER_FROM,
-                                                                HapiParserUtil.asHeadlongAddress(
-                                                                        asAddress(
-                                                                                spec.registry()
-                                                                                        .getTokenID(
-                                                                                                FUNGIBLE_TOKEN))),
-                                                                HapiParserUtil.asHeadlongAddress(
-                                                                        asAddress(
-                                                                                spec.registry()
-                                                                                        .getContractId(
-                                                                                                ERC_20_CONTRACT))),
-                                                                HapiParserUtil.asHeadlongAddress(
-                                                                        asAddress(
-                                                                                spec.registry()
-                                                                                        .getContractId(
-                                                                                                nestedContract))),
-                                                                BigInteger.valueOf(5))
-                                                        .payingWith(ACCOUNT)
-                                                        .alsoSigningWithFullPrefix(
-                                                                TRANSFER_SIG_NAME)
-                                                        .via(
-                                                                transferFromOtherContractWithSignaturesTxn))))
-                .then(
-                        getContractInfo(ERC_20_CONTRACT).saveToRegistry(ERC_20_CONTRACT),
-                        getContractInfo(nestedContract).saveToRegistry(nestedContract),
-                        withOpContext(
-                                (spec, log) -> {
-                                    final var sender =
-                                            spec.registry()
-                                                    .getContractInfo(ERC_20_CONTRACT)
-                                                    .getContractID();
-                                    final var receiver =
-                                            spec.registry()
-                                                    .getContractInfo(nestedContract)
-                                                    .getContractID();
-
-                                    var transferRecord =
-                                            getTxnRecord(TRANSFER_TXN)
-                                                    .hasPriority(
-                                                            recordWith()
-                                                                    .contractCallResult(
-                                                                            resultWith()
-                                                                                    .logs(
-                                                                                            inOrder(
-                                                                                                    logWith()
-                                                                                                            .withTopicsInOrder(
-                                                                                                                    List
-                                                                                                                            .of(
-                                                                                                                                    eventSignatureOf(
-                                                                                                                                            TRANSFER_SIGNATURE),
-                                                                                                                                    parsedToByteString(
-                                                                                                                                            sender
-                                                                                                                                                    .getContractNum()),
-                                                                                                                                    parsedToByteString(
-                                                                                                                                            receiver
-                                                                                                                                                    .getContractNum())))
-                                                                                                            .longValue(
-                                                                                                                    5)))))
-                                                    .andAllChildRecords();
-
-                                    var transferFromOtherContractWithSignaturesTxnRecord =
-                                            getTxnRecord(transferFromOtherContractWithSignaturesTxn)
-                                                    .hasPriority(
-                                                            recordWith()
-                                                                    .contractCallResult(
-                                                                            resultWith()
-                                                                                    .logs(
-                                                                                            inOrder(
-                                                                                                    logWith()
-                                                                                                            .withTopicsInOrder(
-                                                                                                                    List
-                                                                                                                            .of(
-                                                                                                                                    eventSignatureOf(
-                                                                                                                                            TRANSFER_SIGNATURE),
-                                                                                                                                    parsedToByteString(
-                                                                                                                                            sender
-                                                                                                                                                    .getContractNum()),
-                                                                                                                                    parsedToByteString(
-                                                                                                                                            receiver
-                                                                                                                                                    .getContractNum())))
-                                                                                                            .longValue(
-                                                                                                                    5)))))
-                                                    .andAllChildRecords();
-
-                                    allRunFor(
-                                            spec,
-                                            transferRecord,
-                                            transferFromOtherContractWithSignaturesTxnRecord);
-                                }),
-                        childRecordsCheck(
-                                TRANSFER_TXN,
-                                SUCCESS,
-                                recordWith()
-                                        .status(SUCCESS)
-                                        .contractCallResult(
-                                                resultWith()
-                                                        .contractCallResult(
-                                                                htsPrecompileResult()
-                                                                        .forFunction(
-                                                                                FunctionType
-                                                                                        .ERC_TRANSFER)
-                                                                        .withErcFungibleTransferStatus(
-                                                                                true)))),
-                        childRecordsCheck(
-                                transferFromOtherContractWithSignaturesTxn,
-                                SUCCESS,
-                                recordWith()
-                                        .status(SUCCESS)
-                                        .contractCallResult(
-                                                resultWith()
-                                                        .contractCallResult(
-                                                                htsPrecompileResult()
-                                                                        .forFunction(
-                                                                                FunctionType
-                                                                                        .ERC_TRANSFER)
-                                                                        .withErcFungibleTransferStatus(
-                                                                                true)))),
-                        getAccountBalance(ERC_20_CONTRACT).hasTokenBalance(FUNGIBLE_TOKEN, 10),
-                        getAccountBalance(nestedContract).hasTokenBalance(FUNGIBLE_TOKEN, 10));
-    }
-
-    private HapiSpec erc20Allowance() {
-        return defaultHapiSpec("ERC_20_ALLOWANCE")
-                .given(
-                        overriding("hedera.allowances.isEnabled", "true"),
-                        newKeyNamed(MULTI_KEY),
-                        cryptoCreate(OWNER).balance(100 * ONE_HUNDRED_HBARS),
-                        cryptoCreate(SPENDER),
-                        cryptoCreate(TOKEN_TREASURY),
-                        tokenCreate(FUNGIBLE_TOKEN)
-                                .tokenType(TokenType.FUNGIBLE_COMMON)
-                                .supplyType(TokenSupplyType.FINITE)
-                                .initialSupply(10L)
-                                .maxSupply(1000L)
-                                .treasury(TOKEN_TREASURY)
-                                .adminKey(MULTI_KEY)
-                                .supplyKey(MULTI_KEY),
-                        uploadInitCode(ERC_20_CONTRACT),
-                        contractCreate(ERC_20_CONTRACT),
-                        tokenAssociate(OWNER, FUNGIBLE_TOKEN),
-                        cryptoTransfer(moving(10, FUNGIBLE_TOKEN).between(TOKEN_TREASURY, OWNER)),
-                        cryptoApproveAllowance()
-                                .payingWith(DEFAULT_PAYER)
-                                .addTokenAllowance(OWNER, FUNGIBLE_TOKEN, SPENDER, 2L)
-                                .via(BASE_APPROVE_TXN)
-                                .logged()
-                                .signedBy(DEFAULT_PAYER, OWNER)
-                                .fee(ONE_HBAR))
-                .when(
-                        withOpContext(
-                                (spec, opLog) ->
-                                        allRunFor(
-                                                spec,
-                                                contractCall(
-                                                                ERC_20_CONTRACT,
-                                                                ALLOWANCE,
-                                                                HapiParserUtil.asHeadlongAddress(
-                                                                        asAddress(
-                                                                                spec.registry()
-                                                                                        .getTokenID(
-                                                                                                FUNGIBLE_TOKEN))),
-                                                                HapiParserUtil.asHeadlongAddress(
-                                                                        asAddress(
-                                                                                spec.registry()
-                                                                                        .getAccountID(
-                                                                                                OWNER))),
-                                                                HapiParserUtil.asHeadlongAddress(
-                                                                        asAddress(
-                                                                                spec.registry()
-                                                                                        .getAccountID(
-                                                                                                SPENDER))))
-                                                        .payingWith(OWNER)
-                                                        .via(ALLOWANCE_TXN)
-                                                        .hasKnownStatus(SUCCESS))))
-                .then(
-                        getTxnRecord(ALLOWANCE_TXN).andAllChildRecords().logged(),
-                        childRecordsCheck(
-                                ALLOWANCE_TXN,
-                                SUCCESS,
-                                recordWith()
-                                        .status(SUCCESS)
-                                        .contractCallResult(
-                                                resultWith()
-                                                        .contractCallResult(
-                                                                htsPrecompileResult()
-                                                                        .forFunction(
-                                                                                FunctionType
-                                                                                        .ERC_ALLOWANCE)
-                                                                        .withAllowance(2)))));
-    }
-
-    private HapiSpec erc20Approve() {
-        final var approveTxn = "approveTxn";
-
-        return defaultHapiSpec("ERC_20_APPROVE")
-                .given(
-                        overriding("hedera.allowances.isEnabled", "true"),
-                        newKeyNamed(MULTI_KEY),
-                        cryptoCreate(OWNER).balance(100 * ONE_HUNDRED_HBARS),
-                        cryptoCreate(SPENDER),
-                        cryptoCreate(TOKEN_TREASURY),
-                        tokenCreate(FUNGIBLE_TOKEN)
-                                .tokenType(TokenType.FUNGIBLE_COMMON)
-                                .supplyType(TokenSupplyType.FINITE)
-                                .initialSupply(10L)
-                                .maxSupply(1000L)
-                                .treasury(TOKEN_TREASURY)
-                                .adminKey(MULTI_KEY)
-                                .supplyKey(MULTI_KEY),
-                        uploadInitCode(ERC_20_CONTRACT),
-                        contractCreate(ERC_20_CONTRACT),
-                        tokenAssociate(OWNER, FUNGIBLE_TOKEN),
-                        tokenAssociate(ERC_20_CONTRACT, FUNGIBLE_TOKEN))
-                .when(
-                        withOpContext(
-                                (spec, opLog) ->
-                                        allRunFor(
-                                                spec,
-                                                contractCall(
-                                                                ERC_20_CONTRACT,
-                                                                APPROVE,
-                                                                HapiParserUtil.asHeadlongAddress(
-                                                                        asAddress(
-                                                                                spec.registry()
-                                                                                        .getTokenID(
-                                                                                                FUNGIBLE_TOKEN))),
-                                                                HapiParserUtil.asHeadlongAddress(
-                                                                        asAddress(
-                                                                                spec.registry()
-                                                                                        .getAccountID(
-                                                                                                SPENDER))),
-                                                                BigInteger.valueOf(10))
-                                                        .payingWith(OWNER)
-                                                        .gas(4_000_000L)
-                                                        .via(approveTxn)
-                                                        .hasKnownStatus(SUCCESS))))
-                .then(
-                        childRecordsCheck(approveTxn, SUCCESS, recordWith().status(SUCCESS)),
-                        getTxnRecord(approveTxn).andAllChildRecords().logged());
-    }
-
-    private HapiSpec getErc20TokenDecimalsFromErc721TokenFails() {
-        final var invalidDecimalsTxn = "decimalsFromErc721Txn";
-
-        return defaultHapiSpec("ERC_20_DECIMALS_FROM_ERC_721_TOKEN")
-                .given(
-                        overriding("hedera.allowances.isEnabled", "true"),
-                        newKeyNamed(MULTI_KEY),
-                        cryptoCreate(ACCOUNT).balance(100 * ONE_HUNDRED_HBARS),
-                        cryptoCreate(TOKEN_TREASURY),
-                        tokenCreate(NON_FUNGIBLE_TOKEN)
-                                .tokenType(TokenType.NON_FUNGIBLE_UNIQUE)
-                                .initialSupply(0)
-                                .treasury(TOKEN_TREASURY)
-                                .adminKey(MULTI_KEY)
-                                .supplyKey(MULTI_KEY),
-                        mintToken(NON_FUNGIBLE_TOKEN, List.of(FIRST_META)),
-                        fileCreate(ERC_20_CONTRACT_NAME),
-                        uploadInitCode(ERC_20_CONTRACT),
-                        contractCreate(ERC_20_CONTRACT))
-                .when(
-                        withOpContext(
-                                (spec, opLog) ->
-                                        allRunFor(
-                                                spec,
-                                                contractCall(
-                                                                ERC_20_CONTRACT,
-                                                                DECIMALS,
-                                                                asHeadlongAddress(
-                                                                        asHexedAddress(
-                                                                                spec.registry()
-                                                                                        .getTokenID(
-                                                                                                NON_FUNGIBLE_TOKEN))))
-                                                        .payingWith(ACCOUNT)
-                                                        .via(invalidDecimalsTxn)
-                                                        .hasKnownStatus(CONTRACT_REVERT_EXECUTED)
-                                                        .gas(GAS_TO_OFFER))))
-                .then(getTxnRecord(invalidDecimalsTxn).andAllChildRecords().logged());
-    }
-
-    private HapiSpec transferErc20TokenFromErc721TokenFails() {
-        return defaultHapiSpec("ERC_20_TRANSFER_FROM_ERC_721_TOKEN")
-                .given(
-                        overriding("hedera.allowances.isEnabled", "true"),
-                        newKeyNamed(MULTI_KEY),
-                        cryptoCreate(ACCOUNT).balance(100 * ONE_MILLION_HBARS),
-                        cryptoCreate(RECIPIENT),
-                        cryptoCreate(TOKEN_TREASURY),
-                        tokenCreate(NON_FUNGIBLE_TOKEN)
-                                .tokenType(TokenType.NON_FUNGIBLE_UNIQUE)
-                                .initialSupply(0)
-                                .treasury(TOKEN_TREASURY)
-                                .adminKey(MULTI_KEY)
-                                .supplyKey(MULTI_KEY),
-                        mintToken(NON_FUNGIBLE_TOKEN, List.of(FIRST_META)),
-                        tokenAssociate(ACCOUNT, List.of(NON_FUNGIBLE_TOKEN)),
-                        tokenAssociate(RECIPIENT, List.of(NON_FUNGIBLE_TOKEN)),
-                        cryptoTransfer(
-                                        movingUnique(NON_FUNGIBLE_TOKEN, 1)
-                                                .between(TOKEN_TREASURY, ACCOUNT))
-                                .payingWith(ACCOUNT),
-                        uploadInitCode(ERC_20_CONTRACT),
-                        contractCreate(ERC_20_CONTRACT))
-                .when(
-                        withOpContext(
-                                (spec, opLog) ->
-                                        allRunFor(
-                                                spec,
-                                                contractCall(
-                                                                ERC_20_CONTRACT,
-                                                                TRANSFER,
-                                                                HapiParserUtil.asHeadlongAddress(
-                                                                        asAddress(
-                                                                                spec.registry()
-                                                                                        .getTokenID(
-                                                                                                NON_FUNGIBLE_TOKEN))),
-                                                                HapiParserUtil.asHeadlongAddress(
-                                                                        asAddress(
-                                                                                spec.registry()
-                                                                                        .getAccountID(
-                                                                                                RECIPIENT))),
-                                                                BigInteger.TWO)
-                                                        .payingWith(ACCOUNT)
-                                                        .alsoSigningWithFullPrefix(MULTI_KEY)
-                                                        .via(TRANSFER_TXN)
-                                                        .gas(GAS_TO_OFFER)
-                                                        .hasKnownStatus(CONTRACT_REVERT_EXECUTED))))
-                .then(getTxnRecord(TRANSFER_TXN).andAllChildRecords().logged());
     }
 
     private HapiSpec getErc721TokenName() {
@@ -2633,444 +2085,6 @@ public class ERCPrecompileSuite extends HapiSuite {
                                                         BigInteger.valueOf(5))
                                                 .gas(1_000_000)),
                         getTokenNftInfo(NF_TOKEN, 5L).hasAccountID(B_CIVILIAN).hasNoSpender());
-    }
-
-    private HapiSpec someERC20ApproveAllowanceScenariosPass() {
-        final AtomicReference<String> tokenMirrorAddr = new AtomicReference<>();
-        final AtomicReference<String> contractMirrorAddr = new AtomicReference<>();
-        final AtomicReference<String> aCivilianMirrorAddr = new AtomicReference<>();
-        final AtomicReference<String> bCivilianMirrorAddr = new AtomicReference<>();
-        final AtomicReference<String> zCivilianMirrorAddr = new AtomicReference<>();
-
-        return defaultHapiSpec("someERC20ApproveAllowanceScenariosPass")
-                .given(
-                        overriding("hedera.allowances.isEnabled", "true"),
-                        newKeyNamed(MULTI_KEY_NAME),
-                        cryptoCreate(A_CIVILIAN)
-                                .exposingCreatedIdTo(
-                                        id -> aCivilianMirrorAddr.set(asHexedSolidityAddress(id))),
-                        cryptoCreate(B_CIVILIAN)
-                                .exposingCreatedIdTo(
-                                        id -> bCivilianMirrorAddr.set(asHexedSolidityAddress(id))),
-                        uploadInitCode(SOME_ERC_20_SCENARIOS),
-                        contractCreate(SOME_ERC_20_SCENARIOS).adminKey(MULTI_KEY_NAME),
-                        tokenCreate(TOKEN)
-                                .supplyKey(MULTI_KEY_NAME)
-                                .tokenType(FUNGIBLE_COMMON)
-                                .treasury(B_CIVILIAN)
-                                .initialSupply(10)
-                                .exposingCreatedIdTo(
-                                        idLit ->
-                                                tokenMirrorAddr.set(
-                                                        asHexedSolidityAddress(
-                                                                HapiPropertySource.asToken(
-                                                                        idLit)))))
-                .when(
-                        withOpContext(
-                                (spec, opLog) -> {
-                                    zCivilianMirrorAddr.set(
-                                            asHexedSolidityAddress(
-                                                    AccountID.newBuilder()
-                                                            .setAccountNum(666_666_666L)
-                                                            .build()));
-                                    contractMirrorAddr.set(
-                                            asHexedSolidityAddress(
-                                                    spec.registry()
-                                                            .getAccountID(SOME_ERC_20_SCENARIOS)));
-                                }),
-                        sourcing(
-                                () ->
-                                        contractCall(
-                                                        SOME_ERC_20_SCENARIOS,
-                                                        DO_SPECIFIC_APPROVAL,
-                                                        asHeadlongAddress(tokenMirrorAddr.get()),
-                                                        asHeadlongAddress(
-                                                                aCivilianMirrorAddr.get()),
-                                                        BigInteger.ZERO)
-                                                .via("ACCOUNT_NOT_ASSOCIATED_TXN")
-                                                .gas(1_000_000)
-                                                .hasKnownStatus(CONTRACT_REVERT_EXECUTED)),
-                        tokenAssociate(SOME_ERC_20_SCENARIOS, TOKEN),
-                        sourcing(
-                                () ->
-                                        contractCall(
-                                                        SOME_ERC_20_SCENARIOS,
-                                                        DO_SPECIFIC_APPROVAL,
-                                                        asHeadlongAddress(tokenMirrorAddr.get()),
-                                                        asHeadlongAddress(
-                                                                zCivilianMirrorAddr.get()),
-                                                        BigInteger.valueOf(5))
-                                                .via(MISSING_TO)
-                                                .gas(1_000_000)
-                                                .hasKnownStatus(CONTRACT_REVERT_EXECUTED)),
-                        sourcing(
-                                () ->
-                                        contractCall(
-                                                        SOME_ERC_20_SCENARIOS,
-                                                        DO_SPECIFIC_APPROVAL,
-                                                        asHeadlongAddress(tokenMirrorAddr.get()),
-                                                        asHeadlongAddress(contractMirrorAddr.get()),
-                                                        BigInteger.valueOf(5))
-                                                .via("SPENDER_SAME_AS_OWNER_TXN")
-                                                .gas(1_000_000)
-                                                .hasKnownStatus(CONTRACT_REVERT_EXECUTED)),
-                        sourcing(
-                                () ->
-                                        contractCall(
-                                                        SOME_ERC_20_SCENARIOS,
-                                                        DO_SPECIFIC_APPROVAL,
-                                                        asHeadlongAddress(tokenMirrorAddr.get()),
-                                                        asHeadlongAddress(
-                                                                aCivilianMirrorAddr.get()),
-                                                        BigInteger.valueOf(5))
-                                                .via("SUCCESSFUL_APPROVE_TXN")
-                                                .gas(1_000_000)
-                                                .hasKnownStatus(SUCCESS)),
-                        sourcing(
-                                () ->
-                                        contractCall(
-                                                        SOME_ERC_20_SCENARIOS,
-                                                        GET_ALLOWANCE,
-                                                        asHeadlongAddress(tokenMirrorAddr.get()),
-                                                        asHeadlongAddress(contractMirrorAddr.get()),
-                                                        asHeadlongAddress(
-                                                                aCivilianMirrorAddr.get()))
-                                                .via("ALLOWANCE_TXN")
-                                                .gas(1_000_000)
-                                                .hasKnownStatus(SUCCESS)),
-                        sourcing(
-                                () ->
-                                        contractCallLocal(
-                                                SOME_ERC_20_SCENARIOS,
-                                                GET_ALLOWANCE,
-                                                asHeadlongAddress(tokenMirrorAddr.get()),
-                                                asHeadlongAddress(contractMirrorAddr.get()),
-                                                asHeadlongAddress(aCivilianMirrorAddr.get()))),
-                        sourcing(
-                                () ->
-                                        contractCall(
-                                                        SOME_ERC_20_SCENARIOS,
-                                                        DO_SPECIFIC_APPROVAL,
-                                                        asHeadlongAddress(tokenMirrorAddr.get()),
-                                                        asHeadlongAddress(
-                                                                aCivilianMirrorAddr.get()),
-                                                        BigInteger.ZERO)
-                                                .via("SUCCESSFUL_REVOKE_TXN")
-                                                .gas(1_000_000)
-                                                .hasKnownStatus(SUCCESS)),
-                        sourcing(
-                                () ->
-                                        contractCall(
-                                                        SOME_ERC_20_SCENARIOS,
-                                                        GET_ALLOWANCE,
-                                                        asHeadlongAddress(tokenMirrorAddr.get()),
-                                                        asHeadlongAddress(contractMirrorAddr.get()),
-                                                        asHeadlongAddress(
-                                                                aCivilianMirrorAddr.get()))
-                                                .via("ALLOWANCE_AFTER_REVOKE_TXN")
-                                                .gas(1_000_000)
-                                                .hasKnownStatus(SUCCESS)),
-                        sourcing(
-                                () ->
-                                        contractCall(
-                                                        SOME_ERC_20_SCENARIOS,
-                                                        GET_ALLOWANCE,
-                                                        asHeadlongAddress(tokenMirrorAddr.get()),
-                                                        asHeadlongAddress(
-                                                                zCivilianMirrorAddr.get()),
-                                                        asHeadlongAddress(
-                                                                aCivilianMirrorAddr.get()))
-                                                .via("MISSING_OWNER_ID")
-                                                .gas(1_000_000)
-                                                .hasKnownStatus(CONTRACT_REVERT_EXECUTED)))
-                .then(
-                        childRecordsCheck(
-                                "ACCOUNT_NOT_ASSOCIATED_TXN",
-                                CONTRACT_REVERT_EXECUTED,
-                                recordWith().status(TOKEN_NOT_ASSOCIATED_TO_ACCOUNT)),
-                        childRecordsCheck(
-                                MISSING_TO,
-                                CONTRACT_REVERT_EXECUTED,
-                                recordWith().status(INVALID_ALLOWANCE_SPENDER_ID)),
-                        childRecordsCheck(
-                                "SPENDER_SAME_AS_OWNER_TXN",
-                                CONTRACT_REVERT_EXECUTED,
-                                recordWith().status(SPENDER_ACCOUNT_SAME_AS_OWNER)),
-                        childRecordsCheck(
-                                "SUCCESSFUL_APPROVE_TXN", SUCCESS, recordWith().status(SUCCESS)),
-                        childRecordsCheck(
-                                "SUCCESSFUL_REVOKE_TXN", SUCCESS, recordWith().status(SUCCESS)),
-                        childRecordsCheck(
-                                "MISSING_OWNER_ID",
-                                CONTRACT_REVERT_EXECUTED,
-                                recordWith().status(INVALID_ALLOWANCE_OWNER_ID)),
-                        childRecordsCheck(
-                                "ALLOWANCE_TXN",
-                                SUCCESS,
-                                recordWith()
-                                        .status(SUCCESS)
-                                        .contractCallResult(
-                                                resultWith()
-                                                        .contractCallResult(
-                                                                htsPrecompileResult()
-                                                                        .forFunction(
-                                                                                FunctionType
-                                                                                        .ERC_ALLOWANCE)
-                                                                        .withAllowance(5L)))),
-                        childRecordsCheck(
-                                "ALLOWANCE_AFTER_REVOKE_TXN",
-                                SUCCESS,
-                                recordWith()
-                                        .status(SUCCESS)
-                                        .contractCallResult(
-                                                resultWith()
-                                                        .contractCallResult(
-                                                                htsPrecompileResult()
-                                                                        .forFunction(
-                                                                                FunctionType
-                                                                                        .ERC_ALLOWANCE)
-                                                                        .withAllowance(0L)))));
-    }
-
-    private HapiSpec someERC20NegativeTransferFromScenariosPass() {
-        final AtomicReference<String> tokenMirrorAddr = new AtomicReference<>();
-        final AtomicReference<String> contractMirrorAddr = new AtomicReference<>();
-        final AtomicReference<String> aCivilianMirrorAddr = new AtomicReference<>();
-        final AtomicReference<String> bCivilianMirrorAddr = new AtomicReference<>();
-        final AtomicReference<String> zCivilianMirrorAddr = new AtomicReference<>();
-
-        return defaultHapiSpec("someERC20NegativeTransferFromScenariosPass")
-                .given(
-                        overriding("hedera.allowances.isEnabled", "true"),
-                        newKeyNamed(MULTI_KEY_NAME),
-                        cryptoCreate(A_CIVILIAN)
-                                .exposingCreatedIdTo(
-                                        id -> aCivilianMirrorAddr.set(asHexedSolidityAddress(id))),
-                        cryptoCreate(B_CIVILIAN)
-                                .exposingCreatedIdTo(
-                                        id -> bCivilianMirrorAddr.set(asHexedSolidityAddress(id))),
-                        uploadInitCode(SOME_ERC_20_SCENARIOS),
-                        contractCreate(SOME_ERC_20_SCENARIOS).adminKey(MULTI_KEY_NAME),
-                        tokenCreate(TOKEN)
-                                .supplyKey(MULTI_KEY_NAME)
-                                .tokenType(FUNGIBLE_COMMON)
-                                .treasury(SOME_ERC_20_SCENARIOS)
-                                .initialSupply(10)
-                                .exposingCreatedIdTo(
-                                        idLit ->
-                                                tokenMirrorAddr.set(
-                                                        asHexedSolidityAddress(
-                                                                HapiPropertySource.asToken(
-                                                                        idLit)))))
-                .when(
-                        withOpContext(
-                                (spec, opLog) -> {
-                                    zCivilianMirrorAddr.set(
-                                            asHexedSolidityAddress(
-                                                    AccountID.newBuilder()
-                                                            .setAccountNum(666_666_666L)
-                                                            .build()));
-                                    contractMirrorAddr.set(
-                                            asHexedSolidityAddress(
-                                                    spec.registry()
-                                                            .getAccountID(SOME_ERC_20_SCENARIOS)));
-                                }),
-                        sourcing(
-                                () ->
-                                        contractCall(
-                                                        SOME_ERC_20_SCENARIOS,
-                                                        DO_TRANSFER_FROM,
-                                                        asHeadlongAddress(tokenMirrorAddr.get()),
-                                                        asHeadlongAddress(contractMirrorAddr.get()),
-                                                        asHeadlongAddress(
-                                                                bCivilianMirrorAddr.get()),
-                                                        BigInteger.ONE)
-                                                .payingWith(GENESIS)
-                                                .via("TOKEN_NOT_ASSOCIATED_TO_ACCOUNT_TXN")
-                                                .hasKnownStatus(CONTRACT_REVERT_EXECUTED)),
-                        tokenAssociate(B_CIVILIAN, TOKEN),
-                        sourcing(
-                                () ->
-                                        contractCall(
-                                                        SOME_ERC_20_SCENARIOS,
-                                                        DO_TRANSFER_FROM,
-                                                        asHeadlongAddress(tokenMirrorAddr.get()),
-                                                        asHeadlongAddress(
-                                                                zCivilianMirrorAddr.get()),
-                                                        asHeadlongAddress(
-                                                                bCivilianMirrorAddr.get()),
-                                                        BigInteger.ONE)
-                                                .payingWith(GENESIS)
-                                                .via(MISSING_FROM)
-                                                .hasKnownStatus(CONTRACT_REVERT_EXECUTED)),
-                        sourcing(
-                                () ->
-                                        contractCall(
-                                                        SOME_ERC_20_SCENARIOS,
-                                                        DO_TRANSFER_FROM,
-                                                        asHeadlongAddress(tokenMirrorAddr.get()),
-                                                        asHeadlongAddress(contractMirrorAddr.get()),
-                                                        asHeadlongAddress(
-                                                                bCivilianMirrorAddr.get()),
-                                                        BigInteger.ONE)
-                                                .payingWith(GENESIS)
-                                                .via(MSG_SENDER_IS_THE_SAME_AS_FROM)
-                                                .hasKnownStatus(SUCCESS)),
-                        cryptoTransfer(
-                                moving(9L, TOKEN).between(SOME_ERC_20_SCENARIOS, B_CIVILIAN)),
-                        tokenAssociate(A_CIVILIAN, TOKEN),
-                        sourcing(
-                                () ->
-                                        contractCall(
-                                                        SOME_ERC_20_SCENARIOS,
-                                                        DO_TRANSFER_FROM,
-                                                        asHeadlongAddress(tokenMirrorAddr.get()),
-                                                        asHeadlongAddress(
-                                                                bCivilianMirrorAddr.get()),
-                                                        asHeadlongAddress(
-                                                                aCivilianMirrorAddr.get()),
-                                                        BigInteger.ONE)
-                                                .payingWith(GENESIS)
-                                                .via(MSG_SENDER_IS_NOT_THE_SAME_AS_FROM)
-                                                .hasKnownStatus(CONTRACT_REVERT_EXECUTED)),
-                        cryptoApproveAllowance()
-                                .payingWith(B_CIVILIAN)
-                                .addTokenAllowance(B_CIVILIAN, TOKEN, SOME_ERC_20_SCENARIOS, 1L)
-                                .signedBy(DEFAULT_PAYER, B_CIVILIAN)
-                                .fee(ONE_HBAR),
-                        sourcing(
-                                () ->
-                                        contractCall(
-                                                        SOME_ERC_20_SCENARIOS,
-                                                        DO_TRANSFER_FROM,
-                                                        asHeadlongAddress(tokenMirrorAddr.get()),
-                                                        asHeadlongAddress(
-                                                                bCivilianMirrorAddr.get()),
-                                                        asHeadlongAddress(
-                                                                aCivilianMirrorAddr.get()),
-                                                        BigInteger.valueOf(5))
-                                                .payingWith(GENESIS)
-                                                .via(
-                                                        "TRY_TO_TRANSFER_MORE_THAN_APPROVED_AMOUNT_TXN")
-                                                .hasKnownStatus(CONTRACT_REVERT_EXECUTED)),
-                        cryptoApproveAllowance()
-                                .payingWith(B_CIVILIAN)
-                                .addTokenAllowance(B_CIVILIAN, TOKEN, SOME_ERC_20_SCENARIOS, 20L)
-                                .signedBy(DEFAULT_PAYER, B_CIVILIAN)
-                                .fee(ONE_HBAR),
-                        sourcing(
-                                () ->
-                                        contractCall(
-                                                        SOME_ERC_20_SCENARIOS,
-                                                        DO_TRANSFER_FROM,
-                                                        asHeadlongAddress(tokenMirrorAddr.get()),
-                                                        asHeadlongAddress(
-                                                                bCivilianMirrorAddr.get()),
-                                                        asHeadlongAddress(
-                                                                aCivilianMirrorAddr.get()),
-                                                        BigInteger.valueOf(20))
-                                                .payingWith(GENESIS)
-                                                .via("TRY_TO_TRANSFER_MORE_THAN_OWNERS_BALANCE_TXN")
-                                                .hasKnownStatus(CONTRACT_REVERT_EXECUTED)))
-                .then(
-                        childRecordsCheck(
-                                "TOKEN_NOT_ASSOCIATED_TO_ACCOUNT_TXN",
-                                CONTRACT_REVERT_EXECUTED,
-                                recordWith().status(TOKEN_NOT_ASSOCIATED_TO_ACCOUNT)),
-                        childRecordsCheck(
-                                MISSING_FROM,
-                                CONTRACT_REVERT_EXECUTED,
-                                recordWith().status(INVALID_ACCOUNT_ID)),
-                        childRecordsCheck(
-                                MSG_SENDER_IS_THE_SAME_AS_FROM,
-                                SUCCESS,
-                                recordWith().status(SUCCESS)),
-                        childRecordsCheck(
-                                MSG_SENDER_IS_NOT_THE_SAME_AS_FROM,
-                                CONTRACT_REVERT_EXECUTED,
-                                recordWith().status(SPENDER_DOES_NOT_HAVE_ALLOWANCE)),
-                        childRecordsCheck(
-                                "TRY_TO_TRANSFER_MORE_THAN_APPROVED_AMOUNT_TXN",
-                                CONTRACT_REVERT_EXECUTED,
-                                recordWith().status(AMOUNT_EXCEEDS_ALLOWANCE)),
-                        childRecordsCheck(
-                                "TRY_TO_TRANSFER_MORE_THAN_OWNERS_BALANCE_TXN",
-                                CONTRACT_REVERT_EXECUTED,
-                                recordWith().status(INSUFFICIENT_TOKEN_BALANCE)));
-    }
-
-    private HapiSpec someERC20ApproveAllowanceScenarioInOneCall() {
-        final AtomicReference<String> tokenMirrorAddr = new AtomicReference<>();
-        final AtomicReference<String> contractMirrorAddr = new AtomicReference<>();
-        final AtomicReference<String> aCivilianMirrorAddr = new AtomicReference<>();
-        final AtomicReference<String> bCivilianMirrorAddr = new AtomicReference<>();
-        final AtomicReference<String> zCivilianMirrorAddr = new AtomicReference<>();
-
-        return defaultHapiSpec("someERC20ApproveAllowanceScenarioInOneCall")
-                .given(
-                        overriding("hedera.allowances.isEnabled", "true"),
-                        newKeyNamed(MULTI_KEY_NAME),
-                        cryptoCreate(A_CIVILIAN)
-                                .exposingCreatedIdTo(
-                                        id -> aCivilianMirrorAddr.set(asHexedSolidityAddress(id))),
-                        cryptoCreate(B_CIVILIAN)
-                                .exposingCreatedIdTo(
-                                        id -> bCivilianMirrorAddr.set(asHexedSolidityAddress(id))),
-                        uploadInitCode(SOME_ERC_20_SCENARIOS),
-                        contractCreate(SOME_ERC_20_SCENARIOS).adminKey(MULTI_KEY_NAME),
-                        tokenCreate(TOKEN)
-                                .supplyKey(MULTI_KEY_NAME)
-                                .tokenType(FUNGIBLE_COMMON)
-                                .treasury(B_CIVILIAN)
-                                .initialSupply(10)
-                                .exposingCreatedIdTo(
-                                        idLit ->
-                                                tokenMirrorAddr.set(
-                                                        asHexedSolidityAddress(
-                                                                HapiPropertySource.asToken(
-                                                                        idLit)))),
-                        tokenAssociate(SOME_ERC_20_SCENARIOS, TOKEN))
-                .when(
-                        withOpContext(
-                                (spec, opLog) -> {
-                                    zCivilianMirrorAddr.set(
-                                            asHexedSolidityAddress(
-                                                    AccountID.newBuilder()
-                                                            .setAccountNum(666_666_666L)
-                                                            .build()));
-                                    contractMirrorAddr.set(
-                                            asHexedSolidityAddress(
-                                                    spec.registry()
-                                                            .getAccountID(SOME_ERC_20_SCENARIOS)));
-                                }),
-                        sourcing(
-                                () ->
-                                        contractCall(
-                                                        SOME_ERC_20_SCENARIOS,
-                                                        "approveAndGetAllowanceAmount",
-                                                        asHeadlongAddress(tokenMirrorAddr.get()),
-                                                        asHeadlongAddress(
-                                                                aCivilianMirrorAddr.get()),
-                                                        BigInteger.valueOf(5))
-                                                .via("APPROVE_AND_GET_ALLOWANCE_TXN")
-                                                .gas(1_000_000)
-                                                .hasKnownStatus(SUCCESS)
-                                                .logged()))
-                .then(
-                        childRecordsCheck(
-                                "APPROVE_AND_GET_ALLOWANCE_TXN",
-                                SUCCESS,
-                                recordWith().status(SUCCESS),
-                                recordWith()
-                                        .status(SUCCESS)
-                                        .contractCallResult(
-                                                resultWith()
-                                                        .contractCallResult(
-                                                                htsPrecompileResult()
-                                                                        .forFunction(
-                                                                                FunctionType
-                                                                                        .ERC_ALLOWANCE)
-                                                                        .withAllowance(5L)))));
     }
 
     private HapiSpec directCallsWorkForERC721() {
@@ -4259,199 +3273,6 @@ public class ERCPrecompileSuite extends HapiSuite {
                                                                                                                         .getAccountID(
                                                                                                                                 SPENDER)))))))),
                         getTxnRecord(ALLOWANCE_TXN).andAllChildRecords().logged());
-    }
-
-    private HapiSpec erc20TransferFrom() {
-        final var allowanceTxn2 = "allowanceTxn2";
-
-        return defaultHapiSpec("ERC_20_ALLOWANCE")
-                .given(
-                        overriding("hedera.allowances.isEnabled", "true"),
-                        newKeyNamed(MULTI_KEY),
-                        cryptoCreate(OWNER).balance(100 * ONE_HUNDRED_HBARS),
-                        cryptoCreate(RECIPIENT),
-                        cryptoCreate(TOKEN_TREASURY),
-                        tokenCreate(FUNGIBLE_TOKEN)
-                                .tokenType(TokenType.FUNGIBLE_COMMON)
-                                .supplyType(TokenSupplyType.FINITE)
-                                .initialSupply(10L)
-                                .maxSupply(1000L)
-                                .treasury(TOKEN_TREASURY)
-                                .adminKey(MULTI_KEY)
-                                .supplyKey(MULTI_KEY),
-                        uploadInitCode(ERC_20_CONTRACT),
-                        contractCreate(ERC_20_CONTRACT),
-                        tokenAssociate(OWNER, FUNGIBLE_TOKEN),
-                        tokenAssociate(RECIPIENT, FUNGIBLE_TOKEN),
-                        tokenAssociate(ERC_20_CONTRACT, FUNGIBLE_TOKEN),
-                        cryptoTransfer(moving(10, FUNGIBLE_TOKEN).between(TOKEN_TREASURY, OWNER)))
-                .when(
-                        withOpContext(
-                                (spec, opLog) ->
-                                        allRunFor(
-                                                spec,
-                                                // ERC_20_CONTRACT is approved as spender of
-                                                // fungible tokens for OWNER
-                                                cryptoApproveAllowance()
-                                                        .payingWith(DEFAULT_PAYER)
-                                                        .addTokenAllowance(
-                                                                OWNER,
-                                                                FUNGIBLE_TOKEN,
-                                                                ERC_20_CONTRACT,
-                                                                2L)
-                                                        .via(BASE_APPROVE_TXN)
-                                                        .logged()
-                                                        .signedBy(DEFAULT_PAYER, OWNER)
-                                                        .fee(ONE_HBAR),
-                                                // Check that ERC_20_CONTRACT has allowance of 2
-                                                contractCall(
-                                                                ERC_20_CONTRACT,
-                                                                ALLOWANCE,
-                                                                HapiParserUtil.asHeadlongAddress(
-                                                                        asAddress(
-                                                                                spec.registry()
-                                                                                        .getTokenID(
-                                                                                                FUNGIBLE_TOKEN))),
-                                                                HapiParserUtil.asHeadlongAddress(
-                                                                        asAddress(
-                                                                                spec.registry()
-                                                                                        .getAccountID(
-                                                                                                OWNER))),
-                                                                HapiParserUtil.asHeadlongAddress(
-                                                                        asAddress(
-                                                                                spec.registry()
-                                                                                        .getAccountID(
-                                                                                                ERC_20_CONTRACT))))
-                                                        .gas(500_000L)
-                                                        .via(ALLOWANCE_TXN)
-                                                        .hasKnownStatus(SUCCESS),
-                                                // ERC_20_CONTRACT calls the precompile transferFrom
-                                                // as the spender
-                                                contractCall(
-                                                                ERC_20_CONTRACT,
-                                                                TRANSFER_FROM,
-                                                                HapiParserUtil.asHeadlongAddress(
-                                                                        asAddress(
-                                                                                spec.registry()
-                                                                                        .getTokenID(
-                                                                                                FUNGIBLE_TOKEN))),
-                                                                HapiParserUtil.asHeadlongAddress(
-                                                                        asAddress(
-                                                                                spec.registry()
-                                                                                        .getAccountID(
-                                                                                                OWNER))),
-                                                                HapiParserUtil.asHeadlongAddress(
-                                                                        asAddress(
-                                                                                spec.registry()
-                                                                                        .getAccountID(
-                                                                                                RECIPIENT))),
-                                                                BigInteger.TWO)
-                                                        .gas(500_000L)
-                                                        .via(TRANSFER_FROM_ACCOUNT_TXN)
-                                                        .hasKnownStatus(SUCCESS),
-                                                // ERC_20_CONTRACT should have spent its allowance
-                                                contractCall(
-                                                                ERC_20_CONTRACT,
-                                                                ALLOWANCE,
-                                                                HapiParserUtil.asHeadlongAddress(
-                                                                        asAddress(
-                                                                                spec.registry()
-                                                                                        .getTokenID(
-                                                                                                FUNGIBLE_TOKEN))),
-                                                                HapiParserUtil.asHeadlongAddress(
-                                                                        asAddress(
-                                                                                spec.registry()
-                                                                                        .getAccountID(
-                                                                                                OWNER))),
-                                                                HapiParserUtil.asHeadlongAddress(
-                                                                        asAddress(
-                                                                                spec.registry()
-                                                                                        .getAccountID(
-                                                                                                ERC_20_CONTRACT))))
-                                                        .gas(500_000L)
-                                                        .via(allowanceTxn2)
-                                                        .hasKnownStatus(SUCCESS))))
-                .then(
-                        childRecordsCheck(
-                                ALLOWANCE_TXN,
-                                SUCCESS,
-                                recordWith()
-                                        .status(SUCCESS)
-                                        .contractCallResult(
-                                                resultWith()
-                                                        .contractCallResult(
-                                                                htsPrecompileResult()
-                                                                        .forFunction(
-                                                                                FunctionType
-                                                                                        .ERC_ALLOWANCE)
-                                                                        .withAllowance(2)))),
-                        childRecordsCheck(
-                                allowanceTxn2,
-                                SUCCESS,
-                                recordWith()
-                                        .status(SUCCESS)
-                                        .contractCallResult(
-                                                resultWith()
-                                                        .contractCallResult(
-                                                                htsPrecompileResult()
-                                                                        .forFunction(
-                                                                                FunctionType
-                                                                                        .ERC_ALLOWANCE)
-                                                                        .withAllowance(0)))));
-    }
-
-    private HapiSpec erc20TransferFromSelf() {
-        return defaultHapiSpec("Erc20TransferFromSelf")
-                .given(
-                        overriding("hedera.allowances.isEnabled", "true"),
-                        newKeyNamed(MULTI_KEY),
-                        cryptoCreate(RECIPIENT),
-                        cryptoCreate(TOKEN_TREASURY),
-                        tokenCreate(FUNGIBLE_TOKEN)
-                                .tokenType(TokenType.FUNGIBLE_COMMON)
-                                .supplyType(TokenSupplyType.FINITE)
-                                .initialSupply(10L)
-                                .maxSupply(1000L)
-                                .treasury(TOKEN_TREASURY)
-                                .adminKey(MULTI_KEY)
-                                .supplyKey(MULTI_KEY),
-                        uploadInitCode(ERC_20_CONTRACT),
-                        contractCreate(ERC_20_CONTRACT),
-                        tokenAssociate(RECIPIENT, FUNGIBLE_TOKEN),
-                        tokenAssociate(ERC_20_CONTRACT, FUNGIBLE_TOKEN),
-                        cryptoTransfer(
-                                moving(10, FUNGIBLE_TOKEN)
-                                        .between(TOKEN_TREASURY, ERC_20_CONTRACT)))
-                .when(
-                        withOpContext(
-                                (spec, opLog) ->
-                                        allRunFor(
-                                                spec,
-                                                // ERC_20_CONTRACT should be able to transfer its
-                                                // own tokens
-                                                contractCall(
-                                                                ERC_20_CONTRACT,
-                                                                TRANSFER_FROM,
-                                                                HapiParserUtil.asHeadlongAddress(
-                                                                        asAddress(
-                                                                                spec.registry()
-                                                                                        .getTokenID(
-                                                                                                FUNGIBLE_TOKEN))),
-                                                                HapiParserUtil.asHeadlongAddress(
-                                                                        asAddress(
-                                                                                spec.registry()
-                                                                                        .getAccountID(
-                                                                                                ERC_20_CONTRACT))),
-                                                                HapiParserUtil.asHeadlongAddress(
-                                                                        asAddress(
-                                                                                spec.registry()
-                                                                                        .getAccountID(
-                                                                                                RECIPIENT))),
-                                                                BigInteger.TWO)
-                                                        .gas(500_000L)
-                                                        .via(TRANSFER_FROM_ACCOUNT_TXN)
-                                                        .hasKnownStatus(SUCCESS))))
-                .then(getAccountBalance(RECIPIENT).hasTokenBalance(FUNGIBLE_TOKEN, 2));
     }
 
     private HapiSpec erc721TransferFromWithApproval() {

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoApproveAllowanceSuite.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoApproveAllowanceSuite.java
@@ -1320,11 +1320,11 @@ public class CryptoApproveAllowanceSuite extends HapiSuite {
                                 .addCryptoAllowance(OWNER, OWNER, 100L)
                                 .fee(ONE_HUNDRED_HBARS)
                                 .hasPrecheck(ResponseCodeEnum.SPENDER_ACCOUNT_SAME_AS_OWNER),
+                        // Only reject self approvals for NFTs, else allow as per OZ ERC-20 standard
                         cryptoApproveAllowance()
                                 .payingWith(OWNER)
                                 .addTokenAllowance(OWNER, FUNGIBLE_TOKEN, OWNER, 100L)
-                                .fee(ONE_HUNDRED_HBARS)
-                                .hasPrecheck(ResponseCodeEnum.SPENDER_ACCOUNT_SAME_AS_OWNER),
+                                .fee(ONE_HUNDRED_HBARS),
                         cryptoApproveAllowance()
                                 .payingWith(OWNER)
                                 .addNftAllowance(
@@ -1338,7 +1338,7 @@ public class CryptoApproveAllowanceSuite extends HapiSuite {
                                         accountDetailsWith()
                                                 .cryptoAllowancesCount(0)
                                                 .nftApprovedForAllAllowancesCount(0)
-                                                .tokenAllowancesCount(0)));
+                                                .tokenAllowancesCount(1)));
     }
 
     private HapiSpec negativeAmountFailsForFungible() {

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoUpdateSuite.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoUpdateSuite.java
@@ -16,7 +16,6 @@
 package com.hedera.services.bdd.suites.crypto;
 
 import static com.hedera.services.bdd.spec.HapiSpec.defaultHapiSpec;
-import static com.hedera.services.bdd.spec.HapiSpec.onlyDefaultHapiSpec;
 import static com.hedera.services.bdd.spec.assertions.AccountDetailsAsserts.accountDetailsWith;
 import static com.hedera.services.bdd.spec.assertions.ContractInfoAsserts.contractWith;
 import static com.hedera.services.bdd.spec.keys.ControlForKey.forKey;
@@ -420,7 +419,7 @@ public class CryptoUpdateSuite extends HapiSuite {
         final String CONTRACT = "Multipurpose";
         final String ADMIN_KEY = "adminKey";
 
-        return onlyDefaultHapiSpec("updateMaxAutoAssociationsWorks")
+        return defaultHapiSpec("updateMaxAutoAssociationsWorks")
                 .given(
                         cryptoCreate(treasury).balance(ONE_HUNDRED_HBARS),
                         newKeyNamed(ADMIN_KEY),

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/ethereum/HelloWorldEthereumSuite.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/ethereum/HelloWorldEthereumSuite.java
@@ -19,7 +19,6 @@ import static com.hedera.services.bdd.spec.HapiPropertySource.asAccountString;
 import static com.hedera.services.bdd.spec.HapiPropertySource.asHexedSolidityAddress;
 import static com.hedera.services.bdd.spec.HapiPropertySource.asToken;
 import static com.hedera.services.bdd.spec.HapiSpec.defaultHapiSpec;
-import static com.hedera.services.bdd.spec.HapiSpec.onlyDefaultHapiSpec;
 import static com.hedera.services.bdd.spec.assertions.AccountInfoAsserts.accountWith;
 import static com.hedera.services.bdd.spec.assertions.AssertUtils.inOrder;
 import static com.hedera.services.bdd.spec.assertions.ContractFnResultAsserts.resultWith;
@@ -395,7 +394,7 @@ public class HelloWorldEthereumSuite extends HapiSuite {
     HapiSpec createWithSelfDestructInConstructorHasSaneRecord() {
         final var txn = "txn";
         final var selfDestructingContract = "FactorySelfDestructConstructor";
-        return onlyDefaultHapiSpec("CreateWithSelfDestructInConstructorHasSaneRecord")
+        return defaultHapiSpec("CreateWithSelfDestructInConstructorHasSaneRecord")
                 .given(
                         newKeyNamed(SECP_256K1_SOURCE_KEY).shape(SECP_256K1_SHAPE),
                         cryptoCreate(RELAYER).balance(6 * ONE_MILLION_HBARS),

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/leaky/LeakyContractTestsSuite.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/leaky/LeakyContractTestsSuite.java
@@ -130,7 +130,6 @@ import static com.hedera.services.bdd.suites.contract.precompile.CreatePrecompil
 import static com.hedera.services.bdd.suites.contract.precompile.CreatePrecompileSuite.TOKEN_CREATE_CONTRACT_AS_KEY;
 import static com.hedera.services.bdd.suites.contract.precompile.CreatePrecompileSuite.TOKEN_NAME;
 import static com.hedera.services.bdd.suites.contract.precompile.CreatePrecompileSuite.TOKEN_SYMBOL;
-import static com.hedera.services.bdd.suites.contract.precompile.CryptoTransferHTSSuite.DELEGATE_KEY;
 import static com.hedera.services.bdd.suites.contract.precompile.CryptoTransferHTSSuite.TOTAL_SUPPLY;
 import static com.hedera.services.bdd.suites.contract.precompile.CryptoTransferHTSSuite.TRANSFER_MULTIPLE_TOKENS;
 import static com.hedera.services.bdd.suites.contract.precompile.ERCPrecompileSuite.ALLOWANCE;
@@ -249,6 +248,12 @@ public class LeakyContractTestsSuite extends HapiSuite {
     private static final String CONTRACT_ALLOW_ASSOCIATIONS_PROPERTY =
             "contracts.allowAutoAssociations";
     private static final String TRANSFER_CONTRACT = "NonDelegateCryptoTransfer";
+    private static final String HEDERA_ALLOWANCES_IS_ENABLED = "hedera.allowances.isEnabled";
+    private static final String CONTRACTS_ALLOW_SYSTEM_USE_OF_HAPI_SIGS =
+            "contracts.allowSystemUseOfHapiSigs";
+    private static final String CRYPTO_TRANSFER = "CryptoTransfer";
+    private static final String FALSE = "false";
+    private static final String TRUE = "true";
 
     public static void main(String... args) {
         new LeakyContractTestsSuite().runSuiteSync();
@@ -302,9 +307,9 @@ public class LeakyContractTestsSuite extends HapiSuite {
 
     private HapiSpec erc20TransferFromSelf() {
         return propertyPreservingHapiSpec("Erc20TransferFromSelf")
-                .preserving("hedera.allowances.isEnabled")
+                .preserving(HEDERA_ALLOWANCES_IS_ENABLED)
                 .given(
-                        overriding("hedera.allowances.isEnabled", "true"),
+                        overriding(HEDERA_ALLOWANCES_IS_ENABLED, TRUE),
                         newKeyNamed(MULTI_KEY),
                         cryptoCreate(RECIPIENT),
                         cryptoCreate(TOKEN_TREASURY),
@@ -359,9 +364,9 @@ public class LeakyContractTestsSuite extends HapiSuite {
         final var allowanceTxn2 = "allowanceTxn2";
 
         return propertyPreservingHapiSpec("ERC_20_ALLOWANCE")
-                .preserving("hedera.allowances.isEnabled")
+                .preserving(HEDERA_ALLOWANCES_IS_ENABLED)
                 .given(
-                        overriding("hedera.allowances.isEnabled", "true"),
+                        overriding(HEDERA_ALLOWANCES_IS_ENABLED, TRUE),
                         newKeyNamed(MULTI_KEY),
                         cryptoCreate(OWNER).balance(100 * ONE_HUNDRED_HBARS),
                         cryptoCreate(RECIPIENT),
@@ -504,7 +509,7 @@ public class LeakyContractTestsSuite extends HapiSuite {
 
         return defaultHapiSpec("someERC20ApproveAllowanceScenariosPass")
                 .given(
-                        overriding("hedera.allowances.isEnabled", "true"),
+                        overriding(HEDERA_ALLOWANCES_IS_ENABLED, TRUE),
                         newKeyNamed(MULTI_KEY_NAME),
                         cryptoCreate(A_CIVILIAN)
                                 .exposingCreatedIdTo(
@@ -700,9 +705,9 @@ public class LeakyContractTestsSuite extends HapiSuite {
         final AtomicReference<String> zCivilianMirrorAddr = new AtomicReference<>();
 
         return propertyPreservingHapiSpec("someERC20NegativeTransferFromScenariosPass")
-                .preserving("hedera.allowances.isEnabled")
+                .preserving(HEDERA_ALLOWANCES_IS_ENABLED)
                 .given(
-                        overriding("hedera.allowances.isEnabled", "true"),
+                        overriding(HEDERA_ALLOWANCES_IS_ENABLED, TRUE),
                         newKeyNamed(MULTI_KEY_NAME),
                         cryptoCreate(A_CIVILIAN)
                                 .exposingCreatedIdTo(
@@ -868,9 +873,9 @@ public class LeakyContractTestsSuite extends HapiSuite {
         final AtomicReference<String> zCivilianMirrorAddr = new AtomicReference<>();
 
         return propertyPreservingHapiSpec("someERC20ApproveAllowanceScenarioInOneCall")
-                .preserving("hedera.allowances.isEnabled")
+                .preserving(HEDERA_ALLOWANCES_IS_ENABLED)
                 .given(
-                        overriding("hedera.allowances.isEnabled", "true"),
+                        overriding(HEDERA_ALLOWANCES_IS_ENABLED, TRUE),
                         newKeyNamed(MULTI_KEY_NAME),
                         cryptoCreate(A_CIVILIAN)
                                 .exposingCreatedIdTo(
@@ -937,9 +942,9 @@ public class LeakyContractTestsSuite extends HapiSuite {
 
     private HapiSpec erc20Allowance() {
         return propertyPreservingHapiSpec("ERC_20_ALLOWANCE")
-                .preserving("hedera.allowances.isEnabled")
+                .preserving(HEDERA_ALLOWANCES_IS_ENABLED)
                 .given(
-                        overriding("hedera.allowances.isEnabled", "true"),
+                        overriding(HEDERA_ALLOWANCES_IS_ENABLED, TRUE),
                         newKeyNamed(MULTI_KEY),
                         cryptoCreate(OWNER).balance(100 * ONE_HUNDRED_HBARS),
                         cryptoCreate(SPENDER),
@@ -1010,9 +1015,9 @@ public class LeakyContractTestsSuite extends HapiSuite {
         final var approveTxn = "approveTxn";
 
         return propertyPreservingHapiSpec("ERC_20_APPROVE")
-                .preserving("hedera.allowances.isEnabled")
+                .preserving(HEDERA_ALLOWANCES_IS_ENABLED)
                 .given(
-                        overriding("hedera.allowances.isEnabled", "true"),
+                        overriding(HEDERA_ALLOWANCES_IS_ENABLED, TRUE),
                         newKeyNamed(MULTI_KEY),
                         cryptoCreate(OWNER).balance(100 * ONE_HUNDRED_HBARS),
                         cryptoCreate(SPENDER),
@@ -1061,9 +1066,9 @@ public class LeakyContractTestsSuite extends HapiSuite {
         final var invalidDecimalsTxn = "decimalsFromErc721Txn";
 
         return propertyPreservingHapiSpec("ERC_20_DECIMALS_FROM_ERC_721_TOKEN")
-                .preserving("hedera.allowances.isEnabled")
+                .preserving(HEDERA_ALLOWANCES_IS_ENABLED)
                 .given(
-                        overriding("hedera.allowances.isEnabled", "true"),
+                        overriding(HEDERA_ALLOWANCES_IS_ENABLED, TRUE),
                         newKeyNamed(MULTI_KEY),
                         cryptoCreate(ACCOUNT).balance(100 * ONE_HUNDRED_HBARS),
                         cryptoCreate(TOKEN_TREASURY),
@@ -1099,9 +1104,9 @@ public class LeakyContractTestsSuite extends HapiSuite {
 
     private HapiSpec transferErc20TokenFromErc721TokenFails() {
         return propertyPreservingHapiSpec("ERC_20_TRANSFER_FROM_ERC_721_TOKEN")
-                .preserving("hedera.allowances.isEnabled")
+                .preserving(HEDERA_ALLOWANCES_IS_ENABLED)
                 .given(
-                        overriding("hedera.allowances.isEnabled", "true"),
+                        overriding(HEDERA_ALLOWANCES_IS_ENABLED, TRUE),
                         newKeyNamed(MULTI_KEY),
                         cryptoCreate(ACCOUNT).balance(100 * ONE_MILLION_HBARS),
                         cryptoCreate(RECIPIENT),
@@ -1154,7 +1159,7 @@ public class LeakyContractTestsSuite extends HapiSuite {
         final var nestedContract = "NestedERC20Contract";
 
         return propertyPreservingHapiSpec("ERC_20_TRANSFER_FROM_CONTRACT_WITH_APPROVAL")
-                .preserving("contracts.allowSystemUseOfHapiSigs")
+                .preserving(CONTRACTS_ALLOW_SYSTEM_USE_OF_HAPI_SIGS)
                 .given(
                         newKeyNamed(MULTI_KEY),
                         cryptoCreate(ACCOUNT).balance(10 * ONE_MILLION_HBARS),
@@ -1170,7 +1175,7 @@ public class LeakyContractTestsSuite extends HapiSuite {
                         newKeyNamed(TRANSFER_SIG_NAME).shape(SIMPLE.signedWith(ON)),
                         contractCreate(ERC_20_CONTRACT).adminKey(TRANSFER_SIG_NAME),
                         contractCreate(nestedContract).adminKey(TRANSFER_SIG_NAME),
-                        overriding("contracts.allowSystemUseOfHapiSigs", "CryptoTransfer"))
+                        overriding(CONTRACTS_ALLOW_SYSTEM_USE_OF_HAPI_SIGS, CRYPTO_TRANSFER))
                 .when(
                         withOpContext(
                                 (spec, opLog) ->
@@ -1359,9 +1364,9 @@ public class LeakyContractTestsSuite extends HapiSuite {
         final AtomicReference<String> tokenAddr = new AtomicReference<>();
 
         return propertyPreservingHapiSpec("ERC_20_DECIMALS")
-                .preserving("hedera.allowances.isEnabled")
+                .preserving(HEDERA_ALLOWANCES_IS_ENABLED)
                 .given(
-                        overriding("hedera.allowances.isEnabled", "true"),
+                        overriding(HEDERA_ALLOWANCES_IS_ENABLED, TRUE),
                         newKeyNamed(MULTI_KEY),
                         cryptoCreate(ACCOUNT).balance(100 * ONE_HUNDRED_HBARS),
                         cryptoCreate(TOKEN_TREASURY),
@@ -1422,9 +1427,9 @@ public class LeakyContractTestsSuite extends HapiSuite {
 
     private HapiSpec getErc20TokenName() {
         return propertyPreservingHapiSpec("ERC_20_NAME")
-                .preserving("hedera.allowances.isEnabled")
+                .preserving(HEDERA_ALLOWANCES_IS_ENABLED)
                 .given(
-                        overriding("hedera.allowances.isEnabled", "true"),
+                        overriding(HEDERA_ALLOWANCES_IS_ENABLED, TRUE),
                         newKeyNamed(MULTI_KEY),
                         cryptoCreate(ACCOUNT).balance(100 * ONE_HUNDRED_HBARS),
                         cryptoCreate(TOKEN_TREASURY),
@@ -1472,7 +1477,7 @@ public class LeakyContractTestsSuite extends HapiSuite {
     }
 
     private HapiSpec transferDontWorkWithoutTopLevelSignatures() {
-        final String ALLOW_SYSTEM_USE_OF_HAPI_SIGS = "contracts.allowSystemUseOfHapiSigs";
+        final String ALLOW_SYSTEM_USE_OF_HAPI_SIGS = CONTRACTS_ALLOW_SYSTEM_USE_OF_HAPI_SIGS;
         final var transferTokenTxn = "transferTokenTxn";
         final var transferTokensTxn = "transferTokensTxn";
         final var transferNFTTxn = "transferNFTTxn";
@@ -1636,7 +1641,7 @@ public class LeakyContractTestsSuite extends HapiSuite {
     }
 
     private HapiSpec transferWorksWithTopLevelSignatures() {
-        final String ALLOW_SYSTEM_USE_OF_HAPI_SIGS = "contracts.allowSystemUseOfHapiSigs";
+        final String ALLOW_SYSTEM_USE_OF_HAPI_SIGS = CONTRACTS_ALLOW_SYSTEM_USE_OF_HAPI_SIGS;
         final var transferTokenTxn = "transferTokenTxn";
         final var transferTokensTxn = "transferTokensTxn";
         final var transferNFTTxn = "transferNFTTxn";
@@ -1651,7 +1656,7 @@ public class LeakyContractTestsSuite extends HapiSuite {
                 .given(
                         // enable top level signatures for
                         // transferToken/transferTokens/transferNft/transferNfts
-                        overriding(ALLOW_SYSTEM_USE_OF_HAPI_SIGS, "CryptoTransfer"),
+                        overriding(ALLOW_SYSTEM_USE_OF_HAPI_SIGS, CRYPTO_TRANSFER),
                         newKeyNamed(SUPPLY_KEY),
                         cryptoCreate(ACCOUNT).exposingCreatedIdTo(accountID::set),
                         cryptoCreate(TOKEN_TREASURY),
@@ -2347,7 +2352,7 @@ public class LeakyContractTestsSuite extends HapiSuite {
                                 .nonce(0)
                                 .gasLimit(GAS_LIMIT)
                                 .hasKnownStatus(INVALID_ACCOUNT_ID))
-                .then(overriding(CRYPTO_CREATE_WITH_ALIAS_AND_EVM_ADDRESS_ENABLED, "true"));
+                .then(overriding(CRYPTO_CREATE_WITH_ALIAS_AND_EVM_ADDRESS_ENABLED, TRUE));
     }
 
     private HapiSpec transferToCaller() {
@@ -2687,11 +2692,11 @@ public class LeakyContractTestsSuite extends HapiSuite {
                 .given(
                         overridingThree(
                                 "entities.limitTokenAssociations",
-                                "true",
+                                TRUE,
                                 "tokens.maxPerAccount",
                                 "" + 1,
                                 CONTRACT_ALLOW_ASSOCIATIONS_PROPERTY,
-                                "true"))
+                                TRUE))
                 .when()
                 .then(
                         newKeyNamed(ADMIN_KEY),
@@ -2937,7 +2942,7 @@ public class LeakyContractTestsSuite extends HapiSuite {
     }
 
     private HapiSpec lazyCreateThroughPrecompileNotSupportedWhenFlagDisabled() {
-        final var CONTRACT = "CryptoTransfer";
+        final var CONTRACT = CRYPTO_TRANSFER;
         final var SENDER = "sender";
         final var FUNGIBLE_TOKEN = "fungibleToken";
         final var DELEGATE_KEY = "contractKey";
@@ -2948,8 +2953,8 @@ public class LeakyContractTestsSuite extends HapiSuite {
         return propertyPreservingHapiSpec("lazyCreateThroughPrecompileNotSupportedWhenFlagDisabled")
                 .preserving(ALLOW_AUTO_ASSOCIATIONS_PROPERTY, LAZY_CREATION_ENABLED)
                 .given(
-                        overriding(ALLOW_AUTO_ASSOCIATIONS_PROPERTY, "true"),
-                        UtilVerbs.overriding(LAZY_CREATION_ENABLED, "false"),
+                        overriding(ALLOW_AUTO_ASSOCIATIONS_PROPERTY, TRUE),
+                        UtilVerbs.overriding(LAZY_CREATION_ENABLED, FALSE),
                         cryptoCreate(SENDER).balance(10 * ONE_HUNDRED_HBARS),
                         cryptoCreate(TOKEN_TREASURY),
                         tokenCreate(FUNGIBLE_TOKEN)
@@ -3032,11 +3037,11 @@ public class LeakyContractTestsSuite extends HapiSuite {
                 .given(
                         overridingThree(
                                 lazyCreationProperty,
-                                "true",
+                                TRUE,
                                 contractsEvmVersionProperty,
                                 "v0.34",
                                 contractsEvmVersionDynamicProperty,
-                                "true"),
+                                TRUE),
                         newKeyNamed(ECDSA_KEY).shape(SECP_256K1_SHAPE),
                         uploadInitCode(LAZY_CREATE_CONTRACT),
                         contractCreate(LAZY_CREATE_CONTRACT).via(CALL_TX_REC),
@@ -3107,7 +3112,7 @@ public class LeakyContractTestsSuite extends HapiSuite {
         final var amountPerTransfer = 50L;
         return propertyPreservingHapiSpec(
                         "RequiresTopLevelSignatureOrApprovalDependingOnControllingProperty")
-                .preserving("contracts.allowSystemUseOfHapiSigs")
+                .preserving(CONTRACTS_ALLOW_SYSTEM_USE_OF_HAPI_SIGS)
                 .given(
                         cryptoCreate(SENDER)
                                 .keyShape(SECP256K1_ON)
@@ -3129,7 +3134,7 @@ public class LeakyContractTestsSuite extends HapiSuite {
                         uploadInitCode(TRANSFER_CONTRACT),
                         contractCreate(TRANSFER_CONTRACT),
                         // First revoke use of top-level signatures from all precompiles
-                        overriding("contracts.allowSystemUseOfHapiSigs", ""))
+                        overriding(CONTRACTS_ALLOW_SYSTEM_USE_OF_HAPI_SIGS, ""))
                 .when(
                         // Then, try to transfer tokens using a top-level signature
                         sourcing(
@@ -3159,7 +3164,7 @@ public class LeakyContractTestsSuite extends HapiSuite {
                                                 .gas(GAS_TO_OFFER)
                                                 .hasKnownStatus(CONTRACT_REVERT_EXECUTED)),
                         // Switch to allow use of top-level signatures from CryptoTransfer
-                        overriding("contracts.allowSystemUseOfHapiSigs", "CryptoTransfer"),
+                        overriding(CONTRACTS_ALLOW_SYSTEM_USE_OF_HAPI_SIGS, CRYPTO_TRANSFER),
                         // Validate now the top-level signature works
                         sourcing(
                                 () ->
@@ -3223,7 +3228,7 @@ public class LeakyContractTestsSuite extends HapiSuite {
                                                 .hasKnownStatus(CONTRACT_REVERT_EXECUTED)),
                         // Then revoke use of top-level signatures once more, so the approval will
                         // be used automatically
-                        overriding("contracts.allowSystemUseOfHapiSigs", ""))
+                        overriding(CONTRACTS_ALLOW_SYSTEM_USE_OF_HAPI_SIGS, ""))
                 .then(
                         // Validate the approval is used automatically (although not specified in
                         // the contract)
@@ -3309,12 +3314,12 @@ public class LeakyContractTestsSuite extends HapiSuite {
                         contractsEvmVersionDynamicProperty,
                         contractsEvmVersionDynamicProperty)
                 .given(
-                        overridingTwo(lazyCreationProperty, "true", maxPrecedingRecords, "1"),
+                        overridingTwo(lazyCreationProperty, TRUE, maxPrecedingRecords, "1"),
                         overridingTwo(
                                 contractsEvmVersionProperty,
                                 "v0.34",
                                 contractsEvmVersionDynamicProperty,
-                                "true"),
+                                TRUE),
                         newKeyNamed(ECDSA_KEY).shape(SECP_256K1_SHAPE),
                         newKeyNamed(ECDSA_KEY2).shape(SECP_256K1_SHAPE),
                         uploadInitCode(LAZY_CREATE_CONTRACT),
@@ -3360,7 +3365,7 @@ public class LeakyContractTestsSuite extends HapiSuite {
     private HapiSpec rejectsCreationAndUpdateOfAssociationsWhenFlagDisabled() {
         return propertyPreservingHapiSpec("rejectsCreationAndUpdateOfAssociationsWhenFlagDisabled")
                 .preserving(CONTRACT_ALLOW_ASSOCIATIONS_PROPERTY)
-                .given(overriding(CONTRACT_ALLOW_ASSOCIATIONS_PROPERTY, "false"))
+                .given(overriding(CONTRACT_ALLOW_ASSOCIATIONS_PROPERTY, FALSE))
                 .when(uploadInitCode(EMPTY_CONSTRUCTOR_CONTRACT))
                 .then(
                         contractCreate(EMPTY_CONSTRUCTOR_CONTRACT)
@@ -3376,7 +3381,7 @@ public class LeakyContractTestsSuite extends HapiSuite {
     private HapiSpec erc20TransferFromDoesNotWorkIfFlagIsDisabled() {
         return defaultHapiSpec("erc20TransferFromDoesNotWorkIfFlagIsDisabled")
                 .given(
-                        overriding("hedera.allowances.isEnabled", "false"),
+                        overriding(HEDERA_ALLOWANCES_IS_ENABLED, FALSE),
                         newKeyNamed(MULTI_KEY),
                         cryptoCreate(OWNER).balance(100 * ONE_HUNDRED_HBARS),
                         cryptoCreate(RECIPIENT),
@@ -3426,7 +3431,7 @@ public class LeakyContractTestsSuite extends HapiSuite {
                         getTxnRecord(TRANSFER_FROM_ACCOUNT_TXN)
                                 .logged(), // has gasUsed little less than supplied 500K in
                         // contractCall result
-                        overriding("hedera.allowances.isEnabled", "true"));
+                        overriding(HEDERA_ALLOWANCES_IS_ENABLED, TRUE));
     }
 
     @Override

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/leaky/LeakyContractTestsSuite.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/leaky/LeakyContractTestsSuite.java
@@ -21,18 +21,22 @@ import static com.hedera.services.bdd.spec.HapiPropertySource.asHexedSolidityAdd
 import static com.hedera.services.bdd.spec.HapiPropertySource.asSolidityAddress;
 import static com.hedera.services.bdd.spec.HapiPropertySource.asTokenString;
 import static com.hedera.services.bdd.spec.HapiSpec.*;
+import static com.hedera.services.bdd.spec.assertions.AssertUtils.inOrder;
 import static com.hedera.services.bdd.spec.assertions.ContractFnResultAsserts.resultWith;
 import static com.hedera.services.bdd.spec.assertions.ContractInfoAsserts.contractWith;
+import static com.hedera.services.bdd.spec.assertions.ContractLogAsserts.logWith;
 import static com.hedera.services.bdd.spec.assertions.TransactionRecordAsserts.recordWith;
 import static com.hedera.services.bdd.spec.keys.KeyFactory.KeyType.THRESHOLD;
 import static com.hedera.services.bdd.spec.keys.KeyShape.CONTRACT;
 import static com.hedera.services.bdd.spec.keys.KeyShape.DELEGATE_CONTRACT;
 import static com.hedera.services.bdd.spec.keys.KeyShape.ED25519;
 import static com.hedera.services.bdd.spec.keys.KeyShape.SECP256K1;
+import static com.hedera.services.bdd.spec.keys.KeyShape.SIMPLE;
 import static com.hedera.services.bdd.spec.keys.KeyShape.sigs;
 import static com.hedera.services.bdd.spec.keys.SigControl.ED25519_ON;
 import static com.hedera.services.bdd.spec.keys.SigControl.ON;
 import static com.hedera.services.bdd.spec.keys.SigControl.SECP256K1_ON;
+import static com.hedera.services.bdd.spec.queries.QueryVerbs.contractCallLocal;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getAccountBalance;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getAccountInfo;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getAliasedAccountInfo;
@@ -50,6 +54,7 @@ import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoCreate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoTransfer;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoUpdate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.ethereumContractCreate;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.fileCreate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.mintToken;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.tokenAssociate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.tokenCreate;
@@ -87,8 +92,11 @@ import static com.hedera.services.bdd.spec.utilops.UtilVerbs.usableTxnIdNamed;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.withOpContext;
 import static com.hedera.services.bdd.suites.contract.Utils.FunctionType.FUNCTION;
 import static com.hedera.services.bdd.suites.contract.Utils.asAddress;
+import static com.hedera.services.bdd.suites.contract.Utils.asHexedAddress;
 import static com.hedera.services.bdd.suites.contract.Utils.asToken;
+import static com.hedera.services.bdd.suites.contract.Utils.eventSignatureOf;
 import static com.hedera.services.bdd.suites.contract.Utils.getABIFor;
+import static com.hedera.services.bdd.suites.contract.Utils.parsedToByteString;
 import static com.hedera.services.bdd.suites.contract.hapi.ContractCallSuite.ACCOUNT_INFO;
 import static com.hedera.services.bdd.suites.contract.hapi.ContractCallSuite.ACCOUNT_INFO_AFTER_CALL;
 import static com.hedera.services.bdd.suites.contract.hapi.ContractCallSuite.CALL_TX;
@@ -96,12 +104,14 @@ import static com.hedera.services.bdd.suites.contract.hapi.ContractCallSuite.CAL
 import static com.hedera.services.bdd.suites.contract.hapi.ContractCallSuite.CONTRACTS_MAX_GAS_PER_SEC;
 import static com.hedera.services.bdd.suites.contract.hapi.ContractCallSuite.CONTRACTS_MAX_REFUND_PERCENT_OF_GAS_LIMIT;
 import static com.hedera.services.bdd.suites.contract.hapi.ContractCallSuite.CONTRACT_FROM;
+import static com.hedera.services.bdd.suites.contract.hapi.ContractCallSuite.DECIMALS;
 import static com.hedera.services.bdd.suites.contract.hapi.ContractCallSuite.DEFAULT_MAX_AUTO_RENEW_PERIOD;
 import static com.hedera.services.bdd.suites.contract.hapi.ContractCallSuite.DEPOSIT;
 import static com.hedera.services.bdd.suites.contract.hapi.ContractCallSuite.LEDGER_AUTO_RENEW_PERIOD_MAX_DURATION;
 import static com.hedera.services.bdd.suites.contract.hapi.ContractCallSuite.PAY_RECEIVABLE_CONTRACT;
 import static com.hedera.services.bdd.suites.contract.hapi.ContractCallSuite.RECEIVER_2;
 import static com.hedera.services.bdd.suites.contract.hapi.ContractCallSuite.SIMPLE_UPDATE_CONTRACT;
+import static com.hedera.services.bdd.suites.contract.hapi.ContractCallSuite.TRANSFER;
 import static com.hedera.services.bdd.suites.contract.hapi.ContractCallSuite.TRANSFERRING_CONTRACT;
 import static com.hedera.services.bdd.suites.contract.hapi.ContractCallSuite.TRANSFER_TO_CALLER;
 import static com.hedera.services.bdd.suites.contract.hapi.ContractCreateSuite.EMPTY_CONSTRUCTOR_CONTRACT;
@@ -123,15 +133,37 @@ import static com.hedera.services.bdd.suites.contract.precompile.CreatePrecompil
 import static com.hedera.services.bdd.suites.contract.precompile.CryptoTransferHTSSuite.DELEGATE_KEY;
 import static com.hedera.services.bdd.suites.contract.precompile.CryptoTransferHTSSuite.TOTAL_SUPPLY;
 import static com.hedera.services.bdd.suites.contract.precompile.CryptoTransferHTSSuite.TRANSFER_MULTIPLE_TOKENS;
+import static com.hedera.services.bdd.suites.contract.precompile.ERCPrecompileSuite.ALLOWANCE;
+import static com.hedera.services.bdd.suites.contract.precompile.ERCPrecompileSuite.ALLOWANCE_TXN;
+import static com.hedera.services.bdd.suites.contract.precompile.ERCPrecompileSuite.APPROVE;
+import static com.hedera.services.bdd.suites.contract.precompile.ERCPrecompileSuite.A_CIVILIAN;
+import static com.hedera.services.bdd.suites.contract.precompile.ERCPrecompileSuite.B_CIVILIAN;
+import static com.hedera.services.bdd.suites.contract.precompile.ERCPrecompileSuite.DO_SPECIFIC_APPROVAL;
+import static com.hedera.services.bdd.suites.contract.precompile.ERCPrecompileSuite.DO_TRANSFER_FROM;
 import static com.hedera.services.bdd.suites.contract.precompile.ERCPrecompileSuite.ERC_20_CONTRACT;
+import static com.hedera.services.bdd.suites.contract.precompile.ERCPrecompileSuite.ERC_20_CONTRACT_NAME;
+import static com.hedera.services.bdd.suites.contract.precompile.ERCPrecompileSuite.GET_ALLOWANCE;
+import static com.hedera.services.bdd.suites.contract.precompile.ERCPrecompileSuite.MISSING_FROM;
+import static com.hedera.services.bdd.suites.contract.precompile.ERCPrecompileSuite.MISSING_TO;
+import static com.hedera.services.bdd.suites.contract.precompile.ERCPrecompileSuite.MSG_SENDER_IS_NOT_THE_SAME_AS_FROM;
+import static com.hedera.services.bdd.suites.contract.precompile.ERCPrecompileSuite.MSG_SENDER_IS_THE_SAME_AS_FROM;
+import static com.hedera.services.bdd.suites.contract.precompile.ERCPrecompileSuite.MULTI_KEY_NAME;
+import static com.hedera.services.bdd.suites.contract.precompile.ERCPrecompileSuite.NAME_TXN;
 import static com.hedera.services.bdd.suites.contract.precompile.ERCPrecompileSuite.RECIPIENT;
+import static com.hedera.services.bdd.suites.contract.precompile.ERCPrecompileSuite.SOME_ERC_20_SCENARIOS;
 import static com.hedera.services.bdd.suites.contract.precompile.ERCPrecompileSuite.TRANSFER_FROM;
 import static com.hedera.services.bdd.suites.contract.precompile.ERCPrecompileSuite.TRANSFER_FROM_ACCOUNT_TXN;
+import static com.hedera.services.bdd.suites.contract.precompile.ERCPrecompileSuite.TRANSFER_SIGNATURE;
+import static com.hedera.services.bdd.suites.contract.precompile.ERCPrecompileSuite.TRANSFER_SIG_NAME;
+import static com.hedera.services.bdd.suites.contract.precompile.LazyCreateThroughPrecompileSuite.FIRST_META;
 import static com.hedera.services.bdd.suites.contract.precompile.LazyCreateThroughPrecompileSuite.mirrorAddrWith;
 import static com.hedera.services.bdd.suites.contract.precompile.WipeTokenAccountPrecompileSuite.GAS_TO_OFFER;
 import static com.hedera.services.bdd.suites.crypto.CryptoApproveAllowanceSuite.ADMIN_KEY;
+import static com.hedera.services.bdd.suites.crypto.CryptoApproveAllowanceSuite.BASE_APPROVE_TXN;
 import static com.hedera.services.bdd.suites.crypto.CryptoApproveAllowanceSuite.FUNGIBLE_TOKEN;
+import static com.hedera.services.bdd.suites.crypto.CryptoApproveAllowanceSuite.NON_FUNGIBLE_TOKEN;
 import static com.hedera.services.bdd.suites.crypto.CryptoApproveAllowanceSuite.OWNER;
+import static com.hedera.services.bdd.suites.crypto.CryptoApproveAllowanceSuite.SPENDER;
 import static com.hedera.services.bdd.suites.crypto.CryptoCreateSuite.ACCOUNT;
 import static com.hedera.services.bdd.suites.crypto.CryptoCreateSuite.LAZY_CREATION_ENABLED;
 import static com.hedera.services.bdd.suites.ethereum.EthereumSuite.GAS_LIMIT;
@@ -143,6 +175,7 @@ import static com.hedera.services.bdd.suites.token.TokenTransactSpecs.TRANSFER_T
 import static com.hedera.services.bdd.suites.utils.contracts.precompile.HTSPrecompileResult.htsPrecompileResult;
 import static com.hedera.services.yahcli.commands.validation.ValidationCommand.RECEIVER;
 import static com.hedera.services.yahcli.commands.validation.ValidationCommand.SENDER;
+import static com.hedera.services.yahcli.commands.validation.ValidationCommand.TOKEN;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.*;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.CONTRACT_REVERT_EXECUTED;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.CUSTOM_FEE_DENOMINATION_MUST_BE_FUNGIBLE_COMMON;
@@ -163,6 +196,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.esaulpaugh.headlong.abi.Address;
 import com.esaulpaugh.headlong.abi.Tuple;
 import com.google.protobuf.ByteString;
+import com.hedera.node.app.hapi.utils.contracts.ParsingConstants.FunctionType;
 import com.hedera.node.app.hapi.utils.ethereum.EthTxData;
 import com.hedera.node.app.hapi.utils.fee.FeeBuilder;
 import com.hedera.services.bdd.spec.HapiPropertySource;
@@ -178,6 +212,7 @@ import com.hedera.services.bdd.spec.keys.KeyShape;
 import com.hedera.services.bdd.spec.queries.QueryVerbs;
 import com.hedera.services.bdd.spec.queries.meta.HapiGetTxnRecord;
 import com.hedera.services.bdd.spec.transactions.contract.HapiParserUtil;
+import com.hedera.services.bdd.spec.transactions.token.TokenMovement;
 import com.hedera.services.bdd.spec.utilops.CustomSpecAssert;
 import com.hedera.services.bdd.spec.utilops.UtilVerbs;
 import com.hedera.services.bdd.suites.HapiSuite;
@@ -250,7 +285,1190 @@ public class LeakyContractTestsSuite extends HapiSuite {
                 rejectsCreationAndUpdateOfAssociationsWhenFlagDisabled(),
                 requiresTopLevelSignatureOrApprovalDependingOnControllingProperty(),
                 transferWorksWithTopLevelSignatures(),
-                transferDontWorkWithoutTopLevelSignatures());
+                transferDontWorkWithoutTopLevelSignatures(),
+                getErc20TokenName(),
+                getErc20TokenDecimals(),
+                transferErc20TokenFromContractWithApproval(),
+                erc20Allowance(),
+                erc20Approve(),
+                transferErc20TokenFromErc721TokenFails(),
+                getErc20TokenDecimalsFromErc721TokenFails(),
+                someERC20ApproveAllowanceScenariosPass(),
+                someERC20NegativeTransferFromScenariosPass(),
+                someERC20ApproveAllowanceScenarioInOneCall(),
+                erc20TransferFrom(),
+                erc20TransferFromSelf());
+    }
+
+    private HapiSpec erc20TransferFromSelf() {
+        return propertyPreservingHapiSpec("Erc20TransferFromSelf")
+                .preserving("hedera.allowances.isEnabled")
+                .given(
+                        overriding("hedera.allowances.isEnabled", "true"),
+                        newKeyNamed(MULTI_KEY),
+                        cryptoCreate(RECIPIENT),
+                        cryptoCreate(TOKEN_TREASURY),
+                        tokenCreate(FUNGIBLE_TOKEN)
+                                .tokenType(TokenType.FUNGIBLE_COMMON)
+                                .supplyType(TokenSupplyType.FINITE)
+                                .initialSupply(10L)
+                                .maxSupply(1000L)
+                                .treasury(TOKEN_TREASURY)
+                                .adminKey(MULTI_KEY)
+                                .supplyKey(MULTI_KEY),
+                        uploadInitCode(ERC_20_CONTRACT),
+                        contractCreate(ERC_20_CONTRACT),
+                        tokenAssociate(RECIPIENT, FUNGIBLE_TOKEN),
+                        tokenAssociate(ERC_20_CONTRACT, FUNGIBLE_TOKEN),
+                        cryptoTransfer(
+                                moving(10, FUNGIBLE_TOKEN)
+                                        .between(TOKEN_TREASURY, ERC_20_CONTRACT)))
+                .when(
+                        withOpContext(
+                                (spec, opLog) ->
+                                        allRunFor(
+                                                spec,
+                                                // ERC_20_CONTRACT should be able to transfer its
+                                                // own tokens
+                                                contractCall(
+                                                                ERC_20_CONTRACT,
+                                                                TRANSFER_FROM,
+                                                                HapiParserUtil.asHeadlongAddress(
+                                                                        asAddress(
+                                                                                spec.registry()
+                                                                                        .getTokenID(
+                                                                                                FUNGIBLE_TOKEN))),
+                                                                HapiParserUtil.asHeadlongAddress(
+                                                                        asAddress(
+                                                                                spec.registry()
+                                                                                        .getAccountID(
+                                                                                                ERC_20_CONTRACT))),
+                                                                HapiParserUtil.asHeadlongAddress(
+                                                                        asAddress(
+                                                                                spec.registry()
+                                                                                        .getAccountID(
+                                                                                                RECIPIENT))),
+                                                                BigInteger.TWO)
+                                                        .gas(500_000L)
+                                                        .via(TRANSFER_FROM_ACCOUNT_TXN)
+                                                        .hasKnownStatus(SUCCESS))))
+                .then(getAccountBalance(RECIPIENT).hasTokenBalance(FUNGIBLE_TOKEN, 2));
+    }
+
+    private HapiSpec erc20TransferFrom() {
+        final var allowanceTxn2 = "allowanceTxn2";
+
+        return propertyPreservingHapiSpec("ERC_20_ALLOWANCE")
+                .preserving("hedera.allowances.isEnabled")
+                .given(
+                        overriding("hedera.allowances.isEnabled", "true"),
+                        newKeyNamed(MULTI_KEY),
+                        cryptoCreate(OWNER).balance(100 * ONE_HUNDRED_HBARS),
+                        cryptoCreate(RECIPIENT),
+                        cryptoCreate(TOKEN_TREASURY),
+                        tokenCreate(FUNGIBLE_TOKEN)
+                                .tokenType(TokenType.FUNGIBLE_COMMON)
+                                .supplyType(TokenSupplyType.FINITE)
+                                .initialSupply(10L)
+                                .maxSupply(1000L)
+                                .treasury(TOKEN_TREASURY)
+                                .adminKey(MULTI_KEY)
+                                .supplyKey(MULTI_KEY),
+                        uploadInitCode(ERC_20_CONTRACT),
+                        contractCreate(ERC_20_CONTRACT),
+                        tokenAssociate(OWNER, FUNGIBLE_TOKEN),
+                        tokenAssociate(RECIPIENT, FUNGIBLE_TOKEN),
+                        tokenAssociate(ERC_20_CONTRACT, FUNGIBLE_TOKEN),
+                        cryptoTransfer(moving(10, FUNGIBLE_TOKEN).between(TOKEN_TREASURY, OWNER)))
+                .when(
+                        withOpContext(
+                                (spec, opLog) ->
+                                        allRunFor(
+                                                spec,
+                                                // ERC_20_CONTRACT is approved as spender of
+                                                // fungible tokens for OWNER
+                                                cryptoApproveAllowance()
+                                                        .payingWith(DEFAULT_PAYER)
+                                                        .addTokenAllowance(
+                                                                OWNER,
+                                                                FUNGIBLE_TOKEN,
+                                                                ERC_20_CONTRACT,
+                                                                2L)
+                                                        .via(BASE_APPROVE_TXN)
+                                                        .logged()
+                                                        .signedBy(DEFAULT_PAYER, OWNER)
+                                                        .fee(ONE_HBAR),
+                                                // Check that ERC_20_CONTRACT has allowance of 2
+                                                contractCall(
+                                                                ERC_20_CONTRACT,
+                                                                ALLOWANCE,
+                                                                HapiParserUtil.asHeadlongAddress(
+                                                                        asAddress(
+                                                                                spec.registry()
+                                                                                        .getTokenID(
+                                                                                                FUNGIBLE_TOKEN))),
+                                                                HapiParserUtil.asHeadlongAddress(
+                                                                        asAddress(
+                                                                                spec.registry()
+                                                                                        .getAccountID(
+                                                                                                OWNER))),
+                                                                HapiParserUtil.asHeadlongAddress(
+                                                                        asAddress(
+                                                                                spec.registry()
+                                                                                        .getAccountID(
+                                                                                                ERC_20_CONTRACT))))
+                                                        .gas(500_000L)
+                                                        .via(ALLOWANCE_TXN)
+                                                        .hasKnownStatus(SUCCESS),
+                                                // ERC_20_CONTRACT calls the precompile transferFrom
+                                                // as the spender
+                                                contractCall(
+                                                                ERC_20_CONTRACT,
+                                                                TRANSFER_FROM,
+                                                                HapiParserUtil.asHeadlongAddress(
+                                                                        asAddress(
+                                                                                spec.registry()
+                                                                                        .getTokenID(
+                                                                                                FUNGIBLE_TOKEN))),
+                                                                HapiParserUtil.asHeadlongAddress(
+                                                                        asAddress(
+                                                                                spec.registry()
+                                                                                        .getAccountID(
+                                                                                                OWNER))),
+                                                                HapiParserUtil.asHeadlongAddress(
+                                                                        asAddress(
+                                                                                spec.registry()
+                                                                                        .getAccountID(
+                                                                                                RECIPIENT))),
+                                                                BigInteger.TWO)
+                                                        .gas(500_000L)
+                                                        .via(TRANSFER_FROM_ACCOUNT_TXN)
+                                                        .hasKnownStatus(SUCCESS),
+                                                // ERC_20_CONTRACT should have spent its allowance
+                                                contractCall(
+                                                                ERC_20_CONTRACT,
+                                                                ALLOWANCE,
+                                                                HapiParserUtil.asHeadlongAddress(
+                                                                        asAddress(
+                                                                                spec.registry()
+                                                                                        .getTokenID(
+                                                                                                FUNGIBLE_TOKEN))),
+                                                                HapiParserUtil.asHeadlongAddress(
+                                                                        asAddress(
+                                                                                spec.registry()
+                                                                                        .getAccountID(
+                                                                                                OWNER))),
+                                                                HapiParserUtil.asHeadlongAddress(
+                                                                        asAddress(
+                                                                                spec.registry()
+                                                                                        .getAccountID(
+                                                                                                ERC_20_CONTRACT))))
+                                                        .gas(500_000L)
+                                                        .via(allowanceTxn2)
+                                                        .hasKnownStatus(SUCCESS))))
+                .then(
+                        childRecordsCheck(
+                                ALLOWANCE_TXN,
+                                SUCCESS,
+                                recordWith()
+                                        .status(SUCCESS)
+                                        .contractCallResult(
+                                                resultWith()
+                                                        .contractCallResult(
+                                                                htsPrecompileResult()
+                                                                        .forFunction(
+                                                                                FunctionType
+                                                                                        .ERC_ALLOWANCE)
+                                                                        .withAllowance(2)))),
+                        childRecordsCheck(
+                                allowanceTxn2,
+                                SUCCESS,
+                                recordWith()
+                                        .status(SUCCESS)
+                                        .contractCallResult(
+                                                resultWith()
+                                                        .contractCallResult(
+                                                                htsPrecompileResult()
+                                                                        .forFunction(
+                                                                                FunctionType
+                                                                                        .ERC_ALLOWANCE)
+                                                                        .withAllowance(0)))));
+    }
+
+    private HapiSpec someERC20ApproveAllowanceScenariosPass() {
+        final AtomicReference<String> tokenMirrorAddr = new AtomicReference<>();
+        final AtomicReference<String> contractMirrorAddr = new AtomicReference<>();
+        final AtomicReference<String> aCivilianMirrorAddr = new AtomicReference<>();
+        final AtomicReference<String> bCivilianMirrorAddr = new AtomicReference<>();
+        final AtomicReference<String> zCivilianMirrorAddr = new AtomicReference<>();
+
+        return defaultHapiSpec("someERC20ApproveAllowanceScenariosPass")
+                .given(
+                        overriding("hedera.allowances.isEnabled", "true"),
+                        newKeyNamed(MULTI_KEY_NAME),
+                        cryptoCreate(A_CIVILIAN)
+                                .exposingCreatedIdTo(
+                                        id -> aCivilianMirrorAddr.set(asHexedSolidityAddress(id))),
+                        cryptoCreate(B_CIVILIAN)
+                                .exposingCreatedIdTo(
+                                        id -> bCivilianMirrorAddr.set(asHexedSolidityAddress(id))),
+                        uploadInitCode(SOME_ERC_20_SCENARIOS),
+                        contractCreate(SOME_ERC_20_SCENARIOS).adminKey(MULTI_KEY_NAME),
+                        tokenCreate(TOKEN)
+                                .supplyKey(MULTI_KEY_NAME)
+                                .tokenType(FUNGIBLE_COMMON)
+                                .treasury(B_CIVILIAN)
+                                .initialSupply(10)
+                                .exposingCreatedIdTo(
+                                        idLit ->
+                                                tokenMirrorAddr.set(
+                                                        asHexedSolidityAddress(
+                                                                HapiPropertySource.asToken(
+                                                                        idLit)))))
+                .when(
+                        withOpContext(
+                                (spec, opLog) -> {
+                                    zCivilianMirrorAddr.set(
+                                            asHexedSolidityAddress(
+                                                    AccountID.newBuilder()
+                                                            .setAccountNum(666_666_666L)
+                                                            .build()));
+                                    contractMirrorAddr.set(
+                                            asHexedSolidityAddress(
+                                                    spec.registry()
+                                                            .getAccountID(SOME_ERC_20_SCENARIOS)));
+                                }),
+                        sourcing(
+                                () ->
+                                        contractCall(
+                                                        SOME_ERC_20_SCENARIOS,
+                                                        DO_SPECIFIC_APPROVAL,
+                                                        asHeadlongAddress(tokenMirrorAddr.get()),
+                                                        asHeadlongAddress(
+                                                                aCivilianMirrorAddr.get()),
+                                                        BigInteger.ZERO)
+                                                .via("ACCOUNT_NOT_ASSOCIATED_TXN")
+                                                .gas(1_000_000)
+                                                .hasKnownStatus(CONTRACT_REVERT_EXECUTED)),
+                        tokenAssociate(SOME_ERC_20_SCENARIOS, TOKEN),
+                        sourcing(
+                                () ->
+                                        contractCall(
+                                                        SOME_ERC_20_SCENARIOS,
+                                                        DO_SPECIFIC_APPROVAL,
+                                                        asHeadlongAddress(tokenMirrorAddr.get()),
+                                                        asHeadlongAddress(
+                                                                zCivilianMirrorAddr.get()),
+                                                        BigInteger.valueOf(5))
+                                                .via(MISSING_TO)
+                                                .gas(1_000_000)
+                                                .hasKnownStatus(CONTRACT_REVERT_EXECUTED)),
+                        sourcing(
+                                () ->
+                                        contractCall(
+                                                        SOME_ERC_20_SCENARIOS,
+                                                        DO_SPECIFIC_APPROVAL,
+                                                        asHeadlongAddress(tokenMirrorAddr.get()),
+                                                        asHeadlongAddress(contractMirrorAddr.get()),
+                                                        BigInteger.valueOf(5))
+                                                .via("SPENDER_SAME_AS_OWNER_TXN")
+                                                .gas(1_000_000)
+                                                .hasKnownStatus(CONTRACT_REVERT_EXECUTED)),
+                        sourcing(
+                                () ->
+                                        contractCall(
+                                                        SOME_ERC_20_SCENARIOS,
+                                                        DO_SPECIFIC_APPROVAL,
+                                                        asHeadlongAddress(tokenMirrorAddr.get()),
+                                                        asHeadlongAddress(
+                                                                aCivilianMirrorAddr.get()),
+                                                        BigInteger.valueOf(5))
+                                                .via("SUCCESSFUL_APPROVE_TXN")
+                                                .gas(1_000_000)
+                                                .hasKnownStatus(SUCCESS)),
+                        sourcing(
+                                () ->
+                                        contractCall(
+                                                        SOME_ERC_20_SCENARIOS,
+                                                        GET_ALLOWANCE,
+                                                        asHeadlongAddress(tokenMirrorAddr.get()),
+                                                        asHeadlongAddress(contractMirrorAddr.get()),
+                                                        asHeadlongAddress(
+                                                                aCivilianMirrorAddr.get()))
+                                                .via("ALLOWANCE_TXN")
+                                                .gas(1_000_000)
+                                                .hasKnownStatus(SUCCESS)),
+                        sourcing(
+                                () ->
+                                        contractCallLocal(
+                                                SOME_ERC_20_SCENARIOS,
+                                                GET_ALLOWANCE,
+                                                asHeadlongAddress(tokenMirrorAddr.get()),
+                                                asHeadlongAddress(contractMirrorAddr.get()),
+                                                asHeadlongAddress(aCivilianMirrorAddr.get()))),
+                        sourcing(
+                                () ->
+                                        contractCall(
+                                                        SOME_ERC_20_SCENARIOS,
+                                                        DO_SPECIFIC_APPROVAL,
+                                                        asHeadlongAddress(tokenMirrorAddr.get()),
+                                                        asHeadlongAddress(
+                                                                aCivilianMirrorAddr.get()),
+                                                        BigInteger.ZERO)
+                                                .via("SUCCESSFUL_REVOKE_TXN")
+                                                .gas(1_000_000)
+                                                .hasKnownStatus(SUCCESS)),
+                        sourcing(
+                                () ->
+                                        contractCall(
+                                                        SOME_ERC_20_SCENARIOS,
+                                                        GET_ALLOWANCE,
+                                                        asHeadlongAddress(tokenMirrorAddr.get()),
+                                                        asHeadlongAddress(contractMirrorAddr.get()),
+                                                        asHeadlongAddress(
+                                                                aCivilianMirrorAddr.get()))
+                                                .via("ALLOWANCE_AFTER_REVOKE_TXN")
+                                                .gas(1_000_000)
+                                                .hasKnownStatus(SUCCESS)),
+                        sourcing(
+                                () ->
+                                        contractCall(
+                                                        SOME_ERC_20_SCENARIOS,
+                                                        GET_ALLOWANCE,
+                                                        asHeadlongAddress(tokenMirrorAddr.get()),
+                                                        asHeadlongAddress(
+                                                                zCivilianMirrorAddr.get()),
+                                                        asHeadlongAddress(
+                                                                aCivilianMirrorAddr.get()))
+                                                .via("MISSING_OWNER_ID")
+                                                .gas(1_000_000)
+                                                .hasKnownStatus(CONTRACT_REVERT_EXECUTED)))
+                .then(
+                        childRecordsCheck(
+                                "ACCOUNT_NOT_ASSOCIATED_TXN",
+                                CONTRACT_REVERT_EXECUTED,
+                                recordWith().status(TOKEN_NOT_ASSOCIATED_TO_ACCOUNT)),
+                        childRecordsCheck(
+                                MISSING_TO,
+                                CONTRACT_REVERT_EXECUTED,
+                                recordWith().status(INVALID_ALLOWANCE_SPENDER_ID)),
+                        childRecordsCheck(
+                                "SPENDER_SAME_AS_OWNER_TXN",
+                                CONTRACT_REVERT_EXECUTED,
+                                recordWith().status(SPENDER_ACCOUNT_SAME_AS_OWNER)),
+                        childRecordsCheck(
+                                "SUCCESSFUL_APPROVE_TXN", SUCCESS, recordWith().status(SUCCESS)),
+                        childRecordsCheck(
+                                "SUCCESSFUL_REVOKE_TXN", SUCCESS, recordWith().status(SUCCESS)),
+                        childRecordsCheck(
+                                "MISSING_OWNER_ID",
+                                CONTRACT_REVERT_EXECUTED,
+                                recordWith().status(INVALID_ALLOWANCE_OWNER_ID)),
+                        childRecordsCheck(
+                                "ALLOWANCE_TXN",
+                                SUCCESS,
+                                recordWith()
+                                        .status(SUCCESS)
+                                        .contractCallResult(
+                                                resultWith()
+                                                        .contractCallResult(
+                                                                htsPrecompileResult()
+                                                                        .forFunction(
+                                                                                FunctionType
+                                                                                        .ERC_ALLOWANCE)
+                                                                        .withAllowance(5L)))),
+                        childRecordsCheck(
+                                "ALLOWANCE_AFTER_REVOKE_TXN",
+                                SUCCESS,
+                                recordWith()
+                                        .status(SUCCESS)
+                                        .contractCallResult(
+                                                resultWith()
+                                                        .contractCallResult(
+                                                                htsPrecompileResult()
+                                                                        .forFunction(
+                                                                                FunctionType
+                                                                                        .ERC_ALLOWANCE)
+                                                                        .withAllowance(0L)))));
+    }
+
+    private HapiSpec someERC20NegativeTransferFromScenariosPass() {
+        final AtomicReference<String> tokenMirrorAddr = new AtomicReference<>();
+        final AtomicReference<String> contractMirrorAddr = new AtomicReference<>();
+        final AtomicReference<String> aCivilianMirrorAddr = new AtomicReference<>();
+        final AtomicReference<String> bCivilianMirrorAddr = new AtomicReference<>();
+        final AtomicReference<String> zCivilianMirrorAddr = new AtomicReference<>();
+
+        return propertyPreservingHapiSpec("someERC20NegativeTransferFromScenariosPass")
+                .preserving("hedera.allowances.isEnabled")
+                .given(
+                        overriding("hedera.allowances.isEnabled", "true"),
+                        newKeyNamed(MULTI_KEY_NAME),
+                        cryptoCreate(A_CIVILIAN)
+                                .exposingCreatedIdTo(
+                                        id -> aCivilianMirrorAddr.set(asHexedSolidityAddress(id))),
+                        cryptoCreate(B_CIVILIAN)
+                                .exposingCreatedIdTo(
+                                        id -> bCivilianMirrorAddr.set(asHexedSolidityAddress(id))),
+                        uploadInitCode(SOME_ERC_20_SCENARIOS),
+                        contractCreate(SOME_ERC_20_SCENARIOS).adminKey(MULTI_KEY_NAME),
+                        tokenCreate(TOKEN)
+                                .supplyKey(MULTI_KEY_NAME)
+                                .tokenType(FUNGIBLE_COMMON)
+                                .treasury(SOME_ERC_20_SCENARIOS)
+                                .initialSupply(10)
+                                .exposingCreatedIdTo(
+                                        idLit ->
+                                                tokenMirrorAddr.set(
+                                                        asHexedSolidityAddress(
+                                                                HapiPropertySource.asToken(
+                                                                        idLit)))))
+                .when(
+                        withOpContext(
+                                (spec, opLog) -> {
+                                    zCivilianMirrorAddr.set(
+                                            asHexedSolidityAddress(
+                                                    AccountID.newBuilder()
+                                                            .setAccountNum(666_666_666L)
+                                                            .build()));
+                                    contractMirrorAddr.set(
+                                            asHexedSolidityAddress(
+                                                    spec.registry()
+                                                            .getAccountID(SOME_ERC_20_SCENARIOS)));
+                                }),
+                        sourcing(
+                                () ->
+                                        contractCall(
+                                                        SOME_ERC_20_SCENARIOS,
+                                                        DO_TRANSFER_FROM,
+                                                        asHeadlongAddress(tokenMirrorAddr.get()),
+                                                        asHeadlongAddress(contractMirrorAddr.get()),
+                                                        asHeadlongAddress(
+                                                                bCivilianMirrorAddr.get()),
+                                                        BigInteger.ONE)
+                                                .payingWith(GENESIS)
+                                                .via("TOKEN_NOT_ASSOCIATED_TO_ACCOUNT_TXN")
+                                                .hasKnownStatus(CONTRACT_REVERT_EXECUTED)),
+                        tokenAssociate(B_CIVILIAN, TOKEN),
+                        sourcing(
+                                () ->
+                                        contractCall(
+                                                        SOME_ERC_20_SCENARIOS,
+                                                        DO_TRANSFER_FROM,
+                                                        asHeadlongAddress(tokenMirrorAddr.get()),
+                                                        asHeadlongAddress(
+                                                                zCivilianMirrorAddr.get()),
+                                                        asHeadlongAddress(
+                                                                bCivilianMirrorAddr.get()),
+                                                        BigInteger.ONE)
+                                                .payingWith(GENESIS)
+                                                .via(MISSING_FROM)
+                                                .hasKnownStatus(CONTRACT_REVERT_EXECUTED)),
+                        sourcing(
+                                () ->
+                                        contractCall(
+                                                        SOME_ERC_20_SCENARIOS,
+                                                        DO_TRANSFER_FROM,
+                                                        asHeadlongAddress(tokenMirrorAddr.get()),
+                                                        asHeadlongAddress(contractMirrorAddr.get()),
+                                                        asHeadlongAddress(
+                                                                bCivilianMirrorAddr.get()),
+                                                        BigInteger.ONE)
+                                                .payingWith(GENESIS)
+                                                .via(MSG_SENDER_IS_THE_SAME_AS_FROM)
+                                                .hasKnownStatus(SUCCESS)),
+                        cryptoTransfer(
+                                moving(9L, TOKEN).between(SOME_ERC_20_SCENARIOS, B_CIVILIAN)),
+                        tokenAssociate(A_CIVILIAN, TOKEN),
+                        sourcing(
+                                () ->
+                                        contractCall(
+                                                        SOME_ERC_20_SCENARIOS,
+                                                        DO_TRANSFER_FROM,
+                                                        asHeadlongAddress(tokenMirrorAddr.get()),
+                                                        asHeadlongAddress(
+                                                                bCivilianMirrorAddr.get()),
+                                                        asHeadlongAddress(
+                                                                aCivilianMirrorAddr.get()),
+                                                        BigInteger.ONE)
+                                                .payingWith(GENESIS)
+                                                .via(MSG_SENDER_IS_NOT_THE_SAME_AS_FROM)
+                                                .hasKnownStatus(CONTRACT_REVERT_EXECUTED)),
+                        cryptoApproveAllowance()
+                                .payingWith(B_CIVILIAN)
+                                .addTokenAllowance(B_CIVILIAN, TOKEN, SOME_ERC_20_SCENARIOS, 1L)
+                                .signedBy(DEFAULT_PAYER, B_CIVILIAN)
+                                .fee(ONE_HBAR),
+                        sourcing(
+                                () ->
+                                        contractCall(
+                                                        SOME_ERC_20_SCENARIOS,
+                                                        DO_TRANSFER_FROM,
+                                                        asHeadlongAddress(tokenMirrorAddr.get()),
+                                                        asHeadlongAddress(
+                                                                bCivilianMirrorAddr.get()),
+                                                        asHeadlongAddress(
+                                                                aCivilianMirrorAddr.get()),
+                                                        BigInteger.valueOf(5))
+                                                .payingWith(GENESIS)
+                                                .via(
+                                                        "TRY_TO_TRANSFER_MORE_THAN_APPROVED_AMOUNT_TXN")
+                                                .hasKnownStatus(CONTRACT_REVERT_EXECUTED)),
+                        cryptoApproveAllowance()
+                                .payingWith(B_CIVILIAN)
+                                .addTokenAllowance(B_CIVILIAN, TOKEN, SOME_ERC_20_SCENARIOS, 20L)
+                                .signedBy(DEFAULT_PAYER, B_CIVILIAN)
+                                .fee(ONE_HBAR),
+                        sourcing(
+                                () ->
+                                        contractCall(
+                                                        SOME_ERC_20_SCENARIOS,
+                                                        DO_TRANSFER_FROM,
+                                                        asHeadlongAddress(tokenMirrorAddr.get()),
+                                                        asHeadlongAddress(
+                                                                bCivilianMirrorAddr.get()),
+                                                        asHeadlongAddress(
+                                                                aCivilianMirrorAddr.get()),
+                                                        BigInteger.valueOf(20))
+                                                .payingWith(GENESIS)
+                                                .via("TRY_TO_TRANSFER_MORE_THAN_OWNERS_BALANCE_TXN")
+                                                .hasKnownStatus(CONTRACT_REVERT_EXECUTED)))
+                .then(
+                        childRecordsCheck(
+                                "TOKEN_NOT_ASSOCIATED_TO_ACCOUNT_TXN",
+                                CONTRACT_REVERT_EXECUTED,
+                                recordWith().status(TOKEN_NOT_ASSOCIATED_TO_ACCOUNT)),
+                        childRecordsCheck(
+                                MISSING_FROM,
+                                CONTRACT_REVERT_EXECUTED,
+                                recordWith().status(INVALID_ACCOUNT_ID)),
+                        childRecordsCheck(
+                                MSG_SENDER_IS_THE_SAME_AS_FROM,
+                                SUCCESS,
+                                recordWith().status(SUCCESS)),
+                        childRecordsCheck(
+                                MSG_SENDER_IS_NOT_THE_SAME_AS_FROM,
+                                CONTRACT_REVERT_EXECUTED,
+                                recordWith().status(SPENDER_DOES_NOT_HAVE_ALLOWANCE)),
+                        childRecordsCheck(
+                                "TRY_TO_TRANSFER_MORE_THAN_APPROVED_AMOUNT_TXN",
+                                CONTRACT_REVERT_EXECUTED,
+                                recordWith().status(AMOUNT_EXCEEDS_ALLOWANCE)),
+                        childRecordsCheck(
+                                "TRY_TO_TRANSFER_MORE_THAN_OWNERS_BALANCE_TXN",
+                                CONTRACT_REVERT_EXECUTED,
+                                recordWith().status(INSUFFICIENT_TOKEN_BALANCE)));
+    }
+
+    private HapiSpec someERC20ApproveAllowanceScenarioInOneCall() {
+        final AtomicReference<String> tokenMirrorAddr = new AtomicReference<>();
+        final AtomicReference<String> contractMirrorAddr = new AtomicReference<>();
+        final AtomicReference<String> aCivilianMirrorAddr = new AtomicReference<>();
+        final AtomicReference<String> bCivilianMirrorAddr = new AtomicReference<>();
+        final AtomicReference<String> zCivilianMirrorAddr = new AtomicReference<>();
+
+        return propertyPreservingHapiSpec("someERC20ApproveAllowanceScenarioInOneCall")
+                .preserving("hedera.allowances.isEnabled")
+                .given(
+                        overriding("hedera.allowances.isEnabled", "true"),
+                        newKeyNamed(MULTI_KEY_NAME),
+                        cryptoCreate(A_CIVILIAN)
+                                .exposingCreatedIdTo(
+                                        id -> aCivilianMirrorAddr.set(asHexedSolidityAddress(id))),
+                        cryptoCreate(B_CIVILIAN)
+                                .exposingCreatedIdTo(
+                                        id -> bCivilianMirrorAddr.set(asHexedSolidityAddress(id))),
+                        uploadInitCode(SOME_ERC_20_SCENARIOS),
+                        contractCreate(SOME_ERC_20_SCENARIOS).adminKey(MULTI_KEY_NAME),
+                        tokenCreate(TOKEN)
+                                .supplyKey(MULTI_KEY_NAME)
+                                .tokenType(FUNGIBLE_COMMON)
+                                .treasury(B_CIVILIAN)
+                                .initialSupply(10)
+                                .exposingCreatedIdTo(
+                                        idLit ->
+                                                tokenMirrorAddr.set(
+                                                        asHexedSolidityAddress(
+                                                                HapiPropertySource.asToken(
+                                                                        idLit)))),
+                        tokenAssociate(SOME_ERC_20_SCENARIOS, TOKEN))
+                .when(
+                        withOpContext(
+                                (spec, opLog) -> {
+                                    zCivilianMirrorAddr.set(
+                                            asHexedSolidityAddress(
+                                                    AccountID.newBuilder()
+                                                            .setAccountNum(666_666_666L)
+                                                            .build()));
+                                    contractMirrorAddr.set(
+                                            asHexedSolidityAddress(
+                                                    spec.registry()
+                                                            .getAccountID(SOME_ERC_20_SCENARIOS)));
+                                }),
+                        sourcing(
+                                () ->
+                                        contractCall(
+                                                        SOME_ERC_20_SCENARIOS,
+                                                        "approveAndGetAllowanceAmount",
+                                                        asHeadlongAddress(tokenMirrorAddr.get()),
+                                                        asHeadlongAddress(
+                                                                aCivilianMirrorAddr.get()),
+                                                        BigInteger.valueOf(5))
+                                                .via("APPROVE_AND_GET_ALLOWANCE_TXN")
+                                                .gas(1_000_000)
+                                                .hasKnownStatus(SUCCESS)
+                                                .logged()))
+                .then(
+                        childRecordsCheck(
+                                "APPROVE_AND_GET_ALLOWANCE_TXN",
+                                SUCCESS,
+                                recordWith().status(SUCCESS),
+                                recordWith()
+                                        .status(SUCCESS)
+                                        .contractCallResult(
+                                                resultWith()
+                                                        .contractCallResult(
+                                                                htsPrecompileResult()
+                                                                        .forFunction(
+                                                                                FunctionType
+                                                                                        .ERC_ALLOWANCE)
+                                                                        .withAllowance(5L)))));
+    }
+
+    private HapiSpec erc20Allowance() {
+        return propertyPreservingHapiSpec("ERC_20_ALLOWANCE")
+                .preserving("hedera.allowances.isEnabled")
+                .given(
+                        overriding("hedera.allowances.isEnabled", "true"),
+                        newKeyNamed(MULTI_KEY),
+                        cryptoCreate(OWNER).balance(100 * ONE_HUNDRED_HBARS),
+                        cryptoCreate(SPENDER),
+                        cryptoCreate(TOKEN_TREASURY),
+                        tokenCreate(FUNGIBLE_TOKEN)
+                                .tokenType(TokenType.FUNGIBLE_COMMON)
+                                .supplyType(TokenSupplyType.FINITE)
+                                .initialSupply(10L)
+                                .maxSupply(1000L)
+                                .treasury(TOKEN_TREASURY)
+                                .adminKey(MULTI_KEY)
+                                .supplyKey(MULTI_KEY),
+                        uploadInitCode(ERC_20_CONTRACT),
+                        contractCreate(ERC_20_CONTRACT),
+                        tokenAssociate(OWNER, FUNGIBLE_TOKEN),
+                        cryptoTransfer(moving(10, FUNGIBLE_TOKEN).between(TOKEN_TREASURY, OWNER)),
+                        cryptoApproveAllowance()
+                                .payingWith(DEFAULT_PAYER)
+                                .addTokenAllowance(OWNER, FUNGIBLE_TOKEN, SPENDER, 2L)
+                                .via(BASE_APPROVE_TXN)
+                                .logged()
+                                .signedBy(DEFAULT_PAYER, OWNER)
+                                .fee(ONE_HBAR))
+                .when(
+                        withOpContext(
+                                (spec, opLog) ->
+                                        allRunFor(
+                                                spec,
+                                                contractCall(
+                                                                ERC_20_CONTRACT,
+                                                                ALLOWANCE,
+                                                                HapiParserUtil.asHeadlongAddress(
+                                                                        asAddress(
+                                                                                spec.registry()
+                                                                                        .getTokenID(
+                                                                                                FUNGIBLE_TOKEN))),
+                                                                HapiParserUtil.asHeadlongAddress(
+                                                                        asAddress(
+                                                                                spec.registry()
+                                                                                        .getAccountID(
+                                                                                                OWNER))),
+                                                                HapiParserUtil.asHeadlongAddress(
+                                                                        asAddress(
+                                                                                spec.registry()
+                                                                                        .getAccountID(
+                                                                                                SPENDER))))
+                                                        .payingWith(OWNER)
+                                                        .via(ALLOWANCE_TXN)
+                                                        .hasKnownStatus(SUCCESS))))
+                .then(
+                        getTxnRecord(ALLOWANCE_TXN).andAllChildRecords().logged(),
+                        childRecordsCheck(
+                                ALLOWANCE_TXN,
+                                SUCCESS,
+                                recordWith()
+                                        .status(SUCCESS)
+                                        .contractCallResult(
+                                                resultWith()
+                                                        .contractCallResult(
+                                                                htsPrecompileResult()
+                                                                        .forFunction(
+                                                                                FunctionType
+                                                                                        .ERC_ALLOWANCE)
+                                                                        .withAllowance(2)))));
+    }
+
+    private HapiSpec erc20Approve() {
+        final var approveTxn = "approveTxn";
+
+        return propertyPreservingHapiSpec("ERC_20_APPROVE")
+                .preserving("hedera.allowances.isEnabled")
+                .given(
+                        overriding("hedera.allowances.isEnabled", "true"),
+                        newKeyNamed(MULTI_KEY),
+                        cryptoCreate(OWNER).balance(100 * ONE_HUNDRED_HBARS),
+                        cryptoCreate(SPENDER),
+                        cryptoCreate(TOKEN_TREASURY),
+                        tokenCreate(FUNGIBLE_TOKEN)
+                                .tokenType(TokenType.FUNGIBLE_COMMON)
+                                .supplyType(TokenSupplyType.FINITE)
+                                .initialSupply(10L)
+                                .maxSupply(1000L)
+                                .treasury(TOKEN_TREASURY)
+                                .adminKey(MULTI_KEY)
+                                .supplyKey(MULTI_KEY),
+                        uploadInitCode(ERC_20_CONTRACT),
+                        contractCreate(ERC_20_CONTRACT),
+                        tokenAssociate(OWNER, FUNGIBLE_TOKEN),
+                        tokenAssociate(ERC_20_CONTRACT, FUNGIBLE_TOKEN))
+                .when(
+                        withOpContext(
+                                (spec, opLog) ->
+                                        allRunFor(
+                                                spec,
+                                                contractCall(
+                                                                ERC_20_CONTRACT,
+                                                                APPROVE,
+                                                                HapiParserUtil.asHeadlongAddress(
+                                                                        asAddress(
+                                                                                spec.registry()
+                                                                                        .getTokenID(
+                                                                                                FUNGIBLE_TOKEN))),
+                                                                HapiParserUtil.asHeadlongAddress(
+                                                                        asAddress(
+                                                                                spec.registry()
+                                                                                        .getAccountID(
+                                                                                                SPENDER))),
+                                                                BigInteger.valueOf(10))
+                                                        .payingWith(OWNER)
+                                                        .gas(4_000_000L)
+                                                        .via(approveTxn)
+                                                        .hasKnownStatus(SUCCESS))))
+                .then(
+                        childRecordsCheck(approveTxn, SUCCESS, recordWith().status(SUCCESS)),
+                        getTxnRecord(approveTxn).andAllChildRecords().logged());
+    }
+
+    private HapiSpec getErc20TokenDecimalsFromErc721TokenFails() {
+        final var invalidDecimalsTxn = "decimalsFromErc721Txn";
+
+        return propertyPreservingHapiSpec("ERC_20_DECIMALS_FROM_ERC_721_TOKEN")
+                .preserving("hedera.allowances.isEnabled")
+                .given(
+                        overriding("hedera.allowances.isEnabled", "true"),
+                        newKeyNamed(MULTI_KEY),
+                        cryptoCreate(ACCOUNT).balance(100 * ONE_HUNDRED_HBARS),
+                        cryptoCreate(TOKEN_TREASURY),
+                        tokenCreate(NON_FUNGIBLE_TOKEN)
+                                .tokenType(TokenType.NON_FUNGIBLE_UNIQUE)
+                                .initialSupply(0)
+                                .treasury(TOKEN_TREASURY)
+                                .adminKey(MULTI_KEY)
+                                .supplyKey(MULTI_KEY),
+                        mintToken(NON_FUNGIBLE_TOKEN, List.of(FIRST_META)),
+                        fileCreate(ERC_20_CONTRACT_NAME),
+                        uploadInitCode(ERC_20_CONTRACT),
+                        contractCreate(ERC_20_CONTRACT))
+                .when(
+                        withOpContext(
+                                (spec, opLog) ->
+                                        allRunFor(
+                                                spec,
+                                                contractCall(
+                                                                ERC_20_CONTRACT,
+                                                                DECIMALS,
+                                                                asHeadlongAddress(
+                                                                        asHexedAddress(
+                                                                                spec.registry()
+                                                                                        .getTokenID(
+                                                                                                NON_FUNGIBLE_TOKEN))))
+                                                        .payingWith(ACCOUNT)
+                                                        .via(invalidDecimalsTxn)
+                                                        .hasKnownStatus(CONTRACT_REVERT_EXECUTED)
+                                                        .gas(GAS_TO_OFFER))))
+                .then(getTxnRecord(invalidDecimalsTxn).andAllChildRecords().logged());
+    }
+
+    private HapiSpec transferErc20TokenFromErc721TokenFails() {
+        return propertyPreservingHapiSpec("ERC_20_TRANSFER_FROM_ERC_721_TOKEN")
+                .preserving("hedera.allowances.isEnabled")
+                .given(
+                        overriding("hedera.allowances.isEnabled", "true"),
+                        newKeyNamed(MULTI_KEY),
+                        cryptoCreate(ACCOUNT).balance(100 * ONE_MILLION_HBARS),
+                        cryptoCreate(RECIPIENT),
+                        cryptoCreate(TOKEN_TREASURY),
+                        tokenCreate(NON_FUNGIBLE_TOKEN)
+                                .tokenType(TokenType.NON_FUNGIBLE_UNIQUE)
+                                .initialSupply(0)
+                                .treasury(TOKEN_TREASURY)
+                                .adminKey(MULTI_KEY)
+                                .supplyKey(MULTI_KEY),
+                        mintToken(NON_FUNGIBLE_TOKEN, List.of(FIRST_META)),
+                        tokenAssociate(ACCOUNT, List.of(NON_FUNGIBLE_TOKEN)),
+                        tokenAssociate(RECIPIENT, List.of(NON_FUNGIBLE_TOKEN)),
+                        cryptoTransfer(
+                                        movingUnique(NON_FUNGIBLE_TOKEN, 1)
+                                                .between(TOKEN_TREASURY, ACCOUNT))
+                                .payingWith(ACCOUNT),
+                        uploadInitCode(ERC_20_CONTRACT),
+                        contractCreate(ERC_20_CONTRACT))
+                .when(
+                        withOpContext(
+                                (spec, opLog) ->
+                                        allRunFor(
+                                                spec,
+                                                contractCall(
+                                                                ERC_20_CONTRACT,
+                                                                TRANSFER,
+                                                                HapiParserUtil.asHeadlongAddress(
+                                                                        asAddress(
+                                                                                spec.registry()
+                                                                                        .getTokenID(
+                                                                                                NON_FUNGIBLE_TOKEN))),
+                                                                HapiParserUtil.asHeadlongAddress(
+                                                                        asAddress(
+                                                                                spec.registry()
+                                                                                        .getAccountID(
+                                                                                                RECIPIENT))),
+                                                                BigInteger.TWO)
+                                                        .payingWith(ACCOUNT)
+                                                        .alsoSigningWithFullPrefix(MULTI_KEY)
+                                                        .via(TRANSFER_TXN)
+                                                        .gas(GAS_TO_OFFER)
+                                                        .hasKnownStatus(CONTRACT_REVERT_EXECUTED))))
+                .then(getTxnRecord(TRANSFER_TXN).andAllChildRecords().logged());
+    }
+
+    private HapiSpec transferErc20TokenFromContractWithApproval() {
+        final var transferFromOtherContractWithSignaturesTxn =
+                "transferFromOtherContractWithSignaturesTxn";
+        final var nestedContract = "NestedERC20Contract";
+
+        return propertyPreservingHapiSpec("ERC_20_TRANSFER_FROM_CONTRACT_WITH_APPROVAL")
+                .preserving("contracts.allowSystemUseOfHapiSigs")
+                .given(
+                        newKeyNamed(MULTI_KEY),
+                        cryptoCreate(ACCOUNT).balance(10 * ONE_MILLION_HBARS),
+                        cryptoCreate(RECIPIENT),
+                        cryptoCreate(TOKEN_TREASURY),
+                        tokenCreate(FUNGIBLE_TOKEN)
+                                .tokenType(TokenType.FUNGIBLE_COMMON)
+                                .initialSupply(35)
+                                .treasury(TOKEN_TREASURY)
+                                .adminKey(MULTI_KEY)
+                                .supplyKey(MULTI_KEY),
+                        uploadInitCode(ERC_20_CONTRACT, nestedContract),
+                        newKeyNamed(TRANSFER_SIG_NAME).shape(SIMPLE.signedWith(ON)),
+                        contractCreate(ERC_20_CONTRACT).adminKey(TRANSFER_SIG_NAME),
+                        contractCreate(nestedContract).adminKey(TRANSFER_SIG_NAME),
+                        overriding("contracts.allowSystemUseOfHapiSigs", "CryptoTransfer"))
+                .when(
+                        withOpContext(
+                                (spec, opLog) ->
+                                        allRunFor(
+                                                spec,
+                                                tokenAssociate(ACCOUNT, List.of(FUNGIBLE_TOKEN)),
+                                                tokenAssociate(RECIPIENT, List.of(FUNGIBLE_TOKEN)),
+                                                tokenAssociate(
+                                                        ERC_20_CONTRACT, List.of(FUNGIBLE_TOKEN)),
+                                                tokenAssociate(
+                                                        nestedContract, List.of(FUNGIBLE_TOKEN)),
+                                                cryptoTransfer(
+                                                                TokenMovement.moving(
+                                                                                20, FUNGIBLE_TOKEN)
+                                                                        .between(
+                                                                                TOKEN_TREASURY,
+                                                                                ERC_20_CONTRACT))
+                                                        .payingWith(ACCOUNT),
+                                                contractCall(
+                                                                ERC_20_CONTRACT,
+                                                                APPROVE,
+                                                                HapiParserUtil.asHeadlongAddress(
+                                                                        asAddress(
+                                                                                spec.registry()
+                                                                                        .getTokenID(
+                                                                                                FUNGIBLE_TOKEN))),
+                                                                HapiParserUtil.asHeadlongAddress(
+                                                                        asAddress(
+                                                                                spec.registry()
+                                                                                        .getContractId(
+                                                                                                ERC_20_CONTRACT))),
+                                                                BigInteger.valueOf(20))
+                                                        .gas(1_000_000)
+                                                        .payingWith(ACCOUNT)
+                                                        .alsoSigningWithFullPrefix(
+                                                                TRANSFER_SIG_NAME),
+                                                contractCall(
+                                                                ERC_20_CONTRACT,
+                                                                TRANSFER_FROM,
+                                                                HapiParserUtil.asHeadlongAddress(
+                                                                        asAddress(
+                                                                                spec.registry()
+                                                                                        .getTokenID(
+                                                                                                FUNGIBLE_TOKEN))),
+                                                                HapiParserUtil.asHeadlongAddress(
+                                                                        asAddress(
+                                                                                spec.registry()
+                                                                                        .getContractId(
+                                                                                                ERC_20_CONTRACT))),
+                                                                HapiParserUtil.asHeadlongAddress(
+                                                                        asAddress(
+                                                                                spec.registry()
+                                                                                        .getContractId(
+                                                                                                nestedContract))),
+                                                                BigInteger.valueOf(5))
+                                                        .via(TRANSFER_TXN)
+                                                        .alsoSigningWithFullPrefix(
+                                                                TRANSFER_SIG_NAME)
+                                                        .hasKnownStatus(SUCCESS),
+                                                contractCall(
+                                                                ERC_20_CONTRACT,
+                                                                TRANSFER_FROM,
+                                                                HapiParserUtil.asHeadlongAddress(
+                                                                        asAddress(
+                                                                                spec.registry()
+                                                                                        .getTokenID(
+                                                                                                FUNGIBLE_TOKEN))),
+                                                                HapiParserUtil.asHeadlongAddress(
+                                                                        asAddress(
+                                                                                spec.registry()
+                                                                                        .getContractId(
+                                                                                                ERC_20_CONTRACT))),
+                                                                HapiParserUtil.asHeadlongAddress(
+                                                                        asAddress(
+                                                                                spec.registry()
+                                                                                        .getContractId(
+                                                                                                nestedContract))),
+                                                                BigInteger.valueOf(5))
+                                                        .payingWith(ACCOUNT)
+                                                        .alsoSigningWithFullPrefix(
+                                                                TRANSFER_SIG_NAME)
+                                                        .via(
+                                                                transferFromOtherContractWithSignaturesTxn))))
+                .then(
+                        getContractInfo(ERC_20_CONTRACT).saveToRegistry(ERC_20_CONTRACT),
+                        getContractInfo(nestedContract).saveToRegistry(nestedContract),
+                        withOpContext(
+                                (spec, log) -> {
+                                    final var sender =
+                                            spec.registry()
+                                                    .getContractInfo(ERC_20_CONTRACT)
+                                                    .getContractID();
+                                    final var receiver =
+                                            spec.registry()
+                                                    .getContractInfo(nestedContract)
+                                                    .getContractID();
+
+                                    var transferRecord =
+                                            getTxnRecord(TRANSFER_TXN)
+                                                    .hasPriority(
+                                                            recordWith()
+                                                                    .contractCallResult(
+                                                                            resultWith()
+                                                                                    .logs(
+                                                                                            inOrder(
+                                                                                                    logWith()
+                                                                                                            .withTopicsInOrder(
+                                                                                                                    List
+                                                                                                                            .of(
+                                                                                                                                    eventSignatureOf(
+                                                                                                                                            TRANSFER_SIGNATURE),
+                                                                                                                                    parsedToByteString(
+                                                                                                                                            sender
+                                                                                                                                                    .getContractNum()),
+                                                                                                                                    parsedToByteString(
+                                                                                                                                            receiver
+                                                                                                                                                    .getContractNum())))
+                                                                                                            .longValue(
+                                                                                                                    5)))))
+                                                    .andAllChildRecords();
+
+                                    var transferFromOtherContractWithSignaturesTxnRecord =
+                                            getTxnRecord(transferFromOtherContractWithSignaturesTxn)
+                                                    .hasPriority(
+                                                            recordWith()
+                                                                    .contractCallResult(
+                                                                            resultWith()
+                                                                                    .logs(
+                                                                                            inOrder(
+                                                                                                    logWith()
+                                                                                                            .withTopicsInOrder(
+                                                                                                                    List
+                                                                                                                            .of(
+                                                                                                                                    eventSignatureOf(
+                                                                                                                                            TRANSFER_SIGNATURE),
+                                                                                                                                    parsedToByteString(
+                                                                                                                                            sender
+                                                                                                                                                    .getContractNum()),
+                                                                                                                                    parsedToByteString(
+                                                                                                                                            receiver
+                                                                                                                                                    .getContractNum())))
+                                                                                                            .longValue(
+                                                                                                                    5)))))
+                                                    .andAllChildRecords();
+
+                                    allRunFor(
+                                            spec,
+                                            transferRecord,
+                                            transferFromOtherContractWithSignaturesTxnRecord);
+                                }),
+                        childRecordsCheck(
+                                TRANSFER_TXN,
+                                SUCCESS,
+                                recordWith()
+                                        .status(SUCCESS)
+                                        .contractCallResult(
+                                                resultWith()
+                                                        .contractCallResult(
+                                                                htsPrecompileResult()
+                                                                        .forFunction(
+                                                                                FunctionType
+                                                                                        .ERC_TRANSFER)
+                                                                        .withErcFungibleTransferStatus(
+                                                                                true)))),
+                        childRecordsCheck(
+                                transferFromOtherContractWithSignaturesTxn,
+                                SUCCESS,
+                                recordWith()
+                                        .status(SUCCESS)
+                                        .contractCallResult(
+                                                resultWith()
+                                                        .contractCallResult(
+                                                                htsPrecompileResult()
+                                                                        .forFunction(
+                                                                                FunctionType
+                                                                                        .ERC_TRANSFER)
+                                                                        .withErcFungibleTransferStatus(
+                                                                                true)))),
+                        getAccountBalance(ERC_20_CONTRACT).hasTokenBalance(FUNGIBLE_TOKEN, 10),
+                        getAccountBalance(nestedContract).hasTokenBalance(FUNGIBLE_TOKEN, 10));
+    }
+
+    private HapiSpec getErc20TokenDecimals() {
+        final var decimals = 10;
+        final var decimalsTxn = "decimalsTxn";
+        final AtomicReference<String> tokenAddr = new AtomicReference<>();
+
+        return propertyPreservingHapiSpec("ERC_20_DECIMALS")
+                .preserving("hedera.allowances.isEnabled")
+                .given(
+                        overriding("hedera.allowances.isEnabled", "true"),
+                        newKeyNamed(MULTI_KEY),
+                        cryptoCreate(ACCOUNT).balance(100 * ONE_HUNDRED_HBARS),
+                        cryptoCreate(TOKEN_TREASURY),
+                        tokenCreate(FUNGIBLE_TOKEN)
+                                .tokenType(TokenType.FUNGIBLE_COMMON)
+                                .supplyType(TokenSupplyType.INFINITE)
+                                .initialSupply(5)
+                                .decimals(decimals)
+                                .treasury(TOKEN_TREASURY)
+                                .adminKey(MULTI_KEY)
+                                .supplyKey(MULTI_KEY)
+                                .exposingCreatedIdTo(
+                                        id ->
+                                                tokenAddr.set(
+                                                        asHexedSolidityAddress(
+                                                                HapiPropertySource.asToken(id)))),
+                        fileCreate(ERC_20_CONTRACT_NAME),
+                        uploadInitCode(ERC_20_CONTRACT),
+                        contractCreate(ERC_20_CONTRACT))
+                .when(
+                        withOpContext(
+                                (spec, opLog) ->
+                                        allRunFor(
+                                                spec,
+                                                contractCall(
+                                                                ERC_20_CONTRACT,
+                                                                DECIMALS,
+                                                                asHeadlongAddress(
+                                                                        asHexedAddress(
+                                                                                spec.registry()
+                                                                                        .getTokenID(
+                                                                                                FUNGIBLE_TOKEN))))
+                                                        .payingWith(ACCOUNT)
+                                                        .via(decimalsTxn)
+                                                        .hasKnownStatus(SUCCESS)
+                                                        .gas(GAS_TO_OFFER))))
+                .then(
+                        childRecordsCheck(
+                                decimalsTxn,
+                                SUCCESS,
+                                recordWith()
+                                        .status(SUCCESS)
+                                        .contractCallResult(
+                                                resultWith()
+                                                        .contractCallResult(
+                                                                htsPrecompileResult()
+                                                                        .forFunction(
+                                                                                FunctionType
+                                                                                        .ERC_DECIMALS)
+                                                                        .withDecimals(decimals)))),
+                        sourcing(
+                                () ->
+                                        contractCallLocal(
+                                                ERC_20_CONTRACT,
+                                                DECIMALS,
+                                                asHeadlongAddress(tokenAddr.get()))));
+    }
+
+    private HapiSpec getErc20TokenName() {
+        return propertyPreservingHapiSpec("ERC_20_NAME")
+                .preserving("hedera.allowances.isEnabled")
+                .given(
+                        overriding("hedera.allowances.isEnabled", "true"),
+                        newKeyNamed(MULTI_KEY),
+                        cryptoCreate(ACCOUNT).balance(100 * ONE_HUNDRED_HBARS),
+                        cryptoCreate(TOKEN_TREASURY),
+                        tokenCreate(FUNGIBLE_TOKEN)
+                                .tokenType(TokenType.FUNGIBLE_COMMON)
+                                .supplyType(TokenSupplyType.INFINITE)
+                                .initialSupply(5)
+                                .name(TOKEN_NAME)
+                                .treasury(TOKEN_TREASURY)
+                                .adminKey(MULTI_KEY)
+                                .supplyKey(MULTI_KEY),
+                        uploadInitCode(ERC_20_CONTRACT),
+                        contractCreate(ERC_20_CONTRACT))
+                .when(
+                        withOpContext(
+                                (spec, opLog) ->
+                                        allRunFor(
+                                                spec,
+                                                contractCall(
+                                                                ERC_20_CONTRACT,
+                                                                "name",
+                                                                asHeadlongAddress(
+                                                                        asHexedAddress(
+                                                                                spec.registry()
+                                                                                        .getTokenID(
+                                                                                                FUNGIBLE_TOKEN))))
+                                                        .payingWith(ACCOUNT)
+                                                        .via(NAME_TXN)
+                                                        .gas(4_000_000)
+                                                        .hasKnownStatus(SUCCESS))))
+                .then(
+                        childRecordsCheck(
+                                NAME_TXN,
+                                SUCCESS,
+                                recordWith()
+                                        .status(SUCCESS)
+                                        .contractCallResult(
+                                                resultWith()
+                                                        .contractCallResult(
+                                                                htsPrecompileResult()
+                                                                        .forFunction(
+                                                                                FunctionType
+                                                                                        .ERC_NAME)
+                                                                        .withName(TOKEN_NAME)))));
     }
 
     private HapiSpec transferDontWorkWithoutTopLevelSignatures() {

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/leaky/LeakyContractTestsSuite.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/leaky/LeakyContractTestsSuite.java
@@ -356,8 +356,9 @@ public class LeakyContractTestsSuite extends HapiSuite {
                                                                 BigInteger.TWO)
                                                         .gas(500_000L)
                                                         .via(TRANSFER_FROM_ACCOUNT_TXN)
-                                                        .hasKnownStatus(SUCCESS))))
-                .then(getAccountBalance(RECIPIENT).hasTokenBalance(FUNGIBLE_TOKEN, 2));
+                                                        // No longer works unless you have allowance
+                                                        .hasKnownStatus(CONTRACT_REVERT_EXECUTED))))
+                .then(getAccountBalance(RECIPIENT).hasTokenBalance(FUNGIBLE_TOKEN, 0));
     }
 
     private HapiSpec erc20TransferFrom() {
@@ -578,7 +579,7 @@ public class LeakyContractTestsSuite extends HapiSuite {
                                                         BigInteger.valueOf(5))
                                                 .via("SPENDER_SAME_AS_OWNER_TXN")
                                                 .gas(1_000_000)
-                                                .hasKnownStatus(CONTRACT_REVERT_EXECUTED)),
+                                                .hasKnownStatus(SUCCESS)),
                         sourcing(
                                 () ->
                                         contractCall(
@@ -658,9 +659,7 @@ public class LeakyContractTestsSuite extends HapiSuite {
                                 CONTRACT_REVERT_EXECUTED,
                                 recordWith().status(INVALID_ALLOWANCE_SPENDER_ID)),
                         childRecordsCheck(
-                                "SPENDER_SAME_AS_OWNER_TXN",
-                                CONTRACT_REVERT_EXECUTED,
-                                recordWith().status(SPENDER_ACCOUNT_SAME_AS_OWNER)),
+                                "SPENDER_SAME_AS_OWNER_TXN", SUCCESS, recordWith().status(SUCCESS)),
                         childRecordsCheck(
                                 "SUCCESSFUL_APPROVE_TXN", SUCCESS, recordWith().status(SUCCESS)),
                         childRecordsCheck(
@@ -781,7 +780,7 @@ public class LeakyContractTestsSuite extends HapiSuite {
                                                         BigInteger.ONE)
                                                 .payingWith(GENESIS)
                                                 .via(MSG_SENDER_IS_THE_SAME_AS_FROM)
-                                                .hasKnownStatus(SUCCESS)),
+                                                .hasKnownStatus(CONTRACT_REVERT_EXECUTED)),
                         cryptoTransfer(
                                 moving(9L, TOKEN).between(SOME_ERC_20_SCENARIOS, B_CIVILIAN)),
                         tokenAssociate(A_CIVILIAN, TOKEN),
@@ -849,8 +848,8 @@ public class LeakyContractTestsSuite extends HapiSuite {
                                 recordWith().status(INVALID_ACCOUNT_ID)),
                         childRecordsCheck(
                                 MSG_SENDER_IS_THE_SAME_AS_FROM,
-                                SUCCESS,
-                                recordWith().status(SUCCESS)),
+                                CONTRACT_REVERT_EXECUTED,
+                                recordWith().status(SPENDER_DOES_NOT_HAVE_ALLOWANCE)),
                         childRecordsCheck(
                                 MSG_SENDER_IS_NOT_THE_SAME_AS_FROM,
                                 CONTRACT_REVERT_EXECUTED,
@@ -2337,7 +2336,7 @@ public class LeakyContractTestsSuite extends HapiSuite {
 
     HapiSpec accountWithoutAliasCanMakeEthTxnsDueToAutomaticAliasCreation() {
         final String ACCOUNT = "account";
-        return defaultHapiSpec(
+        return onlyDefaultHapiSpec(
                         "ETX_026_accountWithoutAliasCanMakeEthTxnsDueToAutomaticAliasCreation")
                 .given(
                         overriding(CRYPTO_CREATE_WITH_ALIAS_AND_EVM_ADDRESS_ENABLED, FALSE_VALUE),

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/leaky/LeakyContractTestsSuite.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/leaky/LeakyContractTestsSuite.java
@@ -2336,7 +2336,7 @@ public class LeakyContractTestsSuite extends HapiSuite {
 
     HapiSpec accountWithoutAliasCanMakeEthTxnsDueToAutomaticAliasCreation() {
         final String ACCOUNT = "account";
-        return onlyDefaultHapiSpec(
+        return defaultHapiSpec(
                         "ETX_026_accountWithoutAliasCanMakeEthTxnsDueToAutomaticAliasCreation")
                 .given(
                         overriding(CRYPTO_CREATE_WITH_ALIAS_AND_EVM_ADDRESS_ENABLED, FALSE_VALUE),

--- a/test-clients/src/main/resource/bootstrap.properties
+++ b/test-clients/src/main/resource/bootstrap.properties
@@ -76,6 +76,7 @@ contracts.redirectTokenCalls=true
 contracts.precompile.htsDefaultGasCost=10000
 contracts.precompile.exportRecordResults=true
 contracts.precompile.htsEnableTokenCreate=true
+contracts.precompile.unsupportedCustomFeeReceiverDebits=
 contracts.precompile.atomicCryptoTransfer.enabled=true
 fees.minCongestionPeriod=60
 fees.percentCongestionMultipliers=90,10x,95,25x,99,100x


### PR DESCRIPTION
When an NFT with fallback royalty fee is transferred and there is a debit from receiver, receiver should sign the transaction.
Adds a dynamic property for this feature