### PR TITLE
Revert to `v0.35.3` `ContractKey.hashCode()`

### DIFF
--- a/hedera-node/hedera-mono-service/build.gradle.kts
+++ b/hedera-node/hedera-mono-service/build.gradle.kts
@@ -101,6 +101,10 @@ val jmhDaggerSources = file("build/generated/sources/annotationProcessor/java/jm
 
 java.sourceSets["jmh"].java.srcDir(jmhDaggerSources)
 
+val generatedSources = file("build/generated/sources/annotationProcessor/java/main")
+
+java.sourceSets["main"].java.srcDir(generatedSources)
+
 // Replace variables in semantic-version.properties with build variables
 tasks.processResources {
   filesMatching("semantic-version.properties") {

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/virtual/ContractKey.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/virtual/ContractKey.java
@@ -19,7 +19,6 @@ package com.hedera.node.app.service.mono.state.virtual;
 import static com.hedera.node.app.service.mono.state.virtual.KeyPackingUtils.deserializeUint256Key;
 import static com.hedera.node.app.service.mono.state.virtual.KeyPackingUtils.serializePackedBytes;
 import static com.hedera.node.app.service.mono.state.virtual.KeyPackingUtils.serializePackedBytesToBuffer;
-import static com.swirlds.common.utility.NonCryptographicHashing.hash32;
 
 import com.hederahashgraph.api.proto.java.AccountID;
 import com.swirlds.common.io.streams.SerializableDataInputStream;
@@ -133,7 +132,7 @@ public final class ContractKey implements VirtualKey<ContractKey> {
     /** Special hash to make sure we get good distribution. */
     @Override
     public int hashCode() {
-        return hash32(
+        return (int) stableHash64(
                 contractId,
                 uint256Key[7],
                 uint256Key[6],
@@ -327,5 +326,42 @@ public final class ContractKey implements VirtualKey<ContractKey> {
     @Override
     public int getMinimumSupportedVersion() {
         return 1;
+    }
+
+    /**
+     * An unchanging, UNTOUCHABLE implementation of {@code hashCode()} to reduce hash collisions.
+     *
+     * @param x0 the first long to hash
+     * @param x1 the second long to hash
+     * @param x2 the third long to hash
+     * @param x3 the fourth long to hash
+     * @param x4 the fifth long to hash
+     * @param x5 the sixth long to hash
+     * @param x6 the seventh long to hash
+     * @param x7 the eighth long to hash
+     * @param x8 the ninth long to hash
+     * @return a near-optimal non-cryptographic hash of the given longs
+     */
+    private static long stableHash64(long x0, long x1, long x2, long x3, long x4, long x5, long x6, long x7, long x8) {
+        return stablePerm64(stablePerm64(stablePerm64(stablePerm64(stablePerm64(stablePerm64(
+                                                        stablePerm64(stablePerm64(stablePerm64(x0) ^ x1) ^ x2) ^ x3)
+                                                ^ x4)
+                                        ^ x5)
+                                ^ x6)
+                        ^ x7)
+                ^ x8);
+    }
+
+    private static long stablePerm64(long x) {
+        x += x << 30;
+        x ^= x >>> 27;
+        x += x << 16;
+        x ^= x >>> 20;
+        x += x << 5;
+        x ^= x >>> 18;
+        x += x << 10;
+        x ^= x >>> 24;
+        x += x << 30;
+        return x;
     }
 }

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/virtual/ContractKeyTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/virtual/ContractKeyTest.java
@@ -32,6 +32,7 @@ import static org.mockito.Mockito.mock;
 import com.google.common.primitives.Ints;
 import com.swirlds.common.io.streams.SerializableDataInputStream;
 import com.swirlds.common.io.streams.SerializableDataOutputStream;
+import com.swirlds.common.utility.CommonUtils;
 import java.io.IOException;
 import java.math.BigInteger;
 import java.nio.ByteBuffer;
@@ -61,6 +62,27 @@ class ContractKeyTest {
         assertEquals(-1, base.compareTo(largerNum));
         final var smallerKey = new ContractKey(contractNum, 1);
         assertEquals(+1, base.compareTo(smallerKey));
+    }
+
+    // The first two columns form a ContractKey(id, 32-byte word) and the third column is the
+    // result of running ContractKey.hashCode() on that key using the v0.35.3 tag.
+    @CsvSource({
+        "5347959350198992124,cd53935a7e183dac3557134dfc73766479c520c7ffeace8723488bffa2da3fa2,-672529924",
+        "4793581390134811504,4a164095f80400a99cc906b97cda21a0ccbdcc68c30f25acfb3be365188ffa92,-117896145",
+        "495049458345236169,ccc59e0e848fc33929be60250bea580a0b627462a40caa923cef92b52521d91d,-2046179395",
+        "1431041771021977088,b9d0e90be872a7dbec4374994456d827511b5119e91753e4c470bce5f70ae8c9,1791841599",
+        "7691249564562953528,3c9c72d879d1f8d3c58bfd3646104bc4b3e15a1ab9620046110281148be061a5,-791511019",
+        "5054707002752848259,a8d3ac6828f9b9c0c40d1d852928e32d2c3ac8594b833dfde0690d860c146679,-864395628",
+        "3197462047532630427,302b67d47cae0cbb28a088c54e06a7f9d0f7294c79c9a24a7a7dd338c2120d04,-416588588",
+        "7450692693395689069,83155a9613b37702263c403a1155634391fe2cb52a602c471111afc5556a10bc,-1845261180",
+        "6927692228180407389,0eee723a1379e18de57b833948aaaa27a3ab50782ec3e3357c033324c8e6b6ea,1695791916",
+        "4625164975176510159,f7526434d62eb147a11c0d186c795d98ad5053089f9b677fb99e637978bf8d6d,-173217838",
+    })
+    @ParameterizedTest
+    void computesV035HashCodes(final long contractNum, final String keyHex, final int expectedCode) {
+        final var word = CommonUtils.unhex(keyHex);
+        final var subject = new ContractKey(contractNum, word);
+        assertEquals(expectedCode, subject.hashCode());
     }
 
     @Test


### PR DESCRIPTION
**Description**:
 - Reinstates original `ContractKey.hashCode()` implementation with some test vectors created using the `v0.35.3` tag.
 - Adds the Dagger2-generated code to the `mono-service` source set to avoid some build annoyances.