### PR TITLE
Reset JUL `LogManager` if `netty.loggingOff=true`

### DIFF
--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/config/PropertyNames.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/config/PropertyNames.java
@@ -228,6 +228,7 @@ public class PropertyNames {
     public static final String HEDERA_RECORD_STREAM_LOG_EVERY_TRANSACTION = "hedera.recordStream.logEveryTransaction";
     public static final String ISS_RESET_PERIOD = "iss.resetPeriod";
     public static final String ISS_ROUNDS_TO_LOG = "iss.roundsToLog";
+    public static final String NETTY_LOGGING_OFF = "netty.loggingOff";
     public static final String NETTY_MODE = "netty.mode";
     public static final String NETTY_PROD_FLOW_CONTROL_WINDOW = "netty.prod.flowControlWindow";
     public static final String NETTY_PROD_MAX_CONCURRENT_CALLS = "netty.prod.maxConcurrentCalls";

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/MonoServicesMain.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/MonoServicesMain.java
@@ -18,10 +18,12 @@ package com.hedera.node.app;
 
 import static com.hedera.node.app.service.mono.context.AppsManager.APPS;
 import static com.hedera.node.app.service.mono.context.properties.SemanticVersions.SEMANTIC_VERSIONS;
+import static com.hedera.node.app.spi.config.PropertyNames.NETTY_LOGGING_OFF;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 import com.hedera.node.app.service.mono.ServicesApp;
 import com.hedera.node.app.service.mono.ServicesState;
+import com.hedera.node.app.service.mono.context.properties.BootstrapProperties;
 import com.swirlds.common.notification.listeners.PlatformStatusChangeListener;
 import com.swirlds.common.notification.listeners.ReconnectCompleteListener;
 import com.swirlds.common.notification.listeners.StateWriteToDiskCompleteListener;
@@ -98,6 +100,11 @@ public class MonoServicesMain implements SwirldMain {
     }
 
     private void doStagedInit() {
+        final var disableJULogging = new BootstrapProperties(false).getBooleanProperty(NETTY_LOGGING_OFF);
+        if (disableJULogging) {
+            java.util.logging.LogManager.getLogManager().reset();
+        }
+
         validateLedgerState();
         log.info("Ledger state ok");
 

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/MonoServicesMain.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/MonoServicesMain.java
@@ -100,6 +100,7 @@ public class MonoServicesMain implements SwirldMain {
     }
 
     private void doStagedInit() {
+        // Construct BootstrapProperties with false to suppress redundant property listing in logs
         final var disableJULogging = new BootstrapProperties(false).getBooleanProperty(NETTY_LOGGING_OFF);
         if (disableJULogging) {
             java.util.logging.LogManager.getLogManager().reset();

--- a/hedera-node/hedera-app/src/main/java/module-info.java
+++ b/hedera-node/hedera-app/src/main/java/module-info.java
@@ -40,6 +40,7 @@ module com.hedera.node.app {
     requires com.hedera.hashgraph.protobuf.java.api;
     requires com.hedera.node.app.hapi.fees;
     requires com.hedera.node.hapi;
+    requires java.logging;
 
     exports com.hedera.node.app to
             com.swirlds.platform;

--- a/hedera-node/hedera-app/src/test/resources/bootstrap.properties
+++ b/hedera-node/hedera-app/src/test/resources/bootstrap.properties
@@ -188,6 +188,7 @@ hedera.recordStream.logEveryTransaction=false
 hedera.recordStream.compressFilesOnCreation=false
 iss.resetPeriod=60
 iss.roundsToLog=5000
+netty.loggingOff=true
 netty.mode=PROD
 netty.prod.flowControlWindow=10240
 netty.prod.maxConcurrentCalls=10

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/properties/BootstrapProperties.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/properties/BootstrapProperties.java
@@ -163,6 +163,7 @@ import static com.hedera.node.app.spi.config.PropertyNames.LEDGER_TOKEN_TRANSFER
 import static com.hedera.node.app.spi.config.PropertyNames.LEDGER_TOTAL_TINY_BAR_FLOAT;
 import static com.hedera.node.app.spi.config.PropertyNames.LEDGER_TRANSFERS_MAX_LEN;
 import static com.hedera.node.app.spi.config.PropertyNames.LEDGER_XFER_BAL_CHANGES_MAX_LEN;
+import static com.hedera.node.app.spi.config.PropertyNames.NETTY_LOGGING_OFF;
 import static com.hedera.node.app.spi.config.PropertyNames.NETTY_MODE;
 import static com.hedera.node.app.spi.config.PropertyNames.NETTY_PROD_FLOW_CONTROL_WINDOW;
 import static com.hedera.node.app.spi.config.PropertyNames.NETTY_PROD_KEEP_ALIVE_TIME;
@@ -576,6 +577,7 @@ public final class BootstrapProperties implements PropertySource {
             HEDERA_RECORD_STREAM_QUEUE_CAPACITY,
             ISS_RESET_PERIOD,
             ISS_ROUNDS_TO_LOG,
+            NETTY_LOGGING_OFF,
             NETTY_MODE,
             NETTY_PROD_FLOW_CONTROL_WINDOW,
             NETTY_PROD_MAX_CONCURRENT_CALLS,
@@ -680,6 +682,7 @@ public final class BootstrapProperties implements PropertySource {
             entry(AUTO_RENEW_GRANT_FREE_RENEWALS, AS_BOOLEAN),
             entry(LEDGER_AUTO_RENEW_PERIOD_MAX_DURATION, AS_LONG),
             entry(LEDGER_AUTO_RENEW_PERIOD_MIN_DURATION, AS_LONG),
+            entry(NETTY_LOGGING_OFF, AS_BOOLEAN),
             entry(NETTY_MODE, AS_PROFILE),
             entry(QUERIES_BLOB_LOOK_UP_RETRIES, AS_INT),
             entry(NETTY_START_RETRIES, AS_INT),

--- a/hedera-node/hedera-mono-service/src/main/resources/bootstrap.properties
+++ b/hedera-node/hedera-mono-service/src/main/resources/bootstrap.properties
@@ -190,6 +190,7 @@ hedera.recordStream.logEveryTransaction=false
 hedera.recordStream.compressFilesOnCreation=true
 iss.resetPeriod=60
 iss.roundsToLog=5000
+netty.loggingOff=true
 netty.mode=PROD
 netty.prod.flowControlWindow=10240
 netty.prod.maxConcurrentCalls=10

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/context/properties/BootstrapPropertiesTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/context/properties/BootstrapPropertiesTest.java
@@ -169,6 +169,7 @@ import static com.hedera.node.app.spi.config.PropertyNames.LEDGER_TOKEN_TRANSFER
 import static com.hedera.node.app.spi.config.PropertyNames.LEDGER_TOTAL_TINY_BAR_FLOAT;
 import static com.hedera.node.app.spi.config.PropertyNames.LEDGER_TRANSFERS_MAX_LEN;
 import static com.hedera.node.app.spi.config.PropertyNames.LEDGER_XFER_BAL_CHANGES_MAX_LEN;
+import static com.hedera.node.app.spi.config.PropertyNames.NETTY_LOGGING_OFF;
 import static com.hedera.node.app.spi.config.PropertyNames.NETTY_MODE;
 import static com.hedera.node.app.spi.config.PropertyNames.NETTY_PROD_FLOW_CONTROL_WINDOW;
 import static com.hedera.node.app.spi.config.PropertyNames.NETTY_PROD_KEEP_ALIVE_TIME;
@@ -434,6 +435,7 @@ class BootstrapPropertiesTest {
             entry(LEDGER_SCHEDULE_TX_EXPIRY_TIME_SECS, 1800),
             entry(ISS_RESET_PERIOD, 60),
             entry(ISS_ROUNDS_TO_LOG, 5000),
+            entry(NETTY_LOGGING_OFF, true),
             entry(NETTY_MODE, Profile.PROD),
             entry(NETTY_PROD_FLOW_CONTROL_WINDOW, 10240),
             entry(NETTY_PROD_MAX_CONCURRENT_CALLS, 10),

--- a/hedera-node/hedera-mono-service/src/test/resources/bootstrap.properties
+++ b/hedera-node/hedera-mono-service/src/test/resources/bootstrap.properties
@@ -189,6 +189,7 @@ hedera.recordStream.logEveryTransaction=false
 hedera.recordStream.compressFilesOnCreation=false
 iss.resetPeriod=60
 iss.roundsToLog=5000
+netty.loggingOff=true
 netty.mode=PROD
 netty.prod.flowControlWindow=10240
 netty.prod.maxConcurrentCalls=10

--- a/hedera-node/hedera-mono-service/src/test/resources/bootstrap/standard.properties
+++ b/hedera-node/hedera-mono-service/src/test/resources/bootstrap/standard.properties
@@ -190,6 +190,7 @@ hedera.recordStream.logEveryTransaction=false
 hedera.recordStream.compressFilesOnCreation=true
 iss.resetPeriod=60
 iss.roundsToLog=5000
+netty.loggingOff=true
 netty.mode=PROD
 netty.prod.flowControlWindow=10240
 netty.prod.maxConcurrentCalls=10


### PR DESCRIPTION
**Description**:
 - Closes #5990 
 - When `netty.loggingOff=true` (the default), disables all `java.util.logging` to suppress the possibly verbose warnings from gRPC and Netty to stderr.

**Note to reviewers:** You can locally verify this works by,

1️⃣ Overriding `netty.loggingOff=false` in _data/config/bootstrap.properties_, then adding a line to e.g. the `cryptoTransfer()` method [here](https://github.com/hashgraph/hedera-services/blob/develop/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/grpc/controllers/CryptoController.java#L124) like,
```
    @Override
    public void cryptoTransfer(Transaction signedTxn, StreamObserver<TransactionResponse> observer) {
        // Terminates stream, will cause an internal error in gRPC lib
        super.cryptoTransfer(signedTxn, observer);
        txnHelper.submit(signedTxn, observer, CryptoTransfer);
    }
```

2️⃣ Running Gradle `clean assemble` and then starting the node via a _start-node.sh_ script,
```
#!/usr/bin/env bash
/usr/bin/env java -cp "data/lib/*"  com.swirlds.platform.Browser > >(tee stdout.log) 2>&1
```
located in _hedera-node/_ like,
```
$ ./start-node.sh
```

3️⃣ Submitting a `CryptoTransfer` to the node, e.g. via `CryptoTransferSuite`. You will see in the console (and _stdout.log_),
```
2023-04-06 16:22:29.054 INFO  58   CurrentRecordStreamType - Record stream file header is [6, 0, 36, 1]
Apr 06, 2023 4:22:31 PM io.grpc.internal.SerializingExecutor run
SEVERE: Exception while executing runnable io.grpc.internal.ServerImpl$JumpToApplicationThreadServerStreamListener$1HalfClosed@146d69e1
java.lang.IllegalStateException: Stream was terminated by error, no further calls are allowed
	at com.google.common.base.Preconditions.checkState(Preconditions.java:502)
	at io.grpc.stub.ServerCalls$ServerCallStreamObserverImpl.onNext(ServerCalls.java:374)
	at ...
```

4️⃣ Repeating steps (1)-(3) with `netty.loggingOff=true`.