### PR TITLE
05987 - write human readable state address book during state save.

### DIFF
--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/signed/SignedStateFileUtils.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/signed/SignedStateFileUtils.java
@@ -47,7 +47,7 @@ public final class SignedStateFileUtils {
     /**
      * The name of the file that contains the human-readable address book in the saved state
      */
-    public static final String STATE_ADDRESS_BOOK_FILE_NAME = "stateAddressBook.txt";
+    public static final String CURRENT_ADDRESS_BOOK_FILE_NAME = "currentAddressBook.txt";
 
     /**
      * The signed state file was not versioned before, this byte was introduced to mark a versioned file

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/signed/SignedStateFileUtils.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/signed/SignedStateFileUtils.java
@@ -45,6 +45,11 @@ public final class SignedStateFileUtils {
     public static final String HASH_INFO_FILE_NAME = "hashInfo.txt";
 
     /**
+     * The name of the file that contains the human-readable address book in the saved state
+     */
+    public static final String STATE_ADDRESS_BOOK_FILE_NAME = "stateAddressBook.txt";
+
+    /**
      * The signed state file was not versioned before, this byte was introduced to mark a versioned file
      */
     public static final byte VERSIONED_FILE_BYTE = Byte.MAX_VALUE;

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/signed/SignedStateFileWriter.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/signed/SignedStateFileWriter.java
@@ -23,15 +23,18 @@ import static com.swirlds.logging.LogMarker.STATE_TO_DISK;
 import static com.swirlds.platform.state.signed.SignedStateFileUtils.FILE_VERSION;
 import static com.swirlds.platform.state.signed.SignedStateFileUtils.HASH_INFO_FILE_NAME;
 import static com.swirlds.platform.state.signed.SignedStateFileUtils.SIGNED_STATE_FILE_NAME;
+import static com.swirlds.platform.state.signed.SignedStateFileUtils.STATE_ADDRESS_BOOK_FILE_NAME;
 import static com.swirlds.platform.state.signed.SignedStateFileUtils.VERSIONED_FILE_BYTE;
 
 import com.swirlds.common.io.streams.MerkleDataOutputStream;
 import com.swirlds.common.merkle.utility.MerkleTreeVisualizer;
+import com.swirlds.common.system.address.AddressBook;
 import com.swirlds.logging.payloads.StateSavedToDiskPayload;
 import com.swirlds.platform.Settings;
 import com.swirlds.platform.state.EmergencyRecoveryFile;
 import com.swirlds.platform.state.State;
 import com.swirlds.platform.state.StateSettings;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.BufferedWriter;
 import java.io.FileWriter;
 import java.io.IOException;
@@ -130,6 +133,22 @@ public final class SignedStateFileWriter {
         writeMetadataFile(selfId, directory, signedState);
         writeEmergencyRecoveryFile(directory, signedState);
         Settings.getInstance().writeSettingsUsed(directory);
+        writeStateAddressBookFile(directory, signedState.getAddressBook());
+    }
+
+    /**
+     * Write the state's address book in human-readable form.
+     *
+     * @param directory   the directory to write to
+     * @param addressBook the address book to write
+     */
+    private static void writeStateAddressBookFile(@NonNull final Path directory, @NonNull final AddressBook addressBook)
+            throws IOException {
+        final Path addressBookFile = directory.resolve(STATE_ADDRESS_BOOK_FILE_NAME);
+
+        try (final BufferedWriter writer = new BufferedWriter(new FileWriter(addressBookFile.toFile()))) {
+            writer.write(addressBook.toConfigText());
+        }
     }
 
     /**

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/signed/SignedStateFileWriter.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/signed/SignedStateFileWriter.java
@@ -20,10 +20,10 @@ import static com.swirlds.common.io.utility.FileUtils.executeAndRename;
 import static com.swirlds.common.io.utility.FileUtils.writeAndFlush;
 import static com.swirlds.logging.LogMarker.EXCEPTION;
 import static com.swirlds.logging.LogMarker.STATE_TO_DISK;
+import static com.swirlds.platform.state.signed.SignedStateFileUtils.CURRENT_ADDRESS_BOOK_FILE_NAME;
 import static com.swirlds.platform.state.signed.SignedStateFileUtils.FILE_VERSION;
 import static com.swirlds.platform.state.signed.SignedStateFileUtils.HASH_INFO_FILE_NAME;
 import static com.swirlds.platform.state.signed.SignedStateFileUtils.SIGNED_STATE_FILE_NAME;
-import static com.swirlds.platform.state.signed.SignedStateFileUtils.STATE_ADDRESS_BOOK_FILE_NAME;
 import static com.swirlds.platform.state.signed.SignedStateFileUtils.VERSIONED_FILE_BYTE;
 
 import com.swirlds.common.io.streams.MerkleDataOutputStream;
@@ -144,7 +144,7 @@ public final class SignedStateFileWriter {
      */
     private static void writeStateAddressBookFile(@NonNull final Path directory, @NonNull final AddressBook addressBook)
             throws IOException {
-        final Path addressBookFile = directory.resolve(STATE_ADDRESS_BOOK_FILE_NAME);
+        final Path addressBookFile = directory.resolve(CURRENT_ADDRESS_BOOK_FILE_NAME);
 
         try (final BufferedWriter writer = new BufferedWriter(new FileWriter(addressBookFile.toFile()))) {
             writer.write(addressBook.toConfigText());

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/SignedStateFileReadWriteTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/SignedStateFileReadWriteTest.java
@@ -22,6 +22,7 @@ import static com.swirlds.common.threading.manager.AdHocThreadManager.getStaticT
 import static com.swirlds.platform.state.signed.SignedStateFileReader.readStateFile;
 import static com.swirlds.platform.state.signed.SignedStateFileUtils.HASH_INFO_FILE_NAME;
 import static com.swirlds.platform.state.signed.SignedStateFileUtils.SIGNED_STATE_FILE_NAME;
+import static com.swirlds.platform.state.signed.SignedStateFileUtils.STATE_ADDRESS_BOOK_FILE_NAME;
 import static com.swirlds.platform.state.signed.SignedStateFileUtils.getSignedStateDirectory;
 import static com.swirlds.platform.state.signed.SignedStateFileUtils.getSignedStatesBaseDirectory;
 import static com.swirlds.platform.state.signed.SignedStateFileUtils.getSignedStatesDirectoryForApp;
@@ -150,6 +151,7 @@ class SignedStateFileReadWriteTest {
         final Path stateFile = directory.resolve(SIGNED_STATE_FILE_NAME);
         final Path hashInfoFile = directory.resolve(HASH_INFO_FILE_NAME);
         final Path settingsUsedFile = directory.resolve("settingsUsed.txt");
+        final Path addressBookFile = directory.resolve(STATE_ADDRESS_BOOK_FILE_NAME);
 
         throwIfFileExists(stateFile, hashInfoFile, settingsUsedFile, directory);
         writeSignedStateToDisk(0, directory, signedState, "test");
@@ -157,6 +159,7 @@ class SignedStateFileReadWriteTest {
         assertTrue(exists(stateFile), "state file should exist");
         assertTrue(exists(hashInfoFile), "hash info file should exist");
         assertTrue(exists(settingsUsedFile), "settings used file should exist");
+        assertTrue(exists(addressBookFile), "address book file should exist");
     }
 
     @Test

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/SignedStateFileReadWriteTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/SignedStateFileReadWriteTest.java
@@ -20,9 +20,9 @@ import static com.swirlds.common.io.utility.FileUtils.getAbsolutePath;
 import static com.swirlds.common.io.utility.FileUtils.throwIfFileExists;
 import static com.swirlds.common.threading.manager.AdHocThreadManager.getStaticThreadManager;
 import static com.swirlds.platform.state.signed.SignedStateFileReader.readStateFile;
+import static com.swirlds.platform.state.signed.SignedStateFileUtils.CURRENT_ADDRESS_BOOK_FILE_NAME;
 import static com.swirlds.platform.state.signed.SignedStateFileUtils.HASH_INFO_FILE_NAME;
 import static com.swirlds.platform.state.signed.SignedStateFileUtils.SIGNED_STATE_FILE_NAME;
-import static com.swirlds.platform.state.signed.SignedStateFileUtils.STATE_ADDRESS_BOOK_FILE_NAME;
 import static com.swirlds.platform.state.signed.SignedStateFileUtils.getSignedStateDirectory;
 import static com.swirlds.platform.state.signed.SignedStateFileUtils.getSignedStatesBaseDirectory;
 import static com.swirlds.platform.state.signed.SignedStateFileUtils.getSignedStatesDirectoryForApp;
@@ -151,7 +151,7 @@ class SignedStateFileReadWriteTest {
         final Path stateFile = directory.resolve(SIGNED_STATE_FILE_NAME);
         final Path hashInfoFile = directory.resolve(HASH_INFO_FILE_NAME);
         final Path settingsUsedFile = directory.resolve("settingsUsed.txt");
-        final Path addressBookFile = directory.resolve(STATE_ADDRESS_BOOK_FILE_NAME);
+        final Path addressBookFile = directory.resolve(CURRENT_ADDRESS_BOOK_FILE_NAME);
 
         throwIfFileExists(stateFile, hashInfoFile, settingsUsedFile, directory);
         writeSignedStateToDisk(0, directory, signedState, "test");


### PR DESCRIPTION
**Description**:
Every time a state is saved, a human readable form of the state's address book is written in the directory where the state is saved to. 
- adds `STATE_ADDRESS_BOOK_FILE_NAME` to SignedStateFileUtils.java
- adds `writeStateAddressBookFile()` method to SignedStateFileWriter.java
- adds assertion to unit test to verify existence of written address book.

**Related issue(s)**:

Fixes #5987 

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
