### PR TITLE
fix: update log rollover configuration

### DIFF
--- a/hedera-node/configuration/compose/log4j2.xml
+++ b/hedera-node/configuration/compose/log4j2.xml
@@ -7,49 +7,95 @@
     </Console>
 
     <RollingFile name="RollingFile" fileName="output/hgcaa.log"
-      filePattern="output/hgcaa.log-%d{yyyy-MM-dd}-%i.log">
+      filePattern="output/hgcaa-%d{yyyy-MM-dd}-%i.log.gz">
       <PatternLayout>
         <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %-5p %-4L %c{1} - %m{nolookups}%n</pattern>
       </PatternLayout>
       <Policies>
+        <TimeBasedTriggeringPolicy/>
         <SizeBasedTriggeringPolicy size="100 MB"/>
       </Policies>
-      <DefaultRolloverStrategy max="10"/>
+      <DefaultRolloverStrategy max="20">
+        <Delete basePath="output" maxDepth="1">
+          <IfFileName glob="*/hgcaa-*.log.gz">
+            <IfLastModified age="P3D"/>
+          </IfFileName>
+        </Delete>
+      </DefaultRolloverStrategy>
     </RollingFile>
 
     <RollingFile name="QueriesRollingFile" fileName="output/queries.log"
-      filePattern="output/queries.log-%d{yyyy-MM-dd}-%i.log">
+      filePattern="output/queries-%d{yyyy-MM-dd}-%i.log.gz">
       <BurstFilter level="INFO" rate="50" maxBurst="500"/>
       <PatternLayout>
         <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %-5p %-4L %c{1} - %m{nolookups}%n</pattern>
       </PatternLayout>
       <Policies>
+        <TimeBasedTriggeringPolicy/>
         <SizeBasedTriggeringPolicy size="100 MB"/>
       </Policies>
-      <DefaultRolloverStrategy max="10"/>
+      <DefaultRolloverStrategy max="20">
+        <Delete basePath="output" maxDepth="1">
+          <IfFileName glob="*/queries-*.log.gz">
+            <IfLastModified age="P3D"/>
+          </IfFileName>
+        </Delete>
+      </DefaultRolloverStrategy>
     </RollingFile>
 
     <RollingFile name="fileLog" fileName="output/swirlds.log"
-      filePattern="output/swirlds.log-%d{yyyy-MM-dd}-%i.log">
+      filePattern="output/swirlds-sdk-%d{yyyy-MM-dd}-%i.log.gz">
       <PatternLayout>
         <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %-8sn %-5p %-16marker &lt;%t&gt; %c{1}: %msg{nolookups}%n</pattern>
       </PatternLayout>
       <Policies>
+        <TimeBasedTriggeringPolicy/>
         <SizeBasedTriggeringPolicy size="100 MB"/>
       </Policies>
-      <DefaultRolloverStrategy max="10"/>
+      <DefaultRolloverStrategy max="20">
+        <Delete basePath="output" maxDepth="1">
+          <IfFileName glob="*/swirlds-sdk-*.log.gz">
+            <IfLastModified age="P10D"/>
+          </IfFileName>
+        </Delete>
+      </DefaultRolloverStrategy>
+    </RollingFile>
+
+    <RollingFile name="vMapLog" fileName="output/swirlds-vmap.log"
+      filePattern="output/swirlds-vmap-%d{yyyy-MM-dd}-%i.log.gz">
+      <PatternLayout>
+        <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %-8sn %-5p %-16marker &lt;%t&gt; %c{1}: %msg{nolookups}%n</pattern>
+      </PatternLayout>
+      <Policies>
+        <TimeBasedTriggeringPolicy/>
+        <SizeBasedTriggeringPolicy size="100 MB"/>
+      </Policies>
+      <DefaultRolloverStrategy max="20">
+        <Delete basePath="output" maxDepth="1">
+          <IfFileName glob="*/swirlds-vmap-*.log.gz">
+            <IfLastModified age="P3D"/>
+          </IfFileName>
+        </Delete>
+      </DefaultRolloverStrategy>
     </RollingFile>
 
     <!-- Platform hash stream logs -->
     <RollingFile name="swirldsHashStream" fileName="output/swirlds-hashstream/swirlds-hashstream.log"
-                 filePattern="output/swirlds-hashstream/swirlds-hashstream.log-%d{yyyy-MM-dd}-%i.log">
+      filePattern="output/swirlds-hashstream/swirlds-hashstream-%d{yyyy-MM-dd}-%i.log.gz">
       <PatternLayout>
         <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %-8sn %-5p %-16marker &lt;%t&gt; %c{1}: %msg{nolookups}%n</pattern>
       </PatternLayout>
       <Policies>
+        <TimeBasedTriggeringPolicy/>
         <SizeBasedTriggeringPolicy size="100 MB"/>
       </Policies>
-      <DefaultRolloverStrategy max="10"/>
+      <DefaultRolloverStrategy max="20">
+        <Delete basePath="output" maxDepth="1">
+          <IfFileName glob="*/swirlds-hashstream/swirlds-hashstream-*.log.gz">
+            <IfLastModified age="P3D"/>
+          </IfFileName>
+        </Delete>
+      </DefaultRolloverStrategy>
     </RollingFile>
 
   </Appenders>
@@ -60,7 +106,34 @@
     </Root>
 
     <Logger name="com.swirlds" level="INFO" additivity="false">
-      <AppenderRef ref="fileLog" />
+      <AppenderRef ref="fileLog">
+        <Filters>
+          <!-- JasperDB / MerkleDb & Virtual Merkle -->
+          <MarkerFilter marker="JASPER_DB"              onMatch="DENY" onMismatch="NEUTRAL"/>
+          <MarkerFilter marker="MERKLE_DB"              onMatch="DENY" onMismatch="NEUTRAL"/>
+          <MarkerFilter marker="VIRTUAL_MERKLE_STATS"   onMatch="DENY" onMismatch="NEUTRAL"/>
+          <MarkerFilter marker="STATE_HASH"             onMatch="DENY" onMismatch="NEUTRAL"/>
+        </Filters>
+      </AppenderRef>
+
+      <AppenderRef ref="vMapLog">
+        <Filters>
+          <!-- JasperDB / MerkleDb & Virtual Merkle -->
+          <MarkerFilter marker="JASPER_DB"              onMatch="ACCEPT" onMismatch="NEUTRAL"/>
+          <MarkerFilter marker="MERKLE_DB"              onMatch="ACCEPT" onMismatch="NEUTRAL"/>
+          <MarkerFilter marker="VIRTUAL_MERKLE_STATS"   onMatch="ACCEPT" onMismatch="NEUTRAL"/>
+          <MarkerFilter marker="DISABLED"               onMatch="DENY"   onMismatch="DENY" />
+        </Filters>
+      </AppenderRef>
+
+      <AppenderRef ref="swirldsHashStream">
+        <Filters>
+          <!-- Hash stream log -->
+          <MarkerFilter marker="STATE_HASH"             onMatch="ACCEPT"  onMismatch="NEUTRAL"/>
+          <MarkerFilter marker="DISABLED"               onMatch="DENY"    onMismatch="DENY" />
+        </Filters>
+      </AppenderRef>
+
       <!--
 	  Due to known log4j2 issues with how Markers and LogLevels are evaluated there must be a top level <Filter> element
 	  to ensure that the root logger does not execute all the lambda arguments erroneously. Potential work around in the
@@ -69,7 +142,7 @@
 	  -->
       <Filters>
         <!-- Filter out levels above INFO (ex: DEBUG & TRACE) -->
-        <!-- Intentially left disabled by default -->
+        <!-- Intentionally left disabled by default -->
         <!-- <ThresholdFilter level="INFO"                 onMatch="NEUTRAL" onMismatch="DENY" />-->
 
         <!-- In the following, enable a marker with onMatch="ACCEPT" and disable with onMatch="DENY". -->
@@ -127,7 +200,7 @@
         <!-- Saved States -->
         <MarkerFilter marker="SNAPSHOT_MANAGER"       onMatch="ACCEPT" onMismatch="NEUTRAL"/>
         <MarkerFilter marker="STATE_TO_DISK"          onMatch="ACCEPT" onMismatch="NEUTRAL"/>
-        <MarkerFilter marker="STATE_HASH"             onMatch="DENY"   onMismatch="NEUTRAL"/>
+        <MarkerFilter marker="STATE_HASH"             onMatch="ACCEPT" onMismatch="NEUTRAL"/>
 
         <!-- Beta Mirror -->
         <MarkerFilter marker="BETA_MIRROR_NODE"       onMatch="ACCEPT" onMismatch="NEUTRAL"/>
@@ -146,6 +219,11 @@
         <MarkerFilter marker="MERKLE_HASHING"         onMatch="DENY"   onMismatch="NEUTRAL"/>
         <MarkerFilter marker="MERKLE_GENERATION"      onMatch="DENY"   onMismatch="NEUTRAL"/>
         <MarkerFilter marker="MERKLE_LOCKS"           onMatch="DENY"   onMismatch="NEUTRAL"/>
+
+        <!-- JasperDB / MerkleDb & Virtual Merkle -->
+        <MarkerFilter marker="JASPER_DB"              onMatch="ACCEPT" onMismatch="NEUTRAL"/>
+        <MarkerFilter marker="MERKLE_DB"              onMatch="ACCEPT" onMismatch="NEUTRAL"/>
+        <MarkerFilter marker="VIRTUAL_MERKLE_STATS"   onMatch="ACCEPT" onMismatch="NEUTRAL"/>
 
         <MarkerFilter marker="DISABLED"               onMatch="DENY"   onMismatch="DENY" />
       </Filters>
@@ -203,7 +281,7 @@
       <!-- <AppenderRef ref="Console"/> -->
       <AppenderRef ref="RollingFile"/>
     </Logger>
-	<Logger name="com.hedera.services.legacy.config" level="info" additivity="false">
+  	<Logger name="com.hedera.services.legacy.config" level="info" additivity="false">
       <AppenderRef ref="RollingFile"/>
       <AppenderRef ref="Console"/>
     </Logger>

--- a/hedera-node/configuration/dev/log4j2.xml
+++ b/hedera-node/configuration/dev/log4j2.xml
@@ -7,60 +7,95 @@
     </Console>
 
     <RollingFile name="RollingFile" fileName="output/hgcaa.log"
-      filePattern="output/hgcaa.log-%d{yyyy-MM-dd}-%i.log">
+      filePattern="output/hgcaa-%d{yyyy-MM-dd}-%i.log.gz">
       <PatternLayout>
         <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %-5p %-4L %c{1} - %m{nolookups}%n</pattern>
       </PatternLayout>
       <Policies>
+        <TimeBasedTriggeringPolicy/>
         <SizeBasedTriggeringPolicy size="100 MB"/>
       </Policies>
-      <DefaultRolloverStrategy max="10"/>
+      <DefaultRolloverStrategy max="20">
+        <Delete basePath="output" maxDepth="1">
+          <IfFileName glob="*/hgcaa-*.log.gz">
+            <IfLastModified age="P3D"/>
+          </IfFileName>
+        </Delete>
+      </DefaultRolloverStrategy>
     </RollingFile>
 
     <RollingFile name="QueriesRollingFile" fileName="output/queries.log"
-      filePattern="output/queries.log-%d{yyyy-MM-dd}-%i.log">
+      filePattern="output/queries-%d{yyyy-MM-dd}-%i.log.gz">
       <BurstFilter level="INFO" rate="50" maxBurst="500"/>
       <PatternLayout>
         <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %-5p %-4L %c{1} - %m{nolookups}%n</pattern>
       </PatternLayout>
       <Policies>
+        <TimeBasedTriggeringPolicy/>
         <SizeBasedTriggeringPolicy size="100 MB"/>
       </Policies>
-      <DefaultRolloverStrategy max="10"/>
+      <DefaultRolloverStrategy max="20">
+        <Delete basePath="output" maxDepth="1">
+          <IfFileName glob="*/queries-*.log.gz">
+            <IfLastModified age="P3D"/>
+          </IfFileName>
+        </Delete>
+      </DefaultRolloverStrategy>
     </RollingFile>
 
     <RollingFile name="fileLog" fileName="output/swirlds.log"
-      filePattern="output/swirlds.log-%d{yyyy-MM-dd}-%i.log">
+      filePattern="output/swirlds-sdk-%d{yyyy-MM-dd}-%i.log.gz">
       <PatternLayout>
         <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %-8sn %-5p %-16marker &lt;%t&gt; %c{1}: %msg{nolookups}%n</pattern>
       </PatternLayout>
       <Policies>
+        <TimeBasedTriggeringPolicy/>
         <SizeBasedTriggeringPolicy size="100 MB"/>
       </Policies>
-      <DefaultRolloverStrategy max="10"/>
+      <DefaultRolloverStrategy max="20">
+        <Delete basePath="output" maxDepth="1">
+          <IfFileName glob="*/swirlds-sdk-*.log.gz">
+            <IfLastModified age="P10D"/>
+          </IfFileName>
+        </Delete>
+      </DefaultRolloverStrategy>
     </RollingFile>
 
     <RollingFile name="vMapLog" fileName="output/swirlds-vmap.log"
-                 filePattern="output/swirlds-vmap.log-%d{yyyy-MM-dd}-%i.log">
+      filePattern="output/swirlds-vmap-%d{yyyy-MM-dd}-%i.log.gz">
       <PatternLayout>
         <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %-8sn %-5p %-16marker &lt;%t&gt; %c{1}: %msg{nolookups}%n</pattern>
       </PatternLayout>
       <Policies>
+        <TimeBasedTriggeringPolicy/>
         <SizeBasedTriggeringPolicy size="100 MB"/>
       </Policies>
-      <DefaultRolloverStrategy max="10"/>
+      <DefaultRolloverStrategy max="20">
+        <Delete basePath="output" maxDepth="1">
+          <IfFileName glob="*/swirlds-vmap-*.log.gz">
+            <IfLastModified age="P3D"/>
+          </IfFileName>
+        </Delete>
+      </DefaultRolloverStrategy>
     </RollingFile>
 
     <!-- Platform hash stream logs -->
     <RollingFile name="swirldsHashStream" fileName="output/swirlds-hashstream/swirlds-hashstream.log"
-                             filePattern="output/swirlds-hashstream/swirlds-hashstream.log-%d{yyyy-MM-dd}-%i.log">
+      filePattern="output/swirlds-hashstream/swirlds-hashstream-%d{yyyy-MM-dd}-%i.log.gz">
       <PatternLayout>
         <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %-8sn %-5p %-16marker &lt;%t&gt; %c{1}: %msg{nolookups}%n</pattern>
       </PatternLayout>
       <Policies>
+        <TimeBasedTriggeringPolicy/>
         <SizeBasedTriggeringPolicy size="100 MB"/>
       </Policies>
-      <DefaultRolloverStrategy max="10"/>
+      <DefaultRolloverStrategy max="20">
+        <Delete basePath="output" maxDepth="1">
+          <IfFileName glob="*/swirlds-hashstream/swirlds-hashstream-*.log.gz">
+            <IfLastModified age="P3D"/>
+          </IfFileName>
+        </Delete>
+      </DefaultRolloverStrategy>
     </RollingFile>
 
   </Appenders>
@@ -185,7 +220,7 @@
         <MarkerFilter marker="MERKLE_GENERATION"      onMatch="DENY"   onMismatch="NEUTRAL"/>
         <MarkerFilter marker="MERKLE_LOCKS"           onMatch="DENY"   onMismatch="NEUTRAL"/>
 
-        <!-- JasperDB / MerkleDd & Virtual Merkle -->
+        <!-- JasperDB / MerkleDb & Virtual Merkle -->
         <MarkerFilter marker="JASPER_DB"              onMatch="ACCEPT" onMismatch="NEUTRAL"/>
         <MarkerFilter marker="MERKLE_DB"              onMatch="ACCEPT" onMismatch="NEUTRAL"/>
         <MarkerFilter marker="VIRTUAL_MERKLE_STATS"   onMatch="ACCEPT" onMismatch="NEUTRAL"/>
@@ -246,7 +281,7 @@
       <!-- <AppenderRef ref="Console"/> -->
       <AppenderRef ref="RollingFile"/>
     </Logger>
-	<Logger name="com.hedera.services.legacy.config" level="info" additivity="false">
+  	<Logger name="com.hedera.services.legacy.config" level="info" additivity="false">
       <AppenderRef ref="RollingFile"/>
       <AppenderRef ref="Console"/>
     </Logger>

--- a/hedera-node/configuration/mainnet/log4j2.xml
+++ b/hedera-node/configuration/mainnet/log4j2.xml
@@ -7,61 +7,97 @@
     </Console>
 
     <RollingFile name="RollingFile" fileName="output/hgcaa.log"
-      filePattern="output/hgcaa.log-%d{yyyy-MM-dd}-%i.log">
+      filePattern="output/hgcaa-%d{yyyy-MM-dd}-%i.log.gz">
       <PatternLayout>
         <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %-5p %-4L %c{1} - %m{nolookups}%n</pattern>
       </PatternLayout>
       <Policies>
+        <TimeBasedTriggeringPolicy/>
         <SizeBasedTriggeringPolicy size="100 MB"/>
       </Policies>
-      <DefaultRolloverStrategy max="10"/>
+      <DefaultRolloverStrategy max="20">
+        <Delete basePath="output" maxDepth="1">
+          <IfFileName glob="*/hgcaa-*.log.gz">
+            <IfLastModified age="P3D"/>
+          </IfFileName>
+        </Delete>
+      </DefaultRolloverStrategy>
     </RollingFile>
 
     <RollingFile name="QueriesRollingFile" fileName="output/queries.log"
-      filePattern="output/queries.log-%d{yyyy-MM-dd}-%i.log">
+      filePattern="output/queries-%d{yyyy-MM-dd}-%i.log.gz">
       <BurstFilter level="INFO" rate="50" maxBurst="500"/>
       <PatternLayout>
         <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %-5p %-4L %c{1} - %m{nolookups}%n</pattern>
       </PatternLayout>
       <Policies>
+        <TimeBasedTriggeringPolicy/>
         <SizeBasedTriggeringPolicy size="100 MB"/>
       </Policies>
-      <DefaultRolloverStrategy max="10"/>
+      <DefaultRolloverStrategy max="20">
+        <Delete basePath="output" maxDepth="1">
+          <IfFileName glob="*/queries-*.log.gz">
+            <IfLastModified age="P3D"/>
+          </IfFileName>
+        </Delete>
+      </DefaultRolloverStrategy>
     </RollingFile>
 
     <RollingFile name="fileLog" fileName="output/swirlds.log"
-      filePattern="output/swirlds.log-%d{yyyy-MM-dd}-%i.log">
+      filePattern="output/swirlds-sdk-%d{yyyy-MM-dd}-%i.log.gz">
       <PatternLayout>
         <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %-8sn %-5p %-16marker &lt;%t&gt; %c{1}: %msg{nolookups}%n</pattern>
       </PatternLayout>
       <Policies>
+        <TimeBasedTriggeringPolicy/>
         <SizeBasedTriggeringPolicy size="100 MB"/>
       </Policies>
-      <DefaultRolloverStrategy max="10"/>
+      <DefaultRolloverStrategy max="20">
+        <Delete basePath="output" maxDepth="1">
+          <IfFileName glob="*/swirlds-sdk-*.log.gz">
+            <IfLastModified age="P10D"/>
+          </IfFileName>
+        </Delete>
+      </DefaultRolloverStrategy>
     </RollingFile>
 
     <RollingFile name="vMapLog" fileName="output/swirlds-vmap.log"
-                 filePattern="output/swirlds-vmap.log-%d{yyyy-MM-dd}-%i.log">
+      filePattern="output/swirlds-vmap-%d{yyyy-MM-dd}-%i.log.gz">
       <PatternLayout>
         <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %-8sn %-5p %-16marker &lt;%t&gt; %c{1}: %msg{nolookups}%n</pattern>
       </PatternLayout>
       <Policies>
+        <TimeBasedTriggeringPolicy/>
         <SizeBasedTriggeringPolicy size="100 MB"/>
       </Policies>
-      <DefaultRolloverStrategy max="10"/>
+      <DefaultRolloverStrategy max="20">
+        <Delete basePath="output" maxDepth="1">
+          <IfFileName glob="*/swirlds-vmap-*.log.gz">
+            <IfLastModified age="P3D"/>
+          </IfFileName>
+        </Delete>
+      </DefaultRolloverStrategy>
     </RollingFile>
 
     <!-- Platform hash stream logs -->
     <RollingFile name="swirldsHashStream" fileName="output/swirlds-hashstream/swirlds-hashstream.log"
-                 filePattern="output/swirlds-hashstream/swirlds-hashstream.log-%d{yyyy-MM-dd}-%i.log">
+      filePattern="output/swirlds-hashstream/swirlds-hashstream-%d{yyyy-MM-dd}-%i.log.gz">
       <PatternLayout>
         <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %-8sn %-5p %-16marker &lt;%t&gt; %c{1}: %msg{nolookups}%n</pattern>
       </PatternLayout>
       <Policies>
+        <TimeBasedTriggeringPolicy/>
         <SizeBasedTriggeringPolicy size="100 MB"/>
       </Policies>
-      <DefaultRolloverStrategy max="10"/>
+      <DefaultRolloverStrategy max="20">
+        <Delete basePath="output" maxDepth="1">
+          <IfFileName glob="*/swirlds-hashstream/swirlds-hashstream-*.log.gz">
+            <IfLastModified age="P3D"/>
+          </IfFileName>
+        </Delete>
+      </DefaultRolloverStrategy>
     </RollingFile>
+
   </Appenders>
   <Loggers>
     <Root level="FATAL">
@@ -97,6 +133,7 @@
           <MarkerFilter marker="DISABLED"               onMatch="DENY"    onMismatch="DENY" />
         </Filters>
       </AppenderRef>
+
       <!--
 	  Due to known log4j2 issues with how Markers and LogLevels are evaluated there must be a top level <Filter> element
 	  to ensure that the root logger does not execute all the lambda arguments erroneously. Potential work around in the
@@ -163,7 +200,7 @@
         <!-- Saved States -->
         <MarkerFilter marker="SNAPSHOT_MANAGER"       onMatch="ACCEPT" onMismatch="NEUTRAL"/>
         <MarkerFilter marker="STATE_TO_DISK"          onMatch="ACCEPT" onMismatch="NEUTRAL"/>
-        <MarkerFilter marker="STATE_HASH"             onMatch="ACCEPT"   onMismatch="NEUTRAL"/>
+        <MarkerFilter marker="STATE_HASH"             onMatch="ACCEPT" onMismatch="NEUTRAL"/>
 
         <!-- Beta Mirror -->
         <MarkerFilter marker="BETA_MIRROR_NODE"       onMatch="ACCEPT" onMismatch="NEUTRAL"/>
@@ -244,7 +281,7 @@
       <!-- <AppenderRef ref="Console"/> -->
       <AppenderRef ref="RollingFile"/>
     </Logger>
-	<Logger name="com.hedera.services.legacy.config" level="info" additivity="false">
+  	<Logger name="com.hedera.services.legacy.config" level="info" additivity="false">
       <AppenderRef ref="RollingFile"/>
       <AppenderRef ref="Console"/>
     </Logger>

--- a/hedera-node/configuration/preprod/log4j2.xml
+++ b/hedera-node/configuration/preprod/log4j2.xml
@@ -21,11 +21,6 @@
             <IfLastModified age="P3D"/>
           </IfFileName>
         </Delete>
-        <Delete basePath="output" maxDepth="1">
-          <IfFileName glob="*/hgcaa.log-*.log">
-            <IfLastModified age="P3D"/>
-          </IfFileName>
-        </Delete>
       </DefaultRolloverStrategy>
     </RollingFile>
 
@@ -45,16 +40,11 @@
             <IfLastModified age="P3D"/>
           </IfFileName>
         </Delete>
-        <Delete basePath="output" maxDepth="1">
-          <IfFileName glob="*/queries.log-*.log">
-            <IfLastModified age="P3D"/>
-          </IfFileName>
-        </Delete>
       </DefaultRolloverStrategy>
     </RollingFile>
 
     <RollingFile name="fileLog" fileName="output/swirlds.log"
-      filePattern="output/swirlds-sdk-%d{yyyy-MM-dd}-%i.log">
+      filePattern="output/swirlds-sdk-%d{yyyy-MM-dd}-%i.log.gz">
       <PatternLayout>
         <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %-8sn %-5p %-16marker &lt;%t&gt; %c{1}: %msg{nolookups}%n</pattern>
       </PatternLayout>
@@ -68,16 +58,11 @@
             <IfLastModified age="P10D"/>
           </IfFileName>
         </Delete>
-        <Delete basePath="output" maxDepth="1">
-          <IfFileName glob="*/swirlds.log-*.log">
-            <IfLastModified age="P10D"/>
-          </IfFileName>
-        </Delete>
       </DefaultRolloverStrategy>
     </RollingFile>
 
     <RollingFile name="vMapLog" fileName="output/swirlds-vmap.log"
-      filePattern="output/swirlds-vmap-%d{yyyy-MM-dd}-%i.log">
+      filePattern="output/swirlds-vmap-%d{yyyy-MM-dd}-%i.log.gz">
       <PatternLayout>
         <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %-8sn %-5p %-16marker &lt;%t&gt; %c{1}: %msg{nolookups}%n</pattern>
       </PatternLayout>
@@ -91,17 +76,12 @@
             <IfLastModified age="P3D"/>
           </IfFileName>
         </Delete>
-        <Delete basePath="output" maxDepth="1">
-          <IfFileName glob="*/swirlds-vmap.log-*.log">
-            <IfLastModified age="P3D"/>
-          </IfFileName>
-        </Delete>
       </DefaultRolloverStrategy>
     </RollingFile>
 
     <!-- Platform hash stream logs -->
     <RollingFile name="swirldsHashStream" fileName="output/swirlds-hashstream/swirlds-hashstream.log"
-      filePattern="output/swirlds-hashstream/swirlds-hashstream-%d{yyyy-MM-dd}-%i.log">
+      filePattern="output/swirlds-hashstream/swirlds-hashstream-%d{yyyy-MM-dd}-%i.log.gz">
       <PatternLayout>
         <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %-8sn %-5p %-16marker &lt;%t&gt; %c{1}: %msg{nolookups}%n</pattern>
       </PatternLayout>
@@ -112,11 +92,6 @@
       <DefaultRolloverStrategy max="20">
         <Delete basePath="output" maxDepth="1">
           <IfFileName glob="*/swirlds-hashstream/swirlds-hashstream-*.log.gz">
-            <IfLastModified age="P3D"/>
-          </IfFileName>
-        </Delete>
-        <Delete basePath="output" maxDepth="1">
-          <IfFileName glob="*/swirlds-hashstream/swirlds-hashstream.log-*.log">
             <IfLastModified age="P3D"/>
           </IfFileName>
         </Delete>

--- a/hedera-node/configuration/previewnet/log4j2.xml
+++ b/hedera-node/configuration/previewnet/log4j2.xml
@@ -7,60 +7,95 @@
     </Console>
 
     <RollingFile name="RollingFile" fileName="output/hgcaa.log"
-      filePattern="output/hgcaa.log-%d{yyyy-MM-dd}-%i.log">
+      filePattern="output/hgcaa-%d{yyyy-MM-dd}-%i.log.gz">
       <PatternLayout>
         <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %-5p %-4L %c{1} - %m{nolookups}%n</pattern>
       </PatternLayout>
       <Policies>
+        <TimeBasedTriggeringPolicy/>
         <SizeBasedTriggeringPolicy size="100 MB"/>
       </Policies>
-      <DefaultRolloverStrategy max="10"/>
+      <DefaultRolloverStrategy max="20">
+        <Delete basePath="output" maxDepth="1">
+          <IfFileName glob="*/hgcaa-*.log.gz">
+            <IfLastModified age="P3D"/>
+          </IfFileName>
+        </Delete>
+      </DefaultRolloverStrategy>
     </RollingFile>
 
     <RollingFile name="QueriesRollingFile" fileName="output/queries.log"
-      filePattern="output/queries.log-%d{yyyy-MM-dd}-%i.log">
+      filePattern="output/queries-%d{yyyy-MM-dd}-%i.log.gz">
       <BurstFilter level="INFO" rate="50" maxBurst="500"/>
       <PatternLayout>
         <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %-5p %-4L %c{1} - %m{nolookups}%n</pattern>
       </PatternLayout>
       <Policies>
+        <TimeBasedTriggeringPolicy/>
         <SizeBasedTriggeringPolicy size="100 MB"/>
       </Policies>
-      <DefaultRolloverStrategy max="10"/>
+      <DefaultRolloverStrategy max="20">
+        <Delete basePath="output" maxDepth="1">
+          <IfFileName glob="*/queries-*.log.gz">
+            <IfLastModified age="P3D"/>
+          </IfFileName>
+        </Delete>
+      </DefaultRolloverStrategy>
     </RollingFile>
 
     <RollingFile name="fileLog" fileName="output/swirlds.log"
-      filePattern="output/swirlds.log-%d{yyyy-MM-dd}-%i.log">
+      filePattern="output/swirlds-sdk-%d{yyyy-MM-dd}-%i.log.gz">
       <PatternLayout>
         <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %-8sn %-5p %-16marker &lt;%t&gt; %c{1}: %msg{nolookups}%n</pattern>
       </PatternLayout>
       <Policies>
+        <TimeBasedTriggeringPolicy/>
         <SizeBasedTriggeringPolicy size="100 MB"/>
       </Policies>
-      <DefaultRolloverStrategy max="10"/>
+      <DefaultRolloverStrategy max="20">
+        <Delete basePath="output" maxDepth="1">
+          <IfFileName glob="*/swirlds-sdk-*.log.gz">
+            <IfLastModified age="P10D"/>
+          </IfFileName>
+        </Delete>
+      </DefaultRolloverStrategy>
     </RollingFile>
 
     <RollingFile name="vMapLog" fileName="output/swirlds-vmap.log"
-                 filePattern="output/swirlds-vmap.log-%d{yyyy-MM-dd}-%i.log">
+      filePattern="output/swirlds-vmap-%d{yyyy-MM-dd}-%i.log.gz">
       <PatternLayout>
         <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %-8sn %-5p %-16marker &lt;%t&gt; %c{1}: %msg{nolookups}%n</pattern>
       </PatternLayout>
       <Policies>
+        <TimeBasedTriggeringPolicy/>
         <SizeBasedTriggeringPolicy size="100 MB"/>
       </Policies>
-      <DefaultRolloverStrategy max="10"/>
+      <DefaultRolloverStrategy max="20">
+        <Delete basePath="output" maxDepth="1">
+          <IfFileName glob="*/swirlds-vmap-*.log.gz">
+            <IfLastModified age="P3D"/>
+          </IfFileName>
+        </Delete>
+      </DefaultRolloverStrategy>
     </RollingFile>
 
     <!-- Platform hash stream logs -->
     <RollingFile name="swirldsHashStream" fileName="output/swirlds-hashstream/swirlds-hashstream.log"
-                 filePattern="output/swirlds-hashstream/swirlds-hashstream.log-%d{yyyy-MM-dd}-%i.log">
+      filePattern="output/swirlds-hashstream/swirlds-hashstream-%d{yyyy-MM-dd}-%i.log.gz">
       <PatternLayout>
         <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %-8sn %-5p %-16marker &lt;%t&gt; %c{1}: %msg{nolookups}%n</pattern>
       </PatternLayout>
       <Policies>
+        <TimeBasedTriggeringPolicy/>
         <SizeBasedTriggeringPolicy size="100 MB"/>
       </Policies>
-      <DefaultRolloverStrategy max="10"/>
+      <DefaultRolloverStrategy max="20">
+        <Delete basePath="output" maxDepth="1">
+          <IfFileName glob="*/swirlds-hashstream/swirlds-hashstream-*.log.gz">
+            <IfLastModified age="P3D"/>
+          </IfFileName>
+        </Delete>
+      </DefaultRolloverStrategy>
     </RollingFile>
 
   </Appenders>
@@ -246,7 +281,7 @@
       <!-- <AppenderRef ref="Console"/> -->
       <AppenderRef ref="RollingFile"/>
     </Logger>
-	<Logger name="com.hedera.services.legacy.config" level="info" additivity="false">
+  	<Logger name="com.hedera.services.legacy.config" level="info" additivity="false">
       <AppenderRef ref="RollingFile"/>
       <AppenderRef ref="Console"/>
     </Logger>

--- a/hedera-node/configuration/testnet/log4j2.xml
+++ b/hedera-node/configuration/testnet/log4j2.xml
@@ -7,60 +7,95 @@
     </Console>
 
     <RollingFile name="RollingFile" fileName="output/hgcaa.log"
-      filePattern="output/hgcaa.log-%d{yyyy-MM-dd}-%i.log">
+      filePattern="output/hgcaa-%d{yyyy-MM-dd}-%i.log.gz">
       <PatternLayout>
         <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %-5p %-4L %c{1} - %m{nolookups}%n</pattern>
       </PatternLayout>
       <Policies>
+        <TimeBasedTriggeringPolicy/>
         <SizeBasedTriggeringPolicy size="100 MB"/>
       </Policies>
-      <DefaultRolloverStrategy max="10"/>
+      <DefaultRolloverStrategy max="20">
+        <Delete basePath="output" maxDepth="1">
+          <IfFileName glob="*/hgcaa-*.log.gz">
+            <IfLastModified age="P3D"/>
+          </IfFileName>
+        </Delete>
+      </DefaultRolloverStrategy>
     </RollingFile>
 
     <RollingFile name="QueriesRollingFile" fileName="output/queries.log"
-      filePattern="output/queries.log-%d{yyyy-MM-dd}-%i.log">
+      filePattern="output/queries-%d{yyyy-MM-dd}-%i.log.gz">
       <BurstFilter level="INFO" rate="50" maxBurst="500"/>
       <PatternLayout>
         <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %-5p %-4L %c{1} - %m{nolookups}%n</pattern>
       </PatternLayout>
       <Policies>
+        <TimeBasedTriggeringPolicy/>
         <SizeBasedTriggeringPolicy size="100 MB"/>
       </Policies>
-      <DefaultRolloverStrategy max="10"/>
+      <DefaultRolloverStrategy max="20">
+        <Delete basePath="output" maxDepth="1">
+          <IfFileName glob="*/queries-*.log.gz">
+            <IfLastModified age="P3D"/>
+          </IfFileName>
+        </Delete>
+      </DefaultRolloverStrategy>
     </RollingFile>
 
     <RollingFile name="fileLog" fileName="output/swirlds.log"
-      filePattern="output/swirlds.log-%d{yyyy-MM-dd}-%i.log">
+      filePattern="output/swirlds-sdk-%d{yyyy-MM-dd}-%i.log.gz">
       <PatternLayout>
         <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %-8sn %-5p %-16marker &lt;%t&gt; %c{1}: %msg{nolookups}%n</pattern>
       </PatternLayout>
       <Policies>
+        <TimeBasedTriggeringPolicy/>
         <SizeBasedTriggeringPolicy size="100 MB"/>
       </Policies>
-      <DefaultRolloverStrategy max="10"/>
+      <DefaultRolloverStrategy max="20">
+        <Delete basePath="output" maxDepth="1">
+          <IfFileName glob="*/swirlds-sdk-*.log.gz">
+            <IfLastModified age="P10D"/>
+          </IfFileName>
+        </Delete>
+      </DefaultRolloverStrategy>
     </RollingFile>
 
     <RollingFile name="vMapLog" fileName="output/swirlds-vmap.log"
-                 filePattern="output/swirlds-vmap.log-%d{yyyy-MM-dd}-%i.log">
+      filePattern="output/swirlds-vmap-%d{yyyy-MM-dd}-%i.log.gz">
       <PatternLayout>
         <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %-8sn %-5p %-16marker &lt;%t&gt; %c{1}: %msg{nolookups}%n</pattern>
       </PatternLayout>
       <Policies>
+        <TimeBasedTriggeringPolicy/>
         <SizeBasedTriggeringPolicy size="100 MB"/>
       </Policies>
-      <DefaultRolloverStrategy max="10"/>
+      <DefaultRolloverStrategy max="20">
+        <Delete basePath="output" maxDepth="1">
+          <IfFileName glob="*/swirlds-vmap-*.log.gz">
+            <IfLastModified age="P3D"/>
+          </IfFileName>
+        </Delete>
+      </DefaultRolloverStrategy>
     </RollingFile>
 
     <!-- Platform hash stream logs -->
     <RollingFile name="swirldsHashStream" fileName="output/swirlds-hashstream/swirlds-hashstream.log"
-                 filePattern="output/swirlds-hashstream/swirlds-hashstream.log-%d{yyyy-MM-dd}-%i.log">
+      filePattern="output/swirlds-hashstream/swirlds-hashstream-%d{yyyy-MM-dd}-%i.log.gz">
       <PatternLayout>
         <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %-8sn %-5p %-16marker &lt;%t&gt; %c{1}: %msg{nolookups}%n</pattern>
       </PatternLayout>
       <Policies>
+        <TimeBasedTriggeringPolicy/>
         <SizeBasedTriggeringPolicy size="100 MB"/>
       </Policies>
-      <DefaultRolloverStrategy max="10"/>
+      <DefaultRolloverStrategy max="20">
+        <Delete basePath="output" maxDepth="1">
+          <IfFileName glob="*/swirlds-hashstream/swirlds-hashstream-*.log.gz">
+            <IfLastModified age="P3D"/>
+          </IfFileName>
+        </Delete>
+      </DefaultRolloverStrategy>
     </RollingFile>
 
   </Appenders>
@@ -246,7 +281,7 @@
       <!-- <AppenderRef ref="Console"/> -->
       <AppenderRef ref="RollingFile"/>
     </Logger>
-	<Logger name="com.hedera.services.legacy.config" level="info" additivity="false">
+  	<Logger name="com.hedera.services.legacy.config" level="info" additivity="false">
       <AppenderRef ref="RollingFile"/>
       <AppenderRef ref="Console"/>
     </Logger>


### PR DESCRIPTION
## Description

Updates the log4j2 appender configurations to enable time and size based rollovers with automatic cleanup. Additionally, this enables automatic gzip compression of archived logs.

### Related Issues

- Closes #4745 
