### PR TITLE
Omit auto-renew id if unused in synth `ContractCreateTransactionBody`

### DIFF
--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ledger/accounts/AccountCustomizer.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ledger/accounts/AccountCustomizer.java
@@ -39,6 +39,7 @@ import com.hedera.node.app.service.mono.ledger.properties.BeanProperty;
 import com.hedera.node.app.service.mono.ledger.properties.ChangeSummaryManager;
 import com.hedera.node.app.service.mono.legacy.core.jproto.JKey;
 import com.hedera.node.app.service.mono.state.submerkle.EntityId;
+import edu.umd.cs.findbugs.annotations.Nullable;
 import java.util.EnumMap;
 import java.util.Map;
 
@@ -165,7 +166,13 @@ public abstract class AccountCustomizer<
         return self();
     }
 
-    public T autoRenewAccount(final EntityId option) {
+    /**
+     * Sets the auto-renew account id to be used for an account (or contract) customized with this instance.
+     *
+     * @param option the id of the auto-renew account, or null if none was set
+     * @return this instance
+     */
+    public T autoRenewAccount(@Nullable final EntityId option) {
         if (option != null) {
             changeManager.update(changes, optionProperties.get(AUTO_RENEW_ACCOUNT_ID), option);
         }

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ledger/accounts/ContractCustomizer.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ledger/accounts/ContractCustomizer.java
@@ -22,7 +22,6 @@ import static com.hedera.node.app.service.mono.ledger.properties.AccountProperty
 import static com.hedera.node.app.service.mono.ledger.properties.AccountProperty.EXPIRY;
 import static com.hedera.node.app.service.mono.ledger.properties.AccountProperty.KEY;
 import static com.hedera.node.app.service.mono.ledger.properties.AccountProperty.MEMO;
-import static com.hedera.node.app.service.mono.state.submerkle.EntityId.MISSING_ENTITY_ID;
 import static com.hedera.node.app.service.mono.utils.MiscUtils.asKeyUnchecked;
 
 import com.hedera.node.app.service.mono.ledger.TransactionalLedger;
@@ -70,8 +69,9 @@ public class ContractCustomizer {
         final var expiry = consensusTime.getEpochSecond() + autoRenewPeriod;
 
         final var key = (decodedKey instanceof JContractIDKey) ? null : decodedKey;
+        // The customizer ignores null values, so use null if no auto-renew account is specified
         final var autoRenewAccount =
-                op.hasAutoRenewAccountId() ? EntityId.fromGrpcAccountId(op.getAutoRenewAccountId()) : MISSING_ENTITY_ID;
+                op.hasAutoRenewAccountId() ? EntityId.fromGrpcAccountId(op.getAutoRenewAccountId()) : null;
         final var customizer = new HederaAccountCustomizer()
                 .memo(op.getMemo())
                 .expiry(expiry)


### PR DESCRIPTION
**Description**:
 - Closes #6109 
 - Instead of setting `0.0.0` for an unused auto-renew account id, leaves `ContractCreateTransactionBody`'s `auto_renew_account_id` field unset as expected.
