### PR TITLE
Enable writing pcli plugins in `hedera-services` and provide an example plugin

### DIFF
--- a/hedera-node/cli-clients/build.gradle.kts
+++ b/hedera-node/cli-clients/build.gradle.kts
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+plugins {
+  id("com.hedera.hashgraph.conventions")
+  id("com.hedera.hashgraph.shadow-jar")
+  id("org.gradle.java-test-fixtures")
+}
+
+description = "Hedera Services Command-Line Clients"
+
+tasks.jar { manifest { attributes("Automatic-Module-Name" to "com.hedera.services.cli") } }
+
+configurations.all {
+  exclude("javax.anno0tation", "javax.annotation.api")
+  exclude("com.google.code.findbugs", "jsr305")
+  exclude("org.jetbrains", "annotations")
+  exclude("org.checkerframework", "checker-qual")
+  exclude("org.hamcrest", "hamcrest-core")
+}
+
+dependencies {
+  compileOnly(libs.spotbugs.annotations)
+  implementation(libs.bundles.swirlds)
+  implementation(project(":hedera-node:hedera-mono-service"))
+  implementation(testLibs.classgraph)
+  implementation(testLibs.picocli)
+  testImplementation(testLibs.bundles.testing)
+}

--- a/hedera-node/cli-clients/build.gradle.kts
+++ b/hedera-node/cli-clients/build.gradle.kts
@@ -25,7 +25,7 @@ description = "Hedera Services Command-Line Clients"
 tasks.jar { manifest { attributes("Automatic-Module-Name" to "com.hedera.services.cli") } }
 
 configurations.all {
-  exclude("javax.anno0tation", "javax.annotation.api")
+  exclude("javax.annotation", "javax.annotation.api")
   exclude("com.google.code.findbugs", "jsr305")
   exclude("org.jetbrains", "annotations")
   exclude("org.checkerframework", "checker-qual")
@@ -36,7 +36,6 @@ dependencies {
   compileOnly(libs.spotbugs.annotations)
   implementation(libs.bundles.swirlds)
   implementation(project(":hedera-node:hedera-mono-service"))
-  implementation(testLibs.classgraph)
   implementation(testLibs.picocli)
   testImplementation(testLibs.bundles.testing)
 }

--- a/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/ExamplePcliPlugin.java
+++ b/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/ExamplePcliPlugin.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.services.cli;
+
+import com.hedera.services.cli.signedstate.SummarizeSignedStateFileCommand;
+import com.swirlds.cli.PlatformCli;
+import com.swirlds.cli.utility.AbstractCommand;
+import com.swirlds.cli.utility.SubcommandOf;
+import picocli.CommandLine;
+import picocli.CommandLine.Model.CommandSpec;
+import picocli.CommandLine.ParameterException;
+import picocli.CommandLine.Spec;
+
+@CommandLine.Command(
+        name = "example",
+        mixinStandardHelpOptions = true,
+        description = "Example Pcli Plugin for Services",
+        subcommands = {SummarizeSignedStateFileCommand.class})
+@SubcommandOf(PlatformCli.class)
+public final class ExamplePcliPlugin extends AbstractCommand {
+
+    @Spec
+    CommandSpec spec;
+
+    private ExamplePcliPlugin() {}
+
+    @Override
+    public Integer call() {
+        throw new ParameterException(spec.commandLine(), "Please specify a subcommand!");
+    }
+}

--- a/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/signedstate/SignedStateHolder.java
+++ b/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/signedstate/SignedStateHolder.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.services.cli.signedstate;
+
+import com.hedera.node.app.service.mono.ServicesState;
+import com.hedera.node.app.service.mono.state.adapters.VirtualMapLike;
+import com.hedera.node.app.service.mono.state.migration.AccountStorageAdapter;
+import com.hedera.node.app.service.mono.state.virtual.VirtualBlobKey;
+import com.hedera.node.app.service.mono.state.virtual.VirtualBlobKey.Type;
+import com.hedera.node.app.service.mono.state.virtual.VirtualBlobValue;
+import com.swirlds.common.constructable.ConstructableRegistry;
+import com.swirlds.platform.state.signed.SignedStateFileReader;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Navigates a signed state "file" and returns information from it
+ *
+ * <p>A "signed state" is actually a directory tree, at the top level of which is the serialized
+ * merkle tree of the hashgraph state. That is in a file named `SignedState.swh` and file is called
+ * the "signed state file". But the whole directory tree must be present.
+ *
+ * <p>This uses a `SignedStateFileReader` to suck that entire merkle tree into memory, plus the
+ * indexes of the virtual maps ("vmap"s) - ~1Gb serialized (2022-11). Then you can traverse the
+ * rematerialized hashgraph state.
+ *
+ * <p>Currently implements only operations needed for looking at contracts: - {@link
+ * #getAllKnownContracts()} looks in all the accounts to get all the contract ids present, - {@link
+ * #getAllContractContents(Collection)} returns a map, indexed by contract id, of the contract
+ * bytecodes.
+ */
+public class SignedStateHolder {
+
+    @NonNull
+    private final Path swh;
+
+    @NonNull
+    private ServicesState platformState;
+
+    public SignedStateHolder(@NonNull final Path swhFile) throws Exception {
+        swh = swhFile;
+        platformState = dehydrate();
+    }
+
+    /** Deserialize the signed state file into an in-memory data structure. */
+    private ServicesState dehydrate() throws Exception {
+        // register all applicable classes on classpath before deserializing signed state
+        ConstructableRegistry.getInstance().registerConstructables("*");
+        platformState = (ServicesState)
+                (SignedStateFileReader.readStateFile(swh).signedState().getSwirldState());
+        assertSignedStateComponentExists(platformState, "platform state (Swirlds)");
+        return platformState;
+    }
+
+    /**
+     * A contract - some bytecode associated with its contract id(s)
+     *
+     * @param ids - direct from the signed state file there's one contract id for each bytecode, but
+     *     there are duplicates which can be coalesced and then there's a set of ids for the single
+     *     contract
+     * @param bytecode - bytecode of the contractd
+     */
+    public record Contract(@NonNull Set</*@NonNull*/ Integer> ids, @NonNull byte[] bytecode) {
+
+        @Override
+        public boolean equals(Object o) {
+            return o instanceof Contract other && ids.equals(other.ids) && Arrays.equals(bytecode, other.bytecode);
+        }
+
+        @Override
+        public int hashCode() {
+            return ids.hashCode() * 31 + Arrays.hashCode(bytecode);
+        }
+
+        @Override
+        public String toString() {
+
+            var csvIds = new StringBuilder(250);
+            for (var id : ids()) {
+                csvIds.append(id); // hides a `toString` which is why `String::join` isn't enough
+                csvIds.append(',');
+            }
+            csvIds.setLength(csvIds.length() - 1);
+
+            return "Contract{ids=(%s), bytecode=%s}".formatted(csvIds.toString(), Arrays.toString(bytecode));
+        }
+    }
+
+    /**
+     * All contracts extracted from a signed state file
+     *
+     * @param contracts - dictionary of contract bytecodes indexed by their contract id (as a Long)
+     * @param registeredContractsCount - total #contracts known to the _accounts_ in the signed
+     *     state file (not all actually have bytecodes in the file store, and of those, some have
+     *     0-length bytecode files)
+     */
+    public record Contracts(@NonNull Collection</*@NonNull*/ Contract> contracts, int registeredContractsCount) {}
+
+    /**
+     * Convenience method: Given the signed state file's name (the `.swh` file) return all the
+     * bytecodes for all the contracts in that state.
+     */
+    public static @NonNull Contracts getContracts(@NonNull final Path inputFile) throws Exception {
+        final var signedState = new SignedStateHolder(inputFile);
+        final var contractIds = signedState.getAllKnownContracts();
+        final var contractContents = signedState.getAllContractContents(contractIds);
+        return new Contracts(contractContents, contractIds.size());
+    }
+
+    public @NonNull ServicesState getPlatformState() {
+        return platformState;
+    }
+
+    /** Gets all existing accounts */
+    public @NonNull AccountStorageAdapter getAccounts() {
+        final var accounts = platformState.accounts();
+        assertSignedStateComponentExists(accounts, "accounts");
+        return accounts;
+    }
+
+    /**
+     * Returns the file store from the state
+     *
+     * <p>The file state contains, among other things, all the contracts' bytecodes.
+     */
+    public @NonNull VirtualMapLike<VirtualBlobKey, VirtualBlobValue> getFileStore() {
+        final var fileStore = platformState.storage();
+        assertSignedStateComponentExists(fileStore, "fileStore");
+        return fileStore;
+    }
+
+    /**
+     * Returns all contracts known via Hedera accounts, by their contract id (lowered to an Integer)
+     */
+    public @NonNull Set</*@NonNull*/ Integer> getAllKnownContracts() {
+        var ids = new HashSet<Integer>();
+        getAccounts().forEach((k, v) -> {
+            if (null != k && null != v && v.isSmartContract()) ids.add(k.intValue());
+        });
+        return ids;
+    }
+
+    /** Returns the bytecodes for all the requested contracts */
+    public @NonNull Collection</*@NonNull*/ Contract> getAllContractContents(
+            @NonNull final Collection</*@NonNull*/ Integer> contractIds) {
+
+        final var fileStore = getFileStore();
+        var codes = new ArrayList<Contract>();
+        for (var cid : contractIds) {
+            final var vbk = new VirtualBlobKey(Type.CONTRACT_BYTECODE, cid);
+            if (fileStore.containsKey(vbk)) {
+                final var blob = fileStore.get(vbk);
+                if (null != blob) {
+                    final var c = new Contract(Set.of(cid), blob.getData());
+                    codes.add(c);
+                }
+            }
+        }
+        return codes;
+    }
+
+    public static class MissingSignedStateComponent extends NullPointerException {
+        public MissingSignedStateComponent(@NonNull final String component, @NonNull final Path swh) {
+            super("Expected non-null %s from signed state file %s".formatted(component, swh.toString()));
+        }
+    }
+
+    private void assertSignedStateComponentExists(final Object component, @NonNull final String componentName) {
+        if (null == component) throw new MissingSignedStateComponent(componentName, swh);
+    }
+}

--- a/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/signedstate/SummarizeSignedStateFileCommand.java
+++ b/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/signedstate/SummarizeSignedStateFileCommand.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.services.cli.signedstate;
+
+import static com.hedera.services.cli.signedstate.SignedStateHolder.getContracts;
+
+import com.hedera.services.cli.ExamplePcliPlugin;
+import com.hedera.services.cli.signedstate.SignedStateHolder.Contract;
+import java.lang.reflect.Array;
+import java.nio.file.Path;
+import java.util.concurrent.Callable;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.ParentCommand;
+
+@Command(
+        name = "summarize",
+        subcommands = {picocli.CommandLine.HelpCommand.class},
+        description = "Summarizes contents of signed state file (to stdout)")
+public class SummarizeSignedStateFileCommand implements Callable<Integer> {
+    @ParentCommand
+    private ExamplePcliPlugin examplePcliPlugin;
+
+    @Option(
+            names = {"-f", "--file"},
+            arity = "1",
+            description = "Input signed state file")
+    Path inputFile;
+
+    @Override
+    public Integer call() throws Exception {
+
+        final var knownContracts = getContracts(inputFile);
+
+        final int contractsWithBytecodeFound = knownContracts.contracts().size();
+        final var bytesFound = knownContracts.contracts().stream()
+                .map(Contract::bytecode)
+                .mapToInt(Array::getLength)
+                .sum();
+
+        System.out.printf(
+                "SummarizeSignedStateFile: %d contractIDs found %d contracts found in file store"
+                        + " (%d bytes total)%n",
+                knownContracts.registeredContractsCount(), contractsWithBytecodeFound, bytesFound);
+
+        return 0;
+    }
+}

--- a/hedera-node/cli-clients/src/main/java/module-info.java
+++ b/hedera-node/cli-clients/src/main/java/module-info.java
@@ -1,0 +1,12 @@
+module com.hedera.services.cli {
+    exports com.hedera.services.cli;
+
+    requires static com.github.spotbugs.annotations;
+    requires com.hedera.node.app.service.mono;
+    requires com.swirlds.cli;
+    requires com.swirlds.virtualmap;
+    requires com.swirlds.platform;
+    requires com.swirlds.common;
+    requires info.picocli;
+    requires io.github.classgraph;
+}

--- a/hedera-node/cli-clients/src/main/java/module-info.java
+++ b/hedera-node/cli-clients/src/main/java/module-info.java
@@ -8,5 +8,4 @@ module com.hedera.services.cli {
     requires com.swirlds.platform;
     requires com.swirlds.common;
     requires info.picocli;
-    requires io.github.classgraph;
 }

--- a/hedera-node/hedera-mono-service/src/main/java/module-info.java
+++ b/hedera-node/hedera-mono-service/src/main/java/module-info.java
@@ -44,7 +44,8 @@ module com.hedera.node.app.service.mono {
             com.hedera.node.app.service.consensus.impl,
             com.hedera.node.app.service.network.impl,
             com.hedera.node.app.service.consensus.impl.test,
-            com.hedera.node.app.service.network.impl.test;
+            com.hedera.node.app.service.network.impl.test,
+            com.hedera.services.cli;
     exports com.hedera.node.app.service.mono.ledger to
             com.hedera.node.app.service.mono.testFixtures,
             com.hedera.node.app;

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -83,6 +83,8 @@ include(":hedera-node:hedera-evm-impl")
 
 include(":hedera-node:hedera-mono-service")
 
+include(":hedera-node:cli-clients")
+
 include(":hedera-node:test-clients")
 
 // Enable Gradle Build Scan
@@ -178,7 +180,8 @@ dependencyResolutionManagement {
               "swirlds-fcqueue",
               "swirlds-jasperdb",
               "swirlds-virtualmap",
-              "swirlds-test-framework"))
+              "swirlds-test-framework",
+              "swirlds-cli"))
 
       // Define the individual libraries
       library("pbj-runtime", "com.hedera.pbj", "pbj-runtime").versionRef("pbj-version")
@@ -248,6 +251,7 @@ dependencyResolutionManagement {
           .versionRef("swirlds-version")
       library("swirlds-test-framework", "com.swirlds", "swirlds-test-framework")
           .versionRef("swirlds-version")
+      library("swirlds-cli", "com.swirlds", "swirlds-cli").versionRef("swirlds-version")
       library("tuweni-units", "org.apache.tuweni", "tuweni-units").versionRef("tuweni-version")
       library("jna", "net.java.dev.jna", "jna").versionRef("jna-version")
       library("spotbugs-annotations", "com.github.spotbugs", "spotbugs-annotations")


### PR DESCRIPTION
**Description**:

Example pcli plugin implements one command - summarize a signed state file. This is simply a command I had at hand that uses services functionality (specificially `hedera-mono-service`) on top of platform functionality.

Purpose is to
1) enable development of pcli plugins in the services repo, and 
1) provide a working example as PoC.


<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->

**Related issue(s)**:

Fixes #5694 

**Notes for reviewer**:

To execute, change directory to `platform-sdk/swirlds-cli` and execute

```
./pcli.sh --load ../../hedera-node  example summarize -f <path-to-a-SignedState.swh>
```

(Takes about 12s to start on my laptop, just to provide help.  Then it takes ~25s on top of that to read the signed state file.)

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
