### PR TITLE
Include ownerId in synthetic child createApproveAllowanceForAllNFT txn

### DIFF
--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/SyntheticTxnFactory.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/SyntheticTxnFactory.java
@@ -343,13 +343,14 @@ public class SyntheticTxnFactory {
     }
 
     public TransactionBody.Builder createApproveAllowanceForAllNFT(
-            final SetApprovalForAllWrapper setApprovalForAllWrapper) {
+        @NonNull final SetApprovalForAllWrapper setApprovalForAllWrapper, @NonNull EntityId ownerId) {
 
         final var builder = CryptoApproveAllowanceTransactionBody.newBuilder();
 
         builder.addNftAllowances(NftAllowance.newBuilder()
                 .setApprovedForAll(BoolValue.of(setApprovalForAllWrapper.approved()))
                 .setTokenId(setApprovalForAllWrapper.tokenId())
+                .setOwner(Objects.requireNonNull(ownerId).toGrpcAccountId())
                 .setSpender(setApprovalForAllWrapper.to())
                 .build());
 

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/SyntheticTxnFactory.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/SyntheticTxnFactory.java
@@ -343,7 +343,7 @@ public class SyntheticTxnFactory {
     }
 
     public TransactionBody.Builder createApproveAllowanceForAllNFT(
-        @NonNull final SetApprovalForAllWrapper setApprovalForAllWrapper, @NonNull EntityId ownerId) {
+            @NonNull final SetApprovalForAllWrapper setApprovalForAllWrapper, @NonNull EntityId ownerId) {
 
         final var builder = CryptoApproveAllowanceTransactionBody.newBuilder();
 

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/SetApprovalForAllPrecompile.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/SetApprovalForAllPrecompile.java
@@ -62,7 +62,6 @@ public class SetApprovalForAllPrecompile extends AbstractWritePrecompile {
     private final TokenID tokenId;
     private final Address senderAddress;
     private SetApprovalForAllWrapper setApprovalForAllWrapper;
-    private EntityId ownerId;
 
     public SetApprovalForAllPrecompile(
             final TokenID tokenId,
@@ -90,8 +89,8 @@ public class SetApprovalForAllPrecompile extends AbstractWritePrecompile {
     @Override
     public TransactionBody.Builder body(final Bytes input, final UnaryOperator<byte[]> aliasResolver) {
         final var nestedInput = tokenId == null ? input : input.slice(24);
+        final var ownerId = EntityId.fromAddress(senderAddress);
         setApprovalForAllWrapper = decodeSetApprovalForAll(nestedInput, tokenId, aliasResolver);
-        ownerId = EntityId.fromAddress(senderAddress);
         transactionBody = syntheticTxnFactory.createApproveAllowanceForAllNFT(setApprovalForAllWrapper, ownerId);
         return transactionBody;
     }

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/SetApprovalForAllPrecompile.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/SetApprovalForAllPrecompile.java
@@ -30,6 +30,7 @@ import com.esaulpaugh.headlong.abi.Function;
 import com.esaulpaugh.headlong.abi.Tuple;
 import com.esaulpaugh.headlong.abi.TypeFactory;
 import com.hedera.node.app.service.mono.context.SideEffectsTracker;
+import com.hedera.node.app.service.mono.state.submerkle.EntityId;
 import com.hedera.node.app.service.mono.store.contracts.WorldLedgers;
 import com.hedera.node.app.service.mono.store.contracts.precompile.AbiConstants;
 import com.hedera.node.app.service.mono.store.contracts.precompile.InfrastructureFactory;
@@ -61,6 +62,7 @@ public class SetApprovalForAllPrecompile extends AbstractWritePrecompile {
     private final TokenID tokenId;
     private final Address senderAddress;
     private SetApprovalForAllWrapper setApprovalForAllWrapper;
+    private EntityId ownerId;
 
     public SetApprovalForAllPrecompile(
             final TokenID tokenId,
@@ -89,7 +91,8 @@ public class SetApprovalForAllPrecompile extends AbstractWritePrecompile {
     public TransactionBody.Builder body(final Bytes input, final UnaryOperator<byte[]> aliasResolver) {
         final var nestedInput = tokenId == null ? input : input.slice(24);
         setApprovalForAllWrapper = decodeSetApprovalForAll(nestedInput, tokenId, aliasResolver);
-        transactionBody = syntheticTxnFactory.createApproveAllowanceForAllNFT(setApprovalForAllWrapper);
+        ownerId = EntityId.fromAddress(senderAddress);
+        transactionBody = syntheticTxnFactory.createApproveAllowanceForAllNFT(setApprovalForAllWrapper, ownerId);
         return transactionBody;
     }
 

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/ERC721PrecompilesTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/ERC721PrecompilesTest.java
@@ -967,7 +967,7 @@ class ERC721PrecompilesTest {
         given(feeCalculator.computeFee(any(), any(), any(), any())).willReturn(mockFeeObject);
         given(mockFeeObject.serviceFee()).willReturn(1L);
 
-        given(syntheticTxnFactory.createApproveAllowanceForAllNFT(SET_APPROVAL_FOR_ALL_WRAPPER))
+        given(syntheticTxnFactory.createApproveAllowanceForAllNFT(SET_APPROVAL_FOR_ALL_WRAPPER, new EntityId(0, 0, 7L)))
                 .willReturn(mockSynthBodyBuilder);
         given(mockSynthBodyBuilder.build())
                 .willReturn(TransactionBody.newBuilder().build());
@@ -1036,7 +1036,7 @@ class ERC721PrecompilesTest {
         given(feeCalculator.computeFee(any(), any(), any(), any())).willReturn(mockFeeObject);
         given(mockFeeObject.serviceFee()).willReturn(1L);
 
-        given(syntheticTxnFactory.createApproveAllowanceForAllNFT(SET_APPROVAL_FOR_ALL_WRAPPER))
+        given(syntheticTxnFactory.createApproveAllowanceForAllNFT(SET_APPROVAL_FOR_ALL_WRAPPER, new EntityId(0, 0, 7L)))
                 .willReturn(mockSynthBodyBuilder);
         given(mockSynthBodyBuilder.build())
                 .willReturn(TransactionBody.newBuilder().build());

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/SyntheticTxnFactoryTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/SyntheticTxnFactoryTest.java
@@ -746,8 +746,7 @@ class SyntheticTxnFactoryTest {
                 receiver,
                 txnBody.getCryptoApproveAllowance().getNftAllowances(0).getSpender());
         assertEquals(
-                sender,
-                txnBody.getCryptoApproveAllowance().getNftAllowances(0).getOwner());
+                sender, txnBody.getCryptoApproveAllowance().getNftAllowances(0).getOwner());
         assertEquals(
                 nonFungible,
                 txnBody.getCryptoApproveAllowance().getNftAllowances(0).getTokenId());

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/SyntheticTxnFactoryTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/SyntheticTxnFactoryTest.java
@@ -29,6 +29,7 @@ import static com.hedera.node.app.service.mono.store.contracts.precompile.HTSTes
 import static com.hedera.node.app.service.mono.store.contracts.precompile.HTSTestsUtil.payer;
 import static com.hedera.node.app.service.mono.store.contracts.precompile.HTSTestsUtil.receiver;
 import static com.hedera.node.app.service.mono.store.contracts.precompile.HTSTestsUtil.royaltyFee;
+import static com.hedera.node.app.service.mono.store.contracts.precompile.HTSTestsUtil.sender;
 import static com.hedera.node.app.service.mono.store.contracts.precompile.HTSTestsUtil.senderId;
 import static com.hedera.node.app.service.mono.store.contracts.precompile.HTSTestsUtil.token;
 import static com.hedera.node.app.service.mono.store.contracts.precompile.SyntheticTxnFactory.MOCK_INITCODE;
@@ -738,12 +739,15 @@ class SyntheticTxnFactoryTest {
     void createsAdjustAllowanceForAllNFT() {
         final var allowances = new SetApprovalForAllWrapper(nonFungible, receiver, true);
 
-        final var result = subject.createApproveAllowanceForAllNFT(allowances);
+        final var result = subject.createApproveAllowanceForAllNFT(allowances, senderId);
         final var txnBody = result.build();
 
         assertEquals(
                 receiver,
                 txnBody.getCryptoApproveAllowance().getNftAllowances(0).getSpender());
+        assertEquals(
+                sender,
+                txnBody.getCryptoApproveAllowance().getNftAllowances(0).getOwner());
         assertEquals(
                 nonFungible,
                 txnBody.getCryptoApproveAllowance().getNftAllowances(0).getTokenId());


### PR DESCRIPTION
**Description**:

- Sets msg.sender as ownerId in synthetic createApproveAllowanceForAllNFT txn.

**Related issue(s)**:

Fixes #6135 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
