### PR TITLE
Turn on the Shanghai version of the EVM in previewnet

### DIFF
--- a/hedera-node/configuration/previewnet/bootstrap.properties
+++ b/hedera-node/configuration/previewnet/bootstrap.properties
@@ -3,3 +3,5 @@ contracts.chainId=297
 bootstrap.genesisPublicKey=c249a323c878f5b5e2daccda6d731e6fdc32f870228d1cd4fae559d947dbc36c
 accounts.blocklist.enabled=false
 accounts.blocklist.resource=
+contracts.evm.version=v0.38
+contracts.evm.version.dynamic=true


### PR DESCRIPTION
**Description**:

Update for bootstrap.properties file for previewnet to turn on the Shanghai version of the EVM for previewnet

