### PR TITLE
SigningTool defined as app

### DIFF
--- a/platform-sdk/swirlds-sign-tool/build.gradle.kts
+++ b/platform-sdk/swirlds-sign-tool/build.gradle.kts
@@ -18,6 +18,7 @@ plugins {
   id("com.swirlds.platform.conventions")
   id("com.swirlds.platform.library")
   id("com.swirlds.platform.maven-publish")
+  id("com.swirlds.platform.application")
 }
 
 dependencies {

--- a/platform-sdk/swirlds-sign-tool/gradle.properties
+++ b/platform-sdk/swirlds-sign-tool/gradle.properties
@@ -1,0 +1,17 @@
+#
+# Copyright (C) 2023 Hedera Hashgraph, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#
+mainClass=com.swirlds.signingtool.SigningTool


### PR DESCRIPTION
@JeffreyDallas found some unexpected behavior based on the extraction of the SigningTool: The jar is not copied to the sdk folder anymore. Based on this PR the SigningTool is defined as app and copied to the sdk.