### PR TITLE
Migrated AdminService to new design

### DIFF
--- a/hedera-node/hedera-admin-service-impl/src/main/java/com/hedera/node/app/service/admin/impl/ReadableSpecialFileStoreImpl.java
+++ b/hedera-node/hedera-admin-service-impl/src/main/java/com/hedera/node/app/service/admin/impl/ReadableSpecialFileStoreImpl.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.node.app.service.admin.impl;
+
+import com.hedera.node.app.service.admin.ReadableSpecialFileStore;
+import com.hedera.node.app.spi.state.ReadableKVState;
+import com.hedera.node.app.spi.state.ReadableStates;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Implementation of {@link ReadableSpecialFileStore}
+ */
+public class ReadableSpecialFileStoreImpl implements ReadableSpecialFileStore {
+
+    /** The underlying data storage class that holds the file data. */
+    private final ReadableKVState<Long, byte[]> freezeFilesById;
+
+    /**
+     * Create a new {@link ReadableSpecialFileStoreImpl} instance.
+     *
+     * @param states The state to use.
+     */
+    public ReadableSpecialFileStoreImpl(@NonNull final ReadableStates states) {
+        Objects.requireNonNull(states);
+        this.freezeFilesById = states.get(FreezeServiceImpl.UPGRADE_FILES_KEY);
+    }
+
+    @Override
+    @NonNull
+    public Optional<byte[]> get(long fileId) {
+        final var file = freezeFilesById.get(fileId);
+        return Optional.ofNullable(file);
+    }
+}

--- a/hedera-node/hedera-admin-service-impl/src/main/java/com/hedera/node/app/service/admin/impl/handlers/FreezeHandler.java
+++ b/hedera-node/hedera-admin-service-impl/src/main/java/com/hedera/node/app/service/admin/impl/handlers/FreezeHandler.java
@@ -27,7 +27,7 @@ import com.hedera.hapi.node.base.HederaFunctionality;
 import com.hedera.hapi.node.base.Timestamp;
 import com.hedera.hapi.node.freeze.FreezeTransactionBody;
 import com.hedera.hapi.node.freeze.FreezeType;
-import com.hedera.node.app.service.admin.impl.ReadableSpecialFileStore;
+import com.hedera.node.app.service.admin.ReadableSpecialFileStore;
 import com.hedera.node.app.spi.workflows.PreCheckException;
 import com.hedera.node.app.spi.workflows.PreHandleContext;
 import com.hedera.node.app.spi.workflows.TransactionHandler;
@@ -51,19 +51,11 @@ public class FreezeHandler implements TransactionHandler {
         // Dagger2
     }
 
-    /**
-     * This method is called during the pre-handle workflow for Freeze transactions.
-     *
-     * @param context the {@link PreHandleContext} which collects all information that will be
-     *     passed to {@code handle()}
-     * @see <a href="https://hashgraph.github.io/hedera-protobufs/#freeze.proto">Protobuf freeze documentation</a>
-     */
+    @Override
     @SuppressWarnings("java:S1874") // disable the warnings for use of deprecated code
     // it is necessary to check getStartHour, getStartMin, getEndHour, getEndMin, all of which are deprecated
     // because if any are present then we set a status of INVALID_FREEZE_TRANSACTION_BODY
-    public void preHandle(
-            @NonNull final PreHandleContext context, @NonNull final ReadableSpecialFileStore specialFileStore)
-            throws PreCheckException {
+    public void preHandle(@NonNull final PreHandleContext context) throws PreCheckException {
         requireNonNull(context);
 
         FreezeTransactionBody freezeTxn = context.body().freeze();
@@ -79,6 +71,7 @@ public class FreezeHandler implements TransactionHandler {
         }
 
         final FreezeType freezeType = freezeTxn.freezeType();
+        final ReadableSpecialFileStore specialFileStore = context.createStore(ReadableSpecialFileStore.class);
         switch (freezeType) {
                 // default value for freezeType is UNKNOWN_FREEZE_TYPE
                 // reject any freeze transactions that do not set freezeType or set it to UNKNOWN_FREEZE_TYPE

--- a/hedera-node/hedera-admin-service-impl/src/test/java/module-info.java
+++ b/hedera-node/hedera-admin-service-impl/src/test/java/module-info.java
@@ -10,6 +10,7 @@ module com.hedera.node.app.service.admin.impl.test {
     requires com.swirlds.fcqueue;
     requires com.google.protobuf;
     requires com.hedera.node.app.spi.fixtures;
+    requires com.hedera.node.app.service.token;
 
     opens com.hedera.node.app.service.admin.impl.test to
             org.junit.platform.commons,

--- a/hedera-node/hedera-admin-service/src/main/java/com/hedera/node/app/service/admin/ReadableSpecialFileStore.java
+++ b/hedera-node/hedera-admin-service/src/main/java/com/hedera/node/app/service/admin/ReadableSpecialFileStore.java
@@ -14,33 +14,16 @@
  * limitations under the License.
  */
 
-package com.hedera.node.app.service.admin.impl;
+package com.hedera.node.app.service.admin;
 
-import com.hedera.node.app.spi.state.ReadableKVState;
-import com.hedera.node.app.spi.state.ReadableStates;
 import edu.umd.cs.findbugs.annotations.NonNull;
-import java.util.Objects;
 import java.util.Optional;
 
 /**
  * Provides read-only methods for interacting with the underlying data storage mechanisms for
  * working with special files used in freeze transactions.
- *
- * <p>This class is not exported from the module. It is an internal implementation detail.
  */
-public class ReadableSpecialFileStore {
-    /** The underlying data storage class that holds the file data. */
-    private final ReadableKVState<Long, byte[]> freezeFilesById;
-
-    /**
-     * Create a new {@link ReadableSpecialFileStore} instance.
-     *
-     * @param states The state to use.
-     */
-    public ReadableSpecialFileStore(@NonNull final ReadableStates states) {
-        Objects.requireNonNull(states);
-        this.freezeFilesById = states.get(FreezeServiceImpl.UPGRADE_FILES_KEY);
-    }
+public interface ReadableSpecialFileStore {
 
     /**
      * Gets the freeze file with the given ID. If there is no file with given ID
@@ -49,8 +32,6 @@ public class ReadableSpecialFileStore {
      * @param fileId given id for the file
      * @return the file with the given id
      */
-    public Optional<byte[]> get(final Long fileId) {
-        final var file = freezeFilesById.get(fileId);
-        return Optional.ofNullable(file);
-    }
+    @NonNull
+    Optional<byte[]> get(long fileId);
 }

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/dispatcher/ReadableStoreFactory.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/dispatcher/ReadableStoreFactory.java
@@ -19,7 +19,8 @@ package com.hedera.node.app.workflows.dispatcher;
 import static java.util.Objects.requireNonNull;
 
 import com.hedera.node.app.service.admin.FreezeService;
-import com.hedera.node.app.service.admin.impl.ReadableSpecialFileStore;
+import com.hedera.node.app.service.admin.ReadableSpecialFileStore;
+import com.hedera.node.app.service.admin.impl.ReadableSpecialFileStoreImpl;
 import com.hedera.node.app.service.consensus.ConsensusService;
 import com.hedera.node.app.service.consensus.impl.ReadableTopicStore;
 import com.hedera.node.app.service.schedule.ScheduleService;
@@ -52,7 +53,7 @@ public class ReadableStoreFactory {
             ReadableTokenStore.class, new StoreEntry(TokenService.NAME, ReadableTokenStoreImpl::new),
             ReadableTopicStore.class, new StoreEntry(ConsensusService.NAME, ReadableTopicStore::new),
             ReadableScheduleStore.class, new StoreEntry(ScheduleService.NAME, ReadableScheduleStore::new),
-            ReadableSpecialFileStore.class, new StoreEntry(FreezeService.NAME, ReadableSpecialFileStore::new));
+            ReadableSpecialFileStore.class, new StoreEntry(FreezeService.NAME, ReadableSpecialFileStoreImpl::new));
 
     private final HederaState state;
 

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/dispatcher/TransactionDispatcher.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/dispatcher/TransactionDispatcher.java
@@ -23,7 +23,6 @@ import com.hedera.hapi.node.consensus.ConsensusCreateTopicTransactionBody;
 import com.hedera.hapi.node.consensus.ConsensusDeleteTopicTransactionBody;
 import com.hedera.hapi.node.consensus.ConsensusUpdateTopicTransactionBody;
 import com.hedera.hapi.node.transaction.TransactionBody;
-import com.hedera.node.app.service.admin.impl.ReadableSpecialFileStore;
 import com.hedera.node.app.service.consensus.impl.ReadableTopicStore;
 import com.hedera.node.app.service.consensus.impl.WritableTopicStore;
 import com.hedera.node.app.service.consensus.impl.config.ConsensusServiceConfig;
@@ -152,8 +151,7 @@ public class TransactionDispatcher {
             case FILE_DELETE -> handlers.fileDeleteHandler().preHandle(context);
             case FILE_APPEND -> handlers.fileAppendHandler().preHandle(context);
 
-            case FREEZE -> handlers.freezeHandler()
-                    .preHandle(context, context.createStore(ReadableSpecialFileStore.class));
+            case FREEZE -> handlers.freezeHandler().preHandle(context);
 
             case UNCHECKED_SUBMIT -> handlers.networkUncheckedSubmitHandler().preHandle(context);
 

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/dispatcher/MonoTransactionDispatcherTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/dispatcher/MonoTransactionDispatcherTest.java
@@ -627,6 +627,13 @@ class MonoTransactionDispatcherTest {
                         (Function<TransactionHandlers, TransactionHandler>)
                                 TransactionHandlers::cryptoDeleteLiveHashHandler),
 
+                // freeze
+                Arguments.of(
+                        TransactionBody.newBuilder()
+                                .freeze(FreezeTransactionBody.DEFAULT)
+                                .build(),
+                        (Function<TransactionHandlers, TransactionHandler>) TransactionHandlers::freezeHandler),
+
                 // token
                 Arguments.of(
                         TransactionBody.newBuilder()
@@ -812,14 +819,6 @@ class MonoTransactionDispatcherTest {
                                 .build(),
                         (DispatchToHandler) (handlers, meta) ->
                                 verify(handlers.fileAppendHandler()).preHandle(meta)),
-
-                // freeze
-                Arguments.of(
-                        TransactionBody.newBuilder()
-                                .freeze(FreezeTransactionBody.DEFAULT)
-                                .build(),
-                        (DispatchToHandler) (handlers, meta) ->
-                                verify(handlers.freezeHandler()).preHandle(eq(meta), any())),
 
                 // network
                 Arguments.of(


### PR DESCRIPTION
This PR migrates the AdminService to the new design:

- Makes the `preHandle()` method generic. It has only one parameter `context` and is defined in `TransactionHandler`.
- Introduces interfaces for each store (e.g. `ReadableTokenStore`) in the corresponding api-module
- Adds the suffix 'Impl' to names of store implementations (e.g. `ReadableTokenStoreImpl`). The classes implement the new interfaces.
- `PreHandleContext` will become an interface in an upcoming PR. To prepare for this change, tests were updated.
- We will stop to use `AccountAccess` soon. Instead the new interface `ReadableAccountStore` should be used instead.