### PR TITLE
Traceability migration now gated only on migration feature flag

### DIFF
--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/expiry/EntityAutoExpiry.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/expiry/EntityAutoExpiry.java
@@ -137,7 +137,6 @@ public class EntityAutoExpiry {
 
     private boolean canDoWorkGiven(final long wrapNum, final Instant now) {
         return wrapNum != firstEntityToScan
-                && dynamicProps.shouldAutoRenewSomeEntityType()
                 && consensusTimeTracker.hasMoreStandaloneRecordTime()
                 && !recordsHistorian.nextSystemTransactionIdIsUnknown()
                 && !expiryThrottle.stillLacksMinFreeCapAfterLeakingUntil(now);

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/expiry/EntityAutoExpiry.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/expiry/EntityAutoExpiry.java
@@ -54,6 +54,15 @@ public class EntityAutoExpiry {
     private int maxIdsToScan;
     private int maxEntitiesToProcess;
 
+    /** This class manages the system tasks that do a little bit of background work as each
+     * consensus transaction is incorporated into the hashgraph.
+     *
+     * Currently, the name of this class is not accurate:  It is no longer dealing only with
+     * auto-expiration entities.  It controls the progress of all "system tasks" (via the
+     * {@link SystemTaskManager}) and one of those system tasks is to perform traceability migration
+     * of contracts that were created prior to the availability of contract sidecars
+     * ({@link com.hedera.node.app.service.mono.state.tasks.TraceabilityExportTask}.
+     */
     @Inject
     public EntityAutoExpiry(
             final ExpiryStats expiryStats,
@@ -128,6 +137,12 @@ public class EntityAutoExpiry {
 
     private boolean canContinueGiven(
             final @Nullable SystemTaskResult result, final int idsScanned, final int entitiesProcessed) {
+        // You can do some more work during this consensus transaction if
+        // * you haven't exceeded the max number of ids to just look at AND
+        // * you haven't exceeded the max number of things to actually handle AND
+        // * you've got remaining capacity in the overall throttle AND
+        // * you've got remaining capacity in the per-task-type throttle (`NEEDS_DIFFERENT_CONTEXT`) AND
+        // * you still have remaining allowed clock-time in this consensus transaction.
         return idsScanned < maxIdsToScan
                 && entitiesProcessed < maxEntitiesToProcess
                 && result != NO_CAPACITY_LEFT
@@ -136,6 +151,12 @@ public class EntityAutoExpiry {
     }
 
     private boolean canDoWorkGiven(final long wrapNum, final Instant now) {
+        // You can do any work during this consensus transaction if all of:
+        // * you still have entities you haven't considered (i.e., have not wrapped around the count) AND
+        // * you still have remaining allowed clock-time in this consensus transaction AND
+        // * the next system transaction has been generated (i.e., because you know its id) AND
+        // * you've got remaining capacity in the overall throttle.
+
         return wrapNum != firstEntityToScan
                 && consensusTimeTracker.hasMoreStandaloneRecordTime()
                 && !recordsHistorian.nextSystemTransactionIdIsUnknown()

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/expiry/ExpiryProcess.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/expiry/ExpiryProcess.java
@@ -20,10 +20,12 @@ import static com.hedera.node.app.service.mono.state.tasks.SystemTaskResult.NEED
 import static com.hedera.node.app.service.mono.state.tasks.SystemTaskResult.NOTHING_TO_DO;
 import static com.hedera.node.app.service.mono.state.tasks.SystemTaskResult.NO_CAPACITY_LEFT;
 
+import com.hedera.node.app.service.mono.context.properties.GlobalDynamicProperties;
 import com.hedera.node.app.service.mono.records.ConsensusTimeTracker;
 import com.hedera.node.app.service.mono.state.expiry.classification.ClassificationWork;
 import com.hedera.node.app.service.mono.state.expiry.removal.RemovalWork;
 import com.hedera.node.app.service.mono.state.expiry.renewal.RenewalWork;
+import com.hedera.node.app.service.mono.state.merkle.MerkleNetworkContext;
 import com.hedera.node.app.service.mono.state.tasks.SystemTask;
 import com.hedera.node.app.service.mono.state.tasks.SystemTaskResult;
 import com.hedera.node.app.service.mono.utils.EntityNum;
@@ -33,6 +35,7 @@ import javax.inject.Inject;
 public class ExpiryProcess implements SystemTask {
     private final RenewalWork renewalWork;
     private final RemovalWork removalWork;
+    private final GlobalDynamicProperties dynamicProperties;
     private final ClassificationWork classifier;
     private final ConsensusTimeTracker consensusTimeTracker;
 
@@ -41,11 +44,18 @@ public class ExpiryProcess implements SystemTask {
             final ClassificationWork classifier,
             final RenewalWork renewalWork,
             final RemovalWork removalWork,
+            final GlobalDynamicProperties dynamicProperties,
             final ConsensusTimeTracker consensusTimeTracker) {
         this.consensusTimeTracker = consensusTimeTracker;
         this.renewalWork = renewalWork;
         this.removalWork = removalWork;
+        this.dynamicProperties = dynamicProperties;
         this.classifier = classifier;
+    }
+
+    @Override
+    public boolean isActive(final long literalNum, final MerkleNetworkContext curNetworkCtx) {
+        return dynamicProperties.shouldAutoRenewSomeEntityType();
     }
 
     @Override

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/tasks/SystemTask.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/tasks/SystemTask.java
@@ -22,6 +22,9 @@ import java.time.Instant;
 /**
  * Minimal interface for a system task that needs to perform deterministic work on (possibly) every
  * entity in state.
+ * <p>
+ * When you add a new `SystemTask` remember to wire it up in {@link TaskModule} or it
+ * won't get run.
  */
 public interface SystemTask {
     /**

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/tasks/TaskModule.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/tasks/TaskModule.java
@@ -25,7 +25,7 @@ import javax.inject.Singleton;
 
 /**
  * Binds the {@link SystemTask} implementations, which should always include {@link ExpiryProcess},
- * but may include others such as the 0.31.x {@link TraceabilityExportTask}.
+ * but may include others such as the 0.31.x/0.36/0.37 {@link TraceabilityExportTask}.
  *
  * <p>Note we are keeping {@link TraceabilityExportTask} in the codebase at this time for two
  * reasons:
@@ -43,4 +43,10 @@ public interface TaskModule {
     @Singleton
     @StringKey("1_ENTITY_EXPIRATION")
     SystemTask bindEntityExpirationTask(ExpiryProcess expiryProcess);
+
+    @Binds
+    @IntoMap
+    @Singleton
+    @StringKey("2_TRACEABILITY_EXPORT")
+    SystemTask bindTraceabilityExportTask(TraceabilityExportTask traceabilityExportTask);
 }

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/tasks/TraceabilityExportTask.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/tasks/TraceabilityExportTask.java
@@ -87,6 +87,8 @@ public class TraceabilityExportTask implements SystemTask {
     private final Supplier<AccountStorageAdapter> accounts;
     private final Supplier<VirtualMapLike<ContractKey, IterableContractValue>> contractStorage;
 
+    private boolean firstTime = true;
+
     // Used to occasionally log the progress of the traceability export; because this is
     // not in state, will become inaccurate on a node that falls behind or restarts, but
     // that doesn't matter---exports will finish within a few hours and we can just check
@@ -122,6 +124,12 @@ public class TraceabilityExportTask implements SystemTask {
     @Override
     public SystemTaskResult process(
             final long literalNum, final Instant now, final MerkleNetworkContext curNetworkCtx) {
+
+        if (firstTime) {
+            log.info("Traceability migration is active and beginning work");
+            firstTime = false;
+        }
+
         if (!recordsHelper.canExportNow() || needsBackPressure(now, curNetworkCtx)) {
             return NEEDS_DIFFERENT_CONTEXT;
         }

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/expiry/EntityAutoExpiryTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/expiry/EntityAutoExpiryTest.java
@@ -90,19 +90,6 @@ class EntityAutoExpiryTest {
     }
 
     @Test
-    void abortsIfNotAutoRenewing() {
-        // setup:
-        mockDynamicProps.disableAutoRenew();
-
-        // when:
-        subject.execute(instantNow);
-
-        // then:
-        verifyNoInteractions(taskManager);
-        verify(networkCtx).syncExpiryThrottle(expiryThrottle);
-    }
-
-    @Test
     void abortsIfExpiryThrottleCannotSupportMinUnitOfWork() {
         given(consensusTimeTracker.hasMoreStandaloneRecordTime()).willReturn(true);
         given(expiryThrottle.stillLacksMinFreeCapAfterLeakingUntil(instantNow)).willReturn(true);

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/expiry/ExpiryProcessTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/expiry/ExpiryProcessTest.java
@@ -132,7 +132,7 @@ class ExpiryProcessTest {
     @BeforeEach
     void setUp() {
         setUpPreRequisites();
-        subject = new ExpiryProcess(classifier, renewalWork, removalWork, consensusTimeTracker);
+        subject = new ExpiryProcess(classifier, renewalWork, removalWork, dynamicProperties, consensusTimeTracker);
         given(consensusTimeTracker.hasMoreStandaloneRecordTime()).willReturn(true);
     }
 


### PR DESCRIPTION
**Description**:

Signed-off-by: David Bakin <117694041+david-bakin-sl@users.noreply.github.com>


Traceability migration should run when the migration feature flag is on (and there are contracts which haven't been migrated.  But in fact it was _also_ gated on `autoRenew` entities having been enabled.  And too it _also_ needed
to be listed in `TaskModule` so dagger would include it as a system task to run.  Both done here.

And a one-time info-level log message is emitted the first time the traceability task is invoked.  After that you can look
for "n-thousand contracts exported" messages (not the exact text) to see progress.  (But the current system task
API doesn't allow for a "migration done" message.)


**Related issue(s)**:

Fixes #6256

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit)
