### PR TITLE
Scale up weights while exporting to mirror node

### DIFF
--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ledger/accounts/staking/EndOfStakingPeriodCalculator.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ledger/accounts/staking/EndOfStakingPeriodCalculator.java
@@ -219,7 +219,7 @@ public class EndOfStakingPeriodCalculator {
             return zeroStake;
         } else {
             // This should never happen, but if it does, return zero
-            if(totalStakeOfAllNodes == 0) {
+            if (totalStakeOfAllNodes == 0) {
                 return 0;
             }
             final var oldMinWeight = 1;

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ledger/accounts/staking/EndOfStakingPeriodCalculator.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ledger/accounts/staking/EndOfStakingPeriodCalculator.java
@@ -203,7 +203,7 @@ public class EndOfStakingPeriodCalculator {
     }
 
     /**
-     * Scales up the weight of the node to the range [minStake, maxStake] from the consensus weight range [0, 500].
+     * Scales up the weight of the node to the range [minStake, maxSTakeOfAllNodes] from the consensus weight range [0, 500].
      * @param weight weight of the node
      * @param minStake min stake of the node
      * @param maxStakeOfAllNodes real max stake of all nodes computed by taking max(stakeOfNode1, stakeOfNode2, ...)

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/staking/StakingSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/staking/StakingSuite.java
@@ -17,6 +17,7 @@
 package com.hedera.services.bdd.suites.crypto.staking;
 
 import static com.hedera.services.bdd.spec.HapiSpec.defaultHapiSpec;
+import static com.hedera.services.bdd.spec.HapiSpec.onlyDefaultHapiSpec;
 import static com.hedera.services.bdd.spec.assertions.AccountInfoAsserts.accountWith;
 import static com.hedera.services.bdd.spec.assertions.ContractInfoAsserts.contractWith;
 import static com.hedera.services.bdd.spec.assertions.TransactionRecordAsserts.recordWith;
@@ -660,7 +661,7 @@ public class StakingSuite extends HapiSuite {
     }
 
     private HapiSpec endOfStakingPeriodRecTest() {
-        return defaultHapiSpec("EndOfStakingPeriodRecTest")
+        return onlyDefaultHapiSpec("EndOfStakingPeriodRecTest")
                 .given(
                         cryptoCreate("a1").balance(24000 * ONE_MILLION_HBARS).stakedNodeId(0),
                         cryptoCreate("a2").balance(2000 * ONE_MILLION_HBARS).stakedNodeId(0),

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/staking/StakingSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/staking/StakingSuite.java
@@ -661,7 +661,7 @@ public class StakingSuite extends HapiSuite {
     }
 
     private HapiSpec endOfStakingPeriodRecTest() {
-        return onlyDefaultHapiSpec("EndOfStakingPeriodRecTest")
+        return defaultHapiSpec("EndOfStakingPeriodRecTest")
                 .given(
                         cryptoCreate("a1").balance(24000 * ONE_MILLION_HBARS).stakedNodeId(0),
                         cryptoCreate("a2").balance(2000 * ONE_MILLION_HBARS).stakedNodeId(0),

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/staking/StakingSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/staking/StakingSuite.java
@@ -17,7 +17,6 @@
 package com.hedera.services.bdd.suites.crypto.staking;
 
 import static com.hedera.services.bdd.spec.HapiSpec.defaultHapiSpec;
-import static com.hedera.services.bdd.spec.HapiSpec.onlyDefaultHapiSpec;
 import static com.hedera.services.bdd.spec.assertions.AccountInfoAsserts.accountWith;
 import static com.hedera.services.bdd.spec.assertions.ContractInfoAsserts.contractWith;
 import static com.hedera.services.bdd.spec.assertions.TransactionRecordAsserts.recordWith;


### PR DESCRIPTION
Scale up the consensus weights [0, 500] to [minStake, maxStake] while exporting to mirror node