### PR TITLE
Faster class scan for config records

### DIFF
--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/config/ConfigUtils.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/config/ConfigUtils.java
@@ -16,7 +16,6 @@
 
 package com.swirlds.common.config;
 
-import com.swirlds.base.ArgumentUtils;
 import com.swirlds.common.constructable.URLClassLoaderWithLookup;
 import com.swirlds.config.api.ConfigData;
 import com.swirlds.config.api.ConfigurationBuilder;
@@ -26,6 +25,7 @@ import io.github.classgraph.ClassInfoList;
 import io.github.classgraph.ScanResult;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -34,10 +34,16 @@ import java.util.stream.Collectors;
  */
 public final class ConfigUtils {
 
+    private static final String SWIRLDS_PACKAGE = "com.swirlds";
+    private static final String HEDERA_PACKAGE = "com.hedera";
+
     private ConfigUtils() {}
 
     /**
-     * Scan all classes in a classpath and register all configuration data types with a configuration builder.
+     * Scan all classes in classpath/modulepath and register all configuration data types with a configuration builder.
+     * This call will only scan the {@code com.swirlds} and {@code com.hedera} packages. If you want to scan all
+     * available packages you need to call {@link #scanAndRegisterAllConfigTypes(ConfigurationBuilder, Set)} with an
+     * empty string Set.
      *
      * @param configurationBuilder a configuration builder
      * @return the configuration builder that was passed as a param (for fluent api)
@@ -45,11 +51,12 @@ public final class ConfigUtils {
     @NonNull
     public static ConfigurationBuilder scanAndRegisterAllConfigTypes(
             @NonNull final ConfigurationBuilder configurationBuilder) {
-        return scanAndRegisterAllConfigTypes(configurationBuilder, Collections.emptySet(), Collections.emptyList());
+        return scanAndRegisterAllConfigTypes(configurationBuilder, Set.of(SWIRLDS_PACKAGE, HEDERA_PACKAGE));
     }
 
     /**
-     * Scan all classes in a classpath and register all configuration data types with a configuration builder.
+     * Scan all classes in a classpath and register all configuration data types with a configuration builder. If the
+     * given {@code packagePrefixes} array is empty all packages will be scanned.
      *
      * @param configurationBuilder a configuration builder
      * @param packagePrefixes      the package prefixes to scan
@@ -57,9 +64,9 @@ public final class ConfigUtils {
      */
     @NonNull
     public static ConfigurationBuilder scanAndRegisterAllConfigTypes(
-            @NonNull final ConfigurationBuilder configurationBuilder, @NonNull final String... packagePrefixes) {
-        ArgumentUtils.throwArgNull(packagePrefixes, "packagePrefixes");
-        return scanAndRegisterAllConfigTypes(configurationBuilder, Set.of(packagePrefixes), Collections.emptyList());
+            @NonNull final ConfigurationBuilder configurationBuilder, @NonNull final Set<String> packagePrefixes) {
+        Objects.requireNonNull(packagePrefixes, "packagePrefixes must not be null");
+        return scanAndRegisterAllConfigTypes(configurationBuilder, packagePrefixes, Collections.emptyList());
     }
 
     /**
@@ -75,7 +82,7 @@ public final class ConfigUtils {
             @NonNull final ConfigurationBuilder configurationBuilder,
             @NonNull final Set<String> packagePrefixes,
             @NonNull final List<URLClassLoaderWithLookup> additionalClassLoaders) {
-        ArgumentUtils.throwArgNull(configurationBuilder, "configurationBuilder");
+        Objects.requireNonNull(configurationBuilder, "configurationBuilder must not be null");
         loadAllConfigDataRecords(packagePrefixes, additionalClassLoaders)
                 .forEach(configurationBuilder::withConfigDataType);
         return configurationBuilder;
@@ -85,8 +92,8 @@ public final class ConfigUtils {
     private static Set<Class<? extends Record>> loadAllConfigDataRecords(
             @NonNull final Set<String> packagePrefixes,
             @NonNull final List<URLClassLoaderWithLookup> additionalClassLoaders) {
-        ArgumentUtils.throwArgNull(packagePrefixes, "packagePrefix");
-        ArgumentUtils.throwArgNull(additionalClassLoaders, "additionalClassLoaders");
+        Objects.requireNonNull(packagePrefixes, "packagePrefix must not be null");
+        Objects.requireNonNull(additionalClassLoaders, "additionalClassLoaders must not be null");
 
         final ClassGraph classGraph = new ClassGraph().enableAnnotationInfo();
 

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/config/ConfigUtilsTest.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/config/ConfigUtilsTest.java
@@ -24,6 +24,7 @@ import com.swirlds.common.metrics.config.MetricsConfig;
 import com.swirlds.common.metrics.platform.prometheus.PrometheusConfig;
 import com.swirlds.config.api.Configuration;
 import com.swirlds.config.api.ConfigurationBuilder;
+import java.util.Set;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -57,7 +58,7 @@ class ConfigUtilsTest {
         final ConfigurationBuilder configurationBuilder = ConfigurationBuilder.create();
 
         // when
-        ConfigUtils.scanAndRegisterAllConfigTypes(configurationBuilder, "not.available.package");
+        ConfigUtils.scanAndRegisterAllConfigTypes(configurationBuilder, Set.of("not.available.package"));
         final Configuration configuration = configurationBuilder.build();
 
         // then
@@ -70,7 +71,7 @@ class ConfigUtilsTest {
         final ConfigurationBuilder configurationBuilder = ConfigurationBuilder.create();
 
         // when
-        ConfigUtils.scanAndRegisterAllConfigTypes(configurationBuilder, "com.swirlds.common.config.sub");
+        ConfigUtils.scanAndRegisterAllConfigTypes(configurationBuilder, Set.of("com.swirlds.common.config.sub"));
         final Configuration configuration = configurationBuilder.build();
 
         // then

--- a/platform-sdk/swirlds-config-benchmark/src/jmh/java/com/swirlds/config/benchmark/ConfigUtilsBenchmark.java
+++ b/platform-sdk/swirlds-config-benchmark/src/jmh/java/com/swirlds/config/benchmark/ConfigUtilsBenchmark.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.swirlds.config.benchmark;
+
+import com.swirlds.common.config.ConfigUtils;
+import com.swirlds.config.api.ConfigData;
+import com.swirlds.config.api.Configuration;
+import com.swirlds.config.api.ConfigurationBuilder;
+import java.nio.file.FileSystem;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+@State(Scope.Benchmark)
+public class ConfigUtilsBenchmark {
+
+    Configuration configuration;
+
+    private FileSystem fileSystem;
+
+    public static void main(final String[] args) throws RunnerException {
+        final Options opt = new OptionsBuilder().build();
+        new Runner(opt).run();
+    }
+
+    @Benchmark
+    @Fork(1)
+    @Warmup(iterations = 3, time = 2)
+    @Measurement(iterations = 5, time = 2)
+    @OutputTimeUnit(TimeUnit.MILLISECONDS)
+    @BenchmarkMode({Mode.Throughput, Mode.SampleTime})
+    public void loadConfigurationNoScan(final Blackhole blackhole) {
+        final ConfigurationBuilder configurationBuilder = ConfigurationBuilder.create();
+        final ConfigurationBuilder modified = configurationBuilder.withConfigDataType(AppConfig.class);
+        blackhole.consume(modified);
+    }
+
+    @Benchmark
+    @Fork(1)
+    @Warmup(iterations = 3, time = 2)
+    @Measurement(iterations = 5, time = 2)
+    @OutputTimeUnit(TimeUnit.MILLISECONDS)
+    @BenchmarkMode({Mode.Throughput, Mode.SampleTime})
+    public void loadConfigurationDefault(final Blackhole blackhole) {
+        final ConfigurationBuilder configurationBuilder = ConfigurationBuilder.create();
+        final ConfigurationBuilder modified = ConfigUtils.scanAndRegisterAllConfigTypes(configurationBuilder);
+        blackhole.consume(modified);
+    }
+
+    @Benchmark
+    @Fork(1)
+    @Warmup(iterations = 3, time = 2)
+    @Measurement(iterations = 5, time = 2)
+    @OutputTimeUnit(TimeUnit.MILLISECONDS)
+    @BenchmarkMode({Mode.Throughput, Mode.SampleTime})
+    public void loadConfigurationWithAllPackages(final Blackhole blackhole) {
+        final ConfigurationBuilder configurationBuilder = ConfigurationBuilder.create();
+        final ConfigurationBuilder modified = ConfigUtils.scanAndRegisterAllConfigTypes(configurationBuilder, Set.of());
+        blackhole.consume(modified);
+    }
+
+    @ConfigData("app")
+    public record AppConfig(String name, int version) {}
+}

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/recovery/EventRecoveryWorkflow.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/recovery/EventRecoveryWorkflow.java
@@ -59,6 +59,7 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -109,7 +110,7 @@ public final class EventRecoveryWorkflow {
         }
 
         final ConfigurationBuilder configurationBuilder = ConfigurationBuilder.create();
-        ConfigUtils.scanAndRegisterAllConfigTypes(configurationBuilder, "com.swirlds");
+        ConfigUtils.scanAndRegisterAllConfigTypes(configurationBuilder, Set.of("com.swirlds"));
 
         // Recovery workflow doesn't need the metrics output.
         configurationBuilder.withSource(new SimpleConfigSource("disableMetricsOutput", "true"));

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/util/BootstrapUtils.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/util/BootstrapUtils.java
@@ -39,6 +39,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -48,7 +49,7 @@ import org.apache.logging.log4j.Logger;
 public final class BootstrapUtils {
 
     /** The logger for this class */
-    private static Logger logger = LogManager.getLogger(BootstrapUtils.class);
+    private static final Logger logger = LogManager.getLogger(BootstrapUtils.class);
 
     private BootstrapUtils() {}
 
@@ -82,7 +83,7 @@ public final class BootstrapUtils {
             final Class<?> mainClass = Class.forName(appMainName);
             final Constructor<?>[] constructors = mainClass.getDeclaredConstructors();
             Constructor<?> constructor = null;
-            for (Constructor<?> c : constructors) {
+            for (final Constructor<?> c : constructors) {
                 if (c.getGenericParameterTypes().length == 0) {
                     constructor = c;
                     break;
@@ -108,7 +109,7 @@ public final class BootstrapUtils {
     public static Configuration loadConfiguration(final List<Path> configurationPaths) throws IOException {
         final ConfigurationBuilder configurationBuilder = ConfigurationBuilder.create();
 
-        ConfigUtils.scanAndRegisterAllConfigTypes(configurationBuilder, "com.swirlds");
+        ConfigUtils.scanAndRegisterAllConfigTypes(configurationBuilder, Set.of("com.swirlds"));
 
         for (final Path configPath : configurationPaths) {
             configurationBuilder.withSource(new LegacyFileConfigSource(configPath));

--- a/platform-sdk/swirlds-unit-tests/common/swirlds-test-framework/src/main/java/com/swirlds/test/framework/config/TestConfigBuilder.java
+++ b/platform-sdk/swirlds-unit-tests/common/swirlds-test-framework/src/main/java/com/swirlds/test/framework/config/TestConfigBuilder.java
@@ -16,8 +16,6 @@
 
 package com.swirlds.test.framework.config;
 
-import static com.swirlds.common.utility.CommonUtils.throwArgNull;
-
 import com.swirlds.common.config.ConfigUtils;
 import com.swirlds.common.config.singleton.ConfigurationHolder;
 import com.swirlds.common.config.sources.SimpleConfigSource;
@@ -27,7 +25,12 @@ import com.swirlds.common.threading.locks.locked.Locked;
 import com.swirlds.config.api.ConfigData;
 import com.swirlds.config.api.Configuration;
 import com.swirlds.config.api.ConfigurationBuilder;
+import com.swirlds.config.api.converter.ConfigConverter;
 import com.swirlds.config.api.source.ConfigSource;
+import com.swirlds.config.api.validation.ConfigValidator;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+import java.util.Objects;
 
 /**
  * Helper for use the config in test and change the config for specific tests. Instance can be used per class or per
@@ -42,15 +45,30 @@ public class TestConfigBuilder {
     private final ConfigurationBuilder builder;
 
     /**
-     * Creates a new instance and automatically registers all config data records on classpath (see {@link ConfigData})
+     * Creates a new instance and automatically registers all config data records (see {@link ConfigData}) on classpath
+     * / modulepath that are part of the packages {@code com.swirlds} and {@code com.hedera} (see {@link ConfigUtils}).
      */
     public TestConfigBuilder() {
         this(true);
     }
 
     /**
-     * Creates a new instance and add all records on classpath that are annotated with {@link ConfigData} as config data
-     * types if the {@code registerAllTypes} param is true.
+     * Creates a new instance and automatically registers all given config data records. This call will not do a class
+     * scan for config data records on classpath / modulepath like some of the other constructors do.
+     *
+     * @param dataTypes
+     */
+    public TestConfigBuilder(@Nullable final Class<? extends Record> dataTypes) {
+        this(false);
+        if (dataTypes != null) {
+            this.builder.withConfigDataTypes(dataTypes);
+        }
+    }
+
+    /**
+     * Creates a new instance and automatically registers all config data records (see {@link ConfigData}) on classpath
+     * / modulepath that are part of the packages {@code com.swirlds} and {@code com.hedera} (see {@link ConfigUtils})
+     * if the {@code registerAllTypes} param is true.
      *
      * @param registerAllTypes if true all config data records on classpath will automatically be registered
      */
@@ -69,7 +87,8 @@ public class TestConfigBuilder {
      * @param value        the value
      * @return the {@link TestConfigBuilder} instance (for fluent API)
      */
-    public TestConfigBuilder withValue(final String propertyName, final String value) {
+    @NonNull
+    public TestConfigBuilder withValue(@NonNull final String propertyName, @Nullable final String value) {
         return withSource(new SimpleConfigSource(propertyName, value));
     }
 
@@ -80,7 +99,8 @@ public class TestConfigBuilder {
      * @param value        the value
      * @return the {@link TestConfigBuilder} instance (for fluent API)
      */
-    public TestConfigBuilder withValue(final String propertyName, final int value) {
+    @NonNull
+    public TestConfigBuilder withValue(@NonNull final String propertyName, final int value) {
         return withSource(new SimpleConfigSource(propertyName, value));
     }
 
@@ -91,7 +111,8 @@ public class TestConfigBuilder {
      * @param value        the value
      * @return the {@link TestConfigBuilder} instance (for fluent API)
      */
-    public TestConfigBuilder withValue(final String propertyName, final double value) {
+    @NonNull
+    public TestConfigBuilder withValue(@NonNull final String propertyName, final double value) {
         return withSource(new SimpleConfigSource(propertyName, value));
     }
 
@@ -102,7 +123,8 @@ public class TestConfigBuilder {
      * @param value        the value
      * @return the {@link TestConfigBuilder} instance (for fluent API)
      */
-    public TestConfigBuilder withValue(final String propertyName, final long value) {
+    @NonNull
+    public TestConfigBuilder withValue(@NonNull final String propertyName, final long value) {
         return withSource(new SimpleConfigSource(propertyName, value));
     }
 
@@ -113,21 +135,21 @@ public class TestConfigBuilder {
      * @param value        the value
      * @return the {@link TestConfigBuilder} instance (for fluent API)
      */
-    public TestConfigBuilder withValue(final String propertyName, final boolean value) {
+    @NonNull
+    public TestConfigBuilder withValue(@NonNull final String propertyName, final boolean value) {
         return withSource(new SimpleConfigSource(propertyName, value));
     }
 
     /**
      * Sets the value for the config.
      *
-     * @param propertyName
-     * 		name of the property
-     * @param value
-     * 		the value
+     * @param propertyName name of the property
+     * @param value        the value
      * @return the {@link TestConfigBuilder} instance (for fluent API)
      */
-    public TestConfigBuilder withValue(final String propertyName, final Object value) {
-        throwArgNull(value, "value");
+    @NonNull
+    public TestConfigBuilder withValue(@NonNull final String propertyName, @NonNull final Object value) {
+        Objects.requireNonNull(value, "value must not be null");
         return withSource(new SimpleConfigSource(propertyName, value.toString()));
     }
 
@@ -139,6 +161,7 @@ public class TestConfigBuilder {
      *
      * @return the created configuration
      */
+    @NonNull
     public Configuration getOrCreateConfig() {
         try (final Locked ignore = configLock.lock()) {
             if (configuration == null) {
@@ -163,9 +186,51 @@ public class TestConfigBuilder {
      * @param configSource the config source that will be added
      * @return the {@link TestConfigBuilder} instance (for fluent API)
      */
-    public TestConfigBuilder withSource(final ConfigSource configSource) {
+    @NonNull
+    public TestConfigBuilder withSource(@NonNull final ConfigSource configSource) {
         checkConfigState();
         builder.withSource(configSource);
+        return this;
+    }
+
+    /**
+     * Adds the given config converter to the builder
+     *
+     * @param converter the config converter that will be added
+     * @param <T>       the type of the config converter
+     * @return the {@link TestConfigBuilder} instance (for fluent API)
+     */
+    @NonNull
+    public <T> TestConfigBuilder withConverter(@NonNull final ConfigConverter<T> converter) {
+        checkConfigState();
+        builder.withConverter(converter);
+        return this;
+    }
+
+    /**
+     * Adds the given config validator to the builder
+     *
+     * @param validator the config validator that will be added
+     * @return the {@link TestConfigBuilder} instance (for fluent API)
+     */
+    @NonNull
+    public TestConfigBuilder withValidator(@NonNull final ConfigValidator validator) {
+        checkConfigState();
+        builder.withValidator(validator);
+        return this;
+    }
+
+    /**
+     * Adds the given config data type to the builder
+     *
+     * @param type the config data type that will be added
+     * @param <T>  the type of the config data type
+     * @return the {@link TestConfigBuilder} instance (for fluent API)
+     */
+    @NonNull
+    public <T extends Record> TestConfigBuilder withValidator(@NonNull final Class<T> type) {
+        checkConfigState();
+        builder.withConfigDataType(type);
         return this;
     }
 }


### PR DESCRIPTION
To simplify the creation of tests we provide the `TestConfigBuilder` class that creates a new config for each test execution. To not add all available config records by hand the class internally does a class scan to find all that records (see `ConfigUtils`). As you might assume such scan takes some time and in services that has much more stuff on the class path with a lot of unit tests the amount of time that it takes to do all the scans for each test is super high.

This PR improves the performance by default only scanning classes in the `com.swirlds` and `com.hedera` packages. Next to that the functionality to deactivate the scan for the creation of a `TestConfigBuilder` instance is added.

I added a JMH benchmark to test the performance of all 3 variants:

- Not doing a scan at all and adding the record manually needs **10⁻⁴ ms** for execution
- Using the new scan that only scans the `com.swirlds` and `com.hedera` packages needs  **24,805 ms** for execution 
- The old implementation that scans the complete class path / module path needs **249,561 ms** for execution

Based on that all test executions should be about 220 ms faster. I hope that that will bring a lot of performance to the test runs. If some tests are executed thousands of times since they are parameterized it would still make sense to check if a scan is needed for them or if we can simply add the needed config records by hand.

