### PR TITLE
AppTestBase use simple config

### DIFF
--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/AppTestBase.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/AppTestBase.java
@@ -27,7 +27,8 @@ import com.swirlds.common.metrics.platform.DefaultMetrics;
 import com.swirlds.common.metrics.platform.DefaultMetricsFactory;
 import com.swirlds.common.metrics.platform.MetricKeyRegistry;
 import com.swirlds.common.system.NodeId;
-import com.swirlds.test.framework.config.TestConfigBuilder;
+import com.swirlds.config.api.Configuration;
+import com.swirlds.config.api.ConfigurationBuilder;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 
@@ -44,20 +45,26 @@ public class AppTestBase extends TestBase implements TransactionFactory {
     protected final AccountID nodeSelfAccountId =
             AccountID.newBuilder().shardNum(0).realmNum(0).accountNum(8).build();
 
-    private final MetricsConfig metricsConfig =
-            new TestConfigBuilder().getOrCreateConfig().getConfigData(MetricsConfig.class);
     /**
-     * The gRPC system has extensive metrics. This object allows us to inspect them and make sure
-     * they are being set correctly for different types of calls.
+     * The gRPC system has extensive metrics. This object allows us to inspect them and make sure they are being set
+     * correctly for different types of calls.
      */
-    protected Metrics metrics = new DefaultMetrics(
-            nodeSelfId, new MetricKeyRegistry(), METRIC_EXECUTOR, new DefaultMetricsFactory(), metricsConfig);
+    protected final Metrics metrics;
 
-    protected Counter counterMetric(String name) {
+    public AppTestBase() {
+        final Configuration configuration = ConfigurationBuilder.create()
+                .withConfigDataType(MetricsConfig.class)
+                .build();
+        final MetricsConfig metricsConfig = configuration.getConfigData(MetricsConfig.class);
+        this.metrics = new DefaultMetrics(
+                nodeSelfId, new MetricKeyRegistry(), METRIC_EXECUTOR, new DefaultMetricsFactory(), metricsConfig);
+    }
+
+    protected Counter counterMetric(final String name) {
         return (Counter) metrics.getMetric("app", name);
     }
 
-    protected SpeedometerMetric speedometerMetric(String name) {
+    protected SpeedometerMetric speedometerMetric(final String name) {
         return (SpeedometerMetric) metrics.getMetric("app", name);
     }
 }


### PR DESCRIPTION
Instead of using the test config and doing a full class scan the AppTestBase class use a basic config that only knows about the metrics config.