### PR TITLE
Call getNumberOfChildren() less in iterator.

### DIFF
--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/iterators/internal/PostOrderedDepthFirstRandomAlgorithm.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/iterators/internal/PostOrderedDepthFirstRandomAlgorithm.java
@@ -38,8 +38,9 @@ public class PostOrderedDepthFirstRandomAlgorithm extends PostOrderedDepthFirstA
      */
     @Override
     public void pushChildren(final MerkleInternal parent, final ObjIntConsumer<MerkleInternal> pushNode) {
-        final List<Integer> iterationOrder = new ArrayList<>(parent.getNumberOfChildren());
-        for (int childIndex = 0; childIndex < parent.getNumberOfChildren(); childIndex++) {
+        final int childCount = parent.getNumberOfChildren();
+        final List<Integer> iterationOrder = new ArrayList<>(childCount);
+        for (int childIndex = 0; childIndex < childCount; childIndex++) {
             iterationOrder.add(childIndex);
         }
 


### PR DESCRIPTION
Closes #6278 

Emergency mitigation for performance issue noticed by Oleg where calling `parent.getNumberOfChildren()` ends up being very expensive due to the way Java does inheritance and virtual methods.

This is not a full fix, but will reduce the number of times this method is called to 1/4th its previous number (for binary trees).
