### PR TITLE
Distinguish auto-approvals in synthetic `CryptoTransfer` transfer lists

### DIFF
--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/TransferPrecompile.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/TransferPrecompile.java
@@ -735,7 +735,7 @@ public class TransferPrecompile extends AbstractWritePrecompile {
                 if (hbarAdjust.getAmount() < 0) {
                     hbarAdjust.setIsApproval(true);
                 } else {
-                    log.warn(CHANGE_SWITCHED_TO_APPROVAL_MATCHED_CREDIT_IN, switchedChange, opBuilder);
+                    log.error(CHANGE_SWITCHED_TO_APPROVAL_MATCHED_CREDIT_IN, switchedChange, opBuilder);
                 }
                 return;
             }
@@ -743,7 +743,7 @@ public class TransferPrecompile extends AbstractWritePrecompile {
         // This doesn't make sense, as it implies the TransferPrecompile has switched a non-custom-fee hbar
         // adjustment to approval-based authorization, but the synthetic CryptoTransfer op doesn't have a
         // matching adjustment in its transfer list
-        log.warn(CHANGE_SWITCHED_TO_APPROVAL_WITHOUT_MATCHING_ADJUSTMENT_IN, switchedChange, opBuilder);
+        log.error(CHANGE_SWITCHED_TO_APPROVAL_WITHOUT_MATCHING_ADJUSTMENT_IN, switchedChange, opBuilder);
     }
 
     /**
@@ -792,7 +792,7 @@ public class TransferPrecompile extends AbstractWritePrecompile {
                             .getTransfersBuilder(j)
                             .setIsApproval(true);
                 } else {
-                    log.warn(CHANGE_SWITCHED_TO_APPROVAL_MATCHED_CREDIT_IN, switchedChange, opBuilder);
+                    log.error(CHANGE_SWITCHED_TO_APPROVAL_MATCHED_CREDIT_IN, switchedChange, opBuilder);
                 }
                 return;
             }
@@ -800,7 +800,7 @@ public class TransferPrecompile extends AbstractWritePrecompile {
         // This doesn't make sense, as it implies the TransferPrecompile has switched a non-custom-fee fungible
         // adjustment to approval-based authorization, but the synthetic CryptoTransfer op doesn't have a
         // matching adjustment in its token transfer list
-        log.warn(CHANGE_SWITCHED_TO_APPROVAL_WITHOUT_MATCHING_ADJUSTMENT_IN, switchedChange, opBuilder);
+        log.error(CHANGE_SWITCHED_TO_APPROVAL_WITHOUT_MATCHING_ADJUSTMENT_IN, switchedChange, opBuilder);
     }
 
     /**
@@ -830,6 +830,6 @@ public class TransferPrecompile extends AbstractWritePrecompile {
         // This doesn't make sense, as it implies the TransferPrecompile has switched a non-custom-fee NFT
         // ownership change to approval-based authorization, but the synthetic CryptoTransfer op doesn't
         // have a matching ownership change in its token transfer list
-        log.warn(CHANGE_SWITCHED_TO_APPROVAL_WITHOUT_MATCHING_ADJUSTMENT_IN, switchedChange, opBuilder);
+        log.error(CHANGE_SWITCHED_TO_APPROVAL_WITHOUT_MATCHING_ADJUSTMENT_IN, switchedChange, opBuilder);
     }
 }

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/TransferPrecompile.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/TransferPrecompile.java
@@ -78,6 +78,7 @@ import com.hederahashgraph.api.proto.java.Timestamp;
 import com.hederahashgraph.api.proto.java.TokenID;
 import com.hederahashgraph.api.proto.java.TokenTransferList;
 import com.hederahashgraph.api.proto.java.TransactionBody;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -88,11 +89,14 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.function.Predicate;
 import java.util.function.UnaryOperator;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes;
 import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.evm.frame.MessageFrame;
 
 public class TransferPrecompile extends AbstractWritePrecompile {
+    private static final Logger log = LogManager.getLogger(TransferPrecompile.class);
     private static final Function CRYPTO_TRANSFER_FUNCTION =
             new Function("cryptoTransfer((address,(address,int64)[],(address,address,int64)[])[])", INT);
     private static final Function CRYPTO_TRANSFER_FUNCTION_V2 = new Function(
@@ -123,6 +127,8 @@ public class TransferPrecompile extends AbstractWritePrecompile {
     private static final Bytes TRANSFER_NFT_SELECTOR = Bytes.wrap(TRANSFER_NFT_FUNCTION.selector());
     private static final ABIType<Tuple> TRANSFER_NFT_DECODER = TypeFactory.create("(bytes32,bytes32,bytes32,int64)");
     private static final String TRANSFER = String.format(FAILURE_MESSAGE, "transfer");
+    private static final String CHANGE_SWITCHED_TO_APPROVAL_WITHOUT_MATCHING_ADJUSTMENT_IN =
+            "Change {} switched to approval without matching adjustment in {}";
     private final HederaStackedWorldStateUpdater updater;
     private final EvmSigsVerifier sigsVerifier;
     private final int functionId;
@@ -276,7 +282,7 @@ public class TransferPrecompile extends AbstractWritePrecompile {
                 // one of the HAPI-style transfer precompiles
                 if (!senderHasSignedOrIsMsgSenderInFrame && !topLevelSigsAreEnabled && canFallbackToApprovals) {
                     change.switchToApproved();
-                    updateBodyForAutoApprovalOf(transactionBody.getCryptoTransferBuilder(), change);
+                    updateSynthOpForAutoApprovalOf(transactionBody.getCryptoTransferBuilder(), change);
                     continue;
                 } else {
                     validateTrue(
@@ -365,77 +371,6 @@ public class TransferPrecompile extends AbstractWritePrecompile {
         final var hbarOnly = transferOp.transferWrapper().hbarTransfers().size();
         impliedTransfers = impliedTransfersMarshal.assessCustomFeesAndValidate(
                 hbarOnly, 0, numLazyCreates, explicitChanges, NO_ALIASES, impliedTransfersMarshal.currentProps());
-    }
-
-    @VisibleForTesting
-    static void updateBodyForAutoApprovalOf(
-            final CryptoTransferTransactionBody.Builder opBuilder, final BalanceChange switchedChange) {
-        if (switchedChange.isForHbar()) {
-            updateBodyForAutoApprovalOfHbar(opBuilder, switchedChange);
-        } else {
-            updateBodyForAutoApprovalOfToken(opBuilder, switchedChange);
-        }
-    }
-
-    private static void updateBodyForAutoApprovalOfHbar(
-            final CryptoTransferTransactionBody.Builder opBuilder, final BalanceChange switchedChange) {
-        final var transfersBuilder = opBuilder.getTransfersBuilder();
-        for (int i = 0, n = transfersBuilder.getAccountAmountsCount(); i < n; i++) {
-            final var hbarAdjust = transfersBuilder.getAccountAmountsBuilder(i);
-            if (hbarAdjust.getAccountID().equals(switchedChange.accountId())) {
-                hbarAdjust.setIsApproval(true);
-                return;
-            }
-        }
-    }
-
-    private static void updateBodyForAutoApprovalOfToken(
-            final CryptoTransferTransactionBody.Builder opBuilder, final BalanceChange switchedChange) {
-        for (int i = 0, n = opBuilder.getTokenTransfersCount(); i < n; i++) {
-            final var tokenTransfers = opBuilder.getTokenTransfers(i);
-            if (tokenTransfers.getToken().equals(switchedChange.tokenId())) {
-                if (switchedChange.isForNft()) {
-                    updateBodyForAutoApprovalOfNonFungible(opBuilder, tokenTransfers, switchedChange, i);
-                } else {
-                    updateBodyForAutoApprovalOfFungible(opBuilder, tokenTransfers, switchedChange, i);
-                }
-            }
-        }
-    }
-
-    private static void updateBodyForAutoApprovalOfFungible(
-            final CryptoTransferTransactionBody.Builder opBuilder,
-            final TokenTransferList tokenTransfers,
-            final BalanceChange switchedChange,
-            final int tokenTransfersIndex) {
-        for (int j = 0, m = tokenTransfers.getTransfersCount(); j < m; j++) {
-            final var adjust = tokenTransfers.getTransfers(j);
-            if (adjust.getAccountID().equals(switchedChange.accountId())) {
-                opBuilder
-                        .getTokenTransfersBuilder(tokenTransfersIndex)
-                        .getTransfersBuilder(j)
-                        .setIsApproval(true);
-                break;
-            }
-        }
-    }
-
-    private static void updateBodyForAutoApprovalOfNonFungible(
-            final CryptoTransferTransactionBody.Builder opBuilder,
-            final TokenTransferList tokenTransfers,
-            final BalanceChange switchedChange,
-            final int tokenTransfersIndex) {
-        for (int j = 0, m = tokenTransfers.getNftTransfersCount(); j < m; j++) {
-            final var change = tokenTransfers.getNftTransfers(j);
-            if (change.getSenderAccountID().equals(switchedChange.accountId())
-                    && change.getSerialNumber() == switchedChange.serialNo()) {
-                opBuilder
-                        .getTokenTransfersBuilder(tokenTransfersIndex)
-                        .getNftTransfersBuilder(j)
-                        .setIsApproval(true);
-                break;
-            }
-        }
     }
 
     @Override
@@ -752,5 +687,139 @@ public class TransferPrecompile extends AbstractWritePrecompile {
 
     public void setCanFallbackToApprovals(final boolean canFallbackToApprovals) {
         this.canFallbackToApprovals = canFallbackToApprovals;
+    }
+
+    /**
+     * Given a {@link BalanceChange} that was switched from key-based authorization to approval-based authorization,
+     * tries to update the matching adjustment in the transfer list of the in-progress synthetic {@code CryptoTransfer}
+     * op to reflect the switch.
+     *
+     * <p><b>Important:</b> this method acts via side effects, mutating the given {@code opBuilder} in-place.
+     *
+     * @param opBuilder the builder for the in-progress synthetic {@code CryptoTransfer} op
+     * @param switchedChange the {@code BalanceChange} switched to approval-based authorization
+     */
+    @VisibleForTesting
+    static void updateSynthOpForAutoApprovalOf(
+            @NonNull final CryptoTransferTransactionBody.Builder opBuilder,
+            @NonNull final BalanceChange switchedChange) {
+        if (switchedChange.isForCustomFee()) {
+            // The synthetic CryptoTransfer op won't have any transfer list entry for a custom fee adjustment,
+            // so we can't externalize any more info in this case (given the current record creation logic)
+            return;
+        }
+        if (switchedChange.isForHbar()) {
+            updateSynthOpForAutoApprovalOfHbar(opBuilder, switchedChange);
+        } else {
+            updateSynthOpForAutoApprovalOfToken(opBuilder, switchedChange);
+        }
+    }
+
+    /**
+     * Given an hbar {@link BalanceChange} that was switched from key-based authorization to approval-based
+     * authorization, tries to update the matching adjustment in the hbar transfer list of the in-progress
+     * synthetic {@code CryptoTransfer} op to reflect the switch.
+     *
+     * @param opBuilder the builder for the in-progress synthetic {@code CryptoTransfer} op
+     * @param switchedChange the hbar {@code BalanceChange} switched to approval-based authorization
+     */
+    private static void updateSynthOpForAutoApprovalOfHbar(
+            @NonNull final CryptoTransferTransactionBody.Builder opBuilder,
+            @NonNull final BalanceChange switchedChange) {
+        final var transfersBuilder = opBuilder.getTransfersBuilder();
+        for (int i = 0, n = transfersBuilder.getAccountAmountsCount(); i < n; i++) {
+            final var hbarAdjust = transfersBuilder.getAccountAmountsBuilder(i);
+            if (hbarAdjust.getAccountID().equals(switchedChange.accountId())) {
+                hbarAdjust.setIsApproval(true);
+                return;
+            }
+        }
+        // This doesn't make sense, as it implies the TransferPrecompile has switched a non-custom-fee hbar
+        // adjustment to approval-based authorization, but the synthetic CryptoTransfer op doesn't have a
+        // matching adjustment in its transfer list
+        log.warn(CHANGE_SWITCHED_TO_APPROVAL_WITHOUT_MATCHING_ADJUSTMENT_IN, switchedChange, opBuilder);
+    }
+
+    /**
+     * Given a token {@link BalanceChange} that was switched from key-based authorization to approval-based
+     * authorization, tries to update the matching adjustment in the token transfer list of the in-progress
+     * synthetic {@code CryptoTransfer} op to reflect the switch.
+     *
+     * @param opBuilder the builder for the in-progress synthetic {@code CryptoTransfer} op
+     * @param switchedChange the token {@code BalanceChange} switched to approval-based authorization
+     */
+    private static void updateSynthOpForAutoApprovalOfToken(
+            final CryptoTransferTransactionBody.Builder opBuilder, final BalanceChange switchedChange) {
+        for (int i = 0, n = opBuilder.getTokenTransfersCount(); i < n; i++) {
+            final var tokenTransfers = opBuilder.getTokenTransfers(i);
+            if (tokenTransfers.getToken().equals(switchedChange.tokenId())) {
+                if (switchedChange.isForNft()) {
+                    updateBodyForAutoApprovalOfNonFungible(opBuilder, tokenTransfers, switchedChange, i);
+                } else {
+                    updateBodyForAutoApprovalOfFungible(opBuilder, tokenTransfers, switchedChange, i);
+                }
+                // Token ids cannot be repeated, so if there was an adjustment matching this change, it was in this list
+                return;
+            }
+        }
+    }
+
+    /**
+     * Given a fungible {@link BalanceChange} that was switched from key-based authorization to approval-based
+     * authorization, tries to update the matching adjustment in the token transfer list of the in-progress
+     * synthetic {@code CryptoTransfer} op to reflect the switch.
+     *
+     * @param opBuilder the builder for the in-progress synthetic {@code CryptoTransfer} op
+     * @param switchedChange the fungible {@code BalanceChange} switched to approval-based authorization
+     */
+    private static void updateBodyForAutoApprovalOfFungible(
+            final CryptoTransferTransactionBody.Builder opBuilder,
+            final TokenTransferList tokenTransfers,
+            final BalanceChange switchedChange,
+            final int tokenTransfersIndex) {
+        for (int j = 0, m = tokenTransfers.getTransfersCount(); j < m; j++) {
+            final var adjust = tokenTransfers.getTransfers(j);
+            if (adjust.getAccountID().equals(switchedChange.accountId())) {
+                opBuilder
+                        .getTokenTransfersBuilder(tokenTransfersIndex)
+                        .getTransfersBuilder(j)
+                        .setIsApproval(true);
+                return;
+            }
+        }
+        // This doesn't make sense, as it implies the TransferPrecompile has switched a non-custom-fee fungible
+        // adjustment to approval-based authorization, but the synthetic CryptoTransfer op doesn't have a
+        // matching adjustment in its token transfer list
+        log.warn(CHANGE_SWITCHED_TO_APPROVAL_WITHOUT_MATCHING_ADJUSTMENT_IN, switchedChange, opBuilder);
+    }
+
+    /**
+     * Given a non-fungible {@link BalanceChange} that was switched from key-based authorization to approval-based
+     * authorization, tries to update the matching adjustment in the token transfer list of the in-progress
+     * synthetic {@code CryptoTransfer} op to reflect the switch.
+     *
+     * @param opBuilder the builder for the in-progress synthetic {@code CryptoTransfer} op
+     * @param switchedChange the non-fungible {@code BalanceChange} switched to approval-based authorization
+     */
+    private static void updateBodyForAutoApprovalOfNonFungible(
+            final CryptoTransferTransactionBody.Builder opBuilder,
+            final TokenTransferList tokenTransfers,
+            final BalanceChange switchedChange,
+            final int tokenTransfersIndex) {
+        for (int j = 0, m = tokenTransfers.getNftTransfersCount(); j < m; j++) {
+            final var change = tokenTransfers.getNftTransfers(j);
+            if (change.getSenderAccountID().equals(switchedChange.accountId())
+                    && change.getSerialNumber() == switchedChange.serialNo()) {
+                opBuilder
+                        .getTokenTransfersBuilder(tokenTransfersIndex)
+                        .getNftTransfersBuilder(j)
+                        .setIsApproval(true);
+                return;
+            }
+        }
+        // This doesn't make sense, as it implies the TransferPrecompile has switched a non-custom-fee NFT
+        // ownership change to approval-based authorization, but the synthetic CryptoTransfer op doesn't
+        // have a matching ownership change in its token transfer list
+        log.warn(CHANGE_SWITCHED_TO_APPROVAL_WITHOUT_MATCHING_ADJUSTMENT_IN, switchedChange, opBuilder);
     }
 }

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/ERC20PrecompilesTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/ERC20PrecompilesTest.java
@@ -1572,6 +1572,7 @@ class ERC20PrecompilesTest {
                         .setCryptoTransfer(cryptoTransferTransactionBody)
                         .build());
         given(mockSynthBodyBuilder.setTransactionID(any(TransactionID.class))).willReturn(mockSynthBodyBuilder);
+        given(mockSynthBodyBuilder.getCryptoTransferBuilder()).willReturn(CryptoTransferTransactionBody.newBuilder());
         given(feeCalculator.computeFee(any(), any(), any(), any())).willReturn(mockFeeObject);
         given(mockFeeObject.serviceFee()).willReturn(1L);
         given(creator.createSuccessfulSyntheticRecord(Collections.emptyList(), sideEffects, EMPTY_MEMO))

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/SynthApprovalRecordsTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/SynthApprovalRecordsTest.java
@@ -35,10 +35,10 @@ class SynthApprovalRecordsTest {
         final var amount = 10;
         final var debited = IdUtils.asModelId("0.0.3");
         final var payer = IdUtils.asModelId("0.0.5");
-        final var hbarAdjust = BalanceChange.changingHbar(
-                aaWith(debited.asGrpcAccount(), -amount).build(), payer.asGrpcAccount());
+        final var aaDebit = aaWith(debited.asGrpcAccount(), -amount).build();
+        final var hbarAdjust = BalanceChange.changingHbar(aaDebit, payer.asGrpcAccount());
         final var synthOp = CryptoTransferTransactionBody.newBuilder()
-                .setTransfers(TransferList.newBuilder().addAccountAmounts(aaWith(debited.asGrpcAccount(), -amount)));
+                .setTransfers(TransferList.newBuilder().addAccountAmounts(aaDebit));
         final var approvedSynthOp = CryptoTransferTransactionBody.newBuilder()
                 .setTransfers(TransferList.newBuilder()
                         .addAccountAmounts(

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/SynthApprovalRecordsTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/SynthApprovalRecordsTest.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.node.app.service.mono.store.contracts.precompile.impl;
+
+import static com.hedera.node.app.service.mono.store.contracts.precompile.impl.TransferPrecompile.updateBodyForAutoApprovalOf;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.hedera.node.app.service.mono.ledger.BalanceChange;
+import com.hedera.test.utils.IdUtils;
+import com.hederahashgraph.api.proto.java.AccountAmount;
+import com.hederahashgraph.api.proto.java.AccountID;
+import com.hederahashgraph.api.proto.java.CryptoTransferTransactionBody;
+import com.hederahashgraph.api.proto.java.NftTransfer;
+import com.hederahashgraph.api.proto.java.TokenTransferList;
+import com.hederahashgraph.api.proto.java.TransferList;
+import org.junit.jupiter.api.Test;
+
+class SynthApprovalRecordsTest {
+    @Test
+    void canUpdateHbarAutoApprovals() {
+        final var amount = 10;
+        final var debited = IdUtils.asModelId("0.0.3");
+        final var payer = IdUtils.asModelId("0.0.5");
+        final var hbarAdjust = BalanceChange.changingHbar(
+                aaWith(debited.asGrpcAccount(), -amount).build(), payer.asGrpcAccount());
+        final var synthOp = CryptoTransferTransactionBody.newBuilder()
+                .setTransfers(TransferList.newBuilder().addAccountAmounts(aaWith(debited.asGrpcAccount(), -amount)));
+        final var approvedSynthOp = CryptoTransferTransactionBody.newBuilder()
+                .setTransfers(TransferList.newBuilder()
+                        .addAccountAmounts(
+                                aaWith(debited.asGrpcAccount(), -amount).setIsApproval(true)));
+
+        updateBodyForAutoApprovalOf(synthOp, hbarAdjust);
+
+        assertEquals(approvedSynthOp.build(), synthOp.build());
+    }
+
+    @Test
+    void canUpdateFungibleAutoApprovals() {
+        final var amount = 10;
+        final var debited = IdUtils.asModelId("0.0.3");
+        final var credited = IdUtils.asModelId("0.0.6");
+        final var payer = IdUtils.asModelId("0.0.5");
+        final var tokenId = IdUtils.asModelId("0.0.4");
+        final var tokenCredit =
+                BalanceChange.tokenAdjust(credited, tokenId, +amount, payer.asGrpcAccount(), false, false);
+        final var tokenDebit =
+                BalanceChange.tokenAdjust(debited, tokenId, -amount, payer.asGrpcAccount(), false, false);
+        final var synthOp = CryptoTransferTransactionBody.newBuilder()
+                .addTokenTransfers(TokenTransferList.newBuilder()
+                        .setToken(tokenId.asGrpcToken())
+                        .addTransfers(aaWith(credited.asGrpcAccount(), +amount))
+                        .addTransfers(aaWith(debited.asGrpcAccount(), -amount)));
+        final var approvedSynthOp = CryptoTransferTransactionBody.newBuilder()
+                .addTokenTransfers(TokenTransferList.newBuilder()
+                        .setToken(tokenId.asGrpcToken())
+                        .addTransfers(aaWith(credited.asGrpcAccount(), +amount))
+                        .addTransfers(aaWith(debited.asGrpcAccount(), -amount).setIsApproval(true)));
+
+        updateBodyForAutoApprovalOf(synthOp, tokenDebit);
+
+        assertEquals(approvedSynthOp.build(), synthOp.build());
+    }
+
+    @Test
+    void canUpdateNonFungibleAutoApprovals() {
+        final var changedSerialNo = 666L;
+        final var unchangedSerialNo = 777L;
+        final var sender = IdUtils.asModelId("0.0.3");
+        final var receiver = IdUtils.asModelId("0.0.6");
+        final var payer = IdUtils.asModelId("0.0.5");
+        final var tokenId = IdUtils.asModelId("0.0.4");
+        final var nftTransfer = ntWith(sender.asGrpcAccount(), receiver.asGrpcAccount(), changedSerialNo)
+                .build();
+        final var otherNftTransfer = ntWith(sender.asGrpcAccount(), receiver.asGrpcAccount(), unchangedSerialNo)
+                .build();
+        final var nftExchange =
+                BalanceChange.changingNftOwnership(tokenId, tokenId.asGrpcToken(), nftTransfer, payer.asGrpcAccount());
+        final var synthOp = CryptoTransferTransactionBody.newBuilder()
+                .addTokenTransfers(TokenTransferList.newBuilder()
+                        .setToken(tokenId.asGrpcToken())
+                        .addNftTransfers(otherNftTransfer)
+                        .addNftTransfers(nftTransfer));
+        final var approvedSynthOp = CryptoTransferTransactionBody.newBuilder()
+                .addTokenTransfers(TokenTransferList.newBuilder()
+                        .setToken(tokenId.asGrpcToken())
+                        .addNftTransfers(otherNftTransfer)
+                        .addNftTransfers(
+                                nftTransfer.toBuilder().setIsApproval(true).build()));
+
+        updateBodyForAutoApprovalOf(synthOp, nftExchange);
+
+        assertEquals(approvedSynthOp.build(), synthOp.build());
+    }
+
+    private static AccountAmount.Builder aaWith(final AccountID account, final long amount) {
+        return AccountAmount.newBuilder().setAccountID(account).setAmount(amount);
+    }
+
+    private static NftTransfer.Builder ntWith(final AccountID sender, final AccountID receiver, final long serialNo) {
+        return NftTransfer.newBuilder()
+                .setSenderAccountID(sender)
+                .setReceiverAccountID(receiver)
+                .setSerialNumber(serialNo);
+    }
+}

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/HapiSpecRegistry.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/HapiSpecRegistry.java
@@ -556,6 +556,10 @@ public class HapiSpecRegistry {
         return get(name, TransactionID.class);
     }
 
+    public Optional<TransactionID> getMaybeTxnId(String name) {
+        return Optional.ofNullable(getOrElse(name, TransactionID.class, null));
+    }
+
     public void saveAccountId(String name, AccountID id) {
         put(name, id);
         put(asAccountString(id), name);

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/UtilVerbs.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/UtilVerbs.java
@@ -110,10 +110,12 @@ import com.hedera.services.bdd.spec.utilops.pauses.NodeLivenessTimeout;
 import com.hedera.services.bdd.spec.utilops.streams.RecordAssertions;
 import com.hedera.services.bdd.spec.utilops.streams.RecordFileChecker;
 import com.hedera.services.bdd.spec.utilops.streams.RecordStreamVerification;
+import com.hedera.services.bdd.spec.utilops.streams.assertions.AssertingBiConsumer;
 import com.hedera.services.bdd.spec.utilops.streams.assertions.CryptoCreateAssertion;
 import com.hedera.services.bdd.spec.utilops.streams.assertions.EventualAssertion;
 import com.hedera.services.bdd.spec.utilops.streams.assertions.EventualRecordStreamAssertion;
 import com.hedera.services.bdd.spec.utilops.streams.assertions.RecordStreamAssertion;
+import com.hedera.services.bdd.spec.utilops.streams.assertions.TransactionBodyAssertion;
 import com.hedera.services.bdd.spec.utilops.throughput.FinishThroughputObs;
 import com.hedera.services.bdd.spec.utilops.throughput.StartThroughputObs;
 import com.hedera.services.bdd.suites.HapiSuite;
@@ -135,6 +137,7 @@ import com.hederahashgraph.api.proto.java.Setting;
 import com.hederahashgraph.api.proto.java.Timestamp;
 import com.hederahashgraph.api.proto.java.TokenID;
 import com.hederahashgraph.api.proto.java.Transaction;
+import com.hederahashgraph.api.proto.java.TransactionBody;
 import com.hederahashgraph.api.proto.java.TransactionRecord;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -489,6 +492,11 @@ public class UtilVerbs {
             config.accept(assertion);
             return assertion;
         };
+    }
+
+    public static Function<HapiSpec, RecordStreamAssertion> recordedChildBodyWithId(
+            final String specTxnId, final int nonce, final AssertingBiConsumer<HapiSpec, TransactionBody> assertion) {
+        return spec -> new TransactionBodyAssertion(specTxnId, spec, txnId -> txnId.getNonce() == nonce, assertion);
     }
 
     public static RecordFileChecker verifyRecordFile(

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/streams/assertions/AssertingBiConsumer.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/streams/assertions/AssertingBiConsumer.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.services.bdd.spec.utilops.streams.assertions;
+
+@FunctionalInterface
+public interface AssertingBiConsumer<T, U> {
+    void accept(final T t, final U u) throws AssertionError;
+}

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/streams/assertions/BaseIdScreenedAssertion.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/streams/assertions/BaseIdScreenedAssertion.java
@@ -25,15 +25,15 @@ import edu.umd.cs.findbugs.annotations.NonNull;
  * A small starter class for assertions that match a record stream item by {@code transactionID}, and
  * then assert something about the body or record in the item.
  *
- * <p>This class does not restrict to id's with {@code nonce=0} (i.e. it includes items for both the
- * given transaction id and all its child items); but subclasses can do so if desired by overriding
- * the {@link #filter(TransactionID)} method.
+ * <p>This class does not restrict to id's with {@code nonce=0} or with {@code scheduled=false} (i.e. it
+ * includes items for both the given transaction id and all its child items); but subclasses can do so
+ * if desired by overriding * the {@link #filter(TransactionID)} method.
  */
-public abstract class IdScreenedAssertion implements RecordStreamAssertion {
+public abstract class BaseIdScreenedAssertion implements RecordStreamAssertion {
     private final String specTxnId;
     protected final HapiSpec spec;
 
-    public IdScreenedAssertion(@NonNull final String specTxnId, @NonNull final HapiSpec spec) {
+    protected BaseIdScreenedAssertion(@NonNull final String specTxnId, @NonNull final HapiSpec spec) {
         this.specTxnId = specTxnId;
         this.spec = spec;
     }
@@ -49,7 +49,7 @@ public abstract class IdScreenedAssertion implements RecordStreamAssertion {
         }
         final var txnId = maybeTxnId.get();
         final var observedId = item.getRecord().getTransactionID();
-        return nonNonceFieldsMatch(txnId, observedId) && filter(observedId);
+        return baseFieldsMatch(txnId, observedId) && filter(observedId);
     }
 
     /**
@@ -64,7 +64,7 @@ public abstract class IdScreenedAssertion implements RecordStreamAssertion {
         return true;
     }
 
-    private boolean nonNonceFieldsMatch(@NonNull final TransactionID a, @NonNull final TransactionID b) {
+    private boolean baseFieldsMatch(@NonNull final TransactionID a, @NonNull final TransactionID b) {
         return a.getTransactionValidStart().equals(b.getTransactionValidStart())
                 && a.getAccountID().equals(b.getAccountID());
     }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/streams/assertions/IdScreenedAssertion.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/streams/assertions/IdScreenedAssertion.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.services.bdd.spec.utilops.streams.assertions;
+
+import com.hedera.services.bdd.spec.HapiSpec;
+import com.hedera.services.stream.proto.RecordStreamItem;
+import com.hederahashgraph.api.proto.java.TransactionID;
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+/**
+ * A small starter class for assertions that match a record stream item by {@code transactionID}, and
+ * then assert something about the body or record in the item.
+ *
+ * <p>This class does not restrict to id's with {@code nonce=0} (i.e. it includes items for both the
+ * given transaction id and all its child items); but subclasses can do so if desired by overriding
+ * the {@link #filter(TransactionID)} method.
+ */
+public abstract class IdScreenedAssertion implements RecordStreamAssertion {
+    private final String specTxnId;
+    protected final HapiSpec spec;
+
+    public IdScreenedAssertion(@NonNull final String specTxnId, @NonNull final HapiSpec spec) {
+        this.specTxnId = specTxnId;
+        this.spec = spec;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean isApplicableTo(@NonNull final RecordStreamItem item) {
+        final var maybeTxnId = spec.registry().getMaybeTxnId(specTxnId);
+        if (maybeTxnId.isEmpty()) {
+            return false;
+        }
+        final var txnId = maybeTxnId.get();
+        final var observedId = item.getRecord().getTransactionID();
+        return nonNonceFieldsMatch(txnId, observedId) && filter(observedId);
+    }
+
+    /**
+     * Allows subclasses to further refine the filtering of record stream items by {@code TransactionID};
+     * for example, a subclass might only be interested when the {@code TransactionID} has a particular
+     * {@code nonce} value.
+     *
+     * @param txnId the {@code TransactionID} of the record stream item
+     * @return whether if the item should be included in the assertion
+     */
+    protected boolean filter(@NonNull final TransactionID txnId) {
+        return true;
+    }
+
+    private boolean nonNonceFieldsMatch(@NonNull final TransactionID a, @NonNull final TransactionID b) {
+        return a.getTransactionValidStart().equals(b.getTransactionValidStart())
+                && a.getAccountID().equals(b.getAccountID());
+    }
+}

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/streams/assertions/TransactionBodyAssertion.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/streams/assertions/TransactionBodyAssertion.java
@@ -31,7 +31,7 @@ import org.opentest4j.AssertionFailedError;
  * Implementation support for a {@link RecordStreamAssertion} that filters to a single
  * record stream item, and passes as long as a given assertion does not throw an exception.
  */
-public class TransactionBodyAssertion extends IdScreenedAssertion {
+public class TransactionBodyAssertion extends BaseIdScreenedAssertion {
     private final Predicate<TransactionID> idFilter;
     private final AssertingBiConsumer<HapiSpec, TransactionBody> bodyAssertion;
 

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/streams/assertions/TransactionBodyAssertion.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/streams/assertions/TransactionBodyAssertion.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.services.bdd.spec.utilops.streams.assertions;
+
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.hedera.node.app.hapi.utils.CommonUtils;
+import com.hedera.services.bdd.spec.HapiSpec;
+import com.hedera.services.stream.proto.RecordStreamItem;
+import com.hederahashgraph.api.proto.java.TransactionBody;
+import com.hederahashgraph.api.proto.java.TransactionID;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.function.Predicate;
+import org.jetbrains.annotations.NotNull;
+import org.opentest4j.AssertionFailedError;
+
+/**
+ * Implementation support for a {@link RecordStreamAssertion} that filters to a single
+ * record stream item, and passes as long as a given assertion does not throw an exception.
+ */
+public class TransactionBodyAssertion extends IdScreenedAssertion {
+    private final Predicate<TransactionID> idFilter;
+    private final AssertingBiConsumer<HapiSpec, TransactionBody> bodyAssertion;
+
+    public TransactionBodyAssertion(
+            @NotNull final String specTxnId,
+            @NotNull final HapiSpec spec,
+            @NonNull final Predicate<TransactionID> idFilter,
+            @NonNull final AssertingBiConsumer<HapiSpec, TransactionBody> bodyAssertion) {
+        super(specTxnId, spec);
+        this.idFilter = idFilter;
+        this.bodyAssertion = bodyAssertion;
+    }
+
+    @Override
+    protected boolean filter(@NotNull final TransactionID txnId) {
+        return idFilter.test(txnId);
+    }
+
+    @Override
+    public boolean test(@NonNull final RecordStreamItem item) throws AssertionError {
+        try {
+            final var txn = CommonUtils.extractTransactionBody(item.getTransaction());
+            bodyAssertion.accept(spec, txn);
+            return true;
+        } catch (InvalidProtocolBufferException e) {
+            throw new AssertionFailedError("Transaction body could not be parsed from item " + item);
+        }
+    }
+}

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/ContractKeysStillWorkAsExpectedSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/ContractKeysStillWorkAsExpectedSuite.java
@@ -18,7 +18,6 @@ package com.hedera.services.bdd.suites.contract.precompile;
 
 import static com.hedera.services.bdd.spec.HapiPropertySource.idAsHeadlongAddress;
 import static com.hedera.services.bdd.spec.HapiSpec.defaultHapiSpec;
-import static com.hedera.services.bdd.spec.HapiSpec.onlyPropertyPreservingHapiSpec;
 import static com.hedera.services.bdd.spec.HapiSpec.propertyPreservingHapiSpec;
 import static com.hedera.services.bdd.spec.assertions.ContractInfoAsserts.contractWith;
 import static com.hedera.services.bdd.spec.assertions.TransactionRecordAsserts.recordWith;
@@ -466,7 +465,7 @@ public class ContractKeysStillWorkAsExpectedSuite extends HapiSuite {
         final AtomicReference<Address> bSenderAddr = new AtomicReference<>();
         final AtomicReference<Address> bReceiverAddr = new AtomicReference<>();
 
-        return onlyPropertyPreservingHapiSpec("ApprovalFallbacksRequiredWithoutTopLevelSigAccess")
+        return propertyPreservingHapiSpec("ApprovalFallbacksRequiredWithoutTopLevelSigAccess")
                 .preserving(CONTRACTS_MAX_NUM_WITH_HAPI_SIGS_ACCESS)
                 .given(
                         streamMustInclude(recordedChildBodyWithId(TOKEN_UNIT_FROM_TO_OTHERS_TXN, 1, (spec, txn) -> {

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/ContractKeysStillWorkAsExpectedSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/ContractKeysStillWorkAsExpectedSuite.java
@@ -388,7 +388,7 @@ public class ContractKeysStillWorkAsExpectedSuite extends HapiSuite {
                 .then(
                         sourcing(() -> contractCall(
                                         WELL_KNOWN_TREASURY_CONTRACT,
-                                        "transferTokenUnitFromToOthers",
+                                        TOKEN_UNIT_FROM_TO_OTHERS_TXN,
                                         fungibleTokenMirrorAddr.get(),
                                         treasuryContractAddr.get(),
                                         aReceiverAddr.get())
@@ -641,7 +641,7 @@ public class ContractKeysStillWorkAsExpectedSuite extends HapiSuite {
         return blockingOrder(
                 sourcing(() -> contractCall(
                                 WELL_KNOWN_TREASURY_CONTRACT,
-                                "transferTokenUnitFromToOthers",
+                                TOKEN_UNIT_FROM_TO_OTHERS_TXN,
                                 fungibleTokenMirrorAddr.get(),
                                 aSenderAddr.get(),
                                 aReceiverAddr.get())


### PR DESCRIPTION
**Description**:
 - Closes #6262 
 - Updates `TransferPrecompile` to produce a synthetic `CryptoTransferTransactionBody` with `is_approval = true` for each asset change that was automatically switched to use an approval/allowance.
 - Includes EET to verify this behavior using a new `RecordStreamAssertion` implementation.