### PR TITLE
6316 bump platform version 38 adhoc

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/HandleWorkflowModule.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/HandleWorkflowModule.java
@@ -79,7 +79,7 @@ public interface HandleWorkflowModule {
     @SuppressWarnings({"unchecked", "rawtypes"})
     static Supplier<AutoCloseableWrapper<HederaState>> provideStateSupplier(@NonNull final Platform platform) {
         // Always return the latest immutable state until we support state proofs
-        return () -> (AutoCloseableWrapper) platform.getLatestImmutableState();
+        return () -> (AutoCloseableWrapper) platform.getLatestImmutableState(HandleWorkflowModule.class.getName());
     }
 
     @Provides

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/query/QueryWorkflowModule.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/query/QueryWorkflowModule.java
@@ -57,7 +57,7 @@ public interface QueryWorkflowModule {
     static Function<ResponseType, AutoCloseableWrapper<HederaState>> provideStateAccess(
             @NonNull final Platform platform) {
         // Always return the latest immutable state until we support state proofs
-        return responseType -> (AutoCloseableWrapper) platform.getLatestImmutableState();
+        return responseType -> (AutoCloseableWrapper) platform.getLatestImmutableState(QueryWorkflowModule.class.getName());
     }
 
     @Provides

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/query/QueryWorkflowModule.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/query/QueryWorkflowModule.java
@@ -57,7 +57,8 @@ public interface QueryWorkflowModule {
     static Function<ResponseType, AutoCloseableWrapper<HederaState>> provideStateAccess(
             @NonNull final Platform platform) {
         // Always return the latest immutable state until we support state proofs
-        return responseType -> (AutoCloseableWrapper) platform.getLatestImmutableState(QueryWorkflowModule.class.getName());
+        return responseType ->
+                (AutoCloseableWrapper) platform.getLatestImmutableState(QueryWorkflowModule.class.getName());
     }
 
     @Provides

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/state/merkle/StateLifecyclesTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/state/merkle/StateLifecyclesTest.java
@@ -35,11 +35,15 @@ import com.hedera.node.app.HederaApp;
 import com.hedera.node.app.service.mono.context.properties.BootstrapProperties;
 import com.hedera.node.app.service.mono.state.migration.StateChildIndices;
 import com.hedera.node.app.service.mono.stream.RecordsRunningHashLeaf;
+import com.swirlds.common.config.singleton.ConfigurationHolder;
+import com.swirlds.common.context.DefaultPlatformContext;
+import com.swirlds.common.context.PlatformContext;
 import com.swirlds.common.crypto.CryptographyHolder;
 import com.swirlds.common.crypto.Hash;
 import com.swirlds.common.crypto.RunningHash;
 import com.swirlds.common.crypto.SerializablePublicKey;
 import com.swirlds.common.crypto.engine.CryptoEngine;
+import com.swirlds.common.metrics.noop.NoOpMetrics;
 import com.swirlds.common.system.InitTrigger;
 import com.swirlds.common.system.NodeId;
 import com.swirlds.common.system.Platform;
@@ -162,9 +166,13 @@ class StateLifecyclesTest extends ResponsibleVMapUser {
     }
 
     private static SignedState loadSignedState(final String path) throws IOException {
-        final var signedPair = SignedStateFileReader.readStateFile(Paths.get(path));
+        final PlatformContext platformContext = new DefaultPlatformContext(
+                ConfigurationHolder.getInstance().get(), new NoOpMetrics(), CryptographyHolder.get());
+        final var signedPair = SignedStateFileReader.readStateFile(platformContext, Paths.get(path));
         // Because it's possible we are loading old data, we cannot check equivalence of the hash.
-        Assertions.assertNotNull(signedPair.signedState());
-        return signedPair.signedState();
+        try (var reservedSignedState = signedPair.reservedSignedState()) {
+            Assertions.assertNotNull(reservedSignedState.get());
+            return reservedSignedState.get();
+        }
     }
 }

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/primitives/SignedStateViewFactory.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/primitives/SignedStateViewFactory.java
@@ -117,7 +117,8 @@ public class SignedStateViewFactory {
      * @throws NoValidSignedStateException
      */
     private void doWithLatest(final Consumer<StateChildrenProvider> action) throws NoValidSignedStateException {
-        try (final AutoCloseableWrapper<SwirldState> wrapper = platform.getLatestImmutableState(this.getClass().getName())) {
+        try (final AutoCloseableWrapper<SwirldState> wrapper =
+                platform.getLatestImmutableState(this.getClass().getName())) {
             final var provider = (StateChildrenProvider) wrapper.get();
             if (!isUsable(provider)) {
                 throw new NoValidSignedStateException();

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/primitives/SignedStateViewFactory.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/primitives/SignedStateViewFactory.java
@@ -117,7 +117,7 @@ public class SignedStateViewFactory {
      * @throws NoValidSignedStateException
      */
     private void doWithLatest(final Consumer<StateChildrenProvider> action) throws NoValidSignedStateException {
-        try (final AutoCloseableWrapper<SwirldState> wrapper = platform.getLatestImmutableState()) {
+        try (final AutoCloseableWrapper<SwirldState> wrapper = platform.getLatestImmutableState(this.getClass().getName())) {
             final var provider = (StateChildrenProvider) wrapper.get();
             if (!isUsable(provider)) {
                 throw new NoValidSignedStateException();

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/sigs/order/SigReqsManager.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/sigs/order/SigReqsManager.java
@@ -106,7 +106,7 @@ public class SigReqsManager {
     /**
      * Uses the "best available" {@link SigRequirements} implementation to expand the platform
      * signatures linked to the given transaction; prefers the implementation backed by the latest
-     * signed state as returned from {@link Platform#getLatestImmutableState()}.
+     * signed state as returned from {@link Platform#getLatestImmutableState(String)}.
      *
      * @param provider an immutable state appropriate for signature expansion
      * @param accessor a transaction that needs linked signatures expanded

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/forensics/ServicesIssListener.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/forensics/ServicesIssListener.java
@@ -55,7 +55,8 @@ public class ServicesIssListener implements IssListener {
         final long round = notice.getRound();
         final long otherNodeId = notice.getOtherNodeId();
         final String msg = String.format(ISS_ERROR_MSG_PATTERN, round, otherNodeId);
-        try (final AutoCloseableWrapper<ServicesState> wrapper = platform.getLatestImmutableState(this.getClass().getName() + " " + msg)) {
+        try (final AutoCloseableWrapper<ServicesState> wrapper =
+                platform.getLatestImmutableState(this.getClass().getName() + " " + msg)) {
             final ServicesState issState = wrapper.get();
             issEventInfo.alert(issState.getTimeOfLastHandledTxn());
             if (issEventInfo.shouldLogThisRound()) {

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/forensics/ServicesIssListener.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/forensics/ServicesIssListener.java
@@ -54,12 +54,12 @@ public class ServicesIssListener implements IssListener {
 
         final long round = notice.getRound();
         final long otherNodeId = notice.getOtherNodeId();
-        try (final AutoCloseableWrapper<ServicesState> wrapper = platform.getLatestImmutableState()) {
+        final String msg = String.format(ISS_ERROR_MSG_PATTERN, round, otherNodeId);
+        try (final AutoCloseableWrapper<ServicesState> wrapper = platform.getLatestImmutableState(this.getClass().getName() + " " + msg)) {
             final ServicesState issState = wrapper.get();
             issEventInfo.alert(issState.getTimeOfLastHandledTxn());
             if (issEventInfo.shouldLogThisRound()) {
                 issEventInfo.decrementRoundsToLog();
-                final String msg = String.format(ISS_ERROR_MSG_PATTERN, round, otherNodeId);
                 log.error(msg);
                 issState.logSummary();
             }

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ServicesStateTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ServicesStateTest.java
@@ -35,6 +35,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
@@ -102,19 +103,17 @@ import com.swirlds.common.system.events.Event;
 import com.swirlds.fchashmap.FCHashMap;
 import com.swirlds.merkle.map.MerkleMap;
 import com.swirlds.platform.state.DualStateImpl;
-import com.swirlds.platform.state.signed.SignedState;
+import com.swirlds.platform.state.signed.ReservedSignedState;
 import com.swirlds.platform.state.signed.SignedStateFileReader;
 import com.swirlds.virtualmap.VirtualMap;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Paths;
 import java.time.Instant;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -837,12 +836,15 @@ class ServicesStateTest extends ResponsibleVMapUser {
     @Test
     void testLoading0305State() {
         ClassLoaderHelper.loadClassPathDependencies();
-        final AtomicReference<SignedState> ref = new AtomicReference<>();
-        assertDoesNotThrow(() -> ref.set(loadSignedState(signedStateDir + "v0.30.5/SignedState.swh")));
-        final var mockPlatform = createMockPlatformWithCrypto();
-        given(mockPlatform.getAddressBook()).willReturn(addressBook);
-        ServicesState swirldState = (ServicesState) ref.get().getSwirldState();
-        tracked(swirldState).init(mockPlatform, new DualStateImpl(), RESTART, forHapiAndHedera("0.30.0", "0.30.5"));
+        // This signed state should be auto-closed by the try block
+        try (ReservedSignedState state = loadSignedState(signedStateDir + "v0.30.5/SignedState.swh")) {
+            final var mockPlatform = createMockPlatformWithCrypto();
+            given(mockPlatform.getAddressBook()).willReturn(addressBook);
+            ServicesState swirldState = (ServicesState) state.get().getSwirldState();
+            swirldState.init(mockPlatform, new DualStateImpl(), RESTART, forHapiAndHedera("0.30.0", "0.30.5"));
+        } catch (IOException e) {
+            fail("State file should be loaded correctly!");
+        }
     }
 
     @Test
@@ -926,15 +928,18 @@ class ServicesStateTest extends ResponsibleVMapUser {
         return platform;
     }
 
-    private static SignedState loadSignedState(final String path) throws IOException {
+    /**
+     * Because this method returns a {@code ReservedSignedState}, <b>make sure to close it when done!</b>
+     *
+     * @param path the path to the signed state file
+     * @throws IOException if the file cannot be read
+     */
+    private static ReservedSignedState loadSignedState(final String path) throws IOException {
         final PlatformContext platformContext = new DefaultPlatformContext(
                 ConfigurationHolder.getInstance().get(), new NoOpMetrics(), CryptographyHolder.get());
         final var signedPair = SignedStateFileReader.readStateFile(platformContext, Paths.get(path));
         // Because it's possible we are loading old data, we cannot check equivalence of the hash.
-        try (var reservedSignedState = signedPair.reservedSignedState()) {
-            Assertions.assertNotNull(reservedSignedState.get());
-            return reservedSignedState.get();
-        }
+        return signedPair.reservedSignedState();
     }
 
     private void mockAllMaps(final MerkleMap<?, ?> mockMm, final VirtualMap<?, ?> mockVm) {

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/context/primitives/SignedStateViewFactoryTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/context/primitives/SignedStateViewFactoryTest.java
@@ -148,7 +148,8 @@ class SignedStateViewFactoryTest {
 
     @Test
     void canUpdateSuccessfully() {
-        given(platform.getLatestImmutableState(this.getClass().getName())).willReturn(new AutoCloseableWrapper<>(state, () -> {}));
+        given(platform.getLatestImmutableState(this.getClass().getName()))
+                .willReturn(new AutoCloseableWrapper<>(state, () -> {}));
         final var childrenToUpdate = new MutableStateChildren();
         givenStateWithMockChildren();
         given(state.getTimeOfLastHandledTxn()).willReturn(Instant.now());
@@ -161,7 +162,8 @@ class SignedStateViewFactoryTest {
 
     @Test
     void throwsIfUpdatedWithInvalidState() {
-        given(platform.getLatestImmutableState(this.getClass().getName())).willReturn(new AutoCloseableWrapper<>(state, () -> {}));
+        given(platform.getLatestImmutableState(this.getClass().getName()))
+                .willReturn(new AutoCloseableWrapper<>(state, () -> {}));
         given(state.getTimeOfLastHandledTxn()).willReturn(null);
         assertFalse(factory.isUsable(state));
         assertThrows(
@@ -171,7 +173,8 @@ class SignedStateViewFactoryTest {
 
     @Test
     void returnsEmptyWhenGettingFromInvalidState() {
-        given(platform.getLatestImmutableState(this.getClass().getName())).willReturn(new AutoCloseableWrapper<>(state, () -> {}));
+        given(platform.getLatestImmutableState(this.getClass().getName()))
+                .willReturn(new AutoCloseableWrapper<>(state, () -> {}));
         given(state.getTimeOfLastHandledTxn()).willReturn(null);
         assertFalse(factory.isUsable(state));
         final var children = factory.childrenOfLatestSignedState();
@@ -180,7 +183,8 @@ class SignedStateViewFactoryTest {
 
     @Test
     void getsLatestImmutableChildren() {
-        given(platform.getLatestImmutableState(this.getClass().getName())).willReturn(new AutoCloseableWrapper<>(state, () -> {}));
+        given(platform.getLatestImmutableState(this.getClass().getName()))
+                .willReturn(new AutoCloseableWrapper<>(state, () -> {}));
         given(state.getTimeOfLastHandledTxn()).willReturn(Instant.ofEpochSecond(12345));
         given(state.getStateVersion()).willReturn(StateVersions.CURRENT_VERSION);
         given(state.isInitialized()).willReturn(true);
@@ -241,7 +245,8 @@ class SignedStateViewFactoryTest {
         given(state.getStateVersion()).willReturn(StateVersions.CURRENT_VERSION);
         given(state.isInitialized()).willReturn(true);
         assertTrue(factory.isUsable(state));
-        given(platform.getLatestImmutableState(this.getClass().getName())).willReturn(new AutoCloseableWrapper<>(state, () -> {}));
+        given(platform.getLatestImmutableState(this.getClass().getName()))
+                .willReturn(new AutoCloseableWrapper<>(state, () -> {}));
         final var stateView = factory.latestSignedStateView();
         assertFalse(stateView.isEmpty());
     }
@@ -250,7 +255,8 @@ class SignedStateViewFactoryTest {
     void failsToConstructStateViewIfChildrenEmpty() {
         given(state.getTimeOfLastHandledTxn()).willReturn(null);
         assertFalse(factory.isUsable(state));
-        given(platform.getLatestImmutableState(this.getClass().getName())).willReturn(new AutoCloseableWrapper<>(state, () -> {}));
+        given(platform.getLatestImmutableState(this.getClass().getName()))
+                .willReturn(new AutoCloseableWrapper<>(state, () -> {}));
         final var stateView = factory.latestSignedStateView();
         assertTrue(stateView.isEmpty());
     }

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/context/primitives/SignedStateViewFactoryTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/context/primitives/SignedStateViewFactoryTest.java
@@ -148,7 +148,7 @@ class SignedStateViewFactoryTest {
 
     @Test
     void canUpdateSuccessfully() {
-        given(platform.getLatestImmutableState()).willReturn(new AutoCloseableWrapper<>(state, () -> {}));
+        given(platform.getLatestImmutableState(this.getClass().getName())).willReturn(new AutoCloseableWrapper<>(state, () -> {}));
         final var childrenToUpdate = new MutableStateChildren();
         givenStateWithMockChildren();
         given(state.getTimeOfLastHandledTxn()).willReturn(Instant.now());
@@ -161,7 +161,7 @@ class SignedStateViewFactoryTest {
 
     @Test
     void throwsIfUpdatedWithInvalidState() {
-        given(platform.getLatestImmutableState()).willReturn(new AutoCloseableWrapper<>(state, () -> {}));
+        given(platform.getLatestImmutableState(this.getClass().getName())).willReturn(new AutoCloseableWrapper<>(state, () -> {}));
         given(state.getTimeOfLastHandledTxn()).willReturn(null);
         assertFalse(factory.isUsable(state));
         assertThrows(
@@ -171,7 +171,7 @@ class SignedStateViewFactoryTest {
 
     @Test
     void returnsEmptyWhenGettingFromInvalidState() {
-        given(platform.getLatestImmutableState()).willReturn(new AutoCloseableWrapper<>(state, () -> {}));
+        given(platform.getLatestImmutableState(this.getClass().getName())).willReturn(new AutoCloseableWrapper<>(state, () -> {}));
         given(state.getTimeOfLastHandledTxn()).willReturn(null);
         assertFalse(factory.isUsable(state));
         final var children = factory.childrenOfLatestSignedState();
@@ -180,7 +180,7 @@ class SignedStateViewFactoryTest {
 
     @Test
     void getsLatestImmutableChildren() {
-        given(platform.getLatestImmutableState()).willReturn(new AutoCloseableWrapper<>(state, () -> {}));
+        given(platform.getLatestImmutableState(this.getClass().getName())).willReturn(new AutoCloseableWrapper<>(state, () -> {}));
         given(state.getTimeOfLastHandledTxn()).willReturn(Instant.ofEpochSecond(12345));
         given(state.getStateVersion()).willReturn(StateVersions.CURRENT_VERSION);
         given(state.isInitialized()).willReturn(true);
@@ -191,7 +191,7 @@ class SignedStateViewFactoryTest {
 
     @Test
     void getsNewStateEachTime() {
-        given(platform.getLatestImmutableState())
+        given(platform.getLatestImmutableState(this.getClass().getName()))
                 .willReturn(new AutoCloseableWrapper<>(state, () -> {}))
                 .willReturn(new AutoCloseableWrapper<>(secondState, () -> {}));
         final var firstHandleTime = Instant.ofEpochSecond(12345);
@@ -213,7 +213,7 @@ class SignedStateViewFactoryTest {
 
     @Test
     void updatesUsingNewStateEachTime() throws NoValidSignedStateException {
-        given(platform.getLatestImmutableState())
+        given(platform.getLatestImmutableState(this.getClass().getName()))
                 .willReturn(new AutoCloseableWrapper<>(state, () -> {}))
                 .willReturn(new AutoCloseableWrapper<>(secondState, () -> {}));
         final var firstHandleTime = Instant.ofEpochSecond(12345);
@@ -241,7 +241,7 @@ class SignedStateViewFactoryTest {
         given(state.getStateVersion()).willReturn(StateVersions.CURRENT_VERSION);
         given(state.isInitialized()).willReturn(true);
         assertTrue(factory.isUsable(state));
-        given(platform.getLatestImmutableState()).willReturn(new AutoCloseableWrapper<>(state, () -> {}));
+        given(platform.getLatestImmutableState(this.getClass().getName())).willReturn(new AutoCloseableWrapper<>(state, () -> {}));
         final var stateView = factory.latestSignedStateView();
         assertFalse(stateView.isEmpty());
     }
@@ -250,7 +250,7 @@ class SignedStateViewFactoryTest {
     void failsToConstructStateViewIfChildrenEmpty() {
         given(state.getTimeOfLastHandledTxn()).willReturn(null);
         assertFalse(factory.isUsable(state));
-        given(platform.getLatestImmutableState()).willReturn(new AutoCloseableWrapper<>(state, () -> {}));
+        given(platform.getLatestImmutableState(this.getClass().getName())).willReturn(new AutoCloseableWrapper<>(state, () -> {}));
         final var stateView = factory.latestSignedStateView();
         assertTrue(stateView.isEmpty());
     }

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/context/primitives/SignedStateViewFactoryTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/context/primitives/SignedStateViewFactoryTest.java
@@ -23,6 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.notNull;
 import static org.mockito.BDDMockito.given;
 
 import com.google.protobuf.ByteString;
@@ -148,8 +149,7 @@ class SignedStateViewFactoryTest {
 
     @Test
     void canUpdateSuccessfully() {
-        given(platform.getLatestImmutableState(this.getClass().getName()))
-                .willReturn(new AutoCloseableWrapper<>(state, () -> {}));
+        given(platform.getLatestImmutableState(notNull())).willReturn(new AutoCloseableWrapper<>(state, () -> {}));
         final var childrenToUpdate = new MutableStateChildren();
         givenStateWithMockChildren();
         given(state.getTimeOfLastHandledTxn()).willReturn(Instant.now());
@@ -162,8 +162,7 @@ class SignedStateViewFactoryTest {
 
     @Test
     void throwsIfUpdatedWithInvalidState() {
-        given(platform.getLatestImmutableState(this.getClass().getName()))
-                .willReturn(new AutoCloseableWrapper<>(state, () -> {}));
+        given(platform.getLatestImmutableState(notNull())).willReturn(new AutoCloseableWrapper<>(state, () -> {}));
         given(state.getTimeOfLastHandledTxn()).willReturn(null);
         assertFalse(factory.isUsable(state));
         assertThrows(
@@ -173,8 +172,7 @@ class SignedStateViewFactoryTest {
 
     @Test
     void returnsEmptyWhenGettingFromInvalidState() {
-        given(platform.getLatestImmutableState(this.getClass().getName()))
-                .willReturn(new AutoCloseableWrapper<>(state, () -> {}));
+        given(platform.getLatestImmutableState(notNull())).willReturn(new AutoCloseableWrapper<>(state, () -> {}));
         given(state.getTimeOfLastHandledTxn()).willReturn(null);
         assertFalse(factory.isUsable(state));
         final var children = factory.childrenOfLatestSignedState();
@@ -183,8 +181,7 @@ class SignedStateViewFactoryTest {
 
     @Test
     void getsLatestImmutableChildren() {
-        given(platform.getLatestImmutableState(this.getClass().getName()))
-                .willReturn(new AutoCloseableWrapper<>(state, () -> {}));
+        given(platform.getLatestImmutableState(notNull())).willReturn(new AutoCloseableWrapper<>(state, () -> {}));
         given(state.getTimeOfLastHandledTxn()).willReturn(Instant.ofEpochSecond(12345));
         given(state.getStateVersion()).willReturn(StateVersions.CURRENT_VERSION);
         given(state.isInitialized()).willReturn(true);
@@ -195,7 +192,7 @@ class SignedStateViewFactoryTest {
 
     @Test
     void getsNewStateEachTime() {
-        given(platform.getLatestImmutableState(this.getClass().getName()))
+        given(platform.getLatestImmutableState(notNull()))
                 .willReturn(new AutoCloseableWrapper<>(state, () -> {}))
                 .willReturn(new AutoCloseableWrapper<>(secondState, () -> {}));
         final var firstHandleTime = Instant.ofEpochSecond(12345);
@@ -217,7 +214,7 @@ class SignedStateViewFactoryTest {
 
     @Test
     void updatesUsingNewStateEachTime() throws NoValidSignedStateException {
-        given(platform.getLatestImmutableState(this.getClass().getName()))
+        given(platform.getLatestImmutableState(notNull()))
                 .willReturn(new AutoCloseableWrapper<>(state, () -> {}))
                 .willReturn(new AutoCloseableWrapper<>(secondState, () -> {}));
         final var firstHandleTime = Instant.ofEpochSecond(12345);
@@ -245,8 +242,7 @@ class SignedStateViewFactoryTest {
         given(state.getStateVersion()).willReturn(StateVersions.CURRENT_VERSION);
         given(state.isInitialized()).willReturn(true);
         assertTrue(factory.isUsable(state));
-        given(platform.getLatestImmutableState(this.getClass().getName()))
-                .willReturn(new AutoCloseableWrapper<>(state, () -> {}));
+        given(platform.getLatestImmutableState(notNull())).willReturn(new AutoCloseableWrapper<>(state, () -> {}));
         final var stateView = factory.latestSignedStateView();
         assertFalse(stateView.isEmpty());
     }
@@ -255,8 +251,7 @@ class SignedStateViewFactoryTest {
     void failsToConstructStateViewIfChildrenEmpty() {
         given(state.getTimeOfLastHandledTxn()).willReturn(null);
         assertFalse(factory.isUsable(state));
-        given(platform.getLatestImmutableState(this.getClass().getName()))
-                .willReturn(new AutoCloseableWrapper<>(state, () -> {}));
+        given(platform.getLatestImmutableState(notNull())).willReturn(new AutoCloseableWrapper<>(state, () -> {}));
         final var stateView = factory.latestSignedStateView();
         assertTrue(stateView.isEmpty());
     }

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/forensics/ServicesIssListenerTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/forensics/ServicesIssListenerTest.java
@@ -19,6 +19,7 @@ package com.hedera.node.app.service.mono.state.forensics;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.collection.IsIterableContainingInOrder.contains;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.notNull;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -102,7 +103,7 @@ class ServicesIssListenerTest {
         given(issEventInfo.shouldLogThisRound()).willReturn(true);
         given(state.getTimeOfLastHandledTxn()).willReturn(consensusTime);
         given(wrapper.get()).willReturn(state);
-        given(platform.getLatestImmutableState(this.getClass().getName())).willReturn(wrapper);
+        given(platform.getLatestImmutableState(notNull())).willReturn(wrapper);
 
         subject.notify(issNotification);
 
@@ -122,7 +123,7 @@ class ServicesIssListenerTest {
         given(issEventInfo.shouldLogThisRound()).willReturn(false);
         given(state.getTimeOfLastHandledTxn()).willReturn(consensusTime);
         given(wrapper.get()).willReturn(state);
-        given(platform.getLatestImmutableState(this.getClass().getName())).willReturn(wrapper);
+        given(platform.getLatestImmutableState(notNull())).willReturn(wrapper);
 
         // when:
         subject.notify(issNotification);

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/forensics/ServicesIssListenerTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/forensics/ServicesIssListenerTest.java
@@ -102,7 +102,7 @@ class ServicesIssListenerTest {
         given(issEventInfo.shouldLogThisRound()).willReturn(true);
         given(state.getTimeOfLastHandledTxn()).willReturn(consensusTime);
         given(wrapper.get()).willReturn(state);
-        given(platform.getLatestImmutableState()).willReturn(wrapper);
+        given(platform.getLatestImmutableState(this.getClass().getName())).willReturn(wrapper);
 
         subject.notify(issNotification);
 
@@ -122,7 +122,7 @@ class ServicesIssListenerTest {
         given(issEventInfo.shouldLogThisRound()).willReturn(false);
         given(state.getTimeOfLastHandledTxn()).willReturn(consensusTime);
         given(wrapper.get()).willReturn(state);
-        given(platform.getLatestImmutableState()).willReturn(wrapper);
+        given(platform.getLatestImmutableState(this.getClass().getName())).willReturn(wrapper);
 
         // when:
         subject.notify(issNotification);

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -144,7 +144,7 @@ dependencyResolutionManagement {
       version("netty-version", "4.1.66.Final")
       version("protobuf-java-version", "3.19.4")
       version("slf4j-version", "2.0.3")
-      version("swirlds-version", "0.38.0-adhoc.xb74a8ba8")
+      version("swirlds-version", "0.38.0-adhoc.x72f08eed")
       version("tuweni-version", "2.2.0")
       version("jna-version", "5.12.1")
       version("jsr305-version", "3.0.2")


### PR DESCRIPTION
Use latest platform adhoc build. The latest platform build caused two sets of breaking changes in services build. Both stem from PR #6142

1) Platform.getLatestImmutableState now takes a String as an argument, the reason why the signed state is being retrieved. This is for debugging if there is ever a state reference leak. It is only logged when there is a leak. I used the name of the method making the call in most places.
2) SignedStateFileReader.readStateFile method signature changed, both the parameters and the return type. @cody-littley and @david-bakin-sl helped me figure out how to update the code to use the new signature.