### PR TITLE
Only clear memo in `TokenUpdateLogic` if client code can signal unset vs empty

### DIFF
--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/AbstractTokenUpdatePrecompile.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/AbstractTokenUpdatePrecompile.java
@@ -100,8 +100,13 @@ public abstract class AbstractTokenUpdatePrecompile extends AbstractWritePrecomp
         validateTrue(validity == OK, validity);
         /* --- Execute the transaction and capture its results --- */
         switch (type) {
+                // We pass true as the last argument to indicate that even if the contract left the
+                // memo field unset in its call to this precompile, we want to leave the memo as-is
+                // instead of erasing it (with a protobuf message through HAPI we can distinguish
+                // between an unset memo and an empty/erased memo; but we cannot with an ABI-encoded
+                // call, so the more reasonable default here is to leave the memo as-is
             case UPDATE_TOKEN_INFO -> updateLogic.updateToken(
-                    updateOp, frame.getBlockValues().getTimestamp());
+                    updateOp, frame.getBlockValues().getTimestamp(), true);
             case UPDATE_TOKEN_KEYS -> updateLogic.updateTokenKeys(
                     updateOp, frame.getBlockValues().getTimestamp());
             case UPDATE_TOKEN_EXPIRY -> updateLogic.updateTokenExpiryInfo(updateOp);

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/tokens/HederaTokenStore.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/tokens/HederaTokenStore.java
@@ -629,7 +629,7 @@ public class HederaTokenStore extends HederaStore implements TokenStore {
     }
 
     private void updateMemoIfAppropriate(final MerkleToken token, final TokenUpdateTransactionBody changes) {
-        if (changes.hasMemo() && changes.getMemo().getValue().length() > 0) {
+        if (changes.hasMemo()) {
             token.setMemo(changes.getMemo().getValue());
         }
     }

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/AbstractTokenUpdatePrecompileTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/AbstractTokenUpdatePrecompileTest.java
@@ -156,7 +156,7 @@ class AbstractTokenUpdatePrecompileTest {
                         eq(ledgers),
                         eq(aliases),
                         eq(TokenUpdate));
-        verify(updateLogic).updateToken(any(), anyLong());
+        verify(updateLogic).updateToken(any(), anyLong(), eq(true));
         // and when:
         final var tests = captor.getAllValues();
         final var legacyTests = legacyCaptor.getAllValues();
@@ -260,7 +260,7 @@ class AbstractTokenUpdatePrecompileTest {
                 .validateKey(
                         eq(frame), eq(tokenMirrorAddress), captor.capture(), eq(ledgers), eq(aliases), eq(TokenUpdate));
         verifyNoMoreInteractions(keyValidator);
-        verify(updateLogic).updateToken(any(), anyLong());
+        verify(updateLogic).updateToken(any(), anyLong(), eq(true));
         // and when:
         final var tests = captor.getAllValues();
         tests.get(0).apply(false, tokenMirrorAddress, pretendActiveContract, ledgers, CryptoTransfer);

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/TokenUpdatePrecompileSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/TokenUpdatePrecompileSuite.java
@@ -17,7 +17,6 @@
 package com.hedera.services.bdd.suites.contract.precompile;
 
 import static com.hedera.services.bdd.spec.HapiSpec.defaultHapiSpec;
-import static com.hedera.services.bdd.spec.HapiSpec.onlyDefaultHapiSpec;
 import static com.hedera.services.bdd.spec.assertions.ContractFnResultAsserts.resultWith;
 import static com.hedera.services.bdd.spec.assertions.TransactionRecordAsserts.recordWith;
 import static com.hedera.services.bdd.spec.keys.KeyShape.CONTRACT;
@@ -1086,7 +1085,7 @@ public class TokenUpdatePrecompileSuite extends HapiSuite {
     private HapiSpec updateTokenWithoutNameSymbolMemo() {
         final var updateTokenWithoutNameSymbolMemoFunc = "updateTokenWithoutNameSymbolMemo";
         final AtomicReference<TokenID> vanillaTokenID = new AtomicReference<>();
-        return onlyDefaultHapiSpec(updateTokenWithoutNameSymbolMemoFunc)
+        return defaultHapiSpec(updateTokenWithoutNameSymbolMemoFunc)
                 .given(
                         newKeyNamed(ED25519KEY).shape(ED25519),
                         newKeyNamed(ECDSA_KEY).shape(SECP256K1),

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/TokenUpdatePrecompileSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/TokenUpdatePrecompileSuite.java
@@ -17,6 +17,7 @@
 package com.hedera.services.bdd.suites.contract.precompile;
 
 import static com.hedera.services.bdd.spec.HapiSpec.defaultHapiSpec;
+import static com.hedera.services.bdd.spec.HapiSpec.onlyDefaultHapiSpec;
 import static com.hedera.services.bdd.spec.assertions.ContractFnResultAsserts.resultWith;
 import static com.hedera.services.bdd.spec.assertions.TransactionRecordAsserts.recordWith;
 import static com.hedera.services.bdd.spec.keys.KeyShape.CONTRACT;
@@ -1085,7 +1086,7 @@ public class TokenUpdatePrecompileSuite extends HapiSuite {
     private HapiSpec updateTokenWithoutNameSymbolMemo() {
         final var updateTokenWithoutNameSymbolMemoFunc = "updateTokenWithoutNameSymbolMemo";
         final AtomicReference<TokenID> vanillaTokenID = new AtomicReference<>();
-        return defaultHapiSpec(updateTokenWithoutNameSymbolMemoFunc)
+        return onlyDefaultHapiSpec(updateTokenWithoutNameSymbolMemoFunc)
                 .given(
                         newKeyNamed(ED25519KEY).shape(ED25519),
                         newKeyNamed(ECDSA_KEY).shape(SECP256K1),


### PR DESCRIPTION
**Description**:
 - Closes #6268 
 - Adds a `boolean mergeUnsetMemoFromExisting` flag to `TokenUpdateLogic.updateToken()` so that when client code cannot properly signal the difference between an _unset_ `memo` field and an _empty_ `memo` field, we don't unconditionally clear the token's existing memo.
 - This is relevant when the client code is an `updateToken()` system contract, whose current ABI does not let it distinguish between a contract (1) leaving the `memo` field unset and (2) explicitly setting `memo = ""` to erase the memo.