### PR TITLE
Abort `EntityAutoExpiry` cycle immediately once all entities are scanned

### DIFF
--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/expiry/EntityAutoExpiry.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/expiry/EntityAutoExpiry.java
@@ -89,9 +89,16 @@ public class EntityAutoExpiry {
     }
 
     public void execute(final Instant currentConsTime) {
+        final var curNetworkCtx = networkCtx.get();
+        // Because there is only one viable SystemTask (traceability export) in release 0.37,
+        // as no entity type expires in this release, we can finish immediately once we have
+        // scanned all the pre-upgrade entities.
+        if (curNetworkCtx.areAllPreUpgradeEntitiesScanned()) {
+            return;
+        }
         executeInternal(currentConsTime);
         // Ensure we capture any capacity used in the expiry throttle
-        networkCtx.get().syncExpiryThrottle(expiryThrottle);
+        curNetworkCtx.syncExpiryThrottle(expiryThrottle);
     }
 
     private void executeInternal(final Instant now) {

--- a/hedera-node/hedera-mono-service/src/main/resources/bootstrap.properties
+++ b/hedera-node/hedera-mono-service/src/main/resources/bootstrap.properties
@@ -141,7 +141,7 @@ sigs.expandFromImmutableState=true
 staking.fees.nodeRewardPercentage=0
 staking.fees.stakingRewardPercentage=0
 staking.maxDailyStakeRewardThPerH=17_808
-traceability.maxExportsPerConsSec=10
+traceability.maxExportsPerConsSec=1
 traceability.minFreeToUsedGasThrottleRatio=9
 # A possibly empty comma-separated <nodeId>:<ratio> list; default ratio is 4
 staking.nodeMaxToMinStakeRatios=

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/expiry/EntityAutoExpiryTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/expiry/EntityAutoExpiryTest.java
@@ -17,6 +17,7 @@
 package com.hedera.node.app.service.mono.state.expiry;
 
 import static com.hedera.node.app.service.mono.state.tasks.SystemTaskResult.*;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
@@ -87,6 +88,13 @@ class EntityAutoExpiryTest {
                 () -> networkCtx,
                 consensusTimeTracker,
                 () -> seqNo);
+    }
+
+    @Test
+    void doesNothingIfAllEntitiesScanned() {
+        given(networkCtx.areAllPreUpgradeEntitiesScanned()).willReturn(true);
+
+        assertDoesNotThrow(() -> subject.execute(instantNow));
     }
 
     @Test


### PR DESCRIPTION
**Description**:
 - Eliminates `EntityAutoExpiry` overhead post-traceability migration by aborting `execute()` as soon as all pre-existing entities are scanned.