### PR TITLE
06331 - `AddressBook.forceUseOfAddressBook` default setting to false

### DIFF
--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/config/AddressBookConfig.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/config/AddressBookConfig.java
@@ -41,6 +41,6 @@ import com.swirlds.config.api.ConfigProperty;
 @ConfigData("addressBook")
 public record AddressBookConfig(
         @ConfigProperty(defaultValue = "true") boolean updateAddressBookOnlyAtUpgrade,
-        @ConfigProperty(defaultValue = "true") boolean forceUseOfConfigAddressBook,
+        @ConfigProperty(defaultValue = "false") boolean forceUseOfConfigAddressBook,
         @ConfigProperty(defaultValue = "data/saved/address_book") String addressBookDirectory,
         @ConfigProperty(defaultValue = "50") int maxRecordedAddressBookFiles) {}


### PR DESCRIPTION
**Description**:
This PR targeting the develop branch contains the commit that is targeting the release/0.38 branch in PR #6334 
- Changed the default to `false` in AddressBookConfig.java
- Fixed bug in Demo GUI using `Address.isOwnHost()` on state loaded AddressBook in AddressBookUtils.java

Fixes #6331 
