### PR TITLE
Ensure throttle timeline is monotonic increasing

### DIFF
--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/tasks/TraceabilityExportTask.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/tasks/TraceabilityExportTask.java
@@ -130,7 +130,7 @@ public class TraceabilityExportTask implements SystemTask {
             firstTime = false;
         }
 
-        if (!recordsHelper.canExportNow() || needsBackPressure(now, curNetworkCtx)) {
+        if (!recordsHelper.canExportNow() || needsBackPressure(curNetworkCtx)) {
             return NEEDS_DIFFERENT_CONTEXT;
         }
         // It would be a lot of work to split even a single sidecar's construction across
@@ -163,13 +163,18 @@ public class TraceabilityExportTask implements SystemTask {
         throw new UnsupportedOperationException();
     }
 
-    private boolean needsBackPressure(final Instant now, final MerkleNetworkContext curNetworkCtx) {
-        return inHighGasRegime(now)
+    private boolean needsBackPressure(final MerkleNetworkContext curNetworkCtx) {
+        return inHighGasRegime()
                 || curNetworkCtx.getEntitiesTouchedThisSecond() >= dynamicProperties.traceabilityMaxExportsPerConsSec();
     }
 
-    private boolean inHighGasRegime(final Instant now) {
-        return handleThrottling.gasLimitThrottle().freeToUsedRatio(now)
+    private boolean inHighGasRegime() {
+        return handleThrottling
+                        .gasLimitThrottle()
+                        .freeToUsedRatio(handleThrottling
+                                .gasLimitThrottle()
+                                .usageSnapshot()
+                                .lastDecisionTime())
                 < dynamicProperties.traceabilityMinFreeToUsedGasThrottleRatio();
     }
 


### PR DESCRIPTION
**Description**:
 - Ensure gas utilization check in `TraceabilityExportTask` doesn't cause throttle timeline to regress.