### PR TITLE
Update `SignedStateHolder` for proper resource usage of signed state

### DIFF
--- a/hedera-node/cli-clients/build.gradle.kts
+++ b/hedera-node/cli-clients/build.gradle.kts
@@ -25,18 +25,20 @@ description = "Hedera Services Command-Line Clients"
 tasks.jar { manifest { attributes("Automatic-Module-Name" to "com.hedera.services.cli") } }
 
 configurations.all {
-  exclude("javax.annotation", "javax.annotation.api")
   exclude("com.google.code.findbugs", "jsr305")
-  exclude("org.jetbrains", "annotations")
+  exclude("javax.annotation", "javax.annotation.api")
   exclude("org.checkerframework", "checker-qual")
   exclude("org.hamcrest", "hamcrest-core")
+  exclude("org.jetbrains", "annotations")
 }
 
 dependencies {
-  implementation(project(mapOf("path" to ":hedera-node:hapi-utils")))
   compileOnly(libs.spotbugs.annotations)
   implementation(libs.bundles.swirlds)
+  implementation(libs.log4j.api)
+  implementation(libs.log4j.core)
   implementation(project(":hedera-node:hedera-mono-service"))
+  implementation(project(mapOf("path" to ":hedera-node:hapi-utils")))
   implementation(testLibs.picocli)
   testImplementation(testLibs.bundles.testing)
 }

--- a/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/signedstate/SignedStateCommand.java
+++ b/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/signedstate/SignedStateCommand.java
@@ -14,32 +14,16 @@
  * limitations under the License.
  */
 
-package com.hedera.services.cli;
+package com.hedera.services.cli.signedstate;
 
-import com.hedera.services.cli.signedstate.SummarizeSignedStateFileCommand;
 import com.swirlds.cli.PlatformCli;
 import com.swirlds.cli.utility.AbstractCommand;
 import com.swirlds.cli.utility.SubcommandOf;
-import picocli.CommandLine;
-import picocli.CommandLine.Model.CommandSpec;
-import picocli.CommandLine.ParameterException;
-import picocli.CommandLine.Spec;
+import picocli.CommandLine.Command;
 
-@CommandLine.Command(
-        name = "example",
-        mixinStandardHelpOptions = true,
-        description = "Example Pcli Plugin for Services",
-        subcommands = {SummarizeSignedStateFileCommand.class})
+@Command(
+        name = "signedstate",
+        subcommands = {SummarizeSignedStateFileCommand.class},
+        description = "Dealing with signed state files")
 @SubcommandOf(PlatformCli.class)
-public final class ExamplePcliPlugin extends AbstractCommand {
-
-    @Spec
-    CommandSpec spec;
-
-    private ExamplePcliPlugin() {}
-
-    @Override
-    public Integer call() {
-        throw new ParameterException(spec.commandLine(), "Please specify a subcommand!");
-    }
-}
+public class SignedStateCommand extends AbstractCommand {}

--- a/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/signedstate/SummarizeSignedStateFileCommand.java
+++ b/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/signedstate/SummarizeSignedStateFileCommand.java
@@ -16,8 +16,8 @@
 
 package com.hedera.services.cli.signedstate;
 
-import com.hedera.services.cli.utils.SignedStateHolder;
-import com.hedera.services.cli.utils.SignedStateHolder.Contract;
+import com.hedera.services.cli.signedstate.utils.SignedStateHolder;
+import com.hedera.services.cli.signedstate.utils.SignedStateHolder.Contract;
 import com.swirlds.common.io.utility.FileUtils;
 import java.lang.reflect.Array;
 import java.nio.file.Path;

--- a/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/signedstate/SummarizeSignedStateFileCommand.java
+++ b/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/signedstate/SummarizeSignedStateFileCommand.java
@@ -16,47 +16,72 @@
 
 package com.hedera.services.cli.signedstate;
 
-import static com.hedera.services.cli.signedstate.SignedStateHolder.getContracts;
-
-import com.hedera.services.cli.ExamplePcliPlugin;
-import com.hedera.services.cli.signedstate.SignedStateHolder.Contract;
+import com.hedera.services.cli.utils.SignedStateHolder;
+import com.hedera.services.cli.utils.SignedStateHolder.Contract;
+import com.swirlds.common.io.utility.FileUtils;
 import java.lang.reflect.Array;
 import java.nio.file.Path;
 import java.util.concurrent.Callable;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.config.Configurator;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
-import picocli.CommandLine.ParentCommand;
 
 @Command(
         name = "summarize",
-        subcommands = {picocli.CommandLine.HelpCommand.class},
+        mixinStandardHelpOptions = true,
         description = "Summarizes contents of signed state file (to stdout)")
 public class SummarizeSignedStateFileCommand implements Callable<Integer> {
-    @ParentCommand
-    private ExamplePcliPlugin examplePcliPlugin;
 
     @Option(
             names = {"-f", "--file"},
-            arity = "1",
+            required = true,
             description = "Input signed state file")
     Path inputFile;
+
+    @Option(
+            names = {"--do-logs"},
+            description = "Enable logging (at INFO level)")
+    boolean doLogging;
 
     @Override
     public Integer call() throws Exception {
 
-        final var knownContracts = getContracts(inputFile);
+        setupLogging();
 
-        final int contractsWithBytecodeFound = knownContracts.contracts().size();
-        final var bytesFound = knownContracts.contracts().stream()
-                .map(Contract::bytecode)
-                .mapToInt(Array::getLength)
-                .sum();
+        try (final var signedState = new SignedStateHolder(inputFile)) {
 
-        System.out.printf(
-                "SummarizeSignedStateFile: %d contractIDs found %d contracts found in file store"
-                        + " (%d bytes total)%n",
-                knownContracts.registeredContractsCount(), contractsWithBytecodeFound, bytesFound);
+            final var knownContracts = signedState.getContracts();
+
+            final int contractsWithBytecodeFound = knownContracts.contracts().size();
+            final var bytesFound = knownContracts.contracts().stream()
+                    .map(Contract::bytecode)
+                    .mapToInt(Array::getLength)
+                    .sum();
+
+            System.out.printf(
+                    ">>> SummarizeSignedStateFile: %d contractIDs found %d contracts found in file store"
+                            + " (%d bytes total) (%d deleted ones too)%n",
+                    knownContracts.registeredContractsCount(),
+                    contractsWithBytecodeFound,
+                    bytesFound,
+                    knownContracts.deletedContracts().size());
+        }
 
         return 0;
+    }
+
+    private void setupLogging() {
+        setRootLogLevel(doLogging ? Level.INFO : Level.ERROR);
+    }
+
+    private void setRootLogLevel(final Level level) {
+        final var logger = LogManager.getRootLogger();
+
+        Configurator.setAllLevels(logger.getName(), level);
+        // Don't understand this: I get two log messages from `FileUtils` at `INFO` level (marker: `STATE_TO_DISK`) and
+        // not only does the above line not suppress them, neither does the following line suppress them:
+        Configurator.setLevel(FileUtils.class, level);
     }
 }

--- a/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/signedstate/utils/SignedStateHolder.java
+++ b/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/signedstate/utils/SignedStateHolder.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.hedera.services.cli.utils;
+package com.hedera.services.cli.signedstate.utils;
 
 import com.hedera.node.app.service.mono.ServicesState;
 import com.hedera.node.app.service.mono.state.adapters.VirtualMapLike;

--- a/hedera-node/cli-clients/src/main/java/module-info.java
+++ b/hedera-node/cli-clients/src/main/java/module-info.java
@@ -1,16 +1,20 @@
 module com.hedera.services.cli {
-    exports com.hedera.services.cli;
     exports com.hedera.services.cli.sign;
+    exports com.hedera.services.cli.signedstate;
 
     requires static com.github.spotbugs.annotations;
+    requires com.google.protobuf;
+    requires com.hedera.hashgraph.protobuf.java.api;
+    requires com.hedera.node.app.hapi.utils;
     requires com.hedera.node.app.service.mono;
     requires com.swirlds.cli;
-    requires com.swirlds.virtualmap;
-    requires com.swirlds.platform;
     requires com.swirlds.common;
+    requires com.swirlds.platform;
+    requires com.swirlds.virtualmap;
     requires info.picocli;
-    requires com.hedera.hashgraph.protobuf.java.api;
     requires org.apache.commons.lang3;
-    requires com.hedera.node.app.hapi.utils;
-    requires com.google.protobuf;
+    requires org.apache.logging.log4j.core;
+    requires org.apache.logging.log4j;
+    requires tuweni.bytes;
+    requires tuweni.units;
 }


### PR DESCRIPTION
**Description**:

1. Implements `AutoClosableNonThrowing` now
2. Put the `summarize` command for signed state under a new `signedstate` command and eliminate now-unnecessary `ExamplePcliPlugin`.

**Related issue(s)**:

Fixes #6427

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (manual, on various signed state files)
