### PR TITLE
Platform version change release 0.38.0-alpha.3

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -144,7 +144,7 @@ dependencyResolutionManagement {
       version("netty-version", "4.1.66.Final")
       version("protobuf-java-version", "3.19.4")
       version("slf4j-version", "2.0.3")
-      version("swirlds-version", "0.38.0-alpha.2")
+      version("swirlds-version", "0.38.0-alpha.3")
       version("tuweni-version", "2.2.0")
       version("jna-version", "5.12.1")
       version("jsr305-version", "3.0.2")


### PR DESCRIPTION
This change is requested by the platform team because of some fix the @cody-littley applied and we had to update the version to 0.38.0-alpha.3
