### PR TITLE
volatile config instead of atomic wrapper

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/config/ConfigProviderImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/config/ConfigProviderImpl.java
@@ -58,13 +58,13 @@ public class ConfigProviderImpl implements ConfigProvider {
     public void update() {
         try (final var lock = updateLock.lock()) {
             final Configuration config = new ConfigurationAdaptor(propertySource);
-            configuration =
-                    new VersionedConfigImpl(config, this.configuration.get().getVersion() + 1);
+            long nextVersion = this.configuration.getVersion() + 1;
+            configuration = new VersionedConfigImpl(config, nextVersion);
         }
     }
 
     @Override
     public VersionedConfiguration getConfiguration() {
-        return configuration.get();
+        return configuration;
     }
 }

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/config/ConfigProviderImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/config/ConfigProviderImpl.java
@@ -26,7 +26,6 @@ import com.swirlds.common.threading.locks.AutoClosableLock;
 import com.swirlds.common.threading.locks.Locks;
 import com.swirlds.config.api.Configuration;
 import edu.umd.cs.findbugs.annotations.NonNull;
-
 import java.util.Objects;
 
 /**


### PR DESCRIPTION
as discussed in https://github.com/hashgraph/hedera-services/pull/6227 I changed the atomic wrapper to a volatile instance