### PR TITLE
Cherry-Pick into v0.38 for 06479 - AddressBookInitializer skip validating state loaded addressbook

### DIFF
--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/AddressBookInitializer.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/AddressBookInitializer.java
@@ -164,9 +164,11 @@ public class AddressBookInitializer {
                     "The loaded signed state is null. The candidateAddressBook is set to "
                             + "the address book from config.txt.");
             candidateAddressBook = configAddressBook;
+            checkCandidateAddressBookValidity(candidateAddressBook);
         } else if (!softwareUpgrade) {
             logger.info(STARTUP.getMarker(), "Using the loaded signed state's address book and weight values.");
             candidateAddressBook = loadedAddressBook;
+            // since state address book was checked for validity prior to adoption, no check needed here.
         } else {
             // There is a software upgrade
             logger.info(
@@ -176,8 +178,8 @@ public class AddressBookInitializer {
                     .getSwirldState()
                     .updateWeight(configAddressBook.copy(), platformContext)
                     .copy();
+            candidateAddressBook = checkCandidateAddressBookValidity(candidateAddressBook);
         }
-        candidateAddressBook = checkCandidateAddressBookValidity(candidateAddressBook);
         recordAddressBooks(candidateAddressBook);
         return candidateAddressBook;
     }


### PR DESCRIPTION
Closes #6479
Prior Behavior: 
* During restarts that did not have a software upgrade, if the state loaded address book differed from the config.txt address book in any way other than stake values, the config.txt address book would be used with a warning.  

New Behavior
* During restarts that do not have a software upgrade, the state loaded address book is always used. 
