### PR TITLE
Add Dockerfile, publish `gcr.io/hedera-registry/validation-scenarios:0.1.0`

### DIFF
--- a/hedera-node/test-clients/build.gradle.kts
+++ b/hedera-node/test-clients/build.gradle.kts
@@ -186,6 +186,19 @@ val validationJar =
       }
     }
 
+val copyValidation =
+    tasks.register<Copy>("copyValidation") {
+      group = "copy"
+      from(validationJar)
+      into(project.file("validation-scenarios"))
+    }
+
+val cleanValidation =
+    tasks.register<Delete>("cleanValidation") {
+      group = "build"
+      delete(File(project.file("validation-scenarios"), "ValidationScenarios.jar"))
+    }
+
 val copyYahCli =
     tasks.register<Copy>("copyYahCli") {
       group = "copy"
@@ -205,4 +218,7 @@ tasks.assemble {
   dependsOn(copyYahCli)
 }
 
-tasks.clean { dependsOn(cleanYahCli) }
+tasks.clean {
+  dependsOn(cleanYahCli)
+  dependsOn(cleanValidation)
+}

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/utils/validation/ValidationScenarios.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/utils/validation/ValidationScenarios.java
@@ -1269,8 +1269,7 @@ public class ValidationScenarios extends HapiSuite {
             }
             var contract = scenarios.getContract();
 
-            Object[] donationArgs =
-                    new Object[] {Long.valueOf((int) targetNetwork().getBootstrap()), "Hey, Ma!"};
+            Object[] donationArgs = new Object[] {800L, "Hey, Ma!"};
 
             return customHapiSpec("ContractScenario")
                     .withProperties(Map.of(

--- a/hedera-node/test-clients/validation-scenarios/Dockerfile
+++ b/hedera-node/test-clients/validation-scenarios/Dockerfile
@@ -1,0 +1,69 @@
+FROM ubuntu:22.04
+# JDK
+ENV JAVA_HOME /opt/java/openjdk
+ENV PATH $JAVA_HOME/bin:$PATH
+
+# Default to UTF-8 file.encoding
+ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
+
+RUN apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends tzdata curl wget ca-certificates fontconfig locales binutils \
+    && echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen \
+    && locale-gen en_US.UTF-8 \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV JAVA_VERSION jdk-17.0.5+8
+
+RUN set -eux; \
+    ARCH="$(dpkg --print-architecture)"; \
+    case "${ARCH}" in \
+       aarch64|arm64) \
+         ESUM='34d6414710db27cd7760fe369135f3b9927ccc81410280606613166d4106d60a'; \
+         BINARY_URL='https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.5%2B8/OpenJDK17U-jre_aarch64_linux_hotspot_17.0.5_8.tar.gz'; \
+         ;; \
+       armhf|arm) \
+         ESUM='9e0d1745139fe502f22df1e261d2ed1ad807085dd75a8b333d481289b579870d'; \
+         BINARY_URL='https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.5%2B8/OpenJDK17U-jre_arm_linux_hotspot_17.0.5_8.tar.gz'; \
+         ;; \
+       ppc64el|powerpc:common64) \
+         ESUM='51dd491505bd2e096676b9dc8ecaf196d78993215af16c0f9dfddfe3dbc0205b'; \
+         BINARY_URL='https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.5%2B8/OpenJDK17U-jre_ppc64le_linux_hotspot_17.0.5_8.tar.gz'; \
+         ;; \
+       s390x|s390:64-bit) \
+         ESUM='eeb1e92b8267e7e015908f3e3b80e48f418b37a2b4491f65290bc5d25e5daf93'; \
+         BINARY_URL='https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.5%2B8/OpenJDK17U-jre_s390x_linux_hotspot_17.0.5_8.tar.gz'; \
+         ;; \
+       amd64|i386:x86-64) \
+         ESUM='11326464a14b63e6328d1d2088a23fb559c0e36b3f380e4c1f8dcbe160a8b95e'; \
+         BINARY_URL='https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.5%2B8/OpenJDK17U-jre_x64_linux_hotspot_17.0.5_8.tar.gz'; \
+         ;; \
+       *) \
+         echo "Unsupported arch: ${ARCH}"; \
+         exit 1; \
+         ;; \
+    esac; \
+	  wget -O /tmp/openjdk.tar.gz ${BINARY_URL}; \
+	  echo "${ESUM} */tmp/openjdk.tar.gz" | sha256sum -c -; \
+	  mkdir -p "$JAVA_HOME"; \
+	  tar --extract \
+	      --file /tmp/openjdk.tar.gz \
+	      --directory "$JAVA_HOME" \
+	      --strip-components 1 \
+	      --no-same-owner \
+	  ; \
+    rm /tmp/openjdk.tar.gz; \
+# https://github.com/docker-library/openjdk/issues/331#issuecomment-498834472
+    find "$JAVA_HOME/lib" -name '*.so' -exec dirname '{}' ';' | sort -u > /etc/ld.so.conf.d/docker-openjdk.conf; \
+    ldconfig; \
+# https://github.com/docker-library/openjdk/issues/212#issuecomment-420979840
+# https://openjdk.java.net/jeps/341
+    java -Xshare:dump;
+
+RUN mkdir -p /launch /opt/bin
+
+COPY ValidationScenarios.jar /opt/bin
+COPY assets/screened-launch.sh /opt/bin
+
+WORKDIR /launch
+
+ENTRYPOINT ["/opt/bin/screened-launch.sh"]

--- a/hedera-node/test-clients/validation-scenarios/assets/screened-launch.sh
+++ b/hedera-node/test-clients/validation-scenarios/assets/screened-launch.sh
@@ -1,0 +1,5 @@
+#! /bin/sh
+java -jar /opt/bin/ValidationScenarios.jar "$@" 2>syserr.log
+RC=$?
+  cat syserr.log
+exit $RC

--- a/hedera-node/test-clients/validation-scenarios/run/build.sh
+++ b/hedera-node/test-clients/validation-scenarios/run/build.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -eo pipefail
 
-TAG=${1:-'0.3.9'}
+TAG=${1:-'0.1.0'}
 SCRIPT_SOURCE="${BASH_SOURCE[0]}"
 
 READLINK_OPTS=""
@@ -19,11 +19,8 @@ SCRIPT_PATH="$(cd "$(dirname "${SCRIPT_SOURCE}")" && pwd)"
 OLD_CWD="$(pwd)"
 
 cd "${SCRIPT_PATH}/../../../../"
-./gradlew assemble
+./gradlew assemble cleanValidation validationJar copyValidation
 cd "${SCRIPT_PATH}/.."
 
-rm -f assets/yahcli.jar >/dev/null 2>&1 || true
-cp -f yahcli.jar assets/
-
-docker build -t yahcli:$TAG .
+docker build -t validation-scenarios:$TAG .
 cd "${OLD_CWD}"

--- a/hedera-node/test-clients/yahcli/run/publish.sh
+++ b/hedera-node/test-clients/yahcli/run/publish.sh
@@ -18,7 +18,7 @@ SCRIPT_PATH="$(cd "$(dirname "${SCRIPT_SOURCE}")" && pwd)"
 
 OLD_CWD="$(pwd)"
 
-cd "${SCRIPT_PATH}/../../.."
+cd "${SCRIPT_PATH}/../../../../"
 ./gradlew assemble
 cd "${SCRIPT_PATH}/.."
 


### PR DESCRIPTION
**Description**:
 - Closes #6478 
 - Updates `contract` validation scenario to send 1 tinybar in value to `0.0.800` instead of bootstrap payer (since in dev env this is may be an account in precompile range).
 - Adds Docker build assets, publishes `gcr.io/hedera-registry/validation-scenarios:0.1.0`
 - Follows yahcli bind mount convention, typical usage would be,
```
docker run -e BOOTSTRAP_PASSPHRASE=swirlds \
  -v $(pwd):/launch gcr.io/hedera-registry/validation-scenarios:0.1.0 \
  target=localhost novel=true scenarios=staking,contract,xfers
```
