### PR TITLE
Remove HTS performance test from nightly regression

### DIFF
--- a/.github/workflows/node-flow-fsts-daily-interval-05.yaml
+++ b/.github/workflows/node-flow-fsts-daily-interval-05.yaml
@@ -39,7 +39,6 @@ concurrency:
   group: ${{ github.event.inputs.concurrency-group || format('{0}-{1}-flow-jrs-daily-interval-groups', github.ref_name, github.sha) }}
 
 # Panel Definition & Timings:
-#    "configs/services/suites/daily/GCP-Daily-Services-HTS-Restart-Performance-7N-7C.json"          ----         160m
 #    "configs/services/suites/daily/GCP-Daily-Services-Comp-Reconnect-6N-1C.json"                   ----         150m
 #    "configs/services/suites/daily/GCP-Daily-Services-Comp-NI-Reconnect-Correctness-6N-1C.json"    ----         150m
 #
@@ -48,27 +47,6 @@ concurrency:
 
 
 jobs:
-  hts-restart-performance-7n-7c:
-    name: HTS-Restart-Performance-7N-7C
-    uses: ./.github/workflows/zxc-jrs-regression.yaml
-    with:
-      ref: ${{ github.event.inputs.ref }}
-      branch-name: ${{ github.event.inputs.branch-name }}
-      hedera-tests-enabled: true
-      slack-results-channel: hedera-regression
-      slack-summary-channel: hedera-regression-summary
-      use-branch-for-slack-channel: false
-      panel-config: "configs/services/suites/daily/GCP-Daily-Services-HTS-Restart-Performance-7N-7C.json"
-    secrets:
-      access-token: ${{ secrets.PLATFORM_GH_ACCESS_TOKEN }}
-      jrs-ssh-user-name: ${{ secrets.PLATFORM_JRS_SSH_USER_NAME }}
-      jrs-ssh-key-file: ${{ secrets.PLATFORM_JRS_SSH_KEY_FILE }}
-      gcp-project-number: ${{ secrets.PLATFORM_GCP_PROJECT_NUMBER }}
-      gcp-sa-key-contents: ${{ secrets.PLATFORM_GCP_KEY_FILE }}
-      slack-api-token: ${{ secrets.PLATFORM_SLACK_API_TOKEN }}
-    if: ${{ !cancelled() && always() }}
-
-
   comp-reconnect-6n-1c:
     name: Comp-Reconnect-6N-1C
     uses: ./.github/workflows/zxc-jrs-regression.yaml


### PR DESCRIPTION
We have no longer maintain the saved state file used in this performance test,
and also the performance test will be covered by perfNet test