### PR TITLE
Accommodate varying sig map sizes in `canAutoCreateWithFungibleTokenTransfersToAlias()`

### DIFF
--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/HapiTxnOp.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/HapiTxnOp.java
@@ -742,4 +742,8 @@ public abstract class HapiTxnOp<T extends HapiTxnOp<T>> extends HapiSpecOperatio
     public ResponseCodeEnum getActualPrecheck() {
         return actualPrecheck;
     }
+
+    public ResponseCodeEnum getActualStatus() {
+        return lastReceipt.getStatus();
+    }
 }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/HapiTxnOp.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/HapiTxnOp.java
@@ -743,6 +743,10 @@ public abstract class HapiTxnOp<T extends HapiTxnOp<T>> extends HapiSpecOperatio
         return actualPrecheck;
     }
 
+    public boolean hasActualStatus() {
+        return lastReceipt != null;
+    }
+
     public ResponseCodeEnum getActualStatus() {
         return lastReceipt.getStatus();
     }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/LazyCreateThroughPrecompileSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/LazyCreateThroughPrecompileSuite.java
@@ -418,7 +418,10 @@ public class LazyCreateThroughPrecompileSuite extends HapiSuite {
                             .alsoSigningWithFullPrefix(CIVILIAN)
                             .hasKnownStatusFrom(SUCCESS, CONTRACT_REVERT_EXECUTED);
                     allRunFor(spec, op);
-                    if (op.getActualStatus() == CONTRACT_REVERT_EXECUTED) {
+                    // If this ContractCall was converted to an EthereumTransaction, then it will
+                    // not be tracking the last receipt and we can't do this extra logging; this is
+                    // fine for now, since the _Eth spec hasn't been flaky
+                    if (op.hasActualStatus() && op.getActualStatus() == CONTRACT_REVERT_EXECUTED) {
                         final var lookup = getTxnRecord(creationAttempt).andAllChildRecords();
                         allRunFor(spec, lookup);
                         Assertions.fail("canCreateViaFungibleWithFractionalFee() failed w/ record "

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/AutoAccountCreationSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/AutoAccountCreationSuite.java
@@ -20,7 +20,6 @@ import static com.google.protobuf.ByteString.copyFromUtf8;
 import static com.hedera.node.app.service.evm.utils.EthSigsUtils.recoverAddressFromPubKey;
 import static com.hedera.services.bdd.spec.HapiPropertySource.asSolidityAddress;
 import static com.hedera.services.bdd.spec.HapiSpec.defaultHapiSpec;
-import static com.hedera.services.bdd.spec.HapiSpec.onlyDefaultHapiSpec;
 import static com.hedera.services.bdd.spec.PropertySource.asAccount;
 import static com.hedera.services.bdd.spec.PropertySource.asAccountString;
 import static com.hedera.services.bdd.spec.assertions.AccountInfoAsserts.accountWith;
@@ -576,7 +575,7 @@ public class AutoAccountCreationSuite extends HapiSuite {
         // the sig map, depending on the lengths of the public key prefixes required
         final long approxTransferFee = 1163019L;
 
-        return onlyDefaultHapiSpec("canAutoCreateWithFungibleTokenTransfersToAlias")
+        return defaultHapiSpec("canAutoCreateWithFungibleTokenTransfersToAlias")
                 .given(
                         newKeyNamed(VALID_ALIAS),
                         cryptoCreate(TOKEN_TREASURY).balance(ONE_HUNDRED_HBARS),

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/AutoAccountCreationSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/AutoAccountCreationSuite.java
@@ -20,6 +20,7 @@ import static com.google.protobuf.ByteString.copyFromUtf8;
 import static com.hedera.node.app.service.evm.utils.EthSigsUtils.recoverAddressFromPubKey;
 import static com.hedera.services.bdd.spec.HapiPropertySource.asSolidityAddress;
 import static com.hedera.services.bdd.spec.HapiSpec.defaultHapiSpec;
+import static com.hedera.services.bdd.spec.HapiSpec.onlyDefaultHapiSpec;
 import static com.hedera.services.bdd.spec.PropertySource.asAccount;
 import static com.hedera.services.bdd.spec.PropertySource.asAccountString;
 import static com.hedera.services.bdd.spec.assertions.AccountInfoAsserts.accountWith;
@@ -81,6 +82,7 @@ import static com.hederahashgraph.api.proto.java.TokenSupplyType.FINITE;
 import static com.hederahashgraph.api.proto.java.TokenType.FUNGIBLE_COMMON;
 import static com.hederahashgraph.api.proto.java.TokenType.NON_FUNGIBLE_UNIQUE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.protobuf.ByteString;
 import com.hedera.services.bdd.spec.HapiSpec;
@@ -569,9 +571,12 @@ public class AutoAccountCreationSuite extends HapiSuite {
     private HapiSpec canAutoCreateWithFungibleTokenTransfersToAlias() {
         final var initialTokenSupply = 1000;
         final var sameTokenXfer = "sameTokenXfer";
-        final long transferFee = 1163019L;
+        // The expected fee for two token transfers to a receiver with no auto-creation;
+        // note it is approximate because the fee will vary slightly with the size of
+        // the sig map, depending on the lengths of the public key prefixes required
+        final long approxTransferFee = 1163019L;
 
-        return defaultHapiSpec("canAutoCreateWithFungibleTokenTransfersToAlias")
+        return onlyDefaultHapiSpec("canAutoCreateWithFungibleTokenTransfersToAlias")
                 .given(
                         newKeyNamed(VALID_ALIAS),
                         cryptoCreate(TOKEN_TREASURY).balance(ONE_HUNDRED_HBARS),
@@ -634,7 +639,7 @@ public class AutoAccountCreationSuite extends HapiSuite {
                             final var payer = spec.registry().getAccountID(CIVILIAN);
                             final var parent = lookup.getResponseRecord();
                             final var child = lookup.getChildRecord(0);
-                            assertAliasBalanceAndFeeInChildRecord(parent, child, sponsor, payer, 0L, transferFee);
+                            assertAliasBalanceAndFeeInChildRecord(parent, child, sponsor, payer, 0L, approxTransferFee);
                         }))
                 .then(
                         /* --- transfer another token to created alias */
@@ -1172,7 +1177,7 @@ public class AutoAccountCreationSuite extends HapiSuite {
             final AccountID sponsor,
             final AccountID defaultPayer,
             final long newAccountFunding,
-            final long transferFee) {
+            final long approxTransferFee) {
         long receivedBalance = 0;
         long creationFeeSplit = 0;
         long payerBalWithAutoCreationFee = 0;
@@ -1201,8 +1206,19 @@ public class AutoAccountCreationSuite extends HapiSuite {
             }
         }
         assertEquals(newAccountFunding, receivedBalance, "Transferred incorrect amount to alias");
-        assertEquals(
-                creationFeeSplit - transferFee, child.getTransactionFee(), "Child record did not specify deducted fee");
+        // The charged auto-creation fee is the total fee collected minus the transfer fee; but
+        // recall the transfer fee can vary a bit based on the size of the sig map, so we'll enforce
+        // just approximate equality with the fee in the child record
+        final var approxAutoCreationFee = creationFeeSplit - approxTransferFee;
+        final var recordFee = child.getTransactionFee();
+        // A single extra byte in the signature map will cost just ~40 tinybar more, so allowing
+        // a delta of 1000 tinybar is sufficient to stabilize this test indefinitely
+        final var permissibleDelta = 1000L;
+        final var observedDelta = Math.abs(approxAutoCreationFee - recordFee);
+        assertTrue(
+                observedDelta <= permissibleDelta,
+                "Child record did not specify the auto-creation fee (expected ~" + approxAutoCreationFee + " but was "
+                        + recordFee + ")");
         assertEquals(0, payerBalWithAutoCreationFee, "Auto creation fee is deducted from payer");
     }
 


### PR DESCRIPTION
**Description**:
 - Fixes `canAutoCreateWithFungibleTokenTransfersToAlias()` flakiness (c.f. #6486) by recognizing that varying `pubKeyPrefix` overlap lengths will change `SignatureMap` size, which will slightly change the fee charged.
 - Adds logging to improve diagnosis of `canCreateViaFungibleWithFractionalFee()` failure.