### PR TITLE
6524: Skip sending class IDs for virtual leaf records during reconnects

### DIFF
--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/synchronization/internal/NodeToSend.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/synchronization/internal/NodeToSend.java
@@ -131,7 +131,7 @@ public class NodeToSend {
     }
 
     /**
-     * Wait for a resonse from the learner. Will return immediately if a response has already been received or
+     * Wait for a response from the learner. Will return immediately if a response has already been received or
      * if an ancestor has received a positive response. May sleep a short period if neither are true.
      * There is no guarantee that a response will have been received when this method returns.
      */
@@ -141,7 +141,7 @@ public class NodeToSend {
         }
 
         final long currentTime = System.currentTimeMillis();
-        if (currentTime > unconditionalSendTimeMilliseconds) {
+        if (currentTime >= unconditionalSendTimeMilliseconds) {
             return;
         }
 

--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/reconnect/VirtualLearnerTreeView.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/reconnect/VirtualLearnerTreeView.java
@@ -232,7 +232,7 @@ public final class VirtualLearnerTreeView<K extends VirtualKey, V extends Virtua
             firstLeaf = false;
         }
 
-        final VirtualLeafRecord<K, V> leaf = in.readSerializable();
+        final VirtualLeafRecord<K, V> leaf = in.readSerializable(false, VirtualLeafRecord::new);
         nodeRemover.newLeafNode(leaf.getPath(), leaf.getKey());
         root.handleReconnectLeaf(leaf); // may block if hashing is slower than ingest
         return leaf.getPath();

--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/reconnect/VirtualTeacherTreeView.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/reconnect/VirtualTeacherTreeView.java
@@ -210,7 +210,7 @@ public final class VirtualTeacherTreeView<K extends VirtualKey, V extends Virtua
         checkValidLeaf(leaf, reconnectState);
         final VirtualLeafRecord<K, V> leafRecord = records.findLeafRecord(leaf, false);
         assert leafRecord != null : "Unexpected null leaf record at path=" + leaf;
-        out.writeSerializable(leafRecord, true);
+        out.writeSerializable(leafRecord, false);
     }
 
     /**


### PR DESCRIPTION
A minor improvement to skip sending redundant class IDs during virtual node reconnects. All leaf nodes processed by `VirtualTeacherTreeView` and `VirtualLearnerTreeView` are always instances of `VirtualLeafRecord`, so there is no need to (de)serialize them as generic serializable objects.

I tried to enhance the fix to also skip sending virtual key/value class IDs, but it appeared to be complicated. On the teacher side there is no information about keys/values other than compile-time generic types. There is no class ID to send to the learner, there is no way to have a self-serializable supplier (similar to JasperDB's `SelfSerializableSupplier`) without virtual map API changes.

Testing: existing unit tests cover these changes.

Fixes: https://github.com/hashgraph/hedera-services/issues/6524
Signed-off-by: Artem Ananev <artem.ananev@swirldslabs.com>
