### PR TITLE
Add optional keys and optional hollow accounts to pre-handle context

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1046,6 +1046,10 @@ platform-sdk/sdk/metricsDoc.tsv
 # Temporary Test Folders (Poorly Behaved Tests)
 **/swirlds-tmp
 swirlds-platform-core/data/**
+hedera-node/cli-clients/testFile
+hedera-node/hedera-mono-service/src/test/resources/balance*/**
+hedera-node/hedera-mono-service/temp/**
+hedera-node/hedera-mono-service/swirlds-sst-tmp/**
 
 # Test Files (Poorly Behaved Tests)
 *.json.gz

--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/workflows/PreCheckException.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/workflows/PreCheckException.java
@@ -16,10 +16,10 @@
 
 package com.hedera.node.app.spi.workflows;
 
-import static java.util.Objects.requireNonNull;
-
 import com.hedera.hapi.node.base.ResponseCodeEnum;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+import java.util.Objects;
 
 /**
  * Thrown if the request itself is bad. The protobuf decoded correctly, but it failed one or more of the ingestion
@@ -36,7 +36,35 @@ public class PreCheckException extends Exception {
      */
     public PreCheckException(@NonNull final ResponseCodeEnum responseCode) {
         super();
-        this.responseCode = requireNonNull(responseCode);
+        this.responseCode = Objects.requireNonNull(responseCode);
+    }
+
+    /**
+     * <strong>Disallowed</strong> constructor of {@code PreCheckException}.
+     * This {@link Exception} subclass is used as a form of unconditional jump, rather than a true
+     * exception.  If another {@link Throwable} caused this exception to be thrown, then that other
+     * throwable <strong>must</strong> be logged to appropriate diagnostics before the {@code PreCheckException}
+     * is thrown.
+     *
+     * @param responseCode the {@link ResponseCodeEnum responseCode}.  This is ignored.
+     * @param cause the {@link Throwable} that caused this exception.  This is ignored.
+     * @throws UnsupportedOperationException always.  This constructor must not be called.
+     */
+    private PreCheckException(@NonNull final ResponseCodeEnum responseCode, @Nullable final Throwable cause) {
+        throw new UnsupportedOperationException("PreCheckException must not chain a cause");
+    }
+
+    /**
+     * {@inheritDoc}
+     * This implementation prevents initializing a cause.  PreCheckException is a result code carrier and
+     * must not have a cause.  If another {@link Throwable} caused this exception to be thrown, then that other
+     * throwable <strong>must</strong> be logged to appropriate diagnostics before the {@code PreCheckException}
+     * is thrown.
+     * @throws UnsupportedOperationException always.  This method must not be called.
+     */
+    @Override
+    public Throwable initCause(Throwable cause) {
+        throw new UnsupportedOperationException("PreCheckException must not chain a cause");
     }
 
     /**

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/prehandle/PreHandleContextImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/prehandle/PreHandleContextImpl.java
@@ -60,6 +60,14 @@ public class PreHandleContextImpl implements PreHandleContext {
     private final Set<Key> requiredNonPayerKeys = new LinkedHashSet<>();
     /** The set of all hollow accounts that need to be validated. */
     private final Set<Account> requiredHollowAccounts = new LinkedHashSet<>();
+    /**
+     * The set of all optional non-payer keys. A {@link LinkedHashSet} is used to maintain a consistent ordering.
+     * While not strictly necessary, it is useful at the moment to ensure tests are deterministic. The tests should
+     * be updated to compare set contents rather than ordering.
+     */
+    private final Set<Key> optionalNonPayerKeys = new LinkedHashSet<>();
+    /** The set of all hollow accounts that <strong>might</strong> need to be validated, but also might not. */
+    private final Set<Account> optionalHollowAccounts = new LinkedHashSet<>();
     /** Scheduled transactions have a secondary "inner context". Seems not quite right. */
     private PreHandleContext innerContext;
 
@@ -67,33 +75,27 @@ public class PreHandleContextImpl implements PreHandleContext {
 
     public PreHandleContextImpl(@NonNull final ReadableStoreFactory storeFactory, @NonNull final TransactionBody txn)
             throws PreCheckException {
-        this(
-                storeFactory,
-                txn,
-                txn.transactionIDOrElse(TransactionID.DEFAULT).accountIDOrElse(AccountID.DEFAULT),
-                ResponseCodeEnum.INVALID_PAYER_ACCOUNT_ID);
+        this(storeFactory, txn, txn.transactionIDOrElse(TransactionID.DEFAULT).accountIDOrElse(AccountID.DEFAULT));
     }
 
     /** Create a new instance */
     private PreHandleContextImpl(
             @NonNull final ReadableStoreFactory storeFactory,
             @NonNull final TransactionBody txn,
-            @NonNull final AccountID payer,
-            @NonNull final ResponseCodeEnum responseCode)
+            @NonNull final AccountID payer)
             throws PreCheckException {
         this.storeFactory = requireNonNull(storeFactory, "The supplied argument 'storeFactory' must not be null.");
         this.txn = requireNonNull(txn, "The supplied argument 'txn' cannot be null!");
         this.payer = requireNonNull(payer, "The supplied argument 'payer' cannot be null!");
 
-        this.accountStore = storeFactory.createStore(ReadableAccountStore.class);
-
+        accountStore = storeFactory.createStore(ReadableAccountStore.class);
         // Find the account, which must exist or throw a PreCheckException with the given response code.
         final var account = accountStore.getAccountById(payer);
-        mustExist(account, responseCode);
+        mustExist(account, ResponseCodeEnum.INVALID_PAYER_ACCOUNT_ID);
         // NOTE: While it is true that the key can be null on some special accounts like
         // account 800, those accounts cannot be the payer.
-        this.payerKey = account.key();
-        mustExist(this.payerKey, responseCode);
+        payerKey = account.key();
+        mustExist(payerKey, ResponseCodeEnum.INVALID_PAYER_ACCOUNT_ID);
     }
 
     @Override
@@ -118,6 +120,48 @@ public class PreHandleContextImpl implements PreHandleContext {
     @Override
     public Set<Key> requiredNonPayerKeys() {
         return Collections.unmodifiableSet(requiredNonPayerKeys);
+    }
+
+    @NonNull
+    @Override
+    public Set<Key> optionalNonPayerKeys() {
+        return Collections.unmodifiableSet(optionalNonPayerKeys);
+    }
+
+    @NonNull
+    @Override
+    public PreHandleContext optionalKey(@NonNull final Key key) {
+        if (!key.equals(payerKey) && isValid(key)) {
+            optionalNonPayerKeys.add(key);
+        }
+        return this;
+    }
+
+    @NonNull
+    @Override
+    public PreHandleContext optionalKeys(@NonNull final Set<Key> keys) {
+        for (final Key nextKey : keys) {
+            optionalKey(nextKey);
+        }
+        return this;
+    }
+
+    @NonNull
+    @Override
+    public Set<Account> optionalHollowAccounts() {
+        return Collections.unmodifiableSet(optionalHollowAccounts);
+    }
+
+    @NonNull
+    @Override
+    public PreHandleContext optionalSignatureForHollowAccount(@NonNull final Account hollowAccount) {
+        requireNonNull(hollowAccount);
+        if (!isHollow(hollowAccount)) {
+            throw new IllegalArgumentException(
+                    "Account %d is not a hollow account".formatted(hollowAccount.accountNumber()));
+        }
+        optionalHollowAccounts.add(hollowAccount);
+        return this;
     }
 
     @Override
@@ -285,11 +329,9 @@ public class PreHandleContextImpl implements PreHandleContext {
     @Override
     @NonNull
     public PreHandleContext createNestedContext(
-            @NonNull final TransactionBody nestedTxn,
-            @NonNull final AccountID payerForNested,
-            @NonNull final ResponseCodeEnum responseCode)
+            @NonNull final TransactionBody nestedTxn, @NonNull final AccountID payerForNested)
             throws PreCheckException {
-        this.innerContext = new PreHandleContextImpl(storeFactory, nestedTxn, payerForNested, responseCode);
+        this.innerContext = new PreHandleContextImpl(storeFactory, nestedTxn, payerForNested);
         return this.innerContext;
     }
 

--- a/hedera-node/hedera-schedule-service-impl/src/main/java/module-info.java
+++ b/hedera-node/hedera-schedule-service-impl/src/main/java/module-info.java
@@ -10,6 +10,7 @@ module com.hedera.node.app.service.schedule.impl {
     requires javax.inject;
     requires com.swirlds.common;
     requires com.github.spotbugs.annotations;
+    requires org.apache.logging.log4j;
 
     exports com.hedera.node.app.service.schedule.impl to
             com.hedera.node.app.service.schedule.impl.test,


### PR DESCRIPTION
**Description**:
Added initial methods to PreHandleContext for optional keys and optional hollow accounts, and skeleton implementations in implementing classes.
Also fixed a minor issue in PreHandleContext leftover from earlier work.

**Changes**:

* Removed unnecessary (and always ignored) response code parameter from PreHandleContext create inner context.
* Added methods to PreHandleContext to add one optional key, or a Set of optional keys
* Added a method on PreHandleContext to return the Set of optional keys
* Added a method on PreHandleContext to add one optional hollow account
* Added a method on PreHandleContext to return the Set of optional hollow accounts
* Added base implementations for the new methods
* Adjusted AbstractScheduleHandler to process the inner context correctly and handle the exceptions as expected (ensuring tests still pass without changes to test methods).
