### PR TITLE
0.38.x: Move (some) signatures and decoders of versioned ABIs to a dedicated location

### DIFF
--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/codec/BurnWrapper.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/codec/BurnWrapper.java
@@ -21,6 +21,7 @@ import static com.hederahashgraph.api.proto.java.TokenType.NON_FUNGIBLE_UNIQUE;
 
 import com.hederahashgraph.api.proto.java.TokenID;
 import com.hederahashgraph.api.proto.java.TokenType;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.Collections;
 import java.util.List;
 
@@ -28,10 +29,12 @@ public record BurnWrapper(long amount, TokenID tokenType, List<Long> serialNos) 
     private static final long NONFUNGIBLE_BURN_AMOUNT = -1;
     private static final List<Long> FUNGIBLE_BURN_SERIAL_NOS = Collections.emptyList();
 
+    @NonNull
     public static BurnWrapper forNonFungible(final TokenID tokenType, final List<Long> serialNos) {
         return new BurnWrapper(NONFUNGIBLE_BURN_AMOUNT, tokenType, serialNos);
     }
 
+    @NonNull
     public static BurnWrapper forFungible(final TokenID tokenType, final long amount) {
         return new BurnWrapper(amount, tokenType, FUNGIBLE_BURN_SERIAL_NOS);
     }

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/codec/MintWrapper.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/codec/MintWrapper.java
@@ -22,6 +22,7 @@ import static com.hederahashgraph.api.proto.java.TokenType.NON_FUNGIBLE_UNIQUE;
 import com.google.protobuf.ByteString;
 import com.hederahashgraph.api.proto.java.TokenID;
 import com.hederahashgraph.api.proto.java.TokenType;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.Collections;
 import java.util.List;
 
@@ -29,10 +30,12 @@ public record MintWrapper(long amount, TokenID tokenType, List<ByteString> metad
     private static final long NONFUNGIBLE_MINT_AMOUNT = -1;
     private static final List<ByteString> FUNGIBLE_MINT_METADATA = Collections.emptyList();
 
+    @NonNull
     public static MintWrapper forNonFungible(final TokenID tokenType, final List<ByteString> metadata) {
         return new MintWrapper(NONFUNGIBLE_MINT_AMOUNT, tokenType, metadata);
     }
 
+    @NonNull
     public static MintWrapper forFungible(final TokenID tokenType, final long amount) {
         return new MintWrapper(amount, tokenType, FUNGIBLE_MINT_METADATA);
     }

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/BurnPrecompile.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/BurnPrecompile.java
@@ -16,7 +16,6 @@
 
 package com.hedera.node.app.service.mono.store.contracts.precompile.impl;
 
-import static com.hedera.node.app.hapi.utils.contracts.ParsingConstants.INT;
 import static com.hedera.node.app.service.evm.utils.ValidationUtils.validateTrue;
 import static com.hedera.node.app.service.mono.store.contracts.precompile.codec.DecodingFacade.convertAddressBytesToTokenID;
 import static com.hedera.node.app.service.mono.store.contracts.precompile.codec.DecodingFacade.decodeFunctionCall;
@@ -28,10 +27,7 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_FULL_P
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OK;
 import static com.hederahashgraph.api.proto.java.TokenType.NON_FUNGIBLE_UNIQUE;
 
-import com.esaulpaugh.headlong.abi.ABIType;
-import com.esaulpaugh.headlong.abi.Function;
 import com.esaulpaugh.headlong.abi.Tuple;
-import com.esaulpaugh.headlong.abi.TypeFactory;
 import com.hedera.node.app.service.mono.context.SideEffectsTracker;
 import com.hedera.node.app.service.mono.contracts.sources.EvmSigsVerifier;
 import com.hedera.node.app.service.mono.ledger.accounts.ContractAliases;
@@ -48,6 +44,7 @@ import com.hedera.node.app.service.mono.store.models.Id;
 import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
 import com.hederahashgraph.api.proto.java.Timestamp;
 import com.hederahashgraph.api.proto.java.TransactionBody;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -60,11 +57,6 @@ public class BurnPrecompile extends AbstractWritePrecompile {
     private final int functionId;
     private static final List<Long> NO_SERIAL_NOS = Collections.emptyList();
     private static final String BURN = String.format(FAILURE_MESSAGE, "burn");
-    private static final Function BURN_TOKEN_FUNCTION = new Function("burnToken(address,uint64,int64[])", INT);
-    private static final Function BURN_TOKEN_FUNCTION_V2 = new Function("burnToken(address,int64,int64[])", INT);
-    private static final Bytes BURN_TOKEN_SELECTOR = Bytes.wrap(BURN_TOKEN_FUNCTION.selector());
-    private static final Bytes BURN_TOKEN_SELECTOR_V2 = Bytes.wrap(BURN_TOKEN_FUNCTION_V2.selector());
-    private static final ABIType<Tuple> BURN_TOKEN_DECODER = TypeFactory.create("(bytes32,int64,int64[])");
     private final EncodingFacade encoder;
     private final ContractAliases aliases;
     private final EvmSigsVerifier sigsVerifier;
@@ -89,10 +81,14 @@ public class BurnPrecompile extends AbstractWritePrecompile {
 
     @Override
     public TransactionBody.Builder body(final Bytes input, final UnaryOperator<byte[]> aliasResolver) {
-        burnOp = switch (functionId) {
-            case AbiConstants.ABI_ID_BURN_TOKEN -> decodeBurn(input);
-            case AbiConstants.ABI_ID_BURN_TOKEN_V2 -> decodeBurnV2(input);
-            default -> null;};
+        final var burnAbi =
+                switch (functionId) {
+                    case AbiConstants.ABI_ID_BURN_TOKEN -> SystemContractAbis.BURN_TOKEN_V1;
+                    case AbiConstants.ABI_ID_BURN_TOKEN_V2 -> SystemContractAbis.BURN_TOKEN_V2;
+                    default -> throw new IllegalArgumentException("invalid selector to burn precompile");
+                };
+        burnOp = getBurnWrapper(input, burnAbi);
+        if (burnOp == null) throw new IllegalArgumentException("unable to create burn wrapper from decoded input");
         transactionBody = syntheticTxnFactory.createBurn(burnOp);
         return transactionBody;
     }
@@ -143,15 +139,11 @@ public class BurnPrecompile extends AbstractWritePrecompile {
         return encoder.encodeBurnFailure(status);
     }
 
-    public static BurnWrapper decodeBurn(final Bytes input) {
-        return getBurnWrapper(input, BURN_TOKEN_SELECTOR);
-    }
-
-    private static BurnWrapper getBurnWrapper(final Bytes input, final Bytes burnTokenSelector) {
-        final Tuple decodedArguments = decodeFunctionCall(input, burnTokenSelector, BURN_TOKEN_DECODER);
+    public static BurnWrapper getBurnWrapper(final Bytes input, @NonNull final SystemContractAbis abi) {
+        final Tuple decodedArguments = decodeFunctionCall(input, abi.selector, abi.decoder);
 
         final var tokenID = convertAddressBytesToTokenID(decodedArguments.get(0));
-        final var fungibleAmount = (long) decodedArguments.get(1);
+        final var fungibleAmount = SystemContractAbis.toLongSafely(decodedArguments.get(1));
         final var serialNumbers = (long[]) decodedArguments.get(2);
 
         if (fungibleAmount > 0) {
@@ -160,9 +152,5 @@ public class BurnPrecompile extends AbstractWritePrecompile {
             return BurnWrapper.forNonFungible(
                     tokenID, Arrays.stream(serialNumbers).boxed().toList());
         }
-    }
-
-    public static BurnWrapper decodeBurnV2(final Bytes input) {
-        return getBurnWrapper(input, BURN_TOKEN_SELECTOR_V2);
     }
 }

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/BurnPrecompile.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/BurnPrecompile.java
@@ -88,7 +88,6 @@ public class BurnPrecompile extends AbstractWritePrecompile {
                     default -> throw new IllegalArgumentException("invalid selector to burn precompile");
                 };
         burnOp = getBurnWrapper(input, burnAbi);
-        if (burnOp == null) throw new IllegalArgumentException("unable to create burn wrapper from decoded input");
         transactionBody = syntheticTxnFactory.createBurn(burnOp);
         return transactionBody;
     }

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/MintPrecompile.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/MintPrecompile.java
@@ -16,7 +16,6 @@
 
 package com.hedera.node.app.service.mono.store.contracts.precompile.impl;
 
-import static com.hedera.node.app.hapi.utils.contracts.ParsingConstants.INT;
 import static com.hedera.node.app.service.evm.utils.ValidationUtils.validateTrue;
 import static com.hedera.node.app.service.mono.store.contracts.precompile.codec.DecodingFacade.convertAddressBytesToTokenID;
 import static com.hedera.node.app.service.mono.store.contracts.precompile.codec.DecodingFacade.decodeFunctionCall;
@@ -28,10 +27,7 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_FULL_P
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OK;
 import static com.hederahashgraph.api.proto.java.TokenType.NON_FUNGIBLE_UNIQUE;
 
-import com.esaulpaugh.headlong.abi.ABIType;
-import com.esaulpaugh.headlong.abi.Function;
 import com.esaulpaugh.headlong.abi.Tuple;
-import com.esaulpaugh.headlong.abi.TypeFactory;
 import com.google.protobuf.ByteString;
 import com.hedera.node.app.hapi.utils.ByteStringUtils;
 import com.hedera.node.app.service.mono.context.SideEffectsTracker;
@@ -101,7 +97,6 @@ public class MintPrecompile extends AbstractWritePrecompile {
                     default -> throw new IllegalArgumentException("invalid selector to mint precompile");
                 };
         mintOp = getMintWrapper(input, mintAbi);
-        if (mintOp == null) throw new IllegalArgumentException("unable to create mint wrapper from decoded input");
         transactionBody = syntheticTxnFactory.createMint(mintOp);
         return transactionBody;
     }

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/MintPrecompile.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/MintPrecompile.java
@@ -51,6 +51,7 @@ import com.hedera.node.app.service.mono.store.models.Id;
 import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
 import com.hederahashgraph.api.proto.java.Timestamp;
 import com.hederahashgraph.api.proto.java.TransactionBody;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -64,11 +65,6 @@ public class MintPrecompile extends AbstractWritePrecompile {
     private final int functionId;
     private static final List<ByteString> NO_METADATA = Collections.emptyList();
     private static final String MINT = String.format(FAILURE_MESSAGE, "mint");
-    private static final Function MINT_TOKEN_FUNCTION = new Function("mintToken(address,uint64,bytes[])", INT);
-    private static final Function MINT_TOKEN_FUNCTION_V2 = new Function("mintToken(address,int64,bytes[])", INT);
-    public static final Bytes MINT_TOKEN_SELECTOR = Bytes.wrap(MINT_TOKEN_FUNCTION.selector());
-    private static final Bytes MINT_TOKEN_SELECTOR_V2 = Bytes.wrap(MINT_TOKEN_FUNCTION_V2.selector());
-    private static final ABIType<Tuple> MINT_TOKEN_DECODER = TypeFactory.create("(bytes32,int64,bytes[])");
     private final EncodingFacade encoder;
     private final ContractAliases aliases;
     private final EvmSigsVerifier sigsVerifier;
@@ -98,10 +94,14 @@ public class MintPrecompile extends AbstractWritePrecompile {
     @Override
     public TransactionBody.Builder body(final Bytes input, final UnaryOperator<byte[]> aliasResolver) {
         this.transactionBody = null;
-        mintOp = switch (functionId) {
-            case AbiConstants.ABI_ID_MINT_TOKEN -> decodeMint(input);
-            case AbiConstants.ABI_ID_MINT_TOKEN_V2 -> decodeMintV2(input);
-            default -> null;};
+        final var mintAbi =
+                switch (functionId) {
+                    case AbiConstants.ABI_ID_MINT_TOKEN -> SystemContractAbis.MINT_TOKEN_V1;
+                    case AbiConstants.ABI_ID_MINT_TOKEN_V2 -> SystemContractAbis.MINT_TOKEN_V2;
+                    default -> throw new IllegalArgumentException("invalid selector to mint precompile");
+                };
+        mintOp = getMintWrapper(input, mintAbi);
+        if (mintOp == null) throw new IllegalArgumentException("unable to create mint wrapper from decoded input");
         transactionBody = syntheticTxnFactory.createMint(mintOp);
         return transactionBody;
     }
@@ -155,15 +155,11 @@ public class MintPrecompile extends AbstractWritePrecompile {
         return encoder.encodeMintFailure(status);
     }
 
-    public static MintWrapper decodeMint(final Bytes input) {
-        return getMintWrapper(input, MINT_TOKEN_SELECTOR);
-    }
-
-    private static MintWrapper getMintWrapper(final Bytes input, final Bytes mintTokenSelector) {
-        final Tuple decodedArguments = decodeFunctionCall(input, mintTokenSelector, MINT_TOKEN_DECODER);
+    public static MintWrapper getMintWrapper(final Bytes input, @NonNull final SystemContractAbis abi) {
+        final Tuple decodedArguments = decodeFunctionCall(input, abi.selector, abi.decoder);
 
         final var tokenID = convertAddressBytesToTokenID(decodedArguments.get(0));
-        final var fungibleAmount = (long) decodedArguments.get(1);
+        final var fungibleAmount = SystemContractAbis.toLongSafely(decodedArguments.get(1));
         final var metadataList = (byte[][]) decodedArguments.get(2);
         final List<ByteString> wrappedMetadata = new ArrayList<>();
         for (final var meta : metadataList) {
@@ -175,9 +171,5 @@ public class MintPrecompile extends AbstractWritePrecompile {
         } else {
             return MintWrapper.forNonFungible(tokenID, wrappedMetadata);
         }
-    }
-
-    public static MintWrapper decodeMintV2(final Bytes input) {
-        return getMintWrapper(input, MINT_TOKEN_SELECTOR_V2);
     }
 }

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/SystemContractAbis.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/SystemContractAbis.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.node.app.service.mono.store.contracts.precompile.impl;
+
+import static com.hedera.node.app.service.mono.store.contracts.precompile.impl.SystemContractTypes.*;
+
+import com.esaulpaugh.headlong.abi.ABIType;
+import com.esaulpaugh.headlong.abi.Function;
+import com.esaulpaugh.headlong.abi.Tuple;
+import com.esaulpaugh.headlong.abi.TypeFactory;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.math.BigInteger;
+import org.apache.tuweni.bytes.Bytes;
+
+/**
+ * Ground truth for everything related to system contract ABIs: their names, signatures, argument
+ * decoders, etc., for all versions of each ABI
+ * <p>
+ * N.B.: Currently ONLY the ABIs in multiple versions are in this enum; it is intended that ALL
+ * system contract ABIs go in this enum
+ * N.B.: Currently there are _multiple_ sources of this information in the code base, scattered
+ * about; it is intended that ALL those other sources will be refactored away, leaving only this
+ * enum as the single source of information about these ABIs
+ * N.B.: Currently this file needs to be maintained by hand when ABIs are added or versioned; it is
+ * intended that this file be GENERATED from the actual Solidity contracts (in the smart contracts
+ * repository)
+ * N.B.: Need to add return types, and argument names (which could be used for various purposes)
+ */
+@SuppressWarnings("java:S1192") // duplicate string literals - in this case, removing duplication makes code
+//                       more difficult to read
+public enum SystemContractAbis {
+
+    // HTS, versioned ABIs only
+
+    BURN_TOKEN_V1(1, "burnToken(address,uint64,int64[])"),
+    BURN_TOKEN_V2(2, "burnToken(address,int64,int64[])"),
+
+    CREATE_FUNGIBLE_TOKEN_V1(1, "createFungibleToken(%s,uint256,uint256)".formatted(HEDERA_TOKEN_STRUCT_V1)),
+    CREATE_FUNGIBLE_TOKEN_V2(2, "createFungibleToken(%s,uint64,uint32)".formatted(HEDERA_TOKEN_STRUCT_V2)),
+    CREATE_FUNGIBLE_TOKEN_V3(3, "createFungibleToken(%s,int64,int32)".formatted(HEDERA_TOKEN_STRUCT_V3)),
+
+    CREATE_FUNGIBLE_TOKEN_WITH_CUSTOM_FEES_V1(
+            1,
+            "createFungibleTokenWithCustomFees(%s,uint256,uint256,%s[],%s[])"
+                    .formatted(HEDERA_TOKEN_STRUCT_V1, FIXED_FEE_V1, FRACTIONAL_FEE_V1)),
+    CREATE_FUNGIBLE_TOKEN_WITH_CUSTOM_FEES_V2(
+            2,
+            "createFungibleTokenWithCustomFees(%s,uint64,uint32,%s[],%s[])"
+                    .formatted(HEDERA_TOKEN_STRUCT_V2, FIXED_FEE_V1, FRACTIONAL_FEE_V1)),
+    CREATE_FUNGIBLE_TOKEN_WITH_CUSTOM_FEES_V3(
+            3,
+            "createFungibleTokenWithCustomFees(%s,int64,int32,%s[],%s[])"
+                    .formatted(HEDERA_TOKEN_STRUCT_V3, FIXED_FEE_V2, FRACTIONAL_FEE_V2)),
+
+    CREATE_NON_FUNGIBLE_TOKEN_V1(1, "createNonFungibleToken(%s)".formatted(HEDERA_TOKEN_STRUCT_V1)),
+    CREATE_NON_FUNGIBLE_TOKEN_V2(2, "createNonFungibleToken(%s)".formatted(HEDERA_TOKEN_STRUCT_V2)),
+    CREATE_NON_FUNGIBLE_TOKEN_V3(3, "createNonFungibleToken(%s)".formatted(HEDERA_TOKEN_STRUCT_V3)),
+
+    CREATE_NON_FUNGIBLE_TOKEN_WITH_CUSTOM_FEES_V1("createNonFungibleTokenWithCustomFees(%s,%s[],%s[])"
+            .formatted(HEDERA_TOKEN_STRUCT_V1, FIXED_FEE_V1, ROYALTY_FEE_V1)),
+    CREATE_NON_FUNGIBLE_TOKEN_WITH_CUSTOM_FEES_V2("createNonFungibleTokenWithCustomFees(%s,%s[],%s[])"
+            .formatted(HEDERA_TOKEN_STRUCT_V2, FIXED_FEE_V1, ROYALTY_FEE_V1)),
+    CREATE_NON_FUNGIBLE_TOKEN_WITH_CUSTOM_FEES_V3("createNonFungibleTokenWithCustomFees(%s,%s[],%s[])"
+            .formatted(HEDERA_TOKEN_STRUCT_V3, FIXED_FEE_V2, ROYALTY_FEE_V2)),
+
+    CRYPTO_TRANSFER_V1(1, "cryptoTransfer(%s[])".formatted(TOKEN_TRANSFER_LIST_V1)),
+    CRYPTO_TRANSFER_V2(2, "cryptoTransfer(%s,%s[])".formatted(TRANSFER_LIST_V1, TOKEN_TRANSFER_LIST_V2)),
+
+    MINT_TOKEN_V1(1, "mintToken(address,uint64,bytes[])"),
+    MINT_TOKEN_V2(2, "mintToken(address,int64,bytes[])"),
+
+    UPDATE_TOKEN_EXPIRY_INFO_V1(1, "updateTokenExpiryInfo(address,%s)".formatted(EXPIRY_V1)),
+    UPDATE_TOKEN_EXPIRY_INFO_V2(2, "updateTokenExpiryInfo(address,%s)".formatted(EXPIRY_V2)),
+
+    UPDATE_TOKEN_INFO_V1(1, "updateTokenInfo(address,%s)".formatted(HEDERA_TOKEN_STRUCT_V1)),
+    UPDATE_TOKEN_INFO_V2(2, "updateTokenInfo(address,%s)".formatted(HEDERA_TOKEN_STRUCT_V2)),
+    UPDATE_TOKEN_INFO_V3(3, "updateTokenInfo(address,%s)".formatted(HEDERA_TOKEN_STRUCT_V3)),
+
+    WIPE_TOKEN_ACCOUNT_V1(1, "wipeTokenAccount(address,address,uint32)"),
+    WIPE_TOKEN_ACCOUNT_V2(2, "wipeTokenAccount(address,address,int64)");
+
+    SystemContractAbis(int version, @NonNull final String signature) {
+        this.version = version;
+        this.signature = stripBlanks(signature);
+        this.decoderSignature = stripName(addressToUint(this.signature));
+        this.decoder = TypeFactory.create(this.decoderSignature);
+        this.selector = Bytes.wrap(new Function(this.signature).selector());
+        this.methodName = nameFrom(this.signature);
+    }
+
+    SystemContractAbis(@NonNull final String signature) {
+        this(1, signature);
+    }
+
+    public final int version;
+    public final String signature;
+    public final String decoderSignature;
+    public final ABIType<Tuple> decoder;
+    public final Bytes selector;
+    public final String methodName;
+
+    @NonNull
+    public String selectorAsHex() {
+        return to8CharHexString(selector);
+    }
+
+    @NonNull
+    String nameFrom(@NonNull final String s) {
+        return s.split("[(]", 2)[0];
+    }
+
+    @NonNull
+    String addressToUint(@NonNull final String s) {
+        return s.replace("address", "bytes32");
+    }
+
+    @NonNull
+    String stripBlanks(@NonNull final String s) {
+        return s.replaceAll("\\s+", "");
+    }
+
+    @NonNull
+    String stripName(@NonNull final String s) {
+        return s.substring(s.indexOf('('));
+    }
+
+    @NonNull
+    String to8CharHexString(@NonNull final Bytes bytes) {
+        final var shortHex = "00000000" + bytes.toUnprefixedHexString();
+        return "0x" + shortHex.substring(shortHex.length() - 8);
+    }
+
+    /** Safely convert from either a BigInteger or a Long to a Long.
+     * <p>
+     * The method parameter decoder returns Objects. In the case of a Solidity `uint64` it will
+     * be a `BigInteger`, for a `int64` it will be a `Long`.  Safely convert to a `long` (the given
+     * `BigInteger.longValue` does a narrowing primitive conversion (which simply truncates to the
+     * low 64 bits)).
+     */
+    public static long toLongSafely(@NonNull final Object bigNumeric) {
+        if (bigNumeric instanceof BigInteger big) {
+            if (big.compareTo(LONG_MIN) < 0 || big.compareTo(LONG_MAX) > 0)
+                throw new IllegalArgumentException("uint64 out of range for Java.long");
+            return big.longValue();
+        } else if (bigNumeric instanceof Long big) {
+            return big;
+        } else return (long) bigNumeric;
+    }
+
+    private static final BigInteger LONG_MIN = BigInteger.valueOf(Long.MIN_VALUE);
+    private static final BigInteger LONG_MAX = BigInteger.valueOf(Long.MAX_VALUE);
+}

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/SystemContractAbis.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/SystemContractAbis.java
@@ -120,11 +120,15 @@ public enum SystemContractAbis {
 
     @NonNull
     String nameFrom(@NonNull final String s) {
-        return s.split("[(]", 2)[0];
+        // signature must look like `fooMethod(arg1,arg2,arg3)` so this just pulls out that
+        // part before the first `(`
+        return s.substring(0, s.indexOf('('));
     }
 
     @NonNull
     String addressToUint(@NonNull final String s) {
+        // for some reason the decoder library doesn't accept the Solidity type `address` and
+        // requires the equivalent `bytes32` instead
         return s.replace("address", "bytes32");
     }
 
@@ -135,11 +139,17 @@ public enum SystemContractAbis {
 
     @NonNull
     String stripName(@NonNull final String s) {
+        // signature must look like `fooMethod(arg1,arg2,arg3)` so this just trims off
+        // the `fooMethod` at the beginning
         return s.substring(s.indexOf('('));
     }
 
     @NonNull
     String to8CharHexString(@NonNull final Bytes bytes) {
+        // `Bytes` has a bunch of "toHex"-ish routines - but not one that can be asked to cough
+        // up a _fixed-width_ hex value.  So you've got to pad it yourself.  And the way it is
+        // done here is to glue the hex digits onto the back of 8 `0`s and then just take the last
+        // 8 characters of that.
         final var shortHex = "00000000" + bytes.toUnprefixedHexString();
         return "0x" + shortHex.substring(shortHex.length() - 8);
     }

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/SystemContractTypes.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/SystemContractTypes.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.node.app.service.mono.store.contracts.precompile.impl;
+
+import com.hedera.node.app.hapi.utils.contracts.ParsingConstants;
+import com.hedera.node.app.service.mono.store.contracts.precompile.codec.DecodingFacade;
+
+/**
+ * Solidity types used by ABI methods defined in `SystemContractAbis`
+ * <p>
+ * Must be broken out into a separate class to avoid forward references if they're put where
+ * they're more appropriate: Right into the enum declaration `SystemContractAbis`.
+ */
+public final class SystemContractTypes {
+
+    public static final String ACCOUNT_AMOUNT_V1 = "(address,int64)";
+    public static final String ACCOUNT_AMOUNT_V2 = "(address,int64,bool)";
+
+    public static final String EXPIRY_V1 = ParsingConstants.EXPIRY;
+    public static final String EXPIRY_V2 = ParsingConstants.EXPIRY_V2;
+
+    public static final String FIXED_FEE_V1 = ParsingConstants.FIXED_FEE;
+    public static final String FIXED_FEE_V2 = ParsingConstants.FIXED_FEE_V2;
+
+    public static final String FRACTIONAL_FEE_V1 = ParsingConstants.FRACTIONAL_FEE;
+    public static final String FRACTIONAL_FEE_V2 = ParsingConstants.FRACTIONAL_FEE_V2;
+
+    public static final String HEDERA_TOKEN_STRUCT_V1 = DecodingFacade.HEDERA_TOKEN_STRUCT;
+    public static final String HEDERA_TOKEN_STRUCT_V2 = DecodingFacade.HEDERA_TOKEN_STRUCT_V2;
+    public static final String HEDERA_TOKEN_STRUCT_V3 = DecodingFacade.HEDERA_TOKEN_STRUCT_V3;
+
+    public static final String NFT_TRANSFER_V1 = "(address,address,int64)";
+    public static final String NFT_TRANSFER_V2 = "(address,address,int64,bool)";
+
+    public static final String ROYALTY_FEE_V1 = ParsingConstants.ROYALTY_FEE;
+    public static final String ROYALTY_FEE_V2 = ParsingConstants.ROYALTY_FEE_V2;
+
+    public static final String TOKEN_TRANSFER_LIST_V1 =
+            "(address,%s[],%s[])".formatted(ACCOUNT_AMOUNT_V1, NFT_TRANSFER_V1);
+    public static final String TOKEN_TRANSFER_LIST_V2 =
+            "(address,%s[],%s[])".formatted(ACCOUNT_AMOUNT_V2, NFT_TRANSFER_V2);
+
+    public static final String TRANSFER_LIST_V1 = "(%s[])".formatted(ACCOUNT_AMOUNT_V2);
+
+    private SystemContractTypes() {}
+}

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/WipeFungiblePrecompile.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/store/contracts/precompile/impl/WipeFungiblePrecompile.java
@@ -16,16 +16,12 @@
 
 package com.hedera.node.app.service.mono.store.contracts.precompile.impl;
 
-import static com.hedera.node.app.hapi.utils.contracts.ParsingConstants.INT;
 import static com.hedera.node.app.service.mono.store.contracts.precompile.codec.DecodingFacade.convertAddressBytesToTokenID;
 import static com.hedera.node.app.service.mono.store.contracts.precompile.codec.DecodingFacade.convertLeftPaddedAddressToAccountId;
 import static com.hedera.node.app.service.mono.store.contracts.precompile.codec.DecodingFacade.decodeFunctionCall;
 import static com.hedera.node.app.service.mono.store.contracts.precompile.utils.PrecompilePricingUtils.GasCostType.WIPE_FUNGIBLE;
 
-import com.esaulpaugh.headlong.abi.ABIType;
-import com.esaulpaugh.headlong.abi.Function;
 import com.esaulpaugh.headlong.abi.Tuple;
-import com.esaulpaugh.headlong.abi.TypeFactory;
 import com.hedera.node.app.service.mono.context.SideEffectsTracker;
 import com.hedera.node.app.service.mono.contracts.sources.EvmSigsVerifier;
 import com.hedera.node.app.service.mono.ledger.accounts.ContractAliases;
@@ -37,20 +33,13 @@ import com.hedera.node.app.service.mono.store.contracts.precompile.codec.WipeWra
 import com.hedera.node.app.service.mono.store.contracts.precompile.utils.PrecompilePricingUtils;
 import com.hederahashgraph.api.proto.java.Timestamp;
 import com.hederahashgraph.api.proto.java.TransactionBody;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.Objects;
 import java.util.function.UnaryOperator;
 import org.apache.tuweni.bytes.Bytes;
 
 public class WipeFungiblePrecompile extends AbstractWipePrecompile {
     private final int functionId;
-    private static final Function WIPE_TOKEN_ACCOUNT_FUNCTION =
-            new Function("wipeTokenAccount(address,address,uint32)", INT);
-    private static final Function WIPE_TOKEN_ACCOUNT_FUNCTION_V2 =
-            new Function("wipeTokenAccount(address,address,int64)", INT);
-    private static final Bytes WIPE_TOKEN_ACCOUNT_SELECTOR = Bytes.wrap(WIPE_TOKEN_ACCOUNT_FUNCTION.selector());
-    private static final Bytes WIPE_TOKEN_ACCOUNT_SELECTOR_V2 = Bytes.wrap(WIPE_TOKEN_ACCOUNT_FUNCTION_V2.selector());
-    private static final ABIType<Tuple> WIPE_TOKEN_ACCOUNT_DECODER = TypeFactory.create("(bytes32,bytes32,uint32)");
-    private static final ABIType<Tuple> WIPE_TOKEN_ACCOUNT_DECODER_V2 = TypeFactory.create("(bytes32,bytes32,int64)");
 
     public WipeFungiblePrecompile(
             final WorldLedgers ledgers,
@@ -67,10 +56,13 @@ public class WipeFungiblePrecompile extends AbstractWipePrecompile {
 
     @Override
     public TransactionBody.Builder body(final Bytes input, final UnaryOperator<byte[]> aliasResolver) {
-        wipeOp = switch (functionId) {
-            case AbiConstants.ABI_WIPE_TOKEN_ACCOUNT_FUNGIBLE -> decodeWipe(input, aliasResolver);
-            case AbiConstants.ABI_WIPE_TOKEN_ACCOUNT_FUNGIBLE_V2 -> decodeWipeV2(input, aliasResolver);
-            default -> null;};
+        final var wipeAbi =
+                switch (functionId) {
+                    case AbiConstants.ABI_WIPE_TOKEN_ACCOUNT_FUNGIBLE -> SystemContractAbis.WIPE_TOKEN_ACCOUNT_V1;
+                    case AbiConstants.ABI_WIPE_TOKEN_ACCOUNT_FUNGIBLE_V2 -> SystemContractAbis.WIPE_TOKEN_ACCOUNT_V2;
+                    default -> throw new IllegalArgumentException("invalid selector to wipe precompile");
+                };
+        wipeOp = getWipeWrapper(input, aliasResolver, wipeAbi);
         transactionBody = syntheticTxnFactory.createWipe(wipeOp);
         return transactionBody;
     }
@@ -81,20 +73,9 @@ public class WipeFungiblePrecompile extends AbstractWipePrecompile {
         return pricingUtils.getMinimumPriceInTinybars(WIPE_FUNGIBLE, consensusTime);
     }
 
-    public static WipeWrapper decodeWipe(final Bytes input, final UnaryOperator<byte[]> aliasResolver) {
-        return getWipeWrapper(input, aliasResolver, WIPE_TOKEN_ACCOUNT_SELECTOR, WIPE_TOKEN_ACCOUNT_DECODER);
-    }
-
-    public static WipeWrapper decodeWipeV2(final Bytes input, final UnaryOperator<byte[]> aliasResolver) {
-        return getWipeWrapper(input, aliasResolver, WIPE_TOKEN_ACCOUNT_SELECTOR_V2, WIPE_TOKEN_ACCOUNT_DECODER_V2);
-    }
-
-    private static WipeWrapper getWipeWrapper(
-            final Bytes input,
-            final UnaryOperator<byte[]> aliasResolver,
-            final Bytes wipeTokenAccountSelector,
-            final ABIType<Tuple> wipeTokenAccountDecoder) {
-        final Tuple decodedArguments = decodeFunctionCall(input, wipeTokenAccountSelector, wipeTokenAccountDecoder);
+    public static WipeWrapper getWipeWrapper(
+            final Bytes input, final UnaryOperator<byte[]> aliasResolver, @NonNull final SystemContractAbis abi) {
+        final Tuple decodedArguments = decodeFunctionCall(input, abi.selector, abi.decoder);
 
         final var tokenID = convertAddressBytesToTokenID(decodedArguments.get(0));
         final var accountID = convertLeftPaddedAddressToAccountId(decodedArguments.get(1), aliasResolver);

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/BurnPrecompilesTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/BurnPrecompilesTest.java
@@ -20,8 +20,7 @@ import static com.hedera.node.app.service.mono.state.EntityCreator.EMPTY_MEMO;
 import static com.hedera.node.app.service.mono.store.contracts.precompile.AbiConstants.ABI_ID_BURN_TOKEN;
 import static com.hedera.node.app.service.mono.store.contracts.precompile.HTSTestsUtil.contractAddress;
 import static com.hedera.node.app.service.mono.store.contracts.precompile.HTSTestsUtil.recipientAddress;
-import static com.hedera.node.app.service.mono.store.contracts.precompile.impl.BurnPrecompile.decodeBurn;
-import static com.hedera.node.app.service.mono.store.contracts.precompile.impl.BurnPrecompile.decodeBurnV2;
+import static com.hedera.node.app.service.mono.store.contracts.precompile.impl.BurnPrecompile.getBurnWrapper;
 import static com.hederahashgraph.api.proto.java.HederaFunctionality.TokenBurn;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.FAIL_INVALID;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_SIGNATURE;
@@ -73,6 +72,7 @@ import com.hedera.node.app.service.mono.store.contracts.HederaStackedWorldStateU
 import com.hedera.node.app.service.mono.store.contracts.WorldLedgers;
 import com.hedera.node.app.service.mono.store.contracts.precompile.codec.EncodingFacade;
 import com.hedera.node.app.service.mono.store.contracts.precompile.impl.BurnPrecompile;
+import com.hedera.node.app.service.mono.store.contracts.precompile.impl.SystemContractAbis;
 import com.hedera.node.app.service.mono.store.contracts.precompile.utils.PrecompilePricingUtils;
 import com.hedera.node.app.service.mono.store.models.NftId;
 import com.hedera.node.app.service.mono.txns.token.BurnLogic;
@@ -114,7 +114,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 class BurnPrecompilesTest {
 
-    private final Bytes pretendArguments = Bytes.of(Integers.toBytes(ABI_ID_BURN_TOKEN));
+    private final Bytes pretendArguments = SystemContractAbis.BURN_TOKEN_V1.selector;
 
     @Mock
     private AccountStore accountStore;
@@ -228,11 +228,11 @@ class BurnPrecompilesTest {
     private static final int HBAR_RATE = 1;
     private static final long EXPECTED_GAS_PRICE =
             (TEST_SERVICE_FEE + TEST_NETWORK_FEE + TEST_NODE_FEE) / HTSTestsUtil.DEFAULT_GAS_PRICE * 6 / 5;
-    private static final Bytes FUNGIBLE_BURN_INPUT = Bytes.fromHexString(
+    private static final Bytes FUNGIBLE_BURN_INPUT_V1 = Bytes.fromHexString(
             "0xacb9cff90000000000000000000000000000000000000000000000000000000000000498000000000000000000000000000000000000000000000000000000000000002100000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000000000000000000");
     private static final Bytes FUNGIBLE_BURN_INPUT_V2 = Bytes.fromHexString(
             "0xd6910d060000000000000000000000000000000000000000000000000000000000000498000000000000000000000000000000000000000000000000000000000000002100000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000000000000000000");
-    private static final Bytes NON_FUNGIBLE_BURN_INPUT = Bytes.fromHexString(
+    private static final Bytes NON_FUNGIBLE_BURN_INPUT_V1 = Bytes.fromHexString(
             "0xacb9cff9000000000000000000000000000000000000000000000000000000000000049e000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000007b00000000000000000000000000000000000000000000000000000000000000ea");
     private static final Bytes NON_FUNGIBLE_BURN_INPUT_V2 = Bytes.fromHexString(
             "0xd6910d06000000000000000000000000000000000000000000000000000000000000049e000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000007b00000000000000000000000000000000000000000000000000000000000000ea");
@@ -404,7 +404,7 @@ class BurnPrecompilesTest {
         given(creator.createUnsuccessfulSyntheticRecord(INVALID_TOKEN_ID)).willReturn(mockRecordBuilder);
 
         subject.prepareFields(frame);
-        subject.prepareComputation(pretendArguments, а -> а);
+        subject.prepareComputation(pretendArguments, a -> a);
         subject.getPrecompile().getGasRequirement(HTSTestsUtil.TEST_CONSENSUS_TIME);
         subject.computeInternal(frame);
 
@@ -463,7 +463,9 @@ class BurnPrecompilesTest {
         given(worldUpdater.wrappedTrackingLedgers(any())).willReturn(wrappedLedgers);
         givenIfDelegateCall();
         doCallRealMethod().when(frame).setExceptionalHaltReason(any());
-        burnPrecompile.when(() -> decodeBurn(pretendArguments)).thenReturn(HTSTestsUtil.fungibleBurnAmountOversize);
+        burnPrecompile
+                .when(() -> getBurnWrapper(pretendArguments, SystemContractAbis.BURN_TOKEN_V1))
+                .thenReturn(HTSTestsUtil.fungibleBurnAmountOversize);
         // when:
         final var result = subject.computePrecompile(pretendArguments, frame);
         // then:
@@ -483,7 +485,9 @@ class BurnPrecompilesTest {
         given(worldUpdater.permissivelyUnaliased(any()))
                 .willAnswer(invocationOnMock -> invocationOnMock.getArgument(0));
 
-        burnPrecompile.when(() -> decodeBurn(pretendArguments)).thenReturn(HTSTestsUtil.fungibleBurnMaxAmount);
+        burnPrecompile
+                .when(() -> getBurnWrapper(pretendArguments, SystemContractAbis.BURN_TOKEN_V1))
+                .thenReturn(HTSTestsUtil.fungibleBurnMaxAmount);
         given(syntheticTxnFactory.createBurn(HTSTestsUtil.fungibleBurnMaxAmount))
                 .willReturn(mockSynthBodyBuilder);
         given(sigsVerifier.hasActiveSupplyKey(
@@ -526,7 +530,9 @@ class BurnPrecompilesTest {
         given(infrastructureFactory.newSideEffects()).willReturn(sideEffects);
         given(worldUpdater.permissivelyUnaliased(any()))
                 .willAnswer(invocationOnMock -> invocationOnMock.getArgument(0));
-        burnPrecompile.when(() -> decodeBurn(pretendArguments)).thenReturn(HTSTestsUtil.fungibleBurn);
+        burnPrecompile
+                .when(() -> getBurnWrapper(pretendArguments, SystemContractAbis.BURN_TOKEN_V1))
+                .thenReturn(HTSTestsUtil.fungibleBurn);
         given(syntheticTxnFactory.createBurn(any()))
                 .willReturn(TransactionBody.newBuilder().setTokenBurn(TokenBurnTransactionBody.newBuilder()));
         given(feeCalculator.computeFee(any(), any(), any(), any()))
@@ -544,9 +550,9 @@ class BurnPrecompilesTest {
     }
 
     @Test
-    void decodeFungibleBurnInput() {
+    void decodeFungibleBurnInputV1() {
         burnPrecompile.close();
-        final var decodedInput = decodeBurn(FUNGIBLE_BURN_INPUT);
+        final var decodedInput = getBurnWrapper(FUNGIBLE_BURN_INPUT_V1, SystemContractAbis.BURN_TOKEN_V1);
 
         assertTrue(decodedInput.tokenType().getTokenNum() > 0);
         assertEquals(33, decodedInput.amount());
@@ -557,7 +563,7 @@ class BurnPrecompilesTest {
     @Test
     void decodeFungibleBurnInputV2() {
         burnPrecompile.close();
-        final var decodedInput = decodeBurnV2(FUNGIBLE_BURN_INPUT_V2);
+        final var decodedInput = getBurnWrapper(FUNGIBLE_BURN_INPUT_V2, SystemContractAbis.BURN_TOKEN_V2);
 
         assertTrue(decodedInput.tokenType().getTokenNum() > 0);
         assertEquals(33, decodedInput.amount());
@@ -566,9 +572,9 @@ class BurnPrecompilesTest {
     }
 
     @Test
-    void decodeNonFungibleBurnInput() {
+    void decodeNonFungibleBurnInputV1() {
         burnPrecompile.close();
-        final var decodedInput = decodeBurn(NON_FUNGIBLE_BURN_INPUT);
+        final var decodedInput = getBurnWrapper(NON_FUNGIBLE_BURN_INPUT_V1, SystemContractAbis.BURN_TOKEN_V1);
 
         assertTrue(decodedInput.tokenType().getTokenNum() > 0);
         assertEquals(-1, decodedInput.amount());
@@ -581,7 +587,7 @@ class BurnPrecompilesTest {
     @Test
     void decodeNonFungibleBurnInputV2() {
         burnPrecompile.close();
-        final var decodedInput = decodeBurnV2(NON_FUNGIBLE_BURN_INPUT_V2);
+        final var decodedInput = getBurnWrapper(NON_FUNGIBLE_BURN_INPUT_V2, SystemContractAbis.BURN_TOKEN_V2);
 
         assertTrue(decodedInput.tokenType().getTokenNum() > 0);
         assertEquals(-1, decodedInput.amount());
@@ -593,13 +599,17 @@ class BurnPrecompilesTest {
 
     private void givenNonfungibleFrameContext() {
         givenFrameContext();
-        burnPrecompile.when(() -> decodeBurn(pretendArguments)).thenReturn(HTSTestsUtil.nonFungibleBurn);
+        burnPrecompile
+                .when(() -> getBurnWrapper(pretendArguments, SystemContractAbis.BURN_TOKEN_V1))
+                .thenReturn(HTSTestsUtil.nonFungibleBurn);
         given(syntheticTxnFactory.createBurn(HTSTestsUtil.nonFungibleBurn)).willReturn(mockSynthBodyBuilder);
     }
 
     private void givenFungibleFrameContext() {
         givenFrameContext();
-        burnPrecompile.when(() -> decodeBurn(pretendArguments)).thenReturn(HTSTestsUtil.fungibleBurn);
+        burnPrecompile
+                .when(() -> getBurnWrapper(pretendArguments, SystemContractAbis.BURN_TOKEN_V1))
+                .thenReturn(HTSTestsUtil.fungibleBurn);
         given(syntheticTxnFactory.createBurn(HTSTestsUtil.fungibleBurn)).willReturn(mockSynthBodyBuilder);
     }
 

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/HTSPrecompiledContractTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/HTSPrecompiledContractTest.java
@@ -956,7 +956,9 @@ class HTSPrecompiledContractTest {
         // given
         givenFrameContext();
         final Bytes input = Bytes.of(Integers.toBytes(ABI_ID_MINT_TOKEN));
-        mintPrecompile.when(() -> MintPrecompile.decodeMint(any())).thenReturn(fungibleMintAmountOversize);
+        mintPrecompile
+                .when(() -> MintPrecompile.getMintWrapper(any(), eq(SystemContractAbis.MINT_TOKEN_V1)))
+                .thenReturn(fungibleMintAmountOversize);
         given(worldUpdater.permissivelyUnaliased(any()))
                 .willAnswer(invocationOnMock -> invocationOnMock.getArgument(0));
         givenIfDelegateCall();
@@ -975,7 +977,9 @@ class HTSPrecompiledContractTest {
         // given
         givenFrameContext();
         final Bytes input = Bytes.of(Integers.toBytes(ABI_ID_BURN_TOKEN_V2));
-        burnPrecompile.when(() -> BurnPrecompile.decodeBurnV2(any())).thenReturn(nonFungibleBurn);
+        burnPrecompile
+                .when(() -> BurnPrecompile.getBurnWrapper(any(), eq(SystemContractAbis.BURN_TOKEN_V2)))
+                .thenReturn(nonFungibleBurn);
         given(worldUpdater.permissivelyUnaliased(any()))
                 .willAnswer(invocationOnMock -> invocationOnMock.getArgument(0));
         givenIfDelegateCall();
@@ -1028,7 +1032,9 @@ class HTSPrecompiledContractTest {
         givenFrameContext();
         givenPricingUtilsContext();
         final Bytes input = Bytes.of(Integers.toBytes(ABI_ID_MINT_TOKEN));
-        mintPrecompile.when(() -> MintPrecompile.decodeMint(any())).thenReturn(fungibleMint);
+        mintPrecompile
+                .when(() -> MintPrecompile.getMintWrapper(any(), eq(SystemContractAbis.MINT_TOKEN_V1)))
+                .thenReturn(fungibleMint);
         given(messageFrame.getRemainingGas()).willReturn(0L);
         given(syntheticTxnFactory.createMint(fungibleMint)).willReturn(mockSynthBodyBuilder);
         given(feeCalculator.estimatedGasPriceInTinybars(HederaFunctionality.ContractCall, HTSTestsUtil.timestamp))
@@ -1271,7 +1277,8 @@ class HTSPrecompiledContractTest {
         givenFrameContext();
         final Bytes input = Bytes.of(Integers.toBytes(ABI_WIPE_TOKEN_ACCOUNT_FUNGIBLE));
         wipeFungiblePrecompile
-                .when(() -> WipeFungiblePrecompile.decodeWipe(any(), any()))
+                .when(() -> WipeFungiblePrecompile.getWipeWrapper(
+                        any(), any(), eq(SystemContractAbis.WIPE_TOKEN_ACCOUNT_V1)))
                 .thenReturn(fungibleWipe);
         given(worldUpdater.permissivelyUnaliased(any()))
                 .willAnswer(invocationOnMock -> invocationOnMock.getArgument(0));
@@ -1290,7 +1297,8 @@ class HTSPrecompiledContractTest {
         givenFrameContext();
         final Bytes input = Bytes.of(Integers.toBytes(ABI_WIPE_TOKEN_ACCOUNT_FUNGIBLE_V2));
         wipeFungiblePrecompile
-                .when(() -> WipeFungiblePrecompile.decodeWipeV2(any(), any()))
+                .when(() -> WipeFungiblePrecompile.getWipeWrapper(
+                        any(), any(), eq(SystemContractAbis.WIPE_TOKEN_ACCOUNT_V2)))
                 .thenReturn(fungibleWipe);
         given(worldUpdater.permissivelyUnaliased(any()))
                 .willAnswer(invocationOnMock -> invocationOnMock.getArgument(0));
@@ -1366,7 +1374,8 @@ class HTSPrecompiledContractTest {
         givenFrameContext();
         final Bytes input = Bytes.of(Integers.toBytes(ABI_ID_UPDATE_TOKEN_EXPIRY_INFO));
         updateTokenExpiryInfoPrecompile
-                .when(() -> UpdateTokenExpiryInfoPrecompile.decodeUpdateTokenExpiryInfo(any(), any()))
+                .when(() -> UpdateTokenExpiryInfoPrecompile.getTokenUpdateExpiryInfoWrapper(
+                        any(), any(), eq(SystemContractAbis.UPDATE_TOKEN_EXPIRY_INFO_V1)))
                 .thenReturn(tokenUpdateExpiryInfoWrapper);
         given(worldUpdater.permissivelyUnaliased(any()))
                 .willAnswer(invocationOnMock -> invocationOnMock.getArgument(0));
@@ -1385,7 +1394,8 @@ class HTSPrecompiledContractTest {
         givenFrameContext();
         final Bytes input = Bytes.of(Integers.toBytes(ABI_ID_UPDATE_TOKEN_EXPIRY_INFO_V2));
         updateTokenExpiryInfoPrecompile
-                .when(() -> UpdateTokenExpiryInfoPrecompile.decodeUpdateTokenExpiryInfoV2(any(), any()))
+                .when(() -> UpdateTokenExpiryInfoPrecompile.getTokenUpdateExpiryInfoWrapper(
+                        any(), any(), eq(SystemContractAbis.UPDATE_TOKEN_EXPIRY_INFO_V2)))
                 .thenReturn(tokenUpdateExpiryInfoWrapper);
         given(worldUpdater.permissivelyUnaliased(any()))
                 .willAnswer(invocationOnMock -> invocationOnMock.getArgument(0));

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/SystemContractAbisTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/SystemContractAbisTest.java
@@ -39,10 +39,11 @@ class SystemContractAbisTest {
     void confirmAllSelectorsKnown() {
         final var allKnownABISelectors = EnumSet.allOf(SystemContractAbis.class).stream()
                 .map(SystemContractAbis::selectorAsHex)
-                .map(s -> s.substring(2))
+                .map(s -> s.substring(2)) // lose the `0x`
                 .map(HexFormat::fromHexDigits)
                 .toList();
         softly.assertThat(allAbiConstants).containsAll(allKnownABISelectors);
+        softly.assertThat(listAllSystemContractAbis()).isEmpty();
     }
 
     // From `mono/store/contracts/precompile/AbiConstants.java` via emacs:

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/SystemContractAbisTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/SystemContractAbisTest.java
@@ -43,7 +43,6 @@ class SystemContractAbisTest {
                 .map(HexFormat::fromHexDigits)
                 .toList();
         softly.assertThat(allAbiConstants).containsAll(allKnownABISelectors);
-        softly.assertThat(listAllSystemContractAbis()).isEmpty();
     }
 
     // From `mono/store/contracts/precompile/AbiConstants.java` via emacs:

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/SystemContractAbisTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/SystemContractAbisTest.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.node.app.service.mono.store.contracts.precompile;
+
+import com.hedera.node.app.service.mono.store.contracts.precompile.impl.SystemContractAbis;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.EnumSet;
+import java.util.HexFormat;
+import java.util.List;
+import org.assertj.core.api.SoftAssertions;
+import org.assertj.core.api.junit.jupiter.InjectSoftAssertions;
+import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(SoftAssertionsExtension.class)
+class SystemContractAbisTest {
+
+    @InjectSoftAssertions
+    SoftAssertions softly;
+
+    @Test
+    @DisplayName("Confirm all values defined in SystemContractTypes are known to AbiConstants.java")
+    void confirmAllSelectorsKnown() {
+        final var allKnownABISelectors = EnumSet.allOf(SystemContractAbis.class).stream()
+                .map(SystemContractAbis::selectorAsHex)
+                .map(s -> s.substring(2))
+                .map(HexFormat::fromHexDigits)
+                .toList();
+        softly.assertThat(allAbiConstants).containsAll(allKnownABISelectors);
+    }
+
+    // From `mono/store/contracts/precompile/AbiConstants.java` via emacs:
+    final List<Integer> allAbiConstants = List.of(
+            AbiConstants.ABI_ID_CRYPTO_TRANSFER,
+            AbiConstants.ABI_ID_CRYPTO_TRANSFER_V2,
+            AbiConstants.ABI_ID_TRANSFER_TOKENS,
+            AbiConstants.ABI_ID_TRANSFER_TOKEN,
+            AbiConstants.ABI_ID_TRANSFER_NFTS,
+            AbiConstants.ABI_ID_TRANSFER_NFT,
+            AbiConstants.ABI_ID_MINT_TOKEN,
+            AbiConstants.ABI_ID_MINT_TOKEN_V2,
+            AbiConstants.ABI_ID_BURN_TOKEN,
+            AbiConstants.ABI_ID_BURN_TOKEN_V2,
+            AbiConstants.ABI_ID_DELETE_TOKEN,
+            AbiConstants.ABI_ID_ASSOCIATE_TOKENS,
+            AbiConstants.ABI_ID_ASSOCIATE_TOKEN,
+            AbiConstants.ABI_ID_DISSOCIATE_TOKENS,
+            AbiConstants.ABI_ID_DISSOCIATE_TOKEN,
+            AbiConstants.ABI_ID_PAUSE_TOKEN,
+            AbiConstants.ABI_ID_UNPAUSE_TOKEN,
+            AbiConstants.ABI_ID_ALLOWANCE,
+            AbiConstants.ABI_ID_APPROVE,
+            AbiConstants.ABI_ID_APPROVE_NFT,
+            AbiConstants.ABI_ID_SET_APPROVAL_FOR_ALL,
+            AbiConstants.ABI_ID_GET_APPROVED,
+            AbiConstants.ABI_ID_IS_APPROVED_FOR_ALL,
+            AbiConstants.ABI_ID_TRANSFER_FROM,
+            AbiConstants.ABI_ID_TRANSFER_FROM_NFT,
+            AbiConstants.ABI_ID_REDIRECT_FOR_TOKEN,
+            AbiConstants.ABI_ID_ERC_NAME,
+            AbiConstants.ABI_ID_ERC_SYMBOL,
+            AbiConstants.ABI_ID_ERC_DECIMALS,
+            AbiConstants.ABI_ID_ERC_TOTAL_SUPPLY_TOKEN,
+            AbiConstants.ABI_ID_ERC_BALANCE_OF_TOKEN,
+            AbiConstants.ABI_ID_ERC_TRANSFER,
+            AbiConstants.ABI_ID_ERC_TRANSFER_FROM,
+            AbiConstants.ABI_ID_ERC_ALLOWANCE,
+            AbiConstants.ABI_ID_ERC_APPROVE,
+            AbiConstants.ABI_ID_ERC_SET_APPROVAL_FOR_ALL,
+            AbiConstants.ABI_ID_ERC_GET_APPROVED,
+            AbiConstants.ABI_ID_ERC_IS_APPROVED_FOR_ALL,
+            AbiConstants.ABI_ID_ERC_OWNER_OF_NFT,
+            AbiConstants.ABI_ID_ERC_TOKEN_URI_NFT,
+            AbiConstants.ABI_ID_HRC_ASSOCIATE,
+            AbiConstants.ABI_ID_HRC_DISSOCIATE,
+            AbiConstants.ABI_WIPE_TOKEN_ACCOUNT_FUNGIBLE,
+            AbiConstants.ABI_WIPE_TOKEN_ACCOUNT_FUNGIBLE_V2,
+            AbiConstants.ABI_WIPE_TOKEN_ACCOUNT_NFT,
+            AbiConstants.ABI_ID_IS_FROZEN,
+            AbiConstants.ABI_ID_FREEZE,
+            AbiConstants.ABI_ID_UNFREEZE,
+            AbiConstants.ABI_ID_UPDATE_TOKEN_INFO,
+            AbiConstants.ABI_ID_UPDATE_TOKEN_INFO_V2,
+            AbiConstants.ABI_ID_UPDATE_TOKEN_INFO_V3,
+            AbiConstants.ABI_ID_UPDATE_TOKEN_KEYS,
+            AbiConstants.ABI_ID_GET_TOKEN_KEY,
+            AbiConstants.ABI_ID_CREATE_FUNGIBLE_TOKEN,
+            AbiConstants.ABI_ID_CREATE_FUNGIBLE_TOKEN_V2,
+            AbiConstants.ABI_ID_CREATE_FUNGIBLE_TOKEN_V3,
+            AbiConstants.ABI_ID_CREATE_FUNGIBLE_TOKEN_WITH_FEES,
+            AbiConstants.ABI_ID_CREATE_FUNGIBLE_TOKEN_WITH_FEES_V2,
+            AbiConstants.ABI_ID_CREATE_FUNGIBLE_TOKEN_WITH_FEES_V3,
+            AbiConstants.ABI_ID_CREATE_NON_FUNGIBLE_TOKEN,
+            AbiConstants.ABI_ID_CREATE_NON_FUNGIBLE_TOKEN_V2,
+            AbiConstants.ABI_ID_CREATE_NON_FUNGIBLE_TOKEN_V3,
+            AbiConstants.ABI_ID_CREATE_NON_FUNGIBLE_TOKEN_WITH_FEES,
+            AbiConstants.ABI_ID_CREATE_NON_FUNGIBLE_TOKEN_WITH_FEES_V2,
+            AbiConstants.ABI_ID_CREATE_NON_FUNGIBLE_TOKEN_WITH_FEES_V3,
+            AbiConstants.ABI_ID_GET_FUNGIBLE_TOKEN_INFO,
+            AbiConstants.ABI_ID_GET_TOKEN_INFO,
+            AbiConstants.ABI_ID_GET_NON_FUNGIBLE_TOKEN_INFO,
+            AbiConstants.ABI_ID_GET_TOKEN_DEFAULT_FREEZE_STATUS,
+            AbiConstants.ABI_ID_GET_TOKEN_DEFAULT_KYC_STATUS,
+            AbiConstants.ABI_ID_IS_KYC,
+            AbiConstants.ABI_ID_GRANT_TOKEN_KYC,
+            AbiConstants.ABI_ID_REVOKE_TOKEN_KYC,
+            AbiConstants.ABI_ID_GET_TOKEN_CUSTOM_FEES,
+            AbiConstants.ABI_ID_IS_TOKEN,
+            AbiConstants.ABI_ID_GET_TOKEN_TYPE,
+            AbiConstants.ABI_ID_GET_TOKEN_EXPIRY_INFO,
+            AbiConstants.ABI_ID_UPDATE_TOKEN_EXPIRY_INFO,
+            AbiConstants.ABI_ID_UPDATE_TOKEN_EXPIRY_INFO_V2);
+
+    @NonNull
+    String listAllSystemContractAbis() {
+        final var allSystemContractABIs = EnumSet.allOf(SystemContractAbis.class);
+
+        final var sb = new StringBuilder(2000);
+        sb.append('\n');
+        for (final var abi : allSystemContractABIs) {
+            sb.append("%s (%d) %s[%d]: %s {%s}%n"
+                    .formatted(
+                            abi.selectorAsHex(),
+                            abi.selector.toInt(),
+                            abi.methodName,
+                            abi.version,
+                            abi.signature,
+                            abi.decoderSignature));
+        }
+
+        return sb.toString();
+    }
+}

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/UpdateTokenExpiryInfoPrecompileTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/UpdateTokenExpiryInfoPrecompileTest.java
@@ -27,12 +27,12 @@ import static com.hedera.node.app.service.mono.store.contracts.precompile.HTSTes
 import static com.hedera.node.app.service.mono.store.contracts.precompile.HTSTestsUtil.tokenAddress;
 import static com.hedera.node.app.service.mono.store.contracts.precompile.HTSTestsUtil.tokenUpdateExpiryInfoWrapper;
 import static com.hedera.node.app.service.mono.store.contracts.precompile.HTSTestsUtil.tokenUpdateExpiryInfoWrapperWithInvalidTokenID;
-import static com.hedera.node.app.service.mono.store.contracts.precompile.impl.UpdateTokenExpiryInfoPrecompile.decodeUpdateTokenExpiryInfo;
-import static com.hedera.node.app.service.mono.store.contracts.precompile.impl.UpdateTokenExpiryInfoPrecompile.decodeUpdateTokenExpiryInfoV2;
+import static com.hedera.node.app.service.mono.store.contracts.precompile.impl.UpdateTokenExpiryInfoPrecompile.getTokenUpdateExpiryInfoWrapper;
 import static java.util.function.UnaryOperator.identity;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 
 import com.esaulpaugh.headlong.util.Integers;
@@ -62,6 +62,7 @@ import com.hedera.node.app.service.mono.state.submerkle.ExpirableTxnRecord;
 import com.hedera.node.app.service.mono.store.contracts.HederaStackedWorldStateUpdater;
 import com.hedera.node.app.service.mono.store.contracts.WorldLedgers;
 import com.hedera.node.app.service.mono.store.contracts.precompile.codec.EncodingFacade;
+import com.hedera.node.app.service.mono.store.contracts.precompile.impl.SystemContractAbis;
 import com.hedera.node.app.service.mono.store.contracts.precompile.impl.UpdateTokenExpiryInfoPrecompile;
 import com.hedera.node.app.service.mono.store.contracts.precompile.utils.PrecompilePricingUtils;
 import com.hedera.node.app.service.mono.store.models.NftId;
@@ -282,7 +283,7 @@ class UpdateTokenExpiryInfoPrecompileTest {
         given(worldUpdater.permissivelyUnaliased(any()))
                 .willAnswer(invocationOnMock -> invocationOnMock.getArgument(0));
         updateTokenExpiryInfoPrecompile
-                .when(() -> decodeUpdateTokenExpiryInfo(any(), any()))
+                .when(() -> getTokenUpdateExpiryInfoWrapper(any(), any(), any()))
                 .thenReturn(tokenUpdateExpiryInfoWrapperWithInvalidTokenID);
         givenPricingUtilsContext();
         // when
@@ -297,7 +298,8 @@ class UpdateTokenExpiryInfoPrecompileTest {
     @Test
     void decodeUpdateExpiryInfoForTokenInput() {
         updateTokenExpiryInfoPrecompile.close();
-        final var decodedInput = decodeUpdateTokenExpiryInfo(UPDATE_EXPIRY_INFO_FOR_TOKEN_INPUT, identity());
+        final var decodedInput = getTokenUpdateExpiryInfoWrapper(
+                UPDATE_EXPIRY_INFO_FOR_TOKEN_INPUT, identity(), SystemContractAbis.UPDATE_TOKEN_EXPIRY_INFO_V1);
 
         assertTrue(decodedInput.tokenID().getTokenNum() > 0);
         assertTrue(decodedInput.expiry().second() > 0);
@@ -308,7 +310,8 @@ class UpdateTokenExpiryInfoPrecompileTest {
     @Test
     void decodeUpdateExpiryInfoV2ForTokenInput() {
         updateTokenExpiryInfoPrecompile.close();
-        final var decodedInput = decodeUpdateTokenExpiryInfoV2(UPDATE_EXPIRY_INFO_FOR_TOKEN_INPUT_V2, identity());
+        final var decodedInput = getTokenUpdateExpiryInfoWrapper(
+                UPDATE_EXPIRY_INFO_FOR_TOKEN_INPUT_V2, identity(), SystemContractAbis.UPDATE_TOKEN_EXPIRY_INFO_V2);
 
         assertTrue(decodedInput.tokenID().getTokenNum() > 0);
         assertTrue(decodedInput.expiry().second() > 0);
@@ -344,7 +347,8 @@ class UpdateTokenExpiryInfoPrecompileTest {
                 .willReturn(updateLogic);
         given(updateLogic.validate(any())).willReturn(ResponseCodeEnum.OK);
         updateTokenExpiryInfoPrecompile
-                .when(() -> decodeUpdateTokenExpiryInfo(any(), any()))
+                .when(() -> getTokenUpdateExpiryInfoWrapper(
+                        any(), any(), eq(SystemContractAbis.UPDATE_TOKEN_EXPIRY_INFO_V1)))
                 .thenReturn(tokenUpdateExpiryInfoWrapper);
         given(syntheticTxnFactory.createTokenUpdateExpiryInfo(tokenUpdateExpiryInfoWrapper))
                 .willReturn(TransactionBody.newBuilder().setTokenUpdate(TokenUpdateTransactionBody.newBuilder()));
@@ -360,7 +364,8 @@ class UpdateTokenExpiryInfoPrecompileTest {
                 .willReturn(updateLogic);
         given(updateLogic.validate(any())).willReturn(ResponseCodeEnum.OK);
         updateTokenExpiryInfoPrecompile
-                .when(() -> decodeUpdateTokenExpiryInfoV2(any(), any()))
+                .when(() -> getTokenUpdateExpiryInfoWrapper(
+                        any(), any(), eq(SystemContractAbis.UPDATE_TOKEN_EXPIRY_INFO_V2)))
                 .thenReturn(tokenUpdateExpiryInfoWrapper);
         given(syntheticTxnFactory.createTokenUpdateExpiryInfo(tokenUpdateExpiryInfoWrapper))
                 .willReturn(TransactionBody.newBuilder().setTokenUpdate(TokenUpdateTransactionBody.newBuilder()));


### PR DESCRIPTION
(Essentially a cherry-pick from develop, but done on my machine before the merge to develop happened.  See #6564 for the original PR.)

Start of a new method for having one-stop-shopping for everything we
need related to system contract ABIs.  (Subsequent additions will
include _all_ system contract ABIs, and then moving to use this enum
as the source of ground truth for ABI (names, selectors, etc.)
everywhere.

**N.B.:** The initial goal of this is to simplify correct maintenance by putting everything related to our ABI in one place, instead of being scattered all over the place the way it is now.  The ultimate goal is to _generate_ this enum from the ground truth Solidity system contracts in our smart contracts repo.


Of the versioned ABIs, in this PR are: burn, mint, update token expiry info.

Subsequent PR will add all the creates, crypto transfer, and update token info.

Signed-off-by: David Bakin <117694041+david-bakin-sl@users.noreply.github.com>**Description**:

**Related issue(s)**:

Fixes #6559

**Notes for reviewer**:

The meat is in the new enum `SystemContractAbis` which provides an enum element for each versioned ABI that supplies things like its selector and its decoder and also other interesting stuff.  All the versioned ABIs are in there, and the unit test checks that the selectors computed from the signatures given match the ones we depend on in `AbiConstants`.

The enum contains _all_ versioned ABIs though this PR only has fixed up the code for burn, mint, and update token expiry.

Future work will finish the work on incorporating the versioned ABIs from this enum into the precompiles, add all the non-versioned ABIs, and eventually refactor with an aim of eliminating other files where this stuff is scattered about, including `ParsingConstants` and `DecodingFacade`.  We should also generate `AbiConstants`.


**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
