### PR TITLE
6585: ReusableBucketPool synchronization redone

### DIFF
--- a/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/files/hashmap/ReusableBucketPool.java
+++ b/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/files/hashmap/ReusableBucketPool.java
@@ -76,7 +76,7 @@ public class ReusableBucketPool<K extends VirtualKey> {
         buckets = new ConcurrentLinkedDeque<>();
         keySerializer = serializer.getKeySerializer();
         for (int i = 0; i < size; i++) {
-            buckets.offerLast(new Bucket<K>(keySerializer, this));
+            buckets.offerLast(new Bucket<>(keySerializer, this));
         }
     }
 
@@ -90,7 +90,7 @@ public class ReusableBucketPool<K extends VirtualKey> {
     public Bucket<K> getBucket() {
         Bucket<K> bucket = buckets.pollLast();
         if (bucket == null) {
-            bucket = new Bucket<K>(keySerializer, this);
+            bucket = new Bucket<>(keySerializer, this);
         }
         bucket.clear();
         return bucket;


### PR DESCRIPTION
Closes #6585
Use straightforward `ConcurrentLinkedDeque` in `ReusableBucketPool`.
Control the number of concurrent read tasks in `HalfDiskHashMap.endWriting()` to limit the number of outstanding `Buckets` sitting in the output queue.