### PR TITLE
6627: FCQueue is not properly destroyed

### DIFF
--- a/platform-sdk/swirlds-fcqueue/src/main/java/com/swirlds/fcqueue/FCQueue.java
+++ b/platform-sdk/swirlds-fcqueue/src/main/java/com/swirlds/fcqueue/FCQueue.java
@@ -418,11 +418,7 @@ public class FCQueue<E extends FastCopyable & SerializableHashable> extends Part
 
     @Override
     protected synchronized void destroyNode() {
-        clearInternal();
-    }
-
-    private void clearInternal() {
-        head = tail;
+        head = tail = null;
         size = 0;
         hash = null;
     }
@@ -716,7 +712,9 @@ public class FCQueue<E extends FastCopyable & SerializableHashable> extends Part
     public synchronized void clear() {
         throwIfImmutable();
 
-        clearInternal();
+        head = tail;
+        size = 0;
+        hash = null;
     }
 
     //////////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Closes #6627.

Null all internal references when `FCQueue` is destroyed.