### PR TITLE
Added comment that hashCode test values must not be changed

### DIFF
--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/virtual/ContractKeyTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/virtual/ContractKeyTest.java
@@ -56,9 +56,9 @@ class ContractKeyTest {
     // The first two columns form a ContractKey(id, 32-byte word) and the third column is the
     // result of running ContractKey.hashCode() on that key using the v0.35.3 tag.
     //
-    // Important! These values should never be changed! If this test fails in
+    // Important! 🛑 ⛔ 🚫 ⚠ ✸ ☞  These values should never be changed! If this test fails in
     // the future, it means the hashCode implementation was changed and these
-    // values should not be changed to make the test pass. 
+    // values should not be changed to make the test pass.
     @CsvSource({
         "5347959350198992124,cd53935a7e183dac3557134dfc73766479c520c7ffeace8723488bffa2da3fa2,-672529924",
         "4793581390134811504,4a164095f80400a99cc906b97cda21a0ccbdcc68c30f25acfb3be365188ffa92,-117896145",

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/virtual/ContractKeyTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/virtual/ContractKeyTest.java
@@ -55,6 +55,10 @@ class ContractKeyTest {
 
     // The first two columns form a ContractKey(id, 32-byte word) and the third column is the
     // result of running ContractKey.hashCode() on that key using the v0.35.3 tag.
+    //
+    // Important! These values should never be changed! If this test fails in
+    // the future, it means the hashCode implementation was changed and these
+    // values should not be changed to make the test pass. 
     @CsvSource({
         "5347959350198992124,cd53935a7e183dac3557134dfc73766479c520c7ffeace8723488bffa2da3fa2,-672529924",
         "4793581390134811504,4a164095f80400a99cc906b97cda21a0ccbdcc68c30f25acfb3be365188ffa92,-117896145",


### PR DESCRIPTION
**Description**: We recently copied the hashCode function from Platform into Services. We need to ensure that the result of this hash code never changes or risk data ending up in a corrupted state, (under incorrect keys).

Fixes #6581 
