### PR TITLE
06651 Added missing rehash for VirtualMap leaves

### DIFF
--- a/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/platform/PlatformTestingToolState.java
+++ b/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/platform/PlatformTestingToolState.java
@@ -1271,8 +1271,20 @@ public class PlatformTestingToolState extends PartialNaryMerkleInternal implemen
 
         if (trigger == InitTrigger.GENESIS) {
             genesisInit();
+        } else {
+            logger.info(LOGM_STARTUP, "Doing full rehash for the initialized VirtualMaps");
+            fullLeafRehash(getVirtualMap());
+            fullLeafRehash(getVirtualMapForSmartContracts());
+            fullLeafRehash(getVirtualMapForSmartContractsByteCode());
+            logger.info(LOGM_STARTUP, "Full rehash is complete");
         }
         this.invalidateHash();
+    }
+
+    private void fullLeafRehash(VirtualMap<?, ?> virtualMap) {
+        if (virtualMap != null) {
+            virtualMap.fullLeafRehash();
+        }
     }
 
     private void expandSignatures(final Transaction trans) {


### PR DESCRIPTION
**Description**:

This PR adds `fullLeafRehash` call to `VirtualMap` instances created by `VirtualMerkleStateInitializer` in `PlatformTestingTool`


**Related issue(s)**:

Fixes #6651 

**Notes for reviewer**:
This test should fix https://github.com/swirlds/swirlds-platform-regression/issues/3411

