### PR TITLE
Reflect mainnet 0.0.111 (fees) and 0.0.123 (throttles) contents in repo

### DIFF
--- a/hedera-node/configuration/mainnet/upgrade/feeSchedules.json
+++ b/hedera-node/configuration/mainnet/upgrade/feeSchedules.json
@@ -1,6578 +1,6592 @@
 [
   {
-	"currentFeeSchedule": [
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "CryptoCreate",
-		  "fees": [
-			{
-			  "subType": "DEFAULT",
-			  "nodedata": {
-				"constant": 11461413665,
-				"bpt": 508982,
-				"vpt": 1272455960,
-				"rbh": 339,
-				"sbh": 25,
-				"gas": 3393,
-				"bpr": 508982,
-				"sbpr": 12725,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 229228273302,
-				"bpt": 10179648,
-				"vpt": 25449119198,
-				"rbh": 6786,
-				"sbh": 509,
-				"gas": 67864,
-				"bpr": 10179648,
-				"sbpr": 254491,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 229228273302,
-				"bpt": 10179648,
-				"vpt": 25449119198,
-				"rbh": 6786,
-				"sbh": 509,
-				"gas": 67864,
-				"bpr": 10179648,
-				"sbpr": 254491,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "CryptoDeleteAllowance",
-		  "fees": [
-			{
-			  "subType": "DEFAULT",
-			  "nodedata": {
-				"constant": 3794963556,
-				"bpt": 6067009,
-				"vpt": 15167523735,
-				"rbh": 4045,
-				"sbh": 303,
-				"gas": 40447,
-				"bpr": 6067009,
-				"sbpr": 151675,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 75899271121,
-				"bpt": 121340190,
-				"vpt": 303350474702,
-				"rbh": 80893,
-				"sbh": 6067,
-				"gas": 808935,
-				"bpr": 121340190,
-				"sbpr": 3033505,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 75899271121,
-				"bpt": 121340190,
-				"vpt": 303350474702,
-				"rbh": 80893,
-				"sbh": 6067,
-				"gas": 808935,
-				"bpr": 121340190,
-				"sbpr": 3033505,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "CryptoApproveAllowance",
-		  "fees": [
-			{
-			  "subType": "DEFAULT",
-			  "nodedata": {
-				"constant": 3766772044,
-				"bpt": 6021940,
-				"vpt": 15054849285,
-				"rbh": 4015,
-				"sbh": 301,
-				"gas": 40146,
-				"bpr": 6021940,
-				"sbpr": 150548,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 75335440874,
-				"bpt": 120438794,
-				"vpt": 301096985700,
-				"rbh": 80293,
-				"sbh": 6022,
-				"gas": 802925,
-				"bpr": 120438794,
-				"sbpr": 3010970,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 75335440874,
-				"bpt": 120438794,
-				"vpt": 301096985700,
-				"rbh": 80293,
-				"sbh": 6022,
-				"gas": 802925,
-				"bpr": 120438794,
-				"sbpr": 3010970,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "CryptoAccountAutoRenew",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 59972622,
-				"bpt": 95878,
-				"vpt": 239695625,
-				"rbh": 64,
-				"sbh": 5,
-				"gas": 639,
-				"bpr": 95878,
-				"sbpr": 2397,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 959561945,
-				"bpt": 1534052,
-				"vpt": 3835129999,
-				"rbh": 1023,
-				"sbh": 77,
-				"gas": 10227,
-				"bpr": 1534052,
-				"sbpr": 38351,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 959561945,
-				"bpt": 1534052,
-				"vpt": 3835129999,
-				"rbh": 1023,
-				"sbh": 77,
-				"gas": 10227,
-				"bpr": 1534052,
-				"sbpr": 38351,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "CryptoUpdate",
-		  "fees": [
-			{
-			  "subType": "DEFAULT",
-			  "nodedata": {
-				"constant": 16302371,
-				"bpt": 26063,
-				"vpt": 65156516,
-				"rbh": 17,
-				"sbh": 1,
-				"gas": 174,
-				"bpr": 26063,
-				"sbpr": 652,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 326047427,
-				"bpt": 521252,
-				"vpt": 1303130322,
-				"rbh": 348,
-				"sbh": 26,
-				"gas": 3475,
-				"bpr": 521252,
-				"sbpr": 13031,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 326047427,
-				"bpt": 521252,
-				"vpt": 1303130322,
-				"rbh": 348,
-				"sbh": 26,
-				"gas": 3475,
-				"bpr": 521252,
-				"sbpr": 13031,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "CryptoTransfer",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 7574478,
-				"bpt": 12109,
-				"vpt": 30273301,
-				"rbh": 8,
-				"sbh": 1,
-				"gas": 81,
-				"bpr": 12109,
-				"sbpr": 303,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 151489557,
-				"bpt": 242186,
-				"vpt": 605466012,
-				"rbh": 161,
-				"sbh": 12,
-				"gas": 1615,
-				"bpr": 242186,
-				"sbpr": 6055,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 151489557,
-				"bpt": 242186,
-				"vpt": 605466012,
-				"rbh": 161,
-				"sbh": 12,
-				"gas": 1615,
-				"bpr": 242186,
-				"sbpr": 6055,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			},
-			{
-			  "subType": "TOKEN_FUNGIBLE_COMMON",
-			  "nodedata": {
-				"constant": 7983519,
-				"bpt": 12763,
-				"vpt": 31908136,
-				"rbh": 9,
-				"sbh": 1,
-				"gas": 85,
-				"bpr": 12763,
-				"sbpr": 319,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 159670382,
-				"bpt": 255265,
-				"vpt": 638162730,
-				"rbh": 170,
-				"sbh": 13,
-				"gas": 1702,
-				"bpr": 255265,
-				"sbpr": 6382,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 159670382,
-				"bpt": 255265,
-				"vpt": 638162730,
-				"rbh": 170,
-				"sbh": 13,
-				"gas": 1702,
-				"bpr": 255265,
-				"sbpr": 6382,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			},
-			{
-			  "subType": "TOKEN_FUNGIBLE_COMMON_WITH_CUSTOM_FEES",
-			  "nodedata": {
-				"constant": 15967037,
-				"bpt": 25527,
-				"vpt": 63816270,
-				"rbh": 17,
-				"sbh": 1,
-				"gas": 170,
-				"bpr": 25527,
-				"sbpr": 638,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 319340747,
-				"bpt": 510530,
-				"vpt": 1276325394,
-				"rbh": 340,
-				"sbh": 26,
-				"gas": 3404,
-				"bpr": 510530,
-				"sbpr": 12763,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 319340747,
-				"bpt": 510530,
-				"vpt": 1276325394,
-				"rbh": 340,
-				"sbh": 26,
-				"gas": 3404,
-				"bpr": 510530,
-				"sbpr": 12763,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			},
-			{
-			  "subType": "TOKEN_NON_FUNGIBLE_UNIQUE",
-			  "nodedata": {
-				"constant": 22833842,
-				"bpt": 36504,
-				"vpt": 91261178,
-				"rbh": 24,
-				"sbh": 2,
-				"gas": 243,
-				"bpr": 36504,
-				"sbpr": 913,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 456676846,
-				"bpt": 730089,
-				"vpt": 1825223562,
-				"rbh": 487,
-				"sbh": 37,
-				"gas": 4867,
-				"bpr": 730089,
-				"sbpr": 18252,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 456676846,
-				"bpt": 730089,
-				"vpt": 1825223562,
-				"rbh": 487,
-				"sbh": 37,
-				"gas": 4867,
-				"bpr": 730089,
-				"sbpr": 18252,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			},
-			{
-			  "subType": "TOKEN_NON_FUNGIBLE_UNIQUE_WITH_CUSTOM_FEES",
-			  "nodedata": {
-				"constant": 45667678,
-				"bpt": 73009,
-				"vpt": 182522330,
-				"rbh": 49,
-				"sbh": 4,
-				"gas": 487,
-				"bpr": 73009,
-				"sbpr": 1825,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 913353558,
-				"bpt": 1460179,
-				"vpt": 3650446591,
-				"rbh": 973,
-				"sbh": 73,
-				"gas": 9735,
-				"bpr": 1460179,
-				"sbpr": 36504,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 913353558,
-				"bpt": 1460179,
-				"vpt": 3650446591,
-				"rbh": 973,
-				"sbh": 73,
-				"gas": 9735,
-				"bpr": 1460179,
-				"sbpr": 36504,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "CryptoDelete",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 471427939,
-				"bpt": 753672,
-				"vpt": 1884180005,
-				"rbh": 502,
-				"sbh": 38,
-				"gas": 5024,
-				"bpr": 753672,
-				"sbpr": 18842,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 7542847021,
-				"bpt": 12058752,
-				"vpt": 30146880078,
-				"rbh": 8039,
-				"sbh": 603,
-				"gas": 80392,
-				"bpr": 12058752,
-				"sbpr": 301469,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 7542847021,
-				"bpt": 12058752,
-				"vpt": 30146880078,
-				"rbh": 8039,
-				"sbh": 603,
-				"gas": 80392,
-				"bpr": 12058752,
-				"sbpr": 301469,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "CryptoAddLiveHash",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 5561692202,
-				"bpt": 8891479,
-				"vpt": 22228697914,
-				"rbh": 5928,
-				"sbh": 445,
-				"gas": 59277,
-				"bpr": 8891479,
-				"sbpr": 222287,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 88987075231,
-				"bpt": 142263667,
-				"vpt": 355659166619,
-				"rbh": 94842,
-				"sbh": 7113,
-				"gas": 948424,
-				"bpr": 142263667,
-				"sbpr": 3556592,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 88987075231,
-				"bpt": 142263667,
-				"vpt": 355659166619,
-				"rbh": 94842,
-				"sbh": 7113,
-				"gas": 948424,
-				"bpr": 142263667,
-				"sbpr": 3556592,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "CryptoDeleteLiveHash",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 468546396,
-				"bpt": 749065,
-				"vpt": 1872663195,
-				"rbh": 499,
-				"sbh": 37,
-				"gas": 4994,
-				"bpr": 749065,
-				"sbpr": 18727,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 7496742329,
-				"bpt": 11985044,
-				"vpt": 29962611113,
-				"rbh": 7990,
-				"sbh": 599,
-				"gas": 79900,
-				"bpr": 11985044,
-				"sbpr": 299626,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 7496742329,
-				"bpt": 11985044,
-				"vpt": 29962611113,
-				"rbh": 7990,
-				"sbh": 599,
-				"gas": 79900,
-				"bpr": 11985044,
-				"sbpr": 299626,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "CryptoGetLiveHash",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 58926,
-				"bpt": 94,
-				"vpt": 235514,
-				"rbh": 0,
-				"sbh": 0,
-				"gas": 1,
-				"bpr": 94,
-				"sbpr": 2,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 942822,
-				"bpt": 1507,
-				"vpt": 3768224,
-				"rbh": 1,
-				"sbh": 0,
-				"gas": 10,
-				"bpr": 1507,
-				"sbpr": 38,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 942822,
-				"bpt": 1507,
-				"vpt": 3768224,
-				"rbh": 1,
-				"sbh": 0,
-				"gas": 10,
-				"bpr": 1507,
-				"sbpr": 38,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "CryptoGetAccountRecords",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 22044,
-				"bpt": 35,
-				"vpt": 88105,
-				"rbh": 0,
-				"sbh": 0,
-				"gas": 0,
-				"bpr": 35,
-				"sbpr": 1,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 352708,
-				"bpt": 564,
-				"vpt": 1409688,
-				"rbh": 0,
-				"sbh": 0,
-				"gas": 4,
-				"bpr": 564,
-				"sbpr": 14,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 352708,
-				"bpt": 564,
-				"vpt": 1409688,
-				"rbh": 0,
-				"sbh": 0,
-				"gas": 4,
-				"bpr": 564,
-				"sbpr": 14,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "CryptoGetAccountBalance",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 68774,
-				"bpt": 110,
-				"vpt": 274874,
-				"rbh": 0,
-				"sbh": 0,
-				"gas": 1,
-				"bpr": 110,
-				"sbpr": 3,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 1100389,
-				"bpt": 1759,
-				"vpt": 4397982,
-				"rbh": 1,
-				"sbh": 0,
-				"gas": 12,
-				"bpr": 1759,
-				"sbpr": 44,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 1100389,
-				"bpt": 1759,
-				"vpt": 4397982,
-				"rbh": 1,
-				"sbh": 0,
-				"gas": 12,
-				"bpr": 1759,
-				"sbpr": 44,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "CryptoGetInfo",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 63990,
-				"bpt": 102,
-				"vpt": 255752,
-				"rbh": 0,
-				"sbh": 0,
-				"gas": 1,
-				"bpr": 102,
-				"sbpr": 3,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 1023841,
-				"bpt": 1637,
-				"vpt": 4092038,
-				"rbh": 1,
-				"sbh": 0,
-				"gas": 11,
-				"bpr": 1637,
-				"sbpr": 41,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 1023841,
-				"bpt": 1637,
-				"vpt": 4092038,
-				"rbh": 1,
-				"sbh": 0,
-				"gas": 11,
-				"bpr": 1637,
-				"sbpr": 41,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "CryptoGetStakers",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 15251,
-				"bpt": 24,
-				"vpt": 60953,
-				"rbh": 0,
-				"sbh": 0,
-				"gas": 0,
-				"bpr": 24,
-				"sbpr": 1,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 244011,
-				"bpt": 390,
-				"vpt": 975251,
-				"rbh": 0,
-				"sbh": 0,
-				"gas": 3,
-				"bpr": 390,
-				"sbpr": 10,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 244011,
-				"bpt": 390,
-				"vpt": 975251,
-				"rbh": 0,
-				"sbh": 0,
-				"gas": 3,
-				"bpr": 390,
-				"sbpr": 10,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "ConsensusCreateTopic",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 921577366,
-				"bpt": 1473326,
-				"vpt": 3683315100,
-				"rbh": 982,
-				"sbh": 74,
-				"gas": 9822,
-				"bpr": 1473326,
-				"sbpr": 36833,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 14745237852,
-				"bpt": 23573217,
-				"vpt": 58933041595,
-				"rbh": 15715,
-				"sbh": 1179,
-				"gas": 157155,
-				"bpr": 23573217,
-				"sbpr": 589330,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 14745237852,
-				"bpt": 23573217,
-				"vpt": 58933041595,
-				"rbh": 15715,
-				"sbh": 1179,
-				"gas": 157155,
-				"bpr": 23573217,
-				"sbpr": 589330,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "ConsensusUpdateTopic",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 20193780,
-				"bpt": 32284,
-				"vpt": 80709508,
-				"rbh": 22,
-				"sbh": 2,
-				"gas": 215,
-				"bpr": 32284,
-				"sbpr": 807,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 323100486,
-				"bpt": 516541,
-				"vpt": 1291352134,
-				"rbh": 344,
-				"sbh": 26,
-				"gas": 3444,
-				"bpr": 516541,
-				"sbpr": 12914,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 323100486,
-				"bpt": 516541,
-				"vpt": 1291352134,
-				"rbh": 344,
-				"sbh": 26,
-				"gas": 3444,
-				"bpr": 516541,
-				"sbpr": 12914,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "ConsensusDeleteTopic",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 474345144,
-				"bpt": 758336,
-				"vpt": 1895839348,
-				"rbh": 506,
-				"sbh": 38,
-				"gas": 5056,
-				"bpr": 758336,
-				"sbpr": 18958,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 7589522307,
-				"bpt": 12133372,
-				"vpt": 30333429564,
-				"rbh": 8089,
-				"sbh": 607,
-				"gas": 80889,
-				"bpr": 12133372,
-				"sbpr": 303334,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 7589522307,
-				"bpt": 12133372,
-				"vpt": 30333429564,
-				"rbh": 8089,
-				"sbh": 607,
-				"gas": 80889,
-				"bpr": 12133372,
-				"sbpr": 303334,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "ConsensusSubmitMessage",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 9248442,
-				"bpt": 14785,
-				"vpt": 36963719,
-				"rbh": 10,
-				"sbh": 1,
-				"gas": 99,
-				"bpr": 14785,
-				"sbpr": 370,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 147975076,
-				"bpt": 236568,
-				"vpt": 591419509,
-				"rbh": 158,
-				"sbh": 12,
-				"gas": 1577,
-				"bpr": 236568,
-				"sbpr": 5914,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 147975076,
-				"bpt": 236568,
-				"vpt": 591419509,
-				"rbh": 158,
-				"sbh": 12,
-				"gas": 1577,
-				"bpr": 236568,
-				"sbpr": 5914,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "ConsensusGetTopicInfo",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 64253,
-				"bpt": 103,
-				"vpt": 256803,
-				"rbh": 0,
-				"sbh": 0,
-				"gas": 1,
-				"bpr": 103,
-				"sbpr": 3,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 1028048,
-				"bpt": 1644,
-				"vpt": 4108851,
-				"rbh": 1,
-				"sbh": 0,
-				"gas": 11,
-				"bpr": 1644,
-				"sbpr": 41,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 1028048,
-				"bpt": 1644,
-				"vpt": 4108851,
-				"rbh": 1,
-				"sbh": 0,
-				"gas": 11,
-				"bpr": 1644,
-				"sbpr": 41,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule" : {
-		  "hederaFunctionality" : "UtilPrng",
-		  "fees" : [ {
-			"subType" : "DEFAULT",
-			"nodedata" : {
-			  "constant" : 76998002,
-			  "bpt" : 123097,
-			  "vpt" : 307741829,
-			  "rbh" : 82,
-			  "sbh" : 6,
-			  "gas" : 821,
-			  "bpr" : 123097,
-			  "sbpr" : 3077,
-			  "min" : 0,
-			  "max" : 1000000000000000
-			},
-			"networkdata" : {
-			  "constant" : 1539960046,
-			  "bpt" : 2461935,
-			  "vpt" : 6154836589,
-			  "rbh" : 1641,
-			  "sbh" : 123,
-			  "gas" : 16413,
-			  "bpr" : 2461935,
-			  "sbpr" : 61548,
-			  "min" : 0,
-			  "max" : 1000000000000000
-			},
-			"servicedata" : {
-			  "constant" : 1539960046,
-			  "bpt" : 2461935,
-			  "vpt" : 6154836589,
-			  "rbh" : 1641,
-			  "sbh" : 123,
-			  "gas" : 16413,
-			  "bpr" : 2461935,
-			  "sbpr" : 61548,
-			  "min" : 0,
-			  "max" : 1000000000000000
-			}
-		  } ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "TokenCreate",
-		  "fees": [
-			{
-			  "subType": "TOKEN_FUNGIBLE_COMMON_WITH_CUSTOM_FEES",
-			  "nodedata": {
-				"constant": 393746195920,
-				"bpt": 17485616,
-				"vpt": 43714039850,
-				"rbh": 11657,
-				"sbh": 874,
-				"gas": 116571,
-				"bpr": 17485616,
-				"sbpr": 437140,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 7874923918408,
-				"bpt": 349712319,
-				"vpt": 874280797002,
-				"rbh": 233142,
-				"sbh": 17486,
-				"gas": 2331415,
-				"bpr": 349712319,
-				"sbpr": 8742808,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 7874923918408,
-				"bpt": 349712319,
-				"vpt": 874280797002,
-				"rbh": 233142,
-				"sbh": 17486,
-				"gas": 2331415,
-				"bpr": 349712319,
-				"sbpr": 8742808,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			},
-			{
-			  "subType": "TOKEN_FUNGIBLE_COMMON",
-			  "nodedata": {
-				"constant": 197306974233,
-				"bpt": 8762076,
-				"vpt": 21905189240,
-				"rbh": 5841,
-				"sbh": 438,
-				"gas": 58414,
-				"bpr": 8762076,
-				"sbpr": 219052,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 3946139484654,
-				"bpt": 175241514,
-				"vpt": 438103784807,
-				"rbh": 116828,
-				"sbh": 8762,
-				"gas": 1168277,
-				"bpr": 175241514,
-				"sbpr": 4381038,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 3946139484654,
-				"bpt": 175241514,
-				"vpt": 438103784807,
-				"rbh": 116828,
-				"sbh": 8762,
-				"gas": 1168277,
-				"bpr": 175241514,
-				"sbpr": 4381038,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			},
-			{
-			  "subType": "TOKEN_NON_FUNGIBLE_UNIQUE",
-			  "nodedata": {
-				"constant": 197031853851,
-				"bpt": 8749858,
-				"vpt": 21874645140,
-				"rbh": 5833,
-				"sbh": 437,
-				"gas": 58332,
-				"bpr": 8749858,
-				"sbpr": 218746,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 3940637077020,
-				"bpt": 174997161,
-				"vpt": 437492902800,
-				"rbh": 116665,
-				"sbh": 8750,
-				"gas": 1166648,
-				"bpr": 174997161,
-				"sbpr": 4374929,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 3940637077020,
-				"bpt": 174997161,
-				"vpt": 437492902800,
-				"rbh": 116665,
-				"sbh": 8750,
-				"gas": 1166648,
-				"bpr": 174997161,
-				"sbpr": 4374929,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			},
-			{
-			  "subType": "TOKEN_NON_FUNGIBLE_UNIQUE_WITH_CUSTOM_FEES",
-			  "nodedata": {
-				"constant": 393198370765,
-				"bpt": 17461288,
-				"vpt": 43653219832,
-				"rbh": 11641,
-				"sbh": 873,
-				"gas": 116409,
-				"bpr": 17461288,
-				"sbpr": 436532,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 7863967415309,
-				"bpt": 349225759,
-				"vpt": 873064396645,
-				"rbh": 232817,
-				"sbh": 17461,
-				"gas": 2328172,
-				"bpr": 349225759,
-				"sbpr": 8730644,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 7863967415309,
-				"bpt": 349225759,
-				"vpt": 873064396645,
-				"rbh": 232817,
-				"sbh": 17461,
-				"gas": 2328172,
-				"bpr": 349225759,
-				"sbpr": 8730644,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "TokenDelete",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 94285588,
-				"bpt": 150734,
-				"vpt": 376836001,
-				"rbh": 100,
-				"sbh": 8,
-				"gas": 1005,
-				"bpr": 150734,
-				"sbpr": 3768,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 1508569404,
-				"bpt": 2411750,
-				"vpt": 6029376016,
-				"rbh": 1608,
-				"sbh": 121,
-				"gas": 16078,
-				"bpr": 2411750,
-				"sbpr": 60294,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 1508569404,
-				"bpt": 2411750,
-				"vpt": 6029376016,
-				"rbh": 1608,
-				"sbh": 121,
-				"gas": 16078,
-				"bpr": 2411750,
-				"sbpr": 60294,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "TokenFeeScheduleUpdate",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 73998596,
-				"bpt": 118302,
-				"vpt": 295753948,
-				"rbh": 79,
-				"sbh": 6,
-				"gas": 789,
-				"bpr": 118302,
-				"sbpr": 2958,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 1479971913,
-				"bpt": 2366032,
-				"vpt": 5915078967,
-				"rbh": 1577,
-				"sbh": 118,
-				"gas": 15774,
-				"bpr": 2366032,
-				"sbpr": 59151,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 1479971913,
-				"bpt": 2366032,
-				"vpt": 5915078967,
-				"rbh": 1577,
-				"sbh": 118,
-				"gas": 15774,
-				"bpr": 2366032,
-				"sbpr": 59151,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "TokenUpdate",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 93900697,
-				"bpt": 150119,
-				"vpt": 375297688,
-				"rbh": 100,
-				"sbh": 8,
-				"gas": 1001,
-				"bpr": 150119,
-				"sbpr": 3753,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 1502411149,
-				"bpt": 2401905,
-				"vpt": 6004763005,
-				"rbh": 1601,
-				"sbh": 120,
-				"gas": 16013,
-				"bpr": 2401905,
-				"sbpr": 60048,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 1502411149,
-				"bpt": 2401905,
-				"vpt": 6004763005,
-				"rbh": 1601,
-				"sbh": 120,
-				"gas": 16013,
-				"bpr": 2401905,
-				"sbpr": 60048,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "TokenMint",
-		  "fees": [
-			{
-			  "subType": "TOKEN_FUNGIBLE_COMMON",
-			  "nodedata": {
-				"constant": 94092119,
-				"bpt": 150425,
-				"vpt": 376062755,
-				"rbh": 100,
-				"sbh": 8,
-				"gas": 1003,
-				"bpr": 150425,
-				"sbpr": 3761,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 1505473906,
-				"bpt": 2406802,
-				"vpt": 6017004081,
-				"rbh": 1605,
-				"sbh": 120,
-				"gas": 16045,
-				"bpr": 2406802,
-				"sbpr": 60170,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 1505473906,
-				"bpt": 2406802,
-				"vpt": 6017004081,
-				"rbh": 1605,
-				"sbh": 120,
-				"gas": 16045,
-				"bpr": 2406802,
-				"sbpr": 60170,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			},
-			{
-			  "subType": "TOKEN_NON_FUNGIBLE_UNIQUE",
-			  "nodedata": {
-				"constant": 3606440483,
-				"bpt": 5765618,
-				"vpt": 14414043986,
-				"rbh": 3844,
-				"sbh": 288,
-				"gas": 38437,
-				"bpr": 5765618,
-				"sbpr": 144140,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 72128809656,
-				"bpt": 115312352,
-				"vpt": 288280879722,
-				"rbh": 76875,
-				"sbh": 5766,
-				"gas": 768749,
-				"bpr": 115312352,
-				"sbpr": 2882809,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 72128809656,
-				"bpt": 115312352,
-				"vpt": 288280879722,
-				"rbh": 76875,
-				"sbh": 5766,
-				"gas": 768749,
-				"bpr": 115312352,
-				"sbpr": 2882809,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "TokenBurn",
-		  "fees": [
-			{
-			  "subType": "TOKEN_FUNGIBLE_COMMON",
-			  "nodedata": {
-				"constant": 94092119,
-				"bpt": 150425,
-				"vpt": 376062755,
-				"rbh": 100,
-				"sbh": 8,
-				"gas": 1003,
-				"bpr": 150425,
-				"sbpr": 3761,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 1505473906,
-				"bpt": 2406802,
-				"vpt": 6017004081,
-				"rbh": 1605,
-				"sbh": 120,
-				"gas": 16045,
-				"bpr": 2406802,
-				"sbpr": 60170,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 1505473906,
-				"bpt": 2406802,
-				"vpt": 6017004081,
-				"rbh": 1605,
-				"sbh": 120,
-				"gas": 16045,
-				"bpr": 2406802,
-				"sbpr": 60170,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			},
-			{
-			  "subType": "TOKEN_NON_FUNGIBLE_UNIQUE",
-			  "nodedata": {
-				"constant": 76366243,
-				"bpt": 122087,
-				"vpt": 305216845,
-				"rbh": 81,
-				"sbh": 6,
-				"gas": 814,
-				"bpr": 122087,
-				"sbpr": 3052,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 1527324859,
-				"bpt": 2441735,
-				"vpt": 6104336894,
-				"rbh": 1628,
-				"sbh": 122,
-				"gas": 16278,
-				"bpr": 2441735,
-				"sbpr": 61043,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 1527324859,
-				"bpt": 2441735,
-				"vpt": 6104336894,
-				"rbh": 1628,
-				"sbh": 122,
-				"gas": 16278,
-				"bpr": 2441735,
-				"sbpr": 61043,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "TokenAssociateToAccount",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 4574479485,
-				"bpt": 7313222,
-				"vpt": 18283054670,
-				"rbh": 4875,
-				"sbh": 366,
-				"gas": 48755,
-				"bpr": 7313222,
-				"sbpr": 182831,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 73191671761,
-				"bpt": 117011550,
-				"vpt": 292528874720,
-				"rbh": 78008,
-				"sbh": 5851,
-				"gas": 780077,
-				"bpr": 117011550,
-				"sbpr": 2925289,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 73191671761,
-				"bpt": 117011550,
-				"vpt": 292528874720,
-				"rbh": 78008,
-				"sbh": 5851,
-				"gas": 780077,
-				"bpr": 117011550,
-				"sbpr": 2925289,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "TokenDissociateFromAccount",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 4714279388,
-				"bpt": 7536720,
-				"vpt": 18841800049,
-				"rbh": 5024,
-				"sbh": 377,
-				"gas": 50245,
-				"bpr": 7536720,
-				"sbpr": 188418,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 75428470213,
-				"bpt": 120587520,
-				"vpt": 301468800784,
-				"rbh": 80392,
-				"sbh": 6029,
-				"gas": 803917,
-				"bpr": 120587520,
-				"sbpr": 3014688,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 75428470213,
-				"bpt": 120587520,
-				"vpt": 301468800784,
-				"rbh": 80392,
-				"sbh": 6029,
-				"gas": 803917,
-				"bpr": 120587520,
-				"sbpr": 3014688,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "TokenGrantKycToAccount",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 94285551,
-				"bpt": 150734,
-				"vpt": 376835856,
-				"rbh": 100,
-				"sbh": 8,
-				"gas": 1005,
-				"bpr": 150734,
-				"sbpr": 3768,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 1508568822,
-				"bpt": 2411749,
-				"vpt": 6029373689,
-				"rbh": 1608,
-				"sbh": 121,
-				"gas": 16078,
-				"bpr": 2411749,
-				"sbpr": 60294,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 1508568822,
-				"bpt": 2411749,
-				"vpt": 6029373689,
-				"rbh": 1608,
-				"sbh": 121,
-				"gas": 16078,
-				"bpr": 2411749,
-				"sbpr": 60294,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "TokenRevokeKycFromAccount",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 94285551,
-				"bpt": 150734,
-				"vpt": 376835856,
-				"rbh": 100,
-				"sbh": 8,
-				"gas": 1005,
-				"bpr": 150734,
-				"sbpr": 3768,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 1508568822,
-				"bpt": 2411749,
-				"vpt": 6029373689,
-				"rbh": 1608,
-				"sbh": 121,
-				"gas": 16078,
-				"bpr": 2411749,
-				"sbpr": 60294,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 1508568822,
-				"bpt": 2411749,
-				"vpt": 6029373689,
-				"rbh": 1608,
-				"sbh": 121,
-				"gas": 16078,
-				"bpr": 2411749,
-				"sbpr": 60294,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "TokenFreezeAccount",
-		  "fees": [
-			{
-			  "subType": "DEFAULT",
-			  "nodedata": {
-				"constant": 76054309,
-				"bpt": 121588,
-				"vpt": 303970122,
-				"rbh": 81,
-				"sbh": 6,
-				"gas": 811,
-				"bpr": 121588,
-				"sbpr": 3040,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 1521086180,
-				"bpt": 2431761,
-				"vpt": 6079402448,
-				"rbh": 1621,
-				"sbh": 122,
-				"gas": 16212,
-				"bpr": 2431761,
-				"sbpr": 60794,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 1521086180,
-				"bpt": 2431761,
-				"vpt": 6079402448,
-				"rbh": 1621,
-				"sbh": 122,
-				"gas": 16212,
-				"bpr": 2431761,
-				"sbpr": 60794,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "TokenUnfreezeAccount",
-		  "fees": [
-			{
-			  "subType": "DEFAULT",
-			  "nodedata": {
-				"constant": 76054309,
-				"bpt": 121588,
-				"vpt": 303970122,
-				"rbh": 81,
-				"sbh": 6,
-				"gas": 811,
-				"bpr": 121588,
-				"sbpr": 3040,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 1521086180,
-				"bpt": 2431761,
-				"vpt": 6079402448,
-				"rbh": 1621,
-				"sbh": 122,
-				"gas": 16212,
-				"bpr": 2431761,
-				"sbpr": 60794,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 1521086180,
-				"bpt": 2431761,
-				"vpt": 6079402448,
-				"rbh": 1621,
-				"sbh": 122,
-				"gas": 16212,
-				"bpr": 2431761,
-				"sbpr": 60794,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "TokenPause",
-		  "fees": [
-			{
-			  "subType": "DEFAULT",
-			  "nodedata": {
-				"constant": 76523246,
-				"bpt": 122338,
-				"vpt": 305844348,
-				"rbh": 82,
-				"sbh": 6,
-				"gas": 816,
-				"bpr": 122338,
-				"sbpr": 3058,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 1530464926,
-				"bpt": 2446755,
-				"vpt": 6116886962,
-				"rbh": 1631,
-				"sbh": 122,
-				"gas": 16312,
-				"bpr": 2446755,
-				"sbpr": 61169,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 1530464926,
-				"bpt": 2446755,
-				"vpt": 6116886962,
-				"rbh": 1631,
-				"sbh": 122,
-				"gas": 16312,
-				"bpr": 2446755,
-				"sbpr": 61169,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "TokenUnpause",
-		  "fees": [
-			{
-			  "subType": "DEFAULT",
-			  "nodedata": {
-				"constant": 76523246,
-				"bpt": 122338,
-				"vpt": 305844348,
-				"rbh": 82,
-				"sbh": 6,
-				"gas": 816,
-				"bpr": 122338,
-				"sbpr": 3058,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 1530464926,
-				"bpt": 2446755,
-				"vpt": 6116886962,
-				"rbh": 1631,
-				"sbh": 122,
-				"gas": 16312,
-				"bpr": 2446755,
-				"sbpr": 61169,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 1530464926,
-				"bpt": 2446755,
-				"vpt": 6116886962,
-				"rbh": 1631,
-				"sbh": 122,
-				"gas": 16312,
-				"bpr": 2446755,
-				"sbpr": 61169,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "TokenAccountWipe",
-		  "fees": [
-			{
-			  "subType": "TOKEN_FUNGIBLE_COMMON",
-			  "nodedata": {
-				"constant": 94092119,
-				"bpt": 150425,
-				"vpt": 376062755,
-				"rbh": 100,
-				"sbh": 8,
-				"gas": 1003,
-				"bpr": 150425,
-				"sbpr": 3761,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 1505473906,
-				"bpt": 2406802,
-				"vpt": 6017004081,
-				"rbh": 1605,
-				"sbh": 120,
-				"gas": 16045,
-				"bpr": 2406802,
-				"sbpr": 60170,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 1505473906,
-				"bpt": 2406802,
-				"vpt": 6017004081,
-				"rbh": 1605,
-				"sbh": 120,
-				"gas": 16045,
-				"bpr": 2406802,
-				"sbpr": 60170,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			},
-			{
-			  "subType": "TOKEN_NON_FUNGIBLE_UNIQUE",
-			  "nodedata": {
-				"constant": 76366243,
-				"bpt": 122087,
-				"vpt": 305216845,
-				"rbh": 81,
-				"sbh": 6,
-				"gas": 814,
-				"bpr": 122087,
-				"sbpr": 3052,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 1527324859,
-				"bpt": 2441735,
-				"vpt": 6104336894,
-				"rbh": 1628,
-				"sbh": 122,
-				"gas": 16278,
-				"bpr": 2441735,
-				"sbpr": 61043,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 1527324859,
-				"bpt": 2441735,
-				"vpt": 6104336894,
-				"rbh": 1628,
-				"sbh": 122,
-				"gas": 16278,
-				"bpr": 2441735,
-				"sbpr": 61043,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "TokenGetInfo",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 61717,
-				"bpt": 99,
-				"vpt": 246668,
-				"rbh": 0,
-				"sbh": 0,
-				"gas": 1,
-				"bpr": 99,
-				"sbpr": 2,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 987474,
-				"bpt": 1579,
-				"vpt": 3946688,
-				"rbh": 1,
-				"sbh": 0,
-				"gas": 11,
-				"bpr": 1579,
-				"sbpr": 39,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 987474,
-				"bpt": 1579,
-				"vpt": 3946688,
-				"rbh": 1,
-				"sbh": 0,
-				"gas": 11,
-				"bpr": 1579,
-				"sbpr": 39,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "TokenGetNftInfo",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 54605,
-				"bpt": 87,
-				"vpt": 218244,
-				"rbh": 0,
-				"sbh": 0,
-				"gas": 1,
-				"bpr": 87,
-				"sbpr": 2,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 0,
-				"bpt": 0,
-				"vpt": 0,
-				"rbh": 0,
-				"sbh": 0,
-				"gas": 0,
-				"bpr": 0,
-				"sbpr": 0,
-				"min": 0,
-				"max": 0
-			  },
-			  "servicedata": {
-				"constant": 0,
-				"bpt": 0,
-				"vpt": 0,
-				"rbh": 0,
-				"sbh": 0,
-				"gas": 0,
-				"bpr": 0,
-				"sbpr": 0,
-				"min": 0,
-				"max": 0
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "ScheduleCreate",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 563513000,
-				"bpt": 900888,
-				"vpt": 2252221049,
-				"rbh": 601,
-				"sbh": 45,
-				"gas": 6006,
-				"bpr": 900888,
-				"sbpr": 22522,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 9016208000,
-				"bpt": 14414215,
-				"vpt": 36035536788,
-				"rbh": 9609,
-				"sbh": 721,
-				"gas": 96095,
-				"bpr": 14414215,
-				"sbpr": 360355,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 9016208000,
-				"bpt": 14414215,
-				"vpt": 36035536788,
-				"rbh": 9609,
-				"sbh": 721,
-				"gas": 96095,
-				"bpr": 14414215,
-				"sbpr": 360355,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "ScheduleSign",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 58040915,
-				"bpt": 92790,
-				"vpt": 231975077,
-				"rbh": 62,
-				"sbh": 5,
-				"gas": 619,
-				"bpr": 92790,
-				"sbpr": 2320,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 928654648,
-				"bpt": 1484640,
-				"vpt": 3711601232,
-				"rbh": 990,
-				"sbh": 74,
-				"gas": 9898,
-				"bpr": 1484640,
-				"sbpr": 37116,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 928654648,
-				"bpt": 1484640,
-				"vpt": 3711601232,
-				"rbh": 990,
-				"sbh": 74,
-				"gas": 9898,
-				"bpr": 1484640,
-				"sbpr": 37116,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "ScheduleDelete",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 95360774,
-				"bpt": 152453,
-				"vpt": 381133253,
-				"rbh": 102,
-				"sbh": 8,
-				"gas": 1016,
-				"bpr": 152453,
-				"sbpr": 3811,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 1525772386,
-				"bpt": 2439253,
-				"vpt": 6098132047,
-				"rbh": 1626,
-				"sbh": 122,
-				"gas": 16262,
-				"bpr": 2439253,
-				"sbpr": 60981,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 1525772386,
-				"bpt": 2439253,
-				"vpt": 6098132047,
-				"rbh": 1626,
-				"sbh": 122,
-				"gas": 16262,
-				"bpr": 2439253,
-				"sbpr": 60981,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "ScheduleGetInfo",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 53393,
-				"bpt": 85,
-				"vpt": 213400,
-				"rbh": 0,
-				"sbh": 0,
-				"gas": 1,
-				"bpr": 85,
-				"sbpr": 2,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 854295,
-				"bpt": 1366,
-				"vpt": 3414402,
-				"rbh": 1,
-				"sbh": 0,
-				"gas": 9,
-				"bpr": 1366,
-				"sbpr": 34,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 854295,
-				"bpt": 1366,
-				"vpt": 3414402,
-				"rbh": 1,
-				"sbh": 0,
-				"gas": 9,
-				"bpr": 1366,
-				"sbpr": 34,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "ContractCreate",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 45218052173,
-				"bpt": 72290115,
-				"vpt": 180725287466,
-				"rbh": 48193,
-				"sbh": 3615,
-				"gas": 481934,
-				"bpr": 72290115,
-				"sbpr": 1807253,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 723488834765,
-				"bpt": 1156641840,
-				"vpt": 2891604599463,
-				"rbh": 771095,
-				"sbh": 57832,
-				"gas": 7710946,
-				"bpr": 1156641840,
-				"sbpr": 28916046,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 0,
-				"bpt": 0,
-				"vpt": 0,
-				"rbh": 0,
-				"sbh": 0,
-				"gas": 11566419,
-				"bpr": 0,
-				"sbpr": 0,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "ContractUpdate",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 2438037058,
-				"bpt": 3897691,
-				"vpt": 9744226629,
-				"rbh": 2598,
-				"sbh": 195,
-				"gas": 25985,
-				"bpr": 3897691,
-				"sbpr": 97442,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 39008592923,
-				"bpt": 62363050,
-				"vpt": 155907626067,
-				"rbh": 41575,
-				"sbh": 3118,
-				"gas": 415754,
-				"bpr": 62363050,
-				"sbpr": 1559076,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 39008592923,
-				"bpt": 62363050,
-				"vpt": 155907626067,
-				"rbh": 41575,
-				"sbh": 3118,
-				"gas": 415754,
-				"bpr": 62363050,
-				"sbpr": 1559076,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "ContractDelete",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 664083202,
-				"bpt": 1061670,
-				"vpt": 2654175087,
-				"rbh": 708,
-				"sbh": 53,
-				"gas": 7078,
-				"bpr": 1061670,
-				"sbpr": 26542,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 10625331229,
-				"bpt": 16986721,
-				"vpt": 42466801390,
-				"rbh": 11324,
-				"sbh": 849,
-				"gas": 113245,
-				"bpr": 16986721,
-				"sbpr": 424668,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 10625331229,
-				"bpt": 16986721,
-				"vpt": 42466801390,
-				"rbh": 11324,
-				"sbh": 849,
-				"gas": 113245,
-				"bpr": 16986721,
-				"sbpr": 424668,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "ContractCall",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 3336515210,
-				"bpt": 5334088,
-				"vpt": 13335219927,
-				"rbh": 3556,
-				"sbh": 267,
-				"gas": 35561,
-				"bpr": 5334088,
-				"sbpr": 133352,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 53384243355,
-				"bpt": 85345408,
-				"vpt": 213363518838,
-				"rbh": 56897,
-				"sbh": 4267,
-				"gas": 568969,
-				"bpr": 85345408,
-				"sbpr": 2133635,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 0,
-				"bpt": 0,
-				"vpt": 0,
-				"rbh": 0,
-				"sbh": 0,
-				"gas": 853454,
-				"bpr": 0,
-				"sbpr": 0,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "EthereumTransaction",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 6122046,
-				"bpt": 9787,
-				"vpt": 24468293,
-				"rbh": 6,
-				"sbh": 0,
-				"gas": 65,
-				"bpr": 9787,
-				"sbpr": 244,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 97952740,
-				"bpt": 156597,
-				"vpt": 391492695,
-				"rbh": 104,
-				"sbh": 7,
-				"gas": 1043,
-				"bpr": 156597,
-				"sbpr": 3914,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 0,
-				"bpt": 0,
-				"vpt": 0,
-				"rbh": 0,
-				"sbh": 0,
-				"gas": 853454,
-				"bpr": 0,
-				"sbpr": 0,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "ContractGetInfo",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 71015,
-				"bpt": 114,
-				"vpt": 283830,
-				"rbh": 0,
-				"sbh": 0,
-				"gas": 1,
-				"bpr": 114,
-				"sbpr": 3,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 1136244,
-				"bpt": 1817,
-				"vpt": 4541284,
-				"rbh": 1,
-				"sbh": 0,
-				"gas": 12,
-				"bpr": 1817,
-				"sbpr": 45,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 1136244,
-				"bpt": 1817,
-				"vpt": 4541284,
-				"rbh": 1,
-				"sbh": 0,
-				"gas": 12,
-				"bpr": 1817,
-				"sbpr": 45,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "ContractCallLocal",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 2610100486,
-				"bpt": 4172769,
-				"vpt": 10431921279,
-				"rbh": 2782,
-				"sbh": 209,
-				"gas": 27818,
-				"bpr": 4172769,
-				"sbpr": 104319,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 41761607776,
-				"bpt": 66764296,
-				"vpt": 166910740461,
-				"rbh": 44510,
-				"sbh": 3338,
-				"gas": 445095,
-				"bpr": 66764296,
-				"sbpr": 1669107,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 41761607776,
-				"bpt": 66764296,
-				"vpt": 166910740461,
-				"rbh": 44510,
-				"sbh": 3338,
-				"gas": 445095,
-				"bpr": 66764296,
-				"sbpr": 1669107,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "ContractGetBytecode",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 226589259813,
-				"bpt": 362248325,
-				"vpt": 905620811793,
-				"rbh": 241499,
-				"sbh": 18112,
-				"gas": 2414989,
-				"bpr": 362248325,
-				"sbpr": 9056208,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 3625428157003,
-				"bpt": 5795973195,
-				"vpt": 14489932988688,
-				"rbh": 3863982,
-				"sbh": 289799,
-				"gas": 38639821,
-				"bpr": 5795973195,
-				"sbpr": 144899330,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 3625428157003,
-				"bpt": 5795973195,
-				"vpt": 14489932988688,
-				"rbh": 3863982,
-				"sbh": 289799,
-				"gas": 38639821,
-				"bpr": 5795973195,
-				"sbpr": 144899330,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "GetBySolidityID",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 69385,
-				"bpt": 111,
-				"vpt": 277313,
-				"rbh": 0,
-				"sbh": 0,
-				"gas": 1,
-				"bpr": 111,
-				"sbpr": 3,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 1110154,
-				"bpt": 1775,
-				"vpt": 4437010,
-				"rbh": 1,
-				"sbh": 0,
-				"gas": 12,
-				"bpr": 1775,
-				"sbpr": 44,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 1110154,
-				"bpt": 1775,
-				"vpt": 4437010,
-				"rbh": 1,
-				"sbh": 0,
-				"gas": 12,
-				"bpr": 1775,
-				"sbpr": 44,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "ContractGetRecords",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 10093,
-				"bpt": 16,
-				"vpt": 40339,
-				"rbh": 0,
-				"sbh": 0,
-				"gas": 0,
-				"bpr": 16,
-				"sbpr": 0,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 161486,
-				"bpt": 258,
-				"vpt": 645421,
-				"rbh": 0,
-				"sbh": 0,
-				"gas": 2,
-				"bpr": 258,
-				"sbpr": 6,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 161486,
-				"bpt": 258,
-				"vpt": 645421,
-				"rbh": 0,
-				"sbh": 0,
-				"gas": 2,
-				"bpr": 258,
-				"sbpr": 6,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule" : {
-		  "hederaFunctionality" : "ContractAutoRenew",
-		  "fees" : [ {
-			"subType" : "DEFAULT",
-			"nodedata" : {
-			  "constant" : 5396134280,
-			  "bpt" : 8626802,
-			  "vpt" : 21567004154,
-			  "rbh" : 5751,
-			  "sbh" : 431,
-			  "gas" : 57512,
-			  "bpr" : 8626802,
-			  "sbpr" : 215670,
-			  "min" : 0,
-			  "max" : 1000000000000000
-			},
-			"networkdata" : {
-			  "constant" : 107922685608,
-			  "bpt" : 172536033,
-			  "vpt" : 431340083072,
-			  "rbh" : 115024,
-			  "sbh" : 8627,
-			  "gas" : 1150240,
-			  "bpr" : 172536033,
-			  "sbpr" : 4313401,
-			  "min" : 0,
-			  "max" : 1000000000000000
-			},
-			"servicedata" : {
-			  "constant" : 107922685608,
-			  "bpt" : 172536033,
-			  "vpt" : 431340083072,
-			  "rbh" : 115024,
-			  "sbh" : 8627,
-			  "gas" : 1150240,
-			  "bpr" : 172536033,
-			  "sbpr" : 4313401,
-			  "min" : 0,
-			  "max" : 1000000000000000
-			}
-		  } ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "FileCreate",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 3657315129,
-				"bpt": 5846951,
-				"vpt": 14617377270,
-				"rbh": 3898,
-				"sbh": 292,
-				"gas": 38980,
-				"bpr": 5846951,
-				"sbpr": 146174,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 58517042062,
-				"bpt": 93551215,
-				"vpt": 233878036318,
-				"rbh": 62367,
-				"sbh": 4678,
-				"gas": 623675,
-				"bpr": 93551215,
-				"sbpr": 2338780,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 58517042062,
-				"bpt": 93551215,
-				"vpt": 233878036318,
-				"rbh": 62367,
-				"sbh": 4678,
-				"gas": 623675,
-				"bpr": 93551215,
-				"sbpr": 2338780,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "FileUpdate",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 3663140881,
-				"bpt": 5856265,
-				"vpt": 14640661348,
-				"rbh": 3904,
-				"sbh": 293,
-				"gas": 39042,
-				"bpr": 5856265,
-				"sbpr": 146407,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 58610254089,
-				"bpt": 93700233,
-				"vpt": 234250581567,
-				"rbh": 62467,
-				"sbh": 4685,
-				"gas": 624668,
-				"bpr": 93700233,
-				"sbpr": 2342506,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 58610254089,
-				"bpt": 93700233,
-				"vpt": 234250581567,
-				"rbh": 62467,
-				"sbh": 4685,
-				"gas": 624668,
-				"bpr": 93700233,
-				"sbpr": 2342506,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "FileDelete",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 664083202,
-				"bpt": 1061670,
-				"vpt": 2654175087,
-				"rbh": 708,
-				"sbh": 53,
-				"gas": 7078,
-				"bpr": 1061670,
-				"sbpr": 26542,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 10625331229,
-				"bpt": 16986721,
-				"vpt": 42466801390,
-				"rbh": 11324,
-				"sbh": 849,
-				"gas": 113245,
-				"bpr": 16986721,
-				"sbpr": 424668,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 10625331229,
-				"bpt": 16986721,
-				"vpt": 42466801390,
-				"rbh": 11324,
-				"sbh": 849,
-				"gas": 113245,
-				"bpr": 16986721,
-				"sbpr": 424668,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "FileAppend",
-		  "fees": [
-			{
-			  "subType": "DEFAULT",
-			  "nodedata": {
-				"constant": 2981423158,
-				"bpt": 4766402,
-				"vpt": 11916005477,
-				"rbh": 3178,
-				"sbh": 238,
-				"gas": 31776,
-				"bpr": 4766402,
-				"sbpr": 119160,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 59628463168,
-				"bpt": 95328044,
-				"vpt": 238320109546,
-				"rbh": 63552,
-				"sbh": 4766,
-				"gas": 635520,
-				"bpr": 95328044,
-				"sbpr": 2383201,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 59628463168,
-				"bpt": 95328044,
-				"vpt": 238320109546,
-				"rbh": 63552,
-				"sbh": 4766,
-				"gas": 635520,
-				"bpr": 95328044,
-				"sbpr": 2383201,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "FileGetContents",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 69308,
-				"bpt": 111,
-				"vpt": 277006,
-				"rbh": 0,
-				"sbh": 0,
-				"gas": 1,
-				"bpr": 111,
-				"sbpr": 3,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 1108924,
-				"bpt": 1773,
-				"vpt": 4432093,
-				"rbh": 1,
-				"sbh": 0,
-				"gas": 12,
-				"bpr": 1773,
-				"sbpr": 44,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 1108924,
-				"bpt": 1773,
-				"vpt": 4432093,
-				"rbh": 1,
-				"sbh": 0,
-				"gas": 12,
-				"bpr": 1773,
-				"sbpr": 44,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "FileGetInfo",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 71080,
-				"bpt": 114,
-				"vpt": 284088,
-				"rbh": 0,
-				"sbh": 0,
-				"gas": 1,
-				"bpr": 114,
-				"sbpr": 3,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 1137277,
-				"bpt": 1818,
-				"vpt": 4545413,
-				"rbh": 1,
-				"sbh": 0,
-				"gas": 12,
-				"bpr": 1818,
-				"sbpr": 45,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 1137277,
-				"bpt": 1818,
-				"vpt": 4545413,
-				"rbh": 1,
-				"sbh": 0,
-				"gas": 12,
-				"bpr": 1818,
-				"sbpr": 45,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "GetVersionInfo",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 6519421057,
-				"bpt": 10422601,
-				"vpt": 26056501507,
-				"rbh": 6948,
-				"sbh": 521,
-				"gas": 69484,
-				"bpr": 10422601,
-				"sbpr": 260565,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 104310736905,
-				"bpt": 166761610,
-				"vpt": 416904024105,
-				"rbh": 111174,
-				"sbh": 8338,
-				"gas": 1111744,
-				"bpr": 166761610,
-				"sbpr": 4169040,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 104310736905,
-				"bpt": 166761610,
-				"vpt": 416904024105,
-				"rbh": 111174,
-				"sbh": 8338,
-				"gas": 1111744,
-				"bpr": 166761610,
-				"sbpr": 4169040,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "GetByKey",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 1,
-				"bpt": 0,
-				"vpt": 0,
-				"rbh": 0,
-				"sbh": 0,
-				"gas": 0,
-				"bpr": 0,
-				"sbpr": 0,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 1,
-				"bpt": 0,
-				"vpt": 0,
-				"rbh": 0,
-				"sbh": 0,
-				"gas": 0,
-				"bpr": 0,
-				"sbpr": 0,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 1,
-				"bpt": 0,
-				"vpt": 0,
-				"rbh": 0,
-				"sbh": 0,
-				"gas": 0,
-				"bpr": 0,
-				"sbpr": 0,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "TransactionGetReceipt",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 1,
-				"bpt": 0,
-				"vpt": 0,
-				"rbh": 0,
-				"sbh": 0,
-				"gas": 0,
-				"bpr": 0,
-				"sbpr": 0,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 1,
-				"bpt": 0,
-				"vpt": 0,
-				"rbh": 0,
-				"sbh": 0,
-				"gas": 0,
-				"bpr": 0,
-				"sbpr": 0,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 1,
-				"bpt": 0,
-				"vpt": 0,
-				"rbh": 0,
-				"sbh": 0,
-				"gas": 0,
-				"bpr": 0,
-				"sbpr": 0,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "SystemDelete",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 0,
-				"bpt": 0,
-				"vpt": 0,
-				"rbh": 0,
-				"sbh": 0,
-				"gas": 0,
-				"bpr": 0,
-				"sbpr": 0,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 0,
-				"bpt": 0,
-				"vpt": 0,
-				"rbh": 0,
-				"sbh": 0,
-				"gas": 0,
-				"bpr": 0,
-				"sbpr": 0,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 0,
-				"bpt": 0,
-				"vpt": 0,
-				"rbh": 0,
-				"sbh": 0,
-				"gas": 0,
-				"bpr": 0,
-				"sbpr": 0,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "SystemUndelete",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 0,
-				"bpt": 0,
-				"vpt": 0,
-				"rbh": 0,
-				"sbh": 0,
-				"gas": 0,
-				"bpr": 0,
-				"sbpr": 0,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 0,
-				"bpt": 0,
-				"vpt": 0,
-				"rbh": 0,
-				"sbh": 0,
-				"gas": 0,
-				"bpr": 0,
-				"sbpr": 0,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 0,
-				"bpt": 0,
-				"vpt": 0,
-				"rbh": 0,
-				"sbh": 0,
-				"gas": 0,
-				"bpr": 0,
-				"sbpr": 0,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "TransactionGetRecord",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 54605,
-				"bpt": 87,
-				"vpt": 218244,
-				"rbh": 0,
-				"sbh": 0,
-				"gas": 1,
-				"bpr": 87,
-				"sbpr": 2,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 873685,
-				"bpt": 1397,
-				"vpt": 3491900,
-				"rbh": 1,
-				"sbh": 0,
-				"gas": 9,
-				"bpr": 1397,
-				"sbpr": 35,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 873685,
-				"bpt": 1397,
-				"vpt": 3491900,
-				"rbh": 1,
-				"sbh": 0,
-				"gas": 9,
-				"bpr": 1397,
-				"sbpr": 35,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"expiryTime": 1630800000
-	  }
-	]
+    "currentFeeSchedule": [
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "CryptoCreate",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 11461413665,
+                "bpt": 508982,
+                "vpt": 1272455960,
+                "rbh": 339,
+                "sbh": 25,
+                "gas": 3393,
+                "bpr": 508982,
+                "sbpr": 12725,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 229228273302,
+                "bpt": 10179648,
+                "vpt": 25449119198,
+                "rbh": 6786,
+                "sbh": 509,
+                "gas": 67864,
+                "bpr": 10179648,
+                "sbpr": 254491,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 229228273302,
+                "bpt": 10179648,
+                "vpt": 25449119198,
+                "rbh": 6786,
+                "sbh": 509,
+                "gas": 67864,
+                "bpr": 10179648,
+                "sbpr": 254491,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "CryptoDeleteAllowance",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 3794963556,
+                "bpt": 6067009,
+                "vpt": 15167523735,
+                "rbh": 4045,
+                "sbh": 303,
+                "gas": 40447,
+                "bpr": 6067009,
+                "sbpr": 151675,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 75899271121,
+                "bpt": 121340190,
+                "vpt": 303350474702,
+                "rbh": 80893,
+                "sbh": 6067,
+                "gas": 808935,
+                "bpr": 121340190,
+                "sbpr": 3033505,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 75899271121,
+                "bpt": 121340190,
+                "vpt": 303350474702,
+                "rbh": 80893,
+                "sbh": 6067,
+                "gas": 808935,
+                "bpr": 121340190,
+                "sbpr": 3033505,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "CryptoApproveAllowance",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 3766772044,
+                "bpt": 6021940,
+                "vpt": 15054849285,
+                "rbh": 4015,
+                "sbh": 301,
+                "gas": 40146,
+                "bpr": 6021940,
+                "sbpr": 150548,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 75335440874,
+                "bpt": 120438794,
+                "vpt": 301096985700,
+                "rbh": 80293,
+                "sbh": 6022,
+                "gas": 802925,
+                "bpr": 120438794,
+                "sbpr": 3010970,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 75335440874,
+                "bpt": 120438794,
+                "vpt": 301096985700,
+                "rbh": 80293,
+                "sbh": 6022,
+                "gas": 802925,
+                "bpr": 120438794,
+                "sbpr": 3010970,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "CryptoAccountAutoRenew",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 59972622,
+                "bpt": 95878,
+                "vpt": 239695625,
+                "rbh": 64,
+                "sbh": 5,
+                "gas": 639,
+                "bpr": 95878,
+                "sbpr": 2397,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 959561945,
+                "bpt": 1534052,
+                "vpt": 3835129999,
+                "rbh": 1023,
+                "sbh": 77,
+                "gas": 10227,
+                "bpr": 1534052,
+                "sbpr": 38351,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 959561945,
+                "bpt": 1534052,
+                "vpt": 3835129999,
+                "rbh": 1023,
+                "sbh": 77,
+                "gas": 10227,
+                "bpr": 1534052,
+                "sbpr": 38351,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "CryptoUpdate",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 16302371,
+                "bpt": 26063,
+                "vpt": 65156516,
+                "rbh": 17,
+                "sbh": 1,
+                "gas": 174,
+                "bpr": 26063,
+                "sbpr": 652,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 326047427,
+                "bpt": 521252,
+                "vpt": 1303130322,
+                "rbh": 348,
+                "sbh": 26,
+                "gas": 3475,
+                "bpr": 521252,
+                "sbpr": 13031,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 326047427,
+                "bpt": 521252,
+                "vpt": 1303130322,
+                "rbh": 348,
+                "sbh": 26,
+                "gas": 3475,
+                "bpr": 521252,
+                "sbpr": 13031,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "CryptoTransfer",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 7574478,
+                "bpt": 12109,
+                "vpt": 30273301,
+                "rbh": 8,
+                "sbh": 1,
+                "gas": 81,
+                "bpr": 12109,
+                "sbpr": 303,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 151489557,
+                "bpt": 242186,
+                "vpt": 605466012,
+                "rbh": 161,
+                "sbh": 12,
+                "gas": 1615,
+                "bpr": 242186,
+                "sbpr": 6055,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 151489557,
+                "bpt": 242186,
+                "vpt": 605466012,
+                "rbh": 161,
+                "sbh": 12,
+                "gas": 1615,
+                "bpr": 242186,
+                "sbpr": 6055,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            },
+            {
+              "subType": "TOKEN_FUNGIBLE_COMMON",
+              "nodedata": {
+                "constant": 7983519,
+                "bpt": 12763,
+                "vpt": 31908136,
+                "rbh": 9,
+                "sbh": 1,
+                "gas": 85,
+                "bpr": 12763,
+                "sbpr": 319,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 159670382,
+                "bpt": 255265,
+                "vpt": 638162730,
+                "rbh": 170,
+                "sbh": 13,
+                "gas": 1702,
+                "bpr": 255265,
+                "sbpr": 6382,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 159670382,
+                "bpt": 255265,
+                "vpt": 638162730,
+                "rbh": 170,
+                "sbh": 13,
+                "gas": 1702,
+                "bpr": 255265,
+                "sbpr": 6382,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            },
+            {
+              "subType": "TOKEN_FUNGIBLE_COMMON_WITH_CUSTOM_FEES",
+              "nodedata": {
+                "constant": 15967037,
+                "bpt": 25527,
+                "vpt": 63816270,
+                "rbh": 17,
+                "sbh": 1,
+                "gas": 170,
+                "bpr": 25527,
+                "sbpr": 638,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 319340747,
+                "bpt": 510530,
+                "vpt": 1276325394,
+                "rbh": 340,
+                "sbh": 26,
+                "gas": 3404,
+                "bpr": 510530,
+                "sbpr": 12763,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 319340747,
+                "bpt": 510530,
+                "vpt": 1276325394,
+                "rbh": 340,
+                "sbh": 26,
+                "gas": 3404,
+                "bpr": 510530,
+                "sbpr": 12763,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            },
+            {
+              "subType": "TOKEN_NON_FUNGIBLE_UNIQUE",
+              "nodedata": {
+                "constant": 22833842,
+                "bpt": 36504,
+                "vpt": 91261178,
+                "rbh": 24,
+                "sbh": 2,
+                "gas": 243,
+                "bpr": 36504,
+                "sbpr": 913,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 456676846,
+                "bpt": 730089,
+                "vpt": 1825223562,
+                "rbh": 487,
+                "sbh": 37,
+                "gas": 4867,
+                "bpr": 730089,
+                "sbpr": 18252,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 456676846,
+                "bpt": 730089,
+                "vpt": 1825223562,
+                "rbh": 487,
+                "sbh": 37,
+                "gas": 4867,
+                "bpr": 730089,
+                "sbpr": 18252,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            },
+            {
+              "subType": "TOKEN_NON_FUNGIBLE_UNIQUE_WITH_CUSTOM_FEES",
+              "nodedata": {
+                "constant": 45667678,
+                "bpt": 73009,
+                "vpt": 182522330,
+                "rbh": 49,
+                "sbh": 4,
+                "gas": 487,
+                "bpr": 73009,
+                "sbpr": 1825,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 913353558,
+                "bpt": 1460179,
+                "vpt": 3650446591,
+                "rbh": 973,
+                "sbh": 73,
+                "gas": 9735,
+                "bpr": 1460179,
+                "sbpr": 36504,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 913353558,
+                "bpt": 1460179,
+                "vpt": 3650446591,
+                "rbh": 973,
+                "sbh": 73,
+                "gas": 9735,
+                "bpr": 1460179,
+                "sbpr": 36504,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "CryptoDelete",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 471427939,
+                "bpt": 753672,
+                "vpt": 1884180005,
+                "rbh": 502,
+                "sbh": 38,
+                "gas": 5024,
+                "bpr": 753672,
+                "sbpr": 18842,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 7542847021,
+                "bpt": 12058752,
+                "vpt": 30146880078,
+                "rbh": 8039,
+                "sbh": 603,
+                "gas": 80392,
+                "bpr": 12058752,
+                "sbpr": 301469,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 7542847021,
+                "bpt": 12058752,
+                "vpt": 30146880078,
+                "rbh": 8039,
+                "sbh": 603,
+                "gas": 80392,
+                "bpr": 12058752,
+                "sbpr": 301469,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "CryptoAddLiveHash",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 5561692202,
+                "bpt": 8891479,
+                "vpt": 22228697914,
+                "rbh": 5928,
+                "sbh": 445,
+                "gas": 59277,
+                "bpr": 8891479,
+                "sbpr": 222287,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 88987075231,
+                "bpt": 142263667,
+                "vpt": 355659166619,
+                "rbh": 94842,
+                "sbh": 7113,
+                "gas": 948424,
+                "bpr": 142263667,
+                "sbpr": 3556592,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 88987075231,
+                "bpt": 142263667,
+                "vpt": 355659166619,
+                "rbh": 94842,
+                "sbh": 7113,
+                "gas": 948424,
+                "bpr": 142263667,
+                "sbpr": 3556592,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "CryptoDeleteLiveHash",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 468546396,
+                "bpt": 749065,
+                "vpt": 1872663195,
+                "rbh": 499,
+                "sbh": 37,
+                "gas": 4994,
+                "bpr": 749065,
+                "sbpr": 18727,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 7496742329,
+                "bpt": 11985044,
+                "vpt": 29962611113,
+                "rbh": 7990,
+                "sbh": 599,
+                "gas": 79900,
+                "bpr": 11985044,
+                "sbpr": 299626,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 7496742329,
+                "bpt": 11985044,
+                "vpt": 29962611113,
+                "rbh": 7990,
+                "sbh": 599,
+                "gas": 79900,
+                "bpr": 11985044,
+                "sbpr": 299626,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "CryptoGetLiveHash",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 58926,
+                "bpt": 94,
+                "vpt": 235514,
+                "rbh": 0,
+                "sbh": 0,
+                "gas": 1,
+                "bpr": 94,
+                "sbpr": 2,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 942822,
+                "bpt": 1507,
+                "vpt": 3768224,
+                "rbh": 1,
+                "sbh": 0,
+                "gas": 10,
+                "bpr": 1507,
+                "sbpr": 38,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 942822,
+                "bpt": 1507,
+                "vpt": 3768224,
+                "rbh": 1,
+                "sbh": 0,
+                "gas": 10,
+                "bpr": 1507,
+                "sbpr": 38,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "CryptoGetAccountRecords",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 22044,
+                "bpt": 35,
+                "vpt": 88105,
+                "rbh": 0,
+                "sbh": 0,
+                "gas": 0,
+                "bpr": 35,
+                "sbpr": 1,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 352708,
+                "bpt": 564,
+                "vpt": 1409688,
+                "rbh": 0,
+                "sbh": 0,
+                "gas": 4,
+                "bpr": 564,
+                "sbpr": 14,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 352708,
+                "bpt": 564,
+                "vpt": 1409688,
+                "rbh": 0,
+                "sbh": 0,
+                "gas": 4,
+                "bpr": 564,
+                "sbpr": 14,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "CryptoGetAccountBalance",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 68774,
+                "bpt": 110,
+                "vpt": 274874,
+                "rbh": 0,
+                "sbh": 0,
+                "gas": 1,
+                "bpr": 110,
+                "sbpr": 3,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 1100389,
+                "bpt": 1759,
+                "vpt": 4397982,
+                "rbh": 1,
+                "sbh": 0,
+                "gas": 12,
+                "bpr": 1759,
+                "sbpr": 44,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 1100389,
+                "bpt": 1759,
+                "vpt": 4397982,
+                "rbh": 1,
+                "sbh": 0,
+                "gas": 12,
+                "bpr": 1759,
+                "sbpr": 44,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "CryptoGetInfo",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 63990,
+                "bpt": 102,
+                "vpt": 255752,
+                "rbh": 0,
+                "sbh": 0,
+                "gas": 1,
+                "bpr": 102,
+                "sbpr": 3,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 1023841,
+                "bpt": 1637,
+                "vpt": 4092038,
+                "rbh": 1,
+                "sbh": 0,
+                "gas": 11,
+                "bpr": 1637,
+                "sbpr": 41,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 1023841,
+                "bpt": 1637,
+                "vpt": 4092038,
+                "rbh": 1,
+                "sbh": 0,
+                "gas": 11,
+                "bpr": 1637,
+                "sbpr": 41,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "CryptoGetStakers",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 15251,
+                "bpt": 24,
+                "vpt": 60953,
+                "rbh": 0,
+                "sbh": 0,
+                "gas": 0,
+                "bpr": 24,
+                "sbpr": 1,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 244011,
+                "bpt": 390,
+                "vpt": 975251,
+                "rbh": 0,
+                "sbh": 0,
+                "gas": 3,
+                "bpr": 390,
+                "sbpr": 10,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 244011,
+                "bpt": 390,
+                "vpt": 975251,
+                "rbh": 0,
+                "sbh": 0,
+                "gas": 3,
+                "bpr": 390,
+                "sbpr": 10,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "ConsensusCreateTopic",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 921577366,
+                "bpt": 1473326,
+                "vpt": 3683315100,
+                "rbh": 982,
+                "sbh": 74,
+                "gas": 9822,
+                "bpr": 1473326,
+                "sbpr": 36833,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 14745237852,
+                "bpt": 23573217,
+                "vpt": 58933041595,
+                "rbh": 15715,
+                "sbh": 1179,
+                "gas": 157155,
+                "bpr": 23573217,
+                "sbpr": 589330,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 14745237852,
+                "bpt": 23573217,
+                "vpt": 58933041595,
+                "rbh": 15715,
+                "sbh": 1179,
+                "gas": 157155,
+                "bpr": 23573217,
+                "sbpr": 589330,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "ConsensusUpdateTopic",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 20193780,
+                "bpt": 32284,
+                "vpt": 80709508,
+                "rbh": 22,
+                "sbh": 2,
+                "gas": 215,
+                "bpr": 32284,
+                "sbpr": 807,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 323100486,
+                "bpt": 516541,
+                "vpt": 1291352134,
+                "rbh": 344,
+                "sbh": 26,
+                "gas": 3444,
+                "bpr": 516541,
+                "sbpr": 12914,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 323100486,
+                "bpt": 516541,
+                "vpt": 1291352134,
+                "rbh": 344,
+                "sbh": 26,
+                "gas": 3444,
+                "bpr": 516541,
+                "sbpr": 12914,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "ConsensusDeleteTopic",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 474345144,
+                "bpt": 758336,
+                "vpt": 1895839348,
+                "rbh": 506,
+                "sbh": 38,
+                "gas": 5056,
+                "bpr": 758336,
+                "sbpr": 18958,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 7589522307,
+                "bpt": 12133372,
+                "vpt": 30333429564,
+                "rbh": 8089,
+                "sbh": 607,
+                "gas": 80889,
+                "bpr": 12133372,
+                "sbpr": 303334,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 7589522307,
+                "bpt": 12133372,
+                "vpt": 30333429564,
+                "rbh": 8089,
+                "sbh": 607,
+                "gas": 80889,
+                "bpr": 12133372,
+                "sbpr": 303334,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "ConsensusSubmitMessage",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 9248442,
+                "bpt": 14785,
+                "vpt": 36963719,
+                "rbh": 10,
+                "sbh": 1,
+                "gas": 99,
+                "bpr": 14785,
+                "sbpr": 370,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 147975076,
+                "bpt": 236568,
+                "vpt": 591419509,
+                "rbh": 158,
+                "sbh": 12,
+                "gas": 1577,
+                "bpr": 236568,
+                "sbpr": 5914,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 147975076,
+                "bpt": 236568,
+                "vpt": 591419509,
+                "rbh": 158,
+                "sbh": 12,
+                "gas": 1577,
+                "bpr": 236568,
+                "sbpr": 5914,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "ConsensusGetTopicInfo",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 64253,
+                "bpt": 103,
+                "vpt": 256803,
+                "rbh": 0,
+                "sbh": 0,
+                "gas": 1,
+                "bpr": 103,
+                "sbpr": 3,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 1028048,
+                "bpt": 1644,
+                "vpt": 4108851,
+                "rbh": 1,
+                "sbh": 0,
+                "gas": 11,
+                "bpr": 1644,
+                "sbpr": 41,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 1028048,
+                "bpt": 1644,
+                "vpt": 4108851,
+                "rbh": 1,
+                "sbh": 0,
+                "gas": 11,
+                "bpr": 1644,
+                "sbpr": 41,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "TokenCreate",
+          "fees": [
+            {
+              "subType": "TOKEN_FUNGIBLE_COMMON_WITH_CUSTOM_FEES",
+              "nodedata": {
+                "constant": 393746195920,
+                "bpt": 17485616,
+                "vpt": 43714039850,
+                "rbh": 11657,
+                "sbh": 874,
+                "gas": 116571,
+                "bpr": 17485616,
+                "sbpr": 437140,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 7874923918408,
+                "bpt": 349712319,
+                "vpt": 874280797002,
+                "rbh": 233142,
+                "sbh": 17486,
+                "gas": 2331415,
+                "bpr": 349712319,
+                "sbpr": 8742808,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 7874923918408,
+                "bpt": 349712319,
+                "vpt": 874280797002,
+                "rbh": 233142,
+                "sbh": 17486,
+                "gas": 2331415,
+                "bpr": 349712319,
+                "sbpr": 8742808,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            },
+            {
+              "subType": "TOKEN_FUNGIBLE_COMMON",
+              "nodedata": {
+                "constant": 197306974233,
+                "bpt": 8762076,
+                "vpt": 21905189240,
+                "rbh": 5841,
+                "sbh": 438,
+                "gas": 58414,
+                "bpr": 8762076,
+                "sbpr": 219052,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 3946139484654,
+                "bpt": 175241514,
+                "vpt": 438103784807,
+                "rbh": 116828,
+                "sbh": 8762,
+                "gas": 1168277,
+                "bpr": 175241514,
+                "sbpr": 4381038,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 3946139484654,
+                "bpt": 175241514,
+                "vpt": 438103784807,
+                "rbh": 116828,
+                "sbh": 8762,
+                "gas": 1168277,
+                "bpr": 175241514,
+                "sbpr": 4381038,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            },
+            {
+              "subType": "TOKEN_NON_FUNGIBLE_UNIQUE",
+              "nodedata": {
+                "constant": 197031853851,
+                "bpt": 8749858,
+                "vpt": 21874645140,
+                "rbh": 5833,
+                "sbh": 437,
+                "gas": 58332,
+                "bpr": 8749858,
+                "sbpr": 218746,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 3940637077020,
+                "bpt": 174997161,
+                "vpt": 437492902800,
+                "rbh": 116665,
+                "sbh": 8750,
+                "gas": 1166648,
+                "bpr": 174997161,
+                "sbpr": 4374929,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 3940637077020,
+                "bpt": 174997161,
+                "vpt": 437492902800,
+                "rbh": 116665,
+                "sbh": 8750,
+                "gas": 1166648,
+                "bpr": 174997161,
+                "sbpr": 4374929,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            },
+            {
+              "subType": "TOKEN_NON_FUNGIBLE_UNIQUE_WITH_CUSTOM_FEES",
+              "nodedata": {
+                "constant": 393198370765,
+                "bpt": 17461288,
+                "vpt": 43653219832,
+                "rbh": 11641,
+                "sbh": 873,
+                "gas": 116409,
+                "bpr": 17461288,
+                "sbpr": 436532,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 7863967415309,
+                "bpt": 349225759,
+                "vpt": 873064396645,
+                "rbh": 232817,
+                "sbh": 17461,
+                "gas": 2328172,
+                "bpr": 349225759,
+                "sbpr": 8730644,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 7863967415309,
+                "bpt": 349225759,
+                "vpt": 873064396645,
+                "rbh": 232817,
+                "sbh": 17461,
+                "gas": 2328172,
+                "bpr": 349225759,
+                "sbpr": 8730644,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "TokenDelete",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 94285588,
+                "bpt": 150734,
+                "vpt": 376836001,
+                "rbh": 100,
+                "sbh": 8,
+                "gas": 1005,
+                "bpr": 150734,
+                "sbpr": 3768,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 1508569404,
+                "bpt": 2411750,
+                "vpt": 6029376016,
+                "rbh": 1608,
+                "sbh": 121,
+                "gas": 16078,
+                "bpr": 2411750,
+                "sbpr": 60294,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 1508569404,
+                "bpt": 2411750,
+                "vpt": 6029376016,
+                "rbh": 1608,
+                "sbh": 121,
+                "gas": 16078,
+                "bpr": 2411750,
+                "sbpr": 60294,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "TokenFeeScheduleUpdate",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 73998596,
+                "bpt": 118302,
+                "vpt": 295753948,
+                "rbh": 79,
+                "sbh": 6,
+                "gas": 789,
+                "bpr": 118302,
+                "sbpr": 2958,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 1479971913,
+                "bpt": 2366032,
+                "vpt": 5915078967,
+                "rbh": 1577,
+                "sbh": 118,
+                "gas": 15774,
+                "bpr": 2366032,
+                "sbpr": 59151,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 1479971913,
+                "bpt": 2366032,
+                "vpt": 5915078967,
+                "rbh": 1577,
+                "sbh": 118,
+                "gas": 15774,
+                "bpr": 2366032,
+                "sbpr": 59151,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "TokenUpdate",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 93900697,
+                "bpt": 150119,
+                "vpt": 375297688,
+                "rbh": 100,
+                "sbh": 8,
+                "gas": 1001,
+                "bpr": 150119,
+                "sbpr": 3753,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 1502411149,
+                "bpt": 2401905,
+                "vpt": 6004763005,
+                "rbh": 1601,
+                "sbh": 120,
+                "gas": 16013,
+                "bpr": 2401905,
+                "sbpr": 60048,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 1502411149,
+                "bpt": 2401905,
+                "vpt": 6004763005,
+                "rbh": 1601,
+                "sbh": 120,
+                "gas": 16013,
+                "bpr": 2401905,
+                "sbpr": 60048,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "TokenMint",
+          "fees": [
+            {
+              "subType": "TOKEN_FUNGIBLE_COMMON",
+              "nodedata": {
+                "constant": 94092119,
+                "bpt": 150425,
+                "vpt": 376062755,
+                "rbh": 100,
+                "sbh": 8,
+                "gas": 1003,
+                "bpr": 150425,
+                "sbpr": 3761,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 1505473906,
+                "bpt": 2406802,
+                "vpt": 6017004081,
+                "rbh": 1605,
+                "sbh": 120,
+                "gas": 16045,
+                "bpr": 2406802,
+                "sbpr": 60170,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 1505473906,
+                "bpt": 2406802,
+                "vpt": 6017004081,
+                "rbh": 1605,
+                "sbh": 120,
+                "gas": 16045,
+                "bpr": 2406802,
+                "sbpr": 60170,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            },
+            {
+              "subType": "TOKEN_NON_FUNGIBLE_UNIQUE",
+              "nodedata": {
+                "constant": 3606440483,
+                "bpt": 5765618,
+                "vpt": 14414043986,
+                "rbh": 3844,
+                "sbh": 288,
+                "gas": 38437,
+                "bpr": 5765618,
+                "sbpr": 144140,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 72128809656,
+                "bpt": 115312352,
+                "vpt": 288280879722,
+                "rbh": 76875,
+                "sbh": 5766,
+                "gas": 768749,
+                "bpr": 115312352,
+                "sbpr": 2882809,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 72128809656,
+                "bpt": 115312352,
+                "vpt": 288280879722,
+                "rbh": 76875,
+                "sbh": 5766,
+                "gas": 768749,
+                "bpr": 115312352,
+                "sbpr": 2882809,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "TokenBurn",
+          "fees": [
+            {
+              "subType": "TOKEN_FUNGIBLE_COMMON",
+              "nodedata": {
+                "constant": 94092119,
+                "bpt": 150425,
+                "vpt": 376062755,
+                "rbh": 100,
+                "sbh": 8,
+                "gas": 1003,
+                "bpr": 150425,
+                "sbpr": 3761,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 1505473906,
+                "bpt": 2406802,
+                "vpt": 6017004081,
+                "rbh": 1605,
+                "sbh": 120,
+                "gas": 16045,
+                "bpr": 2406802,
+                "sbpr": 60170,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 1505473906,
+                "bpt": 2406802,
+                "vpt": 6017004081,
+                "rbh": 1605,
+                "sbh": 120,
+                "gas": 16045,
+                "bpr": 2406802,
+                "sbpr": 60170,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            },
+            {
+              "subType": "TOKEN_NON_FUNGIBLE_UNIQUE",
+              "nodedata": {
+                "constant": 76366243,
+                "bpt": 122087,
+                "vpt": 305216845,
+                "rbh": 81,
+                "sbh": 6,
+                "gas": 814,
+                "bpr": 122087,
+                "sbpr": 3052,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 1527324859,
+                "bpt": 2441735,
+                "vpt": 6104336894,
+                "rbh": 1628,
+                "sbh": 122,
+                "gas": 16278,
+                "bpr": 2441735,
+                "sbpr": 61043,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 1527324859,
+                "bpt": 2441735,
+                "vpt": 6104336894,
+                "rbh": 1628,
+                "sbh": 122,
+                "gas": 16278,
+                "bpr": 2441735,
+                "sbpr": 61043,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "TokenAssociateToAccount",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 4574479485,
+                "bpt": 7313222,
+                "vpt": 18283054670,
+                "rbh": 4875,
+                "sbh": 366,
+                "gas": 48755,
+                "bpr": 7313222,
+                "sbpr": 182831,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 73191671761,
+                "bpt": 117011550,
+                "vpt": 292528874720,
+                "rbh": 78008,
+                "sbh": 5851,
+                "gas": 780077,
+                "bpr": 117011550,
+                "sbpr": 2925289,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 73191671761,
+                "bpt": 117011550,
+                "vpt": 292528874720,
+                "rbh": 78008,
+                "sbh": 5851,
+                "gas": 780077,
+                "bpr": 117011550,
+                "sbpr": 2925289,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "TokenDissociateFromAccount",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 4714279388,
+                "bpt": 7536720,
+                "vpt": 18841800049,
+                "rbh": 5024,
+                "sbh": 377,
+                "gas": 50245,
+                "bpr": 7536720,
+                "sbpr": 188418,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 75428470213,
+                "bpt": 120587520,
+                "vpt": 301468800784,
+                "rbh": 80392,
+                "sbh": 6029,
+                "gas": 803917,
+                "bpr": 120587520,
+                "sbpr": 3014688,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 75428470213,
+                "bpt": 120587520,
+                "vpt": 301468800784,
+                "rbh": 80392,
+                "sbh": 6029,
+                "gas": 803917,
+                "bpr": 120587520,
+                "sbpr": 3014688,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "TokenGrantKycToAccount",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 94285551,
+                "bpt": 150734,
+                "vpt": 376835856,
+                "rbh": 100,
+                "sbh": 8,
+                "gas": 1005,
+                "bpr": 150734,
+                "sbpr": 3768,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 1508568822,
+                "bpt": 2411749,
+                "vpt": 6029373689,
+                "rbh": 1608,
+                "sbh": 121,
+                "gas": 16078,
+                "bpr": 2411749,
+                "sbpr": 60294,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 1508568822,
+                "bpt": 2411749,
+                "vpt": 6029373689,
+                "rbh": 1608,
+                "sbh": 121,
+                "gas": 16078,
+                "bpr": 2411749,
+                "sbpr": 60294,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "TokenRevokeKycFromAccount",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 94285551,
+                "bpt": 150734,
+                "vpt": 376835856,
+                "rbh": 100,
+                "sbh": 8,
+                "gas": 1005,
+                "bpr": 150734,
+                "sbpr": 3768,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 1508568822,
+                "bpt": 2411749,
+                "vpt": 6029373689,
+                "rbh": 1608,
+                "sbh": 121,
+                "gas": 16078,
+                "bpr": 2411749,
+                "sbpr": 60294,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 1508568822,
+                "bpt": 2411749,
+                "vpt": 6029373689,
+                "rbh": 1608,
+                "sbh": 121,
+                "gas": 16078,
+                "bpr": 2411749,
+                "sbpr": 60294,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "TokenFreezeAccount",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 76054309,
+                "bpt": 121588,
+                "vpt": 303970122,
+                "rbh": 81,
+                "sbh": 6,
+                "gas": 811,
+                "bpr": 121588,
+                "sbpr": 3040,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 1521086180,
+                "bpt": 2431761,
+                "vpt": 6079402448,
+                "rbh": 1621,
+                "sbh": 122,
+                "gas": 16212,
+                "bpr": 2431761,
+                "sbpr": 60794,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 1521086180,
+                "bpt": 2431761,
+                "vpt": 6079402448,
+                "rbh": 1621,
+                "sbh": 122,
+                "gas": 16212,
+                "bpr": 2431761,
+                "sbpr": 60794,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "TokenUnfreezeAccount",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 76054309,
+                "bpt": 121588,
+                "vpt": 303970122,
+                "rbh": 81,
+                "sbh": 6,
+                "gas": 811,
+                "bpr": 121588,
+                "sbpr": 3040,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 1521086180,
+                "bpt": 2431761,
+                "vpt": 6079402448,
+                "rbh": 1621,
+                "sbh": 122,
+                "gas": 16212,
+                "bpr": 2431761,
+                "sbpr": 60794,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 1521086180,
+                "bpt": 2431761,
+                "vpt": 6079402448,
+                "rbh": 1621,
+                "sbh": 122,
+                "gas": 16212,
+                "bpr": 2431761,
+                "sbpr": 60794,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "TokenPause",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 76523246,
+                "bpt": 122338,
+                "vpt": 305844348,
+                "rbh": 82,
+                "sbh": 6,
+                "gas": 816,
+                "bpr": 122338,
+                "sbpr": 3058,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 1530464926,
+                "bpt": 2446755,
+                "vpt": 6116886962,
+                "rbh": 1631,
+                "sbh": 122,
+                "gas": 16312,
+                "bpr": 2446755,
+                "sbpr": 61169,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 1530464926,
+                "bpt": 2446755,
+                "vpt": 6116886962,
+                "rbh": 1631,
+                "sbh": 122,
+                "gas": 16312,
+                "bpr": 2446755,
+                "sbpr": 61169,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "TokenUnpause",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 76523246,
+                "bpt": 122338,
+                "vpt": 305844348,
+                "rbh": 82,
+                "sbh": 6,
+                "gas": 816,
+                "bpr": 122338,
+                "sbpr": 3058,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 1530464926,
+                "bpt": 2446755,
+                "vpt": 6116886962,
+                "rbh": 1631,
+                "sbh": 122,
+                "gas": 16312,
+                "bpr": 2446755,
+                "sbpr": 61169,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 1530464926,
+                "bpt": 2446755,
+                "vpt": 6116886962,
+                "rbh": 1631,
+                "sbh": 122,
+                "gas": 16312,
+                "bpr": 2446755,
+                "sbpr": 61169,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "TokenAccountWipe",
+          "fees": [
+            {
+              "subType": "TOKEN_FUNGIBLE_COMMON",
+              "nodedata": {
+                "constant": 94092119,
+                "bpt": 150425,
+                "vpt": 376062755,
+                "rbh": 100,
+                "sbh": 8,
+                "gas": 1003,
+                "bpr": 150425,
+                "sbpr": 3761,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 1505473906,
+                "bpt": 2406802,
+                "vpt": 6017004081,
+                "rbh": 1605,
+                "sbh": 120,
+                "gas": 16045,
+                "bpr": 2406802,
+                "sbpr": 60170,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 1505473906,
+                "bpt": 2406802,
+                "vpt": 6017004081,
+                "rbh": 1605,
+                "sbh": 120,
+                "gas": 16045,
+                "bpr": 2406802,
+                "sbpr": 60170,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            },
+            {
+              "subType": "TOKEN_NON_FUNGIBLE_UNIQUE",
+              "nodedata": {
+                "constant": 76366243,
+                "bpt": 122087,
+                "vpt": 305216845,
+                "rbh": 81,
+                "sbh": 6,
+                "gas": 814,
+                "bpr": 122087,
+                "sbpr": 3052,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 1527324859,
+                "bpt": 2441735,
+                "vpt": 6104336894,
+                "rbh": 1628,
+                "sbh": 122,
+                "gas": 16278,
+                "bpr": 2441735,
+                "sbpr": 61043,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 1527324859,
+                "bpt": 2441735,
+                "vpt": 6104336894,
+                "rbh": 1628,
+                "sbh": 122,
+                "gas": 16278,
+                "bpr": 2441735,
+                "sbpr": 61043,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "TokenGetInfo",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 61717,
+                "bpt": 99,
+                "vpt": 246668,
+                "rbh": 0,
+                "sbh": 0,
+                "gas": 1,
+                "bpr": 99,
+                "sbpr": 2,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 987474,
+                "bpt": 1579,
+                "vpt": 3946688,
+                "rbh": 1,
+                "sbh": 0,
+                "gas": 11,
+                "bpr": 1579,
+                "sbpr": 39,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 987474,
+                "bpt": 1579,
+                "vpt": 3946688,
+                "rbh": 1,
+                "sbh": 0,
+                "gas": 11,
+                "bpr": 1579,
+                "sbpr": 39,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "TokenGetNftInfo",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 54605,
+                "bpt": 87,
+                "vpt": 218244,
+                "rbh": 0,
+                "sbh": 0,
+                "gas": 1,
+                "bpr": 87,
+                "sbpr": 2,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 0,
+                "bpt": 0,
+                "vpt": 0,
+                "rbh": 0,
+                "sbh": 0,
+                "gas": 0,
+                "bpr": 0,
+                "sbpr": 0,
+                "min": 0,
+                "max": 0
+              },
+              "servicedata": {
+                "constant": 0,
+                "bpt": 0,
+                "vpt": 0,
+                "rbh": 0,
+                "sbh": 0,
+                "gas": 0,
+                "bpr": 0,
+                "sbpr": 0,
+                "min": 0,
+                "max": 0
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "ScheduleCreate",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 563513000,
+                "bpt": 900888,
+                "vpt": 2252221049,
+                "rbh": 601,
+                "sbh": 45,
+                "gas": 6006,
+                "bpr": 900888,
+                "sbpr": 22522,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 9016208000,
+                "bpt": 14414215,
+                "vpt": 36035536788,
+                "rbh": 9609,
+                "sbh": 721,
+                "gas": 96095,
+                "bpr": 14414215,
+                "sbpr": 360355,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 9016208000,
+                "bpt": 14414215,
+                "vpt": 36035536788,
+                "rbh": 9609,
+                "sbh": 721,
+                "gas": 96095,
+                "bpr": 14414215,
+                "sbpr": 360355,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "ScheduleSign",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 58040915,
+                "bpt": 92790,
+                "vpt": 231975077,
+                "rbh": 62,
+                "sbh": 5,
+                "gas": 619,
+                "bpr": 92790,
+                "sbpr": 2320,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 928654648,
+                "bpt": 1484640,
+                "vpt": 3711601232,
+                "rbh": 990,
+                "sbh": 74,
+                "gas": 9898,
+                "bpr": 1484640,
+                "sbpr": 37116,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 928654648,
+                "bpt": 1484640,
+                "vpt": 3711601232,
+                "rbh": 990,
+                "sbh": 74,
+                "gas": 9898,
+                "bpr": 1484640,
+                "sbpr": 37116,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "ScheduleDelete",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 95360774,
+                "bpt": 152453,
+                "vpt": 381133253,
+                "rbh": 102,
+                "sbh": 8,
+                "gas": 1016,
+                "bpr": 152453,
+                "sbpr": 3811,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 1525772386,
+                "bpt": 2439253,
+                "vpt": 6098132047,
+                "rbh": 1626,
+                "sbh": 122,
+                "gas": 16262,
+                "bpr": 2439253,
+                "sbpr": 60981,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 1525772386,
+                "bpt": 2439253,
+                "vpt": 6098132047,
+                "rbh": 1626,
+                "sbh": 122,
+                "gas": 16262,
+                "bpr": 2439253,
+                "sbpr": 60981,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "ScheduleGetInfo",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 53393,
+                "bpt": 85,
+                "vpt": 213400,
+                "rbh": 0,
+                "sbh": 0,
+                "gas": 1,
+                "bpr": 85,
+                "sbpr": 2,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 854295,
+                "bpt": 1366,
+                "vpt": 3414402,
+                "rbh": 1,
+                "sbh": 0,
+                "gas": 9,
+                "bpr": 1366,
+                "sbpr": 34,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 854295,
+                "bpt": 1366,
+                "vpt": 3414402,
+                "rbh": 1,
+                "sbh": 0,
+                "gas": 9,
+                "bpr": 1366,
+                "sbpr": 34,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "ContractCreate",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 45218052173,
+                "bpt": 72290115,
+                "vpt": 180725287466,
+                "rbh": 48193,
+                "sbh": 3615,
+                "gas": 852000,
+                "bpr": 72290115,
+                "sbpr": 1807253,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 723488834765,
+                "bpt": 1156641840,
+                "vpt": 2891604599463,
+                "rbh": 771095,
+                "sbh": 57832,
+                "gas": 852000,
+                "bpr": 1156641840,
+                "sbpr": 28916046,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 0,
+                "bpt": 0,
+                "vpt": 0,
+                "rbh": 0,
+                "sbh": 0,
+                "gas": 852000,
+                "bpr": 0,
+                "sbpr": 0,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "ContractUpdate",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 2438037058,
+                "bpt": 3897691,
+                "vpt": 9744226629,
+                "rbh": 2598,
+                "sbh": 195,
+                "gas": 25985,
+                "bpr": 3897691,
+                "sbpr": 97442,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 39008592923,
+                "bpt": 62363050,
+                "vpt": 155907626067,
+                "rbh": 41575,
+                "sbh": 3118,
+                "gas": 415754,
+                "bpr": 62363050,
+                "sbpr": 1559076,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 39008592923,
+                "bpt": 62363050,
+                "vpt": 155907626067,
+                "rbh": 41575,
+                "sbh": 3118,
+                "gas": 415754,
+                "bpr": 62363050,
+                "sbpr": 1559076,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "ContractDelete",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 664083202,
+                "bpt": 1061670,
+                "vpt": 2654175087,
+                "rbh": 708,
+                "sbh": 53,
+                "gas": 7078,
+                "bpr": 1061670,
+                "sbpr": 26542,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 10625331229,
+                "bpt": 16986721,
+                "vpt": 42466801390,
+                "rbh": 11324,
+                "sbh": 849,
+                "gas": 113245,
+                "bpr": 16986721,
+                "sbpr": 424668,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 10625331229,
+                "bpt": 16986721,
+                "vpt": 42466801390,
+                "rbh": 11324,
+                "sbh": 849,
+                "gas": 113245,
+                "bpr": 16986721,
+                "sbpr": 424668,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "ContractCall",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 0,
+                "bpt": 0,
+                "vpt": 0,
+                "rbh": 0,
+                "sbh": 0,
+                "gas": 0,
+                "bpr": 0,
+                "sbpr": 0,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 0,
+                "bpt": 0,
+                "vpt": 0,
+                "rbh": 0,
+                "sbh": 0,
+                "gas": 0,
+                "bpr": 0,
+                "sbpr": 0,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 0,
+                "bpt": 0,
+                "vpt": 0,
+                "rbh": 0,
+                "sbh": 0,
+                "gas": 852000,
+                "bpr": 0,
+                "sbpr": 0,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "EthereumTransaction",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 3336515210,
+                "bpt": 5334088,
+                "vpt": 13335219927,
+                "rbh": 3556,
+                "sbh": 267,
+                "gas": 0,
+                "bpr": 5334088,
+                "sbpr": 133352,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 53384243355,
+                "bpt": 85345408,
+                "vpt": 213363518838,
+                "rbh": 56897,
+                "sbh": 4267,
+                "gas": 0,
+                "bpr": 85345408,
+                "sbpr": 2133635,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 0,
+                "bpt": 0,
+                "vpt": 0,
+                "rbh": 0,
+                "sbh": 0,
+                "gas": 852000,
+                "bpr": 0,
+                "sbpr": 0,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "ContractGetInfo",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 71015,
+                "bpt": 114,
+                "vpt": 283830,
+                "rbh": 0,
+                "sbh": 0,
+                "gas": 1,
+                "bpr": 114,
+                "sbpr": 3,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 1136244,
+                "bpt": 1817,
+                "vpt": 4541284,
+                "rbh": 1,
+                "sbh": 0,
+                "gas": 12,
+                "bpr": 1817,
+                "sbpr": 45,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 1136244,
+                "bpt": 1817,
+                "vpt": 4541284,
+                "rbh": 1,
+                "sbh": 0,
+                "gas": 12,
+                "bpr": 1817,
+                "sbpr": 45,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "ContractCallLocal",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 2610100486,
+                "bpt": 4172769,
+                "vpt": 10431921279,
+                "rbh": 2782,
+                "sbh": 209,
+                "gas": 852000,
+                "bpr": 4172769,
+                "sbpr": 104319,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 41761607776,
+                "bpt": 66764296,
+                "vpt": 166910740461,
+                "rbh": 44510,
+                "sbh": 3338,
+                "gas": 852000,
+                "bpr": 66764296,
+                "sbpr": 1669107,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 41761607776,
+                "bpt": 66764296,
+                "vpt": 166910740461,
+                "rbh": 44510,
+                "sbh": 3338,
+                "gas": 852000,
+                "bpr": 66764296,
+                "sbpr": 1669107,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "ContractGetBytecode",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 226589259813,
+                "bpt": 362248325,
+                "vpt": 905620811793,
+                "rbh": 241499,
+                "sbh": 18112,
+                "gas": 2414989,
+                "bpr": 362248325,
+                "sbpr": 9056208,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 3625428157003,
+                "bpt": 5795973195,
+                "vpt": 14489932988688,
+                "rbh": 3863982,
+                "sbh": 289799,
+                "gas": 38639821,
+                "bpr": 5795973195,
+                "sbpr": 144899330,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 3625428157003,
+                "bpt": 5795973195,
+                "vpt": 14489932988688,
+                "rbh": 3863982,
+                "sbh": 289799,
+                "gas": 38639821,
+                "bpr": 5795973195,
+                "sbpr": 144899330,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "GetBySolidityID",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 69385,
+                "bpt": 111,
+                "vpt": 277313,
+                "rbh": 0,
+                "sbh": 0,
+                "gas": 1,
+                "bpr": 111,
+                "sbpr": 3,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 1110154,
+                "bpt": 1775,
+                "vpt": 4437010,
+                "rbh": 1,
+                "sbh": 0,
+                "gas": 12,
+                "bpr": 1775,
+                "sbpr": 44,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 1110154,
+                "bpt": 1775,
+                "vpt": 4437010,
+                "rbh": 1,
+                "sbh": 0,
+                "gas": 12,
+                "bpr": 1775,
+                "sbpr": 44,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "ContractGetRecords",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 10093,
+                "bpt": 16,
+                "vpt": 40339,
+                "rbh": 0,
+                "sbh": 0,
+                "gas": 0,
+                "bpr": 16,
+                "sbpr": 0,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 161486,
+                "bpt": 258,
+                "vpt": 645421,
+                "rbh": 0,
+                "sbh": 0,
+                "gas": 2,
+                "bpr": 258,
+                "sbpr": 6,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 161486,
+                "bpt": 258,
+                "vpt": 645421,
+                "rbh": 0,
+                "sbh": 0,
+                "gas": 2,
+                "bpr": 258,
+                "sbpr": 6,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "ContractAutoRenew",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 3399972997,
+                "bpt": 5435538,
+                "vpt": 13588844891,
+                "rbh": 3624,
+                "sbh": 272,
+                "gas": 36237,
+                "bpr": 5435538,
+                "sbpr": 135888,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 67999459941,
+                "bpt": 108710759,
+                "vpt": 271776897828,
+                "rbh": 72474,
+                "sbh": 5436,
+                "gas": 724738,
+                "bpr": 108710759,
+                "sbpr": 2717769,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 67999459941,
+                "bpt": 108710759,
+                "vpt": 271776897828,
+                "rbh": 72474,
+                "sbh": 5436,
+                "gas": 724738,
+                "bpr": 108710759,
+                "sbpr": 2717769,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "FileCreate",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 3657315129,
+                "bpt": 5846951,
+                "vpt": 14617377270,
+                "rbh": 3898,
+                "sbh": 292,
+                "gas": 38980,
+                "bpr": 5846951,
+                "sbpr": 146174,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 58517042062,
+                "bpt": 93551215,
+                "vpt": 233878036318,
+                "rbh": 62367,
+                "sbh": 4678,
+                "gas": 623675,
+                "bpr": 93551215,
+                "sbpr": 2338780,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 58517042062,
+                "bpt": 93551215,
+                "vpt": 233878036318,
+                "rbh": 62367,
+                "sbh": 4678,
+                "gas": 623675,
+                "bpr": 93551215,
+                "sbpr": 2338780,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "FileUpdate",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 3663140881,
+                "bpt": 5856265,
+                "vpt": 14640661348,
+                "rbh": 3904,
+                "sbh": 293,
+                "gas": 39042,
+                "bpr": 5856265,
+                "sbpr": 146407,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 58610254089,
+                "bpt": 93700233,
+                "vpt": 234250581567,
+                "rbh": 62467,
+                "sbh": 4685,
+                "gas": 624668,
+                "bpr": 93700233,
+                "sbpr": 2342506,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 58610254089,
+                "bpt": 93700233,
+                "vpt": 234250581567,
+                "rbh": 62467,
+                "sbh": 4685,
+                "gas": 624668,
+                "bpr": 93700233,
+                "sbpr": 2342506,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "FileDelete",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 664083202,
+                "bpt": 1061670,
+                "vpt": 2654175087,
+                "rbh": 708,
+                "sbh": 53,
+                "gas": 7078,
+                "bpr": 1061670,
+                "sbpr": 26542,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 10625331229,
+                "bpt": 16986721,
+                "vpt": 42466801390,
+                "rbh": 11324,
+                "sbh": 849,
+                "gas": 113245,
+                "bpr": 16986721,
+                "sbpr": 424668,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 10625331229,
+                "bpt": 16986721,
+                "vpt": 42466801390,
+                "rbh": 11324,
+                "sbh": 849,
+                "gas": 113245,
+                "bpr": 16986721,
+                "sbpr": 424668,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "FileAppend",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 2981423158,
+                "bpt": 4766402,
+                "vpt": 11916005477,
+                "rbh": 3178,
+                "sbh": 238,
+                "gas": 31776,
+                "bpr": 4766402,
+                "sbpr": 119160,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 59628463168,
+                "bpt": 95328044,
+                "vpt": 238320109546,
+                "rbh": 63552,
+                "sbh": 4766,
+                "gas": 635520,
+                "bpr": 95328044,
+                "sbpr": 2383201,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 59628463168,
+                "bpt": 95328044,
+                "vpt": 238320109546,
+                "rbh": 63552,
+                "sbh": 4766,
+                "gas": 635520,
+                "bpr": 95328044,
+                "sbpr": 2383201,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "FileGetContents",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 69308,
+                "bpt": 111,
+                "vpt": 277006,
+                "rbh": 0,
+                "sbh": 0,
+                "gas": 1,
+                "bpr": 111,
+                "sbpr": 3,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 1108924,
+                "bpt": 1773,
+                "vpt": 4432093,
+                "rbh": 1,
+                "sbh": 0,
+                "gas": 12,
+                "bpr": 1773,
+                "sbpr": 44,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 1108924,
+                "bpt": 1773,
+                "vpt": 4432093,
+                "rbh": 1,
+                "sbh": 0,
+                "gas": 12,
+                "bpr": 1773,
+                "sbpr": 44,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "FileGetInfo",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 71080,
+                "bpt": 114,
+                "vpt": 284088,
+                "rbh": 0,
+                "sbh": 0,
+                "gas": 1,
+                "bpr": 114,
+                "sbpr": 3,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 1137277,
+                "bpt": 1818,
+                "vpt": 4545413,
+                "rbh": 1,
+                "sbh": 0,
+                "gas": 12,
+                "bpr": 1818,
+                "sbpr": 45,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 1137277,
+                "bpt": 1818,
+                "vpt": 4545413,
+                "rbh": 1,
+                "sbh": 0,
+                "gas": 12,
+                "bpr": 1818,
+                "sbpr": 45,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "GetVersionInfo",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 6519421057,
+                "bpt": 10422601,
+                "vpt": 26056501507,
+                "rbh": 6948,
+                "sbh": 521,
+                "gas": 69484,
+                "bpr": 10422601,
+                "sbpr": 260565,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 104310736905,
+                "bpt": 166761610,
+                "vpt": 416904024105,
+                "rbh": 111174,
+                "sbh": 8338,
+                "gas": 1111744,
+                "bpr": 166761610,
+                "sbpr": 4169040,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 104310736905,
+                "bpt": 166761610,
+                "vpt": 416904024105,
+                "rbh": 111174,
+                "sbh": 8338,
+                "gas": 1111744,
+                "bpr": 166761610,
+                "sbpr": 4169040,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "GetByKey",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 1,
+                "bpt": 0,
+                "vpt": 0,
+                "rbh": 0,
+                "sbh": 0,
+                "gas": 0,
+                "bpr": 0,
+                "sbpr": 0,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 1,
+                "bpt": 0,
+                "vpt": 0,
+                "rbh": 0,
+                "sbh": 0,
+                "gas": 0,
+                "bpr": 0,
+                "sbpr": 0,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 1,
+                "bpt": 0,
+                "vpt": 0,
+                "rbh": 0,
+                "sbh": 0,
+                "gas": 0,
+                "bpr": 0,
+                "sbpr": 0,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "TransactionGetReceipt",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 1,
+                "bpt": 0,
+                "vpt": 0,
+                "rbh": 0,
+                "sbh": 0,
+                "gas": 0,
+                "bpr": 0,
+                "sbpr": 0,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 1,
+                "bpt": 0,
+                "vpt": 0,
+                "rbh": 0,
+                "sbh": 0,
+                "gas": 0,
+                "bpr": 0,
+                "sbpr": 0,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 1,
+                "bpt": 0,
+                "vpt": 0,
+                "rbh": 0,
+                "sbh": 0,
+                "gas": 0,
+                "bpr": 0,
+                "sbpr": 0,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "SystemDelete",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 0,
+                "bpt": 0,
+                "vpt": 0,
+                "rbh": 0,
+                "sbh": 0,
+                "gas": 0,
+                "bpr": 0,
+                "sbpr": 0,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 0,
+                "bpt": 0,
+                "vpt": 0,
+                "rbh": 0,
+                "sbh": 0,
+                "gas": 0,
+                "bpr": 0,
+                "sbpr": 0,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 0,
+                "bpt": 0,
+                "vpt": 0,
+                "rbh": 0,
+                "sbh": 0,
+                "gas": 0,
+                "bpr": 0,
+                "sbpr": 0,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "SystemUndelete",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 0,
+                "bpt": 0,
+                "vpt": 0,
+                "rbh": 0,
+                "sbh": 0,
+                "gas": 0,
+                "bpr": 0,
+                "sbpr": 0,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 0,
+                "bpt": 0,
+                "vpt": 0,
+                "rbh": 0,
+                "sbh": 0,
+                "gas": 0,
+                "bpr": 0,
+                "sbpr": 0,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 0,
+                "bpt": 0,
+                "vpt": 0,
+                "rbh": 0,
+                "sbh": 0,
+                "gas": 0,
+                "bpr": 0,
+                "sbpr": 0,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "TransactionGetRecord",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 54605,
+                "bpt": 87,
+                "vpt": 218244,
+                "rbh": 0,
+                "sbh": 0,
+                "gas": 1,
+                "bpr": 87,
+                "sbpr": 2,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 873685,
+                "bpt": 1397,
+                "vpt": 3491900,
+                "rbh": 1,
+                "sbh": 0,
+                "gas": 9,
+                "bpr": 1397,
+                "sbpr": 35,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 873685,
+                "bpt": 1397,
+                "vpt": 3491900,
+                "rbh": 1,
+                "sbh": 0,
+                "gas": 9,
+                "bpr": 1397,
+                "sbpr": 35,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "expiryTime": 1630800000
+      }
+    ]
   },
   {
-	"nextFeeSchedule": [
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "CryptoCreate",
-		  "fees": [
-			{
-			  "subType": "DEFAULT",
-			  "nodedata": {
-				"constant": 11461413665,
-				"bpt": 508982,
-				"vpt": 1272455960,
-				"rbh": 339,
-				"sbh": 25,
-				"gas": 3393,
-				"bpr": 508982,
-				"sbpr": 12725,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 229228273302,
-				"bpt": 10179648,
-				"vpt": 25449119198,
-				"rbh": 6786,
-				"sbh": 509,
-				"gas": 67864,
-				"bpr": 10179648,
-				"sbpr": 254491,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 229228273302,
-				"bpt": 10179648,
-				"vpt": 25449119198,
-				"rbh": 6786,
-				"sbh": 509,
-				"gas": 67864,
-				"bpr": 10179648,
-				"sbpr": 254491,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "CryptoDeleteAllowance",
-		  "fees": [
-			{
-			  "subType": "DEFAULT",
-			  "nodedata": {
-				"constant": 3794963556,
-				"bpt": 6067009,
-				"vpt": 15167523735,
-				"rbh": 4045,
-				"sbh": 303,
-				"gas": 40447,
-				"bpr": 6067009,
-				"sbpr": 151675,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 75899271121,
-				"bpt": 121340190,
-				"vpt": 303350474702,
-				"rbh": 80893,
-				"sbh": 6067,
-				"gas": 808935,
-				"bpr": 121340190,
-				"sbpr": 3033505,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 75899271121,
-				"bpt": 121340190,
-				"vpt": 303350474702,
-				"rbh": 80893,
-				"sbh": 6067,
-				"gas": 808935,
-				"bpr": 121340190,
-				"sbpr": 3033505,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "CryptoApproveAllowance",
-		  "fees": [
-			{
-			  "subType": "DEFAULT",
-			  "nodedata": {
-				"constant": 3766772044,
-				"bpt": 6021940,
-				"vpt": 15054849285,
-				"rbh": 4015,
-				"sbh": 301,
-				"gas": 40146,
-				"bpr": 6021940,
-				"sbpr": 150548,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 75335440874,
-				"bpt": 120438794,
-				"vpt": 301096985700,
-				"rbh": 80293,
-				"sbh": 6022,
-				"gas": 802925,
-				"bpr": 120438794,
-				"sbpr": 3010970,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 75335440874,
-				"bpt": 120438794,
-				"vpt": 301096985700,
-				"rbh": 80293,
-				"sbh": 6022,
-				"gas": 802925,
-				"bpr": 120438794,
-				"sbpr": 3010970,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "CryptoAccountAutoRenew",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 59972622,
-				"bpt": 95878,
-				"vpt": 239695625,
-				"rbh": 64,
-				"sbh": 5,
-				"gas": 639,
-				"bpr": 95878,
-				"sbpr": 2397,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 959561945,
-				"bpt": 1534052,
-				"vpt": 3835129999,
-				"rbh": 1023,
-				"sbh": 77,
-				"gas": 10227,
-				"bpr": 1534052,
-				"sbpr": 38351,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 959561945,
-				"bpt": 1534052,
-				"vpt": 3835129999,
-				"rbh": 1023,
-				"sbh": 77,
-				"gas": 10227,
-				"bpr": 1534052,
-				"sbpr": 38351,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "CryptoUpdate",
-		  "fees": [
-			{
-			  "subType": "DEFAULT",
-			  "nodedata": {
-				"constant": 16302371,
-				"bpt": 26063,
-				"vpt": 65156516,
-				"rbh": 17,
-				"sbh": 1,
-				"gas": 174,
-				"bpr": 26063,
-				"sbpr": 652,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 326047427,
-				"bpt": 521252,
-				"vpt": 1303130322,
-				"rbh": 348,
-				"sbh": 26,
-				"gas": 3475,
-				"bpr": 521252,
-				"sbpr": 13031,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 326047427,
-				"bpt": 521252,
-				"vpt": 1303130322,
-				"rbh": 348,
-				"sbh": 26,
-				"gas": 3475,
-				"bpr": 521252,
-				"sbpr": 13031,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "CryptoTransfer",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 7574478,
-				"bpt": 12109,
-				"vpt": 30273301,
-				"rbh": 8,
-				"sbh": 1,
-				"gas": 81,
-				"bpr": 12109,
-				"sbpr": 303,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 151489557,
-				"bpt": 242186,
-				"vpt": 605466012,
-				"rbh": 161,
-				"sbh": 12,
-				"gas": 1615,
-				"bpr": 242186,
-				"sbpr": 6055,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 151489557,
-				"bpt": 242186,
-				"vpt": 605466012,
-				"rbh": 161,
-				"sbh": 12,
-				"gas": 1615,
-				"bpr": 242186,
-				"sbpr": 6055,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			},
-			{
-			  "subType": "TOKEN_FUNGIBLE_COMMON",
-			  "nodedata": {
-				"constant": 7983519,
-				"bpt": 12763,
-				"vpt": 31908136,
-				"rbh": 9,
-				"sbh": 1,
-				"gas": 85,
-				"bpr": 12763,
-				"sbpr": 319,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 159670382,
-				"bpt": 255265,
-				"vpt": 638162730,
-				"rbh": 170,
-				"sbh": 13,
-				"gas": 1702,
-				"bpr": 255265,
-				"sbpr": 6382,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 159670382,
-				"bpt": 255265,
-				"vpt": 638162730,
-				"rbh": 170,
-				"sbh": 13,
-				"gas": 1702,
-				"bpr": 255265,
-				"sbpr": 6382,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			},
-			{
-			  "subType": "TOKEN_FUNGIBLE_COMMON_WITH_CUSTOM_FEES",
-			  "nodedata": {
-				"constant": 15967037,
-				"bpt": 25527,
-				"vpt": 63816270,
-				"rbh": 17,
-				"sbh": 1,
-				"gas": 170,
-				"bpr": 25527,
-				"sbpr": 638,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 319340747,
-				"bpt": 510530,
-				"vpt": 1276325394,
-				"rbh": 340,
-				"sbh": 26,
-				"gas": 3404,
-				"bpr": 510530,
-				"sbpr": 12763,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 319340747,
-				"bpt": 510530,
-				"vpt": 1276325394,
-				"rbh": 340,
-				"sbh": 26,
-				"gas": 3404,
-				"bpr": 510530,
-				"sbpr": 12763,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			},
-			{
-			  "subType": "TOKEN_NON_FUNGIBLE_UNIQUE",
-			  "nodedata": {
-				"constant": 22833842,
-				"bpt": 36504,
-				"vpt": 91261178,
-				"rbh": 24,
-				"sbh": 2,
-				"gas": 243,
-				"bpr": 36504,
-				"sbpr": 913,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 456676846,
-				"bpt": 730089,
-				"vpt": 1825223562,
-				"rbh": 487,
-				"sbh": 37,
-				"gas": 4867,
-				"bpr": 730089,
-				"sbpr": 18252,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 456676846,
-				"bpt": 730089,
-				"vpt": 1825223562,
-				"rbh": 487,
-				"sbh": 37,
-				"gas": 4867,
-				"bpr": 730089,
-				"sbpr": 18252,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			},
-			{
-			  "subType": "TOKEN_NON_FUNGIBLE_UNIQUE_WITH_CUSTOM_FEES",
-			  "nodedata": {
-				"constant": 45667678,
-				"bpt": 73009,
-				"vpt": 182522330,
-				"rbh": 49,
-				"sbh": 4,
-				"gas": 487,
-				"bpr": 73009,
-				"sbpr": 1825,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 913353558,
-				"bpt": 1460179,
-				"vpt": 3650446591,
-				"rbh": 973,
-				"sbh": 73,
-				"gas": 9735,
-				"bpr": 1460179,
-				"sbpr": 36504,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 913353558,
-				"bpt": 1460179,
-				"vpt": 3650446591,
-				"rbh": 973,
-				"sbh": 73,
-				"gas": 9735,
-				"bpr": 1460179,
-				"sbpr": 36504,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "CryptoDelete",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 471427939,
-				"bpt": 753672,
-				"vpt": 1884180005,
-				"rbh": 502,
-				"sbh": 38,
-				"gas": 5024,
-				"bpr": 753672,
-				"sbpr": 18842,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 7542847021,
-				"bpt": 12058752,
-				"vpt": 30146880078,
-				"rbh": 8039,
-				"sbh": 603,
-				"gas": 80392,
-				"bpr": 12058752,
-				"sbpr": 301469,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 7542847021,
-				"bpt": 12058752,
-				"vpt": 30146880078,
-				"rbh": 8039,
-				"sbh": 603,
-				"gas": 80392,
-				"bpr": 12058752,
-				"sbpr": 301469,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "CryptoAddLiveHash",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 5561692202,
-				"bpt": 8891479,
-				"vpt": 22228697914,
-				"rbh": 5928,
-				"sbh": 445,
-				"gas": 59277,
-				"bpr": 8891479,
-				"sbpr": 222287,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 88987075231,
-				"bpt": 142263667,
-				"vpt": 355659166619,
-				"rbh": 94842,
-				"sbh": 7113,
-				"gas": 948424,
-				"bpr": 142263667,
-				"sbpr": 3556592,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 88987075231,
-				"bpt": 142263667,
-				"vpt": 355659166619,
-				"rbh": 94842,
-				"sbh": 7113,
-				"gas": 948424,
-				"bpr": 142263667,
-				"sbpr": 3556592,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "CryptoDeleteLiveHash",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 468546396,
-				"bpt": 749065,
-				"vpt": 1872663195,
-				"rbh": 499,
-				"sbh": 37,
-				"gas": 4994,
-				"bpr": 749065,
-				"sbpr": 18727,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 7496742329,
-				"bpt": 11985044,
-				"vpt": 29962611113,
-				"rbh": 7990,
-				"sbh": 599,
-				"gas": 79900,
-				"bpr": 11985044,
-				"sbpr": 299626,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 7496742329,
-				"bpt": 11985044,
-				"vpt": 29962611113,
-				"rbh": 7990,
-				"sbh": 599,
-				"gas": 79900,
-				"bpr": 11985044,
-				"sbpr": 299626,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "CryptoGetLiveHash",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 58926,
-				"bpt": 94,
-				"vpt": 235514,
-				"rbh": 0,
-				"sbh": 0,
-				"gas": 1,
-				"bpr": 94,
-				"sbpr": 2,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 942822,
-				"bpt": 1507,
-				"vpt": 3768224,
-				"rbh": 1,
-				"sbh": 0,
-				"gas": 10,
-				"bpr": 1507,
-				"sbpr": 38,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 942822,
-				"bpt": 1507,
-				"vpt": 3768224,
-				"rbh": 1,
-				"sbh": 0,
-				"gas": 10,
-				"bpr": 1507,
-				"sbpr": 38,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "CryptoGetAccountRecords",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 22044,
-				"bpt": 35,
-				"vpt": 88105,
-				"rbh": 0,
-				"sbh": 0,
-				"gas": 0,
-				"bpr": 35,
-				"sbpr": 1,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 352708,
-				"bpt": 564,
-				"vpt": 1409688,
-				"rbh": 0,
-				"sbh": 0,
-				"gas": 4,
-				"bpr": 564,
-				"sbpr": 14,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 352708,
-				"bpt": 564,
-				"vpt": 1409688,
-				"rbh": 0,
-				"sbh": 0,
-				"gas": 4,
-				"bpr": 564,
-				"sbpr": 14,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "CryptoGetAccountBalance",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 68774,
-				"bpt": 110,
-				"vpt": 274874,
-				"rbh": 0,
-				"sbh": 0,
-				"gas": 1,
-				"bpr": 110,
-				"sbpr": 3,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 1100389,
-				"bpt": 1759,
-				"vpt": 4397982,
-				"rbh": 1,
-				"sbh": 0,
-				"gas": 12,
-				"bpr": 1759,
-				"sbpr": 44,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 1100389,
-				"bpt": 1759,
-				"vpt": 4397982,
-				"rbh": 1,
-				"sbh": 0,
-				"gas": 12,
-				"bpr": 1759,
-				"sbpr": 44,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "CryptoGetInfo",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 63990,
-				"bpt": 102,
-				"vpt": 255752,
-				"rbh": 0,
-				"sbh": 0,
-				"gas": 1,
-				"bpr": 102,
-				"sbpr": 3,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 1023841,
-				"bpt": 1637,
-				"vpt": 4092038,
-				"rbh": 1,
-				"sbh": 0,
-				"gas": 11,
-				"bpr": 1637,
-				"sbpr": 41,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 1023841,
-				"bpt": 1637,
-				"vpt": 4092038,
-				"rbh": 1,
-				"sbh": 0,
-				"gas": 11,
-				"bpr": 1637,
-				"sbpr": 41,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "CryptoGetStakers",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 15251,
-				"bpt": 24,
-				"vpt": 60953,
-				"rbh": 0,
-				"sbh": 0,
-				"gas": 0,
-				"bpr": 24,
-				"sbpr": 1,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 244011,
-				"bpt": 390,
-				"vpt": 975251,
-				"rbh": 0,
-				"sbh": 0,
-				"gas": 3,
-				"bpr": 390,
-				"sbpr": 10,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 244011,
-				"bpt": 390,
-				"vpt": 975251,
-				"rbh": 0,
-				"sbh": 0,
-				"gas": 3,
-				"bpr": 390,
-				"sbpr": 10,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "ConsensusCreateTopic",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 921577366,
-				"bpt": 1473326,
-				"vpt": 3683315100,
-				"rbh": 982,
-				"sbh": 74,
-				"gas": 9822,
-				"bpr": 1473326,
-				"sbpr": 36833,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 14745237852,
-				"bpt": 23573217,
-				"vpt": 58933041595,
-				"rbh": 15715,
-				"sbh": 1179,
-				"gas": 157155,
-				"bpr": 23573217,
-				"sbpr": 589330,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 14745237852,
-				"bpt": 23573217,
-				"vpt": 58933041595,
-				"rbh": 15715,
-				"sbh": 1179,
-				"gas": 157155,
-				"bpr": 23573217,
-				"sbpr": 589330,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "ConsensusUpdateTopic",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 20193780,
-				"bpt": 32284,
-				"vpt": 80709508,
-				"rbh": 22,
-				"sbh": 2,
-				"gas": 215,
-				"bpr": 32284,
-				"sbpr": 807,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 323100486,
-				"bpt": 516541,
-				"vpt": 1291352134,
-				"rbh": 344,
-				"sbh": 26,
-				"gas": 3444,
-				"bpr": 516541,
-				"sbpr": 12914,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 323100486,
-				"bpt": 516541,
-				"vpt": 1291352134,
-				"rbh": 344,
-				"sbh": 26,
-				"gas": 3444,
-				"bpr": 516541,
-				"sbpr": 12914,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "ConsensusDeleteTopic",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 474345144,
-				"bpt": 758336,
-				"vpt": 1895839348,
-				"rbh": 506,
-				"sbh": 38,
-				"gas": 5056,
-				"bpr": 758336,
-				"sbpr": 18958,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 7589522307,
-				"bpt": 12133372,
-				"vpt": 30333429564,
-				"rbh": 8089,
-				"sbh": 607,
-				"gas": 80889,
-				"bpr": 12133372,
-				"sbpr": 303334,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 7589522307,
-				"bpt": 12133372,
-				"vpt": 30333429564,
-				"rbh": 8089,
-				"sbh": 607,
-				"gas": 80889,
-				"bpr": 12133372,
-				"sbpr": 303334,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "ConsensusSubmitMessage",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 9248442,
-				"bpt": 14785,
-				"vpt": 36963719,
-				"rbh": 10,
-				"sbh": 1,
-				"gas": 99,
-				"bpr": 14785,
-				"sbpr": 370,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 147975076,
-				"bpt": 236568,
-				"vpt": 591419509,
-				"rbh": 158,
-				"sbh": 12,
-				"gas": 1577,
-				"bpr": 236568,
-				"sbpr": 5914,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 147975076,
-				"bpt": 236568,
-				"vpt": 591419509,
-				"rbh": 158,
-				"sbh": 12,
-				"gas": 1577,
-				"bpr": 236568,
-				"sbpr": 5914,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "ConsensusGetTopicInfo",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 64253,
-				"bpt": 103,
-				"vpt": 256803,
-				"rbh": 0,
-				"sbh": 0,
-				"gas": 1,
-				"bpr": 103,
-				"sbpr": 3,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 1028048,
-				"bpt": 1644,
-				"vpt": 4108851,
-				"rbh": 1,
-				"sbh": 0,
-				"gas": 11,
-				"bpr": 1644,
-				"sbpr": 41,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 1028048,
-				"bpt": 1644,
-				"vpt": 4108851,
-				"rbh": 1,
-				"sbh": 0,
-				"gas": 11,
-				"bpr": 1644,
-				"sbpr": 41,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule" : {
-		  "hederaFunctionality" : "UtilPrng",
-		  "fees" : [ {
-			"subType" : "DEFAULT",
-			"nodedata" : {
-			  "constant" : 76998002,
-			  "bpt" : 123097,
-			  "vpt" : 307741829,
-			  "rbh" : 82,
-			  "sbh" : 6,
-			  "gas" : 821,
-			  "bpr" : 123097,
-			  "sbpr" : 3077,
-			  "min" : 0,
-			  "max" : 1000000000000000
-			},
-			"networkdata" : {
-			  "constant" : 1539960046,
-			  "bpt" : 2461935,
-			  "vpt" : 6154836589,
-			  "rbh" : 1641,
-			  "sbh" : 123,
-			  "gas" : 16413,
-			  "bpr" : 2461935,
-			  "sbpr" : 61548,
-			  "min" : 0,
-			  "max" : 1000000000000000
-			},
-			"servicedata" : {
-			  "constant" : 1539960046,
-			  "bpt" : 2461935,
-			  "vpt" : 6154836589,
-			  "rbh" : 1641,
-			  "sbh" : 123,
-			  "gas" : 16413,
-			  "bpr" : 2461935,
-			  "sbpr" : 61548,
-			  "min" : 0,
-			  "max" : 1000000000000000
-			}
-		  } ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "TokenCreate",
-		  "fees": [
-			{
-			  "subType": "TOKEN_FUNGIBLE_COMMON_WITH_CUSTOM_FEES",
-			  "nodedata": {
-				"constant": 393746195920,
-				"bpt": 17485616,
-				"vpt": 43714039850,
-				"rbh": 11657,
-				"sbh": 874,
-				"gas": 116571,
-				"bpr": 17485616,
-				"sbpr": 437140,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 7874923918408,
-				"bpt": 349712319,
-				"vpt": 874280797002,
-				"rbh": 233142,
-				"sbh": 17486,
-				"gas": 2331415,
-				"bpr": 349712319,
-				"sbpr": 8742808,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 7874923918408,
-				"bpt": 349712319,
-				"vpt": 874280797002,
-				"rbh": 233142,
-				"sbh": 17486,
-				"gas": 2331415,
-				"bpr": 349712319,
-				"sbpr": 8742808,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			},
-			{
-			  "subType": "TOKEN_FUNGIBLE_COMMON",
-			  "nodedata": {
-				"constant": 197306974233,
-				"bpt": 8762076,
-				"vpt": 21905189240,
-				"rbh": 5841,
-				"sbh": 438,
-				"gas": 58414,
-				"bpr": 8762076,
-				"sbpr": 219052,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 3946139484654,
-				"bpt": 175241514,
-				"vpt": 438103784807,
-				"rbh": 116828,
-				"sbh": 8762,
-				"gas": 1168277,
-				"bpr": 175241514,
-				"sbpr": 4381038,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 3946139484654,
-				"bpt": 175241514,
-				"vpt": 438103784807,
-				"rbh": 116828,
-				"sbh": 8762,
-				"gas": 1168277,
-				"bpr": 175241514,
-				"sbpr": 4381038,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			},
-			{
-			  "subType": "TOKEN_NON_FUNGIBLE_UNIQUE",
-			  "nodedata": {
-				"constant": 197031853851,
-				"bpt": 8749858,
-				"vpt": 21874645140,
-				"rbh": 5833,
-				"sbh": 437,
-				"gas": 58332,
-				"bpr": 8749858,
-				"sbpr": 218746,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 3940637077020,
-				"bpt": 174997161,
-				"vpt": 437492902800,
-				"rbh": 116665,
-				"sbh": 8750,
-				"gas": 1166648,
-				"bpr": 174997161,
-				"sbpr": 4374929,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 3940637077020,
-				"bpt": 174997161,
-				"vpt": 437492902800,
-				"rbh": 116665,
-				"sbh": 8750,
-				"gas": 1166648,
-				"bpr": 174997161,
-				"sbpr": 4374929,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			},
-			{
-			  "subType": "TOKEN_NON_FUNGIBLE_UNIQUE_WITH_CUSTOM_FEES",
-			  "nodedata": {
-				"constant": 393198370765,
-				"bpt": 17461288,
-				"vpt": 43653219832,
-				"rbh": 11641,
-				"sbh": 873,
-				"gas": 116409,
-				"bpr": 17461288,
-				"sbpr": 436532,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 7863967415309,
-				"bpt": 349225759,
-				"vpt": 873064396645,
-				"rbh": 232817,
-				"sbh": 17461,
-				"gas": 2328172,
-				"bpr": 349225759,
-				"sbpr": 8730644,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 7863967415309,
-				"bpt": 349225759,
-				"vpt": 873064396645,
-				"rbh": 232817,
-				"sbh": 17461,
-				"gas": 2328172,
-				"bpr": 349225759,
-				"sbpr": 8730644,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "TokenDelete",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 94285588,
-				"bpt": 150734,
-				"vpt": 376836001,
-				"rbh": 100,
-				"sbh": 8,
-				"gas": 1005,
-				"bpr": 150734,
-				"sbpr": 3768,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 1508569404,
-				"bpt": 2411750,
-				"vpt": 6029376016,
-				"rbh": 1608,
-				"sbh": 121,
-				"gas": 16078,
-				"bpr": 2411750,
-				"sbpr": 60294,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 1508569404,
-				"bpt": 2411750,
-				"vpt": 6029376016,
-				"rbh": 1608,
-				"sbh": 121,
-				"gas": 16078,
-				"bpr": 2411750,
-				"sbpr": 60294,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "TokenFeeScheduleUpdate",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 73998596,
-				"bpt": 118302,
-				"vpt": 295753948,
-				"rbh": 79,
-				"sbh": 6,
-				"gas": 789,
-				"bpr": 118302,
-				"sbpr": 2958,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 1479971913,
-				"bpt": 2366032,
-				"vpt": 5915078967,
-				"rbh": 1577,
-				"sbh": 118,
-				"gas": 15774,
-				"bpr": 2366032,
-				"sbpr": 59151,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 1479971913,
-				"bpt": 2366032,
-				"vpt": 5915078967,
-				"rbh": 1577,
-				"sbh": 118,
-				"gas": 15774,
-				"bpr": 2366032,
-				"sbpr": 59151,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "TokenUpdate",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 93900697,
-				"bpt": 150119,
-				"vpt": 375297688,
-				"rbh": 100,
-				"sbh": 8,
-				"gas": 1001,
-				"bpr": 150119,
-				"sbpr": 3753,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 1502411149,
-				"bpt": 2401905,
-				"vpt": 6004763005,
-				"rbh": 1601,
-				"sbh": 120,
-				"gas": 16013,
-				"bpr": 2401905,
-				"sbpr": 60048,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 1502411149,
-				"bpt": 2401905,
-				"vpt": 6004763005,
-				"rbh": 1601,
-				"sbh": 120,
-				"gas": 16013,
-				"bpr": 2401905,
-				"sbpr": 60048,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "TokenMint",
-		  "fees": [
-			{
-			  "subType": "TOKEN_FUNGIBLE_COMMON",
-			  "nodedata": {
-				"constant": 94092119,
-				"bpt": 150425,
-				"vpt": 376062755,
-				"rbh": 100,
-				"sbh": 8,
-				"gas": 1003,
-				"bpr": 150425,
-				"sbpr": 3761,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 1505473906,
-				"bpt": 2406802,
-				"vpt": 6017004081,
-				"rbh": 1605,
-				"sbh": 120,
-				"gas": 16045,
-				"bpr": 2406802,
-				"sbpr": 60170,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 1505473906,
-				"bpt": 2406802,
-				"vpt": 6017004081,
-				"rbh": 1605,
-				"sbh": 120,
-				"gas": 16045,
-				"bpr": 2406802,
-				"sbpr": 60170,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			},
-			{
-			  "subType": "TOKEN_NON_FUNGIBLE_UNIQUE",
-			  "nodedata": {
-				"constant": 3606440483,
-				"bpt": 5765618,
-				"vpt": 14414043986,
-				"rbh": 3844,
-				"sbh": 288,
-				"gas": 38437,
-				"bpr": 5765618,
-				"sbpr": 144140,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 72128809656,
-				"bpt": 115312352,
-				"vpt": 288280879722,
-				"rbh": 76875,
-				"sbh": 5766,
-				"gas": 768749,
-				"bpr": 115312352,
-				"sbpr": 2882809,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 72128809656,
-				"bpt": 115312352,
-				"vpt": 288280879722,
-				"rbh": 76875,
-				"sbh": 5766,
-				"gas": 768749,
-				"bpr": 115312352,
-				"sbpr": 2882809,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "TokenBurn",
-		  "fees": [
-			{
-			  "subType": "TOKEN_FUNGIBLE_COMMON",
-			  "nodedata": {
-				"constant": 94092119,
-				"bpt": 150425,
-				"vpt": 376062755,
-				"rbh": 100,
-				"sbh": 8,
-				"gas": 1003,
-				"bpr": 150425,
-				"sbpr": 3761,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 1505473906,
-				"bpt": 2406802,
-				"vpt": 6017004081,
-				"rbh": 1605,
-				"sbh": 120,
-				"gas": 16045,
-				"bpr": 2406802,
-				"sbpr": 60170,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 1505473906,
-				"bpt": 2406802,
-				"vpt": 6017004081,
-				"rbh": 1605,
-				"sbh": 120,
-				"gas": 16045,
-				"bpr": 2406802,
-				"sbpr": 60170,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			},
-			{
-			  "subType": "TOKEN_NON_FUNGIBLE_UNIQUE",
-			  "nodedata": {
-				"constant": 76366243,
-				"bpt": 122087,
-				"vpt": 305216845,
-				"rbh": 81,
-				"sbh": 6,
-				"gas": 814,
-				"bpr": 122087,
-				"sbpr": 3052,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 1527324859,
-				"bpt": 2441735,
-				"vpt": 6104336894,
-				"rbh": 1628,
-				"sbh": 122,
-				"gas": 16278,
-				"bpr": 2441735,
-				"sbpr": 61043,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 1527324859,
-				"bpt": 2441735,
-				"vpt": 6104336894,
-				"rbh": 1628,
-				"sbh": 122,
-				"gas": 16278,
-				"bpr": 2441735,
-				"sbpr": 61043,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "TokenAssociateToAccount",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 4574479485,
-				"bpt": 7313222,
-				"vpt": 18283054670,
-				"rbh": 4875,
-				"sbh": 366,
-				"gas": 48755,
-				"bpr": 7313222,
-				"sbpr": 182831,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 73191671761,
-				"bpt": 117011550,
-				"vpt": 292528874720,
-				"rbh": 78008,
-				"sbh": 5851,
-				"gas": 780077,
-				"bpr": 117011550,
-				"sbpr": 2925289,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 73191671761,
-				"bpt": 117011550,
-				"vpt": 292528874720,
-				"rbh": 78008,
-				"sbh": 5851,
-				"gas": 780077,
-				"bpr": 117011550,
-				"sbpr": 2925289,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "TokenDissociateFromAccount",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 4714279388,
-				"bpt": 7536720,
-				"vpt": 18841800049,
-				"rbh": 5024,
-				"sbh": 377,
-				"gas": 50245,
-				"bpr": 7536720,
-				"sbpr": 188418,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 75428470213,
-				"bpt": 120587520,
-				"vpt": 301468800784,
-				"rbh": 80392,
-				"sbh": 6029,
-				"gas": 803917,
-				"bpr": 120587520,
-				"sbpr": 3014688,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 75428470213,
-				"bpt": 120587520,
-				"vpt": 301468800784,
-				"rbh": 80392,
-				"sbh": 6029,
-				"gas": 803917,
-				"bpr": 120587520,
-				"sbpr": 3014688,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "TokenGrantKycToAccount",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 94285551,
-				"bpt": 150734,
-				"vpt": 376835856,
-				"rbh": 100,
-				"sbh": 8,
-				"gas": 1005,
-				"bpr": 150734,
-				"sbpr": 3768,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 1508568822,
-				"bpt": 2411749,
-				"vpt": 6029373689,
-				"rbh": 1608,
-				"sbh": 121,
-				"gas": 16078,
-				"bpr": 2411749,
-				"sbpr": 60294,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 1508568822,
-				"bpt": 2411749,
-				"vpt": 6029373689,
-				"rbh": 1608,
-				"sbh": 121,
-				"gas": 16078,
-				"bpr": 2411749,
-				"sbpr": 60294,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "TokenRevokeKycFromAccount",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 94285551,
-				"bpt": 150734,
-				"vpt": 376835856,
-				"rbh": 100,
-				"sbh": 8,
-				"gas": 1005,
-				"bpr": 150734,
-				"sbpr": 3768,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 1508568822,
-				"bpt": 2411749,
-				"vpt": 6029373689,
-				"rbh": 1608,
-				"sbh": 121,
-				"gas": 16078,
-				"bpr": 2411749,
-				"sbpr": 60294,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 1508568822,
-				"bpt": 2411749,
-				"vpt": 6029373689,
-				"rbh": 1608,
-				"sbh": 121,
-				"gas": 16078,
-				"bpr": 2411749,
-				"sbpr": 60294,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "TokenFreezeAccount",
-		  "fees": [
-			{
-			  "subType": "DEFAULT",
-			  "nodedata": {
-				"constant": 76054309,
-				"bpt": 121588,
-				"vpt": 303970122,
-				"rbh": 81,
-				"sbh": 6,
-				"gas": 811,
-				"bpr": 121588,
-				"sbpr": 3040,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 1521086180,
-				"bpt": 2431761,
-				"vpt": 6079402448,
-				"rbh": 1621,
-				"sbh": 122,
-				"gas": 16212,
-				"bpr": 2431761,
-				"sbpr": 60794,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 1521086180,
-				"bpt": 2431761,
-				"vpt": 6079402448,
-				"rbh": 1621,
-				"sbh": 122,
-				"gas": 16212,
-				"bpr": 2431761,
-				"sbpr": 60794,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "TokenUnfreezeAccount",
-		  "fees": [
-			{
-			  "subType": "DEFAULT",
-			  "nodedata": {
-				"constant": 76054309,
-				"bpt": 121588,
-				"vpt": 303970122,
-				"rbh": 81,
-				"sbh": 6,
-				"gas": 811,
-				"bpr": 121588,
-				"sbpr": 3040,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 1521086180,
-				"bpt": 2431761,
-				"vpt": 6079402448,
-				"rbh": 1621,
-				"sbh": 122,
-				"gas": 16212,
-				"bpr": 2431761,
-				"sbpr": 60794,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 1521086180,
-				"bpt": 2431761,
-				"vpt": 6079402448,
-				"rbh": 1621,
-				"sbh": 122,
-				"gas": 16212,
-				"bpr": 2431761,
-				"sbpr": 60794,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "TokenPause",
-		  "fees": [
-			{
-			  "subType": "DEFAULT",
-			  "nodedata": {
-				"constant": 76523246,
-				"bpt": 122338,
-				"vpt": 305844348,
-				"rbh": 82,
-				"sbh": 6,
-				"gas": 816,
-				"bpr": 122338,
-				"sbpr": 3058,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 1530464926,
-				"bpt": 2446755,
-				"vpt": 6116886962,
-				"rbh": 1631,
-				"sbh": 122,
-				"gas": 16312,
-				"bpr": 2446755,
-				"sbpr": 61169,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 1530464926,
-				"bpt": 2446755,
-				"vpt": 6116886962,
-				"rbh": 1631,
-				"sbh": 122,
-				"gas": 16312,
-				"bpr": 2446755,
-				"sbpr": 61169,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "TokenUnpause",
-		  "fees": [
-			{
-			  "subType": "DEFAULT",
-			  "nodedata": {
-				"constant": 76523246,
-				"bpt": 122338,
-				"vpt": 305844348,
-				"rbh": 82,
-				"sbh": 6,
-				"gas": 816,
-				"bpr": 122338,
-				"sbpr": 3058,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 1530464926,
-				"bpt": 2446755,
-				"vpt": 6116886962,
-				"rbh": 1631,
-				"sbh": 122,
-				"gas": 16312,
-				"bpr": 2446755,
-				"sbpr": 61169,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 1530464926,
-				"bpt": 2446755,
-				"vpt": 6116886962,
-				"rbh": 1631,
-				"sbh": 122,
-				"gas": 16312,
-				"bpr": 2446755,
-				"sbpr": 61169,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "TokenAccountWipe",
-		  "fees": [
-			{
-			  "subType": "TOKEN_FUNGIBLE_COMMON",
-			  "nodedata": {
-				"constant": 94092119,
-				"bpt": 150425,
-				"vpt": 376062755,
-				"rbh": 100,
-				"sbh": 8,
-				"gas": 1003,
-				"bpr": 150425,
-				"sbpr": 3761,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 1505473906,
-				"bpt": 2406802,
-				"vpt": 6017004081,
-				"rbh": 1605,
-				"sbh": 120,
-				"gas": 16045,
-				"bpr": 2406802,
-				"sbpr": 60170,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 1505473906,
-				"bpt": 2406802,
-				"vpt": 6017004081,
-				"rbh": 1605,
-				"sbh": 120,
-				"gas": 16045,
-				"bpr": 2406802,
-				"sbpr": 60170,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			},
-			{
-			  "subType": "TOKEN_NON_FUNGIBLE_UNIQUE",
-			  "nodedata": {
-				"constant": 76366243,
-				"bpt": 122087,
-				"vpt": 305216845,
-				"rbh": 81,
-				"sbh": 6,
-				"gas": 814,
-				"bpr": 122087,
-				"sbpr": 3052,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 1527324859,
-				"bpt": 2441735,
-				"vpt": 6104336894,
-				"rbh": 1628,
-				"sbh": 122,
-				"gas": 16278,
-				"bpr": 2441735,
-				"sbpr": 61043,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 1527324859,
-				"bpt": 2441735,
-				"vpt": 6104336894,
-				"rbh": 1628,
-				"sbh": 122,
-				"gas": 16278,
-				"bpr": 2441735,
-				"sbpr": 61043,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "TokenGetInfo",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 61717,
-				"bpt": 99,
-				"vpt": 246668,
-				"rbh": 0,
-				"sbh": 0,
-				"gas": 1,
-				"bpr": 99,
-				"sbpr": 2,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 987474,
-				"bpt": 1579,
-				"vpt": 3946688,
-				"rbh": 1,
-				"sbh": 0,
-				"gas": 11,
-				"bpr": 1579,
-				"sbpr": 39,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 987474,
-				"bpt": 1579,
-				"vpt": 3946688,
-				"rbh": 1,
-				"sbh": 0,
-				"gas": 11,
-				"bpr": 1579,
-				"sbpr": 39,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "ScheduleCreate",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 563513000,
-				"bpt": 900888,
-				"vpt": 2252221049,
-				"rbh": 601,
-				"sbh": 45,
-				"gas": 6006,
-				"bpr": 900888,
-				"sbpr": 22522,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 9016208000,
-				"bpt": 14414215,
-				"vpt": 36035536788,
-				"rbh": 9609,
-				"sbh": 721,
-				"gas": 96095,
-				"bpr": 14414215,
-				"sbpr": 360355,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 9016208000,
-				"bpt": 14414215,
-				"vpt": 36035536788,
-				"rbh": 9609,
-				"sbh": 721,
-				"gas": 96095,
-				"bpr": 14414215,
-				"sbpr": 360355,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "TokenGetNftInfo",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 54605,
-				"bpt": 87,
-				"vpt": 218244,
-				"rbh": 0,
-				"sbh": 0,
-				"gas": 1,
-				"bpr": 87,
-				"sbpr": 2,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 0,
-				"bpt": 0,
-				"vpt": 0,
-				"rbh": 0,
-				"sbh": 0,
-				"gas": 0,
-				"bpr": 0,
-				"sbpr": 0,
-				"min": 0,
-				"max": 0
-			  },
-			  "servicedata": {
-				"constant": 0,
-				"bpt": 0,
-				"vpt": 0,
-				"rbh": 0,
-				"sbh": 0,
-				"gas": 0,
-				"bpr": 0,
-				"sbpr": 0,
-				"min": 0,
-				"max": 0
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "ScheduleSign",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 58040915,
-				"bpt": 92790,
-				"vpt": 231975077,
-				"rbh": 62,
-				"sbh": 5,
-				"gas": 619,
-				"bpr": 92790,
-				"sbpr": 2320,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 928654648,
-				"bpt": 1484640,
-				"vpt": 3711601232,
-				"rbh": 990,
-				"sbh": 74,
-				"gas": 9898,
-				"bpr": 1484640,
-				"sbpr": 37116,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 928654648,
-				"bpt": 1484640,
-				"vpt": 3711601232,
-				"rbh": 990,
-				"sbh": 74,
-				"gas": 9898,
-				"bpr": 1484640,
-				"sbpr": 37116,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "ScheduleDelete",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 95360774,
-				"bpt": 152453,
-				"vpt": 381133253,
-				"rbh": 102,
-				"sbh": 8,
-				"gas": 1016,
-				"bpr": 152453,
-				"sbpr": 3811,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 1525772386,
-				"bpt": 2439253,
-				"vpt": 6098132047,
-				"rbh": 1626,
-				"sbh": 122,
-				"gas": 16262,
-				"bpr": 2439253,
-				"sbpr": 60981,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 1525772386,
-				"bpt": 2439253,
-				"vpt": 6098132047,
-				"rbh": 1626,
-				"sbh": 122,
-				"gas": 16262,
-				"bpr": 2439253,
-				"sbpr": 60981,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "ScheduleGetInfo",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 53393,
-				"bpt": 85,
-				"vpt": 213400,
-				"rbh": 0,
-				"sbh": 0,
-				"gas": 1,
-				"bpr": 85,
-				"sbpr": 2,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 854295,
-				"bpt": 1366,
-				"vpt": 3414402,
-				"rbh": 1,
-				"sbh": 0,
-				"gas": 9,
-				"bpr": 1366,
-				"sbpr": 34,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 854295,
-				"bpt": 1366,
-				"vpt": 3414402,
-				"rbh": 1,
-				"sbh": 0,
-				"gas": 9,
-				"bpr": 1366,
-				"sbpr": 34,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "ContractCreate",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 45218052173,
-				"bpt": 72290115,
-				"vpt": 180725287466,
-				"rbh": 48193,
-				"sbh": 3615,
-				"gas": 481934,
-				"bpr": 72290115,
-				"sbpr": 1807253,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 723488834765,
-				"bpt": 1156641840,
-				"vpt": 2891604599463,
-				"rbh": 771095,
-				"sbh": 57832,
-				"gas": 7710946,
-				"bpr": 1156641840,
-				"sbpr": 28916046,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 0,
-				"bpt": 0,
-				"vpt": 0,
-				"rbh": 0,
-				"sbh": 0,
-				"gas": 11566419,
-				"bpr": 0,
-				"sbpr": 0,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "ContractUpdate",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 2438037058,
-				"bpt": 3897691,
-				"vpt": 9744226629,
-				"rbh": 2598,
-				"sbh": 195,
-				"gas": 25985,
-				"bpr": 3897691,
-				"sbpr": 97442,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 39008592923,
-				"bpt": 62363050,
-				"vpt": 155907626067,
-				"rbh": 41575,
-				"sbh": 3118,
-				"gas": 415754,
-				"bpr": 62363050,
-				"sbpr": 1559076,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 39008592923,
-				"bpt": 62363050,
-				"vpt": 155907626067,
-				"rbh": 41575,
-				"sbh": 3118,
-				"gas": 415754,
-				"bpr": 62363050,
-				"sbpr": 1559076,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "ContractDelete",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 664083202,
-				"bpt": 1061670,
-				"vpt": 2654175087,
-				"rbh": 708,
-				"sbh": 53,
-				"gas": 7078,
-				"bpr": 1061670,
-				"sbpr": 26542,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 10625331229,
-				"bpt": 16986721,
-				"vpt": 42466801390,
-				"rbh": 11324,
-				"sbh": 849,
-				"gas": 113245,
-				"bpr": 16986721,
-				"sbpr": 424668,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 10625331229,
-				"bpt": 16986721,
-				"vpt": 42466801390,
-				"rbh": 11324,
-				"sbh": 849,
-				"gas": 113245,
-				"bpr": 16986721,
-				"sbpr": 424668,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "ContractCall",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 3336515210,
-				"bpt": 5334088,
-				"vpt": 13335219927,
-				"rbh": 3556,
-				"sbh": 267,
-				"gas": 35561,
-				"bpr": 5334088,
-				"sbpr": 133352,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 53384243355,
-				"bpt": 85345408,
-				"vpt": 213363518838,
-				"rbh": 56897,
-				"sbh": 4267,
-				"gas": 568969,
-				"bpr": 85345408,
-				"sbpr": 2133635,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 0,
-				"bpt": 0,
-				"vpt": 0,
-				"rbh": 0,
-				"sbh": 0,
-				"gas": 853454,
-				"bpr": 0,
-				"sbpr": 0,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "EthereumTransaction",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 6122046,
-				"bpt": 9787,
-				"vpt": 24468293,
-				"rbh": 6,
-				"sbh": 0,
-				"gas": 65,
-				"bpr": 9787,
-				"sbpr": 244,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 97952740,
-				"bpt": 156597,
-				"vpt": 391492695,
-				"rbh": 104,
-				"sbh": 7,
-				"gas": 1043,
-				"bpr": 156597,
-				"sbpr": 3914,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 0,
-				"bpt": 0,
-				"vpt": 0,
-				"rbh": 0,
-				"sbh": 0,
-				"gas": 853454,
-				"bpr": 0,
-				"sbpr": 0,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "ContractGetInfo",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 71015,
-				"bpt": 114,
-				"vpt": 283830,
-				"rbh": 0,
-				"sbh": 0,
-				"gas": 1,
-				"bpr": 114,
-				"sbpr": 3,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 1136244,
-				"bpt": 1817,
-				"vpt": 4541284,
-				"rbh": 1,
-				"sbh": 0,
-				"gas": 12,
-				"bpr": 1817,
-				"sbpr": 45,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 1136244,
-				"bpt": 1817,
-				"vpt": 4541284,
-				"rbh": 1,
-				"sbh": 0,
-				"gas": 12,
-				"bpr": 1817,
-				"sbpr": 45,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "ContractCallLocal",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 2610100486,
-				"bpt": 4172769,
-				"vpt": 10431921279,
-				"rbh": 2782,
-				"sbh": 209,
-				"gas": 27818,
-				"bpr": 4172769,
-				"sbpr": 104319,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 41761607776,
-				"bpt": 66764296,
-				"vpt": 166910740461,
-				"rbh": 44510,
-				"sbh": 3338,
-				"gas": 445095,
-				"bpr": 66764296,
-				"sbpr": 1669107,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 41761607776,
-				"bpt": 66764296,
-				"vpt": 166910740461,
-				"rbh": 44510,
-				"sbh": 3338,
-				"gas": 445095,
-				"bpr": 66764296,
-				"sbpr": 1669107,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "ContractGetBytecode",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 226589259813,
-				"bpt": 362248325,
-				"vpt": 905620811793,
-				"rbh": 241499,
-				"sbh": 18112,
-				"gas": 2414989,
-				"bpr": 362248325,
-				"sbpr": 9056208,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 3625428157003,
-				"bpt": 5795973195,
-				"vpt": 14489932988688,
-				"rbh": 3863982,
-				"sbh": 289799,
-				"gas": 38639821,
-				"bpr": 5795973195,
-				"sbpr": 144899330,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 3625428157003,
-				"bpt": 5795973195,
-				"vpt": 14489932988688,
-				"rbh": 3863982,
-				"sbh": 289799,
-				"gas": 38639821,
-				"bpr": 5795973195,
-				"sbpr": 144899330,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "GetBySolidityID",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 69385,
-				"bpt": 111,
-				"vpt": 277313,
-				"rbh": 0,
-				"sbh": 0,
-				"gas": 1,
-				"bpr": 111,
-				"sbpr": 3,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 1110154,
-				"bpt": 1775,
-				"vpt": 4437010,
-				"rbh": 1,
-				"sbh": 0,
-				"gas": 12,
-				"bpr": 1775,
-				"sbpr": 44,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 1110154,
-				"bpt": 1775,
-				"vpt": 4437010,
-				"rbh": 1,
-				"sbh": 0,
-				"gas": 12,
-				"bpr": 1775,
-				"sbpr": 44,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "ContractGetRecords",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 10093,
-				"bpt": 16,
-				"vpt": 40339,
-				"rbh": 0,
-				"sbh": 0,
-				"gas": 0,
-				"bpr": 16,
-				"sbpr": 0,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 161486,
-				"bpt": 258,
-				"vpt": 645421,
-				"rbh": 0,
-				"sbh": 0,
-				"gas": 2,
-				"bpr": 258,
-				"sbpr": 6,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 161486,
-				"bpt": 258,
-				"vpt": 645421,
-				"rbh": 0,
-				"sbh": 0,
-				"gas": 2,
-				"bpr": 258,
-				"sbpr": 6,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule" : {
-		  "hederaFunctionality" : "ContractAutoRenew",
-		  "fees" : [ {
-			"subType" : "DEFAULT",
-			"nodedata" : {
-			  "constant" : 5396134280,
-			  "bpt" : 8626802,
-			  "vpt" : 21567004154,
-			  "rbh" : 5751,
-			  "sbh" : 431,
-			  "gas" : 57512,
-			  "bpr" : 8626802,
-			  "sbpr" : 215670,
-			  "min" : 0,
-			  "max" : 1000000000000000
-			},
-			"networkdata" : {
-			  "constant" : 107922685608,
-			  "bpt" : 172536033,
-			  "vpt" : 431340083072,
-			  "rbh" : 115024,
-			  "sbh" : 8627,
-			  "gas" : 1150240,
-			  "bpr" : 172536033,
-			  "sbpr" : 4313401,
-			  "min" : 0,
-			  "max" : 1000000000000000
-			},
-			"servicedata" : {
-			  "constant" : 107922685608,
-			  "bpt" : 172536033,
-			  "vpt" : 431340083072,
-			  "rbh" : 115024,
-			  "sbh" : 8627,
-			  "gas" : 1150240,
-			  "bpr" : 172536033,
-			  "sbpr" : 4313401,
-			  "min" : 0,
-			  "max" : 1000000000000000
-			}
-		  } ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "FileCreate",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 3657315129,
-				"bpt": 5846951,
-				"vpt": 14617377270,
-				"rbh": 3898,
-				"sbh": 292,
-				"gas": 38980,
-				"bpr": 5846951,
-				"sbpr": 146174,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 58517042062,
-				"bpt": 93551215,
-				"vpt": 233878036318,
-				"rbh": 62367,
-				"sbh": 4678,
-				"gas": 623675,
-				"bpr": 93551215,
-				"sbpr": 2338780,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 58517042062,
-				"bpt": 93551215,
-				"vpt": 233878036318,
-				"rbh": 62367,
-				"sbh": 4678,
-				"gas": 623675,
-				"bpr": 93551215,
-				"sbpr": 2338780,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "FileUpdate",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 3663140881,
-				"bpt": 5856265,
-				"vpt": 14640661348,
-				"rbh": 3904,
-				"sbh": 293,
-				"gas": 39042,
-				"bpr": 5856265,
-				"sbpr": 146407,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 58610254089,
-				"bpt": 93700233,
-				"vpt": 234250581567,
-				"rbh": 62467,
-				"sbh": 4685,
-				"gas": 624668,
-				"bpr": 93700233,
-				"sbpr": 2342506,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 58610254089,
-				"bpt": 93700233,
-				"vpt": 234250581567,
-				"rbh": 62467,
-				"sbh": 4685,
-				"gas": 624668,
-				"bpr": 93700233,
-				"sbpr": 2342506,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "FileDelete",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 664083202,
-				"bpt": 1061670,
-				"vpt": 2654175087,
-				"rbh": 708,
-				"sbh": 53,
-				"gas": 7078,
-				"bpr": 1061670,
-				"sbpr": 26542,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 10625331229,
-				"bpt": 16986721,
-				"vpt": 42466801390,
-				"rbh": 11324,
-				"sbh": 849,
-				"gas": 113245,
-				"bpr": 16986721,
-				"sbpr": 424668,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 10625331229,
-				"bpt": 16986721,
-				"vpt": 42466801390,
-				"rbh": 11324,
-				"sbh": 849,
-				"gas": 113245,
-				"bpr": 16986721,
-				"sbpr": 424668,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "FileAppend",
-		  "fees": [
-			{
-			  "subType": "DEFAULT",
-			  "nodedata": {
-				"constant": 2981423158,
-				"bpt": 4766402,
-				"vpt": 11916005477,
-				"rbh": 3178,
-				"sbh": 238,
-				"gas": 31776,
-				"bpr": 4766402,
-				"sbpr": 119160,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 59628463168,
-				"bpt": 95328044,
-				"vpt": 238320109546,
-				"rbh": 63552,
-				"sbh": 4766,
-				"gas": 635520,
-				"bpr": 95328044,
-				"sbpr": 2383201,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 59628463168,
-				"bpt": 95328044,
-				"vpt": 238320109546,
-				"rbh": 63552,
-				"sbh": 4766,
-				"gas": 635520,
-				"bpr": 95328044,
-				"sbpr": 2383201,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "FileGetContents",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 69308,
-				"bpt": 111,
-				"vpt": 277006,
-				"rbh": 0,
-				"sbh": 0,
-				"gas": 1,
-				"bpr": 111,
-				"sbpr": 3,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 1108924,
-				"bpt": 1773,
-				"vpt": 4432093,
-				"rbh": 1,
-				"sbh": 0,
-				"gas": 12,
-				"bpr": 1773,
-				"sbpr": 44,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 1108924,
-				"bpt": 1773,
-				"vpt": 4432093,
-				"rbh": 1,
-				"sbh": 0,
-				"gas": 12,
-				"bpr": 1773,
-				"sbpr": 44,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "FileGetInfo",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 71080,
-				"bpt": 114,
-				"vpt": 284088,
-				"rbh": 0,
-				"sbh": 0,
-				"gas": 1,
-				"bpr": 114,
-				"sbpr": 3,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 1137277,
-				"bpt": 1818,
-				"vpt": 4545413,
-				"rbh": 1,
-				"sbh": 0,
-				"gas": 12,
-				"bpr": 1818,
-				"sbpr": 45,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 1137277,
-				"bpt": 1818,
-				"vpt": 4545413,
-				"rbh": 1,
-				"sbh": 0,
-				"gas": 12,
-				"bpr": 1818,
-				"sbpr": 45,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "GetVersionInfo",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 6519421057,
-				"bpt": 10422601,
-				"vpt": 26056501507,
-				"rbh": 6948,
-				"sbh": 521,
-				"gas": 69484,
-				"bpr": 10422601,
-				"sbpr": 260565,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 104310736905,
-				"bpt": 166761610,
-				"vpt": 416904024105,
-				"rbh": 111174,
-				"sbh": 8338,
-				"gas": 1111744,
-				"bpr": 166761610,
-				"sbpr": 4169040,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 104310736905,
-				"bpt": 166761610,
-				"vpt": 416904024105,
-				"rbh": 111174,
-				"sbh": 8338,
-				"gas": 1111744,
-				"bpr": 166761610,
-				"sbpr": 4169040,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "GetByKey",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 1,
-				"bpt": 0,
-				"vpt": 0,
-				"rbh": 0,
-				"sbh": 0,
-				"gas": 0,
-				"bpr": 0,
-				"sbpr": 0,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 1,
-				"bpt": 0,
-				"vpt": 0,
-				"rbh": 0,
-				"sbh": 0,
-				"gas": 0,
-				"bpr": 0,
-				"sbpr": 0,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 1,
-				"bpt": 0,
-				"vpt": 0,
-				"rbh": 0,
-				"sbh": 0,
-				"gas": 0,
-				"bpr": 0,
-				"sbpr": 0,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "TransactionGetReceipt",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 1,
-				"bpt": 0,
-				"vpt": 0,
-				"rbh": 0,
-				"sbh": 0,
-				"gas": 0,
-				"bpr": 0,
-				"sbpr": 0,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 1,
-				"bpt": 0,
-				"vpt": 0,
-				"rbh": 0,
-				"sbh": 0,
-				"gas": 0,
-				"bpr": 0,
-				"sbpr": 0,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 1,
-				"bpt": 0,
-				"vpt": 0,
-				"rbh": 0,
-				"sbh": 0,
-				"gas": 0,
-				"bpr": 0,
-				"sbpr": 0,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "SystemDelete",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 0,
-				"bpt": 0,
-				"vpt": 0,
-				"rbh": 0,
-				"sbh": 0,
-				"gas": 0,
-				"bpr": 0,
-				"sbpr": 0,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 0,
-				"bpt": 0,
-				"vpt": 0,
-				"rbh": 0,
-				"sbh": 0,
-				"gas": 0,
-				"bpr": 0,
-				"sbpr": 0,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 0,
-				"bpt": 0,
-				"vpt": 0,
-				"rbh": 0,
-				"sbh": 0,
-				"gas": 0,
-				"bpr": 0,
-				"sbpr": 0,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "SystemUndelete",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 0,
-				"bpt": 0,
-				"vpt": 0,
-				"rbh": 0,
-				"sbh": 0,
-				"gas": 0,
-				"bpr": 0,
-				"sbpr": 0,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 0,
-				"bpt": 0,
-				"vpt": 0,
-				"rbh": 0,
-				"sbh": 0,
-				"gas": 0,
-				"bpr": 0,
-				"sbpr": 0,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 0,
-				"bpt": 0,
-				"vpt": 0,
-				"rbh": 0,
-				"sbh": 0,
-				"gas": 0,
-				"bpr": 0,
-				"sbpr": 0,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "TransactionGetRecord",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 54605,
-				"bpt": 87,
-				"vpt": 218244,
-				"rbh": 0,
-				"sbh": 0,
-				"gas": 1,
-				"bpr": 87,
-				"sbpr": 2,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 873685,
-				"bpt": 1397,
-				"vpt": 3491900,
-				"rbh": 1,
-				"sbh": 0,
-				"gas": 9,
-				"bpr": 1397,
-				"sbpr": 35,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 873685,
-				"bpt": 1397,
-				"vpt": 3491900,
-				"rbh": 1,
-				"sbh": 0,
-				"gas": 9,
-				"bpr": 1397,
-				"sbpr": 35,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"expiryTime": 1633392000
-	  }
-	]
+    "nextFeeSchedule": [
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "CryptoCreate",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 11461413665,
+                "bpt": 508982,
+                "vpt": 1272455960,
+                "rbh": 339,
+                "sbh": 25,
+                "gas": 3393,
+                "bpr": 508982,
+                "sbpr": 12725,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 229228273302,
+                "bpt": 10179648,
+                "vpt": 25449119198,
+                "rbh": 6786,
+                "sbh": 509,
+                "gas": 67864,
+                "bpr": 10179648,
+                "sbpr": 254491,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 229228273302,
+                "bpt": 10179648,
+                "vpt": 25449119198,
+                "rbh": 6786,
+                "sbh": 509,
+                "gas": 67864,
+                "bpr": 10179648,
+                "sbpr": 254491,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "CryptoDeleteAllowance",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 3794963556,
+                "bpt": 6067009,
+                "vpt": 15167523735,
+                "rbh": 4045,
+                "sbh": 303,
+                "gas": 40447,
+                "bpr": 6067009,
+                "sbpr": 151675,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 75899271121,
+                "bpt": 121340190,
+                "vpt": 303350474702,
+                "rbh": 80893,
+                "sbh": 6067,
+                "gas": 808935,
+                "bpr": 121340190,
+                "sbpr": 3033505,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 75899271121,
+                "bpt": 121340190,
+                "vpt": 303350474702,
+                "rbh": 80893,
+                "sbh": 6067,
+                "gas": 808935,
+                "bpr": 121340190,
+                "sbpr": 3033505,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "CryptoApproveAllowance",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 3766772044,
+                "bpt": 6021940,
+                "vpt": 15054849285,
+                "rbh": 4015,
+                "sbh": 301,
+                "gas": 40146,
+                "bpr": 6021940,
+                "sbpr": 150548,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 75335440874,
+                "bpt": 120438794,
+                "vpt": 301096985700,
+                "rbh": 80293,
+                "sbh": 6022,
+                "gas": 802925,
+                "bpr": 120438794,
+                "sbpr": 3010970,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 75335440874,
+                "bpt": 120438794,
+                "vpt": 301096985700,
+                "rbh": 80293,
+                "sbh": 6022,
+                "gas": 802925,
+                "bpr": 120438794,
+                "sbpr": 3010970,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "CryptoAccountAutoRenew",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 59972622,
+                "bpt": 95878,
+                "vpt": 239695625,
+                "rbh": 64,
+                "sbh": 5,
+                "gas": 639,
+                "bpr": 95878,
+                "sbpr": 2397,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 959561945,
+                "bpt": 1534052,
+                "vpt": 3835129999,
+                "rbh": 1023,
+                "sbh": 77,
+                "gas": 10227,
+                "bpr": 1534052,
+                "sbpr": 38351,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 959561945,
+                "bpt": 1534052,
+                "vpt": 3835129999,
+                "rbh": 1023,
+                "sbh": 77,
+                "gas": 10227,
+                "bpr": 1534052,
+                "sbpr": 38351,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "CryptoUpdate",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 16302371,
+                "bpt": 26063,
+                "vpt": 65156516,
+                "rbh": 17,
+                "sbh": 1,
+                "gas": 174,
+                "bpr": 26063,
+                "sbpr": 652,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 326047427,
+                "bpt": 521252,
+                "vpt": 1303130322,
+                "rbh": 348,
+                "sbh": 26,
+                "gas": 3475,
+                "bpr": 521252,
+                "sbpr": 13031,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 326047427,
+                "bpt": 521252,
+                "vpt": 1303130322,
+                "rbh": 348,
+                "sbh": 26,
+                "gas": 3475,
+                "bpr": 521252,
+                "sbpr": 13031,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "CryptoTransfer",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 7574478,
+                "bpt": 12109,
+                "vpt": 30273301,
+                "rbh": 8,
+                "sbh": 1,
+                "gas": 81,
+                "bpr": 12109,
+                "sbpr": 303,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 151489557,
+                "bpt": 242186,
+                "vpt": 605466012,
+                "rbh": 161,
+                "sbh": 12,
+                "gas": 1615,
+                "bpr": 242186,
+                "sbpr": 6055,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 151489557,
+                "bpt": 242186,
+                "vpt": 605466012,
+                "rbh": 161,
+                "sbh": 12,
+                "gas": 1615,
+                "bpr": 242186,
+                "sbpr": 6055,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            },
+            {
+              "subType": "TOKEN_FUNGIBLE_COMMON",
+              "nodedata": {
+                "constant": 7983519,
+                "bpt": 12763,
+                "vpt": 31908136,
+                "rbh": 9,
+                "sbh": 1,
+                "gas": 85,
+                "bpr": 12763,
+                "sbpr": 319,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 159670382,
+                "bpt": 255265,
+                "vpt": 638162730,
+                "rbh": 170,
+                "sbh": 13,
+                "gas": 1702,
+                "bpr": 255265,
+                "sbpr": 6382,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 159670382,
+                "bpt": 255265,
+                "vpt": 638162730,
+                "rbh": 170,
+                "sbh": 13,
+                "gas": 1702,
+                "bpr": 255265,
+                "sbpr": 6382,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            },
+            {
+              "subType": "TOKEN_FUNGIBLE_COMMON_WITH_CUSTOM_FEES",
+              "nodedata": {
+                "constant": 15967037,
+                "bpt": 25527,
+                "vpt": 63816270,
+                "rbh": 17,
+                "sbh": 1,
+                "gas": 170,
+                "bpr": 25527,
+                "sbpr": 638,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 319340747,
+                "bpt": 510530,
+                "vpt": 1276325394,
+                "rbh": 340,
+                "sbh": 26,
+                "gas": 3404,
+                "bpr": 510530,
+                "sbpr": 12763,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 319340747,
+                "bpt": 510530,
+                "vpt": 1276325394,
+                "rbh": 340,
+                "sbh": 26,
+                "gas": 3404,
+                "bpr": 510530,
+                "sbpr": 12763,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            },
+            {
+              "subType": "TOKEN_NON_FUNGIBLE_UNIQUE",
+              "nodedata": {
+                "constant": 22833842,
+                "bpt": 36504,
+                "vpt": 91261178,
+                "rbh": 24,
+                "sbh": 2,
+                "gas": 243,
+                "bpr": 36504,
+                "sbpr": 913,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 456676846,
+                "bpt": 730089,
+                "vpt": 1825223562,
+                "rbh": 487,
+                "sbh": 37,
+                "gas": 4867,
+                "bpr": 730089,
+                "sbpr": 18252,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 456676846,
+                "bpt": 730089,
+                "vpt": 1825223562,
+                "rbh": 487,
+                "sbh": 37,
+                "gas": 4867,
+                "bpr": 730089,
+                "sbpr": 18252,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            },
+            {
+              "subType": "TOKEN_NON_FUNGIBLE_UNIQUE_WITH_CUSTOM_FEES",
+              "nodedata": {
+                "constant": 45667678,
+                "bpt": 73009,
+                "vpt": 182522330,
+                "rbh": 49,
+                "sbh": 4,
+                "gas": 487,
+                "bpr": 73009,
+                "sbpr": 1825,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 913353558,
+                "bpt": 1460179,
+                "vpt": 3650446591,
+                "rbh": 973,
+                "sbh": 73,
+                "gas": 9735,
+                "bpr": 1460179,
+                "sbpr": 36504,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 913353558,
+                "bpt": 1460179,
+                "vpt": 3650446591,
+                "rbh": 973,
+                "sbh": 73,
+                "gas": 9735,
+                "bpr": 1460179,
+                "sbpr": 36504,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "CryptoDelete",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 471427939,
+                "bpt": 753672,
+                "vpt": 1884180005,
+                "rbh": 502,
+                "sbh": 38,
+                "gas": 5024,
+                "bpr": 753672,
+                "sbpr": 18842,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 7542847021,
+                "bpt": 12058752,
+                "vpt": 30146880078,
+                "rbh": 8039,
+                "sbh": 603,
+                "gas": 80392,
+                "bpr": 12058752,
+                "sbpr": 301469,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 7542847021,
+                "bpt": 12058752,
+                "vpt": 30146880078,
+                "rbh": 8039,
+                "sbh": 603,
+                "gas": 80392,
+                "bpr": 12058752,
+                "sbpr": 301469,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "CryptoAddLiveHash",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 5561692202,
+                "bpt": 8891479,
+                "vpt": 22228697914,
+                "rbh": 5928,
+                "sbh": 445,
+                "gas": 59277,
+                "bpr": 8891479,
+                "sbpr": 222287,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 88987075231,
+                "bpt": 142263667,
+                "vpt": 355659166619,
+                "rbh": 94842,
+                "sbh": 7113,
+                "gas": 948424,
+                "bpr": 142263667,
+                "sbpr": 3556592,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 88987075231,
+                "bpt": 142263667,
+                "vpt": 355659166619,
+                "rbh": 94842,
+                "sbh": 7113,
+                "gas": 948424,
+                "bpr": 142263667,
+                "sbpr": 3556592,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "CryptoDeleteLiveHash",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 468546396,
+                "bpt": 749065,
+                "vpt": 1872663195,
+                "rbh": 499,
+                "sbh": 37,
+                "gas": 4994,
+                "bpr": 749065,
+                "sbpr": 18727,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 7496742329,
+                "bpt": 11985044,
+                "vpt": 29962611113,
+                "rbh": 7990,
+                "sbh": 599,
+                "gas": 79900,
+                "bpr": 11985044,
+                "sbpr": 299626,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 7496742329,
+                "bpt": 11985044,
+                "vpt": 29962611113,
+                "rbh": 7990,
+                "sbh": 599,
+                "gas": 79900,
+                "bpr": 11985044,
+                "sbpr": 299626,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "CryptoGetLiveHash",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 58926,
+                "bpt": 94,
+                "vpt": 235514,
+                "rbh": 0,
+                "sbh": 0,
+                "gas": 1,
+                "bpr": 94,
+                "sbpr": 2,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 942822,
+                "bpt": 1507,
+                "vpt": 3768224,
+                "rbh": 1,
+                "sbh": 0,
+                "gas": 10,
+                "bpr": 1507,
+                "sbpr": 38,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 942822,
+                "bpt": 1507,
+                "vpt": 3768224,
+                "rbh": 1,
+                "sbh": 0,
+                "gas": 10,
+                "bpr": 1507,
+                "sbpr": 38,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "CryptoGetAccountRecords",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 22044,
+                "bpt": 35,
+                "vpt": 88105,
+                "rbh": 0,
+                "sbh": 0,
+                "gas": 0,
+                "bpr": 35,
+                "sbpr": 1,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 352708,
+                "bpt": 564,
+                "vpt": 1409688,
+                "rbh": 0,
+                "sbh": 0,
+                "gas": 4,
+                "bpr": 564,
+                "sbpr": 14,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 352708,
+                "bpt": 564,
+                "vpt": 1409688,
+                "rbh": 0,
+                "sbh": 0,
+                "gas": 4,
+                "bpr": 564,
+                "sbpr": 14,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "CryptoGetAccountBalance",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 68774,
+                "bpt": 110,
+                "vpt": 274874,
+                "rbh": 0,
+                "sbh": 0,
+                "gas": 1,
+                "bpr": 110,
+                "sbpr": 3,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 1100389,
+                "bpt": 1759,
+                "vpt": 4397982,
+                "rbh": 1,
+                "sbh": 0,
+                "gas": 12,
+                "bpr": 1759,
+                "sbpr": 44,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 1100389,
+                "bpt": 1759,
+                "vpt": 4397982,
+                "rbh": 1,
+                "sbh": 0,
+                "gas": 12,
+                "bpr": 1759,
+                "sbpr": 44,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "CryptoGetInfo",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 63990,
+                "bpt": 102,
+                "vpt": 255752,
+                "rbh": 0,
+                "sbh": 0,
+                "gas": 1,
+                "bpr": 102,
+                "sbpr": 3,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 1023841,
+                "bpt": 1637,
+                "vpt": 4092038,
+                "rbh": 1,
+                "sbh": 0,
+                "gas": 11,
+                "bpr": 1637,
+                "sbpr": 41,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 1023841,
+                "bpt": 1637,
+                "vpt": 4092038,
+                "rbh": 1,
+                "sbh": 0,
+                "gas": 11,
+                "bpr": 1637,
+                "sbpr": 41,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "CryptoGetStakers",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 15251,
+                "bpt": 24,
+                "vpt": 60953,
+                "rbh": 0,
+                "sbh": 0,
+                "gas": 0,
+                "bpr": 24,
+                "sbpr": 1,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 244011,
+                "bpt": 390,
+                "vpt": 975251,
+                "rbh": 0,
+                "sbh": 0,
+                "gas": 3,
+                "bpr": 390,
+                "sbpr": 10,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 244011,
+                "bpt": 390,
+                "vpt": 975251,
+                "rbh": 0,
+                "sbh": 0,
+                "gas": 3,
+                "bpr": 390,
+                "sbpr": 10,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "ConsensusCreateTopic",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 921577366,
+                "bpt": 1473326,
+                "vpt": 3683315100,
+                "rbh": 982,
+                "sbh": 74,
+                "gas": 9822,
+                "bpr": 1473326,
+                "sbpr": 36833,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 14745237852,
+                "bpt": 23573217,
+                "vpt": 58933041595,
+                "rbh": 15715,
+                "sbh": 1179,
+                "gas": 157155,
+                "bpr": 23573217,
+                "sbpr": 589330,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 14745237852,
+                "bpt": 23573217,
+                "vpt": 58933041595,
+                "rbh": 15715,
+                "sbh": 1179,
+                "gas": 157155,
+                "bpr": 23573217,
+                "sbpr": 589330,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "ConsensusUpdateTopic",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 20193780,
+                "bpt": 32284,
+                "vpt": 80709508,
+                "rbh": 22,
+                "sbh": 2,
+                "gas": 215,
+                "bpr": 32284,
+                "sbpr": 807,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 323100486,
+                "bpt": 516541,
+                "vpt": 1291352134,
+                "rbh": 344,
+                "sbh": 26,
+                "gas": 3444,
+                "bpr": 516541,
+                "sbpr": 12914,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 323100486,
+                "bpt": 516541,
+                "vpt": 1291352134,
+                "rbh": 344,
+                "sbh": 26,
+                "gas": 3444,
+                "bpr": 516541,
+                "sbpr": 12914,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "ConsensusDeleteTopic",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 474345144,
+                "bpt": 758336,
+                "vpt": 1895839348,
+                "rbh": 506,
+                "sbh": 38,
+                "gas": 5056,
+                "bpr": 758336,
+                "sbpr": 18958,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 7589522307,
+                "bpt": 12133372,
+                "vpt": 30333429564,
+                "rbh": 8089,
+                "sbh": 607,
+                "gas": 80889,
+                "bpr": 12133372,
+                "sbpr": 303334,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 7589522307,
+                "bpt": 12133372,
+                "vpt": 30333429564,
+                "rbh": 8089,
+                "sbh": 607,
+                "gas": 80889,
+                "bpr": 12133372,
+                "sbpr": 303334,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "ConsensusSubmitMessage",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 9248442,
+                "bpt": 14785,
+                "vpt": 36963719,
+                "rbh": 10,
+                "sbh": 1,
+                "gas": 99,
+                "bpr": 14785,
+                "sbpr": 370,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 147975076,
+                "bpt": 236568,
+                "vpt": 591419509,
+                "rbh": 158,
+                "sbh": 12,
+                "gas": 1577,
+                "bpr": 236568,
+                "sbpr": 5914,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 147975076,
+                "bpt": 236568,
+                "vpt": 591419509,
+                "rbh": 158,
+                "sbh": 12,
+                "gas": 1577,
+                "bpr": 236568,
+                "sbpr": 5914,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "ConsensusGetTopicInfo",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 64253,
+                "bpt": 103,
+                "vpt": 256803,
+                "rbh": 0,
+                "sbh": 0,
+                "gas": 1,
+                "bpr": 103,
+                "sbpr": 3,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 1028048,
+                "bpt": 1644,
+                "vpt": 4108851,
+                "rbh": 1,
+                "sbh": 0,
+                "gas": 11,
+                "bpr": 1644,
+                "sbpr": 41,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 1028048,
+                "bpt": 1644,
+                "vpt": 4108851,
+                "rbh": 1,
+                "sbh": 0,
+                "gas": 11,
+                "bpr": 1644,
+                "sbpr": 41,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "TokenCreate",
+          "fees": [
+            {
+              "subType": "TOKEN_FUNGIBLE_COMMON_WITH_CUSTOM_FEES",
+              "nodedata": {
+                "constant": 393746195920,
+                "bpt": 17485616,
+                "vpt": 43714039850,
+                "rbh": 11657,
+                "sbh": 874,
+                "gas": 116571,
+                "bpr": 17485616,
+                "sbpr": 437140,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 7874923918408,
+                "bpt": 349712319,
+                "vpt": 874280797002,
+                "rbh": 233142,
+                "sbh": 17486,
+                "gas": 2331415,
+                "bpr": 349712319,
+                "sbpr": 8742808,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 7874923918408,
+                "bpt": 349712319,
+                "vpt": 874280797002,
+                "rbh": 233142,
+                "sbh": 17486,
+                "gas": 2331415,
+                "bpr": 349712319,
+                "sbpr": 8742808,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            },
+            {
+              "subType": "TOKEN_FUNGIBLE_COMMON",
+              "nodedata": {
+                "constant": 197306974233,
+                "bpt": 8762076,
+                "vpt": 21905189240,
+                "rbh": 5841,
+                "sbh": 438,
+                "gas": 58414,
+                "bpr": 8762076,
+                "sbpr": 219052,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 3946139484654,
+                "bpt": 175241514,
+                "vpt": 438103784807,
+                "rbh": 116828,
+                "sbh": 8762,
+                "gas": 1168277,
+                "bpr": 175241514,
+                "sbpr": 4381038,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 3946139484654,
+                "bpt": 175241514,
+                "vpt": 438103784807,
+                "rbh": 116828,
+                "sbh": 8762,
+                "gas": 1168277,
+                "bpr": 175241514,
+                "sbpr": 4381038,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            },
+            {
+              "subType": "TOKEN_NON_FUNGIBLE_UNIQUE",
+              "nodedata": {
+                "constant": 197031853851,
+                "bpt": 8749858,
+                "vpt": 21874645140,
+                "rbh": 5833,
+                "sbh": 437,
+                "gas": 58332,
+                "bpr": 8749858,
+                "sbpr": 218746,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 3940637077020,
+                "bpt": 174997161,
+                "vpt": 437492902800,
+                "rbh": 116665,
+                "sbh": 8750,
+                "gas": 1166648,
+                "bpr": 174997161,
+                "sbpr": 4374929,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 3940637077020,
+                "bpt": 174997161,
+                "vpt": 437492902800,
+                "rbh": 116665,
+                "sbh": 8750,
+                "gas": 1166648,
+                "bpr": 174997161,
+                "sbpr": 4374929,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            },
+            {
+              "subType": "TOKEN_NON_FUNGIBLE_UNIQUE_WITH_CUSTOM_FEES",
+              "nodedata": {
+                "constant": 393198370765,
+                "bpt": 17461288,
+                "vpt": 43653219832,
+                "rbh": 11641,
+                "sbh": 873,
+                "gas": 116409,
+                "bpr": 17461288,
+                "sbpr": 436532,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 7863967415309,
+                "bpt": 349225759,
+                "vpt": 873064396645,
+                "rbh": 232817,
+                "sbh": 17461,
+                "gas": 2328172,
+                "bpr": 349225759,
+                "sbpr": 8730644,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 7863967415309,
+                "bpt": 349225759,
+                "vpt": 873064396645,
+                "rbh": 232817,
+                "sbh": 17461,
+                "gas": 2328172,
+                "bpr": 349225759,
+                "sbpr": 8730644,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "TokenDelete",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 94285588,
+                "bpt": 150734,
+                "vpt": 376836001,
+                "rbh": 100,
+                "sbh": 8,
+                "gas": 1005,
+                "bpr": 150734,
+                "sbpr": 3768,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 1508569404,
+                "bpt": 2411750,
+                "vpt": 6029376016,
+                "rbh": 1608,
+                "sbh": 121,
+                "gas": 16078,
+                "bpr": 2411750,
+                "sbpr": 60294,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 1508569404,
+                "bpt": 2411750,
+                "vpt": 6029376016,
+                "rbh": 1608,
+                "sbh": 121,
+                "gas": 16078,
+                "bpr": 2411750,
+                "sbpr": 60294,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "TokenFeeScheduleUpdate",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 73998596,
+                "bpt": 118302,
+                "vpt": 295753948,
+                "rbh": 79,
+                "sbh": 6,
+                "gas": 789,
+                "bpr": 118302,
+                "sbpr": 2958,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 1479971913,
+                "bpt": 2366032,
+                "vpt": 5915078967,
+                "rbh": 1577,
+                "sbh": 118,
+                "gas": 15774,
+                "bpr": 2366032,
+                "sbpr": 59151,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 1479971913,
+                "bpt": 2366032,
+                "vpt": 5915078967,
+                "rbh": 1577,
+                "sbh": 118,
+                "gas": 15774,
+                "bpr": 2366032,
+                "sbpr": 59151,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "TokenUpdate",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 93900697,
+                "bpt": 150119,
+                "vpt": 375297688,
+                "rbh": 100,
+                "sbh": 8,
+                "gas": 1001,
+                "bpr": 150119,
+                "sbpr": 3753,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 1502411149,
+                "bpt": 2401905,
+                "vpt": 6004763005,
+                "rbh": 1601,
+                "sbh": 120,
+                "gas": 16013,
+                "bpr": 2401905,
+                "sbpr": 60048,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 1502411149,
+                "bpt": 2401905,
+                "vpt": 6004763005,
+                "rbh": 1601,
+                "sbh": 120,
+                "gas": 16013,
+                "bpr": 2401905,
+                "sbpr": 60048,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "TokenMint",
+          "fees": [
+            {
+              "subType": "TOKEN_FUNGIBLE_COMMON",
+              "nodedata": {
+                "constant": 94092119,
+                "bpt": 150425,
+                "vpt": 376062755,
+                "rbh": 100,
+                "sbh": 8,
+                "gas": 1003,
+                "bpr": 150425,
+                "sbpr": 3761,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 1505473906,
+                "bpt": 2406802,
+                "vpt": 6017004081,
+                "rbh": 1605,
+                "sbh": 120,
+                "gas": 16045,
+                "bpr": 2406802,
+                "sbpr": 60170,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 1505473906,
+                "bpt": 2406802,
+                "vpt": 6017004081,
+                "rbh": 1605,
+                "sbh": 120,
+                "gas": 16045,
+                "bpr": 2406802,
+                "sbpr": 60170,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            },
+            {
+              "subType": "TOKEN_NON_FUNGIBLE_UNIQUE",
+              "nodedata": {
+                "constant": 3606440483,
+                "bpt": 5765618,
+                "vpt": 14414043986,
+                "rbh": 3844,
+                "sbh": 288,
+                "gas": 38437,
+                "bpr": 5765618,
+                "sbpr": 144140,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 72128809656,
+                "bpt": 115312352,
+                "vpt": 288280879722,
+                "rbh": 76875,
+                "sbh": 5766,
+                "gas": 768749,
+                "bpr": 115312352,
+                "sbpr": 2882809,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 72128809656,
+                "bpt": 115312352,
+                "vpt": 288280879722,
+                "rbh": 76875,
+                "sbh": 5766,
+                "gas": 768749,
+                "bpr": 115312352,
+                "sbpr": 2882809,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "TokenBurn",
+          "fees": [
+            {
+              "subType": "TOKEN_FUNGIBLE_COMMON",
+              "nodedata": {
+                "constant": 94092119,
+                "bpt": 150425,
+                "vpt": 376062755,
+                "rbh": 100,
+                "sbh": 8,
+                "gas": 1003,
+                "bpr": 150425,
+                "sbpr": 3761,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 1505473906,
+                "bpt": 2406802,
+                "vpt": 6017004081,
+                "rbh": 1605,
+                "sbh": 120,
+                "gas": 16045,
+                "bpr": 2406802,
+                "sbpr": 60170,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 1505473906,
+                "bpt": 2406802,
+                "vpt": 6017004081,
+                "rbh": 1605,
+                "sbh": 120,
+                "gas": 16045,
+                "bpr": 2406802,
+                "sbpr": 60170,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            },
+            {
+              "subType": "TOKEN_NON_FUNGIBLE_UNIQUE",
+              "nodedata": {
+                "constant": 76366243,
+                "bpt": 122087,
+                "vpt": 305216845,
+                "rbh": 81,
+                "sbh": 6,
+                "gas": 814,
+                "bpr": 122087,
+                "sbpr": 3052,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 1527324859,
+                "bpt": 2441735,
+                "vpt": 6104336894,
+                "rbh": 1628,
+                "sbh": 122,
+                "gas": 16278,
+                "bpr": 2441735,
+                "sbpr": 61043,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 1527324859,
+                "bpt": 2441735,
+                "vpt": 6104336894,
+                "rbh": 1628,
+                "sbh": 122,
+                "gas": 16278,
+                "bpr": 2441735,
+                "sbpr": 61043,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "TokenAssociateToAccount",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 4574479485,
+                "bpt": 7313222,
+                "vpt": 18283054670,
+                "rbh": 4875,
+                "sbh": 366,
+                "gas": 48755,
+                "bpr": 7313222,
+                "sbpr": 182831,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 73191671761,
+                "bpt": 117011550,
+                "vpt": 292528874720,
+                "rbh": 78008,
+                "sbh": 5851,
+                "gas": 780077,
+                "bpr": 117011550,
+                "sbpr": 2925289,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 73191671761,
+                "bpt": 117011550,
+                "vpt": 292528874720,
+                "rbh": 78008,
+                "sbh": 5851,
+                "gas": 780077,
+                "bpr": 117011550,
+                "sbpr": 2925289,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "TokenDissociateFromAccount",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 4714279388,
+                "bpt": 7536720,
+                "vpt": 18841800049,
+                "rbh": 5024,
+                "sbh": 377,
+                "gas": 50245,
+                "bpr": 7536720,
+                "sbpr": 188418,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 75428470213,
+                "bpt": 120587520,
+                "vpt": 301468800784,
+                "rbh": 80392,
+                "sbh": 6029,
+                "gas": 803917,
+                "bpr": 120587520,
+                "sbpr": 3014688,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 75428470213,
+                "bpt": 120587520,
+                "vpt": 301468800784,
+                "rbh": 80392,
+                "sbh": 6029,
+                "gas": 803917,
+                "bpr": 120587520,
+                "sbpr": 3014688,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "TokenGrantKycToAccount",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 94285551,
+                "bpt": 150734,
+                "vpt": 376835856,
+                "rbh": 100,
+                "sbh": 8,
+                "gas": 1005,
+                "bpr": 150734,
+                "sbpr": 3768,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 1508568822,
+                "bpt": 2411749,
+                "vpt": 6029373689,
+                "rbh": 1608,
+                "sbh": 121,
+                "gas": 16078,
+                "bpr": 2411749,
+                "sbpr": 60294,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 1508568822,
+                "bpt": 2411749,
+                "vpt": 6029373689,
+                "rbh": 1608,
+                "sbh": 121,
+                "gas": 16078,
+                "bpr": 2411749,
+                "sbpr": 60294,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "TokenRevokeKycFromAccount",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 94285551,
+                "bpt": 150734,
+                "vpt": 376835856,
+                "rbh": 100,
+                "sbh": 8,
+                "gas": 1005,
+                "bpr": 150734,
+                "sbpr": 3768,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 1508568822,
+                "bpt": 2411749,
+                "vpt": 6029373689,
+                "rbh": 1608,
+                "sbh": 121,
+                "gas": 16078,
+                "bpr": 2411749,
+                "sbpr": 60294,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 1508568822,
+                "bpt": 2411749,
+                "vpt": 6029373689,
+                "rbh": 1608,
+                "sbh": 121,
+                "gas": 16078,
+                "bpr": 2411749,
+                "sbpr": 60294,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "TokenFreezeAccount",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 76054309,
+                "bpt": 121588,
+                "vpt": 303970122,
+                "rbh": 81,
+                "sbh": 6,
+                "gas": 811,
+                "bpr": 121588,
+                "sbpr": 3040,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 1521086180,
+                "bpt": 2431761,
+                "vpt": 6079402448,
+                "rbh": 1621,
+                "sbh": 122,
+                "gas": 16212,
+                "bpr": 2431761,
+                "sbpr": 60794,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 1521086180,
+                "bpt": 2431761,
+                "vpt": 6079402448,
+                "rbh": 1621,
+                "sbh": 122,
+                "gas": 16212,
+                "bpr": 2431761,
+                "sbpr": 60794,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "TokenUnfreezeAccount",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 76054309,
+                "bpt": 121588,
+                "vpt": 303970122,
+                "rbh": 81,
+                "sbh": 6,
+                "gas": 811,
+                "bpr": 121588,
+                "sbpr": 3040,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 1521086180,
+                "bpt": 2431761,
+                "vpt": 6079402448,
+                "rbh": 1621,
+                "sbh": 122,
+                "gas": 16212,
+                "bpr": 2431761,
+                "sbpr": 60794,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 1521086180,
+                "bpt": 2431761,
+                "vpt": 6079402448,
+                "rbh": 1621,
+                "sbh": 122,
+                "gas": 16212,
+                "bpr": 2431761,
+                "sbpr": 60794,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "TokenPause",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 76523246,
+                "bpt": 122338,
+                "vpt": 305844348,
+                "rbh": 82,
+                "sbh": 6,
+                "gas": 816,
+                "bpr": 122338,
+                "sbpr": 3058,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 1530464926,
+                "bpt": 2446755,
+                "vpt": 6116886962,
+                "rbh": 1631,
+                "sbh": 122,
+                "gas": 16312,
+                "bpr": 2446755,
+                "sbpr": 61169,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 1530464926,
+                "bpt": 2446755,
+                "vpt": 6116886962,
+                "rbh": 1631,
+                "sbh": 122,
+                "gas": 16312,
+                "bpr": 2446755,
+                "sbpr": 61169,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "TokenUnpause",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 76523246,
+                "bpt": 122338,
+                "vpt": 305844348,
+                "rbh": 82,
+                "sbh": 6,
+                "gas": 816,
+                "bpr": 122338,
+                "sbpr": 3058,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 1530464926,
+                "bpt": 2446755,
+                "vpt": 6116886962,
+                "rbh": 1631,
+                "sbh": 122,
+                "gas": 16312,
+                "bpr": 2446755,
+                "sbpr": 61169,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 1530464926,
+                "bpt": 2446755,
+                "vpt": 6116886962,
+                "rbh": 1631,
+                "sbh": 122,
+                "gas": 16312,
+                "bpr": 2446755,
+                "sbpr": 61169,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "TokenAccountWipe",
+          "fees": [
+            {
+              "subType": "TOKEN_FUNGIBLE_COMMON",
+              "nodedata": {
+                "constant": 94092119,
+                "bpt": 150425,
+                "vpt": 376062755,
+                "rbh": 100,
+                "sbh": 8,
+                "gas": 1003,
+                "bpr": 150425,
+                "sbpr": 3761,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 1505473906,
+                "bpt": 2406802,
+                "vpt": 6017004081,
+                "rbh": 1605,
+                "sbh": 120,
+                "gas": 16045,
+                "bpr": 2406802,
+                "sbpr": 60170,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 1505473906,
+                "bpt": 2406802,
+                "vpt": 6017004081,
+                "rbh": 1605,
+                "sbh": 120,
+                "gas": 16045,
+                "bpr": 2406802,
+                "sbpr": 60170,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            },
+            {
+              "subType": "TOKEN_NON_FUNGIBLE_UNIQUE",
+              "nodedata": {
+                "constant": 76366243,
+                "bpt": 122087,
+                "vpt": 305216845,
+                "rbh": 81,
+                "sbh": 6,
+                "gas": 814,
+                "bpr": 122087,
+                "sbpr": 3052,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 1527324859,
+                "bpt": 2441735,
+                "vpt": 6104336894,
+                "rbh": 1628,
+                "sbh": 122,
+                "gas": 16278,
+                "bpr": 2441735,
+                "sbpr": 61043,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 1527324859,
+                "bpt": 2441735,
+                "vpt": 6104336894,
+                "rbh": 1628,
+                "sbh": 122,
+                "gas": 16278,
+                "bpr": 2441735,
+                "sbpr": 61043,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "TokenGetInfo",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 61717,
+                "bpt": 99,
+                "vpt": 246668,
+                "rbh": 0,
+                "sbh": 0,
+                "gas": 1,
+                "bpr": 99,
+                "sbpr": 2,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 987474,
+                "bpt": 1579,
+                "vpt": 3946688,
+                "rbh": 1,
+                "sbh": 0,
+                "gas": 11,
+                "bpr": 1579,
+                "sbpr": 39,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 987474,
+                "bpt": 1579,
+                "vpt": 3946688,
+                "rbh": 1,
+                "sbh": 0,
+                "gas": 11,
+                "bpr": 1579,
+                "sbpr": 39,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "ScheduleCreate",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 563513000,
+                "bpt": 900888,
+                "vpt": 2252221049,
+                "rbh": 601,
+                "sbh": 45,
+                "gas": 6006,
+                "bpr": 900888,
+                "sbpr": 22522,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 9016208000,
+                "bpt": 14414215,
+                "vpt": 36035536788,
+                "rbh": 9609,
+                "sbh": 721,
+                "gas": 96095,
+                "bpr": 14414215,
+                "sbpr": 360355,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 9016208000,
+                "bpt": 14414215,
+                "vpt": 36035536788,
+                "rbh": 9609,
+                "sbh": 721,
+                "gas": 96095,
+                "bpr": 14414215,
+                "sbpr": 360355,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "TokenGetNftInfo",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 54605,
+                "bpt": 87,
+                "vpt": 218244,
+                "rbh": 0,
+                "sbh": 0,
+                "gas": 1,
+                "bpr": 87,
+                "sbpr": 2,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 0,
+                "bpt": 0,
+                "vpt": 0,
+                "rbh": 0,
+                "sbh": 0,
+                "gas": 0,
+                "bpr": 0,
+                "sbpr": 0,
+                "min": 0,
+                "max": 0
+              },
+              "servicedata": {
+                "constant": 0,
+                "bpt": 0,
+                "vpt": 0,
+                "rbh": 0,
+                "sbh": 0,
+                "gas": 0,
+                "bpr": 0,
+                "sbpr": 0,
+                "min": 0,
+                "max": 0
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "ScheduleSign",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 58040915,
+                "bpt": 92790,
+                "vpt": 231975077,
+                "rbh": 62,
+                "sbh": 5,
+                "gas": 619,
+                "bpr": 92790,
+                "sbpr": 2320,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 928654648,
+                "bpt": 1484640,
+                "vpt": 3711601232,
+                "rbh": 990,
+                "sbh": 74,
+                "gas": 9898,
+                "bpr": 1484640,
+                "sbpr": 37116,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 928654648,
+                "bpt": 1484640,
+                "vpt": 3711601232,
+                "rbh": 990,
+                "sbh": 74,
+                "gas": 9898,
+                "bpr": 1484640,
+                "sbpr": 37116,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "ScheduleDelete",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 95360774,
+                "bpt": 152453,
+                "vpt": 381133253,
+                "rbh": 102,
+                "sbh": 8,
+                "gas": 1016,
+                "bpr": 152453,
+                "sbpr": 3811,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 1525772386,
+                "bpt": 2439253,
+                "vpt": 6098132047,
+                "rbh": 1626,
+                "sbh": 122,
+                "gas": 16262,
+                "bpr": 2439253,
+                "sbpr": 60981,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 1525772386,
+                "bpt": 2439253,
+                "vpt": 6098132047,
+                "rbh": 1626,
+                "sbh": 122,
+                "gas": 16262,
+                "bpr": 2439253,
+                "sbpr": 60981,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "ScheduleGetInfo",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 53393,
+                "bpt": 85,
+                "vpt": 213400,
+                "rbh": 0,
+                "sbh": 0,
+                "gas": 1,
+                "bpr": 85,
+                "sbpr": 2,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 854295,
+                "bpt": 1366,
+                "vpt": 3414402,
+                "rbh": 1,
+                "sbh": 0,
+                "gas": 9,
+                "bpr": 1366,
+                "sbpr": 34,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 854295,
+                "bpt": 1366,
+                "vpt": 3414402,
+                "rbh": 1,
+                "sbh": 0,
+                "gas": 9,
+                "bpr": 1366,
+                "sbpr": 34,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "ContractCreate",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 45218052173,
+                "bpt": 72290115,
+                "vpt": 180725287466,
+                "rbh": 48193,
+                "sbh": 3615,
+                "gas": 852000,
+                "bpr": 72290115,
+                "sbpr": 1807253,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 723488834765,
+                "bpt": 1156641840,
+                "vpt": 2891604599463,
+                "rbh": 771095,
+                "sbh": 57832,
+                "gas": 852000,
+                "bpr": 1156641840,
+                "sbpr": 28916046,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 0,
+                "bpt": 0,
+                "vpt": 0,
+                "rbh": 0,
+                "sbh": 0,
+                "gas": 852000,
+                "bpr": 0,
+                "sbpr": 0,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "ContractUpdate",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 2438037058,
+                "bpt": 3897691,
+                "vpt": 9744226629,
+                "rbh": 2598,
+                "sbh": 195,
+                "gas": 25985,
+                "bpr": 3897691,
+                "sbpr": 97442,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 39008592923,
+                "bpt": 62363050,
+                "vpt": 155907626067,
+                "rbh": 41575,
+                "sbh": 3118,
+                "gas": 415754,
+                "bpr": 62363050,
+                "sbpr": 1559076,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 39008592923,
+                "bpt": 62363050,
+                "vpt": 155907626067,
+                "rbh": 41575,
+                "sbh": 3118,
+                "gas": 415754,
+                "bpr": 62363050,
+                "sbpr": 1559076,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "ContractDelete",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 664083202,
+                "bpt": 1061670,
+                "vpt": 2654175087,
+                "rbh": 708,
+                "sbh": 53,
+                "gas": 7078,
+                "bpr": 1061670,
+                "sbpr": 26542,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 10625331229,
+                "bpt": 16986721,
+                "vpt": 42466801390,
+                "rbh": 11324,
+                "sbh": 849,
+                "gas": 113245,
+                "bpr": 16986721,
+                "sbpr": 424668,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 10625331229,
+                "bpt": 16986721,
+                "vpt": 42466801390,
+                "rbh": 11324,
+                "sbh": 849,
+                "gas": 113245,
+                "bpr": 16986721,
+                "sbpr": 424668,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "ContractCall",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 0,
+                "bpt": 0,
+                "vpt": 0,
+                "rbh": 0,
+                "sbh": 0,
+                "gas": 0,
+                "bpr": 0,
+                "sbpr": 0,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 0,
+                "bpt": 0,
+                "vpt": 0,
+                "rbh": 0,
+                "sbh": 0,
+                "gas": 0,
+                "bpr": 0,
+                "sbpr": 0,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 0,
+                "bpt": 0,
+                "vpt": 0,
+                "rbh": 0,
+                "sbh": 0,
+                "gas": 852000,
+                "bpr": 0,
+                "sbpr": 0,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "EthereumTransaction",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 3336515210,
+                "bpt": 5334088,
+                "vpt": 13335219927,
+                "rbh": 3556,
+                "sbh": 267,
+                "gas": 0,
+                "bpr": 5334088,
+                "sbpr": 133352,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 53384243355,
+                "bpt": 85345408,
+                "vpt": 213363518838,
+                "rbh": 56897,
+                "sbh": 4267,
+                "gas": 0,
+                "bpr": 85345408,
+                "sbpr": 2133635,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 0,
+                "bpt": 0,
+                "vpt": 0,
+                "rbh": 0,
+                "sbh": 0,
+                "gas": 852000,
+                "bpr": 0,
+                "sbpr": 0,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "ContractGetInfo",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 71015,
+                "bpt": 114,
+                "vpt": 283830,
+                "rbh": 0,
+                "sbh": 0,
+                "gas": 1,
+                "bpr": 114,
+                "sbpr": 3,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 1136244,
+                "bpt": 1817,
+                "vpt": 4541284,
+                "rbh": 1,
+                "sbh": 0,
+                "gas": 12,
+                "bpr": 1817,
+                "sbpr": 45,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 1136244,
+                "bpt": 1817,
+                "vpt": 4541284,
+                "rbh": 1,
+                "sbh": 0,
+                "gas": 12,
+                "bpr": 1817,
+                "sbpr": 45,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "ContractCallLocal",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 2610100486,
+                "bpt": 4172769,
+                "vpt": 10431921279,
+                "rbh": 2782,
+                "sbh": 209,
+                "gas": 852000,
+                "bpr": 4172769,
+                "sbpr": 104319,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 41761607776,
+                "bpt": 66764296,
+                "vpt": 166910740461,
+                "rbh": 44510,
+                "sbh": 3338,
+                "gas": 852000,
+                "bpr": 66764296,
+                "sbpr": 1669107,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 41761607776,
+                "bpt": 66764296,
+                "vpt": 166910740461,
+                "rbh": 44510,
+                "sbh": 3338,
+                "gas": 852000,
+                "bpr": 66764296,
+                "sbpr": 1669107,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "ContractGetBytecode",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 226589259813,
+                "bpt": 362248325,
+                "vpt": 905620811793,
+                "rbh": 241499,
+                "sbh": 18112,
+                "gas": 2414989,
+                "bpr": 362248325,
+                "sbpr": 9056208,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 3625428157003,
+                "bpt": 5795973195,
+                "vpt": 14489932988688,
+                "rbh": 3863982,
+                "sbh": 289799,
+                "gas": 38639821,
+                "bpr": 5795973195,
+                "sbpr": 144899330,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 3625428157003,
+                "bpt": 5795973195,
+                "vpt": 14489932988688,
+                "rbh": 3863982,
+                "sbh": 289799,
+                "gas": 38639821,
+                "bpr": 5795973195,
+                "sbpr": 144899330,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "GetBySolidityID",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 69385,
+                "bpt": 111,
+                "vpt": 277313,
+                "rbh": 0,
+                "sbh": 0,
+                "gas": 1,
+                "bpr": 111,
+                "sbpr": 3,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 1110154,
+                "bpt": 1775,
+                "vpt": 4437010,
+                "rbh": 1,
+                "sbh": 0,
+                "gas": 12,
+                "bpr": 1775,
+                "sbpr": 44,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 1110154,
+                "bpt": 1775,
+                "vpt": 4437010,
+                "rbh": 1,
+                "sbh": 0,
+                "gas": 12,
+                "bpr": 1775,
+                "sbpr": 44,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "ContractGetRecords",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 10093,
+                "bpt": 16,
+                "vpt": 40339,
+                "rbh": 0,
+                "sbh": 0,
+                "gas": 0,
+                "bpr": 16,
+                "sbpr": 0,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 161486,
+                "bpt": 258,
+                "vpt": 645421,
+                "rbh": 0,
+                "sbh": 0,
+                "gas": 2,
+                "bpr": 258,
+                "sbpr": 6,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 161486,
+                "bpt": 258,
+                "vpt": 645421,
+                "rbh": 0,
+                "sbh": 0,
+                "gas": 2,
+                "bpr": 258,
+                "sbpr": 6,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "ContractAutoRenew",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 3399972997,
+                "bpt": 5435538,
+                "vpt": 13588844891,
+                "rbh": 3624,
+                "sbh": 272,
+                "gas": 36237,
+                "bpr": 5435538,
+                "sbpr": 135888,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 67999459941,
+                "bpt": 108710759,
+                "vpt": 271776897828,
+                "rbh": 72474,
+                "sbh": 5436,
+                "gas": 724738,
+                "bpr": 108710759,
+                "sbpr": 2717769,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 67999459941,
+                "bpt": 108710759,
+                "vpt": 271776897828,
+                "rbh": 72474,
+                "sbh": 5436,
+                "gas": 724738,
+                "bpr": 108710759,
+                "sbpr": 2717769,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "FileCreate",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 3657315129,
+                "bpt": 5846951,
+                "vpt": 14617377270,
+                "rbh": 3898,
+                "sbh": 292,
+                "gas": 38980,
+                "bpr": 5846951,
+                "sbpr": 146174,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 58517042062,
+                "bpt": 93551215,
+                "vpt": 233878036318,
+                "rbh": 62367,
+                "sbh": 4678,
+                "gas": 623675,
+                "bpr": 93551215,
+                "sbpr": 2338780,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 58517042062,
+                "bpt": 93551215,
+                "vpt": 233878036318,
+                "rbh": 62367,
+                "sbh": 4678,
+                "gas": 623675,
+                "bpr": 93551215,
+                "sbpr": 2338780,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "FileUpdate",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 3663140881,
+                "bpt": 5856265,
+                "vpt": 14640661348,
+                "rbh": 3904,
+                "sbh": 293,
+                "gas": 39042,
+                "bpr": 5856265,
+                "sbpr": 146407,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 58610254089,
+                "bpt": 93700233,
+                "vpt": 234250581567,
+                "rbh": 62467,
+                "sbh": 4685,
+                "gas": 624668,
+                "bpr": 93700233,
+                "sbpr": 2342506,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 58610254089,
+                "bpt": 93700233,
+                "vpt": 234250581567,
+                "rbh": 62467,
+                "sbh": 4685,
+                "gas": 624668,
+                "bpr": 93700233,
+                "sbpr": 2342506,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "FileDelete",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 664083202,
+                "bpt": 1061670,
+                "vpt": 2654175087,
+                "rbh": 708,
+                "sbh": 53,
+                "gas": 7078,
+                "bpr": 1061670,
+                "sbpr": 26542,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 10625331229,
+                "bpt": 16986721,
+                "vpt": 42466801390,
+                "rbh": 11324,
+                "sbh": 849,
+                "gas": 113245,
+                "bpr": 16986721,
+                "sbpr": 424668,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 10625331229,
+                "bpt": 16986721,
+                "vpt": 42466801390,
+                "rbh": 11324,
+                "sbh": 849,
+                "gas": 113245,
+                "bpr": 16986721,
+                "sbpr": 424668,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "FileAppend",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 2981423158,
+                "bpt": 4766402,
+                "vpt": 11916005477,
+                "rbh": 3178,
+                "sbh": 238,
+                "gas": 31776,
+                "bpr": 4766402,
+                "sbpr": 119160,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 59628463168,
+                "bpt": 95328044,
+                "vpt": 238320109546,
+                "rbh": 63552,
+                "sbh": 4766,
+                "gas": 635520,
+                "bpr": 95328044,
+                "sbpr": 2383201,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 59628463168,
+                "bpt": 95328044,
+                "vpt": 238320109546,
+                "rbh": 63552,
+                "sbh": 4766,
+                "gas": 635520,
+                "bpr": 95328044,
+                "sbpr": 2383201,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "FileGetContents",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 69308,
+                "bpt": 111,
+                "vpt": 277006,
+                "rbh": 0,
+                "sbh": 0,
+                "gas": 1,
+                "bpr": 111,
+                "sbpr": 3,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 1108924,
+                "bpt": 1773,
+                "vpt": 4432093,
+                "rbh": 1,
+                "sbh": 0,
+                "gas": 12,
+                "bpr": 1773,
+                "sbpr": 44,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 1108924,
+                "bpt": 1773,
+                "vpt": 4432093,
+                "rbh": 1,
+                "sbh": 0,
+                "gas": 12,
+                "bpr": 1773,
+                "sbpr": 44,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "FileGetInfo",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 71080,
+                "bpt": 114,
+                "vpt": 284088,
+                "rbh": 0,
+                "sbh": 0,
+                "gas": 1,
+                "bpr": 114,
+                "sbpr": 3,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 1137277,
+                "bpt": 1818,
+                "vpt": 4545413,
+                "rbh": 1,
+                "sbh": 0,
+                "gas": 12,
+                "bpr": 1818,
+                "sbpr": 45,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 1137277,
+                "bpt": 1818,
+                "vpt": 4545413,
+                "rbh": 1,
+                "sbh": 0,
+                "gas": 12,
+                "bpr": 1818,
+                "sbpr": 45,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "GetVersionInfo",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 6519421057,
+                "bpt": 10422601,
+                "vpt": 26056501507,
+                "rbh": 6948,
+                "sbh": 521,
+                "gas": 69484,
+                "bpr": 10422601,
+                "sbpr": 260565,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 104310736905,
+                "bpt": 166761610,
+                "vpt": 416904024105,
+                "rbh": 111174,
+                "sbh": 8338,
+                "gas": 1111744,
+                "bpr": 166761610,
+                "sbpr": 4169040,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 104310736905,
+                "bpt": 166761610,
+                "vpt": 416904024105,
+                "rbh": 111174,
+                "sbh": 8338,
+                "gas": 1111744,
+                "bpr": 166761610,
+                "sbpr": 4169040,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "GetByKey",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 1,
+                "bpt": 0,
+                "vpt": 0,
+                "rbh": 0,
+                "sbh": 0,
+                "gas": 0,
+                "bpr": 0,
+                "sbpr": 0,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 1,
+                "bpt": 0,
+                "vpt": 0,
+                "rbh": 0,
+                "sbh": 0,
+                "gas": 0,
+                "bpr": 0,
+                "sbpr": 0,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 1,
+                "bpt": 0,
+                "vpt": 0,
+                "rbh": 0,
+                "sbh": 0,
+                "gas": 0,
+                "bpr": 0,
+                "sbpr": 0,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "TransactionGetReceipt",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 1,
+                "bpt": 0,
+                "vpt": 0,
+                "rbh": 0,
+                "sbh": 0,
+                "gas": 0,
+                "bpr": 0,
+                "sbpr": 0,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 1,
+                "bpt": 0,
+                "vpt": 0,
+                "rbh": 0,
+                "sbh": 0,
+                "gas": 0,
+                "bpr": 0,
+                "sbpr": 0,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 1,
+                "bpt": 0,
+                "vpt": 0,
+                "rbh": 0,
+                "sbh": 0,
+                "gas": 0,
+                "bpr": 0,
+                "sbpr": 0,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "SystemDelete",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 0,
+                "bpt": 0,
+                "vpt": 0,
+                "rbh": 0,
+                "sbh": 0,
+                "gas": 0,
+                "bpr": 0,
+                "sbpr": 0,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 0,
+                "bpt": 0,
+                "vpt": 0,
+                "rbh": 0,
+                "sbh": 0,
+                "gas": 0,
+                "bpr": 0,
+                "sbpr": 0,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 0,
+                "bpt": 0,
+                "vpt": 0,
+                "rbh": 0,
+                "sbh": 0,
+                "gas": 0,
+                "bpr": 0,
+                "sbpr": 0,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "SystemUndelete",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 0,
+                "bpt": 0,
+                "vpt": 0,
+                "rbh": 0,
+                "sbh": 0,
+                "gas": 0,
+                "bpr": 0,
+                "sbpr": 0,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 0,
+                "bpt": 0,
+                "vpt": 0,
+                "rbh": 0,
+                "sbh": 0,
+                "gas": 0,
+                "bpr": 0,
+                "sbpr": 0,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 0,
+                "bpt": 0,
+                "vpt": 0,
+                "rbh": 0,
+                "sbh": 0,
+                "gas": 0,
+                "bpr": 0,
+                "sbpr": 0,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "TransactionGetRecord",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 54605,
+                "bpt": 87,
+                "vpt": 218244,
+                "rbh": 0,
+                "sbh": 0,
+                "gas": 1,
+                "bpr": 87,
+                "sbpr": 2,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 873685,
+                "bpt": 1397,
+                "vpt": 3491900,
+                "rbh": 1,
+                "sbh": 0,
+                "gas": 9,
+                "bpr": 1397,
+                "sbpr": 35,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 873685,
+                "bpt": 1397,
+                "vpt": 3491900,
+                "rbh": 1,
+                "sbh": 0,
+                "gas": 9,
+                "bpr": 1397,
+                "sbpr": 35,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "expiryTime": 1633392000
+      }
+    ]
   }
 ]

--- a/hedera-node/configuration/mainnet/upgrade/throttles.json
+++ b/hedera-node/configuration/mainnet/upgrade/throttles.json
@@ -1,172 +1,181 @@
 {
   "buckets": [
-	{
-	  "burstPeriod": 0,
-	  "burstPeriodMs": 3000,
-	  "name": "ThroughputLimits",
-	  "throttleGroups": [
-		{
-		  "opsPerSec": 10000,
-		  "milliOpsPerSec": 10000000,
-		  "operations": [
-			"ScheduleCreate",
-			"CryptoCreate",
-			"CryptoTransfer",
-			"CryptoUpdate",
-			"CryptoDelete",
-			"CryptoGetInfo",
-			"CryptoGetAccountRecords",
-			"ConsensusCreateTopic",
-			"ConsensusSubmitMessage",
-			"ConsensusUpdateTopic",
-			"ConsensusDeleteTopic",
-			"ConsensusGetTopicInfo",
-			"TokenGetNftInfo",
-			"TokenGetInfo",
-			"ScheduleDelete",
-			"ScheduleGetInfo",
-			"FileGetContents",
-			"FileGetInfo",
-			"ContractUpdate",
-			"ContractDelete",
-			"ContractGetInfo",
-			"ContractGetBytecode",
-			"ContractGetRecords",
-			"ContractCallLocal",
-			"TransactionGetRecord",
-			"GetVersionInfo",
-			"TokenGetAccountNftInfos",
-			"TokenGetNftInfos",
-			"CryptoApproveAllowance",
-			"CryptoDeleteAllowance",
-			"UtilPrng"
-		  ]
-		},
-		{
-		  "opsPerSec": 13,
-		  "milliOpsPerSec": 13000,
-		  "operations": [
-			"FileCreate",
-			"FileUpdate",
-			"FileAppend",
-			"FileDelete"
-		  ]
-		},
-		{
-		  "opsPerSec": 100,
-		  "milliOpsPerSec": 100000,
-		  "operations": [
-			"ScheduleSign"
-		  ]
-		},
-		{
-		  "opsPerSec": 350,
-		  "operations": [
-			"ContractCall",
-			"ContractCreate",
-                        "EthereumTransaction"
-                   ]
-		},
-		{
-		  "opsPerSec": 3000,
-		  "milliOpsPerSec": 3000000,
-		  "operations": [
-			"TokenCreate",
-			"TokenDelete",
-			"TokenMint",
-			"TokenBurn",
-			"TokenUpdate",
-			"TokenFeeScheduleUpdate",
-			"TokenAssociateToAccount",
-			"TokenAccountWipe",
-			"TokenDissociateFromAccount",
-			"TokenFreezeAccount",
-			"TokenUnfreezeAccount",
-			"TokenGrantKycToAccount",
-			"TokenRevokeKycFromAccount",
-			"TokenPause",
-			"TokenUnpause"
-		  ]
-		}
-	  ]
-	},
-	{
-	  "burstPeriod": 1,
-	  "name": "OffHeapQueryLimits",
-	  "throttleGroups": [
-		{
-		  "opsPerSec": 700,
-		  "operations": [
-			"FileGetContents",
-			"FileGetInfo",
-			"ContractGetInfo",
-			"ContractGetBytecode",
-			"ContractCallLocal"
-		  ]
-		}
-	  ]
-	},
-	{
-	  "burstPeriod": 0,
-	  "burstPeriodMs": 3000,
-	  "name": "PriorityReservations",
-	  "throttleGroups": [
-		{
-		  "opsPerSec": 10,
-		  "milliOpsPerSec": 10000,
-		  "operations": [
-			"FileCreate",
-			"FileUpdate",
-			"FileAppend",
-			"FileDelete"
-		  ]
-		}
-	  ]
-	},
-	{
-	  "burstPeriod": 0,
-	  "burstPeriodMs": 15000,
-	  "name": "CreationLimits",
-	  "throttleGroups": [
-		{
-		  "opsPerSec": 2,
-		  "milliOpsPerSec": 2000,
-		  "operations": [
-			"CryptoCreate"
-		  ]
-		},
-		{
-		  "opsPerSec": 5,
-		  "milliOpsPerSec": 5000,
-		  "operations": [
-			"ConsensusCreateTopic"
-		  ]
-		},
-		{
-		  "opsPerSec": 100,
-		  "milliOpsPerSec": 100000,
-		  "operations": [
-			"TokenCreate",
-			"TokenAssociateToAccount",
-			"ScheduleCreate"
-		  ]
-		}
-	  ]
-	},
-	{
-	  "burstPeriod": 0,
-	  "burstPeriodMs": 1000,
-	  "name": "FreeQueryLimits",
-	  "throttleGroups": [
-		{
-		  "opsPerSec": 1000000,
-		  "milliOpsPerSec": 1000000000,
-		  "operations": [
-			"CryptoGetAccountBalance",
-			"TransactionGetReceipt"
-		  ]
-		}
-	  ]
-	}
+    {
+      "burstPeriod": 0,
+      "burstPeriodMs": 15000,
+      "name": "ThroughputLimits",
+      "throttleGroups": [
+        {
+          "opsPerSec": 0,
+          "milliOpsPerSec": 10500000,
+          "operations": [
+            "ScheduleCreate",
+            "CryptoCreate",
+            "CryptoTransfer",
+            "CryptoUpdate",
+            "CryptoDelete",
+            "CryptoGetInfo",
+            "CryptoGetAccountRecords",
+            "ConsensusCreateTopic",
+            "ConsensusSubmitMessage",
+            "ConsensusUpdateTopic",
+            "ConsensusDeleteTopic",
+            "ConsensusGetTopicInfo",
+            "TokenGetNftInfo",
+            "TokenGetInfo",
+            "ScheduleDelete",
+            "ScheduleGetInfo",
+            "FileGetContents",
+            "FileGetInfo",
+            "ContractUpdate",
+            "ContractDelete",
+            "ContractGetInfo",
+            "ContractGetBytecode",
+            "ContractGetRecords",
+            "ContractCallLocal",
+            "TransactionGetRecord",
+            "GetVersionInfo",
+            "TokenGetAccountNftInfos",
+            "TokenGetNftInfos",
+            "CryptoApproveAllowance",
+            "CryptoDeleteAllowance",
+            "UtilPrng"
+          ]
+        },
+        {
+          "opsPerSec": 0,
+          "milliOpsPerSec": 13000,
+          "operations": [
+            "FileCreate",
+            "FileUpdate",
+            "FileAppend",
+            "FileDelete"
+          ]
+        },
+        {
+          "opsPerSec": 0,
+          "milliOpsPerSec": 100000,
+          "operations": [
+            "ScheduleSign"
+          ]
+        },
+        {
+          "opsPerSec": 0,
+          "milliOpsPerSec": 125000,
+          "operations": [
+            "TokenMint"
+          ]
+        },
+        {
+          "opsPerSec": 0,
+          "milliOpsPerSec": 350000,
+          "operations": [
+            "ContractCall",
+            "ContractCreate",
+            "EthereumTransaction"
+          ]
+        },
+        {
+          "opsPerSec": 0,
+          "milliOpsPerSec": 3000000,
+          "operations": [
+            "TokenCreate",
+            "TokenDelete",
+            "TokenBurn",
+            "TokenUpdate",
+            "TokenFeeScheduleUpdate",
+            "TokenAssociateToAccount",
+            "TokenAccountWipe",
+            "TokenDissociateFromAccount",
+            "TokenFreezeAccount",
+            "TokenUnfreezeAccount",
+            "TokenGrantKycToAccount",
+            "TokenRevokeKycFromAccount",
+            "TokenPause",
+            "TokenUnpause"
+          ]
+        }
+      ]
+    },
+    {
+      "burstPeriod": 0,
+      "burstPeriodMs": 1000,
+      "name": "OffHeapQueryLimits",
+      "throttleGroups": [
+        {
+          "opsPerSec": 0,
+          "milliOpsPerSec": 700000,
+          "operations": [
+            "FileGetContents",
+            "FileGetInfo",
+            "ContractGetInfo",
+            "ContractGetBytecode",
+            "ContractCallLocal"
+          ]
+        }
+      ]
+    },
+    {
+      "burstPeriod": 0,
+      "burstPeriodMs": 3000,
+      "name": "PriorityReservations",
+      "throttleGroups": [
+        {
+          "opsPerSec": 0,
+          "milliOpsPerSec": 10000,
+          "operations": [
+            "FileCreate",
+            "FileUpdate",
+            "FileAppend",
+            "FileDelete"
+          ]
+        }
+      ]
+    },
+    {
+      "burstPeriod": 0,
+      "burstPeriodMs": 15000,
+      "name": "CreationLimits",
+      "throttleGroups": [
+        {
+          "opsPerSec": 0,
+          "milliOpsPerSec": 2000,
+          "operations": [
+            "CryptoCreate"
+          ]
+        },
+        {
+          "opsPerSec": 0,
+          "milliOpsPerSec": 5000,
+          "operations": [
+            "ConsensusCreateTopic"
+          ]
+        },
+        {
+          "opsPerSec": 0,
+          "milliOpsPerSec": 100000,
+          "operations": [
+            "TokenCreate",
+            "TokenAssociateToAccount",
+            "ScheduleCreate"
+          ]
+        }
+      ]
+    },
+    {
+      "burstPeriod": 0,
+      "burstPeriodMs": 1000,
+      "name": "FreeQueryLimits",
+      "throttleGroups": [
+        {
+          "opsPerSec": 0,
+          "milliOpsPerSec": 1000000000,
+          "operations": [
+            "CryptoGetAccountBalance",
+            "TransactionGetReceipt"
+          ]
+        }
+      ]
+    }
   ]
 }

--- a/hedera-node/hedera-mono-service/src/main/resources/feeSchedules.json
+++ b/hedera-node/hedera-mono-service/src/main/resources/feeSchedules.json
@@ -1,6656 +1,6592 @@
 [
   {
-	"currentFeeSchedule": [
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "CryptoCreate",
-		  "fees": [
-			{
-			  "subType": "DEFAULT",
-			  "nodedata": {
-				"constant": 11461413665,
-				"bpt": 508982,
-				"vpt": 1272455960,
-				"rbh": 339,
-				"sbh": 25,
-				"gas": 3393,
-				"bpr": 508982,
-				"sbpr": 12725,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 229228273302,
-				"bpt": 10179648,
-				"vpt": 25449119198,
-				"rbh": 6786,
-				"sbh": 509,
-				"gas": 67864,
-				"bpr": 10179648,
-				"sbpr": 254491,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 229228273302,
-				"bpt": 10179648,
-				"vpt": 25449119198,
-				"rbh": 6786,
-				"sbh": 509,
-				"gas": 67864,
-				"bpr": 10179648,
-				"sbpr": 254491,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "CryptoDeleteAllowance",
-		  "fees": [
-			{
-			  "subType": "DEFAULT",
-			  "nodedata": {
-				"constant": 3794963556,
-				"bpt": 6067009,
-				"vpt": 15167523735,
-				"rbh": 4045,
-				"sbh": 303,
-				"gas": 40447,
-				"bpr": 6067009,
-				"sbpr": 151675,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 75899271121,
-				"bpt": 121340190,
-				"vpt": 303350474702,
-				"rbh": 80893,
-				"sbh": 6067,
-				"gas": 808935,
-				"bpr": 121340190,
-				"sbpr": 3033505,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 75899271121,
-				"bpt": 121340190,
-				"vpt": 303350474702,
-				"rbh": 80893,
-				"sbh": 6067,
-				"gas": 808935,
-				"bpr": 121340190,
-				"sbpr": 3033505,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "CryptoApproveAllowance",
-		  "fees": [
-			{
-			  "subType": "DEFAULT",
-			  "nodedata": {
-				"constant": 3766772044,
-				"bpt": 6021940,
-				"vpt": 15054849285,
-				"rbh": 4015,
-				"sbh": 301,
-				"gas": 40146,
-				"bpr": 6021940,
-				"sbpr": 150548,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 75335440874,
-				"bpt": 120438794,
-				"vpt": 301096985700,
-				"rbh": 80293,
-				"sbh": 6022,
-				"gas": 802925,
-				"bpr": 120438794,
-				"sbpr": 3010970,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 75335440874,
-				"bpt": 120438794,
-				"vpt": 301096985700,
-				"rbh": 80293,
-				"sbh": 6022,
-				"gas": 802925,
-				"bpr": 120438794,
-				"sbpr": 3010970,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "CryptoAccountAutoRenew",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 59972622,
-				"bpt": 95878,
-				"vpt": 239695625,
-				"rbh": 64,
-				"sbh": 5,
-				"gas": 639,
-				"bpr": 95878,
-				"sbpr": 2397,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 959561945,
-				"bpt": 1534052,
-				"vpt": 3835129999,
-				"rbh": 1023,
-				"sbh": 77,
-				"gas": 10227,
-				"bpr": 1534052,
-				"sbpr": 38351,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 959561945,
-				"bpt": 1534052,
-				"vpt": 3835129999,
-				"rbh": 1023,
-				"sbh": 77,
-				"gas": 10227,
-				"bpr": 1534052,
-				"sbpr": 38351,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "CryptoUpdate",
-		  "fees": [
-			{
-			  "subType": "DEFAULT",
-			  "nodedata": {
-				"constant": 16302371,
-				"bpt": 26063,
-				"vpt": 65156516,
-				"rbh": 17,
-				"sbh": 1,
-				"gas": 174,
-				"bpr": 26063,
-				"sbpr": 652,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 326047427,
-				"bpt": 521252,
-				"vpt": 1303130322,
-				"rbh": 348,
-				"sbh": 26,
-				"gas": 3475,
-				"bpr": 521252,
-				"sbpr": 13031,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 326047427,
-				"bpt": 521252,
-				"vpt": 1303130322,
-				"rbh": 348,
-				"sbh": 26,
-				"gas": 3475,
-				"bpr": 521252,
-				"sbpr": 13031,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "CryptoTransfer",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 7574478,
-				"bpt": 12109,
-				"vpt": 30273301,
-				"rbh": 8,
-				"sbh": 1,
-				"gas": 81,
-				"bpr": 12109,
-				"sbpr": 303,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 151489557,
-				"bpt": 242186,
-				"vpt": 605466012,
-				"rbh": 161,
-				"sbh": 12,
-				"gas": 1615,
-				"bpr": 242186,
-				"sbpr": 6055,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 151489557,
-				"bpt": 242186,
-				"vpt": 605466012,
-				"rbh": 161,
-				"sbh": 12,
-				"gas": 1615,
-				"bpr": 242186,
-				"sbpr": 6055,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			},
-			{
-			  "subType": "TOKEN_FUNGIBLE_COMMON",
-			  "nodedata": {
-				"constant": 7983519,
-				"bpt": 12763,
-				"vpt": 31908136,
-				"rbh": 9,
-				"sbh": 1,
-				"gas": 85,
-				"bpr": 12763,
-				"sbpr": 319,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 159670382,
-				"bpt": 255265,
-				"vpt": 638162730,
-				"rbh": 170,
-				"sbh": 13,
-				"gas": 1702,
-				"bpr": 255265,
-				"sbpr": 6382,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 159670382,
-				"bpt": 255265,
-				"vpt": 638162730,
-				"rbh": 170,
-				"sbh": 13,
-				"gas": 1702,
-				"bpr": 255265,
-				"sbpr": 6382,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			},
-			{
-			  "subType": "TOKEN_FUNGIBLE_COMMON_WITH_CUSTOM_FEES",
-			  "nodedata": {
-				"constant": 15967037,
-				"bpt": 25527,
-				"vpt": 63816270,
-				"rbh": 17,
-				"sbh": 1,
-				"gas": 170,
-				"bpr": 25527,
-				"sbpr": 638,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 319340747,
-				"bpt": 510530,
-				"vpt": 1276325394,
-				"rbh": 340,
-				"sbh": 26,
-				"gas": 3404,
-				"bpr": 510530,
-				"sbpr": 12763,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 319340747,
-				"bpt": 510530,
-				"vpt": 1276325394,
-				"rbh": 340,
-				"sbh": 26,
-				"gas": 3404,
-				"bpr": 510530,
-				"sbpr": 12763,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			},
-			{
-			  "subType": "TOKEN_NON_FUNGIBLE_UNIQUE",
-			  "nodedata": {
-				"constant": 22833842,
-				"bpt": 36504,
-				"vpt": 91261178,
-				"rbh": 24,
-				"sbh": 2,
-				"gas": 243,
-				"bpr": 36504,
-				"sbpr": 913,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 456676846,
-				"bpt": 730089,
-				"vpt": 1825223562,
-				"rbh": 487,
-				"sbh": 37,
-				"gas": 4867,
-				"bpr": 730089,
-				"sbpr": 18252,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 456676846,
-				"bpt": 730089,
-				"vpt": 1825223562,
-				"rbh": 487,
-				"sbh": 37,
-				"gas": 4867,
-				"bpr": 730089,
-				"sbpr": 18252,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			},
-			{
-			  "subType": "TOKEN_NON_FUNGIBLE_UNIQUE_WITH_CUSTOM_FEES",
-			  "nodedata": {
-				"constant": 45667678,
-				"bpt": 73009,
-				"vpt": 182522330,
-				"rbh": 49,
-				"sbh": 4,
-				"gas": 487,
-				"bpr": 73009,
-				"sbpr": 1825,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 913353558,
-				"bpt": 1460179,
-				"vpt": 3650446591,
-				"rbh": 973,
-				"sbh": 73,
-				"gas": 9735,
-				"bpr": 1460179,
-				"sbpr": 36504,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 913353558,
-				"bpt": 1460179,
-				"vpt": 3650446591,
-				"rbh": 973,
-				"sbh": 73,
-				"gas": 9735,
-				"bpr": 1460179,
-				"sbpr": 36504,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "CryptoDelete",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 471427939,
-				"bpt": 753672,
-				"vpt": 1884180005,
-				"rbh": 502,
-				"sbh": 38,
-				"gas": 5024,
-				"bpr": 753672,
-				"sbpr": 18842,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 7542847021,
-				"bpt": 12058752,
-				"vpt": 30146880078,
-				"rbh": 8039,
-				"sbh": 603,
-				"gas": 80392,
-				"bpr": 12058752,
-				"sbpr": 301469,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 7542847021,
-				"bpt": 12058752,
-				"vpt": 30146880078,
-				"rbh": 8039,
-				"sbh": 603,
-				"gas": 80392,
-				"bpr": 12058752,
-				"sbpr": 301469,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "CryptoAddLiveHash",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 5561692202,
-				"bpt": 8891479,
-				"vpt": 22228697914,
-				"rbh": 5928,
-				"sbh": 445,
-				"gas": 59277,
-				"bpr": 8891479,
-				"sbpr": 222287,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 88987075231,
-				"bpt": 142263667,
-				"vpt": 355659166619,
-				"rbh": 94842,
-				"sbh": 7113,
-				"gas": 948424,
-				"bpr": 142263667,
-				"sbpr": 3556592,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 88987075231,
-				"bpt": 142263667,
-				"vpt": 355659166619,
-				"rbh": 94842,
-				"sbh": 7113,
-				"gas": 948424,
-				"bpr": 142263667,
-				"sbpr": 3556592,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "CryptoDeleteLiveHash",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 468546396,
-				"bpt": 749065,
-				"vpt": 1872663195,
-				"rbh": 499,
-				"sbh": 37,
-				"gas": 4994,
-				"bpr": 749065,
-				"sbpr": 18727,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 7496742329,
-				"bpt": 11985044,
-				"vpt": 29962611113,
-				"rbh": 7990,
-				"sbh": 599,
-				"gas": 79900,
-				"bpr": 11985044,
-				"sbpr": 299626,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 7496742329,
-				"bpt": 11985044,
-				"vpt": 29962611113,
-				"rbh": 7990,
-				"sbh": 599,
-				"gas": 79900,
-				"bpr": 11985044,
-				"sbpr": 299626,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "CryptoGetLiveHash",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 58926,
-				"bpt": 94,
-				"vpt": 235514,
-				"rbh": 0,
-				"sbh": 0,
-				"gas": 1,
-				"bpr": 94,
-				"sbpr": 2,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 942822,
-				"bpt": 1507,
-				"vpt": 3768224,
-				"rbh": 1,
-				"sbh": 0,
-				"gas": 10,
-				"bpr": 1507,
-				"sbpr": 38,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 942822,
-				"bpt": 1507,
-				"vpt": 3768224,
-				"rbh": 1,
-				"sbh": 0,
-				"gas": 10,
-				"bpr": 1507,
-				"sbpr": 38,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "CryptoGetAccountRecords",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 22044,
-				"bpt": 35,
-				"vpt": 88105,
-				"rbh": 0,
-				"sbh": 0,
-				"gas": 0,
-				"bpr": 35,
-				"sbpr": 1,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 352708,
-				"bpt": 564,
-				"vpt": 1409688,
-				"rbh": 0,
-				"sbh": 0,
-				"gas": 4,
-				"bpr": 564,
-				"sbpr": 14,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 352708,
-				"bpt": 564,
-				"vpt": 1409688,
-				"rbh": 0,
-				"sbh": 0,
-				"gas": 4,
-				"bpr": 564,
-				"sbpr": 14,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "CryptoGetAccountBalance",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 68774,
-				"bpt": 110,
-				"vpt": 274874,
-				"rbh": 0,
-				"sbh": 0,
-				"gas": 1,
-				"bpr": 110,
-				"sbpr": 3,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 1100389,
-				"bpt": 1759,
-				"vpt": 4397982,
-				"rbh": 1,
-				"sbh": 0,
-				"gas": 12,
-				"bpr": 1759,
-				"sbpr": 44,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 1100389,
-				"bpt": 1759,
-				"vpt": 4397982,
-				"rbh": 1,
-				"sbh": 0,
-				"gas": 12,
-				"bpr": 1759,
-				"sbpr": 44,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "CryptoGetInfo",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 63990,
-				"bpt": 102,
-				"vpt": 255752,
-				"rbh": 0,
-				"sbh": 0,
-				"gas": 1,
-				"bpr": 102,
-				"sbpr": 3,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 1023841,
-				"bpt": 1637,
-				"vpt": 4092038,
-				"rbh": 1,
-				"sbh": 0,
-				"gas": 11,
-				"bpr": 1637,
-				"sbpr": 41,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 1023841,
-				"bpt": 1637,
-				"vpt": 4092038,
-				"rbh": 1,
-				"sbh": 0,
-				"gas": 11,
-				"bpr": 1637,
-				"sbpr": 41,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "CryptoGetStakers",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 15251,
-				"bpt": 24,
-				"vpt": 60953,
-				"rbh": 0,
-				"sbh": 0,
-				"gas": 0,
-				"bpr": 24,
-				"sbpr": 1,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 244011,
-				"bpt": 390,
-				"vpt": 975251,
-				"rbh": 0,
-				"sbh": 0,
-				"gas": 3,
-				"bpr": 390,
-				"sbpr": 10,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 244011,
-				"bpt": 390,
-				"vpt": 975251,
-				"rbh": 0,
-				"sbh": 0,
-				"gas": 3,
-				"bpr": 390,
-				"sbpr": 10,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "ConsensusCreateTopic",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 921577366,
-				"bpt": 1473326,
-				"vpt": 3683315100,
-				"rbh": 982,
-				"sbh": 74,
-				"gas": 9822,
-				"bpr": 1473326,
-				"sbpr": 36833,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 14745237852,
-				"bpt": 23573217,
-				"vpt": 58933041595,
-				"rbh": 15715,
-				"sbh": 1179,
-				"gas": 157155,
-				"bpr": 23573217,
-				"sbpr": 589330,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 14745237852,
-				"bpt": 23573217,
-				"vpt": 58933041595,
-				"rbh": 15715,
-				"sbh": 1179,
-				"gas": 157155,
-				"bpr": 23573217,
-				"sbpr": 589330,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "ConsensusUpdateTopic",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 20193780,
-				"bpt": 32284,
-				"vpt": 80709508,
-				"rbh": 22,
-				"sbh": 2,
-				"gas": 215,
-				"bpr": 32284,
-				"sbpr": 807,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 323100486,
-				"bpt": 516541,
-				"vpt": 1291352134,
-				"rbh": 344,
-				"sbh": 26,
-				"gas": 3444,
-				"bpr": 516541,
-				"sbpr": 12914,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 323100486,
-				"bpt": 516541,
-				"vpt": 1291352134,
-				"rbh": 344,
-				"sbh": 26,
-				"gas": 3444,
-				"bpr": 516541,
-				"sbpr": 12914,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "ConsensusDeleteTopic",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 474345144,
-				"bpt": 758336,
-				"vpt": 1895839348,
-				"rbh": 506,
-				"sbh": 38,
-				"gas": 5056,
-				"bpr": 758336,
-				"sbpr": 18958,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 7589522307,
-				"bpt": 12133372,
-				"vpt": 30333429564,
-				"rbh": 8089,
-				"sbh": 607,
-				"gas": 80889,
-				"bpr": 12133372,
-				"sbpr": 303334,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 7589522307,
-				"bpt": 12133372,
-				"vpt": 30333429564,
-				"rbh": 8089,
-				"sbh": 607,
-				"gas": 80889,
-				"bpr": 12133372,
-				"sbpr": 303334,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "ConsensusSubmitMessage",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 9248442,
-				"bpt": 14785,
-				"vpt": 36963719,
-				"rbh": 10,
-				"sbh": 1,
-				"gas": 99,
-				"bpr": 14785,
-				"sbpr": 370,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 147975076,
-				"bpt": 236568,
-				"vpt": 591419509,
-				"rbh": 158,
-				"sbh": 12,
-				"gas": 1577,
-				"bpr": 236568,
-				"sbpr": 5914,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 147975076,
-				"bpt": 236568,
-				"vpt": 591419509,
-				"rbh": 158,
-				"sbh": 12,
-				"gas": 1577,
-				"bpr": 236568,
-				"sbpr": 5914,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "ConsensusGetTopicInfo",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 64253,
-				"bpt": 103,
-				"vpt": 256803,
-				"rbh": 0,
-				"sbh": 0,
-				"gas": 1,
-				"bpr": 103,
-				"sbpr": 3,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 1028048,
-				"bpt": 1644,
-				"vpt": 4108851,
-				"rbh": 1,
-				"sbh": 0,
-				"gas": 11,
-				"bpr": 1644,
-				"sbpr": 41,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 1028048,
-				"bpt": 1644,
-				"vpt": 4108851,
-				"rbh": 1,
-				"sbh": 0,
-				"gas": 11,
-				"bpr": 1644,
-				"sbpr": 41,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule" : {
-		  "hederaFunctionality" : "UtilPrng",
-		  "fees" : [ {
-			"subType" : "DEFAULT",
-			"nodedata" : {
-			  "constant" : 76998002,
-			  "bpt" : 123097,
-			  "vpt" : 307741829,
-			  "rbh" : 82,
-			  "sbh" : 6,
-			  "gas" : 821,
-			  "bpr" : 123097,
-			  "sbpr" : 3077,
-			  "min" : 0,
-			  "max" : 1000000000000000
-			},
-			"networkdata" : {
-			  "constant" : 1539960046,
-			  "bpt" : 2461935,
-			  "vpt" : 6154836589,
-			  "rbh" : 1641,
-			  "sbh" : 123,
-			  "gas" : 16413,
-			  "bpr" : 2461935,
-			  "sbpr" : 61548,
-			  "min" : 0,
-			  "max" : 1000000000000000
-			},
-			"servicedata" : {
-			  "constant" : 1539960046,
-			  "bpt" : 2461935,
-			  "vpt" : 6154836589,
-			  "rbh" : 1641,
-			  "sbh" : 123,
-			  "gas" : 16413,
-			  "bpr" : 2461935,
-			  "sbpr" : 61548,
-			  "min" : 0,
-			  "max" : 1000000000000000
-			}
-		  } ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "TokenCreate",
-		  "fees": [
-			{
-			  "subType": "TOKEN_FUNGIBLE_COMMON_WITH_CUSTOM_FEES",
-			  "nodedata": {
-				"constant": 393746195920,
-				"bpt": 17485616,
-				"vpt": 43714039850,
-				"rbh": 11657,
-				"sbh": 874,
-				"gas": 116571,
-				"bpr": 17485616,
-				"sbpr": 437140,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 7874923918408,
-				"bpt": 349712319,
-				"vpt": 874280797002,
-				"rbh": 233142,
-				"sbh": 17486,
-				"gas": 2331415,
-				"bpr": 349712319,
-				"sbpr": 8742808,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 7874923918408,
-				"bpt": 349712319,
-				"vpt": 874280797002,
-				"rbh": 233142,
-				"sbh": 17486,
-				"gas": 2331415,
-				"bpr": 349712319,
-				"sbpr": 8742808,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			},
-			{
-			  "subType": "TOKEN_FUNGIBLE_COMMON",
-			  "nodedata": {
-				"constant": 197306974233,
-				"bpt": 8762076,
-				"vpt": 21905189240,
-				"rbh": 5841,
-				"sbh": 438,
-				"gas": 58414,
-				"bpr": 8762076,
-				"sbpr": 219052,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 3946139484654,
-				"bpt": 175241514,
-				"vpt": 438103784807,
-				"rbh": 116828,
-				"sbh": 8762,
-				"gas": 1168277,
-				"bpr": 175241514,
-				"sbpr": 4381038,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 3946139484654,
-				"bpt": 175241514,
-				"vpt": 438103784807,
-				"rbh": 116828,
-				"sbh": 8762,
-				"gas": 1168277,
-				"bpr": 175241514,
-				"sbpr": 4381038,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			},
-			{
-			  "subType": "TOKEN_NON_FUNGIBLE_UNIQUE",
-			  "nodedata": {
-				"constant": 197031853851,
-				"bpt": 8749858,
-				"vpt": 21874645140,
-				"rbh": 5833,
-				"sbh": 437,
-				"gas": 58332,
-				"bpr": 8749858,
-				"sbpr": 218746,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 3940637077020,
-				"bpt": 174997161,
-				"vpt": 437492902800,
-				"rbh": 116665,
-				"sbh": 8750,
-				"gas": 1166648,
-				"bpr": 174997161,
-				"sbpr": 4374929,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 3940637077020,
-				"bpt": 174997161,
-				"vpt": 437492902800,
-				"rbh": 116665,
-				"sbh": 8750,
-				"gas": 1166648,
-				"bpr": 174997161,
-				"sbpr": 4374929,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			},
-			{
-			  "subType": "TOKEN_NON_FUNGIBLE_UNIQUE_WITH_CUSTOM_FEES",
-			  "nodedata": {
-				"constant": 393198370765,
-				"bpt": 17461288,
-				"vpt": 43653219832,
-				"rbh": 11641,
-				"sbh": 873,
-				"gas": 116409,
-				"bpr": 17461288,
-				"sbpr": 436532,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 7863967415309,
-				"bpt": 349225759,
-				"vpt": 873064396645,
-				"rbh": 232817,
-				"sbh": 17461,
-				"gas": 2328172,
-				"bpr": 349225759,
-				"sbpr": 8730644,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 7863967415309,
-				"bpt": 349225759,
-				"vpt": 873064396645,
-				"rbh": 232817,
-				"sbh": 17461,
-				"gas": 2328172,
-				"bpr": 349225759,
-				"sbpr": 8730644,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "TokenDelete",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 94285588,
-				"bpt": 150734,
-				"vpt": 376836001,
-				"rbh": 100,
-				"sbh": 8,
-				"gas": 1005,
-				"bpr": 150734,
-				"sbpr": 3768,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 1508569404,
-				"bpt": 2411750,
-				"vpt": 6029376016,
-				"rbh": 1608,
-				"sbh": 121,
-				"gas": 16078,
-				"bpr": 2411750,
-				"sbpr": 60294,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 1508569404,
-				"bpt": 2411750,
-				"vpt": 6029376016,
-				"rbh": 1608,
-				"sbh": 121,
-				"gas": 16078,
-				"bpr": 2411750,
-				"sbpr": 60294,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "TokenFeeScheduleUpdate",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 73998596,
-				"bpt": 118302,
-				"vpt": 295753948,
-				"rbh": 79,
-				"sbh": 6,
-				"gas": 789,
-				"bpr": 118302,
-				"sbpr": 2958,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 1479971913,
-				"bpt": 2366032,
-				"vpt": 5915078967,
-				"rbh": 1577,
-				"sbh": 118,
-				"gas": 15774,
-				"bpr": 2366032,
-				"sbpr": 59151,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 1479971913,
-				"bpt": 2366032,
-				"vpt": 5915078967,
-				"rbh": 1577,
-				"sbh": 118,
-				"gas": 15774,
-				"bpr": 2366032,
-				"sbpr": 59151,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "TokenUpdate",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 93900697,
-				"bpt": 150119,
-				"vpt": 375297688,
-				"rbh": 100,
-				"sbh": 8,
-				"gas": 1001,
-				"bpr": 150119,
-				"sbpr": 3753,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 1502411149,
-				"bpt": 2401905,
-				"vpt": 6004763005,
-				"rbh": 1601,
-				"sbh": 120,
-				"gas": 16013,
-				"bpr": 2401905,
-				"sbpr": 60048,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 1502411149,
-				"bpt": 2401905,
-				"vpt": 6004763005,
-				"rbh": 1601,
-				"sbh": 120,
-				"gas": 16013,
-				"bpr": 2401905,
-				"sbpr": 60048,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "TokenMint",
-		  "fees": [
-			{
-			  "subType": "TOKEN_FUNGIBLE_COMMON",
-			  "nodedata": {
-				"constant": 94092119,
-				"bpt": 150425,
-				"vpt": 376062755,
-				"rbh": 100,
-				"sbh": 8,
-				"gas": 1003,
-				"bpr": 150425,
-				"sbpr": 3761,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 1505473906,
-				"bpt": 2406802,
-				"vpt": 6017004081,
-				"rbh": 1605,
-				"sbh": 120,
-				"gas": 16045,
-				"bpr": 2406802,
-				"sbpr": 60170,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 1505473906,
-				"bpt": 2406802,
-				"vpt": 6017004081,
-				"rbh": 1605,
-				"sbh": 120,
-				"gas": 16045,
-				"bpr": 2406802,
-				"sbpr": 60170,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			},
-			{
-			  "subType": "TOKEN_NON_FUNGIBLE_UNIQUE",
-			  "nodedata": {
-				"constant": 3606440483,
-				"bpt": 5765618,
-				"vpt": 14414043986,
-				"rbh": 3844,
-				"sbh": 288,
-				"gas": 38437,
-				"bpr": 5765618,
-				"sbpr": 144140,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 72128809656,
-				"bpt": 115312352,
-				"vpt": 288280879722,
-				"rbh": 76875,
-				"sbh": 5766,
-				"gas": 768749,
-				"bpr": 115312352,
-				"sbpr": 2882809,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 72128809656,
-				"bpt": 115312352,
-				"vpt": 288280879722,
-				"rbh": 76875,
-				"sbh": 5766,
-				"gas": 768749,
-				"bpr": 115312352,
-				"sbpr": 2882809,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "TokenBurn",
-		  "fees": [
-			{
-			  "subType": "TOKEN_FUNGIBLE_COMMON",
-			  "nodedata": {
-				"constant": 94092119,
-				"bpt": 150425,
-				"vpt": 376062755,
-				"rbh": 100,
-				"sbh": 8,
-				"gas": 1003,
-				"bpr": 150425,
-				"sbpr": 3761,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 1505473906,
-				"bpt": 2406802,
-				"vpt": 6017004081,
-				"rbh": 1605,
-				"sbh": 120,
-				"gas": 16045,
-				"bpr": 2406802,
-				"sbpr": 60170,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 1505473906,
-				"bpt": 2406802,
-				"vpt": 6017004081,
-				"rbh": 1605,
-				"sbh": 120,
-				"gas": 16045,
-				"bpr": 2406802,
-				"sbpr": 60170,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			},
-			{
-			  "subType": "TOKEN_NON_FUNGIBLE_UNIQUE",
-			  "nodedata": {
-				"constant": 76366243,
-				"bpt": 122087,
-				"vpt": 305216845,
-				"rbh": 81,
-				"sbh": 6,
-				"gas": 814,
-				"bpr": 122087,
-				"sbpr": 3052,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 1527324859,
-				"bpt": 2441735,
-				"vpt": 6104336894,
-				"rbh": 1628,
-				"sbh": 122,
-				"gas": 16278,
-				"bpr": 2441735,
-				"sbpr": 61043,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 1527324859,
-				"bpt": 2441735,
-				"vpt": 6104336894,
-				"rbh": 1628,
-				"sbh": 122,
-				"gas": 16278,
-				"bpr": 2441735,
-				"sbpr": 61043,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "TokenAssociateToAccount",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 4574479485,
-				"bpt": 7313222,
-				"vpt": 18283054670,
-				"rbh": 4875,
-				"sbh": 366,
-				"gas": 48755,
-				"bpr": 7313222,
-				"sbpr": 182831,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 73191671761,
-				"bpt": 117011550,
-				"vpt": 292528874720,
-				"rbh": 78008,
-				"sbh": 5851,
-				"gas": 780077,
-				"bpr": 117011550,
-				"sbpr": 2925289,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 73191671761,
-				"bpt": 117011550,
-				"vpt": 292528874720,
-				"rbh": 78008,
-				"sbh": 5851,
-				"gas": 780077,
-				"bpr": 117011550,
-				"sbpr": 2925289,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "TokenDissociateFromAccount",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 4714279388,
-				"bpt": 7536720,
-				"vpt": 18841800049,
-				"rbh": 5024,
-				"sbh": 377,
-				"gas": 50245,
-				"bpr": 7536720,
-				"sbpr": 188418,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 75428470213,
-				"bpt": 120587520,
-				"vpt": 301468800784,
-				"rbh": 80392,
-				"sbh": 6029,
-				"gas": 803917,
-				"bpr": 120587520,
-				"sbpr": 3014688,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 75428470213,
-				"bpt": 120587520,
-				"vpt": 301468800784,
-				"rbh": 80392,
-				"sbh": 6029,
-				"gas": 803917,
-				"bpr": 120587520,
-				"sbpr": 3014688,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "TokenGrantKycToAccount",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 94285551,
-				"bpt": 150734,
-				"vpt": 376835856,
-				"rbh": 100,
-				"sbh": 8,
-				"gas": 1005,
-				"bpr": 150734,
-				"sbpr": 3768,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 1508568822,
-				"bpt": 2411749,
-				"vpt": 6029373689,
-				"rbh": 1608,
-				"sbh": 121,
-				"gas": 16078,
-				"bpr": 2411749,
-				"sbpr": 60294,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 1508568822,
-				"bpt": 2411749,
-				"vpt": 6029373689,
-				"rbh": 1608,
-				"sbh": 121,
-				"gas": 16078,
-				"bpr": 2411749,
-				"sbpr": 60294,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "TokenRevokeKycFromAccount",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 94285551,
-				"bpt": 150734,
-				"vpt": 376835856,
-				"rbh": 100,
-				"sbh": 8,
-				"gas": 1005,
-				"bpr": 150734,
-				"sbpr": 3768,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 1508568822,
-				"bpt": 2411749,
-				"vpt": 6029373689,
-				"rbh": 1608,
-				"sbh": 121,
-				"gas": 16078,
-				"bpr": 2411749,
-				"sbpr": 60294,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 1508568822,
-				"bpt": 2411749,
-				"vpt": 6029373689,
-				"rbh": 1608,
-				"sbh": 121,
-				"gas": 16078,
-				"bpr": 2411749,
-				"sbpr": 60294,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "TokenFreezeAccount",
-		  "fees": [
-			{
-			  "subType": "DEFAULT",
-			  "nodedata": {
-				"constant": 76054309,
-				"bpt": 121588,
-				"vpt": 303970122,
-				"rbh": 81,
-				"sbh": 6,
-				"gas": 811,
-				"bpr": 121588,
-				"sbpr": 3040,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 1521086180,
-				"bpt": 2431761,
-				"vpt": 6079402448,
-				"rbh": 1621,
-				"sbh": 122,
-				"gas": 16212,
-				"bpr": 2431761,
-				"sbpr": 60794,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 1521086180,
-				"bpt": 2431761,
-				"vpt": 6079402448,
-				"rbh": 1621,
-				"sbh": 122,
-				"gas": 16212,
-				"bpr": 2431761,
-				"sbpr": 60794,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "TokenUnfreezeAccount",
-		  "fees": [
-			{
-			  "subType": "DEFAULT",
-			  "nodedata": {
-				"constant": 76054309,
-				"bpt": 121588,
-				"vpt": 303970122,
-				"rbh": 81,
-				"sbh": 6,
-				"gas": 811,
-				"bpr": 121588,
-				"sbpr": 3040,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 1521086180,
-				"bpt": 2431761,
-				"vpt": 6079402448,
-				"rbh": 1621,
-				"sbh": 122,
-				"gas": 16212,
-				"bpr": 2431761,
-				"sbpr": 60794,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 1521086180,
-				"bpt": 2431761,
-				"vpt": 6079402448,
-				"rbh": 1621,
-				"sbh": 122,
-				"gas": 16212,
-				"bpr": 2431761,
-				"sbpr": 60794,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "TokenPause",
-		  "fees": [
-			{
-			  "subType": "DEFAULT",
-			  "nodedata": {
-				"constant": 76523246,
-				"bpt": 122338,
-				"vpt": 305844348,
-				"rbh": 82,
-				"sbh": 6,
-				"gas": 816,
-				"bpr": 122338,
-				"sbpr": 3058,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 1530464926,
-				"bpt": 2446755,
-				"vpt": 6116886962,
-				"rbh": 1631,
-				"sbh": 122,
-				"gas": 16312,
-				"bpr": 2446755,
-				"sbpr": 61169,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 1530464926,
-				"bpt": 2446755,
-				"vpt": 6116886962,
-				"rbh": 1631,
-				"sbh": 122,
-				"gas": 16312,
-				"bpr": 2446755,
-				"sbpr": 61169,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "TokenUnpause",
-		  "fees": [
-			{
-			  "subType": "DEFAULT",
-			  "nodedata": {
-				"constant": 76523246,
-				"bpt": 122338,
-				"vpt": 305844348,
-				"rbh": 82,
-				"sbh": 6,
-				"gas": 816,
-				"bpr": 122338,
-				"sbpr": 3058,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 1530464926,
-				"bpt": 2446755,
-				"vpt": 6116886962,
-				"rbh": 1631,
-				"sbh": 122,
-				"gas": 16312,
-				"bpr": 2446755,
-				"sbpr": 61169,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 1530464926,
-				"bpt": 2446755,
-				"vpt": 6116886962,
-				"rbh": 1631,
-				"sbh": 122,
-				"gas": 16312,
-				"bpr": 2446755,
-				"sbpr": 61169,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "TokenAccountWipe",
-		  "fees": [
-			{
-			  "subType": "TOKEN_FUNGIBLE_COMMON",
-			  "nodedata": {
-				"constant": 94092119,
-				"bpt": 150425,
-				"vpt": 376062755,
-				"rbh": 100,
-				"sbh": 8,
-				"gas": 1003,
-				"bpr": 150425,
-				"sbpr": 3761,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 1505473906,
-				"bpt": 2406802,
-				"vpt": 6017004081,
-				"rbh": 1605,
-				"sbh": 120,
-				"gas": 16045,
-				"bpr": 2406802,
-				"sbpr": 60170,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 1505473906,
-				"bpt": 2406802,
-				"vpt": 6017004081,
-				"rbh": 1605,
-				"sbh": 120,
-				"gas": 16045,
-				"bpr": 2406802,
-				"sbpr": 60170,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			},
-			{
-			  "subType": "TOKEN_NON_FUNGIBLE_UNIQUE",
-			  "nodedata": {
-				"constant": 76366243,
-				"bpt": 122087,
-				"vpt": 305216845,
-				"rbh": 81,
-				"sbh": 6,
-				"gas": 814,
-				"bpr": 122087,
-				"sbpr": 3052,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 1527324859,
-				"bpt": 2441735,
-				"vpt": 6104336894,
-				"rbh": 1628,
-				"sbh": 122,
-				"gas": 16278,
-				"bpr": 2441735,
-				"sbpr": 61043,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 1527324859,
-				"bpt": 2441735,
-				"vpt": 6104336894,
-				"rbh": 1628,
-				"sbh": 122,
-				"gas": 16278,
-				"bpr": 2441735,
-				"sbpr": 61043,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "TokenGetInfo",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 61717,
-				"bpt": 99,
-				"vpt": 246668,
-				"rbh": 0,
-				"sbh": 0,
-				"gas": 1,
-				"bpr": 99,
-				"sbpr": 2,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 987474,
-				"bpt": 1579,
-				"vpt": 3946688,
-				"rbh": 1,
-				"sbh": 0,
-				"gas": 11,
-				"bpr": 1579,
-				"sbpr": 39,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 987474,
-				"bpt": 1579,
-				"vpt": 3946688,
-				"rbh": 1,
-				"sbh": 0,
-				"gas": 11,
-				"bpr": 1579,
-				"sbpr": 39,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "TokenGetNftInfo",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 54605,
-				"bpt": 87,
-				"vpt": 218244,
-				"rbh": 0,
-				"sbh": 0,
-				"gas": 1,
-				"bpr": 87,
-				"sbpr": 2,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 0,
-				"bpt": 0,
-				"vpt": 0,
-				"rbh": 0,
-				"sbh": 0,
-				"gas": 0,
-				"bpr": 0,
-				"sbpr": 0,
-				"min": 0,
-				"max": 0
-			  },
-			  "servicedata": {
-				"constant": 0,
-				"bpt": 0,
-				"vpt": 0,
-				"rbh": 0,
-				"sbh": 0,
-				"gas": 0,
-				"bpr": 0,
-				"sbpr": 0,
-				"min": 0,
-				"max": 0
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "ScheduleCreate",
-		  "fees": [
-			{
-			  "subType" : "DEFAULT",
-			  "nodedata" : {
-				"constant" : 2182553692,
-				"bpt" : 96924,
-				"vpt" : 242308980,
-				"rbh" : 65,
-				"sbh" : 5,
-				"gas" : 646,
-				"bpr" : 96924,
-				"sbpr" : 2423,
-				"min" : 0,
-				"max" : 1000000000000000
-			  },
-			  "networkdata" : {
-				"constant" : 43651073832,
-				"bpt" : 1938472,
-				"vpt" : 4846179597,
-				"rbh" : 1292,
-				"sbh" : 97,
-				"gas" : 12923,
-				"bpr" : 1938472,
-				"sbpr" : 48462,
-				"min" : 0,
-				"max" : 1000000000000000
-			  },
-			  "servicedata" : {
-				"constant" : 43651073832,
-				"bpt" : 1938472,
-				"vpt" : 4846179597,
-				"rbh" : 1292,
-				"sbh" : 97,
-				"gas" : 12923,
-				"bpr" : 1938472,
-				"sbpr" : 48462,
-				"min" : 0,
-				"max" : 1000000000000000
-			  }
-			}, {
-			  "subType" : "SCHEDULE_CREATE_CONTRACT_CALL",
-			  "nodedata" : {
-				"constant" : 22946919652,
-				"bpt" : 1019035,
-				"vpt" : 2547586670,
-				"rbh" : 679,
-				"sbh" : 51,
-				"gas" : 6794,
-				"bpr" : 1019035,
-				"sbpr" : 25476,
-				"min" : 0,
-				"max" : 1000000000000000
-			  },
-			  "networkdata" : {
-				"constant" : 458938393039,
-				"bpt" : 20380693,
-				"vpt" : 50951733401,
-				"rbh" : 13587,
-				"sbh" : 1019,
-				"gas" : 135871,
-				"bpr" : 20380693,
-				"sbpr" : 509517,
-				"min" : 0,
-				"max" : 1000000000000000
-			  },
-			  "servicedata" : {
-				"constant" : 458938393039,
-				"bpt" : 20380693,
-				"vpt" : 50951733401,
-				"rbh" : 13587,
-				"sbh" : 1019,
-				"gas" : 135871,
-				"bpr" : 20380693,
-				"sbpr" : 509517,
-				"min" : 0,
-				"max" : 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "ScheduleSign",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 58040915,
-				"bpt": 92790,
-				"vpt": 231975077,
-				"rbh": 62,
-				"sbh": 5,
-				"gas": 619,
-				"bpr": 92790,
-				"sbpr": 2320,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 928654648,
-				"bpt": 1484640,
-				"vpt": 3711601232,
-				"rbh": 990,
-				"sbh": 74,
-				"gas": 9898,
-				"bpr": 1484640,
-				"sbpr": 37116,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 928654648,
-				"bpt": 1484640,
-				"vpt": 3711601232,
-				"rbh": 990,
-				"sbh": 74,
-				"gas": 9898,
-				"bpr": 1484640,
-				"sbpr": 37116,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "ScheduleDelete",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 95360774,
-				"bpt": 152453,
-				"vpt": 381133253,
-				"rbh": 102,
-				"sbh": 8,
-				"gas": 1016,
-				"bpr": 152453,
-				"sbpr": 3811,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 1525772386,
-				"bpt": 2439253,
-				"vpt": 6098132047,
-				"rbh": 1626,
-				"sbh": 122,
-				"gas": 16262,
-				"bpr": 2439253,
-				"sbpr": 60981,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 1525772386,
-				"bpt": 2439253,
-				"vpt": 6098132047,
-				"rbh": 1626,
-				"sbh": 122,
-				"gas": 16262,
-				"bpr": 2439253,
-				"sbpr": 60981,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "ScheduleGetInfo",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 53393,
-				"bpt": 85,
-				"vpt": 213400,
-				"rbh": 0,
-				"sbh": 0,
-				"gas": 1,
-				"bpr": 85,
-				"sbpr": 2,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 854295,
-				"bpt": 1366,
-				"vpt": 3414402,
-				"rbh": 1,
-				"sbh": 0,
-				"gas": 9,
-				"bpr": 1366,
-				"sbpr": 34,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 854295,
-				"bpt": 1366,
-				"vpt": 3414402,
-				"rbh": 1,
-				"sbh": 0,
-				"gas": 9,
-				"bpr": 1366,
-				"sbpr": 34,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "ContractCreate",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 45218052173,
-				"bpt": 72290115,
-				"vpt": 180725287466,
-				"rbh": 48193,
-				"sbh": 3615,
-				"gas": 481934,
-				"bpr": 72290115,
-				"sbpr": 1807253,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 723488834765,
-				"bpt": 1156641840,
-				"vpt": 2891604599463,
-				"rbh": 771095,
-				"sbh": 57832,
-				"gas": 7710946,
-				"bpr": 1156641840,
-				"sbpr": 28916046,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 0,
-				"bpt": 0,
-				"vpt": 0,
-				"rbh": 0,
-				"sbh": 0,
-				"gas": 11566419,
-				"bpr": 0,
-				"sbpr": 0,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "ContractUpdate",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 2438037058,
-				"bpt": 3897691,
-				"vpt": 9744226629,
-				"rbh": 2598,
-				"sbh": 195,
-				"gas": 25985,
-				"bpr": 3897691,
-				"sbpr": 97442,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 39008592923,
-				"bpt": 62363050,
-				"vpt": 155907626067,
-				"rbh": 41575,
-				"sbh": 3118,
-				"gas": 415754,
-				"bpr": 62363050,
-				"sbpr": 1559076,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 39008592923,
-				"bpt": 62363050,
-				"vpt": 155907626067,
-				"rbh": 41575,
-				"sbh": 3118,
-				"gas": 415754,
-				"bpr": 62363050,
-				"sbpr": 1559076,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "ContractDelete",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 664083202,
-				"bpt": 1061670,
-				"vpt": 2654175087,
-				"rbh": 708,
-				"sbh": 53,
-				"gas": 7078,
-				"bpr": 1061670,
-				"sbpr": 26542,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 10625331229,
-				"bpt": 16986721,
-				"vpt": 42466801390,
-				"rbh": 11324,
-				"sbh": 849,
-				"gas": 113245,
-				"bpr": 16986721,
-				"sbpr": 424668,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 10625331229,
-				"bpt": 16986721,
-				"vpt": 42466801390,
-				"rbh": 11324,
-				"sbh": 849,
-				"gas": 113245,
-				"bpr": 16986721,
-				"sbpr": 424668,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "ContractCall",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 3336515210,
-				"bpt": 5334088,
-				"vpt": 13335219927,
-				"rbh": 3556,
-				"sbh": 267,
-				"gas": 35561,
-				"bpr": 5334088,
-				"sbpr": 133352,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 53384243355,
-				"bpt": 85345408,
-				"vpt": 213363518838,
-				"rbh": 56897,
-				"sbh": 4267,
-				"gas": 568969,
-				"bpr": 85345408,
-				"sbpr": 2133635,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 0,
-				"bpt": 0,
-				"vpt": 0,
-				"rbh": 0,
-				"sbh": 0,
-				"gas": 853454,
-				"bpr": 0,
-				"sbpr": 0,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "EthereumTransaction",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 6122046,
-				"bpt": 9787,
-				"vpt": 24468293,
-				"rbh": 6,
-				"sbh": 0,
-				"gas": 65,
-				"bpr": 9787,
-				"sbpr": 244,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 97952740,
-				"bpt": 156597,
-				"vpt": 391492695,
-				"rbh": 104,
-				"sbh": 7,
-				"gas": 1043,
-				"bpr": 156597,
-				"sbpr": 3914,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 0,
-				"bpt": 0,
-				"vpt": 0,
-				"rbh": 0,
-				"sbh": 0,
-				"gas": 853454,
-				"bpr": 0,
-				"sbpr": 0,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "ContractGetInfo",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 71015,
-				"bpt": 114,
-				"vpt": 283830,
-				"rbh": 0,
-				"sbh": 0,
-				"gas": 1,
-				"bpr": 114,
-				"sbpr": 3,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 1136244,
-				"bpt": 1817,
-				"vpt": 4541284,
-				"rbh": 1,
-				"sbh": 0,
-				"gas": 12,
-				"bpr": 1817,
-				"sbpr": 45,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 1136244,
-				"bpt": 1817,
-				"vpt": 4541284,
-				"rbh": 1,
-				"sbh": 0,
-				"gas": 12,
-				"bpr": 1817,
-				"sbpr": 45,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "ContractCallLocal",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 2610100486,
-				"bpt": 4172769,
-				"vpt": 10431921279,
-				"rbh": 2782,
-				"sbh": 209,
-				"gas": 27818,
-				"bpr": 4172769,
-				"sbpr": 104319,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 41761607776,
-				"bpt": 66764296,
-				"vpt": 166910740461,
-				"rbh": 44510,
-				"sbh": 3338,
-				"gas": 445095,
-				"bpr": 66764296,
-				"sbpr": 1669107,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 41761607776,
-				"bpt": 66764296,
-				"vpt": 166910740461,
-				"rbh": 44510,
-				"sbh": 3338,
-				"gas": 445095,
-				"bpr": 66764296,
-				"sbpr": 1669107,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "ContractGetBytecode",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 226589259813,
-				"bpt": 362248325,
-				"vpt": 905620811793,
-				"rbh": 241499,
-				"sbh": 18112,
-				"gas": 2414989,
-				"bpr": 362248325,
-				"sbpr": 9056208,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 3625428157003,
-				"bpt": 5795973195,
-				"vpt": 14489932988688,
-				"rbh": 3863982,
-				"sbh": 289799,
-				"gas": 38639821,
-				"bpr": 5795973195,
-				"sbpr": 144899330,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 3625428157003,
-				"bpt": 5795973195,
-				"vpt": 14489932988688,
-				"rbh": 3863982,
-				"sbh": 289799,
-				"gas": 38639821,
-				"bpr": 5795973195,
-				"sbpr": 144899330,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "GetBySolidityID",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 69385,
-				"bpt": 111,
-				"vpt": 277313,
-				"rbh": 0,
-				"sbh": 0,
-				"gas": 1,
-				"bpr": 111,
-				"sbpr": 3,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 1110154,
-				"bpt": 1775,
-				"vpt": 4437010,
-				"rbh": 1,
-				"sbh": 0,
-				"gas": 12,
-				"bpr": 1775,
-				"sbpr": 44,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 1110154,
-				"bpt": 1775,
-				"vpt": 4437010,
-				"rbh": 1,
-				"sbh": 0,
-				"gas": 12,
-				"bpr": 1775,
-				"sbpr": 44,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "ContractGetRecords",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 10093,
-				"bpt": 16,
-				"vpt": 40339,
-				"rbh": 0,
-				"sbh": 0,
-				"gas": 0,
-				"bpr": 16,
-				"sbpr": 0,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 161486,
-				"bpt": 258,
-				"vpt": 645421,
-				"rbh": 0,
-				"sbh": 0,
-				"gas": 2,
-				"bpr": 258,
-				"sbpr": 6,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 161486,
-				"bpt": 258,
-				"vpt": 645421,
-				"rbh": 0,
-				"sbh": 0,
-				"gas": 2,
-				"bpr": 258,
-				"sbpr": 6,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule" : {
-		  "hederaFunctionality" : "ContractAutoRenew",
-		  "fees" : [ {
-			"subType" : "DEFAULT",
-			"nodedata" : {
-			  "constant" : 5396134280,
-			  "bpt" : 8626802,
-			  "vpt" : 21567004154,
-			  "rbh" : 5751,
-			  "sbh" : 431,
-			  "gas" : 57512,
-			  "bpr" : 8626802,
-			  "sbpr" : 215670,
-			  "min" : 0,
-			  "max" : 1000000000000000
-			},
-			"networkdata" : {
-			  "constant" : 107922685608,
-			  "bpt" : 172536033,
-			  "vpt" : 431340083072,
-			  "rbh" : 115024,
-			  "sbh" : 8627,
-			  "gas" : 1150240,
-			  "bpr" : 172536033,
-			  "sbpr" : 4313401,
-			  "min" : 0,
-			  "max" : 1000000000000000
-			},
-			"servicedata" : {
-			  "constant" : 107922685608,
-			  "bpt" : 172536033,
-			  "vpt" : 431340083072,
-			  "rbh" : 115024,
-			  "sbh" : 8627,
-			  "gas" : 1150240,
-			  "bpr" : 172536033,
-			  "sbpr" : 4313401,
-			  "min" : 0,
-			  "max" : 1000000000000000
-			}
-		  } ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "FileCreate",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 3657315129,
-				"bpt": 5846951,
-				"vpt": 14617377270,
-				"rbh": 3898,
-				"sbh": 292,
-				"gas": 38980,
-				"bpr": 5846951,
-				"sbpr": 146174,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 58517042062,
-				"bpt": 93551215,
-				"vpt": 233878036318,
-				"rbh": 62367,
-				"sbh": 4678,
-				"gas": 623675,
-				"bpr": 93551215,
-				"sbpr": 2338780,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 58517042062,
-				"bpt": 93551215,
-				"vpt": 233878036318,
-				"rbh": 62367,
-				"sbh": 4678,
-				"gas": 623675,
-				"bpr": 93551215,
-				"sbpr": 2338780,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "FileUpdate",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 3663140881,
-				"bpt": 5856265,
-				"vpt": 14640661348,
-				"rbh": 3904,
-				"sbh": 293,
-				"gas": 39042,
-				"bpr": 5856265,
-				"sbpr": 146407,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 58610254089,
-				"bpt": 93700233,
-				"vpt": 234250581567,
-				"rbh": 62467,
-				"sbh": 4685,
-				"gas": 624668,
-				"bpr": 93700233,
-				"sbpr": 2342506,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 58610254089,
-				"bpt": 93700233,
-				"vpt": 234250581567,
-				"rbh": 62467,
-				"sbh": 4685,
-				"gas": 624668,
-				"bpr": 93700233,
-				"sbpr": 2342506,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "FileDelete",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 664083202,
-				"bpt": 1061670,
-				"vpt": 2654175087,
-				"rbh": 708,
-				"sbh": 53,
-				"gas": 7078,
-				"bpr": 1061670,
-				"sbpr": 26542,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 10625331229,
-				"bpt": 16986721,
-				"vpt": 42466801390,
-				"rbh": 11324,
-				"sbh": 849,
-				"gas": 113245,
-				"bpr": 16986721,
-				"sbpr": 424668,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 10625331229,
-				"bpt": 16986721,
-				"vpt": 42466801390,
-				"rbh": 11324,
-				"sbh": 849,
-				"gas": 113245,
-				"bpr": 16986721,
-				"sbpr": 424668,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "FileAppend",
-		  "fees": [
-			{
-			  "subType": "DEFAULT",
-			  "nodedata": {
-				"constant": 2981423158,
-				"bpt": 4766402,
-				"vpt": 11916005477,
-				"rbh": 3178,
-				"sbh": 238,
-				"gas": 31776,
-				"bpr": 4766402,
-				"sbpr": 119160,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 59628463168,
-				"bpt": 95328044,
-				"vpt": 238320109546,
-				"rbh": 63552,
-				"sbh": 4766,
-				"gas": 635520,
-				"bpr": 95328044,
-				"sbpr": 2383201,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 59628463168,
-				"bpt": 95328044,
-				"vpt": 238320109546,
-				"rbh": 63552,
-				"sbh": 4766,
-				"gas": 635520,
-				"bpr": 95328044,
-				"sbpr": 2383201,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "FileGetContents",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 69308,
-				"bpt": 111,
-				"vpt": 277006,
-				"rbh": 0,
-				"sbh": 0,
-				"gas": 1,
-				"bpr": 111,
-				"sbpr": 3,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 1108924,
-				"bpt": 1773,
-				"vpt": 4432093,
-				"rbh": 1,
-				"sbh": 0,
-				"gas": 12,
-				"bpr": 1773,
-				"sbpr": 44,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 1108924,
-				"bpt": 1773,
-				"vpt": 4432093,
-				"rbh": 1,
-				"sbh": 0,
-				"gas": 12,
-				"bpr": 1773,
-				"sbpr": 44,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "FileGetInfo",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 71080,
-				"bpt": 114,
-				"vpt": 284088,
-				"rbh": 0,
-				"sbh": 0,
-				"gas": 1,
-				"bpr": 114,
-				"sbpr": 3,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 1137277,
-				"bpt": 1818,
-				"vpt": 4545413,
-				"rbh": 1,
-				"sbh": 0,
-				"gas": 12,
-				"bpr": 1818,
-				"sbpr": 45,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 1137277,
-				"bpt": 1818,
-				"vpt": 4545413,
-				"rbh": 1,
-				"sbh": 0,
-				"gas": 12,
-				"bpr": 1818,
-				"sbpr": 45,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "GetVersionInfo",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 6519421057,
-				"bpt": 10422601,
-				"vpt": 26056501507,
-				"rbh": 6948,
-				"sbh": 521,
-				"gas": 69484,
-				"bpr": 10422601,
-				"sbpr": 260565,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 104310736905,
-				"bpt": 166761610,
-				"vpt": 416904024105,
-				"rbh": 111174,
-				"sbh": 8338,
-				"gas": 1111744,
-				"bpr": 166761610,
-				"sbpr": 4169040,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 104310736905,
-				"bpt": 166761610,
-				"vpt": 416904024105,
-				"rbh": 111174,
-				"sbh": 8338,
-				"gas": 1111744,
-				"bpr": 166761610,
-				"sbpr": 4169040,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "GetByKey",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 1,
-				"bpt": 0,
-				"vpt": 0,
-				"rbh": 0,
-				"sbh": 0,
-				"gas": 0,
-				"bpr": 0,
-				"sbpr": 0,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 1,
-				"bpt": 0,
-				"vpt": 0,
-				"rbh": 0,
-				"sbh": 0,
-				"gas": 0,
-				"bpr": 0,
-				"sbpr": 0,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 1,
-				"bpt": 0,
-				"vpt": 0,
-				"rbh": 0,
-				"sbh": 0,
-				"gas": 0,
-				"bpr": 0,
-				"sbpr": 0,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "TransactionGetReceipt",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 1,
-				"bpt": 0,
-				"vpt": 0,
-				"rbh": 0,
-				"sbh": 0,
-				"gas": 0,
-				"bpr": 0,
-				"sbpr": 0,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 1,
-				"bpt": 0,
-				"vpt": 0,
-				"rbh": 0,
-				"sbh": 0,
-				"gas": 0,
-				"bpr": 0,
-				"sbpr": 0,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 1,
-				"bpt": 0,
-				"vpt": 0,
-				"rbh": 0,
-				"sbh": 0,
-				"gas": 0,
-				"bpr": 0,
-				"sbpr": 0,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "SystemDelete",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 0,
-				"bpt": 0,
-				"vpt": 0,
-				"rbh": 0,
-				"sbh": 0,
-				"gas": 0,
-				"bpr": 0,
-				"sbpr": 0,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 0,
-				"bpt": 0,
-				"vpt": 0,
-				"rbh": 0,
-				"sbh": 0,
-				"gas": 0,
-				"bpr": 0,
-				"sbpr": 0,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 0,
-				"bpt": 0,
-				"vpt": 0,
-				"rbh": 0,
-				"sbh": 0,
-				"gas": 0,
-				"bpr": 0,
-				"sbpr": 0,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "SystemUndelete",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 0,
-				"bpt": 0,
-				"vpt": 0,
-				"rbh": 0,
-				"sbh": 0,
-				"gas": 0,
-				"bpr": 0,
-				"sbpr": 0,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 0,
-				"bpt": 0,
-				"vpt": 0,
-				"rbh": 0,
-				"sbh": 0,
-				"gas": 0,
-				"bpr": 0,
-				"sbpr": 0,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 0,
-				"bpt": 0,
-				"vpt": 0,
-				"rbh": 0,
-				"sbh": 0,
-				"gas": 0,
-				"bpr": 0,
-				"sbpr": 0,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "TransactionGetRecord",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 54605,
-				"bpt": 87,
-				"vpt": 218244,
-				"rbh": 0,
-				"sbh": 0,
-				"gas": 1,
-				"bpr": 87,
-				"sbpr": 2,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 873685,
-				"bpt": 1397,
-				"vpt": 3491900,
-				"rbh": 1,
-				"sbh": 0,
-				"gas": 9,
-				"bpr": 1397,
-				"sbpr": 35,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 873685,
-				"bpt": 1397,
-				"vpt": 3491900,
-				"rbh": 1,
-				"sbh": 0,
-				"gas": 9,
-				"bpr": 1397,
-				"sbpr": 35,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"expiryTime": 1630800000
-	  }
-	]
+    "currentFeeSchedule": [
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "CryptoCreate",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 11461413665,
+                "bpt": 508982,
+                "vpt": 1272455960,
+                "rbh": 339,
+                "sbh": 25,
+                "gas": 3393,
+                "bpr": 508982,
+                "sbpr": 12725,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 229228273302,
+                "bpt": 10179648,
+                "vpt": 25449119198,
+                "rbh": 6786,
+                "sbh": 509,
+                "gas": 67864,
+                "bpr": 10179648,
+                "sbpr": 254491,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 229228273302,
+                "bpt": 10179648,
+                "vpt": 25449119198,
+                "rbh": 6786,
+                "sbh": 509,
+                "gas": 67864,
+                "bpr": 10179648,
+                "sbpr": 254491,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "CryptoDeleteAllowance",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 3794963556,
+                "bpt": 6067009,
+                "vpt": 15167523735,
+                "rbh": 4045,
+                "sbh": 303,
+                "gas": 40447,
+                "bpr": 6067009,
+                "sbpr": 151675,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 75899271121,
+                "bpt": 121340190,
+                "vpt": 303350474702,
+                "rbh": 80893,
+                "sbh": 6067,
+                "gas": 808935,
+                "bpr": 121340190,
+                "sbpr": 3033505,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 75899271121,
+                "bpt": 121340190,
+                "vpt": 303350474702,
+                "rbh": 80893,
+                "sbh": 6067,
+                "gas": 808935,
+                "bpr": 121340190,
+                "sbpr": 3033505,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "CryptoApproveAllowance",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 3766772044,
+                "bpt": 6021940,
+                "vpt": 15054849285,
+                "rbh": 4015,
+                "sbh": 301,
+                "gas": 40146,
+                "bpr": 6021940,
+                "sbpr": 150548,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 75335440874,
+                "bpt": 120438794,
+                "vpt": 301096985700,
+                "rbh": 80293,
+                "sbh": 6022,
+                "gas": 802925,
+                "bpr": 120438794,
+                "sbpr": 3010970,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 75335440874,
+                "bpt": 120438794,
+                "vpt": 301096985700,
+                "rbh": 80293,
+                "sbh": 6022,
+                "gas": 802925,
+                "bpr": 120438794,
+                "sbpr": 3010970,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "CryptoAccountAutoRenew",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 59972622,
+                "bpt": 95878,
+                "vpt": 239695625,
+                "rbh": 64,
+                "sbh": 5,
+                "gas": 639,
+                "bpr": 95878,
+                "sbpr": 2397,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 959561945,
+                "bpt": 1534052,
+                "vpt": 3835129999,
+                "rbh": 1023,
+                "sbh": 77,
+                "gas": 10227,
+                "bpr": 1534052,
+                "sbpr": 38351,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 959561945,
+                "bpt": 1534052,
+                "vpt": 3835129999,
+                "rbh": 1023,
+                "sbh": 77,
+                "gas": 10227,
+                "bpr": 1534052,
+                "sbpr": 38351,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "CryptoUpdate",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 16302371,
+                "bpt": 26063,
+                "vpt": 65156516,
+                "rbh": 17,
+                "sbh": 1,
+                "gas": 174,
+                "bpr": 26063,
+                "sbpr": 652,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 326047427,
+                "bpt": 521252,
+                "vpt": 1303130322,
+                "rbh": 348,
+                "sbh": 26,
+                "gas": 3475,
+                "bpr": 521252,
+                "sbpr": 13031,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 326047427,
+                "bpt": 521252,
+                "vpt": 1303130322,
+                "rbh": 348,
+                "sbh": 26,
+                "gas": 3475,
+                "bpr": 521252,
+                "sbpr": 13031,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "CryptoTransfer",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 7574478,
+                "bpt": 12109,
+                "vpt": 30273301,
+                "rbh": 8,
+                "sbh": 1,
+                "gas": 81,
+                "bpr": 12109,
+                "sbpr": 303,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 151489557,
+                "bpt": 242186,
+                "vpt": 605466012,
+                "rbh": 161,
+                "sbh": 12,
+                "gas": 1615,
+                "bpr": 242186,
+                "sbpr": 6055,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 151489557,
+                "bpt": 242186,
+                "vpt": 605466012,
+                "rbh": 161,
+                "sbh": 12,
+                "gas": 1615,
+                "bpr": 242186,
+                "sbpr": 6055,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            },
+            {
+              "subType": "TOKEN_FUNGIBLE_COMMON",
+              "nodedata": {
+                "constant": 7983519,
+                "bpt": 12763,
+                "vpt": 31908136,
+                "rbh": 9,
+                "sbh": 1,
+                "gas": 85,
+                "bpr": 12763,
+                "sbpr": 319,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 159670382,
+                "bpt": 255265,
+                "vpt": 638162730,
+                "rbh": 170,
+                "sbh": 13,
+                "gas": 1702,
+                "bpr": 255265,
+                "sbpr": 6382,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 159670382,
+                "bpt": 255265,
+                "vpt": 638162730,
+                "rbh": 170,
+                "sbh": 13,
+                "gas": 1702,
+                "bpr": 255265,
+                "sbpr": 6382,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            },
+            {
+              "subType": "TOKEN_FUNGIBLE_COMMON_WITH_CUSTOM_FEES",
+              "nodedata": {
+                "constant": 15967037,
+                "bpt": 25527,
+                "vpt": 63816270,
+                "rbh": 17,
+                "sbh": 1,
+                "gas": 170,
+                "bpr": 25527,
+                "sbpr": 638,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 319340747,
+                "bpt": 510530,
+                "vpt": 1276325394,
+                "rbh": 340,
+                "sbh": 26,
+                "gas": 3404,
+                "bpr": 510530,
+                "sbpr": 12763,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 319340747,
+                "bpt": 510530,
+                "vpt": 1276325394,
+                "rbh": 340,
+                "sbh": 26,
+                "gas": 3404,
+                "bpr": 510530,
+                "sbpr": 12763,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            },
+            {
+              "subType": "TOKEN_NON_FUNGIBLE_UNIQUE",
+              "nodedata": {
+                "constant": 22833842,
+                "bpt": 36504,
+                "vpt": 91261178,
+                "rbh": 24,
+                "sbh": 2,
+                "gas": 243,
+                "bpr": 36504,
+                "sbpr": 913,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 456676846,
+                "bpt": 730089,
+                "vpt": 1825223562,
+                "rbh": 487,
+                "sbh": 37,
+                "gas": 4867,
+                "bpr": 730089,
+                "sbpr": 18252,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 456676846,
+                "bpt": 730089,
+                "vpt": 1825223562,
+                "rbh": 487,
+                "sbh": 37,
+                "gas": 4867,
+                "bpr": 730089,
+                "sbpr": 18252,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            },
+            {
+              "subType": "TOKEN_NON_FUNGIBLE_UNIQUE_WITH_CUSTOM_FEES",
+              "nodedata": {
+                "constant": 45667678,
+                "bpt": 73009,
+                "vpt": 182522330,
+                "rbh": 49,
+                "sbh": 4,
+                "gas": 487,
+                "bpr": 73009,
+                "sbpr": 1825,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 913353558,
+                "bpt": 1460179,
+                "vpt": 3650446591,
+                "rbh": 973,
+                "sbh": 73,
+                "gas": 9735,
+                "bpr": 1460179,
+                "sbpr": 36504,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 913353558,
+                "bpt": 1460179,
+                "vpt": 3650446591,
+                "rbh": 973,
+                "sbh": 73,
+                "gas": 9735,
+                "bpr": 1460179,
+                "sbpr": 36504,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "CryptoDelete",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 471427939,
+                "bpt": 753672,
+                "vpt": 1884180005,
+                "rbh": 502,
+                "sbh": 38,
+                "gas": 5024,
+                "bpr": 753672,
+                "sbpr": 18842,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 7542847021,
+                "bpt": 12058752,
+                "vpt": 30146880078,
+                "rbh": 8039,
+                "sbh": 603,
+                "gas": 80392,
+                "bpr": 12058752,
+                "sbpr": 301469,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 7542847021,
+                "bpt": 12058752,
+                "vpt": 30146880078,
+                "rbh": 8039,
+                "sbh": 603,
+                "gas": 80392,
+                "bpr": 12058752,
+                "sbpr": 301469,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "CryptoAddLiveHash",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 5561692202,
+                "bpt": 8891479,
+                "vpt": 22228697914,
+                "rbh": 5928,
+                "sbh": 445,
+                "gas": 59277,
+                "bpr": 8891479,
+                "sbpr": 222287,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 88987075231,
+                "bpt": 142263667,
+                "vpt": 355659166619,
+                "rbh": 94842,
+                "sbh": 7113,
+                "gas": 948424,
+                "bpr": 142263667,
+                "sbpr": 3556592,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 88987075231,
+                "bpt": 142263667,
+                "vpt": 355659166619,
+                "rbh": 94842,
+                "sbh": 7113,
+                "gas": 948424,
+                "bpr": 142263667,
+                "sbpr": 3556592,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "CryptoDeleteLiveHash",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 468546396,
+                "bpt": 749065,
+                "vpt": 1872663195,
+                "rbh": 499,
+                "sbh": 37,
+                "gas": 4994,
+                "bpr": 749065,
+                "sbpr": 18727,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 7496742329,
+                "bpt": 11985044,
+                "vpt": 29962611113,
+                "rbh": 7990,
+                "sbh": 599,
+                "gas": 79900,
+                "bpr": 11985044,
+                "sbpr": 299626,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 7496742329,
+                "bpt": 11985044,
+                "vpt": 29962611113,
+                "rbh": 7990,
+                "sbh": 599,
+                "gas": 79900,
+                "bpr": 11985044,
+                "sbpr": 299626,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "CryptoGetLiveHash",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 58926,
+                "bpt": 94,
+                "vpt": 235514,
+                "rbh": 0,
+                "sbh": 0,
+                "gas": 1,
+                "bpr": 94,
+                "sbpr": 2,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 942822,
+                "bpt": 1507,
+                "vpt": 3768224,
+                "rbh": 1,
+                "sbh": 0,
+                "gas": 10,
+                "bpr": 1507,
+                "sbpr": 38,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 942822,
+                "bpt": 1507,
+                "vpt": 3768224,
+                "rbh": 1,
+                "sbh": 0,
+                "gas": 10,
+                "bpr": 1507,
+                "sbpr": 38,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "CryptoGetAccountRecords",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 22044,
+                "bpt": 35,
+                "vpt": 88105,
+                "rbh": 0,
+                "sbh": 0,
+                "gas": 0,
+                "bpr": 35,
+                "sbpr": 1,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 352708,
+                "bpt": 564,
+                "vpt": 1409688,
+                "rbh": 0,
+                "sbh": 0,
+                "gas": 4,
+                "bpr": 564,
+                "sbpr": 14,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 352708,
+                "bpt": 564,
+                "vpt": 1409688,
+                "rbh": 0,
+                "sbh": 0,
+                "gas": 4,
+                "bpr": 564,
+                "sbpr": 14,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "CryptoGetAccountBalance",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 68774,
+                "bpt": 110,
+                "vpt": 274874,
+                "rbh": 0,
+                "sbh": 0,
+                "gas": 1,
+                "bpr": 110,
+                "sbpr": 3,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 1100389,
+                "bpt": 1759,
+                "vpt": 4397982,
+                "rbh": 1,
+                "sbh": 0,
+                "gas": 12,
+                "bpr": 1759,
+                "sbpr": 44,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 1100389,
+                "bpt": 1759,
+                "vpt": 4397982,
+                "rbh": 1,
+                "sbh": 0,
+                "gas": 12,
+                "bpr": 1759,
+                "sbpr": 44,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "CryptoGetInfo",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 63990,
+                "bpt": 102,
+                "vpt": 255752,
+                "rbh": 0,
+                "sbh": 0,
+                "gas": 1,
+                "bpr": 102,
+                "sbpr": 3,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 1023841,
+                "bpt": 1637,
+                "vpt": 4092038,
+                "rbh": 1,
+                "sbh": 0,
+                "gas": 11,
+                "bpr": 1637,
+                "sbpr": 41,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 1023841,
+                "bpt": 1637,
+                "vpt": 4092038,
+                "rbh": 1,
+                "sbh": 0,
+                "gas": 11,
+                "bpr": 1637,
+                "sbpr": 41,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "CryptoGetStakers",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 15251,
+                "bpt": 24,
+                "vpt": 60953,
+                "rbh": 0,
+                "sbh": 0,
+                "gas": 0,
+                "bpr": 24,
+                "sbpr": 1,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 244011,
+                "bpt": 390,
+                "vpt": 975251,
+                "rbh": 0,
+                "sbh": 0,
+                "gas": 3,
+                "bpr": 390,
+                "sbpr": 10,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 244011,
+                "bpt": 390,
+                "vpt": 975251,
+                "rbh": 0,
+                "sbh": 0,
+                "gas": 3,
+                "bpr": 390,
+                "sbpr": 10,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "ConsensusCreateTopic",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 921577366,
+                "bpt": 1473326,
+                "vpt": 3683315100,
+                "rbh": 982,
+                "sbh": 74,
+                "gas": 9822,
+                "bpr": 1473326,
+                "sbpr": 36833,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 14745237852,
+                "bpt": 23573217,
+                "vpt": 58933041595,
+                "rbh": 15715,
+                "sbh": 1179,
+                "gas": 157155,
+                "bpr": 23573217,
+                "sbpr": 589330,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 14745237852,
+                "bpt": 23573217,
+                "vpt": 58933041595,
+                "rbh": 15715,
+                "sbh": 1179,
+                "gas": 157155,
+                "bpr": 23573217,
+                "sbpr": 589330,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "ConsensusUpdateTopic",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 20193780,
+                "bpt": 32284,
+                "vpt": 80709508,
+                "rbh": 22,
+                "sbh": 2,
+                "gas": 215,
+                "bpr": 32284,
+                "sbpr": 807,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 323100486,
+                "bpt": 516541,
+                "vpt": 1291352134,
+                "rbh": 344,
+                "sbh": 26,
+                "gas": 3444,
+                "bpr": 516541,
+                "sbpr": 12914,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 323100486,
+                "bpt": 516541,
+                "vpt": 1291352134,
+                "rbh": 344,
+                "sbh": 26,
+                "gas": 3444,
+                "bpr": 516541,
+                "sbpr": 12914,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "ConsensusDeleteTopic",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 474345144,
+                "bpt": 758336,
+                "vpt": 1895839348,
+                "rbh": 506,
+                "sbh": 38,
+                "gas": 5056,
+                "bpr": 758336,
+                "sbpr": 18958,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 7589522307,
+                "bpt": 12133372,
+                "vpt": 30333429564,
+                "rbh": 8089,
+                "sbh": 607,
+                "gas": 80889,
+                "bpr": 12133372,
+                "sbpr": 303334,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 7589522307,
+                "bpt": 12133372,
+                "vpt": 30333429564,
+                "rbh": 8089,
+                "sbh": 607,
+                "gas": 80889,
+                "bpr": 12133372,
+                "sbpr": 303334,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "ConsensusSubmitMessage",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 9248442,
+                "bpt": 14785,
+                "vpt": 36963719,
+                "rbh": 10,
+                "sbh": 1,
+                "gas": 99,
+                "bpr": 14785,
+                "sbpr": 370,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 147975076,
+                "bpt": 236568,
+                "vpt": 591419509,
+                "rbh": 158,
+                "sbh": 12,
+                "gas": 1577,
+                "bpr": 236568,
+                "sbpr": 5914,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 147975076,
+                "bpt": 236568,
+                "vpt": 591419509,
+                "rbh": 158,
+                "sbh": 12,
+                "gas": 1577,
+                "bpr": 236568,
+                "sbpr": 5914,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "ConsensusGetTopicInfo",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 64253,
+                "bpt": 103,
+                "vpt": 256803,
+                "rbh": 0,
+                "sbh": 0,
+                "gas": 1,
+                "bpr": 103,
+                "sbpr": 3,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 1028048,
+                "bpt": 1644,
+                "vpt": 4108851,
+                "rbh": 1,
+                "sbh": 0,
+                "gas": 11,
+                "bpr": 1644,
+                "sbpr": 41,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 1028048,
+                "bpt": 1644,
+                "vpt": 4108851,
+                "rbh": 1,
+                "sbh": 0,
+                "gas": 11,
+                "bpr": 1644,
+                "sbpr": 41,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "TokenCreate",
+          "fees": [
+            {
+              "subType": "TOKEN_FUNGIBLE_COMMON_WITH_CUSTOM_FEES",
+              "nodedata": {
+                "constant": 393746195920,
+                "bpt": 17485616,
+                "vpt": 43714039850,
+                "rbh": 11657,
+                "sbh": 874,
+                "gas": 116571,
+                "bpr": 17485616,
+                "sbpr": 437140,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 7874923918408,
+                "bpt": 349712319,
+                "vpt": 874280797002,
+                "rbh": 233142,
+                "sbh": 17486,
+                "gas": 2331415,
+                "bpr": 349712319,
+                "sbpr": 8742808,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 7874923918408,
+                "bpt": 349712319,
+                "vpt": 874280797002,
+                "rbh": 233142,
+                "sbh": 17486,
+                "gas": 2331415,
+                "bpr": 349712319,
+                "sbpr": 8742808,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            },
+            {
+              "subType": "TOKEN_FUNGIBLE_COMMON",
+              "nodedata": {
+                "constant": 197306974233,
+                "bpt": 8762076,
+                "vpt": 21905189240,
+                "rbh": 5841,
+                "sbh": 438,
+                "gas": 58414,
+                "bpr": 8762076,
+                "sbpr": 219052,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 3946139484654,
+                "bpt": 175241514,
+                "vpt": 438103784807,
+                "rbh": 116828,
+                "sbh": 8762,
+                "gas": 1168277,
+                "bpr": 175241514,
+                "sbpr": 4381038,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 3946139484654,
+                "bpt": 175241514,
+                "vpt": 438103784807,
+                "rbh": 116828,
+                "sbh": 8762,
+                "gas": 1168277,
+                "bpr": 175241514,
+                "sbpr": 4381038,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            },
+            {
+              "subType": "TOKEN_NON_FUNGIBLE_UNIQUE",
+              "nodedata": {
+                "constant": 197031853851,
+                "bpt": 8749858,
+                "vpt": 21874645140,
+                "rbh": 5833,
+                "sbh": 437,
+                "gas": 58332,
+                "bpr": 8749858,
+                "sbpr": 218746,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 3940637077020,
+                "bpt": 174997161,
+                "vpt": 437492902800,
+                "rbh": 116665,
+                "sbh": 8750,
+                "gas": 1166648,
+                "bpr": 174997161,
+                "sbpr": 4374929,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 3940637077020,
+                "bpt": 174997161,
+                "vpt": 437492902800,
+                "rbh": 116665,
+                "sbh": 8750,
+                "gas": 1166648,
+                "bpr": 174997161,
+                "sbpr": 4374929,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            },
+            {
+              "subType": "TOKEN_NON_FUNGIBLE_UNIQUE_WITH_CUSTOM_FEES",
+              "nodedata": {
+                "constant": 393198370765,
+                "bpt": 17461288,
+                "vpt": 43653219832,
+                "rbh": 11641,
+                "sbh": 873,
+                "gas": 116409,
+                "bpr": 17461288,
+                "sbpr": 436532,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 7863967415309,
+                "bpt": 349225759,
+                "vpt": 873064396645,
+                "rbh": 232817,
+                "sbh": 17461,
+                "gas": 2328172,
+                "bpr": 349225759,
+                "sbpr": 8730644,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 7863967415309,
+                "bpt": 349225759,
+                "vpt": 873064396645,
+                "rbh": 232817,
+                "sbh": 17461,
+                "gas": 2328172,
+                "bpr": 349225759,
+                "sbpr": 8730644,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "TokenDelete",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 94285588,
+                "bpt": 150734,
+                "vpt": 376836001,
+                "rbh": 100,
+                "sbh": 8,
+                "gas": 1005,
+                "bpr": 150734,
+                "sbpr": 3768,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 1508569404,
+                "bpt": 2411750,
+                "vpt": 6029376016,
+                "rbh": 1608,
+                "sbh": 121,
+                "gas": 16078,
+                "bpr": 2411750,
+                "sbpr": 60294,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 1508569404,
+                "bpt": 2411750,
+                "vpt": 6029376016,
+                "rbh": 1608,
+                "sbh": 121,
+                "gas": 16078,
+                "bpr": 2411750,
+                "sbpr": 60294,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "TokenFeeScheduleUpdate",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 73998596,
+                "bpt": 118302,
+                "vpt": 295753948,
+                "rbh": 79,
+                "sbh": 6,
+                "gas": 789,
+                "bpr": 118302,
+                "sbpr": 2958,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 1479971913,
+                "bpt": 2366032,
+                "vpt": 5915078967,
+                "rbh": 1577,
+                "sbh": 118,
+                "gas": 15774,
+                "bpr": 2366032,
+                "sbpr": 59151,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 1479971913,
+                "bpt": 2366032,
+                "vpt": 5915078967,
+                "rbh": 1577,
+                "sbh": 118,
+                "gas": 15774,
+                "bpr": 2366032,
+                "sbpr": 59151,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "TokenUpdate",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 93900697,
+                "bpt": 150119,
+                "vpt": 375297688,
+                "rbh": 100,
+                "sbh": 8,
+                "gas": 1001,
+                "bpr": 150119,
+                "sbpr": 3753,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 1502411149,
+                "bpt": 2401905,
+                "vpt": 6004763005,
+                "rbh": 1601,
+                "sbh": 120,
+                "gas": 16013,
+                "bpr": 2401905,
+                "sbpr": 60048,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 1502411149,
+                "bpt": 2401905,
+                "vpt": 6004763005,
+                "rbh": 1601,
+                "sbh": 120,
+                "gas": 16013,
+                "bpr": 2401905,
+                "sbpr": 60048,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "TokenMint",
+          "fees": [
+            {
+              "subType": "TOKEN_FUNGIBLE_COMMON",
+              "nodedata": {
+                "constant": 94092119,
+                "bpt": 150425,
+                "vpt": 376062755,
+                "rbh": 100,
+                "sbh": 8,
+                "gas": 1003,
+                "bpr": 150425,
+                "sbpr": 3761,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 1505473906,
+                "bpt": 2406802,
+                "vpt": 6017004081,
+                "rbh": 1605,
+                "sbh": 120,
+                "gas": 16045,
+                "bpr": 2406802,
+                "sbpr": 60170,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 1505473906,
+                "bpt": 2406802,
+                "vpt": 6017004081,
+                "rbh": 1605,
+                "sbh": 120,
+                "gas": 16045,
+                "bpr": 2406802,
+                "sbpr": 60170,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            },
+            {
+              "subType": "TOKEN_NON_FUNGIBLE_UNIQUE",
+              "nodedata": {
+                "constant": 3606440483,
+                "bpt": 5765618,
+                "vpt": 14414043986,
+                "rbh": 3844,
+                "sbh": 288,
+                "gas": 38437,
+                "bpr": 5765618,
+                "sbpr": 144140,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 72128809656,
+                "bpt": 115312352,
+                "vpt": 288280879722,
+                "rbh": 76875,
+                "sbh": 5766,
+                "gas": 768749,
+                "bpr": 115312352,
+                "sbpr": 2882809,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 72128809656,
+                "bpt": 115312352,
+                "vpt": 288280879722,
+                "rbh": 76875,
+                "sbh": 5766,
+                "gas": 768749,
+                "bpr": 115312352,
+                "sbpr": 2882809,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "TokenBurn",
+          "fees": [
+            {
+              "subType": "TOKEN_FUNGIBLE_COMMON",
+              "nodedata": {
+                "constant": 94092119,
+                "bpt": 150425,
+                "vpt": 376062755,
+                "rbh": 100,
+                "sbh": 8,
+                "gas": 1003,
+                "bpr": 150425,
+                "sbpr": 3761,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 1505473906,
+                "bpt": 2406802,
+                "vpt": 6017004081,
+                "rbh": 1605,
+                "sbh": 120,
+                "gas": 16045,
+                "bpr": 2406802,
+                "sbpr": 60170,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 1505473906,
+                "bpt": 2406802,
+                "vpt": 6017004081,
+                "rbh": 1605,
+                "sbh": 120,
+                "gas": 16045,
+                "bpr": 2406802,
+                "sbpr": 60170,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            },
+            {
+              "subType": "TOKEN_NON_FUNGIBLE_UNIQUE",
+              "nodedata": {
+                "constant": 76366243,
+                "bpt": 122087,
+                "vpt": 305216845,
+                "rbh": 81,
+                "sbh": 6,
+                "gas": 814,
+                "bpr": 122087,
+                "sbpr": 3052,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 1527324859,
+                "bpt": 2441735,
+                "vpt": 6104336894,
+                "rbh": 1628,
+                "sbh": 122,
+                "gas": 16278,
+                "bpr": 2441735,
+                "sbpr": 61043,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 1527324859,
+                "bpt": 2441735,
+                "vpt": 6104336894,
+                "rbh": 1628,
+                "sbh": 122,
+                "gas": 16278,
+                "bpr": 2441735,
+                "sbpr": 61043,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "TokenAssociateToAccount",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 4574479485,
+                "bpt": 7313222,
+                "vpt": 18283054670,
+                "rbh": 4875,
+                "sbh": 366,
+                "gas": 48755,
+                "bpr": 7313222,
+                "sbpr": 182831,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 73191671761,
+                "bpt": 117011550,
+                "vpt": 292528874720,
+                "rbh": 78008,
+                "sbh": 5851,
+                "gas": 780077,
+                "bpr": 117011550,
+                "sbpr": 2925289,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 73191671761,
+                "bpt": 117011550,
+                "vpt": 292528874720,
+                "rbh": 78008,
+                "sbh": 5851,
+                "gas": 780077,
+                "bpr": 117011550,
+                "sbpr": 2925289,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "TokenDissociateFromAccount",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 4714279388,
+                "bpt": 7536720,
+                "vpt": 18841800049,
+                "rbh": 5024,
+                "sbh": 377,
+                "gas": 50245,
+                "bpr": 7536720,
+                "sbpr": 188418,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 75428470213,
+                "bpt": 120587520,
+                "vpt": 301468800784,
+                "rbh": 80392,
+                "sbh": 6029,
+                "gas": 803917,
+                "bpr": 120587520,
+                "sbpr": 3014688,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 75428470213,
+                "bpt": 120587520,
+                "vpt": 301468800784,
+                "rbh": 80392,
+                "sbh": 6029,
+                "gas": 803917,
+                "bpr": 120587520,
+                "sbpr": 3014688,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "TokenGrantKycToAccount",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 94285551,
+                "bpt": 150734,
+                "vpt": 376835856,
+                "rbh": 100,
+                "sbh": 8,
+                "gas": 1005,
+                "bpr": 150734,
+                "sbpr": 3768,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 1508568822,
+                "bpt": 2411749,
+                "vpt": 6029373689,
+                "rbh": 1608,
+                "sbh": 121,
+                "gas": 16078,
+                "bpr": 2411749,
+                "sbpr": 60294,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 1508568822,
+                "bpt": 2411749,
+                "vpt": 6029373689,
+                "rbh": 1608,
+                "sbh": 121,
+                "gas": 16078,
+                "bpr": 2411749,
+                "sbpr": 60294,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "TokenRevokeKycFromAccount",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 94285551,
+                "bpt": 150734,
+                "vpt": 376835856,
+                "rbh": 100,
+                "sbh": 8,
+                "gas": 1005,
+                "bpr": 150734,
+                "sbpr": 3768,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 1508568822,
+                "bpt": 2411749,
+                "vpt": 6029373689,
+                "rbh": 1608,
+                "sbh": 121,
+                "gas": 16078,
+                "bpr": 2411749,
+                "sbpr": 60294,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 1508568822,
+                "bpt": 2411749,
+                "vpt": 6029373689,
+                "rbh": 1608,
+                "sbh": 121,
+                "gas": 16078,
+                "bpr": 2411749,
+                "sbpr": 60294,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "TokenFreezeAccount",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 76054309,
+                "bpt": 121588,
+                "vpt": 303970122,
+                "rbh": 81,
+                "sbh": 6,
+                "gas": 811,
+                "bpr": 121588,
+                "sbpr": 3040,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 1521086180,
+                "bpt": 2431761,
+                "vpt": 6079402448,
+                "rbh": 1621,
+                "sbh": 122,
+                "gas": 16212,
+                "bpr": 2431761,
+                "sbpr": 60794,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 1521086180,
+                "bpt": 2431761,
+                "vpt": 6079402448,
+                "rbh": 1621,
+                "sbh": 122,
+                "gas": 16212,
+                "bpr": 2431761,
+                "sbpr": 60794,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "TokenUnfreezeAccount",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 76054309,
+                "bpt": 121588,
+                "vpt": 303970122,
+                "rbh": 81,
+                "sbh": 6,
+                "gas": 811,
+                "bpr": 121588,
+                "sbpr": 3040,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 1521086180,
+                "bpt": 2431761,
+                "vpt": 6079402448,
+                "rbh": 1621,
+                "sbh": 122,
+                "gas": 16212,
+                "bpr": 2431761,
+                "sbpr": 60794,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 1521086180,
+                "bpt": 2431761,
+                "vpt": 6079402448,
+                "rbh": 1621,
+                "sbh": 122,
+                "gas": 16212,
+                "bpr": 2431761,
+                "sbpr": 60794,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "TokenPause",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 76523246,
+                "bpt": 122338,
+                "vpt": 305844348,
+                "rbh": 82,
+                "sbh": 6,
+                "gas": 816,
+                "bpr": 122338,
+                "sbpr": 3058,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 1530464926,
+                "bpt": 2446755,
+                "vpt": 6116886962,
+                "rbh": 1631,
+                "sbh": 122,
+                "gas": 16312,
+                "bpr": 2446755,
+                "sbpr": 61169,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 1530464926,
+                "bpt": 2446755,
+                "vpt": 6116886962,
+                "rbh": 1631,
+                "sbh": 122,
+                "gas": 16312,
+                "bpr": 2446755,
+                "sbpr": 61169,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "TokenUnpause",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 76523246,
+                "bpt": 122338,
+                "vpt": 305844348,
+                "rbh": 82,
+                "sbh": 6,
+                "gas": 816,
+                "bpr": 122338,
+                "sbpr": 3058,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 1530464926,
+                "bpt": 2446755,
+                "vpt": 6116886962,
+                "rbh": 1631,
+                "sbh": 122,
+                "gas": 16312,
+                "bpr": 2446755,
+                "sbpr": 61169,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 1530464926,
+                "bpt": 2446755,
+                "vpt": 6116886962,
+                "rbh": 1631,
+                "sbh": 122,
+                "gas": 16312,
+                "bpr": 2446755,
+                "sbpr": 61169,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "TokenAccountWipe",
+          "fees": [
+            {
+              "subType": "TOKEN_FUNGIBLE_COMMON",
+              "nodedata": {
+                "constant": 94092119,
+                "bpt": 150425,
+                "vpt": 376062755,
+                "rbh": 100,
+                "sbh": 8,
+                "gas": 1003,
+                "bpr": 150425,
+                "sbpr": 3761,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 1505473906,
+                "bpt": 2406802,
+                "vpt": 6017004081,
+                "rbh": 1605,
+                "sbh": 120,
+                "gas": 16045,
+                "bpr": 2406802,
+                "sbpr": 60170,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 1505473906,
+                "bpt": 2406802,
+                "vpt": 6017004081,
+                "rbh": 1605,
+                "sbh": 120,
+                "gas": 16045,
+                "bpr": 2406802,
+                "sbpr": 60170,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            },
+            {
+              "subType": "TOKEN_NON_FUNGIBLE_UNIQUE",
+              "nodedata": {
+                "constant": 76366243,
+                "bpt": 122087,
+                "vpt": 305216845,
+                "rbh": 81,
+                "sbh": 6,
+                "gas": 814,
+                "bpr": 122087,
+                "sbpr": 3052,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 1527324859,
+                "bpt": 2441735,
+                "vpt": 6104336894,
+                "rbh": 1628,
+                "sbh": 122,
+                "gas": 16278,
+                "bpr": 2441735,
+                "sbpr": 61043,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 1527324859,
+                "bpt": 2441735,
+                "vpt": 6104336894,
+                "rbh": 1628,
+                "sbh": 122,
+                "gas": 16278,
+                "bpr": 2441735,
+                "sbpr": 61043,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "TokenGetInfo",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 61717,
+                "bpt": 99,
+                "vpt": 246668,
+                "rbh": 0,
+                "sbh": 0,
+                "gas": 1,
+                "bpr": 99,
+                "sbpr": 2,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 987474,
+                "bpt": 1579,
+                "vpt": 3946688,
+                "rbh": 1,
+                "sbh": 0,
+                "gas": 11,
+                "bpr": 1579,
+                "sbpr": 39,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 987474,
+                "bpt": 1579,
+                "vpt": 3946688,
+                "rbh": 1,
+                "sbh": 0,
+                "gas": 11,
+                "bpr": 1579,
+                "sbpr": 39,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "TokenGetNftInfo",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 54605,
+                "bpt": 87,
+                "vpt": 218244,
+                "rbh": 0,
+                "sbh": 0,
+                "gas": 1,
+                "bpr": 87,
+                "sbpr": 2,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 0,
+                "bpt": 0,
+                "vpt": 0,
+                "rbh": 0,
+                "sbh": 0,
+                "gas": 0,
+                "bpr": 0,
+                "sbpr": 0,
+                "min": 0,
+                "max": 0
+              },
+              "servicedata": {
+                "constant": 0,
+                "bpt": 0,
+                "vpt": 0,
+                "rbh": 0,
+                "sbh": 0,
+                "gas": 0,
+                "bpr": 0,
+                "sbpr": 0,
+                "min": 0,
+                "max": 0
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "ScheduleCreate",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 563513000,
+                "bpt": 900888,
+                "vpt": 2252221049,
+                "rbh": 601,
+                "sbh": 45,
+                "gas": 6006,
+                "bpr": 900888,
+                "sbpr": 22522,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 9016208000,
+                "bpt": 14414215,
+                "vpt": 36035536788,
+                "rbh": 9609,
+                "sbh": 721,
+                "gas": 96095,
+                "bpr": 14414215,
+                "sbpr": 360355,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 9016208000,
+                "bpt": 14414215,
+                "vpt": 36035536788,
+                "rbh": 9609,
+                "sbh": 721,
+                "gas": 96095,
+                "bpr": 14414215,
+                "sbpr": 360355,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "ScheduleSign",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 58040915,
+                "bpt": 92790,
+                "vpt": 231975077,
+                "rbh": 62,
+                "sbh": 5,
+                "gas": 619,
+                "bpr": 92790,
+                "sbpr": 2320,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 928654648,
+                "bpt": 1484640,
+                "vpt": 3711601232,
+                "rbh": 990,
+                "sbh": 74,
+                "gas": 9898,
+                "bpr": 1484640,
+                "sbpr": 37116,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 928654648,
+                "bpt": 1484640,
+                "vpt": 3711601232,
+                "rbh": 990,
+                "sbh": 74,
+                "gas": 9898,
+                "bpr": 1484640,
+                "sbpr": 37116,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "ScheduleDelete",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 95360774,
+                "bpt": 152453,
+                "vpt": 381133253,
+                "rbh": 102,
+                "sbh": 8,
+                "gas": 1016,
+                "bpr": 152453,
+                "sbpr": 3811,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 1525772386,
+                "bpt": 2439253,
+                "vpt": 6098132047,
+                "rbh": 1626,
+                "sbh": 122,
+                "gas": 16262,
+                "bpr": 2439253,
+                "sbpr": 60981,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 1525772386,
+                "bpt": 2439253,
+                "vpt": 6098132047,
+                "rbh": 1626,
+                "sbh": 122,
+                "gas": 16262,
+                "bpr": 2439253,
+                "sbpr": 60981,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "ScheduleGetInfo",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 53393,
+                "bpt": 85,
+                "vpt": 213400,
+                "rbh": 0,
+                "sbh": 0,
+                "gas": 1,
+                "bpr": 85,
+                "sbpr": 2,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 854295,
+                "bpt": 1366,
+                "vpt": 3414402,
+                "rbh": 1,
+                "sbh": 0,
+                "gas": 9,
+                "bpr": 1366,
+                "sbpr": 34,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 854295,
+                "bpt": 1366,
+                "vpt": 3414402,
+                "rbh": 1,
+                "sbh": 0,
+                "gas": 9,
+                "bpr": 1366,
+                "sbpr": 34,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "ContractCreate",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 45218052173,
+                "bpt": 72290115,
+                "vpt": 180725287466,
+                "rbh": 48193,
+                "sbh": 3615,
+                "gas": 852000,
+                "bpr": 72290115,
+                "sbpr": 1807253,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 723488834765,
+                "bpt": 1156641840,
+                "vpt": 2891604599463,
+                "rbh": 771095,
+                "sbh": 57832,
+                "gas": 852000,
+                "bpr": 1156641840,
+                "sbpr": 28916046,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 0,
+                "bpt": 0,
+                "vpt": 0,
+                "rbh": 0,
+                "sbh": 0,
+                "gas": 852000,
+                "bpr": 0,
+                "sbpr": 0,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "ContractUpdate",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 2438037058,
+                "bpt": 3897691,
+                "vpt": 9744226629,
+                "rbh": 2598,
+                "sbh": 195,
+                "gas": 25985,
+                "bpr": 3897691,
+                "sbpr": 97442,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 39008592923,
+                "bpt": 62363050,
+                "vpt": 155907626067,
+                "rbh": 41575,
+                "sbh": 3118,
+                "gas": 415754,
+                "bpr": 62363050,
+                "sbpr": 1559076,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 39008592923,
+                "bpt": 62363050,
+                "vpt": 155907626067,
+                "rbh": 41575,
+                "sbh": 3118,
+                "gas": 415754,
+                "bpr": 62363050,
+                "sbpr": 1559076,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "ContractDelete",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 664083202,
+                "bpt": 1061670,
+                "vpt": 2654175087,
+                "rbh": 708,
+                "sbh": 53,
+                "gas": 7078,
+                "bpr": 1061670,
+                "sbpr": 26542,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 10625331229,
+                "bpt": 16986721,
+                "vpt": 42466801390,
+                "rbh": 11324,
+                "sbh": 849,
+                "gas": 113245,
+                "bpr": 16986721,
+                "sbpr": 424668,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 10625331229,
+                "bpt": 16986721,
+                "vpt": 42466801390,
+                "rbh": 11324,
+                "sbh": 849,
+                "gas": 113245,
+                "bpr": 16986721,
+                "sbpr": 424668,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "ContractCall",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 0,
+                "bpt": 0,
+                "vpt": 0,
+                "rbh": 0,
+                "sbh": 0,
+                "gas": 0,
+                "bpr": 0,
+                "sbpr": 0,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 0,
+                "bpt": 0,
+                "vpt": 0,
+                "rbh": 0,
+                "sbh": 0,
+                "gas": 0,
+                "bpr": 0,
+                "sbpr": 0,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 0,
+                "bpt": 0,
+                "vpt": 0,
+                "rbh": 0,
+                "sbh": 0,
+                "gas": 852000,
+                "bpr": 0,
+                "sbpr": 0,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "EthereumTransaction",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 3336515210,
+                "bpt": 5334088,
+                "vpt": 13335219927,
+                "rbh": 3556,
+                "sbh": 267,
+                "gas": 0,
+                "bpr": 5334088,
+                "sbpr": 133352,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 53384243355,
+                "bpt": 85345408,
+                "vpt": 213363518838,
+                "rbh": 56897,
+                "sbh": 4267,
+                "gas": 0,
+                "bpr": 85345408,
+                "sbpr": 2133635,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 0,
+                "bpt": 0,
+                "vpt": 0,
+                "rbh": 0,
+                "sbh": 0,
+                "gas": 852000,
+                "bpr": 0,
+                "sbpr": 0,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "ContractGetInfo",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 71015,
+                "bpt": 114,
+                "vpt": 283830,
+                "rbh": 0,
+                "sbh": 0,
+                "gas": 1,
+                "bpr": 114,
+                "sbpr": 3,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 1136244,
+                "bpt": 1817,
+                "vpt": 4541284,
+                "rbh": 1,
+                "sbh": 0,
+                "gas": 12,
+                "bpr": 1817,
+                "sbpr": 45,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 1136244,
+                "bpt": 1817,
+                "vpt": 4541284,
+                "rbh": 1,
+                "sbh": 0,
+                "gas": 12,
+                "bpr": 1817,
+                "sbpr": 45,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "ContractCallLocal",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 2610100486,
+                "bpt": 4172769,
+                "vpt": 10431921279,
+                "rbh": 2782,
+                "sbh": 209,
+                "gas": 852000,
+                "bpr": 4172769,
+                "sbpr": 104319,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 41761607776,
+                "bpt": 66764296,
+                "vpt": 166910740461,
+                "rbh": 44510,
+                "sbh": 3338,
+                "gas": 852000,
+                "bpr": 66764296,
+                "sbpr": 1669107,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 41761607776,
+                "bpt": 66764296,
+                "vpt": 166910740461,
+                "rbh": 44510,
+                "sbh": 3338,
+                "gas": 852000,
+                "bpr": 66764296,
+                "sbpr": 1669107,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "ContractGetBytecode",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 226589259813,
+                "bpt": 362248325,
+                "vpt": 905620811793,
+                "rbh": 241499,
+                "sbh": 18112,
+                "gas": 2414989,
+                "bpr": 362248325,
+                "sbpr": 9056208,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 3625428157003,
+                "bpt": 5795973195,
+                "vpt": 14489932988688,
+                "rbh": 3863982,
+                "sbh": 289799,
+                "gas": 38639821,
+                "bpr": 5795973195,
+                "sbpr": 144899330,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 3625428157003,
+                "bpt": 5795973195,
+                "vpt": 14489932988688,
+                "rbh": 3863982,
+                "sbh": 289799,
+                "gas": 38639821,
+                "bpr": 5795973195,
+                "sbpr": 144899330,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "GetBySolidityID",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 69385,
+                "bpt": 111,
+                "vpt": 277313,
+                "rbh": 0,
+                "sbh": 0,
+                "gas": 1,
+                "bpr": 111,
+                "sbpr": 3,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 1110154,
+                "bpt": 1775,
+                "vpt": 4437010,
+                "rbh": 1,
+                "sbh": 0,
+                "gas": 12,
+                "bpr": 1775,
+                "sbpr": 44,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 1110154,
+                "bpt": 1775,
+                "vpt": 4437010,
+                "rbh": 1,
+                "sbh": 0,
+                "gas": 12,
+                "bpr": 1775,
+                "sbpr": 44,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "ContractGetRecords",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 10093,
+                "bpt": 16,
+                "vpt": 40339,
+                "rbh": 0,
+                "sbh": 0,
+                "gas": 0,
+                "bpr": 16,
+                "sbpr": 0,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 161486,
+                "bpt": 258,
+                "vpt": 645421,
+                "rbh": 0,
+                "sbh": 0,
+                "gas": 2,
+                "bpr": 258,
+                "sbpr": 6,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 161486,
+                "bpt": 258,
+                "vpt": 645421,
+                "rbh": 0,
+                "sbh": 0,
+                "gas": 2,
+                "bpr": 258,
+                "sbpr": 6,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "ContractAutoRenew",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 3399972997,
+                "bpt": 5435538,
+                "vpt": 13588844891,
+                "rbh": 3624,
+                "sbh": 272,
+                "gas": 36237,
+                "bpr": 5435538,
+                "sbpr": 135888,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 67999459941,
+                "bpt": 108710759,
+                "vpt": 271776897828,
+                "rbh": 72474,
+                "sbh": 5436,
+                "gas": 724738,
+                "bpr": 108710759,
+                "sbpr": 2717769,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 67999459941,
+                "bpt": 108710759,
+                "vpt": 271776897828,
+                "rbh": 72474,
+                "sbh": 5436,
+                "gas": 724738,
+                "bpr": 108710759,
+                "sbpr": 2717769,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "FileCreate",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 3657315129,
+                "bpt": 5846951,
+                "vpt": 14617377270,
+                "rbh": 3898,
+                "sbh": 292,
+                "gas": 38980,
+                "bpr": 5846951,
+                "sbpr": 146174,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 58517042062,
+                "bpt": 93551215,
+                "vpt": 233878036318,
+                "rbh": 62367,
+                "sbh": 4678,
+                "gas": 623675,
+                "bpr": 93551215,
+                "sbpr": 2338780,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 58517042062,
+                "bpt": 93551215,
+                "vpt": 233878036318,
+                "rbh": 62367,
+                "sbh": 4678,
+                "gas": 623675,
+                "bpr": 93551215,
+                "sbpr": 2338780,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "FileUpdate",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 3663140881,
+                "bpt": 5856265,
+                "vpt": 14640661348,
+                "rbh": 3904,
+                "sbh": 293,
+                "gas": 39042,
+                "bpr": 5856265,
+                "sbpr": 146407,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 58610254089,
+                "bpt": 93700233,
+                "vpt": 234250581567,
+                "rbh": 62467,
+                "sbh": 4685,
+                "gas": 624668,
+                "bpr": 93700233,
+                "sbpr": 2342506,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 58610254089,
+                "bpt": 93700233,
+                "vpt": 234250581567,
+                "rbh": 62467,
+                "sbh": 4685,
+                "gas": 624668,
+                "bpr": 93700233,
+                "sbpr": 2342506,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "FileDelete",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 664083202,
+                "bpt": 1061670,
+                "vpt": 2654175087,
+                "rbh": 708,
+                "sbh": 53,
+                "gas": 7078,
+                "bpr": 1061670,
+                "sbpr": 26542,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 10625331229,
+                "bpt": 16986721,
+                "vpt": 42466801390,
+                "rbh": 11324,
+                "sbh": 849,
+                "gas": 113245,
+                "bpr": 16986721,
+                "sbpr": 424668,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 10625331229,
+                "bpt": 16986721,
+                "vpt": 42466801390,
+                "rbh": 11324,
+                "sbh": 849,
+                "gas": 113245,
+                "bpr": 16986721,
+                "sbpr": 424668,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "FileAppend",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 2981423158,
+                "bpt": 4766402,
+                "vpt": 11916005477,
+                "rbh": 3178,
+                "sbh": 238,
+                "gas": 31776,
+                "bpr": 4766402,
+                "sbpr": 119160,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 59628463168,
+                "bpt": 95328044,
+                "vpt": 238320109546,
+                "rbh": 63552,
+                "sbh": 4766,
+                "gas": 635520,
+                "bpr": 95328044,
+                "sbpr": 2383201,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 59628463168,
+                "bpt": 95328044,
+                "vpt": 238320109546,
+                "rbh": 63552,
+                "sbh": 4766,
+                "gas": 635520,
+                "bpr": 95328044,
+                "sbpr": 2383201,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "FileGetContents",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 69308,
+                "bpt": 111,
+                "vpt": 277006,
+                "rbh": 0,
+                "sbh": 0,
+                "gas": 1,
+                "bpr": 111,
+                "sbpr": 3,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 1108924,
+                "bpt": 1773,
+                "vpt": 4432093,
+                "rbh": 1,
+                "sbh": 0,
+                "gas": 12,
+                "bpr": 1773,
+                "sbpr": 44,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 1108924,
+                "bpt": 1773,
+                "vpt": 4432093,
+                "rbh": 1,
+                "sbh": 0,
+                "gas": 12,
+                "bpr": 1773,
+                "sbpr": 44,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "FileGetInfo",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 71080,
+                "bpt": 114,
+                "vpt": 284088,
+                "rbh": 0,
+                "sbh": 0,
+                "gas": 1,
+                "bpr": 114,
+                "sbpr": 3,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 1137277,
+                "bpt": 1818,
+                "vpt": 4545413,
+                "rbh": 1,
+                "sbh": 0,
+                "gas": 12,
+                "bpr": 1818,
+                "sbpr": 45,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 1137277,
+                "bpt": 1818,
+                "vpt": 4545413,
+                "rbh": 1,
+                "sbh": 0,
+                "gas": 12,
+                "bpr": 1818,
+                "sbpr": 45,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "GetVersionInfo",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 6519421057,
+                "bpt": 10422601,
+                "vpt": 26056501507,
+                "rbh": 6948,
+                "sbh": 521,
+                "gas": 69484,
+                "bpr": 10422601,
+                "sbpr": 260565,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 104310736905,
+                "bpt": 166761610,
+                "vpt": 416904024105,
+                "rbh": 111174,
+                "sbh": 8338,
+                "gas": 1111744,
+                "bpr": 166761610,
+                "sbpr": 4169040,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 104310736905,
+                "bpt": 166761610,
+                "vpt": 416904024105,
+                "rbh": 111174,
+                "sbh": 8338,
+                "gas": 1111744,
+                "bpr": 166761610,
+                "sbpr": 4169040,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "GetByKey",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 1,
+                "bpt": 0,
+                "vpt": 0,
+                "rbh": 0,
+                "sbh": 0,
+                "gas": 0,
+                "bpr": 0,
+                "sbpr": 0,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 1,
+                "bpt": 0,
+                "vpt": 0,
+                "rbh": 0,
+                "sbh": 0,
+                "gas": 0,
+                "bpr": 0,
+                "sbpr": 0,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 1,
+                "bpt": 0,
+                "vpt": 0,
+                "rbh": 0,
+                "sbh": 0,
+                "gas": 0,
+                "bpr": 0,
+                "sbpr": 0,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "TransactionGetReceipt",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 1,
+                "bpt": 0,
+                "vpt": 0,
+                "rbh": 0,
+                "sbh": 0,
+                "gas": 0,
+                "bpr": 0,
+                "sbpr": 0,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 1,
+                "bpt": 0,
+                "vpt": 0,
+                "rbh": 0,
+                "sbh": 0,
+                "gas": 0,
+                "bpr": 0,
+                "sbpr": 0,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 1,
+                "bpt": 0,
+                "vpt": 0,
+                "rbh": 0,
+                "sbh": 0,
+                "gas": 0,
+                "bpr": 0,
+                "sbpr": 0,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "SystemDelete",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 0,
+                "bpt": 0,
+                "vpt": 0,
+                "rbh": 0,
+                "sbh": 0,
+                "gas": 0,
+                "bpr": 0,
+                "sbpr": 0,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 0,
+                "bpt": 0,
+                "vpt": 0,
+                "rbh": 0,
+                "sbh": 0,
+                "gas": 0,
+                "bpr": 0,
+                "sbpr": 0,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 0,
+                "bpt": 0,
+                "vpt": 0,
+                "rbh": 0,
+                "sbh": 0,
+                "gas": 0,
+                "bpr": 0,
+                "sbpr": 0,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "SystemUndelete",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 0,
+                "bpt": 0,
+                "vpt": 0,
+                "rbh": 0,
+                "sbh": 0,
+                "gas": 0,
+                "bpr": 0,
+                "sbpr": 0,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 0,
+                "bpt": 0,
+                "vpt": 0,
+                "rbh": 0,
+                "sbh": 0,
+                "gas": 0,
+                "bpr": 0,
+                "sbpr": 0,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 0,
+                "bpt": 0,
+                "vpt": 0,
+                "rbh": 0,
+                "sbh": 0,
+                "gas": 0,
+                "bpr": 0,
+                "sbpr": 0,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "TransactionGetRecord",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 54605,
+                "bpt": 87,
+                "vpt": 218244,
+                "rbh": 0,
+                "sbh": 0,
+                "gas": 1,
+                "bpr": 87,
+                "sbpr": 2,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 873685,
+                "bpt": 1397,
+                "vpt": 3491900,
+                "rbh": 1,
+                "sbh": 0,
+                "gas": 9,
+                "bpr": 1397,
+                "sbpr": 35,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 873685,
+                "bpt": 1397,
+                "vpt": 3491900,
+                "rbh": 1,
+                "sbh": 0,
+                "gas": 9,
+                "bpr": 1397,
+                "sbpr": 35,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "expiryTime": 1630800000
+      }
+    ]
   },
   {
-	"nextFeeSchedule": [
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "CryptoCreate",
-		  "fees": [
-			{
-			  "subType": "DEFAULT",
-			  "nodedata": {
-				"constant": 11461413665,
-				"bpt": 508982,
-				"vpt": 1272455960,
-				"rbh": 339,
-				"sbh": 25,
-				"gas": 3393,
-				"bpr": 508982,
-				"sbpr": 12725,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 229228273302,
-				"bpt": 10179648,
-				"vpt": 25449119198,
-				"rbh": 6786,
-				"sbh": 509,
-				"gas": 67864,
-				"bpr": 10179648,
-				"sbpr": 254491,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 229228273302,
-				"bpt": 10179648,
-				"vpt": 25449119198,
-				"rbh": 6786,
-				"sbh": 509,
-				"gas": 67864,
-				"bpr": 10179648,
-				"sbpr": 254491,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "CryptoDeleteAllowance",
-		  "fees": [
-			{
-			  "subType": "DEFAULT",
-			  "nodedata": {
-				"constant": 3794963556,
-				"bpt": 6067009,
-				"vpt": 15167523735,
-				"rbh": 4045,
-				"sbh": 303,
-				"gas": 40447,
-				"bpr": 6067009,
-				"sbpr": 151675,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 75899271121,
-				"bpt": 121340190,
-				"vpt": 303350474702,
-				"rbh": 80893,
-				"sbh": 6067,
-				"gas": 808935,
-				"bpr": 121340190,
-				"sbpr": 3033505,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 75899271121,
-				"bpt": 121340190,
-				"vpt": 303350474702,
-				"rbh": 80893,
-				"sbh": 6067,
-				"gas": 808935,
-				"bpr": 121340190,
-				"sbpr": 3033505,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "CryptoApproveAllowance",
-		  "fees": [
-			{
-			  "subType": "DEFAULT",
-			  "nodedata": {
-				"constant": 3766772044,
-				"bpt": 6021940,
-				"vpt": 15054849285,
-				"rbh": 4015,
-				"sbh": 301,
-				"gas": 40146,
-				"bpr": 6021940,
-				"sbpr": 150548,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 75335440874,
-				"bpt": 120438794,
-				"vpt": 301096985700,
-				"rbh": 80293,
-				"sbh": 6022,
-				"gas": 802925,
-				"bpr": 120438794,
-				"sbpr": 3010970,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 75335440874,
-				"bpt": 120438794,
-				"vpt": 301096985700,
-				"rbh": 80293,
-				"sbh": 6022,
-				"gas": 802925,
-				"bpr": 120438794,
-				"sbpr": 3010970,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "CryptoAccountAutoRenew",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 59972622,
-				"bpt": 95878,
-				"vpt": 239695625,
-				"rbh": 64,
-				"sbh": 5,
-				"gas": 639,
-				"bpr": 95878,
-				"sbpr": 2397,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 959561945,
-				"bpt": 1534052,
-				"vpt": 3835129999,
-				"rbh": 1023,
-				"sbh": 77,
-				"gas": 10227,
-				"bpr": 1534052,
-				"sbpr": 38351,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 959561945,
-				"bpt": 1534052,
-				"vpt": 3835129999,
-				"rbh": 1023,
-				"sbh": 77,
-				"gas": 10227,
-				"bpr": 1534052,
-				"sbpr": 38351,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "CryptoUpdate",
-		  "fees": [
-			{
-			  "subType": "DEFAULT",
-			  "nodedata": {
-				"constant": 16302371,
-				"bpt": 26063,
-				"vpt": 65156516,
-				"rbh": 17,
-				"sbh": 1,
-				"gas": 174,
-				"bpr": 26063,
-				"sbpr": 652,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 326047427,
-				"bpt": 521252,
-				"vpt": 1303130322,
-				"rbh": 348,
-				"sbh": 26,
-				"gas": 3475,
-				"bpr": 521252,
-				"sbpr": 13031,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 326047427,
-				"bpt": 521252,
-				"vpt": 1303130322,
-				"rbh": 348,
-				"sbh": 26,
-				"gas": 3475,
-				"bpr": 521252,
-				"sbpr": 13031,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "CryptoTransfer",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 7574478,
-				"bpt": 12109,
-				"vpt": 30273301,
-				"rbh": 8,
-				"sbh": 1,
-				"gas": 81,
-				"bpr": 12109,
-				"sbpr": 303,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 151489557,
-				"bpt": 242186,
-				"vpt": 605466012,
-				"rbh": 161,
-				"sbh": 12,
-				"gas": 1615,
-				"bpr": 242186,
-				"sbpr": 6055,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 151489557,
-				"bpt": 242186,
-				"vpt": 605466012,
-				"rbh": 161,
-				"sbh": 12,
-				"gas": 1615,
-				"bpr": 242186,
-				"sbpr": 6055,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			},
-			{
-			  "subType": "TOKEN_FUNGIBLE_COMMON",
-			  "nodedata": {
-				"constant": 7983519,
-				"bpt": 12763,
-				"vpt": 31908136,
-				"rbh": 9,
-				"sbh": 1,
-				"gas": 85,
-				"bpr": 12763,
-				"sbpr": 319,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 159670382,
-				"bpt": 255265,
-				"vpt": 638162730,
-				"rbh": 170,
-				"sbh": 13,
-				"gas": 1702,
-				"bpr": 255265,
-				"sbpr": 6382,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 159670382,
-				"bpt": 255265,
-				"vpt": 638162730,
-				"rbh": 170,
-				"sbh": 13,
-				"gas": 1702,
-				"bpr": 255265,
-				"sbpr": 6382,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			},
-			{
-			  "subType": "TOKEN_FUNGIBLE_COMMON_WITH_CUSTOM_FEES",
-			  "nodedata": {
-				"constant": 15967037,
-				"bpt": 25527,
-				"vpt": 63816270,
-				"rbh": 17,
-				"sbh": 1,
-				"gas": 170,
-				"bpr": 25527,
-				"sbpr": 638,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 319340747,
-				"bpt": 510530,
-				"vpt": 1276325394,
-				"rbh": 340,
-				"sbh": 26,
-				"gas": 3404,
-				"bpr": 510530,
-				"sbpr": 12763,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 319340747,
-				"bpt": 510530,
-				"vpt": 1276325394,
-				"rbh": 340,
-				"sbh": 26,
-				"gas": 3404,
-				"bpr": 510530,
-				"sbpr": 12763,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			},
-			{
-			  "subType": "TOKEN_NON_FUNGIBLE_UNIQUE",
-			  "nodedata": {
-				"constant": 22833842,
-				"bpt": 36504,
-				"vpt": 91261178,
-				"rbh": 24,
-				"sbh": 2,
-				"gas": 243,
-				"bpr": 36504,
-				"sbpr": 913,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 456676846,
-				"bpt": 730089,
-				"vpt": 1825223562,
-				"rbh": 487,
-				"sbh": 37,
-				"gas": 4867,
-				"bpr": 730089,
-				"sbpr": 18252,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 456676846,
-				"bpt": 730089,
-				"vpt": 1825223562,
-				"rbh": 487,
-				"sbh": 37,
-				"gas": 4867,
-				"bpr": 730089,
-				"sbpr": 18252,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			},
-			{
-			  "subType": "TOKEN_NON_FUNGIBLE_UNIQUE_WITH_CUSTOM_FEES",
-			  "nodedata": {
-				"constant": 45667678,
-				"bpt": 73009,
-				"vpt": 182522330,
-				"rbh": 49,
-				"sbh": 4,
-				"gas": 487,
-				"bpr": 73009,
-				"sbpr": 1825,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 913353558,
-				"bpt": 1460179,
-				"vpt": 3650446591,
-				"rbh": 973,
-				"sbh": 73,
-				"gas": 9735,
-				"bpr": 1460179,
-				"sbpr": 36504,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 913353558,
-				"bpt": 1460179,
-				"vpt": 3650446591,
-				"rbh": 973,
-				"sbh": 73,
-				"gas": 9735,
-				"bpr": 1460179,
-				"sbpr": 36504,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "CryptoDelete",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 471427939,
-				"bpt": 753672,
-				"vpt": 1884180005,
-				"rbh": 502,
-				"sbh": 38,
-				"gas": 5024,
-				"bpr": 753672,
-				"sbpr": 18842,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 7542847021,
-				"bpt": 12058752,
-				"vpt": 30146880078,
-				"rbh": 8039,
-				"sbh": 603,
-				"gas": 80392,
-				"bpr": 12058752,
-				"sbpr": 301469,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 7542847021,
-				"bpt": 12058752,
-				"vpt": 30146880078,
-				"rbh": 8039,
-				"sbh": 603,
-				"gas": 80392,
-				"bpr": 12058752,
-				"sbpr": 301469,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "CryptoAddLiveHash",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 5561692202,
-				"bpt": 8891479,
-				"vpt": 22228697914,
-				"rbh": 5928,
-				"sbh": 445,
-				"gas": 59277,
-				"bpr": 8891479,
-				"sbpr": 222287,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 88987075231,
-				"bpt": 142263667,
-				"vpt": 355659166619,
-				"rbh": 94842,
-				"sbh": 7113,
-				"gas": 948424,
-				"bpr": 142263667,
-				"sbpr": 3556592,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 88987075231,
-				"bpt": 142263667,
-				"vpt": 355659166619,
-				"rbh": 94842,
-				"sbh": 7113,
-				"gas": 948424,
-				"bpr": 142263667,
-				"sbpr": 3556592,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "CryptoDeleteLiveHash",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 468546396,
-				"bpt": 749065,
-				"vpt": 1872663195,
-				"rbh": 499,
-				"sbh": 37,
-				"gas": 4994,
-				"bpr": 749065,
-				"sbpr": 18727,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 7496742329,
-				"bpt": 11985044,
-				"vpt": 29962611113,
-				"rbh": 7990,
-				"sbh": 599,
-				"gas": 79900,
-				"bpr": 11985044,
-				"sbpr": 299626,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 7496742329,
-				"bpt": 11985044,
-				"vpt": 29962611113,
-				"rbh": 7990,
-				"sbh": 599,
-				"gas": 79900,
-				"bpr": 11985044,
-				"sbpr": 299626,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "CryptoGetLiveHash",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 58926,
-				"bpt": 94,
-				"vpt": 235514,
-				"rbh": 0,
-				"sbh": 0,
-				"gas": 1,
-				"bpr": 94,
-				"sbpr": 2,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 942822,
-				"bpt": 1507,
-				"vpt": 3768224,
-				"rbh": 1,
-				"sbh": 0,
-				"gas": 10,
-				"bpr": 1507,
-				"sbpr": 38,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 942822,
-				"bpt": 1507,
-				"vpt": 3768224,
-				"rbh": 1,
-				"sbh": 0,
-				"gas": 10,
-				"bpr": 1507,
-				"sbpr": 38,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "CryptoGetAccountRecords",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 22044,
-				"bpt": 35,
-				"vpt": 88105,
-				"rbh": 0,
-				"sbh": 0,
-				"gas": 0,
-				"bpr": 35,
-				"sbpr": 1,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 352708,
-				"bpt": 564,
-				"vpt": 1409688,
-				"rbh": 0,
-				"sbh": 0,
-				"gas": 4,
-				"bpr": 564,
-				"sbpr": 14,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 352708,
-				"bpt": 564,
-				"vpt": 1409688,
-				"rbh": 0,
-				"sbh": 0,
-				"gas": 4,
-				"bpr": 564,
-				"sbpr": 14,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "CryptoGetAccountBalance",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 68774,
-				"bpt": 110,
-				"vpt": 274874,
-				"rbh": 0,
-				"sbh": 0,
-				"gas": 1,
-				"bpr": 110,
-				"sbpr": 3,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 1100389,
-				"bpt": 1759,
-				"vpt": 4397982,
-				"rbh": 1,
-				"sbh": 0,
-				"gas": 12,
-				"bpr": 1759,
-				"sbpr": 44,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 1100389,
-				"bpt": 1759,
-				"vpt": 4397982,
-				"rbh": 1,
-				"sbh": 0,
-				"gas": 12,
-				"bpr": 1759,
-				"sbpr": 44,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "CryptoGetInfo",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 63990,
-				"bpt": 102,
-				"vpt": 255752,
-				"rbh": 0,
-				"sbh": 0,
-				"gas": 1,
-				"bpr": 102,
-				"sbpr": 3,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 1023841,
-				"bpt": 1637,
-				"vpt": 4092038,
-				"rbh": 1,
-				"sbh": 0,
-				"gas": 11,
-				"bpr": 1637,
-				"sbpr": 41,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 1023841,
-				"bpt": 1637,
-				"vpt": 4092038,
-				"rbh": 1,
-				"sbh": 0,
-				"gas": 11,
-				"bpr": 1637,
-				"sbpr": 41,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "CryptoGetStakers",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 15251,
-				"bpt": 24,
-				"vpt": 60953,
-				"rbh": 0,
-				"sbh": 0,
-				"gas": 0,
-				"bpr": 24,
-				"sbpr": 1,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 244011,
-				"bpt": 390,
-				"vpt": 975251,
-				"rbh": 0,
-				"sbh": 0,
-				"gas": 3,
-				"bpr": 390,
-				"sbpr": 10,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 244011,
-				"bpt": 390,
-				"vpt": 975251,
-				"rbh": 0,
-				"sbh": 0,
-				"gas": 3,
-				"bpr": 390,
-				"sbpr": 10,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "ConsensusCreateTopic",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 921577366,
-				"bpt": 1473326,
-				"vpt": 3683315100,
-				"rbh": 982,
-				"sbh": 74,
-				"gas": 9822,
-				"bpr": 1473326,
-				"sbpr": 36833,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 14745237852,
-				"bpt": 23573217,
-				"vpt": 58933041595,
-				"rbh": 15715,
-				"sbh": 1179,
-				"gas": 157155,
-				"bpr": 23573217,
-				"sbpr": 589330,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 14745237852,
-				"bpt": 23573217,
-				"vpt": 58933041595,
-				"rbh": 15715,
-				"sbh": 1179,
-				"gas": 157155,
-				"bpr": 23573217,
-				"sbpr": 589330,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "ConsensusUpdateTopic",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 20193780,
-				"bpt": 32284,
-				"vpt": 80709508,
-				"rbh": 22,
-				"sbh": 2,
-				"gas": 215,
-				"bpr": 32284,
-				"sbpr": 807,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 323100486,
-				"bpt": 516541,
-				"vpt": 1291352134,
-				"rbh": 344,
-				"sbh": 26,
-				"gas": 3444,
-				"bpr": 516541,
-				"sbpr": 12914,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 323100486,
-				"bpt": 516541,
-				"vpt": 1291352134,
-				"rbh": 344,
-				"sbh": 26,
-				"gas": 3444,
-				"bpr": 516541,
-				"sbpr": 12914,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "ConsensusDeleteTopic",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 474345144,
-				"bpt": 758336,
-				"vpt": 1895839348,
-				"rbh": 506,
-				"sbh": 38,
-				"gas": 5056,
-				"bpr": 758336,
-				"sbpr": 18958,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 7589522307,
-				"bpt": 12133372,
-				"vpt": 30333429564,
-				"rbh": 8089,
-				"sbh": 607,
-				"gas": 80889,
-				"bpr": 12133372,
-				"sbpr": 303334,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 7589522307,
-				"bpt": 12133372,
-				"vpt": 30333429564,
-				"rbh": 8089,
-				"sbh": 607,
-				"gas": 80889,
-				"bpr": 12133372,
-				"sbpr": 303334,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "ConsensusSubmitMessage",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 9248442,
-				"bpt": 14785,
-				"vpt": 36963719,
-				"rbh": 10,
-				"sbh": 1,
-				"gas": 99,
-				"bpr": 14785,
-				"sbpr": 370,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 147975076,
-				"bpt": 236568,
-				"vpt": 591419509,
-				"rbh": 158,
-				"sbh": 12,
-				"gas": 1577,
-				"bpr": 236568,
-				"sbpr": 5914,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 147975076,
-				"bpt": 236568,
-				"vpt": 591419509,
-				"rbh": 158,
-				"sbh": 12,
-				"gas": 1577,
-				"bpr": 236568,
-				"sbpr": 5914,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "ConsensusGetTopicInfo",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 64253,
-				"bpt": 103,
-				"vpt": 256803,
-				"rbh": 0,
-				"sbh": 0,
-				"gas": 1,
-				"bpr": 103,
-				"sbpr": 3,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 1028048,
-				"bpt": 1644,
-				"vpt": 4108851,
-				"rbh": 1,
-				"sbh": 0,
-				"gas": 11,
-				"bpr": 1644,
-				"sbpr": 41,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 1028048,
-				"bpt": 1644,
-				"vpt": 4108851,
-				"rbh": 1,
-				"sbh": 0,
-				"gas": 11,
-				"bpr": 1644,
-				"sbpr": 41,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule" : {
-		  "hederaFunctionality" : "UtilPrng",
-		  "fees" : [ {
-			"subType" : "DEFAULT",
-			"nodedata" : {
-			  "constant" : 76998002,
-			  "bpt" : 123097,
-			  "vpt" : 307741829,
-			  "rbh" : 82,
-			  "sbh" : 6,
-			  "gas" : 821,
-			  "bpr" : 123097,
-			  "sbpr" : 3077,
-			  "min" : 0,
-			  "max" : 1000000000000000
-			},
-			"networkdata" : {
-			  "constant" : 1539960046,
-			  "bpt" : 2461935,
-			  "vpt" : 6154836589,
-			  "rbh" : 1641,
-			  "sbh" : 123,
-			  "gas" : 16413,
-			  "bpr" : 2461935,
-			  "sbpr" : 61548,
-			  "min" : 0,
-			  "max" : 1000000000000000
-			},
-			"servicedata" : {
-			  "constant" : 1539960046,
-			  "bpt" : 2461935,
-			  "vpt" : 6154836589,
-			  "rbh" : 1641,
-			  "sbh" : 123,
-			  "gas" : 16413,
-			  "bpr" : 2461935,
-			  "sbpr" : 61548,
-			  "min" : 0,
-			  "max" : 1000000000000000
-			}
-		  } ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "TokenCreate",
-		  "fees": [
-			{
-			  "subType": "TOKEN_FUNGIBLE_COMMON_WITH_CUSTOM_FEES",
-			  "nodedata": {
-				"constant": 393746195920,
-				"bpt": 17485616,
-				"vpt": 43714039850,
-				"rbh": 11657,
-				"sbh": 874,
-				"gas": 116571,
-				"bpr": 17485616,
-				"sbpr": 437140,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 7874923918408,
-				"bpt": 349712319,
-				"vpt": 874280797002,
-				"rbh": 233142,
-				"sbh": 17486,
-				"gas": 2331415,
-				"bpr": 349712319,
-				"sbpr": 8742808,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 7874923918408,
-				"bpt": 349712319,
-				"vpt": 874280797002,
-				"rbh": 233142,
-				"sbh": 17486,
-				"gas": 2331415,
-				"bpr": 349712319,
-				"sbpr": 8742808,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			},
-			{
-			  "subType": "TOKEN_FUNGIBLE_COMMON",
-			  "nodedata": {
-				"constant": 197306974233,
-				"bpt": 8762076,
-				"vpt": 21905189240,
-				"rbh": 5841,
-				"sbh": 438,
-				"gas": 58414,
-				"bpr": 8762076,
-				"sbpr": 219052,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 3946139484654,
-				"bpt": 175241514,
-				"vpt": 438103784807,
-				"rbh": 116828,
-				"sbh": 8762,
-				"gas": 1168277,
-				"bpr": 175241514,
-				"sbpr": 4381038,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 3946139484654,
-				"bpt": 175241514,
-				"vpt": 438103784807,
-				"rbh": 116828,
-				"sbh": 8762,
-				"gas": 1168277,
-				"bpr": 175241514,
-				"sbpr": 4381038,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			},
-			{
-			  "subType": "TOKEN_NON_FUNGIBLE_UNIQUE",
-			  "nodedata": {
-				"constant": 197031853851,
-				"bpt": 8749858,
-				"vpt": 21874645140,
-				"rbh": 5833,
-				"sbh": 437,
-				"gas": 58332,
-				"bpr": 8749858,
-				"sbpr": 218746,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 3940637077020,
-				"bpt": 174997161,
-				"vpt": 437492902800,
-				"rbh": 116665,
-				"sbh": 8750,
-				"gas": 1166648,
-				"bpr": 174997161,
-				"sbpr": 4374929,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 3940637077020,
-				"bpt": 174997161,
-				"vpt": 437492902800,
-				"rbh": 116665,
-				"sbh": 8750,
-				"gas": 1166648,
-				"bpr": 174997161,
-				"sbpr": 4374929,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			},
-			{
-			  "subType": "TOKEN_NON_FUNGIBLE_UNIQUE_WITH_CUSTOM_FEES",
-			  "nodedata": {
-				"constant": 393198370765,
-				"bpt": 17461288,
-				"vpt": 43653219832,
-				"rbh": 11641,
-				"sbh": 873,
-				"gas": 116409,
-				"bpr": 17461288,
-				"sbpr": 436532,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 7863967415309,
-				"bpt": 349225759,
-				"vpt": 873064396645,
-				"rbh": 232817,
-				"sbh": 17461,
-				"gas": 2328172,
-				"bpr": 349225759,
-				"sbpr": 8730644,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 7863967415309,
-				"bpt": 349225759,
-				"vpt": 873064396645,
-				"rbh": 232817,
-				"sbh": 17461,
-				"gas": 2328172,
-				"bpr": 349225759,
-				"sbpr": 8730644,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "TokenDelete",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 94285588,
-				"bpt": 150734,
-				"vpt": 376836001,
-				"rbh": 100,
-				"sbh": 8,
-				"gas": 1005,
-				"bpr": 150734,
-				"sbpr": 3768,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 1508569404,
-				"bpt": 2411750,
-				"vpt": 6029376016,
-				"rbh": 1608,
-				"sbh": 121,
-				"gas": 16078,
-				"bpr": 2411750,
-				"sbpr": 60294,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 1508569404,
-				"bpt": 2411750,
-				"vpt": 6029376016,
-				"rbh": 1608,
-				"sbh": 121,
-				"gas": 16078,
-				"bpr": 2411750,
-				"sbpr": 60294,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "TokenFeeScheduleUpdate",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 73998596,
-				"bpt": 118302,
-				"vpt": 295753948,
-				"rbh": 79,
-				"sbh": 6,
-				"gas": 789,
-				"bpr": 118302,
-				"sbpr": 2958,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 1479971913,
-				"bpt": 2366032,
-				"vpt": 5915078967,
-				"rbh": 1577,
-				"sbh": 118,
-				"gas": 15774,
-				"bpr": 2366032,
-				"sbpr": 59151,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 1479971913,
-				"bpt": 2366032,
-				"vpt": 5915078967,
-				"rbh": 1577,
-				"sbh": 118,
-				"gas": 15774,
-				"bpr": 2366032,
-				"sbpr": 59151,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "TokenUpdate",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 93900697,
-				"bpt": 150119,
-				"vpt": 375297688,
-				"rbh": 100,
-				"sbh": 8,
-				"gas": 1001,
-				"bpr": 150119,
-				"sbpr": 3753,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 1502411149,
-				"bpt": 2401905,
-				"vpt": 6004763005,
-				"rbh": 1601,
-				"sbh": 120,
-				"gas": 16013,
-				"bpr": 2401905,
-				"sbpr": 60048,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 1502411149,
-				"bpt": 2401905,
-				"vpt": 6004763005,
-				"rbh": 1601,
-				"sbh": 120,
-				"gas": 16013,
-				"bpr": 2401905,
-				"sbpr": 60048,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "TokenMint",
-		  "fees": [
-			{
-			  "subType": "TOKEN_FUNGIBLE_COMMON",
-			  "nodedata": {
-				"constant": 94092119,
-				"bpt": 150425,
-				"vpt": 376062755,
-				"rbh": 100,
-				"sbh": 8,
-				"gas": 1003,
-				"bpr": 150425,
-				"sbpr": 3761,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 1505473906,
-				"bpt": 2406802,
-				"vpt": 6017004081,
-				"rbh": 1605,
-				"sbh": 120,
-				"gas": 16045,
-				"bpr": 2406802,
-				"sbpr": 60170,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 1505473906,
-				"bpt": 2406802,
-				"vpt": 6017004081,
-				"rbh": 1605,
-				"sbh": 120,
-				"gas": 16045,
-				"bpr": 2406802,
-				"sbpr": 60170,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			},
-			{
-			  "subType": "TOKEN_NON_FUNGIBLE_UNIQUE",
-			  "nodedata": {
-				"constant": 3606440483,
-				"bpt": 5765618,
-				"vpt": 14414043986,
-				"rbh": 3844,
-				"sbh": 288,
-				"gas": 38437,
-				"bpr": 5765618,
-				"sbpr": 144140,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 72128809656,
-				"bpt": 115312352,
-				"vpt": 288280879722,
-				"rbh": 76875,
-				"sbh": 5766,
-				"gas": 768749,
-				"bpr": 115312352,
-				"sbpr": 2882809,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 72128809656,
-				"bpt": 115312352,
-				"vpt": 288280879722,
-				"rbh": 76875,
-				"sbh": 5766,
-				"gas": 768749,
-				"bpr": 115312352,
-				"sbpr": 2882809,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "TokenBurn",
-		  "fees": [
-			{
-			  "subType": "TOKEN_FUNGIBLE_COMMON",
-			  "nodedata": {
-				"constant": 94092119,
-				"bpt": 150425,
-				"vpt": 376062755,
-				"rbh": 100,
-				"sbh": 8,
-				"gas": 1003,
-				"bpr": 150425,
-				"sbpr": 3761,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 1505473906,
-				"bpt": 2406802,
-				"vpt": 6017004081,
-				"rbh": 1605,
-				"sbh": 120,
-				"gas": 16045,
-				"bpr": 2406802,
-				"sbpr": 60170,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 1505473906,
-				"bpt": 2406802,
-				"vpt": 6017004081,
-				"rbh": 1605,
-				"sbh": 120,
-				"gas": 16045,
-				"bpr": 2406802,
-				"sbpr": 60170,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			},
-			{
-			  "subType": "TOKEN_NON_FUNGIBLE_UNIQUE",
-			  "nodedata": {
-				"constant": 76366243,
-				"bpt": 122087,
-				"vpt": 305216845,
-				"rbh": 81,
-				"sbh": 6,
-				"gas": 814,
-				"bpr": 122087,
-				"sbpr": 3052,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 1527324859,
-				"bpt": 2441735,
-				"vpt": 6104336894,
-				"rbh": 1628,
-				"sbh": 122,
-				"gas": 16278,
-				"bpr": 2441735,
-				"sbpr": 61043,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 1527324859,
-				"bpt": 2441735,
-				"vpt": 6104336894,
-				"rbh": 1628,
-				"sbh": 122,
-				"gas": 16278,
-				"bpr": 2441735,
-				"sbpr": 61043,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "TokenAssociateToAccount",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 4574479485,
-				"bpt": 7313222,
-				"vpt": 18283054670,
-				"rbh": 4875,
-				"sbh": 366,
-				"gas": 48755,
-				"bpr": 7313222,
-				"sbpr": 182831,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 73191671761,
-				"bpt": 117011550,
-				"vpt": 292528874720,
-				"rbh": 78008,
-				"sbh": 5851,
-				"gas": 780077,
-				"bpr": 117011550,
-				"sbpr": 2925289,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 73191671761,
-				"bpt": 117011550,
-				"vpt": 292528874720,
-				"rbh": 78008,
-				"sbh": 5851,
-				"gas": 780077,
-				"bpr": 117011550,
-				"sbpr": 2925289,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "TokenDissociateFromAccount",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 4714279388,
-				"bpt": 7536720,
-				"vpt": 18841800049,
-				"rbh": 5024,
-				"sbh": 377,
-				"gas": 50245,
-				"bpr": 7536720,
-				"sbpr": 188418,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 75428470213,
-				"bpt": 120587520,
-				"vpt": 301468800784,
-				"rbh": 80392,
-				"sbh": 6029,
-				"gas": 803917,
-				"bpr": 120587520,
-				"sbpr": 3014688,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 75428470213,
-				"bpt": 120587520,
-				"vpt": 301468800784,
-				"rbh": 80392,
-				"sbh": 6029,
-				"gas": 803917,
-				"bpr": 120587520,
-				"sbpr": 3014688,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "TokenGrantKycToAccount",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 94285551,
-				"bpt": 150734,
-				"vpt": 376835856,
-				"rbh": 100,
-				"sbh": 8,
-				"gas": 1005,
-				"bpr": 150734,
-				"sbpr": 3768,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 1508568822,
-				"bpt": 2411749,
-				"vpt": 6029373689,
-				"rbh": 1608,
-				"sbh": 121,
-				"gas": 16078,
-				"bpr": 2411749,
-				"sbpr": 60294,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 1508568822,
-				"bpt": 2411749,
-				"vpt": 6029373689,
-				"rbh": 1608,
-				"sbh": 121,
-				"gas": 16078,
-				"bpr": 2411749,
-				"sbpr": 60294,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "TokenRevokeKycFromAccount",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 94285551,
-				"bpt": 150734,
-				"vpt": 376835856,
-				"rbh": 100,
-				"sbh": 8,
-				"gas": 1005,
-				"bpr": 150734,
-				"sbpr": 3768,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 1508568822,
-				"bpt": 2411749,
-				"vpt": 6029373689,
-				"rbh": 1608,
-				"sbh": 121,
-				"gas": 16078,
-				"bpr": 2411749,
-				"sbpr": 60294,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 1508568822,
-				"bpt": 2411749,
-				"vpt": 6029373689,
-				"rbh": 1608,
-				"sbh": 121,
-				"gas": 16078,
-				"bpr": 2411749,
-				"sbpr": 60294,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "TokenFreezeAccount",
-		  "fees": [
-			{
-			  "subType": "DEFAULT",
-			  "nodedata": {
-				"constant": 76054309,
-				"bpt": 121588,
-				"vpt": 303970122,
-				"rbh": 81,
-				"sbh": 6,
-				"gas": 811,
-				"bpr": 121588,
-				"sbpr": 3040,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 1521086180,
-				"bpt": 2431761,
-				"vpt": 6079402448,
-				"rbh": 1621,
-				"sbh": 122,
-				"gas": 16212,
-				"bpr": 2431761,
-				"sbpr": 60794,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 1521086180,
-				"bpt": 2431761,
-				"vpt": 6079402448,
-				"rbh": 1621,
-				"sbh": 122,
-				"gas": 16212,
-				"bpr": 2431761,
-				"sbpr": 60794,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "TokenUnfreezeAccount",
-		  "fees": [
-			{
-			  "subType": "DEFAULT",
-			  "nodedata": {
-				"constant": 76054309,
-				"bpt": 121588,
-				"vpt": 303970122,
-				"rbh": 81,
-				"sbh": 6,
-				"gas": 811,
-				"bpr": 121588,
-				"sbpr": 3040,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 1521086180,
-				"bpt": 2431761,
-				"vpt": 6079402448,
-				"rbh": 1621,
-				"sbh": 122,
-				"gas": 16212,
-				"bpr": 2431761,
-				"sbpr": 60794,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 1521086180,
-				"bpt": 2431761,
-				"vpt": 6079402448,
-				"rbh": 1621,
-				"sbh": 122,
-				"gas": 16212,
-				"bpr": 2431761,
-				"sbpr": 60794,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "TokenPause",
-		  "fees": [
-			{
-			  "subType": "DEFAULT",
-			  "nodedata": {
-				"constant": 76523246,
-				"bpt": 122338,
-				"vpt": 305844348,
-				"rbh": 82,
-				"sbh": 6,
-				"gas": 816,
-				"bpr": 122338,
-				"sbpr": 3058,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 1530464926,
-				"bpt": 2446755,
-				"vpt": 6116886962,
-				"rbh": 1631,
-				"sbh": 122,
-				"gas": 16312,
-				"bpr": 2446755,
-				"sbpr": 61169,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 1530464926,
-				"bpt": 2446755,
-				"vpt": 6116886962,
-				"rbh": 1631,
-				"sbh": 122,
-				"gas": 16312,
-				"bpr": 2446755,
-				"sbpr": 61169,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "TokenUnpause",
-		  "fees": [
-			{
-			  "subType": "DEFAULT",
-			  "nodedata": {
-				"constant": 76523246,
-				"bpt": 122338,
-				"vpt": 305844348,
-				"rbh": 82,
-				"sbh": 6,
-				"gas": 816,
-				"bpr": 122338,
-				"sbpr": 3058,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 1530464926,
-				"bpt": 2446755,
-				"vpt": 6116886962,
-				"rbh": 1631,
-				"sbh": 122,
-				"gas": 16312,
-				"bpr": 2446755,
-				"sbpr": 61169,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 1530464926,
-				"bpt": 2446755,
-				"vpt": 6116886962,
-				"rbh": 1631,
-				"sbh": 122,
-				"gas": 16312,
-				"bpr": 2446755,
-				"sbpr": 61169,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "TokenAccountWipe",
-		  "fees": [
-			{
-			  "subType": "TOKEN_FUNGIBLE_COMMON",
-			  "nodedata": {
-				"constant": 94092119,
-				"bpt": 150425,
-				"vpt": 376062755,
-				"rbh": 100,
-				"sbh": 8,
-				"gas": 1003,
-				"bpr": 150425,
-				"sbpr": 3761,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 1505473906,
-				"bpt": 2406802,
-				"vpt": 6017004081,
-				"rbh": 1605,
-				"sbh": 120,
-				"gas": 16045,
-				"bpr": 2406802,
-				"sbpr": 60170,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 1505473906,
-				"bpt": 2406802,
-				"vpt": 6017004081,
-				"rbh": 1605,
-				"sbh": 120,
-				"gas": 16045,
-				"bpr": 2406802,
-				"sbpr": 60170,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			},
-			{
-			  "subType": "TOKEN_NON_FUNGIBLE_UNIQUE",
-			  "nodedata": {
-				"constant": 76366243,
-				"bpt": 122087,
-				"vpt": 305216845,
-				"rbh": 81,
-				"sbh": 6,
-				"gas": 814,
-				"bpr": 122087,
-				"sbpr": 3052,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 1527324859,
-				"bpt": 2441735,
-				"vpt": 6104336894,
-				"rbh": 1628,
-				"sbh": 122,
-				"gas": 16278,
-				"bpr": 2441735,
-				"sbpr": 61043,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 1527324859,
-				"bpt": 2441735,
-				"vpt": 6104336894,
-				"rbh": 1628,
-				"sbh": 122,
-				"gas": 16278,
-				"bpr": 2441735,
-				"sbpr": 61043,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "TokenGetInfo",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 61717,
-				"bpt": 99,
-				"vpt": 246668,
-				"rbh": 0,
-				"sbh": 0,
-				"gas": 1,
-				"bpr": 99,
-				"sbpr": 2,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 987474,
-				"bpt": 1579,
-				"vpt": 3946688,
-				"rbh": 1,
-				"sbh": 0,
-				"gas": 11,
-				"bpr": 1579,
-				"sbpr": 39,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 987474,
-				"bpt": 1579,
-				"vpt": 3946688,
-				"rbh": 1,
-				"sbh": 0,
-				"gas": 11,
-				"bpr": 1579,
-				"sbpr": 39,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "ScheduleCreate",
-		  "fees" : [
-			{
-			  "subType" : "DEFAULT",
-			  "nodedata" : {
-				"constant" : 2182553692,
-				"bpt" : 96924,
-				"vpt" : 242308980,
-				"rbh" : 65,
-				"sbh" : 5,
-				"gas" : 646,
-				"bpr" : 96924,
-				"sbpr" : 2423,
-				"min" : 0,
-				"max" : 1000000000000000
-			  },
-			  "networkdata" : {
-				"constant" : 43651073832,
-				"bpt" : 1938472,
-				"vpt" : 4846179597,
-				"rbh" : 1292,
-				"sbh" : 97,
-				"gas" : 12923,
-				"bpr" : 1938472,
-				"sbpr" : 48462,
-				"min" : 0,
-				"max" : 1000000000000000
-			  },
-			  "servicedata" : {
-				"constant" : 43651073832,
-				"bpt" : 1938472,
-				"vpt" : 4846179597,
-				"rbh" : 1292,
-				"sbh" : 97,
-				"gas" : 12923,
-				"bpr" : 1938472,
-				"sbpr" : 48462,
-				"min" : 0,
-				"max" : 1000000000000000
-			  }
-			}, {
-			  "subType" : "SCHEDULE_CREATE_CONTRACT_CALL",
-			  "nodedata" : {
-				"constant" : 22946919652,
-				"bpt" : 1019035,
-				"vpt" : 2547586670,
-				"rbh" : 679,
-				"sbh" : 51,
-				"gas" : 6794,
-				"bpr" : 1019035,
-				"sbpr" : 25476,
-				"min" : 0,
-				"max" : 1000000000000000
-			  },
-			  "networkdata" : {
-				"constant" : 458938393039,
-				"bpt" : 20380693,
-				"vpt" : 50951733401,
-				"rbh" : 13587,
-				"sbh" : 1019,
-				"gas" : 135871,
-				"bpr" : 20380693,
-				"sbpr" : 509517,
-				"min" : 0,
-				"max" : 1000000000000000
-			  },
-			  "servicedata" : {
-				"constant" : 458938393039,
-				"bpt" : 20380693,
-				"vpt" : 50951733401,
-				"rbh" : 13587,
-				"sbh" : 1019,
-				"gas" : 135871,
-				"bpr" : 20380693,
-				"sbpr" : 509517,
-				"min" : 0,
-				"max" : 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "TokenGetNftInfo",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 54605,
-				"bpt": 87,
-				"vpt": 218244,
-				"rbh": 0,
-				"sbh": 0,
-				"gas": 1,
-				"bpr": 87,
-				"sbpr": 2,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 0,
-				"bpt": 0,
-				"vpt": 0,
-				"rbh": 0,
-				"sbh": 0,
-				"gas": 0,
-				"bpr": 0,
-				"sbpr": 0,
-				"min": 0,
-				"max": 0
-			  },
-			  "servicedata": {
-				"constant": 0,
-				"bpt": 0,
-				"vpt": 0,
-				"rbh": 0,
-				"sbh": 0,
-				"gas": 0,
-				"bpr": 0,
-				"sbpr": 0,
-				"min": 0,
-				"max": 0
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "ScheduleSign",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 58040915,
-				"bpt": 92790,
-				"vpt": 231975077,
-				"rbh": 62,
-				"sbh": 5,
-				"gas": 619,
-				"bpr": 92790,
-				"sbpr": 2320,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 928654648,
-				"bpt": 1484640,
-				"vpt": 3711601232,
-				"rbh": 990,
-				"sbh": 74,
-				"gas": 9898,
-				"bpr": 1484640,
-				"sbpr": 37116,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 928654648,
-				"bpt": 1484640,
-				"vpt": 3711601232,
-				"rbh": 990,
-				"sbh": 74,
-				"gas": 9898,
-				"bpr": 1484640,
-				"sbpr": 37116,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "ScheduleDelete",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 95360774,
-				"bpt": 152453,
-				"vpt": 381133253,
-				"rbh": 102,
-				"sbh": 8,
-				"gas": 1016,
-				"bpr": 152453,
-				"sbpr": 3811,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 1525772386,
-				"bpt": 2439253,
-				"vpt": 6098132047,
-				"rbh": 1626,
-				"sbh": 122,
-				"gas": 16262,
-				"bpr": 2439253,
-				"sbpr": 60981,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 1525772386,
-				"bpt": 2439253,
-				"vpt": 6098132047,
-				"rbh": 1626,
-				"sbh": 122,
-				"gas": 16262,
-				"bpr": 2439253,
-				"sbpr": 60981,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "ScheduleGetInfo",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 53393,
-				"bpt": 85,
-				"vpt": 213400,
-				"rbh": 0,
-				"sbh": 0,
-				"gas": 1,
-				"bpr": 85,
-				"sbpr": 2,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 854295,
-				"bpt": 1366,
-				"vpt": 3414402,
-				"rbh": 1,
-				"sbh": 0,
-				"gas": 9,
-				"bpr": 1366,
-				"sbpr": 34,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 854295,
-				"bpt": 1366,
-				"vpt": 3414402,
-				"rbh": 1,
-				"sbh": 0,
-				"gas": 9,
-				"bpr": 1366,
-				"sbpr": 34,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "ContractCreate",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 45218052173,
-				"bpt": 72290115,
-				"vpt": 180725287466,
-				"rbh": 48193,
-				"sbh": 3615,
-				"gas": 481934,
-				"bpr": 72290115,
-				"sbpr": 1807253,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 723488834765,
-				"bpt": 1156641840,
-				"vpt": 2891604599463,
-				"rbh": 771095,
-				"sbh": 57832,
-				"gas": 7710946,
-				"bpr": 1156641840,
-				"sbpr": 28916046,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 0,
-				"bpt": 0,
-				"vpt": 0,
-				"rbh": 0,
-				"sbh": 0,
-				"gas": 11566419,
-				"bpr": 0,
-				"sbpr": 0,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "ContractUpdate",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 2438037058,
-				"bpt": 3897691,
-				"vpt": 9744226629,
-				"rbh": 2598,
-				"sbh": 195,
-				"gas": 25985,
-				"bpr": 3897691,
-				"sbpr": 97442,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 39008592923,
-				"bpt": 62363050,
-				"vpt": 155907626067,
-				"rbh": 41575,
-				"sbh": 3118,
-				"gas": 415754,
-				"bpr": 62363050,
-				"sbpr": 1559076,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 39008592923,
-				"bpt": 62363050,
-				"vpt": 155907626067,
-				"rbh": 41575,
-				"sbh": 3118,
-				"gas": 415754,
-				"bpr": 62363050,
-				"sbpr": 1559076,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "ContractDelete",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 664083202,
-				"bpt": 1061670,
-				"vpt": 2654175087,
-				"rbh": 708,
-				"sbh": 53,
-				"gas": 7078,
-				"bpr": 1061670,
-				"sbpr": 26542,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 10625331229,
-				"bpt": 16986721,
-				"vpt": 42466801390,
-				"rbh": 11324,
-				"sbh": 849,
-				"gas": 113245,
-				"bpr": 16986721,
-				"sbpr": 424668,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 10625331229,
-				"bpt": 16986721,
-				"vpt": 42466801390,
-				"rbh": 11324,
-				"sbh": 849,
-				"gas": 113245,
-				"bpr": 16986721,
-				"sbpr": 424668,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "ContractCall",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 3336515210,
-				"bpt": 5334088,
-				"vpt": 13335219927,
-				"rbh": 3556,
-				"sbh": 267,
-				"gas": 35561,
-				"bpr": 5334088,
-				"sbpr": 133352,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 53384243355,
-				"bpt": 85345408,
-				"vpt": 213363518838,
-				"rbh": 56897,
-				"sbh": 4267,
-				"gas": 568969,
-				"bpr": 85345408,
-				"sbpr": 2133635,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 0,
-				"bpt": 0,
-				"vpt": 0,
-				"rbh": 0,
-				"sbh": 0,
-				"gas": 853454,
-				"bpr": 0,
-				"sbpr": 0,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "EthereumTransaction",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 6122046,
-				"bpt": 9787,
-				"vpt": 24468293,
-				"rbh": 6,
-				"sbh": 0,
-				"gas": 65,
-				"bpr": 9787,
-				"sbpr": 244,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 97952740,
-				"bpt": 156597,
-				"vpt": 391492695,
-				"rbh": 104,
-				"sbh": 7,
-				"gas": 1043,
-				"bpr": 156597,
-				"sbpr": 3914,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 0,
-				"bpt": 0,
-				"vpt": 0,
-				"rbh": 0,
-				"sbh": 0,
-				"gas": 853454,
-				"bpr": 0,
-				"sbpr": 0,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "ContractGetInfo",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 71015,
-				"bpt": 114,
-				"vpt": 283830,
-				"rbh": 0,
-				"sbh": 0,
-				"gas": 1,
-				"bpr": 114,
-				"sbpr": 3,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 1136244,
-				"bpt": 1817,
-				"vpt": 4541284,
-				"rbh": 1,
-				"sbh": 0,
-				"gas": 12,
-				"bpr": 1817,
-				"sbpr": 45,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 1136244,
-				"bpt": 1817,
-				"vpt": 4541284,
-				"rbh": 1,
-				"sbh": 0,
-				"gas": 12,
-				"bpr": 1817,
-				"sbpr": 45,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "ContractCallLocal",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 2610100486,
-				"bpt": 4172769,
-				"vpt": 10431921279,
-				"rbh": 2782,
-				"sbh": 209,
-				"gas": 27818,
-				"bpr": 4172769,
-				"sbpr": 104319,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 41761607776,
-				"bpt": 66764296,
-				"vpt": 166910740461,
-				"rbh": 44510,
-				"sbh": 3338,
-				"gas": 445095,
-				"bpr": 66764296,
-				"sbpr": 1669107,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 41761607776,
-				"bpt": 66764296,
-				"vpt": 166910740461,
-				"rbh": 44510,
-				"sbh": 3338,
-				"gas": 445095,
-				"bpr": 66764296,
-				"sbpr": 1669107,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "ContractGetBytecode",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 226589259813,
-				"bpt": 362248325,
-				"vpt": 905620811793,
-				"rbh": 241499,
-				"sbh": 18112,
-				"gas": 2414989,
-				"bpr": 362248325,
-				"sbpr": 9056208,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 3625428157003,
-				"bpt": 5795973195,
-				"vpt": 14489932988688,
-				"rbh": 3863982,
-				"sbh": 289799,
-				"gas": 38639821,
-				"bpr": 5795973195,
-				"sbpr": 144899330,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 3625428157003,
-				"bpt": 5795973195,
-				"vpt": 14489932988688,
-				"rbh": 3863982,
-				"sbh": 289799,
-				"gas": 38639821,
-				"bpr": 5795973195,
-				"sbpr": 144899330,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "GetBySolidityID",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 69385,
-				"bpt": 111,
-				"vpt": 277313,
-				"rbh": 0,
-				"sbh": 0,
-				"gas": 1,
-				"bpr": 111,
-				"sbpr": 3,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 1110154,
-				"bpt": 1775,
-				"vpt": 4437010,
-				"rbh": 1,
-				"sbh": 0,
-				"gas": 12,
-				"bpr": 1775,
-				"sbpr": 44,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 1110154,
-				"bpt": 1775,
-				"vpt": 4437010,
-				"rbh": 1,
-				"sbh": 0,
-				"gas": 12,
-				"bpr": 1775,
-				"sbpr": 44,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "ContractGetRecords",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 10093,
-				"bpt": 16,
-				"vpt": 40339,
-				"rbh": 0,
-				"sbh": 0,
-				"gas": 0,
-				"bpr": 16,
-				"sbpr": 0,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 161486,
-				"bpt": 258,
-				"vpt": 645421,
-				"rbh": 0,
-				"sbh": 0,
-				"gas": 2,
-				"bpr": 258,
-				"sbpr": 6,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 161486,
-				"bpt": 258,
-				"vpt": 645421,
-				"rbh": 0,
-				"sbh": 0,
-				"gas": 2,
-				"bpr": 258,
-				"sbpr": 6,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule" : {
-		  "hederaFunctionality" : "ContractAutoRenew",
-		  "fees" : [ {
-			"subType" : "DEFAULT",
-			"nodedata" : {
-			  "constant" : 5396134280,
-			  "bpt" : 8626802,
-			  "vpt" : 21567004154,
-			  "rbh" : 5751,
-			  "sbh" : 431,
-			  "gas" : 57512,
-			  "bpr" : 8626802,
-			  "sbpr" : 215670,
-			  "min" : 0,
-			  "max" : 1000000000000000
-			},
-			"networkdata" : {
-			  "constant" : 107922685608,
-			  "bpt" : 172536033,
-			  "vpt" : 431340083072,
-			  "rbh" : 115024,
-			  "sbh" : 8627,
-			  "gas" : 1150240,
-			  "bpr" : 172536033,
-			  "sbpr" : 4313401,
-			  "min" : 0,
-			  "max" : 1000000000000000
-			},
-			"servicedata" : {
-			  "constant" : 107922685608,
-			  "bpt" : 172536033,
-			  "vpt" : 431340083072,
-			  "rbh" : 115024,
-			  "sbh" : 8627,
-			  "gas" : 1150240,
-			  "bpr" : 172536033,
-			  "sbpr" : 4313401,
-			  "min" : 0,
-			  "max" : 1000000000000000
-			}
-		  } ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "FileCreate",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 3657315129,
-				"bpt": 5846951,
-				"vpt": 14617377270,
-				"rbh": 3898,
-				"sbh": 292,
-				"gas": 38980,
-				"bpr": 5846951,
-				"sbpr": 146174,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 58517042062,
-				"bpt": 93551215,
-				"vpt": 233878036318,
-				"rbh": 62367,
-				"sbh": 4678,
-				"gas": 623675,
-				"bpr": 93551215,
-				"sbpr": 2338780,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 58517042062,
-				"bpt": 93551215,
-				"vpt": 233878036318,
-				"rbh": 62367,
-				"sbh": 4678,
-				"gas": 623675,
-				"bpr": 93551215,
-				"sbpr": 2338780,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "FileUpdate",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 3663140881,
-				"bpt": 5856265,
-				"vpt": 14640661348,
-				"rbh": 3904,
-				"sbh": 293,
-				"gas": 39042,
-				"bpr": 5856265,
-				"sbpr": 146407,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 58610254089,
-				"bpt": 93700233,
-				"vpt": 234250581567,
-				"rbh": 62467,
-				"sbh": 4685,
-				"gas": 624668,
-				"bpr": 93700233,
-				"sbpr": 2342506,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 58610254089,
-				"bpt": 93700233,
-				"vpt": 234250581567,
-				"rbh": 62467,
-				"sbh": 4685,
-				"gas": 624668,
-				"bpr": 93700233,
-				"sbpr": 2342506,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "FileDelete",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 664083202,
-				"bpt": 1061670,
-				"vpt": 2654175087,
-				"rbh": 708,
-				"sbh": 53,
-				"gas": 7078,
-				"bpr": 1061670,
-				"sbpr": 26542,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 10625331229,
-				"bpt": 16986721,
-				"vpt": 42466801390,
-				"rbh": 11324,
-				"sbh": 849,
-				"gas": 113245,
-				"bpr": 16986721,
-				"sbpr": 424668,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 10625331229,
-				"bpt": 16986721,
-				"vpt": 42466801390,
-				"rbh": 11324,
-				"sbh": 849,
-				"gas": 113245,
-				"bpr": 16986721,
-				"sbpr": 424668,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "FileAppend",
-		  "fees": [
-			{
-			  "subType": "DEFAULT",
-			  "nodedata": {
-				"constant": 2981423158,
-				"bpt": 4766402,
-				"vpt": 11916005477,
-				"rbh": 3178,
-				"sbh": 238,
-				"gas": 31776,
-				"bpr": 4766402,
-				"sbpr": 119160,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 59628463168,
-				"bpt": 95328044,
-				"vpt": 238320109546,
-				"rbh": 63552,
-				"sbh": 4766,
-				"gas": 635520,
-				"bpr": 95328044,
-				"sbpr": 2383201,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 59628463168,
-				"bpt": 95328044,
-				"vpt": 238320109546,
-				"rbh": 63552,
-				"sbh": 4766,
-				"gas": 635520,
-				"bpr": 95328044,
-				"sbpr": 2383201,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "FileGetContents",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 69308,
-				"bpt": 111,
-				"vpt": 277006,
-				"rbh": 0,
-				"sbh": 0,
-				"gas": 1,
-				"bpr": 111,
-				"sbpr": 3,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 1108924,
-				"bpt": 1773,
-				"vpt": 4432093,
-				"rbh": 1,
-				"sbh": 0,
-				"gas": 12,
-				"bpr": 1773,
-				"sbpr": 44,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 1108924,
-				"bpt": 1773,
-				"vpt": 4432093,
-				"rbh": 1,
-				"sbh": 0,
-				"gas": 12,
-				"bpr": 1773,
-				"sbpr": 44,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "FileGetInfo",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 71080,
-				"bpt": 114,
-				"vpt": 284088,
-				"rbh": 0,
-				"sbh": 0,
-				"gas": 1,
-				"bpr": 114,
-				"sbpr": 3,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 1137277,
-				"bpt": 1818,
-				"vpt": 4545413,
-				"rbh": 1,
-				"sbh": 0,
-				"gas": 12,
-				"bpr": 1818,
-				"sbpr": 45,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 1137277,
-				"bpt": 1818,
-				"vpt": 4545413,
-				"rbh": 1,
-				"sbh": 0,
-				"gas": 12,
-				"bpr": 1818,
-				"sbpr": 45,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "GetVersionInfo",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 6519421057,
-				"bpt": 10422601,
-				"vpt": 26056501507,
-				"rbh": 6948,
-				"sbh": 521,
-				"gas": 69484,
-				"bpr": 10422601,
-				"sbpr": 260565,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 104310736905,
-				"bpt": 166761610,
-				"vpt": 416904024105,
-				"rbh": 111174,
-				"sbh": 8338,
-				"gas": 1111744,
-				"bpr": 166761610,
-				"sbpr": 4169040,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 104310736905,
-				"bpt": 166761610,
-				"vpt": 416904024105,
-				"rbh": 111174,
-				"sbh": 8338,
-				"gas": 1111744,
-				"bpr": 166761610,
-				"sbpr": 4169040,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "GetByKey",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 1,
-				"bpt": 0,
-				"vpt": 0,
-				"rbh": 0,
-				"sbh": 0,
-				"gas": 0,
-				"bpr": 0,
-				"sbpr": 0,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 1,
-				"bpt": 0,
-				"vpt": 0,
-				"rbh": 0,
-				"sbh": 0,
-				"gas": 0,
-				"bpr": 0,
-				"sbpr": 0,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 1,
-				"bpt": 0,
-				"vpt": 0,
-				"rbh": 0,
-				"sbh": 0,
-				"gas": 0,
-				"bpr": 0,
-				"sbpr": 0,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "TransactionGetReceipt",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 1,
-				"bpt": 0,
-				"vpt": 0,
-				"rbh": 0,
-				"sbh": 0,
-				"gas": 0,
-				"bpr": 0,
-				"sbpr": 0,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 1,
-				"bpt": 0,
-				"vpt": 0,
-				"rbh": 0,
-				"sbh": 0,
-				"gas": 0,
-				"bpr": 0,
-				"sbpr": 0,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 1,
-				"bpt": 0,
-				"vpt": 0,
-				"rbh": 0,
-				"sbh": 0,
-				"gas": 0,
-				"bpr": 0,
-				"sbpr": 0,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "SystemDelete",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 0,
-				"bpt": 0,
-				"vpt": 0,
-				"rbh": 0,
-				"sbh": 0,
-				"gas": 0,
-				"bpr": 0,
-				"sbpr": 0,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 0,
-				"bpt": 0,
-				"vpt": 0,
-				"rbh": 0,
-				"sbh": 0,
-				"gas": 0,
-				"bpr": 0,
-				"sbpr": 0,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 0,
-				"bpt": 0,
-				"vpt": 0,
-				"rbh": 0,
-				"sbh": 0,
-				"gas": 0,
-				"bpr": 0,
-				"sbpr": 0,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "SystemUndelete",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 0,
-				"bpt": 0,
-				"vpt": 0,
-				"rbh": 0,
-				"sbh": 0,
-				"gas": 0,
-				"bpr": 0,
-				"sbpr": 0,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 0,
-				"bpt": 0,
-				"vpt": 0,
-				"rbh": 0,
-				"sbh": 0,
-				"gas": 0,
-				"bpr": 0,
-				"sbpr": 0,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 0,
-				"bpt": 0,
-				"vpt": 0,
-				"rbh": 0,
-				"sbh": 0,
-				"gas": 0,
-				"bpr": 0,
-				"sbpr": 0,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"transactionFeeSchedule": {
-		  "hederaFunctionality": "TransactionGetRecord",
-		  "fees": [
-			{
-			  "nodedata": {
-				"constant": 54605,
-				"bpt": 87,
-				"vpt": 218244,
-				"rbh": 0,
-				"sbh": 0,
-				"gas": 1,
-				"bpr": 87,
-				"sbpr": 2,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "networkdata": {
-				"constant": 873685,
-				"bpt": 1397,
-				"vpt": 3491900,
-				"rbh": 1,
-				"sbh": 0,
-				"gas": 9,
-				"bpr": 1397,
-				"sbpr": 35,
-				"min": 0,
-				"max": 1000000000000000
-			  },
-			  "servicedata": {
-				"constant": 873685,
-				"bpt": 1397,
-				"vpt": 3491900,
-				"rbh": 1,
-				"sbh": 0,
-				"gas": 9,
-				"bpr": 1397,
-				"sbpr": 35,
-				"min": 0,
-				"max": 1000000000000000
-			  }
-			}
-		  ]
-		}
-	  },
-	  {
-		"expiryTime": 1633392000
-	  }
-	]
+    "nextFeeSchedule": [
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "CryptoCreate",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 11461413665,
+                "bpt": 508982,
+                "vpt": 1272455960,
+                "rbh": 339,
+                "sbh": 25,
+                "gas": 3393,
+                "bpr": 508982,
+                "sbpr": 12725,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 229228273302,
+                "bpt": 10179648,
+                "vpt": 25449119198,
+                "rbh": 6786,
+                "sbh": 509,
+                "gas": 67864,
+                "bpr": 10179648,
+                "sbpr": 254491,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 229228273302,
+                "bpt": 10179648,
+                "vpt": 25449119198,
+                "rbh": 6786,
+                "sbh": 509,
+                "gas": 67864,
+                "bpr": 10179648,
+                "sbpr": 254491,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "CryptoDeleteAllowance",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 3794963556,
+                "bpt": 6067009,
+                "vpt": 15167523735,
+                "rbh": 4045,
+                "sbh": 303,
+                "gas": 40447,
+                "bpr": 6067009,
+                "sbpr": 151675,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 75899271121,
+                "bpt": 121340190,
+                "vpt": 303350474702,
+                "rbh": 80893,
+                "sbh": 6067,
+                "gas": 808935,
+                "bpr": 121340190,
+                "sbpr": 3033505,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 75899271121,
+                "bpt": 121340190,
+                "vpt": 303350474702,
+                "rbh": 80893,
+                "sbh": 6067,
+                "gas": 808935,
+                "bpr": 121340190,
+                "sbpr": 3033505,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "CryptoApproveAllowance",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 3766772044,
+                "bpt": 6021940,
+                "vpt": 15054849285,
+                "rbh": 4015,
+                "sbh": 301,
+                "gas": 40146,
+                "bpr": 6021940,
+                "sbpr": 150548,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 75335440874,
+                "bpt": 120438794,
+                "vpt": 301096985700,
+                "rbh": 80293,
+                "sbh": 6022,
+                "gas": 802925,
+                "bpr": 120438794,
+                "sbpr": 3010970,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 75335440874,
+                "bpt": 120438794,
+                "vpt": 301096985700,
+                "rbh": 80293,
+                "sbh": 6022,
+                "gas": 802925,
+                "bpr": 120438794,
+                "sbpr": 3010970,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "CryptoAccountAutoRenew",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 59972622,
+                "bpt": 95878,
+                "vpt": 239695625,
+                "rbh": 64,
+                "sbh": 5,
+                "gas": 639,
+                "bpr": 95878,
+                "sbpr": 2397,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 959561945,
+                "bpt": 1534052,
+                "vpt": 3835129999,
+                "rbh": 1023,
+                "sbh": 77,
+                "gas": 10227,
+                "bpr": 1534052,
+                "sbpr": 38351,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 959561945,
+                "bpt": 1534052,
+                "vpt": 3835129999,
+                "rbh": 1023,
+                "sbh": 77,
+                "gas": 10227,
+                "bpr": 1534052,
+                "sbpr": 38351,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "CryptoUpdate",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 16302371,
+                "bpt": 26063,
+                "vpt": 65156516,
+                "rbh": 17,
+                "sbh": 1,
+                "gas": 174,
+                "bpr": 26063,
+                "sbpr": 652,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 326047427,
+                "bpt": 521252,
+                "vpt": 1303130322,
+                "rbh": 348,
+                "sbh": 26,
+                "gas": 3475,
+                "bpr": 521252,
+                "sbpr": 13031,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 326047427,
+                "bpt": 521252,
+                "vpt": 1303130322,
+                "rbh": 348,
+                "sbh": 26,
+                "gas": 3475,
+                "bpr": 521252,
+                "sbpr": 13031,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "CryptoTransfer",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 7574478,
+                "bpt": 12109,
+                "vpt": 30273301,
+                "rbh": 8,
+                "sbh": 1,
+                "gas": 81,
+                "bpr": 12109,
+                "sbpr": 303,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 151489557,
+                "bpt": 242186,
+                "vpt": 605466012,
+                "rbh": 161,
+                "sbh": 12,
+                "gas": 1615,
+                "bpr": 242186,
+                "sbpr": 6055,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 151489557,
+                "bpt": 242186,
+                "vpt": 605466012,
+                "rbh": 161,
+                "sbh": 12,
+                "gas": 1615,
+                "bpr": 242186,
+                "sbpr": 6055,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            },
+            {
+              "subType": "TOKEN_FUNGIBLE_COMMON",
+              "nodedata": {
+                "constant": 7983519,
+                "bpt": 12763,
+                "vpt": 31908136,
+                "rbh": 9,
+                "sbh": 1,
+                "gas": 85,
+                "bpr": 12763,
+                "sbpr": 319,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 159670382,
+                "bpt": 255265,
+                "vpt": 638162730,
+                "rbh": 170,
+                "sbh": 13,
+                "gas": 1702,
+                "bpr": 255265,
+                "sbpr": 6382,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 159670382,
+                "bpt": 255265,
+                "vpt": 638162730,
+                "rbh": 170,
+                "sbh": 13,
+                "gas": 1702,
+                "bpr": 255265,
+                "sbpr": 6382,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            },
+            {
+              "subType": "TOKEN_FUNGIBLE_COMMON_WITH_CUSTOM_FEES",
+              "nodedata": {
+                "constant": 15967037,
+                "bpt": 25527,
+                "vpt": 63816270,
+                "rbh": 17,
+                "sbh": 1,
+                "gas": 170,
+                "bpr": 25527,
+                "sbpr": 638,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 319340747,
+                "bpt": 510530,
+                "vpt": 1276325394,
+                "rbh": 340,
+                "sbh": 26,
+                "gas": 3404,
+                "bpr": 510530,
+                "sbpr": 12763,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 319340747,
+                "bpt": 510530,
+                "vpt": 1276325394,
+                "rbh": 340,
+                "sbh": 26,
+                "gas": 3404,
+                "bpr": 510530,
+                "sbpr": 12763,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            },
+            {
+              "subType": "TOKEN_NON_FUNGIBLE_UNIQUE",
+              "nodedata": {
+                "constant": 22833842,
+                "bpt": 36504,
+                "vpt": 91261178,
+                "rbh": 24,
+                "sbh": 2,
+                "gas": 243,
+                "bpr": 36504,
+                "sbpr": 913,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 456676846,
+                "bpt": 730089,
+                "vpt": 1825223562,
+                "rbh": 487,
+                "sbh": 37,
+                "gas": 4867,
+                "bpr": 730089,
+                "sbpr": 18252,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 456676846,
+                "bpt": 730089,
+                "vpt": 1825223562,
+                "rbh": 487,
+                "sbh": 37,
+                "gas": 4867,
+                "bpr": 730089,
+                "sbpr": 18252,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            },
+            {
+              "subType": "TOKEN_NON_FUNGIBLE_UNIQUE_WITH_CUSTOM_FEES",
+              "nodedata": {
+                "constant": 45667678,
+                "bpt": 73009,
+                "vpt": 182522330,
+                "rbh": 49,
+                "sbh": 4,
+                "gas": 487,
+                "bpr": 73009,
+                "sbpr": 1825,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 913353558,
+                "bpt": 1460179,
+                "vpt": 3650446591,
+                "rbh": 973,
+                "sbh": 73,
+                "gas": 9735,
+                "bpr": 1460179,
+                "sbpr": 36504,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 913353558,
+                "bpt": 1460179,
+                "vpt": 3650446591,
+                "rbh": 973,
+                "sbh": 73,
+                "gas": 9735,
+                "bpr": 1460179,
+                "sbpr": 36504,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "CryptoDelete",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 471427939,
+                "bpt": 753672,
+                "vpt": 1884180005,
+                "rbh": 502,
+                "sbh": 38,
+                "gas": 5024,
+                "bpr": 753672,
+                "sbpr": 18842,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 7542847021,
+                "bpt": 12058752,
+                "vpt": 30146880078,
+                "rbh": 8039,
+                "sbh": 603,
+                "gas": 80392,
+                "bpr": 12058752,
+                "sbpr": 301469,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 7542847021,
+                "bpt": 12058752,
+                "vpt": 30146880078,
+                "rbh": 8039,
+                "sbh": 603,
+                "gas": 80392,
+                "bpr": 12058752,
+                "sbpr": 301469,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "CryptoAddLiveHash",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 5561692202,
+                "bpt": 8891479,
+                "vpt": 22228697914,
+                "rbh": 5928,
+                "sbh": 445,
+                "gas": 59277,
+                "bpr": 8891479,
+                "sbpr": 222287,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 88987075231,
+                "bpt": 142263667,
+                "vpt": 355659166619,
+                "rbh": 94842,
+                "sbh": 7113,
+                "gas": 948424,
+                "bpr": 142263667,
+                "sbpr": 3556592,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 88987075231,
+                "bpt": 142263667,
+                "vpt": 355659166619,
+                "rbh": 94842,
+                "sbh": 7113,
+                "gas": 948424,
+                "bpr": 142263667,
+                "sbpr": 3556592,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "CryptoDeleteLiveHash",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 468546396,
+                "bpt": 749065,
+                "vpt": 1872663195,
+                "rbh": 499,
+                "sbh": 37,
+                "gas": 4994,
+                "bpr": 749065,
+                "sbpr": 18727,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 7496742329,
+                "bpt": 11985044,
+                "vpt": 29962611113,
+                "rbh": 7990,
+                "sbh": 599,
+                "gas": 79900,
+                "bpr": 11985044,
+                "sbpr": 299626,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 7496742329,
+                "bpt": 11985044,
+                "vpt": 29962611113,
+                "rbh": 7990,
+                "sbh": 599,
+                "gas": 79900,
+                "bpr": 11985044,
+                "sbpr": 299626,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "CryptoGetLiveHash",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 58926,
+                "bpt": 94,
+                "vpt": 235514,
+                "rbh": 0,
+                "sbh": 0,
+                "gas": 1,
+                "bpr": 94,
+                "sbpr": 2,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 942822,
+                "bpt": 1507,
+                "vpt": 3768224,
+                "rbh": 1,
+                "sbh": 0,
+                "gas": 10,
+                "bpr": 1507,
+                "sbpr": 38,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 942822,
+                "bpt": 1507,
+                "vpt": 3768224,
+                "rbh": 1,
+                "sbh": 0,
+                "gas": 10,
+                "bpr": 1507,
+                "sbpr": 38,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "CryptoGetAccountRecords",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 22044,
+                "bpt": 35,
+                "vpt": 88105,
+                "rbh": 0,
+                "sbh": 0,
+                "gas": 0,
+                "bpr": 35,
+                "sbpr": 1,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 352708,
+                "bpt": 564,
+                "vpt": 1409688,
+                "rbh": 0,
+                "sbh": 0,
+                "gas": 4,
+                "bpr": 564,
+                "sbpr": 14,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 352708,
+                "bpt": 564,
+                "vpt": 1409688,
+                "rbh": 0,
+                "sbh": 0,
+                "gas": 4,
+                "bpr": 564,
+                "sbpr": 14,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "CryptoGetAccountBalance",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 68774,
+                "bpt": 110,
+                "vpt": 274874,
+                "rbh": 0,
+                "sbh": 0,
+                "gas": 1,
+                "bpr": 110,
+                "sbpr": 3,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 1100389,
+                "bpt": 1759,
+                "vpt": 4397982,
+                "rbh": 1,
+                "sbh": 0,
+                "gas": 12,
+                "bpr": 1759,
+                "sbpr": 44,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 1100389,
+                "bpt": 1759,
+                "vpt": 4397982,
+                "rbh": 1,
+                "sbh": 0,
+                "gas": 12,
+                "bpr": 1759,
+                "sbpr": 44,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "CryptoGetInfo",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 63990,
+                "bpt": 102,
+                "vpt": 255752,
+                "rbh": 0,
+                "sbh": 0,
+                "gas": 1,
+                "bpr": 102,
+                "sbpr": 3,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 1023841,
+                "bpt": 1637,
+                "vpt": 4092038,
+                "rbh": 1,
+                "sbh": 0,
+                "gas": 11,
+                "bpr": 1637,
+                "sbpr": 41,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 1023841,
+                "bpt": 1637,
+                "vpt": 4092038,
+                "rbh": 1,
+                "sbh": 0,
+                "gas": 11,
+                "bpr": 1637,
+                "sbpr": 41,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "CryptoGetStakers",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 15251,
+                "bpt": 24,
+                "vpt": 60953,
+                "rbh": 0,
+                "sbh": 0,
+                "gas": 0,
+                "bpr": 24,
+                "sbpr": 1,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 244011,
+                "bpt": 390,
+                "vpt": 975251,
+                "rbh": 0,
+                "sbh": 0,
+                "gas": 3,
+                "bpr": 390,
+                "sbpr": 10,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 244011,
+                "bpt": 390,
+                "vpt": 975251,
+                "rbh": 0,
+                "sbh": 0,
+                "gas": 3,
+                "bpr": 390,
+                "sbpr": 10,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "ConsensusCreateTopic",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 921577366,
+                "bpt": 1473326,
+                "vpt": 3683315100,
+                "rbh": 982,
+                "sbh": 74,
+                "gas": 9822,
+                "bpr": 1473326,
+                "sbpr": 36833,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 14745237852,
+                "bpt": 23573217,
+                "vpt": 58933041595,
+                "rbh": 15715,
+                "sbh": 1179,
+                "gas": 157155,
+                "bpr": 23573217,
+                "sbpr": 589330,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 14745237852,
+                "bpt": 23573217,
+                "vpt": 58933041595,
+                "rbh": 15715,
+                "sbh": 1179,
+                "gas": 157155,
+                "bpr": 23573217,
+                "sbpr": 589330,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "ConsensusUpdateTopic",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 20193780,
+                "bpt": 32284,
+                "vpt": 80709508,
+                "rbh": 22,
+                "sbh": 2,
+                "gas": 215,
+                "bpr": 32284,
+                "sbpr": 807,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 323100486,
+                "bpt": 516541,
+                "vpt": 1291352134,
+                "rbh": 344,
+                "sbh": 26,
+                "gas": 3444,
+                "bpr": 516541,
+                "sbpr": 12914,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 323100486,
+                "bpt": 516541,
+                "vpt": 1291352134,
+                "rbh": 344,
+                "sbh": 26,
+                "gas": 3444,
+                "bpr": 516541,
+                "sbpr": 12914,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "ConsensusDeleteTopic",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 474345144,
+                "bpt": 758336,
+                "vpt": 1895839348,
+                "rbh": 506,
+                "sbh": 38,
+                "gas": 5056,
+                "bpr": 758336,
+                "sbpr": 18958,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 7589522307,
+                "bpt": 12133372,
+                "vpt": 30333429564,
+                "rbh": 8089,
+                "sbh": 607,
+                "gas": 80889,
+                "bpr": 12133372,
+                "sbpr": 303334,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 7589522307,
+                "bpt": 12133372,
+                "vpt": 30333429564,
+                "rbh": 8089,
+                "sbh": 607,
+                "gas": 80889,
+                "bpr": 12133372,
+                "sbpr": 303334,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "ConsensusSubmitMessage",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 9248442,
+                "bpt": 14785,
+                "vpt": 36963719,
+                "rbh": 10,
+                "sbh": 1,
+                "gas": 99,
+                "bpr": 14785,
+                "sbpr": 370,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 147975076,
+                "bpt": 236568,
+                "vpt": 591419509,
+                "rbh": 158,
+                "sbh": 12,
+                "gas": 1577,
+                "bpr": 236568,
+                "sbpr": 5914,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 147975076,
+                "bpt": 236568,
+                "vpt": 591419509,
+                "rbh": 158,
+                "sbh": 12,
+                "gas": 1577,
+                "bpr": 236568,
+                "sbpr": 5914,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "ConsensusGetTopicInfo",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 64253,
+                "bpt": 103,
+                "vpt": 256803,
+                "rbh": 0,
+                "sbh": 0,
+                "gas": 1,
+                "bpr": 103,
+                "sbpr": 3,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 1028048,
+                "bpt": 1644,
+                "vpt": 4108851,
+                "rbh": 1,
+                "sbh": 0,
+                "gas": 11,
+                "bpr": 1644,
+                "sbpr": 41,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 1028048,
+                "bpt": 1644,
+                "vpt": 4108851,
+                "rbh": 1,
+                "sbh": 0,
+                "gas": 11,
+                "bpr": 1644,
+                "sbpr": 41,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "TokenCreate",
+          "fees": [
+            {
+              "subType": "TOKEN_FUNGIBLE_COMMON_WITH_CUSTOM_FEES",
+              "nodedata": {
+                "constant": 393746195920,
+                "bpt": 17485616,
+                "vpt": 43714039850,
+                "rbh": 11657,
+                "sbh": 874,
+                "gas": 116571,
+                "bpr": 17485616,
+                "sbpr": 437140,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 7874923918408,
+                "bpt": 349712319,
+                "vpt": 874280797002,
+                "rbh": 233142,
+                "sbh": 17486,
+                "gas": 2331415,
+                "bpr": 349712319,
+                "sbpr": 8742808,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 7874923918408,
+                "bpt": 349712319,
+                "vpt": 874280797002,
+                "rbh": 233142,
+                "sbh": 17486,
+                "gas": 2331415,
+                "bpr": 349712319,
+                "sbpr": 8742808,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            },
+            {
+              "subType": "TOKEN_FUNGIBLE_COMMON",
+              "nodedata": {
+                "constant": 197306974233,
+                "bpt": 8762076,
+                "vpt": 21905189240,
+                "rbh": 5841,
+                "sbh": 438,
+                "gas": 58414,
+                "bpr": 8762076,
+                "sbpr": 219052,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 3946139484654,
+                "bpt": 175241514,
+                "vpt": 438103784807,
+                "rbh": 116828,
+                "sbh": 8762,
+                "gas": 1168277,
+                "bpr": 175241514,
+                "sbpr": 4381038,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 3946139484654,
+                "bpt": 175241514,
+                "vpt": 438103784807,
+                "rbh": 116828,
+                "sbh": 8762,
+                "gas": 1168277,
+                "bpr": 175241514,
+                "sbpr": 4381038,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            },
+            {
+              "subType": "TOKEN_NON_FUNGIBLE_UNIQUE",
+              "nodedata": {
+                "constant": 197031853851,
+                "bpt": 8749858,
+                "vpt": 21874645140,
+                "rbh": 5833,
+                "sbh": 437,
+                "gas": 58332,
+                "bpr": 8749858,
+                "sbpr": 218746,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 3940637077020,
+                "bpt": 174997161,
+                "vpt": 437492902800,
+                "rbh": 116665,
+                "sbh": 8750,
+                "gas": 1166648,
+                "bpr": 174997161,
+                "sbpr": 4374929,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 3940637077020,
+                "bpt": 174997161,
+                "vpt": 437492902800,
+                "rbh": 116665,
+                "sbh": 8750,
+                "gas": 1166648,
+                "bpr": 174997161,
+                "sbpr": 4374929,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            },
+            {
+              "subType": "TOKEN_NON_FUNGIBLE_UNIQUE_WITH_CUSTOM_FEES",
+              "nodedata": {
+                "constant": 393198370765,
+                "bpt": 17461288,
+                "vpt": 43653219832,
+                "rbh": 11641,
+                "sbh": 873,
+                "gas": 116409,
+                "bpr": 17461288,
+                "sbpr": 436532,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 7863967415309,
+                "bpt": 349225759,
+                "vpt": 873064396645,
+                "rbh": 232817,
+                "sbh": 17461,
+                "gas": 2328172,
+                "bpr": 349225759,
+                "sbpr": 8730644,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 7863967415309,
+                "bpt": 349225759,
+                "vpt": 873064396645,
+                "rbh": 232817,
+                "sbh": 17461,
+                "gas": 2328172,
+                "bpr": 349225759,
+                "sbpr": 8730644,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "TokenDelete",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 94285588,
+                "bpt": 150734,
+                "vpt": 376836001,
+                "rbh": 100,
+                "sbh": 8,
+                "gas": 1005,
+                "bpr": 150734,
+                "sbpr": 3768,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 1508569404,
+                "bpt": 2411750,
+                "vpt": 6029376016,
+                "rbh": 1608,
+                "sbh": 121,
+                "gas": 16078,
+                "bpr": 2411750,
+                "sbpr": 60294,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 1508569404,
+                "bpt": 2411750,
+                "vpt": 6029376016,
+                "rbh": 1608,
+                "sbh": 121,
+                "gas": 16078,
+                "bpr": 2411750,
+                "sbpr": 60294,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "TokenFeeScheduleUpdate",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 73998596,
+                "bpt": 118302,
+                "vpt": 295753948,
+                "rbh": 79,
+                "sbh": 6,
+                "gas": 789,
+                "bpr": 118302,
+                "sbpr": 2958,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 1479971913,
+                "bpt": 2366032,
+                "vpt": 5915078967,
+                "rbh": 1577,
+                "sbh": 118,
+                "gas": 15774,
+                "bpr": 2366032,
+                "sbpr": 59151,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 1479971913,
+                "bpt": 2366032,
+                "vpt": 5915078967,
+                "rbh": 1577,
+                "sbh": 118,
+                "gas": 15774,
+                "bpr": 2366032,
+                "sbpr": 59151,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "TokenUpdate",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 93900697,
+                "bpt": 150119,
+                "vpt": 375297688,
+                "rbh": 100,
+                "sbh": 8,
+                "gas": 1001,
+                "bpr": 150119,
+                "sbpr": 3753,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 1502411149,
+                "bpt": 2401905,
+                "vpt": 6004763005,
+                "rbh": 1601,
+                "sbh": 120,
+                "gas": 16013,
+                "bpr": 2401905,
+                "sbpr": 60048,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 1502411149,
+                "bpt": 2401905,
+                "vpt": 6004763005,
+                "rbh": 1601,
+                "sbh": 120,
+                "gas": 16013,
+                "bpr": 2401905,
+                "sbpr": 60048,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "TokenMint",
+          "fees": [
+            {
+              "subType": "TOKEN_FUNGIBLE_COMMON",
+              "nodedata": {
+                "constant": 94092119,
+                "bpt": 150425,
+                "vpt": 376062755,
+                "rbh": 100,
+                "sbh": 8,
+                "gas": 1003,
+                "bpr": 150425,
+                "sbpr": 3761,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 1505473906,
+                "bpt": 2406802,
+                "vpt": 6017004081,
+                "rbh": 1605,
+                "sbh": 120,
+                "gas": 16045,
+                "bpr": 2406802,
+                "sbpr": 60170,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 1505473906,
+                "bpt": 2406802,
+                "vpt": 6017004081,
+                "rbh": 1605,
+                "sbh": 120,
+                "gas": 16045,
+                "bpr": 2406802,
+                "sbpr": 60170,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            },
+            {
+              "subType": "TOKEN_NON_FUNGIBLE_UNIQUE",
+              "nodedata": {
+                "constant": 3606440483,
+                "bpt": 5765618,
+                "vpt": 14414043986,
+                "rbh": 3844,
+                "sbh": 288,
+                "gas": 38437,
+                "bpr": 5765618,
+                "sbpr": 144140,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 72128809656,
+                "bpt": 115312352,
+                "vpt": 288280879722,
+                "rbh": 76875,
+                "sbh": 5766,
+                "gas": 768749,
+                "bpr": 115312352,
+                "sbpr": 2882809,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 72128809656,
+                "bpt": 115312352,
+                "vpt": 288280879722,
+                "rbh": 76875,
+                "sbh": 5766,
+                "gas": 768749,
+                "bpr": 115312352,
+                "sbpr": 2882809,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "TokenBurn",
+          "fees": [
+            {
+              "subType": "TOKEN_FUNGIBLE_COMMON",
+              "nodedata": {
+                "constant": 94092119,
+                "bpt": 150425,
+                "vpt": 376062755,
+                "rbh": 100,
+                "sbh": 8,
+                "gas": 1003,
+                "bpr": 150425,
+                "sbpr": 3761,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 1505473906,
+                "bpt": 2406802,
+                "vpt": 6017004081,
+                "rbh": 1605,
+                "sbh": 120,
+                "gas": 16045,
+                "bpr": 2406802,
+                "sbpr": 60170,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 1505473906,
+                "bpt": 2406802,
+                "vpt": 6017004081,
+                "rbh": 1605,
+                "sbh": 120,
+                "gas": 16045,
+                "bpr": 2406802,
+                "sbpr": 60170,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            },
+            {
+              "subType": "TOKEN_NON_FUNGIBLE_UNIQUE",
+              "nodedata": {
+                "constant": 76366243,
+                "bpt": 122087,
+                "vpt": 305216845,
+                "rbh": 81,
+                "sbh": 6,
+                "gas": 814,
+                "bpr": 122087,
+                "sbpr": 3052,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 1527324859,
+                "bpt": 2441735,
+                "vpt": 6104336894,
+                "rbh": 1628,
+                "sbh": 122,
+                "gas": 16278,
+                "bpr": 2441735,
+                "sbpr": 61043,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 1527324859,
+                "bpt": 2441735,
+                "vpt": 6104336894,
+                "rbh": 1628,
+                "sbh": 122,
+                "gas": 16278,
+                "bpr": 2441735,
+                "sbpr": 61043,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "TokenAssociateToAccount",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 4574479485,
+                "bpt": 7313222,
+                "vpt": 18283054670,
+                "rbh": 4875,
+                "sbh": 366,
+                "gas": 48755,
+                "bpr": 7313222,
+                "sbpr": 182831,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 73191671761,
+                "bpt": 117011550,
+                "vpt": 292528874720,
+                "rbh": 78008,
+                "sbh": 5851,
+                "gas": 780077,
+                "bpr": 117011550,
+                "sbpr": 2925289,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 73191671761,
+                "bpt": 117011550,
+                "vpt": 292528874720,
+                "rbh": 78008,
+                "sbh": 5851,
+                "gas": 780077,
+                "bpr": 117011550,
+                "sbpr": 2925289,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "TokenDissociateFromAccount",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 4714279388,
+                "bpt": 7536720,
+                "vpt": 18841800049,
+                "rbh": 5024,
+                "sbh": 377,
+                "gas": 50245,
+                "bpr": 7536720,
+                "sbpr": 188418,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 75428470213,
+                "bpt": 120587520,
+                "vpt": 301468800784,
+                "rbh": 80392,
+                "sbh": 6029,
+                "gas": 803917,
+                "bpr": 120587520,
+                "sbpr": 3014688,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 75428470213,
+                "bpt": 120587520,
+                "vpt": 301468800784,
+                "rbh": 80392,
+                "sbh": 6029,
+                "gas": 803917,
+                "bpr": 120587520,
+                "sbpr": 3014688,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "TokenGrantKycToAccount",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 94285551,
+                "bpt": 150734,
+                "vpt": 376835856,
+                "rbh": 100,
+                "sbh": 8,
+                "gas": 1005,
+                "bpr": 150734,
+                "sbpr": 3768,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 1508568822,
+                "bpt": 2411749,
+                "vpt": 6029373689,
+                "rbh": 1608,
+                "sbh": 121,
+                "gas": 16078,
+                "bpr": 2411749,
+                "sbpr": 60294,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 1508568822,
+                "bpt": 2411749,
+                "vpt": 6029373689,
+                "rbh": 1608,
+                "sbh": 121,
+                "gas": 16078,
+                "bpr": 2411749,
+                "sbpr": 60294,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "TokenRevokeKycFromAccount",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 94285551,
+                "bpt": 150734,
+                "vpt": 376835856,
+                "rbh": 100,
+                "sbh": 8,
+                "gas": 1005,
+                "bpr": 150734,
+                "sbpr": 3768,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 1508568822,
+                "bpt": 2411749,
+                "vpt": 6029373689,
+                "rbh": 1608,
+                "sbh": 121,
+                "gas": 16078,
+                "bpr": 2411749,
+                "sbpr": 60294,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 1508568822,
+                "bpt": 2411749,
+                "vpt": 6029373689,
+                "rbh": 1608,
+                "sbh": 121,
+                "gas": 16078,
+                "bpr": 2411749,
+                "sbpr": 60294,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "TokenFreezeAccount",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 76054309,
+                "bpt": 121588,
+                "vpt": 303970122,
+                "rbh": 81,
+                "sbh": 6,
+                "gas": 811,
+                "bpr": 121588,
+                "sbpr": 3040,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 1521086180,
+                "bpt": 2431761,
+                "vpt": 6079402448,
+                "rbh": 1621,
+                "sbh": 122,
+                "gas": 16212,
+                "bpr": 2431761,
+                "sbpr": 60794,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 1521086180,
+                "bpt": 2431761,
+                "vpt": 6079402448,
+                "rbh": 1621,
+                "sbh": 122,
+                "gas": 16212,
+                "bpr": 2431761,
+                "sbpr": 60794,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "TokenUnfreezeAccount",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 76054309,
+                "bpt": 121588,
+                "vpt": 303970122,
+                "rbh": 81,
+                "sbh": 6,
+                "gas": 811,
+                "bpr": 121588,
+                "sbpr": 3040,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 1521086180,
+                "bpt": 2431761,
+                "vpt": 6079402448,
+                "rbh": 1621,
+                "sbh": 122,
+                "gas": 16212,
+                "bpr": 2431761,
+                "sbpr": 60794,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 1521086180,
+                "bpt": 2431761,
+                "vpt": 6079402448,
+                "rbh": 1621,
+                "sbh": 122,
+                "gas": 16212,
+                "bpr": 2431761,
+                "sbpr": 60794,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "TokenPause",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 76523246,
+                "bpt": 122338,
+                "vpt": 305844348,
+                "rbh": 82,
+                "sbh": 6,
+                "gas": 816,
+                "bpr": 122338,
+                "sbpr": 3058,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 1530464926,
+                "bpt": 2446755,
+                "vpt": 6116886962,
+                "rbh": 1631,
+                "sbh": 122,
+                "gas": 16312,
+                "bpr": 2446755,
+                "sbpr": 61169,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 1530464926,
+                "bpt": 2446755,
+                "vpt": 6116886962,
+                "rbh": 1631,
+                "sbh": 122,
+                "gas": 16312,
+                "bpr": 2446755,
+                "sbpr": 61169,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "TokenUnpause",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 76523246,
+                "bpt": 122338,
+                "vpt": 305844348,
+                "rbh": 82,
+                "sbh": 6,
+                "gas": 816,
+                "bpr": 122338,
+                "sbpr": 3058,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 1530464926,
+                "bpt": 2446755,
+                "vpt": 6116886962,
+                "rbh": 1631,
+                "sbh": 122,
+                "gas": 16312,
+                "bpr": 2446755,
+                "sbpr": 61169,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 1530464926,
+                "bpt": 2446755,
+                "vpt": 6116886962,
+                "rbh": 1631,
+                "sbh": 122,
+                "gas": 16312,
+                "bpr": 2446755,
+                "sbpr": 61169,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "TokenAccountWipe",
+          "fees": [
+            {
+              "subType": "TOKEN_FUNGIBLE_COMMON",
+              "nodedata": {
+                "constant": 94092119,
+                "bpt": 150425,
+                "vpt": 376062755,
+                "rbh": 100,
+                "sbh": 8,
+                "gas": 1003,
+                "bpr": 150425,
+                "sbpr": 3761,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 1505473906,
+                "bpt": 2406802,
+                "vpt": 6017004081,
+                "rbh": 1605,
+                "sbh": 120,
+                "gas": 16045,
+                "bpr": 2406802,
+                "sbpr": 60170,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 1505473906,
+                "bpt": 2406802,
+                "vpt": 6017004081,
+                "rbh": 1605,
+                "sbh": 120,
+                "gas": 16045,
+                "bpr": 2406802,
+                "sbpr": 60170,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            },
+            {
+              "subType": "TOKEN_NON_FUNGIBLE_UNIQUE",
+              "nodedata": {
+                "constant": 76366243,
+                "bpt": 122087,
+                "vpt": 305216845,
+                "rbh": 81,
+                "sbh": 6,
+                "gas": 814,
+                "bpr": 122087,
+                "sbpr": 3052,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 1527324859,
+                "bpt": 2441735,
+                "vpt": 6104336894,
+                "rbh": 1628,
+                "sbh": 122,
+                "gas": 16278,
+                "bpr": 2441735,
+                "sbpr": 61043,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 1527324859,
+                "bpt": 2441735,
+                "vpt": 6104336894,
+                "rbh": 1628,
+                "sbh": 122,
+                "gas": 16278,
+                "bpr": 2441735,
+                "sbpr": 61043,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "TokenGetInfo",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 61717,
+                "bpt": 99,
+                "vpt": 246668,
+                "rbh": 0,
+                "sbh": 0,
+                "gas": 1,
+                "bpr": 99,
+                "sbpr": 2,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 987474,
+                "bpt": 1579,
+                "vpt": 3946688,
+                "rbh": 1,
+                "sbh": 0,
+                "gas": 11,
+                "bpr": 1579,
+                "sbpr": 39,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 987474,
+                "bpt": 1579,
+                "vpt": 3946688,
+                "rbh": 1,
+                "sbh": 0,
+                "gas": 11,
+                "bpr": 1579,
+                "sbpr": 39,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "ScheduleCreate",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 563513000,
+                "bpt": 900888,
+                "vpt": 2252221049,
+                "rbh": 601,
+                "sbh": 45,
+                "gas": 6006,
+                "bpr": 900888,
+                "sbpr": 22522,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 9016208000,
+                "bpt": 14414215,
+                "vpt": 36035536788,
+                "rbh": 9609,
+                "sbh": 721,
+                "gas": 96095,
+                "bpr": 14414215,
+                "sbpr": 360355,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 9016208000,
+                "bpt": 14414215,
+                "vpt": 36035536788,
+                "rbh": 9609,
+                "sbh": 721,
+                "gas": 96095,
+                "bpr": 14414215,
+                "sbpr": 360355,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "TokenGetNftInfo",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 54605,
+                "bpt": 87,
+                "vpt": 218244,
+                "rbh": 0,
+                "sbh": 0,
+                "gas": 1,
+                "bpr": 87,
+                "sbpr": 2,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 0,
+                "bpt": 0,
+                "vpt": 0,
+                "rbh": 0,
+                "sbh": 0,
+                "gas": 0,
+                "bpr": 0,
+                "sbpr": 0,
+                "min": 0,
+                "max": 0
+              },
+              "servicedata": {
+                "constant": 0,
+                "bpt": 0,
+                "vpt": 0,
+                "rbh": 0,
+                "sbh": 0,
+                "gas": 0,
+                "bpr": 0,
+                "sbpr": 0,
+                "min": 0,
+                "max": 0
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "ScheduleSign",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 58040915,
+                "bpt": 92790,
+                "vpt": 231975077,
+                "rbh": 62,
+                "sbh": 5,
+                "gas": 619,
+                "bpr": 92790,
+                "sbpr": 2320,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 928654648,
+                "bpt": 1484640,
+                "vpt": 3711601232,
+                "rbh": 990,
+                "sbh": 74,
+                "gas": 9898,
+                "bpr": 1484640,
+                "sbpr": 37116,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 928654648,
+                "bpt": 1484640,
+                "vpt": 3711601232,
+                "rbh": 990,
+                "sbh": 74,
+                "gas": 9898,
+                "bpr": 1484640,
+                "sbpr": 37116,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "ScheduleDelete",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 95360774,
+                "bpt": 152453,
+                "vpt": 381133253,
+                "rbh": 102,
+                "sbh": 8,
+                "gas": 1016,
+                "bpr": 152453,
+                "sbpr": 3811,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 1525772386,
+                "bpt": 2439253,
+                "vpt": 6098132047,
+                "rbh": 1626,
+                "sbh": 122,
+                "gas": 16262,
+                "bpr": 2439253,
+                "sbpr": 60981,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 1525772386,
+                "bpt": 2439253,
+                "vpt": 6098132047,
+                "rbh": 1626,
+                "sbh": 122,
+                "gas": 16262,
+                "bpr": 2439253,
+                "sbpr": 60981,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "ScheduleGetInfo",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 53393,
+                "bpt": 85,
+                "vpt": 213400,
+                "rbh": 0,
+                "sbh": 0,
+                "gas": 1,
+                "bpr": 85,
+                "sbpr": 2,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 854295,
+                "bpt": 1366,
+                "vpt": 3414402,
+                "rbh": 1,
+                "sbh": 0,
+                "gas": 9,
+                "bpr": 1366,
+                "sbpr": 34,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 854295,
+                "bpt": 1366,
+                "vpt": 3414402,
+                "rbh": 1,
+                "sbh": 0,
+                "gas": 9,
+                "bpr": 1366,
+                "sbpr": 34,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "ContractCreate",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 45218052173,
+                "bpt": 72290115,
+                "vpt": 180725287466,
+                "rbh": 48193,
+                "sbh": 3615,
+                "gas": 852000,
+                "bpr": 72290115,
+                "sbpr": 1807253,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 723488834765,
+                "bpt": 1156641840,
+                "vpt": 2891604599463,
+                "rbh": 771095,
+                "sbh": 57832,
+                "gas": 852000,
+                "bpr": 1156641840,
+                "sbpr": 28916046,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 0,
+                "bpt": 0,
+                "vpt": 0,
+                "rbh": 0,
+                "sbh": 0,
+                "gas": 852000,
+                "bpr": 0,
+                "sbpr": 0,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "ContractUpdate",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 2438037058,
+                "bpt": 3897691,
+                "vpt": 9744226629,
+                "rbh": 2598,
+                "sbh": 195,
+                "gas": 25985,
+                "bpr": 3897691,
+                "sbpr": 97442,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 39008592923,
+                "bpt": 62363050,
+                "vpt": 155907626067,
+                "rbh": 41575,
+                "sbh": 3118,
+                "gas": 415754,
+                "bpr": 62363050,
+                "sbpr": 1559076,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 39008592923,
+                "bpt": 62363050,
+                "vpt": 155907626067,
+                "rbh": 41575,
+                "sbh": 3118,
+                "gas": 415754,
+                "bpr": 62363050,
+                "sbpr": 1559076,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "ContractDelete",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 664083202,
+                "bpt": 1061670,
+                "vpt": 2654175087,
+                "rbh": 708,
+                "sbh": 53,
+                "gas": 7078,
+                "bpr": 1061670,
+                "sbpr": 26542,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 10625331229,
+                "bpt": 16986721,
+                "vpt": 42466801390,
+                "rbh": 11324,
+                "sbh": 849,
+                "gas": 113245,
+                "bpr": 16986721,
+                "sbpr": 424668,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 10625331229,
+                "bpt": 16986721,
+                "vpt": 42466801390,
+                "rbh": 11324,
+                "sbh": 849,
+                "gas": 113245,
+                "bpr": 16986721,
+                "sbpr": 424668,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "ContractCall",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 0,
+                "bpt": 0,
+                "vpt": 0,
+                "rbh": 0,
+                "sbh": 0,
+                "gas": 0,
+                "bpr": 0,
+                "sbpr": 0,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 0,
+                "bpt": 0,
+                "vpt": 0,
+                "rbh": 0,
+                "sbh": 0,
+                "gas": 0,
+                "bpr": 0,
+                "sbpr": 0,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 0,
+                "bpt": 0,
+                "vpt": 0,
+                "rbh": 0,
+                "sbh": 0,
+                "gas": 852000,
+                "bpr": 0,
+                "sbpr": 0,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "EthereumTransaction",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 3336515210,
+                "bpt": 5334088,
+                "vpt": 13335219927,
+                "rbh": 3556,
+                "sbh": 267,
+                "gas": 0,
+                "bpr": 5334088,
+                "sbpr": 133352,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 53384243355,
+                "bpt": 85345408,
+                "vpt": 213363518838,
+                "rbh": 56897,
+                "sbh": 4267,
+                "gas": 0,
+                "bpr": 85345408,
+                "sbpr": 2133635,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 0,
+                "bpt": 0,
+                "vpt": 0,
+                "rbh": 0,
+                "sbh": 0,
+                "gas": 852000,
+                "bpr": 0,
+                "sbpr": 0,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "ContractGetInfo",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 71015,
+                "bpt": 114,
+                "vpt": 283830,
+                "rbh": 0,
+                "sbh": 0,
+                "gas": 1,
+                "bpr": 114,
+                "sbpr": 3,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 1136244,
+                "bpt": 1817,
+                "vpt": 4541284,
+                "rbh": 1,
+                "sbh": 0,
+                "gas": 12,
+                "bpr": 1817,
+                "sbpr": 45,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 1136244,
+                "bpt": 1817,
+                "vpt": 4541284,
+                "rbh": 1,
+                "sbh": 0,
+                "gas": 12,
+                "bpr": 1817,
+                "sbpr": 45,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "ContractCallLocal",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 2610100486,
+                "bpt": 4172769,
+                "vpt": 10431921279,
+                "rbh": 2782,
+                "sbh": 209,
+                "gas": 852000,
+                "bpr": 4172769,
+                "sbpr": 104319,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 41761607776,
+                "bpt": 66764296,
+                "vpt": 166910740461,
+                "rbh": 44510,
+                "sbh": 3338,
+                "gas": 852000,
+                "bpr": 66764296,
+                "sbpr": 1669107,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 41761607776,
+                "bpt": 66764296,
+                "vpt": 166910740461,
+                "rbh": 44510,
+                "sbh": 3338,
+                "gas": 852000,
+                "bpr": 66764296,
+                "sbpr": 1669107,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "ContractGetBytecode",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 226589259813,
+                "bpt": 362248325,
+                "vpt": 905620811793,
+                "rbh": 241499,
+                "sbh": 18112,
+                "gas": 2414989,
+                "bpr": 362248325,
+                "sbpr": 9056208,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 3625428157003,
+                "bpt": 5795973195,
+                "vpt": 14489932988688,
+                "rbh": 3863982,
+                "sbh": 289799,
+                "gas": 38639821,
+                "bpr": 5795973195,
+                "sbpr": 144899330,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 3625428157003,
+                "bpt": 5795973195,
+                "vpt": 14489932988688,
+                "rbh": 3863982,
+                "sbh": 289799,
+                "gas": 38639821,
+                "bpr": 5795973195,
+                "sbpr": 144899330,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "GetBySolidityID",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 69385,
+                "bpt": 111,
+                "vpt": 277313,
+                "rbh": 0,
+                "sbh": 0,
+                "gas": 1,
+                "bpr": 111,
+                "sbpr": 3,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 1110154,
+                "bpt": 1775,
+                "vpt": 4437010,
+                "rbh": 1,
+                "sbh": 0,
+                "gas": 12,
+                "bpr": 1775,
+                "sbpr": 44,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 1110154,
+                "bpt": 1775,
+                "vpt": 4437010,
+                "rbh": 1,
+                "sbh": 0,
+                "gas": 12,
+                "bpr": 1775,
+                "sbpr": 44,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "ContractGetRecords",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 10093,
+                "bpt": 16,
+                "vpt": 40339,
+                "rbh": 0,
+                "sbh": 0,
+                "gas": 0,
+                "bpr": 16,
+                "sbpr": 0,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 161486,
+                "bpt": 258,
+                "vpt": 645421,
+                "rbh": 0,
+                "sbh": 0,
+                "gas": 2,
+                "bpr": 258,
+                "sbpr": 6,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 161486,
+                "bpt": 258,
+                "vpt": 645421,
+                "rbh": 0,
+                "sbh": 0,
+                "gas": 2,
+                "bpr": 258,
+                "sbpr": 6,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "ContractAutoRenew",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 3399972997,
+                "bpt": 5435538,
+                "vpt": 13588844891,
+                "rbh": 3624,
+                "sbh": 272,
+                "gas": 36237,
+                "bpr": 5435538,
+                "sbpr": 135888,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 67999459941,
+                "bpt": 108710759,
+                "vpt": 271776897828,
+                "rbh": 72474,
+                "sbh": 5436,
+                "gas": 724738,
+                "bpr": 108710759,
+                "sbpr": 2717769,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 67999459941,
+                "bpt": 108710759,
+                "vpt": 271776897828,
+                "rbh": 72474,
+                "sbh": 5436,
+                "gas": 724738,
+                "bpr": 108710759,
+                "sbpr": 2717769,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "FileCreate",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 3657315129,
+                "bpt": 5846951,
+                "vpt": 14617377270,
+                "rbh": 3898,
+                "sbh": 292,
+                "gas": 38980,
+                "bpr": 5846951,
+                "sbpr": 146174,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 58517042062,
+                "bpt": 93551215,
+                "vpt": 233878036318,
+                "rbh": 62367,
+                "sbh": 4678,
+                "gas": 623675,
+                "bpr": 93551215,
+                "sbpr": 2338780,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 58517042062,
+                "bpt": 93551215,
+                "vpt": 233878036318,
+                "rbh": 62367,
+                "sbh": 4678,
+                "gas": 623675,
+                "bpr": 93551215,
+                "sbpr": 2338780,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "FileUpdate",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 3663140881,
+                "bpt": 5856265,
+                "vpt": 14640661348,
+                "rbh": 3904,
+                "sbh": 293,
+                "gas": 39042,
+                "bpr": 5856265,
+                "sbpr": 146407,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 58610254089,
+                "bpt": 93700233,
+                "vpt": 234250581567,
+                "rbh": 62467,
+                "sbh": 4685,
+                "gas": 624668,
+                "bpr": 93700233,
+                "sbpr": 2342506,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 58610254089,
+                "bpt": 93700233,
+                "vpt": 234250581567,
+                "rbh": 62467,
+                "sbh": 4685,
+                "gas": 624668,
+                "bpr": 93700233,
+                "sbpr": 2342506,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "FileDelete",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 664083202,
+                "bpt": 1061670,
+                "vpt": 2654175087,
+                "rbh": 708,
+                "sbh": 53,
+                "gas": 7078,
+                "bpr": 1061670,
+                "sbpr": 26542,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 10625331229,
+                "bpt": 16986721,
+                "vpt": 42466801390,
+                "rbh": 11324,
+                "sbh": 849,
+                "gas": 113245,
+                "bpr": 16986721,
+                "sbpr": 424668,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 10625331229,
+                "bpt": 16986721,
+                "vpt": 42466801390,
+                "rbh": 11324,
+                "sbh": 849,
+                "gas": 113245,
+                "bpr": 16986721,
+                "sbpr": 424668,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "FileAppend",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 2981423158,
+                "bpt": 4766402,
+                "vpt": 11916005477,
+                "rbh": 3178,
+                "sbh": 238,
+                "gas": 31776,
+                "bpr": 4766402,
+                "sbpr": 119160,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 59628463168,
+                "bpt": 95328044,
+                "vpt": 238320109546,
+                "rbh": 63552,
+                "sbh": 4766,
+                "gas": 635520,
+                "bpr": 95328044,
+                "sbpr": 2383201,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 59628463168,
+                "bpt": 95328044,
+                "vpt": 238320109546,
+                "rbh": 63552,
+                "sbh": 4766,
+                "gas": 635520,
+                "bpr": 95328044,
+                "sbpr": 2383201,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "FileGetContents",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 69308,
+                "bpt": 111,
+                "vpt": 277006,
+                "rbh": 0,
+                "sbh": 0,
+                "gas": 1,
+                "bpr": 111,
+                "sbpr": 3,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 1108924,
+                "bpt": 1773,
+                "vpt": 4432093,
+                "rbh": 1,
+                "sbh": 0,
+                "gas": 12,
+                "bpr": 1773,
+                "sbpr": 44,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 1108924,
+                "bpt": 1773,
+                "vpt": 4432093,
+                "rbh": 1,
+                "sbh": 0,
+                "gas": 12,
+                "bpr": 1773,
+                "sbpr": 44,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "FileGetInfo",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 71080,
+                "bpt": 114,
+                "vpt": 284088,
+                "rbh": 0,
+                "sbh": 0,
+                "gas": 1,
+                "bpr": 114,
+                "sbpr": 3,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 1137277,
+                "bpt": 1818,
+                "vpt": 4545413,
+                "rbh": 1,
+                "sbh": 0,
+                "gas": 12,
+                "bpr": 1818,
+                "sbpr": 45,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 1137277,
+                "bpt": 1818,
+                "vpt": 4545413,
+                "rbh": 1,
+                "sbh": 0,
+                "gas": 12,
+                "bpr": 1818,
+                "sbpr": 45,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "GetVersionInfo",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 6519421057,
+                "bpt": 10422601,
+                "vpt": 26056501507,
+                "rbh": 6948,
+                "sbh": 521,
+                "gas": 69484,
+                "bpr": 10422601,
+                "sbpr": 260565,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 104310736905,
+                "bpt": 166761610,
+                "vpt": 416904024105,
+                "rbh": 111174,
+                "sbh": 8338,
+                "gas": 1111744,
+                "bpr": 166761610,
+                "sbpr": 4169040,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 104310736905,
+                "bpt": 166761610,
+                "vpt": 416904024105,
+                "rbh": 111174,
+                "sbh": 8338,
+                "gas": 1111744,
+                "bpr": 166761610,
+                "sbpr": 4169040,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "GetByKey",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 1,
+                "bpt": 0,
+                "vpt": 0,
+                "rbh": 0,
+                "sbh": 0,
+                "gas": 0,
+                "bpr": 0,
+                "sbpr": 0,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 1,
+                "bpt": 0,
+                "vpt": 0,
+                "rbh": 0,
+                "sbh": 0,
+                "gas": 0,
+                "bpr": 0,
+                "sbpr": 0,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 1,
+                "bpt": 0,
+                "vpt": 0,
+                "rbh": 0,
+                "sbh": 0,
+                "gas": 0,
+                "bpr": 0,
+                "sbpr": 0,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "TransactionGetReceipt",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 1,
+                "bpt": 0,
+                "vpt": 0,
+                "rbh": 0,
+                "sbh": 0,
+                "gas": 0,
+                "bpr": 0,
+                "sbpr": 0,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 1,
+                "bpt": 0,
+                "vpt": 0,
+                "rbh": 0,
+                "sbh": 0,
+                "gas": 0,
+                "bpr": 0,
+                "sbpr": 0,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 1,
+                "bpt": 0,
+                "vpt": 0,
+                "rbh": 0,
+                "sbh": 0,
+                "gas": 0,
+                "bpr": 0,
+                "sbpr": 0,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "SystemDelete",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 0,
+                "bpt": 0,
+                "vpt": 0,
+                "rbh": 0,
+                "sbh": 0,
+                "gas": 0,
+                "bpr": 0,
+                "sbpr": 0,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 0,
+                "bpt": 0,
+                "vpt": 0,
+                "rbh": 0,
+                "sbh": 0,
+                "gas": 0,
+                "bpr": 0,
+                "sbpr": 0,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 0,
+                "bpt": 0,
+                "vpt": 0,
+                "rbh": 0,
+                "sbh": 0,
+                "gas": 0,
+                "bpr": 0,
+                "sbpr": 0,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "SystemUndelete",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 0,
+                "bpt": 0,
+                "vpt": 0,
+                "rbh": 0,
+                "sbh": 0,
+                "gas": 0,
+                "bpr": 0,
+                "sbpr": 0,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 0,
+                "bpt": 0,
+                "vpt": 0,
+                "rbh": 0,
+                "sbh": 0,
+                "gas": 0,
+                "bpr": 0,
+                "sbpr": 0,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 0,
+                "bpt": 0,
+                "vpt": 0,
+                "rbh": 0,
+                "sbh": 0,
+                "gas": 0,
+                "bpr": 0,
+                "sbpr": 0,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "transactionFeeSchedule": {
+          "hederaFunctionality": "TransactionGetRecord",
+          "fees": [
+            {
+              "subType": "DEFAULT",
+              "nodedata": {
+                "constant": 54605,
+                "bpt": 87,
+                "vpt": 218244,
+                "rbh": 0,
+                "sbh": 0,
+                "gas": 1,
+                "bpr": 87,
+                "sbpr": 2,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "networkdata": {
+                "constant": 873685,
+                "bpt": 1397,
+                "vpt": 3491900,
+                "rbh": 1,
+                "sbh": 0,
+                "gas": 9,
+                "bpr": 1397,
+                "sbpr": 35,
+                "min": 0,
+                "max": 1000000000000000
+              },
+              "servicedata": {
+                "constant": 873685,
+                "bpt": 1397,
+                "vpt": 3491900,
+                "rbh": 1,
+                "sbh": 0,
+                "gas": 9,
+                "bpr": 1397,
+                "sbpr": 35,
+                "min": 0,
+                "max": 1000000000000000
+              }
+            }
+          ]
+        }
+      },
+      {
+        "expiryTime": 1633392000
+      }
+    ]
   }
 ]

--- a/hedera-node/hedera-mono-service/src/main/resources/throttles.json
+++ b/hedera-node/hedera-mono-service/src/main/resources/throttles.json
@@ -1,172 +1,181 @@
 {
   "buckets": [
-	{
-	  "burstPeriod": 0,
-	  "burstPeriodMs": 3000,
-	  "name": "ThroughputLimits",
-	  "throttleGroups": [
-		{
-		  "opsPerSec": 10000,
-		  "milliOpsPerSec": 10000000,
-		  "operations": [
-			"ScheduleCreate",
-			"CryptoCreate",
-			"CryptoTransfer",
-			"CryptoUpdate",
-			"CryptoDelete",
-			"CryptoGetInfo",
-			"CryptoGetAccountRecords",
-			"UtilPrng",
-			"ConsensusCreateTopic",
-			"ConsensusSubmitMessage",
-			"ConsensusUpdateTopic",
-			"ConsensusDeleteTopic",
-			"ConsensusGetTopicInfo",
-			"TokenGetNftInfo",
-			"TokenGetInfo",
-			"ScheduleDelete",
-			"ScheduleGetInfo",
-			"FileGetContents",
-			"FileGetInfo",
-			"ContractUpdate",
-			"ContractDelete",
-			"ContractGetInfo",
-			"ContractGetBytecode",
-			"ContractGetRecords",
-			"ContractCallLocal",
-			"TransactionGetRecord",
-			"GetVersionInfo",
-			"TokenGetAccountNftInfos",
-			"TokenGetNftInfos",
-			"CryptoApproveAllowance",
-			"CryptoDeleteAllowance"
-		  ]
-		},
-		{
-		  "opsPerSec": 13,
-		  "milliOpsPerSec": 13000,
-		  "operations": [
-			"FileCreate",
-			"FileUpdate",
-			"FileAppend",
-			"FileDelete"
-		  ]
-		},
-		{
-		  "opsPerSec": 100,
-		  "milliOpsPerSec": 100000,
-		  "operations": [
-			"ScheduleSign"
-		  ]
-		},
-		{
-		  "opsPerSec": 350,
-		  "operations": [
-			"ContractCall",
-			"ContractCreate",
-                        "EthereumTransaction"
-                   ]
-		},
-		{
-		  "opsPerSec": 3000,
-		  "milliOpsPerSec": 3000000,
-		  "operations": [
-			"TokenCreate",
-			"TokenDelete",
-			"TokenMint",
-			"TokenBurn",
-			"TokenUpdate",
-			"TokenFeeScheduleUpdate",
-			"TokenAssociateToAccount",
-			"TokenAccountWipe",
-			"TokenDissociateFromAccount",
-			"TokenFreezeAccount",
-			"TokenUnfreezeAccount",
-			"TokenGrantKycToAccount",
-			"TokenRevokeKycFromAccount",
-			"TokenPause",
-			"TokenUnpause"
-		  ]
-		}
-	  ]
-	},
-	{
-	  "burstPeriod": 1,
-	  "name": "OffHeapQueryLimits",
-	  "throttleGroups": [
-		{
-		  "opsPerSec": 700,
-		  "operations": [
-			"FileGetContents",
-			"FileGetInfo",
-			"ContractGetInfo",
-			"ContractGetBytecode",
-			"ContractCallLocal"
-		  ]
-		}
-	  ]
-	},
-	{
-	  "burstPeriod": 0,
-	  "burstPeriodMs": 3000,
-	  "name": "PriorityReservations",
-	  "throttleGroups": [
-		{
-		  "opsPerSec": 10,
-		  "milliOpsPerSec": 10000,
-		  "operations": [
-			"FileCreate",
-			"FileUpdate",
-			"FileAppend",
-			"FileDelete"
-		  ]
-		}
-	  ]
-	},
-	{
-	  "burstPeriod": 0,
-	  "burstPeriodMs": 15000,
-	  "name": "CreationLimits",
-	  "throttleGroups": [
-		{
-		  "opsPerSec": 2,
-		  "milliOpsPerSec": 2000,
-		  "operations": [
-			"CryptoCreate"
-		  ]
-		},
-		{
-		  "opsPerSec": 5,
-		  "milliOpsPerSec": 5000,
-		  "operations": [
-			"ConsensusCreateTopic"
-		  ]
-		},
-		{
-		  "opsPerSec": 100,
-		  "milliOpsPerSec": 100000,
-		  "operations": [
-			"TokenCreate",
-			"TokenAssociateToAccount",
-			"ScheduleCreate"
-		  ]
-		}
-	  ]
-	},
-	{
-	  "burstPeriod": 0,
-	  "burstPeriodMs": 1000,
-	  "name": "FreeQueryLimits",
-	  "throttleGroups": [
-		{
-		  "opsPerSec": 1000000,
-		  "milliOpsPerSec": 1000000000,
-		  "operations": [
-			"CryptoGetAccountBalance",
-			"TransactionGetReceipt"
-		  ]
-		}
-	  ]
-	}
+    {
+      "burstPeriod": 0,
+      "burstPeriodMs": 15000,
+      "name": "ThroughputLimits",
+      "throttleGroups": [
+        {
+          "opsPerSec": 0,
+          "milliOpsPerSec": 10500000,
+          "operations": [
+            "ScheduleCreate",
+            "CryptoCreate",
+            "CryptoTransfer",
+            "CryptoUpdate",
+            "CryptoDelete",
+            "CryptoGetInfo",
+            "CryptoGetAccountRecords",
+            "ConsensusCreateTopic",
+            "ConsensusSubmitMessage",
+            "ConsensusUpdateTopic",
+            "ConsensusDeleteTopic",
+            "ConsensusGetTopicInfo",
+            "TokenGetNftInfo",
+            "TokenGetInfo",
+            "ScheduleDelete",
+            "ScheduleGetInfo",
+            "FileGetContents",
+            "FileGetInfo",
+            "ContractUpdate",
+            "ContractDelete",
+            "ContractGetInfo",
+            "ContractGetBytecode",
+            "ContractGetRecords",
+            "ContractCallLocal",
+            "TransactionGetRecord",
+            "GetVersionInfo",
+            "TokenGetAccountNftInfos",
+            "TokenGetNftInfos",
+            "CryptoApproveAllowance",
+            "CryptoDeleteAllowance",
+            "UtilPrng"
+          ]
+        },
+        {
+          "opsPerSec": 0,
+          "milliOpsPerSec": 13000,
+          "operations": [
+            "FileCreate",
+            "FileUpdate",
+            "FileAppend",
+            "FileDelete"
+          ]
+        },
+        {
+          "opsPerSec": 0,
+          "milliOpsPerSec": 100000,
+          "operations": [
+            "ScheduleSign"
+          ]
+        },
+        {
+          "opsPerSec": 0,
+          "milliOpsPerSec": 125000,
+          "operations": [
+            "TokenMint"
+          ]
+        },
+        {
+          "opsPerSec": 0,
+          "milliOpsPerSec": 350000,
+          "operations": [
+            "ContractCall",
+            "ContractCreate",
+            "EthereumTransaction"
+          ]
+        },
+        {
+          "opsPerSec": 0,
+          "milliOpsPerSec": 3000000,
+          "operations": [
+            "TokenCreate",
+            "TokenDelete",
+            "TokenBurn",
+            "TokenUpdate",
+            "TokenFeeScheduleUpdate",
+            "TokenAssociateToAccount",
+            "TokenAccountWipe",
+            "TokenDissociateFromAccount",
+            "TokenFreezeAccount",
+            "TokenUnfreezeAccount",
+            "TokenGrantKycToAccount",
+            "TokenRevokeKycFromAccount",
+            "TokenPause",
+            "TokenUnpause"
+          ]
+        }
+      ]
+    },
+    {
+      "burstPeriod": 0,
+      "burstPeriodMs": 1000,
+      "name": "OffHeapQueryLimits",
+      "throttleGroups": [
+        {
+          "opsPerSec": 0,
+          "milliOpsPerSec": 700000,
+          "operations": [
+            "FileGetContents",
+            "FileGetInfo",
+            "ContractGetInfo",
+            "ContractGetBytecode",
+            "ContractCallLocal"
+          ]
+        }
+      ]
+    },
+    {
+      "burstPeriod": 0,
+      "burstPeriodMs": 3000,
+      "name": "PriorityReservations",
+      "throttleGroups": [
+        {
+          "opsPerSec": 0,
+          "milliOpsPerSec": 10000,
+          "operations": [
+            "FileCreate",
+            "FileUpdate",
+            "FileAppend",
+            "FileDelete"
+          ]
+        }
+      ]
+    },
+    {
+      "burstPeriod": 0,
+      "burstPeriodMs": 15000,
+      "name": "CreationLimits",
+      "throttleGroups": [
+        {
+          "opsPerSec": 0,
+          "milliOpsPerSec": 2000,
+          "operations": [
+            "CryptoCreate"
+          ]
+        },
+        {
+          "opsPerSec": 0,
+          "milliOpsPerSec": 5000,
+          "operations": [
+            "ConsensusCreateTopic"
+          ]
+        },
+        {
+          "opsPerSec": 0,
+          "milliOpsPerSec": 100000,
+          "operations": [
+            "TokenCreate",
+            "TokenAssociateToAccount",
+            "ScheduleCreate"
+          ]
+        }
+      ]
+    },
+    {
+      "burstPeriod": 0,
+      "burstPeriodMs": 1000,
+      "name": "FreeQueryLimits",
+      "throttleGroups": [
+        {
+          "opsPerSec": 0,
+          "milliOpsPerSec": 1000000000,
+          "operations": [
+            "CryptoGetAccountBalance",
+            "TransactionGetReceipt"
+          ]
+        }
+      ]
+    }
   ]
 }


### PR DESCRIPTION
**Description**:
 - The _throttles.json_ and _feeSchedules.json_ resources [here](https://github.com/hashgraph/hedera-services/tree/develop/hedera-node/hedera-mono-service/src/main/resources) and [here](https://github.com/hashgraph/hedera-services/tree/develop/hedera-node/configuration/mainnet/upgrade) don't reflect the current contents of system files `0.0.111` and `0.0.123` on mainnet. 
 - This PR updates these resources from mainnet system files to avoid confusion.