### PR TITLE
06667 colorize pcli logs

### DIFF
--- a/platform-sdk/swirlds-cli/color-logs.py
+++ b/platform-sdk/swirlds-cli/color-logs.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+
+#
+# Copyright 2016-2022 Hedera Hashgraph, LLC
+#
+# This software is the confidential and proprietary information of
+# Hedera Hashgraph, LLC. ("Confidential Information"). You shall not
+# disclose such Confidential Information and shall use it only in
+# accordance with the terms of the license agreement you entered into
+# with Hedera Hashgraph.
+#
+# HEDERA HASHGRAPH MAKES NO REPRESENTATIONS OR WARRANTIES ABOUT THE SUITABILITY OF
+# THE SOFTWARE, EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+# TO THE IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+# PARTICULAR PURPOSE, OR NON-INFRINGEMENT. HEDERA HASHGRAPH SHALL NOT BE LIABLE FOR
+# ANY DAMAGES SUFFERED BY LICENSEE AS A RESULT OF USING, MODIFYING OR
+# DISTRIBUTING THIS SOFTWARE OR ITS DERIVATIVES.
+#
+
+# A log piped into this script will be printed to the console with extra colors.
+
+from sys import stdin
+import re
+
+# The format of the lines colorized by this script is as follows. Any lines not conforming to this format
+# are ignored and forwarded to the standard out without any added colorization.
+#
+# 2023-05-18 09:03:03.618 80       INFO  PLATFORM_STATUS  <main> SwirldsPlatform: Platform status changed to...
+#         |               |          |           |           |           |                        |
+#      timestamp          |          |        marker         |           |                  arbitrary string
+#                     log number     |                  thread name      |
+#                                    |                                class name
+#                                 log level
+
+whitespace_regex = '\s+'
+captured_whitespace_regex = '(\s+)'
+timestamp_regex = '(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d+)'
+log_number_regex = '(\d+)'
+log_level_regex = '(TRACE|DEBUG|INFO|WARN|ERROR|FATAL)'
+marker_regex = '([A-Za-z0-9_]+)'
+thread_name_regex = '(<<?[^>]+>>?)'
+class_thread_name_regex = '([A-Za-z0-9_]+)'
+remainder_of_line_regex = '(.*)'
+
+full_regex = timestamp_regex + whitespace_regex + \
+             log_number_regex + captured_whitespace_regex + \
+             log_level_regex + captured_whitespace_regex + \
+             marker_regex + captured_whitespace_regex + \
+             thread_name_regex + whitespace_regex + \
+             class_thread_name_regex + remainder_of_line_regex
+
+RED = '\033[91m'
+TEAL = '\033[96m'
+YELLOW = '\033[93m'
+GREEN = '\033[92m'
+BRIGHT_BLUE = '\033[94m'
+GRAY = '\033[90m'
+PURPLE = '\033[95m'
+WHITE = '\033[37m'
+BRIGHT_WHITE = '\033[97m'
+END = '\033[0m'
+
+def format_timestamp(timestamp):
+  return GRAY + timestamp + END
+
+def format_log_number(log_number):
+  return WHITE + log_number + END
+
+def format_log_level(log_level):
+    if log_level in ('TRACE', 'DEBUG', 'INFO'):
+      return GREEN + log_level + END
+    elif log_level == 'WARN':
+      return YELLOW + log_level + END
+    else:
+      return RED + log_level + END
+
+def format_marker(marker):
+  return BRIGHT_BLUE + marker + END
+
+def format_thread_name(thread_name):
+  return BRIGHT_WHITE + thread_name + END
+
+def format_class_name(class_name):
+  return TEAL + class_name + END
+
+def format(line):
+  match = regex.match(line)
+  if match is None:
+    return line
+
+  index = 1
+
+  timestamp = match.group(index)
+  index += 1
+
+  log_number = match.group(index)
+  index += 1
+
+  log_number_whitespace = match.group(index)
+  index += 1
+
+  log_level = match.group(index)
+  index += 1
+
+  log_level_whitespace = match.group(index)
+  index += 1
+
+  marker = match.group(index)
+  index += 1
+
+  marker_whitespace = match.group(index)
+  index += 1
+
+  thread_name = match.group(index)
+  index += 1
+
+  class_name = match.group(index)
+  index += 1
+
+  remainder = match.group(index)
+  index += 1
+
+#   print("   " + str(match))
+#   print("   timestamp: " + str(timestamp))
+#   print("   log number: " + str(log_number))
+#   print("   log level: " + str(log_level))
+#   print("   marker: " + str(marker))
+#   print("   thread name: " + str(thread_name))
+#   print("   class name: " + str(class_name))
+#   print("   remainder: " + str(remainder))
+
+  return format_timestamp(timestamp) + ' ' + \
+          format_log_number(log_number) + log_number_whitespace + \
+          format_log_level(log_level) + log_level_whitespace + \
+          format_marker(marker) + marker_whitespace + \
+          format_thread_name(thread_name) + ' ' + \
+          format_class_name(class_name) + \
+          remainder + "\n"
+
+regex = re.compile(full_regex)
+
+for line in stdin:
+  print(format(line), end='')
+

--- a/platform-sdk/swirlds-cli/color-logs.py
+++ b/platform-sdk/swirlds-cli/color-logs.py
@@ -49,6 +49,8 @@ full_regex = timestamp_regex + whitespace_regex + \
              thread_name_regex + whitespace_regex + \
              class_thread_name_regex + remainder_of_line_regex
 
+regex = re.compile(full_regex)
+
 RED = '\033[91m'
 TEAL = '\033[96m'
 YELLOW = '\033[93m'
@@ -120,15 +122,6 @@ def format(line):
   remainder = match.group(index)
   index += 1
 
-#   print("   " + str(match))
-#   print("   timestamp: " + str(timestamp))
-#   print("   log number: " + str(log_number))
-#   print("   log level: " + str(log_level))
-#   print("   marker: " + str(marker))
-#   print("   thread name: " + str(thread_name))
-#   print("   class name: " + str(class_name))
-#   print("   remainder: " + str(remainder))
-
   return format_timestamp(timestamp) + ' ' + \
           format_log_number(log_number) + log_number_whitespace + \
           format_log_level(log_level) + log_level_whitespace + \
@@ -136,8 +129,6 @@ def format(line):
           format_thread_name(thread_name) + ' ' + \
           format_class_name(class_name) + \
           remainder + "\n"
-
-regex = re.compile(full_regex)
 
 for line in stdin:
   print(format(line), end='')

--- a/platform-sdk/swirlds-cli/pcli.sh
+++ b/platform-sdk/swirlds-cli/pcli.sh
@@ -140,10 +140,12 @@ if [[ "$LOG4J_SET" = false ]]; then
   fi
 fi
 
+COLOR_LOGS_PATH="${SCRIPT_PATH}/color-logs.py"
+
 if [[ "$JVM_CLASSPATH" = '' ]]; then
   echo 'ERROR: the JVM classpath is empty!'
   echo 'Try adding jar or directories containing jarfiles to the classpath via the "--load /path/to/my/jars" argument.'
   exit 1
 fi
 
-java "${JVM_ARGS[@]}" -cp "${JVM_CLASSPATH}" $MAIN_CLASS_NAME "${PROGRAM_ARGS[@]}"
+java "${JVM_ARGS[@]}" -cp "${JVM_CLASSPATH}" $MAIN_CLASS_NAME "${PROGRAM_ARGS[@]}" | $COLOR_LOGS_PATH

--- a/platform-sdk/swirlds-cli/pcli.sh
+++ b/platform-sdk/swirlds-cli/pcli.sh
@@ -65,6 +65,10 @@ SCRIPT_PATH="$( cd -- "$(dirname "$0")" >/dev/null 2>&1 || exit ; pwd -P )"
 # The entrypoint into the platform CLI (i.e. where the main() method is)
 MAIN_CLASS_NAME='com.swirlds.cli.PlatformCli'
 
+COLOR=true
+# If python is not installed then we can't colorize the output.
+python3 --version >/dev/null 2>&1 || COLOR=false
+
 # Iterate over arguments and strip out the classpath arguments and JVM arguments.
 # This needs to be handled by this bash script and not by the java program,
 # since we need to pass this data directly to the JVM.
@@ -115,6 +119,9 @@ for ((CURRENT_INDEX=1; CURRENT_INDEX<=$#; CURRENT_INDEX++)); do
     if [[ "$ARG" = '--log4j' ]]; then
         # If the user has specified a log4j path then we don't want to attempt to override it with the default.
         LOG4J_SET=true
+    elif [[ "$ARG" = '--no-color' ]]; then
+        # A boring person doesn't want log coloration.
+        COLOR=false
     fi;
 
     PROGRAM_ARGS+=("${ARG}")
@@ -148,4 +155,8 @@ if [[ "$JVM_CLASSPATH" = '' ]]; then
   exit 1
 fi
 
-java "${JVM_ARGS[@]}" -cp "${JVM_CLASSPATH}" $MAIN_CLASS_NAME "${PROGRAM_ARGS[@]}" | $COLOR_LOGS_PATH
+if [[ "$COLOR" = true ]]; then
+  java "${JVM_ARGS[@]}" -cp "${JVM_CLASSPATH}" $MAIN_CLASS_NAME "${PROGRAM_ARGS[@]}" | $COLOR_LOGS_PATH
+else
+  java "${JVM_ARGS[@]}" -cp "${JVM_CLASSPATH}" $MAIN_CLASS_NAME "${PROGRAM_ARGS[@]}"
+fi


### PR DESCRIPTION
Closes #6667 

In this PR, PCLI colorizes log output sent to the console. It elegantly handles situations where python is not installed, and will not add color to the output if the `--no-color` flag is present.

![Screenshot 2023-05-18 at 11 44 55 AM](https://github.com/hashgraph/hedera-services/assets/56973212/856551a9-8a89-4d50-864f-a95913394263)
