### PR TITLE
06716 MAX_FULL_REHASHING_BUFFER_TIMEOUT is increased to 60 seconds.

### DIFF
--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/merkle/VirtualRootNode.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/merkle/VirtualRootNode.java
@@ -86,6 +86,7 @@ import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Stream;
@@ -163,10 +164,10 @@ public final class VirtualRootNode<K extends VirtualKey, V extends VirtualValue>
     private static final int MAX_RECONNECT_HASHING_BUFFER_TIMEOUT = 60;
 
     /**
-     * The number of seconds to wait for the hashing buffer during full leaf rehash
-     * (see {@link VirtualRootNode#fullLeafRehash()}) before we cancel the rehashing with an exception.
+     * The number of seconds to wait for the full leaf rehash process to finish
+     * (see {@link VirtualRootNode#fullLeafRehash()}) before we fail with an exception.
      */
-    private static final int MAX_FULL_REHASHING_BUFFER_TIMEOUT = 60;
+    private static final int MAX_FULL_REHASHING_TIMEOUT = 21600; // 6 hours
 
     /**
      * Placeholder (since this is such a hotspot) to hold the results from {@link VirtualMapSettingsFactory#get()}
@@ -477,41 +478,70 @@ public final class VirtualRootNode<K extends VirtualKey, V extends VirtualValue>
                 .build()
                 .start();
 
-        for (long i = firstLeafPath; i <= lastLeafPath; i++) {
-
-            try {
-                VirtualLeafRecord<K, V> leafRecord = dataSource.loadLeafRecord(i);
-                if (leafRecord != null) {
-                    try {
-                        final boolean success =
-                                rehashIterator.supply(leafRecord, MAX_FULL_REHASHING_BUFFER_TIMEOUT, SECONDS);
-                        if (!success) {
-                            throw new MerkleSynchronizationException(
-                                    "Timed out waiting to supply a new leaf to the hashing iterator buffer");
+        // This background thread will be responsible for feeding the iterator with data.
+        new ThreadConfiguration(getStaticThreadManager())
+                .setComponent("virtualmap")
+                .setThreadName("leafFeeder")
+                .setRunnable(() -> {
+                    long onePercent = (lastLeafPath - firstLeafPath) / 100 + 1;
+                    for (long i = firstLeafPath; i <= lastLeafPath; i++) {
+                        try {
+                            VirtualLeafRecord<K, V> leafRecord = dataSource.loadLeafRecord(i);
+                            if (leafRecord != null) {
+                                try {
+                                    final boolean success =
+                                            rehashIterator.supply(leafRecord, Integer.MAX_VALUE, SECONDS);
+                                    if (!success) {
+                                        throw new MerkleSynchronizationException(
+                                                "Timed out waiting to supply a new leaf to the hashing iterator buffer");
+                                    }
+                                } catch (final MerkleSynchronizationException e) {
+                                    throw e;
+                                } catch (final InterruptedException e) {
+                                    Thread.currentThread().interrupt();
+                                    throw new MerkleSynchronizationException(
+                                            "Interrupted while waiting to supply a new leaf to the hashing iterator buffer",
+                                            e);
+                                } catch (final Exception e) {
+                                    throw new MerkleSynchronizationException(
+                                            "Failed to handle a leaf during full rehashing", e);
+                                }
+                            }
+                        } catch (IOException e) {
+                            throw new UncheckedIOException(e);
                         }
-                    } catch (final MerkleSynchronizationException e) {
-                        throw e;
-                    } catch (final InterruptedException e) {
-                        Thread.currentThread().interrupt();
-                        throw new MerkleSynchronizationException(
-                                "Interrupted while waiting to supply a new leaf to the hashing iterator buffer", e);
-                    } catch (final Exception e) {
-                        throw new MerkleSynchronizationException("Failed to handle a leaf during full rehashing", e);
+                        // we don't care about tracking progress on small maps.
+                        if (onePercent > 10 && i % onePercent == 0) {
+                            logger.info(
+                                    STARTUP.getMarker(),
+                                    "Full rehash progress for the VirtualMap at {}: {}%",
+                                    getRoute(),
+                                    (i - firstLeafPath) / onePercent + 1);
+                        }
                     }
-                }
-            } catch (IOException e) {
-                throw new UncheckedIOException(e);
-            }
-        }
-        rehashIterator.close();
+                    rehashIterator.close();
+                })
+                .setExceptionHandler((thread, exception) -> {
+                    // Shut down the iterator.
+                    rehashIterator.close();
+                    final var message = "VirtualMap@" + getRoute() + " failed to do full rehash";
+                    logger.error(EXCEPTION.getMarker(), message, exception);
+                    fullRehashFuture.completeExceptionally(new MerkleSynchronizationException(message, exception));
+                })
+                .build()
+                .start();
+
         try {
-            super.setHash(fullRehashFuture.get());
+            super.setHash(fullRehashFuture.get(MAX_FULL_REHASHING_TIMEOUT, SECONDS));
         } catch (ExecutionException e) {
             final var message = "VirtualMap@" + getRoute() + " failed to get hash during full rehashing";
             throw new MerkleSynchronizationException(message, e);
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             final var message = "VirtualMap@" + getRoute() + " interrupted while full rehashing";
+            throw new MerkleSynchronizationException(message, e);
+        } catch (TimeoutException e) {
+            final var message = "VirtualMap@" + getRoute() + "wasn't able to finish full rehashing in time";
             throw new MerkleSynchronizationException(message, e);
         }
     }

--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/merkle/VirtualRootNode.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/merkle/VirtualRootNode.java
@@ -166,7 +166,7 @@ public final class VirtualRootNode<K extends VirtualKey, V extends VirtualValue>
      * The number of seconds to wait for the hashing buffer during full leaf rehash
      * (see {@link VirtualRootNode#fullLeafRehash()}) before we cancel the rehashing with an exception.
      */
-    private static final int MAX_FULL_REHASHING_BUFFER_TIMEOUT = 10;
+    private static final int MAX_FULL_REHASHING_BUFFER_TIMEOUT = 60;
 
     /**
      * Placeholder (since this is such a hotspot) to hold the results from {@link VirtualMapSettingsFactory#get()}

--- a/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/VirtualMapHashingTest.java
+++ b/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/VirtualMapHashingTest.java
@@ -345,29 +345,26 @@ class VirtualMapHashingTest {
         assertEquals(numInternals, deletedInternals, "The number of deleted internals doesn't match");
     }
 
-    @Test
-    void fullLeavesRehash() {
+    @ParameterizedTest
+    @ValueSource(ints = {1001, 3333, 7777})
+    void fullLeavesRehash(int nEntries) {
         final VirtualMap<TestKey, TestValue> map = createMap();
 
-        // add 100 elements
-        IntStream.range(1, 101).forEach(index -> {
-            map.put(new TestKey(index), new TestValue(nextInt()));
-        });
+        // add n elements
+        IntStream.range(1, nEntries).forEach(index -> map.put(new TestKey(index), new TestValue(nextInt())));
 
         VirtualRootNode<TestKey, TestValue> root = map.getRoot();
         root.enableFlush();
         // make sure that the elements have no hashes
-        IntStream.range(1, 101).forEach(index -> {
-            assertNull(root.getRecords().findHash(index));
-        });
+        IntStream.range(1, nEntries)
+                .forEach(index -> assertNull(root.getRecords().findHash(index)));
 
         // prepare the root for h full leaf rehash
         doFullRehash(root);
 
         // make sure that the elements have hashes
-        IntStream.range(1, 101).forEach(index -> {
-            assertNotNull(root.getRecords().findHash(index));
-        });
+        IntStream.range(1, nEntries)
+                .forEach(index -> assertNotNull(root.getRecords().findHash(index)));
 
         // should not throw any exceptions
         map.fullLeafRehash();

--- a/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/internal/merkle/VirtualRootNodeTest.java
+++ b/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/internal/merkle/VirtualRootNodeTest.java
@@ -454,7 +454,7 @@ class VirtualRootNodeTest extends VirtualTestBase {
         final VirtualRootNode<TestKey, TestValue> root = prepareRootForFullRehash();
         ((InMemoryDataSource) root.getDataSource()).setFailureOnLeafRecordLookup(true);
 
-        assertThrows(UncheckedIOException.class, () -> root.fullLeafRehash());
+        assertThrows(MerkleSynchronizationException.class, () -> root.fullLeafRehash());
     }
 
     @Test


### PR DESCRIPTION
**Description**:
Current MAX_FULL_REHASHING_BUFFER_TIMEOUT equals to 10 seconds. Performance testing demonstrated that it's not enough. Increase MAX_FULL_REHASHING_BUFFER_TIMEOUT to 60 seconds. I chose 60 seconds because we have a similar hashing mechanism for the reconnect. It has the same buffer size (10,000,000) and timeout of 60 seconds. My reasoning is that if it's enough for the hashing during reconnect, it should be enough for rehashing of 10m leaves as well.

**Update:** Oleg suggested following improvements:
- instead of having a timeout on iterator, let's fail the whole rehashing if it can't make it on time. The timeout is set to 6 hours.
- to rehash a prod-sized virtual map it may take up to 3-4 hours. It necessary to see if it's making any progress. I added progress-tracking logs/


**Related issue(s)**:

Fixes #6716 , #5825 

**Notes for reviewer**:

Logs from perf test

```
2023-05-22 17:51:13.291 4068     INFO  STARTUP          <main> VirtualRootNode: Doing full rehash for the path range: 208748393 - 417496786  in the VirtualMap at [0 -> 11 -> 1]
2023-05-22 17:52:14.068 4562     ERROR EXCEPTION        <main> SwirldsPlatform: Saved state not loaded:
com.swirlds.common.merkle.synchronization.utility.MerkleSynchronizationException: Timed out waiting to supply a new leaf to the hashing iterator buffer
	at com.swirlds.virtualmap.internal.merkle.VirtualRootNode.fullLeafRehash(VirtualRootNode.java:489) ~[swirlds-virtualmap-0.39.0-adhoc.xa92eb106.jar:?]
	at com.swirlds.virtualmap.VirtualMap.fullLeafRehash(VirtualMap.java:231) ~[swirlds-virtualmap-0.39.0-adhoc.xa92eb106.jar:?]
	at com.hedera.node.app.service.mono.ServicesState.internalInit(ServicesState.java:410) ~[hedera-mono-service-0.39.0-06625-perfnet-testing.xb6b583f.jar:?]
	at com.hedera.node.app.service.mono.ServicesState.deserializedInit(ServicesState.java:312) ~[hedera-mono-service-0.39.0-06625-perfnet-testing.xb6b583f.jar:?]
	at com.hedera.node.app.service.mono.ServicesState.init(ServicesState.java:252) ~[hedera-mono-service-0.39.0-06625-perfnet-testing.xb6b583f.jar:?]
	at com.swirlds.platform.SwirldsPlatform.loadSavedState(SwirldsPlatform.java:973) ~[swirlds-platform-core-0.39.0-adhoc.xa92eb106.jar:?]
	at com.swirlds.platform.SwirldsPlatform.initializeLoadedStateFromSignedState(SwirldsPlatform.java:934) ~[swirlds-platform-core-0.39.0-adhoc.xa92eb106.jar:?]
	at com.swirlds.platform.SwirldsPlatform.<init>(SwirldsPlatform.java:613) ~[swirlds-platform-core-0.39.0-adhoc.xa92eb106.jar:?]
	at com.swirlds.platform.Browser.createLocalPlatforms(Browser.java:689) ~[swirlds-platform-core-0.39.0-adhoc.xa92eb106.jar:?]
	at com.swirlds.platform.Browser.startPlatforms(Browser.java:829) ~[swirlds-platform-core-0.39.0-adhoc.xa92eb106.jar:?]
	at com.swirlds.platform.Browser.<init>(Browser.java:311) ~[swirlds-platform-core-0.39.0-adhoc.xa92eb106.jar:?]
	at com.swirlds.platform.Browser.launch(Browser.java:541) ~[swirlds-platform-core-0.39.0-adhoc.xa92eb106.jar:?]
	at com.swirlds.platform.Browser.parseCommandLineArgsAndLaunch(Browser.java:497) ~[swirlds-platform-core-0.39.0-adhoc.xa92eb106.jar:?]
	at com.swirlds.platform.Browser.main(Browser.java:853) ~[swirlds-platform-core-0.39.0-adhoc.xa92eb106.jar:?]
```

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
