### PR TITLE
Consolidate all records in single `FCQueue`

### DIFF
--- a/hedera-node/data/config/bootstrap.properties
+++ b/hedera-node/data/config/bootstrap.properties
@@ -11,3 +11,6 @@ tokens.storeRelsOnDisk=false
 tokens.nfts.useVirtualMerkle=false
 cache.cryptoTransfer.warmThreads=30
 records.useConsolidatedFcq=true
+accounts.storeOnDisk=true
+tokens.storeRelsOnDisk=true
+tokens.nfts.useVirtualMerkle=true

--- a/hedera-node/data/config/bootstrap.properties
+++ b/hedera-node/data/config/bootstrap.properties
@@ -10,3 +10,4 @@ accounts.storeOnDisk=false
 tokens.storeRelsOnDisk=false
 tokens.nfts.useVirtualMerkle=false
 cache.cryptoTransfer.warmThreads=30
+records.useConsolidatedFcq=true

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/merkle/MerkleHederaState.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/merkle/MerkleHederaState.java
@@ -736,12 +736,10 @@ public class MerkleHederaState extends PartialNaryMerkleInternal implements Merk
             @Override
             @SuppressWarnings("unchecked")
             public AccountStorageAdapter accounts() {
-                return AccountStorageAdapter.fromOnDisk(
-                        mapLikePayerRecords(),
-                        VirtualMapLikeAdapter.unwrapping(
-                                (StateMetadata<EntityNumVirtualKey, OnDiskAccount>)
-                                        services.get(TokenService.NAME).get("ACCOUNTS"),
-                                getChild(findNodeIndex(TokenService.NAME, "ACCOUNTS"))));
+                return AccountStorageAdapter.fromOnDisk(VirtualMapLikeAdapter.unwrapping(
+                        (StateMetadata<EntityNumVirtualKey, OnDiskAccount>)
+                                services.get(TokenService.NAME).get("ACCOUNTS"),
+                        getChild(findNodeIndex(TokenService.NAME, "ACCOUNTS"))));
             }
 
             @SuppressWarnings("unchecked")

--- a/hedera-node/hedera-app/src/test/resources/bootstrap.properties
+++ b/hedera-node/hedera-app/src/test/resources/bootstrap.properties
@@ -131,6 +131,7 @@ ledger.records.maxQueryableByAccount=180
 ledger.schedule.txExpiryTimeSecs=1800
 rates.intradayChangeLimitPercent=25
 rates.midnightCheckInterval=1
+records.useConsolidatedFcq=false
 scheduling.whitelist=ConsensusSubmitMessage,CryptoTransfer,TokenMint,TokenBurn,CryptoApproveAllowance
 scheduling.longTermEnabled=false
 scheduling.maxNumber=10_000_000

--- a/hedera-node/hedera-mono-service/src/jmh/java/com/hedera/node/app/service/mono/mocks/MockRecordsHistorian.java
+++ b/hedera-node/hedera-mono-service/src/jmh/java/com/hedera/node/app/service/mono/mocks/MockRecordsHistorian.java
@@ -105,11 +105,6 @@ public class MockRecordsHistorian implements RecordsHistorian {
     }
 
     @Override
-    public void noteNewExpirationEvents() {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
     public Instant nextFollowingChildConsensusTime() {
         throw new UnsupportedOperationException();
     }

--- a/hedera-node/hedera-mono-service/src/jmh/java/com/hedera/node/app/service/mono/mocks/MockTransactionContext.java
+++ b/hedera-node/hedera-mono-service/src/jmh/java/com/hedera/node/app/service/mono/mocks/MockTransactionContext.java
@@ -21,7 +21,6 @@ import com.hedera.node.app.hapi.utils.ethereum.EthTxData;
 import com.hedera.node.app.service.mono.context.TransactionContext;
 import com.hedera.node.app.service.mono.legacy.core.jproto.JKey;
 import com.hedera.node.app.service.mono.setup.Constructables;
-import com.hedera.node.app.service.mono.state.expiry.ExpiringEntity;
 import com.hedera.node.app.service.mono.state.submerkle.EntityId;
 import com.hedera.node.app.service.mono.state.submerkle.EvmFnResult;
 import com.hedera.node.app.service.mono.state.submerkle.ExpirableTxnRecord.Builder;
@@ -38,7 +37,6 @@ import com.hederahashgraph.api.proto.java.TopicID;
 import com.hederahashgraph.api.proto.java.TransactionID;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import java.time.Instant;
-import java.util.Collection;
 import java.util.List;
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -195,16 +193,6 @@ public class MockTransactionContext implements TransactionContext {
 
     @Override
     public TxnAccessor triggeredTxn() {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public void addExpiringEntities(final Collection<ExpiringEntity> expiringEntities) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public List<ExpiringEntity> expiringEntities() {
         throw new UnsupportedOperationException();
     }
 

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ServicesState.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ServicesState.java
@@ -46,8 +46,8 @@ import com.hedera.node.app.service.mono.state.merkle.MerkleTokenRelStatus;
 import com.hedera.node.app.service.mono.state.merkle.MerkleTopic;
 import com.hedera.node.app.service.mono.state.merkle.MerkleUniqueToken;
 import com.hedera.node.app.service.mono.state.migration.AccountStorageAdapter;
-import com.hedera.node.app.service.mono.state.migration.RecordConsolidation;
 import com.hedera.node.app.service.mono.state.migration.MapMigrationToDisk;
+import com.hedera.node.app.service.mono.state.migration.RecordConsolidation;
 import com.hedera.node.app.service.mono.state.migration.RecordsStorageAdapter;
 import com.hedera.node.app.service.mono.state.migration.StakingInfoMapBuilder;
 import com.hedera.node.app.service.mono.state.migration.StateChildIndices;
@@ -106,7 +106,6 @@ import com.swirlds.virtualmap.VirtualValue;
 import com.swirlds.virtualmap.internal.merkle.VirtualRootNode;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
-
 import java.time.Instant;
 import java.util.HashMap;
 import java.util.List;
@@ -116,7 +115,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import java.util.function.Supplier;
-
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -532,10 +530,10 @@ public class ServicesState extends PartialNaryMerkleInternal
         final var accountsStorage = getChild(StateChildIndices.ACCOUNTS);
         return (accountsStorage instanceof VirtualMap)
                 ? AccountStorageAdapter.fromOnDisk(
-                MerkleMapLike.from(getChild(StateChildIndices.PAYER_RECORDS_OR_CONSOLIDATED_FCQ)),
-                VirtualMapLike.from((VirtualMap<EntityNumVirtualKey, OnDiskAccount>) accountsStorage))
+                        MerkleMapLike.from(getChild(StateChildIndices.PAYER_RECORDS_OR_CONSOLIDATED_FCQ)),
+                        VirtualMapLike.from((VirtualMap<EntityNumVirtualKey, OnDiskAccount>) accountsStorage))
                 : AccountStorageAdapter.fromInMemory(
-                MerkleMapLike.from((MerkleMap<EntityNum, MerkleAccount>) accountsStorage));
+                        MerkleMapLike.from((MerkleMap<EntityNum, MerkleAccount>) accountsStorage));
     }
 
     public VirtualMapLike<VirtualBlobKey, VirtualBlobValue> storage() {
@@ -555,7 +553,7 @@ public class ServicesState extends PartialNaryMerkleInternal
         final var relsStorage = getChild(StateChildIndices.TOKEN_ASSOCIATIONS);
         return (relsStorage instanceof VirtualMap)
                 ? TokenRelStorageAdapter.fromOnDisk(
-                VirtualMapLike.from((VirtualMap<EntityNumVirtualKey, OnDiskTokenRel>) relsStorage))
+                        VirtualMapLike.from((VirtualMap<EntityNumVirtualKey, OnDiskTokenRel>) relsStorage))
                 : TokenRelStorageAdapter.fromInMemory((MerkleMap<EntityNumPair, MerkleTokenRelStatus>) relsStorage);
     }
 
@@ -585,7 +583,7 @@ public class ServicesState extends PartialNaryMerkleInternal
         return tokensMap.getClass() == MerkleMap.class
                 ? UniqueTokenMapAdapter.wrap((MerkleMap<EntityNumPair, MerkleUniqueToken>) tokensMap)
                 : UniqueTokenMapAdapter.wrap(
-                VirtualMapLike.from((VirtualMap<UniqueTokenKey, UniqueTokenValue>) tokensMap));
+                        VirtualMapLike.from((VirtualMap<UniqueTokenKey, UniqueTokenValue>) tokensMap));
     }
 
     public RecordsStorageAdapter payerRecords() {
@@ -616,9 +614,7 @@ public class ServicesState extends PartialNaryMerkleInternal
     }
 
     void createGenesisChildren(
-            final AddressBook addressBook,
-            final long seqStart,
-            final BootstrapProperties bootstrapProperties) {
+            final AddressBook addressBook, final long seqStart, final BootstrapProperties bootstrapProperties) {
         final VirtualMapFactory virtualMapFactory = getVirtualMapFactory();
         if (enabledVirtualNft) {
             setChild(StateChildIndices.UNIQUE_TOKENS, virtualMapFactory.newVirtualizedUniqueTokenStorage());
@@ -699,8 +695,8 @@ public class ServicesState extends PartialNaryMerkleInternal
     }
 
     boolean recordConsolidationRequiresMigration() {
-        return consolidateRecordStorage &&
-                (getNumberOfChildren() < StateChildIndices.NUM_032X_CHILDREN
+        return consolidateRecordStorage
+                && (getNumberOfChildren() < StateChildIndices.NUM_032X_CHILDREN
                         || getChild(StateChildIndices.PAYER_RECORDS_OR_CONSOLIDATED_FCQ) instanceof MerkleMap<?, ?>);
     }
 

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ServicesState.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ServicesState.java
@@ -530,7 +530,6 @@ public class ServicesState extends PartialNaryMerkleInternal
         final var accountsStorage = getChild(StateChildIndices.ACCOUNTS);
         return (accountsStorage instanceof VirtualMap)
                 ? AccountStorageAdapter.fromOnDisk(
-                        MerkleMapLike.from(getChild(StateChildIndices.PAYER_RECORDS_OR_CONSOLIDATED_FCQ)),
                         VirtualMapLike.from((VirtualMap<EntityNumVirtualKey, OnDiskAccount>) accountsStorage))
                 : AccountStorageAdapter.fromInMemory(
                         MerkleMapLike.from((MerkleMap<EntityNum, MerkleAccount>) accountsStorage));

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/BasicTransactionContext.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/BasicTransactionContext.java
@@ -28,7 +28,6 @@ import com.hedera.node.app.service.mono.ledger.ids.EntityIdSource;
 import com.hedera.node.app.service.mono.legacy.core.jproto.JKey;
 import com.hedera.node.app.service.mono.legacy.core.jproto.TxnReceipt;
 import com.hedera.node.app.service.mono.state.EntityCreator;
-import com.hedera.node.app.service.mono.state.expiry.ExpiringEntity;
 import com.hedera.node.app.service.mono.state.merkle.MerkleTopic;
 import com.hedera.node.app.service.mono.state.migration.AccountStorageAdapter;
 import com.hedera.node.app.service.mono.state.submerkle.EntityId;
@@ -50,7 +49,6 @@ import com.hederahashgraph.api.proto.java.TopicID;
 import com.hederahashgraph.api.proto.java.TransactionID;
 import java.time.Instant;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -104,7 +102,6 @@ public class BasicTransactionContext implements TransactionContext {
     private final NarratedCharging narratedCharging;
     private final HbarCentExchange exchange;
     private final SideEffectsTracker sideEffectsTracker;
-    private final List<ExpiringEntity> expiringEntities = new ArrayList<>();
     private final Supplier<AccountStorageAdapter> accounts;
 
     @Inject
@@ -132,7 +129,6 @@ public class BasicTransactionContext implements TransactionContext {
         this.submittingMember = submittingMember;
         this.triggeredTxn = null;
         this.deletedBeneficiaries = null;
-        this.expiringEntities.clear();
 
         otherNonThresholdFees = 0L;
         hash = accessor.getHash();
@@ -358,16 +354,6 @@ public class BasicTransactionContext implements TransactionContext {
     @Override
     public TxnAccessor triggeredTxn() {
         return triggeredTxn;
-    }
-
-    @Override
-    public void addExpiringEntities(final Collection<ExpiringEntity> entities) {
-        expiringEntities.addAll(entities);
-    }
-
-    @Override
-    public List<ExpiringEntity> expiringEntities() {
-        return expiringEntities;
     }
 
     @Override

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/ImmutableStateChildren.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/ImmutableStateChildren.java
@@ -30,6 +30,7 @@ import com.hedera.node.app.service.mono.state.migration.AccountStorageAdapter;
 import com.hedera.node.app.service.mono.state.migration.RecordsStorageAdapter;
 import com.hedera.node.app.service.mono.state.migration.TokenRelStorageAdapter;
 import com.hedera.node.app.service.mono.state.migration.UniqueTokenMapAdapter;
+import com.hedera.node.app.service.mono.state.submerkle.ExpirableTxnRecord;
 import com.hedera.node.app.service.mono.state.virtual.ContractKey;
 import com.hedera.node.app.service.mono.state.virtual.IterableContractValue;
 import com.hedera.node.app.service.mono.state.virtual.VirtualBlobKey;
@@ -38,6 +39,8 @@ import com.hedera.node.app.service.mono.stream.RecordsRunningHashLeaf;
 import com.hedera.node.app.service.mono.utils.EntityNum;
 import com.hedera.node.app.service.mono.utils.NonAtomicReference;
 import com.swirlds.common.system.address.AddressBook;
+import com.swirlds.fcqueue.FCQueue;
+import edu.umd.cs.findbugs.annotations.Nullable;
 import java.time.Instant;
 import java.util.Map;
 import java.util.Objects;
@@ -160,6 +163,12 @@ public class ImmutableStateChildren implements StateChildren {
     @Override
     public RecordsRunningHashLeaf runningHashLeaf() {
         return Objects.requireNonNull(runningHashLeaf.get());
+    }
+
+    @Override
+    @Nullable
+    public FCQueue<ExpirableTxnRecord> records() {
+        throw new AssertionError("Not implemented");
     }
 
     @Override

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/ImmutableStateChildren.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/ImmutableStateChildren.java
@@ -30,7 +30,6 @@ import com.hedera.node.app.service.mono.state.migration.AccountStorageAdapter;
 import com.hedera.node.app.service.mono.state.migration.RecordsStorageAdapter;
 import com.hedera.node.app.service.mono.state.migration.TokenRelStorageAdapter;
 import com.hedera.node.app.service.mono.state.migration.UniqueTokenMapAdapter;
-import com.hedera.node.app.service.mono.state.submerkle.ExpirableTxnRecord;
 import com.hedera.node.app.service.mono.state.virtual.ContractKey;
 import com.hedera.node.app.service.mono.state.virtual.IterableContractValue;
 import com.hedera.node.app.service.mono.state.virtual.VirtualBlobKey;
@@ -39,8 +38,6 @@ import com.hedera.node.app.service.mono.stream.RecordsRunningHashLeaf;
 import com.hedera.node.app.service.mono.utils.EntityNum;
 import com.hedera.node.app.service.mono.utils.NonAtomicReference;
 import com.swirlds.common.system.address.AddressBook;
-import com.swirlds.fcqueue.FCQueue;
-import edu.umd.cs.findbugs.annotations.Nullable;
 import java.time.Instant;
 import java.util.Map;
 import java.util.Objects;
@@ -163,12 +160,6 @@ public class ImmutableStateChildren implements StateChildren {
     @Override
     public RecordsRunningHashLeaf runningHashLeaf() {
         return Objects.requireNonNull(runningHashLeaf.get());
-    }
-
-    @Override
-    @Nullable
-    public FCQueue<ExpirableTxnRecord> records() {
-        throw new AssertionError("Not implemented");
     }
 
     @Override

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/MutableStateChildren.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/MutableStateChildren.java
@@ -31,7 +31,6 @@ import com.hedera.node.app.service.mono.state.migration.AccountStorageAdapter;
 import com.hedera.node.app.service.mono.state.migration.RecordsStorageAdapter;
 import com.hedera.node.app.service.mono.state.migration.TokenRelStorageAdapter;
 import com.hedera.node.app.service.mono.state.migration.UniqueTokenMapAdapter;
-import com.hedera.node.app.service.mono.state.submerkle.ExpirableTxnRecord;
 import com.hedera.node.app.service.mono.state.virtual.ContractKey;
 import com.hedera.node.app.service.mono.state.virtual.IterableContractValue;
 import com.hedera.node.app.service.mono.state.virtual.VirtualBlobKey;
@@ -40,8 +39,6 @@ import com.hedera.node.app.service.mono.stream.RecordsRunningHashLeaf;
 import com.hedera.node.app.service.mono.utils.EntityNum;
 import com.hedera.node.app.service.mono.utils.NonAtomicReference;
 import com.swirlds.common.system.address.AddressBook;
-import com.swirlds.fcqueue.FCQueue;
-import edu.umd.cs.findbugs.annotations.Nullable;
 import java.time.Instant;
 import java.util.Map;
 import java.util.Objects;
@@ -225,12 +222,6 @@ public class MutableStateChildren implements StateChildren {
     @Override
     public Map<ByteString, EntityNum> aliases() {
         return Objects.requireNonNull(aliases.get());
-    }
-
-    @Nullable
-    @Override
-    public FCQueue<ExpirableTxnRecord> records() {
-        throw new AssertionError("Not implemented");
     }
 
     public void updateFromImmutable(final StateChildrenProvider provider, final Instant lowerBoundOnSigningTime) {

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/MutableStateChildren.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/MutableStateChildren.java
@@ -31,6 +31,7 @@ import com.hedera.node.app.service.mono.state.migration.AccountStorageAdapter;
 import com.hedera.node.app.service.mono.state.migration.RecordsStorageAdapter;
 import com.hedera.node.app.service.mono.state.migration.TokenRelStorageAdapter;
 import com.hedera.node.app.service.mono.state.migration.UniqueTokenMapAdapter;
+import com.hedera.node.app.service.mono.state.submerkle.ExpirableTxnRecord;
 import com.hedera.node.app.service.mono.state.virtual.ContractKey;
 import com.hedera.node.app.service.mono.state.virtual.IterableContractValue;
 import com.hedera.node.app.service.mono.state.virtual.VirtualBlobKey;
@@ -39,6 +40,8 @@ import com.hedera.node.app.service.mono.stream.RecordsRunningHashLeaf;
 import com.hedera.node.app.service.mono.utils.EntityNum;
 import com.hedera.node.app.service.mono.utils.NonAtomicReference;
 import com.swirlds.common.system.address.AddressBook;
+import com.swirlds.fcqueue.FCQueue;
+import edu.umd.cs.findbugs.annotations.Nullable;
 import java.time.Instant;
 import java.util.Map;
 import java.util.Objects;
@@ -222,6 +225,12 @@ public class MutableStateChildren implements StateChildren {
     @Override
     public Map<ByteString, EntityNum> aliases() {
         return Objects.requireNonNull(aliases.get());
+    }
+
+    @Nullable
+    @Override
+    public FCQueue<ExpirableTxnRecord> records() {
+        throw new AssertionError("Not implemented");
     }
 
     public void updateFromImmutable(final StateChildrenProvider provider, final Instant lowerBoundOnSigningTime) {

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/StateChildren.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/StateChildren.java
@@ -29,6 +29,7 @@ import com.hedera.node.app.service.mono.state.migration.AccountStorageAdapter;
 import com.hedera.node.app.service.mono.state.migration.RecordsStorageAdapter;
 import com.hedera.node.app.service.mono.state.migration.TokenRelStorageAdapter;
 import com.hedera.node.app.service.mono.state.migration.UniqueTokenMapAdapter;
+import com.hedera.node.app.service.mono.state.submerkle.ExpirableTxnRecord;
 import com.hedera.node.app.service.mono.state.virtual.ContractKey;
 import com.hedera.node.app.service.mono.state.virtual.IterableContractValue;
 import com.hedera.node.app.service.mono.state.virtual.VirtualBlobKey;
@@ -36,6 +37,8 @@ import com.hedera.node.app.service.mono.state.virtual.VirtualBlobValue;
 import com.hedera.node.app.service.mono.stream.RecordsRunningHashLeaf;
 import com.hedera.node.app.service.mono.utils.EntityNum;
 import com.swirlds.common.system.address.AddressBook;
+import com.swirlds.fcqueue.FCQueue;
+import edu.umd.cs.findbugs.annotations.Nullable;
 import java.time.Instant;
 import java.util.Map;
 
@@ -71,4 +74,7 @@ public interface StateChildren {
     RecordsRunningHashLeaf runningHashLeaf();
 
     Map<ByteString, EntityNum> aliases();
+
+    @Nullable
+    FCQueue<ExpirableTxnRecord> records();
 }

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/StateChildren.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/StateChildren.java
@@ -29,7 +29,6 @@ import com.hedera.node.app.service.mono.state.migration.AccountStorageAdapter;
 import com.hedera.node.app.service.mono.state.migration.RecordsStorageAdapter;
 import com.hedera.node.app.service.mono.state.migration.TokenRelStorageAdapter;
 import com.hedera.node.app.service.mono.state.migration.UniqueTokenMapAdapter;
-import com.hedera.node.app.service.mono.state.submerkle.ExpirableTxnRecord;
 import com.hedera.node.app.service.mono.state.virtual.ContractKey;
 import com.hedera.node.app.service.mono.state.virtual.IterableContractValue;
 import com.hedera.node.app.service.mono.state.virtual.VirtualBlobKey;
@@ -37,8 +36,6 @@ import com.hedera.node.app.service.mono.state.virtual.VirtualBlobValue;
 import com.hedera.node.app.service.mono.stream.RecordsRunningHashLeaf;
 import com.hedera.node.app.service.mono.utils.EntityNum;
 import com.swirlds.common.system.address.AddressBook;
-import com.swirlds.fcqueue.FCQueue;
-import edu.umd.cs.findbugs.annotations.Nullable;
 import java.time.Instant;
 import java.util.Map;
 
@@ -74,7 +71,4 @@ public interface StateChildren {
     RecordsRunningHashLeaf runningHashLeaf();
 
     Map<ByteString, EntityNum> aliases();
-
-    @Nullable
-    FCQueue<ExpirableTxnRecord> records();
 }

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/TransactionContext.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/TransactionContext.java
@@ -20,7 +20,6 @@ import com.google.protobuf.ByteString;
 import com.hedera.node.app.hapi.utils.ethereum.EthTxData;
 import com.hedera.node.app.service.mono.ledger.interceptors.StakingAccountsCommitInterceptor;
 import com.hedera.node.app.service.mono.legacy.core.jproto.JKey;
-import com.hedera.node.app.service.mono.state.expiry.ExpiringEntity;
 import com.hedera.node.app.service.mono.state.submerkle.EntityId;
 import com.hedera.node.app.service.mono.state.submerkle.EvmFnResult;
 import com.hedera.node.app.service.mono.state.submerkle.ExpirableTxnRecord;
@@ -37,7 +36,6 @@ import com.hederahashgraph.api.proto.java.ScheduleID;
 import com.hederahashgraph.api.proto.java.TopicID;
 import com.hederahashgraph.api.proto.java.TransactionID;
 import java.time.Instant;
-import java.util.Collection;
 import java.util.List;
 
 /**
@@ -262,21 +260,6 @@ public interface TransactionContext {
      * @return a triggered TxnAccessor
      */
     TxnAccessor triggeredTxn();
-
-    /**
-     * Adds a collection of {@link ExpiringEntity} to be later tracked for purging when expired
-     *
-     * @param expiringEntities the information about entities which will be tracked for future purge
-     */
-    void addExpiringEntities(Collection<ExpiringEntity> expiringEntities);
-
-    /**
-     * Gets all expiring entities to the defined type {@link ExpiringEntity} currently being
-     * processed.
-     *
-     * @return {@code List<ExpiringEntity>} for the current expiring entities.
-     */
-    List<ExpiringEntity> expiringEntities();
 
     /**
      * Set the assessed custom fees as a result of the active transaction. It is used for {@link

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/init/EntitiesInitializationFlow.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/init/EntitiesInitializationFlow.java
@@ -46,7 +46,6 @@ public class EntitiesInitializationFlow {
         expiries.reviewExistingPayerRecords();
         log.info("Payer records reviewed");
         /* Use any entities stored in state to rebuild queue of expired entities. */
-        expiries.reviewExistingShortLivedEntities();
         log.info("Short-lived entities reviewed");
 
         sigImpactHistorian.invalidateCurrentWindow();

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/properties/BootstrapProperties.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/properties/BootstrapProperties.java
@@ -182,6 +182,7 @@ import static com.hedera.node.app.service.mono.context.properties.PropertyNames.
 import static com.hedera.node.app.service.mono.context.properties.PropertyNames.QUERIES_BLOB_LOOK_UP_RETRIES;
 import static com.hedera.node.app.service.mono.context.properties.PropertyNames.RATES_INTRA_DAY_CHANGE_LIMIT_PERCENT;
 import static com.hedera.node.app.service.mono.context.properties.PropertyNames.RATES_MIDNIGHT_CHECK_INTERVAL;
+import static com.hedera.node.app.service.mono.context.properties.PropertyNames.RECORDS_USE_CONSOLIDATED_FCQ;
 import static com.hedera.node.app.service.mono.context.properties.PropertyNames.SCHEDULING_LONG_TERM_ENABLED;
 import static com.hedera.node.app.service.mono.context.properties.PropertyNames.SCHEDULING_MAX_EXPIRATION_FUTURE_SECS;
 import static com.hedera.node.app.service.mono.context.properties.PropertyNames.SCHEDULING_MAX_NUM;
@@ -432,7 +433,8 @@ public final class BootstrapProperties implements PropertySource {
             STAKING_STARTUP_HELPER_RECOMPUTE,
             WORKFLOWS_ENABLED,
             STAKING_SUM_OF_CONSENSUS_WEIGHTS,
-            CONFIG_VERSION);
+            CONFIG_VERSION,
+            RECORDS_USE_CONSOLIDATED_FCQ);
 
     static final Set<String> GLOBAL_DYNAMIC_PROPS = Set.of(
             ACCOUNTS_MAX_NUM,

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/properties/BootstrapProperties.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/properties/BootstrapProperties.java
@@ -791,6 +791,7 @@ public final class BootstrapProperties implements PropertySource {
             entry(CONTRACTS_DYNAMIC_EVM_VERSION, AS_BOOLEAN),
             entry(RATES_INTRA_DAY_CHANGE_LIMIT_PERCENT, AS_INT),
             entry(RATES_MIDNIGHT_CHECK_INTERVAL, AS_LONG),
+            entry(RECORDS_USE_CONSOLIDATED_FCQ, AS_BOOLEAN),
             entry(SIGS_EXPAND_FROM_IMMUTABLE_STATE, AS_BOOLEAN),
             entry(SCHEDULING_LONG_TERM_ENABLED, AS_BOOLEAN),
             entry(SCHEDULING_MAX_TXN_PER_SEC, AS_LONG),

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/properties/PropertyNames.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/context/properties/PropertyNames.java
@@ -157,6 +157,7 @@ public class PropertyNames {
     public static final String LEDGER_SCHEDULE_TX_EXPIRY_TIME_SECS = "ledger.schedule.txExpiryTimeSecs";
     public static final String RATES_INTRA_DAY_CHANGE_LIMIT_PERCENT = "rates.intradayChangeLimitPercent";
     public static final String RATES_MIDNIGHT_CHECK_INTERVAL = "rates.midnightCheckInterval";
+    public static final String RECORDS_USE_CONSOLIDATED_FCQ = "records.useConsolidatedFcq";
     public static final String SCHEDULING_LONG_TERM_ENABLED = "scheduling.longTermEnabled";
     public static final String SCHEDULING_MAX_TXN_PER_SEC = "scheduling.maxTxnPerSecond";
     public static final String SCHEDULING_MAX_NUM = "scheduling.maxNumber";

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ledger/HederaLedger.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/ledger/HederaLedger.java
@@ -212,7 +212,6 @@ public class HederaLedger {
             nftsLedger.commit();
         }
         historian.saveExpirableTransactionRecords();
-        historian.noteNewExpirationEvents();
     }
 
     public String currentChangeSet() {

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/records/RecordsHistorian.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/records/RecordsHistorian.java
@@ -17,7 +17,6 @@
 package com.hedera.node.app.service.mono.records;
 
 import com.hedera.node.app.service.mono.state.EntityCreator;
-import com.hedera.node.app.service.mono.state.expiry.ExpiryManager;
 import com.hedera.node.app.service.mono.state.submerkle.ExpirableTxnRecord;
 import com.hedera.node.app.service.mono.state.submerkle.TxnId;
 import com.hedera.node.app.service.mono.stream.RecordStreamObject;
@@ -139,12 +138,6 @@ public interface RecordsHistorian {
      * @param sourceId the id of the source whose records should be reverted
      */
     void revertChildRecordsFromSource(int sourceId);
-
-    /**
-     * At the moment before committing the active transaction, takes the opportunity to track any
-     * new expiring entities with the {@link ExpiryManager}.
-     */
-    void noteNewExpirationEvents();
 
     /**
      * Provides the next consensus timestamp that will be used; needed for assigning creation times

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/records/TxnAwareRecordsHistorian.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/records/TxnAwareRecordsHistorian.java
@@ -41,7 +41,6 @@ import java.util.function.Consumer;
 import java.util.function.Predicate;
 import javax.inject.Inject;
 import javax.inject.Singleton;
-import org.apache.commons.lang3.tuple.Pair;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -142,14 +141,6 @@ public class TxnAwareRecordsHistorian implements RecordsHistorian {
         save(followingChildStreamObjs, effPayer, submittingMember);
 
         consensusTimeTracker.setActualFollowingRecordsCount(followingChildStreamObjs.size());
-    }
-
-    @Override
-    public void noteNewExpirationEvents() {
-        for (final var expiringEntity : txnCtx.expiringEntities()) {
-            expiries.trackExpirationEvent(
-                    Pair.of(expiringEntity.id().num(), expiringEntity.consumer()), expiringEntity.expiry());
-        }
     }
 
     @Override

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/records/TxnAwareRecordsHistorian.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/records/TxnAwareRecordsHistorian.java
@@ -25,7 +25,6 @@ import com.google.common.annotations.VisibleForTesting;
 import com.hedera.node.app.service.mono.context.TransactionContext;
 import com.hedera.node.app.service.mono.exceptions.ResourceLimitException;
 import com.hedera.node.app.service.mono.state.EntityCreator;
-import com.hedera.node.app.service.mono.state.expiry.ExpiryManager;
 import com.hedera.node.app.service.mono.state.submerkle.ExpirableTxnRecord;
 import com.hedera.node.app.service.mono.state.submerkle.RichInstant;
 import com.hedera.node.app.service.mono.state.submerkle.TxnId;
@@ -51,7 +50,6 @@ public class TxnAwareRecordsHistorian implements RecordsHistorian {
     public static final int DEFAULT_SOURCE_ID = 0;
 
     private final RecordCache recordCache;
-    private final ExpiryManager expiries;
     private final TransactionContext txnCtx;
     private final ConsensusTimeTracker consensusTimeTracker;
     private final List<RecordStreamObject> precedingChildStreamObjs = new ArrayList<>();
@@ -67,11 +65,7 @@ public class TxnAwareRecordsHistorian implements RecordsHistorian {
 
     @Inject
     public TxnAwareRecordsHistorian(
-            RecordCache recordCache,
-            TransactionContext txnCtx,
-            ExpiryManager expiries,
-            ConsensusTimeTracker consensusTimeTracker) {
-        this.expiries = expiries;
+            RecordCache recordCache, TransactionContext txnCtx, ConsensusTimeTracker consensusTimeTracker) {
         this.txnCtx = txnCtx;
         this.recordCache = recordCache;
         this.consensusTimeTracker = consensusTimeTracker;

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/expiry/ExpiryManager.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/expiry/ExpiryManager.java
@@ -17,71 +17,49 @@
 package com.hedera.node.app.service.mono.state.expiry;
 
 import static java.util.Comparator.comparing;
+import static java.util.Objects.requireNonNull;
 
-import com.hedera.node.app.service.mono.config.HederaNumbers;
-import com.hedera.node.app.service.mono.ledger.SigImpactHistorian;
 import com.hedera.node.app.service.mono.records.TxnIdRecentHistory;
 import com.hedera.node.app.service.mono.state.migration.RecordsStorageAdapter;
-import com.hedera.node.app.service.mono.state.submerkle.EntityId;
+import com.hedera.node.app.service.mono.state.migration.StorageStrategy;
 import com.hedera.node.app.service.mono.state.submerkle.ExpirableTxnRecord;
 import com.hedera.node.app.service.mono.utils.EntityNum;
 import com.hederahashgraph.api.proto.java.AccountID;
 import com.hederahashgraph.api.proto.java.TransactionID;
 import com.swirlds.fcqueue.FCQueue;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.AbstractMap;
 import java.util.ArrayList;
-import java.util.Comparator;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Consumer;
+import java.util.Queue;
 import java.util.function.Supplier;
 import javax.inject.Inject;
 import javax.inject.Singleton;
-import org.apache.commons.lang3.tuple.Pair;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
- * Manager of two queues of expiration events---one for payer records, one for schedule entities.
- *
- * <p>There are two management responsibilities:
- *
- * <ol>
- *   <li>On restart or reconnect, rebuild the expiration queues from state.
- *   <li>At the first consensus second an entity is expired, remove it from its parent collection.
- * </ol>
+ * Manages the purging of expired records and their associated transaction histories from state and
+ * auxiliary data structures. Behaves differently depending on the storage strategy in use.
  */
 @Singleton
 public class ExpiryManager {
-    /* Since the key in Pair<Long, Consumer<EntityId>> is the schedule entity number---and
-    entity numbers are unique---the downstream comparator below will guarantee a fixed
-    ordering for ExpiryEvents with the same expiry. The reason for different scheduled entities having
-    the same expiry is that we round expiration times to a consensus second. */
-    private static final Comparator<ExpiryEvent<Pair<Long, Consumer<EntityId>>>> PQ_CMP = Comparator.comparingLong(
-                    ExpiryEvent<Pair<Long, Consumer<EntityId>>>::expiry)
-            .thenComparingLong(ee -> ee.id().getKey());
+    private static final Logger log = LogManager.getLogger(ExpiryManager.class);
 
-    private final long shard;
-    private final long realm;
-
-    private final SigImpactHistorian sigImpactHistorian;
     private final Map<TransactionID, TxnIdRecentHistory> txnHistories;
-    private final Supplier<RecordsStorageAdapter> payerRecords;
-
+    private final Supplier<RecordsStorageAdapter> records;
+    private final StorageStrategy strategyInUse;
+    // Needed is strategyInUse != IN_SINGLE_FCQ so we can do deterministic expiration
     private final MonotonicFullQueueExpiries<Long> payerRecordExpiries = new MonotonicFullQueueExpiries<>();
-    private final PriorityQueueExpiries<Pair<Long, Consumer<EntityId>>> shortLivedEntityExpiries =
-            new PriorityQueueExpiries<>(PQ_CMP);
 
     @Inject
     public ExpiryManager(
-            final HederaNumbers hederaNums,
-            final SigImpactHistorian sigImpactHistorian,
-            final Map<TransactionID, TxnIdRecentHistory> txnHistories,
-            final Supplier<RecordsStorageAdapter> payerRecords) {
-        this.payerRecords = payerRecords;
+            final Map<TransactionID, TxnIdRecentHistory> txnHistories, final Supplier<RecordsStorageAdapter> records) {
+        this.records = records;
         this.txnHistories = txnHistories;
-        this.sigImpactHistorian = sigImpactHistorian;
-
-        this.shard = hederaNums.shard();
-        this.realm = hederaNums.realm();
+        this.strategyInUse = records.get().getStrategy();
     }
 
     /**
@@ -90,18 +68,11 @@ public class ExpiryManager {
      * @param now the consensus second
      */
     public void purge(final long now) {
-        purgeExpiredRecordsAt(now);
-        purgeExpiredShortLivedEntities(now);
-    }
-
-    /**
-     * Begins tracking an expiration event.
-     *
-     * @param event the expiration event to track
-     * @param expiry the earliest consensus second at which it should fire
-     */
-    public void trackExpirationEvent(final Pair<Long, Consumer<EntityId>> event, final long expiry) {
-        shortLivedEntityExpiries.track(event, expiry);
+        if (strategyInUse == StorageStrategy.IN_SINGLE_FCQ) {
+            purgeExpiredRecordsFromConsolidatedStorageAt(now);
+        } else {
+            purgeExpiredRecordsFromPayerScopedStorageAt(now);
+        }
     }
 
     /**
@@ -118,35 +89,65 @@ public class ExpiryManager {
         payerRecordExpiries.reset();
 
         final var payerExpiries = new ArrayList<Map.Entry<Long, Long>>();
-        payerRecords
-                .get()
-                .doForEach((payerNum, accountRecords) ->
-                        stageExpiringRecords(payerNum.longValue(), accountRecords, payerExpiries));
-        payerExpiries.sort(comparing(Map.Entry<Long, Long>::getValue).thenComparing(Map.Entry::getKey));
-        payerExpiries.forEach(entry -> payerRecordExpiries.track(entry.getKey(), entry.getValue()));
+        final var savedRecords = records.get();
+        if (strategyInUse == StorageStrategy.IN_SINGLE_FCQ) {
+            final var queryableRecords = requireNonNull(savedRecords.getQueryableRecords());
+            queryableRecords.clear();
+            requireNonNull(savedRecords.getRecords()).forEach(savedRecord -> {
+                stage(savedRecord);
+                // TODO - the effective payer for this record could have been different than the
+                // account in the transaction id (in case of node diligence failure); to address,
+                // we will need to add the effective payer number to the ExpirableTxnRecord type
+                final var payerNum = savedRecord.getPayerNum();
+                queryableRecords
+                        .computeIfAbsent(payerNum, ignore -> new LinkedList<>())
+                        .add(savedRecord);
+            });
+        } else {
+            savedRecords.doForEach((payerNum, accountRecords) ->
+                    stageExpiringRecords(payerNum.longValue(), accountRecords, payerExpiries));
+            payerExpiries.sort(comparing(Map.Entry<Long, Long>::getValue).thenComparing(Map.Entry::getKey));
+            payerExpiries.forEach(entry -> payerRecordExpiries.track(entry.getKey(), entry.getValue()));
+        }
 
         txnHistories.values().forEach(TxnIdRecentHistory::observeStaged);
     }
 
-    /**
-     * Entities that typically expire on the order of days or months (topics, accounts, tokens,
-     * etc.) are monitored and automatically renewed or removed by the {@link EntityAutoExpiry}
-     * process.
-     *
-     * <p>The only entities that currently qualify as "short-lived" are schedule entities, which
-     * have a default expiration time of 30 minutes. So this method's only function is to scan the
-     * current {@code schedules} FCM and enqueue their expiration events.
-     */
-    public void reviewExistingShortLivedEntities() {
-        shortLivedEntityExpiries.reset();
-    }
-
     void trackRecordInState(final AccountID owner, final long expiry) {
-        payerRecordExpiries.track(owner.getAccountNum(), expiry);
+        // We only need to use an auxiliary expiration queue if records are kept per-payer in state
+        if (strategyInUse != StorageStrategy.IN_SINGLE_FCQ) {
+            payerRecordExpiries.track(owner.getAccountNum(), expiry);
+        }
     }
 
-    private void purgeExpiredRecordsAt(final long now) {
-        final var curPayerRecords = payerRecords.get();
+    private void purgeExpiredRecordsFromConsolidatedStorageAt(final long now) {
+        final var curRecords = requireNonNull(records.get().getRecords());
+        final var curQueryableRecords = requireNonNull(records.get().getQueryableRecords());
+        for (int i = 0, n = curRecords.size(); i < n; i++) {
+            final var nextRecord = curRecords.peek();
+            if (requireNonNull(nextRecord).getExpiry() > now) {
+                break;
+            }
+            curRecords.poll();
+            purgeHistoryFor(nextRecord, now);
+
+            final var payerRecords = curQueryableRecords.get(nextRecord.getPayerNum());
+            if (payerRecords != null && !payerRecords.isEmpty()) {
+                final var nextPayerRecord = payerRecords.poll();
+                if (!nextRecord.equals(nextPayerRecord)) {
+                    log.error("Inconsistent queryable record {} for expired record {}", nextPayerRecord, nextRecord);
+                }
+            } else {
+                log.error(
+                        "No queryable records found for payer {} despite link to expiring record {}",
+                        nextRecord.getPayerNum(),
+                        nextRecord);
+            }
+        }
+    }
+
+    private void purgeExpiredRecordsFromPayerScopedStorageAt(final long now) {
+        final var curPayerRecords = records.get();
         while (payerRecordExpiries.hasExpiringAt(now)) {
             final var key = EntityNum.fromLong(payerRecordExpiries.expireNextAt(now));
             final var mutableRecords = curPayerRecords.getMutablePayerRecords(key);
@@ -158,28 +159,23 @@ public class ExpiryManager {
         ExpirableTxnRecord nextRecord;
         while ((nextRecord = records.peek()) != null && nextRecord.getExpiry() <= now) {
             nextRecord = records.poll();
-            final var txnId = nextRecord.getTxnId().toGrpc();
-            final var history = txnHistories.get(txnId);
-            if (history != null) {
-                history.forgetExpiredAt(now);
-                if (history.isForgotten()) {
-                    txnHistories.remove(txnId);
-                }
+            purgeHistoryFor(requireNonNull(nextRecord), now);
+        }
+    }
+
+    private void purgeHistoryFor(@NonNull final ExpirableTxnRecord expiredRecord, final long now) {
+        final var txnId = expiredRecord.getTxnId().toGrpc();
+        final var history = txnHistories.get(txnId);
+        if (history != null) {
+            history.forgetExpiredAt(now);
+            if (history.isForgotten()) {
+                txnHistories.remove(txnId);
             }
         }
     }
 
-    private void purgeExpiredShortLivedEntities(final long now) {
-        while (shortLivedEntityExpiries.hasExpiringAt(now)) {
-            final var current = shortLivedEntityExpiries.expireNextAt(now);
-            final var expiredNum = (long) current.getKey();
-            current.getValue().accept(entityWith(expiredNum));
-            sigImpactHistorian.markEntityChanged(expiredNum);
-        }
-    }
-
     private void stageExpiringRecords(
-            final Long num, final FCQueue<ExpirableTxnRecord> records, final List<Map.Entry<Long, Long>> expiries) {
+            final Long num, final Queue<ExpirableTxnRecord> records, final List<Map.Entry<Long, Long>> expiries) {
         long lastAdded = -1;
         for (final var expirableTxnRecord : records) {
             stage(expirableTxnRecord);
@@ -194,13 +190,5 @@ public class ExpiryManager {
     private void stage(final ExpirableTxnRecord expirableTxnRecord) {
         final var txnId = expirableTxnRecord.getTxnId().toGrpc();
         txnHistories.computeIfAbsent(txnId, ignore -> new TxnIdRecentHistory()).stage(expirableTxnRecord);
-    }
-
-    private EntityId entityWith(final long num) {
-        return new EntityId(shard, realm, num);
-    }
-
-    PriorityQueueExpiries<Pair<Long, Consumer<EntityId>>> getShortLivedEntityExpiries() {
-        return shortLivedEntityExpiries;
     }
 }

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/expiry/ExpiryManager.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/expiry/ExpiryManager.java
@@ -51,7 +51,7 @@ public class ExpiryManager {
     private final Map<TransactionID, TxnIdRecentHistory> txnHistories;
     private final Supplier<RecordsStorageAdapter> records;
     private final StorageStrategy strategyInUse;
-    // Needed is strategyInUse != IN_SINGLE_FCQ so we can do deterministic expiration
+    // Needed if strategyInUse != IN_SINGLE_FCQ so we can do deterministic expiration
     private final MonotonicFullQueueExpiries<Long> payerRecordExpiries = new MonotonicFullQueueExpiries<>();
 
     @Inject
@@ -59,7 +59,7 @@ public class ExpiryManager {
             final Map<TransactionID, TxnIdRecentHistory> txnHistories, final Supplier<RecordsStorageAdapter> records) {
         this.records = records;
         this.txnHistories = txnHistories;
-        this.strategyInUse = records.get().getStrategy();
+        this.strategyInUse = records.get().storageStrategy();
     }
 
     /**
@@ -109,7 +109,6 @@ public class ExpiryManager {
             payerExpiries.sort(comparing(Map.Entry<Long, Long>::getValue).thenComparing(Map.Entry::getKey));
             payerExpiries.forEach(entry -> payerRecordExpiries.track(entry.getKey(), entry.getValue()));
         }
-
         txnHistories.values().forEach(TxnIdRecentHistory::observeStaged);
     }
 

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/migration/AccountStorageAdapter.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/migration/AccountStorageAdapter.java
@@ -21,12 +21,12 @@ import static com.swirlds.common.threading.manager.AdHocThreadManager.getStaticT
 import com.hedera.node.app.service.mono.state.adapters.MerkleMapLike;
 import com.hedera.node.app.service.mono.state.adapters.VirtualMapLike;
 import com.hedera.node.app.service.mono.state.merkle.MerkleAccount;
-import com.hedera.node.app.service.mono.state.merkle.MerklePayerRecords;
 import com.hedera.node.app.service.mono.state.virtual.EntityNumVirtualKey;
 import com.hedera.node.app.service.mono.state.virtual.entities.OnDiskAccount;
 import com.hedera.node.app.service.mono.utils.EntityNum;
 import com.swirlds.common.crypto.Hash;
 import edu.umd.cs.findbugs.annotations.Nullable;
+import java.util.HashSet;
 import java.util.Set;
 import java.util.function.BiConsumer;
 import org.apache.logging.log4j.LogManager;
@@ -37,33 +37,27 @@ public class AccountStorageAdapter {
     private static final int THREAD_COUNT = 32;
     private final boolean accountsOnDisk;
     private final @Nullable MerkleMapLike<EntityNum, MerkleAccount> inMemoryAccounts;
-    private final @Nullable MerkleMapLike<EntityNum, MerklePayerRecords> payerRecords;
     private final @Nullable VirtualMapLike<EntityNumVirtualKey, OnDiskAccount> onDiskAccounts;
 
     public static AccountStorageAdapter fromInMemory(final MerkleMapLike<EntityNum, MerkleAccount> accounts) {
-        return new AccountStorageAdapter(accounts, null, null);
+        return new AccountStorageAdapter(accounts, null);
     }
 
-    public static AccountStorageAdapter fromOnDisk(
-            final MerkleMapLike<EntityNum, MerklePayerRecords> payerRecords,
-            final VirtualMapLike<EntityNumVirtualKey, OnDiskAccount> accounts) {
-        return new AccountStorageAdapter(null, payerRecords, accounts);
+    public static AccountStorageAdapter fromOnDisk(final VirtualMapLike<EntityNumVirtualKey, OnDiskAccount> accounts) {
+        return new AccountStorageAdapter(null, accounts);
     }
 
     private AccountStorageAdapter(
             @Nullable final MerkleMapLike<EntityNum, MerkleAccount> inMemoryAccounts,
-            @Nullable final MerkleMapLike<EntityNum, MerklePayerRecords> payerRecords,
             @Nullable final VirtualMapLike<EntityNumVirtualKey, OnDiskAccount> onDiskAccounts) {
         if (inMemoryAccounts != null) {
             this.accountsOnDisk = false;
             this.inMemoryAccounts = inMemoryAccounts;
             this.onDiskAccounts = null;
-            this.payerRecords = null;
         } else {
             this.accountsOnDisk = true;
             this.inMemoryAccounts = null;
             this.onDiskAccounts = onDiskAccounts;
-            this.payerRecords = payerRecords;
         }
     }
 
@@ -110,7 +104,9 @@ public class AccountStorageAdapter {
 
     public Set<EntityNum> keySet() {
         if (accountsOnDisk) {
-            return payerRecords.keySet();
+            final Set<EntityNum> allAccountNums = new HashSet<>();
+            forEachOnDisk((num, account) -> allAccountNums.add(num));
+            return allAccountNums;
         } else {
             return inMemoryAccounts.keySet();
         }
@@ -118,18 +114,22 @@ public class AccountStorageAdapter {
 
     public void forEach(final BiConsumer<EntityNum, HederaAccount> visitor) {
         if (accountsOnDisk) {
-            try {
-                onDiskAccounts.extractVirtualMapData(
-                        getStaticThreadManager(),
-                        entry -> visitor.accept(entry.getKey().asEntityNum(), entry.getValue()),
-                        THREAD_COUNT);
-            } catch (final InterruptedException e) {
-                log.error("Interrupted while extracting VM data", e);
-                Thread.currentThread().interrupt();
-                throw new IllegalStateException(e);
-            }
+            forEachOnDisk(visitor);
         } else {
             inMemoryAccounts.forEach(visitor);
+        }
+    }
+
+    private void forEachOnDisk(final BiConsumer<EntityNum, HederaAccount> visitor) {
+        try {
+            onDiskAccounts.extractVirtualMapData(
+                    getStaticThreadManager(),
+                    entry -> visitor.accept(entry.getKey().asEntityNum(), entry.getValue()),
+                    THREAD_COUNT);
+        } catch (final InterruptedException e) {
+            log.error("Interrupted while extracting VM data", e);
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException(e);
         }
     }
 
@@ -145,10 +145,5 @@ public class AccountStorageAdapter {
     @Nullable
     public VirtualMapLike<EntityNumVirtualKey, OnDiskAccount> getOnDiskAccounts() {
         return onDiskAccounts;
-    }
-
-    @Nullable
-    public MerkleMapLike<EntityNum, MerklePayerRecords> getPayerRecords() {
-        return payerRecords;
     }
 }

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/migration/AccountStorageAdapter.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/migration/AccountStorageAdapter.java
@@ -146,4 +146,9 @@ public class AccountStorageAdapter {
     public VirtualMapLike<EntityNumVirtualKey, OnDiskAccount> getOnDiskAccounts() {
         return onDiskAccounts;
     }
+
+    @Nullable
+    public MerkleMapLike<EntityNum, MerklePayerRecords> getPayerRecords() {
+        return payerRecords;
+    }
 }

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/migration/MapMigrationToDisk.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/migration/MapMigrationToDisk.java
@@ -17,7 +17,7 @@
 package com.hedera.node.app.service.mono.state.migration;
 
 import static com.hedera.node.app.service.mono.state.migration.StateChildIndices.ACCOUNTS;
-import static com.hedera.node.app.service.mono.state.migration.StateChildIndices.PAYER_RECORDS;
+import static com.hedera.node.app.service.mono.state.migration.StateChildIndices.PAYER_RECORDS_OR_CONSOLIDATED_FCQ;
 import static com.hedera.node.app.service.mono.state.migration.StateChildIndices.TOKEN_ASSOCIATIONS;
 import static com.hedera.node.app.service.mono.utils.MiscUtils.forEach;
 import static com.hedera.node.app.service.mono.utils.MiscUtils.withLoggedDuration;
@@ -90,7 +90,7 @@ public class MapMigrationToDisk {
                 log,
                 "accounts-to-disk migration");
         mutableState.setChild(ACCOUNTS, onDiskAccounts.get());
-        mutableState.setChild(PAYER_RECORDS, payerRecords);
+        mutableState.setChild(PAYER_RECORDS_OR_CONSOLIDATED_FCQ, payerRecords);
     }
 
     @SuppressWarnings("unchecked")

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/migration/RecordConsolidation.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/migration/RecordConsolidation.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.hedera.node.app.service.mono.state.migration;
 
 import com.hedera.node.app.service.mono.ServicesState;
@@ -6,28 +22,25 @@ import com.hedera.node.app.service.mono.state.submerkle.ExpirableTxnRecord;
 import com.hedera.node.app.service.mono.utils.EntityNum;
 import com.swirlds.fcqueue.FCQueue;
 import edu.umd.cs.findbugs.annotations.NonNull;
-
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 
 public class RecordConsolidation {
     private static final Comparator<ExpirableTxnRecord> BY_EXPIRY_THEN_CONSENSUS_TIME =
-            Comparator.comparing(ExpirableTxnRecord::getExpiry)
-                    .thenComparing(ExpirableTxnRecord::getConsensusTime);
+            Comparator.comparing(ExpirableTxnRecord::getExpiry).thenComparing(ExpirableTxnRecord::getConsensusTime);
 
     public static void toSingleFcq(@NonNull final ServicesState mutableState) {
         final var accounts = mutableState.accounts();
         if (accounts.areOnDisk()) {
-            throw new AssertionError("Not implemented");
+            toSingleFcqFromDisk(mutableState, accounts);
         } else {
             toSingleFcqFromInMemory(mutableState, accounts);
         }
     }
 
     private static void toSingleFcqFromInMemory(
-            @NonNull final ServicesState mutableState,
-            @NonNull final AccountStorageAdapter accounts) {
+            @NonNull final ServicesState mutableState, @NonNull final AccountStorageAdapter accounts) {
         final List<ExpirableTxnRecord> savedRecords = new ArrayList<>();
         final List<EntityNum> numsWithRecords = new ArrayList<>();
 
@@ -45,17 +58,34 @@ public class RecordConsolidation {
         numsWithRecords.sort(Comparator.naturalOrder());
         numsWithRecords.forEach(accounts::remove);
 
+        finishConsolidation(savedRecords, mutableState);
+    }
+
+    private static void toSingleFcqFromDisk(
+            @NonNull final ServicesState mutableState, @NonNull final AccountStorageAdapter accounts) {
+        final List<ExpirableTxnRecord> savedRecords = new ArrayList<>();
+
+        // Traverse all payer records in state and accumulate
+        final var payerRecords = accounts.getPayerRecords();
+        payerRecords.forEach((num, recordsHere) -> {
+            final var fcq = recordsHere.mutableQueue();
+            if (fcq.isEmpty()) {
+                return;
+            }
+            savedRecords.addAll(fcq);
+        });
+
+        // This overwrites the payer records in state, they will be garbage collected naturally
+        finishConsolidation(savedRecords, mutableState);
+    }
+
+    private static void finishConsolidation(
+            @NonNull final List<ExpirableTxnRecord> savedRecords, @NonNull final ServicesState mutableState) {
         // Sort and consolidate all records into a single FCQ
         savedRecords.sort(BY_EXPIRY_THEN_CONSENSUS_TIME);
         final FCQueue<ExpirableTxnRecord> consolidatedRecords = new FCQueue<>();
         consolidatedRecords.addAll(savedRecords);
         mutableState.setChild(StateChildIndices.PAYER_RECORDS_OR_CONSOLIDATED_FCQ, consolidatedRecords);
-    }
-
-    private static void toSingleFcqFromDisk(
-            @NonNull final ServicesState mutableState,
-            @NonNull final AccountStorageAdapter accounts) {
-        throw new AssertionError("Not implemented");
     }
 
     private RecordConsolidation() {

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/migration/RecordConsolidation.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/migration/RecordConsolidation.java
@@ -1,0 +1,64 @@
+package com.hedera.node.app.service.mono.state.migration;
+
+import com.hedera.node.app.service.mono.ServicesState;
+import com.hedera.node.app.service.mono.state.merkle.MerkleAccount;
+import com.hedera.node.app.service.mono.state.submerkle.ExpirableTxnRecord;
+import com.hedera.node.app.service.mono.utils.EntityNum;
+import com.swirlds.fcqueue.FCQueue;
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+
+public class RecordConsolidation {
+    private static final Comparator<ExpirableTxnRecord> BY_EXPIRY_THEN_CONSENSUS_TIME =
+            Comparator.comparing(ExpirableTxnRecord::getExpiry)
+                    .thenComparing(ExpirableTxnRecord::getConsensusTime);
+
+    public static void toSingleFcq(@NonNull final ServicesState mutableState) {
+        final var accounts = mutableState.accounts();
+        if (accounts.areOnDisk()) {
+            throw new AssertionError("Not implemented");
+        } else {
+            toSingleFcqFromInMemory(mutableState, accounts);
+        }
+    }
+
+    private static void toSingleFcqFromInMemory(
+            @NonNull final ServicesState mutableState,
+            @NonNull final AccountStorageAdapter accounts) {
+        final List<ExpirableTxnRecord> savedRecords = new ArrayList<>();
+        final List<EntityNum> numsWithRecords = new ArrayList<>();
+
+        // Traverse all accounts in state and collect their records
+        accounts.forEach((num, account) -> {
+            final var merkleAccount = (MerkleAccount) account;
+            if (merkleAccount.records().isEmpty()) {
+                return;
+            }
+            savedRecords.addAll(merkleAccount.records());
+            numsWithRecords.add(num);
+        });
+
+        // Remove all records from legacy accounts
+        numsWithRecords.sort(Comparator.naturalOrder());
+        numsWithRecords.forEach(accounts::remove);
+
+        // Sort and consolidate all records into a single FCQ
+        savedRecords.sort(BY_EXPIRY_THEN_CONSENSUS_TIME);
+        final FCQueue<ExpirableTxnRecord> consolidatedRecords = new FCQueue<>();
+        consolidatedRecords.addAll(savedRecords);
+        mutableState.setChild(StateChildIndices.PAYER_RECORDS_OR_CONSOLIDATED_FCQ, consolidatedRecords);
+    }
+
+    private static void toSingleFcqFromDisk(
+            @NonNull final ServicesState mutableState,
+            @NonNull final AccountStorageAdapter accounts) {
+        throw new AssertionError("Not implemented");
+    }
+
+    private RecordConsolidation() {
+        throw new UnsupportedOperationException("Utility Class");
+    }
+}

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/migration/RecordsStorageAdapter.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/migration/RecordsStorageAdapter.java
@@ -154,8 +154,8 @@ public class RecordsStorageAdapter {
                 mutableRecords.offer(payerRecord);
             }
             case IN_SINGLE_FCQ -> {
-                requireNonNull(records).add(payerRecord);
-                requireNonNull(queryableRecords).get(payerNum).add(payerRecord);
+                requireNonNull(records).offer(payerRecord);
+                requireNonNull(queryableRecords).get(payerNum).offer(payerRecord);
             }
         }
     }

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/migration/StateChildIndices.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/migration/StateChildIndices.java
@@ -31,7 +31,7 @@ public final class StateChildIndices {
     public static final int LEGACY_ADDRESS_BOOK = 10;
     public static final int CONTRACT_STORAGE = 11;
     public static final int STAKING_INFO = 12;
-    public static final int PAYER_RECORDS = 13;
+    public static final int PAYER_RECORDS_OR_CONSOLIDATED_FCQ = 13;
 
     public static final int NUM_025X_CHILDREN = 12;
     public static final int NUM_032X_CHILDREN = 14;

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/migration/StorageStrategy.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/migration/StorageStrategy.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.node.app.service.mono.state.migration;
+
+public enum StorageStrategy {
+    IN_ACCOUNT_CHILD_FCQ,
+    IN_PAYER_SCOPED_FCQ,
+    IN_SINGLE_FCQ
+}

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/submerkle/ExpirableTxnRecord.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/submerkle/ExpirableTxnRecord.java
@@ -37,6 +37,7 @@ import com.hedera.node.app.hapi.utils.ByteStringUtils;
 import com.hedera.node.app.service.mono.legacy.core.jproto.TxnReceipt;
 import com.hedera.node.app.service.mono.state.merkle.internals.BitPackUtils;
 import com.hedera.node.app.service.mono.state.serdes.IoUtils;
+import com.hedera.node.app.service.mono.utils.EntityNum;
 import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
 import com.hederahashgraph.api.proto.java.TokenTransferList;
 import com.hederahashgraph.api.proto.java.TransactionRecord;
@@ -461,6 +462,10 @@ public class ExpirableTxnRecord implements FastCopyable, SerializableHashable {
 
     public TxnReceipt getReceipt() {
         return receipt;
+    }
+
+    public EntityNum getPayerNum() {
+        return txnId.getPayerAccount().asNum();
     }
 
     public ResponseCodeEnum getEnumStatus() {

--- a/hedera-node/hedera-mono-service/src/main/resources/bootstrap.properties
+++ b/hedera-node/hedera-mono-service/src/main/resources/bootstrap.properties
@@ -133,6 +133,7 @@ ledger.records.maxQueryableByAccount=180
 ledger.schedule.txExpiryTimeSecs=1800
 rates.intradayChangeLimitPercent=25
 rates.midnightCheckInterval=1
+records.useConsolidatedFcq=false
 scheduling.whitelist=ConsensusSubmitMessage,CryptoTransfer,TokenMint,TokenBurn,CryptoApproveAllowance
 scheduling.longTermEnabled=false
 scheduling.maxNumber=10_000_000

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ServicesStateTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ServicesStateTest.java
@@ -111,7 +111,6 @@ import com.swirlds.platform.state.DualStateImpl;
 import com.swirlds.platform.state.signed.ReservedSignedState;
 import com.swirlds.platform.state.signed.SignedStateFileReader;
 import com.swirlds.virtualmap.VirtualMap;
-
 import java.io.File;
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -122,7 +121,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.function.Supplier;
 import java.util.function.UnaryOperator;
-
 import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
@@ -221,6 +219,7 @@ class ServicesStateTest extends ResponsibleVMapUser {
 
     @Mock
     private ServicesState.MapToDiskMigration mapToDiskMigration;
+
     @Mock
     private ServicesState.RecordConsolidator recordConsolidator;
 
@@ -797,6 +796,8 @@ class ServicesStateTest extends ResponsibleVMapUser {
                 .willReturn(true);
         given(bootstrapProperties.getBooleanProperty(PropertyNames.TOKENS_STORE_RELS_ON_DISK))
                 .willReturn(false);
+        given(bootstrapProperties.getBooleanProperty(PropertyNames.RECORDS_USE_CONSOLIDATED_FCQ))
+                .willReturn(false);
         ServicesState.setMapToDiskMigration(mapToDiskMigration);
         ServicesState.setVmFactory(vmf);
         given(vmf.get()).willReturn(virtualMapFactory);
@@ -845,6 +846,8 @@ class ServicesStateTest extends ResponsibleVMapUser {
                 .willReturn(false);
         given(bootstrapProperties.getBooleanProperty(PropertyNames.TOKENS_STORE_RELS_ON_DISK))
                 .willReturn(true);
+        given(bootstrapProperties.getBooleanProperty(PropertyNames.RECORDS_USE_CONSOLIDATED_FCQ))
+                .willReturn(false);
         ServicesState.setMapToDiskMigration(mapToDiskMigration);
         ServicesState.setVmFactory(vmf);
         given(vmf.get()).willReturn(virtualMapFactory);

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ServicesStateTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ServicesStateTest.java
@@ -803,7 +803,8 @@ class ServicesStateTest extends ResponsibleVMapUser {
         given(vmf.get()).willReturn(virtualMapFactory);
 
         final var vmap = mock(VirtualMap.class);
-        mockAllMaps(mock(MerkleMap.class), vmap);
+        final var mmap = mock(MerkleMap.class);
+        mockAllMaps(mmap, vmap);
         subject.setChild(StateChildIndices.NETWORK_CTX, networkContext);
         subject.setChild(StateChildIndices.STORAGE, vmap);
         subject.setChild(StateChildIndices.CONTRACT_STORAGE, vmap);
@@ -832,6 +833,8 @@ class ServicesStateTest extends ResponsibleVMapUser {
                         virtualMapFactory,
                         ServicesState.accountMigrator,
                         ServicesState.tokenRelMigrator);
+        subject.setChild(StateChildIndices.PAYER_RECORDS_OR_CONSOLIDATED_FCQ, mmap);
+        assertEquals(StorageStrategy.IN_PAYER_SCOPED_FCQ, subject.payerRecords().storageStrategy());
 
         ServicesState.setMapToDiskMigration(MapMigrationToDisk::migrateToDiskAsApropos);
         ServicesState.setVmFactory(VirtualMapFactory::new);

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/context/BasicTransactionContextTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/context/BasicTransactionContextTest.java
@@ -672,18 +672,6 @@ class BasicTransactionContextTest {
     }
 
     @Test
-    void addsExpiringEntities() {
-        // given:
-        var expected = Collections.singletonList(expiringEntity);
-
-        // when:
-        subject.addExpiringEntities(expected);
-
-        // then:
-        assertEquals(subject.expiringEntities(), expected);
-    }
-
-    @Test
     void throwsIfAccessorIsAlreadyTriggered() {
         given(accessor.isTriggeredTxn()).willReturn(true);
         assertThrows(IllegalStateException.class, () -> subject.trigger(accessor));

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/context/init/EntitiesInitializationFlowTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/context/init/EntitiesInitializationFlowTest.java
@@ -52,7 +52,6 @@ class EntitiesInitializationFlowTest {
 
         // then:
         verify(expiryManager).reviewExistingPayerRecords();
-        verify(expiryManager).reviewExistingShortLivedEntities();
         verify(sigImpactHistorian).invalidateCurrentWindow();
         verify(networkCtxManager).setObservableFilesNotLoaded();
         verify(networkCtxManager).loadObservableSysFilesIfNeeded();

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/context/properties/BootstrapPropertiesTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/context/properties/BootstrapPropertiesTest.java
@@ -182,6 +182,7 @@ import static com.hedera.node.app.service.mono.context.properties.PropertyNames.
 import static com.hedera.node.app.service.mono.context.properties.PropertyNames.QUERIES_BLOB_LOOK_UP_RETRIES;
 import static com.hedera.node.app.service.mono.context.properties.PropertyNames.RATES_INTRA_DAY_CHANGE_LIMIT_PERCENT;
 import static com.hedera.node.app.service.mono.context.properties.PropertyNames.RATES_MIDNIGHT_CHECK_INTERVAL;
+import static com.hedera.node.app.service.mono.context.properties.PropertyNames.RECORDS_USE_CONSOLIDATED_FCQ;
 import static com.hedera.node.app.service.mono.context.properties.PropertyNames.SCHEDULING_LONG_TERM_ENABLED;
 import static com.hedera.node.app.service.mono.context.properties.PropertyNames.SCHEDULING_MAX_EXPIRATION_FUTURE_SECS;
 import static com.hedera.node.app.service.mono.context.properties.PropertyNames.SCHEDULING_MAX_NUM;
@@ -556,7 +557,8 @@ class BootstrapPropertiesTest {
             entry(ACCOUNTS_BLOCKLIST_RESOURCE, "evm-addresses-blocklist.csv"),
             entry(STAKING_SUM_OF_CONSENSUS_WEIGHTS, 500),
             entry(CACHE_CRYPTO_TRANSFER_WARM_THREADS, 30),
-            entry(CONFIG_VERSION, 10));
+            entry(CONFIG_VERSION, 10),
+            entry(RECORDS_USE_CONSOLIDATED_FCQ, false));
 
     @Test
     void containsProperty() {

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/HederaLedgerLiveTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/HederaLedgerLiveTest.java
@@ -142,7 +142,6 @@ class HederaLedgerLiveTest extends BaseHederaLedgerTestHelper {
         subject.commit();
 
         verify(historian).saveExpirableTransactionRecords();
-        verify(historian).noteNewExpirationEvents();
     }
 
     @Test

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/records/TxnAwareRecordsHistorianTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/records/TxnAwareRecordsHistorianTest.java
@@ -29,9 +29,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyShort;
-import static org.mockito.BDDMockito.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.mock;
 import static org.mockito.BDDMockito.verify;
@@ -62,10 +60,7 @@ import com.hederahashgraph.api.proto.java.TransactionBody;
 import com.hederahashgraph.api.proto.java.TransactionID;
 import com.swirlds.common.crypto.RunningHash;
 import java.time.Instant;
-import java.util.Collections;
 import java.util.List;
-import java.util.function.Consumer;
-import org.apache.commons.lang3.tuple.Pair;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -460,43 +455,6 @@ class TxnAwareRecordsHistorianTest {
         subject.clearHistory();
 
         assertEquals(1, subject.nextChildRecordSourceId());
-    }
-
-    @Test
-    @SuppressWarnings("unchecked")
-    void tracksExpiringEntities() {
-        final Consumer<EntityId> mockConsumer = mock(Consumer.class);
-        given(expiringEntity.id()).willReturn(aEntity);
-        given(expiringEntity.consumer()).willReturn(mockConsumer);
-        given(expiringEntity.expiry()).willReturn(nows);
-        given(txnCtx.expiringEntities()).willReturn(Collections.singletonList(expiringEntity));
-
-        // when:
-        subject.noteNewExpirationEvents();
-
-        // then:
-        verify(txnCtx).expiringEntities();
-        verify(expiringEntity).id();
-        verify(expiringEntity).consumer();
-        verify(expiringEntity).expiry();
-        // and:
-        verify(expiries).trackExpirationEvent(Pair.of(aEntity.num(), mockConsumer), nows);
-    }
-
-    @Test
-    void doesNotTrackExpiringEntity() {
-        given(txnCtx.expiringEntities()).willReturn(Collections.emptyList());
-
-        // when:
-        subject.noteNewExpirationEvents();
-
-        // then:
-        verify(txnCtx).expiringEntities();
-        verify(expiringEntity, never()).id();
-        verify(expiringEntity, never()).consumer();
-        verify(expiringEntity, never()).expiry();
-        // and:
-        verify(expiries, never()).trackExpirationEvent(any(), anyLong());
     }
 
     @Test

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/records/TxnAwareRecordsHistorianTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/records/TxnAwareRecordsHistorianTest.java
@@ -40,8 +40,6 @@ import static org.mockito.internal.verification.VerificationModeFactory.times;
 import com.hedera.node.app.service.mono.context.TransactionContext;
 import com.hedera.node.app.service.mono.legacy.core.jproto.TxnReceipt;
 import com.hedera.node.app.service.mono.state.expiry.ExpiringCreations;
-import com.hedera.node.app.service.mono.state.expiry.ExpiringEntity;
-import com.hedera.node.app.service.mono.state.expiry.ExpiryManager;
 import com.hedera.node.app.service.mono.state.submerkle.CurrencyAdjustments;
 import com.hedera.node.app.service.mono.state.submerkle.EntityId;
 import com.hedera.node.app.service.mono.state.submerkle.ExpirableTxnRecord;
@@ -104,13 +102,7 @@ class TxnAwareRecordsHistorianTest {
     private RecordCache recordCache;
 
     @Mock
-    private ExpiryManager expiries;
-
-    @Mock
     private ExpiringCreations creator;
-
-    @Mock
-    private ExpiringEntity expiringEntity;
 
     @Mock
     private TransactionContext txnCtx;
@@ -131,7 +123,7 @@ class TxnAwareRecordsHistorianTest {
 
     @BeforeEach
     void setUp() {
-        subject = new TxnAwareRecordsHistorian(recordCache, txnCtx, expiries, consensusTimeTracker);
+        subject = new TxnAwareRecordsHistorian(recordCache, txnCtx, consensusTimeTracker);
         subject.setCreator(creator);
     }
 

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/migration/AccountStorageAdapterTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/migration/AccountStorageAdapterTest.java
@@ -72,6 +72,7 @@ class AccountStorageAdapterTest {
         assertTrue(subject.areOnDisk());
         assertNull(subject.getInMemoryAccounts());
         assertNotNull(subject.getOnDiskAccounts());
+        assertNotNull(subject.getPayerRecords());
     }
 
     @Test
@@ -80,6 +81,7 @@ class AccountStorageAdapterTest {
         assertFalse(subject.areOnDisk());
         assertNotNull(subject.getInMemoryAccounts());
         assertNull(subject.getOnDiskAccounts());
+        assertNull(subject.getPayerRecords());
     }
 
     @Test

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/migration/AccountStorageAdapterTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/migration/AccountStorageAdapterTest.java
@@ -17,17 +17,23 @@
 package com.hedera.node.app.service.mono.state.migration;
 
 import static com.swirlds.common.threading.manager.AdHocThreadManager.getStaticThreadManager;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willAnswer;
 import static org.mockito.BDDMockito.willThrow;
 import static org.mockito.Mockito.verify;
 
 import com.hedera.node.app.service.mono.state.adapters.MerkleMapLike;
 import com.hedera.node.app.service.mono.state.adapters.VirtualMapLike;
 import com.hedera.node.app.service.mono.state.merkle.MerkleAccount;
-import com.hedera.node.app.service.mono.state.merkle.MerklePayerRecords;
 import com.hedera.node.app.service.mono.state.virtual.EntityNumVirtualKey;
 import com.hedera.node.app.service.mono.state.virtual.entities.OnDiskAccount;
 import com.hedera.node.app.service.mono.utils.EntityNum;
@@ -39,24 +45,23 @@ import java.util.function.BiConsumer;
 import org.apache.commons.lang3.tuple.Pair;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 class AccountStorageAdapterTest {
     private static final EntityNum SOME_NUM = EntityNum.fromInt(1234);
+    private static final EntityNum SOME_OTHER_NUM = EntityNum.fromInt(2345);
+    private static final EntityNum YET_ANOTHER_NUM = EntityNum.fromInt(3456);
     private static final Hash SOME_HASH = new Hash();
     private static final Set<EntityNum> SOME_KEY_SET = Set.of(SOME_NUM);
+    private static final Set<EntityNum> SOME_ON_DISK_KEY_SET = Set.of(SOME_NUM, SOME_OTHER_NUM, YET_ANOTHER_NUM);
     private static final EntityNumVirtualKey SOME_KEY = EntityNumVirtualKey.from(SOME_NUM);
     private static final MerkleAccount IN_MEMORY_STAND_IN = new MerkleAccount();
     private final OnDiskAccount onDiskStandIn = new OnDiskAccount();
 
     @Mock
     private MerkleMap<EntityNum, MerkleAccount> inMemoryAccounts;
-
-    @Mock
-    private MerkleMap<EntityNum, MerklePayerRecords> payerRecords;
 
     @Mock
     private VirtualMapLike<EntityNumVirtualKey, OnDiskAccount> onDiskAccounts;
@@ -72,7 +77,6 @@ class AccountStorageAdapterTest {
         assertTrue(subject.areOnDisk());
         assertNull(subject.getInMemoryAccounts());
         assertNotNull(subject.getOnDiskAccounts());
-        assertNotNull(subject.getPayerRecords());
     }
 
     @Test
@@ -81,7 +85,6 @@ class AccountStorageAdapterTest {
         assertFalse(subject.areOnDisk());
         assertNotNull(subject.getInMemoryAccounts());
         assertNull(subject.getOnDiskAccounts());
-        assertNull(subject.getPayerRecords());
     }
 
     @Test
@@ -170,13 +173,6 @@ class AccountStorageAdapterTest {
     }
 
     @Test
-    void keySetIdentifiesOnDisk() {
-        withOnDiskSubject();
-        given(payerRecords.keySet()).willReturn(SOME_KEY_SET);
-        assertSame(SOME_KEY_SET, subject.keySet());
-    }
-
-    @Test
     void keySetIdentifiesInMemory() {
         withInMemorySubject();
         given(inMemoryAccounts.keySet()).willReturn(SOME_KEY_SET);
@@ -193,13 +189,20 @@ class AccountStorageAdapterTest {
     @Test
     @SuppressWarnings("unchecked")
     void onDiskForEachDelegates() throws InterruptedException {
-        final ArgumentCaptor<InterruptableConsumer<Pair<EntityNumVirtualKey, OnDiskAccount>>> captor =
-                ArgumentCaptor.forClass(InterruptableConsumer.class);
         withOnDiskSubject();
-        subject.forEach(visitor);
-        verify(onDiskAccounts).extractVirtualMapData(eq(getStaticThreadManager()), captor.capture(), eq(32));
-        captor.getValue().accept(Pair.of(SOME_KEY, onDiskStandIn));
-        verify(visitor).accept(SOME_NUM, onDiskStandIn);
+        willAnswer(invocation -> {
+                    final var observer = invocation.getArgument(1, InterruptableConsumer.class);
+                    observer.accept(Pair.of(SOME_KEY, onDiskStandIn));
+                    observer.accept(Pair.of(EntityNumVirtualKey.from(SOME_OTHER_NUM), onDiskStandIn));
+                    observer.accept(Pair.of(EntityNumVirtualKey.from(YET_ANOTHER_NUM), onDiskStandIn));
+                    return null;
+                })
+                .given(onDiskAccounts)
+                .extractVirtualMapData(eq(getStaticThreadManager()), any(InterruptableConsumer.class), eq(32));
+
+        final var actual = subject.keySet();
+
+        assertEquals(SOME_ON_DISK_KEY_SET, actual);
     }
 
     @Test
@@ -217,6 +220,6 @@ class AccountStorageAdapterTest {
     }
 
     private void withOnDiskSubject() {
-        subject = AccountStorageAdapter.fromOnDisk(MerkleMapLike.from(payerRecords), onDiskAccounts);
+        subject = AccountStorageAdapter.fromOnDisk(onDiskAccounts);
     }
 }

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/migration/MapMigrationToDiskTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/migration/MapMigrationToDiskTest.java
@@ -109,7 +109,7 @@ class MapMigrationToDiskTest {
                 1, mutableState, accountsOnly, virtualMapFactory, accountMigrator, tokenRelMigrator);
 
         verify(mutableState).setChild(ACCOUNTS, accountStore);
-        verify(mutableState).setChild(eq(StateChildIndices.PAYER_RECORDS), captor.capture());
+        verify(mutableState).setChild(eq(StateChildIndices.PAYER_RECORDS_OR_CONSOLIDATED_FCQ), captor.capture());
         final var payerRecords = captor.getValue();
         final var aRecords = payerRecords.get(aNum);
         final var bRecords = payerRecords.get(bNum);

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/migration/RecordConsolidationTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/migration/RecordConsolidationTest.java
@@ -1,4 +1,27 @@
+/*
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.hedera.node.app.service.mono.state.migration;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentCaptor.forClass;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
 
 import com.hedera.node.app.service.mono.ServicesState;
 import com.hedera.node.app.service.mono.state.adapters.MerkleMapLike;
@@ -13,6 +36,11 @@ import com.swirlds.common.constructable.ConstructableRegistry;
 import com.swirlds.common.constructable.ConstructableRegistryException;
 import com.swirlds.fcqueue.FCQueue;
 import com.swirlds.merkle.map.MerkleMap;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Queue;
 import org.apache.commons.lang3.tuple.Pair;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -20,23 +48,11 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Queue;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentCaptor.forClass;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.verify;
-
 @ExtendWith(MockitoExtension.class)
 class RecordConsolidationTest {
     @Mock
     private ServicesState mutableState;
+
     @Mock
     private AccountStorageAdapter accounts;
 
@@ -51,14 +67,12 @@ class RecordConsolidationTest {
         final int maxRecordsPerAccount = 5;
         final var accountsAndRecords = randomLegacyAccounts(numAccounts, maxRecordsPerAccount);
 
-        given(mutableState.accounts()).willReturn(
-                AccountStorageAdapter.fromInMemory(MerkleMapLike.from(accountsAndRecords.getKey())));
+        given(mutableState.accounts())
+                .willReturn(AccountStorageAdapter.fromInMemory(MerkleMapLike.from(accountsAndRecords.getKey())));
 
         RecordConsolidation.toSingleFcq(mutableState);
 
-        verify(mutableState).setChild(
-                eq(StateChildIndices.PAYER_RECORDS_OR_CONSOLIDATED_FCQ),
-                recordsCaptor.capture());
+        verify(mutableState).setChild(eq(StateChildIndices.PAYER_RECORDS_OR_CONSOLIDATED_FCQ), recordsCaptor.capture());
         final var capturedRecords = recordsCaptor.getValue();
         assertEquals(accountsAndRecords.getValue(), new LinkedList<>(capturedRecords));
 
@@ -84,13 +98,9 @@ class RecordConsolidationTest {
 
         RecordConsolidation.toSingleFcq(mutableState);
 
-        verify(mutableState).setChild(
-                eq(StateChildIndices.PAYER_RECORDS_OR_CONSOLIDATED_FCQ),
-                recordsCaptor.capture());
+        verify(mutableState).setChild(eq(StateChildIndices.PAYER_RECORDS_OR_CONSOLIDATED_FCQ), recordsCaptor.capture());
         final var capturedRecords = recordsCaptor.getValue();
         assertEquals(payerAndAllRecords.getValue(), new LinkedList<>(capturedRecords));
-
-        assertTrue(payerAndAllRecords.getKey().isEmpty());
     }
 
     private Pair<MerkleMap<EntityNum, MerkleAccount>, Queue<ExpirableTxnRecord>> randomLegacyAccounts(

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/migration/RecordConsolidationTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/migration/RecordConsolidationTest.java
@@ -93,7 +93,8 @@ class RecordConsolidationTest {
         final var payerAndAllRecords = randomPayerRecords(numAccounts, maxRecordsPerAccount);
 
         given(accounts.areOnDisk()).willReturn(true);
-        given(accounts.getPayerRecords()).willReturn(MerkleMapLike.from(payerAndAllRecords.getKey()));
+        given(mutableState.getChild(StateChildIndices.PAYER_RECORDS_OR_CONSOLIDATED_FCQ))
+                .willReturn(payerAndAllRecords.getKey());
         given(mutableState.accounts()).willReturn(accounts);
 
         RecordConsolidation.toSingleFcq(mutableState);

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/migration/RecordConsolidationTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/migration/RecordConsolidationTest.java
@@ -1,0 +1,136 @@
+package com.hedera.node.app.service.mono.state.migration;
+
+import com.hedera.node.app.service.mono.ServicesState;
+import com.hedera.node.app.service.mono.state.adapters.MerkleMapLike;
+import com.hedera.node.app.service.mono.state.merkle.MerkleAccount;
+import com.hedera.node.app.service.mono.state.merkle.MerkleAccountState;
+import com.hedera.node.app.service.mono.state.merkle.MerklePayerRecords;
+import com.hedera.node.app.service.mono.state.submerkle.ExpirableTxnRecord;
+import com.hedera.node.app.service.mono.utils.EntityNum;
+import com.hedera.test.utils.SeededPropertySource;
+import com.swirlds.common.constructable.ClassConstructorPair;
+import com.swirlds.common.constructable.ConstructableRegistry;
+import com.swirlds.common.constructable.ConstructableRegistryException;
+import com.swirlds.fcqueue.FCQueue;
+import com.swirlds.merkle.map.MerkleMap;
+import org.apache.commons.lang3.tuple.Pair;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Queue;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentCaptor.forClass;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class RecordConsolidationTest {
+    @Mock
+    private ServicesState mutableState;
+    @Mock
+    private AccountStorageAdapter accounts;
+
+    @Test
+    void canMigrateFromLegacyAccounts() throws ConstructableRegistryException {
+        ConstructableRegistry.getInstance()
+                .registerConstructable(new ClassConstructorPair(MerkleAccount.class, MerkleAccount::new));
+
+        final ArgumentCaptor<FCQueue<ExpirableTxnRecord>> recordsCaptor = forClass(FCQueue.class);
+
+        final int numAccounts = 20;
+        final int maxRecordsPerAccount = 5;
+        final var accountsAndRecords = randomLegacyAccounts(numAccounts, maxRecordsPerAccount);
+
+        given(mutableState.accounts()).willReturn(
+                AccountStorageAdapter.fromInMemory(MerkleMapLike.from(accountsAndRecords.getKey())));
+
+        RecordConsolidation.toSingleFcq(mutableState);
+
+        verify(mutableState).setChild(
+                eq(StateChildIndices.PAYER_RECORDS_OR_CONSOLIDATED_FCQ),
+                recordsCaptor.capture());
+        final var capturedRecords = recordsCaptor.getValue();
+        assertEquals(accountsAndRecords.getValue(), new LinkedList<>(capturedRecords));
+
+        accountsAndRecords.getKey().forEach((num, account) -> {
+            assertTrue(account.records().isEmpty());
+        });
+    }
+
+    @Test
+    void canMigrateFromOnDiskAccounts() throws ConstructableRegistryException {
+        ConstructableRegistry.getInstance()
+                .registerConstructable(new ClassConstructorPair(MerklePayerRecords.class, MerklePayerRecords::new));
+
+        final ArgumentCaptor<FCQueue<ExpirableTxnRecord>> recordsCaptor = forClass(FCQueue.class);
+
+        final int numAccounts = 20;
+        final int maxRecordsPerAccount = 5;
+        final var payerAndAllRecords = randomPayerRecords(numAccounts, maxRecordsPerAccount);
+
+        given(accounts.areOnDisk()).willReturn(true);
+        given(accounts.getPayerRecords()).willReturn(MerkleMapLike.from(payerAndAllRecords.getKey()));
+        given(mutableState.accounts()).willReturn(accounts);
+
+        RecordConsolidation.toSingleFcq(mutableState);
+
+        verify(mutableState).setChild(
+                eq(StateChildIndices.PAYER_RECORDS_OR_CONSOLIDATED_FCQ),
+                recordsCaptor.capture());
+        final var capturedRecords = recordsCaptor.getValue();
+        assertEquals(payerAndAllRecords.getValue(), new LinkedList<>(capturedRecords));
+
+        assertTrue(payerAndAllRecords.getKey().isEmpty());
+    }
+
+    private Pair<MerkleMap<EntityNum, MerkleAccount>, Queue<ExpirableTxnRecord>> randomLegacyAccounts(
+            final int numAccounts, final int maxRecordsPerAccount) {
+        final MerkleMap<EntityNum, MerkleAccount> accounts = new MerkleMap<>();
+        final var propertySource = SeededPropertySource.forSerdeTest(14, 1);
+        final List<ExpirableTxnRecord> allRecords = new ArrayList<>();
+        for (int i = 0; i < numAccounts; i++) {
+            final FCQueue<ExpirableTxnRecord> recordsHere = new FCQueue<>();
+            for (int j = 0, n = propertySource.nextInt(maxRecordsPerAccount); j < n; j++) {
+                final var nextRecord = propertySource.nextRecord();
+                recordsHere.add(nextRecord);
+                allRecords.add(nextRecord);
+            }
+            final var account = new MerkleAccount(List.of(new MerkleAccountState(), recordsHere));
+            accounts.put(EntityNum.fromInt(i), account);
+        }
+        allRecords.sort(Comparator.comparing(ExpirableTxnRecord::getExpiry)
+                .thenComparing(ExpirableTxnRecord::getConsensusTime));
+        return Pair.of(accounts, new LinkedList<>(allRecords));
+    }
+
+    private Pair<MerkleMap<EntityNum, MerklePayerRecords>, Queue<ExpirableTxnRecord>> randomPayerRecords(
+            final int numAccounts, final int maxRecordsPerAccount) {
+        final MerkleMap<EntityNum, MerklePayerRecords> payerRecords = new MerkleMap<>();
+        final var propertySource = SeededPropertySource.forSerdeTest(14, 1);
+        final List<ExpirableTxnRecord> allRecords = new ArrayList<>();
+        for (int i = 0; i < numAccounts; i++) {
+            final FCQueue<ExpirableTxnRecord> recordsHere = new FCQueue<>();
+            for (int j = 0, n = propertySource.nextInt(maxRecordsPerAccount); j < n; j++) {
+                final var nextRecord = propertySource.nextRecord();
+                recordsHere.add(nextRecord);
+                allRecords.add(nextRecord);
+            }
+            final var thesePayerRecords = new MerklePayerRecords();
+            thesePayerRecords.mutableQueue().addAll(recordsHere);
+            payerRecords.put(EntityNum.fromInt(i), thesePayerRecords);
+        }
+        allRecords.sort(Comparator.comparing(ExpirableTxnRecord::getExpiry)
+                .thenComparing(ExpirableTxnRecord::getConsensusTime));
+        return Pair.of(payerRecords, new LinkedList<>(allRecords));
+    }
+}

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/migration/RecordsStorageAdapterTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/migration/RecordsStorageAdapterTest.java
@@ -33,6 +33,7 @@ import com.hedera.test.utils.SeededPropertySource;
 import com.swirlds.fcqueue.FCQueue;
 import com.swirlds.merkle.map.MerkleMap;
 import edu.umd.cs.findbugs.annotations.Nullable;
+import java.util.Queue;
 import java.util.function.BiConsumer;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -57,7 +58,7 @@ class RecordsStorageAdapterTest {
     private MerklePayerRecords accountRecords;
 
     @Mock
-    private BiConsumer<EntityNum, FCQueue<ExpirableTxnRecord>> observer;
+    private BiConsumer<EntityNum, Queue<ExpirableTxnRecord>> observer;
 
     private RecordsStorageAdapter subject;
 

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/migration/RecordsStorageAdapterTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/migration/RecordsStorageAdapterTest.java
@@ -210,6 +210,13 @@ class RecordsStorageAdapterTest {
     }
 
     @Test
+    void gettingReadOnlyForNoQueryableWithConsolidatedPayerWorks() {
+        withConsolidatedSubject();
+        final var queryable = subject.getReadOnlyPayerRecords(SOME_NUM);
+        assertSame(QueryableRecords.NO_QUERYABLE_RECORDS, queryable);
+    }
+
+    @Test
     void gettingReadOnlyWithLegacyPayerWorks() {
         withLegacySubject();
         final var aRecord = SeededPropertySource.forSerdeTest(11, 1).nextRecord();

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/schedule/ScheduleCreateTransitionLogicTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/schedule/ScheduleCreateTransitionLogicTest.java
@@ -187,7 +187,6 @@ class ScheduleCreateTransitionLogicTest {
         verify(store).createProvisionally(scheduleValue, RichInstant.fromJava(now));
         verify(replSigningWitness).observeInScope(schedule, store, validScheduleKeys, activationHelper, false);
         verify(store).commitCreation();
-        verify(txnCtx, never()).addExpiringEntities(any());
         verify(txnCtx).setStatus(SUCCESS);
         verify(txnCtx).setScheduledTxnId(scheduledTxnId);
         verify(sigImpactHistorian).markEntityChanged(schedule.getScheduleNum());
@@ -210,7 +209,6 @@ class ScheduleCreateTransitionLogicTest {
         subject.doStateTransition();
 
         verify(store).commitCreation();
-        verify(txnCtx, never()).addExpiringEntities(any());
         verify(txnCtx).setStatus(SUCCESS);
         verify(txnCtx).setScheduledTxnId(scheduledTxnId);
         verify(executor, never()).processImmediateExecution(schedule, store, txnCtx);
@@ -237,7 +235,6 @@ class ScheduleCreateTransitionLogicTest {
         verify(replSigningWitness).observeInScope(schedule, store, validScheduleKeys, activationHelper, true);
         verify(replSigningWitness, never()).observeInScope(any(), any(), any(), any(), eq(false));
         verify(store).commitCreation();
-        verify(txnCtx, never()).addExpiringEntities(any());
         verify(txnCtx).setStatus(SUCCESS);
         verify(txnCtx).setScheduledTxnId(scheduledTxnId);
         verify(sigImpactHistorian).markEntityChanged(schedule.getScheduleNum());
@@ -262,7 +259,6 @@ class ScheduleCreateTransitionLogicTest {
         verify(replSigningWitness).observeInScope(schedule, store, validScheduleKeys, activationHelper, false);
         verify(replSigningWitness, never()).observeInScope(any(), any(), any(), any(), eq(true));
         verify(store).commitCreation();
-        verify(txnCtx, never()).addExpiringEntities(any());
         verify(txnCtx).setStatus(SUCCESS);
         verify(txnCtx).setScheduledTxnId(scheduledTxnId);
         verify(sigImpactHistorian).markEntityChanged(schedule.getScheduleNum());
@@ -276,7 +272,6 @@ class ScheduleCreateTransitionLogicTest {
         subject.doStateTransition();
 
         verify(store).lookupSchedule(bodyBytes);
-        verify(txnCtx, never()).addExpiringEntities(any());
         verify(txnCtx).setStatus(MAX_ENTITIES_IN_PRICE_REGIME_HAVE_BEEN_CREATED);
     }
 
@@ -290,7 +285,6 @@ class ScheduleCreateTransitionLogicTest {
 
         verify(store, never()).createProvisionally(any(), any());
         verify(store, never()).commitCreation();
-        verify(txnCtx, never()).addExpiringEntities(any());
         verify(txnCtx).setStatus(IDENTICAL_SCHEDULE_ALREADY_CREATED);
         verify(txnCtx).setCreated(schedule);
         verify(txnCtx).setScheduledTxnId(scheduledTxnId);

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/utils/UtilsConstructorTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/utils/UtilsConstructorTest.java
@@ -54,6 +54,7 @@ import com.hedera.node.app.service.mono.state.merkle.MerkleAccount;
 import com.hedera.node.app.service.mono.state.merkle.internals.BitPackUtils;
 import com.hedera.node.app.service.mono.state.merkle.internals.ByteUtils;
 import com.hedera.node.app.service.mono.state.migration.MapMigrationToDisk;
+import com.hedera.node.app.service.mono.state.migration.RecordConsolidation;
 import com.hedera.node.app.service.mono.state.migration.StakingInfoMapBuilder;
 import com.hedera.node.app.service.mono.state.migration.StateChildIndices;
 import com.hedera.node.app.service.mono.state.migration.StateVersions;
@@ -127,6 +128,7 @@ class UtilsConstructorTest {
             MerkleAccount.ChildIndices.class,
             BitPackUtils.class,
             MapMigrationToDisk.class,
+            RecordConsolidation.class,
             StateChildIndices.class,
             StateVersions.class,
             ExpiryStats.Names.class,

--- a/hedera-node/hedera-mono-service/src/test/resources/bootstrap.properties
+++ b/hedera-node/hedera-mono-service/src/test/resources/bootstrap.properties
@@ -132,6 +132,7 @@ ledger.records.maxQueryableByAccount=180
 ledger.schedule.txExpiryTimeSecs=1800
 rates.intradayChangeLimitPercent=25
 rates.midnightCheckInterval=1
+records.useConsolidatedFcq=false
 scheduling.whitelist=ConsensusSubmitMessage,CryptoTransfer,TokenMint,TokenBurn,CryptoApproveAllowance
 scheduling.longTermEnabled=false
 scheduling.maxNumber=10_000_000

--- a/hedera-node/hedera-mono-service/src/test/resources/bootstrap/standard.properties
+++ b/hedera-node/hedera-mono-service/src/test/resources/bootstrap/standard.properties
@@ -131,6 +131,7 @@ ledger.records.maxQueryableByAccount=180
 ledger.schedule.txExpiryTimeSecs=1800
 rates.intradayChangeLimitPercent=25
 rates.midnightCheckInterval=1
+records.useConsolidatedFcq=false
 scheduling.whitelist=ConsensusSubmitMessage,CryptoTransfer,TokenMint,TokenBurn
 scheduling.longTermEnabled=false
 scheduling.maxNumber=10_000_000


### PR DESCRIPTION
**Description**:
 - Adds static property `records.useConsolidatedFcq=false` that when switched to `true`,
    * On `RESTART`, migrates all records in state into a single top-level `FCQueue<ExpirableTxnRecord>`; and,
    * At `GENESIS`, simply creates this top-level `FCQ`.
- Preserves ability to answer `getAccountRecords()` query by also keeping a rebuilt `Map<EntityNum, Queue<ExpirableTxnRecord>>`; this is **intentionally** not a `FCHashMap` copied with the `ServicesState` lifecycle, because the `getAccountRecords()` query is only best-effort and any extra overhead is unnecessary.
- Uses a `StorageStrategy` enum (`IN_ACCOUNT_CHILD_FCQ` ,`IN_PAYER_SCOPED_FCQ`, or `IN_SINGLE_FCQ`) to toggle internals of `RecordsStorageAdapter` given the choices of record storage.
- Refactors `ExpiryManager` to only use its own re-built expiration queue when the strategy is **not** `IN_SINGLE_FCQ`; when there is a single `FCQ` in state, it needs no help here.
- Removes some now-obsolete methods in `TransactionContext` and `RecordsHistorian` for managing short-lived scheduled transactions.