### PR TITLE
Use instantaneous capacity checks for gauges and `TraceabilityExportTask`

### DIFF
--- a/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/throttles/BucketThrottle.java
+++ b/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/throttles/BucketThrottle.java
@@ -151,6 +151,15 @@ public class BucketThrottle {
         return 100.0 * (used - Math.min(used, effectiveLeak(givenElapsedNanos))) / bucket.totalCapacity();
     }
 
+    /**
+     * Returns the percent of the throttle bucket's capacity that is used at this instant.
+     *
+     * @return the percent of the bucket that is used
+     */
+    public double instantaneousPercentUsed() {
+        return 100.0 * bucket.capacityUsed() / bucket.totalCapacity();
+    }
+
     private long effectiveLeak(final long elapsedNanos) {
         return productWouldOverflow(elapsedNanos, mtps) ? bucket.totalCapacity() : elapsedNanos * mtps;
     }

--- a/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/throttles/DeterministicThrottle.java
+++ b/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/throttles/DeterministicThrottle.java
@@ -172,6 +172,19 @@ public class DeterministicThrottle implements CongestibleThrottle {
         return delegate.percentUsed(elapsedNanos);
     }
 
+    /**
+     * Returns the percent usage of this throttle, at the time of the last throttling decision, or
+     * zero if no throttling decision has been made.
+     *
+     * @return the percent usage at the time of the last throttling decision
+     */
+    public double instantaneousPercentUsed() {
+        if (lastDecisionTime == null) {
+            return 0.0;
+        }
+        return delegate.instantaneousPercentUsed();
+    }
+
     public void resetUsageTo(final UsageSnapshot usageSnapshot) {
         final var bucket = delegate.bucket();
         lastDecisionTime = usageSnapshot.lastDecisionTime();

--- a/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/throttles/GasLimitBucketThrottle.java
+++ b/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/throttles/GasLimitBucketThrottle.java
@@ -79,6 +79,15 @@ public class GasLimitBucketThrottle {
     }
 
     /**
+     * Returns the percent of the throttle bucket's capacity that is used, as of the last throttling decision.
+     *
+     * @return the percent of the bucket that is used
+     */
+    double instantaneousPercentUsed() {
+        return 100.0 * bucket.capacityUsed() / bucket.totalCapacity();
+    }
+
+    /**
      * Returns the approximate ratio of free-to-used capacity in the underlying bucket; if there is
      * no capacity used, returns {@code Long.MAX_VALUE}
      *

--- a/hedera-node/hapi-utils/src/test/java/com/hedera/node/app/hapi/utils/throttles/BucketThrottleTest.java
+++ b/hedera-node/hapi-utils/src/test/java/com/hedera/node/app/hapi/utils/throttles/BucketThrottleTest.java
@@ -241,6 +241,18 @@ class BucketThrottleTest {
     }
 
     @Test
+    void hasExpectedInstantaneousPercentUsed() {
+        int mtps = 500;
+        int burstPeriod = 2;
+
+        var subject = BucketThrottle.withMtpsAndBurstPeriod(mtps, burstPeriod);
+        final var totalCap = subject.bucket().totalCapacity();
+        subject.bucket().useCapacity(totalCap / 2);
+
+        assertEquals(50.0, subject.instantaneousPercentUsed());
+    }
+
+    @Test
     void canReclaimCapacity() {
         // setup:
         int mtps = 500;

--- a/hedera-node/hapi-utils/src/test/java/com/hedera/node/app/hapi/utils/throttles/DeterministicThrottleTest.java
+++ b/hedera-node/hapi-utils/src/test/java/com/hedera/node/app/hapi/utils/throttles/DeterministicThrottleTest.java
@@ -133,6 +133,15 @@ class DeterministicThrottleTest {
     }
 
     @Test
+    void canGetInstantaneousPercentUsed() {
+        final var now = Instant.ofEpochSecond(1_234_567L);
+        final var subject = DeterministicThrottle.withMtpsAndBurstPeriod(500, 4);
+        assertEquals(0.0, subject.instantaneousPercentUsed());
+        subject.allow(1, now.plusNanos(1));
+        assertEquals(50.0, subject.instantaneousPercentUsed());
+    }
+
+    @Test
     void throttlesWithinPermissibleTolerance() throws InterruptedException {
         final long mtps = 123_456L;
         final var subject = DeterministicThrottle.withMtps(mtps);

--- a/hedera-node/hapi-utils/src/test/java/com/hedera/node/app/hapi/utils/throttles/GasLimitBucketThrottleTest.java
+++ b/hedera-node/hapi-utils/src/test/java/com/hedera/node/app/hapi/utils/throttles/GasLimitBucketThrottleTest.java
@@ -41,6 +41,14 @@ class GasLimitBucketThrottleTest {
     }
 
     @Test
+    void hasExpectedInstantaneousPercentUsed() {
+        final var capacity = 1_000_000;
+        var subject = new GasLimitBucketThrottle(capacity);
+        subject.bucket().useCapacity(capacity / 2);
+        assertEquals(50.0, subject.instantaneousPercentUsed());
+    }
+
+    @Test
     void hasExpectedUsageRatio() {
         final var capacity = 1_000_000;
         var subject = new GasLimitBucketThrottle(capacity);

--- a/hedera-node/hapi-utils/src/test/java/com/hedera/node/app/hapi/utils/throttles/GasLimitDeterministicThrottleTest.java
+++ b/hedera-node/hapi-utils/src/test/java/com/hedera/node/app/hapi/utils/throttles/GasLimitDeterministicThrottleTest.java
@@ -70,23 +70,30 @@ class GasLimitDeterministicThrottleTest {
     }
 
     @Test
+    void canGetInstantaneousPercentUsed() {
+        final var now = Instant.ofEpochSecond(1_234_567L);
+        final var capacity = 1_000_000;
+        final var subject = new GasLimitDeterministicThrottle(capacity);
+        assertEquals(0.0, subject.instantaneousPercentUsed());
+        subject.allow(now, capacity / 2);
+        assertEquals(50.0, subject.instantaneousPercentUsed());
+    }
+
+    @Test
     void canGetFreeToUsedRatio() {
         final var now = Instant.ofEpochSecond(1_234_567L);
         final var capacity = 1_000_000;
         final var subject = new GasLimitDeterministicThrottle(capacity);
         subject.allow(now, capacity / 4);
-        assertEquals(3, subject.freeToUsedRatio(now));
+        assertEquals(3, subject.instantaneousFreeToUsedRatio());
     }
 
     @Test
     void leaksUntilNowBeforeEstimatingFreeToUsed() {
         final var now = Instant.ofEpochSecond(1_234_567L);
-        final var then = now.plusSeconds(1234);
         final var capacity = 1_000_000;
         final var subject = new GasLimitDeterministicThrottle(capacity);
-        subject.allow(now, capacity / 4);
-        assertEquals(Long.MAX_VALUE, subject.freeToUsedRatio(then));
-        assertEquals(then, subject.getLastDecisionTime());
+        assertEquals(Long.MAX_VALUE, subject.instantaneousFreeToUsedRatio());
     }
 
     @Test

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/tasks/TraceabilityExportTask.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/state/tasks/TraceabilityExportTask.java
@@ -130,7 +130,7 @@ public class TraceabilityExportTask implements SystemTask {
             firstTime = false;
         }
 
-        if (!recordsHelper.canExportNow() || needsBackPressure(now, curNetworkCtx)) {
+        if (!recordsHelper.canExportNow() || needsBackPressure(curNetworkCtx)) {
             return NEEDS_DIFFERENT_CONTEXT;
         }
         // It would be a lot of work to split even a single sidecar's construction across
@@ -163,13 +163,13 @@ public class TraceabilityExportTask implements SystemTask {
         throw new UnsupportedOperationException();
     }
 
-    private boolean needsBackPressure(final Instant now, final MerkleNetworkContext curNetworkCtx) {
-        return inHighGasRegime(now)
+    private boolean needsBackPressure(final MerkleNetworkContext curNetworkCtx) {
+        return inHighGasRegime()
                 || curNetworkCtx.getEntitiesTouchedThisSecond() >= dynamicProperties.traceabilityMaxExportsPerConsSec();
     }
 
-    private boolean inHighGasRegime(final Instant now) {
-        return handleThrottling.gasLimitThrottle().freeToUsedRatio(now)
+    private boolean inHighGasRegime() {
+        return handleThrottling.gasLimitThrottle().instantaneousFreeToUsedRatio()
                 < dynamicProperties.traceabilityMinFreeToUsedGasThrottleRatio();
     }
 

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/tasks/TraceabilityExportTaskTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/tasks/TraceabilityExportTaskTest.java
@@ -154,7 +154,7 @@ class TraceabilityExportTaskTest {
         given(recordsHelper.canExportNow()).willReturn(true);
         given(dynamicProperties.traceabilityMinFreeToUsedGasThrottleRatio()).willReturn(5L);
         given(throttling.gasLimitThrottle()).willReturn(gasThrottle);
-        given(gasThrottle.freeToUsedRatio(NOW)).willReturn(4L);
+        given(gasThrottle.instantaneousFreeToUsedRatio()).willReturn(4L);
 
         assertEquals(SystemTaskResult.NEEDS_DIFFERENT_CONTEXT, subject.process(ENTITY_NUM, NOW, networkCtx));
     }
@@ -164,7 +164,7 @@ class TraceabilityExportTaskTest {
         given(recordsHelper.canExportNow()).willReturn(true);
         given(dynamicProperties.traceabilityMinFreeToUsedGasThrottleRatio()).willReturn(5L);
         given(throttling.gasLimitThrottle()).willReturn(gasThrottle);
-        given(gasThrottle.freeToUsedRatio(NOW)).willReturn(6L);
+        given(gasThrottle.instantaneousFreeToUsedRatio()).willReturn(6L);
         given(networkCtx.getEntitiesTouchedThisSecond()).willReturn(21L);
         given(dynamicProperties.traceabilityMaxExportsPerConsSec()).willReturn(20L);
 

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/stats/ThrottleGaugesTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/stats/ThrottleGaugesTest.java
@@ -95,10 +95,10 @@ class ThrottleGaugesTest {
         givenThrottleCollabs();
         given(hapiThrottling.gasLimitThrottle()).willReturn(hapiGasThrottle);
         given(handleThrottling.gasLimitThrottle()).willReturn(consGasThrottle);
-        given(aThrottle.percentUsed(any())).willReturn(10.0);
-        given(bThrottle.percentUsed(any())).willReturn(50.0);
-        given(consGasThrottle.percentUsed(any())).willReturn(33.0);
-        given(hapiGasThrottle.percentUsed(any())).willReturn(13.0);
+        given(aThrottle.instantaneousPercentUsed()).willReturn(10.0);
+        given(bThrottle.instantaneousPercentUsed()).willReturn(50.0);
+        given(consGasThrottle.instantaneousPercentUsed()).willReturn(33.0);
+        given(hapiGasThrottle.instantaneousPercentUsed()).willReturn(13.0);
         final var platformContext = mock(PlatformContext.class);
         given(platform.getContext()).willReturn(platformContext);
         given(platformContext.getMetrics()).willReturn(metrics);
@@ -107,18 +107,18 @@ class ThrottleGaugesTest {
         subject.registerWith(platform);
         subject.updateAll();
 
-        verify(aThrottle, times(2)).percentUsed(any());
-        verify(bThrottle, times(1)).percentUsed(any());
-        verify(consGasThrottle).percentUsed(any());
-        verify(hapiGasThrottle).percentUsed(any());
+        verify(aThrottle, times(2)).instantaneousPercentUsed();
+        verify(bThrottle, times(1)).instantaneousPercentUsed();
+        verify(consGasThrottle).instantaneousPercentUsed();
+        verify(hapiGasThrottle).instantaneousPercentUsed();
     }
 
     @Test
     void updatesAsExpectedWithNoGasThrottles() {
         givenThrottleMocksWithoutGas();
         givenThrottleCollabs();
-        given(aThrottle.percentUsed(any())).willReturn(10.0);
-        given(bThrottle.percentUsed(any())).willReturn(50.0);
+        given(aThrottle.instantaneousPercentUsed()).willReturn(10.0);
+        given(bThrottle.instantaneousPercentUsed()).willReturn(50.0);
         final var platformContext = mock(PlatformContext.class);
         given(platform.getContext()).willReturn(platformContext);
         given(platformContext.getMetrics()).willReturn(metrics);
@@ -127,8 +127,8 @@ class ThrottleGaugesTest {
         subject.registerWith(platform);
         subject.updateAll();
 
-        verify(aThrottle, times(2)).percentUsed(any());
-        verify(bThrottle, times(1)).percentUsed(any());
+        verify(aThrottle, times(2)).instantaneousPercentUsed();
+        verify(bThrottle, times(1)).instantaneousPercentUsed();
     }
 
     @Test


### PR DESCRIPTION
**Description**:
 - Closes #6706 
 - When setting a gauge metric for throttle utilization, instead of calling `percentUsed(Instant)` (which simulates leaking capacity until the given time), just sets the metric to utilization at the last decision time for the throttle.
 - 😢 Note the regrettable duplication in the `Gas*` variants; will not be fixed here.
 - Also switches the `freeToUsedRatio(Instant)` method to be an instantaneous measurement to fix an annoying problem that can surface in `TraceabilityExportTask`.