### PR TITLE
Allow queried `TransactionID` to have deleted payer account

### DIFF
--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/queries/meta/GetTxnRecordAnswer.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/queries/meta/GetTxnRecordAnswer.java
@@ -17,6 +17,7 @@
 package com.hedera.node.app.service.mono.queries.meta;
 
 import static com.hederahashgraph.api.proto.java.HederaFunctionality.TransactionGetRecord;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.ACCOUNT_DELETED;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_ACCOUNT_ID;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OK;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.RECORD_NOT_FOUND;
@@ -165,7 +166,8 @@ public class GetTxnRecordAnswer implements AnswerService {
             return INVALID_ACCOUNT_ID;
         }
 
-        return optionValidator.queryableAccountStatus(fallbackId, view.accounts());
+        final var payerIdStatus = optionValidator.queryableAccountStatus(fallbackId, view.accounts());
+        return payerIdStatus == ACCOUNT_DELETED ? OK : payerIdStatus;
     }
 
     @Override

--- a/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/contract/helpers/DeletionLogic.java
+++ b/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/contract/helpers/DeletionLogic.java
@@ -25,6 +25,7 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.ACCOUNT_STILL_
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OBTAINER_DOES_NOT_EXIST;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OBTAINER_REQUIRED;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OBTAINER_SAME_CONTRACT_ID;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.PERMANENT_REMOVAL_REQUIRES_SYSTEM_INITIATION;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TRANSACTION_REQUIRES_ZERO_TOKEN_BALANCES;
 
 import com.hedera.node.app.service.mono.ledger.HederaLedger;
@@ -63,6 +64,9 @@ public class DeletionLogic {
     }
 
     public ResponseCodeEnum precheckValidity(final ContractDeleteTransactionBody op) {
+        if (op.getPermanentRemoval()) {
+            return PERMANENT_REMOVAL_REQUIRES_SYSTEM_INITIATION;
+        }
         final var id = unaliased(op.getContractID(), aliasManager);
         return validator.queryableContractStatus(id, contracts.get());
     }

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/queries/meta/GetTxnRecordAnswerTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/queries/meta/GetTxnRecordAnswerTest.java
@@ -287,14 +287,14 @@ class GetTxnRecordAnswerTest {
     }
 
     @Test
-    void syntaxCheckPrioritizesAccountStatus() {
+    void validityCheckRealizesPayerAccountMightHaveBeenDeletedAndThatIsOk() {
         final var query = queryOf(txnRecordQuery(targetTxnId, ANSWER_ONLY, 123L));
         given(optionValidator.queryableAccountStatus(eq(targetTxnId.getAccountID()), any()))
                 .willReturn(ACCOUNT_DELETED);
 
         final var validity = subject.checkValidity(query, view);
 
-        assertEquals(ACCOUNT_DELETED, validity);
+        assertEquals(OK, validity);
     }
 
     @Test

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/contract/helpers/DeletionLogicTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/contract/helpers/DeletionLogicTest.java
@@ -24,6 +24,7 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.CONTRACT_DELET
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OBTAINER_DOES_NOT_EXIST;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OBTAINER_REQUIRED;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OBTAINER_SAME_CONTRACT_ID;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.PERMANENT_REMOVAL_REQUIRES_SYSTEM_INITIATION;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TRANSACTION_REQUIRES_ZERO_TOKEN_BALANCES;
 import static com.swirlds.common.utility.CommonUtils.unhex;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -86,6 +87,14 @@ class DeletionLogicTest {
         final var op = opWithAccountObtainer(mirrorId, obtainer);
         given(validator.queryableContractStatus(id, contracts)).willReturn(CONTRACT_DELETED);
         assertEquals(CONTRACT_DELETED, subject.precheckValidity(op));
+    }
+
+    @Test
+    void rejectsPermanentDeletion() {
+        final var op = opWithAccountObtainer(aliasId, obtainer).toBuilder()
+                .setPermanentRemoval(true)
+                .build();
+        assertEquals(PERMANENT_REMOVAL_REQUIRES_SYSTEM_INITIATION, subject.precheckValidity(op));
     }
 
     @Test

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/contract/HapiContractDelete.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/contract/HapiContractDelete.java
@@ -38,6 +38,7 @@ import java.util.function.Function;
 
 public class HapiContractDelete extends HapiTxnOp<HapiContractDelete> {
     private boolean shouldPurge = false;
+    private boolean claimingPermanentRemoval = false;
     private final String contract;
     private Optional<String> transferAccount = Optional.empty();
     private Optional<String> transferContract = Optional.empty();
@@ -54,6 +55,11 @@ public class HapiContractDelete extends HapiTxnOp<HapiContractDelete> {
 
     public HapiContractDelete(String contract) {
         this.contract = contract;
+    }
+
+    public HapiContractDelete claimingPermanentRemoval() {
+        claimingPermanentRemoval = true;
+        return this;
     }
 
     public HapiContractDelete transferAccount(String to) {
@@ -88,6 +94,9 @@ public class HapiContractDelete extends HapiTxnOp<HapiContractDelete> {
                                     c -> builder.setTransferContractID(TxnUtils.asContractId(c, spec)));
                             transferAccount.ifPresent(a ->
                                     builder.setTransferAccountID(spec.registry().getAccountID(a)));
+                            if (claimingPermanentRemoval) {
+                                builder.setPermanentRemoval(true);
+                            }
                         });
         return builder -> builder.setContractDeleteInstance(opBody);
     }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hapi/ContractDeleteSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hapi/ContractDeleteSuite.java
@@ -261,6 +261,9 @@ public class ContractDeleteSuite extends HapiSuite {
                         createDefaultContract(tbdContract).bytecode(tbdFile).hasKnownStatus(FILE_DELETED))
                 .when(uploadInitCode(CONTRACT), contractCreate(CONTRACT))
                 .then(
+                        contractDelete(CONTRACT)
+                                .claimingPermanentRemoval()
+                                .hasPrecheck(PERMANENT_REMOVAL_REQUIRES_SYSTEM_INITIATION),
                         contractDelete(CONTRACT),
                         getContractInfo(CONTRACT).has(contractWith().isDeleted()));
     }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/schedule/ScheduleExecutionSpecs.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/schedule/ScheduleExecutionSpecs.java
@@ -1658,7 +1658,9 @@ public class ScheduleExecutionSpecs extends HapiSuite {
                         getAccountBalance(SENDER).hasTinyBars(transferAmount),
                         getAccountBalance(RECEIVER).hasTinyBars(noBalance),
                         getScheduleInfo(BASIC_XFER).isExecuted(),
-                        getTxnRecord(CREATE_TXN).scheduled().hasCostAnswerPrecheck(ACCOUNT_DELETED));
+                        getTxnRecord(CREATE_TXN)
+                                .scheduled()
+                                .hasPriority(recordWith().status(INSUFFICIENT_PAYER_BALANCE)));
     }
 
     public HapiSpec executionWithCustomPayerButAccountDeletedFails() {


### PR DESCRIPTION
**Description**:
 - Closes #6593 
 - Fixes `getTransactionRecord` validity check, which treated a deleted account as an invalid `TransactionID#accountID` field.