### PR TITLE
06737 - AddressBook.toConfigText() Supports Memo Field

### DIFF
--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/system/address/Address.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/system/address/Address.java
@@ -671,6 +671,20 @@ public class Address implements SelfSerializable {
     }
 
     /**
+     * Create a new Address object based this one with different memo.
+     *
+     * @param memo New memo for the created Address.
+     * @return The new Address.
+     */
+    @NonNull
+    public Address copySetMemo(@NonNull final String memo) {
+        Objects.requireNonNull(memo, "memo must not be null");
+        final Address a = copy();
+        a.memo = memo;
+        return a;
+    }
+
+    /**
      * Create a new Address object based on this one.
      *
      * @return A duplication of current Address object.

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/system/address/AddressBook.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/system/address/AddressBook.java
@@ -218,8 +218,8 @@ public class AddressBook extends PartialMerkleLeaf implements Iterable<Address>,
     }
 
     /**
-     * Get the total weight of all members added together, where each member has nonnegative weight. This is zero if there
-     * are no members.
+     * Get the total weight of all members added together, where each member has nonnegative weight. This is zero if
+     * there are no members.
      *
      * @return the total weight
      */
@@ -348,11 +348,11 @@ public class AddressBook extends PartialMerkleLeaf implements Iterable<Address>,
 
     /**
      * Updates the weight on the address with the given ID. If the address does not exist, a NoSuchElementException is
-     * thrown. If the weight value is negative, an IllegalArgumentException is thrown.  If the address book is immutable,
-     * a MutabilityException is thrown. This method does not validate the address book after updating the address.  When
-     * the user is finished with making incremental changes, the final address book should be validated.
+     * thrown. If the weight value is negative, an IllegalArgumentException is thrown.  If the address book is
+     * immutable, a MutabilityException is thrown. This method does not validate the address book after updating the
+     * address.  When the user is finished with making incremental changes, the final address book should be validated.
      *
-     * @param id    the ID of the address to update.
+     * @param id     the ID of the address to update.
      * @param weight the new weight value.  The weight must be nonnegative.
      * @throws NoSuchElementException   if the address does not exist.
      * @throws IllegalArgumentException if the weight is negative.
@@ -560,15 +560,20 @@ public class AddressBook extends PartialMerkleLeaf implements Iterable<Address>,
     public String toConfigText() {
         final TextTable table = new TextTable().setBordersEnabled(false);
         for (final Address address : this) {
+            final String memo = address.getMemo();
+            final boolean hasMemo = !memo.trim().isEmpty();
+            final boolean hasInternalIpv4 = address.getAddressInternalIpv4() != null;
+            final boolean hasExternalIpv4 = address.getAddressExternalIpv4() != null;
             table.addRow(
                     "address,",
                     address.getNickname() + ",",
                     address.getSelfName() + ",",
                     address.getWeight() + ",",
-                    ipString(address.getAddressInternalIpv4()) + ",",
+                    (hasInternalIpv4 ? ipString(address.getAddressInternalIpv4()) : "") + ",",
                     address.getPortInternalIpv4() + ",",
-                    ipString(address.getAddressExternalIpv4()) + ",",
-                    address.getPortExternalIpv4());
+                    (hasExternalIpv4 ? ipString(address.getAddressExternalIpv4()) : "") + ",",
+                    address.getPortExternalIpv4() + (hasMemo ? "," : ""),
+                    memo);
         }
         return table.render();
     }

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/system/address/AddressBookUtils.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/system/address/AddressBookUtils.java
@@ -31,6 +31,9 @@ public class AddressBookUtils {
 
     /**
      * Parses an address from a single line of text.  The address must be in the form used in config.txt
+     * <p>
+     * If the memo field can be parsed, the provided memo field is ignored.  If there is no memo field parsed, the
+     * provided memo field is used.
      *
      * @param addressLine         the string to parse an Address form.
      * @param id                  the id to give to the parsed Address.
@@ -49,8 +52,8 @@ public class AddressBookUtils {
         Objects.requireNonNull(isOwnHostDeterminer, "The isOwnHostDeterminer must not be null.");
         Objects.requireNonNull(memo, "The memo must not be null.");
         final String[] parts = addressLine.trim().split(",");
-        if (parts.length != 8) {
-            throw new ParseException("Not enough parts in the address line to parse correctly.", parts.length);
+        if (parts.length < 8 || parts.length > 9) {
+            throw new ParseException("Incorrect number of parts in the address line to parse correctly.", parts.length);
         }
         for (int i = 0; i < parts.length; i++) {
             parts[i] = parts[i].trim();
@@ -90,6 +93,13 @@ public class AddressBookUtils {
         } catch (NumberFormatException e) {
             throw new ParseException("Cannot parse ip port from '" + parts[7] + "'", 7);
         }
+        final String memoToUse;
+        if (parts.length == 9) {
+            memoToUse = parts[8];
+        } else {
+            memoToUse = memo;
+        }
+
         final boolean isOwnHost = isOwnHostDeterminer.apply(internalIp);
 
         return new Address(
@@ -102,7 +112,7 @@ public class AddressBookUtils {
                 internalPort,
                 externalIp.getAddress(),
                 externalPort,
-                memo);
+                memoToUse);
     }
 
     /**

--- a/platform-sdk/swirlds-unit-tests/common/swirlds-common-test/src/test/java/com/swirlds/common/test/AddressBookTests.java
+++ b/platform-sdk/swirlds-unit-tests/common/swirlds-common-test/src/test/java/com/swirlds/common/test/AddressBookTests.java
@@ -454,6 +454,8 @@ class AddressBookTests {
     void roundTripSerializeAndDeserializeCompatibleWithConfigTxt() throws ParseException {
         final RandomAddressBookGenerator generator = new RandomAddressBookGenerator(getRandomPrintSeed());
         final AddressBook addressBook = generator.build();
+        // make one of the memo fields an empty string
+        addressBook.add(addressBook.iterator().next().copySetMemo(""));
         final String addressBookText = addressBook.toConfigText();
         final Map<Long, Long> posToId = new HashMap<>();
         long pos = 0;
@@ -480,7 +482,7 @@ class AddressBookTests {
         validateParseException("address, nickname, selfname, 10, 192.168.0.1, 5000, 8.8.8.8", 7);
 
         // Too many parts
-        validateParseException("address, nickname, selfname, 10, 192.168.0.1, 5000, 8.8.8.8, 5000, extra", 9);
+        validateParseException("address, nickname, selfname, 10, 192.168.0.1, 5000, 8.8.8.8, 5000, memo, extra", 10);
 
         // bad parsing of parts.
         validateParseException("not an address, nickname, selfname, 10, 192.168.0.1, 5000, 8.8.8.8, 5000", 0);

--- a/platform-sdk/swirlds-unit-tests/common/swirlds-common-test/src/test/java/com/swirlds/common/test/AddressBookTests.java
+++ b/platform-sdk/swirlds-unit-tests/common/swirlds-common-test/src/test/java/com/swirlds/common/test/AddressBookTests.java
@@ -471,8 +471,8 @@ class AddressBookTests {
         // Equality done on toConfigText() strings since the randomly generated address book has public key data.
         assertEquals(addressBookText, parsedAddressBook.toConfigText(), "The AddressBooks are not equal.");
         Iterator<Address> parsedIterator = parsedAddressBook.iterator();
-        assertTrue(parsedIterator.next().getMemo().isEmpty());
-        assertEquals("has a memo", parsedIterator.next().getMemo());
+        assertTrue(parsedIterator.next().getMemo().isEmpty(), "a memo appeared where no memo was expected.");
+        assertEquals("has a memo", parsedIterator.next().getMemo(), "memo did not survive round trip");
     }
 
     @Test

--- a/platform-sdk/swirlds-unit-tests/common/swirlds-common-test/src/test/java/com/swirlds/common/test/AddressBookTests.java
+++ b/platform-sdk/swirlds-unit-tests/common/swirlds-common-test/src/test/java/com/swirlds/common/test/AddressBookTests.java
@@ -472,7 +472,7 @@ class AddressBookTests {
         assertEquals(addressBookText, parsedAddressBook.toConfigText(), "The AddressBooks are not equal.");
         Iterator<Address> parsedIterator = parsedAddressBook.iterator();
         assertTrue(parsedIterator.next().getMemo().isEmpty());
-        assertTrue(parsedIterator.next().getMemo().equals("has a memo"));
+        assertEquals("has a memo", parsedIterator.next().getMemo());
     }
 
     @Test

--- a/platform-sdk/swirlds-unit-tests/common/swirlds-common-test/src/test/java/com/swirlds/common/test/AddressBookTests.java
+++ b/platform-sdk/swirlds-unit-tests/common/swirlds-common-test/src/test/java/com/swirlds/common/test/AddressBookTests.java
@@ -41,6 +41,7 @@ import java.io.IOException;
 import java.text.ParseException;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Random;
@@ -455,7 +456,9 @@ class AddressBookTests {
         final RandomAddressBookGenerator generator = new RandomAddressBookGenerator(getRandomPrintSeed());
         final AddressBook addressBook = generator.build();
         // make one of the memo fields an empty string
-        addressBook.add(addressBook.iterator().next().copySetMemo(""));
+        Iterator<Address> iterator = addressBook.iterator();
+        addressBook.add(iterator.next().copySetMemo(""));
+        addressBook.add(iterator.next().copySetMemo("has a memo"));
         final String addressBookText = addressBook.toConfigText();
         final Map<Long, Long> posToId = new HashMap<>();
         long pos = 0;
@@ -467,6 +470,9 @@ class AddressBookTests {
                 parseAddressBookConfigText(addressBookText, posToId::get, ip -> false, id -> "");
         // Equality done on toConfigText() strings since the randomly generated address book has public key data.
         assertEquals(addressBookText, parsedAddressBook.toConfigText(), "The AddressBooks are not equal.");
+        Iterator<Address> parsedIterator = parsedAddressBook.iterator();
+        assertTrue(parsedIterator.next().getMemo().isEmpty());
+        assertTrue(parsedIterator.next().getMemo().equals("has a memo"));
     }
 
     @Test

--- a/platform-sdk/swirlds-unit-tests/common/swirlds-common-test/src/test/java/com/swirlds/common/test/AddressBookTests.java
+++ b/platform-sdk/swirlds-unit-tests/common/swirlds-common-test/src/test/java/com/swirlds/common/test/AddressBookTests.java
@@ -497,9 +497,12 @@ class AddressBookTests {
 
         // Too many parts
         validateParseException("address, nickname, selfname, 10, 192.168.0.1, 5000, 8.8.8.8, 5000, memo, extra", 10);
-        validateParseException("address, nickname, selfname, 10, 192.168.0.1, 5000, 8.8.8.8, 5000, memo.with,comma,", 10);
-        validateParseException("address, nickname, selfname, 10, 192.168.0.1, 5000, 8.8.8.8, 5000, 'memo.with,comma',", 10);
-        validateParseException("address, nickname, selfname, 10, 192.168.0.1, 5000, 8.8.8.8, 5000, \"memo.with,comma\",", 10);
+        validateParseException(
+                "address, nickname, selfname, 10, 192.168.0.1, 5000, 8.8.8.8, 5000, memo.with,comma,", 10);
+        validateParseException(
+                "address, nickname, selfname, 10, 192.168.0.1, 5000, 8.8.8.8, 5000, 'memo.with,comma',", 10);
+        validateParseException(
+                "address, nickname, selfname, 10, 192.168.0.1, 5000, 8.8.8.8, 5000, \"memo.with,comma\",", 10);
 
         // bad parsing of parts.
         validateParseException("not an address, nickname, selfname, 10, 192.168.0.1, 5000, 8.8.8.8, 5000", 0);


### PR DESCRIPTION
**Description**:

Fixes #6737 

Not a cherry pick from develop, but performs the same logic as PR #6740 

original `config.txt`: 
```
swirld, 123

app,		HashgraphDemo.jar,	   1,0,0,0,0,0,0,0,0,0, all

 address,  A, Alice,    1, 127.0.0.1, 15301, 127.0.0.1, 15301
 address,  B, Bob,      1, 127.0.0.1, 15302, 127.0.0.1, 15302, has a memo
 address,  C, Carol,    1, 127.0.0.1, 15303, 127.0.0.1, 15303
 address,  D, Dave,     1, 127.0.0.1, 15304, 127.0.0.1, 15304, has a memo2
```

output of `currentAddressBook.txt`:
```
address, A, Alice, 1, 127.0.0.1, 15301, 127.0.0.1, 15301              
address, B, Bob,   1, 127.0.0.1, 15302, 127.0.0.1, 15302, has a memo  
address, C, Carol, 1, 127.0.0.1, 15303, 127.0.0.1, 15303              
address, D, Dave,  1, 127.0.0.1, 15304, 127.0.0.1, 15304, has a memo2 
```

