### PR TITLE
fix: updates daily CI tasks to properly handle the release branch names

### DIFF
--- a/.github/workflows/platform-zxcron-release-jrs-regression.yaml
+++ b/.github/workflows/platform-zxcron-release-jrs-regression.yaml
@@ -46,7 +46,14 @@ jobs:
           BRANCH_LIST="$(git branch --list --remotes --format='%(refname:strip=3)' | cat)"
 
           while IFS= read -r line; do
-            [[ "${line}" =~ ^release-[0-9]+.[0-9]+.[0-9]+ ]] || continue
+            [[ "${line}" =~ ^release/([0-9]+).([0-9]+) ]] || continue
+            
+            major="${BASH_REMATCH[1]}"
+            minor="${BASH_REMATCH[2]}"
+          
+            if [[ "${major}" -eq 0 && "${minor}" -lt 38 ]]; then
+              continue
+            fi
 
             echo "::group::Identified Branch: ${line}"
             echo "${line}" | tee -a "${BRANCH_LIST_FILE}"

--- a/.github/workflows/zxc-jrs-regression.yaml
+++ b/.github/workflows/zxc-jrs-regression.yaml
@@ -358,7 +358,7 @@ jobs:
         run: |
           set -x
 
-          readonly BRANCH_VERSION_REGEX="([A-Za-z]+)-?[0-9]+\.([0-9]+)\.[0-9]+-?[A-Za-z]*\.?[0-9]*"
+          readonly BRANCH_VERSION_REGEX="([A-Za-z]+)/?[0-9]+\.([0-9]+)\.[0-9]+-?[A-Za-z]*\.?[0-9]*"
 
           if [[ -z "${{ github.actor }}" ]]; then
             JRS_USER="swirlds-automation"


### PR DESCRIPTION
## Description

Update the daily CI tasks to use a regex which properly supports the `hedera-services` release branch names.

### Related Issues 

- Closes #6708 