### PR TITLE
Bump platform version to 0.38.3

### DIFF
--- a/.github/workflows/platform-zxcron-release-jrs-regression.yaml
+++ b/.github/workflows/platform-zxcron-release-jrs-regression.yaml
@@ -47,10 +47,10 @@ jobs:
 
           while IFS= read -r line; do
             [[ "${line}" =~ ^release/([0-9]+).([0-9]+) ]] || continue
-            
+
             major="${BASH_REMATCH[1]}"
             minor="${BASH_REMATCH[2]}"
-          
+
             if [[ "${major}" -eq 0 && "${minor}" -lt 38 ]]; then
               continue
             fi

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -144,7 +144,7 @@ dependencyResolutionManagement {
       version("netty-version", "4.1.66.Final")
       version("protobuf-java-version", "3.19.4")
       version("slf4j-version", "2.0.3")
-      version("swirlds-version", "0.38.0")
+      version("swirlds-version", "0.38.1")
       version("tuweni-version", "2.2.0")
       version("jna-version", "5.12.1")
       version("jsr305-version", "3.0.2")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -144,7 +144,7 @@ dependencyResolutionManagement {
       version("netty-version", "4.1.66.Final")
       version("protobuf-java-version", "3.19.4")
       version("slf4j-version", "2.0.3")
-      version("swirlds-version", "0.38.1")
+      version("swirlds-version", "0.38.3")
       version("tuweni-version", "2.2.0")
       version("jna-version", "5.12.1")
       version("jsr305-version", "3.0.2")


### PR DESCRIPTION
Bump platform version to 0.38.3

Fixes #6771 

Note: Tests will not pass for this PR until platform 0.38.3 is uploaded to Maven Central.