### PR TITLE
Update zero weights for new nodes

### DIFF
--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ServicesStateTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ServicesStateTest.java
@@ -1014,16 +1014,35 @@ class ServicesStateTest extends ResponsibleVMapUser {
 
     @Test
     void updatesAddressBookWithZeroWeightOnGenesisStart() {
+        final var node0 = new NodeId(0);
+        final var node1 = new NodeId(1);
+        given(platform.getSelfId()).willReturn(node0);
+
+        final var pretendAddressBook = createPretendBookFrom(platform, true);
+
         final MerkleMap<EntityNum, MerkleStakingInfo> stakingMap = subject.getChild(StateChildIndices.STAKING_INFO);
         assertEquals(1, stakingMap.size());
         assertEquals(0, stakingMap.get(EntityNum.fromLong(0L)).getWeight());
 
-        subject.updateWeight(addressBook, platform.getContext());
-        verify(addressBook).updateWeight(new NodeId(0), 0);
+        assertEquals(10L, pretendAddressBook.getAddress(node0).getWeight());
+        assertEquals(10L, pretendAddressBook.getAddress(node1).getWeight());
+
+        subject.updateWeight(pretendAddressBook, platform.getContext());
+
+        // if staking info map has node with 0 weight and a new node is added,
+        // both gets weight of 0
+        assertEquals(0L, pretendAddressBook.getAddress(node0).getWeight());
+        assertEquals(0L, pretendAddressBook.getAddress(node1).getWeight());
     }
 
     @Test
-    void updatesAddressBookWithNonZeroWeightsOnGenesisStart() {
+    void updatesAddressBookWithZeroWeightForNewNodes() {
+        final var node0 = new NodeId(0);
+        final var node1 = new NodeId(1);
+
+        given(platform.getSelfId()).willReturn(node0);
+
+        final var pretendAddressBook = createPretendBookFrom(platform, true);
         final MerkleMap<EntityNum, MerkleStakingInfo> stakingMap = subject.getChild(StateChildIndices.STAKING_INFO);
         assertEquals(1, stakingMap.size());
         assertEquals(0, stakingMap.get(EntityNum.fromLong(0L)).getWeight());
@@ -1035,8 +1054,43 @@ class ServicesStateTest extends ResponsibleVMapUser {
         assertEquals(1000L, stakingMap.get(EntityNum.fromLong(0L)).getStake());
         subject.setChild(StateChildIndices.STAKING_INFO, stakingMap);
 
-        subject.updateWeight(addressBook, platform.getContext());
-        verify(addressBook).updateWeight(new NodeId(0), 500);
+        assertEquals(10L, pretendAddressBook.getAddress(node0).getWeight());
+        assertEquals(10L, pretendAddressBook.getAddress(node1).getWeight());
+
+        subject.updateWeight(pretendAddressBook, platform.getContext());
+
+        // only one node in state and new node added in config.txt gets weight of 0
+        assertEquals(500, pretendAddressBook.getAddress(node0).getWeight());
+        assertEquals(0L, pretendAddressBook.getAddress(node1).getWeight());
+    }
+
+    @Test
+    void updatesAddressBookWithNonZeroWeightsOnGenesisStartIfStakesExist() {
+        final var node0 = new NodeId(0);
+        final var node1 = new NodeId(1);
+        given(platform.getSelfId()).willReturn(node0);
+        final var pretendAddressBook = createPretendBookFrom(platform, true);
+
+        final MerkleMap<EntityNum, MerkleStakingInfo> stakingMap = subject.getChild(StateChildIndices.STAKING_INFO);
+        assertEquals(1, stakingMap.size());
+        assertEquals(0, stakingMap.get(EntityNum.fromLong(0L)).getWeight());
+
+        stakingMap.put(EntityNum.fromLong(1L), new MerkleStakingInfo());
+        stakingMap.forEach((k, v) -> {
+            v.setStake(1000L);
+            v.setWeight(500);
+        });
+        assertEquals(1000L, stakingMap.get(EntityNum.fromLong(0L)).getStake());
+        subject.setChild(StateChildIndices.STAKING_INFO, stakingMap);
+
+        assertEquals(10L, pretendAddressBook.getAddress(node0).getWeight());
+        assertEquals(10L, pretendAddressBook.getAddress(node1).getWeight());
+
+        subject.updateWeight(pretendAddressBook, platform.getContext());
+
+        // both nodes in staking info gets weight as in state
+        assertEquals(500, pretendAddressBook.getAddress(node0).getWeight());
+        assertEquals(500L, pretendAddressBook.getAddress(node1).getWeight());
     }
 
     private static ServicesApp createApp(final Platform platform) {

--- a/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/utils/AddresBookUtils.java
+++ b/hedera-node/hedera-mono-service/src/testFixtures/java/com/hedera/test/utils/AddresBookUtils.java
@@ -20,8 +20,8 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 
 import com.google.common.primitives.Ints;
-import com.google.common.primitives.Longs;
 import com.swirlds.common.crypto.SerializablePublicKey;
+import com.swirlds.common.system.NodeId;
 import com.swirlds.common.system.Platform;
 import com.swirlds.common.system.address.Address;
 import com.swirlds.common.system.address.AddressBook;
@@ -36,15 +36,11 @@ public class AddresBookUtils {
     public static AddressBook createPretendBookFrom(final Platform platform, final boolean withKeyDetails) {
         final var pubKey = mock(PublicKey.class);
         given(pubKey.getAlgorithm()).willReturn("EC");
-        if (withKeyDetails) {
-            given(pubKey.getEncoded()).willReturn(Longs.toByteArray(Long.MAX_VALUE));
-        }
-        final var node = platform.getSelfId();
-        final var address = new Address(
-                node,
+        final var address1 = new Address(
+                platform.getSelfId(),
                 "",
                 "",
-                1L,
+                10L,
                 false,
                 null,
                 -1,
@@ -58,6 +54,24 @@ public class AddresBookUtils {
                 null,
                 new SerializablePublicKey(pubKey),
                 "");
-        return new AddressBook(List.of(address));
+        final var address2 = new Address(
+                new NodeId(1),
+                "",
+                "",
+                10L,
+                false,
+                null,
+                -1,
+                Ints.toByteArray(123456789),
+                -1,
+                null,
+                -1,
+                null,
+                -1,
+                new SerializablePublicKey(pubKey),
+                null,
+                new SerializablePublicKey(pubKey),
+                "");
+        return new AddressBook(List.of(address1, address2));
     }
 }


### PR DESCRIPTION
Fixes https://github.com/hashgraph/hedera-services/issues/6778
Updates weights of newly added nodes to 0, irrespective of the weights specified in `config.txt`