### PR TITLE
Allow `INVALID_SIGNATURE` status on `EthTx` value sent to EOA with `receiverSigRequired=true`

### DIFF
--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/providers/ops/crypto/EthereumTransferToRandomEVMAddress.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/providers/ops/crypto/EthereumTransferToRandomEVMAddress.java
@@ -67,7 +67,10 @@ public class EthereumTransferToRandomEVMAddress implements OpProvider {
                 .maxGasAllowance(FIVE_HBARS)
                 .gasLimit(2_000_000L)
                 .via(PAY_TXN)
-                .hasKnownStatus(SUCCESS);
+                // Since the receiver _could_ have receiverSigRequired=true (c.f. the
+                // InitialAccountIdentifiers.customize() method), INVALID_SIGNATURE is a valid
+                // response code
+                .hasKnownStatusFrom(SUCCESS, INVALID_SIGNATURE);
 
         incrementNonce();
 


### PR DESCRIPTION
**Description**:
 - Closes #6774 
 - Since it is possible for `addressAliasIdFuzzing()` [to create an account with `receiverSigRequired=true`](https://github.com/hashgraph/hedera-services/blob/develop/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/meta/InitialAccountIdentifiers.java#L87), it is possible for [`EthereumTransferToRandomEVMAddress`](https://github.com/hashgraph/hedera-services/blob/develop/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/providers/ops/crypto/EthereumTransferToRandomEVMAddress.java#L59) to be using an `EthereumTransaction` to send value with a `to` address with `receiverSigRequired=true`.
    * But then we fail [here](https://github.com/hashgraph/hedera-services/blob/develop/hedera-node/hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/txns/contract/ContractCallTransitionLogic.java#L151) with `INVALID_SIGNATURE`.
    * So to stabilize the spec we need to use `.hasKnownStatusFrom(SUCCESS, INVALID_SIGNATURE)`.