### PR TITLE
Revert on-disk, consolidated FCQ dev overrides

### DIFF
--- a/hedera-node/data/config/bootstrap.properties
+++ b/hedera-node/data/config/bootstrap.properties
@@ -10,7 +10,3 @@ accounts.storeOnDisk=false
 tokens.storeRelsOnDisk=false
 tokens.nfts.useVirtualMerkle=false
 cache.cryptoTransfer.warmThreads=30
-records.useConsolidatedFcq=true
-accounts.storeOnDisk=true
-tokens.storeRelsOnDisk=true
-tokens.nfts.useVirtualMerkle=true


### PR DESCRIPTION
**Description**:
 - Revert _data/config/bootstrap.properties_ from [this PR](https://github.com/hashgraph/hedera-services/pull/6718/files) since these are actually used in JRS tests and will cause problems tonight.