### PR TITLE
PREVIEWNET, LOCAL: Sunset old security model for smart contracts

### DIFF
--- a/hedera-node/configuration/previewnet/bootstrap.properties
+++ b/hedera-node/configuration/previewnet/bootstrap.properties
@@ -4,3 +4,4 @@ bootstrap.genesisPublicKey=c249a323c878f5b5e2daccda6d731e6fdc32f870228d1cd4fae55
 accounts.blocklist.enabled=false
 accounts.blocklist.resource=
 contracts.evm.version.dynamic=true
+contracts.maxNumWithHapiSigsAccess=0

--- a/hedera-node/data/config/bootstrap.properties
+++ b/hedera-node/data/config/bootstrap.properties
@@ -11,3 +11,4 @@ tokens.storeRelsOnDisk=true
 tokens.nfts.useVirtualMerkle=true
 virtualdatasource.jasperdbToMerkledb=true
 cache.cryptoTransfer.warmThreads=30
+contracts.maxNumWithHapiSigsAccess=0


### PR DESCRIPTION
**Description**:

Sunset old security model for smart contracts by changing the HAPI signature check block boundary to 0 (from 10M).

Pushing this for PREVIEWNET and node running locally in the repo only.

Tested by confirming that contract itests running locally against the repo node now _fail_ as expected.

Signed-off-by: David Bakin <117694041+david-bakin-sl@users.noreply.github.com>

**Related issue(s)**:

Partial f*x of #6767 

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested - when running built node locally (in IntelliJ) contract itests fail _as expected_
