### PR TITLE
Rename multiple bdd tests (`HapiSpec`s) to eliminate wrong names, nor…

### DIFF
--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/TxnUtils.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/TxnUtils.java
@@ -55,6 +55,7 @@ import com.hedera.services.bdd.spec.keys.SigControl;
 import com.hedera.services.bdd.spec.queries.contract.HapiGetContractInfo;
 import com.hedera.services.bdd.spec.queries.file.HapiGetFileInfo;
 import com.hedera.services.bdd.spec.transactions.contract.HapiContractCall;
+import com.hedera.services.bdd.suites.contract.Utils;
 import com.hederahashgraph.api.proto.java.AccountAmount;
 import com.hederahashgraph.api.proto.java.AccountID;
 import com.hederahashgraph.api.proto.java.ContractID;
@@ -612,7 +613,9 @@ public class TxnUtils {
     }
 
     public static String bytecodePath(final String contractName) {
-        return String.format("src/main/resource/contract/contracts/%s/%s.bin", contractName, contractName);
+        // Quick fix for https://github.com/hashgraph/hedera-services/issues/6821, a better solution will be provided
+        // when the issue is resolved
+        return Utils.getResourcePath(contractName, ".bin");
     }
 
     public static ByteString literalInitcodeFor(final String contract) {

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/BddMethodIsNotATest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/BddMethodIsNotATest.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.services.bdd.suites;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/** Used in BDD suites to mark methods that, though returning `HapiSpec`, are not themselves test methods. */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface BddMethodIsNotATest {}

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/BddTestNameDoesNotMatchMethodName.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/BddTestNameDoesNotMatchMethodName.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.services.bdd.suites;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/** Used in BDD suites to mark methods that produce one or more `HapiSpecs` whose
+ * name does not match this method's name.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface BddTestNameDoesNotMatchMethodName {}

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/consensus/TopicUpdateSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/consensus/TopicUpdateSuite.java
@@ -82,7 +82,7 @@ public class TopicUpdateSuite extends HapiSuite {
     }
 
     private HapiSpec updateToMissingTopicFails() {
-        return defaultHapiSpec("UpdateTopicHandlesMissingTopicGracefully")
+        return defaultHapiSpec("updateToMissingTopicFails")
                 .given()
                 .when()
                 .then(updateTopic("1.2.3").hasKnownStatus(INVALID_TOPIC_ID));

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hapi/ContractCallLocalSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hapi/ContractCallLocalSuite.java
@@ -68,7 +68,7 @@ public class ContractCallLocalSuite extends HapiSuite {
     @Override
     public List<HapiSpec> getSpecsInSuite() {
         return List.of(new HapiSpec[] {
-            deletedContract(),
+            invalidDeletedContract(),
             invalidContractID(),
             impureCallFails(),
             insufficientFeeFails(),
@@ -80,7 +80,7 @@ public class ContractCallLocalSuite extends HapiSuite {
     }
 
     private HapiSpec vanillaSuccess() {
-        return defaultHapiSpec("VanillaSuccess")
+        return defaultHapiSpec("vanillaSuccess")
                 .given(uploadInitCode(CONTRACT), contractCreate(CONTRACT).adminKey(THRESHOLD))
                 .when(contractCall(CONTRACT, "create").gas(785_000))
                 .then(
@@ -93,7 +93,7 @@ public class ContractCallLocalSuite extends HapiSuite {
     }
 
     private HapiSpec impureCallFails() {
-        return defaultHapiSpec("ImpureCallFails")
+        return defaultHapiSpec("impureCallFails")
                 .given(uploadInitCode(CONTRACT), contractCreate(CONTRACT).adminKey(THRESHOLD))
                 .when()
                 .then(
@@ -103,8 +103,8 @@ public class ContractCallLocalSuite extends HapiSuite {
                                 .hasAnswerOnlyPrecheck(ResponseCodeEnum.LOCAL_CALL_MODIFICATION_EXCEPTION));
     }
 
-    private HapiSpec deletedContract() {
-        return defaultHapiSpec("InvalidDeletedContract")
+    private HapiSpec invalidDeletedContract() {
+        return defaultHapiSpec("invalidDeletedContract")
                 .given(uploadInitCode(CONTRACT), contractCreate(CONTRACT))
                 .when(contractDelete(CONTRACT))
                 .then(contractCallLocal(CONTRACT, "create")
@@ -130,7 +130,7 @@ public class ContractCallLocalSuite extends HapiSuite {
     private HapiSpec insufficientFeeFails() {
         final long adequateQueryPayment = 500_000L;
 
-        return defaultHapiSpec("InsufficientFee")
+        return defaultHapiSpec("insufficientFeeFails")
                 .given(cryptoCreate("payer"), uploadInitCode(CONTRACT), contractCreate(CONTRACT))
                 .when(contractCall(CONTRACT, "create").gas(785_000))
                 .then(
@@ -145,7 +145,7 @@ public class ContractCallLocalSuite extends HapiSuite {
     private HapiSpec lowBalanceFails() {
         final long adequateQueryPayment = 500_000_000L;
 
-        return defaultHapiSpec("LowBalanceFails")
+        return defaultHapiSpec("lowBalanceFails")
                 .given(
                         cryptoCreate("payer"),
                         cryptoCreate("payer").balance(adequateQueryPayment),
@@ -169,7 +169,7 @@ public class ContractCallLocalSuite extends HapiSuite {
                 + "\"outputs\": [{\"name\": \"\",\"type\": \"uint8\"}],\"payable\": false,"
                 + "\"type\": \"function\"}";
 
-        return defaultHapiSpec("erc20Queries")
+        return defaultHapiSpec("erc20Query")
                 .given(tokenCreate(TOKEN).decimals(DECIMALS).symbol(SYMBOL).asCallableContract())
                 .when()
                 .then(contractCallLocalWithFunctionAbi(TOKEN, decimalsABI)
@@ -178,7 +178,7 @@ public class ContractCallLocalSuite extends HapiSuite {
 
     // https://github.com/hashgraph/hedera-services/pull/5485
     private HapiSpec callLocalDoesNotCheckSignaturesNorPayer() {
-        return defaultHapiSpec("VanillaSuccess")
+        return defaultHapiSpec("callLocalDoesNotCheckSignaturesNorPayer")
                 .given(uploadInitCode(CONTRACT), contractCreate(CONTRACT).adminKey(THRESHOLD))
                 .when(contractCall(CONTRACT, "create").gas(785_000))
                 .then(withOpContext((spec, opLog) -> IntStream.range(0, 2000).forEach(i -> {

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hapi/ContractCallSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hapi/ContractCallSuite.java
@@ -239,7 +239,7 @@ public class ContractCallSuite extends HapiSuite {
                 sendHbarsToDifferentAddresses(),
                 sendHbarsFromDifferentAddressessToAddress(),
                 sendHbarsFromAndToDifferentAddressess(),
-                transferNegativeAmountOfHbars(),
+                transferNegativeAmountOfHbarsFails(),
                 transferZeroHbars(),
                 sendHbarsToOuterContractFromDifferentAddresses(),
                 sendHbarsToCallerFromDifferentAddresses(),
@@ -505,7 +505,7 @@ public class ContractCallSuite extends HapiSuite {
     }
 
     private HapiSpec depositMoreThanBalanceFailsGracefully() {
-        return defaultHapiSpec("Deposit More Than Balance Fails Gracefully")
+        return defaultHapiSpec("depositMoreThanBalanceFailsGracefully")
                 .given(
                         uploadInitCode(PAY_RECEIVABLE_CONTRACT),
                         cryptoCreate(ACCOUNT).balance(ONE_HBAR - 1))
@@ -944,7 +944,7 @@ public class ContractCallSuite extends HapiSuite {
         // Valid UTF-8 bytes cannot include 0xff
         final var hexedNonUtf8Meta = "ff";
 
-        return defaultHapiSpec("Erc721TokenUriAndHtsNftInfoSeeSameMetadata")
+        return defaultHapiSpec("erc721TokenUriAndHtsNftInfoTreatNonUtf8BytesDifferently")
                 .given(
                         uploadInitCode(contractAlternatives),
                         contractCreate(contractAlternatives),
@@ -1715,7 +1715,7 @@ public class ContractCallSuite extends HapiSuite {
     }
 
     private HapiSpec hscsEvm006ContractHBarTransferToAccount() {
-        return defaultHapiSpec("HSCS_EVM_006_ContractHBarTransferToAccount")
+        return defaultHapiSpec("hscsEvm006ContractHBarTransferToAccount")
                 .given(
                         cryptoCreate(ACCOUNT).balance(ONE_HUNDRED_HBARS),
                         cryptoCreate(RECEIVER).balance(10_000L),
@@ -1744,7 +1744,7 @@ public class ContractCallSuite extends HapiSuite {
         final var subLevelContract = "SubLevelTransferring";
         final var INITIAL_CONTRACT_BALANCE = 100;
 
-        return defaultHapiSpec("HSCS_EVM_005_TransfersWithSubLevelCallsBetweenContracts")
+        return defaultHapiSpec("hscsEvm005TransfersWithSubLevelCallsBetweenContracts")
                 .given(
                         cryptoCreate(ACCOUNT).balance(ONE_HUNDRED_HBARS),
                         uploadInitCode(topLevelContract, subLevelContract))
@@ -1799,7 +1799,7 @@ public class ContractCallSuite extends HapiSuite {
     private HapiSpec hscsEvm005TransferOfHBarsWorksBetweenContracts() {
         final var to = "To";
 
-        return defaultHapiSpec("HSCS_EVM_005_TransferOfHBarsWorksBetweenContracts")
+        return defaultHapiSpec("hscsEvm005TransferOfHBarsWorksBetweenContracts")
                 .given(
                         cryptoCreate(ACCOUNT).balance(ONE_HUNDRED_HBARS),
                         uploadInitCode(TRANSFERRING_CONTRACT),
@@ -1831,7 +1831,7 @@ public class ContractCallSuite extends HapiSuite {
     private HapiSpec hscsEvm010ReceiverMustSignContractTx() {
         final var ACC = "acc";
         final var RECEIVER_KEY = "receiverKey";
-        return defaultHapiSpec("HSCS_EVM_010_ReceiverMustSignContractTx")
+        return defaultHapiSpec("hscsEvm010ReceiverMustSignContractTx")
                 .given(
                         newKeyNamed(RECEIVER_KEY),
                         cryptoCreate(ACC)
@@ -1869,7 +1869,7 @@ public class ContractCallSuite extends HapiSuite {
         final var PAYER_KEY = "pkey";
         final var OTHER_KEY = "okey";
         final var KEY_LIST = "klist";
-        return defaultHapiSpec("HSCS_EVM_010_MultiSignatureAccounts")
+        return defaultHapiSpec("hscsEvm010MultiSignatureAccounts")
                 .given(
                         newKeyNamed(PAYER_KEY),
                         newKeyNamed(OTHER_KEY),
@@ -2204,7 +2204,7 @@ public class ContractCallSuite extends HapiSuite {
                                 .has(contractWith().balance(10_000 - 60L))));
     }
 
-    private HapiSpec transferNegativeAmountOfHbars() {
+    private HapiSpec transferNegativeAmountOfHbarsFails() {
         return defaultHapiSpec("transferNegativeAmountOfHbarsFails")
                 .given(
                         cryptoCreate(ACCOUNT).balance(ONE_HUNDRED_HBARS),
@@ -2318,7 +2318,7 @@ public class ContractCallSuite extends HapiSuite {
         final AtomicReference<String> lpTokenAddr = new AtomicReference<>();
         final AtomicReference<String> rentPayerAddr = new AtomicReference<>();
 
-        return defaultHapiSpec("FarmSimulation")
+        return defaultHapiSpec("lpFarmSimulation")
                 .given(
                         newKeyNamed(adminKey),
                         fileCreate(initcode),

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hapi/ContractCreateSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hapi/ContractCreateSuite.java
@@ -212,7 +212,7 @@ public class ContractCreateSuite extends HapiSuite {
     }
 
     private HapiSpec createsVanillaContractAsExpectedWithOmittedAdminKey() {
-        return defaultHapiSpec("CreatesVanillaContract")
+        return defaultHapiSpec("createsVanillaContractAsExpectedWithOmittedAdminKey")
                 .given(uploadInitCode(EMPTY_CONSTRUCTOR_CONTRACT))
                 .when()
                 .then(
@@ -264,7 +264,7 @@ public class ContractCreateSuite extends HapiSuite {
     }
 
     private HapiSpec createEmptyConstructor() {
-        return defaultHapiSpec("EmptyConstructor")
+        return defaultHapiSpec("createEmptyConstructor")
                 .given(uploadInitCode(EMPTY_CONSTRUCTOR_CONTRACT))
                 .when()
                 .then(contractCreate(EMPTY_CONSTRUCTOR_CONTRACT).hasKnownStatus(SUCCESS));
@@ -477,7 +477,7 @@ public class ContractCreateSuite extends HapiSuite {
         final var FILE_KEY = "fileKey";
         final var KEY_LIST = "keyList";
         final var ACCOUNT = "acc";
-        return defaultHapiSpec("cannotCreateLargeContract")
+        return defaultHapiSpec("cannotCreateTooLargeContract")
                 .given(
                         newKeyNamed(FILE_KEY),
                         newKeyListNamed(KEY_LIST, List.of(FILE_KEY)),
@@ -499,7 +499,7 @@ public class ContractCreateSuite extends HapiSuite {
         final var firstBlock = "firstBlock";
         final var timeLoggingTxn = "timeLoggingTxn";
 
-        return defaultHapiSpec("BlockTimestampIsConsensusTime")
+        return defaultHapiSpec("blockTimestampChangesWithinFewSeconds")
                 .given(uploadInitCode(contract), contractCreate(contract))
                 .when(
                         contractCall(contract, "logNow").via(firstBlock),

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hapi/ContractDeleteSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hapi/ContractDeleteSuite.java
@@ -231,7 +231,7 @@ public class ContractDeleteSuite extends HapiSuite {
     }
 
     HapiSpec rejectsWithoutProperSig() {
-        return defaultHapiSpec("ScDelete")
+        return defaultHapiSpec("rejectsWithoutProperSig")
                 .given(uploadInitCode(CONTRACT), contractCreate(CONTRACT))
                 .when()
                 .then(contractDelete(CONTRACT).signedBy(GENESIS).hasKnownStatus(INVALID_SIGNATURE));

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hapi/ContractUpdateSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hapi/ContractUpdateSuite.java
@@ -415,9 +415,10 @@ public class ContractUpdateSuite extends HapiSuite {
     }
 
     private HapiSpec updateDoesNotChangeBytecode() {
+        // HSCS-DCPR-001
         final var simpleStorageContract = "SimpleStorage";
         final var emptyConstructorContract = "EmptyConstructor";
-        return defaultHapiSpec("HSCS-DCPR-001")
+        return defaultHapiSpec("updateDoesNotChangeBytecode")
                 .given(
                         uploadInitCode(simpleStorageContract, emptyConstructorContract),
                         contractCreate(simpleStorageContract),

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/opcodes/Create2OperationSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/opcodes/Create2OperationSuite.java
@@ -763,7 +763,7 @@ public class Create2OperationSuite extends HapiSuite {
 
         final var salt = unhex(SALT);
 
-        return defaultHapiSpec("CanUseAliasesInPrecompiles")
+        return defaultHapiSpec("canUseAliasesInPrecompilesAndContractKeys")
                 .given(
                         newKeyNamed(multiKey),
                         cryptoCreate(TOKEN_TREASURY),

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/opcodes/CreateOperationSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/opcodes/CreateOperationSuite.java
@@ -81,7 +81,7 @@ public class CreateOperationSuite extends HapiSuite {
                 inheritanceOfNestedCreatedContracts(),
                 factoryAndSelfDestructInConstructorContract(),
                 factoryQuickSelfDestructContract(),
-                contractCreateWithNewOpInConstructor(),
+                contractCreateWithNewOpInConstructorAbandoningParent(),
                 childContractStorageWorks());
     }
 
@@ -143,7 +143,7 @@ public class CreateOperationSuite extends HapiSuite {
     }
 
     HapiSpec simpleFactoryWorks() {
-        return defaultHapiSpec("ContractFactoryWorksHappyPath")
+        return defaultHapiSpec("simpleFactoryWorks")
                 .given(uploadInitCode(CONTRACT), contractCreate(CONTRACT))
                 .when(contractCall(CONTRACT, DEPLOYMENT_SUCCESS_FUNCTION)
                         .gas(780_000)
@@ -275,9 +275,9 @@ public class CreateOperationSuite extends HapiSuite {
                 }));
     }
 
-    private HapiSpec contractCreateWithNewOpInConstructor() {
+    private HapiSpec contractCreateWithNewOpInConstructorAbandoningParent() {
         final var contract = "AbandoningParent";
-        return defaultHapiSpec("ContractCreateWithNewOpInConstructorAbandoningParent")
+        return defaultHapiSpec("contractCreateWithNewOpInConstructorAbandoningParent")
                 .given(uploadInitCode(contract), contractCreate(contract).via("AbandoningParentTxn"))
                 .when()
                 .then(

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/opcodes/SStoreSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/opcodes/SStoreSuite.java
@@ -68,7 +68,7 @@ public class SStoreSuite extends HapiSuite {
     HapiSpec multipleSStoreOpsSucceed() {
         final var contract = "GrowArray";
         final var GAS_TO_OFFER = 6_000_000L;
-        return HapiSpec.defaultHapiSpec("MultipleSStoresShouldWork")
+        return HapiSpec.defaultHapiSpec("multipleSStoreOpsSucceed")
                 .given(uploadInitCode(contract), contractCreate(contract))
                 .when(withOpContext((spec, opLog) -> {
                     final var step = 16;
@@ -167,7 +167,7 @@ public class SStoreSuite extends HapiSuite {
         final var GAS_LIMIT = 1_000_000;
         var value = Bytes.fromHexString("0x0000000000000000000000000000000000000000000000000000000000000005")
                 .toArray();
-        return defaultHapiSpec("SimpleStorage")
+        return defaultHapiSpec("benchmarkSingleSetter")
                 .given(cryptoCreate("payer").balance(10 * ONE_HUNDRED_HBARS), uploadInitCode(contract))
                 .when(
                         contractCreate(contract)

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/opcodes/SelfDestructSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/opcodes/SelfDestructSuite.java
@@ -71,7 +71,7 @@ public class SelfDestructSuite extends HapiSuite {
     private HapiSpec hscsEvm008SelfDestructInConstructorWorks() {
         final var contract = "FactorySelfDestructConstructor";
         final var nextAccount = "civilian";
-        return defaultHapiSpec("HSCS_EVM_008_SelfDestructInConstructorWorks")
+        return defaultHapiSpec("hscsEvm008SelfDestructInConstructorWorks")
                 .given(cryptoCreate(BENEFICIARY).balance(ONE_HUNDRED_HBARS), uploadInitCode(contract))
                 .when(
                         contractCreate(contract)
@@ -93,7 +93,7 @@ public class SelfDestructSuite extends HapiSuite {
     }
 
     private HapiSpec hscsEvm008SelfDestructWhenCalling() {
-        return defaultHapiSpec("HSCS_EVM_008_SelfDestructWhenCalling")
+        return defaultHapiSpec("hscsEvm008SelfDestructWhenCalling")
                 .given(
                         cryptoCreate("acc").balance(5 * ONE_HUNDRED_HBARS),
                         uploadInitCode(SELF_DESTRUCT_CALLABLE_CONTRACT))

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/openzeppelin/ERC1155ContractInteractions.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/openzeppelin/ERC1155ContractInteractions.java
@@ -62,7 +62,7 @@ public class ERC1155ContractInteractions extends HapiSuite {
     }
 
     private HapiSpec erc1155() {
-        return defaultHapiSpec("ERC-1155")
+        return defaultHapiSpec("erc1155")
                 .given(
                         newKeyNamed("ec").shape(SECP_256K1_SHAPE),
                         cryptoCreate(ACCOUNT1),

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/AssociatePrecompileSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/AssociatePrecompileSuite.java
@@ -129,7 +129,7 @@ public class AssociatePrecompileSuite extends HapiSuite {
 
     /* -- HSCS-PREC-27 from HTS Precompile Test Plan -- */
     private HapiSpec functionCallWithLessThanFourBytesFailsWithinSingleContractCall() {
-        return defaultHapiSpec("FunctionCallWithLessThanFourBytesFailsWithinSingleContractCall")
+        return defaultHapiSpec("functionCallWithLessThanFourBytesFailsWithinSingleContractCall")
                 .given(uploadInitCode(THE_GRACEFULLY_FAILING_CONTRACT), contractCreate(THE_GRACEFULLY_FAILING_CONTRACT))
                 .when(contractCall(
                                 THE_GRACEFULLY_FAILING_CONTRACT,
@@ -144,7 +144,7 @@ public class AssociatePrecompileSuite extends HapiSuite {
 
     /* -- HSCS-PREC-27 from HTS Precompile Test Plan -- */
     private HapiSpec invalidAbiCallGracefullyFailsWithinSingleContractCall() {
-        return defaultHapiSpec("InvalidAbiCallGracefullyFailsWithinSingleContractCall")
+        return defaultHapiSpec("invalidAbiCallGracefullyFailsWithinSingleContractCall")
                 .given(uploadInitCode(THE_GRACEFULLY_FAILING_CONTRACT), contractCreate(THE_GRACEFULLY_FAILING_CONTRACT))
                 .when(contractCall(
                                 THE_GRACEFULLY_FAILING_CONTRACT,
@@ -161,7 +161,7 @@ public class AssociatePrecompileSuite extends HapiSuite {
 
     /* -- HSCS-PREC-26 from HTS Precompile Test Plan -- */
     private HapiSpec nonSupportedAbiCallGracefullyFailsWithinSingleContractCall() {
-        return defaultHapiSpec("NonSupportedAbiCallGracefullyFailsWithinSingleContractCall")
+        return defaultHapiSpec("nonSupportedAbiCallGracefullyFailsWithinSingleContractCall")
                 .given(uploadInitCode(THE_GRACEFULLY_FAILING_CONTRACT), contractCreate(THE_GRACEFULLY_FAILING_CONTRACT))
                 .when(contractCall(
                                 THE_GRACEFULLY_FAILING_CONTRACT,
@@ -178,7 +178,7 @@ public class AssociatePrecompileSuite extends HapiSuite {
         final AtomicReference<AccountID> accountID = new AtomicReference<>();
         final AtomicReference<TokenID> vanillaTokenID = new AtomicReference<>();
 
-        return defaultHapiSpec("NonSupportedAbiCallGracefullyFails")
+        return defaultHapiSpec("nonSupportedAbiCallGracefullyFailsWithMultipleContractCalls")
                 .given(
                         cryptoCreate(ACCOUNT).exposingCreatedIdTo(accountID::set),
                         cryptoCreate(TOKEN_TREASURY),
@@ -227,7 +227,7 @@ public class AssociatePrecompileSuite extends HapiSuite {
         final AtomicReference<TokenID> vanillaTokenID = new AtomicReference<>();
         final var invalidAbiArgument = new byte[20];
 
-        return defaultHapiSpec("InvalidlyFormattedAbiCallGracefullyFails")
+        return defaultHapiSpec("invalidlyFormattedAbiCallGracefullyFailsWithMultipleContractCalls")
                 .given(
                         cryptoCreate(ACCOUNT).exposingCreatedIdTo(accountID::set),
                         cryptoCreate(TOKEN_TREASURY),
@@ -407,7 +407,7 @@ public class AssociatePrecompileSuite extends HapiSuite {
                 Address.wrap(Address.toChecksumAddress("0xabababababababababababababababababababab"));
         final var txn = "txn";
 
-        return defaultHapiSpec("AssociateWithMissingEvmAddressHasSaneTxnAndRecord")
+        return defaultHapiSpec("associateWithMissingEvmAddressHasSaneTxnAndRecord")
                 .given(
                         cryptoCreate(TOKEN_TREASURY),
                         uploadInitCode(INNER_CONTRACT),
@@ -427,7 +427,7 @@ public class AssociatePrecompileSuite extends HapiSuite {
 
     /* -- HSCS-PREC-27 from HTS Precompile Test Plan -- */
     private HapiSpec invalidSingleAbiCallConsumesAllProvidedGas() {
-        return defaultHapiSpec("InvalidSingleAbiCallConsumesAllProvidedGas")
+        return defaultHapiSpec("invalidSingleAbiCallConsumesAllProvidedGas")
                 .given(uploadInitCode(THE_GRACEFULLY_FAILING_CONTRACT), contractCreate(THE_GRACEFULLY_FAILING_CONTRACT))
                 .when(
                         contractCall(

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/ContractBurnHTSSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/ContractBurnHTSSuite.java
@@ -123,7 +123,7 @@ public class ContractBurnHTSSuite extends HapiSuite {
 
     private HapiSpec hscsPrec004TokenBurnOfFungibleTokenUnits() {
         final var gasUsed = 14085L;
-        return defaultHapiSpec("HSCS_PREC_004_token_burn_of_fungible_token_units")
+        return defaultHapiSpec("hscsPrec004TokenBurnOfFungibleTokenUnits")
                 .given(
                         newKeyNamed(MULTI_KEY),
                         cryptoCreate(ALICE).balance(10 * ONE_HUNDRED_HBARS),
@@ -204,7 +204,7 @@ public class ContractBurnHTSSuite extends HapiSuite {
 
     private HapiSpec hscsPrec005TokenBurnOfNft() {
         final var gasUsed = 14085;
-        return defaultHapiSpec("HSCS_PREC_005_token_burn_of_NFT")
+        return defaultHapiSpec("hscsPrec005TokenBurnOfNft")
                 .given(
                         newKeyNamed(MULTI_KEY),
                         cryptoCreate(ALICE).balance(10 * ONE_HUNDRED_HBARS),
@@ -258,7 +258,7 @@ public class ContractBurnHTSSuite extends HapiSuite {
         final var outerContract = "NestedBurn";
         final var revisedKey = KeyShape.threshOf(1, SIMPLE, DELEGATE_CONTRACT, DELEGATE_CONTRACT);
 
-        return defaultHapiSpec("HSCS_PREC_011_burn_after_nested_mint")
+        return defaultHapiSpec("hscsPrec011BurnAfterNestedMint")
                 .given(
                         newKeyNamed(MULTI_KEY),
                         cryptoCreate(ALICE).balance(10 * ONE_HUNDRED_HBARS),
@@ -328,7 +328,7 @@ public class ContractBurnHTSSuite extends HapiSuite {
         final var tokenWithHbarFee = "tokenWithHbarFee";
         final var theContract = "TransferAndBurn";
 
-        return defaultHapiSpec("HSCS_PREC_020_rollback_burn_that_fails_after_a_precompile_transfer")
+        return defaultHapiSpec("hscsPreC020RollbackBurnThatFailsAfterAPrecompileTransfer")
                 .given(
                         newKeyNamed(SUPPLY_KEY),
                         cryptoCreate(ALICE).balance(ONE_HUNDRED_HBARS),

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/ContractHTSSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/ContractHTSSuite.java
@@ -139,7 +139,7 @@ public class ContractHTSSuite extends HapiSuite {
         final var tokenWithHbarFee = "tokenWithHbarFee";
         final var theContract = "TransferAmountAndToken";
 
-        return defaultHapiSpec("HSCS_PREC_017_rollback_after_insufficient_balance")
+        return defaultHapiSpec("hscsPrec017RollbackAfterInsufficientBalance")
                 .given(
                         newKeyNamed(supplyKey),
                         cryptoCreate(alice).balance(7 * ONE_HBAR),

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/ContractKeysHTSSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/ContractKeysHTSSuite.java
@@ -1034,7 +1034,7 @@ public class ContractKeysHTSSuite extends HapiSuite {
         final AtomicReference<AccountID> accountID = new AtomicReference<>();
         final AtomicReference<TokenID> vanillaTokenID = new AtomicReference<>();
 
-        return defaultHapiSpec("callAssociateWithDelegateContractKey")
+        return defaultHapiSpec("callForAssociateWithDelegateContractKey")
                 .given(
                         cryptoCreate(ACCOUNT).exposingCreatedIdTo(accountID::set),
                         cryptoCreate(TOKEN_TREASURY),
@@ -1074,7 +1074,7 @@ public class ContractKeysHTSSuite extends HapiSuite {
         final AtomicReference<AccountID> accountID = new AtomicReference<>();
         final AtomicReference<TokenID> vanillaTokenID = new AtomicReference<>();
 
-        return defaultHapiSpec("callAssociateWithContractKey")
+        return defaultHapiSpec("callForAssociateWithContractKey")
                 .given(
                         cryptoCreate(ACCOUNT).exposingCreatedIdTo(accountID::set),
                         cryptoCreate(TOKEN_TREASURY),
@@ -1116,7 +1116,7 @@ public class ContractKeysHTSSuite extends HapiSuite {
         final AtomicReference<TokenID> vanillaTokenID = new AtomicReference<>();
         final var totalSupply = 1_000;
 
-        return defaultHapiSpec("callDissociateWithDelegateContractKey")
+        return defaultHapiSpec("callForDissociateWithDelegateContractKey")
                 .given(
                         cryptoCreate(ACCOUNT).exposingCreatedIdTo(accountID::set),
                         cryptoCreate(TOKEN_TREASURY).exposingCreatedIdTo(treasuryID::set),
@@ -1180,7 +1180,7 @@ public class ContractKeysHTSSuite extends HapiSuite {
         final AtomicReference<TokenID> vanillaTokenID = new AtomicReference<>();
         final var totalSupply = 1_000;
 
-        return defaultHapiSpec("callDissociateWithContractKey")
+        return defaultHapiSpec("callForDissociateWithContractKey")
                 .given(
                         cryptoCreate(ACCOUNT).exposingCreatedIdTo(accountID::set),
                         cryptoCreate(TOKEN_TREASURY).exposingCreatedIdTo(treasuryID::set),
@@ -1239,7 +1239,7 @@ public class ContractKeysHTSSuite extends HapiSuite {
     }
 
     private HapiSpec callForBurnWithDelegateContractKey() {
-        return defaultHapiSpec("callBurnWithDelegateContractKey")
+        return defaultHapiSpec("callForBurnWithDelegateContractKey")
                 .given(
                         newKeyNamed(MULTI_KEY),
                         cryptoCreate(TOKEN_TREASURY),
@@ -2370,7 +2370,7 @@ public class ContractKeysHTSSuite extends HapiSuite {
     }
 
     private HapiSpec callForBurnWithContractKey() {
-        return defaultHapiSpec("callBurnWithContractKey")
+        return defaultHapiSpec("callForBurnWithContractKey")
                 .given(
                         newKeyNamed(MULTI_KEY),
                         cryptoCreate(TOKEN_TREASURY),

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/ContractMintHTSSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/ContractMintHTSSuite.java
@@ -300,7 +300,7 @@ public class ContractMintHTSSuite extends HapiSuite {
         final var gasUsed = 14085L;
         final AtomicReference<TokenID> fungible = new AtomicReference<>();
 
-        return defaultHapiSpec("FungibleMint")
+        return defaultHapiSpec("happyPathFungibleTokenMint")
                 .given(
                         newKeyNamed(MULTI_KEY),
                         cryptoCreate(ACCOUNT).balance(ONE_MILLION_HBARS).payingWith(GENESIS),
@@ -351,7 +351,7 @@ public class ContractMintHTSSuite extends HapiSuite {
         final var totalSupply = 2;
         final AtomicReference<TokenID> nonFungible = new AtomicReference<>();
 
-        return defaultHapiSpec("NonFungibleMint")
+        return defaultHapiSpec("happyPathNonFungibleTokenMint")
                 .given(
                         newKeyNamed(MULTI_KEY),
                         cryptoCreate(ACCOUNT).balance(10 * ONE_HUNDRED_HBARS),

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/CryptoTransferHTSSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/CryptoTransferHTSSuite.java
@@ -1040,7 +1040,7 @@ public class CryptoTransferHTSSuite extends HapiSuite {
         final var senderKey = "senderKey";
         final var contractKey = "contractAdminKey";
 
-        return defaultHapiSpec("ActiveContractIsVerifiedWithoutCheckingSignatures")
+        return defaultHapiSpec("activeContractInFrameIsVerifiedWithoutNeedForSignature")
                 .given(
                         newKeyNamed(multiKey),
                         newKeyNamed(senderKey),

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/ERCPrecompileSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/ERCPrecompileSuite.java
@@ -194,14 +194,14 @@ public class ERCPrecompileSuite extends HapiSuite {
                 transferErc20TokenFailWithAccount(),
                 erc20Allowance(),
                 erc20Approve(),
-                someERC20ApproveAllowanceScenariosPass(),
-                someERC20NegativeTransferFromScenariosPass(),
-                someERC20ApproveAllowanceScenarioInOneCall(),
+                someErc20ApproveAllowanceScenariosPass(),
+                someErc20NegativeTransferFromScenariosPass(),
+                someErc20ApproveAllowanceScenarioInOneCall(),
                 getErc20TokenDecimalsFromErc721TokenFails(),
                 transferErc20TokenReceiverContract(),
                 transferErc20TokenAliasedSender(),
-                directCallsWorkForERC20(),
-                erc20TransferFrom(),
+                directCallsWorkForErc20(),
+                erc20TransferFromAllowance(),
                 erc20TransferFromSelf(),
                 getErc20TokenNameExceedingLimits(),
                 transferErc20TokenFromContractWithNoApproval());
@@ -219,21 +219,21 @@ public class ERCPrecompileSuite extends HapiSuite {
                 erc721GetApproved(),
                 getErc721TokenURIFromErc20TokenFails(),
                 getErc721OwnerOfFromErc20TokenFails(),
-                directCallsWorkForERC721(),
-                someERC721ApproveAndRemoveScenariosPass(),
-                someERC721NegativeTransferFromScenariosPass(),
+                directCallsWorkForErc721(),
+                someErc721ApproveAndRemoveScenariosPass(),
+                someErc721NegativeTransferFromScenariosPass(),
                 erc721TransferFromWithApproval(),
                 erc721TransferFromWithApproveForAll(),
-                someERC721GetApprovedScenariosPass(),
-                someERC721BalanceOfScenariosPass(),
-                someERC721OwnerOfScenariosPass(),
-                someERC721IsApprovedForAllScenariosPass(),
+                someErc721GetApprovedScenariosPass(),
+                someErc721BalanceOfScenariosPass(),
+                someErc721OwnerOfScenariosPass(),
+                someErc721IsApprovedForAllScenariosPass(),
                 getErc721IsApprovedForAll(),
-                someERC721SetApprovedForAllScenariosPass());
+                someErc721SetApprovedForAllScenariosPass());
     }
 
     private HapiSpec getErc20TokenName() {
-        return defaultHapiSpec("ERC_20_NAME")
+        return defaultHapiSpec("getErc20TokenName")
                 .given(
                         newKeyNamed(MULTI_KEY),
                         cryptoCreate(ACCOUNT).balance(100 * ONE_HUNDRED_HBARS),
@@ -274,7 +274,7 @@ public class ERCPrecompileSuite extends HapiSuite {
         final var tokenSymbol = "F";
         final AtomicReference<String> tokenAddr = new AtomicReference<>();
 
-        return defaultHapiSpec("ERC_20_SYMBOL")
+        return defaultHapiSpec("getErc20TokenSymbol")
                 .given(
                         newKeyNamed(MULTI_KEY),
                         cryptoCreate(ACCOUNT).balance(100 * ONE_HUNDRED_HBARS),
@@ -320,7 +320,7 @@ public class ERCPrecompileSuite extends HapiSuite {
         final var decimalsTxn = "decimalsTxn";
         final AtomicReference<String> tokenAddr = new AtomicReference<>();
 
-        return defaultHapiSpec("ERC_20_DECIMALS")
+        return defaultHapiSpec("getErc20TokenDecimals")
                 .given(
                         newKeyNamed(MULTI_KEY),
                         cryptoCreate(ACCOUNT).balance(100 * ONE_HUNDRED_HBARS),
@@ -368,7 +368,7 @@ public class ERCPrecompileSuite extends HapiSuite {
         final var supplyTxn = "supplyTxn";
         final AtomicReference<String> tokenAddr = new AtomicReference<>();
 
-        return defaultHapiSpec("ERC_20_TOTAL_SUPPLY")
+        return defaultHapiSpec("getErc20TotalSupply")
                 .given(
                         newKeyNamed(MULTI_KEY),
                         cryptoCreate(ACCOUNT).balance(100 * ONE_HUNDRED_HBARS),
@@ -414,7 +414,7 @@ public class ERCPrecompileSuite extends HapiSuite {
         final AtomicReference<String> tokenAddr = new AtomicReference<>();
         final AtomicReference<String> accountAddr = new AtomicReference<>();
 
-        return defaultHapiSpec("ERC_20_BALANCE_OF")
+        return defaultHapiSpec("getErc20BalanceOfAccount")
                 .given(
                         newKeyNamed(MULTI_KEY),
                         cryptoCreate(ACCOUNT)
@@ -489,7 +489,7 @@ public class ERCPrecompileSuite extends HapiSuite {
         final AtomicReference<String> tokenAddr = new AtomicReference<>();
         final AtomicReference<String> accountAddr = new AtomicReference<>();
 
-        return defaultHapiSpec("ERC_20_TRANSFER")
+        return defaultHapiSpec("transferErc20Token")
                 .given(
                         newKeyNamed(MULTI_KEY),
                         cryptoCreate(ACCOUNT)
@@ -575,7 +575,7 @@ public class ERCPrecompileSuite extends HapiSuite {
         final AtomicReference<String> tokenAddr = new AtomicReference<>();
         final AtomicReference<String> accountAddr = new AtomicReference<>();
 
-        return defaultHapiSpec("ERC_20_TRANSFER")
+        return defaultHapiSpec("transferErc20TokenFailWithAccount")
                 .given(
                         newKeyNamed(MULTI_KEY),
                         cryptoCreate(ACCOUNT)
@@ -618,7 +618,7 @@ public class ERCPrecompileSuite extends HapiSuite {
     private HapiSpec transferErc20TokenReceiverContract() {
         final var nestedContract = NESTED_ERC_20_CONTRACT;
 
-        return defaultHapiSpec("ERC_20_TRANSFER_RECEIVER_CONTRACT")
+        return defaultHapiSpec("transferErc20TokenReceiverContract")
                 .given(
                         newKeyNamed(MULTI_KEY),
                         cryptoCreate(ACCOUNT).balance(100 * ONE_MILLION_HBARS),
@@ -702,7 +702,7 @@ public class ERCPrecompileSuite extends HapiSuite {
         final AtomicReference<String> childMirror = new AtomicReference<>();
         final AtomicReference<String> childEip1014 = new AtomicReference<>();
 
-        return defaultHapiSpec("ERC_20_TRANSFER_ALIASED_SENDER")
+        return defaultHapiSpec("transferErc20TokenAliasedSender")
                 .given(
                         newKeyNamed(MULTI_KEY),
                         cryptoCreate(OWNER),
@@ -776,7 +776,7 @@ public class ERCPrecompileSuite extends HapiSuite {
         final var transferFromOtherContractWithSignaturesTxn = "transferFromOtherContractWithSignaturesTxn";
         final var nestedContract = NESTED_ERC_20_CONTRACT;
 
-        return defaultHapiSpec("ERC_20_TRANSFER_FROM_CONTRACT_WITH_NO_APPROVAL")
+        return defaultHapiSpec("transferErc20TokenFromContractWithNoApproval")
                 .given(
                         newKeyNamed(MULTI_KEY),
                         cryptoCreate(ACCOUNT).balance(10 * ONE_MILLION_HBARS),
@@ -841,7 +841,7 @@ public class ERCPrecompileSuite extends HapiSuite {
     }
 
     private HapiSpec erc20Allowance() {
-        return defaultHapiSpec("ERC_20_ALLOWANCE")
+        return defaultHapiSpec("erc20Allowance")
                 .given(
                         newKeyNamed(MULTI_KEY),
                         cryptoCreate(OWNER).balance(100 * ONE_HUNDRED_HBARS),
@@ -896,7 +896,7 @@ public class ERCPrecompileSuite extends HapiSuite {
     private HapiSpec erc20Approve() {
         final var approveTxn = "approveTxn";
 
-        return defaultHapiSpec("ERC_20_APPROVE")
+        return defaultHapiSpec("erc20Approve")
                 .given(
                         newKeyNamed(MULTI_KEY),
                         cryptoCreate(OWNER).balance(100 * ONE_HUNDRED_HBARS),
@@ -936,7 +936,7 @@ public class ERCPrecompileSuite extends HapiSuite {
     private HapiSpec getErc20TokenDecimalsFromErc721TokenFails() {
         final var invalidDecimalsTxn = "decimalsFromErc721Txn";
 
-        return defaultHapiSpec("ERC_20_DECIMALS_FROM_ERC_721_TOKEN")
+        return defaultHapiSpec("getErc20TokenDecimalsFromErc721TokenFails")
                 .given(
                         newKeyNamed(MULTI_KEY),
                         cryptoCreate(ACCOUNT).balance(100 * ONE_HUNDRED_HBARS),
@@ -966,7 +966,7 @@ public class ERCPrecompileSuite extends HapiSuite {
     }
 
     private HapiSpec getErc721TokenName() {
-        return defaultHapiSpec("ERC_721_NAME")
+        return defaultHapiSpec("getErc721TokenName")
                 .given(
                         newKeyNamed(MULTI_KEY),
                         cryptoCreate(ACCOUNT).balance(100 * ONE_HUNDRED_HBARS),
@@ -1062,7 +1062,7 @@ public class ERCPrecompileSuite extends HapiSuite {
     private HapiSpec getErc721Symbol() {
         final var tokenSymbol = "N";
 
-        return defaultHapiSpec("ERC_721_SYMBOL")
+        return defaultHapiSpec("getErc721Symbol")
                 .given(
                         newKeyNamed(MULTI_KEY),
                         cryptoCreate(ACCOUNT).balance(100 * ONE_HUNDRED_HBARS),
@@ -1104,7 +1104,7 @@ public class ERCPrecompileSuite extends HapiSuite {
         final var nonExistingTokenURITxn = "nonExistingTokenURITxn";
         final var ERC721MetadataNonExistingToken = "ERC721Metadata: URI query for nonexistent token";
 
-        return defaultHapiSpec("ERC_721_TOKEN_URI")
+        return defaultHapiSpec("getErc721TokenURI")
                 .given(
                         newKeyNamed(MULTI_KEY),
                         cryptoCreate(ACCOUNT).balance(100 * ONE_HUNDRED_HBARS),
@@ -1162,7 +1162,7 @@ public class ERCPrecompileSuite extends HapiSuite {
     }
 
     private HapiSpec getErc721TotalSupply() {
-        return defaultHapiSpec("ERC_721_TOTAL_SUPPLY")
+        return defaultHapiSpec("getErc721TotalSupply")
                 .given(
                         newKeyNamed(MULTI_KEY),
                         cryptoCreate(ACCOUNT).balance(100 * ONE_HUNDRED_HBARS),
@@ -1201,7 +1201,7 @@ public class ERCPrecompileSuite extends HapiSuite {
     private HapiSpec getErc721BalanceOf() {
         final var zeroBalanceOfTxn = "zbalanceOfTxn";
 
-        return defaultHapiSpec("ERC_721_BALANCE_OF")
+        return defaultHapiSpec("getErc721BalanceOf")
                 .given(
                         newKeyNamed(MULTI_KEY),
                         cryptoCreate(OWNER).balance(100 * ONE_HUNDRED_HBARS),
@@ -1268,7 +1268,7 @@ public class ERCPrecompileSuite extends HapiSuite {
         final AtomicReference<byte[]> ownerAddr = new AtomicReference<>();
         final AtomicReference<String> tokenAddr = new AtomicReference<>();
 
-        return defaultHapiSpec("ERC_721_OWNER_OF")
+        return defaultHapiSpec("getErc721OwnerOf")
                 .given(
                         newKeyNamed(MULTI_KEY),
                         cryptoCreate(OWNER).balance(100 * ONE_HUNDRED_HBARS),
@@ -1322,7 +1322,7 @@ public class ERCPrecompileSuite extends HapiSuite {
     private HapiSpec getErc721TokenURIFromErc20TokenFails() {
         final var invalidTokenURITxn = "tokenURITxnFromErc20";
 
-        return defaultHapiSpec("ERC_721_TOKEN_URI_FROM_ERC_20_TOKEN")
+        return defaultHapiSpec("getErc721TokenURIFromErc20TokenFails")
                 .given(
                         newKeyNamed(MULTI_KEY),
                         cryptoCreate(ACCOUNT).balance(100 * ONE_HUNDRED_HBARS),
@@ -1353,7 +1353,7 @@ public class ERCPrecompileSuite extends HapiSuite {
     private HapiSpec getErc721OwnerOfFromErc20TokenFails() {
         final var invalidOwnerOfTxn = "ownerOfTxnFromErc20Token";
 
-        return defaultHapiSpec("ERC_721_OWNER_OF_FROM_ERC_20_TOKEN")
+        return defaultHapiSpec("getErc721OwnerOfFromErc20TokenFails")
                 .given(
                         newKeyNamed(MULTI_KEY),
                         cryptoCreate(OWNER).balance(100 * ONE_HUNDRED_HBARS),
@@ -1383,7 +1383,7 @@ public class ERCPrecompileSuite extends HapiSuite {
                 .then(getTxnRecord(invalidOwnerOfTxn).andAllChildRecords().logged());
     }
 
-    private HapiSpec directCallsWorkForERC20() {
+    private HapiSpec directCallsWorkForErc20() {
         final AtomicReference<String> tokenNum = new AtomicReference<>();
 
         final var tokenSymbol = "FDFGF";
@@ -1393,7 +1393,7 @@ public class ERCPrecompileSuite extends HapiSuite {
 
         final var decimalsTxn = "decimalsTxn";
 
-        return defaultHapiSpec("DirectCallsWorkForERC20")
+        return defaultHapiSpec("directCallsWorkForErc20")
                 .given(
                         newKeyNamed(MULTI_KEY),
                         cryptoCreate(ACCOUNT).balance(100 * ONE_HUNDRED_HBARS),
@@ -1529,14 +1529,14 @@ public class ERCPrecompileSuite extends HapiSuite {
                                                         .withErcFungibleTransferStatus(true)))))));
     }
 
-    private HapiSpec someERC721NegativeTransferFromScenariosPass() {
+    private HapiSpec someErc721NegativeTransferFromScenariosPass() {
         final AtomicReference<String> tokenMirrorAddr = new AtomicReference<>();
         final AtomicReference<String> contractMirrorAddr = new AtomicReference<>();
         final AtomicReference<String> aCivilianMirrorAddr = new AtomicReference<>();
         final AtomicReference<String> bCivilianMirrorAddr = new AtomicReference<>();
         final AtomicReference<String> zCivilianMirrorAddr = new AtomicReference<>();
 
-        return defaultHapiSpec("SomeERC721NegativeTransferFromScenariosPass")
+        return defaultHapiSpec("someErc721NegativeTransferFromScenariosPass")
                 .given(
                         newKeyNamed(MULTI_KEY_NAME),
                         cryptoCreate(A_CIVILIAN)
@@ -1638,13 +1638,13 @@ public class ERCPrecompileSuite extends HapiSuite {
                                 recordWith().status(SPENDER_DOES_NOT_HAVE_ALLOWANCE)));
     }
 
-    private HapiSpec someERC721ApproveAndRemoveScenariosPass() {
+    private HapiSpec someErc721ApproveAndRemoveScenariosPass() {
         final AtomicReference<String> tokenMirrorAddr = new AtomicReference<>();
         final AtomicReference<String> aCivilianMirrorAddr = new AtomicReference<>();
         final AtomicReference<String> bCivilianMirrorAddr = new AtomicReference<>();
         final AtomicReference<String> zCivilianMirrorAddr = new AtomicReference<>();
 
-        return defaultHapiSpec("SomeERC721ApproveAndRemoveScenariosPass")
+        return defaultHapiSpec("someErc721ApproveAndRemoveScenariosPass")
                 .given(
                         newKeyNamed(MULTI_KEY_NAME),
                         cryptoCreate(A_CIVILIAN)
@@ -1833,14 +1833,14 @@ public class ERCPrecompileSuite extends HapiSuite {
                         getTokenNftInfo(NF_TOKEN, 5L).hasAccountID(B_CIVILIAN).hasNoSpender());
     }
 
-    private HapiSpec someERC20ApproveAllowanceScenariosPass() {
+    private HapiSpec someErc20ApproveAllowanceScenariosPass() {
         final AtomicReference<String> tokenMirrorAddr = new AtomicReference<>();
         final AtomicReference<String> contractMirrorAddr = new AtomicReference<>();
         final AtomicReference<String> aCivilianMirrorAddr = new AtomicReference<>();
         final AtomicReference<String> bCivilianMirrorAddr = new AtomicReference<>();
         final AtomicReference<String> zCivilianMirrorAddr = new AtomicReference<>();
 
-        return defaultHapiSpec("someERC20ApproveAllowanceScenariosPass")
+        return defaultHapiSpec("someErc20ApproveAllowanceScenariosPass")
                 .given(
                         newKeyNamed(MULTI_KEY_NAME),
                         cryptoCreate(A_CIVILIAN)
@@ -1984,14 +1984,14 @@ public class ERCPrecompileSuite extends HapiSuite {
                                                         .withAllowance(0L)))));
     }
 
-    private HapiSpec someERC20NegativeTransferFromScenariosPass() {
+    private HapiSpec someErc20NegativeTransferFromScenariosPass() {
         final AtomicReference<String> tokenMirrorAddr = new AtomicReference<>();
         final AtomicReference<String> contractMirrorAddr = new AtomicReference<>();
         final AtomicReference<String> aCivilianMirrorAddr = new AtomicReference<>();
         final AtomicReference<String> bCivilianMirrorAddr = new AtomicReference<>();
         final AtomicReference<String> zCivilianMirrorAddr = new AtomicReference<>();
 
-        return defaultHapiSpec("someERC20NegativeTransferFromScenariosPass")
+        return defaultHapiSpec("someErc20NegativeTransferFromScenariosPass")
                 .given(
                         newKeyNamed(MULTI_KEY_NAME),
                         cryptoCreate(A_CIVILIAN)
@@ -2115,14 +2115,14 @@ public class ERCPrecompileSuite extends HapiSuite {
                                 recordWith().status(INSUFFICIENT_TOKEN_BALANCE)));
     }
 
-    private HapiSpec someERC20ApproveAllowanceScenarioInOneCall() {
+    private HapiSpec someErc20ApproveAllowanceScenarioInOneCall() {
         final AtomicReference<String> tokenMirrorAddr = new AtomicReference<>();
         final AtomicReference<String> contractMirrorAddr = new AtomicReference<>();
         final AtomicReference<String> aCivilianMirrorAddr = new AtomicReference<>();
         final AtomicReference<String> bCivilianMirrorAddr = new AtomicReference<>();
         final AtomicReference<String> zCivilianMirrorAddr = new AtomicReference<>();
 
-        return defaultHapiSpec("someERC20ApproveAllowanceScenarioInOneCall")
+        return defaultHapiSpec("someErc20ApproveAllowanceScenarioInOneCall")
                 .given(
                         newKeyNamed(MULTI_KEY_NAME),
                         cryptoCreate(A_CIVILIAN)
@@ -2169,7 +2169,7 @@ public class ERCPrecompileSuite extends HapiSuite {
                                                 .withAllowance(5L)))));
     }
 
-    private HapiSpec directCallsWorkForERC721() {
+    private HapiSpec directCallsWorkForErc721() {
 
         final AtomicReference<String> tokenNum = new AtomicReference<>();
 
@@ -2179,7 +2179,7 @@ public class ERCPrecompileSuite extends HapiSuite {
         final var tokenURITxn = "tokenURITxn";
         final var ownerOfTxn = "ownerOfTxn";
 
-        return defaultHapiSpec("DirectCallsWorkForERC721")
+        return defaultHapiSpec("directCallsWorkForErc721")
                 .given(
                         newKeyNamed(MULTI_KEY),
                         cryptoCreate(ACCOUNT).balance(100 * ONE_HUNDRED_HBARS),
@@ -2308,13 +2308,13 @@ public class ERCPrecompileSuite extends HapiSuite {
                                                                 spec.registry().getAccountID(ACCOUNT)))))))));
     }
 
-    private HapiSpec someERC721GetApprovedScenariosPass() {
+    private HapiSpec someErc721GetApprovedScenariosPass() {
         final AtomicReference<String> tokenMirrorAddr = new AtomicReference<>();
         final AtomicReference<String> aCivilianMirrorAddr = new AtomicReference<>();
         final AtomicReference<String> zCivilianMirrorAddr = new AtomicReference<>();
         final AtomicReference<String> zTokenMirrorAddr = new AtomicReference<>();
 
-        return defaultHapiSpec("someERC721GetApprovedScenariosPass")
+        return defaultHapiSpec("someErc721GetApprovedScenariosPass")
                 .given(
                         newKeyNamed(MULTI_KEY_NAME),
                         cryptoCreate(A_CIVILIAN)
@@ -2416,13 +2416,13 @@ public class ERCPrecompileSuite extends HapiSuite {
                                                                 spec.registry().getAccountID(A_CIVILIAN)))))))));
     }
 
-    private HapiSpec someERC721BalanceOfScenariosPass() {
+    private HapiSpec someErc721BalanceOfScenariosPass() {
         final AtomicReference<String> tokenMirrorAddr = new AtomicReference<>();
         final AtomicReference<String> aCivilianMirrorAddr = new AtomicReference<>();
         final AtomicReference<String> bCivilianMirrorAddr = new AtomicReference<>();
         final AtomicReference<String> zTokenMirrorAddr = new AtomicReference<>();
 
-        return defaultHapiSpec("someERC721BalanceOfScenariosPass")
+        return defaultHapiSpec("someErc721BalanceOfScenariosPass")
                 .given(
                         newKeyNamed(MULTI_KEY_NAME),
                         cryptoCreate(A_CIVILIAN)
@@ -2495,13 +2495,13 @@ public class ERCPrecompileSuite extends HapiSuite {
                                                         .withBalance(0)))));
     }
 
-    private HapiSpec someERC721OwnerOfScenariosPass() {
+    private HapiSpec someErc721OwnerOfScenariosPass() {
         final AtomicReference<String> tokenMirrorAddr = new AtomicReference<>();
         final AtomicReference<String> aCivilianMirrorAddr = new AtomicReference<>();
         final AtomicReference<String> zCivilianMirrorAddr = new AtomicReference<>();
         final AtomicReference<String> zTokenMirrorAddr = new AtomicReference<>();
 
-        return defaultHapiSpec("someERC721OwnerOfScenariosPass")
+        return defaultHapiSpec("someErc721OwnerOfScenariosPass")
                 .given(
                         newKeyNamed(MULTI_KEY_NAME),
                         cryptoCreate(A_CIVILIAN)
@@ -2587,14 +2587,14 @@ public class ERCPrecompileSuite extends HapiSuite {
                                                                 spec.registry().getAccountID(A_CIVILIAN)))))))));
     }
 
-    private HapiSpec someERC721IsApprovedForAllScenariosPass() {
+    private HapiSpec someErc721IsApprovedForAllScenariosPass() {
         final AtomicReference<String> tokenMirrorAddr = new AtomicReference<>();
         final AtomicReference<String> contractMirrorAddr = new AtomicReference<>();
         final AtomicReference<String> aCivilianMirrorAddr = new AtomicReference<>();
         final AtomicReference<String> zCivilianMirrorAddr = new AtomicReference<>();
         final AtomicReference<String> zTokenMirrorAddr = new AtomicReference<>();
 
-        return defaultHapiSpec("someERC721IsApprovedForAllScenariosPass")
+        return defaultHapiSpec("someErc721IsApprovedForAllScenariosPass")
                 .given(
                         newKeyNamed(MULTI_KEY_NAME),
                         cryptoCreate(A_CIVILIAN)
@@ -2713,14 +2713,14 @@ public class ERCPrecompileSuite extends HapiSuite {
                                                         .withIsApprovedForAll(true)))))));
     }
 
-    private HapiSpec someERC721SetApprovedForAllScenariosPass() {
+    private HapiSpec someErc721SetApprovedForAllScenariosPass() {
         final AtomicReference<String> tokenMirrorAddr = new AtomicReference<>();
         final AtomicReference<String> contractMirrorAddr = new AtomicReference<>();
         final AtomicReference<String> aCivilianMirrorAddr = new AtomicReference<>();
         final AtomicReference<String> zCivilianMirrorAddr = new AtomicReference<>();
         final AtomicReference<String> zTokenMirrorAddr = new AtomicReference<>();
 
-        return defaultHapiSpec("someERC721SetApprovedForAllScenariosPass")
+        return defaultHapiSpec("someErc721SetApprovedForAllScenariosPass")
                 .given(
                         newKeyNamed(MULTI_KEY_NAME),
                         cryptoCreate(A_CIVILIAN)
@@ -2929,7 +2929,7 @@ public class ERCPrecompileSuite extends HapiSuite {
     }
 
     private HapiSpec erc721TokenApprove() {
-        return defaultHapiSpec("Erc721TokenApprove")
+        return defaultHapiSpec("erc721TokenApprove")
                 .given(
                         newKeyNamed(MULTI_KEY),
                         cryptoCreate(ACCOUNT).balance(100 * ONE_HUNDRED_HBARS),
@@ -2968,7 +2968,7 @@ public class ERCPrecompileSuite extends HapiSuite {
     private HapiSpec erc721GetApproved() {
         final var theSpender2 = "spender2";
 
-        return defaultHapiSpec("Erc721GetApproved")
+        return defaultHapiSpec("erc721GetApproved")
                 .given(
                         newKeyNamed(MULTI_KEY),
                         cryptoCreate(OWNER).balance(100 * ONE_HUNDRED_HBARS).maxAutomaticTokenAssociations(10),
@@ -3022,10 +3022,10 @@ public class ERCPrecompileSuite extends HapiSuite {
                         getTxnRecord(ALLOWANCE_TXN).andAllChildRecords().logged());
     }
 
-    private HapiSpec erc20TransferFrom() {
+    private HapiSpec erc20TransferFromAllowance() {
         final var allowanceTxn2 = "allowanceTxn2";
 
-        return defaultHapiSpec("ERC_20_ALLOWANCE")
+        return defaultHapiSpec("erc20TransferFromAllowance")
                 .given(
                         newKeyNamed(MULTI_KEY),
                         cryptoCreate(OWNER).balance(100 * ONE_HUNDRED_HBARS),
@@ -3119,7 +3119,7 @@ public class ERCPrecompileSuite extends HapiSuite {
     }
 
     private HapiSpec erc20TransferFromSelf() {
-        return defaultHapiSpec("Erc20TransferFromSelf")
+        return defaultHapiSpec("erc20TransferFromSelf")
                 .given(
                         newKeyNamed(MULTI_KEY),
                         cryptoCreate(RECIPIENT),
@@ -3164,7 +3164,7 @@ public class ERCPrecompileSuite extends HapiSuite {
     }
 
     private HapiSpec erc721TransferFromWithApproval() {
-        return defaultHapiSpec("ERC_721_TRANSFER_FROM_WITH_APPROVAL")
+        return defaultHapiSpec("erc721TransferFromWithApproval")
                 .given(
                         newKeyNamed(MULTI_KEY),
                         cryptoCreate(OWNER).balance(100 * ONE_HUNDRED_HBARS),
@@ -3242,7 +3242,7 @@ public class ERCPrecompileSuite extends HapiSuite {
     }
 
     private HapiSpec erc721TransferFromWithApproveForAll() {
-        return defaultHapiSpec("ERC_721_TRANSFER_FROM_WITH_APPROVAL_FOR_ALL")
+        return defaultHapiSpec("erc721TransferFromWithApproveForAll")
                 .given(
                         newKeyNamed(MULTI_KEY),
                         cryptoCreate(OWNER).balance(100 * ONE_HUNDRED_HBARS),

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/LazyCreateThroughPrecompileSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/LazyCreateThroughPrecompileSuite.java
@@ -170,7 +170,7 @@ public class LazyCreateThroughPrecompileSuite extends HapiSuite {
                 cryptoTransferV1LazyCreate(),
                 cryptoTransferV2LazyCreate(),
                 transferTokenLazyCreate(),
-                transferTokensLazyCreate(),
+                transferTokensToEVMAddressAliasRevertAndTransferAgainSuccessfully(),
                 transferNftLazyCreate(),
                 transferNftsLazyCreate(),
                 erc20TransferLazyCreate(),
@@ -918,7 +918,7 @@ public class LazyCreateThroughPrecompileSuite extends HapiSuite {
                 .then();
     }
 
-    private HapiSpec transferTokensLazyCreate() {
+    private HapiSpec transferTokensToEVMAddressAliasRevertAndTransferAgainSuccessfully() {
         final AtomicReference<String> tokenAddr = new AtomicReference<>();
 
         return defaultHapiSpec("transferTokensToEVMAddressAliasRevertAndTransferAgainSuccessfully")

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/MixedHTSPrecompileTestsSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/MixedHTSPrecompileTestsSuite.java
@@ -91,7 +91,7 @@ public class MixedHTSPrecompileTestsSuite extends HapiSuite {
         final var outerContract = "AssociateTryCatch";
         final var nestedContract = "CalledContract";
 
-        return defaultHapiSpec("HSCS_PREC_021_try_catch_construct_only_rolls_back_the_failed_precompile")
+        return defaultHapiSpec("hscsPrec021TryCatchConstructOnlyRollsBackTheFailedPrecompile")
                 .given(
                         cryptoCreate(theAccount).balance(10 * ONE_HUNDRED_HBARS),
                         cryptoCreate(TOKEN_TREASURY),

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/PauseUnpauseTokenAccountPrecompileSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/PauseUnpauseTokenAccountPrecompileSuite.java
@@ -151,7 +151,7 @@ public class PauseUnpauseTokenAccountPrecompileSuite extends HapiSuite {
     private HapiSpec noAccountKeyReverts() {
         final AtomicReference<AccountID> accountID = new AtomicReference<>();
         final AtomicReference<TokenID> vanillaTokenID = new AtomicReference<>();
-        return defaultHapiSpec("noKeyReverts")
+        return defaultHapiSpec("noAccountKeyReverts")
                 .given(
                         newKeyNamed(MULTI_KEY),
                         cryptoCreate(ACCOUNT).balance(100 * ONE_HBAR).exposingCreatedIdTo(accountID::set),

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/SigningReqsSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/SigningReqsSuite.java
@@ -388,7 +388,7 @@ public class SigningReqsSuite extends HapiSuite {
         final AtomicReference<Address> tokenMirrorAddr = new AtomicReference<>();
         final AtomicReference<Address> newAutoRenewAliasAddr = new AtomicReference<>();
 
-        return defaultHapiSpec("NewAutoRenewAccountMustSign")
+        return defaultHapiSpec("newAutoRenewAccountMustSignUpdate")
                 .given(
                         newKeyNamed(adminKey),
                         newKeyNamed(narKey).shape(SECP256K1),

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/TokenInfoHTSSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/TokenInfoHTSSuite.java
@@ -772,7 +772,7 @@ public class TokenInfoHTSSuite extends HapiSuite {
     }
 
     private HapiSpec getInfoOnDeletedFungibleTokenWorks() {
-        return defaultHapiSpec("GetInfoOnDeletedFungibleTokenFails")
+        return defaultHapiSpec("getInfoOnDeletedFungibleTokenWorks")
                 .given(
                         cryptoCreate(TOKEN_TREASURY).balance(0L),
                         cryptoCreate(AUTO_RENEW_ACCOUNT).balance(0L),
@@ -817,7 +817,7 @@ public class TokenInfoHTSSuite extends HapiSuite {
     }
 
     private HapiSpec getInfoOnInvalidFungibleTokenFails() {
-        return defaultHapiSpec("GetInfoOnInvalidFungibleTokenFails")
+        return defaultHapiSpec("getInfoOnInvalidFungibleTokenFails")
                 .given(
                         cryptoCreate(TOKEN_TREASURY).balance(0L),
                         cryptoCreate(AUTO_RENEW_ACCOUNT).balance(0L),
@@ -860,7 +860,7 @@ public class TokenInfoHTSSuite extends HapiSuite {
 
     private HapiSpec getInfoOnDeletedNonFungibleTokenFails() {
         final ByteString meta = ByteString.copyFrom(META.getBytes(StandardCharsets.UTF_8));
-        return defaultHapiSpec("GetInfoOnDeletedNonFungibleTokenFails")
+        return defaultHapiSpec("getInfoOnDeletedNonFungibleTokenFails")
                 .given(
                         cryptoCreate(TOKEN_TREASURY).balance(0L),
                         cryptoCreate(AUTO_RENEW_ACCOUNT).balance(0L),
@@ -902,7 +902,7 @@ public class TokenInfoHTSSuite extends HapiSuite {
 
     private HapiSpec getInfoOnInvalidNonFungibleTokenFails() {
         final ByteString meta = ByteString.copyFrom(META.getBytes(StandardCharsets.UTF_8));
-        return defaultHapiSpec("GetInfoOnDeletedNonFungibleTokenFails")
+        return defaultHapiSpec("getInfoOnInvalidNonFungibleTokenFails")
                 .given(
                         cryptoCreate(TOKEN_TREASURY).balance(0L),
                         cryptoCreate(AUTO_RENEW_ACCOUNT).balance(0L),
@@ -1076,7 +1076,7 @@ public class TokenInfoHTSSuite extends HapiSuite {
 
     private HapiSpec happyPathUpdateTokenKeysAndReadLatestInformation() {
         final String TOKEN_INFO_AS_KEY = "TOKEN_INFO_CONTRACT_KEY";
-        return defaultHapiSpec("UpdateTokenKeysAndReadLatestInformation")
+        return defaultHapiSpec("happyPathUpdateTokenKeysAndReadLatestInformation")
                 .given(
                         cryptoCreate(TOKEN_TREASURY).balance(0L),
                         cryptoCreate(AUTO_RENEW_ACCOUNT).balance(0L),

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/TokenUpdatePrecompileSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/TokenUpdatePrecompileSuite.java
@@ -153,7 +153,7 @@ public class TokenUpdatePrecompileSuite extends HapiSuite {
                 updateWithTooLongNameAndSymbol(),
                 updateTokenWithKeysNegative(),
                 updateTokenWithInvalidKeyValues(),
-                updateNftTokenKeysWithWrongTokenIdAndMissingAdmin(),
+                updateNftTokenKeysWithWrongTokenIdAndMissingAdminKey(),
                 getTokenKeyForNonFungibleNegative());
     }
 
@@ -947,7 +947,7 @@ public class TokenUpdatePrecompileSuite extends HapiSuite {
                                 .hasPauseKey(TOKEN_UPDATE_AS_KEY))));
     }
 
-    public HapiSpec updateNftTokenKeysWithWrongTokenIdAndMissingAdmin() {
+    public HapiSpec updateNftTokenKeysWithWrongTokenIdAndMissingAdminKey() {
         final AtomicReference<TokenID> nftToken = new AtomicReference<>();
         return defaultHapiSpec("updateNftTokenKeysWithWrongTokenIdAndMissingAdminKey")
                 .given(

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/records/RecordsSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/records/RecordsSuite.java
@@ -55,9 +55,10 @@ public class RecordsSuite extends HapiSuite {
 
     HapiSpec bigCall() {
         final var contract = "BigBig";
+        final var txName = "BigCall";
         final long byteArraySize = (long) (87.5 * 1_024);
 
-        return defaultHapiSpec("BigRecord")
+        return defaultHapiSpec("bigCall")
                 .given(
                         cryptoCreate("payer").balance(10 * ONE_HUNDRED_HBARS),
                         uploadInitCode(contract),
@@ -65,8 +66,8 @@ public class RecordsSuite extends HapiSuite {
                 .when(contractCall(contract, "pick", byteArraySize)
                         .payingWith("payer")
                         .gas(400_000L)
-                        .via("bigCall"))
-                .then(getTxnRecord("bigCall"));
+                        .via(txName))
+                .then(getTxnRecord(txName));
     }
 
     HapiSpec txRecordsContainValidTransfers() {

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/AutoAccountCreationSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/AutoAccountCreationSuite.java
@@ -186,7 +186,7 @@ public class AutoAccountCreationSuite extends HapiSuite {
                 /* -- HTS auto creates -- */
                 canAutoCreateWithFungibleTokenTransfersToAlias(),
                 multipleTokenTransfersSucceed(),
-                nftTransfersToAlias(),
+                canAutoCreateWithNftTransfersToAlias(),
                 autoCreateWithNftFallBackFeeFails(),
                 repeatedAliasInSameTransferListFails(),
                 canAutoCreateWithHbarAndTokenTransfers(),
@@ -203,7 +203,7 @@ public class AutoAccountCreationSuite extends HapiSuite {
 
     private HapiSpec canAutoCreateWithHbarAndTokenTransfers() {
         final var initialTokenSupply = 1000;
-        return defaultHapiSpec("hbarAndTokenTransfers")
+        return defaultHapiSpec("canAutoCreateWithHbarAndTokenTransfers")
                 .given(
                         newKeyNamed(VALID_ALIAS),
                         cryptoCreate(TOKEN_TREASURY).balance(10 * ONE_HUNDRED_HBARS),
@@ -357,7 +357,7 @@ public class AutoAccountCreationSuite extends HapiSuite {
                         getAliasedAccountInfo(VALID_ALIAS).hasOwnedNfts(2));
     }
 
-    private HapiSpec nftTransfersToAlias() {
+    private HapiSpec canAutoCreateWithNftTransfersToAlias() {
         final var civilianBal = 10 * ONE_HBAR;
         final var transferFee = 0.44012644 * ONE_HBAR;
         final var multiNftTransfer = "multiNftTransfer";
@@ -524,7 +524,7 @@ public class AutoAccountCreationSuite extends HapiSuite {
         final var secondPayer = "secondPayer";
         final AtomicLong totalAutoCreationFees = new AtomicLong();
 
-        return defaultHapiSpec("PayerBalanceIsReflectsAllChangesBeforeFeeCharging")
+        return defaultHapiSpec("payerBalanceIsReflectsAllChangesBeforeFeeCharging")
                 .given(
                         newKeyNamed(VALID_ALIAS),
                         cryptoCreate(TOKEN_TREASURY),
@@ -652,7 +652,7 @@ public class AutoAccountCreationSuite extends HapiSuite {
     private HapiSpec noStakePeriodStartIfNotStakingToNode() {
         final var user = "user";
         final var contract = "contract";
-        return defaultHapiSpec("NoStakePeriodStartIfNotStakingToNode")
+        return defaultHapiSpec("noStakePeriodStartIfNotStakingToNode")
                 .given(
                         newKeyNamed(ADMIN_KEY),
                         cryptoCreate(user).key(ADMIN_KEY).stakedNodeId(0L),
@@ -674,7 +674,7 @@ public class AutoAccountCreationSuite extends HapiSuite {
         final AtomicReference<AccountID> civilianId = new AtomicReference<>();
         final AtomicReference<ByteString> civilianAlias = new AtomicReference<>();
         final AtomicReference<ByteString> evmAddress = new AtomicReference<>();
-        return defaultHapiSpec("HollowAccountCreationWithCryptoTransfer")
+        return defaultHapiSpec("hollowAccountCreationWithCryptoTransfer")
                 .given(
                         newKeyNamed(MULTI_KEY),
                         newKeyNamed(SECP_256K1_SOURCE_KEY).shape(SECP_256K1_SHAPE),
@@ -775,7 +775,7 @@ public class AutoAccountCreationSuite extends HapiSuite {
         final var underfunded = "underfunded";
         final var secondTransferTxn = "SecondTransferTxn";
         final AtomicReference<ByteString> targetAddress = new AtomicReference<>();
-        return defaultHapiSpec("FailureAfterHollowAccountCreationReclaimsAlias")
+        return defaultHapiSpec("failureAfterHollowAccountCreationReclaimsAlias")
                 .given(
                         newKeyNamed(SECP_256K1_SOURCE_KEY).shape(SECP_256K1_SHAPE),
                         cryptoCreate(LAZY_CREATE_SPONSOR).balance(INITIAL_BALANCE * ONE_HBAR))
@@ -825,7 +825,7 @@ public class AutoAccountCreationSuite extends HapiSuite {
         final var ed25519Shape = KeyShape.ED25519;
         final var autoCreation = "autoCreation";
 
-        return defaultHapiSpec("CanGetBalanceAndInfoViaAlias")
+        return defaultHapiSpec("canGetBalanceAndInfoViaAlias")
                 .given(
                         cryptoCreate(CIVILIAN).balance(ONE_HUNDRED_HBARS),
                         newKeyNamed(ed25519SourceKey).shape(ed25519Shape),
@@ -867,7 +867,7 @@ public class AutoAccountCreationSuite extends HapiSuite {
     }
 
     private HapiSpec aliasCanBeUsedOnManyAccountsNotAsAlias() {
-        return defaultHapiSpec("AliasCanBeUsedOnManyAccountsNotAsAlias")
+        return defaultHapiSpec("aliasCanBeUsedOnManyAccountsNotAsAlias")
                 .given(
                         /* have alias key on other accounts and tokens not as alias */
                         newKeyNamed(VALID_ALIAS),
@@ -900,7 +900,7 @@ public class AutoAccountCreationSuite extends HapiSuite {
     }
 
     private HapiSpec accountCreatedIfAliasUsedAsPubKey() {
-        return defaultHapiSpec("AccountCreatedIfAliasUsedAsPubKey")
+        return defaultHapiSpec("accountCreatedIfAliasUsedAsPubKey")
                 .given(
                         newKeyNamed(ALIAS),
                         cryptoCreate(PAYER_1)
@@ -926,7 +926,7 @@ public class AutoAccountCreationSuite extends HapiSuite {
     }
 
     private HapiSpec autoAccountCreationWorksWhenUsingAliasOfDeletedAccount() {
-        return defaultHapiSpec("AutoAccountCreationWorksWhenUsingAliasOfDeletedAccount")
+        return defaultHapiSpec("autoAccountCreationWorksWhenUsingAliasOfDeletedAccount")
                 .given(
                         newKeyNamed(ALIAS),
                         newKeyNamed(ALIAS_2),
@@ -1106,7 +1106,7 @@ public class AutoAccountCreationSuite extends HapiSuite {
     private HapiSpec autoAccountCreationBadAlias() {
         final var invalidAlias = VALID_25519_ALIAS.substring(0, 10);
 
-        return defaultHapiSpec("AutoAccountCreationBadAlias")
+        return defaultHapiSpec("autoAccountCreationBadAlias")
                 .given(cryptoCreate(PAYER).balance(INITIAL_BALANCE * ONE_HBAR))
                 .when(cryptoTransfer(tinyBarsFromTo(PAYER, invalidAlias, ONE_HUNDRED_HBARS))
                         .hasKnownStatus(INVALID_ALIAS_KEY)
@@ -1117,7 +1117,7 @@ public class AutoAccountCreationSuite extends HapiSuite {
     private HapiSpec autoAccountCreationsHappyPath() {
         final var creationTime = new AtomicLong();
         final long transferFee = 185030L;
-        return defaultHapiSpec("AutoAccountCreationsHappyPath")
+        return defaultHapiSpec("autoAccountCreationsHappyPath")
                 .given(
                         newKeyNamed(VALID_ALIAS),
                         cryptoCreate(CIVILIAN).balance(10 * ONE_HBAR),
@@ -1222,7 +1222,7 @@ public class AutoAccountCreationSuite extends HapiSuite {
     }
 
     private HapiSpec multipleAutoAccountCreations() {
-        return defaultHapiSpec("MultipleAutoAccountCreations")
+        return defaultHapiSpec("multipleAutoAccountCreations")
                 .given(cryptoCreate(PAYER).balance(INITIAL_BALANCE * ONE_HBAR))
                 .when(
                         newKeyNamed("alias1"),
@@ -1259,7 +1259,7 @@ public class AutoAccountCreationSuite extends HapiSuite {
         final AtomicReference<ByteString> partyAlias = new AtomicReference<>();
         final AtomicReference<ByteString> counterAlias = new AtomicReference<>();
 
-        return defaultHapiSpec("TransferHbarsToEVMAddressAlias")
+        return defaultHapiSpec("transferHbarsToEVMAddressAlias")
                 .given(
                         cryptoCreate(PARTY).maxAutomaticTokenAssociations(2),
                         newKeyNamed(SECP_256K1_SOURCE_KEY).shape(SECP_256K1_SHAPE),
@@ -1363,7 +1363,7 @@ public class AutoAccountCreationSuite extends HapiSuite {
         final AtomicReference<ByteString> partyAlias = new AtomicReference<>();
         final AtomicReference<ByteString> counterAlias = new AtomicReference<>();
 
-        return defaultHapiSpec("TransferFungibleToEVMAddressAlias")
+        return defaultHapiSpec("transferFungibleToEVMAddressAlias")
                 .given(
                         newKeyNamed(SECP_256K1_SOURCE_KEY).shape(SECP_256K1_SHAPE),
                         cryptoCreate(PARTY).balance(INITIAL_BALANCE * ONE_HBAR).maxAutomaticTokenAssociations(2),
@@ -1454,7 +1454,7 @@ public class AutoAccountCreationSuite extends HapiSuite {
         final AtomicReference<ByteString> partyAlias = new AtomicReference<>();
         final AtomicReference<ByteString> counterAlias = new AtomicReference<>();
 
-        return defaultHapiSpec("TransferNonFungibleToEVMAddressAlias")
+        return defaultHapiSpec("transferNonFungibleToEVMAddressAlias")
                 .given(
                         newKeyNamed(MULTI_KEY),
                         newKeyNamed(SECP_256K1_SOURCE_KEY).shape(SECP_256K1_SHAPE),
@@ -1549,7 +1549,7 @@ public class AutoAccountCreationSuite extends HapiSuite {
         final AtomicReference<ByteString> evmAddress = new AtomicReference<>();
         final var longZeroAddress = ByteString.copyFrom(CommonUtils.unhex("0000000000000000000000000000000fffffffff"));
 
-        return defaultHapiSpec("CannotAutoCreateWithTxnToLongZero")
+        return defaultHapiSpec("cannotAutoCreateWithTxnToLongZero")
                 .given(
                         newKeyNamed(SECP_256K1_SOURCE_KEY).shape(SECP_256K1_SHAPE),
                         cryptoCreate(PAYER).balance(10 * ONE_HBAR),

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoApproveAllowanceSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoApproveAllowanceSuite.java
@@ -227,7 +227,7 @@ public class CryptoApproveAllowanceSuite extends HapiSuite {
     private HapiSpec approveForAllSpenderCanDelegateOnNFT() {
         final String delegatingSpender = "delegatingSpender";
         final String newSpender = "newSpender";
-        return defaultHapiSpec("ApproveForAllSpenderCanDelegateOnNFTs")
+        return defaultHapiSpec("approveForAllSpenderCanDelegateOnNFT")
                 .given(
                         newKeyNamed(SUPPLY_KEY),
                         cryptoCreate(OWNER).balance(ONE_HUNDRED_HBARS).maxAutomaticTokenAssociations(10),
@@ -1360,7 +1360,7 @@ public class CryptoApproveAllowanceSuite extends HapiSuite {
     }
 
     private HapiSpec approveForAllDoesNotSetExplicitNFTSpender() {
-        return defaultHapiSpec("ApproveForAllSetNFTSpender")
+        return defaultHapiSpec("approveForAllDoesNotSetExplicitNFTSpender")
                 .given(
                         newKeyNamed(SUPPLY_KEY),
                         cryptoCreate(OWNER).balance(ONE_HUNDRED_HBARS).maxAutomaticTokenAssociations(10),

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoCreateSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoCreateSuite.java
@@ -175,7 +175,7 @@ public class CryptoCreateSuite extends HapiSuite {
         final var ecdsaKey = "ecdsaKey";
         final var longZeroAddress = ByteString.copyFrom(CommonUtils.unhex("0000000000000000000000000000000fffffffff"));
         final var creation = "creation";
-        return defaultHapiSpec("CannotCreateAnAccountWithLongZeroKey")
+        return defaultHapiSpec("cannotCreateAnAccountWithLongZeroKeyButCanUseEvmAddress")
                 .given(
                         cryptoCreate(ACCOUNT).evmAddress(longZeroAddress).hasPrecheck(INVALID_ALIAS_KEY),
                         newKeyNamed(ecdsaKey).shape(SECP256K1_ON))
@@ -297,7 +297,7 @@ public class CryptoCreateSuite extends HapiSuite {
         KeyShape shape = threshOf(2, emptyThresholdShape, emptyListShape);
         long initialBalance = 10_000L;
 
-        return defaultHapiSpec("createAnAccountEmptyThresholdKey")
+        return defaultHapiSpec("createAnAccountEmptyNestedKey")
                 .given()
                 .when()
                 .then(cryptoCreate(NO_KEYS)
@@ -409,7 +409,7 @@ public class CryptoCreateSuite extends HapiSuite {
 
         long initialBalance = 10_000L;
 
-        return defaultHapiSpec("createAnAccountInvalidNestedKeyList")
+        return defaultHapiSpec("createAnAccountInvalidNestedThresholdKey")
                 .given()
                 .when()
                 .then(

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoTransferSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoTransferSuite.java
@@ -277,7 +277,7 @@ public class CryptoTransferSuite extends HapiSuite {
     }
 
     private HapiSpec okToRepeatSerialNumbersInBurnList() {
-        return defaultHapiSpec("CannotRepeatSerialNumbersInBurnList")
+        return defaultHapiSpec("okToRepeatSerialNumbersInBurnList")
                 .given(
                         newKeyNamed(SUPPLY_KEY),
                         newKeyNamed(WIPE_KEY),
@@ -1207,7 +1207,7 @@ public class CryptoTransferSuite extends HapiSuite {
         final var selfDenominatedCollector = "selfDenominatedCollector";
         final var plentyOfSlots = 10;
 
-        return defaultHapiSpec("RoyaltyCollectorsCanUseAutoAssociation")
+        return defaultHapiSpec("dissociatedRoyaltyCollectorsCanUseAutoAssociation")
                 .given(
                         cryptoCreate(TOKEN_TREASURY),
                         cryptoCreate(fractionalCollector).maxAutomaticTokenAssociations(plentyOfSlots),
@@ -1372,7 +1372,7 @@ public class CryptoTransferSuite extends HapiSuite {
         final var multipurpose = MULTI_KEY;
         final var hodlXfer = HODL_XFER;
 
-        return defaultHapiSpec("RoyaltyCollectorsCanUseAutoAssociationWithoutOpenSlots")
+        return defaultHapiSpec("royaltyCollectorsCannotUseAutoAssociationWithoutOpenSlots")
                 .given(
                         cryptoCreate(TOKEN_TREASURY),
                         cryptoCreate(royaltyCollectorNoSlots),
@@ -1496,7 +1496,7 @@ public class CryptoTransferSuite extends HapiSuite {
         final var nftXferTxn = "nftXferTxn";
         final var nftXferTxnWithCustomFee = "nftXferTxnWithCustomFee";
 
-        return defaultHapiSpec("BaseCryptoTransferIsChargedAsExpected")
+        return defaultHapiSpec("baseCryptoTransferFeeChargedAsExpected")
                 .given(
                         cryptoCreate(nonTreasurySender).balance(ONE_HUNDRED_HBARS),
                         cryptoCreate(SENDER).balance(ONE_HUNDRED_HBARS),
@@ -1790,7 +1790,7 @@ public class CryptoTransferSuite extends HapiSuite {
     }
 
     private HapiSpec transferWithMissingAccountGetsInvalidAccountId() {
-        return defaultHapiSpec("TransferWithMissingAccount")
+        return defaultHapiSpec("transferWithMissingAccountGetsInvalidAccountId")
                 .given(cryptoCreate(PAYEE_SIG_REQ).receiverSigRequired(true))
                 .when(cryptoTransfer(tinyBarsFromTo("1.2.3", PAYEE_SIG_REQ, 1_000L))
                         .signedBy(DEFAULT_PAYER, PAYEE_SIG_REQ)
@@ -1835,7 +1835,7 @@ public class CryptoTransferSuite extends HapiSuite {
         final var FUNGIBLE_TOKEN_FEE = "fungibleTokenFee";
         final var RECEIVER_SIGNATURE = "receiverSignature";
         final var SPENDER_SIGNATURE = "spenderSignature";
-        return defaultHapiSpec("HapiTransferFromForNFTWithCustomFees")
+        return defaultHapiSpec("hapiTransferFromForNFTWithCustomFeesWithAllowance")
                 .given(
                         newKeyNamed(MULTI_KEY),
                         newKeyNamed(RECEIVER_SIGNATURE),
@@ -1983,7 +1983,7 @@ public class CryptoTransferSuite extends HapiSuite {
         final var FUNGIBLE_TOKEN_FEE = "fungibleTokenFee";
         final var RECEIVER_SIGNATURE = "receiverSignature";
         final var SPENDER_SIGNATURE = "spenderSignature";
-        return defaultHapiSpec("HapiTransferFromForNFTWithCustomFees")
+        return defaultHapiSpec("hapiTransferFromForFungibleTokenWithCustomFeesWithAllowance")
                 .given(
                         newKeyNamed(RECEIVER_SIGNATURE),
                         newKeyNamed(SPENDER_SIGNATURE),

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoUpdateSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoUpdateSuite.java
@@ -123,7 +123,7 @@ public class CryptoUpdateSuite extends HapiSuite {
                 updateFailsIfMissingSigs(),
                 updateFailsWithContractKey(),
                 updateFailsWithOverlyLongLifetime(),
-                usdFeeAsExpected(),
+                usdFeeAsExpectedCryptoUpdate(),
                 sysAccountKeyUpdateBySpecialWontNeedNewKeyTxnSign(),
                 updateMaxAutoAssociationsWorks(),
                 updateStakingFieldsWorks());
@@ -178,7 +178,7 @@ public class CryptoUpdateSuite extends HapiSuite {
                                 .logged());
     }
 
-    private HapiSpec usdFeeAsExpected() {
+    private HapiSpec usdFeeAsExpectedCryptoUpdate() {
         double autoAssocSlotPrice = 0.0018;
         double baseFee = 0.00022;
         double plusOneSlotFee = baseFee + autoAssocSlotPrice;
@@ -190,7 +190,7 @@ public class CryptoUpdateSuite extends HapiSuite {
         final var allowedPercentDiff = 1.0;
 
         AtomicLong expiration = new AtomicLong();
-        return defaultHapiSpec("UsdFeeAsExpectedCryptoUpdate")
+        return defaultHapiSpec("usdFeeAsExpectedCryptoUpdate")
                 .given(
                         newKeyNamed("key").shape(SIMPLE),
                         cryptoCreate("payer").key("key").balance(1_000 * ONE_HBAR),
@@ -370,7 +370,7 @@ public class CryptoUpdateSuite extends HapiSuite {
     private HapiSpec updateWithEmptyKeyFails() {
         SigControl updKeySigs = threshOf(0, 0);
 
-        return defaultHapiSpec("UpdateWithEmptyKey")
+        return defaultHapiSpec("updateWithEmptyKeyFails")
                 .given(
                         newKeyNamed(ORIG_KEY).shape(KeyShape.SIMPLE),
                         newKeyNamed(UPD_KEY).shape(updKeySigs))

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/ethereum/EthereumSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/ethereum/EthereumSuite.java
@@ -82,6 +82,7 @@ import com.hedera.services.bdd.spec.assertions.TransactionRecordAsserts;
 import com.hedera.services.bdd.spec.keys.SigControl;
 import com.hedera.services.bdd.spec.queries.meta.HapiGetTxnRecord;
 import com.hedera.services.bdd.spec.transactions.TxnUtils;
+import com.hedera.services.bdd.suites.BddTestNameDoesNotMatchMethodName;
 import com.hedera.services.bdd.suites.HapiSuite;
 import com.hedera.services.bdd.suites.contract.Utils;
 import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
@@ -157,7 +158,7 @@ public class EthereumSuite extends HapiSuite {
     HapiSpec sendingLargerBalanceThanAvailableFailsGracefully() {
         final AtomicReference<Address> tokenCreateContractAddress = new AtomicReference<>();
 
-        return defaultHapiSpec("Sending Larger Balance Than Available Fails Gracefully")
+        return defaultHapiSpec("sendingLargerBalanceThanAvailableFailsGracefully")
                 .given(
                         newKeyNamed(SECP_256K1_SOURCE_KEY).shape(SECP_256K1_SHAPE),
                         cryptoCreate(RELAYER).balance(6 * ONE_MILLION_HBARS),
@@ -400,7 +401,7 @@ public class EthereumSuite extends HapiSuite {
     HapiSpec etx010TransferToCryptoAccountSucceeds() {
         String RECEIVER = "RECEIVER";
         final String aliasBalanceSnapshot = "aliasBalance";
-        return defaultHapiSpec("ETX_010_transferToCryptoAccountSucceeds")
+        return defaultHapiSpec("etx010TransferToCryptoAccountSucceeds")
                 .given(
                         newKeyNamed(SECP_256K1_SOURCE_KEY).shape(SECP_256K1_SHAPE),
                         cryptoCreate(RECEIVER).balance(0L),
@@ -482,6 +483,7 @@ public class EthereumSuite extends HapiSuite {
                 .toList();
     }
 
+    @BddTestNameDoesNotMatchMethodName
     HapiSpec matrixedPayerRelayerTest(
             final boolean success, final long senderGasPrice, final long relayerOffered, final long senderCharged) {
         return defaultHapiSpec("feePaymentMatrix "
@@ -564,7 +566,7 @@ public class EthereumSuite extends HapiSuite {
         final String PROXY = "proxy";
         final long INITIAL_BALANCE = 100L;
         final long AUTO_RENEW_PERIOD = THREE_MONTHS_IN_SECONDS + 60;
-        return defaultHapiSpec("ContractCreateInheritsProperties")
+        return defaultHapiSpec("etx014ContractCreateInheritsSignerProperties")
                 .given(
                         newKeyNamed(SECP_256K1_SOURCE_KEY).shape(SECP_256K1_SHAPE),
                         cryptoCreate(RELAYER).balance(6 * ONE_MILLION_HBARS),
@@ -611,7 +613,7 @@ public class EthereumSuite extends HapiSuite {
     HapiSpec etx031InvalidNonceEthereumTxFailsAndChargesRelayer() {
         final var relayerSnapshot = "relayer";
         final var senderSnapshot = "sender";
-        return defaultHapiSpec("ETX_031_invalidNonceEthereumTxFailsAndChargesRelayer")
+        return defaultHapiSpec("etx031InvalidNonceEthereumTxFailsAndChargesRelayer")
                 .given(
                         newKeyNamed(SECP_256K1_SOURCE_KEY).shape(SECP_256K1_SHAPE),
                         cryptoCreate(RELAYER).balance(6 * ONE_MILLION_HBARS),
@@ -653,7 +655,7 @@ public class EthereumSuite extends HapiSuite {
         final AtomicReference<TokenID> fungible = new AtomicReference<>();
         final String fungibleToken = TOKEN;
         final String mintTxn = MINT_TXN;
-        return defaultHapiSpec("ETX_012_precompileCallSucceedsWhenNeededSignatureInEthTxn")
+        return defaultHapiSpec("etx012PrecompileCallSucceedsWhenNeededSignatureInEthTxn")
                 .given(
                         newKeyNamed(SECP_256K1_SOURCE_KEY).shape(SECP_256K1_SHAPE),
                         cryptoCreate(RELAYER).balance(6 * ONE_MILLION_HBARS),
@@ -703,7 +705,7 @@ public class EthereumSuite extends HapiSuite {
         final String fungibleToken = TOKEN;
         final String mintTxn = MINT_TXN;
         final String MULTI_KEY = "MULTI_KEY";
-        return defaultHapiSpec("ETX_013_precompileCallSucceedsWhenNeededSignatureInHederaTxn")
+        return defaultHapiSpec("etx013PrecompileCallSucceedsWhenNeededSignatureInHederaTxn")
                 .given(
                         newKeyNamed(MULTI_KEY),
                         newKeyNamed(SECP_256K1_SOURCE_KEY).shape(SECP_256K1_SHAPE),
@@ -755,7 +757,7 @@ public class EthereumSuite extends HapiSuite {
         final String fungibleToken = TOKEN;
         final String mintTxn = MINT_TXN;
         final String MULTI_KEY = "MULTI_KEY";
-        return defaultHapiSpec("ETX_013_precompileCallFailsWhenSignatureMissingFromBothEthereumAndHederaTxn")
+        return defaultHapiSpec("etx013PrecompileCallFailsWhenSignatureMissingFromBothEthereumAndHederaTxn")
                 .given(
                         newKeyNamed(MULTI_KEY),
                         newKeyNamed(SECP_256K1_SOURCE_KEY).shape(SECP_256K1_SHAPE),
@@ -804,7 +806,7 @@ public class EthereumSuite extends HapiSuite {
         final AtomicReference<String> tokenNum = new AtomicReference<>();
         final var totalSupply = 50;
 
-        return defaultHapiSpec("CallsToTokenAddresses")
+        return defaultHapiSpec("etx009CallsToTokenAddresses")
                 .given(
                         newKeyNamed(SECP_256K1_SOURCE_KEY).shape(SECP_256K1_SHAPE),
                         cryptoCreate(RELAYER).balance(6 * ONE_MILLION_HBARS),
@@ -894,7 +896,7 @@ public class EthereumSuite extends HapiSuite {
         final var txn = "creation";
         final var contract = "Fuse";
 
-        return defaultHapiSpec("ETX_008_contractCreateExecutesWithExpectedRecord")
+        return defaultHapiSpec("etx008ContractCreateExecutesWithExpectedRecord")
                 .given(
                         newKeyNamed(SECP_256K1_SOURCE_KEY).shape(SECP_256K1_SHAPE),
                         cryptoCreate(RELAYER).balance(6 * ONE_MILLION_HBARS),
@@ -925,7 +927,7 @@ public class EthereumSuite extends HapiSuite {
         final var firstTxn = "firstCreateTxn";
         final long DEFAULT_AMOUNT_TO_SEND = 20 * ONE_HBAR;
 
-        return defaultHapiSpec("ETX_007_fungibleTokenCreateWithFeesHappyPath")
+        return defaultHapiSpec("etx007FungibleTokenCreateWithFeesHappyPath")
                 .given(
                         newKeyNamed(SECP_256K1_SOURCE_KEY).shape(SECP_256K1_SHAPE),
                         cryptoCreate(RELAYER).balance(6 * ONE_MILLION_HBARS),
@@ -987,7 +989,7 @@ public class EthereumSuite extends HapiSuite {
     private HapiSpec etxSvc003ContractGetBytecodeQueryReturnsDeployedCode() {
         final var txn = "creation";
         final var contract = "EmptyConstructor";
-        return HapiSpec.defaultHapiSpec("contractGetBytecodeQueryReturnsDeployedCode")
+        return HapiSpec.defaultHapiSpec("etxSvc003ContractGetBytecodeQueryReturnsDeployedCode")
                 .given(
                         newKeyNamed(SECP_256K1_SOURCE_KEY).shape(SECP_256K1_SHAPE),
                         cryptoCreate(RELAYER).balance(6 * ONE_MILLION_HBARS),

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/ethereum/HelloWorldEthereumSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/ethereum/HelloWorldEthereumSuite.java
@@ -187,7 +187,7 @@ public class HelloWorldEthereumSuite extends HapiSuite {
     HapiSpec relayerFeeAsExpectedIfSenderCoversGas() {
         final var canonicalTxn = "canonical";
 
-        return defaultHapiSpec("RelayerFeeAsExpected")
+        return defaultHapiSpec("relayerFeeAsExpectedIfSenderCoversGas")
                 .given(
                         newKeyNamed(SECP_256K1_SOURCE_KEY).shape(SECP_256K1_SHAPE),
                         cryptoCreate(RELAYER).balance(ONE_HUNDRED_HBARS),
@@ -216,7 +216,7 @@ public class HelloWorldEthereumSuite extends HapiSuite {
     }
 
     HapiSpec depositSuccess() {
-        return defaultHapiSpec("DepositSuccess")
+        return defaultHapiSpec("depositSuccess")
                 .given(
                         newKeyNamed(SECP_256K1_SOURCE_KEY).shape(SECP_256K1_SHAPE),
                         cryptoCreate(RELAYER).balance(6 * ONE_MILLION_HBARS),
@@ -324,7 +324,7 @@ public class HelloWorldEthereumSuite extends HapiSuite {
     HapiSpec createWithSelfDestructInConstructorHasSaneRecord() {
         final var txn = "txn";
         final var selfDestructingContract = "FactorySelfDestructConstructor";
-        return defaultHapiSpec("CreateWithSelfDestructInConstructorHasSaneRecord")
+        return defaultHapiSpec("createWithSelfDestructInConstructorHasSaneRecord")
                 .given(
                         newKeyNamed(SECP_256K1_SOURCE_KEY).shape(SECP_256K1_SHAPE),
                         cryptoCreate(RELAYER).balance(6 * ONE_MILLION_HBARS),
@@ -343,7 +343,7 @@ public class HelloWorldEthereumSuite extends HapiSuite {
     }
 
     HapiSpec smallContractCreate() {
-        return defaultHapiSpec("SmallContractCreate")
+        return defaultHapiSpec("smallContractCreate")
                 .given(
                         newKeyNamed(SECP_256K1_SOURCE_KEY).shape(SECP_256K1_SHAPE),
                         cryptoCreate(RELAYER).balance(6 * ONE_MILLION_HBARS),
@@ -387,7 +387,7 @@ public class HelloWorldEthereumSuite extends HapiSuite {
 
     private HapiSpec bigContractCreate() {
         final var contractAdminKey = "contractAdminKey";
-        return defaultHapiSpec("BigContractCreate")
+        return defaultHapiSpec("bigContractCreate")
                 .given(
                         newKeyNamed(SECP_256K1_SOURCE_KEY).shape(SECP_256K1_SHAPE),
                         cryptoCreate(RELAYER).balance(6 * ONE_MILLION_HBARS),
@@ -432,7 +432,7 @@ public class HelloWorldEthereumSuite extends HapiSuite {
 
     private HapiSpec contractCreateWithConstructorArgs() {
         final var contractAdminKey = "contractAdminKey";
-        return defaultHapiSpec("ContractCreateWithConstructorArgs")
+        return defaultHapiSpec("contractCreateWithConstructorArgs")
                 .given(
                         newKeyNamed(SECP_256K1_SOURCE_KEY).shape(SECP_256K1_SHAPE),
                         cryptoCreate(RELAYER).balance(6 * ONE_MILLION_HBARS),
@@ -487,7 +487,7 @@ public class HelloWorldEthereumSuite extends HapiSuite {
 
     HapiSpec topLevelBurnToZeroAddressReverts() {
         final var ethBurnAddress = new byte[20];
-        return defaultHapiSpec("TopLevelBurnToZeroAddressReverts")
+        return defaultHapiSpec("topLevelBurnToZeroAddressReverts")
                 .given(
                         newKeyNamed(SECP_256K1_SOURCE_KEY).shape(SECP_256K1_SHAPE),
                         cryptoCreate(RELAYER).balance(123 * ONE_HUNDRED_HBARS))
@@ -505,7 +505,7 @@ public class HelloWorldEthereumSuite extends HapiSuite {
 
     HapiSpec topLevelLazyCreateOfMirrorAddressReverts() {
         final var nonExistentMirrorAddress = Utils.asSolidityAddress(0, 0, 666_666);
-        return defaultHapiSpec("TopLevelBurnToZeroAddressReverts")
+        return defaultHapiSpec("topLevelLazyCreateOfMirrorAddressReverts")
                 .given(
                         newKeyNamed(SECP_256K1_SOURCE_KEY).shape(SECP_256K1_SHAPE),
                         cryptoCreate(RELAYER).balance(123 * ONE_HUNDRED_HBARS))
@@ -525,7 +525,7 @@ public class HelloWorldEthereumSuite extends HapiSuite {
         final var receiverSigAccount = "receiverSigAccount";
         final AtomicReference<byte[]> receiverMirrorAddr = new AtomicReference<>();
         final var preCallBalance = "preCallBalance";
-        return defaultHapiSpec("TopLevelSendToReceiverSigRequiredAccountReverts")
+        return defaultHapiSpec("topLevelSendToReceiverSigRequiredAccountReverts")
                 .given(
                         newKeyNamed(SECP_256K1_SOURCE_KEY).shape(SECP_256K1_SHAPE),
                         cryptoCreate(RELAYER).balance(123 * ONE_HUNDRED_HBARS),
@@ -550,7 +550,7 @@ public class HelloWorldEthereumSuite extends HapiSuite {
     }
 
     HapiSpec internalBurnToZeroAddressReverts() {
-        return defaultHapiSpec("InternalBurnToZeroAddressReverts")
+        return defaultHapiSpec("internalBurnToZeroAddressReverts")
                 .given(
                         newKeyNamed(SECP_256K1_SOURCE_KEY).shape(SECP_256K1_SHAPE),
                         cryptoCreate(RELAYER).balance(123 * ONE_HUNDRED_HBARS),

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/file/negative/UpdateFailuresSpec.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/file/negative/UpdateFailuresSpec.java
@@ -88,7 +88,7 @@ public class UpdateFailuresSpec extends HapiSuite {
     }
 
     private HapiSpec precheckRejectsUnauthorized() {
-        return defaultHapiSpec("PrecheckRejectsUnauthAddressBookUpdate")
+        return defaultHapiSpec("precheckRejectsUnauthorized")
                 .given(cryptoCreate(CIVILIAN))
                 .when()
                 .then(

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/file/positive/SysDelSysUndelSpec.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/file/positive/SysDelSysUndelSpec.java
@@ -93,7 +93,7 @@ public class SysDelSysUndelSpec extends HapiSuite {
         var lifetime = THREE_MONTHS_IN_SECONDS;
         AtomicLong initExpiry = new AtomicLong();
 
-        return defaultHapiSpec("happyPathFlows")
+        return defaultHapiSpec("systemDeleteThenUndeleteRestoresContentsAndExpiry")
                 .given(
                         fileCreate("misc").lifetime(lifetime).contents(ORIG_FILE),
                         UtilVerbs.withOpContext((spec, opLog) -> initExpiry.set(

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/leaky/FeatureFlagSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/leaky/FeatureFlagSuite.java
@@ -78,7 +78,7 @@ public class FeatureFlagSuite extends HapiSuite {
     }
 
     private HapiSpec disableAllFeatureFlagsAndConfirmNotSupported() {
-        return defaultHapiSpec("DisablesAllFeatureFlagsAndConfirmsNotSupported")
+        return defaultHapiSpec("disableAllFeatureFlagsAndConfirmNotSupported")
                 .given(overridingAllOf(FeatureFlags.FEATURE_FLAGS.allDisabled()))
                 .when()
                 .then(inParallel(
@@ -89,7 +89,7 @@ public class FeatureFlagSuite extends HapiSuite {
     }
 
     private HapiSpec enableAllFeatureFlagsAndDisableThrottlesForFurtherCiTesting() {
-        return defaultHapiSpec("EnablesAllFeatureFlagsForFurtherCiTesting")
+        return defaultHapiSpec("enableAllFeatureFlagsAndDisableThrottlesForFurtherCiTesting")
                 .given()
                 .when()
                 .then(enableAllFeatureFlagsAndDisableContractThrottles());

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/leaky/LeakyContractTestsSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/leaky/LeakyContractTestsSuite.java
@@ -238,7 +238,6 @@ public class LeakyContractTestsSuite extends HapiSuite {
     private static final String CONTRACTS_ALLOW_SYSTEM_USE_OF_HAPI_SIGS = "contracts.allowSystemUseOfHapiSigs";
     private static final String CRYPTO_TRANSFER = "CryptoTransfer";
     private static final String TOKEN_TRANSFER_CONTRACT = "TokenTransferContract";
-    private static final String TRANSFER_WORKS_WITH_TOP_LEVEL_SIGNATURES = "transferWorksWithTopLevelSignatures";
     private static final String TRANSFER_TOKEN_PUBLIC = "transferTokenPublic";
     private static final String HEDERA_ALLOWANCES_IS_ENABLED = "hedera.allowances.isEnabled";
 
@@ -268,7 +267,7 @@ public class LeakyContractTestsSuite extends HapiSuite {
                 contractCreationStoragePriceMatchesFinalExpiry(),
                 createTokenWithInvalidFixedFeeWithERC721Denomination(),
                 maxRefundIsMaxGasRefundConfiguredWhenTXGasPriceIsSmaller(),
-                accountWithoutAliasCanMakeEthTxnsDueToAutomaticAliasCreation(),
+                etx026AccountWithoutAliasCanMakeEthTxnsDueToAutomaticAliasCreation(),
                 createMaxRefundIsMaxGasRefundConfiguredWhenTXGasPriceIsSmaller(),
                 lazyCreateThroughPrecompileNotSupportedWhenFlagDisabled(),
                 evmLazyCreateViaSolidityCall(),
@@ -286,7 +285,7 @@ public class LeakyContractTestsSuite extends HapiSuite {
     }
 
     private HapiSpec transferErc20TokenFromErc721TokenFails() {
-        return propertyPreservingHapiSpec("ERC_20_TRANSFER_FROM_ERC_721_TOKEN")
+        return propertyPreservingHapiSpec("transferErc20TokenFromErc721TokenFails")
                 .preserving(HEDERA_ALLOWANCES_IS_ENABLED)
                 .given(
                         overriding(HEDERA_ALLOWANCES_IS_ENABLED, "true"),
@@ -461,7 +460,7 @@ public class LeakyContractTestsSuite extends HapiSuite {
         final AtomicReference<AccountID> accountID = new AtomicReference<>();
         final AtomicReference<TokenID> vanillaTokenID = new AtomicReference<>();
         final AtomicReference<TokenID> vanillaNftID = new AtomicReference<>();
-        return propertyPreservingHapiSpec(TRANSFER_WORKS_WITH_TOP_LEVEL_SIGNATURES)
+        return propertyPreservingHapiSpec("transferDontWorkWithoutTopLevelSignatures")
                 .preserving(CONTRACTS_ALLOW_SYSTEM_USE_OF_HAPI_SIGS)
                 .given(
                         // disable top level signatures for all functions
@@ -600,7 +599,7 @@ public class LeakyContractTestsSuite extends HapiSuite {
         final AtomicReference<AccountID> accountID = new AtomicReference<>();
         final AtomicReference<TokenID> vanillaTokenID = new AtomicReference<>();
         final AtomicReference<TokenID> vanillaNftID = new AtomicReference<>();
-        return propertyPreservingHapiSpec(TRANSFER_WORKS_WITH_TOP_LEVEL_SIGNATURES)
+        return propertyPreservingHapiSpec("transferWorksWithTopLevelSignatures")
                 .preserving(CONTRACTS_ALLOW_SYSTEM_USE_OF_HAPI_SIGS)
                 .given(
                         // enable top level signatures for
@@ -754,7 +753,7 @@ public class LeakyContractTestsSuite extends HapiSuite {
 
         final AtomicReference<AccountID> accountID = new AtomicReference<>();
         final AtomicReference<TokenID> vanillaTokenID = new AtomicReference<>();
-        return propertyPreservingHapiSpec(TRANSFER_WORKS_WITH_TOP_LEVEL_SIGNATURES)
+        return propertyPreservingHapiSpec("transferFailsWithIncorrectAmounts")
                 .preserving(CONTRACTS_ALLOW_SYSTEM_USE_OF_HAPI_SIGS)
                 .given(
                         overriding(CONTRACTS_ALLOW_SYSTEM_USE_OF_HAPI_SIGS, CRYPTO_TRANSFER),
@@ -1154,9 +1153,9 @@ public class LeakyContractTestsSuite extends HapiSuite {
                         }));
     }
 
-    HapiSpec accountWithoutAliasCanMakeEthTxnsDueToAutomaticAliasCreation() {
+    HapiSpec etx026AccountWithoutAliasCanMakeEthTxnsDueToAutomaticAliasCreation() {
         final String ACCOUNT = "account";
-        return defaultHapiSpec("ETX_026_accountWithoutAliasCanMakeEthTxnsDueToAutomaticAliasCreation")
+        return defaultHapiSpec("etx026AccountWithoutAliasCanMakeEthTxnsDueToAutomaticAliasCreation")
                 .given(
                         overriding(CRYPTO_CREATE_WITH_ALIAS_ENABLED, FALSE_VALUE),
                         newKeyNamed(SECP_256K1_SOURCE_KEY).shape(SECP_256K1_SHAPE),
@@ -1175,7 +1174,7 @@ public class LeakyContractTestsSuite extends HapiSuite {
     private HapiSpec transferToCaller() {
         final var transferTxn = TRANSFER_TXN;
         final var sender = "sender";
-        return defaultHapiSpec(TRANSFER_TO_CALLER)
+        return defaultHapiSpec("transferToCaller")
                 .given(
                         uploadInitCode(TRANSFERRING_CONTRACT),
                         contractCreate(TRANSFERRING_CONTRACT).balance(10_000L),

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/meta/VersionInfoSpec.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/meta/VersionInfoSpec.java
@@ -21,6 +21,7 @@ import static com.hedera.services.bdd.spec.HapiSpec.defaultHapiSpec;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getVersionInfo;
 
 import com.hedera.services.bdd.spec.HapiSpec;
+import com.hedera.services.bdd.suites.BddTestNameDoesNotMatchMethodName;
 import com.hedera.services.bdd.suites.HapiSuite;
 import java.util.List;
 import java.util.Map;
@@ -69,6 +70,7 @@ public class VersionInfoSpec extends HapiSuite {
                         );
     }
 
+    @BddTestNameDoesNotMatchMethodName
     private HapiSpec discoversExpectedVersions() {
         if (specConfig != null) {
             return customHapiSpec("getVersionInfo")
@@ -77,7 +79,7 @@ public class VersionInfoSpec extends HapiSuite {
                     .when()
                     .then(getVersionInfo().withYahcliLogging().noLogging());
         } else {
-            return defaultHapiSpec("getsExpectedVersions")
+            return defaultHapiSpec("discoversExpectedVersions")
                     .given()
                     .when()
                     .then(getVersionInfo().logged().hasNoDegenerateSemvers());

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/regression/TargetNetworkPrep.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/regression/TargetNetworkPrep.java
@@ -68,10 +68,10 @@ public class TargetNetworkPrep extends HapiSuite {
 
     @Override
     public List<HapiSpec> getSpecsInSuite() {
-        return List.of(ensureSystemStateAsExpected());
+        return List.of(ensureSystemStateAsExpectedWithSystemDefaultFiles());
     }
 
-    private HapiSpec ensureSystemStateAsExpected() {
+    private HapiSpec ensureSystemStateAsExpectedWithSystemDefaultFiles() {
         final var emptyKey =
                 Key.newBuilder().setKeyList(KeyList.getDefaultInstance()).build();
         final var snapshot800 = "800startBalance";
@@ -84,7 +84,7 @@ public class TargetNetworkPrep extends HapiSuite {
                     Files.readString(relocatedIfNotPresentInWorkingDir(Paths.get(defaultPermissionsLoc)));
             final var serde = StandardSerdes.SYS_FILE_SERDES.get(122L);
 
-            return defaultHapiSpec("EnsureDefaultSystemFiles")
+            return defaultHapiSpec("ensureSystemStateAsExpectedWithSystemDefaultFiles")
                     .given(
                             uploadDefaultFeeSchedules(GENESIS),
                             fileUpdate(API_PERMISSIONS)

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/throttling/PrivilegedOpsSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/throttling/PrivilegedOpsSuite.java
@@ -63,15 +63,14 @@ public class PrivilegedOpsSuite extends HapiSuite {
 
     @Override
     public List<HapiSpec> getSpecsInSuite() {
-        return List.of(new HapiSpec[] {
-            superusersAreNeverThrottledOnTransfers(),
-            superusersAreNeverThrottledOnMiscTxns(),
-            superusersAreNeverThrottledOnHcsTxns(),
-            superusersAreNeverThrottledOnMiscQueries(),
-            superusersAreNeverThrottledOnHcsQueries(),
-            systemAccountUpdatePrivilegesAsExpected(),
-            freezeAdminPrivilegesAsExpected(),
-        });
+        return List.of(
+                superusersAreNeverThrottledOnTransfers(),
+                superusersAreNeverThrottledOnMiscTxns(),
+                superusersAreNeverThrottledOnHcsTxns(),
+                superusersAreNeverThrottledOnMiscQueries(),
+                superusersAreNeverThrottledOnHcsQueries(),
+                systemAccountUpdatePrivilegesAsExpected(),
+                freezeAdminPrivilegesAsExpected());
     }
 
     Function<String, HapiSpecOperation[]> transferBurstFn = payer -> IntStream.range(0, BURST_SIZE)
@@ -79,26 +78,26 @@ public class PrivilegedOpsSuite extends HapiSuite {
                     .payingWith(payer)
                     .fee(ONE_HUNDRED_HBARS)
                     .deferStatusResolution())
-            .toArray(n -> new HapiSpecOperation[n]);
+            .toArray(HapiSpecOperation[]::new);
     Function<String, HapiSpecOperation[]> miscTxnBurstFn = payer -> IntStream.range(0, BURST_SIZE)
             .mapToObj(i -> cryptoCreate(String.format("Account%d", i))
                     .payingWith(payer)
                     .deferStatusResolution())
-            .toArray(n -> new HapiSpecOperation[n]);
+            .toArray(HapiSpecOperation[]::new);
     Function<String, HapiSpecOperation[]> hcsTxnBurstFn = payer -> IntStream.range(0, BURST_SIZE)
             .mapToObj(i ->
                     createTopic(String.format("Topic%d", i)).payingWith(payer).deferStatusResolution())
-            .toArray(n -> new HapiSpecOperation[n]);
+            .toArray(HapiSpecOperation[]::new);
     Function<String, HapiSpecOperation[]> miscQueryBurstFn = payer -> IntStream.range(0, BURST_SIZE)
             .mapToObj(
                     i -> getAccountInfo(ADDRESS_BOOK_CONTROL).nodePayment(100L).payingWith(payer))
-            .toArray(n -> new HapiSpecOperation[n]);
+            .toArray(HapiSpecOperation[]::new);
     Function<String, HapiSpecOperation[]> hcsQueryBurstFn = payer -> IntStream.range(0, BURST_SIZE)
             .mapToObj(i -> getTopicInfo("misc").nodePayment(100L).payingWith(payer))
-            .toArray(n -> new HapiSpecOperation[n]);
+            .toArray(HapiSpecOperation[]::new);
 
     private HapiSpec freezeAdminPrivilegesAsExpected() {
-        return defaultHapiSpec("FreezeAdminPrivilegesAsExpected")
+        return defaultHapiSpec("freezeAdminPrivilegesAsExpected")
                 .given(
                         cryptoCreate(CIVILIAN),
                         cryptoTransfer(tinyBarsFromTo(GENESIS, EXCHANGE_RATE_CONTROL, ONE_MILLION_HBARS)))
@@ -141,7 +140,7 @@ public class PrivilegedOpsSuite extends HapiSuite {
 
     private HapiSpec systemAccountUpdatePrivilegesAsExpected() {
         final var tmpTreasury = "tmpTreasury";
-        return defaultHapiSpec("SystemAccountUpdatePrivilegesAsExpected")
+        return defaultHapiSpec("systemAccountUpdatePrivilegesAsExpected")
                 .given(newKeyNamed(tmpTreasury), newKeyNamed(NEW_88), cryptoCreate(CIVILIAN))
                 .when(cryptoUpdate(ACCOUNT_88)
                         .payingWith(GENESIS)
@@ -193,7 +192,7 @@ public class PrivilegedOpsSuite extends HapiSuite {
     }
 
     private HapiSpec superusersAreNeverThrottledOnTransfers() {
-        return defaultHapiSpec("SuperusersAreNeverThrottledOnTransfers")
+        return defaultHapiSpec("superusersAreNeverThrottledOnTransfers")
                 .given(
                         cryptoTransfer(tinyBarsFromTo(GENESIS, ADDRESS_BOOK_CONTROL, 1_000_000_000_000L))
                                 .fee(ONE_HUNDRED_HBARS),
@@ -213,7 +212,7 @@ public class PrivilegedOpsSuite extends HapiSuite {
     }
 
     private HapiSpec superusersAreNeverThrottledOnMiscTxns() {
-        return defaultHapiSpec("MasterIsNeverThrottledOnMiscTxns")
+        return defaultHapiSpec("superusersAreNeverThrottledOnMiscTxns")
                 .given(
                         cryptoTransfer(tinyBarsFromTo(GENESIS, ADDRESS_BOOK_CONTROL, 1_000_000_000_000L))
                                 .fee(ONE_HUNDRED_HBARS),
@@ -233,7 +232,7 @@ public class PrivilegedOpsSuite extends HapiSuite {
     }
 
     private HapiSpec superusersAreNeverThrottledOnHcsTxns() {
-        return defaultHapiSpec("MasterIsNeverThrottledOnHcsTxns")
+        return defaultHapiSpec("superusersAreNeverThrottledOnHcsTxns")
                 .given(
                         cryptoTransfer(tinyBarsFromTo(GENESIS, ADDRESS_BOOK_CONTROL, 1_000_000_000_000L)),
                         cryptoTransfer(tinyBarsFromTo(GENESIS, SYSTEM_ADMIN, 1_000_000_000_000L)))
@@ -250,7 +249,7 @@ public class PrivilegedOpsSuite extends HapiSuite {
     }
 
     private HapiSpec superusersAreNeverThrottledOnMiscQueries() {
-        return defaultHapiSpec("MasterIsNeverThrottledOnMiscQueries")
+        return defaultHapiSpec("superusersAreNeverThrottledOnMiscQueries")
                 .given(
                         cryptoTransfer(tinyBarsFromTo(GENESIS, ADDRESS_BOOK_CONTROL, 1_000_000_000_000L)),
                         cryptoTransfer(tinyBarsFromTo(GENESIS, SYSTEM_ADMIN, 1_000_000_000_000L)))
@@ -267,7 +266,7 @@ public class PrivilegedOpsSuite extends HapiSuite {
     }
 
     private HapiSpec superusersAreNeverThrottledOnHcsQueries() {
-        return defaultHapiSpec("MasterIsNeverThrottledOnHcsQueries")
+        return defaultHapiSpec("superusersAreNeverThrottledOnHcsQueries")
                 .given(
                         cryptoTransfer(tinyBarsFromTo(GENESIS, ADDRESS_BOOK_CONTROL, 1_000_000_000_000L)),
                         cryptoTransfer(tinyBarsFromTo(GENESIS, SYSTEM_ADMIN, 1_000_000_000_000L)),

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenAssociationSpecs.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenAssociationSpecs.java
@@ -195,7 +195,7 @@ public class TokenAssociationSpecs extends HapiSuite {
 
     public HapiSpec accountInfoQueriesAsExpected() {
         final var account = "account";
-        return defaultHapiSpec("InfoQueriesAsExpected")
+        return defaultHapiSpec("accountInfoQueriesAsExpected")
                 .given(
                         newKeyNamed(SIMPLE),
                         tokenCreate("a").decimals(1),

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenCreateSpecs.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenCreateSpecs.java
@@ -770,7 +770,7 @@ public class TokenCreateSpecs extends HapiSuite {
     }
 
     private HapiSpec feeCollectorSigningReqsWorkForTokenCreate() {
-        return defaultHapiSpec("FeeCollectorSigningReqsEnforced")
+        return defaultHapiSpec("feeCollectorSigningReqsWorkForTokenCreate")
                 .given(
                         newKeyNamed(customFeesKey),
                         cryptoCreate(htsCollector).receiverSigRequired(true),

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenPauseSpecs.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenPauseSpecs.java
@@ -126,7 +126,7 @@ public final class TokenPauseSpecs extends HapiSuite {
     }
 
     private HapiSpec cannotPauseWithInvalidPauseKey() {
-        return defaultHapiSpec("CannotPauseWithInvlaidPauseKey")
+        return defaultHapiSpec("cannotPauseWithInvalidPauseKey")
                 .given(newKeyNamed(PAUSE_KEY), newKeyNamed(OTHER_KEY))
                 .when(tokenCreate(PRIMARY).pauseKey(PAUSE_KEY))
                 .then(tokenPause(PRIMARY).signedBy(DEFAULT_PAYER, OTHER_KEY).hasKnownStatus(INVALID_SIGNATURE));

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenTransactSpecs.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenTransactSpecs.java
@@ -152,62 +152,61 @@ public class TokenTransactSpecs extends HapiSuite {
     @Override
     @SuppressWarnings("java:S3878")
     public List<HapiSpec> getSpecsInSuite() {
-        return List.of(new HapiSpec[] {
-            balancesChangeOnTokenTransfer(),
-            accountsMustBeExplicitlyUnfrozenOnlyIfDefaultFreezeIsTrue(),
-            senderSigsAreValid(),
-            balancesAreChecked(),
-            duplicateAccountsInTokenTransferRejected(),
-            tokenOnlyTxnsAreAtomic(),
-            tokenPlusHbarTxnsAreAtomic(),
-            nonZeroTransfersRejected(),
-            missingEntitiesRejected(),
-            allRequiredSigsAreChecked(),
-            uniqueTokenTxnAccountBalance(),
-            uniqueTokenTxnAccountBalancesForTreasury(),
-            uniqueTokenTxnWithNoAssociation(),
-            uniqueTokenTxnWithFrozenAccount(),
-            uniqueTokenTxnWithSenderNotSigned(),
-            uniqueTokenTxnWithReceiverNotSigned(),
-            uniqueTokenTxnsAreAtomic(),
-            uniqueTokenDeletedTxn(),
-            cannotSendFungibleToDissociatedContractsOrAccounts(),
-            cannotGiveNftsToDissociatedContractsOrAccounts(),
-            recordsIncludeBothFungibleTokenChangesAndOwnershipChange(),
-            transferListsEnforceTokenTypeRestrictions(),
-            // HIP-18 charging case studies
-            fixedHbarCaseStudy(),
-            fractionalCaseStudy(),
-            simpleHtsFeeCaseStudy(),
-            nestedHbarCaseStudy(),
-            nestedFractionalCaseStudy(),
-            nestedHtsCaseStudy(),
-            treasuriesAreExemptFromAllCustomFees(),
-            collectorsAreExemptFromTheirOwnFeesButNotOthers(),
-            multipleRoyaltyFallbackCaseStudy(),
-            normalRoyaltyCaseStudy(),
-            canTransactInTokenWithSelfDenominatedFixedFee(),
-            nftOwnersChangeAtomically(),
-            fractionalNetOfTransfersCaseStudy(),
-            royaltyAndFractionalTogetherCaseStudy(),
-            respondsCorrectlyWhenNonFungibleTokenWithRoyaltyUsedInTransferList(),
-            // HIP-573 charging case studies
-            collectorIsChargedFixedFeeUnlessExempt(),
-            collectorIsChargedFractionalFeeUnlessExempt(),
-            collectorIsChargedNetOfTransferFractionalFeeUnlessExempt(),
-            collectorIsChargedRoyaltyFeeUnlessExempt(),
-            collectorIsChargedRoyaltyFallbackFeeUnlessExempt(),
-            // HIP-23
-            happyPathAutoAssociationsWorkForBothTokenTypes(),
-            failedAutoAssociationHasNoSideEffectsOrHistoryForUnrelatedProblem(),
-            newSlotsCanBeOpenedViaUpdate(),
-            newSlotsCanBeOpenedViaDissociate(),
-            autoAssociationWithKycTokenHasNoSideEffectsOrHistory(),
-            autoAssociationWithFrozenByDefaultTokenHasNoSideEffectsOrHistory(),
-            autoAssociationWorksForContracts(),
-            // Interactions between HIP-18 and HIP-542
-            customFeesHaveExpectedAutoCreateInteractions(),
-        });
+        return List.of(
+                balancesChangeOnTokenTransfer(),
+                accountsMustBeExplicitlyUnfrozenOnlyIfDefaultFreezeIsTrue(),
+                senderSigsAreValid(),
+                balancesAreChecked(),
+                duplicateAccountsInTokenTransferRejected(),
+                tokenOnlyTxnsAreAtomic(),
+                tokenPlusHbarTxnsAreAtomic(),
+                nonZeroTransfersRejected(),
+                missingEntitiesRejected(),
+                allRequiredSigsAreChecked(),
+                uniqueTokenTxnAccountBalance(),
+                uniqueTokenTxnAccountBalancesForTreasury(),
+                uniqueTokenTxnWithNoAssociation(),
+                uniqueTokenTxnWithFrozenAccount(),
+                uniqueTokenTxnWithSenderNotSigned(),
+                uniqueTokenTxnWithReceiverNotSigned(),
+                uniqueTokenTxnsAreAtomic(),
+                uniqueTokenDeletedTxn(),
+                cannotSendFungibleToDissociatedContractsOrAccounts(),
+                cannotGiveNftsToDissociatedContractsOrAccounts(),
+                recordsIncludeBothFungibleTokenChangesAndOwnershipChange(),
+                transferListsEnforceTokenTypeRestrictions(),
+                // HIP-18 charging case studies
+                fixedHbarCaseStudy(),
+                fractionalCaseStudy(),
+                simpleHtsFeeCaseStudy(),
+                nestedHbarCaseStudy(),
+                nestedFractionalCaseStudy(),
+                nestedHtsCaseStudy(),
+                treasuriesAreExemptFromAllCustomFees(),
+                collectorsAreExemptFromTheirOwnFeesButNotOthers(),
+                multipleRoyaltyFallbackCaseStudy(),
+                normalRoyaltyCaseStudy(),
+                canTransactInTokenWithSelfDenominatedFixedFee(),
+                nftOwnersChangeAtomically(),
+                fractionalNetOfTransfersCaseStudy(),
+                royaltyAndFractionalTogetherCaseStudy(),
+                respondsCorrectlyWhenNonFungibleTokenWithRoyaltyUsedInTransferList(),
+                // HIP-573 charging case studies
+                collectorIsChargedFixedFeeUnlessExempt(),
+                collectorIsChargedFractionalFeeUnlessExempt(),
+                collectorIsChargedNetOfTransferFractionalFeeUnlessExempt(),
+                collectorIsChargedRoyaltyFeeUnlessExempt(),
+                collectorIsChargedRoyaltyFallbackFeeUnlessExempt(),
+                // HIP-23
+                happyPathAutoAssociationsWorkForBothTokenTypes(),
+                failedAutoAssociationHasNoSideEffectsOrHistoryForUnrelatedProblem(),
+                newSlotsCanBeOpenedViaUpdate(),
+                newSlotsCanBeOpenedViaDissociate(),
+                autoAssociationWithKycTokenHasNoSideEffectsOrHistory(),
+                autoAssociationWithFrozenByDefaultTokenHasNoSideEffectsOrHistory(),
+                autoAssociationWorksForContracts(),
+                // Interactions between HIP-18 and HIP-542
+                customFeesHaveExpectedAutoCreateInteractions());
     }
 
     private HapiSpec customFeesHaveExpectedAutoCreateInteractions() {
@@ -403,7 +402,7 @@ public class TokenTransactSpecs extends HapiSuite {
         final var multiPurpose = MULTI_PURPOSE;
         final var transferTxn = TRANSFER_TXN;
 
-        return defaultHapiSpec("failedAutoAssociationHasNoSideEffectsOrHistory")
+        return defaultHapiSpec("failedAutoAssociationHasNoSideEffectsOrHistoryForUnrelatedProblem")
                 .given(
                         newKeyNamed(multiPurpose),
                         cryptoCreate(TOKEN_TREASURY),
@@ -804,7 +803,7 @@ public class TokenTransactSpecs extends HapiSuite {
     }
 
     public HapiSpec missingEntitiesRejected() {
-        return defaultHapiSpec("MissingTokensRejected")
+        return defaultHapiSpec("missingEntitiesRejected")
                 .given(tokenCreate("some").treasury(DEFAULT_PAYER))
                 .when()
                 .then(
@@ -1139,7 +1138,7 @@ public class TokenTransactSpecs extends HapiSuite {
     }
 
     public HapiSpec uniqueTokenTxnWithSenderNotSigned() {
-        return defaultHapiSpec("UniqueTokenTxnWithOwnerNotSigned")
+        return defaultHapiSpec("uniqueTokenTxnWithSenderNotSigned")
                 .given(
                         newKeyNamed(SUPPLY_KEY),
                         newKeyNamed(SIGNING_KEY_TREASURY),
@@ -1158,7 +1157,7 @@ public class TokenTransactSpecs extends HapiSuite {
     }
 
     public HapiSpec uniqueTokenTxnWithReceiverNotSigned() {
-        return defaultHapiSpec("UniqueTokenTxnWithOwnerNotSigned")
+        return defaultHapiSpec("uniqueTokenTxnWithReceiverNotSigned")
                 .given(
                         newKeyNamed(SUPPLY_KEY),
                         newKeyNamed(SIGNING_KEY_TREASURY),
@@ -1926,7 +1925,7 @@ public class TokenTransactSpecs extends HapiSuite {
         final var txnFromTreasury = TXN_FROM_TREASURY;
         final var txnFromNonTreasury = "txnFromNonTreasury";
 
-        return defaultHapiSpec("TreasuriesAreExemptFromAllFees")
+        return defaultHapiSpec("treasuriesAreExemptFromAllCustomFees")
                 .given(
                         cryptoCreate(edgar),
                         cryptoCreate(nonTreasury),

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenUpdateSpecs.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenUpdateSpecs.java
@@ -324,7 +324,7 @@ public class TokenUpdateSpecs extends HapiSuite {
     public HapiSpec validAutoRenewWorks() {
         final var firstPeriod = THREE_MONTHS_IN_SECONDS;
         final var secondPeriod = THREE_MONTHS_IN_SECONDS + 1234;
-        return defaultHapiSpec("AutoRenewInfoChanges")
+        return defaultHapiSpec("validAutoRenewWorks")
                 .given(
                         cryptoCreate("autoRenew").balance(0L),
                         cryptoCreate("newAutoRenew").balance(0L),


### PR DESCRIPTION
**Description**:

Rename multiple bdd tests (`HapiSpec`s) to eliminate wrong names, normalize them

Many bdd tests had incorrect names.  (Copy/paste errors.)  Fixed those, and normalized many more.  Goal is to get all test names to match method names in order to make test launch tools able to detect errors, missing tests, etc.

Added an annotation to help with identifying non-test methods in suites that nevertheless return `HapiSpec`.
And another annotation to identify test methods that return one or more `HapiSpec` that don't match their
method name (useful for "parameterized tests").

Ultimately we may get the test names from the method name directly and eliminate these potential mismatches.

**Related issue(s)**:

Fixes #6840 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
