### PR TITLE
use ledger id from config and not from the netwrok

### DIFF
--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/HandleContextImplTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/HandleContextImplTest.java
@@ -58,7 +58,6 @@ import com.hedera.node.app.workflows.handle.stack.SavepointStackImpl;
 import com.hedera.node.config.testfixtures.HederaTestConfigBuilder;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.swirlds.config.api.Configuration;
-import com.swirlds.test.framework.config.TestConfigBuilder;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
@@ -499,8 +498,8 @@ class HandleContextImplTest extends StateTestBase {
                 E_KEY, EGGPLANT,
                 F_KEY, FIG,
                 G_KEY, GRAPE);
-        private static final Configuration CONFIG_1 = new TestConfigBuilder().getOrCreateConfig();
-        private static final Configuration CONFIG_2 = new TestConfigBuilder().getOrCreateConfig();
+        private static final Configuration CONFIG_1 = new HederaTestConfigBuilder().getOrCreateConfig();
+        private static final Configuration CONFIG_2 = new HederaTestConfigBuilder().getOrCreateConfig();
 
         @Mock(strictness = LENIENT)
         private HederaState baseState;

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/prehandle/PreHandleWorkflowImplTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/prehandle/PreHandleWorkflowImplTest.java
@@ -52,10 +52,10 @@ import com.hedera.node.app.workflows.TransactionChecker;
 import com.hedera.node.app.workflows.dispatcher.ReadableStoreFactory;
 import com.hedera.node.app.workflows.dispatcher.TransactionDispatcher;
 import com.hedera.node.config.ConfigProvider;
+import com.hedera.node.config.testfixtures.HederaTestConfigBuilder;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.swirlds.common.system.transaction.Transaction;
 import com.swirlds.common.system.transaction.internal.SwirldTransaction;
-import com.swirlds.test.framework.config.TestConfigBuilder;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -136,7 +136,7 @@ final class PreHandleWorkflowImplTest extends AppTestBase implements Scenarios {
         storeFactory = new ReadableStoreFactory(fakeHederaState);
 
         final var config =
-                new VersionedConfigImpl(new TestConfigBuilder(false).getOrCreateConfig(), DEFAULT_CONFIG_VERSION);
+                new VersionedConfigImpl(new HederaTestConfigBuilder(false).getOrCreateConfig(), DEFAULT_CONFIG_VERSION);
         when(configProvider.getConfiguration()).thenReturn(config);
 
         workflow = new PreHandleWorkflowImpl(

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/query/QueryWorkflowImplTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/query/QueryWorkflowImplTest.java
@@ -70,12 +70,12 @@ import com.hedera.node.app.workflows.TransactionInfo;
 import com.hedera.node.app.workflows.ingest.IngestChecker;
 import com.hedera.node.app.workflows.ingest.SubmissionManager;
 import com.hedera.node.config.ConfigProvider;
+import com.hedera.node.config.testfixtures.HederaTestConfigBuilder;
 import com.hedera.pbj.runtime.Codec;
 import com.hedera.pbj.runtime.io.buffer.BufferedData;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.hederahashgraph.api.proto.java.NetworkGetExecutionTimeQuery;
 import com.swirlds.common.utility.AutoCloseableWrapper;
-import com.swirlds.test.framework.config.TestConfigBuilder;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 import java.io.IOException;
@@ -179,7 +179,7 @@ class QueryWorkflowImplTest extends AppTestBase {
         when(handler.findResponse(any(), eq(responseHeader))).thenReturn(response);
 
         final var config =
-                new VersionedConfigImpl(new TestConfigBuilder(false).getOrCreateConfig(), DEFAULT_CONFIG_VERSION);
+                new VersionedConfigImpl(new HederaTestConfigBuilder(false).getOrCreateConfig(), DEFAULT_CONFIG_VERSION);
         when(configProvider.getConfiguration()).thenReturn(config);
 
         workflow = new QueryWorkflowImpl(

--- a/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/LedgerConfig.java
+++ b/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/LedgerConfig.java
@@ -16,6 +16,7 @@
 
 package com.hedera.node.config.data;
 
+import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.swirlds.config.api.ConfigData;
 import com.swirlds.config.api.ConfigProperty;
 
@@ -28,7 +29,7 @@ public record LedgerConfig(
         @ConfigProperty(defaultValue = "5000") int maxAutoAssociations,
         @ConfigProperty(defaultValue = "100") int numSystemAccounts,
         @ConfigProperty(defaultValue = "5000000000000000000") long totalTinyBarFloat,
-        @ConfigProperty(defaultValue = "0x03") String id,
+        @ConfigProperty(defaultValue = "0x03") Bytes id,
         @ConfigProperty(value = "changeHistorian.memorySecs", defaultValue = "20") int changeHistorianMemorySecs,
         @ConfigProperty(value = "autoRenewPeriod.maxDuration", defaultValue = "8000001")
                 long autoRenewPeriodMaxDuration,

--- a/hedera-node/hedera-file-service-impl/src/main/java/com/hedera/node/app/service/file/impl/handlers/FileGetContentsHandler.java
+++ b/hedera-node/hedera-file-service-impl/src/main/java/com/hedera/node/app/service/file/impl/handlers/FileGetContentsHandler.java
@@ -31,7 +31,6 @@ import com.hedera.hapi.node.transaction.Query;
 import com.hedera.hapi.node.transaction.Response;
 import com.hedera.node.app.service.file.impl.ReadableFileStoreImpl;
 import com.hedera.node.app.service.file.impl.base.FileQueryBase;
-import com.hedera.node.app.spi.info.NetworkInfo;
 import com.hedera.node.app.spi.workflows.PreCheckException;
 import com.hedera.node.app.spi.workflows.QueryContext;
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -45,12 +44,9 @@ import javax.inject.Singleton;
  */
 @Singleton
 public class FileGetContentsHandler extends FileQueryBase {
-    private final NetworkInfo networkInfo;
 
     @Inject
-    public FileGetContentsHandler(@NonNull final NetworkInfo networkInfo) {
-        this.networkInfo = requireNonNull(networkInfo);
-    }
+    public FileGetContentsHandler() {}
 
     @Override
     public @NonNull QueryHeader extractHeader(@NonNull final Query query) {

--- a/hedera-node/hedera-file-service-impl/src/test/java/com/hedera/node/app/service/file/impl/test/handlers/FileGetContentsHandlerTest.java
+++ b/hedera-node/hedera-file-service-impl/src/test/java/com/hedera/node/app/service/file/impl/test/handlers/FileGetContentsHandlerTest.java
@@ -43,7 +43,6 @@ import com.hedera.node.app.service.file.impl.ReadableFileStoreImpl;
 import com.hedera.node.app.service.file.impl.handlers.FileGetContentsHandler;
 import com.hedera.node.app.service.mono.utils.EntityNum;
 import com.hedera.node.app.spi.fixtures.state.MapReadableKVState;
-import com.hedera.node.app.spi.info.NetworkInfo;
 import com.hedera.node.app.spi.workflows.PreCheckException;
 import com.hedera.node.app.spi.workflows.QueryContext;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
@@ -57,16 +56,13 @@ import org.mockito.junit.jupiter.MockitoExtension;
 class FileGetContentsHandlerTest extends FileHandlerTestBase {
 
     @Mock
-    private NetworkInfo networkInfo;
-
-    @Mock
     private QueryContext context;
 
     private FileGetContentsHandler subject;
 
     @BeforeEach
     void setUp() {
-        subject = new FileGetContentsHandler(networkInfo);
+        subject = new FileGetContentsHandler();
     }
 
     @Test

--- a/hedera-node/hedera-file-service-impl/src/test/java/com/hedera/node/app/service/file/impl/test/handlers/FileGetInfoHandlerTest.java
+++ b/hedera-node/hedera-file-service-impl/src/test/java/com/hedera/node/app/service/file/impl/test/handlers/FileGetInfoHandlerTest.java
@@ -26,6 +26,8 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mock.Strictness.LENIENT;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.when;
 
 import com.hedera.hapi.node.base.FileID;
@@ -44,9 +46,9 @@ import com.hedera.node.app.service.file.impl.ReadableFileStoreImpl;
 import com.hedera.node.app.service.file.impl.handlers.FileGetInfoHandler;
 import com.hedera.node.app.service.mono.utils.EntityNum;
 import com.hedera.node.app.spi.fixtures.state.MapReadableKVState;
-import com.hedera.node.app.spi.info.NetworkInfo;
 import com.hedera.node.app.spi.workflows.PreCheckException;
 import com.hedera.node.app.spi.workflows.QueryContext;
+import com.hedera.node.config.testfixtures.HederaTestConfigBuilder;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -56,17 +58,16 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 class FileGetInfoHandlerTest extends FileHandlerTestBase {
 
-    @Mock
-    private NetworkInfo networkInfo;
-
-    @Mock
+    @Mock(strictness = LENIENT)
     private QueryContext context;
 
     private FileGetInfoHandler subject;
 
     @BeforeEach
     void setUp() {
-        subject = new FileGetInfoHandler(networkInfo);
+        subject = new FileGetInfoHandler();
+        final var configuration = new HederaTestConfigBuilder().getOrCreateConfig();
+        lenient().when(context.configuration()).thenReturn(configuration);
     }
 
     @Test
@@ -167,7 +168,6 @@ class FileGetInfoHandlerTest extends FileHandlerTestBase {
     @Test
     void getsResponseIfOkResponse() {
         givenValidFile();
-        given(networkInfo.ledgerId()).willReturn(ledgerId);
         final var responseHeader = ResponseHeader.newBuilder()
                 .nodeTransactionPrecheckCode(ResponseCodeEnum.OK)
                 .build();

--- a/hedera-node/hedera-file-service-impl/src/test/java/com/hedera/node/app/service/file/impl/test/handlers/FileHandlerTestBase.java
+++ b/hedera-node/hedera-file-service-impl/src/test/java/com/hedera/node/app/service/file/impl/test/handlers/FileHandlerTestBase.java
@@ -77,7 +77,7 @@ public class FileHandlerTestBase {
             FileID.newBuilder().fileNum(fileSystemEntityNum.longValue()).build();
     protected final String beneficiaryIdStr = "0.0.3";
     protected final long paymentAmount = 1_234L;
-    protected final Bytes ledgerId = Bytes.wrap("0x03");
+    protected final Bytes ledgerId = Bytes.wrap(new byte[] {3});
     protected final String memo = "test memo";
     protected final long expirationTime = 1_234_567L;
     protected final long sequenceNumber = 1L;


### PR DESCRIPTION
I refactor the file query details and the content not to use the network and instead to use the ledger id from the ledger config.
Also refactoring all the places depends on it.

**Related issue(s)**:

Fixes #6751 

