### PR TITLE
Update HAPI version

### DIFF
--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/CryptoCreateHandlerTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/CryptoCreateHandlerTest.java
@@ -27,7 +27,6 @@ import static com.hedera.hapi.node.base.ResponseCodeEnum.PROXY_ACCOUNT_ID_FIELD_
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -249,7 +248,7 @@ class CryptoCreateHandlerTest extends CryptoHandlerTestBase {
         assertTrue(createdAccount.tokenAllowances().isEmpty());
         assertEquals(0, createdAccount.numberTreasuryTitles());
         assertFalse(createdAccount.expiredAndPendingRemoval());
-        assertNull(createdAccount.firstContractStorageKey());
+        assertEquals(0, createdAccount.firstContractStorageKey().length());
 
         // validate payer balance reduced
         assertEquals(9_900L, writableStore.get(id).tinybarBalance());
@@ -315,7 +314,7 @@ class CryptoCreateHandlerTest extends CryptoHandlerTestBase {
         assertTrue(createdAccount.tokenAllowances().isEmpty());
         assertEquals(0, createdAccount.numberTreasuryTitles());
         assertFalse(createdAccount.expiredAndPendingRemoval());
-        assertNull(createdAccount.firstContractStorageKey());
+        assertEquals(0, createdAccount.firstContractStorageKey().length());
 
         // validate payer balance reduced
         assertEquals(9_900L, writableStore.get(id).tinybarBalance());

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -114,7 +114,7 @@ dependencyResolutionManagement {
     // runtime.
     create("libs") {
       // The HAPI API version to use, this need to match the tag set on gitRepositories above
-      version("hapi-version", "0.40.0-alpha.0-SNAPSHOT")
+      version("hapi-version", "0.40.0-contract-nft-state-SNAPSHOT")
 
       // Definition of version numbers for all libraries
       version("pbj-version", "0.6.0")


### PR DESCRIPTION
**Description**:
 - Syncs proto artifact with [latest merge to `add-pbj-types`](https://github.com/hashgraph/hedera-protobufs/commits/add-pbj-types-for-state).