### PR TITLE
6885: Enable / disable data on disk and MerkleDb in dev environments

### DIFF
--- a/hedera-node/configuration/dev/bootstrap.properties
+++ b/hedera-node/configuration/dev/bootstrap.properties
@@ -2,6 +2,6 @@ bootstrap.throttleDefsJson.resource=throttles-dev.json
 accounts.storeOnDisk=false
 tokens.storeRelsOnDisk=false
 tokens.nfts.useVirtualMerkle=false
-virtualdatasource.jasperdbToMerkledb=false
+virtualdatasource.jasperdbToMerkledb=true
 accounts.blocklist.enabled=false
 accounts.blocklist.resource=

--- a/hedera-node/configuration/dev/bootstrap.properties
+++ b/hedera-node/configuration/dev/bootstrap.properties
@@ -1,7 +1,7 @@
 bootstrap.throttleDefsJson.resource=throttles-dev.json
-accounts.storeOnDisk=true
-tokens.storeRelsOnDisk=true
-tokens.nfts.useVirtualMerkle=true
-virtualdatasource.jasperdbToMerkledb=true
+accounts.storeOnDisk=false
+tokens.storeRelsOnDisk=false
+tokens.nfts.useVirtualMerkle=false
+virtualdatasource.jasperdbToMerkledb=false
 accounts.blocklist.enabled=false
 accounts.blocklist.resource=

--- a/hedera-node/data/config/bootstrap.properties
+++ b/hedera-node/data/config/bootstrap.properties
@@ -9,6 +9,6 @@ hedera.workflows.enabled=
 accounts.storeOnDisk=false
 tokens.storeRelsOnDisk=false
 tokens.nfts.useVirtualMerkle=false
-virtualdatasource.jasperdbToMerkledb=false
+virtualdatasource.jasperdbToMerkledb=true
 cache.cryptoTransfer.warmThreads=30
 contracts.maxNumWithHapiSigsAccess=0

--- a/hedera-node/data/config/bootstrap.properties
+++ b/hedera-node/data/config/bootstrap.properties
@@ -6,9 +6,9 @@ scheduling.whitelist=ConsensusSubmitMessage,CryptoTransfer,TokenMint,TokenBurn,C
 hedera.workflows.enabled=
 #hedera.workflows.enabled=ConsensusCreateTopic,ConsensusUpdateTopic,ConsensusDeleteTopic,ConsensusSubmitMessage,ConsensusGetTopicInfo
 # Initial Service workflow schemas require on-disk storage, so all these need to be true if enabling workflows
-accounts.storeOnDisk=true
-tokens.storeRelsOnDisk=true
-tokens.nfts.useVirtualMerkle=true
-virtualdatasource.jasperdbToMerkledb=true
+accounts.storeOnDisk=false
+tokens.storeRelsOnDisk=false
+tokens.nfts.useVirtualMerkle=false
+virtualdatasource.jasperdbToMerkledb=false
 cache.cryptoTransfer.warmThreads=30
 contracts.maxNumWithHapiSigsAccess=0


### PR DESCRIPTION
Change default dev env settings (e.g. used by nightly services JRS runs) to defaults: no data on disk, JasperDB as virtual map backend.

Fixes: https://github.com/hashgraph/hedera-services/issues/6885
Signed-off-by: Artem Ananev <artem.ananev@swirldslabs.com>
